### PR TITLE
chore(monolith-public): bump chart to 0.85.0 to roll out the docs site restructure

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.84.0
+version: 0.85.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.84.0
+      targetRevision: 0.85.0
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
The docs restructure merged after the 0.84.0 bump, re-publishing 0.84.0
with new public-frontend tags; ArgoCD applied its cached 0.84.0 and
reports Synced while serving the pre-docs build (project README pages
404 on jomcgi.dev/docs). Fresh version to converge on.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
