### PR TITLE
fix(monolith): re-pin charts after fcstory image-pin race

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.31
+version: 0.89.32
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.31
+      targetRevision: 0.89.32
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.80
+version: 0.285.81
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.80
+      targetRevision: 0.285.81
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Recovery for a build-time image-pin race.

The fcstory mobile-fix merge (#3328) landed ~5s after an unrelated grimoire PR. Its `helm_images_values` pin resolved the image that existed at chart-build time (`2026.07.09.14.05.45-f7f1bec`, the grimoire image) rather than its own (`2026.07.09.14.06.01-9735403`), which finished building ~16s later. Result: chart `0.89.31` / `0.285.80` deployed `Synced/Healthy` but running the previous frontend, so `/app/firecracker` still serves the pre-fix page (no `<title>`, old `svelte-ue7qe5` scope hash).

The fix source is already on `main`. This PR only bumps `monolith-public` `0.89.31 → 0.89.32` and `monolith` `0.285.80 → 0.285.81` so CI republishes the charts pinning an image that contains the fcstory change. Verified after merge by confirming the pinned tag is `…-9735403` (or newer) and the live SSR HTML carries the new `<title>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)