### PR TITLE
fix(grimoire): stop next-section heading bleeding into prior chunk

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.271.0
+version: 0.272.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.271.0
+      targetRevision: 0.272.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/grimoire/marker.py
+++ b/projects/monolith/grimoire/marker.py
@@ -147,7 +147,21 @@ def effective_section_id(block: dict, headers: dict[str, str]) -> str | None:
     id whose header text is not in ``_CONTINUATION_HEADERS`` (so ACTIONS /
     REACTIONS / LEGENDARY ACTIONS blocks merge into their monster). Falls back to
     the deepest id if every level is a continuation header.
+
+    A non-continuation SectionHeader block keys on *itself*, regardless of what
+    section_hierarchy claims: a heading definitionally names the section it
+    opens. Real Marker output for a heading that starts a new section often
+    still lists the *previous* header at this block's deepest level (its own
+    entry is not pushed onto the running stack until after the block is
+    emitted), which would otherwise fold the new heading into the prior
+    section's chunk (its title bleeding in as a trailing line). Continuation
+    headers (ACTIONS/REACTIONS/...) are excluded here so they still resolve up
+    to their parent monster via the hierarchy walk below.
     """
+    if block.get("block_type") == "SectionHeader":
+        hid = block.get("id")
+        if hid and headers.get(hid, "").strip().upper() not in _CONTINUATION_HEADERS:
+            return hid
     sh = block.get("section_hierarchy") or {}
     if not sh:
         return None

--- a/projects/monolith/grimoire/marker_test.py
+++ b/projects/monolith/grimoire/marker_test.py
@@ -165,6 +165,53 @@ def test_to_chunks_prepends_section_name_when_absent_from_body():
     assert header_chunk["content"].startswith("THE UNDERDARK")
 
 
+def test_to_chunks_new_header_with_stale_hierarchy_does_not_bleed():
+    """A heading that opens a new section but whose section_hierarchy still
+    points at the *previous* header (real Marker output: the new header's own
+    entry is not yet on the running stack) must start its own chunk, not append
+    its title to the prior section's body."""
+    doc = {
+        "children": [
+            _page(
+                0,
+                [
+                    {
+                        "id": "/page/0/SectionHeader/0",
+                        "block_type": "SectionHeader",
+                        "html": "<h1>HOW TO USE THIS BOOK</h1>",
+                        "section_hierarchy": {"1": "/page/0/SectionHeader/0"},
+                    },
+                    {
+                        "id": "/page/0/Text/0",
+                        "block_type": "Text",
+                        "html": "<p>Pick up the Starter Set.</p>",
+                        "section_hierarchy": {"1": "/page/0/SectionHeader/0"},
+                    },
+                    {
+                        # The next section's heading, but Marker still reports the
+                        # PREVIOUS header at its deepest level, not itself.
+                        "id": "/page/0/SectionHeader/1",
+                        "block_type": "SectionHeader",
+                        "html": "<h1>WHAT IS A MONSTER?</h1>",
+                        "section_hierarchy": {"1": "/page/0/SectionHeader/0"},
+                    },
+                ],
+            )
+        ],
+        "metadata": {},
+    }
+    chunks = marker.to_chunks(doc, image_key_prefix="p/")
+    text = [c for c in chunks if "image_ref" not in c]
+    assert len(text) == 2
+    intro = [c for c in text if c["section_path"] == "HOW TO USE THIS BOOK"][0]
+    monster = [c for c in text if c["section_path"] == "WHAT IS A MONSTER?"][0]
+    # The next heading must NOT bleed into the previous section's body.
+    assert "WHAT IS A MONSTER?" not in intro["content"]
+    assert "Pick up the Starter Set." in intro["content"]
+    assert monster["content"].startswith("WHAT IS A MONSTER?")
+    assert monster["chunk_ref"] == "/page/0/SectionHeader/1"
+
+
 def test_to_chunks_drops_empty_content():
     doc = {
         "children": [


### PR DESCRIPTION
## Problem

A section chunk was ending with the heading of the *next* section as its trailing line (e.g. "WHAT IS A MONSTER?" appended to the end of "HOW TO USE THIS BOOK"), even though the next section is also correctly extracted as its own chunk.

## Root cause

`marker.to_chunks` groups blocks into runs by resolved section *name*, and `effective_section_id` resolved every block, including `SectionHeader` blocks, purely through `section_hierarchy`. Real Marker output for a heading that opens a new section often still lists the **previous** header at that block's deepest hierarchy level: the new header's own entry is not pushed onto the running stack until after the block is emitted. So the new heading resolved to the prior section and its title landed at the tail of the previous chunk.

The unit-test fixtures happened to self-reference headers, so this never showed up in tests.

## Fix

A non-continuation `SectionHeader` now keys on its own id in `effective_section_id`: a heading definitionally names the section it opens. This is a no-op when Marker matches the fixtures and a correction when it lists the stale predecessor.

- Continuation headers (ACTIONS/REACTIONS/LEGENDARY ACTIONS/...) are still resolved up to their parent monster via the hierarchy walk, so stat-block merging is unchanged.
- Runs are keyed by section *name* downstream, so two same-named headers (the split lore/stat-block layout) still merge into one chunk. `test_to_chunks_merges_split_monster_and_actions` still passes.

Adds `test_to_chunks_new_header_with_stale_hierarchy_does_not_bleed` reproducing the exact bug. Bumps the monolith chart to 0.272.0 to roll out.

## Note on existing data

This corrects **future** ingests. Chunks already stored for the Monster Manual keep their old boundaries until that book is re-ingested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)