### PR TITLE
feat(demos): render goose agent internals correlated in the waterfall

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.61
+version: 0.285.62
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/demos/firecracker_api.py
+++ b/projects/monolith/demos/firecracker_api.py
@@ -35,7 +35,7 @@ from opentelemetry.context import Context
 from pydantic import BaseModel
 
 import goosecracker.api as goosecracker
-from home.observability.traces import fetch_trace_spans
+from home.observability.traces import fetch_correlated_spans, fetch_trace_spans
 from sandbox.client import run_python_in_sandbox
 from semgrep.client import scan_files
 
@@ -182,6 +182,13 @@ async def get_trace(trace_id: str) -> dict:
     ``complete`` is false while the trace is still ingesting (spans lag emission
     by ~5-10s) or if the trace id is malformed; the frontend polls until spans
     appear.
+
+    ``correlated`` carries the goose agent's own internal spans (service
+    `goose-coding`). Goose does not honor an inbound TRACEPARENT, so those spans
+    live in their own trace; the runner stamps `caller.trace_id=<trace_id>` onto
+    them so we recover them here and render them as their own sub-timeline.
+    ``complete`` stays keyed on the main ``spans`` only.
     """
     spans = await fetch_trace_spans(trace_id)
-    return {"spans": spans, "complete": len(spans) > 0}
+    correlated = await fetch_correlated_spans(trace_id)
+    return {"spans": spans, "correlated": correlated, "complete": len(spans) > 0}

--- a/projects/monolith/demos/firecracker_api_test.py
+++ b/projects/monolith/demos/firecracker_api_test.py
@@ -133,23 +133,58 @@ def test_trace_complete_true_when_spans_present(monkeypatch):
         assert trace_id == "a" * 32
         return [{"span_id": "s1", "name": "demo.python", "start_ms": 0.0}]
 
+    async def fake_correlated(trace_id):
+        return []
+
     monkeypatch.setattr(fc, "fetch_trace_spans", fake_fetch)
+    monkeypatch.setattr(fc, "fetch_correlated_spans", fake_correlated)
 
     resp = _client().get(f"/api/demos/firecracker/trace/{'a' * 32}")
     assert resp.status_code == 200
     body = resp.json()
     assert body["complete"] is True
     assert body["spans"][0]["span_id"] == "s1"
+    assert body["correlated"] == []
 
 
 def test_trace_incomplete_when_no_spans(monkeypatch):
     async def fake_fetch(trace_id):
         return []
 
+    async def fake_correlated(trace_id):
+        return []
+
     monkeypatch.setattr(fc, "fetch_trace_spans", fake_fetch)
+    monkeypatch.setattr(fc, "fetch_correlated_spans", fake_correlated)
 
     resp = _client().get(f"/api/demos/firecracker/trace/{'b' * 32}")
     assert resp.status_code == 200
     body = resp.json()
     assert body["complete"] is False
     assert body["spans"] == []
+    assert body["correlated"] == []
+
+
+def test_trace_includes_correlated_goose_spans(monkeypatch):
+    """The endpoint surfaces the agent's correlated goose spans separately.
+
+    `complete` stays keyed on the main spans only: correlated goose spans can
+    stream in before or after the main trace's spans and must not flip it.
+    """
+
+    async def fake_fetch(trace_id):
+        return []
+
+    async def fake_correlated(trace_id):
+        assert trace_id == "c" * 32
+        return [{"span_id": "g1", "name": "reply", "service": "goose-coding"}]
+
+    monkeypatch.setattr(fc, "fetch_trace_spans", fake_fetch)
+    monkeypatch.setattr(fc, "fetch_correlated_spans", fake_correlated)
+
+    resp = _client().get(f"/api/demos/firecracker/trace/{'c' * 32}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["complete"] is False
+    assert body["spans"] == []
+    assert body["correlated"][0]["span_id"] == "g1"

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.61
+      targetRevision: 0.285.62
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/TraceWaterfall.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/TraceWaterfall.svelte
@@ -47,6 +47,11 @@
   }
 
   let spans = $state([]);
+  // Goose's own internal spans (service `goose-coding`), correlated to this run
+  // by the runner stamping `caller.trace_id` on them. Goose does not honor an
+  // inbound TRACEPARENT, so these live in their own trace and cannot be truly
+  // nested under the main waterfall: they render as their own sub-timeline.
+  let correlated = $state([]);
   // "waiting" (no spans yet), "live" (spans present, still polling for
   // stability), "done" (stable or timed out), "error" (repeated failures
   // with zero spans ever seen).
@@ -71,11 +76,13 @@
 
   async function pollOnce(id) {
     let newSpans = null;
+    let newCorrelated = null;
     try {
       const res = await fetch(`/api/demos/firecracker/trace/${id}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       newSpans = Array.isArray(data.spans) ? data.spans : [];
+      newCorrelated = Array.isArray(data.correlated) ? data.correlated : [];
       fetchError = null;
       consecutiveErrors = 0;
     } catch (e) {
@@ -90,6 +97,10 @@
     }
 
     if (traceId !== id) return; // traceId changed mid-flight, effect already restarted
+
+    if (newCorrelated !== null) {
+      correlated = newCorrelated;
+    }
 
     if (newSpans !== null) {
       spans = newSpans;
@@ -118,6 +129,7 @@
   $effect(() => {
     stopPolling();
     spans = [];
+    correlated = [];
     status = "waiting";
     fetchError = null;
     lastCount = -1;
@@ -133,9 +145,11 @@
 
   // Span depth by walking the parent chain, for a light indent that reads
   // as a call tree without needing a real tree layout. A span whose parent
-  // isn't in the current span set is treated as a root (depth 0).
-  let depthById = $derived.by(() => {
-    const byId = new Map(spans.map((s) => [s.span_id, s]));
+  // isn't in the given span set is treated as a root (depth 0). Scoped to the
+  // passed set so the main waterfall and the correlated goose set each get
+  // their own depth map.
+  function depthMapFor(set) {
+    const byId = new Map(set.map((s) => [s.span_id, s]));
     const depth = new Map();
     function depthOf(id, guard = 0) {
       if (depth.has(id)) return depth.get(id);
@@ -150,15 +164,31 @@
       depth.set(id, d);
       return d;
     }
-    for (const s of spans) depthOf(s.span_id);
+    for (const s of set) depthOf(s.span_id);
     return depth;
-  });
+  }
 
+  function timelineEndFor(set) {
+    return Math.max(1, ...set.map((s) => (s.start_ms ?? 0) + (s.duration_ms ?? 0)));
+  }
+
+  // Bar geometry against a set's OWN timelineEnd, so the correlated goose set
+  // renders as its own self-contained sub-timeline (its earliest span at 0).
+  function barStyleFor(span, timelineEnd) {
+    const left = (Math.max(0, span.start_ms ?? 0) / timelineEnd) * 100;
+    const width = Math.max(0.6, ((span.duration_ms ?? 0) / timelineEnd) * 100);
+    return `left: ${left}%; width: ${width}%;`;
+  }
+
+  let depthById = $derived(depthMapFor(spans));
   let sortedSpans = $derived([...spans].sort((a, b) => a.start_ms - b.start_ms));
+  let timelineEnd = $derived(timelineEndFor(spans));
 
-  let timelineEnd = $derived(
-    Math.max(1, ...spans.map((s) => (s.start_ms ?? 0) + (s.duration_ms ?? 0))),
+  let correlatedDepthById = $derived(depthMapFor(correlated));
+  let sortedCorrelated = $derived(
+    [...correlated].sort((a, b) => a.start_ms - b.start_ms),
   );
+  let correlatedTimelineEnd = $derived(timelineEndFor(correlated));
 
   let axisTicks = $derived.by(() => {
     const end = timelineEnd;
@@ -167,12 +197,6 @@
       label: `${Math.round(f * end)}ms`,
     }));
   });
-
-  function barStyle(span) {
-    const left = (Math.max(0, span.start_ms ?? 0) / timelineEnd) * 100;
-    const width = Math.max(0.6, ((span.duration_ms ?? 0) / timelineEnd) * 100);
-    return `left: ${left}%; width: ${width}%;`;
-  }
 </script>
 
 <div class="waterfall">
@@ -227,7 +251,7 @@
             <div
               class="row-bar"
               class:row-bar--error={span.error}
-              style={`${barStyle(span)} background: ${span.error ? "var(--danger)" : colorFor(span.service)};`}
+              style={`${barStyleFor(span, timelineEnd)} background: ${span.error ? "var(--danger)" : colorFor(span.service)};`}
             >
               <span class="row-duration">{span.duration_ms}ms</span>
             </div>
@@ -242,6 +266,42 @@
         updating, showing {spans.length} span{spans.length === 1 ? "" : "s"} so far
       </div>
     {/if}
+  {/if}
+
+  {#if correlated.length > 0}
+    <div class="correlated">
+      <div class="correlated-header">
+        <h4 class="correlated-title">Agent internals (goose)</h4>
+        <span class="correlated-badge">correlated</span>
+      </div>
+      <p class="correlated-note">
+        The agent's own spans, correlated to this run by trace id. Goose runs in
+        its own trace (it does not honor an inbound parent context), so these are
+        shown on their own relative timeline rather than nested above.
+      </p>
+      <div class="rows">
+        {#each sortedCorrelated as span (span.span_id)}
+          <div
+            class="row"
+            style={`padding-left: ${(correlatedDepthById.get(span.span_id) ?? 0) * 0.9}rem;`}
+          >
+            <span class="row-label" title={`${span.name} · ${span.service}`}>
+              {span.name}
+              <span class="row-service">{span.service}</span>
+            </span>
+            <div class="row-track">
+              <div
+                class="row-bar"
+                class:row-bar--error={span.error}
+                style={`${barStyleFor(span, correlatedTimelineEnd)} background: ${span.error ? "var(--danger)" : "var(--svc-goose)"};`}
+              >
+                <span class="row-duration">{span.duration_ms}ms</span>
+              </div>
+            </div>
+          </div>
+        {/each}
+      </div>
+    </div>
   {/if}
 </div>
 
@@ -404,6 +464,47 @@
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
     text-shadow: 0 0 2px rgba(0, 0, 0, 0.35);
+  }
+
+  .correlated {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    border-top: 1px dashed var(--line);
+    padding-top: 12px;
+  }
+
+  .correlated-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .correlated-title {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--ink);
+    margin: 0;
+  }
+
+  .correlated-badge {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--svc-goose);
+    border: 1px solid var(--svc-goose);
+    border-radius: 999px;
+    padding: 1px 7px;
+  }
+
+  .correlated-note {
+    font-size: 11.5px;
+    color: var(--text-faint);
+    line-height: 1.4;
+    margin: 0;
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -57,6 +57,11 @@ logger = logging.getLogger(__name__)
 # from Helm values; never hardcoded.
 FC_INVOKE_URL = os.environ.get("FC_INVOKE_URL", "")
 
+# The trace-id field of a W3C traceparent (00-<32hex traceID>-<16hex spanID>-<flags>)
+# is 32 lowercase hex chars. We validate it before stamping it onto the goose run
+# env as `caller.trace_id`, so a malformed traceparent never injects a bad value.
+_CALLER_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+
 # The monolith's own in-cluster progress endpoint base, reached by the guest
 # through the fc-invoke egress funnel. The runner appends "/{session}" so the
 # guest's id-less {"chunk": ...} posts land in the right per-session buffer.
@@ -743,6 +748,25 @@ async def _invoke_turn(
             "router.yaml": render_fallback_router(),
         }
         effective_recipe = "/injected-context/router.yaml"
+    # Goose trace correlation: goose (v1.39.0) does NOT honor an inbound
+    # TRACEPARENT, so its OTEL spans (service `goose-coding`) land in their own
+    # trace, unnestable under this run. But goose DOES honor
+    # OTEL_RESOURCE_ATTRIBUTES, stamping them as resource attributes on every
+    # span. So we stamp the caller's trace id onto every goose span as
+    # `caller.trace_id`, and the demos backend recovers them by that key to
+    # render the agent's own internals under the demo waterfall. Merge, don't
+    # overwrite: a tier may already set OTEL_RESOURCE_ATTRIBUTES (service.* etc),
+    # so append. `env` here is a fresh per-run dict (env_for_tier returns a copy
+    # and the steering path already rebuilt it with {**env}), but rebuild once
+    # more with {**env} so this stays mutation-safe regardless of that history.
+    if traceparent:
+        parts = traceparent.split("-")
+        caller_trace_id = parts[1] if len(parts) >= 2 else ""
+        if _CALLER_TRACE_ID_RE.match(caller_trace_id):
+            attr = f"caller.trace_id={caller_trace_id}"
+            existing = env.get("OTEL_RESOURCE_ATTRIBUTES", "")
+            merged = f"{existing},{attr}" if existing else attr
+            env = {**env, "OTEL_RESOURCE_ATTRIBUTES": merged}
     payload = {
         "recipe": effective_recipe,
         "task": task,

--- a/projects/monolith/home/observability/traces.py
+++ b/projects/monolith/home/observability/traces.py
@@ -27,6 +27,20 @@ FROM signoz_traces.distributed_signoz_index_v3
 WHERE traceID = '{trace_id}'
 ORDER BY timestamp"""
 
+# Goose (service `goose-coding`) does NOT honor an inbound TRACEPARENT (v1.39.0),
+# so its spans live in their own trace, not nested under the demo run. The runner
+# stamps the caller's trace id onto every goose span as the resource attribute
+# `caller.trace_id` (via OTEL_RESOURCE_ATTRIBUTES), so we recover the agent's own
+# internal spans by that correlation key and render them as their own sub-timeline
+# under the demo waterfall. Resource attributes live in the `resources_string` Map.
+_CORRELATED_QUERY = """\
+SELECT spanID, parentSpanID, name, serviceName, durationNano, hasError,
+       toUnixTimestamp64Nano(timestamp) AS start_nano
+FROM signoz_traces.distributed_signoz_index_v3
+WHERE serviceName = 'goose-coding'
+  AND resources_string['caller.trace_id'] = '{trace_id}'
+ORDER BY timestamp"""
+
 
 async def fetch_trace_spans(trace_id: str) -> list[dict]:
     """Return normalized spans for trace_id, sorted by start time.
@@ -46,6 +60,34 @@ async def fetch_trace_spans(trace_id: str) -> list[dict]:
     )
     try:
         rows = await client.query_rows(_SPANS_QUERY.format(trace_id=trace_id))
+    finally:
+        await client.close()
+
+    return _normalize_spans(rows)
+
+
+async def fetch_correlated_spans(trace_id: str) -> list[dict]:
+    """Return normalized `goose-coding` spans correlated to trace_id.
+
+    Goose runs in its own trace (it does not honor an inbound parent context),
+    but the runner stamps `caller.trace_id=<trace_id>` onto every goose span as
+    a resource attribute, so we recover the agent's own internal spans by that
+    key. Normalized identically to :func:`fetch_trace_spans`, with start_ms
+    relative to this correlated set's OWN earliest span, so it renders as its
+    own self-contained sub-timeline. Returns [] when none have landed yet (they
+    stream in as the agent works) or if trace_id is malformed.
+    """
+    if not _TRACE_ID_RE.match(trace_id):
+        logger.warning("Rejecting malformed trace_id: %r", trace_id)
+        return []
+
+    client = ClickHouseClient(
+        base_url=os.environ.get("CLICKHOUSE_URL", ""),
+        user=os.environ.get("CLICKHOUSE_USER", ""),
+        password=os.environ.get("CLICKHOUSE_PASSWORD", ""),
+    )
+    try:
+        rows = await client.query_rows(_CORRELATED_QUERY.format(trace_id=trace_id))
     finally:
         await client.close()
 

--- a/projects/monolith/home/observability/traces_test.py
+++ b/projects/monolith/home/observability/traces_test.py
@@ -152,3 +152,94 @@ async def test_fetch_trace_spans_root_with_orphan_parent_is_kept():
 
     assert len(result) == 1
     assert result[0]["parent_span_id"] == "missing-parent"
+
+
+@pytest.mark.asyncio
+async def test_fetch_correlated_spans_queries_by_caller_trace_id():
+    """The correlated query filters goose-coding spans by caller.trace_id."""
+    rows = [
+        {
+            "spanID": "reply",
+            "parentSpanID": "",
+            "name": "reply",
+            "serviceName": "goose-coding",
+            "durationNano": 4_000_000,
+            "hasError": False,
+            "start_nano": 5_000_000_000,
+        },
+    ]
+    mock_ch = _mock_ch_client(rows)
+
+    with patch("home.observability.traces.ClickHouseClient", return_value=mock_ch):
+        result = await traces.fetch_correlated_spans(VALID_TRACE_ID)
+
+    # The correlated spans render on their OWN relative timeline (earliest at 0).
+    assert result == [
+        {
+            "span_id": "reply",
+            "parent_span_id": "",
+            "name": "reply",
+            "service": "goose-coding",
+            "start_ms": 0.0,
+            "duration_ms": 4.0,
+            "error": False,
+        },
+    ]
+    query = mock_ch.query_rows.await_args.args[0]
+    assert "serviceName = 'goose-coding'" in query
+    assert f"resources_string['caller.trace_id'] = '{VALID_TRACE_ID}'" in query
+
+
+@pytest.mark.asyncio
+async def test_fetch_correlated_spans_relative_to_own_earliest():
+    rows = [
+        {
+            "spanID": "later",
+            "parentSpanID": "",
+            "name": "dispatch_tool_call",
+            "serviceName": "goose-coding",
+            "durationNano": 1_000_000,
+            "hasError": False,
+            "start_nano": 12_000_000_000,  # 2ms after earliest
+        },
+        {
+            "spanID": "first",
+            "parentSpanID": "",
+            "name": "stream_response_from_provider",
+            "serviceName": "goose-coding",
+            "durationNano": 1_000_000,
+            "hasError": False,
+            "start_nano": 10_000_000_000,  # earliest of the correlated set
+        },
+    ]
+    mock_ch = _mock_ch_client(rows)
+
+    with patch("home.observability.traces.ClickHouseClient", return_value=mock_ch):
+        result = await traces.fetch_correlated_spans(VALID_TRACE_ID)
+
+    assert [span["span_id"] for span in result] == ["first", "later"]
+    assert [span["start_ms"] for span in result] == [0.0, 2000.0]
+
+
+@pytest.mark.asyncio
+async def test_fetch_correlated_spans_returns_empty_when_no_rows():
+    mock_ch = _mock_ch_client([])
+
+    with patch("home.observability.traces.ClickHouseClient", return_value=mock_ch):
+        result = await traces.fetch_correlated_spans(VALID_TRACE_ID)
+
+    assert result == []
+    mock_ch.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_correlated_spans_rejects_malformed_trace_id():
+    mock_ch = _mock_ch_client([])
+
+    with patch(
+        "home.observability.traces.ClickHouseClient", return_value=mock_ch
+    ) as mock_client_cls:
+        result = await traces.fetch_correlated_spans("not-a-trace-id; DROP TABLE x")
+
+    assert result == []
+    mock_client_cls.assert_not_called()


### PR DESCRIPTION
## What

Renders the goose agent's own internal spans (service `goose-coding`: tool calls, inference streaming, replies) on the demo page, correlated to the run, completing the goose waterfall.

## Why not nested?

goose v1.39.0 does not honor an inbound `TRACEPARENT` (verified against its source: no parent-context extraction anywhere), so its spans always start a fresh root trace and cannot be true children of `demo.goose`. But goose DOES honor `OTEL_RESOURCE_ATTRIBUTES`, so we correlate instead.

## How

- **Inject** (`runner.py`): parse the caller trace id from the `traceparent` already threaded into `_invoke_turn`, and append `caller.trace_id=<id>` to the goose run's `OTEL_RESOURCE_ATTRIBUTES` (merge-safe; tier env is a fresh dict). Every `goose-coding` span then carries `resources_string['caller.trace_id']`.
- **Query** (`traces.py`): `fetch_correlated_spans(trace_id)` returns `goose-coding` spans where `resources_string['caller.trace_id']` matches, normalized like the main spans (own earliest=0 timeline).
- **Endpoint** (`firecracker_api.py`): `GET /trace/{id}` now returns `{spans, correlated, complete}`.
- **Frontend** (`TraceWaterfall.svelte`): an "Agent internals (goose)" sub-waterfall in `--svc-goose` amber, streaming in over the existing 3-minute poll.

Works for Discord/MCP agent runs too (they get the same correlation attribute from their own caller context). Semgrep is unaffected (emits no OTLP traces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
