### PR TITLE
fix(loom): disable chart NetworkPolicy, namespace is Linkerd-meshed

### DIFF
--- a/projects/loom/deploy/values.yaml
+++ b/projects/loom/deploy/values.yaml
@@ -63,3 +63,12 @@ postgres:
 
 objectStore:
   size: 5Gi
+
+# The cluster's Kyverno policy annotates every namespace linkerd.io/inject:
+# enabled, so loom pods are meshed. The chart's default-deny NetworkPolicy
+# blocks the linkerd-proxy's control-plane egress (linkerd-await times out,
+# PostStartHookError). Homelab convention: never combine K8s NetworkPolicies
+# with Linkerd-meshed namespaces; mTLS + Linkerd policy is the enforcement
+# layer here instead.
+networkPolicy:
+  enabled: false


### PR DESCRIPTION
Kyverno's inject-linkerd-namespace-annotation policy meshes every new namespace, and the loom chart's default-deny NetworkPolicy blocks the linkerd-proxy control-plane egress: linkerd-await exits 69 at its 120s timeout and both service pods sit in PostStartHookError.

One values line: networkPolicy.enabled=false. Meshed mTLS + Linkerd policy is the enforcement layer, per the repo convention of never combining K8s NetworkPolicies with Linkerd-meshed namespaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)