### PR TITLE
feat(chat): shield chat-agent replies from leaked tool-call scaffolding

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1148,6 +1148,19 @@ py_test(
 )
 
 py_test(
+    name = "chat_reply_sanitize_test",
+    srcs = ["chat/reply_sanitize_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "chat_goosecracker_progress_test",
     srcs = ["chat/goosecracker_progress_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.62
+version: 0.285.63
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260707170000_agent_reply_repair.sql
+++ b/projects/monolith/chart/migrations/20260707170000_agent_reply_repair.sql
@@ -1,0 +1,21 @@
+-- Log of chat-agent replies that leaked tool-call scaffolding (chat.reply_sanitize).
+-- One row per reply where the small model dumped <tool_call>/<arg_*> scaffolding
+-- into its answer and the shield had to scrub and, when needed, run the bounded
+-- model-repair loop. Kept so the copy can be evaluated later and the reply/plan
+-- prompts iterated against real failures. Safe to create empty.
+CREATE TABLE IF NOT EXISTS chat.agent_reply_repair (
+    id BIGSERIAL PRIMARY KEY,
+    channel_id TEXT NOT NULL DEFAULT '',
+    author_id TEXT NOT NULL DEFAULT '',
+    route TEXT NOT NULL DEFAULT 'chat',
+    markers TEXT NOT NULL DEFAULT '',
+    raw_text TEXT NOT NULL DEFAULT '',
+    scrubbed_text TEXT NOT NULL DEFAULT '',
+    final_text TEXT NOT NULL DEFAULT '',
+    repair_attempts INTEGER NOT NULL DEFAULT 0,
+    outcome TEXT NOT NULL DEFAULT 'clean_after_repair',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT agent_reply_repair_outcome_valid
+        CHECK (outcome IN ('clean_after_repair', 'still_dirty'))
+);
+CREATE INDEX IF NOT EXISTS agent_reply_repair_created ON chat.agent_reply_repair (created_at DESC);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ZaRd51RpLRyzxlrqMqqDpsEHfbcoDZb0djKA9DuuKmw=
+h1:XL0QTuJBPkZZKTWahDchiWjuF+3bY/aPEKFl+LFHx3o=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -110,3 +110,4 @@ h1:ZaRd51RpLRyzxlrqMqqDpsEHfbcoDZb0djKA9DuuKmw=
 20260706010000_grimoire_table_type.sql h1:pw2njEe9GQobGDUWLSZgGtYH1khJqoRpxtll/uNzHuU=
 20260706190000_chat_messages_fts.sql h1:RGg6aFMSxA72kAjADloWTco0EZ9uulKyohTFkbAT/cU=
 20260706200000_grimoire_chat.sql h1:8Id0bGWTFbXyrvOUIOe0gjQU2XPw56RWfXQTD4O4WdQ=
+20260707170000_agent_reply_repair.sql h1:Z31AFbfJDO/7/i/NzLLd2aO22UEVCYxAJedQVMzkEt0=

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -39,7 +39,9 @@ from chat import directives
 from chat import goosecracker
 from chat import goosecracker_progress
 from chat import orchestrator
+from chat import reply_repair_log
 from chat import summarizer
+from chat.reply_sanitize import repair_leaked_reply
 from chat.models import ReactionEvent
 from app.db import get_engine
 
@@ -59,6 +61,11 @@ STREAM_EDIT_INTERVAL = 1.0
 # against Discord's own base-tier upload limit, not the primary control.
 RUN_PYTHON_MAX_ATTACHMENTS = 8
 RUN_PYTHON_MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024
+# Bounded model-repair passes when a chat reply leaks tool-call scaffolding
+# (chat.reply_sanitize). 0 disables repair (scrub only).
+AGENT_REPLY_REPAIR_MAX_TURNS = int(os.environ.get("AGENT_REPLY_REPAIR_MAX_TURNS", "2"))
+# Shown when the shield cannot recover any clean text but a chart was produced.
+_CHART_ONLY_CAPTION = "Here's the chart 👇"
 
 
 def _build_run_python_attachments(generated_files: list) -> "list[discord.File]":
@@ -86,6 +93,37 @@ def _build_run_python_attachments(generated_files: list) -> "list[discord.File]"
             ", ".join(dropped),
         )
     return files
+
+
+async def _deliver_chat_reply(send, text: "str | None", generated_files: list):
+    """Post a chat-route reply and any generated files as ONE message.
+
+    Discord's send/reply take ``content`` and ``files`` together, so a generated
+    chart no longer arrives as a separate second message after the text. When
+    the shield (chat.reply_sanitize) recovered no clean text but a chart exists,
+    caption it; when there is neither text nor a file, skip. ``send`` is the
+    site's send callable (``interaction.followup.send`` or ``message.reply``).
+    Returns the sent message, or None. Best-effort: on failure, falls back to a
+    text-only send so the reply is not lost entirely.
+    """
+    files = _build_run_python_attachments(generated_files) if generated_files else []
+    body = (text or "").strip()
+    if not body and files:
+        body = _CHART_ONLY_CAPTION
+    if not body and not files:
+        return None
+    try:
+        if files:
+            return await send(content=body or None, files=files)
+        return await send(body)
+    except Exception:
+        logger.exception("run_python: failed to deliver chat reply with attachments")
+        if body:
+            try:
+                return await send(body)
+            except Exception:
+                logger.exception("run_python: text-only fallback also failed")
+        return None
 
 
 # Fact-check (the "Get your facts STR8!" button). The result streams into a
@@ -1022,17 +1060,13 @@ class ChatBot(discord.Client):
         outcome = await self.start_agent_flow(channel, interaction.user, prompt, repo)
         if outcome.chat_reply is not None:
             # ADR 036: the orchestrator routed this to chat, so reply inline
-            # instead of opening a session thread.
-            await interaction.followup.send(outcome.chat_reply)
-            if outcome.generated_files:
-                try:
-                    files = _build_run_python_attachments(outcome.generated_files)
-                    if files:
-                        await interaction.followup.send(files=files)
-                except Exception:
-                    logger.exception(
-                        "run_python: failed to flush chat-verdict attachments"
-                    )
+            # instead of opening a session thread. Text + any chart go in ONE
+            # message (see _deliver_chat_reply).
+            await _deliver_chat_reply(
+                interaction.followup.send,
+                outcome.chat_reply,
+                outcome.generated_files,
+            )
             # No motivating message on the slash path, so pass "".
             await self._flush_directive_proposals(
                 outcome.pending_proposal,
@@ -1309,11 +1343,30 @@ class ChatBot(discord.Client):
                     orchestrator_guidance=guidance,
                 )
                 result = await self.agent.run(prompt, deps=deps)
-                return (
-                    result.output,
-                    list(deps.generated_files),
-                    list(deps.pending_proposal),
+                files = list(deps.generated_files)
+                proposals = list(deps.pending_proposal)
+            # Shield the reply from leaked tool-call scaffolding (a small model
+            # emitting a run_python call as plain text) and from stray markdown
+            # image tags. Always scrub; when a leak is detected, run the bounded
+            # model-repair loop and log the occurrence for later eval. Outside
+            # the session block: the repair uses its own inference seam, not the
+            # store-backed tools. Best-effort: a shield failure falls back to the
+            # raw output so a reply still ships.
+            try:
+                shielded = await repair_leaked_reply(
+                    result.output or "",
+                    llm_call=summarizer.build_llm_caller(),
+                    max_turns=AGENT_REPLY_REPAIR_MAX_TURNS,
                 )
+                if shielded.leaked:
+                    await asyncio.to_thread(
+                        reply_repair_log.log_repair, channel_id, user_id, shielded
+                    )
+                reply_text = shielded.final
+            except Exception:
+                logger.exception("orchestrator: reply shield failed")
+                reply_text = result.output
+            return reply_text, files, proposals
         except Exception:
             logger.exception("orchestrator: chat reply generation failed")
             return None, [], []
@@ -1634,18 +1687,12 @@ class ChatBot(discord.Client):
         )
         if outcome.chat_reply is not None:
             # ADR 036: routed to chat, so reply to the triggering message rather
-            # than opening a session thread.
+            # than opening a session thread. Text + any chart go in ONE message
+            # (see _deliver_chat_reply).
             try:
-                sent = await message.reply(outcome.chat_reply)
-                if outcome.generated_files:
-                    try:
-                        files = _build_run_python_attachments(outcome.generated_files)
-                        if files:
-                            await message.reply(files=files)
-                    except Exception:
-                        logger.exception(
-                            "run_python: failed to flush chat-verdict attachments"
-                        )
+                sent = await _deliver_chat_reply(
+                    message.reply, outcome.chat_reply, outcome.generated_files
+                )
                 await self._flush_directive_proposals(
                     outcome.pending_proposal,
                     str(channel.id),
@@ -1656,14 +1703,16 @@ class ChatBot(discord.Client):
                 # Link this in-channel reply to the ambient engage decision so a
                 # reaction on it joins to the engage exactly (ADR 035 /
                 # improve-ambient). The thread-opening path has no single
-                # in-channel reply, so it stays null. Best-effort.
+                # in-channel reply, so it stays null; likewise when the shield
+                # delivered nothing (sent is None). Best-effort.
                 try:
-                    await asyncio.to_thread(
-                        attention_log.set_reply_message,
-                        str(channel.id),
-                        str(message.id),
-                        str(sent.id),
-                    )
+                    if sent is not None:
+                        await asyncio.to_thread(
+                            attention_log.set_reply_message,
+                            str(channel.id),
+                            str(message.id),
+                            str(sent.id),
+                        )
                 except Exception:
                     logger.exception(
                         "attention: failed to record agent reply id for %s",

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -316,6 +316,39 @@ class ReactionEvent(SQLModel, table=True):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
+class AgentReplyRepair(SQLModel, table=True):
+    """Log of chat-agent replies that leaked tool-call scaffolding.
+
+    One row per reply where the small model dumped ``<tool_call>``/``<arg_*>``
+    scaffolding into its answer and the shield (chat.reply_sanitize) had to
+    scrub and, when needed, run the bounded model-repair loop. Kept so the copy
+    can be evaluated later and the reply/plan prompts iterated against real
+    failures. outcome records how it resolved; raw/scrubbed/final are the text
+    at each stage (raw is what the model emitted, final is what shipped).
+    """
+
+    __tablename__ = "agent_reply_repair"
+    __table_args__ = (
+        CheckConstraint(
+            "outcome IN ('clean_after_repair', 'still_dirty')",
+            name="agent_reply_repair_outcome_valid",
+        ),
+        {"schema": "chat", "extend_existing": True},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    channel_id: str = Field(default="")
+    author_id: str = Field(default="")
+    route: str = Field(default="chat")
+    markers: str = Field(default="")
+    raw_text: str = Field(default="")
+    scrubbed_text: str = Field(default="")
+    final_text: str = Field(default="")
+    repair_attempts: int = Field(default=0)
+    outcome: str = Field(default="clean_after_repair")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
 class ChannelDirective(SQLModel, table=True):
     """Living per-channel behavioural directive (ADR 035 phase 5).
 

--- a/projects/monolith/chat/reply_repair_log.py
+++ b/projects/monolith/chat/reply_repair_log.py
@@ -1,0 +1,53 @@
+"""Persist chat-agent reply-repair events (tool-call leak shield).
+
+Every reply where the shield (chat.reply_sanitize) detected leaked tool-call
+scaffolding is logged here, so the copy can be evaluated later and the reply /
+plan prompts iterated against real failures. Mirrors ``attention_log``:
+synchronous (opens its own session), best-effort (never raises into the caller,
+since a logging failure must not block a reply). Call via
+``asyncio.to_thread`` from the bot's async handlers.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlmodel import Session
+
+from app.db import get_engine
+from chat.models import AgentReplyRepair
+from chat.reply_sanitize import RepairOutcome
+
+logger = logging.getLogger(__name__)
+
+# Guard rail so a pathological megabyte of leaked code never bloats the table.
+_MAX_TEXT = 8000
+
+
+def log_repair(
+    channel_id: object,
+    author_id: object,
+    outcome: RepairOutcome,
+    route: str = "chat",
+) -> None:
+    """Persist one reply-repair event. No-op when nothing leaked."""
+    if not outcome.leaked:
+        return
+    try:
+        with Session(get_engine()) as session:
+            session.add(
+                AgentReplyRepair(
+                    channel_id=str(channel_id),
+                    author_id=str(author_id),
+                    route=route,
+                    markers="tool_call",
+                    raw_text=(outcome.raw or "")[:_MAX_TEXT],
+                    scrubbed_text=(outcome.scrubbed or "")[:_MAX_TEXT],
+                    final_text=(outcome.final or "")[:_MAX_TEXT],
+                    repair_attempts=int(outcome.attempts),
+                    outcome=outcome.outcome,
+                )
+            )
+            session.commit()
+    except Exception:
+        logger.exception("reply_repair_log: failed to log repair event")

--- a/projects/monolith/chat/reply_sanitize.py
+++ b/projects/monolith/chat/reply_sanitize.py
@@ -1,0 +1,185 @@
+"""Shield chat-agent replies from leaked tool-call scaffolding.
+
+The chat route (ADR 036) runs the same tool-enabled concierge agent a direct
+mention does, so a small model (Qwen) sometimes emits a ``run_python`` tool call
+as plain assistant text that the harness failed to parse. The raw
+``<tool_call><arg_key>code</arg_key><arg_value>...</arg_value></tool_call>``
+scaffolding (and the Python it wraps) then leaks into the Discord message. It
+also likes to embed ``![alt](chart.png)`` markdown image tags that Discord does
+not render, even though the file is already attached separately.
+
+Two layers, applied in ``_orchestrator_chat_reply`` before delivery:
+
+1. ``scrub_tool_leak`` always runs: it strips the tool-call tags + wrapped code
+   and any markdown image tags, and reports whether tool-call markers were
+   present (``leaked``). Markdown-image stripping is cosmetic and does NOT set
+   ``leaked`` on its own.
+2. ``repair_leaked_reply`` runs the deterministic scrub and, only when a leak
+   was detected, hands the raw output back to the model for a bounded number of
+   reformat passes (``max_turns``) to recover a clean natural-language answer.
+   Every leak occurrence is logged (see ``reply_repair_log``) for later eval and
+   prompt iteration.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Substrings that mean the model dumped tool-call scaffolding into its answer.
+# Whole set kept in sync with the strip patterns below and mirrored in the
+# repair prompt so the model knows exactly what to remove.
+_TOOL_LEAK_MARKERS = (
+    "<tool_call>",
+    "</tool_call>",
+    "<arg_key>",
+    "<arg_value>",
+    "<parameter>",
+    "</parameter>",
+    "<function=",
+)
+
+# A closed <tool_call>...</tool_call> block (the common, well-formed leak).
+_TOOL_CALL_BLOCK = re.compile(r"<tool_call>.*?</tool_call>", re.DOTALL)
+# An unclosed <tool_call> that runs to the end of the message (a truncated
+# leak): everything from the opening tag onward is scaffolding.
+_TOOL_CALL_TRUNCATED = re.compile(r"<tool_call>.*\Z", re.DOTALL)
+# Arg/parameter blocks that appear without a <tool_call> wrapper; the content
+# between them is the raw code, so drop the whole block. A malforming small
+# model does not close tags consistently (e.g. <arg_value>...</parameter>), so
+# any scaffolding open pairs with any scaffolding close (no backreference);
+# non-greedy stops at the first close.
+_ARG_BLOCK = re.compile(
+    r"<(?:arg_key|arg_value|parameter)>.*?</(?:arg_key|arg_value|parameter)>",
+    re.DOTALL,
+)
+# Any orphaned open/close scaffolding tag left after the block strips.
+_ORPHAN_TAG = re.compile(r"</?(?:tool_call|arg_key|arg_value|parameter|function)[^>]*>")
+# Markdown image tag: Discord renders it as literal text, and the file is
+# attached separately, so it is pure noise.
+_MARKDOWN_IMAGE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+# Collapse the blank-line runs the strips leave behind.
+_EXCESS_BLANKS = re.compile(r"\n{3,}")
+
+
+def scrub_tool_leak(text: str) -> tuple[str, bool]:
+    """Strip leaked tool-call scaffolding and markdown image tags from ``text``.
+
+    Returns ``(cleaned, leaked)`` where ``leaked`` is True when tool-call
+    markers were present (the signal that gates the model-repair loop and the
+    log write). Markdown-image removal always happens but does not set
+    ``leaked``: a stray image tag needs no repair, only stripping.
+    """
+    if not text:
+        return "", False
+    leaked = any(marker in text for marker in _TOOL_LEAK_MARKERS)
+    cleaned = _TOOL_CALL_BLOCK.sub("", text)
+    cleaned = _TOOL_CALL_TRUNCATED.sub("", cleaned)
+    cleaned = _ARG_BLOCK.sub("", cleaned)
+    cleaned = _ORPHAN_TAG.sub("", cleaned)
+    cleaned = _MARKDOWN_IMAGE.sub("", cleaned)
+    cleaned = _EXCESS_BLANKS.sub("\n\n", cleaned).strip()
+    return cleaned, leaked
+
+
+_REPAIR_PROMPT = (
+    "The following assistant message accidentally leaked internal tool-call "
+    "scaffolding (XML tags like <tool_call>, <arg_key>, <arg_value>, "
+    "<parameter>, or raw code) into what should have been a normal chat reply. "
+    "Rewrite it as the clean final answer for the user: natural language only, "
+    "no XML tags, no tool-call syntax, and no code block unless the user "
+    "explicitly asked for code. If the message describes a chart or image, "
+    "refer to it as already attached (do not include a markdown image tag). "
+    "Preserve the actual findings and tone; just remove the scaffolding.\n\n"
+    "Message to rewrite:\n"
+)
+
+
+@dataclass
+class RepairOutcome:
+    """Result of scrubbing (and maybe repairing) one chat reply.
+
+    ``final`` is what to deliver. ``leaked`` is whether tool-call scaffolding was
+    detected at all (gates logging). ``attempts`` counts model-repair passes
+    actually made (0 when the scrub alone sufficed or nothing leaked).
+    ``still_dirty`` is True when even the last pass still carried markers, so the
+    best scrubbed text is delivered as a floor. ``raw``/``scrubbed`` are kept for
+    the log row.
+    """
+
+    final: str
+    leaked: bool
+    attempts: int
+    still_dirty: bool
+    raw: str
+    scrubbed: str
+
+    @property
+    def outcome(self) -> str:
+        # Only leaked replies are ever logged, so this maps to the DB CHECK
+        # values. A detected leak always runs at least one repair pass, so it
+        # resolves to clean_after_repair or still_dirty (never scrub-only).
+        if not self.leaked:
+            return "clean"
+        return "still_dirty" if self.still_dirty else "clean_after_repair"
+
+
+async def repair_leaked_reply(
+    raw: str,
+    *,
+    llm_call: Callable[[str], Awaitable[str]],
+    max_turns: int = 2,
+) -> RepairOutcome:
+    """Always scrub ``raw``; if a tool-call leak was present, run up to
+    ``max_turns`` model-repair passes to recover a clean answer.
+
+    Each pass hands the raw output back to ``llm_call`` with a reformat
+    instruction and re-scrubs the result, stopping as soon as the scrub finds no
+    markers. If every pass still leaks, the best deterministic scrub is returned
+    as ``final`` (never worse than the raw). A model-call failure ends the loop
+    and falls back to the scrub. Never raises: a repair failure must not block
+    the reply.
+    """
+    scrubbed, leaked = scrub_tool_leak(raw)
+    if not leaked:
+        return RepairOutcome(
+            final=scrubbed,
+            leaked=False,
+            attempts=0,
+            still_dirty=False,
+            raw=raw,
+            scrubbed=scrubbed,
+        )
+
+    best = scrubbed
+    still_dirty = True
+    attempts = 0
+    for attempt in range(1, max(0, max_turns) + 1):
+        try:
+            rewritten = await llm_call(_REPAIR_PROMPT + raw)
+        except Exception:
+            logger.exception("reply_sanitize: repair pass %d failed", attempt)
+            break
+        attempts = attempt
+        cand, cand_leaked = scrub_tool_leak(rewritten or "")
+        if cand and not cand_leaked:
+            best = cand
+            still_dirty = False
+            break
+        # A non-empty candidate that still leaks is no better than the scrub;
+        # keep the scrub as the floor and try again (up to the cap).
+        if cand and not best:
+            best = cand
+
+    return RepairOutcome(
+        final=best,
+        leaked=True,
+        attempts=attempts,
+        still_dirty=still_dirty,
+        raw=raw,
+        scrubbed=scrubbed,
+    )

--- a/projects/monolith/chat/reply_sanitize_test.py
+++ b/projects/monolith/chat/reply_sanitize_test.py
@@ -1,0 +1,129 @@
+"""Tests for chat.reply_sanitize: the tool-call leak shield.
+
+scrub_tool_leak strips leaked <tool_call>/<arg_*> scaffolding and markdown image
+tags, reporting whether tool-call markers were present. repair_leaked_reply
+always scrubs and, only on a detected leak, runs a bounded model-repair loop
+(injected caller) to recover a clean answer, falling back to the scrub.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from chat.reply_sanitize import repair_leaked_reply, scrub_tool_leak
+
+# A leak shaped like the real one: a closed tool_call wrapping arg blocks + code.
+_LEAK = (
+    "<tool_call><arg_key>code</arg_key><arg_value>import matplotlib.pyplot as plt\n"
+    "plt.savefig('chart.png')</arg_value></tool_call>"
+)
+
+
+class TestScrub:
+    def test_clean_text_passes_through_unflagged(self):
+        cleaned, leaked = scrub_tool_leak("BMWs are overweight, but fun.")
+        assert cleaned == "BMWs are overweight, but fun."
+        assert leaked is False
+
+    def test_empty(self):
+        assert scrub_tool_leak("") == ("", False)
+
+    def test_closed_tool_call_block_stripped_and_flagged(self):
+        cleaned, leaked = scrub_tool_leak("Here you go.\n" + _LEAK)
+        assert leaked is True
+        assert "<tool_call>" not in cleaned
+        assert "savefig" not in cleaned
+        assert cleaned == "Here you go."
+
+    def test_truncated_unclosed_tool_call_stripped_to_end(self):
+        raw = "The answer is 42.\n<tool_call><arg_key>code</arg_key><arg_value>x = 1"
+        cleaned, leaked = scrub_tool_leak(raw)
+        assert leaked is True
+        assert cleaned == "The answer is 42."
+
+    def test_arg_blocks_without_wrapper_stripped(self):
+        raw = "<arg_key>code</arg_key><arg_value>print(1)</parameter>"
+        cleaned, leaked = scrub_tool_leak(raw)
+        assert leaked is True
+        assert "print(1)" not in cleaned
+        assert "<arg" not in cleaned
+
+    def test_orphan_tags_removed(self):
+        cleaned, leaked = scrub_tool_leak("text </parameter></tool_call>")
+        assert leaked is True
+        assert "<" not in cleaned
+        assert cleaned == "text"
+
+    def test_markdown_image_stripped_without_leak_flag(self):
+        # A stray markdown image is cosmetic: strip it, but do NOT flag a leak
+        # (so it never triggers the model-repair loop).
+        cleaned, leaked = scrub_tool_leak("See the chart ![c](chart.png) attached")
+        assert leaked is False
+        assert "![" not in cleaned
+        assert "chart.png" not in cleaned
+
+
+class TestRepair:
+    @pytest.mark.asyncio
+    async def test_clean_reply_skips_the_model(self):
+        caller = AsyncMock()
+        out = await repair_leaked_reply("All good here.", llm_call=caller)
+        assert out.leaked is False
+        assert out.attempts == 0
+        assert out.final == "All good here."
+        assert out.outcome == "clean"
+        caller.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_leak_repaired_by_model(self):
+        caller = AsyncMock(return_value="The M3 out-torques the STI across the board.")
+        out = await repair_leaked_reply("Here.\n" + _LEAK, llm_call=caller, max_turns=2)
+        assert out.leaked is True
+        assert out.attempts == 1
+        assert out.still_dirty is False
+        assert out.final == "The M3 out-torques the STI across the board."
+        assert out.outcome == "clean_after_repair"
+        caller.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_leak_model_keeps_leaking_falls_back_to_scrub(self):
+        # Every repair pass still leaks: exhaust max_turns, deliver the scrub.
+        caller = AsyncMock(return_value="still dirty " + _LEAK)
+        out = await repair_leaked_reply(
+            "Prose.\n" + _LEAK, llm_call=caller, max_turns=2
+        )
+        assert out.leaked is True
+        assert out.attempts == 2
+        assert out.still_dirty is True
+        assert out.final == "Prose."  # scrub floor
+        assert out.outcome == "still_dirty"
+        assert caller.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_model_failure_falls_back_to_scrub(self):
+        caller = AsyncMock(side_effect=RuntimeError("model down"))
+        out = await repair_leaked_reply(
+            "Prose.\n" + _LEAK, llm_call=caller, max_turns=2
+        )
+        assert out.leaked is True
+        assert out.attempts == 0
+        assert out.still_dirty is True
+        assert out.final == "Prose."
+        assert out.outcome == "still_dirty"
+
+    @pytest.mark.asyncio
+    async def test_markdown_image_only_does_not_trigger_repair(self):
+        caller = AsyncMock()
+        out = await repair_leaked_reply("See ![c](c.png) below", llm_call=caller)
+        assert out.leaked is False
+        assert "![" not in out.final
+        caller.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_max_turns_zero_scrubs_only(self):
+        caller = AsyncMock()
+        out = await repair_leaked_reply("Hi.\n" + _LEAK, llm_call=caller, max_turns=0)
+        assert out.leaked is True
+        assert out.attempts == 0
+        assert out.final == "Hi."
+        caller.assert_not_called()

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.62
+      targetRevision: 0.285.63
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Fixes two leaks in the chat-agent reply path (ADR 036 route-to-chat), from Joe's Discord screenshots of Bosun's chart replies.

## What was wrong

The chat route runs the tool-enabled concierge agent, so Qwen sometimes emits a `run_python` tool call as plain assistant text the harness can't parse. The result leaked into Discord verbatim:

1. **Tool-call scaffolding** — `<tool_call><arg_key>code</arg_key><arg_value>import matplotlib…savefig('final_danke_chart.png')</parameter></tool_call>` posted as the message body.
2. **Markdown image tag + double message** — `![alt](chart.png)` rendered as literal text, and the chart PNG posted as a *separate second message* after the text.

No prompt reliably stops a small model from leaking scaffolding, so the shield is deterministic + a bounded model-repair fallback, at the delivery boundary.

## Changes

- **`chat/reply_sanitize.py`** (new, pure + unit-tested):
  - `scrub_tool_leak(text) -> (cleaned, leaked)` strips `<tool_call>`/`<arg_*>`/`<parameter>` scaffolding (closed, truncated-to-end, and wrapper-less forms), orphan tags, and `![…](…)` markdown image tags. Markdown-image stripping runs always (cosmetic, zero latency) and does **not** set `leaked`.
  - `repair_leaked_reply(raw, *, llm_call, max_turns)` always scrubs and, **only on a detected leak**, runs up to `max_turns` model-repair passes (reformat the raw output into a clean answer), stopping when clean, falling back to the scrub floor. Repair uses `build_llm_caller()` (plain text→text), **not** `self.agent.run` — re-running the agent could re-invoke `run_python` and re-leak.
- **`_orchestrator_chat_reply`** wires the shield in after the agent run.
- **`_deliver_chat_reply`** posts text + chart as **one** message (`content` + `files` together); captions the chart when the shield left no text; both delivery sites (slash + ambient) routed through it.
- **`chat.agent_reply_repair` table** (+ migration) logs every leak occurrence — `raw_text`, `scrubbed_text`, `final_text`, `repair_attempts`, `outcome` (`clean_after_repair` | `still_dirty`) — for later eval and prompt iteration (Joe's ask).
- Config: `AGENT_REPLY_REPAIR_MAX_TURNS` (default 2; 0 = scrub only).

## Behavior

| Input | Scrub | Repair loop | Log |
| --- | --- | --- | --- |
| Clean reply | no-op | skipped | no |
| Stray `![](png)` only | strips tag | skipped | no |
| Tool-call leak | strips scaffolding | runs (≤ max_turns) | yes |
| Leak, model recovers | — | `clean_after_repair` | yes |
| Leak, model keeps failing | — | falls back to scrub floor, `still_dirty` | yes |

Unit tests cover every row (`chat/reply_sanitize_test.py`). atlas.sum regenerated with the CI-pinned atlas community v1.1.0. Monolith chart bumped (0.285.63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)