### PR TITLE
fix(goosecracker): mount tmpfs at /injected-context so the guest can write it

### DIFF
--- a/projects/firecracker/goosecracker/guest-init/cmd/main.go
+++ b/projects/firecracker/goosecracker/guest-init/cmd/main.go
@@ -66,6 +66,13 @@ func run(logger *slog.Logger) error {
 	// /tmp additionally backs the writable HOME set below.
 	mountTmpfs(logger, "/tmp", "256m")
 	mountTmpfs(logger, handler.Workspace, "256m")
+	// /injected-context (ADR 040) receives the caller-staged context bundle the
+	// per-invoke handler unpacks (the recipe reads its router.yaml/plan.md from
+	// here). Like /workspace it is a path the guest WRITES to, so it needs a tmpfs
+	// over the read-only rootfs; the mountpoint is baked into the rootfs image
+	// (apko.yaml) so this can mount over it. Without it, the handler's mkdir fails
+	// with "read-only file system" and goose aborts on the missing recipe file.
+	mountTmpfs(logger, handler.InjectedContextDir, "64m")
 
 	// A raw Firecracker boot hands PID 1 no environment (the kernel ignores the OCI
 	// image config), so establish the baseline goose needs. goose lives in

--- a/projects/firecracker/goosecracker/guest-init/internal/handler/handler.go
+++ b/projects/firecracker/goosecracker/guest-init/internal/handler/handler.go
@@ -54,7 +54,7 @@ type AgentRequest struct {
 	SessionDb   string            `json:"sessionDb"`   // optional: base64 prior sessions.db to hydrate before resume
 	// InjectedContext is an opaque map of filename to text content the caller
 	// staged for this run (ADR 040). The handler unpacks it verbatim to
-	// injectedContextDir; it never interprets the source (Discord, etc.). Keys
+	// InjectedContextDir; it never interprets the source (Discord, etc.). Keys
 	// are basenames; traversal/absolute/nested keys are skipped defensively.
 	InjectedContext map[string]string `json:"injectedContext"`
 }
@@ -258,11 +258,12 @@ var artifactPath = "/tmp/artifact.html"
 var (
 	taskFilePath    = "/tmp/goose/task.md"
 	contextFilePath = "/tmp/goose/context.md"
-	// injectedContextDir is where the caller-provided context bundle (ADR 040)
+	// InjectedContextDir is where the caller-provided context bundle (ADR 040)
 	// is unpacked, one file per InjectedContext entry, so the agent can grep it
-	// like any other on-disk source. Package var so tests can point it at a
-	// temp dir.
-	injectedContextDir = "/injected-context"
+	// like any other on-disk source. Exported so guest-init mounts a tmpfs over
+	// the same path this handler writes to (the rootfs is read-only). Package var
+	// so tests can point it at a temp dir.
+	InjectedContextDir = "/injected-context"
 )
 
 // writeTaskFile writes the task to taskFilePath and truncates contextFilePath to
@@ -285,20 +286,20 @@ func writeTaskFile(task string) error {
 	return nil
 }
 
-// writeInjectedContext unpacks files verbatim into injectedContextDir (ADR
+// writeInjectedContext unpacks files verbatim into InjectedContextDir (ADR
 // 040). It is deliberately context-agnostic: it never interprets where a
 // filename or its content came from, it just writes what it was given. Every
 // failure is soft (logged and skipped): injected context is best-effort
 // caller-side staging, and must never fail the run. Names are constrained to
 // their basename; a key that is absolute, traversal, or nested under a
-// subdirectory is skipped rather than allowed to escape injectedContextDir.
+// subdirectory is skipped rather than allowed to escape InjectedContextDir.
 func writeInjectedContext(files map[string]string) {
 	if len(files) == 0 {
 		return
 	}
-	if err := os.MkdirAll(injectedContextDir, 0o755); err != nil {
+	if err := os.MkdirAll(InjectedContextDir, 0o755); err != nil {
 		slog.Warn("handler: create injected context dir failed; skipping injected context",
-			"dir", injectedContextDir, "err", err)
+			"dir", InjectedContextDir, "err", err)
 		return
 	}
 	for name, content := range files {
@@ -307,7 +308,7 @@ func writeInjectedContext(files map[string]string) {
 			slog.Warn("handler: skipping unsafe injected context key", "name", name)
 			continue
 		}
-		path := filepath.Join(injectedContextDir, base)
+		path := filepath.Join(InjectedContextDir, base)
 		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 			slog.Warn("handler: write injected context file failed", "name", name, "err", err)
 		}

--- a/projects/firecracker/goosecracker/guest-init/internal/handler/handler_test.go
+++ b/projects/firecracker/goosecracker/guest-init/internal/handler/handler_test.go
@@ -121,7 +121,7 @@ func TestMain(m *testing.M) {
 	}
 	taskFilePath = filepath.Join(dir, "task.md")
 	contextFilePath = filepath.Join(dir, "context.md")
-	injectedContextDir = filepath.Join(dir, "injected-context")
+	InjectedContextDir = filepath.Join(dir, "injected-context")
 	code := m.Run()
 	_ = os.RemoveAll(dir)
 	os.Exit(code)
@@ -568,7 +568,7 @@ func TestNoArtifactHTMLWhenAbsent(t *testing.T) {
 }
 
 // TestInjectedContextWrittenToDir verifies that InjectedContext entries are
-// unpacked verbatim to injectedContextDir (ADR 040): the handler stays
+// unpacked verbatim to InjectedContextDir (ADR 040): the handler stays
 // context-agnostic and just writes what it was given.
 func TestInjectedContextWrittenToDir(t *testing.T) {
 	runner := &fakeRunner{out: "done"}
@@ -593,7 +593,7 @@ func TestInjectedContextWrittenToDir(t *testing.T) {
 	}
 
 	for name, want := range req.InjectedContext {
-		got, err := os.ReadFile(filepath.Join(injectedContextDir, name))
+		got, err := os.ReadFile(filepath.Join(InjectedContextDir, name))
 		if err != nil {
 			t.Fatalf("read %s: %v", name, err)
 		}
@@ -604,7 +604,7 @@ func TestInjectedContextWrittenToDir(t *testing.T) {
 }
 
 // TestInjectedContextSkipsUnsafeKeys verifies that traversal, absolute, and
-// nested keys are skipped defensively rather than escaping injectedContextDir,
+// nested keys are skipped defensively rather than escaping InjectedContextDir,
 // while a safe key alongside them is still written.
 func TestInjectedContextSkipsUnsafeKeys(t *testing.T) {
 	runner := &fakeRunner{out: "done"}
@@ -630,19 +630,19 @@ func TestInjectedContextSkipsUnsafeKeys(t *testing.T) {
 		t.Fatalf("status = %q, want ok (err=%q)", res.Status, res.Error)
 	}
 
-	got, err := os.ReadFile(filepath.Join(injectedContextDir, "ok.md"))
+	got, err := os.ReadFile(filepath.Join(InjectedContextDir, "ok.md"))
 	if err != nil || string(got) != "safe content" {
 		t.Errorf("ok.md = %q (err %v), want %q", got, err, "safe content")
 	}
 
-	if _, err := os.Stat(filepath.Join(filepath.Dir(injectedContextDir), "escape.md")); !os.IsNotExist(err) {
-		t.Errorf("escape.md must not exist outside injectedContextDir (err=%v)", err)
+	if _, err := os.Stat(filepath.Join(filepath.Dir(InjectedContextDir), "escape.md")); !os.IsNotExist(err) {
+		t.Errorf("escape.md must not exist outside InjectedContextDir (err=%v)", err)
 	}
 	if _, err := os.Stat("/abs.md"); !os.IsNotExist(err) {
 		t.Errorf("/abs.md must not have been written (err=%v)", err)
 	}
-	if _, err := os.Stat(filepath.Join(injectedContextDir, "sub")); !os.IsNotExist(err) {
-		t.Errorf("nested sub dir must not have been created under injectedContextDir (err=%v)", err)
+	if _, err := os.Stat(filepath.Join(InjectedContextDir, "sub")); !os.IsNotExist(err) {
+		t.Errorf("nested sub dir must not have been created under InjectedContextDir (err=%v)", err)
 	}
 }
 

--- a/projects/firecracker/goosecracker/guest/apko.lock.json
+++ b/projects/firecracker/goosecracker/guest/apko.lock.json
@@ -2,7 +2,7 @@
   "version": "v1",
   "config": {
     "name": "projects/firecracker/goosecracker/guest/apko.yaml",
-    "checksum": "sha256-r/vOVRAFcxQ2yuwpWOuI27WSMUmEiTZpbFGyeElpaSY="
+    "checksum": "sha256-b7HrscK/lHrJJ7yjqCsDOWVo/fskPZwe9w5TkKfoaGc="
   },
   "contents": {
     "keyring": [

--- a/projects/firecracker/goosecracker/guest/apko.yaml
+++ b/projects/firecracker/goosecracker/guest/apko.yaml
@@ -72,6 +72,15 @@ paths:
     uid: 65532
     gid: 65532
     permissions: 0o755
+  # Mountpoint for the ADR 040 caller-staged context bundle. The rootfs is booted
+  # read-only, so guest-init mounts a tmpfs over this baked dir (as it does for
+  # /workspace); without the pre-created mountpoint the tmpfs mount and the
+  # handler's write both fail on the read-only rootfs.
+  - path: /injected-context
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
 
 entrypoint:
   command: /usr/local/bin/fc-agent-init

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.30
+version: 0.4.31

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.30
+      targetRevision: 0.4.31
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## The bug

Every Discord agent run has been failing with **"Run failed: exit status 1"**. Root cause, from the fc-invoke guest log:

```
WARN  handler: create injected context dir failed; skipping injected context
      dir=/injected-context  err=mkdir /injected-context: read-only file system
INFO  goose  Error: Failed to read recipe file /injected-context/router.yaml:
      No such file or directory (os error 2)
```

The agent guest boots its rootfs **read-only** (`root=/dev/vda ro`; all mutable state is tmpfs). The ADR 040 injected-context handler unpacks the caller-staged bundle (including the `router.yaml` recipe goose runs) to `/injected-context/` at the rootfs root, which has **no tmpfs**. So `mkdir` fails, the recipe never lands, and goose aborts.

This was never a model problem (Cerebras 402 / Nemotron 503 / Qwen capacity were all red herrings), it's the guest executor. It regressed when goose guests moved onto the read-only snapshot-warm substrate (ADR 037); the injected-context feature predates that and assumed a writable rootfs.

## The fix (follows the existing `/workspace` pattern)

`/injected-context` is a cross-cutting contract (host sets `--recipe /injected-context/router.yaml`, the recipe prose points the agent there, tests assert it), so relocating it would touch ~8 files. Instead, make the existing path writable, exactly how `/workspace` already is:

- **`apko.yaml`**: pre-create `/injected-context` as a mountpoint in the read-only rootfs image (a tmpfs can't mount over a path that doesn't exist).
- **`guest-init/cmd/main.go`**: mount a tmpfs over it at boot, alongside `/tmp` and `/workspace`.
- **`handler.go`**: export `InjectedContextDir` so guest-init mounts the exact path the handler writes (single source of truth); `handler_test.go` updated for the rename.
- Bump substrate chart 0.4.30 -> 0.4.31 to roll out the rebuilt guest image (guest image tag is Bazel-pinned at chart-build).

## Verification

- Existing `handler_test.go` covers the unpack logic; it passed with the rename.
- Real proof is the live rollout: after this deploys, a Discord agent run should get past guest startup (the recipe file will exist). I'll confirm from the guest logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)