### PR TITLE
fix(fc-invoke): raise semgrep guest to 1536Mi (768 OOM'd base build)

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.49
+version: 0.4.50

--- a/projects/firecracker/substrate/chart/values.yaml
+++ b/projects/firecracker/substrate/chart/values.yaml
@@ -143,12 +143,13 @@ workloads:
     rootfsPath: /disks/nvme-02/fc-invoke/semgrep/rootfs.ext4
     harnessInit: /usr/local/bin/semgrep-guest-init
     # Right-sized from measured per-invocation stats (fc.guest.* span attrs):
-    # single-file scans (the diff-hook usage) run single-core, and peak RSS is
-    # ~394Mi (dominated by the resident warmed LSP + rules, not file size). 1
-    # vcpu matches the observed 1 core; 768Mi is ~2x the scan peak, padded above
-    # 512 to cover the unmeasured rule-compile peak during base build.
+    # single-file scans (the diff-hook usage) run single-core, so 1 vcpu matches
+    # the observed 1 core. Memory is NOT sized to the steady scan (~394Mi): the
+    # high-water is the rule-compile during base build, where semgrep-core peaked
+    # at ~697Mi anon-rss (768Mi OOM-killed it in-guest on 0.4.49). 1536Mi clears
+    # that peak plus guest-OS overhead with headroom, still a 25% cut from 2048.
     vcpus: 1
-    memMib: 768
+    memMib: 1536
     concurrency: 2
     egressEnabled: false
     warmBase: true
@@ -200,8 +201,8 @@ workloads:
 
 # The limit must hold the capped peak of every workload's guests plus the
 # daemon. After right-sizing from measured stats: semgrep caps at concurrency
-# 2 * 768Mi = 1.5Gi; agent at concurrency 2 * 4Gi = 8Gi; sandbox at concurrency
-# 2 * 512Mi = 1Gi; plus ~1Gi daemon overhead = ~11.5Gi if all three run at full
+# 2 * 1536Mi = 3Gi; agent at concurrency 2 * 4Gi = 8Gi; sandbox at concurrency
+# 2 * 512Mi = 1Gi; plus ~1Gi daemon overhead = ~13Gi if all three run at full
 # tilt, so 14Gi leaves headroom. Bursty: request a small floor, let the limit
 # cover the admission-capped peak (the firecracker guests are child processes in
 # this container's cgroup, so they count against this limit, not the request).

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.49
+      targetRevision: 0.4.50
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## What

Follow-up to #3323. The 768Mi cut was too aggressive: on rollout, semgrep's `semgrep-core` was **OOM-killed inside the guest during base build** (rule compilation), so the warm base never built and semgrep fell back to cold boots.

```
Out of memory: Killed process 121 (semgrep-core) ... anon-rss:713412kB
```

## Root cause

Semgrep's memory high-water is the **rule-compile during base build (~697Mi anon)**, not the steady scan (~394Mi). My per-invocation `fc.guest.*` instrumentation samples `Invoke`, not `BuildBase`, so it never saw this peak, which is exactly the risk I called out in #3323 and under-padded (768 instead of enough).

## Fix

`semgrep memMib: 768 → 1536` — clears the observed ~697Mi warmup peak plus guest-OS overhead with headroom, still a **25% cut** from the original 2048. `vcpus: 1` and `concurrency: 2` stand (single-file scans are confirmed single-core). Daemon peak is now ~13Gi, so the 14Gi limit holds. Sandbox (512Mi) built fine and is untouched.

Caught by rollout monitoring as planned; no outage (cold-boot fallback kept semgrep serving, just slow).

Bumps fc-invoke chart to 0.4.50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiToanX2G4tc8pZWEcwxQb