### PR TITLE
feat(orchestrator): planner primary NVIDIA Nemotron with ordered fallback chain

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.279.0
+version: 0.280.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -267,17 +267,19 @@ spec:
             # Secret rather than sync the item twice; the field names match the
             # conventions the goosecracker item exposes. Note the Secret is named
             # "goosecracker" (not fullname-prefixed).
-            # ORCHESTRATOR_API_KEY drives the primary provider (Cerebras); the
-            # client falls back to OPENROUTER_API_KEY if this is absent.
+            # ORCHESTRATOR_API_KEY drives the PRIMARY provider; the Secret field it
+            # reads is set by orchestrator.apiKeySecretKey (e.g. NVIDIA_API_KEY for
+            # Nemotron). The client falls back to OPENROUTER_API_KEY if absent.
             - name: ORCHESTRATOR_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: goosecracker
-                  key: CEREBRAS_API_KEY
-                  # Optional: the client fails over to the fallback provider (and
-                  # ultimately fails open) when the key is absent.
+                  key: {{ .Values.orchestrator.apiKeySecretKey | quote }}
+                  # Optional: the client walks the fallback chain (and ultimately
+                  # fails open) when the key is absent.
                   optional: true
-            # OPENROUTER_API_KEY drives the DeepSeek fallback provider.
+            # OPENROUTER_API_KEY drives the DeepSeek fallback tier (referenced by
+            # apiKeyEnv in the ORCHESTRATOR_FALLBACKS chain).
             - name: OPENROUTER_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -291,11 +293,11 @@ spec:
               value: {{ .Values.orchestrator.model | quote }}
             - name: ORCHESTRATOR_BASE_URL
               value: {{ .Values.orchestrator.baseUrl | quote }}
-            {{- if .Values.orchestrator.fallbackModel }}
-            - name: ORCHESTRATOR_FALLBACK_MODEL
-              value: {{ .Values.orchestrator.fallbackModel | quote }}
-            - name: ORCHESTRATOR_FALLBACK_BASE_URL
-              value: {{ .Values.orchestrator.fallbackBaseUrl | quote }}
+            {{- if .Values.orchestrator.fallbacks }}
+            # Ordered fallback chain (JSON): each entry is {model, base_url,
+            # api_key_env}. The client tries the primary, then these in order.
+            - name: ORCHESTRATOR_FALLBACKS
+              value: {{ .Values.orchestrator.fallbacks | toJson | quote }}
             {{- end }}
             - name: ORCHESTRATOR_TIMEOUT_S
               value: {{ .Values.orchestrator.timeoutSeconds | quote }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -647,12 +647,18 @@ orchestrator:
   enabled: false
   model: "deepseek/deepseek-v4-flash"
   baseUrl: "https://openrouter.ai/api/v1"
-  # Fallback provider: tried once when the primary raises OrchestratorUnavailable
-  # (timeout, 5xx, or an unusable/absent tool call), before the flow fails open to
-  # direct submit. Empty fallbackModel means no fallback (single-attempt contract).
-  # The fallback key reuses OPENROUTER_API_KEY from the "goosecracker" Secret.
-  fallbackModel: ""
-  fallbackBaseUrl: "https://openrouter.ai/api/v1"
+  # Field in the "goosecracker" Secret that drives the PRIMARY provider's key
+  # (ORCHESTRATOR_API_KEY). Cluster values point this at the primary of the day
+  # (e.g. NVIDIA_API_KEY for Nemotron); the client falls back to OPENROUTER_API_KEY
+  # if the named field is absent.
+  apiKeySecretKey: "OPENROUTER_API_KEY"
+  # Ordered fallback chain, tried in turn when the primary raises
+  # OrchestratorUnavailable (timeout, 5xx/429, or an unusable/absent tool call),
+  # before the flow fails open to direct submit. Each entry (snake_case, passed
+  # verbatim to the client as JSON): model, base_url, and api_key_env (the env var
+  # holding that provider's key; empty = no auth, e.g. in-cluster Qwen). Empty
+  # list = no fallback (single-attempt contract).
+  fallbacks: []
   # Initial-compile budget: covers BOTH the route-decision call and the
   # submit_plan tool call (plan construction is real work, not a quick classify).
   timeoutSeconds: 60

--- a/projects/monolith/chat/orchestrator_client.py
+++ b/projects/monolith/chat/orchestrator_client.py
@@ -7,15 +7,16 @@ each provider attempt makes exactly one call: any timeout, HTTP error, or
 unusable response shape raises ``OrchestratorUnavailable``.
 
 The primary provider is pinned via ``ORCHESTRATOR_MODEL`` / ``ORCHESTRATOR_BASE_URL``
-/ ``ORCHESTRATOR_API_KEY``. When ``ORCHESTRATOR_FALLBACK_MODEL`` is set, a primary
-``OrchestratorUnavailable`` triggers exactly one retry against the fallback
-provider (``ORCHESTRATOR_FALLBACK_BASE_URL`` / ``ORCHESTRATOR_FALLBACK_API_KEY``)
-before the exception propagates. This exists so a Preview primary model
-(``zai-glm-4.7`` on Cerebras) degrades to the proven DeepSeek/OpenRouter path
-instead of failing open to direct submit. With no fallback configured the
-behavior is byte-identical to the original single-attempt contract. There is
-still no per-provider retry loop (contrast with build_llm_caller's 3 retries),
-because escalations must degrade quickly, not stall on a paid call.
+/ ``ORCHESTRATOR_API_KEY``. ``ORCHESTRATOR_FALLBACKS`` is an ordered JSON array of
+additional providers (``{"model", "base_url", "api_key_env"}``); a primary
+``OrchestratorUnavailable`` walks that chain in order, stopping at the first
+success, before the exception finally propagates and the caller fails open to
+direct submit. This exists so a free rate-limited primary (Nemotron on NVIDIA's
+40 RPM tier) degrades to DeepSeek/OpenRouter, then to always-available in-cluster
+Qwen, rather than dropping the whole brief on one throttle or blip. With no chain
+configured the behavior is byte-identical to the original single-attempt contract.
+There is still no per-provider retry loop (contrast with build_llm_caller's 3
+retries), because escalations must degrade quickly, not stall on any single call.
 
 ``call_tool`` is the typed sibling used for the runtime ``submit_plan``
 plan (ADR 036 amendment, docs/plans/2026-07-03-deepseek-runtime-recipes.md):
@@ -87,27 +88,41 @@ def _read_config() -> tuple[str, str, str, float]:
     return model, base_url, api_key, timeout_s
 
 
-def _read_fallback_config() -> tuple[str, str, str] | None:
-    """Read the fallback provider (model, base URL, API key), or ``None``.
+def _read_fallback_chain() -> list[tuple[str, str, str]]:
+    """Read the ordered fallback chain as ``[(model, base_url, api_key), ...]``.
 
-    The fallback is a second OpenAI-compatible provider tried once when the
-    primary attempt raises ``OrchestratorUnavailable``. Returns ``None`` when
-    ``ORCHESTRATOR_FALLBACK_MODEL`` is unset, which restores the single-attempt
-    contract exactly. The fallback API key prefers
-    ``ORCHESTRATOR_FALLBACK_API_KEY`` and falls back to ``OPENROUTER_API_KEY``
-    (the DeepSeek/OpenRouter path reuses the key already synced for it).
+    Parses ``ORCHESTRATOR_FALLBACKS``, a JSON array of
+    ``{"model", "base_url", "api_key_env"}`` objects in priority order. Each
+    ``api_key_env`` names the env var holding that provider's key (injected from a
+    Secret; empty/absent means no auth, e.g. the in-cluster Qwen tier). A primary
+    ``OrchestratorUnavailable`` walks this list in order, so a rate-limited or
+    erroring primary degrades to DeepSeek, then to always-available in-cluster
+    Qwen, before failing open. Returns ``[]`` when unset or unparseable, which
+    restores the single-attempt contract exactly.
     """
-    model = os.environ.get("ORCHESTRATOR_FALLBACK_MODEL", "").strip()
-    if not model:
-        return None
-    base_url = (
-        os.environ.get("ORCHESTRATOR_FALLBACK_BASE_URL", "").strip()
-        or _DEFAULT_BASE_URL
-    )
-    api_key = os.environ.get("ORCHESTRATOR_FALLBACK_API_KEY", "") or os.environ.get(
-        "OPENROUTER_API_KEY", ""
-    )
-    return model, base_url, api_key
+    raw = os.environ.get("ORCHESTRATOR_FALLBACKS", "").strip()
+    if not raw:
+        return []
+    try:
+        entries = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.exception("orchestrator: ORCHESTRATOR_FALLBACKS is not valid JSON")
+        return []
+    if not isinstance(entries, list):
+        logger.error("orchestrator: ORCHESTRATOR_FALLBACKS must be a JSON array")
+        return []
+    chain: list[tuple[str, str, str]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        model = str(entry.get("model", "")).strip()
+        if not model:
+            continue
+        base_url = str(entry.get("base_url", "")).strip() or _DEFAULT_BASE_URL
+        api_key_env = str(entry.get("api_key_env", "")).strip()
+        api_key = os.environ.get(api_key_env, "") if api_key_env else ""
+        chain.append((model, base_url, api_key))
+    return chain
 
 
 def _extract_usage(payload: dict) -> tuple[int | None, int | None, int | None]:
@@ -133,7 +148,7 @@ async def _attempt_call(
 ) -> OrchestratorResponse:
     """One provider attempt for ``call``: POST + parse, or raise
     ``OrchestratorUnavailable``. No retry loop here (the caller decides whether
-    to retry against a fallback provider)."""
+    to walk the fallback chain)."""
     started = time.monotonic()
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(timeout_s)) as client:
@@ -178,28 +193,27 @@ async def _attempt_call(
 async def call(system: str, user: str) -> OrchestratorResponse:
     """Send one system/user turn to the configured model and parse the response.
 
-    Tries the primary provider once; on ``OrchestratorUnavailable`` and when a
-    fallback is configured, retries once against the fallback provider. Raises
-    ``OrchestratorUnavailable`` if the primary fails with no fallback, or if the
-    fallback also fails.
+    Tries the primary provider, then each provider in the fallback chain in
+    order, stopping at the first success. Raises ``OrchestratorUnavailable`` only
+    when every provider fails (or when no chain is configured and the primary
+    fails), so the caller then fails open to direct submit.
     """
     model, base_url, api_key, timeout_s = _read_config()
-    try:
-        return await _attempt_call(model, base_url, api_key, timeout_s, system, user)
-    except OrchestratorUnavailable as primary_exc:
-        fallback = _read_fallback_config()
-        if fallback is None:
-            raise
-        fb_model, fb_base_url, fb_api_key = fallback
-        logger.warning(
-            "orchestrator primary model %s unavailable (%s); falling back to %s",
-            model,
-            primary_exc,
-            fb_model,
-        )
-        return await _attempt_call(
-            fb_model, fb_base_url, fb_api_key, timeout_s, system, user
-        )
+    providers = [(model, base_url, api_key), *_read_fallback_chain()]
+    last_exc: OrchestratorUnavailable | None = None
+    for i, (m, b, k) in enumerate(providers):
+        try:
+            return await _attempt_call(m, b, k, timeout_s, system, user)
+        except OrchestratorUnavailable as exc:
+            last_exc = exc
+            if i + 1 < len(providers):
+                logger.warning(
+                    "orchestrator provider %s unavailable (%s); trying next: %s",
+                    m,
+                    exc,
+                    providers[i + 1][0],
+                )
+    raise last_exc or OrchestratorUnavailable("no orchestrator providers configured")
 
 
 async def _attempt_call_tool(
@@ -288,46 +302,29 @@ async def call_tool(
     ``call()``'s usage/latency accounting (``response.content`` holds the
     raw arguments JSON string).
 
-    Tries the primary provider once; on ``OrchestratorUnavailable`` (timeout,
-    HTTP error, missing ``tool_calls``, or JSON parse error) and when a fallback
-    is configured, retries once against the fallback provider. This is where a
-    primary model with weaker forced-tool-call support degrades to the proven
-    path. Single attempt per provider, no retry loop. Uses ``timeout_s`` if
-    given, else the configured default (see ``_read_config``).
+    Tries the primary provider, then each provider in the fallback chain in
+    order, stopping at the first success. This is where a primary with weaker
+    forced-tool-call support (or an exhausted rate limit) degrades to the proven
+    path. One attempt per provider, no retry loop. Uses ``timeout_s`` if given,
+    else the configured default (see ``_read_config``).
     """
     model, base_url, api_key, default_timeout_s = _read_config()
     effective_timeout_s = timeout_s if timeout_s is not None else default_timeout_s
-
-    try:
-        return await _attempt_call_tool(
-            model,
-            base_url,
-            api_key,
-            effective_timeout_s,
-            system,
-            user,
-            schema,
-            tool_name,
-        )
-    except OrchestratorUnavailable as primary_exc:
-        fallback = _read_fallback_config()
-        if fallback is None:
-            raise
-        fb_model, fb_base_url, fb_api_key = fallback
-        logger.warning(
-            "orchestrator primary model %s tool-call unavailable (%s); "
-            "falling back to %s",
-            model,
-            primary_exc,
-            fb_model,
-        )
-        return await _attempt_call_tool(
-            fb_model,
-            fb_base_url,
-            fb_api_key,
-            effective_timeout_s,
-            system,
-            user,
-            schema,
-            tool_name,
-        )
+    providers = [(model, base_url, api_key), *_read_fallback_chain()]
+    last_exc: OrchestratorUnavailable | None = None
+    for i, (m, b, k) in enumerate(providers):
+        try:
+            return await _attempt_call_tool(
+                m, b, k, effective_timeout_s, system, user, schema, tool_name
+            )
+        except OrchestratorUnavailable as exc:
+            last_exc = exc
+            if i + 1 < len(providers):
+                logger.warning(
+                    "orchestrator provider %s tool-call unavailable (%s); "
+                    "trying next: %s",
+                    m,
+                    exc,
+                    providers[i + 1][0],
+                )
+    raise last_exc or OrchestratorUnavailable("no orchestrator providers configured")

--- a/projects/monolith/chat/orchestrator_client_test.py
+++ b/projects/monolith/chat/orchestrator_client_test.py
@@ -9,7 +9,7 @@ import pytest
 from chat.orchestrator_client import (
     OrchestratorUnavailable,
     _read_config,
-    _read_fallback_config,
+    _read_fallback_chain,
     call,
     call_tool,
 )
@@ -179,11 +179,40 @@ _TOOL_SCHEMA = {
 
 
 _FALLBACK_ENV = {
-    "ORCHESTRATOR_MODEL": "zai-glm-4.7",
-    "ORCHESTRATOR_BASE_URL": "https://api.cerebras.ai/v1",
-    "ORCHESTRATOR_API_KEY": "cerebras-key",
-    "ORCHESTRATOR_FALLBACK_MODEL": "deepseek/deepseek-v4-flash",
-    "ORCHESTRATOR_FALLBACK_BASE_URL": "https://openrouter.ai/api/v1",
+    "ORCHESTRATOR_MODEL": "nvidia/nemotron-3-ultra-550b-a55b",
+    "ORCHESTRATOR_BASE_URL": "https://integrate.api.nvidia.com/v1",
+    "ORCHESTRATOR_API_KEY": "nvidia-key",
+    "ORCHESTRATOR_FALLBACKS": json.dumps(
+        [
+            {
+                "model": "deepseek/deepseek-v4-flash",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key_env": "OPENROUTER_API_KEY",
+            }
+        ]
+    ),
+    "OPENROUTER_API_KEY": "openrouter-key",
+}
+
+# A three-tier chain: NVIDIA primary -> DeepSeek -> in-cluster Qwen (no auth).
+_CHAIN_ENV = {
+    "ORCHESTRATOR_MODEL": "nvidia/nemotron-3-ultra-550b-a55b",
+    "ORCHESTRATOR_BASE_URL": "https://integrate.api.nvidia.com/v1",
+    "ORCHESTRATOR_API_KEY": "nvidia-key",
+    "ORCHESTRATOR_FALLBACKS": json.dumps(
+        [
+            {
+                "model": "deepseek/deepseek-v4-flash",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key_env": "OPENROUTER_API_KEY",
+            },
+            {
+                "model": "qwen3.6-27b",
+                "base_url": "http://inference.inference.svc.cluster.local:8080/v1",
+                "api_key_env": "",
+            },
+        ]
+    ),
     "OPENROUTER_API_KEY": "openrouter-key",
 }
 
@@ -191,8 +220,8 @@ _FALLBACK_ENV = {
 class TestCallFallback:
     @pytest.mark.asyncio
     async def test_falls_back_to_secondary_on_primary_failure(self):
-        """A primary transport failure retries once on the fallback provider,
-        which supplies the result (its model/base URL/key)."""
+        """A primary transport failure retries on the next chain provider, which
+        supplies the result (its model/base URL/key)."""
         payload = {"choices": [{"message": {"content": "fallback brief"}}]}
         instance = _mock_client(
             post_side_effect=[
@@ -208,9 +237,9 @@ class TestCallFallback:
 
         assert result.content == "fallback brief"
         assert instance.post.call_count == 2
-        # The primary attempt targeted Cerebras/GLM...
+        # The primary attempt targeted NVIDIA/Nemotron...
         first_args, _ = instance.post.call_args_list[0]
-        assert first_args[0] == "https://api.cerebras.ai/v1/chat/completions"
+        assert first_args[0] == "https://integrate.api.nvidia.com/v1/chat/completions"
         # ...and the fallback attempt targeted DeepSeek/OpenRouter with its key.
         second_args, second_kwargs = instance.post.call_args_list[1]
         assert second_args[0] == "https://openrouter.ai/api/v1/chat/completions"
@@ -218,26 +247,56 @@ class TestCallFallback:
         assert second_kwargs["json"]["model"] == "deepseek/deepseek-v4-flash"
 
     @pytest.mark.asyncio
-    async def test_raises_when_both_primary_and_fallback_fail(self):
+    async def test_walks_full_chain_to_last_provider(self):
+        """Primary and first fallback both fail; the third tier (Qwen, no auth)
+        succeeds. Confirms an ordered N-tier walk, not a single fallback."""
+        payload = {"choices": [{"message": {"content": "qwen brief"}}]}
         instance = _mock_client(
             post_side_effect=[
-                httpx.ConnectError("primary refused"),
-                httpx.ConnectError("fallback refused"),
+                httpx.ConnectError("nvidia 429"),
+                httpx.ConnectError("openrouter 500"),
+                _ok_response(payload),
             ]
         )
         with (
             patch("chat.orchestrator_client.httpx.AsyncClient", return_value=instance),
-            patch.dict("os.environ", _FALLBACK_ENV, clear=False),
+            patch.dict("os.environ", _CHAIN_ENV, clear=False),
+        ):
+            result = await call("system", "user")
+
+        assert result.content == "qwen brief"
+        assert instance.post.call_count == 3
+        third_args, third_kwargs = instance.post.call_args_list[2]
+        assert (
+            third_args[0]
+            == "http://inference.inference.svc.cluster.local:8080/v1/chat/completions"
+        )
+        # Empty api_key_env => no-auth Bearer (in-cluster Qwen).
+        assert third_kwargs["headers"]["Authorization"] == "Bearer "
+        assert third_kwargs["json"]["model"] == "qwen3.6-27b"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_entire_chain_fails(self):
+        instance = _mock_client(
+            post_side_effect=[
+                httpx.ConnectError("nvidia refused"),
+                httpx.ConnectError("openrouter refused"),
+                httpx.ConnectError("qwen refused"),
+            ]
+        )
+        with (
+            patch("chat.orchestrator_client.httpx.AsyncClient", return_value=instance),
+            patch.dict("os.environ", _CHAIN_ENV, clear=False),
         ):
             with pytest.raises(OrchestratorUnavailable):
                 await call("system", "user")
 
-        assert instance.post.call_count == 2
+        assert instance.post.call_count == 3
 
     @pytest.mark.asyncio
-    async def test_no_fallback_configured_is_single_attempt(self, monkeypatch):
-        """With no ORCHESTRATOR_FALLBACK_MODEL the single-attempt contract holds."""
-        monkeypatch.delenv("ORCHESTRATOR_FALLBACK_MODEL", raising=False)
+    async def test_no_chain_configured_is_single_attempt(self, monkeypatch):
+        """With no ORCHESTRATOR_FALLBACKS the single-attempt contract holds."""
+        monkeypatch.delenv("ORCHESTRATOR_FALLBACKS", raising=False)
         instance = _mock_client(post_side_effect=httpx.ConnectError("refused"))
         env = {"ORCHESTRATOR_MODEL": "m", "OPENROUTER_API_KEY": "k"}
         with (
@@ -292,22 +351,55 @@ class TestCallToolFallback:
         assert second_kwargs["json"]["model"] == "deepseek/deepseek-v4-flash"
 
 
-class TestReadFallbackConfig:
-    def test_none_when_model_unset(self, monkeypatch):
-        monkeypatch.delenv("ORCHESTRATOR_FALLBACK_MODEL", raising=False)
-        assert _read_fallback_config() is None
+class TestReadFallbackChain:
+    def test_empty_when_unset(self, monkeypatch):
+        monkeypatch.delenv("ORCHESTRATOR_FALLBACKS", raising=False)
+        assert _read_fallback_chain() == []
 
-    def test_reads_model_base_url_and_key(self, monkeypatch):
-        monkeypatch.setenv("ORCHESTRATOR_FALLBACK_MODEL", "deepseek/deepseek-v4-flash")
+    def test_empty_when_unparseable(self, monkeypatch):
+        monkeypatch.setenv("ORCHESTRATOR_FALLBACKS", "{not json")
+        assert _read_fallback_chain() == []
+
+    def test_parses_ordered_chain_and_resolves_keys(self, monkeypatch):
         monkeypatch.setenv(
-            "ORCHESTRATOR_FALLBACK_BASE_URL", "https://openrouter.ai/api/v1"
+            "ORCHESTRATOR_FALLBACKS",
+            json.dumps(
+                [
+                    {
+                        "model": "deepseek/deepseek-v4-flash",
+                        "base_url": "https://openrouter.ai/api/v1",
+                        "api_key_env": "OPENROUTER_API_KEY",
+                    },
+                    {
+                        "model": "qwen3.6-27b",
+                        "base_url": "http://inference.inference.svc.cluster.local:8080/v1",
+                        "api_key_env": "",
+                    },
+                ]
+            ),
         )
-        monkeypatch.delenv("ORCHESTRATOR_FALLBACK_API_KEY", raising=False)
         monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-key")
-        model, base_url, api_key = _read_fallback_config()
-        assert model == "deepseek/deepseek-v4-flash"
-        assert base_url == "https://openrouter.ai/api/v1"
-        assert api_key == "openrouter-key"
+        chain = _read_fallback_chain()
+        assert chain == [
+            (
+                "deepseek/deepseek-v4-flash",
+                "https://openrouter.ai/api/v1",
+                "openrouter-key",
+            ),
+            (
+                "qwen3.6-27b",
+                "http://inference.inference.svc.cluster.local:8080/v1",
+                "",
+            ),
+        ]
+
+    def test_skips_entries_without_a_model(self, monkeypatch):
+        monkeypatch.setenv(
+            "ORCHESTRATOR_FALLBACKS",
+            json.dumps([{"base_url": "https://x/v1"}, {"model": "keep/me"}]),
+        )
+        chain = _read_fallback_chain()
+        assert [m for m, _b, _k in chain] == ["keep/me"]
 
 
 class TestReadConfig:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.279.0
+      targetRevision: 0.280.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -270,19 +270,28 @@ grimoire:
   extractBaseUrl: "http://inference.inference.svc.cluster.local:8080/v1/chat/completions"
 
 # ADR 036 orchestrator brief compiler (Phase 3 live enable). The primary planner
-# is GLM-4.7 on Cerebras (free, fast; ORCHESTRATOR_API_KEY sourced from the
-# CEREBRAS_API_KEY field of the existing "goosecracker" Secret). It falls back to
-# DeepSeek on OpenRouter (the proven forced-tool-call path) when Cerebras times
-# out, errors, or returns an unusable plan; the fallback key reuses the same
-# Secret's OPENROUTER_API_KEY field, so nothing extra to sync here. The
+# is NVIDIA Nemotron 3 Ultra (free, 256K context, orchestrator-tuned tool calling;
+# ORCHESTRATOR_API_KEY sourced from the NVIDIA_API_KEY field of the existing
+# "goosecracker" Secret). NVIDIA's free tier is ~40 RPM per key, so on a rate
+# limit or error the ordered chain degrades to DeepSeek on OpenRouter (the proven
+# forced-tool-call path), then to always-available in-cluster Qwen, before failing
+# open to direct submit. All keys reuse the same "goosecracker" Secret. The
 # orchestrator only runs on channels with the ADR 029 "orchestrator" consent
 # grant; ungranted channels fail open to direct submit with no external traffic.
 orchestrator:
   enabled: true
-  model: "zai-glm-4.7"
-  baseUrl: "https://api.cerebras.ai/v1"
-  fallbackModel: "deepseek/deepseek-v4-flash"
-  fallbackBaseUrl: "https://openrouter.ai/api/v1"
+  model: "nvidia/nemotron-3-ultra-550b-a55b"
+  baseUrl: "https://integrate.api.nvidia.com/v1"
+  apiKeySecretKey: "NVIDIA_API_KEY"
+  # snake_case keys: this list is serialized verbatim to the ORCHESTRATOR_FALLBACKS
+  # JSON that the Python client parses (model, base_url, api_key_env).
+  fallbacks:
+    - model: "deepseek/deepseek-v4-flash"
+      base_url: "https://openrouter.ai/api/v1"
+      api_key_env: "OPENROUTER_API_KEY"
+    - model: "qwen3.6-27b"
+      base_url: "http://inference.inference.svc.cluster.local:8080/v1"
+      api_key_env: ""
 
 agent:
   discord:


### PR DESCRIPTION
## What

Replaces the Cerebras GLM-4.7 planner (turned out **paid**, Preview/eval-only, and was 402ing on an unbilled account) with **NVIDIA Nemotron 3 Ultra 550B on the free tier**, and generalizes the single fallback into an **ordered chain**: Nemotron -> DeepSeek (OpenRouter) -> Qwen (in-cluster).

## Why

- **Cerebras was paid, not free** ($2.25/$2.75 for GLM, and GLM is "eval only, not for production"). The whole plan was premised on it being free.
- **NVIDIA build.nvidia.com is genuinely free** (rate-limited ~40 RPM per key, no credit cap on this account), OpenAI-compatible, and Nemotron 3 Ultra is their first-party, orchestrator-tuned model with 256K context and strong tool calling, an ideal brief compiler.
- **~40 RPM per key means one fallback isn't enough.** A burst can throttle the primary, so the client now walks an ordered chain and only fails open after every tier fails.

## Changes

- **orchestrator_client.py**: `_read_fallback_config` -> `_read_fallback_chain`, parsing `ORCHESTRATOR_FALLBACKS` (JSON array of `{model, base_url, api_key_env}`). `call`/`call_tool` walk primary + chain in order, first success wins, raise only when all fail. Empty chain = single-attempt contract, unchanged.
- **Helm**: `deploy/values.yaml` sets Nemotron primary + the two-tier fallback list; `orchestrator.apiKeySecretKey` parameterizes which `goosecracker` Secret field drives the primary key (`NVIDIA_API_KEY`); `ORCHESTRATOR_FALLBACKS` injected as JSON; old `fallbackModel`/`fallbackBaseUrl` env removed. Chart 0.279.0 -> 0.280.0.
- **Tests**: three-tier walk (primary -> DeepSeek -> no-auth Qwen), whole-chain-fails-raises, no-chain-single-attempt, and `_read_fallback_chain` parsing (ordered, key resolution, no-auth entry, skips model-less entries).

## Architecture note

Guest coding stays on **in-cluster Qwen** (free, no RPM cap, always up). Goose binds one provider per run and can't chain-fallback natively (multi-provider auto-switch is an open WIP upstream), so the chain is **host-side only**. Moving the guest to a rate-limited external model would need a LiteLLM-style gateway in front of goose, a deliberate future step.

## Validation

- Helm renders the chain JSON with snake_case keys matching the client's parser; `key: "NVIDIA_API_KEY"` on the primary.
- `NVIDIA_API_KEY` already synced into the `goosecracker` Secret from 1Password.
- Nemotron's forced-tool-call behavior gets confirmed on first live test; if it misbehaves it degrades to DeepSeek automatically (same as we observed with Cerebras 402s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)