### PR TITLE
chore(monolith): bump chart to 0.274.0 to roll out grimoire extraction changes

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.273.0
+version: 0.274.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.273.0
+      targetRevision: 0.274.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Two commits (bb26a8ca, a926fd3a) merged after the 0.273.0 bump,
re-publishing chart 0.273.0 with new image tags and recreating the
same-version OutOfSync wedge. Fresh version to converge on.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
