### PR TITLE
chore(monolith): bump chart to 0.278.0 to roll out the GLM-4.7 planner routing

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.277.0
+version: 0.278.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.277.0
+      targetRevision: 0.278.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
e217b9db8 merged after the 0.277.0 bump, re-publishing 0.277.0 with new
image tags (same-version wedge). Trailing bump to converge.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
