### PR TITLE
fix(grimoire): Explore graph fills to the page bottom

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.11
+version: 0.89.12
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.11
+      targetRevision: 0.89.12
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.43
+version: 0.285.44
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.43
+      targetRevision: 0.285.44
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/explore/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/explore/+page.svelte
@@ -370,7 +370,12 @@
   .explore-page {
     max-width: 1180px;
     margin: 0 auto;
-    padding: 40px 28px 80px;
+    padding: 40px 28px 0;
+    /* Fill the viewport (minus the 58px sticky topbar) as a flex column so the
+       graph stage grows to the bottom edge with no leftover paper strip. */
+    display: flex;
+    flex-direction: column;
+    min-height: calc(100dvh - 58px);
   }
 
   .eyebrow {
@@ -491,12 +496,11 @@
        page instead of sitting in a bordered card surrounded by whitespace. */
     margin-left: calc(-50vw + 50%);
     margin-right: calc(-50vw + 50%);
-    height: calc(100vh - 210px);
+    flex: 1 1 auto;
     min-height: 480px;
     overflow: hidden;
     background: var(--grim-surface);
     border-top: 1px solid var(--grim-line);
-    border-bottom: 1px solid var(--grim-line);
   }
 
   :global(.grimoire.dark) .ex-stage {
@@ -593,7 +597,7 @@
 
   @media (max-width: 640px) {
     .explore-page {
-      padding: 28px 20px 60px;
+      padding: 28px 20px 0;
     }
   }
 </style>


### PR DESCRIPTION
The Explore graph had a fixed height + page bottom padding, leaving a paper strip below the map. Flex-fill the stage to the viewport bottom. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)