### PR TITLE
feat(chat): render Discord tables via the render_table helper (ADR 044)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.34
+version: 0.285.35
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -241,10 +241,13 @@ def build_system_prompt() -> str:
         "it yourself inline.\n\n"
         "FORMATTING FOR DISCORD:\n"
         "- Discord does NOT render markdown tables: a | col | col | table shows "
-        "up as raw pipes and dashes. For tabular data, either wrap it in a "
-        "triple-backtick code block so the columns line up in monospace, or for "
-        "wide or many-row data render it as an image with run_python and let "
-        "that attach.\n"
+        "up as raw pipes and dashes. To present tabular data, render it as an "
+        "image with run_python: the sandbox has a baked helper, so `from "
+        "sandbox_tools import render_table` then render_table(headers, rows, "
+        "title=...) which saves a styled table.png that attaches automatically. "
+        "For a tiny two or three row aside a triple-backtick code block also "
+        "reads fine (monospace lines the columns up), but prefer the rendered "
+        "image for anything real.\n"
         "- When run_python saves a file (a chart, an image), it is attached to "
         "your reply automatically. Never write a markdown image link or paste a "
         "file path like /tmp/chart.png: just say what it shows.\n\n"
@@ -684,6 +687,9 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
         /tmp: only files in the working directory are returned. Saved files are
         attached to the Discord reply automatically, so do not write a markdown
         image link or print the file path, just describe what the chart shows.
+        For tabular data, use the baked helper: `from sandbox_tools import
+        render_table` then render_table(headers, rows, title=None) writes a
+        styled table.png for you.
         """
         result = await run_python_in_sandbox(code)
         if result.get("error"):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.34
+      targetRevision: 0.285.35
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/sandbox/mcp.py
+++ b/projects/monolith/sandbox/mcp.py
@@ -35,6 +35,10 @@ async def run_python(code: str, files: list[dict] | None = None) -> dict:
     chart.png. Only files written to the working directory are returned, so an
     absolute path or a /tmp path is lost.
 
+    For tabular data there is a baked helper. Run "from sandbox_tools import
+    render_table" then render_table(headers, rows, title=None) to write a styled
+    table.png (dark header, zebra rows, numeric columns right-aligned).
+
     Args:
         code: The Python source to run. It is written to a file and executed
             with python3. Use print(...) for anything you want back as


### PR DESCRIPTION
PR 2 of 2 for table-as-image. HOLD merge until the guest helper (#3247, fc-invoke 0.4.41) is live in the sandbox, so Bosun never calls render_table before it is deployed.

Upgrades the interim code-block table rule (#3244): tabular data now renders as a styled image via the baked sandbox helper (`from sandbox_tools import render_table`), which attaches automatically. A code block stays as the lightweight fallback for a tiny 2-3 row aside.

Documented in three places: the concierge run_python @agent.tool docstring, the MCP run_python docstring (free of Context Forge forbidden characters), and the FORMATTING FOR DISCORD system-prompt rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
