### PR TITLE
chore(monolith): bump chart to 0.271.0 to roll out grimoire UI overhaul

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.270.0
+version: 0.271.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.270.0
+      targetRevision: 0.271.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
The grimoire UI overhaul (#3147) merged to `main` and its `frontend`/`backend` images are built and pushed (`//bazel/images:push_all` green on `70d1192`), but `chart-version-bot` did not bump the chart. As a result ArgoCD is still serving chart `0.270.0`, which was built at the pre-grimoire commit `a42581c`, so the new UI is not deployed.

This bumps `Chart.yaml` `version` and the `application.yaml` chart `targetRevision` from `0.270.0` to `0.271.0` — the version `bazel/helm/chart-version.sh` computes for the grimoire `feat` commits. On merge, the main CI `push_all` publishes chart `0.271.0` pinning the grimoire images, and ArgoCD (now targeting `0.271.0`) syncs the rollout. This is exactly what the bot would have committed; it's applied by hand because the bot lagged.

Verified: chart `0.271.0` is not yet in OCI (`ghcr.io/jomcgi/homelab/charts/monolith`), so this bump is what triggers its publish; `0.270.0` exists and is the current deployed revision. Chart.yaml version and application.yaml targetRevision are kept in sync (the `check-chart-version-targetrevision-sync` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLFRakoWR1yeaXbK6voMrv)_