### PR TITLE
fix(goosecracker): give the implement recipe the working REST-API PR path

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/implement.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/implement.yaml
@@ -6,8 +6,9 @@ instructions: |
   microVM, on a checkout of the repo at /workspace.
 
   Implement the task below. Use the shell and editor to read, edit, and
-  build. Commit with Conventional Commits and push a claude/-prefixed
-  branch, opening a PR when the change is ready.
+  build. When the change is ready, open a PR by following the
+  "Opening the PR" steps below. This sandbox has NO writable git remote,
+  so `git push` cannot work here: do not attempt it (see below).
 
   Before you make changes, read the repo's root CLAUDE.md and the
   CLAUDE.md in any project directory you touch
@@ -28,6 +29,39 @@ instructions: |
   (`head`, `wc -l` first, sample) rather than dumping a full `git log` or
   large files, which can overflow context and trigger a compaction that loses
   progress.
+
+  Opening the PR. The `origin` remote here is a READ-ONLY git mirror
+  (a `git://git-mirror...` URL). `git push` over it, or over any GitHub
+  HTTPS/SSH remote you set, WILL fail ("Password authentication is not
+  supported", "send-pack: unexpected disconnect", "could not read from
+  remote"). Do not retry pushing with different remotes, credentials, or
+  protocols: none work. The `gh` CLI IS authenticated, but only for the
+  GitHub REST API, so open the PR through the API instead of pushing.
+
+  Do NOT commit locally (a local commit cannot leave this VM). Instead
+  build the branch server-side via the REST API. Set
+  `R=jomcgi/homelab` and `B=claude/<short-slug-for-the-task>`, then:
+
+    1. Base SHA:      `BASE=$(gh api repos/$R/git/ref/heads/main --jq .object.sha)`
+    2. Base tree:     `BT=$(gh api repos/$R/git/commits/$BASE --jq .tree.sha)`
+    3. For EACH changed file, create a blob and collect a tree entry
+       (mode 100644, type blob). Delete a file with an entry whose `sha`
+       is null instead of a blob. Build one JSON array of entries, e.g.
+       per file:
+         `S=$(gh api repos/$R/git/blobs -f content="$(cat path)" -f encoding=utf-8 --jq .sha)`
+       then append `{"path":"path","mode":"100644","type":"blob","sha":"$S"}`.
+    4. New tree:      `gh api repos/$R/git/trees -F base_tree=$BT -F 'tree=@entries.json' --jq .sha`
+       (write the entries array to a file and pass it with `-F tree=@file`).
+    5. New commit:    `NC=$(gh api repos/$R/git/commits -f message="<conventional-commit>" -f tree=$NEWTREE -f parents[]=$BASE --jq .sha)`
+    6. Create branch: `gh api repos/$R/git/refs -f ref="refs/heads/$B" -f sha=$NC`
+    7. Open the PR:   `gh pr create --repo $R --base main --head $B --title "<title>" --body "<body>"`
+       (or `gh api repos/$R/pulls -f title=... -f head=$B -f base=main -f body=...`).
+
+  Use a Conventional Commit message and a `claude/`-prefixed branch. Keep
+  the changed-file set small; for more than a few files, script step 3 by
+  iterating `git diff --name-status main`. If any `gh api` call errors,
+  read its message and fix the specific call: do not fall back to
+  `git push`, which cannot succeed here.
 
   Your final message is returned verbatim to the routing agent: state the
   action taken and the outcome in one or two sentences, the branch name,

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.31
+version: 0.4.32

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.31
+      targetRevision: 0.4.32
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## What

The `implement` sub-recipe (`projects/firecracker/goosecracker/guest/recipes/implement.yaml`) instructed the guest to `git push` a `claude/`-prefixed branch and open a PR. That instruction is impossible in the sandbox, so the one thing the recipe says about PR creation is the one thing that cannot work.

- `origin` is the **read-only** git mirror (`git://git-mirror...:9418`, ADR 026).
- The `gh` token works for the **REST API** but not `git push`: `remote: Invalid username or token. Password authentication is not supported for Git operations.`

This edit replaces the `git push` instruction with an "Opening the PR" section that states the remote is read-only and gives the exact `gh api` sequence that actually works: base ref -> base tree -> blob(s) -> tree -> commit -> `refs/heads/claude/<slug>` -> `gh pr create`.

## Evidence (every hunk cites a session)

Classified from prod, `taxonomy_version: 2`, `recipes_ref: ce7f642` (the recipe version that ran). eval.json written for both.

| session_id | outcome | active_s | tool calls | retries | failure modes | addressed by |
| --- | --- | --- | --- | --- | --- | --- |
| `1522851555555016824` ("create a dummy pr") | PR #3181 landed, the hard way | 126 | 50 (44 shell) | node script rerun 8x | `missing-context`, `tool-flail` | the "Opening the PR" `gh api` sequence replaces ~40 calls of push-then-rediscover-REST-API with a documented ~7-call path |
| `1522242441284026459` ("PR PLEASE") | **gave up, no PR** | 140 | 33 | 2 push attempts | `missing-context`, `under-delivery` | same section; the guest is told up front that push fails and how to open the PR, so it no longer dead-ends |

Transcript excerpts:
- `...5016824`: after `git://` push (`send-pack: unexpected disconnect`), HTTPS push (`Password authentication is not supported`), and `gh auth setup-git` all failed, the guest rebuilt the commit via `POST /repos/jomcgi/homelab/git/{blobs,trees,commits,refs}` in a hand-written `create_dummy_pr.js`, run 8 times before it succeeded. Its own final output: *"using the GitHub REST API via a Node.js script since the git:// origin remote does not support push operations."*
- `...4026459` final output: *"no writable push remote is configured, the only remote is a read-only git:// mirror, so the PR cannot be opened from here."* The owner's next message was *"are you OK now? PR PLEASE"* (the second owner turn this PR is meant to eliminate).

## Aggregates note

A recipe-generation before/after table is not computable for this window: `orchestrator_route` / `plan_json` were `null` for all 84 sessions gathered (the runtime-recipe telemetry landed only at the window boundary), so both PR sessions are legacy-path runs with no plan metadata. The PR-path metrics above are the evidence; the next `/improve-recipes` run is what confirms the fix.

## Out of scope, observed (the durable fix)

- **ADR 027 (Draft), agent GitHub App roles.** The intended design gives an implementer thread a `jomcgi-implementer[bot]` installation token scoped to push `claude/*`. Once that lands, plain `git push origin claude/<slug>` works and this recipe workaround should be reverted to a simple push. Until then, the REST-API path is the only one that works.
- **Two FAILED PR attempts** (`1522831802526335127`, `1522831912748450013`) died at 1-2s with `exit status 1` and no sessions.db (guest never ran) - an env/creds fault, out of recipe scope, not diffed.

## Deploy

Guest-recipe change, so the substrate chart is bumped (`0.4.31 -> 0.4.32`, `application.yaml` `targetRevision` in sync) to rebuild the goosecracker guest image.