### PR TITLE
fix(grimoire): sweep highlights, harden corpus panel, drop "shelf" copy

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.50
+version: 0.4.51

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.50
+      targetRevision: 0.4.51
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/firecracker/substrate/node/invoker/invoker.go
+++ b/projects/firecracker/substrate/node/invoker/invoker.go
@@ -217,6 +217,22 @@ func (inv *Invoker) BuildBase(ctx context.Context) error {
 	// No throughput concern here (no invocation slot rides on it), so tear down
 	// memory then disk synchronously.
 	defer func() {
+		// Sample the build guest's /proc high-water marks BEFORE releaseGuest
+		// kills the process (afterwards /proc/<pid> is gone). VmHWM is a peak, so
+		// this captures the transient rule-compile spike (the number that dictates
+		// memMib), not just the post-compile resident set the Invoke path sees.
+		// Stamp it on base_snapshot_build, which is still open here (this defer
+		// runs before buildSpan.End() by LIFO). Best-effort; a read failure just
+		// omits the attributes. Closes the base-build sampling blind spot so the
+		// next right-sizing reads the peak instead of discovering it via an OOM.
+		if stats, err := inv.driver.Stats(h); err == nil {
+			buildSpan.SetAttributes(
+				attribute.Int64("fc.guest.cpu_ms", stats.CPUMillis),
+				attribute.Int64("fc.guest.peak_rss_mib", stats.PeakRSSMib),
+			)
+		} else {
+			inv.logger.Debug("invoker: base build guest stats unavailable", "thread", h.ThreadID, "err", err)
+		}
 		inv.releaseGuest(h)
 		inv.removeGuestBundle(h.ThreadID)
 	}()

--- a/projects/firecracker/substrate/node/invoker/invoker_test.go
+++ b/projects/firecracker/substrate/node/invoker/invoker_test.go
@@ -349,6 +349,28 @@ func TestInvokeSamplesGuestStatsBeforeRelease(t *testing.T) {
 	}
 }
 
+// TestBuildBaseSamplesGuestStatsBeforeRelease verifies the base-build path also
+// samples the guest's /proc high-water marks (fc.guest.peak_rss_mib) before it
+// tears the build VM down. The base build's transient rule-compile peak is what
+// dictates memMib, so leaving it unsampled is the blind spot this closes.
+func TestBuildBaseSamplesGuestStatsBeforeRelease(t *testing.T) {
+	drv := &fakeDriver{}
+	tr := &funcTransport{}
+	inv := New(drv, tr, defaultConfig(), nil)
+
+	if err := inv.BuildBase(context.Background()); err != nil {
+		t.Fatalf("BuildBase: %v", err)
+	}
+	// The base build releases its VM synchronously in a defer; Stats is sampled
+	// in that same defer, just before releaseGuest.
+	if got := drv.statsCount(); got < 1 {
+		t.Errorf("Stats called %d time(s) during BuildBase, want >= 1 (base peak sampled)", got)
+	}
+	if drv.statsAfterRelease {
+		t.Error("Stats was called after Release in BuildBase; it must sample the live guest first")
+	}
+}
+
 // TestInvokeReleasesVMOnTransportError verifies that when RoundTrip fails the
 // VM is still Released and RemoveBundle is still called (defer fires), and that
 // the returned error is NOT a *GuestUnavailableError (it is a raw 502 error).

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.29
+version: 0.89.30
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.29
+      targetRevision: 0.89.30
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.78
+version: 0.285.79
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.78
+      targetRevision: 0.285.79
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
@@ -559,16 +559,34 @@
     });
     chunksWrapEl.style.visibility = cardsOut >= 1 ? "hidden" : "visible";
 
-    // mention marks tint at the start of the entities phase
-    const pMark = ease(sub(t, 0.44, 0.48));
-    markEls.forEach((m) => {
+    // Marks highlight like a hand sweeping a marker across each phrase: a
+    // left-to-right fill wipe, staggered in DOM order (top-to-bottom, then
+    // left-to-right down the cards) so the whole page reads as being
+    // highlighted by hand. The tail of the sweep overlaps the card lift-off
+    // (cardsOut, 0.5-0.58) on purpose: the lower phrases are still being
+    // marked as their cards begin to fly away.
+    const HL_START = 0.435; // first phrase begins
+    const HL_STAGGER = 0.085; // spread of start times across all marks
+    const HL_FILL = 0.05; // each phrase's own swipe duration
+    const nMark = markEls.length;
+    markEls.forEach((m, i) => {
       const c = m.dataset.c;
-      m.style.background =
-        pMark > 0
-          ? `color-mix(in srgb, ${c} ${Math.round(pMark * 22)}%, transparent)`
-          : "transparent";
-      m.style.color = pMark > 0.5 ? c : "inherit";
-      m.style.fontWeight = pMark > 0.5 ? "700" : "inherit";
+      const frac = nMark > 1 ? i / (nMark - 1) : 0;
+      const from = HL_START + frac * HL_STAGGER;
+      const pen = sub(t, from, from + HL_FILL); // 0..1 swipe for this phrase
+      if (pen <= 0) {
+        m.style.background = "transparent";
+        m.style.color = "inherit";
+        m.style.fontWeight = "inherit";
+        return;
+      }
+      const pct = pen * 100;
+      const tint = `color-mix(in srgb, ${c} 26%, transparent)`;
+      // hard trailing edge with a small feather ahead of it = a marker tip
+      // leading the fill from the left
+      m.style.background = `linear-gradient(90deg, ${tint} ${pct.toFixed(1)}%, transparent ${Math.min(100, pct + 5).toFixed(1)}%)`;
+      m.style.color = pen > 0.55 ? c : "inherit";
+      m.style.fontWeight = pen > 0.55 ? "700" : "inherit";
     });
 
     // chips fly from the card column to their graph nodes; edges draw in
@@ -974,14 +992,16 @@
       </div>
 
       <div class="scale-panel" bind:this={scalePanelEl}>
-        <div class="scale-head grim-title">One page in. The whole shelf follows.</div>
+        <div class="scale-head grim-title">One page in. Here's everything behind it.</div>
         <div class="this-page">
-          <span class="k">THIS PAGE</span>
+          <span class="k">THIS PAGE EXTRACTED</span>
           <span>{story.bboxes.length} blocks</span><span class="k">/</span>
           <span>{story.chunks.length} chunks</span><span class="k">/</span>
           <span>{story.entities.length} entities</span><span class="k">/</span>
           <span>{graphEdges.length} relationships</span>
-          <span class="arrow">&darr;</span><span class="k">THE SHELF</span>
+        </div>
+        <div class="project-lead">
+          <span class="arrow">&darr;</span> Our project contains
         </div>
         <div class="counters">
           {#each COUNTS as [label], i (label)}
@@ -1147,7 +1167,7 @@
     </section>
 
     <section class="static-scene">
-      <p class="static-cap"><b>4 / The whole shelf.</b> You just watched one page. Every book on the shelf gets the same treatment.</p>
+      <p class="static-cap"><b>4 / The whole project.</b> You just watched one page. Every book in the corpus gets the same treatment.</p>
       <div class="static-counters">
         {#each COUNTS as [label, value] (label)}
           <div class="counter">
@@ -1592,8 +1612,10 @@
     width: min(92vw, 860px);
     padding: 24px 28px 22px;
     border-radius: 18px;
-    background: color-mix(in srgb, var(--grim-paper) 78%, transparent);
-    backdrop-filter: blur(3px);
+    background: color-mix(in srgb, var(--grim-paper) 94%, transparent);
+    backdrop-filter: blur(8px);
+    border: 1px solid var(--grim-line);
+    box-shadow: 0 12px 44px rgba(10, 14, 22, 0.16);
     pointer-events: none;
   }
   .chat-head {
@@ -1609,6 +1631,7 @@
   .this-page {
     margin-top: 18px;
     font-size: 14px;
+    font-weight: 600;
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--grim-ink);
@@ -1624,9 +1647,18 @@
     font-weight: 700;
     font-size: 12px;
   }
-  .this-page .arrow {
+  .project-lead {
+    margin-top: 14px;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--grim-ink);
+  }
+  .project-lead .arrow {
     color: var(--grim-accent);
-    font-size: 14px;
+    margin-right: 4px;
   }
   .counters {
     display: flex;
@@ -1645,8 +1677,9 @@
     color: var(--grim-ink);
   }
   .counter .l {
-    font-size: 12.5px;
-    letter-spacing: 0.2em;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
     color: var(--grim-ink);
     margin-top: 6px;
@@ -1681,7 +1714,7 @@
   .tchip .n {
     color: var(--grim-ink);
     font-variant-numeric: tabular-nums;
-    font-weight: 500;
+    font-weight: 700;
   }
 
   .chat-sub {

--- a/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/timeline.js
+++ b/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/timeline.js
@@ -65,7 +65,7 @@ export const PHASES = [
     end: 0.82,
     hold: 0.76,
     rest: 0.79,
-    label: "SHELF",
+    label: "PROJECT",
   },
   { id: "chat", start: 0.82, end: 1.0, hold: 0.97, rest: 1.0, label: "ASK" },
 ];


### PR DESCRIPTION
Polish pass on the public `/app/grimoire` scroll-story landing, from a live screenshot review.

## 1. Highlights sweep like a hand marking the page
The entity marks used to tint uniformly in one step. Now each phrase fills **left-to-right** (a gradient pen wipe), staggered in DOM order so the highlighting flows **top-to-bottom, then left-to-right** down the cards. The tail of the sweep deliberately overlaps the card lift-off, so the lower phrases are still being marked as their cards fly away toward the entity graph.

## 2. Corpus scale panel is legible now
The panel was 78% paper over the confetti field, so the dots bled through and washed out the small mono text. It is now a near-solid card (94% + blur + border + shadow), and the `THIS PAGE` line, counter labels, and type-pill counts are thickened (weight 700, tighter tracking).

## 3. "Shelf" metaphor is gone
- Headline: "One page in. The whole shelf follows." -> "One page in. Here's everything behind it."
- Transition copy: `THIS PAGE` -> `THIS PAGE EXTRACTED`; `↓ THE SHELF` -> `↓ Our project contains`
- Static (no-JS) fallback caption updated
- Progress-rail label: `SHELF` -> `PROJECT`

## Verification
Verified locally against the dev server with a Playwright scroll-fraction capture loop at the entities phase (t≈0.47-0.52) and the scale phase (t≈0.73-0.77). The pen wipe reads correctly mid-stroke (words half-highlighted as the sweep crosses them) and the panel text is crisp over the confetti.

Chart bumps for both public-serving tiers (monolith + monolith-public) included so the change actually rolls out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)