### PR TITLE
feat(grimoire): route-driven UI overhaul (Library, chunk reader, stat blocks)

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2731,6 +2731,21 @@ py_test(
 )
 
 py_test(
+    name = "grimoire_library_test",
+    srcs = ["grimoire/library_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "grimoire_ingest_test",
     srcs = ["grimoire/ingest_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/migrations/20260703250000_grimoire_chunk_seq_and_book.sql
+++ b/projects/monolith/chart/migrations/20260703250000_grimoire_chunk_seq_and_book.sql
@@ -1,0 +1,50 @@
+-- Grimoire UI overhaul, Phase 2: reading-order chunk sequence + book metadata
+-- (docs/plans/2026-07-03-grimoire-ui-overhaul.md, Task 2.1).
+--
+-- The Library and chunk reader need two things the schema does not yet carry:
+--   1. A stable reading order per book. created_at is unreliable (bulk upserts
+--      share a timestamp; re-uploads mutate rows in place), so add an explicit
+--      seq populated from NDJSON line order at ingest.
+--   2. Human display names for books. book_id is a slug/UUID today; the Library
+--      renames it via grimoire.book.display_name.
+
+-- 1. seq: reading-order position within a book, 0-based, assigned from NDJSON
+--    line order by the loader. Nullable (a row exists briefly before the loader
+--    sets it, and pre-existing rows are backfilled below).
+ALTER TABLE grimoire.knowledge_chunk ADD COLUMN seq INTEGER;
+
+-- Backfill existing chunks: (created_at, chunk_ref) approximates reading order
+-- for the already-loaded corpus. A later re-upload rewrites seq from true line
+-- order (see ingest._upsert_book_chunks); the risks section of the plan accepts
+-- this approximation for the one book loaded before this migration.
+WITH ordered AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (
+            PARTITION BY book_id ORDER BY created_at, chunk_ref
+        ) - 1 AS rn
+    FROM grimoire.knowledge_chunk
+)
+UPDATE grimoire.knowledge_chunk AS kc
+SET seq = ordered.rn
+FROM ordered
+WHERE kc.id = ordered.id;
+
+-- Reading-order lookups (section tree, chunk reader prev/next, paged chunk list)
+-- all scan by (book_id, seq); index it so they stay index-ordered as the corpus
+-- grows past the seq-scan-is-fine v1 scale.
+CREATE INDEX idx_grimoire_knowledge_chunk_book_seq
+    ON grimoire.knowledge_chunk (book_id, seq);
+
+-- 2. Book metadata: one row per book_id, display_name defaults to the id until
+--    renamed from the Library UI (PATCH /books/{book_id}).
+CREATE TABLE grimoire.book (
+    id           TEXT PRIMARY KEY,
+    display_name TEXT NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Register the books already present as chunks (display_name defaults to id).
+INSERT INTO grimoire.book (id, display_name)
+SELECT DISTINCT book_id, book_id FROM grimoire.knowledge_chunk
+ON CONFLICT (id) DO NOTHING;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:V+1hFVhmzb5t9sNecodR3/sD6WPIHvuWfElivJQPpug=
+h1:KsNgTF7JqmsAGCcL/Z2geqj5Qsyq0hCjWDXXp5aLAUA=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -93,3 +93,4 @@ h1:V+1hFVhmzb5t9sNecodR3/sD6WPIHvuWfElivJQPpug=
 20260703210000_chat_orchestrator_brief.sql h1:UwPShsuwtKgx0XCXf3p8yErVdGE2JBcYTm0Y740rBjw=
 20260703230000_goosecracker_progress_message.sql h1:AQHwWDeJm8urU4Vd5VHpgC09Xk/rE5tmKrMTnV5qY7w=
 20260703240000_grimoire_chunk_image_ref.sql h1:SJh3mta2uHO3SFXTHV3LEQdde4a5fPJCVSfDpZDyFDs=
+20260703250000_grimoire_chunk_seq_and_book.sql h1:5CGypr1+w41FLGdqrdYj9djiz1go2OdS3ai+Nb07At8=

--- a/projects/monolith/frontend/src/lib/grimoire/ChunkReader.svelte
+++ b/projects/monolith/frontend/src/lib/grimoire/ChunkReader.svelte
@@ -1,0 +1,280 @@
+<script>
+  import { goto } from "$app/navigation";
+  import { apiFetch, asQuery, entityHref, chunkHref } from "$lib/grimoire/api.js";
+
+  let { campaignId, bookId, chunkId, viewpoint } = $props();
+
+  let chunk = $state(null);
+  let loading = $state(true);
+  let error = $state("");
+
+  $effect(() => {
+    load(campaignId, chunkId, viewpoint);
+  });
+
+  async function load(cid, id, vp) {
+    loading = true;
+    error = "";
+    chunk = null;
+    try {
+      chunk = await apiFetch(
+        `/chunks/${id}?${asQuery(vp, { campaign: cid })}`,
+      );
+    } catch (e) {
+      error = e.message;
+    } finally {
+      loading = false;
+    }
+  }
+
+  function goChunk(id) {
+    if (!id) return;
+    goto(chunkHref(campaignId, bookId, id, viewpoint));
+  }
+</script>
+
+<div class="reader">
+  {#if loading}
+    <div class="skeleton-lines">
+      {#each Array(6) as _, i (i)}
+        <div class="line"></div>
+      {/each}
+    </div>
+  {:else if error}
+    <p class="status status--error">{error}</p>
+  {:else if chunk}
+    <div class="reader-body grim-paper">
+      {#if chunk.section_path}
+        <p class="section grim-smallcaps">{chunk.section_path}</p>
+      {/if}
+
+      {#if chunk.image_url}
+        <figure class="figure">
+          <img class="image" src={chunk.image_url} alt={chunk.content} />
+          {#if chunk.content}
+            <figcaption class="caption">{chunk.content}</figcaption>
+          {/if}
+        </figure>
+      {:else}
+        <div class="prose">
+          {#each chunk.content.split(/\n\n+/) as para, i (i)}
+            <p>{para}</p>
+          {/each}
+        </div>
+      {/if}
+
+      {#if chunk.entities?.length}
+        <div class="entities">
+          <span class="entities-label grim-smallcaps">On this page</span>
+          <div class="chips">
+            {#each chunk.entities as ent (ent.id)}
+              <a
+                class="chip"
+                class:chip--dim={ent.recognition_only}
+                href={entityHref(campaignId, ent.id, viewpoint)}
+              >
+                {ent.name}
+              </a>
+            {/each}
+          </div>
+        </div>
+      {/if}
+    </div>
+
+    <nav class="pager" aria-label="Reading navigation">
+      <button
+        class="page-btn"
+        disabled={!chunk.prev_id}
+        onclick={() => goChunk(chunk.prev_id)}
+      >
+        ← Prev
+      </button>
+      <span class="seq">#{chunk.seq ?? "—"}</span>
+      <button
+        class="page-btn"
+        disabled={!chunk.next_id}
+        onclick={() => goChunk(chunk.next_id)}
+      >
+        Next →
+      </button>
+    </nav>
+  {/if}
+</div>
+
+<style>
+  .reader {
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+  }
+
+  .reader-body {
+    flex: 1;
+    padding: clamp(1.25rem, 5vw, 3rem) clamp(1rem, 5vw, 2rem);
+  }
+
+  .section {
+    font-size: 0.72rem;
+    color: var(--grim-accent);
+    margin-bottom: 1rem;
+  }
+
+  .prose {
+    max-width: 65ch;
+    margin: 0 auto;
+    font-family: var(--grim-serif);
+    font-size: 1.05rem;
+    line-height: 1.65;
+    color: var(--grim-ink);
+  }
+
+  .prose :global(p) {
+    margin-bottom: 0.85rem;
+  }
+
+  .figure {
+    max-width: 46rem;
+    margin: 0 auto;
+  }
+
+  .image {
+    width: 100%;
+    height: auto;
+    border: 1px solid var(--grim-paper-line);
+  }
+
+  .caption {
+    margin-top: 0.6rem;
+    font-family: var(--grim-serif);
+    font-style: italic;
+    font-size: 0.9rem;
+    color: var(--grim-ink-soft);
+    text-align: center;
+  }
+
+  .entities {
+    max-width: 65ch;
+    margin: 2rem auto 0;
+    padding-top: 1rem;
+    border-top: 1px solid var(--grim-paper-line);
+  }
+
+  .entities-label {
+    font-size: 0.68rem;
+    color: var(--grim-ink-soft);
+  }
+
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-top: 0.5rem;
+  }
+
+  .chip {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    min-height: 2.25rem;
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.6rem;
+    border: 1px solid var(--grim-accent);
+    color: var(--grim-accent);
+    background: var(--bg);
+  }
+
+  .chip--dim {
+    opacity: 0.55;
+    border-color: var(--grim-paper-line);
+    color: var(--grim-ink-soft);
+  }
+
+  .pager {
+    position: sticky;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+    background: var(--bg);
+    border-top: var(--border-thin);
+  }
+
+  .page-btn {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    min-height: 2.75rem;
+    padding: 0.5rem 1.25rem;
+    background: var(--bg);
+    color: var(--fg);
+    border: var(--border-thin);
+    cursor: pointer;
+  }
+
+  .page-btn:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+
+  .page-btn:not(:disabled):hover {
+    border-color: var(--grim-accent);
+    color: var(--grim-accent);
+  }
+
+  .seq {
+    font-size: 0.7rem;
+    color: var(--fg-tertiary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .status--error {
+    color: var(--danger);
+    font-size: 0.8rem;
+    padding: 1.5rem;
+  }
+
+  .skeleton-lines {
+    padding: 2rem;
+    max-width: 65ch;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 100%;
+  }
+
+  .line {
+    height: 1rem;
+    background: linear-gradient(
+      90deg,
+      var(--surface) 25%,
+      transparent 37%,
+      var(--surface) 63%
+    );
+    background-size: 400% 100%;
+    animation: shimmer 1.4s ease infinite;
+  }
+
+  .line:nth-child(3) {
+    width: 80%;
+  }
+  .line:nth-child(6) {
+    width: 60%;
+  }
+
+  @keyframes shimmer {
+    0% {
+      background-position: 100% 0;
+    }
+    100% {
+      background-position: 0 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .line {
+      animation: none;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/lib/grimoire/GrantChips.svelte
+++ b/projects/monolith/frontend/src/lib/grimoire/GrantChips.svelte
@@ -1,0 +1,312 @@
+<script>
+  import { apiFetch } from "$lib/grimoire/api.js";
+  import {
+    META_FIELDS,
+    formatFieldName,
+    scalarToText,
+  } from "$lib/grimoire/format.js";
+
+  // DM-only contextual grant editor. Per-character scope chips write straight
+  // to the grant endpoints; partial opens a field picker over the entity's
+  // populated fields and builds revealed_details from the real values.
+  let { campaignId, entityId, entity, characters } = $props();
+
+  const SCOPES = [
+    { key: "none", label: "none" },
+    { key: "name_only", label: "name only" },
+    { key: "partial", label: "partial" },
+    { key: "full", label: "full" },
+  ];
+
+  let grants = $state([]); // full grant rows for THIS entity
+  let error = $state("");
+  let pickerFor = $state(null); // character id while choosing partial fields
+  let picked = $state(new Set());
+
+  // Fields eligible for a partial reveal: the entity's populated, non-meta
+  // scalar-or-structured fields (the DM sees the full entity here).
+  const revealableFields = $derived(
+    Object.keys(entity ?? {}).filter(
+      (k) => !META_FIELDS.has(k) && entity[k] != null && entity[k] !== "",
+    ),
+  );
+
+  async function load() {
+    try {
+      const all = await apiFetch(`/campaigns/${campaignId}/grants`);
+      grants = all.filter((g) => g.entity_id === entityId);
+    } catch (e) {
+      error = e.message;
+    }
+  }
+
+  $effect(() => {
+    // Reload whenever the entity changes.
+    entityId;
+    load();
+  });
+
+  const grantFor = (charId) => grants.find((g) => g.player_character_id === charId);
+  const scopeOf = (charId) => grantFor(charId)?.grant_scope ?? "none";
+
+  async function setScope(charId, scope) {
+    error = "";
+    const existing = grantFor(charId);
+    try {
+      if (scope === "none") {
+        if (existing) {
+          await apiFetch(`/campaigns/${campaignId}/grants/${existing.id}`, {
+            method: "DELETE",
+          });
+        }
+      } else if (scope === "partial") {
+        // Defer the write until the field picker confirms.
+        picked = new Set(Object.keys(existing?.revealed_details ?? {}));
+        pickerFor = charId;
+        return;
+      } else if (existing) {
+        await apiFetch(`/campaigns/${campaignId}/grants/${existing.id}`, {
+          method: "PATCH",
+          body: JSON.stringify({ grant_scope: scope }),
+        });
+      } else {
+        await apiFetch(`/campaigns/${campaignId}/grants`, {
+          method: "POST",
+          body: JSON.stringify({
+            entity_id: entityId,
+            player_character_id: charId,
+            grant_scope: scope,
+          }),
+        });
+      }
+      await load();
+    } catch (e) {
+      error = e.message;
+    }
+  }
+
+  function toggleField(key) {
+    const next = new Set(picked);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    picked = next;
+  }
+
+  async function confirmPartial() {
+    const charId = pickerFor;
+    error = "";
+    const revealed = {};
+    for (const key of picked) revealed[key] = entity[key];
+    const existing = grantFor(charId);
+    try {
+      if (existing) {
+        await apiFetch(`/campaigns/${campaignId}/grants/${existing.id}`, {
+          method: "PATCH",
+          body: JSON.stringify({
+            grant_scope: "partial",
+            revealed_details: revealed,
+          }),
+        });
+      } else {
+        await apiFetch(`/campaigns/${campaignId}/grants`, {
+          method: "POST",
+          body: JSON.stringify({
+            entity_id: entityId,
+            player_character_id: charId,
+            grant_scope: "partial",
+            revealed_details: revealed,
+          }),
+        });
+      }
+      pickerFor = null;
+      await load();
+    } catch (e) {
+      error = e.message;
+    }
+  }
+</script>
+
+<section class="grants">
+  <h3 class="grim-smallcaps head">Reveals</h3>
+
+  {#if characters.length === 0}
+    <p class="hint">No characters in this campaign yet.</p>
+  {:else}
+    <ul class="rows">
+      {#each characters as char (char.id)}
+        <li class="row">
+          <span class="char">{char.character_name}</span>
+          <div class="chips">
+            {#each SCOPES as scope (scope.key)}
+              <button
+                class="chip"
+                class:chip--active={scopeOf(char.id) === scope.key}
+                onclick={() => setScope(char.id, scope.key)}
+              >
+                {scope.label}
+              </button>
+            {/each}
+          </div>
+
+          {#if pickerFor === char.id}
+            <div class="picker">
+              <p class="picker-head">Reveal which fields to {char.character_name}?</p>
+              <div class="picker-fields">
+                {#each revealableFields as key (key)}
+                  <label class="field">
+                    <input
+                      type="checkbox"
+                      checked={picked.has(key)}
+                      onchange={() => toggleField(key)}
+                    />
+                    <span class="field-name">{formatFieldName(key)}</span>
+                    <span class="field-val">{scalarToText(entity[key]).slice(0, 40)}</span>
+                  </label>
+                {/each}
+              </div>
+              <div class="picker-actions">
+                <button class="btn" onclick={confirmPartial}>Save reveal</button>
+                <button class="btn btn--ghost" onclick={() => (pickerFor = null)}>
+                  Cancel
+                </button>
+              </div>
+            </div>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  {#if error}<p class="error">{error}</p>{/if}
+</section>
+
+<style>
+  .grants {
+    border: 1px solid var(--grim-paper-line);
+    padding: 1rem;
+  }
+
+  .head {
+    font-size: 0.9rem;
+    color: var(--grim-accent);
+    margin-bottom: 0.75rem;
+  }
+
+  .rows {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 0.75rem;
+  }
+
+  .char {
+    font-family: var(--grim-serif);
+    font-weight: 700;
+    min-width: 8rem;
+  }
+
+  .chips {
+    display: flex;
+    gap: 0.3rem;
+    flex-wrap: wrap;
+  }
+
+  .chip {
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    min-height: 2.25rem;
+    padding: 0.3rem 0.55rem;
+    background: var(--bg);
+    color: var(--fg-secondary);
+    border: var(--border-thin);
+    cursor: pointer;
+  }
+
+  .chip--active {
+    background: var(--grim-accent);
+    border-color: var(--grim-accent);
+    color: #fff;
+  }
+
+  .picker {
+    flex-basis: 100%;
+    border: 1px dashed var(--grim-paper-line);
+    padding: 0.75rem;
+    margin-top: 0.25rem;
+  }
+
+  .picker-head {
+    font-size: 0.72rem;
+    color: var(--fg-secondary);
+    margin-bottom: 0.5rem;
+  }
+
+  .picker-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-bottom: 0.6rem;
+  }
+
+  .field {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    font-size: 0.8rem;
+  }
+
+  .field-name {
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-tertiary);
+    min-width: 6rem;
+  }
+
+  .field-val {
+    font-family: var(--grim-serif);
+    color: var(--fg-secondary);
+  }
+
+  .picker-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .btn {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    min-height: 2.5rem;
+    padding: 0.4rem 0.9rem;
+    background: var(--grim-accent);
+    color: #fff;
+    border: none;
+    cursor: pointer;
+  }
+
+  .btn--ghost {
+    background: var(--bg);
+    color: var(--fg-secondary);
+    border: var(--border-thin);
+  }
+
+  .hint {
+    font-size: 0.78rem;
+    color: var(--fg-tertiary);
+  }
+
+  .error {
+    color: var(--danger);
+    font-size: 0.78rem;
+    margin-top: 0.5rem;
+  }
+</style>

--- a/projects/monolith/frontend/src/lib/grimoire/Omnibox.svelte
+++ b/projects/monolith/frontend/src/lib/grimoire/Omnibox.svelte
@@ -1,0 +1,266 @@
+<script>
+  import { goto } from "$app/navigation";
+  import {
+    apiFetch,
+    asQuery,
+    entityHref,
+    chunkHref,
+  } from "$lib/grimoire/api.js";
+
+  let { campaignId, viewpoint } = $props();
+
+  let query = $state("");
+  let open = $state(false);
+  let activeIndex = $state(-1);
+
+  let nameHits = $state([]);
+  let semanticEntities = $state([]);
+  let loreHits = $state([]);
+
+  let nameTimer;
+  let semanticTimer;
+
+  // One flat, ordered list so a single active index can move across all groups.
+  const flat = $derived([
+    ...nameHits.map((e) => ({ kind: "entity", entity: e, group: "Entities" })),
+    ...semanticEntities.map((e) => ({
+      kind: "entity",
+      entity: e,
+      group: "Related entities",
+    })),
+    ...loreHits.map((c) => ({ kind: "chunk", chunk: c, group: "Lore" })),
+  ]);
+
+  function reset() {
+    nameHits = [];
+    semanticEntities = [];
+    loreHits = [];
+    activeIndex = -1;
+  }
+
+  async function runNameSearch(q) {
+    try {
+      const body = await apiFetch(
+        `/campaigns/${campaignId}/entities?${asQuery(viewpoint, {
+          q,
+          limit: "6",
+        })}`,
+      );
+      nameHits = body.items ?? [];
+    } catch {
+      nameHits = [];
+    }
+  }
+
+  async function runSemanticSearch(q) {
+    try {
+      const hits = await apiFetch(
+        `/campaigns/${campaignId}/search?${asQuery(viewpoint, { q, k: "8" })}`,
+      );
+      const nameIds = new Set(nameHits.map((e) => e.id));
+      semanticEntities = hits.filter(
+        (h) => h.kind === "entity" && !nameIds.has(h.id),
+      );
+      loreHits = hits.filter((h) => h.kind === "chunk");
+    } catch {
+      semanticEntities = [];
+      loreHits = [];
+    }
+  }
+
+  // Instant name matches (150ms) render first; semantic results (300ms) fill in.
+  $effect(() => {
+    const q = query.trim();
+    clearTimeout(nameTimer);
+    clearTimeout(semanticTimer);
+    if (!q) {
+      reset();
+      return;
+    }
+    open = true;
+    nameTimer = setTimeout(() => runNameSearch(q), 150);
+    semanticTimer = setTimeout(() => runSemanticSearch(q), 300);
+    return () => {
+      clearTimeout(nameTimer);
+      clearTimeout(semanticTimer);
+    };
+  });
+
+  function choose(item) {
+    open = false;
+    query = "";
+    reset();
+    if (item.kind === "entity") {
+      goto(entityHref(campaignId, item.entity.id, viewpoint));
+    } else {
+      goto(
+        chunkHref(campaignId, item.chunk.book_id, item.chunk.id, viewpoint),
+      );
+    }
+  }
+
+  function onKeydown(e) {
+    if (e.key === "Escape") {
+      open = false;
+      activeIndex = -1;
+      return;
+    }
+    if (!flat.length) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      activeIndex = (activeIndex + 1) % flat.length;
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      activeIndex = (activeIndex - 1 + flat.length) % flat.length;
+    } else if (e.key === "Enter" && activeIndex >= 0) {
+      e.preventDefault();
+      choose(flat[activeIndex]);
+    }
+  }
+
+  // Group headers: emit a header row before the first item of each group.
+  const rows = $derived(
+    flat.map((item, i) => ({
+      item,
+      i,
+      header: i === 0 || flat[i - 1].group !== item.group ? item.group : null,
+    })),
+  );
+</script>
+
+<div class="omnibox" onfocusout={(e) => {
+  if (!e.currentTarget.contains(e.relatedTarget)) open = false;
+}}>
+  <input
+    class="ob-input"
+    type="search"
+    placeholder="Search entities and lore…"
+    bind:value={query}
+    onfocus={() => query.trim() && (open = true)}
+    onkeydown={onKeydown}
+    role="combobox"
+    aria-expanded={open}
+    aria-controls="ob-results"
+    aria-autocomplete="list"
+  />
+
+  {#if open && query.trim()}
+    <div class="ob-panel" id="ob-results" role="listbox">
+      {#if flat.length === 0}
+        <p class="ob-empty">No matches yet…</p>
+      {:else}
+        {#each rows as row (row.i)}
+          {#if row.header}
+            <div class="ob-group">{row.header}</div>
+          {/if}
+          <button
+            class="ob-hit"
+            class:ob-hit--active={activeIndex === row.i}
+            role="option"
+            aria-selected={activeIndex === row.i}
+            onmouseenter={() => (activeIndex = row.i)}
+            onclick={() => choose(row.item)}
+          >
+            {#if row.item.kind === "entity"}
+              <span class="ob-title">{row.item.entity.name}</span>
+              <span class="ob-type">{row.item.entity.entity_type}</span>
+            {:else}
+              <span class="ob-title">{row.item.chunk.display_name}</span>
+              <span class="ob-type">{row.item.chunk.section_path ?? "lore"}</span
+              >
+            {/if}
+          </button>
+        {/each}
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .omnibox {
+    position: relative;
+    width: 100%;
+  }
+
+  .ob-input {
+    width: 100%;
+    min-height: 2.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--bg);
+    color: var(--fg);
+    border: var(--border-thin);
+  }
+
+  .ob-input:focus {
+    outline: 2px solid var(--grim-accent);
+    outline-offset: -2px;
+  }
+
+  .ob-panel {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    z-index: 40;
+    max-height: 60vh;
+    overflow-y: auto;
+    background: var(--bg);
+    border: var(--border-heavy);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  }
+
+  .ob-empty {
+    padding: 0.75rem;
+    font-size: 0.78rem;
+    color: var(--fg-tertiary);
+  }
+
+  .ob-group {
+    padding: 0.4rem 0.75rem 0.2rem;
+    font-size: 0.6rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--fg-tertiary);
+    background: var(--surface);
+  }
+
+  .ob-hit {
+    width: 100%;
+    text-align: left;
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    min-height: 2.5rem;
+    padding: 0.45rem 0.75rem;
+    background: none;
+    border: none;
+    border-top: 1px solid var(--surface);
+    cursor: pointer;
+    font-family: var(--font-mono);
+    color: var(--fg);
+  }
+
+  .ob-hit--active {
+    background: var(--surface);
+  }
+
+  .ob-title {
+    font-weight: 700;
+    font-size: 0.82rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .ob-type {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-tertiary);
+    margin-left: auto;
+    white-space: nowrap;
+  }
+</style>

--- a/projects/monolith/frontend/src/lib/grimoire/Omnibox.svelte
+++ b/projects/monolith/frontend/src/lib/grimoire/Omnibox.svelte
@@ -38,6 +38,11 @@
     activeIndex = -1;
   }
 
+  // A response is stale once the query has moved on; discard it rather than
+  // clobbering results for the newer query (network completion order is not
+  // guaranteed, so a slow "a" can land after "ab").
+  const isStale = (q) => q !== query.trim();
+
   async function runNameSearch(q) {
     try {
       const body = await apiFetch(
@@ -46,9 +51,10 @@
           limit: "6",
         })}`,
       );
+      if (isStale(q)) return;
       nameHits = body.items ?? [];
     } catch {
-      nameHits = [];
+      if (!isStale(q)) nameHits = [];
     }
   }
 
@@ -57,14 +63,17 @@
       const hits = await apiFetch(
         `/campaigns/${campaignId}/search?${asQuery(viewpoint, { q, k: "8" })}`,
       );
+      if (isStale(q)) return;
       const nameIds = new Set(nameHits.map((e) => e.id));
       semanticEntities = hits.filter(
         (h) => h.kind === "entity" && !nameIds.has(h.id),
       );
       loreHits = hits.filter((h) => h.kind === "chunk");
     } catch {
-      semanticEntities = [];
-      loreHits = [];
+      if (!isStale(q)) {
+        semanticEntities = [];
+        loreHits = [];
+      }
     }
   }
 

--- a/projects/monolith/frontend/src/lib/grimoire/api.js
+++ b/projects/monolith/frontend/src/lib/grimoire/api.js
@@ -1,0 +1,88 @@
+// Client-side data access + per-device preferences for the Grimoire app. Every
+// page is `ssr = false` and fetches through here against /api/grimoire (the
+// campaign/viewpoint/entity picks are interactive state, not something a server
+// load() would usefully pre-render), matching the private/notes + private/chat
+// pattern.
+
+export const API = "/api/grimoire";
+
+export async function apiFetch(path, options = {}) {
+  const res = await fetch(`${API}${path}`, {
+    ...options,
+    headers: options.body ? { "Content-Type": "application/json" } : undefined,
+  });
+  let body = null;
+  try {
+    body = await res.json();
+  } catch {
+    body = null;
+  }
+  if (!res.ok) {
+    throw new Error(body?.detail ?? `request failed (${res.status})`);
+  }
+  return body;
+}
+
+// ── Per-device preferences (localStorage, guarded for SSR/private windows) ──
+
+const LS_CAMPAIGN = "grimoire:campaign";
+const LS_VIEWPOINT = "grimoire:viewpoint";
+
+function readLS(key) {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeLS(key, value) {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // ignore (private mode / SSR)
+  }
+}
+
+export const lastCampaignId = () => readLS(LS_CAMPAIGN);
+export const rememberCampaign = (id) => writeLS(LS_CAMPAIGN, id);
+export const lastViewpoint = () => readLS(LS_VIEWPOINT);
+export const rememberViewpoint = (v) => writeLS(LS_VIEWPOINT, v);
+
+// "New since last visit" is a per-device signal: compare a book's latest_chunk_at
+// against the timestamp we last recorded for that book on this device.
+export const bookLastSeen = (bookId) => readLS(`grimoire:lastSeen:${bookId}`);
+export const markBookSeen = (bookId, iso) =>
+  writeLS(`grimoire:lastSeen:${bookId}`, iso ?? new Date().toISOString());
+
+// ── Viewpoint (the `?as=` query param is the source of truth) ──
+
+export const isDm = (viewpoint) => viewpoint === "dm";
+
+// Effective viewpoint for a page: the URL wins; localStorage only seeds the
+// default when the URL omits it; DM is the final fallback (matching the old
+// loadCharacters semantics).
+export function resolveViewpoint(url) {
+  return url.searchParams.get("as") || lastViewpoint() || "dm";
+}
+
+// A query string carrying the viewpoint (plus any extras), for building API
+// URLs and shareable in-app links.
+export function asQuery(viewpoint, extra = {}) {
+  return new URLSearchParams({ as: viewpoint, ...extra }).toString();
+}
+
+// ── Route builders (keep every in-app link viewpoint-carrying + shareable) ──
+
+const base = (campaignId) => `/app/grimoire/${campaignId}`;
+
+export const libraryHref = (campaignId, viewpoint) =>
+  `${base(campaignId)}?${asQuery(viewpoint)}`;
+export const entitiesHref = (campaignId, viewpoint) =>
+  `${base(campaignId)}/entities?${asQuery(viewpoint)}`;
+export const entityHref = (campaignId, id, viewpoint) =>
+  `${base(campaignId)}/entity/${id}?${asQuery(viewpoint)}`;
+export const bookHref = (campaignId, bookId, viewpoint) =>
+  `${base(campaignId)}/book/${encodeURIComponent(bookId)}?${asQuery(viewpoint)}`;
+export const chunkHref = (campaignId, bookId, chunkId, viewpoint) =>
+  `${base(campaignId)}/book/${encodeURIComponent(bookId)}/c/${chunkId}?${asQuery(viewpoint)}`;

--- a/projects/monolith/frontend/src/lib/grimoire/format.js
+++ b/projects/monolith/frontend/src/lib/grimoire/format.js
@@ -1,0 +1,114 @@
+// Presentation helpers shared by the entity renderers. Kept framework-free so
+// they are easy to reason about and reuse across the stat-block components.
+
+// Fields that are spine/meta/projection plumbing, never rendered as content.
+export const META_FIELDS = new Set([
+  "id",
+  "entity_type",
+  "name",
+  "grant",
+  "grants",
+  "revealed_details",
+  "source_type",
+  "is_global",
+  "source_book",
+  "created_in_session",
+  "created_at",
+  "kind",
+  "score",
+  "recognition_only",
+  "mention_text",
+]);
+
+export function formatFieldName(key) {
+  return String(key).replaceAll("_", " ");
+}
+
+// D&D ability modifier: floor((score - 10) / 2), signed.
+export function abilityModifier(score) {
+  const n = Number(score);
+  if (!Number.isFinite(n)) return "";
+  const mod = Math.floor((n - 10) / 2);
+  return mod >= 0 ? `+${mod}` : `${mod}`;
+}
+
+export const ABILITIES = ["str", "dex", "con", "int", "wis", "cha"];
+
+// {"walk": 40, "fly": 80} -> "walk 40 ft., fly 80 ft."; a plain string passes
+// through; anything else becomes "".
+export function formatSpeed(speed) {
+  if (!speed) return "";
+  if (typeof speed === "string") return speed;
+  if (typeof speed === "object") {
+    const parts = Object.entries(speed).map(([mode, dist]) =>
+      typeof dist === "number" ? `${mode} ${dist} ft.` : `${mode} ${dist}`,
+    );
+    return parts.join(", ");
+  }
+  return "";
+}
+
+// Normalize a JSONB actions/traits payload into [{name, text}] blocks. Accepts a
+// list of objects ({name, desc|description|text|...}), a list of strings, or a
+// {name: text} dict, so the renderer never has to know which shape extraction
+// produced and never falls back to raw JSON.
+export function normalizeBlocks(value) {
+  if (!value) return [];
+  const blocks = [];
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (item == null) continue;
+      if (typeof item === "string") {
+        blocks.push({ name: "", text: item });
+      } else if (typeof item === "object") {
+        const name = item.name ?? item.title ?? "";
+        const text =
+          item.desc ??
+          item.description ??
+          item.text ??
+          item.effect ??
+          objectToText(item, ["name", "title"]);
+        blocks.push({ name, text });
+      }
+    }
+  } else if (typeof value === "object") {
+    for (const [name, text] of Object.entries(value)) {
+      blocks.push({ name, text: scalarToText(text) });
+    }
+  } else if (typeof value === "string") {
+    blocks.push({ name: "", text: value });
+  }
+  return blocks.filter((b) => b.name || b.text);
+}
+
+function scalarToText(v) {
+  if (v == null) return "";
+  if (
+    typeof v === "string" ||
+    typeof v === "number" ||
+    typeof v === "boolean"
+  ) {
+    return String(v);
+  }
+  if (Array.isArray(v)) return v.map(scalarToText).filter(Boolean).join(", ");
+  if (typeof v === "object") return objectToText(v);
+  return "";
+}
+
+// Render an object as "key value" prose (never JSON), skipping the given keys.
+function objectToText(obj, skip = []) {
+  return Object.entries(obj)
+    .filter(([k]) => !skip.includes(k))
+    .map(([k, v]) => `${formatFieldName(k)}: ${scalarToText(v)}`)
+    .filter((s) => !s.endsWith(": "))
+    .join("; ");
+}
+
+// A field is "long prose" (render as a paragraph) vs a short inline value.
+export function isProse(key, value) {
+  return (
+    typeof value === "string" && (value.length > 80 || key === "description")
+  );
+}
+
+export { scalarToText };

--- a/projects/monolith/frontend/src/lib/grimoire/statblock/Creature.svelte
+++ b/projects/monolith/frontend/src/lib/grimoire/statblock/Creature.svelte
@@ -1,0 +1,196 @@
+<script>
+  import {
+    ABILITIES,
+    abilityModifier,
+    formatSpeed,
+    normalizeBlocks,
+  } from "$lib/grimoire/format.js";
+
+  let { data } = $props();
+
+  const strap = $derived(
+    [data.size, data.creature_type].filter(Boolean).join(" "),
+  );
+  const speed = $derived(formatSpeed(data.speed));
+  const scores = $derived(data.ability_scores ?? {});
+  const hasScores = $derived(
+    ABILITIES.some((a) => scores[a] != null || scores[a.toUpperCase()] != null),
+  );
+  const score = (a) => scores[a] ?? scores[a.toUpperCase()] ?? null;
+  const traits = $derived(normalizeBlocks(data.traits));
+  const actions = $derived(normalizeBlocks(data.actions));
+</script>
+
+<article class="statblock grim-paper">
+  <h2 class="grim-title name">{data.name}</h2>
+  {#if strap}<p class="grim-smallcaps strap">{strap}</p>{/if}
+
+  <hr class="grim-rule" />
+
+  <dl class="topline">
+    {#if data.ac != null}
+      <div><dt>Armor Class</dt>
+        <dd>{data.ac}</dd></div>
+    {/if}
+    {#if data.hp_avg != null}
+      <div><dt>Hit Points</dt>
+        <dd>{data.hp_avg}</dd></div>
+    {/if}
+    {#if speed}
+      <div><dt>Speed</dt>
+        <dd>{speed}</dd></div>
+    {/if}
+    {#if data.cr != null}
+      <div><dt>Challenge</dt>
+        <dd>{data.cr}</dd></div>
+    {/if}
+  </dl>
+
+  {#if hasScores}
+    <hr class="grim-rule" />
+    <table class="abilities">
+      <thead>
+        <tr>
+          {#each ABILITIES as a (a)}
+            <th class="grim-smallcaps">{a}</th>
+          {/each}
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          {#each ABILITIES as a (a)}
+            <td>
+              {#if score(a) != null}
+                <span class="ab-score">{score(a)}</span>
+                <span class="ab-mod">({abilityModifier(score(a))})</span>
+              {:else}
+                <span class="ab-score">—</span>
+              {/if}
+            </td>
+          {/each}
+        </tr>
+      </tbody>
+    </table>
+  {/if}
+
+  {#if traits.length}
+    <hr class="grim-rule" />
+    <div class="blocks">
+      {#each traits as t, i (i)}
+        <p class="block">
+          {#if t.name}<strong class="block-name">{t.name}.</strong>{/if}
+          {t.text}
+        </p>
+      {/each}
+    </div>
+  {/if}
+
+  {#if actions.length}
+    <h3 class="grim-smallcaps section-head">Actions</h3>
+    <div class="blocks">
+      {#each actions as a, i (i)}
+        <p class="block">
+          {#if a.name}<strong class="block-name">{a.name}.</strong>{/if}
+          {a.text}
+        </p>
+      {/each}
+    </div>
+  {/if}
+</article>
+
+<style>
+  .statblock {
+    padding: clamp(1rem, 3vw, 1.5rem);
+    border: 1px solid var(--grim-paper-line);
+    border-top: 3px solid var(--grim-accent);
+    max-width: 40rem;
+  }
+
+  .name {
+    font-size: clamp(1.4rem, 4vw, 1.9rem);
+    color: var(--grim-accent-strong);
+  }
+
+  .strap {
+    font-size: 0.85rem;
+    color: var(--grim-ink-soft);
+    font-style: italic;
+  }
+
+  .topline {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem 1.5rem;
+  }
+
+  .topline div {
+    display: flex;
+    gap: 0.4rem;
+    align-items: baseline;
+  }
+
+  .topline dt {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--grim-ink-soft);
+  }
+
+  .topline dd {
+    font-family: var(--grim-serif);
+    font-weight: 700;
+  }
+
+  .abilities {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: center;
+  }
+
+  .abilities th {
+    font-size: 0.72rem;
+    color: var(--grim-accent);
+    padding-bottom: 0.2rem;
+  }
+
+  .abilities td {
+    padding: 0.15rem 0.2rem;
+    font-family: var(--grim-serif);
+  }
+
+  .ab-score {
+    font-weight: 700;
+  }
+
+  .ab-mod {
+    color: var(--grim-ink-soft);
+    font-size: 0.8em;
+  }
+
+  .section-head {
+    font-size: 0.95rem;
+    color: var(--grim-accent);
+    border-bottom: 1px solid var(--grim-accent);
+    margin-top: 0.75rem;
+    padding-bottom: 0.15rem;
+  }
+
+  .blocks {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+  }
+
+  .block {
+    font-family: var(--grim-serif);
+    font-size: 0.95rem;
+    line-height: 1.5;
+    color: var(--grim-ink);
+  }
+
+  .block-name {
+    font-style: italic;
+  }
+</style>

--- a/projects/monolith/frontend/src/lib/grimoire/statblock/EntityDetail.svelte
+++ b/projects/monolith/frontend/src/lib/grimoire/statblock/EntityDetail.svelte
@@ -1,0 +1,46 @@
+<script>
+  import Creature from "./Creature.svelte";
+  import Spell from "./Spell.svelte";
+  import Generic from "./Generic.svelte";
+
+  let { entity } = $props();
+
+  // A partial grant to a player is {id, entity_type, name, revealed_details}
+  // with no full spine. Render the revealed subset through the same typed
+  // renderer so partial knowledge looks like a redacted stat block, never JSON.
+  const partial = $derived(
+    !!(entity?.revealed_details && !("source_type" in entity)),
+  );
+
+  const data = $derived(
+    partial
+      ? {
+          name: entity.name,
+          entity_type: entity.entity_type,
+          ...(entity.revealed_details ?? {}),
+        }
+      : entity,
+  );
+
+  const RENDERERS = { creature: Creature, spell: Spell };
+  const Renderer = $derived(RENDERERS[data?.entity_type] ?? Generic);
+</script>
+
+{#if partial}
+  <p class="partial-note">
+    Partial knowledge — only what the DM has revealed is shown.
+  </p>
+{/if}
+
+<Renderer {data} />
+
+<style>
+  .partial-note {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--grim-accent);
+    margin-bottom: 0.5rem;
+  }
+</style>

--- a/projects/monolith/frontend/src/lib/grimoire/statblock/Generic.svelte
+++ b/projects/monolith/frontend/src/lib/grimoire/statblock/Generic.svelte
@@ -1,0 +1,132 @@
+<script>
+  import {
+    META_FIELDS,
+    formatFieldName,
+    isProse,
+    normalizeBlocks,
+    scalarToText,
+  } from "$lib/grimoire/format.js";
+
+  let { data } = $props();
+
+  // Split populated, non-meta fields into short inline values, long prose
+  // paragraphs, and structured (object/array) blocks -- never raw JSON.
+  const fields = $derived(
+    Object.entries(data ?? {})
+      .filter(([k, v]) => !META_FIELDS.has(k) && v != null && v !== "")
+      .map(([key, value]) => {
+        if (typeof value === "object") {
+          return { key, kind: "blocks", blocks: normalizeBlocks(value) };
+        }
+        if (isProse(key, value)) {
+          return { key, kind: "prose", text: String(value) };
+        }
+        return { key, kind: "inline", text: scalarToText(value) };
+      })
+      .filter((f) => f.kind !== "blocks" || f.blocks.length),
+  );
+</script>
+
+<article class="generic grim-paper">
+  <h2 class="grim-title name">{data.name}</h2>
+  {#if data.entity_type}
+    <p class="grim-smallcaps strap">{data.entity_type}</p>
+  {/if}
+
+  <hr class="grim-rule" />
+
+  {#if fields.length === 0}
+    <p class="none">No further details recorded.</p>
+  {:else}
+    <div class="fields">
+      {#each fields as field (field.key)}
+        {#if field.kind === "inline"}
+          <div class="row">
+            <span class="key">{formatFieldName(field.key)}</span>
+            <span class="val">{field.text}</span>
+          </div>
+        {:else if field.kind === "prose"}
+          <div class="prose">
+            <span class="key">{formatFieldName(field.key)}</span>
+            <p class="para">{field.text}</p>
+          </div>
+        {:else}
+          <div class="prose">
+            <span class="key">{formatFieldName(field.key)}</span>
+            {#each field.blocks as b, i (i)}
+              <p class="para">
+                {#if b.name}<strong>{b.name}.</strong>{/if}
+                {b.text}
+              </p>
+            {/each}
+          </div>
+        {/if}
+      {/each}
+    </div>
+  {/if}
+</article>
+
+<style>
+  .generic {
+    padding: clamp(1rem, 3vw, 1.5rem);
+    border: 1px solid var(--grim-paper-line);
+    border-top: 3px solid var(--grim-accent);
+    max-width: 40rem;
+  }
+
+  .name {
+    font-size: clamp(1.4rem, 4vw, 1.9rem);
+    color: var(--grim-accent-strong);
+  }
+
+  .strap {
+    font-size: 0.8rem;
+    color: var(--grim-ink-soft);
+  }
+
+  .fields {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  .row {
+    display: flex;
+    gap: 0.75rem;
+    align-items: baseline;
+  }
+
+  .key {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--grim-ink-soft);
+    min-width: 7rem;
+    flex-shrink: 0;
+  }
+
+  .val {
+    font-family: var(--grim-serif);
+    color: var(--grim-ink);
+  }
+
+  .prose .key {
+    display: block;
+    margin-bottom: 0.2rem;
+  }
+
+  .para {
+    font-family: var(--grim-serif);
+    font-size: 0.95rem;
+    line-height: 1.55;
+    color: var(--grim-ink);
+    margin-bottom: 0.3rem;
+  }
+
+  .none {
+    font-family: var(--grim-serif);
+    font-style: italic;
+    color: var(--grim-ink-soft);
+  }
+</style>

--- a/projects/monolith/frontend/src/lib/grimoire/statblock/Spell.svelte
+++ b/projects/monolith/frontend/src/lib/grimoire/statblock/Spell.svelte
@@ -1,0 +1,138 @@
+<script>
+  import { normalizeBlocks, scalarToText } from "$lib/grimoire/format.js";
+
+  let { data } = $props();
+
+  const strap = $derived(
+    data.level === 0 || data.level === "0"
+      ? [data.school, "cantrip"].filter(Boolean).join(" ")
+      : ["Level", data.level, data.school].filter((x) => x != null && x !== "")
+          .join(" "),
+  );
+
+  const grid = $derived(
+    [
+      ["Casting Time", data.casting_time],
+      ["Range", data.range],
+      ["Components", data.components],
+      ["Duration", data.duration],
+    ].filter(([, v]) => v != null && v !== ""),
+  );
+
+  const classes = $derived(
+    data.classes
+      ? Array.isArray(data.classes)
+        ? data.classes.join(", ")
+        : scalarToText(data.classes)
+      : "",
+  );
+
+  const description = $derived(normalizeBlocks(data.description));
+</script>
+
+<article class="spell grim-paper">
+  <h2 class="grim-title name">{data.name}</h2>
+  {#if strap}<p class="grim-smallcaps strap">{strap}</p>{/if}
+
+  <hr class="grim-rule" />
+
+  {#if grid.length}
+    <dl class="meta">
+      {#each grid as [label, value] (label)}
+        <div>
+          <dt>{label}</dt>
+          <dd>{value}</dd>
+        </div>
+      {/each}
+    </dl>
+  {/if}
+
+  {#if classes}
+    <p class="classes"><span class="classes-label">Classes:</span> {classes}</p>
+  {/if}
+
+  {#if description.length}
+    <hr class="grim-rule" />
+    <div class="body">
+      {#each description as p, i (i)}
+        <p class="para">
+          {#if p.name}<strong>{p.name}.</strong>{/if}
+          {p.text}
+        </p>
+      {/each}
+    </div>
+  {/if}
+</article>
+
+<style>
+  .spell {
+    padding: clamp(1rem, 3vw, 1.5rem);
+    border: 1px solid var(--grim-paper-line);
+    border-top: 3px solid var(--grim-accent);
+    max-width: 40rem;
+  }
+
+  .name {
+    font-size: clamp(1.4rem, 4vw, 1.9rem);
+    color: var(--grim-accent-strong);
+  }
+
+  .strap {
+    font-size: 0.85rem;
+    color: var(--grim-ink-soft);
+    font-style: italic;
+  }
+
+  .meta {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.5rem 1.25rem;
+  }
+
+  .meta dt {
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--grim-ink-soft);
+  }
+
+  .meta dd {
+    font-family: var(--grim-serif);
+    font-weight: 700;
+    font-size: 0.95rem;
+  }
+
+  .classes {
+    margin-top: 0.6rem;
+    font-family: var(--grim-serif);
+    font-size: 0.9rem;
+  }
+
+  .classes-label {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--grim-ink-soft);
+  }
+
+  .body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .para {
+    font-family: var(--grim-serif);
+    font-size: 0.95rem;
+    line-height: 1.55;
+    color: var(--grim-ink);
+  }
+
+  @media (max-width: 480px) {
+    .meta {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/lib/grimoire/theme.css
+++ b/projects/monolith/frontend/src/lib/grimoire/theme.css
@@ -1,0 +1,106 @@
+/* Grimoire visual identity, layered over the shared monolith tokens and scoped
+ * to the .grimoire route tree (never forks the token system). An arcane ledger,
+ * not a terminal: keep --font-mono for chrome (labels, nav, badges), add a
+ * serif display face for names and titles, swap the blue accent for oxblood,
+ * and tint the reading pane like paper.
+ *
+ * The display face is a system serif stack (Iowan / Palatino / Georgia) rather
+ * than a self-hosted woff2: it ships no binary, needs no font-loading gotcha,
+ * and every listed family supports the small-caps + old-style figures the stat
+ * blocks want. Swapping in a licensed self-hosted serif later is a drop-in
+ * change to --grim-serif.
+ */
+
+.grimoire {
+  /* Oxblood / madder red, inherited from the Monster Manual stat-block heritage.
+   * Overriding --accent here recolors every descendant that reads it (links,
+   * active states) without touching the global token. */
+  --grim-accent: #7c2b2b;
+  --grim-accent-strong: #5c1d1d;
+  --accent: var(--grim-accent);
+
+  --grim-serif:
+    "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia,
+    "Times New Roman", serif;
+
+  /* Paper: a warm near-white for reading surfaces only (the reader + stat
+   * block), never the whole chrome. */
+  --grim-paper: #faf6ee;
+  --grim-paper-line: #e6ddca;
+  --grim-ink: #241c15;
+  --grim-ink-soft: #5b4f42;
+}
+
+body.dark .grimoire {
+  --grim-accent: #c56d6d;
+  --grim-accent-strong: #d98a8a;
+  --grim-paper: #17130f;
+  --grim-paper-line: #322920;
+  --grim-ink: #ece3d4;
+  --grim-ink-soft: #b3a793;
+}
+
+/* ── Display type ─────────────────────────────────────────── */
+
+.grim-title {
+  font-family: var(--grim-serif);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  line-height: 1.15;
+}
+
+.grim-smallcaps {
+  font-family: var(--grim-serif);
+  font-variant: small-caps;
+  letter-spacing: 0.06em;
+}
+
+/* ── Tapered rule divider (stat-block flourish) ───────────── */
+
+.grim-rule {
+  height: 3px;
+  border: 0;
+  margin: 0.5rem 0;
+  background: var(--grim-accent);
+  /* Taper the ends so it reads as an engraved rule, not a plain border. */
+  clip-path: polygon(0 45%, 100% 0, 100% 100%, 0 55%);
+}
+
+/* ── Paper reading surface ────────────────────────────────── */
+
+.grim-paper {
+  background: var(--grim-paper);
+  color: var(--grim-ink);
+}
+
+/* ── Motion: transform/opacity only, and only when motion is allowed ─── */
+
+@media (prefers-reduced-motion: no-preference) {
+  .grim-stagger > * {
+    opacity: 0;
+    transform: translateY(4px);
+    animation: grim-rise 0.32s ease-out forwards;
+  }
+  .grim-stagger > *:nth-child(1) {
+    animation-delay: 0.02s;
+  }
+  .grim-stagger > *:nth-child(2) {
+    animation-delay: 0.06s;
+  }
+  .grim-stagger > *:nth-child(3) {
+    animation-delay: 0.1s;
+  }
+  .grim-stagger > *:nth-child(4) {
+    animation-delay: 0.14s;
+  }
+  .grim-stagger > *:nth-child(n + 5) {
+    animation-delay: 0.18s;
+  }
+}
+
+@keyframes grim-rise {
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/projects/monolith/frontend/src/routes/private/app/grimoire/+layout.ts
+++ b/projects/monolith/frontend/src/routes/private/app/grimoire/+layout.ts
@@ -1,0 +1,5 @@
+// The whole Grimoire subtree is client-only: campaign/viewpoint/entity picks are
+// interactive state fetched against /api/grimoire, not something a server load()
+// would usefully pre-render (same rationale as private/notes + private/chat).
+// Declaring ssr = false at the layout covers the index and every [campaign] route.
+export const ssr = false;

--- a/projects/monolith/frontend/src/routes/private/app/grimoire/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/app/grimoire/+page.svelte
@@ -1,898 +1,226 @@
 <script>
   import { onMount } from "svelte";
+  import { goto } from "$app/navigation";
+  import {
+    apiFetch,
+    lastCampaignId,
+    rememberCampaign,
+    lastViewpoint,
+    libraryHref,
+  } from "$lib/grimoire/api.js";
+  import "$lib/grimoire/theme.css";
 
-  const API = "/api/grimoire";
-  const LS_CAMPAIGN = "grimoire:campaign";
-  const LS_VIEWPOINT = "grimoire:viewpoint";
-
-  const ENTITY_TYPES = [
-    "creature",
-    "spell",
-    "location",
-    "npc",
-    "faction",
-    "deity",
-    "item",
-  ];
-  const GRANT_SCOPES = ["full", "partial", "name_only"];
-
-  // ── Campaigns ──────────────────────────────
   let campaigns = $state([]);
-  let campaignId = $state("");
-  let campaignsLoading = $state(true);
-  let campaignsError = $state("");
+  let loading = $state(true);
+  let error = $state("");
 
-  let newCampaignName = $state("");
-  let newCampaignDm = $state("");
-  let creatingCampaign = $state(false);
-  let createCampaignError = $state("");
+  let newName = $state("");
+  let newDm = $state("");
+  let creating = $state(false);
+  let createError = $state("");
 
-  // ── Characters / viewpoint ─────────────────
-  let characters = $state([]);
-  let charactersLoading = $state(false);
-  let viewpoint = $state("dm");
+  const viewpoint = () => lastViewpoint() || "dm";
 
-  let showAddCharacter = $state(false);
-  let newCharName = $state("");
-  let newCharPlayer = $state("");
-  let addingCharacter = $state(false);
-  let addCharacterError = $state("");
-
-  // ── Entity browser ─────────────────────────
-  let entities = $state([]);
-  let entitiesLoading = $state(false);
-  let entitiesError = $state("");
-  let typeFilter = $state("");
-  let nameQuery = $state("");
-
-  // ── Entity detail ──────────────────────────
-  let selectedEntityId = $state(null);
-  let entityDetail = $state(null);
-  let entityRelationships = $state([]);
-  let detailLoading = $state(false);
-  let detailError = $state("");
-
-  // ── Search ──────────────────────────────────
-  let searchQuery = $state("");
-  let searchResults = $state([]);
-  let searching = $state(false);
-  let searchError = $state("");
-  let searchTimer;
-
-  // ── DM grant editor ─────────────────────────
-  let grants = $state([]);
-  let grantsLoading = $state(false);
-  let grantEntityId = $state("");
-  let grantCharacterId = $state("");
-  let grantScope = $state("full");
-  let grantRevealedDetails = $state("");
-  let creatingGrant = $state(false);
-  let grantError = $state("");
-
-  let isDm = $derived(viewpoint === "dm");
-  let entityById = $derived(new Map(entities.map((e) => [e.id, e])));
-  let characterById = $derived(new Map(characters.map((c) => [c.id, c])));
-
-  async function apiFetch(path, options = {}) {
-    const res = await fetch(`${API}${path}`, {
-      ...options,
-      headers: options.body
-        ? { "Content-Type": "application/json" }
-        : undefined,
-    });
-    let body = null;
-    try {
-      body = await res.json();
-    } catch {
-      body = null;
-    }
-    if (!res.ok) {
-      throw new Error(body?.detail ?? `request failed (${res.status})`);
-    }
-    return body;
+  function enter(id) {
+    rememberCampaign(id);
+    goto(libraryHref(id, viewpoint()));
   }
 
-  async function loadCampaigns() {
-    campaignsLoading = true;
-    campaignsError = "";
+  onMount(async () => {
     try {
       campaigns = await apiFetch("/campaigns");
-      const stored = localStorage.getItem(LS_CAMPAIGN);
-      if (stored && campaigns.some((c) => c.id === stored)) {
-        campaignId = stored;
-      } else if (campaigns.length > 0) {
-        campaignId = campaigns[0].id;
+      const stored = lastCampaignId();
+      const target =
+        campaigns.find((c) => c.id === stored)?.id ?? campaigns[0]?.id;
+      // Redirect straight into the remembered (or first) campaign; the picker
+      // only shows when there is a genuine choice to make or nothing yet.
+      if (target && campaigns.length === 1) {
+        enter(target);
+        return;
       }
     } catch (e) {
-      campaignsError = e.message;
+      error = e.message;
     } finally {
-      campaignsLoading = false;
+      loading = false;
     }
-  }
-
-  onMount(loadCampaigns);
-
-  function selectCampaign(id) {
-    campaignId = id;
-    localStorage.setItem(LS_CAMPAIGN, id);
-  }
+  });
 
   async function createCampaign() {
-    if (!newCampaignName.trim()) return;
-    creatingCampaign = true;
-    createCampaignError = "";
+    if (!newName.trim()) return;
+    creating = true;
+    createError = "";
     try {
       const campaign = await apiFetch("/campaigns", {
         method: "POST",
         body: JSON.stringify({
-          name: newCampaignName.trim(),
-          dm_name: newCampaignDm.trim() || null,
+          name: newName.trim(),
+          dm_name: newDm.trim() || null,
         }),
       });
-      campaigns = [...campaigns, campaign];
-      newCampaignName = "";
-      newCampaignDm = "";
-      selectCampaign(campaign.id);
-      showAddCharacter = true;
+      enter(campaign.id);
     } catch (e) {
-      createCampaignError = e.message;
+      createError = e.message;
     } finally {
-      creatingCampaign = false;
+      creating = false;
     }
   }
-
-  async function loadCharacters(id) {
-    if (!id) {
-      characters = [];
-      return;
-    }
-    charactersLoading = true;
-    try {
-      characters = await apiFetch(`/campaigns/${id}/characters`);
-      const stored = localStorage.getItem(LS_VIEWPOINT);
-      viewpoint =
-        stored === "dm" || characters.some((c) => c.id === stored)
-          ? stored
-          : "dm";
-      showAddCharacter = characters.length === 0;
-    } catch {
-      characters = [];
-      viewpoint = "dm";
-    } finally {
-      charactersLoading = false;
-    }
-  }
-
-  function selectViewpoint(v) {
-    viewpoint = v;
-    localStorage.setItem(LS_VIEWPOINT, v);
-    selectedEntityId = null;
-    entityDetail = null;
-    entityRelationships = [];
-  }
-
-  async function addCharacter() {
-    if (!campaignId || !newCharName.trim()) return;
-    addingCharacter = true;
-    addCharacterError = "";
-    try {
-      const character = await apiFetch(`/campaigns/${campaignId}/characters`, {
-        method: "POST",
-        body: JSON.stringify({
-          character_name: newCharName.trim(),
-          player_name: newCharPlayer.trim() || null,
-        }),
-      });
-      characters = [...characters, character];
-      newCharName = "";
-      newCharPlayer = "";
-      showAddCharacter = false;
-    } catch (e) {
-      addCharacterError = e.message;
-    } finally {
-      addingCharacter = false;
-    }
-  }
-
-  async function loadEntities() {
-    if (!campaignId) {
-      entities = [];
-      return;
-    }
-    entitiesLoading = true;
-    entitiesError = "";
-    try {
-      const params = new URLSearchParams({ as: viewpoint });
-      if (typeFilter) params.set("type", typeFilter);
-      if (nameQuery.trim()) params.set("q", nameQuery.trim());
-      entities = await apiFetch(`/campaigns/${campaignId}/entities?${params}`);
-    } catch (e) {
-      entitiesError = e.message;
-      entities = [];
-    } finally {
-      entitiesLoading = false;
-    }
-  }
-
-  async function openEntity(id) {
-    if (!campaignId || !id) return;
-    selectedEntityId = id;
-    detailLoading = true;
-    detailError = "";
-    entityDetail = null;
-    entityRelationships = [];
-    const asParam = `as=${encodeURIComponent(viewpoint)}`;
-    try {
-      const [detail, relationships] = await Promise.all([
-        apiFetch(`/campaigns/${campaignId}/entities/${id}?${asParam}`),
-        apiFetch(
-          `/campaigns/${campaignId}/entities/${id}/relationships?${asParam}`,
-        ),
-      ]);
-      entityDetail = detail;
-      entityRelationships = relationships;
-    } catch (e) {
-      detailError = e.message;
-    } finally {
-      detailLoading = false;
-    }
-  }
-
-  async function runSearch() {
-    if (!campaignId || !searchQuery.trim()) return;
-    searching = true;
-    searchError = "";
-    try {
-      const params = new URLSearchParams({
-        as: viewpoint,
-        q: searchQuery.trim(),
-      });
-      searchResults = await apiFetch(`/campaigns/${campaignId}/search?${params}`);
-    } catch (e) {
-      searchError = e.message;
-      searchResults = [];
-    } finally {
-      searching = false;
-    }
-  }
-
-  async function loadGrants() {
-    if (!campaignId) {
-      grants = [];
-      return;
-    }
-    grantsLoading = true;
-    try {
-      grants = await apiFetch(`/campaigns/${campaignId}/grants`);
-    } catch {
-      grants = [];
-    } finally {
-      grantsLoading = false;
-    }
-  }
-
-  async function createGrant() {
-    if (!campaignId || !grantEntityId || !grantCharacterId) return;
-    creatingGrant = true;
-    grantError = "";
-    let revealedDetails = null;
-    if (grantScope === "partial" && grantRevealedDetails.trim()) {
-      try {
-        revealedDetails = JSON.parse(grantRevealedDetails);
-      } catch {
-        grantError = "revealed details must be valid JSON";
-        creatingGrant = false;
-        return;
-      }
-    }
-    try {
-      await apiFetch(`/campaigns/${campaignId}/grants`, {
-        method: "POST",
-        body: JSON.stringify({
-          entity_id: grantEntityId,
-          player_character_id: grantCharacterId,
-          grant_scope: grantScope,
-          revealed_details: revealedDetails,
-        }),
-      });
-      grantRevealedDetails = "";
-      await Promise.all([loadGrants(), loadEntities()]);
-    } catch (e) {
-      grantError = e.message;
-    } finally {
-      creatingGrant = false;
-    }
-  }
-
-  async function updateGrantScope(grant, scope) {
-    grantError = "";
-    try {
-      await apiFetch(`/campaigns/${campaignId}/grants/${grant.id}`, {
-        method: "PATCH",
-        body: JSON.stringify({ grant_scope: scope }),
-      });
-      await Promise.all([loadGrants(), loadEntities()]);
-    } catch (e) {
-      grantError = e.message;
-    }
-  }
-
-  function entityLabel(id) {
-    return entityById.get(id)?.name ?? id;
-  }
-
-  function characterLabel(id) {
-    return characterById.get(id)?.character_name ?? id;
-  }
-
-  function entityBadge(entity) {
-    if (isDm) {
-      const count = entity.grants?.length ?? 0;
-      return count > 0 ? `${count} grant${count === 1 ? "" : "s"}` : "";
-    }
-    return "revealed_details" in entity && !("source_type" in entity)
-      ? "partial"
-      : "";
-  }
-
-  const DETAIL_SKIP_FIELDS = new Set([
-    "id",
-    "entity_type",
-    "name",
-    "grant",
-    "grants",
-    "revealed_details",
-  ]);
-
-  function detailFields(entity) {
-    if (!entity) return [];
-    return Object.entries(entity).filter(
-      ([key, value]) => !DETAIL_SKIP_FIELDS.has(key) && value !== null,
-    );
-  }
-
-  function formatFieldName(key) {
-    return key.replaceAll("_", " ");
-  }
-
-  $effect(() => {
-    loadCharacters(campaignId);
-  });
-
-  $effect(() => {
-    campaignId;
-    viewpoint;
-    typeFilter;
-    nameQuery;
-    loadEntities();
-  });
-
-  $effect(() => {
-    if (isDm) loadGrants();
-  });
-
-  $effect(() => {
-    campaignId;
-    viewpoint;
-    selectedEntityId = null;
-    entityDetail = null;
-    entityRelationships = [];
-    searchQuery = "";
-    searchResults = [];
-    searchError = "";
-  });
-
-  $effect(() => {
-    clearTimeout(searchTimer);
-    const q = searchQuery;
-    if (!q.trim()) {
-      searchResults = [];
-      searchError = "";
-      return;
-    }
-    searchTimer = setTimeout(runSearch, 300);
-    return () => clearTimeout(searchTimer);
-  });
 </script>
 
-<div class="root">
-  <header class="topbar">
-    <h1 class="title">Grimoire</h1>
-
-    {#if campaigns.length > 0}
-      <select
-        class="campaign-select"
-        value={campaignId}
-        onchange={(e) => selectCampaign(e.target.value)}
-      >
-        {#each campaigns as campaign (campaign.id)}
-          <option value={campaign.id}>{campaign.name}</option>
-        {/each}
-      </select>
-    {/if}
-
-    <nav class="viewpoints">
-      <button
-        class="viewpoint-btn"
-        class:viewpoint-btn--active={viewpoint === "dm"}
-        onclick={() => selectViewpoint("dm")}
-      >
-        DM
-      </button>
-      {#each characters as character (character.id)}
-        <button
-          class="viewpoint-btn"
-          class:viewpoint-btn--active={viewpoint === character.id}
-          onclick={() => selectViewpoint(character.id)}
-        >
-          {character.character_name}
-        </button>
-      {/each}
-      <button
-        class="viewpoint-btn viewpoint-btn--add"
-        onclick={() => (showAddCharacter = !showAddCharacter)}
-        disabled={!campaignId}
-      >
-        + character
-      </button>
-    </nav>
+<div class="grimoire picker">
+  <header class="head">
+    <h1 class="grim-title brand">Grimoire</h1>
+    <p class="tagline">An arcane ledger for your table.</p>
   </header>
 
-  {#if campaignsLoading}
-    <p class="status">loading campaigns...</p>
-  {:else if campaignsError}
-    <p class="status status--error">{campaignsError}</p>
-  {:else if campaigns.length === 0}
-    <section class="onboarding">
-      <h2 class="section-label">new campaign</h2>
-      <div class="form-row">
+  {#if loading}
+    <div class="skeleton-list">
+      <div class="skeleton"></div>
+      <div class="skeleton"></div>
+    </div>
+  {:else if error}
+    <p class="status status--error">{error}</p>
+  {:else}
+    {#if campaigns.length > 0}
+      <section class="block">
+        <h2 class="label">choose a campaign</h2>
+        <ul class="campaign-list">
+          {#each campaigns as campaign (campaign.id)}
+            <li>
+              <button class="campaign-row" onclick={() => enter(campaign.id)}>
+                <span class="grim-title campaign-name">{campaign.name}</span>
+                {#if campaign.dm_name}
+                  <span class="campaign-dm">DM: {campaign.dm_name}</span>
+                {/if}
+              </button>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
+    <section class="block">
+      <h2 class="label">new campaign</h2>
+      <div class="form">
         <input
           class="text-input"
           placeholder="campaign name"
-          bind:value={newCampaignName}
+          bind:value={newName}
         />
         <input
           class="text-input"
           placeholder="dm name (optional)"
-          bind:value={newCampaignDm}
+          bind:value={newDm}
         />
         <button
           class="btn"
-          disabled={creatingCampaign || !newCampaignName.trim()}
+          disabled={creating || !newName.trim()}
           onclick={createCampaign}
         >
           create
         </button>
       </div>
-      {#if createCampaignError}
-        <p class="status status--error">{createCampaignError}</p>
+      {#if createError}
+        <p class="status status--error">{createError}</p>
       {/if}
     </section>
-  {:else}
-    {#if showAddCharacter}
-      <section class="onboarding">
-        <h2 class="section-label">add character</h2>
-        <div class="form-row">
-          <input
-            class="text-input"
-            placeholder="character name"
-            bind:value={newCharName}
-          />
-          <input
-            class="text-input"
-            placeholder="player name (optional)"
-            bind:value={newCharPlayer}
-          />
-          <button
-            class="btn"
-            disabled={addingCharacter || !newCharName.trim()}
-            onclick={addCharacter}
-          >
-            add
-          </button>
-          <button class="btn btn--ghost" onclick={() => (showAddCharacter = false)}>
-            close
-          </button>
-        </div>
-        {#if addCharacterError}
-          <p class="status status--error">{addCharacterError}</p>
-        {/if}
-      </section>
-    {/if}
-
-    <div class="layout">
-      <aside class="sidebar">
-        <section class="panel">
-          <h2 class="section-label">entities</h2>
-          <div class="filter-row">
-            <select
-              class="type-select"
-              value={typeFilter}
-              onchange={(e) => (typeFilter = e.target.value)}
-            >
-              <option value="">all types</option>
-              {#each ENTITY_TYPES as t}
-                <option value={t}>{t}</option>
-              {/each}
-            </select>
-          </div>
-          <input
-            class="text-input"
-            placeholder="search by name..."
-            bind:value={nameQuery}
-          />
-
-          {#if entitiesLoading}
-            <p class="status">loading...</p>
-          {:else if entitiesError}
-            <p class="status status--error">{entitiesError}</p>
-          {:else if entities.length === 0}
-            <p class="status">no entities visible</p>
-          {:else}
-            <ul class="entity-list">
-              {#each entities as entity (entity.id)}
-                <li>
-                  <button
-                    class="entity-card"
-                    class:entity-card--active={selectedEntityId === entity.id}
-                    onclick={() => openEntity(entity.id)}
-                  >
-                    <span class="entity-name">{entity.name}</span>
-                    <span class="entity-meta">
-                      <span class="entity-type">{entity.entity_type}</span>
-                      {#if entityBadge(entity)}
-                        <span class="badge">{entityBadge(entity)}</span>
-                      {/if}
-                    </span>
-                  </button>
-                </li>
-              {/each}
-            </ul>
-          {/if}
-        </section>
-      </aside>
-
-      <main class="main">
-        <section class="panel">
-          <h2 class="section-label">search</h2>
-          <input
-            class="text-input"
-            placeholder="search entities and lore..."
-            bind:value={searchQuery}
-          />
-          {#if searching}
-            <p class="status">searching...</p>
-          {:else if searchError}
-            <p class="status status--error">{searchError}</p>
-          {:else if searchResults.length > 0}
-            <ul class="search-list">
-              {#each searchResults as hit, i (hit.id ?? i)}
-                <li class="search-hit">
-                  {#if hit.kind === "entity"}
-                    <button class="search-hit-btn" onclick={() => openEntity(hit.id)}>
-                      <span class="search-hit-title">{hit.name}</span>
-                      <span class="entity-type">{hit.entity_type}</span>
-                      <span class="score">{hit.score.toFixed(2)}</span>
-                    </button>
-                  {:else}
-                    <div class="search-hit-chunk">
-                      <span class="search-hit-title">
-                        {hit.book_id} &middot; {hit.section_path}
-                      </span>
-                      <span class="score">{hit.score.toFixed(2)}</span>
-                      <p class="chunk-preview">{hit.preview}</p>
-                    </div>
-                  {/if}
-                </li>
-              {/each}
-            </ul>
-          {/if}
-        </section>
-
-        <section class="panel">
-          <h2 class="section-label">detail</h2>
-          {#if detailLoading}
-            <p class="status">loading...</p>
-          {:else if detailError}
-            <p class="status status--error">{detailError}</p>
-          {:else if entityDetail}
-            <div class="detail">
-              <h3 class="detail-name">{entityDetail.name}</h3>
-              <span class="entity-type">{entityDetail.entity_type}</span>
-
-              {#if entityDetail.revealed_details}
-                <pre class="detail-json">{JSON.stringify(
-                    entityDetail.revealed_details,
-                    null,
-                    2,
-                  )}</pre>
-              {/if}
-
-              {#each detailFields(entityDetail) as [key, value]}
-                <div class="detail-row">
-                  <span class="detail-key">{formatFieldName(key)}</span>
-                  {#if typeof value === "object"}
-                    <pre class="detail-json">{JSON.stringify(value, null, 2)}</pre>
-                  {:else}
-                    <span class="detail-value">{String(value)}</span>
-                  {/if}
-                </div>
-              {/each}
-
-              {#if isDm && entityDetail.grants}
-                <div class="detail-row">
-                  <span class="detail-key">grants</span>
-                  {#if entityDetail.grants.length === 0}
-                    <span class="detail-value">none</span>
-                  {:else}
-                    <ul class="grant-mini-list">
-                      {#each entityDetail.grants as g}
-                        <li>
-                          {characterLabel(g.player_character_id)}: {g.grant_scope}
-                        </li>
-                      {/each}
-                    </ul>
-                  {/if}
-                </div>
-              {/if}
-
-              <h4 class="section-label">relationships</h4>
-              {#if entityRelationships.length === 0}
-                <p class="status">none visible</p>
-              {:else}
-                <ul class="rel-list">
-                  {#each entityRelationships as rel, i (i)}
-                    <li
-                      class="rel-row"
-                      class:rel-row--dim={rel.entity.recognition_only}
-                    >
-                      <span class="rel-arrow">{rel.direction === "out" ? "→" : "←"}</span>
-                      <span class="rel-type">{rel.rel_type}</span>
-                      {#if rel.entity.recognition_only}
-                        <span class="rel-name">{rel.entity.name}</span>
-                        <span class="badge">name only</span>
-                      {:else}
-                        <button
-                          class="rel-name rel-name--link"
-                          onclick={() => openEntity(rel.entity.id)}
-                        >
-                          {rel.entity.name}
-                        </button>
-                      {/if}
-                    </li>
-                  {/each}
-                </ul>
-              {/if}
-            </div>
-          {:else}
-            <p class="status">select an entity</p>
-          {/if}
-        </section>
-
-        {#if isDm}
-          <section class="panel">
-            <h2 class="section-label">grant editor</h2>
-            <div class="grant-form">
-              <select
-                class="type-select"
-                bind:value={grantEntityId}
-              >
-                <option value="">entity...</option>
-                {#each entities as entity (entity.id)}
-                  <option value={entity.id}>{entity.name} ({entity.entity_type})</option>
-                {/each}
-              </select>
-              <select
-                class="type-select"
-                bind:value={grantCharacterId}
-              >
-                <option value="">character...</option>
-                {#each characters as character (character.id)}
-                  <option value={character.id}>{character.character_name}</option>
-                {/each}
-              </select>
-              <select class="type-select" bind:value={grantScope}>
-                {#each GRANT_SCOPES as scope}
-                  <option value={scope}>{scope}</option>
-                {/each}
-              </select>
-              {#if grantScope === "partial"}
-                <textarea
-                  class="text-input json-input"
-                  placeholder={`{"note": "revealed details as json"}`}
-                  bind:value={grantRevealedDetails}
-                ></textarea>
-              {/if}
-              <button
-                class="btn"
-                disabled={creatingGrant || !grantEntityId || !grantCharacterId}
-                onclick={createGrant}
-              >
-                grant
-              </button>
-            </div>
-            {#if grantError}
-              <p class="status status--error">{grantError}</p>
-            {/if}
-
-            {#if grantsLoading}
-              <p class="status">loading grants...</p>
-            {:else if grants.length === 0}
-              <p class="status">no grants yet</p>
-            {:else}
-              <ul class="grant-list">
-                {#each grants as grant (grant.id)}
-                  <li class="grant-row">
-                    <span class="grant-entity">{entityLabel(grant.entity_id)}</span>
-                    <span class="grant-arrow">&rarr;</span>
-                    <span class="grant-character">
-                      {characterLabel(grant.player_character_id)}
-                    </span>
-                    <select
-                      class="type-select type-select--inline"
-                      value={grant.grant_scope}
-                      onchange={(e) => updateGrantScope(grant, e.target.value)}
-                    >
-                      {#each GRANT_SCOPES as scope}
-                        <option value={scope}>{scope}</option>
-                      {/each}
-                    </select>
-                  </li>
-                {/each}
-              </ul>
-            {/if}
-          </section>
-        {/if}
-      </main>
-    </div>
   {/if}
 </div>
 
 <style>
-  .root {
-    height: 100vh;
+  .picker {
+    min-height: 100dvh;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: var(--font-mono);
+    padding: clamp(1.5rem, 6vw, 5rem) 1.5rem;
+    max-width: 46rem;
+    margin: 0 auto;
     display: flex;
     flex-direction: column;
-    font-family: var(--font);
-    color: var(--fg);
-    background: var(--bg);
+    gap: 2rem;
   }
 
-  .topbar {
-    display: flex;
-    align-items: center;
-    gap: 1.25rem;
-    padding: 1rem 1.5rem;
-    border-bottom: var(--border-heavy);
-    flex-wrap: wrap;
+  .brand {
+    font-size: clamp(2rem, 8vw, 3rem);
+    color: var(--grim-accent);
   }
 
-  .title {
-    font-size: 1.1rem;
+  .tagline {
+    color: var(--muted);
+    font-size: 0.85rem;
+    margin-top: 0.35rem;
+  }
+
+  .label {
+    font-size: 0.65rem;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
-    margin-right: auto;
+    letter-spacing: 0.14em;
+    color: var(--fg-tertiary);
+    margin-bottom: 0.75rem;
   }
 
-  .campaign-select {
-    font-family: var(--font);
-    font-size: 0.85rem;
-    padding: 0.35rem 0.5rem;
+  .campaign-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .campaign-row {
+    width: 100%;
+    min-height: 3rem;
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.75rem 1rem;
     background: var(--bg);
     color: var(--fg);
-    border: var(--border-thin);
-  }
-
-  .viewpoints {
-    display: flex;
-    gap: 0.4rem;
-    flex-wrap: wrap;
-  }
-
-  .viewpoint-btn {
-    font-family: var(--font);
-    font-size: 0.75rem;
-    padding: 0.35rem 0.6rem;
-    background: var(--bg);
-    color: var(--fg-secondary);
     border: var(--border-thin);
     cursor: pointer;
   }
 
-  .viewpoint-btn--active {
-    background: var(--fg);
-    color: var(--bg);
+  .campaign-row:hover {
+    border-color: var(--grim-accent);
   }
 
-  .viewpoint-btn--add {
+  .campaign-name {
+    font-size: 1.15rem;
+  }
+
+  .campaign-dm {
+    font-size: 0.7rem;
     color: var(--fg-tertiary);
-    border-style: dashed;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
   }
 
-  .viewpoint-btn:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-
-  .onboarding {
-    padding: 1.25rem 1.5rem;
-    border-bottom: var(--border-thin);
-  }
-
-  .form-row {
+  .form {
     display: flex;
     gap: 0.5rem;
     flex-wrap: wrap;
     align-items: center;
   }
 
-  .layout {
-    flex: 1;
-    display: flex;
-    overflow: hidden;
-  }
-
-  .sidebar {
-    width: 22rem;
-    flex-shrink: 0;
-    border-right: var(--border-thin);
-    overflow-y: auto;
-  }
-
-  .main {
-    flex: 1;
-    overflow-y: auto;
-  }
-
-  .panel {
-    padding: 1.25rem 1.5rem;
-    border-bottom: var(--border-thin);
-    display: flex;
-    flex-direction: column;
-    gap: 0.6rem;
-  }
-
-  .section-label {
-    font-size: 0.65rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-    color: var(--fg-tertiary);
-  }
-
-  .text-input,
-  .type-select {
-    font-family: var(--font);
-    font-size: 0.85rem;
-    padding: 0.4rem 0.5rem;
+  .text-input {
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    min-height: 2.75rem;
+    padding: 0.5rem 0.65rem;
     background: var(--bg);
     color: var(--fg);
     border: var(--border-thin);
-  }
-
-  .json-input {
-    min-height: 4rem;
-    resize: vertical;
-  }
-
-  .type-select--inline {
-    padding: 0.15rem 0.3rem;
-    font-size: 0.75rem;
-  }
-
-  .filter-row {
-    display: flex;
-    gap: 0.5rem;
+    flex: 1 1 12rem;
   }
 
   .btn {
-    font-family: var(--font);
-    font-size: 0.8rem;
-    padding: 0.4rem 0.75rem;
-    background: var(--fg);
-    color: var(--bg);
-    border: var(--border-thin);
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    min-height: 2.75rem;
+    padding: 0.5rem 1rem;
+    background: var(--grim-accent);
+    color: #fff;
+    border: none;
     cursor: pointer;
   }
 
@@ -901,190 +229,41 @@
     cursor: not-allowed;
   }
 
-  .btn--ghost {
-    background: var(--bg);
-    color: var(--fg-secondary);
-  }
-
-  .status {
-    font-size: 0.8rem;
-    color: var(--fg-tertiary);
-  }
-
   .status--error {
     color: var(--danger);
-  }
-
-  .entity-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-  }
-
-  .entity-card {
-    width: 100%;
-    text-align: left;
-    display: flex;
-    flex-direction: column;
-    gap: 0.15rem;
-    padding: 0.5rem 0.6rem;
-    background: var(--bg);
-    color: var(--fg);
-    border: var(--border-thin);
-    cursor: pointer;
-    font-family: var(--font);
-  }
-
-  .entity-card--active {
-    background: var(--surface);
-    border-color: var(--accent);
-  }
-
-  .entity-name {
-    font-weight: 700;
-    font-size: 0.85rem;
-  }
-
-  .entity-meta {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-  }
-
-  .entity-type {
-    font-size: 0.65rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--fg-tertiary);
-  }
-
-  .badge {
-    font-size: 0.6rem;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    padding: 0.1rem 0.35rem;
-    border: var(--border-thin);
-    color: var(--fg-secondary);
-  }
-
-  .search-list,
-  .grant-list,
-  .grant-mini-list,
-  .rel-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-  }
-
-  .search-hit-btn {
-    width: 100%;
-    text-align: left;
-    display: flex;
-    gap: 0.5rem;
-    align-items: baseline;
-    background: none;
-    border: none;
-    padding: 0.3rem 0;
-    cursor: pointer;
-    font-family: var(--font);
-    color: var(--fg);
-  }
-
-  .search-hit-title {
-    font-weight: 700;
-    font-size: 0.85rem;
-  }
-
-  .score {
-    font-size: 0.7rem;
-    color: var(--fg-tertiary);
-    font-variant-numeric: tabular-nums;
-  }
-
-  .search-hit-chunk {
-    padding: 0.3rem 0;
-  }
-
-  .chunk-preview {
     font-size: 0.8rem;
-    color: var(--fg-secondary);
-    margin-top: 0.2rem;
   }
 
-  .detail {
+  .skeleton-list {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
   }
 
-  .detail-name {
-    font-size: 1rem;
-    font-weight: 700;
+  .skeleton {
+    height: 3rem;
+    background: linear-gradient(
+      90deg,
+      var(--surface) 25%,
+      transparent 37%,
+      var(--surface) 63%
+    );
+    background-size: 400% 100%;
+    animation: shimmer 1.4s ease infinite;
   }
 
-  .detail-row {
-    display: flex;
-    gap: 0.5rem;
-    align-items: baseline;
-    font-size: 0.8rem;
+  @keyframes shimmer {
+    0% {
+      background-position: 100% 0;
+    }
+    100% {
+      background-position: 0 0;
+    }
   }
 
-  .detail-key {
-    color: var(--fg-tertiary);
-    text-transform: uppercase;
-    font-size: 0.65rem;
-    letter-spacing: 0.06em;
-    min-width: 8rem;
-  }
-
-  .detail-value {
-    color: var(--fg);
-  }
-
-  .detail-json {
-    font-size: 0.75rem;
-    background: var(--surface);
-    padding: 0.5rem;
-    white-space: pre-wrap;
-    word-break: break-word;
-  }
-
-  .rel-row {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-    font-size: 0.8rem;
-  }
-
-  .rel-row--dim {
-    opacity: 0.5;
-  }
-
-  .rel-name--link {
-    background: none;
-    border: none;
-    color: var(--accent);
-    cursor: pointer;
-    font-family: var(--font);
-    padding: 0;
-    text-decoration: underline;
-  }
-
-  .grant-form {
-    display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-    align-items: center;
-  }
-
-  .grant-row {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-    font-size: 0.8rem;
-  }
-
-  .grant-arrow {
-    color: var(--fg-tertiary);
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton {
+      animation: none;
+    }
   }
 </style>

--- a/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/+layout.svelte
@@ -1,0 +1,284 @@
+<script>
+  import { setContext } from "svelte";
+  import { page } from "$app/stores";
+  import { goto } from "$app/navigation";
+  import {
+    apiFetch,
+    resolveViewpoint,
+    rememberViewpoint,
+    rememberCampaign,
+    libraryHref,
+    entitiesHref,
+  } from "$lib/grimoire/api.js";
+  import Omnibox from "$lib/grimoire/Omnibox.svelte";
+  import "$lib/grimoire/theme.css";
+
+  let { children } = $props();
+
+  const campaignId = $derived($page.params.campaign);
+  const viewpoint = $derived(resolveViewpoint($page.url));
+
+  let campaigns = $state([]);
+  let characters = $state([]);
+
+  // Shared state for child routes (character list for grant UIs, the campaign
+  // list, and the fetch helper) via context with reactive getters.
+  setContext("grimoire", {
+    apiFetch,
+    get campaigns() {
+      return campaigns;
+    },
+    get characters() {
+      return characters;
+    },
+    get campaignId() {
+      return campaignId;
+    },
+    get viewpoint() {
+      return viewpoint;
+    },
+    reloadCharacters: () => loadCharacters(campaignId),
+  });
+
+  async function loadCampaigns() {
+    try {
+      campaigns = await apiFetch("/campaigns");
+    } catch {
+      campaigns = [];
+    }
+  }
+
+  async function loadCharacters(id) {
+    if (!id) {
+      characters = [];
+      return;
+    }
+    try {
+      characters = await apiFetch(`/campaigns/${id}/characters`);
+    } catch {
+      characters = [];
+    }
+  }
+
+  $effect(() => {
+    loadCampaigns();
+  });
+
+  $effect(() => {
+    rememberCampaign(campaignId);
+    loadCharacters(campaignId);
+  });
+
+  function switchCampaign(id) {
+    goto(libraryHref(id, viewpoint));
+  }
+
+  function switchViewpoint(v) {
+    rememberViewpoint(v);
+    const url = new URL($page.url);
+    url.searchParams.set("as", v);
+    goto(url, { keepFocus: true, noScroll: true });
+  }
+</script>
+
+<div class="grimoire root">
+  <header class="topbar">
+    <div class="brand-row">
+      <a class="grim-title brand" href={libraryHref(campaignId, viewpoint)}>
+        Grimoire
+      </a>
+      {#if campaigns.length > 0}
+        <select
+          class="campaign-select"
+          value={campaignId}
+          onchange={(e) => switchCampaign(e.currentTarget.value)}
+          aria-label="Campaign"
+        >
+          {#each campaigns as campaign (campaign.id)}
+            <option value={campaign.id}>{campaign.name}</option>
+          {/each}
+        </select>
+      {/if}
+    </div>
+
+    <div class="omnibox-slot">
+      <Omnibox {campaignId} {viewpoint} />
+    </div>
+
+    <nav class="viewpoints" aria-label="Viewpoint">
+      <span class="viewpoints-label">as</span>
+      <button
+        class="vp"
+        class:vp--active={viewpoint === "dm"}
+        onclick={() => switchViewpoint("dm")}
+      >
+        DM
+      </button>
+      {#each characters as character (character.id)}
+        <button
+          class="vp"
+          class:vp--active={viewpoint === character.id}
+          onclick={() => switchViewpoint(character.id)}
+        >
+          {character.character_name}
+        </button>
+      {/each}
+    </nav>
+
+    <nav class="crumbs" aria-label="Sections">
+      <a
+        class="crumb"
+        class:crumb--active={$page.url.pathname === `/app/grimoire/${campaignId}`}
+        href={libraryHref(campaignId, viewpoint)}>Library</a
+      >
+      <a
+        class="crumb"
+        class:crumb--active={$page.url.pathname.includes("/entities") ||
+          $page.url.pathname.includes("/entity/")}
+        href={entitiesHref(campaignId, viewpoint)}>Entities</a
+      >
+    </nav>
+  </header>
+
+  <main class="frame">
+    {@render children()}
+  </main>
+</div>
+
+<style>
+  .root {
+    height: 100dvh;
+    display: flex;
+    flex-direction: column;
+    font-family: var(--font-mono);
+    color: var(--fg);
+    background: var(--bg);
+    overflow: hidden;
+  }
+
+  .topbar {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas:
+      "brand omnibox viewpoints"
+      "crumbs crumbs crumbs";
+    align-items: center;
+    gap: 0.75rem 1rem;
+    padding: 0.75rem 1rem;
+    border-bottom: var(--border-heavy);
+  }
+
+  .brand-row {
+    grid-area: brand;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .brand {
+    font-size: 1.25rem;
+    color: var(--grim-accent);
+    text-decoration: none;
+  }
+
+  .campaign-select {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    min-height: 2.25rem;
+    padding: 0.3rem 0.4rem;
+    background: var(--bg);
+    color: var(--fg);
+    border: var(--border-thin);
+    max-width: 9rem;
+  }
+
+  .omnibox-slot {
+    grid-area: omnibox;
+    justify-self: stretch;
+    min-width: 0;
+  }
+
+  .viewpoints {
+    grid-area: viewpoints;
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .viewpoints-label {
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--fg-tertiary);
+  }
+
+  .vp {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    min-height: 2.25rem;
+    padding: 0.3rem 0.6rem;
+    background: var(--bg);
+    color: var(--fg-secondary);
+    border: var(--border-thin);
+    cursor: pointer;
+  }
+
+  .vp--active {
+    background: var(--grim-accent);
+    border-color: var(--grim-accent);
+    color: #fff;
+  }
+
+  .crumbs {
+    grid-area: crumbs;
+    display: flex;
+    gap: 1rem;
+  }
+
+  .crumb {
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--fg-tertiary);
+    padding-bottom: 0.1rem;
+    border-bottom: 2px solid transparent;
+  }
+
+  .crumb--active {
+    color: var(--fg);
+    border-bottom-color: var(--grim-accent);
+  }
+
+  .frame {
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  /* Desktop: give the omnibox a comfortable center column and let the top bar
+   * breathe on one row. */
+  @media (min-width: 880px) {
+    .topbar {
+      grid-template-columns: auto minmax(16rem, 34rem) 1fr;
+      grid-template-areas: "brand omnibox viewpoints" "crumbs crumbs crumbs";
+      column-gap: 1.5rem;
+    }
+  }
+
+  /* Narrow phones: stack the omnibox under the brand/viewpoint row so nothing
+   * gets crushed. */
+  @media (max-width: 600px) {
+    .topbar {
+      grid-template-columns: 1fr auto;
+      grid-template-areas:
+        "brand viewpoints"
+        "omnibox omnibox"
+        "crumbs crumbs";
+    }
+    .viewpoints {
+      justify-content: flex-end;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/+page.svelte
@@ -1,0 +1,409 @@
+<script>
+  import { onMount, getContext } from "svelte";
+  import { goto } from "$app/navigation";
+  import {
+    apiFetch,
+    bookHref,
+    entitiesHref,
+    bookLastSeen,
+    markBookSeen,
+  } from "$lib/grimoire/api.js";
+
+  // Campaign + viewpoint come from the layout context (route param + ?as=).
+  const ctx = getContext("grimoire");
+
+  let books = $state([]);
+  let loading = $state(true);
+  let error = $state("");
+
+  let renamingId = $state("");
+  let renameValue = $state("");
+
+  async function load() {
+    loading = true;
+    error = "";
+    try {
+      books = await apiFetch("/books");
+    } catch (e) {
+      error = e.message;
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(load);
+
+  function isNew(book) {
+    if (!book.latest_chunk_at) return false;
+    const seen = bookLastSeen(book.book_id);
+    return !seen || book.latest_chunk_at > seen;
+  }
+
+  function openBook(book) {
+    markBookSeen(book.book_id, book.latest_chunk_at);
+    goto(bookHref(ctx.campaignId, book.book_id, ctx.viewpoint));
+  }
+
+  function coverage(book) {
+    if (!book.chunk_count) return 0;
+    return Math.round((book.extracted_count / book.chunk_count) * 100);
+  }
+
+  function timeAgo(iso) {
+    if (!iso) return "never";
+    const then = new Date(iso).getTime();
+    if (Number.isNaN(then)) return "";
+    const secs = Math.max(0, (Date.now() - then) / 1000);
+    const units = [
+      ["y", 31536000],
+      ["mo", 2592000],
+      ["d", 86400],
+      ["h", 3600],
+      ["m", 60],
+    ];
+    for (const [label, size] of units) {
+      if (secs >= size) return `${Math.floor(secs / size)}${label} ago`;
+    }
+    return "just now";
+  }
+
+  function startRename(book) {
+    renamingId = book.book_id;
+    renameValue = book.display_name;
+  }
+
+  async function saveRename(book) {
+    const name = renameValue.trim();
+    renamingId = "";
+    if (!name || name === book.display_name) return;
+    try {
+      await apiFetch(`/books/${encodeURIComponent(book.book_id)}`, {
+        method: "PATCH",
+        body: JSON.stringify({ display_name: name }),
+      });
+      book.display_name = name;
+      books = [...books];
+    } catch (e) {
+      error = e.message;
+    }
+  }
+</script>
+
+<div class="library grim-paper">
+  <div class="lib-head">
+    <h1 class="grim-title lib-title">Library</h1>
+    <a class="entities-link" href={entitiesHref(ctx.campaignId, ctx.viewpoint)}>
+      Browse entities →
+    </a>
+  </div>
+
+  {#if loading}
+    <div class="skeletons">
+      {#each [1, 2, 3] as n (n)}
+        <div class="skeleton"></div>
+      {/each}
+    </div>
+  {:else if error}
+    <p class="status status--error">{error}</p>
+  {:else if books.length === 0}
+    <div class="empty">
+      <p class="empty-lead">No books loaded yet.</p>
+      <p class="empty-help">
+        Load a sourcebook with <code>tools/upload-book.sh</code>; coverage will
+        appear here and tick up as extraction runs.
+      </p>
+    </div>
+  {:else}
+    <ul class="books">
+      {#each books as book (book.book_id)}
+        <li class="book">
+          <div class="book-main">
+            <div class="book-name-row">
+              {#if renamingId === book.book_id}
+                <!-- svelte-ignore a11y_autofocus -->
+                <input
+                  class="rename-input"
+                  bind:value={renameValue}
+                  autofocus
+                  onblur={() => saveRename(book)}
+                  onkeydown={(e) => {
+                    if (e.key === "Enter") saveRename(book);
+                    if (e.key === "Escape") (renamingId = "");
+                  }}
+                />
+              {:else}
+                <button class="book-name grim-title" onclick={() => openBook(book)}>
+                  {book.display_name}
+                </button>
+                {#if isNew(book)}
+                  <span class="new-badge">new</span>
+                {/if}
+                <button
+                  class="rename-btn"
+                  title="Rename book"
+                  aria-label="Rename book"
+                  onclick={() => startRename(book)}>✎</button
+                >
+              {/if}
+            </div>
+
+            <div class="book-stats grim-stagger">
+              <span class="stat">
+                <strong>{book.extracted_count}</strong> / {book.chunk_count} extracted
+              </span>
+              <span class="stat">{book.image_count} images</span>
+              <span class="stat">{book.entity_count} entities</span>
+              <span class="stat muted">loaded {timeAgo(book.last_loaded_at)}</span>
+            </div>
+
+            <div
+              class="coverage"
+              role="progressbar"
+              aria-valuenow={coverage(book)}
+              aria-valuemin="0"
+              aria-valuemax="100"
+            >
+              <div class="coverage-fill" style="width:{coverage(book)}%"></div>
+            </div>
+          </div>
+
+          <button class="book-open" onclick={() => openBook(book)}>Read →</button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .library {
+    min-height: 100%;
+    padding: clamp(1rem, 4vw, 2.5rem);
+    max-width: 60rem;
+    margin: 0 auto;
+  }
+
+  .lib-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .lib-title {
+    font-size: clamp(1.5rem, 5vw, 2.25rem);
+    color: var(--grim-accent);
+  }
+
+  .entities-link {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--grim-accent);
+    min-height: 2.5rem;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .books {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .book {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.15rem;
+    border: 1px solid var(--grim-paper-line);
+    background: var(--bg);
+  }
+
+  .book-main {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .book-name-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .book-name {
+    font-size: 1.2rem;
+    color: var(--fg);
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .book-name:hover {
+    color: var(--grim-accent);
+  }
+
+  .new-badge {
+    font-size: 0.55rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.1rem 0.35rem;
+    background: var(--grim-accent);
+    color: #fff;
+    font-family: var(--font-mono);
+  }
+
+  .rename-btn {
+    background: none;
+    border: none;
+    color: var(--fg-tertiary);
+    cursor: pointer;
+    font-size: 0.8rem;
+    min-height: 2rem;
+    min-width: 2rem;
+  }
+
+  .rename-btn:hover {
+    color: var(--grim-accent);
+  }
+
+  .rename-input {
+    font-family: var(--grim-serif);
+    font-size: 1.1rem;
+    padding: 0.25rem 0.4rem;
+    border: var(--border-thin);
+    background: var(--bg);
+    color: var(--fg);
+    flex: 1;
+  }
+
+  .book-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    font-size: 0.75rem;
+    color: var(--fg-secondary);
+  }
+
+  .stat strong {
+    color: var(--grim-accent);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stat.muted {
+    color: var(--fg-tertiary);
+  }
+
+  .coverage {
+    height: 4px;
+    background: var(--grim-paper-line);
+    overflow: hidden;
+  }
+
+  .coverage-fill {
+    height: 100%;
+    background: var(--grim-accent);
+    transition: width 0.4s ease;
+  }
+
+  .book-open {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    min-height: 2.5rem;
+    padding: 0.5rem 0.9rem;
+    background: var(--bg);
+    color: var(--fg);
+    border: var(--border-thin);
+    cursor: pointer;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .book-open:hover {
+    border-color: var(--grim-accent);
+    color: var(--grim-accent);
+  }
+
+  .empty {
+    padding: 3rem 1rem;
+    text-align: center;
+  }
+
+  .empty-lead {
+    font-family: var(--grim-serif);
+    font-size: 1.3rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .empty-help {
+    font-size: 0.82rem;
+    color: var(--fg-secondary);
+  }
+
+  .empty-help code {
+    background: var(--surface);
+    padding: 0.1rem 0.3rem;
+  }
+
+  .status--error {
+    color: var(--danger);
+    font-size: 0.8rem;
+  }
+
+  .skeletons {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .skeleton {
+    height: 5.5rem;
+    background: linear-gradient(
+      90deg,
+      var(--surface) 25%,
+      transparent 37%,
+      var(--surface) 63%
+    );
+    background-size: 400% 100%;
+    animation: shimmer 1.4s ease infinite;
+  }
+
+  @keyframes shimmer {
+    0% {
+      background-position: 100% 0;
+    }
+    100% {
+      background-position: 0 0;
+    }
+  }
+
+  @media (min-width: 880px) {
+    .book-stats {
+      gap: 1.25rem;
+    }
+  }
+
+  @media (max-width: 600px) {
+    .book {
+      flex-direction: column;
+      align-items: stretch;
+    }
+    .book-open {
+      align-self: flex-start;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton {
+      animation: none;
+    }
+    .coverage-fill {
+      transition: none;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/book/[book]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/book/[book]/+page.svelte
@@ -1,0 +1,206 @@
+<script>
+  import { getContext } from "svelte";
+  import { page } from "$app/stores";
+  import {
+    apiFetch,
+    chunkHref,
+    libraryHref,
+    bookLastSeen,
+    markBookSeen,
+  } from "$lib/grimoire/api.js";
+
+  const ctx = getContext("grimoire");
+
+  const bookId = $derived(decodeURIComponent($page.params.book));
+
+  let sections = $state([]);
+  let displayName = $state("");
+  let loading = $state(true);
+  let error = $state("");
+
+  $effect(() => {
+    load(bookId);
+  });
+
+  async function load(id) {
+    loading = true;
+    error = "";
+    try {
+      const [secs, books] = await Promise.all([
+        apiFetch(`/books/${encodeURIComponent(id)}/sections`),
+        apiFetch("/books"),
+      ]);
+      sections = secs;
+      const book = books.find((b) => b.book_id === id);
+      displayName = book?.display_name ?? id;
+      // Visiting the book counts as "seen" for the Library's new-badge.
+      if (book?.latest_chunk_at) markBookSeen(id, book.latest_chunk_at);
+    } catch (e) {
+      error = e.message;
+    } finally {
+      loading = false;
+    }
+  }
+
+  const seenAt = $derived(bookLastSeen(bookId));
+  function isNew(section) {
+    return section.latest_chunk_at && (!seenAt || section.latest_chunk_at > seenAt);
+  }
+</script>
+
+<div class="book">
+  <a class="back" href={libraryHref(ctx.campaignId, ctx.viewpoint)}>← Library</a>
+
+  {#if loading}
+    <div class="skeletons">
+      {#each Array(6) as _, i (i)}
+        <div class="skeleton"></div>
+      {/each}
+    </div>
+  {:else if error}
+    <p class="status status--error">{error}</p>
+  {:else}
+    <h1 class="grim-title title">{displayName}</h1>
+
+    {#if sections.length === 0}
+      <p class="empty">This book has no chunks yet.</p>
+    {:else}
+      <ul class="sections">
+        {#each sections as section (section.section_path)}
+          <li>
+            <a
+              class="section"
+              href={chunkHref(
+                ctx.campaignId,
+                bookId,
+                section.first_chunk_id,
+                ctx.viewpoint,
+              )}
+            >
+              <span class="section-title grim-title">{section.title}</span>
+              <span class="section-meta">
+                <span>{section.chunk_count} chunks</span>
+                {#if section.image_count > 0}
+                  <span>{section.image_count} images</span>
+                {/if}
+                {#if isNew(section)}<span class="new">new</span>{/if}
+              </span>
+            </a>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .book {
+    padding: clamp(1rem, 4vw, 2rem);
+    max-width: 52rem;
+    margin: 0 auto;
+  }
+
+  .back {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.5rem;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--grim-accent);
+    margin-bottom: 0.75rem;
+  }
+
+  .title {
+    font-size: clamp(1.5rem, 5vw, 2.25rem);
+    color: var(--grim-accent);
+    margin-bottom: 1.25rem;
+  }
+
+  .sections {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .section {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    min-height: 3rem;
+    padding: 0.7rem 0.9rem;
+    border: 1px solid var(--grim-paper-line);
+    background: var(--bg);
+    color: var(--fg);
+  }
+
+  .section:hover {
+    border-color: var(--grim-accent);
+  }
+
+  .section-title {
+    font-size: 1.05rem;
+  }
+
+  .section-meta {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-tertiary);
+    white-space: nowrap;
+  }
+
+  .new {
+    padding: 0.08rem 0.35rem;
+    background: var(--grim-accent);
+    color: #fff;
+  }
+
+  .empty {
+    font-family: var(--grim-serif);
+    font-style: italic;
+    color: var(--fg-tertiary);
+  }
+
+  .status--error {
+    color: var(--danger);
+    font-size: 0.8rem;
+  }
+
+  .skeletons {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .skeleton {
+    height: 3rem;
+    background: linear-gradient(
+      90deg,
+      var(--surface) 25%,
+      transparent 37%,
+      var(--surface) 63%
+    );
+    background-size: 400% 100%;
+    animation: shimmer 1.4s ease infinite;
+  }
+
+  @keyframes shimmer {
+    0% {
+      background-position: 100% 0;
+    }
+    100% {
+      background-position: 0 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton {
+      animation: none;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/book/[book]/c/[chunk]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/book/[book]/c/[chunk]/+page.svelte
@@ -1,0 +1,42 @@
+<script>
+  import { getContext } from "svelte";
+  import { page } from "$app/stores";
+  import { bookHref } from "$lib/grimoire/api.js";
+  import ChunkReader from "$lib/grimoire/ChunkReader.svelte";
+
+  const ctx = getContext("grimoire");
+  const bookId = $derived(decodeURIComponent($page.params.book));
+  const chunkId = $derived($page.params.chunk);
+</script>
+
+<div class="reader-page">
+  <a class="back" href={bookHref(ctx.campaignId, bookId, ctx.viewpoint)}>
+    ← Sections
+  </a>
+  <ChunkReader
+    campaignId={ctx.campaignId}
+    {bookId}
+    {chunkId}
+    viewpoint={ctx.viewpoint}
+  />
+</div>
+
+<style>
+  .reader-page {
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+  }
+
+  .back {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.5rem;
+    padding: 0 clamp(1rem, 4vw, 2rem);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--grim-accent);
+    flex-shrink: 0;
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/entities/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/entities/+page.svelte
@@ -1,0 +1,309 @@
+<script>
+  import { getContext } from "svelte";
+  import { apiFetch, asQuery, entityHref } from "$lib/grimoire/api.js";
+
+  const ctx = getContext("grimoire");
+
+  const ENTITY_TYPES = [
+    "creature",
+    "spell",
+    "location",
+    "npc",
+    "faction",
+    "deity",
+    "item",
+  ];
+
+  let typeFilter = $state("");
+  let items = $state([]);
+  let total = $state(0);
+  let nextCursor = $state(null);
+  let loading = $state(true);
+  let loadingMore = $state(false);
+  let error = $state("");
+
+  // Reload whenever campaign, viewpoint, or the type filter changes.
+  $effect(() => {
+    load(ctx.campaignId, ctx.viewpoint, typeFilter);
+  });
+
+  async function load(campaignId, viewpoint, type) {
+    loading = true;
+    error = "";
+    items = [];
+    nextCursor = null;
+    try {
+      const extra = { limit: "60" };
+      if (type) extra.type = type;
+      const body = await apiFetch(
+        `/campaigns/${campaignId}/entities?${asQuery(viewpoint, extra)}`,
+      );
+      items = body.items ?? [];
+      total = body.total ?? items.length;
+      nextCursor = body.next_cursor ?? null;
+    } catch (e) {
+      error = e.message;
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function loadMore() {
+    if (!nextCursor) return;
+    loadingMore = true;
+    try {
+      const extra = { limit: "60", cursor: nextCursor };
+      if (typeFilter) extra.type = typeFilter;
+      const body = await apiFetch(
+        `/campaigns/${ctx.campaignId}/entities?${asQuery(ctx.viewpoint, extra)}`,
+      );
+      items = [...items, ...(body.items ?? [])];
+      nextCursor = body.next_cursor ?? null;
+    } catch (e) {
+      error = e.message;
+    } finally {
+      loadingMore = false;
+    }
+  }
+
+  const isDm = $derived(ctx.viewpoint === "dm");
+  const viewerName = $derived(
+    ctx.characters.find((c) => c.id === ctx.viewpoint)?.character_name ?? "you",
+  );
+
+  function grantBadge(entity) {
+    if (isDm) {
+      const n = entity.grants?.length ?? 0;
+      return n > 0 ? `${n} grant${n === 1 ? "" : "s"}` : "";
+    }
+    // A player's partial reveal has revealed_details but no full spine.
+    return "revealed_details" in entity && !("source_type" in entity)
+      ? "partial"
+      : "";
+  }
+</script>
+
+<div class="entities">
+  <div class="filters">
+    <button
+      class="chip"
+      class:chip--active={typeFilter === ""}
+      onclick={() => (typeFilter = "")}>all</button
+    >
+    {#each ENTITY_TYPES as t (t)}
+      <button
+        class="chip"
+        class:chip--active={typeFilter === t}
+        onclick={() => (typeFilter = t)}>{t}</button
+      >
+    {/each}
+    {#if !loading && !error}
+      <span class="count">{total} total</span>
+    {/if}
+  </div>
+
+  {#if loading}
+    <ul class="grid">
+      {#each Array(8) as _, i (i)}
+        <li class="skeleton"></li>
+      {/each}
+    </ul>
+  {:else if error}
+    <p class="status status--error">{error}</p>
+  {:else if items.length === 0}
+    <div class="empty">
+      {#if isDm}
+        <p class="empty-lead">No entities yet.</p>
+        <p class="empty-help">
+          Entities appear as the extraction pass mines the loaded books.
+        </p>
+      {:else}
+        <p class="empty-lead">
+          The DM has not revealed anything to {viewerName} yet.
+        </p>
+        <p class="empty-help">What you learn at the table will show up here.</p>
+      {/if}
+    </div>
+  {:else}
+    <ul class="grid">
+      {#each items as entity (entity.id)}
+        <li>
+          <a
+            class="card"
+            href={entityHref(ctx.campaignId, entity.id, ctx.viewpoint)}
+          >
+            <span class="card-name grim-title">{entity.name}</span>
+            <span class="card-meta">
+              <span class="card-type">{entity.entity_type}</span>
+              {#if grantBadge(entity)}
+                <span class="badge">{grantBadge(entity)}</span>
+              {/if}
+            </span>
+          </a>
+        </li>
+      {/each}
+    </ul>
+
+    {#if nextCursor}
+      <button class="more" disabled={loadingMore} onclick={loadMore}>
+        {loadingMore ? "loading…" : "Load more"}
+      </button>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .entities {
+    padding: clamp(1rem, 4vw, 2rem);
+    max-width: 64rem;
+    margin: 0 auto;
+  }
+
+  .filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    align-items: center;
+    margin-bottom: 1.25rem;
+  }
+
+  .chip {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    min-height: 2.25rem;
+    padding: 0.3rem 0.7rem;
+    background: var(--bg);
+    color: var(--fg-secondary);
+    border: var(--border-thin);
+    cursor: pointer;
+  }
+
+  .chip--active {
+    background: var(--grim-accent);
+    border-color: var(--grim-accent);
+    color: #fff;
+  }
+
+  .count {
+    margin-left: auto;
+    font-size: 0.68rem;
+    color: var(--fg-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+    gap: 0.6rem;
+  }
+
+  .card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    min-height: 3.5rem;
+    padding: 0.75rem 0.85rem;
+    border: 1px solid var(--grim-paper-line);
+    background: var(--bg);
+    color: var(--fg);
+  }
+
+  .card:hover {
+    border-color: var(--grim-accent);
+  }
+
+  .card-name {
+    font-size: 1.02rem;
+  }
+
+  .card-meta {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .card-type {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-tertiary);
+  }
+
+  .badge {
+    font-size: 0.55rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.08rem 0.35rem;
+    border: var(--border-thin);
+    color: var(--fg-secondary);
+  }
+
+  .more {
+    display: block;
+    margin: 1.25rem auto 0;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    min-height: 2.75rem;
+    padding: 0.5rem 1.5rem;
+    background: var(--bg);
+    color: var(--fg);
+    border: var(--border-thin);
+    cursor: pointer;
+  }
+
+  .more:hover {
+    border-color: var(--grim-accent);
+  }
+
+  .empty {
+    padding: 3rem 1rem;
+    text-align: center;
+  }
+
+  .empty-lead {
+    font-family: var(--grim-serif);
+    font-size: 1.25rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .empty-help {
+    font-size: 0.82rem;
+    color: var(--fg-secondary);
+  }
+
+  .status--error {
+    color: var(--danger);
+    font-size: 0.8rem;
+  }
+
+  .skeleton {
+    height: 3.9rem;
+    border: 1px solid var(--grim-paper-line);
+    background: linear-gradient(
+      90deg,
+      var(--surface) 25%,
+      transparent 37%,
+      var(--surface) 63%
+    );
+    background-size: 400% 100%;
+    animation: shimmer 1.4s ease infinite;
+  }
+
+  @keyframes shimmer {
+    0% {
+      background-position: 100% 0;
+    }
+    100% {
+      background-position: 0 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton {
+      animation: none;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/entity/[id]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/entity/[id]/+page.svelte
@@ -1,0 +1,318 @@
+<script>
+  import { getContext } from "svelte";
+  import { page } from "$app/stores";
+  import {
+    apiFetch,
+    asQuery,
+    isDm,
+    entitiesHref,
+    entityHref,
+    chunkHref,
+  } from "$lib/grimoire/api.js";
+  import EntityDetail from "$lib/grimoire/statblock/EntityDetail.svelte";
+  import GrantChips from "$lib/grimoire/GrantChips.svelte";
+
+  const ctx = getContext("grimoire");
+
+  const entityId = $derived($page.params.id);
+
+  let entity = $state(null);
+  let relationships = $state([]);
+  let sources = $state([]);
+  let loading = $state(true);
+  let error = $state("");
+  let notFound = $state(false);
+
+  $effect(() => {
+    load(ctx.campaignId, entityId, ctx.viewpoint);
+  });
+
+  async function load(campaignId, id, viewpoint) {
+    loading = true;
+    error = "";
+    notFound = false;
+    entity = null;
+    relationships = [];
+    sources = [];
+    const q = asQuery(viewpoint);
+    try {
+      entity = await apiFetch(`/campaigns/${campaignId}/entities/${id}?${q}`);
+    } catch (e) {
+      if (String(e.message).includes("not found")) notFound = true;
+      else error = e.message;
+      loading = false;
+      return;
+    }
+    // Relationships + sources are best-effort; a failure there must not blank
+    // the whole detail page.
+    const [rels, mentions] = await Promise.allSettled([
+      apiFetch(`/campaigns/${campaignId}/entities/${id}/relationships?${q}`),
+      apiFetch(`/campaigns/${campaignId}/entities/${id}/mentions?${q}`),
+    ]);
+    relationships = rels.status === "fulfilled" ? rels.value : [];
+    sources = mentions.status === "fulfilled" ? mentions.value : [];
+    loading = false;
+  }
+</script>
+
+<div class="detail-page">
+  <a class="back" href={entitiesHref(ctx.campaignId, ctx.viewpoint)}>← Entities</a>
+
+  {#if loading}
+    <div class="skeleton"></div>
+  {:else if notFound}
+    <div class="empty">
+      <p class="empty-lead">Not revealed.</p>
+      <p class="empty-help">
+        This entity is not part of what your character knows yet.
+      </p>
+    </div>
+  {:else if error}
+    <p class="status status--error">{error}</p>
+  {:else if entity}
+    <div class="columns">
+      <div class="main">
+        <EntityDetail {entity} />
+
+        {#if relationships.length}
+          <section class="rels">
+            <h3 class="grim-smallcaps head">Relationships</h3>
+            <ul class="rel-list">
+              {#each relationships as rel, i (i)}
+                <li class="rel" class:rel--dim={rel.entity.recognition_only}>
+                  <span class="arrow">{rel.direction === "out" ? "→" : "←"}</span>
+                  <span class="rel-type">{rel.rel_type.replaceAll("_", " ")}</span>
+                  {#if rel.entity.recognition_only}
+                    <span class="rel-name">{rel.entity.name}</span>
+                    <span class="badge">name only</span>
+                  {:else}
+                    <a
+                      class="rel-name rel-name--link"
+                      href={entityHref(
+                        ctx.campaignId,
+                        rel.entity.id,
+                        ctx.viewpoint,
+                      )}>{rel.entity.name}</a
+                    >
+                  {/if}
+                </li>
+              {/each}
+            </ul>
+          </section>
+        {/if}
+
+        {#if sources.length}
+          <section class="sources">
+            <h3 class="grim-smallcaps head">Sources</h3>
+            <ul class="source-list">
+              {#each sources as src (src.chunk_id)}
+                <li>
+                  <a
+                    class="source"
+                    href={chunkHref(
+                      ctx.campaignId,
+                      src.book_id,
+                      src.chunk_id,
+                      ctx.viewpoint,
+                    )}
+                  >
+                    <span class="source-where">
+                      {src.section_path ?? "lore"}
+                    </span>
+                    <span class="source-preview">{src.preview}</span>
+                  </a>
+                </li>
+              {/each}
+            </ul>
+          </section>
+        {/if}
+      </div>
+
+      {#if isDm(ctx.viewpoint)}
+        <aside class="aside">
+          <GrantChips
+            campaignId={ctx.campaignId}
+            {entityId}
+            {entity}
+            characters={ctx.characters}
+          />
+        </aside>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .detail-page {
+    padding: clamp(1rem, 4vw, 2rem);
+    max-width: 68rem;
+    margin: 0 auto;
+  }
+
+  .back {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.5rem;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--grim-accent);
+    margin-bottom: 1rem;
+  }
+
+  .columns {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+    align-items: start;
+  }
+
+  .main {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    min-width: 0;
+  }
+
+  .head {
+    font-size: 0.9rem;
+    color: var(--grim-accent);
+    margin-bottom: 0.6rem;
+  }
+
+  .rel-list,
+  .source-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .rel {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+  }
+
+  .rel--dim {
+    opacity: 0.5;
+  }
+
+  .arrow {
+    color: var(--grim-accent);
+    font-weight: 700;
+  }
+
+  .rel-type {
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--fg-tertiary);
+  }
+
+  .rel-name {
+    font-family: var(--grim-serif);
+  }
+
+  .rel-name--link {
+    color: var(--grim-accent);
+    text-decoration: underline;
+  }
+
+  .badge {
+    font-size: 0.55rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.08rem 0.35rem;
+    border: var(--border-thin);
+    color: var(--fg-secondary);
+  }
+
+  .source {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid var(--grim-paper-line);
+    background: var(--bg);
+    color: var(--fg);
+  }
+
+  .source:hover {
+    border-color: var(--grim-accent);
+  }
+
+  .source-where {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-tertiary);
+  }
+
+  .source-preview {
+    font-family: var(--grim-serif);
+    font-size: 0.85rem;
+    color: var(--grim-ink-soft);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .empty {
+    padding: 3rem 1rem;
+    text-align: center;
+  }
+
+  .empty-lead {
+    font-family: var(--grim-serif);
+    font-size: 1.3rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .empty-help {
+    font-size: 0.82rem;
+    color: var(--fg-secondary);
+  }
+
+  .status--error {
+    color: var(--danger);
+    font-size: 0.8rem;
+  }
+
+  .skeleton {
+    height: 18rem;
+    background: linear-gradient(
+      90deg,
+      var(--surface) 25%,
+      transparent 37%,
+      var(--surface) 63%
+    );
+    background-size: 400% 100%;
+    animation: shimmer 1.4s ease infinite;
+  }
+
+  @keyframes shimmer {
+    0% {
+      background-position: 100% 0;
+    }
+    100% {
+      background-position: 0 0;
+    }
+  }
+
+  @media (min-width: 880px) {
+    .columns {
+      grid-template-columns: minmax(0, 1fr) 22rem;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton {
+      animation: none;
+    }
+  }
+</style>

--- a/projects/monolith/grimoire/entities_test.py
+++ b/projects/monolith/grimoire/entities_test.py
@@ -174,7 +174,7 @@ class TestListEntities:
             f"/api/grimoire/campaigns/{seed.campaign.id}/entities?as={seed.alice.id}"
         )
         assert r.status_code == 200
-        names = {item["name"] for item in r.json()}
+        names = {item["name"] for item in r.json()["items"]}
         assert names == {"Umbrasyl", "Strahd", "Castle Ravenloft"}
 
     def test_bob_sees_global_only(self, session, client):
@@ -183,7 +183,7 @@ class TestListEntities:
             f"/api/grimoire/campaigns/{seed.campaign.id}/entities?as={seed.bob.id}"
         )
         assert r.status_code == 200
-        names = {item["name"] for item in r.json()}
+        names = {item["name"] for item in r.json()["items"]}
         assert names == {"Umbrasyl"}
 
     def test_dm_sees_all_with_grant_annotations_aggregated(self, session, client):
@@ -191,7 +191,7 @@ class TestListEntities:
         r = client.get(f"/api/grimoire/campaigns/{seed.campaign.id}/entities?as=dm")
         assert r.status_code == 200
         body = r.json()
-        by_name = {item["name"]: item for item in body}
+        by_name = {item["name"]: item for item in body["items"]}
         assert set(by_name) == {
             "Umbrasyl",
             "Strahd",
@@ -208,7 +208,9 @@ class TestListEntities:
             }
         ]
         # No duplicate rows for entities with exactly one grant.
-        assert len(body) == 5
+        assert len(body["items"]) == 5
+        assert body["total"] == 5
+        assert body["next_cursor"] is None
 
     def test_type_filter(self, session, client):
         seed = seed_scenario(session)
@@ -216,7 +218,7 @@ class TestListEntities:
             f"/api/grimoire/campaigns/{seed.campaign.id}/entities?as=dm&type=creature"
         )
         assert r.status_code == 200
-        names = {item["name"] for item in r.json()}
+        names = {item["name"] for item in r.json()["items"]}
         assert names == {"Umbrasyl"}
 
     def test_q_filter(self, session, client):
@@ -225,8 +227,32 @@ class TestListEntities:
             f"/api/grimoire/campaigns/{seed.campaign.id}/entities?as=dm&q=cast"
         )
         assert r.status_code == 200
-        names = {item["name"] for item in r.json()}
+        names = {item["name"] for item in r.json()["items"]}
         assert names == {"Castle Ravenloft"}
+
+    def test_pagination_limit_and_cursor(self, session, client):
+        seed = seed_scenario(session)
+        base = f"/api/grimoire/campaigns/{seed.campaign.id}/entities?as=dm"
+
+        first = client.get(f"{base}&limit=2")
+        assert first.status_code == 200
+        first_body = first.json()
+        assert first_body["total"] == 5
+        assert len(first_body["items"]) == 2
+        assert first_body["next_cursor"] is not None
+
+        # Walk every page via the cursor and assert we see all 5 entities once,
+        # in the endpoint's name order, with no overlap between pages.
+        seen = list(first_body["items"])
+        cursor = first_body["next_cursor"]
+        while cursor is not None:
+            page = client.get(f"{base}&limit=2&cursor={cursor}").json()
+            seen.extend(page["items"])
+            cursor = page["next_cursor"]
+        names = [item["name"] for item in seen]
+        assert names == sorted(names)
+        assert len(names) == 5
+        assert len(set(names)) == 5
 
     def test_unknown_viewer_pc_404(self, session, client):
         seed = seed_scenario(session)

--- a/projects/monolith/grimoire/extract.py
+++ b/projects/monolith/grimoire/extract.py
@@ -546,6 +546,20 @@ def _prompt_hash() -> str:
     return hashlib.sha256(EXTRACTION_PROMPT.encode("utf-8")).hexdigest()
 
 
+def current_extraction_key() -> tuple[str, str]:
+    """The ``(model, prompt_hash)`` marker key the extraction pass writes right
+    now (env override or DEFAULT_MODEL, current prompt text).
+
+    Read paths that report extraction coverage (grimoire.library) count
+    ``chunk_extraction`` rows under exactly this key, so a book's "extracted"
+    count reflects the live model+prompt: bumping either resets coverage to
+    zero the same way it makes every chunk pending again in
+    ``_select_pending_chunks``.
+    """
+    model = os.environ.get("GRIMOIRE_EXTRACT_MODEL", DEFAULT_MODEL)
+    return model, _prompt_hash()
+
+
 def _select_pending_chunks(
     session: Session, model: str, prompt_hash: str, limit: int
 ) -> list[KnowledgeChunk]:

--- a/projects/monolith/grimoire/ingest.py
+++ b/projects/monolith/grimoire/ingest.py
@@ -382,23 +382,33 @@ async def load_chunks(
     """
     keys = _list_manifest_keys(s3_client, bucket, prefix)
 
-    books = 0
     chunks_upserted = 0
     chunks_embedded = 0
     errors = 0
     pending_embed: list[KnowledgeChunk] = []
-    book_ids: set[str] = set()
 
-    for key in keys:
+    # Concatenate every manifest belonging to a book before upserting, so ``seq``
+    # is assigned once over the book's full chunk sequence. A book may span
+    # several ``<book_id>/chunks/*.ndjson`` files (see _list_manifest_keys); if
+    # each file were enumerated independently, seq would restart at 0 per file
+    # and collide within the book, breaking the reading-order reads in library.py
+    # (keyset pagination, prev/next, section order) that assume seq is unique per
+    # book. Keys are sorted so multi-file books have a deterministic order
+    # (e.g. chunks-001, chunks-002).
+    parsed_by_book: dict[str, list[dict]] = {}
+    for key in sorted(keys):
         book_id = _book_id_from_key(key, prefix)
         body = s3_client.get_object(Bucket=bucket, Key=key)["Body"].read()
         if isinstance(body, bytes):
             body = body.decode("utf-8")
         parsed, err_count = parse_manifest_lines(book_id, body.splitlines())
         errors += err_count
-        books += 1
-        book_ids.add(book_id)
+        parsed_by_book.setdefault(book_id, []).extend(parsed)
 
+    books = len(parsed_by_book)
+    book_ids: set[str] = set(parsed_by_book)
+
+    for book_id, parsed in parsed_by_book.items():
         _upsert_book(session, book_id)
         book_pending, book_upserted = _upsert_book_chunks(session, book_id, parsed)
         chunks_upserted += book_upserted

--- a/projects/monolith/grimoire/ingest.py
+++ b/projects/monolith/grimoire/ingest.py
@@ -34,7 +34,7 @@ from typing import Any, Protocol
 
 from sqlmodel import Session, select
 
-from grimoire.models import Embedding, KnowledgeChunk
+from grimoire.models import Book, Embedding, KnowledgeChunk
 
 logger = logging.getLogger("monolith.grimoire.ingest")
 
@@ -245,20 +245,35 @@ def _book_id_from_key(key: str, prefix: str) -> str:
     return rest.split(_CHUNKS_SEGMENT, 1)[0].split("/", 1)[0]
 
 
+def _upsert_book(session: Session, book_id: str) -> None:
+    """Ensure a grimoire.book row exists for ``book_id`` (display_name defaults
+    to the id until renamed from the Library UI). Never overwrites an existing
+    display_name: a rename must survive re-uploads. Own savepoint so a book-row
+    failure cannot roll back the chunk upserts that follow.
+    """
+    with session.begin_nested():
+        if session.get(Book, book_id) is None:
+            session.add(Book(id=book_id, display_name=book_id))
+
+
 def _upsert_book_chunks(
     session: Session, book_id: str, parsed: list[dict]
 ) -> tuple[list[KnowledgeChunk], int]:
     """Sync upsert of one book's parsed chunks, keyed on (book_id, chunk_ref).
 
     Inserts new chunks, updates changed content/section_path/image_ref, and
-    skips unchanged chunks entirely (so a second run over identical data embeds
-    nothing). Each chunk gets its own savepoint so one bad row cannot roll
-    back the rest of the batch. Returns the rows that need (re-)embedding
-    and how many chunks were upserted (inserted or changed).
+    keeps ``seq`` in lockstep with NDJSON line order (the ``parsed`` list is in
+    manifest order). seq is rewritten on every run, so a re-upload that reorders
+    or inserts lines produces correct reading order even for chunks whose
+    content is otherwise unchanged. A pure seq move does not touch the vector.
+    Each chunk gets its own savepoint so one bad row cannot roll back the rest
+    of the batch. Returns the rows that need (re-)embedding and how many chunks
+    were upserted (inserted or content/metadata-changed; a seq-only shift does
+    not count as an upsert).
     """
     pending_embed: list[KnowledgeChunk] = []
     upserted = 0
-    for item in parsed:
+    for seq, item in enumerate(parsed):
         with session.begin_nested():
             existing = session.execute(
                 select(KnowledgeChunk).where(
@@ -274,6 +289,7 @@ def _upsert_book_chunks(
                     content=item["content"],
                     section_path=item["section_path"],
                     image_ref=item["image_ref"],
+                    seq=seq,
                 )
                 session.add(row)
                 session.flush()
@@ -285,6 +301,11 @@ def _upsert_book_chunks(
                     existing.section_path != item["section_path"]
                     or existing.image_ref != item["image_ref"]
                 )
+                # seq is corrected on every run but is not itself an "upsert":
+                # reading order shifting on a re-upload should not report the
+                # whole book as changed nor trigger re-embedding.
+                if existing.seq != seq:
+                    existing.seq = seq
                 if content_changed or meta_changed:
                     existing.content = item["content"]
                     existing.section_path = item["section_path"]
@@ -294,7 +315,7 @@ def _upsert_book_chunks(
                     # metadata-only fix does not move the vector.
                     if content_changed:
                         pending_embed.append(existing)
-                # else: fully unchanged, skip entirely (idempotent re-run).
+                # else: content/metadata unchanged (seq may have been corrected).
     session.commit()
     return pending_embed, upserted
 
@@ -378,6 +399,7 @@ async def load_chunks(
         books += 1
         book_ids.add(book_id)
 
+        _upsert_book(session, book_id)
         book_pending, book_upserted = _upsert_book_chunks(session, book_id, parsed)
         chunks_upserted += book_upserted
         pending_embed.extend(book_pending)

--- a/projects/monolith/grimoire/ingest_test.py
+++ b/projects/monolith/grimoire/ingest_test.py
@@ -335,6 +335,37 @@ def test_load_chunks_seq_rewritten_on_reorder_without_reembedding(session: Sessi
     assert embedder.calls == embeds_after_first + 1
 
 
+def test_load_chunks_seq_global_across_multiple_manifests(session: Session):
+    # A book split across two manifest files must get one contiguous seq
+    # sequence over both (sorted key order), not a 0-based restart per file --
+    # otherwise seq collides within the book and the reader's ordering breaks.
+    s3 = FakeS3Client(
+        {
+            "books/mm/chunks/chunks-001.ndjson": "\n".join(
+                [_line("a1", "one"), _line("a2", "two")]
+            ),
+            "books/mm/chunks/chunks-002.ndjson": "\n".join(
+                [_line("b1", "three"), _line("b2", "four")]
+            ),
+        }
+    )
+    summary = _run(
+        ingest.load_chunks(session, s3, FakeEmbedClient(), bucket="grimoire")
+    )
+    assert summary["books"] == 1
+
+    by_ref = {
+        c.chunk_ref: c for c in session.execute(select(KnowledgeChunk)).scalars().all()
+    }
+    assert by_ref["a1"].seq == 0
+    assert by_ref["a2"].seq == 1
+    assert by_ref["b1"].seq == 2
+    assert by_ref["b2"].seq == 3
+    # Every seq within the book is distinct.
+    seqs = [c.seq for c in by_ref.values()]
+    assert len(set(seqs)) == len(seqs)
+
+
 def test_load_chunks_upserts_book_row_once(session: Session):
     s3 = FakeS3Client({"books/mm/chunks/chunks.ndjson": _line("c1", "one")})
     embedder = FakeEmbedClient()

--- a/projects/monolith/grimoire/ingest_test.py
+++ b/projects/monolith/grimoire/ingest_test.py
@@ -11,7 +11,7 @@ from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
 from grimoire import ingest
-from grimoire.models import Embedding, KnowledgeChunk
+from grimoire.models import Book, Embedding, KnowledgeChunk
 
 
 @pytest.fixture(name="session")
@@ -286,6 +286,71 @@ def test_load_chunks_two_books_in_one_run(session: Session):
         ("phb", "c1"),
         ("dmg", "c1"),
     }
+
+
+# --- seq (reading order) + book metadata ---------------------------------
+
+
+def test_load_chunks_assigns_seq_from_line_order(session: Session):
+    manifest = "\n".join([_line("c1", "one"), _line("c2", "two"), _line("c3", "three")])
+    s3 = FakeS3Client({"books/phb/chunks/chunks.ndjson": manifest})
+    _run(ingest.load_chunks(session, s3, FakeEmbedClient(), bucket="grimoire"))
+
+    by_ref = {
+        c.chunk_ref: c for c in session.execute(select(KnowledgeChunk)).scalars().all()
+    }
+    assert (by_ref["c1"].seq, by_ref["c2"].seq, by_ref["c3"].seq) == (0, 1, 2)
+
+
+def test_load_chunks_seq_rewritten_on_reorder_without_reembedding(session: Session):
+    # First load: c1, c2. Re-upload with the order swapped and a new line
+    # inserted. seq must follow the new NDJSON order even for unchanged content,
+    # and a pure reorder must not re-embed.
+    s3 = FakeS3Client(
+        {
+            "books/phb/chunks/chunks.ndjson": "\n".join(
+                [_line("c1", "one"), _line("c2", "two")]
+            )
+        }
+    )
+    embedder = FakeEmbedClient()
+    _run(ingest.load_chunks(session, s3, embedder, bucket="grimoire"))
+    embeds_after_first = embedder.calls
+
+    s3.manifests["books/phb/chunks/chunks.ndjson"] = "\n".join(
+        [_line("c2", "two"), _line("new", "new content"), _line("c1", "one")]
+    )
+    summary = _run(ingest.load_chunks(session, s3, embedder, bucket="grimoire"))
+
+    by_ref = {
+        c.chunk_ref: c for c in session.execute(select(KnowledgeChunk)).scalars().all()
+    }
+    assert by_ref["c2"].seq == 0
+    assert by_ref["new"].seq == 1
+    assert by_ref["c1"].seq == 2
+    # Only the brand-new chunk is upserted/embedded; the two reordered ones are
+    # a pure seq shift (not counted as upserts, not re-embedded).
+    assert summary["chunks_upserted"] == 1
+    # The one embed batch this run covers only the new chunk.
+    assert embedder.calls == embeds_after_first + 1
+
+
+def test_load_chunks_upserts_book_row_once(session: Session):
+    s3 = FakeS3Client({"books/mm/chunks/chunks.ndjson": _line("c1", "one")})
+    embedder = FakeEmbedClient()
+    _run(ingest.load_chunks(session, s3, embedder, bucket="grimoire"))
+
+    book = session.get(Book, "mm")
+    assert book is not None
+    # display_name defaults to the id until renamed.
+    assert book.display_name == "mm"
+
+    # A rename must survive a re-upload (the loader never clobbers display_name).
+    book.display_name = "Monster Manual"
+    session.add(book)
+    session.commit()
+    _run(ingest.load_chunks(session, s3, embedder, bucket="grimoire"))
+    assert session.get(Book, "mm").display_name == "Monster Manual"
 
 
 # --- embed batching + self-heal ------------------------------------------

--- a/projects/monolith/grimoire/library.py
+++ b/projects/monolith/grimoire/library.py
@@ -1,0 +1,365 @@
+"""Read-path aggregations for the Library and chunk reader (UI overhaul Phase 2).
+
+The entity read paths (router.py) answer "what does this viewer know"; this
+module answers the complementary "what is in the corpus and how far has
+ingestion/extraction gotten" that the Library surface needs: per-book coverage
+counts, the section tree, paged chunk lists, a single chunk with its neighbours
+and on-page entities, and entity->chunk provenance.
+
+Chunks are corpus-global in v1 (matching search._resolve_chunk_hit), so book,
+section, and chunk reads are NOT campaign-scoped. Only the projections that
+depend on a viewpoint (a chunk's on-page entity chips, an entity's mention list)
+take a campaign + viewer, and those route every visibility decision through the
+same visibility.visible_entities_query()/project_entity() helpers the entity
+endpoints use, so the grant predicate stays in one place.
+
+Every function here is a plain sync helper over a Session (no FastAPI, no
+async): the GET endpoints that call them are sync ``def`` handlers, which
+FastAPI runs in its threadpool, so blocking DB work never touches the event
+loop (the same reason there is no ``asyncio.to_thread`` dance here that
+ingest/extract need for their scheduler-loop handlers).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import func
+from sqlmodel import Session, select
+
+from grimoire.extract import current_extraction_key
+from grimoire.models import (
+    Book,
+    ChunkEntityMention,
+    ChunkExtraction,
+    Entity,
+    KnowledgeChunk,
+)
+from grimoire.visibility import Viewer, project_entity, visible_entities_query
+
+# Characters of chunk content shown in a list/preview row (matches
+# search._CHUNK_PREVIEW_LEN so previews are consistent across surfaces).
+_PREVIEW_LEN = 200
+
+# Default and max page size for the paged chunk list.
+DEFAULT_CHUNK_PAGE = 100
+MAX_CHUNK_PAGE = 500
+
+
+def _as_utc(dt: datetime | None) -> datetime | None:
+    """Coerce a possibly-naive datetime (SQLite tests round-trip TIMESTAMPTZ as
+    naive) to tz-aware UTC, matching the ships/router.py serialization pattern.
+    """
+    if dt is None:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def _iso(dt: datetime | None) -> str | None:
+    coerced = _as_utc(dt)
+    return coerced.isoformat() if coerced else None
+
+
+def _section_title(section_path: str | None) -> str:
+    """A short human label for a section: the last path segment, or a stable
+    placeholder for chunks with no section_path (front matter, stray blocks).
+    """
+    if not section_path:
+        return "(no section)"
+    return section_path.rsplit("/", 1)[-1].strip() or section_path
+
+
+def _kind(chunk: KnowledgeChunk) -> str:
+    return "image" if chunk.image_ref else "text"
+
+
+def list_books(session: Session) -> list[dict[str, Any]]:
+    """Per-book coverage rows for the Library.
+
+    Combines four cheap grouped scans (chunk counts, extraction coverage under
+    the live model+prompt, distinct entity yield, book display names) into one
+    row per book. ``extracted_count`` counts distinct chunks with a
+    ``chunk_extraction`` marker for the current ``(model, prompt_hash)`` key, so
+    it ticks up as the extraction CronWorkflow runs and resets if the model or
+    prompt changes (mirroring extract._select_pending_chunks). Books appear if
+    they have either a grimoire.book row or any chunk, so a freshly-registered
+    empty book still shows.
+    """
+    chunk_rows = session.execute(
+        select(
+            KnowledgeChunk.book_id,
+            func.count().label("chunk_count"),
+            # count(col) counts non-NULL values, so this is the image-chunk count.
+            func.count(KnowledgeChunk.image_ref).label("image_count"),
+            func.max(KnowledgeChunk.created_at).label("latest_chunk_at"),
+        ).group_by(KnowledgeChunk.book_id)
+    ).all()
+    chunk_by_book = {r.book_id: r for r in chunk_rows}
+
+    model, prompt_hash = current_extraction_key()
+    extracted_rows = session.execute(
+        select(
+            KnowledgeChunk.book_id,
+            func.count(func.distinct(ChunkExtraction.chunk_id)).label("n"),
+        )
+        .join(ChunkExtraction, ChunkExtraction.chunk_id == KnowledgeChunk.id)
+        .where(
+            ChunkExtraction.model == model,
+            ChunkExtraction.prompt_hash == prompt_hash,
+        )
+        .group_by(KnowledgeChunk.book_id)
+    ).all()
+    extracted_by_book = {r.book_id: r.n for r in extracted_rows}
+
+    entity_rows = session.execute(
+        select(
+            KnowledgeChunk.book_id,
+            func.count(func.distinct(ChunkEntityMention.entity_id)).label("n"),
+        )
+        .join(ChunkEntityMention, ChunkEntityMention.chunk_id == KnowledgeChunk.id)
+        .group_by(KnowledgeChunk.book_id)
+    ).all()
+    entity_by_book = {r.book_id: r.n for r in entity_rows}
+
+    books = {b.id: b for b in session.exec(select(Book)).all()}
+
+    book_ids = set(chunk_by_book) | set(books)
+    result: list[dict[str, Any]] = []
+    for book_id in book_ids:
+        book = books.get(book_id)
+        chunks = chunk_by_book.get(book_id)
+        result.append(
+            {
+                "book_id": book_id,
+                "display_name": book.display_name if book else book_id,
+                "chunk_count": chunks.chunk_count if chunks else 0,
+                "image_count": chunks.image_count if chunks else 0,
+                "extracted_count": extracted_by_book.get(book_id, 0),
+                "entity_count": entity_by_book.get(book_id, 0),
+                "last_loaded_at": _iso(book.created_at) if book else None,
+                "latest_chunk_at": _iso(chunks.latest_chunk_at) if chunks else None,
+            }
+        )
+    result.sort(key=lambda item: (item["display_name"].lower(), item["book_id"]))
+    return result
+
+
+def list_sections(session: Session, book_id: str) -> list[dict[str, Any]]:
+    """Ordered section tree for one book.
+
+    Sections are grouped by ``section_path`` in reading order (first appearance
+    by ``seq``), not alphabetically. ``first_chunk_id`` is the earliest chunk in
+    the section, so the reader can jump straight to the section start.
+    """
+    rows = session.execute(
+        select(
+            KnowledgeChunk.id,
+            KnowledgeChunk.seq,
+            KnowledgeChunk.section_path,
+            KnowledgeChunk.image_ref,
+            KnowledgeChunk.created_at,
+        )
+        .where(KnowledgeChunk.book_id == book_id)
+        .order_by(KnowledgeChunk.seq, KnowledgeChunk.chunk_ref)
+    ).all()
+
+    sections: dict[str | None, dict[str, Any]] = {}
+    order: list[str | None] = []
+    for chunk_id, _seq, section_path, image_ref, created_at in rows:
+        entry = sections.get(section_path)
+        if entry is None:
+            entry = {
+                "section_path": section_path,
+                "title": _section_title(section_path),
+                "chunk_count": 0,
+                "image_count": 0,
+                "first_chunk_id": chunk_id,
+                "latest_chunk_at": created_at,
+            }
+            sections[section_path] = entry
+            order.append(section_path)
+        entry["chunk_count"] += 1
+        if image_ref:
+            entry["image_count"] += 1
+        current = entry["latest_chunk_at"]
+        if created_at is not None and (current is None or created_at > current):
+            entry["latest_chunk_at"] = created_at
+
+    return [
+        {**sections[key], "latest_chunk_at": _iso(sections[key]["latest_chunk_at"])}
+        for key in order
+    ]
+
+
+def list_chunks(
+    session: Session,
+    book_id: str,
+    *,
+    section: str | None = None,
+    cursor: str | None = None,
+    limit: int = DEFAULT_CHUNK_PAGE,
+) -> dict[str, Any]:
+    """Seq-ordered page of a book's chunks (optionally within one section).
+
+    Keyset paginated on ``seq`` (unique within a book), so ``cursor`` is simply
+    the last seq returned; the next page is ``seq > cursor``. Returns
+    ``{items, next_cursor}`` where ``next_cursor`` is null on the last page.
+    """
+    limit = max(1, min(limit, MAX_CHUNK_PAGE))
+    query = select(KnowledgeChunk).where(KnowledgeChunk.book_id == book_id)
+    if section is not None:
+        query = query.where(KnowledgeChunk.section_path == section)
+    if cursor is not None:
+        try:
+            after = int(cursor)
+        except (TypeError, ValueError):
+            after = None
+        if after is not None:
+            query = query.where(KnowledgeChunk.seq > after)
+    # limit + 1 to detect whether another page follows without a second query.
+    query = query.order_by(KnowledgeChunk.seq).limit(limit + 1)
+    rows = session.exec(query).all()
+
+    has_more = len(rows) > limit
+    rows = rows[:limit]
+    items = [
+        {
+            "id": chunk.id,
+            "seq": chunk.seq,
+            "section_path": chunk.section_path,
+            "kind": _kind(chunk),
+            "preview": chunk.content[:_PREVIEW_LEN],
+            "created_at": _iso(chunk.created_at),
+        }
+        for chunk in rows
+    ]
+    next_cursor = str(rows[-1].seq) if has_more and rows else None
+    return {"items": items, "next_cursor": next_cursor}
+
+
+def _project_page_entity(
+    session: Session, campaign_id: str, viewer: Viewer, entity_id: str
+) -> dict[str, Any] | None:
+    """Project one on-page entity for the reader's "entities here" chips.
+
+    Uses "relationship" context so a name_only grant yields a recognition stub
+    (the player still sees the name they've heard) while a wholly-invisible
+    entity (non-global, ungranted) is dropped, exactly like router._project_
+    neighbor. The DM's grant-join can return multiple rows per entity; only the
+    identity is needed for a chip, so the first row is enough.
+    """
+    rows = session.exec(
+        visible_entities_query(campaign_id, viewer).where(Entity.id == entity_id)
+    ).all()
+    if not rows:
+        return None
+    entity, grant = rows[0]
+    return project_entity(entity, None, grant, viewer, context="relationship")
+
+
+def get_chunk(
+    session: Session, campaign_id: str, viewer: Viewer, chunk_id: str
+) -> dict[str, Any] | None:
+    """One chunk with full content, image URL, seq neighbours, and on-page
+    entities projected for ``viewer``. Returns None if the chunk is missing.
+
+    prev/next walk the book's ``seq`` order (the reading order the loader
+    assigns), so the reader's back/next controls follow the page sequence, not
+    insertion order. Entities come from chunk_entity_mention, viewpoint-filtered.
+    """
+    chunk = session.get(KnowledgeChunk, chunk_id)
+    if chunk is None:
+        return None
+
+    prev_id: str | None = None
+    next_id: str | None = None
+    if chunk.seq is not None:
+        prev_id = session.exec(
+            select(KnowledgeChunk.id)
+            .where(
+                KnowledgeChunk.book_id == chunk.book_id,
+                KnowledgeChunk.seq < chunk.seq,
+            )
+            .order_by(KnowledgeChunk.seq.desc())
+            .limit(1)
+        ).first()
+        next_id = session.exec(
+            select(KnowledgeChunk.id)
+            .where(
+                KnowledgeChunk.book_id == chunk.book_id,
+                KnowledgeChunk.seq > chunk.seq,
+            )
+            .order_by(KnowledgeChunk.seq)
+            .limit(1)
+        ).first()
+
+    mention_rows = session.exec(
+        select(Entity.id, ChunkEntityMention.mention_text)
+        .join(ChunkEntityMention, ChunkEntityMention.entity_id == Entity.id)
+        .where(ChunkEntityMention.chunk_id == chunk_id)
+        .order_by(Entity.name)
+    ).all()
+    entities: list[dict[str, Any]] = []
+    for entity_id, mention_text in mention_rows:
+        projected = _project_page_entity(session, campaign_id, viewer, entity_id)
+        if projected is not None:
+            projected["mention_text"] = mention_text
+            entities.append(projected)
+
+    return {
+        "id": chunk.id,
+        "book_id": chunk.book_id,
+        "content": chunk.content,
+        "section_path": chunk.section_path,
+        "seq": chunk.seq,
+        # A relative URL to the streaming endpoint; null for text chunks so the
+        # reader knows there is no image to render.
+        "image_url": (
+            f"/api/grimoire/chunks/{chunk.id}/image" if chunk.image_ref else None
+        ),
+        "prev_id": prev_id,
+        "next_id": next_id,
+        "entities": entities,
+        "created_at": _iso(chunk.created_at),
+    }
+
+
+def list_entity_mentions(session: Session, entity_id: str) -> list[dict[str, Any]]:
+    """Chunks that mention ``entity_id`` (the "Sources" list on entity detail).
+
+    The caller (router) is responsible for gating on the entity being visible to
+    the viewer before calling this; chunks themselves are global in v1, so no
+    per-chunk visibility filtering happens here. Ordered by book then reading
+    order so sources read top-to-bottom within each book.
+    """
+    rows = session.exec(
+        select(KnowledgeChunk, ChunkEntityMention.mention_text)
+        .join(ChunkEntityMention, ChunkEntityMention.chunk_id == KnowledgeChunk.id)
+        .where(ChunkEntityMention.entity_id == entity_id)
+        .order_by(KnowledgeChunk.book_id, KnowledgeChunk.seq)
+    ).all()
+    return [
+        {
+            "chunk_id": chunk.id,
+            "book_id": chunk.book_id,
+            "section_path": chunk.section_path,
+            "mention_text": mention_text,
+            "preview": chunk.content[:_PREVIEW_LEN],
+        }
+        for chunk, mention_text in rows
+    ]
+
+
+def rename_book(session: Session, book_id: str, display_name: str) -> Book | None:
+    """Set a book's display_name. Returns the updated row, or None if no such
+    book exists (the loader upserts a row per book, so a missing book means the
+    id was never loaded)."""
+    book = session.get(Book, book_id)
+    if book is None:
+        return None
+    book.display_name = display_name
+    session.add(book)
+    session.commit()
+    session.refresh(book)
+    return book

--- a/projects/monolith/grimoire/library.py
+++ b/projects/monolith/grimoire/library.py
@@ -234,7 +234,12 @@ def list_chunks(
         }
         for chunk in rows
     ]
-    next_cursor = str(rows[-1].seq) if has_more and rows else None
+    # Guard against a NULL seq on the boundary row: stringifying it would yield
+    # "None", and the next request's int("None") would fail, drop the cursor, and
+    # re-serve page one forever. seq is backfilled + loader-set so this is an
+    # edge case, but the column is nullable, so fail safe by ending the page.
+    last_seq = rows[-1].seq if rows else None
+    next_cursor = str(last_seq) if has_more and last_seq is not None else None
     return {"items": items, "next_cursor": next_cursor}
 
 

--- a/projects/monolith/grimoire/library_test.py
+++ b/projects/monolith/grimoire/library_test.py
@@ -1,0 +1,344 @@
+"""Unit tests for grimoire/library.py and the Library/reader endpoints.
+
+In-memory SQLite + a minimal FastAPI app mounting only the grimoire router,
+mirroring the schema-stripping + ``app.dependency_overrides[get_session]``
+pattern in router_test.py / entities_test.py. Aggregations are asserted both
+directly (calling library.*) and through the HTTP endpoints.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from app.db import get_session
+from grimoire.extract import current_extraction_key
+from grimoire.models import (
+    Book,
+    ChunkEntityMention,
+    ChunkExtraction,
+    Entity,
+    KnowledgeChunk,
+)
+from grimoire.router import router
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_session] = lambda: session
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _chunk(
+    session, *, book_id, chunk_ref, content, seq, section_path=None, image_ref=None
+):
+    row = KnowledgeChunk(
+        book_id=book_id,
+        chunk_ref=chunk_ref,
+        content=content,
+        section_path=section_path,
+        image_ref=image_ref,
+        seq=seq,
+    )
+    session.add(row)
+    session.commit()
+    session.refresh(row)
+    return row
+
+
+def seed_book(session):
+    """One book, four chunks across two sections (one image chunk), two entities
+    mentioned, partial extraction coverage under the live model+prompt."""
+    session.add(Book(id="mm", display_name="Monster Manual"))
+    c0 = _chunk(
+        session,
+        book_id="mm",
+        chunk_ref="r0",
+        content="Aboleths are ancient aberrations. " * 10,
+        seq=0,
+        section_path="Monsters/Aboleth",
+    )
+    c1 = _chunk(
+        session,
+        book_id="mm",
+        chunk_ref="r1",
+        content="The aboleth's tentacle attack.",
+        seq=1,
+        section_path="Monsters/Aboleth",
+    )
+    c2 = _chunk(
+        session,
+        book_id="mm",
+        chunk_ref="r2",
+        content="Illustration caption: an aboleth lurking.",
+        seq=2,
+        section_path="Monsters/Aboleth",
+        image_ref="s3://grimoire/books/mm/img/aboleth.png",
+    )
+    c3 = _chunk(
+        session,
+        book_id="mm",
+        chunk_ref="r3",
+        content="Beholders float and glare.",
+        seq=3,
+        section_path="Monsters/Beholder",
+    )
+
+    aboleth = Entity(id="e-aboleth", entity_type="creature", name="Aboleth")
+    beholder = Entity(id="e-beholder", entity_type="creature", name="Beholder")
+    session.add_all([aboleth, beholder])
+    session.add_all(
+        [
+            ChunkEntityMention(
+                chunk_id=c0.id, entity_id="e-aboleth", mention_text="Aboleth"
+            ),
+            ChunkEntityMention(
+                chunk_id=c1.id, entity_id="e-aboleth", mention_text="aboleth"
+            ),
+            ChunkEntityMention(
+                chunk_id=c3.id, entity_id="e-beholder", mention_text="Beholder"
+            ),
+        ]
+    )
+
+    # Extraction coverage: mark c0 and c1 done under the live (model, prompt).
+    model, prompt_hash = current_extraction_key()
+    session.add_all(
+        [
+            ChunkExtraction(
+                chunk_id=c0.id, model=model, prompt_hash=prompt_hash, status="ok"
+            ),
+            ChunkExtraction(
+                chunk_id=c1.id, model=model, prompt_hash=prompt_hash, status="empty"
+            ),
+            # A stale-key marker must NOT count toward coverage.
+            ChunkExtraction(
+                chunk_id=c3.id, model="old/model", prompt_hash="stale", status="ok"
+            ),
+        ]
+    )
+    session.commit()
+    return SimpleNamespace(
+        c0=c0, c1=c1, c2=c2, c3=c3, aboleth=aboleth, beholder=beholder
+    )
+
+
+class TestListBooks:
+    def test_coverage_counts(self, session, client):
+        seed_book(session)
+        body = client.get("/api/grimoire/books").json()
+        assert len(body) == 1
+        book = body[0]
+        assert book["book_id"] == "mm"
+        assert book["display_name"] == "Monster Manual"
+        assert book["chunk_count"] == 4
+        assert book["image_count"] == 1
+        # c0 (ok) + c1 (empty) under the live key; the stale-key c3 excluded.
+        assert book["extracted_count"] == 2
+        assert book["entity_count"] == 2
+        assert book["latest_chunk_at"] is not None
+        assert book["last_loaded_at"] is not None
+
+
+class TestSections:
+    def test_ordered_by_reading_order(self, session, client):
+        seed = seed_book(session)
+        body = client.get("/api/grimoire/books/mm/sections").json()
+        assert [s["section_path"] for s in body] == [
+            "Monsters/Aboleth",
+            "Monsters/Beholder",
+        ]
+        aboleth = body[0]
+        assert aboleth["title"] == "Aboleth"
+        assert aboleth["chunk_count"] == 3
+        assert aboleth["image_count"] == 1
+        assert aboleth["first_chunk_id"] == seed.c0.id
+
+
+class TestListChunks:
+    def test_pagination_and_section_filter(self, session, client):
+        seed = seed_book(session)
+        first = client.get("/api/grimoire/books/mm/chunks?limit=2").json()
+        assert [c["seq"] for c in first["items"]] == [0, 1]
+        assert first["next_cursor"] == "1"
+        assert first["items"][0]["kind"] == "text"
+
+        second = client.get(
+            f"/api/grimoire/books/mm/chunks?limit=2&cursor={first['next_cursor']}"
+        ).json()
+        assert [c["seq"] for c in second["items"]] == [2, 3]
+        assert second["next_cursor"] is None
+        # The image chunk reports kind=image.
+        assert second["items"][0]["kind"] == "image"
+
+        section = client.get(
+            "/api/grimoire/books/mm/chunks?section=Monsters/Beholder"
+        ).json()
+        assert [c["id"] for c in section["items"]] == [seed.c3.id]
+
+
+class TestGetChunk:
+    def test_content_neighbours_and_image_url(self, session, client):
+        seed = seed_book(session)
+        body = client.get(f"/api/grimoire/chunks/{seed.c2.id}?campaign=none&as=dm")
+        # campaign "none" does not exist -> 404 before viewpoint resolution.
+        assert body.status_code == 404
+
+        campaign = client.post("/api/grimoire/campaigns", json={"name": "C"}).json()
+        chunk = client.get(
+            f"/api/grimoire/chunks/{seed.c2.id}?campaign={campaign['id']}&as=dm"
+        ).json()
+        assert chunk["seq"] == 2
+        assert chunk["prev_id"] == seed.c1.id
+        assert chunk["next_id"] == seed.c3.id
+        assert chunk["image_url"] == f"/api/grimoire/chunks/{seed.c2.id}/image"
+        assert chunk["content"].startswith("Illustration caption")
+
+        first = client.get(
+            f"/api/grimoire/chunks/{seed.c0.id}?campaign={campaign['id']}&as=dm"
+        ).json()
+        assert first["prev_id"] is None
+        assert first["image_url"] is None
+        assert {e["name"] for e in first["entities"]} == {"Aboleth"}
+
+    def test_missing_chunk_404(self, session, client):
+        campaign = client.post("/api/grimoire/campaigns", json={"name": "C"}).json()
+        r = client.get(f"/api/grimoire/chunks/nope?campaign={campaign['id']}&as=dm")
+        assert r.status_code == 404
+
+    def test_on_page_entities_respect_viewpoint(self, session, client):
+        seed = seed_book(session)
+        # Non-global entity, ungranted to the player: dropped from the chips.
+        seed.aboleth.is_global = False
+        session.add(seed.aboleth)
+        session.commit()
+
+        campaign = client.post("/api/grimoire/campaigns", json={"name": "C"}).json()
+        pc = client.post(
+            f"/api/grimoire/campaigns/{campaign['id']}/characters",
+            json={"character_name": "Rogue"},
+        ).json()
+
+        chunk = client.get(
+            f"/api/grimoire/chunks/{seed.c0.id}?campaign={campaign['id']}&as={pc['id']}"
+        ).json()
+        assert chunk["entities"] == []
+
+        # The DM still sees it.
+        dm = client.get(
+            f"/api/grimoire/chunks/{seed.c0.id}?campaign={campaign['id']}&as=dm"
+        ).json()
+        assert {e["name"] for e in dm["entities"]} == {"Aboleth"}
+
+
+class TestMentions:
+    def test_dm_sees_sources(self, session, client):
+        seed = seed_book(session)
+        campaign = client.post("/api/grimoire/campaigns", json={"name": "C"}).json()
+        body = client.get(
+            f"/api/grimoire/campaigns/{campaign['id']}/entities/e-aboleth/mentions?as=dm"
+        ).json()
+        chunk_ids = {m["chunk_id"] for m in body}
+        assert chunk_ids == {seed.c0.id, seed.c1.id}
+        assert all(m["book_id"] == "mm" for m in body)
+
+    def test_player_without_grant_404(self, session, client):
+        seed = seed_book(session)
+        seed.aboleth.is_global = False
+        session.add(seed.aboleth)
+        session.commit()
+        campaign = client.post("/api/grimoire/campaigns", json={"name": "C"}).json()
+        pc = client.post(
+            f"/api/grimoire/campaigns/{campaign['id']}/characters",
+            json={"character_name": "Rogue"},
+        ).json()
+        r = client.get(
+            f"/api/grimoire/campaigns/{campaign['id']}/entities/e-aboleth/mentions"
+            f"?as={pc['id']}"
+        )
+        assert r.status_code == 404
+
+
+class TestRenameBook:
+    def test_rename_and_404(self, session, client):
+        seed_book(session)
+        r = client.patch(
+            "/api/grimoire/books/mm", json={"display_name": "The Monster Manual"}
+        )
+        assert r.status_code == 200
+        assert r.json()["display_name"] == "The Monster Manual"
+        assert session.get(Book, "mm").display_name == "The Monster Manual"
+
+        missing = client.patch("/api/grimoire/books/nope", json={"display_name": "X"})
+        assert missing.status_code == 404
+
+        empty = client.patch("/api/grimoire/books/mm", json={"display_name": "  "})
+        assert empty.status_code == 422
+
+
+class _FakeBody:
+    def __init__(self, data: bytes):
+        self._data = data
+        self.closed = False
+
+    def iter_chunks(self, chunk_size=65536):
+        for i in range(0, len(self._data), chunk_size):
+            yield self._data[i : i + chunk_size]
+
+    def close(self):
+        self.closed = True
+
+
+class TestChunkImage:
+    def test_streams_image(self, session, client, monkeypatch):
+        seed = seed_book(session)
+        captured = {}
+
+        class _FakeClient:
+            def get_object(self, Bucket, Key):
+                captured["bucket"] = Bucket
+                captured["key"] = Key
+                return {"Body": _FakeBody(b"PNGDATA")}
+
+        monkeypatch.setattr("grimoire.ingest.build_s3_client", lambda: _FakeClient())
+        r = client.get(f"/api/grimoire/chunks/{seed.c2.id}/image")
+        assert r.status_code == 200
+        assert r.headers["content-type"].startswith("image/png")
+        assert r.content == b"PNGDATA"
+        assert captured["bucket"] == "grimoire"
+        assert captured["key"] == "books/mm/img/aboleth.png"
+
+    def test_text_chunk_404(self, session, client):
+        seed = seed_book(session)
+        r = client.get(f"/api/grimoire/chunks/{seed.c0.id}/image")
+        assert r.status_code == 404

--- a/projects/monolith/grimoire/models.py
+++ b/projects/monolith/grimoire/models.py
@@ -175,11 +175,41 @@ class KnowledgeChunk(SQLModel, table=True):
     chunk_ref: str
     content: str
     section_path: str | None = None
+    # Reading-order position within a book, 0-based, assigned by the loader from
+    # NDJSON line order (ingest._upsert_book_chunks). created_at is unreliable for
+    # ordering (bulk upserts share a timestamp; re-uploads mutate in place), so
+    # every reading-order read path (section tree, chunk reader, paged list)
+    # orders by seq instead. Mirror of the column added in
+    # 20260703250000_grimoire_chunk_seq_and_book.sql.
+    seq: int | None = None
     # Full s3:// URI of the source illustration for image-derived chunks (Marker
     # Picture blocks); NULL for text chunks. Stored so the app can later render
     # the image (via imgproxy) alongside the retrieved chunk. Mirror of the
     # column added in 20260703130000_grimoire_chunk_image_ref.sql.
     image_ref: str | None = None
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True)),
+    )
+
+
+class Book(SQLModel, table=True):
+    """Human-facing metadata for a loaded book.
+
+    book_id is a slug/UUID everywhere else in the schema; this table gives it a
+    display_name (defaulting to the id until renamed from the Library UI) so the
+    app never has to show a raw id. The loader upserts one row per book it sees
+    (ingest._upsert_book), and PATCH /books/{book_id} renames it. Mirror of
+    20260703250000_grimoire_chunk_seq_and_book.sql.
+    """
+
+    __tablename__ = "book"
+    __table_args__ = {"schema": "grimoire", "extend_existing": True}
+
+    # book_id is a caller-supplied slug/UUID (the S3 path segment), not a
+    # generated surrogate, so the string id is the primary key directly.
+    id: str = Field(sa_column=Column(String, primary_key=True, nullable=False))
+    display_name: str
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         sa_column=Column(DateTime(timezone=True)),

--- a/projects/monolith/grimoire/models_test.py
+++ b/projects/monolith/grimoire/models_test.py
@@ -185,6 +185,32 @@ def test_chunk_extraction_status_check(session: Session):
     session.rollback()
 
 
+def test_book_and_chunk_seq_roundtrip(session: Session):
+    from grimoire.models import Book, KnowledgeChunk
+
+    session.add(Book(id="mm", display_name="Monster Manual"))
+    session.add(
+        KnowledgeChunk(
+            book_id="mm",
+            chunk_ref="r0",
+            content="Aboleths are aberrations.",
+            section_path="Monsters/Aboleth",
+            seq=0,
+        )
+    )
+    session.commit()
+
+    book = session.get(Book, "mm")
+    assert book is not None
+    assert book.display_name == "Monster Manual"
+    assert book.created_at is not None
+
+    chunk = session.exec(
+        select(KnowledgeChunk).where(KnowledgeChunk.book_id == "mm")
+    ).one()
+    assert chunk.seq == 0
+
+
 def test_knowledge_grant_unique_entity_player_character(session: Session):
     entity = Entity(entity_type="npc", name="Nott")
     campaign, pc = _make_campaign_and_pc(session)

--- a/projects/monolith/grimoire/router.py
+++ b/projects/monolith/grimoire/router.py
@@ -268,6 +268,24 @@ def update_grant(
     return grant
 
 
+@router.delete("/campaigns/{campaign_id}/grants/{grant_id}", status_code=204)
+def delete_grant(
+    campaign_id: str,
+    grant_id: str,
+    session: Session = Depends(get_session),
+) -> None:
+    """Revoke a grant (the grant editor's "none" scope). Idempotent-ish: a
+    missing grant is a 404, matching update_grant's not-found semantics. Removing
+    a grant on a non-global entity returns it to invisible for that character;
+    on a global entity it drops the character back to the default full view."""
+    _get_campaign_or_404(session, campaign_id)
+    grant = session.get(KnowledgeGrant, grant_id)
+    if grant is None or grant.campaign_id != campaign_id:
+        raise HTTPException(status_code=404, detail="grant not found")
+    session.delete(grant)
+    session.commit()
+
+
 # --- Entities (grant-filtered read paths) --------------------------------
 
 # All read paths below build on visible_entities_query()/project_entity()

--- a/projects/monolith/grimoire/router.py
+++ b/projects/monolith/grimoire/router.py
@@ -18,11 +18,13 @@ from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import func
 from sqlmodel import Session, or_, select
 
 from app.db import get_session
+from grimoire import library
 from grimoire.models import (
     Campaign,
     ENTITY_DETAIL_MODELS,
@@ -30,6 +32,7 @@ from grimoire.models import (
     EntityType,
     GameSession,
     GrantScope,
+    KnowledgeChunk,
     KnowledgeGrant,
     PlayerCharacter,
     Relationship,
@@ -337,20 +340,42 @@ def _project_neighbor(
     return project_entity(entity, None, grant, viewer, context="relationship")
 
 
+def _parse_offset(cursor: str | None) -> int:
+    """Decode the opaque entity-list cursor (a stringified offset). A missing or
+    malformed cursor starts from the top rather than erroring, so a stale cursor
+    degrades to page one instead of a 422."""
+    if cursor is None:
+        return 0
+    try:
+        return max(0, int(cursor))
+    except ValueError:
+        return 0
+
+
 @router.get("/campaigns/{campaign_id}/entities")
 def list_entities(
     campaign_id: str,
     as_: str = Query(alias="as"),
     entity_type: EntityType | None = Query(default=None, alias="type"),
     q: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    cursor: str | None = Query(default=None),
     session: Session = Depends(get_session),
-) -> list[dict[str, Any]]:
-    """Grant-filtered entity list, spine-level only (no typed detail rows).
+) -> dict[str, Any]:
+    """Grant-filtered, paginated entity list, spine-level only (no typed detail).
 
-    Returned dict shape is scope-dependent (full spine, partial identity +
-    revealed_details, or a full spine + grants annotation for the DM), so
-    this returns list[dict] rather than a fixed response_model, matching the
-    heterogeneous-payload pattern used by knowledge/router.py.
+    Returns ``{items, total, next_cursor}``. Item dict shape is scope-dependent
+    (full spine, partial identity + revealed_details, or a full spine + grants
+    annotation for the DM), so items are plain dicts rather than a fixed
+    response_model, matching the heterogeneous-payload pattern used by
+    knowledge/router.py.
+
+    The projection (DM grant-aggregation, player grant-filtering, name_only
+    suppression) has to run in Python before the page is known, so the full
+    visible set is materialised and then sliced by ``cursor``/``limit``. At v1
+    corpus scale (hundreds of entities) this stays cheap; keyset pagination
+    would have to reconcile the DM view's one-row-per-grant fan-out and is not
+    worth it yet.
     """
     _get_campaign_or_404(session, campaign_id)
     viewer = _resolve_viewer(session, campaign_id, as_)
@@ -365,14 +390,20 @@ def list_entities(
 
     if viewer == "dm":
         aggregated, order = _aggregate_dm_rows(rows, context="lookup")
-        return [aggregated[entity_id] for entity_id in order]
+        items = [aggregated[entity_id] for entity_id in order]
+    else:
+        items = []
+        for entity, grant in rows:
+            projected = project_entity(entity, None, grant, viewer, context="lookup")
+            if projected is not None:
+                items.append(projected)
 
-    items: list[dict[str, Any]] = []
-    for entity, grant in rows:
-        projected = project_entity(entity, None, grant, viewer, context="lookup")
-        if projected is not None:
-            items.append(projected)
-    return items
+    total = len(items)
+    offset = _parse_offset(cursor)
+    page = items[offset : offset + limit]
+    next_offset = offset + limit
+    next_cursor = str(next_offset) if next_offset < total else None
+    return {"items": page, "total": total, "next_cursor": next_cursor}
 
 
 @router.get("/campaigns/{campaign_id}/entities/{entity_id}")
@@ -468,6 +499,180 @@ def list_entity_relationships(
             }
         )
     return items
+
+
+@router.get("/campaigns/{campaign_id}/entities/{entity_id}/mentions")
+def list_entity_mentions(
+    campaign_id: str,
+    entity_id: str,
+    as_: str = Query(alias="as"),
+    session: Session = Depends(get_session),
+) -> list[dict[str, Any]]:
+    """Chunks that mention this entity (the "Sources" list on entity detail).
+
+    Gated behind the same visibility check as get_entity: the viewer must be
+    able to see the entity in lookup context, or this 404s (existence must not
+    leak, and a name_only viewer gets nothing, consistent with the entity
+    detail 404). Chunks themselves are corpus-global in v1, so once the gate
+    passes every mention is returned.
+    """
+    _get_campaign_or_404(session, campaign_id)
+    viewer = _resolve_viewer(session, campaign_id, as_)
+
+    rows = session.exec(
+        visible_entities_query(campaign_id, viewer).where(Entity.id == entity_id)
+    ).all()
+    if not rows:
+        raise HTTPException(status_code=404, detail="entity not found")
+    if viewer != "dm":
+        entity, grant = rows[0]
+        if project_entity(entity, None, grant, viewer, context="lookup") is None:
+            raise HTTPException(status_code=404, detail="entity not found")
+
+    return library.list_entity_mentions(session, entity_id)
+
+
+# --- Library / corpus (book + chunk reads, corpus-global) ------------
+
+# Books and chunks are NOT campaign-scoped: the corpus is global in v1 (matching
+# search._resolve_chunk_hit). Only a chunk's on-page entity chips take a
+# campaign + viewpoint, since those are grant-projected; everything else here is
+# plain corpus data. All aggregation lives in library.py so these handlers stay
+# thin.
+
+
+class BookRenameRequest(BaseModel):
+    display_name: str
+
+
+@router.get("/books")
+def list_books(session: Session = Depends(get_session)) -> list[dict[str, Any]]:
+    """Per-book coverage rows for the Library (counts, extraction progress,
+    entity yield, timestamps). See library.list_books."""
+    return library.list_books(session)
+
+
+@router.patch("/books/{book_id}")
+def rename_book(
+    book_id: str,
+    body: BookRenameRequest,
+    session: Session = Depends(get_session),
+) -> dict[str, Any]:
+    """Rename a book (set its display_name) from the Library UI."""
+    display_name = body.display_name.strip()
+    if not display_name:
+        raise HTTPException(status_code=422, detail="display_name must not be empty")
+    book = library.rename_book(session, book_id, display_name)
+    if book is None:
+        raise HTTPException(status_code=404, detail="book not found")
+    return {"book_id": book.id, "display_name": book.display_name}
+
+
+@router.get("/books/{book_id}/sections")
+def list_book_sections(
+    book_id: str, session: Session = Depends(get_session)
+) -> list[dict[str, Any]]:
+    """Ordered section tree for one book (reading order, chunk counts)."""
+    return library.list_sections(session, book_id)
+
+
+@router.get("/books/{book_id}/chunks")
+def list_book_chunks(
+    book_id: str,
+    section: str | None = Query(default=None),
+    cursor: str | None = Query(default=None),
+    limit: int = Query(
+        default=library.DEFAULT_CHUNK_PAGE, ge=1, le=library.MAX_CHUNK_PAGE
+    ),
+    session: Session = Depends(get_session),
+) -> dict[str, Any]:
+    """Seq-ordered page of a book's chunks (optionally one section)."""
+    return library.list_chunks(
+        session, book_id, section=section, cursor=cursor, limit=limit
+    )
+
+
+@router.get("/chunks/{chunk_id}")
+def get_chunk(
+    chunk_id: str,
+    campaign: str = Query(),
+    as_: str = Query(alias="as"),
+    session: Session = Depends(get_session),
+) -> dict[str, Any]:
+    """One chunk with full content, image URL, seq neighbours, and on-page
+    entity chips projected for the (campaign, viewpoint). The campaign/viewpoint
+    only shape the entity chips; the chunk body is corpus-global."""
+    _get_campaign_or_404(session, campaign)
+    viewer = _resolve_viewer(session, campaign, as_)
+    chunk = library.get_chunk(session, campaign, viewer, chunk_id)
+    if chunk is None:
+        raise HTTPException(status_code=404, detail="chunk not found")
+    return chunk
+
+
+def _parse_s3_uri(uri: str) -> tuple[str, str] | None:
+    """Split ``s3://bucket/key`` into ``(bucket, key)``; None if malformed."""
+    if not uri.startswith("s3://"):
+        return None
+    rest = uri[len("s3://") :]
+    bucket, _, key = rest.partition("/")
+    if not bucket or not key:
+        return None
+    return bucket, key
+
+
+_IMAGE_CONTENT_TYPES = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "webp": "image/webp",
+    "gif": "image/gif",
+}
+
+
+@router.get("/chunks/{chunk_id}/image")
+def get_chunk_image(
+    chunk_id: str, session: Session = Depends(get_session)
+) -> StreamingResponse:
+    """Stream the source illustration behind an image chunk's ``image_ref``.
+
+    404s for a missing chunk or a text chunk (no image_ref). Reads the object
+    from the shared SeaweedFS S3 endpoint the loader already uses (the API pod
+    carries the same SEAWEEDFS_S3_ENDPOINT/S3_ACCESS_KEY_ID/S3_SECRET_ACCESS_KEY
+    env under the always-set ``stars`` block, so no chart change is needed).
+    This is a sync ``def`` handler, so FastAPI runs the blocking boto3 read in
+    its threadpool, off the event loop. imgproxy resizing is a later
+    optimization (recorded as a follow-up, not built here).
+    """
+    from grimoire.ingest import build_s3_client
+
+    chunk = session.get(KnowledgeChunk, chunk_id)
+    if chunk is None or not chunk.image_ref:
+        raise HTTPException(status_code=404, detail="chunk image not found")
+    parsed = _parse_s3_uri(chunk.image_ref)
+    if parsed is None:
+        raise HTTPException(status_code=404, detail="chunk image not found")
+    bucket, key = parsed
+
+    suffix = key.rsplit(".", 1)[-1].lower() if "." in key else ""
+    content_type = _IMAGE_CONTENT_TYPES.get(suffix, "application/octet-stream")
+
+    client = build_s3_client()
+    try:
+        obj = client.get_object(Bucket=bucket, Key=key)
+    except Exception as exc:  # noqa: BLE001 - any S3 miss/error becomes a 404
+        raise HTTPException(status_code=404, detail="chunk image not found") from exc
+
+    body = obj["Body"]
+
+    def _stream():
+        try:
+            for part in body.iter_chunks(chunk_size=64 * 1024):
+                yield part
+        finally:
+            body.close()
+
+    return StreamingResponse(_stream(), media_type=content_type)
 
 
 # --- Vector search ---------------------------------------------------

--- a/projects/monolith/grimoire/router_test.py
+++ b/projects/monolith/grimoire/router_test.py
@@ -219,7 +219,9 @@ class TestGrants:
             f"/api/grimoire/campaigns/{campaign['id']}/grants/{created['id']}"
         )
         assert deleted.status_code == 204
-        assert client.get(f"/api/grimoire/campaigns/{campaign['id']}/grants").json() == []
+        assert (
+            client.get(f"/api/grimoire/campaigns/{campaign['id']}/grants").json() == []
+        )
 
         # A second delete of the now-missing grant is a 404.
         again = client.delete(

--- a/projects/monolith/grimoire/router_test.py
+++ b/projects/monolith/grimoire/router_test.py
@@ -202,6 +202,31 @@ class TestGrants:
         )
         assert r.status_code == 404
 
+    def test_delete_grant_then_gone(self, client, session):
+        campaign = _create_campaign(client)
+        character = _create_character(client, campaign["id"])
+        _seed_entity(session, "entity-strahd")
+        created = client.post(
+            f"/api/grimoire/campaigns/{campaign['id']}/grants",
+            json={
+                "entity_id": "entity-strahd",
+                "player_character_id": character["id"],
+                "grant_scope": "full",
+            },
+        ).json()
+
+        deleted = client.delete(
+            f"/api/grimoire/campaigns/{campaign['id']}/grants/{created['id']}"
+        )
+        assert deleted.status_code == 204
+        assert client.get(f"/api/grimoire/campaigns/{campaign['id']}/grants").json() == []
+
+        # A second delete of the now-missing grant is a 404.
+        again = client.delete(
+            f"/api/grimoire/campaigns/{campaign['id']}/grants/{created['id']}"
+        )
+        assert again.status_code == 404
+
     def test_create_grant_unknown_entity_404(self, client):
         # entity_id is a FK; a missing entity must be a 404, not the 500 the
         # Postgres IntegrityError would otherwise produce (the SQLite fixture

--- a/projects/monolith/grimoire/search.py
+++ b/projects/monolith/grimoire/search.py
@@ -19,7 +19,7 @@ from typing import Any, Protocol
 
 from sqlmodel import Session, select
 
-from grimoire.models import Embedding, Entity, KnowledgeChunk
+from grimoire.models import Book, Embedding, Entity, KnowledgeChunk
 from grimoire.visibility import project_entity, visible_entities_query
 
 # How many extra candidates to pull past ``k`` before visibility filtering and
@@ -65,10 +65,14 @@ def _resolve_chunk_hit(
     chunk = session.get(KnowledgeChunk, chunk_id)
     if chunk is None:
         return None
+    # Resolve the book's display name so the omnibox can title chunk hits with a
+    # human name (and link into the reader) instead of showing the raw book_id.
+    book = session.get(Book, chunk.book_id)
     return {
         "kind": "chunk",
         "id": chunk.id,
         "book_id": chunk.book_id,
+        "display_name": book.display_name if book else chunk.book_id,
         "section_path": chunk.section_path,
         "preview": chunk.content[:_CHUNK_PREVIEW_LEN],
         "score": 1.0 - distance,

--- a/projects/monolith/grimoire/search_test.py
+++ b/projects/monolith/grimoire/search_test.py
@@ -241,6 +241,9 @@ class TestSearchCampaign:
         assert hit["kind"] == "chunk"
         assert hit["id"] == seed.chunk1.id
         assert hit["book_id"] == "phb"
+        # No grimoire.book row for "phb" in this fixture, so display_name falls
+        # back to the book_id (the loader would have upserted a real name).
+        assert hit["display_name"] == "phb"
         assert hit["section_path"] == "Chapter 1 > Intro"
         assert len(hit["preview"]) == 200
 


### PR DESCRIPTION
Implements the three-phase Grimoire UI overhaul from `docs/plans/2026-07-03-grimoire-ui-overhaul.md`, turning `/app/grimoire` from a single 1090-line CRUD panel into a readable, explorable D&D reference with clean desktop and mobile UX.

## Backend (`projects/monolith/grimoire/`)

- **Migration + models**: add `knowledge_chunk.seq` (reading-order position, backfilled from `created_at, chunk_ref` per book, indexed `(book_id, seq)`) and a `grimoire.book` display-name table. `20260703250000_grimoire_chunk_seq_and_book.sql` (atlas.sum regenerated).
- **Ingest**: assign `seq` from NDJSON line order (rewritten on re-upload, a pure reorder does not re-embed) and upsert a `book` row per book without clobbering a renamed `display_name`.
- **`library.py`** (new): per-book coverage aggregation (chunk/image/extracted/entity counts, `extracted_count` scoped to the live `(model, prompt_hash)`), reading-order section tree, keyset-paged chunk list, single-chunk reader payload (content, image URL, seq neighbours, viewpoint-filtered on-page entities), and entity→chunk provenance.
- **`router.py`**: paginate `list_entities` (`{items, total, next_cursor}`); add `GET /books`, `PATCH /books/{id}`, `/books/{id}/sections`, `/books/{id}/chunks`, `GET /chunks/{id}`, streaming `GET /chunks/{id}/image` (reuses the API pod's existing SeaweedFS creds, no chart change), campaign-scoped `/entities/{id}/mentions`, and `DELETE /grants/{id}` (the grant editor's "none").
- **Search**: chunk hits now carry the book `display_name` so the omnibox titles and links them instead of showing a raw `book_id`.
- **Tests**: new `library_test.py`; extended `ingest_test.py` (seq stability, book upsert), `models_test.py`, `router_test.py` (grant delete), `entities_test.py` (pagination), `search_test.py`. All 115 grimoire backend tests pass locally.

## Frontend (`projects/monolith/frontend/`)

- **Routing + shell**: URL-addressable `[campaign]` / `entity/[id]` / `book/[book]` / `book/[book]/c/[chunk]` routes, a shared responsive top bar (campaign select, viewpoint switcher, one omnibox), `100dvh` frame, 44px touch targets. Viewpoint is the `?as=` query param (localStorage only seeds the default) so every link is shareable in-context and the back button works.
- **Omnibox** replaces both old search boxes: instant name matches, then debounced semantic Lore (chunk) and Related-entity groups, keyboard navigation, no raw scores.
- **Library + chunk exploration**: per-book coverage rows with "new since last visit", reading-order section tree, and a chunk reader (65ch prose measure, image rendering via the streaming endpoint, prev/next, viewpoint-filtered on-page entity chips). Entity detail gains a Sources (provenance) section.
- **Presentation**: per-type renderers (Monster Manual style creature stat block, spell card, prose-first generic) keyed on `entity_type`; partial reveals render the revealed subset through the same renderer, never JSON.
- **Contextual grants (DM)**: per-character scope chips (none / name only / partial / full) with a field picker that builds `revealed_details`; the permanent grant panel and JSON textarea are gone.
- **Identity layer**: grimoire-scoped theme (oxblood accent, system serif display face, paper reading pane, tapered stat-block rules, `prefers-reduced-motion`-safe reveals) layered over the shared tokens (no fork of the token system). The display face is a system serif stack rather than a self-hosted woff2, which ships no binary and keeps `--grim-serif` a drop-in swap later.

## Verification

- Backend: 115 grimoire tests pass locally (SQLite fixtures), ruff clean, `atlas migrate validate` passes.
- Frontend: full `pnpm build` (SvelteKit/vite) compiles all routes cleanly. Private-tier pages have no visual-regression rig, so runtime behaviour is validated by build + manual click-through against prod data.

## Notes

- Image serving streams through the monolith with boto3; imgproxy resizing is left as a follow-up per the plan.
- `?as=` remains convenience, not auth (private tier already gates access), unchanged from today's model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLFRakoWR1yeaXbK6voMrv)_