### PR TITLE
fix(grimoire): loader must not clobber backfilled section_hierarchy with None

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.35
+version: 0.285.36
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -610,8 +610,13 @@ jobs:
         requests:
           cpu: 250m
           memory: 512Mi
+        # marker re-parses each book's whole raw output.json in memory; the
+        # largest (Monster Manual, 45MB raw) OOMs a 512Mi limit. Memory
+        # requests=limits per the sizing convention would cost 4Gi of quota on
+        # an inert cronworkflow, so this manual-only job keeps a low request
+        # with a 4Gi ceiling.
         limits:
-          memory: 512Mi
+          memory: 4Gi
 
 frontend:
   otelCollectorUrl: ""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.35
+      targetRevision: 0.285.36
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/grimoire/ingest.py
+++ b/projects/monolith/grimoire/ingest.py
@@ -324,9 +324,19 @@ def _upsert_book_chunks(
                 # so a change to it is a metadata-only upsert like section_path:
                 # it updates in place and does NOT re-embed. This is what makes the
                 # v2 hierarchy backfill a cheap metadata reload, not a 40k re-embed.
+                #
+                # A None hierarchy in the NDJSON must NOT clobber a stored
+                # breadcrumb: the original books' NDJSONs predate hierarchy baking,
+                # so a scheduled load-chunks re-run would silently erase the whole
+                # hierarchy backfill (it did, 2026-07-06, mid extraction run). The
+                # stored value wins until a re-uploaded NDJSON actually carries a
+                # hierarchy of its own.
+                incoming_hierarchy = item["section_hierarchy"]
+                if incoming_hierarchy is None:
+                    incoming_hierarchy = existing.section_hierarchy
                 meta_changed = (
                     existing.section_path != item["section_path"]
-                    or existing.section_hierarchy != item["section_hierarchy"]
+                    or existing.section_hierarchy != incoming_hierarchy
                     or existing.image_ref != item["image_ref"]
                 )
                 # seq is corrected on every run but is not itself an "upsert":
@@ -337,7 +347,7 @@ def _upsert_book_chunks(
                 if content_changed or meta_changed:
                     existing.content = item["content"]
                     existing.section_path = item["section_path"]
-                    existing.section_hierarchy = item["section_hierarchy"]
+                    existing.section_hierarchy = incoming_hierarchy
                     existing.image_ref = item["image_ref"]
                     upserted += 1
                     # Only re-embed when the embedded text (content) changed; a

--- a/projects/monolith/grimoire/ingest_test.py
+++ b/projects/monolith/grimoire/ingest_test.py
@@ -415,6 +415,41 @@ def test_load_chunks_upserts_book_row_once(session: Session):
     assert session.get(Book, "mm").display_name == "Monster Manual"
 
 
+def test_load_chunks_none_hierarchy_never_clobbers_backfilled_value(
+    session: Session,
+):
+    # The original books' NDJSONs predate hierarchy baking, so a scheduled
+    # loader re-run carries section_hierarchy=None for every chunk. That None
+    # must not erase a breadcrumb the backfill job wrote (it did exactly that
+    # on 2026-07-06, wiping the corpus-wide backfill mid extraction run).
+    s3 = FakeS3Client({"books/cos/chunks/chunks.ndjson": _line("c1", "one")})
+    embedder = FakeEmbedClient()
+    _run(ingest.load_chunks(session, s3, embedder, bucket="grimoire"))
+
+    chunk = session.execute(select(KnowledgeChunk)).scalars().one()
+    assert chunk.section_hierarchy is None
+    chunk.section_hierarchy = "Chapter 4: Castle Ravenloft > K37. Study"
+    session.add(chunk)
+    session.commit()
+
+    # Re-run over the same hierarchy-less NDJSON: the stored breadcrumb wins.
+    _run(ingest.load_chunks(session, s3, embedder, bucket="grimoire"))
+    chunk = session.execute(select(KnowledgeChunk)).scalars().one()
+    assert chunk.section_hierarchy == "Chapter 4: Castle Ravenloft > K37. Study"
+
+    # A re-uploaded NDJSON that actually carries a hierarchy still updates it.
+    s3 = FakeS3Client(
+        {
+            "books/cos/chunks/chunks.ndjson": _line(
+                "c1", "one", section_hierarchy="Chapter 4 > K37. Study (rev)"
+            )
+        }
+    )
+    _run(ingest.load_chunks(session, s3, embedder, bucket="grimoire"))
+    chunk = session.execute(select(KnowledgeChunk)).scalars().one()
+    assert chunk.section_hierarchy == "Chapter 4 > K37. Study (rev)"
+
+
 def test_load_chunks_default_display_name_title_cases_hyphenated_id(
     session: Session,
 ):


### PR DESCRIPTION
The 33 original books' NDJSONs predate hierarchy baking, so the nightly
grimoire-load-chunks run upserted section_hierarchy=None over every chunk,
erasing the corpus-wide backfill (observed 2026-07-06 at 02:00Z, 30 minutes
before the full v5 extraction launched: the run produced zero sited rooms).
The stored breadcrumb now wins unless the NDJSON actually carries one.

Also bumps the manual-only grimoire-backfill-hierarchy job's memory limit
to 4Gi (Monster Manual's 45MB raw OOMs 512Mi), closing the deferred item, so
the backfill can be re-run for all books after this deploys.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F7ZgvJn73wmQFsEnXJEquW
