### PR TITLE
chore(monolith,monolith-public): bump charts to 0.284.0/0.88.0 to roll out the docs polish

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.87.0
+version: 0.88.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.87.0
+      targetRevision: 0.88.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.283.0
+version: 0.284.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.283.0
+      targetRevision: 0.284.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
The docs-polish PR's identical 0.283.0/0.87.0 bump commit was dropped
at rebase-merge as already-upstream (0ba39db bumped the same versions
first), so those charts published without the docs changes. Fresh
versions to converge on.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
