### PR TITLE
fix(firecracker): keep matplotlib font cache out of sandbox output files

### DIFF
--- a/projects/firecracker/sandbox/guest-init/cmd/main.go
+++ b/projects/firecracker/sandbox/guest-init/cmd/main.go
@@ -48,6 +48,18 @@ func run(logger *slog.Logger) error {
 	// request.
 	_ = os.Setenv("PATH", "/usr/bin:/bin:/usr/local/bin")
 
+	// matplotlib's config/cache dir, shared by the warm-import below and every
+	// per-request exec (handler.MPLConfigDir). Created world-writable (0777)
+	// because warm-import runs as root here but per-request python runs as the
+	// dropped uid 65532; both must be able to (re)write the font cache. It
+	// lives on the /tmp tmpfs so it is captured in the warm-base snapshot.
+	_ = os.Setenv("MPLCONFIGDIR", handler.MPLConfigDir)
+	if err := os.MkdirAll(handler.MPLConfigDir, 0o777); err != nil {
+		logger.Warn("could not create MPLCONFIGDIR; matplotlib will fall back and may leak a font cache into workdirs", "err", err)
+	} else {
+		_ = os.Chmod(handler.MPLConfigDir, 0o777)
+	}
+
 	warmImports(logger)
 
 	// The warm-base snapshot (ADR 022) is taken once /shim/ready first
@@ -90,8 +102,16 @@ func run(logger *slog.Logger) error {
 func warmImports(logger *slog.Logger) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
+	// Beyond importing, render one throwaway figure so matplotlib builds its
+	// font cache (fontlist.json) into MPLCONFIGDIR now, captured in the
+	// warm-base snapshot. Without an actual draw the cache is not built at
+	// import time, and the first real plot per guest would both scan fonts and
+	// write the cache into the request workdir.
 	cmd := exec.CommandContext(ctx, "python3", "-c",
-		"import numpy, pandas, matplotlib, matplotlib.pyplot, scipy, PIL, yaml, dateutil")
+		"import matplotlib; matplotlib.use('Agg'); "+
+			"import numpy, pandas, scipy, PIL, yaml, dateutil; "+
+			"import io, matplotlib.pyplot as plt; "+
+			"plt.plot([0, 1], [0, 1]); plt.savefig(io.BytesIO(), format='png')")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		logger.Warn("warm-import failed; guest still serves, just cold on the first request", "err", err, "out", string(out))
 		return

--- a/projects/firecracker/sandbox/guest-init/internal/handler/handler.go
+++ b/projects/firecracker/sandbox/guest-init/internal/handler/handler.go
@@ -40,6 +40,14 @@ const (
 	sandboxGID = 65532
 )
 
+// MPLConfigDir is matplotlib's config/cache directory, set as MPLCONFIGDIR on
+// every python exec. It sits on the /tmp tmpfs OUTSIDE any per-invoke workdir
+// so the font cache matplotlib builds is never collected as an output file.
+// cmd/main.go creates it and pre-populates the font cache during warm-import,
+// so the warm-base snapshot carries it and per-call plotting is both quiet and
+// fast (no first-use font scan).
+const MPLConfigDir = "/tmp/mplconfig"
+
 // dropPrivileges controls whether the python subprocess's Credential is set
 // to sandboxUID/sandboxGID. It defaults on: production always executes
 // untrusted code as uid 65532, never as the guest-init root process.
@@ -237,6 +245,13 @@ func runPython(ctx context.Context, workdir string, timeout time.Duration) ExecR
 		"MPLBACKEND=Agg",
 		"PYTHONUNBUFFERED=1",
 		"TMPDIR=" + workdir,
+		// Keep matplotlib's font cache OUT of the workdir. With HOME=workdir
+		// matplotlib would write $HOME/.cache/matplotlib/fontlist.json on
+		// first use, which collectOutputFiles then returns as a spurious
+		// ~36 KiB attachment on every plot. MPLConfigDir points at a dir the
+		// warm-base snapshot already pre-populated (main.go), so per-call
+		// matplotlib reads the cache from there and writes nothing here.
+		"MPLCONFIGDIR=" + MPLConfigDir,
 	}
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.39
+version: 0.4.40

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.39
+      targetRevision: 0.4.40
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
Small follow-up to ADR agents/044 PR B, found by live-testing the deployed sandbox.

## Problem
Every `run_python` call that touches matplotlib returned a spurious ~36KiB `.cache/matplotlib/fontlist.json` alongside the real output. Cause: the handler sets `HOME=workdir` (it must be writable), matplotlib writes its font cache to `$HOME/.cache/matplotlib/`, and `collectOutputFiles` walks the whole workdir. In Discord that means an unwanted JSON attachment on every chart, the most compelling use case.

## Fix
Point `MPLCONFIGDIR` at `/tmp/mplconfig` (outside any per-invoke workdir) and pre-build the font cache into the warm-base snapshot during warm-import (render one throwaway figure). Per-call matplotlib then reads the cache from there and writes nothing collectable, and also skips the first-use font scan so the first plot is faster.

Verified: `go build`/`vet` native + linux/arm64 clean. Live smoke test before this fix showed the font cache leaking; this removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)