### PR TITLE
feat(whatsapp): full local tools + DeepSeek V4 Flash for the household tier

### DIFF
--- a/projects/firecracker/substrate/deploy/values.yaml
+++ b/projects/firecracker/substrate/deploy/values.yaml
@@ -100,11 +100,19 @@ egress:
     #
     # INVARIANT: the placeholder set here must equal the set of kloak: placeholders
     # the monolith goose tiers hand to guests. kloak_placeholder_drift_test.py
-    # (in projects/monolith) fails CI if they drift. The artifact tier's former
-    # OpenRouter swap (kloak:or:...) was removed when that tier migrated onto the
-    # in-cluster Qwen model (free, keyless); re-adding an OpenRouter guest tier
-    # means restoring both the tier env and the catalog entry together.
+    # (in projects/monolith) fails CI if they drift.
     - env: GITHUB_TOKEN
       placeholder: "kloak:gh:01JZX8K3N7Q2M5R9W4T6Y0F1B8"
       egressTo: [api.github.com]
       secretRef: { name: monolith-chat-secrets, key: GITHUB_TOKEN }
+    # The household tier's OpenRouter key (ADR 039, amended): the WhatsApp guest
+    # runs on DeepSeek V4 Flash, so it holds this placeholder as OPENAI_API_KEY
+    # (goosecracker.tiers.household). The sidecar swaps it for the real key only on
+    # openrouter.ai; external:allow already reaches that host. The real value is the
+    # OPENROUTER_API_KEY field of the "goosecracker" Secret (synced from 1Password,
+    # referenced by that exact name). placeholder MUST match
+    # tiers.household.OPENAI_API_KEY in the monolith deploy values.
+    - env: OPENROUTER_KEY
+      placeholder: "kloak:or:B5BKP27T2KSDN6QW70N34H8DP6"
+      egressTo: [openrouter.ai]
+      secretRef: { name: goosecracker, key: OPENROUTER_API_KEY }

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.65
+version: 0.285.66
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -130,6 +130,11 @@ spec:
                   key: DISCORD_BOT_TOKEN
             - name: LLAMA_CPP_URL
               value: {{ .Values.chat.llamaCppUrl | quote }}
+            # Pinned OpenRouter model for household (WhatsApp) content generation.
+            # The in-monolith concierge reply and the WhatsApp chat agent read this;
+            # the goose guest model is carried in the GOOSECRACKER_TIERS env instead.
+            - name: HOUSEHOLD_LLM_MODEL
+              value: {{ .Values.whatsapp.model | quote }}
             - name: EMBEDDING_URL
               value: {{ .Values.chat.embeddingUrl | quote }}
             - name: SEARXNG_URL

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -834,6 +834,12 @@ orchestrator:
 # chart BUILD images map); never hand-set a digest here.
 whatsapp:
   enabled: false
+  # Pinned OpenRouter model for household CONTENT generation in the monolith: the
+  # concierge agent-result reply and the WhatsApp chat agent both author on this
+  # (strong but cheap). The goose GUEST model is set separately in
+  # goosecracker.tiers.household. Kept as a value (never :auto) so replies stay
+  # attributable; the monolith reaches openrouter.ai directly with OPENROUTER_API_KEY.
+  model: "deepseek/deepseek-v4-flash"
   image:
     repository: ""
     tag: ""

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -320,15 +320,38 @@ def format_context_messages(
     return "\n".join(lines)
 
 
-def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
-    """Create a PydanticAI agent configured for Qwen via llama.cpp."""
-    url = base_url or LLAMA_CPP_URL
+def create_agent(
+    base_url: str | None = None,
+    *,
+    model_name: str | None = None,
+    api_key: str | None = None,
+    provider_base_url: str | None = None,
+    model_settings: ModelSettings | None = None,
+) -> Agent[ChatDeps]:
+    """Create a PydanticAI agent (same tools and prompts for every tier).
+
+    Defaults to in-cluster Qwen via llama.cpp. Pass ``provider_base_url`` +
+    ``api_key`` + ``model_name`` to back it with a hosted OpenAI-compatible model
+    instead (the household/WhatsApp tier -> DeepSeek V4 Flash on OpenRouter); the
+    Qwen path is untouched when those are absent. ``provider_base_url`` is used
+    verbatim (it already includes the API path, e.g. ``.../api/v1``), unlike the
+    llama.cpp ``base_url`` which gets ``/v1`` appended.
+    """
+    if provider_base_url:
+        prov_url = provider_base_url
+        key = api_key or ""
+        name = model_name or "qwen3.6-27b"
+    else:
+        url = base_url or LLAMA_CPP_URL
+        prov_url = f"{url}/v1"
+        key = api_key or "not-needed"
+        name = model_name or "qwen3.6-27b"
 
     model = OpenAIChatModel(
-        "qwen3.6-27b",
+        name,
         provider=OpenAIProvider(
-            base_url=f"{url}/v1",
-            api_key="not-needed",
+            base_url=prov_url,
+            api_key=key,
         ),
     )
 
@@ -352,7 +375,8 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
     agent: Agent[ChatDeps] = Agent(
         model,
         system_prompt=build_system_prompt(),
-        model_settings=ModelSettings(
+        model_settings=model_settings
+        or ModelSettings(
             temperature=1.0,
             top_p=0.95,
             extra_body={
@@ -805,6 +829,34 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
         return "\n".join(parts)
 
     return agent
+
+
+# OpenRouter API path for the household tier's hosted model. Used verbatim as the
+# provider base_url (it already ends in the API version segment).
+_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def create_household_agent() -> Agent[ChatDeps]:
+    """The WhatsApp/household chat agent (ADR 039, amended).
+
+    Same tools, system prompt, and signposts as the default concierge, but backed
+    by DeepSeek V4 Flash on OpenRouter (strong but cheap) rather than in-cluster
+    Qwen: every generated reply on the WhatsApp channel is authored by the hosted
+    model, while Qwen is reserved for the activation classifier. Runs in the
+    monolith, which already holds ``OPENROUTER_API_KEY``, so it reaches
+    openrouter.ai directly (no egress swap; that is only for the goose guest). The
+    model id is pinned via ``household_model()`` (HOUSEHOLD_LLM_MODEL from values).
+    """
+    from chat.summarizer import household_model
+
+    return create_agent(
+        provider_base_url=_OPENROUTER_BASE_URL,
+        api_key=os.environ.get("OPENROUTER_API_KEY", ""),
+        model_name=household_model(),
+        # DeepSeek does not take the Qwen-specific top_k / presence_penalty
+        # extra_body; keep sampling simple and let the model apply its defaults.
+        model_settings=ModelSettings(temperature=0.7, top_p=0.95),
+    )
 
 
 def create_fact_check_agent(base_url: str | None = None) -> "Agent[None]":

--- a/projects/monolith/chat/api.py
+++ b/projects/monolith/chat/api.py
@@ -34,6 +34,7 @@ from chat.orchestrator_plan import Plan  # re-exported
 from chat.orchestrator_plan import PlanStep  # re-exported
 from chat.outbox import enqueue_edit  # re-exported
 from chat.outbox import enqueue_message  # re-exported
+from chat.summarizer import build_openrouter_caller  # re-exported
 from chat.summarizer import conversational_agent_reply  # re-exported
 from chat.summarizer import run_summary_generation  # re-exported
 from chat.whatsapp_session import checklist_final as whatsapp_checklist_final
@@ -49,6 +50,7 @@ __all__ = [
     "ack_inflight",
     "artifact_id_for_thread",
     "build_injected_context",
+    "build_openrouter_caller",
     "conversational_agent_reply",
     "drain_agent_queue",
     "ensure_steering_token",

--- a/projects/monolith/chat/summarizer.py
+++ b/projects/monolith/chat/summarizer.py
@@ -535,3 +535,96 @@ def build_llm_caller(base_url: str | None = None) -> Callable[[str], Awaitable[s
         raise last_exc  # type: ignore[misc]
 
     return call_llm
+
+
+# Household (ADR 039, amended): all generated CONTENT for the WhatsApp channel is
+# authored by a strong-but-cheap hosted model (DeepSeek V4 Flash on OpenRouter),
+# while the in-cluster Qwen is reserved for the activation classifier. The model
+# is pinned (never :auto) so replies stay attributable; the default here is the
+# floor, and HOUSEHOLD_LLM_MODEL (set from Helm values) is the source of truth in
+# a real deployment. This runs IN the monolith, which already holds
+# OPENROUTER_API_KEY for the orchestrator, so it reaches openrouter.ai directly
+# (no egress swap; that is only for the sandboxed goose guest).
+_HOUSEHOLD_MODEL_DEFAULT = "deepseek/deepseek-v4-flash"
+_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def household_model() -> str:
+    """The pinned OpenRouter model id for household content generation."""
+    return os.environ.get("HOUSEHOLD_LLM_MODEL", "").strip() or _HOUSEHOLD_MODEL_DEFAULT
+
+
+def build_openrouter_caller(
+    model: str | None = None, base_url: str | None = None
+) -> Callable[[str], Awaitable[str]]:
+    """Async caller that sends a prompt to an OpenRouter-hosted model.
+
+    Mirrors ``build_llm_caller`` (same retry contract, same ``str -> str`` shape)
+    but targets OpenRouter with ``OPENROUTER_API_KEY`` and a pinned model. Used
+    for household-tier content so the WhatsApp channel answers on DeepSeek V4
+    Flash while Discord stays on in-cluster Qwen.
+    """
+    url = (base_url or _OPENROUTER_BASE_URL).rstrip("/")
+    model_id = model or household_model()
+    api_key = os.environ.get("OPENROUTER_API_KEY", "")
+    client = httpx.AsyncClient(timeout=httpx.Timeout(600.0))
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+
+    async def call_llm(prompt: str, *, max_retries: int = 3) -> str:
+        last_exc: Exception | None = None
+        for attempt in range(max_retries + 1):
+            try:
+                resp = await client.post(
+                    f"{url}/chat/completions",
+                    headers=headers,
+                    json={
+                        "model": model_id,
+                        "messages": [{"role": "user", "content": prompt}],
+                        "max_tokens": _LLM_MAX_TOKENS,
+                    },
+                )
+                resp.raise_for_status()
+                try:
+                    content = resp.json()["choices"][0]["message"]["content"]
+                except (KeyError, IndexError, ValueError) as e:
+                    raise RuntimeError(f"unexpected LLM response shape: {e}") from e
+                if not content:
+                    raise RuntimeError("OpenRouter returned empty content")
+                return content
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code not in _RETRYABLE_STATUS_CODES:
+                    raise
+                last_exc = exc
+            except httpx.ConnectError as exc:
+                last_exc = exc
+
+            if attempt < max_retries:
+                delay = 2**attempt  # 1s, 2s, 4s
+                logger.warning(
+                    "OpenRouter call failed (attempt %d/%d): %s — retrying in %ds",
+                    attempt + 1,
+                    max_retries + 1,
+                    last_exc,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+        raise last_exc  # type: ignore[misc]
+
+    return call_llm
+
+
+def concierge_caller_for_tier(
+    tier: str,
+) -> Callable[[str], Awaitable[str]] | None:
+    """The content-generation caller for a tier, or None to use the default.
+
+    The household tier (WhatsApp) authors content on DeepSeek V4 Flash; every
+    other tier returns None so the caller keeps its existing default (in-cluster
+    Qwen via ``build_llm_caller``). Returning None rather than the Qwen caller
+    keeps the Discord path byte-identical (it never builds a caller it would not
+    have built before).
+    """
+    if tier == "household":
+        return build_openrouter_caller()
+    return None

--- a/projects/monolith/chat/whatsapp_inbound.py
+++ b/projects/monolith/chat/whatsapp_inbound.py
@@ -164,7 +164,7 @@ async def _generate_reply(
     unlike the Discord path which live-streams. Recent group history is loaded
     for context exactly as the Discord concierge does.
     """
-    from chat.agent import ChatDeps, create_agent, format_context_messages
+    from chat.agent import ChatDeps, create_household_agent, format_context_messages
     from chat.store import MessageStore
 
     store = MessageStore(session=session, embed_client=embed_client)
@@ -178,7 +178,9 @@ async def _generate_reply(
         author_id=group_jid,
     )
     prompt = f"{context}\n\nCurrent message from {sender_name or 'someone'}: {text}"
-    agent = create_agent()
+    # Household content is authored by DeepSeek V4 Flash on OpenRouter, not the
+    # in-cluster Qwen the Discord concierge uses (ADR 039, amended).
+    agent = create_household_agent()
     result = await agent.run(prompt, deps=deps)
     output = result.output
     return output if isinstance(output, str) and output else ""

--- a/projects/monolith/chat/whatsapp_session.py
+++ b/projects/monolith/chat/whatsapp_session.py
@@ -43,8 +43,10 @@ from goosecracker.api import tier_allows
 
 logger = logging.getLogger(__name__)
 
-# The household tier for WhatsApp group sessions (ADR 039). Denied repo, cluster,
-# and artifact tools; granted knowledge, calendar, reminders (goosecracker.tiers).
+# The household tier for WhatsApp group sessions (ADR 039, amended). Granted every
+# LOCAL capability (knowledge, calendar, reminders, artifact/chart builds); only
+# repo and cluster stay denied, being the credentialed families the partner-phone
+# guest must not hold (goosecracker.tiers).
 HOUSEHOLD_TIER = "household"
 AGENT_RECIPE = "agent"
 

--- a/projects/monolith/chat/whatsapp_session_test.py
+++ b/projects/monolith/chat/whatsapp_session_test.py
@@ -81,15 +81,18 @@ class TestSessionKey:
 
 
 class TestHouseholdAcl:
-    def test_repo_cluster_artifact_denied(self):
+    def test_repo_cluster_denied(self):
+        # Only the credentialed families stay denied (ADR 039, amended): a
+        # GitHub token / kubeconfig must not reach the partner-phone guest.
         assert whatsapp_session.household_allows("repo") is False
         assert whatsapp_session.household_allows("cluster") is False
-        assert whatsapp_session.household_allows("artifact") is False
 
-    def test_knowledge_calendar_reminders_allowed(self):
+    def test_local_capabilities_allowed(self):
+        # Household gets every LOCAL capability, including artifact/chart builds.
         assert whatsapp_session.household_allows("knowledge") is True
         assert whatsapp_session.household_allows("calendar") is True
         assert whatsapp_session.household_allows("reminders") is True
+        assert whatsapp_session.household_allows("artifact") is True
 
 
 # --- Dispatch ---------------------------------------------------------------

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.65
+      targetRevision: 0.285.66
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -255,11 +255,20 @@ goosecracker:
     # per-principal capability ACL (goosecracker.tiers.tier_allows), NOT here in
     # the guest env; the env only carries the model endpoint and generation caps.
     household:
-      OPENAI_HOST: http://inference.inference.svc.cluster.local:8080
-      OPENAI_API_KEY: sk-noauth
+      # ADR 039 (amended): the household goose guest runs on DeepSeek V4 Flash via
+      # OpenRouter (strong but cheap), not in-cluster Qwen. The guest holds ONLY the
+      # kloak:or: placeholder; the fc-invoke egress sidecar swaps it for the real
+      # OPENROUTER_API_KEY on openrouter.ai (substrate egress.secrets catalog). The
+      # placeholder string MUST match that catalog entry -- kloak_placeholder_drift_
+      # test.py fails CI on drift. repo and cluster tools stay denied at dispatch
+      # (goosecracker.tiers.household), so no GitHub token or kubeconfig is here.
+      OPENAI_HOST: https://openrouter.ai/api/v1
+      OPENAI_API_KEY: "kloak:or:B5BKP27T2KSDN6QW70N34H8DP6"
       GOOSE_PROVIDER: openai
-      GOOSE_MODEL: qwen3.6-27b
-      GOOSE_CONTEXT_LIMIT: "32768"
+      GOOSE_MODEL: deepseek/deepseek-v4-flash
+      # DeepSeek V4 Flash serves a large window; tell goose the real size so it
+      # compacts proactively at ~80% rather than assuming 128k and overrunning.
+      GOOSE_CONTEXT_LIMIT: "131072"
       GOOSE_MAX_TOOL_RESPONSE_SIZE: "10000"
       GOOSE_MAX_TOKENS: "8000"
       GOOSE_TOOL_CALL_CUTOFF: "5"
@@ -337,6 +346,10 @@ orchestrator:
 # `whatsapp` schema.
 whatsapp:
   enabled: false
+  # Household content model (in-monolith concierge reply + WhatsApp chat agent).
+  # DeepSeek V4 Flash on OpenRouter; the goose guest model is in
+  # goosecracker.tiers.household.
+  model: "deepseek/deepseek-v4-flash"
   onepassword:
     itemPath: "vaults/k8s-homelab/items/whatsapp"
   botNumber: ""

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -454,13 +454,18 @@ def _agent_narrative(result: str) -> str:
     return body or "(no output)"
 
 
-async def _agent_reply_message(session: str, summary: str, details: str) -> str:
+async def _agent_reply_message(
+    session: str, summary: str, details: str, provider: str = "discord"
+) -> str:
     """Compose the conversational reply for a coding-agent run.
 
     Rephrases goose's typed ``summary`` (+ optional ``details``) in the bot's own
     voice, grounded in the parent channel's context (recent messages + rolling
     summaries), so the reply reads like the bot talking to the channel rather than
     a raw tool dump. The result URL is appended by the caller, never by the model.
+
+    ``provider`` selects the authoring model: WhatsApp (household) rephrases on
+    DeepSeek V4 Flash, Discord stays on in-cluster Qwen (ADR 039, amended).
 
     Fail-open: the reply must always go out, so any missing channel id, model
     outage, or error yields the deterministic ``summary``/``details`` composition
@@ -469,13 +474,25 @@ async def _agent_reply_message(session: str, summary: str, details: str) -> str:
     """
     deterministic = summary + (f"\n\n{details}" if details else "")
     try:
-        from chat.api import conversational_agent_reply, parent_channel_for_thread
+        from chat.api import (
+            build_openrouter_caller,
+            conversational_agent_reply,
+            parent_channel_for_thread,
+        )
 
         # nosemgrep: no-session-in-to-thread  # `session` is the fc-invoke session-id string, not a SQLAlchemy Session
         parent = await asyncio.to_thread(parent_channel_for_thread, session)
         if not parent:
             return deterministic
-        reply = (await conversational_agent_reply(parent, summary, details)).strip()
+        # Household content is authored by DeepSeek; other tiers keep the default
+        # in-cluster Qwen caller (llm_call=None leaves conversational_agent_reply
+        # byte-identical to the Discord path).
+        llm_call = build_openrouter_caller() if provider == "whatsapp" else None
+        reply = (
+            await conversational_agent_reply(
+                parent, summary, details, llm_call=llm_call
+            )
+        ).strip()
         return reply or deterministic
     except Exception:
         logger.exception(
@@ -485,8 +502,8 @@ async def _agent_reply_message(session: str, summary: str, details: str) -> str:
         return deterministic
 
 
-async def _delivery_message(session: str, data: dict) -> str:
-    """Build the Discord message for a successful run.
+async def _delivery_message(session: str, data: dict, provider: str = "discord") -> str:
+    """Build the channel message for a successful run.
 
     A run that produced artifact HTML (an agent run the router took down the
     artifact-build path) publishes it and posts a clean ``Artifact ready: <url>``
@@ -526,7 +543,7 @@ async def _delivery_message(session: str, data: dict) -> str:
             details = str(structured.get("details", "") or "").strip()
             # Rephrase the typed summary conversationally (channel-scoped context),
             # then append the URL deterministically so it can never be mangled.
-            msg = await _agent_reply_message(session, summary, details)
+            msg = await _agent_reply_message(session, summary, details, provider)
             url = str(structured.get("url", "") or "").strip()
             if url.startswith("http"):
                 msg += f"\n{url}"
@@ -865,7 +882,7 @@ async def _deliver_result(
         # nosemgrep: no-session-in-to-thread  # `session` is the fc-invoke session-id string, not a SQLAlchemy Session
         await asyncio.to_thread(threads.mark_completed, session, result)
         await _settle_result(
-            discord_thread, await _delivery_message(session, data), provider
+            discord_thread, await _delivery_message(session, data, provider), provider
         )
         return True
     err = data.get("error", "") or "goose run failed with no detail"

--- a/projects/monolith/goosecracker/tests/tiers_test.py
+++ b/projects/monolith/goosecracker/tests/tiers_test.py
@@ -63,18 +63,20 @@ def test_explicit_tier_ca_wins_over_process_env(monkeypatch):
 # --- Per-tier capability (tool) subset (ADR 034, ADR 039 household) ---------
 
 
-def test_household_tier_grants_only_household_features():
+def test_household_tier_grants_all_local_features():
+    # ADR 039 (amended): household gets every LOCAL capability; only the
+    # credentialed families (repo, cluster) are withheld.
     granted = tiers.features_for_tier("household")
-    assert granted == {"knowledge", "calendar", "reminders"}
+    assert granted == {"knowledge", "calendar", "reminders", "artifact"}
 
 
-def test_household_tier_allows_its_three_families():
-    for feature in ("knowledge", "calendar", "reminders"):
+def test_household_tier_allows_its_local_families():
+    for feature in ("knowledge", "calendar", "reminders", "artifact"):
         assert tiers.tier_allows("household", feature) is True
 
 
-def test_household_tier_denies_repo_cluster_artifact():
-    for feature in ("repo", "cluster", "artifact"):
+def test_household_tier_denies_repo_and_cluster():
+    for feature in ("repo", "cluster"):
         assert tiers.tier_allows("household", feature) is False
 
 

--- a/projects/monolith/goosecracker/tiers.py
+++ b/projects/monolith/goosecracker/tiers.py
@@ -38,10 +38,14 @@ _DEFAULT_TIER = "default"
 # tier -> allowed-feature mapping the dispatch-time check consults. ADR 034's
 # enforced guest-facing MCP endpoint (bearer -> toolset) is not built yet, so
 # nothing calls this at guest-MCP dispatch time today: Phase 4 wires the
-# session-dispatch check to it. The household tier (ADR 039) is deliberately
-# restricted to knowledge, calendar, and reminders and is denied repo, cluster,
-# and artifact tools.
-_HOUSEHOLD_FEATURES = frozenset({"knowledge", "calendar", "reminders"})
+# session-dispatch check to it. The household tier (ADR 039, amended) gets every
+# LOCAL capability (knowledge, calendar, reminders, and artifact/chart builds);
+# only repo and cluster stay denied, because those are the two families that
+# would need external credentials (a GitHub token, a kubeconfig) in the guest,
+# and the household channel deliberately carries none. The boundary is the
+# channel, not the toolset: household does everything the trusted tiers do that
+# does not require a credential the partner-phone guest must not hold.
+_HOUSEHOLD_FEATURES = frozenset({"knowledge", "calendar", "reminders", "artifact"})
 
 # The full capability set. Any tier not named in _TIER_FEATURES (default,
 # artifact) is unrestricted: it gets everything. Named here so a household-tier


### PR DESCRIPTION
Amends ADR 039: the household (WhatsApp) tier's boundary is the **channel, not the toolset**. Ships gated the same as the rest of the gateway (`whatsapp.enabled: false`), so it is inert until the gateway is turned on.

## What changes

**Tools — household gets every local capability.** `goosecracker.tiers` household features go from `{knowledge, calendar, reminders}` to `{knowledge, calendar, reminders, artifact}`. Only `repo` and `cluster` stay denied, being the two families that would require an external credential (a GitHub token, a kubeconfig) in the partner-phone guest.

**Model — DeepSeek V4 Flash for all household content, Qwen only for activation.** Three sites move to `deepseek/deepseek-v4-flash` on OpenRouter (strong but cheap); the in-cluster Qwen classifier that decides *whether* to engage is untouched:

| Site | Wiring |
|------|--------|
| WhatsApp chat agent (triggered reply) | `create_household_agent()` — DeepSeek-backed pydantic-ai agent, same tools/prompts |
| Concierge agent-result reply | `build_openrouter_caller()` injected in the runner when `provider == whatsapp` |
| Goose guest | `goosecracker.tiers.household` env → OpenRouter + `GOOSE_MODEL: deepseek/deepseek-v4-flash` |

The two in-monolith sites reach `openrouter.ai` directly (`OPENROUTER_API_KEY` is already in the pod env for the orchestrator). The sandboxed guest holds only the `kloak:or:` placeholder; the substrate egress sidecar swaps it for the real key on `openrouter.ai` (catalog entry restored in `substrate/deploy/values.yaml`; `kloak_placeholder_drift_test` enforces the placeholder matches the tier env). Discord stays byte-identical on Qwen.

## Trust boundary

Re-adds a guest→`openrouter.ai` egress path, but the guest never holds the real key — the sidecar swaps the placeholder only on that one host, so a prompt-injected guest can neither exfiltrate the key nor reach elsewhere (same mechanism as the GitHub token). Household still cannot touch repo or cluster.

## Notes
- Model id pinned in values (`whatsapp.model`, `GOOSE_MODEL`), never `:auto`. The orchestrator's existing fallback chain already uses this exact slug via OpenRouter.
- Two apps changed; only the monolith chart is bumped (0.285.66). The substrate change is `deploy/values.yaml` only, synced via the `\$values` git ref, so it rolls the egress proxy on merge with no chart bump.
- Follow-up (separate PR): WhatsApp media transport (so charts/artifacts actually reach the group) + the `ChatContext` refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)