### PR TITLE
fix(grimoire): landing polish from Joe's live review

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.15
+version: 0.89.16
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.15
+      targetRevision: 0.89.16
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.49
+version: 0.285.50
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.49
+      targetRevision: 0.285.50
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
@@ -504,12 +504,24 @@
     }
   }
 
+  // Past the hero the story is immersive: the app topbar fades out (the
+  // layout styles .grimoire-app.story-immersed .topbar) and comes back as the
+  // visitor reaches the finale, so they land back in normal chrome.
+  let appEl = null;
+  let immersed = false;
+  function setImmersed(next) {
+    if (next === immersed) return;
+    immersed = next;
+    appEl?.classList.toggle("story-immersed", next);
+  }
+
   function onFrame() {
     raf = 0;
     if (!measured) return; // wait for the first layout() before scrubbing
     const r = scrollerEl.getBoundingClientRect();
     const span = r.height - H;
     lastT = span > 0 ? clamp(-r.top / span, 0, 1) : 0;
+    setImmersed(lastT > 0.03 && lastT < 0.97);
     frame(lastT);
   }
 
@@ -518,6 +530,7 @@
     if (reduced) return; // stay on the static stacked scenes
 
     ready = true; // reveal the scrubbed stage (re-render, refs already bound)
+    appEl = document.querySelector(".grimoire-app");
     // Proximity snap lives on the document scroll container: the .snap
     // markers' scroll-snap-align does nothing without it. html is outside this
     // component, so set it imperatively and remove it on destroy so other
@@ -563,6 +576,7 @@
     });
 
     return () => {
+      setImmersed(false);
       document.documentElement.style.scrollSnapType = "";
       window.removeEventListener("scroll", queue);
       window.removeEventListener("resize", onResize);
@@ -574,7 +588,13 @@
   });
 </script>
 
-<div class="scrollstory" class:ready>
+<!-- The extra `grimoire` class is a LIGHT ISLAND: the theme tokens are declared
+     on .grimoire and only overridden by .grimoire.dark, so re-applying the bare
+     class here resets every --grim-* token to its light value for the story
+     subtree regardless of app theme (and the canvas color resolver reads off
+     this island, so the constellation follows). The story ships light-only for
+     now; dark-mode art direction is a deliberate later pass. -->
+<div class="scrollstory grimoire" class:ready>
   <!-- ── Scrubbed stage: always in the DOM (refs bind at mount) but hidden by
        CSS until `ready` flips, so no-JS and reduced-motion never see it ── -->
   <div class="scroller" bind:this={scrollerEl}>

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
@@ -81,7 +81,12 @@
       >
     </nav>
     <div class="topbar-spacer"></div>
-    <ThemeToggle />
+    {#if !isHome}
+      <!-- The landing's scroll story is a light-only island, so a theme toggle
+           there would appear to do nothing; the toggle stays on every other
+           route where the dark reskin fully applies. -->
+      <ThemeToggle />
+    {/if}
   </header>
 
   <main class="grimoire-shell">
@@ -134,6 +139,15 @@
     background: color-mix(in srgb, var(--grim-paper) 88%, transparent);
     backdrop-filter: blur(10px);
     border-bottom: 1px solid var(--grim-line);
+    transition: opacity 0.25s ease;
+  }
+
+  /* The landing's ScrollStory toggles .story-immersed on .grimoire-app while
+     the visitor is inside the story (past the hero, before the finale): the
+     chrome gets out of the way of the pinned stage and returns at the end. */
+  .grimoire-app:global(.story-immersed) .topbar {
+    opacity: 0;
+    pointer-events: none;
   }
 
   .wordmark {

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
@@ -1,7 +1,7 @@
 <script>
   // Public Grimoire homepage: a scroll-scrubbed "From scan to query" explainer
-  // (ScrollStory) over the pitch, what exists today, a small invented demo of
-  // the grant system, and the roadmap. This page still makes zero /api/grimoire
+  // (ScrollStory) over a small invented demo of the grant system and the
+  // roadmap. This page still makes zero /api/grimoire
   // fetches, which is what lets the layout render it outside the Turnstile gate
   // (the gate protects the copyrighted corpus, not the product description).
   // The one deliberate exception: ScrollStory embeds ONE Joe-approved curated
@@ -10,37 +10,11 @@
   // allowed out here; any further corpus read must still move behind the gate.
   import ScrollStory from "$lib/public/grimoire/scrollstory/ScrollStory.svelte";
 
-  const features = [
-    {
-      title: "The Library",
-      body: "Every loaded book, grouped by kind (adventures, bestiaries, spellbooks, and more) with per-book chunk, image, and entity counts.",
-    },
-    {
-      title: "Structural reader",
-      body: "Continuous reading in source order with the section hierarchy and art preserved, not a wall of OCR text.",
-    },
-    {
-      title: "Adventures",
-      body: "Anthologies are split into their individual adventures, each with its own roster of the entities that appear in it.",
-    },
-    {
-      title: "Entity browser",
-      body: "Creatures, spells, NPCs, locations, items, and more as typed detail cards: stat blocks, spell levels, filter by type, search by name.",
-    },
-    {
-      title: "EXPLORE canvas",
-      body: "An interactive relationship graph: pick a scope (the whole corpus, one book, one adventure) and a lens (world, story, quests, rules), then wander from entity to entity.",
-    },
-    {
-      title: "Provenance",
-      body: "Every entity links back to the exact chunks it was extracted from, so a claim is always one click from its source text.",
-    },
-    {
-      title: "Campaign grants",
-      body: "In the private tier a DM controls what each player character knows about an entity, from full detail down to name-only recognition.",
-    },
-  ];
-
+  // The feature grid that used to live here was removed once the scroll story
+  // shipped: the story demonstrates the library, reader, entities, graph, and
+  // chat directly, so a prose retelling below it was redundant. The grant demo
+  // and roadmap stay: they cover what the story cannot show (the private tier
+  // and what is coming).
   const roadmap = [
     {
       status: "Planned",
@@ -73,18 +47,6 @@
 <ScrollStory />
 
 <div class="home">
-  <section class="block">
-    <div class="gh"><span class="kind">What's here today</span></div>
-    <ul class="feature-grid">
-      {#each features as f (f.title)}
-        <li class="feature">
-          <h3 class="feature-title">{f.title}</h3>
-          <p class="feature-body">{f.body}</p>
-        </li>
-      {/each}
-    </ul>
-  </section>
-
   <section class="block">
     <div class="gh">
       <span class="kind">At the table</span>
@@ -212,39 +174,6 @@
     color: var(--grim-text-faint);
     font-size: 12.5px;
     line-height: 1.6;
-  }
-
-  /* ── Feature grid ── */
-
-  .feature-grid {
-    list-style: none;
-    margin: 22px 0 0;
-    padding: 0;
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 14px;
-  }
-
-  .feature {
-    background: var(--grim-surface);
-    border: 1px solid var(--grim-line-soft);
-    border-radius: 9px;
-    padding: 16px;
-  }
-
-  .feature-title {
-    margin: 0;
-    font-family: var(--grim-serif);
-    font-size: 16px;
-    font-weight: 600;
-    color: var(--grim-ink);
-  }
-
-  .feature-body {
-    margin: 7px 0 0;
-    color: var(--grim-text-dim);
-    font-size: 12.5px;
-    line-height: 1.55;
   }
 
   /* ── Grant demo cards ── */
@@ -410,7 +339,7 @@
   /* ── Responsive ── */
 
   @media (max-width: 960px) {
-    .feature-grid,
+
     .grant-row {
       grid-template-columns: 1fr 1fr;
     }
@@ -421,7 +350,7 @@
       padding: 36px 20px 60px;
     }
 
-    .feature-grid,
+
     .grant-row {
       grid-template-columns: 1fr;
     }


### PR DESCRIPTION
Follow-up to #3269 from the live desktop review:

- **Light island**: the scroll story re-applies the bare `grimoire` class, pinning every --grim-* token (and the canvas color resolver) to light values regardless of app theme. Dark-mode text in the story was hard to read; a proper dark art-direction pass is deferred. Rest of the page and app stays themed.
- **Theme toggle hidden on the landing only** (it would appear to do nothing there); all other public grimoire routes keep it.
- **Topbar fades out while inside the story** (past the hero, back before the finale) via a `story-immersed` class the story toggles on `.grimoire-app`.
- **Feature grid removed** below the story: the story demonstrates those features directly. Grant demo, roadmap, and the Turnstile foot-note stay.
- Both charts bumped (monolith 0.285.50, monolith-public 0.89.16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)