### PR TITLE
feat(chat): directive evolution observer (ADR 043 Phase 4)

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -937,6 +937,18 @@ py_test(
 )
 
 py_test(
+    name = "chat_observer_test",
+    srcs = ["chat/observer_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
     name = "chat_outbox_test",
     srcs = ["chat/outbox_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -949,6 +949,19 @@ py_test(
 )
 
 py_test(
+    name = "chat_observer_job_test",
+    srcs = ["chat/observer_job_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "chat_outbox_test",
     srcs = ["chat/outbox_test.py"],
     imports = ["."],

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -333,6 +333,23 @@ def chat_drain_reminders() -> None:
     _run_job("chat-drain-reminders", "chat.jobs", "drain_reminders_handler")
 
 
+@app.command("chat-observe-directives")
+def chat_observe_directives() -> None:
+    """Propose channel directive updates from repeated style corrections.
+
+    One-shot of chat.observer_job.observe_directives_handler. Observes only
+    ambient-granted channels (ADR 029), classifies recent bot-directed messages
+    for recurring style friction via Qwen (needs LLAMA_CPP_URL), and enqueues at
+    most one directive-proposal outbox row per channel; the leader's outbox drain
+    posts it and wires the propose-then-confirm flow. Sensitivity is env config:
+    OBSERVER_MIN_EVIDENCE (default 3), OBSERVER_COOLDOWN_DAYS (default 14)."""
+    _run_job(
+        "chat-observe-directives",
+        "chat.observer_job",
+        "observe_directives_handler",
+    )
+
+
 @app.command("evict-artifact-sessions")
 def evict_artifact_sessions() -> None:
     """Evict goose session DBs older than the TTL (ADR 026 Phase 2 Task 2.5).

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.8
+version: 0.285.11
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260704210000_directive_proposal_outbox_kind.sql
+++ b/projects/monolith/chart/migrations/20260704210000_directive_proposal_outbox_kind.sql
@@ -1,0 +1,11 @@
+-- Directive-proposal outbox rows (ADR 035 Phase 4 observer). The observer job
+-- enqueues a normal content post tagged kind='directive_proposal' whose
+-- payload_json carries the channel_id / directive_change / evidence /
+-- motivating_message_id that the leader's drain post-hook needs to wire the
+-- propose-then-confirm flow against the message id it just posted. Plain posts
+-- and reaction/edit rows leave kind='' and payload_json NULL, so this is purely
+-- additive: existing rows and producers are unaffected. Columns mirror the
+-- SQLModel fields so the SQLite test fixtures build the same shape.
+ALTER TABLE chat.discord_outbox
+    ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS payload_json TEXT;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:jAKlupQluxE6qaFthiDqQ/uAhPfyi+ezu/Eqs8aAyJI=
+h1:SPw/aVsFjjv4XQL0hVqvCkOpPxphvhzyRsmvrbsLA7s=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -97,3 +97,4 @@ h1:jAKlupQluxE6qaFthiDqQ/uAhPfyi+ezu/Eqs8aAyJI=
 20260704000000_grimoire_public_reader_grant.sql h1:ZRY8zkuHoX0vtFNbJvP+hBaZp0BdyJ3k0Y5I4U1dx6U=
 20260704010000_grimoire_public_reader_book_extraction.sql h1:Edzhx2fHIgTcRRWOHRR8Re36NJ6fdEg7rMi45QwipQ8=
 20260704203000_chat_reminder.sql h1:Rm7UZ7yhiYgaS5txOFa+uh6oWF1fAmdgvk12BqfH8jA=
+20260704210000_directive_proposal_outbox_kind.sql h1:QxDEAtMyvV0386GJSwG5muHfBJfj4E+n0qVlGlMV384=

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -463,6 +463,29 @@ jobs:
           memory: 256Mi
         limits:
           memory: 256Mi
+    # chat.observe_directives: weekly (Fri 18:00 UTC). Scans ambient-granted
+    # channels for recurring style friction and enqueues at most one
+    # directive-proposal outbox row per channel; the leader drain posts it and
+    # wires the 👍/👎 confirm flow. Sensitivity is env config: OBSERVER_MIN_EVIDENCE
+    # (min distinct evidence messages the classifier must cite) and
+    # OBSERVER_COOLDOWN_DAYS (suppress a channel that saw a recent proposal). The
+    # LLM classify hits Qwen via LLAMA_CPP_URL (injected into the workflows pod).
+    - name: chat-observe-directives
+      args: ["chat-observe-directives"]
+      schedule: "0 18 * * 5"
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 600
+      suspend: false
+      env:
+        LLAMA_CPP_URL: "http://inference.inference.svc.cluster.local:8080"
+        OBSERVER_MIN_EVIDENCE: "3"
+        OBSERVER_COOLDOWN_DAYS: "14"
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
     # campsites.refresh: hourly at :00 UTC (not aligned to the 07:00 PT
     # reservation-opening surge). Reads the static catalog.json, fetches BC Parks
     # availability (~145 paced curl_cffi calls) + Open-Meteo forecast (~145

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -110,6 +110,12 @@ class DiscordOutbox(SQLModel, table=True):
     sets neither. The CHECK mirrors the DB constraint so the SQLite test fixtures
     enforce it too (create_all does not see migration-only constraints, which is
     how a reaction row's NULL/NULL content once slipped past tests into prod).
+
+    kind tags a row that needs post-processing after it posts: a plain post
+    leaves kind="", while a directive_proposal row (enqueued by the observer
+    job) is a normal content post whose payload_json carries the channel /
+    directive_change / evidence the drain's post-hook needs to wire the
+    propose-then-confirm flow against the message id it just posted.
     """
 
     __tablename__ = "discord_outbox"
@@ -137,6 +143,10 @@ class DiscordOutbox(SQLModel, table=True):
     posted_at: datetime | None = Field(default=None)
     attempts: int = Field(default=0)
     last_error: str | None = Field(default=None)
+    # Post-hook discriminator: "" for a plain post, "directive_proposal" for a
+    # row the leader drain follows up on (payload_json below carries the args).
+    kind: str = Field(default="")
+    payload_json: str | None = Field(default=None)
 
 
 # nosemgrep: sqlmodel-datetime-without-factory (running_since is intentionally NULL until a turn goes running)

--- a/projects/monolith/chat/observer.py
+++ b/projects/monolith/chat/observer.py
@@ -1,0 +1,100 @@
+"""Directive-evolution observer (ADR 035 phase 4): style-friction classifier.
+
+Pure: takes a list of recent user messages directed at the bot and an
+injectable async LLM caller, returns a directive-change proposal or None. No
+Discord or DB imports, so it needs no session fixture to test. Callers (Task
+4.2) own fetching the exchanges (ambient-granted channels only) and wiring
+``min_evidence`` from values/env; this module only classifies and prompts.
+"""
+
+import json
+import logging
+from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+_FRICTION_PROMPT = (
+    "You are reviewing recent messages a user sent to a Discord bot, looking "
+    "for RECURRING style friction: the SAME kind of correction repeated more "
+    "than once (for example: replies too long, wrong tone, unwanted replies "
+    "when the bot should have stayed quiet, formatting complaints). A single "
+    "complaint, or several different complaints each raised only once, is "
+    "NOT recurring friction: report friction=false in that case.\n\n"
+    "If you do find recurring friction, describe the change ONLY in terms of "
+    'tone, attention, or interaction style, for example "reply more '
+    'concisely" or "stop replying unless directly addressed". NEVER '
+    "describe a change to tools, permissions, ACLs, ambient mode, or repo "
+    "access: those are out of scope for this classifier and must never "
+    "appear in directive_change.\n\n"
+    "Cite ONLY message_ids that are genuine evidence of the recurring "
+    "complaint, taken from the list below. Never invent an id that is not "
+    "in the list.\n\n"
+    "Messages (message_id: author: text):\n{exchanges}\n\n"
+    'Reply with ONLY a JSON object: {{"friction": true|false, '
+    '"directive_change": string, "evidence_message_ids": [string]}}. No '
+    "prose, no markdown."
+)
+
+
+def _format_exchanges(exchanges: list[dict]) -> str:
+    return "\n".join(
+        f"{e['message_id']}: {e['author']}: {e['text']}" for e in exchanges
+    )
+
+
+def _extract_json(raw: str) -> str:
+    """Pull the first {...} object out of a model reply (tolerates stray text)."""
+    s = raw.find("{")
+    e = raw.rfind("}")
+    return raw[s : e + 1] if s != -1 and e != -1 and e > s else raw
+
+
+async def find_style_friction(
+    exchanges: list[dict],
+    caller: Callable[[str], Awaitable[str]],
+    min_evidence: int = 3,
+) -> dict | None:
+    """Classify recent user exchanges for recurring style friction.
+
+    ``exchanges`` is a chronological-order-agnostic list of dicts
+    ``{"message_id": str, "author": str, "text": str}`` representing recent
+    user messages directed at the bot (replies/mentions), pre-fetched by the
+    caller. Returns ``None`` (fails closed) when: ``exchanges`` is empty (no
+    caller call made), the model reports no friction, fewer than
+    ``min_evidence`` evidence ids are cited, any cited id is not one of the
+    input message_ids (hallucinated evidence), ``directive_change`` is
+    empty/missing, the reply is unparseable, or the caller raises (logged).
+    On success returns ``{"directive_change": str, "evidence_message_ids":
+    [str]}`` with evidence ids deduplicated, order preserved.
+    """
+    if not exchanges:
+        return None
+    try:
+        known_ids = {e["message_id"] for e in exchanges}
+        prompt = _FRICTION_PROMPT.format(exchanges=_format_exchanges(exchanges))
+        raw = await caller(prompt)
+        data = json.loads(_extract_json(raw))
+
+        if not data.get("friction"):
+            return None
+
+        directive_change = data.get("directive_change")
+        if not isinstance(directive_change, str) or not directive_change.strip():
+            return None
+
+        evidence_ids = data.get("evidence_message_ids")
+        if not isinstance(evidence_ids, list) or not evidence_ids:
+            return None
+        deduped_ids = list(dict.fromkeys(evidence_ids))
+        if not set(deduped_ids).issubset(known_ids):
+            return None
+        if len(deduped_ids) < min_evidence:
+            return None
+
+        return {
+            "directive_change": directive_change,
+            "evidence_message_ids": deduped_ids,
+        }
+    except Exception:
+        logger.exception("observer: style-friction classify failed")
+        return None

--- a/projects/monolith/chat/observer_job.py
+++ b/projects/monolith/chat/observer_job.py
@@ -1,0 +1,252 @@
+"""Weekly directive-evolution observer (ADR 035 phase 4).
+
+Proposes per-channel behavioural directive updates when a channel shows the SAME
+style correction repeated more than once. Runs as the ``chat-observe-directives``
+Argo CronWorkflow one-shot (``app/jobs_main.py``, ``chart/values.yaml``
+``jobs.cronWorkflows``), never the dead in-process scheduler: the cron schedule
+in values.yaml is the sole cadence driver.
+
+Scope and safety (Joe's binding conditions):
+
+- **Ambient-granted channels only.** The observer runs exactly the set of
+  channels the attention gate does: those with an ADR 029 ambient grant
+  (``feature="ambient"``, ``subject_id=""`` server-wide, ``scope=<channel_id>``).
+  Ambient grants are per-channel, so this is a direct enumeration.
+- **Sensitivity is deploy-time config**, read from the job env: ``OBSERVER_MIN_EVIDENCE``
+  (default 3) is the minimum distinct evidence messages the classifier must cite;
+  ``OBSERVER_COOLDOWN_DAYS`` (default 14) suppresses a channel that already saw a
+  proposal recently. Cadence is the cron schedule itself.
+- **At most one new proposal per channel per run.**
+
+Exchange retrieval (design note): the ``Message`` schema has no reply or mention
+edges, so a "bot-directed user message" is approximated as a non-bot message
+whose immediately-preceding message in the recency window is a bot message, i.e.
+a user reacting to something the bot just said. That is exactly the
+style-friction signal (a correction of the bot), needs no bot-id configuration,
+and is deterministic. Recency is bounded by a newest-first message-count window.
+
+Concurrency: this follows ``chat.summarizer.conversational_chat_reply`` -- a sync
+DB fetch phase (``asyncio.to_thread``, own session), an async LLM classify phase,
+then a sync enqueue phase (``asyncio.to_thread``, own session). No ``Session``
+ever crosses an ``await`` (semgrep no-sync-session-in-async-def /
+no-session-in-to-thread).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+from sqlmodel import Session, select
+
+from chat import observer, outbox
+from chat.models import ChannelDirective, DiscordFeatureGrant, Message
+
+logger = logging.getLogger("monolith.chat.observer")
+
+_DEFAULT_MIN_EVIDENCE = 3
+_DEFAULT_COOLDOWN_DAYS = 14
+# Newest-first message-count window scanned per channel for friction. Only
+# bot-adjacent user messages become exchanges, so the classifier prompt stays far
+# smaller than this cap.
+_WINDOW_MESSAGES = 200
+# Evidence-snippet budget in the proposal message a human confirms against.
+_MAX_EVIDENCE_SNIPPETS = 3
+_SNIPPET_CHARS = 120
+
+
+def _int_env(name: str, default: int) -> int:
+    """Read a positive int knob from the job env, falling back to ``default`` on a
+    missing, unparseable, or non-positive value: a bad deploy value degrades to
+    the default rather than crashing or disabling the run."""
+    try:
+        value = int(os.environ.get(name, ""))
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def _granted_channel_ids(session: Session) -> list[str]:
+    """Every channel with an ADR 029 ambient grant, across all servers.
+
+    Ambient grants are per-channel (``feature="ambient"``, ``subject_id=""``
+    server-wide, ``scope=<channel_id>``), so the observer's scope is exactly the
+    attention gate's. Deduped and sorted for a stable iteration order.
+    """
+    rows = session.exec(
+        select(DiscordFeatureGrant).where(DiscordFeatureGrant.feature == "ambient")
+    ).all()
+    return sorted({r.scope for r in rows if r.subject_id == "" and r.scope})
+
+
+def _cooldown_active(
+    session: Session, channel_id: str, now: datetime, cooldown_days: int
+) -> bool:
+    """True if the channel saw any directive proposal within the cooldown window.
+
+    A proposal row is any ``ChannelDirective`` with a non-empty
+    ``proposal_message_id`` (both the human /agent path and this observer set it;
+    a seed or reset does not). Blocking on ANY such row inside the window covers
+    both a genuinely-open proposal awaiting 👍/👎 and a just-resolved one: a
+    proposal is only applicable for ``directives.PROPOSAL_TTL`` (10 minutes), far
+    inside the default 14-day cooldown, so a beyond-cooldown inactive proposal is
+    already terminal and correctly stops blocking. This is why the observer needs
+    no open-vs-discarded schema flag.
+    """
+    cutoff = now - timedelta(days=cooldown_days)
+    row = session.exec(
+        select(ChannelDirective)
+        .where(ChannelDirective.channel_id == channel_id)
+        .where(ChannelDirective.proposal_message_id != "")
+        .where(ChannelDirective.created_at >= cutoff)
+        .limit(1)
+    ).first()
+    return row is not None
+
+
+def _channel_exchanges(session: Session, channel_id: str) -> list[dict]:
+    """Recent bot-directed user messages in a channel, shaped as
+    ``find_style_friction`` exchanges (``{"message_id", "author", "text"}``).
+
+    A bot-directed message is a non-bot message immediately following a bot
+    message in the newest-first window (see module docstring). ``message_id`` is
+    the Discord id so the classifier's cited evidence ids line up with the ids the
+    proposal message quotes back and the drain hook stamps as motivating.
+    """
+    newest_first = list(
+        session.exec(
+            select(Message)
+            .where(Message.channel_id == channel_id)
+            .order_by(Message.created_at.desc())
+            .limit(_WINDOW_MESSAGES)
+        ).all()
+    )
+    window = list(reversed(newest_first))  # chronological, oldest first
+    exchanges: list[dict] = []
+    prev_is_bot = False
+    for msg in window:
+        if not msg.is_bot and prev_is_bot:
+            exchanges.append(
+                {
+                    "message_id": msg.discord_message_id,
+                    "author": msg.username,
+                    "text": msg.content,
+                }
+            )
+        prev_is_bot = msg.is_bot
+    return exchanges
+
+
+def _gather_candidates(
+    now: datetime, cooldown_days: int
+) -> list[tuple[str, list[dict]]]:
+    """Sync DB phase: ``(channel_id, exchanges)`` for every ambient-granted
+    channel that is off cooldown and has at least one bot-directed exchange.
+
+    Opens its own session (runs under ``asyncio.to_thread``, so it must never
+    touch the caller's session).
+    """
+    from app.db import get_engine
+
+    candidates: list[tuple[str, list[dict]]] = []
+    with Session(get_engine()) as session:
+        for channel_id in _granted_channel_ids(session):
+            if _cooldown_active(session, channel_id, now, cooldown_days):
+                continue
+            exchanges = _channel_exchanges(session, channel_id)
+            if exchanges:
+                candidates.append((channel_id, exchanges))
+    return candidates
+
+
+def _truncate(text: str, limit: int) -> str:
+    text = text.replace("\n", " ").strip()
+    return text if len(text) <= limit else text[: limit - 3].rstrip() + "..."
+
+
+def _proposal_content(
+    directive_change: str, evidence_ids: list[str], exchanges: list[dict]
+) -> str:
+    """Compose the proposal message: the interactive bot path's summary line plus
+    up to ``_MAX_EVIDENCE_SNIPPETS`` truncated evidence quotes, so a human
+    confirming has the context that motivated the change."""
+    by_id = {e["message_id"]: e for e in exchanges}
+    blocks = [
+        "Proposed directive for this channel:\n> "
+        + directive_change.replace("\n", "\n> ")
+    ]
+    snippets = []
+    for mid in evidence_ids[:_MAX_EVIDENCE_SNIPPETS]:
+        e = by_id.get(mid)
+        if e is not None:
+            snippets.append(f"> {e['author']}: {_truncate(e['text'], _SNIPPET_CHARS)}")
+    if snippets:
+        blocks.append("Based on repeated feedback like:\n" + "\n".join(snippets))
+    blocks.append("React 👍 to apply or 👎 to discard.")
+    return "\n\n".join(blocks)
+
+
+def _enqueue_proposal(channel_id: str, finding: dict, exchanges: list[dict]) -> None:
+    """Sync enqueue phase: stage exactly ONE directive-proposal outbox row for the
+    channel. Opens its own session (``asyncio.to_thread``). The drain's post-hook
+    runs the actual ``propose_update`` once it has the posted message id.
+    """
+    from app.db import get_engine
+
+    evidence_ids = finding["evidence_message_ids"]
+    directive_change = finding["directive_change"]
+    payload = {
+        "channel_id": channel_id,
+        "directive_change": directive_change,
+        "evidence_message_ids": evidence_ids,
+        "motivating_message_id": evidence_ids[0] if evidence_ids else "",
+    }
+    content = _proposal_content(directive_change, evidence_ids, exchanges)
+    with Session(get_engine()) as session:
+        outbox.enqueue_message(
+            session,
+            channel_id,
+            content=content,
+            kind="directive_proposal",
+            payload=payload,
+        )
+        session.commit()
+
+
+async def observe_directives_handler(session: Session) -> None:
+    """Observe ambient-granted channels for recurring style friction and enqueue
+    at most one directive proposal per channel.
+
+    The ``session`` argument (passed by the one-shot CLI wrapper) is unused: all
+    DB I/O runs in worker threads via ``asyncio.to_thread`` with their own
+    sessions. The Argo cron schedule drives cadence, so there is no next-run hint
+    to return.
+    """
+    min_evidence = _int_env("OBSERVER_MIN_EVIDENCE", _DEFAULT_MIN_EVIDENCE)
+    cooldown_days = _int_env("OBSERVER_COOLDOWN_DAYS", _DEFAULT_COOLDOWN_DAYS)
+    now = datetime.now(timezone.utc)
+
+    candidates = await asyncio.to_thread(_gather_candidates, now, cooldown_days)
+    if not candidates:
+        logger.info("chat.observer: no ambient channels with recent exchanges")
+        return
+
+    from chat.summarizer import build_llm_caller
+
+    caller = build_llm_caller()
+    proposed = 0
+    for channel_id, exchanges in candidates:
+        finding = await observer.find_style_friction(
+            exchanges, caller, min_evidence=min_evidence
+        )
+        if finding is None:
+            continue
+        await asyncio.to_thread(_enqueue_proposal, channel_id, finding, exchanges)
+        proposed += 1
+    logger.info(
+        "chat.observer: observed %d channel(s), proposed %d directive change(s)",
+        len(candidates),
+        proposed,
+    )

--- a/projects/monolith/chat/observer_job_test.py
+++ b/projects/monolith/chat/observer_job_test.py
@@ -39,10 +39,10 @@ def engine_fixture():
             table.schema = original[table.name]
 
 
-def _grant(session, scope, *, feature="ambient", subject_id=""):
+def _grant(session, scope, *, feature="ambient", subject_id="", guild_id="g1"):
     session.add(
         DiscordFeatureGrant(
-            guild_id="g1", subject_id=subject_id, feature=feature, scope=scope
+            guild_id=guild_id, subject_id=subject_id, feature=feature, scope=scope
         )
     )
 
@@ -94,7 +94,7 @@ def test_granted_channel_ids_only_server_wide_ambient(engine):
     with Session(engine) as session:
         _grant(session, "chanA")
         _grant(session, "chanB")
-        _grant(session, "chanA")  # duplicate scope, deduped
+        _grant(session, "chanA", guild_id="g2")  # same scope other guild, deduped
         _grant(session, "chanC", feature="agent")  # wrong feature, ignored
         _grant(session, "chanD", subject_id="u1")  # per-user ambient, ignored
         _grant(session, "")  # whole-feature ambient (no channel), ignored

--- a/projects/monolith/chat/observer_job_test.py
+++ b/projects/monolith/chat/observer_job_test.py
@@ -1,0 +1,284 @@
+"""Tests for chat.observer_job: the weekly directive-evolution observer.
+
+The pure DB helpers run against a schema-stripped in-memory SQLite engine; the
+async handler is driven with find_style_friction, the LLM caller, and the DB
+phases faked, so no network or real engine is touched.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+import chat.observer as observer
+import chat.observer_job as observer_job
+from chat.models import ChannelDirective, DiscordFeatureGrant, Message
+
+NOW = datetime(2026, 7, 4, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(name="engine")
+def engine_fixture():
+    """In-memory SQLite engine with the chat schema stripped for SQLite compat."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    for table in SQLModel.metadata.tables.values():
+        if table.name in original:
+            table.schema = original[table.name]
+
+
+def _grant(session, scope, *, feature="ambient", subject_id=""):
+    session.add(
+        DiscordFeatureGrant(
+            guild_id="g1", subject_id=subject_id, feature=feature, scope=scope
+        )
+    )
+
+
+def _message(
+    session, mid, channel_id, is_bot, created_at, *, content="hi", user="Alice"
+):
+    session.add(
+        Message(
+            discord_message_id=mid,
+            channel_id=channel_id,
+            user_id="bot" if is_bot else "u1",
+            username="Bot" if is_bot else user,
+            content=content,
+            is_bot=is_bot,
+            embedding=[0.0] * 1024,
+            created_at=created_at,
+        )
+    )
+
+
+# --- env knob parsing -------------------------------------------------------
+
+
+def test_int_env_defaults_when_missing(monkeypatch):
+    monkeypatch.delenv("OBSERVER_MIN_EVIDENCE", raising=False)
+    assert observer_job._int_env("OBSERVER_MIN_EVIDENCE", 3) == 3
+
+
+def test_int_env_parses_valid(monkeypatch):
+    monkeypatch.setenv("OBSERVER_MIN_EVIDENCE", "5")
+    assert observer_job._int_env("OBSERVER_MIN_EVIDENCE", 3) == 5
+
+
+def test_int_env_falls_back_on_garbage(monkeypatch):
+    monkeypatch.setenv("OBSERVER_COOLDOWN_DAYS", "not-a-number")
+    assert observer_job._int_env("OBSERVER_COOLDOWN_DAYS", 14) == 14
+
+
+def test_int_env_falls_back_on_non_positive(monkeypatch):
+    monkeypatch.setenv("OBSERVER_COOLDOWN_DAYS", "0")
+    assert observer_job._int_env("OBSERVER_COOLDOWN_DAYS", 14) == 14
+
+
+# --- granted-channel enumeration -------------------------------------------
+
+
+def test_granted_channel_ids_only_server_wide_ambient(engine):
+    with Session(engine) as session:
+        _grant(session, "chanA")
+        _grant(session, "chanB")
+        _grant(session, "chanA")  # duplicate scope, deduped
+        _grant(session, "chanC", feature="agent")  # wrong feature, ignored
+        _grant(session, "chanD", subject_id="u1")  # per-user ambient, ignored
+        _grant(session, "")  # whole-feature ambient (no channel), ignored
+        session.commit()
+        assert observer_job._granted_channel_ids(session) == ["chanA", "chanB"]
+
+
+# --- cooldown ---------------------------------------------------------------
+
+
+def _directive(session, channel_id, created_at, *, proposal_id="p1"):
+    session.add(
+        ChannelDirective(
+            channel_id=channel_id,
+            directive="d",
+            version=2,
+            active=False,
+            proposal_message_id=proposal_id,
+            created_at=created_at,
+        )
+    )
+
+
+def test_cooldown_active_within_window(engine):
+    with Session(engine) as session:
+        _directive(session, "chanA", NOW - timedelta(days=2))
+        session.commit()
+        assert observer_job._cooldown_active(session, "chanA", NOW, 14) is True
+
+
+def test_cooldown_inactive_beyond_window(engine):
+    with Session(engine) as session:
+        _directive(session, "chanA", NOW - timedelta(days=30))
+        session.commit()
+        assert observer_job._cooldown_active(session, "chanA", NOW, 14) is False
+
+
+def test_cooldown_ignores_seed_rows(engine):
+    """A seeded/reset directive has no proposal_message_id, so it never counts as
+    a recent proposal that would block the observer."""
+    with Session(engine) as session:
+        _directive(session, "chanA", NOW, proposal_id="")
+        session.commit()
+        assert observer_job._cooldown_active(session, "chanA", NOW, 14) is False
+
+
+# --- exchange retrieval -----------------------------------------------------
+
+
+def test_channel_exchanges_only_bot_adjacent_user_messages(engine):
+    """Only non-bot messages immediately following a bot message become
+    exchanges; a user message not preceded by the bot is dropped."""
+    base = NOW - timedelta(hours=1)
+    with Session(engine) as session:
+        _message(
+            session, "1", "chanA", is_bot=False, created_at=base
+        )  # opener, no bot before
+        _message(
+            session, "2", "chanA", is_bot=True, created_at=base + timedelta(minutes=1)
+        )
+        _message(
+            session,
+            "3",
+            "chanA",
+            is_bot=False,
+            created_at=base + timedelta(minutes=2),
+            content="too long",
+            user="Bob",
+        )  # follows bot -> included
+        _message(
+            session, "4", "chanA", is_bot=False, created_at=base + timedelta(minutes=3)
+        )  # follows a user -> excluded
+        _message(
+            session, "5", "chanA", is_bot=True, created_at=base + timedelta(minutes=4)
+        )
+        _message(
+            session, "6", "chanA", is_bot=False, created_at=base + timedelta(minutes=5)
+        )  # follows bot -> included
+        session.commit()
+        exchanges = observer_job._channel_exchanges(session, "chanA")
+    assert [e["message_id"] for e in exchanges] == ["3", "6"]
+    assert exchanges[0] == {"message_id": "3", "author": "Bob", "text": "too long"}
+
+
+# --- candidate gathering (integration over the sync helpers) ----------------
+
+
+def test_gather_candidates_filters_grants_cooldown_and_empty(engine):
+    base = NOW - timedelta(hours=1)
+    with Session(engine) as session:
+        # chanA: granted, off cooldown, has a bot-adjacent user message -> candidate
+        _grant(session, "chanA")
+        _message(session, "a1", "chanA", is_bot=True, created_at=base)
+        _message(
+            session, "a2", "chanA", is_bot=False, created_at=base + timedelta(minutes=1)
+        )
+        # chanB: granted but in cooldown -> skipped
+        _grant(session, "chanB")
+        _directive(session, "chanB", NOW - timedelta(days=1))
+        _message(session, "b1", "chanB", is_bot=True, created_at=base)
+        _message(
+            session, "b2", "chanB", is_bot=False, created_at=base + timedelta(minutes=1)
+        )
+        # chanC: granted, off cooldown, but no bot-adjacent user message -> skipped
+        _grant(session, "chanC")
+        _message(session, "c1", "chanC", is_bot=False, created_at=base)
+        # chanD: has messages but no ambient grant -> never observed
+        _message(session, "d1", "chanD", is_bot=True, created_at=base)
+        _message(
+            session, "d2", "chanD", is_bot=False, created_at=base + timedelta(minutes=1)
+        )
+        session.commit()
+
+    with patch("app.db.get_engine", return_value=engine):
+        candidates = observer_job._gather_candidates(NOW, 14)
+
+    assert [c[0] for c in candidates] == ["chanA"]
+    assert [e["message_id"] for e in candidates[0][1]] == ["a2"]
+
+
+# --- proposal composition ---------------------------------------------------
+
+
+def test_proposal_content_has_directive_evidence_and_react_line():
+    exchanges = [
+        {"message_id": "1", "author": "Bob", "text": "x" * 200},
+        {"message_id": "2", "author": "Amy", "text": "way too wordy"},
+    ]
+    content = observer_job._proposal_content("reply concisely", ["1", "2"], exchanges)
+    assert content.startswith("Proposed directive for this channel:\n> reply concisely")
+    assert "Bob: " in content and content.count("...") >= 1  # long snippet truncated
+    assert "Amy: way too wordy" in content
+    assert content.endswith("React 👍 to apply or 👎 to discard.")
+
+
+# --- handler orchestration --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handler_proposes_once_per_finding_with_env_knob(monkeypatch):
+    monkeypatch.setenv("OBSERVER_MIN_EVIDENCE", "5")
+    exchanges = [{"message_id": "3", "author": "Bob", "text": "too long"}]
+    finding = {"directive_change": "reply concisely", "evidence_message_ids": ["3"]}
+
+    friction = AsyncMock(return_value=finding)
+    with (
+        patch.object(
+            observer_job, "_gather_candidates", return_value=[("chanA", exchanges)]
+        ),
+        patch.object(observer, "find_style_friction", friction),
+        patch("chat.summarizer.build_llm_caller", return_value=AsyncMock()),
+        patch.object(observer_job, "_enqueue_proposal") as enqueue,
+    ):
+        await observer_job.observe_directives_handler(session=None)
+
+    friction.assert_awaited_once()
+    assert friction.await_args.kwargs["min_evidence"] == 5
+    enqueue.assert_called_once_with("chanA", finding, exchanges)
+
+
+@pytest.mark.asyncio
+async def test_handler_no_finding_enqueues_nothing():
+    exchanges = [{"message_id": "3", "author": "Bob", "text": "one-off complaint"}]
+    with (
+        patch.object(
+            observer_job, "_gather_candidates", return_value=[("chanA", exchanges)]
+        ),
+        patch.object(observer, "find_style_friction", AsyncMock(return_value=None)),
+        patch("chat.summarizer.build_llm_caller", return_value=AsyncMock()),
+        patch.object(observer_job, "_enqueue_proposal") as enqueue,
+    ):
+        await observer_job.observe_directives_handler(session=None)
+
+    enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handler_no_candidates_short_circuits():
+    with (
+        patch.object(observer_job, "_gather_candidates", return_value=[]),
+        patch("chat.summarizer.build_llm_caller") as caller,
+        patch.object(observer, "find_style_friction") as friction,
+    ):
+        await observer_job.observe_directives_handler(session=None)
+
+    caller.assert_not_called()
+    friction.assert_not_called()

--- a/projects/monolith/chat/observer_test.py
+++ b/projects/monolith/chat/observer_test.py
@@ -1,0 +1,187 @@
+"""Tests for chat.observer -- style-friction classifier (ADR 035 phase 4)."""
+
+import json
+
+import pytest
+
+from chat.observer import find_style_friction
+
+
+class _FakeCaller:
+    """Records every prompt it is called with; returns canned responses in
+    order, falling back to a labelled placeholder once they run out."""
+
+    def __init__(self, responses: list[str] | None = None):
+        self.prompts: list[str] = []
+        self._responses = list(responses) if responses is not None else None
+
+    async def __call__(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        if self._responses:
+            return self._responses.pop(0)
+        return f"response-{len(self.prompts)}"
+
+
+class _RaisingCaller:
+    async def __call__(self, prompt: str) -> str:
+        raise RuntimeError("caller boom")
+
+
+def _exchange(message_id: str, text: str = "text", author: str = "joe") -> dict:
+    return {"message_id": message_id, "author": author, "text": text}
+
+
+def _friction_reply(
+    ids: list[str], directive_change: str = "reply more concisely"
+) -> str:
+    return json.dumps(
+        {
+            "friction": True,
+            "directive_change": directive_change,
+            "evidence_message_ids": ids,
+        }
+    )
+
+
+class TestEmptyExchanges:
+    @pytest.mark.asyncio
+    async def test_empty_exchanges_returns_none_without_calling_caller(self):
+        caller = _FakeCaller()
+        result = await find_style_friction([], caller)
+        assert result is None
+        assert caller.prompts == []
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_recurring_friction_returns_directive_change_and_evidence(self):
+        exchanges = [_exchange("m1"), _exchange("m2"), _exchange("m3")]
+        caller = _FakeCaller(responses=[_friction_reply(["m1", "m2", "m3"])])
+        result = await find_style_friction(exchanges, caller, min_evidence=3)
+        assert result == {
+            "directive_change": "reply more concisely",
+            "evidence_message_ids": ["m1", "m2", "m3"],
+        }
+
+    @pytest.mark.asyncio
+    async def test_prompt_lists_message_ids_authors_and_text(self):
+        exchanges = [_exchange("m1", text="too long!", author="joe")]
+        caller = _FakeCaller(responses=[_friction_reply(["m1"])])
+        await find_style_friction(exchanges, caller, min_evidence=1)
+        prompt = caller.prompts[0]
+        assert "m1: joe: too long!" in prompt
+
+    @pytest.mark.asyncio
+    async def test_prompt_restricts_directive_change_to_tone_never_tools_or_access(
+        self,
+    ):
+        exchanges = [_exchange("m1")]
+        caller = _FakeCaller(responses=[_friction_reply(["m1"])])
+        await find_style_friction(exchanges, caller, min_evidence=1)
+        prompt = caller.prompts[0].lower()
+        assert "tone" in prompt
+        assert "attention" in prompt
+        assert "interaction style" in prompt
+        assert "never" in prompt
+        assert "tool" in prompt
+        assert "permission" in prompt
+        assert "ambient" in prompt
+        assert "repo" in prompt
+
+    @pytest.mark.asyncio
+    async def test_prompt_requires_recurring_not_single_complaint(self):
+        exchanges = [_exchange("m1")]
+        caller = _FakeCaller(responses=[_friction_reply(["m1"])])
+        await find_style_friction(exchanges, caller, min_evidence=1)
+        prompt = caller.prompts[0].lower()
+        assert "recurring" in prompt
+        assert "not recurring friction" in prompt or "not" in prompt
+
+    @pytest.mark.asyncio
+    async def test_evidence_ids_deduplicated_order_preserved(self):
+        exchanges = [_exchange("m1"), _exchange("m2"), _exchange("m3")]
+        caller = _FakeCaller(
+            responses=[_friction_reply(["m2", "m1", "m2", "m3", "m1"])]
+        )
+        result = await find_style_friction(exchanges, caller, min_evidence=3)
+        assert result["evidence_message_ids"] == ["m2", "m1", "m3"]
+
+
+class TestFrictionFalse:
+    @pytest.mark.asyncio
+    async def test_friction_false_returns_none(self):
+        exchanges = [_exchange("m1"), _exchange("m2"), _exchange("m3")]
+        reply = json.dumps(
+            {
+                "friction": False,
+                "directive_change": "",
+                "evidence_message_ids": [],
+            }
+        )
+        caller = _FakeCaller(responses=[reply])
+        result = await find_style_friction(exchanges, caller)
+        assert result is None
+
+
+class TestInsufficientEvidence:
+    @pytest.mark.asyncio
+    async def test_fewer_than_min_evidence_returns_none(self):
+        exchanges = [_exchange("m1"), _exchange("m2"), _exchange("m3")]
+        caller = _FakeCaller(responses=[_friction_reply(["m1", "m2"])])
+        result = await find_style_friction(exchanges, caller, min_evidence=3)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_dedup_below_min_evidence_after_dedup_returns_none(self):
+        # Three raw ids but only two distinct ones after dedup: below min_evidence=3.
+        exchanges = [_exchange("m1"), _exchange("m2"), _exchange("m3")]
+        caller = _FakeCaller(responses=[_friction_reply(["m1", "m1", "m2"])])
+        result = await find_style_friction(exchanges, caller, min_evidence=3)
+        assert result is None
+
+
+class TestHallucinatedEvidence:
+    @pytest.mark.asyncio
+    async def test_evidence_id_not_in_input_returns_none(self):
+        exchanges = [_exchange("m1"), _exchange("m2"), _exchange("m3")]
+        caller = _FakeCaller(responses=[_friction_reply(["m1", "m2", "made-up-id"])])
+        result = await find_style_friction(exchanges, caller, min_evidence=3)
+        assert result is None
+
+
+class TestEmptyDirectiveChange:
+    @pytest.mark.asyncio
+    async def test_missing_directive_change_returns_none(self):
+        exchanges = [_exchange("m1"), _exchange("m2"), _exchange("m3")]
+        reply = json.dumps(
+            {"friction": True, "evidence_message_ids": ["m1", "m2", "m3"]}
+        )
+        caller = _FakeCaller(responses=[reply])
+        result = await find_style_friction(exchanges, caller, min_evidence=3)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_blank_directive_change_returns_none(self):
+        exchanges = [_exchange("m1"), _exchange("m2"), _exchange("m3")]
+        caller = _FakeCaller(
+            responses=[_friction_reply(["m1", "m2", "m3"], directive_change="   ")]
+        )
+        result = await find_style_friction(exchanges, caller, min_evidence=3)
+        assert result is None
+
+
+class TestUnparseableReply:
+    @pytest.mark.asyncio
+    async def test_non_json_reply_returns_none(self):
+        exchanges = [_exchange("m1"), _exchange("m2"), _exchange("m3")]
+        caller = _FakeCaller(responses=["not json at all"])
+        result = await find_style_friction(exchanges, caller, min_evidence=3)
+        assert result is None
+
+
+class TestCallerException:
+    @pytest.mark.asyncio
+    async def test_caller_exception_returns_none(self):
+        exchanges = [_exchange("m1"), _exchange("m2"), _exchange("m3")]
+        result = await find_style_friction(exchanges, _RaisingCaller(), min_evidence=3)
+        assert result is None

--- a/projects/monolith/chat/outbox.py
+++ b/projects/monolith/chat/outbox.py
@@ -37,11 +37,18 @@ def enqueue_message(
     content: str | None = None,
     embed: dict | None = None,
     level: str = "info",
+    kind: str = "",
+    payload: dict | None = None,
 ) -> None:
     """Enqueue a Discord post. Exactly one of content/embed must be set.
 
     Caller is responsible for committing the session (matches the rest of the
     chat write API). The leader's drain loop posts the row asynchronously.
+
+    ``kind``/``payload`` tag a row for post-processing after it posts: the
+    observer enqueues a content post with ``kind="directive_proposal"`` and a
+    payload the drain's post-hook reads to wire the propose-then-confirm flow
+    (see ``_run_directive_proposal_hook``).
     """
     if (content is None) == (embed is None):
         raise ValueError("enqueue_message requires exactly one of content/embed")
@@ -51,6 +58,8 @@ def enqueue_message(
             content=content,
             embed_json=json.dumps(embed) if embed is not None else None,
             level=level,
+            kind=kind,
+            payload_json=json.dumps(payload) if payload is not None else None,
         )
     )
 
@@ -127,6 +136,8 @@ def _claim_pending(engine) -> list[dict]:
                 "target_message_id": r.target_message_id,
                 "reaction": r.reaction,
                 "reaction_remove": r.reaction_remove,
+                "kind": r.kind,
+                "payload_json": r.payload_json,
             }
             for r in rows
         ]
@@ -154,9 +165,14 @@ def _mark_failed(engine, row_id: int, error: str) -> None:
 _LEVEL_PREFIX = {"info": "", "warn": "⚠️ ", "error": "\U0001f534 "}
 
 
-async def _post_row(bot, row: dict) -> None:
+async def _post_row(bot, row: dict):
     """Post one outbox row via the bot. Mirrors chat.bot.send_message's channel
-    resolution (cache, then API fetch)."""
+    resolution (cache, then API fetch).
+
+    Returns the ``discord.Message`` a content/embed post created (so a post-hook
+    like the directive-proposal wiring can react on it), or ``None`` for a
+    reaction/edit row, which mutates an existing message rather than creating one.
+    """
     import discord
 
     channel = bot.get_channel(int(row["channel_id"]))
@@ -164,14 +180,16 @@ async def _post_row(bot, row: dict) -> None:
         channel = await bot.fetch_channel(int(row["channel_id"]))
     if row.get("reaction") is not None:
         await _apply_reaction(bot, channel, row)
+        return None
     elif row.get("target_message_id") is not None and row["content"] is not None:
         await _apply_edit(bot, channel, row)
+        return None
     elif row["embed_json"] is not None:
         embed = discord.Embed.from_dict(json.loads(row["embed_json"]))
-        await channel.send(embed=embed)
+        return await channel.send(embed=embed)
     else:
         prefix = _LEVEL_PREFIX.get(row["level"], "")
-        await channel.send(f"{prefix}{row['content']}")
+        return await channel.send(f"{prefix}{row['content']}")
 
 
 async def _apply_reaction(bot, channel, row: dict) -> None:
@@ -218,17 +236,68 @@ async def _apply_edit(bot, channel, row: dict) -> None:
     await message.edit(content=row["content"])
 
 
+# The rejection copy the interactive bot path uses when the style-only guard
+# blocks a proposed directive (chat.bot); the drain hook reuses it verbatim so a
+# guard-rejected observer proposal reads identically to a rejected /agent one.
+_DIRECTIVE_REJECTED = (
+    "That change was rejected (it tried to alter tools, permissions, or access)."
+)
+
+
+async def _run_directive_proposal_hook(row: dict, posted_message) -> None:
+    """Wire the propose-then-confirm flow onto a freshly-posted directive proposal.
+
+    The observer cannot know the Discord message id until the leader posts the
+    summary, so it enqueues a ``kind="directive_proposal"`` content row and lets
+    this hook, running right after the post, stage the proposal keyed on that
+    message id and seed 👍/👎 (or edit to the rejection copy if the style-only
+    guard, re-run inside ``propose_update`` for defense in depth, blocks it).
+
+    Never raises: any failure here (bad payload, a Discord hiccup adding the
+    reactions) is logged and swallowed so the caller still marks the row posted
+    and the drain keeps going, exactly as the task requires. propose_update opens
+    its own session, so it goes through asyncio.to_thread (no session crosses the
+    await, no sync Session in this async def).
+    """
+    from chat import directives
+
+    try:
+        payload = json.loads(row["payload_json"] or "{}")
+        channel_id = payload["channel_id"]
+        directive_change = payload["directive_change"]
+        motivating_message_id = payload.get("motivating_message_id", "")
+        ok, _ = await asyncio.to_thread(
+            directives.propose_update,
+            channel_id,
+            directive_change,
+            "observer",
+            motivating_message_id,
+            str(posted_message.id),
+        )
+        if ok:
+            await posted_message.add_reaction("👍")
+            await posted_message.add_reaction("👎")
+        else:
+            await posted_message.edit(content=_DIRECTIVE_REJECTED)
+    except Exception:
+        logger.exception(
+            "outbox: directive-proposal hook failed for row %s", row.get("id")
+        )
+
+
 async def drain_once(bot, engine) -> int:
     """Post every currently-pending row. Returns the number posted."""
     rows = await asyncio.to_thread(_claim_pending, engine)
     posted = 0
     for row in rows:
         try:
-            await _post_row(bot, row)
+            posted_message = await _post_row(bot, row)
         except Exception as exc:  # noqa: BLE001 - a bad row must not stall the rest
             logger.warning("outbox: failed to post row %s: %s", row["id"], exc)
             await asyncio.to_thread(_mark_failed, engine, row["id"], str(exc))
         else:
+            if row.get("kind") == "directive_proposal" and posted_message is not None:
+                await _run_directive_proposal_hook(row, posted_message)
             await asyncio.to_thread(_mark_posted, engine, row["id"])
             posted += 1
     return posted

--- a/projects/monolith/chat/outbox_test.py
+++ b/projects/monolith/chat/outbox_test.py
@@ -1,5 +1,6 @@
 """Tests for chat.outbox: enqueue validation and the drain posting logic."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
@@ -8,9 +9,42 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
+import chat.directives as directives
 import chat.outbox as outbox
 from chat.models import DiscordOutbox
 from chat.outbox import drain_once, enqueue_edit, enqueue_message, enqueue_reaction
+
+
+def _directive_proposal_row(row_id: int = 8) -> dict:
+    """A pending directive-proposal outbox row as _claim_pending would hand it
+    to the drain (a plain content post carrying kind/payload_json)."""
+    return {
+        "id": row_id,
+        "channel_id": "100",
+        "content": "Proposed directive for this channel:\n> reply concisely",
+        "embed_json": None,
+        "level": "info",
+        "target_message_id": None,
+        "reaction": None,
+        "reaction_remove": False,
+        "kind": "directive_proposal",
+        "payload_json": json.dumps(
+            {
+                "channel_id": "100",
+                "directive_change": "reply concisely",
+                "evidence_message_ids": ["1", "2", "3"],
+                "motivating_message_id": "1",
+            }
+        ),
+    }
+
+
+def _posted_message() -> MagicMock:
+    message = MagicMock()
+    message.id = 999
+    message.add_reaction = AsyncMock()
+    message.edit = AsyncMock()
+    return message
 
 
 @pytest.fixture(name="engine")
@@ -296,6 +330,104 @@ async def test_drain_edit_swallows_missing_message():
 
     mark_posted.assert_called_once()
     mark_failed.assert_not_called()
+
+
+def test_enqueue_message_kind_and_payload_round_trip(engine):
+    """A directive-proposal row persists kind and its JSON-serialised payload;
+    a plain post leaves both at their empty defaults."""
+    payload = {"channel_id": "100", "directive_change": "reply concisely"}
+    with Session(engine) as session:
+        enqueue_message(
+            session,
+            "100",
+            content="proposal",
+            kind="directive_proposal",
+            payload=payload,
+        )
+        enqueue_message(session, "100", content="plain")
+        session.commit()
+    with Session(engine) as session:
+        rows = session.query(DiscordOutbox).order_by(DiscordOutbox.id).all()
+    tagged, plain = rows
+    assert tagged.kind == "directive_proposal"
+    assert json.loads(tagged.payload_json) == payload
+    assert plain.kind == "" and plain.payload_json is None
+
+
+@pytest.mark.asyncio
+async def test_drain_directive_proposal_stages_and_reacts():
+    """A posted directive-proposal row stages the proposal keyed on the posted
+    message id (user_id 'observer') and seeds 👍/👎 when the guard accepts it."""
+    row = _directive_proposal_row()
+    message = _posted_message()
+    channel = MagicMock()
+    channel.send = AsyncMock(return_value=message)
+    bot = MagicMock()
+    bot.get_channel = MagicMock(return_value=channel)
+
+    with (
+        patch.object(outbox, "_claim_pending", return_value=[row]),
+        patch.object(outbox, "_mark_posted") as mark_posted,
+        patch.object(outbox, "_mark_failed") as mark_failed,
+        patch.object(directives, "propose_update", return_value=(True, "")) as prop,
+    ):
+        posted = await drain_once(bot, engine=object())
+
+    prop.assert_called_once_with("100", "reply concisely", "observer", "1", "999")
+    message.add_reaction.assert_any_await("👍")
+    message.add_reaction.assert_any_await("👎")
+    message.edit.assert_not_awaited()
+    mark_posted.assert_called_once()
+    mark_failed.assert_not_called()
+    assert posted == 1
+
+
+@pytest.mark.asyncio
+async def test_drain_directive_proposal_guard_rejected_edits():
+    """A guard-rejected proposal edits the posted message to the rejection copy
+    and adds no reactions; the row still counts as posted."""
+    row = _directive_proposal_row()
+    message = _posted_message()
+    channel = MagicMock()
+    channel.send = AsyncMock(return_value=message)
+    bot = MagicMock()
+    bot.get_channel = MagicMock(return_value=channel)
+
+    with (
+        patch.object(outbox, "_claim_pending", return_value=[row]),
+        patch.object(outbox, "_mark_posted") as mark_posted,
+        patch.object(outbox, "_mark_failed"),
+        patch.object(directives, "propose_update", return_value=(False, "blocked")),
+    ):
+        await drain_once(bot, engine=object())
+
+    message.edit.assert_awaited_once_with(content=outbox._DIRECTIVE_REJECTED)
+    message.add_reaction.assert_not_awaited()
+    mark_posted.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_directive_proposal_hook_failure_does_not_wedge_drain():
+    """A raising hook (bad payload, Discord hiccup) is swallowed: the row is
+    still marked posted and the drain reports it, never stalling on it."""
+    row = _directive_proposal_row()
+    message = _posted_message()
+    channel = MagicMock()
+    channel.send = AsyncMock(return_value=message)
+    bot = MagicMock()
+    bot.get_channel = MagicMock(return_value=channel)
+
+    with (
+        patch.object(outbox, "_claim_pending", return_value=[row]),
+        patch.object(outbox, "_mark_posted") as mark_posted,
+        patch.object(outbox, "_mark_failed") as mark_failed,
+        patch.object(directives, "propose_update", side_effect=RuntimeError("boom")),
+    ):
+        posted = await drain_once(bot, engine=object())
+
+    mark_posted.assert_called_once()
+    mark_failed.assert_not_called()
+    assert posted == 1
 
 
 @pytest.mark.asyncio

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.8
+      targetRevision: 0.285.11
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Phase 4 (final) of docs/plans/2026-07-04-ambient-assistant-parity.md (ADR 043, Feature D). Joe's conditions are binding in the implementation: runs only over ADR 029 ambient-granted channels, and sensitivity is values-tunable (OBSERVER_MIN_EVIDENCE, OBSERVER_COOLDOWN_DAYS env knobs; cadence is the cron schedule).

- `chat/observer.py`: pure style-friction classifier (recurring corrections only, style-only changes, hallucinated-evidence rejection, min-evidence gate)
- `discord_outbox` gains `kind`/`payload_json`; the leader drain's post-hook stages `directives.propose_update` with the real posted message id and seeds the existing 👍/👎 confirm flow, so propose-then-confirm is preserved (observer can only propose; the style-only guard re-runs inside propose_update)
- `chat/observer_job.py` + `chat-observe-directives` Argo CronWorkflow (weekly): ambient channels only, cooldown on any recent proposal, bot-adjacent message retrieval, one proposal max per channel per run

**Deploy note:** this PR's chart bump is 0.285.11 because main's Chart.yaml regressed to 0.285.8: the last merge to touch it (7d7a8f5c7) dropped the 0.285.9/0.285.10 bumps in its rebase (the known concurrent-bump collision). Merging this heals the regression; without it the next root-app sync would downgrade the live monolith below the reminders/channel-data releases.

Reviewer note: `atlas.sum` was regenerated by reimplementing atlas's hash chain (pinned-binary download was sandbox-blocked), verified byte-for-byte against all 98 existing entries; CI's `atlas_sum_test` with the pinned binary is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjE3s1K8v3yVnHLSeAj6zg