### PR TITLE
feat(orchestrator): route ADR 036 planner to GLM-4.7 on Cerebras with DeepSeek fallback

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.276.0
+version: 0.277.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -260,13 +260,24 @@ spec:
             {{- end }}
             {{- if .Values.orchestrator.enabled }}
             # ADR 036 orchestrator brief compiler (host-side only; the guest
-            # egress boundary in ADR 023 never carries this key). OPENROUTER_API_KEY
-            # is sourced from the same "goosecracker" 1Password item that already
+            # egress boundary in ADR 023 never carries these keys). Both keys are
+            # sourced from the same "goosecracker" 1Password item that already
             # syncs into the "goosecracker" Secret for the artifact egress
             # sidecar (see onepassworditem-goosecracker.yaml). We reuse that
-            # Secret rather than sync the item twice; the field name matches the
-            # OPENROUTER_API_KEY convention the goosecracker item exposes. Note
-            # the Secret is named "goosecracker" (not fullname-prefixed).
+            # Secret rather than sync the item twice; the field names match the
+            # conventions the goosecracker item exposes. Note the Secret is named
+            # "goosecracker" (not fullname-prefixed).
+            # ORCHESTRATOR_API_KEY drives the primary provider (Cerebras); the
+            # client falls back to OPENROUTER_API_KEY if this is absent.
+            - name: ORCHESTRATOR_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: goosecracker
+                  key: CEREBRAS_API_KEY
+                  # Optional: the client fails over to the fallback provider (and
+                  # ultimately fails open) when the key is absent.
+                  optional: true
+            # OPENROUTER_API_KEY drives the DeepSeek fallback provider.
             - name: OPENROUTER_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -280,6 +291,12 @@ spec:
               value: {{ .Values.orchestrator.model | quote }}
             - name: ORCHESTRATOR_BASE_URL
               value: {{ .Values.orchestrator.baseUrl | quote }}
+            {{- if .Values.orchestrator.fallbackModel }}
+            - name: ORCHESTRATOR_FALLBACK_MODEL
+              value: {{ .Values.orchestrator.fallbackModel | quote }}
+            - name: ORCHESTRATOR_FALLBACK_BASE_URL
+              value: {{ .Values.orchestrator.fallbackBaseUrl | quote }}
+            {{- end }}
             - name: ORCHESTRATOR_TIMEOUT_S
               value: {{ .Values.orchestrator.timeoutSeconds | quote }}
             - name: ORCHESTRATOR_REPLAN_TIMEOUT_S

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -647,6 +647,12 @@ orchestrator:
   enabled: false
   model: "deepseek/deepseek-v4-flash"
   baseUrl: "https://openrouter.ai/api/v1"
+  # Fallback provider: tried once when the primary raises OrchestratorUnavailable
+  # (timeout, 5xx, or an unusable/absent tool call), before the flow fails open to
+  # direct submit. Empty fallbackModel means no fallback (single-attempt contract).
+  # The fallback key reuses OPENROUTER_API_KEY from the "goosecracker" Secret.
+  fallbackModel: ""
+  fallbackBaseUrl: "https://openrouter.ai/api/v1"
   # Initial-compile budget: covers BOTH the route-decision call and the
   # submit_plan tool call (plan construction is real work, not a quick classify).
   timeoutSeconds: 60

--- a/projects/monolith/chat/orchestrator_client.py
+++ b/projects/monolith/chat/orchestrator_client.py
@@ -1,12 +1,21 @@
-"""ADR 036 orchestrator brief-compiler OpenRouter client.
+"""ADR 036 orchestrator brief-compiler OpenAI-compatible client.
 
 Unary, short-timeout httpx client shaped like ``summarizer.build_llm_caller``
-(summarizer.py:412), but for the paid OpenRouter escalation tier rather than
-the local Qwen executor. Per the fail-open philosophy (ADR 036 Architecture:
-"Fail open"), this client makes exactly one attempt: any timeout or HTTP error
-raises ``OrchestratorUnavailable`` so the caller can fall back to direct
-submit. There is no retry loop here (contrast with build_llm_caller's 3
-retries), because escalations must degrade quickly, not stall on a paid call.
+(summarizer.py:412), but for the hosted escalation tier rather than the local
+Qwen executor. Per the fail-open philosophy (ADR 036 Architecture: "Fail open"),
+each provider attempt makes exactly one call: any timeout, HTTP error, or
+unusable response shape raises ``OrchestratorUnavailable``.
+
+The primary provider is pinned via ``ORCHESTRATOR_MODEL`` / ``ORCHESTRATOR_BASE_URL``
+/ ``ORCHESTRATOR_API_KEY``. When ``ORCHESTRATOR_FALLBACK_MODEL`` is set, a primary
+``OrchestratorUnavailable`` triggers exactly one retry against the fallback
+provider (``ORCHESTRATOR_FALLBACK_BASE_URL`` / ``ORCHESTRATOR_FALLBACK_API_KEY``)
+before the exception propagates. This exists so a Preview primary model
+(``zai-glm-4.7`` on Cerebras) degrades to the proven DeepSeek/OpenRouter path
+instead of failing open to direct submit. With no fallback configured the
+behavior is byte-identical to the original single-attempt contract. There is
+still no per-provider retry loop (contrast with build_llm_caller's 3 retries),
+because escalations must degrade quickly, not stall on a paid call.
 
 ``call_tool`` is the typed sibling used for the runtime ``submit_plan``
 plan (ADR 036 amendment, docs/plans/2026-07-03-deepseek-runtime-recipes.md):
@@ -57,20 +66,48 @@ class OrchestratorResponse:
 
 
 def _read_config() -> tuple[str, str, str, float]:
-    """Read the model, base URL, API key, and timeout from the environment.
+    """Read the primary model, base URL, API key, and timeout from the environment.
 
     The model is expected to be pinned (never ``:auto``) so briefs stay
-    attributable to a specific provider model (ADR 036 Risks table).
+    attributable to a specific provider model (ADR 036 Risks table). The API key
+    prefers the provider-agnostic ``ORCHESTRATOR_API_KEY`` and falls back to
+    ``OPENROUTER_API_KEY`` so a deployment that only wired the legacy OpenRouter
+    key keeps working unchanged.
     """
     model = os.environ.get("ORCHESTRATOR_MODEL", "")
     base_url = os.environ.get("ORCHESTRATOR_BASE_URL", "") or _DEFAULT_BASE_URL
-    api_key = os.environ.get("OPENROUTER_API_KEY", "")
+    api_key = os.environ.get("ORCHESTRATOR_API_KEY", "") or os.environ.get(
+        "OPENROUTER_API_KEY", ""
+    )
     timeout_raw = os.environ.get("ORCHESTRATOR_TIMEOUT_S", "")
     try:
         timeout_s = float(timeout_raw) if timeout_raw else _DEFAULT_TIMEOUT_S
     except ValueError:
         timeout_s = _DEFAULT_TIMEOUT_S
     return model, base_url, api_key, timeout_s
+
+
+def _read_fallback_config() -> tuple[str, str, str] | None:
+    """Read the fallback provider (model, base URL, API key), or ``None``.
+
+    The fallback is a second OpenAI-compatible provider tried once when the
+    primary attempt raises ``OrchestratorUnavailable``. Returns ``None`` when
+    ``ORCHESTRATOR_FALLBACK_MODEL`` is unset, which restores the single-attempt
+    contract exactly. The fallback API key prefers
+    ``ORCHESTRATOR_FALLBACK_API_KEY`` and falls back to ``OPENROUTER_API_KEY``
+    (the DeepSeek/OpenRouter path reuses the key already synced for it).
+    """
+    model = os.environ.get("ORCHESTRATOR_FALLBACK_MODEL", "").strip()
+    if not model:
+        return None
+    base_url = (
+        os.environ.get("ORCHESTRATOR_FALLBACK_BASE_URL", "").strip()
+        or _DEFAULT_BASE_URL
+    )
+    api_key = os.environ.get("ORCHESTRATOR_FALLBACK_API_KEY", "") or os.environ.get(
+        "OPENROUTER_API_KEY", ""
+    )
+    return model, base_url, api_key
 
 
 def _extract_usage(payload: dict) -> tuple[int | None, int | None, int | None]:
@@ -86,12 +123,17 @@ def _extract_usage(payload: dict) -> tuple[int | None, int | None, int | None]:
     return prompt_tokens, completion_tokens, cached_tokens
 
 
-async def call(system: str, user: str) -> OrchestratorResponse:
-    """Send one system/user turn to the configured OpenRouter model and
-    parse the response. Raises ``OrchestratorUnavailable`` on any timeout or
-    HTTP error; makes a single attempt (no retries)."""
-    model, base_url, api_key, timeout_s = _read_config()
-
+async def _attempt_call(
+    model: str,
+    base_url: str,
+    api_key: str,
+    timeout_s: float,
+    system: str,
+    user: str,
+) -> OrchestratorResponse:
+    """One provider attempt for ``call``: POST + parse, or raise
+    ``OrchestratorUnavailable``. No retry loop here (the caller decides whether
+    to retry against a fallback provider)."""
     started = time.monotonic()
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(timeout_s)) as client:
@@ -133,36 +175,48 @@ async def call(system: str, user: str) -> OrchestratorResponse:
     )
 
 
-async def call_tool(
+async def call(system: str, user: str) -> OrchestratorResponse:
+    """Send one system/user turn to the configured model and parse the response.
+
+    Tries the primary provider once; on ``OrchestratorUnavailable`` and when a
+    fallback is configured, retries once against the fallback provider. Raises
+    ``OrchestratorUnavailable`` if the primary fails with no fallback, or if the
+    fallback also fails.
+    """
+    model, base_url, api_key, timeout_s = _read_config()
+    try:
+        return await _attempt_call(model, base_url, api_key, timeout_s, system, user)
+    except OrchestratorUnavailable as primary_exc:
+        fallback = _read_fallback_config()
+        if fallback is None:
+            raise
+        fb_model, fb_base_url, fb_api_key = fallback
+        logger.warning(
+            "orchestrator primary model %s unavailable (%s); falling back to %s",
+            model,
+            primary_exc,
+            fb_model,
+        )
+        return await _attempt_call(
+            fb_model, fb_base_url, fb_api_key, timeout_s, system, user
+        )
+
+
+async def _attempt_call_tool(
+    model: str,
+    base_url: str,
+    api_key: str,
+    timeout_s: float,
     system: str,
     user: str,
-    *,
     schema: dict,
-    tool_name: str = "submit_plan",
-    timeout_s: float | None = None,
+    tool_name: str,
 ) -> tuple[dict, OrchestratorResponse]:
-    """Force a tool call against ``schema`` and parse its arguments.
-
-    Sends ``tools=[{"type": "function", "function": schema}]`` with
-    ``tool_choice`` pinned to ``tool_name``, then parses
-    ``choices[0].message.tool_calls[0].function.arguments`` (a JSON string)
-    into a dict. Returns ``(args, response)`` where ``response`` mirrors
-    ``call()``'s usage/latency accounting (``response.content`` holds the
-    raw arguments JSON string).
-
-    Raises ``OrchestratorUnavailable`` on any timeout, HTTP error, missing
-    ``tool_calls``, or JSON parse error. Single attempt, no retry loop, same
-    fail-open contract as ``call()``. Uses ``timeout_s`` if given, else the
-    configured default (see ``_read_config``).
-    """
-    model, base_url, api_key, default_timeout_s = _read_config()
-    effective_timeout_s = timeout_s if timeout_s is not None else default_timeout_s
-
+    """One provider attempt for ``call_tool``: forced tool call + parse, or raise
+    ``OrchestratorUnavailable``."""
     started = time.monotonic()
     try:
-        async with httpx.AsyncClient(
-            timeout=httpx.Timeout(effective_timeout_s)
-        ) as client:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout_s)) as client:
             resp = await client.post(
                 f"{base_url}/chat/completions",
                 headers={"Authorization": f"Bearer {api_key}"},
@@ -215,3 +269,65 @@ async def call_tool(
         latency_ms=latency_ms,
     )
     return args, response
+
+
+async def call_tool(
+    system: str,
+    user: str,
+    *,
+    schema: dict,
+    tool_name: str = "submit_plan",
+    timeout_s: float | None = None,
+) -> tuple[dict, OrchestratorResponse]:
+    """Force a tool call against ``schema`` and parse its arguments.
+
+    Sends ``tools=[{"type": "function", "function": schema}]`` with
+    ``tool_choice`` pinned to ``tool_name``, then parses
+    ``choices[0].message.tool_calls[0].function.arguments`` (a JSON string)
+    into a dict. Returns ``(args, response)`` where ``response`` mirrors
+    ``call()``'s usage/latency accounting (``response.content`` holds the
+    raw arguments JSON string).
+
+    Tries the primary provider once; on ``OrchestratorUnavailable`` (timeout,
+    HTTP error, missing ``tool_calls``, or JSON parse error) and when a fallback
+    is configured, retries once against the fallback provider. This is where a
+    primary model with weaker forced-tool-call support degrades to the proven
+    path. Single attempt per provider, no retry loop. Uses ``timeout_s`` if
+    given, else the configured default (see ``_read_config``).
+    """
+    model, base_url, api_key, default_timeout_s = _read_config()
+    effective_timeout_s = timeout_s if timeout_s is not None else default_timeout_s
+
+    try:
+        return await _attempt_call_tool(
+            model,
+            base_url,
+            api_key,
+            effective_timeout_s,
+            system,
+            user,
+            schema,
+            tool_name,
+        )
+    except OrchestratorUnavailable as primary_exc:
+        fallback = _read_fallback_config()
+        if fallback is None:
+            raise
+        fb_model, fb_base_url, fb_api_key = fallback
+        logger.warning(
+            "orchestrator primary model %s tool-call unavailable (%s); "
+            "falling back to %s",
+            model,
+            primary_exc,
+            fb_model,
+        )
+        return await _attempt_call_tool(
+            fb_model,
+            fb_base_url,
+            fb_api_key,
+            effective_timeout_s,
+            system,
+            user,
+            schema,
+            tool_name,
+        )

--- a/projects/monolith/chat/orchestrator_client_test.py
+++ b/projects/monolith/chat/orchestrator_client_test.py
@@ -9,6 +9,7 @@ import pytest
 from chat.orchestrator_client import (
     OrchestratorUnavailable,
     _read_config,
+    _read_fallback_config,
     call,
     call_tool,
 )
@@ -175,6 +176,138 @@ _TOOL_SCHEMA = {
     "description": "Submit the delegation plan for this task.",
     "parameters": {"type": "object", "properties": {}},
 }
+
+
+_FALLBACK_ENV = {
+    "ORCHESTRATOR_MODEL": "zai-glm-4.7",
+    "ORCHESTRATOR_BASE_URL": "https://api.cerebras.ai/v1",
+    "ORCHESTRATOR_API_KEY": "cerebras-key",
+    "ORCHESTRATOR_FALLBACK_MODEL": "deepseek/deepseek-v4-flash",
+    "ORCHESTRATOR_FALLBACK_BASE_URL": "https://openrouter.ai/api/v1",
+    "OPENROUTER_API_KEY": "openrouter-key",
+}
+
+
+class TestCallFallback:
+    @pytest.mark.asyncio
+    async def test_falls_back_to_secondary_on_primary_failure(self):
+        """A primary transport failure retries once on the fallback provider,
+        which supplies the result (its model/base URL/key)."""
+        payload = {"choices": [{"message": {"content": "fallback brief"}}]}
+        instance = _mock_client(
+            post_side_effect=[
+                httpx.ConnectError("primary refused"),
+                _ok_response(payload),
+            ]
+        )
+        with (
+            patch("chat.orchestrator_client.httpx.AsyncClient", return_value=instance),
+            patch.dict("os.environ", _FALLBACK_ENV, clear=False),
+        ):
+            result = await call("system", "user")
+
+        assert result.content == "fallback brief"
+        assert instance.post.call_count == 2
+        # The primary attempt targeted Cerebras/GLM...
+        first_args, _ = instance.post.call_args_list[0]
+        assert first_args[0] == "https://api.cerebras.ai/v1/chat/completions"
+        # ...and the fallback attempt targeted DeepSeek/OpenRouter with its key.
+        second_args, second_kwargs = instance.post.call_args_list[1]
+        assert second_args[0] == "https://openrouter.ai/api/v1/chat/completions"
+        assert second_kwargs["headers"]["Authorization"] == "Bearer openrouter-key"
+        assert second_kwargs["json"]["model"] == "deepseek/deepseek-v4-flash"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_both_primary_and_fallback_fail(self):
+        instance = _mock_client(
+            post_side_effect=[
+                httpx.ConnectError("primary refused"),
+                httpx.ConnectError("fallback refused"),
+            ]
+        )
+        with (
+            patch("chat.orchestrator_client.httpx.AsyncClient", return_value=instance),
+            patch.dict("os.environ", _FALLBACK_ENV, clear=False),
+        ):
+            with pytest.raises(OrchestratorUnavailable):
+                await call("system", "user")
+
+        assert instance.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_configured_is_single_attempt(self, monkeypatch):
+        """With no ORCHESTRATOR_FALLBACK_MODEL the single-attempt contract holds."""
+        monkeypatch.delenv("ORCHESTRATOR_FALLBACK_MODEL", raising=False)
+        instance = _mock_client(post_side_effect=httpx.ConnectError("refused"))
+        env = {"ORCHESTRATOR_MODEL": "m", "OPENROUTER_API_KEY": "k"}
+        with (
+            patch("chat.orchestrator_client.httpx.AsyncClient", return_value=instance),
+            patch.dict("os.environ", env, clear=False),
+        ):
+            with pytest.raises(OrchestratorUnavailable):
+                await call("system", "user")
+
+        assert instance.post.call_count == 1
+
+
+class TestCallToolFallback:
+    @pytest.mark.asyncio
+    async def test_tool_call_falls_back_on_unusable_primary_shape(self):
+        """A primary response missing tool_calls (weaker forced-tool support)
+        degrades to the fallback provider, which returns a valid plan."""
+        args_payload = {
+            "enabled_subrecipes": [],
+            "steps": [],
+            "done_criteria": [],
+        }
+        bad = _ok_response({"choices": [{"message": {"content": "no tool call"}}]})
+        good = _ok_response(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "tool_calls": [
+                                {
+                                    "function": {
+                                        "name": "submit_plan",
+                                        "arguments": json.dumps(args_payload),
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        )
+        instance = _mock_client(post_side_effect=[bad, good])
+        with (
+            patch("chat.orchestrator_client.httpx.AsyncClient", return_value=instance),
+            patch.dict("os.environ", _FALLBACK_ENV, clear=False),
+        ):
+            args, response = await call_tool("system", "user", schema=_TOOL_SCHEMA)
+
+        assert args == args_payload
+        assert instance.post.call_count == 2
+        second_args, second_kwargs = instance.post.call_args_list[1]
+        assert second_kwargs["json"]["model"] == "deepseek/deepseek-v4-flash"
+
+
+class TestReadFallbackConfig:
+    def test_none_when_model_unset(self, monkeypatch):
+        monkeypatch.delenv("ORCHESTRATOR_FALLBACK_MODEL", raising=False)
+        assert _read_fallback_config() is None
+
+    def test_reads_model_base_url_and_key(self, monkeypatch):
+        monkeypatch.setenv("ORCHESTRATOR_FALLBACK_MODEL", "deepseek/deepseek-v4-flash")
+        monkeypatch.setenv(
+            "ORCHESTRATOR_FALLBACK_BASE_URL", "https://openrouter.ai/api/v1"
+        )
+        monkeypatch.delenv("ORCHESTRATOR_FALLBACK_API_KEY", raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-key")
+        model, base_url, api_key = _read_fallback_config()
+        assert model == "deepseek/deepseek-v4-flash"
+        assert base_url == "https://openrouter.ai/api/v1"
+        assert api_key == "openrouter-key"
 
 
 class TestReadConfig:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.276.0
+      targetRevision: 0.277.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -269,13 +269,20 @@ grimoire:
   extractModel: "qwen3.6-27b"
   extractBaseUrl: "http://inference.inference.svc.cluster.local:8080/v1/chat/completions"
 
-# ADR 036 orchestrator brief compiler (Phase 3 live enable). The OpenRouter key
-# is sourced from the existing "goosecracker" Secret (no dedicated OnePasswordItem;
-# see chart/templates/deployment.yaml), so nothing extra to sync here. The
+# ADR 036 orchestrator brief compiler (Phase 3 live enable). The primary planner
+# is GLM-4.7 on Cerebras (free, fast; ORCHESTRATOR_API_KEY sourced from the
+# CEREBRAS_API_KEY field of the existing "goosecracker" Secret). It falls back to
+# DeepSeek on OpenRouter (the proven forced-tool-call path) when Cerebras times
+# out, errors, or returns an unusable plan; the fallback key reuses the same
+# Secret's OPENROUTER_API_KEY field, so nothing extra to sync here. The
 # orchestrator only runs on channels with the ADR 029 "orchestrator" consent
-# grant; ungranted channels fail open to direct submit with no OpenRouter traffic.
+# grant; ungranted channels fail open to direct submit with no external traffic.
 orchestrator:
   enabled: true
+  model: "zai-glm-4.7"
+  baseUrl: "https://api.cerebras.ai/v1"
+  fallbackModel: "deepseek/deepseek-v4-flash"
+  fallbackBaseUrl: "https://openrouter.ai/api/v1"
 
 agent:
   discord:


### PR DESCRIPTION
## What

Phase 1 of routing the agent flow to Cerebras (free, fast, decent open models). This PR does the **planner leg only**: the live ADR 036 brief compiler now runs on **GLM-4.7 (zai-glm-4.7) on Cerebras** with an **automatic single-retry fallback to DeepSeek/OpenRouter**.

## Why

Cerebras offers gpt-oss-120b (Production) and GLM-4.7 (Preview) with very generous free quotas (2B and 720M tokens/day). Measured live vLLM usage peaks at ~9.4M tokens/day, so quota is a non-issue by ~75-3000x even after migration. The planner is the highest-value, lowest-risk first target: it already runs in-pod (external egress works), sends a minimal request body, and was chosen for GLM-4.7 per Joe's routing plan.

The DeepSeek fallback is **capability insurance**, not just availability insurance: `call_tool()` forces a named `submit_plan` tool call, and if Cerebras/GLM's forced-tool support is weaker than the DeepSeek path the ADR 036 probe validated, a malformed/absent tool call raises `OrchestratorUnavailable` and transparently retries on DeepSeek before failing open to direct submit.

## Changes

- **orchestrator_client.py**: primary key prefers `ORCHESTRATOR_API_KEY` (falls back to `OPENROUTER_API_KEY`, so existing deployments are unchanged); new `_read_fallback_config` (returns `None` when `ORCHESTRATOR_FALLBACK_MODEL` unset, preserving the single-attempt contract exactly); per-attempt helpers wrapped so a primary `OrchestratorUnavailable` retries once on the fallback.
- **Helm**: `deploy/values.yaml` points the live planner at Cerebras GLM-4.7 + DeepSeek fallback; `deployment.yaml` injects `ORCHESTRATOR_API_KEY` from the `goosecracker` Secret's `CEREBRAS_API_KEY` field (already synced from 1Password) plus fallback env; chart bump 0.276.0 -> 0.277.0.
- **Tests**: fallback-success, both-fail-raises, no-fallback-single-attempt, tool-call-falls-back-on-unusable-shape, and `_read_fallback_config` coverage. Existing tests unchanged and green.

## Deferred to follow-up PRs (scope split from recon)

- **Discord conversational reply -> gpt-oss-120b**: `agent.py` hardcodes the model and shares `LLAMA_CPP_URL` with the deferred vision/summarizer paths; needs reply-specific env plus provider-safe sampling (`top_k` in `extra_body` is not OpenAI-schema and may 400 on Cerebras).
- **Guest coding execution -> gpt-oss-120b**: guests run in Firecracker microVMs and never hold real secrets; needs a `kloak:cerebras` placeholder plus `api.cerebras.ai` allowlist/secret-swap in the fc-invoke egress sidecar (ADR 023), then a tier flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)