### PR TITLE
fix(grimoire): paint overscroll/viewport background to match the theme

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.10
+version: 0.89.11
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.10
+      targetRevision: 0.89.11
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.41
+version: 0.285.42
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.41
+      targetRevision: 0.285.42
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/grimoire/theme.css
+++ b/projects/monolith/frontend/src/lib/grimoire/theme.css
@@ -215,3 +215,19 @@
     transform: none;
   }
 }
+
+/* ── Overscroll / viewport canvas ─────────────────────────────
+ * design-system.css sets `body { background: var(--bg) }` (cream) with no
+ * html background, so the body background propagates to the viewport canvas
+ * and shows in the rubber-band / overscroll area beyond the app content, even
+ * though .grimoire-app itself is on --grim-paper. Override the body background
+ * while a grimoire page is mounted (scoped via :has so the rest of the public
+ * site keeps its own background), and flip it with the toggle. Hardcoded
+ * because body is outside .grimoire and can't read --grim-paper; values mirror
+ * --grim-paper light/dark. */
+body:has(.grimoire) {
+  background: #f3f5f7;
+}
+body:has(.grimoire.dark) {
+  background: #0d1017;
+}


### PR DESCRIPTION
The rubber-band/overscroll area beyond a grimoire page still showed the design-system cream because `body { background: var(--bg) }` propagates to the viewport canvas (html has no background). Override the body background while a grimoire page is mounted (`:has(.grimoire)`-scoped so other public apps are untouched), flipping with the toggle via `:has(.grimoire.dark)`. Frontend-only. Charts: monolith 0.285.42, monolith-public 0.89.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)