### PR TITLE
chore(monolith): bump chart to redeploy jobs image with the embed cap

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.5
+version: 0.285.6
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.5
+      targetRevision: 0.285.6
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Chart 0.285.5 pins jobs image `2026.07.04.15.42.58-e499292`, built before d263cefa3 (the grimoire embed-input-cap fix) merged, so the fix is not live. The idempotent main publisher never re-pushes an existing version; this bump publishes 0.285.6 pinned to the current image. Root-cause investigation of how the stale pin happened is running separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)