### PR TITLE
fix(chat): deliver agent results as Bosun in first person, not a third-person recap

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.17
+version: 0.285.18
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/summarizer.py
+++ b/projects/monolith/chat/summarizer.py
@@ -364,23 +364,32 @@ def _fetch_agent_reply_context(channel_id: str) -> str:
 
 
 def _build_agent_reply_prompt(summary: str, details: str, context: str) -> str:
-    """Prompt the concierge model to rephrase an agent run's typed result as a
-    natural channel reply. The URL is NOT part of this prompt: it is appended
+    """Prompt the concierge model to deliver an agent run's typed result as
+    Bosun's own first-person reply. From the member's side this is one
+    conversation with Bosun, so the model speaks as itself and never narrates a
+    separate "agent". The URL is NOT part of this prompt: it is appended
     deterministically by the caller so the model can never invent or mangle it."""
     reported = f"Summary: {summary}"
     if details:
         reported += f"\nDetails: {details}"
     ctx = context.strip() or "(no channel context available)"
     return (
-        "You are the friendly assistant bot for this Discord channel. The coding "
-        "agent a member asked to run has just finished. Relay what it did to the "
-        "channel in your own voice: natural, warm, and specific, the way you would "
-        "in chat. Keep it to 2 to 4 sentences. Do not invent links, PR numbers, "
-        "file names, or any detail that is not in the agent's report below (any "
-        "link is posted separately). No markdown headers or bullet lists, no "
-        "preamble.\n\n"
-        f"What the agent reported:\n{reported}\n\n"
-        "Channel context, for tone and who is around (do not quote it back):\n"
+        "You are Bosun, the assistant in this Discord channel. You just finished "
+        "the work a member asked you for; the result is below. Deliver it as "
+        'yourself, in the first person ("I looked at", "I found", "I\'d '
+        'suggest"), speaking to the member as "you". From their side this is '
+        'one continuous conversation with you, so never mention "the agent", '
+        '"the coding agent", or "they" as if something else did the work, and '
+        "never write about it in the third person. Do not open with or address "
+        "the member by name. Be natural, warm, and specific. Give the complete "
+        "answer with nothing padded: a quick task is a sentence or two, a review "
+        "or explanation runs as long as it needs to land every real point, with "
+        "no filler. Do not invent links, PR numbers, file names, or any detail "
+        "that is not in the result below (any link is posted separately). No "
+        "markdown headers or bullet lists, no preamble.\n\n"
+        f"What you did and found:\n{reported}\n\n"
+        "Channel context, for tone and who is around (do not quote it back or "
+        "address anyone by name):\n"
         f"{ctx}"
     )
 
@@ -416,12 +425,14 @@ def _build_chat_reply_prompt(question: str, guidance: str, context: str) -> str:
     truth and is never overridden by the guidance."""
     ctx = context.strip() or "(no channel context available)"
     parts = [
-        "You are the friendly assistant bot for this Discord channel. A member "
-        "just messaged you. Answer them directly in your own voice: natural, "
-        "warm, and specific, the way you would in chat. Keep it to 2 to 4 "
-        "sentences. No agent run happened here, so do not narrate one or claim "
-        "you did any work. Do not invent links, PR numbers, or file "
-        "names. No markdown headers or bullet lists, no preamble.",
+        "You are Bosun, the assistant in this Discord channel. A member just "
+        "messaged you. Answer them directly as yourself, in the first person, "
+        'speaking to them as "you". Do not open with or address them by name. '
+        "Be natural, warm, and specific. Give the complete answer with nothing "
+        "padded: a quick question is a sentence or two, a broader one runs as "
+        "long as it needs, with no filler. No run happened here, so do not "
+        "narrate one or claim you did any work. Do not invent links, PR numbers, "
+        "or file names. No markdown headers or bullet lists, no preamble.",
         f"What the member said:\n{question.strip()}",
     ]
     if guidance.strip():

--- a/projects/monolith/chat/summarizer_agent_reply_test.py
+++ b/projects/monolith/chat/summarizer_agent_reply_test.py
@@ -149,6 +149,19 @@ class TestBuildAgentReplyPrompt:
         prompt = _build_agent_reply_prompt("Done.", "", "")
         assert "no channel context available" in prompt
 
+    def test_delivers_as_bosun_in_first_person(self):
+        # From the member's side this is one conversation with Bosun: the reply
+        # is delivered as Bosun in the first person, not as a third-person recap
+        # of "the agent" (the mis-framing that produced "the agent found ...").
+        prompt = _build_agent_reply_prompt("Done.", "", "ctx")
+        assert "Bosun" in prompt
+        assert "first person" in prompt.lower()
+        assert "relay what it did" not in prompt.lower()
+
+    def test_forbids_addressing_member_by_name(self):
+        prompt = _build_agent_reply_prompt("Done.", "", "ctx")
+        assert "by name" in prompt.lower()
+
 
 class TestConversationalAgentReply:
     async def test_calls_llm_with_built_prompt(self, monkeypatch):
@@ -195,6 +208,12 @@ class TestBuildChatReplyPrompt:
     def test_tolerates_empty_context(self):
         prompt = _build_chat_reply_prompt("hi", "", "")
         assert "no channel context available" in prompt
+
+    def test_is_bosun_first_person_and_no_name_address(self):
+        prompt = _build_chat_reply_prompt("hi", "", "ctx")
+        assert "Bosun" in prompt
+        assert "first person" in prompt.lower()
+        assert "by name" in prompt.lower()
 
 
 class TestConversationalChatReply:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.17
+      targetRevision: 0.285.18
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

Agent replies read like a narrator reporting on a separate entity, and opened by name-dropping the member:

> "**The agent** wrapped up the review of your Grimoire Live play design… **it** flagged… **They did** suggest…"
> "**Quinoa, the agent** reviewed your user stories and found them…"

From the member's side this is one continuous conversation with **Bosun**. It should be Bosun's own first-person voice, addressed to "you," with no unnecessary name-drop.

## Cause

`_build_agent_reply_prompt` (the concierge prompt that turns an agent run's typed result into the Discord message) told the model:

> "The **coding agent** a member asked to run has just finished. **Relay what it did**… What **the agent** reported: …"

That framing invites third-person narration and casts the agent as something separate to report on. The name-drop comes from the channel context ("who is around") leaking names with no instruction against addressing people by name.

## Fix

Rewrote both concierge prompts in `summarizer.py`:

- **First-person Bosun.** "You are Bosun… you just finished the work… deliver it as yourself, in the first person ('I looked at', 'I found', 'I'd suggest'), speaking to the member as 'you'. Never mention 'the agent' or 'they' as if something else did the work."
- **No name-address.** "Do not open with or address the member by name" (+ "do not address anyone by name" on the channel-context block).
- **Complete, not capped.** Replaced the rigid "2 to 4 sentences" with length matched to substance: a quick task stays a sentence or two; a review or explanation runs as long as it needs to land every real point, with no padding. This serves the conversational / exploratory / explanatory modes equally.
- Applied the same Bosun-first-person + no-name framing to the chat-route reply prompt for a consistent voice.

Guards preserved: no inventing links/PRs/files, the URL stays appended by the caller (never in the prompt), warmth/specificity, empty-context fallback.

## Tests

Existing assertions (content passthrough, no-invention, URL omitted, empty-context, chat-route "no `coding`" framing) still hold; added tests for the first-person Bosun framing and the no-name-address rule on both prompts.

Monolith chart bumped (0.285.18); monolith-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)