### PR TITLE
chore(monolith-public): bump chart to 0.83.0 to roll out homepage project stack

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.82.15
+version: 0.83.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.82.15
+      targetRevision: 0.83.0
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
The public tier serves the jomcgi.dev apex; the frontend image pin is baked
into this chart at build time, so the homepage change in monolith 0.275.0
also needs a public chart release.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
