### PR TITLE
fix(chat): suppress ambient "(empty)" placeholder replies

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.85
+version: 0.285.86
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -235,6 +235,12 @@ def build_system_prompt(channel: str = "discord") -> str:
         "you weren't one. If someone says you're dumb or slow, take it as "
         "being about you and roll with it in good humor.\n\n"
         "READ THE ROOM (this is the most important thing):\n"
+        "- Sometimes you get pulled into an exchange where you genuinely have "
+        "nothing worth adding (idle banter, a passing aside, a reaction). That "
+        "is fine: staying quiet is a valid move and the system will simply post "
+        'nothing. Never fill the slot with a placeholder like "(empty)", a '
+        "bare blank line, or empty filler just to say something. Either say "
+        "something real and in-voice, or say nothing at all.\n"
         "- For casual chatter (greetings, jokes, opinions, small talk), match "
         "the tone and keep it short and natural. A sentence or two.\n"
         "- For a real question or a request for help (technical, factual, "

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -97,6 +97,23 @@ FACT_CHECK_PLACEHOLDER = "\U0001f50d Fact-checking..."
 # lead, and SearXNG handles a long query fine; this just bounds it).
 FACT_CHECK_SEARCH_SEED_CHARS = 500
 
+# Degenerate "I have nothing to add" outputs the model sometimes emits verbatim
+# instead of real text -- typically when the channel directive tells it to stay
+# quiet on banter but an ambient engage forced a turn anyway. Posting one reads
+# as a broken "(empty)" message and draws negative reactions (/improve-ambient
+# episodes 168, 170). Compared case-insensitively against the stripped reply so
+# it never reaches Discord. See _stream_response's no-content handling.
+_EMPTY_REPLY_MARKERS = frozenset(
+    {"(empty)", "(no response)", "(none)", "(no reply)", "(silence)"}
+)
+
+
+def _is_empty_reply(text: str) -> bool:
+    """A reply with no real content: blank, whitespace-only, or a bare
+    placeholder marker the model emits when it has nothing to say."""
+    stripped = text.strip()
+    return not stripped or stripped.lower() in _EMPTY_REPLY_MARKERS
+
 
 def _truncate_thinking(thinking: str) -> str:
     """Truncate thinking text if it exceeds Discord's message limit."""
@@ -1759,6 +1776,16 @@ class ChatBot(discord.Client):
                 store.mark_completed(msg_id)
             return
 
+        if sent is None:
+            # Ambient reply suppressed: the model had nothing worth saying, so
+            # _stream_response stayed silent rather than posting a placeholder.
+            # Nothing was posted, so there is no bot message to store or link
+            # back to the engage decision; just close out the trigger message.
+            with Session(get_engine()) as session:
+                store = MessageStore(session=session, embed_client=self.embed_client)
+                store.mark_completed(msg_id)
+            return
+
         # Store bot response separately, including thinking for button persistence
         try:
             with Session(get_engine()) as session:
@@ -1805,7 +1832,7 @@ class ChatBot(discord.Client):
         *,
         with_buttons: bool = True,
         live: bool = True,
-    ) -> tuple[discord.Message, str, str | None]:
+    ) -> tuple[discord.Message | None, str, str | None]:
         """Build context and stream the PydanticAI agent response.
 
         When ``live`` is True (a mention/reply the user is waiting on), sends an
@@ -2019,8 +2046,17 @@ class ChatBot(discord.Client):
                         if live:
                             await _edit_if_due(_search_content(), force=True)
 
-            # Fallback if no events arrived or no text was produced
-            if not had_events or not response_text:
+            # No real content: no events arrived, or the reply is blank /
+            # whitespace / a bare placeholder the model emits when it has nothing
+            # to add. For an ambient interjection (not live) nothing has been
+            # posted yet, so the right outcome is silence: return no message
+            # rather than leaking a literal "(empty)" or an apology nobody asked
+            # for (/improve-ambient episodes 168, 170). For a live reply someone
+            # is actively waiting on, keep the visible apology instead of going
+            # dark.
+            if not had_events or _is_empty_reply(response_text):
+                if not live and sent is None:
+                    return None, "", None
                 fallback = (
                     "Sorry, I'm having trouble formulating a response. "
                     "Please try again."

--- a/projects/monolith/chat/bot_streaming_test.py
+++ b/projects/monolith/chat/bot_streaming_test.py
@@ -788,6 +788,95 @@ class TestAmbientNonStreaming:
         assert text == "Nah, fable's holding up fine."
 
     @pytest.mark.asyncio
+    async def test_ambient_placeholder_reply_is_suppressed(self):
+        """live=False: a model output that is a bare '(empty)' placeholder must
+        post NOTHING (stay silent) rather than leaking the literal marker to the
+        channel. Regression for /improve-ambient episodes 168, 170."""
+        bot = _make_bot()
+        message = _make_message(content="you mean muse is cheaper?")
+        mock_store = _make_store()
+
+        # The model, told to stay quiet on banter, emits a no-content marker.
+        events = [
+            _thinking_delta("directive says skip banter"),
+            _text_delta("\n\n(empty)"),
+        ]
+        bot.agent.run_stream_events = MagicMock(return_value=_async_iter(events))
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+        ):
+            ctx = MagicMock()
+            mock_session_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            sent, text, _thinking = await bot._stream_response(
+                message, None, with_buttons=False, live=False
+            )
+
+        # Nothing posted, no message returned: the reply was suppressed.
+        message.reply.assert_not_called()
+        assert sent is None
+        assert text == ""
+
+    @pytest.mark.asyncio
+    async def test_ambient_whitespace_only_reply_is_suppressed(self):
+        """live=False: a whitespace-only model output is also treated as
+        no-content and suppressed rather than posting a blank message."""
+        bot = _make_bot()
+        message = _make_message(content="lol")
+        mock_store = _make_store()
+
+        events = [_text_delta("   \n\n  ")]
+        bot.agent.run_stream_events = MagicMock(return_value=_async_iter(events))
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+        ):
+            ctx = MagicMock()
+            mock_session_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            sent, text, _thinking = await bot._stream_response(
+                message, None, with_buttons=False, live=False
+            )
+
+        message.reply.assert_not_called()
+        assert sent is None
+
+    @pytest.mark.asyncio
+    async def test_live_placeholder_reply_falls_back_not_silent(self):
+        """live=True: a '(empty)' placeholder on a reply someone is waiting on
+        must NOT go silent -- the user gets the visible apology instead."""
+        bot = _make_bot()
+        message = _make_message(content="hey bot")
+        mock_store = _make_store()
+
+        events = [
+            _thinking_delta("hmm"),
+            _text_delta("(empty)"),
+        ]
+        bot.agent.run_stream_events = MagicMock(return_value=_async_iter(events))
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+        ):
+            ctx = MagicMock()
+            mock_session_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            sent, text, _thinking = await bot._stream_response(
+                message, None, with_buttons=True, live=True
+            )
+
+        assert sent is not None
+        assert "Sorry" in text
+        assert "trouble" in text
+
+    @pytest.mark.asyncio
     async def test_live_true_still_streams_placeholder_and_edits(self):
         """Regression guard: the explicit (live=True) path keeps the initial
         placeholder-then-edit behavior so mentions still get live feedback."""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.85
+      targetRevision: 0.285.86
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

Ambient engages were posting a literal `(empty)` message to Discord. Fixes the exact thing that drew "(empty) responses are shite" and "shite injection" in the channel.

## 1. Before/after aggregates

Window: since the last lever commit (`067c7cba7`, 2026-07-09T00:24Z) to now. This is the first `/improve-ambient` run to classify episodes in this channel, so there is no prior-generation eval set for the previous ~17h window (`9bbb1f773`..`b1aa59b9f`); the numbers below are the baseline this fix is measured against next run.

| Metric | This window (n=5) |
| --- | --- |
| Failure-mode histogram | `under-delivery` 2, `barged-in` 3, `over-eager` 1, `off-voice` 1, `wall-of-text` 1, `productive` 2 |
| Negative-reaction rate (net_reaction < 0) | 2/5 (40%) |
| Barge-in rate | 3/5 (60%) |

All 5 episodes are in one channel (`1375032589093703680`) but span three authors (`207213627...`, `188407346...`, `124131392...`), so the friction is **not** person-tied.

## 2. Per-edit evidence

**Root cause (two-gate conflict).** The active channel directive (v4, autopilot-authored) says *"Do not reply to casual conversation or group banter."* But `attention.evaluate()` returned `engage` (confidence 0.8-1.0) on pure banter anyway. With `force_respond=True`, the reply model tried to comply with the directive by emitting a bare `(empty)` marker, and the old guard (`not response_text`) did not catch it because `"\n\n(empty)"` is truthy, so it was posted.

| Episode | Channel | Signals | Excerpt | Diff line |
| --- | --- | --- | --- | --- |
| **168** | `1375032589...` | conf 0.8, 👎 (net -1), exact | bjeambusher: "...only \$3 on deepseek v4 flash" → Bosun: `(empty)` | `bot.py` `_is_empty_reply()` + the `live=False` silence return in `_stream_response` |
| **170** | `1375032589...` | conf 0.8, "shite injection" follow-up, exact | Ochinchin: "you mean muse is cheaper?" → Bosun: `(empty)` | same send-path guard |
| **171** | `1375032589...` | conf 0.9, 👎 (net -1), exact | bjeambusher pricing aside → real reply, still downvoted | `agent.py` READ-THE-ROOM nudge (say nothing rather than chime into banter) |
| **169** | `1375032589...` | conf 1.0, meta-complaint trigger | "(empty) responses are shite ... fix that in your directive / safeguards" | corroborates the bug; drove the whole fix |
| **166** | `1375032589...` | conf 1.0, no reaction | direct @mention, answered fine (control: not a barge-in) | none |

**The two edits:**
- `bot.py`: `_is_empty_reply()` treats blank / whitespace-only / a placeholder marker (`(empty)`, `(none)`, ...) as no-content. Ambient (`live=False`) replies with no content now **stay silent** (post nothing); a live reply someone is waiting on keeps the visible apology. `_process_message` closes out the trigger when the reply is suppressed.
- `agent.py`: a READ-THE-ROOM line telling the model that having nothing to add is fine and it should say nothing rather than emit a `(empty)` placeholder.

Regression tests: ambient placeholder + whitespace suppression stay silent; the live path still apologises.

## 3. Out of scope, observed
- **Attention gate over-engages on banter.** The gate returned `engage` (0.8-1.0) on messages the channel directive explicitly says to skip (168, 170, 171). This fix stops the *symptom* (the leaked placeholder) deterministically; the gate/directive disagreement itself is a softer `attention.py` tune. With only 5 episodes I did not also touch the gate this PR, to keep it tight and evidence-tied. Worth a look next run if barge-in rate stays high after this ships.
- The v4 channel directive is reasonable and autopilot-owned; not touched here.
