### PR TITLE
fix(demos): show setup (landing to exec) not full-envelope overhead

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.75
+version: 0.285.76
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/demos/firecracker_api.py
+++ b/projects/monolith/demos/firecracker_api.py
@@ -78,18 +78,9 @@ class GooseRequest(BaseModel):
 async def run_python(body: PythonRequest) -> dict:
     """Run a Python script in the zero-egress sandbox microVM.
 
-    Returns stdout/stderr/exit_code plus two timings and the trace id of this
-    invocation:
-
-    - ``duration_ms`` is the guest's own exec time (the ``cmd.Run()`` of the
-      script) when the daemon reports it, else the backend wall as a fallback.
-    - ``overhead_ms`` is the sandbox envelope: the invoke total (backend wall
-      around the whole fc-invoke call) minus the guest exec, i.e. everything the
-      microVM costs beyond running the code (slot wait + snapshot restore + vsock
-      prime + readiness + teardown). It is the cleanest single number for the
-      cost of isolation, measured in-cluster so the browser round-trip is
-      excluded. It is None on the fallback path, where there is no distinct guest
-      exec to subtract.
+    Returns stdout/stderr/exit_code plus a backend-measured duration and the
+    trace id of this invocation. Prefers the daemon's own duration_ms when
+    present, falling back to the wall time measured here.
     """
     with _tracer.start_as_current_span("demo.python", context=Context()):
         trace_id = _current_trace_id()
@@ -97,17 +88,11 @@ async def run_python(body: PythonRequest) -> dict:
         result = await run_python_in_sandbox(body.code, body.files)
         elapsed_ms = (perf_counter() - started) * 1000
 
-    guest_ms = result.get("duration_ms")
-    overhead_ms = (
-        None if guest_ms is None else max(0.0, round(elapsed_ms - guest_ms, 1))
-    )
-
     return {
         "stdout": result.get("stdout", ""),
         "stderr": result.get("stderr", ""),
         "exit_code": result.get("exit_code"),
-        "duration_ms": guest_ms if guest_ms is not None else round(elapsed_ms, 1),
-        "overhead_ms": overhead_ms,
+        "duration_ms": result.get("duration_ms", elapsed_ms),
         "error": result.get("error"),
         "trace_id": trace_id,
     }

--- a/projects/monolith/demos/firecracker_api_test.py
+++ b/projects/monolith/demos/firecracker_api_test.py
@@ -48,28 +48,7 @@ def test_python_returns_run_shape_with_trace_id(monkeypatch):
     assert body["stderr"] == ""
     assert body["exit_code"] == 0
     assert body["duration_ms"] == 42
-    # overhead_ms is the sandbox envelope: backend wall minus the guest's 42ms
-    # exec. It is present (the guest reported duration_ms) and non-negative.
-    assert body["overhead_ms"] is not None
-    assert body["overhead_ms"] >= 0.0
     assert _HEX32.match(body["trace_id"])
-
-
-def test_python_overhead_none_when_guest_reports_no_duration(monkeypatch):
-    """On the fallback path (daemon returns no duration_ms) there is no distinct
-    guest exec to subtract, so overhead_ms is None and duration_ms is the backend
-    wall."""
-
-    async def fake_run(code, files=None):
-        return {"stdout": "", "stderr": "", "exit_code": 0}
-
-    monkeypatch.setattr(fc, "run_python_in_sandbox", fake_run)
-
-    resp = _client().post("/api/demos/firecracker/python", json={"code": "print(1)"})
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["overhead_ms"] is None
-    assert isinstance(body["duration_ms"], (int, float))
 
 
 def test_semgrep_returns_findings_shape_with_trace_id(monkeypatch):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.75
+      targetRevision: 0.285.76
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/RunPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/RunPanel.svelte
@@ -250,22 +250,7 @@
         <span class="latency-label">wall</span>
         <span class="latency-value">{displayMs.toFixed(0)}ms</span>
       </span>
-      {#if result?.overhead_ms != null}
-        <!-- When the guest reports its own exec time we can split the two: the
-             code's runtime vs the sandbox envelope around it. The sandbox
-             number is the point of the demo, so it is emphasised. -->
-        <span class="latency-item">
-          <span class="latency-label">exec</span>
-          <span class="latency-value">{result.duration_ms}ms</span>
-        </span>
-        <span
-          class="latency-item latency-item--hero"
-          title="Sandbox envelope: the whole invoke minus your code's exec (snapshot restore, vsock prime, readiness, teardown). Measured in-cluster, so the browser round-trip is excluded."
-        >
-          <span class="latency-label">sandbox</span>
-          <span class="latency-value">{result.overhead_ms}ms</span>
-        </span>
-      {:else if result?.duration_ms != null}
+      {#if result?.duration_ms != null}
         <span class="latency-item">
           <span class="latency-label">invocation</span>
           <span class="latency-value">{result.duration_ms}ms</span>
@@ -486,17 +471,6 @@
     font-weight: 600;
     font-variant-numeric: tabular-nums;
     color: var(--ink);
-  }
-
-  /* The sandbox overhead is the headline metric this demo exists to show, so
-     tint its value with the accent and give its label a cursor hint for the
-     explanatory tooltip. */
-  .latency-item--hero {
-    cursor: help;
-  }
-
-  .latency-item--hero .latency-value {
-    color: var(--accent);
   }
 
   .goose-status {

--- a/projects/monolith/frontend/src/lib/private/components/demos/TraceWaterfall.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/TraceWaterfall.svelte
@@ -207,6 +207,24 @@
       label: `${Math.round(f * end)}ms`,
     }));
   });
+
+  // "setup" is the daemon-side pre-exec latency: from the request landing in the
+  // fc-invoke daemon (its earliest span) to the workload starting to execute
+  // (guest_exec.start). That window is the sandbox envelope BEFORE the code runs:
+  // slot wait + snapshot restore + vsock prime + readiness. It is the number this
+  // demo exists to show, so we derive it from the same spans as the waterfall.
+  // Keyed only on the guest_exec span and its (daemon) service, so it is robust
+  // to the warm/cold paths and to phase-span renames. null until guest_exec has
+  // ingested.
+  let setupMs = $derived.by(() => {
+    const exec = spans.find((s) => s.name === "guest_exec");
+    if (!exec) return null;
+    const daemonStarts = spans
+      .filter((s) => s.service === exec.service)
+      .map((s) => s.start_ms ?? 0);
+    if (daemonStarts.length === 0) return null;
+    return Math.max(0, exec.start_ms - Math.min(...daemonStarts));
+  });
 </script>
 
 <div class="waterfall">
@@ -223,6 +241,19 @@
       </a>
     {/if}
   </div>
+
+  {#if setupMs != null}
+    <!-- Headline metric: the daemon's pre-exec setup, i.e. how long from the
+         request landing in fc-invoke to the workload actually executing. This is
+         the cost of the sandbox before any user code runs. -->
+    <div
+      class="setup-stat"
+      title="From the request landing in the fc-invoke daemon to the workload starting to execute: slot wait + snapshot restore + vsock prime + readiness. The sandbox's cost before your code runs."
+    >
+      <span class="setup-label">setup · landing → exec</span>
+      <span class="setup-value">{setupMs.toFixed(1)}ms</span>
+    </div>
+  {/if}
 
   {#if !traceId}
     <p class="waterfall-empty">Run something to see its trace here.</p>
@@ -355,6 +386,36 @@
 
   .signoz-link:hover {
     text-decoration: underline;
+  }
+
+  /* The setup metric is the headline number this trace exists to expose, so it
+     gets a tinted pill with the value in the accent color and a help cursor for
+     the explanatory tooltip. */
+  .setup-stat {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 8px;
+    align-self: flex-start;
+    padding: 5px 10px;
+    border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--line));
+    background: color-mix(in srgb, var(--accent) 8%, var(--surface));
+    border-radius: 6px;
+    cursor: help;
+  }
+
+  .setup-label {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-faint);
+  }
+
+  .setup-value {
+    font-size: 15px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--accent);
   }
 
   .waterfall-empty {


### PR DESCRIPTION
## What

Corrects the metric added in #3315. That PR's `overhead_ms = backend_wall − guest_exec` is the **full round-trip envelope** measured at the backend, so it also carries the response trip back + the in-cluster hop, and being backend-side it can't separate pre-exec from post-exec.

What was actually wanted: the **daemon-side pre-exec window** — from the request landing in fc-invoke to the workload starting to execute (slot wait + snapshot restore + vsock prime + readiness).

## How

- Reverts `overhead_ms`, the frontend `exec`/`sandbox` split, and its tests (the three files return to their pre-#3315 state).
- Derives `setup` from the trace the demo **already fetches** for the waterfall:
  ```
  setup = guest_exec.start − min(start of spans sharing guest_exec's service)
  ```
  i.e. from the daemon's earliest span (request landed) to exec start. Keyed only on the `guest_exec` span + its service, so it's robust to warm/cold paths and phase-span renames, and it's on the daemon's own clock.
- Rendered as an accent pill above the waterfall, appearing with the very spans it's computed from (no separate fetch, no daemon change).

## Why B (trace-derived) over a daemon header

The exact number lives only in the daemon spans (one clock spanning "received" and "started exec"). The page already pulls those spans, so deriving it needs zero Go/plumbing changes; the ~5-10s ingest lag is a non-issue because it appears alongside the waterfall built from the same data.

This is the number the vsock-prime work (#3315) shrank (383ms tail → ~40ms), now shown directly.

Bumps monolith chart to 0.285.76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiToanX2G4tc8pZWEcwxQb