### PR TITLE
feat(whatsapp): fast-ack replies, snappier drain, sandbox-first + channel-aware prompt

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.69
+version: 0.285.70
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -183,9 +183,29 @@ class ChatDeps:
     orchestrator_guidance: str = ""
 
 
-def build_system_prompt() -> str:
-    """Build the system prompt for the chat agent."""
-    return (
+def build_system_prompt(channel: str = "discord") -> str:
+    """Build the system prompt for the chat agent.
+
+    ``channel`` reframes the venue for a non-Discord agent. The behaviour is
+    shared across channels; only the channel-specific wording differs. Rather
+    than fork the whole prompt, a short READ-FIRST header corrects the
+    Discord-specific framing below when the agent is elsewhere (e.g. WhatsApp),
+    so the model is never told it is on Discord when it is not.
+    """
+    header = ""
+    if channel == "whatsapp":
+        header = (
+            "CHANNEL -- READ FIRST: You are in a WhatsApp group, NOT Discord. "
+            "There are no threads, no server, and no Discord <@id> mentions here. "
+            "Wherever the guidance below says 'Discord', 'server', or 'thread', "
+            "read it as 'this WhatsApp group' and 'heavier work runs in the "
+            "background and replies back here'. Messages are plain WhatsApp text "
+            "(no Discord markdown); an image you generate is sent as a normal "
+            "WhatsApp image, not a Discord attachment. When someone says 'Bosun' "
+            "or 'the bot', or replies to you, they mean YOU. Never mention "
+            "Discord.\n\n"
+        )
+    return header + (
         "You are a friend hanging out in a Discord server, and you're also "
         "genuinely useful. You talk like a real person: casual, direct, and "
         "natural. But people also come here to get real help, and helping "
@@ -213,11 +233,19 @@ def build_system_prompt() -> str:
         "articulate the answer clearly and completely. Getting it right and "
         "being easy to follow matters MORE than sounding breezy. A short list "
         "or a few steps is good when it makes the answer easier to act on.\n"
-        "- Exact numbers are never casual. If a reply turns on a computed "
-        "value (arithmetic beyond one digit, a percentage, date or unit math, "
-        "a statistic), run the python sandbox and report what it returns, even "
-        "mid-banter. Do not eyeball it to stay breezy: a wrong number said "
-        "confidently is worse than a one-second pause to compute it.\n\n"
+        "- Reach for the python sandbox (run_python) by DEFAULT for anything "
+        "computational, and do the work here rather than escalating. That "
+        "covers: exact math (arithmetic beyond one digit, a percentage, date "
+        "or unit math, a statistic), crunching / transforming / analyzing "
+        "data, and any chart, graph, plot, or table. Do not eyeball a number "
+        "or describe a chart you did not actually draw: run the code and "
+        "report or attach what it returns, even mid-banter. A wrong number "
+        "said confidently, or a 'chart' that is really just prose, is worse "
+        "than a few seconds to compute the real thing. The ONLY jobs to hand "
+        "off to an agent thread instead of doing inline are: reading or "
+        "changing a repo, thorough multi-source research, or building a "
+        "standalone interactive webpage. Everything else, do it right here "
+        "with run_python.\n\n"
         "WHAT YOU CAN DO (say this plainly when someone asks how you can help "
         "or what you can do, give the concrete rundown, not a vague 'anything!'):\n"
         "- Answer questions and hold a conversation.\n"
@@ -327,6 +355,7 @@ def create_agent(
     api_key: str | None = None,
     provider_base_url: str | None = None,
     model_settings: ModelSettings | None = None,
+    channel: str = "discord",
 ) -> Agent[ChatDeps]:
     """Create a PydanticAI agent (same tools and prompts for every tier).
 
@@ -374,7 +403,7 @@ def create_agent(
 
     agent: Agent[ChatDeps] = Agent(
         model,
-        system_prompt=build_system_prompt(),
+        system_prompt=build_system_prompt(channel),
         model_settings=model_settings
         or ModelSettings(
             temperature=1.0,
@@ -850,6 +879,7 @@ def create_household_agent() -> Agent[ChatDeps]:
     from chat.summarizer import household_model
 
     return create_agent(
+        channel="whatsapp",
         provider_base_url=_OPENROUTER_BASE_URL,
         api_key=os.environ.get("OPENROUTER_API_KEY", ""),
         model_name=household_model(),

--- a/projects/monolith/chat/whatsapp_inbound.py
+++ b/projects/monolith/chat/whatsapp_inbound.py
@@ -38,14 +38,14 @@ import hmac
 import logging
 import os
 
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Header, HTTPException
 from pydantic import BaseModel, Field
 from sqlmodel import Session, select
 
 from app.db import get_engine
 from chat import attention, attention_log, whatsapp_capabilities, whatsapp_session
 from chat.models import Message, WhatsappGroup, WhatsappOutbox
-from chat.whatsapp_outbox import enqueue_media, enqueue_message
+from chat.whatsapp_outbox import enqueue_media, enqueue_message, enqueue_reaction
 
 logger = logging.getLogger(__name__)
 
@@ -275,6 +275,7 @@ _EMBED_CLIENT = None
 @router.post("/inbound")
 async def inbound(
     body: InboundMessage,
+    background_tasks: BackgroundTasks,
     authorization: str | None = Header(default=None),
 ) -> dict:
     """Authenticate, dedupe, gate attention, and reply (spec sections 2/4).
@@ -394,18 +395,59 @@ async def inbound(
         # refused: a one-line explanation was already enqueued (household ACL).
         return {"status": outcome.get("action", "dispatched")}
 
-    # Chat path: a full conversational reply, enqueued as a single outbox message.
+    # Chat path: acknowledge fast, then author the reply OFF the request path.
+    # Generating a reply is a full model round-trip (seconds to minutes); doing it
+    # inline would hold the gateway's per-group forward worker open the whole time,
+    # serializing the group's other messages behind it. Instead drop an instant
+    # reaction so the group sees the bot is working, and hand the reply to a
+    # background task (FastAPI sends the 200 first, freeing the forward worker).
+    await asyncio.to_thread(_enqueue_ack_reaction, body)
+    background_tasks.add_task(_deliver_chat_reply, embed_client, body)
+    return {"status": "accepted"}
+
+
+def _enqueue_ack_reaction(body: InboundMessage, remove: bool = False) -> None:
+    """Enqueue (or clear) the ⏳ working reaction on the triggering message."""
     with Session(get_engine()) as session:
-        reply_text = await _generate_reply(
-            session, embed_client, body.group_jid, body.sender_name, body.text
+        enqueue_reaction(
+            session,
+            body.group_jid,
+            body.message_id,
+            body.sender_jid,
+            "⏳",
+            remove=remove,
         )
-    if not reply_text:
-        reply_text = (
-            "Sorry, I'm having trouble formulating a response right now. "
-            "Please try again in a moment."
-        )
-    await _enqueue_bot_reply(embed_client, body, reply_text)
-    return {"status": "replied"}
+        session.commit()
+
+
+async def _deliver_chat_reply(embed_client, body: InboundMessage) -> None:
+    """Author the conversational reply and enqueue it, then clear the ⏳ reaction.
+
+    Runs as a background task after the inbound 200, so the model round-trip never
+    blocks the gateway. Best-effort: any failure still clears the reaction and, on
+    a failed generation, enqueues an honest fallback so the group is never left on
+    a bare ⏳.
+    """
+    try:
+        with Session(get_engine()) as session:
+            reply_text = await _generate_reply(
+                session, embed_client, body.group_jid, body.sender_name, body.text
+            )
+        if not reply_text:
+            reply_text = (
+                "Sorry, I'm having trouble formulating a response right now. "
+                "Please try again in a moment."
+            )
+        await _enqueue_bot_reply(embed_client, body, reply_text)
+    except Exception:
+        logger.exception("whatsapp: chat reply delivery failed for %s", body.group_jid)
+    finally:
+        try:
+            await asyncio.to_thread(_enqueue_ack_reaction, body, True)
+        except Exception:
+            logger.exception(
+                "whatsapp: failed to clear ack reaction for %s", body.group_jid
+            )
 
 
 async def _enqueue_bot_reply(

--- a/projects/monolith/chat/whatsapp_inbound_test.py
+++ b/projects/monolith/chat/whatsapp_inbound_test.py
@@ -167,14 +167,19 @@ class TestAttentionRouting:
         )
         # "bosun" is the default trigger name, so this is directed (no classifier).
         resp = _post(client, text="hey bosun what's the ferry plan?", message_id="Q1")
-        assert resp.json()["status"] == "replied"
+        # Fast-ack: the reply is authored in a background task, so the request
+        # returns "accepted" while the reply lands via the outbox.
+        assert resp.json()["status"] == "accepted"
         rows = _outbox(engine)
-        assert len(rows) == 1
-        assert rows[0].kind == "message"
-        assert rows[0].group_jid == _GROUP
-        assert rows[0].content == "the ferry leaves at 9"
+        # The ⏳ working reaction, the reply message, then the ⏳ clear.
+        msgs = [r for r in rows if r.kind == "message"]
+        assert len(msgs) == 1
+        assert msgs[0].group_jid == _GROUP
+        assert msgs[0].content == "the ferry leaves at 9"
         # The reply quotes the triggering message.
-        assert rows[0].quoted_message_id == "Q1"
+        assert msgs[0].quoted_message_id == "Q1"
+        # An instant working reaction was enqueued on the triggering message.
+        assert any(r.kind == "reaction" and r.target_message_id == "Q1" for r in rows)
 
     def test_directed_agent_gets_honest_deferred_reply(
         self, client, engine, monkeypatch
@@ -222,7 +227,7 @@ class TestAttentionRouting:
             message_id="R1",
             quoted_message_id="wamid.BOTSENT",
         )
-        assert resp.json()["status"] == "replied"
+        assert resp.json()["status"] == "accepted"
         replies = [
             r for r in _outbox(engine) if r.content == "you asked about the ferry"
         ]

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.69
+      targetRevision: 0.285.70
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/whatsapp/outbox.go
+++ b/projects/monolith/whatsapp/outbox.go
@@ -28,7 +28,10 @@ const (
 	// Discord drain's _BATCH.
 	outboxBatch = 20
 	// outboxPollInterval is how often the drain wakes to look for pending rows.
-	outboxPollInterval = 3 * time.Second
+	// Kept short so the bot's reactions and replies leave with minimal lag after
+	// the monolith enqueues them (the drain query is a light indexed lookup on the
+	// whatsapp_outbox_pending partial index, so frequent polling is cheap).
+	outboxPollInterval = 500 * time.Millisecond
 )
 
 // sender translates an outbox row into a whatsmeow send. It is an interface so


### PR DESCRIPTION
Four responsiveness/quality fixes for the household chat, wrapping up this round.

- **Fast-ack light path** — the inbound endpoint drops an instant ⏳ reaction and authors the reply in a FastAPI background task, returning 200 immediately. The model round-trip no longer holds the gateway's per-group forward worker open (no head-of-line blocking within a group; whatsmeow's delivery receipt is never back-pressured). The ⏳ clears when the reply lands.
- **Lower send latency** — the outbox drain polls every **500ms** instead of 3s, so the bot's reactions/replies leave with minimal lag (light indexed lookup, cheap to poll). whatsmeow itself is push-based and already un-blocked; this poll interval was the real lever.
- **Sandbox-first prompt** — the chat agent reaches for `run_python` by DEFAULT for anything computational (math, data, charts, tables); only repo work, deep research, or building a webpage hands off to an agent run.
- **Channel-aware prompt** — a READ-FIRST header reframes the shared (Discord-worded) prompt for WhatsApp, so the household agent isn't told it's in a Discord server/thread with `<@id>` mentions. Behaviour stays shared; only the framing differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)