### PR TITLE
fix(grimoire): route public reads through a same-origin proxy

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.85.0
+version: 0.86.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.85.0
+      targetRevision: 0.86.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.281.0
+version: 0.282.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.281.0
+      targetRevision: 0.282.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/grimoire/api.js
+++ b/projects/monolith/frontend/src/lib/public/grimoire/api.js
@@ -5,7 +5,16 @@
 // public corpus is a single global view, so there is no `?as=` query param and
 // no campaign segment in any route.
 
-export const API = "/api/grimoire";
+// Same-origin proxy path, not the backend's /api/grimoire directly: the public
+// gateway has no /api rule, so every read goes through the SvelteKit +server.js
+// proxy at /app/grimoire/api/<path> (see routes/public/app/grimoire/api).
+export const API = "/app/grimoire/api";
+
+// The backend returns image_url as an absolute /api/grimoire/... path (it does
+// not know about the public proxy); rewrite it onto the same-origin proxy so the
+// browser reaches it through the gateway.
+export const proxiedImageUrl = (imageUrl) =>
+  imageUrl ? imageUrl.replace("/api/grimoire", API) : imageUrl;
 
 export async function apiFetch(path, options = {}) {
   const res = await fetch(`${API}${path}`, {

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/api/[...path]/+server.js
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/api/[...path]/+server.js
@@ -1,0 +1,28 @@
+import { error } from "@sveltejs/kit";
+
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// Same-origin proxy for the public Grimoire read API. The public gateway has NO
+// /api rule (the backend is never internet-reachable), so the browser calls this
+// site route (/app/grimoire/api/<path>) and the fetch to the backend's
+// /api/grimoire/<path> runs server-side here, mirroring the notes/ships/stars
+// +server.js proxies. Streams the upstream body through so both the JSON read
+// endpoints and the binary image endpoint work through one catch-all.
+export async function GET({ params, url, fetch }) {
+  const res = await fetch(
+    `${API_BASE}/api/grimoire/${params.path}${url.search}`,
+    { signal: AbortSignal.timeout(15_000) },
+  );
+  if (!res.ok) {
+    throw error(res.status === 404 ? 404 : 503, "grimoire unavailable");
+  }
+  return new Response(res.body, {
+    status: res.status,
+    headers: {
+      "content-type": res.headers.get("content-type") ?? "application/json",
+      // The corpus is near-static; a minute of edge caching keeps origin hits
+      // low without stalling coverage updates while extraction runs.
+      "cache-control": "public, max-age=60",
+    },
+  });
+}

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/c/[chunk]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/c/[chunk]/+page.svelte
@@ -4,7 +4,13 @@
   // whole book in reading order, and the entities mentioned on this page.
   import { page } from "$app/stores";
   import { goto } from "$app/navigation";
-  import { apiFetch, bookHref, chunkHref, entityHref } from "$lib/public/grimoire/api.js";
+  import {
+    apiFetch,
+    bookHref,
+    chunkHref,
+    entityHref,
+    proxiedImageUrl,
+  } from "$lib/public/grimoire/api.js";
   import { renderChunk } from "$lib/public/grimoire/renderChunk.js";
 
   const bookId = $derived(decodeURIComponent($page.params.book));
@@ -86,7 +92,7 @@
           {/if}
           <img
             class="chunk-image"
-            src={chunk.image_url}
+            src={proxiedImageUrl(chunk.image_url)}
             alt={chunk.content || "sourcebook illustration"}
             onerror={() => (imageError = true)}
           />


### PR DESCRIPTION
Follow-up to #3167. During rollout verification I found the public grimoire's data path is broken: the public gateway deliberately has **no `/api` rule** (the backend is never internet-reachable; every read goes through a same-origin SSR/`+server.js` proxy, per `httproute-public.yaml`). The merged code client-fetches `/api/grimoire/...` directly, which 404s in prod.

## Fix
- Add a catch-all `routes/public/app/grimoire/api/[...path]/+server.js` proxy that forwards to `${API_BASE}/api/grimoire/<path>` **server-side** (mirroring the `notes/body`, `ships/track`, `stars/history` proxies), streaming the upstream body so both the JSON read endpoints and the binary image endpoint work through one route.
- Point the client `API` base at `/app/grimoire/api`, and rewrite the backend-returned `image_url` (`/api/grimoire/...`) onto the proxy.
- Bump `monolith` 0.281.0 → 0.282.0 and `monolith-public` 0.85.0 → 0.86.0 to rebuild the shared SSR frontend.

The Turnstile gate stays frontend-only (the endpoints are `public_reader` data anyway); noindex still keeps it uncrawled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)