### PR TITLE
feat(grimoire): Library filter + ungate Library/reader, soften copyright copy

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.36
+version: 0.89.37
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.36
+      targetRevision: 0.89.37
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.85
+version: 0.285.86
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.85
+      targetRevision: 0.285.86
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
@@ -1,13 +1,14 @@
 <script>
   // Public Grimoire app shell: a slim app-own topbar (wordmark + Library /
-  // Entities nav) and a Turnstile gate around the app content. The gate is a
-  // real admission boundary, not decoration: children (and therefore every
-  // /api/grimoire fetch) only mount after onAdmitted fires, so the WotC-
-  // copyrighted corpus never reaches an unsolved visitor or a crawler. The
-  // one exception is the static homepage at the app root (see isHome below),
-  // which carries no corpus content and no fetches. No site Nav/Footer: this
-  // is a standalone shareable app, not a page of the portfolio site. noindex
-  // keeps it out of search entirely (copyright mitigation) regardless of
+  // Entities nav) and a Turnstile gate around the derived-corpus surfaces
+  // (Entities, Explore, Chat, adventure detail): those only mount after
+  // onAdmitted fires. The gate no longer wraps the Library or the reader:
+  // the Library serves only book metadata plus open-licensed full text, and
+  // the reader serves only open-licensed books (copyrighted books 403 and
+  // show a locked notice), so neither carries gated corpus (see isUngated
+  // below). The static homepage at the app root is ungated too. No site
+  // Nav/Footer: this is a standalone shareable app, not a page of the
+  // portfolio site. noindex keeps the whole tree out of search regardless of
   // admission state.
   import { page } from "$app/stores";
   import TurnstileGate from "$lib/public/components/TurnstileGate.svelte";
@@ -25,10 +26,22 @@
   let admitted = $state(false);
 
   // The homepage at the app root is a static pitch page: no corpus content,
-  // no /api/grimoire fetches, so it renders OUTSIDE the Turnstile gate. The
-  // gate exists to keep the copyrighted corpus from bots, not the product
-  // description; every other route (library, reader, entities) stays gated.
+  // no /api/grimoire fetches, so it renders OUTSIDE the Turnstile gate.
   const isHome = $derived(($page.route.id ?? "") === "/public/app/grimoire");
+
+  // Routes that render outside the gate: the homepage, the Library (book list
+  // + counts + open-licensed reader links), and the reader itself under
+  // /book/* (serves only open-licensed text; copyrighted books 403). The gate
+  // now protects only the derived-corpus surfaces (Entities, Explore, Chat,
+  // adventure detail), which is where the whole corpus is surfaced.
+  const isUngated = $derived.by(() => {
+    const id = $page.route.id ?? "";
+    return (
+      isHome ||
+      id === "/public/app/grimoire/library" ||
+      id.startsWith("/public/app/grimoire/book/")
+    );
+  });
 
   // Highlight the active topbar link: the entities index and entity detail
   // pages both count as "entities"; the EXPLORE canvas is its own section;
@@ -50,9 +63,8 @@
     name="description"
     content="A read-only, link-shareable D&D sourcebook library: browse loaded books, read chunk by chunk, and look up creatures and lore."
   />
-  <!-- Link-shareable, not crawlable: the corpus is WotC-copyrighted, so this
-       route is deliberately excluded from indexing and never added to
-       sitemap.xml or a robots.txt allow. -->
+  <!-- Link-shareable, not crawlable: the whole app tree is kept out of search
+       and off sitemap.xml / a robots.txt allow, regardless of admission. -->
   <meta name="robots" content="noindex, nofollow" />
 </svelte:head>
 
@@ -83,17 +95,16 @@
   </header>
 
   <main class="grimoire-shell">
-  {#if isHome || admitted}
+  {#if isUngated || admitted}
     {@render children()}
   {:else}
     <div class="wrap-narrow gate">
       <p class="gate-eyebrow">Grimoire Access</p>
       <h1 class="grim-title gate-title">
-        solve to <span class="gate-accent">read.</span>
+        solve to <span class="gate-accent">explore.</span>
       </h1>
       <p class="gate-copy">
-        One quick check keeps the bots out of a copyrighted sourcebook. The
-        library loads right after.
+        One quick check to keep the bots out. Everything loads right after.
       </p>
       <TurnstileGate
         siteKey={data.turnstileSiteKey}

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
@@ -120,9 +120,9 @@
   </section>
 
   <p class="foot-note">
-    The library itself sits behind a quick human check: the corpus is
-    copyrighted source material, so the reader is link-shareable but kept out
-    of search engines and away from bots.
+    The library is free to browse. The interactive tools sit behind a quick
+    human check to keep bots out, and the whole app stays out of search
+    engines.
   </p>
 </div>
 

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/+page.svelte
@@ -51,16 +51,12 @@
 {#if locked}
   <section class="wrap locked-notice">
     <p class="eyebrow">The Grimoire</p>
-    <h1 class="grim-title locked-title">This book is copyrighted</h1>
+    <h1 class="grim-title locked-title">Not available to read here</h1>
     <p class="locked-body">
-      The full text of this sourcebook isn't available on the public library.
-      Its characters, monsters, spells, and locations still power the
-      <a href="/app/grimoire/entities">Entities</a>,
-      <a href="/app/grimoire/explore">Explore</a>, and
-      <a href="/app/grimoire/chat">Chat</a> features.
+      This book isn't part of the readable library. Browse the freely licensed
+      books instead.
     </p>
     <p class="locked-body">
-      The full-text reader is open only for freely licensed books.
       <a href="/app/grimoire/library">Back to the Library &rarr;</a>
     </p>
   </section>

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/library/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/library/+page.svelte
@@ -98,9 +98,22 @@
     "rulebook",
     "other",
   ];
+  // Filter: "all" shows the whole corpus; "readable" collapses to just the
+  // open-licensed books you can actually open in full. Only a couple of books
+  // are readable, so this is the shortcut that surfaces them out of the
+  // otherwise-long locked list.
+  let filter = $state("all");
+  const readableCount = $derived(
+    books.filter((b) => !b.copyrighted_content).length,
+  );
+
   const grouped = $derived.by(() => {
+    const visible =
+      filter === "readable"
+        ? books.filter((b) => !b.copyrighted_content)
+        : books;
     const by = {};
-    for (const b of books) {
+    for (const b of visible) {
       const k = KIND_LABEL[b.book_kind] ? b.book_kind : "other";
       (by[k] ??= []).push(b);
     }
@@ -130,10 +143,30 @@
       synced {totals.synced}
     </p>
     <p class="legend">
-      Open-licensed books are readable in full. Copyrighted books are listed and
-      power the Entities, Explore, and Chat features, but their full text stays
-      locked.
+      Open-licensed books are readable in full. Others are listed for reference.
     </p>
+    {#if readableCount > 0 && readableCount < totals.books}
+      <div class="filter" role="tablist" aria-label="Filter books">
+        <button
+          class="filter-btn"
+          class:active={filter === "all"}
+          role="tab"
+          aria-selected={filter === "all"}
+          onclick={() => (filter = "all")}
+        >
+          All <span class="filter-n">{totals.books}</span>
+        </button>
+        <button
+          class="filter-btn"
+          class:active={filter === "readable"}
+          role="tab"
+          aria-selected={filter === "readable"}
+          onclick={() => (filter = "readable")}
+        >
+          Readable <span class="filter-n">{readableCount}</span>
+        </button>
+      </div>
+    {/if}
   {/if}
 
   {#if loading}
@@ -163,9 +196,7 @@
                 <span class="brow-main">
                   <span class="title">
                     {book.display_name}
-                    {#if book.copyrighted_content}
-                      <span class="pill pill-locked">Copyrighted</span>
-                    {:else if isNew(book)}
+                    {#if !book.copyrighted_content && isNew(book)}
                       <span class="pill">New</span>
                     {/if}
                   </span>
@@ -179,17 +210,35 @@
                 </span>
               {/snippet}
               {#if book.copyrighted_content}
-                <!-- Full text is copyrighted: listed (breadth of the corpus is
-                     the showcase, and its entities still power Entities/Chat/
-                     Explore) but the Reader is locked. Not a link; the backend
-                     also 403s the read endpoints. -->
-                <div
-                  class="brow locked"
-                  title="Copyrighted: full text isn't available on the public library. Its entities and chat still work."
-                >
+                <!-- Listed for reference (breadth of the corpus is the
+                     showcase) but not readable in full: a quiet lock, no loud
+                     label. Not a link; the backend also 403s the read
+                     endpoints. -->
+                <div class="brow locked" title="Not available to read here">
                   {@render body()}
-                  <span class="read read-locked" aria-label="Reader locked">
-                    Locked
+                  <span class="lock" aria-label="Locked">
+                    <svg
+                      viewBox="0 0 16 16"
+                      width="14"
+                      height="14"
+                      fill="none"
+                      aria-hidden="true"
+                    >
+                      <rect
+                        x="3"
+                        y="7"
+                        width="10"
+                        height="7"
+                        rx="1.5"
+                        stroke="currentColor"
+                        stroke-width="1.3"
+                      />
+                      <path
+                        d="M5 7V5a3 3 0 0 1 6 0v2"
+                        stroke="currentColor"
+                        stroke-width="1.3"
+                      />
+                    </svg>
                   </span>
                 </div>
               {:else}
@@ -245,6 +294,55 @@
     color: var(--grim-text-faint);
     font-size: 12px;
     line-height: 1.5;
+  }
+
+  /* Segmented All / Readable filter: a quiet pill pair on a hairline track. */
+  .filter {
+    display: inline-flex;
+    margin-top: 16px;
+    padding: 3px;
+    gap: 3px;
+    background: var(--grim-surface-2);
+    border: 1px solid var(--grim-line);
+    border-radius: 8px;
+  }
+
+  .filter-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--grim-text-dim);
+    font: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    transition:
+      background 0.12s,
+      color 0.12s;
+  }
+
+  .filter-btn:hover {
+    color: var(--grim-ink);
+  }
+
+  .filter-btn.active {
+    background: var(--grim-paper);
+    color: var(--grim-ink);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  }
+
+  .filter-n {
+    font-variant-numeric: tabular-nums;
+    color: var(--grim-text-faint);
+  }
+
+  .filter-btn.active .filter-n {
+    color: var(--grim-accent);
   }
 
   .dot {
@@ -348,10 +446,12 @@
     background: transparent;
   }
 
-  .pill-locked {
-    color: var(--grim-text-dim);
-    background: var(--grim-surface-2);
-    border: 1px solid var(--grim-line);
+  /* Quiet lock on locked rows: the single, low-key marker (no "Copyrighted"
+     pill, no "Locked" label). Sits where "Read ->" would be on open rows. */
+  .lock {
+    display: inline-flex;
+    align-items: center;
+    color: var(--grim-text-faint);
   }
 
   .read {
@@ -370,12 +470,6 @@
 
   .brow:hover .read {
     opacity: 1;
-  }
-
-  /* The lock label stays visible (there is no hover on a non-link row). */
-  .read-locked {
-    opacity: 1;
-    color: var(--grim-text-faint);
   }
 
   .empty {


### PR DESCRIPTION
Follow-up to #3335. Now that the public reader only serves open-licensed books, the Library and reader no longer carry gated corpus — so the Turnstile friction and the copyright-loud copy there are unnecessary, and the wall of locked rows needed better readability.

## Library UX
- **"All / Readable" segmented filter** so the open books aren't buried among the locked ones (only a couple are readable, so this is the shortcut that surfaces them).
- **Quiet lock icon** replaces the redundant `COPYRIGHTED` pill + `LOCKED` label — one low-key marker per locked row.
- Legend reworded to stop naming Entities/Explore/Chat.

## Turnstile scope
- Exempt the **Library** and the **`/book/*` reader** from the gate (they only surface book metadata + open-licensed text; copyrighted books 403). Uses the same in-layout exemption mechanism as the already-ungated homepage, so topbar/theme/`noindex` are unchanged.
- The gate now wraps **only the derived-corpus surfaces** (Entities, Explore, Chat, adventure detail). This also fixes a UX trap: clicking "Read" on an open SRD from the (now open) Library would otherwise have hit the Turnstile wall.

## Copy (accuracy + tone)
- Gate screen: "solve to **read**" → "solve to **explore**"; drop "keeps the bots out of a **copyrighted sourcebook**".
- Homepage: "the **library** sits behind a check … **copyrighted source material**" → "the library is free to browse; the interactive tools sit behind a quick check".
- Reader locked notice: drop the sentence advertising that copyrighted books "power the Entities, Explore, and Chat features".

## Notes
- Frontend-public only (4 files under `routes/public/app/grimoire`); `monolith-public` chart bumped. No backend/migration change.
- The gate is client-side-only (the `/api/grimoire` proxy never validated a Turnstile token), so this removes UX friction, not a security boundary. `noindex` still covers the whole `/app/grimoire` tree.
- Visual-regression will render the new Library filter/lock treatment in the PR diff (existing fixture already carries `copyrighted_content`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)