### PR TITLE
fix(chat): agent reviews lead with critique, not sycophantic praise

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/implement.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/implement.yaml
@@ -70,7 +70,10 @@ instructions: |
   Your final message is returned verbatim to the routing agent: state the
   action taken and the outcome in one or two sentences, the branch name,
   and the PR URL if you opened one (only a URL you actually received, never
-  an invented one).
+  an invented one). Report the outcome honestly: name anything you were
+  unsure about, had to work around, or left incomplete, and anything that
+  still needs review. Do not oversell the change or call it clean or solid
+  to reassure; a caveat the reviewer needs is worth more than praise.
 
   When you are unsure about an EXTERNAL fact (an upstream API or flag, a
   library version, current best practice) do not guess and do not silently

--- a/projects/firecracker/goosecracker/guest/recipes/query.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/query.yaml
@@ -26,6 +26,16 @@ instructions: |
   - Cite evidence: name the files and paths your answer rests on.
   - If the answer is genuinely not in the repo, say so plainly instead of
     guessing.
+  - When the question asks you to assess, review, critique, or sanity-check
+    something (code, a design, a set of stories, a plan, someone's work),
+    your job is to surface what is weak, risky, missing, or wrong, not to
+    reassure. Lead with the real problems and the strongest objection you
+    can support, each tied to specific evidence. Do not open with praise or
+    a blanket verdict like "this is solid", "well-structured", or "you're in
+    good shape": note a strength only where it is load-bearing to the
+    judgment, and only after the problems. If after looking hard you
+    genuinely find little wrong, say that plainly, but never soften or
+    invent approval to be agreeable.
 
   Finish with a clear, self-contained answer to the question. Your final
   message is returned verbatim to the routing agent, so lead with the answer,

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.35
+version: 0.4.36

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.35
+      targetRevision: 0.4.36
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.18
+version: 0.285.19
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -258,6 +258,10 @@ def build_system_prompt() -> str:
         "fine when it earns its place; skip it for casual chat.\n"
         '- Start messages with "Sure!", "Of course!", "Great question!", '
         "or any other filler.\n"
+        "- Be a sycophant. Don't open with praise, validate an idea you have "
+        "doubts about, or soften a real problem to be agreeable. If something is "
+        'weak, wrong, or risky, say so and lead with it, skipping empty "solid", '
+        '"great point", or "you\'re in good shape" reassurance.\n'
         "- Announce that you're using a tool. Just use it and share "
         "what you found.\n"
         '- Apologize for being an AI or say "as an AI".\n'

--- a/projects/monolith/chat/summarizer.py
+++ b/projects/monolith/chat/summarizer.py
@@ -384,7 +384,11 @@ def _build_agent_reply_prompt(summary: str, details: str, context: str) -> str:
         "the member by name. Be natural, warm, and specific. Give the complete "
         "answer with nothing padded: a quick task is a sentence or two, a review "
         "or explanation runs as long as it needs to land every real point, with "
-        "no filler. Do not invent links, PR numbers, file names, or any detail "
+        "no filler. Warmth is in how you say it, never in inflating the verdict: "
+        "if the result is critical or carries caveats, deliver that criticism at "
+        "full strength and never soften it into reassurance, and never add praise "
+        "or a rosy summary the result does not contain. "
+        "Do not invent links, PR numbers, file names, or any detail "
         "that is not in the result below (any link is posted separately). No "
         "markdown headers or bullet lists, no preamble.\n\n"
         f"What you did and found:\n{reported}\n\n"
@@ -430,7 +434,10 @@ def _build_chat_reply_prompt(question: str, guidance: str, context: str) -> str:
         'speaking to them as "you". Do not open with or address them by name. '
         "Be natural, warm, and specific. Give the complete answer with nothing "
         "padded: a quick question is a sentence or two, a broader one runs as "
-        "long as it needs, with no filler. No run happened here, so do not "
+        "long as it needs, with no filler. Be honest over agreeable: if their "
+        "idea or work has real problems, lead with them instead of validating it "
+        "to be nice, and skip empty openers like 'great question' or 'solid'. "
+        "No run happened here, so do not "
         "narrate one or claim you did any work. Do not invent links, PR numbers, "
         "or file names. No markdown headers or bullet lists, no preamble.",
         f"What the member said:\n{question.strip()}",

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.18
+      targetRevision: 0.285.19
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

Agent code/story reviews came back praise-heavy ("solid, well-structured... you're in good shape!") and this survived even a direct "don't be a sycophant" reply. That's because nothing in either the analysis or the delivery layer countered the model's default agreeableness: a per-turn reply is weaker than the standing recipe/prompt.

## Fix (two layers)

**Analysis origin (guest recipes, baked into the image):**
- `query.yaml`: adds an assessment stance. When asked to review/critique/sanity-check work, lead with what is weak, risky, missing, or wrong, each tied to evidence; no blanket "this is solid" opener; earn any praise and put it after the problems.
- `implement.yaml`: asks the final self-report to name what was uncertain, worked around, or left incomplete, instead of overselling the change.

**Delivery voice (monolith):**
- `summarizer.py` agent-reply + chat-reply prompts: split warmth (tone) from the verdict (substance). Warmth is in *how* it's said, never in inflating the verdict; criticism is relayed at full strength; no praise the result doesn't contain.
- `agent.py` chat system prompt: a new anti-sycophancy `DON'T` bullet.

## Deploy

Bumps **monolith** (0.285.19, for summarizer/agent) and **fc-invoke** (0.4.36, for the new guest image carrying the edited recipes). The recipe half reaches the cluster once the guest image rebuilds and the substrate redeploys the rootfs base; the monolith delivery half is live on the monolith rollout. A follow-up PR moves recipe delivery to code-injection so future recipe edits skip the guest-image + snapshot cadence entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)