### PR TITLE
feat(whatsapp): deliver run_python images inline (media outbox)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.68
+version: 0.285.69
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260708090000_whatsapp_outbox_media.sql
+++ b/projects/monolith/chart/migrations/20260708090000_whatsapp_outbox_media.sql
@@ -1,0 +1,25 @@
+-- WhatsApp media sends (ADR 039, amended): a `media` outbox kind so an image
+-- (a chart PNG, an artifact preview) reaches the group inline instead of only as
+-- text. The gateway uploads media_bytes to WhatsApp and sends an ImageMessage
+-- with content as the optional caption. Bytes live in the row (chart PNGs are
+-- small); no blob store round-trip in the gateway.
+
+ALTER TABLE chat.whatsapp_outbox ADD COLUMN media_bytes bytea;
+ALTER TABLE chat.whatsapp_outbox ADD COLUMN media_mime text;
+
+-- Allow the new kind.
+ALTER TABLE chat.whatsapp_outbox DROP CONSTRAINT whatsapp_outbox_kind_check;
+ALTER TABLE chat.whatsapp_outbox ADD CONSTRAINT whatsapp_outbox_kind_check
+    CHECK (kind = ANY (ARRAY['message'::text, 'edit'::text, 'reaction'::text, 'media'::text]));
+
+-- Extend the per-kind shape guard: a media row needs the bytes and the mime;
+-- content (the caption) stays optional.
+ALTER TABLE chat.whatsapp_outbox DROP CONSTRAINT whatsapp_outbox_kind_valid;
+ALTER TABLE chat.whatsapp_outbox ADD CONSTRAINT whatsapp_outbox_kind_valid
+    CHECK (
+        (kind = 'message' AND content IS NOT NULL)
+        OR (kind = 'edit' AND content IS NOT NULL AND edit_of IS NOT NULL)
+        OR (kind = 'reaction' AND target_message_id IS NOT NULL
+            AND target_sender_jid IS NOT NULL AND reaction IS NOT NULL)
+        OR (kind = 'media' AND media_bytes IS NOT NULL AND media_mime IS NOT NULL)
+    );

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Hv2MCy3MNOq7ABCYov/4eiwEbPRp/5nWD5nLrzLTOqM=
+h1:m2GVEyR1hIRZVRuISJXxFmb5MDqp96nBItJqt7q88HY=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -119,3 +119,4 @@ h1:Hv2MCy3MNOq7ABCYov/4eiwEbPRp/5nWD5nLrzLTOqM=
 20260708060000_chat_whatsapp_calendar_draft.sql h1:H1GaNtiU4ULrR2Hgy/OonNmtMZNWuFIZnSqDb5GuqSA=
 20260708070000_whatsapp_group_last_digest.sql h1:75c0fl9OX8mPKcQ5XYMruM8uACd4sDbwiEQv3EVCyy0=
 20260708080000_whatsapp_outbox_sent_idx.sql h1:rjLtavPiIJg73SeUGkfq2COZz0YISX+5Zni73AV1tpo=
+20260708090000_whatsapp_outbox_media.sql h1:N1dQ0mGx2Uk23QMNsbXLq0YqVwy/JuY5VLq5LNNDHGk=

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -163,7 +163,10 @@ class WhatsappOutbox(SQLModel, table=True):
     (edit_of -> the original send's sent_message_id, with new content), reaction
     (on target_message_id; whatsmeow's reaction build needs target_sender_jid, the
     JID of that message's sender, which the row must carry). reaction_remove sends
-    an empty reaction to clear it.
+    an empty reaction to clear it. media (an image: media_bytes + media_mime, with
+    content as the optional caption) -- the gateway uploads the bytes to WhatsApp
+    and sends an ImageMessage, so a chart/image reaches the group inline (ADR 039,
+    amended).
 
     The combined CHECK mirrors the DB constraint so the SQLite test fixtures
     enforce the per-kind shape too (create_all does not see migration-only
@@ -177,7 +180,9 @@ class WhatsappOutbox(SQLModel, table=True):
             "(kind = 'message' AND content IS NOT NULL)"
             " OR (kind = 'edit' AND content IS NOT NULL AND edit_of IS NOT NULL)"
             " OR (kind = 'reaction' AND target_message_id IS NOT NULL"
-            " AND target_sender_jid IS NOT NULL AND reaction IS NOT NULL)",
+            " AND target_sender_jid IS NOT NULL AND reaction IS NOT NULL)"
+            " OR (kind = 'media' AND media_bytes IS NOT NULL"
+            " AND media_mime IS NOT NULL)",
             name="whatsapp_outbox_kind_valid",
         ),
         {"schema": "chat", "extend_existing": True},
@@ -193,6 +198,10 @@ class WhatsappOutbox(SQLModel, table=True):
     target_sender_jid: str | None = Field(default=None)
     reaction: str | None = Field(default=None)
     reaction_remove: bool = Field(default=False)
+    # media kind: the raw image bytes + its mime type (content is the caption).
+    # bytes -> LargeBinary (BYTEA on Postgres, BLOB on the SQLite test fixtures).
+    media_bytes: bytes | None = Field(default=None)
+    media_mime: str | None = Field(default=None)
     sent_message_id: str | None = Field(default=None)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     posted_at: datetime | None = Field(default=None)

--- a/projects/monolith/chat/whatsapp_inbound.py
+++ b/projects/monolith/chat/whatsapp_inbound.py
@@ -45,9 +45,24 @@ from sqlmodel import Session, select
 from app.db import get_engine
 from chat import attention, attention_log, whatsapp_capabilities, whatsapp_session
 from chat.models import Message, WhatsappGroup, WhatsappOutbox
-from chat.whatsapp_outbox import enqueue_message
+from chat.whatsapp_outbox import enqueue_media, enqueue_message
 
 logger = logging.getLogger(__name__)
+
+# Cap how many run_python-generated images ride one reply, and the per-image byte
+# size (chart PNGs are tens of KB; this guards a runaway sandbox output from
+# bloating an outbox row). WhatsApp itself accepts far larger, but the household
+# reply never needs it.
+_MEDIA_MAX_FILES = 4
+_MEDIA_MAX_BYTES = 8 * 1024 * 1024
+# Filename-extension -> mime for the image types run_python emits.
+_MEDIA_MIME_BY_EXT = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+}
 
 # /internal so it stays off the public HTTPRoute (in-cluster only, reached by the
 # gateway across the cluster network), like the goosecracker progress sink.
@@ -182,8 +197,49 @@ async def _generate_reply(
     # in-cluster Qwen the Discord concierge uses (ADR 039, amended).
     agent = create_household_agent()
     result = await agent.run(prompt, deps=deps)
+    # Deliver any images run_python generated (charts, etc.) as inline media, the
+    # same files the Discord path attaches. Best-effort: a media failure must not
+    # drop the text reply.
+    await _enqueue_generated_media(group_jid, getattr(deps, "generated_files", []))
     output = result.output
     return output if isinstance(output, str) and output else ""
+
+
+def _enqueue_media_sync(group_jid: str, files: list) -> int:
+    """Enqueue up to _MEDIA_MAX_FILES run_python images as media outbox rows.
+
+    ``files`` are (filename, bytes) tuples (chat.agent.ChatDeps.generated_files).
+    Returns the count enqueued. Sync (opens its own Session); call via to_thread.
+    """
+    sent = 0
+    with Session(get_engine()) as session:
+        for filename, data in files[:_MEDIA_MAX_FILES]:
+            if not data or len(data) > _MEDIA_MAX_BYTES:
+                continue
+            ext = str(filename).rsplit(".", 1)[-1].lower() if filename else ""
+            mime = _MEDIA_MIME_BY_EXT.get(ext)
+            if mime is None:
+                # Not an image type we know how to send; skip (never guess a mime).
+                continue
+            enqueue_media(session, group_jid, data=data, mime=mime)
+            sent += 1
+        if sent:
+            session.commit()
+    return sent
+
+
+async def _enqueue_generated_media(group_jid: str, files: list) -> None:
+    """Enqueue run_python-generated images to the group. Best-effort."""
+    if not files:
+        return
+    try:
+        n = await asyncio.to_thread(_enqueue_media_sync, group_jid, list(files))
+        if n:
+            logger.info("whatsapp: enqueued %d media file(s) for %s", n, group_jid)
+    except Exception:
+        logger.exception(
+            "whatsapp: failed to enqueue generated media for %s", group_jid
+        )
 
 
 def _compute_directed(

--- a/projects/monolith/chat/whatsapp_outbox.py
+++ b/projects/monolith/chat/whatsapp_outbox.py
@@ -15,6 +15,36 @@ from sqlmodel import Session
 from chat.models import WhatsappOutbox
 
 
+def enqueue_media(
+    session: Session,
+    group_jid: str,
+    *,
+    data: bytes,
+    mime: str,
+    caption: str | None = None,
+) -> None:
+    """Enqueue an image to ``group_jid`` (ADR 039, amended).
+
+    The gateway uploads ``data`` to WhatsApp and sends an ImageMessage with
+    ``caption`` as the optional text, so a chart/image reaches the group inline.
+    Raises ValueError on empty bytes or mime (the DB CHECK also rejects it, but
+    failing here gives the caller a clear error instead of an IntegrityError).
+    """
+    if not data:
+        raise ValueError("enqueue_media requires non-empty data")
+    if not mime:
+        raise ValueError("enqueue_media requires a mime type")
+    session.add(
+        WhatsappOutbox(
+            group_jid=group_jid,
+            kind="media",
+            media_bytes=data,
+            media_mime=mime,
+            content=caption,
+        )
+    )
+
+
 def enqueue_message(
     session: Session,
     group_jid: str,

--- a/projects/monolith/chat/whatsapp_outbox_test.py
+++ b/projects/monolith/chat/whatsapp_outbox_test.py
@@ -15,7 +15,12 @@ from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
 from chat.models import WhatsappOutbox
-from chat.whatsapp_outbox import enqueue_edit, enqueue_message, enqueue_reaction
+from chat.whatsapp_outbox import (
+    enqueue_edit,
+    enqueue_media,
+    enqueue_message,
+    enqueue_reaction,
+)
 
 
 @pytest.fixture(name="engine")
@@ -50,6 +55,44 @@ def test_enqueue_message_adds_row():
     assert row.kind == "message"
     assert row.content == "hello"
     assert row.quoted_message_id is None
+
+
+def test_enqueue_media_adds_row():
+    session = MagicMock()
+    enqueue_media(session, "g@wa", data=b"\x89PNG...", mime="image/png", caption="hi")
+    row = session.add.call_args.args[0]
+    assert row.group_jid == "g@wa"
+    assert row.kind == "media"
+    assert row.media_bytes == b"\x89PNG..."
+    assert row.media_mime == "image/png"
+    assert row.content == "hi"
+
+
+def test_enqueue_media_rejects_empty_data():
+    with pytest.raises(ValueError):
+        enqueue_media(MagicMock(), "g@wa", data=b"", mime="image/png")
+
+
+def test_enqueue_media_rejects_empty_mime():
+    with pytest.raises(ValueError):
+        enqueue_media(MagicMock(), "g@wa", data=b"x", mime="")
+
+
+def test_media_check_accepts_valid_row(engine):
+    with Session(engine) as session:
+        enqueue_media(session, "g@wa", data=b"x", mime="image/png")
+        session.commit()
+        assert session.query(WhatsappOutbox).count() == 1
+
+
+def test_media_check_rejects_missing_bytes(engine):
+    # The mirrored CHECK must reject a media row with no bytes (SQLite fixture).
+    with Session(engine) as session:
+        session.add(
+            WhatsappOutbox(group_jid="g@wa", kind="media", media_mime="image/png")
+        )
+        with pytest.raises(IntegrityError):
+            session.commit()
 
 
 def test_enqueue_message_with_quote():

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.68
+      targetRevision: 0.285.69
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/whatsapp/outbox.go
+++ b/projects/monolith/whatsapp/outbox.go
@@ -47,6 +47,9 @@ type sender interface {
 	SendText(ctx context.Context, groupJID, content, quotedMessageID string) (string, error)
 	// SendEdit edits targetMessageID in groupJID to newContent.
 	SendEdit(ctx context.Context, groupJID, targetMessageID, newContent string) error
+	// SendImage uploads data (an image of the given mime) to groupJID and sends
+	// it as an ImageMessage with an optional caption, returning the sent id.
+	SendImage(ctx context.Context, groupJID string, data []byte, mime, caption string) (string, error)
 	// SendReaction reacts to targetMessageID (whose sender is targetSenderJID)
 	// with reaction; an empty reaction clears a previous one.
 	SendReaction(ctx context.Context, groupJID, targetMessageID, targetSenderJID, reaction string) error
@@ -65,6 +68,8 @@ type outboxRow struct {
 	targetSenderJID sql.NullString
 	reaction        sql.NullString
 	reactionRemove  bool
+	mediaBytes      []byte // NULL -> nil; the image for a kind='media' row
+	mediaMime       sql.NullString
 }
 
 // store is the drain's persistence seam. Production is pgStore over a *sql.DB;
@@ -254,6 +259,27 @@ func (d *OutboxDrain) processRow(ctx context.Context, row outboxRow) bool {
 		d.post(ctx, row.id, "")
 		return false
 
+	case "media":
+		if len(row.mediaBytes) == 0 || !row.mediaMime.Valid {
+			// Malformed (the CHECK should prevent this); park rather than loop.
+			d.fail(ctx, row.id, fmt.Errorf("media row missing bytes or mime"))
+			return true
+		}
+		id, err := d.sender.SendImage(ctx, row.groupJID, row.mediaBytes, row.mediaMime.String, row.content.String)
+		if err != nil {
+			if transient(err) {
+				// Socket down: leave pending, block the group, retry in order.
+				d.log.Warn("whatsapp image deferred; socket not ready", "id", row.id, "err", err)
+				return true
+			}
+			d.fail(ctx, row.id, err)
+			return true
+		}
+		if d.post(ctx, row.id, id) {
+			return true
+		}
+		return false
+
 	default:
 		// Unknown kind (the CHECK should prevent this); park it.
 		d.fail(ctx, row.id, fmt.Errorf("unknown kind %q", row.kind))
@@ -303,7 +329,8 @@ type pgStore struct {
 func (s *pgStore) claimPending(ctx context.Context) ([]outboxRow, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, group_jid, kind, content, quoted_message_id, edit_of,
-		       target_message_id, target_sender_jid, reaction, reaction_remove
+		       target_message_id, target_sender_jid, reaction, reaction_remove,
+		       media_bytes, media_mime
 		FROM chat.whatsapp_outbox
 		WHERE posted_at IS NULL AND attempts < $1
 		ORDER BY group_jid, created_at, id
@@ -316,7 +343,8 @@ func (s *pgStore) claimPending(ctx context.Context) ([]outboxRow, error) {
 	for rows.Next() {
 		var r outboxRow
 		if err := rows.Scan(&r.id, &r.groupJID, &r.kind, &r.content, &r.quotedMessageID,
-			&r.editOf, &r.targetMessageID, &r.targetSenderJID, &r.reaction, &r.reactionRemove); err != nil {
+			&r.editOf, &r.targetMessageID, &r.targetSenderJID, &r.reaction, &r.reactionRemove,
+			&r.mediaBytes, &r.mediaMime); err != nil {
 			return nil, fmt.Errorf("scan pending: %w", err)
 		}
 		out = append(out, r)
@@ -407,6 +435,36 @@ func (w *whatsmeowSender) SendText(ctx context.Context, groupJID, content, quote
 		msg = &waE2E.Message{Conversation: strptr(content)}
 	}
 	resp, err := w.client.SendMessage(ctx, chat, msg)
+	if err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
+func (w *whatsmeowSender) SendImage(ctx context.Context, groupJID string, data []byte, mime, caption string) (string, error) {
+	chat, err := types.ParseJID(groupJID)
+	if err != nil {
+		return "", fmt.Errorf("parse group jid: %w", err)
+	}
+	// Encrypt-and-upload to WhatsApp's media servers; the returned handles go into
+	// the ImageMessage so recipients can fetch and decrypt it.
+	up, err := w.client.Upload(ctx, data, whatsmeow.MediaImage)
+	if err != nil {
+		return "", fmt.Errorf("upload image: %w", err)
+	}
+	img := &waE2E.ImageMessage{
+		Mimetype:      strptr(mime),
+		URL:           strptr(up.URL),
+		DirectPath:    strptr(up.DirectPath),
+		MediaKey:      up.MediaKey,
+		FileEncSHA256: up.FileEncSHA256,
+		FileSHA256:    up.FileSHA256,
+		FileLength:    &up.FileLength,
+	}
+	if caption != "" {
+		img.Caption = strptr(caption)
+	}
+	resp, err := w.client.SendMessage(ctx, chat, &waE2E.Message{ImageMessage: img})
 	if err != nil {
 		return "", err
 	}

--- a/projects/monolith/whatsapp/outbox_test.go
+++ b/projects/monolith/whatsapp/outbox_test.go
@@ -47,6 +47,18 @@ func (f *fakeSender) SendText(_ context.Context, groupJID, content, quotedMessag
 	return id, nil
 }
 
+func (f *fakeSender) SendImage(_ context.Context, groupJID string, data []byte, mime, caption string) (string, error) {
+	f.calls = append(f.calls, sendCall{"image", groupJID, mime, caption, ""})
+	if f.textErr != nil && (f.failGroup == "" || f.failGroup == groupJID) {
+		return "", f.textErr
+	}
+	id := f.sentID
+	if id == "" {
+		id = "wamid.SENT"
+	}
+	return id, nil
+}
+
 func (f *fakeSender) SendEdit(_ context.Context, groupJID, targetMessageID, newContent string) error {
 	f.calls = append(f.calls, sendCall{"edit", groupJID, targetMessageID, newContent, ""})
 	return f.editErr


### PR DESCRIPTION
Charts/images the light-path chat agent generates now reach the WhatsApp group as real image bubbles, instead of being described in text and dropped. This is the deferred media-transport piece.

## How
- **`chat.whatsapp_outbox` gains a `media` kind** carrying `media_bytes` (BYTEA) + `media_mime`, with `content` as the optional caption. The migration extends both the kind CHECK and the per-kind shape CHECK; the model mirrors it for the SQLite fixtures. Image bytes live in the row (chart PNGs are small — capped 8 MiB), so the gateway needs no blob-store round-trip.
- **`enqueue_media()` writer**; `_generate_reply` now enqueues the `run_python`-generated files (`chat.agent.ChatDeps.generated_files` — the exact tuples the Discord path attaches) as media rows. Best-effort (a media failure never drops the text reply), capped at 4 files, image mimes only.
- **Go gateway**: `SendImage` encrypts-and-uploads via whatsmeow `client.Upload(MediaImage)` and sends an `ImageMessage` with the caption; `processRow` handles `kind='media'` with the same transient/park/post semantics as the other kinds.

## Effect
A "chart X" request on the light path already generated the PNG (and threw it away). Now that PNG arrives inline in the group. The heavy artifact-URL path (from #3306) still exists for genuine "build me a page" asks — this covers the "I want to *see* the chart in the chat" case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)