### PR TITLE
fix(frontend): blue highlight chip for the rack eyebrow stat line

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.87.0
+version: 0.88.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.87.0
+      targetRevision: 0.88.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.283.0
+version: 0.284.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.283.0
+      targetRevision: 0.284.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
+++ b/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
@@ -1,5 +1,5 @@
 <section class="rack-section" id="homelab" aria-label="Homelab hardware and systems">
-  <p class="eyebrow">4 nodes &middot; 52 CPUs &middot; 112 GB &middot; one RTX 4090</p>
+  <p class="rack-eyebrow">4 nodes &middot; 52 CPUs &middot; 112 GB &middot; one RTX 4090</p>
   <h2>HOMELAB</h2>
 
   <div class="rack-grid">
@@ -89,6 +89,18 @@
     max-width: 1360px;
     margin: 0 auto;
     padding: 48px 32px;
+  }
+  .rack-eyebrow {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ink);
+    background: var(--blue);
+    padding: 4px 10px;
+    margin: 0;
   }
   h2 {
     font-family: var(--mono);


### PR DESCRIPTION
The global .eyebrow grey is unreadable on the cream ground. Ink text on
a blue chip instead. Bumps monolith 0.284.0 and monolith-public 0.88.0.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
