### PR TITLE
feat(fc-invoke): separate guest_teardown span

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.43
+version: 0.4.44

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.43
+      targetRevision: 0.4.44
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/firecracker/substrate/node/invoker/invoker.go
+++ b/projects/firecracker/substrate/node/invoker/invoker.go
@@ -361,7 +361,17 @@ func (inv *Invoker) claimInvoke(ctx context.Context, spec substrate.ClaimSpec, s
 	// every path (each eager error return below, and the success body Close).
 	discardGuest := func() {
 		egressCancel()
+		// Wrap the VM teardown (driver Release + bundle removal) in its own span.
+		// On the success path this runs at response-body Close, AFTER the caller
+		// already has its response, so it is off the critical path. Without its
+		// own span it inflates the parent fc_invoke span past the caller's client
+		// span and reads as extra exec time. Parent under ctx (which carries the
+		// fc_invoke span) for nesting; inv.discard uses its own background context
+		// internally so cleanup still runs even if ctx is cancelled, which is
+		// independent of span parentage.
+		_, teardownSpan := tracer.Start(ctx, "guest_teardown")
 		inv.discard(h)
+		teardownSpan.End()
 	}
 
 	// A warm restore is already warmed in the snapshot, so it answers /shim/ready


### PR DESCRIPTION
## What

Wraps the microVM teardown (driver `Release` + bundle removal, `inv.discard`) in its own `guest_teardown` span, parented under `fc_invoke`.

## Why

On the success path, teardown runs at response-body `Close`, AFTER the caller already has its response, so it is off the critical path. Folded into the parent `fc_invoke` span it made `fc_invoke` (e.g. 1012ms) run longer than its parent client `POST` span (982ms) and read as extra exec time in the waterfall. As its own span the trailing time is explicitly labeled teardown, and the child-exceeds-parent stops looking like a glitch. `discardGuest` runs on every path (eager error returns + success cleanup), so the one span covers all.

Parented under `ctx` (which carries the `fc_invoke` span); `inv.discard` keeps its own background context internally so cleanup still runs if `ctx` is cancelled, independent of span parentage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)