### PR TITLE
fix(chat): stop the attention gate barging in on bare shares and shut-up messages

### DIFF
--- a/.claude/skills/improve-ambient/scripts/improve_ambient_tool.py
+++ b/.claude/skills/improve-ambient/scripts/improve_ambient_tool.py
@@ -267,15 +267,19 @@ ORDER BY created_at, id
 """
 
 # EXACT match on the reply id when known, else the channel + window fallback.
-# The nullable :reply_message_id bind needs ::text casts so psycopg can type the
-# NULL in the IS NULL / IS NOT NULL branches (repo gotcha).
+# The nullable :reply_message_id bind is cast to text so psycopg can type the
+# NULL in the IS NULL / IS NOT NULL branches (repo gotcha). Use CAST(... AS text)
+# rather than the `::text` spelling: SQLAlchemy's text() lexer refuses to bind a
+# param immediately followed by `::`, leaving `:reply_message_id::text` literal
+# and tripping a Postgres "syntax error at or near :".
 _FETCH_REACTIONS_SQL = """
 SELECT message_id, emoji, reactor_id, action, created_at
 FROM chat.reaction_event
 WHERE channel_id = :channel_id
   AND (
-      (:reply_message_id::text IS NOT NULL AND message_id = :reply_message_id::text)
-   OR (:reply_message_id::text IS NULL
+      (CAST(:reply_message_id AS text) IS NOT NULL
+           AND message_id = CAST(:reply_message_id AS text))
+   OR (CAST(:reply_message_id AS text) IS NULL
            AND created_at >= :engage_at
            AND created_at <= :engage_at + make_interval(mins => :window))
   )

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.61
+version: 0.285.62
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/attention.py
+++ b/projects/monolith/chat/attention.py
@@ -56,14 +56,19 @@ async def evaluate(
             caller = build_llm_caller()
         text = (message.content or "")[:500]
         prompt = (
-            "You are Bosun, a friendly, chatty bot hanging out in this Discord "
-            "channel. Lean toward joining the conversation. Engage (true) if the "
-            "message addresses you or the group, greets you, asks anything, is "
-            "trying to get your attention, could use a reply, or would benefit "
-            "from a web search or fact-check. Only ignore (false) if it is clearly "
-            "aimed at another specific person (not you), is pure noise or a bare "
-            "reaction with nothing to respond to, or is between other people and "
-            "not for you. When unsure, engage.\n"
+            "You are Bosun, a friendly bot hanging out in this Discord channel. "
+            "You are one voice among friends, not a reply guy: join in when there "
+            "is a real opening, and otherwise let people talk. Engage (true) if "
+            "the message addresses you, greets you, asks a question, is trying to "
+            "get your attention, or clearly invites your take, or if it states "
+            "something checkable that would genuinely benefit from a web search or "
+            "fact-check. Ignore (false) if it is aimed at another specific person "
+            "(not you), is pure noise or a bare reaction, is a link, image, or "
+            "media share posted without a question or a request for your take, is "
+            "people thinking out loud to each other, or tells you to stop, says "
+            "you talk too much, or otherwise signals you are not wanted right now. "
+            "When a message is not addressed to you and you are unsure whether it "
+            "actually wants a reply, stay quiet.\n"
             + (
                 "You were recently mentioned in this channel, so lean even harder "
                 "toward engaging on the follow-up.\n"

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.61
+      targetRevision: 0.285.62
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
On-demand `/improve-ambient` run. Window: since the last lever commit (`2801704d2`, 2026-07-07T00:11Z) through 2026-07-07T16:06Z. 20 ambient engages gathered (episodes 80-99), above the ~5 minimum, so a lever edit is warranted.

## 1. Before/after aggregates (by emoji valence)

`net_reaction` in the tool is adds-minus-removes, **not** valence (a 👎 scores +1), so these are computed by reading the emojis in `reaction_counts`, not by `net_reaction < 0`. See "Out of scope, observed".

| Metric | Previous gen (13 eps) | This gen (20 eps) |
| --- | --- | --- |
| Negative-reaction rate (👎 present) | 1/13 = 7.7% | 4/20 = 20% |
| Explicit "stop / too chatty" complaints | 0 | 1 (ep 89) |
| Failure histogram (this gen, classified subset) | | barged-in ×4, over-eager ×1, wall-of-text ×1, off-voice ×2, productive ×2 |

The last two lever commits (`route python-chartable`, `history query tool`) never touched engagement calibration, and over-engagement rose. Barge-ins concentrate in the ambient chat channels; the agent-chart channel (`1467736008312488080`) is healthy (🔥 reactions, eps 94/95).

## 2. Per-edit evidence

Single lever: the ambient attention gate prompt in `chat/attention.py` `evaluate()`. Every cited episode is a `reaction_match: "exact"` engage (matched on `reply_message_id`), so the 👎 are on Bosun's own replies.

| episode | channel / author | signals | what happened | diff line addressing it |
| --- | --- | --- | --- | --- |
| 88 | `…3680` / Joe | conf 0.9, 👎×1, human told it to stop | 2-paragraph unsolicited opinion on a **bare reddit link** (no @mention, no question) | "is a link, image, or media share posted without a question or a request for your take" |
| 89 | `…3680` / Joe | conf 1.0 | engaged on **"stop yapping so much, we dont need your input on everything"** and replied again | "tells you to stop, says you talk too much, or otherwise signals you are not wanted right now" |
| 96 | `…7968` / Bjeu | conf 0.7, 👎×2 | asked for a screenshot on a **peer link share** not addressed to it | link/media-share clause + "When … not addressed to you and you are unsure … stay quiet" |
| 98 | `…7968` / Bjeu | conf 0.95, 👎×2 | inserted an over-familiar riff into a **human-to-human musing**; author talked past it | "is people thinking out loud to each other" |
| 80 | `…3680` / Bjeu | conf 1.0, 👎×1 | roast was explicitly requested (engagement correct); single 👎 reads playful. Weak signal, **not** a driver; "asks a question" still engages roast requests | (no suppression; preserved) |

**Routing (three-level rule):** the negative signal spans two channels (`…3680`, `…7968`) and two authors (Joe, Bjeu) → case (a), a global gate edit, not a per-channel directive. Channel `…3680` is already at directive_version 3 and still gets "stop yapping", so per-channel tuning has hit its ceiling. Thresholds are deliberately untouched (raising `ATTENTION_THRESHOLD` would also mute the productive agent-chart channel); the fix is prompt calibration only. Preserved engage paths: @mentions/replies (short-circuit), questions, greetings, genuine fact-check needs, and the agent path.

## 3. Out of scope, observed

- **Tool scoring gap (fixed the SQL, flagged the semantics):** `net_reaction` = adds − removes, so a thumbs-down never makes it negative and the skill's own "rank by `net_reaction < 0`" rule is blind to the exact signal it wants. This run ranked by emoji valence by hand. A valence-aware `net_valence` field is worth adding to the tool (kept out of this PR to avoid coupling a semantics change the directive autopilot reads to a prompt tune). This PR does include the tool's SQL bind fix (`::text` → `CAST(... AS text)`) so `gather` runs from a clean checkout.
- **Agent-delivered image UX:** agent chart replies emit a literal `![alt](file.png)` markdown tag in the text and post the image as a **separate** second message. That is a `summarizer.py` agent-reply-prompt + delivery-mechanism issue, not the attention gate. Tracking separately.

Chart bumped to 0.285.62 in the same PR (prompt edit ships with the monolith image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)