### PR TITLE
feat(chat): hybrid vector + full-text history search

### DIFF
--- a/docs/plans/assets/2026-07-05-grimoire-reskin-mockup.html
+++ b/docs/plans/assets/2026-07-05-grimoire-reskin-mockup.html
@@ -11,7 +11,7 @@
     --faint: #8a94a2;
     --accent: #33507a;
     --accent-strong: #26406a;
-    --accent-soft: rgba(51, 80, 122, 0.10);
+    --accent-soft: rgba(51, 80, 122, 0.1);
 
     --t-location: #2f8f6b;
     --t-creature: #c0492b;
@@ -24,7 +24,9 @@
     --t-event: #7a6f3a;
     --t-quest: #2f8f8a;
 
-    --serif: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
+    --serif:
+      "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia,
+      serif;
     --sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     --mono: "SF Mono", ui-monospace, "Cascadia Code", Menlo, monospace;
   }
@@ -53,175 +55,709 @@
     --t-quest: #4fb0aa;
   }
 
-  * { box-sizing: border-box; }
-  html, body { margin: 0; }
+  * {
+    box-sizing: border-box;
+  }
+  html,
+  body {
+    margin: 0;
+  }
   body {
     background: var(--paper);
     color: var(--text);
     font-family: var(--sans);
     -webkit-font-smoothing: antialiased;
-    transition: background 0.3s, color 0.3s;
+    transition:
+      background 0.3s,
+      color 0.3s;
   }
 
   /* ---------------- top bar ---------------- */
   header {
-    position: sticky; top: 0; z-index: 10;
-    display: flex; align-items: center; gap: 28px;
-    padding: 0 28px; height: 58px;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    gap: 28px;
+    padding: 0 28px;
+    height: 58px;
     background: color-mix(in srgb, var(--paper) 88%, transparent);
     backdrop-filter: blur(10px);
     border-bottom: 1px solid var(--line);
   }
   .wordmark {
-    font-family: var(--sans); font-weight: 700; font-size: 14px;
-    letter-spacing: 0.28em; text-transform: uppercase; color: var(--text);
+    font-family: var(--sans);
+    font-weight: 700;
+    font-size: 14px;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--text);
   }
-  nav.tabs { display: flex; gap: 4px; margin-left: 8px; }
+  nav.tabs {
+    display: flex;
+    gap: 4px;
+    margin-left: 8px;
+  }
   nav.tabs button {
-    background: none; border: 0; cursor: pointer; padding: 6px 12px;
-    font-family: var(--sans); font-size: 11px; font-weight: 600;
-    letter-spacing: 0.16em; text-transform: uppercase; color: var(--faint);
-    border-bottom: 2px solid transparent; margin-bottom: -1px;
+    background: none;
+    border: 0;
+    cursor: pointer;
+    padding: 6px 12px;
+    font-family: var(--sans);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--faint);
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
   }
-  nav.tabs button:hover { color: var(--dim); }
-  nav.tabs button.active { color: var(--text); border-bottom-color: var(--accent); }
-  .spacer { margin-left: auto; }
+  nav.tabs button:hover {
+    color: var(--dim);
+  }
+  nav.tabs button.active {
+    color: var(--text);
+    border-bottom-color: var(--accent);
+  }
+  .spacer {
+    margin-left: auto;
+  }
   .toggle {
-    display: inline-flex; align-items: center; gap: 7px;
-    background: var(--surface-2); border: 1px solid var(--line);
-    border-radius: 999px; padding: 5px 6px; cursor: pointer; color: var(--dim);
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    background: var(--surface-2);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 5px 6px;
+    cursor: pointer;
+    color: var(--dim);
   }
-  .toggle svg { width: 15px; height: 15px; display: block; }
+  .toggle svg {
+    width: 15px;
+    height: 15px;
+    display: block;
+  }
   .toggle .knob {
-    width: 20px; height: 20px; border-radius: 50%;
-    display: grid; place-items: center; color: var(--accent);
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    color: var(--accent);
     background: var(--surface);
   }
 
-  main { max-width: 1180px; margin: 0 auto; padding: 40px 28px 80px; }
-  .view { display: none; }
-  .view.active { display: block; }
+  main {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 40px 28px 80px;
+  }
+  .view {
+    display: none;
+  }
+  .view.active {
+    display: block;
+  }
 
-  .eyebrow { font-size: 11px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--faint); font-weight: 600; }
-  h1.display { font-family: var(--serif); font-weight: 600; font-size: 46px; line-height: 1.02; margin: 6px 0 0; letter-spacing: -0.01em; }
-  .backlink { font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent); text-decoration: none; }
-  .backlink:hover { text-decoration: underline; }
-  .summary { margin-top: 14px; color: var(--dim); font-size: 13.5px; font-variant-numeric: tabular-nums; }
-  .summary b { color: var(--text); font-weight: 600; }
-  .summary .dot { color: var(--faint); margin: 0 8px; }
+  .eyebrow {
+    font-size: 11px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--faint);
+    font-weight: 600;
+  }
+  h1.display {
+    font-family: var(--serif);
+    font-weight: 600;
+    font-size: 46px;
+    line-height: 1.02;
+    margin: 6px 0 0;
+    letter-spacing: -0.01em;
+  }
+  .backlink {
+    font-size: 11px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--accent);
+    text-decoration: none;
+  }
+  .backlink:hover {
+    text-decoration: underline;
+  }
+  .summary {
+    margin-top: 14px;
+    color: var(--dim);
+    font-size: 13.5px;
+    font-variant-numeric: tabular-nums;
+  }
+  .summary b {
+    color: var(--text);
+    font-weight: 600;
+  }
+  .summary .dot {
+    color: var(--faint);
+    margin: 0 8px;
+  }
 
   /* ---------------- Library (grouped by book type, dense rows) ---------------- */
-  #bookList { margin-top: 6px; }
-  .lib-group { margin-top: 32px; }
-  .lib-group .gh { display: flex; align-items: baseline; gap: 10px; padding: 0 8px 8px; margin-bottom: 2px; border-bottom: 1px solid var(--line); }
-  .lib-group .gh .kind { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); font-weight: 700; }
-  .lib-group .gh .kn { font-size: 11px; color: var(--faint); font-variant-numeric: tabular-nums; }
-  .brow { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 15px; padding: 11px 8px; text-decoration: none; color: inherit; border-bottom: 1px solid var(--line-soft); border-radius: 7px; }
-  .brow:last-child { border-bottom: 0; }
-  .brow:hover { background: var(--surface-2); }
-  .brow .title { font-family: var(--serif); font-size: 18px; font-weight: 600; display: flex; align-items: center; gap: 9px; }
-  .brow .meta { margin-top: 2px; color: var(--dim); font-size: 12px; font-variant-numeric: tabular-nums; }
-  .brow .meta .dot { color: var(--faint); margin: 0 6px; }
-  .pill { font-family: var(--sans); font-size: 9px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent); background: var(--accent-soft); border-radius: 4px; padding: 2px 6px; }
-  .read { display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; font-size: 11px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent); opacity: 0; transition: opacity 0.15s; }
-  .brow:hover .read { opacity: 1; }
+  #bookList {
+    margin-top: 6px;
+  }
+  .lib-group {
+    margin-top: 32px;
+  }
+  .lib-group .gh {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 0 8px 8px;
+    margin-bottom: 2px;
+    border-bottom: 1px solid var(--line);
+  }
+  .lib-group .gh .kind {
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--accent);
+    font-weight: 700;
+  }
+  .lib-group .gh .kn {
+    font-size: 11px;
+    color: var(--faint);
+    font-variant-numeric: tabular-nums;
+  }
+  .brow {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 15px;
+    padding: 11px 8px;
+    text-decoration: none;
+    color: inherit;
+    border-bottom: 1px solid var(--line-soft);
+    border-radius: 7px;
+  }
+  .brow:last-child {
+    border-bottom: 0;
+  }
+  .brow:hover {
+    background: var(--surface-2);
+  }
+  .brow .title {
+    font-family: var(--serif);
+    font-size: 18px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+  }
+  .brow .meta {
+    margin-top: 2px;
+    color: var(--dim);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+  }
+  .brow .meta .dot {
+    color: var(--faint);
+    margin: 0 6px;
+  }
+  .pill {
+    font-family: var(--sans);
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    background: var(--accent-soft);
+    border-radius: 4px;
+    padding: 2px 6px;
+  }
+  .read {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    white-space: nowrap;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent);
+    opacity: 0;
+    transition: opacity 0.15s;
+  }
+  .brow:hover .read {
+    opacity: 1;
+  }
 
   /* ---------------- Entities ---------------- */
-  .controls { margin-top: 26px; display: flex; flex-direction: column; gap: 14px; }
-  .search { position: relative; }
+  .controls {
+    margin-top: 26px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .search {
+    position: relative;
+  }
   .search input {
-    width: 100%; height: 44px; padding: 0 14px 0 40px;
-    background: var(--surface); border: 1px solid var(--line); border-radius: 9px;
-    font-family: var(--sans); font-size: 15px; color: var(--text); outline: none;
+    width: 100%;
+    height: 44px;
+    padding: 0 14px 0 40px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 9px;
+    font-family: var(--sans);
+    font-size: 15px;
+    color: var(--text);
+    outline: none;
   }
-  .search input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
-  .search .i { position: absolute; left: 14px; top: 13px; color: var(--faint); }
-  .chips { display: flex; flex-wrap: wrap; gap: 7px; }
+  .search input:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
+  }
+  .search .i {
+    position: absolute;
+    left: 14px;
+    top: 13px;
+    color: var(--faint);
+  }
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 7px;
+  }
   .chip {
-    display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
-    background: var(--surface); border: 1px solid var(--line); border-radius: 999px;
-    padding: 6px 13px 6px 10px; font-size: 12.5px; color: var(--dim);
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    cursor: pointer;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 6px 13px 6px 10px;
+    font-size: 12.5px;
+    color: var(--dim);
   }
-  .chip .sw { width: 9px; height: 9px; border-radius: 50%; }
-  .chip.on { color: var(--text); border-color: color-mix(in srgb, var(--accent) 45%, var(--line)); background: var(--accent-soft); }
-  .chip.all.on { background: var(--accent); color: #fff; border-color: var(--accent); }
-  .chip .n { color: var(--faint); font-size: 11px; font-variant-numeric: tabular-nums; }
+  .chip .sw {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+  }
+  .chip.on {
+    color: var(--text);
+    border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
+    background: var(--accent-soft);
+  }
+  .chip.all.on {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+  }
+  .chip .n {
+    color: var(--faint);
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+  }
 
   .ent-grid {
-    margin-top: 22px; display: grid; gap: 8px;
+    margin-top: 22px;
+    display: grid;
+    gap: 8px;
     grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   }
   .ent {
-    display: flex; align-items: center; gap: 12px; cursor: pointer;
-    background: var(--surface); border: 1px solid var(--line-soft); border-radius: 8px;
-    border-left: 3px solid var(--ec, var(--faint)); padding: 11px 14px;
-    text-decoration: none; color: inherit; transition: background 0.12s, border-color 0.12s;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    cursor: pointer;
+    background: var(--surface);
+    border: 1px solid var(--line-soft);
+    border-radius: 8px;
+    border-left: 3px solid var(--ec, var(--faint));
+    padding: 11px 14px;
+    text-decoration: none;
+    color: inherit;
+    transition:
+      background 0.12s,
+      border-color 0.12s;
   }
-  .ent:hover { background: var(--surface-2); border-color: var(--line); border-left-color: var(--ec); }
-  .ent .nm { font-family: var(--serif); font-size: 16px; line-height: 1.2; }
-  .ent .ty { margin-left: auto; font-size: 9.5px; letter-spacing: 0.13em; text-transform: uppercase; color: var(--faint); font-weight: 600; }
-  .ent .ty b { color: var(--ec); font-weight: 600; }
+  .ent:hover {
+    background: var(--surface-2);
+    border-color: var(--line);
+    border-left-color: var(--ec);
+  }
+  .ent .nm {
+    font-family: var(--serif);
+    font-size: 16px;
+    line-height: 1.2;
+  }
+  .ent .ty {
+    margin-left: auto;
+    font-size: 9.5px;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+    color: var(--faint);
+    font-weight: 600;
+  }
+  .ent .ty b {
+    color: var(--ec);
+    font-weight: 600;
+  }
 
   /* ---------------- Reader ---------------- */
-  .reader-wrap { display: grid; grid-template-columns: 244px 1fr; gap: 44px; margin-top: 28px; align-items: start; }
-  .toc { position: sticky; top: 90px; max-height: calc(100vh - 130px); overflow-y: auto; border-right: 1px solid var(--line-soft); padding-right: 20px; }
-  .toc h4 { font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--faint); margin: 0 0 12px; font-weight: 700; }
-  .toc ul { list-style: none; margin: 0; padding: 0; }
-  .toc .chap > a { font-family: var(--serif); font-size: 14.5px; color: var(--text); font-weight: 600; }
-  .toc a { display: block; text-decoration: none; color: var(--dim); padding: 4px 0 4px 12px; border-left: 2px solid transparent; margin-left: -2px; font-size: 13px; line-height: 1.3; }
-  .toc .sub a { padding-left: 22px; font-size: 12.5px; color: var(--dim); font-family: var(--sans); }
-  .toc a:hover { color: var(--text); }
-  .toc a.cur { color: var(--accent); border-left-color: var(--accent); font-weight: 600; }
-  .toc .chap { margin-bottom: 4px; }
-  .toc .sub { margin: 0 0 8px; }
+  .reader-wrap {
+    display: grid;
+    grid-template-columns: 244px 1fr;
+    gap: 44px;
+    margin-top: 28px;
+    align-items: start;
+  }
+  .toc {
+    position: sticky;
+    top: 90px;
+    max-height: calc(100vh - 130px);
+    overflow-y: auto;
+    border-right: 1px solid var(--line-soft);
+    padding-right: 20px;
+  }
+  .toc h4 {
+    font-size: 10px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--faint);
+    margin: 0 0 12px;
+    font-weight: 700;
+  }
+  .toc ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .toc .chap > a {
+    font-family: var(--serif);
+    font-size: 14.5px;
+    color: var(--text);
+    font-weight: 600;
+  }
+  .toc a {
+    display: block;
+    text-decoration: none;
+    color: var(--dim);
+    padding: 4px 0 4px 12px;
+    border-left: 2px solid transparent;
+    margin-left: -2px;
+    font-size: 13px;
+    line-height: 1.3;
+  }
+  .toc .sub a {
+    padding-left: 22px;
+    font-size: 12.5px;
+    color: var(--dim);
+    font-family: var(--sans);
+  }
+  .toc a:hover {
+    color: var(--text);
+  }
+  .toc a.cur {
+    color: var(--accent);
+    border-left-color: var(--accent);
+    font-weight: 600;
+  }
+  .toc .chap {
+    margin-bottom: 4px;
+  }
+  .toc .sub {
+    margin: 0 0 8px;
+  }
 
-  article.page { max-width: 68ch; }
-  article.page .sec-label { font-size: 10.5px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); font-weight: 700; margin-bottom: 6px; }
-  article.page h2 { font-family: var(--serif); font-size: 30px; font-weight: 600; margin: 0 0 4px; letter-spacing: -0.01em; }
-  article.page h3 { font-family: var(--serif); font-size: 19px; font-weight: 600; margin: 30px 0 2px; }
-  article.page .rule { height: 1px; background: var(--line); border: 0; margin: 20px 0; }
-  article.page p { font-family: var(--serif); font-size: 17px; line-height: 1.66; margin: 0 0 14px; color: color-mix(in srgb, var(--text) 92%, var(--paper)); }
-  article.page p.credit { margin: 0 0 8px; }
-  article.page p.credit b { font-weight: 600; color: var(--text); }
-  article.page .drop::first-letter { initial-letter: 2; font-family: var(--serif); font-weight: 600; color: var(--accent); margin-right: 8px; }
-  .reader-topline { display: flex; align-items: center; gap: 10px; color: var(--faint); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; }
-  .reader-topline b { color: var(--dim); font-weight: 600; }
+  article.page {
+    max-width: 68ch;
+  }
+  article.page .sec-label {
+    font-size: 10.5px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--accent);
+    font-weight: 700;
+    margin-bottom: 6px;
+  }
+  article.page h2 {
+    font-family: var(--serif);
+    font-size: 30px;
+    font-weight: 600;
+    margin: 0 0 4px;
+    letter-spacing: -0.01em;
+  }
+  article.page h3 {
+    font-family: var(--serif);
+    font-size: 19px;
+    font-weight: 600;
+    margin: 30px 0 2px;
+  }
+  article.page .rule {
+    height: 1px;
+    background: var(--line);
+    border: 0;
+    margin: 20px 0;
+  }
+  article.page p {
+    font-family: var(--serif);
+    font-size: 17px;
+    line-height: 1.66;
+    margin: 0 0 14px;
+    color: color-mix(in srgb, var(--text) 92%, var(--paper));
+  }
+  article.page p.credit {
+    margin: 0 0 8px;
+  }
+  article.page p.credit b {
+    font-weight: 600;
+    color: var(--text);
+  }
+  article.page .drop::first-letter {
+    initial-letter: 2;
+    font-family: var(--serif);
+    font-weight: 600;
+    color: var(--accent);
+    margin-right: 8px;
+  }
+  .reader-topline {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--faint);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+  .reader-topline b {
+    color: var(--dim);
+    font-weight: 600;
+  }
 
   /* ---------------- Explore ---------------- */
-  .ex-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; margin-bottom: 16px; }
-  .lens-switch { display: flex; gap: 2px; background: var(--surface-2); border: 1px solid var(--line); border-radius: 9px; padding: 3px; }
-  .lens-switch button { background: none; border: 0; cursor: pointer; padding: 7px 14px; border-radius: 6px; font-family: var(--sans); font-size: 12px; font-weight: 600; color: var(--dim); }
-  .lens-switch button.on { background: var(--surface); color: var(--accent); box-shadow: 0 1px 2px rgba(20,30,50,0.1); }
-  .ex-controls { display: flex; align-items: center; gap: 14px; }
-  .scope-sel { display: inline-flex; align-items: center; gap: 8px; font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--faint); font-weight: 700; }
-  .scope-sel select { font-family: var(--serif); font-size: 15px; font-weight: 600; letter-spacing: 0; text-transform: none; color: var(--text); background: var(--surface); border: 1px solid var(--line); border-radius: 8px; padding: 8px 12px; cursor: pointer; }
-  .scope-sel select:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
-  .ex-stage { position: relative; height: calc(100vh - 236px); min-height: 440px; border: 1px solid var(--line); border-radius: 12px; overflow: hidden; background: var(--surface); }
-  body.dark .ex-stage { background: var(--paper); }
-  .ex-stage canvas { display: block; width: 100%; height: 100%; cursor: grab; }
-  .ex-stage canvas.drag { cursor: grabbing; }
-  .ex-legend { position: absolute; top: 14px; left: 14px; display: flex; flex-direction: column; gap: 6px; background: color-mix(in srgb, var(--surface) 80%, transparent); backdrop-filter: blur(8px); border: 1px solid var(--line); border-radius: 9px; padding: 11px 13px; }
-  .ex-legend .row { display: flex; align-items: center; gap: 8px; font-size: 11.5px; color: var(--dim); }
-  .ex-legend .row .sw { width: 9px; height: 9px; border-radius: 50%; }
-  .ex-codex { position: absolute; top: 0; right: 0; bottom: 0; width: min(344px, 86%); background: color-mix(in srgb, var(--surface) 94%, transparent); backdrop-filter: blur(12px); border-left: 1px solid var(--line); transform: translateX(100%); transition: transform 0.3s cubic-bezier(0.22,0.61,0.36,1); padding: 24px 24px 32px; overflow-y: auto; }
-  .ex-codex.open { transform: translateX(0); }
-  .ex-codex .cx-close { position: absolute; top: 13px; right: 15px; background: none; border: 1px solid var(--line); border-radius: 6px; width: 27px; height: 27px; cursor: pointer; color: var(--dim); font-size: 15px; }
-  .ex-codex .cx-close:hover { color: var(--text); border-color: var(--accent); }
-  .ex-codex .cx-type { display: flex; align-items: center; gap: 8px; font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--faint); font-weight: 600; }
-  .ex-codex .cx-type .sw { width: 9px; height: 9px; border-radius: 50%; }
-  .ex-codex h2 { font-family: var(--serif); font-size: 25px; font-weight: 600; margin: 9px 0 0; line-height: 1.1; }
-  .ex-codex .cx-sum { font-family: var(--serif); font-size: 15px; line-height: 1.56; color: var(--dim); margin-top: 11px; }
-  .ex-codex .cx-h { font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); font-weight: 700; margin: 24px 0 8px; border-bottom: 1px solid var(--line-soft); padding-bottom: 7px; }
-  .ex-codex .cx-rel { display: flex; align-items: center; gap: 9px; padding: 6px 0; cursor: pointer; }
-  .ex-codex .cx-rel .sw { width: 7px; height: 7px; border-radius: 50%; flex: none; }
-  .ex-codex .cx-rel .v { font-family: var(--mono); font-size: 10px; color: var(--dim); min-width: 96px; }
-  .ex-codex .cx-rel .p { font-family: var(--serif); font-size: 14.5px; }
-  .ex-codex .cx-rel:hover .p { color: var(--accent); }
+  .ex-head {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 20px;
+    margin-bottom: 16px;
+  }
+  .lens-switch {
+    display: flex;
+    gap: 2px;
+    background: var(--surface-2);
+    border: 1px solid var(--line);
+    border-radius: 9px;
+    padding: 3px;
+  }
+  .lens-switch button {
+    background: none;
+    border: 0;
+    cursor: pointer;
+    padding: 7px 14px;
+    border-radius: 6px;
+    font-family: var(--sans);
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--dim);
+  }
+  .lens-switch button.on {
+    background: var(--surface);
+    color: var(--accent);
+    box-shadow: 0 1px 2px rgba(20, 30, 50, 0.1);
+  }
+  .ex-controls {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+  }
+  .scope-sel {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 10px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--faint);
+    font-weight: 700;
+  }
+  .scope-sel select {
+    font-family: var(--serif);
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: 0;
+    text-transform: none;
+    color: var(--text);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 8px 12px;
+    cursor: pointer;
+  }
+  .scope-sel select:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
+  }
+  .ex-stage {
+    position: relative;
+    height: calc(100vh - 236px);
+    min-height: 440px;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--surface);
+  }
+  body.dark .ex-stage {
+    background: var(--paper);
+  }
+  .ex-stage canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+    cursor: grab;
+  }
+  .ex-stage canvas.drag {
+    cursor: grabbing;
+  }
+  .ex-legend {
+    position: absolute;
+    top: 14px;
+    left: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    background: color-mix(in srgb, var(--surface) 80%, transparent);
+    backdrop-filter: blur(8px);
+    border: 1px solid var(--line);
+    border-radius: 9px;
+    padding: 11px 13px;
+  }
+  .ex-legend .row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 11.5px;
+    color: var(--dim);
+  }
+  .ex-legend .row .sw {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+  }
+  .ex-codex {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(344px, 86%);
+    background: color-mix(in srgb, var(--surface) 94%, transparent);
+    backdrop-filter: blur(12px);
+    border-left: 1px solid var(--line);
+    transform: translateX(100%);
+    transition: transform 0.3s cubic-bezier(0.22, 0.61, 0.36, 1);
+    padding: 24px 24px 32px;
+    overflow-y: auto;
+  }
+  .ex-codex.open {
+    transform: translateX(0);
+  }
+  .ex-codex .cx-close {
+    position: absolute;
+    top: 13px;
+    right: 15px;
+    background: none;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    width: 27px;
+    height: 27px;
+    cursor: pointer;
+    color: var(--dim);
+    font-size: 15px;
+  }
+  .ex-codex .cx-close:hover {
+    color: var(--text);
+    border-color: var(--accent);
+  }
+  .ex-codex .cx-type {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 10px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--faint);
+    font-weight: 600;
+  }
+  .ex-codex .cx-type .sw {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+  }
+  .ex-codex h2 {
+    font-family: var(--serif);
+    font-size: 25px;
+    font-weight: 600;
+    margin: 9px 0 0;
+    line-height: 1.1;
+  }
+  .ex-codex .cx-sum {
+    font-family: var(--serif);
+    font-size: 15px;
+    line-height: 1.56;
+    color: var(--dim);
+    margin-top: 11px;
+  }
+  .ex-codex .cx-h {
+    font-size: 10px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--accent);
+    font-weight: 700;
+    margin: 24px 0 8px;
+    border-bottom: 1px solid var(--line-soft);
+    padding-bottom: 7px;
+  }
+  .ex-codex .cx-rel {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding: 6px 0;
+    cursor: pointer;
+  }
+  .ex-codex .cx-rel .sw {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex: none;
+  }
+  .ex-codex .cx-rel .v {
+    font-family: var(--mono);
+    font-size: 10px;
+    color: var(--dim);
+    min-width: 96px;
+  }
+  .ex-codex .cx-rel .p {
+    font-family: var(--serif);
+    font-size: 14.5px;
+  }
+  .ex-codex .cx-rel:hover .p {
+    color: var(--accent);
+  }
 
   @media (max-width: 760px) {
-    .reader-wrap { grid-template-columns: 1fr; }
-    .toc { display: none; }
-    h1.display { font-size: 36px; }
+    .reader-wrap {
+      grid-template-columns: 1fr;
+    }
+    .toc {
+      display: none;
+    }
+    h1.display {
+      font-size: 36px;
+    }
   }
 </style>
 
@@ -243,7 +779,15 @@
   <section class="view active" id="v-library">
     <div class="eyebrow">The Grimoire</div>
     <h1 class="display">Library</h1>
-    <div class="summary"><b>33</b> books<span class="dot">/</span><b>40,514</b> chunks<span class="dot">/</span><b>5,750</b> images<span class="dot">/</span><b>9,147</b> entities<span class="dot">/</span>synced 1d ago</div>
+    <div class="summary">
+      <b>33</b> books<span class="dot">/</span><b>40,514</b> chunks<span
+        class="dot"
+        >/</span
+      ><b>5,750</b> images<span class="dot">/</span><b>9,147</b> entities<span
+        class="dot"
+        >/</span
+      >synced 1d ago
+    </div>
 
     <div class="book-list" id="bookList"></div>
   </section>
@@ -251,13 +795,17 @@
   <!-- ================= ENTITIES ================= -->
   <section class="view" id="v-entities">
     <a class="backlink" data-view="library" href="#">&larr; Library</a>
-    <h1 class="display" style="margin-top:10px">Entities</h1>
+    <h1 class="display" style="margin-top: 10px">Entities</h1>
     <div class="summary"><b>24,879</b> indexed across the corpus</div>
 
     <div class="controls">
       <div class="search">
         <span class="i">&#9906;</span>
-        <input type="text" placeholder="Search 24,879 entities by name..." aria-label="Search entities" />
+        <input
+          type="text"
+          placeholder="Search 24,879 entities by name..."
+          aria-label="Search entities"
+        />
       </div>
       <div class="chips" id="chips"></div>
     </div>
@@ -267,31 +815,57 @@
 
   <!-- ================= READER ================= -->
   <section class="view" id="v-reader">
-    <a class="backlink" data-view="library" href="#" style="display:inline-block;margin-bottom:20px">&larr; Library</a>
+    <a
+      class="backlink"
+      data-view="library"
+      href="#"
+      style="display: inline-block; margin-bottom: 20px"
+      >&larr; Library</a
+    >
     <div class="reader-wrap">
       <aside class="toc">
         <h4>Curse of Strahd</h4>
         <ul id="tocList"></ul>
       </aside>
       <div>
-        <div class="reader-topline"><b>Chapter 1</b> &middot; Into the Mists</div>
+        <div class="reader-topline">
+          <b>Chapter 1</b> &middot; Into the Mists
+        </div>
         <article class="page">
           <div class="sec-label">Introduction</div>
           <h2>Into the Mists</h2>
           <hr class="rule" />
-          <p class="drop">Under raging storm clouds, the vampire Count Strahd von Zarovich stands silhouetted against the ancient walls of Castle Ravenloft. Rumbling thunder pounds the castle spires. The wind's howling increases as he turns his gaze down toward the village of Barovia.</p>
-          <p>A lone figure emerges from the fog-shrouded gate, and Strahd knows it is time. His prey has arrived, and the hunt can begin anew. He has hunted this soul before, across centuries, and he will hunt it again.</p>
+          <p class="drop">
+            Under raging storm clouds, the vampire Count Strahd von Zarovich
+            stands silhouetted against the ancient walls of Castle Ravenloft.
+            Rumbling thunder pounds the castle spires. The wind's howling
+            increases as he turns his gaze down toward the village of Barovia.
+          </p>
+          <p>
+            A lone figure emerges from the fog-shrouded gate, and Strahd knows
+            it is time. His prey has arrived, and the hunt can begin anew. He
+            has hunted this soul before, across centuries, and he will hunt it
+            again.
+          </p>
 
           <h3>The Land of Barovia</h3>
-          <p>The Land of Barovia is surrounded by a wall of mist that whisks away anyone foolish enough to enter it. It is a place of death, controlled entirely by its monstrous lord.</p>
+          <p>
+            The Land of Barovia is surrounded by a wall of mist that whisks away
+            anyone foolish enough to enter it. It is a place of death,
+            controlled entirely by its monstrous lord.
+          </p>
 
           <h3>Credits</h3>
-          <p class="credit"><b>Imaging Technicians:</b> Daniel Corona, Kevin Yee</p>
+          <p class="credit">
+            <b>Imaging Technicians:</b> Daniel Corona, Kevin Yee
+          </p>
           <p class="credit"><b>Prepress Specialist:</b> Jefferson Dunlap</p>
           <hr class="rule" />
           <div class="sec-label">D&amp;D Studio</div>
           <p class="credit"><b>Executive Producer:</b> Kyle Brink</p>
-          <p class="credit"><b>Game Architects:</b> Jeremy Crawford, Christopher Perkins</p>
+          <p class="credit">
+            <b>Game Architects:</b> Jeremy Crawford, Christopher Perkins
+          </p>
           <p class="credit"><b>Studio Art Director:</b> Josh Herman</p>
         </article>
       </div>
@@ -301,9 +875,13 @@
   <!-- ================= EXPLORE ================= -->
   <section class="view" id="v-explore">
     <div class="ex-head">
-      <div><div class="eyebrow">The Grimoire</div><h1 class="display" style="margin-top:4px">Explore</h1></div>
+      <div>
+        <div class="eyebrow">The Grimoire</div>
+        <h1 class="display" style="margin-top: 4px">Explore</h1>
+      </div>
       <div class="ex-controls">
-        <label class="scope-sel"><span>Scope</span>
+        <label class="scope-sel"
+          ><span>Scope</span>
           <select id="scopeSel">
             <option value="cos">Curse of Strahd</option>
             <option value="lmop">Lost Mine of Phandelver</option>
@@ -311,7 +889,10 @@
           </select>
         </label>
         <div class="lens-switch" id="lensSwitch">
-          <button class="on" data-lens="world">World</button><button data-lens="story">Story</button><button data-lens="quests">Quests</button><button data-lens="rules">Rules</button>
+          <button class="on" data-lens="world">World</button
+          ><button data-lens="story">Story</button
+          ><button data-lens="quests">Quests</button
+          ><button data-lens="rules">Rules</button>
         </div>
       </div>
     </div>
@@ -319,7 +900,9 @@
       <canvas id="exCanvas"></canvas>
       <div class="ex-legend" id="exLegend"></div>
       <aside class="ex-codex" id="exCodex">
-        <button class="cx-close" id="cxClose" aria-label="Close">&times;</button>
+        <button class="cx-close" id="cxClose" aria-label="Close">
+          &times;
+        </button>
         <div id="cxBody"></div>
       </aside>
     </div>
@@ -328,394 +911,991 @@
 
 <script>
   // ---- theme toggle ----
-  const SUN = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>';
-  const MOON = '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>';
-  const knob = document.getElementById('knob');
-  function paintToggle() { knob.innerHTML = document.body.classList.contains('dark') ? MOON : SUN; }
-  document.getElementById('themeToggle').addEventListener('click', () => {
-    document.body.classList.toggle('dark'); paintToggle();
+  const SUN =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>';
+  const MOON =
+    '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>';
+  const knob = document.getElementById("knob");
+  function paintToggle() {
+    knob.innerHTML = document.body.classList.contains("dark") ? MOON : SUN;
+  }
+  document.getElementById("themeToggle").addEventListener("click", () => {
+    document.body.classList.toggle("dark");
+    paintToggle();
   });
   paintToggle();
 
   // ---- view switching ----
   function show(view) {
-    document.querySelectorAll('.view').forEach(v => v.classList.toggle('active', v.id === 'v-' + view));
-    const tab = view === 'reader' ? 'library' : view;  // Reader is nested under Library
-    document.querySelectorAll('nav.tabs button').forEach(b => b.classList.toggle('active', b.dataset.view === tab));
+    document
+      .querySelectorAll(".view")
+      .forEach((v) => v.classList.toggle("active", v.id === "v-" + view));
+    const tab = view === "reader" ? "library" : view; // Reader is nested under Library
+    document
+      .querySelectorAll("nav.tabs button")
+      .forEach((b) => b.classList.toggle("active", b.dataset.view === tab));
     window.scrollTo(0, 0);
   }
-  document.querySelectorAll('[data-view]').forEach(el =>
-    el.addEventListener('click', e => { e.preventDefault(); show(el.dataset.view); }));
+  document.querySelectorAll("[data-view]").forEach((el) =>
+    el.addEventListener("click", (e) => {
+      e.preventDefault();
+      show(el.dataset.view);
+    }),
+  );
 
   // ---- Library data (grouped by book_kind) ----
-  const KIND_LABEL = { adventure: "Adventures", "adventure-anthology": "Anthologies", "setting-guide": "Setting Guides", bestiary: "Bestiaries", spellbook: "Spellbooks", "magic-items": "Magic Items", rulebook: "Rulebooks" };
-  const KIND_ORDER = ["adventure", "adventure-anthology", "setting-guide", "bestiary", "spellbook", "magic-items", "rulebook"];
-  const BOOKS = [
-    { t: "Curse of Strahd", i: "S", k: "adventure", chunks: 1057, images: 180, entities: 412 },
-    { t: "Lost Mine of Phandelver", i: "P", k: "adventure", chunks: 210, images: 44, entities: 96 },
-    { t: "Rime of the Frostmaiden", i: "R", k: "adventure", chunks: 1120, images: 240, entities: 388 },
-    { t: "Descent into Avernus", i: "A", k: "adventure", chunks: 990, images: 210, entities: 301 },
-    { t: "Candlekeep Mysteries", i: "C", k: "adventure-anthology", chunks: 932, images: 131, entities: 0, new: true },
-    { t: "Ghosts of Saltmarsh", i: "G", k: "adventure-anthology", chunks: 870, images: 150, entities: 214 },
-    { t: "Explorer's Guide to Wildemount", i: "W", k: "setting-guide", chunks: 1310, images: 280, entities: 640 },
-    { t: "Sword Coast Adventurer's Guide", i: "C", k: "setting-guide", chunks: 720, images: 110, entities: 355 },
-    { t: "Monster Manual", i: "M", k: "bestiary", chunks: 1200, images: 380, entities: 2412 },
-    { t: "Bigby Presents: Glory of Giants", i: "B", k: "bestiary", chunks: 827, images: 200, entities: 0, new: true },
-    { t: "Deep Magic", i: "D", k: "spellbook", chunks: 540, images: 60, entities: 720 },
-    { t: "Vault of Magic", i: "V", k: "magic-items", chunks: 610, images: 190, entities: 900 },
-    { t: "Player's Handbook", i: "H", k: "rulebook", chunks: 1440, images: 210, entities: 1806 },
-    { t: "Dungeon Master's Guide", i: "D", k: "rulebook", chunks: 1290, images: 170, entities: 640 },
+  const KIND_LABEL = {
+    adventure: "Adventures",
+    "adventure-anthology": "Anthologies",
+    "setting-guide": "Setting Guides",
+    bestiary: "Bestiaries",
+    spellbook: "Spellbooks",
+    "magic-items": "Magic Items",
+    rulebook: "Rulebooks",
+  };
+  const KIND_ORDER = [
+    "adventure",
+    "adventure-anthology",
+    "setting-guide",
+    "bestiary",
+    "spellbook",
+    "magic-items",
+    "rulebook",
   ];
-  document.getElementById('bookList').innerHTML = KIND_ORDER.map(k => {
-    const rows = BOOKS.filter(b => b.k === k);
+  const BOOKS = [
+    {
+      t: "Curse of Strahd",
+      i: "S",
+      k: "adventure",
+      chunks: 1057,
+      images: 180,
+      entities: 412,
+    },
+    {
+      t: "Lost Mine of Phandelver",
+      i: "P",
+      k: "adventure",
+      chunks: 210,
+      images: 44,
+      entities: 96,
+    },
+    {
+      t: "Rime of the Frostmaiden",
+      i: "R",
+      k: "adventure",
+      chunks: 1120,
+      images: 240,
+      entities: 388,
+    },
+    {
+      t: "Descent into Avernus",
+      i: "A",
+      k: "adventure",
+      chunks: 990,
+      images: 210,
+      entities: 301,
+    },
+    {
+      t: "Candlekeep Mysteries",
+      i: "C",
+      k: "adventure-anthology",
+      chunks: 932,
+      images: 131,
+      entities: 0,
+      new: true,
+    },
+    {
+      t: "Ghosts of Saltmarsh",
+      i: "G",
+      k: "adventure-anthology",
+      chunks: 870,
+      images: 150,
+      entities: 214,
+    },
+    {
+      t: "Explorer's Guide to Wildemount",
+      i: "W",
+      k: "setting-guide",
+      chunks: 1310,
+      images: 280,
+      entities: 640,
+    },
+    {
+      t: "Sword Coast Adventurer's Guide",
+      i: "C",
+      k: "setting-guide",
+      chunks: 720,
+      images: 110,
+      entities: 355,
+    },
+    {
+      t: "Monster Manual",
+      i: "M",
+      k: "bestiary",
+      chunks: 1200,
+      images: 380,
+      entities: 2412,
+    },
+    {
+      t: "Bigby Presents: Glory of Giants",
+      i: "B",
+      k: "bestiary",
+      chunks: 827,
+      images: 200,
+      entities: 0,
+      new: true,
+    },
+    {
+      t: "Deep Magic",
+      i: "D",
+      k: "spellbook",
+      chunks: 540,
+      images: 60,
+      entities: 720,
+    },
+    {
+      t: "Vault of Magic",
+      i: "V",
+      k: "magic-items",
+      chunks: 610,
+      images: 190,
+      entities: 900,
+    },
+    {
+      t: "Player's Handbook",
+      i: "H",
+      k: "rulebook",
+      chunks: 1440,
+      images: 210,
+      entities: 1806,
+    },
+    {
+      t: "Dungeon Master's Guide",
+      i: "D",
+      k: "rulebook",
+      chunks: 1290,
+      images: 170,
+      entities: 640,
+    },
+  ];
+  document.getElementById("bookList").innerHTML = KIND_ORDER.map((k) => {
+    const rows = BOOKS.filter((b) => b.k === k);
     if (!rows.length) return "";
     return `<div class="lib-group">
       <div class="gh"><span class="kind">${KIND_LABEL[k]}</span><span class="kn">${rows.length}</span></div>
-      ${rows.map(b => `<a class="brow" data-view="reader" href="#">
-        <span><span class="title">${b.t}${b.new ? '<span class="pill">New</span>' : ''}</span>
+      ${rows
+        .map(
+          (b) => `<a class="brow" data-view="reader" href="#">
+        <span><span class="title">${b.t}${b.new ? '<span class="pill">New</span>' : ""}</span>
         <span class="meta">${b.chunks.toLocaleString()} chunks<span class="dot">/</span>${b.images} images<span class="dot">/</span>${b.entities.toLocaleString()} entities</span></span>
         <span class="read">Read &rarr;</span>
-      </a>`).join('')}
+      </a>`,
+        )
+        .join("")}
     </div>`;
-  }).join('');
-  document.querySelectorAll('#bookList [data-view]').forEach(el =>
-    el.addEventListener('click', e => { e.preventDefault(); show(el.dataset.view); }));
+  }).join("");
+  document.querySelectorAll("#bookList [data-view]").forEach((el) =>
+    el.addEventListener("click", (e) => {
+      e.preventDefault();
+      show(el.dataset.view);
+    }),
+  );
 
   // ---- Entities data ----
   const TYPES = {
-    creature: "--t-creature", spell: "--t-spell", location: "--t-location",
-    npc: "--t-npc", faction: "--t-faction", deity: "--t-deity",
-    item: "--t-item", class: "--t-class",
+    creature: "--t-creature",
+    spell: "--t-spell",
+    location: "--t-location",
+    npc: "--t-npc",
+    faction: "--t-faction",
+    deity: "--t-deity",
+    item: "--t-item",
+    class: "--t-class",
   };
   const ENTS = [
-    ["Strahd von Zarovich","npc"],["Barovia","location"],["Castle Ravenloft","location"],
-    ["Ireena Kolyana","npc"],["Fireball","spell"],["Counterspell","spell"],
-    ["Vampire Spawn","creature"],["The Raven Queen","deity"],["Sun Blade","item"],
-    ["Aarakocra","creature"],["Wind Dukes of Aaqa","faction"],["Aaqa","location"],
-    ["Gundren Rockseeker","npc"],["Cragmaw Tribe","faction"],["Wave Echo Cave","location"],
-    ["Nezznar the Black Spider","npc"],["Lathander","deity"],["Symbol of Ravenkind","item"],
-    ["Wizard","class"],["Delayed Blast Fireball","spell"],["Klarg","creature"],
-    ["Redbrands","faction"],["Phandalin","location"],["Speak with Dead","spell"],
+    ["Strahd von Zarovich", "npc"],
+    ["Barovia", "location"],
+    ["Castle Ravenloft", "location"],
+    ["Ireena Kolyana", "npc"],
+    ["Fireball", "spell"],
+    ["Counterspell", "spell"],
+    ["Vampire Spawn", "creature"],
+    ["The Raven Queen", "deity"],
+    ["Sun Blade", "item"],
+    ["Aarakocra", "creature"],
+    ["Wind Dukes of Aaqa", "faction"],
+    ["Aaqa", "location"],
+    ["Gundren Rockseeker", "npc"],
+    ["Cragmaw Tribe", "faction"],
+    ["Wave Echo Cave", "location"],
+    ["Nezznar the Black Spider", "npc"],
+    ["Lathander", "deity"],
+    ["Symbol of Ravenkind", "item"],
+    ["Wizard", "class"],
+    ["Delayed Blast Fireball", "spell"],
+    ["Klarg", "creature"],
+    ["Redbrands", "faction"],
+    ["Phandalin", "location"],
+    ["Speak with Dead", "spell"],
   ];
-  const chipDefs = [["all","All",TYPES],["creature","Creature"],["spell","Spell"],["location","Location"],
-    ["npc","NPC"],["faction","Faction"],["deity","Deity"],["item","Item"],["class","Class"]];
-  const counts = {}; ENTS.forEach(([,t]) => counts[t] = (counts[t]||0)+1);
-  document.getElementById('chips').innerHTML = chipDefs.map(([k,label]) => {
-    if (k === "all") return `<span class="chip all on" data-type="all">All <span class="n">${ENTS.length}</span></span>`;
-    return `<span class="chip" data-type="${k}"><span class="sw" style="background:var(${TYPES[k]})"></span>${label} <span class="n">${counts[k]||0}</span></span>`;
-  }).join('');
+  const chipDefs = [
+    ["all", "All", TYPES],
+    ["creature", "Creature"],
+    ["spell", "Spell"],
+    ["location", "Location"],
+    ["npc", "NPC"],
+    ["faction", "Faction"],
+    ["deity", "Deity"],
+    ["item", "Item"],
+    ["class", "Class"],
+  ];
+  const counts = {};
+  ENTS.forEach(([, t]) => (counts[t] = (counts[t] || 0) + 1));
+  document.getElementById("chips").innerHTML = chipDefs
+    .map(([k, label]) => {
+      if (k === "all")
+        return `<span class="chip all on" data-type="all">All <span class="n">${ENTS.length}</span></span>`;
+      return `<span class="chip" data-type="${k}"><span class="sw" style="background:var(${TYPES[k]})"></span>${label} <span class="n">${counts[k] || 0}</span></span>`;
+    })
+    .join("");
   function renderEnts(filter) {
-    const rows = ENTS.filter(([,t]) => filter === "all" || t === filter);
-    document.getElementById('entGrid').innerHTML = rows.map(([n,t]) => `
+    const rows = ENTS.filter(([, t]) => filter === "all" || t === filter);
+    document.getElementById("entGrid").innerHTML = rows
+      .map(
+        ([n, t]) => `
       <a class="ent" href="#" style="--ec:var(${TYPES[t]})">
         <span class="nm">${n}</span>
         <span class="ty"><b>${t}</b></span>
-      </a>`).join('');
+      </a>`,
+      )
+      .join("");
   }
   renderEnts("all");
-  document.querySelectorAll('#chips .chip').forEach(c =>
-    c.addEventListener('click', () => {
-      document.querySelectorAll('#chips .chip').forEach(x => x.classList.remove('on'));
-      c.classList.add('on');
+  document.querySelectorAll("#chips .chip").forEach((c) =>
+    c.addEventListener("click", () => {
+      document
+        .querySelectorAll("#chips .chip")
+        .forEach((x) => x.classList.remove("on"));
+      c.classList.add("on");
       renderEnts(c.dataset.type);
-    }));
+    }),
+  );
 
   // ---- Reader TOC ----
   const TOC = [
     ["Introduction", [], true],
-    ["Ch 1 · Into the Mists", ["The Land of Barovia","The Death House","Credits"], false, "Credits"],
-    ["Ch 2 · The Lands of Barovia", ["Village of Barovia","Old Bonegrinder","Vallaki"], false],
+    [
+      "Ch 1 · Into the Mists",
+      ["The Land of Barovia", "The Death House", "Credits"],
+      false,
+      "Credits",
+    ],
+    [
+      "Ch 2 · The Lands of Barovia",
+      ["Village of Barovia", "Old Bonegrinder", "Vallaki"],
+      false,
+    ],
     ["Ch 3 · Tarokka Deck", [], false],
-    ["Appendix · Monsters", ["Strahd von Zarovich","Rahadin"], false],
+    ["Appendix · Monsters", ["Strahd von Zarovich", "Rahadin"], false],
   ];
-  document.getElementById('tocList').innerHTML = TOC.map(([chap, subs, curChap, curSub]) => `
-    <li class="chap"><a href="#" class="${curChap ? 'cur' : ''}">${chap}</a></li>
-    ${subs.length ? `<li class="sub"><ul>${subs.map(s => `<li><a href="#" class="${s===curSub?'cur':''}">${s}</a></li>`).join('')}</ul></li>` : ''}
-  `).join('');
+  document.getElementById("tocList").innerHTML = TOC.map(
+    ([chap, subs, curChap, curSub]) => `
+    <li class="chap"><a href="#" class="${curChap ? "cur" : ""}">${chap}</a></li>
+    ${subs.length ? `<li class="sub"><ul>${subs.map((s) => `<li><a href="#" class="${s === curSub ? "cur" : ""}">${s}</a></li>`).join("")}</ul></li>` : ""}
+  `,
+  ).join("");
 
   // ============================================================
   //  EXPLORE graph (atlas renderer, drawing colors from the shared
   //  theme tokens so it flips with the light/dark toggle)
   // ============================================================
-  const LORE = new Set(["creature","spell","location","npc","faction","deity","item"]);
-  const GAMEPLAY = new Set(["event","quest"]);
-  const catOf = t => LORE.has(t) ? "lore" : (GAMEPLAY.has(t) ? "gameplay" : "mechanics");
+  const LORE = new Set([
+    "creature",
+    "spell",
+    "location",
+    "npc",
+    "faction",
+    "deity",
+    "item",
+  ]);
+  const GAMEPLAY = new Set(["event", "quest"]);
+  const catOf = (t) =>
+    LORE.has(t) ? "lore" : GAMEPLAY.has(t) ? "gameplay" : "mechanics";
   const EX_TYPES = {
-    location: "--t-location", creature: "--t-creature", npc: "--t-npc", faction: "--t-faction",
-    deity: "--t-deity", item: "--t-item", spell: "--t-spell", event: "--t-event", quest: "--t-quest", class: "--t-class",
+    location: "--t-location",
+    creature: "--t-creature",
+    npc: "--t-npc",
+    faction: "--t-faction",
+    deity: "--t-deity",
+    item: "--t-item",
+    spell: "--t-spell",
+    event: "--t-event",
+    quest: "--t-quest",
+    class: "--t-class",
   };
-  const EX_TYPE_LABEL = { location:"Location", creature:"Creature", npc:"NPC", faction:"Faction", deity:"Deity", item:"Item", spell:"Spell", event:"Event", quest:"Quest", class:"Class" };
+  const EX_TYPE_LABEL = {
+    location: "Location",
+    creature: "Creature",
+    npc: "NPC",
+    faction: "Faction",
+    deity: "Deity",
+    item: "Item",
+    spell: "Spell",
+    event: "Event",
+    quest: "Quest",
+    class: "Class",
+  };
   // adv: which adventure roster the node belongs to ("*" = shared core content)
-  const EX_N = (id,type,name,summary,adv,temp)=>({id,type,name,summary,adv,temp:temp||null,cat:catOf(type)});
+  const EX_N = (id, type, name, summary, adv, temp) => ({
+    id,
+    type,
+    name,
+    summary,
+    adv,
+    temp: temp || null,
+    cat: catOf(type),
+  });
   const EX_NODES = [
     // -- Curse of Strahd --
-    EX_N("strahd","npc","Strahd von Zarovich","The vampire lord of Barovia.","cos"),
-    EX_N("ireena","npc","Ireena Kolyana","A Barovian noblewoman, the reincarnation of Strahd's lost love.","cos"),
-    EX_N("ravenloft","location","Castle Ravenloft","A fortress of black stone, seat of Strahd's power.","cos"),
-    EX_N("barovia","location","Barovia","A mist-shrouded domain of the Shadowfell.","cos"),
-    EX_N("vampspawn","creature","Vampire Spawn","Lesser undead bound to Strahd's will.","cos"),
-    EX_N("ravenqueen","deity","The Raven Queen","Goddess of death and fate.","cos"),
-    EX_N("sunblade","item","Sun Blade","A radiant blade of sunlight, anathema to the undead.","cos"),
-    EX_N("ev_tatyana","event","Death of Tatyana","Strahd's beloved fell from the walls of Ravenloft, ages past.","cos","historical"),
-    EX_N("ev_ascension","event","Strahd's Ascension","Strahd struck a pact with death and became the first vampire.","cos","historical"),
-    EX_N("ev_arrival","event","The Party Enters Barovia","The mists draw a new group of heroes into the valley.","cos","present"),
-    EX_N("q_ireena","quest","Escort Ireena to Safety","Keep Ireena beyond Strahd's reach.","cos","present"),
-    EX_N("q_tome","quest","Recover the Tome of Strahd","Find the vampire's own history to learn his weaknesses.","cos","present"),
+    EX_N(
+      "strahd",
+      "npc",
+      "Strahd von Zarovich",
+      "The vampire lord of Barovia.",
+      "cos",
+    ),
+    EX_N(
+      "ireena",
+      "npc",
+      "Ireena Kolyana",
+      "A Barovian noblewoman, the reincarnation of Strahd's lost love.",
+      "cos",
+    ),
+    EX_N(
+      "ravenloft",
+      "location",
+      "Castle Ravenloft",
+      "A fortress of black stone, seat of Strahd's power.",
+      "cos",
+    ),
+    EX_N(
+      "barovia",
+      "location",
+      "Barovia",
+      "A mist-shrouded domain of the Shadowfell.",
+      "cos",
+    ),
+    EX_N(
+      "vampspawn",
+      "creature",
+      "Vampire Spawn",
+      "Lesser undead bound to Strahd's will.",
+      "cos",
+    ),
+    EX_N(
+      "ravenqueen",
+      "deity",
+      "The Raven Queen",
+      "Goddess of death and fate.",
+      "cos",
+    ),
+    EX_N(
+      "sunblade",
+      "item",
+      "Sun Blade",
+      "A radiant blade of sunlight, anathema to the undead.",
+      "cos",
+    ),
+    EX_N(
+      "ev_tatyana",
+      "event",
+      "Death of Tatyana",
+      "Strahd's beloved fell from the walls of Ravenloft, ages past.",
+      "cos",
+      "historical",
+    ),
+    EX_N(
+      "ev_ascension",
+      "event",
+      "Strahd's Ascension",
+      "Strahd struck a pact with death and became the first vampire.",
+      "cos",
+      "historical",
+    ),
+    EX_N(
+      "ev_arrival",
+      "event",
+      "The Party Enters Barovia",
+      "The mists draw a new group of heroes into the valley.",
+      "cos",
+      "present",
+    ),
+    EX_N(
+      "q_ireena",
+      "quest",
+      "Escort Ireena to Safety",
+      "Keep Ireena beyond Strahd's reach.",
+      "cos",
+      "present",
+    ),
+    EX_N(
+      "q_tome",
+      "quest",
+      "Recover the Tome of Strahd",
+      "Find the vampire's own history to learn his weaknesses.",
+      "cos",
+      "present",
+    ),
     // -- Lost Mine of Phandelver --
-    EX_N("gundren","npc","Gundren Rockseeker","A dwarf who rediscovered the lost Wave Echo Cave.","lmop"),
-    EX_N("nezznar","npc","Nezznar the Black Spider","A drow mastermind seeking the Forge of Spells.","lmop"),
-    EX_N("klarg","creature","Klarg","A bugbear chief of the Cragmaw goblins.","lmop"),
-    EX_N("cragmaw","faction","Cragmaw Tribe","Goblins in the pay of the Black Spider.","lmop"),
-    EX_N("redbrands","faction","Redbrands","Ruffians terrorizing the town of Phandalin.","lmop"),
-    EX_N("phandalin","location","Phandalin","A frontier town on the Sword Coast.","lmop"),
-    EX_N("waveecho","location","Wave Echo Cave","A lost mine housing the Forge of Spells.","lmop"),
-    EX_N("ev_ambush","event","Goblin Ambush","Cragmaw goblins waylay the party on the Triboar Trail.","lmop","present"),
-    EX_N("ev_pact","event","The Phandelver Pact","The ancient alliance that forged the magic of Wave Echo Cave.","lmop","historical"),
-    EX_N("q_findgundren","quest","Find Gundren Rockseeker","Track down the captured dwarf.","lmop","present"),
+    EX_N(
+      "gundren",
+      "npc",
+      "Gundren Rockseeker",
+      "A dwarf who rediscovered the lost Wave Echo Cave.",
+      "lmop",
+    ),
+    EX_N(
+      "nezznar",
+      "npc",
+      "Nezznar the Black Spider",
+      "A drow mastermind seeking the Forge of Spells.",
+      "lmop",
+    ),
+    EX_N(
+      "klarg",
+      "creature",
+      "Klarg",
+      "A bugbear chief of the Cragmaw goblins.",
+      "lmop",
+    ),
+    EX_N(
+      "cragmaw",
+      "faction",
+      "Cragmaw Tribe",
+      "Goblins in the pay of the Black Spider.",
+      "lmop",
+    ),
+    EX_N(
+      "redbrands",
+      "faction",
+      "Redbrands",
+      "Ruffians terrorizing the town of Phandalin.",
+      "lmop",
+    ),
+    EX_N(
+      "phandalin",
+      "location",
+      "Phandalin",
+      "A frontier town on the Sword Coast.",
+      "lmop",
+    ),
+    EX_N(
+      "waveecho",
+      "location",
+      "Wave Echo Cave",
+      "A lost mine housing the Forge of Spells.",
+      "lmop",
+    ),
+    EX_N(
+      "ev_ambush",
+      "event",
+      "Goblin Ambush",
+      "Cragmaw goblins waylay the party on the Triboar Trail.",
+      "lmop",
+      "present",
+    ),
+    EX_N(
+      "ev_pact",
+      "event",
+      "The Phandelver Pact",
+      "The ancient alliance that forged the magic of Wave Echo Cave.",
+      "lmop",
+      "historical",
+    ),
+    EX_N(
+      "q_findgundren",
+      "quest",
+      "Find Gundren Rockseeker",
+      "Track down the captured dwarf.",
+      "lmop",
+      "present",
+    ),
     // -- Shared core content (appears in every adventure's roster) --
-    EX_N("fireball","spell","Fireball","A streak of flame that blossoms into an explosion.","*"),
-    EX_N("counterspell","spell","Counterspell","Interrupts a creature in the act of casting.","*"),
-    EX_N("wizard","class","Wizard","A scholarly magic-user wielding arcane spells.","*"),
+    EX_N(
+      "fireball",
+      "spell",
+      "Fireball",
+      "A streak of flame that blossoms into an explosion.",
+      "*",
+    ),
+    EX_N(
+      "counterspell",
+      "spell",
+      "Counterspell",
+      "Interrupts a creature in the act of casting.",
+      "*",
+    ),
+    EX_N(
+      "wizard",
+      "class",
+      "Wizard",
+      "A scholarly magic-user wielding arcane spells.",
+      "*",
+    ),
   ];
-  const EX_E = (a,b,r)=>({a,b,r});
+  const EX_E = (a, b, r) => ({ a, b, r });
   const EX_EDGES = [
     // CoS lore
-    EX_E("strahd","ravenloft","LOCATED_IN"), EX_E("ravenloft","barovia","LOCATED_IN"),
-    EX_E("strahd","ireena","RELATED_TO"), EX_E("vampspawn","strahd","SERVES"),
-    EX_E("ireena","sunblade","WIELDS"), EX_E("ravenqueen","barovia","RELATED_TO"),
-    EX_E("strahd","fireball","CASTS"),
+    EX_E("strahd", "ravenloft", "LOCATED_IN"),
+    EX_E("ravenloft", "barovia", "LOCATED_IN"),
+    EX_E("strahd", "ireena", "RELATED_TO"),
+    EX_E("vampspawn", "strahd", "SERVES"),
+    EX_E("ireena", "sunblade", "WIELDS"),
+    EX_E("ravenqueen", "barovia", "RELATED_TO"),
+    EX_E("strahd", "fireball", "CASTS"),
     // CoS events + quests (these edges reach into lore -> the cross-category joins)
-    EX_E("ev_tatyana","ev_ascension","PRECEDED"), EX_E("ev_ascension","ev_arrival","PRECEDED"),
-    EX_E("ev_ascension","strahd","INVOLVED"), EX_E("ev_ascension","ravenloft","OCCURRED_AT"),
-    EX_E("ev_tatyana","ireena","INVOLVED"), EX_E("q_ireena","ireena","GIVEN_BY"),
-    EX_E("q_ireena","barovia","OBJECTIVE_AT"), EX_E("q_tome","ravenloft","OBJECTIVE_AT"),
-    EX_E("q_tome","sunblade","REWARDS"), EX_E("ev_arrival","q_ireena","ADVANCES"),
+    EX_E("ev_tatyana", "ev_ascension", "PRECEDED"),
+    EX_E("ev_ascension", "ev_arrival", "PRECEDED"),
+    EX_E("ev_ascension", "strahd", "INVOLVED"),
+    EX_E("ev_ascension", "ravenloft", "OCCURRED_AT"),
+    EX_E("ev_tatyana", "ireena", "INVOLVED"),
+    EX_E("q_ireena", "ireena", "GIVEN_BY"),
+    EX_E("q_ireena", "barovia", "OBJECTIVE_AT"),
+    EX_E("q_tome", "ravenloft", "OBJECTIVE_AT"),
+    EX_E("q_tome", "sunblade", "REWARDS"),
+    EX_E("ev_arrival", "q_ireena", "ADVANCES"),
     // LMoP
-    EX_E("gundren","phandalin","LOCATED_IN"), EX_E("klarg","cragmaw","MEMBER_OF"),
-    EX_E("nezznar","cragmaw","ALLY_OF"), EX_E("nezznar","gundren","ENEMY_OF"),
-    EX_E("redbrands","phandalin","LOCATED_IN"), EX_E("gundren","waveecho","RELATED_TO"),
-    EX_E("nezznar","fireball","CASTS"), EX_E("ev_ambush","klarg","INVOLVED"),
-    EX_E("ev_ambush","gundren","INVOLVED"), EX_E("ev_pact","waveecho","OCCURRED_AT"),
-    EX_E("q_findgundren","cragmaw","OBJECTIVE_AT"),
+    EX_E("gundren", "phandalin", "LOCATED_IN"),
+    EX_E("klarg", "cragmaw", "MEMBER_OF"),
+    EX_E("nezznar", "cragmaw", "ALLY_OF"),
+    EX_E("nezznar", "gundren", "ENEMY_OF"),
+    EX_E("redbrands", "phandalin", "LOCATED_IN"),
+    EX_E("gundren", "waveecho", "RELATED_TO"),
+    EX_E("nezznar", "fireball", "CASTS"),
+    EX_E("ev_ambush", "klarg", "INVOLVED"),
+    EX_E("ev_ambush", "gundren", "INVOLVED"),
+    EX_E("ev_pact", "waveecho", "OCCURRED_AT"),
+    EX_E("q_findgundren", "cragmaw", "OBJECTIVE_AT"),
     // shared mechanics/spells
-    EX_E("fireball","counterspell","COUNTERED_BY"),
+    EX_E("fireball", "counterspell", "COUNTERED_BY"),
   ];
-  const EX_BY = {}; EX_NODES.forEach(n => { EX_BY[n.id] = n; n.deg = 0; });
-  EX_EDGES.forEach(e => { EX_BY[e.a].deg++; EX_BY[e.b].deg++; });
-  const EX_ADJ = {}; EX_NODES.forEach(n => EX_ADJ[n.id] = []);
-  EX_EDGES.forEach(e => { EX_ADJ[e.a].push(e); EX_ADJ[e.b].push(e); });
+  const EX_BY = {};
+  EX_NODES.forEach((n) => {
+    EX_BY[n.id] = n;
+    n.deg = 0;
+  });
+  EX_EDGES.forEach((e) => {
+    EX_BY[e.a].deg++;
+    EX_BY[e.b].deg++;
+  });
+  const EX_ADJ = {};
+  EX_NODES.forEach((n) => (EX_ADJ[n.id] = []));
+  EX_EDGES.forEach((e) => {
+    EX_ADJ[e.a].push(e);
+    EX_ADJ[e.b].push(e);
+  });
 
   // ---- scope x lens state + filtering (the actual demonstration) ----
-  let exScope = "cos", exLens = "world";
-  const exGuests = new Set();   // nodes pulled in by following a cross-lens edge
-  let VIS = [], VE = [];
-  function inScope(n) { return exScope === "everything" || n.adv === exScope || n.adv === "*"; }
+  let exScope = "cos",
+    exLens = "world";
+  const exGuests = new Set(); // nodes pulled in by following a cross-lens edge
+  let VIS = [],
+    VE = [];
+  function inScope(n) {
+    return exScope === "everything" || n.adv === exScope || n.adv === "*";
+  }
   function inLens(n) {
-    if (exLens === "world") return n.cat === "lore" || ((n.type === "event" || n.type === "quest") && n.temp === "historical");
+    if (exLens === "world")
+      return (
+        n.cat === "lore" ||
+        ((n.type === "event" || n.type === "quest") && n.temp === "historical")
+      );
     if (exLens === "story") return n.type === "event";
     if (exLens === "quests") return n.type === "quest";
     if (exLens === "rules") return n.cat === "mechanics" || n.type === "spell";
     return true;
   }
   function computeVisible() {
-    const ok = new Set(EX_NODES.filter(n => (inScope(n) && inLens(n)) || exGuests.has(n.id)).map(n => n.id));
-    VIS = EX_NODES.filter(n => ok.has(n.id));
-    VE = EX_EDGES.filter(e => ok.has(e.a) && ok.has(e.b));
+    const ok = new Set(
+      EX_NODES.filter(
+        (n) => (inScope(n) && inLens(n)) || exGuests.has(n.id),
+      ).map((n) => n.id),
+    );
+    VIS = EX_NODES.filter((n) => ok.has(n.id));
+    VE = EX_EDGES.filter((e) => ok.has(e.a) && ok.has(e.b));
     VIS.forEach((n, i) => {
       if (n.x === undefined) {
-        const a = (i / VIS.length) * Math.PI * 2, r = 108 + (i % 4) * 34;
-        n.x = Math.cos(a) * r; n.y = Math.sin(a) * r; n.vx = 0; n.vy = 0;
+        const a = (i / VIS.length) * Math.PI * 2,
+          r = 108 + (i % 4) * 34;
+        n.x = Math.cos(a) * r;
+        n.y = Math.sin(a) * r;
+        n.vx = 0;
+        n.vy = 0;
       }
     });
     exEnergy = 1;
     buildLegend();
   }
   function buildLegend() {
-    const el = document.getElementById('exLegend');
+    const el = document.getElementById("exLegend");
     if (!el) return;
-    const present = [...new Set(VIS.map(n => n.type))].filter(t => EX_TYPE_LABEL[t]);
+    const present = [...new Set(VIS.map((n) => n.type))].filter(
+      (t) => EX_TYPE_LABEL[t],
+    );
     el.innerHTML = present.length
-      ? present.map(t => `<div class="row"><span class="sw" style="background:${COL[t] || `var(${EX_TYPES[t]})`}"></span>${EX_TYPE_LABEL[t]}</div>`).join('')
+      ? present
+          .map(
+            (t) =>
+              `<div class="row"><span class="sw" style="background:${COL[t] || `var(${EX_TYPES[t]})`}"></span>${EX_TYPE_LABEL[t]}</div>`,
+          )
+          .join("")
       : '<div class="row" style="color:var(--faint)">no entities in this view</div>';
   }
 
-  let exInited = false, exCanvas, exCtx, exW, exH, exDPR, exFocus = null, exHover = null;
-  let exView = { x: 0, y: 0, k: 1 }, exEnergy = 1;
+  let exInited = false,
+    exCanvas,
+    exCtx,
+    exW,
+    exH,
+    exDPR,
+    exFocus = null,
+    exHover = null;
+  let exView = { x: 0, y: 0, k: 1 },
+    exEnergy = 1;
   let COL = {};
-  function cssVar(n) { return getComputedStyle(document.body).getPropertyValue(n).trim(); }
+  function cssVar(n) {
+    return getComputedStyle(document.body).getPropertyValue(n).trim();
+  }
   function refreshExColors() {
-    COL = { paper: cssVar('--paper'), line: cssVar('--line'), text: cssVar('--text'),
-            dim: cssVar('--dim'), faint: cssVar('--faint'), accent: cssVar('--accent'),
-            surface: cssVar('--surface') };
+    COL = {
+      paper: cssVar("--paper"),
+      line: cssVar("--line"),
+      text: cssVar("--text"),
+      dim: cssVar("--dim"),
+      faint: cssVar("--faint"),
+      accent: cssVar("--accent"),
+      surface: cssVar("--surface"),
+    };
     for (const t in EX_TYPES) COL[t] = cssVar(EX_TYPES[t]);
     buildLegend();
   }
   function exResize() {
     exDPR = Math.min(window.devicePixelRatio || 1, 2);
-    exW = exCanvas.clientWidth; exH = exCanvas.clientHeight;
-    exCanvas.width = exW * exDPR; exCanvas.height = exH * exDPR;
+    exW = exCanvas.clientWidth;
+    exH = exCanvas.clientHeight;
+    exCanvas.width = exW * exDPR;
+    exCanvas.height = exH * exDPR;
   }
-  function exToScreen(n) { return { x: n.x * exView.k + exView.x, y: n.y * exView.k + exView.y }; }
-  function exRadius(n) { return (6 + Math.min(n.deg, 7) * 1.6) * Math.sqrt(exView.k); }
+  function exToScreen(n) {
+    return { x: n.x * exView.k + exView.x, y: n.y * exView.k + exView.y };
+  }
+  function exRadius(n) {
+    return (6 + Math.min(n.deg, 7) * 1.6) * Math.sqrt(exView.k);
+  }
 
   function exTick() {
     for (let i = 0; i < VIS.length; i++) {
       const a = VIS[i];
       for (let j = i + 1; j < VIS.length; j++) {
         const b = VIS[j];
-        let dx = a.x - b.x, dy = a.y - b.y, d2 = dx*dx + dy*dy || 0.01;
-        const f = 6200 / d2, d = Math.sqrt(d2), fx = (dx/d)*f, fy = (dy/d)*f;
-        a.vx += fx; a.vy += fy; b.vx -= fx; b.vy -= fy;
+        let dx = a.x - b.x,
+          dy = a.y - b.y,
+          d2 = dx * dx + dy * dy || 0.01;
+        const f = 6200 / d2,
+          d = Math.sqrt(d2),
+          fx = (dx / d) * f,
+          fy = (dy / d) * f;
+        a.vx += fx;
+        a.vy += fy;
+        b.vx -= fx;
+        b.vy -= fy;
       }
     }
-    VE.forEach(e => {
-      const a = EX_BY[e.a], b = EX_BY[e.b];
-      let dx = b.x - a.x, dy = b.y - a.y, d = Math.sqrt(dx*dx + dy*dy) || 0.01;
-      const f = (d - 104) * 0.03, fx = (dx/d)*f, fy = (dy/d)*f;
-      a.vx += fx; a.vy += fy; b.vx -= fx; b.vy -= fy;
+    VE.forEach((e) => {
+      const a = EX_BY[e.a],
+        b = EX_BY[e.b];
+      let dx = b.x - a.x,
+        dy = b.y - a.y,
+        d = Math.sqrt(dx * dx + dy * dy) || 0.01;
+      const f = (d - 104) * 0.03,
+        fx = (dx / d) * f,
+        fy = (dy / d) * f;
+      a.vx += fx;
+      a.vy += fy;
+      b.vx -= fx;
+      b.vy -= fy;
     });
-    VIS.forEach(n => {
-      n.vx += -n.x * 0.0018; n.vy += -n.y * 0.0018;
-      n.vx *= 0.86; n.vy *= 0.86; n.x += n.vx * exEnergy; n.y += n.vy * exEnergy;
+    VIS.forEach((n) => {
+      n.vx += -n.x * 0.0018;
+      n.vy += -n.y * 0.0018;
+      n.vx *= 0.86;
+      n.vy *= 0.86;
+      n.x += n.vx * exEnergy;
+      n.y += n.vy * exEnergy;
     });
-    exEnergy *= 0.992; if (exEnergy < 0) exEnergy = 0;
+    exEnergy *= 0.992;
+    if (exEnergy < 0) exEnergy = 0;
   }
 
   function exDraw() {
     exCtx.setTransform(exDPR, 0, 0, exDPR, 0, 0);
     exCtx.clearRect(0, 0, exW, exH);
-    const focusAdj = exFocus ? new Set(VE.filter(e => e.a === exFocus || e.b === exFocus).map(e => e.a === exFocus ? e.b : e.a)) : null;
+    const focusAdj = exFocus
+      ? new Set(
+          VE.filter((e) => e.a === exFocus || e.b === exFocus).map((e) =>
+            e.a === exFocus ? e.b : e.a,
+          ),
+        )
+      : null;
     // edges (quiet; incident-to-focus in accent)
-    VE.forEach(e => {
-      const a = exToScreen(EX_BY[e.a]), b = exToScreen(EX_BY[e.b]);
+    VE.forEach((e) => {
+      const a = exToScreen(EX_BY[e.a]),
+        b = exToScreen(EX_BY[e.b]);
       const incident = exFocus && (e.a === exFocus || e.b === exFocus);
       exCtx.strokeStyle = incident ? COL.accent : COL.line;
       exCtx.globalAlpha = exFocus ? (incident ? 0.9 : 0.35) : 0.7;
       exCtx.lineWidth = incident ? 1.8 : 1;
-      exCtx.beginPath(); exCtx.moveTo(a.x, a.y); exCtx.lineTo(b.x, b.y); exCtx.stroke();
+      exCtx.beginPath();
+      exCtx.moveTo(a.x, a.y);
+      exCtx.lineTo(b.x, b.y);
+      exCtx.stroke();
     });
     exCtx.globalAlpha = 1;
     // nodes
-    VIS.forEach(n => {
-      const p = exToScreen(n), r = exRadius(n), c = COL[n.type];
+    VIS.forEach((n) => {
+      const p = exToScreen(n),
+        r = exRadius(n),
+        c = COL[n.type];
       const dim = exFocus && n.id !== exFocus && !focusAdj.has(n.id);
       exCtx.globalAlpha = dim ? 0.32 : 1;
-      exCtx.shadowColor = 'rgba(20,30,50,0.25)'; exCtx.shadowBlur = dim ? 0 : 6; exCtx.shadowOffsetY = dim ? 0 : 1;
-      exCtx.fillStyle = c; exCtx.beginPath(); exCtx.arc(p.x, p.y, r, 0, 7); exCtx.fill();
-      exCtx.shadowBlur = 0; exCtx.shadowOffsetY = 0;
-      exCtx.lineWidth = 1.6; exCtx.strokeStyle = COL.paper;
-      exCtx.beginPath(); exCtx.arc(p.x, p.y, r, 0, 7); exCtx.stroke();
-      if (n.id === exFocus) { exCtx.globalAlpha = 1; exCtx.strokeStyle = COL.accent; exCtx.lineWidth = 2.5; exCtx.beginPath(); exCtx.arc(p.x, p.y, r + 5, 0, 7); exCtx.stroke(); }
-      else if (n.id === exHover) { exCtx.globalAlpha = 0.85; exCtx.strokeStyle = COL.text; exCtx.lineWidth = 1.5; exCtx.beginPath(); exCtx.arc(p.x, p.y, r + 4, 0, 7); exCtx.stroke(); }
+      exCtx.shadowColor = "rgba(20,30,50,0.25)";
+      exCtx.shadowBlur = dim ? 0 : 6;
+      exCtx.shadowOffsetY = dim ? 0 : 1;
+      exCtx.fillStyle = c;
+      exCtx.beginPath();
+      exCtx.arc(p.x, p.y, r, 0, 7);
+      exCtx.fill();
+      exCtx.shadowBlur = 0;
+      exCtx.shadowOffsetY = 0;
+      exCtx.lineWidth = 1.6;
+      exCtx.strokeStyle = COL.paper;
+      exCtx.beginPath();
+      exCtx.arc(p.x, p.y, r, 0, 7);
+      exCtx.stroke();
+      if (n.id === exFocus) {
+        exCtx.globalAlpha = 1;
+        exCtx.strokeStyle = COL.accent;
+        exCtx.lineWidth = 2.5;
+        exCtx.beginPath();
+        exCtx.arc(p.x, p.y, r + 5, 0, 7);
+        exCtx.stroke();
+      } else if (n.id === exHover) {
+        exCtx.globalAlpha = 0.85;
+        exCtx.strokeStyle = COL.text;
+        exCtx.lineWidth = 1.5;
+        exCtx.beginPath();
+        exCtx.arc(p.x, p.y, r + 4, 0, 7);
+        exCtx.stroke();
+      }
       // guest (pulled in from another lens/scope): dashed accent ring
-      if (exGuests.has(n.id) && n.id !== exFocus) { exCtx.globalAlpha = 0.9; exCtx.setLineDash([3, 3]); exCtx.strokeStyle = COL.accent; exCtx.lineWidth = 1.5; exCtx.beginPath(); exCtx.arc(p.x, p.y, r + 4, 0, 7); exCtx.stroke(); exCtx.setLineDash([]); }
+      if (exGuests.has(n.id) && n.id !== exFocus) {
+        exCtx.globalAlpha = 0.9;
+        exCtx.setLineDash([3, 3]);
+        exCtx.strokeStyle = COL.accent;
+        exCtx.lineWidth = 1.5;
+        exCtx.beginPath();
+        exCtx.arc(p.x, p.y, r + 4, 0, 7);
+        exCtx.stroke();
+        exCtx.setLineDash([]);
+      }
     });
     // labels (all, for readability)
-    exCtx.globalAlpha = 1; exCtx.textAlign = 'center'; exCtx.textBaseline = 'top';
-    VIS.forEach(n => {
-      const p = exToScreen(n), r = exRadius(n);
-      const isF = n.id === exFocus, isN = focusAdj && focusAdj.has(n.id);
+    exCtx.globalAlpha = 1;
+    exCtx.textAlign = "center";
+    exCtx.textBaseline = "top";
+    VIS.forEach((n) => {
+      const p = exToScreen(n),
+        r = exRadius(n);
+      const isF = n.id === exFocus,
+        isN = focusAdj && focusAdj.has(n.id);
       const dim = exFocus && !isF && !isN;
-      exCtx.font = (isF ? '600 14px ' : '13px ') + '"Iowan Old Style", Palatino, Georgia, serif';
+      exCtx.font =
+        (isF ? "600 14px " : "13px ") +
+        '"Iowan Old Style", Palatino, Georgia, serif';
       const ty = p.y + r + 5;
-      exCtx.lineWidth = 3.5; exCtx.strokeStyle = COL.paper;
+      exCtx.lineWidth = 3.5;
+      exCtx.strokeStyle = COL.paper;
       exCtx.strokeText(n.name, p.x, ty);
-      exCtx.fillStyle = dim ? COL.faint : (isF ? COL.text : COL.dim);
+      exCtx.fillStyle = dim ? COL.faint : isF ? COL.text : COL.dim;
       exCtx.fillText(n.name, p.x, ty);
     });
   }
-  function exLoop() { if (exEnergy > 0.001) exTick(); if (exInited) { exDraw(); requestAnimationFrame(exLoop); } }
+  function exLoop() {
+    if (exEnergy > 0.001) exTick();
+    if (exInited) {
+      exDraw();
+      requestAnimationFrame(exLoop);
+    }
+  }
 
   function exHit(mx, my) {
     for (let i = VIS.length - 1; i >= 0; i--) {
-      const n = VIS[i], p = exToScreen(n), r = exRadius(n) + 6;
+      const n = VIS[i],
+        p = exToScreen(n),
+        r = exRadius(n) + 6;
       if ((mx - p.x) ** 2 + (my - p.y) ** 2 <= r * r) return n.id;
     }
     return null;
   }
-  function exRelLabel(r) { return r.replace(/_/g, ' ').toLowerCase(); }
+  function exRelLabel(r) {
+    return r.replace(/_/g, " ").toLowerCase();
+  }
   function exSelect(id) {
     exFocus = id;
     const n = EX_BY[id];
-    const rels = EX_ADJ[id].map(e => {
-      const out = e.a === id, peer = EX_BY[out ? e.b : e.a];
-      return { r: e.r, peer, sym: ["RELATED_TO","ALLY_OF","ENEMY_OF","NEAR"].includes(e.r), out };
+    const rels = EX_ADJ[id].map((e) => {
+      const out = e.a === id,
+        peer = EX_BY[out ? e.b : e.a];
+      return {
+        r: e.r,
+        peer,
+        sym: ["RELATED_TO", "ALLY_OF", "ENEMY_OF", "NEAR"].includes(e.r),
+        out,
+      };
     });
-    document.getElementById('cxBody').innerHTML = `
+    document.getElementById("cxBody").innerHTML = `
       <div class="cx-type"><span class="sw" style="background:${COL[n.type]}"></span>${EX_TYPE_LABEL[n.type]}</div>
       <h2>${n.name}</h2>
       <div class="cx-sum">${n.summary}</div>
       <div class="cx-h">Relationships &middot; ${rels.length}</div>
-      ${rels.map(x => `<div class="cx-rel" data-go="${x.peer.id}">
-        <span class="v">${x.sym ? '&harr;' : (x.out ? '&rarr;' : '&larr;')} ${exRelLabel(x.r)}</span>
+      ${rels
+        .map(
+          (x) => `<div class="cx-rel" data-go="${x.peer.id}">
+        <span class="v">${x.sym ? "&harr;" : x.out ? "&rarr;" : "&larr;"} ${exRelLabel(x.r)}</span>
         <span class="sw" style="background:${COL[x.peer.type]}"></span>
-        <span class="p">${x.peer.name}</span></div>`).join('')}`;
-    document.getElementById('exCodex').classList.add('open');
-    document.querySelectorAll('#cxBody [data-go]').forEach(el => el.addEventListener('click', () => {
-      const pid = el.dataset.go;
-      // following an edge to a node outside the current lens/scope pulls it in as a guest
-      if (!VIS.some(v => v.id === pid)) { exGuests.add(pid); computeVisible(); }
-      exSelect(pid);
-    }));
+        <span class="p">${x.peer.name}</span></div>`,
+        )
+        .join("")}`;
+    document.getElementById("exCodex").classList.add("open");
+    document.querySelectorAll("#cxBody [data-go]").forEach((el) =>
+      el.addEventListener("click", () => {
+        const pid = el.dataset.go;
+        // following an edge to a node outside the current lens/scope pulls it in as a guest
+        if (!VIS.some((v) => v.id === pid)) {
+          exGuests.add(pid);
+          computeVisible();
+        }
+        exSelect(pid);
+      }),
+    );
   }
 
   function initExplore() {
-    if (exInited) { exResize(); return; }
+    if (exInited) {
+      exResize();
+      return;
+    }
     exInited = true;
-    exCanvas = document.getElementById('exCanvas');
-    exCtx = exCanvas.getContext('2d');
-    exResize(); refreshExColors(); computeVisible();
-    exView.x = exW / 2; exView.y = exH / 2;
-    let down = null, moved = false;
-    exCanvas.addEventListener('mousedown', e => { down = { x: e.clientX, y: e.clientY, vx: exView.x, vy: exView.y }; moved = false; exCanvas.classList.add('drag'); });
-    window.addEventListener('mouseup', e => {
-      exCanvas.classList.remove('drag');
+    exCanvas = document.getElementById("exCanvas");
+    exCtx = exCanvas.getContext("2d");
+    exResize();
+    refreshExColors();
+    computeVisible();
+    exView.x = exW / 2;
+    exView.y = exH / 2;
+    let down = null,
+      moved = false;
+    exCanvas.addEventListener("mousedown", (e) => {
+      down = { x: e.clientX, y: e.clientY, vx: exView.x, vy: exView.y };
+      moved = false;
+      exCanvas.classList.add("drag");
+    });
+    window.addEventListener("mouseup", (e) => {
+      exCanvas.classList.remove("drag");
       if (down && !moved) {
         const rect = exCanvas.getBoundingClientRect();
         const id = exHit(e.clientX - rect.left, e.clientY - rect.top);
-        if (id) exSelect(id); else { exFocus = null; document.getElementById('exCodex').classList.remove('open'); }
+        if (id) exSelect(id);
+        else {
+          exFocus = null;
+          document.getElementById("exCodex").classList.remove("open");
+        }
       }
       down = null;
     });
-    window.addEventListener('mousemove', e => {
+    window.addEventListener("mousemove", (e) => {
       const rect = exCanvas.getBoundingClientRect();
       if (down) {
-        const dx = e.clientX - down.x, dy = e.clientY - down.y;
+        const dx = e.clientX - down.x,
+          dy = e.clientY - down.y;
         if (Math.abs(dx) + Math.abs(dy) > 4) moved = true;
-        exView.x = down.vx + dx; exView.y = down.vy + dy;
+        exView.x = down.vx + dx;
+        exView.y = down.vy + dy;
       } else {
         const h = exHit(e.clientX - rect.left, e.clientY - rect.top);
-        if (h !== exHover) { exHover = h; exCanvas.style.cursor = h ? 'pointer' : 'grab'; }
+        if (h !== exHover) {
+          exHover = h;
+          exCanvas.style.cursor = h ? "pointer" : "grab";
+        }
       }
     });
-    exCanvas.addEventListener('wheel', e => {
-      e.preventDefault();
-      const rect = exCanvas.getBoundingClientRect(), mx = e.clientX - rect.left, my = e.clientY - rect.top;
-      const wx = (mx - exView.x) / exView.k, wy = (my - exView.y) / exView.k;
-      const k2 = Math.max(0.4, Math.min(3, exView.k * (e.deltaY < 0 ? 1.12 : 0.89)));
-      exView.k = k2; exView.x = mx - wx * k2; exView.y = my - wy * k2;
-    }, { passive: false });
-    document.getElementById('cxClose').addEventListener('click', () => { exFocus = null; document.getElementById('exCodex').classList.remove('open'); });
+    exCanvas.addEventListener(
+      "wheel",
+      (e) => {
+        e.preventDefault();
+        const rect = exCanvas.getBoundingClientRect(),
+          mx = e.clientX - rect.left,
+          my = e.clientY - rect.top;
+        const wx = (mx - exView.x) / exView.k,
+          wy = (my - exView.y) / exView.k;
+        const k2 = Math.max(
+          0.4,
+          Math.min(3, exView.k * (e.deltaY < 0 ? 1.12 : 0.89)),
+        );
+        exView.k = k2;
+        exView.x = mx - wx * k2;
+        exView.y = my - wy * k2;
+      },
+      { passive: false },
+    );
+    document.getElementById("cxClose").addEventListener("click", () => {
+      exFocus = null;
+      document.getElementById("exCodex").classList.remove("open");
+    });
     exLoop();
-    setTimeout(() => exSelect('strahd'), 350);
+    setTimeout(() => exSelect("strahd"), 350);
   }
 
-  document.querySelectorAll('[data-view="explore"]').forEach(el =>
-    el.addEventListener('click', () => setTimeout(initExplore, 30)));
-  document.getElementById('themeToggle').addEventListener('click', () => { if (exInited) refreshExColors(); });
+  document
+    .querySelectorAll('[data-view="explore"]')
+    .forEach((el) =>
+      el.addEventListener("click", () => setTimeout(initExplore, 30)),
+    );
+  document.getElementById("themeToggle").addEventListener("click", () => {
+    if (exInited) refreshExColors();
+  });
   // lens switch (functional: re-filters by category/temporality WITHIN the current scope)
-  document.querySelectorAll('#lensSwitch button').forEach(b =>
-    b.addEventListener('click', () => {
-      document.querySelectorAll('#lensSwitch button').forEach(x => x.classList.remove('on'));
-      b.classList.add('on');
-      exLens = b.dataset.lens; exGuests.clear();
-      if (exFocus && !(inScope(EX_BY[exFocus]) && inLens(EX_BY[exFocus]))) { exFocus = null; document.getElementById('exCodex').classList.remove('open'); }
+  document.querySelectorAll("#lensSwitch button").forEach((b) =>
+    b.addEventListener("click", () => {
+      document
+        .querySelectorAll("#lensSwitch button")
+        .forEach((x) => x.classList.remove("on"));
+      b.classList.add("on");
+      exLens = b.dataset.lens;
+      exGuests.clear();
+      if (exFocus && !(inScope(EX_BY[exFocus]) && inLens(EX_BY[exFocus]))) {
+        exFocus = null;
+        document.getElementById("exCodex").classList.remove("open");
+      }
       if (exInited) computeVisible();
-    }));
+    }),
+  );
   // scope selector (functional: intersects the adventure roster with the lens)
-  document.getElementById('scopeSel').addEventListener('change', e => {
-    exScope = e.target.value; exGuests.clear();
-    exFocus = null; document.getElementById('exCodex').classList.remove('open');
+  document.getElementById("scopeSel").addEventListener("change", (e) => {
+    exScope = e.target.value;
+    exGuests.clear();
+    exFocus = null;
+    document.getElementById("exCodex").classList.remove("open");
     if (exInited) computeVisible();
   });
 </script>

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.45
+version: 0.285.46
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260706190000_chat_messages_fts.sql
+++ b/projects/monolith/chart/migrations/20260706190000_chat_messages_fts.sql
@@ -1,0 +1,14 @@
+-- Hybrid history search: add a full-text search vector alongside the existing
+-- pgvector embedding so chat history recall can fuse semantic (vector) and
+-- lexical (keyword) matches. Vector search alone misses exact tokens a user
+-- asks for by name: a username, a URL, an error code, a rare proper noun.
+--
+-- content_tsv is a GENERATED STORED column so it is maintained automatically on
+-- every insert/update with no application bookkeeping. The GIN index makes the
+-- @@ / ts_rank lookups fast; queries stay channel-scoped via the existing
+-- channel indexes.
+ALTER TABLE chat.messages
+    ADD COLUMN content_tsv tsvector
+    GENERATED ALWAYS AS (to_tsvector('english', content)) STORED;
+
+CREATE INDEX chat_messages_content_tsv ON chat.messages USING gin (content_tsv);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:T4kKtWbe6PSVmIKwS+DJA0VxLG8b9Gjy0zEl4ml2BuM=
+h1:gk530omWG6RIDm2kWEnY8SR61NyHHY/Lxqlcb+57+ug=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -108,3 +108,4 @@ h1:T4kKtWbe6PSVmIKwS+DJA0VxLG8b9Gjy0zEl4ml2BuM=
 20260705170000_grimoire_adventure_seed.sql h1:Vl1WQ3RxunbWB/FmRTPGvehf0r21idknxokKIsEPZGY=
 20260706000000_grimoire_extraction_hardening.sql h1:R5hltTip79gwuh+mJqTAbN8IY9D2TR8jDA6qBlHZXBM=
 20260706010000_grimoire_table_type.sql h1:pw2njEe9GQobGDUWLSZgGtYH1khJqoRpxtll/uNzHuU=
+20260706190000_chat_messages_fts.sql h1:RGg6aFMSxA72kAjADloWTco0EZ9uulKyohTFkbAT/cU=

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -435,8 +435,9 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
             coerced = _coerce_username(username)
             if coerced:
                 user_id = deps.store.find_user_id_by_username(deps.channel_id, coerced)
-        results = deps.store.search_similar(
+        results = deps.store.search_hybrid(
             channel_id=deps.channel_id,
+            query_text=query,
             query_embedding=query_embedding,
             limit=min(limit, 20),
             user_id=user_id,

--- a/projects/monolith/chat/agent_helper_functions_test.py
+++ b/projects/monolith/chat/agent_helper_functions_test.py
@@ -522,7 +522,7 @@ class TestSearchHistoryQueryEmbedding:
         embed_client.embed.return_value = [0.1] * 1024
         store = MagicMock()
         store.find_user_id_by_username.return_value = None
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(store=store, embed_client=embed_client)
         await create_agent(base_url="http://fake:8080").run(
@@ -537,14 +537,14 @@ class TestSearchHistoryQueryEmbedding:
         embed_client.embed.assert_called_once_with("deployment logs")
 
     @pytest.mark.asyncio
-    async def test_passes_embedding_and_channel_to_search_similar(self):
-        """search_history forwards embedding and channel_id to store.search_similar."""
+    async def test_passes_embedding_and_channel_to_search_hybrid(self):
+        """search_history forwards embedding and channel_id to store.search_hybrid."""
         embedding = [0.7] * 1024
         embed_client = AsyncMock()
         embed_client.embed.return_value = embedding
         store = MagicMock()
         store.find_user_id_by_username.return_value = None
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(store=store, embed_client=embed_client, channel_id="chan-x")
         await create_agent(base_url="http://fake:8080").run(
@@ -555,9 +555,10 @@ class TestSearchHistoryQueryEmbedding:
             deps=deps,
         )
 
-        kw = store.search_similar.call_args.kwargs
+        kw = store.search_hybrid.call_args.kwargs
         assert kw["query_embedding"] == embedding
         assert kw["channel_id"] == "chan-x"
+        assert kw["query_text"] == "foo"
 
     @pytest.mark.asyncio
     async def test_no_results_returns_sentinel(self):
@@ -566,7 +567,7 @@ class TestSearchHistoryQueryEmbedding:
         embed_client.embed.return_value = [0.0] * 1024
         store = MagicMock()
         store.find_user_id_by_username.return_value = None
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         captured: list[str] = []
         deps = _make_deps(store=store, embed_client=embed_client)
@@ -588,7 +589,7 @@ class TestSearchHistoryUsernameCoercion:
         embed_client = AsyncMock()
         embed_client.embed.return_value = [0.0] * 1024
         store = MagicMock()
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(store=store, embed_client=embed_client)
         await create_agent(base_url="http://fake:8080").run(
@@ -608,7 +609,7 @@ class TestSearchHistoryUsernameCoercion:
         embed_client.embed.return_value = [0.0] * 1024
         store = MagicMock()
         store.find_user_id_by_username.return_value = "uid-alice"
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(store=store, embed_client=embed_client, channel_id="ch-t")
         await create_agent(base_url="http://fake:8080").run(
@@ -628,7 +629,7 @@ class TestSearchHistoryUsernameCoercion:
         embed_client.embed.return_value = [0.0] * 1024
         store = MagicMock()
         store.find_user_id_by_username.return_value = "uid-charlie"
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(store=store, embed_client=embed_client, channel_id="ch-dict")
         await create_agent(base_url="http://fake:8080").run(
@@ -652,7 +653,7 @@ class TestSearchHistoryUsernameCoercion:
         embed_client = AsyncMock()
         embed_client.embed.return_value = [0.0] * 1024
         store = MagicMock()
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(store=store, embed_client=embed_client)
         await create_agent(base_url="http://fake:8080").run(
@@ -665,7 +666,7 @@ class TestSearchHistoryUsernameCoercion:
         )
 
         store.find_user_id_by_username.assert_not_called()
-        assert store.search_similar.call_args.kwargs.get("user_id") is None
+        assert store.search_hybrid.call_args.kwargs.get("user_id") is None
 
     @pytest.mark.asyncio
     async def test_discord_user_id_mention_dict_used_directly(self):
@@ -673,7 +674,7 @@ class TestSearchHistoryUsernameCoercion:
         embed_client = AsyncMock()
         embed_client.embed.return_value = [0.0] * 1024
         store = MagicMock()
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(
             store=store, embed_client=embed_client, channel_id="ch-mention"
@@ -692,16 +693,16 @@ class TestSearchHistoryUsernameCoercion:
         )
 
         store.find_user_id_by_username.assert_not_called()
-        assert store.search_similar.call_args.kwargs["user_id"] == "1294788769672593501"
+        assert store.search_hybrid.call_args.kwargs["user_id"] == "1294788769672593501"
 
     @pytest.mark.asyncio
-    async def test_resolved_user_id_forwarded_to_search_similar(self):
-        """Resolved user_id from store lookup is passed to store.search_similar."""
+    async def test_resolved_user_id_forwarded_to_search_hybrid(self):
+        """Resolved user_id from store lookup is passed to store.search_hybrid."""
         embed_client = AsyncMock()
         embed_client.embed.return_value = [0.0] * 1024
         store = MagicMock()
         store.find_user_id_by_username.return_value = "uid-found"
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(store=store, embed_client=embed_client)
         await create_agent(base_url="http://fake:8080").run(
@@ -712,18 +713,18 @@ class TestSearchHistoryUsernameCoercion:
             deps=deps,
         )
 
-        assert store.search_similar.call_args.kwargs["user_id"] == "uid-found"
+        assert store.search_hybrid.call_args.kwargs["user_id"] == "uid-found"
 
 
 class TestSearchHistoryLimit:
     @pytest.mark.asyncio
     async def test_limit_above_20_is_clamped(self):
-        """A limit > 20 is clamped to 20 when calling store.search_similar."""
+        """A limit > 20 is clamped to 20 when calling store.search_hybrid."""
         embed_client = AsyncMock()
         embed_client.embed.return_value = [0.0] * 1024
         store = MagicMock()
         store.find_user_id_by_username.return_value = None
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(store=store, embed_client=embed_client)
         await create_agent(base_url="http://fake:8080").run(
@@ -734,7 +735,7 @@ class TestSearchHistoryLimit:
             deps=deps,
         )
 
-        assert store.search_similar.call_args.kwargs["limit"] == 20
+        assert store.search_hybrid.call_args.kwargs["limit"] == 20
 
     @pytest.mark.asyncio
     async def test_limit_exactly_20_not_capped_further(self):
@@ -743,7 +744,7 @@ class TestSearchHistoryLimit:
         embed_client.embed.return_value = [0.0] * 1024
         store = MagicMock()
         store.find_user_id_by_username.return_value = None
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(store=store, embed_client=embed_client)
         await create_agent(base_url="http://fake:8080").run(
@@ -754,16 +755,16 @@ class TestSearchHistoryLimit:
             deps=deps,
         )
 
-        assert store.search_similar.call_args.kwargs["limit"] == 20
+        assert store.search_hybrid.call_args.kwargs["limit"] == 20
 
     @pytest.mark.asyncio
     async def test_limit_below_20_passed_unchanged(self):
-        """A limit below 20 is passed as-is to store.search_similar."""
+        """A limit below 20 is passed as-is to store.search_hybrid."""
         embed_client = AsyncMock()
         embed_client.embed.return_value = [0.0] * 1024
         store = MagicMock()
         store.find_user_id_by_username.return_value = None
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(store=store, embed_client=embed_client)
         await create_agent(base_url="http://fake:8080").run(
@@ -774,7 +775,7 @@ class TestSearchHistoryLimit:
             deps=deps,
         )
 
-        assert store.search_similar.call_args.kwargs["limit"] == 3
+        assert store.search_hybrid.call_args.kwargs["limit"] == 3
 
 
 # ===========================================================================

--- a/projects/monolith/chat/agent_tool_execution_test.py
+++ b/projects/monolith/chat/agent_tool_execution_test.py
@@ -59,7 +59,7 @@ class TestSearchHistoryNoResults:
 
         store = MagicMock()
         store.find_user_id_by_username.return_value = None
-        store.search_similar.return_value = []  # no results
+        store.search_hybrid.return_value = []  # no results
 
         deps = _make_deps(store, embed_client)
         agent = create_agent(base_url="http://fake:8080")
@@ -100,7 +100,7 @@ class TestSearchHistoryNoResults:
 
         store = MagicMock()
         store.find_user_id_by_username.return_value = None
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(store, embed_client)
         agent = create_agent(base_url="http://fake:8080")
@@ -117,15 +117,15 @@ class TestSearchHistoryNoResults:
         embed_client.embed.assert_called_once_with("python deploy")
 
     @pytest.mark.asyncio
-    async def test_search_similar_called_with_channel_id_and_embedding(self):
-        """search_history passes channel_id and query_embedding to store.search_similar."""
+    async def test_search_hybrid_called_with_channel_id_and_embedding(self):
+        """search_history passes channel_id and query_embedding to store.search_hybrid."""
         embedding = [0.5] * 1024
         embed_client = AsyncMock()
         embed_client.embed.return_value = embedding
 
         store = MagicMock()
         store.find_user_id_by_username.return_value = None
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(store, embed_client, channel_id="my-channel")
         agent = create_agent(base_url="http://fake:8080")
@@ -139,8 +139,8 @@ class TestSearchHistoryNoResults:
             deps=deps,
         )
 
-        store.search_similar.assert_called_once()
-        call_kwargs = store.search_similar.call_args
+        store.search_hybrid.assert_called_once()
+        call_kwargs = store.search_hybrid.call_args
         assert call_kwargs.kwargs.get("channel_id") == "my-channel"
         assert call_kwargs.kwargs.get("query_embedding") == embedding
 
@@ -174,7 +174,7 @@ class TestSearchHistoryWithResults:
 
         store = MagicMock()
         store.find_user_id_by_username.return_value = None
-        store.search_similar.return_value = [found_msg]
+        store.search_hybrid.return_value = [found_msg]
 
         deps = _make_deps(store, embed_client)
         agent = create_agent(base_url="http://fake:8080")
@@ -223,7 +223,7 @@ class TestSearchHistoryWithUsername:
 
         store = MagicMock()
         store.find_user_id_by_username.return_value = "u-alice"
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(store, embed_client)
         agent = create_agent(base_url="http://fake:8080")
@@ -240,14 +240,14 @@ class TestSearchHistoryWithUsername:
         store.find_user_id_by_username.assert_called_once_with("ch1", "alice")
 
     @pytest.mark.asyncio
-    async def test_passes_user_id_to_search_similar(self):
-        """search_history forwards the resolved user_id to store.search_similar."""
+    async def test_passes_user_id_to_search_hybrid(self):
+        """search_history forwards the resolved user_id to store.search_hybrid."""
         embed_client = AsyncMock()
         embed_client.embed.return_value = [0.0] * 1024
 
         store = MagicMock()
         store.find_user_id_by_username.return_value = "u-alice"
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(store, embed_client)
         agent = create_agent(base_url="http://fake:8080")
@@ -261,7 +261,7 @@ class TestSearchHistoryWithUsername:
             deps=deps,
         )
 
-        call_kwargs = store.search_similar.call_args.kwargs
+        call_kwargs = store.search_hybrid.call_args.kwargs
         assert call_kwargs.get("user_id") == "u-alice"
 
     @pytest.mark.asyncio
@@ -272,7 +272,7 @@ class TestSearchHistoryWithUsername:
 
         store = MagicMock()
         store.find_user_id_by_username.return_value = None
-        store.search_similar.return_value = []
+        store.search_hybrid.return_value = []
 
         deps = _make_deps(store, embed_client)
         agent = create_agent(base_url="http://fake:8080")
@@ -286,7 +286,7 @@ class TestSearchHistoryWithUsername:
             deps=deps,
         )
 
-        call_kwargs = store.search_similar.call_args.kwargs
+        call_kwargs = store.search_hybrid.call_args.kwargs
         assert call_kwargs.get("limit") == 20
 
 

--- a/projects/monolith/chat/store.py
+++ b/projects/monolith/chat/store.py
@@ -282,6 +282,105 @@ class MessageStore:
         result = self.session.exec(sql, params=params)
         return [Message.model_validate(row) for row in result]
 
+    def lexical_search(
+        self,
+        channel_id: str,
+        query_text: str,
+        limit: int = 5,
+        exclude_ids: list[int] | None = None,
+        user_id: str | None = None,
+    ) -> list[Message]:
+        """Full-text keyword search over channel history using the generated
+        content_tsv column (GIN indexed). Complements search_similar: vector
+        search finds semantic matches, this finds exact tokens (a username, a
+        URL, an error code, a rare noun) that embeddings routinely miss.
+
+        Raw SQL because tsvector/websearch_to_tsquery have no ORM equivalent.
+        Returns [] on an empty or stop-word-only query rather than every row.
+        """
+        if not query_text or not query_text.strip():
+            return []
+        exclude = exclude_ids or []
+        params: dict[str, object] = {
+            "channel_id": channel_id,
+            "q": query_text,
+            "limit": limit,
+        }
+        filters = "m.channel_id = :channel_id AND m.content_tsv @@ q.q"
+        if exclude:
+            placeholders = []
+            for idx, eid in enumerate(exclude):
+                key = f"excl_{idx}"
+                placeholders.append(f":{key}")
+                params[key] = int(eid)
+            filters += f" AND m.id NOT IN ({', '.join(placeholders)})"
+        if user_id:
+            filters += " AND m.user_id = :user_id"
+            params["user_id"] = user_id
+
+        # websearch_to_tsquery tolerates arbitrary free text (never raises on
+        # punctuation the way to_tsquery does), so a user's raw question is a
+        # safe query. Compute it once in a CTE (q.q) and reuse for both the @@
+        # filter and the rank.
+        sql = text(
+            "WITH q AS (SELECT websearch_to_tsquery('english', :q) AS q) "
+            f"SELECT m.* FROM chat.messages m, q WHERE {filters} "
+            "ORDER BY ts_rank_cd(m.content_tsv, q.q) DESC, m.created_at DESC "
+            "LIMIT :limit"
+        )
+        result = self.session.exec(sql, params=params)
+        return [Message.model_validate(row) for row in result]
+
+    def search_hybrid(
+        self,
+        channel_id: str,
+        query_text: str,
+        query_embedding: list[float],
+        limit: int = 5,
+        exclude_ids: list[int] | None = None,
+        user_id: str | None = None,
+        candidate_k: int = 20,
+        rrf_k: int = 60,
+    ) -> list[Message]:
+        """Hybrid history search: fuse semantic (pgvector) and lexical
+        (full-text) results with Reciprocal Rank Fusion.
+
+        RRF scores each message by the sum of 1/(rrf_k + rank) across the lists
+        it appears in, so a message ranked highly by either retriever floats up
+        and one ranked by both wins. RRF fuses by rank order alone, so the two
+        incomparable scores (cosine distance vs ts_rank) never need
+        normalizing. Falls back to whichever list is non-empty when the other
+        returns nothing (e.g. a stop-word-only query yields no lexical hits).
+        """
+        vector_hits = self.search_similar(
+            channel_id=channel_id,
+            query_embedding=query_embedding,
+            limit=candidate_k,
+            exclude_ids=exclude_ids,
+            user_id=user_id,
+        )
+        lexical_hits = self.lexical_search(
+            channel_id=channel_id,
+            query_text=query_text,
+            limit=candidate_k,
+            exclude_ids=exclude_ids,
+            user_id=user_id,
+        )
+        scores: dict[int, float] = {}
+        by_id: dict[int, Message] = {}
+        for ranked in (vector_hits, lexical_hits):
+            for rank, msg in enumerate(ranked):
+                if msg.id is None:
+                    continue
+                scores[msg.id] = scores.get(msg.id, 0.0) + 1.0 / (rrf_k + rank)
+                by_id.setdefault(msg.id, msg)
+        fused = sorted(
+            by_id.values(),
+            key=lambda m: (scores[m.id], m.created_at),
+            reverse=True,
+        )
+        return fused[:limit]
+
     def get_attachments(
         self, message_ids: list[int]
     ) -> dict[int, list[tuple[Attachment, Blob]]]:

--- a/projects/monolith/chat/store_coverage_test.py
+++ b/projects/monolith/chat/store_coverage_test.py
@@ -148,3 +148,89 @@ class TestSearchSimilar:
         params = call_kwargs[1]["params"]
         excl_keys = [k for k in params if k.startswith("excl_")]
         assert excl_keys == []
+
+
+class TestLexicalSearch:
+    def test_empty_query_returns_empty_without_querying(self, store, mock_session):
+        """A blank/whitespace query short-circuits to [] and never hits the DB."""
+        assert store.lexical_search(channel_id="ch1", query_text="  ") == []
+        mock_session.exec.assert_not_called()
+
+    def test_returns_messages_from_exec(self, store, mock_session):
+        msg = _make_message(id=1, content="deploy failed with ORA-00942")
+        mock_session.exec.return_value = [msg]
+
+        results = store.lexical_search(channel_id="ch1", query_text="ORA-00942")
+
+        assert results == [msg]
+        mock_session.exec.assert_called_once()
+
+    def test_query_text_bound_as_param(self, store, mock_session):
+        mock_session.exec.return_value = []
+
+        store.lexical_search(channel_id="ch1", query_text="bandwidth war")
+
+        params = mock_session.exec.call_args[1]["params"]
+        assert params["q"] == "bandwidth war"
+        assert params["channel_id"] == "ch1"
+
+
+class TestSearchHybrid:
+    def test_rrf_ranks_shared_hit_first(self, store, mock_session):
+        """A message returned by BOTH retrievers outranks messages in one list."""
+        m1, m2, m3, m4 = (_make_message(id=i) for i in (1, 2, 3, 4))
+        # vector order: m1, m2, m3 ; lexical order: m3, m4 -> m3 is in both.
+        mock_session.exec.side_effect = [[m1, m2, m3], [m3, m4]]
+
+        results = store.search_hybrid(
+            channel_id="ch1",
+            query_text="something",
+            query_embedding=[0.1] * 1024,
+            limit=3,
+        )
+
+        assert results[0].id == 3  # shared hit wins on fused score
+        assert results[1].id == 1  # top of the vector list next
+        assert len(results) == 3
+
+    def test_falls_back_to_vector_when_lexical_empty(self, store, mock_session):
+        """When lexical returns nothing, hybrid still yields the vector hits."""
+        m1, m2 = _make_message(id=1), _make_message(id=2)
+        mock_session.exec.side_effect = [[m1, m2], []]
+
+        results = store.search_hybrid(
+            channel_id="ch1",
+            query_text="x",
+            query_embedding=[0.0] * 1024,
+            limit=5,
+        )
+
+        assert {m.id for m in results} == {1, 2}
+
+    def test_deduplicates_across_lists(self, store, mock_session):
+        """A message in both lists appears once, not twice, in the fused output."""
+        m1 = _make_message(id=1)
+        mock_session.exec.side_effect = [[m1], [m1]]
+
+        results = store.search_hybrid(
+            channel_id="ch1",
+            query_text="x",
+            query_embedding=[0.0] * 1024,
+        )
+
+        assert [m.id for m in results] == [1]
+
+    def test_blank_query_still_returns_vector_hits(self, store, mock_session):
+        """A stop-word-only query yields no lexical hits but hybrid still works
+        off the vector list (lexical_search short-circuits, so exec is called
+        only once, for the vector query)."""
+        m1 = _make_message(id=1)
+        mock_session.exec.side_effect = [[m1]]
+
+        results = store.search_hybrid(
+            channel_id="ch1",
+            query_text="   ",
+            query_embedding=[0.0] * 1024,
+        )
+
+        assert [m.id for m in results] == [1]

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.45
+      targetRevision: 0.285.46
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Why

Bosun's `search_history` tool was pure semantic search (pgvector cosine, `store.search_similar`). Vector search is strong on meaning but weak on exact tokens a user asks for by name: a username, a URL, an error code, a rare proper noun, a verbatim quote. Since history search is Bosun's only recall path beyond the last ~20 messages, that's a real quality gap in exactly the lookups these channels do.

## What

Hybrid retrieval = vector + Postgres full-text, fused with Reciprocal Rank Fusion.

- **Migration** `20260706190000_chat_messages_fts.sql`: `chat.messages` gains a `GENERATED ALWAYS ... STORED` `content_tsv tsvector` column (auto-maintained on every insert/update, no application bookkeeping) + a GIN index.
- **`store.lexical_search`**: full-text search via `websearch_to_tsquery` (tolerates arbitrary free text) ranked by `ts_rank_cd`, channel-scoped, with the same `exclude_ids` / `user_id` filters as `search_similar`. Blank/stop-word-only queries short-circuit to `[]`.
- **`store.search_hybrid`**: fuses the two ranked lists with RRF (score = Σ 1/(k+rank), k=60). RRF ranks by position, so the two incomparable scores (cosine distance vs `ts_rank`) never need normalizing; a hit ranked by either retriever surfaces, one ranked by both wins. Falls back to whichever list is non-empty.
- **`search_history`** now calls `search_hybrid`. The `bot.py` related-message context injection stays pure vector for now (no free-text query there); it's a candidate follow-up.

## Tests

`store_coverage_test.py` gains `TestLexicalSearch` + `TestSearchHybrid`: RRF ordering (shared hit ranks first), vector-only fallback when lexical is empty, dedup across lists, and blank-query behavior. Tests fuse mocked `exec` rows, so no real Postgres is needed (mirrors the existing `search_similar` tests).

## Notes

- `atlas.sum` regenerated with pinned atlas-community v1.1.0 (not homebrew, which writes a hash only the RBE `atlas_sum_test` rejects).
- Chart bumped to 0.285.46.