### PR TITLE
feat(loom): move the Iceberg warehouse from local PVC to SeaweedFS S3

### DIFF
--- a/projects/loom/deploy/kustomization.yaml
+++ b/projects/loom/deploy/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
   - argocd-repo-cred.yaml
   - image-pull-secret.yaml
   - serviceaccount.yaml
+  - s3-credentials.yaml
   - httproute.yaml
   - application.yaml

--- a/projects/loom/deploy/s3-credentials.yaml
+++ b/projects/loom/deploy/s3-credentials.yaml
@@ -1,0 +1,14 @@
+# Dummy S3 credentials for the loom warehouse. The in-cluster SeaweedFS S3
+# gateway runs with no identity config (anonymous full access inside the
+# cluster), but the loom chart requires a credentials secret to reference, and
+# the AWS SDK wants non-empty keys to sign with. These values are not a
+# credential; SeaweedFS ignores them.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: loom-s3-credentials
+  namespace: loom
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: anonymous
+  AWS_SECRET_ACCESS_KEY: anonymous

--- a/projects/loom/deploy/values.yaml
+++ b/projects/loom/deploy/values.yaml
@@ -61,8 +61,20 @@ postgres:
   storage:
     size: 3Gi
 
+# Iceberg warehouse on the cluster SeaweedFS (s3://loom). The in-cluster S3
+# gateway runs without identities (anonymous), so the referenced secret
+# (s3-credentials.yaml) carries dummy keys purely to satisfy the chart's
+# required secretKeyRef. Enabling S3 drops the local PVC and the ingest/
+# query-api co-scheduling affinity; the previous loom-data PVC is retained by
+# the chart and can be deleted once the switch is verified.
 objectStore:
-  size: 5Gi
+  s3:
+    enabled: true
+    bucket: loom
+    endpoint: http://seaweedfs-s3.seaweedfs:8333
+    region: us-east-1
+    port: 8333
+    credentialsSecret: loom-s3-credentials
 
 # The UI rides private.jomcgi.dev/app/loom (httproute.yaml strips the prefix
 # before query-api); the SPA needs the prefix on its API calls, mounted as a


### PR DESCRIPTION
Switches loom's warehouse to `s3://loom` on the in-cluster SeaweedFS S3 gateway (`seaweedfs-s3.seaweedfs:8333`, anonymous like the other cluster buckets; bucket pre-created). The chart's S3 mode drops the local PVC and the RWO co-scheduling affinity, so ingest and query-api can spread across nodes.

- `loom-s3-credentials`: dummy keys, committed openly on purpose; SeaweedFS runs with no identities and the values only satisfy the chart's required secretKeyRef + SDK signing
- loss-free: `iceberg_mirror.data_file` is empty (all demo data is inline mirror rows in CNPG), nothing on the old PVC to migrate
- rendered against the current chart: warehouse URI/endpoint/creds on all three containers, no PVC, no podAffinity, UI config intact

Post-merge: sync, roll, then land an above-inline-threshold batch to prove real Parquet lands in the bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)