### PR TITLE
feat(demos): goose shows fc-invoke spans, defaults to homelab repo, 3m trace poll

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.59
+version: 0.285.60
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/demos/firecracker_api.py
+++ b/projects/monolith/demos/firecracker_api.py
@@ -138,6 +138,11 @@ async def submit_goose(body: GooseRequest) -> dict:
             session=session,
             recipe=body.recipe,
             tier=body.tier,
+            # Default the demo to a checkout of this repo at main so the agent
+            # has something real to work on (an empty /workspace makes every
+            # "summarize this repo" task impossible). owner/repo form: the runner
+            # resolves it to <git-mirror>/jomcgi/homelab (see _effective_mirror_ref).
+            repo="jomcgi/homelab",
         )
 
     return {

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.59
+      targetRevision: 0.285.60
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/TraceWaterfall.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/TraceWaterfall.svelte
@@ -13,15 +13,21 @@
   // landed", not "fully ingested": treating it as terminal was the bug that
   // made the page get stuck "loading" or show a partial waterfall. Instead
   // we render every poll's spans immediately (progressive rendering) and
-  // keep polling until the span COUNT has been stable across 3 consecutive
-  // polls after it first went above zero (a reasonable proxy for "no more
-  // spans are arriving"), or a hard 60s timeout elapses, whichever comes
-  // first.
+  // keep polling for a full 3-minute window so late spans keep streaming in
+  // (a long async agent run emits its fc-invoke spans over minutes). We poll
+  // every 1s while the span count is still changing, then back off to every
+  // 3s once it looks stable, rather than stopping, so new spans still appear
+  // without hammering the endpoint.
   let { traceId } = $props();
 
-  const POLL_MS = 1000;
-  const STABLE_POLLS_REQUIRED = 3;
-  const HARD_TIMEOUT_MS = 60_000;
+  // Poll fast while spans are still arriving, then back off to a slower
+  // cadence once the count looks stable, but KEEP polling for the full
+  // window: long async agent runs stream their fc-invoke spans in over
+  // minutes, so stopping early (the old behavior) hid them.
+  const POLL_MS_ACTIVE = 1000;
+  const POLL_MS_IDLE = 3000;
+  const STABLE_POLLS_BEFORE_IDLE = 3;
+  const HARD_TIMEOUT_MS = 180_000;
   const MAX_CONSECUTIVE_ERRORS_WHEN_EMPTY = 3;
 
   // Stable-ish palette keyed by service name via a small string hash, so
@@ -95,15 +101,15 @@
       }
     }
 
-    if (stableStreak >= STABLE_POLLS_REQUIRED) {
-      finish();
-      return;
-    }
     if (performance.now() - pollStart >= HARD_TIMEOUT_MS) {
       finish();
       return;
     }
-    pollHandle = setTimeout(() => pollOnce(id), POLL_MS);
+    // Keep polling for the whole window so late spans (long agent runs) stream
+    // in; once the count looks stable, slow the cadence rather than stopping.
+    const interval =
+      stableStreak >= STABLE_POLLS_BEFORE_IDLE ? POLL_MS_IDLE : POLL_MS_ACTIVE;
+    pollHandle = setTimeout(() => pollOnce(id), interval);
   }
 
   $effect(() => {

--- a/projects/monolith/goosecracker/dispatch.py
+++ b/projects/monolith/goosecracker/dispatch.py
@@ -16,6 +16,8 @@ import threading
 from collections.abc import Coroutine
 from typing import TYPE_CHECKING, Any
 
+from opentelemetry.propagate import inject
+
 from goosecracker import runner, threads
 
 if TYPE_CHECKING:
@@ -89,6 +91,16 @@ def submit(
         task=task,
         discord_thread=discord_thread,
     )
+    # Capture the caller's active trace context (e.g. the demo page's
+    # `demo.goose` span) as a W3C traceparent string. `submit` runs via
+    # asyncio.to_thread, which copies the caller's contextvars, so the current
+    # span is live here; the run itself executes on a fresh daemon-thread event
+    # loop with no context, so we carry the string and re-attach it as a header
+    # on the fc-invoke POST, letting the agent's fc-invoke spans nest under the
+    # caller's trace instead of forming a detached one.
+    carrier: dict[str, str] = {}
+    inject(carrier)
+    traceparent = carrier.get("traceparent", "")
     _schedule(
         runner.run_and_deliver(
             session,
@@ -100,6 +112,7 @@ def submit(
             git_ref=git_ref,
             discord_thread=discord_thread,
             plan=plan,
+            traceparent=traceparent,
         )
     )
     return {

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -531,7 +531,9 @@ async def _persist_session_db(session: str, session_db_b64: str | None) -> None:
         logger.exception("goosecracker: failed to persist session db for %s", session)
 
 
-async def _post_agent_run(url: str, payload: dict, on_retry) -> dict:
+async def _post_agent_run(
+    url: str, payload: dict, on_retry, traceparent: str = ""
+) -> dict:
     """POST a goose run to fc-invoke, retrying transient failures with backoff.
 
     Returns the parsed JSON body on the first success. Retries only failures
@@ -554,7 +556,13 @@ async def _post_agent_run(url: str, payload: dict, on_retry) -> dict:
                 # Carry this pod's ServiceAccount token so fc-invoke's
                 # TokenReview gate admits the call (read fresh per attempt to
                 # pick up kubelet token rotation).
-                resp = await client.post(url, json=payload, headers=auth_headers())
+                headers = auth_headers()
+                # Nest the agent's fc-invoke spans under the caller's trace (the
+                # demo page's `demo.goose` span) by forwarding its traceparent;
+                # fc-invoke extracts it at ingress. Empty when no caller context.
+                if traceparent:
+                    headers["traceparent"] = traceparent
+                resp = await client.post(url, json=payload, headers=headers)
                 resp.raise_for_status()
                 return resp.json()
         except httpx.HTTPStatusError as exc:
@@ -595,6 +603,7 @@ async def _invoke_turn(
     git_ref: str,
     discord_thread: str,
     plan: "Plan | None",
+    traceparent: str = "",
 ) -> dict:
     """POST one goose invocation to fc-invoke and return the raw AgentResult dict.
 
@@ -752,7 +761,7 @@ async def _invoke_turn(
             f"(attempt {attempt}, waiting {wait:.0f}s)…",
         )
 
-    return await _post_agent_run(url, payload, _notify_retry)
+    return await _post_agent_run(url, payload, _notify_retry, traceparent=traceparent)
 
 
 async def _deliver_result(session: str, discord_thread: str, data: dict) -> bool:
@@ -823,6 +832,7 @@ async def _run_one_turn(
     git_ref: str,
     discord_thread: str,
     plan: "Plan | None" = None,
+    traceparent: str = "",
 ) -> bool:
     """Run one goose turn (with the capped replan escape hatch) and deliver it.
 
@@ -864,6 +874,7 @@ async def _run_one_turn(
                 git_ref=git_ref,
                 discord_thread=discord_thread,
                 plan=current_plan,
+                traceparent=traceparent,
             )
             # Replan only on a plan-driven turn whose run actually produced a
             # result, and only while under the cap. The baked/fallback path
@@ -923,6 +934,7 @@ async def run_and_deliver(
     git_ref: str,
     discord_thread: str,
     plan: "Plan | None" = None,
+    traceparent: str = "",
 ) -> None:
     """Run a conversational agent thread to completion, one turn at a time.
 
@@ -972,6 +984,7 @@ async def run_and_deliver(
             git_ref=git_ref,
             discord_thread=discord_thread,
             plan=turn_plan,
+            traceparent=traceparent,
         )
         turn_plan = None  # only the first (orchestrated) turn gets the plan
 


### PR DESCRIPTION
## What

Three goose-demo fixes from live feedback, plus a shared tracing improvement.

## Goose fc-invoke spans now appear in the waterfall

The goose agent run is dispatched detached (submit returns after the ~3ms DB write; the fc-invoke `/invoke/agent` call runs on a fresh daemon-thread event loop with no trace context), so its fc-invoke spans landed in a separate trace and never showed in the demo's `demo.goose` waterfall. Fixed by capturing the caller's `traceparent` in `dispatch.submit` and threading it through `run_and_deliver -> _run_one_turn -> _invoke_turn -> _post_agent_run`, where it's forwarded as a header on the fc-invoke POST. fc-invoke already extracts `traceparent` at ingress, so the agent's `fc_invoke` subtree now nests under `demo.goose`. This also links Discord/MCP agent runs to their triggering trace (benign, additive; empty traceparent when no caller context).

## Goose demo defaults to a homelab checkout

The demo submitted with no `repo`, so `/workspace` was empty and any "summarize this repo" task was impossible. Now passes `repo="jomcgi/homelab"` (owner/repo form the git-mirror serves; `_effective_mirror_ref` resolves it to `<mirror>/jomcgi/homelab` at `main`).

## Waterfall polls for 3 minutes

Was capped at 60s and stopped once the span count was stable for 3 polls, so a long agent run's spans (arriving over minutes) never streamed in. Now polls the full 3 minutes: every 1s while the count is changing, backing off to every 3s once stable, so late spans keep appearing without hammering the endpoint.

## Not changed (answered, correct as-is)

- The `read`-tool complaint is expected: goose's `developer` extension has no `read` tool (only write/edit/shell/tree/read_image); the agent correctly falls back to `shell`+`cat`. Global to all goose runs.
- `recipe="agent"` (the router) and empty tier (falls back to the default in-cluster Qwen) are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
