### PR TITLE
feat(grimoire): v6 prompt (tables as one entity, class_feature heading recall) + table type

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.36
+version: 0.285.37
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260706010000_grimoire_table_type.sql
+++ b/projects/monolith/chart/migrations/20260706010000_grimoire_table_type.sql
@@ -1,0 +1,31 @@
+-- Grimoire extraction v6: the `table` entity type (mechanics category).
+-- A table or list of options (a treasure/magic-item table, a spell list, a class
+-- progression, a random-encounter table) is now captured as ONE `table` entity
+-- instead of exploding into dozens of junk row entities ("+1 Arrow", a bare
+-- "3rd Level" spell-list heading). Metadata-only: this widens the entity_type
+-- CHECK by one value; no new column, no data backfill.
+
+-- Expand the entity_type CHECK to add `table`. The live constraint is
+-- entity_entity_type_check: the original inline column CHECK in
+-- 20260703070000_grimoire_schema.sql was unnamed, so Postgres auto-named it
+-- entity_entity_type_check (the "_check" convention), and
+-- 20260705150000_grimoire_extraction_v4.sql dropped and re-added it under that
+-- same name. Drop and re-add it again with `table` appended to the v4 taxonomy.
+ALTER TABLE grimoire.entity DROP CONSTRAINT entity_entity_type_check;
+ALTER TABLE grimoire.entity ADD CONSTRAINT entity_entity_type_check CHECK (
+    entity_type IN (
+        -- lore (unchanged from v1)
+        'creature', 'spell', 'location', 'npc', 'faction', 'deity', 'item',
+        -- gameplay
+        'event', 'quest',
+        -- mechanics
+        'condition', 'feat', 'race', 'background', 'class', 'subclass',
+        'class_feature', 'action', 'rule',
+        -- v6: a table/list captured as one entity
+        'table'
+    )
+);
+
+-- `category` needs no change: `table` falls into the GENERATED column's ELSE
+-- 'mechanics' branch (added in 20260705150000_grimoire_extraction_v4.sql),
+-- mirrored code-side by models._ENTITY_CATEGORY_EXPR.

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:2Rfk50T6VgAWNLsw/uAVnHBT3VC83R6pPHgupQhHjh0=
+h1:T4kKtWbe6PSVmIKwS+DJA0VxLG8b9Gjy0zEl4ml2BuM=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -107,3 +107,4 @@ h1:2Rfk50T6VgAWNLsw/uAVnHBT3VC83R6pPHgupQhHjh0=
 20260705160000_grimoire_adventure.sql h1:xn1/EzoHZiJs5V8AbhnKGAK/LTKm72hNEN4//1ku9FQ=
 20260705170000_grimoire_adventure_seed.sql h1:Vl1WQ3RxunbWB/FmRTPGvehf0r21idknxokKIsEPZGY=
 20260706000000_grimoire_extraction_hardening.sql h1:R5hltTip79gwuh+mJqTAbN8IY9D2TR8jDA6qBlHZXBM=
+20260706010000_grimoire_table_type.sql h1:pw2njEe9GQobGDUWLSZgGtYH1khJqoRpxtll/uNzHuU=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.36
+      targetRevision: 0.285.37
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/grimoire/extract.py
+++ b/projects/monolith/grimoire/extract.py
@@ -20,7 +20,11 @@ recurs across dungeons and books): a ``location`` is deduped within its own
 entry (see ``_room_site``). Two same-named rooms under different sites, or in
 different books, stay separate nodes; a bare same-book reference that names no
 site still resolves to the book's single candidate, but an ambiguous one never
-guesses. Every other entity type keeps the global ``(entity_type, lower(name))``
+guesses. ``table`` (v6) is deduped within ``source_book`` too but WITHOUT the
+site logic: table captions ("Random Encounters") repeat across books, so a
+same-named table in another book stays separate, while a repeat within one book
+(a table split across chunks) reuses the oldest candidate and key-merges its
+rows. Every other entity type keeps the global ``(entity_type, lower(name))``
 dedup unchanged.
 
 Cache-key semantics: a chunk is considered processed for a given
@@ -98,12 +102,13 @@ DEFAULT_LIMIT = 25
 # also bounds the group size for the incremental per-group commit below.
 DEFAULT_CONCURRENCY = 6
 
-# v4 generic typed-extraction taxonomy (spec v4). ~18 entity types grouped by the
-# DERIVED category: lore (unchanged from v1), gameplay (event/quest), and mechanics
-# (D&D game rules). ``category`` itself is a stored generated column on the entity
-# spine (models._ENTITY_CATEGORY_EXPR / the migration), not a value the extractor
-# emits. ENTITY_TYPES is the union: it gates the spine (unknown types are dropped
-# in _get_or_create_entity) and feeds the json_schema entity_type enum.
+# v4 generic typed-extraction taxonomy (spec v4), widened to 19 types by v6's
+# ``table``. Grouped by the DERIVED category: lore (unchanged from v1), gameplay
+# (event/quest), and mechanics (D&D game rules + the v6 ``table`` container).
+# ``category`` itself is a stored generated column on the entity spine
+# (models._ENTITY_CATEGORY_EXPR / the migration), not a value the extractor emits.
+# ENTITY_TYPES is the union: it gates the spine (unknown types are dropped in
+# _get_or_create_entity) and feeds the json_schema entity_type enum.
 LORE_TYPES: frozenset[str] = frozenset(
     {"creature", "spell", "location", "npc", "faction", "deity", "item"}
 )
@@ -119,6 +124,10 @@ MECHANICS_TYPES: frozenset[str] = frozenset(
         "class_feature",
         "action",
         "rule",
+        # v6: a table/list of options captured as ONE entity (a treasure/magic-item
+        # table, spell list, class progression, random-encounter table) instead of
+        # N junk row entities. Book-scoped dedup in _get_or_create_entity.
+        "table",
     }
 )
 ENTITY_TYPES = set(LORE_TYPES | GAMEPLAY_TYPES | MECHANICS_TYPES)
@@ -879,19 +888,49 @@ A `class_feature` is a feature a PLAYER CHARACTER gains from a class or subclass
 _V5_PROMPT_TEXT = _V4_PROMPT_TEXT + _V5_MECHANICS_CLARIFICATION_ADDENDUM
 
 
+# v6: two extraction defects the first full v5 corpus run surfaced (see
+# grimoire/prompt-backlog.md). (1) Treasure/magic-item tables and spell lists were
+# exploded into dozens of junk row entities ("+1 Arrow", "10 Gems worth 100 GP")
+# and a bare "3rd Level" spell-list heading became a phantom class_feature; the new
+# ``table`` type captures a whole table as ONE entity. (2) 2024-format class
+# features under "LEVEL N: NAME" headings returned empty (recall loss). v5 verbatim
+# (so v5 stays byte-frozen) PLUS an addendum; the schema object is unchanged (it now
+# carries the wider entity_type enum via EXTRACT_SCHEMA). Built by concatenation; do
+# NOT edit this text once released, add a v7 instead.
+_V6_TABLE_AND_RECALL_ADDENDUM = """
+
+TABLES, CLASS FEATURE HEADINGS, AND ANTHOLOGIES (v6)
+Everything above still holds. These four clarifications change nothing else.
+
+TABLES ARE ONE ENTITY, NEVER ROW ENTITIES
+When a chunk is a table or a list of options (a treasure or magic-item table, a spell list, a class progression or level table, a random-encounter table, a rarity table), emit ONE entity with entity_type "table", named from the table's caption or the section heading (never from a row), and put the structure in "detail": dice (str, e.g. "d100", when it is a rollable table), columns (array of column names), rows (object keyed by the roll range or row index, with the row's text as the value). Do NOT emit the rows as entities: "+1 Arrow" from a treasure table, a spell name from a class spell list, or a level row is NOT an item, spell, or class_feature entity. A row's subject is an entity only when it is separately the stat-blocked subject of its own entry elsewhere. If the table continues from a previous chunk (no caption, rows only), still emit the same-named table entity with the additional rows.
+The table's "summary" MUST say what the table is FOR and what its rows contain, so it can be found by meaning, not just by caption: "Random magic items of common and uncommon rarity for treasure hoards at levels 5-10, rolled on a d100", never a restatement of the caption like "A table of magic items." The table entity's summary MUST be genuinely descriptive: say what the table is FOR and what its rows contain, because only name + summary is embedded for search (the rows in detail are never embedded), so a bare caption restatement is invisible to search by meaning. Write "Random magic items of common and uncommon rarity for treasure hoards at levels 5-10, rolled on a d100", NOT "A table of magic items", and never leave the summary as a restatement of the caption.
+
+CLASS FEATURE HEADINGS
+In a class or subclass chapter, a heading of the form "LEVEL N: FEATURE NAME" (for example "LEVEL 3: HAND OF HEALING", "LEVEL 7: EVASION") IS that class or subclass feature: extract it as class_feature with detail.level = N. But a BARE level heading with no feature name ("3RD LEVEL", "10th Level") sitting over a list of spells or options is a table or list heading, NOT a class_feature; capture it as a "table".
+
+ADVENTURE ANTHOLOGIES
+A book genre of "adventure-anthology" is a collection of standalone adventures; apply the adventure-module rules to each adventure's content.
+
+Keep it tight: these clarifications change nothing else; everything above still holds."""
+
+_V6_PROMPT_TEXT = _V5_PROMPT_TEXT + _V6_TABLE_AND_RECALL_ADDENDUM
+
+
 PROMPT_VERSIONS: dict[str, PromptVersion] = {
     "v1": PromptVersion(text=_V1_PROMPT_TEXT, schema=None),
     "v2": PromptVersion(text=_V2_PROMPT_TEXT, schema=EXTRACT_SCHEMA),
     "v3": PromptVersion(text=_V3_PROMPT_TEXT, schema=EXTRACT_SCHEMA),
     "v4": PromptVersion(text=_V4_PROMPT_TEXT, schema=EXTRACT_SCHEMA),
     "v5": PromptVersion(text=_V5_PROMPT_TEXT, schema=EXTRACT_SCHEMA),
+    "v6": PromptVersion(text=_V6_PROMPT_TEXT, schema=EXTRACT_SCHEMA),
 }
 
 # The version the extraction pass writes and reads by default. Env-overridable so
-# a candidate (v5) can run on a fresh book without touching code; promotion is
+# a candidate (v7) can run on a fresh book without touching code; promotion is
 # moving this pointer. Read at import: jobs run as fresh processes, so the env is
 # honored per run.
-ACTIVE_PROMPT_VERSION = os.environ.get("GRIMOIRE_PROMPT_VERSION", "v5")
+ACTIVE_PROMPT_VERSION = os.environ.get("GRIMOIRE_PROMPT_VERSION", "v6")
 
 # Backward-compatible alias: the active version's system text. The
 # self-correction turn and any caller referencing EXTRACTION_PROMPT get the live
@@ -1401,11 +1440,24 @@ def _apply_generic_detail(entity: Entity, item: dict) -> None:
     are merged with existing keys winning (a fresh dict is reassigned so SQLAlchemy
     flags the column dirty), and temporality (a top-level field or a ``detail`` key)
     fills only when still NULL and only for event/quest.
+
+    The merge is one level deep for nested dict values: a top-level key whose value
+    is a dict in both the incoming and stored detail is itself key-merged (existing
+    keys winning) rather than replaced wholesale. This is what lets a ``table`` (v6)
+    split across chunks accumulate its ``rows`` object, and a class accumulate its
+    ``features_by_level`` map, instead of a continuation chunk being dropped. It
+    mirrors ``_create_or_enrich_detail``'s JSONB-column enrichment; arrays and
+    scalars still take existing-wins wholesale.
     """
     detail = item.get("detail")
     if isinstance(detail, dict) and detail:
         current = entity.detail or {}
-        entity.detail = {**detail, **current}
+        merged = {**detail, **current}
+        for key, incoming in detail.items():
+            stored = current.get(key)
+            if isinstance(incoming, dict) and isinstance(stored, dict):
+                merged[key] = {**incoming, **stored}
+        entity.detail = merged
     if entity.entity_type in TEMPORAL_TYPES and entity.temporality is None:
         temporality = item.get("temporality")
         if not isinstance(temporality, str) and isinstance(detail, dict):
@@ -1549,9 +1601,12 @@ def _get_or_create_entity(
     (missing/invalid entity_type or name).
 
     Dedup is global by ``(entity_type, lower(name))`` for every type except
-    ``location``, which is scoped to ``source_book`` and a ``site`` key (the
-    room's parent place; see ``_room_site`` / ``_pick_location_candidate``) so
-    same-named rooms across dungeons and books do not merge.
+    ``location`` and ``table``. ``location`` is scoped to ``source_book`` and a
+    ``site`` key (the room's parent place; see ``_room_site`` /
+    ``_pick_location_candidate``) so same-named rooms across dungeons and books do
+    not merge. ``table`` (v6) is scoped to ``source_book`` alone (no site): repeated
+    table captions like "Random Encounters" stay distinct across books but a table
+    split across chunks in one book reuses the oldest same-named candidate.
     """
     entity_type = item.get("entity_type")
     name = item.get("name")
@@ -1580,6 +1635,25 @@ def _get_or_create_entity(
             .all()
         )
         existing = _pick_location_candidate(candidates, site)
+    elif entity_type == "table":
+        # Book-scoped dedup WITHOUT site logic (v6): a table caption like "Random
+        # Encounters" recurs across books, so scope to source_book and reuse the
+        # oldest same-named candidate (a table split across chunks in one book), but
+        # never merge tables across books.
+        site = None
+        existing = (
+            session.execute(
+                select(Entity)
+                .where(
+                    Entity.entity_type == "table",
+                    func.lower(Entity.name) == name_key,
+                    Entity.source_book == chunk.book_id,
+                )
+                .order_by(Entity.created_at)
+            )
+            .scalars()
+            .first()
+        )
     else:
         site = None
         existing = (

--- a/projects/monolith/grimoire/extract_test.py
+++ b/projects/monolith/grimoire/extract_test.py
@@ -646,6 +646,7 @@ def test_released_prompt_versions_are_frozen_by_hash():
         "v3": "1d4f924fb55bc021dddffb320461e4a93c065bd2ef1946aeca95293e25959377",
         "v4": "2437034db1f660f0b2f0f130d55d1f94c4cdd039a170af6bd269dd7264ff71c9",
         "v5": "df94db206235900ce377e50162a2678c06b000f75960d0af4c2982972e4e7459",
+        "v6": "ebd026a353b5d752ff882112842e5bbb233e8c41cdb4742e73f4561d410f0c59",
     }
     # Every released version must be pinned (a new version needs a new pin here).
     assert set(frozen) == set(PROMPT_VERSIONS)
@@ -683,12 +684,11 @@ def test_v4_extends_v3():
     assert "OCCURRED_AT" in v4_text and "SUBCLASS_OF" in v4_text
 
 
-def test_v5_is_active_and_extends_v4():
-    """v5 is the active version, carries the same schema as v4, and contains v4's
-    text verbatim (built by concatenation) plus the two mechanics clarifications
-    (condition scope, class_feature vs monster abilities). Prompt text only: same
-    schema object as v4."""
-    assert ACTIVE_PROMPT_VERSION == "v5"
+def test_v5_extends_v4():
+    """v5 carries the same schema as v4 and contains v4's text verbatim (built by
+    concatenation) plus the two mechanics clarifications (condition scope,
+    class_feature vs monster abilities). Prompt text only: same schema object as
+    v4. (v5 was the active version through v6's promotion.)"""
     assert PROMPT_VERSIONS["v5"].schema is PROMPT_VERSIONS["v4"].schema
     v5_text = PROMPT_VERSIONS["v5"].text
     assert v5_text.startswith(PROMPT_VERSIONS["v4"].text)
@@ -697,6 +697,26 @@ def test_v5_is_active_and_extends_v4():
     assert "Dancing Lights" in v5_text and "Darkvision" in v5_text
     assert "CLASS_FEATURE VS MONSTER ABILITIES" in v5_text
     assert "do not extract monster abilities as" in v5_text
+
+
+def test_v6_is_active_and_extends_v5():
+    """v6 is the active version, carries the same schema OBJECT as v4/v5 (now
+    widened with the `table` entity_type via EXTRACT_SCHEMA), and contains v5's
+    text verbatim (built by concatenation) plus the table / class_feature-heading /
+    anthology clarifications."""
+    assert ACTIVE_PROMPT_VERSION == "v6"
+    assert PROMPT_VERSIONS["v6"].schema is PROMPT_VERSIONS["v4"].schema
+    v6_text = PROMPT_VERSIONS["v6"].text
+    assert v6_text.startswith(PROMPT_VERSIONS["v5"].text)
+    # The table summary must be descriptive (it is the only text embedded for
+    # entity vector search besides the name).
+    assert "found by meaning, not just by caption" in v6_text
+    assert "TABLES ARE ONE ENTITY" in v6_text
+    assert "LEVEL N: FEATURE NAME" in v6_text
+    assert "adventure-anthology" in v6_text
+    # A table's rows live in detail (never embedded), so its summary must carry the
+    # searchable meaning; the addendum requires a genuinely descriptive summary.
+    assert "summary MUST be genuinely descriptive" in v6_text
 
 
 def test_non_enum_rel_type_mapped_to_related_to(session: Session):
@@ -2035,3 +2055,135 @@ def test_adventure_passes_full_hierarchy_section_context(session: Session):
 
     assert captured["book_kind"] == "adventure"
     assert captured["section_path"] == "Chapter 13: The Abbey > L17. Surgery"
+
+
+# --- v6 table type (one entity per table, book-scoped dedup, row merge) --------
+
+
+def _table_response(name: str, detail: dict) -> dict:
+    return {
+        "entities": [
+            {
+                "entity_type": "table",
+                "name": name,
+                "summary": "A rollable table.",
+                "detail": detail,
+            }
+        ],
+        "mentions": [],
+        "relationships": [],
+    }
+
+
+def test_table_entity_persists_with_mechanics_category_and_detail(session: Session):
+    """A table chunk yields ONE 'table' entity (not N row entities): it derives
+    category 'mechanics' and stores its structure in the generic detail JSONB."""
+    _summary, rows = _extract_entities(
+        session,
+        entities=[
+            {
+                "entity_type": "table",
+                "name": "Random Encounters",
+                "summary": "Roll for a wandering threat.",
+                "detail": {
+                    "dice": "d100",
+                    "columns": ["Roll", "Encounter"],
+                    "rows": {"01-10": "2 goblins", "11-20": "A brown bear"},
+                },
+            }
+        ],
+    )
+    assert len(rows) == 1  # one table entity, no row entities
+    table = rows[0]
+    assert table.entity_type == "table"
+    assert table.category == "mechanics"  # ELSE branch of the derived category
+    assert table.detail["dice"] == "d100"
+    assert table.detail["columns"] == ["Roll", "Encounter"]
+    assert table.detail["rows"]["01-10"] == "2 goblins"
+
+
+def test_table_same_name_different_books_stay_separate(session: Session):
+    """The same table caption in two books stays two entities (table dedup is
+    book-scoped, like locations)."""
+    c1 = _make_chunk(session, "dmg", "dmg-001", "Treasure table, DMG.")
+    c2 = _make_chunk(session, "xge", "xge-001", "Treasure table, XGE.")
+    responses = {
+        c1.content: _table_response("Random Encounters", {"rows": {"01": "A"}}),
+        c2.content: _table_response("Random Encounters", {"rows": {"01": "B"}}),
+    }
+    _run(extract_chunks(session, FakeOpenRouterClient(responses), FakeEmbedClient()))
+
+    tables = (
+        session.execute(select(Entity).where(Entity.entity_type == "table"))
+        .scalars()
+        .all()
+    )
+    assert len(tables) == 2
+    assert {e.source_book for e in tables} == {"dmg", "xge"}
+    # Tables carry no site (unlike locations); the spine site column stays NULL.
+    assert {e.site for e in tables} == {None}
+
+
+def test_table_same_book_reused_and_rows_key_merged(session: Session):
+    """The same table name within one book reuses the existing entity and key-merges
+    its rows: an existing row key wins on conflict, a new row key is added."""
+    c1 = _make_chunk(session, "dmg", "dmg-001", "Magic Item Table A, first half.")
+    c2 = _make_chunk(session, "dmg", "dmg-002", "Magic Item Table A, second half.")
+    responses = {
+        c1.content: _table_response(
+            "Magic Item Table A",
+            {"dice": "d100", "rows": {"01-50": "Potion of Healing"}},
+        ),
+        c2.content: _table_response(
+            # 01-50 conflicts (chunk1 must win); 51-60 is a new row key.
+            "Magic Item Table A",
+            {"rows": {"01-50": "WRONG", "51-60": "+1 Armor"}},
+        ),
+    }
+    summary = _run(
+        extract_chunks(session, FakeOpenRouterClient(responses), FakeEmbedClient())
+    )
+
+    tables = (
+        session.execute(select(Entity).where(Entity.entity_type == "table"))
+        .scalars()
+        .all()
+    )
+    assert len(tables) == 1
+    assert summary["entities_created"] == 1
+    assert summary["entities_reused"] == 1
+    detail = tables[0].detail
+    assert detail["dice"] == "d100"  # retained from chunk1
+    assert detail["rows"] == {"01-50": "Potion of Healing", "51-60": "+1 Armor"}
+
+
+def test_table_rows_merge_across_separate_runs(session: Session):
+    """A table split across chunks processed in SEPARATE runs accumulates rows: the
+    second run reuses the committed table entity and adds its new row keys without
+    clobbering the existing ones (the prompt's 'table continues from a previous
+    chunk' contract)."""
+    c1 = _make_chunk(session, "dmg", "dmg-001", "Wild Magic Surge, part 1.")
+    c2 = _make_chunk(session, "dmg", "dmg-002", "Wild Magic Surge, part 2.")
+    responses = {
+        c1.content: _table_response(
+            "Wild Magic Surge", {"dice": "d100", "rows": {"01-02": "Reroll"}}
+        ),
+        c2.content: _table_response(
+            "Wild Magic Surge", {"rows": {"03-04": "Fireball", "01-02": "CLOBBER"}}
+        ),
+    }
+    or_client = FakeOpenRouterClient(responses)
+    embed_client = FakeEmbedClient()
+    _run(extract_chunks(session, or_client, embed_client, limit=1))  # commits c1
+    _run(extract_chunks(session, or_client, embed_client, limit=1))  # reuses, merges
+
+    tables = (
+        session.execute(select(Entity).where(Entity.entity_type == "table"))
+        .scalars()
+        .all()
+    )
+    assert len(tables) == 1
+    detail = tables[0].detail
+    assert detail["dice"] == "d100"
+    # New row key added, existing key kept (chunk1 wins the 01-02 conflict).
+    assert detail["rows"] == {"01-02": "Reroll", "03-04": "Fireball"}

--- a/projects/monolith/grimoire/models.py
+++ b/projects/monolith/grimoire/models.py
@@ -28,8 +28,9 @@ from sqlmodel import JSON, Field, SQLModel
 # Mirror of the CHECK constraint in
 # chart/migrations/20260703070000_grimoire_schema.sql, expanded by
 # 20260705150000_grimoire_extraction_v4.sql to the generic typed-extraction set
-# (lore + gameplay + mechanics) - keep in sync. Grouped by the DERIVED category:
-# lore (unchanged from v1), gameplay (event/quest), mechanics (D&D game rules).
+# (lore + gameplay + mechanics) and by 20260706010000_grimoire_table_type.sql with
+# the mechanics `table` type - keep in sync. Grouped by the DERIVED category: lore
+# (unchanged from v1), gameplay (event/quest), mechanics (D&D game rules).
 EntityType = Literal[
     # lore
     "creature",
@@ -52,6 +53,9 @@ EntityType = Literal[
     "class_feature",
     "action",
     "rule",
+    # a table/list of options captured as ONE entity (v6): a treasure or magic-item
+    # table, a spell list, a class progression, a random-encounter table.
+    "table",
 ]
 # Category is DERIVED from entity_type by a stored generated column (see
 # _ENTITY_CATEGORY_EXPR / the migration), never written by the app.
@@ -107,7 +111,7 @@ class Entity(SQLModel, table=True):
             "'creature', 'spell', 'location', 'npc', 'faction', 'deity', 'item', "
             "'event', 'quest', "
             "'condition', 'feat', 'race', 'background', 'class', 'subclass', "
-            "'class_feature', 'action', 'rule')",
+            "'class_feature', 'action', 'rule', 'table')",
             name="entity_entity_type_chk",
         ),
         CheckConstraint(


### PR DESCRIPTION
Second relaunch-gating change from the aborted v5 run's live defects (see grimoire/prompt-backlog.md):

- New `table` entity type (mechanics category via the GENERATED column's ELSE branch): a treasure/magic-item table, spell list, class progression, or random-encounter table is ONE entity with dice/columns/rows in detail JSONB, never dozens of junk row entities ("+1 Arrow", a phantom "3rd Level" class_feature). Book-scoped dedup (captions repeat across books); split-across-chunks tables reassemble via a one-level deep-merge of nested detail dicts. Summary is required to be descriptive since name + summary is all that embeds for entity vector search.
- class_feature recall fix: 2024-format "LEVEL N: FEATURE NAME" headings extract as that feature (bare level headings over spell lists are tables, not features).
- adventure-anthology genre clause.

v1-v5 prompt texts byte-frozen (hashes re-verified); v6 built by concatenation; ACTIVE -> v6. Migration widens the entity_type CHECK by one value (drop/re-add of the live entity_entity_type_check, name verified against prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7ZgvJn73wmQFsEnXJEquW