### PR TITLE
fix(inference): right-size embeddings to 12Gi after bulk-load OOM crash loop

### DIFF
--- a/projects/inference/deploy/values.yaml
+++ b/projects/inference/deploy/values.yaml
@@ -335,13 +335,16 @@ embeddings:
     linkerd.io/inject: disabled
     prometheus.io/scrape: "true"
     prometheus.io/port: "8080"
-  # 7-day SigNoz RSS is ~5.5Gi and almost entirely anonymous (working_set == RSS:
-  # llama.cpp holds the GGUF weights in host RAM, n-gpu-layers 0), so the 4Gi
-  # request under-reserved what it actually needs. Raised 4 -> 6 to reserve the
-  # real footprint; the 8Gi limit keeps headroom for ubatch spikes.
+  # 7-day SigNoz RSS is ~5.5Gi (llama.cpp holds the GGUF weights in host RAM,
+  # n-gpu-layers 0), and the grimoire bulk sourcebook load (2026-07-04, ~40k
+  # chunks at 60k-char batches against 8192-token ubatch) OOMKilled the pod at
+  # the old 8Gi limit and crash-looped it: each restart got slammed by retry
+  # backlog while still allocating model + slot memory. 12Gi covers steady
+  # state plus max-batch spikes; requests == limits per the sizing convention
+  # so the reservation is honest. Node-4 sits at ~38% memory requested.
   resources:
     requests:
       cpu: 2
-      memory: "6Gi"
+      memory: "12Gi"
     limits:
-      memory: "8Gi"
+      memory: "12Gi"


### PR DESCRIPTION
inference-embeddings is in CrashLoopBackOff (11 restarts, OOMKilled at the 8Gi limit ~21s after each start): the grimoire bulk load pushed sustained near-8192-token batches through it and each restart gets hit by retry backlog while llama.cpp is still allocating model + slot memory. Steady-state RSS was already ~5.5Gi.

12Gi requests == limits (sizing convention); node-4 has ~46Gi free (38% requested). Chart is git-sourced at HEAD so merge deploys directly.

Unblocks the grimoire loader run (died at 16.6k/39.7k embeddings on ConnectError when the pod went down; resumes incrementally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)