### PR TITLE
feat(demos): make the semgrep demo showcase Pro interprocedural taint

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.90
+version: 0.285.91
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.90
+      targetRevision: 0.285.91
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/demos/firecracker/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/demos/firecracker/+page.svelte
@@ -23,19 +23,28 @@ print(f"sqrt(2) = {math.sqrt(2):.6f}")
 `;
 
   const SEMGREP_SAMPLE = `import subprocess
+from flask import Flask, request
+
+app = Flask(__name__)
 
 
-def run_backup(filename):
-    # Builds a shell command from an unsanitised argument, a classic
-    # command-injection pattern that semgrep's python.lang.security
-    # rules flag.
-    cmd = f"tar czf backup.tar.gz {filename}"
-    subprocess.call(cmd, shell=True)
+def read_target():
+    # Taint SOURCE: an attacker-controlled query parameter.
+    return request.args.get("host")
 
 
-def load_config(raw):
-    # eval() on untrusted input.
-    return eval(raw)
+def ping(target):
+    # Taint SINK: a shell command built from untrusted input.
+    subprocess.run(f"ping -c1 {target}", shell=True)
+
+
+@app.route("/ping")
+def handle():
+    # Source and sink live in different functions. Only Semgrep Pro's
+    # interprocedural taint analysis connects them across this call; the
+    # open-source engine sees each function alone and misses the flow.
+    ping(read_target())
+    return "ok"
 `;
 
   const GOOSE_TASK_SAMPLE =
@@ -51,8 +60,9 @@ def load_config(raw):
     {
       key: "semgrep",
       label: "Semgrep",
-      tagline: "Static-analysis scan of a file, run in the sandbox.",
-      sample: { path: "app/backup.py", code: SEMGREP_SAMPLE },
+      tagline:
+        "Pro interprocedural taint scan: a source and sink in different functions, caught in the sandbox.",
+      sample: { path: "app/ping.py", code: SEMGREP_SAMPLE },
     },
     {
       key: "goose",


### PR DESCRIPTION
Now that the offline-Pro scan-server is live (#3342), make the firecracker demo's semgrep sample actually demonstrate the new capability.

**Before:** two independent single-function patterns (`shell=True`, `eval`) — both caught by the OSS engine, so nothing Pro-specific.

**After:** a genuine cross-function taint flow — a flask `request.args.get` source in `read_target()` reaching a `subprocess.run(..., shell=True)` sink in `ping()`, connected by a call in the route. Only the Pro engine's interprocedural taint analysis connects source→sink across the functions; OSS sees each function alone and misses it.

The demo scans **live** via the fc-invoke daemon, so the new Pro findings render automatically. Verified against the live prod daemon — it returns `subprocess-injection` + `tainted-os-command` (Pro-only taint rules) plus the pattern findings.

Also updated the tagline to name the interprocedural-taint story. Chart bump deploys the monolith frontend. Not a visual-regression target, so no snapshot change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)