### PR TITLE
feat(fc-invoke): record per-invocation guest CPU and peak RSS on spans

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.46
+version: 0.4.47

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.46
+      targetRevision: 0.4.47
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/firecracker/substrate/node/fcvm/driver/BUILD
+++ b/projects/firecracker/substrate/node/fcvm/driver/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "driver",
     srcs = [
         "driver.go",
+        "gueststats.go",
         "launcher.go",
         "mountns_linux.go",
         "mountns_other.go",
@@ -22,6 +23,7 @@ go_test(
     name = "driver_test",
     srcs = [
         "driver_test.go",
+        "gueststats_test.go",
         "provisioner_test.go",
     ],
     embed = [":driver"],

--- a/projects/firecracker/substrate/node/fcvm/driver/driver.go
+++ b/projects/firecracker/substrate/node/fcvm/driver/driver.go
@@ -91,6 +91,10 @@ func (c Config) withDefaults() Config {
 type Process interface {
 	Kill() error
 	Wait() error
+	// Pid returns the OS process id of the firecracker process, or 0 if it has
+	// not started. Used to read the process's /proc resource counters for
+	// per-invocation stats before teardown.
+	Pid() int
 }
 
 // Launcher starts a Firecracker process whose API socket is at socketPath and

--- a/projects/firecracker/substrate/node/fcvm/driver/driver_test.go
+++ b/projects/firecracker/substrate/node/fcvm/driver/driver_test.go
@@ -25,10 +25,12 @@ type fakeLauncher struct {
 type fakeProcess struct {
 	srv    *http.Server
 	killed bool
+	pid    int
 }
 
 func (p *fakeProcess) Kill() error { p.killed = true; return p.srv.Close() }
 func (p *fakeProcess) Wait() error { return nil }
+func (p *fakeProcess) Pid() int    { return p.pid }
 
 func (l *fakeLauncher) Launch(_ context.Context, _ string, socketPath string) (Process, error) {
 	l.mu.Lock()

--- a/projects/firecracker/substrate/node/fcvm/driver/gueststats.go
+++ b/projects/firecracker/substrate/node/fcvm/driver/gueststats.go
@@ -1,0 +1,109 @@
+package driver
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/jomcgi/homelab/projects/firecracker/substrate/substrate"
+)
+
+// userHZ is the kernel clock-tick rate that /proc/<pid>/stat's utime/stime are
+// counted in. It is 100 on effectively every Linux build (USER_HZ), including
+// the daemon's container, so we treat it as a constant rather than paying a cgo
+// sysconf(_SC_CLK_TCK) call. This makes CPU resolution ~10ms, coarse for a
+// sub-20ms python run but fine for the semgrep/agent scans this is used to
+// right-size.
+const userHZ = 100
+
+// Stats reads the guest's firecracker process resource counters from /proc and
+// returns them as whole-invocation totals (see substrate.GuestStats). It is
+// meant to be called once, just before Release kills the process: /proc/<pid>
+// disappears with the process, so a later read would fail. Best-effort by
+// contract; the caller records the values on a span and continues on error.
+func (d *Driver) Stats(h substrate.Handle) (substrate.GuestStats, error) {
+	inst := d.get(h.ID)
+	if inst == nil {
+		return substrate.GuestStats{}, fmt.Errorf("driver: stats of unknown handle %q", h.ID)
+	}
+	pid := inst.proc.Pid()
+	if pid <= 0 {
+		return substrate.GuestStats{}, fmt.Errorf("driver: stats: no pid for handle %q", h.ID)
+	}
+	return readProcStats(pid)
+}
+
+// readProcStats reads /proc/<pid>/stat and /proc/<pid>/status for one pid and
+// returns the parsed CPU and peak-RSS totals.
+func readProcStats(pid int) (substrate.GuestStats, error) {
+	statData, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return substrate.GuestStats{}, fmt.Errorf("driver: read proc stat: %w", err)
+	}
+	cpuMs, err := parseProcStatCPUMillis(statData)
+	if err != nil {
+		return substrate.GuestStats{}, err
+	}
+	statusData, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		return substrate.GuestStats{}, fmt.Errorf("driver: read proc status: %w", err)
+	}
+	rssMib, err := parseProcStatusPeakRSSMib(statusData)
+	if err != nil {
+		return substrate.GuestStats{}, err
+	}
+	return substrate.GuestStats{CPUMillis: cpuMs, PeakRSSMib: rssMib}, nil
+}
+
+// parseProcStatCPUMillis extracts utime+stime (thread-group totals, so summed
+// across every vCPU + VMM thread) from a /proc/<pid>/stat line and converts
+// clock ticks to milliseconds.
+//
+// The comm field (field 2) is wrapped in parens and may itself contain spaces
+// or parens, so we split AFTER the last ')': the remaining fields start at
+// field 3 (state), making utime (field 14) index 11 and stime (field 15) index
+// 12 of the remainder.
+func parseProcStatCPUMillis(data []byte) (int64, error) {
+	s := string(data)
+	rparen := strings.LastIndexByte(s, ')')
+	if rparen < 0 || rparen+2 > len(s) {
+		return 0, fmt.Errorf("driver: malformed proc stat: no comm field")
+	}
+	fields := strings.Fields(s[rparen+1:])
+	// Need up to field 15 (stime) => index 12 of the post-comm fields.
+	if len(fields) < 13 {
+		return 0, fmt.Errorf("driver: malformed proc stat: only %d fields after comm", len(fields))
+	}
+	utime, err := strconv.ParseInt(fields[11], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("driver: parse utime: %w", err)
+	}
+	stime, err := strconv.ParseInt(fields[12], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("driver: parse stime: %w", err)
+	}
+	return (utime + stime) * 1000 / userHZ, nil
+}
+
+// parseProcStatusPeakRSSMib extracts the VmHWM (peak resident set high-water
+// mark) line from /proc/<pid>/status, reported in kB, and returns it in MiB
+// (rounded down). VmHWM is kernel-maintained, so this needs no sampling loop.
+func parseProcStatusPeakRSSMib(data []byte) (int64, error) {
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, "VmHWM:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		// "VmHWM:" <number> "kB"
+		if len(fields) < 2 {
+			return 0, fmt.Errorf("driver: malformed VmHWM line: %q", line)
+		}
+		kb, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("driver: parse VmHWM: %w", err)
+		}
+		return kb / 1024, nil
+	}
+	return 0, fmt.Errorf("driver: no VmHWM line in proc status")
+}

--- a/projects/firecracker/substrate/node/fcvm/driver/gueststats_test.go
+++ b/projects/firecracker/substrate/node/fcvm/driver/gueststats_test.go
@@ -1,0 +1,77 @@
+package driver
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestParseProcStatCPUMillis(t *testing.T) {
+	// utime=55, stime=12 (fields 14,15) => 67 ticks => 670ms at USER_HZ=100.
+	line := []byte("1234 (firecracker) S 1 1234 1234 0 -1 4194304 100 0 0 0 55 12 0 0 20 0 5 0 100\n")
+	got, err := parseProcStatCPUMillis(line)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got != 670 {
+		t.Errorf("cpu_ms = %d, want 670", got)
+	}
+}
+
+func TestParseProcStatCPUMillisCommWithSpacesAndParens(t *testing.T) {
+	// The comm field can contain spaces and parens; parsing must key on the LAST
+	// ')', not the first, so utime/stime are still read correctly.
+	line := []byte("1234 ((odd) fire cracker) R 1 1234 1234 0 -1 4194304 7 0 0 0 30 10 0 0 20 0 4 0 9\n")
+	got, err := parseProcStatCPUMillis(line)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got != 400 { // (30+10)*10
+		t.Errorf("cpu_ms = %d, want 400", got)
+	}
+}
+
+func TestParseProcStatCPUMillisMalformed(t *testing.T) {
+	if _, err := parseProcStatCPUMillis([]byte("no parens here")); err == nil {
+		t.Error("want error on a line with no comm parens, got nil")
+	}
+	if _, err := parseProcStatCPUMillis([]byte("1 (x) S 1 2 3")); err == nil {
+		t.Error("want error when there are too few fields after comm, got nil")
+	}
+}
+
+func TestParseProcStatusPeakRSSMib(t *testing.T) {
+	status := []byte("Name:\tfirecracker\nState:\tS (sleeping)\nVmPeak:\t 600000 kB\nVmHWM:\t 524288 kB\nVmRSS:\t 400000 kB\n")
+	got, err := parseProcStatusPeakRSSMib(status)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got != 512 { // 524288 kB / 1024
+		t.Errorf("peak_rss_mib = %d, want 512", got)
+	}
+}
+
+func TestParseProcStatusPeakRSSMibMissing(t *testing.T) {
+	if _, err := parseProcStatusPeakRSSMib([]byte("Name:\tfirecracker\nVmRSS:\t 4 kB\n")); err == nil {
+		t.Error("want error when VmHWM line is absent, got nil")
+	}
+}
+
+// TestReadProcStatsSelf exercises the full /proc read against this test
+// process on linux, proving the file paths and parsing agree with a real
+// kernel. Skipped off linux (no /proc).
+func TestReadProcStatsSelf(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("proc stats only available on linux")
+	}
+	stats, err := readProcStats(os.Getpid())
+	if err != nil {
+		t.Fatalf("readProcStats(self): %v", err)
+	}
+	if stats.PeakRSSMib <= 0 {
+		t.Errorf("peak_rss_mib = %d, want > 0 for a running process", stats.PeakRSSMib)
+	}
+	if stats.CPUMillis < 0 { // may be 0 at 10ms granularity for a fast test
+		t.Errorf("cpu_ms = %d, want >= 0", stats.CPUMillis)
+	}
+}

--- a/projects/firecracker/substrate/node/fcvm/driver/launcher.go
+++ b/projects/firecracker/substrate/node/fcvm/driver/launcher.go
@@ -57,6 +57,14 @@ func (p *execProcess) Kill() error {
 
 func (p *execProcess) Wait() error { return p.cmd.Wait() }
 
+// Pid returns the OS pid of the firecracker process, or 0 before Start.
+func (p *execProcess) Pid() int {
+	if p.cmd == nil || p.cmd.Process == nil {
+		return 0
+	}
+	return p.cmd.Process.Pid
+}
+
 // Launch starts firecracker with its API socket at socketPath and blocks until
 // the socket is connectable (or the timeout/context fires).
 func (l *ExecLauncher) Launch(ctx context.Context, vmID, socketPath string) (Process, error) {

--- a/projects/firecracker/substrate/node/invoker/invoker.go
+++ b/projects/firecracker/substrate/node/invoker/invoker.go
@@ -57,6 +57,11 @@ type vmDriver interface {
 	// vsock device; the transport addresses the guest shim HTTP port relative
 	// to it.
 	VsockUDSPath(threadID string) string
+	// Stats reads the guest's host-side resource counters (whole-invocation CPU
+	// and peak RSS) from /proc. It must be called while the guest is still
+	// alive, i.e. before Release. Best-effort: the caller records the values on
+	// a span and continues on error.
+	Stats(h substrate.Handle) (substrate.GuestStats, error)
 }
 
 // transport is the host-side HTTP-over-vsock client. The real
@@ -546,6 +551,20 @@ func (inv *Invoker) ownResponse(ctx context.Context, resp *http.Response, td inv
 			td.egressCancel()
 			td.cancelRT()
 			_, releaseSpan := tracer.Start(ctx, "vm_release")
+			// Sample the guest's whole-invocation resource use from /proc BEFORE
+			// Release kills the process (afterwards /proc/<pid> is gone). Record
+			// it on vm_release: it is the live span here (fc_invoke and guest_exec
+			// have already ended by body Close), and it is where the values are
+			// queryable per invocation. Best-effort; a read failure just omits the
+			// attributes. These describe the whole invocation, not the release.
+			if stats, err := inv.driver.Stats(td.h); err == nil {
+				releaseSpan.SetAttributes(
+					attribute.Int64("fc.guest.cpu_ms", stats.CPUMillis),
+					attribute.Int64("fc.guest.peak_rss_mib", stats.PeakRSSMib),
+				)
+			} else {
+				inv.logger.Debug("invoker: guest stats unavailable", "thread", td.h.ThreadID, "err", err)
+			}
 			inv.releaseGuest(td.h)
 			releaseSpan.End()
 			// (b) VM memory reclaimed: free the slot now so the next queued

--- a/projects/firecracker/substrate/node/invoker/invoker_test.go
+++ b/projects/firecracker/substrate/node/invoker/invoker_test.go
@@ -32,6 +32,9 @@ type fakeDriver struct {
 	removedBundles   []string
 	snapshotBaseKeys []string
 
+	statsCalls        int  // number of Stats calls
+	statsAfterRelease bool // set if Stats was called after Release for a handle (a bug)
+
 	seq int // monotonic counter for generated threadIDs
 }
 
@@ -81,6 +84,27 @@ func (f *fakeDriver) RemoveBundle(threadID string) error {
 
 func (f *fakeDriver) VsockUDSPath(threadID string) string {
 	return "/fake/" + threadID + "/vsock.sock"
+}
+
+func (f *fakeDriver) Stats(h substrate.Handle) (substrate.GuestStats, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.statsCalls++
+	// Stats must be sampled while the guest is alive, i.e. BEFORE Release. Flag a
+	// violation if this handle was already released.
+	for _, r := range f.releaseHandles {
+		if r.ID == h.ID {
+			f.statsAfterRelease = true
+		}
+	}
+	return substrate.GuestStats{CPUMillis: 20, PeakRSSMib: 128}, nil
+}
+
+// statsCount returns the number of Stats calls recorded so far.
+func (f *fakeDriver) statsCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.statsCalls
 }
 
 // claimCount returns the number of Claim calls recorded so far.
@@ -294,6 +318,34 @@ func TestInvokeColdPathSkipsPrime(t *testing.T) {
 
 	if primeCount != 0 {
 		t.Errorf("Prime called %d time(s) on the cold path, want 0", primeCount)
+	}
+}
+
+// TestInvokeSamplesGuestStatsBeforeRelease verifies the teardown reads the
+// guest's resource counters (for the fc.guest.* span attributes) while the VM
+// is still alive, i.e. before Release kills the process. Sampling after Release
+// would read a dead /proc entry, so ordering is the correctness point.
+func TestInvokeSamplesGuestStatsBeforeRelease(t *testing.T) {
+	drv := &fakeDriver{}
+	tr := &funcTransport{}
+	inv := New(drv, tr, defaultConfig(), nil)
+
+	if err := inv.BuildBase(context.Background()); err != nil {
+		t.Fatalf("BuildBase: %v", err)
+	}
+	resp, err := inv.Invoke(context.Background(), "sess-1", strings.NewReader("body"))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	// Stats is sampled in the body-close teardown, just before Release.
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("resp.Body.Close: %v", err)
+	}
+	if got := drv.statsCount(); got < 1 {
+		t.Errorf("Stats called %d time(s), want >= 1 (sampled at teardown)", got)
+	}
+	if drv.statsAfterRelease {
+		t.Error("Stats was called after Release; it must sample the live guest before teardown")
 	}
 }
 

--- a/projects/firecracker/substrate/substrate/substrate.go
+++ b/projects/firecracker/substrate/substrate/substrate.go
@@ -58,6 +58,23 @@ type Handle struct {
 	Node string
 }
 
+// GuestStats is a host-side resource sample for one guest's firecracker
+// process, read from /proc just before the VM is torn down. Because each
+// invocation is a fresh single-use process (its CPU counter starts at zero at
+// Launch and its RSS high-water-mark accumulates over its whole life), these are
+// whole-invocation totals, not a windowed delta:
+//   - CPUMillis is the total user+system CPU consumed across all the process's
+//     threads (every vCPU plus VMM housekeeping) since Launch. CPUMillis/wall
+//     approximates the average cores used, so a value well above the wall time
+//     means the guest ran multi-core and a value near it means single-core.
+//   - PeakRSSMib is the kernel's peak resident set (VmHWM) for the process, an
+//     upper bound on the VM's host memory footprint (it blends per-VM dirtied
+//     pages with copy-on-write pages faulted in from the shared base snapshot).
+type GuestStats struct {
+	CPUMillis  int64
+	PeakRSSMib int64
+}
+
 // Request is a unit of work to run inside a claimed environment. Exec runs an
 // opaque process and streams its output; the harness (Claude CLI, Goose recipe)
 // is a property of the workload image, not the platform (ADR 019).


### PR DESCRIPTION
## What

Adds per-invocation resource usage to fc-invoke traces, closing the observability gap that made "how much CPU/RAM does a semgrep/python microVM actually use" unanswerable (`kubectl top` is pod-level: daemon + every live guest lumped together, and a sub-second scan is too transient to catch).

Two new attributes on the `vm_release` span:
- **`fc.guest.cpu_ms`** — `utime+stime` summed across all the firecracker process's threads (every vCPU + VMM). `cpu_ms / wall` ≈ **cores used**, so this directly answers "is the semgrep scan single- or multi-core" (→ right-size `vcpus`).
- **`fc.guest.peak_rss_mib`** — `VmHWM`, the kernel's peak-RSS high-water-mark (→ right-size `memMib`).

## How

- Sampled at **teardown, just before `Release`** kills the process (afterwards `/proc/<pid>` is gone). Recorded on `vm_release` because it's the live span at that point (`fc_invoke`/`guest_exec` have ended by body Close).
- **Whole-invocation totals with no bracket needed**: each invocation is a fresh single-use firecracker process, so its CPU counter starts at 0 at Launch and `VmHWM` is a kernel high-water-mark, both are single reads.
- New `Process.Pid()`, a `driver.Stats(handle)` reading `/proc/<pid>/{stat,status}` via testable parsers (robust to `comm` fields containing spaces/parens), and `GuestStats` placed in the `substrate` package so the invoker's narrow driver interface stays decoupled.
- **Best-effort**: a `/proc` read failure just omits the attributes; teardown proceeds.

## Notes
- `cpu_ms` is ~10ms (USER_HZ) granularity — coarse for a sub-20ms python run, fine for the semgrep/agent scans this is meant to size.
- Span attributes only (Option A). A follow-up can emit the same values as OTEL metric histograms (labeled by workload) for right-sizing dashboards; the span attributes are already ClickHouse-queryable for the distribution.

## Tests
- Parser units: `parseProcStatCPUMillis` (incl. comm-with-parens + malformed), `parseProcStatusPeakRSSMib` (incl. missing VmHWM), and a linux self-read.
- `TestInvokeSamplesGuestStatsBeforeRelease` locks the ordering invariant (sample the live guest before Release).

Bumps fc-invoke chart to 0.4.47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiToanX2G4tc8pZWEcwxQb