### PR TITLE
feat(inference): enable vLLM automatic prefix caching via FlashInfer

### DIFF
--- a/projects/inference/deploy/Chart.yaml
+++ b/projects/inference/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inference
 description: A Helm chart for LLM inference (vLLM LLM serving + llama.cpp CPU embeddings)
 type: application
-version: 2.5.4
+version: 2.5.5
 appVersion: "b5270"
 keywords:
   - llm

--- a/projects/inference/deploy/templates/deployment.yaml
+++ b/projects/inference/deploy/templates/deployment.yaml
@@ -40,6 +40,11 @@ spec:
         - name: llama-server
           image: "{{ .Values.image.vllm.repository }}:{{ .Values.image.vllm.tag }}"
           imagePullPolicy: {{ .Values.image.vllm.pullPolicy }}
+          env:
+            {{- range $k, $v := .Values.vllm.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           command: ["/bin/sh", "-c"]

--- a/projects/inference/deploy/values.yaml
+++ b/projects/inference/deploy/values.yaml
@@ -218,6 +218,17 @@ vllm:
     - "8"
     - "--kv-cache-dtype"
     - "fp8"
+    # FlashInfer (below) supports fp8 KV cache + automatic prefix caching
+    # together on CUDA; the default FlashAttention-2 backend silently disables
+    # APC when kv-cache-dtype is fp8. Multi-turn chat re-prefills full history
+    # today and goose agents share an identical tool-def prefix, so this is a
+    # real TTFT win at no extra VRAM cost (APC reuses the existing KV pool).
+    - "--enable-prefix-caching"
+  # Selects the FlashInfer attention backend (see extraArgs comment above).
+  # FlashInfer ships in the official vllm/vllm-openai:v0.19.1 image already,
+  # so no image rebuild is needed.
+  env:
+    VLLM_ATTENTION_BACKEND: FLASHINFER
 
 runtimeClassName: nvidia
 


### PR DESCRIPTION
## Summary

fp8 KV cache currently auto-disables automatic prefix caching (APC) on the default FlashAttention-2 backend, confirmed live: `enable_prefix_caching=False`, prefix cache hit rate 0.0%. This switches the attention backend to FlashInfer, which supports fp8 KV cache and APC together on CUDA, and explicitly enables prefix caching, while keeping fp8 KV cache and the existing `vllm/vllm-openai:v0.19.1` image (FlashInfer already ships in that image, so no rebuild is needed).

## Changes

- `projects/inference/deploy/values.yaml`: added `--enable-prefix-caching` to `vllm.extraArgs`, and a new `vllm.env` map setting `VLLM_ATTENTION_BACKEND: FLASHINFER`.
- `projects/inference/deploy/templates/deployment.yaml`: added an `env:` block on the vllm container that ranges over `.Values.vllm.env`.
- `projects/inference/deploy/Chart.yaml`: bumped `version: 2.5.4 -> 2.5.5`. Note: this project's `application.yaml` uses a single-source, direct git path (`targetRevision: HEAD`), not the OCI-pinned multi-source pattern most services use, so there is no matching semver `targetRevision` to update here (`bump-chart.sh` correctly refuses to run against it for that reason). Only `Chart.yaml` needed the bump.

## Why this matters

- Multi-turn chat re-prefills the entire conversation history on every turn today; goose agents share an identical tool-definition prefix across calls; grimoire has moderate repeated-prefix traffic. APC should meaningfully cut time-to-first-token (TTFT) across all three once the prefix cache starts hitting.
- APC reuses the existing KV cache pool, so this adds no extra VRAM cost. The only thing worth watching on the 24GB RTX 4090 is FlashInfer's own workspace buffer; if it doesn't fit, the fallbacks are `--enforce-eager` or trimming `gpuMemoryUtilization` from 0.95 towards 0.93.

## Validation plan (post-deploy, in a low-traffic window)

- Boot log shows `enable_prefix_caching=True`, the FlashInfer backend selected, and no `plan()` errors during warmup.
- `vllm:prefix_cache_hit_rate` climbs from 0% as repeated-prefix traffic (chat, goose, grimoire) comes in.
- TTFT drops on multi-turn chat requests specifically (the biggest expected win).
- Spot-check chat, goose agent, and grimoire outputs for correctness (no behavior change expected, only latency).

**Deploy note:** `strategy: Recreate` on this deployment means the rollout causes a brief inference outage. Merge and let it deploy during a low-traffic window; that call is left to the human reviewer, not automated here.

## Verification already done

Rendered the chart locally (`helm template inference projects/inference/deploy/ -f projects/inference/deploy/values.yaml`) and confirmed both the env var and the flag are injected:

```yaml
        - name: llama-server
          image: "vllm/vllm-openai:v0.19.1"
          imagePullPolicy: IfNotPresent
          env:
            - name: VLLM_ATTENTION_BACKEND
              value: "FLASHINFER"
          securityContext:
            ...
```

and in the rendered `vllm serve` args:

```
                "--kv-cache-dtype" \
                "fp8" \
                "--enable-prefix-caching" \
```

Ran `bazel/tools/format/fast-format.sh`: clean, no additional drift.

## Test plan

- [ ] CI (BuildBuddy) passes on this branch
- [ ] Reviewer confirms low-traffic deploy window before merging (Recreate strategy causes a brief outage)
- [ ] Post-deploy: boot log shows FlashInfer + `enable_prefix_caching=True`
- [ ] Post-deploy: `vllm:prefix_cache_hit_rate` climbs from 0
- [ ] Post-deploy: spot-check chat/goose/grimoire behavior unchanged

Not merged, not deployed: opened for review only, per request.