### PR TITLE
feat(chat): record ambient reply id for exact reaction linking

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.22
+version: 0.285.23
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260705010000_attention_decision_reply_message_id.sql
+++ b/projects/monolith/chart/migrations/20260705010000_attention_decision_reply_message_id.sql
@@ -1,0 +1,9 @@
+-- Record the discord id of the reply Bosun sends for an ambient engage, so the
+-- /improve-ambient loop can join an engagement to its reply (and thus to
+-- reaction_event rows) exactly, instead of guessing by a time window. Nullable:
+-- backfills forward from this migration, and stays null for the agent-thread
+-- path (which has no single in-channel reply).
+ALTER TABLE chat.attention_decision
+    ADD COLUMN IF NOT EXISTS reply_message_id TEXT;
+CREATE INDEX IF NOT EXISTS attention_decision_reply_message_idx
+    ON chat.attention_decision (reply_message_id);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:DK3tC0lgk7ACY6Z6z/gK0HkC2DvyYM58vSmMWu3/+Sw=
+h1:YCn/uXrssR4N/cZ3V2dIap1BS4HQ0zFuPRo4dTEyz0k=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -99,3 +99,4 @@ h1:DK3tC0lgk7ACY6Z6z/gK0HkC2DvyYM58vSmMWu3/+Sw=
 20260704203000_chat_reminder.sql h1:Rm7UZ7yhiYgaS5txOFa+uh6oWF1fAmdgvk12BqfH8jA=
 20260704210000_directive_proposal_outbox_kind.sql h1:QxDEAtMyvV0386GJSwG5muHfBJfj4E+n0qVlGlMV384=
 20260705000000_chat_reaction_event.sql h1:3MvdfW0S6G5QhFVKPoz+w5/i5caQF4fXcYL2wUIAVTs=
+20260705010000_attention_decision_reply_message_id.sql h1:8jB2RoxsYtgV3IPxel0tV8PUg2IZtZwwrUBdUiDyHK4=

--- a/projects/monolith/chat/attention_log.py
+++ b/projects/monolith/chat/attention_log.py
@@ -11,7 +11,7 @@ import logging
 import os
 import random
 
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app.db import get_engine
 from chat.models import AttentionDecision
@@ -56,3 +56,33 @@ def log_decision(
             session.commit()
     except Exception:
         logger.exception("attention: failed to log decision")
+
+
+def set_reply_message(
+    channel_id: object, trigger_message_id: object, reply_message_id: object
+) -> None:
+    """Attach the bot reply's discord id to the most recent engage decision for
+    this trigger message, so reactions on the reply join back to the engage.
+
+    Matched by channel_id + message_id + decision='engage', newest first. No-op
+    if there is no engage row (e.g. a non-ambient reply, or an engage whose
+    ignore was sampled out). Synchronous (opens its own session); call via
+    ``asyncio.to_thread`` from the bot's async handlers. Best-effort: never
+    raises into the caller, since a logging failure should not block a reply.
+    """
+    try:
+        with Session(get_engine()) as session:
+            row = session.exec(
+                select(AttentionDecision)
+                .where(AttentionDecision.channel_id == str(channel_id))
+                .where(AttentionDecision.message_id == str(trigger_message_id))
+                .where(AttentionDecision.decision == "engage")
+                .order_by(AttentionDecision.id.desc())
+            ).first()
+            if row is None:
+                return
+            row.reply_message_id = str(reply_message_id)
+            session.add(row)
+            session.commit()
+    except Exception:
+        logger.exception("attention: failed to set reply message")

--- a/projects/monolith/chat/attention_log_test.py
+++ b/projects/monolith/chat/attention_log_test.py
@@ -75,6 +75,61 @@ class TestLogDecision:
         assert row.message_id == "222"
 
 
+class TestSetReplyMessage:
+    def test_updates_latest_engage_row(self, engine):
+        with patch("chat.attention_log.get_engine", return_value=engine):
+            attention_log.log_decision("c1", "m1", "engage", 0.9, _rng=lambda: 0.0)
+            attention_log.set_reply_message("c1", "m1", "reply1")
+        with Session(engine) as session:
+            row = session.exec(select(AttentionDecision)).one()
+        assert row.reply_message_id == "reply1"
+
+    def test_picks_newest_engage_for_trigger(self, engine):
+        with patch("chat.attention_log.get_engine", return_value=engine):
+            attention_log.log_decision("c1", "m1", "engage", 0.9, _rng=lambda: 0.0)
+            attention_log.log_decision("c1", "m1", "engage", 0.9, _rng=lambda: 0.0)
+            attention_log.set_reply_message("c1", "m1", "reply1")
+        with Session(engine) as session:
+            rows = session.exec(
+                select(AttentionDecision).order_by(AttentionDecision.id)
+            ).all()
+        # Only the newest engage row (highest id) is linked.
+        assert rows[0].reply_message_id is None
+        assert rows[1].reply_message_id == "reply1"
+
+    def test_noop_when_no_engage_row(self, engine):
+        with patch("chat.attention_log.get_engine", return_value=engine):
+            # An ignore row exists for the trigger, but no engage: no-op.
+            attention_log.log_decision("c1", "m1", "ignore", 0.1, _rng=lambda: 0.0)
+            attention_log.set_reply_message("c1", "m1", "reply1")
+        with Session(engine) as session:
+            row = session.exec(select(AttentionDecision)).one()
+        assert row.reply_message_id is None
+
+    def test_updates_only_matching_channel_and_trigger(self, engine):
+        with patch("chat.attention_log.get_engine", return_value=engine):
+            attention_log.log_decision("c1", "m1", "engage", 0.9, _rng=lambda: 0.0)
+            attention_log.log_decision("c2", "m1", "engage", 0.9, _rng=lambda: 0.0)
+            attention_log.log_decision("c1", "m2", "engage", 0.9, _rng=lambda: 0.0)
+            attention_log.set_reply_message("c1", "m1", "reply1")
+        with Session(engine) as session:
+            rows = {
+                (r.channel_id, r.message_id): r.reply_message_id
+                for r in session.exec(select(AttentionDecision)).all()
+            }
+        assert rows[("c1", "m1")] == "reply1"
+        assert rows[("c2", "m1")] is None
+        assert rows[("c1", "m2")] is None
+
+    def test_ids_are_stringified(self, engine):
+        with patch("chat.attention_log.get_engine", return_value=engine):
+            attention_log.log_decision(111, 222, "engage", 0.9, _rng=lambda: 0.0)
+            attention_log.set_reply_message(111, 222, 333)
+        with Session(engine) as session:
+            row = session.exec(select(AttentionDecision)).one()
+        assert row.reply_message_id == "333"
+
+
 class TestDecisionCheckConstraint:
     def test_rejects_invalid_decision(self, engine):
         with Session(engine) as session:

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -1492,7 +1492,23 @@ class ChatBot(discord.Client):
             # ADR 036: routed to chat, so reply to the triggering message rather
             # than opening a session thread.
             try:
-                await message.reply(outcome.chat_reply)
+                sent = await message.reply(outcome.chat_reply)
+                # Link this in-channel reply to the ambient engage decision so a
+                # reaction on it joins to the engage exactly (ADR 035 /
+                # improve-ambient). The thread-opening path has no single
+                # in-channel reply, so it stays null. Best-effort.
+                try:
+                    await asyncio.to_thread(
+                        attention_log.set_reply_message,
+                        str(channel.id),
+                        str(message.id),
+                        str(sent.id),
+                    )
+                except Exception:
+                    logger.exception(
+                        "attention: failed to record agent reply id for %s",
+                        message.id,
+                    )
             except discord.HTTPException:
                 logger.exception("orchestrator: failed to send chat reply")
         elif outcome.thread is None and explicit:
@@ -1598,6 +1614,25 @@ class ChatBot(discord.Client):
                 )
         except Exception:
             logger.exception("Failed to store bot response for message %s", msg_id)
+
+        # Link this reply back to the ambient engage decision (ADR 035 /
+        # improve-ambient), so a reaction on the reply joins to the engage
+        # exactly rather than by a time window. Only the ambient path
+        # (force_respond) has an engage row to attach to; a normal mention/reply
+        # has none, so guard on force_respond. Best-effort: never block the
+        # reply on a bookkeeping failure.
+        if force_respond:
+            try:
+                await asyncio.to_thread(
+                    attention_log.set_reply_message,
+                    channel_id,
+                    str(message.id),
+                    str(sent.id),
+                )
+            except Exception:
+                logger.exception(
+                    "attention: failed to record reply id for message %s", msg_id
+                )
 
         with Session(get_engine()) as session:
             store = MessageStore(session=session, embed_client=self.embed_client)

--- a/projects/monolith/chat/bot_on_message_test.py
+++ b/projects/monolith/chat/bot_on_message_test.py
@@ -680,6 +680,115 @@ class TestAttentionGate:
             mock_proc.assert_called_once_with(message)
 
 
+class TestAmbientReplyIdRecorded:
+    """The ambient in-channel reply's discord id is linked back to the engage
+    decision (PR 1.5 of /improve-ambient), so a reaction on the reply joins to
+    the engage exactly rather than by a time window."""
+
+    @pytest.fixture(name="engine")
+    def engine_fixture(self):
+        engine = create_engine(
+            "sqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        original_schemas = {}
+        for table in SQLModel.metadata.tables.values():
+            if table.schema is not None:
+                original_schemas[table.name] = table.schema
+                table.schema = None
+        SQLModel.metadata.create_all(engine)
+        yield engine
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+    @pytest.mark.asyncio
+    async def test_process_message_links_reply_to_engage(self, engine):
+        """_process_message(force_respond=True) records the delivered reply's id
+        on the newest engage row for the trigger message."""
+        from chat import attention_log
+        from chat.models import AttentionDecision
+
+        bot = _make_bot()
+        message = _make_message(
+            content="what's a good name for a boat?", channel_id=99, msg_id=7
+        )
+        message.reference = None
+
+        # Seed the engage decision on_message would have logged for this trigger.
+        with patch("chat.attention_log.get_engine", return_value=engine):
+            attention_log.log_decision("99", "7", "engage", 0.9, _rng=lambda: 0.0)
+
+        mock_store = _make_store()
+        sent = MagicMock(id=100)
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+            patch("chat.attention_log.get_engine", return_value=engine),
+            patch.object(
+                bot,
+                "_stream_response",
+                AsyncMock(return_value=(sent, "The SS Anytime", None)),
+            ),
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot._process_message(message, force_respond=True)
+
+        with Session(engine) as session:
+            row = session.exec(select(AttentionDecision)).one()
+        assert row.reply_message_id == "100"
+
+    @pytest.mark.asyncio
+    async def test_non_ambient_reply_does_not_link(self, engine):
+        """A normal (non-force_respond) reply has no engage row and must not
+        attempt to record a reply id, so the seeded ignore row stays untouched."""
+        from chat import attention_log
+        from chat.models import AttentionDecision
+
+        bot = _make_bot()
+        bot._connection.user.id = 999
+        bot_user = bot.user
+        message = _make_message(
+            content="Hey bot!", channel_id=99, msg_id=7, mentions=[bot_user]
+        )
+        message.reference = None
+
+        with patch("chat.attention_log.get_engine", return_value=engine):
+            attention_log.log_decision("99", "7", "ignore", 0.1, _rng=lambda: 0.0)
+
+        mock_store = _make_store()
+        sent = MagicMock(id=100)
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+            patch("chat.attention_log.get_engine", return_value=engine),
+            patch("chat.bot.attention_log.set_reply_message") as mock_set_reply,
+            patch.object(
+                bot,
+                "_stream_response",
+                AsyncMock(return_value=(sent, "Hi there", None)),
+            ),
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot._process_message(message, force_respond=False)
+
+        mock_set_reply.assert_not_called()
+        with Session(engine) as session:
+            row = session.exec(select(AttentionDecision)).one()
+        assert row.reply_message_id is None
+
+
 class TestRecentlyTagged:
     """ChatBot._recently_tagged: recent-tag weighting for the attention gate."""
 

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -282,6 +282,7 @@ class AttentionDecision(SQLModel, table=True):
     decision: str = Field(default="ignore")
     confidence: float = Field(default=0.0)
     directive_version: int = Field(default=0)
+    reply_message_id: str | None = Field(default=None)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.22
+      targetRevision: 0.285.23
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

Part of the `/improve-ambient` program. Adds a nullable `chat.attention_decision.reply_message_id` and populates it with the discord id of the reply Bosun sends for an ambient engage. This turns episode -> reply -> reaction linking from a time-window heuristic into an exact join (`reaction_event.message_id = attention_decision.reply_message_id`).

## Why

`attention_decision` logged only the human trigger message, not the reply it produced, so the feedback loop could only guess which reply (and its reactions) belonged to an engage. We already hold the sent message object at reply time, so recording its id is cheap and makes the signal exact going forward.

## Changes

- Migration `20260705010000_attention_decision_reply_message_id.sql`: nullable column + index.
- `AttentionDecision.reply_message_id` model field.
- `attention_log.set_reply_message(channel_id, trigger_message_id, reply_message_id)`: updates the newest engage row for that trigger (no-op if none), own session, best-effort.
- Populate calls in `chat/bot.py`: the ambient `_process_message` reply (same message saved to `chat.messages`) and the `_engage_agent` in-channel `chat_reply`. The agent thread-opening path has no single in-channel reply, so it stays null and the loop falls back to the temporal heuristic there (accrues forward, same model as `reaction_event`).
- Tests + chart bump 0.285.22 -> 0.285.23.

## Review

Opus-reviewed: match-key alignment, ambient-only guarding, async/session safety, and discriminating tests all confirmed. Known minor edges (no `_engage_agent` bot-path test; sweep/reprocess path records nothing) noted as non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)