### PR TITLE
feat(chat): channel-data artifacts via injected context (ADR 043 Phase 3)

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/artifact-build.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/artifact-build.yaml
@@ -138,6 +138,13 @@ prompt: |
 
   Router context may be in the file {{ context_file }} (it may be empty or
   missing): read it if it is a non-empty file.
+
+  A structured dataset the caller already extracted for this request may be
+  staged at /injected-context/channel-data.json (a title, columns, rows, and a
+  source_window describing the conversation window it came from). If it
+  exists, build the artifact from that data instead of inventing numbers, and
+  cite the source window somewhere on the page, for example a caption or
+  footnote. If it does not exist, build from {{ task_file }} alone as usual.
 parameters:
   - key: task_file
     description: "Path to a file describing what to build"

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.33
+version: 0.4.34

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.33
+      targetRevision: 0.4.34
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -955,6 +955,7 @@ py_test(
         ":monolith_backend",
         "@pip//pgvector",
         "@pip//pytest",
+        "@pip//pytest_asyncio",
         "@pip//sqlmodel",
     ],
 )

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -925,6 +925,18 @@ py_test(
 )
 
 py_test(
+    name = "chat_channel_data_test",
+    srcs = ["chat/channel_data_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
     name = "chat_outbox_test",
     srcs = ["chat/outbox_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.9
+version: 0.285.10
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/api.py
+++ b/projects/monolith/chat/api.py
@@ -10,6 +10,7 @@ from chat.bot import send_message  # re-exported
 from chat.changelog import run_changelog_for_config  # re-exported
 from chat.goosecracker import ack_inflight  # re-exported
 from chat.goosecracker import artifact_id_for_thread  # re-exported
+from chat.goosecracker import build_channel_dataset  # re-exported
 from chat.goosecracker import build_injected_context  # re-exported
 from chat.goosecracker import drain_agent_queue  # re-exported
 from chat.goosecracker import ensure_steering_token  # re-exported
@@ -38,6 +39,7 @@ __all__ = [
     "replan",
     "ack_inflight",
     "artifact_id_for_thread",
+    "build_channel_dataset",
     "build_injected_context",
     "conversational_agent_reply",
     "drain_agent_queue",

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -874,7 +874,12 @@ class ChatBot(discord.Client):
             thread = await channel.create_thread(
                 name=name, type=discord.ChannelType.public_thread
             )
-            await asyncio.to_thread(goosecracker.start_session, str(thread.id), prompt)
+            await asyncio.to_thread(
+                goosecracker.start_session,
+                str(thread.id),
+                prompt,
+                str(channel.id),
+            )
         except Exception:
             logger.exception("goosecracker: failed to start session")
             await interaction.followup.send(

--- a/projects/monolith/chat/channel_data.py
+++ b/projects/monolith/chat/channel_data.py
@@ -36,6 +36,9 @@ _EXTRACT_PROMPT = (
     "Every row must have exactly one value per column, in the same order as "
     "columns. Keep it to at most {max_rows} rows; if there are more "
     "candidates, pick the {max_rows} most relevant.\n\n"
+    "If the user's request does not actually ask for data, a chart, or a "
+    "visualization drawn from this conversation, reply with exactly "
+    '{{"none": true}} instead.\n\n'
     'User request: "{request}"\n\n'
     "Messages:\n{messages}"
 )
@@ -98,7 +101,10 @@ async def extract_dataset(
     messages, never trusted from the model reply. Returns None if messages is
     empty (without calling caller), if the reply fails to parse or validate,
     or if caller raises: this is a fail-open contract, so a caller can treat
-    None as "no dataset, dispatch proceeds without one".
+    None as "no dataset, dispatch proceeds without one". The prompt also asks
+    the model to reply ``{"none": true}`` when the request is not actually
+    asking for a dataset; that shape fails validation (no "title") the same as
+    any other malformed reply, so it needs no separate handling here.
     """
     if not messages:
         return None

--- a/projects/monolith/chat/channel_data.py
+++ b/projects/monolith/chat/channel_data.py
@@ -1,0 +1,133 @@
+"""Structured dataset extraction from a chat channel window -- pure,
+caller-injected.
+
+Pure: takes messages and an injectable async LLM caller, returns a JSON
+string (or None on any failure). No Discord or DB imports, so it needs no
+session fixture to test. Callers own fetching the window
+(chat.store.MessageStore.fetch_window) and building the caller
+(chat.summarizer.build_llm_caller); this module only formats, prompts, and
+validates the model's structured reply.
+
+The returned source_window metadata is computed from the input messages,
+never trusted from the model reply, so a downstream consumer (the
+Firecracker guest reading /injected-context/channel-data.json) can rely on
+it.
+"""
+
+import json
+import logging
+from collections.abc import Awaitable, Callable
+
+from chat.models import Message
+
+logger = logging.getLogger(__name__)
+
+# Row cap on the extracted dataset. A reply over this is rejected rather than
+# truncated: truncating silently would let a caller present a partial dataset
+# as complete.
+MAX_ROWS = 200
+
+_EXTRACT_PROMPT = (
+    "The user wants a structured dataset extracted from the following "
+    "Discord conversation window. Reply with STRICT JSON ONLY (no markdown, "
+    "no preamble, no code fences) in this exact shape:\n"
+    '{{"title": "short dataset title", "columns": ["col1", "col2", ...], '
+    '"rows": [["value", "value", ...], ...]}}\n'
+    "Every row must have exactly one value per column, in the same order as "
+    "columns. Keep it to at most {max_rows} rows; if there are more "
+    "candidates, pick the {max_rows} most relevant.\n\n"
+    'User request: "{request}"\n\n'
+    "Messages:\n{messages}"
+)
+
+
+def _format_lines(messages: list[Message]) -> list[str]:
+    return [
+        f"[{m.created_at.strftime('%H:%M')}] {m.username}: {m.content}"
+        for m in messages
+    ]
+
+
+def _extract_json(raw: str) -> str:
+    """Pull the first {...} object out of a model reply (tolerates code
+    fences and stray text around the JSON)."""
+    s = raw.find("{")
+    e = raw.rfind("}")
+    return raw[s : e + 1] if s != -1 and e != -1 and e > s else raw
+
+
+def _validated_fields(data: object) -> tuple[str, list[str], list[list[object]]] | None:
+    """Check the parsed reply against the extract_dataset contract, returning
+    the (title, columns, rows) tuple on success or None on any violation."""
+    if not isinstance(data, dict):
+        return None
+
+    title = data.get("title")
+    if not isinstance(title, str) or not title:
+        return None
+
+    columns = data.get("columns")
+    if (
+        not isinstance(columns, list)
+        or not columns
+        or not all(isinstance(c, str) for c in columns)
+    ):
+        return None
+
+    rows = data.get("rows")
+    if not isinstance(rows, list) or len(rows) > MAX_ROWS:
+        return None
+    for row in rows:
+        if not isinstance(row, list) or len(row) != len(columns):
+            return None
+
+    return title, columns, rows
+
+
+async def extract_dataset(
+    messages: list[Message],
+    request: str,
+    caller: Callable[[str], Awaitable[str]],
+) -> str | None:
+    """Extract a structured title/columns/rows dataset from a message window.
+
+    ``messages`` must be chronological oldest-first (fetch_window's
+    contract). On success returns a JSON string of {"title", "columns",
+    "rows", "source_window"}, where source_window ({"messages": N, "oldest":
+    ISO timestamp of the oldest message}) is computed from the input
+    messages, never trusted from the model reply. Returns None if messages is
+    empty (without calling caller), if the reply fails to parse or validate,
+    or if caller raises: this is a fail-open contract, so a caller can treat
+    None as "no dataset, dispatch proceeds without one".
+    """
+    if not messages:
+        return None
+
+    lines = _format_lines(messages)
+    prompt = _EXTRACT_PROMPT.format(
+        max_rows=MAX_ROWS, request=request, messages="\n".join(lines)
+    )
+
+    try:
+        raw = await caller(prompt)
+        data = json.loads(_extract_json(raw))
+    except Exception:
+        logger.exception("channel_data: extract_dataset caller/parse failed")
+        return None
+
+    validated = _validated_fields(data)
+    if validated is None:
+        logger.warning("channel_data: extract_dataset reply failed validation")
+        return None
+    title, columns, rows = validated
+
+    result = {
+        "title": title,
+        "columns": columns,
+        "rows": rows,
+        "source_window": {
+            "messages": len(messages),
+            "oldest": messages[0].created_at.isoformat(),
+        },
+    }
+    return json.dumps(result)

--- a/projects/monolith/chat/channel_data_test.py
+++ b/projects/monolith/chat/channel_data_test.py
@@ -228,3 +228,22 @@ class TestCallerFailsOpen:
     async def test_caller_exception_returns_none_not_raise(self, messages):
         result = await extract_dataset(messages, "req", _RaisingCaller())
         assert result is None
+
+
+class TestNoneEscapeHatch:
+    @pytest.mark.asyncio
+    async def test_none_reply_returns_none(self, messages):
+        # The model's documented escape hatch for a request that isn't
+        # actually asking for a dataset; falls out of the ordinary
+        # validation path (no "title") with no special-casing needed.
+        reply = json.dumps({"none": True})
+        result = await extract_dataset(
+            messages, "how's everyone doing?", _FakeCaller(reply)
+        )
+        assert result is None
+
+    def test_prompt_documents_the_none_escape_hatch(self):
+        from chat.channel_data import _EXTRACT_PROMPT
+
+        prompt = _EXTRACT_PROMPT.format(max_rows=200, request="req", messages="m")
+        assert '{"none": true}' in prompt

--- a/projects/monolith/chat/channel_data_test.py
+++ b/projects/monolith/chat/channel_data_test.py
@@ -1,0 +1,230 @@
+"""Tests for chat.channel_data -- structured dataset extraction."""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from chat.channel_data import MAX_ROWS, extract_dataset
+from chat.models import Message
+
+
+class _FakeCaller:
+    """Records every prompt it is called with; returns a canned response."""
+
+    def __init__(self, response: str = "{}"):
+        self.prompts: list[str] = []
+        self._response = response
+
+    async def __call__(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return self._response
+
+
+class _RaisingCaller:
+    async def __call__(self, prompt: str) -> str:
+        raise RuntimeError("caller boom")
+
+
+def _make_message(
+    *, username: str, content: str, minutes_ago: int, base: datetime
+) -> Message:
+    return Message(
+        discord_message_id=f"{minutes_ago}",
+        channel_id="ch1",
+        user_id=username.lower(),
+        username=username,
+        content=content,
+        is_bot=False,
+        embedding=[],
+        created_at=base - timedelta(minutes=minutes_ago),
+    )
+
+
+@pytest.fixture
+def base_time():
+    return datetime(2026, 7, 4, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def messages(base_time):
+    return [
+        _make_message(
+            username="Alice",
+            content="we shipped 3 features",
+            minutes_ago=5,
+            base=base_time,
+        ),
+        _make_message(
+            username="Bob", content="and fixed 2 bugs", minutes_ago=1, base=base_time
+        ),
+    ]
+
+
+_VALID_REPLY = json.dumps(
+    {
+        "title": "Weekly counts",
+        "columns": ["person", "count"],
+        "rows": [["Alice", 3], ["Bob", 2]],
+    }
+)
+
+
+class TestEmptyWindow:
+    @pytest.mark.asyncio
+    async def test_empty_messages_returns_none_without_calling_caller(self):
+        caller = _FakeCaller(_VALID_REPLY)
+        result = await extract_dataset([], "count features", caller)
+        assert result is None
+        assert caller.prompts == []
+
+
+class TestSuccessfulExtraction:
+    @pytest.mark.asyncio
+    async def test_prompt_includes_formatted_messages_and_request(self, messages):
+        caller = _FakeCaller(_VALID_REPLY)
+        await extract_dataset(messages, "count features per person", caller)
+        assert len(caller.prompts) == 1
+        prompt = caller.prompts[0]
+        assert "[11:55] Alice: we shipped 3 features" in prompt
+        assert "[11:59] Bob: and fixed 2 bugs" in prompt
+        assert "count features per person" in prompt
+
+    @pytest.mark.asyncio
+    async def test_returns_json_string_with_title_columns_rows(self, messages):
+        caller = _FakeCaller(_VALID_REPLY)
+        result = await extract_dataset(messages, "count features", caller)
+        assert result is not None
+        data = json.loads(result)
+        assert data["title"] == "Weekly counts"
+        assert data["columns"] == ["person", "count"]
+        assert data["rows"] == [["Alice", 3], ["Bob", 2]]
+
+    @pytest.mark.asyncio
+    async def test_source_window_computed_from_input_messages_not_model(
+        self, messages, base_time
+    ):
+        # A malicious/confused reply claiming a different window is ignored:
+        # source_window must reflect the actual input messages.
+        reply = json.dumps(
+            {
+                "title": "t",
+                "columns": ["a"],
+                "rows": [["1"]],
+                "source_window": {
+                    "messages": 999,
+                    "oldest": "2000-01-01T00:00:00+00:00",
+                },
+            }
+        )
+        caller = _FakeCaller(reply)
+        result = await extract_dataset(messages, "req", caller)
+        data = json.loads(result)
+        assert data["source_window"]["messages"] == len(messages)
+        assert data["source_window"]["oldest"] == messages[0].created_at.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_strips_markdown_code_fences_before_parsing(self, messages):
+        fenced = f"```json\n{_VALID_REPLY}\n```"
+        caller = _FakeCaller(fenced)
+        result = await extract_dataset(messages, "count features", caller)
+        assert result is not None
+        data = json.loads(result)
+        assert data["title"] == "Weekly counts"
+
+    @pytest.mark.asyncio
+    async def test_tolerates_stray_preamble_text_around_json(self, messages):
+        chatty = f"Sure, here you go:\n{_VALID_REPLY}\nHope that helps!"
+        caller = _FakeCaller(chatty)
+        result = await extract_dataset(messages, "count features", caller)
+        assert result is not None
+        data = json.loads(result)
+        assert data["title"] == "Weekly counts"
+
+
+class TestValidationFailures:
+    @pytest.mark.asyncio
+    async def test_unparseable_json_returns_none(self, messages):
+        caller = _FakeCaller("not json at all")
+        result = await extract_dataset(messages, "req", caller)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_missing_title_returns_none(self, messages):
+        reply = json.dumps({"columns": ["a"], "rows": [["1"]]})
+        result = await extract_dataset(messages, "req", _FakeCaller(reply))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_title_returns_none(self, messages):
+        reply = json.dumps({"title": "", "columns": ["a"], "rows": [["1"]]})
+        result = await extract_dataset(messages, "req", _FakeCaller(reply))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_missing_columns_returns_none(self, messages):
+        reply = json.dumps({"title": "t", "rows": [["1"]]})
+        result = await extract_dataset(messages, "req", _FakeCaller(reply))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_columns_returns_none(self, messages):
+        reply = json.dumps({"title": "t", "columns": [], "rows": []})
+        result = await extract_dataset(messages, "req", _FakeCaller(reply))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_non_string_column_returns_none(self, messages):
+        reply = json.dumps({"title": "t", "columns": ["a", 1], "rows": []})
+        result = await extract_dataset(messages, "req", _FakeCaller(reply))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_row_length_mismatch_returns_none(self, messages):
+        reply = json.dumps(
+            {"title": "t", "columns": ["a", "b"], "rows": [["1", "2", "3"]]}
+        )
+        result = await extract_dataset(messages, "req", _FakeCaller(reply))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_row_not_a_list_returns_none(self, messages):
+        reply = json.dumps({"title": "t", "columns": ["a"], "rows": ["not-a-row"]})
+        result = await extract_dataset(messages, "req", _FakeCaller(reply))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_too_many_rows_returns_none(self, messages):
+        reply = json.dumps(
+            {
+                "title": "t",
+                "columns": ["a"],
+                "rows": [[str(i)] for i in range(MAX_ROWS + 1)],
+            }
+        )
+        result = await extract_dataset(messages, "req", _FakeCaller(reply))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_exactly_max_rows_is_accepted(self, messages):
+        reply = json.dumps(
+            {
+                "title": "t",
+                "columns": ["a"],
+                "rows": [[str(i)] for i in range(MAX_ROWS)],
+            }
+        )
+        result = await extract_dataset(messages, "req", _FakeCaller(reply))
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_reply_that_is_a_json_list_not_object_returns_none(self, messages):
+        result = await extract_dataset(messages, "req", _FakeCaller("[1, 2, 3]"))
+        assert result is None
+
+
+class TestCallerFailsOpen:
+    @pytest.mark.asyncio
+    async def test_caller_exception_returns_none_not_raise(self, messages):
+        result = await extract_dataset(messages, "req", _RaisingCaller())
+        assert result is None

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -15,6 +15,7 @@ helpers are synchronous and open their own session, so the bot calls them via
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import secrets
@@ -147,8 +148,14 @@ def _is_stale(row: GoosecrackerSession, now: datetime) -> bool:
     return (now - since) > STALE_AFTER
 
 
-def start_session(thread_id: str, prompt: str) -> dict:
+def start_session(thread_id: str, prompt: str, parent_channel_id: str = "") -> dict:
     """Record a new thread's transcript and dispatch the first artifact run.
+
+    ``parent_channel_id`` is the channel the /artifact command was run from (the
+    thread's parent), mirroring ``start_agent_session``'s param of the same
+    name; stored on the row so the runner can fetch channel-scoped context
+    (recent messages, and the extracted dataset) for the artifact build. Empty
+    when the caller has none to record (e.g. an older call site).
 
     Synchronous (opens its own session); call via ``asyncio.to_thread``. Returns
     the dispatch result (``thread_id`` + ``action``).
@@ -171,7 +178,13 @@ def start_session(thread_id: str, prompt: str) -> dict:
         discord_thread=thread_id,
     )
     with Session(get_engine()) as session:
-        session.add(GoosecrackerSession(discord_thread=thread_id, transcript=prompt))
+        session.add(
+            GoosecrackerSession(
+                discord_thread=thread_id,
+                parent_channel_id=parent_channel_id,
+                transcript=prompt,
+            )
+        )
         session.commit()
     return result
 
@@ -984,6 +997,53 @@ def _context_from_own_transcript(transcript: str) -> dict[str, str]:
         'it" against what the thread was already working on.\n'
     )
     return {"README.md": readme, "transcript.md": body}
+
+
+def _channel_dataset_window(thread_id: str) -> list[Message]:
+    """Fetch the recent message window for a thread's parent channel, oldest
+    first, or [] when the thread has no parent channel recorded (or the
+    channel has no messages). Sync; call via ``asyncio.to_thread``. Mirrors
+    the channel query ``build_injected_context`` uses, same message cap.
+    """
+    parent = parent_channel_for_thread(thread_id)
+    if not parent:
+        return []
+    with Session(get_engine()) as session:
+        rows = session.exec(
+            select(Message)
+            .where(Message.channel_id == parent)
+            .order_by(Message.created_at.desc())
+            .limit(_INJECTED_CONTEXT_MSG_LIMIT)
+        ).all()
+    return list(reversed(rows))
+
+
+async def build_channel_dataset(thread_id: str, request: str) -> str | None:
+    """Extract a structured dataset from an artifact thread's parent channel.
+
+    Attached to an artifact dispatch's ``/injected-context/channel-data.json``
+    so the guest can build a chart/table from real conversation data instead of
+    improvising. Delegates to ``chat.channel_data.extract_dataset`` once the
+    channel window is resolved.
+
+    Fail-open like ``build_roast``/``build_injected_context``: returns None
+    when the thread has no parent channel recorded, the channel has no
+    messages, or extraction fails for any reason (a Qwen outage must not block
+    an artifact dispatch, the exact class of bug that bit Phase 1). Sync DB
+    fetch is offloaded via ``asyncio.to_thread``; the rest is async (LLM call).
+    """
+    try:
+        window = await asyncio.to_thread(_channel_dataset_window, thread_id)
+        if not window:
+            return None
+        from chat.channel_data import extract_dataset
+        from chat.summarizer import build_llm_caller
+
+        caller = build_llm_caller()
+        return await extract_dataset(window, request, caller)
+    except Exception:
+        logger.exception("goosecracker: build_channel_dataset failed for %s", thread_id)
+        return None
 
 
 async def build_roast(attempt_text: str) -> str:

--- a/projects/monolith/chat/goosecracker_test.py
+++ b/projects/monolith/chat/goosecracker_test.py
@@ -3,6 +3,7 @@ session dispatch (ADR 024 Task 4). DB-backed tests run against in-memory SQLite
 with the chat schema stripped. goosecracker.api is injected as a fake module so
 the test does not pull the real executor (and so no run is dispatched)."""
 
+import json
 import sys
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
@@ -135,6 +136,28 @@ def test_start_session_records_transcript_and_dispatches(engine, fake_api):
         row = session.get(GoosecrackerSession, "thread-1")
         assert row is not None
         assert row.transcript == "build a clock"
+
+
+def test_start_session_records_parent_channel_id(engine, fake_api):
+    """The /artifact command's parent channel is recorded on the row, mirroring
+    start_agent_session, so parent_channel_for_thread resolves it later."""
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        goosecracker.start_session("thread-1", "build a clock", "channel-1")
+    with Session(engine) as session:
+        row = session.get(GoosecrackerSession, "thread-1")
+        assert row is not None
+        assert row.parent_channel_id == "channel-1"
+
+
+def test_start_session_defaults_parent_channel_id_to_empty(engine, fake_api):
+    """Callers that omit parent_channel_id (e.g. an older call site) still work:
+    the row gets the field's empty default rather than an error."""
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        goosecracker.start_session("thread-1", "build a clock")
+    with Session(engine) as session:
+        row = session.get(GoosecrackerSession, "thread-1")
+        assert row is not None
+        assert row.parent_channel_id == ""
 
 
 def test_continue_session_appends_and_resubmits_full_transcript(engine, fake_api):
@@ -392,6 +415,131 @@ class TestBuildInjectedContext:
         with patch("chat.goosecracker.get_engine", return_value=engine):
             bundle = goosecracker.build_injected_context("thr-first", tier="")
         assert bundle == {}
+
+
+class _FakeDatasetCaller:
+    """Records the prompt it was called with; returns a canned reply."""
+
+    def __init__(self, response: str):
+        self.prompts: list[str] = []
+        self._response = response
+
+    async def __call__(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return self._response
+
+
+class TestBuildChannelDataset:
+    """chat.summarizer.build_llm_caller is the established seam to patch (same
+    as TestBuildRoast further down); extract_dataset itself is exercised in
+    chat/channel_data_test.py, so these tests focus on the wiring: window
+    resolution and fail-open behavior."""
+
+    @pytest.mark.asyncio
+    async def test_no_parent_channel_returns_none_without_calling_caller(
+        self, engine, fake_api
+    ):
+        with Session(engine) as session:
+            session.add(
+                GoosecrackerSession(
+                    discord_thread="thr-art",
+                    recipe="artifact",
+                    tier="artifact",
+                    parent_channel_id="",
+                )
+            )
+            session.commit()
+
+        caller = _FakeDatasetCaller("{}")
+        with (
+            patch("chat.goosecracker.get_engine", return_value=engine),
+            patch("chat.summarizer.build_llm_caller", return_value=caller),
+        ):
+            result = await goosecracker.build_channel_dataset("thr-art", "count bugs")
+
+        assert result is None
+        assert caller.prompts == []
+
+    @pytest.mark.asyncio
+    async def test_parent_channel_with_no_messages_returns_none(self, engine, fake_api):
+        with Session(engine) as session:
+            session.add(
+                GoosecrackerSession(
+                    discord_thread="thr-art",
+                    recipe="artifact",
+                    tier="artifact",
+                    parent_channel_id="chan-empty",
+                )
+            )
+            session.commit()
+
+        caller = _FakeDatasetCaller("{}")
+        with (
+            patch("chat.goosecracker.get_engine", return_value=engine),
+            patch("chat.summarizer.build_llm_caller", return_value=caller),
+        ):
+            result = await goosecracker.build_channel_dataset("thr-art", "count bugs")
+
+        assert result is None
+        assert caller.prompts == []
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_extract_dataset_with_channel_window(
+        self, engine, fake_api
+    ):
+        with Session(engine) as session:
+            session.add(
+                GoosecrackerSession(
+                    discord_thread="thr-art",
+                    recipe="artifact",
+                    tier="artifact",
+                    parent_channel_id="chan-1",
+                )
+            )
+            session.commit()
+            _msg(session, "chan-1", "alice", "we shipped 3 features", 1)
+            _msg(session, "chan-1", "bob", "and fixed 2 bugs", 2)
+
+        reply = json.dumps({"title": "t", "columns": ["a"], "rows": [["1"]]})
+        caller = _FakeDatasetCaller(reply)
+        with (
+            patch("chat.goosecracker.get_engine", return_value=engine),
+            patch("chat.summarizer.build_llm_caller", return_value=caller),
+        ):
+            result = await goosecracker.build_channel_dataset(
+                "thr-art", "count features per person"
+            )
+
+        assert result is not None
+        assert json.loads(result)["title"] == "t"
+        assert len(caller.prompts) == 1
+        assert "we shipped 3 features" in caller.prompts[0]
+        assert "count features per person" in caller.prompts[0]
+
+    @pytest.mark.asyncio
+    async def test_caller_exception_returns_none_not_raise(self, engine, fake_api):
+        with Session(engine) as session:
+            session.add(
+                GoosecrackerSession(
+                    discord_thread="thr-art",
+                    recipe="artifact",
+                    tier="artifact",
+                    parent_channel_id="chan-1",
+                )
+            )
+            session.commit()
+            _msg(session, "chan-1", "alice", "hello", 1)
+
+        def _raise():
+            raise RuntimeError("no model configured")
+
+        with (
+            patch("chat.goosecracker.get_engine", return_value=engine),
+            patch("chat.summarizer.build_llm_caller", side_effect=_raise),
+        ):
+            result = await goosecracker.build_channel_dataset("thr-art", "count bugs")
+
+        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.9
+      targetRevision: 0.285.10
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -631,6 +631,29 @@ async def _invoke_turn(
                 "continuing without it",
                 session,
             )
+        # Task 3.2: attach an extracted dataset for an artifact dispatch only
+        # (the agent-route gap is a documented follow-up, out of scope here).
+        # build_channel_dataset is already fail-open internally (a Qwen outage
+        # must not block the dispatch), but it is wrapped again here so a
+        # surprise exception in the chat.api boundary itself cannot fail the
+        # run either.
+        if recipe == "artifact":
+            from chat.api import build_channel_dataset
+
+            try:
+                dataset = await build_channel_dataset(discord_thread, task)
+            except Exception:
+                logger.exception(
+                    "goosecracker: build_channel_dataset failed for %s; "
+                    "continuing without it",
+                    session,
+                )
+                dataset = None
+            if dataset is not None:
+                injected_context = {
+                    **injected_context,
+                    "channel-data.json": dataset,
+                }
     # WS2 - Hydration: default the mirror and ref when the caller did not
     # specify them. The mirror is read from GOOSECRACKER_GIT_MIRROR, injected
     # via Helm values. An empty effective_mirror means no clone (no mirror

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -606,6 +606,124 @@ async def test_run_one_turn_ships_injected_context_in_payload(monkeypatch):
     assert captured_payload["injectedContext"]["transcript.md"] == "hi"
 
 
+async def _run_artifact_turn_with_dataset_producer(monkeypatch, producer):
+    """Shared setup for the channel-data.json wiring tests (Task 3.2): stub
+    every seam _run_one_turn touches (mirrors
+    test_run_one_turn_ships_injected_context_in_payload) for an
+    artifact-recipe turn, with ``producer`` standing in for
+    chat.api.build_channel_dataset. Returns the captured fc-invoke payload."""
+    import chat.api
+
+    captured_payload = {}
+
+    async def fake_post(url, payload, on_retry):
+        captured_payload.update(payload)
+        return {"status": "ok", "result": "done", "sessionDb": ""}
+
+    monkeypatch.setattr(runner, "_post_agent_run", fake_post)
+    monkeypatch.setattr(runner, "FC_INVOKE_URL", "http://fc-invoke")
+    monkeypatch.setattr(runner.sessions, "load", MagicMock(return_value=None))
+    monkeypatch.setattr(runner.threads, "mark_completed", MagicMock())
+    monkeypatch.setattr(runner, "_deliver", AsyncMock())
+    monkeypatch.setattr(runner, "_mark_progress_done", MagicMock())
+    monkeypatch.setattr(runner, "_persist_session_db", AsyncMock())
+    monkeypatch.setattr(chat.api, "reset_goosecracker_progress", MagicMock())
+    monkeypatch.setattr(chat.api, "ensure_steering_token", lambda _s: "")
+    monkeypatch.setattr(
+        chat.api, "build_injected_context", lambda tid, tier="": {"transcript.md": "hi"}
+    )
+    monkeypatch.setattr(chat.api, "build_channel_dataset", producer)
+
+    ok = await runner._run_one_turn(
+        "sess-1",
+        task="q",
+        recipe="artifact",
+        tier="artifact",
+        git_mirror="",
+        git_ref="",
+        discord_thread="thr-1",
+    )
+    assert ok is True
+    return captured_payload
+
+
+async def test_run_one_turn_artifact_with_dataset_ships_channel_data_json(
+    monkeypatch,
+):
+    """Task 3.2: an artifact-recipe turn whose extraction succeeds ships the
+    dataset alongside the ADR 040 per-turn context, never replacing it."""
+    producer = AsyncMock(return_value='{"title": "t"}')
+    payload = await _run_artifact_turn_with_dataset_producer(monkeypatch, producer)
+
+    producer.assert_called_once_with("thr-1", "q")
+    assert payload["injectedContext"]["channel-data.json"] == '{"title": "t"}'
+    assert payload["injectedContext"]["transcript.md"] == "hi"
+
+
+async def test_run_one_turn_artifact_without_dataset_omits_key(monkeypatch):
+    """None (no channel to extract from, or a fail-open) means no key at all,
+    not an empty string: the guest's presence check must be a clean miss."""
+    producer = AsyncMock(return_value=None)
+    payload = await _run_artifact_turn_with_dataset_producer(monkeypatch, producer)
+
+    assert "channel-data.json" not in payload["injectedContext"]
+
+
+async def test_run_one_turn_artifact_dataset_producer_raising_still_dispatches(
+    monkeypatch,
+):
+    """A surprise exception from the chat.api boundary itself (build_channel_
+    dataset is already fail-open internally, but this is belt-and-suspenders)
+    must not fail the dispatch: the run still succeeds, just without the key."""
+    producer = AsyncMock(side_effect=RuntimeError("boom"))
+    payload = await _run_artifact_turn_with_dataset_producer(monkeypatch, producer)
+
+    assert "channel-data.json" not in payload["injectedContext"]
+
+
+async def test_run_one_turn_agent_recipe_never_calls_build_channel_dataset(
+    monkeypatch,
+):
+    """The dataset attachment is artifact-recipe only (Task 3.2); the agent
+    route is a documented follow-up, out of scope here."""
+    import chat.api
+
+    captured_payload = {}
+
+    async def fake_post(url, payload, on_retry):
+        captured_payload.update(payload)
+        return {"status": "ok", "result": "done", "sessionDb": ""}
+
+    monkeypatch.setattr(runner, "_post_agent_run", fake_post)
+    monkeypatch.setattr(runner, "FC_INVOKE_URL", "http://fc-invoke")
+    monkeypatch.setattr(runner.sessions, "load", MagicMock(return_value=None))
+    monkeypatch.setattr(runner.threads, "mark_completed", MagicMock())
+    monkeypatch.setattr(runner, "_deliver", AsyncMock())
+    monkeypatch.setattr(runner, "_mark_progress_done", MagicMock())
+    monkeypatch.setattr(runner, "_persist_session_db", AsyncMock())
+    monkeypatch.setattr(chat.api, "reset_goosecracker_progress", MagicMock())
+    monkeypatch.setattr(chat.api, "ensure_steering_token", lambda _s: "")
+    monkeypatch.setattr(
+        chat.api, "build_injected_context", lambda tid, tier="": {"transcript.md": "hi"}
+    )
+    producer = AsyncMock(return_value='{"title": "t"}')
+    monkeypatch.setattr(chat.api, "build_channel_dataset", producer)
+
+    ok = await runner._run_one_turn(
+        "sess-1",
+        task="q",
+        recipe="agent",
+        tier="",
+        git_mirror="",
+        git_ref="",
+        discord_thread="thr-1",
+    )
+
+    assert ok is True
+    producer.assert_not_called()
+    assert "channel-data.json" not in captured_payload["injectedContext"]
+
+
 def _one_step_plan():
     """A minimal Plan for the plan-delivery payload tests (Task 6)."""
     from chat.orchestrator_plan import Plan, PlanStep


### PR DESCRIPTION
Phase 3 of docs/plans/2026-07-04-ambient-assistant-parity.md (ADR 043, Feature C).

- `chat/channel_data.py`: strict-JSON dataset extraction over a channel window (title/columns/rows, 200-row cap, host-computed `source_window`, `{"none": true}` escape hatch, None on any failure)
- `build_channel_dataset` producer wired into `_invoke_turn`'s injected-context block, gated to `recipe == "artifact"`, fail-open at both layers: the guest receives `/injected-context/channel-data.json` only when extraction succeeded
- Fix en route: artifact threads never recorded `parent_channel_id` (only agent threads did), so the parent-channel resolution was structurally dead for the exact path this feature serves. `start_session` now accepts and persists it; the /artifact handler passes `channel.id`. Call-site sweep of `parent_channel_for_thread` confirmed no behavior change elsewhere (the #3096 rephrase path is unreachable for artifact recipe by `_delivery_message` branching).
- `artifact-build.yaml` prompt teaches the guest to render from the dataset and cite the source window (goose resolves `recipe="artifact"` to this file by its `title`); fc-invoke chart 0.4.34 bumped so guests receive it

Known scope edge (by design): the router-mediated artifact path (agent recipe delegating to artifact-build) does not receive channel-data.json yet; only the direct /artifact command does. Documented follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjE3s1K8v3yVnHLSeAj6zg