### PR TITLE
feat(grimoire): add public homepage with pitch, pipeline diagram, and roadmap

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.8
+version: 0.89.9
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.8
+      targetRevision: 0.89.9
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.39
+version: 0.285.40
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.39
+      targetRevision: 0.285.40
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/grimoire/api.js
+++ b/projects/monolith/frontend/src/lib/public/grimoire/api.js
@@ -37,7 +37,8 @@ export async function apiFetch(path, options = {}) {
 
 // ── Route builders (public URL structure: no [campaign], no ?as=) ──
 
-export const libraryHref = () => "/app/grimoire";
+export const homeHref = () => "/app/grimoire";
+export const libraryHref = () => "/app/grimoire/library";
 export const entitiesHref = () => "/app/grimoire/entities";
 export const exploreHref = () => "/app/grimoire/explore";
 export const entityHref = (id) =>

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
@@ -3,15 +3,18 @@
   // Entities nav) and a Turnstile gate around the app content. The gate is a
   // real admission boundary, not decoration: children (and therefore every
   // /api/grimoire fetch) only mount after onAdmitted fires, so the WotC-
-  // copyrighted corpus never reaches an unsolved visitor or a crawler. No
-  // site Nav/Footer: this is a standalone shareable app, not a page of the
-  // portfolio site. noindex keeps it out of search entirely (copyright
-  // mitigation) regardless of admission state.
+  // copyrighted corpus never reaches an unsolved visitor or a crawler. The
+  // one exception is the static homepage at the app root (see isHome below),
+  // which carries no corpus content and no fetches. No site Nav/Footer: this
+  // is a standalone shareable app, not a page of the portfolio site. noindex
+  // keeps it out of search entirely (copyright mitigation) regardless of
+  // admission state.
   import { page } from "$app/stores";
   import TurnstileGate from "$lib/public/components/TurnstileGate.svelte";
   import ThemeToggle from "$lib/grimoire/ThemeToggle.svelte";
   import "$lib/grimoire/theme.css";
   import {
+    homeHref,
     libraryHref,
     entitiesHref,
     exploreHref,
@@ -21,13 +24,21 @@
 
   let admitted = $state(false);
 
+  // The homepage at the app root is a static pitch page: no corpus content,
+  // no /api/grimoire fetches, so it renders OUTSIDE the Turnstile gate. The
+  // gate exists to keep the copyrighted corpus from bots, not the product
+  // description; every other route (library, reader, entities) stays gated.
+  const isHome = $derived(($page.route.id ?? "") === "/public/app/grimoire");
+
   // Highlight the active topbar link: the entities index and entity detail
   // pages both count as "entities"; the EXPLORE canvas is its own section;
-  // everything else is the library flow.
+  // the homepage highlights nothing; every other page (library, book reader,
+  // adventures) is the library flow.
   const section = $derived.by(() => {
     const id = $page.route.id ?? "";
     if (id.includes("/entities") || id.includes("/entity/")) return "entities";
     if (id.includes("/explore")) return "explore";
+    if (isHome) return "home";
     return "library";
   });
 </script>
@@ -46,7 +57,7 @@
 
 <div class="grimoire-app grimoire">
   <header class="topbar">
-    <a class="wordmark" href={libraryHref()}>Grimoire</a>
+    <a class="wordmark" href={homeHref()}>Grimoire</a>
     <nav class="topbar-nav" aria-label="Grimoire sections">
       <a
         class="topbar-link"
@@ -69,7 +80,9 @@
   </header>
 
   <main class="grimoire-shell">
-  {#if !admitted}
+  {#if isHome || admitted}
+    {@render children()}
+  {:else}
     <div class="wrap-narrow gate">
       <p class="gate-eyebrow">Grimoire Access</p>
       <h1 class="grim-title gate-title">
@@ -84,8 +97,6 @@
         onAdmitted={() => (admitted = true)}
       />
     </div>
-  {:else}
-    {@render children()}
   {/if}
   </main>
 </div>

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
@@ -1,188 +1,225 @@
 <script>
-  // Public Grimoire Library: every loaded book, plus a quiet one-line stats
-  // summary at the top. Fetches AFTER the layout's TurnstileGate admits
-  // (this component only mounts once `admitted` is true), so there is no
-  // corpus fetch before the challenge is solved.
-  //
-  // Rows are grouped by book_kind (Adventures / Anthologies / Setting Guides /
-  // Bestiaries / Spellbooks / Magic Items / Rulebooks). book_kind is derived
-  // server-side from the slug (grimoire.extract.book_kind) and returned by GET
-  // /books; unmapped slugs fall into an "Other" bucket.
-  import { onMount } from "svelte";
-  import { apiFetch, bookHref } from "$lib/public/grimoire/api.js";
+  // Public Grimoire homepage: the pitch, how the pipeline works, what exists
+  // today, a small invented demo of the grant system, and the roadmap. This
+  // page is deliberately STATIC: it makes zero /api/grimoire fetches and
+  // contains no corpus content, which is what lets the layout render it
+  // outside the Turnstile gate (the gate protects the copyrighted corpus,
+  // not the product description). Keep it that way: any corpus read added
+  // here must move behind the gate instead.
+  import { libraryHref, entitiesHref } from "$lib/public/grimoire/api.js";
 
-  let books = $state([]);
-  let loading = $state(true);
-  let error = $state("");
-
-  onMount(load);
-
-  async function load() {
-    loading = true;
-    error = "";
-    try {
-      books = await apiFetch("/books");
-    } catch (e) {
-      error = e.message;
-    } finally {
-      loading = false;
-    }
-  }
-
-  function timeAgo(iso) {
-    if (!iso) return "never";
-    const then = new Date(iso).getTime();
-    if (Number.isNaN(then)) return "";
-    const secs = Math.max(0, (Date.now() - then) / 1000);
-    const units = [
-      ["y", 31536000],
-      ["mo", 2592000],
-      ["d", 86400],
-      ["h", 3600],
-      ["m", 60],
-    ];
-    for (const [label, size] of units) {
-      if (secs >= size) return `${Math.floor(secs / size)}${label} ago`;
-    }
-    return "just now";
-  }
-
-  // NEW pill: a book with a chunk loaded in the last 7 days. Public visitors
-  // are anonymous, so there is no per-device "last seen" bookkeeping (that was
-  // a private-app-only localStorage convenience); a fixed recency window keeps
-  // this simple and stateless.
-  const NEW_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
-  function isNew(book) {
-    if (!book.latest_chunk_at) return false;
-    const then = new Date(book.latest_chunk_at).getTime();
-    if (Number.isNaN(then)) return false;
-    return Date.now() - then < NEW_WINDOW_MS;
-  }
-
-  // Corpus totals for the one-line summary: aggregate across every loaded
-  // book, with the most recent sync time.
-  const totals = $derived.by(() => {
-    const sum = (key) => books.reduce((acc, b) => acc + (b[key] ?? 0), 0);
-    const latest = books
-      .map((b) => b.latest_chunk_at)
-      .filter(Boolean)
-      .sort()
-      .at(-1);
-    return {
-      books: books.length,
-      chunks: sum("chunk_count"),
-      images: sum("image_count"),
-      entities: sum("entity_count"),
-      synced: timeAgo(latest),
-    };
-  });
-
-  // Book-type grouping (book_kind comes from GET /books, derived from the slug).
-  const KIND_LABEL = {
-    adventure: "Adventures",
-    "adventure-anthology": "Anthologies",
-    "setting-guide": "Setting Guides",
-    bestiary: "Bestiaries",
-    spellbook: "Spellbooks",
-    "magic-items": "Magic Items",
-    rulebook: "Rulebooks",
-    other: "Other",
-  };
-  const KIND_ORDER = [
-    "adventure",
-    "adventure-anthology",
-    "setting-guide",
-    "bestiary",
-    "spellbook",
-    "magic-items",
-    "rulebook",
-    "other",
+  const pipeline = [
+    {
+      title: "Sourcebook PDF",
+      body: "Marker extraction plus structural chunking: a monster's lore, stat block, and actions land in one chunk, in reading order.",
+    },
+    {
+      title: "Postgres + embeddings",
+      body: "Chunks land in Postgres keyed by book and section, and every chunk is embedded (pgvector) for semantic lookup.",
+    },
+    {
+      title: "LLM entity extraction",
+      body: "A frontier model reads each chunk and extracts typed entities, the chunks that mention them, and how they relate.",
+    },
+    {
+      title: "Reader + entity browser",
+      body: "Read a book chunk by chunk, or start from a creature or spell and jump straight to the passages it came from.",
+    },
   ];
-  const grouped = $derived.by(() => {
-    const by = {};
-    for (const b of books) {
-      const k = KIND_LABEL[b.book_kind] ? b.book_kind : "other";
-      (by[k] ??= []).push(b);
-    }
-    return KIND_ORDER.filter((k) => by[k]?.length).map((k) => ({
-      kind: k,
-      label: KIND_LABEL[k],
-      rows: by[k],
-    }));
-  });
+
+  const features = [
+    {
+      title: "The Library",
+      body: "Every loaded book, grouped by kind (adventures, bestiaries, spellbooks, and more) with per-book chunk, image, and entity counts.",
+    },
+    {
+      title: "Structural reader",
+      body: "Continuous reading in source order with the section hierarchy and art preserved, not a wall of OCR text.",
+    },
+    {
+      title: "Adventures",
+      body: "Anthologies are split into their individual adventures, each with its own roster of the entities that appear in it.",
+    },
+    {
+      title: "Entity browser",
+      body: "Creatures, spells, NPCs, locations, items, and more as typed detail cards: stat blocks, spell levels, filter by type, search by name.",
+    },
+    {
+      title: "EXPLORE canvas",
+      body: "An interactive relationship graph: pick a scope (the whole corpus, one book, one adventure) and a lens (world, story, quests, rules), then wander from entity to entity.",
+    },
+    {
+      title: "Provenance",
+      body: "Every entity links back to the exact chunks it was extracted from, so a claim is always one click from its source text.",
+    },
+    {
+      title: "Campaign grants",
+      body: "In the private tier a DM controls what each player character knows about an entity, from full detail down to name-only recognition.",
+    },
+  ];
+
+  const roadmap = [
+    {
+      status: "Planned",
+      title: "Evidence-grounded verification",
+      body: "A trailing job re-checks every extracted stat against the source passages, correcting what it can ground and nulling what it cannot.",
+    },
+    {
+      status: "Planned",
+      title: "Alias merge",
+      body: 'Split-name twins ("Gundren" and "Gundren Rockseeker") get merged into one entity, report-first with a human approving every pair.',
+    },
+    {
+      status: "Designed",
+      title: "One search everywhere",
+      body: "A single omnibox blending instant name matches with semantic hits over lore chunks and related entities.",
+    },
+    {
+      status: "Designed",
+      title: "Live-play tools",
+      body: "DM advice capture and a live session view, so the grimoire is useful mid-encounter and not just between sessions.",
+    },
+    {
+      status: "Long term",
+      title: "Loom migration",
+      body: "The schema is deliberately kept compatible with a governed lakehouse system of record, with per-session hot-tier checkouts when it lands.",
+    },
+  ];
 </script>
 
-<div class="library-page">
-  <p class="eyebrow">The Grimoire</p>
-  <h1 class="grim-title lib-title">Library</h1>
-
-  {#if !loading && !error && books.length > 0}
-    <p class="summary">
-      <b>{totals.books.toLocaleString()}</b>
-      {totals.books === 1 ? "book" : "books"}
-      <span class="dot">/</span>
-      <b>{totals.chunks.toLocaleString()}</b> chunks
-      <span class="dot">/</span>
-      <b>{totals.images.toLocaleString()}</b> images
-      <span class="dot">/</span>
-      <b>{totals.entities.toLocaleString()}</b> entities
-      <span class="dot">/</span>
-      synced {totals.synced}
+<div class="home">
+  <section class="hero">
+    <p class="eyebrow">The Grimoire</p>
+    <h1 class="grim-title hero-title">
+      Your sourcebooks, <span class="accent">read and understood.</span>
+    </h1>
+    <p class="lede">
+      Grimoire ingests D&amp;D sourcebook PDFs, chunks them along their real
+      section structure, and has an LLM extract a typed knowledge graph of
+      creatures, spells, NPCs, locations, and items. The result is a library
+      you can read cover to cover and a corpus you can query entity by
+      entity, with every fact traceable back to the page it came from.
     </p>
-  {/if}
+    <div class="cta-row">
+      <a class="cta cta-primary" href={libraryHref()}>Browse the library</a>
+      <a class="cta cta-ghost" href={entitiesHref()}>Explore entities</a>
+    </div>
+  </section>
 
-  {#if loading}
-    <div class="skeletons" aria-hidden="true">
-      {#each [1, 2, 3, 4, 5] as n (n)}
-        <div class="skeleton-row"></div>
+  <section class="block">
+    <div class="gh"><span class="kind">How it works</span></div>
+    <ol class="pipeline">
+      {#each pipeline as step, i (step.title)}
+        <li class="step">
+          <span class="step-n">{i + 1}</span>
+          <h3 class="step-title">{step.title}</h3>
+          <p class="step-body">{step.body}</p>
+        </li>
       {/each}
+    </ol>
+    <p class="block-note">
+      Ingest runs as idempotent batch jobs: re-loading an unchanged book is a
+      no-op, and extraction prompts are versioned so the corpus can be
+      re-extracted deliberately, never accidentally.
+    </p>
+  </section>
+
+  <section class="block">
+    <div class="gh"><span class="kind">What's here today</span></div>
+    <ul class="feature-grid">
+      {#each features as f (f.title)}
+        <li class="feature">
+          <h3 class="feature-title">{f.title}</h3>
+          <p class="feature-body">{f.body}</p>
+        </li>
+      {/each}
+    </ul>
+  </section>
+
+  <section class="block">
+    <div class="gh">
+      <span class="kind">At the table</span>
+      <span class="kn">demo</span>
     </div>
-  {:else if error}
-    <p class="status-error">{error}</p>
-  {:else if books.length === 0}
-    <div class="empty">
-      <p class="grim-title empty-lead">Nothing loaded yet.</p>
-      <p class="empty-help">Check back once a sourcebook has been uploaded.</p>
+    <p class="block-lede">
+      Knowledge is granted, not global. The same entity renders differently
+      for each player character depending on the scope their DM has granted.
+      The creature below is invented for this demo; the real corpus works the
+      same way.
+    </p>
+    <div class="grant-row">
+      <article class="grant-card">
+        <p class="scope scope-full">full</p>
+        <h3 class="grim-title card-name">Vellum Lurker</h3>
+        <p class="card-type">Medium aberration</p>
+        <p class="card-stats">AC 15 <span class="dot">/</span> HP 66 <span class="dot">/</span> CR 4</p>
+        <p class="card-body">
+          A predator that folds itself flat between the pages of unattended
+          books. Vulnerable to fire; regenerates in libraries.
+        </p>
+      </article>
+      <article class="grant-card">
+        <p class="scope scope-partial">partial</p>
+        <h3 class="grim-title card-name">Vellum Lurker</h3>
+        <p class="card-type">Medium aberration</p>
+        <p class="card-stats redacted" aria-label="hidden stats">
+          AC &#9612;&#9612; <span class="dot">/</span> HP &#9612;&#9612;
+          <span class="dot">/</span> CR &#9612;&#9612;
+        </p>
+        <p class="card-body">
+          A predator that folds itself flat between the pages of unattended
+          books. <span class="redacted-run" aria-label="hidden text"
+            >&#9612;&#9612;&#9612;&#9612;&#9612;&#9612;&#9612;&#9612;&#9612;&#9612;&#9612;&#9612;&#9612;&#9612;</span
+          >
+        </p>
+      </article>
+      <article class="grant-card">
+        <p class="scope scope-name">name only</p>
+        <h3 class="grim-title card-name">Vellum Lurker</h3>
+        <p class="card-body card-body-faint">
+          You recognise the name. Nothing more.
+        </p>
+      </article>
     </div>
-  {:else}
-    {#each grouped as group (group.kind)}
-      <section class="lib-group">
-        <div class="gh">
-          <span class="kind">{group.label}</span>
-          <span class="kn">{group.rows.length}</span>
-        </div>
-        <ul class="book-list">
-          {#each group.rows as book (book.book_id)}
-            <li>
-              <a class="brow" href={bookHref(book.book_id)}>
-                <span class="brow-main">
-                  <span class="title">
-                    {book.display_name}
-                    {#if isNew(book)}<span class="pill">New</span>{/if}
-                  </span>
-                  <span class="meta">
-                    {book.chunk_count.toLocaleString()} chunks
-                    <span class="dot">/</span>
-                    {book.image_count.toLocaleString()} images
-                    <span class="dot">/</span>
-                    {book.entity_count.toLocaleString()} entities
-                  </span>
-                </span>
-                <span class="read">Read &rarr;</span>
-              </a>
-            </li>
-          {/each}
-        </ul>
-      </section>
-    {/each}
-  {/if}
+    <p class="block-note">
+      One visibility predicate implements this everywhere: entity lookups,
+      search results, and the reader's "entities on this page" chips all
+      project through the same grant check.
+    </p>
+  </section>
+
+  <section class="block">
+    <div class="gh"><span class="kind">Roadmap</span></div>
+    <ul class="roadmap">
+      {#each roadmap as item (item.title)}
+        <li class="roadmap-row">
+          <span
+            class="status"
+            class:status-planned={item.status === "Planned"}
+            class:status-designed={item.status === "Designed"}
+            class:status-long={item.status === "Long term"}>{item.status}</span
+          >
+          <span class="roadmap-text">
+            <span class="roadmap-title">{item.title}</span>
+            <span class="roadmap-body">{item.body}</span>
+          </span>
+        </li>
+      {/each}
+    </ul>
+  </section>
+
+  <p class="foot-note">
+    The library itself sits behind a quick human check: the corpus is
+    copyrighted source material, so the reader is link-shareable but kept out
+    of search engines and away from bots.
+  </p>
 </div>
 
 <style>
-  .library-page {
+  .home {
     max-width: 1180px;
     margin: 0 auto;
-    padding: 40px 28px 80px;
+    padding: 56px 28px 80px;
   }
 
   .eyebrow {
@@ -194,30 +231,64 @@
     margin: 0;
   }
 
-  .lib-title {
-    font-size: clamp(36px, 6vw, 46px);
-    margin: 6px 0 0;
+  .hero-title {
+    font-size: clamp(34px, 6vw, 54px);
+    margin: 10px 0 0;
+    max-width: 22ch;
   }
 
-  .summary {
-    margin-top: 14px;
+  .accent {
+    color: var(--grim-accent);
+  }
+
+  .lede {
+    margin-top: 18px;
+    max-width: 68ch;
     color: var(--grim-text-dim);
-    font-size: 13.5px;
-    font-variant-numeric: tabular-nums;
+    font-size: 15.5px;
+    line-height: 1.65;
   }
 
-  .summary b {
-    color: var(--grim-ink);
-    font-weight: 600;
+  .cta-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 26px;
   }
 
-  .dot {
-    color: var(--grim-text-faint);
-    margin: 0 8px;
+  .cta {
+    display: inline-flex;
+    align-items: center;
+    min-height: 42px;
+    padding: 8px 18px;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    text-decoration: none;
+    border-radius: 7px;
   }
 
-  .lib-group {
-    margin-top: 32px;
+  .cta-primary {
+    background: var(--grim-accent);
+    color: var(--grim-on-accent);
+  }
+
+  .cta-primary:hover {
+    background: var(--grim-accent-strong);
+  }
+
+  .cta-ghost {
+    color: var(--grim-accent);
+    border: 1px solid var(--grim-line);
+  }
+
+  .cta-ghost:hover {
+    background: var(--grim-surface-2);
+  }
+
+  .block {
+    margin-top: 56px;
   }
 
   .gh {
@@ -238,144 +309,309 @@
 
   .gh .kn {
     font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
     color: var(--grim-text-faint);
+  }
+
+  .block-lede {
+    margin: 18px 8px 0;
+    max-width: 68ch;
+    color: var(--grim-text-dim);
+    font-size: 14px;
+    line-height: 1.6;
+  }
+
+  .block-note {
+    margin: 20px 8px 0;
+    max-width: 68ch;
+    color: var(--grim-text-faint);
+    font-size: 12.5px;
+    line-height: 1.6;
+  }
+
+  /* ── Pipeline diagram: numbered step cards joined by arrows ── */
+
+  .pipeline {
+    list-style: none;
+    margin: 22px 0 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 26px;
+  }
+
+  .step {
+    position: relative;
+    background: var(--grim-surface);
+    border: 1px solid var(--grim-line);
+    border-radius: 9px;
+    padding: 16px 16px 18px;
+  }
+
+  .step:not(:last-child)::after {
+    content: "\2192";
+    position: absolute;
+    top: 50%;
+    right: -21px;
+    transform: translateY(-50%);
+    color: var(--grim-text-faint);
+    font-size: 15px;
+  }
+
+  .step-n {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: var(--grim-accent-soft);
+    color: var(--grim-accent);
+    font-size: 11px;
+    font-weight: 700;
     font-variant-numeric: tabular-nums;
   }
 
-  .book-list {
-    list-style: none;
-    margin: 2px 0 0;
-    padding: 0;
-  }
-
-  .brow {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    align-items: center;
-    gap: 15px;
-    padding: 13px 8px;
-    text-decoration: none;
-    color: inherit;
-    border-bottom: 1px solid var(--grim-line-soft);
-    border-radius: 7px;
-  }
-
-  .book-list li:last-child .brow {
-    border-bottom: 0;
-  }
-
-  .brow:hover {
-    background: var(--grim-surface-2);
-  }
-
-  .brow .title {
+  .step-title {
+    margin: 10px 0 0;
     font-family: var(--grim-serif);
-    font-size: 18px;
+    font-size: 16px;
     font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 9px;
     color: var(--grim-ink);
   }
 
-  .brow .meta {
-    display: block;
-    margin-top: 3px;
+  .step-body {
+    margin: 7px 0 0;
     color: var(--grim-text-dim);
-    font-size: 12px;
+    font-size: 12.5px;
+    line-height: 1.55;
+  }
+
+  /* ── Feature grid ── */
+
+  .feature-grid {
+    list-style: none;
+    margin: 22px 0 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 14px;
+  }
+
+  .feature {
+    background: var(--grim-surface);
+    border: 1px solid var(--grim-line-soft);
+    border-radius: 9px;
+    padding: 16px;
+  }
+
+  .feature-title {
+    margin: 0;
+    font-family: var(--grim-serif);
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--grim-ink);
+  }
+
+  .feature-body {
+    margin: 7px 0 0;
+    color: var(--grim-text-dim);
+    font-size: 12.5px;
+    line-height: 1.55;
+  }
+
+  /* ── Grant demo cards ── */
+
+  .grant-row {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 14px;
+    margin-top: 20px;
+  }
+
+  .grant-card {
+    background: var(--grim-surface);
+    border: 1px solid var(--grim-line);
+    border-radius: 9px;
+    padding: 16px;
+  }
+
+  .scope {
+    display: inline-block;
+    margin: 0 0 10px;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    border-radius: 4px;
+    padding: 3px 7px;
+  }
+
+  .scope-full {
+    color: var(--grim-type-location);
+    background: color-mix(in srgb, var(--grim-type-location) 12%, transparent);
+  }
+
+  .scope-partial {
+    color: var(--grim-type-npc);
+    background: color-mix(in srgb, var(--grim-type-npc) 12%, transparent);
+  }
+
+  .scope-name {
+    color: var(--grim-text-faint);
+    background: var(--grim-surface-2);
+  }
+
+  .card-name {
+    margin: 0;
+    font-size: 19px;
+  }
+
+  .card-type {
+    margin: 3px 0 0;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--grim-type-creature);
+    font-weight: 600;
+  }
+
+  .card-stats {
+    margin: 10px 0 0;
+    font-size: 12.5px;
+    color: var(--grim-ink);
     font-variant-numeric: tabular-nums;
   }
 
-  .brow .meta .dot {
+  .card-stats .dot,
+  .card-body .dot {
+    color: var(--grim-text-faint);
     margin: 0 6px;
   }
 
-  .pill {
+  .redacted,
+  .redacted-run {
+    color: var(--grim-text-faint);
+    opacity: 0.55;
+    letter-spacing: 0.05em;
+  }
+
+  .card-body {
+    margin: 10px 0 0;
+    color: var(--grim-text-dim);
+    font-size: 12.5px;
+    line-height: 1.55;
+  }
+
+  .card-body-faint {
+    color: var(--grim-text-faint);
+    font-style: italic;
+  }
+
+  /* ── Roadmap ── */
+
+  .roadmap {
+    list-style: none;
+    margin: 8px 0 0;
+    padding: 0;
+  }
+
+  .roadmap-row {
+    display: grid;
+    grid-template-columns: 92px 1fr;
+    gap: 16px;
+    align-items: start;
+    padding: 15px 8px;
+    border-bottom: 1px solid var(--grim-line-soft);
+  }
+
+  .roadmap-row:last-child {
+    border-bottom: 0;
+  }
+
+  .status {
+    justify-self: start;
     font-size: 9px;
     font-weight: 700;
     letter-spacing: 0.12em;
     text-transform: uppercase;
+    border-radius: 4px;
+    padding: 3px 7px;
+    margin-top: 2px;
+    white-space: nowrap;
+  }
+
+  .status-planned {
     color: var(--grim-accent);
     background: var(--grim-accent-soft);
-    border-radius: 4px;
-    padding: 2px 6px;
   }
 
-  .read {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    white-space: nowrap;
-    font-size: 11px;
+  .status-designed {
+    color: var(--grim-type-spell);
+    background: color-mix(in srgb, var(--grim-type-spell) 12%, transparent);
+  }
+
+  .status-long {
+    color: var(--grim-text-faint);
+    background: var(--grim-surface-2);
+  }
+
+  .roadmap-title {
+    display: block;
+    font-family: var(--grim-serif);
+    font-size: 16px;
     font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--grim-accent);
-    opacity: 0;
-    transition: opacity 0.15s;
+    color: var(--grim-ink);
   }
 
-  .brow:hover .read {
-    opacity: 1;
-  }
-
-  .empty {
-    padding: 64px 0;
-  }
-
-  .empty-lead {
-    font-size: 28px;
-    margin-bottom: 10px;
-  }
-
-  .empty-help {
+  .roadmap-body {
+    display: block;
+    margin-top: 4px;
     color: var(--grim-text-dim);
-    font-size: 13px;
+    font-size: 12.5px;
+    line-height: 1.55;
   }
 
-  .status-error {
-    color: var(--grim-type-creature);
-    padding: 24px 0;
+  .foot-note {
+    margin: 48px 8px 0;
+    max-width: 68ch;
+    color: var(--grim-text-faint);
+    font-size: 12px;
+    line-height: 1.6;
   }
 
-  .skeletons {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    margin-top: 24px;
-  }
+  /* ── Responsive ── */
 
-  .skeleton-row {
-    height: 62px;
-    border-radius: 7px;
-    background: linear-gradient(
-      90deg,
-      var(--grim-surface-2) 25%,
-      transparent 37%,
-      var(--grim-surface-2) 63%
-    );
-    background-size: 400% 100%;
-    animation: shimmer 1.4s ease infinite;
-  }
-
-  @keyframes shimmer {
-    0% {
-      background-position: 100% 0;
+  @media (max-width: 960px) {
+    .pipeline {
+      grid-template-columns: 1fr 1fr;
     }
-    100% {
-      background-position: 0 0;
+
+    .step:not(:last-child)::after {
+      content: none;
+    }
+
+    .feature-grid,
+    .grant-row {
+      grid-template-columns: 1fr 1fr;
     }
   }
 
   @media (max-width: 640px) {
-    .library-page {
-      padding: 28px 20px 60px;
+    .home {
+      padding: 36px 20px 60px;
     }
-  }
 
-  @media (prefers-reduced-motion: reduce) {
-    .skeleton-row {
-      animation: none;
+    .pipeline,
+    .feature-grid,
+    .grant-row {
+      grid-template-columns: 1fr;
+    }
+
+    .roadmap-row {
+      grid-template-columns: 1fr;
+      gap: 6px;
     }
   }
 </style>

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/library/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/library/+page.svelte
@@ -1,0 +1,381 @@
+<script>
+  // Public Grimoire Library: every loaded book, plus a quiet one-line stats
+  // summary at the top. Fetches AFTER the layout's TurnstileGate admits
+  // (this component only mounts once `admitted` is true), so there is no
+  // corpus fetch before the challenge is solved.
+  //
+  // Rows are grouped by book_kind (Adventures / Anthologies / Setting Guides /
+  // Bestiaries / Spellbooks / Magic Items / Rulebooks). book_kind is derived
+  // server-side from the slug (grimoire.extract.book_kind) and returned by GET
+  // /books; unmapped slugs fall into an "Other" bucket.
+  import { onMount } from "svelte";
+  import { apiFetch, bookHref } from "$lib/public/grimoire/api.js";
+
+  let books = $state([]);
+  let loading = $state(true);
+  let error = $state("");
+
+  onMount(load);
+
+  async function load() {
+    loading = true;
+    error = "";
+    try {
+      books = await apiFetch("/books");
+    } catch (e) {
+      error = e.message;
+    } finally {
+      loading = false;
+    }
+  }
+
+  function timeAgo(iso) {
+    if (!iso) return "never";
+    const then = new Date(iso).getTime();
+    if (Number.isNaN(then)) return "";
+    const secs = Math.max(0, (Date.now() - then) / 1000);
+    const units = [
+      ["y", 31536000],
+      ["mo", 2592000],
+      ["d", 86400],
+      ["h", 3600],
+      ["m", 60],
+    ];
+    for (const [label, size] of units) {
+      if (secs >= size) return `${Math.floor(secs / size)}${label} ago`;
+    }
+    return "just now";
+  }
+
+  // NEW pill: a book with a chunk loaded in the last 7 days. Public visitors
+  // are anonymous, so there is no per-device "last seen" bookkeeping (that was
+  // a private-app-only localStorage convenience); a fixed recency window keeps
+  // this simple and stateless.
+  const NEW_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+  function isNew(book) {
+    if (!book.latest_chunk_at) return false;
+    const then = new Date(book.latest_chunk_at).getTime();
+    if (Number.isNaN(then)) return false;
+    return Date.now() - then < NEW_WINDOW_MS;
+  }
+
+  // Corpus totals for the one-line summary: aggregate across every loaded
+  // book, with the most recent sync time.
+  const totals = $derived.by(() => {
+    const sum = (key) => books.reduce((acc, b) => acc + (b[key] ?? 0), 0);
+    const latest = books
+      .map((b) => b.latest_chunk_at)
+      .filter(Boolean)
+      .sort()
+      .at(-1);
+    return {
+      books: books.length,
+      chunks: sum("chunk_count"),
+      images: sum("image_count"),
+      entities: sum("entity_count"),
+      synced: timeAgo(latest),
+    };
+  });
+
+  // Book-type grouping (book_kind comes from GET /books, derived from the slug).
+  const KIND_LABEL = {
+    adventure: "Adventures",
+    "adventure-anthology": "Anthologies",
+    "setting-guide": "Setting Guides",
+    bestiary: "Bestiaries",
+    spellbook: "Spellbooks",
+    "magic-items": "Magic Items",
+    rulebook: "Rulebooks",
+    other: "Other",
+  };
+  const KIND_ORDER = [
+    "adventure",
+    "adventure-anthology",
+    "setting-guide",
+    "bestiary",
+    "spellbook",
+    "magic-items",
+    "rulebook",
+    "other",
+  ];
+  const grouped = $derived.by(() => {
+    const by = {};
+    for (const b of books) {
+      const k = KIND_LABEL[b.book_kind] ? b.book_kind : "other";
+      (by[k] ??= []).push(b);
+    }
+    return KIND_ORDER.filter((k) => by[k]?.length).map((k) => ({
+      kind: k,
+      label: KIND_LABEL[k],
+      rows: by[k],
+    }));
+  });
+</script>
+
+<div class="library-page">
+  <p class="eyebrow">The Grimoire</p>
+  <h1 class="grim-title lib-title">Library</h1>
+
+  {#if !loading && !error && books.length > 0}
+    <p class="summary">
+      <b>{totals.books.toLocaleString()}</b>
+      {totals.books === 1 ? "book" : "books"}
+      <span class="dot">/</span>
+      <b>{totals.chunks.toLocaleString()}</b> chunks
+      <span class="dot">/</span>
+      <b>{totals.images.toLocaleString()}</b> images
+      <span class="dot">/</span>
+      <b>{totals.entities.toLocaleString()}</b> entities
+      <span class="dot">/</span>
+      synced {totals.synced}
+    </p>
+  {/if}
+
+  {#if loading}
+    <div class="skeletons" aria-hidden="true">
+      {#each [1, 2, 3, 4, 5] as n (n)}
+        <div class="skeleton-row"></div>
+      {/each}
+    </div>
+  {:else if error}
+    <p class="status-error">{error}</p>
+  {:else if books.length === 0}
+    <div class="empty">
+      <p class="grim-title empty-lead">Nothing loaded yet.</p>
+      <p class="empty-help">Check back once a sourcebook has been uploaded.</p>
+    </div>
+  {:else}
+    {#each grouped as group (group.kind)}
+      <section class="lib-group">
+        <div class="gh">
+          <span class="kind">{group.label}</span>
+          <span class="kn">{group.rows.length}</span>
+        </div>
+        <ul class="book-list">
+          {#each group.rows as book (book.book_id)}
+            <li>
+              <a class="brow" href={bookHref(book.book_id)}>
+                <span class="brow-main">
+                  <span class="title">
+                    {book.display_name}
+                    {#if isNew(book)}<span class="pill">New</span>{/if}
+                  </span>
+                  <span class="meta">
+                    {book.chunk_count.toLocaleString()} chunks
+                    <span class="dot">/</span>
+                    {book.image_count.toLocaleString()} images
+                    <span class="dot">/</span>
+                    {book.entity_count.toLocaleString()} entities
+                  </span>
+                </span>
+                <span class="read">Read &rarr;</span>
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .library-page {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 40px 28px 80px;
+  }
+
+  .eyebrow {
+    font-size: 11px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--grim-text-faint);
+    font-weight: 600;
+    margin: 0;
+  }
+
+  .lib-title {
+    font-size: clamp(36px, 6vw, 46px);
+    margin: 6px 0 0;
+  }
+
+  .summary {
+    margin-top: 14px;
+    color: var(--grim-text-dim);
+    font-size: 13.5px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .summary b {
+    color: var(--grim-ink);
+    font-weight: 600;
+  }
+
+  .dot {
+    color: var(--grim-text-faint);
+    margin: 0 8px;
+  }
+
+  .lib-group {
+    margin-top: 32px;
+  }
+
+  .gh {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 0 8px 8px;
+    border-bottom: 1px solid var(--grim-line);
+  }
+
+  .gh .kind {
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--grim-accent);
+    font-weight: 700;
+  }
+
+  .gh .kn {
+    font-size: 11px;
+    color: var(--grim-text-faint);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .book-list {
+    list-style: none;
+    margin: 2px 0 0;
+    padding: 0;
+  }
+
+  .brow {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 15px;
+    padding: 13px 8px;
+    text-decoration: none;
+    color: inherit;
+    border-bottom: 1px solid var(--grim-line-soft);
+    border-radius: 7px;
+  }
+
+  .book-list li:last-child .brow {
+    border-bottom: 0;
+  }
+
+  .brow:hover {
+    background: var(--grim-surface-2);
+  }
+
+  .brow .title {
+    font-family: var(--grim-serif);
+    font-size: 18px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    color: var(--grim-ink);
+  }
+
+  .brow .meta {
+    display: block;
+    margin-top: 3px;
+    color: var(--grim-text-dim);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .brow .meta .dot {
+    margin: 0 6px;
+  }
+
+  .pill {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--grim-accent);
+    background: var(--grim-accent-soft);
+    border-radius: 4px;
+    padding: 2px 6px;
+  }
+
+  .read {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    white-space: nowrap;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--grim-accent);
+    opacity: 0;
+    transition: opacity 0.15s;
+  }
+
+  .brow:hover .read {
+    opacity: 1;
+  }
+
+  .empty {
+    padding: 64px 0;
+  }
+
+  .empty-lead {
+    font-size: 28px;
+    margin-bottom: 10px;
+  }
+
+  .empty-help {
+    color: var(--grim-text-dim);
+    font-size: 13px;
+  }
+
+  .status-error {
+    color: var(--grim-type-creature);
+    padding: 24px 0;
+  }
+
+  .skeletons {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 24px;
+  }
+
+  .skeleton-row {
+    height: 62px;
+    border-radius: 7px;
+    background: linear-gradient(
+      90deg,
+      var(--grim-surface-2) 25%,
+      transparent 37%,
+      var(--grim-surface-2) 63%
+    );
+    background-size: 400% 100%;
+    animation: shimmer 1.4s ease infinite;
+  }
+
+  @keyframes shimmer {
+    0% {
+      background-position: 100% 0;
+    }
+    100% {
+      background-position: 0 0;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .library-page {
+      padding: 28px 20px 60px;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton-row {
+      animation: none;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/visual/targets.json
+++ b/projects/monolith/frontend/visual/targets.json
@@ -25,9 +25,10 @@
       "path": "/app/grimoire/book/mm",
       "static_initial": true
     },
+    { "id": "grimoire-home", "path": "/app/grimoire" },
     {
       "id": "grimoire-library",
-      "path": "/app/grimoire",
+      "path": "/app/grimoire/library",
       "static_initial": true
     },
     {


### PR DESCRIPTION
## What

The public Grimoire app (`jomcgi.dev/app/grimoire`) gets a proper homepage at the app root:

- **Hero pitch**: what Grimoire is in two sentences, with CTAs into the Library and Entities.
- **How it works**: a four-step pipeline diagram (PDF -> structural chunking -> Postgres + embeddings -> LLM extraction -> reader + browser), plus a note on idempotent, versioned ingest.
- **What's here today**: feature grid covering the library, structural reader, adventures, entity browser, the EXPLORE canvas, provenance, and campaign grants.
- **At the table (demo)**: the same invented creature ("Vellum Lurker", original content, no WotC text) rendered at `full` / `partial` / `name_only` grant scopes, explaining the visibility model.
- **Roadmap**: evidence-grounded verification and alias merge (ADR 014), omnibox search, live-play tools, and the long-term Loom migration (ADR 012), each with a status pill.

## Routing and nav

- The library moves from `/app/grimoire` to `/app/grimoire/library` (route builders in `lib/public/grimoire/api.js` are the single source, so book/entity backlinks follow automatically).
- The topbar nav is unchanged (Library / Entities / Explore); the **Grimoire wordmark now links to the homepage**.

## Turnstile gate

The homepage is deliberately static: zero corpus content, zero `/api/grimoire` fetches. It therefore renders **outside** the Turnstile gate, so a shared link shows the pitch immediately; the library, reader, adventure, entity, and explore pages all stay behind the gate exactly as before (the gate protects the copyrighted corpus, not the product description). A comment on the page pins this invariant: any corpus read added to the homepage must move behind the gate.

## Public-tier checklist

- No new tables or reads: static page, no `public_reader` grant changes needed.
- No `/api` calls from the new page at all.
- Visual regression: new `grimoire-home` target at `/app/grimoire`; `grimoire-library` target follows the moved route.
- Chart bumps included for **both** `monolith` (0.285.40) and `monolith-public` (0.89.9), re-numbered after rebasing over main's EXPLORE merge which took the originally allocated versions.

Post-merge verification: `curl -sS -o /dev/null -w '%{http_code}\n' https://jomcgi.dev/app/grimoire` and a click-through of wordmark -> homepage -> Library (gate) -> reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qkp8KfzaRmtM7EvDVTqdXe