### PR TITLE
build(format): scope local prettier to code, not prose, to match CI

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -32,3 +32,19 @@
 # kept byte-identical to upstream so the vendored copy stays verifiable. Baked
 # into the goosecracker guest image at /opt/impeccable/.
 **/vendor/impeccable/**
+
+# Prose (Markdown) and YAML: Prettier owns CODE, not prose. The CI formatter
+# (//bazel/tools/format:format_code) wires prettier to the `javascript` language
+# slot ONLY, so CI never reformats .md or .yaml. The local fast-format.sh runs a
+# bare `prettier --write .`, which DOES cover prettier's default extensions incl.
+# Markdown and YAML, so a whole-repo local run reflowed hundreds of hand-written
+# ADRs/docs/READMEs and rule YAMLs that CI leaves untouched forever (emphasis
+# `*x*` -> `_x_`, blank-line-before-list, etc.), producing spurious churn a
+# contributor then has to hand-revert. Ignoring these here scopes local prettier
+# to match CI: prose is hand-written (see the repo's no-em-dash / minimal-churn
+# rules) and no CI check enforces its formatting. The specific generated .md/.json
+# entries above are kept as documentation of why those particular files are
+# generator-owned, even though this blanket rule now also covers the .md ones.
+**/*.md
+**/*.yaml
+**/*.yml


### PR DESCRIPTION
## Problem

Running the standalone `bazel/tools/format/fast-format.sh` over the whole repo (as the root `CLAUDE.md` Essential Commands suggest) reflows **dozens of hand-written Markdown and YAML files** (ADRs, docs, READMEs, semgrep rule YAMLs) that are non-conformant on `main` — forcing a contributor to hand-revert the spurious churn before committing an unrelated change. Hit this while shipping the stars-refresh OOM fix (#3187): the formatter touched 35 unrelated files.

## Root cause: a scope mismatch, not a version/config one

Both local and CI run prettier **3.8.1** with the same config. The divergence is *which files* each feeds to prettier:

- **CI** (`//bazel/tools/format:format_code`) is an `aspect_rules_lint` `format_multirun` that wires prettier to the **`javascript` language slot only**. aspect treats `markdown`/`yaml`/`json`/`css`/`html` as separate slots — none wired — so **CI never runs prettier on `.md` or `.yaml`.**
- **Local** `fast-format.sh` runs a bare `prettier --write .`, which covers prettier's default extensions **including Markdown and YAML**.

So local normalizes prose (`*x*` -> `_x_`, blank-line-before-list, etc.) that CI leaves untouched forever. Because CI only auto-commits the diff *it* produces, that prose drift accumulates silently on `main` and surfaces as churn the next time someone runs a whole-repo local format.

Proof it's CI-invisible: the churned files were last edited in March/June and have survived dozens of CI format runs still non-conformant.

## Fix

Ignore `.md` / `.yaml` / `.yml` in `.prettierignore` so local prettier is scoped to code like CI. Prettier honors `.prettierignore` for both `prettier --write .` **and** explicitly-listed staged files, so this covers the full-repo and the pre-commit (`--staged`) paths in one place.

Prose stays hand-written (the repo's no-em-dash and minimal-churn rules already treat it that way) and no CI check enforces its formatting, so nothing regresses.

## Verification

A full-repo `fast-format.sh` run now produces **zero** changes (only this `.prettierignore` edit) where it previously reflowed **35 files**.

### Alternative considered

Broadening CI to also format prose was rejected: it would mass-reflow every ADR/doc/README once (hundreds of files) and fight the repo's hand-written-prose ethos. Narrowing local to match CI is the low-churn, correct direction.