### PR TITLE
feat(chat): give DeepSeek a scope-filtered repo menu to select the brief repo

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -4630,6 +4630,16 @@ py_test(
 )
 
 py_test(
+    name = "goosecracker_repo_catalog_test",
+    srcs = ["goosecracker/tests/repo_catalog_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "goosecracker_recipe_catalog_test",
     srcs = ["goosecracker/tests/recipe_catalog_test.py"],
     # The drift-guard test reads the real, checked-in guest recipe YAMLs at

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.16
+version: 0.285.17
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/orchestrator.py
+++ b/projects/monolith/chat/orchestrator.py
@@ -43,7 +43,7 @@ from app.db import get_engine
 from chat import acl, orchestrator_client, orchestrator_plan
 from chat.models import OrchestratorBrief
 from chat.orchestrator_plan import Plan
-from goosecracker.api import CATALOG
+from goosecracker.api import CATALOG, describe_repos
 
 logger = logging.getLogger(__name__)
 
@@ -208,6 +208,7 @@ def assemble_prompt(
     similar_messages: list[str],
     channel_context: str,
     request: str,
+    repo_menu: str = "",
 ) -> tuple[str, str]:
     """Assemble the (system, user) messages in strict stability order (spec
     section 4).
@@ -216,8 +217,10 @@ def assemble_prompt(
     timestamps, ids, or unsorted collections, so two consecutive escalations in
     the same channel produce byte-identical ``system`` messages and the
     provider's prefix cache hits. All volatile content (contextually similar
-    past messages, channel context, the request) goes in ``user``.
-    Byte-deterministic: identical inputs give identical bytes.
+    past messages, channel context, the invoker-scoped repo menu, the request)
+    goes in ``user``. ``repo_menu`` is per-invoker (their ADR 029 grants), so it
+    rides here rather than in the cached system prefix. Byte-deterministic:
+    identical inputs give identical bytes.
     """
     system = (
         bundle.rstrip("\n")
@@ -233,6 +236,11 @@ def assemble_prompt(
         + similar_block
         + "\n\n## Channel context\n\n"
         + (channel_context.strip() or "(none)")
+        + "\n\n## Available repos\n\n"
+        + "When the request needs a repo checkout, set the goose brief's `repo` "
+        "to exactly one of these owner/repo ids, and leave it empty only for a "
+        "repo-less artifact or build. Never name a repo that is not listed.\n\n"
+        + (repo_menu.strip() or "(none)")
         + "\n\n## Request\n\n"
         + request.strip()
         + "\n"
@@ -577,6 +585,7 @@ async def compile(ctx: RequestContext) -> Verdict:
         ctx.similar_messages,
         ctx.channel_context,
         ctx.request,
+        describe_repos(ctx.allowed_scopes),
     )
 
     try:

--- a/projects/monolith/chat/orchestrator_test.py
+++ b/projects/monolith/chat/orchestrator_test.py
@@ -146,6 +146,21 @@ class TestAssemblePrompt:
         # The channel context stays a separate, distinct block.
         assert "## Channel context" in user
 
+    def test_repo_menu_rides_in_user_not_system(self):
+        system, user = assemble_prompt(
+            "BUNDLE",
+            Directive(version=1, text="d"),
+            ["kg a"],
+            "chan ctx",
+            "do it",
+            "- jomcgi/homelab = the homelab repo",
+        )
+        assert "## Available repos" in user
+        assert "- jomcgi/homelab = the homelab repo" in user
+        # Per-invoker (their grants), so it must never enter the cache-stable
+        # system prefix, or the provider prefix cache would miss every invoker.
+        assert "jomcgi/homelab" not in system
+
 
 # ---------------------------------------------------------------------------
 # parse_brief
@@ -464,6 +479,31 @@ class TestCompile:
         assert verdict.repo == "weave-hand/loom"
         assert verdict.repo_replaced is True
         assert _rows(engine)[0].brief_json["repo_replaced"] is True
+
+    @pytest.mark.asyncio
+    async def test_route_call_user_message_lists_granted_repos(
+        self, engine, monkeypatch
+    ):
+        # compile injects the invoker's scope-filtered repo menu into the route
+        # call, so DeepSeek selects the brief's repo from a real, grant-limited
+        # list instead of guessing a name that gets validated away.
+        monkeypatch.setenv("ORCHESTRATOR_MODEL", "test/model")
+        monkeypatch.setattr(acl, "is_granted", lambda *a, **k: True)
+        captured = {}
+
+        async def fake_call(system, user):
+            captured["system"] = system
+            captured["user"] = user
+            return _response(_CHAT_JSON)
+
+        monkeypatch.setattr(orchestrator_client, "call", fake_call)
+        monkeypatch.setattr(orchestrator, "get_engine", lambda: engine)
+
+        await orchestrator.compile(_ctx(allowed_scopes=frozenset({"weave-hand/loom"})))
+        assert "## Available repos" in captured["user"]
+        assert "weave-hand/loom" in captured["user"]
+        # A repo the invoker does not hold is not offered.
+        assert "jomcgi/homelab" not in captured["user"]
 
     @pytest.mark.asyncio
     async def test_goose_verdict_carries_brief_row_id(self, engine, monkeypatch):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.16
+      targetRevision: 0.285.17
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/api.py
+++ b/projects/monolith/goosecracker/api.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from goosecracker.dispatch import resume, status, submit  # re-exported
 from goosecracker.recipe_catalog import CATALOG, enabled_enum  # re-exported
+from goosecracker.repo_catalog import describe_repos  # re-exported
 from goosecracker.router_render import (  # re-exported
     render_plan_file,
     render_router,
@@ -18,6 +19,7 @@ from goosecracker.threads import get_run, list_runs, serialize  # re-exported
 
 __all__ = [
     "CATALOG",
+    "describe_repos",
     "enabled_enum",
     "get_run",
     "list_runs",

--- a/projects/monolith/goosecracker/repo_catalog.py
+++ b/projects/monolith/goosecracker/repo_catalog.py
@@ -1,0 +1,82 @@
+"""Repo catalog: descriptions of the hydratable repos, for repo selection.
+
+The DeepSeek orchestrator (ADR 036) picks the goose brief's ``repo`` from the
+invoker's ADR 029 grants. Names alone (jomcgi/homelab, weave-hand/loom) are a
+weak signal, so this module carries a one-line description per registered repo
+and renders the invoker-scoped menu that the route prompt injects into its user
+message. It rides in the user message (never the byte-stable system bundle)
+because the granted set is per-invoker: a scope-specific list in the cached
+system prefix would break the provider prefix cache.
+
+The ids MUST track the git-mirror's registered repos
+(``projects/firecracker/git-mirror/deploy/values.yaml``). The two sets are
+allowed to drift gracefully in one direction only: a repo in a grant but not
+here still appears in the menu with a generic description (a grant is never
+hidden from selection), while a repo here but not on the mirror simply cannot
+hydrate. Seed descriptions are hand-written; a future routine may regenerate
+them from each repo's README/CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RepoEntry:
+    """One hydratable repo: its owner/repo id and a one-line selection description."""
+
+    id: str
+    description: str
+
+
+# Ordered owner/repo -> description. The order is preserved in the rendered menu
+# for the repos an invoker holds; keep it stable rather than alphabetizing so
+# the owner's two primary repos lead.
+REPO_CATALOG: dict[str, RepoEntry] = {
+    "jomcgi/homelab": RepoEntry(
+        "jomcgi/homelab",
+        "This secure Kubernetes homelab: every service, operator, and website "
+        "colocated with its GitOps deploy config (Helm + ArgoCD), built with "
+        "Bazel + apko. Go, Python, JavaScript, Starlark. Choose this for the "
+        "cluster, its apps and websites, CI, or infrastructure work.",
+    ),
+    "weave-hand/loom": RepoEntry(
+        "weave-hand/loom",
+        "Loom: a pre-alpha open-source typed-object data platform replicating "
+        "Palantir Foundry's core concepts with a ports-and-adapters "
+        "architecture. Private, under the weave-hand org. Choose this for Loom "
+        "platform, data-object, or ontology work.",
+    ),
+    "colincee/homelab": RepoEntry(
+        "colincee/homelab",
+        "A collaborator's own homelab fork (ColinCee): their personal "
+        "Kubernetes/infra setup, not this cluster. Choose this only when the "
+        "task is explicitly about ColinCee's repo.",
+    ),
+    "scotscottmca/parkedlikea": RepoEntry(
+        "scotscottmca/parkedlikea",
+        "A collaborator's project (scotscottmca/parkedlikea). Choose this only "
+        "when the task explicitly names it.",
+    ),
+}
+
+
+def describe_repos(scopes: Iterable[str]) -> str:
+    """Render the repo-selection menu for an invoker's granted ``scopes``.
+
+    Lists the granted repos as ``- <owner/repo> = <description>`` lines: catalog
+    order first for known repos the invoker holds, then any granted-but-
+    uncatalogued repo (sorted) with a generic description, so a grant is never
+    hidden. Deterministic for a given scope set. Returns a "(none)" sentinel
+    when the invoker holds no repo grants.
+    """
+    scope_set = set(scopes)
+    known = [entry for entry in REPO_CATALOG.values() if entry.id in scope_set]
+    extra = sorted(scope_set - set(REPO_CATALOG))
+    if not known and not extra:
+        return "(none: the invoker holds no repo grants, so no repo may be named)"
+    lines = [f"- {entry.id} = {entry.description}" for entry in known]
+    lines += [f"- {rid} = (no description on file)" for rid in extra]
+    return "\n".join(lines)

--- a/projects/monolith/goosecracker/tests/repo_catalog_test.py
+++ b/projects/monolith/goosecracker/tests/repo_catalog_test.py
@@ -1,0 +1,53 @@
+"""Tests for goosecracker.repo_catalog: the invoker-scoped repo menu the
+DeepSeek orchestrator uses to select the goose brief's repo."""
+
+from goosecracker.repo_catalog import REPO_CATALOG, describe_repos
+
+
+def test_menu_lists_only_granted_repos():
+    menu = describe_repos(frozenset({"jomcgi/homelab"}))
+    assert "- jomcgi/homelab = " in menu
+    # A repo the invoker does not hold is never offered.
+    assert "weave-hand/loom" not in menu
+
+
+def test_menu_carries_the_catalog_description():
+    menu = describe_repos(frozenset({"weave-hand/loom"}))
+    assert "- weave-hand/loom = " in menu
+    assert "Loom" in menu
+
+
+def test_known_repos_render_in_catalog_order():
+    menu = describe_repos(frozenset({"weave-hand/loom", "jomcgi/homelab"}))
+    # Catalog order (homelab before loom) is preserved regardless of set order.
+    assert menu.index("jomcgi/homelab") < menu.index("weave-hand/loom")
+
+
+def test_granted_but_uncatalogued_repo_still_appears():
+    # A grant is never hidden: an id not in the catalog gets a generic line so
+    # the model can still select a valid repo it holds.
+    menu = describe_repos(frozenset({"someone/newrepo"}))
+    assert "- someone/newrepo = (no description on file)" in menu
+
+
+def test_known_repos_lead_uncatalogued_follow():
+    menu = describe_repos(frozenset({"someone/newrepo", "jomcgi/homelab"}))
+    assert menu.index("jomcgi/homelab") < menu.index("someone/newrepo")
+
+
+def test_no_grants_renders_none_sentinel():
+    menu = describe_repos(frozenset())
+    assert menu.startswith("(none")
+
+
+def test_deterministic_for_a_given_scope_set():
+    scopes = frozenset({"jomcgi/homelab", "weave-hand/loom", "z/z", "a/a"})
+    assert describe_repos(scopes) == describe_repos(scopes)
+
+
+def test_catalog_ids_are_owner_slash_repo():
+    # Every catalog key is an owner/repo id (the ADR 029 scope shape), so a
+    # menu line is directly usable as the brief's repo and the mirror path.
+    for rid, entry in REPO_CATALOG.items():
+        assert rid == entry.id
+        assert rid.count("/") == 1 and all(rid.split("/"))


### PR DESCRIPTION
## Problem

Repo selection (Option A of the design discussion) was the weak link. The orchestrator route prompt gave DeepSeek **no list of the invoker's repos at all** — `assemble_prompt` carries the directive, similar messages, channel context, and request, but nothing about which GitHub repos exist or which the invoker holds. DeepSeek named `repo` from its own baked knowledge; `_parse_goose` then validated that guess against the invoker's ADR 029 grants and **discarded it** (replacing with `invoker_scope`, which is `""` for mention/ambient) when out of scope. So the repo the guest hydrated was frequently wrong or empty. (The `## Repo structure` in the bundle is the homelab repo's *internal directory layout*, not the set of selectable repos.)

## Fix (Option A)

- New `goosecracker/repo_catalog.py`: a one-line description per registered mirror repo (`jomcgi/homelab`, `weave-hand/loom`, and the collaborator forks), plus `describe_repos(scopes)` which renders the invoker's **scope-filtered** menu.
- `compile` renders that menu from `ctx.allowed_scopes` and passes it to `assemble_prompt`, which places it in the route call's **user message** with an instruction to set `repo` to exactly one listed id (or leave it empty for a repo-less artifact).
- Re-exported through the `goosecracker.api` seam (like `CATALOG`), so the `chat -> goosecracker` import boundary holds.

Design choices worth noting:
- **User message, not the system bundle.** The granted set is per-invoker; a scope-specific list in the byte-stable system prefix would break the provider prefix cache. The bundle is also a generated, golden-tested artifact, so it stays untouched.
- **A grant is never hidden.** A granted repo missing from the catalog still appears with a generic description, so the model can always pick a valid repo it holds.
- **Delivery unchanged.** The selected repo still reaches the guest's PR path via `/injected-context/repo` (the prior PR #3213). Selection improves *what* we inject.
- Descriptions are hand-seeded; a routine can later regenerate them from each repo's README/CLAUDE.md (the "regularly regenerate" follow-up).

## Tests

- `repo_catalog_test.py` (new target): scope filtering, catalog-order rendering, granted-but-uncatalogued fallback, `(none)` sentinel, determinism, id shape.
- `orchestrator_test.py`: the menu rides in the user message and never the system prefix; `compile` lists the invoker's granted repos (and not ungranted ones) in the route call.

Monolith chart bumped (0.285.17); monolith-only change.

## Multirepo workflows: how this extends (design note, not built here)

You flagged multirepo. This change is deliberately the foundation for it, and the natural extension path is:

1. **Selection** — the menu already lists *all* the invoker's granted repos, so multi-select is a prompt/schema change: the brief's `repo` (string) becomes `repos` (a list), and `_parse_goose` validates each against `allowed_scopes` (every named repo must be granted — the privacy invariant is unchanged).
2. **Hydration** — the real work. The substrate clones one mirror at `/workspace` today; multirepo needs N clones (e.g. `/workspace/<owner>/<repo>`), which touches `runner._effective_mirror_ref`, the fc-invoke payload, and guest-init. Boot cost scales with repo count, so hydrate the primary eagerly and others lazily/on-demand.
3. **Injection** — `/injected-context/repo` (singular) generalises to a `repos` list (one `owner/repo` per line); the implement recipe maps each changed path to its repo and opens **a PR per repo**.
4. **Privacy** — every hydrated repo must be in `allowed_scopes`. Multirepo never crosses a grant boundary, which is exactly why the "just clone everything" shortcut is off the table.

Recommendation: land this (single-repo selection) now, measure whether multi-repo tasks actually show up on the next `/improve-recipes` run (routing telemetry is now fixed), and if they do, spin items 1-4 into an ADR since hydration is a substrate-level decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)