### PR TITLE
chore(monolith): bump chart to 0.273.0 to roll out grimoire fixes

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.272.0
+version: 0.273.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.272.0
+      targetRevision: 0.273.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Chart 0.272.0 was re-published with different content (new image tags for commits 4a2a8f0..ac0573da, plus the OPENROUTER_API_KEY secret move) without a version bump, leaving the monolith Application wedged OutOfSync: the live Deployment runs the 08d4f45 images while the desired manifest pins ac0573d.

Standard fix: bump Chart.yaml and targetRevision together to 0.273.0 so ArgoCD pulls a fresh chart revision and converges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)