### PR TITLE
fix(grimoire): flyers match chunks by marker ref, not uuid

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.18
+version: 0.89.19
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.18
+      targetRevision: 0.89.19
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.53
+version: 0.285.54
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.53
+      targetRevision: 0.285.54
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
@@ -77,6 +77,7 @@
   // per-frame mark tinting reads data-c off these same nodes.
   const cards = story.chunks.map((c) => ({
     id: c.id,
+    ref: c.ref,
     path: c.section.split("/").pop(),
     bodyHtml: segHtml(segmentize(c.content.slice(0, 240), PHRASES)),
   }));
@@ -85,8 +86,11 @@
   // the chunking phase each flyer lifts OFF the page at its box's position and
   // lands on its chunk card, so the blocks visibly become the cards instead of
   // the two animations merely happening near each other.
+  // NB a bbox's chunkId is the chunk's marker REF PATH (/page/N/Kind/M), not
+  // its UUID: match on ref. Matching on id here once made flyBoxes silently
+  // empty and the whole flight a no-op in prod.
   const flyBoxes = story.bboxes
-    .map((b) => ({ ...b, card: cards.findIndex((c) => c.id === b.chunkId) }))
+    .map((b) => ({ ...b, card: cards.findIndex((c) => c.ref === b.chunkId) }))
     // no art flyers: a full-page illustration's bbox in flight is a giant slab
     // that reads as a glitch. Its caption still flies, which carries the story.
     .filter((f) => f.card >= 0 && f.kind !== "art");


### PR DESCRIPTION
The scroll story's box-to-card flight has been a silent no-op in prod: bbox.chunkId carries the chunk's marker ref path (/page/N/Kind/M) while the lookup compared it to the chunk UUID, so flyBoxes was always empty. Matched by ref instead: 0 flyers before, 21 after, verified against the baked data. Charts bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)