### PR TITLE
fix(ci): retry crane digest so the missed-bump guard resolves fresh tags

### DIFF
--- a/bazel/helm/push.sh.tpl
+++ b/bazel/helm/push.sh.tpl
@@ -47,13 +47,31 @@ while (( $# > 0 )); do
   esac
 done
 
+# Resolve one repo:tag to its manifest digest, retrying a few times. The fresh
+# tags are pushed moments earlier in this same push_all run, so a first read can
+# race ghcr propagation, and a burst of reads across all charts can hit
+# transient rate limits (observed: monolith resolved but monolith-public did not
+# in the same run under the same auth). Retry with backoff; a genuinely gone tag
+# (an old published version whose image was GC'd) still ends UNRESOLVED, which
+# the caller treats as "skip", not "fail".
+_crane_digest() {
+  local ref="$1" i d
+  for i in 1 2 3; do
+    if d=$("$CRANE" digest "$ref" 2>/dev/null) && [[ -n "$d" ]]; then
+      printf '%s' "$d"
+      return 0
+    fi
+    if [[ $i -lt 3 ]]; then sleep 3; fi
+  done
+  printf 'UNRESOLVED'
+}
+
 # Emit sorted "repo=digest" lines for each ghcr.io/jomcgi image pinned in a
 # chart. Args are passed straight to `helm show values` (a .tgz path, or
 # "REPO/NAME --version X"). The pinned tag embeds a build timestamp so it
 # changes every build even for identical content; resolving it to the manifest
-# digest via crane gives a content-stable identity to compare. A tag that fails
-# to resolve is emitted as UNRESOLVED so the caller can skip rather than
-# false-fail on a transient registry error.
+# digest gives a content-stable identity to compare. UNRESOLVED tags let the
+# caller skip rather than false-fail on a transient registry error.
 _image_digests() {
   "$HELM" show values "$@" 2>/dev/null | awk '
     /^[[:space:]]*repository:[[:space:]]*/ { repo=$2 }
@@ -61,8 +79,7 @@ _image_digests() {
     while IFS="$(printf '\t')" read -r repo tag; do
       case "$repo" in
         ghcr.io/jomcgi/*)
-          d=$("$CRANE" digest "${repo}:${tag}" 2>/dev/null) || d="UNRESOLVED"
-          printf '%s=%s\n' "$repo" "$d"
+          printf '%s=%s\n' "$repo" "$(_crane_digest "${repo}:${tag}")"
           ;;
       esac
     done | sort


### PR DESCRIPTION
Follow-up to #3284. The first post-merge run of the digest-based missed-bump guard skipped `monolith-public` and 4 other charts with `WARNING: could not resolve all image digests` — so the guard degraded to the (broken) version-scoped detector for them, including a case it should have caught (the demos `+layout` change vs published `monolith-public` 0.89.22).

**Not auth:** `monolith` resolved cleanly in the same run under the same `docker login`. The cause is timing: the fresh image tags are pushed moments earlier in the same `push_all` run, so a first `crane digest` read races ghcr propagation, and a burst of reads across all charts can hit transient rate limits.

**Fix:** retry `crane digest` 3× with a 3s backoff. Genuinely GC'd old tags (an old published version whose image was collected) still end `UNRESOLVED` and skip — so the guard stays fail-safe (never false-fails), it just now resolves the fresh/rate-limited tags it was missing.

Same caveat as #3284: this code only runs on the `main` push path, so it isn't exercised by this PR's own CI; I'll watch the post-merge run to confirm the WARNINGs clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)