### PR TITLE
refactor(goosecracker): inject sub-recipe bodies instead of baking them into the guest image

### DIFF
--- a/projects/firecracker/goosecracker/guest-init/cmd/main.go
+++ b/projects/firecracker/goosecracker/guest-init/cmd/main.go
@@ -83,12 +83,17 @@ func run(logger *slog.Logger) error {
 	// dirs are set EXPLICITLY (not left to derive from HOME) because goose resolves
 	// its state/data/config/cache via the XDG base dirs, and an unset XDG var can
 	// resolve to a bare "/.local/..." path (off HOME) that is also unwritable.
-	// GOOSE_RECIPE_PATH still points at the baked recipe library on the read-only
-	// rootfs, which is fine: recipes are only read. ensureEnv only sets an unset
-	// key, so an injected value still wins; HOME/XDG are force-set (a read-only
-	// value must never win).
+	// GOOSE_RECIPE_PATH points at /injected-context, where the monolith injects
+	// the router and every sub-recipe body each turn (recipes are no longer baked
+	// into the rootfs). In practice goose loads them by absolute path (--recipe
+	// /injected-context/router.yaml, and the router's sub_recipes list absolute
+	// paths for delegate), so this search path is only a fallback for a bare
+	// recipe name; set it there so any such lookup resolves against the injected
+	// recipes rather than a directory that no longer exists. ensureEnv only sets
+	// an unset key, so an injected value still wins; HOME/XDG are force-set (a
+	// read-only value must never win).
 	ensureEnv("PATH", "/usr/local/bin:/usr/bin:/bin:/sbin:/usr/local/sbin")
-	ensureEnv("GOOSE_RECIPE_PATH", "/home/goose-agent/recipes")
+	ensureEnv("GOOSE_RECIPE_PATH", "/injected-context")
 	const gooseHome = "/tmp/goose-home"
 	for k, v := range map[string]string{
 		"HOME":            gooseHome,

--- a/projects/firecracker/goosecracker/guest/BUILD
+++ b/projects/firecracker/goosecracker/guest/BUILD
@@ -18,19 +18,13 @@ pkg_tar(
     package_dir = "/home/goose-agent/.config/goose",
 )
 
-# Bake the recipe library at ~/recipes (FC_GOOSE_RECIPE points here).
-pkg_tar(
-    name = "recipes_tar",
-    srcs = glob(["recipes/*.yaml"]),
-    mode = "0644",
-    owner = "65532.65532",
-    package_dir = "/home/goose-agent/recipes",
-)
-
-# Expose the recipe YAMLs (read-only) to the monolith's recipe_catalog
-# drift-guard test, which asserts the monolith's sub-recipe id manifest
-# matches this checked-in set. Same source glob as recipes_tar above; this
-# just adds a public label so a cross-package py_test can take it as data.
+# Recipe bodies are NOT baked into the image any more. The monolith runner
+# injects them into the guest's /injected-context each turn (the same channel
+# that delivers the router), so both fresh and snapshot-resumed threads run
+# current recipe text. This filegroup is the single source of truth: the
+# monolith takes it as data both for runtime injection (`//projects/monolith:main`)
+# and for the recipe_catalog drift-guard test (which asserts the monolith's
+# sub-recipe id manifest matches this checked-in set).
 filegroup(
     name = "recipe_yamls",
     srcs = glob(["recipes/*.yaml"]),
@@ -90,7 +84,6 @@ apko_image(
     repository = "ghcr.io/jomcgi/homelab/projects/firecracker/goosecracker/guest",
     tars = [
         ":config_tar",
-        ":recipes_tar",
         ":impeccable_tar",
     ],
 )

--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -230,33 +230,33 @@ parameters:
 # safe.
 sub_recipes:
   - name: query
-    path: /home/goose-agent/recipes/query.yaml
+    path: /injected-context/query.yaml
     values:
       task_file: "{{ task_file }}"
       context_file: /tmp/goose/context.md
   - name: research
-    path: /home/goose-agent/recipes/research.yaml
+    path: /injected-context/research.yaml
     values:
       task_file: "{{ task_file }}"
       context_file: /tmp/goose/context.md
   - name: plan
-    path: /home/goose-agent/recipes/plan.yaml
+    path: /injected-context/plan.yaml
     values:
       task_file: "{{ task_file }}"
       context_file: /tmp/goose/context.md
   - name: implement
-    path: /home/goose-agent/recipes/implement.yaml
+    path: /injected-context/implement.yaml
     sequential_when_repeated: true
     values:
       task_file: "{{ task_file }}"
       context_file: /tmp/goose/context.md
   - name: artifact-build
-    path: /home/goose-agent/recipes/artifact-build.yaml
+    path: /injected-context/artifact-build.yaml
     values:
       task_file: "{{ task_file }}"
       context_file: /tmp/goose/context.md
   - name: artifact-review
-    path: /home/goose-agent/recipes/artifact-review.yaml
+    path: /injected-context/artifact-review.yaml
     values:
       task_file: "{{ task_file }}"
       context_file: /tmp/goose/context.md

--- a/projects/firecracker/goosecracker/guest/recipes/implement.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/implement.yaml
@@ -107,7 +107,7 @@ extensions:
     name: developer
 sub_recipes:
   - name: research
-    path: /home/goose-agent/recipes/research.yaml
+    path: /injected-context/research.yaml
     values:
       task_file: /tmp/goose/research-question.md
       context_file: /tmp/goose/context.md

--- a/projects/firecracker/goosecracker/guest/recipes/plan.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/plan.yaml
@@ -75,7 +75,7 @@ extensions:
     name: developer
 sub_recipes:
   - name: research
-    path: /home/goose-agent/recipes/research.yaml
+    path: /injected-context/research.yaml
     values:
       task_file: /tmp/goose/research-question.md
       context_file: /tmp/goose/context.md

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.36
+version: 0.4.37

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.36
+      targetRevision: 0.4.37
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -117,6 +117,12 @@ py_venv_binary(
         # 036); the "chat/**/*.py" glob does not capture the .md, so ship it
         # explicitly or every escalation fails open with FileNotFoundError.
         "chat/orchestrator_bundle.md",
+        # goosecracker.runner injects the guest sub-recipe bodies into
+        # /injected-context each turn (they are no longer baked into the guest
+        # image), reading them from runfiles via Path(__file__).parents[2] /
+        # "firecracker/goosecracker/guest/recipes". Ship the source YAMLs into
+        # runfiles as data or every agent run fails with FileNotFoundError.
+        "//projects/firecracker/goosecracker/guest:recipe_yamls",
         "knowledge/repo_docs_manifest.ndjson",
         ":frontend_dist",
     ],
@@ -146,6 +152,10 @@ py_venv_binary(
         # must ship in the jobs image too (data on :main does not propagate to
         # this separate binary).
         "campsites/catalog.json",
+        # A scheduled routine can dispatch a goosecracker run, which reaches
+        # goosecracker.runner and reads the injected sub-recipe bodies from
+        # runfiles; ship them here too (data on :main does not propagate here).
+        "//projects/firecracker/goosecracker/guest:recipe_yamls",
     ],
     imports = ["."],  # keep
     main = "app/jobs_main.py",
@@ -4601,6 +4611,11 @@ py_test(
 py_test(
     name = "goosecracker_runner_test",
     srcs = ["goosecracker/tests/runner_test.py"],
+    # runner._subrecipe_bodies() reads the checked-in guest recipe YAMLs from
+    # runfiles (Path(__file__).parents[2]) to inject them each turn; the loader
+    # test exercises that read, so ship the recipes as data (same filegroup
+    # goosecracker_router_render_test uses) or the test hits FileNotFoundError.
+    data = ["//projects/firecracker/goosecracker/guest:recipe_yamls"],
     imports = ["."],
     deps = [
         ":monolith_backend",

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.19
+version: 0.285.20
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.19
+      targetRevision: 0.285.20
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/recipe_catalog.py
+++ b/projects/monolith/goosecracker/recipe_catalog.py
@@ -2,9 +2,12 @@
 
 This module is the one place that knows the sub-recipe id set, the human
 descriptions surfaced in the DeepSeek orchestrator's ``submit_plan`` tool
-schema, and the baked guest recipe paths those ids resolve to. Everything
+schema, and the injected guest recipe paths those ids resolve to. Everything
 downstream (the tool schema enum, the router renderer's ``sub_recipes``
 list) derives from ``CATALOG`` rather than repeating the id set.
+
+Sub-recipe bodies are injected into ``/injected-context/`` by the runner each
+turn (not baked into the guest image), so the paths point there.
 
 The router recipe itself (``agent.yaml``) is the classifier the runtime
 router replaces; it is not a selectable sub-recipe and is intentionally
@@ -20,18 +23,18 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class RecipeEntry:
-    """One selectable sub-recipe: its id, tool-schema description, and baked guest path."""
+    """One selectable sub-recipe: its id, tool-schema description, and injected guest path."""
 
     id: str
     description: str
-    baked_path: str
+    injected_path: str
 
 
 def _entry(recipe_id: str, description: str) -> RecipeEntry:
     return RecipeEntry(
         id=recipe_id,
         description=description,
-        baked_path=f"/home/goose-agent/recipes/{recipe_id}.yaml",
+        injected_path=f"/injected-context/{recipe_id}.yaml",
     )
 
 

--- a/projects/monolith/goosecracker/router_render.py
+++ b/projects/monolith/goosecracker/router_render.py
@@ -7,9 +7,11 @@ guest ``agent.yaml`` scaffolding. The generated router is a specialization,
 not a novel recipe (Design invariant 4):
 
 - ``sub_recipes:`` lists ONLY the plan's enabled sub-recipes, each pointing at
-  its stable baked guest path ``/home/goose-agent/recipes/<id>.yaml`` (goose's
-  ``delegate`` resolves a source name against the recipe's own local
-  ``sub_recipes`` list, so listing them here is required and sufficient).
+  its injected path ``/injected-context/<id>.yaml`` (goose's ``delegate``
+  resolves a source name against the recipe's own local ``sub_recipes`` list,
+  so listing them here is required and sufficient). Sub-recipe bodies are no
+  longer baked into the guest image: the runner injects them fresh each turn
+  alongside this router, so resumed threads run current sub-recipe text too.
 - The ``agent.yaml`` "classify and route" preamble is replaced by an EXPLICIT
   ORDERED PLAN: the caller already decided the route, so the model executes the
   steps in order instead of classifying.
@@ -325,9 +327,16 @@ _AGENT_RESPONSE_SCHEMA = {
 }
 
 
-def _baked_path(recipe_id: str) -> str:
-    """The stable guest path a sub-recipe id resolves to (Design invariant 5)."""
-    return f"/home/goose-agent/recipes/{recipe_id}.yaml"
+def _injected_recipe_path(recipe_id: str) -> str:
+    """The guest path a sub-recipe id resolves to.
+
+    Sub-recipe bodies are no longer baked into the guest image: the runner
+    injects them fresh every turn into ``/injected-context/`` (the same
+    mechanism that already delivers the router), so both fresh and
+    snapshot-resumed threads run current sub-recipe text. This path is where
+    that injected body lands, and what the router's ``sub_recipes`` list and
+    goose's ``delegate`` resolve against."""
+    return f"/injected-context/{recipe_id}.yaml"
 
 
 # Verbatim from agent.yaml: the /injected-context/ (ADR 040) handling block.
@@ -570,7 +579,7 @@ def _sub_recipes(plan: Plan) -> list[dict]:
     order, each pointing at its baked guest path. A disabled id appears nowhere."""
     entries: list[dict] = []
     for recipe_id in plan.enabled_subrecipes:
-        entry: dict = {"name": recipe_id, "path": _baked_path(recipe_id)}
+        entry: dict = {"name": recipe_id, "path": _injected_recipe_path(recipe_id)}
         # Preserve agent.yaml's sequential_when_repeated for implement.
         if recipe_id == "implement":
             entry["sequential_when_repeated"] = True
@@ -703,7 +712,7 @@ def render_router(plan: Plan) -> str:
 
 
 def _fallback_sub_recipes() -> list[dict]:
-    """All catalog sub-recipes, in catalog order, each at its baked guest path.
+    """All catalog sub-recipes, in catalog order, each at its injected path.
 
     Mirrors the guest agent.yaml sub_recipes block so the injected fallback
     router is byte-faithful to it. Sourced from ``recipe_catalog.CATALOG`` (the
@@ -714,7 +723,7 @@ def _fallback_sub_recipes() -> list[dict]:
 
     entries: list[dict] = []
     for recipe_id in CATALOG:
-        entry: dict = {"name": recipe_id, "path": _baked_path(recipe_id)}
+        entry: dict = {"name": recipe_id, "path": _injected_recipe_path(recipe_id)}
         # Preserve agent.yaml's sequential_when_repeated for implement.
         if recipe_id == "implement":
             entry["sequential_when_repeated"] = True
@@ -739,9 +748,10 @@ def render_fallback_router() -> str:
 
     The recipe is a verbatim reproduction of the checked-in guest agent.yaml,
     pinned by ``tests/router_render_test.py`` (full parse-equality). Sub-recipe
-    BODIES still resolve to their baked guest paths, exactly as
-    :func:`render_router` does: this restores the delegate tool + current router
-    text, not sub-recipe body currency.
+    BODIES resolve to their injected paths (``/injected-context/<id>.yaml``),
+    exactly as :func:`render_router` does: the runner injects those bodies fresh
+    each turn, so a resumed thread runs current router text AND current
+    sub-recipe text, not the frozen copies its rootfs was snapshotted with.
     """
     recipe = {
         "version": _RECIPE_VERSION,

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -28,6 +28,8 @@ import logging
 import os
 import re
 import time
+from functools import lru_cache
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import httpx
@@ -91,6 +93,44 @@ _MAX_DISCORD = 1800
 # to this many replans. The cap is enforced deterministically here, never
 # trusting a recipe-side counter; at the cap the current result is finalized.
 _MAX_REPLANS = 3
+
+# Sub-recipe bodies (query/plan/implement/research/artifact-*) are NOT baked
+# into the guest image any more: the runner injects them into /injected-context
+# fresh every turn, the same channel that already delivers the router. That is
+# what lets a snapshot-resumed thread run CURRENT sub-recipe text instead of the
+# frozen copy its rootfs was snapshotted with. The source YAMLs live in the
+# guest recipe package and are shipped into this binary's runfiles as data (see
+# `//projects/monolith:main` data -> `:recipe_yamls`); read cross-package via
+# the same parents[] hop the recipe-catalog drift test uses.
+# No .resolve(): the runfiles entry is a symlink, and resolving it would follow
+# the file out to a content-addressed store where this relative parents[] hop no
+# longer reaches the sibling firecracker/ package. The recipe-catalog drift test
+# reads the same dir the same way (parents-relative, unresolved).
+_GUEST_RECIPES_DIR = (
+    Path(__file__).parents[2] / "firecracker/goosecracker/guest/recipes"
+)
+
+
+@lru_cache(maxsize=1)
+def _subrecipe_bodies() -> dict[str, str]:
+    """Every catalog sub-recipe body, keyed by the basename the router points at.
+
+    Returns ``{"<id>.yaml": <body>}`` for each id in ``CATALOG``, ready to merge
+    into ``injectedContext`` so the guest finds each body at
+    ``/injected-context/<id>.yaml`` (the path ``render_router`` /
+    ``render_fallback_router`` resolve ``delegate`` against). All ids are always
+    injected, not just a plan's enabled subset, because an enabled sub-recipe can
+    transitively delegate to another (plan and implement both delegate research).
+    Cached: the bodies are immutable in the image, so read once.
+    """
+    from goosecracker.recipe_catalog import CATALOG
+
+    return {
+        f"{recipe_id}.yaml": (_GUEST_RECIPES_DIR / f"{recipe_id}.yaml").read_text(
+            encoding="utf-8"
+        )
+        for recipe_id in CATALOG
+    }
 
 
 def _progress_url(session: str) -> str:
@@ -670,19 +710,21 @@ async def _invoke_turn(
         injected_context = {**injected_context, "repo": repo}
     # Task 6: a Plan present means the DeepSeek orchestrator constructed a
     # runtime plan for this turn. Render the router + plan file and ADD them
-    # to injected_context (the ADR 040 per-turn context built above is
-    # preserved untouched), then point the guest at the injected router
-    # instead of the baked agent recipe. Basenames only (router.yaml,
-    # plan.md), as writeInjectedContext requires. Absent a plan, this is a
-    # no-op: recipe stays "agent" (or whatever the caller passed), exactly
-    # today's behavior. On a Task 7 replan re-run, this is called again with a
-    # revised plan, so the router/plan file reflect the new plan each time.
+    # to injected_context, alongside the sub-recipe bodies the router delegates
+    # to (the ADR 040 per-turn context built above is preserved untouched), then
+    # point the guest at the injected router instead of the baked agent recipe.
+    # Basenames only (router.yaml, plan.md, <id>.yaml), as writeInjectedContext
+    # requires. Absent a plan, this is a no-op: recipe stays "agent" (or whatever
+    # the caller passed), exactly today's behavior. On a Task 7 replan re-run,
+    # this is called again with a revised plan, so the router/plan file reflect
+    # the new plan each time.
     effective_recipe = recipe
     if plan is not None:
         from goosecracker.router_render import render_plan_file, render_router
 
         injected_context = {
             **injected_context,
+            **_subrecipe_bodies(),
             "router.yaml": render_router(plan),
             "plan.md": render_plan_file(plan),
         }
@@ -701,6 +743,7 @@ async def _invoke_turn(
 
         injected_context = {
             **injected_context,
+            **_subrecipe_bodies(),
             "router.yaml": render_fallback_router(),
         }
         effective_recipe = "/injected-context/router.yaml"

--- a/projects/monolith/goosecracker/tests/recipe_catalog_test.py
+++ b/projects/monolith/goosecracker/tests/recipe_catalog_test.py
@@ -31,7 +31,7 @@ def test_manifest_ids_and_paths() -> None:
     ]
     for rid, entry in cat.items():
         assert entry.id == rid
-        assert entry.baked_path == f"/home/goose-agent/recipes/{rid}.yaml"
+        assert entry.injected_path == f"/injected-context/{rid}.yaml"
         assert entry.description  # non-empty, used in the tool schema
 
     assert recipe_catalog.enabled_enum() == list(cat)

--- a/projects/monolith/goosecracker/tests/router_render_test.py
+++ b/projects/monolith/goosecracker/tests/router_render_test.py
@@ -90,7 +90,7 @@ def test_sub_recipes_match_enabled_in_order() -> None:
     names = [s["name"] for s in doc["sub_recipes"]]
     assert tuple(names) == plan.enabled_subrecipes
     for sub in doc["sub_recipes"]:
-        assert sub["path"] == f"/home/goose-agent/recipes/{sub['name']}.yaml"
+        assert sub["path"] == f"/injected-context/{sub['name']}.yaml"
         assert sub["values"]["task_file"] == "{{ task_file }}"
         assert sub["values"]["context_file"] == "/tmp/goose/context.md"
 
@@ -258,7 +258,7 @@ def test_fallback_router_lists_all_sub_recipes_for_delegate() -> None:
     names = [s["name"] for s in doc["sub_recipes"]]
     assert tuple(names) == _ALL_IDS
     for sub in doc["sub_recipes"]:
-        assert sub["path"] == f"/home/goose-agent/recipes/{sub['name']}.yaml"
+        assert sub["path"] == f"/injected-context/{sub['name']}.yaml"
         assert sub["values"]["task_file"] == "{{ task_file }}"
         assert sub["values"]["context_file"] == "/tmp/goose/context.md"
     impl = next(s for s in doc["sub_recipes"] if s["name"] == "implement")

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -25,6 +25,46 @@ _GOOSE_RESULT = (
 )
 
 
+def test_subrecipe_bodies_loads_every_catalog_id_from_runfiles():
+    """The runner reads every catalog sub-recipe body from runfiles for injection.
+
+    Guards the cross-package data dep (goosecracker_runner_test data ->
+    :recipe_yamls) and the parents[] runfiles hop in ``_GUEST_RECIPES_DIR``: a
+    missing data dep or a wrong path fails here in CI, not at runtime with a
+    FileNotFoundError that would kill every agent run.
+    """
+    import yaml
+
+    from goosecracker.recipe_catalog import CATALOG
+
+    runner._subrecipe_bodies.cache_clear()
+    bodies = runner._subrecipe_bodies()
+    assert set(bodies) == {f"{rid}.yaml" for rid in CATALOG}
+    for name, body in bodies.items():
+        parsed = yaml.safe_load(body)
+        assert isinstance(parsed, dict) and parsed.get("instructions"), name
+
+
+def test_router_delegate_paths_match_injected_bodies():
+    """Every path the fallback router delegates to is a body the runner injects.
+
+    The naming contract binds render_fallback_router() to _subrecipe_bodies():
+    the router points ``delegate`` at ``/injected-context/<id>.yaml`` and the
+    runner must inject a body under that exact basename, or the guest delegates
+    to a file that was never staged.
+    """
+    import yaml
+
+    from goosecracker.router_render import render_fallback_router
+
+    runner._subrecipe_bodies.cache_clear()
+    keys = set(runner._subrecipe_bodies())
+    doc = yaml.safe_load(render_fallback_router())
+    for sub in doc["sub_recipes"]:
+        assert sub["path"] == f"/injected-context/{sub['name']}.yaml"
+        assert f"{sub['name']}.yaml" in keys
+
+
 def test_extract_summary_pulls_summary_line():
     assert (
         runner._extract_summary(_GOOSE_RESULT) == "A bouncing ball demo with gravity."


### PR DESCRIPTION
## Why

The router recipe is already injected into `/injected-context` every turn (so snapshot-resumed threads run current router text), but the **sub-recipe bodies** (`query`/`plan`/`implement`/`research`/`artifact-*`) were still baked into the guest image at `/home/goose-agent/recipes/<id>.yaml`. That split meant a recipe wording change (like the sycophancy fix in #3219) only reached resumed threads after a guest-image rebuild **plus** snapshot-base regen, never on the monolith's chart cadence. `recipe="artifact"` etc. are not DeepSeek-authored, but that doesn't mean they need baking either.

## What

Move the sub-recipe bodies to the same code-injection channel as the router:

- **`runner.py`** injects all catalog sub-recipe bodies into `/injected-context` each turn, read from the checked-in guest YAMLs shipped into runfiles as `data`. All ids are injected (not just a plan's enabled subset) because an enabled sub-recipe can transitively delegate to another (`plan`/`implement` both delegate `research`).
- **`router_render.py` + `recipe_catalog.py`** point `sub_recipes` paths at `/injected-context/<id>.yaml`; `agent.yaml`/`plan.yaml`/`implement.yaml` source paths move in lockstep so the fallback-router **parse-equality drift guard still holds**.
- **`guest/BUILD`** drops `recipes_tar` (no longer baked). The `recipe_yamls` filegroup becomes the single source of truth, taken as `data` by the monolith runtime targets and the drift tests.
- New `runner_test` cases exercise the runfiles read and the router↔loader naming contract, so a missing data dep or path drift fails in CI, not at runtime.

DeepSeek still cannot author recipe bodies: the monolith writes them, exactly as it already writes the router.

## Deploy

Bumps **monolith** `0.285.20` (runner change) and **fc-invoke** `0.4.37` (guest image no longer carries recipes). After this, a sub-recipe edit reaches even snapshot-resumed threads on the next turn, no guest-image/snapshot cadence.

## Note (out of scope)

While tracing resolution I found `/artifact` (the Discord slash command) looks broken independently: `ARTIFACT_RECIPE = "artifact"` but `artifact.yaml` was renamed to `artifact-build.yaml` in `a70620224`. Flagged separately; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)