### PR TITLE
fix(monolith-public): bump chart to roll grimoire hero copy to public tier

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.23
+version: 0.89.24
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.23
+      targetRevision: 0.89.24
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
## Why

PR #3288 changed the Grimoire scroll-story hero copy and bumped the `monolith` chart, but **not** the `monolith-public` chart. The public tier (`monolith-public`) is what serves the public `/app/grimoire` route, and its deployed chart (`0.89.23`) still pins the pre-merge `public-frontend` image (`...14.58.03-3773855`, built before #3288 merged at 15:07). So the change is live on the main tier but not on the tier users actually hit.

## Fix

Bare version bump `0.89.23 -> 0.89.24`. No code change: the `public-frontend` image builds from the shared `projects/monolith/frontend` source, so the bump alone forces a chart republish that re-pins the freshly-built image carrying the new copy.

## Follow-up (separate)

Investigating whether the missed-bump guardrail's dependency closure should have flagged that a `projects/monolith/frontend` change also requires a `monolith-public` bump. If the closure is under-scoped it fails open here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)