### PR TITLE
feat(grimoire): v4 generic typed extraction (lore + gameplay + mechanics)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.28
+version: 0.285.29
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260705150000_grimoire_extraction_v4.sql
+++ b/projects/monolith/chart/migrations/20260705150000_grimoire_extraction_v4.sql
@@ -7,9 +7,12 @@
 -- No data backfill: existing rows compute `category` from their entity_type via
 -- the generated column, and fresh v4 extraction populates the rest.
 
--- Expand the entity_type CHECK to the full v4 taxonomy.
-ALTER TABLE grimoire.entity DROP CONSTRAINT entity_entity_type_chk;
-ALTER TABLE grimoire.entity ADD CONSTRAINT entity_entity_type_chk CHECK (
+-- Expand the entity_type CHECK to the full v4 taxonomy. The original inline
+-- column CHECK in 20260703070000_grimoire_schema.sql was unnamed, so Postgres
+-- auto-named it entity_entity_type_check (the "_check" convention, matching
+-- entity_source_type_check); drop and re-add under that same name.
+ALTER TABLE grimoire.entity DROP CONSTRAINT entity_entity_type_check;
+ALTER TABLE grimoire.entity ADD CONSTRAINT entity_entity_type_check CHECK (
     entity_type IN (
         -- lore (unchanged from v1)
         'creature', 'spell', 'location', 'npc', 'faction', 'deity', 'item',

--- a/projects/monolith/chart/migrations/20260705150000_grimoire_extraction_v4.sql
+++ b/projects/monolith/chart/migrations/20260705150000_grimoire_extraction_v4.sql
@@ -1,0 +1,46 @@
+-- Grimoire extraction v4: generic typed extraction (lore + gameplay + mechanics).
+-- Expands the entity_type set from the 7 lore types to ~18 (adds gameplay
+-- event/quest and the mechanics types), derives a stored `category` column from
+-- entity_type, adds a nullable `temporality` (set only for event/quest), and adds
+-- a generic `detail` JSONB for the new types that have no dedicated detail table.
+-- creature/location/npc/spell keep their existing typed detail tables unchanged.
+-- No data backfill: existing rows compute `category` from their entity_type via
+-- the generated column, and fresh v4 extraction populates the rest.
+
+-- Expand the entity_type CHECK to the full v4 taxonomy.
+ALTER TABLE grimoire.entity DROP CONSTRAINT entity_entity_type_chk;
+ALTER TABLE grimoire.entity ADD CONSTRAINT entity_entity_type_chk CHECK (
+    entity_type IN (
+        -- lore (unchanged from v1)
+        'creature', 'spell', 'location', 'npc', 'faction', 'deity', 'item',
+        -- gameplay
+        'event', 'quest',
+        -- mechanics
+        'condition', 'feat', 'race', 'background', 'class', 'subclass',
+        'class_feature', 'action', 'rule'
+    )
+);
+
+-- category is DERIVED from entity_type by a stored generated column, so it is
+-- always consistent regardless of write path. spell derives to 'lore'; the
+-- mechanics surface unions spell in at query time (category = 'mechanics' OR
+-- entity_type = 'spell'), not at the column level.
+ALTER TABLE grimoire.entity ADD COLUMN category TEXT
+    GENERATED ALWAYS AS (
+        CASE
+            WHEN entity_type IN (
+                'creature', 'spell', 'location', 'npc', 'faction', 'deity', 'item'
+            ) THEN 'lore'
+            WHEN entity_type IN ('event', 'quest') THEN 'gameplay'
+            ELSE 'mechanics'
+        END
+    ) STORED;
+CREATE INDEX idx_grimoire_entity_category ON grimoire.entity (category);
+
+-- temporality is set only for event/quest (nullable everywhere else).
+ALTER TABLE grimoire.entity ADD COLUMN temporality TEXT
+    CHECK (temporality IS NULL OR temporality IN ('historical', 'present', 'future'));
+
+-- Generic typed-detail payload for the gameplay/mechanics types that have no
+-- dedicated detail table. creature/location/npc/spell keep their own tables.
+ALTER TABLE grimoire.entity ADD COLUMN detail JSONB;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:hcNiZ6c7R/HVhMVYkF8n9sKvbKJCPZfyDQ/0S24Juqg=
+h1:IMjZcQigZHJ76K0FL0Xc+soqaiHNcx1N0y+3bzwBhe0=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -103,4 +103,4 @@ h1:hcNiZ6c7R/HVhMVYkF8n9sKvbKJCPZfyDQ/0S24Juqg=
 20260705120000_grimoire_prompt_version.sql h1:AuXYV7dJF8stoRAaN5RMGc7hICLgy6BvJzqaRS7L2WA=
 20260705130000_grimoire_chunk_section_hierarchy.sql h1:2v1iZZipu+Fnw+rUrdyKYJ81u7IlLD0IU/HaM/EB79A=
 20260705140000_directive_autopilot.sql h1:Yo3ZBeYtbC9SCxMGQ7POv9QJtLXWnosmD6fI8AJK29I=
-20260705150000_grimoire_extraction_v4.sql h1:r68gGgDmDdn0JSW9t0hY9YKUoc2h51ztpqOaoZm4Fr8=
+20260705150000_grimoire_extraction_v4.sql h1:6jZyBNNUrqDYx4+0ZyUMbSVN8sqxA0o/wEKNXXLewYc=

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:BDv/csOUkMnnb/IShg3GhJOhb+PUUMNqk3n4rqi6Wvo=
+h1:hcNiZ6c7R/HVhMVYkF8n9sKvbKJCPZfyDQ/0S24Juqg=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -103,3 +103,4 @@ h1:BDv/csOUkMnnb/IShg3GhJOhb+PUUMNqk3n4rqi6Wvo=
 20260705120000_grimoire_prompt_version.sql h1:AuXYV7dJF8stoRAaN5RMGc7hICLgy6BvJzqaRS7L2WA=
 20260705130000_grimoire_chunk_section_hierarchy.sql h1:2v1iZZipu+Fnw+rUrdyKYJ81u7IlLD0IU/HaM/EB79A=
 20260705140000_directive_autopilot.sql h1:Yo3ZBeYtbC9SCxMGQ7POv9QJtLXWnosmD6fI8AJK29I=
+20260705150000_grimoire_extraction_v4.sql h1:r68gGgDmDdn0JSW9t0hY9YKUoc2h51ztpqOaoZm4Fr8=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.28
+      targetRevision: 0.285.29
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/grimoire/extract.py
+++ b/projects/monolith/grimoire/extract.py
@@ -88,7 +88,34 @@ DEFAULT_LIMIT = 25
 # by chat_public.limits; Discord / private chat / agents share the rest). It
 # also bounds the group size for the incremental per-group commit below.
 DEFAULT_CONCURRENCY = 6
-ENTITY_TYPES = {"creature", "spell", "location", "npc", "faction", "deity", "item"}
+
+# v4 generic typed-extraction taxonomy (spec v4). ~18 entity types grouped by the
+# DERIVED category: lore (unchanged from v1), gameplay (event/quest), and mechanics
+# (D&D game rules). ``category`` itself is a stored generated column on the entity
+# spine (models._ENTITY_CATEGORY_EXPR / the migration), not a value the extractor
+# emits. ENTITY_TYPES is the union: it gates the spine (unknown types are dropped
+# in _get_or_create_entity) and feeds the json_schema entity_type enum.
+LORE_TYPES: frozenset[str] = frozenset(
+    {"creature", "spell", "location", "npc", "faction", "deity", "item"}
+)
+GAMEPLAY_TYPES: frozenset[str] = frozenset({"event", "quest"})
+MECHANICS_TYPES: frozenset[str] = frozenset(
+    {
+        "condition",
+        "feat",
+        "race",
+        "background",
+        "class",
+        "subclass",
+        "class_feature",
+        "action",
+        "rule",
+    }
+)
+ENTITY_TYPES = set(LORE_TYPES | GAMEPLAY_TYPES | MECHANICS_TYPES)
+# temporality is set only for these two gameplay types (nullable elsewhere).
+TEMPORAL_TYPES: frozenset[str] = GAMEPLAY_TYPES
+TEMPORALITY_VALUES: frozenset[str] = frozenset({"historical", "present", "future"})
 
 # Mirrors ingest._Embedder: a per-module Protocol so extract.py does not
 # depend on ingest.py's private name across the package boundary.
@@ -145,6 +172,19 @@ REL_TYPES: tuple[str, ...] = (
     # Taxonomy
     "VARIANT_OF",
     "ORIGINATES_FROM",
+    # Events / gameplay (v4)
+    "OCCURRED_AT",
+    "INVOLVED",
+    "PRECEDED",
+    "CAUSED",
+    "ADVANCES",
+    "GIVEN_BY",
+    "OBJECTIVE_AT",
+    "REWARDS",
+    # Mechanics (v4)
+    "SUBCLASS_OF",
+    "FEATURE_OF",
+    "REQUIRES",
     # Fallback (escape hatch so the model never invents outside the set)
     "RELATED_TO",
 )
@@ -157,6 +197,9 @@ RELATED_TO = "RELATED_TO"
 AGENT_TYPES: frozenset[str] = frozenset({"npc", "creature", "faction", "deity"})
 PLACE_TYPES: frozenset[str] = frozenset({"location"})
 _KIN_TYPES: frozenset[str] = frozenset({"npc", "creature", "deity"})
+# Gameplay / mechanics endpoint groups for the v4 relationship signatures.
+EVENT_TYPES: frozenset[str] = frozenset({"event"})
+QUEST_TYPES: frozenset[str] = frozenset({"quest"})
 _ALL_TYPES: frozenset[str] = frozenset(ENTITY_TYPES)
 
 
@@ -195,7 +238,12 @@ REL_SIGNATURES: dict[str, RelSignature] = {
     "LOCATED_IN": RelSignature(_pairs(_ALL_TYPES, PLACE_TYPES), spatial=True),
     "CONTAINS": RelSignature(_pairs(PLACE_TYPES, _ALL_TYPES), spatial=True),
     "PART_OF": RelSignature(
-        _pairs(PLACE_TYPES, PLACE_TYPES) | _pairs({"faction"}, {"faction"}),
+        _pairs(PLACE_TYPES, PLACE_TYPES)
+        | _pairs({"faction"}, {"faction"})
+        # v4: a sub-event/sub-quest is PART_OF its parent (same-type; spatial flag
+        # keeps it from being reordered, which is harmless for same-type endpoints).
+        | _pairs(EVENT_TYPES, EVENT_TYPES)
+        | _pairs(QUEST_TYPES, QUEST_TYPES),
         spatial=True,
     ),
     "NEAR": RelSignature(
@@ -233,6 +281,22 @@ REL_SIGNATURES: dict[str, RelSignature] = {
     "DESCENDANT_OF": RelSignature(_pairs(_KIN_TYPES, _KIN_TYPES)),
     "SIBLING_OF": RelSignature(_pairs(_KIN_TYPES, _KIN_TYPES), symmetric=True),
     "SPOUSE_OF": RelSignature(_pairs(_KIN_TYPES, _KIN_TYPES), symmetric=True),
+    # Events / gameplay (v4; all asymmetric, so a backwards edge swaps and an
+    # impossible one downgrades to RELATED_TO, exactly like the rest).
+    "OCCURRED_AT": RelSignature(_pairs(EVENT_TYPES, PLACE_TYPES)),
+    "INVOLVED": RelSignature(_pairs(EVENT_TYPES, AGENT_TYPES)),
+    # event -> event: same-type endpoints, so a reversed edge cannot be detected
+    # by type alone (like kinship); an off-type endpoint still downgrades.
+    "PRECEDED": RelSignature(_pairs(EVENT_TYPES, EVENT_TYPES)),
+    "CAUSED": RelSignature(_pairs(EVENT_TYPES, EVENT_TYPES)),
+    "ADVANCES": RelSignature(_pairs(EVENT_TYPES, QUEST_TYPES)),
+    "GIVEN_BY": RelSignature(_pairs(QUEST_TYPES, {"npc"})),
+    "OBJECTIVE_AT": RelSignature(_pairs(QUEST_TYPES, PLACE_TYPES)),
+    "REWARDS": RelSignature(_pairs(QUEST_TYPES, {"item"})),
+    # Mechanics (v4; asymmetric).
+    "SUBCLASS_OF": RelSignature(_pairs({"subclass"}, {"class"})),
+    "FEATURE_OF": RelSignature(_pairs({"class_feature"}, {"class", "subclass"})),
+    "REQUIRES": RelSignature(_pairs({"feat"}, {"feat", "class", "race"})),
     # Fallback: any <-> any, so a downgraded edge is always valid.
     "RELATED_TO": RelSignature(_pairs(_ALL_TYPES, _ALL_TYPES), symmetric=True),
 }
@@ -291,6 +355,11 @@ EXTRACT_SCHEMA: dict[str, Any] = {
                     "entity_type": {"type": "string", "enum": sorted(ENTITY_TYPES)},
                     "name": {"type": "string"},
                     "summary": {"type": "string"},
+                    # v4: set only for event/quest; enum-constrained but optional.
+                    "temporality": {
+                        "type": "string",
+                        "enum": sorted(TEMPORALITY_VALUES),
+                    },
                     "detail": {"type": "object"},
                 },
                 "required": ["entity_type", "name", "summary"],
@@ -695,17 +764,82 @@ A named identity or alias, even one that names an object (a disguised villain, a
 _V3_PROMPT_TEXT = _V2_PROMPT_TEXT + _V3_REL_SIGNATURE_ADDENDUM
 
 
+# v4: generic typed extraction over lore + gameplay + mechanics (spec v4). v3
+# verbatim (so v3 stays byte-frozen) PLUS a taxonomy addendum that widens the
+# entity vocabulary from the 7 lore types to ~18, introduces the derived category
+# and the event/quest temporality, promotes game mechanics (conditions, feats,
+# races, classes, class features, actions, rules) to first-class entities, and
+# adds the new relationship types. All of v3's lore/enrichment, dungeon-room,
+# canonical-naming, and relationship-direction guidance still applies. Built by
+# concatenation; do NOT edit this text once released, add a v5 instead.
+_V4_TAXONOMY_ADDENDUM = """
+
+GENERIC TYPED EXTRACTION (v4): LORE + GAMEPLAY + MECHANICS
+Everything above still holds. This section WIDENS what counts as an entity beyond the seven lore types. Each entity_type below derives a category automatically (you do NOT emit category): lore, gameplay, or mechanics.
+
+- category=lore (unchanged): creature, npc, location, faction, deity, item, spell.
+- category=gameplay: event, quest. Each carries a "temporality" field (see below).
+- category=mechanics: condition, feat, race, background, class, subclass, class_feature, action, rule.
+
+WHAT COUNTS for the new types (extract when the chunk genuinely describes one; a bare mention still belongs in "mentions"):
+- event: a specific happening in the world's history or the adventure's plot (a battle, a cataclysm, a founding, a prophesied doom). Not a generic recurring activity.
+- quest: an objective the party can pursue (a main plot goal, a side task, or an adventure hook), typically with a giver, an objective, and a reward.
+- condition: a defined game condition or status effect (Poisoned, Grappled, Frightened, Exhaustion).
+- feat: a named character feat (Sentinel, Great Weapon Master).
+- race: a playable species/ancestry (Elf, Dwarf, Tiefling) and its traits.
+- background: a character background (Acolyte, Criminal, Folk Hero).
+- class: a character class (Wizard, Fighter, Cleric).
+- subclass: a class's subclass/archetype (Circle of the Moon, School of Evocation).
+- class_feature: a feature a class or subclass grants at a level (Rage, Sneak Attack, Wild Shape). A class feature is class_feature, NEVER spell, even when it resembles magic.
+- action: a defined action, bonus action, or reaction available in play (Dodge, Dash, Opportunity Attack).
+- rule: a named rules subsystem or procedure worth capturing as an entity (Concentration, Cover, Exhaustion track). Keep pure prose rules text that names nothing as empty, as before.
+
+TEMPORALITY (event and quest only; set the top-level "temporality" field, one of historical|present|future):
+- historical: setting backstory or a past occurrence (an ancient war, a fallen empire).
+- present: current to the adventure (an ongoing siege, an active quest).
+- future: prophesied or scheduled (a foretold return, a planned ritual).
+Do NOT set temporality for any other type.
+
+MECHANICS GUIDANCE
+Extract game mechanics wherever they appear: in rulebooks (a class chapter, the conditions appendix) AND when an adventure or guide references them by name. This does NOT reopen the generic-suppression rule: a generic monster or mundane item mentioned in a scene is still furniture (put it in mentions). But a named condition, feat, race, class, subclass, class feature, action, or rule is now a first-class entity, not junk. Reconciling with the v3 "CLASS FEATURES ARE NOT SPELLS" rule: a class feature is now its OWN entity_type class_feature (still never spell).
+
+DETAIL fields for the new types (include only what the text supports; omit the rest):
+- event: temporality(historical|present|future), when(str), when_ordering(str), where(str), participants(array), outcome(str)
+- quest: temporality(present|future|historical), objective(str), giver(str), reward(str or array), quest_type(main|side|hook)
+- condition: effects(str)
+- feat: prerequisite(str), benefit(str)
+- race: ability_scores(object), traits(object), speed(str), size(str), subraces(array)
+- background: proficiencies(str), feature(str), equipment(str)
+- class: hit_die(str), primary_ability(str), saves(str), features_by_level(object)
+- subclass: parent_class(str), features_by_level(object)
+- class_feature: class(str), subclass(str), level(int), description(str)
+- action: action_type(action|bonus|reaction), description(str)
+- rule: rule_category(combat|exploration|social|magic), description(str)
+
+NEW RELATIONSHIP TYPES (added to the closed set; same direction discipline as above, a wrong-typed edge is worse than no edge):
+- OCCURRED_AT: event -> location (where an event happened).
+- INVOLVED: event -> agent (npc/creature/faction/deity that took part).
+- PRECEDED: event -> event (the from-event happened before the to-event). CAUSED: event -> event (the from-event caused the to-event).
+- ADVANCES: event -> quest (an event that moves a quest forward).
+- GIVEN_BY: quest -> npc (the quest giver). OBJECTIVE_AT: quest -> location (where the objective is). REWARDS: quest -> item (an item the quest grants).
+- SUBCLASS_OF: subclass -> class. FEATURE_OF: class_feature -> class or subclass. REQUIRES: feat -> feat, class, or race (a prerequisite).
+- Reuse the existing set where it fits: PART_OF for a sub-event/sub-quest of a larger one, GRANTS for a class/subclass/feat that grants a spell or class feature, RELATED_TO as the fallback."""
+
+_V4_PROMPT_TEXT = _V3_PROMPT_TEXT + _V4_TAXONOMY_ADDENDUM
+
+
 PROMPT_VERSIONS: dict[str, PromptVersion] = {
     "v1": PromptVersion(text=_V1_PROMPT_TEXT, schema=None),
     "v2": PromptVersion(text=_V2_PROMPT_TEXT, schema=EXTRACT_SCHEMA),
     "v3": PromptVersion(text=_V3_PROMPT_TEXT, schema=EXTRACT_SCHEMA),
+    "v4": PromptVersion(text=_V4_PROMPT_TEXT, schema=EXTRACT_SCHEMA),
 }
 
 # The version the extraction pass writes and reads by default. Env-overridable so
 # a candidate (v4) can run on a fresh book without touching code; promotion is
 # moving this pointer. Read at import: jobs run as fresh processes, so the env is
 # honored per run.
-ACTIVE_PROMPT_VERSION = os.environ.get("GRIMOIRE_PROMPT_VERSION", "v3")
+ACTIVE_PROMPT_VERSION = os.environ.get("GRIMOIRE_PROMPT_VERSION", "v4")
 
 # Backward-compatible alias: the active version's system text. The
 # self-correction turn and any caller referencing EXTRACTION_PROMPT get the live
@@ -1129,6 +1263,29 @@ def _coerce_detail_fields(
     return coerced
 
 
+def _apply_generic_detail(entity: Entity, item: dict) -> None:
+    """Route a new-type entity's detail into the generic JSONB column and lift
+    temporality onto the spine (spec v4).
+
+    Used for the gameplay/mechanics types (and any spine-only lore type) that have
+    no dedicated detail table; creature/location/npc/spell keep their typed tables
+    and never reach here. Enrich, not overwrite, to match ADR 012 rev.: JSONB keys
+    are merged with existing keys winning (a fresh dict is reassigned so SQLAlchemy
+    flags the column dirty), and temporality (a top-level field or a ``detail`` key)
+    fills only when still NULL and only for event/quest.
+    """
+    detail = item.get("detail")
+    if isinstance(detail, dict) and detail:
+        current = entity.detail or {}
+        entity.detail = {**detail, **current}
+    if entity.entity_type in TEMPORAL_TYPES and entity.temporality is None:
+        temporality = item.get("temporality")
+        if not isinstance(temporality, str) and isinstance(detail, dict):
+            temporality = detail.get("temporality")
+        if temporality in TEMPORALITY_VALUES:
+            entity.temporality = temporality
+
+
 def _create_or_enrich_detail(
     session: Session, detail_model: type, entity_id: str, entity_name: str, detail: dict
 ) -> None:
@@ -1244,10 +1401,16 @@ def _get_or_create_entity(
 
     # Both paths enrich detail: a new entity's row is created, an existing one
     # is filled where NULL (so a monster split across chunks ends up whole).
+    # creature/location/npc/spell use their typed detail tables; every other type
+    # (event/quest/mechanics, plus spine-only faction/deity/item) routes into the
+    # generic detail JSONB and lifts temporality onto the spine (spec v4).
     detail_model = ENTITY_DETAIL_MODELS.get(entity_type)
     detail = item.get("detail")
-    if detail_model is not None and isinstance(detail, dict) and detail:
-        _create_or_enrich_detail(session, detail_model, entity.id, name, detail)
+    if detail_model is not None:
+        if isinstance(detail, dict) and detail:
+            _create_or_enrich_detail(session, detail_model, entity.id, name, detail)
+    else:
+        _apply_generic_detail(entity, item)
 
     return entity, created
 

--- a/projects/monolith/grimoire/extract_test.py
+++ b/projects/monolith/grimoire/extract_test.py
@@ -620,6 +620,7 @@ def test_released_prompt_versions_are_frozen_by_hash():
         "v1": "64cb5df96d35c282f0ad004233ef01ef52c0eb86eed94342f9bfec4479ac949f",
         "v2": "aeb536de96f21e54bcd54ed073efc9945b92b125e3dae6f748808e4f0325ab52",
         "v3": "1d4f924fb55bc021dddffb320461e4a93c065bd2ef1946aeca95293e25959377",
+        "v4": "2437034db1f660f0b2f0f130d55d1f94c4cdd039a170af6bd269dd7264ff71c9",
     }
     # Every released version must be pinned (a new version needs a new pin here).
     assert set(frozen) == set(PROMPT_VERSIONS)
@@ -635,15 +636,27 @@ def test_v2_has_schema_v1_does_not():
     assert PROMPT_VERSIONS["v2"].schema is not None
 
 
-def test_v3_is_active_and_extends_v2():
-    """v3 is the active version, carries the same schema as v2, and contains v2's
-    text verbatim (built by concatenation) plus the type-signature guidance."""
-    assert ACTIVE_PROMPT_VERSION == "v3"
+def test_v3_extends_v2():
+    """v3 carries the same schema as v2 and contains v2's text verbatim (built by
+    concatenation) plus the type-signature guidance."""
     assert PROMPT_VERSIONS["v3"].schema is PROMPT_VERSIONS["v2"].schema
     v3_text = PROMPT_VERSIONS["v3"].text
     assert v3_text.startswith(PROMPT_VERSIONS["v2"].text)
     assert "RELATIONSHIP TYPE SIGNATURES" in v3_text
     assert "A NAMED IDENTITY IS AN NPC, NOT AN ITEM" in v3_text
+
+
+def test_v4_is_active_and_extends_v3():
+    """v4 is the active version, carries the same schema as v3, and contains v3's
+    text verbatim (built by concatenation) plus the generic-typed-extraction
+    taxonomy (gameplay + mechanics types, category/temporality, new rels)."""
+    assert ACTIVE_PROMPT_VERSION == "v4"
+    assert PROMPT_VERSIONS["v4"].schema is PROMPT_VERSIONS["v3"].schema
+    v4_text = PROMPT_VERSIONS["v4"].text
+    assert v4_text.startswith(PROMPT_VERSIONS["v3"].text)
+    assert "GENERIC TYPED EXTRACTION" in v4_text
+    assert "class_feature, NEVER spell" in v4_text
+    assert "OCCURRED_AT" in v4_text and "SUBCLASS_OF" in v4_text
 
 
 def test_non_enum_rel_type_mapped_to_related_to(session: Session):
@@ -870,6 +883,211 @@ def test_rel_signature_swaps_reversed_non_spatial_edge(session: Session):
     assert summary["rel_signature_downgrades"] == {}
     assert rels[0].rel_type == "MEMBER_OF"
     assert _endpoint_names(session, rels[0]) == ("Glasstaff", "Redbrands")
+
+
+# --- v4 generic typed extraction (category / temporality / detail / new rels) --
+
+
+def _extract_entities(
+    session: Session, entities: list[dict]
+) -> tuple[dict, list[Entity]]:
+    """Run one chunk carrying the given entities; return the summary and the
+    persisted Entity rows (re-selected so the DB-derived category is loaded)."""
+    chunk = _make_chunk(session, "phb", "phb-001", "A rules chunk.")
+    or_client = FakeOpenRouterClient(
+        {chunk.content: {"entities": entities, "mentions": [], "relationships": []}}
+    )
+    summary = _run(extract_chunks(session, or_client, FakeEmbedClient(), limit=25))
+    rows = session.execute(select(Entity)).scalars().all()
+    return summary, rows
+
+
+def test_category_derived_for_each_category_including_spell_lore(session: Session):
+    """category is a stored generated column derived from entity_type: lore for the
+    seven lore types (spell included), gameplay for event/quest, mechanics for the
+    rules types. spell is lore at the column level (the mechanics surface unions it
+    in at query time, not here)."""
+    _summary, rows = _extract_entities(
+        session,
+        entities=[
+            {"entity_type": "creature", "name": "Beholder", "summary": "An eye."},
+            {"entity_type": "spell", "name": "Fireball", "summary": "A boom."},
+            {"entity_type": "item", "name": "Sun Blade", "summary": "A sword."},
+            {"entity_type": "event", "name": "Sundering", "summary": "A cataclysm."},
+            {"entity_type": "quest", "name": "Find the Gem", "summary": "A task."},
+            {"entity_type": "condition", "name": "Poisoned", "summary": "Ill."},
+            {"entity_type": "class", "name": "Wizard", "summary": "A caster."},
+            {"entity_type": "class_feature", "name": "Rage", "summary": "Anger."},
+        ],
+    )
+    by_name = {e.name: e for e in rows}
+    assert by_name["Beholder"].category == "lore"
+    assert by_name["Fireball"].category == "lore"  # spell derives to lore
+    assert by_name["Sun Blade"].category == "lore"
+    assert by_name["Sundering"].category == "gameplay"
+    assert by_name["Find the Gem"].category == "gameplay"
+    assert by_name["Poisoned"].category == "mechanics"
+    assert by_name["Wizard"].category == "mechanics"
+    assert by_name["Rage"].category == "mechanics"
+
+
+def test_temporality_set_only_for_event_and_quest(session: Session):
+    """temporality is lifted onto the spine for event/quest only; a creature that
+    (wrongly) carries a temporality field is ignored."""
+    _summary, rows = _extract_entities(
+        session,
+        entities=[
+            {
+                "entity_type": "event",
+                "name": "Dragon War",
+                "summary": "A long war.",
+                "temporality": "historical",
+            },
+            {
+                "entity_type": "quest",
+                "name": "Stop the Ritual",
+                "summary": "Urgent.",
+                "detail": {"temporality": "present", "objective": "Stop it"},
+            },
+            {
+                "entity_type": "creature",
+                "name": "Goblin",
+                "summary": "Small.",
+                "temporality": "future",
+            },
+        ],
+    )
+    by_name = {e.name: e for e in rows}
+    assert by_name["Dragon War"].temporality == "historical"
+    assert by_name["Stop the Ritual"].temporality == "present"  # read from detail
+    assert by_name["Goblin"].temporality is None  # ignored for non-gameplay types
+
+
+def test_new_type_persists_with_generic_detail_jsonb(session: Session):
+    """A gameplay/mechanics type has no typed detail table: its detail is stored on
+    the entity's generic JSONB column, and category is derived."""
+    _summary, rows = _extract_entities(
+        session,
+        entities=[
+            {
+                "entity_type": "quest",
+                "name": "Retrieve the Orb",
+                "summary": "Fetch it.",
+                "detail": {
+                    "objective": "Bring the Orb to Sildar",
+                    "giver": "Sildar",
+                    "reward": "500 gp",
+                    "quest_type": "side",
+                    "temporality": "present",
+                },
+            }
+        ],
+    )
+    quest = rows[0]
+    assert quest.entity_type == "quest"
+    assert quest.category == "gameplay"
+    assert quest.temporality == "present"
+    assert quest.detail["objective"] == "Bring the Orb to Sildar"
+    assert quest.detail["quest_type"] == "side"
+
+
+def test_class_feature_accepted_as_own_type_not_spell(session: Session):
+    """class_feature is a first-class entity_type (mechanics), never coerced to
+    spell, and gets no entity_spell detail row."""
+    from grimoire.models import EntitySpell
+
+    _summary, rows = _extract_entities(
+        session,
+        entities=[
+            {
+                "entity_type": "class_feature",
+                "name": "Sneak Attack",
+                "summary": "Extra damage.",
+                "detail": {"class": "Rogue", "level": 1},
+            }
+        ],
+    )
+    feature = rows[0]
+    assert feature.entity_type == "class_feature"
+    assert feature.category == "mechanics"
+    assert feature.detail["class"] == "Rogue"
+    # No spell detail table row was created for it.
+    assert session.execute(select(EntitySpell)).scalars().all() == []
+
+
+def test_apply_rel_signature_new_v4_rels():
+    """The v4 asymmetric rels swap a reversed edge and downgrade an off-type one."""
+    # Valid as-is.
+    assert _apply_rel_signature("event", "location", "OCCURRED_AT") == (
+        "OCCURRED_AT",
+        False,
+        None,
+    )
+    assert _apply_rel_signature("subclass", "class", "SUBCLASS_OF") == (
+        "SUBCLASS_OF",
+        False,
+        None,
+    )
+    # Reversed asymmetric -> swap.
+    assert _apply_rel_signature("location", "event", "OCCURRED_AT") == (
+        "OCCURRED_AT",
+        True,
+        "swap",
+    )
+    # Off-type in both directions -> downgrade (quest GIVEN_BY a location).
+    assert _apply_rel_signature("quest", "location", "GIVEN_BY") == (
+        "RELATED_TO",
+        False,
+        "downgrade",
+    )
+
+
+def test_rel_signature_swaps_reversed_occurred_at(session: Session):
+    """`Neverwinter OCCURRED_AT Siege` is backwards: swap to `Siege OCCURRED_AT
+    Neverwinter` (event -> location)."""
+    summary, rels = _extract_one_edge(
+        session,
+        entities=[
+            {"entity_type": "location", "name": "Neverwinter", "summary": "A city."},
+            {"entity_type": "event", "name": "Siege", "summary": "A battle."},
+        ],
+        relationships=[
+            {
+                "from_name": "Neverwinter",
+                "to_name": "Siege",
+                "rel_type": "OCCURRED_AT",
+            }
+        ],
+    )
+    assert summary["relationships_created"] == 1
+    assert summary["rel_signature_swaps"] == {"OCCURRED_AT": 1}
+    assert summary["rel_signature_downgrades"] == {}
+    assert rels[0].rel_type == "OCCURRED_AT"
+    assert _endpoint_names(session, rels[0]) == ("Siege", "Neverwinter")
+
+
+def test_rel_signature_downgrades_given_by_wrong_endpoint(session: Session):
+    """`Find the Gem GIVEN_BY Neverwinter` (a quest given by a place) is impossible
+    in both directions: keep the edge but downgrade rel_type to RELATED_TO."""
+    summary, rels = _extract_one_edge(
+        session,
+        entities=[
+            {"entity_type": "quest", "name": "Find the Gem", "summary": "A task."},
+            {"entity_type": "location", "name": "Neverwinter", "summary": "A city."},
+        ],
+        relationships=[
+            {
+                "from_name": "Find the Gem",
+                "to_name": "Neverwinter",
+                "rel_type": "GIVEN_BY",
+            }
+        ],
+    )
+    assert summary["relationships_created"] == 1
+    assert summary["rel_signature_downgrades"] == {"GIVEN_BY": 1}
+    assert summary["rel_signature_swaps"] == {}
+    assert rels[0].rel_type == "RELATED_TO"
+    assert _endpoint_names(session, rels[0]) == ("Find the Gem", "Neverwinter")
 
 
 def test_canonicalize_name_strips_map_key_prefix():

--- a/projects/monolith/grimoire/models.py
+++ b/projects/monolith/grimoire/models.py
@@ -15,6 +15,7 @@ from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
     CheckConstraint,
     Column,
+    Computed,
     DateTime,
     ForeignKey,
     String,
@@ -25,8 +26,38 @@ from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlmodel import JSON, Field, SQLModel
 
 # Mirror of the CHECK constraint in
-# chart/migrations/20260703070000_grimoire_schema.sql - keep in sync.
-EntityType = Literal["creature", "spell", "location", "npc", "faction", "deity", "item"]
+# chart/migrations/20260703070000_grimoire_schema.sql, expanded by
+# 20260705150000_grimoire_extraction_v4.sql to the generic typed-extraction set
+# (lore + gameplay + mechanics) - keep in sync. Grouped by the DERIVED category:
+# lore (unchanged from v1), gameplay (event/quest), mechanics (D&D game rules).
+EntityType = Literal[
+    # lore
+    "creature",
+    "spell",
+    "location",
+    "npc",
+    "faction",
+    "deity",
+    "item",
+    # gameplay
+    "event",
+    "quest",
+    # mechanics
+    "condition",
+    "feat",
+    "race",
+    "background",
+    "class",
+    "subclass",
+    "class_feature",
+    "action",
+    "rule",
+]
+# Category is DERIVED from entity_type by a stored generated column (see
+# _ENTITY_CATEGORY_EXPR / the migration), never written by the app.
+Category = Literal["lore", "gameplay", "mechanics"]
+# Temporality is set only for event/quest (nullable everywhere else).
+Temporality = Literal["historical", "present", "future"]
 SourceType = Literal["extracted", "homebrew"]
 EmbeddableKind = Literal["entity", "chunk", "transcript"]
 SessionStatus = Literal["active", "paused", "ended"]
@@ -52,16 +83,40 @@ def _uuid_column(
     return Column(*args, primary_key=primary_key, nullable=nullable)
 
 
+# Type -> category derivation (spec v4): a stored generated column so category is
+# ALWAYS a clean function of entity_type on both Postgres (the migration) and
+# SQLite (create_all fixtures). spell stays in lore here; the mechanics surface
+# unions spell in at QUERY time (category='mechanics' OR entity_type='spell'), not
+# at the column level. Mirror of the CASE in
+# 20260705150000_grimoire_extraction_v4.sql - keep in sync.
+_ENTITY_CATEGORY_EXPR = (
+    "CASE "
+    "WHEN entity_type IN ("
+    "'creature', 'spell', 'location', 'npc', 'faction', 'deity', 'item'"
+    ") THEN 'lore' "
+    "WHEN entity_type IN ('event', 'quest') THEN 'gameplay' "
+    "ELSE 'mechanics' END"
+)
+
+
 class Entity(SQLModel, table=True):
     __tablename__ = "entity"
     __table_args__ = (
         CheckConstraint(
-            "entity_type IN ('creature', 'spell', 'location', 'npc', 'faction', 'deity', 'item')",
+            "entity_type IN ("
+            "'creature', 'spell', 'location', 'npc', 'faction', 'deity', 'item', "
+            "'event', 'quest', "
+            "'condition', 'feat', 'race', 'background', 'class', 'subclass', "
+            "'class_feature', 'action', 'rule')",
             name="entity_entity_type_chk",
         ),
         CheckConstraint(
             "source_type IN ('extracted', 'homebrew')",
             name="entity_source_type_chk",
+        ),
+        CheckConstraint(
+            "temporality IS NULL OR temporality IN ('historical', 'present', 'future')",
+            name="entity_temporality_chk",
         ),
         {"schema": "grimoire", "extend_existing": True},
     )
@@ -75,6 +130,23 @@ class Entity(SQLModel, table=True):
     )
     entity_type: EntityType = Field(sa_column=Column(String, nullable=False))
     name: str
+    # DERIVED, never written: a stored generated column over entity_type. Read
+    # after a flush/refresh; the app must not pass a value (the DB computes it).
+    category: Category | None = Field(
+        default=None,
+        sa_column=Column(
+            String, Computed(_ENTITY_CATEGORY_EXPR, persisted=True), nullable=False
+        ),
+    )
+    # Set only for event/quest (the DB CHECK allows NULL for every other type).
+    temporality: Temporality | None = Field(
+        default=None, sa_column=Column(String, nullable=True)
+    )
+    # Generic typed-detail payload for the gameplay/mechanics types that have no
+    # dedicated detail table (event/quest/condition/feat/.../rule). creature,
+    # location, npc, and spell keep their own typed detail tables and do NOT use
+    # this column. Postgres JSONB, SQLite JSON.
+    detail: dict | None = Field(default=None, sa_column=Column(_JSONB))
     source_type: SourceType = Field(
         default="extracted", sa_column=Column(String, nullable=False)
     )


### PR DESCRIPTION
## Summary
Grimoire extraction **v4**: one generic typed extraction pass over all chunks emitting a ~18-type taxonomy grouped by a **derived** `category` (lore, gameplay, mechanics). Builds on v1/v2/v3 (all merged); keeps everything v3 does (enrichment, dungeon-rooms, book+section context, closed rel enum, REL_SIGNATURES validator, magical-exception handling). Opens for review; **do not merge**, and extraction has **not** been run.

## Type taxonomy (18) and derived category
- **lore** (unchanged): creature, npc, location, faction, deity, item, spell
- **gameplay** (carry `temporality`): event, quest
- **mechanics**: condition, feat, race, background, class, subclass, class_feature, action, rule

`category` is a **stored generated column** (`GENERATED ALWAYS AS (CASE ...) STORED`) over `entity_type`, so it is always consistent regardless of write path and existing rows derive it with no backfill. Mirrored in `models.py` via SQLAlchemy `Computed()` so SQLite `create_all` fixtures derive it identically. **spell derives to `lore`**; the mechanics surface unions spell in at query time (`category='mechanics' OR entity_type='spell'`), not at the column level.

## Migration
`projects/monolith/chart/migrations/20260705150000_grimoire_extraction_v4.sql` (after head `20260705140000`): expand `entity_type` CHECK to 18, add generated `category` (+ index), nullable `temporality` enum, generic `detail` JSONB. creature/location/npc/spell keep their typed detail tables. `atlas.sum` regenerated with the pinned atlas community v1.1.0 (`migrate validate` rc=0).

## Prompt + schema
v4 prompt = v3 verbatim + a taxonomy addendum (new-type "what counts", category/temporality rules, mechanics guidance incl "class features are class_feature not spell"), registered by concatenation so **v3 stays byte-frozen**. `ACTIVE_PROMPT_VERSION=v4`. json_schema: entity_type enum -> 18, rel_type enum -> +11, new optional `temporality` enum.

## New relationships + signatures
OCCURRED_AT (event->location), INVOLVED (event->agent), PRECEDED/CAUSED (event->event), ADVANCES (event->quest), GIVEN_BY (quest->npc), OBJECTIVE_AT (quest->location), REWARDS (quest->item), SUBCLASS_OF (subclass->class), FEATURE_OF (class_feature->class|subclass), REQUIRES (feat->feat|class|race); PART_OF extended to event/quest same-type. Same graduated swap/downgrade/spatial-lenient logic as the existing rels.

## Tests
Category derivation per category incl spell=lore; temporality set only for event/quest; generic-detail JSONB persistence; class_feature accepted as its own type (not spell); new rel-signature swap (OCCURRED_AT reversed) + downgrade (GIVEN_BY wrong endpoint) cases; re-pinned frozen-hash test. Ran the grimoire suite locally in a venv: **v1/v2/v3 frozen hashes unchanged**, v4 pinned; all grimoire tests pass (2 unrelated failures were missing botocore in the ad-hoc venv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4SN3nVxYECUdX2gSCFCxD