### PR TITLE
fix(fcstory): clear disk-shelf vs timing-track overlap on laptop heights

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.38
+version: 0.89.39
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.38
+      targetRevision: 0.89.39
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.87
+version: 0.285.88
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.87
+      targetRevision: 0.285.88
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/fcstory/FcScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/fcstory/FcScrollStory.svelte
@@ -1217,24 +1217,41 @@
   /* ---------- short-viewport (laptop / low-res) compaction ---------- */
   /* Separate concern from the mobile bug below: the desktop three-region
      spread (caption left, machine right, track bottom, zoom inset lower-right)
-     was laid out for a TALL viewport. On any shorter window the machine's disk
-     shelf and the .zoom magnifier both want the lower-right and overlap. These
-     are HEIGHT breakpoints (not width) because the failure is purely vertical,
-     so they fire the same on a 4K monitor zoomed in as on a small laptop. */
+     was laid out for a TALL viewport. On any shorter window three things on the
+     right column collide vertically: the centered machine's disk shelf reaches
+     the bottom timing track (base.vmstate lands on the cold total), and the
+     .zoom inset overlaps the disk shelf. This is a HEIGHT breakpoint (not
+     width) because the failure is purely vertical, so it fires the same on a 4K
+     monitor zoomed in as on a small laptop. One threshold covers the whole
+     band: piecemeal cutoffs left a gap just above them (e.g. a 14" MacBook
+     window at ~880px cleared an 840px cutoff yet still collided).
 
-  /* The zoom inset only fits on tall displays. Below that it collides with the
-     disk shelf; the replay console further down the page shows the exact same
-     per-phase breakdown, so hiding it here loses no information (mobile already
-     drops it for the same reason). */
-  @media (max-height: 1100px) {
+     Below the threshold we compact the entire right column: a smaller, higher
+     machine so its disk shelf clears the track; a track pulled tight to the
+     bottom with shorter rows; and the zoom dropped (its per-phase breakdown is
+     reproduced verbatim by the replay console below the fold, exactly as mobile
+     already does, so hiding it loses no information). */
+
+  /* The zoom inset needs MORE headroom than the rest: it sits below the disk
+     shelf and only clears it on a genuinely tall display (~1400px+, i.e. a
+     1440p/4K monitor). Its own, higher threshold; between here and 1100px the
+     full machine already sits high enough that the disk shelf clears the track
+     on its own, so only the zoom needs dropping in that band. */
+  @media (max-height: 1400px) {
     .zoom {
       display: none;
     }
   }
 
-  /* Very short windows: pull the timing track tight against the bottom and
-     shrink its rows so it clears the vertically-centered caption. */
-  @media (max-height: 840px) {
+  @media (max-height: 1100px) {
+    /* smaller + higher machine so the disk shelf sits well above the track */
+    .machine {
+      top: 40%;
+    }
+    .ram {
+      height: clamp(140px, 26vh, 300px);
+    }
+    /* track pulled tight to the bottom with shorter rows */
     .track {
       bottom: 3vh;
     }


### PR DESCRIPTION
## What

Follow-up to #3339. Joe still saw the cold total **`9,264 ms`** overlapping the **`base.vmstate`** disk card on his 14" MacBook.

Root cause I missed the first time: my harness probed `disk/zoom` and `caption/track` but **not `disk/track`**. The vertically-centered machine's disk shelf hangs down on the right and lands on the bottom timing track's cold total. It failed across a **broad band** of heights (measured 860–900px and 680–720px); the earlier 840px track compaction cleared it *below* 840 but not just above, so a ~880px 14" window still collided.

## Fix (all height-keyed)

- **Merge the track compaction into one `max-height: 1100px` breakpoint** (was 840px) that also shrinks the RAM grid and raises the machine (`top: 43% → 40%`) so the disk shelf sits well above the track. Kills `disk/track` across the whole 660–1100px band.
- **Give the zoom inset its own higher threshold (`max-height: 1400px`)** — it sits *below* the disk shelf and needs ~1400px+ to clear it. Between 1100–1400px only the zoom drops; the full machine already clears the track there.

## Verification

Extended the headless-chromium harness with the missing `disk/track` (and `vmstate/9264`) probes and ran a **fine height sweep, 660→1440px in 20px steps, at widths 1024/1280/1440/1512**:

```
w=1512: CLEAN 660-1440
w=1440: CLEAN 660-1440
w=1280: CLEAN 660-1440
w=1024: CLEAN 660-1440
```

(before this change the same sweep flagged `disk/track` at 680–720 and 860–900, and `disk/zoom` at 1120–1340.) Mobile layout unchanged and re-confirmed clean.

Charts bumped in-PR (`monolith` 0.285.88, `monolith-public` 0.89.39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)