### PR TITLE
fix(grimoire): dedupe reader heading, widen pages, nest sections under chapters

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.5
+version: 0.89.6
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.5
+      targetRevision: 0.89.6
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.12
+version: 0.285.13
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.12
+      targetRevision: 0.285.13
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/grimoire/Reader.svelte
+++ b/projects/monolith/frontend/src/lib/grimoire/Reader.svelte
@@ -87,6 +87,24 @@
     })),
   );
 
+  // Ingest prepends the section name as a title line to every chunk's content
+  // (marker.py flush(), so the entity extractor can name the monster from text
+  // alone). The reader already shows that name as the section <h2> and in the
+  // sticky bar, so a leading block that merely repeats it renders the title
+  // twice. Drop it, comparing case-insensitively against both the full
+  // section_path and its last "/" segment (the visible title).
+  function bodyBlocks(item) {
+    const blocks = renderChunk(item.content);
+    const first = blocks[0];
+    if (!first || (first.type !== "heading" && first.type !== "para")) return blocks;
+    const norm = (s) => (s ?? "").trim().toUpperCase();
+    const head = norm(first.text);
+    if (head && (head === norm(item.section_path) || head === norm(sectionTitle(item.section_path)))) {
+      return blocks.slice(1);
+    }
+    return blocks;
+  }
+
   async function loadMore() {
     if (loadingMore || !nextCursor) return;
     loadingMore = true;
@@ -247,7 +265,7 @@
             {/if}
           </figure>
         {:else}
-          {#each renderChunk(row.item.content) as block, bi (bi)}
+          {#each bodyBlocks(row.item) as block, bi (bi)}
             {#if block.type === "heading"}
               <h3 class="grimb-inline-heading">{block.text}</h3>
             {:else if block.type === "list"}
@@ -321,7 +339,7 @@
   }
 
   .grimb-panel {
-    max-width: 50rem;
+    max-width: 60rem;
     margin: 0 auto;
     padding: clamp(1.5rem, 5vw, 3rem) clamp(1.25rem, 6vw, 3rem);
     background: var(--grimb-paper);
@@ -334,7 +352,7 @@
     align-items: center;
     gap: 1rem;
     margin: 2.5rem 0;
-    max-width: 66ch;
+    max-width: 72ch;
     margin-inline: auto;
   }
 
@@ -351,7 +369,7 @@
   }
 
   .grimb-heading {
-    max-width: 66ch;
+    max-width: 72ch;
     margin: 0 auto 1.25rem;
   }
 
@@ -380,7 +398,7 @@
 
   .grimb-chunk {
     position: relative;
-    max-width: 66ch;
+    max-width: 72ch;
     margin: 0 auto;
     font-family: var(--grimb-serif);
     font-size: 1.13rem;

--- a/projects/monolith/frontend/src/lib/public/grimoire/Reader.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/Reader.svelte
@@ -73,6 +73,24 @@
     })),
   );
 
+  // Ingest prepends the section name as a title line to every chunk's content
+  // (marker.py flush(), so the entity extractor can name the monster from text
+  // alone). The reader already shows that name as the section <h2> and in the
+  // sticky bar, so a leading block that merely repeats it renders the title
+  // twice. Drop it, comparing case-insensitively against both the full
+  // section_path and its last "/" segment (the visible title).
+  function bodyBlocks(item) {
+    const blocks = renderChunk(item.content);
+    const first = blocks[0];
+    if (!first || (first.type !== "heading" && first.type !== "para")) return blocks;
+    const norm = (s) => (s ?? "").trim().toUpperCase();
+    const head = norm(first.text);
+    if (head && (head === norm(item.section_path) || head === norm(sectionTitle(item.section_path)))) {
+      return blocks.slice(1);
+    }
+    return blocks;
+  }
+
   async function loadMore() {
     if (loadingMore || !nextCursor) return;
     loadingMore = true;
@@ -209,7 +227,7 @@
             {/if}
           </figure>
         {:else}
-          {#each renderChunk(row.item.content) as block, bi (bi)}
+          {#each bodyBlocks(row.item) as block, bi (bi)}
             {#if block.type === "heading"}
               <h3 class="eyebrow pub-inline-heading">{block.text}</h3>
             {:else if block.type === "list"}
@@ -282,7 +300,7 @@
   }
 
   .pub-panel {
-    max-width: 800px;
+    max-width: 960px;
     margin: 0 auto;
     padding: clamp(24px, 5vw, 48px) clamp(20px, 6vw, 48px);
     background: var(--paper);
@@ -295,7 +313,7 @@
     align-items: center;
     gap: 16px;
     margin: 40px 0;
-    max-width: 66ch;
+    max-width: 72ch;
     margin-inline: auto;
   }
 
@@ -311,7 +329,7 @@
   }
 
   .pub-heading {
-    max-width: 66ch;
+    max-width: 72ch;
     margin: 0 auto 20px;
   }
 
@@ -336,7 +354,7 @@
 
   .pub-chunk {
     position: relative;
-    max-width: 66ch;
+    max-width: 72ch;
     margin: 0 auto;
     font-family: var(--sans);
     font-size: 18px;

--- a/projects/monolith/grimoire/marker.py
+++ b/projects/monolith/grimoire/marker.py
@@ -179,6 +179,37 @@ def _page_of(block: dict) -> str:
     return f"{m.group(1)}/_nosection" if m else "/_nosection"
 
 
+def _section_breadcrumb(
+    hier_block: dict | None, headers: dict[str, str], leaf: str | None
+) -> str | None:
+    """A ``chapter/section/leaf`` breadcrumb for the run whose leaf section is
+    ``leaf``, so the reader and Chapters nav can nest sections under their real
+    chapter (they split ``section_path`` on ``/``).
+
+    Ancestry comes from ``hier_block``'s ``section_hierarchy`` (level -> header
+    id): the non-continuation ancestor header names, shallowest first, with the
+    leaf appended last. Only a *content* block (never a SectionHeader) should be
+    passed as ``hier_block``: a header block's own ``section_hierarchy`` is stale
+    (it still lists the previous sibling at its level, see ``effective_section_id``),
+    which would graft a sibling on as a bogus parent. Callers pass ``None`` for
+    header-only runs, degrading to the bare ``leaf`` rather than risk that.
+    """
+    if not leaf:
+        return leaf
+    parents: list[str] = []
+    sh = (hier_block or {}).get("section_hierarchy") or {}
+    for level in sorted(sh, key=lambda k: int(k)):
+        txt = headers.get(sh[level], "").strip()
+        # Skip empties, stat-block continuation headers, the leaf itself (it is
+        # appended once at the end), and any run of the same name.
+        if not txt or txt.upper() in _CONTINUATION_HEADERS or txt == leaf:
+            continue
+        if parents and parents[-1] == txt:
+            continue
+        parents.append(txt)
+    return "/".join([*parents, leaf])
+
+
 def parse_image_block(html: str) -> tuple[str, str, str]:
     """From a Picture block's html, return (src_filename, alt, caption)."""
     src_m = _IMG_SRC_RE.search(html)
@@ -227,12 +258,17 @@ def to_chunks(doc: dict, *, image_key_prefix: str) -> list[dict]:
         body = "\n\n".join(run["parts"]).strip()
         if not body:
             return
-        sp = run["section_path"]
+        leaf = run["section_path"]
         # The extractor sees only `content`, so the section/monster name must
         # live in the text itself (not just section_path) for the entity to be
-        # named reliably. Prepend it as a title line unless already leading.
-        if sp and not body.upper().startswith(sp.upper()):
-            body = f"{sp}\n\n{body}"
+        # named reliably. Prepend the *leaf* name (never the full breadcrumb) as
+        # a title line unless already leading.
+        if leaf and not body.upper().startswith(leaf.upper()):
+            body = f"{leaf}\n\n{body}"
+        # Stored path is the chapter/section/leaf breadcrumb (from the run's
+        # first content block's trustworthy ancestry); the leaf alone when the
+        # run has no content block to read ancestry from.
+        sp = _section_breadcrumb(run["hier_block"], headers, leaf)
         ordered.append(
             (
                 run["order"],
@@ -250,13 +286,18 @@ def to_chunks(doc: dict, *, image_key_prefix: str) -> list[dict]:
             content = _image_content(alt, caption)
             if content:
                 img_sid = effective_section_id(block, headers)
+                img_leaf = headers.get(img_sid) if img_sid else None
+                # A Picture is a content block, so its own section_hierarchy is
+                # trustworthy ancestry: read the breadcrumb straight off it.
                 ordered.append(
                     (
                         idx,
                         {
                             "chunk_ref": block.get("id", ""),
                             "content": content,
-                            "section_path": (headers.get(img_sid) if img_sid else None),
+                            "section_path": _section_breadcrumb(
+                                block, headers, img_leaf
+                            ),
                             "image_ref": (image_key_prefix + src) if src else None,
                         },
                     )
@@ -284,9 +325,15 @@ def to_chunks(doc: dict, *, image_key_prefix: str) -> list[dict]:
                 # overwrite each other on load.
                 "chunk_ref": block.get("id") or _page_of(block),
                 "section_path": section_path or None,
+                # First non-header block of the run, read at flush for the
+                # section's ancestry. A SectionHeader's own hierarchy is stale
+                # (see _section_breadcrumb), so headers never fill this slot.
+                "hier_block": None,
                 "parts": [],
                 "order": idx,
             }
+        if btype != "SectionHeader" and run["hier_block"] is None:
+            run["hier_block"] = block
         run["parts"].append(text)
     flush()
 

--- a/projects/monolith/grimoire/marker_test.py
+++ b/projects/monolith/grimoire/marker_test.py
@@ -264,6 +264,60 @@ def test_to_chunks_new_header_with_stale_hierarchy_does_not_bleed():
     assert monster["chunk_ref"] == "/page/0/SectionHeader/1"
 
 
+def test_to_chunks_breadcrumbs_nested_section_under_chapter():
+    """A section that sits under a chapter gets a ``chapter/leaf`` section_path
+    (read off a content block's trustworthy ancestry), while the leaf title
+    alone is what the body is prefixed with and what the header-only chapter
+    chunk stores."""
+    doc = {
+        "children": [
+            _page(
+                0,
+                [
+                    {
+                        "id": "/page/0/SectionHeader/0",
+                        "block_type": "SectionHeader",
+                        "html": "<h1>GIANT KIN</h1>",
+                        "section_hierarchy": {"1": "/page/0/SectionHeader/0"},
+                    },
+                    {
+                        "id": "/page/0/SectionHeader/1",
+                        "block_type": "SectionHeader",
+                        "html": "<h2>GOLIATHS AND FIRBOLGS</h2>",
+                        "section_hierarchy": {
+                            "1": "/page/0/SectionHeader/0",
+                            "2": "/page/0/SectionHeader/1",
+                        },
+                    },
+                    {
+                        "id": "/page/0/Text/0",
+                        "block_type": "Text",
+                        "html": "<p>Two humanoid kinds claim kinship to giants.</p>",
+                        "section_hierarchy": {
+                            "1": "/page/0/SectionHeader/0",
+                            "2": "/page/0/SectionHeader/1",
+                        },
+                    },
+                ],
+            )
+        ],
+        "metadata": {},
+    }
+    chunks = marker.to_chunks(doc, image_key_prefix="p/")
+    by_leaf = {c["section_path"].rsplit("/", 1)[-1]: c for c in chunks}
+
+    goliaths = by_leaf["GOLIATHS AND FIRBOLGS"]
+    # Breadcrumb nests the section under its chapter, so the Chapters nav and
+    # reader can group it (they split section_path on "/").
+    assert goliaths["section_path"] == "GIANT KIN/GOLIATHS AND FIRBOLGS"
+    # The body is prefixed with the leaf name only, never the full breadcrumb.
+    assert goliaths["content"].startswith("GOLIATHS AND FIRBOLGS")
+    assert not goliaths["content"].startswith("GIANT KIN/")
+
+    # The chapter header (no direct content) keeps its bare top-level path.
+    assert by_leaf["GIANT KIN"]["section_path"] == "GIANT KIN"
+
+
 def test_to_chunks_drops_empty_content():
     doc = {
         "children": [


### PR DESCRIPTION
Follow-up polish on the continuous book Reader (ChaptersNav work already merged as 39845a986). Three issues Joe spotted while rolling grimoire out.

## 1. Double section heading
Ingest (`marker.py` `flush()`) prepends the section name as a chunk's first content line so the entity extractor can name the monster from text alone. `renderChunk` turned that ALL-CAPS line into a heading block, which the reader drew on top of the section `<h2>` it already renders from `section_path`: the title appeared twice (big serif, then the same words as a mono eyebrow). `bodyBlocks()` now drops a leading heading/para block that just repeats the section title. Both tiers.

## 2. Pages too narrow
Reading column widened: panel 50→60rem (private) / 800→960px (public), measure 66→72ch. Both tiers.

## 3. Chapters were leaf sections, not chapters
`section_path` stored only the leaf header name, so the Chapters nav and reader (both already split `section_path` on `/`) could never nest a section under its chapter. `marker.py` now derives a `chapter/section/leaf` breadcrumb from each run's first *content* block, whose Marker `section_hierarchy` is trustworthy ancestry (a SectionHeader's own hierarchy is stale, so header-only runs fall back to the bare leaf). Grouping, monster-merging, and the title-line prefix are unchanged; the prefix uses the leaf name, never the breadcrumb. New unit test covers a nested chapter/section; existing GOBLIN-merge and stale-hierarchy tests still pass.

**Note:** #3 only changes new conversions. Existing books need a re-chunk (re-run `marker.py` over the retained `raw/output.json.gz`) + re-ingest for their `section_path`s to gain the hierarchy. Tracked separately.

Charts: monolith 0.285.13, monolith-public 0.89.6.