### PR TITLE
ci(helm): fail a PR pre-merge when an image rebuild misses a chart bump

### DIFF
--- a/bazel/helm/BUILD
+++ b/bazel/helm/BUILD
@@ -2,14 +2,22 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@multitool//:tools.bzl", MULTITOOL_TOOLS = "TOOLS")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 exports_files([
     "chart-version.sh",
+    "check-missed-bump.sh",
     "helm-assert-annotations.sh",
     "helm-template-test.sh",
     "push.sh.tpl",
     "render-manifests.sh",
 ])
+
+sh_test(
+    name = "check_missed_bump_test",
+    srcs = ["check-missed-bump_test.sh"],
+    data = [":check-missed-bump.sh"],
+)
 
 sh_binary(
     name = "validate_manifests",

--- a/bazel/helm/check-missed-bump.sh
+++ b/bazel/helm/check-missed-bump.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# check-missed-bump.sh: content-stable "missed chart bump" guard.
+#
+# Given a chart whose current version is ALREADY published, compare the image
+# digests pinned in the freshly built chart against the ones in the published
+# chart of the same version. If they differ, an image was rebuilt without a
+# chart bump, so the merge would publish nothing and silently not deploy (or
+# fail main's Push images idempotency check). Exit 1 with the exact bump command
+# in that case; exit 0 otherwise.
+#
+# This is the same digest-content check push.sh.tpl runs post-merge on main,
+# factored out so it can also run pre-merge on a PR branch and be unit tested
+# with stubbed helm/crane. It is deliberately content-stable (compares manifest
+# digests, not the build-timestamped tags) and FAILS OPEN: an unresolved digest
+# or an unpublished version is treated as "nothing to assert", never a failure,
+# so a transient registry error cannot wedge a PR.
+#
+# Usage:
+#   HELM=/path/helm CRANE=/path/crane REPOSITORY=oci://ghcr.io/... \
+#     check-missed-bump.sh <chart_name> <chart_version> <fresh_chart_tgz> <project_dir>
+#
+# Env:
+#   HELM         path to the helm binary (required)
+#   CRANE        path to the crane binary (required)
+#   REPOSITORY   OCI chart repository (required), e.g. oci://ghcr.io/jomcgi/homelab/charts
+set -o errexit -o nounset -o pipefail
+
+CHART_NAME="${1:?chart_name required}"
+CHART_VERSION="${2:?chart_version required}"
+CHART_TGZ="${3:?fresh chart .tgz required}"
+PROJECT_DIR="${4:?project_dir required}"
+
+HELM="${HELM:?HELM env required}"
+CRANE="${CRANE:?CRANE env required}"
+REPOSITORY="${REPOSITORY:?REPOSITORY env required}"
+
+# Resolve one repo:tag to its manifest digest, retrying to absorb ghcr
+# propagation lag / transient rate limits. A genuinely gone tag ends UNRESOLVED,
+# which the caller treats as "skip", not "fail".
+_crane_digest() {
+	local ref="$1" i d
+	for i in 1 2 3; do
+		if d=$("$CRANE" digest "$ref" 2>/dev/null) && [[ -n "$d" ]]; then
+			printf '%s' "$d"
+			return 0
+		fi
+		if [[ $i -lt 3 ]]; then sleep 3; fi
+	done
+	printf 'UNRESOLVED'
+}
+
+# Emit sorted "repo=digest" lines for each ghcr.io/jomcgi image pinned in a
+# chart. Args pass straight to `helm show values` (a .tgz path, or
+# "REPO/NAME --version X"). The pinned tag embeds a build timestamp so it
+# changes every build even for identical content; resolving it to the manifest
+# digest gives a content-stable identity to compare.
+_image_digests() {
+	"$HELM" show values "$@" 2>/dev/null | awk '
+    /^[[:space:]]*repository:[[:space:]]*/ { repo=$2 }
+    /^[[:space:]]*tag:[[:space:]]*/ && repo!="" { print repo"\t"$2; repo="" }' |
+		while IFS="$(printf '\t')" read -r repo tag; do
+			case "$repo" in
+			ghcr.io/jomcgi/*)
+				printf '%s=%s\n' "$repo" "$(_crane_digest "${repo}:${tag}")"
+				;;
+			esac
+		done | sort
+}
+
+# Only meaningful when this version is already published. If `helm show chart`
+# fails, the version is new (this PR bumped it) and there is nothing to assert.
+if ! "$HELM" show chart "${REPOSITORY}/${CHART_NAME}" --version "${CHART_VERSION}" >/dev/null 2>&1; then
+	echo "check-missed-bump: ${CHART_NAME} ${CHART_VERSION} is not published yet; nothing to check."
+	exit 0
+fi
+
+FRESH_DIGESTS=$(_image_digests "$CHART_TGZ") || FRESH_DIGESTS=""
+PUB_DIGESTS=$(_image_digests "${REPOSITORY}/${CHART_NAME}" --version "${CHART_VERSION}") || PUB_DIGESTS=""
+
+# Fail open on any unresolved or empty digest set: a registry hiccup must not
+# block a PR. The version-scoped detector on main is the backstop for these.
+if [[ "$FRESH_DIGESTS" == *UNRESOLVED* ]] || [[ "$PUB_DIGESTS" == *UNRESOLVED* ]]; then
+	echo "check-missed-bump: WARNING: could not resolve all image digests for ${CHART_NAME}; skipping (fail open)." >&2
+	exit 0
+fi
+if [[ -z "$FRESH_DIGESTS" ]] || [[ -z "$PUB_DIGESTS" ]]; then
+	echo "check-missed-bump: no ghcr.io/jomcgi images pinned in ${CHART_NAME}; nothing to check."
+	exit 0
+fi
+
+if [[ "$FRESH_DIGESTS" != "$PUB_DIGESTS" ]]; then
+	{
+		echo "ERROR: ${CHART_NAME} ${CHART_VERSION} is already published, but its pinned image digests differ from the published chart (an image was rebuilt)."
+		echo "This PR will NOT deploy until the chart version is bumped."
+		echo ""
+		echo "Fix: in a fresh worktree run"
+		echo "  bazel/tools/git/bump-chart.sh ${PROJECT_DIR}"
+		echo "then commit the bump to this PR."
+	} >&2
+	exit 1
+fi
+
+echo "check-missed-bump: ${CHART_NAME} ${CHART_VERSION} image digests match the published chart; OK."
+exit 0

--- a/bazel/helm/check-missed-bump_test.sh
+++ b/bazel/helm/check-missed-bump_test.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Unit tests for check-missed-bump.sh.
+#
+# The script under test compares the ghcr.io/jomcgi image digests pinned in a
+# freshly built chart against the published chart of the same version and fails
+# (exit 1) only when the version is already published AND the digests differ.
+# helm and crane are stubbed so no network or real binaries are needed. The
+# stubs key their behaviour off env vars set per case:
+#   STUB_CHART_RC     exit code of `helm show chart` (0 = published)
+#   STUB_FRESH_TAG    tag `helm show values <tgz>` reports (the PR build)
+#   STUB_PUB_TAG      tag `helm show values ... --version` reports (published)
+#   STUB_FRESH_DIGEST digest crane maps STUB_FRESH_TAG to
+#   STUB_PUB_DIGEST   digest crane maps STUB_PUB_TAG to
+#   STUB_UNRESOLVED_TAG a tag crane fails to resolve (forces UNRESOLVED)
+#   STUB_NO_IMAGES    if set, `helm show values` pins no images
+set -o errexit -o nounset -o pipefail
+
+SCRIPT_REL="bazel/helm/check-missed-bump.sh"
+SCRIPT=""
+for candidate in \
+	"${RUNFILES_DIR:-}/_main/${SCRIPT_REL}" \
+	"${TEST_SRCDIR:-}/_main/${SCRIPT_REL}" \
+	"${BASH_SOURCE[0]%/*}/check-missed-bump.sh"; do
+	if [[ -f "$candidate" ]]; then
+		SCRIPT="$candidate"
+		break
+	fi
+done
+if [[ -z "$SCRIPT" ]]; then
+	echo "ERROR: cannot locate check-missed-bump.sh in runfiles" >&2
+	exit 1
+fi
+
+TMP="${TEST_TMPDIR:-$(mktemp -d)}"
+FAILURES=0
+
+# --- stubs -----------------------------------------------------------------
+STUB_HELM="$TMP/helm"
+cat >"$STUB_HELM" <<'EOF'
+#!/usr/bin/env bash
+sub="${1:-} ${2:-}"
+case "$sub" in
+  "show chart")
+    exit "${STUB_CHART_RC:-0}" ;;
+  "show values")
+    [[ -n "${STUB_NO_IMAGES:-}" ]] && exit 0
+    if [[ "$*" == *--version* ]]; then tag="${STUB_PUB_TAG}"; else tag="${STUB_FRESH_TAG}"; fi
+    printf 'image:\n  repository: ghcr.io/jomcgi/homelab/projects/foo/backend\n  tag: %s\n' "$tag" ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$STUB_HELM"
+
+STUB_CRANE="$TMP/crane"
+cat >"$STUB_CRANE" <<'EOF'
+#!/usr/bin/env bash
+# args: digest <ref>
+ref="${2:-}"
+tag="${ref##*:}"
+if [[ -n "${STUB_UNRESOLVED_TAG:-}" && "$tag" == "${STUB_UNRESOLVED_TAG}" ]]; then
+  exit 1
+fi
+case "$tag" in
+  "${STUB_FRESH_TAG:-__f}") echo "sha256:${STUB_FRESH_DIGEST:-f}" ;;
+  "${STUB_PUB_TAG:-__p}")   echo "sha256:${STUB_PUB_DIGEST:-p}" ;;
+  *) echo "sha256:deadbeef" ;;
+esac
+EOF
+chmod +x "$STUB_CRANE"
+
+FAKE_TGZ="$TMP/foo.tgz"
+: >"$FAKE_TGZ"
+
+run_check() {
+	# Echoes exit code; stdout+stderr captured in $TMP/out.
+	set +e
+	env HELM="$STUB_HELM" CRANE="$STUB_CRANE" \
+		REPOSITORY="oci://ghcr.io/jomcgi/homelab/charts" \
+		"$@" \
+		bash "$SCRIPT" foo 1.2.3 "$FAKE_TGZ" projects/foo >"$TMP/out" 2>&1
+	local rc=$?
+	set -e
+	echo "$rc"
+}
+
+expect() {
+	# $1 test name, $2 expected exit, $3 exit, $4 substring (optional), out=$TMP/out
+	local name="$1" want="$2" got="$3" needle="${4:-}"
+	if [[ "$got" != "$want" ]]; then
+		echo "FAIL: ${name}: expected exit ${want}, got ${got}"
+		echo "  --- output ---"
+		sed 's/^/  /' "$TMP/out"
+		FAILURES=$((FAILURES + 1))
+		return
+	fi
+	if [[ -n "$needle" ]] && ! grep -qF "$needle" "$TMP/out"; then
+		echo "FAIL: ${name}: output missing '${needle}'"
+		echo "  --- output ---"
+		sed 's/^/  /' "$TMP/out"
+		FAILURES=$((FAILURES + 1))
+		return
+	fi
+	echo "PASS: ${name}"
+}
+
+# 1. Published + digests differ -> FAIL with the bump command.
+rc=$(run_check STUB_CHART_RC=0 STUB_FRESH_TAG=fresh STUB_PUB_TAG=pub \
+	STUB_FRESH_DIGEST=aaa STUB_PUB_DIGEST=bbb)
+expect "published+drift fails" 1 "$rc" "will NOT deploy"
+[[ "$rc" == 1 ]] && grep -qF "bazel/tools/git/bump-chart.sh projects/foo" "$TMP/out" &&
+	echo "PASS: fail message names the bump command" ||
+	{
+		echo "FAIL: fail message missing bump command"
+		FAILURES=$((FAILURES + 1))
+	}
+
+# 2. Published + identical digests (different build-timestamp tags) -> OK.
+rc=$(run_check STUB_CHART_RC=0 STUB_FRESH_TAG=fresh STUB_PUB_TAG=pub \
+	STUB_FRESH_DIGEST=same STUB_PUB_DIGEST=same)
+expect "published+match passes" 0 "$rc" "digests match"
+
+# 3. Version not yet published (this PR bumped it) -> OK, nothing to assert.
+rc=$(run_check STUB_CHART_RC=1 STUB_FRESH_TAG=fresh STUB_PUB_TAG=pub \
+	STUB_FRESH_DIGEST=aaa STUB_PUB_DIGEST=bbb)
+expect "unpublished passes" 0 "$rc" "not published yet"
+
+# 4. A digest cannot be resolved -> FAIL OPEN (never block on registry flake).
+rc=$(run_check STUB_CHART_RC=0 STUB_FRESH_TAG=fresh STUB_PUB_TAG=pub \
+	STUB_UNRESOLVED_TAG=fresh STUB_FRESH_DIGEST=aaa STUB_PUB_DIGEST=bbb)
+expect "unresolved fails open" 0 "$rc" "fail open"
+
+# 5. No ghcr.io/jomcgi images pinned -> OK, nothing to compare.
+rc=$(run_check STUB_CHART_RC=0 STUB_NO_IMAGES=1)
+expect "no images passes" 0 "$rc" "nothing to check"
+
+if [[ "$FAILURES" -gt 0 ]]; then
+	echo "${FAILURES} test(s) failed"
+	exit 1
+fi
+echo "All check-missed-bump tests passed"

--- a/bazel/helm/push.bzl
+++ b/bazel/helm/push.bzl
@@ -143,10 +143,11 @@ def _helm_push_impl(ctx):
             "{{REPOSITORY}}": ctx.attr.repository,
             "{{CHART_VERSION_SH}}": chart_version_sh_path,
             "{{CHART_DIR}}": ctx.attr.chart_dir,
+            "{{CHECK_MISSED_BUMP}}": _rlocationpath(ctx.file._check_missed_bump, workspace_name),
         },
     )
 
-    runfiles_files = [ctx.file.chart]
+    runfiles_files = [ctx.file.chart, ctx.file._check_missed_bump]
     if ctx.file._chart_version_sh:
         runfiles_files.append(ctx.file._chart_version_sh)
 
@@ -178,6 +179,10 @@ helm_push = rule(
         ),
         "_chart_version_sh": attr.label(
             default = "//bazel/helm:chart-version.sh",
+            allow_single_file = True,
+        ),
+        "_check_missed_bump": attr.label(
+            default = "//bazel/helm:check-missed-bump.sh",
             allow_single_file = True,
         ),
         "_push_template": attr.label(

--- a/bazel/helm/push.sh.tpl
+++ b/bazel/helm/push.sh.tpl
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Push a packaged Helm chart to an OCI registry
-# Template substitutions: {{HELM}}, {{CHART_TGZ}}, {{REPOSITORY}}, {{CHART_VERSION_SH}}, {{CHART_DIR}}
+# Template substitutions: {{HELM}}, {{CRANE}}, {{CHART_TGZ}}, {{REPOSITORY}}, {{CHART_VERSION_SH}}, {{CHART_DIR}}, {{CHECK_MISSED_BUMP}}
 
 set -o errexit -o nounset -o pipefail
 
@@ -23,6 +23,7 @@ fi
 readonly HELM="$(rlocation "{{HELM}}")"
 readonly CRANE="$(rlocation "{{CRANE}}")"
 readonly CHART_TGZ="$(rlocation "{{CHART_TGZ}}")"
+readonly CHECK_MISSED_BUMP="$(rlocation "{{CHECK_MISSED_BUMP}}")"
 REPOSITORY="{{REPOSITORY}}"
 CHART_VERSION_SH="{{CHART_VERSION_SH}}"
 CHART_DIR="{{CHART_DIR}}"
@@ -234,6 +235,27 @@ elif [[ "$CAN_VERSION" == "true" ]]; then
     echo "Version bump committed and pushed to ${CURRENT_BRANCH}"
   else
     echo "Chart version unchanged at ${CURRENT_VERSION}"
+    # PR-time missed-bump guard. The version-scoped auto-bump above declined to
+    # bump, but an image can be rebuilt to a new digest without touching the
+    # bazel dependency closure that detector queries (a shared base-image change
+    # under --keep_going), which then merges and only fails main's Push images
+    # post-merge, wedging the NEXT person's deploy. Run the content-stable digest
+    # check now so the PR cannot merge un-bumped. The guard fails OPEN on any
+    # registry/resolution hiccup, so it never false-blocks a PR; when it does
+    # fail it exits non-zero and errexit aborts the push with the bump command.
+    if [[ -n "$CHECK_MISSED_BUMP" ]] && [[ -f "$CHECK_MISSED_BUMP" ]] && \
+       [[ -n "$ABS_CHART_DIR" ]] && [[ -f "${ABS_CHART_DIR}/Chart.yaml" ]]; then
+      GUARD_CHART_NAME=$(grep '^name:' "${ABS_CHART_DIR}/Chart.yaml" | head -1 | awk '{print $2}' | tr -d '"')
+      if [[ -f "${ABS_CHART_DIR}/application.yaml" ]]; then
+        GUARD_PROJECT_DIR="$CHART_DIR"
+      else
+        GUARD_PROJECT_DIR=$(dirname "$CHART_DIR")
+      fi
+      if [[ -n "$GUARD_CHART_NAME" ]]; then
+        HELM="$HELM" CRANE="$CRANE" REPOSITORY="$REPOSITORY" \
+          bash "$CHECK_MISSED_BUMP" "$GUARD_CHART_NAME" "$CURRENT_VERSION" "$CHART_TGZ" "$GUARD_PROJECT_DIR"
+      fi
+    fi
   fi
 
   # Re-package chart with semver-compatible pre-release tag for OCI push (PRs use ephemeral tags).

--- a/bazel/helm/push.sh.tpl
+++ b/bazel/helm/push.sh.tpl
@@ -252,7 +252,11 @@ elif [[ "$CAN_VERSION" == "true" ]]; then
         GUARD_PROJECT_DIR=$(dirname "$CHART_DIR")
       fi
       if [[ -n "$GUARD_CHART_NAME" ]]; then
-        HELM="$HELM" CRANE="$CRANE" REPOSITORY="$REPOSITORY" \
+        # Pass HELM/CRANE via `env`, not a command prefix: both are readonly in
+        # this shell, and a `HELM=... cmd` prefix is a shell assignment that
+        # bash rejects with "HELM: readonly variable". `env` sets them only in
+        # the child's environment.
+        env HELM="$HELM" CRANE="$CRANE" REPOSITORY="$REPOSITORY" \
           bash "$CHECK_MISSED_BUMP" "$GUARD_CHART_NAME" "$CURRENT_VERSION" "$CHART_TGZ" "$GUARD_PROJECT_DIR"
       fi
     fi


### PR DESCRIPTION
## Problem

The digest-drift detector that catches "image rebuilt but chart version not bumped" only ran when `CURRENT_BRANCH == main` in `push.sh.tpl`, so it fired **post-merge** on the main "Push images" action. By then the un-bumped change has already landed, and because chart publish is idempotent it silently does not deploy **and** the now-red main action blocks the next person's deploy until someone bumps.

This is exactly what stalled the WhatsApp prompt-fix rollout (#3312/#3314) and left `oci-model-cache-operator` + `fc-invoke` drifting (#3316):

> ERROR: monolith 0.285.73 is already published, but its pinned image digests differ from the published chart (an image was rebuilt). This merge will NOT deploy until the chart version is bumped.

## Fix

Extract the content-stable digest check into a standalone, unit-tested script (`bazel/helm/check-missed-bump.sh`) and call it from `push.sh.tpl`'s **PR path** when the version-scoped auto-bump declined to bump. A PR that rebuilds an image without bumping its chart now fails its own "Push images" action with the exact bump command, so it cannot merge un-bumped.

Design notes:
- **Content-stable:** compares resolved manifest digests, not the build-timestamped tags, so identical content across two builds passes even though the tags differ (test case 2).
- **Fails open:** an unpublished version, an unresolved digest, or a registry hiccup is treated as "nothing to assert", never a false block. The main-branch detector remains the backstop for these.
- **Low blast radius:** reproducible rules_oci/apko builds mean an unrelated PR rebuilds identical digests and passes; only a PR that actually changes an image's content (e.g. a shared base-image bump) without a chart bump goes red. That is the PR that should be blocked.
- Main-branch detector left untouched (zero change to the working publish flow); the new script is used only by the PR guard and the test.

## Test

`bazel/helm/check-missed-bump_test.sh` (`sh_test`) stubs `helm`/`crane` and asserts:
1. published + digests differ -> exit 1 with `bump-chart.sh <dir>` in the message
2. published + identical digests (different build-timestamp tags) -> pass
3. version not yet published (PR bumped it) -> pass
4. a digest cannot be resolved -> fail open (pass)
5. no ghcr.io/jomcgi images pinned -> pass

Ran locally: all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)