### PR TITLE
fix(grimoire): compress highlight sweep, stop the font-weight reflow

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.30
+version: 0.89.31
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.30
+      targetRevision: 0.89.31
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.79
+version: 0.285.80
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.79
+      targetRevision: 0.285.80
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
@@ -561,13 +561,15 @@
 
     // Marks highlight like a hand sweeping a marker across each phrase: a
     // left-to-right fill wipe, staggered in DOM order (top-to-bottom, then
-    // left-to-right down the cards) so the whole page reads as being
-    // highlighted by hand. The tail of the sweep overlaps the card lift-off
-    // (cardsOut, 0.5-0.58) on purpose: the lower phrases are still being
-    // marked as their cards begin to fly away.
-    const HL_START = 0.435; // first phrase begins
-    const HL_STAGGER = 0.085; // spread of start times across all marks
-    const HL_FILL = 0.05; // each phrase's own swipe duration
+    // left-to-right down the cards). The whole sweep is compressed to finish
+    // by ~0.515, just as the cards begin to lift off (cardsOut starts at 0.5),
+    // so every phrase is fully marked before its card flies away. We only
+    // animate paint properties (background + color): font-weight is NOT
+    // touched, because changing weight reflows the glyphs and makes the text
+    // visibly jump/grow as each word highlights.
+    const HL_START = 0.44; // first phrase begins
+    const HL_STAGGER = 0.045; // spread of start times across all marks
+    const HL_FILL = 0.03; // each phrase's own (fast) swipe duration
     const nMark = markEls.length;
     markEls.forEach((m, i) => {
       const c = m.dataset.c;
@@ -577,7 +579,6 @@
       if (pen <= 0) {
         m.style.background = "transparent";
         m.style.color = "inherit";
-        m.style.fontWeight = "inherit";
         return;
       }
       const pct = pen * 100;
@@ -585,8 +586,7 @@
       // hard trailing edge with a small feather ahead of it = a marker tip
       // leading the fill from the left
       m.style.background = `linear-gradient(90deg, ${tint} ${pct.toFixed(1)}%, transparent ${Math.min(100, pct + 5).toFixed(1)}%)`;
-      m.style.color = pen > 0.55 ? c : "inherit";
-      m.style.fontWeight = pen > 0.55 ? "700" : "inherit";
+      m.style.color = pen > 0.5 ? c : "inherit";
     });
 
     // chips fly from the card column to their graph nodes; edges draw in


### PR DESCRIPTION
Follow-up polish on the entity-highlight sweep (PR #3329), from Joe's live review.

## 1. Text no longer jumps/grows as it highlights
The marks flipped to `font-weight: 700` at the midpoint of their fill. Weight is a reflow-triggering property (bold glyphs are wider), so each word visibly shifted and looked bigger the instant it highlighted. Now only paint properties animate: the left-to-right background gradient and the text color. No reflow.

## 2. Highlight finishes before the cards fly off
The sweep ran to ~0.57, but the cards begin their fly-out at t=0.50 and are gone by 0.58, so the lower cards faded away mid-highlight. The sweep is compressed (`HL_START 0.44`, `HL_STAGGER 0.045`, `HL_FILL 0.03`) to complete by ~0.515 — every phrase is fully marked while its card is still on screen, then the cards leave fully highlighted.

## Verification
Playwright scroll-fraction capture: at t=0.51 all cards top-to-bottom are highlighted and still in place (only the chips have started flying); by t=0.55 the cards have flown out fully marked. Marks render at the same weight as surrounding text (no bold).

Chart bumps for both public tiers (monolith 0.285.80, monolith-public 0.89.31) included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)