### PR TITLE
fix(chat): make run_python charts attach and tables render on Discord

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.32
+version: 0.285.34
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -239,6 +239,15 @@ def build_system_prompt() -> str:
         "live web artifact (a visualization, page, or interactive tool). When "
         "someone wants any of that, start the thread rather than trying to do "
         "it yourself inline.\n\n"
+        "FORMATTING FOR DISCORD:\n"
+        "- Discord does NOT render markdown tables: a | col | col | table shows "
+        "up as raw pipes and dashes. For tabular data, either wrap it in a "
+        "triple-backtick code block so the columns line up in monospace, or for "
+        "wide or many-row data render it as an image with run_python and let "
+        "that attach.\n"
+        "- When run_python saves a file (a chart, an image), it is attached to "
+        "your reply automatically. Never write a markdown image link or paste a "
+        "file path like /tmp/chart.png: just say what it shows.\n\n"
         "CATCHING UP:\n"
         "- If someone asks to be caught up, wants a recap, or asks "
         'something like "what happened here" or "summarize this thread," '
@@ -668,7 +677,14 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
         "output, not a change."
     )
     async def run_python(ctx: RunContext[ChatDeps], code: str) -> str:
-        """Run a short Python script in an isolated sandbox and return its output. No network. Save charts/files to the working directory and they will be attached to the reply."""
+        """Run a short Python script in an isolated sandbox and return its output. No network.
+
+        To hand back a chart or file, save it with a plain relative filename
+        (for example plt.savefig("chart.png")), never an absolute path and never
+        /tmp: only files in the working directory are returned. Saved files are
+        attached to the Discord reply automatically, so do not write a markdown
+        image link or print the file path, just describe what the chart shows.
+        """
         result = await run_python_in_sandbox(code)
         if result.get("error"):
             return f"sandbox error: {result['error']}"

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.32
+      targetRevision: 0.285.34
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/sandbox/mcp.py
+++ b/projects/monolith/sandbox/mcp.py
@@ -31,6 +31,10 @@ async def run_python(code: str, files: list[dict] | None = None) -> dict:
     duckdb, sympy, tabulate, or openpyxl, and no requests, httpx, or any
     other HTTP client, since the sandbox cannot reach the network at all.
 
+    Save any figure or output file with a plain relative filename such as
+    chart.png. Only files written to the working directory are returned, so an
+    absolute path or a /tmp path is lost.
+
     Args:
         code: The Python source to run. It is written to a file and executed
             with python3. Use print(...) for anything you want back as


### PR DESCRIPTION
Two fixes from a live 'chart the sun for vancouver' reply where the compute worked but (a) the PNG did not attach and (b) the data table rendered as raw pipes.

## Chart attach
The model saved to /tmp/vancouver_sun_2026_jul.png (absolute). The sandbox handler only collects files in the per-invoke working directory (os.MkdirTemp workdir, cwd=workdir, collectOutputFiles walks workdir only), so the file was never returned and the model wrote a dead markdown image link to that path. Strengthen the run_python descriptions (concierge @agent.tool docstring + the MCP tool docstring) to mandate a plain relative filename like chart.png, never absolute or /tmp, state files auto-attach, and forbid markdown image links or pasting the path.

## Discord tables
Discord does not render markdown tables. Added a FORMATTING FOR DISCORD rule to build_system_prompt: wrap tabular data in a code block for monospace column alignment, or render wide data as an image via run_python. No new tool: a prompt rule covers it (a dedicated rich-table tool would be over-engineering for readable tables).

Prose/description only. The MCP docstring edit is free of Context Forge forbidden characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
