### PR TITLE
feat(chat): time-based reminders (ADR 043 Phase 2)

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -803,6 +803,19 @@ py_test(
 )
 
 py_test(
+    name = "chat_reminders_test",
+    srcs = ["chat/reminders_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "chat_models_coverage_test",
     srcs = ["chat/models_coverage_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -790,6 +790,19 @@ py_test(
 )
 
 py_test(
+    name = "chat_models_reminder_test",
+    srcs = ["chat/models_reminder_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "chat_models_coverage_test",
     srcs = ["chat/models_coverage_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1740,6 +1740,20 @@ py_test(
 )
 
 py_test(
+    name = "chat_agent_reminder_tools_test",
+    srcs = ["chat/agent_reminder_tools_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pydantic_ai_slim",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "chat_bot_attachments_test",
     srcs = ["chat/bot_attachments_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -816,6 +816,19 @@ py_test(
 )
 
 py_test(
+    name = "chat_jobs_reminder_test",
+    srcs = ["chat/jobs_reminder_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "chat_models_coverage_test",
     srcs = ["chat/models_coverage_test.py"],
     imports = ["."],

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -325,6 +325,14 @@ def chat_changelog(name: str) -> None:
     logger.info("chat-changelog[%s]: done", name)
 
 
+@app.command("chat-drain-reminders")
+def chat_drain_reminders() -> None:
+    """Deliver due reminders into the Discord outbox (one-shot of
+    chat.jobs.drain_reminders_handler). No bot required; the leader's outbox
+    drain posts the enqueued rows."""
+    _run_job("chat-drain-reminders", "chat.jobs", "drain_reminders_handler")
+
+
 @app.command("evict-artifact-sessions")
 def evict_artifact_sessions() -> None:
     """Evict goose session DBs older than the TTL (ADR 026 Phase 2 Task 2.5).

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.8
+version: 0.285.9
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260704203000_chat_reminder.sql
+++ b/projects/monolith/chart/migrations/20260704203000_chat_reminder.sql
@@ -1,0 +1,21 @@
+-- Ambient-assistant reminders (Phase 2). A chat tool inserts a row with
+-- due_at in the future; the scheduler drain job queries pending rows whose
+-- due_at has passed, posts them into chat.discord_outbox, then stamps
+-- delivered_at and flips status to 'delivered'. A user can cancel a
+-- still-pending reminder before it fires (status='cancelled'). The status
+-- CHECK is mirrored in the SQLModel __table_args__ so the SQLite test
+-- fixtures enforce it too (create_all does not see migration-only
+-- constraints).
+CREATE TABLE IF NOT EXISTS chat.reminder (
+    id BIGSERIAL PRIMARY KEY,
+    channel_id TEXT NOT NULL,
+    author_id TEXT NOT NULL,
+    content TEXT NOT NULL,
+    due_at TIMESTAMPTZ NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    delivered_at TIMESTAMPTZ,
+    CONSTRAINT reminder_status_valid CHECK (status IN ('pending', 'delivered', 'cancelled'))
+);
+-- Drain query: pending reminders whose due_at has passed, oldest first.
+CREATE INDEX IF NOT EXISTS reminder_status_due_at ON chat.reminder (status, due_at);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Jep/6DsNO8OCx/MYYgRO4T6OHu8OEnSik2MGZJgknsE=
+h1:jAKlupQluxE6qaFthiDqQ/uAhPfyi+ezu/Eqs8aAyJI=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -96,3 +96,4 @@ h1:Jep/6DsNO8OCx/MYYgRO4T6OHu8OEnSik2MGZJgknsE=
 20260703250000_grimoire_chunk_seq_and_book.sql h1:5CGypr1+w41FLGdqrdYj9djiz1go2OdS3ai+Nb07At8=
 20260704000000_grimoire_public_reader_grant.sql h1:ZRY8zkuHoX0vtFNbJvP+hBaZp0BdyJ3k0Y5I4U1dx6U=
 20260704010000_grimoire_public_reader_book_extraction.sql h1:Edzhx2fHIgTcRRWOHRR8Re36NJ6fdEg7rMi45QwipQ8=
+20260704203000_chat_reminder.sql h1:Rm7UZ7yhiYgaS5txOFa+uh6oWF1fAmdgvk12BqfH8jA=

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -444,6 +444,25 @@ jobs:
           memory: 512Mi
         limits:
           memory: 512Mi
+    # chat.jobs.drain_reminders_handler: net-new (never ran in-process, so no
+    # `replaces`/ARGO_JOBS entry needed). Delivers due chat reminders into the
+    # Discord outbox; DB-only, no bot in the job. 2-minute cadence is the
+    # fastest plain-cron interval already in use elsewhere in this file
+    # (observability-stats-rollup); the reminder spec's delivery tolerance is
+    # minutes, not seconds, so this stays inside that envelope instead of
+    # introducing the first sub-minute `@every` schedule.
+    - name: chat-drain-reminders
+      args: ["chat-drain-reminders"]
+      schedule: "*/2 * * * *"
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 120
+      suspend: false
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
     # campsites.refresh: hourly at :00 UTC (not aligned to the 07:00 PT
     # reservation-opening surge). Reads the static catalog.json, fetches BC Parks
     # availability (~145 paced curl_cffi calls) + Open-Meteo forecast (~145

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -73,6 +73,71 @@ def signposted(text: str):
     return decorator
 
 
+def _parse_due_at(due_at_iso: Any) -> datetime | None:
+    """Parse a tool-supplied ISO 8601 datetime, accepting a trailing "Z" and
+    treating a naive parse as UTC. Returns None instead of raising -- this
+    reads LLM-supplied text (and, in e2e tests, pydantic-ai's TestModel's
+    schema-generated garbage strings), so an unparseable value is an expected
+    input, not a bug."""
+    if not isinstance(due_at_iso, str) or not due_at_iso.strip():
+        return None
+    text = due_at_iso.strip()
+    if text[-1:] in ("Z", "z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _create_reminder_sync(
+    channel_id: str, author_id: str, content: str, due_at: datetime
+) -> tuple[int, datetime] | str:
+    """Open a session, create the reminder, and extract the (id, due_at) the
+    caller needs before the session closes and the ORM instance expires. Runs
+    off the event loop via asyncio.to_thread."""
+    from app.db import get_engine
+    from chat import reminders
+    from sqlmodel import Session
+
+    with Session(get_engine()) as session:
+        result = reminders.create_reminder(
+            session, channel_id, author_id, content, due_at
+        )
+        if isinstance(result, str):
+            return result
+        session.commit()
+        return (result.id, result.due_at)
+
+
+def _list_pending_sync(author_id: str) -> list[tuple[int, datetime, str]]:
+    """Open a session, list the author's pending reminders, and extract the
+    fields the caller needs before the session closes."""
+    from app.db import get_engine
+    from chat import reminders
+    from sqlmodel import Session
+
+    with Session(get_engine()) as session:
+        rows = reminders.list_pending(session, author_id)
+        return [(row.id, row.due_at, row.content) for row in rows]
+
+
+def _cancel_reminder_sync(author_id: str, reminder_id: int) -> bool:
+    """Open a session and cancel the reminder, committing only on success."""
+    from app.db import get_engine
+    from chat import reminders
+    from sqlmodel import Session
+
+    with Session(get_engine()) as session:
+        ok = reminders.cancel_reminder(session, author_id, reminder_id)
+        if ok:
+            session.commit()
+        return ok
+
+
 def _coerce_username(value: Any) -> str | None:
     """Coerce a username value to a string.
 
@@ -146,6 +211,8 @@ def build_system_prompt() -> str:
         "when asked.\n"
         "- Catch someone up on this channel, or pull out the decisions and "
         "action items from it, when asked.\n"
+        "- Set a one-shot reminder for someone in this channel, list what "
+        "they've got pending, or cancel one.\n"
         "- Kick off an agent thread for heavier work, which runs in an "
         "isolated sandbox and reports back in the thread. It can investigate a "
         "repo or the cluster and answer questions about it, turn a request "
@@ -163,6 +230,16 @@ def build_system_prompt() -> str:
         "- Both tools lead with a coverage line stating how many messages "
         "they covered and how far back -- always fold that into your reply "
         "so nobody thinks you saw more of the conversation than you did.\n\n"
+        "REMINDERS:\n"
+        "- When someone asks to be reminded of something, convert what they "
+        "said into an absolute ISO 8601 UTC timestamp (using today's date "
+        "and any timezone clues they gave) and call set_reminder with it.\n"
+        "- Always confirm back the resolved absolute date and time so they "
+        "can catch a misread, and mention it lands in this channel within a "
+        "couple of minutes of falling due.\n"
+        "- Reminders are one-shot, not recurring. Use list_my_reminders when "
+        "someone asks what's queued, and cancel_reminder when they want one "
+        "removed.\n\n"
         "DO:\n"
         "- Answer directly. Lead with the useful answer, not preamble.\n"
         "- Match the vibe of the conversation. Be chill, funny, or serious "
@@ -468,6 +545,86 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
             logger.exception("directives: reset_channel_directive failed")
             return "I couldn't reset the directive right now, try again in a bit."
         return "This channel's directive is back to the default."
+
+    @agent.tool
+    @signposted(
+        "When someone asks you to remind them about something at a specific "
+        "time, or to set or schedule a reminder."
+    )
+    async def set_reminder(
+        ctx: RunContext[ChatDeps], due_at_iso: str, text: str
+    ) -> str:
+        """Schedule a one-shot reminder for the requesting user, delivered to this channel when it comes due. due_at_iso must be an absolute ISO 8601 UTC timestamp, e.g. '2026-07-05T09:00:00Z'."""
+        if not ctx.deps.author_id:
+            return "I can't manage reminders here."
+        due_at = _parse_due_at(due_at_iso)
+        if due_at is None:
+            return (
+                "I couldn't understand that time -- give me an absolute "
+                "date and time, like '2026-07-05T09:00:00Z'."
+            )
+        try:
+            result = await asyncio.to_thread(
+                _create_reminder_sync,
+                ctx.deps.channel_id,
+                ctx.deps.author_id,
+                text,
+                due_at,
+            )
+        except Exception:
+            logger.exception("set_reminder: create_reminder failed")
+            return "I couldn't set that reminder right now, try again in a bit."
+        if isinstance(result, str):
+            return result
+        reminder_id, resolved_due_at = result
+        return (
+            f"Reminder #{reminder_id} set for "
+            f"{resolved_due_at.strftime('%Y-%m-%d %H:%M')} UTC."
+        )
+
+    @agent.tool
+    @signposted(
+        "When someone asks what reminders they have pending, or wants to "
+        "check what's still queued up for them."
+    )
+    async def list_my_reminders(ctx: RunContext[ChatDeps]) -> str:
+        """List the requesting user's pending reminders."""
+        if not ctx.deps.author_id:
+            return "I can't manage reminders here."
+        try:
+            rows = await asyncio.to_thread(_list_pending_sync, ctx.deps.author_id)
+        except Exception:
+            logger.exception("list_my_reminders: list_pending failed")
+            return "I couldn't check your reminders right now, try again in a bit."
+        if not rows:
+            return "You have no pending reminders."
+        lines = ["Your pending reminders:"]
+        for reminder_id, due_at, content in rows:
+            lines.append(
+                f"- #{reminder_id} {due_at.strftime('%Y-%m-%d %H:%M')} UTC: {content}"
+            )
+        return "\n".join(lines)
+
+    @agent.tool
+    @signposted(
+        "When someone wants to cancel, remove, or delete a reminder they set earlier."
+    )
+    async def cancel_reminder(ctx: RunContext[ChatDeps], reminder_id: int) -> str:
+        """Cancel one of the requesting user's still-pending reminders by id."""
+        if not ctx.deps.author_id:
+            return "I can't manage reminders here."
+        try:
+            rid = int(reminder_id)
+        except (TypeError, ValueError):
+            return "That doesn't look like a valid reminder id."
+        try:
+            ok = await asyncio.to_thread(_cancel_reminder_sync, ctx.deps.author_id, rid)
+        except Exception:
+            logger.exception("cancel_reminder: cancel_reminder failed")
+            return "I couldn't cancel that reminder right now, try again in a bit."
+        if not ok:
+            return f"No pending reminder #{rid} found for you."
+        return f"Reminder #{rid} cancelled."
 
     return agent
 

--- a/projects/monolith/chat/agent_reminder_tools_test.py
+++ b/projects/monolith/chat/agent_reminder_tools_test.py
@@ -1,0 +1,514 @@
+"""Tests for the reminder agent tools (set_reminder, list_my_reminders,
+cancel_reminder) via FunctionModel, mirroring agent_channel_digest_tool_test.py.
+
+Unlike the digest tools (which fake out build_llm_caller), these exercise the
+real chat.reminders CRUD end to end against an in-memory SQLite engine patched
+onto app.db.get_engine -- the interesting behaviour here is the tool's own
+ISO-8601 parsing, id coercion, and error-string plumbing around a real
+create/list/cancel round trip, not the CRUD logic itself (already covered by
+chat/reminders_test.py).
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart, ToolReturnPart
+from pydantic_ai.models.function import FunctionModel
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from chat.agent import ChatDeps, create_agent
+from chat.reminders import create_reminder
+
+
+@pytest.fixture(name="engine")
+def engine_fixture():
+    """In-memory SQLite engine with the full chat schema, schema stripped so
+    SQLite accepts the DDL -- mirrors chat.reminders_test's session_fixture,
+    but yields the engine (not a session) since the tool code under test
+    opens its own session per call via app.db.get_engine."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    for table in SQLModel.metadata.tables.values():
+        if table.name in original:
+            table.schema = original[table.name]
+
+
+def _make_deps(channel_id: str = "ch1", author_id: str = "user-1") -> ChatDeps:
+    return ChatDeps(
+        channel_id=channel_id,
+        store=MagicMock(),
+        embed_client=AsyncMock(),
+        author_id=author_id,
+    )
+
+
+async def _run_tool_capturing_return(
+    agent, tool_name: str, args: dict, deps: ChatDeps
+) -> str:
+    captured = []
+
+    def model_func(messages, info):  # type: ignore[type-arg]
+        for msg in messages:
+            if hasattr(msg, "parts"):
+                for part in msg.parts:
+                    if isinstance(part, ToolReturnPart):
+                        captured.append(part.content)
+                        return ModelResponse(parts=[TextPart("done")])
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name=tool_name, args=args, tool_call_id="call-1")]
+        )
+
+    await agent.run("go", model=FunctionModel(model_func), deps=deps)
+    assert len(captured) == 1
+    return captured[0]
+
+
+@pytest.fixture
+def future_iso():
+    dt = datetime.now(timezone.utc) + timedelta(days=1)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+
+# ---------------------------------------------------------------------------
+# set_reminder -- happy path
+# ---------------------------------------------------------------------------
+
+
+class TestSetReminderHappyPath:
+    @pytest.mark.asyncio
+    async def test_creates_pending_reminder_and_confirms_absolute_time(
+        self, engine, future_iso
+    ):
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps()
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent,
+                "set_reminder",
+                {"due_at_iso": future_iso, "text": "stand up"},
+                deps,
+            )
+
+        assert result.startswith("Reminder #")
+        assert "UTC." in result
+
+        with Session(engine) as s:
+            from chat.reminders import list_pending
+
+            pending = list_pending(s, "user-1")
+        assert len(pending) == 1
+        assert pending[0].content == "stand up"
+
+    @pytest.mark.asyncio
+    async def test_accepts_trailing_z_suffix(self, engine):
+        dt = datetime.now(timezone.utc) + timedelta(days=1)
+        due_at_iso = dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps()
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent,
+                "set_reminder",
+                {"due_at_iso": due_at_iso, "text": "check the oven"},
+                deps,
+            )
+
+        assert result.startswith("Reminder #")
+
+    @pytest.mark.asyncio
+    async def test_treats_naive_timestamp_as_utc(self, engine):
+        dt = datetime.now(timezone.utc) + timedelta(days=1)
+        due_at_iso = dt.strftime("%Y-%m-%dT%H:%M:%S")  # no offset, no Z
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps()
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent,
+                "set_reminder",
+                {"due_at_iso": due_at_iso, "text": "naive time"},
+                deps,
+            )
+
+        assert result.startswith("Reminder #")
+
+
+# ---------------------------------------------------------------------------
+# set_reminder -- unparseable input never raises
+# ---------------------------------------------------------------------------
+
+
+class TestSetReminderUnparseableInput:
+    @pytest.mark.asyncio
+    async def test_returns_plain_language_error_on_garbage_string(self, engine):
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps()
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent,
+                "set_reminder",
+                {"due_at_iso": "a", "text": "a"},
+                deps,
+            )
+
+        assert "couldn't understand" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_returns_plain_language_error_on_empty_string(self, engine):
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps()
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent,
+                "set_reminder",
+                {"due_at_iso": "", "text": "reminder text"},
+                deps,
+            )
+
+        assert "couldn't understand" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# set_reminder -- CRUD error strings pass through verbatim
+# ---------------------------------------------------------------------------
+
+
+class TestSetReminderCrudErrorsPassThrough:
+    @pytest.mark.asyncio
+    async def test_past_due_at_returns_crud_error_verbatim(self, engine):
+        past_iso = (datetime.now(timezone.utc) - timedelta(hours=1)).strftime(
+            "%Y-%m-%dT%H:%M:%S+00:00"
+        )
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps()
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent,
+                "set_reminder",
+                {"due_at_iso": past_iso, "text": "too late"},
+                deps,
+            )
+
+        assert result == "due_at must be in the future"
+
+    @pytest.mark.asyncio
+    async def test_beyond_horizon_returns_crud_error_verbatim(self, engine):
+        far_iso = (datetime.now(timezone.utc) + timedelta(days=400)).strftime(
+            "%Y-%m-%dT%H:%M:%S+00:00"
+        )
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps()
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent,
+                "set_reminder",
+                {"due_at_iso": far_iso, "text": "far future"},
+                deps,
+            )
+
+        assert "366" in result
+
+    @pytest.mark.asyncio
+    async def test_pending_limit_returns_crud_error_verbatim(self, engine, future_iso):
+        with Session(engine) as s:
+            for i in range(10):
+                create_reminder(
+                    s,
+                    "ch1",
+                    "user-1",
+                    f"r{i}",
+                    datetime.now(timezone.utc) + timedelta(hours=i + 1),
+                )
+            s.commit()
+
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps()
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent,
+                "set_reminder",
+                {"due_at_iso": future_iso, "text": "one too many"},
+                deps,
+            )
+
+        assert "10" in result
+
+
+# ---------------------------------------------------------------------------
+# set_reminder -- no author_id
+# ---------------------------------------------------------------------------
+
+
+class TestSetReminderNoAuthor:
+    @pytest.mark.asyncio
+    async def test_returns_cant_manage_reminders_here(self, engine, future_iso):
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps(author_id="")
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent,
+                "set_reminder",
+                {"due_at_iso": future_iso, "text": "no author"},
+                deps,
+            )
+
+        assert result == "I can't manage reminders here."
+
+
+# ---------------------------------------------------------------------------
+# set_reminder -- fails open on unexpected exception
+# ---------------------------------------------------------------------------
+
+
+class TestSetReminderFailsOpen:
+    @pytest.mark.asyncio
+    async def test_returns_failure_string_instead_of_raising(self, future_iso):
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps()
+
+        with patch("app.db.get_engine", side_effect=RuntimeError("db unreachable")):
+            result = await _run_tool_capturing_return(
+                agent,
+                "set_reminder",
+                {"due_at_iso": future_iso, "text": "boom"},
+                deps,
+            )
+
+        assert result == "I couldn't set that reminder right now, try again in a bit."
+
+
+# ---------------------------------------------------------------------------
+# list_my_reminders
+# ---------------------------------------------------------------------------
+
+
+class TestListMyReminders:
+    @pytest.mark.asyncio
+    async def test_lists_pending_reminders_for_author(self, engine):
+        with Session(engine) as s:
+            create_reminder(
+                s,
+                "ch1",
+                "user-1",
+                "first",
+                datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+            create_reminder(
+                s,
+                "ch1",
+                "user-1",
+                "second",
+                datetime.now(timezone.utc) + timedelta(hours=2),
+            )
+            s.commit()
+
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps()
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent, "list_my_reminders", {}, deps
+            )
+
+        assert "first" in result
+        assert "second" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_no_pending_reminders_message_when_empty(self, engine):
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps()
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent, "list_my_reminders", {}, deps
+            )
+
+        assert "no pending reminders" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_only_shows_authors_own_reminders(self, engine):
+        with Session(engine) as s:
+            create_reminder(
+                s,
+                "ch1",
+                "user-1",
+                "mine",
+                datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+            create_reminder(
+                s,
+                "ch1",
+                "user-2",
+                "theirs",
+                datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+            s.commit()
+
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps(author_id="user-1")
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent, "list_my_reminders", {}, deps
+            )
+
+        assert "mine" in result
+        assert "theirs" not in result
+
+    @pytest.mark.asyncio
+    async def test_returns_cant_manage_reminders_here_without_author(self, engine):
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps(author_id="")
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent, "list_my_reminders", {}, deps
+            )
+
+        assert result == "I can't manage reminders here."
+
+    @pytest.mark.asyncio
+    async def test_fails_open_on_unexpected_exception(self):
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps()
+
+        with patch("app.db.get_engine", side_effect=RuntimeError("db unreachable")):
+            result = await _run_tool_capturing_return(
+                agent, "list_my_reminders", {}, deps
+            )
+
+        assert (
+            result == "I couldn't check your reminders right now, try again in a bit."
+        )
+
+
+# ---------------------------------------------------------------------------
+# cancel_reminder
+# ---------------------------------------------------------------------------
+
+
+class TestCancelReminder:
+    @pytest.mark.asyncio
+    async def test_cancels_own_pending_reminder(self, engine):
+        with Session(engine) as s:
+            row = create_reminder(
+                s,
+                "ch1",
+                "user-1",
+                "cancel me",
+                datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+            s.commit()
+            reminder_id = row.id
+
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps()
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent,
+                "cancel_reminder",
+                {"reminder_id": reminder_id},
+                deps,
+            )
+
+        assert result == f"Reminder #{reminder_id} cancelled."
+
+        with Session(engine) as s:
+            from chat.models import Reminder
+
+            refreshed = s.get(Reminder, reminder_id)
+        assert refreshed.status == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_string_for_missing_reminder(self, engine):
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps()
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent,
+                "cancel_reminder",
+                {"reminder_id": 999999},
+                deps,
+            )
+
+        assert result == "No pending reminder #999999 found for you."
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_string_for_other_authors_reminder(self, engine):
+        with Session(engine) as s:
+            row = create_reminder(
+                s,
+                "ch1",
+                "user-2",
+                "not yours",
+                datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+            s.commit()
+            reminder_id = row.id
+
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps(author_id="user-1")
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent,
+                "cancel_reminder",
+                {"reminder_id": reminder_id},
+                deps,
+            )
+
+        assert result == f"No pending reminder #{reminder_id} found for you."
+
+    @pytest.mark.asyncio
+    async def test_returns_cant_manage_reminders_here_without_author(self, engine):
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps(author_id="")
+
+        with patch("app.db.get_engine", return_value=engine):
+            result = await _run_tool_capturing_return(
+                agent,
+                "cancel_reminder",
+                {"reminder_id": 1},
+                deps,
+            )
+
+        assert result == "I can't manage reminders here."
+
+    @pytest.mark.asyncio
+    async def test_fails_open_on_unexpected_exception(self):
+        agent = create_agent(base_url="http://fake:8080")
+        deps = _make_deps()
+
+        with patch("app.db.get_engine", side_effect=RuntimeError("db unreachable")):
+            result = await _run_tool_capturing_return(
+                agent,
+                "cancel_reminder",
+                {"reminder_id": 1},
+                deps,
+            )
+
+        assert (
+            result == "I couldn't cancel that reminder right now, try again in a bit."
+        )

--- a/projects/monolith/chat/jobs.py
+++ b/projects/monolith/chat/jobs.py
@@ -1,0 +1,61 @@
+"""Scheduler job draining due reminders into the Discord outbox.
+
+Runs as the chat-drain-reminders Argo CronWorkflow one-shot (see
+app/jobs_main.py, chart/values.yaml jobs.cronWorkflows), not the legacy
+in-process scheduler.register_job path: that dispatch loop was deleted (see
+app/main.py's lifespan comment), so Argo's own cron schedule is the sole
+cadence driver here and the handler's return value is unused by anything.
+
+Pure DB work, no network phase, so the whole job runs in one worker thread via
+asyncio.to_thread rather than splitting an async network phase from a sync DB
+phase (mirrors ships.retention.partition_maintenance_handler, not
+hikes.jobs which has a real network fetch to await first).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from sqlmodel import Session
+
+from chat import reminders
+
+logger = logging.getLogger("monolith.chat")
+
+
+def _drain_reminders_core(session: Session, now: datetime) -> datetime | None:
+    """Deliver due reminders and report the earliest remaining pending due_at
+    (or None). Session-parameterized so the SQLite create_all test fixture can
+    drive it directly. Caller commits.
+    """
+    delivered = reminders.deliver_due(session, now)
+    if delivered:
+        logger.info("chat.reminders: delivered %d due reminder(s)", delivered)
+    return reminders.next_due(session)
+
+
+def _drain_reminders() -> datetime | None:
+    """Open a fresh session and drain due reminders. Runs off the event loop
+    via asyncio.to_thread (so it must own its session, never the caller's).
+    """
+    from app.db import get_engine
+
+    now = datetime.now(timezone.utc)
+    with Session(get_engine()) as session:
+        next_run = _drain_reminders_core(session, now)
+        session.commit()
+    return next_run
+
+
+async def drain_reminders_handler(session: Session) -> None:
+    """Drain due reminders into the Discord outbox.
+
+    All Session I/O runs in a worker thread (semgrep no-sync-session-in-async-def
+    / no-session-in-to-thread); the ``session`` argument passed in by the
+    one-shot CLI wrapper is unused and never touched here. The Argo cron
+    schedule is what actually determines cadence, so unlike the legacy
+    register_job contract there is no next-run hint to return.
+    """
+    await asyncio.to_thread(_drain_reminders)

--- a/projects/monolith/chat/jobs_reminder_test.py
+++ b/projects/monolith/chat/jobs_reminder_test.py
@@ -1,0 +1,111 @@
+"""Tests for chat.jobs._drain_reminders_core: the testable sync core behind
+the chat-drain-reminders Argo CronWorkflow one-shot (see chat/jobs.py).
+
+Only the core is unit tested; the thin async handler (drain_reminders_handler)
+just opens its own session and delegates via asyncio.to_thread, per
+projects/monolith/CLAUDE.md, and is not covered here (repo convention).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from chat.jobs import _drain_reminders_core
+from chat.models import DiscordOutbox, Reminder
+from chat.reminders import create_reminder
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    """In-memory SQLite session with the full chat schema, schema stripped so
+    SQLite accepts the DDL -- mirrors chat.reminders_test's session_fixture."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as s:
+        yield s
+    for table in SQLModel.metadata.tables.values():
+        if table.name in original:
+            table.schema = original[table.name]
+
+
+def _future(**kwargs) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(**kwargs)
+
+
+class TestDrainRemindersCore:
+    def test_delivers_due_rows_and_enqueues_outbox(self, session):
+        due = Reminder(
+            channel_id="chan-1",
+            author_id="user-1",
+            content="stand up",
+            due_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        )
+        session.add(due)
+        session.commit()
+
+        now = datetime.now(timezone.utc)
+        result = _drain_reminders_core(session, now)
+        session.commit()
+
+        refreshed = session.get(Reminder, due.id)
+        assert refreshed.status == "delivered"
+        outbox_rows = session.query(DiscordOutbox).all()
+        assert len(outbox_rows) == 1
+        assert outbox_rows[0].channel_id == "chan-1"
+        assert result is None
+
+    def test_returns_earliest_remaining_pending_due_at(self, session):
+        due = Reminder(
+            channel_id="chan-1",
+            author_id="user-1",
+            content="do the thing",
+            due_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        )
+        session.add(due)
+        create_reminder(session, "chan-1", "user-1", "later", _future(hours=1))
+        session.commit()
+
+        result = _drain_reminders_core(session, datetime.now(timezone.utc))
+        session.commit()
+
+        pending = session.query(Reminder).filter(Reminder.status == "pending").all()
+        assert len(pending) == 1
+        assert result == pending[0].due_at
+
+    def test_returns_none_when_nothing_pending_remains(self, session):
+        due = Reminder(
+            channel_id="chan-1",
+            author_id="user-1",
+            content="only one",
+            due_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        )
+        session.add(due)
+        session.commit()
+
+        result = _drain_reminders_core(session, datetime.now(timezone.utc))
+        session.commit()
+
+        assert result is None
+
+    def test_nothing_due_leaves_pending_rows_untouched(self, session):
+        create_reminder(session, "chan-1", "user-1", "later", _future(hours=1))
+        session.commit()
+
+        result = _drain_reminders_core(session, datetime.now(timezone.utc))
+        session.commit()
+
+        assert session.query(DiscordOutbox).count() == 0
+        pending = session.query(Reminder).filter(Reminder.status == "pending").all()
+        assert len(pending) == 1
+        assert result == pending[0].due_at

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -338,6 +338,38 @@ class OrchestratorBrief(SQLModel, table=True):
     error: str | None = Field(default=None)
 
 
+# nosemgrep: sqlmodel-datetime-without-factory (delivered_at is intentionally NULL until the drain delivers the row)
+class Reminder(SQLModel, table=True):
+    """A user-scheduled reminder (ambient-assistant parity, Phase 2).
+
+    A chat tool inserts a row with due_at in the future; the scheduler drain
+    job queries pending rows whose due_at has passed (status, due_at index),
+    posts them into chat.discord_outbox, then stamps delivered_at and flips
+    status to 'delivered'. A user can cancel a still-pending reminder before
+    it fires (status='cancelled'). The status CHECK mirrors the migration so
+    the SQLite test fixtures enforce it too (create_all does not see
+    migration-only constraints).
+    """
+
+    __tablename__ = "reminder"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('pending', 'delivered', 'cancelled')",
+            name="reminder_status_valid",
+        ),
+        {"schema": "chat", "extend_existing": True},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    channel_id: str = Field(index=True)
+    author_id: str
+    content: str
+    due_at: datetime
+    status: str = Field(default="pending")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    delivered_at: datetime | None = Field(default=None)
+
+
 class UserStylePref(SQLModel, table=True):
     """Per-user style preference (ADR 035 phase 5).
 

--- a/projects/monolith/chat/models_reminder_test.py
+++ b/projects/monolith/chat/models_reminder_test.py
@@ -1,0 +1,129 @@
+"""DB-level tests for the chat.Reminder SQLModel (ambient-assistant Phase 2).
+
+Follows the models_db_constraints_test.py idiom: a real SQLite engine builds
+the table via create_all (schema stripped so SQLite accepts the DDL) and
+exercises both the column defaults and the status CHECK, which is declared
+only in the migration SQL and mirrored in __table_args__ specifically so this
+fixture can enforce it too.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from chat.models import Reminder
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    """In-memory SQLite session with only the Reminder table created."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    table = Reminder.__table__
+    saved_schema = table.schema
+    table.schema = None
+    SQLModel.metadata.create_all(engine, tables=[table])
+
+    with Session(engine) as s:
+        yield s
+
+    table.schema = saved_schema
+
+
+class TestReminderRoundTrip:
+    """A Reminder row round-trips through SQLite with the expected defaults."""
+
+    def test_insert_and_fetch(self, session):
+        due_at = datetime.now(timezone.utc) + timedelta(hours=1)
+        session.add(
+            Reminder(
+                channel_id="ch-1",
+                author_id="user-1",
+                content="stand up",
+                due_at=due_at,
+            )
+        )
+        session.commit()
+
+        row = session.query(Reminder).one()
+        assert row.channel_id == "ch-1"
+        assert row.author_id == "user-1"
+        assert row.content == "stand up"
+        # SQLite returns naive datetimes regardless of what was stored; assert
+        # the type round-trips, not the tzinfo.
+        assert isinstance(row.due_at, datetime)
+        assert isinstance(row.created_at, datetime)
+        assert row.delivered_at is None
+
+    def test_status_defaults_to_pending(self, session):
+        session.add(
+            Reminder(
+                channel_id="ch-1",
+                author_id="user-1",
+                content="stand up",
+                due_at=datetime.now(timezone.utc),
+            )
+        )
+        session.commit()
+
+        row = session.query(Reminder).one()
+        assert row.status == "pending"
+
+    def test_delivered_at_is_nullable_and_settable(self, session):
+        reminder = Reminder(
+            channel_id="ch-1",
+            author_id="user-1",
+            content="stand up",
+            due_at=datetime.now(timezone.utc),
+        )
+        session.add(reminder)
+        session.commit()
+        assert reminder.delivered_at is None
+
+        delivered_at = datetime.now(timezone.utc)
+        reminder.status = "delivered"
+        reminder.delivered_at = delivered_at
+        session.add(reminder)
+        session.commit()
+
+        row = session.query(Reminder).one()
+        assert row.status == "delivered"
+        assert isinstance(row.delivered_at, datetime)
+
+
+class TestReminderStatusCheckConstraint:
+    """SQLite enforcement of the Reminder.status CHECK (mirrors the migration)."""
+
+    def test_valid_statuses_insert(self, session):
+        session.add_all(
+            [
+                Reminder(
+                    channel_id="ch-1",
+                    author_id="user-1",
+                    content="stand up",
+                    due_at=datetime.now(timezone.utc),
+                    status=status,
+                )
+                for status in ("pending", "delivered", "cancelled")
+            ]
+        )
+        session.commit()  # must not raise
+
+    def test_invalid_status_raises_integrity_error(self, session):
+        session.add(
+            Reminder(
+                channel_id="ch-1",
+                author_id="user-1",
+                content="stand up",
+                due_at=datetime.now(timezone.utc),
+                status="bogus",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            session.commit()

--- a/projects/monolith/chat/reminders.py
+++ b/projects/monolith/chat/reminders.py
@@ -1,0 +1,125 @@
+"""Reminder CRUD and due-drain core (ambient-assistant parity, Phase 2).
+
+Every function here is synchronous and session-parameterized: unlike
+directives.py (which opens its own session per call), these take an explicit
+``session`` argument and never commit it themselves. The SQLite ``create_all``
+test fixture drives them directly against an in-memory session, and Task 2.3's
+scheduler job wraps deliver_due/next_due in its own session/commit, matching
+the rest of the chat write API (see chat.outbox.enqueue_message).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlmodel import Session, select
+
+from chat.models import Reminder
+from chat.outbox import enqueue_message
+
+# A user can only have this many reminders pending at once; past this, new
+# ones are rejected rather than silently queued forever.
+MAX_PENDING_PER_USER = 10
+# A reminder cannot be scheduled further out than this many days; a typo'd
+# year (or an LLM hallucinating a far-future date) would otherwise wait
+# unnoticed for a very long time.
+MAX_HORIZON_DAYS = 366
+
+
+def _aware(dt: datetime) -> datetime:
+    """Coerce a naive datetime (as SQLite hands back regardless of what was
+    stored) to UTC-aware so it can be compared against datetime.now(utc)."""
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def create_reminder(
+    session: Session,
+    channel_id: str,
+    author_id: str,
+    content: str,
+    due_at: datetime,
+) -> Reminder | str:
+    """Insert a pending reminder, or return an error string instead of
+    raising if due_at is not in the future, is more than MAX_HORIZON_DAYS
+    out, or the author already has MAX_PENDING_PER_USER pending reminders.
+    Caller commits."""
+    now = datetime.now(timezone.utc)
+    if _aware(due_at) <= now:
+        return "due_at must be in the future"
+    if _aware(due_at) > now + timedelta(days=MAX_HORIZON_DAYS):
+        return f"due_at cannot be more than {MAX_HORIZON_DAYS} days out"
+    if len(list_pending(session, author_id)) >= MAX_PENDING_PER_USER:
+        return f"you already have {MAX_PENDING_PER_USER} pending reminders"
+
+    reminder = Reminder(
+        channel_id=channel_id,
+        author_id=author_id,
+        content=content,
+        due_at=due_at,
+    )
+    session.add(reminder)
+    return reminder
+
+
+def list_pending(session: Session, author_id: str) -> list[Reminder]:
+    """The author's pending reminders, earliest due first."""
+    return list(
+        session.exec(
+            select(Reminder)
+            .where(Reminder.author_id == author_id)
+            .where(Reminder.status == "pending")
+            .order_by(Reminder.due_at)
+        ).all()
+    )
+
+
+def cancel_reminder(session: Session, author_id: str, reminder_id: int) -> bool:
+    """Flip a still-pending reminder owned by author_id to cancelled. Returns
+    False (no-op) if the row is missing, already resolved, or owned by
+    someone else. Caller commits."""
+    reminder = session.get(Reminder, reminder_id)
+    if reminder is None:
+        return False
+    if reminder.author_id != author_id or reminder.status != "pending":
+        return False
+    reminder.status = "cancelled"
+    session.add(reminder)
+    return True
+
+
+def deliver_due(session: Session, now: datetime) -> int:
+    """Enqueue a Discord outbox post for every pending reminder whose due_at
+    has passed as of ``now``, flip each to delivered, and return the count
+    delivered. The due comparison happens in Python (not a SQL WHERE clause)
+    because due_at may be stored naive by the SQLite test fixture while
+    ``now`` is tz-aware, and the two are not string/numeric comparable at the
+    SQL level; the pending row count is small enough that this is cheap.
+    Caller commits."""
+    now = _aware(now)
+    pending = session.exec(select(Reminder).where(Reminder.status == "pending")).all()
+    delivered = 0
+    for reminder in pending:
+        if _aware(reminder.due_at) > now:
+            continue
+        enqueue_message(
+            session,
+            reminder.channel_id,
+            content=f"⏰ <@{reminder.author_id}> reminder: {reminder.content}",
+        )
+        # reminder comes from this session's own query, so it is already
+        # tracked; mutating attributes marks it dirty and commit() flushes
+        # the update. No session.add() needed (and adding inside a loop
+        # trips session-add-in-loop, which is for freshly constructed rows,
+        # not already-tracked ones).
+        reminder.status = "delivered"
+        reminder.delivered_at = now
+        delivered += 1
+    return delivered
+
+
+def next_due(session: Session) -> datetime | None:
+    """The earliest due_at among pending reminders, None if there are none."""
+    reminder = session.exec(
+        select(Reminder).where(Reminder.status == "pending").order_by(Reminder.due_at)
+    ).first()
+    return reminder.due_at if reminder is not None else None

--- a/projects/monolith/chat/reminders_test.py
+++ b/projects/monolith/chat/reminders_test.py
@@ -1,0 +1,278 @@
+"""Tests for chat.reminders: CRUD guards, ordering, cancellation, and drain."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from chat.models import DiscordOutbox, Reminder
+from chat.reminders import (
+    MAX_HORIZON_DAYS,
+    MAX_PENDING_PER_USER,
+    cancel_reminder,
+    create_reminder,
+    deliver_due,
+    list_pending,
+    next_due,
+)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    """In-memory SQLite session with the full chat schema (Reminder AND
+    DiscordOutbox, since deliver_due writes both), schema stripped so SQLite
+    accepts the DDL -- mirrors chat.outbox_test's engine_fixture."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as s:
+        yield s
+    for table in SQLModel.metadata.tables.values():
+        if table.name in original:
+            table.schema = original[table.name]
+
+
+def _future(**kwargs) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(**kwargs)
+
+
+class TestCreateReminder:
+    def test_creates_pending_row(self, session):
+        due_at = _future(hours=1)
+        result = create_reminder(session, "chan-1", "user-1", "stand up", due_at)
+        session.commit()
+
+        assert isinstance(result, Reminder)
+        assert result.status == "pending"
+        assert result.channel_id == "chan-1"
+        assert result.author_id == "user-1"
+        assert result.content == "stand up"
+
+    def test_rejects_due_at_in_the_past(self, session):
+        result = create_reminder(session, "chan-1", "user-1", "late", _future(hours=-1))
+        assert result == "due_at must be in the future"
+
+    def test_rejects_due_at_equal_to_now(self, session):
+        result = create_reminder(
+            session, "chan-1", "user-1", "now", datetime.now(timezone.utc)
+        )
+        assert isinstance(result, str)
+
+    def test_rejects_due_at_beyond_horizon(self, session):
+        result = create_reminder(
+            session,
+            "chan-1",
+            "user-1",
+            "far",
+            _future(days=MAX_HORIZON_DAYS + 1),
+        )
+        assert "366" in result or str(MAX_HORIZON_DAYS) in result
+
+    def test_accepts_due_at_within_horizon(self, session):
+        result = create_reminder(
+            session,
+            "chan-1",
+            "user-1",
+            "far but ok",
+            _future(days=MAX_HORIZON_DAYS - 1),
+        )
+        assert isinstance(result, Reminder)
+
+    def test_rejects_when_author_at_pending_limit(self, session):
+        for i in range(MAX_PENDING_PER_USER):
+            create_reminder(session, "chan-1", "user-1", f"r{i}", _future(hours=i + 1))
+        session.commit()
+
+        result = create_reminder(
+            session, "chan-1", "user-1", "one too many", _future(hours=99)
+        )
+        assert isinstance(result, str)
+        assert "10" in result
+
+    def test_pending_limit_is_per_author(self, session):
+        for i in range(MAX_PENDING_PER_USER):
+            create_reminder(session, "chan-1", "user-1", f"r{i}", _future(hours=i + 1))
+        session.commit()
+
+        result = create_reminder(
+            session, "chan-1", "user-2", "other user", _future(hours=1)
+        )
+        assert isinstance(result, Reminder)
+
+    def test_cancelled_reminders_do_not_count_toward_limit(self, session):
+        rows = []
+        for i in range(MAX_PENDING_PER_USER):
+            row = create_reminder(
+                session, "chan-1", "user-1", f"r{i}", _future(hours=i + 1)
+            )
+            rows.append(row)
+        session.commit()
+
+        assert cancel_reminder(session, "user-1", rows[0].id)
+        session.commit()
+
+        result = create_reminder(
+            session, "chan-1", "user-1", "room now", _future(hours=99)
+        )
+        assert isinstance(result, Reminder)
+
+
+class TestListPending:
+    def test_orders_by_due_at_ascending(self, session):
+        create_reminder(session, "chan-1", "user-1", "third", _future(hours=3))
+        create_reminder(session, "chan-1", "user-1", "first", _future(hours=1))
+        create_reminder(session, "chan-1", "user-1", "second", _future(hours=2))
+        session.commit()
+
+        pending = list_pending(session, "user-1")
+        assert [r.content for r in pending] == ["first", "second", "third"]
+
+    def test_excludes_other_authors_and_non_pending(self, session):
+        create_reminder(session, "chan-1", "user-1", "mine", _future(hours=1))
+        create_reminder(session, "chan-1", "user-2", "theirs", _future(hours=1))
+        session.commit()
+
+        pending = list_pending(session, "user-1")
+        assert len(pending) == 1
+        assert pending[0].content == "mine"
+
+
+class TestCancelReminder:
+    def test_cancels_own_pending_reminder(self, session):
+        row = create_reminder(
+            session, "chan-1", "user-1", "cancel me", _future(hours=1)
+        )
+        session.commit()
+
+        assert cancel_reminder(session, "user-1", row.id) is True
+        session.commit()
+
+        refreshed = session.get(Reminder, row.id)
+        assert refreshed.status == "cancelled"
+
+    def test_rejects_wrong_author(self, session):
+        row = create_reminder(session, "chan-1", "user-1", "mine", _future(hours=1))
+        session.commit()
+
+        assert cancel_reminder(session, "user-2", row.id) is False
+        assert session.get(Reminder, row.id).status == "pending"
+
+    def test_rejects_already_resolved_reminder(self, session):
+        row = create_reminder(session, "chan-1", "user-1", "mine", _future(hours=1))
+        session.commit()
+        assert cancel_reminder(session, "user-1", row.id) is True
+        session.commit()
+
+        assert cancel_reminder(session, "user-1", row.id) is False
+
+    def test_rejects_missing_reminder(self, session):
+        assert cancel_reminder(session, "user-1", 999999) is False
+
+
+class TestDeliverDue:
+    def test_delivers_only_due_pending_rows(self, session):
+        due = Reminder(
+            channel_id="chan-1",
+            author_id="user-1",
+            content="do the thing",
+            due_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        )
+        cancelled = Reminder(
+            channel_id="chan-1",
+            author_id="user-1",
+            content="cancelled",
+            due_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+            status="cancelled",
+        )
+        future = Reminder(
+            channel_id="chan-1",
+            author_id="user-1",
+            content="not yet",
+            due_at=_future(hours=1),
+        )
+        session.add_all([due, cancelled, future])
+        session.commit()
+
+        now = datetime.now(timezone.utc)
+        count = deliver_due(session, now)
+        session.commit()
+
+        assert count == 1
+
+        due_refreshed = session.get(Reminder, due.id)
+        assert due_refreshed.status == "delivered"
+        assert due_refreshed.delivered_at is not None
+
+        cancelled_refreshed = session.get(Reminder, cancelled.id)
+        assert cancelled_refreshed.status == "cancelled"
+        assert cancelled_refreshed.delivered_at is None
+
+        future_refreshed = session.get(Reminder, future.id)
+        assert future_refreshed.status == "pending"
+
+        outbox_rows = session.query(DiscordOutbox).all()
+        assert len(outbox_rows) == 1
+        assert outbox_rows[0].channel_id == "chan-1"
+        assert outbox_rows[0].content == "⏰ <@user-1> reminder: do the thing"
+
+    def test_handles_naive_due_at_from_sqlite(self, session):
+        """A row fetched back from SQLite has a naive due_at regardless of
+        what was stored; deliver_due must still compare it correctly."""
+        row = Reminder(
+            channel_id="chan-1",
+            author_id="user-1",
+            content="naive",
+            due_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        )
+        session.add(row)
+        session.commit()
+
+        refetched = session.get(Reminder, row.id)
+        assert refetched.due_at.tzinfo is None
+
+        count = deliver_due(session, datetime.now(timezone.utc))
+        session.commit()
+        assert count == 1
+
+    def test_returns_zero_when_nothing_due(self, session):
+        create_reminder(session, "chan-1", "user-1", "later", _future(hours=1))
+        session.commit()
+
+        count = deliver_due(session, datetime.now(timezone.utc))
+        assert count == 0
+        assert session.query(DiscordOutbox).count() == 0
+
+
+class TestNextDue:
+    def test_returns_earliest_pending_due_at(self, session):
+        create_reminder(session, "chan-1", "user-1", "later", _future(hours=5))
+        create_reminder(session, "chan-1", "user-1", "sooner", _future(hours=1))
+        session.commit()
+
+        result = next_due(session)
+        assert result is not None
+
+        # sooner is the earliest; compare via the fetched row rather than a
+        # fresh _future() call so this isn't flaky against wall-clock drift.
+        sooner = list_pending(session, "user-1")[0]
+        assert result == sooner.due_at
+
+    def test_ignores_non_pending_rows(self, session):
+        row = create_reminder(session, "chan-1", "user-1", "only one", _future(hours=1))
+        session.commit()
+        cancel_reminder(session, "user-1", row.id)
+        session.commit()
+
+        assert next_due(session) is None
+
+    def test_none_when_no_reminders(self, session):
+        assert next_due(session) is None

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.8
+      targetRevision: 0.285.9
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Phase 2 of docs/plans/2026-07-04-ambient-assistant-parity.md (ADR 043, Feature B).

- `chat.reminder` table (migration 20260704203000) + Reminder model with status CHECK
- `chat/reminders.py`: create/list/cancel/deliver_due/next_due, caps (10 pending/user, 366-day horizon), error strings not exceptions
- Drain wired as an Argo CronWorkflow (`chat-drain-reminders`, every 2 min) via jobs_main.py, delivering through the durable discord_outbox with an author mention
- `set_reminder` / `list_my_reminders` / `cancel_reminder` chat-agent tools, fail-open, TestModel-safe (garbage input returns error strings)

**Plan deviation (documented):** the plan specified `scheduler.api.register_job`, but that seam is dead code since PR #2815 (the in-process dispatch loop was deleted; nothing polls scheduler.scheduled_jobs). A register_job-based drain would unit-test green and never run in prod. Wired as an Argo CronWorkflow instead, matching the fleet convention; `*/2 * * * *` stays within the fleet's fastest existing cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjE3s1K8v3yVnHLSeAj6zg
