### PR TITLE
fix(goosecracker): three recipe/observability defects from /improve-recipes deep-read

### DIFF
--- a/.claude/skills/improve-recipes/SKILL.md
+++ b/.claude/skills/improve-recipes/SKILL.md
@@ -107,7 +107,15 @@ it to compute the before/after aggregates for the PR body.
 
 ## Rank rules
 
-Score completed sessions on wall_seconds and owner_turns. Any session in a
+Score completed sessions on `active_seconds` and owner_turns. Rank on
+`active_seconds` (real guest work time, summed from sessions.db message gaps
+with owner-reply pauses excluded), NOT `wall_seconds`: wall_seconds is the
+whole thread lifetime and is dominated by time waiting for owner replies
+between turns, so it overstates effort by 10x or more (a 2510s thread whose
+guest actually ran ~152s). `wall_seconds` stays in the record for reference and
+for spotting threads that sat idle a long time, but a slow, expensive session
+is one with high `active_seconds`. `active_seconds` is null when the session
+has no sessions.db (fall back to wall_seconds for those). Any session in a
 FAILED state, or with a non-empty result_error, is automatically in the worst
 set regardless of score. A session whose `orchestrator_route` is `failopen`
 (fell back to the baked agent) is worth attention even if it completed: a
@@ -170,7 +178,8 @@ session's sessions.db in `s3://artifacts/{session_id}/`. Required keys:
 - `recipe`
 - `taxonomy_version`
 - `failure_modes`: list of `{mode, confidence, rationale}`
-- `metrics`: `{wall_seconds, owner_turns, tool_calls, retries}`
+- `metrics`: `{active_seconds, wall_seconds, owner_turns, tool_calls, retries}`
+  (rank on `active_seconds`; keep `wall_seconds` for reference)
 - `classified_at`: ISO timestamp, from `date -u`
 - `recipes_ref`: git SHA of `origin/main` for the recipe levers at run time
 

--- a/.claude/skills/improve-recipes/scripts/improve_recipes_tool.py
+++ b/.claude/skills/improve-recipes/scripts/improve_recipes_tool.py
@@ -15,13 +15,27 @@ Postgres access is read-only (SELECT only). S3 writes are limited to eval.json.
 
 import base64
 import json
+import logging
+import sqlite3
 import sys
+import tempfile
 
 from sqlalchemy import text
 
 from app.db import get_engine
 from artifact import s3
 from goosecracker import sessions
+
+# stdout carries the NDJSON records, so best-effort failures log to stderr.
+logger = logging.getLogger(__name__)
+
+# Inter-message gaps above this (seconds) are treated as idle (waiting for an
+# owner reply between turns) and excluded from active_seconds; gaps at or below
+# it are contiguous guest work and summed. Chosen above a slow single work step
+# (a local-model turn or a slow tool call, observed up to ~75s) and well below a
+# typical owner-reply pause (minutes), so a multi-turn thread's idle waits drop
+# out while its real work bursts are kept.
+_ACTIVE_IDLE_GAP_SECONDS = 180
 
 _GATHER_SQL = """
 SELECT at.thread_id, at.session_id, at.recipe, at.tier, at.state,
@@ -66,6 +80,57 @@ def _owner_turns(transcript):
     return len([b for b in transcript.split("\n\n") if b.strip()])
 
 
+def _active_seconds(session_id):
+    """Real guest work time for a session, from goose sessions.db timestamps.
+
+    wall_seconds (thread created_at -> completed_at) counts the whole thread
+    lifetime, most of which is waiting for owner replies between turns, so it
+    wildly overstates effort (a 2510s thread whose guest ran ~150s). This sums
+    the gaps between consecutive goose messages, dropping any gap above
+    _ACTIVE_IDLE_GAP_SECONDS (an owner-reply pause) and keeping the rest (the
+    contiguous tool-call / model / tool-result cadence of an active run). Robust
+    to goose recording tool results as role=user (which breaks a naive
+    user->assistant turn span). Best-effort: returns None when the db is
+    absent, unreadable, or has too few messages to span any time.
+    """
+    try:
+        blob = sessions.load(session_id)
+    except Exception:
+        logger.exception("active_seconds: sessions.load failed for %s", session_id)
+        return None
+    if not blob:
+        return None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".db") as f:
+            f.write(blob)
+            f.flush()
+            con = sqlite3.connect(f.name)
+            try:
+                ts = [
+                    row[0]
+                    for row in con.execute(
+                        "SELECT created_timestamp FROM messages "
+                        "ORDER BY created_timestamp, id"
+                    )
+                    if row[0] is not None
+                ]
+            finally:
+                con.close()
+    except Exception:
+        logger.exception(
+            "active_seconds: reading sessions.db failed for %s", session_id
+        )
+        return None
+    if len(ts) < 2:
+        return None
+    total = 0.0
+    for earlier, later in zip(ts, ts[1:]):
+        gap = later - earlier
+        if 0 < gap <= _ACTIVE_IDLE_GAP_SECONDS:
+            total += gap
+    return total
+
+
 def _bucket_index():
     """One paginated listing of the artifacts bucket -> per-session key sets."""
     client = s3._client()
@@ -104,6 +169,13 @@ def gather(since):
             )
             leaves = have.get(sid, set())
             rec["has_sessions_db"] = "sessions.db" in leaves
+            # Real guest work time from sessions.db message gaps (see
+            # _active_seconds): rank on this, not wall_seconds, which is thread
+            # lifetime inflated by owner-reply waits. Only computable when the
+            # session db is present.
+            rec["active_seconds"] = (
+                _active_seconds(sid) if rec["has_sessions_db"] else None
+            )
             rec["has_eval"] = "eval.json" in leaves
             rec["eval_taxonomy_version"] = None
             if rec["has_eval"]:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.275.0
+version: 0.276.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -857,6 +857,9 @@ def parent_channel_for_thread(thread_id: str) -> str:
 # the budget for the rest of the turn).
 _INJECTED_CONTEXT_MSG_LIMIT = 50
 _INJECTED_CONTEXT_PER_MSG_CHARS = 2000
+# Fallback path (own-transcript): keep the most recent slice so a long-running
+# thread's context stays bounded, mirroring the channel path's overall budget.
+_INJECTED_CONTEXT_OWN_CHARS = 8000
 
 
 def build_injected_context(thread_id: str, tier: str = "") -> dict[str, str]:
@@ -872,18 +875,39 @@ def build_injected_context(thread_id: str, tier: str = "") -> dict[str, str]:
     invoking channel.
     """
     parent = parent_channel_for_thread(thread_id)
-    if not parent:
-        return {}
-    with Session(get_engine()) as session:
-        rows = session.exec(
-            select(Message)
-            .where(Message.channel_id == parent)
-            .order_by(Message.created_at.desc())
-            .limit(_INJECTED_CONTEXT_MSG_LIMIT)
-        ).all()
-    if not rows:
-        return {}
-    rows = list(reversed(rows))  # oldest -> newest reads naturally
+    if parent:
+        with Session(get_engine()) as session:
+            rows = session.exec(
+                select(Message)
+                .where(Message.channel_id == parent)
+                .order_by(Message.created_at.desc())
+                .limit(_INJECTED_CONTEXT_MSG_LIMIT)
+            ).all()
+        if rows:
+            return _context_from_channel(list(reversed(rows)), parent)
+    # The parent-channel path resolved nothing: either no parent channel is
+    # recorded on the session row (an MCP-dispatched run, an id space that does
+    # not key a GoosecrackerSession, or an older thread) or the parent channel
+    # has no messages. Fall back to the thread's OWN accumulated transcript so a
+    # "do it again" / "change it" follow-up still carries this thread's earlier
+    # turns instead of shipping an empty /injected-context/ and costing the owner
+    # a correction turn.
+    own = _own_thread_transcript(thread_id)
+    if own:
+        logger.warning(
+            "build_injected_context: parent-channel context empty for thread "
+            "%s; falling back to the thread's own transcript (%d chars)",
+            thread_id,
+            len(own),
+        )
+        return _context_from_own_transcript(own)
+    # Truly nothing to inject: a brand-new thread with no prior turns. Expected
+    # on a first turn, so nothing to warn about.
+    return {}
+
+
+def _context_from_channel(rows: list[Message], parent: str) -> dict[str, str]:
+    """Build the injected-context bundle from a parent channel's recent messages."""
     lines = []
     truncated = 0
     for m in rows:
@@ -911,6 +935,41 @@ def build_injected_context(thread_id: str, tier: str = "") -> dict[str, str]:
         "as of this turn. Rebuilt every turn, so it grows as the thread advances.\n"
     )
     return {"README.md": readme, "transcript.md": transcript}
+
+
+def _own_thread_transcript(thread_id: str) -> str:
+    """The thread's own accumulated prompt transcript (its prior turns), or "".
+
+    ``GoosecrackerSession.transcript`` records the user's prompts for this
+    thread, one turn per blank-line-separated block. Sync; call via
+    ``asyncio.to_thread``.
+    """
+    with Session(get_engine()) as session:
+        row = session.get(GoosecrackerSession, thread_id)
+        return (row.transcript or "").strip() if row else ""
+
+
+def _context_from_own_transcript(transcript: str) -> dict[str, str]:
+    """Build the injected-context bundle from the thread's own prior turns.
+
+    Used when the parent-channel path is unavailable. Keeps the most recent
+    slice so a long thread stays within budget.
+    """
+    body = transcript
+    if len(body) > _INJECTED_CONTEXT_OWN_CHARS:
+        body = "[...earlier turns omitted...]\n" + body[-_INJECTED_CONTEXT_OWN_CHARS:]
+    readme = (
+        "# Injected context\n\n"
+        "This directory (`/injected-context/`) holds context the caller staged "
+        "for this task. You did not gather it and it is not in the repo. Grep or "
+        "read it when the user refers to an earlier discussion.\n\n"
+        "- Source: this agent thread's own prior turns (the parent Discord "
+        "channel was unavailable this turn).\n"
+        "- `transcript.md`: the prompts sent to this thread so far, oldest "
+        'first. Use it to resolve a follow-up like "do it again" or "change '
+        'it" against what the thread was already working on.\n'
+    )
+    return {"README.md": readme, "transcript.md": body}
 
 
 async def build_roast(attempt_text: str) -> str:

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -894,12 +894,26 @@ def build_injected_context(thread_id: str, tier: str = "") -> dict[str, str]:
     # a correction turn.
     own = _own_thread_transcript(thread_id)
     if own:
-        logger.warning(
-            "build_injected_context: parent-channel context empty for thread "
-            "%s; falling back to the thread's own transcript (%d chars)",
-            thread_id,
-            len(own),
-        )
+        if parent:
+            # A parent channel WAS recorded but resolved no messages: the primary
+            # context path failed unexpectedly, so warn to make it visible.
+            logger.warning(
+                "build_injected_context: parent channel %s for thread %s had no "
+                "messages; falling back to the thread's own transcript (%d chars)",
+                parent,
+                thread_id,
+                len(own),
+            )
+        else:
+            # No parent channel recorded (an MCP-dispatched thread, or an older
+            # thread predating the column): the own-transcript fallback is the
+            # normal path here, not an anomaly, so log at info.
+            logger.info(
+                "build_injected_context: no parent channel for thread %s; using "
+                "the thread's own transcript (%d chars)",
+                thread_id,
+                len(own),
+            )
         return _context_from_own_transcript(own)
     # Truly nothing to inject: a brand-new thread with no prior turns. Expected
     # on a first turn, so nothing to warn about.

--- a/projects/monolith/chat/goosecracker_test.py
+++ b/projects/monolith/chat/goosecracker_test.py
@@ -327,6 +327,72 @@ class TestBuildInjectedContext:
             bundle = goosecracker.build_injected_context("unknown-thread", tier="")
         assert bundle == {}
 
+    def test_falls_back_to_own_transcript_when_parent_has_no_messages(
+        self, engine, fake_api
+    ):
+        # Parent channel recorded but empty: a "do it again" follow-up must still
+        # carry this thread's own prior turns, not ship an empty bundle.
+        with Session(engine) as session:
+            session.add(
+                GoosecrackerSession(
+                    discord_thread="thr-own",
+                    recipe="agent",
+                    tier="",
+                    repo="homelab",
+                    parent_channel_id="chan-empty",
+                    transcript="wc2026 themed ball site\n\nYes let's do it again",
+                )
+            )
+            session.commit()
+
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            bundle = goosecracker.build_injected_context("thr-own", tier="")
+
+        assert set(bundle) == {"README.md", "transcript.md"}
+        assert "Yes let's do it again" in bundle["transcript.md"]
+        assert "own prior turns" in bundle["README.md"]
+
+    def test_falls_back_to_own_transcript_when_no_parent_channel(
+        self, engine, fake_api
+    ):
+        with Session(engine) as session:
+            session.add(
+                GoosecrackerSession(
+                    discord_thread="thr-np",
+                    recipe="agent",
+                    tier="",
+                    repo="homelab",
+                    parent_channel_id="",
+                    transcript="build me a chart",
+                )
+            )
+            session.commit()
+
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            bundle = goosecracker.build_injected_context("thr-np", tier="")
+
+        assert "build me a chart" in bundle["transcript.md"]
+
+    def test_empty_when_no_parent_and_no_prior_turns(self, engine, fake_api):
+        # First turn of a thread with no parent channel and no transcript yet:
+        # genuinely nothing to inject, so an empty bundle is correct.
+        with Session(engine) as session:
+            session.add(
+                GoosecrackerSession(
+                    discord_thread="thr-first",
+                    recipe="agent",
+                    tier="",
+                    repo="homelab",
+                    parent_channel_id="",
+                    transcript="",
+                )
+            )
+            session.commit()
+
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            bundle = goosecracker.build_injected_context("thr-first", tier="")
+        assert bundle == {}
+
 
 # ---------------------------------------------------------------------------
 # Agent conversational path: continue_session queuing + dispatching

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.275.0
+      targetRevision: 0.276.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/router_render.py
+++ b/projects/monolith/goosecracker/router_render.py
@@ -64,6 +64,267 @@ _CONTEXT_FILE = "/tmp/goose/context.md"
 _PLAN_FILE = "/injected-context/plan.md"
 
 
+# --- Fallback router (plan-less path): a VERBATIM pin of the checked-in guest
+# agent.yaml (the full classify-and-route recipe). ADR 022 snapshot-resumed
+# threads boot a frozen rootfs whose baked agent.yaml can predate later recipe
+# changes (e.g. the sub_recipes block that exposes the `delegate` tool, added
+# 2026-07-01), so passing bare recipe="agent" re-applies a stale recipe and the
+# router loses delegate. render_fallback_router() injects THIS current agent.yaml
+# every turn instead. The constants below are generated from agent.yaml and
+# pinned by tests/router_render_test.py (full parse-equality), so a guest recipe
+# change fails CI until this pin is refreshed.
+_AGENT_INSTRUCTIONS = """\
+You are the routing agent for an isolated Firecracker microVM, on a
+checkout of the repo at /workspace. You do not do the work yourself; you
+classify the task, gather the context the worker needs, and dispatch ONE
+sub-recipe to do it.
+
+If a directory /injected-context/ exists, it holds context the caller staged
+for this task that is not in the repo and not in your own history (for example
+an earlier conversation). Read /injected-context/README.md first, then grep the
+other files when the task refers to prior discussion. Pass it on: mention it in
+the context briefing you write to /tmp/goose/context.md so the worker sub-recipe
+can use it too.
+
+Route the task to exactly one of:
+- query: the task is a question. It wants an answer or an explanation,
+  not a change. ("how does X work", "where is Y configured", "why did
+  Z fail")
+- research: the task needs facts from OUTSIDE the repo and cluster:
+  upstream docs, current versions, API details, best practices, product
+  comparisons, news. ("what's the latest X", "how do I use library Y",
+  "compare A vs B"). If the answer lives in this repo or this cluster,
+  that is query, not research.
+
+  You do NOT research yourself in the router, even when the question looks
+  easy. Only the research sub-recipe has the working web-search wiring (the
+  SEARXNG_URL endpoint and its exact query incantation); the router does
+  not, so inline research wastes many turns failing against public search
+  endpoints that block you. You run it as a delegated subagent, using the
+  `delegate` tool, exactly like an artifact:
+    1. `delegate(source: "research")` and WAIT. That subagent reads the
+       question from /tmp/goose/task.md, searches, reads sources, and
+       returns a short cited answer as its result.
+    2. `recipe__final_output` with `mode: research`, putting the subagent's
+       returned answer into `summary` (and `details` if it is long). You are
+       RELAYING the subagent's answer, not describing that you routed: the
+       summary must contain the actual finding and its sources, never a
+       sentence like "routed to research" or "dispatched the sub-recipe".
+
+  HARD GATE: do NOT emit `mode: research` until the `delegate(source:
+  "research")` call has RETURNED a result in THIS turn. Deciding to delegate
+  is not delegating: if your most recent action was a thought rather than an
+  actual `delegate` tool call, nothing has happened yet and you have no
+  answer to relay. Never answer the research question yourself.
+- plan: the task wants a design or implementation plan written, or is a
+  large/ambiguous change where planning must precede code. The deliverable
+  is a plan document, not the change itself.
+- implement: the task is a concrete, actionable change to code, config,
+  or docs. The deliverable is a commit and a PR.
+- artifact: the task asks for a thing to look at, a visualization, an
+  interactive page, a chart, a small demo, a dashboard, or a report rendered
+  as a web page ("make me / build me / show me a ..."). The deliverable is a
+  live web page published to a URL, not a repo change. The artifact runs in a
+  sandboxed iframe and cannot touch a repo.
+
+  You do NOT build the page yourself. Artifacts are BUILD then REVIEW, and you
+  run BOTH steps as delegated subagents, using the `delegate` tool, so that the
+  design bar, the JavaScript parse gate and the fresh-eyes review actually run.
+  If you write the HTML yourself instead, ALL THREE are skipped and a broken
+  page ships. Each delegate call is bracketed by the PROGRESS MARKERS protocol
+  below (two stages: build, review). The steps, in order, each waiting for the
+  result:
+    1. `delegate(source: "artifact-build")` and WAIT. That subagent reads the
+       task from /tmp/goose/task.md and writes the page to /tmp/artifact.html.
+    2. Before dispatching, check for steering per the STEERING section above.
+       `delegate(source: "artifact-review")` and WAIT. That subagent reads
+       /tmp/artifact.html in a fresh context, fixes real correctness and design
+       issues in place, and re-checks that the inline script parses.
+    3. `recipe__final_output` with `mode: artifact` and an empty `url` (the
+       harness publishes /tmp/artifact.html and appends the live URL). Just
+       summarize what was built or changed.
+
+  HARD GATE: do NOT emit `mode: artifact` until BOTH `delegate` calls have
+  RETURNED a result in THIS turn. Deciding to delegate is not delegating: if
+  your most recent action was a thought rather than an actual `delegate` tool
+  call, nothing has happened yet. Never write /tmp/artifact.html yourself and
+  never skip the review.
+
+When a task mixes modes, pick the deliverable the user actually asked
+for. "Fix X" is implement. "How should we fix X" is plan. "Is X broken"
+is query. On a resumed thread, classify the NEW message: a follow-up
+question after an implement run routes to query, and "now do it" after a
+plan run routes to implement.
+
+ALWAYS re-read /tmp/goose/task.md as your FIRST action on EVERY turn,
+including a resumed thread. The file is overwritten with the CURRENT message
+each turn, so it is almost always a NEW request, not a repeat of what you did
+before. NEVER answer "already completed", "already built", or "repeated
+prompt" without cat-ing the file first: assuming the task is unchanged is the
+single most common way this router fails the owner. A follow-up on an artifact
+thread ("add X", "change the Y", "make it Z", "that is broken") is a NEW
+artifact task: re-run BOTH delegates (artifact-build then artifact-review).
+The previous /tmp/artifact.html is still on disk, so artifact-build modifies
+it in place rather than starting over.
+
+Before dispatching, spend at most a few tool calls gathering context the
+worker will need: skim the repo's root CLAUDE.md, locate the relevant
+project directory, and note prior thread state (an earlier plan or PR in
+this conversation). The root conventions file is not always ./CLAUDE.md:
+in this repo it lives at .claude/CLAUDE.md. Locate it before reading, for
+example `find . -maxdepth 2 -name CLAUDE.md`, rather than assuming the
+path (a wrong guess wastes tool calls on a "No such file" error). Write
+what you found as a short briefing to the file /tmp/goose/context.md (for
+example with the editor, or `printf '%s' '...' > /tmp/goose/context.md`):
+relevant paths, constraints, and any earlier results the worker cannot see
+(sub-recipes do not share your conversation history). Every sub-recipe reads
+that file automatically, so this is how the briefing reaches the worker. Keep
+it short; if you have nothing useful to add, leave the file untouched. Do not
+do the task yourself and do not deep-dive; the worker re-reads what it needs.
+
+PROGRESS MARKERS (required, not optional). The owner watches a live
+checklist built from marker lines you print to stdout. Emit them with the
+developer extension as shell `printf` commands, exactly in the forms below,
+one printf per step. A marker line is `::stage::<index>::<state>::<title>`;
+states are pending, running, done, failed, skipped; titles are short human
+phrases and must not contain `::`. If you skip these the owner sees no
+progress, so treat them as mandatory steps of the run, not decoration.
+Never write markers as prose in your reply; only ever via printf.
+
+For a single-route task (query, research, plan, implement) the plan is ONE
+stage. Pick a Title for the route: query -> "Answering", research ->
+"Researching", plan -> "Planning", implement -> "Implementing".
+  1. Immediately before you call the sub-recipe tool, run:
+       printf '::stages::1\\n::stage::0::running::<Title>\\n'
+  2. As soon as the sub-recipe returns successfully, run:
+       printf '::stage::0::done::<Title>\\n'
+  3. If it fails or you must abort, run instead:
+       printf '::stage::0::failed::<short reason, one line, no ::>\\n'
+
+For an artifact task the plan is TWO stages (build, then review):
+  1. Before delegate(source: "artifact-build"), run:
+       printf '::stages::2\\n::stage::0::running::Building the page\\n::stage::1::pending::Reviewing the page\\n'
+  2. After artifact-build returns, before delegate(source: "artifact-review"), run:
+       printf '::stage::0::done::Building the page\\n::stage::1::running::Reviewing the page\\n'
+  3. After artifact-review returns, run:
+       printf '::stage::1::done::Reviewing the page\\n'
+  If either step fails, run printf '::stage::<i>::failed::<short reason>\\n'
+  for the stage that failed instead of its done marker.
+
+STEERING (mid-run adjustments from the thread). While your run is in flight,
+people in the thread can post steering messages. Check for them at each stage
+boundary: right before you dispatch a sub-recipe, and (for artifacts) between
+the build and review delegations, run:
+    curl -s "${GOOSECRACKER_STEERING_URL}"
+If GOOSECRACKER_STEERING_URL is empty or the call fails, just proceed (steering
+is best-effort, never block the run on it). The response is JSON:
+  {"messages": [{"author_id": "...", "tier": "...", "text": "..."}, ...]}
+Handle it as follows:
+  - No messages: proceed normally.
+  - A message whose text is exactly "stop" or "cancel" (case-insensitive,
+    trimmed): abort the run. Emit a skipped marker for every stage not yet done
+    (printf '::stage::<i>::skipped::<title>\\n' for each remaining stage), then a
+    final done marker for the plan, then call recipe__final_output summarizing
+    that the run was cancelled by a participant, and STOP. Do not dispatch
+    further sub-recipes.
+  - Otherwise (real steering content): fold it into the work. Append each
+    message to /tmp/goose/context.md as a line "Steering from <author_id>:
+    <text>" (so the sub-recipe sees it), and if it changes the plan (adds or
+    reorders work) re-announce the plan with a fresh ::stages:: block and
+    per-stage markers (the checklist reflects the change). Then continue.
+Keep the steering check to a single curl per boundary (do not poll in a loop).
+
+Dispatch the actual work; never run it in the router. Your context is
+shared across the whole thread, so a large tool output here (a full
+`git log`, a wide `grep`, a big file) can overflow it and trigger a
+compaction that drops the answer mid-run. Context-gathering is a couple of
+SMALL reads only. If answering needs the git history, many files, or large
+output, that is the sub-recipe's job, not yours: route it. Bound anything
+you do read (pipe through `head`, count with `wc -l` first, sample) and
+never pull hundreds of log lines into your context.
+
+Before dispatching, check for steering per the STEERING section above. Then
+call the matching sub-recipe tool and wait for its result, bracketed by
+the single-stage PROGRESS MARKERS protocol above. The task and your context
+briefing reach the worker through files (the task via {{ task_file }}, the
+briefing via /tmp/goose/context.md), pre-wired on each sub-recipe, so you do
+not pass them as tool arguments.
+
+When it returns, produce the structured result enforced by the response
+schema below, from the sub-recipe's output: a short `summary` of the
+action and outcome, or the answer itself if the task was a question;
+optional `details` for the fuller answer or notable findings; the `mode`
+you routed to; a `type` (pr/issue/note/answer/artifact); and a `url` only if
+the worker reported a real PR or issue URL. For an artifact the harness
+publishes the page and adds its live URL to the reply, so leave `url` empty
+and just summarize what you built. Before emitting `mode: artifact`, re-check
+the HARD GATE above: BOTH `delegate(source: "artifact-build")` and
+`delegate(source: "artifact-review")` must have returned in this turn. Do not
+summarize a page you only intended to build. The summary describes the ACTION
+and RESULT, not your reasoning.
+
+Be brief and finish fast. Length is the main thing that makes a reply feel
+slow: this runs on a local model, so every extra sentence is real wall-time,
+and the owner reads the result in a chat window. Default to answering the
+question in one or two sentences in `summary`, and leave `details` empty.
+Fill `details` only when the task explicitly asks for depth (a full
+explanation, a breakdown, a report), and keep it to a few short paragraphs
+even then. Match the owner's register: a casual one-line question gets a
+one-line answer, not an essay.
+
+As soon as you have the answer, emit the final result and stop. Do not keep
+exploring, re-explaining, or re-drafting a longer version once the answer is
+known: extra turns are wasted wall-time. Over-answering costs the owner a
+follow-up turn asking you to be concise, which is exactly the outcome this
+recipe exists to avoid.
+
+CRITICAL, tool name: deliver the structured result by calling the tool named
+exactly `recipe__final_output`. That is its real registered name. Some system
+messages will tell you to "call the `final_output` tool", that bare name is
+NOT registered and returns "tool not found"; the correct name always carries
+the `recipe__` prefix. Call `recipe__final_output` on your first attempt and
+do not retry the unprefixed name.
+"""
+
+_AGENT_PROMPT = """\
+Your task is in the file {{ task_file }}. Read it in full first, for example
+`cat {{ task_file }}`, then classify and route it.
+"""
+
+_AGENT_TITLE = "Agent"
+_AGENT_DESCRIPTION = "Routing agent for a snapshot-managed microVM thread (ADR 022): classifies the task and dispatches the matching sub-recipe."
+_AGENT_SETTINGS = {"max_turns": 25, "max_tool_repetitions": 5}
+_AGENT_EXTENSIONS = [{"type": "builtin", "name": "developer"}]
+_AGENT_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "summary": {
+            "type": "string",
+            "description": "One or two sentences: the action taken and the outcome, or the answer itself if the task was a question.",
+        },
+        "details": {
+            "type": "string",
+            "description": "Optional longer detail: the full answer, notable findings, or next steps. May be empty.",
+        },
+        "mode": {
+            "type": "string",
+            "enum": ["query", "plan", "implement", "artifact", "research"],
+            "description": "Which sub-recipe the task was routed to.",
+        },
+        "type": {
+            "type": "string",
+            "enum": ["pr", "issue", "note", "answer", "artifact"],
+            "description": "The kind of result. Use 'artifact' for a published web page; the harness adds its live URL, so leave `url` empty.",
+        },
+        "url": {
+            "type": "string",
+            "description": "A PR or issue URL ONLY if the worker actually opened one in this run (it reported the real URL); otherwise an empty string. Never invent, guess, or reconstruct a URL.",
+        },
+    },
+    "required": ["summary"],
+}
+
+
 def _baked_path(recipe_id: str) -> str:
     """The stable guest path a sub-recipe id resolves to (Design invariant 5)."""
     return f"/home/goose-agent/recipes/{recipe_id}.yaml"
@@ -437,5 +698,68 @@ def render_router(plan: Plan) -> str:
         "extensions": [{"type": "builtin", "name": "developer"}],
         "settings": {"max_turns": 25, "max_tool_repetitions": 5},
         "response": {"json_schema": _response_schema(plan)},
+    }
+    return yaml.safe_dump(recipe, sort_keys=False, default_flow_style=False)
+
+
+def _fallback_sub_recipes() -> list[dict]:
+    """All catalog sub-recipes, in catalog order, each at its baked guest path.
+
+    Mirrors the guest agent.yaml sub_recipes block so the injected fallback
+    router is byte-faithful to it. Sourced from ``recipe_catalog.CATALOG`` (the
+    single source of truth for the id set), imported lazily to avoid eager
+    import cost at module load.
+    """
+    from goosecracker.recipe_catalog import CATALOG
+
+    entries: list[dict] = []
+    for recipe_id in CATALOG:
+        entry: dict = {"name": recipe_id, "path": _baked_path(recipe_id)}
+        # Preserve agent.yaml's sequential_when_repeated for implement.
+        if recipe_id == "implement":
+            entry["sequential_when_repeated"] = True
+        entry["values"] = {
+            "task_file": "{{ task_file }}",
+            "context_file": _CONTEXT_FILE,
+        }
+        entries.append(entry)
+    return entries
+
+
+def render_fallback_router() -> str:
+    """Render the plan-less fallback router: the current guest agent.yaml.
+
+    This is the plan-less twin of :func:`render_router`. Same injection
+    mechanism (the caller writes the result to ``/injected-context/router.yaml``
+    and points ``--recipe`` at it), but it carries the FULL classify-and-route
+    agent rather than a pre-decided ordered plan. Because the recipe is injected
+    fresh every turn, a snapshot-resumed thread runs current recipe text (and so
+    keeps the ``delegate`` tool the ``sub_recipes`` block registers) instead of
+    the frozen baked ``agent.yaml`` its rootfs was snapshotted with.
+
+    The recipe is a verbatim reproduction of the checked-in guest agent.yaml,
+    pinned by ``tests/router_render_test.py`` (full parse-equality). Sub-recipe
+    BODIES still resolve to their baked guest paths, exactly as
+    :func:`render_router` does: this restores the delegate tool + current router
+    text, not sub-recipe body currency.
+    """
+    recipe = {
+        "version": _RECIPE_VERSION,
+        "title": _AGENT_TITLE,
+        "description": _AGENT_DESCRIPTION,
+        "instructions": _AGENT_INSTRUCTIONS,
+        "prompt": _AGENT_PROMPT,
+        "parameters": [
+            {
+                "key": "task_file",
+                "description": "Path to a file containing the task to perform",
+                "input_type": "string",
+                "requirement": "required",
+            }
+        ],
+        "sub_recipes": _fallback_sub_recipes(),
+        "extensions": _AGENT_EXTENSIONS,
+        "settings": _AGENT_SETTINGS,
+        "response": {"json_schema": _AGENT_RESPONSE_SCHEMA},
     }
     return yaml.safe_dump(recipe, sort_keys=False, default_flow_style=False)

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -655,6 +655,23 @@ async def _invoke_turn(
             "plan.md": render_plan_file(plan),
         }
         effective_recipe = "/injected-context/router.yaml"
+    elif recipe == "agent":
+        # Plan-less agent path: inject the CURRENT agent.yaml as the router rather
+        # than passing bare recipe="agent". ADR 022 snapshot-resumed threads boot a
+        # frozen rootfs whose baked agent.yaml can predate later recipe changes (the
+        # sub_recipes block that exposes the `delegate` tool was added 2026-07-01),
+        # so the bare-name path silently runs a stale recipe with no delegate tool
+        # and the router improvises inline. render_fallback_router() is a
+        # drift-guarded verbatim copy of agent.yaml, injected fresh every turn, so
+        # both fresh and resumed threads run current recipe text. Same mechanism as
+        # the plan branch above; only the recipe body differs.
+        from goosecracker.router_render import render_fallback_router
+
+        injected_context = {
+            **injected_context,
+            "router.yaml": render_fallback_router(),
+        }
+        effective_recipe = "/injected-context/router.yaml"
     payload = {
         "recipe": effective_recipe,
         "task": task,

--- a/projects/monolith/goosecracker/tests/router_render_test.py
+++ b/projects/monolith/goosecracker/tests/router_render_test.py
@@ -235,3 +235,48 @@ def test_drift_guard_scaffold_tokens_exist_in_guest_agent_yaml() -> None:
     assert "::stage::" in text
     assert "recipe__final_output" in text
     assert "GOOSECRACKER_STEERING_URL" in text
+
+
+def test_fallback_router_parses_equal_to_guest_agent_yaml() -> None:
+    # The plan-less fallback router (injected for snapshot-resumed threads so
+    # they run current recipe text with the `delegate` tool) is a VERBATIM pin
+    # of the guest agent.yaml. Full parse-equality is the drift guard: any edit
+    # to the guest agent.yaml fails this test until the pinned constants in
+    # router_render.py are regenerated, which is exactly what keeps a resumed
+    # thread's injected recipe current instead of frozen at snapshot time.
+    rendered = _loaded(router_render.render_fallback_router())
+    agent = yaml.safe_load(_AGENT_YAML.read_text())
+    assert rendered == agent
+
+
+def test_fallback_router_lists_all_sub_recipes_for_delegate() -> None:
+    # The defect this fixes: a resumed snapshot ran a baked agent.yaml with NO
+    # sub_recipes block, so goose never registered the `delegate` tool and the
+    # router improvised inline. The injected fallback must carry every catalog
+    # sub-recipe (that block is what registers delegate), each at its baked path.
+    doc = _loaded(router_render.render_fallback_router())
+    names = [s["name"] for s in doc["sub_recipes"]]
+    assert tuple(names) == _ALL_IDS
+    for sub in doc["sub_recipes"]:
+        assert sub["path"] == f"/home/goose-agent/recipes/{sub['name']}.yaml"
+        assert sub["values"]["task_file"] == "{{ task_file }}"
+        assert sub["values"]["context_file"] == "/tmp/goose/context.md"
+    impl = next(s for s in doc["sub_recipes"] if s["name"] == "implement")
+    assert impl["sequential_when_repeated"] is True
+
+
+def test_fallback_router_is_classifier_not_ordered_plan() -> None:
+    # Unlike render_router (a pre-decided ordered plan with a replan escape
+    # hatch), the fallback is the full classify-and-route agent: its mode enum
+    # spans all routes and it carries no replan field.
+    doc = _loaded(router_render.render_fallback_router())
+    schema = doc["response"]["json_schema"]
+    assert schema["required"] == ["summary"]
+    assert "replan" not in schema["properties"]
+    assert set(schema["properties"]["mode"]["enum"]) == {
+        "query",
+        "plan",
+        "implement",
+        "artifact",
+        "research",
+    }

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -599,7 +599,11 @@ async def test_run_one_turn_ships_injected_context_in_payload(monkeypatch):
     )
 
     assert ok is True
-    assert captured_payload["injectedContext"] == {"transcript.md": "hi"}
+    # The ADR 040 per-turn context is shipped. On the agent path the payload also
+    # carries the injected fallback router (see
+    # test_run_one_turn_without_plan_injects_fallback_router); here we only assert
+    # the ADR 040 entry survives alongside it.
+    assert captured_payload["injectedContext"]["transcript.md"] == "hi"
 
 
 def _one_step_plan():
@@ -670,14 +674,22 @@ async def test_run_one_turn_with_plan_injects_router_and_plan_file(monkeypatch):
     assert payload["injectedContext"]["transcript.md"] == "hi"
 
 
-async def test_run_one_turn_without_plan_keeps_baked_agent_recipe(monkeypatch):
-    """Task 6 fallback (Design invariant 2): with no Plan, behavior is
-    unchanged: recipe stays "agent" and neither router.yaml nor plan.md is
-    injected."""
+async def test_run_one_turn_without_plan_injects_fallback_router(monkeypatch):
+    """Plan-less agent path: with no Plan the runner injects the CURRENT
+    agent.yaml as the router (render_fallback_router) and points the recipe at
+    the injected copy, so a snapshot-resumed thread runs current recipe text
+    with the delegate tool instead of its frozen baked agent.yaml. No plan.md is
+    injected (there is no ordered plan), and the ADR 040 per-turn context is
+    preserved."""
+    from goosecracker import router_render
+
     payload = await _run_one_turn_with_captured_payload(monkeypatch, plan=None)
 
-    assert payload["recipe"] == "agent"
-    assert "router.yaml" not in payload["injectedContext"]
+    assert payload["recipe"] == "/injected-context/router.yaml"
+    assert (
+        payload["injectedContext"]["router.yaml"]
+        == router_render.render_fallback_router()
+    )
     assert "plan.md" not in payload["injectedContext"]
     assert payload["injectedContext"]["transcript.md"] == "hi"
 


### PR DESCRIPTION
Fixes three defects surfaced by an `/improve-recipes` deep-read of goosecracker session `1522787568511488221` (thread `t-0b1f539a21aa`).

## Defect 1: snapshot-resumed threads ran stale baked recipes (delegate tool missing)

A thread resumed from a microVM snapshot (ADR 022) boots a frozen rootfs whose baked `agent.yaml` predated the `sub_recipes` block that exposes goose's `delegate` tool (added 2026-07-01, `9bc11aaac`). Passing bare `recipe="agent"` re-applied that stale recipe, so the router lost `delegate` and improvised the artifact inline, skipping artifact-build/artifact-review.

**Fix (Option A1):** the runtime-router path (ADR 036) already escapes the frozen rootfs by injecting `router.yaml` into `/injected-context/` and pointing `--recipe` at it. The plan-less fallback now does the same: `render_fallback_router()` reproduces the current guest `agent.yaml` and the runner injects it every turn, so both fresh and resumed threads run current recipe text with the delegate tool. The reproduction is a verbatim pin of `agent.yaml`, guarded by a full parse-equality test, so a guest recipe change fails CI until the pin is refreshed. Sub-recipe bodies still resolve to their baked guest paths, identical to the plan path (by design; snapshot body currency is out of scope).

## Defect 2: empty `/injected-context/` on a follow-up turn

**Prod finding (read-only query): both hypotheses in the brief were falsified.** For thread `t-0b1f539a21aa` / session `1522787568511488221`, `parent_channel_id` was set (`1501965852969402517`) and that channel had 38 messages including the World Cup requests, so under current code the thread resolves context fine. The empty `/injected-context/` in the transcript was an artifact of the older chart the snapshot ran on.

**Fix (durable + observable):** `build_injected_context` now falls back to the thread's own accumulated `GoosecrackerSession.transcript` when the parent-channel path yields nothing, so a "do it again" follow-up always carries this thread's earlier turns. It warns when the parent path resolves empty but the fallback recovers (the primary path failing is now loud instead of silent); a genuine first turn with no prior turns still returns an empty bundle.

## Defect 3: misleading `/improve-recipes` metrics (separate commit)

`wall_seconds` is thread lifetime, dominated by waiting for owner replies (2510s wall vs ~152s real work here). Added `active_seconds`, summed from goose `sessions.db` message-timestamp gaps with owner-reply pauses (>180s) dropped, robust to goose recording tool results as `role=user`. Rank rules now rank on `active_seconds`, keeping `wall_seconds` for reference. Verified in prod: session `1522787568511488221` reports `active_seconds=152.0` against `wall_seconds=2510`.

## Verification
- `render_fallback_router()` parses **equal** to the checked-in `agent.yaml` (verified locally with PyYAML; enforced by a new drift-guard test).
- `active_seconds` verified end-to-end in prod via `gather` (152.0 vs 2510 wall).
- Local `py_compile` + `ruff format`/`check` clean on all changed files.
- Chart bumped 0.275.0 -> 0.276.0 (Chart.yaml + application.yaml targetRevision) to roll out the monolith-side Defect 1 & 2 fixes.

The next `/improve-recipes` run validates Defects 1-3 via the before/after aggregates (fewer failopen/improvised-artifact sessions, and `active_seconds`-based ranking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)