### PR TITLE
feat(demos): show sandbox overhead (invoke minus exec) on firecracker page

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.74
+version: 0.285.75
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/demos/firecracker_api.py
+++ b/projects/monolith/demos/firecracker_api.py
@@ -78,9 +78,18 @@ class GooseRequest(BaseModel):
 async def run_python(body: PythonRequest) -> dict:
     """Run a Python script in the zero-egress sandbox microVM.
 
-    Returns stdout/stderr/exit_code plus a backend-measured duration and the
-    trace id of this invocation. Prefers the daemon's own duration_ms when
-    present, falling back to the wall time measured here.
+    Returns stdout/stderr/exit_code plus two timings and the trace id of this
+    invocation:
+
+    - ``duration_ms`` is the guest's own exec time (the ``cmd.Run()`` of the
+      script) when the daemon reports it, else the backend wall as a fallback.
+    - ``overhead_ms`` is the sandbox envelope: the invoke total (backend wall
+      around the whole fc-invoke call) minus the guest exec, i.e. everything the
+      microVM costs beyond running the code (slot wait + snapshot restore + vsock
+      prime + readiness + teardown). It is the cleanest single number for the
+      cost of isolation, measured in-cluster so the browser round-trip is
+      excluded. It is None on the fallback path, where there is no distinct guest
+      exec to subtract.
     """
     with _tracer.start_as_current_span("demo.python", context=Context()):
         trace_id = _current_trace_id()
@@ -88,11 +97,17 @@ async def run_python(body: PythonRequest) -> dict:
         result = await run_python_in_sandbox(body.code, body.files)
         elapsed_ms = (perf_counter() - started) * 1000
 
+    guest_ms = result.get("duration_ms")
+    overhead_ms = (
+        None if guest_ms is None else max(0.0, round(elapsed_ms - guest_ms, 1))
+    )
+
     return {
         "stdout": result.get("stdout", ""),
         "stderr": result.get("stderr", ""),
         "exit_code": result.get("exit_code"),
-        "duration_ms": result.get("duration_ms", elapsed_ms),
+        "duration_ms": guest_ms if guest_ms is not None else round(elapsed_ms, 1),
+        "overhead_ms": overhead_ms,
         "error": result.get("error"),
         "trace_id": trace_id,
     }

--- a/projects/monolith/demos/firecracker_api_test.py
+++ b/projects/monolith/demos/firecracker_api_test.py
@@ -48,7 +48,28 @@ def test_python_returns_run_shape_with_trace_id(monkeypatch):
     assert body["stderr"] == ""
     assert body["exit_code"] == 0
     assert body["duration_ms"] == 42
+    # overhead_ms is the sandbox envelope: backend wall minus the guest's 42ms
+    # exec. It is present (the guest reported duration_ms) and non-negative.
+    assert body["overhead_ms"] is not None
+    assert body["overhead_ms"] >= 0.0
     assert _HEX32.match(body["trace_id"])
+
+
+def test_python_overhead_none_when_guest_reports_no_duration(monkeypatch):
+    """On the fallback path (daemon returns no duration_ms) there is no distinct
+    guest exec to subtract, so overhead_ms is None and duration_ms is the backend
+    wall."""
+
+    async def fake_run(code, files=None):
+        return {"stdout": "", "stderr": "", "exit_code": 0}
+
+    monkeypatch.setattr(fc, "run_python_in_sandbox", fake_run)
+
+    resp = _client().post("/api/demos/firecracker/python", json={"code": "print(1)"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["overhead_ms"] is None
+    assert isinstance(body["duration_ms"], (int, float))
 
 
 def test_semgrep_returns_findings_shape_with_trace_id(monkeypatch):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.74
+      targetRevision: 0.285.75
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/RunPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/RunPanel.svelte
@@ -250,7 +250,22 @@
         <span class="latency-label">wall</span>
         <span class="latency-value">{displayMs.toFixed(0)}ms</span>
       </span>
-      {#if result?.duration_ms != null}
+      {#if result?.overhead_ms != null}
+        <!-- When the guest reports its own exec time we can split the two: the
+             code's runtime vs the sandbox envelope around it. The sandbox
+             number is the point of the demo, so it is emphasised. -->
+        <span class="latency-item">
+          <span class="latency-label">exec</span>
+          <span class="latency-value">{result.duration_ms}ms</span>
+        </span>
+        <span
+          class="latency-item latency-item--hero"
+          title="Sandbox envelope: the whole invoke minus your code's exec (snapshot restore, vsock prime, readiness, teardown). Measured in-cluster, so the browser round-trip is excluded."
+        >
+          <span class="latency-label">sandbox</span>
+          <span class="latency-value">{result.overhead_ms}ms</span>
+        </span>
+      {:else if result?.duration_ms != null}
         <span class="latency-item">
           <span class="latency-label">invocation</span>
           <span class="latency-value">{result.duration_ms}ms</span>
@@ -471,6 +486,17 @@
     font-weight: 600;
     font-variant-numeric: tabular-nums;
     color: var(--ink);
+  }
+
+  /* The sandbox overhead is the headline metric this demo exists to show, so
+     tint its value with the accent and give its label a cursor hint for the
+     explanatory tooltip. */
+  .latency-item--hero {
+    cursor: help;
+  }
+
+  .latency-item--hero .latency-value {
+    color: var(--accent);
   }
 
   .goose-status {


### PR DESCRIPTION
## What

Adds the metric that cleanest demonstrates the microVM's value on the firecracker demo page: the **sandbox overhead**, the gap between the invoke total and the code's own exec time.

Before: `wall` (browser) · `invocation` (guest exec)
After (python): `wall` · `exec` · **`sandbox`** (accent-tinted, tooltip)

## How

- **Backend** (`/python`) returns `overhead_ms = elapsed_ms − guest duration_ms`, where `elapsed_ms` is the backend wall around the whole fc-invoke call and `duration_ms` is the guest's `cmd.Run()`. Measured **in-cluster**, so the browser round-trip is excluded, this is the pure isolation cost (slot + snapshot restore + vsock prime + readiness + teardown). `None` on the fallback path (no distinct guest exec to subtract).
- **Frontend** splits the python stat into `exec` + `sandbox`; the sandbox value is emphasised with the accent color and a tooltip naming the envelope. Semgrep has no separable guest exec, so it keeps its single `invocation` stat (gated on `overhead_ms`).

## Why this diff, not `wall − invocation`

`wall − invocation` (browser-side) would fold in the noisy Cloudflare→backend round-trip, swamping the ~tens-of-ms envelope we want to show. The backend `invoke − exec` is network-light and honest.

This pairs with #3315 (vsock priming): that PR cut the envelope's tail; this PR makes the envelope visible so the win is legible on the page.

## Tests
- `test_python_returns_run_shape_with_trace_id` now asserts `overhead_ms` is present and non-negative.
- `test_python_overhead_none_when_guest_reports_no_duration` locks the fallback path.

Bumps monolith chart to 0.285.75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiToanX2G4tc8pZWEcwxQb