### PR TITLE
docs: list Grimoire, Notes, LLM Leaderboard, and NHS jobs as public apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Public apps served by the monolith at [jomcgi.dev/app](https://jomcgi.dev/app):
 - [**Campsites**](projects/monolith/frontend/src/routes/public/app/campsites/): BC Parks availability crossed with weather.
 - [**World Cup 2026 odds**](projects/monolith/frontend/src/routes/public/app/wc2026/): Scotland's qualification odds via an Elo Monte Carlo model.
 - [**Hiking routes**](projects/monolith/frontend/src/routes/public/app/hikes/): Scottish route finder with weather-based recommendations.
+- [**Grimoire**](projects/monolith/frontend/src/routes/public/app/grimoire/): Postgres-first D&D campaign manager with a public rules and lore explorer.
+- [**Notes**](projects/monolith/frontend/src/routes/public/app/notes/): Anonymous chat over an on-cluster Qwen model on a shared public scratchpad.
+- [**LLM Leaderboard**](projects/monolith/frontend/src/routes/public/app/llm-leaderboard/): Agentic coding benchmark results across models, from the model-bench harness.
+- [**NHS jobs**](projects/monolith/frontend/src/routes/public/app/dr-jobs/): NHS Scotland anaesthetics consultant vacancy aggregator.
 
 ## Infrastructure patterns
 


### PR DESCRIPTION
## What

Adds 4 public apps to the README's Applications list that had shipped without being documented: Grimoire, Notes, LLM Leaderboard, and NHS jobs (`dr-jobs`).

## How it was found

This is the **first real output of the `refresh-structure-docs` skill** from #3280, run as a dry run to validate it. The skill's method surfaced that the README listed 6 apps while 11 route dirs exist under `public/app/`. Judgment calls it made:

- **Added** (4): grimoire, notes, llm-leaderboard, dr-jobs, all real public SvelteKit apps.
- **Omitted** (1): `frank`, a static `frank.html` served via `+server.js` with no `+page.svelte` (a novelty page, not an app).

Nicely demonstrates the two-part split: the deterministic checker in #3280 passed here (every listed link resolves, no deleted-project links), yet the list was incomplete because apps were *added*, which only the judgment half can catch.

## Verified
- All 4 new link targets exist.
- `check_readme_structure.py` (from #3280) exits 0 against this tree.
- New bullets use colons, no new em-dashes.

Independent of #3280 (that PR is the tooling; this is the content it flagged).