### PR TITLE
fix(monolith): dedupe OPENROUTER_API_KEY env declaration wedging ArgoCD OutOfSync

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.275.0
+version: 0.276.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -229,6 +229,12 @@ spec:
             # OPENROUTER_API_KEY is synced from the "openrouter" 1Password item
             # into the {{ include "monolith.fullname" . }}-openrouter Secret; the
             # extract job skips cleanly if it is absent.
+            {{- if not .Values.orchestrator.enabled }}
+            # Only declared when the orchestrator block below is not already
+            # declaring OPENROUTER_API_KEY (from the goosecracker Secret).
+            # Declaring the same env name twice makes the API server collapse
+            # the duplicate on apply, so ArgoCD renders two entries but reads
+            # back one: the Deployment is then permanently OutOfSync.
             - name: OPENROUTER_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -238,6 +244,7 @@ spec:
                   # 1Password item is created; the pod must not be blocked on it
                   # (the extract job already skips cleanly when the key is unset).
                   optional: true
+            {{- end }}
             - name: GRIMOIRE_S3_BUCKET
               value: {{ .Values.grimoire.s3Bucket | quote }}
             - name: GRIMOIRE_EXTRACT_MODEL

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.275.0
+      targetRevision: 0.276.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
The grimoire block (monolith-openrouter Secret) and the ADR 036
orchestrator block (goosecracker Secret) each declared
OPENROUTER_API_KEY. With both features enabled the API server collapses
the duplicate on apply, so the chart renders two entries but the live
Deployment has one: permanently OutOfSync, sync succeeds but never
converges. Emit the grimoire declaration only when the orchestrator is
not already declaring the key. Live behavior is unchanged (the
monolith-openrouter Secret does not exist yet; goosecracker was
winning the collapse anyway).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
