### PR TITLE
refactor(chat): remove the redundant /artifact slash command

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.20
+version: 0.285.21
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/acl.py
+++ b/projects/monolith/chat/acl.py
@@ -126,9 +126,9 @@ def bootstrap_defaults() -> None:
 
     Reads the existing owner/home-server env so the home server always works out
     of the box: the home server gets /agent on the public homelab repo for
-    everyone, the owner additionally gets /agent on the private loom repo and
-    /artifact, and the Loom server gets /agent on loom for its members. Safe to
-    call on every startup; existing rows are left untouched.
+    everyone, the owner additionally gets /agent on the private loom repo, and
+    the Loom server gets /agent on loom for its members. Safe to call on every
+    startup; existing rows are left untouched.
     """
     home = os.environ.get("MONOLITH_AGENT_DISCORD_DEFAULT_SERVER_ID", "")
     owner = os.environ.get("OWNER_DISCORD_USER_ID", "")
@@ -151,12 +151,7 @@ def bootstrap_defaults() -> None:
             # home-server member cannot drive the private repo. Loom-server
             # members get loom via the LOOM_GUILD_ID grant below.
             defaults.append((home, owner, "agent", "weave-hand/loom"))
-            defaults.append((home, owner, "artifact", ""))
     defaults.append((LOOM_GUILD_ID, "", "agent", "weave-hand/loom"))
-    # Artifact viewing is behind unguessable capability URLs and runs on the free
-    # qwen tier, so it is safe to open /artifact to the Loom server (ADR 024
-    # amendment). Everyone in the Loom server may build artifacts there.
-    defaults.append((LOOM_GUILD_ID, "", "artifact", ""))
 
     to_add: list[DiscordFeatureGrant] = []
     with Session(get_engine()) as session:

--- a/projects/monolith/chat/acl_test.py
+++ b/projects/monolith/chat/acl_test.py
@@ -149,8 +149,6 @@ class TestBootstrapDefaults:
             assert (
                 acl.is_granted("home1", "anyone", "agent", "weave-hand/loom") is False
             )
-            assert acl.is_granted("home1", "owner1", "artifact") is True
-            assert acl.is_granted("home1", "someone", "artifact") is False
             # loom-server members get loom, but never homelab
             assert (
                 acl.is_granted(acl.LOOM_GUILD_ID, "anyone", "agent", "weave-hand/loom")
@@ -160,8 +158,6 @@ class TestBootstrapDefaults:
                 acl.is_granted(acl.LOOM_GUILD_ID, "anyone", "agent", "jomcgi/homelab")
                 is False
             )
-            # loom server can build artifacts (safe: capability URLs + qwen)
-            assert acl.is_granted(acl.LOOM_GUILD_ID, "anyone", "artifact") is True
             # ADR 036: the orchestrator tier is granted server-wide on the home
             # server (any channel), and nowhere else by default.
             assert (
@@ -180,9 +176,8 @@ class TestBootstrapDefaults:
             acl.bootstrap_defaults()
             with Session(engine) as session:
                 rows = session.exec(select(DiscordFeatureGrant)).all()
-            # home: 2 agent + 1 artifact + 1 orchestrator, loom: 1 agent + 1
-            # artifact = 6, not doubled
-            assert len(rows) == 6
+            # home: 2 agent + 1 orchestrator, loom: 1 agent = 4, not doubled
+            assert len(rows) == 4
 
     def test_no_home_env_still_seeds_loom(self, engine, monkeypatch):
         monkeypatch.delenv("MONOLITH_AGENT_DISCORD_DEFAULT_SERVER_ID", raising=False)

--- a/projects/monolith/chat/api.py
+++ b/projects/monolith/chat/api.py
@@ -10,7 +10,6 @@ from chat.bot import send_message  # re-exported
 from chat.changelog import run_changelog_for_config  # re-exported
 from chat.goosecracker import ack_inflight  # re-exported
 from chat.goosecracker import artifact_id_for_thread  # re-exported
-from chat.goosecracker import build_channel_dataset  # re-exported
 from chat.goosecracker import build_injected_context  # re-exported
 from chat.goosecracker import drain_agent_queue  # re-exported
 from chat.goosecracker import ensure_steering_token  # re-exported
@@ -39,7 +38,6 @@ __all__ = [
     "replan",
     "ack_inflight",
     "artifact_id_for_thread",
-    "build_channel_dataset",
     "build_injected_context",
     "conversational_agent_reply",
     "drain_agent_queue",

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -69,7 +69,7 @@ def _truncate_thinking(thinking: str) -> str:
     return thinking[:THINKING_TRUNCATE_AT] + "... (truncated)"
 
 
-# Live /artifact progress streaming (ADR 024). The guest streams goose's
+# Live goosecracker progress streaming (ADR 024). The guest streams goose's
 # stdout to the in-process progress buffer; the bot edits the thread message on
 # this cadence so the owner sees activity instead of a multi-minute silent wait.
 GOOSECRACKER_STREAM_INTERVAL = 1.5  # seconds between Discord edits (rate-limit safe)
@@ -83,7 +83,7 @@ _GOOSECRACKER_WROTE_RE = re.compile(r"Created\s+\S+\s+\((\d+)\s+lines?\)")
 _GOOSECRACKER_SUMMARY_RE = re.compile(r"^\s*summary:\s*(.+?)\s*`*\s*$", re.MULTILINE)
 
 
-def _render_goosecracker_progress(snap, elapsed: int, kind: str = "artifact") -> str:
+def _render_goosecracker_progress(snap, elapsed: int, kind: str = "agent") -> str:
     """Render a concise live progress message from a progress snapshot.
 
     ``snap`` is a chat.goosecracker_progress.Progress or None (nothing yet).
@@ -602,7 +602,7 @@ class ChatBot(discord.Client):
         self.embed_client = EmbeddingClient()
         self.vision_client = VisionClient()
         self.agent = create_agent()
-        # Slash commands (e.g. /artifact, ADR 024 Task 4) live on a
+        # Slash commands (e.g. /agent, ADR 024) live on a
         # CommandTree; on_message handles plain chat. Registered at construction,
         # synced to the guild in on_ready.
         self.tree = discord.app_commands.CommandTree(self)
@@ -610,16 +610,6 @@ class ChatBot(discord.Client):
 
     def _register_commands(self) -> None:
         """Register application (slash) commands on the tree."""
-
-        @self.tree.command(
-            name="artifact",
-            description="Build a self-contained web artifact (owner only)",
-        )
-        @discord.app_commands.describe(prompt="What to build")
-        async def goosecracker_command(
-            interaction: discord.Interaction, prompt: str
-        ) -> None:
-            await self._handle_goosecracker_command(interaction, prompt)
 
         @self.tree.command(
             name="agent",
@@ -748,7 +738,7 @@ class ChatBot(discord.Client):
             logger.exception("Failed to acquire lock for message %s", msg_id)
             return
 
-        # A reply inside a goosecracker thread iterates the artifact (Model B)
+        # A reply inside a goosecracker thread continues that agent session
         # instead of going to the chat agent. Only threads can be goosecracker
         # sessions, so the DB lookup is skipped for ordinary channels.
         if isinstance(message.channel, discord.Thread):
@@ -842,58 +832,6 @@ class ChatBot(discord.Client):
             await summary.add_reaction("✅" if applied else "❌")
         except discord.HTTPException:
             logger.exception("directives: failed to finalize proposal reactions")
-
-    async def _handle_goosecracker_command(
-        self, interaction: discord.Interaction, prompt: str
-    ) -> None:
-        """Grant-gated /artifact: open a thread and dispatch the first run."""
-        if not await asyncio.to_thread(
-            acl.is_granted, interaction.guild_id, interaction.user.id, "artifact"
-        ):
-            # Defer first: the roast hits the qwen model (with retries), which
-            # routinely exceeds Discord's 3s initial-response deadline. Without
-            # the defer the interaction 404s and the roast never lands.
-            await interaction.response.defer(ephemeral=True)
-            roast = await goosecracker.build_roast(prompt)
-            await interaction.followup.send(roast, ephemeral=True)
-            return
-
-        channel = interaction.channel
-        if not isinstance(channel, discord.TextChannel):
-            await interaction.response.send_message(
-                "Run /artifact from a normal text channel so I can open a thread.",
-                ephemeral=True,
-            )
-            return
-
-        # Dispatch (DB inserts) can take a beat; ack first so the interaction
-        # never times out, then create the thread and kick off the run.
-        await interaction.response.defer(thinking=True)
-        try:
-            name = f"goosecracker: {prompt}"[:90]
-            thread = await channel.create_thread(
-                name=name, type=discord.ChannelType.public_thread
-            )
-            await asyncio.to_thread(
-                goosecracker.start_session,
-                str(thread.id),
-                prompt,
-                str(channel.id),
-            )
-        except Exception:
-            logger.exception("goosecracker: failed to start session")
-            await interaction.followup.send(
-                "Couldn't start that one. Check the logs.", ephemeral=True
-            )
-            return
-
-        await interaction.followup.send(f"Building your artifact in {thread.mention}")
-        try:
-            # ADR 035: see the matching comment in _handle_agent_command.
-            intro = await thread.send("🛠 Planning...")
-            self._start_goosecracker_stream(str(thread.id), intro)
-        except Exception:
-            logger.exception("goosecracker: failed to post thread intro")
 
     async def _handle_agent_command(
         self, interaction: discord.Interaction, prompt: str, repo: str
@@ -1189,7 +1127,7 @@ class ChatBot(discord.Client):
             return None
 
     def _start_goosecracker_stream(
-        self, artifact_id: str, message: discord.Message, kind: str = "artifact"
+        self, artifact_id: str, message: discord.Message, kind: str = "agent"
     ) -> None:
         """Spawn the background task that live-edits ``message`` with run output.
 
@@ -1209,7 +1147,7 @@ class ChatBot(discord.Client):
         task.add_done_callback(streams.discard)
 
     async def _stream_goosecracker_progress(
-        self, artifact_id: str, message: discord.Message, kind: str = "artifact"
+        self, artifact_id: str, message: discord.Message, kind: str = "agent"
     ) -> None:
         """Edit ``message`` with goose's live build output until done or timeout.
 
@@ -1315,41 +1253,27 @@ class ChatBot(discord.Client):
         if message.author.bot:
             await asyncio.to_thread(self._complete_lock, msg_id)
             return True
-        # Artifact threads are open to whoever is granted /artifact in this
-        # server (ADR 024 amendment), so the person who built an artifact can
-        # iterate on it, not just the owner. Agent threads are per-server ACL
-        # gated on the session's own repo scope (ADR 035 Phase 2): steering an
-        # in-flight agent turn needs the same grant that opened it.
-        is_agent = await asyncio.to_thread(goosecracker.is_agent_thread, thread_id)
+        # Goosecracker threads are per-server ACL gated on the session's own repo
+        # scope (ADR 035 Phase 2): steering or continuing an in-flight turn needs
+        # the same `agent` grant that opened it. A repo-less run (an artifact the
+        # agent built with no repo) uses the empty scope.
         guild_id = message.guild.id if message.guild else None
-        if is_agent:
-            repo = await asyncio.to_thread(goosecracker.session_scope, thread_id) or ""
-            if not await asyncio.to_thread(
-                acl.is_granted, guild_id, message.author.id, "agent", repo
-            ):
-                scopes = await asyncio.to_thread(
-                    acl.allowed_scopes, guild_id, message.author.id, "agent"
-                )
-                allowed = ", ".join(sorted(scopes)) or "none"
-                roast = await goosecracker.build_roast(message.content)
-                target = f"`{repo}`" if repo else "this"
-                await message.reply(
-                    f"{roast}\nYou'd need an `agent` grant for {target} in this "
-                    f"server to steer here. Allowed here: {allowed}."
-                )
-                await asyncio.to_thread(self._complete_lock, msg_id)
-                return True
-        else:
-            allowed = goosecracker.is_owner(
-                message.author.id
-            ) or await asyncio.to_thread(
-                acl.is_granted, guild_id, message.author.id, "artifact"
+        repo = await asyncio.to_thread(goosecracker.session_scope, thread_id) or ""
+        if not await asyncio.to_thread(
+            acl.is_granted, guild_id, message.author.id, "agent", repo
+        ):
+            scopes = await asyncio.to_thread(
+                acl.allowed_scopes, guild_id, message.author.id, "agent"
             )
-            if not allowed:
-                roast = await goosecracker.build_roast(message.content)
-                await message.reply(roast)
-                await asyncio.to_thread(self._complete_lock, msg_id)
-                return True
+            allowed = ", ".join(sorted(scopes)) or "none"
+            roast = await goosecracker.build_roast(message.content)
+            target = f"`{repo}`" if repo else "this"
+            await message.reply(
+                f"{roast}\nYou'd need an `agent` grant for {target} in this "
+                f"server to steer here. Allowed here: {allowed}."
+            )
+            await asyncio.to_thread(self._complete_lock, msg_id)
+            return True
 
         try:
             result = await asyncio.to_thread(
@@ -1395,19 +1319,10 @@ class ChatBot(discord.Client):
             await asyncio.to_thread(self._complete_lock, msg_id)
             return True
 
-        if action == "dispatched":
-            # Agent thread: a new turn was dispatched (session was idle).
-            # ADR 035: see the matching comment in _handle_agent_command.
-            progress_msg = await message.reply("🤖 Planning...")
-            self._start_goosecracker_stream(thread_id, progress_msg, kind="agent")
-            await asyncio.to_thread(self._complete_lock, msg_id)
-            return True
-
-        # Artifact path: continue_session returned the raw submit result dict
-        # (action is "create" or "resume" from threads.upsert_run).
+        # Otherwise a new turn was dispatched (session was idle or reclaimed).
         # ADR 035: see the matching comment in _handle_agent_command.
-        progress_msg = await message.reply("🛠 Planning...")
-        self._start_goosecracker_stream(thread_id, progress_msg)
+        progress_msg = await message.reply("🤖 Planning...")
+        self._start_goosecracker_stream(thread_id, progress_msg, kind="agent")
         await asyncio.to_thread(self._complete_lock, msg_id)
         return True
 

--- a/projects/monolith/chat/bot_on_message_test.py
+++ b/projects/monolith/chat/bot_on_message_test.py
@@ -355,7 +355,6 @@ def _make_goosecracker_mock(**overrides) -> MagicMock:
     """A chat.bot.goosecracker stand-in for an agent thread mid-turn."""
     mock = MagicMock()
     mock.is_goosecracker_thread = MagicMock(return_value=True)
-    mock.is_agent_thread = MagicMock(return_value=True)
     mock.session_scope = MagicMock(return_value="homelab")
     mock.is_owner = MagicMock(return_value=False)
     mock.build_roast = AsyncMock(return_value="Nice try.")

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -1,21 +1,20 @@
-"""goosecracker: the owner-gated Discord artifact agent (ADR 024 Task 4).
+"""goosecracker: the Discord coding-agent session logic (ADR 024 / ADR 035).
 
-``/artifact <prompt>`` opens a Discord thread and runs goose in a
-Firecracker microVM (the ``artifact`` recipe + tier), which builds a
-self-contained HTML artifact and publishes it; fc-agentd posts the artifact URL
-back into the thread (Task 5). Each owner follow-up in the thread re-runs goose
-from scratch with the FULL accumulated transcript (Model B), re-publishing the
-same artifact id so the live page hot-reloads.
+The ``/agent`` command opens a Discord thread and runs goose in a Firecracker
+microVM; the router classifies the task and delegates a sub-recipe (query, plan,
+implement, or artifact-build/review for a repo-less "build me a page" run), and
+the result is posted back into the thread. Each owner follow-up in the thread
+continues the same agent session: it steers an in-flight turn or dispatches the
+next one (ADR 035 Phase 2).
 
-This module is the pure logic seam (gate + transcript + dispatch + roast) so the
-Discord wiring in ``chat.bot`` stays thin and this stays unit-testable. The DB
-helpers are synchronous and open their own session, so the bot calls them via
-``asyncio.to_thread`` (never blocking the gateway loop).
+This module is the pure logic seam (gate + transcript + steering + dispatch +
+roast) so the Discord wiring in ``chat.bot`` stays thin and this stays
+unit-testable. The DB helpers are synchronous and open their own session, so the
+bot calls them via ``asyncio.to_thread`` (never blocking the gateway loop).
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 import secrets
@@ -54,20 +53,16 @@ INSTANCE_TOKEN = secrets.token_hex(8)
 # from under itself. The startup sweep is the fast path; this is the backstop.
 STALE_AFTER = timedelta(minutes=30)
 
-# The artifact recipe + model tier (ADR 024). The tier selects Gemini via
-# OpenRouter (key swapped at egress) and bounds the secret placeholders the guest
-# holds; the recipe is the write-only artifact builder.
-ARTIFACT_RECIPE = "artifact"
-ARTIFACT_TIER = "artifact"
-
 # The agent recipe + tier: default (empty) tier runs on the in-cluster Qwen model.
-# The agent recipe is the general coding agent (goosecracker general mode).
+# The agent recipe is the general coding agent (goosecracker general mode); an
+# artifact is just an agent run with no repo, which the router builds by
+# delegating the artifact-build / artifact-review sub-recipes.
 AGENT_RECIPE = "agent"
 AGENT_TIER = ""
 
 # Shown when the owner gate rejects someone and the qwen roast path is
 # unavailable (model down), so a non-owner always gets a clear refusal.
-_FALLBACK_ROAST = "Nice try. /artifact is owner-only."
+_FALLBACK_ROAST = "Nice try. You need an agent grant to drive that thread."
 
 
 def owner_id() -> str:
@@ -148,47 +143,6 @@ def _is_stale(row: GoosecrackerSession, now: datetime) -> bool:
     return (now - since) > STALE_AFTER
 
 
-def start_session(thread_id: str, prompt: str, parent_channel_id: str = "") -> dict:
-    """Record a new thread's transcript and dispatch the first artifact run.
-
-    ``parent_channel_id`` is the channel the /artifact command was run from (the
-    thread's parent), mirroring ``start_agent_session``'s param of the same
-    name; stored on the row so the runner can fetch channel-scoped context
-    (recent messages, and the extracted dataset) for the artifact build. Empty
-    when the caller has none to record (e.g. an older call site).
-
-    Synchronous (opens its own session); call via ``asyncio.to_thread``. Returns
-    the dispatch result (``thread_id`` + ``action``).
-    """
-    prompt = prompt.strip()
-    # Imported lazily (not at module load): chat.bot imports this module and
-    # goosecracker.runner imports chat.api, so a module-level import would risk a
-    # circular import. goosecracker.api is the boundary-approved surface.
-    from goosecracker.api import submit
-
-    # Dispatch first: if submit raises, no session row is left behind (which
-    # would otherwise make later replies look like a live goosecracker thread
-    # with no backing run). The Discord thread id doubles as the run session so
-    # the guest's progress stream and the bot's poll key line up.
-    result = submit(
-        prompt,
-        session=thread_id,
-        recipe=ARTIFACT_RECIPE,
-        tier=ARTIFACT_TIER,
-        discord_thread=thread_id,
-    )
-    with Session(get_engine()) as session:
-        session.add(
-            GoosecrackerSession(
-                discord_thread=thread_id,
-                parent_channel_id=parent_channel_id,
-                transcript=prompt,
-            )
-        )
-        session.commit()
-    return result
-
-
 def set_progress_message(thread_id: str, message_id: str) -> None:
     """Record the id of the run's single live message on the session row.
 
@@ -236,20 +190,15 @@ def continue_session(
     author_id: str = "",
     tier: str = "",
 ) -> dict | None:
-    """Append an owner follow-up and re-dispatch or queue depending on recipe.
+    """Append an owner follow-up to an agent thread and steer, queue, or dispatch.
 
-    Artifact sessions (recipe="artifact"): re-dispatch the full transcript (Model
-    B), preserving the original ADR 026 Phase 2 resume gate. Returns the raw
-    submit result dict.
-
-    Agent sessions (recipe="agent"): conversational queuing. If a turn is already
-    running (and not stale), the reply becomes STEERING (ADR 035 Phase 2): an
-    undelivered ``GoosecrackerSteering`` row is inserted for the running guest to
-    consume mid-run, and ``{"action": "steering"}`` is returned so the bot can
-    acknowledge with a 👀 reaction instead of a text reply. ``author_id``/``tier``
-    are only used on this path (a steering row needs an attributed author; tier
-    falls back to the session's own tier when blank). When idle (or the prior
-    turn is stale and reclaimed), build the next task from any backlog + this
+    Conversational queuing. If a turn is already running (and not stale), the reply
+    becomes STEERING (ADR 035 Phase 2): an undelivered ``GoosecrackerSteering`` row
+    is inserted for the running guest to consume mid-run, and
+    ``{"action": "steering"}`` is returned so the bot can acknowledge with a 👀
+    reaction instead of a text reply. ``author_id``/``tier`` attribute the steering
+    row (tier falls back to the session's own tier when blank). When idle (or the
+    prior turn is stale and reclaimed), build the next task from any backlog + this
     message, set running=True, dispatch, and return
     ``{"action": "dispatched", ...submit result}``.
 
@@ -259,12 +208,10 @@ def continue_session(
     """
     message = message.strip()
     # Captured inside the session for use after the with-block.
-    _is_agent = False
     _task = ""
     _stored_recipe = ""
     _stored_tier = ""
     _stored_repo = ""
-    _transcript = ""
 
     with Session(get_engine()) as session:
         # Lock the row for the whole read-modify-write so a concurrent
@@ -277,110 +224,79 @@ def continue_session(
         now = datetime.now(timezone.utc)
         row.updated_at = now
 
-        if row.recipe == AGENT_RECIPE:
-            _is_agent = True
-            if row.running and not _is_stale(row, now):
-                # A live turn is in flight: this reply steers it rather than
-                # queuing behind it (ADR 035 Phase 2). The steering insert and the
-                # running-check above must be atomic under the row lock, so a
-                # turn finishing concurrently can never be missed between the
-                # check and the write. Do NOT append to the transcript here:
-                # fetch_steering owns that write (with attribution) when the
-                # running guest consumes the row, so appending it here too would
-                # double it.
-                session.add(
-                    GoosecrackerSteering(
-                        thread_id=thread_id,
-                        message_id=message_id,
-                        author_id=author_id,
-                        tier=tier or row.tier,
-                        text=message,
-                        delivered=False,
-                    )
+        if row.running and not _is_stale(row, now):
+            # A live turn is in flight: this reply steers it rather than
+            # queuing behind it (ADR 035 Phase 2). The steering insert and the
+            # running-check above must be atomic under the row lock, so a
+            # turn finishing concurrently can never be missed between the
+            # check and the write. Do NOT append to the transcript here:
+            # fetch_steering owns that write (with attribution) when the
+            # running guest consumes the row, so appending it here too would
+            # double it.
+            session.add(
+                GoosecrackerSteering(
+                    thread_id=thread_id,
+                    message_id=message_id,
+                    author_id=author_id,
+                    tier=tier or row.tier,
+                    text=message,
+                    delivered=False,
                 )
-                session.commit()
-                return {"action": "steering"}
-            if row.running:
-                # Stale/foreign-owned turn: the owner died or wedged. Reclaim its
-                # in-flight work by folding it back into this dispatch so nothing
-                # is lost (the startup sweep is the fast path; this is the inline
-                # backstop when the process lived but the turn died silently).
-                logger.warning(
-                    "goosecracker: reclaiming stale turn for thread %s "
-                    "(owner=%s, since=%s)",
-                    thread_id,
-                    row.runner_instance or "?",
-                    row.running_since,
-                )
-            # Idle (or reclaimed): the transcript gets this turn verbatim (the
-            # dispatch path is the record of what was asked, unlike steering).
-            row.transcript = _join_transcript(row.transcript, message)
-            # Consume the dead turn's task (if any), the backlog, and this
-            # message as a single task. Backlog + reclaimed message ids become
-            # this turn's ack set (they show the reaction lifecycle); the
-            # triggering message rides the live progress reply. Join non-empty
-            # parts only: an empty pending/inflight must not inject a blank line
-            # into the task.
-            _task = "\n".join(p for p in (row.inflight_task, row.pending, message) if p)
-            ack_ids = _merge_ids(row.inflight_ack_ids, row.pending_message_ids)
-            _stored_recipe = row.recipe
-            _stored_tier = row.tier
-            _stored_repo = row.repo
-            row.pending = ""
-            row.pending_message_ids = ""
-            row.inflight_task = _task
-            row.inflight_ack_ids = ack_ids
-            row.running = True
-            row.running_since = now
-            row.runner_instance = INSTANCE_TOKEN
-            session.add(row)
+            )
             session.commit()
-        else:
-            # Artifact path: append this turn to the transcript, commit, then do
-            # the S3 check.
-            row.transcript = _join_transcript(row.transcript, message)
-            _transcript = row.transcript
-            session.add(row)
-            session.commit()
+            return {"action": "steering"}
+        if row.running:
+            # Stale/foreign-owned turn: the owner died or wedged. Reclaim its
+            # in-flight work by folding it back into this dispatch so nothing
+            # is lost (the startup sweep is the fast path; this is the inline
+            # backstop when the process lived but the turn died silently).
+            logger.warning(
+                "goosecracker: reclaiming stale turn for thread %s "
+                "(owner=%s, since=%s)",
+                thread_id,
+                row.runner_instance or "?",
+                row.running_since,
+            )
+        # Idle (or reclaimed): the transcript gets this turn verbatim (the
+        # dispatch path is the record of what was asked, unlike steering).
+        row.transcript = _join_transcript(row.transcript, message)
+        # Consume the dead turn's task (if any), the backlog, and this
+        # message as a single task. Backlog + reclaimed message ids become
+        # this turn's ack set (they show the reaction lifecycle); the
+        # triggering message rides the live progress reply. Join non-empty
+        # parts only: an empty pending/inflight must not inject a blank line
+        # into the task.
+        _task = "\n".join(p for p in (row.inflight_task, row.pending, message) if p)
+        ack_ids = _merge_ids(row.inflight_ack_ids, row.pending_message_ids)
+        _stored_recipe = row.recipe
+        _stored_tier = row.tier
+        _stored_repo = row.repo
+        row.pending = ""
+        row.pending_message_ids = ""
+        row.inflight_task = _task
+        row.inflight_ack_ids = ack_ids
+        row.running = True
+        row.running_since = now
+        row.runner_instance = INSTANCE_TOKEN
+        session.add(row)
+        session.commit()
 
     # Imports are lazy (circular import guard: chat.bot -> chat.goosecracker ->
     # goosecracker.runner -> chat.api).
     from goosecracker.api import submit
 
-    if _is_agent:
-        result = submit(
-            _task,
-            session=thread_id,
-            recipe=_stored_recipe,
-            tier=_stored_tier,
-            repo=_stored_repo,
-            discord_thread=thread_id,
-        )
-        # Spread the submit result first, then set action: submit returns its own
-        # "action" (create/resume) and a later key wins in a dict merge, so
-        # "dispatched" must come last to override it (the bot routes on this).
-        return {**result, "action": "dispatched"}
-
-    # Artifact path: ADR 026 Phase 2 (Model A vs B). If a persisted goose session
-    # exists for this thread, send only the new reply (Model A) so the guest can
-    # restore the session and edit in place; otherwise cold-rebuild from the full
-    # transcript (Model B). The S3 check is best-effort: a failure falls back to
-    # Model B, never a hard error.
-    from artifact import s3
-
-    has_session = False
-    try:
-        has_session = s3.head_session(thread_id) is not None
-    except Exception:
-        logger.exception("goosecracker: session existence check failed; cold rebuild")
-    task = message if has_session else _transcript
-    return submit(
-        task,
+    result = submit(
+        _task,
         session=thread_id,
-        recipe=ARTIFACT_RECIPE,
-        tier=ARTIFACT_TIER,
+        recipe=_stored_recipe,
+        tier=_stored_tier,
+        repo=_stored_repo,
         discord_thread=thread_id,
     )
+    # Spread the submit result first, then set action: submit returns its own
+    # "action" (create/resume) and a later key wins in a dict merge, so
+    # "dispatched" must come last to override it (the bot routes on this).
+    return {**result, "action": "dispatched"}
 
 
 def enqueue_steering(
@@ -701,8 +617,8 @@ def start_agent_session(
 
     Dispatches the first turn and writes a GoosecrackerSession row so that
     follow-up replies in the thread are routed through ``continue_session``
-    (agent path) with queuing support. The row is written AFTER dispatch so
-    that a failed submit leaves no row (mirroring ``start_session``).
+    with queuing support. The row is written AFTER dispatch so that a failed
+    submit leaves no orphan row.
 
     ``parent_channel_id`` is the channel the /agent command was run from (the
     thread's parent); stored on the row so the runner can fetch channel-scoped
@@ -724,8 +640,8 @@ def start_agent_session(
     """
     prompt = prompt.strip()
     task = (task or prompt).strip()
-    # Imported lazily for the same reason as start_session (circular import
-    # guard: chat.bot -> chat.goosecracker -> goosecracker.runner -> chat.api).
+    # Imported lazily to avoid a circular import (chat.bot ->
+    # chat.goosecracker -> goosecracker.runner -> chat.api).
     from goosecracker.api import submit
 
     # Dispatch first: a failed submit leaves no session row, avoiding a stuck
@@ -764,17 +680,6 @@ def is_goosecracker_thread(thread_id: str) -> bool:
     """Whether a Discord thread id has a goosecracker session. Synchronous."""
     with Session(get_engine()) as session:
         return session.get(GoosecrackerSession, thread_id) is not None
-
-
-def is_agent_thread(thread_id: str) -> bool:
-    """True for an agent (not artifact) goosecracker thread. Synchronous.
-
-    Lets the reply gate open agent threads to everyone while keeping artifact
-    threads owner-only (ADR 029).
-    """
-    with Session(get_engine()) as session:
-        row = session.get(GoosecrackerSession, thread_id)
-        return row is not None and row.recipe == AGENT_RECIPE
 
 
 def session_scope(thread_id: str) -> str | None:
@@ -999,53 +904,6 @@ def _context_from_own_transcript(transcript: str) -> dict[str, str]:
     return {"README.md": readme, "transcript.md": body}
 
 
-def _channel_dataset_window(thread_id: str) -> list[Message]:
-    """Fetch the recent message window for a thread's parent channel, oldest
-    first, or [] when the thread has no parent channel recorded (or the
-    channel has no messages). Sync; call via ``asyncio.to_thread``. Mirrors
-    the channel query ``build_injected_context`` uses, same message cap.
-    """
-    parent = parent_channel_for_thread(thread_id)
-    if not parent:
-        return []
-    with Session(get_engine()) as session:
-        rows = session.exec(
-            select(Message)
-            .where(Message.channel_id == parent)
-            .order_by(Message.created_at.desc())
-            .limit(_INJECTED_CONTEXT_MSG_LIMIT)
-        ).all()
-    return list(reversed(rows))
-
-
-async def build_channel_dataset(thread_id: str, request: str) -> str | None:
-    """Extract a structured dataset from an artifact thread's parent channel.
-
-    Attached to an artifact dispatch's ``/injected-context/channel-data.json``
-    so the guest can build a chart/table from real conversation data instead of
-    improvising. Delegates to ``chat.channel_data.extract_dataset`` once the
-    channel window is resolved.
-
-    Fail-open like ``build_roast``/``build_injected_context``: returns None
-    when the thread has no parent channel recorded, the channel has no
-    messages, or extraction fails for any reason (a Qwen outage must not block
-    an artifact dispatch, the exact class of bug that bit Phase 1). Sync DB
-    fetch is offloaded via ``asyncio.to_thread``; the rest is async (LLM call).
-    """
-    try:
-        window = await asyncio.to_thread(_channel_dataset_window, thread_id)
-        if not window:
-            return None
-        from chat.channel_data import extract_dataset
-        from chat.summarizer import build_llm_caller
-
-        caller = build_llm_caller()
-        return await extract_dataset(window, request, caller)
-    except Exception:
-        logger.exception("goosecracker: build_channel_dataset failed for %s", thread_id)
-        return None
-
-
 async def build_roast(attempt_text: str) -> str:
     """Roast a non-owner who tried to run the agent, via the in-cluster qwen
     model (same path as the changelog roasts). Falls back to a fixed line if the
@@ -1055,8 +913,8 @@ async def build_roast(attempt_text: str) -> str:
 
     attempt_text = (attempt_text or "").strip()[:300]
     prompt = (
-        "You are a cynical senior engineer. Someone who is NOT the owner just "
-        "tried to run the owner-only /artifact command"
+        "You are a cynical senior engineer. Someone who is NOT granted just "
+        "tried to steer a coding-agent thread that isn't theirs to drive"
         + (f' with: "{attempt_text}"' if attempt_text else "")
         + ". Roast them in one or two dry sentences for reaching for a tool that "
         "isn't theirs. Past tense or present, declarative. No preamble, no "

--- a/projects/monolith/chat/goosecracker_test.py
+++ b/projects/monolith/chat/goosecracker_test.py
@@ -3,7 +3,6 @@ session dispatch (ADR 024 Task 4). DB-backed tests run against in-memory SQLite
 with the chat schema stripped. goosecracker.api is injected as a fake module so
 the test does not pull the real executor (and so no run is dispatched)."""
 
-import json
 import sys
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
@@ -121,63 +120,6 @@ def test_progress_message_helpers_noop_without_row(engine):
         assert goosecracker.take_progress_message("missing") == ""
 
 
-def test_start_session_records_transcript_and_dispatches(engine, fake_api):
-    with patch("chat.goosecracker.get_engine", return_value=engine):
-        goosecracker.start_session("thread-1", "  build a clock  ")
-
-    fake_api.submit.assert_called_once_with(
-        "build a clock",
-        session="thread-1",
-        recipe="artifact",
-        tier="artifact",
-        discord_thread="thread-1",
-    )
-    with Session(engine) as session:
-        row = session.get(GoosecrackerSession, "thread-1")
-        assert row is not None
-        assert row.transcript == "build a clock"
-
-
-def test_start_session_records_parent_channel_id(engine, fake_api):
-    """The /artifact command's parent channel is recorded on the row, mirroring
-    start_agent_session, so parent_channel_for_thread resolves it later."""
-    with patch("chat.goosecracker.get_engine", return_value=engine):
-        goosecracker.start_session("thread-1", "build a clock", "channel-1")
-    with Session(engine) as session:
-        row = session.get(GoosecrackerSession, "thread-1")
-        assert row is not None
-        assert row.parent_channel_id == "channel-1"
-
-
-def test_start_session_defaults_parent_channel_id_to_empty(engine, fake_api):
-    """Callers that omit parent_channel_id (e.g. an older call site) still work:
-    the row gets the field's empty default rather than an error."""
-    with patch("chat.goosecracker.get_engine", return_value=engine):
-        goosecracker.start_session("thread-1", "build a clock")
-    with Session(engine) as session:
-        row = session.get(GoosecrackerSession, "thread-1")
-        assert row is not None
-        assert row.parent_channel_id == ""
-
-
-def test_continue_session_appends_and_resubmits_full_transcript(engine, fake_api):
-    with patch("chat.goosecracker.get_engine", return_value=engine):
-        goosecracker.start_session("thread-1", "build a clock")
-        fake_api.submit.reset_mock()
-        goosecracker.continue_session("thread-1", "make it red")
-
-    fake_api.submit.assert_called_once_with(
-        "build a clock\n\nmake it red",
-        session="thread-1",
-        recipe="artifact",
-        tier="artifact",
-        discord_thread="thread-1",
-    )
-    with Session(engine) as session:
-        row = session.get(GoosecrackerSession, "thread-1")
-        assert row.transcript == "build a clock\n\nmake it red"
-
-
 def test_continue_session_unknown_thread_returns_none(engine, fake_api):
     with patch("chat.goosecracker.get_engine", return_value=engine):
         result = goosecracker.continue_session("nope", "hi")
@@ -185,60 +127,41 @@ def test_continue_session_unknown_thread_returns_none(engine, fake_api):
     fake_api.submit.assert_not_called()
 
 
+def test_continue_session_agent_thread_dispatches_with_agent_recipe(engine, fake_api):
+    """continue_session is agent-only now: an idle agent thread's reply is
+    dispatched with recipe='agent' (there is no artifact re-dispatch branch to
+    fall into)."""
+    with Session(engine) as session:
+        session.add(
+            GoosecrackerSession(
+                discord_thread="thread-1",
+                recipe="agent",
+                transcript="build a clock",
+                running=False,
+            )
+        )
+        session.commit()
+
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        result = goosecracker.continue_session("thread-1", "make it red")
+
+    assert result is not None
+    assert result.get("action") == "dispatched"
+    fake_api.submit.assert_called_once()
+    assert fake_api.submit.call_args.kwargs["recipe"] == "agent"
+
+
 def test_is_goosecracker_thread(engine, fake_api):
     with patch("chat.goosecracker.get_engine", return_value=engine):
-        goosecracker.start_session("thread-1", "build a clock")
+        with Session(engine) as session:
+            session.add(
+                GoosecrackerSession(
+                    discord_thread="thread-1", transcript="build a clock"
+                )
+            )
+            session.commit()
         assert goosecracker.is_goosecracker_thread("thread-1") is True
         assert goosecracker.is_goosecracker_thread("other") is False
-
-
-# ---------------------------------------------------------------------------
-# ADR 026 Phase 2: continue_session resume gate
-# ---------------------------------------------------------------------------
-
-
-def test_continue_session_resume_path_when_session_exists(
-    engine, fake_api, monkeypatch
-):
-    """When head_session returns a truthy etag (Model A), the task is the latest
-    stripped message (not the full transcript)."""
-    from artifact import s3
-
-    monkeypatch.setattr(s3, "head_session", lambda _: "abc123")
-
-    with patch("chat.goosecracker.get_engine", return_value=engine):
-        goosecracker.start_session("thread-1", "build a clock")
-        fake_api.submit.reset_mock()
-        goosecracker.continue_session("thread-1", "  make it red  ")
-
-    fake_api.submit.assert_called_once_with(
-        "make it red",
-        session="thread-1",
-        recipe="artifact",
-        tier="artifact",
-        discord_thread="thread-1",
-    )
-
-
-def test_continue_session_cold_path_when_no_session(engine, fake_api, monkeypatch):
-    """When head_session returns None (Model B), the task is the full accumulated
-    transcript."""
-    from artifact import s3
-
-    monkeypatch.setattr(s3, "head_session", lambda _: None)
-
-    with patch("chat.goosecracker.get_engine", return_value=engine):
-        goosecracker.start_session("thread-1", "build a clock")
-        fake_api.submit.reset_mock()
-        goosecracker.continue_session("thread-1", "make it red")
-
-    fake_api.submit.assert_called_once_with(
-        "build a clock\n\nmake it red",
-        session="thread-1",
-        recipe="artifact",
-        tier="artifact",
-        discord_thread="thread-1",
-    )
 
 
 def test_start_agent_session_dispatches_with_agent_recipe(engine, fake_api):
@@ -417,131 +340,6 @@ class TestBuildInjectedContext:
         assert bundle == {}
 
 
-class _FakeDatasetCaller:
-    """Records the prompt it was called with; returns a canned reply."""
-
-    def __init__(self, response: str):
-        self.prompts: list[str] = []
-        self._response = response
-
-    async def __call__(self, prompt: str) -> str:
-        self.prompts.append(prompt)
-        return self._response
-
-
-class TestBuildChannelDataset:
-    """chat.summarizer.build_llm_caller is the established seam to patch (same
-    as TestBuildRoast further down); extract_dataset itself is exercised in
-    chat/channel_data_test.py, so these tests focus on the wiring: window
-    resolution and fail-open behavior."""
-
-    @pytest.mark.asyncio
-    async def test_no_parent_channel_returns_none_without_calling_caller(
-        self, engine, fake_api
-    ):
-        with Session(engine) as session:
-            session.add(
-                GoosecrackerSession(
-                    discord_thread="thr-art",
-                    recipe="artifact",
-                    tier="artifact",
-                    parent_channel_id="",
-                )
-            )
-            session.commit()
-
-        caller = _FakeDatasetCaller("{}")
-        with (
-            patch("chat.goosecracker.get_engine", return_value=engine),
-            patch("chat.summarizer.build_llm_caller", return_value=caller),
-        ):
-            result = await goosecracker.build_channel_dataset("thr-art", "count bugs")
-
-        assert result is None
-        assert caller.prompts == []
-
-    @pytest.mark.asyncio
-    async def test_parent_channel_with_no_messages_returns_none(self, engine, fake_api):
-        with Session(engine) as session:
-            session.add(
-                GoosecrackerSession(
-                    discord_thread="thr-art",
-                    recipe="artifact",
-                    tier="artifact",
-                    parent_channel_id="chan-empty",
-                )
-            )
-            session.commit()
-
-        caller = _FakeDatasetCaller("{}")
-        with (
-            patch("chat.goosecracker.get_engine", return_value=engine),
-            patch("chat.summarizer.build_llm_caller", return_value=caller),
-        ):
-            result = await goosecracker.build_channel_dataset("thr-art", "count bugs")
-
-        assert result is None
-        assert caller.prompts == []
-
-    @pytest.mark.asyncio
-    async def test_delegates_to_extract_dataset_with_channel_window(
-        self, engine, fake_api
-    ):
-        with Session(engine) as session:
-            session.add(
-                GoosecrackerSession(
-                    discord_thread="thr-art",
-                    recipe="artifact",
-                    tier="artifact",
-                    parent_channel_id="chan-1",
-                )
-            )
-            session.commit()
-            _msg(session, "chan-1", "alice", "we shipped 3 features", 1)
-            _msg(session, "chan-1", "bob", "and fixed 2 bugs", 2)
-
-        reply = json.dumps({"title": "t", "columns": ["a"], "rows": [["1"]]})
-        caller = _FakeDatasetCaller(reply)
-        with (
-            patch("chat.goosecracker.get_engine", return_value=engine),
-            patch("chat.summarizer.build_llm_caller", return_value=caller),
-        ):
-            result = await goosecracker.build_channel_dataset(
-                "thr-art", "count features per person"
-            )
-
-        assert result is not None
-        assert json.loads(result)["title"] == "t"
-        assert len(caller.prompts) == 1
-        assert "we shipped 3 features" in caller.prompts[0]
-        assert "count features per person" in caller.prompts[0]
-
-    @pytest.mark.asyncio
-    async def test_caller_exception_returns_none_not_raise(self, engine, fake_api):
-        with Session(engine) as session:
-            session.add(
-                GoosecrackerSession(
-                    discord_thread="thr-art",
-                    recipe="artifact",
-                    tier="artifact",
-                    parent_channel_id="chan-1",
-                )
-            )
-            session.commit()
-            _msg(session, "chan-1", "alice", "hello", 1)
-
-        def _raise():
-            raise RuntimeError("no model configured")
-
-        with (
-            patch("chat.goosecracker.get_engine", return_value=engine),
-            patch("chat.summarizer.build_llm_caller", side_effect=_raise),
-        ):
-            result = await goosecracker.build_channel_dataset("thr-art", "count bugs")
-
-        assert result is None
-
-
 # ---------------------------------------------------------------------------
 # Agent conversational path: continue_session queuing + dispatching
 # ---------------------------------------------------------------------------
@@ -688,32 +486,6 @@ def test_continue_agent_session_consumes_pending_on_dispatch(engine, fake_api):
         row = session.get(GoosecrackerSession, "agent-t4")
     assert row.pending == ""
     assert row.running
-
-
-def test_continue_session_falls_back_to_cold_on_head_session_error(
-    engine, fake_api, monkeypatch
-):
-    """When head_session raises any exception, the handler logs and falls back
-    to the cold (Model B) rebuild path using the full transcript."""
-    from artifact import s3
-
-    def _raise(_):
-        raise RuntimeError("S3 unavailable")
-
-    monkeypatch.setattr(s3, "head_session", _raise)
-
-    with patch("chat.goosecracker.get_engine", return_value=engine):
-        goosecracker.start_session("thread-1", "build a clock")
-        fake_api.submit.reset_mock()
-        goosecracker.continue_session("thread-1", "make it red")
-
-    fake_api.submit.assert_called_once_with(
-        "build a clock\n\nmake it red",
-        session="thread-1",
-        recipe="artifact",
-        tier="artifact",
-        discord_thread="thread-1",
-    )
 
 
 def test_drain_agent_queue_returns_task_and_clears_pending(engine):

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -154,11 +154,11 @@ class GoosecrackerSession(SQLModel, table=True):
     """Per-Discord-thread curated transcript for the goosecracker agent (ADR 024).
 
     One row per thread; transcript accumulates the owner's instructions (never
-    ambient chatter or the bot's replies). ``recipe`` distinguishes artifact
-    sessions (iterative HTML builder) from agent sessions (conversational coding
-    agent). Agent sessions are conversational: ``running`` is True while a turn is
-    in flight; replies that arrive during a run are appended to ``pending`` and
-    dispatched as the next turn when the current one finishes.
+    ambient chatter or the bot's replies). Every session is an agent session
+    (conversational coding agent; an artifact is an agent run with no repo):
+    ``running`` is True while a turn is in flight; replies that arrive during a
+    run are appended to ``pending`` and dispatched as the next turn when the
+    current one finishes.
     """
 
     __tablename__ = "goosecracker_sessions"
@@ -168,7 +168,7 @@ class GoosecrackerSession(SQLModel, table=True):
     transcript: str = Field(default="")
     # recipe/tier/repo mirror the dispatch.submit params so continue_session can
     # re-dispatch without the caller re-supplying them.
-    recipe: str = Field(default="artifact")
+    recipe: str = Field(default="agent")
     tier: str = Field(default="")
     repo: str = Field(default="")
     # Discord parent channel the /agent thread was opened from. The thread itself

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.20
+      targetRevision: 0.285.21
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -221,34 +221,6 @@ goosecracker:
       # values). Leave unset in deployments without SearXNG: the recipe
       # skips web search gracefully.
       SEARXNG_URL: http://monolith-searxng.monolith.svc.cluster.local:8080
-    # The artifact tier runs on the in-cluster qwen model (free, no OpenRouter
-    # cost). Artifacts are served behind unguessable capability URLs, so a paid
-    # large-context tier is no longer needed. Same OpenAI-compatible in-cluster
-    # endpoint as the default tier, plus the artifact publish/progress sinks.
-    artifact:
-      OPENAI_HOST: http://inference.inference.svc.cluster.local:8080
-      OPENAI_API_KEY: sk-noauth
-      GOOSE_PROVIDER: openai
-      GOOSE_MODEL: qwen3.6-27b
-      # Match vLLM maxModelLen so goose compacts before the wall; leave ample room
-      # for a single HTML write (max_tokens counts the write tool_call output).
-      GOOSE_CONTEXT_LIMIT: "32768"
-      GOOSE_MAX_TOKENS: "16000"
-      # Where the artifact recipe publishes (in-cluster monolith backend, reached
-      # through the egress funnel; no secret swap for this host).
-      ARTIFACT_PUBLISH_URL: http://monolith.monolith.svc.cluster.local:8000/internal/artifact
-      # Live build-progress sink for the artifact recipe (same monolith endpoint).
-      PROGRESS_PUBLISH_URL: http://monolith.monolith.svc.cluster.local:8000/internal/goosecracker/progress
-      GOOSE_MODE: auto
-      GOOSE_DISABLE_SESSION_NAMING: "true"
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318
-      OTEL_SERVICE_NAME: goosecracker-artifact
-      # SearXNG JSON API for the research sub-recipe. Not a secret; the
-      # egress sidecar must also allowlist this host:port (substrate deploy
-      # values). Leave unset in deployments without SearXNG: the recipe
-      # skips web search gracefully.
-      SEARXNG_URL: http://monolith-searxng.monolith.svc.cluster.local:8080
-
 # Taken offline 2026-06-14 for the ADR 006 Phase 4 transition: with the
 # gardener paused, the raw export / file moves can be done as a controlled
 # one-off, and the gardener stays down until the CLI-based version (Phase 4a-ii)

--- a/projects/monolith/goosecracker/__init__.py
+++ b/projects/monolith/goosecracker/__init__.py
@@ -2,7 +2,7 @@
 
 Trigger-agnostic core: ``submit`` writes a run ledger row and fires an fc-invoke
 run + result delivery off detached; ``status`` / ``list_runs`` / ``get_run`` read
-the ledger. Thin adapters (chat's /artifact command, agent's MCP tools) call
+the ledger. Thin adapters (chat's /agent command, agent's MCP tools) call
 ``submit`` and poll the ledger; they own no execution logic.
 """
 

--- a/projects/monolith/goosecracker/api.py
+++ b/projects/monolith/goosecracker/api.py
@@ -1,6 +1,6 @@
 """goosecracker domain public API: the only surface other domains may import.
 
-Other domains (chat's /artifact adapter, agent's MCP tools) must import from
+Other domains (chat's /agent command, agent's MCP tools) must import from
 ``goosecracker.api``, never from ``goosecracker`` internals such as
 ``goosecracker.runner`` (enforced by ``import_boundaries_test``).
 """

--- a/projects/monolith/goosecracker/dispatch.py
+++ b/projects/monolith/goosecracker/dispatch.py
@@ -1,6 +1,6 @@
 """Trigger-agnostic goose dispatch: the ``submit`` seam every trigger calls.
 
-A trigger (the Discord ``/artifact`` adapter, an MCP tool, a future CI hook)
+A trigger (the Discord ``/agent`` command, an MCP tool, a future CI hook)
 supplies a task + a stable ``session`` id and calls :func:`submit`. This writes
 the run ledger row and fires the fc-invoke run off as a detached task, then
 returns immediately with the session, thread id, and whether the row was created
@@ -74,9 +74,9 @@ def submit(
 
     Writes/updates the ledger row (state RUNNING) and kicks off the fc-invoke run
     + result delivery as a detached task. ``session`` is the stable run id (the
-    Discord thread id for /artifact, or a caller-generated id for MCP). ``tier``
-    selects the guest model env (default -> in-cluster Qwen; "artifact" ->
-    OpenRouter, pending egress secret-swap). ``plan`` is the optional runtime
+    Discord thread id for /agent, or a caller-generated id for MCP). ``tier``
+    selects the guest model env (default -> in-cluster Qwen). ``plan`` is the
+    optional runtime
     :class:`~chat.orchestrator_plan.Plan` from the DeepSeek orchestrator (Task 6);
     when present the runner delivers a rendered router + plan file via
     ``injectedContext`` instead of the baked ``recipe="agent"`` path. Returns

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -440,18 +440,17 @@ async def _agent_reply_message(session: str, summary: str, details: str) -> str:
         return deterministic
 
 
-async def _delivery_message(session: str, recipe: str, data: dict) -> str:
+async def _delivery_message(session: str, data: dict) -> str:
     """Build the Discord message for a successful run.
 
-    Artifact runs publish the built HTML and post a clean ``Artifact ready: <url>``
-    (plus the recipe's one-line summary) instead of the raw goose transcript. A run
-    that was meant to build an artifact but produced none gets a clear miss message.
-    Any other run (e.g. the coding ``agent``) prefers the recipe's typed response
-    (a JSON object from response.json_schema): summary, optional details, and a
-    PR/issue url. It falls back to the legacy markdown summary, then goose's
-    trailing narrative, so there is always a meaningful response. When the guest
-    recorded a scratch ref (WS3), a ``recorded: refs/agents/<session>`` line is
-    appended for all run types.
+    A run that produced artifact HTML (an agent run the router took down the
+    artifact-build path) publishes it and posts a clean ``Artifact ready: <url>``
+    plus the one-line summary, instead of the raw goose transcript. Any other run
+    prefers the recipe's typed response (a JSON object from response.json_schema):
+    summary, optional details, and a PR/issue url. It falls back to the legacy
+    markdown summary, then goose's trailing narrative, so there is always a
+    meaningful response. When the guest recorded a scratch ref (WS3), a
+    ``recorded: refs/agents/<session>`` line is appended for all run types.
     """
     html = data.get("artifactHtml")
     if html:
@@ -461,18 +460,14 @@ async def _delivery_message(session: str, recipe: str, data: dict) -> str:
         except Exception:
             logger.exception("goosecracker: artifact publish failed for %s", session)
             return "Build finished, but publishing the artifact failed. Check the logs."
-        # Summary can come from the artifact recipe's markdown goose-result
-        # (/artifact command) or the router's typed JSON (a /agent run routed to
-        # the artifact sub-recipe). Prefer the structured summary, fall back to
-        # the markdown one.
+        # Summary comes from the router's typed JSON (a /agent run routed to the
+        # artifact-build sub-recipe), falling back to the markdown goose-result.
         result_text = data.get("result", "") or ""
         structured = _parse_structured_result(result_text)
         summary = (
             str(structured.get("summary", "")).strip() if structured else ""
         ) or _extract_summary(result_text)
         msg = f"Artifact ready: {url}" + (f"\n\n{summary}" if summary else "")
-    elif recipe == "artifact":
-        msg = "Build finished but produced no artifact. Try rephrasing the request."
     else:
         # Coding agent (and any non-artifact recipe). Prefer the typed response
         # (the agent recipe's response.json_schema makes goose emit a JSON object
@@ -671,29 +666,6 @@ async def _invoke_turn(
                 "continuing without it",
                 session,
             )
-        # Task 3.2: attach an extracted dataset for an artifact dispatch only
-        # (the agent-route gap is a documented follow-up, out of scope here).
-        # build_channel_dataset is already fail-open internally (a Qwen outage
-        # must not block the dispatch), but it is wrapped again here so a
-        # surprise exception in the chat.api boundary itself cannot fail the
-        # run either.
-        if recipe == "artifact":
-            from chat.api import build_channel_dataset
-
-            try:
-                dataset = await build_channel_dataset(discord_thread, task)
-            except Exception:
-                logger.exception(
-                    "goosecracker: build_channel_dataset failed for %s; "
-                    "continuing without it",
-                    session,
-                )
-                dataset = None
-            if dataset is not None:
-                injected_context = {
-                    **injected_context,
-                    "channel-data.json": dataset,
-                }
     # WS2 - Hydration: default the mirror and ref when the caller did not
     # specify them. The mirror is read from GOOSECRACKER_GIT_MIRROR, injected
     # via Helm values. An empty effective_mirror means no clone (no mirror
@@ -783,9 +755,7 @@ async def _invoke_turn(
     return await _post_agent_run(url, payload, _notify_retry)
 
 
-async def _deliver_result(
-    session: str, recipe: str, discord_thread: str, data: dict
-) -> bool:
+async def _deliver_result(session: str, discord_thread: str, data: dict) -> bool:
     """Mark the ledger and settle a run's terminal result into its Discord thread.
 
     This is the delivery half split out of the old ``_run_one_turn`` (Task 7): it
@@ -804,7 +774,7 @@ async def _deliver_result(
         await _persist_session_db(session, data.get("sessionDb"))
         # nosemgrep: no-session-in-to-thread  # `session` is the fc-invoke session-id string, not a SQLAlchemy Session
         await asyncio.to_thread(threads.mark_completed, session, result)
-        await _settle(discord_thread, await _delivery_message(session, recipe, data))
+        await _settle(discord_thread, await _delivery_message(session, data))
         return True
     err = data.get("error", "") or "goose run failed with no detail"
     # nosemgrep: no-session-in-to-thread  # `session` is the fc-invoke session-id string, not a SQLAlchemy Session
@@ -927,7 +897,7 @@ async def _run_one_turn(
                     )
             # No replan requested, replan budget exhausted, orchestrator
             # fail-open, or a non-plan turn: this result is final. Deliver it.
-            ok = await _deliver_result(session, recipe, discord_thread, data)
+            ok = await _deliver_result(session, discord_thread, data)
             break
     except Exception as exc:  # noqa: BLE001 - any failure must mark + deliver
         logger.exception("goosecracker: run_and_deliver failed for %s", session)

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -96,7 +96,7 @@ _AGENT_RESULT_WITH_PR = (
 
 async def test_delivery_message_agent_posts_summary_not_transcript():
     data = {"result": _AGENT_RESULT, "recordedRef": "refs/agents/s-1"}
-    msg = await runner._delivery_message("s-1", "agent", data)
+    msg = await runner._delivery_message("s-1", data)
     assert "Added a null check in parse()." in msg
     # the raw transcript (recipe banner + tool lines) must NOT be dumped
     assert "▸ shell" not in msg
@@ -107,16 +107,14 @@ async def test_delivery_message_agent_posts_summary_not_transcript():
 
 
 async def test_delivery_message_agent_appends_real_pr_url():
-    msg = await runner._delivery_message(
-        "s-2", "agent", {"result": _AGENT_RESULT_WITH_PR}
-    )
+    msg = await runner._delivery_message("s-2", {"result": _AGENT_RESULT_WITH_PR})
     assert "Opened a PR fixing the parser." in msg
     assert "https://github.com/jomcgi/homelab/pull/42" in msg
 
 
 async def test_delivery_message_agent_falls_back_to_transcript_without_block():
     msg = await runner._delivery_message(
-        "s-3", "agent", {"result": "just some raw output, no result block"}
+        "s-3", {"result": "just some raw output, no result block"}
     )
     assert "just some raw output" in msg
 
@@ -130,7 +128,7 @@ async def test_delivery_message_agent_posts_trailing_narrative():
         "  __( O)>  goose is ready\n"
         "Joe has been working on the git mirror and the /agent command this week."
     )
-    msg = await runner._delivery_message("s-9", "agent", {"result": result})
+    msg = await runner._delivery_message("s-9", {"result": result})
     assert "Joe has been working on the git mirror" in msg
     assert "Loading recipe" not in msg  # recipe banner stripped
     assert "goose is ready" not in msg  # no terminal chrome leaks
@@ -154,7 +152,7 @@ async def test_delivery_message_agent_suppresses_raw_transcript():
         "  ────────────────────────────────\n"
         "Now I have a thorough picture. Let me compile the answer."
     )
-    msg = await runner._delivery_message("s-12", "agent", {"result": result})
+    msg = await runner._delivery_message("s-12", {"result": result})
     assert "rfind(marker)" not in msg  # did not ship (or slice into) the cat-ed source
     assert "▸" not in msg
     assert "goose is ready" not in msg
@@ -172,7 +170,7 @@ async def test_delivery_message_agent_prefers_typed_response():
         '"details": "Added a guard in parse() and a regression test.", '
         '"url": "https://github.com/jomcgi/homelab/pull/99"}'
     )
-    msg = await runner._delivery_message("s-10", "agent", {"result": result})
+    msg = await runner._delivery_message("s-10", {"result": result})
     assert "Fixed the parser null check." in msg
     assert "Added a guard in parse()" in msg
     assert "https://github.com/jomcgi/homelab/pull/99" in msg
@@ -181,7 +179,7 @@ async def test_delivery_message_agent_prefers_typed_response():
 
 async def test_delivery_message_agent_typed_response_summary_only():
     result = '{"type": "answer", "summary": "There were 3 commits today."}'
-    msg = await runner._delivery_message("s-11", "agent", {"result": result})
+    msg = await runner._delivery_message("s-11", {"result": result})
     assert "There were 3 commits today." in msg
 
 
@@ -197,7 +195,7 @@ async def test_delivery_message_publishes_and_links(monkeypatch):
     )
     data = {"artifactHtml": "<html>x</html>", "result": _GOOSE_RESULT}
 
-    msg = await runner._delivery_message("sess", "artifact", data)
+    msg = await runner._delivery_message("sess", data)
 
     assert "https://jomcgi.dev/artifact/abc123" in msg
     assert "A bouncing ball demo with gravity." in msg
@@ -205,26 +203,17 @@ async def test_delivery_message_publishes_and_links(monkeypatch):
     assert "▸ write path" not in msg
 
 
-async def test_delivery_message_artifact_run_with_no_artifact():
-    msg = await runner._delivery_message(
-        "sess", "artifact", {"result": "chatted instead"}
-    )
-    assert "no artifact" in msg.lower()
-
-
 async def test_delivery_message_publish_failure_is_reported(monkeypatch):
     def boom(_s, _h):
         raise RuntimeError("s3 down")
 
     monkeypatch.setattr(runner, "_publish_artifact", boom)
-    msg = await runner._delivery_message(
-        "sess", "artifact", {"artifactHtml": "<html>x</html>"}
-    )
+    msg = await runner._delivery_message("sess", {"artifactHtml": "<html>x</html>"})
     assert "failed" in msg.lower()
 
 
 async def test_delivery_message_non_artifact_posts_result():
-    msg = await runner._delivery_message("sess", "agent", {"result": "hello from qwen"})
+    msg = await runner._delivery_message("sess", {"result": "hello from qwen"})
     assert msg == "hello from qwen"
 
 
@@ -305,7 +294,7 @@ def test_effective_mirror_explicit_git_mirror_overrides_repo(monkeypatch):
 async def test_delivery_message_appends_recorded_ref_for_agent():
     """A recorded scratch ref is appended to the agent result message."""
     data = {"result": "did the work", "recordedRef": "refs/agents/sess-abc"}
-    msg = await runner._delivery_message("sess-abc", "agent", data)
+    msg = await runner._delivery_message("sess-abc", data)
     assert "did the work" in msg
     assert "recorded: refs/agents/sess-abc" in msg
 
@@ -320,14 +309,14 @@ async def test_delivery_message_appends_recorded_ref_for_artifact(monkeypatch):
         "result": "",
         "recordedRef": "refs/agents/sess-art",
     }
-    msg = await runner._delivery_message("sess-art", "artifact", data)
+    msg = await runner._delivery_message("sess-art", data)
     assert "https://jomcgi.dev/artifact/x" in msg
     assert "recorded: refs/agents/sess-art" in msg
 
 
 async def test_delivery_message_no_recorded_ref_unchanged():
     """When no recordedRef is present, the message is unchanged."""
-    msg = await runner._delivery_message("sess", "agent", {"result": "result text"})
+    msg = await runner._delivery_message("sess", {"result": "result text"})
     assert msg == "result text"
     assert "recorded:" not in msg
 
@@ -710,124 +699,6 @@ async def test_run_one_turn_repoless_omits_repo_key(monkeypatch):
     assert "repo" not in payload["injectedContext"]
 
 
-async def _run_artifact_turn_with_dataset_producer(monkeypatch, producer):
-    """Shared setup for the channel-data.json wiring tests (Task 3.2): stub
-    every seam _run_one_turn touches (mirrors
-    test_run_one_turn_ships_injected_context_in_payload) for an
-    artifact-recipe turn, with ``producer`` standing in for
-    chat.api.build_channel_dataset. Returns the captured fc-invoke payload."""
-    import chat.api
-
-    captured_payload = {}
-
-    async def fake_post(url, payload, on_retry):
-        captured_payload.update(payload)
-        return {"status": "ok", "result": "done", "sessionDb": ""}
-
-    monkeypatch.setattr(runner, "_post_agent_run", fake_post)
-    monkeypatch.setattr(runner, "FC_INVOKE_URL", "http://fc-invoke")
-    monkeypatch.setattr(runner.sessions, "load", MagicMock(return_value=None))
-    monkeypatch.setattr(runner.threads, "mark_completed", MagicMock())
-    monkeypatch.setattr(runner, "_deliver", AsyncMock())
-    monkeypatch.setattr(runner, "_mark_progress_done", MagicMock())
-    monkeypatch.setattr(runner, "_persist_session_db", AsyncMock())
-    monkeypatch.setattr(chat.api, "reset_goosecracker_progress", MagicMock())
-    monkeypatch.setattr(chat.api, "ensure_steering_token", lambda _s: "")
-    monkeypatch.setattr(
-        chat.api, "build_injected_context", lambda tid, tier="": {"transcript.md": "hi"}
-    )
-    monkeypatch.setattr(chat.api, "build_channel_dataset", producer)
-
-    ok = await runner._run_one_turn(
-        "sess-1",
-        task="q",
-        recipe="artifact",
-        tier="artifact",
-        git_mirror="",
-        git_ref="",
-        discord_thread="thr-1",
-    )
-    assert ok is True
-    return captured_payload
-
-
-async def test_run_one_turn_artifact_with_dataset_ships_channel_data_json(
-    monkeypatch,
-):
-    """Task 3.2: an artifact-recipe turn whose extraction succeeds ships the
-    dataset alongside the ADR 040 per-turn context, never replacing it."""
-    producer = AsyncMock(return_value='{"title": "t"}')
-    payload = await _run_artifact_turn_with_dataset_producer(monkeypatch, producer)
-
-    producer.assert_called_once_with("thr-1", "q")
-    assert payload["injectedContext"]["channel-data.json"] == '{"title": "t"}'
-    assert payload["injectedContext"]["transcript.md"] == "hi"
-
-
-async def test_run_one_turn_artifact_without_dataset_omits_key(monkeypatch):
-    """None (no channel to extract from, or a fail-open) means no key at all,
-    not an empty string: the guest's presence check must be a clean miss."""
-    producer = AsyncMock(return_value=None)
-    payload = await _run_artifact_turn_with_dataset_producer(monkeypatch, producer)
-
-    assert "channel-data.json" not in payload["injectedContext"]
-
-
-async def test_run_one_turn_artifact_dataset_producer_raising_still_dispatches(
-    monkeypatch,
-):
-    """A surprise exception from the chat.api boundary itself (build_channel_
-    dataset is already fail-open internally, but this is belt-and-suspenders)
-    must not fail the dispatch: the run still succeeds, just without the key."""
-    producer = AsyncMock(side_effect=RuntimeError("boom"))
-    payload = await _run_artifact_turn_with_dataset_producer(monkeypatch, producer)
-
-    assert "channel-data.json" not in payload["injectedContext"]
-
-
-async def test_run_one_turn_agent_recipe_never_calls_build_channel_dataset(
-    monkeypatch,
-):
-    """The dataset attachment is artifact-recipe only (Task 3.2); the agent
-    route is a documented follow-up, out of scope here."""
-    import chat.api
-
-    captured_payload = {}
-
-    async def fake_post(url, payload, on_retry):
-        captured_payload.update(payload)
-        return {"status": "ok", "result": "done", "sessionDb": ""}
-
-    monkeypatch.setattr(runner, "_post_agent_run", fake_post)
-    monkeypatch.setattr(runner, "FC_INVOKE_URL", "http://fc-invoke")
-    monkeypatch.setattr(runner.sessions, "load", MagicMock(return_value=None))
-    monkeypatch.setattr(runner.threads, "mark_completed", MagicMock())
-    monkeypatch.setattr(runner, "_deliver", AsyncMock())
-    monkeypatch.setattr(runner, "_mark_progress_done", MagicMock())
-    monkeypatch.setattr(runner, "_persist_session_db", AsyncMock())
-    monkeypatch.setattr(chat.api, "reset_goosecracker_progress", MagicMock())
-    monkeypatch.setattr(chat.api, "ensure_steering_token", lambda _s: "")
-    monkeypatch.setattr(
-        chat.api, "build_injected_context", lambda tid, tier="": {"transcript.md": "hi"}
-    )
-    producer = AsyncMock(return_value='{"title": "t"}')
-    monkeypatch.setattr(chat.api, "build_channel_dataset", producer)
-
-    ok = await runner._run_one_turn(
-        "sess-1",
-        task="q",
-        recipe="agent",
-        tier="",
-        git_mirror="",
-        git_ref="",
-        discord_thread="thr-1",
-    )
-
-    assert ok is True
-    producer.assert_not_called()
-    assert "channel-data.json" not in captured_payload["injectedContext"]
-
-
 def _one_step_plan():
     """A minimal Plan for the plan-delivery payload tests (Task 6)."""
     from chat.orchestrator_plan import Plan, PlanStep
@@ -989,7 +860,7 @@ async def test_delivery_message_agent_appends_url_after_conversational(monkeypat
         '"details": "guard + test", '
         '"url": "https://github.com/jomcgi/homelab/pull/99"}'
     )
-    msg = await runner._delivery_message("s-10", "agent", {"result": result})
+    msg = await runner._delivery_message("s-10", {"result": result})
     assert msg.startswith("All done, opened a PR for you.")
     assert "https://github.com/jomcgi/homelab/pull/99" in msg
     assert "guard + test" not in msg  # raw details replaced by the conversational reply

--- a/projects/monolith/goosecracker/tiers.py
+++ b/projects/monolith/goosecracker/tiers.py
@@ -8,16 +8,13 @@ fc-invoke egress proxy swaps them for real secrets at the egress hop.
 
 The map itself is injected as the ``GOOSECRACKER_TIERS`` env var (a JSON object
 ``{tier: {ENV_KEY: value}}``) from Helm values, never hardcoded here: the values
-carry in-cluster service URLs (OPENAI_HOST, the OTLP endpoint,
-ARTIFACT_PUBLISH_URL) that would break silently on a release rename if baked into
-Python (semgrep ``no-hardcoded-k8s-service-url``).
+carry in-cluster service URLs (OPENAI_HOST, the OTLP endpoint) that would break
+silently on a release rename if baked into Python (semgrep
+``no-hardcoded-k8s-service-url``).
 
 Tiers:
-  default -> in-cluster Qwen on vLLM (the proven cold-run path).
-  artifact -> Gemini via OpenRouter. Kept, but the OpenRouter key is a placeholder
-    the fc-invoke egress proxy must swap on openrouter.ai; until that egress
-    secret-swap lands, the artifact tier will not reach the model. Correctness
-    here is focused on the default/Qwen tier.
+  default -> in-cluster Qwen on vLLM (the proven cold-run path). The only tier;
+    artifacts are just an agent run with no repo, so they run here too.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Why

Artifact building is self-selecting now: a natural-language "build me a page" runs `/agent`, whose router classifies it as an artifact and delegates the `artifact-build` / `artifact-review` sub-recipes. The explicit `/artifact` slash command was a second, worse path that dispatched a bare `recipe="artifact"` — which has had **no recipe file since `artifact.yaml` was renamed to `artifact-build.yaml`** (`a70620224`), so it was broken.

## What

Remove the command and the whole `recipe="artifact"` concept behind it, keeping everything the `/agent` artifact path shares:

- Delete the `/artifact` command + handler (`bot.py`), `start_session`, and `ARTIFACT_RECIPE` / `ARTIFACT_TIER`.
- `continue_session` becomes agent-only (drop the artifact re-dispatch branch and the ADR 026 S3 Model-A/B tail); the thread reply-gate uses the `agent` grant for all threads; `is_agent_thread` is gone.
- Drop the orphaned `build_channel_dataset` and the runner's `recipe=="artifact"` branches. **The shared artifact PUBLISH path (`_publish_artifact` / `artifactHtml`) is untouched.**
- Remove the `artifact:` tier from deploy values and the `"artifact"` ACL default grant; the default tier already carries what artifact builds need (`SEARXNG_URL` etc.).
- Flip the `GoosecrackerSession` recipe default to `"agent"`; refresh stale docstrings/comments.

The `artifact-build` / `artifact-review` sub-recipes and the publish/serve path stay: **the agent still produces artifacts.**

## Scope

Monolith-only (chart `0.285.21`, no substrate/guest change). Net **-658 lines**. An Opus reviewer verified the agent-path `continue_session`/reply-gate surgery preserves behavior and the shared publish path is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)