### PR TITLE
fix(fcstory): repair mobile layout of the firecracker story

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.28
+version: 0.89.29
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.28
+      targetRevision: 0.89.29
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.77
+version: 0.285.78
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.77
+      targetRevision: 0.285.78
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/fcstory/FcScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/fcstory/FcScrollStory.svelte
@@ -137,7 +137,11 @@
   }
 
   function frame(t) {
-    topbarEl.classList.toggle("dim", t > 0.04 && t < 0.97);
+    // Fade the branding out the moment the reader scrolls off the hero, and
+    // keep it gone for the rest of the story and the replay section (it used
+    // to only dim to 0.3, then snap back to full opacity near the end and
+    // collide with the "Feel it. Restore one now." heading).
+    topbarEl.style.opacity = 1 - sub(t, 0.02, 0.06);
 
     const ho = 1 - sub(t, PHASES.heroOut[0], PHASES.heroOut[1]);
     heroEl.style.opacity = ho;
@@ -640,11 +644,6 @@
     color: var(--fc-ink);
     font-weight: 600;
   }
-  /* toggled imperatively via classList.toggle in frame(), not Svelte
-     class:, so the selector needs :global to survive scoped-CSS pruning */
-  .topbar:global(.dim) {
-    opacity: 0.3;
-  }
 
   /* ---------- scroll story ---------- */
   .scroller {
@@ -1146,48 +1145,101 @@
   }
 
   /* ---------- mobile ---------- */
+  /* A phone has one column, not three, so the desktop caption-left /
+     machine-right / track-bottom spread collapses into overlap. Stack the
+     story into three clear horizontal bands instead: the visual (machine or
+     chips) pinned to the top, the timing bars in the middle, and the
+     narration as a scrim'd bottom sheet so text never lands on top of the
+     machine or the bars behind it. */
   @media (max-width: 820px) {
-    .caption {
-      left: 6vw;
-      right: 6vw;
-      top: auto;
-      bottom: 18vh;
-      transform: none;
-      width: auto;
+    .hero h1 {
+      font-size: 44px;
     }
-    .caption h2 {
-      font-size: 26px;
-    }
+
+    /* visual (machine / chips) pinned to the top band */
     .machine {
-      right: 6vw;
-      left: 6vw;
-      top: 12vh;
+      right: 5vw;
+      left: 5vw;
+      top: 3vh;
       transform: none;
       width: auto;
     }
     .ram {
-      height: clamp(160px, 24vh, 240px);
+      height: clamp(118px, 14vh, 160px);
+    }
+    .disk {
+      margin-top: 16px;
+    }
+    .files {
+      gap: 12px;
+    }
+    .file {
+      padding: 11px 14px;
     }
     .chips {
-      right: 6vw;
-      left: 6vw;
-      top: 14vh;
+      right: 5vw;
+      left: 5vw;
+      top: 3vh;
       transform: none;
       width: auto;
       grid-template-columns: repeat(3, 1fr);
+      gap: 10px;
     }
+    .chip {
+      padding: 11px 12px;
+      font-size: 13px;
+    }
+
+    /* timing track sits below the machine, clear of the caption sheet */
     .track {
-      bottom: 3vh;
-      left: 6vw;
-      right: 6vw;
+      top: auto;
+      bottom: 33vh;
+      left: 5vw;
+      right: 5vw;
     }
+    .track .row {
+      margin-bottom: 12px;
+    }
+    .track .row-head .total {
+      font-size: 17px;
+    }
+    .barwrap {
+      height: 34px;
+    }
+
+    /* the magnifier inset has no room on a phone; the replay console below
+       shows the same per-phase breakdown */
     .zoom {
-      bottom: 104px;
-      right: 0;
-      width: min(340px, 88vw);
+      display: none;
     }
-    .hero h1 {
-      font-size: 44px;
+
+    /* caption becomes a bottom sheet with a scrim, so the narration never
+       collides with the machine or the bars behind it */
+    .caption {
+      left: 0;
+      right: 0;
+      bottom: 0;
+      top: auto;
+      transform: none;
+      width: auto;
+      max-height: 27vh;
+      overflow: hidden;
+      padding: 44px 5vw calc(4vh + 6px);
+      background: linear-gradient(
+        180deg,
+        transparent 0%,
+        var(--fc-ground) 24%,
+        var(--fc-ground) 100%
+      );
+    }
+    .caption h2 {
+      font-size: 22px;
+      margin-bottom: 8px;
+    }
+    .caption p {
+      font-size: 14.5px;
+      line-height: 1.45;
+      max-width: none;
     }
   }
 </style>

--- a/projects/monolith/frontend/src/lib/public/fcstory/reference-mockup.html
+++ b/projects/monolith/frontend/src/lib/public/fcstory/reference-mockup.html
@@ -61,9 +61,6 @@
     color: var(--ink);
     font-weight: 600;
   }
-  .topbar.dim {
-    opacity: 0.3;
-  }
 
   /* ---------- scroll story ---------- */
   .scroller {
@@ -693,47 +690,94 @@
 
   /* ---------- mobile ---------- */
   @media (max-width: 820px) {
-    .caption {
-      left: 6vw;
-      right: 6vw;
-      top: auto;
-      bottom: 18vh;
-      transform: none;
-      width: auto;
+    .hero h1 {
+      font-size: 44px;
     }
-    .caption h2 {
-      font-size: 26px;
-    }
+
+    /* visual (machine / chips) pinned to the top band */
     .machine {
-      right: 6vw;
-      left: 6vw;
-      top: 12vh;
+      right: 5vw;
+      left: 5vw;
+      top: 3vh;
       transform: none;
       width: auto;
     }
     .ram {
-      height: clamp(160px, 24vh, 240px);
+      height: clamp(118px, 14vh, 160px);
+    }
+    .disk {
+      margin-top: 16px;
+    }
+    .files {
+      gap: 12px;
+    }
+    .file {
+      padding: 11px 14px;
     }
     .chips {
-      right: 6vw;
-      left: 6vw;
-      top: 14vh;
+      right: 5vw;
+      left: 5vw;
+      top: 3vh;
       transform: none;
       width: auto;
       grid-template-columns: repeat(3, 1fr);
+      gap: 10px;
     }
+    .chip {
+      padding: 11px 12px;
+      font-size: 13px;
+    }
+
+    /* timing track sits below the machine, clear of the caption sheet */
     .track {
-      bottom: 3vh;
-      left: 6vw;
-      right: 6vw;
+      top: auto;
+      bottom: 33vh;
+      left: 5vw;
+      right: 5vw;
     }
+    .track .row {
+      margin-bottom: 12px;
+    }
+    .track .row-head .total {
+      font-size: 17px;
+    }
+    .barwrap {
+      height: 34px;
+    }
+
+    /* the magnifier inset has no room on a phone; the replay console below
+       shows the same per-phase breakdown */
     .zoom {
-      bottom: 104px;
-      right: 0;
-      width: min(340px, 88vw);
+      display: none;
     }
-    .hero h1 {
-      font-size: 44px;
+
+    /* caption becomes a bottom sheet with a scrim, so the narration never
+       collides with the machine or the bars behind it */
+    .caption {
+      left: 0;
+      right: 0;
+      bottom: 0;
+      top: auto;
+      transform: none;
+      width: auto;
+      max-height: 27vh;
+      overflow: hidden;
+      padding: 44px 5vw calc(4vh + 6px);
+      background: linear-gradient(
+        180deg,
+        transparent 0%,
+        var(--ground) 24%,
+        var(--ground) 100%
+      );
+    }
+    .caption h2 {
+      font-size: 22px;
+      margin-bottom: 8px;
+    }
+    .caption p {
+      font-size: 14.5px;
+      line-height: 1.45;
+      max-width: none;
     }
   }
 </style>
@@ -1254,7 +1298,7 @@
 
   function frame(t) {
     el.hud.textContent = "t " + t.toFixed(2);
-    el.topbar.classList.toggle("dim", t > 0.04 && t < 0.97);
+    el.topbar.style.opacity = 1 - seg(t, 0.02, 0.06);
 
     const ho = 1 - seg(t, P.heroOut[0], P.heroOut[1]);
     el.hero.style.opacity = ho;


### PR DESCRIPTION
## What

Fixes the mobile sizing and layout of the public `/app/firecracker` scroll story ("Boot once. Restore forever."). On a phone the elements were crowding and overlapping, and the branding topbar stayed visible while scrolling.

## Why

The story's desktop layout spreads three things across the viewport: the caption on the left, the machine (RAM panel + disk shelf) on the right, and the timing track along the bottom. On a phone that collapses into a single column, so the machine, the track, and the caption all competed for the same vertical space and overlapped (e.g. the caption paragraph landing on top of the "COLD: BUILD THE BASE SNAPSHOT" track label). Separately, the topbar only dimmed to 0.3 during the story and then snapped back to full opacity near the end, colliding with the "Feel it. Restore one now." replay heading.

## Changes

- **Topbar fades out on scroll.** As soon as the reader scrolls off the hero the `jomcgi.dev / firecracker` branding fades fully out and stays gone for the rest of the story and the replay section, instead of dimming and reappearing. Removed the now-unused `.dim` rule.
- **Mobile relayout into three clear bands.** The visual (machine or run chips) is pinned to the top, the timing bars sit in the middle, and the narration becomes a scrim'd bottom sheet, so text never lands on top of the machine or the bars behind it.
- **Right-sized the pieces to fit** a 390-wide phone: smaller RAM grid, tighter disk shelf and run chips, and the magnifier inset hidden on mobile (the replay console below already shows the same per-phase breakdown).
- Kept `reference-mockup.html` in sync with the Svelte port (the component is a faithful port of it).

## Verification

Rendered the reference mockup with headless Chromium at 390x844 across every scroll beat (hero, build, freeze, restore, repeat, replay). Confirmed: topbar gone on scroll, no caption/track/machine overlap in any phase, and the replay heading clear of the branding. Desktop layout is unchanged apart from the topbar now fading fully out rather than dimming.

Both `monolith` and `monolith-public` charts are bumped in this PR so the public page actually rolls out (per the public-tier checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcGRREcKVqetq8MCfM9WFb)_