### PR TITLE
fix(grimoire): cap embedding input length to stop loader 500s

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.3
+version: 0.285.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.3
+      targetRevision: 0.285.5
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/grimoire/ingest.py
+++ b/projects/monolith/grimoire/ingest.py
@@ -63,6 +63,14 @@ EMBED_CHAR_BUDGET = (
     60000  # ~15k tokens, ~36s server-side, safe even under the default 60s read timeout
 )
 EMBED_MAX_BATCH = 64
+# Hard cap on a SINGLE text sent for embedding. The llama.cpp embedding server
+# rejects (HTTP 500) any input longer than its 8192-token slot, and dense table
+# chunks tokenize at roughly 2.5-3 chars/token, so 12000 chars keeps the worst
+# case comfortably inside the window. Applies to the embed INPUT only: the
+# stored chunk keeps its full content for retrieval. Seen live 2026-07-04:
+# 20k-47k char merged-table chunks (DMG'24 magic items, PHB'24 spell lists)
+# failed every grimoire-load-chunks run until capped.
+EMBED_INPUT_MAX_CHARS = 12000
 
 
 class _Embedder(Protocol):
@@ -435,7 +443,9 @@ async def load_chunks(
     # interrupted run leaves durable partial progress and the next run's
     # self-heal finishes the rest.
     for batch in _embed_batches(pending_embed, EMBED_CHAR_BUDGET, EMBED_MAX_BATCH):
-        vectors = await embed_client.embed_batch([row.content for row in batch])
+        vectors = await embed_client.embed_batch(
+            [(row.content or "")[:EMBED_INPUT_MAX_CHARS] for row in batch]
+        )
         chunks_embedded += upsert_embedding_batch(
             session, embed_client.model, "chunk", batch, vectors
         )

--- a/projects/monolith/grimoire/ingest_test.py
+++ b/projects/monolith/grimoire/ingest_test.py
@@ -69,9 +69,11 @@ class FakeEmbedClient:
 
     def __init__(self):
         self.calls = 0
+        self.texts_seen: list[str] = []
 
     async def embed_batch(self, texts: list[str]) -> list[list[float]]:
         self.calls += 1
+        self.texts_seen.extend(texts)
         return [[0.1] * 1024 for _ in texts]
 
 
@@ -177,6 +179,24 @@ def test_load_chunks_fresh_load_creates_chunks_and_embeddings(session: Session):
     assert {e.embeddable_kind for e in embeddings} == {"chunk"}
     assert {e.model for e in embeddings} == {"voyage-4-nano"}
     assert {e.dim for e in embeddings} == {1024}
+
+
+def test_load_chunks_truncates_oversized_embed_input(session: Session):
+    """A chunk longer than EMBED_INPUT_MAX_CHARS embeds a truncated input (the
+    llama.cpp server 500s past its token window) while the stored chunk keeps
+    its full content for retrieval."""
+    giant = "spell table row " * 3000  # 48k chars, like the PHB'24 spell lists
+    manifest = _line("c-giant", giant)
+    s3 = FakeS3Client({"books/phb/chunks/chunks.ndjson": manifest})
+    embedder = FakeEmbedClient()
+
+    summary = _run(ingest.load_chunks(session, s3, embedder, bucket="grimoire"))
+
+    assert summary["chunks_embedded"] == 1
+    assert len(embedder.texts_seen) == 1
+    assert len(embedder.texts_seen[0]) == ingest.EMBED_INPUT_MAX_CHARS
+    chunk = session.execute(select(KnowledgeChunk)).scalars().one()
+    assert len(chunk.content) == len(giant)
 
 
 def test_load_chunks_persists_image_ref_and_derives_book_id_from_path(


### PR DESCRIPTION
## Summary
- `grimoire-load-chunks` fails deterministically (HTTP 500 from `inference-embeddings`) on the newly uploaded sourcebooks: three merged-table chunks (DMG'24 magic items 35.8k chars, PHB'24 spell lists 46.8k, Sword Coast 20.4k) exceed the llama.cpp server's 8192-token slot.
- `_embed_batches` already yields an over-budget row alone (timeout protection) but nothing bounded a single input's length for the server's context window.
- Fix: truncate the embedding INPUT to `EMBED_INPUT_MAX_CHARS = 12000` at the embed callsite. Stored chunk content is untouched; retrieval still returns full text. Entity-name embeddings in extract.py are short and unaffected.
- Chart bumped to 0.285.5 so the jobs CronWorkflow image picks up the fix.

## Test plan
- [x] New `test_load_chunks_truncates_oversized_embed_input`: 48k-char chunk embeds a 12000-char input while the stored chunk keeps full content
- [ ] CI green, then re-run the loader Workflow and confirm all 9 new books embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)