### PR TITLE
build(monolith): republish chart for v4 migration after 0.285.29 collision

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.30
+version: 0.285.31
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.30
+      targetRevision: 0.285.31
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
The v4 generic-typed-extraction migration (`20260705150000`) and jobs image never deployed: v4's `0.285.29` chart bump collided with a concurrent run_python bump that published 0.285.29 first, so the idempotent chart publish skipped v4. This bumps to a fresh version to force a republish of the v4 migration + image.

Fixes the stuck grimoire v4 rollout (ConfigMap missing `20260705150000`, `grimoire.entity.category` column absent).