### PR TITLE
fix(whatsapp): drop /v1 from household OpenRouter host (goose 404)

### DIFF
--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -262,7 +262,10 @@ goosecracker:
       # placeholder string MUST match that catalog entry -- kloak_placeholder_drift_
       # test.py fails CI on drift. repo and cluster tools stay denied at dispatch
       # (goosecracker.tiers.household), so no GitHub token or kubeconfig is here.
-      OPENAI_HOST: https://openrouter.ai/api/v1
+      # NOTE: no /v1 suffix -- goose's OpenAI provider appends /v1/chat/completions
+      # to OPENAI_HOST, so the base must end at /api or the request path doubles to
+      # /api/v1/v1/chat/completions and OpenRouter 404s.
+      OPENAI_HOST: https://openrouter.ai/api
       OPENAI_API_KEY: "kloak:or:B5BKP27T2KSDN6QW70N34H8DP6"
       GOOSE_PROVIDER: openai
       GOOSE_MODEL: deepseek/deepseek-v4-flash


### PR DESCRIPTION
The first heavy WhatsApp goose run 404'd every DeepSeek call: `https://openrouter.ai/api/v1/v1/chat/completions` (doubled `/v1`).

goose's OpenAI provider appends `/v1/chat/completions` to `OPENAI_HOST`, so the base must end at `/api`, not `/api/v1`. The egress swap, the `kloak:or` key delivery, and the model id are all confirmed working in the logs — only the host path was wrong. The in-monolith DeepSeek callers are unaffected (they append `/chat/completions` to the same base, so they never doubled, which is why chat replies always worked).

Deploy-values only (`GOOSECRACKER_TIERS` via the $values ref); no chart bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)