### PR TITLE
chore(monolith): let chat-directive-autopilot runs overlap (Allow)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.44
+version: 0.285.45
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -498,7 +498,12 @@ jobs:
     - name: chat-directive-autopilot
       args: ["chat-directive-autopilot"]
       schedule: "30 4 * * *"
-      concurrencyPolicy: Forbid
+      # Allow, not Forbid: a manual one-off trigger (verifying a tune, or
+      # forcing an adjustment now) must not cause the next scheduled run to be
+      # skipped on window overlap and lose that window's signal. The autopilot
+      # has no run-lock; safety comes from per-apply cooldown + self-validation
+      # + revert-on-regression, so an overlapping second run is bounded.
+      concurrencyPolicy: Allow
       activeDeadlineSeconds: 600
       suspend: false
       env:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.44
+      targetRevision: 0.285.45
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
The directive autopilot CronWorkflow used `concurrencyPolicy: Forbid`. A manual one-off trigger (verifying a tune, or forcing an adjustment now) that overlaps the 04:30 scheduled run would cause the scheduled run to be **skipped**, losing that window's ambient signal.

Switch to `Allow` so manual and scheduled runs never starve each other. There is no app-level run-lock; safety comes from per-apply cooldown (`AUTOPILOT_COOLDOWN_DAYS`) + one-window self-validation + revert-on-regression, so an overlapping second run is bounded (worst case a redundant version bump that self-corrects next window).

Chart bumped to 0.285.45.