### PR TITLE
chore(monolith): bump chart to 0.285.74 to deploy WhatsApp prompt fix

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.73
+version: 0.285.74
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.73
+      targetRevision: 0.285.74
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
PR #3312 merged the WhatsApp phantom-artifact prompt fix (`agent.py`) but its chart bump collided: it picked `0.285.73`, which a concurrent merge had already published to OCI with different image digests. Idempotent chart publish refused to re-push, so the "Push images" action failed:

> ERROR: monolith 0.285.73 is already published, but its pinned image digests differ from the published chart (an image was rebuilt). This merge will NOT deploy until the chart version is bumped.

This re-bumps to `0.285.74` (base `0.285.73`, no collision) so the current main image, which already carries the prompt change, publishes under a fresh version and ArgoCD deploys it. Chart-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)