### PR TITLE
feat(grimoire): add extraction prompt v5 (condition + class_feature scope tune)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.32
+version: 0.285.33
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.32
+      targetRevision: 0.285.33
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/grimoire/extract.py
+++ b/projects/monolith/grimoire/extract.py
@@ -828,18 +828,41 @@ NEW RELATIONSHIP TYPES (added to the closed set; same direction discipline as ab
 _V4_PROMPT_TEXT = _V3_PROMPT_TEXT + _V4_TAXONOMY_ADDENDUM
 
 
+# v5: prompt-only tune of two mechanics-extraction drifts a two-sample SRD 5.2
+# eval surfaced in v4. v4 verbatim (so v4 stays byte-frozen) PLUS a short
+# addendum that tightens exactly two definitions: (1) condition was over-eager,
+# sweeping in spells, items, senses/traits, and general mechanics; (2)
+# class_feature was conflated with monster/NPC innate abilities (135 FEATURE_OF
+# edges to a creature/npc were downgraded to RELATED_TO by the validator). No
+# schema, REL_SIGNATURES, or migration change: this is prompt text only. Built by
+# concatenation; do NOT edit this text once released, add a v6 instead.
+_V5_MECHANICS_CLARIFICATION_ADDENDUM = """
+
+MECHANICS CLARIFICATIONS (v5): condition scope and class_feature vs monster abilities
+Everything above still holds. These two clarifications tighten what counts as a condition and a class_feature; nothing else changes.
+
+CONDITION SCOPE
+A `condition` is a status effect that changes a creature's capabilities (e.g. Prone, Frightened, Grappled, Incapacitated, Poisoned, Exhaustion, Restrained). Do NOT classify a spell (`Dancing Lights`), an item (`Scrolls`), a sense or trait (`Darkvision`), or a general mechanic (`Advantage`) as a condition.
+
+CLASS_FEATURE VS MONSTER ABILITIES
+A `class_feature` is a feature a PLAYER CHARACTER gains from a class or subclass (e.g. Sneak Attack, Rage, Second Wind, Wild Shape), and connects `FEATURE_OF` a `class` or `subclass`. A monster's or NPC's innate traits/actions are part of that creature's own detail, NOT a `class_feature` - do not extract monster abilities as `class_feature`."""
+
+_V5_PROMPT_TEXT = _V4_PROMPT_TEXT + _V5_MECHANICS_CLARIFICATION_ADDENDUM
+
+
 PROMPT_VERSIONS: dict[str, PromptVersion] = {
     "v1": PromptVersion(text=_V1_PROMPT_TEXT, schema=None),
     "v2": PromptVersion(text=_V2_PROMPT_TEXT, schema=EXTRACT_SCHEMA),
     "v3": PromptVersion(text=_V3_PROMPT_TEXT, schema=EXTRACT_SCHEMA),
     "v4": PromptVersion(text=_V4_PROMPT_TEXT, schema=EXTRACT_SCHEMA),
+    "v5": PromptVersion(text=_V5_PROMPT_TEXT, schema=EXTRACT_SCHEMA),
 }
 
 # The version the extraction pass writes and reads by default. Env-overridable so
-# a candidate (v4) can run on a fresh book without touching code; promotion is
+# a candidate (v5) can run on a fresh book without touching code; promotion is
 # moving this pointer. Read at import: jobs run as fresh processes, so the env is
 # honored per run.
-ACTIVE_PROMPT_VERSION = os.environ.get("GRIMOIRE_PROMPT_VERSION", "v4")
+ACTIVE_PROMPT_VERSION = os.environ.get("GRIMOIRE_PROMPT_VERSION", "v5")
 
 # Backward-compatible alias: the active version's system text. The
 # self-correction turn and any caller referencing EXTRACTION_PROMPT get the live

--- a/projects/monolith/grimoire/extract_test.py
+++ b/projects/monolith/grimoire/extract_test.py
@@ -621,6 +621,7 @@ def test_released_prompt_versions_are_frozen_by_hash():
         "v2": "aeb536de96f21e54bcd54ed073efc9945b92b125e3dae6f748808e4f0325ab52",
         "v3": "1d4f924fb55bc021dddffb320461e4a93c065bd2ef1946aeca95293e25959377",
         "v4": "2437034db1f660f0b2f0f130d55d1f94c4cdd039a170af6bd269dd7264ff71c9",
+        "v5": "df94db206235900ce377e50162a2678c06b000f75960d0af4c2982972e4e7459",
     }
     # Every released version must be pinned (a new version needs a new pin here).
     assert set(frozen) == set(PROMPT_VERSIONS)
@@ -646,17 +647,32 @@ def test_v3_extends_v2():
     assert "A NAMED IDENTITY IS AN NPC, NOT AN ITEM" in v3_text
 
 
-def test_v4_is_active_and_extends_v3():
-    """v4 is the active version, carries the same schema as v3, and contains v3's
-    text verbatim (built by concatenation) plus the generic-typed-extraction
-    taxonomy (gameplay + mechanics types, category/temporality, new rels)."""
-    assert ACTIVE_PROMPT_VERSION == "v4"
+def test_v4_extends_v3():
+    """v4 carries the same schema as v3 and contains v3's text verbatim (built by
+    concatenation) plus the generic-typed-extraction taxonomy (gameplay +
+    mechanics types, category/temporality, new rels)."""
     assert PROMPT_VERSIONS["v4"].schema is PROMPT_VERSIONS["v3"].schema
     v4_text = PROMPT_VERSIONS["v4"].text
     assert v4_text.startswith(PROMPT_VERSIONS["v3"].text)
     assert "GENERIC TYPED EXTRACTION" in v4_text
     assert "class_feature, NEVER spell" in v4_text
     assert "OCCURRED_AT" in v4_text and "SUBCLASS_OF" in v4_text
+
+
+def test_v5_is_active_and_extends_v4():
+    """v5 is the active version, carries the same schema as v4, and contains v4's
+    text verbatim (built by concatenation) plus the two mechanics clarifications
+    (condition scope, class_feature vs monster abilities). Prompt text only: same
+    schema object as v4."""
+    assert ACTIVE_PROMPT_VERSION == "v5"
+    assert PROMPT_VERSIONS["v5"].schema is PROMPT_VERSIONS["v4"].schema
+    v5_text = PROMPT_VERSIONS["v5"].text
+    assert v5_text.startswith(PROMPT_VERSIONS["v4"].text)
+    assert "MECHANICS CLARIFICATIONS" in v5_text
+    assert "CONDITION SCOPE" in v5_text
+    assert "Dancing Lights" in v5_text and "Darkvision" in v5_text
+    assert "CLASS_FEATURE VS MONSTER ABILITIES" in v5_text
+    assert "do not extract monster abilities as" in v5_text
 
 
 def test_non_enum_rel_type_mapped_to_related_to(session: Session):


### PR DESCRIPTION
## What

Adds grimoire extraction prompt **v5**, a prompt-only tune of two mechanics-extraction drifts a two-sample SRD 5.2 eval surfaced in v4 (which validated well overall). No schema, `REL_SIGNATURES`, or migration change.

v5 = v4 text verbatim (byte-frozen, built by concatenation) PLUS a short addendum with exactly two clarifications, and `ACTIVE_PROMPT_VERSION = "v5"`.

## The two fixes

1. **condition was over-eager**, sweeping in spells (`Dancing Lights`), items (`Scrolls`), senses/traits (`Darkvision`), and general mechanics (`Advantage`). v5 restricts `condition` to status effects that change a creature's capabilities.
2. **class_feature was conflated with monster/NPC innate abilities** (135 `FEATURE_OF` edges to a creature/npc were downgraded to `RELATED_TO` by the validator). v5 scopes `class_feature` to player-character class/subclass features and forbids extracting monster abilities as `class_feature`.

## Freezing

- v5 registered in `PROMPT_VERSIONS`, same schema object as v4.
- Frozen-hash test pins v5 (`df94db20...`) and re-confirms v1-v4 hashes are byte-identical to their existing pins (proof v1-v4 are untouched).
- Added `test_v5_is_active_and_extends_v4`; renamed the old v4-active test to `test_v4_extends_v3` and dropped its now-stale active assertion.

## Chart

Bumped monolith chart 0.285.30 -> 0.285.31 (`Chart.yaml` + `application.yaml` together).

Do NOT merge yet: opened for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4SN3nVxYECUdX2gSCFCxD