### PR TITLE
chore(loom): bump images to sha-6797f45 for the ingest HTTP body cap

### DIFF
--- a/projects/loom/deploy/values.yaml
+++ b/projects/loom/deploy/values.yaml
@@ -7,7 +7,7 @@
 
 ingest:
   image:
-    tag: sha-2acba02
+    tag: sha-6797f45
     digest: ""
     pullPolicy: IfNotPresent
   resources:
@@ -19,7 +19,7 @@ ingest:
 
 queryApi:
   image:
-    tag: sha-2acba02
+    tag: sha-6797f45
     digest: ""
     pullPolicy: IfNotPresent
   resources:
@@ -32,7 +32,7 @@ queryApi:
 # DataFusion serving engine (sidecar in the query-api pod).
 engine:
   image:
-    tag: sha-2acba02
+    tag: sha-6797f45
     digest: ""
     pullPolicy: IfNotPresent
   resources:


### PR DESCRIPTION
Picks up weave-hand/loom#371 (`LOOM_HTTP_MAX_BODY_BYTES`, default 64 MiB): above-inline-threshold Arrow IPC lands stop 413ing and reach the DataFusion Parquet path, so the SeaweedFS warehouse switch can be proven with a real write. Tag-only bump, all three images to the same main sha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)