### PR TITLE
feat(chat): give Bosun accurate self-knowledge and stop meta-leaks

### DIFF
--- a/.claude/skills/improve-ambient/scripts/improve_ambient_tool.py
+++ b/.claude/skills/improve-ambient/scripts/improve_ambient_tool.py
@@ -267,15 +267,19 @@ ORDER BY created_at, id
 """
 
 # EXACT match on the reply id when known, else the channel + window fallback.
-# The nullable :reply_message_id bind needs ::text casts so psycopg can type the
-# NULL in the IS NULL / IS NOT NULL branches (repo gotcha).
+# The nullable :reply_message_id bind is cast to text so psycopg can type the
+# NULL in the IS NULL / IS NOT NULL branches (repo gotcha). Use CAST(... AS text)
+# rather than the `::text` spelling: SQLAlchemy's text() lexer refuses to bind a
+# param immediately followed by `::`, leaving `:reply_message_id::text` literal
+# and tripping a Postgres "syntax error at or near :".
 _FETCH_REACTIONS_SQL = """
 SELECT message_id, emoji, reactor_id, action, created_at
 FROM chat.reaction_event
 WHERE channel_id = :channel_id
   AND (
-      (:reply_message_id::text IS NOT NULL AND message_id = :reply_message_id::text)
-   OR (:reply_message_id::text IS NULL
+      (CAST(:reply_message_id AS text) IS NOT NULL
+           AND message_id = CAST(:reply_message_id AS text))
+   OR (CAST(:reply_message_id AS text) IS NULL
            AND created_at >= :engage_at
            AND created_at <= :engage_at + make_interval(mins => :window))
   )

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.46
+version: 0.285.47
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -239,6 +239,25 @@ def build_system_prompt() -> str:
         "live web artifact (a visualization, page, or interactive tool). When "
         "someone wants any of that, start the thread rather than trying to do "
         "it yourself inline.\n\n"
+        "HOW YOU ACTUALLY WORK (so you can answer questions about yourself "
+        "accurately instead of guessing):\n"
+        "- You are a Qwen language model running locally via llama.cpp on "
+        "community hardware, not a hosted API.\n"
+        "- Each time you reply you are given: the last ~20 messages of THIS "
+        "channel, a short rolling summary of the channel and of the regulars "
+        "in it (refreshed periodically from activity, not live), and whatever "
+        "you pull in yourself with history search. You do NOT hold the whole "
+        "channel in memory, and you have no 'RAM', 'token buffer', or 'scrape "
+        "queue' that stores messages: it's a recent window plus summaries plus "
+        "on-demand search.\n"
+        "- For anything older than that recent window, use history search "
+        "rather than claiming to remember it.\n"
+        "- If someone asks how far back you remember, how your memory is "
+        "stored, what your exact limits are, or how you're wired, and you are "
+        "not sure, SAY you're not sure. Never invent a plausible-sounding "
+        "internal mechanism (buffers, RAM, message caps, framework internals) "
+        "and state it as fact: making up your own internals is the same sin as "
+        "making up a statistic.\n\n"
         "FORMATTING FOR DISCORD:\n"
         "- Discord does NOT render markdown tables: a | col | col | table shows "
         "up as raw pipes and dashes. To present tabular data, render it as an "
@@ -294,9 +313,19 @@ def build_system_prompt() -> str:
         '"great point", or "you\'re in good shape" reassurance.\n'
         "- Announce that you're using a tool. Just use it and share "
         "what you found.\n"
+        "- Narrate your own participation decision. Never post a message "
+        'saying you\'re "skipping this one", "passing to keep the volume '
+        'down", or that a request "isn\'t something I\'m executing here". If a '
+        "message doesn't need a reply, either say something brief and in "
+        "character or stay silent, but never post meta-commentary about "
+        "whether or why you're choosing to engage.\n"
         '- Apologize for being an AI or say "as an AI".\n'
         "- Pretend you looked something up when you didn't. If you haven't "
-        "used web_search, don't claim to have checked."
+        "used web_search, don't claim to have checked. In particular, never "
+        "present figures, headcounts, or statistics as sourced ('based on the "
+        "latest report', 'according to the workforce data') unless you "
+        "actually retrieved them this turn: give a rough number and flag it as "
+        "an estimate, or search, but don't dress a guess up as a citation."
     )
 
 

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.46
+      targetRevision: 0.285.47
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
improve-ambient loop, window since `c9ffac64a` (last lever commit). 15 ambient episodes (45-59); 3 deep-read and classified (evals in `s3://artifacts/ambient-evals/{51,53,59}.json`, taxonomy v1). Reaction data was nearly empty this window, so classification leans on follow-up content, as the skill's fidelity rule requires.

## 1. Before/after aggregates

Previous generation was a ~10-minute gap between two lever commits with no episodes, so there is no meaningful prior baseline; this is the first real generation. This window:

- Episodes: 15
- Negative-reaction rate: 0/15 (no 👎; only 1 👍, ep 47) — reactions are not yet a reliable signal
- Failure signal came from follow-up content: fact-checks, re-asks, and explicit complaints ("our dude seems fixated on message counts")

## 2. Per-edit evidence

**HOW YOU WORK block + don't-invent-internals guard** (`agent.py`)
- Live banter transcript: Bosun invented its own architecture: "a couple thousand messages depending on its token limit and RAM ... queueing up whatever the bot framework pulls before it flushes the buffer." False. Real mechanism: last ~20 channel messages (`bot.py:1821`) + a periodic rolling channel/user summary (`bot.py:1836-1845`) + on-demand `search_history`. The block states this and forbids inventing internals.

**Meta-leak DON'T line** (`agent.py`)
- Episode 53: Bosun posted its attention reasoning to the channel: "I'm skipping this one. There's no @mention or technical question attached ... so I'll pass to keep the volume down." Same transcript: hedgy "isn't something I'm executing here today" meta-commentary after escalating a casual suggestion into an agent thread.

**Sharpen anti-fabrication for sourced stats** (`agent.py`)
- Episode 51: "Make a chart about anaesthetists in Scotland" → confident "~870 total" with no search; user fact-checked ("that's not correct for Glasgow"); Bosun then produced NEW figures "based on the latest NHS Scotland workforce statistics" with no evidence of retrieval. The existing "don't pretend you looked something up" rule didn't cover dressing a guess as a citation; this sharpens it.

**Fix `fetch-episode` tool** (`.claude/skills/improve-ambient/scripts/improve_ambient_tool.py`)
- The reaction query mixed placeholder styles: `:reply_message_id::text` defeated SQLAlchemy's `text()` bind (its lexer won't bind a param flush against `::`), so Postgres received a literal `:` and threw "syntax error at or near :". `fetch-episode` was completely broken. Fixed with `CAST(:reply_message_id AS text)`.

## 3. Out of scope, observed

- **Message-count fixation, banter channel `1375032589093703680`** (ep 53, 59): joke metrics ("mogging", "thiccest gooner", tierlist) get literal message-count leaderboards, self-reinforced because Bosun's own prior counts replies re-enter via the 20-message context window. This is concentrated in one channel → a **channel directive**, staged separately (propose-then-👍), not a code edit. Directive text drafted; see PR discussion.
- **Over-eager `needs_agent`**: a casual "make it less responsive here" suggestion escalated into a full agent thread (attention lever, `attention.py::needs_agent`). Noted, not tuned this run.
- **Ambient-in-threads bug**: fixed separately in #3261 (already merged).

Chart bumped to 0.285.44 so the prompt edits deploy.