### PR TITLE
feat(grimoire): harden extraction (site-scoped rooms, numeric grounding, edge provenance)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.34
+version: 0.285.35
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260706000000_grimoire_extraction_hardening.sql
+++ b/projects/monolith/chart/migrations/20260706000000_grimoire_extraction_hardening.sql
@@ -1,0 +1,20 @@
+-- Grimoire extraction hardening: two nullable columns that sharpen extraction
+-- identity and provenance. Both are metadata-only additions (a nullable column
+-- with no default is no table rewrite and no backfill).
+
+-- entity.site: the parent-place key for a location that is its own keyed entry
+-- (a dungeon room's containing site), lower-cased. Dedup for locations becomes
+-- book-scoped and site-aware, so same-named rooms in different dungeons or books
+-- ("Kitchen" is a heading in 11 books) stay distinct instead of merging under
+-- the global (entity_type, lower(name)) key. NULL for non-location entities and
+-- for prose location references that name no site. Mirror of Entity.site in
+-- grimoire/models.py.
+ALTER TABLE grimoire.entity
+    ADD COLUMN site TEXT;
+
+-- relationship.chunk_id: the knowledge_chunk an edge was first extracted from.
+-- Dedup stays on the (from, to, rel_type) triple, so the first writer's chunk
+-- wins and a duplicate never overwrites it. Nullable: edges written before this
+-- column have NULL. Mirror of Relationship.chunk_id in grimoire/models.py.
+ALTER TABLE grimoire.relationship
+    ADD COLUMN chunk_id uuid REFERENCES grimoire.knowledge_chunk (id);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:0PMgy3K3jSKFtQsP3ErjJYlAqRwGSW7TkewY/W59+K4=
+h1:2Rfk50T6VgAWNLsw/uAVnHBT3VC83R6pPHgupQhHjh0=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -106,3 +106,4 @@ h1:0PMgy3K3jSKFtQsP3ErjJYlAqRwGSW7TkewY/W59+K4=
 20260705150000_grimoire_extraction_v4.sql h1:6jZyBNNUrqDYx4+0ZyUMbSVN8sqxA0o/wEKNXXLewYc=
 20260705160000_grimoire_adventure.sql h1:xn1/EzoHZiJs5V8AbhnKGAK/LTKm72hNEN4//1ku9FQ=
 20260705170000_grimoire_adventure_seed.sql h1:Vl1WQ3RxunbWB/FmRTPGvehf0r21idknxokKIsEPZGY=
+20260706000000_grimoire_extraction_hardening.sql h1:R5hltTip79gwuh+mJqTAbN8IY9D2TR8jDA6qBlHZXBM=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.34
+      targetRevision: 0.285.35
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/grimoire/extract.py
+++ b/projects/monolith/grimoire/extract.py
@@ -14,6 +14,15 @@ split across chunks (lore in one, stat block in another) ends up whole, while a
 later chunk never clobbers a value an earlier one already set. This keeps the
 job idempotent (a re-run fills nothing new) and needs no reconciliation pass.
 
+Locations are the one exception (they alone name rooms, and the same room name
+recurs across dungeons and books): a ``location`` is deduped within its own
+``source_book`` and by a ``site`` key, the parent place of the room's keyed
+entry (see ``_room_site``). Two same-named rooms under different sites, or in
+different books, stay separate nodes; a bare same-book reference that names no
+site still resolves to the book's single candidate, but an ambiguous one never
+guesses. Every other entity type keeps the global ``(entity_type, lower(name))``
+dedup unchanged.
+
 Cache-key semantics: a chunk is considered processed for a given
 ``(model, prompt_version)`` once a ``grimoire.chunk_extraction`` marker row
 exists for that key (see ``models.ChunkExtraction``). The key uses the prompt
@@ -1260,15 +1269,84 @@ _DETAIL_FIELD_TYPES: dict[type, dict[str, type]] = {
 }
 
 
+# Numeric detail fields gated on being anchored in the chunk text (spec Change 3):
+# creature ac/hp_avg/cr and spell level. On a chunk with no stat block the model
+# sometimes fills these from memory, and on third-party books those are reliably
+# wrong. A value that fails the check is dropped (never fails the chunk) and
+# counted in the run's ``detail_ungrounded_drops``. Ability scores, speed,
+# actions, traits, and prose fields are NOT gated (a post-run verifier covers
+# those).
+_GROUNDED_NUMERIC_FIELDS: frozenset[str] = frozenset({"ac", "hp_avg", "cr", "level"})
+
+# Non-integral CRs that appear as a fraction in stat blocks. A decimal cr maps to
+# both its decimal spelling and this fraction; an integral cr appears as a plain
+# int ("Challenge 2"), handled by ``{value:g}``.
+_CR_FRACTIONS: dict[float, str] = {0.125: "1/8", 0.25: "1/4", 0.5: "1/2"}
+
+
+def _cr_text_variants(value: float) -> list[str]:
+    """Textual forms a CR value may take in a stat block: the decimal spelling
+    ("2", "0.5") plus the canonical fraction for the three fractional CRs."""
+    variants = [f"{value:g}"]
+    fraction = _CR_FRACTIONS.get(round(float(value), 3))
+    if fraction is not None:
+        variants.append(fraction)
+    return variants
+
+
+def _grounded_numeric(chunk_text: str, field_name: str, value: Any) -> bool:
+    """Whether a numeric detail value is anchored in the chunk text (spec Change 3).
+
+    Case-insensitive. ``ac``/``hp_avg`` match their stat-block label followed by
+    the integer; ``cr`` matches Challenge/CR followed by the decimal or fraction
+    form; spell ``level`` matches "cantrip" for 0 and the ordinal or "level N"
+    form for N >= 1. A field not covered here is treated as grounded.
+    """
+    flags = re.IGNORECASE
+    if field_name == "ac":
+        v = re.escape(str(int(value)))
+        return bool(
+            re.search(rf"\bArmor Class[:\s]*{v}\b", chunk_text, flags)
+            or re.search(rf"\bAC[:\s]*{v}\b", chunk_text, flags)
+        )
+    if field_name == "hp_avg":
+        v = re.escape(str(int(value)))
+        return bool(
+            re.search(rf"\bHit Points[:\s]*{v}\b", chunk_text, flags)
+            or re.search(rf"\bHP[:\s]*{v}\b", chunk_text, flags)
+        )
+    if field_name == "cr":
+        alts = "|".join(re.escape(v) for v in _cr_text_variants(float(value)))
+        return bool(
+            re.search(rf"\bChallenge[:\s]*(?:{alts})\b", chunk_text, flags)
+            or re.search(rf"\bCR[:\s]*(?:{alts})\b", chunk_text, flags)
+        )
+    if field_name == "level":
+        n = int(value)
+        if n == 0:
+            return bool(re.search(r"\bcantrip\b", chunk_text, flags))
+        return bool(
+            re.search(rf"\b{n}(?:st|nd|rd|th)[-\s]level", chunk_text, flags)
+            or re.search(rf"\blevel {n}\b", chunk_text, flags)
+        )
+    return True
+
+
 def _coerce_detail_fields(
-    detail_model: type, entity_name: str, detail: dict
+    detail_model: type,
+    entity_name: str,
+    detail: dict,
+    chunk_text: str,
+    drops: dict[str, int],
 ) -> dict[str, Any]:
     """Coerce a raw detail payload to typed field kwargs (no entity_id).
 
     Any key in ``detail`` not in the model's known field set is silently
     ignored (defensive against the model inventing extra fields); a known
     field whose value cannot be coerced to the expected type is dropped
-    with a warning rather than failing the whole chunk.
+    with a warning rather than failing the whole chunk. The four numeric
+    stat fields in ``_GROUNDED_NUMERIC_FIELDS`` are additionally dropped (and
+    tallied in ``drops``) when their value is not anchored in ``chunk_text``.
     """
     field_types = _DETAIL_FIELD_TYPES[detail_model]
     coerced: dict[str, Any] = {}
@@ -1294,7 +1372,7 @@ def _coerce_detail_fields(
             continue
         # int / float
         try:
-            coerced[field_name] = expected_type(value)
+            coerced_value = expected_type(value)
         except (TypeError, ValueError):
             logger.warning(
                 "grimoire extract: dropping uncoercible detail field %s.%s=%r for %r",
@@ -1303,6 +1381,13 @@ def _coerce_detail_fields(
                 value,
                 entity_name,
             )
+            continue
+        if field_name in _GROUNDED_NUMERIC_FIELDS and not _grounded_numeric(
+            chunk_text, field_name, coerced_value
+        ):
+            drops[field_name] = drops.get(field_name, 0) + 1
+            continue
+        coerced[field_name] = coerced_value
     return coerced
 
 
@@ -1330,7 +1415,13 @@ def _apply_generic_detail(entity: Entity, item: dict) -> None:
 
 
 def _create_or_enrich_detail(
-    session: Session, detail_model: type, entity_id: str, entity_name: str, detail: dict
+    session: Session,
+    detail_model: type,
+    entity_id: str,
+    entity_name: str,
+    detail: dict,
+    chunk_text: str,
+    drops: dict[str, int],
 ) -> None:
     """Insert the typed detail row, or enrich an existing one (ADR 012 rev.).
 
@@ -1338,8 +1429,12 @@ def _create_or_enrich_detail(
     is still NULL, and a JSONB dict column is key-merged with existing keys
     winning. So a monster whose lore and stat block land in different chunks
     ends up whole, while a later chunk never clobbers an earlier one's value.
+    ``chunk_text``/``drops`` flow into the numeric grounding gate in
+    ``_coerce_detail_fields``.
     """
-    coerced = _coerce_detail_fields(detail_model, entity_name, detail)
+    coerced = _coerce_detail_fields(
+        detail_model, entity_name, detail, chunk_text, drops
+    )
     if not coerced:
         return
     existing = session.get(detail_model, entity_id)
@@ -1395,16 +1490,68 @@ def _canonicalize_name(name: str) -> str:
     return name
 
 
+def _room_site(chunk: KnowledgeChunk, canonical_name: str) -> str | None:
+    """The parent-place ``site`` key for a location that IS this chunk's own keyed
+    entry, used to keep same-named rooms in different dungeons/books distinct.
+
+    The breadcrumb (``section_hierarchy``, else ``section_path``) is split on
+    " > ". Only when it has >= 2 segments AND its leaf canonicalizes to this
+    entity's own name (so the chunk is that location's keyed entry, not a passing
+    mention) is the second-to-last segment returned, canonicalized and
+    lower-cased, as the site. A prose mention (leaf != name) or a top-level place
+    (< 2 segments) returns None, so a bare reference never guesses a site.
+    """
+    breadcrumb = chunk.section_hierarchy or chunk.section_path
+    if not breadcrumb:
+        return None
+    segments = breadcrumb.split(" > ")
+    if len(segments) < 2:
+        return None
+    if _canonicalize_name(segments[-1]).lower() != canonical_name.lower():
+        return None
+    return _canonicalize_name(segments[-2]).lower()
+
+
+def _pick_location_candidate(
+    candidates: list[Entity], site: str | None
+) -> Entity | None:
+    """Choose which same-book, same-name location (if any) to reuse (spec Change 1).
+
+    ``candidates`` are the same-book locations sharing this name, oldest first.
+    A room entry (site set) reuses only a candidate whose site matches, else it
+    forces a new node. A site-less reference prefers a site-less candidate, else
+    reuses the lone candidate when there is exactly one, else stays ambiguous
+    (None -> new node) so a bare "Kitchen" never guesses among several rooms.
+    """
+    if site is not None:
+        for candidate in candidates:
+            if candidate.site == site:
+                return candidate
+        return None
+    null_site = [c for c in candidates if c.site is None]
+    if null_site:
+        return null_site[0]
+    if len(candidates) == 1:
+        return candidates[0]
+    return None
+
+
 def _get_or_create_entity(
     session: Session,
     chunk: KnowledgeChunk,
     item: dict,
     local_by_name: dict[str, Entity],
+    drops: dict[str, int],
 ) -> tuple[Entity, bool] | None:
     """Resolve or create the Entity spine (+ detail row, if new) for one extracted entity.
 
     Returns ``(entity, created)`` or None if ``item`` is not a usable entity
     (missing/invalid entity_type or name).
+
+    Dedup is global by ``(entity_type, lower(name))`` for every type except
+    ``location``, which is scoped to ``source_book`` and a ``site`` key (the
+    room's parent place; see ``_room_site`` / ``_pick_location_candidate``) so
+    same-named rooms across dungeons and books do not merge.
     """
     entity_type = item.get("entity_type")
     name = item.get("name")
@@ -1415,16 +1562,37 @@ def _get_or_create_entity(
         return None
     name_key = name.lower()
 
-    existing = (
-        session.execute(
-            select(Entity).where(
-                Entity.entity_type == entity_type,
-                func.lower(Entity.name) == name_key,
+    if entity_type == "location":
+        # Book- and site-scoped dedup: a global (location, lower(name)) key would
+        # merge every "Kitchen"/"Cellar" room across dungeons and books.
+        site = _room_site(chunk, name)
+        candidates = list(
+            session.execute(
+                select(Entity)
+                .where(
+                    Entity.entity_type == "location",
+                    func.lower(Entity.name) == name_key,
+                    Entity.source_book == chunk.book_id,
+                )
+                .order_by(Entity.created_at)
             )
+            .scalars()
+            .all()
         )
-        .scalars()
-        .first()
-    )
+        existing = _pick_location_candidate(candidates, site)
+    else:
+        site = None
+        existing = (
+            session.execute(
+                select(Entity).where(
+                    Entity.entity_type == entity_type,
+                    func.lower(Entity.name) == name_key,
+                )
+            )
+            .scalars()
+            .first()
+        )
+
     if existing is not None:
         entity = existing
         created = False
@@ -1436,6 +1604,7 @@ def _get_or_create_entity(
             source_type="extracted",
             is_global=True,
             source_book=chunk.book_id,
+            site=site,
         )
         session.add(entity)
         session.flush()
@@ -1451,7 +1620,9 @@ def _get_or_create_entity(
     detail = item.get("detail")
     if detail_model is not None:
         if isinstance(detail, dict) and detail:
-            _create_or_enrich_detail(session, detail_model, entity.id, name, detail)
+            _create_or_enrich_detail(
+                session, detail_model, entity.id, name, detail, chunk.content, drops
+            )
     else:
         _apply_generic_detail(entity, item)
 
@@ -1459,22 +1630,36 @@ def _get_or_create_entity(
 
 
 def _resolve_entity_name(
-    session: Session, local_by_name: dict[str, Entity], name: str
+    session: Session, local_by_name: dict[str, Entity], name: str, book_id: str
 ) -> Entity | None:
-    """Resolve a bare name to an Entity: this chunk's extraction first, then the DB.
+    """Resolve a bare name to an Entity for a mention/relationship endpoint.
 
-    Name lookup is global (not scoped to a single entity_type), matching how
-    mentions/relationships reference entities by name alone. If more than
-    one entity_type shares a name, an arbitrary match is returned; this
-    ambiguity is accepted for v1. The name is canonicalized the same way the
-    spine name is, so an endpoint referencing "The Zhentarim" resolves to the
-    "Zhentarim" node (spec #3).
+    Resolution order: this chunk's freshly-extracted entities (the local map),
+    then the oldest same-``book_id`` entity of that name, then the global first
+    match. The same-book step keeps an endpoint pointing at its own book's node
+    (e.g. a room's book-scoped keyed entry) instead of a same-named node from
+    another book. Lookup is not scoped to a single entity_type, matching how
+    mentions/relationships reference entities by name alone; an arbitrary match
+    is still accepted when several types share a name. The name is canonicalized
+    the same way the spine name is, so an endpoint referencing "The Zhentarim"
+    resolves to the "Zhentarim" node (spec #3).
     """
     name_key = _canonicalize_name(name).lower()
     if not name_key:
         return None
     if name_key in local_by_name:
         return local_by_name[name_key]
+    same_book = (
+        session.execute(
+            select(Entity)
+            .where(func.lower(Entity.name) == name_key, Entity.source_book == book_id)
+            .order_by(Entity.created_at)
+        )
+        .scalars()
+        .first()
+    )
+    if same_book is not None:
+        return same_book
     return (
         session.execute(select(Entity).where(func.lower(Entity.name) == name_key))
         .scalars()
@@ -1506,7 +1691,11 @@ def _insert_mention(
 
 
 def _insert_relationship(
-    session: Session, from_entity_id: str, to_entity_id: str, rel_type: str
+    session: Session,
+    from_entity_id: str,
+    to_entity_id: str,
+    rel_type: str,
+    chunk_id: str,
 ) -> bool:
     existing = (
         session.execute(
@@ -1520,10 +1709,15 @@ def _insert_relationship(
         .first()
     )
     if existing is not None:
+        # First writer wins: the dedup triple already exists, so its chunk_id
+        # provenance is left as-is.
         return False
     session.add(
         Relationship(
-            from_entity_id=from_entity_id, to_entity_id=to_entity_id, rel_type=rel_type
+            from_entity_id=from_entity_id,
+            to_entity_id=to_entity_id,
+            rel_type=rel_type,
+            chunk_id=chunk_id,
         )
     )
     return True
@@ -1602,6 +1796,12 @@ def _apply_extraction(
         # to reorder a backwards edge or downgrade an impossible one to RELATED_TO.
         "rel_signature_swaps": {},
         "rel_signature_downgrades": {},
+        # Per-field tally of numeric detail values dropped for not being anchored
+        # in the chunk text (creature ac/hp_avg/cr, spell level; spec Change 3).
+        "detail_ungrounded_drops": {},
+        # Edges skipped because both endpoints resolved to the same entity (a
+        # self loop, e.g. a validator downgrade produced X RELATED_TO X).
+        "rel_self_loops_dropped": 0,
     }
     with session.begin_nested():
         local_by_name: dict[str, Entity] = {}
@@ -1609,7 +1809,9 @@ def _apply_extraction(
         for item in extraction["entities"]:
             if not isinstance(item, dict):
                 continue
-            result = _get_or_create_entity(session, chunk, item, local_by_name)
+            result = _get_or_create_entity(
+                session, chunk, item, local_by_name, counts["detail_ungrounded_drops"]
+            )
             if result is None:
                 continue
             entity, created = result
@@ -1629,7 +1831,7 @@ def _apply_extraction(
             name = mention.get("entity_name")
             if not isinstance(name, str):
                 continue
-            entity = _resolve_entity_name(session, local_by_name, name)
+            entity = _resolve_entity_name(session, local_by_name, name, chunk.book_id)
             if entity is None:
                 logger.debug(
                     "grimoire extract: chunk %s unresolvable mention name %r",
@@ -1660,8 +1862,12 @@ def _apply_extraction(
             # small strict-schema leak (a provider that silently downgrades
             # json_schema), so the graph keeps a queryable closed vocabulary.
             rel_type = rel_type if rel_type in REL_TYPE_SET else RELATED_TO
-            from_entity = _resolve_entity_name(session, local_by_name, from_name)
-            to_entity = _resolve_entity_name(session, local_by_name, to_name)
+            from_entity = _resolve_entity_name(
+                session, local_by_name, from_name, chunk.book_id
+            )
+            to_entity = _resolve_entity_name(
+                session, local_by_name, to_name, chunk.book_id
+            )
             # Drop edges whose endpoints do not resolve to an emitted/known
             # entity: they would be silently lost at write time anyway, and an
             # unresolvable endpoint is the signature of a generic-type or unnamed
@@ -1695,7 +1901,16 @@ def _apply_extraction(
                     counts["rel_signature_downgrades"].get(rel_type, 0) + 1
                 )
             rel_type = new_rel_type
-            if _insert_relationship(session, from_entity.id, to_entity.id, rel_type):
+            # Self-loop guard: after resolution and any validator swap, both
+            # endpoints can be the same entity (two name variants resolving to one
+            # node, sometimes after a downgrade to RELATED_TO). An X -> X edge is
+            # never meaningful, so drop it and count it.
+            if from_entity.id == to_entity.id:
+                counts["rel_self_loops_dropped"] += 1
+                continue
+            if _insert_relationship(
+                session, from_entity.id, to_entity.id, rel_type, chunk.id
+            ):
                 counts["relationships_created"] += 1
 
     return counts
@@ -1727,6 +1942,26 @@ async def _embed_new_entities(
             session, embed_client.model, "entity", entities_only, vectors
         )
     return embedded
+
+
+def _section_context(chunk: KnowledgeChunk, kind: str | None) -> str | None:
+    """Section breadcrumb to feed the extractor for one chunk (spec Change 2).
+
+    Non-bestiary books get the full ancestry breadcrumb (``section_hierarchy``,
+    else the leaf ``section_path``), the same context the model was tuned on. But
+    the backfilled bestiary hierarchies mis-nest sibling entries under one heading
+    (a large share of a bestiary's chunks falsely nest under a neighbor), so the
+    full breadcrumb would feed the model false containment. For a bestiary we pass
+    leaf-only context instead: the 2-level ``section_path`` when set, else the last
+    " > " segment of the hierarchy.
+    """
+    if kind == "bestiary":
+        if chunk.section_path:
+            return chunk.section_path
+        if chunk.section_hierarchy:
+            return chunk.section_hierarchy.split(" > ")[-1]
+        return None
+    return chunk.section_hierarchy or chunk.section_path
 
 
 def _load_book_titles(session: Session) -> dict[str, str]:
@@ -1788,6 +2023,10 @@ async def extract_chunks(
         # merged across chunks below.
         "rel_signature_swaps": {},
         "rel_signature_downgrades": {},
+        # Per-field ungrounded numeric-detail drops (dict field -> count) and the
+        # self-loop edge drop count, merged across chunks below.
+        "detail_ungrounded_drops": {},
+        "rel_self_loops_dropped": 0,
     }
 
     for group_start in range(0, len(chunks), group_size):
@@ -1799,9 +2038,10 @@ async def extract_chunks(
             *(
                 or_client.extract(
                     chunk.content,
-                    # Prefer the full hierarchy breadcrumb; fall back to the leaf
-                    # heading when a chunk predates the section_hierarchy backfill.
-                    section_path=chunk.section_hierarchy or chunk.section_path,
+                    # Full hierarchy breadcrumb by default (leaf-only for
+                    # bestiaries, whose backfilled hierarchies mis-nest); falls
+                    # back to the leaf heading when a chunk predates the backfill.
+                    section_path=_section_context(chunk, book_kind(chunk.book_id)),
                     image_ref=chunk.image_ref,
                     book_title=book_titles.get(chunk.book_id, chunk.book_id),
                     book_kind=book_kind(chunk.book_id),

--- a/projects/monolith/grimoire/extract_test.py
+++ b/projects/monolith/grimoire/extract_test.py
@@ -190,7 +190,11 @@ def test_extract_chunks_earlier_groups_commit_before_a_later_failure(
 
 def test_extract_chunks_happy_path(session: Session):
     chunk = _make_chunk(
-        session, "mm", "mm-001", "An owlbear stalks the Zhentarim camp."
+        session,
+        "mm",
+        "mm-001",
+        "An owlbear stalks the Zhentarim camp. "
+        "Armor Class 13, Hit Points 59, Challenge 3.",
     )
 
     existing_npc = Entity(entity_type="npc", name="Existing NPC", source_book="mm")
@@ -248,6 +252,9 @@ def test_extract_chunks_happy_path(session: Session):
         # no swap, no downgrade.
         "rel_signature_swaps": {},
         "rel_signature_downgrades": {},
+        # Stats are anchored in the chunk text, so nothing is dropped; no self loop.
+        "detail_ungrounded_drops": {},
+        "rel_self_loops_dropped": 0,
     }
 
     entities = session.execute(select(Entity)).scalars().all()
@@ -312,6 +319,8 @@ def test_extract_chunks_rerun_skips_already_marked_chunks(session: Session):
         "entities_embedded": 0,
         "rel_signature_swaps": {},
         "rel_signature_downgrades": {},
+        "detail_ungrounded_drops": {},
+        "rel_self_loops_dropped": 0,
     }
     assert len(or_client.calls) == calls_before
 
@@ -433,8 +442,18 @@ def test_failed_extraction_leaves_no_marker(session: Session):
 def test_extract_chunks_name_dedup_reuses_and_does_not_overwrite_detail(
     session: Session,
 ):
-    chunk1 = _make_chunk(session, "mm", "mm-001", "An owlbear guards the lair.")
-    chunk2 = _make_chunk(session, "mm", "mm-002", "The owlbear returns to its den.")
+    chunk1 = _make_chunk(
+        session,
+        "mm",
+        "mm-001",
+        "An owlbear guards the lair. Armor Class 13, Hit Points 59.",
+    )
+    chunk2 = _make_chunk(
+        session,
+        "mm",
+        "mm-002",
+        "The owlbear returns to its den. Armor Class 99, Hit Points 1.",
+    )
     responses = {
         chunk1.content: {
             "entities": [
@@ -488,8 +507,13 @@ def test_extract_chunks_enriches_disjoint_detail_across_chunks(
     # A monster whose lore and stat block land in different chunks: chunk1 sets
     # only cr + a partial actions blob, chunk2 adds ac/hp + more actions. The
     # entity must end up whole (ADR 012 rev. enrich, not first-wins).
-    chunk1 = _make_chunk(session, "mm", "mm-001", "Aboleth lore, cr only.")
-    chunk2 = _make_chunk(session, "mm", "mm-002", "Aboleth stat block.")
+    chunk1 = _make_chunk(session, "mm", "mm-001", "Aboleth lore. Challenge 10.")
+    chunk2 = _make_chunk(
+        session,
+        "mm",
+        "mm-002",
+        "Aboleth stat block. Armor Class 17, Hit Points 135, Challenge 99.",
+    )
     responses = {
         chunk1.content: {
             "entities": [
@@ -1163,16 +1187,17 @@ def test_canonical_names_dedupe_article_and_map_key_variants(session: Session):
 
 
 def test_extract_passes_context_to_client(session: Session):
-    """extract_chunks threads the hierarchy (preferred over leaf), image_ref, and
-    book title + genre into the extract call."""
-    session.add(Book(id="monster-manual", display_name="Monster Manual"))
+    """extract_chunks threads the hierarchy (preferred over leaf for a non-bestiary
+    book), image_ref, and book title + genre into the extract call. Bestiaries take
+    the leaf-only quarantine path, covered separately below."""
+    session.add(Book(id="curse-of-strahd", display_name="Curse of Strahd"))
     chunk = KnowledgeChunk(
-        book_id="monster-manual",
-        chunk_ref="mm-001",
-        content="A caption of a dragon.",
-        section_path="A > BRASS DRAGON",
-        section_hierarchy="Chapter 1: Dragons > Metallic Dragons > BRASS DRAGON",
-        image_ref="s3://grimoire/img/brass.png",
+        book_id="curse-of-strahd",
+        chunk_ref="cos-001",
+        content="A caption of a castle.",
+        section_path="A > Castle Ravenloft",
+        section_hierarchy="Chapter 4: Barovia > Svalich Woods > Castle Ravenloft",
+        image_ref="s3://grimoire/img/castle.png",
     )
     session.add(chunk)
     session.commit()
@@ -1202,11 +1227,11 @@ def test_extract_passes_context_to_client(session: Session):
 
     # The full hierarchy breadcrumb is preferred over the 2-level section_path.
     assert captured["section_path"] == (
-        "Chapter 1: Dragons > Metallic Dragons > BRASS DRAGON"
+        "Chapter 4: Barovia > Svalich Woods > Castle Ravenloft"
     )
-    assert captured["image_ref"] == "s3://grimoire/img/brass.png"
-    assert captured["book_title"] == "Monster Manual"
-    assert captured["book_kind"] == "bestiary"
+    assert captured["image_ref"] == "s3://grimoire/img/castle.png"
+    assert captured["book_title"] == "Curse of Strahd"
+    assert captured["book_kind"] == "adventure"
 
 
 def test_extract_falls_back_to_leaf_section_and_book_id(session: Session):
@@ -1645,3 +1670,368 @@ async def test_openrouter_client_extract_raises_after_failed_correction():
             await client.extract("chunk text")
 
     assert mock_client.post.call_count == 2
+
+
+# --- extraction hardening: site-scoped locations, numeric gate, provenance ----
+
+
+def _make_chunk_h(
+    session: Session,
+    book_id: str,
+    chunk_ref: str,
+    content: str,
+    hierarchy: str,
+) -> KnowledgeChunk:
+    """A chunk carrying a section_hierarchy breadcrumb (for the site/quarantine
+    paths), committed and refreshed like _make_chunk."""
+    chunk = KnowledgeChunk(
+        book_id=book_id,
+        chunk_ref=chunk_ref,
+        content=content,
+        section_hierarchy=hierarchy,
+    )
+    session.add(chunk)
+    session.commit()
+    session.refresh(chunk)
+    return chunk
+
+
+def _location_response(name: str, summary: str) -> dict:
+    return {
+        "entities": [{"entity_type": "location", "name": name, "summary": summary}],
+        "mentions": [],
+        "relationships": [],
+    }
+
+
+def test_location_same_name_different_sites_stay_separate(session: Session):
+    """Two rooms both named 'Kitchen' under different sites in ONE book are two
+    distinct location entities, not one merged node."""
+    c1 = _make_chunk_h(
+        session, "cos", "cos-001", "A castle kitchen.", "Castle Ravenloft > Kitchen"
+    )
+    c2 = _make_chunk_h(
+        session, "cos", "cos-002", "A village kitchen.", "Village of Barovia > Kitchen"
+    )
+    responses = {
+        c1.content: _location_response("Kitchen", "In the castle."),
+        c2.content: _location_response("Kitchen", "In the village."),
+    }
+    _run(extract_chunks(session, FakeOpenRouterClient(responses), FakeEmbedClient()))
+
+    locations = (
+        session.execute(select(Entity).where(Entity.entity_type == "location"))
+        .scalars()
+        .all()
+    )
+    assert len(locations) == 2
+    assert {e.site for e in locations} == {"castle ravenloft", "village of barovia"}
+
+
+def test_location_same_room_entry_reused(session: Session):
+    """A second keyed entry for the same room (same name, site, and book) reuses
+    the existing node instead of forking a duplicate."""
+    c1 = _make_chunk_h(
+        session, "cos", "cos-001", "Kitchen, first pass.", "Castle Ravenloft > Kitchen"
+    )
+    c2 = _make_chunk_h(
+        session, "cos", "cos-002", "Kitchen, second pass.", "Castle Ravenloft > Kitchen"
+    )
+    responses = {
+        c1.content: _location_response("Kitchen", "A."),
+        c2.content: _location_response("Kitchen", "B."),
+    }
+    summary = _run(
+        extract_chunks(session, FakeOpenRouterClient(responses), FakeEmbedClient())
+    )
+
+    locations = (
+        session.execute(select(Entity).where(Entity.entity_type == "location"))
+        .scalars()
+        .all()
+    )
+    assert len(locations) == 1
+    assert locations[0].site == "castle ravenloft"
+    assert summary["entities_created"] == 1
+    assert summary["entities_reused"] == 1
+
+
+def test_location_same_name_different_books_stay_separate(session: Session):
+    """The same room name in two different books never merges (dedup is
+    book-scoped for locations)."""
+    c1 = _make_chunk_h(
+        session, "cos", "cos-001", "Kitchen in cos.", "Castle Ravenloft > Kitchen"
+    )
+    c2 = _make_chunk_h(
+        session, "lmop", "lmop-001", "Kitchen in lmop.", "Cragmaw Castle > Kitchen"
+    )
+    responses = {
+        c1.content: _location_response("Kitchen", "A."),
+        c2.content: _location_response("Kitchen", "B."),
+    }
+    _run(extract_chunks(session, FakeOpenRouterClient(responses), FakeEmbedClient()))
+
+    locations = (
+        session.execute(select(Entity).where(Entity.entity_type == "location"))
+        .scalars()
+        .all()
+    )
+    assert len(locations) == 2
+    assert {e.source_book for e in locations} == {"cos", "lmop"}
+
+
+def test_location_prose_reference_reuses_unique_same_book_candidate(session: Session):
+    """A site-less (prose) reference to a location resolves to the book's single
+    same-named candidate, the keyed room entry, rather than forking a new node."""
+    c1 = _make_chunk_h(
+        session, "swn", "swn-001", "The town of Nightstone.", "Sword Coast > Nightstone"
+    )
+    # No breadcrumb: a bare prose reference, so _room_site returns None.
+    c2 = _make_chunk(session, "swn", "swn-002", "Nightstone is mentioned again.")
+    responses = {
+        c1.content: _location_response("Nightstone", "A town."),
+        c2.content: _location_response("Nightstone", "Seen again."),
+    }
+    summary = _run(
+        extract_chunks(session, FakeOpenRouterClient(responses), FakeEmbedClient())
+    )
+
+    locations = (
+        session.execute(select(Entity).where(Entity.entity_type == "location"))
+        .scalars()
+        .all()
+    )
+    assert len(locations) == 1
+    # The keyed entry's site is retained; the prose reference reused it.
+    assert locations[0].site == "sword coast"
+    assert summary["entities_reused"] == 1
+
+
+def test_creature_dedup_remains_global_across_books(session: Session):
+    """Only locations are book-scoped; a creature of the same name still dedups
+    globally across books."""
+    c1 = _make_chunk(session, "mm", "mm-001", "A goblin lurks.")
+    c2 = _make_chunk(session, "tob", "tob-001", "A goblin reappears.")
+    responses = {
+        c1.content: {
+            "entities": [
+                {"entity_type": "creature", "name": "Goblin", "summary": "A."}
+            ],
+            "mentions": [],
+            "relationships": [],
+        },
+        c2.content: {
+            "entities": [
+                {"entity_type": "creature", "name": "Goblin", "summary": "B."}
+            ],
+            "mentions": [],
+            "relationships": [],
+        },
+    }
+    _run(extract_chunks(session, FakeOpenRouterClient(responses), FakeEmbedClient()))
+
+    creatures = (
+        session.execute(select(Entity).where(Entity.entity_type == "creature"))
+        .scalars()
+        .all()
+    )
+    assert len(creatures) == 1
+
+
+def test_numeric_gate_keeps_grounded_ac_drops_absent_hp(session: Session):
+    """An AC anchored in the chunk text is kept; an HP the model invented (absent
+    from the text) is dropped and tallied in detail_ungrounded_drops."""
+    chunk = _make_chunk(session, "mm", "mm-001", "The ogre is tough. Armor Class 15.")
+    responses = {
+        chunk.content: {
+            "entities": [
+                {
+                    "entity_type": "creature",
+                    "name": "Ogre",
+                    "summary": "Big.",
+                    "detail": {"ac": 15, "hp_avg": 200},
+                }
+            ],
+            "mentions": [],
+            "relationships": [],
+        }
+    }
+    summary = _run(
+        extract_chunks(session, FakeOpenRouterClient(responses), FakeEmbedClient())
+    )
+
+    detail = session.execute(select(EntityCreature)).scalars().one()
+    assert detail.ac == 15
+    assert detail.hp_avg is None
+    assert summary["detail_ungrounded_drops"] == {"hp_avg": 1}
+
+
+def test_numeric_gate_cr_grounded_by_fraction_form(session: Session):
+    """A fractional CR grounds against the fraction spelling in the text
+    ('Challenge 1/2' grounds cr=0.5)."""
+    chunk = _make_chunk(session, "mm", "mm-001", "A weak kobold. Challenge 1/2.")
+    responses = {
+        chunk.content: {
+            "entities": [
+                {
+                    "entity_type": "creature",
+                    "name": "Kobold",
+                    "summary": "Small.",
+                    "detail": {"cr": 0.5},
+                }
+            ],
+            "mentions": [],
+            "relationships": [],
+        }
+    }
+    summary = _run(
+        extract_chunks(session, FakeOpenRouterClient(responses), FakeEmbedClient())
+    )
+
+    detail = session.execute(select(EntityCreature)).scalars().one()
+    assert detail.cr == pytest.approx(0.5)
+    assert summary["detail_ungrounded_drops"] == {}
+
+
+def test_numeric_gate_spell_level_zero_grounded_by_cantrip(session: Session):
+    """Spell level 0 grounds on the word 'cantrip'."""
+    from grimoire.models import EntitySpell
+
+    chunk = _make_chunk(
+        session, "phb", "phb-001", "Prestidigitation is a cantrip of minor magic."
+    )
+    responses = {
+        chunk.content: {
+            "entities": [
+                {
+                    "entity_type": "spell",
+                    "name": "Prestidigitation",
+                    "summary": "Minor magic.",
+                    "detail": {"level": 0, "school": "transmutation"},
+                }
+            ],
+            "mentions": [],
+            "relationships": [],
+        }
+    }
+    summary = _run(
+        extract_chunks(session, FakeOpenRouterClient(responses), FakeEmbedClient())
+    )
+
+    detail = session.execute(select(EntitySpell)).scalars().one()
+    assert detail.level == 0
+    assert detail.school == "transmutation"
+    assert summary["detail_ungrounded_drops"] == {}
+
+
+def test_self_loop_edge_dropped(session: Session):
+    """An edge whose endpoints resolve to the same entity (X -> X) is dropped and
+    counted in rel_self_loops_dropped."""
+    chunk = _make_chunk(session, "cos", "cos-001", "Strahd broods alone.")
+    responses = {
+        chunk.content: {
+            "entities": [
+                {"entity_type": "npc", "name": "Strahd", "summary": "A vampire."}
+            ],
+            "mentions": [],
+            "relationships": [
+                {"from_name": "Strahd", "to_name": "Strahd", "rel_type": "ENEMY_OF"}
+            ],
+        }
+    }
+    summary = _run(
+        extract_chunks(session, FakeOpenRouterClient(responses), FakeEmbedClient())
+    )
+
+    assert summary["rel_self_loops_dropped"] == 1
+    assert summary["relationships_created"] == 0
+    assert session.execute(select(Relationship)).scalars().all() == []
+
+
+def test_relationship_rows_carry_chunk_id(session: Session):
+    """A newly created relationship row records the chunk it was extracted from."""
+    chunk = _make_chunk(session, "lmop", "lmop-001", "Klarg leads the Cragmaw goblins.")
+    responses = {
+        chunk.content: {
+            "entities": [
+                {"entity_type": "npc", "name": "Klarg", "summary": "A bugbear."},
+                {"entity_type": "faction", "name": "Cragmaw", "summary": "A tribe."},
+            ],
+            "mentions": [],
+            "relationships": [
+                {"from_name": "Klarg", "to_name": "Cragmaw", "rel_type": "LEADER_OF"}
+            ],
+        }
+    }
+    _run(extract_chunks(session, FakeOpenRouterClient(responses), FakeEmbedClient()))
+
+    rel = session.execute(select(Relationship)).scalars().one()
+    assert rel.chunk_id == chunk.id
+
+
+def test_bestiary_passes_leaf_only_section_context(session: Session):
+    """A bestiary chunk gets leaf-only section context (the backfilled hierarchy
+    mis-nests, so it is quarantined in favor of the 2-level section_path)."""
+    session.add(Book(id="monster-manual", display_name="Monster Manual"))
+    chunk = KnowledgeChunk(
+        book_id="monster-manual",
+        chunk_ref="mm-001",
+        content="Aarakocra patrol the Howling Gyre.",
+        section_path="AARAKOCRA",
+        section_hierarchy="Appendix A > Misnested Sibling > AARAKOCRA",
+    )
+    session.add(chunk)
+    session.commit()
+
+    captured: dict = {}
+
+    class CapturingClient(FakeOpenRouterClient):
+        async def extract(
+            self,
+            chunk_text,
+            section_path=None,
+            image_ref=None,
+            book_title=None,
+            book_kind=None,
+        ):
+            captured.update(section_path=section_path, book_kind=book_kind)
+            return {"entities": [], "mentions": [], "relationships": []}
+
+    _run(extract_chunks(session, CapturingClient({}), FakeEmbedClient(), limit=25))
+
+    assert captured["book_kind"] == "bestiary"
+    # Leaf-only: the mis-nesting hierarchy is dropped, the 2-level section_path wins.
+    assert captured["section_path"] == "AARAKOCRA"
+
+
+def test_adventure_passes_full_hierarchy_section_context(session: Session):
+    """A non-bestiary (adventure) chunk keeps the full ancestry breadcrumb."""
+    session.add(Book(id="curse-of-strahd", display_name="Curse of Strahd"))
+    chunk = KnowledgeChunk(
+        book_id="curse-of-strahd",
+        chunk_ref="cos-001",
+        content="A blood-stained surgery.",
+        section_path="Chapter 13 > Surgery",
+        section_hierarchy="Chapter 13: The Abbey > L17. Surgery",
+    )
+    session.add(chunk)
+    session.commit()
+
+    captured: dict = {}
+
+    class CapturingClient(FakeOpenRouterClient):
+        async def extract(
+            self,
+            chunk_text,
+            section_path=None,
+            image_ref=None,
+            book_title=None,
+            book_kind=None,
+        ):
+            captured.update(section_path=section_path, book_kind=book_kind)
+            return {"entities": [], "mentions": [], "relationships": []}
+
+    _run(extract_chunks(session, CapturingClient({}), FakeEmbedClient(), limit=25))
+
+    assert captured["book_kind"] == "adventure"
+    assert captured["section_path"] == "Chapter 13: The Abbey > L17. Surgery"

--- a/projects/monolith/grimoire/models.py
+++ b/projects/monolith/grimoire/models.py
@@ -152,6 +152,13 @@ class Entity(SQLModel, table=True):
     )
     is_global: bool = True
     source_book: str | None = None
+    # Parent-place key for a location that is its own keyed entry (a dungeon
+    # room's containing site), lower-cased. Keeps same-named rooms in different
+    # dungeons/books distinct under the otherwise-global (entity_type,
+    # lower(name)) dedup; NULL for non-location entities and for prose location
+    # references that name no site. Mirror of the column added in
+    # 20260706000000_grimoire_extraction_hardening.sql.
+    site: str | None = None
     created_in_session: str | None = Field(default=None, sa_column=_uuid_column())
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
@@ -419,6 +426,15 @@ class Relationship(SQLModel, table=True):
     )
     rel_type: str
     properties: dict = Field(default_factory=dict, sa_column=Column(_JSONB))
+    # The knowledge_chunk this edge was first extracted from (provenance). Dedup
+    # is on the (from, to, rel_type) triple, so the first writer's chunk wins and
+    # a later duplicate never overwrites it. Nullable: edges written before this
+    # column, and any future non-extraction writer, have NULL. Mirror of the
+    # column added in 20260706000000_grimoire_extraction_hardening.sql.
+    chunk_id: str | None = Field(
+        default=None,
+        sa_column=_uuid_column(nullable=True, fk="grimoire.knowledge_chunk.id"),
+    )
 
 
 class Embedding(SQLModel, table=True):


### PR DESCRIPTION
Pre-run hardening from the Fable final eval (TUNE-FIRST items), gating the one-time full-corpus v5 extraction.

- Site-scoped location identity: new nullable grimoire.entity.site column. A keyed-room entry (entity name == canonicalized leaf heading) dedups by (name, source_book, site = parent breadcrumb segment); other locations dedup by (name, source_book); all other types keep global dedup. Prevents the cross-book and within-book franken-room merges (kitchen appears as a heading in 11 books; 3251 colliding canonical leaf headings corpus-wide). Endpoint/mention resolution now prefers chunk-local then same-book before global.
- Bestiary breadcrumb quarantine: bestiaries get leaf-only section context; the backfilled bestiary hierarchies mis-nest sibling entries (41% of tome-of-beasts-3 chunks falsely nested under one heading) and the prompt trusts the breadcrumb for containment.
- Numeric grounding gate: creature ac/hp_avg/cr and spell level persist only when anchored in the chunk text (2014 and 2024 stat-block formats, fraction-aware CR). Eval showed in-chunk stats transcribe ~100% faithfully while from-memory stats on third-party books were wrong in 3/3 cases. Drops are counted in a new detail_ungrounded_drops run-summary monitor.
- Self-loop guard: X -> X edges are dropped and counted (a validator downgrade produced one in the eval).
- Edge provenance: relationship.chunk_id records the first extracting chunk (audit metadata; dedup triple unchanged).

Code-side only: no prompt text changes, all PROMPT_VERSIONS remain byte-frozen. Migration adds two nullable columns (no rewrite, no backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7ZgvJn73wmQFsEnXJEquW