### PR TITLE
chore: bump monolith-public + fc-invoke to deploy pending image changes (guard-flagged)

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.42
+version: 0.4.43

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.42
+      targetRevision: 0.4.43
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.22
+version: 0.89.23
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.22
+      targetRevision: 0.89.23
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
The new digest-based missed-bump guard (#3284 + #3287) fired on its first fully-working run and correctly caught **two real un-deployed changes** — charts whose pinned images were rebuilt but whose versions were never bumped, so the changes never reached the cluster:

- **monolith-public 0.89.22 → 0.89.23**: `public-frontend` was rebuilt by the demos `+layout.svelte` change (`71ae235… → ae63062…`). Only `monolith` was bumped at the time, not `monolith-public`.
- **fc-invoke 0.4.42 → 0.4.43**: the `semgrep/guest` image was rebuilt by `build(semgrep): update artifact digests` (`564b835… → de127b1…`) with no chart bump. The chart's other 5 images are unchanged.

Both verified as true positives (not build non-determinism — the unchanged images resolve identically across builds). This bump deploys those pending changes and clears the red `Push images` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)