### PR TITLE
feat(grimoire): safe metadata-only section_hierarchy backfill job

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -3025,6 +3025,19 @@ py_test(
 )
 
 py_test(
+    name = "grimoire_hierarchy_backfill_test",
+    srcs = ["grimoire/hierarchy_backfill_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "ships_models_test",
     srcs = ["ships/models_test.py"],
     imports = ["."],

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -236,6 +236,22 @@ def grimoire_extract_entities() -> None:
     _run_job("grimoire-extract-entities", "grimoire.jobs", "grimoire_extract_entities")
 
 
+@app.command("grimoire-backfill-hierarchy")
+def grimoire_backfill_hierarchy() -> None:
+    """Backfill section_hierarchy onto already-loaded grimoire chunks.
+
+    One-shot of the metadata-only hierarchy backfill: re-runs marker chunking
+    over each book's archived raw output.json and writes ONLY the
+    section_hierarchy column of matching (book_id, chunk_ref) rows. Never inserts
+    a chunk and never re-embeds. Needs the same env as grimoire-load-chunks (S3
+    env + GRIMOIRE_S3_BUCKET, injected by the cronWorkflows `grimoire: true`
+    flag). Set GRIMOIRE_BACKFILL_BOOK to scope to a single book for a safe verify
+    run; unset processes every book with loaded chunks."""
+    _run_job(
+        "grimoire-backfill-hierarchy", "grimoire.jobs", "grimoire_backfill_hierarchy"
+    )
+
+
 @app.command("stars-load-grid")
 def stars_load_grid() -> None:
     """Reload the stars site grid from S3 (one-shot of stars.load_grid)."""

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.26
+version: 0.285.27
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -582,6 +582,36 @@ jobs:
           memory: 1Gi
         limits:
           memory: 1Gi
+    # grimoire.backfill_hierarchy: one-off metadata backfill (NOT a re-load). Some
+    # books were loaded before marker.py emitted section_hierarchy, so their rows
+    # have it NULL. This re-runs marker's chunking over each book's archived raw
+    # output.json and writes ONLY the section_hierarchy column of matching
+    # (book_id, chunk_ref) rows: it never inserts a chunk and never re-embeds, so
+    # it is cheap and safe to re-run. Reuses the same `grimoire: true` env as the
+    # loader (S3 env + GRIMOIRE_S3_BUCKET + DATABASE_URL). Ships SUSPENDED
+    # (manual-only): submit by hand with
+    #   argo submit --from cronworkflow/grimoire-backfill-hierarchy -n monolith-workflows
+    # To scope to ONE book for a safe verify run first, set GRIMOIRE_BACKFILL_BOOK
+    # below to the book id (e.g. "monster-manual"), deploy, submit, then revert to
+    # "" (empty = every book with loaded chunks). The inert yearly schedule is
+    # belt-and-suspenders.
+    - name: grimoire-backfill-hierarchy
+      args: ["grimoire-backfill-hierarchy"]
+      schedule: "0 0 1 1 *" # inert; suspended, manual-only
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 1800
+      suspend: true
+      grimoire: true
+      env:
+        # Empty = backfill every book with loaded chunks. Set to a single book id
+        # for a scoped verify run, then revert to "".
+        GRIMOIRE_BACKFILL_BOOK: ""
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
 
 frontend:
   otelCollectorUrl: ""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.26
+      targetRevision: 0.285.27
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/grimoire/hierarchy_backfill_test.py
+++ b/projects/monolith/grimoire/hierarchy_backfill_test.py
@@ -1,0 +1,202 @@
+"""Tests for the grimoire section_hierarchy backfill sync core.
+
+Covers ``grimoire.jobs._apply_hierarchy_updates``: given a
+``{chunk_ref: section_hierarchy}`` map and pre-seeded chunks, it must update
+section_hierarchy ONLY for matching chunk_refs, leave non-matching rows
+untouched, insert nothing, and touch no other column (content/section_path/seq).
+Uses the SQLite ``create_all`` fixture (no migrations), mirroring ingest_test.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+from grimoire import jobs
+from grimoire.models import KnowledgeChunk
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    # The models declare a Postgres schema; strip it so SQLite create_all works,
+    # then restore (mirrors grimoire/ingest_test.py).
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def _seed(session: Session, rows: list[dict]) -> None:
+    session.add_all(
+        KnowledgeChunk(
+            book_id=r["book_id"],
+            chunk_ref=r["chunk_ref"],
+            content=r["content"],
+            section_path=r.get("section_path"),
+            section_hierarchy=r.get("section_hierarchy"),
+            seq=r.get("seq", 0),
+        )
+        for r in rows
+    )
+    session.commit()
+
+
+def _by_ref(session: Session, book_id: str) -> dict[str, KnowledgeChunk]:
+    return {
+        c.chunk_ref: c
+        for c in session.execute(
+            select(KnowledgeChunk).where(KnowledgeChunk.book_id == book_id)
+        )
+        .scalars()
+        .all()
+    }
+
+
+def test_updates_only_matching_chunk_refs(session: Session):
+    _seed(
+        session,
+        [
+            {"book_id": "phb", "chunk_ref": "a", "content": "A", "seq": 0},
+            {"book_id": "phb", "chunk_ref": "b", "content": "B", "seq": 1},
+            {"book_id": "phb", "chunk_ref": "c", "content": "C", "seq": 2},
+        ],
+    )
+
+    # Map covers a and b; c is absent (its boundary shifted) and stays NULL.
+    matched, updated = jobs._apply_hierarchy_updates(
+        session,
+        "phb",
+        {"a": "Chapter 1 > Section > A", "b": "Chapter 1 > Section > B"},
+    )
+    session.commit()
+
+    assert (matched, updated) == (2, 2)
+    rows = _by_ref(session, "phb")
+    assert rows["a"].section_hierarchy == "Chapter 1 > Section > A"
+    assert rows["b"].section_hierarchy == "Chapter 1 > Section > B"
+    assert rows["c"].section_hierarchy is None
+
+
+def test_leaves_other_columns_untouched(session: Session):
+    _seed(
+        session,
+        [
+            {
+                "book_id": "phb",
+                "chunk_ref": "a",
+                "content": "original content",
+                "section_path": "Chapter 1/A",
+                "seq": 7,
+            },
+        ],
+    )
+
+    jobs._apply_hierarchy_updates(session, "phb", {"a": "Chapter 1 > A"})
+    session.commit()
+
+    row = _by_ref(session, "phb")["a"]
+    assert row.section_hierarchy == "Chapter 1 > A"
+    # Only section_hierarchy changed; everything else is exactly as seeded.
+    assert row.content == "original content"
+    assert row.section_path == "Chapter 1/A"
+    assert row.seq == 7
+
+
+def test_never_inserts_unmatched_refs(session: Session):
+    _seed(
+        session,
+        [{"book_id": "phb", "chunk_ref": "a", "content": "A", "seq": 0}],
+    )
+
+    # Map references chunk_refs that do not exist for this book: nothing inserted.
+    matched, updated = jobs._apply_hierarchy_updates(
+        session, "phb", {"ghost1": "X", "ghost2": "Y"}
+    )
+    session.commit()
+
+    assert (matched, updated) == (0, 0)
+    all_rows = session.execute(select(KnowledgeChunk)).scalars().all()
+    assert {r.chunk_ref for r in all_rows} == {"a"}
+
+
+def test_scopes_to_book_id(session: Session):
+    _seed(
+        session,
+        [
+            {"book_id": "phb", "chunk_ref": "shared", "content": "P", "seq": 0},
+            {"book_id": "dmg", "chunk_ref": "shared", "content": "D", "seq": 0},
+        ],
+    )
+
+    jobs._apply_hierarchy_updates(session, "phb", {"shared": "PHB hierarchy"})
+    session.commit()
+
+    assert _by_ref(session, "phb")["shared"].section_hierarchy == "PHB hierarchy"
+    # A same-named chunk_ref in another book is not touched.
+    assert _by_ref(session, "dmg")["shared"].section_hierarchy is None
+
+
+def test_idempotent_second_run_updates_nothing(session: Session):
+    _seed(
+        session,
+        [{"book_id": "phb", "chunk_ref": "a", "content": "A", "seq": 0}],
+    )
+    mapping = {"a": "Chapter 1 > A"}
+
+    first_matched, first_updated = jobs._apply_hierarchy_updates(
+        session, "phb", mapping
+    )
+    session.commit()
+    second_matched, second_updated = jobs._apply_hierarchy_updates(
+        session, "phb", mapping
+    )
+    session.commit()
+
+    assert (first_matched, first_updated) == (1, 1)
+    # Already at the target value (IS DISTINCT FROM): matched again, updated none.
+    assert (second_matched, second_updated) == (1, 0)
+
+
+def test_can_clear_to_null_when_raw_has_no_hierarchy(session: Session):
+    _seed(
+        session,
+        [
+            {
+                "book_id": "phb",
+                "chunk_ref": "a",
+                "content": "A",
+                "section_hierarchy": "stale value",
+                "seq": 0,
+            }
+        ],
+    )
+
+    matched, updated = jobs._apply_hierarchy_updates(session, "phb", {"a": None})
+    session.commit()
+
+    assert (matched, updated) == (1, 1)
+    assert _by_ref(session, "phb")["a"].section_hierarchy is None
+
+
+def test_empty_map_is_noop(session: Session):
+    _seed(
+        session,
+        [{"book_id": "phb", "chunk_ref": "a", "content": "A", "seq": 0}],
+    )
+
+    assert jobs._apply_hierarchy_updates(session, "phb", {}) == (0, 0)

--- a/projects/monolith/grimoire/jobs.py
+++ b/projects/monolith/grimoire/jobs.py
@@ -22,14 +22,23 @@ private-tier only).
 
 from __future__ import annotations
 
+import asyncio
+import gzip
+import json
 import logging
 import os
 
-from sqlmodel import Session
+from sqlmodel import Session, select
+
+from grimoire.models import KnowledgeChunk
 
 logger = logging.getLogger("monolith.grimoire.jobs")
 
 DEFAULT_BUCKET = "grimoire"
+# Books live under ``books/<book_id>/`` in the grimoire bucket; the verbatim
+# Marker extraction is archived under ``raw/`` (see grimoire/tools/upload-book.sh)
+# as a gzipped ``output.json``. Mirrors ingest.DEFAULT_PREFIX.
+_BOOKS_PREFIX = "books/"
 DEFAULT_EXTRACT_LIMIT = 25
 # Concurrent extract calls; kept below vLLM --max-num-seqs (8) so this bulk job
 # leaves decode-slot headroom for trusted interactive callers. See
@@ -144,4 +153,235 @@ async def grimoire_extract_entities(session: Session) -> None:
         session, or_client, embed_client, limit=limit, concurrency=concurrency
     )
     logger.info("grimoire_extract_entities done: %s", summary)
+    return None
+
+
+# --- section_hierarchy backfill (spec: metadata-only, chunk_ref-keyed) --------
+#
+# ``section_hierarchy`` is extraction-context metadata that marker.py only
+# started emitting into the chunks NDJSON after the 33 existing books were
+# uploaded, so their loaded rows have it NULL. This backfill recomputes the
+# ``{chunk_ref: section_hierarchy}`` map by re-running marker's EXISTING chunking
+# (grimoire.marker.to_chunks) over each book's archived raw ``output.json`` and
+# writes ONLY the section_hierarchy column onto the already-loaded chunks, keyed
+# on (book_id, chunk_ref). It NEVER inserts a chunk, never touches
+# content/embedding/mentions/relationships/extraction markers, and never
+# re-embeds: a chunk whose chunk_ref no longer matches (a since-fixed section
+# boundary shifted it) is simply left untouched. Re-running marker+reload would
+# be unsafe precisely because a shifted chunk_ref would CREATE a new chunk and
+# re-embed; keying the UPDATE on chunk_ref makes the backfill a cheap metadata
+# write instead.
+
+
+def _find_raw_output_key(s3_client, bucket: str, book_id: str) -> str | None:
+    """Locate a book's archived Marker ``output.json`` under ``books/<id>/raw/``.
+
+    The uploader gzips it to ``output.json.gz`` (grimoire/tools/upload-book.sh),
+    but tolerate an uncompressed ``output.json`` too; prefer the gzipped one when
+    both exist. Lists with the same paginated ``list_objects_v2`` pattern
+    ingest.py uses. Returns the S3 key or ``None`` if no raw extraction is found.
+    """
+    prefix = f"{_BOOKS_PREFIX}{book_id}/raw/"
+    gz_key: str | None = None
+    plain_key: str | None = None
+    continuation_token: str | None = None
+    while True:
+        kwargs: dict[str, str] = {"Bucket": bucket, "Prefix": prefix}
+        if continuation_token:
+            kwargs["ContinuationToken"] = continuation_token
+        resp = s3_client.list_objects_v2(**kwargs)
+        for obj in resp.get("Contents", []):
+            key = obj["Key"]
+            base = key.rsplit("/", 1)[-1]
+            if base == "output.json.gz":
+                gz_key = key
+            elif base == "output.json":
+                plain_key = key
+        if resp.get("IsTruncated"):
+            continuation_token = resp.get("NextContinuationToken")
+        else:
+            break
+    return gz_key or plain_key
+
+
+def _read_raw_doc(s3_client, bucket: str, book_id: str) -> dict | None:
+    """Read + parse a book's raw Marker ``output.json`` (gunzipping if needed).
+
+    Returns the JSONOutput dict, or ``None`` when the book has no archived raw
+    extraction (older/manually-loaded books) so the caller can skip it.
+    """
+    key = _find_raw_output_key(s3_client, bucket, book_id)
+    if not key:
+        return None
+    body = s3_client.get_object(Bucket=bucket, Key=key)["Body"].read()
+    if key.endswith(".gz"):
+        body = gzip.decompress(body)
+    if isinstance(body, bytes):
+        body = body.decode("utf-8")
+    return json.loads(body)
+
+
+def _hierarchy_map_from_doc(
+    doc: dict, bucket: str, book_id: str
+) -> dict[str, str | None]:
+    """Build ``{chunk_ref: section_hierarchy}`` by re-running marker's chunking.
+
+    Uses the SAME entrypoint the loader's manifests were produced with
+    (grimoire.marker.to_chunks with the identical image_key_prefix), so chunk_ref
+    is computed identically and matches the already-loaded rows. Chunking output
+    is otherwise discarded: only chunk_ref + section_hierarchy are read.
+    """
+    from grimoire import marker
+
+    image_key_prefix = f"s3://{bucket}/{_BOOKS_PREFIX}{book_id}/raw/img/"
+    chunks = marker.to_chunks(doc, image_key_prefix=image_key_prefix)
+    mapping: dict[str, str | None] = {}
+    for chunk in chunks:
+        chunk_ref = chunk.get("chunk_ref")
+        if chunk_ref:
+            mapping[chunk_ref] = chunk.get("section_hierarchy")
+    return mapping
+
+
+def _apply_hierarchy_updates(
+    session: Session, book_id: str, hierarchy_by_ref: dict[str, str | None]
+) -> tuple[int, int]:
+    """Sync core: write ONLY section_hierarchy onto existing (book_id, chunk_ref)
+    rows. Returns ``(chunk_ref_matched, updated)``; does not commit (the caller
+    owns the per-book commit so tests can drive it directly).
+
+    Selects the already-loaded chunks whose chunk_ref is in the map and mutates
+    section_hierarchy in place only when it actually differs (``IS DISTINCT
+    FROM`` semantics, NULL-safe in Python). Rows are already session-tracked from
+    the SELECT, so the mutation flushes on commit with no ``session.add`` and no
+    per-row ``session.execute`` (semgrep session-add-in-loop). No row is ever
+    inserted: a chunk_ref present in the map but absent from the table (a shifted
+    boundary) simply does not appear in ``rows`` and is skipped. No other column,
+    embedding, or extraction marker is touched.
+    """
+    if not hierarchy_by_ref:
+        return 0, 0
+    rows = list(
+        session.execute(
+            select(KnowledgeChunk).where(
+                KnowledgeChunk.book_id == book_id,
+                KnowledgeChunk.chunk_ref.in_(list(hierarchy_by_ref)),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    updated = 0
+    for row in rows:
+        new_hierarchy = hierarchy_by_ref[row.chunk_ref]
+        if row.section_hierarchy != new_hierarchy:
+            row.section_hierarchy = new_hierarchy
+            updated += 1
+    return len(rows), updated
+
+
+def _persist_book_hierarchy(
+    book_id: str, hierarchy_by_ref: dict[str, str | None]
+) -> tuple[int, int]:
+    """Open a fresh session, apply one book's hierarchy updates, and commit.
+
+    Runs off the event loop via ``asyncio.to_thread`` (so it owns its own
+    session, never the scheduler's), committing per book for incremental
+    durability. Delegates the testable write to ``_apply_hierarchy_updates``.
+    """
+    from app.db import get_engine
+
+    with Session(get_engine()) as session:
+        matched, updated = _apply_hierarchy_updates(session, book_id, hierarchy_by_ref)
+        session.commit()
+    return matched, updated
+
+
+def _distinct_book_ids(only_book: str | None) -> list[str]:
+    """Book ids to backfill: the single scoped book, or every book with chunks.
+
+    ``GRIMOIRE_BACKFILL_BOOK`` (via ``only_book``) scopes to one book for a safe
+    single-book verify run. Otherwise reads the distinct book_ids straight off
+    knowledge_chunk in a fresh session so only books that actually have loaded
+    chunks are processed.
+    """
+    if only_book:
+        return [only_book]
+    from app.db import get_engine
+
+    with Session(get_engine()) as session:
+        book_ids = (
+            session.execute(select(KnowledgeChunk.book_id).distinct()).scalars().all()
+        )
+    return sorted(book_ids)
+
+
+async def grimoire_backfill_hierarchy(session: Session) -> None:
+    """Backfill section_hierarchy onto already-loaded chunks (metadata-only).
+
+    For each book (all books with chunks, or the single ``GRIMOIRE_BACKFILL_BOOK``
+    for a scoped verify): read its archived raw Marker ``output.json`` from S3,
+    re-run marker's chunking to recompute ``{chunk_ref: section_hierarchy}``, and
+    UPDATE only the section_hierarchy column of matching (book_id, chunk_ref)
+    rows. Never inserts a chunk, never re-embeds, never touches any other column
+    or the extraction markers. S3 reads happen here in the async handler; every
+    Session write is delegated to ``asyncio.to_thread`` with a fresh session
+    (monolith async-handler rule), committing per book. Returns None so the
+    scheduler advances by the configured interval.
+    """
+    from grimoire.ingest import build_s3_client
+
+    bucket = os.environ.get("GRIMOIRE_S3_BUCKET", DEFAULT_BUCKET)
+    only_book = os.environ.get("GRIMOIRE_BACKFILL_BOOK") or None
+    s3_client = build_s3_client()
+
+    book_ids = await asyncio.to_thread(_distinct_book_ids, only_book)
+    logger.info(
+        "grimoire_backfill_hierarchy: %d book(s) to process%s",
+        len(book_ids),
+        f" (scoped to {only_book!r})" if only_book else "",
+    )
+
+    total_chunks_in_raw = 0
+    total_matched = 0
+    total_updated = 0
+    books_processed = 0
+    books_skipped = 0
+
+    for book_id in book_ids:
+        doc = _read_raw_doc(s3_client, bucket, book_id)
+        if doc is None:
+            logger.warning(
+                "grimoire_backfill_hierarchy: no raw output.json for %s, skipping",
+                book_id,
+            )
+            books_skipped += 1
+            continue
+
+        hierarchy_by_ref = _hierarchy_map_from_doc(doc, bucket, book_id)
+        chunks_in_raw = len(hierarchy_by_ref)
+        matched, updated = await asyncio.to_thread(
+            _persist_book_hierarchy, book_id, hierarchy_by_ref
+        )
+        logger.info(
+            "grimoire_backfill_hierarchy: %s chunks_in_raw=%d chunk_ref_matched=%d "
+            "updated=%d",
+            book_id,
+            chunks_in_raw,
+            matched,
+            updated,
+        )
+        total_chunks_in_raw += chunks_in_raw
+        total_matched += matched
+        total_updated += updated
+        books_processed += 1
+
+    summary = {
+        "books_processed": books_processed,
+        "books_skipped": books_skipped,
+        "chunks_in_raw": total_chunks_in_raw,
+        "chunk_ref_matched": total_matched,
+        "updated": total_updated,
+    }
+    logger.info("grimoire_backfill_hierarchy done: %s", summary)
     return None


### PR DESCRIPTION
## Problem

`grimoire.knowledge_chunk.section_hierarchy` is 0/40k populated. `marker.py` only started writing `section_hierarchy` into the chunks NDJSON after the 33 existing books were uploaded, so their loaded rows have it NULL.

## Why not re-chunk + reload

Unsafe. `marker.py`'s chunking changed since upload (a section-boundary fix, deferred for monster-manual), so a fresh run can shift chunk boundaries, produce new `chunk_ref`s, and make the loader CREATE new chunks, re-embed them (hours), and orphan old ones while invalidating `chunk_extraction` markers.

## Approach (metadata-only, chunk_ref-keyed)

New jobs subcommand `grimoire-backfill-hierarchy`, per book:

1. Reads the archived raw Marker `output.json` from `s3://<bucket>/books/<book_id>/raw/output.json[.gz]` (reuses `ingest.build_s3_client()` and the same paginated `list_objects_v2` pattern; gunzips).
2. Re-runs marker's EXISTING chunking (`grimoire.marker.to_chunks` with the identical `image_key_prefix`) so `chunk_ref` is computed identically, and builds a `{chunk_ref: section_hierarchy}` map.
3. Writes ONLY the `section_hierarchy` column onto matching `(book_id, chunk_ref)` rows (`IS DISTINCT FROM` semantics). Never INSERTs a chunk, never re-embeds, never touches content / embedding / mentions / relationships / extraction markers. Boundary-shifted chunks (chunk_ref no longer matches) are simply left untouched.
4. Commits per book (incremental durability).

Follows the monolith async-handler rule: S3 reads in the async handler; all Session I/O delegated to `asyncio.to_thread` with a fresh session in a sync helper (no `session.add`/`execute` in a loop, tracked-row mutation only).

## Wiring

- `app/jobs_main.py`: `grimoire-backfill-hierarchy` subcommand via `_run_job`.
- `chart/values.yaml`: `jobs.cronWorkflows` entry, `suspend: true` (manual-only, inert yearly schedule), `activeDeadlineSeconds: 1800`, reusing the loader's `grimoire: true` env (S3 creds, `GRIMOIRE_S3_BUCKET`, `DATABASE_URL`). `GRIMOIRE_BACKFILL_BOOK` (empty default) scopes to one book for a safe verify run.
- Chart bumped 0.285.26 -> 0.285.27.

## Trigger

Suspended CronWorkflow, submit by hand:

```
argo submit --from cronworkflow/grimoire-backfill-hierarchy -n monolith-workflows
```

Scope to one book for a safe verify run first: set `GRIMOIRE_BACKFILL_BOOK` on the entry to the book id (e.g. `monster-manual`), deploy, submit, then revert to `""` (empty = every book with loaded chunks).

## Tests

`grimoire/hierarchy_backfill_test.py` (SQLite create_all, hand-added `py_test` target) covers the sync core `_apply_hierarchy_updates`: updates only matching chunk_refs, leaves non-matching untouched, inserts nothing, touches no other column, is idempotent, scopes by book_id, and can clear a stale value to NULL.

## Verification

- `helm template` renders the new CronWorkflow with the full env block (`DATABASE_URL`, `GRIMOIRE_BACKFILL_BOOK`, S3 creds, `GRIMOIRE_S3_BUCKET`, `EMBEDDING_URL`).
- Formatter + gazelle clean; local semgrep pre-push passed; `py_compile` clean.

Do not merge yet: for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4SN3nVxYECUdX2gSCFCxD