### PR TITLE
feat(chat): ambient engages post one complete message, not thinking->edit

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.16
+version: 0.285.17
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -1558,7 +1558,10 @@ class ChatBot(discord.Client):
         try:
             async with message.channel.typing():
                 sent, response_text, thinking = await self._stream_response(
-                    message, attachments, with_buttons=not force_respond
+                    message,
+                    attachments,
+                    with_buttons=not force_respond,
+                    live=not force_respond,
                 )
         except Exception:
             logger.exception("Failed to respond to message %s", msg_id)
@@ -1600,12 +1603,19 @@ class ChatBot(discord.Client):
         current_attachments: list[dict] | None = None,
         *,
         with_buttons: bool = True,
+        live: bool = True,
     ) -> tuple[discord.Message, str, str | None]:
         """Build context and stream the PydanticAI agent response.
 
-        Sends an initial Discord reply on the first event, then progressively
-        edits the message as new content arrives. Returns
-        (sent_message, response_text, thinking_text).
+        When ``live`` is True (a mention/reply the user is waiting on), sends an
+        initial Discord reply on the first event, then progressively edits the
+        message as thinking/search/text arrives. When ``live`` is False (an
+        ambient interjection nobody explicitly asked for), suppresses the
+        placeholder and the progressive edits and posts one complete message at
+        the end, so the bot reads as chiming in rather than visibly "typing" a
+        message it edits in place (the channel's native typing indicator still
+        signals composition). Returns (sent_message, response_text,
+        thinking_text).
 
         ``with_buttons`` controls whether the "Show thinking" / fact-check
         action row is attached. Ambient (unprompted) replies pass ``False`` so
@@ -1759,12 +1769,14 @@ class ChatBot(discord.Client):
                         response_text = final_output
                 elif isinstance(event, PartDeltaEvent):
                     if isinstance(event.delta, ThinkingPartDelta):
-                        await _ensure_sent("\U0001f4ad Thinking...")
+                        if live:
+                            await _ensure_sent("\U0001f4ad Thinking...")
                         thinking_parts.append(event.delta.content_delta)
                     elif isinstance(event.delta, TextPartDelta):
                         response_text += event.delta.content_delta
-                        await _ensure_sent(response_text)
-                        await _edit_if_due(response_text)
+                        if live:
+                            await _ensure_sent(response_text)
+                            await _edit_if_due(response_text)
                 elif isinstance(event, FunctionToolCallEvent):
                     args = event.part.args
                     if isinstance(args, str):
@@ -1785,9 +1797,10 @@ class ChatBot(discord.Client):
                     # result event for either id flips the shared row to done.
                     if query not in search_status:
                         search_status[query] = False
-                        content = _search_content()
-                        await _ensure_sent(content)
-                        await _edit_if_due(content, force=True)
+                        if live:
+                            content = _search_content()
+                            await _ensure_sent(content)
+                            await _edit_if_due(content, force=True)
                 elif isinstance(event, FunctionToolResultEvent):
                     # A search returned: flip its row from \u23f3 to \u2705.
                     done_query = id_to_query.get(event.tool_call_id)
@@ -1795,7 +1808,8 @@ class ChatBot(discord.Client):
                         done_query, True
                     ):
                         search_status[done_query] = True
-                        await _edit_if_due(_search_content(), force=True)
+                        if live:
+                            await _edit_if_due(_search_content(), force=True)
 
             # Fallback if no events arrived or no text was produced
             if not had_events or not response_text:
@@ -1826,9 +1840,11 @@ class ChatBot(discord.Client):
                     content=response_text,
                     view=BotMessageView(response_text, thinking_text),
                 )
-            else:
-                # Ambient reply: no action row, so it reads as an organic message.
+            elif live:
+                # Streamed reply without buttons: settle the final delta in place.
                 await sent.edit(content=response_text)
+            # Ambient (not live): the finalizing _ensure_sent above already posted
+            # the complete text as one message, so there is nothing left to edit.
 
             # A directive change proposed this run needs a human 👍/👎 confirm
             # before it applies (ADR 035 Phase 5): post the summary, seed the

--- a/projects/monolith/chat/bot_streaming_test.py
+++ b/projects/monolith/chat/bot_streaming_test.py
@@ -741,3 +741,81 @@ class TestEditIfDueRateLimiting:
         # Both tool queries must appear in edit calls despite rapid arrival
         assert "first" in combined
         assert "second" in combined
+
+
+class TestAmbientNonStreaming:
+    """Ambient (unprompted) engages skip the thinking->edit flow and post one
+    complete message, so the bot reads as chiming in rather than visibly typing
+    a message it edits in place."""
+
+    @pytest.mark.asyncio
+    async def test_ambient_posts_single_complete_message(self):
+        """live=False: no placeholder, no progressive edits — one reply with the
+        full final text, and no intermediate "Thinking"/"Searching" render."""
+        bot = _make_bot()
+        message = _make_message(content="fable is kinda woof no?")
+        mock_store = _make_store()
+
+        events = [
+            _thinking_delta("Let me weigh that"),
+            _tool_call_event("web_search", {"query": "fable stats patch"}),
+            _tool_result_event("web_search", tool_call_id="c1"),
+            _text_delta("Nah, "),
+            _text_delta("fable's holding up fine."),
+        ]
+        bot.agent.run_stream_events = MagicMock(return_value=_async_iter(events))
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+        ):
+            ctx = MagicMock()
+            mock_session_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            sent, text, _thinking = await bot._stream_response(
+                message, None, with_buttons=False, live=False
+            )
+
+        # Exactly one message posted — the complete response, not a placeholder.
+        message.reply.assert_called_once()
+        posted = message.reply.call_args_list[0][0][0]
+        assert posted == "Nah, fable's holding up fine."
+        assert "Thinking" not in posted
+        assert "Searching" not in posted
+        # No progressive/in-place edits in ambient mode.
+        sent.edit.assert_not_called()
+        assert text == "Nah, fable's holding up fine."
+
+    @pytest.mark.asyncio
+    async def test_live_true_still_streams_placeholder_and_edits(self):
+        """Regression guard: the explicit (live=True) path keeps the initial
+        placeholder-then-edit behavior so mentions still get live feedback."""
+        bot = _make_bot()
+        message = _make_message(content="hey bot")
+        mock_store = _make_store()
+
+        events = [
+            _thinking_delta("hmm"),
+            _text_delta("Hello "),
+            _text_delta("there."),
+        ]
+        bot.agent.run_stream_events = MagicMock(return_value=_async_iter(events))
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+        ):
+            ctx = MagicMock()
+            mock_session_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            sent, text, _thinking = await bot._stream_response(
+                message, None, with_buttons=True, live=True
+            )
+
+        # The placeholder went out first (thinking indicator), then edits followed.
+        first_reply = message.reply.call_args_list[0][0][0]
+        assert "\U0001f4ad Thinking..." == first_reply
+        sent.edit.assert_called()
+        assert text == "Hello there."

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.16
+      targetRevision: 0.285.17
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

Ambient (unprompted) engages now post **one complete message** instead of the live thinking→edit stream. Mentions and replies are unchanged: they still stream a "💭 Thinking…" placeholder that edits in place, because there the user is explicitly waiting and the live feedback is reassurance.

## Why

For an ambient interjection nobody asked for, the placeholder-that-edits-itself reads as noise: the bot visibly "types" and rewrites a message in a channel it just chose to chime into. Coming in with a finished message reads like a person joining the conversation. The channel's native typing indicator (already wrapping the call in `_process_message`) still signals composition during the silent window.

## How

- New `live: bool` param on `_stream_response`, set by the caller to `not force_respond`, so it tracks the existing ambient signal exactly.
- When `live=False`: the in-loop `_ensure_sent`/`_edit_if_due` calls are skipped (accumulation still happens), and the finalizing `_ensure_sent(response_text)` posts the one complete message using the authoritative response text.
- When `live=True`: today's behavior, untouched.

Only the conversational chat path is affected. The deep-agent path (`_engage_agent`) uses reactions + a thread, not thinking→edit, and is out of scope.

## Tests

- `TestAmbientNonStreaming::test_ambient_posts_single_complete_message` — one reply, full text, no placeholder/search render, no in-place edits.
- `test_live_true_still_streams_placeholder_and_edits` — regression guard that the explicit path keeps streaming.

Chart bumped 0.285.16 → 0.285.17 so it deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)