### PR TITLE
feat(loom): expose the loom web UI at private.jomcgi.dev/app/loom

### DIFF
--- a/projects/loom/deploy/httproute.yaml
+++ b/projects/loom/deploy/httproute.yaml
@@ -1,0 +1,63 @@
+# loom web UI + API on the private hostname, under /app/loom. The upstream
+# chart's HTTPRoute has no rewrite support, so this route is ours: the SPA
+# bundle is built same-origin-rooted, so the /app/loom prefix is stripped
+# before it reaches query-api, and values.yaml sets ui.apiBase=/app/loom so
+# the SPA prepends the prefix to its API calls (the chart mounts that as a
+# config.js override).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: loom-private
+  namespace: loom
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: cloudflare-ingress
+      namespace: envoy-gateway-system
+  hostnames:
+    - private.jomcgi.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /app/loom
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: loom-query-api
+          port: 8080
+---
+# Bare /app/loom (no trailing slash) must redirect to /app/loom/: the SPA's
+# index.html loads ./config.js and ./app.js relative to the page URL, so
+# without the slash the browser resolves them against /app/. Same pattern as
+# signoz-private-slash-redirect.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: loom-private-slash-redirect
+  namespace: loom
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: cloudflare-ingress
+      namespace: envoy-gateway-system
+  hostnames:
+    - private.jomcgi.dev
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /app/loom
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /app/loom/
+            statusCode: 301

--- a/projects/loom/deploy/kustomization.yaml
+++ b/projects/loom/deploy/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - argocd-repo-cred.yaml
   - image-pull-secret.yaml
   - serviceaccount.yaml
+  - httproute.yaml
   - application.yaml

--- a/projects/loom/deploy/values.yaml
+++ b/projects/loom/deploy/values.yaml
@@ -7,7 +7,7 @@
 
 ingest:
   image:
-    tag: sha-139e5c1
+    tag: sha-2acba02
     digest: ""
     pullPolicy: IfNotPresent
   resources:
@@ -19,7 +19,7 @@ ingest:
 
 queryApi:
   image:
-    tag: sha-139e5c1
+    tag: sha-2acba02
     digest: ""
     pullPolicy: IfNotPresent
   resources:
@@ -32,7 +32,7 @@ queryApi:
 # DataFusion serving engine (sidecar in the query-api pod).
 engine:
   image:
-    tag: sha-139e5c1
+    tag: sha-2acba02
     digest: ""
     pullPolicy: IfNotPresent
   resources:
@@ -63,6 +63,12 @@ postgres:
 
 objectStore:
   size: 5Gi
+
+# The UI rides private.jomcgi.dev/app/loom (httproute.yaml strips the prefix
+# before query-api); the SPA needs the prefix on its API calls, mounted as a
+# config.js override by the chart.
+ui:
+  apiBase: /app/loom
 
 # The cluster's Kyverno policy annotates every namespace linkerd.io/inject:
 # enabled, so loom pods are meshed. The chart's default-deny NetworkPolicy


### PR DESCRIPTION
Upstream loom now ships its wasm UI inside the query-api image and serves it when `LOOM_UI_DIR` is set (weave-hand/loom#368, merged as `2acba02`). This routes it on the private hostname:

- `httproute.yaml`: `/app/loom` PathPrefix with `ReplacePrefixMatch: /` (SPA bundle is origin-rooted; upstream chart route has no rewrite), plus the bare-path 301 to `/app/loom/` so `./config.js`/`./app.js` resolve (same pattern as `signoz-private-slash-redirect`)
- values: `ui.apiBase=/app/loom` (mounted as a config.js override by the new chart) and all three image tags bumped to `sha-2acba02`

Rendered the new chart against these values locally: `LOOM_UI_DIR`, the config.js subPath mount, and the tag pins all land. After merge the loom app needs a hard refresh (same-version `0.0.0-edge` chart re-publish) before sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)