### PR TITLE
fix(chat): let ambient engagement cascade into threads

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.42
+version: 0.285.43
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -831,9 +831,19 @@ class ChatBot(discord.Client):
         # run to be safe to extend.
         guild_id = message.guild.id if message.guild else None
         try:
-            is_ambient = channel_id in await asyncio.to_thread(
-                acl.ambient_channels, guild_id
-            )
+            ambient = await asyncio.to_thread(acl.ambient_channels, guild_id)
+            # A Discord thread is its own channel with its own id, distinct from
+            # its parent. Ambient grants are scoped to the parent channel, so a
+            # thread inherits ambient from its parent: check the parent id too
+            # when this is a thread. Agent/artifact threads never reach here
+            # (they return above), so this only opens ordinary user threads
+            # under a granted channel. channel_id stays the thread id, so the
+            # directive lookup, recent-tag check, and decision log all key off
+            # the thread's own history.
+            is_ambient = channel_id in ambient
+            if not is_ambient and isinstance(message.channel, discord.Thread):
+                parent_id = message.channel.parent_id
+                is_ambient = parent_id is not None and str(parent_id) in ambient
         except Exception:
             # Best-effort: if the grants read fails (DB blip), treat the channel
             # as non-ambient and fall through to normal handling rather than

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.42
+      targetRevision: 0.285.43
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

Ambient (Bosun auto-engagement) was enabled per channel, but never fired inside Discord **threads** even when the parent channel was granted.

## Root cause

A Discord thread is its own channel with its own id, distinct from its parent. Ambient grants (`chat.discord_feature_grant`, `feature="ambient"`, `scope=<channel id>`) are scoped to the parent channel. The attention gate keyed only on `str(message.channel.id)` (`bot.py:807`) and tested it against `acl.ambient_channels` (`bot.py:834`). A message inside a thread resolves to the **thread's** id, which isn't in the ambient set, so `is_ambient=False` and the message fell through to the ordinary mention/reply path. Net effect: explicit @mentions still got answered in threads, but **unprompted ambient engagement never fired**.

## Fix

When the message is in a `discord.Thread`, also test `message.channel.parent_id` against the ambient set, so a thread inherits its parent channel's ambient grant. `channel_id` stays the thread id, so the directive lookup, recent-tag check, and decision log all key off the thread's own history (a *channel* directive on the parent does not carry into the thread; acceptable for v1).

Agent/artifact (goosecracker) threads return earlier (`bot.py:821-823`) and never reach this gate, so this only opens ordinary user threads under a granted channel.

Chart bumped 0.285.41 -> 0.285.43 so the change deploys.