### PR TITLE
feat(fc-invoke): sample base-build guest /proc stats

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.50
+version: 0.4.51

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.50
+      targetRevision: 0.4.51
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/firecracker/substrate/node/invoker/invoker.go
+++ b/projects/firecracker/substrate/node/invoker/invoker.go
@@ -217,6 +217,22 @@ func (inv *Invoker) BuildBase(ctx context.Context) error {
 	// No throughput concern here (no invocation slot rides on it), so tear down
 	// memory then disk synchronously.
 	defer func() {
+		// Sample the build guest's /proc high-water marks BEFORE releaseGuest
+		// kills the process (afterwards /proc/<pid> is gone). VmHWM is a peak, so
+		// this captures the transient rule-compile spike (the number that dictates
+		// memMib), not just the post-compile resident set the Invoke path sees.
+		// Stamp it on base_snapshot_build, which is still open here (this defer
+		// runs before buildSpan.End() by LIFO). Best-effort; a read failure just
+		// omits the attributes. Closes the base-build sampling blind spot so the
+		// next right-sizing reads the peak instead of discovering it via an OOM.
+		if stats, err := inv.driver.Stats(h); err == nil {
+			buildSpan.SetAttributes(
+				attribute.Int64("fc.guest.cpu_ms", stats.CPUMillis),
+				attribute.Int64("fc.guest.peak_rss_mib", stats.PeakRSSMib),
+			)
+		} else {
+			inv.logger.Debug("invoker: base build guest stats unavailable", "thread", h.ThreadID, "err", err)
+		}
 		inv.releaseGuest(h)
 		inv.removeGuestBundle(h.ThreadID)
 	}()

--- a/projects/firecracker/substrate/node/invoker/invoker_test.go
+++ b/projects/firecracker/substrate/node/invoker/invoker_test.go
@@ -349,6 +349,28 @@ func TestInvokeSamplesGuestStatsBeforeRelease(t *testing.T) {
 	}
 }
 
+// TestBuildBaseSamplesGuestStatsBeforeRelease verifies the base-build path also
+// samples the guest's /proc high-water marks (fc.guest.peak_rss_mib) before it
+// tears the build VM down. The base build's transient rule-compile peak is what
+// dictates memMib, so leaving it unsampled is the blind spot this closes.
+func TestBuildBaseSamplesGuestStatsBeforeRelease(t *testing.T) {
+	drv := &fakeDriver{}
+	tr := &funcTransport{}
+	inv := New(drv, tr, defaultConfig(), nil)
+
+	if err := inv.BuildBase(context.Background()); err != nil {
+		t.Fatalf("BuildBase: %v", err)
+	}
+	// The base build releases its VM synchronously in a defer; Stats is sampled
+	// in that same defer, just before releaseGuest.
+	if got := drv.statsCount(); got < 1 {
+		t.Errorf("Stats called %d time(s) during BuildBase, want >= 1 (base peak sampled)", got)
+	}
+	if drv.statsAfterRelease {
+		t.Error("Stats was called after Release in BuildBase; it must sample the live guest first")
+	}
+}
+
 // TestInvokeReleasesVMOnTransportError verifies that when RoundTrip fails the
 // VM is still Released and RemoveBundle is still called (defer fires), and that
 // the returned error is NOT a *GuestUnavailableError (it is a raw 502 error).


### PR DESCRIPTION
## What

`BuildBase` now samples the build guest's `/proc` high-water marks (`fc.guest.cpu_ms`, `fc.guest.peak_rss_mib`) before tearing the VM down, stamping them onto the `base_snapshot_build` span.

## Why

The Invoke teardown already samples guest stats in `vm_release`, but the base-build path did not. That left the base build's transient rule-compile peak, the number that actually dictates `memMib` (semgrep peaks at ~697 MiB during rule compile, then settles to ~394 MiB resident), invisible to telemetry. The last semgrep right-sizing had to discover it via a live OOM instead of reading it off a span.

`VmHWM` is a high-water mark, so sampling right before `releaseGuest` captures the compile spike even though the snapshot itself is taken after memory settles.

## Effect

The next right-sizing reads the base peak directly off SigNoz, turning the two-cycle correction (size, OOM, correct) into one.

Part 1 of 2 from the fc-invoke right-sizing follow-up. Part 2 (two-stage base build to actually decouple base-build size from the steady-state restore ceiling) is a larger, ADR-gated change tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)