### PR TITLE
fix(chat): route python-chartable asks to chat, not the guest agent

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.51
+version: 0.285.52
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/attention.py
+++ b/projects/monolith/chat/attention.py
@@ -94,11 +94,15 @@ async def evaluate(
 async def needs_agent(message, *, _caller=None) -> bool:
     """Cheap depth classify: does this engaged message need the goose agent?
 
-    True for repo work, artifact/build requests, or thorough multi-source
-    research; False for conversation, general knowledge, or a simple factual
-    question (a basic web lookup is fine in chat). Fails closed to False so a
-    classify failure degrades to a fast in-monolith reply, never a surprise
-    heavy guest run. ``_caller`` is an injectable llm-caller for tests.
+    True only for repo work, a standalone interactive webpage/app, or thorough
+    multi-source research; False for conversation, general knowledge, a simple
+    factual question, OR anything the chat agent's own tools already cover -
+    including charting/plotting data (run_python renders a chart that attaches
+    to Discord) and computing this channel's activity stats (counts, rankings,
+    per-user/per-day breakdowns). The bright line for a chart request: a Python
+    image stays chat; only a click-around webpage is agent. Fails closed to
+    False so a classify failure degrades to a fast in-monolith reply, never a
+    surprise heavy guest run. ``_caller`` is an injectable llm-caller for tests.
     """
     try:
         caller = _caller
@@ -109,15 +113,34 @@ async def needs_agent(message, *, _caller=None) -> bool:
         text = (message.content or "")[:500]
         prompt = (
             "You decide whether a chat message needs the heavyweight coding "
-            'agent or can be answered directly. Answer "agent" ONLY if it '
-            "needs to read, analyze, or change THIS repository/codebase, "
-            "build or generate an artifact/page, or do thorough multi-source "
-            'research. Answer "chat" for conversation, general knowledge, '
-            "or a simple factual question (a basic web lookup is fine in "
-            "chat). Summarizing this conversation, catching up on channel "
-            "history, or extracting decisions or action items from it is "
-            'also "chat", not "agent": the chat agent already has tools '
-            "for that. Reply with ONLY a JSON object: "
+            "agent (a sandboxed microVM that reads/writes THIS "
+            "repository/codebase and builds standalone interactive webpages) "
+            "or can be answered right here in chat. Default to chat: the chat "
+            "assistant already has strong tools, so prefer chat whenever they "
+            "suffice. Chat tools include:\n"
+            "- search and read this channel's message history (semantic + "
+            "keyword)\n"
+            "- counts, rankings, and per-user or per-day breakdowns of this "
+            "channel's own activity (who posted most, messages per day)\n"
+            "- run_python: run code to compute results AND draw "
+            "charts/graphs/plots with matplotlib; the resulting image "
+            "attaches directly here in the chat\n"
+            "- render tables, and look things up on the web\n"
+            "Summarizing this conversation, catching up on channel history, or "
+            'extracting decisions or action items from it is also "chat", '
+            'not "agent": the chat agent already has tools for that. Answer '
+            '"agent" ONLY if the message truly needs one of: (a) reading, '
+            "analyzing, or changing THIS repository/codebase; (b) a "
+            "standalone, interactive webpage, dashboard, or app - an "
+            "artifact/page you click around in, not a single image; or (c) "
+            "thorough multi-source research. KEY RULE: if the ask is to chart, "
+            "graph, plot, or visualize DATA (including this channel's own "
+            "stats, e.g. 'messages per user per day'), that is \"chat\" - "
+            "run_python makes the chart and it attaches here. Do NOT choose "
+            '"agent" just because a chart or visualization was requested; '
+            'choose "agent" for a chart only if the user explicitly asked for '
+            "an interactive or standalone webpage rather than an image. Reply "
+            "with ONLY a JSON object: "
             '{"needs_agent": true|false}. Message: ' + text
         )
         raw = await caller(prompt)

--- a/projects/monolith/chat/attention_test.py
+++ b/projects/monolith/chat/attention_test.py
@@ -198,3 +198,24 @@ class TestNeedsAgent:
         assert "repository/codebase" in prompt
         assert "artifact/page" in prompt
         assert "thorough multi-source" in prompt
+
+    @pytest.mark.asyncio
+    async def test_prompt_routes_python_charts_to_chat(self):
+        """A chart/plot of data (including this channel's own stats) must stay
+        "chat": the chat agent has run_python to render and attach the image.
+        The prompt must enumerate that capability and state the bright line so
+        a "chart messages per user per day" ask no longer trips to the agent
+        just for containing the word "chart"."""
+        message = _make_message(content="chart messages per user per day")
+        caller = AsyncMock(return_value='{"needs_agent": false}')
+        await needs_agent(message, _caller=caller)
+        prompt = caller.call_args[0][0].lower()
+        # the tool that makes an inline chart possible is named for the model
+        assert "run_python" in prompt
+        # the bright line: a python image is chat, a click-around page is agent
+        assert "chart" in prompt
+        assert "attaches" in prompt
+        assert "not a single image" in prompt
+        # the channel-stats capability is surfaced so the model knows the data
+        # is reachable without the heavy guest
+        assert "per-user or per-day breakdowns" in prompt

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.51
+      targetRevision: 0.285.52
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Why

Follow-up to #3271. A user asked Bosun to "chart messages per user per day / who's the yappiest gooner" and it routed to the **goosecracker guest** to build a webpage, so the chat agent's brand-new `explore_history` tool (plus `run_python` charting) never fired. Worse, the guest builds such a chart off *injected context*, not a real query, which is the exact ep-72 limitation #3271 fixed.

## Cause

`chat/attention.py::needs_agent` is a cheap LLM depth-classifier (chat-reply vs spawn-guest), and it sits **upstream** of the chat agent's tools. Its prompt answered `"agent"` for anything that reads as *"build or generate an artifact/page"* — and "chart" tripped that.

## Fix

Rewrite the classifier prompt to:
- **Enumerate the chat agent's actual tools** so the model knows the data/rendering is reachable inline: channel-history search, per-user/per-day stat breakdowns (`explore_history`), `run_python` charts that attach to Discord, tables, web lookup.
- **State a bright-line rule:** charting/plotting/visualizing data (including this channel's own stats) is `chat` — `run_python` renders it and the image attaches here. Route to `agent` for a chart *only* when the user explicitly wants a standalone/interactive webpage, not a single image.

Repo/codebase work, standalone interactive webpages/apps, and thorough multi-source research still route to the guest.

## Tests

`attention_test.py`: existing prompt-content assertions preserved (repo/codebase, artifact/page, summarize/catch-up/extract wording all retained); new `test_prompt_routes_python_charts_to_chat` pins the tool enumeration + the python-chart-vs-webpage rule so it can't silently regress. Verified the runtime-concatenated prompt contains every asserted substring.

Chart bumped to `0.285.52` (ships via monolith image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)