### PR TITLE
feat(demos): clearer monolith color + off-critical-path teardown marking

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.62
+version: 0.285.63
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.62
+      targetRevision: 0.285.63
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/TraceWaterfall.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/TraceWaterfall.svelte
@@ -46,6 +46,16 @@
     return SERVICE_COLORS[service] ?? "var(--svc-default)";
   }
 
+  // Spans that run AFTER the response is already returned to the caller (VM
+  // teardown / bundle cleanup): real work, but off the caller's critical path,
+  // so we dim them and tag them rather than let them read as latency the caller
+  // waited on.
+  const OFF_PATH_SPANS = new Set(["guest_teardown", "vm_release", "bundle_cleanup"]);
+
+  function isOffPath(name) {
+    return OFF_PATH_SPANS.has(name);
+  }
+
   let spans = $state([]);
   // Goose's own internal spans (service `goose-coding`), correlated to this run
   // by the runner stamping `caller.trace_id` on them. Goose does not honor an
@@ -241,10 +251,12 @@
       {#each sortedSpans as span (span.span_id)}
         <div
           class="row"
+          class:row--offpath={isOffPath(span.name)}
           style={`padding-left: ${(depthById.get(span.span_id) ?? 0) * 0.9}rem;`}
         >
           <span class="row-label" title={`${span.name} · ${span.service}`}>
             {span.name}
+            {#if isOffPath(span.name)}<span class="row-tag">off critical path</span>{/if}
             <span class="row-service">{span.service}</span>
           </span>
           <div class="row-track">
@@ -436,6 +448,24 @@
     color: var(--text-faint);
     text-transform: uppercase;
     letter-spacing: 0.05em;
+  }
+
+  /* Off-critical-path spans (teardown/cleanup after the response): dimmed bar
+     plus a small tag so they do not read as latency the caller waited on. */
+  .row--offpath .row-bar {
+    opacity: 0.4;
+  }
+
+  .row-tag {
+    font-size: 9px;
+    color: var(--text-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    border: 1px solid var(--line);
+    border-radius: 3px;
+    padding: 0 4px;
+    margin-left: 4px;
+    white-space: nowrap;
   }
 
   .row-track {

--- a/projects/monolith/frontend/src/lib/private/demos/theme.css
+++ b/projects/monolith/frontend/src/lib/private/demos/theme.css
@@ -20,7 +20,7 @@
   /* Per-service trace-waterfall colors: one stable, distinct hue per layer so a
    * trace reads as bands (monolith request -> fc-invoke VM management -> guest
    * agent) instead of a wall of same-ish blue. Muted to sit on the paper. */
-  --svc-monolith: #33507a; /* the request layer, matches --accent */
+  --svc-monolith: #3a72b5; /* the request layer: a clearer blue than the slate accent, tone-matched to the other service colors */
   --svc-fc: #3f7a5c; /* fc-invoke: VM lifecycle */
   --svc-goose: #a86a1f; /* goose-coding: the agent inside */
   --svc-semgrep: #8a5a9a; /* semgrep scan */


### PR DESCRIPTION
- `--svc-monolith` slate `#33507a` -> clearer blue `#3a72b5`, tone-matched to the other service colors and easier to read.
- Spans that run after the response is returned (`guest_teardown`, and future `vm_release`/`bundle_cleanup`) render dimmed with an "off critical path" tag, so the waterfall stops implying the caller waited on teardown. The caller does not: the client `POST` span ends before `fc_invoke` (teardown runs server-side after the response).

🤖 Generated with [Claude Code](https://claude.com/claude-code)