### PR TITLE
chore: bump drifted charts (fc-invoke, oci-model-cache-operator) to restore deploys

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.45
+version: 0.4.46

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.45
+      targetRevision: 0.4.46
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/operators/oci-model-cache/deploy/application.yaml
+++ b/projects/operators/oci-model-cache/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: oci-model-cache-operator
-      targetRevision: 0.1.5
+      targetRevision: 0.2.3
       helm:
         valueFiles:
           - $values/projects/operators/oci-model-cache/deploy/values.yaml

--- a/projects/operators/oci-model-cache/helm/oci-model-cache-operator/Chart.yaml
+++ b/projects/operators/oci-model-cache/helm/oci-model-cache-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: oci-model-cache-operator
 description: A Helm chart for the OCI Model Cache Operator - caches HuggingFace models as OCI artifacts
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "latest"
 keywords:
   - oci


### PR DESCRIPTION
Main's "Push images" action was failing the missed-bump guard on two charts whose images were rebuilt without a chart bump, which blocks every subsequent merge from deploying (surfaced during the WhatsApp prompt-fix rollout, PR #3312/#3314).

**fc-invoke** `0.4.45 -> 0.4.46`: Chart.yaml + targetRevision were in sync; a clean one-version-forward deploy of the rebuilt substrate image.

**oci-model-cache-operator** `0.2.2 -> 0.2.3`, and the app **unstuck** `targetRevision 0.1.5 -> 0.2.3`: the operator app had been pinned at 0.1.5 since 2026-04-04 while the chart auto-bumped to 0.2.2, so it had not deployed forward in ~3 months (the auto-bump bot moved Chart.yaml but the app pin lagged). This advances the operator across the accumulated image rebuilds in one ArgoCD sync (confirmed with Joe). Done manually because this project's `helm/oci-model-cache-operator/` + `deploy/` layout does not match `bump-chart.sh`'s chart+deploy sibling convention.

A follow-up PR adds a PR-time guard so image-rebuild drift can no longer merge un-bumped (the detector currently only runs post-merge on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)