### PR TITLE
fix(grimoire): map the last three genre-blind books in BOOK_KIND

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.33
+version: 0.285.34
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.33
+      targetRevision: 0.285.34
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/grimoire/extract.py
+++ b/projects/monolith/grimoire/extract.py
@@ -421,6 +421,14 @@ BOOK_KIND: dict[str, str] = {
     "descent-into-avernus": "adventure",
     "the-wild-beyond-the-witchlight": "adventure",
     "waterdeep-dungeon-of-the-mad-mage": "adventure",
+    # Dragon/giant compendia share Mordenkainen's lore + player options +
+    # bestiary shape; the bestiary stat-block rule only fires on chunks that
+    # actually are stat-block entries, so it is safe for their mixed chapters.
+    "fizbans-treasury-of-dragons": "bestiary",
+    "bigby-presents-glory-of-giants": "bestiary",
+    # Majority lore/locations/items around the Deck of Many Things; the
+    # bestiary appendix is a minority of the book.
+    "the-book-of-many-things": "setting-guide",
 }
 # The two book_kind values the structural adventure layer (grimoire.adventure)
 # operates over: single-adventure books and multi-adventure anthologies. Used

--- a/projects/monolith/grimoire/extract_test.py
+++ b/projects/monolith/grimoire/extract_test.py
@@ -1252,6 +1252,11 @@ def test_book_kind_mapping():
     # Prefix family match after an exact miss.
     assert book_kind("tome-of-beasts-2") == "bestiary"
     assert book_kind("sword-coast-adventurers-guide") == "setting-guide"
+    # Mixed lore + player options + bestiary compendia map to bestiary.
+    assert book_kind("fizbans-treasury-of-dragons") == "bestiary"
+    assert book_kind("bigby-presents-glory-of-giants") == "bestiary"
+    # Majority-lore book around the Deck of Many Things.
+    assert book_kind("the-book-of-many-things") == "setting-guide"
     # Unmapped slug: no guessed genre.
     assert book_kind("some-random-homebrew") is None
 


### PR DESCRIPTION
Maps the three remaining unmapped books so no chunk extracts genre-blind:

| book | chunks | kind |
|---|---|---|
| fizbans-treasury-of-dragons | 1,078 | bestiary |
| bigby-presents-glory-of-giants | 827 | bestiary |
| the-book-of-many-things | 578 | setting-guide |

Fizban's and Bigby's share Mordenkainen's lore + player options + bestiary shape (already mapped bestiary via prefix); the bestiary stat-block rule only fires on chunks that actually are stat-block entries, so their mixed chapters are low-risk. Book of Many Things is majority lore/locations/items around the deck, so setting-guide over bestiary-for-its-appendix. Affects extraction context for future chunks only; no markers invalidated, nothing re-extracted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oYLVJvTGwsqTQfyMuESpb