### PR TITLE
fix(grimoire): forward 403 through public reader proxies + punchier gate copy

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.39
+version: 0.89.40
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.39
+      targetRevision: 0.89.40
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.88
+version: 0.285.89
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.88
+      targetRevision: 0.285.89
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
@@ -104,7 +104,7 @@
         solve to <span class="gate-accent">explore.</span>
       </h1>
       <p class="gate-copy">
-        One quick check to keep the bots out. Everything loads right after.
+        Bots? <em>Get outta here!</em>
       </p>
       <TurnstileGate
         siteKey={data.turnstileSiteKey}

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/api/[...path]/+server.js
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/api/[...path]/+server.js
@@ -15,7 +15,17 @@ export async function GET({ params, url, fetch }) {
     { signal: AbortSignal.timeout(15_000) },
   );
   if (!res.ok) {
-    throw error(res.status === 404 ? 404 : 503, "grimoire unavailable");
+    // Forward the backend's own 404/403 rather than masking them as a generic
+    // 503: 403 is the deliberate license gate on copyrighted books (see
+    // router_public.read_book), and reporting it as "unavailable" reads like an
+    // outage and trips 5xx alerting. 503 stays for real upstream failures.
+    const status = res.status === 404 ? 404 : res.status === 403 ? 403 : 503;
+    throw error(
+      status,
+      status === 403
+        ? "this book is not available to read publicly"
+        : "grimoire unavailable",
+    );
   }
   return new Response(res.body, {
     status: res.status,

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/+page.server.js
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/+page.server.js
@@ -26,6 +26,8 @@ export async function load({ params, url, fetch }) {
     return { bookId, locked: true, items: [], nextCursor: null };
   }
   if (!res.ok) {
+    // 403 is already handled above (locked marker); anything else is a real
+    // failure. 404 stays a 404; the rest surface as a 503.
     throw error(res.status === 404 ? 404 : 503, "grimoire unavailable");
   }
   const page = signReadPage(await res.json());

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/read/+server.js
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/book/[book]/read/+server.js
@@ -20,7 +20,15 @@ export async function GET({ params, url, fetch }) {
     { signal: AbortSignal.timeout(15_000) },
   );
   if (!res.ok) {
-    throw error(res.status === 404 ? 404 : 503, "grimoire unavailable");
+    // Forward the backend's 404/403 (403 = the copyrighted-book license gate)
+    // instead of collapsing to a misleading 503. See the api/[...path] proxy.
+    const status = res.status === 404 ? 404 : res.status === 403 ? 403 : 503;
+    throw error(
+      status,
+      status === 403
+        ? "this book is not available to read publicly"
+        : "grimoire unavailable",
+    );
   }
   const page = signReadPage(await res.json());
   return new Response(JSON.stringify(page), {


### PR DESCRIPTION
## What

Two small public-Grimoire tweaks:

1. **Forward the backend's 403 through the public reader proxies.** The proxies collapsed every non-404 upstream status to `503 "grimoire unavailable"`, so the copyrighted-book license gate (a deliberate `403` from `router_public.read_book`) surfaced to the browser as a generic outage. That reads like a real failure and trips 5xx alerting. Now `403` (and `404`) pass through; `503` means an actual upstream failure.
   - `api/[...path]/+server.js` (the catch-all API proxy, what `curl .../curse-of-strahd/read` hit)
   - `book/[book]/read/+server.js` (reader infinite-scroll pages)
   - `book/[book]/+page.server.js` already renders a `locked` marker on 403 (from #3337); left as-is with a clarifying comment.

2. **Punchier Turnstile gate copy**: "One quick check to keep the bots out..." → "Bots? *Get outta here!*"

## Why

Found while ingesting the two new open books: `curse-of-strahd/read` returned `503` instead of `403`. The gate itself always held (no copyrighted text served); this only fixes the status the browser sees.

## Deploy

Frontend change under `public/app/grimoire`, which rebuilds both the monolith and monolith-public images, so both charts are bumped (monolith `0.285.89`, monolith-public `0.89.40`).

## Test

Verify after deploy: `curl -o /dev/null -w "%{http_code}" .../api/books/curse-of-strahd/read` returns `403`; an open SRD returns `200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)