### PR TITLE
chore(monolith-public): bump chart to 0.89.22 (deploy grimoire polish to public tier)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.21
+version: 0.89.22
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.21
+      targetRevision: 0.89.22
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
The public grimoire landing (jomcgi.dev/app/grimoire) is served by `monolith-public-frontend`, whose chart pins the public frontend image. The merged grimoire change (#3279) plus the monolith bump (#3282) do not deploy the public page without this second bump (a public-page change needs BOTH monolith and monolith-public chart bumps). Deployed public-frontend was still `-e1892ec`.

Follow-up: fixing the auto-bump/guardrail that let this slip is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)