### PR TITLE
fix(argocd): ignore /spec/replicas globally for Deployments

### DIFF
--- a/projects/platform/argocd/values.yaml
+++ b/projects/platform/argocd/values.yaml
@@ -34,6 +34,14 @@ argo-cd:
         jsonPointers:
           - /spec/template/metadata/annotations/otel.injected-by
           - /spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt
+          # HPA-managed replicas. App-level spec.ignoreDifferences is not
+          # applied by the controller (observed on v3.1.6: the monolith app's
+          # /spec/replicas entry was inert while these global rules worked, so
+          # the HPA-set replicas kept the Deployment permanently OutOfSync
+          # against a chart that deliberately omits replicas). Only HPAs mutate
+          # replicas in this cluster (kubectl scale is forbidden by convention),
+          # so a fleet-wide ignore is safe.
+          - /spec/replicas
     rbac:
       policy.csv: |
         p, mcp-agent, applications, *, */*, allow


### PR DESCRIPTION
The monolith app's own spec.ignoreDifferences /spec/replicas entry is
not applied by the controller (v3.1.6), so the HPA-set replicas kept
the Deployment permanently OutOfSync against a chart that omits
replicas. The global argocd-cm customization demonstrably works (the
OTEL entries there normalize correctly), so the replicas ignore moves
there. Only HPAs mutate replicas in this cluster.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
