### PR TITLE
feat(frontend): systems-first homepage stack v2

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.83.0
+version: 0.84.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.83.0
+      targetRevision: 0.84.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.276.0
+version: 0.277.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.276.0
+      targetRevision: 0.277.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/homepage-stack.js
+++ b/projects/monolith/frontend/src/lib/public/homepage-stack.js
@@ -1,136 +1,102 @@
 // Hand-curated content for the front-page project stack. This is the single
-// source of truth for what the homepage says we run. Add new apps here.
+// source of truth for what the homepage says we run. Add new systems here.
 // kind: "projects" items render as story cards; kind: "strip" items render
-// as plain labeled chips. Story cards are only for things built in this repo,
-// not things merely run here.
+// as labeled chips (linked when href is set). Story cards are the systems
+// built here; the public apps are a strip of live links on top.
 
 const GH = "https://github.com/jomcgi/homelab/tree/main";
 
 export const stack = [
   {
     id: "apps",
-    label: "APPS",
+    label: "APPS · LIVE",
+    kind: "strip",
+    items: [
+      { name: "Ships", href: "/app/ships" },
+      { name: "Stars", href: "/app/stars" },
+      { name: "Hikes", href: "/app/hikes" },
+      { name: "Campsites", href: "/app/campsites" },
+      { name: "Trips", href: "/app/trips" },
+      { name: "Dr Jobs", href: "/app/dr-jobs" },
+      { name: "WC 2026", href: "/app/wc2026" },
+      { name: "Chat", href: "/chat" },
+      { name: "Docs", href: "/docs" },
+    ],
+  },
+  {
+    id: "systems",
+    label: "SYSTEMS",
     kind: "projects",
     items: [
       {
-        id: "ships",
-        name: "SHIPS",
-        blurb: "Live AIS map of ship traffic off the BC coast.",
+        id: "agents",
+        name: "AGENT PLATFORM",
+        blurb: "Coding agents in hardware-isolated Firecracker microVMs.",
         engineering:
-          "CDN-cached SSR snapshots over daily-partitioned Postgres, with a GPU heatmap of every voyage ever seen.",
-        tags: ["SvelteKit", "Postgres", "MapLibre"],
-        links: { live: "/app/ships", readme: `${GH}/projects/monolith/ships` },
-      },
-      {
-        id: "stars",
-        name: "STARS",
-        blurb: "Stargazing forecast for anywhere in western Canada.",
-        engineering:
-          "Clear-dark-hours scoring on a 14,000-point grid, blended with CERRA cloud climatology and edge-cached for a year.",
-        tags: ["SvelteKit", "Python", "ERA5/CERRA"],
-        links: { live: "/app/stars", readme: `${GH}/projects/monolith/stars` },
-      },
-      {
-        id: "hikes",
-        name: "HIKES",
-        blurb: "Trail catalog with conditions and weather.",
-        engineering:
-          "Seeded out-of-band to keep bulk data away from the GitOps migration path.",
-        tags: ["SvelteKit", "Postgres"],
-        links: { live: "/app/hikes", readme: `${GH}/projects/monolith/hikes` },
-      },
-      {
-        id: "campsites",
-        name: "CAMPSITES",
-        blurb: "BC Parks campsite availability crossed with weather.",
-        engineering:
-          "Availability polling joined against forecast windows so a free weekend actually means a good weekend.",
-        tags: ["SvelteKit", "Postgres"],
+          "Snapshot-restored sandboxes with vsock-only egress and secret swapping at the boundary; agent recipes are compiled at runtime by a planner model.",
+        tags: ["Firecracker", "Go", "MCP"],
         links: {
-          live: "/app/campsites",
-          readme: `${GH}/projects/monolith/campsites`,
+          docs: "/docs/agents",
+          code: `${GH}/projects/firecracker`,
         },
       },
       {
-        id: "trips",
-        name: "TRIPS",
-        blurb: "Shared trip planning and itineraries.",
+        id: "monolith",
+        name: "MONOLITH",
+        blurb: "One deployable that serves everything on this domain.",
         engineering:
-          "Folded from a standalone service into the monolith to cut operational surface.",
-        tags: ["SvelteKit", "Postgres"],
-        links: { live: "/app/trips", readme: `${GH}/projects/monolith/trips` },
-      },
-      {
-        id: "dr-jobs",
-        name: "DR JOBS",
-        blurb: "NHS Scotland anaesthetics vacancy aggregator.",
-        engineering:
-          "Scrapes and normalises health-board job feeds into one searchable view.",
-        tags: ["Python", "Postgres"],
+          "SvelteKit and Python behind split public and private tiers, Atlas-managed Postgres migrations, and a dozen apps riding a single GitOps rollout, including this page.",
+        tags: ["SvelteKit", "Python", "Postgres"],
         links: {
-          live: "/app/dr-jobs",
-          readme: `${GH}/projects/monolith/dr_jobs`,
+          docs: "/docs/services",
+          code: `${GH}/projects/monolith`,
         },
-      },
-      {
-        id: "wc2026",
-        name: "WC 2026",
-        blurb: "Scotland's World Cup 2026 odds, updated as results land.",
-        engineering:
-          "Elo-driven Monte Carlo simulation of the full tournament, re-run on every fixture.",
-        tags: ["Python", "Monte Carlo"],
-        links: {
-          live: "/app/wc2026",
-          readme: `${GH}/projects/monolith/worldcup`,
-        },
-      },
-      {
-        id: "chat",
-        name: "CHAT",
-        blurb: "Self-hosted LLM chat running on a local GPU.",
-        engineering:
-          "vLLM serving a Qwen MoE model, with tool use wired to the same MCP surface the agents use.",
-        tags: ["vLLM", "Qwen", "MCP"],
-        links: { live: "/chat", readme: `${GH}/projects/monolith/chat` },
       },
       {
         id: "knowledge",
-        name: "KNOWLEDGE",
+        name: "KNOWLEDGE GRAPH",
         blurb: "A fileless knowledge graph that gardens itself.",
         engineering:
           "Raw captures decomposed into atomic notes by scheduled agents; bodies in Postgres, embeddings for RAG, no files anywhere.",
         tags: ["Postgres", "Embeddings", "Agents"],
         links: {
           live: "/app/notes",
-          readme: `${GH}/projects/monolith/knowledge`,
+          code: `${GH}/projects/monolith/knowledge`,
         },
       },
       {
-        id: "agents",
-        name: "AGENTS",
-        blurb: "An agent platform with hardware-isolated sandboxes.",
+        id: "gitops",
+        name: "GITOPS PIPELINE",
+        blurb: "Every change lands by git push; ArgoCD does the rest.",
         engineering:
-          "Firecracker microVMs per session, vsock-only egress with token swapping, recipes compiled at runtime.",
-        tags: ["Firecracker", "Go", "MCP"],
-        links: { readme: `${GH}/projects/firecracker` },
+          "Bazel builds dual-arch apko images on remote executors, pins digests into OCI Helm charts, and ArgoCD syncs the cluster from the repo.",
+        tags: ["ArgoCD", "Bazel", "apko"],
+        links: {
+          docs: "/docs/contributing",
+          code: "https://github.com/jomcgi/homelab",
+        },
       },
       {
-        id: "grimoire",
-        name: "GRIMOIRE",
-        blurb: "A Postgres-first D&D campaign manager.",
+        id: "observability",
+        name: "OBSERVABILITY",
+        blurb: "Traces, logs, and metrics for everything, self-hosted.",
         engineering:
-          "Long-form book content chunked and sequenced in Postgres with an omnibox over the lot.",
-        tags: ["SvelteKit", "Postgres"],
-        links: { readme: `${GH}/projects/monolith/grimoire` },
+          "OTEL instrumentation meshed through Linkerd into SigNoz on ClickHouse, with SLO rollups snapshotted into Postgres.",
+        tags: ["SigNoz", "OTEL", "ClickHouse"],
+        links: {
+          docs: "/docs/observability",
+        },
       },
       {
-        id: "docs",
-        name: "DOCS",
-        blurb: "This repo's design docs and ADRs, published.",
+        id: "inference",
+        name: "INFERENCE",
+        blurb: "Local LLM serving on a single consumer GPU.",
         engineering:
-          "Markdown indexed at build time and served by the same monolith that everything else runs on.",
-        tags: ["SvelteKit", "Markdown"],
-        links: { live: "/docs", readme: `${GH}/docs` },
+          "vLLM serving a Qwen MoE plus embedding models, shared by chat, the agents, and the knowledge graph's RAG loop.",
+        tags: ["vLLM", "Qwen", "GPU"],
+        links: {
+          code: `${GH}/projects/inference`,
+        },
       },
     ],
   },
@@ -139,15 +105,12 @@ export const stack = [
     label: "PLATFORM",
     kind: "strip",
     items: [
-      { name: "ArgoCD", href: "https://github.com/argoproj/argo-cd" },
-      { name: "Linkerd", href: "https://linkerd.io" },
-      { name: "SigNoz", href: "https://signoz.io" },
-      { name: "Envoy Gateway", href: "https://gateway.envoyproxy.io" },
-      {
-        name: "1Password Operator",
-        href: "https://github.com/1Password/onepassword-operator",
-      },
-      { name: "Atlas", href: "https://atlasgo.io" },
+      { name: "ArgoCD" },
+      { name: "Linkerd" },
+      { name: "SigNoz" },
+      { name: "Envoy Gateway" },
+      { name: "1Password Operator" },
+      { name: "Atlas" },
     ],
   },
   {
@@ -155,11 +118,11 @@ export const stack = [
     label: "COMPUTE",
     kind: "strip",
     items: [
-      { name: "Kubernetes", href: "https://kubernetes.io" },
-      { name: "Firecracker", href: "https://firecracker-microvm.github.io" },
-      { name: "Longhorn", href: "https://longhorn.io" },
-      { name: "SeaweedFS", href: "https://github.com/seaweedfs/seaweedfs" },
-      { name: "vLLM on GPU", href: "https://github.com/vllm-project/vllm" },
+      { name: "Kubernetes" },
+      { name: "Firecracker" },
+      { name: "Longhorn" },
+      { name: "SeaweedFS" },
+      { name: "vLLM on GPU" },
     ],
   },
   {
@@ -169,7 +132,14 @@ export const stack = [
     items: [
       { name: "4 nodes" },
       { name: "1 GPU" },
-      { name: "Cloudflare edge", href: "https://www.cloudflare.com" },
+      { name: "Cloudflare edge" },
     ],
   },
+];
+
+// Ordered labels for the typed card links.
+export const LINK_LABELS = [
+  ["live", "Visit live"],
+  ["docs", "Read the docs"],
+  ["code", "Read the code"],
 ];

--- a/projects/monolith/frontend/src/lib/public/homepage-stack.test.js
+++ b/projects/monolith/frontend/src/lib/public/homepage-stack.test.js
@@ -1,40 +1,57 @@
 import { describe, it, expect } from "vitest";
-import { stack } from "./homepage-stack.js";
+import { stack, LINK_LABELS } from "./homepage-stack.js";
 
-const projects = stack
+const systems = stack
   .filter((l) => l.kind === "projects")
   .flatMap((l) => l.items);
 
 describe("homepage stack config", () => {
-  it("has the four strata in order", () => {
+  it("has the five strata in order", () => {
     expect(stack.map((l) => l.id)).toEqual([
       "apps",
+      "systems",
       "platform",
       "compute",
       "metal",
     ]);
   });
 
-  it("has unique project ids", () => {
-    const ids = projects.map((p) => p.id);
+  it("has unique system ids", () => {
+    const ids = systems.map((s) => s.id);
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it("every project has the required story fields", () => {
-    for (const p of projects) {
-      expect(p.name, p.id).toBeTruthy();
-      expect(p.blurb, p.id).toBeTruthy();
-      expect(p.engineering, p.id).toBeTruthy();
-      expect(p.tags?.length, p.id).toBeGreaterThan(0);
-      expect(p.links?.readme, p.id).toMatch(
-        /^https:\/\/github\.com\/jomcgi\/homelab\/tree\/main\//,
-      );
+  it("every system has the required story fields and at least one link", () => {
+    const linkKeys = LINK_LABELS.map(([key]) => key);
+    for (const s of systems) {
+      expect(s.name, s.id).toBeTruthy();
+      expect(s.blurb, s.id).toBeTruthy();
+      expect(s.engineering, s.id).toBeTruthy();
+      expect(s.tags?.length, s.id).toBeGreaterThan(0);
+      const keys = Object.keys(s.links ?? {});
+      expect(keys.length, s.id).toBeGreaterThan(0);
+      for (const k of keys) expect(linkKeys, `${s.id}.${k}`).toContain(k);
     }
   });
 
-  it("live links are same-origin paths", () => {
-    for (const p of projects) {
-      if (p.links.live) expect(p.links.live, p.id).toMatch(/^\//);
+  it("live and docs links are same-origin paths, code links point at the repo", () => {
+    for (const s of systems) {
+      if (s.links.live) expect(s.links.live, s.id).toMatch(/^\//);
+      if (s.links.docs) expect(s.links.docs, s.id).toMatch(/^\/docs/);
+      if (s.links.code) {
+        expect(s.links.code, s.id).toMatch(
+          /^https:\/\/github\.com\/jomcgi\/homelab(\/tree\/main\/.+)?$/,
+        );
+      }
+    }
+  });
+
+  it("apps strip items are all live same-origin links", () => {
+    const apps = stack.find((l) => l.id === "apps");
+    expect(apps.kind).toBe("strip");
+    for (const item of apps.items) {
+      expect(item.name, "apps").toBeTruthy();
+      expect(item.href, item.name).toMatch(/^\//);
     }
   });
 

--- a/projects/monolith/frontend/src/routes/public/HomepageStack.svelte
+++ b/projects/monolith/frontend/src/routes/public/HomepageStack.svelte
@@ -26,7 +26,7 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <section class="stack" id="homelab" aria-label="What this homelab runs">
-  <p class="eyebrow">The stack, top to bottom. Click a project.</p>
+  <p class="eyebrow">The stack, top to bottom. Click a system.</p>
   <h2>WHAT RUNS HERE</h2>
 
   <div class="strata">
@@ -39,7 +39,8 @@
               <StackProjectCard
                 {project}
                 expanded={selected === project.id}
-                onselect={() => setSelected(selected === project.id ? null : project.id)}
+                onselect={() =>
+                  setSelected(selected === project.id ? null : project.id)}
               />
             {/each}
           </div>
@@ -48,7 +49,7 @@
             {#each layer.items as item}
               <li>
                 {#if item.href}
-                  <a href={item.href} target="_blank" rel="noopener">{item.name}</a>
+                  <a href={item.href}>{item.name}</a>
                 {:else}
                   <span>{item.name}</span>
                 {/if}
@@ -75,12 +76,10 @@
   }
   .strata {
     border: 2px solid var(--ink);
-    box-shadow: var(--shadow-hard);
     background: var(--paper);
   }
   .layer {
-    position: relative;
-    padding: 28px 24px 20px;
+    padding: 20px 24px;
     border-top: 2px dashed var(--rule-2);
   }
   .layer:first-child {
@@ -89,39 +88,29 @@
   .layer.alt {
     background: var(--cream);
   }
-  .layer-label {
-    position: absolute;
-    top: -1px;
-    left: 16px;
-    transform: translateY(-50%);
-    font-family: var(--mono);
-    font-size: 8px;
-    font-weight: 700;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    background: var(--paper);
-    border: 1px dashed var(--rule-2);
-    padding: 2px 8px;
+  .layer[data-kind="projects"] {
+    padding: 20px 24px 28px;
   }
-  .layer:first-child .layer-label {
-    top: 0;
-    transform: none;
-    border: none;
-    padding-left: 0;
-    position: static;
+  .layer-label {
     display: block;
-    margin-bottom: 12px;
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+    margin-bottom: 14px;
   }
   .cards {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: 16px;
     align-items: start;
   }
   .strip {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px 12px;
+    gap: 8px 10px;
     list-style: none;
     margin: 0;
     padding: 0;
@@ -132,15 +121,27 @@
     font-size: 11px;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: var(--ink-2);
     text-decoration: none;
-    border: 1px solid var(--rule);
-    background: var(--paper);
-    padding: 4px 10px;
+    padding: 5px 12px;
     display: inline-block;
   }
-  .strip li a:hover {
+  .strip li span {
+    color: var(--ink-2);
+    border: 1px solid var(--rule);
+    background: var(--paper);
+  }
+  .strip li a {
+    font-weight: 700;
     color: var(--ink);
-    border-color: var(--ink);
+    border: 2px solid var(--ink);
+    background: var(--paper);
+    transition:
+      transform 0.12s ease,
+      box-shadow 0.12s ease;
+  }
+  .strip li a:hover {
+    transform: translate(-1px, -1px);
+    box-shadow: var(--shadow-hard-sm);
+    background: var(--accent);
   }
 </style>

--- a/projects/monolith/frontend/src/routes/public/StackProjectCard.svelte
+++ b/projects/monolith/frontend/src/routes/public/StackProjectCard.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { LINK_LABELS } from "$lib/public/homepage-stack.js";
+
   /**
    * @type {{
    *   project: object,
@@ -7,6 +9,15 @@
    * }}
    */
   let { project, expanded = false, onselect } = $props();
+
+  const links = $derived(
+    LINK_LABELS.filter(([key]) => project.links[key]).map(([key, label]) => ({
+      key,
+      label,
+      href: project.links[key],
+      external: project.links[key].startsWith("http"),
+    })),
+  );
 </script>
 
 <article class="card" class:expanded>
@@ -28,12 +39,17 @@
     <div class="story">
       <p>{project.engineering}</p>
       <div class="actions">
-        {#if project.links.live}
-          <a class="card-btn card-btn-live" href={project.links.live}>Visit live &nearr;</a>
-        {/if}
-        <a class="card-btn" href={project.links.readme} target="_blank" rel="noopener">
-          Read the code &nearr;
-        </a>
+        {#each links as link (link.key)}
+          <a
+            class="card-btn"
+            class:card-btn-live={link.key === "live"}
+            href={link.href}
+            target={link.external ? "_blank" : undefined}
+            rel={link.external ? "noopener" : undefined}
+          >
+            {link.label} &nearr;
+          </a>
+        {/each}
       </div>
     </div>
   {/if}
@@ -43,14 +59,13 @@
   .card {
     background: var(--paper);
     border: 2px solid var(--ink);
-    box-shadow: var(--shadow-hard-sm);
     transition:
       transform 0.12s ease,
       box-shadow 0.12s ease;
   }
   .card:hover {
     transform: translate(-2px, -2px);
-    box-shadow: var(--shadow-hard);
+    box-shadow: var(--shadow-hard-sm);
   }
   .card.expanded {
     background: var(--accent);
@@ -59,7 +74,7 @@
   .card-face {
     display: block;
     width: 100%;
-    padding: 14px 16px;
+    padding: 18px 20px 14px;
     text-align: left;
     background: none;
     border: none;
@@ -69,15 +84,15 @@
   }
   h3 {
     font-family: var(--mono);
-    font-size: 13px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    margin: 0 0 6px;
+    font-size: 17px;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    margin: 0 0 8px;
   }
   .blurb {
-    font-size: 13px;
-    line-height: 1.4;
-    margin: 0 0 10px;
+    font-size: 14px;
+    line-height: 1.45;
+    margin: 0 0 12px;
     color: var(--ink-2);
   }
   .card.expanded .blurb {
@@ -100,12 +115,12 @@
     border: 1px solid var(--rule);
   }
   .story {
-    padding: 0 16px 14px;
+    padding: 0 20px 18px;
   }
   .story p {
-    font-size: 13px;
+    font-size: 14px;
     line-height: 1.5;
-    margin: 0 0 12px;
+    margin: 0 0 14px;
   }
   .actions {
     display: flex;
@@ -123,11 +138,10 @@
     background: var(--paper);
     border: 2px solid var(--ink);
     padding: 6px 10px;
-    box-shadow: var(--shadow-hard-sm);
   }
   .card-btn:hover {
     transform: translate(-1px, -1px);
-    box-shadow: var(--shadow-hard);
+    box-shadow: var(--shadow-hard-sm);
   }
   .card-btn-live {
     background: var(--ink);

--- a/projects/monolith/frontend/visual/targets.json
+++ b/projects/monolith/frontend/visual/targets.json
@@ -5,7 +5,7 @@
   ],
   "pages": [
     { "id": "home", "path": "/" },
-    { "id": "home-project", "path": "/?project=ships" },
+    { "id": "home-project", "path": "/?project=agents" },
     { "id": "dr-jobs", "path": "/app/dr-jobs" },
     { "id": "wc2026", "path": "/app/wc2026" },
     { "id": "hikes", "path": "/app/hikes", "map": true },


### PR DESCRIPTION
Feedback-driven v2 of the homepage project stack (#3155):

- Story cards inverted to the engineering systems (agent platform, monolith, knowledge graph, GitOps pipeline, observability, inference), each linking to internal /docs pages and repo directories instead of a wall of small app cards.
- Public apps become a compact strip of live links at the top of the stack.
- Platform/compute/metal chips drop external upstream links (they added little).
- Visual: container shadow removed, cards rest flat and lift on hover only, 17px titles, inline layer labels, 3-column grid.
- Bumps BOTH monolith (0.277.0) and monolith-public (0.84.0) charts; the public tier serves the apex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)