### PR TITLE
perf(grimoire): edge-cache public reader routes at the CDN

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.26
+version: 0.89.27
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.26
+      targetRevision: 0.89.27
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.72
+version: 0.285.73
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.72
+      targetRevision: 0.285.73
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/cache-headers.js
+++ b/projects/monolith/frontend/src/lib/cache-headers.js
@@ -117,3 +117,15 @@ export const TRIPS_CACHE_CONTROL =
 // projects/monolith/campsites/router.py, keep in sync.
 export const CAMPSITES_SNAPSHOT_CACHE_CONTROL =
   "public, max-age=0, s-maxage=60, stale-while-revalidate=3600, stale-if-error=86400";
+
+// /app/grimoire read API (the api/[...path] catch-all JSON + binary image proxy
+// and the book/read pagination proxy). The corpus is a read-only, near-static
+// D&D book library, so it takes an aggressive 1 h edge cache: this is the CDN
+// offload that keeps a share-driven traffic spike off the origin. max-age=0 keeps
+// the browser revalidating so a redeploy (new coverage while extraction runs) is
+// visible within the hour, while s-maxage lets Cloudflare fan warm copies out to
+// viewers. 1 d SWR (background refresh) and 1 d SIE (serve-stale on origin error)
+// preserve offload and resilience. Note the sibling book/read proxy signs
+// image_key -> image_url per response, but the signature is deterministic for a
+// given key so the signed page is safe to edge-cache.
+export const GRIMOIRE_READ_CACHE_CONTROL = `public, max-age=0, s-maxage=${ONE_HOUR}, stale-while-revalidate=${ONE_DAY}, stale-if-error=${ONE_DAY}`;

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/api/[...path]/+server.js
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/api/[...path]/+server.js
@@ -1,4 +1,5 @@
 import { error } from "@sveltejs/kit";
+import { GRIMOIRE_READ_CACHE_CONTROL } from "$lib/cache-headers.js";
 
 const API_BASE = process.env.API_BASE || "http://localhost:8000";
 
@@ -20,9 +21,11 @@ export async function GET({ params, url, fetch }) {
     status: res.status,
     headers: {
       "content-type": res.headers.get("content-type") ?? "application/json",
-      // The corpus is near-static; a minute of edge caching keeps origin hits
-      // low without stalling coverage updates while extraction runs.
-      "cache-control": "public, max-age=60",
+      // The corpus is a read-only, near-static book library, so it takes an
+      // aggressive 1 h edge cache (CDN offload that keeps a share-driven spike
+      // off the origin). max-age=0 keeps the browser revalidating so new
+      // coverage lands within the hour. See GRIMOIRE_READ_CACHE_CONTROL.
+      "cache-control": GRIMOIRE_READ_CACHE_CONTROL,
     },
   });
 }

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/read/+server.js
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/read/+server.js
@@ -4,6 +4,7 @@
 // streams image_key straight through unsigned) and signs every image_key into
 // image_url server-side.
 import { error } from "@sveltejs/kit";
+import { GRIMOIRE_READ_CACHE_CONTROL } from "$lib/cache-headers.js";
 import { apiBase, signReadPage } from "$lib/server/grimoire-read.js";
 
 export async function GET({ params, url, fetch }) {
@@ -23,6 +24,13 @@ export async function GET({ params, url, fetch }) {
   }
   const page = signReadPage(await res.json());
   return new Response(JSON.stringify(page), {
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      // Edge-cache the reader pages like the api/[...path] proxy: the signed
+      // image_url is a deterministic, non-expiring HMAC (grimoire-img.js), so a
+      // 1 h page cache never serves a stale signature. See
+      // GRIMOIRE_READ_CACHE_CONTROL.
+      "cache-control": GRIMOIRE_READ_CACHE_CONTROL,
+    },
   });
 }


### PR DESCRIPTION
## What

Puts the public Grimoire's read routes behind the Cloudflare CDN. It was shared before caching was wired, so every viewer's page-turns hit the origin.

Two read proxies were not CDN-cacheable:
- `api/[...path]/+server.js` emitted browser-only `public, max-age=60` (no `s-maxage`, so the edge did not cache/fan it out).
- `book/[book]/read/+server.js` emitted **no** `cache-control` at all.

## Change

Both now use a new `GRIMOIRE_READ_CACHE_CONTROL` constant in `lib/cache-headers.js`:

```
public, max-age=0, s-maxage=3600, stale-while-revalidate=86400, stale-if-error=86400
```

This matches the `s-maxage` CDN idiom the sibling public apps (ships, stars, hikes, llm-leaderboard) already use. `max-age=0` keeps browsers revalidating (new extraction coverage lands within the hour); `s-maxage=1h` lets Cloudflare serve warm copies; 1d SWR/SIE preserve offload and origin-outage resilience.

## Why it's safe to cache the signed reader pages

The `book/read` proxy signs `image_key` into `image_url`, but `signedGrimImgUrl` is a **deterministic HMAC over the path with no expiry** (not an AWS-style presign), so a cached page never serves a stale/expired signature.

## Rollout

Dual chart bump (`monolith` 0.285.73 + `monolith-public` 0.89.27) per `docs/runbooks/public-tier-checklist.md`: jomcgi.dev is served by the `monolith-public` frontend image.

Post-deploy verification: `curl -sI https://jomcgi.dev/app/grimoire/api/books` should show the new `cache-control`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)