### PR TITLE
chore(monolith): bump chart to 0.285.58 (deploy grimoire polish)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.57
+version: 0.285.58
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.57
+      targetRevision: 0.285.58
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Deploys the merged grimoire mobile-polish change (#3279 / 2a63277fc), which landed without a chart bump, so its rebuilt monolith image is referenced by no published chart version and is not live (deployed image is still tagged `-e1892ec`).

Bumps `chart/Chart.yaml` + `deploy/application.yaml` together via `bump-chart.sh`. On merge, CI rebuilds the monolith image at this main commit (which includes the grimoire change) and publishes chart 0.285.58 for ArgoCD to pull.

Follow-up (separate PR): fix the CI guardrail so a merge whose image changed without a chart bump fails loudly, since it did not fire for #3279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)