### PR TITLE
fix(grimoire): keep highlighted text ink, not the entity hue

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.35
+version: 0.89.36
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.35
+      targetRevision: 0.89.36
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.84
+version: 0.285.85
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.84
+      targetRevision: 0.285.85
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
@@ -584,9 +584,10 @@
       const pct = pen * 100;
       const tint = `color-mix(in srgb, ${c} 34%, transparent)`;
       // hard trailing edge with a small feather ahead of it = a marker tip
-      // leading the fill from the left
+      // leading the fill from the left. The text stays ink (never recoloured to
+      // the entity hue): a real highlighter is dark text on a colour fill, and
+      // same-hue text on a same-hue tint is low-contrast and hard to read.
       m.style.background = `linear-gradient(90deg, ${tint} ${pct.toFixed(1)}%, transparent ${Math.min(100, pct + 5).toFixed(1)}%)`;
-      m.style.color = pen > 0.5 ? c : "inherit";
     });
 
     // chips fly from the card column to their graph nodes; edges draw in


### PR DESCRIPTION
Follow-up to the palette PR (#3333). The chunk-card highlight marks recoloured their text to the entity hue at the midpoint of the fill, so coloured text ended up on a same-hue tint and blended, hard to read.

A real highlighter is dark text on a colour fill. This drops the text recolour so marks keep ink text over the (vivid) tint, maximum luminance contrast, fully legible, while the engaging colours stay.

Verified locally with the Playwright scroll-fraction capture. Chart bumps for both public tiers included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)