### PR TITLE
feat(readme): guard structure with a CI check plus a weekly refresh routine

### DIFF
--- a/.claude/skills/refresh-structure-docs/SKILL.md
+++ b/.claude/skills/refresh-structure-docs/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: refresh-structure-docs
+description: Freshen the root README's structural prose against the real repository, the judgment half that the CI structure check cannot cover, and land any change as a reviewable PR against main (never auto-merged). Use when asked to "refresh the README", "the README is out of date", "update the repo structure docs", or when the weekly refresh-structure-docs routine fires. The deterministic guardrail (broken links, unmentioned projects) is enforced separately in CI by bazel/tools/format/readme_structure; this skill handles the prose a test cannot judge.
+---
+
+Freshen the top-level `README.md` so its prose matches what the repository has
+actually become, and open a PR with any change. This is the judgment half of a
+two-part scheme:
+
+- **CI guardrail (deterministic, already enforced):**
+  `bazel/tools/format/readme_structure/check_readme_structure.py` fails the
+  "Format check" action on a link to a deleted project or a new top-level
+  `projects/*` dir mentioned nowhere. You do not need to re-police those; CI
+  already blocks them at merge.
+- **This skill (judgment):** the staleness a test cannot decide, a wrong model
+  name, a renamed subsystem, a count that has drifted, a new *major* project
+  worth promoting into the layout tree, a description that no longer fits.
+
+Land every change as a PR against `main`. **Never auto-merge** (unlike the STPA
+routine): README prose is a human-voice artifact and Joe reviews it.
+
+## Method
+
+1. **Read the current README and the mechanical status.** Read `README.md`.
+   Run `python3 ./bazel/tools/format/readme_structure/check_readme_structure.py`
+   from the repo root. A non-zero exit means the deterministic check is already
+   red on `main` (rare, since CI blocks it); if so, fix that first, it is the
+   highest-value edit.
+
+2. **Diff each structural claim against reality.** Work through the README
+   section by section and verify against the tree, not memory:
+   - **Systems / Applications lists:** does each linked path still exist and
+     still do what the blurb says? `ls` the target. Has a headline system been
+     added (a new `projects/*` with its own chart/deploy and a real story) that
+     deserves a bullet?
+   - **Repo layout tree:** does every entry still exist? Is a genuinely major
+     new project missing? The tree deliberately shows "major dirs" only, so do
+     NOT list every project, promote only ones that have become load-bearing.
+   - **Infrastructure patterns table:** spot-check the volatile cells, model
+     name and serving stack (grep `inference/` values and the actual deployed
+     model), CI/GitOps/mesh tooling names. These drift silently.
+   - **Counts and superlatives** ("N apps", "the big one"), confirm or drop.
+
+3. **Make the smallest honest edit.** Change only what is wrong. Do not
+   restructure, re-voice, or churn correct prose, a large diff is a signal you
+   overreached. Match the existing terse, declarative register. **Never write
+   an em-dash**; use a comma, colon, parentheses, or split the sentence (repo
+   rule, a `check-commit-msg-ascii.sh` gate rejects them in commit messages and
+   a non-ASCII em-dash in copy is off-voice regardless).
+
+4. **If nothing is stale, stop.** Do not open an empty or cosmetic PR. When the
+   README is accurate, say so and exit. A no-op week is the expected common case.
+
+5. **Land the change as a PR** (only if you edited something):
+   ```bash
+   git switch -c chore/refresh-structure-docs-$(git rev-parse --short HEAD)
+   git add README.md
+   git commit -m "docs: refresh README structure to match repo"
+   git push -u origin HEAD
+   gh pr create --fill --base main \
+     --title "docs: refresh README structure to match repo" \
+     --body "Weekly structure-docs refresh. What changed and why:\n<one line per edit>"
+   ```
+   Use rebase merge only, and only after Joe reviews. Do not enable auto-merge.
+
+## Scope guardrails
+
+- **Root `README.md` only.** Per-project READMEs are out of scope; if one looks
+  badly wrong, note it in the PR body rather than editing it here.
+- **Prose, not structure enforcement.** Adding a new project to satisfy the
+  coverage check is the author's job in their own PR (or a one-line
+  `COVERAGE_ALLOWLIST` entry); do not paper over a genuinely undocumented new
+  project just to green the check, surface it.
+- **One PR per run, small diff, no auto-merge.**

--- a/bazel/tools/format/readme_structure/BUILD
+++ b/bazel/tools/format/readme_structure/BUILD
@@ -1,0 +1,24 @@
+# Hand-managed targets (same convention as projects/firecracker/tools/env_readme):
+# the checker is invoked as plain python3 from the CI "Format check" step against
+# the full working tree (a sandboxed bazel test cannot list projects/* on RBE),
+# so only the pure-logic contract is pinned by a bazel test here.
+# gazelle:exclude check_readme_structure.py
+# gazelle:exclude check_readme_structure_test.py
+
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+load("//bazel/tools/pytest:defs.bzl", "py_test")
+
+py_library(
+    name = "check_readme_structure_lib",
+    srcs = ["check_readme_structure.py"],
+    imports = ["."],
+)
+
+py_test(
+    name = "check_readme_structure_test",
+    srcs = ["check_readme_structure_test.py"],
+    deps = [
+        ":check_readme_structure_lib",
+        "@pip//pytest",
+    ],
+)

--- a/bazel/tools/format/readme_structure/check_readme_structure.py
+++ b/bazel/tools/format/readme_structure/check_readme_structure.py
@@ -1,0 +1,167 @@
+"""Guard the root README's structural claims against the real tree.
+
+Two failure modes rot the top-level README as the repo changes:
+
+  1. **Deleted-project links**: a `[text](path)` in the README points at a
+     directory or file that no longer exists (a project was renamed/removed).
+  2. **Missing entries**: a new top-level `projects/*` directory lands with no
+     mention anywhere in the README.
+
+Both are mechanically decidable, so they are enforced here rather than left to
+a human noticing. Prose staleness (a wrong model name, an out-of-date count)
+needs judgment and is handled out of band by the weekly refresh routine.
+
+Invoked two ways, mirroring `projects/firecracker/tools/env_readme/`:
+
+  * As a CLI from the CI "Format check" step (`check()` against the real
+    checkout, `exit 1` on any violation). That step runs on the full working
+    tree, so it can list `projects/*` and resolve links, something a sandboxed
+    `bazel test` cannot do on RBE.
+  * As pure functions imported by `check_readme_structure_test.py`, which pins
+    the contract with synthetic inputs (sandbox-safe, no real files).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+# Top-level projects/* directories that are intentionally NOT called out in the
+# README. Keep this list honest and commented: adding a name here is a decision
+# that "this project is not worth a top-level README mention", not a way to
+# silence the check. A brand-new project should fail the coverage check until
+# someone either lists it in the README or adds it here on purpose.
+COVERAGE_ALLOWLIST = frozenset(
+    {
+        "__pycache__",  # stray bytecode, never a project
+        "shared",  # cross-project helpers, not a standalone system
+        # The README's layout tree explicitly shows "major dirs" only; these are
+        # real projects deliberately left out of that top-level tree. Promote one
+        # into the README (and drop it from here) if it grows into a headline system.
+        "advent_of_code",
+        "firecracker",
+        "grimoire",
+        "hikes",
+        "loom",
+        "model-bench",
+        "ships",
+        "websites",
+    }
+)
+
+# A repo-relative markdown link worth resolving: skip external schemes, in-page
+# anchors, and mailto. Captures the path, minus any #anchor or ?query tail.
+_LINK_RE = re.compile(r"\]\(([^)]+)\)")
+_SKIP_PREFIXES = ("http://", "https://", "mailto:", "#", "tel:")
+
+# A layout-tree entry: a line whose only leading content is tree-drawing glyphs
+# / whitespace, then a directory token ending in "/". The README documents most
+# top-level dirs this way (`├── platform/   # ...`) inside a `projects/` fence,
+# rather than as inline projects/<name> links, so both forms count as coverage.
+_TREE_ENTRY_RE = re.compile(r"(?m)^[\s│├└─|`+*-]*([A-Za-z0-9._-]+)/")
+
+
+def extract_repo_links(readme_text: str) -> list[str]:
+    """Repo-relative link targets from markdown, de-anchored and de-duped."""
+    seen: dict[str, None] = {}
+    for raw in _LINK_RE.findall(readme_text):
+        target = raw.strip()
+        if not target or target.startswith(_SKIP_PREFIXES):
+            continue
+        # Drop #fragment / ?query tails; a link to foo.md#heading resolves to foo.md.
+        target = target.split("#", 1)[0].split("?", 1)[0]
+        if target:
+            seen.setdefault(target, None)
+    return list(seen)
+
+
+def find_broken_links(
+    repo_root: pathlib.Path, readme_rel: str, readme_text: str
+) -> list[str]:
+    """Repo-relative links whose path does not exist on disk.
+
+    Links are resolved relative to the README's own directory, exactly as a
+    reader following them would.
+    """
+    base = (repo_root / readme_rel).parent
+    broken = []
+    for link in extract_repo_links(readme_text):
+        if not (base / link).exists():
+            broken.append(link)
+    return broken
+
+
+def mentioned_names(readme_text: str) -> set[str]:
+    """Top-level names the README documents, in either supported form.
+
+    A name counts as documented if it appears as an inline `projects/<name>`
+    link OR as a `<name>/` entry in a layout tree. A bare prose mention of the
+    name is intentionally NOT enough: the point is that the structural
+    references stay real, not that the word appears somewhere.
+    """
+    names = set(_TREE_ENTRY_RE.findall(readme_text))
+    for link in extract_repo_links(readme_text):
+        parts = link.split("/")
+        if len(parts) >= 2 and parts[0] == "projects" and parts[1]:
+            names.add(parts[1])
+    return names
+
+
+def find_uncovered_projects(
+    project_dirs: list[str],
+    readme_text: str,
+    allowlist: frozenset[str] = COVERAGE_ALLOWLIST,
+) -> list[str]:
+    """Top-level project names neither documented in the README nor allowlisted."""
+    documented = mentioned_names(readme_text)
+    return [
+        name
+        for name in project_dirs
+        if name not in allowlist and name not in documented
+    ]
+
+
+def list_project_dirs(repo_root: pathlib.Path) -> list[str]:
+    """Names of the immediate subdirectories of projects/."""
+    projects = repo_root / "projects"
+    return sorted(p.name for p in projects.iterdir() if p.is_dir())
+
+
+def check(repo_root: pathlib.Path, readme_rel: str = "README.md") -> list[str]:
+    """Return human-readable violation lines; empty means the README is intact."""
+    readme_text = (repo_root / readme_rel).read_text()
+    violations = []
+
+    for link in find_broken_links(repo_root, readme_rel, readme_text):
+        violations.append(
+            f"{readme_rel}: link target does not exist: {link} "
+            f"(a project may have been renamed or removed)"
+        )
+
+    project_dirs = list_project_dirs(repo_root)
+    for name in find_uncovered_projects(project_dirs, readme_text):
+        violations.append(
+            f"projects/{name}: new top-level project not referenced in {readme_rel}. "
+            f"Either add it to the README or, if it is intentionally minor, add "
+            f"'{name}' to COVERAGE_ALLOWLIST in "
+            f"bazel/tools/format/readme_structure/check_readme_structure.py"
+        )
+
+    return violations
+
+
+def main() -> int:
+    repo_root = pathlib.Path.cwd()
+    violations = check(repo_root)
+    if not violations:
+        print("README structure intact")
+        return 0
+    print("README structure check failed:", file=sys.stderr)
+    for v in violations:
+        print(f"  - {v}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bazel/tools/format/readme_structure/check_readme_structure_test.py
+++ b/bazel/tools/format/readme_structure/check_readme_structure_test.py
@@ -1,0 +1,73 @@
+"""Tests for check_readme_structure.py.
+
+These use synthetic README text and a synthetic project-name list so the test
+is sandbox-safe (no dependency on the real working tree, which a bazel test on
+RBE cannot see). The real-tree enforcement runs as a standalone CLI in the CI
+"Format check" step; here we only pin the logic contract.
+"""
+
+import pathlib
+
+from check_readme_structure import (
+    extract_repo_links,
+    find_broken_links,
+    find_uncovered_projects,
+)
+
+README = """# Homelab
+
+- [Monolith](projects/monolith/): the big one
+- [Sextant](projects/sextant/): code generator
+- [Security](docs/security.md#threat-model): anchored link
+- [GitHub](https://github.com/jomcgi/homelab): external, ignored
+- Contact: [email](mailto:joe@example.com)
+"""
+
+
+def test_extract_ignores_external_anchor_and_mailto():
+    links = extract_repo_links(README)
+    assert "projects/monolith/" in links
+    assert "docs/security.md" in links  # #threat-model stripped
+    assert not any(link.startswith(("http", "mailto")) for link in links)
+    assert "#threat-model" not in "".join(links)
+
+
+def test_broken_link_detected(tmp_path: pathlib.Path):
+    (tmp_path / "projects" / "monolith").mkdir(parents=True)
+    (tmp_path / "projects" / "sextant").mkdir()
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "security.md").write_text("x")
+    # README links to projects/sextant/, which exists, and projects/monolith/,
+    # which exists, but we delete sextant to simulate a removed project.
+    (tmp_path / "projects" / "sextant").rmdir()
+
+    broken = find_broken_links(tmp_path, "README.md", README)
+    assert broken == ["projects/sextant/"]
+
+
+def test_no_broken_links_when_all_present(tmp_path: pathlib.Path):
+    for d in ("projects/monolith", "projects/sextant", "docs"):
+        (tmp_path / d).mkdir(parents=True)
+    (tmp_path / "docs" / "security.md").write_text("x")
+    assert find_broken_links(tmp_path, "README.md", README) == []
+
+
+def test_uncovered_project_detected():
+    dirs = ["monolith", "sextant", "brand_new_thing"]
+    uncovered = find_uncovered_projects(dirs, README, allowlist=frozenset())
+    assert uncovered == ["brand_new_thing"]
+
+
+def test_allowlisted_project_is_covered():
+    dirs = ["monolith", "brand_new_thing"]
+    uncovered = find_uncovered_projects(
+        dirs, README, allowlist=frozenset({"brand_new_thing"})
+    )
+    assert uncovered == []
+
+
+def test_mention_requires_projects_path_not_bare_name():
+    # The README talks about "sextant" in prose but never links projects/sextant.
+    readme = "# Homelab\n\nWe use sextant to generate code.\n"
+    uncovered = find_uncovered_projects(["sextant"], readme, allowlist=frozenset())
+    assert uncovered == ["sextant"]

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -50,6 +50,12 @@ actions:
           # executable; a 644 script exits 126 in sessions and enforces nothing.
           ./bazel/tools/hooks/validate-hooks-executable.sh
 
+          # The root README's structural claims must stay real: no links to
+          # deleted projects, no new top-level projects/* dir left unmentioned.
+          # Runs on the full checkout (a sandboxed bazel test cannot list
+          # projects/* on RBE); the pure logic is pinned by a bazel test.
+          python3 ./bazel/tools/format/readme_structure/check_readme_structure.py
+
           # Check for formatting changes
           if git diff --exit-code; then
             echo "All files formatted correctly"

--- a/projects/monolith/claude_routines/refresh-structure-docs.yaml
+++ b/projects/monolith/claude_routines/refresh-structure-docs.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=./schema.json
+name: Refresh Structure Docs (weekly)
+schedule:
+  cron: "0 7 * * 1" # Mondays 07:00 UTC
+enabled: true
+model: claude-sonnet-4-6
+environment: Default
+sources:
+  - https://github.com/jomcgi/homelab
+allowed_tools: []
+mcp_connectors:
+  - homelab
+prompt: |
+  Freshen the root README's structural prose against the real repository and
+  open a reviewable PR with any change. This is the judgment half of the repo's
+  structure-docs scheme: the deterministic guardrail (links to deleted
+  projects, unmentioned new projects/* dirs) is already enforced in CI by
+  bazel/tools/format/readme_structure, so do NOT re-police those, handle the
+  staleness a test cannot judge.
+
+  Follow the `refresh-structure-docs` skill in this repo
+  (.claude/skills/refresh-structure-docs/SKILL.md) for the full method. In brief:
+
+  1. Read README.md and run
+     `python3 ./bazel/tools/format/readme_structure/check_readme_structure.py`
+     for the mechanical status.
+  2. Diff each structural claim against the real tree: the Systems and
+     Applications lists (do linked paths still exist and still fit their
+     blurb?), the layout tree (any headline new project missing?), and the
+     Infrastructure patterns table (model name, serving stack, tooling names
+     drift silently, spot-check them against inference/ values and the cluster).
+  3. Make the smallest honest edit. Match the terse register. Never write an
+     em-dash (repo rule): use a comma, colon, parentheses, or split the sentence.
+  4. If nothing is stale, stop. Do NOT open an empty or cosmetic PR, a no-op
+     week is the expected common case.
+  5. If you edited something, land it as a PR against main with a body listing
+     what changed and why. NEVER auto-merge and never enable auto-merge, Joe
+     reviews README prose.
+
+  Constraints:
+    - Root README.md only. Note (do not edit) badly-wrong per-project READMEs
+      in the PR body.
+    - At most one PR per run, small diff.
+    - Do not add a project to the README just to green the coverage check, that
+      is the author's job; surface a genuinely undocumented new project instead.


### PR DESCRIPTION
## What

The top-level `README.md` quietly rots as projects come and go. This adds a two-part scheme to keep it honest, matching what was discussed: a **test** (merge-time guardrail) plus a **weekly cron** (picks up the prose slack a test cannot judge).

### Part A: deterministic guardrail (blocks merge)
`bazel/tools/format/readme_structure/`
- **Broken-link check (strict):** every repo-relative link in `README.md` must resolve. Catches links to renamed/deleted projects.
- **Coverage check (soft):** every top-level `projects/*` dir must be documented in the README (as an inline `projects/x` link **or** a `x/` entry in the layout tree) or listed in a commented `COVERAGE_ALLOWLIST`. A brand-new project fails CI until someone lists or allowlists it.
- Wired into the CI **Format check** step, which runs on the full checkout. A sandboxed `bazel test` cannot `ls projects/*` on RBE, so a `py_test` pins the pure logic with synthetic inputs instead (same split as `projects/firecracker/tools/env_readme/`).
- Allowlist seeded with today's intentional omissions only (`__pycache__`, `shared`, and the ~8 minor project dirs the layout tree deliberately drops). The 5 dirs the tree *does* document (`platform`, `inference`, `mcp`, `monolith-public`, `home-cluster`) are recognized via the tree form, not suppressed.

### Part B: judgment gardener (weekly, opens a PR)
- `.claude/skills/refresh-structure-docs/SKILL.md` freshens the prose a test can't judge (stale model name, moved path, a new *major* project worth promoting), makes the smallest honest edit, obeys the no-em-dash rule, and opens a reviewable PR. **Never auto-merges.**
- `projects/monolith/claude_routines/refresh-structure-docs.yaml` runs it Mondays 07:00 UTC.

## Verified
- `check_readme_structure.py` exits 0 on the current tree; catches a synthetic deleted-project link.
- 6 unit tests pass locally.
- `fast-format.sh` clean; no em-dashes in new files.

## One manual follow-up
The routine YAML is intent state. Run `/update-claude-routines refresh-structure-docs` in a session to create it in claude.ai (I can't sync that autonomously).