### PR TITLE
fix(grimoire): grant public_reader SELECT on book and chunk_extraction

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.282.0
+version: 0.283.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260704010000_grimoire_public_reader_book_extraction.sql
+++ b/projects/monolith/chart/migrations/20260704010000_grimoire_public_reader_book_extraction.sql
@@ -1,0 +1,12 @@
+-- Follow-up to 20260704000000: grant public_reader SELECT on the two corpus
+-- metadata tables the public Library read path also needs. list_books reads
+-- grimoire.book (display names) and grimoire.chunk_extraction (the extraction
+-- markers behind the coverage count), and search_public reads grimoire.book for
+-- lore-hit display names. Both are corpus metadata, not campaign-private data,
+-- so they join the public corpus grant. Same opt-in posture as the first
+-- migration: named tables only, no schema-wide default privilege.
+
+GRANT SELECT ON
+    grimoire.book,
+    grimoire.chunk_extraction
+    TO public_reader;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:WEqN6qnieNddA0kHMmqLwc4Gan/jxhJWf4gq02TjBR8=
+h1:Jep/6DsNO8OCx/MYYgRO4T6OHu8OEnSik2MGZJgknsE=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -95,3 +95,4 @@ h1:WEqN6qnieNddA0kHMmqLwc4Gan/jxhJWf4gq02TjBR8=
 20260703240000_grimoire_chunk_image_ref.sql h1:SJh3mta2uHO3SFXTHV3LEQdde4a5fPJCVSfDpZDyFDs=
 20260703250000_grimoire_chunk_seq_and_book.sql h1:5CGypr1+w41FLGdqrdYj9djiz1go2OdS3ai+Nb07At8=
 20260704000000_grimoire_public_reader_grant.sql h1:ZRY8zkuHoX0vtFNbJvP+hBaZp0BdyJ3k0Y5I4U1dx6U=
+20260704010000_grimoire_public_reader_book_extraction.sql h1:Edzhx2fHIgTcRRWOHRR8Re36NJ6fdEg7rMi45QwipQ8=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.282.0
+      targetRevision: 0.283.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Follow-up to #3167 / #3171. Rollout verification showed `/app/grimoire/api/entities` works end-to-end (378 entities, secondary fields, compound cursor) but `/books` 503s: the Library query (`list_books`) reads `grimoire.book` (display names) and `grimoire.chunk_extraction` (the coverage markers), and `search_public` reads `book` for lore-hit display names, but the first grant migration (`20260704000000`) omitted both.

Grant `public_reader` SELECT on those two corpus metadata tables (still opt-in named grants, no schema-wide default). Bump `monolith` 0.282.0 → 0.283.0 (the migration ships in the monolith chart).

Verified the first migration applied cleanly (public_reader has SELECT on the 9 originally-granted tables + schema USAGE); this adds the two the Library path also needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)