### PR TITLE
build(monolith-public): chart bump to 0.89.25 for rebuilt image digests

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.24
+version: 0.89.25
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.24
+      targetRevision: 0.89.25
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
## What

Bumps the `monolith-public` chart `0.89.24 -> 0.89.25` (Chart.yaml + deploy/application.yaml targetRevision together, via `bump-chart.sh`).

## Why

The `Push images` action on main failed with:

> ERROR: monolith-public 0.89.24 is already published, but its pinned image digests differ from the published chart (an image was rebuilt). This merge will NOT deploy until the chart version is bumped.

A `monolith-public` image was rebuilt, changing its pinned digest, but the chart at `0.89.24` was already published to OCI pointing at the old digests. ArgoCD pulls charts by version, so the new render will not deploy until the version is bumped. This mints `0.89.25` capturing the current digests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)