### PR TITLE
fix(grimoire): 2-level chapter/leaf section breadcrumbs

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.13
+version: 0.285.14
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.13
+      targetRevision: 0.285.14
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/grimoire/marker.py
+++ b/projects/monolith/grimoire/marker.py
@@ -69,6 +69,14 @@ _CONTINUATION_HEADERS = frozenset(
     }
 )
 
+# What counts as a chapter for the Chapters nav: an explicit "CHAPTER N",
+# "APPENDIX X", or "PART" header. This is the one signal that survives Marker's
+# noisy running section_hierarchy across every book here: rulebooks and
+# adventures mark chapters this way, while alphabetical bestiaries have none and
+# so stay (correctly) flat. Structural page headers (CONTENTS/INDEX) and running
+# titles (MONSTER MANUAL®) never match, so they can't masquerade as a chapter.
+_CHAPTER_RE = re.compile(r"^\s*(chapter|appendix|part)\b", re.IGNORECASE)
+
 _TAG_RE = re.compile(r"<[^>]+>")
 # Tags whose boundary should become a newline when flattening HTML to text.
 _BLOCK_BREAK_RE = re.compile(
@@ -182,32 +190,40 @@ def _page_of(block: dict) -> str:
 def _section_breadcrumb(
     hier_block: dict | None, headers: dict[str, str], leaf: str | None
 ) -> str | None:
-    """A ``chapter/section/leaf`` breadcrumb for the run whose leaf section is
-    ``leaf``, so the reader and Chapters nav can nest sections under their real
-    chapter (they split ``section_path`` on ``/``).
+    """A ``chapter/leaf`` breadcrumb for the run whose leaf section is ``leaf``,
+    so the reader and Chapters nav can group sections under their chapter (they
+    split ``section_path`` on ``/``).
 
-    Ancestry comes from ``hier_block``'s ``section_hierarchy`` (level -> header
-    id): the non-continuation ancestor header names, shallowest first, with the
-    leaf appended last. Only a *content* block (never a SectionHeader) should be
-    passed as ``hier_block``: a header block's own ``section_hierarchy`` is stale
-    (it still lists the previous sibling at its level, see ``effective_section_id``),
-    which would graft a sibling on as a bogus parent. Callers pass ``None`` for
+    Deliberately only TWO levels: chapter + leaf. The full ``section_hierarchy``
+    ancestry is noisy (see this module's docstring: "stale ancestors leak in") —
+    on the real 2024 PHB it roots every section under the table-of-contents page
+    ("CONTENTS/CHAPTER 1.../DICE NOTATION/PERCENTILE DICE"), which is neither a
+    real hierarchy nor a usable menu. So the chapter is the shallowest ancestor
+    whose header is an explicit chapter marker (``_CHAPTER_RE``): "CHAPTER 3
+    CHARACTER CLASSES", "APPENDIX A ...". Ancestors that are subsections, running
+    titles, or the ToC never match, and a section with no chapter marker above it
+    (e.g. a monster in an alphabetical bestiary) stays flat.
+
+    Only a *content* block (never a SectionHeader) should be passed as
+    ``hier_block``: a header block's own ``section_hierarchy`` is stale (it still
+    lists the previous sibling at its level, see ``effective_section_id``), which
+    would graft a sibling on as a bogus parent. Callers pass ``None`` for
     header-only runs, degrading to the bare ``leaf`` rather than risk that.
     """
     if not leaf:
         return leaf
-    parents: list[str] = []
     sh = (hier_block or {}).get("section_hierarchy") or {}
-    for level in sorted(sh, key=lambda k: int(k)):
+    for level in sorted(sh, key=lambda k: int(k)):  # shallowest first
         txt = headers.get(sh[level], "").strip()
-        # Skip empties, stat-block continuation headers, the leaf itself (it is
-        # appended once at the end), and any run of the same name.
-        if not txt or txt.upper() in _CONTINUATION_HEADERS or txt == leaf:
+        if not txt or txt == leaf:
             continue
-        if parents and parents[-1] == txt:
-            continue
-        parents.append(txt)
-    return "/".join([*parents, leaf])
+        # The shallowest chapter-marked ancestor is this section's chapter; pair
+        # it with the leaf and stop. Non-chapter ancestors (subsections, running
+        # titles, the ToC) are skipped, so a section with no chapter above it
+        # stays flat rather than nesting under noise.
+        if _CHAPTER_RE.match(txt):
+            return f"{txt}/{leaf}"
+    return leaf
 
 
 def parse_image_block(html: str) -> tuple[str, str, str]:

--- a/projects/monolith/grimoire/marker_test.py
+++ b/projects/monolith/grimoire/marker_test.py
@@ -264,12 +264,11 @@ def test_to_chunks_new_header_with_stale_hierarchy_does_not_bleed():
     assert monster["chunk_ref"] == "/page/0/SectionHeader/1"
 
 
-def test_to_chunks_breadcrumbs_nested_section_under_chapter():
-    """A section that sits under a chapter gets a ``chapter/leaf`` section_path
-    (read off a content block's trustworthy ancestry), while the leaf title
-    alone is what the body is prefixed with and what the header-only chapter
-    chunk stores."""
-    doc = {
+def _giants_doc(chapter_html: str) -> dict:
+    """A ``chapter -> section -> content`` page: the chapter heading, a section
+    heading under it, and a content paragraph whose section_hierarchy carries
+    both (the trustworthy ancestry the breadcrumb reads)."""
+    return {
         "children": [
             _page(
                 0,
@@ -277,7 +276,7 @@ def test_to_chunks_breadcrumbs_nested_section_under_chapter():
                     {
                         "id": "/page/0/SectionHeader/0",
                         "block_type": "SectionHeader",
-                        "html": "<h1>GIANT KIN</h1>",
+                        "html": chapter_html,
                         "section_hierarchy": {"1": "/page/0/SectionHeader/0"},
                     },
                     {
@@ -303,19 +302,39 @@ def test_to_chunks_breadcrumbs_nested_section_under_chapter():
         ],
         "metadata": {},
     }
-    chunks = marker.to_chunks(doc, image_key_prefix="p/")
+
+
+def test_to_chunks_nests_section_under_chapter_marker():
+    """A section under an explicit CHAPTER heading gets a ``chapter/leaf``
+    section_path, while the body is prefixed with (and the header-only chapter
+    chunk stores) the leaf name alone."""
+    chunks = marker.to_chunks(
+        _giants_doc("<h1>CHAPTER 6 GIANTS</h1>"), image_key_prefix="p/"
+    )
     by_leaf = {c["section_path"].rsplit("/", 1)[-1]: c for c in chunks}
 
     goliaths = by_leaf["GOLIATHS AND FIRBOLGS"]
-    # Breadcrumb nests the section under its chapter, so the Chapters nav and
-    # reader can group it (they split section_path on "/").
-    assert goliaths["section_path"] == "GIANT KIN/GOLIATHS AND FIRBOLGS"
+    # Breadcrumb nests the section under its chapter (nav/reader split on "/").
+    assert goliaths["section_path"] == "CHAPTER 6 GIANTS/GOLIATHS AND FIRBOLGS"
     # The body is prefixed with the leaf name only, never the full breadcrumb.
     assert goliaths["content"].startswith("GOLIATHS AND FIRBOLGS")
-    assert not goliaths["content"].startswith("GIANT KIN/")
+    assert not goliaths["content"].startswith("CHAPTER 6 GIANTS/")
+    # The chapter heading (no direct content) keeps its bare top-level path.
+    assert by_leaf["CHAPTER 6 GIANTS"]["section_path"] == "CHAPTER 6 GIANTS"
 
-    # The chapter header (no direct content) keeps its bare top-level path.
-    assert by_leaf["GIANT KIN"]["section_path"] == "GIANT KIN"
+
+def test_to_chunks_leaves_section_flat_without_chapter_marker():
+    """A non-chapter ancestor (a plain section name, a running title, the ToC)
+    must NOT be promoted to a chapter: the section stays flat rather than nesting
+    under noise."""
+    chunks = marker.to_chunks(
+        _giants_doc("<h1>MONSTER MANUAL</h1>"), image_key_prefix="p/"
+    )
+    paths = {c["section_path"] for c in chunks if "image_ref" not in c}
+    # "MONSTER MANUAL" is not a CHAPTER/APPENDIX/PART heading, so it never
+    # becomes a parent; the section keeps its bare leaf path.
+    assert "GOLIATHS AND FIRBOLGS" in paths
+    assert not any("/" in p for p in paths)
 
 
 def test_to_chunks_drops_empty_content():


### PR DESCRIPTION
Follow-up to #3210. The first breadcrumb pass walked the full Marker `section_hierarchy`, which real data showed is noisy: on the 2024 PHB it rooted every section under the table-of-contents page (`CONTENTS/CHAPTER 1.../DICE NOTATION/PERCENTILE DICE`), and elsewhere a running title (`MONSTER MANUAL`) or a mid-level subsection got promoted to a chapter.

This caps the breadcrumb to `chapter/leaf`, where the chapter is the shallowest ancestor whose header is an explicit `CHAPTER`/`APPENDIX`/`PART` marker. Rulebooks and adventures nest under real chapters; alphabetical bestiaries have no such marker and stay flat (correct).

Validated by re-chunking three book types from their retained raw JSON:
- `players-handbook-2024` → 7 chapters (CHAPTER 1/3/5/6/7, APPENDIX A/C)
- `monster-manual` → flat (569 flat / 128 nested under APPENDIX A/B)
- `curse-of-strahd` → 12 chapters (CHAPTER 1-15, APPENDIX A-E)

Content stays byte-identical (leaf-name prefix unchanged), so the re-chunk + re-ingest of existing books is metadata-only: no re-embedding, no re-extraction.

Chart: monolith 0.285.14.