### PR TITLE
perf(grimoire): concurrent entity extraction + incremental commit

### DIFF
--- a/projects/inference/deploy/Chart.yaml
+++ b/projects/inference/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inference
 description: A Helm chart for LLM inference (vLLM LLM serving + llama.cpp CPU embeddings)
 type: application
-version: 2.5.3
+version: 2.5.4
 appVersion: "b5270"
 keywords:
   - llm

--- a/projects/inference/deploy/values.yaml
+++ b/projects/inference/deploy/values.yaml
@@ -207,8 +207,15 @@ vllm:
     - "qwen3"
     - "--reasoning-config"
     - '{"reasoning_start_str": "<think>", "reasoning_end_str": "</think>"}'
+    # Total concurrent decode sequences. Widened 3 -> 8 so the shared vLLM can
+    # batch bulk callers (grimoire entity extraction fans out ~6 concurrent
+    # short requests) alongside interactive traffic instead of forcing batch
+    # size 1. KV memory is a fixed pool (gpu-memory-utilization below); more
+    # seqs just share it, with graceful preemption on a rare full-context req.
+    # Consumers budget against this: chat_public caps public at 2, grimoire at
+    # 6, leaving headroom for Discord / private chat / agents.
     - "--max-num-seqs"
-    - "3"
+    - "8"
     - "--kv-cache-dtype"
     - "fp8"
 

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -93,8 +93,9 @@ chatPublic:
   sessionTtlSeconds: 1800
   # CLUSTER-WIDE ceiling: max in-flight public inference calls at once across ALL
   # replicas (ADR 005 layer 2+3). Enforced via Postgres advisory locks, not a
-  # per-pod counter, so it holds as the backend scales out. vLLM max_num_seqs=3,
-  # reserve 1 slot for trusted callers, so public = 2. Mirrored as
+  # per-pod counter, so it holds as the backend scales out. vLLM max_num_seqs=8,
+  # public is capped here at 2, leaving the rest for trusted callers (grimoire
+  # extraction, Discord, private chat, agents). Mirrored as
   # CHAT_PUBLIC_GLOBAL_MAX_CONCURRENT on web.env below.
   globalMaxConcurrent: 2
   # Turnstile siteverify HTTP timeout (seconds): keep short so a slow/unreachable
@@ -233,8 +234,8 @@ web:
       value: "1800"
     # CLUSTER-WIDE cap on concurrent public inference calls (not per-pod): the
     # limiter is enforced via Postgres advisory locks, so this is the aggregate
-    # ceiling across ALL replicas. vLLM max_num_seqs=3, reserve 1 slot for
-    # trusted callers (Discord / private chat / agents), so public = 2.
+    # ceiling across ALL replicas. vLLM max_num_seqs=8; public is capped at 2,
+    # leaving the rest for trusted callers (grimoire, Discord, private, agents).
     - name: CHAT_PUBLIC_GLOBAL_MAX_CONCURRENT
       value: "2"
     # Shared vLLM endpoint for public-chat inference (ADR 005 layer 6 / Phase 3).

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.272.0
+version: 0.273.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -158,6 +158,13 @@ spec:
             - name: GRIMOIRE_EXTRACT_LIMIT
               value: {{ $.Values.grimoire.extractLimit | quote }}
             {{- end }}
+            {{- if $.Values.grimoire.extractConcurrency }}
+            # Concurrent extract calls to vLLM. Keep <= vLLM --max-num-seqs so
+            # requests batch rather than queue; empty falls back to the code
+            # default (6).
+            - name: GRIMOIRE_EXTRACT_CONCURRENCY
+              value: {{ $.Values.grimoire.extractConcurrency | quote }}
+            {{- end }}
             {{- end }}
           {{- with .resources }}
           resources:

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -628,6 +628,12 @@ grimoire:
   # Unset here so the code default (25) applies; set to tune without a code
   # change.
   extractLimit: ""
+  # extractConcurrency: optional cap on concurrent extract calls to the vLLM
+  # server (lets it continuous-batch instead of running batch size 1). Unset
+  # here so the code default (6) applies; keep it below vLLM --max-num-seqs (8)
+  # so this bulk job leaves decode-slot headroom for trusted interactive
+  # callers. Set to tune without a code change.
+  extractConcurrency: ""
 
 # ADR 036 orchestrator brief compiler: a host-side OpenRouter call that routes
 # chat vs goose and compiles a grounded task brief for escalations. Disabled

--- a/projects/monolith/chat_public/limits.py
+++ b/projects/monolith/chat_public/limits.py
@@ -61,8 +61,8 @@ SESSION_TTL_SECONDS = int(os.environ.get("CHAT_PUBLIC_SESSION_TTL_SECONDS", "180
 #
 # SIZING RULE (reserved-headroom): public aggregate in-flight inference is capped
 # at GLOBAL_MAX_CONCURRENT across ALL pods, and the remaining vLLM decode slots
-# are reserved for trusted callers. Today max_num_seqs=3 and we reserve 1, so the
-# public cluster-wide cap is 2.
+# are left for trusted callers (grimoire extraction, Discord, private chat,
+# agents). Today max_num_seqs=8 and public is capped at 2.
 GLOBAL_MAX_CONCURRENT = int(os.environ.get("CHAT_PUBLIC_GLOBAL_MAX_CONCURRENT", "2"))
 
 # Advisory-lock namespace (classid) for the GPU limiter. A stable app-specific

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.272.0
+      targetRevision: 0.273.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/grimoire/extract.py
+++ b/projects/monolith/grimoire/extract.py
@@ -67,6 +67,15 @@ EXTRACT_CONNECT_TIMEOUT = 5.0
 EXTRACT_READ_TIMEOUT = 120.0  # frontier-model completions are slower than embeds
 
 DEFAULT_LIMIT = 25
+# Concurrent in-flight extract calls. The per-chunk work is GPU inference on
+# the shared vLLM server, and a sequential (one-at-a-time) client starves
+# vLLM's continuous batcher, so the GPU runs at batch size 1 (its worst case).
+# Firing several requests concurrently lets vLLM batch them. Kept BELOW the
+# server's --max-num-seqs (8) so this bulk job leaves decode-slot headroom for
+# latency-sensitive trusted callers (public chat is separately hard-capped at 2
+# by chat_public.limits; Discord / private chat / agents share the rest). It
+# also bounds the group size for the incremental per-group commit below.
+DEFAULT_CONCURRENCY = 6
 ENTITY_TYPES = {"creature", "spell", "location", "npc", "faction", "deity", "item"}
 
 # Mirrors ingest._Embedder: a per-module Protocol so extract.py does not
@@ -681,22 +690,54 @@ def _commit(session: Session) -> None:
     session.commit()
 
 
+async def _embed_new_entities(
+    session: Session,
+    embed_client: _Embedder,
+    newly_created: list[tuple[Entity, str]],
+) -> int:
+    """Embed (name + summary) the entities created in one group, in batches.
+
+    ``upsert_embedding_batch`` commits internally, so calling this while the
+    group's entities/mentions/markers are still pending in the session
+    persists them together with their embeddings in one transaction -- an
+    entity and its vector are never split across a crash.
+    """
+    embedded = 0
+    for start in range(0, len(newly_created), EMBED_BATCH_SIZE):
+        batch = newly_created[start : start + EMBED_BATCH_SIZE]
+        texts = [f"{entity.name}: {summary_text}" for entity, summary_text in batch]
+        vectors = await embed_client.embed_batch(texts)
+        entities_only = [entity for entity, _ in batch]
+        embedded += upsert_embedding_batch(
+            session, embed_client.model, "entity", entities_only, vectors
+        )
+    return embedded
+
+
 async def extract_chunks(
     session: Session,
     or_client: OpenRouterClient,
     embed_client: _Embedder,
     limit: int = DEFAULT_LIMIT,
+    concurrency: int = DEFAULT_CONCURRENCY,
 ) -> dict:
     """Extract entities/mentions/relationships from up to ``limit`` unprocessed chunks.
 
     A chunk is "unprocessed" if it has no ``chunk_extraction`` marker row
-    for this ``(model, prompt_hash)`` key yet (see module docstring). All
-    Session I/O lives in the sync helpers above, called (not awaited)
-    directly from this function's body, mirroring ``ingest.load_chunks``;
-    the ``await`` calls here are only ``or_client.extract`` and
-    ``embed_client.embed_batch``. Newly created entities are embedded (name
-    + summary) in batches after the write loop, reusing
-    ``ingest.upsert_embedding_batch``.
+    for this ``(model, prompt_hash)`` key yet (see module docstring).
+
+    Chunks are processed in groups of ``concurrency``. Within a group the
+    GPU-bound ``or_client.extract`` calls are issued **concurrently**
+    (``asyncio.gather``) so the vLLM server continuous-batches them instead
+    of running at batch size 1; the network fan-out is the only concurrent
+    step. All Session I/O then runs **serially** over the group's results
+    (the sync helpers here are not safe to share across tasks, and entity
+    name-dedup reads-then-writes), then the group is committed. This
+    per-group commit is incremental durability: a job killed at its deadline
+    loses at most the in-flight group, not the whole run (every completed
+    group already committed and is skipped on the next run). Each group's new
+    entities are embedded before its commit so entity + vector persist
+    together.
 
     Returns
     ``{"chunks_processed", "chunks_failed", "entities_created",
@@ -706,6 +747,7 @@ async def extract_chunks(
     model = or_client.model
     prompt_hash = _prompt_hash()
     chunks = _select_pending_chunks(session, model, prompt_hash, limit)
+    group_size = max(1, concurrency)
 
     summary = {
         "chunks_processed": 0,
@@ -716,76 +758,89 @@ async def extract_chunks(
         "relationships_created": 0,
         "entities_embedded": 0,
     }
-    # (entity, embed_text) for entities created this run; captured here
-    # rather than read back from Entity (which has no summary column) since
-    # the summary only exists transiently in the extraction payload.
-    newly_created: list[tuple[Entity, str]] = []
 
-    for chunk in chunks:
-        try:
-            extraction = await or_client.extract(chunk.content)
-        except (OpenRouterError, ValueError) as exc:
-            logger.warning(
-                "grimoire extract: chunk %s failed extraction: %s", chunk.id, exc
-            )
-            summary["chunks_failed"] += 1
-            continue
-
-        entities = extraction.get("entities")
-        mentions = extraction.get("mentions")
-        relationships = extraction.get("relationships")
-        if (
-            not isinstance(entities, list)
-            or not isinstance(mentions, list)
-            or not isinstance(relationships, list)
-        ):
-            logger.warning(
-                "grimoire extract: chunk %s extraction shape invalid", chunk.id
-            )
-            summary["chunks_failed"] += 1
-            continue
-
-        counts = _apply_extraction(
-            session,
-            chunk,
-            {
-                "entities": entities,
-                "mentions": mentions,
-                "relationships": relationships,
-            },
-            newly_created,
+    for group_start in range(0, len(chunks), group_size):
+        group = chunks[group_start : group_start + group_size]
+        # Concurrent network fan-out: overlap the extract calls so vLLM
+        # batches them. No Session is touched here. return_exceptions keeps
+        # one chunk's failure from cancelling its siblings' in-flight calls.
+        extractions = await asyncio.gather(
+            *(or_client.extract(chunk.content) for chunk in group),
+            return_exceptions=True,
         )
-        for key, value in counts.items():
-            summary[key] += value
-        summary["chunks_processed"] += 1
 
-        status = (
-            "ok"
-            if counts["entities_created"]
-            or counts["entities_reused"]
-            or counts["mentions_created"]
-            else "empty"
-        )
-        with session.begin_nested():
-            session.add(
-                ChunkExtraction(
-                    chunk_id=chunk.id,
-                    model=model,
-                    prompt_hash=prompt_hash,
-                    status=status,
+        # (entity, embed_text) for entities created in THIS group; captured
+        # here rather than read back from Entity (which has no summary
+        # column) since the summary only exists transiently in the payload.
+        newly_created: list[tuple[Entity, str]] = []
+
+        for chunk, extraction in zip(group, extractions):
+            if isinstance(extraction, Exception):
+                if isinstance(extraction, (OpenRouterError, ValueError)):
+                    logger.warning(
+                        "grimoire extract: chunk %s failed extraction: %s",
+                        chunk.id,
+                        extraction,
+                    )
+                    summary["chunks_failed"] += 1
+                    continue
+                # Unexpected error (not the extract client's own failure
+                # modes): surface it rather than silently marking the chunk
+                # failed. Prior groups are already committed.
+                raise extraction
+
+            entities = extraction.get("entities")
+            mentions = extraction.get("mentions")
+            relationships = extraction.get("relationships")
+            if (
+                not isinstance(entities, list)
+                or not isinstance(mentions, list)
+                or not isinstance(relationships, list)
+            ):
+                logger.warning(
+                    "grimoire extract: chunk %s extraction shape invalid", chunk.id
                 )
+                summary["chunks_failed"] += 1
+                continue
+
+            counts = _apply_extraction(
+                session,
+                chunk,
+                {
+                    "entities": entities,
+                    "mentions": mentions,
+                    "relationships": relationships,
+                },
+                newly_created,
             )
+            for key, value in counts.items():
+                summary[key] += value
+            summary["chunks_processed"] += 1
 
-    _commit(session)
+            status = (
+                "ok"
+                if counts["entities_created"]
+                or counts["entities_reused"]
+                or counts["mentions_created"]
+                else "empty"
+            )
+            with session.begin_nested():
+                session.add(
+                    ChunkExtraction(
+                        chunk_id=chunk.id,
+                        model=model,
+                        prompt_hash=prompt_hash,
+                        status=status,
+                    )
+                )
 
-    for start in range(0, len(newly_created), EMBED_BATCH_SIZE):
-        batch = newly_created[start : start + EMBED_BATCH_SIZE]
-        texts = [f"{entity.name}: {summary_text}" for entity, summary_text in batch]
-        vectors = await embed_client.embed_batch(texts)
-        entities_only = [entity for entity, _ in batch]
-        summary["entities_embedded"] += upsert_embedding_batch(
-            session, embed_client.model, "entity", entities_only, vectors
+        # Embed this group's new entities (commits entities + vectors
+        # together), then a final commit ensures the group's markers/mentions
+        # are durable even when it created no new entities.
+        summary["entities_embedded"] += await _embed_new_entities(
+            session, embed_client, newly_created
         )
+        _commit(session)
 
     logger.info("grimoire extract: %s", summary)
     return summary

--- a/projects/monolith/grimoire/extract_test.py
+++ b/projects/monolith/grimoire/extract_test.py
@@ -104,6 +104,75 @@ def _run(coro):
 # --- extract_chunks --------------------------------------------------------
 
 
+def test_extract_chunks_multiple_groups_all_marked(session: Session):
+    """concurrency < chunk count runs several groups; every chunk is marked."""
+    contents = [f"Chunk {i}: a goblin lurks." for i in range(5)]
+    chunks = [
+        _make_chunk(session, "mm", f"mm-{i:03d}", content)
+        for i, content in enumerate(contents)
+    ]
+    responses = {
+        content: {
+            "entities": [
+                {"entity_type": "creature", "name": f"Goblin {i}", "summary": "Small."}
+            ],
+            "mentions": [],
+            "relationships": [],
+        }
+        for i, content in enumerate(contents)
+    }
+    or_client = FakeOpenRouterClient(responses)
+    embed_client = FakeEmbedClient()
+
+    # 5 chunks at concurrency=2 -> groups [2, 2, 1].
+    summary = _run(
+        extract_chunks(session, or_client, embed_client, limit=25, concurrency=2)
+    )
+
+    assert summary["chunks_processed"] == 5
+    assert summary["chunks_failed"] == 0
+    assert summary["entities_created"] == 5
+    assert summary["entities_embedded"] == 5
+    # Every chunk got a marker (so a rerun would skip all of them).
+    markers = session.execute(select(ChunkExtraction)).scalars().all()
+    assert {m.chunk_id for m in markers} == {c.id for c in chunks}
+    assert len(or_client.calls) == 5
+
+
+def test_extract_chunks_earlier_groups_commit_before_a_later_failure(
+    session: Session,
+):
+    """A hard failure in a later group leaves earlier groups' work committed.
+
+    This is the incremental-commit contract: a run killed/aborted partway
+    through never rolls back the groups it already finished, so reruns resume
+    instead of redoing everything.
+    """
+    good = [_make_chunk(session, "mm", f"mm-{i:03d}", f"Good {i}") for i in range(2)]
+    boom = _make_chunk(session, "mm", "mm-100", "Boom")
+    responses = {
+        "Good 0": {"entities": [], "mentions": [], "relationships": []},
+        "Good 1": {"entities": [], "mentions": [], "relationships": []},
+        # A non-extract-client error (not OpenRouterError/ValueError) must
+        # propagate rather than be swallowed as a failed chunk.
+        "Boom": RuntimeError("unexpected"),
+    }
+    or_client = FakeOpenRouterClient(responses)
+    embed_client = FakeEmbedClient()
+
+    # concurrency=1 -> groups [Good 0], [Good 1], [Boom]; the third raises.
+    with pytest.raises(RuntimeError, match="unexpected"):
+        _run(extract_chunks(session, or_client, embed_client, limit=25, concurrency=1))
+
+    # The two good chunks committed before the failing group ran.
+    session.rollback()  # drop the aborted (uncommitted) third group
+    marked = {
+        m.chunk_id for m in session.execute(select(ChunkExtraction)).scalars().all()
+    }
+    assert marked == {good[0].id, good[1].id}
+    assert boom.id not in marked
+
+
 def test_extract_chunks_happy_path(session: Session):
     chunk = _make_chunk(
         session, "mm", "mm-001", "An owlbear stalks the Zhentarim camp."

--- a/projects/monolith/grimoire/jobs.py
+++ b/projects/monolith/grimoire/jobs.py
@@ -31,6 +31,10 @@ logger = logging.getLogger("monolith.grimoire.jobs")
 
 DEFAULT_BUCKET = "grimoire"
 DEFAULT_EXTRACT_LIMIT = 25
+# Concurrent extract calls; kept below vLLM --max-num-seqs (8) so this bulk job
+# leaves decode-slot headroom for trusted interactive callers. See
+# grimoire.extract.DEFAULT_CONCURRENCY.
+DEFAULT_EXTRACT_CONCURRENCY = 6
 
 
 def _embedding_client():
@@ -56,6 +60,30 @@ def _extract_limit() -> int:
             DEFAULT_EXTRACT_LIMIT,
         )
         return DEFAULT_EXTRACT_LIMIT
+
+
+def _extract_concurrency() -> int:
+    """Read GRIMOIRE_EXTRACT_CONCURRENCY (concurrent vLLM extract calls).
+
+    Falls back to the default on a bad or non-positive value; keep it <= the
+    vLLM server's --max-num-seqs so requests batch rather than queue.
+    """
+    raw = os.environ.get(
+        "GRIMOIRE_EXTRACT_CONCURRENCY", str(DEFAULT_EXTRACT_CONCURRENCY)
+    )
+    try:
+        value = int(raw)
+    except ValueError:
+        value = 0
+    if value < 1:
+        logger.warning(
+            "grimoire_extract_entities: invalid GRIMOIRE_EXTRACT_CONCURRENCY %r, "
+            "using %d",
+            raw,
+            DEFAULT_EXTRACT_CONCURRENCY,
+        )
+        return DEFAULT_EXTRACT_CONCURRENCY
+    return value
 
 
 async def grimoire_load_chunks(session: Session) -> None:
@@ -101,8 +129,11 @@ async def grimoire_extract_entities(session: Session) -> None:
         return None
 
     limit = _extract_limit()
+    concurrency = _extract_concurrency()
     or_client = OpenRouterClient(api_key=api_key)  # base_url/model read from env
     embed_client = _embedding_client()
-    summary = await extract_chunks(session, or_client, embed_client, limit=limit)
+    summary = await extract_chunks(
+        session, or_client, embed_client, limit=limit, concurrency=concurrency
+    )
     logger.info("grimoire_extract_entities done: %s", summary)
     return None

--- a/projects/monolith/grimoire/jobs_test.py
+++ b/projects/monolith/grimoire/jobs_test.py
@@ -71,7 +71,9 @@ class TestExtractEntitiesHandler:
     def test_skips_when_api_key_unset(self, monkeypatch, stub_clients):
         called = {"extract": False}
 
-        async def spy_extract_chunks(session, or_client, embed_client, limit):
+        async def spy_extract_chunks(
+            session, or_client, embed_client, limit, concurrency
+        ):
             called["extract"] = True
             return {}
 
@@ -90,7 +92,9 @@ class TestExtractEntitiesHandler:
     ):
         called = {"extract": False}
 
-        async def spy_extract_chunks(session, or_client, embed_client, limit):
+        async def spy_extract_chunks(
+            session, or_client, embed_client, limit, concurrency
+        ):
             called["extract"] = True
             return {}
 
@@ -108,7 +112,9 @@ class TestExtractEntitiesHandler:
     def test_runs_keyless_against_local_qwen_base_url(self, monkeypatch, stub_clients):
         captured: dict = {}
 
-        async def spy_extract_chunks(session, or_client, embed_client, limit):
+        async def spy_extract_chunks(
+            session, or_client, embed_client, limit, concurrency
+        ):
             captured["ran"] = True
             captured["api_key"] = or_client.api_key
             captured["base_url"] = or_client.base_url
@@ -136,8 +142,11 @@ class TestExtractEntitiesHandler:
     ):
         captured: dict = {}
 
-        async def spy_extract_chunks(session, or_client, embed_client, limit):
+        async def spy_extract_chunks(
+            session, or_client, embed_client, limit, concurrency
+        ):
             captured["limit"] = limit
+            captured["concurrency"] = concurrency
             captured["api_key"] = or_client.api_key
             captured["embed_client"] = embed_client
             return {
@@ -153,17 +162,47 @@ class TestExtractEntitiesHandler:
         monkeypatch.setattr("grimoire.extract.extract_chunks", spy_extract_chunks)
         monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test-key")
         monkeypatch.setenv("GRIMOIRE_EXTRACT_LIMIT", "7")
+        monkeypatch.delenv("GRIMOIRE_EXTRACT_CONCURRENCY", raising=False)
 
         _run(jobs.grimoire_extract_entities(session=None))
 
         assert captured["limit"] == 7
+        # Concurrency env unset -> code default.
+        assert captured["concurrency"] == jobs.DEFAULT_EXTRACT_CONCURRENCY
         assert captured["api_key"] == "sk-test-key"
         assert isinstance(captured["embed_client"], _SpyEmbedClient)
+
+    def test_passes_concurrency_env_and_falls_back_when_invalid(
+        self, monkeypatch, stub_clients
+    ):
+        captured: dict = {}
+
+        async def spy_extract_chunks(
+            session, or_client, embed_client, limit, concurrency
+        ):
+            captured["concurrency"] = concurrency
+            return {}
+
+        monkeypatch.setattr("grimoire.extract.extract_chunks", spy_extract_chunks)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test-key")
+
+        monkeypatch.setenv("GRIMOIRE_EXTRACT_CONCURRENCY", "3")
+        _run(jobs.grimoire_extract_entities(session=None))
+        assert captured["concurrency"] == 3
+
+        # Non-positive / non-numeric values fall back to the default rather
+        # than passing 0 (which would stall) or raising.
+        for bad in ("0", "-2", "not-a-number"):
+            monkeypatch.setenv("GRIMOIRE_EXTRACT_CONCURRENCY", bad)
+            _run(jobs.grimoire_extract_entities(session=None))
+            assert captured["concurrency"] == jobs.DEFAULT_EXTRACT_CONCURRENCY
 
     def test_defaults_limit_when_env_unset(self, monkeypatch, stub_clients):
         captured: dict = {}
 
-        async def spy_extract_chunks(session, or_client, embed_client, limit):
+        async def spy_extract_chunks(
+            session, or_client, embed_client, limit, concurrency
+        ):
             captured["limit"] = limit
             return {}
 
@@ -178,7 +217,9 @@ class TestExtractEntitiesHandler:
     def test_invalid_limit_env_falls_back_to_default(self, monkeypatch, stub_clients):
         captured: dict = {}
 
-        async def spy_extract_chunks(session, or_client, embed_client, limit):
+        async def spy_extract_chunks(
+            session, or_client, embed_client, limit, concurrency
+        ):
             captured["limit"] = limit
             return {}
 


### PR DESCRIPTION
## Why

Checking on the stalled grimoire extraction run (95/1224 chunks, ~8%), the bottleneck wasn't CPU (cluster at 4.6/49 cores) — it was that the extract job hits the shared vLLM **one chunk at a time**. A sequential client starves vLLM's continuous batcher, so the 4090 ran at batch size 1 (its worst case) even while reading 100% util. Separately, the batch committed **once at the end**, so every deadline kill rolled back all the work it had done (why prior 25-min-deadline runs left so little behind).

## What

- **Concurrent extraction, serial writes.** `extract_chunks` now processes chunks in groups of `concurrency` (default 6). Within a group the GPU-bound `or_client.extract` calls fan out via `asyncio.gather` so vLLM batches them; results are then applied **serially** (single `Session`, entity name-dedup reads-then-writes), the group's new entities embedded, and the group committed.
- **Incremental commit = crash-safe.** Per-group commit means a run killed at its deadline loses at most the in-flight group; marker-based idempotency (`(model, prompt_hash)`) skips the rest next run. Embedding *before* the group commit also closes the pre-existing committed-but-unembedded entity orphan window.
- **Widen the shared vLLM.** `--max-num-seqs 3 → 8` so it has decode slots to batch into. KV memory is a fixed pool (13% used at rest), so more seqs just share it. Grimoire stays at **6** to leave headroom for latency-sensitive trusted callers — public chat is separately hard-capped at 2 by `chat_public.limits` (advisory locks). Updated the now-stale `max_num_seqs=3` references there and in `monolith-public` values.
- **Tunable without a rebuild:** `GRIMOIRE_EXTRACT_CONCURRENCY` env / `grimoire.extractConcurrency` value.
- Chart bumps: monolith `0.272.0 → 0.273.0`, inference `2.5.3 → 2.5.4`.

## Expected impact

Up to ~6x extraction throughput (bounded by the reserved decode slots), turning the ~1129-chunk backlog from a dozen sequential runs into a couple, and deadline kills no longer waste committed work.

## Tests

Added `extract_test.py` coverage for multi-group processing (every chunk marked) and the incremental-commit contract (earlier groups stay committed when a later group hard-fails). Existing tests use ≤3 chunks (< concurrency 6), so they run as a single group with unchanged behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)