### PR TITLE
feat(grimoire): tighten scroll-story hero copy, enlarge subtitle

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.59
+version: 0.285.60
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.59
+      targetRevision: 0.285.60
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
@@ -876,10 +876,10 @@
       <div class="hero-copy" bind:this={heroCopyEl}>
         <h1 class="grim-title">
           <span class="line">Grimoire.</span><span class="line accent"
-            >Who is the Black Spider, and what does he actually want?</span
+            >Who is the Black Spider?</span
           >
         </h1>
-        <p>The answer is buried in this page. Scroll to watch Grimoire dig it out.</p>
+        <p>Scroll to watch Grimoire extract the answer.</p>
         <div class="cue">SCROLL <span class="arrow">&darr;</span></div>
       </div>
 
@@ -1271,7 +1271,7 @@
   }
   .hero-copy p {
     color: var(--grim-text-dim);
-    font-size: 14.5px;
+    font-size: 16px;
     line-height: 1.6;
     margin-top: 16px;
   }


### PR DESCRIPTION
## What

Refines the Grimoire scroll-story landing hero (`ScrollStory.svelte`):

- **H2**: `Who is the Black Spider, and what does he actually want?` -> `Who is the Black Spider?` (single, punchier hook)
- **Subtitle**: `The answer is buried in this page. Scroll to watch Grimoire dig it out.` -> `Scroll to watch Grimoire extract the answer.` (drops the setup line so the hero is two beats: provoke, then instruct; "extract" matches what Grimoire does)
- **Subtitle size**: `14.5px` -> `16px` (it is effectively the CTA and was the least-readable line; contrast was already WCAG AA, so size is the only lever)

## Not changed

`data/transcript.js` keeps the full question `...and what does he actually want?` on purpose: it is a real captured chat exchange whose answer covers Nezznar's motive, so trimming it would make the answer over-deliver relative to the question.

## Review surface

The **Visual regression** action screenshots the hero before/after inline on this PR: that is the render check for the copy + size change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)