### PR TITLE
feat(chat): catch-up and decisions-extraction tools (ADR 043 Phase 1)

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -861,6 +861,19 @@ py_test(
 )
 
 py_test(
+    name = "chat_store_fetch_window_test",
+    srcs = ["chat/store_fetch_window_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "chat_outbox_test",
     srcs = ["chat/outbox_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1687,6 +1687,20 @@ py_test(
 )
 
 py_test(
+    name = "chat_agent_channel_digest_tool_test",
+    srcs = ["chat/agent_channel_digest_tool_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pydantic_ai_slim",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "chat_bot_attachments_test",
     srcs = ["chat/bot_attachments_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -874,6 +874,18 @@ py_test(
 )
 
 py_test(
+    name = "chat_digest_test",
+    srcs = ["chat/digest_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
     name = "chat_outbox_test",
     srcs = ["chat/outbox_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.7
+version: 0.285.8
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -385,10 +385,14 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
         window = deps.store.fetch_window(deps.channel_id)
         if not window:
             return "Nothing to summarize yet -- this channel doesn't have any messages."
-        from chat.summarizer import build_llm_caller
+        try:
+            from chat.summarizer import build_llm_caller
 
-        caller = build_llm_caller()
-        return await digest_window(window, "summary", caller)
+            caller = build_llm_caller()
+            return await digest_window(window, "summary", caller)
+        except Exception:
+            logger.exception("catch_up: digest failed")
+            return "Summarizing isn't available right now."
 
     @agent.tool
     @signposted(
@@ -403,10 +407,14 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
         window = deps.store.fetch_window(deps.channel_id)
         if not window:
             return "Nothing to extract yet -- this channel doesn't have any messages."
-        from chat.summarizer import build_llm_caller
+        try:
+            from chat.summarizer import build_llm_caller
 
-        caller = build_llm_caller()
-        return await digest_window(window, "decisions", caller)
+            caller = build_llm_caller()
+            return await digest_window(window, "decisions", caller)
+        except Exception:
+            logger.exception("extract_decisions: digest failed")
+            return "Decision extraction isn't available right now."
 
     @agent.tool
     @signposted(

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -144,6 +144,8 @@ def build_system_prompt() -> str:
         "what's known about the people here.\n"
         "- Adjust how you behave for the whole channel or just for one person "
         "when asked.\n"
+        "- Catch someone up on this channel, or pull out the decisions and "
+        "action items from it, when asked.\n"
         "- Kick off an agent thread for heavier work, which runs in an "
         "isolated sandbox and reports back in the thread. It can investigate a "
         "repo or the cluster and answer questions about it, turn a request "
@@ -152,6 +154,15 @@ def build_system_prompt() -> str:
         "live web artifact (a visualization, page, or interactive tool). When "
         "someone wants any of that, start the thread rather than trying to do "
         "it yourself inline.\n\n"
+        "CATCHING UP:\n"
+        "- If someone asks to be caught up, wants a recap, or asks "
+        'something like "what happened here" or "summarize this thread," '
+        "use catch_up.\n"
+        "- If someone asks what was decided, wants action items, or is "
+        "asking about open questions, use extract_decisions instead.\n"
+        "- Both tools lead with a coverage line stating how many messages "
+        "they covered and how far back -- always fold that into your reply "
+        "so nobody thinks you saw more of the conversation than you did.\n\n"
         "DO:\n"
         "- Answer directly. Lead with the useful answer, not preamble.\n"
         "- Match the vibe of the conversation. Be chill, funny, or serious "
@@ -360,6 +371,42 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
             f"(updated {summary.updated_at.strftime('%Y-%m-%d')}):\n"
             f"{summary.summary}"
         )
+
+    @agent.tool
+    @signposted(
+        "When someone asks to be caught up, wants a recap, or asks "
+        'something like "what happened here" or "summarize this thread".'
+    )
+    async def catch_up(ctx: RunContext[ChatDeps]) -> str:
+        """Summarize the recent conversation in this channel."""
+        from chat.digest import digest_window
+
+        deps = ctx.deps
+        window = deps.store.fetch_window(deps.channel_id)
+        if not window:
+            return "Nothing to summarize yet -- this channel doesn't have any messages."
+        from chat.summarizer import build_llm_caller
+
+        caller = build_llm_caller()
+        return await digest_window(window, "summary", caller)
+
+    @agent.tool
+    @signposted(
+        "When someone asks what was decided, wants action items, or asks "
+        "about open questions from this channel."
+    )
+    async def extract_decisions(ctx: RunContext[ChatDeps]) -> str:
+        """Pull decisions, action items, and open questions out of this channel."""
+        from chat.digest import digest_window
+
+        deps = ctx.deps
+        window = deps.store.fetch_window(deps.channel_id)
+        if not window:
+            return "Nothing to extract yet -- this channel doesn't have any messages."
+        from chat.summarizer import build_llm_caller
+
+        caller = build_llm_caller()
+        return await digest_window(window, "decisions", caller)
 
     @agent.tool
     @signposted(

--- a/projects/monolith/chat/agent_channel_digest_tool_test.py
+++ b/projects/monolith/chat/agent_channel_digest_tool_test.py
@@ -1,0 +1,272 @@
+"""Tests for the catch_up and extract_decisions tool bodies via FunctionModel.
+
+Drives the actual tool execution paths (not just registration), mirroring
+agent_tool_execution_test.py. build_llm_caller is faked by patching
+chat.summarizer.build_llm_caller -- the same seam summarizer_startup_test.py
+uses -- rather than adding an injectable parameter, since any parameter on a
+@agent.tool function past RunContext is exposed in the tool's JSON schema to
+the LLM.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart, ToolReturnPart
+from pydantic_ai.models.function import FunctionModel
+
+from chat.agent import ChatDeps, create_agent
+from chat.models import Message
+
+
+def _make_deps(store: MagicMock, channel_id: str = "ch1") -> ChatDeps:
+    return ChatDeps(channel_id=channel_id, store=store, embed_client=AsyncMock())
+
+
+def _make_message(
+    *, username: str, content: str, minutes_ago: int, base: datetime
+) -> Message:
+    return Message(
+        discord_message_id=f"{minutes_ago}",
+        channel_id="ch1",
+        user_id=username.lower(),
+        username=username,
+        content=content,
+        is_bot=False,
+        embedding=[],
+        created_at=base - timedelta(minutes=minutes_ago),
+    )
+
+
+def _tool_once_then_done(tool_name: str) -> FunctionModel:
+    """Call the named tool with no args, then finish once it returns."""
+
+    def model_func(messages, info):  # type: ignore[type-arg]
+        for msg in messages:
+            if hasattr(msg, "parts"):
+                for part in msg.parts:
+                    if isinstance(part, ToolReturnPart):
+                        return ModelResponse(parts=[TextPart("done")])
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name=tool_name, args={}, tool_call_id="call-1")]
+        )
+
+    return FunctionModel(model_func)
+
+
+async def _run_tool_capturing_return(agent, tool_name: str, deps: ChatDeps) -> str:
+    captured = []
+
+    def model_func(messages, info):  # type: ignore[type-arg]
+        for msg in messages:
+            if hasattr(msg, "parts"):
+                for part in msg.parts:
+                    if isinstance(part, ToolReturnPart):
+                        captured.append(part.content)
+                        return ModelResponse(parts=[TextPart("done")])
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name=tool_name, args={}, tool_call_id="call-1")]
+        )
+
+    await agent.run("go", model=FunctionModel(model_func), deps=deps)
+    assert len(captured) == 1
+    return captured[0]
+
+
+@pytest.fixture
+def base_time():
+    return datetime(2026, 7, 4, 12, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# catch_up -- empty window short-circuits without building a caller
+# ---------------------------------------------------------------------------
+
+
+class TestCatchUpEmptyWindow:
+    @pytest.mark.asyncio
+    async def test_returns_nothing_to_summarize_without_building_caller(self):
+        store = MagicMock()
+        store.fetch_window.return_value = []
+        deps = _make_deps(store)
+        agent = create_agent(base_url="http://fake:8080")
+
+        with patch("chat.summarizer.build_llm_caller") as mock_build:
+            result = await _run_tool_capturing_return(agent, "catch_up", deps)
+
+        assert (
+            result
+            == "Nothing to summarize yet -- this channel doesn't have any messages."
+        )
+        mock_build.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fetches_window_for_the_channel(self):
+        store = MagicMock()
+        store.fetch_window.return_value = []
+        deps = _make_deps(store, channel_id="my-chan")
+        agent = create_agent(base_url="http://fake:8080")
+
+        with patch("chat.summarizer.build_llm_caller"):
+            await agent.run(
+                "catch me up",
+                model=_tool_once_then_done("catch_up"),
+                deps=deps,
+            )
+
+        store.fetch_window.assert_called_once_with("my-chan")
+
+
+# ---------------------------------------------------------------------------
+# catch_up -- non-empty window digests via the summary mode
+# ---------------------------------------------------------------------------
+
+
+class TestCatchUpNonEmptyWindow:
+    @pytest.mark.asyncio
+    async def test_returns_digest_output_with_coverage_line(self, base_time):
+        messages = [
+            _make_message(
+                username="Alice",
+                content="we should ship Friday",
+                minutes_ago=5,
+                base=base_time,
+            ),
+            _make_message(
+                username="Bob",
+                content="agreed, sounds good",
+                minutes_ago=1,
+                base=base_time,
+            ),
+        ]
+        store = MagicMock()
+        store.fetch_window.return_value = messages
+        deps = _make_deps(store)
+        agent = create_agent(base_url="http://fake:8080")
+
+        fake_caller = AsyncMock(return_value="They agreed to ship on Friday.")
+
+        with patch("chat.summarizer.build_llm_caller", return_value=fake_caller):
+            result = await _run_tool_capturing_return(agent, "catch_up", deps)
+
+        assert "(window: 2 messages, back to " in result
+        assert "They agreed to ship on Friday." in result
+        fake_caller.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_uses_summary_prompt_not_decisions_prompt(self, base_time):
+        messages = [
+            _make_message(
+                username="Alice", content="hello there", minutes_ago=1, base=base_time
+            ),
+        ]
+        store = MagicMock()
+        store.fetch_window.return_value = messages
+        deps = _make_deps(store)
+        agent = create_agent(base_url="http://fake:8080")
+
+        fake_caller = AsyncMock(return_value="summary text")
+
+        with patch("chat.summarizer.build_llm_caller", return_value=fake_caller):
+            await _run_tool_capturing_return(agent, "catch_up", deps)
+
+        prompt = fake_caller.call_args.args[0]
+        assert "Summarize the following Discord conversation window" in prompt
+        assert "Decisions" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# extract_decisions -- empty window short-circuits without building a caller
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDecisionsEmptyWindow:
+    @pytest.mark.asyncio
+    async def test_returns_nothing_to_extract_without_building_caller(self):
+        store = MagicMock()
+        store.fetch_window.return_value = []
+        deps = _make_deps(store)
+        agent = create_agent(base_url="http://fake:8080")
+
+        with patch("chat.summarizer.build_llm_caller") as mock_build:
+            result = await _run_tool_capturing_return(agent, "extract_decisions", deps)
+
+        assert (
+            result
+            == "Nothing to extract yet -- this channel doesn't have any messages."
+        )
+        mock_build.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fetches_window_for_the_channel(self):
+        store = MagicMock()
+        store.fetch_window.return_value = []
+        deps = _make_deps(store, channel_id="my-chan")
+        agent = create_agent(base_url="http://fake:8080")
+
+        with patch("chat.summarizer.build_llm_caller"):
+            await agent.run(
+                "what did we decide",
+                model=_tool_once_then_done("extract_decisions"),
+                deps=deps,
+            )
+
+        store.fetch_window.assert_called_once_with("my-chan")
+
+
+# ---------------------------------------------------------------------------
+# extract_decisions -- non-empty window digests via the decisions mode
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDecisionsNonEmptyWindow:
+    @pytest.mark.asyncio
+    async def test_returns_digest_output_with_coverage_line(self, base_time):
+        messages = [
+            _make_message(
+                username="Alice",
+                content="let's ship Friday",
+                minutes_ago=5,
+                base=base_time,
+            ),
+            _make_message(
+                username="Bob",
+                content="I'll write the release notes",
+                minutes_ago=1,
+                base=base_time,
+            ),
+        ]
+        store = MagicMock()
+        store.fetch_window.return_value = messages
+        deps = _make_deps(store)
+        agent = create_agent(base_url="http://fake:8080")
+
+        fake_caller = AsyncMock(return_value="Decisions: ship Friday.")
+
+        with patch("chat.summarizer.build_llm_caller", return_value=fake_caller):
+            result = await _run_tool_capturing_return(agent, "extract_decisions", deps)
+
+        assert "(window: 2 messages, back to " in result
+        assert "Decisions: ship Friday." in result
+        fake_caller.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_uses_decisions_prompt_not_summary_prompt(self, base_time):
+        messages = [
+            _make_message(
+                username="Alice", content="hello there", minutes_ago=1, base=base_time
+            ),
+        ]
+        store = MagicMock()
+        store.fetch_window.return_value = messages
+        deps = _make_deps(store)
+        agent = create_agent(base_url="http://fake:8080")
+
+        fake_caller = AsyncMock(return_value="decisions text")
+
+        with patch("chat.summarizer.build_llm_caller", return_value=fake_caller):
+            await _run_tool_capturing_return(agent, "extract_decisions", deps)
+
+        prompt = fake_caller.call_args.args[0]
+        assert "extract three" in prompt
+        assert "Decisions, Action Items, and Open Questions" in prompt

--- a/projects/monolith/chat/agent_channel_digest_tool_test.py
+++ b/projects/monolith/chat/agent_channel_digest_tool_test.py
@@ -176,6 +176,33 @@ class TestCatchUpNonEmptyWindow:
 
 
 # ---------------------------------------------------------------------------
+# catch_up -- fails open when the model caller errors
+# ---------------------------------------------------------------------------
+
+
+class TestCatchUpCallerFails:
+    @pytest.mark.asyncio
+    async def test_returns_failure_string_instead_of_raising(self, base_time):
+        messages = [
+            _make_message(
+                username="Alice", content="hello there", minutes_ago=1, base=base_time
+            ),
+        ]
+        store = MagicMock()
+        store.fetch_window.return_value = messages
+        deps = _make_deps(store)
+        agent = create_agent(base_url="http://fake:8080")
+
+        with patch(
+            "chat.summarizer.build_llm_caller",
+            side_effect=RuntimeError("model unreachable"),
+        ):
+            result = await _run_tool_capturing_return(agent, "catch_up", deps)
+
+        assert result == "Summarizing isn't available right now."
+
+
+# ---------------------------------------------------------------------------
 # extract_decisions -- empty window short-circuits without building a caller
 # ---------------------------------------------------------------------------
 
@@ -270,3 +297,30 @@ class TestExtractDecisionsNonEmptyWindow:
         prompt = fake_caller.call_args.args[0]
         assert "extract three" in prompt
         assert "Decisions, Action Items, and Open Questions" in prompt
+
+
+# ---------------------------------------------------------------------------
+# extract_decisions -- fails open when the model caller errors
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDecisionsCallerFails:
+    @pytest.mark.asyncio
+    async def test_returns_failure_string_instead_of_raising(self, base_time):
+        messages = [
+            _make_message(
+                username="Alice", content="hello there", minutes_ago=1, base=base_time
+            ),
+        ]
+        store = MagicMock()
+        store.fetch_window.return_value = messages
+        deps = _make_deps(store)
+        agent = create_agent(base_url="http://fake:8080")
+
+        with patch(
+            "chat.summarizer.build_llm_caller",
+            side_effect=RuntimeError("model unreachable"),
+        ):
+            result = await _run_tool_capturing_return(agent, "extract_decisions", deps)
+
+        assert result == "Decision extraction isn't available right now."

--- a/projects/monolith/chat/attention.py
+++ b/projects/monolith/chat/attention.py
@@ -114,7 +114,10 @@ async def needs_agent(message, *, _caller=None) -> bool:
             "build or generate an artifact/page, or do thorough multi-source "
             'research. Answer "chat" for conversation, general knowledge, '
             "or a simple factual question (a basic web lookup is fine in "
-            "chat). Reply with ONLY a JSON object: "
+            "chat). Summarizing this conversation, catching up on channel "
+            "history, or extracting decisions or action items from it is "
+            'also "chat", not "agent": the chat agent already has tools '
+            "for that. Reply with ONLY a JSON object: "
             '{"needs_agent": true|false}. Message: ' + text
         )
         raw = await caller(prompt)

--- a/projects/monolith/chat/attention_test.py
+++ b/projects/monolith/chat/attention_test.py
@@ -172,3 +172,29 @@ class TestNeedsAgent:
         caller = AsyncMock(return_value='sure! {"needs_agent": true} ok')
         result = await needs_agent(message, _caller=caller)
         assert result is True
+
+    @pytest.mark.asyncio
+    async def test_prompt_keeps_channel_summarization_on_chat(self):
+        """The chat agent now has catch_up/extract_decisions tools (Task 1.3):
+        summarizing this conversation or pulling decisions/action items out of
+        channel history must stay "chat", not route to the heavy agent."""
+        message = _make_message(content="can you summarize this thread?")
+        caller = AsyncMock(return_value='{"needs_agent": false}')
+        await needs_agent(message, _caller=caller)
+        prompt = caller.call_args[0][0].lower()
+        assert "summarizing this conversation" in prompt
+        assert "catching up" in prompt
+        assert "channel history" in prompt
+        assert "decisions" in prompt
+        assert "action items" in prompt
+
+    @pytest.mark.asyncio
+    async def test_prompt_still_mentions_repo_artifact_and_research(self):
+        """Additive change: the existing depth-classify wording must survive."""
+        message = _make_message(content="anything")
+        caller = AsyncMock(return_value='{"needs_agent": false}')
+        await needs_agent(message, _caller=caller)
+        prompt = caller.call_args[0][0].lower()
+        assert "repository/codebase" in prompt
+        assert "artifact/page" in prompt
+        assert "thorough multi-source" in prompt

--- a/projects/monolith/chat/digest.py
+++ b/projects/monolith/chat/digest.py
@@ -1,0 +1,162 @@
+"""Chunked window digest -- summary and decisions modes over a message window.
+
+Pure: takes messages and an injectable async LLM caller, returns a string. No
+Discord or DB imports, so it needs no session fixture to test. Callers own
+fetching the window (chat.store.MessageStore.fetch_window) and building the
+caller (chat.summarizer.build_llm_caller); this module only formats and
+prompts.
+"""
+
+from collections.abc import Awaitable, Callable
+
+from chat.models import Message
+
+# Budget per LLM call, in formatted-text characters. A window under this goes
+# out in a single call; a bigger window is split into chunks each under this
+# budget, summarized independently, then combined with one reduce call.
+_CHUNK_CHARS = 8000
+
+_EMPTY_WINDOW_TEXT = "No messages in the window."
+
+_SUMMARY_SINGLE_PROMPT = (
+    "Summarize the following Discord conversation window in 3-6 concise "
+    "sentences, covering the main topics discussed and any notable "
+    "outcomes. No preamble, no markdown headers.\n\n"
+    "Messages:\n{messages}"
+)
+
+_SUMMARY_CHUNK_PROMPT = (
+    "Summarize this excerpt from a longer Discord conversation in 2-4 "
+    "concise sentences, capturing the key topics and outcomes. This is one "
+    "piece of a longer window that will be combined with other pieces "
+    "later: no preamble, do not refer to it as an excerpt.\n\n"
+    "Messages:\n{messages}"
+)
+
+_SUMMARY_REDUCE_PROMPT = (
+    "The following are summaries of consecutive pieces of a longer Discord "
+    "conversation, in chronological order. Combine them into one coherent "
+    "3-6 sentence summary of the overall conversation. Do not summarize "
+    "each piece separately or refer to them as pieces.\n\n"
+    "Piece summaries:\n{chunks}"
+)
+
+_DECISIONS_SINGLE_PROMPT = (
+    "Review the following Discord conversation window and extract three "
+    "things: decisions that were made, action items (noting who said "
+    "them), and open questions that were raised but never resolved. If you "
+    "cannot tell who is responsible for a decision or action item, leave it "
+    "unattributed rather than guessing. Reply with short bullet points "
+    "under the headings Decisions, Action Items, and Open Questions; omit a "
+    "heading entirely if it has nothing to report.\n\n"
+    "Messages:\n{messages}"
+)
+
+_DECISIONS_CHUNK_PROMPT = (
+    "Review this excerpt from a longer Discord conversation and extract any "
+    "decisions, action items (noting who said them), and open questions. If "
+    "you cannot tell who is responsible for a decision or action item, "
+    "leave it unattributed rather than guessing. This is one piece of a "
+    "longer window that will be combined with other pieces later: no "
+    "preamble.\n\n"
+    "Messages:\n{messages}"
+)
+
+_DECISIONS_REDUCE_PROMPT = (
+    "The following are decisions, action items, and open questions "
+    "extracted from consecutive pieces of a longer Discord conversation, in "
+    "chronological order. Combine and deduplicate them into one list under "
+    "the headings Decisions, Action Items, and Open Questions. Keep the "
+    "attributions given; leave an item unattributed rather than guessing "
+    "who is responsible. Omit a heading entirely if it has nothing to "
+    "report.\n\n"
+    "Extracted pieces:\n{chunks}"
+)
+
+_MODE_PROMPTS = {
+    "summary": {
+        "single": _SUMMARY_SINGLE_PROMPT,
+        "chunk": _SUMMARY_CHUNK_PROMPT,
+        "reduce": _SUMMARY_REDUCE_PROMPT,
+    },
+    "decisions": {
+        "single": _DECISIONS_SINGLE_PROMPT,
+        "chunk": _DECISIONS_CHUNK_PROMPT,
+        "reduce": _DECISIONS_REDUCE_PROMPT,
+    },
+}
+
+
+def _format_lines(messages: list[Message]) -> list[str]:
+    return [
+        f"[{m.created_at.strftime('%H:%M')}] {m.username}: {m.content}"
+        for m in messages
+    ]
+
+
+def _chunk_lines(lines: list[str], chunk_chars: int) -> list[list[str]]:
+    """Group lines into consecutive chunks each under chunk_chars, in order.
+
+    A single line longer than chunk_chars still gets its own chunk (never
+    dropped), mirroring MessageStore.fetch_window's newest-always-kept rule.
+    """
+    chunks: list[list[str]] = []
+    current: list[str] = []
+    current_chars = 0
+    for line in lines:
+        line_chars = len(line) + 1  # +1 for the joining newline
+        if current and current_chars + line_chars > chunk_chars:
+            chunks.append(current)
+            current = []
+            current_chars = 0
+        current.append(line)
+        current_chars += line_chars
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _reduce_chunks_text(partials: list[str]) -> str:
+    return "\n\n".join(
+        f"--- Piece {i + 1} ---\n{partial}" for i, partial in enumerate(partials)
+    )
+
+
+async def digest_window(
+    messages: list[Message],
+    mode: str,
+    caller: Callable[[str], Awaitable[str]],
+) -> str:
+    """Digest a message window into a summary or a decisions/action-items/
+    open-questions report, chunking the prompt when the window is large.
+
+    ``messages`` must be chronological oldest-first (fetch_window's contract).
+    The returned string always leads with a coverage line stating how many
+    messages were in the window and how far back it reached, so a caller
+    relaying this to a user can never silently understate what was covered.
+    """
+    if mode not in _MODE_PROMPTS:
+        raise ValueError(f"unknown digest mode: {mode!r}")
+    if not messages:
+        return _EMPTY_WINDOW_TEXT
+
+    prompts = _MODE_PROMPTS[mode]
+    coverage = (
+        f"(window: {len(messages)} messages, "
+        f"back to {messages[0].created_at.isoformat()})"
+    )
+
+    lines = _format_lines(messages)
+    full_text = "\n".join(lines)
+
+    if len(full_text) <= _CHUNK_CHARS:
+        body = await caller(prompts["single"].format(messages=full_text))
+        return f"{coverage}\n\n{body}"
+
+    chunks = _chunk_lines(lines, _CHUNK_CHARS)
+    partials = [
+        await caller(prompts["chunk"].format(messages="\n".join(chunk)))
+        for chunk in chunks
+    ]
+    body = await caller(prompts["reduce"].format(chunks=_reduce_chunks_text(partials)))
+    return f"{coverage}\n\n{body}"

--- a/projects/monolith/chat/digest_test.py
+++ b/projects/monolith/chat/digest_test.py
@@ -1,0 +1,160 @@
+"""Tests for chat.digest -- chunked window digest (summary/decisions modes)."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from chat.digest import digest_window
+from chat.models import Message
+
+
+class _FakeCaller:
+    """Records every prompt it is called with; returns canned responses in
+    order, falling back to a labelled placeholder once they run out."""
+
+    def __init__(self, responses: list[str] | None = None):
+        self.prompts: list[str] = []
+        self._responses = list(responses) if responses is not None else None
+
+    async def __call__(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        if self._responses:
+            return self._responses.pop(0)
+        return f"response-{len(self.prompts)}"
+
+
+def _make_message(
+    *, username: str, content: str, minutes_ago: int, base: datetime
+) -> Message:
+    return Message(
+        discord_message_id=f"{minutes_ago}",
+        channel_id="ch1",
+        user_id=username.lower(),
+        username=username,
+        content=content,
+        is_bot=False,
+        embedding=[],
+        created_at=base - timedelta(minutes=minutes_ago),
+    )
+
+
+@pytest.fixture
+def base_time():
+    return datetime(2026, 7, 4, 12, 0, tzinfo=timezone.utc)
+
+
+class TestEmptyWindow:
+    @pytest.mark.asyncio
+    async def test_empty_messages_returns_plain_string_without_calling_caller(self):
+        caller = _FakeCaller()
+        result = await digest_window([], "summary", caller)
+        assert result == "No messages in the window."
+        assert caller.prompts == []
+
+
+class TestSingleCallWindow:
+    @pytest.mark.asyncio
+    async def test_formats_messages_as_time_username_content_lines(self, base_time):
+        messages = [
+            _make_message(
+                username="Alice", content="hello there", minutes_ago=5, base=base_time
+            ),
+            _make_message(
+                username="Bob", content="hi back", minutes_ago=1, base=base_time
+            ),
+        ]
+        caller = _FakeCaller()
+        await digest_window(messages, "summary", caller)
+        assert len(caller.prompts) == 1
+        prompt = caller.prompts[0]
+        assert "[11:55] Alice: hello there" in prompt
+        assert "[11:59] Bob: hi back" in prompt
+
+    @pytest.mark.asyncio
+    async def test_window_under_budget_makes_exactly_one_call(self, base_time):
+        messages = [
+            _make_message(
+                username="Alice", content=f"msg {i}", minutes_ago=i, base=base_time
+            )
+            for i in range(10)
+        ]
+        caller = _FakeCaller()
+        await digest_window(messages, "summary", caller)
+        assert len(caller.prompts) == 1
+
+    @pytest.mark.asyncio
+    async def test_returned_string_starts_with_coverage_line(self, base_time):
+        messages = [
+            _make_message(
+                username="Alice", content="a", minutes_ago=30, base=base_time
+            ),
+            _make_message(username="Bob", content="b", minutes_ago=0, base=base_time),
+        ]
+        caller = _FakeCaller(responses=["the digest body"])
+        result = await digest_window(messages, "summary", caller)
+        oldest_iso = messages[0].created_at.isoformat()
+        assert result.startswith(f"(window: 2 messages, back to {oldest_iso})")
+        assert "the digest body" in result
+
+
+class TestChunkedWindow:
+    @pytest.mark.asyncio
+    async def test_large_window_chunks_then_reduces_with_one_final_call(
+        self, base_time
+    ):
+        # Each line is ~3015 chars. The first two together (~6032) fit under the
+        # 8000-char chunk budget, but the third pushes past it, so this splits
+        # into exactly two chunks (2 messages, then 1) plus one reduce call.
+        messages = [
+            _make_message(
+                username="Alice", content="x" * 3000, minutes_ago=i, base=base_time
+            )
+            for i in range(3)
+        ]
+        caller = _FakeCaller(
+            responses=["chunk summary one", "chunk summary two", "final digest"]
+        )
+        result = await digest_window(messages, "summary", caller)
+
+        # 2 chunk calls + 1 reduce call.
+        assert len(caller.prompts) == 3
+        reduce_prompt = caller.prompts[-1]
+        assert "chunk summary one" in reduce_prompt
+        assert "chunk summary two" in reduce_prompt
+        assert "final digest" in result
+
+
+class TestDecisionsMode:
+    @pytest.mark.asyncio
+    async def test_prompt_asks_for_decisions_actions_and_open_questions(
+        self, base_time
+    ):
+        messages = [
+            _make_message(
+                username="Alice",
+                content="let's ship it Friday",
+                minutes_ago=1,
+                base=base_time,
+            )
+        ]
+        caller = _FakeCaller()
+        await digest_window(messages, "decisions", caller)
+        prompt = caller.prompts[0]
+        assert "decisions" in prompt.lower()
+        assert "action item" in prompt.lower()
+        assert "who" in prompt.lower()
+        assert "open question" in prompt.lower()
+        assert "unattributed" in prompt.lower()
+        assert "guess" in prompt.lower()
+
+
+class TestInvalidMode:
+    @pytest.mark.asyncio
+    async def test_unknown_mode_raises_without_calling_caller(self, base_time):
+        messages = [
+            _make_message(username="Alice", content="hi", minutes_ago=0, base=base_time)
+        ]
+        caller = _FakeCaller()
+        with pytest.raises(ValueError):
+            await digest_window(messages, "bogus", caller)
+        assert caller.prompts == []

--- a/projects/monolith/chat/store.py
+++ b/projects/monolith/chat/store.py
@@ -205,6 +205,40 @@ class MessageStore:
         messages.reverse()
         return messages
 
+    def fetch_window(
+        self,
+        channel_id: str,
+        *,
+        max_messages: int = 300,
+        max_chars: int = 30_000,
+    ) -> list[Message]:
+        """Return a bounded chronological (oldest first) window for one channel.
+
+        Feeds summarization tools that need honest caps: walks newest-first,
+        stopping at whichever cap (message count or cumulative content chars)
+        is hit first, then reverses to chronological order. The newest message
+        is always kept even if its content alone exceeds max_chars, so a
+        non-empty channel never yields an empty window.
+        """
+        stmt = (
+            select(Message)
+            .where(Message.channel_id == channel_id)
+            .order_by(Message.created_at.desc())
+            .limit(max_messages)
+        )
+        newest_first = list(self.session.exec(stmt).all())
+
+        window: list[Message] = []
+        total_chars = 0
+        for msg in newest_first:
+            total_chars += len(msg.content)
+            if total_chars > max_chars and window:
+                break
+            window.append(msg)
+
+        window.reverse()
+        return window
+
     def search_similar(
         self,
         channel_id: str,

--- a/projects/monolith/chat/store_fetch_window_test.py
+++ b/projects/monolith/chat/store_fetch_window_test.py
@@ -1,0 +1,135 @@
+"""Tests for MessageStore.fetch_window -- bounded chronological channel window."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from chat.store import MessageStore
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    """In-memory SQLite session (schema-stripped for SQLite compat)."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+    for table in SQLModel.metadata.tables.values():
+        if table.name in original_schemas:
+            table.schema = original_schemas[table.name]
+
+
+@pytest.fixture
+def store(session):
+    embed_client = AsyncMock()
+    embed_client.embed_batch.return_value = [[0.0] * 1024]
+    return MessageStore(session=session, embed_client=embed_client)
+
+
+class TestFetchWindow:
+    @pytest.mark.asyncio
+    async def test_empty_channel_returns_empty_list(self, store):
+        """A channel with no messages returns an empty list."""
+        assert store.fetch_window("nochannel") == []
+
+    @pytest.mark.asyncio
+    async def test_returns_chronological_order(self, store):
+        """Messages come back oldest first."""
+        for i in range(5):
+            await store.save_message(
+                discord_message_id=str(i),
+                channel_id="ch1",
+                user_id="u1",
+                username="Alice",
+                content=f"msg {i}",
+                is_bot=False,
+            )
+        window = store.fetch_window("ch1")
+        assert [m.content for m in window] == [f"msg {i}" for i in range(5)]
+
+    @pytest.mark.asyncio
+    async def test_filters_by_channel(self, store):
+        """Only messages from the requested channel are returned; others never leak."""
+        await store.save_message("a", "ch1", "u1", "Alice", "in ch1", False)
+        await store.save_message("b", "ch2", "u1", "Alice", "in ch2", False)
+        window = store.fetch_window("ch1")
+        assert len(window) == 1
+        assert window[0].content == "in ch1"
+
+    @pytest.mark.asyncio
+    async def test_max_messages_caps_and_keeps_newest(self, store):
+        """When max_messages is hit first, the oldest messages are dropped."""
+        for i in range(10):
+            await store.save_message(
+                discord_message_id=str(i),
+                channel_id="ch1",
+                user_id="u1",
+                username="Alice",
+                content=f"msg {i}",
+                is_bot=False,
+            )
+        window = store.fetch_window("ch1", max_messages=3)
+        assert [m.content for m in window] == ["msg 7", "msg 8", "msg 9"]
+
+    @pytest.mark.asyncio
+    async def test_max_chars_caps_and_keeps_newest(self, store):
+        """When max_chars is hit first, the oldest messages are dropped."""
+        # Each message is exactly 10 chars; a cap of 25 keeps only the newest
+        # 2 (20 chars), since a 3rd would push the total to 30 and cross it.
+        for i in range(5):
+            await store.save_message(
+                discord_message_id=str(i),
+                channel_id="ch1",
+                user_id="u1",
+                username="Alice",
+                content=f"{i:010d}",
+                is_bot=False,
+            )
+        window = store.fetch_window("ch1", max_messages=300, max_chars=25)
+        assert [m.content for m in window] == ["0000000003", "0000000004"]
+
+    @pytest.mark.asyncio
+    async def test_max_chars_always_returns_newest_even_if_it_alone_exceeds_cap(
+        self, store
+    ):
+        """The newest message is always included even if its length alone crosses
+        max_chars, so a non-empty channel never returns an empty window."""
+        await store.save_message(
+            discord_message_id="1",
+            channel_id="ch1",
+            user_id="u1",
+            username="Alice",
+            content="x" * 50,
+            is_bot=False,
+        )
+        window = store.fetch_window("ch1", max_chars=10)
+        assert len(window) == 1
+        assert window[0].content == "x" * 50
+
+    @pytest.mark.asyncio
+    async def test_default_caps_return_full_small_channel(self, store):
+        """With default caps, a small channel's whole history comes back."""
+        for i in range(3):
+            await store.save_message(
+                discord_message_id=str(i),
+                channel_id="ch1",
+                user_id="u1",
+                username="Alice",
+                content=f"msg {i}",
+                is_bot=False,
+            )
+        window = store.fetch_window("ch1")
+        assert len(window) == 3

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.7
+      targetRevision: 0.285.8
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Phase 1 of docs/plans/2026-07-04-ambient-assistant-parity.md (ADR 043, Feature A).

- `MessageStore.fetch_window`: bounded chronological channel window (count + char caps, newest always kept)
- `chat/digest.py`: pure chunked map-reduce digest helper, summary + decisions modes, mandatory coverage line
- `catch_up` / `extract_decisions` chat-agent tools + system-prompt guidance
- `needs_agent` prompt keeps channel-summarization requests on the chat route

Chat-route only: no guest, no new data access (window is provenance-scoped to the requesting channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjE3s1K8v3yVnHLSeAj6zg