### PR TITLE
fix(grimoire): fantasy compendium copy, two-block panel, punchier entity palette

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.33
+version: 0.89.34
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.33
+      targetRevision: 0.89.34
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.82
+version: 0.285.83
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.82
+      targetRevision: 0.285.83
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/grimoire/theme.css
+++ b/projects/monolith/frontend/src/lib/grimoire/theme.css
@@ -50,16 +50,16 @@
 
   /* Entity-type accent colors: used by Entities rows, statblocks, and the
    * Explore canvas to give each entity type a stable, distinct hue. */
-  --grim-type-location: #2f8f6b;
-  --grim-type-creature: #c0492b;
-  --grim-type-npc: #b07d1e;
-  --grim-type-faction: #7a52b0;
-  --grim-type-deity: #a8811f;
-  --grim-type-item: #b83f7a;
-  --grim-type-spell: #2f7fbf;
-  --grim-type-class: #556070;
-  --grim-type-event: #7a6f3a;
-  --grim-type-quest: #2f8f8a;
+  --grim-type-location: #0f9e63;
+  --grim-type-creature: #db3b1c;
+  --grim-type-npc: #c98a08;
+  --grim-type-faction: #8636d4;
+  --grim-type-deity: #c1920c;
+  --grim-type-item: #d92878;
+  --grim-type-spell: #1487e0;
+  --grim-type-class: #566484;
+  --grim-type-event: #9a7d10;
+  --grim-type-quest: #0f9e97;
   /* Mechanics types share the slate "class" hue (one family). Defined as
      aliases so they resolve to --grim-type-class without repeating the
      value below. */

--- a/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
@@ -582,7 +582,7 @@
         return;
       }
       const pct = pen * 100;
-      const tint = `color-mix(in srgb, ${c} 26%, transparent)`;
+      const tint = `color-mix(in srgb, ${c} 34%, transparent)`;
       // hard trailing edge with a small feather ahead of it = a marker tip
       // leading the fill from the left
       m.style.background = `linear-gradient(90deg, ${tint} ${pct.toFixed(1)}%, transparent ${Math.min(100, pct + 5).toFixed(1)}%)`;
@@ -992,16 +992,15 @@
       </div>
 
       <div class="scale-panel" bind:this={scalePanelEl}>
-        <div class="scale-head grim-title">One page in. Here's everything behind it.</div>
+        <div class="scale-head grim-title section-head">Unearthed from this page</div>
         <div class="this-page">
-          <span class="k">THIS PAGE EXTRACTED</span>
           <span>{story.bboxes.length} blocks</span><span class="k">/</span>
           <span>{story.chunks.length} chunks</span><span class="k">/</span>
           <span>{story.entities.length} entities</span><span class="k">/</span>
           <span>{graphEdges.length} relationships</span>
         </div>
-        <div class="project-lead">
-          <span class="arrow">&darr;</span> Our project contains
+        <div class="scale-head grim-title section-head compendium-head">
+          The entire compendium contains
         </div>
         <div class="counters">
           {#each COUNTS as [label], i (label)}
@@ -1167,7 +1166,7 @@
     </section>
 
     <section class="static-scene">
-      <p class="static-cap"><b>4 / The whole project.</b> You just watched one page. Every book in the corpus gets the same treatment.</p>
+      <p class="static-cap"><b>4 / The entire compendium.</b> You just watched a single page unearthed. Every book in the compendium gets the same treatment.</p>
       <div class="static-counters">
         {#each COUNTS as [label, value] (label)}
           <div class="counter">
@@ -1628,8 +1627,18 @@
     text-wrap: balance;
     color: var(--grim-ink);
   }
+  /* The two panel hooks ("Unearthed from this page" / "The entire compendium
+     contains") are one matched pair: a repeated [heading -> counts] rhythm.
+     Sized below the 40px hero scale so both headings can breathe and the big
+     corpus numbers stay the loudest element. */
+  .section-head {
+    font-size: clamp(21px, 2.6vw, 32px);
+  }
+  .compendium-head {
+    margin-top: 34px;
+  }
   .this-page {
-    margin-top: 18px;
+    margin-top: 10px;
     font-size: 14px;
     font-weight: 600;
     letter-spacing: 0.14em;
@@ -1647,24 +1656,11 @@
     font-weight: 700;
     font-size: 12px;
   }
-  .project-lead {
-    margin-top: 14px;
-    font-family: var(--font-mono);
-    font-size: 13px;
-    font-weight: 700;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    color: var(--grim-ink);
-  }
-  .project-lead .arrow {
-    color: var(--grim-accent);
-    margin-right: 4px;
-  }
   .counters {
     display: flex;
     justify-content: center;
     gap: clamp(18px, 4.5vw, 58px);
-    margin-top: 18px;
+    margin-top: 14px;
   }
   .counter {
     text-align: center;

--- a/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/timeline.js
+++ b/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/timeline.js
@@ -65,7 +65,7 @@ export const PHASES = [
     end: 0.82,
     hold: 0.76,
     rest: 0.79,
-    label: "PROJECT",
+    label: "COMPENDIUM",
   },
   { id: "chat", start: 0.82, end: 1.0, hold: 0.97, rest: 1.0, label: "ASK" },
 ];


### PR DESCRIPTION
From Joe's copy + colour review of the `/app/grimoire` scale scene.

## Copy + layout
Two matched `[heading -> counts]` blocks with one shared section-head size, so the rhythm repeats and the big corpus numbers stay the loudest element:
- **"Unearthed from this page"** + the per-page counts
- **"The entire compendium contains"** + the corpus counters + type pills

Dropped the standalone "One page in..." headline and the tiny `THIS PAGE EXTRACTED` / `OUR PROJECT CONTAINS` mono labels. Fantasy voice throughout: rail label `PROJECT -> COMPENDIUM`, static fallback caption reworded.

## Colour (more engaging entities/highlighting)
- Punched up the `--grim-type-*` palette: more saturated hues at similar lightness so entity-name text stays legible on light paper.
- Raised the chunk-card highlight tint `26% -> 34%` so the marker fill actually reads (the hue change is invisible at 26%).

**Site-wide note:** the `--grim-type-*` tokens key every entity-typed surface — highlights, pills, constellation dots, the Explore graph, Entities rows, statblocks. So this recolours the whole Grimoire app, not just the landing. The **Visual regression** check on this PR will render before/after for every changed public page so you can preview the recolour; easy to dial the saturation up or down from there.

Verified locally with the Playwright scroll-fraction capture (highlight + scale scenes); entity-colour text remains readable over the stronger tint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)