### PR TITLE
feat(chat): make Bosun run python for exact numbers instead of estimating

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.28
+version: 0.285.29
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -206,7 +206,12 @@ def build_system_prompt() -> str:
         "relevant context (search the web, search this channel's history) and "
         "articulate the answer clearly and completely. Getting it right and "
         "being easy to follow matters MORE than sounding breezy. A short list "
-        "or a few steps is good when it makes the answer easier to act on.\n\n"
+        "or a few steps is good when it makes the answer easier to act on.\n"
+        "- Exact numbers are never casual. If a reply turns on a computed "
+        "value (arithmetic beyond one digit, a percentage, date or unit math, "
+        "a statistic), run the python sandbox and report what it returns, even "
+        "mid-banter. Do not eyeball it to stay breezy: a wrong number said "
+        "confidently is worse than a one-second pause to compute it.\n\n"
         "WHAT YOU CAN DO (say this plainly when someone asks how you can help "
         "or what you can do, give the concrete rundown, not a vague 'anything!'):\n"
         "- Answer questions and hold a conversation.\n"
@@ -640,11 +645,12 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
 
     @agent.tool
     @signposted(
-        "When a message needs an exact computed answer (arithmetic beyond "
-        "trivial, date math, unit conversions, statistics, simulations, "
-        "parsing pasted data, or a quick chart), run real code in the sandbox "
-        "instead of estimating from memory. Prefer this over starting an "
-        "agent thread when the goal is an output, not a change."
+        "Never do multi-digit arithmetic, date math, unit conversions, or "
+        "statistics in your head; run it here. Estimating an exact number "
+        "from memory is a bug, not a shortcut, even for a throwaway aside. "
+        "Also use this for simulations, parsing pasted data, or a quick "
+        "chart. Prefer it over starting an agent thread when the goal is an "
+        "output, not a change."
     )
     async def run_python(ctx: RunContext[ChatDeps], code: str) -> str:
         """Run a short Python script in an isolated sandbox and return its output. No network. Save charts/files to the working directory and they will be attached to the reply."""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.28
+      targetRevision: 0.285.29
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Follow-up to ADR agents/044. Live-testing showed the tool works, but an activation audit found `run_python` was under-prompted: its signpost was a soft conditional ("when a message needs an exact computed answer") while the tools that fire reliably (web_search) are imperative ("Default to searching. Never guess"). On the local Qwen concierge picking among 12 tools, that meant it under-fired on the highest-value case, casual arithmetic the model is quietly wrong about, because "keep it short / read the room" classifies it as chatter.

## Change
- **Signpost -> imperative**: "Never do multi-digit arithmetic, date math, unit conversions, or statistics in your head; run it here. Estimating an exact number from memory is a bug, not a shortcut." (Injected into the tool description via @signposted.)
- **READ THE ROOM rule**: "Exact numbers are never casual... run the python sandbox and report what it returns, even mid-banter. A wrong number said confidently is worse than a one-second pause to compute it." Placed exactly where the brevity-vs-tool tension is resolved, so "keep it short" no longer suppresses computing.

Chose the strong (web_search-parity) level deliberately; the accepted tradeoff is Bosun occasionally computing a throwaway number, which is preferable to it stating a wrong one confidently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)