### PR TITLE
feat(grimoire): dedicated mobile choreography for the scroll story

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.19
+version: 0.89.20
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.19
+      targetRevision: 0.89.20
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.54
+version: 0.285.55
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.54
+      targetRevision: 0.285.55
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
@@ -45,6 +45,7 @@
   const entById = Object.fromEntries(story.entities.map((e) => [e.id, e]));
   const nodes = graphLayout(story.entities, story.edges);
   const nById = Object.fromEntries(nodes.map((n) => [n.id, n]));
+  const idxById = Object.fromEntries(nodes.map((n, i) => [n.id, i]));
   const graphEdges = story.edges.filter((e) => nById[e.from] && nById[e.to]);
 
   // Every real highlightable phrase on the page: entity names plus recorded
@@ -156,6 +157,12 @@
   // ── Reactive state (coarse only) ──
   let ready = $state(false); // scrubbed path is live (JS on, motion allowed)
   let reduced = $state(false);
+  // Narrow/touch viewports get a dedicated portrait choreography: same phases,
+  // same data, but a single centred column instead of the desktop two-column
+  // stage (page centre, cards full width, a tall clamped constellation, a
+  // bottom dot rail). Decided at mount, re-checked on resize. See the ported
+  // reference-mockup-mobile.html for the design source.
+  let mobile = $state(false);
   let phaseId = $state("hero");
   let popIdx = $state(-1);
 
@@ -204,6 +211,11 @@
   let measured = false;
   let dots = [];
   const lastNodePos = [];
+  // mobile-only per-frame geometry: the centred page's rest centre and each
+  // chip's half-width (to clamp chips fully inside the narrow viewport)
+  let pageCX = 0;
+  let pageCY = 0;
+  let chipHalf = [];
 
   // Canvas can't read CSS custom properties, so resolve the --grim-type-*
   // tokens to concrete colors off the (in-.grimoire) canvas element, and
@@ -276,8 +288,14 @@
   function placePopout() {
     if (popIdx < 0 || !popoutEl) return;
     const [x, y] = popAnchor || lastNodePos[popIdx] || [W / 2, H / 2];
-    popoutEl.style.left = clamp(x + 16, 12, W - 300) + "px";
-    popoutEl.style.top = clamp(y + 14, 12, H - 240) + "px";
+    if (mobile) {
+      // centre the narrower card on the tapped node, kept inside the viewport
+      popoutEl.style.left = clamp(x - 130, 10, W - 270) + "px";
+      popoutEl.style.top = clamp(y + 16, 12, H - 220) + "px";
+    } else {
+      popoutEl.style.left = clamp(x + 16, 12, W - 300) + "px";
+      popoutEl.style.top = clamp(y + 14, 12, H - 240) + "px";
+    }
   }
 
   function railTo(p) {
@@ -293,16 +311,29 @@
   function layout() {
     W = window.innerWidth;
     H = window.innerHeight;
-    pageH = H * 0.76;
-    pageW = pageH * aspect;
-    if (pageW > W * 0.42) {
-      pageW = W * 0.42;
+    if (mobile) {
+      // centred, sized for portrait: fits the width with margin, tall enough
+      // to read as the scanned page
+      pageW = Math.min(W * 0.66, H * 0.46 * aspect);
       pageH = pageW / aspect;
+      const left = (W - pageW) / 2;
+      const top = H * 0.5 - pageH / 2;
+      pageWrapEl.style.left = left + "px";
+      pageWrapEl.style.top = top + "px";
+      pageCX = left + pageW / 2;
+      pageCY = top + pageH / 2;
+    } else {
+      pageH = H * 0.76;
+      pageW = pageH * aspect;
+      if (pageW > W * 0.42) {
+        pageW = W * 0.42;
+        pageH = pageW / aspect;
+      }
+      pageWrapEl.style.left = W * 0.56 - pageW / 2 + "px";
+      pageWrapEl.style.top = (H - pageH) / 2 + "px";
     }
     pageWrapEl.style.width = pageW + "px";
     pageWrapEl.style.height = pageH + "px";
-    pageWrapEl.style.left = W * 0.56 - pageW / 2 + "px";
-    pageWrapEl.style.top = (H - pageH) / 2 + "px";
     dpr = Math.min(window.devicePixelRatio || 1, 2);
     canvasEl.width = W * dpr;
     canvasEl.height = H * dpr;
@@ -327,6 +358,9 @@
         h: el.offsetHeight,
       };
     });
+    chipEls.forEach((el, i) => {
+      if (el) chipHalf[i] = el.offsetWidth / 2;
+    });
   }
 
   // Graph node screen position: middle band during its phase, shrinking to a
@@ -347,6 +381,25 @@
     ];
   }
 
+  // Portrait constellation: a narrow x radius keeps chips within the width
+  // while a taller y radius spreads them down the screen. The caller clamps
+  // each chip's centre by its measured half-width so no label is ever cut off.
+  function nodePosMobile(n, shrink, chatP = 0) {
+    const cx = W * 0.5;
+    const cy = H * 0.52;
+    const Rx = W * 0.4;
+    const Ry = H * 0.32;
+    let sx = cx + n.x * Rx;
+    let sy = cy + n.y * Ry;
+    if (sy < H * 0.2) sy = H * 0.2 + (H * 0.2 - sy) * 0.3;
+    const kx = lerp(cx, W * 0.5, chatP);
+    const ky = lerp(H * 0.72, H * 0.42, chatP);
+    return [
+      lerp(sx, kx + n.x * Rx * 0.2, shrink),
+      lerp(sy, ky + n.y * Ry * 0.12, shrink),
+    ];
+  }
+
   // ── the per-frame choreography (ported verbatim from the mockup) ──
   function frame(t) {
     const phase = phaseAt(t);
@@ -361,7 +414,9 @@
     // hero copy
     const pHero = sub(t, 0.04, 0.08);
     heroCopyEl.style.opacity = 1 - pHero;
-    heroCopyEl.style.transform = `translateY(${-pHero * 30}px)`;
+    heroCopyEl.style.transform = mobile
+      ? `translateX(-50%) translateY(${-pHero * 24}px)`
+      : `translateY(${-pHero * 30}px)`;
     heroCopyEl.style.visibility = pHero >= 1 ? "hidden" : "visible";
 
     // page transform
@@ -369,11 +424,24 @@
     const slide = inOutCubic(sub(t, 0.26, 0.36));
     const recede = outCubic(sub(t, 0.44, 0.54));
     const gone = inOutCubic(sub(t, 0.66, 0.72));
-    const rot = lerp(-3.5, 0, settle);
-    const px = lerp(lerp(0, -W * 0.34, slide), -W * 0.52, gone);
-    const sc = lerp(lerp(lerp(0.94, 1, settle), 0.78, slide), 0.66, recede);
-    pageWrapEl.style.transform = `translate(${px}px,0) rotate(${rot}deg) scale(${sc})`;
-    pageWrapEl.style.opacity = lerp(lerp(1, 0.25, recede), 0, gone);
+    const rot = lerp(mobile ? -3.2 : -3.5, 0, settle);
+    let px = 0;
+    let sc;
+    let pageTY = 0;
+    if (mobile) {
+      // page settles centred, then dissolves upward as the flyers hand it off
+      // to the cards; during the hero it rides lower so the copy + cue clear it
+      const fade = inOutCubic(sub(t, 0.3, 0.44));
+      sc = lerp(lerp(0.96, 1, settle), 0.88, slide);
+      pageTY = (1 - settle) * H * 0.08 + lerp(0, -H * 0.06, slide);
+      pageWrapEl.style.transform = `translate(0,${pageTY}px) rotate(${rot}deg) scale(${sc})`;
+      pageWrapEl.style.opacity = 1 - fade;
+    } else {
+      px = lerp(lerp(0, -W * 0.34, slide), -W * 0.52, gone);
+      sc = lerp(lerp(lerp(0.94, 1, settle), 0.78, slide), 0.66, recede);
+      pageWrapEl.style.transform = `translate(${px}px,0) rotate(${rot}deg) scale(${sc})`;
+      pageWrapEl.style.opacity = lerp(lerp(1, 0.25, recede), 0, gone);
+    }
 
     // layout boxes: crisp staggered scanner strokes, then they fly to cards
     const pLay = sub(t, 0.08, 0.2);
@@ -402,8 +470,8 @@
     // rot is 0 through this window, so the page's stage rect is just its base
     // rect scaled about its center and shifted by the slide translate.
     const rawFly = sub(t, 0.27, 0.4);
-    const pcx = W * 0.56 + px;
-    const pcy = H / 2;
+    const pcx = mobile ? pageCX : W * 0.56 + px;
+    const pcy = mobile ? pageCY + pageTY : H / 2;
     const pw = pageW * sc;
     const ph = pageH * sc;
     flyBoxes.forEach((f, i) => {
@@ -434,7 +502,9 @@
       if (!el) return;
       const dp = outCubic(sub(pChunk, i * 0.06, i * 0.06 + 0.5));
       el.style.opacity = dp * (1 - cardsOut);
-      el.style.transform = `translateX(${lerp(14, 0, dp) + cardsOut * 60}px)`;
+      el.style.transform = mobile
+        ? `translateY(${lerp(12, 0, dp) - cardsOut * 26}px)`
+        : `translateX(${lerp(14, 0, dp) + cardsOut * 60}px)`;
     });
     chunksWrapEl.style.visibility = cardsOut >= 1 ? "hidden" : "visible";
 
@@ -461,24 +531,54 @@
       const raw = sub(pChip, i * 0.025, i * 0.025 + 0.4);
       const move = inOutCubic(raw);
       const pop = outBack(raw);
-      const [gx, gy] = nodePos(n, shrink, chatShift);
+      let gx;
+      let gy;
+      let fromX;
+      let fromY;
+      let opa;
+      let scl;
+      if (mobile) {
+        const [gx0, gy0] = nodePosMobile(n, shrink, chatShift);
+        const hw = chipHalf[i] || 60;
+        gx = clamp(gx0, hw + 10, W - hw - 10);
+        gy = clamp(gy0, H * 0.12, H * 0.9);
+        fromX = W * 0.5;
+        fromY = H * 0.42;
+        // during the shelf/chat phases the page's chips recede to a faint,
+        // small knot so the constellation (the whole corpus) reads as the figure
+        opa = Math.min(raw * 3, 1) * lerp(1, 0.22, Math.max(shrink, graphDim));
+        scl = lerp(0.4, 1, pop) * lerp(1, 0.5, shrink);
+      } else {
+        [gx, gy] = nodePos(n, shrink, chatShift);
+        fromX = W * 0.74;
+        fromY = H * 0.5;
+        opa =
+          Math.min(raw * 3, 1) *
+          lerp(1, 0.4, Math.max(shrink * 0.5, graphDim));
+        scl = lerp(0.4, 1, pop) * lerp(1, 0.66, shrink);
+      }
       lastNodePos[i] = [gx, gy];
-      const x = lerp(W * 0.74, gx, move);
-      const y = lerp(H * 0.5, gy, move);
-      el.style.opacity =
-        Math.min(raw * 3, 1) * lerp(1, 0.4, Math.max(shrink * 0.5, graphDim));
-      el.style.transform = `translate(${x}px,${y}px) translate(-50%,-50%) scale(${
-        lerp(0.4, 1, pop) * lerp(1, 0.66, shrink)
-      })`;
+      const x = lerp(fromX, gx, move);
+      const y = lerp(fromY, gy, move);
+      el.style.opacity = opa;
+      el.style.transform = `translate(${x}px,${y}px) translate(-50%,-50%) scale(${scl})`;
     });
     placePopout();
     const pEdge = outCubic(sub(t, 0.52, 0.6));
     lineEls.forEach((l, i) => {
       if (!l) return;
-      const a = nById[graphEdges[i].from];
-      const b = nById[graphEdges[i].to];
-      const [x1, y1] = nodePos(a, shrink, chatShift);
-      const [x2, y2] = nodePos(b, shrink, chatShift);
+      let x1;
+      let y1;
+      let x2;
+      let y2;
+      if (mobile) {
+        // read the clamped chip centres so edges stay attached to the pills
+        [x1, y1] = lastNodePos[idxById[graphEdges[i].from]] || [0, 0];
+        [x2, y2] = lastNodePos[idxById[graphEdges[i].to]] || [0, 0];
+      } else {
+        [x1, y1] = nodePos(nById[graphEdges[i].from], shrink, chatShift);
+        [x2, y2] = nodePos(nById[graphEdges[i].to], shrink, chatShift);
+      }
       l.setAttribute("x1", x1);
       l.setAttribute("y1", y1);
       l.setAttribute("x2", x2);
@@ -500,9 +600,16 @@
           const d = dots[i];
           const x = d.x * W;
           const y = d.y * H;
-          const edge = clamp(Math.min(x, W - x, y, H - y) / 90, 0, 1);
-          // keep the progress rail's column clear
-          if (x > W - 150 && y > H * 0.26 && y < H * 0.74) continue;
+          const edge = clamp(
+            Math.min(x, W - x, y, H - y) / (mobile ? 70 : 90),
+            0,
+            1,
+          );
+          // keep the progress rail's lane clear (right gutter on desktop, the
+          // bottom dot row on mobile)
+          if (mobile) {
+            if (y > H - 54) continue;
+          } else if (x > W - 150 && y > H * 0.26 && y < H * 0.74) continue;
           if (edge <= 0) continue;
           ctx.globalAlpha = 0.72 * alpha * edge;
           ctx.fillStyle = dotColor(d.t);
@@ -583,6 +690,9 @@
     reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     if (reduced) return; // stay on the static stacked scenes
 
+    // Narrow/touch viewports get the portrait choreography; wider ones the
+    // desktop two-column stage. Checked once here and re-checked on resize.
+    mobile = window.matchMedia("(max-width: 700px)").matches;
     ready = true; // reveal the scrubbed stage (re-render, refs already bound)
     appEl = document.querySelector(".grimoire-app");
     // Proximity snap lives on the document scroll container: the .snap
@@ -598,6 +708,8 @@
       if (!raf) raf = requestAnimationFrame(onFrame);
     };
     const onResize = () => {
+      const nowMobile = window.matchMedia("(max-width: 700px)").matches;
+      if (nowMobile !== mobile) mobile = nowMobile;
       layout();
       queue();
     };
@@ -648,7 +760,7 @@
      subtree regardless of app theme (and the canvas color resolver reads off
      this island, so the constellation follows). The story ships light-only for
      now; dark-mode art direction is a deliberate later pass. -->
-<div class="scrollstory grimoire" class:ready>
+<div class="scrollstory grimoire" class:ready class:mobile>
   <!-- ── Scrubbed stage: always in the DOM (refs bind at mount) but hidden by
        CSS until `ready` flips, so no-JS and reduced-motion never see it ── -->
   <div class="scroller" bind:this={scrollerEl}>
@@ -1737,21 +1849,119 @@
     opacity: 1;
   }
 
+  /* ── dedicated mobile (portrait) composition of the scrubbed stage ──
+     Applied only when `mobile` is set (below 700px). The frame() geometry
+     switches to a single centred column; these rules restyle the same DOM to
+     match. Ported from reference-mockup-mobile.html: keep the two in sync. */
+  .scrollstory.mobile .hero-copy {
+    left: 50%;
+    top: 12vh;
+    width: 86vw;
+    max-width: 34ch;
+    text-align: center;
+    /* frame() writes `translateX(-50%) translateY(...)` here every frame */
+  }
+  .scrollstory.mobile .hero-copy p {
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .scrollstory.mobile .caption {
+    left: 5vw;
+    top: 4vh;
+    max-width: 88vw;
+  }
+  .scrollstory.mobile .caption .txt {
+    font-size: 16px;
+    max-width: 30ch;
+  }
+  .scrollstory.mobile .attribution {
+    left: 0;
+    right: 0;
+    bottom: -34px;
+    text-align: center;
+    white-space: normal;
+    font-size: 9.5px;
+    line-height: 1.4;
+  }
+  .scrollstory.mobile .chunks {
+    left: 4vw;
+    right: 4vw;
+    top: 15vh;
+    width: auto;
+    transform: none;
+    gap: 7px;
+  }
+  .scrollstory.mobile .chunk-card {
+    padding: 8px 12px;
+  }
+  .scrollstory.mobile .chunk-card .body {
+    font-size: 12px;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+  }
+  .scrollstory.mobile .chip {
+    font-size: 10px;
+    padding: 3px 9px 3px 6px;
+  }
+  .scrollstory.mobile .popout {
+    width: 260px;
+  }
+  .scrollstory.mobile .scale-panel,
+  .scrollstory.mobile .chat-head {
+    top: 8vh;
+    width: 92vw;
+    padding: 18px;
+    border-radius: 16px;
+  }
+  .scrollstory.mobile .chat-head {
+    top: 7vh;
+  }
+  .scrollstory.mobile .this-page {
+    gap: 7px;
+    font-size: 10px;
+  }
+  .scrollstory.mobile .counters {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px 8px;
+  }
+  .scrollstory.mobile .type-chips {
+    max-width: 92vw;
+    gap: 6px;
+  }
+  .scrollstory.mobile .chat {
+    width: 92vw;
+    padding: 18px 18px 16px;
+  }
+  .scrollstory.mobile .ctas {
+    flex-direction: column;
+    gap: 8px;
+  }
+  .scrollstory.mobile .cta {
+    padding: 12px 8px;
+  }
+  /* progress rail: a horizontal dot row pinned to the bottom, out of the
+     content's way (the desktop right gutter has no room on a phone) */
+  .scrollstory.mobile .rail {
+    right: auto;
+    left: 50%;
+    top: auto;
+    bottom: 12px;
+    transform: translateX(-50%);
+    flex-direction: row;
+    gap: 12px;
+    padding: 8px 14px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--grim-paper) 78%, transparent);
+    backdrop-filter: blur(4px);
+    box-shadow: 0 2px 10px rgba(10, 14, 22, 0.1);
+  }
+  .scrollstory.mobile .rail .lbl {
+    display: none;
+  }
+
   /* ── responsive ── */
   @media (max-width: 700px) {
-    .hero-copy {
-      top: 14vh;
-    }
-    .chunks {
-      width: 86vw;
-      right: 7vw;
-    }
-    .caption {
-      max-width: 70vw;
-    }
-    .type-chips {
-      max-width: 86vw;
-    }
     .static-cards {
       grid-template-columns: 1fr;
     }

--- a/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/reference-mockup-mobile.html
+++ b/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/reference-mockup-mobile.html
@@ -1,0 +1,1411 @@
+<title>Grimoire: From Scan to Query (MOBILE choreography mockup)</title>
+<!--
+  Portrait recomposition of the "From scan to query" scroll story, for narrow
+  touch viewports. Same six phases, same data, same scrub paradigm as
+  reference-mockup.html, but a single centred column instead of the desktop
+  two-column stage: the page sits centre, cards stack full width, the graph is
+  a tall portrait constellation with every chip clamped inside the viewport,
+  and the progress rail is a horizontal dot row pinned to the bottom.
+
+  This is the design + verification artifact for the mobile branch of
+  ScrollStory.svelte (render it at 390x844 with motion enabled). Keep the two
+  in sync the same way the desktop mockup tracks the desktop branch.
+-->
+<style>
+  :root {
+    --accent: #33507a;
+    --accent-strong: #26406a;
+    --accent-soft: rgba(51, 80, 122, 0.1);
+    --paper: #f3f5f7;
+    --ink: #1a1f28;
+    --ink-soft: #55606f;
+    --faint: #8a94a2;
+    --surface: #ffffff;
+    --surface-2: #edf0f4;
+    --line: #dbe0e7;
+    --serif: "Iowan Old Style", Palatino, Georgia, "Times New Roman", serif;
+    --mono: ui-monospace, "SF Mono", Menlo, monospace;
+    --t-location: #2f8f6b;
+    --t-creature: #c0492b;
+    --t-npc: #b07d1e;
+    --t-faction: #7a52b0;
+    --t-deity: #a8811f;
+    --t-item: #b83f7a;
+    --t-spell: #2f7fbf;
+    --t-quest: #2f8f8a;
+    --t-table: #556070;
+  }
+  html {
+    scroll-snap-type: y proximity;
+  }
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--mono);
+    margin: 0;
+  }
+
+  .scroller {
+    height: 720vh;
+    position: relative;
+  }
+  .snap {
+    position: absolute;
+    left: 0;
+    width: 1px;
+    height: 2px;
+    scroll-snap-align: start;
+  }
+  .stage {
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  /* hero copy: centred column near the top */
+  .hero-copy {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    top: 12vh;
+    width: 86vw;
+    max-width: 34ch;
+    z-index: 6;
+    text-align: center;
+  }
+  .hero-copy h1 {
+    font-family: var(--serif);
+    font-size: clamp(38px, 12vw, 54px);
+    line-height: 1.06;
+    margin: 0;
+    text-wrap: balance;
+  }
+  .hero-copy h1 .line {
+    display: block;
+  }
+  .hero-copy h1 .accent {
+    color: var(--accent);
+    font-size: 0.6em;
+    margin-top: 4px;
+  }
+  .hero-copy p {
+    color: var(--ink-soft);
+    font-size: 14px;
+    line-height: 1.6;
+    margin: 14px auto 0;
+    max-width: 34ch;
+  }
+  .cue {
+    margin-top: 20px;
+    color: var(--faint);
+    font-size: 11px;
+    letter-spacing: 0.18em;
+  }
+  .cue .arrow {
+    display: inline-block;
+    animation: nudge 1.6s ease-in-out infinite;
+  }
+  @keyframes nudge {
+    50% {
+      transform: translateY(4px);
+    }
+  }
+
+  /* caption: top-left strip, compact for narrow screens */
+  .caption {
+    position: absolute;
+    left: 5vw;
+    top: 4vh;
+    z-index: 8;
+    max-width: 88vw;
+    opacity: 0;
+    pointer-events: none;
+    padding: 10px 14px 12px;
+    margin: -10px -14px;
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--paper) 82%, transparent);
+    backdrop-filter: blur(3px);
+  }
+  .caption .num {
+    font-size: 11px;
+    color: var(--accent);
+    font-weight: 700;
+    letter-spacing: 0.16em;
+  }
+  .caption .txt {
+    font-family: var(--serif);
+    font-size: 16px;
+    line-height: 1.34;
+    margin-top: 3px;
+    max-width: 30ch;
+  }
+
+  /* the page scan */
+  .page-wrap {
+    position: absolute;
+    z-index: 2;
+    will-change: transform, opacity;
+    filter: drop-shadow(0 14px 32px rgba(26, 31, 40, 0.26));
+  }
+  .page-wrap img {
+    width: 100%;
+    height: 100%;
+    display: block;
+    border-radius: 3px;
+  }
+  .overlay {
+    position: absolute;
+    inset: 0;
+  }
+  .bbox {
+    position: absolute;
+    border: 1.5px solid;
+    border-radius: 2px;
+    opacity: 0;
+    will-change: transform, opacity;
+  }
+  .bbox.k-header,
+  .flyer.k-header {
+    border-color: var(--t-creature);
+    background: color-mix(in srgb, var(--t-creature) 14%, transparent);
+  }
+  .bbox.k-text,
+  .bbox.k-caption,
+  .flyer.k-text,
+  .flyer.k-caption {
+    border-color: var(--t-spell);
+    background: color-mix(in srgb, var(--t-spell) 10%, transparent);
+  }
+  .bbox.k-aside,
+  .flyer.k-aside {
+    border-color: var(--t-npc);
+    background: color-mix(in srgb, var(--t-npc) 14%, transparent);
+  }
+  .bbox.k-art,
+  .flyer.k-art {
+    border-color: var(--t-faction);
+    background: color-mix(in srgb, var(--t-faction) 10%, transparent);
+  }
+  .flyers {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    pointer-events: none;
+  }
+  .flyer {
+    position: absolute;
+    border: 1.5px solid;
+    opacity: 0;
+    will-change: left, top, width, height, opacity;
+  }
+  .attribution {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -34px;
+    font-size: 9.5px;
+    color: var(--faint);
+    text-align: center;
+    line-height: 1.4;
+  }
+
+  /* chunk cards: full-width column, top-anchored so all seven fit */
+  .chunks {
+    position: absolute;
+    left: 4vw;
+    right: 4vw;
+    top: 15vh;
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+    z-index: 3;
+  }
+  .chunk-card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 8px 12px;
+    opacity: 0;
+    will-change: transform, opacity;
+    box-shadow: 0 4px 14px rgba(26, 31, 40, 0.06);
+  }
+  .chunk-card .path {
+    font-size: 9px;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--accent);
+    font-weight: 700;
+  }
+  .chunk-card .body {
+    font-family: var(--serif);
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--ink-soft);
+    margin-top: 3px;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .chunk-card mark {
+    background: transparent;
+    color: inherit;
+    border-radius: 3px;
+    padding: 0 2px;
+  }
+
+  /* entity chips + graph */
+  .graph {
+    position: absolute;
+    inset: 0;
+    z-index: 4;
+    pointer-events: none;
+  }
+  .edges {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+  .edges line {
+    stroke: var(--faint);
+    stroke-opacity: 0.45;
+    stroke-width: 1;
+  }
+  .chip {
+    position: absolute;
+    left: 0;
+    top: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 3px 9px 3px 6px;
+    font-size: 10px;
+    font-weight: 600;
+    opacity: 0;
+    will-change: transform, opacity;
+    white-space: nowrap;
+    box-shadow: 0 2px 8px rgba(26, 31, 40, 0.08);
+    cursor: pointer;
+  }
+  .chip .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex: none;
+  }
+  .chip.lit {
+    box-shadow:
+      0 0 0 3px color-mix(in srgb, var(--accent) 35%, transparent),
+      0 2px 8px rgba(26, 31, 40, 0.12);
+  }
+  .chip.open {
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 45%, transparent);
+  }
+
+  .popout {
+    position: absolute;
+    z-index: 12;
+    width: 260px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 13px 15px;
+    box-shadow: 0 14px 44px rgba(26, 31, 40, 0.2);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(6px) scale(0.97);
+    transition:
+      opacity 0.18s ease,
+      transform 0.18s ease;
+  }
+  .popout.on {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0) scale(1);
+  }
+  .popout .ptype {
+    display: inline-block;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    border-radius: 4px;
+    padding: 2px 7px;
+  }
+  .popout .pname {
+    font-family: var(--serif);
+    font-size: 18px;
+    font-weight: 600;
+    margin-top: 7px;
+  }
+  .popout .prels {
+    margin: 10px 0 0;
+    padding: 0;
+    list-style: none;
+  }
+  .popout .prels li {
+    font-size: 10.5px;
+    color: var(--ink-soft);
+    padding: 4px 0;
+    border-top: 1px solid var(--surface-2);
+    display: flex;
+    gap: 6px;
+    align-items: baseline;
+  }
+  .popout .rel {
+    color: var(--faint);
+    font-size: 9px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    flex: none;
+  }
+  .popout .pfoot {
+    margin-top: 10px;
+    font-size: 9.5px;
+    color: var(--faint);
+  }
+
+  /* scale phase */
+  .constellation {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+  }
+  .scale-panel,
+  .chat-head {
+    position: absolute;
+    left: 50%;
+    top: 8vh;
+    transform: translateX(-50%);
+    z-index: 6;
+    text-align: center;
+    opacity: 0;
+    width: 92vw;
+    padding: 18px 18px 18px;
+    border-radius: 16px;
+    background: color-mix(in srgb, var(--paper) 80%, transparent);
+    backdrop-filter: blur(3px);
+    pointer-events: none;
+  }
+  .chat-head {
+    top: 7vh;
+  }
+  .scale-head {
+    font-family: var(--serif);
+    font-size: clamp(23px, 7vw, 32px);
+    font-weight: 600;
+    text-wrap: balance;
+  }
+  .this-page {
+    margin-top: 14px;
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-soft);
+    display: flex;
+    justify-content: center;
+    align-items: baseline;
+    gap: 7px;
+    flex-wrap: wrap;
+  }
+  .this-page .k {
+    color: var(--faint);
+    font-weight: 700;
+    font-size: 9px;
+  }
+  .this-page .arrow {
+    color: var(--accent);
+    font-size: 13px;
+  }
+  .counters {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px 8px;
+    margin-top: 16px;
+  }
+  .counter .n {
+    font-family: var(--serif);
+    font-size: clamp(26px, 8vw, 38px);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+  }
+  .counter .l {
+    font-size: 9.5px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ink-soft);
+    margin-top: 2px;
+  }
+  .type-chips {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 6px;
+    margin: 16px auto 0;
+  }
+  .tchip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 3px 10px 3px 6px;
+    font-size: 10px;
+    font-weight: 600;
+    box-shadow: 0 2px 8px rgba(26, 31, 40, 0.06);
+  }
+  .tchip .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+  }
+  .tchip .n {
+    color: var(--ink-soft);
+    font-variant-numeric: tabular-nums;
+    font-weight: 400;
+  }
+  .chat-sub {
+    margin-top: 6px;
+    font-family: var(--serif);
+    font-size: 14px;
+    color: var(--ink-soft);
+  }
+
+  .chat {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, 120vh);
+    width: 92vw;
+    z-index: 7;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    padding: 18px 18px 16px;
+    box-shadow: 0 18px 60px rgba(26, 31, 40, 0.18);
+    will-change: transform;
+  }
+  .bubble-q {
+    background: var(--accent);
+    color: #fff;
+    border-radius: 12px 12px 3px 12px;
+    padding: 9px 13px;
+    font-size: 13px;
+    max-width: 88%;
+    margin-left: auto;
+    width: fit-content;
+  }
+  .bubble-a {
+    font-family: var(--serif);
+    font-size: 14.5px;
+    line-height: 1.5;
+    margin-top: 12px;
+    min-height: 9em;
+  }
+  .bubble-a .sent {
+    opacity: 0;
+  }
+  .bubble-a .pbreak {
+    display: block;
+    height: 0.7em;
+  }
+  .bubble-a mark {
+    background: transparent;
+    font-weight: 600;
+  }
+  .grounded {
+    margin-top: 10px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+    opacity: 0;
+  }
+  .grounded .lbl {
+    font-size: 9px;
+    letter-spacing: 0.16em;
+    color: var(--faint);
+    font-weight: 700;
+  }
+  .gchip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 2px 9px 2px 5px;
+    font-size: 10px;
+    font-weight: 600;
+    background: var(--surface-2);
+    font-family: var(--mono);
+    color: var(--ink);
+    cursor: pointer;
+  }
+  .gchip .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+  }
+  .ctas {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 14px;
+    opacity: 0;
+  }
+  .cta {
+    text-align: center;
+    padding: 12px 8px;
+    border-radius: 8px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    text-decoration: none;
+  }
+  .cta.primary {
+    background: var(--accent);
+    color: #fff;
+  }
+  .cta.ghost {
+    border: 1px solid var(--line);
+    color: var(--accent);
+  }
+  .mock-note {
+    position: absolute;
+    right: 10px;
+    top: 8px;
+    font-size: 9px;
+    color: var(--faint);
+  }
+
+  /* progress rail: horizontal dot row pinned to the bottom */
+  .rail {
+    position: fixed;
+    left: 50%;
+    bottom: 12px;
+    transform: translateX(-50%);
+    z-index: 10;
+    display: flex;
+    flex-direction: row;
+    gap: 12px;
+    padding: 8px 14px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--paper) 78%, transparent);
+    backdrop-filter: blur(4px);
+    box-shadow: 0 2px 10px rgba(26, 31, 40, 0.1);
+  }
+  .rail button {
+    all: unset;
+    cursor: pointer;
+    display: block;
+  }
+  .rail button::before {
+    content: "";
+    display: block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    border: 1.5px solid var(--faint);
+  }
+  .rail button.on::before {
+    background: var(--accent);
+    border-color: var(--accent);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .scroller,
+    .rail {
+      display: none;
+    }
+  }
+</style>
+
+<div class="scroller" id="scroller">
+  <div class="stage" id="stage">
+    <canvas class="constellation" id="constellation"></canvas>
+
+    <div class="hero-copy" id="heroCopy">
+      <h1>
+        <span class="line">Grimoire.</span
+        ><span class="line accent">From scan to query.</span>
+      </h1>
+      <p>
+        Watch one page of Lost Mine of Phandelver become structured, queryable
+        knowledge.
+      </p>
+      <div class="cue">SCROLL <span class="arrow">&darr;</span></div>
+    </div>
+
+    <div class="page-wrap" id="pageWrap">
+      <img
+        id="pageImg"
+        src="__IMG__"
+        alt="Scanned book page: Nezznar the Black Spider"
+      />
+      <div class="overlay" id="overlay"></div>
+      <div class="attribution">
+        Lost Mine of Phandelver, p.50 &middot; Wizards of the Coast &middot;
+        excerpt shown for demonstration
+      </div>
+    </div>
+
+    <div class="flyers" id="flyers"></div>
+
+    <div class="chunks" id="chunks"></div>
+
+    <div class="graph" id="graph">
+      <svg class="edges" id="edgesSvg"></svg>
+      <div id="chips"></div>
+    </div>
+
+    <div class="popout" id="popout"></div>
+
+    <div class="scale-panel" id="scalePanel">
+      <div class="scale-head">One page in. The whole shelf follows.</div>
+      <div class="this-page" id="thisPage"></div>
+      <div class="counters" id="counters"></div>
+      <div class="type-chips" id="typeChips"></div>
+    </div>
+
+    <div class="chat-head" id="chatHead">
+      <div class="scale-head">Ask the Grimoire.</div>
+      <div class="chat-sub">
+        Every claim cites the chunks and entities it came from.
+      </div>
+    </div>
+
+    <div class="chat" id="chat">
+      <div class="mock-note">mock transcript</div>
+      <div class="bubble-q" id="bubbleQ"></div>
+      <div class="bubble-a" id="bubbleA"></div>
+      <div class="grounded" id="grounded">
+        <span class="lbl">GROUNDED IN</span>
+      </div>
+      <div class="ctas" id="ctas">
+        <a class="cta primary" href="#">Ask the Grimoire</a>
+        <a class="cta ghost" href="#">Wander the graph</a>
+        <a class="cta ghost" href="#">Browse the library</a>
+      </div>
+    </div>
+
+    <div class="caption" id="caption">
+      <div class="num" id="capNum"></div>
+      <div class="txt" id="capTxt"></div>
+    </div>
+  </div>
+</div>
+
+<div class="rail" id="rail"></div>
+
+<script>
+  const DATA = __DATA__;
+  const TYPE = {
+    location: "#2f8f6b",
+    creature: "#c0492b",
+    npc: "#b07d1e",
+    faction: "#7a52b0",
+    deity: "#a8811f",
+    item: "#b83f7a",
+    spell: "#2f7fbf",
+    quest: "#2f8f8a",
+    table: "#556070",
+  };
+  const clamp = (v, a, b) => Math.min(Math.max(v, a), b);
+  const lerp = (a, b, t) => a + (b - a) * t;
+  const ease = (t) => (t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2);
+  const sub = (t, a, b) => clamp((t - a) / (b - a), 0, 1);
+  const outCubic = (t) => 1 - (1 - t) ** 3;
+  const outQuart = (t) => 1 - (1 - t) ** 4;
+  const inOutCubic = (t) => (t < 0.5 ? 4 * t ** 3 : 1 - (-2 * t + 2) ** 3 / 2);
+  const outBack = (t) => 1 + 2.2 * (t - 1) ** 3 + 1.2 * (t - 1) ** 2;
+  const outExpo = (t) => (t >= 1 ? 1 : 1 - 2 ** (-10 * t));
+
+  const PHASES = [
+    { id: "hero", start: 0.0, end: 0.08, rest: 0.0, label: "PAGE" },
+    {
+      id: "layout",
+      start: 0.08,
+      end: 0.26,
+      hold: 0.2,
+      rest: 0.22,
+      label: "LAYOUT",
+    },
+    {
+      id: "chunks",
+      start: 0.26,
+      end: 0.44,
+      hold: 0.38,
+      rest: 0.4,
+      label: "CHUNKS",
+    },
+    {
+      id: "entities",
+      start: 0.44,
+      end: 0.66,
+      hold: 0.56,
+      rest: 0.6,
+      label: "ENTITIES",
+    },
+    {
+      id: "scale",
+      start: 0.66,
+      end: 0.82,
+      hold: 0.76,
+      rest: 0.79,
+      label: "SHELF",
+    },
+    { id: "chat", start: 0.82, end: 1.0, hold: 0.97, rest: 1.0, label: "ASK" },
+  ];
+  const CAPTIONS = {
+    layout: [
+      "1 / LAYOUT DETECTION",
+      "Marker reads the scanned page and finds its structure: headers, columns, asides, art.",
+    ],
+    chunks: [
+      "2 / STRUCTURAL CHUNKING",
+      "Blocks become chunks in reading order, keyed to their section.",
+    ],
+    entities: [
+      "3 / ENTITY EXTRACTION",
+      "An LLM emits typed entities and how they relate. Tap a node.",
+    ],
+  };
+  const TRANSCRIPT = {
+    q: "Who is the Black Spider, and what does he actually want?",
+    a: "The Black Spider is Nezznar, a drow directing events from the shadows: he sent the Cragmaw goblins after the Rockseeker brothers and planted the Redbrands in Phandalin. He is exploring Wave Echo Cave with his giant spiders, hunting the Forge of Spells.\n\nCapture him alive and deliver him to Sildar Hallwinter in Phandalin, and the party earns double XP.",
+    grounded: ["Nezznar", "Wave Echo Cave", "Redbrands", "Sildar Hallwinter"],
+  };
+
+  const stage = document.getElementById("stage");
+  const scroller = document.getElementById("scroller");
+  const pageWrap = document.getElementById("pageWrap");
+  const overlay = document.getElementById("overlay");
+  const aspect = DATA.source.aspect;
+
+  const boxEls = DATA.bboxes.map((b) => {
+    const el = document.createElement("div");
+    el.className = "bbox k-" + b.kind;
+    el.style.left = b.x * 100 + "%";
+    el.style.top = b.y * 100 + "%";
+    el.style.width = b.w * 100 + "%";
+    el.style.height = b.h * 100 + "%";
+    overlay.appendChild(el);
+    return el;
+  });
+
+  const chunksEl = document.getElementById("chunks");
+  const entById = Object.fromEntries(DATA.entities.map((e) => [e.id, e]));
+  const esc = (s) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+  const PHRASES = [
+    ...DATA.entities.map((e) => ({
+      phrase: e.name,
+      color: TYPE[e.type] || "#556070",
+    })),
+    ...DATA.mentions
+      .filter((m) => m.text && entById[m.entity])
+      .map((m) => ({
+        phrase: m.text,
+        color: TYPE[entById[m.entity].type] || "#556070",
+      })),
+  ].sort((a, b) => b.phrase.length - a.phrase.length);
+
+  function segmentize(text) {
+    const lower = text.toLowerCase();
+    const marks = [];
+    for (const { phrase, color } of PHRASES) {
+      const nm = phrase.toLowerCase();
+      if (nm.length < 4) continue;
+      let idx = 0;
+      while ((idx = lower.indexOf(nm, idx)) !== -1) {
+        const end = idx + nm.length;
+        if (!marks.some((m) => idx < m.end && end > m.start))
+          marks.push({ start: idx, end, color });
+        idx = end;
+      }
+    }
+    marks.sort((a, b) => a.start - b.start);
+    const segs = [];
+    let pos = 0;
+    for (const m of marks) {
+      if (m.start > pos) segs.push({ t: text.slice(pos, m.start) });
+      segs.push({ t: text.slice(m.start, m.end), c: m.color });
+      pos = m.end;
+    }
+    if (pos < text.length) segs.push({ t: text.slice(pos) });
+    return segs;
+  }
+
+  const cardEls = DATA.chunks.map((c) => {
+    const el = document.createElement("div");
+    el.className = "chunk-card";
+    const body = segmentize(c.content.slice(0, 240))
+      .map((s) => (s.c ? `<mark data-c="${s.c}">${esc(s.t)}</mark>` : esc(s.t)))
+      .join("");
+    el.innerHTML = `<div class="path">${esc(c.section.split("/").pop())}</div><div class="body">${body}</div>`;
+    chunksEl.appendChild(el);
+    return el;
+  });
+  const markEls = [...chunksEl.querySelectorAll("mark")];
+
+  // flyers: one per bbox that belongs to a chunk (lifts off page, lands on card)
+  const cardIndexByChunk = {};
+  DATA.chunks.forEach((c, i) => (cardIndexByChunk[c.id] = i));
+  const flyersEl = document.getElementById("flyers");
+  const flyBoxes = DATA.bboxes
+    .map((b) => ({ ...b, card: cardIndexByChunk[b.chunkId] ?? -1 }))
+    .filter((f) => f.card >= 0);
+  const flyerEls = flyBoxes.map((f) => {
+    const el = document.createElement("div");
+    el.className = "flyer k-" + f.kind;
+    flyersEl.appendChild(el);
+    return el;
+  });
+
+  function mulberry32(a) {
+    return () => {
+      a |= 0;
+      a = (a + 0x6d2b79f5) | 0;
+      let t = Math.imul(a ^ (a >>> 15), 1 | a);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+  const rand = mulberry32(49);
+  const nodes = DATA.entities.map((e) => ({
+    ...e,
+    x: rand() * 2 - 1,
+    y: rand() * 2 - 1,
+  }));
+  const nById = Object.fromEntries(nodes.map((n) => [n.id, n]));
+  const idxById = Object.fromEntries(nodes.map((n, i) => [n.id, i]));
+  const edges = DATA.edges.filter((e) => nById[e.from] && nById[e.to]);
+  for (let it = 0; it < 260; it++) {
+    for (const a of nodes)
+      for (const b of nodes) {
+        if (a === b) continue;
+        let dx = a.x - b.x,
+          dy = a.y - b.y,
+          d2 = dx * dx + dy * dy + 0.001;
+        const f = 0.0028 / d2;
+        a.x += dx * f;
+        a.y += dy * f;
+      }
+    for (const e of edges) {
+      const a = nById[e.from],
+        b = nById[e.to];
+      const dx = b.x - a.x,
+        dy = b.y - a.y,
+        d = Math.hypot(dx, dy);
+      const f = (d - 0.5) * 0.02;
+      a.x += (dx / d) * f;
+      a.y += (dy / d) * f;
+      b.x -= (dx / d) * f;
+      b.y -= (dy / d) * f;
+    }
+    for (const n of nodes) {
+      n.x *= 0.985;
+      n.y *= 0.985;
+    }
+  }
+  for (let it = 0; it < 60; it++) {
+    for (const a of nodes)
+      for (const b of nodes) {
+        if (a === b) continue;
+        const aw = 0.09 + a.name.length * 0.008,
+          bw = 0.09 + b.name.length * 0.008;
+        const dx = a.x - b.x,
+          dy = a.y - b.y;
+        const ox = (aw + bw) / 2 - Math.abs(dx),
+          oy = 0.13 - Math.abs(dy);
+        if (ox > 0 && oy > 0) {
+          const push = 0.5 * Math.min(ox, 0.02) * Math.sign(dx || 0.01);
+          a.x += push;
+          b.x -= push;
+          const pushY = 0.5 * Math.min(oy, 0.02) * Math.sign(dy || 0.01);
+          a.y += pushY;
+          b.y -= pushY;
+        }
+      }
+  }
+
+  const chipsEl = document.getElementById("chips");
+  const chipEls = nodes.map((n, i) => {
+    const el = document.createElement("button");
+    el.className = "chip";
+    el.innerHTML = `<span class="dot" style="background:${TYPE[n.type] || "#556070"}"></span>${n.name}`;
+    el.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      togglePopout(i);
+    });
+    chipsEl.appendChild(el);
+    return el;
+  });
+  const svg = document.getElementById("edgesSvg");
+  const lineEls = edges.map(() => {
+    const l = document.createElementNS("http://www.w3.org/2000/svg", "line");
+    svg.appendChild(l);
+    return l;
+  });
+
+  const popout = document.getElementById("popout");
+  let popIdx = -1,
+    popAnchor = null,
+    popT = 0;
+  function togglePopout(i, anchor = null) {
+    if (popIdx === i) return closePopout();
+    popIdx = i;
+    popAnchor = anchor;
+    popT = lastT;
+    const n = nodes[i];
+    const color = TYPE[n.type] || "#556070";
+    const rels = edges
+      .filter((e) => e.from === n.id || e.to === n.id)
+      .slice(0, 6)
+      .map((e) => {
+        const other = nById[e.from === n.id ? e.to : e.from];
+        return `<li><span class="rel">${e.type.replace(/_/g, " ")}</span> ${other.name}</li>`;
+      })
+      .join("");
+    const nMentions = DATA.mentions.filter((m) => m.entity === n.id).length;
+    popout.innerHTML = `
+      <span class="ptype" style="color:${color};background:color-mix(in srgb, ${color} 12%, transparent)">${n.type}</span>
+      <div class="pname">${n.name}</div>
+      <ul class="prels">${rels || "<li><span class='rel'>no relationships on this page</span></li>"}</ul>
+      <div class="pfoot">extracted from ${nMentions} mention${nMentions === 1 ? "" : "s"} on this page</div>`;
+    chipEls.forEach((c, j) => c.classList.toggle("open", j === i));
+    popout.classList.add("on");
+    placePopout();
+  }
+  function closePopout() {
+    popIdx = -1;
+    popAnchor = null;
+    popout.classList.remove("on");
+    chipEls.forEach((c) => c.classList.remove("open"));
+  }
+  function placePopout() {
+    if (popIdx < 0) return;
+    const [x, y] = popAnchor || lastNodePos[popIdx] || [W / 2, H / 2];
+    popout.style.left = clamp(x - 130, 10, W - 270) + "px";
+    popout.style.top = clamp(y + 16, 12, H - 220) + "px";
+  }
+  document.addEventListener("click", closePopout);
+  addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closePopout();
+  });
+
+  const countersEl = document.getElementById("counters");
+  const COUNTS = [
+    ["books", DATA.corpus.books],
+    ["chunks", DATA.corpus.chunks],
+    ["entities", DATA.corpus.entities],
+    ["relationships", DATA.corpus.edges],
+  ];
+  const counterEls = COUNTS.map(([l]) => {
+    const d = document.createElement("div");
+    d.className = "counter";
+    d.innerHTML = `<div class="n">0</div><div class="l">${l}</div>`;
+    countersEl.appendChild(d);
+    return d.querySelector(".n");
+  });
+  document.getElementById("thisPage").innerHTML =
+    `<span class="k">THIS PAGE</span>` +
+    `<span>${DATA.bboxes.length} blocks</span><span class="k">/</span>` +
+    `<span>${DATA.chunks.length} chunks</span><span class="k">/</span>` +
+    `<span>${DATA.entities.length} entities</span><span class="k">/</span>` +
+    `<span>${edges.length} rels</span>` +
+    `<span class="arrow">&darr;</span><span class="k">THE SHELF</span>`;
+  const typeChipsEl = document.getElementById("typeChips");
+  Object.entries(DATA.corpus.byType)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 6)
+    .forEach(([t, n]) => {
+      const el = document.createElement("span");
+      el.className = "tchip";
+      el.innerHTML = `<span class="dot" style="background:${TYPE[t] || "#556070"}"></span>${t} <span class="n">${n.toLocaleString("en-GB")}</span>`;
+      typeChipsEl.appendChild(el);
+    });
+
+  const canvas = document.getElementById("constellation");
+  const ctx = canvas.getContext("2d");
+  const crand = mulberry32(7);
+  const typePool = [];
+  Object.entries(DATA.corpus.byType).forEach(([t, n]) => {
+    for (let i = 0; i < Math.round((n / DATA.corpus.entities) * 1800); i++)
+      typePool.push(t);
+  });
+  const dots = typePool
+    .map(() => {
+      const r = Math.sqrt(crand()),
+        th = crand() * Math.PI * 2;
+      return {
+        x: 0.5 + r * Math.cos(th) * 0.52,
+        y: 0.5 + r * Math.sin(th) * 0.44,
+        r,
+        s: 1.1 + crand() * 1.6,
+        t: typePool[Math.floor(crand() * typePool.length)],
+      };
+    })
+    .sort((a, b) => a.r - b.r);
+
+  // chat answer: sentence-level reveal (matches the component)
+  const answerSents = [];
+  TRANSCRIPT.a.split("\n\n").forEach((para, pi) => {
+    para.split(/(?<=[.!?])\s+/).forEach((sentence) => {
+      answerSents.push({
+        pi,
+        html: segmentize(sentence)
+          .map((s) =>
+            s.c ? `<mark style="color:${s.c}">${esc(s.t)}</mark>` : esc(s.t),
+          )
+          .join(""),
+      });
+    });
+  });
+  document.getElementById("bubbleQ").textContent = TRANSCRIPT.q;
+  const bubbleA = document.getElementById("bubbleA");
+  const sentEls = answerSents.map((s, j) => {
+    if (j > 0 && s.pi !== answerSents[j - 1].pi) {
+      bubbleA.appendChild(document.createElement("span")).className = "pbreak";
+    }
+    const el = document.createElement("span");
+    el.className = "sent";
+    el.innerHTML = s.html + " ";
+    bubbleA.appendChild(el);
+    return el;
+  });
+  const groundedEl = document.getElementById("grounded");
+  const groundedNodes = TRANSCRIPT.grounded
+    .map((name) =>
+      nodes.find((n) => n.name.toLowerCase().includes(name.toLowerCase())),
+    )
+    .filter(Boolean);
+  groundedNodes.forEach((n) => {
+    const c = document.createElement("button");
+    c.className = "gchip";
+    c.innerHTML = `<span class="dot" style="background:${TYPE[n.type]}"></span>${n.name}`;
+    c.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      const r = ev.currentTarget.getBoundingClientRect();
+      togglePopout(nodes.indexOf(n), [r.left + 20, r.top - 250]);
+    });
+    groundedEl.appendChild(c);
+  });
+
+  const rail = document.getElementById("rail");
+  function scrollToRest(p) {
+    const span = scroller.offsetHeight - innerHeight;
+    scrollTo({ top: scroller.offsetTop + p.rest * span, behavior: "smooth" });
+  }
+  const railBtns = PHASES.map((p) => {
+    const b = document.createElement("button");
+    b.title = p.label;
+    b.onclick = () => scrollToRest(p);
+    rail.appendChild(b);
+    return b;
+  });
+  const snapEls = PHASES.map(() => {
+    const s = document.createElement("div");
+    s.className = "snap";
+    scroller.appendChild(s);
+    return s;
+  });
+
+  const heroCopy = document.getElementById("heroCopy");
+  const chatEl = document.getElementById("chat");
+  const ctasEl = document.getElementById("ctas");
+  const captionEl = document.getElementById("caption");
+  const capNum = document.getElementById("capNum");
+  const capTxt = document.getElementById("capTxt");
+  const scalePanel = document.getElementById("scalePanel");
+  const chatHead = document.getElementById("chatHead");
+
+  let W = 0,
+    H = 0,
+    pageW = 0,
+    pageH = 0,
+    pageCX = 0,
+    pageCY = 0;
+  const cardRest = [];
+  const chipHalf = [];
+  const lastNodePos = [];
+  function layout() {
+    W = innerWidth;
+    H = innerHeight;
+    // page: centred, sized for portrait (fits width with margin)
+    pageW = Math.min(W * 0.66, H * 0.46 * aspect);
+    pageH = pageW / aspect;
+    const left = (W - pageW) / 2;
+    const top = H * 0.5 - pageH / 2;
+    pageWrap.style.width = pageW + "px";
+    pageWrap.style.height = pageH + "px";
+    pageWrap.style.left = left + "px";
+    pageWrap.style.top = top + "px";
+    pageCX = left + pageW / 2;
+    pageCY = top + pageH / 2;
+    canvas.width = W * devicePixelRatio;
+    canvas.height = H * devicePixelRatio;
+    canvas.style.width = W + "px";
+    canvas.style.height = H + "px";
+    svg.setAttribute("viewBox", `0 0 ${W} ${H}`);
+    const span = scroller.offsetHeight - H;
+    snapEls.forEach((s, i) => (s.style.top = PHASES[i].rest * span + "px"));
+    const contRect = chunksEl.getBoundingClientRect();
+    cardEls.forEach((el, i) => {
+      cardRest[i] = {
+        x: contRect.left + el.offsetLeft,
+        y: contRect.top + el.offsetTop,
+        w: el.offsetWidth,
+        h: el.offsetHeight,
+      };
+    });
+    chipEls.forEach((el, i) => (chipHalf[i] = el.offsetWidth / 2));
+  }
+
+  // portrait constellation: x radius fits the narrow width, y spreads taller
+  function nodePos(n, shrink, chatP = 0) {
+    const cx = W * 0.5,
+      cy = H * 0.52;
+    const Rx = W * 0.4,
+      Ry = H * 0.32;
+    let sx = cx + n.x * Rx;
+    let sy = cy + n.y * Ry;
+    if (sy < H * 0.2) sy = H * 0.2 + (H * 0.2 - sy) * 0.3;
+    const kx = lerp(cx, W * 0.5, chatP),
+      ky = lerp(H * 0.72, H * 0.42, chatP);
+    return [
+      lerp(sx, kx + n.x * Rx * 0.2, shrink),
+      lerp(sy, ky + n.y * Ry * 0.12, shrink),
+    ];
+  }
+
+  function fmt(x) {
+    return Math.round(x).toLocaleString("en-GB");
+  }
+
+  function frame(t) {
+    const phase =
+      PHASES.find((p) => t >= p.start && t < p.end) ??
+      PHASES[PHASES.length - 1];
+    railBtns.forEach((b, i) => b.classList.toggle("on", PHASES[i] === phase));
+    const interactive =
+      phase.id === "entities" || phase.id === "scale" || phase.id === "chat";
+    if (popIdx >= 0 && (!interactive || Math.abs(t - popT) > 0.012))
+      closePopout();
+    chipsEl.style.pointerEvents =
+      phase.id === "entities" || phase.id === "scale" ? "auto" : "none";
+
+    // hero copy
+    const pHero = sub(t, 0.04, 0.08);
+    heroCopy.style.opacity = 1 - pHero;
+    heroCopy.style.transform = `translateX(-50%) translateY(${-pHero * 24}px)`;
+    heroCopy.style.visibility = pHero >= 1 ? "hidden" : "visible";
+
+    // page: settles, then dissolves upward as the flyers hand off to cards
+    const settle = outCubic(sub(t, 0, 0.08));
+    const slide = inOutCubic(sub(t, 0.26, 0.36));
+    const fade = inOutCubic(sub(t, 0.3, 0.44));
+    const rot = lerp(-3.2, 0, settle);
+    const scP = lerp(lerp(0.96, 1, settle), 0.88, slide);
+    // during the hero the page rides lower so the copy + SCROLL cue clear it,
+    // then lifts to centre as the page settles into the layout phase
+    const tYp = (1 - settle) * H * 0.08 + lerp(0, -H * 0.06, slide);
+    pageWrap.style.transform = `translate(0,${tYp}px) rotate(${rot}deg) scale(${scP})`;
+    pageWrap.style.opacity = 1 - fade;
+
+    // layout boxes
+    const pLay = sub(t, 0.08, 0.2);
+    const flyP = inOutCubic(sub(t, 0.27, 0.38));
+    DATA.bboxes.forEach((b, i) => {
+      const el = boxEls[i];
+      const dp = outQuart(
+        sub(
+          pLay,
+          (i / DATA.bboxes.length) * 0.7,
+          (i / DATA.bboxes.length) * 0.7 + 0.22,
+        ),
+      );
+      if (flyP <= 0) {
+        el.style.opacity = dp;
+        el.style.transform = `scaleY(${lerp(0.25, 1, dp)})`;
+      } else {
+        el.style.opacity = Math.max(0, 1 - flyP * (b.chunkId ? 4 : 3));
+        el.style.transform = "none";
+      }
+    });
+
+    // flyers: each chunk's boxes lift off the (centred) page and land on cards
+    const rawFly = sub(t, 0.27, 0.4);
+    const pcx = pageCX;
+    const pcy = pageCY + tYp;
+    const pw = pageW * scP;
+    const ph = pageH * scP;
+    flyBoxes.forEach((f, i) => {
+      const el = flyerEls[i];
+      const d = cardRest[f.card];
+      if (rawFly <= 0 || rawFly >= 1 || !d) {
+        el.style.opacity = 0;
+        return;
+      }
+      const fp = inOutCubic(sub(rawFly, f.card * 0.06, f.card * 0.06 + 0.55));
+      el.style.opacity =
+        Math.min(fp * 6, 1) * (1 - Math.max(0, (fp - 0.82) / 0.18));
+      el.style.left = lerp(pcx - pw / 2 + f.x * pw, d.x, fp) + "px";
+      el.style.top = lerp(pcy - ph / 2 + f.y * ph, d.y, fp) + "px";
+      el.style.width = lerp(f.w * pw, d.w, fp) + "px";
+      el.style.height = lerp(f.h * ph, d.h, fp) + "px";
+      el.style.borderRadius = lerp(2, 8, fp) + "px";
+    });
+
+    // chunk cards: rise+fade in, then fade out once chips extract
+    const pChunk = sub(t, 0.29, 0.4);
+    const cardsOut = inOutCubic(sub(t, 0.5, 0.58));
+    cardEls.forEach((el, i) => {
+      const dp = outCubic(sub(pChunk, i * 0.05, i * 0.05 + 0.5));
+      el.style.opacity = dp * (1 - cardsOut);
+      el.style.transform = `translateY(${lerp(12, 0, dp) - cardsOut * 26}px)`;
+    });
+    chunksEl.style.visibility = cardsOut >= 1 ? "hidden" : "visible";
+
+    // mention marks tint
+    const pMark = ease(sub(t, 0.44, 0.48));
+    markEls.forEach((m) => {
+      const c = m.dataset.c;
+      m.style.background =
+        pMark > 0
+          ? `color-mix(in srgb, ${c} ${Math.round(pMark * 22)}%, transparent)`
+          : "transparent";
+      m.style.color = pMark > 0.5 ? c : "inherit";
+      m.style.fontWeight = pMark > 0.5 ? "700" : "inherit";
+    });
+
+    // chips fly from the (centred) card column to their graph nodes
+    const pChip = sub(t, 0.47, 0.56);
+    const shrink = inOutCubic(sub(t, 0.66, 0.74));
+    const graphDim = outCubic(sub(t, 0.82, 0.88));
+    const chatShift = inOutCubic(sub(t, 0.82, 0.9));
+    nodes.forEach((n, i) => {
+      const el = chipEls[i];
+      const raw = sub(pChip, i * 0.025, i * 0.025 + 0.4);
+      const move = inOutCubic(raw);
+      const pop = outBack(raw);
+      const [gx0, gy0] = nodePos(n, shrink, chatShift);
+      const hw = chipHalf[i] || 60;
+      const gx = clamp(gx0, hw + 10, W - hw - 10);
+      const gy = clamp(gy0, H * 0.12, H * 0.9);
+      lastNodePos[i] = [gx, gy];
+      const x = lerp(W * 0.5, gx, move);
+      const y = lerp(H * 0.42, gy, move);
+      // during the shelf/chat phases the page's chips recede to a faint, small
+      // knot so the constellation (the whole corpus) reads as the figure
+      el.style.opacity =
+        Math.min(raw * 3, 1) * lerp(1, 0.22, Math.max(shrink, graphDim));
+      el.style.transform = `translate(${x}px,${y}px) translate(-50%,-50%) scale(${lerp(0.4, 1, pop) * lerp(1, 0.5, shrink)})`;
+    });
+    placePopout();
+    const pEdge = outCubic(sub(t, 0.52, 0.6));
+    lineEls.forEach((l, i) => {
+      const [x1, y1] = lastNodePos[idxById[edges[i].from]] || [0, 0];
+      const [x2, y2] = lastNodePos[idxById[edges[i].to]] || [0, 0];
+      l.setAttribute("x1", x1);
+      l.setAttribute("y1", y1);
+      l.setAttribute("x2", x2);
+      l.setAttribute("y2", y2);
+      const dp = clamp(pEdge * lineEls.length - i * 0.5, 0, 1);
+      l.style.strokeOpacity = 0.4 * dp * lerp(1, 0.25, graphDim);
+    });
+
+    // scale: constellation + counters + type breakdown
+    const pScale = sub(t, 0.66, 0.76);
+    const chatDim = ease(sub(t, 0.82, 0.88));
+    ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+    ctx.clearRect(0, 0, W, H);
+    if (pScale > 0) {
+      const vis = Math.floor(ease(pScale) * dots.length);
+      const alpha = lerp(1, 0.3, chatDim);
+      for (let i = 0; i < vis; i++) {
+        const d = dots[i];
+        const x = d.x * W,
+          y = d.y * H;
+        const edge = clamp(Math.min(x, W - x, y, H - y) / 70, 0, 1);
+        if (y > H - 54) continue; // keep the bottom rail area clear
+        if (edge <= 0) continue;
+        ctx.globalAlpha = 0.72 * alpha * edge;
+        ctx.fillStyle = TYPE[d.t] || "#556070";
+        ctx.beginPath();
+        ctx.arc(x, y, d.s, 0, 7);
+        ctx.fill();
+      }
+      ctx.globalAlpha = 1;
+    }
+    const pCount = outExpo(sub(t, 0.68, 0.76));
+    const panelIn = outCubic(sub(t, 0.665, 0.71));
+    scalePanel.style.opacity = panelIn * (1 - chatDim);
+    scalePanel.style.transform = `translateX(-50%) translateY(${lerp(16, 0, panelIn)}px)`;
+    counterEls.forEach(
+      (el, i) => (el.textContent = fmt(COUNTS[i][1] * pCount)),
+    );
+    typeChipsEl.style.opacity = ease(sub(t, 0.72, 0.76));
+
+    // chat
+    const pChat = sub(t, 0.82, 1);
+    const rise = outCubic(sub(pChat, 0, 0.14));
+    chatHead.style.opacity = rise * ease(sub(pChat, 0.04, 0.16));
+    chatEl.style.transform = `translate(-50%, calc(-42% + ${lerp(120, 0, rise)}vh))`;
+    const pSent = sub(pChat, 0.16, 0.66);
+    const step = answerSents.length > 1 ? 0.72 / answerSents.length : 1;
+    sentEls.forEach(
+      (el, j) =>
+        (el.style.opacity = outCubic(sub(pSent, j * step, j * step + 0.28))),
+    );
+    const pG = ease(sub(pChat, 0.7, 0.8));
+    groundedEl.style.opacity = pG;
+    groundedNodes.forEach((n) => {
+      const i = nodes.indexOf(n);
+      chipEls[i].classList.toggle("lit", pG > 0.5);
+      if (pG > 0.5) chipEls[i].style.opacity = 0.95;
+    });
+    ctasEl.style.opacity = ease(sub(pChat, 0.82, 0.92));
+
+    // caption
+    const cap = CAPTIONS[phase.id];
+    if (cap) {
+      const pin = sub(t, phase.start + 0.005, phase.start + 0.025);
+      const pout =
+        phase.id === "chat" ? 0 : sub(t, phase.end - 0.012, phase.end);
+      captionEl.style.opacity = Math.min(pin, 1 - pout);
+      capNum.textContent = cap[0];
+      capTxt.textContent = cap[1];
+    } else captionEl.style.opacity = 0;
+  }
+
+  let raf = 0,
+    lastT = 0;
+  function onFrame() {
+    raf = 0;
+    const r = scroller.getBoundingClientRect();
+    const span = r.height - H;
+    lastT = span > 0 ? clamp(-r.top / span, 0, 1) : 0;
+    frame(lastT);
+  }
+  function queue() {
+    if (!raf) raf = requestAnimationFrame(onFrame);
+  }
+  addEventListener("scroll", queue, { passive: true });
+  addEventListener(
+    "resize",
+    () => {
+      layout();
+      queue();
+    },
+    { passive: true },
+  );
+  layout();
+  onFrame();
+</script>


### PR DESCRIPTION
## What

Gives the public Grimoire landing's "From scan to query" scroll story a dedicated **portrait choreography** on narrow/touch screens, instead of cramming the wide two-column desktop composition into a phone.

The desktop stage is a two-column layout (scanned page on one side, chunk cards / entity graph fanning out to the other, progress rail in the right gutter). On a portrait phone it broke exactly as reported: the attribution caption and graph chips ran off the right edge, the progress rail overlapped the content column, and the chunk cards spilled past the viewport.

## How

A `mobile` flag is decided at mount (`max-width: 700px`, re-checked on resize) and drives a single centred column. Same six phases, same data, same scrub paradigm:

- **Page** centres and sizes for portrait, riding lower during the hero so the copy and SCROLL cue clear it, then dissolving upward as the flyers hand it off to the cards.
- **Chunk cards** stack full width, top-anchored, so all seven fit in one viewport (2-line clamp).
- **Entity graph** becomes a tall portrait constellation. Every chip is clamped inside the viewport by its measured half-width, so no label is ever cut off, and edges track the clamped chip centres so they stay attached.
- During the **shelf** phase the page's entities recede to a faint small knot inside the whole-corpus constellation.
- **Progress rail** becomes a horizontal dot row pinned to the bottom (the desktop right gutter has no room on a phone).
- Counters go 2x2, CTAs stack, the attribution wraps and centres.

The desktop paths are byte-identical: every divergence is `mobile ? new : existing-desktop-expr`, so wider viewports render exactly as before.

## Design + verification

The choreography was iterated in a committed `reference-mockup-mobile.html` (the same discipline the desktop `reference-mockup.html` follows), rendered at 390x844 with motion enabled. It was then ported into `ScrollStory.svelte` and verified by bundling and rendering the **real** component at 390x844 (zero runtime errors, all six phases correct). That end-to-end render matters here because CI's visual regression runs with `reducedMotion: reduce`, so it only exercises the static stacked fallback, never the scrubbed animation.

## Deploy

Public page change, so both `monolith` and `monolith-public` charts are bumped (per the public-tier checklist: `jomcgi.dev` is served by `monolith-public`).

- monolith `0.285.52` -> `0.285.55`
- monolith-public `0.89.17` -> `0.89.20`

## Files

- `ScrollStory.svelte` - mobile branch in `layout()` / `frame()` / `placePopout()`, `nodePosMobile()`, and a `.scrollstory.mobile` CSS layer
- `reference-mockup-mobile.html` - standalone portrait design/verification artifact
- chart + application manifests for both services

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bg4EBJB81kfnM2Eqc9d3qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bg4EBJB81kfnM2Eqc9d3qG)_