### PR TITLE
fix(grimoire): polish pass (dark mode, degree sort, full-bleed Explore, linkable headings)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.9
+version: 0.89.10
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.9
+      targetRevision: 0.89.10
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.40
+version: 0.285.41
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.40
+      targetRevision: 0.285.41
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/grimoire/Reader.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/Reader.svelte
@@ -35,6 +35,7 @@
   let loadingMore = $state(false);
   let loadError = $state("");
   let scrolledToAnchor = $state(false);
+  let scrolledToSectionAnchor = $state(false);
 
   let bookMeta = $state({ displayName: bookId, chunkCount: null });
   let activeSeq = $state(initialItems[0]?.seq ?? null);
@@ -76,6 +77,17 @@
       .map((p) => p.trim())
       .filter(Boolean);
     return parts.length >= 2 ? parts[parts.length - 2] : null;
+  }
+
+  // Deep-link slug for a section heading, e.g. "Chapter 1 / Into the Mists"
+  // -> "chapter-1-into-the-mists". Callers prefix with "s-" (see the
+  // `.pub-heading` id and anchor below) so section ids can never collide
+  // with a chunk's "c-{id}" id in the same DOM.
+  function sectionSlug(sectionPath) {
+    return (sectionPath ?? "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
   }
 
   const rows = $derived(
@@ -178,6 +190,33 @@
     ).matches;
     el.scrollIntoView({ behavior: reduceMotion ? "auto" : "smooth", block: "start" });
   });
+
+  // Section-heading deep links. The host route (+page.svelte) only parses
+  // "#c-" hashes into the anchorChunkId prop above (the chunk case), so a
+  // "#s-" section link is left to the browser's own hash scroll -- which
+  // only fires on the initial hard navigation. A same-document hash change
+  // (or a hash present before this component's headings exist, e.g. while
+  // an earlier page of items is still loading) needs the same manual
+  // scrollIntoView the chunk case gets, so read the hash directly here
+  // rather than threading a second prop through the route.
+  $effect(() => {
+    void items.length;
+    if (scrolledToSectionAnchor || !containerEl) return;
+    const hash = typeof window !== "undefined" ? window.location.hash : "";
+    if (!hash.startsWith("#s-")) return;
+    let el;
+    try {
+      el = containerEl.querySelector(`#${CSS.escape(hash.slice(1))}`);
+    } catch {
+      el = null;
+    }
+    if (!el) return;
+    scrolledToSectionAnchor = true;
+    const reduceMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    el.scrollIntoView({ behavior: reduceMotion ? "auto" : "smooth", block: "start" });
+  });
 </script>
 
 <div class="pub-reader">
@@ -216,10 +255,18 @@
           {/if}
           <div
             class="pub-heading"
+            id={"s-" + sectionSlug(row.item.section_path)}
             data-heading
             data-seq={row.item.seq}
             data-section={row.item.section_path ?? ""}
           >
+            <a
+              class="pub-anchor"
+              href={"#s-" + sectionSlug(row.item.section_path)}
+              aria-label="Link to this section"
+            >
+              #
+            </a>
             {#if sectionParent(row.item.section_path)}
               <p class="pub-section-label grim-smallcaps">
                 {sectionParent(row.item.section_path)}
@@ -378,8 +425,13 @@
   }
 
   .pub-heading {
+    position: relative;
     max-width: 68ch;
     margin: 0 0 18px;
+  }
+
+  .pub-heading:hover .pub-anchor {
+    opacity: 1;
   }
 
   .pub-section-label {

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
@@ -111,6 +111,10 @@
     min-height: 100vh;
     display: flex;
     flex-direction: column;
+    /* Own the page background so every grimoire page is on the clean --grim
+       paper (not the site-wide design-system cream body) AND flips to dark
+       under .grimoire.dark, instead of a cream page showing behind dark cards. */
+    background: var(--grim-paper);
   }
 
   .topbar {

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/+page.svelte
@@ -134,12 +134,15 @@
 
   .adventure-name {
     font-size: 20px;
+    /* Explicit color: the row is color:inherit, so without this the title
+       renders dark-on-dark in dark mode. */
+    color: var(--grim-ink);
   }
 
   .adventure-level {
     font-family: var(--font-mono);
     font-size: 12px;
-    color: var(--grim-text-faint);
+    color: var(--grim-text-dim);
   }
 
   .adventure-summary {
@@ -149,7 +152,7 @@
 
   .adventure-count {
     font-family: var(--font-mono);
-    color: var(--grim-text-faint);
+    color: var(--grim-text-dim);
     font-size: 11px;
   }
 </style>

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/explore/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/explore/+page.svelte
@@ -46,6 +46,12 @@
   let graphLoading = $state(true);
   let graphError = $state("");
 
+  // Per-lens entity counts for the current scope, from the graph response's
+  // `lens_counts`. Defaults to "everything present" (all 1s, not 0) so the
+  // lens buttons aren't disabled before the first response lands -- greying
+  // out only happens once we actually know a lens is empty.
+  let lensCounts = $state({ world: 1, story: 1, quests: 1, rules: 1 });
+
   // Nodes/edges pulled in by following a relationship to a peer outside the
   // current scope/lens ("guest" nodes, dashed ring on the canvas). Cleared on
   // every scope/lens change -- switching the slice is a fresh view, not a
@@ -160,7 +166,16 @@
     guestNodesById = {};
     guestEdgeMap = {};
     try {
-      baseGraph = (await exploreGraph(scope, lens)) ?? { nodes: [], edges: [] };
+      const result = (await exploreGraph(scope, lens)) ?? { nodes: [], edges: [] };
+      baseGraph = result;
+      // Missing lens_counts (older cached response shape) falls back to
+      // "everything present" rather than disabling every lens button.
+      lensCounts = result.lens_counts ?? {
+        world: 1,
+        story: 1,
+        quests: 1,
+        rules: 1,
+      };
     } catch (e) {
       graphError = e.message;
       baseGraph = { nodes: [], edges: [] };
@@ -184,7 +199,7 @@
   }
 
   function onLensChange(nextLens) {
-    if (nextLens === lens) return;
+    if (nextLens === lens || lensCounts[nextLens] === 0) return;
     lens = nextLens;
     loadGraph();
   }
@@ -294,6 +309,7 @@
             type="button"
             class:on={lens === l.value}
             aria-pressed={lens === l.value}
+            disabled={lensCounts[l.value] === 0}
             onclick={() => onLensChange(l.value)}
           >
             {l.label}
@@ -456,6 +472,16 @@
     background: var(--grim-surface);
     color: var(--grim-accent);
     box-shadow: 0 1px 2px rgba(20, 30, 50, 0.1);
+  }
+
+  .lens-switch button:disabled {
+    color: var(--grim-text-faint);
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .lens-switch button:not(:disabled):hover {
+    color: var(--grim-ink);
   }
 
   .ex-stage {

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/explore/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/explore/+page.svelte
@@ -460,12 +460,17 @@
 
   .ex-stage {
     position: relative;
-    height: calc(100vh - 300px);
-    min-height: 440px;
-    border: 1px solid var(--grim-line);
-    border-radius: 12px;
+    /* Full-bleed: break out of the centered .explore-page column to the full
+       viewport width and drop the boxed border/radius, so the graph uses the
+       page instead of sitting in a bordered card surrounded by whitespace. */
+    margin-left: calc(-50vw + 50%);
+    margin-right: calc(-50vw + 50%);
+    height: calc(100vh - 210px);
+    min-height: 480px;
     overflow: hidden;
     background: var(--grim-surface);
+    border-top: 1px solid var(--grim-line);
+    border-bottom: 1px solid var(--grim-line);
   }
 
   :global(.grimoire.dark) .ex-stage {

--- a/projects/monolith/grimoire/explore.py
+++ b/projects/monolith/grimoire/explore.py
@@ -108,16 +108,39 @@ def scope_entity_ids(session: Session, scope: str, lens: str) -> set[str]:
     return set(session.exec(query).all())
 
 
+_LENS_NAMES = ("world", "story", "quests", "rules")
+
+
+def _lens_counts(
+    session: Session, scope: str, current_lens: str, current_ids: set[str]
+) -> dict[str, int]:
+    """Entity count per lens for ``scope``, via ``scope_entity_ids`` per lens
+    (id-set sized queries, never a full graph fetch) so the frontend can grey
+    out lens buttons with no entities in the current scope. Reuses the
+    caller's already-computed ``current_ids`` for ``current_lens`` instead of
+    re-querying it, so this is 3 extra queries, not 4."""
+    return {
+        name: len(current_ids)
+        if name == current_lens
+        else len(scope_entity_ids(session, scope, name))
+        for name in _LENS_NAMES
+    }
+
+
 def scope_subgraph(session: Session, scope: str, lens: str) -> dict[str, Any]:
-    """Induced subgraph ``{nodes, edges}`` for a scope + lens: the core
-    bulk-load endpoint for the EXPLORE canvas (see plan design decision 4,
-    "bulk over N+1" - the client fetches one payload per scope/lens change
-    instead of one relationship call per node).
+    """Induced subgraph ``{nodes, edges, lens_counts}`` for a scope + lens:
+    the core bulk-load endpoint for the EXPLORE canvas (see plan design
+    decision 4, "bulk over N+1" - the client fetches one payload per
+    scope/lens change instead of one relationship call per node).
 
     Nodes are every entity in ``scope_entity_ids(session, scope, lens)``,
     projected via ``public.entity_cards`` (spine + secondary detail, batched).
     Edges are every relationship whose BOTH endpoints are in that node set
     (a true induced subgraph, not "every edge touching any node").
+
+    ``lens_counts`` is ``{world, story, quests, rules}`` -> entity count in
+    this scope, so the frontend can grey out lens buttons with zero entities
+    without a separate round trip.
 
     A whole-corpus ``scope="everything"`` can return a large payload; no
     truncation happens here (nodes are never silently dropped), so the
@@ -125,8 +148,9 @@ def scope_subgraph(session: Session, scope: str, lens: str) -> dict[str, Any]:
     "everything" as an explicit, occasionally-large view.
     """
     ids = scope_entity_ids(session, scope, lens)
+    lens_counts = _lens_counts(session, scope, lens, ids)
     if not ids:
-        return {"nodes": [], "edges": []}
+        return {"nodes": [], "edges": [], "lens_counts": lens_counts}
     entities = session.exec(select(Entity).where(Entity.id.in_(ids))).all()
     nodes = public.entity_cards(session, entities)
     edges = [
@@ -138,7 +162,7 @@ def scope_subgraph(session: Session, scope: str, lens: str) -> dict[str, Any]:
             )
         ).all()
     ]
-    return {"nodes": nodes, "edges": edges}
+    return {"nodes": nodes, "edges": edges, "lens_counts": lens_counts}
 
 
 def ego_subgraph(session: Session, entity_id: str) -> dict[str, Any]:

--- a/projects/monolith/grimoire/public.py
+++ b/projects/monolith/grimoire/public.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import and_, func, or_
+from sqlalchemy import and_, func, or_, union_all
 from sqlmodel import Session, select
 
 from grimoire.library import _iso, _PREVIEW_LEN
@@ -209,39 +209,84 @@ def list_entities_public(
     limit: int = DEFAULT_ENTITY_PAGE,
     cursor: str | None = None,
 ) -> dict[str, Any]:
-    """All entities, name-ordered, paginated, no grants.
+    """All entities, paginated, no grants.
 
-    Keyset-paginated on name (unlike the private list's in-Python
-    offset slice over the grant-projected set): there is no grant
-    projection to materialise first here, so a straightforward
-    ``ORDER BY (name, id) LIMIT`` keyset page is both simpler and cheaper
-    at corpus scale. ``cursor`` packs the (name, id) of the last row on the
-    previous page. Left-joins the typed detail table per entity_type (creature,
-    spell) to add the secondary line the private list omits (it stays
-    spine-only); location/npc have no secondary fields to add.
+    Default load (no ``q``, no ``entity_type``) orders by relationship DEGREE
+    descending so the most-connected entities surface first, since that is the
+    most useful entry point into the corpus. Degree is the number of edges
+    touching an entity as either endpoint, computed by UNION ALL-ing the
+    relationship table's from/to columns and grouping. This mode paginates by
+    OFFSET (``cursor`` is a stringified integer offset), because a degree tie
+    makes a keyset cursor on (degree, name, id) more trouble than it's worth at
+    corpus scale.
+
+    When a search (``q``) or type (``entity_type``) filter is active the order
+    reverts to name, keyset-paginated on (name, id) (``cursor`` packs the
+    (name, id) of the last row on the previous page): the filtered set is small
+    and name order is what a searching user expects.
+
+    Left-joins the typed detail table per entity_type (creature, spell) to add
+    the secondary line the private list omits (it stays spine-only);
+    location/npc have no secondary fields to add.
     """
     limit = max(1, min(limit, MAX_ENTITY_PAGE))
     # is_global: only the shared corpus is public; campaign-private entities
     # (is_global false) are never listed.
-    query = select(Entity).where(Entity.is_global).order_by(Entity.name, Entity.id)
-    if entity_type is not None:
-        query = query.where(Entity.entity_type == entity_type)
-    if q:
-        query = query.where(func.lower(Entity.name).contains(q.lower()))
-    if cursor is not None:
-        cur_name, cur_id = _decode_cursor(cursor)
-        query = query.where(
-            or_(
-                Entity.name > cur_name,
-                and_(Entity.name == cur_name, Entity.id > cur_id),
-            )
-        )
-    # limit + 1 to detect whether another page follows without a second query.
-    query = query.limit(limit + 1)
-    rows = session.exec(query).all()
+    degree_mode = q is None and entity_type is None
 
-    has_more = len(rows) > limit
-    rows = rows[:limit]
+    if degree_mode:
+        # An entity's degree = count of relationship rows where it is the
+        # from- OR the to-endpoint. UNION ALL (not UNION) so both endpoints of
+        # the same edge each count; a self-loop counts twice, matching "number
+        # of edge endpoints touching this entity".
+        endpoints = union_all(
+            select(Relationship.from_entity_id.label("entity_id")),
+            select(Relationship.to_entity_id.label("entity_id")),
+        ).subquery()
+        degrees = (
+            select(
+                endpoints.c.entity_id.label("entity_id"),
+                func.count().label("degree"),
+            )
+            .group_by(endpoints.c.entity_id)
+            .subquery()
+        )
+        # LEFT JOIN + coalesce so an entity with no edges sorts as degree 0
+        # rather than dropping out of the list.
+        degree_col = func.coalesce(degrees.c.degree, 0)
+        offset = int(cursor) if cursor else 0
+        query = (
+            select(Entity)
+            .outerjoin(degrees, degrees.c.entity_id == Entity.id)
+            .where(Entity.is_global)
+            .order_by(degree_col.desc(), Entity.name, Entity.id)
+            .offset(offset)
+            .limit(limit + 1)  # +1 to detect a following page without a 2nd query.
+        )
+        rows = session.exec(query).all()
+        has_more = len(rows) > limit
+        rows = rows[:limit]
+        next_cursor = str(offset + limit) if has_more else None
+    else:
+        query = select(Entity).where(Entity.is_global).order_by(Entity.name, Entity.id)
+        if entity_type is not None:
+            query = query.where(Entity.entity_type == entity_type)
+        if q:
+            query = query.where(func.lower(Entity.name).contains(q.lower()))
+        if cursor is not None:
+            cur_name, cur_id = _decode_cursor(cursor)
+            query = query.where(
+                or_(
+                    Entity.name > cur_name,
+                    and_(Entity.name == cur_name, Entity.id > cur_id),
+                )
+            )
+        # limit + 1 to detect whether another page follows without a second query.
+        query = query.limit(limit + 1)
+        rows = session.exec(query).all()
+        has_more = len(rows) > limit
+        rows = rows[:limit]
+        next_cursor = _encode_cursor(rows[-1]) if has_more and rows else None
 
     creature_ids = [e.id for e in rows if e.entity_type == "creature"]
     spell_ids = [e.id for e in rows if e.entity_type == "spell"]
@@ -285,7 +330,6 @@ def list_entities_public(
         count_query = count_query.where(func.lower(Entity.name).contains(q.lower()))
     total = session.exec(count_query).one()
 
-    next_cursor = _encode_cursor(rows[-1]) if has_more and rows else None
     return {"items": items, "total": total, "next_cursor": next_cursor}
 
 

--- a/projects/monolith/grimoire/public_test.py
+++ b/projects/monolith/grimoire/public_test.py
@@ -151,6 +151,38 @@ def seed_corpus(session):
     )
 
 
+def seed_degree_corpus(session):
+    """Three global npcs with distinct relationship degrees (Zeta=3, Mu=1,
+    Alpha=0). Names are chosen so degree order (Zeta, Mu, Alpha) is the REVERSE
+    of alphabetical order (Alpha, Mu, Zeta), so a degree-ordered list is
+    distinguishable from a name-ordered one. Zeta's degree is padded with edges
+    to two non-global neighbours, which never appear in the (is_global) list."""
+    session.add_all(
+        [
+            Entity(id="e-zeta", entity_type="npc", name="Zeta"),
+            Entity(id="e-mu", entity_type="npc", name="Mu"),
+            Entity(id="e-alpha", entity_type="npc", name="Alpha"),
+            Entity(id="e-nx", entity_type="npc", name="Nx", is_global=False),
+            Entity(id="e-ny", entity_type="npc", name="Ny", is_global=False),
+        ]
+    )
+    session.commit()
+    session.add_all(
+        [
+            Relationship(
+                from_entity_id="e-zeta", to_entity_id="e-mu", rel_type="knows"
+            ),
+            Relationship(
+                from_entity_id="e-zeta", to_entity_id="e-nx", rel_type="knows"
+            ),
+            Relationship(
+                from_entity_id="e-zeta", to_entity_id="e-ny", rel_type="knows"
+            ),
+        ]
+    )
+    session.commit()
+
+
 class TestGetChunkPublic:
     def test_full_shape_no_grants(self, session):
         seed = seed_corpus(session)
@@ -227,6 +259,41 @@ class TestListEntitiesPublic:
         body = public.list_entities_public(session, q="strahd")
         assert body["total"] == 0
         assert body["items"] == []
+
+    def test_default_orders_by_degree_desc(self, session):
+        """No q, no type filter -> most-connected first. Zeta (degree 3) leads,
+        then Mu (1), then Alpha (0), the reverse of alphabetical order."""
+        seed_degree_corpus(session)
+        body = public.list_entities_public(session)
+        assert body["total"] == 3
+        assert [item["name"] for item in body["items"]] == ["Zeta", "Mu", "Alpha"]
+        assert body["next_cursor"] is None
+
+    def test_type_filter_reverts_to_name_order(self, session):
+        """A type filter switches ordering back to alphabetical by name."""
+        seed_degree_corpus(session)
+        body = public.list_entities_public(session, entity_type="npc")
+        assert [item["name"] for item in body["items"]] == ["Alpha", "Mu", "Zeta"]
+
+    def test_search_reverts_to_name_order(self, session):
+        """A search filter switches ordering back to alphabetical by name.
+        'a' matches Alpha and Zeta (not Mu); degree order would be [Zeta, Alpha]
+        but name order is [Alpha, Zeta]."""
+        seed_degree_corpus(session)
+        body = public.list_entities_public(session, q="a")
+        assert [item["name"] for item in body["items"]] == ["Alpha", "Zeta"]
+
+    def test_degree_mode_offset_pagination(self, session):
+        """Degree mode paginates by a stringified integer offset cursor."""
+        seed_degree_corpus(session)
+        first = public.list_entities_public(session, limit=2)
+        assert [item["name"] for item in first["items"]] == ["Zeta", "Mu"]
+        assert first["next_cursor"] == "2"
+        second = public.list_entities_public(
+            session, limit=2, cursor=first["next_cursor"]
+        )
+        assert [item["name"] for item in second["items"]] == ["Alpha"]
+        assert second["next_cursor"] is None
 
     def test_pagination(self, session):
         seed_corpus(session)

--- a/projects/monolith/grimoire/router_public_test.py
+++ b/projects/monolith/grimoire/router_public_test.py
@@ -492,6 +492,16 @@ class TestExploreGraph:
         assert barovia_node["entity_type"] == "location"
         assert barovia_node["category"] == "lore"
         assert barovia_node["region"] == "Barovia Valley"
+        # this adventure roster has lore (Strahd, Barovia) and mechanics
+        # (Wizard) entities but no events/quests, so world/rules are
+        # non-empty while story/quests are empty: the lens buttons that
+        # should grey out on the public Explore page.
+        assert body["lens_counts"] == {
+            "world": 2,
+            "story": 0,
+            "quests": 0,
+            "rules": 1,
+        }
 
     def test_everything_scope_has_no_roster_restriction_but_still_applies_lens(
         self, session, client
@@ -510,7 +520,11 @@ class TestExploreGraph:
     def test_unknown_adventure_scope_returns_empty_graph(self, session, client):
         r = client.get("/api/grimoire/explore/graph?scope=adventure:nope&lens=world")
         assert r.status_code == 200
-        assert r.json() == {"nodes": [], "edges": []}
+        assert r.json() == {
+            "nodes": [],
+            "edges": [],
+            "lens_counts": {"world": 0, "story": 0, "quests": 0, "rules": 0},
+        }
 
 
 class TestExploreEgo:


### PR DESCRIPTION
Live-feedback polish pass on the grimoire reskin + Explore.

- **Clean app background:** `.grimoire-app` owns `var(--grim-paper)`, so pages are clean in light and flip to dark, instead of showing the site-wide design-system cream body (dull, and outside `.grimoire` scope so it never flipped, dark cards on a cream page).
- **Dark-mode contrast:** the book-page adventure card title was `color: inherit` (dark-on-dark in dark mode), now explicit `--grim-ink`; level/count bumped to `--grim-text-dim`.
- **Reader section headings** are now deep-linkable (stable `s-<slug>` ids + hover `#` anchor + on-load hash scroll), matching chunk paragraphs.
- **Entities default to most-connected** (relationship degree) instead of alphabetical; reverts to name order when a search or type filter is active (backend-only).
- **Explore full-bleed:** the graph uses the viewport width, no bordered box.
- **Explore empty-lens greying:** World/Story/Quests/Rules grey out when the current scope has no entities in that lens (`lens_counts` in the graph response).

Charts: `monolith` 0.285.41, `monolith-public` 0.89.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
