### PR TITLE
feat(whatsapp): enable household full tasks + fix lock-sweep crash

### DIFF
--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -152,6 +152,16 @@ async def _start_singletons(app: FastAPI) -> None:
                         store = MessageStore(session=session, embed_client=embed_client)
                         expired = store.reclaim_expired(ttl_seconds=30, limit=5)
                         for lock in expired:
+                            # Reclaim-and-reprocess is Discord-specific:
+                            # reprocess_message re-fetches the message by int()
+                            # channel/message snowflake. A WhatsApp lock carries a
+                            # string group JID (e.g. "...@g.us"), processed inline
+                            # by the inbound handler (not re-fetchable via the
+                            # Discord bot), so skip it -- otherwise a single
+                            # non-numeric lock raises ValueError and poisons the
+                            # whole sweep, blocking Discord reclaim + cleanup too.
+                            if not str(lock.channel_id).isdigit():
+                                continue
                             logger.info(
                                 "Reclaiming expired lock for message %s",
                                 lock.discord_message_id,

--- a/projects/monolith/app/main_lock_sweep_test.py
+++ b/projects/monolith/app/main_lock_sweep_test.py
@@ -520,6 +520,71 @@ class TestLockSweepLoopWithExpiredLocks:
         mock_bot.reprocess_message.assert_any_await(222, 888)
 
     @pytest.mark.asyncio
+    async def test_sweep_loop_skips_non_discord_locks(self):
+        """A lock whose channel_id is not a numeric snowflake (a WhatsApp group
+        JID) is skipped, never reprocessed via the Discord bot -- and it does not
+        poison the sweep, so a Discord lock in the same batch still reprocesses."""
+        coros, capture_fn, mock_bot = _capture_sweep_coro()
+        mock_bot.reprocess_message = AsyncMock()
+
+        wa_lock = _make_lock(
+            discord_message_id="3B331C180B2C166EE82A",
+            channel_id="120363412404798712@g.us",
+        )
+        discord_lock = _make_lock(discord_message_id=222, channel_id=888)
+
+        mock_store = MagicMock()
+        mock_store.reclaim_expired.return_value = [wa_lock, discord_lock]
+        mock_store.cleanup_completed.return_value = 0
+
+        mock_session_obj = MagicMock()
+        mock_session_obj.__enter__ = MagicMock(return_value=mock_session_obj)
+        mock_session_obj.__exit__ = MagicMock(return_value=False)
+
+        patches = _lifespan_patches_with_discord(mock_bot)
+        with (
+            patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "fake-token"}),
+            patch("asyncio.create_task", side_effect=capture_fn),
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+        ):
+            await _start_singletons(app)
+
+        assert len(coros) == 1
+
+        sleep_count = [0]
+
+        async def controlled_sleep(_secs):
+            sleep_count[0] += 1
+            if sleep_count[0] >= 2:
+                raise asyncio.CancelledError()
+
+        with (
+            patch("asyncio.sleep", side_effect=controlled_sleep),
+            patch("app.db.get_engine", return_value=MagicMock()),
+            patch("sqlmodel.Session", return_value=mock_session_obj),
+            patch("chat.store.MessageStore", return_value=mock_store),
+            patch("shared.embedding.EmbeddingClient", return_value=MagicMock()),
+            patch("app.main.logger"),
+        ):
+            try:
+                await coros[0]
+            except asyncio.CancelledError:
+                pass
+
+        # Only the Discord lock is reprocessed; the WhatsApp JID lock is skipped.
+        assert mock_bot.reprocess_message.await_count == 1
+        mock_bot.reprocess_message.assert_awaited_once_with(222, 888)
+        # cleanup still ran (the sweep was not poisoned by the WhatsApp lock).
+        mock_store.cleanup_completed.assert_called_once_with(max_age_seconds=3600)
+
+    @pytest.mark.asyncio
     async def test_sweep_loop_logs_info_for_each_reclaimed_lock(self):
         """_lock_sweep_loop calls logger.info with the lock's discord_message_id for each reclaimed lock."""
         coros, capture_fn, mock_bot = _capture_sweep_coro()

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.67
+version: 0.285.68
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -135,6 +135,11 @@ spec:
             # the goose guest model is carried in the GOOSECRACKER_TIERS env instead.
             - name: HOUSEHOLD_LLM_MODEL
               value: {{ .Values.whatsapp.model | quote }}
+            # Gate the WhatsApp heavy-agent path (goose household dispatch for
+            # charts/artifacts/full tasks). Off -> a heavy request gets the "not
+            # wired up yet" reply; on -> it dispatches the household goose agent.
+            - name: WHATSAPP_AGENT_ENABLED
+              value: {{ .Values.whatsapp.agentEnabled | quote }}
             - name: EMBEDDING_URL
               value: {{ .Values.chat.embeddingUrl | quote }}
             - name: SEARXNG_URL

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -834,6 +834,10 @@ orchestrator:
 # chart BUILD images map); never hand-set a digest here.
 whatsapp:
   enabled: false
+  # Heavy-agent path (goose household dispatch for charts/artifacts/full tasks).
+  # Off by default: a heavy request replies "not wired up yet" instead of
+  # dispatching. Set true in deploy values to wire it on.
+  agentEnabled: false
   # Pinned OpenRouter model for household CONTENT generation in the monolith: the
   # concierge agent-result reply and the WhatsApp chat agent both author on this
   # (strong but cheap). The goose GUEST model is set separately in

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.67
+      targetRevision: 0.285.68
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -266,6 +266,11 @@ goosecracker:
       OPENAI_API_KEY: "kloak:or:B5BKP27T2KSDN6QW70N34H8DP6"
       GOOSE_PROVIDER: openai
       GOOSE_MODEL: deepseek/deepseek-v4-flash
+      # Artifact/chart builds publish the HTML here and get a capability URL back
+      # (delivered to WhatsApp as text, sidestepping the text-only outbox). Same
+      # in-cluster monolith sinks the artifact tier uses, reached via the funnel.
+      ARTIFACT_PUBLISH_URL: http://monolith.monolith.svc.cluster.local:8000/internal/artifact
+      PROGRESS_PUBLISH_URL: http://monolith.monolith.svc.cluster.local:8000/internal/goosecracker/progress
       # DeepSeek V4 Flash serves a large window; tell goose the real size so it
       # compacts proactively at ~80% rather than assuming 128k and overrunning.
       GOOSE_CONTEXT_LIMIT: "131072"
@@ -346,6 +351,10 @@ orchestrator:
 # `whatsapp` schema.
 whatsapp:
   enabled: true
+  # Heavy-agent path ON: charts/artifacts/full tasks dispatch the household goose
+  # agent (recipe=agent, tier=household, DeepSeek). Charts come back as an artifact
+  # URL (deliverable as text), sidestepping the text-only outbox media limit.
+  agentEnabled: true
   # Household content model (in-monolith concierge reply + WhatsApp chat agent).
   # DeepSeek V4 Flash on OpenRouter; the goose guest model is in
   # goosecracker.tiers.household.


### PR DESCRIPTION
Wires up full tasks (charts/artifacts) in the WhatsApp household group, and fixes a real crash the first heavy request surfaced.

## Changes
- **`WHATSAPP_AGENT_ENABLED`** — the heavy-agent dispatch was shipped behind this flag but never wired to a value, so every chart/artifact request returned *"running full tasks here is not wired up yet."* Now gated on `whatsapp.agentEnabled` (chart default `false`, deploy `true`). On → dispatches the household goose agent (recipe=`agent`, tier=`household`, DeepSeek V4 Flash).
- **Household artifact sinks** — the tier gains `ARTIFACT_PUBLISH_URL` + `PROGRESS_PUBLISH_URL` so an artifact/chart build publishes and returns a capability URL. The URL is *text*, so it delivers over the text-only outbox — **charts arrive as a link**, sidestepping the deferred media transport.
- **Lock-sweep crash fix** — `_lock_sweep_loop` reprocessed every expired lock through the Discord bot (`reprocess_message` → `int(channel_id)`). A WhatsApp lock carries a string group JID (`…@g.us`), so one raised `ValueError` and **poisoned the whole sweep**, blocking Discord reclaim + cleanup too. Now skips non-numeric-channel locks (WhatsApp messages are processed inline by the inbound handler, not re-fetchable via the bot). `str()` coercion keeps the existing int-channel tests green; added a test that a WhatsApp-JID lock is skipped while a Discord lock in the same batch still reprocesses.

## Caveat
Goose-on-WhatsApp is now exercised end-to-end for the first time; may need a round of iteration on the guest run (egress swap for DeepSeek, delivery). Inline chart *images* still won't deliver (media transport is a separate follow-up) — charts come back as artifact URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)