### PR TITLE
fix(fc-invoke): right-size sandbox and semgrep guests from measured stats

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.48
+version: 0.4.49

--- a/projects/firecracker/substrate/chart/values.yaml
+++ b/projects/firecracker/substrate/chart/values.yaml
@@ -142,9 +142,14 @@ workloads:
     image: semgrep-guest
     rootfsPath: /disks/nvme-02/fc-invoke/semgrep/rootfs.ext4
     harnessInit: /usr/local/bin/semgrep-guest-init
-    vcpus: 4
-    memMib: 2048
-    concurrency: 4
+    # Right-sized from measured per-invocation stats (fc.guest.* span attrs):
+    # single-file scans (the diff-hook usage) run single-core, and peak RSS is
+    # ~394Mi (dominated by the resident warmed LSP + rules, not file size). 1
+    # vcpu matches the observed 1 core; 768Mi is ~2x the scan peak, padded above
+    # 512 to cover the unmeasured rule-compile peak during base build.
+    vcpus: 1
+    memMib: 768
+    concurrency: 2
     egressEnabled: false
     warmBase: true
     readyPath: /shim/ready
@@ -181,8 +186,11 @@ workloads:
     image: sandbox-guest
     rootfsPath: /disks/nvme-02/fc-invoke/sandbox/rootfs.ext4
     harnessInit: /usr/local/bin/sandbox-guest-init
-    vcpus: 2
-    memMib: 2048
+    # Right-sized from measured per-invocation stats (fc.guest.* span attrs): a
+    # 600k-row pandas workload peaked at ~227Mi and stayed ~1 core, so 1 vcpu /
+    # 512Mi keeps ~2x headroom over the heaviest observed run.
+    vcpus: 1
+    memMib: 512
     concurrency: 2
     egressEnabled: false
     warmBase: true
@@ -191,18 +199,20 @@ workloads:
     requestTimeout: 30s
 
 # The limit must hold the capped peak of every workload's guests plus the
-# daemon. semgrep caps at concurrency 4 * 2Gi = 8Gi; agent caps at concurrency
-# 2 * 4Gi = 8Gi; sandbox caps at concurrency 2 * 2Gi = 4Gi; plus ~1Gi daemon
-# overhead = 21Gi if all three run at full tilt. Bursty: request a small floor,
-# let the limit cover the admission-capped peak. The per-workload concurrency
-# cap guarantees the cgroup never exceeds it, and oom_score_adj guarantees a
-# guest dies first if it nears (ADR platform/010).
+# daemon. After right-sizing from measured stats: semgrep caps at concurrency
+# 2 * 768Mi = 1.5Gi; agent at concurrency 2 * 4Gi = 8Gi; sandbox at concurrency
+# 2 * 512Mi = 1Gi; plus ~1Gi daemon overhead = ~11.5Gi if all three run at full
+# tilt, so 14Gi leaves headroom. Bursty: request a small floor, let the limit
+# cover the admission-capped peak (the firecracker guests are child processes in
+# this container's cgroup, so they count against this limit, not the request).
+# The per-workload concurrency cap guarantees the cgroup never exceeds it, and
+# oom_score_adj guarantees a guest dies first if it nears (ADR platform/010).
 resources:
   requests:
     cpu: 50m
     memory: 2Gi
   limits:
-    memory: 22Gi
+    memory: 14Gi
 
 # Firecracker substrate paths on node-4. Driving real microVMs (privileged +
 # these host mounts) is gated behind `firecracker.enabled`; until then the

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.48
+      targetRevision: 0.4.49
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## What

Right-sizes the two over-provisioned fc-invoke workloads using the per-invocation `fc.guest.*` span attributes added in #3320.

| workload | before | after | evidence |
|---|---|---|---|
| semgrep | 4 vcpu / 2048Mi / conc 4 | **1 vcpu / 768Mi / conc 2** | single-file scans (diff-hook usage) = ~1 core; peak RSS ~394Mi, file-size-independent |
| sandbox (python) | 2 vcpu / 2048Mi / conc 2 | **1 vcpu / 512Mi / conc 2** | 600k-row pandas run stayed ~1 core, peaked ~227Mi |
| daemon limit | 22Gi | **14Gi** | new peak ~11.5Gi (guests are child procs in the cgroup → count against the limit) |

## Why these exact numbers

- **1 vcpu each**: measured `cpu_ms / exec_wall ≈ 1.0-1.1` for both, even on a bigger semgrep file and a heavy pandas workload. Single-file diff-hook scans can't parallelize across files, so semgrep's 4 vcpus were idle.
- **semgrep 768, not 512**: the scan peak is 394Mi, but the memory high-water is likely the rule-compile during **base build** (in `BuildBase`, which the span instrumentation doesn't sample), so 768 pads ~2x above the measured scan peak as insurance against a base-build OOM.
- **sandbox 512**: ~2.3x headroom over the 227Mi pandas peak.

## Rollout monitoring

Cutting `memMib` re-sizes the memory-backend file, so the daemon **rebuilds each warm base snapshot** at the new size on rollout. The one thing to watch: the semgrep base build must succeed at 768Mi (if it OOMs, the daemon falls back to cold boots). I'll confirm the warm base builds and a live scan succeeds after the pod rolls; rollback is a one-line values revert.

Bumps fc-invoke chart to 0.4.49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiToanX2G4tc8pZWEcwxQb