### PR TITLE
style(grimoire): reskin to a clean, readable light/dark theme

### DIFF
--- a/docs/plans/assets/2026-07-05-grimoire-reskin-mockup.html
+++ b/docs/plans/assets/2026-07-05-grimoire-reskin-mockup.html
@@ -1,0 +1,721 @@
+<title>Grimoire Reskin</title>
+<style>
+  :root {
+    --paper: #f3f5f7;
+    --surface: #ffffff;
+    --surface-2: #edf0f4;
+    --line: #dbe0e7;
+    --line-soft: #e8ebef;
+    --text: #1a1f28;
+    --dim: #55606f;
+    --faint: #8a94a2;
+    --accent: #33507a;
+    --accent-strong: #26406a;
+    --accent-soft: rgba(51, 80, 122, 0.10);
+
+    --t-location: #2f8f6b;
+    --t-creature: #c0492b;
+    --t-npc: #b07d1e;
+    --t-faction: #7a52b0;
+    --t-deity: #a8811f;
+    --t-item: #b83f7a;
+    --t-spell: #2f7fbf;
+    --t-class: #556070;
+    --t-event: #7a6f3a;
+    --t-quest: #2f8f8a;
+
+    --serif: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --mono: "SF Mono", ui-monospace, "Cascadia Code", Menlo, monospace;
+  }
+  body.dark {
+    --paper: #0d1017;
+    --surface: #141924;
+    --surface-2: #1a2130;
+    --line: #2a3140;
+    --line-soft: #212836;
+    --text: #e8e2d0;
+    --dim: #9aa3b2;
+    --faint: #626d7e;
+    --accent: #7d9fd0;
+    --accent-strong: #93b0da;
+    --accent-soft: rgba(125, 159, 208, 0.14);
+
+    --t-location: #4f9a7a;
+    --t-creature: #d0684a;
+    --t-npc: #d9a441;
+    --t-faction: #9f81cc;
+    --t-deity: #e0cf8a;
+    --t-item: #d072a0;
+    --t-spell: #5aa8d6;
+    --t-class: #97a3b5;
+    --t-event: #b3a463;
+    --t-quest: #4fb0aa;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; }
+  body {
+    background: var(--paper);
+    color: var(--text);
+    font-family: var(--sans);
+    -webkit-font-smoothing: antialiased;
+    transition: background 0.3s, color 0.3s;
+  }
+
+  /* ---------------- top bar ---------------- */
+  header {
+    position: sticky; top: 0; z-index: 10;
+    display: flex; align-items: center; gap: 28px;
+    padding: 0 28px; height: 58px;
+    background: color-mix(in srgb, var(--paper) 88%, transparent);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--line);
+  }
+  .wordmark {
+    font-family: var(--sans); font-weight: 700; font-size: 14px;
+    letter-spacing: 0.28em; text-transform: uppercase; color: var(--text);
+  }
+  nav.tabs { display: flex; gap: 4px; margin-left: 8px; }
+  nav.tabs button {
+    background: none; border: 0; cursor: pointer; padding: 6px 12px;
+    font-family: var(--sans); font-size: 11px; font-weight: 600;
+    letter-spacing: 0.16em; text-transform: uppercase; color: var(--faint);
+    border-bottom: 2px solid transparent; margin-bottom: -1px;
+  }
+  nav.tabs button:hover { color: var(--dim); }
+  nav.tabs button.active { color: var(--text); border-bottom-color: var(--accent); }
+  .spacer { margin-left: auto; }
+  .toggle {
+    display: inline-flex; align-items: center; gap: 7px;
+    background: var(--surface-2); border: 1px solid var(--line);
+    border-radius: 999px; padding: 5px 6px; cursor: pointer; color: var(--dim);
+  }
+  .toggle svg { width: 15px; height: 15px; display: block; }
+  .toggle .knob {
+    width: 20px; height: 20px; border-radius: 50%;
+    display: grid; place-items: center; color: var(--accent);
+    background: var(--surface);
+  }
+
+  main { max-width: 1180px; margin: 0 auto; padding: 40px 28px 80px; }
+  .view { display: none; }
+  .view.active { display: block; }
+
+  .eyebrow { font-size: 11px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--faint); font-weight: 600; }
+  h1.display { font-family: var(--serif); font-weight: 600; font-size: 46px; line-height: 1.02; margin: 6px 0 0; letter-spacing: -0.01em; }
+  .backlink { font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent); text-decoration: none; }
+  .backlink:hover { text-decoration: underline; }
+  .summary { margin-top: 14px; color: var(--dim); font-size: 13.5px; font-variant-numeric: tabular-nums; }
+  .summary b { color: var(--text); font-weight: 600; }
+  .summary .dot { color: var(--faint); margin: 0 8px; }
+
+  /* ---------------- Library (grouped by book type, dense rows) ---------------- */
+  #bookList { margin-top: 6px; }
+  .lib-group { margin-top: 32px; }
+  .lib-group .gh { display: flex; align-items: baseline; gap: 10px; padding: 0 8px 8px; margin-bottom: 2px; border-bottom: 1px solid var(--line); }
+  .lib-group .gh .kind { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); font-weight: 700; }
+  .lib-group .gh .kn { font-size: 11px; color: var(--faint); font-variant-numeric: tabular-nums; }
+  .brow { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 15px; padding: 11px 8px; text-decoration: none; color: inherit; border-bottom: 1px solid var(--line-soft); border-radius: 7px; }
+  .brow:last-child { border-bottom: 0; }
+  .brow:hover { background: var(--surface-2); }
+  .brow .title { font-family: var(--serif); font-size: 18px; font-weight: 600; display: flex; align-items: center; gap: 9px; }
+  .brow .meta { margin-top: 2px; color: var(--dim); font-size: 12px; font-variant-numeric: tabular-nums; }
+  .brow .meta .dot { color: var(--faint); margin: 0 6px; }
+  .pill { font-family: var(--sans); font-size: 9px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent); background: var(--accent-soft); border-radius: 4px; padding: 2px 6px; }
+  .read { display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; font-size: 11px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent); opacity: 0; transition: opacity 0.15s; }
+  .brow:hover .read { opacity: 1; }
+
+  /* ---------------- Entities ---------------- */
+  .controls { margin-top: 26px; display: flex; flex-direction: column; gap: 14px; }
+  .search { position: relative; }
+  .search input {
+    width: 100%; height: 44px; padding: 0 14px 0 40px;
+    background: var(--surface); border: 1px solid var(--line); border-radius: 9px;
+    font-family: var(--sans); font-size: 15px; color: var(--text); outline: none;
+  }
+  .search input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+  .search .i { position: absolute; left: 14px; top: 13px; color: var(--faint); }
+  .chips { display: flex; flex-wrap: wrap; gap: 7px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
+    background: var(--surface); border: 1px solid var(--line); border-radius: 999px;
+    padding: 6px 13px 6px 10px; font-size: 12.5px; color: var(--dim);
+  }
+  .chip .sw { width: 9px; height: 9px; border-radius: 50%; }
+  .chip.on { color: var(--text); border-color: color-mix(in srgb, var(--accent) 45%, var(--line)); background: var(--accent-soft); }
+  .chip.all.on { background: var(--accent); color: #fff; border-color: var(--accent); }
+  .chip .n { color: var(--faint); font-size: 11px; font-variant-numeric: tabular-nums; }
+
+  .ent-grid {
+    margin-top: 22px; display: grid; gap: 8px;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  }
+  .ent {
+    display: flex; align-items: center; gap: 12px; cursor: pointer;
+    background: var(--surface); border: 1px solid var(--line-soft); border-radius: 8px;
+    border-left: 3px solid var(--ec, var(--faint)); padding: 11px 14px;
+    text-decoration: none; color: inherit; transition: background 0.12s, border-color 0.12s;
+  }
+  .ent:hover { background: var(--surface-2); border-color: var(--line); border-left-color: var(--ec); }
+  .ent .nm { font-family: var(--serif); font-size: 16px; line-height: 1.2; }
+  .ent .ty { margin-left: auto; font-size: 9.5px; letter-spacing: 0.13em; text-transform: uppercase; color: var(--faint); font-weight: 600; }
+  .ent .ty b { color: var(--ec); font-weight: 600; }
+
+  /* ---------------- Reader ---------------- */
+  .reader-wrap { display: grid; grid-template-columns: 244px 1fr; gap: 44px; margin-top: 28px; align-items: start; }
+  .toc { position: sticky; top: 90px; max-height: calc(100vh - 130px); overflow-y: auto; border-right: 1px solid var(--line-soft); padding-right: 20px; }
+  .toc h4 { font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--faint); margin: 0 0 12px; font-weight: 700; }
+  .toc ul { list-style: none; margin: 0; padding: 0; }
+  .toc .chap > a { font-family: var(--serif); font-size: 14.5px; color: var(--text); font-weight: 600; }
+  .toc a { display: block; text-decoration: none; color: var(--dim); padding: 4px 0 4px 12px; border-left: 2px solid transparent; margin-left: -2px; font-size: 13px; line-height: 1.3; }
+  .toc .sub a { padding-left: 22px; font-size: 12.5px; color: var(--dim); font-family: var(--sans); }
+  .toc a:hover { color: var(--text); }
+  .toc a.cur { color: var(--accent); border-left-color: var(--accent); font-weight: 600; }
+  .toc .chap { margin-bottom: 4px; }
+  .toc .sub { margin: 0 0 8px; }
+
+  article.page { max-width: 68ch; }
+  article.page .sec-label { font-size: 10.5px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); font-weight: 700; margin-bottom: 6px; }
+  article.page h2 { font-family: var(--serif); font-size: 30px; font-weight: 600; margin: 0 0 4px; letter-spacing: -0.01em; }
+  article.page h3 { font-family: var(--serif); font-size: 19px; font-weight: 600; margin: 30px 0 2px; }
+  article.page .rule { height: 1px; background: var(--line); border: 0; margin: 20px 0; }
+  article.page p { font-family: var(--serif); font-size: 17px; line-height: 1.66; margin: 0 0 14px; color: color-mix(in srgb, var(--text) 92%, var(--paper)); }
+  article.page p.credit { margin: 0 0 8px; }
+  article.page p.credit b { font-weight: 600; color: var(--text); }
+  article.page .drop::first-letter { initial-letter: 2; font-family: var(--serif); font-weight: 600; color: var(--accent); margin-right: 8px; }
+  .reader-topline { display: flex; align-items: center; gap: 10px; color: var(--faint); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; }
+  .reader-topline b { color: var(--dim); font-weight: 600; }
+
+  /* ---------------- Explore ---------------- */
+  .ex-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; margin-bottom: 16px; }
+  .lens-switch { display: flex; gap: 2px; background: var(--surface-2); border: 1px solid var(--line); border-radius: 9px; padding: 3px; }
+  .lens-switch button { background: none; border: 0; cursor: pointer; padding: 7px 14px; border-radius: 6px; font-family: var(--sans); font-size: 12px; font-weight: 600; color: var(--dim); }
+  .lens-switch button.on { background: var(--surface); color: var(--accent); box-shadow: 0 1px 2px rgba(20,30,50,0.1); }
+  .ex-controls { display: flex; align-items: center; gap: 14px; }
+  .scope-sel { display: inline-flex; align-items: center; gap: 8px; font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--faint); font-weight: 700; }
+  .scope-sel select { font-family: var(--serif); font-size: 15px; font-weight: 600; letter-spacing: 0; text-transform: none; color: var(--text); background: var(--surface); border: 1px solid var(--line); border-radius: 8px; padding: 8px 12px; cursor: pointer; }
+  .scope-sel select:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+  .ex-stage { position: relative; height: calc(100vh - 236px); min-height: 440px; border: 1px solid var(--line); border-radius: 12px; overflow: hidden; background: var(--surface); }
+  body.dark .ex-stage { background: var(--paper); }
+  .ex-stage canvas { display: block; width: 100%; height: 100%; cursor: grab; }
+  .ex-stage canvas.drag { cursor: grabbing; }
+  .ex-legend { position: absolute; top: 14px; left: 14px; display: flex; flex-direction: column; gap: 6px; background: color-mix(in srgb, var(--surface) 80%, transparent); backdrop-filter: blur(8px); border: 1px solid var(--line); border-radius: 9px; padding: 11px 13px; }
+  .ex-legend .row { display: flex; align-items: center; gap: 8px; font-size: 11.5px; color: var(--dim); }
+  .ex-legend .row .sw { width: 9px; height: 9px; border-radius: 50%; }
+  .ex-codex { position: absolute; top: 0; right: 0; bottom: 0; width: min(344px, 86%); background: color-mix(in srgb, var(--surface) 94%, transparent); backdrop-filter: blur(12px); border-left: 1px solid var(--line); transform: translateX(100%); transition: transform 0.3s cubic-bezier(0.22,0.61,0.36,1); padding: 24px 24px 32px; overflow-y: auto; }
+  .ex-codex.open { transform: translateX(0); }
+  .ex-codex .cx-close { position: absolute; top: 13px; right: 15px; background: none; border: 1px solid var(--line); border-radius: 6px; width: 27px; height: 27px; cursor: pointer; color: var(--dim); font-size: 15px; }
+  .ex-codex .cx-close:hover { color: var(--text); border-color: var(--accent); }
+  .ex-codex .cx-type { display: flex; align-items: center; gap: 8px; font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--faint); font-weight: 600; }
+  .ex-codex .cx-type .sw { width: 9px; height: 9px; border-radius: 50%; }
+  .ex-codex h2 { font-family: var(--serif); font-size: 25px; font-weight: 600; margin: 9px 0 0; line-height: 1.1; }
+  .ex-codex .cx-sum { font-family: var(--serif); font-size: 15px; line-height: 1.56; color: var(--dim); margin-top: 11px; }
+  .ex-codex .cx-h { font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); font-weight: 700; margin: 24px 0 8px; border-bottom: 1px solid var(--line-soft); padding-bottom: 7px; }
+  .ex-codex .cx-rel { display: flex; align-items: center; gap: 9px; padding: 6px 0; cursor: pointer; }
+  .ex-codex .cx-rel .sw { width: 7px; height: 7px; border-radius: 50%; flex: none; }
+  .ex-codex .cx-rel .v { font-family: var(--mono); font-size: 10px; color: var(--dim); min-width: 96px; }
+  .ex-codex .cx-rel .p { font-family: var(--serif); font-size: 14.5px; }
+  .ex-codex .cx-rel:hover .p { color: var(--accent); }
+
+  @media (max-width: 760px) {
+    .reader-wrap { grid-template-columns: 1fr; }
+    .toc { display: none; }
+    h1.display { font-size: 36px; }
+  }
+</style>
+
+<header>
+  <span class="wordmark">Grimoire</span>
+  <nav class="tabs">
+    <button data-view="library" class="active">Library</button>
+    <button data-view="entities">Entities</button>
+    <button data-view="explore">Explore</button>
+  </nav>
+  <span class="spacer"></span>
+  <button class="toggle" id="themeToggle" aria-label="Toggle light and dark">
+    <span class="knob" id="knob"></span>
+  </button>
+</header>
+
+<main>
+  <!-- ================= LIBRARY ================= -->
+  <section class="view active" id="v-library">
+    <div class="eyebrow">The Grimoire</div>
+    <h1 class="display">Library</h1>
+    <div class="summary"><b>33</b> books<span class="dot">/</span><b>40,514</b> chunks<span class="dot">/</span><b>5,750</b> images<span class="dot">/</span><b>9,147</b> entities<span class="dot">/</span>synced 1d ago</div>
+
+    <div class="book-list" id="bookList"></div>
+  </section>
+
+  <!-- ================= ENTITIES ================= -->
+  <section class="view" id="v-entities">
+    <a class="backlink" data-view="library" href="#">&larr; Library</a>
+    <h1 class="display" style="margin-top:10px">Entities</h1>
+    <div class="summary"><b>24,879</b> indexed across the corpus</div>
+
+    <div class="controls">
+      <div class="search">
+        <span class="i">&#9906;</span>
+        <input type="text" placeholder="Search 24,879 entities by name..." aria-label="Search entities" />
+      </div>
+      <div class="chips" id="chips"></div>
+    </div>
+
+    <div class="ent-grid" id="entGrid"></div>
+  </section>
+
+  <!-- ================= READER ================= -->
+  <section class="view" id="v-reader">
+    <a class="backlink" data-view="library" href="#" style="display:inline-block;margin-bottom:20px">&larr; Library</a>
+    <div class="reader-wrap">
+      <aside class="toc">
+        <h4>Curse of Strahd</h4>
+        <ul id="tocList"></ul>
+      </aside>
+      <div>
+        <div class="reader-topline"><b>Chapter 1</b> &middot; Into the Mists</div>
+        <article class="page">
+          <div class="sec-label">Introduction</div>
+          <h2>Into the Mists</h2>
+          <hr class="rule" />
+          <p class="drop">Under raging storm clouds, the vampire Count Strahd von Zarovich stands silhouetted against the ancient walls of Castle Ravenloft. Rumbling thunder pounds the castle spires. The wind's howling increases as he turns his gaze down toward the village of Barovia.</p>
+          <p>A lone figure emerges from the fog-shrouded gate, and Strahd knows it is time. His prey has arrived, and the hunt can begin anew. He has hunted this soul before, across centuries, and he will hunt it again.</p>
+
+          <h3>The Land of Barovia</h3>
+          <p>The Land of Barovia is surrounded by a wall of mist that whisks away anyone foolish enough to enter it. It is a place of death, controlled entirely by its monstrous lord.</p>
+
+          <h3>Credits</h3>
+          <p class="credit"><b>Imaging Technicians:</b> Daniel Corona, Kevin Yee</p>
+          <p class="credit"><b>Prepress Specialist:</b> Jefferson Dunlap</p>
+          <hr class="rule" />
+          <div class="sec-label">D&amp;D Studio</div>
+          <p class="credit"><b>Executive Producer:</b> Kyle Brink</p>
+          <p class="credit"><b>Game Architects:</b> Jeremy Crawford, Christopher Perkins</p>
+          <p class="credit"><b>Studio Art Director:</b> Josh Herman</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= EXPLORE ================= -->
+  <section class="view" id="v-explore">
+    <div class="ex-head">
+      <div><div class="eyebrow">The Grimoire</div><h1 class="display" style="margin-top:4px">Explore</h1></div>
+      <div class="ex-controls">
+        <label class="scope-sel"><span>Scope</span>
+          <select id="scopeSel">
+            <option value="cos">Curse of Strahd</option>
+            <option value="lmop">Lost Mine of Phandelver</option>
+            <option value="everything">Everything</option>
+          </select>
+        </label>
+        <div class="lens-switch" id="lensSwitch">
+          <button class="on" data-lens="world">World</button><button data-lens="story">Story</button><button data-lens="quests">Quests</button><button data-lens="rules">Rules</button>
+        </div>
+      </div>
+    </div>
+    <div class="ex-stage">
+      <canvas id="exCanvas"></canvas>
+      <div class="ex-legend" id="exLegend"></div>
+      <aside class="ex-codex" id="exCodex">
+        <button class="cx-close" id="cxClose" aria-label="Close">&times;</button>
+        <div id="cxBody"></div>
+      </aside>
+    </div>
+  </section>
+</main>
+
+<script>
+  // ---- theme toggle ----
+  const SUN = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>';
+  const MOON = '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>';
+  const knob = document.getElementById('knob');
+  function paintToggle() { knob.innerHTML = document.body.classList.contains('dark') ? MOON : SUN; }
+  document.getElementById('themeToggle').addEventListener('click', () => {
+    document.body.classList.toggle('dark'); paintToggle();
+  });
+  paintToggle();
+
+  // ---- view switching ----
+  function show(view) {
+    document.querySelectorAll('.view').forEach(v => v.classList.toggle('active', v.id === 'v-' + view));
+    const tab = view === 'reader' ? 'library' : view;  // Reader is nested under Library
+    document.querySelectorAll('nav.tabs button').forEach(b => b.classList.toggle('active', b.dataset.view === tab));
+    window.scrollTo(0, 0);
+  }
+  document.querySelectorAll('[data-view]').forEach(el =>
+    el.addEventListener('click', e => { e.preventDefault(); show(el.dataset.view); }));
+
+  // ---- Library data (grouped by book_kind) ----
+  const KIND_LABEL = { adventure: "Adventures", "adventure-anthology": "Anthologies", "setting-guide": "Setting Guides", bestiary: "Bestiaries", spellbook: "Spellbooks", "magic-items": "Magic Items", rulebook: "Rulebooks" };
+  const KIND_ORDER = ["adventure", "adventure-anthology", "setting-guide", "bestiary", "spellbook", "magic-items", "rulebook"];
+  const BOOKS = [
+    { t: "Curse of Strahd", i: "S", k: "adventure", chunks: 1057, images: 180, entities: 412 },
+    { t: "Lost Mine of Phandelver", i: "P", k: "adventure", chunks: 210, images: 44, entities: 96 },
+    { t: "Rime of the Frostmaiden", i: "R", k: "adventure", chunks: 1120, images: 240, entities: 388 },
+    { t: "Descent into Avernus", i: "A", k: "adventure", chunks: 990, images: 210, entities: 301 },
+    { t: "Candlekeep Mysteries", i: "C", k: "adventure-anthology", chunks: 932, images: 131, entities: 0, new: true },
+    { t: "Ghosts of Saltmarsh", i: "G", k: "adventure-anthology", chunks: 870, images: 150, entities: 214 },
+    { t: "Explorer's Guide to Wildemount", i: "W", k: "setting-guide", chunks: 1310, images: 280, entities: 640 },
+    { t: "Sword Coast Adventurer's Guide", i: "C", k: "setting-guide", chunks: 720, images: 110, entities: 355 },
+    { t: "Monster Manual", i: "M", k: "bestiary", chunks: 1200, images: 380, entities: 2412 },
+    { t: "Bigby Presents: Glory of Giants", i: "B", k: "bestiary", chunks: 827, images: 200, entities: 0, new: true },
+    { t: "Deep Magic", i: "D", k: "spellbook", chunks: 540, images: 60, entities: 720 },
+    { t: "Vault of Magic", i: "V", k: "magic-items", chunks: 610, images: 190, entities: 900 },
+    { t: "Player's Handbook", i: "H", k: "rulebook", chunks: 1440, images: 210, entities: 1806 },
+    { t: "Dungeon Master's Guide", i: "D", k: "rulebook", chunks: 1290, images: 170, entities: 640 },
+  ];
+  document.getElementById('bookList').innerHTML = KIND_ORDER.map(k => {
+    const rows = BOOKS.filter(b => b.k === k);
+    if (!rows.length) return "";
+    return `<div class="lib-group">
+      <div class="gh"><span class="kind">${KIND_LABEL[k]}</span><span class="kn">${rows.length}</span></div>
+      ${rows.map(b => `<a class="brow" data-view="reader" href="#">
+        <span><span class="title">${b.t}${b.new ? '<span class="pill">New</span>' : ''}</span>
+        <span class="meta">${b.chunks.toLocaleString()} chunks<span class="dot">/</span>${b.images} images<span class="dot">/</span>${b.entities.toLocaleString()} entities</span></span>
+        <span class="read">Read &rarr;</span>
+      </a>`).join('')}
+    </div>`;
+  }).join('');
+  document.querySelectorAll('#bookList [data-view]').forEach(el =>
+    el.addEventListener('click', e => { e.preventDefault(); show(el.dataset.view); }));
+
+  // ---- Entities data ----
+  const TYPES = {
+    creature: "--t-creature", spell: "--t-spell", location: "--t-location",
+    npc: "--t-npc", faction: "--t-faction", deity: "--t-deity",
+    item: "--t-item", class: "--t-class",
+  };
+  const ENTS = [
+    ["Strahd von Zarovich","npc"],["Barovia","location"],["Castle Ravenloft","location"],
+    ["Ireena Kolyana","npc"],["Fireball","spell"],["Counterspell","spell"],
+    ["Vampire Spawn","creature"],["The Raven Queen","deity"],["Sun Blade","item"],
+    ["Aarakocra","creature"],["Wind Dukes of Aaqa","faction"],["Aaqa","location"],
+    ["Gundren Rockseeker","npc"],["Cragmaw Tribe","faction"],["Wave Echo Cave","location"],
+    ["Nezznar the Black Spider","npc"],["Lathander","deity"],["Symbol of Ravenkind","item"],
+    ["Wizard","class"],["Delayed Blast Fireball","spell"],["Klarg","creature"],
+    ["Redbrands","faction"],["Phandalin","location"],["Speak with Dead","spell"],
+  ];
+  const chipDefs = [["all","All",TYPES],["creature","Creature"],["spell","Spell"],["location","Location"],
+    ["npc","NPC"],["faction","Faction"],["deity","Deity"],["item","Item"],["class","Class"]];
+  const counts = {}; ENTS.forEach(([,t]) => counts[t] = (counts[t]||0)+1);
+  document.getElementById('chips').innerHTML = chipDefs.map(([k,label]) => {
+    if (k === "all") return `<span class="chip all on" data-type="all">All <span class="n">${ENTS.length}</span></span>`;
+    return `<span class="chip" data-type="${k}"><span class="sw" style="background:var(${TYPES[k]})"></span>${label} <span class="n">${counts[k]||0}</span></span>`;
+  }).join('');
+  function renderEnts(filter) {
+    const rows = ENTS.filter(([,t]) => filter === "all" || t === filter);
+    document.getElementById('entGrid').innerHTML = rows.map(([n,t]) => `
+      <a class="ent" href="#" style="--ec:var(${TYPES[t]})">
+        <span class="nm">${n}</span>
+        <span class="ty"><b>${t}</b></span>
+      </a>`).join('');
+  }
+  renderEnts("all");
+  document.querySelectorAll('#chips .chip').forEach(c =>
+    c.addEventListener('click', () => {
+      document.querySelectorAll('#chips .chip').forEach(x => x.classList.remove('on'));
+      c.classList.add('on');
+      renderEnts(c.dataset.type);
+    }));
+
+  // ---- Reader TOC ----
+  const TOC = [
+    ["Introduction", [], true],
+    ["Ch 1 · Into the Mists", ["The Land of Barovia","The Death House","Credits"], false, "Credits"],
+    ["Ch 2 · The Lands of Barovia", ["Village of Barovia","Old Bonegrinder","Vallaki"], false],
+    ["Ch 3 · Tarokka Deck", [], false],
+    ["Appendix · Monsters", ["Strahd von Zarovich","Rahadin"], false],
+  ];
+  document.getElementById('tocList').innerHTML = TOC.map(([chap, subs, curChap, curSub]) => `
+    <li class="chap"><a href="#" class="${curChap ? 'cur' : ''}">${chap}</a></li>
+    ${subs.length ? `<li class="sub"><ul>${subs.map(s => `<li><a href="#" class="${s===curSub?'cur':''}">${s}</a></li>`).join('')}</ul></li>` : ''}
+  `).join('');
+
+  // ============================================================
+  //  EXPLORE graph (atlas renderer, drawing colors from the shared
+  //  theme tokens so it flips with the light/dark toggle)
+  // ============================================================
+  const LORE = new Set(["creature","spell","location","npc","faction","deity","item"]);
+  const GAMEPLAY = new Set(["event","quest"]);
+  const catOf = t => LORE.has(t) ? "lore" : (GAMEPLAY.has(t) ? "gameplay" : "mechanics");
+  const EX_TYPES = {
+    location: "--t-location", creature: "--t-creature", npc: "--t-npc", faction: "--t-faction",
+    deity: "--t-deity", item: "--t-item", spell: "--t-spell", event: "--t-event", quest: "--t-quest", class: "--t-class",
+  };
+  const EX_TYPE_LABEL = { location:"Location", creature:"Creature", npc:"NPC", faction:"Faction", deity:"Deity", item:"Item", spell:"Spell", event:"Event", quest:"Quest", class:"Class" };
+  // adv: which adventure roster the node belongs to ("*" = shared core content)
+  const EX_N = (id,type,name,summary,adv,temp)=>({id,type,name,summary,adv,temp:temp||null,cat:catOf(type)});
+  const EX_NODES = [
+    // -- Curse of Strahd --
+    EX_N("strahd","npc","Strahd von Zarovich","The vampire lord of Barovia.","cos"),
+    EX_N("ireena","npc","Ireena Kolyana","A Barovian noblewoman, the reincarnation of Strahd's lost love.","cos"),
+    EX_N("ravenloft","location","Castle Ravenloft","A fortress of black stone, seat of Strahd's power.","cos"),
+    EX_N("barovia","location","Barovia","A mist-shrouded domain of the Shadowfell.","cos"),
+    EX_N("vampspawn","creature","Vampire Spawn","Lesser undead bound to Strahd's will.","cos"),
+    EX_N("ravenqueen","deity","The Raven Queen","Goddess of death and fate.","cos"),
+    EX_N("sunblade","item","Sun Blade","A radiant blade of sunlight, anathema to the undead.","cos"),
+    EX_N("ev_tatyana","event","Death of Tatyana","Strahd's beloved fell from the walls of Ravenloft, ages past.","cos","historical"),
+    EX_N("ev_ascension","event","Strahd's Ascension","Strahd struck a pact with death and became the first vampire.","cos","historical"),
+    EX_N("ev_arrival","event","The Party Enters Barovia","The mists draw a new group of heroes into the valley.","cos","present"),
+    EX_N("q_ireena","quest","Escort Ireena to Safety","Keep Ireena beyond Strahd's reach.","cos","present"),
+    EX_N("q_tome","quest","Recover the Tome of Strahd","Find the vampire's own history to learn his weaknesses.","cos","present"),
+    // -- Lost Mine of Phandelver --
+    EX_N("gundren","npc","Gundren Rockseeker","A dwarf who rediscovered the lost Wave Echo Cave.","lmop"),
+    EX_N("nezznar","npc","Nezznar the Black Spider","A drow mastermind seeking the Forge of Spells.","lmop"),
+    EX_N("klarg","creature","Klarg","A bugbear chief of the Cragmaw goblins.","lmop"),
+    EX_N("cragmaw","faction","Cragmaw Tribe","Goblins in the pay of the Black Spider.","lmop"),
+    EX_N("redbrands","faction","Redbrands","Ruffians terrorizing the town of Phandalin.","lmop"),
+    EX_N("phandalin","location","Phandalin","A frontier town on the Sword Coast.","lmop"),
+    EX_N("waveecho","location","Wave Echo Cave","A lost mine housing the Forge of Spells.","lmop"),
+    EX_N("ev_ambush","event","Goblin Ambush","Cragmaw goblins waylay the party on the Triboar Trail.","lmop","present"),
+    EX_N("ev_pact","event","The Phandelver Pact","The ancient alliance that forged the magic of Wave Echo Cave.","lmop","historical"),
+    EX_N("q_findgundren","quest","Find Gundren Rockseeker","Track down the captured dwarf.","lmop","present"),
+    // -- Shared core content (appears in every adventure's roster) --
+    EX_N("fireball","spell","Fireball","A streak of flame that blossoms into an explosion.","*"),
+    EX_N("counterspell","spell","Counterspell","Interrupts a creature in the act of casting.","*"),
+    EX_N("wizard","class","Wizard","A scholarly magic-user wielding arcane spells.","*"),
+  ];
+  const EX_E = (a,b,r)=>({a,b,r});
+  const EX_EDGES = [
+    // CoS lore
+    EX_E("strahd","ravenloft","LOCATED_IN"), EX_E("ravenloft","barovia","LOCATED_IN"),
+    EX_E("strahd","ireena","RELATED_TO"), EX_E("vampspawn","strahd","SERVES"),
+    EX_E("ireena","sunblade","WIELDS"), EX_E("ravenqueen","barovia","RELATED_TO"),
+    EX_E("strahd","fireball","CASTS"),
+    // CoS events + quests (these edges reach into lore -> the cross-category joins)
+    EX_E("ev_tatyana","ev_ascension","PRECEDED"), EX_E("ev_ascension","ev_arrival","PRECEDED"),
+    EX_E("ev_ascension","strahd","INVOLVED"), EX_E("ev_ascension","ravenloft","OCCURRED_AT"),
+    EX_E("ev_tatyana","ireena","INVOLVED"), EX_E("q_ireena","ireena","GIVEN_BY"),
+    EX_E("q_ireena","barovia","OBJECTIVE_AT"), EX_E("q_tome","ravenloft","OBJECTIVE_AT"),
+    EX_E("q_tome","sunblade","REWARDS"), EX_E("ev_arrival","q_ireena","ADVANCES"),
+    // LMoP
+    EX_E("gundren","phandalin","LOCATED_IN"), EX_E("klarg","cragmaw","MEMBER_OF"),
+    EX_E("nezznar","cragmaw","ALLY_OF"), EX_E("nezznar","gundren","ENEMY_OF"),
+    EX_E("redbrands","phandalin","LOCATED_IN"), EX_E("gundren","waveecho","RELATED_TO"),
+    EX_E("nezznar","fireball","CASTS"), EX_E("ev_ambush","klarg","INVOLVED"),
+    EX_E("ev_ambush","gundren","INVOLVED"), EX_E("ev_pact","waveecho","OCCURRED_AT"),
+    EX_E("q_findgundren","cragmaw","OBJECTIVE_AT"),
+    // shared mechanics/spells
+    EX_E("fireball","counterspell","COUNTERED_BY"),
+  ];
+  const EX_BY = {}; EX_NODES.forEach(n => { EX_BY[n.id] = n; n.deg = 0; });
+  EX_EDGES.forEach(e => { EX_BY[e.a].deg++; EX_BY[e.b].deg++; });
+  const EX_ADJ = {}; EX_NODES.forEach(n => EX_ADJ[n.id] = []);
+  EX_EDGES.forEach(e => { EX_ADJ[e.a].push(e); EX_ADJ[e.b].push(e); });
+
+  // ---- scope x lens state + filtering (the actual demonstration) ----
+  let exScope = "cos", exLens = "world";
+  const exGuests = new Set();   // nodes pulled in by following a cross-lens edge
+  let VIS = [], VE = [];
+  function inScope(n) { return exScope === "everything" || n.adv === exScope || n.adv === "*"; }
+  function inLens(n) {
+    if (exLens === "world") return n.cat === "lore" || ((n.type === "event" || n.type === "quest") && n.temp === "historical");
+    if (exLens === "story") return n.type === "event";
+    if (exLens === "quests") return n.type === "quest";
+    if (exLens === "rules") return n.cat === "mechanics" || n.type === "spell";
+    return true;
+  }
+  function computeVisible() {
+    const ok = new Set(EX_NODES.filter(n => (inScope(n) && inLens(n)) || exGuests.has(n.id)).map(n => n.id));
+    VIS = EX_NODES.filter(n => ok.has(n.id));
+    VE = EX_EDGES.filter(e => ok.has(e.a) && ok.has(e.b));
+    VIS.forEach((n, i) => {
+      if (n.x === undefined) {
+        const a = (i / VIS.length) * Math.PI * 2, r = 108 + (i % 4) * 34;
+        n.x = Math.cos(a) * r; n.y = Math.sin(a) * r; n.vx = 0; n.vy = 0;
+      }
+    });
+    exEnergy = 1;
+    buildLegend();
+  }
+  function buildLegend() {
+    const el = document.getElementById('exLegend');
+    if (!el) return;
+    const present = [...new Set(VIS.map(n => n.type))].filter(t => EX_TYPE_LABEL[t]);
+    el.innerHTML = present.length
+      ? present.map(t => `<div class="row"><span class="sw" style="background:${COL[t] || `var(${EX_TYPES[t]})`}"></span>${EX_TYPE_LABEL[t]}</div>`).join('')
+      : '<div class="row" style="color:var(--faint)">no entities in this view</div>';
+  }
+
+  let exInited = false, exCanvas, exCtx, exW, exH, exDPR, exFocus = null, exHover = null;
+  let exView = { x: 0, y: 0, k: 1 }, exEnergy = 1;
+  let COL = {};
+  function cssVar(n) { return getComputedStyle(document.body).getPropertyValue(n).trim(); }
+  function refreshExColors() {
+    COL = { paper: cssVar('--paper'), line: cssVar('--line'), text: cssVar('--text'),
+            dim: cssVar('--dim'), faint: cssVar('--faint'), accent: cssVar('--accent'),
+            surface: cssVar('--surface') };
+    for (const t in EX_TYPES) COL[t] = cssVar(EX_TYPES[t]);
+    buildLegend();
+  }
+  function exResize() {
+    exDPR = Math.min(window.devicePixelRatio || 1, 2);
+    exW = exCanvas.clientWidth; exH = exCanvas.clientHeight;
+    exCanvas.width = exW * exDPR; exCanvas.height = exH * exDPR;
+  }
+  function exToScreen(n) { return { x: n.x * exView.k + exView.x, y: n.y * exView.k + exView.y }; }
+  function exRadius(n) { return (6 + Math.min(n.deg, 7) * 1.6) * Math.sqrt(exView.k); }
+
+  function exTick() {
+    for (let i = 0; i < VIS.length; i++) {
+      const a = VIS[i];
+      for (let j = i + 1; j < VIS.length; j++) {
+        const b = VIS[j];
+        let dx = a.x - b.x, dy = a.y - b.y, d2 = dx*dx + dy*dy || 0.01;
+        const f = 6200 / d2, d = Math.sqrt(d2), fx = (dx/d)*f, fy = (dy/d)*f;
+        a.vx += fx; a.vy += fy; b.vx -= fx; b.vy -= fy;
+      }
+    }
+    VE.forEach(e => {
+      const a = EX_BY[e.a], b = EX_BY[e.b];
+      let dx = b.x - a.x, dy = b.y - a.y, d = Math.sqrt(dx*dx + dy*dy) || 0.01;
+      const f = (d - 104) * 0.03, fx = (dx/d)*f, fy = (dy/d)*f;
+      a.vx += fx; a.vy += fy; b.vx -= fx; b.vy -= fy;
+    });
+    VIS.forEach(n => {
+      n.vx += -n.x * 0.0018; n.vy += -n.y * 0.0018;
+      n.vx *= 0.86; n.vy *= 0.86; n.x += n.vx * exEnergy; n.y += n.vy * exEnergy;
+    });
+    exEnergy *= 0.992; if (exEnergy < 0) exEnergy = 0;
+  }
+
+  function exDraw() {
+    exCtx.setTransform(exDPR, 0, 0, exDPR, 0, 0);
+    exCtx.clearRect(0, 0, exW, exH);
+    const focusAdj = exFocus ? new Set(VE.filter(e => e.a === exFocus || e.b === exFocus).map(e => e.a === exFocus ? e.b : e.a)) : null;
+    // edges (quiet; incident-to-focus in accent)
+    VE.forEach(e => {
+      const a = exToScreen(EX_BY[e.a]), b = exToScreen(EX_BY[e.b]);
+      const incident = exFocus && (e.a === exFocus || e.b === exFocus);
+      exCtx.strokeStyle = incident ? COL.accent : COL.line;
+      exCtx.globalAlpha = exFocus ? (incident ? 0.9 : 0.35) : 0.7;
+      exCtx.lineWidth = incident ? 1.8 : 1;
+      exCtx.beginPath(); exCtx.moveTo(a.x, a.y); exCtx.lineTo(b.x, b.y); exCtx.stroke();
+    });
+    exCtx.globalAlpha = 1;
+    // nodes
+    VIS.forEach(n => {
+      const p = exToScreen(n), r = exRadius(n), c = COL[n.type];
+      const dim = exFocus && n.id !== exFocus && !focusAdj.has(n.id);
+      exCtx.globalAlpha = dim ? 0.32 : 1;
+      exCtx.shadowColor = 'rgba(20,30,50,0.25)'; exCtx.shadowBlur = dim ? 0 : 6; exCtx.shadowOffsetY = dim ? 0 : 1;
+      exCtx.fillStyle = c; exCtx.beginPath(); exCtx.arc(p.x, p.y, r, 0, 7); exCtx.fill();
+      exCtx.shadowBlur = 0; exCtx.shadowOffsetY = 0;
+      exCtx.lineWidth = 1.6; exCtx.strokeStyle = COL.paper;
+      exCtx.beginPath(); exCtx.arc(p.x, p.y, r, 0, 7); exCtx.stroke();
+      if (n.id === exFocus) { exCtx.globalAlpha = 1; exCtx.strokeStyle = COL.accent; exCtx.lineWidth = 2.5; exCtx.beginPath(); exCtx.arc(p.x, p.y, r + 5, 0, 7); exCtx.stroke(); }
+      else if (n.id === exHover) { exCtx.globalAlpha = 0.85; exCtx.strokeStyle = COL.text; exCtx.lineWidth = 1.5; exCtx.beginPath(); exCtx.arc(p.x, p.y, r + 4, 0, 7); exCtx.stroke(); }
+      // guest (pulled in from another lens/scope): dashed accent ring
+      if (exGuests.has(n.id) && n.id !== exFocus) { exCtx.globalAlpha = 0.9; exCtx.setLineDash([3, 3]); exCtx.strokeStyle = COL.accent; exCtx.lineWidth = 1.5; exCtx.beginPath(); exCtx.arc(p.x, p.y, r + 4, 0, 7); exCtx.stroke(); exCtx.setLineDash([]); }
+    });
+    // labels (all, for readability)
+    exCtx.globalAlpha = 1; exCtx.textAlign = 'center'; exCtx.textBaseline = 'top';
+    VIS.forEach(n => {
+      const p = exToScreen(n), r = exRadius(n);
+      const isF = n.id === exFocus, isN = focusAdj && focusAdj.has(n.id);
+      const dim = exFocus && !isF && !isN;
+      exCtx.font = (isF ? '600 14px ' : '13px ') + '"Iowan Old Style", Palatino, Georgia, serif';
+      const ty = p.y + r + 5;
+      exCtx.lineWidth = 3.5; exCtx.strokeStyle = COL.paper;
+      exCtx.strokeText(n.name, p.x, ty);
+      exCtx.fillStyle = dim ? COL.faint : (isF ? COL.text : COL.dim);
+      exCtx.fillText(n.name, p.x, ty);
+    });
+  }
+  function exLoop() { if (exEnergy > 0.001) exTick(); if (exInited) { exDraw(); requestAnimationFrame(exLoop); } }
+
+  function exHit(mx, my) {
+    for (let i = VIS.length - 1; i >= 0; i--) {
+      const n = VIS[i], p = exToScreen(n), r = exRadius(n) + 6;
+      if ((mx - p.x) ** 2 + (my - p.y) ** 2 <= r * r) return n.id;
+    }
+    return null;
+  }
+  function exRelLabel(r) { return r.replace(/_/g, ' ').toLowerCase(); }
+  function exSelect(id) {
+    exFocus = id;
+    const n = EX_BY[id];
+    const rels = EX_ADJ[id].map(e => {
+      const out = e.a === id, peer = EX_BY[out ? e.b : e.a];
+      return { r: e.r, peer, sym: ["RELATED_TO","ALLY_OF","ENEMY_OF","NEAR"].includes(e.r), out };
+    });
+    document.getElementById('cxBody').innerHTML = `
+      <div class="cx-type"><span class="sw" style="background:${COL[n.type]}"></span>${EX_TYPE_LABEL[n.type]}</div>
+      <h2>${n.name}</h2>
+      <div class="cx-sum">${n.summary}</div>
+      <div class="cx-h">Relationships &middot; ${rels.length}</div>
+      ${rels.map(x => `<div class="cx-rel" data-go="${x.peer.id}">
+        <span class="v">${x.sym ? '&harr;' : (x.out ? '&rarr;' : '&larr;')} ${exRelLabel(x.r)}</span>
+        <span class="sw" style="background:${COL[x.peer.type]}"></span>
+        <span class="p">${x.peer.name}</span></div>`).join('')}`;
+    document.getElementById('exCodex').classList.add('open');
+    document.querySelectorAll('#cxBody [data-go]').forEach(el => el.addEventListener('click', () => {
+      const pid = el.dataset.go;
+      // following an edge to a node outside the current lens/scope pulls it in as a guest
+      if (!VIS.some(v => v.id === pid)) { exGuests.add(pid); computeVisible(); }
+      exSelect(pid);
+    }));
+  }
+
+  function initExplore() {
+    if (exInited) { exResize(); return; }
+    exInited = true;
+    exCanvas = document.getElementById('exCanvas');
+    exCtx = exCanvas.getContext('2d');
+    exResize(); refreshExColors(); computeVisible();
+    exView.x = exW / 2; exView.y = exH / 2;
+    let down = null, moved = false;
+    exCanvas.addEventListener('mousedown', e => { down = { x: e.clientX, y: e.clientY, vx: exView.x, vy: exView.y }; moved = false; exCanvas.classList.add('drag'); });
+    window.addEventListener('mouseup', e => {
+      exCanvas.classList.remove('drag');
+      if (down && !moved) {
+        const rect = exCanvas.getBoundingClientRect();
+        const id = exHit(e.clientX - rect.left, e.clientY - rect.top);
+        if (id) exSelect(id); else { exFocus = null; document.getElementById('exCodex').classList.remove('open'); }
+      }
+      down = null;
+    });
+    window.addEventListener('mousemove', e => {
+      const rect = exCanvas.getBoundingClientRect();
+      if (down) {
+        const dx = e.clientX - down.x, dy = e.clientY - down.y;
+        if (Math.abs(dx) + Math.abs(dy) > 4) moved = true;
+        exView.x = down.vx + dx; exView.y = down.vy + dy;
+      } else {
+        const h = exHit(e.clientX - rect.left, e.clientY - rect.top);
+        if (h !== exHover) { exHover = h; exCanvas.style.cursor = h ? 'pointer' : 'grab'; }
+      }
+    });
+    exCanvas.addEventListener('wheel', e => {
+      e.preventDefault();
+      const rect = exCanvas.getBoundingClientRect(), mx = e.clientX - rect.left, my = e.clientY - rect.top;
+      const wx = (mx - exView.x) / exView.k, wy = (my - exView.y) / exView.k;
+      const k2 = Math.max(0.4, Math.min(3, exView.k * (e.deltaY < 0 ? 1.12 : 0.89)));
+      exView.k = k2; exView.x = mx - wx * k2; exView.y = my - wy * k2;
+    }, { passive: false });
+    document.getElementById('cxClose').addEventListener('click', () => { exFocus = null; document.getElementById('exCodex').classList.remove('open'); });
+    exLoop();
+    setTimeout(() => exSelect('strahd'), 350);
+  }
+
+  document.querySelectorAll('[data-view="explore"]').forEach(el =>
+    el.addEventListener('click', () => setTimeout(initExplore, 30)));
+  document.getElementById('themeToggle').addEventListener('click', () => { if (exInited) refreshExColors(); });
+  // lens switch (functional: re-filters by category/temporality WITHIN the current scope)
+  document.querySelectorAll('#lensSwitch button').forEach(b =>
+    b.addEventListener('click', () => {
+      document.querySelectorAll('#lensSwitch button').forEach(x => x.classList.remove('on'));
+      b.classList.add('on');
+      exLens = b.dataset.lens; exGuests.clear();
+      if (exFocus && !(inScope(EX_BY[exFocus]) && inLens(EX_BY[exFocus]))) { exFocus = null; document.getElementById('exCodex').classList.remove('open'); }
+      if (exInited) computeVisible();
+    }));
+  // scope selector (functional: intersects the adventure roster with the lens)
+  document.getElementById('scopeSel').addEventListener('change', e => {
+    exScope = e.target.value; exGuests.clear();
+    exFocus = null; document.getElementById('exCodex').classList.remove('open');
+    if (exInited) computeVisible();
+  });
+</script>

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.6
+version: 0.89.7
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.6
+      targetRevision: 0.89.7
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.37
+version: 0.285.38
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.37
+      targetRevision: 0.285.38
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/grimoire/ChaptersNav.svelte
+++ b/projects/monolith/frontend/src/lib/grimoire/ChaptersNav.svelte
@@ -1,17 +1,26 @@
 <script>
-  // Compact chapters dropdown, replacing the old permanent TOC pane
-  // (SectionTree.svelte, since deleted): a button in the reader's sticky book
-  // bar that opens a flat section list, styled exactly like the old TOC (top-
-  // level rows bold mono uppercase, nested rows indented, passage counts
-  // right-aligned tabular-nums). Owns its own /sections fetch (same rationale
-  // as the reader's own book-meta fetch: neither host has to). Rows link
-  // through the same chunkHref -> /c/[chunk] redirect the old TOC used, so a
-  // click still lands in the continuous reader positioned at that section's
-  // first chunk.
+  // Section list for the private reader. Fetches the book's section
+  // hierarchy once and renders a flat, indentation-by-depth list with the
+  // active section highlighted. Rows link through chunkHref -> the /c/[chunk]
+  // redirect, carrying the campaign and DM/player viewpoint (`?as=`) from the
+  // `grimoire` context set by the campaign layout, so a click still lands in
+  // the continuous reader positioned at that section's first chunk under the
+  // same viewpoint the reader is in now.
+  //
+  // Two variants, one fetch/highlight implementation:
+  //  - "sidebar" (default reading surface, desktop >760px): the list is
+  //    always expanded, rendered as Reader.svelte's left section-hierarchy
+  //    sidebar (see docs/plans/assets/2026-07-05-grimoire-reskin-mockup.html's
+  //    Reader tab). No button, no open/close state.
+  //  - "dropdown" (mobile <=760px, where the sidebar is hidden): the original
+  //    compact affordance -- a "Chapters" button in the sticky bar that
+  //    toggles a floating panel.
+  // Styled with the clean grimoire theme (--grim-* tokens), replacing the
+  // brutalist ink/cream/yellow palette this component used before this pass.
   import { getContext } from "svelte";
   import { apiFetch, chunkHref } from "$lib/grimoire/api.js";
 
-  let { bookId, activeSectionPath = null } = $props();
+  let { bookId, activeSectionPath = null, variant = "dropdown" } = $props();
   const ctx = getContext("grimoire");
 
   let open = $state(false);
@@ -37,8 +46,8 @@
   }
 
   // Indent depth from the section_path's segment count (matches the old
-  // TOC's convention: 1 = top-level "chapter" row, bold mono uppercase;
-  // deeper rows indent).
+  // TOC's convention: 1 = top-level "chapter" row, bold uppercase; deeper
+  // rows indent).
   function depth(sectionPath) {
     if (!sectionPath) return 1;
     return Math.max(1, sectionPath.split("/").filter(Boolean).length);
@@ -54,35 +63,37 @@
 
 <svelte:window onclick={onWindowClick} onkeydown={onWindowKeydown} />
 
-<div class="grimb-chapters" bind:this={rootEl}>
-  <button
-    type="button"
-    class="grimb-chapters-btn"
-    class:grimb-chapters-btn--open={open}
-    aria-expanded={open}
-    aria-controls="grimb-chapters-panel"
-    onclick={() => (open = !open)}
-  >
-    Chapters
-  </button>
+<div class="rdr-chapters rdr-chapters--{variant}" bind:this={rootEl}>
+  {#if variant === "dropdown"}
+    <button
+      type="button"
+      class="rdr-chapters-btn"
+      class:rdr-chapters-btn--open={open}
+      aria-expanded={open}
+      aria-controls="rdr-chapters-panel"
+      onclick={() => (open = !open)}
+    >
+      Chapters
+    </button>
+  {/if}
 
-  {#if open}
-    <div class="grimb-chapters-panel" id="grimb-chapters-panel">
+  {#if variant === "sidebar" || open}
+    <div class="rdr-chapters-panel" id="rdr-chapters-panel">
       {#if loading}
-        <p class="grimb-chapters-status">Loading…</p>
+        <p class="rdr-chapters-status">Loading…</p>
       {:else if error}
-        <p class="grimb-chapters-status">{error}</p>
+        <p class="rdr-chapters-status">{error}</p>
       {:else if sections.length === 0}
-        <p class="grimb-chapters-status">This book has no chunks yet.</p>
+        <p class="rdr-chapters-status">This book has no chunks yet.</p>
       {:else}
-        <ul class="grimb-chapters-list">
+        <ul class="rdr-chapters-list">
           {#each sections as section (section.section_path)}
             {@const d = depth(section.section_path)}
             <li>
               <a
-                class="grimb-chapters-row"
-                class:grimb-chapters-row--h1={d <= 1}
-                class:grimb-chapters-row--active={section.section_path ===
+                class="rdr-chapters-row"
+                class:rdr-chapters-row--h1={d <= 1}
+                class:rdr-chapters-row--active={section.section_path ===
                   activeSectionPath}
                 style:padding-left="{0.75 + (d - 1) * 0.9}rem"
                 href={chunkHref(
@@ -93,8 +104,8 @@
                 )}
                 onclick={() => (open = false)}
               >
-                <span class="grimb-chapters-row-title">{section.title}</span>
-                <span class="grimb-chapters-row-count">{section.chunk_count}</span>
+                <span class="rdr-chapters-row-title">{section.title}</span>
+                <span class="rdr-chapters-row-count">{section.chunk_count}</span>
               </a>
             </li>
           {/each}
@@ -105,106 +116,144 @@
 </div>
 
 <style>
-  .grimb-chapters {
+  .rdr-chapters {
     position: relative;
     flex-shrink: 0;
   }
 
-  .grimb-chapters-btn {
+  .rdr-chapters--sidebar {
+    width: 100%;
+  }
+
+  .rdr-chapters-btn {
     display: inline-flex;
     align-items: center;
-    min-height: 2rem;
-    padding: 0.3rem 0.7rem;
-    font-family: var(--grimb-mono);
-    font-size: 0.68rem;
-    font-weight: 700;
+    min-height: 32px;
+    padding: 5px 14px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
-    background: var(--grimb-cream);
-    color: var(--grimb-ink);
-    border: var(--grimb-border);
+    background: var(--grim-surface);
+    color: var(--grim-ink);
+    border: 1px solid var(--grim-line);
+    border-radius: 999px;
     cursor: pointer;
   }
 
-  .grimb-chapters-btn--open {
-    background: var(--grimb-yellow);
+  .rdr-chapters-btn:hover,
+  .rdr-chapters-btn--open {
+    color: var(--grim-accent);
+    border-color: var(--grim-accent);
   }
 
-  /* Self-contained dropdown: positioned relative to .grimb-chapters (this
-   * component's own root), not the bar, so it never depends on the host
-   * bar's own positioning. The button is the last item in the bar's
-   * right-hand flex group, so right:0 already lands the panel flush against
-   * the bar's right edge. Width is capped against the viewport so it never
+  /* Self-contained dropdown, positioned relative to .rdr-chapters (this
+   * component's own root). The button is the last item in the bar's
+   * right-hand flex group, so right:0 lands the panel flush against the
+   * bar's right edge. Width is capped against the viewport so it never
    * overflows horizontally on narrow phones. */
-  .grimb-chapters-panel {
+  .rdr-chapters-panel {
     position: absolute;
     top: 100%;
     right: 0;
     z-index: 6;
-    margin-top: 0.4rem;
-    width: min(20rem, calc(100vw - 2.5rem));
+    margin-top: 6px;
+    width: min(320px, calc(100vw - 40px));
     max-height: 60vh;
     overflow-y: auto;
-    background: var(--grimb-paper);
-    border: var(--grimb-border);
-    font-family: var(--grimb-mono);
+    background: var(--grim-surface);
+    border: 1px solid var(--grim-line);
+    border-radius: 10px;
+    box-shadow: 0 8px 24px rgba(20, 24, 32, 0.14);
+    font-family: var(--font-mono);
   }
 
-  .grimb-chapters-list {
+  /* Sidebar variant: the panel IS the sidebar body, sticky-positioned by
+   * Reader.svelte's <aside> -- reset every dropdown-only affordance so it
+   * reads as a plain nav tree, not a floating card. */
+  .rdr-chapters--sidebar .rdr-chapters-panel {
+    position: static;
+    width: 100%;
+    max-height: none;
+    overflow: visible;
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    margin-top: 0;
+  }
+
+  .rdr-chapters-list {
     display: flex;
     flex-direction: column;
   }
 
-  .grimb-chapters-row {
+  .rdr-chapters-row {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
-    gap: 0.75rem;
-    min-height: 2.5rem;
-    padding: 0.5rem 0.85rem;
-    border-left: 4px solid transparent;
-    color: var(--grimb-ink-3);
+    gap: 12px;
+    min-height: 36px;
+    padding: 7px 14px;
+    border-left: 2px solid transparent;
+    color: var(--grim-text-dim);
   }
 
-  .grimb-chapters-row:hover {
-    color: var(--grimb-ink);
+  .rdr-chapters--sidebar .rdr-chapters-row {
+    min-height: auto;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-right: 4px;
   }
 
-  .grimb-chapters-row--h1 {
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--grimb-ink);
+  .rdr-chapters-row:hover {
+    color: var(--grim-ink);
   }
 
-  .grimb-chapters-row--active {
-    background: var(--grimb-yellow);
-    border-left-color: var(--grimb-ink);
-    color: var(--grimb-ink);
+  .rdr-chapters-row--h1 {
+    font-family: var(--grim-serif);
+    font-weight: 600;
+    color: var(--grim-ink);
   }
 
-  .grimb-chapters-row-title {
-    font-size: 0.85rem;
+  .rdr-chapters-row--active {
+    border-left-color: var(--grim-accent);
+    color: var(--grim-accent);
+    font-weight: 600;
+  }
+
+  .rdr-chapters--dropdown .rdr-chapters-row--active {
+    background: var(--grim-accent-soft);
+  }
+
+  .rdr-chapters-row-title {
+    font-size: 13px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
-  .grimb-chapters-row--h1 .grimb-chapters-row-title {
-    font-size: 0.8rem;
+  .rdr-chapters-row--h1 .rdr-chapters-row-title {
+    font-size: 12.5px;
   }
 
-  .grimb-chapters-row-count {
+  .rdr-chapters-row-count {
     flex-shrink: 0;
-    font-size: 0.72rem;
+    font-size: 11px;
     font-variant-numeric: tabular-nums;
     text-align: right;
-    min-width: 1.5rem;
+    min-width: 22px;
+    color: var(--grim-text-faint);
   }
 
-  .grimb-chapters-status {
-    padding: 1rem 0.85rem;
-    font-size: 0.72rem;
-    color: var(--grimb-ink-3);
+  .rdr-chapters-status {
+    padding: 14px;
+    font-size: 11px;
+    color: var(--grim-text-faint);
+  }
+
+  .rdr-chapters--sidebar .rdr-chapters-status {
+    padding: 0;
   }
 </style>

--- a/projects/monolith/frontend/src/lib/grimoire/EntityIndexList.svelte
+++ b/projects/monolith/frontend/src/lib/grimoire/EntityIndexList.svelte
@@ -180,9 +180,9 @@
     letter-spacing: 0.06em;
     min-height: 2.25rem;
     padding: 0.25rem 0.55rem;
-    background: var(--bg);
-    color: var(--fg-secondary);
-    border: var(--border-thin);
+    background: var(--grim-surface);
+    color: var(--grim-text-dim);
+    border: 1px solid var(--grim-line);
     cursor: pointer;
   }
 
@@ -195,7 +195,7 @@
   .count {
     margin-left: auto;
     font-size: 0.66rem;
-    color: var(--fg-tertiary);
+    color: var(--grim-text-faint);
     font-variant-numeric: tabular-nums;
   }
 
@@ -214,8 +214,8 @@
     padding: 0.4rem 0.6rem;
     border: 1px solid transparent;
     border-left: 2px solid transparent;
-    background: var(--bg);
-    color: var(--fg);
+    background: var(--grim-surface);
+    color: var(--grim-ink);
   }
 
   .row:hover {
@@ -226,7 +226,7 @@
   .row--active {
     border-color: var(--grim-paper-line);
     border-left-color: var(--grim-accent);
-    background: var(--surface);
+    background: var(--grim-surface-2);
   }
 
   .row-name {
@@ -247,7 +247,7 @@
     font-size: 0.58rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: var(--fg-tertiary);
+    color: var(--grim-text-faint);
   }
 
   .badge {
@@ -255,8 +255,8 @@
     text-transform: uppercase;
     letter-spacing: 0.06em;
     padding: 0.08rem 0.35rem;
-    border: var(--border-thin);
-    color: var(--fg-secondary);
+    border: 1px solid var(--grim-line);
+    color: var(--grim-text-dim);
     white-space: nowrap;
   }
 
@@ -267,9 +267,9 @@
     font-size: 0.72rem;
     min-height: 2.75rem;
     padding: 0.4rem 1.25rem;
-    background: var(--bg);
-    color: var(--fg);
-    border: var(--border-thin);
+    background: var(--grim-surface);
+    color: var(--grim-ink);
+    border: 1px solid var(--grim-line);
     cursor: pointer;
   }
 
@@ -290,11 +290,11 @@
 
   .empty-help {
     font-size: 0.78rem;
-    color: var(--fg-secondary);
+    color: var(--grim-text-dim);
   }
 
   .status--error {
-    color: var(--danger);
+    color: var(--grim-type-creature);
     font-size: 0.8rem;
   }
 
@@ -302,9 +302,9 @@
     height: 2.75rem;
     background: linear-gradient(
       90deg,
-      var(--surface) 25%,
+      var(--grim-surface-2) 25%,
       transparent 37%,
-      var(--surface) 63%
+      var(--grim-surface-2) 63%
     );
     background-size: 400% 100%;
     animation: shimmer 1.4s ease infinite;

--- a/projects/monolith/frontend/src/lib/grimoire/Reader.svelte
+++ b/projects/monolith/frontend/src/lib/grimoire/Reader.svelte
@@ -6,10 +6,26 @@
   // the host route's +page.server.js load(); every later page is fetched from
   // the sibling read/+server.js proxy, which signs images the same way.
   //
-  // Deliberately brutalist-styled with the --grimb-* tokens (theme.css), a
-  // second palette used ONLY here and in the sticky bar's Chapters dropdown
-  // (ChaptersNav.svelte): the rest of the grimoire tree (entities, stat
-  // blocks) keeps the oxblood theme untouched.
+  // Styled with the clean grimoire theme (--grim-* tokens from
+  // $lib/grimoire/theme.css, which resolve here via the ancestor `.grimoire`
+  // wrapper) rather than the old brutalist second palette (a separate set of
+  // ink/cream/yellow custom properties) this reader used before this pass: a
+  // cool-paper reading surface, serif body copy, hairline rules, small-caps
+  // section labels, no hard ink borders or mono chrome. Mirrors the public
+  // tier's Reader.svelte (see that file for
+  // the shared design rationale); the differences here are all
+  // private-only: campaignId-scoped routes, and DM/player viewpoint
+  // (`?as=`) carried through ChaptersNav via the `grimoire` context rather
+  // than a plain prop.
+  //
+  // Layout: a left section-hierarchy sidebar (desktop, >760px) alongside the
+  // reading column, per docs/plans/assets/2026-07-05-grimoire-reskin-
+  // mockup.html's Reader tab. The sidebar is ChaptersNav in its new
+  // `variant="sidebar"` mode: the same fetch + active-section-highlight
+  // logic as the original Chapters dropdown, just rendered inline and always
+  // expanded instead of behind a toggle. Below 760px the sidebar is hidden
+  // and the original dropdown affordance (`variant="dropdown"`) reappears in
+  // the sticky bar as the compact mobile chapters entry point.
   import { apiFetch } from "$lib/grimoire/api.js";
   import { renderChunk } from "$lib/grimoire/renderChunk.js";
   import ChaptersNav from "$lib/grimoire/ChaptersNav.svelte";
@@ -69,7 +85,7 @@
     return last || sectionPath;
   }
 
-  // The section's immediate parent segment, for the eyebrow chip — only
+  // The section's immediate parent segment, for the eyebrow label — only
   // present when the section_path nests more than one level deep.
   function sectionParent(sectionPath) {
     if (!sectionPath) return null;
@@ -192,320 +208,369 @@
   });
 </script>
 
-<!-- The public tier's root layout already loads these two families globally;
-     the private app doesn't, so load them here, scoped to wherever the
-     reader actually mounts. ChaptersNav.svelte also uses --grimb-mono but is
-     always a child of this component, so it never needs its own copy of
-     this block. -->
-<svelte:head>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
-    rel="stylesheet"
-  />
-</svelte:head>
-
-<div class="grimb-reader">
-  <div class="grimb-bar">
-    <span class="grimb-bar-title">{bookMeta.displayName}</span>
-    <div class="grimb-bar-right">
-      <span class="grimb-bar-pos">
-        {sectionTitle(activeSectionPath).toUpperCase()}
+<div class="rdr-reader">
+  <div class="rdr-bar">
+    <span class="rdr-bar-title">{bookMeta.displayName}</span>
+    <div class="rdr-bar-right">
+      <span class="rdr-bar-pos">
+        {sectionTitle(activeSectionPath)}
         {#if activeSeq != null && bookMeta.chunkCount}
           · {activeSeq + 1}/{bookMeta.chunkCount}
         {/if}
       </span>
-      <ChaptersNav {bookId} {activeSectionPath} />
+      <!-- Compact mobile-only affordance: the sidebar below is hidden under
+           760px, so the dropdown Chapters button is the only way to jump
+           sections on a phone. Hidden on desktop via CSS (the sidebar
+           replaces it there); still mounts and fetches regardless of
+           viewport, same as the sidebar instance below -- a second cheap GET
+           of /books/{bookId}/sections, not worth a JS media-query gate. -->
+      <div class="rdr-bar-chapters">
+        <ChaptersNav {bookId} {activeSectionPath} variant="dropdown" />
+      </div>
     </div>
   </div>
 
-  <div class="grimb-panel" bind:this={containerEl}>
-    {#each rows as row, i (row.item.id)}
-      {#if row.showHeading}
-        {#if i > 0}
-          <div class="grimb-divider" aria-hidden="true">
-            <span class="grimb-divider-line"></span>
-            <span class="grimb-divider-mark">§</span>
-            <span class="grimb-divider-line"></span>
+  <div class="rdr-layout">
+    <aside class="rdr-toc" aria-label="Sections">
+      <p class="rdr-toc-label">{bookMeta.displayName}</p>
+      <ChaptersNav {bookId} {activeSectionPath} variant="sidebar" />
+    </aside>
+
+    <div class="rdr-panel" bind:this={containerEl}>
+      {#each rows as row, i (row.item.id)}
+        {#if row.showHeading}
+          {#if i > 0}
+            <hr class="rdr-rule" aria-hidden="true" />
+          {/if}
+          <div
+            class="rdr-heading"
+            data-heading
+            data-seq={row.item.seq}
+            data-section={row.item.section_path ?? ""}
+          >
+            {#if sectionParent(row.item.section_path)}
+              <p class="rdr-section-label grim-smallcaps">
+                {sectionParent(row.item.section_path)}
+              </p>
+            {/if}
+            <h2 class="rdr-section-title">{sectionTitle(row.item.section_path)}</h2>
           </div>
         {/if}
-        <div
-          class="grimb-heading"
-          data-heading
-          data-seq={row.item.seq}
-          data-section={row.item.section_path ?? ""}
-        >
-          {#if sectionParent(row.item.section_path)}
-            <span class="grimb-chip">{sectionParent(row.item.section_path)}</span>
-          {/if}
-          <h2 class="grimb-section-title">{sectionTitle(row.item.section_path)}</h2>
-        </div>
-      {/if}
 
-      <div class="grimb-chunk" id="c-{row.item.id}">
-        <a
-          class="grimb-anchor"
-          href="#c-{row.item.id}"
-          aria-label="Link to this passage"
-        >
-          #
-        </a>
-        {#if row.item.kind === "image"}
-          <figure class="grimb-figure">
-            {#if row.item.image_url}
-              <img
-                class="grimb-image"
-                src={row.item.image_url}
-                alt={row.item.content || "sourcebook illustration"}
-              />
-            {/if}
-            {#if row.item.content}
-              <figcaption class="grimb-caption">{row.item.content}</figcaption>
-            {/if}
-          </figure>
-        {:else}
-          {#each bodyBlocks(row.item) as block, bi (bi)}
-            {#if block.type === "heading"}
-              <h3 class="grimb-inline-heading">{block.text}</h3>
-            {:else if block.type === "list"}
-              <ul class="grimb-list">
-                {#each block.items as li, lii (lii)}
-                  <li>{li}</li>
-                {/each}
-              </ul>
-            {:else}
-              <p>{block.text}</p>
-            {/if}
-          {/each}
+        <div class="rdr-chunk" id="c-{row.item.id}">
+          <a
+            class="rdr-anchor"
+            href="#c-{row.item.id}"
+            aria-label="Link to this passage"
+          >
+            #
+          </a>
+          {#if row.item.kind === "image"}
+            <figure class="rdr-figure">
+              {#if row.item.image_url}
+                <img
+                  class="rdr-image"
+                  src={row.item.image_url}
+                  alt={row.item.content || "sourcebook illustration"}
+                />
+              {/if}
+              {#if row.item.content}
+                <figcaption class="rdr-caption">{row.item.content}</figcaption>
+              {/if}
+            </figure>
+          {:else}
+            {#each bodyBlocks(row.item) as block, bi (bi)}
+              {#if block.type === "heading"}
+                <h3 class="rdr-inline-heading">{block.text}</h3>
+              {:else if block.type === "list"}
+                <ul class="rdr-list">
+                  {#each block.items as li, lii (lii)}
+                    <li>{li}</li>
+                  {/each}
+                </ul>
+              {:else}
+                <p>{block.text}</p>
+              {/if}
+            {/each}
+          {/if}
+        </div>
+      {/each}
+
+      <div class="rdr-sentinel" bind:this={sentinelEl}>
+        {#if loadingMore}
+          <p class="rdr-status">Loading…</p>
+        {:else if loadError}
+          <button class="rdr-retry" onclick={loadMore}>Retry</button>
+        {:else if !nextCursor}
+          <p class="rdr-status">— end of book —</p>
         {/if}
       </div>
-    {/each}
-
-    <div class="grimb-sentinel" bind:this={sentinelEl}>
-      {#if loadingMore}
-        <p class="grimb-status">Loading…</p>
-      {:else if loadError}
-        <button class="grimb-retry" onclick={loadMore}>Retry</button>
-      {:else if !nextCursor}
-        <p class="grimb-status">— end of book —</p>
-      {/if}
     </div>
   </div>
 </div>
 
 <style>
-  .grimb-reader {
+  .rdr-reader {
     min-height: 100%;
-    background: var(--grimb-cream);
-    color: var(--grimb-ink);
+    background: var(--grim-paper);
+    color: var(--grim-ink);
   }
 
-  .grimb-bar {
+  .rdr-bar {
     position: sticky;
     top: 0;
     z-index: 5;
     display: flex;
-    align-items: baseline;
+    align-items: center;
     justify-content: space-between;
-    gap: 1rem;
-    padding: 0.75rem 1.25rem;
-    background: var(--grimb-cream);
-    border-bottom: var(--grimb-border);
-    font-family: var(--grimb-mono);
-    font-size: 0.7rem;
-    letter-spacing: 0.05em;
+    gap: 16px;
+    padding: 10px 20px;
+    background: color-mix(in srgb, var(--grim-paper) 90%, transparent);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--grim-line);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.12em;
   }
 
-  .grimb-bar-title {
+  .rdr-bar-title {
     text-transform: uppercase;
-    font-weight: 700;
+    font-weight: 600;
+    color: var(--grim-ink);
   }
 
-  .grimb-bar-right {
+  .rdr-bar-right {
     display: flex;
-    align-items: baseline;
-    gap: 0.75rem;
+    align-items: center;
+    gap: 12px;
     min-width: 0;
   }
 
-  .grimb-bar-pos {
+  .rdr-bar-pos {
     text-transform: uppercase;
-    color: var(--grimb-ink-3);
+    color: var(--grim-text-faint);
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
-  .grimb-panel {
-    max-width: 60rem;
+  /* Sidebar covers this on desktop; only the mobile breakpoint below
+     switches it back on. */
+  .rdr-bar-chapters {
+    display: none;
+  }
+
+  .rdr-layout {
+    max-width: 1080px;
     margin: 0 auto;
-    padding: clamp(1.5rem, 5vw, 3rem) clamp(1.25rem, 6vw, 3rem);
-    background: var(--grimb-paper);
-    border: var(--grimb-border);
-    border-top: none;
+    padding: clamp(24px, 5vw, 48px) clamp(20px, 6vw, 48px) 80px;
+    display: grid;
+    grid-template-columns: 244px 1fr;
+    gap: 44px;
+    align-items: start;
   }
 
-  .grimb-divider {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    margin: 2.5rem 0;
-    max-width: 72ch;
-    margin-inline: auto;
+  .rdr-toc {
+    /* Sticky relative to .pane-read (this reader's scrolling ancestor, set
+       up by Shell.svelte), not the window: the outer app shell's own topbar
+       lives above .pane-read and isn't part of this scroll context, so only
+       .rdr-bar's own height (~52px) needs to be cleared here. The max-height
+       subtraction is a conservative estimate (rounds down) so the aside's
+       own overflow-y:auto scrollbar always has room to appear rather than
+       silently clipping sections off the bottom of the viewport. */
+    position: sticky;
+    top: 56px;
+    max-height: calc(100dvh - 200px);
+    overflow-y: auto;
+    border-right: 1px solid var(--grim-line-soft);
+    padding-right: 20px;
   }
 
-  .grimb-divider-line {
-    flex: 1;
-    height: 2px;
-    background: var(--grimb-ink);
+  .rdr-toc-label {
+    margin: 0 0 14px;
+    font-family: var(--grim-serif);
+    font-weight: 700;
+    font-size: 15px;
+    line-height: 1.25;
+    color: var(--grim-ink);
+    overflow-wrap: break-word;
   }
 
-  .grimb-divider-mark {
-    font-family: var(--grimb-mono);
-    font-size: 0.85rem;
-    color: var(--grimb-ink-3);
+  .rdr-panel {
+    min-width: 0;
   }
 
-  .grimb-heading {
-    max-width: 72ch;
-    margin: 0 auto 1.25rem;
+  .rdr-rule {
+    max-width: 68ch;
+    margin: 28px 0;
+    height: 1px;
+    border: 0;
+    background: var(--grim-line);
   }
 
-  .grimb-chip {
-    display: inline-flex;
-    align-items: center;
-    min-height: 1.5rem;
-    padding: 0.1rem 0.5rem;
-    margin-bottom: 0.6rem;
-    font-family: var(--grimb-mono);
-    font-size: 0.65rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    background: var(--grimb-yellow);
-    color: var(--grimb-ink);
-    border: 1px solid var(--grimb-ink);
+  .rdr-heading {
+    max-width: 68ch;
+    margin: 0 0 18px;
   }
 
-  .grimb-section-title {
-    font-family: var(--grimb-serif);
-    font-weight: 400;
-    font-size: 2rem;
-    line-height: 1.1;
-    color: var(--grimb-ink);
+  .rdr-section-label {
+    margin: 0 0 6px;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--grim-accent);
   }
 
-  .grimb-chunk {
+  .rdr-section-title {
+    margin: 0;
+    font-family: var(--grim-serif);
+    font-size: 30px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    line-height: 1.15;
+    color: var(--grim-ink);
+  }
+
+  .rdr-chunk {
     position: relative;
-    max-width: 72ch;
-    margin: 0 auto;
-    font-family: var(--grimb-serif);
-    font-size: 1.13rem;
+    max-width: 68ch;
+    font-family: var(--grim-serif);
+    font-size: 17px;
     line-height: 1.66;
-    color: var(--grimb-ink);
+    color: var(--grim-ink);
   }
 
-  .grimb-chunk p {
-    margin: 0 0 1rem;
+  .rdr-chunk p {
+    margin: 0 0 14px;
   }
 
-  .grimb-inline-heading {
-    font-family: var(--grimb-mono);
-    font-size: 0.85rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--grimb-ink);
-    margin: 1.5rem 0 0.6rem;
+  .rdr-inline-heading {
+    margin: 26px 0 8px;
+    font-family: var(--grim-serif);
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--grim-ink);
   }
 
-  .grimb-inline-heading:first-child {
+  .rdr-inline-heading:first-child {
     margin-top: 0;
   }
 
-  .grimb-list {
-    margin: 0 0 1rem 1.3rem;
+  .rdr-list {
+    margin: 0 0 14px 22px;
     padding: 0;
     list-style: disc;
   }
 
-  .grimb-list li {
-    margin-bottom: 0.4rem;
+  .rdr-list li {
+    margin-bottom: 6px;
   }
 
-  /* Hover-only anchor: sits in the left margin of the chunk block, invisible
-   * until the block is hovered (or the link itself is focused via keyboard). */
-  .grimb-anchor {
+  .rdr-anchor {
     position: absolute;
-    left: -1.75rem;
-    top: 0.2rem;
-    font-family: var(--grimb-mono);
-    font-size: 0.9rem;
-    color: var(--grimb-ink-3);
+    left: -28px;
+    top: 3px;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--grim-text-faint);
     text-decoration: none;
     opacity: 0;
     transition: opacity 120ms ease;
   }
 
-  .grimb-chunk:hover .grimb-anchor,
-  .grimb-anchor:focus-visible {
+  .rdr-chunk:hover .rdr-anchor,
+  .rdr-anchor:focus-visible {
     opacity: 1;
   }
 
-  .grimb-figure {
-    margin: 1.5rem 0;
+  .rdr-anchor:hover {
+    color: var(--grim-accent);
   }
 
-  .grimb-image {
-    width: 100%;
+  .rdr-figure {
+    margin: 24px 0;
+    max-width: 68ch;
+  }
+
+  /* Never upscale: max-width (not width) + no forced height keep small
+     illustrations at their natural size, while max-height caps oversized
+     scans so they never dominate the reading column. */
+  .rdr-image {
+    display: block;
+    max-width: 100%;
     height: auto;
-    border: var(--grimb-border);
+    max-height: 60vh;
+    margin-inline: auto;
+    border: 1px solid var(--grim-line);
+    border-radius: 8px;
   }
 
-  .grimb-caption {
-    margin-top: 0.6rem;
-    font-family: var(--grimb-serif);
+  .rdr-caption {
+    margin-top: 10px;
+    font-family: var(--grim-serif);
     font-style: italic;
-    font-size: 0.95rem;
-    color: var(--grimb-ink-3);
+    font-size: 14px;
+    color: var(--grim-text-dim);
     text-align: center;
   }
 
-  .grimb-sentinel {
+  .rdr-sentinel {
     display: flex;
     justify-content: center;
-    padding: 2rem 0 0.5rem;
+    padding: 32px 0 8px;
+    max-width: 68ch;
   }
 
-  .grimb-status {
-    font-family: var(--grimb-mono);
-    font-size: 0.72rem;
+  .rdr-status {
+    font-family: var(--font-mono);
+    font-size: 12px;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--grimb-ink-3);
+    color: var(--grim-text-faint);
   }
 
-  .grimb-retry {
-    font-family: var(--grimb-mono);
-    font-size: 0.72rem;
-    text-transform: uppercase;
+  .rdr-retry {
+    font-family: var(--font-mono);
+    min-height: 40px;
+    padding: 8px 18px;
+    font-size: 12px;
+    font-weight: 600;
     letter-spacing: 0.06em;
-    min-height: 2.5rem;
-    padding: 0.5rem 1rem;
-    background: var(--grimb-paper);
-    color: var(--grimb-ink);
-    border: var(--grimb-border);
+    text-transform: uppercase;
+    background: var(--grim-surface);
+    color: var(--grim-ink);
+    border: 1px solid var(--grim-line);
+    border-radius: 9px;
     cursor: pointer;
   }
 
+  .rdr-retry:hover {
+    color: var(--grim-accent);
+    border-color: var(--grim-accent);
+  }
+
+  @media (max-width: 760px) {
+    .rdr-layout {
+      grid-template-columns: 1fr;
+    }
+
+    .rdr-toc {
+      display: none;
+    }
+
+    .rdr-bar-chapters {
+      display: inline-flex;
+    }
+  }
+
   @media (max-width: 640px) {
-    .grimb-anchor {
-      left: 0.25rem;
+    .rdr-anchor {
+      left: 4px;
     }
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .grimb-anchor {
+    .rdr-anchor {
       transition: none;
     }
   }

--- a/projects/monolith/frontend/src/lib/grimoire/ThemeToggle.svelte
+++ b/projects/monolith/frontend/src/lib/grimoire/ThemeToggle.svelte
@@ -1,0 +1,114 @@
+<script>
+  // Sun/moon control for the Grimoire's light/dark theme (2026-07-05 reskin).
+  // Toggles document.body.classList("dark"), the switch the shared tokens
+  // (lib/styles/shared/tokens.css) and this app's --grim-* tokens (theme.css)
+  // both already key off; nothing else in the frontend currently drives that
+  // class, so this is the first control that flips it. Persists per-device to
+  // localStorage and falls back to the OS preference on first visit.
+  // ssr = false everywhere this mounts, but the guard keeps the component
+  // reusable in an ssr context without throwing on `document`/`localStorage`.
+  import { onMount } from "svelte";
+
+  const LS_KEY = "grimoire-theme";
+
+  let isDark = $state(false);
+
+  function readStoredTheme() {
+    try {
+      return localStorage.getItem(LS_KEY);
+    } catch {
+      return null;
+    }
+  }
+
+  function writeStoredTheme(value) {
+    try {
+      localStorage.setItem(LS_KEY, value);
+    } catch {
+      // ignore (private mode / storage disabled)
+    }
+  }
+
+  function apply(dark) {
+    document.body.classList.toggle("dark", dark);
+  }
+
+  onMount(() => {
+    const stored = readStoredTheme();
+    const prefersDark =
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches;
+    isDark = stored ? stored === "dark" : prefersDark;
+    apply(isDark);
+  });
+
+  function toggleTheme() {
+    isDark = !isDark;
+    apply(isDark);
+    writeStoredTheme(isDark ? "dark" : "light");
+  }
+</script>
+
+<button
+  type="button"
+  class="grim-theme-toggle"
+  onclick={toggleTheme}
+  aria-pressed={isDark}
+  aria-label={isDark ? "Switch to light theme" : "Switch to dark theme"}
+>
+  <span class="knob">
+    {#if isDark}
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"
+        ><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" /></svg
+      >
+    {:else}
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        aria-hidden="true"
+        ><circle cx="12" cy="12" r="4" /><path
+          d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"
+        /></svg
+      >
+    {/if}
+  </span>
+</button>
+
+<style>
+  .grim-theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: none;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    background: var(--grim-surface-2);
+    border: 1px solid var(--grim-line);
+    border-radius: 999px;
+    color: var(--grim-text-dim);
+    cursor: pointer;
+  }
+
+  .grim-theme-toggle:hover {
+    color: var(--grim-ink);
+    border-color: var(--grim-accent);
+  }
+
+  .knob {
+    width: 20px;
+    height: 20px;
+    display: grid;
+    place-items: center;
+    color: var(--grim-accent);
+  }
+
+  .knob svg {
+    width: 14px;
+    height: 14px;
+    display: block;
+  }
+</style>

--- a/projects/monolith/frontend/src/lib/grimoire/ThemeToggle.svelte
+++ b/projects/monolith/frontend/src/lib/grimoire/ThemeToggle.svelte
@@ -1,10 +1,12 @@
 <script>
   // Sun/moon control for the Grimoire's light/dark theme (2026-07-05 reskin).
-  // Toggles document.body.classList("dark"), the switch the shared tokens
-  // (lib/styles/shared/tokens.css) and this app's --grim-* tokens (theme.css)
-  // both already key off; nothing else in the frontend currently drives that
-  // class, so this is the first control that flips it. Persists per-device to
-  // localStorage and falls back to the OS preference on first visit.
+  // Toggles a "dark" class on the nearest ".grimoire" ancestor (found via
+  // closest() off this button's own element), NOT document.body: the
+  // grimoire app is one tree among 10 other public apps sharing the site-wide
+  // tokens.css, and flipping a body-level class used to flip every other
+  // app's theme too. Scoping the class to .grimoire.dark (theme.css) keeps
+  // dark mode local to this app tree. Persists per-device to localStorage and
+  // falls back to the OS preference on first visit.
   // ssr = false everywhere this mounts, but the guard keeps the component
   // reusable in an ssr context without throwing on `document`/`localStorage`.
   import { onMount } from "svelte";
@@ -12,6 +14,7 @@
   const LS_KEY = "grimoire-theme";
 
   let isDark = $state(false);
+  let buttonEl;
 
   function readStoredTheme() {
     try {
@@ -30,7 +33,8 @@
   }
 
   function apply(dark) {
-    document.body.classList.toggle("dark", dark);
+    const root = buttonEl?.closest(".grimoire");
+    root?.classList.toggle("dark", dark);
   }
 
   onMount(() => {
@@ -50,6 +54,7 @@
 </script>
 
 <button
+  bind:this={buttonEl}
   type="button"
   class="grim-theme-toggle"
   onclick={toggleTheme}

--- a/projects/monolith/frontend/src/lib/grimoire/theme.css
+++ b/projects/monolith/frontend/src/lib/grimoire/theme.css
@@ -58,7 +58,7 @@
   --grim-type-quest: #2f8f8a;
 }
 
-body.dark .grimoire {
+.grimoire.dark {
   --grim-accent: #7d9fd0;
   --grim-accent-strong: #93b0da;
   /* The dark theme's accent is a lighter blue, so on-accent text flips to dark
@@ -113,7 +113,7 @@ body.dark .grimoire {
   --grimb-serif: "Instrument Serif", Georgia, serif;
 }
 
-body.dark .grimoire {
+.grimoire.dark {
   /* Dark mode: invert cream/ink so the reader stays flat-ink-on-paper rather
    * than rendering white-on-white borders against the app's dark chrome. */
   --grimb-cream: #17130f;

--- a/projects/monolith/frontend/src/lib/grimoire/theme.css
+++ b/projects/monolith/frontend/src/lib/grimoire/theme.css
@@ -43,6 +43,19 @@
   --grim-text-dim: #55606f;
   --grim-text-faint: #8a94a2;
   --grim-accent-soft: rgba(51, 80, 122, 0.1);
+
+  /* Entity-type accent colors: used by Entities rows, statblocks, and the
+   * Explore canvas to give each entity type a stable, distinct hue. */
+  --grim-type-location: #2f8f6b;
+  --grim-type-creature: #c0492b;
+  --grim-type-npc: #b07d1e;
+  --grim-type-faction: #7a52b0;
+  --grim-type-deity: #a8811f;
+  --grim-type-item: #b83f7a;
+  --grim-type-spell: #2f7fbf;
+  --grim-type-class: #556070;
+  --grim-type-event: #7a6f3a;
+  --grim-type-quest: #2f8f8a;
 }
 
 body.dark .grimoire {
@@ -63,6 +76,17 @@ body.dark .grimoire {
   --grim-text-dim: #9aa3b2;
   --grim-text-faint: #626d7e;
   --grim-accent-soft: rgba(125, 159, 208, 0.14);
+
+  --grim-type-location: #4f9a7a;
+  --grim-type-creature: #d0684a;
+  --grim-type-npc: #d9a441;
+  --grim-type-faction: #9f81cc;
+  --grim-type-deity: #e0cf8a;
+  --grim-type-item: #d072a0;
+  --grim-type-spell: #5aa8d6;
+  --grim-type-class: #97a3b5;
+  --grim-type-event: #b3a463;
+  --grim-type-quest: #4fb0aa;
 }
 
 /* ── Reader / Chapters-nav brutalist tokens ────────────────────

--- a/projects/monolith/frontend/src/lib/grimoire/theme.css
+++ b/projects/monolith/frontend/src/lib/grimoire/theme.css
@@ -56,6 +56,18 @@
   --grim-type-class: #556070;
   --grim-type-event: #7a6f3a;
   --grim-type-quest: #2f8f8a;
+  /* Mechanics types share the slate "class" hue (one family). Defined as
+     aliases so they resolve to the dark --grim-type-class value under
+     .grimoire.dark too, without repeating the override below. */
+  --grim-type-condition: var(--grim-type-class);
+  --grim-type-feat: var(--grim-type-class);
+  --grim-type-race: var(--grim-type-class);
+  --grim-type-background: var(--grim-type-class);
+  --grim-type-subclass: var(--grim-type-class);
+  --grim-type-class_feature: var(--grim-type-class);
+  --grim-type-action: var(--grim-type-class);
+  --grim-type-rule: var(--grim-type-class);
+  --grim-type-table: var(--grim-type-class);
 }
 
 .grimoire.dark {

--- a/projects/monolith/frontend/src/lib/grimoire/theme.css
+++ b/projects/monolith/frontend/src/lib/grimoire/theme.css
@@ -12,38 +12,57 @@
  */
 
 .grimoire {
-  /* Oxblood / madder red, inherited from the Monster Manual stat-block heritage.
-   * Overriding --accent here recolors every descendant that reads it (links,
-   * active states) without touching the global token. */
-  --grim-accent: #7c2b2b;
-  --grim-accent-strong: #5c1d1d;
+  /* Clean library palette (2026-07-05 reskin mockup): a cool slate-blue
+   * accent over a light neutral paper, replacing the earlier oxblood/parchment
+   * scheme. Overriding --accent here recolors every descendant that reads it
+   * (links, active states) without touching the global token. */
+  --grim-accent: #33507a;
+  --grim-accent-strong: #26406a;
   --accent: var(--grim-accent);
   /* Text and glyphs on the accent fill (active chips, badges, new markers):
-   * white on the deep light-mode oxblood. */
+   * white on the light-mode accent. */
   --grim-on-accent: #ffffff;
 
   --grim-serif:
     "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia,
     "Times New Roman", serif;
 
-  /* Paper: a warm near-white for reading surfaces only (the reader + stat
-   * block), never the whole chrome. */
-  --grim-paper: #faf6ee;
-  --grim-paper-line: #e6ddca;
-  --grim-ink: #241c15;
-  --grim-ink-soft: #5b4f42;
+  /* Paper: the reading-surface tint (reader + stat block), never the whole
+   * chrome. */
+  --grim-paper: #f3f5f7;
+  --grim-paper-line: #dbe0e7;
+  --grim-ink: #1a1f28;
+  --grim-ink-soft: #55606f;
+
+  /* Neutrals shared by the rest of the chrome (rows, cards, chips, panels):
+   * new token names, additive to the palette above. */
+  --grim-surface: #ffffff;
+  --grim-surface-2: #edf0f4;
+  --grim-line: #dbe0e7;
+  --grim-line-soft: #e8ebef;
+  --grim-text-dim: #55606f;
+  --grim-text-faint: #8a94a2;
+  --grim-accent-soft: rgba(51, 80, 122, 0.1);
 }
 
 body.dark .grimoire {
-  --grim-accent: #c56d6d;
-  --grim-accent-strong: #d98a8a;
-  /* The dark theme's accent is a lighter rose, so on-accent text flips to dark
+  --grim-accent: #7d9fd0;
+  --grim-accent-strong: #93b0da;
+  /* The dark theme's accent is a lighter blue, so on-accent text flips to dark
    * ink for legible contrast. */
-  --grim-on-accent: #17130f;
-  --grim-paper: #17130f;
-  --grim-paper-line: #322920;
-  --grim-ink: #ece3d4;
-  --grim-ink-soft: #b3a793;
+  --grim-on-accent: #0d1017;
+  --grim-paper: #0d1017;
+  --grim-paper-line: #2a3140;
+  --grim-ink: #e8e2d0;
+  --grim-ink-soft: #9aa3b2;
+
+  --grim-surface: #141924;
+  --grim-surface-2: #1a2130;
+  --grim-line: #2a3140;
+  --grim-line-soft: #212836;
+  --grim-text-dim: #9aa3b2;
+  --grim-text-faint: #626d7e;
+  --grim-accent-soft: rgba(125, 159, 208, 0.14);
 }
 
 /* ── Reader / Chapters-nav brutalist tokens ────────────────────

--- a/projects/monolith/frontend/src/lib/grimoire/theme.css
+++ b/projects/monolith/frontend/src/lib/grimoire/theme.css
@@ -99,6 +99,26 @@
   --grim-type-class: #97a3b5;
   --grim-type-event: #b3a463;
   --grim-type-quest: #4fb0aa;
+
+  /* Dark safety net: the public tier's design-system.css (--ink, --cream,
+   * --paper, --bg-elev, --coral, --rule-2, ...) has no dark variant of its
+   * own -- it was built for the site's always-light brutalist pages, not for
+   * a scoped per-app toggle. Every grimoire surface has now been converted
+   * to consume --grim-* tokens directly, but this block is a backstop: any
+   * surface that still reads a design-system token (a future addition, a
+   * class from design-system.css like .eyebrow/.btn/.card-hard leaking in)
+   * gets the matching dark value here instead of silently staying
+   * light-mode-cream. Scoped to .grimoire.dark, so it can never affect the
+   * rest of the site. Values mirror the --grim-* dark tokens above exactly.
+   */
+  --cream: #0d1017;
+  --paper: #141924;
+  --ink: #e8e2d0;
+  --ink-2: #9aa3b2;
+  --ink-3: #626d7e;
+  --rule-2: #2a3140;
+  --coral: #7d9fd0;
+  --bg-elev: #1a2130;
 }
 
 /* ── Focus ────────────────────────────────────────────────────

--- a/projects/monolith/frontend/src/lib/grimoire/theme.css
+++ b/projects/monolith/frontend/src/lib/grimoire/theme.css
@@ -119,6 +119,16 @@
   --rule-2: #2a3140;
   --coral: #7d9fd0;
   --bg-elev: #1a2130;
+
+  /* tokens.css family: the private tier's topbar + Library/Entities chrome
+   * still read --fg/--bg/--muted (a separate legacy family that, like
+   * design-system.css, only flips on the site-wide body.dark). Override them
+   * here too so the whole private grimoire tree stays dark-legible under the
+   * scoped .grimoire.dark toggle instead of leaving those surfaces light. */
+  --bg: #0d1017;
+  --fg: #e8e2d0;
+  --muted: #9aa3b2;
+  --border-thin: 1px solid #2a3140;
 }
 
 /* ── Focus ────────────────────────────────────────────────────

--- a/projects/monolith/frontend/src/lib/grimoire/theme.css
+++ b/projects/monolith/frontend/src/lib/grimoire/theme.css
@@ -101,40 +101,6 @@
   --grim-type-quest: #4fb0aa;
 }
 
-/* ── Reader / Chapters-nav brutalist tokens ────────────────────
- * A second, deliberately separate palette used ONLY by Reader.svelte and its
- * Chapters dropdown (ChaptersNav.svelte) — the continuous book reader.
- * Everything else in the grimoire tree (entity views, stat blocks,
- * GrantChips, the Library) keeps the oxblood/paper identity above untouched:
- * these are new token NAMES, not overrides of --grim-accent/--grim-paper/etc.,
- * so nothing outside the reader/nav can pick them up by accident.
- *
- * Matches the PUBLIC tier's design-system.css palette exactly (same cream /
- * ink / yellow / Instrument Serif / JetBrains Mono brutalist language), so the
- * reading experience looks the same on both hostnames. No box-shadows: every
- * surface break is a flat 2px ink border. */
-.grimoire {
-  --grimb-cream: #f3ede1;
-  --grimb-paper: #ffffff;
-  --grimb-ink: #1a1a1a;
-  --grimb-ink-3: #6b6658;
-  --grimb-yellow: #ffde01;
-  --grimb-border: 2px solid var(--grimb-ink);
-  --grimb-mono:
-    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-  --grimb-serif: "Instrument Serif", Georgia, serif;
-}
-
-.grimoire.dark {
-  /* Dark mode: invert cream/ink so the reader stays flat-ink-on-paper rather
-   * than rendering white-on-white borders against the app's dark chrome. */
-  --grimb-cream: #17130f;
-  --grimb-paper: #211b15;
-  --grimb-ink: #ece3d4;
-  --grimb-ink-3: #a89b86;
-  --grimb-yellow: #ffde01;
-}
-
 /* ── Focus ────────────────────────────────────────────────────
  * One keyboard-focus ring for the whole grimoire tree: the oxblood accent, not
  * the browser default blue that clashes with the theme. :focus-visible so it

--- a/projects/monolith/frontend/src/lib/public/grimoire/ChaptersNav.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/ChaptersNav.svelte
@@ -1,14 +1,22 @@
 <script>
-  // Compact chapters dropdown for the public reader. Mirrors the private
-  // tier's ChaptersNav.svelte (see that file's docblock for the full
-  // rationale): a button in the sticky book bar opens a flat section list,
-  // styled like the old public section-list page (mono uppercase top-level
-  // rows, indented nested rows, right-aligned chunk counts). Reuses the
-  // public design-system tokens directly, same as Reader.svelte, so no new
-  // CSS variables are needed here.
+  // Section list for the public reader. Mirrors the private tier's
+  // ChaptersNav.svelte (see that file's docblock for the full rationale):
+  // fetches the book's section hierarchy once and renders a flat,
+  // indentation-by-depth list with the active section highlighted.
+  //
+  // Two variants, one fetch/highlight implementation:
+  //  - "sidebar" (default reading surface, desktop >760px): the list is
+  //    always expanded, rendered as Reader.svelte's left section-hierarchy
+  //    sidebar (see docs/plans/assets/2026-07-05-grimoire-reskin-mockup.html's
+  //    Reader tab). No button, no open/close state.
+  //  - "dropdown" (mobile <=760px, where the sidebar is hidden): the original
+  //    compact affordance -- a "Chapters" button in the sticky bar that
+  //    toggles a floating panel.
+  // Styled with the clean grimoire theme (--grim-* tokens), not the
+  // site-wide brutalist design-system tokens this component used before.
   import { apiFetch, chunkHref } from "$lib/public/grimoire/api.js";
 
-  let { bookId, activeSectionPath = null } = $props();
+  let { bookId, activeSectionPath = null, variant = "dropdown" } = $props();
 
   let open = $state(false);
   let sections = $state([]);
@@ -47,26 +55,28 @@
 
 <svelte:window onclick={onWindowClick} onkeydown={onWindowKeydown} />
 
-<div class="pub-chapters" bind:this={rootEl}>
-  <button
-    type="button"
-    class="mono pub-chapters-btn"
-    class:pub-chapters-btn--open={open}
-    aria-expanded={open}
-    aria-controls="pub-chapters-panel"
-    onclick={() => (open = !open)}
-  >
-    Chapters
-  </button>
+<div class="pub-chapters pub-chapters--{variant}" bind:this={rootEl}>
+  {#if variant === "dropdown"}
+    <button
+      type="button"
+      class="pub-chapters-btn"
+      class:pub-chapters-btn--open={open}
+      aria-expanded={open}
+      aria-controls="pub-chapters-panel"
+      onclick={() => (open = !open)}
+    >
+      Chapters
+    </button>
+  {/if}
 
-  {#if open}
+  {#if variant === "sidebar" || open}
     <div class="pub-chapters-panel" id="pub-chapters-panel">
       {#if loading}
-        <p class="mono pub-chapters-status">Loading…</p>
+        <p class="pub-chapters-status">Loading…</p>
       {:else if error}
-        <p class="mono pub-chapters-status">{error}</p>
+        <p class="pub-chapters-status">{error}</p>
       {:else if sections.length === 0}
-        <p class="mono pub-chapters-status">This book has no chunks yet.</p>
+        <p class="pub-chapters-status">This book has no chunks yet.</p>
       {:else}
         <ul class="pub-chapters-list">
           {#each sections as section (section.section_path)}
@@ -82,7 +92,7 @@
                 onclick={() => (open = false)}
               >
                 <span class="pub-chapters-row-title">{section.title}</span>
-                <span class="mono pub-chapters-row-count"
+                <span class="pub-chapters-row-count"
                   >{section.chunk_count}</span
                 >
               </a>
@@ -100,23 +110,30 @@
     flex-shrink: 0;
   }
 
+  .pub-chapters--sidebar {
+    width: 100%;
+  }
+
   .pub-chapters-btn {
     display: inline-flex;
     align-items: center;
     min-height: 32px;
-    padding: 5px 11px;
+    padding: 5px 14px;
     font-size: 11px;
-    font-weight: 700;
+    font-weight: 600;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
-    background: var(--cream);
-    color: var(--ink);
-    border: 2px solid var(--ink);
+    background: var(--grim-surface);
+    color: var(--grim-ink);
+    border: 1px solid var(--grim-line);
+    border-radius: 999px;
     cursor: pointer;
   }
 
+  .pub-chapters-btn:hover,
   .pub-chapters-btn--open {
-    background: var(--accent);
+    color: var(--grim-accent);
+    border-color: var(--grim-accent);
   }
 
   /* Self-contained dropdown, positioned relative to .pub-chapters (this
@@ -133,11 +150,28 @@
     width: min(320px, calc(100vw - 40px));
     max-height: 60vh;
     overflow-y: auto;
-    background: var(--paper);
-    border: 2px solid var(--ink);
-    /* Reset from the ancestor .pub-bar's `mono` class: nested rows read in
-     * the sans reading face, top-level rows opt back into mono below. */
+    background: var(--grim-surface);
+    border: 1px solid var(--grim-line);
+    border-radius: 10px;
+    box-shadow: 0 8px 24px rgba(20, 24, 32, 0.14);
+    /* Base reading face for nested rows; top-level rows opt into the serif
+     * display face below. */
     font-family: var(--sans);
+  }
+
+  /* Sidebar variant: the panel IS the sidebar body, sticky-positioned by
+   * Reader.svelte's <aside> -- reset every dropdown-only affordance so it
+   * reads as a plain nav tree, not a floating card. */
+  .pub-chapters--sidebar .pub-chapters-panel {
+    position: static;
+    width: 100%;
+    max-height: none;
+    overflow: visible;
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    margin-top: 0;
   }
 
   .pub-chapters-list {
@@ -150,28 +184,37 @@
     align-items: baseline;
     justify-content: space-between;
     gap: 12px;
-    min-height: 40px;
-    padding: 8px 14px;
-    border-left: 4px solid transparent;
-    color: var(--ink-3);
+    min-height: 36px;
+    padding: 7px 14px;
+    border-left: 2px solid transparent;
+    color: var(--grim-text-dim);
+  }
+
+  .pub-chapters--sidebar .pub-chapters-row {
+    min-height: auto;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-right: 4px;
   }
 
   .pub-chapters-row:hover {
-    color: var(--ink);
+    color: var(--grim-ink);
   }
 
   .pub-chapters-row--h1 {
-    font-family: var(--mono);
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--ink);
+    font-family: var(--grim-serif);
+    font-weight: 600;
+    color: var(--grim-ink);
   }
 
   .pub-chapters-row--active {
-    background: var(--accent);
-    border-left-color: var(--ink);
-    color: var(--ink);
+    border-left-color: var(--grim-accent);
+    color: var(--grim-accent);
+    font-weight: 600;
+  }
+
+  .pub-chapters--dropdown .pub-chapters-row--active {
+    background: var(--grim-accent-soft);
   }
 
   .pub-chapters-row-title {
@@ -182,7 +225,7 @@
   }
 
   .pub-chapters-row--h1 .pub-chapters-row-title {
-    font-size: 12px;
+    font-size: 12.5px;
   }
 
   .pub-chapters-row-count {
@@ -191,11 +234,16 @@
     font-variant-numeric: tabular-nums;
     text-align: right;
     min-width: 22px;
+    color: var(--grim-text-faint);
   }
 
   .pub-chapters-status {
-    padding: 16px 14px;
+    padding: 14px;
     font-size: 11px;
-    color: var(--ink-3);
+    color: var(--grim-text-faint);
+  }
+
+  .pub-chapters--sidebar .pub-chapters-status {
+    padding: 0;
   }
 </style>

--- a/projects/monolith/frontend/src/lib/public/grimoire/Reader.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/Reader.svelte
@@ -2,11 +2,23 @@
   // Continuous book reader for the public tier. Mirrors the private tier's
   // Reader.svelte (see that file's docblock for the full design rationale:
   // flat, boundary-less chunk runs, section headings on section_path change,
-  // infinite scroll via IntersectionObserver, no entity chips). Reuses the
-  // public design-system tokens directly (--cream/--paper/--ink/--accent/
-  // --mono/--serif already ARE the brutalist palette the private reader had
-  // to introduce new tokens to match), so no new CSS variables are needed
-  // here — just flat 2px ink borders, never a box-shadow.
+  // infinite scroll via IntersectionObserver, no entity chips).
+  //
+  // Styled with the clean grimoire theme (--grim-* tokens from
+  // $lib/grimoire/theme.css, which resolve here via the ancestor
+  // `.grimoire` wrapper), not the site-wide brutalist design-system tokens
+  // this reader used before this pass: a cool-paper reading surface, serif
+  // body copy, hairline rules, small-caps section labels, no hard ink
+  // borders or mono chrome.
+  //
+  // Layout: a left section-hierarchy sidebar (desktop, >760px) alongside the
+  // reading column, per docs/plans/assets/2026-07-05-grimoire-reskin-
+  // mockup.html's Reader tab. The sidebar is ChaptersNav in its new
+  // `variant="sidebar"` mode: the same fetch + active-section-highlight
+  // logic as the original Chapters dropdown, just rendered inline and always
+  // expanded instead of behind a toggle. Below 760px the sidebar is hidden
+  // and the original dropdown affordance (`variant="dropdown"`) reappears in
+  // the sticky bar as the compact mobile chapters entry point.
   import { apiFetch } from "$lib/public/grimoire/api.js";
   import { renderChunk } from "$lib/public/grimoire/renderChunk.js";
   import ChaptersNav from "$lib/public/grimoire/ChaptersNav.svelte";
@@ -169,89 +181,102 @@
 </script>
 
 <div class="pub-reader">
-  <div class="pub-bar mono">
+  <div class="pub-bar">
     <span class="pub-bar-title">{bookMeta.displayName}</span>
     <div class="pub-bar-right">
       <span class="pub-bar-pos">
-        {sectionTitle(activeSectionPath).toUpperCase()}
+        {sectionTitle(activeSectionPath)}
         {#if activeSeq != null && bookMeta.chunkCount}
           · {activeSeq + 1}/{bookMeta.chunkCount}
         {/if}
       </span>
-      <ChaptersNav {bookId} {activeSectionPath} />
+      <!-- Compact mobile-only affordance: the sidebar below is hidden under
+           760px, so the dropdown Chapters button is the only way to jump
+           sections on a phone. Hidden on desktop via CSS (the sidebar
+           replaces it there); still mounts and fetches regardless of
+           viewport, same as the sidebar instance below -- a second cheap GET
+           of /books/{bookId}/sections, not worth a JS media-query gate. -->
+      <div class="pub-bar-chapters">
+        <ChaptersNav {bookId} {activeSectionPath} variant="dropdown" />
+      </div>
     </div>
   </div>
 
-  <div class="pub-panel" bind:this={containerEl}>
-    {#each rows as row, i (row.item.id)}
-      {#if row.showHeading}
-        {#if i > 0}
-          <div class="pub-divider" aria-hidden="true">
-            <span class="pub-divider-line"></span>
-            <span class="pub-divider-mark mono">§</span>
-            <span class="pub-divider-line"></span>
+  <div class="pub-layout">
+    <aside class="pub-toc" aria-label="Sections">
+      <p class="pub-toc-label">{bookMeta.displayName}</p>
+      <ChaptersNav {bookId} {activeSectionPath} variant="sidebar" />
+    </aside>
+
+    <div class="pub-panel" bind:this={containerEl}>
+      {#each rows as row, i (row.item.id)}
+        {#if row.showHeading}
+          {#if i > 0}
+            <hr class="pub-rule" aria-hidden="true" />
+          {/if}
+          <div
+            class="pub-heading"
+            data-heading
+            data-seq={row.item.seq}
+            data-section={row.item.section_path ?? ""}
+          >
+            {#if sectionParent(row.item.section_path)}
+              <p class="pub-section-label grim-smallcaps">
+                {sectionParent(row.item.section_path)}
+              </p>
+            {/if}
+            <h2 class="pub-section-title">{sectionTitle(row.item.section_path)}</h2>
           </div>
         {/if}
-        <div
-          class="pub-heading"
-          data-heading
-          data-seq={row.item.seq}
-          data-section={row.item.section_path ?? ""}
-        >
-          {#if sectionParent(row.item.section_path)}
-            <span class="pub-chip mono">{sectionParent(row.item.section_path)}</span>
-          {/if}
-          <h2 class="display pub-section-title">{sectionTitle(row.item.section_path)}</h2>
-        </div>
-      {/if}
 
-      <div class="pub-chunk" id="c-{row.item.id}">
-        <a
-          class="pub-anchor mono"
-          href="#c-{row.item.id}"
-          aria-label="Link to this passage"
-        >
-          #
-        </a>
-        {#if row.item.kind === "image"}
-          <figure class="pub-figure">
-            {#if row.item.image_url}
-              <img
-                class="pub-image"
-                src={row.item.image_url}
-                alt={row.item.content || "sourcebook illustration"}
-              />
-            {/if}
-            {#if row.item.content}
-              <figcaption class="pub-caption">{row.item.content}</figcaption>
-            {/if}
-          </figure>
-        {:else}
-          {#each bodyBlocks(row.item) as block, bi (bi)}
-            {#if block.type === "heading"}
-              <h3 class="eyebrow pub-inline-heading">{block.text}</h3>
-            {:else if block.type === "list"}
-              <ul class="pub-list">
-                {#each block.items as li, lii (lii)}
-                  <li>{li}</li>
-                {/each}
-              </ul>
-            {:else}
-              <p>{block.text}</p>
-            {/if}
-          {/each}
+        <div class="pub-chunk" id="c-{row.item.id}">
+          <a
+            class="pub-anchor"
+            href="#c-{row.item.id}"
+            aria-label="Link to this passage"
+          >
+            #
+          </a>
+          {#if row.item.kind === "image"}
+            <figure class="pub-figure">
+              {#if row.item.image_url}
+                <img
+                  class="pub-image"
+                  src={row.item.image_url}
+                  alt={row.item.content || "sourcebook illustration"}
+                />
+              {/if}
+              {#if row.item.content}
+                <figcaption class="pub-caption">{row.item.content}</figcaption>
+              {/if}
+            </figure>
+          {:else}
+            {#each bodyBlocks(row.item) as block, bi (bi)}
+              {#if block.type === "heading"}
+                <h3 class="pub-inline-heading">{block.text}</h3>
+              {:else if block.type === "list"}
+                <ul class="pub-list">
+                  {#each block.items as li, lii (lii)}
+                    <li>{li}</li>
+                  {/each}
+                </ul>
+              {:else}
+                <p>{block.text}</p>
+              {/if}
+            {/each}
+          {/if}
+        </div>
+      {/each}
+
+      <div class="pub-sentinel" bind:this={sentinelEl}>
+        {#if loadingMore}
+          <p class="pub-status">Loading…</p>
+        {:else if loadError}
+          <button class="pub-retry" onclick={loadMore}>Retry</button>
+        {:else if !nextCursor}
+          <p class="pub-status">— end of book —</p>
         {/if}
       </div>
-    {/each}
-
-    <div class="pub-sentinel" bind:this={sentinelEl}>
-      {#if loadingMore}
-        <p class="mono pub-status">Loading…</p>
-      {:else if loadError}
-        <button class="mono pub-retry" onclick={loadMore}>Retry</button>
-      {:else if !nextCursor}
-        <p class="mono pub-status">— end of book —</p>
-      {/if}
     </div>
   </div>
 </div>
@@ -259,116 +284,140 @@
 <style>
   .pub-reader {
     min-height: 60vh;
-    background: var(--cream);
-    color: var(--ink);
+    background: var(--grim-paper);
+    color: var(--grim-ink);
   }
 
   .pub-bar {
     position: sticky;
-    top: 0;
+    /* 58px is the app-shell topbar's own height (see the grimoire
+       +layout.svelte `.topbar`); both bars are sticky at once, so this one
+       has to park below it rather than at top:0 or they'd overlap. */
+    top: 58px;
     z-index: 5;
     display: flex;
-    align-items: baseline;
+    align-items: center;
     justify-content: space-between;
     gap: 16px;
-    padding: 12px 20px;
-    background: var(--cream);
-    border-bottom: 2px solid var(--ink);
+    padding: 10px 20px;
+    background: color-mix(in srgb, var(--grim-paper) 90%, transparent);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--grim-line);
     font-size: 11px;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.12em;
   }
 
   .pub-bar-title {
     text-transform: uppercase;
-    font-weight: 700;
+    font-weight: 600;
+    color: var(--grim-ink);
   }
 
   .pub-bar-right {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: 12px;
     min-width: 0;
   }
 
   .pub-bar-pos {
     text-transform: uppercase;
-    color: var(--ink-3);
+    color: var(--grim-text-faint);
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
-  .pub-panel {
-    max-width: 960px;
+  /* Sidebar covers this on desktop; only the mobile breakpoint below
+     switches it back on. */
+  .pub-bar-chapters {
+    display: none;
+  }
+
+  .pub-layout {
+    max-width: 1080px;
     margin: 0 auto;
-    padding: clamp(24px, 5vw, 48px) clamp(20px, 6vw, 48px);
-    background: var(--paper);
-    border: 2px solid var(--ink);
-    border-top: none;
+    padding: clamp(24px, 5vw, 48px) clamp(20px, 6vw, 48px) 80px;
+    display: grid;
+    grid-template-columns: 244px 1fr;
+    gap: 44px;
+    align-items: start;
   }
 
-  .pub-divider {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    margin: 40px 0;
-    max-width: 72ch;
-    margin-inline: auto;
+  .pub-toc {
+    position: sticky;
+    /* Approx: 58px app topbar + this reader's own ~42px sticky bar. */
+    top: 100px;
+    max-height: calc(100vh - 140px);
+    overflow-y: auto;
+    border-right: 1px solid var(--grim-line-soft);
+    padding-right: 20px;
   }
 
-  .pub-divider-line {
-    flex: 1;
-    height: 2px;
-    background: var(--ink);
+  .pub-toc-label {
+    margin: 0 0 14px;
+    font-family: var(--grim-serif);
+    font-weight: 700;
+    font-size: 15px;
+    line-height: 1.25;
+    color: var(--grim-ink);
+    overflow-wrap: break-word;
   }
 
-  .pub-divider-mark {
-    font-size: 14px;
-    color: var(--ink-3);
+  .pub-panel {
+    min-width: 0;
+  }
+
+  .pub-rule {
+    max-width: 68ch;
+    margin: 28px 0;
+    height: 1px;
+    border: 0;
+    background: var(--grim-line);
   }
 
   .pub-heading {
-    max-width: 72ch;
-    margin: 0 auto 20px;
+    max-width: 68ch;
+    margin: 0 0 18px;
   }
 
-  .pub-chip {
-    display: inline-flex;
-    align-items: center;
-    min-height: 24px;
-    padding: 2px 8px;
-    margin-bottom: 10px;
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    background: var(--accent);
-    color: var(--ink);
-    border: 1px solid var(--ink);
+  .pub-section-label {
+    margin: 0 0 6px;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--grim-accent);
   }
 
   .pub-section-title {
-    font-size: 32px;
-    color: var(--ink);
+    margin: 0;
+    font-family: var(--grim-serif);
+    font-size: 30px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    line-height: 1.15;
+    color: var(--grim-ink);
   }
 
   .pub-chunk {
     position: relative;
-    max-width: 72ch;
-    margin: 0 auto;
-    font-family: var(--sans);
-    font-size: 18px;
+    max-width: 68ch;
+    font-family: var(--grim-serif);
+    font-size: 17px;
     line-height: 1.66;
-    color: var(--ink);
+    color: var(--grim-ink);
   }
 
   .pub-chunk p {
-    margin: 0 0 16px;
+    margin: 0 0 14px;
   }
 
   .pub-inline-heading {
-    margin: 24px 0 10px;
-    color: var(--ink);
+    margin: 26px 0 8px;
+    font-family: var(--grim-serif);
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--grim-ink);
   }
 
   .pub-inline-heading:first-child {
@@ -376,7 +425,7 @@
   }
 
   .pub-list {
-    margin: 0 0 16px 22px;
+    margin: 0 0 14px 22px;
     padding: 0;
     list-style: disc;
   }
@@ -389,8 +438,8 @@
     position: absolute;
     left: -28px;
     top: 3px;
-    font-size: 14px;
-    color: var(--ink-3);
+    font-size: 13px;
+    color: var(--grim-text-faint);
     text-decoration: none;
     opacity: 0;
     transition: opacity 120ms ease;
@@ -401,22 +450,34 @@
     opacity: 1;
   }
 
-  .pub-figure {
-    margin: 24px 0;
+  .pub-anchor:hover {
+    color: var(--grim-accent);
   }
 
+  .pub-figure {
+    margin: 24px 0;
+    max-width: 68ch;
+  }
+
+  /* Never upscale: max-width (not width) + no forced height keep small
+     illustrations at their natural size, while max-height caps oversized
+     scans so they never dominate the reading column. */
   .pub-image {
-    width: 100%;
+    display: block;
+    max-width: 100%;
     height: auto;
-    border: 2px solid var(--ink);
+    max-height: 60vh;
+    margin-inline: auto;
+    border: 1px solid var(--grim-line);
+    border-radius: 8px;
   }
 
   .pub-caption {
     margin-top: 10px;
-    font-family: var(--sans);
+    font-family: var(--grim-serif);
     font-style: italic;
-    font-size: 15px;
-    color: var(--ink-3);
+    font-size: 14px;
+    color: var(--grim-text-dim);
     text-align: center;
   }
 
@@ -424,32 +485,47 @@
     display: flex;
     justify-content: center;
     padding: 32px 0 8px;
+    max-width: 68ch;
   }
 
   .pub-status {
     font-size: 12px;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--ink-3);
+    color: var(--grim-text-faint);
   }
 
   .pub-retry {
     min-height: 40px;
-    padding: 8px 16px;
-    font-size: 13px;
-    font-weight: 700;
+    padding: 8px 18px;
+    font-size: 12px;
+    font-weight: 600;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    background: var(--paper);
-    color: var(--ink);
-    /* Flat 2px ink border only, no shadow: grimoire never uses box-shadow. */
-    border: 2px solid var(--ink);
+    background: var(--grim-surface);
+    color: var(--grim-ink);
+    border: 1px solid var(--grim-line);
+    border-radius: 9px;
     cursor: pointer;
   }
 
   .pub-retry:hover {
-    color: var(--ink);
-    background: var(--bg-elev);
+    color: var(--grim-accent);
+    border-color: var(--grim-accent);
+  }
+
+  @media (max-width: 760px) {
+    .pub-layout {
+      grid-template-columns: 1fr;
+    }
+
+    .pub-toc {
+      display: none;
+    }
+
+    .pub-bar-chapters {
+      display: inline-flex;
+    }
   }
 
   @media (max-width: 640px) {

--- a/projects/monolith/frontend/src/lib/public/grimoire/api.js
+++ b/projects/monolith/frontend/src/lib/public/grimoire/api.js
@@ -39,6 +39,7 @@ export async function apiFetch(path, options = {}) {
 
 export const libraryHref = () => "/app/grimoire";
 export const entitiesHref = () => "/app/grimoire/entities";
+export const exploreHref = () => "/app/grimoire/explore";
 export const entityHref = (id) =>
   `/app/grimoire/entity/${encodeURIComponent(id)}`;
 export const bookHref = (bookId) =>

--- a/projects/monolith/frontend/src/lib/public/grimoire/statblock/Creature.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/statblock/Creature.svelte
@@ -21,46 +21,38 @@
   const actions = $derived(normalizeBlocks(data.actions));
 </script>
 
-<article class="card-hard frame">
-  <h2 class="display name">{data.name}</h2>
-  {#if strap}<p class="eyebrow strap">{strap}</p>{/if}
+<article class="statblock grim-paper">
+  <h2 class="grim-title name">{data.name}</h2>
+  {#if strap}<p class="grim-smallcaps strap">{strap}</p>{/if}
 
-  <hr class="rule" />
+  <hr class="grim-rule" />
 
   <dl class="topline">
     {#if data.ac != null}
-      <div>
-        <dt class="eyebrow">Armor Class</dt>
-        <dd>{data.ac}</dd>
-      </div>
+      <div><dt>Armor Class</dt>
+        <dd>{data.ac}</dd></div>
     {/if}
     {#if data.hp_avg != null}
-      <div>
-        <dt class="eyebrow">Hit Points</dt>
-        <dd>{data.hp_avg}</dd>
-      </div>
+      <div><dt>Hit Points</dt>
+        <dd>{data.hp_avg}</dd></div>
     {/if}
     {#if speed}
-      <div>
-        <dt class="eyebrow">Speed</dt>
-        <dd>{speed}</dd>
-      </div>
+      <div><dt>Speed</dt>
+        <dd>{speed}</dd></div>
     {/if}
     {#if data.cr != null}
-      <div>
-        <dt class="eyebrow">Challenge</dt>
-        <dd>{data.cr}</dd>
-      </div>
+      <div><dt>Challenge</dt>
+        <dd>{data.cr}</dd></div>
     {/if}
   </dl>
 
   {#if hasScores}
-    <hr class="rule" />
-    <table class="abilities mono">
+    <hr class="grim-rule" />
+    <table class="abilities">
       <thead>
         <tr>
           {#each ABILITIES as a (a)}
-            <th class="eyebrow">{a}</th>
+            <th class="grim-smallcaps">{a}</th>
           {/each}
         </tr>
       </thead>
@@ -82,7 +74,7 @@
   {/if}
 
   {#if traits.length}
-    <hr class="rule" />
+    <hr class="grim-rule" />
     <div class="blocks">
       {#each traits as t, i (i)}
         <p class="block">
@@ -94,7 +86,7 @@
   {/if}
 
   {#if actions.length}
-    <h3 class="eyebrow section-head">Actions</h3>
+    <h3 class="grim-smallcaps section-head">Actions</h3>
     <div class="blocks">
       {#each actions as a, i (i)}
         <p class="block">
@@ -107,44 +99,47 @@
 </article>
 
 <style>
-  /* Classic stat-block content reframed in the design system's flat-ink
-     language: .card-hard supplies the border/shadow, an accent top stripe
-     marks it as a stat block specifically. */
-  .frame {
-    padding: clamp(20px, 4vw, 32px);
-    border-top: 4px solid var(--accent);
-    max-width: 640px;
+  .statblock {
+    padding: clamp(1rem, 3vw, 1.5rem);
+    border: 1px solid var(--grim-paper-line);
+    border-top: 3px solid var(--grim-accent);
+    max-width: 40rem;
   }
 
   .name {
-    font-size: clamp(28px, 5vw, 40px);
+    font-size: clamp(1.4rem, 4vw, 1.9rem);
+    color: var(--grim-accent-strong);
   }
 
   .strap {
-    margin-top: 4px;
-  }
-
-  .rule {
-    border: none;
-    border-top: 2px solid var(--rule);
-    margin: 16px 0;
+    font-size: 0.85rem;
+    color: var(--grim-ink-soft);
+    font-style: italic;
   }
 
   .topline {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px 28px;
+    gap: 0.35rem 1.5rem;
   }
 
   .topline div {
     display: flex;
-    gap: 8px;
+    gap: 0.4rem;
     align-items: baseline;
   }
 
+  .topline dt {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--grim-ink-soft);
+  }
+
   .topline dd {
+    font-family: var(--grim-serif);
     font-weight: 700;
-    font-size: 15px;
   }
 
   .abilities {
@@ -154,14 +149,14 @@
   }
 
   .abilities th {
-    font-size: 12px;
-    color: var(--ink-3);
-    padding-bottom: 6px;
+    font-size: 0.72rem;
+    color: var(--grim-accent);
+    padding-bottom: 0.2rem;
   }
 
   .abilities td {
-    padding: 4px;
-    font-size: 15px;
+    padding: 0.15rem 0.2rem;
+    font-family: var(--grim-serif);
   }
 
   .ab-score {
@@ -169,26 +164,30 @@
   }
 
   .ab-mod {
-    color: var(--ink-3);
-    font-size: 0.85em;
+    color: var(--grim-ink-soft);
+    font-size: 0.8em;
   }
 
   .section-head {
-    margin-top: 20px;
-    padding-bottom: 6px;
-    border-bottom: 2px solid var(--accent);
-    color: var(--ink);
+    font-size: 0.95rem;
+    color: var(--grim-accent);
+    border-bottom: 1px solid var(--grim-accent);
+    margin-top: 0.75rem;
+    padding-bottom: 0.15rem;
   }
 
   .blocks {
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    margin-top: 12px;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
   }
 
   .block {
-    line-height: 1.6;
+    font-family: var(--grim-serif);
+    font-size: 0.95rem;
+    line-height: 1.5;
+    color: var(--grim-ink);
   }
 
   .block-name {

--- a/projects/monolith/frontend/src/lib/public/grimoire/statblock/Generic.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/statblock/Generic.svelte
@@ -29,13 +29,13 @@
   );
 </script>
 
-<article class="card-hard frame">
-  <h2 class="display name">{data.name}</h2>
+<article class="generic grim-paper">
+  <h2 class="grim-title name">{data.name}</h2>
   {#if data.entity_type}
-    <p class="eyebrow strap">{data.entity_type}</p>
+    <p class="grim-smallcaps strap">{data.entity_type}</p>
   {/if}
 
-  <hr class="rule" />
+  <hr class="grim-rule" />
 
   {#if fields.length === 0}
     <p class="none">No further details recorded.</p>
@@ -44,17 +44,17 @@
       {#each fields as field (field.key)}
         {#if field.kind === "inline"}
           <div class="row">
-            <span class="eyebrow key">{formatFieldName(field.key)}</span>
+            <span class="key">{formatFieldName(field.key)}</span>
             <span class="val">{field.text}</span>
           </div>
         {:else if field.kind === "prose"}
           <div class="prose">
-            <span class="eyebrow key">{formatFieldName(field.key)}</span>
+            <span class="key">{formatFieldName(field.key)}</span>
             <p class="para">{field.text}</p>
           </div>
         {:else}
           <div class="prose">
-            <span class="eyebrow key">{formatFieldName(field.key)}</span>
+            <span class="key">{formatFieldName(field.key)}</span>
             {#each field.blocks as b, i (i)}
               <p class="para">
                 {#if b.name}<strong>{b.name}.</strong>{/if}
@@ -69,60 +69,66 @@
 </article>
 
 <style>
-  .frame {
-    padding: clamp(20px, 4vw, 32px);
-    border-top: 4px solid var(--coral);
-    max-width: 640px;
+  .generic {
+    padding: clamp(1rem, 3vw, 1.5rem);
+    border: 1px solid var(--grim-paper-line);
+    border-top: 3px solid var(--grim-accent);
+    max-width: 40rem;
   }
 
   .name {
-    font-size: clamp(28px, 5vw, 40px);
+    font-size: clamp(1.4rem, 4vw, 1.9rem);
+    color: var(--grim-accent-strong);
   }
 
   .strap {
-    margin-top: 4px;
-  }
-
-  .rule {
-    border: none;
-    border-top: 2px solid var(--rule);
-    margin: 16px 0;
+    font-size: 0.8rem;
+    color: var(--grim-ink-soft);
   }
 
   .fields {
     display: flex;
     flex-direction: column;
-    gap: 14px;
+    gap: 0.6rem;
   }
 
   .row {
     display: flex;
-    flex-wrap: wrap;
-    gap: 6px 12px;
+    gap: 0.75rem;
     align-items: baseline;
   }
 
   .key {
-    min-width: 9em;
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--grim-ink-soft);
+    min-width: 7rem;
     flex-shrink: 0;
   }
 
   .val {
-    font-weight: 700;
+    font-family: var(--grim-serif);
+    color: var(--grim-ink);
   }
 
   .prose .key {
     display: block;
-    margin-bottom: 6px;
+    margin-bottom: 0.2rem;
   }
 
   .para {
-    line-height: 1.65;
-    margin-bottom: 6px;
+    font-family: var(--grim-serif);
+    font-size: 0.95rem;
+    line-height: 1.55;
+    color: var(--grim-ink);
+    margin-bottom: 0.3rem;
   }
 
   .none {
+    font-family: var(--grim-serif);
     font-style: italic;
-    color: var(--ink-3);
+    color: var(--grim-ink-soft);
   }
 </style>

--- a/projects/monolith/frontend/src/lib/public/grimoire/statblock/Spell.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/statblock/Spell.svelte
@@ -30,17 +30,17 @@
   const description = $derived(normalizeBlocks(data.description));
 </script>
 
-<article class="card-hard frame">
-  <h2 class="display name">{data.name}</h2>
-  {#if strap}<p class="eyebrow strap">{strap}</p>{/if}
+<article class="spell grim-paper">
+  <h2 class="grim-title name">{data.name}</h2>
+  {#if strap}<p class="grim-smallcaps strap">{strap}</p>{/if}
 
-  <hr class="rule" />
+  <hr class="grim-rule" />
 
   {#if grid.length}
     <dl class="meta">
       {#each grid as [label, value] (label)}
         <div>
-          <dt class="eyebrow">{label}</dt>
+          <dt>{label}</dt>
           <dd>{value}</dd>
         </div>
       {/each}
@@ -48,13 +48,11 @@
   {/if}
 
   {#if classes}
-    <p class="classes">
-      <span class="eyebrow classes-label">Classes</span> {classes}
-    </p>
+    <p class="classes"><span class="classes-label">Classes:</span> {classes}</p>
   {/if}
 
   {#if description.length}
-    <hr class="rule" />
+    <hr class="grim-rule" />
     <div class="body">
       {#each description as p, i (i)}
         <p class="para">
@@ -67,54 +65,69 @@
 </article>
 
 <style>
-  .frame {
-    padding: clamp(20px, 4vw, 32px);
-    border-top: 4px solid var(--blue);
-    max-width: 640px;
+  .spell {
+    padding: clamp(1rem, 3vw, 1.5rem);
+    border: 1px solid var(--grim-paper-line);
+    border-top: 3px solid var(--grim-accent);
+    max-width: 40rem;
   }
 
   .name {
-    font-size: clamp(28px, 5vw, 40px);
+    font-size: clamp(1.4rem, 4vw, 1.9rem);
+    color: var(--grim-accent-strong);
   }
 
   .strap {
-    margin-top: 4px;
-  }
-
-  .rule {
-    border: none;
-    border-top: 2px solid var(--rule);
-    margin: 16px 0;
+    font-size: 0.85rem;
+    color: var(--grim-ink-soft);
+    font-style: italic;
   }
 
   .meta {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 10px 24px;
+    gap: 0.5rem 1.25rem;
+  }
+
+  .meta dt {
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--grim-ink-soft);
   }
 
   .meta dd {
+    font-family: var(--grim-serif);
     font-weight: 700;
-    font-size: 15px;
+    font-size: 0.95rem;
   }
 
   .classes {
-    margin-top: 14px;
-    font-size: 15px;
+    margin-top: 0.6rem;
+    font-family: var(--grim-serif);
+    font-size: 0.9rem;
   }
 
   .classes-label {
-    margin-right: 6px;
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--grim-ink-soft);
   }
 
   .body {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 0.5rem;
   }
 
   .para {
-    line-height: 1.65;
+    font-family: var(--grim-serif);
+    font-size: 0.95rem;
+    line-height: 1.55;
+    color: var(--grim-ink);
   }
 
   @media (max-width: 480px) {

--- a/projects/monolith/frontend/src/routes/private/app/grimoire/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/app/grimoire/+page.svelte
@@ -8,6 +8,7 @@
     lastViewpoint,
     libraryHref,
   } from "$lib/grimoire/api.js";
+  import ThemeToggle from "$lib/grimoire/ThemeToggle.svelte";
   import "$lib/grimoire/theme.css";
 
   let campaigns = $state([]);
@@ -68,8 +69,11 @@
 
 <div class="grimoire picker">
   <header class="head">
-    <h1 class="grim-title brand">Grimoire</h1>
-    <p class="tagline">An arcane ledger for your table.</p>
+    <div class="head-text">
+      <h1 class="grim-title brand">Grimoire</h1>
+      <p class="tagline">An arcane ledger for your table.</p>
+    </div>
+    <ThemeToggle />
   </header>
 
   {#if loading}
@@ -129,8 +133,8 @@
 <style>
   .picker {
     min-height: 100dvh;
-    background: var(--bg);
-    color: var(--fg);
+    background: var(--grim-surface);
+    color: var(--grim-ink);
     font-family: var(--font-mono);
     padding: clamp(1.5rem, 6vw, 5rem) 1.5rem;
     max-width: 46rem;
@@ -140,13 +144,20 @@
     gap: 2rem;
   }
 
+  .head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
   .brand {
     font-size: clamp(2rem, 8vw, 3rem);
     color: var(--grim-accent);
   }
 
   .tagline {
-    color: var(--muted);
+    color: var(--grim-text-dim);
     font-size: 0.85rem;
     margin-top: 0.35rem;
   }
@@ -156,7 +167,7 @@
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.14em;
-    color: var(--fg-tertiary);
+    color: var(--grim-text-faint);
     margin-bottom: 0.75rem;
   }
 
@@ -174,9 +185,9 @@
     flex-direction: column;
     gap: 0.15rem;
     padding: 0.75rem 1rem;
-    background: var(--bg);
-    color: var(--fg);
-    border: var(--border-thin);
+    background: var(--grim-surface);
+    color: var(--grim-ink);
+    border: 1px solid var(--grim-line);
     cursor: pointer;
   }
 
@@ -190,7 +201,7 @@
 
   .campaign-dm {
     font-size: 0.7rem;
-    color: var(--fg-tertiary);
+    color: var(--grim-text-faint);
     text-transform: uppercase;
     letter-spacing: 0.06em;
   }
@@ -207,9 +218,9 @@
     font-size: 0.9rem;
     min-height: 2.75rem;
     padding: 0.5rem 0.65rem;
-    background: var(--bg);
-    color: var(--fg);
-    border: var(--border-thin);
+    background: var(--grim-surface);
+    color: var(--grim-ink);
+    border: 1px solid var(--grim-line);
     flex: 1 1 12rem;
   }
 
@@ -219,7 +230,7 @@
     min-height: 2.75rem;
     padding: 0.5rem 1rem;
     background: var(--grim-accent);
-    color: #fff;
+    color: var(--grim-on-accent);
     border: none;
     cursor: pointer;
   }
@@ -230,7 +241,7 @@
   }
 
   .status--error {
-    color: var(--danger);
+    color: var(--grim-type-creature);
     font-size: 0.8rem;
   }
 
@@ -244,9 +255,9 @@
     height: 3rem;
     background: linear-gradient(
       90deg,
-      var(--surface) 25%,
+      var(--grim-surface-2) 25%,
       transparent 37%,
-      var(--surface) 63%
+      var(--grim-surface-2) 63%
     );
     background-size: 400% 100%;
     animation: shimmer 1.4s ease infinite;

--- a/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/+layout.svelte
@@ -12,6 +12,7 @@
   } from "$lib/grimoire/api.js";
   import Omnibox from "$lib/grimoire/Omnibox.svelte";
   import Shell from "$lib/grimoire/Shell.svelte";
+  import ThemeToggle from "$lib/grimoire/ThemeToggle.svelte";
   import "$lib/grimoire/theme.css";
 
   let { children } = $props();
@@ -122,25 +123,28 @@
       <Omnibox {campaignId} {viewpoint} />
     </div>
 
-    <nav class="viewpoints" aria-label="Viewpoint">
-      <span class="viewpoints-label">as</span>
-      <button
-        class="vp"
-        class:vp--active={viewpoint === "dm"}
-        onclick={() => switchViewpoint("dm")}
-      >
-        DM
-      </button>
-      {#each characters as character (character.id)}
+    <div class="viewpoints-row">
+      <nav class="viewpoints" aria-label="Viewpoint">
+        <span class="viewpoints-label">as</span>
         <button
           class="vp"
-          class:vp--active={viewpoint === character.id}
-          onclick={() => switchViewpoint(character.id)}
+          class:vp--active={viewpoint === "dm"}
+          onclick={() => switchViewpoint("dm")}
         >
-          {character.character_name}
+          DM
         </button>
-      {/each}
-    </nav>
+        {#each characters as character (character.id)}
+          <button
+            class="vp"
+            class:vp--active={viewpoint === character.id}
+            onclick={() => switchViewpoint(character.id)}
+          >
+            {character.character_name}
+          </button>
+        {/each}
+      </nav>
+      <ThemeToggle />
+    </div>
 
     <nav class="crumbs" aria-label="Sections">
       <a
@@ -215,8 +219,15 @@
     min-width: 0;
   }
 
-  .viewpoints {
+  .viewpoints-row {
     grid-area: viewpoints;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    justify-content: flex-end;
+  }
+
+  .viewpoints {
     display: flex;
     align-items: center;
     gap: 0.5rem;

--- a/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/entity/[id]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/app/grimoire/[campaign]/entity/[id]/+page.svelte
@@ -212,7 +212,7 @@
     font-size: 0.66rem;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    color: var(--fg-tertiary);
+    color: var(--grim-text-faint);
   }
 
   .rel-name {
@@ -229,8 +229,8 @@
     text-transform: uppercase;
     letter-spacing: 0.06em;
     padding: 0.08rem 0.35rem;
-    border: var(--border-thin);
-    color: var(--fg-secondary);
+    border: 1px solid var(--grim-line);
+    color: var(--grim-text-dim);
   }
 
   .source {
@@ -239,8 +239,8 @@
     gap: 0.2rem;
     padding: 0.6rem 0.75rem;
     border: 1px solid var(--grim-paper-line);
-    background: var(--bg);
-    color: var(--fg);
+    background: var(--grim-surface);
+    color: var(--grim-ink);
   }
 
   .source:hover {
@@ -252,7 +252,7 @@
     font-size: 0.62rem;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--fg-tertiary);
+    color: var(--grim-text-faint);
   }
 
   .source-preview {
@@ -279,11 +279,11 @@
 
   .empty-help {
     font-size: 0.82rem;
-    color: var(--fg-secondary);
+    color: var(--grim-text-dim);
   }
 
   .status--error {
-    color: var(--danger);
+    color: var(--grim-type-creature);
     font-size: 0.8rem;
   }
 
@@ -291,9 +291,9 @@
     height: 18rem;
     background: linear-gradient(
       90deg,
-      var(--surface) 25%,
+      var(--grim-surface-2) 25%,
       transparent 37%,
-      var(--surface) 63%
+      var(--grim-surface-2) 63%
     );
     background-size: 400% 100%;
     animation: shimmer 1.4s ease infinite;

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
@@ -9,7 +9,13 @@
   // mitigation) regardless of admission state.
   import { page } from "$app/stores";
   import TurnstileGate from "$lib/public/components/TurnstileGate.svelte";
-  import { libraryHref, entitiesHref } from "$lib/public/grimoire/api.js";
+  import ThemeToggle from "$lib/grimoire/ThemeToggle.svelte";
+  import "$lib/grimoire/theme.css";
+  import {
+    libraryHref,
+    entitiesHref,
+    exploreHref,
+  } from "$lib/public/grimoire/api.js";
 
   let { data, children } = $props();
 
@@ -20,6 +26,7 @@
   const section = $derived.by(() => {
     const id = $page.route.id ?? "";
     if (id.includes("/entities") || id.includes("/entity/")) return "entities";
+    if (id.includes("/explore")) return "explore";
     return "library";
   });
 </script>
@@ -36,21 +43,28 @@
   <meta name="robots" content="noindex, nofollow" />
 </svelte:head>
 
-<div class="grimoire-app">
+<div class="grimoire-app grimoire">
   <header class="topbar">
-    <a class="mono wordmark" href={libraryHref()}>GRIMOIRE</a>
+    <a class="wordmark" href={libraryHref()}>Grimoire</a>
     <nav class="topbar-nav" aria-label="Grimoire sections">
       <a
-        class="mono topbar-link"
+        class="topbar-link"
         class:active={section === "library"}
-        href={libraryHref()}>LIBRARY</a
+        href={libraryHref()}>Library</a
       >
       <a
-        class="mono topbar-link"
+        class="topbar-link"
         class:active={section === "entities"}
-        href={entitiesHref()}>ENTITIES</a
+        href={entitiesHref()}>Entities</a
+      >
+      <a
+        class="topbar-link"
+        class:active={section === "explore"}
+        href={exploreHref()}>Explore</a
       >
     </nav>
+    <div class="topbar-spacer"></div>
+    <ThemeToggle />
   </header>
 
   <main class="grimoire-shell">
@@ -105,49 +119,63 @@
   }
 
   .topbar {
+    position: sticky;
+    top: 0;
+    z-index: 10;
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 16px;
-    padding: 10px 32px;
-    border-bottom: 2px solid var(--ink);
-    background: var(--bg);
+    gap: 20px;
+    padding: 0 28px;
+    height: 58px;
+    background: color-mix(in srgb, var(--grim-paper) 88%, transparent);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--grim-line);
   }
 
   .wordmark {
+    font-weight: 700;
     font-size: 14px;
-    font-weight: 800;
-    letter-spacing: 0.14em;
-    color: var(--ink);
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--grim-ink);
     text-decoration: none;
+    flex: none;
   }
 
   .topbar-nav {
     display: flex;
-    gap: 6px;
+    gap: 4px;
+    margin-left: 8px;
   }
 
   .topbar-link {
     display: inline-flex;
     align-items: center;
-    min-height: 36px;
-    padding: 4px 12px;
-    font-size: 12px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    color: var(--ink-3);
+    min-height: 40px;
+    padding: 6px 12px;
+    margin-bottom: -1px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--grim-text-faint);
     text-decoration: none;
+    border-bottom: 2px solid transparent;
   }
 
-  /* High-contrast state change, no lift: ink fill on hover/active. */
+  /* Quiet indigo underline on hover/active, no fill: matches the reskin's
+     denoised chrome (the brutalist ink-block hover is gone). */
   .topbar-link:hover {
-    background: var(--ink);
-    color: var(--paper);
+    color: var(--grim-text-dim);
   }
 
   .topbar-link.active {
-    background: var(--ink);
-    color: var(--paper);
+    color: var(--grim-ink);
+    border-bottom-color: var(--grim-accent);
+  }
+
+  .topbar-spacer {
+    flex: 1;
   }
 
   .grimoire-shell {

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
@@ -80,32 +80,15 @@
 </div>
 
 <style>
-  /* App-own chrome: a slim topbar plus hard-edge overrides. Setting the
-     radius custom properties to 0 on the app root squares off every
-     .card-hard / button / select inside via inheritance, without touching
-     the rest of the public site. */
+  /* App-own chrome: a slim sticky topbar over the clean --grim-* theme. No
+     more design-system .card-hard/.btn overrides here: every surface in this
+     app tree now renders its own --grim-surface cards and hairline borders
+     directly (see theme.css + each route's <style> block), so there is
+     nothing left for a global override to neutralize. */
   .grimoire-app {
-    --radius: 0px;
-    --radius-lg: 0px;
     min-height: 100vh;
     display: flex;
     flex-direction: column;
-  }
-
-  /* The design system's :focus-visible ring is rounded (6px); square it to
-     match the hard-edge language inside the app. */
-  .grimoire-app :global(:focus-visible) {
-    border-radius: 0;
-  }
-
-  /* Grimoire is flat-ink brutalist: no box-shadows anywhere. The shared
-     .card-hard primitive normally lifts with a hard-offset shadow (both at
-     rest and on hover); neutralize both here so every card-hard row across
-     this app (Library book cards, the book section list, entities index,
-     entity detail, stat blocks) renders as a flat 2px ink border instead. */
-  .grimoire-app :global(.card-hard),
-  .grimoire-app :global(.card-hard:hover) {
-    box-shadow: none !important;
   }
 
   .topbar {

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
@@ -70,9 +70,9 @@
   <main class="grimoire-shell">
   {#if !admitted}
     <div class="wrap-narrow gate">
-      <p class="eyebrow">GRIMOIRE ACCESS</p>
-      <h1 class="display gate-title">
-        solve to <span class="hl-yellow">read.</span>
+      <p class="gate-eyebrow">Grimoire Access</p>
+      <h1 class="grim-title gate-title">
+        solve to <span class="gate-accent">read.</span>
       </h1>
       <p class="gate-copy">
         One quick check keeps the bots out of a copyrighted sourcebook. The
@@ -191,13 +191,26 @@
     gap: 16px;
   }
 
+  .gate-eyebrow {
+    margin: 0;
+    font-size: 11px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--grim-text-faint);
+  }
+
   .gate-title {
     font-size: clamp(32px, 6vw, 56px);
   }
 
+  .gate-accent {
+    color: var(--grim-accent);
+  }
+
   .gate-copy {
     max-width: 52ch;
-    color: var(--ink-2);
+    color: var(--grim-text-dim);
     line-height: 1.6;
   }
 </style>

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
@@ -11,11 +11,7 @@
   import TurnstileGate from "$lib/public/components/TurnstileGate.svelte";
   import ThemeToggle from "$lib/grimoire/ThemeToggle.svelte";
   import "$lib/grimoire/theme.css";
-  import {
-    libraryHref,
-    entitiesHref,
-    exploreHref,
-  } from "$lib/public/grimoire/api.js";
+  import { libraryHref, entitiesHref } from "$lib/public/grimoire/api.js";
 
   let { data, children } = $props();
 
@@ -26,7 +22,6 @@
   const section = $derived.by(() => {
     const id = $page.route.id ?? "";
     if (id.includes("/entities") || id.includes("/entity/")) return "entities";
-    if (id.includes("/explore")) return "explore";
     return "library";
   });
 </script>
@@ -56,11 +51,6 @@
         class="topbar-link"
         class:active={section === "entities"}
         href={entitiesHref()}>Entities</a
-      >
-      <a
-        class="topbar-link"
-        class:active={section === "explore"}
-        href={exploreHref()}>Explore</a
       >
     </nav>
     <div class="topbar-spacer"></div>

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
@@ -4,14 +4,10 @@
   // (this component only mounts once `admitted` is true), so there is no
   // corpus fetch before the challenge is solved.
   //
-  // NOTE ON GROUPING: the 2026-07-05 reskin mockup groups rows by book_kind
-  // (Adventures / Anthologies / Setting Guides / Bestiaries / Spellbooks /
-  // Magic Items / Rulebooks). The public GET /books response
-  // (grimoire.library.list_books, mounted at router_public) does not carry a
-  // book_kind field today -- the Book model has no such column -- so this page
-  // deliberately renders a single flat, ungrouped list rather than inventing a
-  // client-side title->kind mapping. Add book_kind grouping here once the
-  // backend response includes it.
+  // Rows are grouped by book_kind (Adventures / Anthologies / Setting Guides /
+  // Bestiaries / Spellbooks / Magic Items / Rulebooks). book_kind is derived
+  // server-side from the slug (grimoire.extract.book_kind) and returned by GET
+  // /books; unmapped slugs fall into an "Other" bucket.
   import { onMount } from "svelte";
   import { apiFetch, bookHref } from "$lib/public/grimoire/api.js";
 
@@ -80,6 +76,40 @@
       synced: timeAgo(latest),
     };
   });
+
+  // Book-type grouping (book_kind comes from GET /books, derived from the slug).
+  const KIND_LABEL = {
+    adventure: "Adventures",
+    "adventure-anthology": "Anthologies",
+    "setting-guide": "Setting Guides",
+    bestiary: "Bestiaries",
+    spellbook: "Spellbooks",
+    "magic-items": "Magic Items",
+    rulebook: "Rulebooks",
+    other: "Other",
+  };
+  const KIND_ORDER = [
+    "adventure",
+    "adventure-anthology",
+    "setting-guide",
+    "bestiary",
+    "spellbook",
+    "magic-items",
+    "rulebook",
+    "other",
+  ];
+  const grouped = $derived.by(() => {
+    const by = {};
+    for (const b of books) {
+      const k = KIND_LABEL[b.book_kind] ? b.book_kind : "other";
+      (by[k] ??= []).push(b);
+    }
+    return KIND_ORDER.filter((k) => by[k]?.length).map((k) => ({
+      kind: k,
+      label: KIND_LABEL[k],
+      rows: by[k],
+    }));
+  });
 </script>
 
 <div class="library-page">
@@ -115,28 +145,36 @@
       <p class="empty-help">Check back once a sourcebook has been uploaded.</p>
     </div>
   {:else}
-    <ul class="book-list">
-      {#each books as book (book.book_id)}
-        <li>
-          <a class="brow" href={bookHref(book.book_id)}>
-            <span class="brow-main">
-              <span class="title">
-                {book.display_name}
-                {#if isNew(book)}<span class="pill">New</span>{/if}
-              </span>
-              <span class="meta">
-                {book.chunk_count.toLocaleString()} chunks
-                <span class="dot">/</span>
-                {book.image_count.toLocaleString()} images
-                <span class="dot">/</span>
-                {book.entity_count.toLocaleString()} entities
-              </span>
-            </span>
-            <span class="read">Read &rarr;</span>
-          </a>
-        </li>
-      {/each}
-    </ul>
+    {#each grouped as group (group.kind)}
+      <section class="lib-group">
+        <div class="gh">
+          <span class="kind">{group.label}</span>
+          <span class="kn">{group.rows.length}</span>
+        </div>
+        <ul class="book-list">
+          {#each group.rows as book (book.book_id)}
+            <li>
+              <a class="brow" href={bookHref(book.book_id)}>
+                <span class="brow-main">
+                  <span class="title">
+                    {book.display_name}
+                    {#if isNew(book)}<span class="pill">New</span>{/if}
+                  </span>
+                  <span class="meta">
+                    {book.chunk_count.toLocaleString()} chunks
+                    <span class="dot">/</span>
+                    {book.image_count.toLocaleString()} images
+                    <span class="dot">/</span>
+                    {book.entity_count.toLocaleString()} entities
+                  </span>
+                </span>
+                <span class="read">Read &rarr;</span>
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/each}
   {/if}
 </div>
 
@@ -178,9 +216,35 @@
     margin: 0 8px;
   }
 
+  .lib-group {
+    margin-top: 32px;
+  }
+
+  .gh {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 0 8px 8px;
+    border-bottom: 1px solid var(--grim-line);
+  }
+
+  .gh .kind {
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--grim-accent);
+    font-weight: 700;
+  }
+
+  .gh .kn {
+    font-size: 11px;
+    color: var(--grim-text-faint);
+    font-variant-numeric: tabular-nums;
+  }
+
   .book-list {
     list-style: none;
-    margin: 24px 0 0;
+    margin: 2px 0 0;
     padding: 0;
   }
 

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
@@ -1,10 +1,18 @@
 <script>
-  // Public Grimoire Library: every loaded book plus a static corpus stats
-  // strip at the top. Fetches AFTER the layout's TurnstileGate admits
+  // Public Grimoire Library: every loaded book, plus a quiet one-line stats
+  // summary at the top. Fetches AFTER the layout's TurnstileGate admits
   // (this component only mounts once `admitted` is true), so there is no
   // corpus fetch before the challenge is solved.
+  //
+  // NOTE ON GROUPING: the 2026-07-05 reskin mockup groups rows by book_kind
+  // (Adventures / Anthologies / Setting Guides / Bestiaries / Spellbooks /
+  // Magic Items / Rulebooks). The public GET /books response
+  // (grimoire.library.list_books, mounted at router_public) does not carry a
+  // book_kind field today -- the Book model has no such column -- so this page
+  // deliberately renders a single flat, ungrouped list rather than inventing a
+  // client-side title->kind mapping. Add book_kind grouping here once the
+  // backend response includes it.
   import { onMount } from "svelte";
-  import Sticker from "$lib/public/components/Sticker.svelte";
   import { apiFetch, bookHref } from "$lib/public/grimoire/api.js";
 
   let books = $state([]);
@@ -43,7 +51,7 @@
     return "just now";
   }
 
-  // NEW badge: a book with a chunk loaded in the last 7 days. Public visitors
+  // NEW pill: a book with a chunk loaded in the last 7 days. Public visitors
   // are anonymous, so there is no per-device "last seen" bookkeeping (that was
   // a private-app-only localStorage convenience); a fixed recency window keeps
   // this simple and stateless.
@@ -55,9 +63,8 @@
     return Date.now() - then < NEW_WINDOW_MS;
   }
 
-  // Static corpus totals for the strip at the top: aggregate across every
-  // loaded book, with the most recent sync time. Static and readable, not a
-  // scrolling marquee.
+  // Corpus totals for the one-line summary: aggregate across every loaded
+  // book, with the most recent sync time.
   const totals = $derived.by(() => {
     const sum = (key) => books.reduce((acc, b) => acc + (b[key] ?? 0), 0);
     const latest = books
@@ -75,170 +82,177 @@
   });
 </script>
 
-<div class="library-page page">
+<div class="library-page">
+  <p class="eyebrow">The Grimoire</p>
+  <h1 class="grim-title lib-title">Library</h1>
+
   {#if !loading && !error && books.length > 0}
-    <div class="stats-strip mono" role="status">
-      <span>{totals.books} {totals.books === 1 ? "BOOK" : "BOOKS"}</span>
-      <span class="strip-dot" aria-hidden="true">●</span>
-      <span>{totals.chunks} CHUNKS</span>
-      <span class="strip-dot" aria-hidden="true">●</span>
-      <span>{totals.images} IMAGES</span>
-      <span class="strip-dot" aria-hidden="true">●</span>
-      <span>{totals.entities} ENTITIES</span>
-      <span class="strip-dot" aria-hidden="true">●</span>
-      <span>SYNCED {totals.synced}</span>
-    </div>
+    <p class="summary">
+      <b>{totals.books.toLocaleString()}</b>
+      {totals.books === 1 ? "book" : "books"}
+      <span class="dot">/</span>
+      <b>{totals.chunks.toLocaleString()}</b> chunks
+      <span class="dot">/</span>
+      <b>{totals.images.toLocaleString()}</b> images
+      <span class="dot">/</span>
+      <b>{totals.entities.toLocaleString()}</b> entities
+      <span class="dot">/</span>
+      synced {totals.synced}
+    </p>
   {/if}
 
-  <div class="wrap">
-    <p class="eyebrow">THE GRIMOIRE</p>
-    <h1 class="display lib-title">Library</h1>
-
   {#if loading}
-    <div class="skeletons">
-      {#each [1, 2, 3] as n (n)}
-        <div class="card-hard skeleton-row"></div>
+    <div class="skeletons" aria-hidden="true">
+      {#each [1, 2, 3, 4, 5] as n (n)}
+        <div class="skeleton-row"></div>
       {/each}
     </div>
   {:else if error}
-    <p class="mono status-error">{error}</p>
+    <p class="status-error">{error}</p>
   {:else if books.length === 0}
     <div class="empty">
-      <p class="display empty-lead">Nothing loaded yet.</p>
-      <p class="mono empty-help">Check back once a sourcebook has been uploaded.</p>
+      <p class="grim-title empty-lead">Nothing loaded yet.</p>
+      <p class="empty-help">Check back once a sourcebook has been uploaded.</p>
     </div>
   {:else}
     <ul class="book-list">
       {#each books as book (book.book_id)}
-        <li class="card-hard book-row">
-          <div class="book-main">
-            <div class="book-name-row">
-              <span class="display book-name">{book.display_name}</span>
-              {#if isNew(book)}
-                <Sticker color="var(--accent)" rotate={-4}>NEW</Sticker>
-              {/if}
-            </div>
-
-            <div class="book-stats">
-              <span class="chip mono">{book.chunk_count} CHUNKS</span>
-              <span class="chip mono">{book.image_count} IMAGES</span>
-              <span class="chip mono">{book.entity_count} ENTITIES</span>
-              <span class="chip mono chip-muted"
-                >SYNCED {timeAgo(book.latest_chunk_at)}</span
-              >
-            </div>
-          </div>
-
-          <a class="btn btn-primary book-read" href={bookHref(book.book_id)}>
-            READ
+        <li>
+          <a class="brow" href={bookHref(book.book_id)}>
+            <span class="brow-main">
+              <span class="title">
+                {book.display_name}
+                {#if isNew(book)}<span class="pill">New</span>{/if}
+              </span>
+              <span class="meta">
+                {book.chunk_count.toLocaleString()} chunks
+                <span class="dot">/</span>
+                {book.image_count.toLocaleString()} images
+                <span class="dot">/</span>
+                {book.entity_count.toLocaleString()} entities
+              </span>
+            </span>
+            <span class="read">Read &rarr;</span>
           </a>
         </li>
       {/each}
     </ul>
   {/if}
-  </div>
 </div>
 
 <style>
-  /* Everything visual (cards, buttons, headings, highlight) comes from the
-     design system. The custom rules below are purely structural: page
-     vertical rhythm, the book-row flex layout, and two small primitives the
-     design system doesn't ship (stat chip pills, a coverage bar) built from
-     its own tokens rather than new colors. */
   .library-page {
-    padding-bottom: 96px;
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 40px 28px 80px;
   }
 
-  /* Static full-bleed stats strip: the ticker's useful numbers without the
-     scroll. Accent ground, hard rule below, wraps on small screens. */
-  .stats-strip {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
-    column-gap: 14px;
-    row-gap: 4px;
-    padding: 10px 16px;
-    background: var(--accent);
-    border-bottom: 2px solid var(--ink);
-    color: var(--ink);
-    font-size: 12px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-  }
-
-  .strip-dot {
-    font-size: 8px;
+  .eyebrow {
+    font-size: 11px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--grim-text-faint);
+    font-weight: 600;
+    margin: 0;
   }
 
   .lib-title {
-    font-size: clamp(36px, 7vw, 64px);
-    margin: 4px 0 28px;
+    font-size: clamp(36px, 6vw, 46px);
+    margin: 6px 0 0;
   }
 
-  .library-page .wrap {
-    padding-top: 40px;
+  .summary {
+    margin-top: 14px;
+    color: var(--grim-text-dim);
+    font-size: 13.5px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .summary b {
+    color: var(--grim-ink);
+    font-weight: 600;
+  }
+
+  .dot {
+    color: var(--grim-text-faint);
+    margin: 0 8px;
   }
 
   .book-list {
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
+    list-style: none;
+    margin: 24px 0 0;
+    padding: 0;
   }
 
-  .book-row {
-    padding: 24px;
+  .brow {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 15px;
+    padding: 13px 8px;
+    text-decoration: none;
+    color: inherit;
+    border-bottom: 1px solid var(--grim-line-soft);
+    border-radius: 7px;
+  }
+
+  .book-list li:last-child .brow {
+    border-bottom: 0;
+  }
+
+  .brow:hover {
+    background: var(--grim-surface-2);
+  }
+
+  .brow .title {
+    font-family: var(--grim-serif);
+    font-size: 18px;
+    font-weight: 600;
     display: flex;
     align-items: center;
-    gap: 20px;
+    gap: 9px;
+    color: var(--grim-ink);
   }
 
-  .book-main {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+  .brow .meta {
+    display: block;
+    margin-top: 3px;
+    color: var(--grim-text-dim);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
   }
 
-  .book-name-row {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    flex-wrap: wrap;
+  .brow .meta .dot {
+    margin: 0 6px;
   }
 
-  .book-name {
-    font-size: clamp(20px, 3vw, 28px);
+  .pill {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--grim-accent);
+    background: var(--grim-accent-soft);
+    border-radius: 4px;
+    padding: 2px 6px;
   }
 
-  .book-stats {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-  }
-
-  .chip {
+  .read {
     display: inline-flex;
     align-items: center;
+    gap: 5px;
+    white-space: nowrap;
     font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    padding: 5px 10px;
-    border: 2px solid var(--ink);
-    background: var(--bg-elev);
-    color: var(--ink);
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--grim-accent);
+    opacity: 0;
+    transition: opacity 0.15s;
   }
 
-  .chip-muted {
-    background: transparent;
-    color: var(--ink-3);
-    border-color: var(--rule-2);
-  }
-
-  .book-read {
-    flex: none;
-    min-height: 44px;
+  .brow:hover .read {
+    opacity: 1;
   }
 
   .empty {
@@ -251,28 +265,30 @@
   }
 
   .empty-help {
-    color: var(--ink-3);
+    color: var(--grim-text-dim);
     font-size: 13px;
   }
 
   .status-error {
-    color: var(--coral);
+    color: var(--grim-type-creature);
     padding: 24px 0;
   }
 
   .skeletons {
     display: flex;
     flex-direction: column;
-    gap: 20px;
+    gap: 12px;
+    margin-top: 24px;
   }
 
   .skeleton-row {
-    height: 110px;
+    height: 62px;
+    border-radius: 7px;
     background: linear-gradient(
       90deg,
-      var(--bg-elev) 25%,
+      var(--grim-surface-2) 25%,
       transparent 37%,
-      var(--bg-elev) 63%
+      var(--grim-surface-2) 63%
     );
     background-size: 400% 100%;
     animation: shimmer 1.4s ease infinite;
@@ -289,17 +305,7 @@
 
   @media (max-width: 640px) {
     .library-page {
-      padding-bottom: 72px;
-    }
-    .library-page .wrap {
-      padding-top: 28px;
-    }
-    .book-row {
-      flex-direction: column;
-      align-items: stretch;
-    }
-    .book-read {
-      align-self: flex-start;
+      padding: 28px 20px 60px;
     }
   }
 

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/adventure/[id]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/adventure/[id]/+page.svelte
@@ -53,19 +53,19 @@
 
 <div class="wrap-narrow detail-page page">
   {#if loading}
-    <div class="card-hard skeleton-block"></div>
+    <div class="skeleton-block"></div>
   {:else if notFound}
     <div class="empty">
-      <p class="empty-lead display">Not found.</p>
+      <p class="grim-title empty-lead">Not found.</p>
       <p class="empty-help">This adventure isn't in the loaded corpus.</p>
     </div>
   {:else if error}
-    <p class="mono status-error">{error}</p>
+    <p class="status-error">{error}</p>
   {:else if adventure}
     <a class="eyebrow back-link" href={bookHref(adventure.book_id)}
       >&larr; {adventure.book_display_name.toUpperCase()}</a
     >
-    <h1 class="display adventure-title">{adventure.name}</h1>
+    <h1 class="grim-title adventure-title">{adventure.name}</h1>
     {#if adventure.level_range}
       <p class="eyebrow adventure-level">LEVEL {adventure.level_range}</p>
     {/if}
@@ -78,7 +78,7 @@
         <h3 class="eyebrow head">Roster</h3>
         {#each groups as group (group.entity_type)}
           <div class="roster-group">
-            <p class="mono roster-group-title">{group.entity_type}</p>
+            <p class="roster-group-title">{group.entity_type}</p>
             <ul class="rel-list">
               {#each group.items as ent (ent.id)}
                 <li class="rel">
@@ -90,7 +90,7 @@
         {/each}
       </section>
     {:else}
-      <p class="mono empty-help roster-empty">
+      <p class="empty-help roster-empty">
         No entities extracted in this range yet.
       </p>
     {/if}
@@ -105,13 +105,22 @@
     gap: 24px;
   }
 
+  .eyebrow {
+    font-size: 11px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--grim-text-faint);
+    font-weight: 600;
+    margin: 0;
+  }
+
   .back-link {
     display: inline-block;
     align-self: flex-start;
   }
 
   .back-link:hover {
-    color: var(--ink);
+    color: var(--grim-ink);
   }
 
   .adventure-title {
@@ -121,11 +130,10 @@
 
   .adventure-level {
     margin-top: -16px;
-    color: var(--ink-3);
   }
 
   .adventure-summary {
-    color: var(--ink-2);
+    color: var(--grim-text-dim);
     font-size: 16px;
     line-height: 1.6;
   }
@@ -143,7 +151,8 @@
   }
 
   .roster-group-title {
-    color: var(--ink-3);
+    font-family: var(--font-mono);
+    color: var(--grim-text-faint);
     text-transform: uppercase;
     letter-spacing: 0.06em;
     font-size: 11px;
@@ -168,10 +177,11 @@
   }
 
   .rel-name:hover {
-    color: var(--ink);
+    color: var(--grim-ink);
   }
 
   .roster-empty {
+    font-family: var(--font-mono);
     font-size: 12px;
   }
 
@@ -186,21 +196,23 @@
   }
 
   .empty-help {
-    color: var(--ink-3);
+    color: var(--grim-text-faint);
   }
 
   .status-error {
-    color: var(--coral);
+    font-family: var(--font-mono);
+    color: var(--grim-type-creature);
     padding: 32px 0;
   }
 
   .skeleton-block {
     height: 320px;
+    border-radius: 7px;
     background: linear-gradient(
       90deg,
-      var(--bg-elev) 25%,
+      var(--grim-surface-2) 25%,
       transparent 37%,
-      var(--bg-elev) 63%
+      var(--grim-surface-2) 63%
     );
     background-size: 400% 100%;
     animation: shimmer 1.4s ease infinite;

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/+page.svelte
@@ -53,17 +53,17 @@
     <ul class="adventures-list">
       {#each adventures as adv (adv.id)}
         <li>
-          <a class="card-hard adventure-row" href={adventureHref(adv.id)}>
+          <a class="adventure-row" href={adventureHref(adv.id)}>
             <div class="adventure-main">
-              <span class="display adventure-name">{adv.name}</span>
+              <span class="grim-title adventure-name">{adv.name}</span>
               {#if adv.level_range}
-                <span class="mono adventure-level">LVL {adv.level_range}</span>
+                <span class="adventure-level">LVL {adv.level_range}</span>
               {/if}
             </div>
             {#if adv.summary}
               <p class="adventure-summary">{adv.summary}</p>
             {/if}
-            <span class="mono adventure-count">{adv.entity_count} ENTITIES</span>
+            <span class="adventure-count">{adv.entity_count} ENTITIES</span>
           </a>
         </li>
       {/each}
@@ -85,6 +85,15 @@
     padding: 28px 32px 0;
   }
 
+  .eyebrow {
+    font-size: 11px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--grim-text-faint);
+    font-weight: 600;
+    margin: 0;
+  }
+
   .adventures-title {
     margin-bottom: 14px;
   }
@@ -101,6 +110,19 @@
     flex-direction: column;
     gap: 6px;
     padding: 16px 20px;
+    text-decoration: none;
+    color: inherit;
+    background: var(--grim-surface);
+    border: 1px solid var(--grim-line-soft);
+    border-radius: 8px;
+    transition:
+      background 0.12s,
+      border-color 0.12s;
+  }
+
+  .adventure-row:hover {
+    background: var(--grim-surface-2);
+    border-color: var(--grim-line);
   }
 
   .adventure-main {
@@ -115,16 +137,19 @@
   }
 
   .adventure-level {
-    color: var(--ink-3);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--grim-text-faint);
   }
 
   .adventure-summary {
-    color: var(--ink-2);
+    color: var(--grim-text-dim);
     font-size: 13px;
   }
 
   .adventure-count {
-    color: var(--ink-3);
+    font-family: var(--font-mono);
+    color: var(--grim-text-faint);
     font-size: 11px;
   }
 </style>

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/c/[chunk]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/c/[chunk]/+page.svelte
@@ -4,11 +4,12 @@
   // fallback only because SvelteKit requires a +page.svelte for the route.
 </script>
 
-<p class="mono redirect-note">Opening reader…</p>
+<p class="redirect-note">Opening reader…</p>
 
 <style>
   .redirect-note {
+    font-family: var(--font-mono);
     padding: 32px;
-    color: var(--ink-3);
+    color: var(--grim-text-faint);
   }
 </style>

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/entities/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/entities/+page.svelte
@@ -195,6 +195,7 @@
         type="button"
         class="chip chip-all"
         class:on={type === ""}
+        aria-pressed={type === ""}
         onclick={() => (type = "")}
       >
         All
@@ -206,6 +207,7 @@
           type="button"
           class="chip"
           class:on={type === t.value}
+          aria-pressed={type === t.value}
           onclick={() => selectType(t.value)}
         >
           <span class="sw" style={`background: var(--grim-type-${t.value})`}

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/entities/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/entities/+page.svelte
@@ -1,11 +1,18 @@
 <script>
   // Public entity index: type filter + name search over the whole corpus (no
   // campaign/grants -- everything is visible). Results page via next_cursor.
+  import { onMount } from "svelte";
   import { apiFetch, libraryHref, entityHref } from "$lib/public/grimoire/api.js";
-  import BrutalistSelect from "$lib/public/components/BrutalistSelect.svelte";
 
-  const TYPE_OPTIONS = [
-    { value: "", label: "All types" },
+  // Color-coded filter chips: only the 10 entity types theme.css assigns a
+  // --grim-type-* hue to (the 7 lore types plus event/quest/class -- see the
+  // token block in $lib/grimoire/theme.css). The backend's EntityType enum
+  // also has ~9 "mechanics" types (condition, feat, race, background,
+  // subclass, class_feature, action, rule, table); those still come back from
+  // GET /entities and still render, just without a dedicated chip or hue (see
+  // typeColorVar's fallback below) -- adding tokens for them is a theme.css
+  // change and out of scope for this page-only restyle.
+  const TYPE_CHIPS = [
     { value: "creature", label: "Creature" },
     { value: "spell", label: "Spell" },
     { value: "location", label: "Location" },
@@ -13,7 +20,21 @@
     { value: "faction", label: "Faction" },
     { value: "deity", label: "Deity" },
     { value: "item", label: "Item" },
+    { value: "event", label: "Event" },
+    { value: "quest", label: "Quest" },
+    { value: "class", label: "Class" },
   ];
+  const KNOWN_TYPES = new Set(TYPE_CHIPS.map((t) => t.value));
+
+  function typeColorVar(entityType) {
+    return KNOWN_TYPES.has(entityType)
+      ? `var(--grim-type-${entityType})`
+      : "var(--grim-text-faint)";
+  }
+
+  function typeLabel(entityType) {
+    return entityType.replace(/_/g, " ");
+  }
 
   let type = $state("");
   let q = $state("");
@@ -24,14 +45,48 @@
   let loadingMore = $state(false);
   let error = $state("");
 
+  // Corpus-wide per-type counts for the chip badges. Fetched once on mount,
+  // independent of the live search/type filter above (limit=1 -- only the
+  // `total` field is read), so a chip's number always reads "how many of
+  // this type exist", not "how many match the current search".
+  let allCount = $state(null);
+  let typeCounts = $state({});
+
+  onMount(loadChipCounts);
+
+  async function loadChipCounts() {
+    try {
+      const all = await apiFetch("/entities?limit=1");
+      allCount = all.total ?? null;
+    } catch {
+      allCount = null;
+    }
+    await Promise.all(
+      TYPE_CHIPS.map(async (t) => {
+        try {
+          const res = await apiFetch(
+            `/entities?type=${encodeURIComponent(t.value)}&limit=1`,
+          );
+          typeCounts = { ...typeCounts, [t.value]: res.total ?? 0 };
+        } catch {
+          // Non-fatal: the chip just renders without a count badge.
+        }
+      }),
+    );
+  }
+
   const LIMIT = 40;
 
   // Debounce the search box so every keystroke doesn't fire a fetch; type
-  // changes (via BrutalistSelect) reload immediately through the $effect below.
+  // changes (via the chip row) reload immediately through the $effect below.
   let searchTimer = null;
   function onSearchInput() {
     clearTimeout(searchTimer);
     searchTimer = setTimeout(() => load(), 300);
+  }
+
+  function selectType(value) {
+    type = type === value ? "" : value;
   }
 
   $effect(() => {
@@ -104,61 +159,101 @@
   }
 </script>
 
-<div class="wrap entities-page page">
-  <a class="eyebrow back-link" href={libraryHref()}>&larr; LIBRARY</a>
-  <h1 class="display page-title">Entities</h1>
+<div class="entities-page">
+  <a class="eyebrow back-link" href={libraryHref()}>&larr; Library</a>
+  <h1 class="grim-title page-title">Entities</h1>
   <p class="eyebrow count-line">
-    {#if !loading}{total} indexed{/if}
+    {#if !loading}{total.toLocaleString()} indexed{/if}
   </p>
 
-  <div class="filters">
-    <div class="filter-select">
-      <BrutalistSelect
-        options={TYPE_OPTIONS}
-        bind:value={type}
-        label="Filter by type"
-        id="entities-type"
+  <div class="controls">
+    <div class="search">
+      <svg
+        class="search-icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        aria-hidden="true"
+      >
+        <circle cx="11" cy="11" r="7" />
+        <path d="M21 21l-4.3-4.3" />
+      </svg>
+      <input
+        class="search-input"
+        type="search"
+        placeholder="Search entities by name..."
+        aria-label="Search entities"
+        bind:value={q}
+        oninput={onSearchInput}
       />
     </div>
-    <input
-      class="mono search-input"
-      type="search"
-      placeholder="Search by name..."
-      bind:value={q}
-      oninput={onSearchInput}
-    />
+
+    <div class="chips" role="group" aria-label="Filter by entity type">
+      <button
+        type="button"
+        class="chip chip-all"
+        class:on={type === ""}
+        onclick={() => (type = "")}
+      >
+        All
+        {#if allCount != null}<span class="n">{allCount.toLocaleString()}</span
+          >{/if}
+      </button>
+      {#each TYPE_CHIPS as t (t.value)}
+        <button
+          type="button"
+          class="chip"
+          class:on={type === t.value}
+          onclick={() => selectType(t.value)}
+        >
+          <span class="sw" style={`background: var(--grim-type-${t.value})`}
+          ></span>
+          {t.label}
+          {#if typeCounts[t.value] != null}<span class="n"
+              >{typeCounts[t.value].toLocaleString()}</span
+            >{/if}
+        </button>
+      {/each}
+    </div>
   </div>
 
   {#if loading}
     <div class="grid">
       {#each Array(8) as _, i (i)}
-        <div class="card-hard skeleton-card"></div>
+        <div class="skeleton-card"></div>
       {/each}
     </div>
   {:else if error}
-    <p class="mono status-error">{error}</p>
+    <p class="status-error">{error}</p>
   {:else if items.length === 0}
     <div class="empty">
-      <p class="empty-lead display">Nothing found.</p>
+      <p class="grim-title empty-lead">Nothing found.</p>
       <p class="empty-help">Try a different type or search term.</p>
     </div>
   {:else}
     <div class="grid">
       {#each items as ent (ent.id)}
-        <a class="card-hard entity-card" href={entityHref(ent.id)}>
-          <p class="display entity-name">{ent.name}</p>
-          <p class="eyebrow entity-type">{ent.entity_type}</p>
-          {#if secondaryLine(ent)}
-            <p class="mono entity-secondary">{secondaryLine(ent)}</p>
-          {/if}
+        <a
+          class="ent"
+          href={entityHref(ent.id)}
+          style={`--ec: ${typeColorVar(ent.entity_type)}`}
+        >
+          <span class="ent-main">
+            <span class="nm">{ent.name}</span>
+            {#if secondaryLine(ent)}<span class="sec">{secondaryLine(ent)}</span
+              >{/if}
+          </span>
+          <span class="ty">{typeLabel(ent.entity_type)}</span>
         </a>
       {/each}
     </div>
 
     {#if nextCursor}
       <div class="load-more-row">
-        <button class="btn btn-secondary" onclick={loadMore} disabled={loadingMore}>
-          {loadingMore ? "LOADING..." : "LOAD MORE"}
+        <button class="load-more" onclick={loadMore} disabled={loadingMore}>
+          {loadingMore ? "Loading..." : "Load more"}
         </button>
       </div>
     {/if}
@@ -167,89 +262,206 @@
 
 <style>
   .entities-page {
-    padding: 48px 32px 96px;
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 40px 28px 80px;
+  }
+
+  .eyebrow {
+    font-size: 11px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--grim-text-faint);
+    font-weight: 600;
+    margin: 0;
   }
 
   .back-link {
     display: inline-block;
     margin-bottom: 20px;
+    text-decoration: none;
   }
 
   .back-link:hover {
-    color: var(--ink);
+    color: var(--grim-text-dim);
   }
 
   .page-title {
-    font-size: clamp(32px, 6vw, 48px);
+    font-size: clamp(32px, 6vw, 46px);
+    margin: 6px 0 0;
   }
 
   .count-line {
-    margin-top: 8px;
+    margin-top: 14px;
     min-height: 14px;
+    font-variant-numeric: tabular-nums;
   }
 
-  .filters {
+  .controls {
+    margin-top: 26px;
     display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
-    margin-top: 28px;
-    margin-bottom: 32px;
+    flex-direction: column;
+    gap: 14px;
   }
 
-  .filter-select {
-    width: 220px;
-    max-width: 100%;
+  .search {
+    position: relative;
+  }
+
+  .search-icon {
+    position: absolute;
+    left: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 16px;
+    height: 16px;
+    color: var(--grim-text-faint);
+    pointer-events: none;
   }
 
   .search-input {
-    flex: 1;
-    min-width: 200px;
-    min-height: 44px;
-    font-size: 13px;
-    padding: 7px 12px;
-    background: var(--cream);
-    border: 2px solid var(--ink);
-    color: var(--ink);
+    width: 100%;
+    height: 44px;
+    padding: 0 14px 0 40px;
+    background: var(--grim-surface);
+    border: 1px solid var(--grim-line);
+    border-radius: 9px;
+    font-size: 15px;
+    color: var(--grim-ink);
+    outline: none;
   }
 
   .search-input:focus-visible {
-    background: var(--paper);
+    border-color: var(--grim-accent);
+    box-shadow: 0 0 0 3px var(--grim-accent-soft);
+  }
+
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 7px;
+  }
+
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    cursor: pointer;
+    background: var(--grim-surface);
+    border: 1px solid var(--grim-line);
+    border-radius: 999px;
+    padding: 6px 13px 6px 10px;
+    font-size: 12.5px;
+    font-family: inherit;
+    color: var(--grim-text-dim);
+    min-height: 32px;
+  }
+
+  .chip:hover {
+    color: var(--grim-ink);
+  }
+
+  .chip .sw {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex: none;
+  }
+
+  .chip .n {
+    color: var(--grim-text-faint);
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .chip.on {
+    color: var(--grim-ink);
+    border-color: color-mix(in srgb, var(--grim-accent) 45%, var(--grim-line));
+    background: var(--grim-accent-soft);
+  }
+
+  .chip-all.on {
+    background: var(--grim-accent);
+    color: var(--grim-on-accent);
+    border-color: var(--grim-accent);
+  }
+
+  .chip-all.on .n {
+    color: inherit;
+    opacity: 0.8;
   }
 
   .grid {
+    margin-top: 22px;
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-    gap: 16px;
+    gap: 8px;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   }
 
-  .entity-card {
+  .ent {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    cursor: pointer;
+    background: var(--grim-surface);
+    border: 1px solid var(--grim-line-soft);
+    border-left: 3px solid var(--ec, var(--grim-text-faint));
+    border-radius: 8px;
+    padding: 11px 14px;
+    text-decoration: none;
+    color: inherit;
+    transition:
+      background 0.12s,
+      border-color 0.12s;
+  }
+
+  .ent:hover {
+    background: var(--grim-surface-2);
+    border-color: var(--grim-line);
+    border-left-color: var(--ec, var(--grim-text-faint));
+  }
+
+  .ent-main {
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    padding: 18px 20px;
-    min-height: 44px;
+    gap: 2px;
+    min-width: 0;
   }
 
-  .entity-name {
-    font-size: 22px;
+  .nm {
+    font-family: var(--grim-serif);
+    font-size: 16px;
+    line-height: 1.2;
+    color: var(--grim-ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
-  .entity-type {
-    color: var(--ink-3);
+  .sec {
+    font-size: 11.5px;
+    color: var(--grim-text-dim);
+    font-variant-numeric: tabular-nums;
   }
 
-  .entity-secondary {
-    color: var(--ink-2);
-    font-size: 12px;
+  .ty {
+    margin-left: auto;
+    flex: none;
+    font-size: 9.5px;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+    color: var(--grim-text-faint);
+    font-weight: 600;
   }
 
   .skeleton-card {
-    height: 96px;
+    height: 64px;
+    border-radius: 8px;
     background: linear-gradient(
       90deg,
-      var(--bg-elev) 25%,
+      var(--grim-surface-2) 25%,
       transparent 37%,
-      var(--bg-elev) 63%
+      var(--grim-surface-2) 63%
     );
     background-size: 400% 100%;
     animation: shimmer 1.4s ease infinite;
@@ -275,11 +487,11 @@
   }
 
   .empty-help {
-    color: var(--ink-3);
+    color: var(--grim-text-dim);
   }
 
   .status-error {
-    color: var(--coral);
+    color: var(--grim-type-creature);
     padding: 32px 0;
   }
 
@@ -287,6 +499,36 @@
     display: flex;
     justify-content: center;
     margin-top: 32px;
+  }
+
+  .load-more {
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    background: var(--grim-surface);
+    border: 1px solid var(--grim-line);
+    border-radius: 9px;
+    color: var(--grim-text-dim);
+    padding: 11px 22px;
+  }
+
+  .load-more:hover {
+    color: var(--grim-ink);
+    border-color: var(--grim-accent);
+  }
+
+  .load-more:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+
+  @media (max-width: 640px) {
+    .entities-page {
+      padding: 28px 20px 60px;
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/entity/[id]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/entity/[id]/+page.svelte
@@ -59,14 +59,14 @@
   <a class="eyebrow back-link" href={entitiesHref()}>&larr; ENTITIES</a>
 
   {#if loading}
-    <div class="card-hard skeleton-block"></div>
+    <div class="skeleton-block"></div>
   {:else if notFound}
     <div class="empty">
-      <p class="empty-lead display">Not found.</p>
+      <p class="grim-title empty-lead">Not found.</p>
       <p class="empty-help">This entity isn't in the loaded corpus.</p>
     </div>
   {:else if error}
-    <p class="mono status-error">{error}</p>
+    <p class="status-error">{error}</p>
   {:else if entity}
     <EntityDetail {entity} />
 
@@ -76,8 +76,8 @@
         <ul class="rel-list">
           {#each relationships as rel, i (i)}
             <li class="rel">
-              <span class="arrow mono">{rel.direction === "out" ? "→" : "←"}</span>
-              <span class="mono rel-type">{rel.rel_type.replaceAll("_", " ")}</span>
+              <span class="arrow">{rel.direction === "out" ? "→" : "←"}</span>
+              <span class="rel-type">{rel.rel_type.replaceAll("_", " ")}</span>
               <a class="rel-name" href={entityHref(rel.entity.id)}
                 >{rel.entity.name}</a
               >
@@ -93,10 +93,7 @@
         <ul class="source-list">
           {#each sources as src, i (i)}
             <li>
-              <a
-                class="card-hard source"
-                href={chunkHref(src.book_id, src.chunk_id)}
-              >
+              <a class="source" href={chunkHref(src.book_id, src.chunk_id)}>
                 <span class="eyebrow source-where">
                   {src.section_path ?? "lore"}
                 </span>
@@ -118,13 +115,22 @@
     gap: 32px;
   }
 
+  .eyebrow {
+    font-size: 11px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--grim-text-faint);
+    font-weight: 600;
+    margin: 0;
+  }
+
   .back-link {
     display: inline-block;
     align-self: flex-start;
   }
 
   .back-link:hover {
-    color: var(--ink);
+    color: var(--grim-ink);
   }
 
   .head {
@@ -146,11 +152,13 @@
   }
 
   .arrow {
-    color: var(--ink-3);
+    font-family: var(--font-mono);
+    color: var(--grim-text-faint);
   }
 
   .rel-type {
-    color: var(--ink-3);
+    font-family: var(--font-mono);
+    color: var(--grim-text-faint);
     font-size: 12px;
   }
 
@@ -160,7 +168,7 @@
   }
 
   .rel-name:hover {
-    color: var(--ink);
+    color: var(--grim-ink);
   }
 
   .source {
@@ -169,10 +177,23 @@
     gap: 4px;
     padding: 14px 16px;
     min-height: 44px;
+    text-decoration: none;
+    color: inherit;
+    background: var(--grim-surface);
+    border: 1px solid var(--grim-line-soft);
+    border-radius: 8px;
+    transition:
+      background 0.12s,
+      border-color 0.12s;
+  }
+
+  .source:hover {
+    background: var(--grim-surface-2);
+    border-color: var(--grim-line);
   }
 
   .source-where {
-    color: var(--ink-3);
+    color: var(--grim-text-faint);
   }
 
   .source-preview {
@@ -181,7 +202,7 @@
     line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
-    color: var(--ink-2);
+    color: var(--grim-text-dim);
   }
 
   .empty {
@@ -195,21 +216,23 @@
   }
 
   .empty-help {
-    color: var(--ink-3);
+    color: var(--grim-text-faint);
   }
 
   .status-error {
-    color: var(--coral);
+    font-family: var(--font-mono);
+    color: var(--grim-type-creature);
     padding: 32px 0;
   }
 
   .skeleton-block {
     height: 320px;
+    border-radius: 7px;
     background: linear-gradient(
       90deg,
-      var(--bg-elev) 25%,
+      var(--grim-surface-2) 25%,
       transparent 37%,
-      var(--bg-elev) 63%
+      var(--grim-surface-2) 63%
     );
     background-size: 400% 100%;
     animation: shimmer 1.4s ease infinite;

--- a/projects/monolith/frontend/visual/fixtures/api/grimoire_books.json
+++ b/projects/monolith/frontend/visual/fixtures/api/grimoire_books.json
@@ -1,10 +1,68 @@
 [
   {
-    "book_id": "mm",
+    "book_id": "curse-of-strahd",
+    "display_name": "Curse of Strahd",
+    "book_kind": "adventure",
+    "chunk_count": 1057,
+    "image_count": 180,
+    "extracted_count": 1057,
+    "entity_count": 412,
+    "latest_chunk_at": "2024-01-10T12:00:00Z",
+    "last_loaded_at": "2024-01-05T12:00:00Z"
+  },
+  {
+    "book_id": "lost-mine-of-phandelver",
+    "display_name": "Lost Mine of Phandelver",
+    "book_kind": "adventure",
+    "chunk_count": 210,
+    "image_count": 44,
+    "extracted_count": 210,
+    "entity_count": 96,
+    "latest_chunk_at": "2023-06-01T12:00:00Z",
+    "last_loaded_at": "2023-06-01T12:00:00Z"
+  },
+  {
+    "book_id": "candlekeep-mysteries",
+    "display_name": "Candlekeep Mysteries",
+    "book_kind": "adventure-anthology",
+    "chunk_count": 932,
+    "image_count": 131,
+    "extracted_count": 400,
+    "entity_count": 0,
+    "latest_chunk_at": "2024-01-15T12:00:00Z",
+    "last_loaded_at": "2024-01-12T12:00:00Z"
+  },
+  {
+    "book_id": "explorers-guide-to-wildemount",
+    "display_name": "Explorer's Guide to Wildemount",
+    "book_kind": "setting-guide",
+    "chunk_count": 1310,
+    "image_count": 280,
+    "extracted_count": 1310,
+    "entity_count": 640,
+    "latest_chunk_at": "2023-06-01T12:00:00Z",
+    "last_loaded_at": "2023-06-01T12:00:00Z"
+  },
+  {
+    "book_id": "monster-manual",
     "display_name": "Monster Manual",
-    "chunk_count": 4,
-    "extracted_count": 4,
-    "entity_count": 2,
-    "latest_chunk_at": "2024-01-15T12:00:00Z"
+    "book_kind": "bestiary",
+    "chunk_count": 1200,
+    "image_count": 380,
+    "extracted_count": 1200,
+    "entity_count": 2412,
+    "latest_chunk_at": "2023-06-01T12:00:00Z",
+    "last_loaded_at": "2023-06-01T12:00:00Z"
+  },
+  {
+    "book_id": "players-handbook-2024",
+    "display_name": "Player's Handbook",
+    "book_kind": "rulebook",
+    "chunk_count": 1440,
+    "image_count": 210,
+    "extracted_count": 1440,
+    "entity_count": 1806,
+    "latest_chunk_at": "2023-06-01T12:00:00Z",
+    "last_loaded_at": "2023-06-01T12:00:00Z"
   }
 ]

--- a/projects/monolith/frontend/visual/fixtures/api/grimoire_entities.json
+++ b/projects/monolith/frontend/visual/fixtures/api/grimoire_entities.json
@@ -1,0 +1,42 @@
+{
+  "items": [
+    {
+      "id": "e1",
+      "name": "Aboleth",
+      "entity_type": "creature",
+      "size": "Large",
+      "cr": "10"
+    },
+    {
+      "id": "e2",
+      "name": "Fireball",
+      "entity_type": "spell",
+      "level": 3,
+      "school": "Evocation"
+    },
+    { "id": "e3", "name": "Strahd von Zarovich", "entity_type": "npc" },
+    { "id": "e4", "name": "Castle Ravenloft", "entity_type": "location" },
+    { "id": "e5", "name": "Cragmaw Tribe", "entity_type": "faction" },
+    { "id": "e6", "name": "The Raven Queen", "entity_type": "deity" },
+    { "id": "e7", "name": "Sun Blade", "entity_type": "item" },
+    { "id": "e8", "name": "Wizard", "entity_type": "class" },
+    {
+      "id": "e9",
+      "name": "Counterspell",
+      "entity_type": "spell",
+      "level": 3,
+      "school": "Abjuration"
+    },
+    {
+      "id": "e10",
+      "name": "Goblin",
+      "entity_type": "creature",
+      "size": "Small",
+      "cr": "1/4"
+    },
+    { "id": "e11", "name": "Frightened", "entity_type": "condition" },
+    { "id": "e12", "name": "Grappling", "entity_type": "action" }
+  ],
+  "total": 24879,
+  "next_cursor": null
+}

--- a/projects/monolith/frontend/visual/mock-server.mjs
+++ b/projects/monolith/frontend/visual/mock-server.mjs
@@ -18,6 +18,7 @@ const ROUTES = [
   ["/api/grimoire/books", "fixtures/api/grimoire_books.json"],
   ["/api/grimoire/books/mm/read", "fixtures/api/grimoire_read.json"],
   ["/api/grimoire/books/mm/sections", "fixtures/api/grimoire_sections.json"],
+  ["/api/grimoire/entities", "fixtures/api/grimoire_entities.json"],
 ];
 const PREFIX = [["/api/trips/trip/", "fixtures/api/trips_trip.json"]];
 

--- a/projects/monolith/frontend/visual/targets.json
+++ b/projects/monolith/frontend/visual/targets.json
@@ -25,6 +25,16 @@
       "path": "/app/grimoire/book/mm",
       "static_initial": true
     },
+    {
+      "id": "grimoire-library",
+      "path": "/app/grimoire",
+      "static_initial": true
+    },
+    {
+      "id": "grimoire-entities",
+      "path": "/app/grimoire/entities",
+      "static_initial": true
+    },
     { "id": "docs", "path": "/docs" },
     { "id": "docs-slug", "path": "/docs/agents" },
     { "id": "cv", "path": "/cv" },

--- a/projects/monolith/grimoire/library.py
+++ b/projects/monolith/grimoire/library.py
@@ -28,7 +28,7 @@ from typing import Any
 from sqlalchemy import and_, func, or_
 from sqlmodel import Session, select
 
-from grimoire.extract import current_extraction_key
+from grimoire.extract import book_kind, current_extraction_key
 from grimoire.models import (
     Adventure,
     Book,
@@ -139,6 +139,7 @@ def list_books(session: Session) -> list[dict[str, Any]]:
             {
                 "book_id": book_id,
                 "display_name": book.display_name if book else book_id,
+                "book_kind": book_kind(book_id),
                 "chunk_count": chunks.chunk_count if chunks else 0,
                 "image_count": chunks.image_count if chunks else 0,
                 "extracted_count": extracted_by_book.get(book_id, 0),

--- a/projects/monolith/grimoire/library_test.py
+++ b/projects/monolith/grimoire/library_test.py
@@ -165,6 +165,8 @@ class TestListBooks:
         book = body[0]
         assert book["book_id"] == "mm"
         assert book["display_name"] == "Monster Manual"
+        # book_kind is derived from the slug; the "mm" test slug is unmapped.
+        assert book["book_kind"] is None
         assert book["chunk_count"] == 4
         assert book["image_count"] == 1
         # c0 (ok) + c1 (empty) under the live key; the stale-key c3 excluded.


### PR DESCRIPTION
Reskins the Grimoire app to a clean, readable light/dark theme (cool paper + indigo), scoped to grimoire only. The site-wide brutalist design system (`design-system.css`) and the other public apps are untouched.

## What changed
- **Migration:** the public grimoire now renders on the `.grimoire`/`theme.css` token system. Dark mode is scoped to `.grimoire` (no leak to other apps) with a user light/dark toggle.
- **Library:** grouped by book type (Adventures, Anthologies, Setting Guides, Bestiaries, Spellbooks, Magic Items, Rulebooks) as dense hairline rows. The backend now derives `book_kind` from the slug (`extract.book_kind`) and returns it on `GET /books`.
- **Entities:** scannable, color-coded rows with type-filter chips.
- **Reader:** left section-hierarchy sidebar + clean reading palette; fixed images upscaling to full column width (natural size, no enlarge, max-height cap).
- **Private DM Reader** brought to parity; removed the dead `--grimb-*` brutalist tokens.

## Review notes
- Visual-regression before/after is posted for grimoire Library, Entities, and Reader.
- Frontend-only plus a derived `book_kind` field: no schema change, no new GRANTs.
- Charts: `monolith` 0.285.38, `monolith-public` 0.89.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
