### PR TITLE
fix(chat): backfill orchestrator_brief.thread_id so routing telemetry links

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.14
+version: 0.285.15
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -1029,6 +1029,17 @@ class ChatBot(discord.Client):
                 task=prompt,
                 plan=plan_verdict.plan if plan_verdict is not None else None,
             )
+            # ADR 036: the orchestrator wrote its telemetry row BEFORE this
+            # thread existed (it decides whether to open one), so the row's
+            # thread_id is null. Backfill it now that the thread id is known, so
+            # the routing verdict joins to the goosecracker_sessions run it
+            # produced (both goose and failopen verdicts carry the row id;
+            # ungranted/disabled fail-opens carry None and are skipped).
+            brief_id = getattr(verdict, "brief_id", None)
+            if brief_id is not None:
+                await asyncio.to_thread(
+                    orchestrator.link_thread, brief_id, str(thread.id)
+                )
         except Exception:
             logger.exception("goosecracker: failed to start agent session")
             return AgentFlowOutcome()

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -317,10 +317,13 @@ class OrchestratorBrief(SQLModel, table=True):
     """ADR 036 orchestrator brief-compiler telemetry (spec section 5).
 
     One row per orchestrator call: chat and goose verdicts and every fail-open
-    degradation. ``thread_id`` links a goose verdict to its
-    ``goosecracker_sessions`` run (null for chat/failopen routes with no
-    thread). ``brief_json`` holds the compiled Brief (goose) or the chat reply
-    guidance, null on failopen. The route CHECK mirrors the migration so the
+    degradation. ``thread_id`` links a goose (or fell-back) verdict to its
+    ``goosecracker_sessions`` run. The orchestrator runs before the session
+    thread exists, so the row is written with a null ``thread_id`` and
+    ``orchestrator.link_thread`` backfills it once ``start_agent_flow`` creates
+    the thread; it stays null for the chat route and for fail-opens that never
+    open a thread (ungranted/disabled). ``brief_json`` holds the compiled Brief
+    (goose) or the chat reply guidance, null on failopen. The route CHECK mirrors the migration so the
     SQLite test fixtures enforce it too (create_all does not see migration-only
     constraints). Token columns come from the provider response when present.
     """

--- a/projects/monolith/chat/orchestrator.py
+++ b/projects/monolith/chat/orchestrator.py
@@ -112,6 +112,9 @@ class PlanVerdict:
     repo: str
     repo_paths: list[str]
     repo_replaced: bool = False
+    # Id of the telemetry row this verdict wrote, so start_agent_flow can
+    # backfill its thread_id once the session thread exists (see link_thread).
+    brief_id: int | None = None
 
 
 @dataclass
@@ -132,6 +135,10 @@ class FailOpen:
     model was actually called, recorded in the telemetry row's ``error``."""
 
     reason: str
+    # Id of the telemetry row, when this fail-open wrote one (the ungranted /
+    # disabled short-circuits write none, so it stays None). start_agent_flow
+    # backfills its thread_id once the fallback thread exists (see link_thread).
+    brief_id: int | None = None
 
 
 @dataclass
@@ -485,28 +492,54 @@ def _record(
     completion_tokens: int | None,
     cached_tokens: int | None,
     error: str | None,
-) -> None:
-    """Write exactly one telemetry row. Best-effort: a logging failure must
-    never break the escalation flow."""
+) -> int | None:
+    """Write exactly one telemetry row and return its id.
+
+    The id lets :func:`compile` hand the row to the caller (on a verdict that
+    opens a thread) so :func:`link_thread` can backfill ``thread_id`` once the
+    thread exists. Best-effort: a write failure must never break the escalation
+    flow and returns None."""
     try:
         with Session(get_engine()) as session:
-            session.add(
-                OrchestratorBrief(
-                    thread_id=ctx.thread_id,
-                    model=model,
-                    route=route,
-                    brief_json=brief_json,
-                    directive_version=ctx.directive.version,
-                    latency_ms=latency_ms,
-                    prompt_tokens=prompt_tokens,
-                    completion_tokens=completion_tokens,
-                    cached_tokens=cached_tokens,
-                    error=error,
-                )
+            row = OrchestratorBrief(
+                thread_id=ctx.thread_id,
+                model=model,
+                route=route,
+                brief_json=brief_json,
+                directive_version=ctx.directive.version,
+                latency_ms=latency_ms,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                cached_tokens=cached_tokens,
+                error=error,
             )
+            session.add(row)
             session.commit()
+            session.refresh(row)
+            return row.id
     except Exception:
         logger.exception("orchestrator: failed to write telemetry row")
+        return None
+
+
+def link_thread(brief_id: int, thread_id: str) -> None:
+    """Backfill a telemetry row's ``thread_id`` once the session thread exists.
+
+    The orchestrator runs BEFORE the session thread is created (deciding whether
+    to open one), so :func:`_record` writes the row with a null ``thread_id``.
+    Once ``start_agent_flow`` (chat/bot.py) has created the thread, it calls this
+    with the row id carried on the verdict, joining the routing verdict to the
+    ``goosecracker_sessions`` run it produced. Best-effort and idempotent: a
+    write failure must never break the run, and an already-linked row (non-null
+    ``thread_id``) is left untouched."""
+    try:
+        with Session(get_engine()) as session:
+            row = session.get(OrchestratorBrief, brief_id)
+            if row is not None and row.thread_id is None:
+                row.thread_id = thread_id
+                session.commit()
+    except Exception:
+        logger.exception("orchestrator: failed to link thread to brief row")
 
 
 async def compile(ctx: RequestContext) -> Verdict:
@@ -551,17 +584,17 @@ async def compile(ctx: RequestContext) -> Verdict:
     except orchestrator_client.OrchestratorUnavailable as exc:
         reason = f"orchestrator unavailable: {exc}"
         logger.warning("orchestrator: failing open, %s", reason)
-        await asyncio.to_thread(
+        brief_id = await asyncio.to_thread(
             _record, ctx, "failopen", model, None, 0, None, None, None, reason
         )
-        return FailOpen(reason)
+        return FailOpen(reason, brief_id=brief_id)
 
     try:
         verdict = parse_brief(resp.content, allowed_scopes=ctx.allowed_scopes)
     except BriefParseError as exc:
         reason = f"unparseable brief: {exc}"
         logger.warning("orchestrator: failing open, %s", reason)
-        await asyncio.to_thread(
+        brief_id = await asyncio.to_thread(
             _record,
             ctx,
             "failopen",
@@ -573,7 +606,7 @@ async def compile(ctx: RequestContext) -> Verdict:
             resp.cached_tokens,
             reason,
         )
-        return FailOpen(reason)
+        return FailOpen(reason, brief_id=brief_id)
 
     if isinstance(verdict, Brief):
         if verdict.repo_replaced:
@@ -601,7 +634,7 @@ async def compile(ctx: RequestContext) -> Verdict:
         except orchestrator_client.OrchestratorUnavailable as exc:
             reason = f"plan call unavailable: {exc}"
             logger.warning("orchestrator: failing open, %s", reason)
-            await asyncio.to_thread(
+            brief_id = await asyncio.to_thread(
                 _record,
                 ctx,
                 "failopen",
@@ -613,7 +646,7 @@ async def compile(ctx: RequestContext) -> Verdict:
                 resp.cached_tokens,
                 reason,
             )
-            return FailOpen(reason)
+            return FailOpen(reason, brief_id=brief_id)
 
         try:
             # Both parse and validate run inside the guard: a malformed tool
@@ -632,7 +665,7 @@ async def compile(ctx: RequestContext) -> Verdict:
 
         if plan is None or plan_error:
             logger.warning("orchestrator: failing open, %s", plan_error)
-            await asyncio.to_thread(
+            brief_id = await asyncio.to_thread(
                 _record,
                 ctx,
                 "failopen",
@@ -644,9 +677,9 @@ async def compile(ctx: RequestContext) -> Verdict:
                 resp.cached_tokens,
                 plan_error,
             )
-            return FailOpen(plan_error)
+            return FailOpen(plan_error, brief_id=brief_id)
 
-        await asyncio.to_thread(
+        brief_id = await asyncio.to_thread(
             _record,
             ctx,
             "goose",
@@ -663,6 +696,7 @@ async def compile(ctx: RequestContext) -> Verdict:
             repo=verdict.repo,
             repo_paths=verdict.repo_paths,
             repo_replaced=verdict.repo_replaced,
+            brief_id=brief_id,
         )
 
     await asyncio.to_thread(

--- a/projects/monolith/chat/orchestrator_test.py
+++ b/projects/monolith/chat/orchestrator_test.py
@@ -465,6 +465,91 @@ class TestCompile:
         assert verdict.repo_replaced is True
         assert _rows(engine)[0].brief_json["repo_replaced"] is True
 
+    @pytest.mark.asyncio
+    async def test_goose_verdict_carries_brief_row_id(self, engine, monkeypatch):
+        # The goose PlanVerdict carries the id of the telemetry row it wrote, so
+        # start_agent_flow can backfill thread_id once the thread exists (the
+        # orchestrator runs before the thread is created, so the row is written
+        # with a null thread_id).
+        monkeypatch.setenv("ORCHESTRATOR_MODEL", "test/model")
+        monkeypatch.setattr(acl, "is_granted", lambda *a, **k: True)
+        monkeypatch.setattr(
+            orchestrator_client, "call", AsyncMock(return_value=_response(_GOOSE_JSON))
+        )
+        monkeypatch.setattr(orchestrator_client, "call_tool", _plan_call())
+        monkeypatch.setattr(orchestrator, "get_engine", lambda: engine)
+
+        verdict = await orchestrator.compile(_ctx(thread_id=None))
+        assert isinstance(verdict, PlanVerdict)
+        rows = _rows(engine)
+        assert len(rows) == 1
+        assert verdict.brief_id == rows[0].id
+
+    @pytest.mark.asyncio
+    async def test_failopen_verdict_carries_brief_row_id(self, engine, monkeypatch):
+        # An enabled fail-open (model called, then unreachable) also carries the
+        # row id: the fallback path still opens a thread, and linking it lets the
+        # skill measure the fallback rate against real sessions.
+        monkeypatch.setenv("ORCHESTRATOR_MODEL", "test/model")
+        monkeypatch.setattr(acl, "is_granted", lambda *a, **k: True)
+        monkeypatch.setattr(
+            orchestrator_client,
+            "call",
+            AsyncMock(side_effect=orchestrator_client.OrchestratorUnavailable("down")),
+        )
+        monkeypatch.setattr(orchestrator, "get_engine", lambda: engine)
+
+        verdict = await orchestrator.compile(_ctx(thread_id=None))
+        assert isinstance(verdict, FailOpen)
+        rows = _rows(engine)
+        assert len(rows) == 1
+        assert verdict.brief_id == rows[0].id
+
+    @pytest.mark.asyncio
+    async def test_ungranted_failopen_has_no_brief_id(self, engine, monkeypatch):
+        # The ungranted short-circuit writes no row, so there is nothing to link.
+        monkeypatch.setenv("ORCHESTRATOR_MODEL", "test/model")
+        monkeypatch.setattr(acl, "is_granted", lambda *a, **k: False)
+        monkeypatch.setattr(orchestrator, "get_engine", lambda: engine)
+
+        verdict = await orchestrator.compile(_ctx(thread_id=None))
+        assert isinstance(verdict, FailOpen)
+        assert verdict.brief_id is None
+        assert _rows(engine) == []
+
+
+class TestLinkThread:
+    """orchestrator.link_thread backfills a telemetry row's thread_id once the
+    session thread exists (the row is written before the thread is created)."""
+
+    def test_backfills_null_thread_id(self, engine, monkeypatch):
+        monkeypatch.setattr(orchestrator, "get_engine", lambda: engine)
+        # A row written before the thread exists (thread_id null), as in prod.
+        brief_id = orchestrator._record(
+            _ctx(thread_id=None), "goose", "m", {"k": "v"}, 1, None, None, None, None
+        )
+        assert brief_id is not None
+        assert _rows(engine)[0].thread_id is None
+
+        orchestrator.link_thread(brief_id, "12345")
+        assert _rows(engine)[0].thread_id == "12345"
+
+    def test_is_idempotent_and_does_not_clobber(self, engine, monkeypatch):
+        monkeypatch.setattr(orchestrator, "get_engine", lambda: engine)
+        brief_id = orchestrator._record(
+            _ctx(thread_id=None), "goose", "m", {"k": "v"}, 1, None, None, None, None
+        )
+        orchestrator.link_thread(brief_id, "12345")
+        # A second link (e.g. a retry) leaves the already-linked row untouched.
+        orchestrator.link_thread(brief_id, "99999")
+        assert _rows(engine)[0].thread_id == "12345"
+
+    def test_missing_row_is_noop(self, engine, monkeypatch):
+        # A stale/absent id must not raise (best-effort telemetry).
+        monkeypatch.setattr(orchestrator, "get_engine", lambda: engine)
+        orchestrator.link_thread(999999, "12345")
+        assert _rows(engine) == []
+
 
 class TestReplan:
     """The capped replan escape hatch's orchestrator side (Task 7).

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.14
+      targetRevision: 0.285.15
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

`/improve-recipes` reported `orchestrator_route: null`, `plan_step_count: null`, and `plan_json: null` for **100% of the 87 goosecracker sessions** in the last week. That looked like the DeepSeek routing brain (ADR 036) was idle, but a read-only probe showed it is running fine:

```
chat.orchestrator_brief: 11 rows (all since 06-27)
routes: goose=8, chat=2, failopen=1
thread_id samples: [null, null, null, null, null, null, null, null]   <-- every row
join_on_session_id: 0     join_on_thread_id: 0
```

The briefs exist; their `thread_id` foreign key is **null on every row**, so the gather join (`orchestrator_brief.thread_id = agent_threads.session_id`) can never match. Root cause, fully traced:

- The orchestrator runs at escalation time, **before** the goose session thread exists (it is deciding whether to open one), so `_record` writes the row with `thread_id=ctx.thread_id`.
- `RequestContext` in `start_agent_flow` (`chat/bot.py:1107`) is built without a `thread_id`, so it defaults to `None`. The thread id is not known until `create_thread` runs a few lines later.
- Nothing ever backfilled the row. So the routing half of `/improve-recipes` (routing quality, and the **fallback rate** the PR aggregates table requires) has been structurally dark.

## Fix

- `_record` now returns the new row id.
- `compile` carries that id on the verdicts that open a thread: `PlanVerdict` and the three enabled fail-opens (unreachable / unparseable / bad-plan). Chat verdicts and ungranted/disabled fail-opens open no thread, so they carry `None` and stay null (correct per the model docstring).
- New `orchestrator.link_thread(brief_id, thread_id)`; `start_agent_flow` calls it right after the thread is created to stamp `str(thread.id)` onto the row. That value equals `agent_threads.session_id` (both are the Discord thread id), so the **existing gather join matches with no SQL change**. It is best-effort and idempotent (never clobbers a non-null `thread_id`).

This also links the failopen-with-thread path, so the fallback rate becomes measurable for free.

## Tests

Added to `orchestrator_test.py`: goose and enabled-failopen verdicts carry the row id; the ungranted short-circuit carries `None`; and a `TestLinkThread` class covering backfill, idempotency (no clobber), and a missing-row no-op. No schema migration (the `thread_id` column already exists, migration `20260703210000`).

## Out of scope, observed

The `/improve-recipes` run that surfaced this was otherwise **report-only**: the default window had 1 completed session, and the week's failure surface was entirely infrastructure (fc-invoke 502/504/unreachable + exit-status-1 guest-boot failures), not recipe quality. The one prior recipe miss (git-push vs REST-API PR path) was already fixed by `1c22fb5`. Once this lands and one generation of real routing telemetry accumulates, the next run can classify with a working fallback-rate number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)