### PR TITLE
feat(goosecracker): inject the target repo so guests open PRs on the right repo

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/implement.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/implement.yaml
@@ -39,8 +39,12 @@ instructions: |
   GitHub REST API, so open the PR through the API instead of pushing.
 
   Do NOT commit locally (a local commit cannot leave this VM). Instead
-  build the branch server-side via the REST API. Set
-  `R=jomcgi/homelab` and `B=claude/<short-slug-for-the-task>`, then:
+  build the branch server-side via the REST API. Your target GitHub repo
+  (owner/repo) was staged for you at /injected-context/repo, so set
+  `R=$(cat /injected-context/repo 2>/dev/null)`. If that file is missing or
+  empty, do NOT guess a repo and do NOT push: say in your final message that
+  no target repo was provided so you could not open a PR. Otherwise set
+  `B=claude/<short-slug-for-the-task>`, then:
 
     1. Base SHA:      `BASE=$(gh api repos/$R/git/ref/heads/main --jq .object.sha)`
     2. Base tree:     `BT=$(gh api repos/$R/git/commits/$BASE --jq .tree.sha)`

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.34
+version: 0.4.35

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.34
+      targetRevision: 0.4.35
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.15
+version: 0.285.16
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.15
+      targetRevision: 0.285.16
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -659,6 +659,15 @@ async def _invoke_turn(
     # via Helm values. An empty effective_mirror means no clone (no mirror
     # configured in this environment).
     effective_mirror, effective_ref = _effective_mirror_ref(git_mirror, git_ref, repo)
+    # The guest's git origin is the read-only mirror, whose URL carries only the
+    # nested clone path, so the guest cannot derive its GitHub owner/repo for the
+    # REST-API PR path. Hand it the resolved ADR 029 scope (owner/repo) via
+    # injected-context so the implement recipe targets the right repo instead of
+    # a hardcoded default. An empty repo (the repo-less artifact path) injects
+    # nothing, so the recipe fails loudly rather than opening a PR against the
+    # wrong repo.
+    if repo:
+        injected_context = {**injected_context, "repo": repo}
     # Task 6: a Plan present means the DeepSeek orchestrator constructed a
     # runtime plan for this turn. Render the router + plan file and ADD them
     # to injected_context (the ADR 040 per-turn context built above is

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -606,6 +606,70 @@ async def test_run_one_turn_ships_injected_context_in_payload(monkeypatch):
     assert captured_payload["injectedContext"]["transcript.md"] == "hi"
 
 
+async def _run_turn_capturing_payload(monkeypatch, **turn_kwargs):
+    """Run a turn with every seam stubbed and return the captured fc-invoke
+    payload (mirrors test_run_one_turn_ships_injected_context_in_payload)."""
+    import chat.api
+
+    captured_payload = {}
+
+    async def fake_post(url, payload, on_retry):
+        captured_payload.update(payload)
+        return {"status": "ok", "result": "done", "sessionDb": ""}
+
+    monkeypatch.setattr(runner, "_post_agent_run", fake_post)
+    monkeypatch.setattr(runner, "FC_INVOKE_URL", "http://fc-invoke")
+    monkeypatch.setattr(runner.sessions, "load", MagicMock(return_value=None))
+    monkeypatch.setattr(runner.threads, "mark_completed", MagicMock())
+    monkeypatch.setattr(runner, "_deliver", AsyncMock())
+    monkeypatch.setattr(runner, "_mark_progress_done", MagicMock())
+    monkeypatch.setattr(runner, "_persist_session_db", AsyncMock())
+    monkeypatch.setattr(chat.api, "reset_goosecracker_progress", MagicMock())
+    monkeypatch.setattr(chat.api, "ensure_steering_token", lambda _s: "")
+    monkeypatch.setattr(
+        chat.api, "build_injected_context", lambda tid, tier="": {"transcript.md": "hi"}
+    )
+    ok = await runner._run_one_turn("sess-1", **turn_kwargs)
+    assert ok is True
+    return captured_payload
+
+
+async def test_run_one_turn_injects_repo_owner_for_pr_path(monkeypatch):
+    """The guest's git origin (the read-only mirror) does not carry its GitHub
+    owner/repo, so the runner stages the resolved ADR 029 scope at
+    /injected-context/repo for the implement recipe's REST-API PR path."""
+    payload = await _run_turn_capturing_payload(
+        monkeypatch,
+        task="open a PR",
+        recipe="agent",
+        tier="",
+        repo="weave-hand/loom",
+        git_mirror="",
+        git_ref="",
+        discord_thread="thr-1",
+    )
+    assert payload["injectedContext"]["repo"] == "weave-hand/loom"
+    # The ADR 040 per-turn context still rides alongside it.
+    assert payload["injectedContext"]["transcript.md"] == "hi"
+
+
+async def test_run_one_turn_repoless_omits_repo_key(monkeypatch):
+    """The repo-less path (e.g. a /agent artifact build with no checkout) injects
+    no repo key, so the recipe's presence check is a clean miss and it fails
+    loudly rather than opening a PR against the wrong repo."""
+    payload = await _run_turn_capturing_payload(
+        monkeypatch,
+        task="build an artifact",
+        recipe="agent",
+        tier="",
+        repo="",
+        git_mirror="",
+        git_ref="",
+        discord_thread="thr-1",
+    )
+    assert "repo" not in payload["injectedContext"]
+
+
 async def _run_artifact_turn_with_dataset_producer(monkeypatch, producer):
     """Shared setup for the channel-data.json wiring tests (Task 3.2): stub
     every seam _run_one_turn touches (mirrors


### PR DESCRIPTION
## Problem

Agents could not open PRs despite the GH token swap working (noted while reviewing goosecracker sessions). Root cause: the `implement` sub-recipe **hardcoded `R=jomcgi/homelab`** for its REST-API PR sequence (`implement.yaml:43`). Every `gh api repos/$R/...` call therefore targeted homelab, so a session working on any other repo (e.g. `weave-hand/loom`) built its blobs, tree, commit, branch, and PR against the wrong repo and failed. The guest cannot derive its own `owner/repo`: its git `origin` is the read-only mirror, whose URL carries only the nested clone path, not the GitHub owner.

This is the `missing-context` failure the improve-recipes evals tagged on sessions `1522242441…` and `1522851555…`. Commit `1c22fb5` fixed the *procedure* (the REST-API sequence) but left the *parameter* (`$R`) hardcoded, so it only ever worked for homelab.

## Why the token needs nothing

The guest holds `GITHUB_TOKEN = "kloak:gh:…"` as an env placeholder; the ADR 023 egress proxy TLS-terminates `api.github.com` and swaps it for the real 1Password-synced token, so `gh api` authenticates transparently. Raw git-over-HTTPS Basic is ADR-deferred, which is exactly why the recipe already forbids `git push`. So this PR injects **repo context, not token context** (injecting token instructions would push agents toward the broken path).

## Fix (Option A, injected-context)

- `runner.py` already resolves the ADR 029 scope (`owner/repo`) for the run; it now stages it at `/injected-context/repo` when non-empty, reusing the ADR 040 per-turn channel (alongside router/plan/transcript). Empty repo (the repo-less artifact path) injects nothing.
- `implement.yaml` reads `R=$(cat /injected-context/repo 2>/dev/null)` and, when that file is missing or empty, refuses to guess a repo or open a PR and says so in its final message, instead of silently targeting a hardcoded default.

## Tests

`runner_test.py`: `repo` is staged in the payload when set (`weave-hand/loom`), and the key is absent on the repo-less path. Existing injected-context assertions are per-key, so the new key is additive.

## Deploy

Two levers, two bumps in this PR: monolith chart (0.285.16, for `runner.py`) and the substrate/guest chart (fc-invoke 0.4.35, rebuilds the guest apko image carrying `implement.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)