### PR TITLE
fix(stars): batch stars-refresh to bound memory and stop OOMKills

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.2
+version: 0.285.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -254,8 +254,14 @@ jobs:
       args: ["stars-refresh"]
       schedule: "0 */3 * * *" # every 3h (was 10800s)
       concurrencyPolicy: Forbid
-      activeDeadlineSeconds: 1800
+      # ~14k met.no fetches at the ~15 req/s courtesy rate is ~15-18 min; the
+      # highest external fanout in the registry. 45 min gives headroom for a slow
+      # met.no day without ever overlapping the next run (Forbid + 3h schedule).
+      activeDeadlineSeconds: 2700
       suspend: false
+      # 512Mi is comfortable now that the refresh fetches + persists in batches
+      # (stars/jobs.py REFRESH_BATCH_SIZE) instead of holding the whole ~14k-site
+      # grid in memory at once, which OOMed this pod.
       resources:
         requests:
           cpu: 250m

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.2
+      targetRevision: 0.285.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/stars/jobs.py
+++ b/projects/monolith/stars/jobs.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+from collections.abc import Iterator
 from datetime import datetime, timezone
 
 from sqlmodel import Session, delete, select
@@ -23,6 +25,16 @@ from stars.forecast import fetch_all
 from stars.models import Site, SiteHour
 
 logger = logging.getLogger("monolith.stars.jobs")
+
+# The refresh fetches, scores, and persists sites in batches of this size rather
+# than accumulating the whole ~14k-site grid at once. The old whole-grid path
+# (one asyncio.gather over every site, then one add_all/commit) held the entire
+# scored result set plus its ORM object graph in memory simultaneously and OOMed
+# the 512Mi job pod. Batching bounds peak memory to O(batch size), independent of
+# the total site count, and commits each batch as it completes. The met.no rate
+# limiter (~15 req/s) is unchanged and dominates wall time, so batching does not
+# slow the run. Env-overridable so the batch size can be tuned without a redeploy.
+REFRESH_BATCH_SIZE = int(os.environ.get("STARS_REFRESH_BATCH_SIZE", "500"))
 
 
 def _load_sites() -> list[dict]:
@@ -127,28 +139,43 @@ def _run_prune() -> int:
     return deleted
 
 
-async def refresh_handler(session: Session) -> datetime | None:
-    """Refresh per-site dark-hour forecasts from met.no.
+def _chunks(items: list, size: int) -> Iterator[list]:
+    """Yield successive ``size``-length slices of ``items`` (the last may be short)."""
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
 
-    The site list is loaded from stars.sites in a worker thread; the network
-    fetch + scoring runs in the async handler; the synchronous write is
-    delegated to a worker thread with its own session. Sites whose fetch failed
-    keep their previous rows (stale beats empty); a total fetch failure writes
-    nothing.
+
+async def refresh_handler(session: Session) -> datetime | None:
+    """Refresh per-site dark-hour forecasts from met.no, in bounded batches.
+
+    The site list is loaded from stars.sites in a worker thread, then processed
+    in REFRESH_BATCH_SIZE-site batches: each batch's network fetch + scoring runs
+    in the async handler and its synchronous write is delegated to a worker
+    thread with its own fresh session. Batching keeps peak memory O(batch size)
+    instead of accumulating the whole ~14k-site grid at once (which OOMed the
+    pod), and commits each batch as it completes so a mid-run failure still lands
+    the batches that finished. Sites whose fetch failed keep their previous rows
+    (stale beats empty); a run where every batch fetched nothing writes nothing.
     """
     sites = await asyncio.to_thread(_load_sites)
     if not sites:
         logger.warning("stars.refresh: no sites in stars.sites, nothing to fetch")
         return None
-    scored = await fetch_all(sites)
-    if not scored:
+    total_written = 0
+    total_scored = 0
+    for batch in _chunks(sites, REFRESH_BATCH_SIZE):
+        scored = await fetch_all(batch)
+        if not scored:
+            continue
+        total_scored += len(scored)
+        total_written += await asyncio.to_thread(_persist_sites, scored)
+    if total_written == 0:
         logger.warning("stars.refresh: empty fetch, keeping existing rows")
         return None
-    written = await asyncio.to_thread(_persist_sites, scored)
     logger.info(
         "stars.refresh ok: %d hours across %d/%d sites",
-        written,
-        len(scored),
+        total_written,
+        total_scored,
         len(sites),
     )
     return None

--- a/projects/monolith/stars/jobs_test.py
+++ b/projects/monolith/stars/jobs_test.py
@@ -264,3 +264,78 @@ def test_refresh_handler_no_sites_is_noop(monkeypatch):
     result = asyncio.run(jobs.refresh_handler(None))
     assert result is None
     assert fetched is False
+
+
+def test_chunks_covers_all_items_without_overlap():
+    # Batching must partition the site list exactly: every item once, last short.
+    items = list(range(7))
+    batches = list(jobs._chunks(items, 3))
+    assert batches == [[0, 1, 2], [3, 4, 5], [6]]
+    assert sum(batches, []) == items
+
+
+def test_chunks_empty_input_yields_nothing():
+    assert list(jobs._chunks([], 3)) == []
+
+
+def test_refresh_handler_processes_all_sites_in_batches(monkeypatch):
+    # More sites than the batch size: the handler fetches + persists in bounded
+    # batches, covering every site exactly once and summing the totals. This is
+    # the OOM fix: fetch_all is never called with the whole grid at once.
+    sites = [
+        {"id": f"s{i}", "lat": 57.0, "lon": -4.0, "altitude_m": 100} for i in range(5)
+    ]
+    monkeypatch.setattr(jobs, "_load_sites", lambda: sites)
+    monkeypatch.setattr(jobs, "REFRESH_BATCH_SIZE", 2)
+
+    fetched_batches = []
+
+    async def _fake_fetch(batch):
+        fetched_batches.append([s["id"] for s in batch])
+        return {s["id"]: [_hour("2026-06-13T23:00:00Z")] for s in batch}
+
+    persisted = []
+
+    def _fake_persist(scored):
+        persisted.append(sorted(scored))
+        return len(scored)  # one hour per site in this batch
+
+    monkeypatch.setattr(jobs, "fetch_all", _fake_fetch)
+    monkeypatch.setattr(jobs, "_persist_sites", _fake_persist)
+
+    result = asyncio.run(jobs.refresh_handler(None))
+    assert result is None
+    # 5 sites, batch size 2 -> batches of [2, 2, 1]; no batch is the whole grid.
+    assert fetched_batches == [["s0", "s1"], ["s2", "s3"], ["s4"]]
+    # Every site is persisted exactly once across the batches.
+    assert sorted(sum(persisted, [])) == ["s0", "s1", "s2", "s3", "s4"]
+
+
+def test_refresh_handler_skips_empty_batches_but_persists_others(monkeypatch):
+    # A batch whose fetch returned nothing (all failed) is skipped, but later
+    # non-empty batches still persist: stale beats empty, per batch.
+    sites = [
+        {"id": f"s{i}", "lat": 57.0, "lon": -4.0, "altitude_m": 100} for i in range(4)
+    ]
+    monkeypatch.setattr(jobs, "_load_sites", lambda: sites)
+    monkeypatch.setattr(jobs, "REFRESH_BATCH_SIZE", 2)
+
+    async def _fake_fetch(batch):
+        # First batch fetches nothing; second batch succeeds.
+        if batch[0]["id"] == "s0":
+            return {}
+        return {s["id"]: [_hour("2026-06-13T23:00:00Z")] for s in batch}
+
+    persisted = []
+
+    def _fake_persist(scored):
+        persisted.append(sorted(scored))
+        return len(scored)
+
+    monkeypatch.setattr(jobs, "fetch_all", _fake_fetch)
+    monkeypatch.setattr(jobs, "_persist_sites", _fake_persist)
+
+    result = asyncio.run(jobs.refresh_handler(None))
+    assert result is None
+    # Only the second batch persisted; the empty first batch was skipped.
+    assert persisted == [["s2", "s3"]]


### PR DESCRIPTION
## Problem

The `stars-refresh` CronWorkflow (namespace `monolith-workflows`) has been **OOMKilled (exit 137) on every run** — 5 of 5 over the last 14h at the 3-hourly schedule. Result: `stars.site_hours` last refreshed **2026-07-02**, so `/app/stars` "clear dark hours" has been serving 2+ day stale forecasts.

Evidence:
```
stars-refresh-1783123200  Failed  main: OOMKilled (exit code 137)
stars-refresh-1783134000  Failed  main: OOMKilled (exit code 137)
stars-refresh-1783144800  Failed  main: OOMKilled (exit code 137)
stars-refresh-1783155600  Failed  main: OOMKilled (exit code 137)
stars-refresh-1783166400  Failed  main: OOMKilled (exit code 137)
```

## Root cause

`stars.sites` holds **14,234 sites**. `refresh_handler` fetched + scored all of them in one `asyncio.gather`, then wrote the entire result set via one `session.add_all` + `commit`. Peak memory (the full scored dict + the full `SiteHour` ORM object graph + SQLAlchemy's unit-of-work) cleared the **512Mi** pod limit. It is currently July (few qualifying dark hours per site); winter's longer nights would make it worse.

## Fix

Process sites in `REFRESH_BATCH_SIZE`-site batches (default **500**, env-overridable via `STARS_REFRESH_BATCH_SIZE`). Each batch fetches, scores, and persists independently, so peak memory is **O(batch size)**, independent of the 14,234 total.

- The per-site delete-then-insert write is already idempotent, so per-batch commits are safe and each batch lands as it completes (partial-fresh beats all-or-nothing on a mid-run failure).
- The met.no ~15 req/s courtesy rate limiter is unchanged and dominates wall time (~15-18 min), so **batching does not slow the run** — it actually makes early sites fresh sooner via incremental commits.
- `activeDeadlineSeconds` raised 1800 -> 2700 for headroom on a slow met.no day. `concurrencyPolicy: Forbid` + the 3h schedule mean a long run never overlaps the next.
- **512Mi limit kept** — the point is that it now fits.

## Tests

Added to `stars/jobs_test.py`: `_chunks` partitioning (no drop/overlap, empty input), multi-batch processing covers every site exactly once and never fetches the whole grid at once, and empty-batch skip still persists later non-empty batches. Existing empty-fetch / no-sites no-op guards preserved.

Chart bumped 0.285.2 -> 0.285.3 so the rebuilt jobs image + values deploy.