### PR TITLE
fix(demos): goose fc-invoke spans nest under demo.goose; per-service trace colors

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.60
+version: 0.285.61
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.60
+      targetRevision: 0.285.61
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/TraceWaterfall.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/TraceWaterfall.svelte
@@ -30,17 +30,20 @@
   const HARD_TIMEOUT_MS = 180_000;
   const MAX_CONSECUTIVE_ERRORS_WHEN_EMPTY = 3;
 
-  // Stable-ish palette keyed by service name via a small string hash, so
-  // the same service always lands on the same swatch across runs.
-  const PALETTE = ["var(--accent)", "#3f7a5c", "#8a6100", "#6b7280"];
+  // One fixed, distinct color per service so the trace's layers read as bands
+  // (monolith request -> fc-invoke VM management -> guest agent) that stay
+  // consistent across runs, instead of a hash that collides several services
+  // onto the same blue. Colors are defined as CSS vars in theme.css; unknown
+  // services fall back to a neutral grey.
+  const SERVICE_COLORS = {
+    "monolith-backend": "var(--svc-monolith)",
+    "fc-invoke": "var(--svc-fc)",
+    "goose-coding": "var(--svc-goose)",
+    semgrep: "var(--svc-semgrep)",
+  };
 
   function colorFor(service) {
-    if (!service) return "#6b7280";
-    let h = 0;
-    for (let i = 0; i < service.length; i++) {
-      h = (h * 31 + service.charCodeAt(i)) | 0;
-    }
-    return PALETTE[Math.abs(h) % PALETTE.length];
+    return SERVICE_COLORS[service] ?? "var(--svc-default)";
   }
 
   let spans = $state([]);

--- a/projects/monolith/frontend/src/lib/private/demos/theme.css
+++ b/projects/monolith/frontend/src/lib/private/demos/theme.css
@@ -16,4 +16,13 @@
   --line: #dbe0e7;
   --accent: #33507a;
   --danger: #a4372e;
+
+  /* Per-service trace-waterfall colors: one stable, distinct hue per layer so a
+   * trace reads as bands (monolith request -> fc-invoke VM management -> guest
+   * agent) instead of a wall of same-ish blue. Muted to sit on the paper. */
+  --svc-monolith: #33507a; /* the request layer, matches --accent */
+  --svc-fc: #3f7a5c; /* fc-invoke: VM lifecycle */
+  --svc-goose: #a86a1f; /* goose-coding: the agent inside */
+  --svc-semgrep: #8a5a9a; /* semgrep scan */
+  --svc-default: #6b7280; /* any other/unknown service */
 }

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -33,6 +33,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import httpx
+from opentelemetry import context as otel_context
+from opentelemetry.propagate import extract
 from sqlmodel import Session
 
 from app.db import get_engine
@@ -558,11 +560,24 @@ async def _post_agent_run(
                 # pick up kubelet token rotation).
                 headers = auth_headers()
                 # Nest the agent's fc-invoke spans under the caller's trace (the
-                # demo page's `demo.goose` span) by forwarding its traceparent;
-                # fc-invoke extracts it at ingress. Empty when no caller context.
-                if traceparent:
-                    headers["traceparent"] = traceparent
-                resp = await client.post(url, json=payload, headers=headers)
+                # demo page's `demo.goose` span). This runs on a detached daemon
+                # thread with NO active OTEL context, so we reconstruct the caller
+                # context from the traceparent string and attach it AROUND the
+                # POST: the auto-instrumented httpx client span then parents under
+                # the caller span and injects the right traceparent downstream. A
+                # manual header alone does not work, HTTPXClientInstrumentor
+                # overwrites it with the current context's, which here would be a
+                # fresh root (the fc-invoke spans would form a separate trace).
+                ctx_token = (
+                    otel_context.attach(extract({"traceparent": traceparent}))
+                    if traceparent
+                    else None
+                )
+                try:
+                    resp = await client.post(url, json=payload, headers=headers)
+                finally:
+                    if ctx_token is not None:
+                        otel_context.detach(ctx_token)
                 resp.raise_for_status()
                 return resp.json()
         except httpx.HTTPStatusError as exc:


### PR DESCRIPTION
## What

Two fixes to the firecracker demos trace waterfall.

## Fix: goose agent fc-invoke spans now nest under demo.goose

The previous PR forwarded the caller's `traceparent` to the fc-invoke `/invoke/agent` POST as a manual header, but it did not work at runtime: the goose run is dispatched on a detached daemon thread with NO active OTEL context, and `HTTPXClientInstrumentor` creates a client span for the POST rooted fresh (no parent) and **overwrites the manual traceparent header** with its own. So the agent's `fc_invoke` subtree formed a separate trace (verified live: it landed in a different traceID with a root `POST` span).

Fix: in `_post_agent_run`, reconstruct the caller context from the traceparent string and `context.attach()` it around the POST, so the instrumented client span parents under the caller span (`demo.goose`) and injects the right context downstream. fc-invoke then nests `fc_invoke` under `demo.goose`. Empty traceparent => no attach => unchanged.

## Feat: distinct per-service colors in the waterfall

The bars were hashed to a 4-color palette, collapsing most services onto the same slate-blue. Now each service has a stable, distinct color (defined in theme.css): `monolith-backend` slate, `fc-invoke` green, `goose-coding` amber, `semgrep` purple, unknown grey. The trace reads as clear layers.

## Not included (investigated, reported)

Guest-interior tracing (goose's own `goose-coding` spans, and semgrep's, nesting under the demo trace) needs the traceparent propagated across the vsock boundary into the guest. Goose: feasible but gated on whether goose v1.39.0 honors an inbound TRACEPARENT env (being verified). Semgrep: not feasible as-is (SEMGREP_SEND_METRICS=off, no OTLP trace exporter, persistent LSP with no per-scan env). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
