### PR TITLE
feat(grimoire): standalone public app chrome, static stats strip, readable prose

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.88.0
+version: 0.89.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.88.0
+      targetRevision: 0.89.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.284.0
+version: 0.285.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.284.0
+      targetRevision: 0.285.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
@@ -1,19 +1,27 @@
 <script>
-  // Public Grimoire app shell: Nav, a Turnstile gate around the app content
-  // (Library/sections/reader/entities), then Footer. The gate is a real
-  // admission boundary, not decoration: children (and therefore every
+  // Public Grimoire app shell: a slim app-own topbar (wordmark + Library /
+  // Entities nav) and a Turnstile gate around the app content. The gate is a
+  // real admission boundary, not decoration: children (and therefore every
   // /api/grimoire fetch) only mount after onAdmitted fires, so the WotC-
-  // copyrighted corpus never reaches an unsolved visitor or a crawler. Nav and
-  // Footer render unconditionally (bracketing the app, matching the public
-  // site's chrome), noindex keeps this out of search entirely (Task 3 /
-  // copyright mitigation) regardless of admission state.
-  import Nav from "$lib/public/components/Nav.svelte";
-  import Footer from "$lib/public/components/Footer.svelte";
+  // copyrighted corpus never reaches an unsolved visitor or a crawler. No
+  // site Nav/Footer: this is a standalone shareable app, not a page of the
+  // portfolio site. noindex keeps it out of search entirely (copyright
+  // mitigation) regardless of admission state.
+  import { page } from "$app/stores";
   import TurnstileGate from "$lib/public/components/TurnstileGate.svelte";
+  import { libraryHref, entitiesHref } from "$lib/public/grimoire/api.js";
 
   let { data, children } = $props();
 
   let admitted = $state(false);
+
+  // Highlight the active topbar link: the entities index and entity detail
+  // pages both count as "entities"; everything else is the library flow.
+  const section = $derived.by(() => {
+    const id = $page.route.id ?? "";
+    if (id.includes("/entities") || id.includes("/entity/")) return "entities";
+    return "library";
+  });
 </script>
 
 <svelte:head>
@@ -28,9 +36,24 @@
   <meta name="robots" content="noindex, nofollow" />
 </svelte:head>
 
-<Nav route="grimoire" />
+<div class="grimoire-app">
+  <header class="topbar">
+    <a class="mono wordmark" href={libraryHref()}>GRIMOIRE</a>
+    <nav class="topbar-nav" aria-label="Grimoire sections">
+      <a
+        class="mono topbar-link"
+        class:active={section === "library"}
+        href={libraryHref()}>LIBRARY</a
+      >
+      <a
+        class="mono topbar-link"
+        class:active={section === "entities"}
+        href={entitiesHref()}>ENTITIES</a
+      >
+    </nav>
+  </header>
 
-<main class="grimoire-shell">
+  <main class="grimoire-shell">
   {#if !admitted}
     <div class="wrap-narrow gate">
       <p class="eyebrow">GRIMOIRE ACCESS</p>
@@ -49,15 +72,76 @@
   {:else}
     {@render children()}
   {/if}
-</main>
-
-<Footer />
+  </main>
+</div>
 
 <style>
-  /* Structural shell only: vertical breathing room between Nav and the app
-     content / Footer. The gate copy reuses .wrap-narrow + .display/.eyebrow/
-     .hl-yellow verbatim, so this is the only custom CSS the shell needs. */
+  /* App-own chrome: a slim topbar plus hard-edge overrides. Setting the
+     radius custom properties to 0 on the app root squares off every
+     .card-hard / button / select inside via inheritance, without touching
+     the rest of the public site. */
+  .grimoire-app {
+    --radius: 0px;
+    --radius-lg: 0px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* The design system's :focus-visible ring is rounded (6px); square it to
+     match the hard-edge language inside the app. */
+  .grimoire-app :global(:focus-visible) {
+    border-radius: 0;
+  }
+
+  .topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 10px 32px;
+    border-bottom: 2px solid var(--ink);
+    background: var(--bg);
+  }
+
+  .wordmark {
+    font-size: 14px;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    color: var(--ink);
+    text-decoration: none;
+  }
+
+  .topbar-nav {
+    display: flex;
+    gap: 6px;
+  }
+
+  .topbar-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 36px;
+    padding: 4px 12px;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: var(--ink-3);
+    text-decoration: none;
+  }
+
+  /* High-contrast state change, no lift: ink fill on hover/active. */
+  .topbar-link:hover {
+    background: var(--ink);
+    color: var(--paper);
+  }
+
+  .topbar-link.active {
+    background: var(--ink);
+    color: var(--paper);
+  }
+
   .grimoire-shell {
+    flex: 1;
     min-height: 60vh;
   }
 

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
@@ -1,10 +1,9 @@
 <script>
-  // Public Grimoire Library: every loaded book, corpus coverage, and a
-  // scrolling status ticker. Fetches AFTER the layout's TurnstileGate admits
+  // Public Grimoire Library: every loaded book plus a static corpus stats
+  // strip at the top. Fetches AFTER the layout's TurnstileGate admits
   // (this component only mounts once `admitted` is true), so there is no
   // corpus fetch before the challenge is solved.
   import { onMount } from "svelte";
-  import Marquee from "$lib/public/components/Marquee.svelte";
   import Sticker from "$lib/public/components/Sticker.svelte";
   import { apiFetch, bookHref } from "$lib/public/grimoire/api.js";
 
@@ -24,11 +23,6 @@
     } finally {
       loading = false;
     }
-  }
-
-  function coverage(book) {
-    if (!book.chunk_count) return 0;
-    return Math.round((book.extracted_count / book.chunk_count) * 100);
   }
 
   function timeAgo(iso) {
@@ -61,26 +55,44 @@
     return Date.now() - then < NEW_WINDOW_MS;
   }
 
-  // One ticker line per book: "<BOOK> · N CHUNKS · N IMAGES · N ENTITIES · KG
-  // SYNCED <ago>". Marquee tiles the array x3 and separates items with its own
-  // dot, so a single joined string per book is the whole line.
-  const tickerItems = $derived(
-    books.map(
-      (b) =>
-        `${b.display_name.toUpperCase()} · ${b.chunk_count} CHUNKS · ${b.image_count} IMAGES · ${b.entity_count} ENTITIES · KG SYNCED ${timeAgo(b.latest_chunk_at)}`,
-    ),
-  );
+  // Static corpus totals for the strip at the top: aggregate across every
+  // loaded book, with the most recent sync time. Static and readable, not a
+  // scrolling marquee.
+  const totals = $derived.by(() => {
+    const sum = (key) => books.reduce((acc, b) => acc + (b[key] ?? 0), 0);
+    const latest = books
+      .map((b) => b.latest_chunk_at)
+      .filter(Boolean)
+      .sort()
+      .at(-1);
+    return {
+      books: books.length,
+      chunks: sum("chunk_count"),
+      images: sum("image_count"),
+      entities: sum("entity_count"),
+      synced: timeAgo(latest),
+    };
+  });
 </script>
 
-<div class="wrap library-page page">
-  <p class="eyebrow">THE GRIMOIRE</p>
-  <h1 class="display lib-title">Library</h1>
-
+<div class="library-page page">
   {#if !loading && !error && books.length > 0}
-    <div class="ticker-slot">
-      <Marquee items={tickerItems} />
+    <div class="stats-strip mono" role="status">
+      <span>{totals.books} {totals.books === 1 ? "BOOK" : "BOOKS"}</span>
+      <span class="strip-dot" aria-hidden="true">●</span>
+      <span>{totals.chunks} CHUNKS</span>
+      <span class="strip-dot" aria-hidden="true">●</span>
+      <span>{totals.images} IMAGES</span>
+      <span class="strip-dot" aria-hidden="true">●</span>
+      <span>{totals.entities} ENTITIES</span>
+      <span class="strip-dot" aria-hidden="true">●</span>
+      <span>SYNCED {totals.synced}</span>
     </div>
   {/if}
+
+  <div class="wrap">
+    <p class="eyebrow">THE GRIMOIRE</p>
+    <h1 class="display lib-title">Library</h1>
 
   {#if loading}
     <div class="skeletons">
@@ -108,25 +120,12 @@
             </div>
 
             <div class="book-stats">
-              <span class="chip mono">
-                {book.extracted_count}/{book.chunk_count} EXTRACTED
-              </span>
+              <span class="chip mono">{book.chunk_count} CHUNKS</span>
               <span class="chip mono">{book.image_count} IMAGES</span>
               <span class="chip mono">{book.entity_count} ENTITIES</span>
               <span class="chip mono chip-muted"
                 >SYNCED {timeAgo(book.latest_chunk_at)}</span
               >
-            </div>
-
-            <div
-              class="coverage-bar"
-              role="progressbar"
-              aria-valuenow={coverage(book)}
-              aria-valuemin="0"
-              aria-valuemax="100"
-              aria-label="{book.display_name} coverage"
-            >
-              <div class="coverage-fill" style="width:{coverage(book)}%"></div>
             </div>
           </div>
 
@@ -137,6 +136,7 @@
       {/each}
     </ul>
   {/if}
+  </div>
 </div>
 
 <style>
@@ -146,7 +146,29 @@
      design system doesn't ship (stat chip pills, a coverage bar) built from
      its own tokens rather than new colors. */
   .library-page {
-    padding: 48px 32px 96px;
+    padding-bottom: 96px;
+  }
+
+  /* Static full-bleed stats strip: the ticker's useful numbers without the
+     scroll. Accent ground, hard rule below, wraps on small screens. */
+  .stats-strip {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    column-gap: 14px;
+    row-gap: 4px;
+    padding: 10px 16px;
+    background: var(--accent);
+    border-bottom: 2px solid var(--ink);
+    color: var(--ink);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+  }
+
+  .strip-dot {
+    font-size: 8px;
   }
 
   .lib-title {
@@ -154,8 +176,8 @@
     margin: 4px 0 28px;
   }
 
-  .ticker-slot {
-    margin: 0 -32px 40px;
+  .library-page .wrap {
+    padding-top: 40px;
   }
 
   .book-list {
@@ -214,19 +236,6 @@
     border-color: var(--rule-2);
   }
 
-  .coverage-bar {
-    height: 10px;
-    border: 2px solid var(--ink);
-    background: var(--bg-elev);
-    overflow: hidden;
-  }
-
-  .coverage-fill {
-    height: 100%;
-    background: var(--blue);
-    transition: width 300ms ease;
-  }
-
   .book-read {
     flex: none;
     min-height: 44px;
@@ -280,10 +289,10 @@
 
   @media (max-width: 640px) {
     .library-page {
-      padding: 32px 16px 72px;
+      padding-bottom: 72px;
     }
-    .ticker-slot {
-      margin: 0 -16px 32px;
+    .library-page .wrap {
+      padding-top: 28px;
     }
     .book-row {
       flex-direction: column;
@@ -297,9 +306,6 @@
   @media (prefers-reduced-motion: reduce) {
     .skeleton-row {
       animation: none;
-    }
-    .coverage-fill {
-      transition: none;
     }
   }
 </style>

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/c/[chunk]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/c/[chunk]/+page.svelte
@@ -193,20 +193,24 @@
     margin-bottom: 16px;
   }
 
+  /* Body text is the workhorse sans, NOT the display serif: Instrument Serif
+     is a high-contrast display face whose hairline thins all but disappear at
+     body sizes, which reads as low contrast even at full ink. Hanken Grotesk
+     carries long-form reading. */
   .prose {
-    font-family: var(--serif);
-    font-size: 19px;
-    line-height: 1.65;
+    font-family: var(--sans);
+    font-size: 18px;
+    line-height: 1.7;
     color: var(--ink);
   }
 
   .prose p {
-    margin-bottom: 16px;
+    margin-bottom: 18px;
   }
 
   .prose-heading {
     margin: 28px 0 12px;
-    color: var(--ink-2);
+    color: var(--ink);
   }
 
   .prose-heading:first-child {
@@ -242,10 +246,10 @@
 
   .caption {
     margin-top: 12px;
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-style: italic;
     font-size: 15px;
-    color: var(--ink-3);
+    color: var(--ink-2);
     text-align: center;
   }
 


### PR DESCRIPTION
Public grimoire polish from Joe's review of the live demo:

- **No Nav/Footer**: the public grimoire is a standalone shareable app now, with its own slim topbar (GRIMOIRE wordmark + LIBRARY / ENTITIES links). This also makes the entity explorer reachable: the /entities page existed but nothing linked to it.
- **Hard edges**: `--radius: 0` scoped to the app root squares off every card, button, and focus ring inside grimoire without touching the rest of the public site.
- **Static stats strip**: the animated Marquee becomes a static full-bleed accent strip at the top with aggregate corpus numbers (books / chunks / images / entities / synced).
- **Readable prose**: reading text switches from Instrument Serif (a display face whose hairline strokes nearly vanish at 19px, reading as low contrast) to Hanken Grotesk 18px/1.7 at full ink. Captions and prose headings darkened to match.
- Dropped the `0/1224 EXTRACTED` chip + empty coverage bar from book rows: the count is known-wrong on the public tier (extraction-key env mismatch) and is pipeline-internal anyway.
- Chart bumps: monolith 0.284.0 + monolith-public 0.87.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)