### PR TITLE
feat(fcstory): link topbar wordmark back to the homepage

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.32
+version: 0.89.33
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.32
+      targetRevision: 0.89.33
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.81
+version: 0.285.82
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.81
+      targetRevision: 0.285.82
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/fcstory/FcScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/fcstory/FcScrollStory.svelte
@@ -62,7 +62,7 @@
 
   // ── Plain (non-reactive) per-frame refs ──
   let scrollerEl, stageEl, machineEl, cellsEl, ramGlowEl;
-  let heroEl, topbarEl;
+  let heroEl, topbarEl, brandEl;
   let capBootEl, capFreezeEl, capRestoreEl, capRepeatEl;
   let vmEl, vmstateEl, diskEl, fileMemEl, fileVmsEl, fillMemEl, fillVmsEl;
   let trackEl, coldBarEl, coldTotalEl, restoreRowEl, restoreBarEl, zoomEl;
@@ -153,7 +153,12 @@
     // keep it gone for the rest of the story and the replay section (it used
     // to only dim to 0.3, then snap back to full opacity near the end and
     // collide with the "Feel it. Restore one now." heading).
-    topbarEl.style.opacity = 1 - sub(t, 0.02, 0.06);
+    const topbarO = 1 - sub(t, 0.02, 0.06);
+    topbarEl.style.opacity = topbarO;
+    // The home link is the only interactive thing in the (pointer-events:none)
+    // topbar; disable it once the bar has faded so it is never an invisible
+    // click target over the story.
+    brandEl.style.pointerEvents = topbarO > 0.5 ? "auto" : "none";
 
     const ho = 1 - sub(t, PHASES.heroOut[0], PHASES.heroOut[1]);
     heroEl.style.opacity = ho;
@@ -335,7 +340,11 @@
 
 <div class="fcstory">
   <header class="topbar" bind:this={topbarEl}>
-    <span><strong>jomcgi.dev</strong> / firecracker</span>
+    <span
+      ><a class="brand" href="/" bind:this={brandEl}
+        ><strong>jomcgi.dev</strong></a
+      > / firecracker</span
+    >
   </header>
 
   <!-- ==================== SCROLL STORY ==================== -->
@@ -675,6 +684,22 @@
   .topbar strong {
     color: var(--fc-ink);
     font-weight: 600;
+  }
+  /* The wordmark links home. The topbar itself stays pointer-events:none so it
+     never intercepts the scroll story; only this link opts back in. */
+  .topbar .brand {
+    pointer-events: auto;
+    color: inherit;
+    text-decoration: none;
+    border-radius: 4px;
+  }
+  .topbar .brand:hover strong {
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+  .topbar .brand:focus-visible {
+    outline: 2px solid var(--fc-ember-deep);
+    outline-offset: 3px;
   }
 
   /* ---------- scroll story ---------- */


### PR DESCRIPTION
Fast-follow to the mobile fix: make the top-left `jomcgi.dev` wordmark a home link.

- `jomcgi.dev` is now `<a href="/">`; `/ firecracker` stays as muted current-page context. Hover underlines just the wordmark.
- The topbar keeps `pointer-events: none` so it never intercepts the scroll-story gestures; only the link opts back in via `pointer-events: auto`.
- The frame loop disables the link once the topbar fades (same opacity threshold), so it's never an invisible click target over the story.
- Plain `<a>`, so it works with no JS and in reduced-motion (where the topbar doesn't fade).

Verified locally with a dev-server render: link resolves `href="/"`, text `jomcgi.dev`, `pointer-events: auto` while visible, wordmark reads `jomcgi.dev / firecracker` with spacing intact, hover underlines only the wordmark.

Bumps `monolith-public 0.89.33` and `monolith 0.285.82` so it deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)