### PR TITLE
fix(bazel): widen py3/go image .info closure so code changes bump charts

### DIFF
--- a/bazel/tools/oci/go_image.bzl
+++ b/bazel/tools/oci/go_image.bzl
@@ -180,10 +180,15 @@ def go_image(name, binary, base = "@distroless_base", repository = None, extra_t
         visibility = visibility,
     )
 
-    # Expose OciImageInfo provider for use by helm_chart(images = {...})
+    # Expose OciImageInfo provider for use by helm_chart(images = {...}).
+    # image is referenced so the chart-version bot's dependency closure reaches
+    # the application sources layered into the image (parity with apko_image);
+    # without it a go-only code change is invisible to both the PR auto-bump
+    # and the main-branch missed-bump guard.
     oci_image_info(
         name = name + ".info",
         repository = _repository,
         image_tags = name + "_stamped_ci.tags.txt",
+        image = ":" + name,
         visibility = ["//visibility:public"],
     )

--- a/bazel/tools/oci/py3_image.bzl
+++ b/bazel/tools/oci/py3_image.bzl
@@ -223,10 +223,16 @@ def py3_image(name, binary, main = None, root = "/", layer_groups = {}, env = {}
         visibility = visibility,
     )
 
-    # Expose OciImageInfo provider for use by helm_chart(images = {...})
+    # Expose OciImageInfo provider for use by helm_chart(images = {...}).
+    # image is referenced so the chart-version bot's dependency closure reaches
+    # the application sources layered into the image (parity with apko_image);
+    # without it a py-only code change is invisible to both the PR auto-bump
+    # and the main-branch missed-bump guard, and a merge deploys nothing
+    # (chart 0.285.5 / d263cefa3 incident, 2026-07-04).
     oci_image_info(
         name = name + ".info",
         repository = _repository,
         image_tags = name + "_stamped_ci.tags.txt",
+        image = ":" + name,
         visibility = ["//visibility:public"],
     )


### PR DESCRIPTION
## Summary
Root cause follow-up from today's grimoire loader incident. `apko_image` passes `image = ":" + name` to `oci_image_info` so the chart-version bot's `deps(chart.package)` closure reaches image content; `py3_image` and `go_image` did not. Consequence: a Python/Go-only code change is invisible to both the PR chart auto-bump and the main-branch missed-bump guard in `bazel/helm/push.sh.tpl`.

Today that gap combined with a chart-version collision: two PRs claimed 0.285.5; the other batch published it first; when d263cefa3 (the grimoire embed-input cap) rebase-merged, its bump became an empty diff and vanished; the guard checked the closure, saw nothing chart-relevant, and passed. Chart 0.285.5 shipped pinning the pre-fix jobs image and the fix silently didn't deploy (unblocked via #3200 / 0.285.6).

With this change, py3/go application sources join the closure, so the same mistake fails the Push images action loudly with the exact bump command (and the PR bot auto-bumps in the first place).

`providers.bzl` documents the attr as closure-widening only, not built into chart outputs, so no output changes are expected.

## Test plan
- [ ] CI: bazel analysis over //... validates the attr wiring
- [ ] After merge: next py-only monolith change without a bump should fail Push images loudly

🤖 Generated with [Claude Code](https://claude.com/claude-code)