### PR TITLE
feat(demos): Semgrep + Sandbox Pro load-test harness with live counters and receipts

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -4616,6 +4616,20 @@ py_test(
 )
 
 py_test(
+    name = "demos_loadtest_test",
+    srcs = ["demos/loadtest_test.py"],
+    # run_load_test defaults its corpus to load_corpus(workload), which reads
+    # the committed .sample files at runtime.
+    data = glob(["demos/loadtest_corpus/**/*.sample"]),
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
     name = "home_observability_rollup_test",
     srcs = ["home/observability/rollup_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -130,8 +130,12 @@ py_venv_binary(
         # runfiles as data or every agent run fails with FileNotFoundError.
         "//projects/firecracker/goosecracker/guest:recipe_yamls",
         "knowledge/repo_docs_manifest.ndjson",
+        # loadtest_corpus.load_corpus reads these committed .sample files at
+        # runtime via Path(__file__).parent; the "demos/**/*.py" glob does not
+        # capture non-.py data, so ship them explicitly into runfiles (mirrors
+        # the worldcup Elo snapshot and campsites catalog above).
         ":frontend_dist",
-    ],
+    ] + glob(["demos/loadtest_corpus/**/*.sample"]),
     imports = ["."],  # keep
     main = "app/main.py",
     visibility = ["//:__subpackages__"],
@@ -4597,6 +4601,17 @@ py_test(
         ":monolith_backend",
         "@pip//pytest",
         "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
+    name = "demos_loadtest_corpus_test",
+    srcs = ["demos/loadtest_corpus_test.py"],
+    data = glob(["demos/loadtest_corpus/**/*.sample"]),
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
     ],
 )
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.92
+version: 0.285.93
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260710000000_load_test_tables.sql
+++ b/projects/monolith/chart/migrations/20260710000000_load_test_tables.sql
@@ -1,0 +1,31 @@
+CREATE SCHEMA IF NOT EXISTS demo;
+
+CREATE TABLE demo.load_run (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    workload      text NOT NULL,
+    started_at    timestamptz NOT NULL DEFAULT now(),
+    finished_at   timestamptz,
+    duration_s    integer NOT NULL DEFAULT 120,
+    status        text NOT NULL DEFAULT 'running',
+    config        jsonb NOT NULL,
+    summary       jsonb
+);
+
+CREATE TABLE demo.load_scan (
+    id             bigserial PRIMARY KEY,
+    run_id         uuid NOT NULL REFERENCES demo.load_run(id) ON DELETE CASCADE,
+    workload       text NOT NULL,
+    seq            integer NOT NULL,
+    name           text NOT NULL,
+    status         text NOT NULL,
+    latency_ms     integer NOT NULL,
+    queue_wait_ms  integer,
+    cpu_ms         integer,
+    peak_rss_mib   integer,
+    result_count   integer,
+    result         jsonb,
+    error          text,
+    created_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_load_scan_run ON demo.load_scan(run_id, seq);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:nFJ2mUOK0Br/MUGUZGYvHnDIgFGJVP1AgSzIsXsMrdQ=
+h1:K5y7aTZxfiBamcTrMKTw4TGybW+wFtVJyJfklHsuxhU=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -121,3 +121,4 @@ h1:nFJ2mUOK0Br/MUGUZGYvHnDIgFGJVP1AgSzIsXsMrdQ=
 20260708080000_whatsapp_outbox_sent_idx.sql h1:rjLtavPiIJg73SeUGkfq2COZz0YISX+5Zni73AV1tpo=
 20260708090000_whatsapp_outbox_media.sql h1:N1dQ0mGx2Uk23QMNsbXLq0YqVwy/JuY5VLq5LNNDHGk=
 20260709120000_grimoire_book_copyrighted.sql h1:9SlSEXYu90EPNlDWO8hmREOznAEmpeL1iqP7eXXsVNA=
+20260710000000_load_test_tables.sql h1:0JCesZBbAxv15xZq55RCWOH+h7cZIrccCUnzuIHSdWc=

--- a/projects/monolith/chart/templates/rbac.yaml
+++ b/projects/monolith/chart/templates/rbac.yaml
@@ -25,8 +25,8 @@ rules:
     resources: ["applications"]
     verbs: ["get", "list", "patch"]
   - apiGroups: ["metrics.k8s.io"]
-    resources: ["nodes"]
-    verbs: ["list"]
+    resources: ["nodes", "pods"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/projects/monolith/cluster/kubernetes.py
+++ b/projects/monolith/cluster/kubernetes.py
@@ -220,6 +220,24 @@ class KubernetesClient:
             "memory_capacity_bytes": mem_cap,
         }
 
+    async def pod_metrics(self, namespace: str) -> list[dict]:
+        """Return raw pod-metrics objects for a namespace (metrics.k8s.io).
+
+        Each item carries ``metadata.name`` and a ``containers`` list of
+        ``{name, usage: {cpu, memory}}``. Used by the load-test sampler to read
+        the fc-invoke pod's cpu/rss footprint. Requires the ``metrics.k8s.io``
+        ``pods`` ``get``/``list`` RBAC verbs (see chart/templates/rbac.yaml).
+        """
+        api = await self._ensure_client()
+        custom = client.CustomObjectsApi(api)
+        result = await custom.list_namespaced_custom_object(
+            group="metrics.k8s.io",
+            version="v1beta1",
+            namespace=namespace,
+            plural="pods",
+        )
+        return result.get("items", [])
+
     def _typed_api(self, group: str, api: ApiClient):
         return client.CoreV1Api(api) if group == "core" else client.AppsV1Api(api)
 

--- a/projects/monolith/demos/firecracker_api.py
+++ b/projects/monolith/demos/firecracker_api.py
@@ -54,7 +54,7 @@ _WORKLOAD_MEM_MIB = {"semgrep": 1536, "sandbox": 512}
 
 # Agent (goose) run ledger non-terminal states: an active agent run holds
 # node-4 capacity, so a load test must not run concurrently with one.
-_AGENT_BUSY_STATES = ("PENDING", "RUNNING", "IDLE")
+_AGENT_BUSY_STATES = ("RUNNING",)
 
 # Detached drain tasks are stashed here so the event loop keeps a strong
 # reference (an unreferenced task can be GC'd mid-run).
@@ -236,9 +236,10 @@ def _agent_is_busy() -> bool:
 
     ASSUMPTION: an active agent run holds node-4 capacity, so a load test must
     not run alongside one. The goosecracker run ledger is
-    ``claude_agent.agent_threads`` (state PENDING -> RUNNING -> IDLE ->
-    COMPLETED | FAILED per migration 20260627120000_agent_threads.sql); the
-    non-terminal states are PENDING, RUNNING, IDLE. Sync; call via to_thread.
+    ``claude_agent.agent_threads``. In the current model the runner only ever
+    writes RUNNING (at dispatch) then COMPLETED or FAILED; the older
+    PENDING/IDLE lifecycle states are vestigial and never set, so RUNNING is the
+    sole active state that matters here. Sync; call via to_thread.
     """
     with Session(get_engine()) as session:
         row = session.execute(

--- a/projects/monolith/demos/firecracker_api.py
+++ b/projects/monolith/demos/firecracker_api.py
@@ -447,6 +447,13 @@ async def start_load_test(workload: str) -> dict:
     ``already_running``); an active goose agent run refuses with HTTP 409.
     Otherwise inserts a load_run row and dispatches ``run_load_test`` on a
     detached task, returning the new run id immediately.
+
+    The one-run guard is best-effort: the running-check and the insert are
+    separate round-trips, so two POSTs racing inside the same ~millisecond could
+    both start. That is acceptable for this single-operator demo; if it ever
+    needs to be airtight, add a partial unique index on
+    ``demo.load_run (status) WHERE status = 'running'`` and treat the
+    unique-violation as "already running".
     """
     if workload not in loadtest.WORKLOADS:
         raise HTTPException(status_code=404, detail=f"unknown workload: {workload}")

--- a/projects/monolith/demos/firecracker_api.py
+++ b/projects/monolith/demos/firecracker_api.py
@@ -25,6 +25,7 @@ owns no fc-invoke or ClickHouse client of its own.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from time import perf_counter
 from uuid import uuid4
@@ -33,8 +34,13 @@ from fastapi import APIRouter, HTTPException
 from opentelemetry import trace
 from opentelemetry.context import Context
 from pydantic import BaseModel
+from sqlalchemy import text
+from sqlmodel import Session
 
+import demos.loadtest as loadtest
 import goosecracker.api as goosecracker
+from app.db import get_engine
+from demos.loadtest_corpus import load_corpus
 from home.observability.traces import fetch_correlated_spans, fetch_trace_spans
 from sandbox.client import run_python_in_sandbox
 from semgrep.client import scan_files
@@ -42,6 +48,17 @@ from semgrep.client import scan_files
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/demos/firecracker", tags=["demos"])
+
+# Per-workload VM memory (MiB) recorded in the run config for the frontend.
+_WORKLOAD_MEM_MIB = {"semgrep": 1536, "sandbox": 512}
+
+# Agent (goose) run ledger non-terminal states: an active agent run holds
+# node-4 capacity, so a load test must not run concurrently with one.
+_AGENT_BUSY_STATES = ("PENDING", "RUNNING", "IDLE")
+
+# Detached drain tasks are stashed here so the event loop keeps a strong
+# reference (an unreferenced task can be GC'd mid-run).
+_RUNNING_DRAINS: set[asyncio.Task] = set()
 
 _tracer = trace.get_tracer("demos.firecracker")
 
@@ -192,3 +209,298 @@ async def get_trace(trace_id: str) -> dict:
     spans = await fetch_trace_spans(trace_id)
     correlated = await fetch_correlated_spans(trace_id)
     return {"spans": spans, "correlated": correlated, "complete": len(spans) > 0}
+
+
+# ---------------------------------------------------------------------------
+# Load test (workload-parametric drain over the fc-invoke daemon).
+# ---------------------------------------------------------------------------
+
+
+def _running_load_run() -> dict | None:
+    """Return the id/started_at of any load_run still 'running', or None.
+
+    Sync; call via asyncio.to_thread.
+    """
+    with Session(get_engine()) as session:
+        row = session.execute(
+            text(
+                "SELECT id, workload FROM demo.load_run "
+                "WHERE status = 'running' ORDER BY started_at DESC LIMIT 1"
+            )
+        ).fetchone()
+    return {"id": str(row.id), "workload": row.workload} if row else None
+
+
+def _agent_is_busy() -> bool:
+    """Return True when any goose agent run is in a non-terminal state.
+
+    ASSUMPTION: an active agent run holds node-4 capacity, so a load test must
+    not run alongside one. The goosecracker run ledger is
+    ``claude_agent.agent_threads`` (state PENDING -> RUNNING -> IDLE ->
+    COMPLETED | FAILED per migration 20260627120000_agent_threads.sql); the
+    non-terminal states are PENDING, RUNNING, IDLE. Sync; call via to_thread.
+    """
+    with Session(get_engine()) as session:
+        row = session.execute(
+            text(
+                "SELECT 1 FROM claude_agent.agent_threads "
+                "WHERE state = ANY(:states) LIMIT 1"
+            ),
+            {"states": list(_AGENT_BUSY_STATES)},
+        ).fetchone()
+    return row is not None
+
+
+def _insert_load_run(workload: str, config: dict) -> str:
+    """Insert a running load_run row and return its id. Sync; via to_thread."""
+    with Session(get_engine()) as session:
+        row = session.execute(
+            text(
+                """
+                INSERT INTO demo.load_run (workload, config)
+                VALUES (:workload, CAST(:config AS jsonb))
+                RETURNING id
+                """
+            ),
+            {"workload": workload, "config": json.dumps(config)},
+        ).fetchone()
+        session.commit()
+    return str(row.id)
+
+
+def _load_run_rollup(run_id: str) -> dict | None:
+    """Return the run row plus a cheap live rollup over its scans.
+
+    A single aggregate query over demo.load_scan (no per-row fetch) keeps the
+    1s poll cheap. Returns None when the run id is unknown. Sync; via to_thread.
+    """
+    with Session(get_engine()) as session:
+        run = session.execute(
+            text(
+                "SELECT id, workload, started_at, finished_at, duration_s, "
+                "status, config, summary FROM demo.load_run WHERE id = :id"
+            ),
+            {"id": run_id},
+        ).fetchone()
+        if run is None:
+            return None
+
+        agg = session.execute(
+            text(
+                """
+                SELECT
+                    count(*) AS total_scans,
+                    count(*) FILTER (WHERE status = 'error') AS errors,
+                    percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_ms)
+                        AS latency_p50,
+                    percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms)
+                        AS latency_p95,
+                    avg(cpu_ms) AS cpu_ms_mean,
+                    avg(peak_rss_mib) AS peak_rss_mib_mean,
+                    extract(epoch FROM (
+                        coalesce(max(created_at), now()) - min(created_at)
+                    )) AS scan_span_s
+                FROM demo.load_scan WHERE run_id = :id
+                """
+            ),
+            {"id": run_id},
+        ).fetchone()
+
+        per_lang = session.execute(
+            text(
+                "SELECT name, count(*) AS c FROM demo.load_scan "
+                "WHERE run_id = :id GROUP BY name"
+            ),
+            {"id": run_id},
+        ).fetchall()
+
+    total = agg.total_scans or 0
+    # Elapsed against the run's wall clock (started_at -> finished_at or now).
+    finished = run.finished_at
+    started = run.started_at
+    if finished is not None:
+        elapsed_s = (finished - started).total_seconds()
+    else:
+        # scan_span_s is the observed span of recorded scans; a good live proxy.
+        elapsed_s = float(agg.scan_span_s or 0.0)
+    throughput = (total / elapsed_s) if elapsed_s and elapsed_s > 0 else 0.0
+    # In-flight estimate: the drain oversubscribes at client_concurrency but the
+    # daemon caps concurrent work at its own concurrency, so while running the
+    # steady in-flight count is ~ the daemon concurrency.
+    cfg = run.config or {}
+    in_flight = cfg.get("daemon_concurrency", 0) if run.status == "running" else 0
+
+    return {
+        "run_id": str(run.id),
+        "workload": run.workload,
+        "status": run.status,
+        "started_at": started.isoformat() if started else None,
+        "finished_at": finished.isoformat() if finished else None,
+        "duration_s": run.duration_s,
+        "config": cfg,
+        "elapsed_s": elapsed_s,
+        "total_scans": total,
+        "errors": agg.errors or 0,
+        "throughput_per_s": throughput,
+        "in_flight_estimate": in_flight,
+        "latency_p50": float(agg.latency_p50) if agg.latency_p50 is not None else None,
+        "latency_p95": float(agg.latency_p95) if agg.latency_p95 is not None else None,
+        "per_lang_counts": {r.name: r.c for r in per_lang},
+        "cpu_ms_mean": float(agg.cpu_ms_mean) if agg.cpu_ms_mean is not None else None,
+        "peak_rss_mib_mean": (
+            float(agg.peak_rss_mib_mean) if agg.peak_rss_mib_mean is not None else None
+        ),
+        "summary": run.summary if run.status == "done" else None,
+    }
+
+
+def _load_scans_page(run_id: str, offset: int, limit: int) -> dict:
+    """Return a page of scan rows (no ``result`` column) plus a total count.
+
+    Sync; call via asyncio.to_thread.
+    """
+    with Session(get_engine()) as session:
+        total = session.execute(
+            text("SELECT count(*) AS c FROM demo.load_scan WHERE run_id = :id"),
+            {"id": run_id},
+        ).fetchone()
+        rows = session.execute(
+            text(
+                """
+                SELECT id, seq, name, status, latency_ms, queue_wait_ms,
+                       cpu_ms, peak_rss_mib, result_count
+                FROM demo.load_scan
+                WHERE run_id = :id
+                ORDER BY seq
+                OFFSET :offset LIMIT :limit
+                """
+            ),
+            {"id": run_id, "offset": offset, "limit": limit},
+        ).fetchall()
+    return {
+        "total": total.c,
+        "offset": offset,
+        "limit": limit,
+        "scans": [
+            {
+                "id": r.id,
+                "seq": r.seq,
+                "name": r.name,
+                "status": r.status,
+                "latency_ms": r.latency_ms,
+                "queue_wait_ms": r.queue_wait_ms,
+                "cpu_ms": r.cpu_ms,
+                "peak_rss_mib": r.peak_rss_mib,
+                "result_count": r.result_count,
+            }
+            for r in rows
+        ],
+    }
+
+
+def _load_scan_detail(run_id: str, scan_id: int) -> dict | None:
+    """Return one scan row WITH its ``result``, or None. Sync; via to_thread."""
+    with Session(get_engine()) as session:
+        r = session.execute(
+            text(
+                """
+                SELECT id, seq, name, status, latency_ms, queue_wait_ms,
+                       cpu_ms, peak_rss_mib, result_count, result, error
+                FROM demo.load_scan
+                WHERE run_id = :id AND id = :scan_id
+                """
+            ),
+            {"id": run_id, "scan_id": scan_id},
+        ).fetchone()
+    if r is None:
+        return None
+    return {
+        "id": r.id,
+        "seq": r.seq,
+        "name": r.name,
+        "status": r.status,
+        "latency_ms": r.latency_ms,
+        "queue_wait_ms": r.queue_wait_ms,
+        "cpu_ms": r.cpu_ms,
+        "peak_rss_mib": r.peak_rss_mib,
+        "result_count": r.result_count,
+        "result": r.result,
+        "error": r.error,
+    }
+
+
+async def _dispatch_drain(run_id: str, workload: str, duration_s: int) -> None:
+    """Run the drain and finalize; log (never raise) on unexpected failure."""
+    try:
+        store = loadtest.LoadStore(run_id, workload)
+        await loadtest.run_load_test(run_id, workload, store, duration_s=duration_s)
+    except Exception:  # noqa: BLE001: detached task; surface via logs only
+        logger.exception("load-test drain failed for run %s", run_id)
+
+
+@router.post("/load-test/{workload}")
+async def start_load_test(workload: str) -> dict:
+    """Start a load-test drain for ``workload`` (semgrep or sandbox).
+
+    Guards: an already-running run short-circuits (returns its id with
+    ``already_running``); an active goose agent run refuses with HTTP 409.
+    Otherwise inserts a load_run row and dispatches ``run_load_test`` on a
+    detached task, returning the new run id immediately.
+    """
+    if workload not in loadtest.WORKLOADS:
+        raise HTTPException(status_code=404, detail=f"unknown workload: {workload}")
+
+    running = await asyncio.to_thread(_running_load_run)
+    if running is not None:
+        return {"run_id": running["id"], "already_running": True}
+
+    if await asyncio.to_thread(_agent_is_busy):
+        raise HTTPException(
+            status_code=409,
+            detail="an agent run is active; load test refused to avoid "
+            "contending for node-4 capacity",
+        )
+
+    corpus = load_corpus(workload)
+    config = {
+        "workload": workload,
+        "daemon_concurrency": loadtest.DAEMON_CONCURRENCY,
+        "client_concurrency": 20,
+        "vcpus": loadtest.VCPUS_PER_SCAN,
+        "mem_mib": _WORKLOAD_MEM_MIB[workload],
+        "node": loadtest.SAMPLE_NODE,
+        "corpus": [c["name"] for c in corpus],
+    }
+    run_id = await asyncio.to_thread(_insert_load_run, workload, config)
+
+    task = asyncio.create_task(_dispatch_drain(run_id, workload, 120))
+    _RUNNING_DRAINS.add(task)
+    task.add_done_callback(_RUNNING_DRAINS.discard)
+
+    return {"run_id": run_id}
+
+
+@router.get("/load-test/{run_id}")
+async def get_load_test(run_id: str) -> dict:
+    """Return the run row + a cheap live rollup (and summary when done)."""
+    rollup = await asyncio.to_thread(_load_run_rollup, run_id)
+    if rollup is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    return rollup
+
+
+@router.get("/load-test/{run_id}/scans")
+async def get_load_test_scans(run_id: str, offset: int = 0, limit: int = 50) -> dict:
+    """Return a paginated page of scan rows (without the ``result`` column)."""
+    limit = max(1, min(limit, 500))
+    offset = max(0, offset)
+    return await asyncio.to_thread(_load_scans_page, run_id, offset, limit)
+
+
+@router.get("/load-test/{run_id}/scans/{scan_id}")
+async def get_load_test_scan(run_id: str, scan_id: int) -> dict:
+    """Return one scan row WITH its ``result`` payload."""
+    detail = await asyncio.to_thread(_load_scan_detail, run_id, scan_id)
+    if detail is None:
+        raise HTTPException(status_code=404, detail="scan not found")
+    return detail

--- a/projects/monolith/demos/loadtest.py
+++ b/projects/monolith/demos/loadtest.py
@@ -1,0 +1,601 @@
+"""Workload-parametric load-test drain for the firecracker demos page.
+
+Drains a corpus of example files through the fc-invoke daemon (semgrep or
+sandbox workload) as fast as the daemon's per-workload semaphore allows, for a
+fixed run duration. It:
+
+- oversubscribes the daemon (``client_concurrency`` = 20 > daemon concurrency
+  15) so the daemon's semaphore stays saturated and throughput is daemon-bound;
+- buffers per-scan rows and writes them to ``demo.load_scan`` in batched
+  multi-row INSERTs (via a sync engine off the event loop);
+- samples the fc-invoke pod and node-4 resource footprint every ~2s
+  best-effort; and
+- computes an aggregate summary (percentiles, per-language breakdown, daemon +
+  node footprint, and a per-node/per-core throughput extrapolation) into
+  ``demo.load_run.summary``.
+
+All DB work is synchronous SQLAlchemy (``app.db`` engine) run in a worker
+thread via ``asyncio.to_thread`` so the drain never blocks the event loop. The
+drain logic is unit-testable without a real DB by injecting a fake ``_invoke``
+and an in-memory store subclass (see ``loadtest_test.py``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+import json
+import logging
+import os
+import time
+from time import perf_counter
+from typing import Any, Awaitable, Callable
+
+import httpx
+from sqlalchemy import text
+from sqlmodel import Session
+
+from app.db import get_engine
+from cluster.api import KubernetesClient
+from demos.loadtest_corpus import load_corpus
+from shared.k8s_auth import auth_headers
+
+logger = logging.getLogger(__name__)
+
+FC_INVOKE_URL = os.environ.get("FC_INVOKE_URL", "")
+
+# The daemon runs each workload at concurrency 15 on node-4, one vcpu per VM.
+DAEMON_CONCURRENCY = 15
+VCPUS_PER_SCAN = 1
+FC_INVOKE_NAMESPACE = "monolith"
+# The fc-invoke pod name carries this prefix; pod-metrics lookup matches on it.
+FC_INVOKE_POD_PREFIX = "fc-invoke"
+SAMPLE_NODE = "node-4"
+
+# Auto-flush the scan buffer once it reaches this many rows (one INSERT).
+_FLUSH_THRESHOLD = 200
+
+
+def _parse_semgrep_result(resp: dict) -> tuple[dict, int | None]:
+    findings = resp.get("findings", []) or []
+    errors = resp.get("errors", []) or []
+    return {"findings": findings, "errors": errors}, len(findings)
+
+
+def _parse_sandbox_result(resp: dict) -> tuple[dict, int | None]:
+    return (
+        {
+            "stdout": resp.get("stdout", ""),
+            "stderr": resp.get("stderr", ""),
+            "exit_code": resp.get("exit_code"),
+            "duration_ms": resp.get("duration_ms"),
+            "truncated": resp.get("truncated"),
+        },
+        None,
+    )
+
+
+# Workload registry: each workload knows how to build its /invoke payload from a
+# corpus item, how to parse a 2xx response into (result_jsonb, result_count),
+# and its read timeout (a bit past the daemon's per-workload request budget).
+WORKLOADS: dict[str, dict[str, Any]] = {
+    "semgrep": {
+        "build_payload": lambda item: {
+            "files": [{"path": item["path"], "content": item["content"]}]
+        },
+        "parse_result": _parse_semgrep_result,
+        "read_timeout": 95.0,
+    },
+    "sandbox": {
+        "build_payload": lambda item: {"code": item["content"]},
+        "parse_result": _parse_sandbox_result,
+        "read_timeout": 40.0,
+    },
+}
+
+
+def _parse_int_header(value: str | None) -> int | None:
+    """Parse an X-Fc-* integer header, returning None when absent/unparseable."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+async def _invoke(
+    workload: str, payload: dict, timeout: float
+) -> tuple[dict, dict, str | None]:
+    """POST one payload to ``/invoke/{workload}`` and return (json, meta, error).
+
+    On any 2xx: returns the decoded JSON plus a ``meta`` dict carrying the
+    daemon's per-scan resource headers (``cpu_ms``, ``peak_rss_mib``,
+    ``queue_wait_ms``), each an int or None. On ANY failure (bad status,
+    connect, timeout, decode, unexpected exception) it returns
+    ``({}, {}, "<error>")`` and never raises, so one bad scan cannot kill a
+    worker.
+    """
+    if not FC_INVOKE_URL:
+        return {}, {}, "FC_INVOKE_URL is not configured"
+
+    client_timeout = httpx.Timeout(timeout, connect=5.0)
+    try:
+        async with httpx.AsyncClient(timeout=client_timeout) as client:
+            resp = await client.post(
+                f"{FC_INVOKE_URL}/invoke/{workload}",
+                json=payload,
+                headers=auth_headers(),
+            )
+            resp.raise_for_status()
+            meta = {
+                "cpu_ms": _parse_int_header(resp.headers.get("X-Fc-Cpu-Ms")),
+                "peak_rss_mib": _parse_int_header(
+                    resp.headers.get("X-Fc-Peak-Rss-Mib")
+                ),
+                "queue_wait_ms": _parse_int_header(
+                    resp.headers.get("X-Fc-Queue-Wait-Ms")
+                ),
+            }
+            return resp.json(), meta, None
+    except httpx.HTTPStatusError as exc:
+        return {}, {}, f"HTTP {exc.response.status_code}: {exc.response.text[:200]}"
+    except Exception as exc:  # noqa: BLE001
+        # Not swallowed: the failure is surfaced to the caller as the error
+        # element of the return tuple and recorded as a status='error' scan row.
+        # Logged at debug so a saturated drain's thousands of expected
+        # connect/timeout errors do not flood the log at the default level.
+        logger.debug("load-test invoke failed: %s", exc)
+        return {}, {}, f"{type(exc).__name__}: {exc}"
+
+
+class LoadStore:
+    """Buffered writer + summary finalizer over ``demo.load_scan`` / ``load_run``.
+
+    ``record`` appends a scan row and flushes when the buffer fills; ``finalize``
+    flushes the tail, computes the summary, and stamps the run done. All DB work
+    is synchronous SQLAlchemy run off the event loop via ``asyncio.to_thread``.
+    Tests use ``FakeLoadStore`` (below) to exercise the drain with no DB.
+    """
+
+    def __init__(self, run_id: str, workload: str) -> None:
+        self.run_id = run_id
+        self.workload = workload
+        self._buffer: list[dict] = []
+        # Every recorded row, retained for the in-process summary computation so
+        # finalize does not have to re-read them from Postgres.
+        self._all_rows: list[dict] = []
+        self._sampler_series: list[dict] = []
+        self._lock = asyncio.Lock()
+
+    def set_sampler_series(self, series: list[dict]) -> None:
+        self._sampler_series = series
+
+    async def record(self, row: dict) -> None:
+        """Append a scan row; flush the buffer to Postgres when it fills."""
+        async with self._lock:
+            self._all_rows.append(row)
+            self._buffer.append(row)
+            if len(self._buffer) >= _FLUSH_THRESHOLD:
+                batch, self._buffer = self._buffer, []
+                await asyncio.to_thread(self._flush_batch, batch)
+
+    async def flush(self) -> None:
+        """Flush any buffered rows to Postgres in one INSERT."""
+        async with self._lock:
+            if not self._buffer:
+                return
+            batch, self._buffer = self._buffer, []
+        await asyncio.to_thread(self._flush_batch, batch)
+
+    def _flush_batch(self, batch: list[dict]) -> None:
+        """One multi-row INSERT into demo.load_scan. Sync; runs in a thread."""
+        if not batch:
+            return
+        params = [
+            {
+                "run_id": self.run_id,
+                "workload": self.workload,
+                "seq": r.get("seq"),
+                "name": r.get("name"),
+                "status": r.get("status"),
+                "latency_ms": r.get("latency_ms"),
+                "queue_wait_ms": r.get("queue_wait_ms"),
+                "cpu_ms": r.get("cpu_ms"),
+                "peak_rss_mib": r.get("peak_rss_mib"),
+                "result_count": r.get("result_count"),
+                "result": json.dumps(r.get("result"))
+                if r.get("result") is not None
+                else None,
+                "error": r.get("error"),
+            }
+            for r in batch
+        ]
+        with Session(get_engine()) as session:
+            session.execute(
+                text(
+                    """
+                    INSERT INTO demo.load_scan
+                        (run_id, workload, seq, name, status, latency_ms,
+                         queue_wait_ms, cpu_ms, peak_rss_mib, result_count,
+                         result, error)
+                    VALUES
+                        (:run_id, :workload, :seq, :name, :status, :latency_ms,
+                         :queue_wait_ms, :cpu_ms, :peak_rss_mib, :result_count,
+                         CAST(:result AS jsonb), :error)
+                    """
+                ),
+                params,
+            )
+            session.commit()
+
+    async def finalize(self, run_id: str) -> dict:
+        """Flush the tail, compute the summary, and mark the run done."""
+        await self.flush()
+        summary = build_summary(self.workload, self._all_rows, self._sampler_series)
+        await asyncio.to_thread(self._write_summary, run_id, summary)
+        return summary
+
+    def _write_summary(self, run_id: str, summary: dict) -> None:
+        """Stamp the run done with its summary. Sync; runs in a thread."""
+        with Session(get_engine()) as session:
+            session.execute(
+                text(
+                    """
+                    UPDATE demo.load_run
+                       SET finished_at = now(),
+                           status = 'done',
+                           summary = CAST(:summary AS jsonb)
+                     WHERE id = :id
+                    """
+                ),
+                {"summary": json.dumps(summary), "id": run_id},
+            )
+            session.commit()
+
+
+def _percentile(sorted_vals: list[float], q: float) -> float | None:
+    """Simple sorted-index percentile (q in [0,1]); None on empty input."""
+    if not sorted_vals:
+        return None
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    idx = q * (len(sorted_vals) - 1)
+    lo = int(idx)
+    hi = min(lo + 1, len(sorted_vals) - 1)
+    frac = idx - lo
+    return sorted_vals[lo] + (sorted_vals[hi] - sorted_vals[lo]) * frac
+
+
+def _pct_block(values: list[float], qs: tuple[float, ...]) -> dict:
+    s = sorted(v for v in values if v is not None)
+    labels = {0.5: "p50", 0.95: "p95", 1.0: "max"}
+    return {labels[q]: _percentile(s, q) for q in qs}
+
+
+def _mean_max(values: list[float]) -> dict:
+    vals = [v for v in values if v is not None]
+    if not vals:
+        return {"mean": None, "max": None}
+    return {"mean": sum(vals) / len(vals), "max": max(vals)}
+
+
+def build_summary(workload: str, rows: list[dict], sampler_series: list[dict]) -> dict:
+    """Aggregate scan rows + sampler series into the run summary jsonb.
+
+    Percentiles are a simple sorted-index estimate (no numpy dependency). When
+    the sampler series is empty (metrics unavailable), ``daemon.source`` is
+    ``"derived"`` and daemon RSS is estimated from per-scan peak RSS; node stats
+    are omitted.
+    """
+    total = len(rows)
+    errors = sum(1 for r in rows if r.get("status") == "error")
+    ok_rows = [r for r in rows if r.get("status") == "ok"]
+
+    latencies = [r.get("latency_ms") for r in rows if r.get("latency_ms") is not None]
+    wall_s = (sum(latencies) / 1000.0) if latencies else 0.0
+    # Wall time of the run: span from the drain, approximated by max scan
+    # finish. We store throughput against the configured duration downstream;
+    # here wall_s is the summed VM-seconds proxy used for extrapolation below.
+
+    # Actual run wall clock comes from the run row's timestamps at query time;
+    # for the summary we use total / duration via the throughput field the
+    # caller fills. We compute throughput from total scans over the observed
+    # span of the sampler (best proxy) or fall back to summed latencies.
+    observed_wall = None
+    if sampler_series:
+        ts = [s.get("t") for s in sampler_series if s.get("t") is not None]
+        if len(ts) >= 2:
+            observed_wall = max(ts) - min(ts)
+    run_wall_s = observed_wall if observed_wall and observed_wall > 0 else wall_s
+    throughput = (total / run_wall_s) if run_wall_s and run_wall_s > 0 else 0.0
+
+    lat_vals = [float(v) for v in latencies]
+    queue_vals = [
+        float(r["queue_wait_ms"]) for r in rows if r.get("queue_wait_ms") is not None
+    ]
+    cpu_vals = [float(r["cpu_ms"]) for r in rows if r.get("cpu_ms") is not None]
+    rss_vals = [
+        float(r["peak_rss_mib"]) for r in rows if r.get("peak_rss_mib") is not None
+    ]
+
+    per_lang: dict[str, dict] = {}
+    names = {r.get("name") for r in rows if r.get("name") is not None}
+    for name in names:
+        group = [r for r in rows if r.get("name") == name]
+        g_lat = sorted(
+            float(r["latency_ms"]) for r in group if r.get("latency_ms") is not None
+        )
+        g_cpu = sorted(float(r["cpu_ms"]) for r in group if r.get("cpu_ms") is not None)
+        per_lang[name] = {
+            "count": len(group),
+            "p50_ms": _percentile(g_lat, 0.5),
+            "p50_cpu_ms": _percentile(g_cpu, 0.5),
+        }
+
+    summary: dict[str, Any] = {
+        "total_scans": total,
+        "errors": errors,
+        "wall_s": run_wall_s,
+        "throughput_per_s": throughput,
+        "latency_ms": _pct_block(lat_vals, (0.5, 0.95, 1.0)),
+        "queue_wait_ms": _pct_block(queue_vals, (0.5, 0.95)),
+        "per_scan_cpu_ms": _pct_block(cpu_vals, (0.5, 0.95)),
+        "per_scan_peak_rss_mib": _pct_block(rss_vals, (0.5, 0.95)),
+        "per_lang": per_lang,
+    }
+
+    # Workload-specific result signal: semgrep reports finding counts, sandbox
+    # reports its exit-code distribution.
+    if workload == "sandbox":
+        ok_exit = sum(
+            1 for r in ok_rows if (r.get("result") or {}).get("exit_code") == 0
+        )
+        nonzero = sum(
+            1
+            for r in ok_rows
+            if (r.get("result") or {}).get("exit_code") not in (0, None)
+        )
+        summary["sandbox_exit"] = {"ok_count": ok_exit, "nonzero_count": nonzero}
+    else:
+        rc = [
+            float(r["result_count"]) for r in rows if r.get("result_count") is not None
+        ]
+        summary["result_count"] = _pct_block(rc, (0.5, 0.95, 1.0))
+
+    # Daemon + node footprint from the sampler, or a derived estimate.
+    if sampler_series:
+        summary["daemon"] = {
+            "pod_cpu_m": _mean_max([s.get("pod_cpu_m") for s in sampler_series]),
+            "pod_rss_mib": _mean_max([s.get("pod_rss_mib") for s in sampler_series]),
+            "source": "metrics",
+        }
+        summary["node"] = {
+            "cpu_m": _mean_max([s.get("node_cpu_m") for s in sampler_series]),
+            "rss_mib": _mean_max([s.get("node_rss_mib") for s in sampler_series]),
+        }
+    else:
+        # No live metrics: estimate daemon RSS as the worst single-scan peak
+        # times the daemon concurrency (approximates the max concurrent
+        # footprint), and omit node stats.
+        max_scan_rss = max(rss_vals) if rss_vals else None
+        derived_rss = (
+            max_scan_rss * DAEMON_CONCURRENCY if max_scan_rss is not None else None
+        )
+        summary["daemon"] = {
+            "pod_cpu_m": {"mean": None, "max": None},
+            "pod_rss_mib": {"mean": derived_rss, "max": derived_rss},
+            "source": "derived",
+        }
+
+    # Extrapolation: throughput is core-bound at ~scans/core/s; N nodes scale
+    # roughly linearly minus fixed per-node daemon overhead.
+    concurrency_cores = DAEMON_CONCURRENCY * VCPUS_PER_SCAN
+    scans_per_core_s = throughput / concurrency_cores if concurrency_cores else 0.0
+    vm_seconds = wall_s  # sum of latency_ms / 1000 across all scans
+    summary["extrapolation"] = {
+        "per_node_throughput_per_s": throughput,
+        "scans_per_core_s": scans_per_core_s,
+        "vm_seconds": vm_seconds,
+        "note": (
+            f"Throughput is core-bound at ~{scans_per_core_s:.2f} scans/core/s; "
+            f"N nodes ~= N x {throughput:.2f} per_node_throughput_per_s (minus "
+            "fixed daemon overhead per node)."
+        ),
+    }
+    return summary
+
+
+def _pod_cpu_milli_and_rss_mib(pod_metric: dict) -> tuple[float, float]:
+    """Sum a pod-metrics object's container cpu (millicores) and rss (MiB)."""
+    from cluster.kubernetes import _parse_cpu, _parse_memory  # reuse parsers
+
+    cpu_cores = 0.0
+    rss_bytes = 0.0
+    for c in pod_metric.get("containers", []) or []:
+        usage = c.get("usage", {}) or {}
+        cpu_cores += _parse_cpu(usage.get("cpu", "0"))
+        rss_bytes += _parse_memory(usage.get("memory", "0"))
+    return cpu_cores * 1000.0, rss_bytes / (1024**2)
+
+
+async def sample_resources(
+    stop_event: asyncio.Event, client: KubernetesClient | None = None
+) -> list[dict]:
+    """Sample fc-invoke pod + node-4 footprint every ~2s until ``stop_event``.
+
+    Best-effort: any sampling failure (RBAC/API error) is logged once and the
+    loop keeps going, returning whatever series was collected (possibly empty).
+    """
+    series: list[dict] = []
+    kube = client or KubernetesClient()
+    owns_client = client is None
+    logged_error = False
+    start = time.monotonic()
+    try:
+        while not stop_event.is_set():
+            try:
+                pod_cpu_m, pod_rss_mib, node_cpu_m, node_rss_mib = await _sample_once(
+                    kube
+                )
+                series.append(
+                    {
+                        "t": time.monotonic() - start,
+                        "pod_cpu_m": pod_cpu_m,
+                        "pod_rss_mib": pod_rss_mib,
+                        "node_cpu_m": node_cpu_m,
+                        "node_rss_mib": node_rss_mib,
+                    }
+                )
+            except Exception:  # noqa: BLE001: sampling is best-effort
+                if not logged_error:
+                    logger.warning(
+                        "load-test resource sampling unavailable; "
+                        "continuing with best-effort series",
+                        exc_info=True,
+                    )
+                    logged_error = True
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=2.0)
+            except asyncio.TimeoutError:
+                pass
+    finally:
+        if owns_client:
+            await kube.close()
+    return series
+
+
+async def _sample_once(
+    kube: KubernetesClient,
+) -> tuple[float | None, float | None, float | None, float | None]:
+    """One sample: fc-invoke pod cpu/rss (from pod-metrics) + node-4 cpu/rss."""
+    pod_cpu_m = pod_rss_mib = None
+    pod_metrics = await kube.pod_metrics(FC_INVOKE_NAMESPACE)
+    for item in pod_metrics:
+        name = (item.get("metadata", {}) or {}).get("name", "")
+        if name.startswith(FC_INVOKE_POD_PREFIX):
+            pod_cpu_m, pod_rss_mib = _pod_cpu_milli_and_rss_mib(item)
+            break
+
+    node = await kube.aggregate_node_resources()
+    node_cpu_m = node.get("cpu_used_cores", 0.0) * 1000.0
+    node_rss_mib = node.get("memory_used_bytes", 0.0) / (1024**2)
+    return pod_cpu_m, pod_rss_mib, node_cpu_m, node_rss_mib
+
+
+async def run_load_test(
+    run_id: str,
+    workload: str,
+    store: LoadStore,
+    duration_s: int = 120,
+    client_concurrency: int = 20,
+    corpus: list[dict] | None = None,
+    sampler: Callable[[asyncio.Event], Awaitable[list[dict]]] | None = None,
+    invoke: Callable[..., Awaitable[tuple[dict, dict, str | None]]] | None = None,
+) -> None:
+    """Drain ``corpus`` through the daemon for ``duration_s`` seconds.
+
+    ``client_concurrency`` (20) intentionally EXCEEDS the daemon's per-workload
+    concurrency (15), so the daemon's semaphore stays saturated and the drain
+    runs as fast as the daemon allows. Each of ``client_concurrency`` worker
+    tasks loops until the deadline, pulling the next corpus item round-robin,
+    invoking the daemon, timing wall latency, and recording the row. A resource
+    sampler runs alongside and is cancelled after the workers finish; then the
+    store is finalized (tail flush + summary + run marked done).
+
+    ``sampler`` and ``invoke`` are injectable for tests (defaults use the real
+    ones). No scan exception ever kills a worker: it is caught and recorded as a
+    ``status='error'`` row.
+    """
+    spec = WORKLOADS[workload]
+    if corpus is None:
+        corpus = load_corpus(workload)
+    if not corpus:
+        await store.finalize(run_id)
+        return
+    invoke_fn = invoke or _invoke
+    sampler_fn = sampler or sample_resources
+
+    build_payload = spec["build_payload"]
+    parse_result = spec["parse_result"]
+    read_timeout = spec["read_timeout"]
+
+    deadline = time.monotonic() + duration_s
+    counter = itertools.count()
+    seq_counter = itertools.count()
+
+    stop_event = asyncio.Event()
+    sampler_task = asyncio.create_task(sampler_fn(stop_event))
+
+    async def worker() -> None:
+        while time.monotonic() < deadline:
+            i = next(counter)
+            item = corpus[i % len(corpus)]
+            seq = next(seq_counter)
+            started = perf_counter()
+            try:
+                payload = build_payload(item)
+                resp, meta, error = await invoke_fn(workload, payload, read_timeout)
+                latency_ms = int((perf_counter() - started) * 1000)
+                if error is not None:
+                    row = {
+                        "seq": seq,
+                        "workload": workload,
+                        "name": item["name"],
+                        "status": "error",
+                        "latency_ms": latency_ms,
+                        "queue_wait_ms": None,
+                        "cpu_ms": None,
+                        "peak_rss_mib": None,
+                        "result_count": None,
+                        "result": None,
+                        "error": error,
+                    }
+                else:
+                    result_jsonb, result_count = parse_result(resp)
+                    row = {
+                        "seq": seq,
+                        "workload": workload,
+                        "name": item["name"],
+                        "status": "ok",
+                        "latency_ms": latency_ms,
+                        "queue_wait_ms": meta.get("queue_wait_ms"),
+                        "cpu_ms": meta.get("cpu_ms"),
+                        "peak_rss_mib": meta.get("peak_rss_mib"),
+                        "result_count": result_count,
+                        "result": result_jsonb,
+                        "error": None,
+                    }
+            except Exception as exc:  # noqa: BLE001
+                # Never let one scan kill a worker: the failure is not swallowed
+                # but recorded as a status='error' scan row (detail below), and
+                # logged at debug so it is visible without flooding the log.
+                logger.debug("load-test scan raised: %s", exc)
+                latency_ms = int((perf_counter() - started) * 1000)
+                row = {
+                    "seq": seq,
+                    "workload": workload,
+                    "name": item.get("name"),
+                    "status": "error",
+                    "latency_ms": latency_ms,
+                    "queue_wait_ms": None,
+                    "cpu_ms": None,
+                    "peak_rss_mib": None,
+                    "result_count": None,
+                    "result": None,
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+            await store.record(row)
+
+    workers = [asyncio.create_task(worker()) for _ in range(client_concurrency)]
+    try:
+        await asyncio.gather(*workers)
+    finally:
+        stop_event.set()
+        try:
+            series = await sampler_task
+        except Exception:  # noqa: BLE001: sampler is best-effort
+            logger.exception("load-test resource sampler task failed")
+            series = []
+        store.set_sampler_series(series or [])
+        await store.finalize(run_id)

--- a/projects/monolith/demos/loadtest.py
+++ b/projects/monolith/demos/loadtest.py
@@ -55,6 +55,13 @@ SAMPLE_NODE = "node-4"
 # Auto-flush the scan buffer once it reaches this many rows (one INSERT).
 _FLUSH_THRESHOLD = 200
 
+# Grace window past the drain deadline for in-flight invokes to finish before
+# stragglers are cancelled. A normal scan is ~1s, so this lets legitimately
+# in-flight scans complete while bounding a wedged run (the run row is the
+# one-run lock, so an unbounded drain would block the next run for up to a full
+# read_timeout). Total drain is thus capped at duration_s + _DRAIN_GRACE_S.
+_DRAIN_GRACE_S = 10
+
 
 def _parse_semgrep_result(resp: dict) -> tuple[dict, int | None]:
     findings = resp.get("findings", []) or []
@@ -589,7 +596,19 @@ async def run_load_test(
 
     workers = [asyncio.create_task(worker()) for _ in range(client_concurrency)]
     try:
-        await asyncio.gather(*workers)
+        # Workers stop starting scans at the deadline, but an in-flight invoke can
+        # run up to read_timeout past it. Cap the overrun with a grace window, then
+        # cancel any straggler so the run always finalizes promptly (a wedged drain
+        # would otherwise hold the 'running' one-run lock and block the next run).
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*workers, return_exceptions=True),
+                timeout=duration_s + _DRAIN_GRACE_S,
+            )
+        except asyncio.TimeoutError:
+            for w in workers:
+                w.cancel()
+            await asyncio.gather(*workers, return_exceptions=True)
     finally:
         stop_event.set()
         try:

--- a/projects/monolith/demos/loadtest_corpus/__init__.py
+++ b/projects/monolith/demos/loadtest_corpus/__init__.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+_DIR = Path(__file__).parent
+
+# workload -> list of (on-disk filename, name, optional virtual path for semgrep)
+_SEMGREP = [
+    ("python.sample", "python", "corpus/app_python.py"),
+    ("golang.sample", "golang", "corpus/app_go.go"),
+    ("javascript.sample", "javascript", "corpus/app_ts.ts"),
+    ("kubernetes.sample", "kubernetes", "corpus/manifest.yaml"),
+    ("rust.sample", "rust", "corpus/app_rs.rs"),
+]
+
+
+def load_corpus(workload: str) -> list[dict]:
+    """Return corpus entries for a workload.
+
+    semgrep entries: {name, path, content} (path is the virtual scan path,
+    whose extension selects the language pack). sandbox entries: {name, content}.
+    """
+    if workload == "semgrep":
+        base = _DIR / "semgrep"
+        return [
+            {"name": name, "path": vpath, "content": (base / fname).read_text()}
+            for fname, name, vpath in _SEMGREP
+        ]
+    if workload == "sandbox":
+        base = _DIR / "sandbox"
+        return sorted(
+            ({"name": p.stem, "content": p.read_text()} for p in base.glob("*.sample")),
+            key=lambda e: e["name"],
+        )
+    raise ValueError(f"unknown workload: {workload}")

--- a/projects/monolith/demos/loadtest_corpus/sandbox/json_roundtrip.sample
+++ b/projects/monolith/demos/loadtest_corpus/sandbox/json_roundtrip.sample
@@ -1,0 +1,70 @@
+"""JSON serialize/parse round-trip workload: exercises stdlib `json` on a
+moderately large nested structure rather than numeric or array compute.
+"""
+
+import json
+import random
+
+
+def build_record(rng: random.Random, index: int) -> dict:
+    return {
+        "id": index,
+        "name": f"entity-{index}",
+        "tags": [f"tag-{rng.randint(0, 50)}" for _ in range(rng.randint(1, 5))],
+        "metrics": {
+            "latency_ms": rng.uniform(1.0, 500.0),
+            "requests": rng.randint(0, 10_000),
+            "error_rate": rng.uniform(0.0, 0.1),
+        },
+        "nested": {
+            "children": [
+                {"key": f"child-{i}", "value": rng.random()}
+                for i in range(rng.randint(0, 4))
+            ]
+        },
+        "active": rng.random() > 0.2,
+    }
+
+
+def build_dataset(count: int, rng: random.Random) -> list[dict]:
+    return [build_record(rng, i) for i in range(count)]
+
+
+def round_trip(records: list[dict]) -> list[dict]:
+    serialized = json.dumps(records)
+    return json.loads(serialized)
+
+
+def validate_round_trip(original: list[dict], restored: list[dict]) -> bool:
+    return original == restored
+
+
+def aggregate_metrics(records: list[dict]) -> dict:
+    total_requests = sum(r["metrics"]["requests"] for r in records)
+    avg_latency = sum(r["metrics"]["latency_ms"] for r in records) / len(records)
+    active_count = sum(1 for r in records if r["active"])
+    return {
+        "total_requests": total_requests,
+        "avg_latency_ms": avg_latency,
+        "active_count": active_count,
+    }
+
+
+def main() -> None:
+    rng = random.Random(23)
+    dataset = build_dataset(5_000, rng)
+
+    restored = round_trip(dataset)
+    matches = validate_round_trip(dataset, restored)
+    aggregates = aggregate_metrics(restored)
+
+    serialized_size = len(json.dumps(dataset))
+
+    print(f"records = {len(dataset)}")
+    print(f"round trip matches = {matches}")
+    print(f"serialized size = {serialized_size} bytes")
+    print(f"aggregates = {aggregates}")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/monolith/demos/loadtest_corpus/sandbox/numeric_loop.sample
+++ b/projects/monolith/demos/loadtest_corpus/sandbox/numeric_loop.sample
@@ -1,0 +1,49 @@
+"""CPU-heavy numeric loop: no imports beyond stdlib, deliberately avoids
+vectorized shortcuts so the loop body actually burns CPU cycles. Exercises
+the "heavy compute, no external libs" corner of the load-test latency
+distribution.
+"""
+
+import math
+
+
+def is_prime(n: int) -> bool:
+    if n < 2:
+        return False
+    if n % 2 == 0:
+        return n == 2
+    limit = int(math.isqrt(n))
+    for divisor in range(3, limit + 1, 2):
+        if n % divisor == 0:
+            return False
+    return True
+
+
+def sum_of_primes(upper_bound: int) -> int:
+    total = 0
+    for candidate in range(2, upper_bound):
+        if is_prime(candidate):
+            total += candidate
+    return total
+
+
+def digit_sum_series(count: int) -> int:
+    total = 0
+    for i in range(count):
+        n = i
+        while n:
+            total += n % 10
+            n //= 10
+    return total
+
+
+def main() -> None:
+    prime_total = sum_of_primes(60_000)
+    digit_total = digit_sum_series(200_000)
+    print(f"sum_of_primes(60000) = {prime_total}")
+    print(f"digit_sum_series(200000) = {digit_total}")
+    print(f"combined = {prime_total + digit_total}")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/monolith/demos/loadtest_corpus/sandbox/numpy_matmul.sample
+++ b/projects/monolith/demos/loadtest_corpus/sandbox/numpy_matmul.sample
@@ -1,0 +1,53 @@
+"""NumPy matrix multiply workload: exercises the warm scientific-library
+page cache with BLAS-backed dense linear algebra rather than pure-Python
+loops.
+"""
+
+import numpy as np
+
+
+def random_matrix(rows: int, cols: int, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal((rows, cols))
+
+
+def multiply_and_stats(a: np.ndarray, b: np.ndarray) -> dict:
+    product = a @ b
+    return {
+        "shape": product.shape,
+        "mean": float(product.mean()),
+        "std": float(product.std()),
+        "max": float(product.max()),
+        "min": float(product.min()),
+    }
+
+
+def normalize_rows(matrix: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    return matrix / norms
+
+
+def top_k_eigenvalues(matrix: np.ndarray, k: int) -> np.ndarray:
+    symmetric = (matrix + matrix.T) / 2
+    eigenvalues = np.linalg.eigvalsh(symmetric)
+    return np.sort(eigenvalues)[-k:]
+
+
+def main() -> None:
+    a = random_matrix(400, 400, seed=1)
+    b = random_matrix(400, 400, seed=2)
+
+    stats = multiply_and_stats(a, b)
+    normalized = normalize_rows(a)
+    top_eigs = top_k_eigenvalues(a[:200, :200], k=5)
+
+    print(f"product shape = {stats['shape']}")
+    print(f"mean = {stats['mean']:.4f}, std = {stats['std']:.4f}")
+    print(f"min = {stats['min']:.4f}, max = {stats['max']:.4f}")
+    print(f"row norms after normalize (first 3) = {np.linalg.norm(normalized, axis=1)[:3]}")
+    print(f"top 5 eigenvalues = {top_eigs}")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/monolith/demos/loadtest_corpus/sandbox/pandas_groupby.sample
+++ b/projects/monolith/demos/loadtest_corpus/sandbox/pandas_groupby.sample
@@ -1,0 +1,57 @@
+"""Small pandas DataFrame groupby/aggregation workload: exercises the warm
+scientific-library page cache (pandas is preloaded in the sandbox guest
+image) rather than raw stdlib compute.
+"""
+
+import random
+
+import pandas as pd
+
+
+def build_dataframe(rows: int, rng: random.Random) -> pd.DataFrame:
+    regions = ["us-east", "us-west", "eu-central", "ap-south"]
+    services = ["monolith", "semgrep", "sandbox", "chat"]
+    return pd.DataFrame(
+        {
+            "region": [rng.choice(regions) for _ in range(rows)],
+            "service": [rng.choice(services) for _ in range(rows)],
+            "latency_ms": [rng.randint(5, 800) for _ in range(rows)],
+            "status_code": [rng.choice([200, 200, 200, 404, 500]) for _ in range(rows)],
+        }
+    )
+
+
+def summarize(df: pd.DataFrame) -> pd.DataFrame:
+    return (
+        df.groupby(["region", "service"])
+        .agg(
+            avg_latency_ms=("latency_ms", "mean"),
+            p95_latency_ms=("latency_ms", lambda s: s.quantile(0.95)),
+            request_count=("latency_ms", "size"),
+            error_count=("status_code", lambda s: (s >= 400).sum()),
+        )
+        .reset_index()
+    )
+
+
+def error_rate_by_service(df: pd.DataFrame) -> pd.Series:
+    errors = df["status_code"] >= 400
+    return errors.groupby(df["service"]).mean()
+
+
+def main() -> None:
+    rng = random.Random(11)
+    df = build_dataframe(15_000, rng)
+
+    summary = summarize(df)
+    error_rates = error_rate_by_service(df)
+
+    print(f"rows = {len(df)}")
+    print(f"summary rows = {len(summary)}")
+    print(summary.sort_values("request_count", ascending=False).head(5).to_string(index=False))
+    print("error rate by service:")
+    print(error_rates.round(4).to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/monolith/demos/loadtest_corpus/sandbox/quicksort_large_list.sample
+++ b/projects/monolith/demos/loadtest_corpus/sandbox/quicksort_large_list.sample
@@ -1,0 +1,60 @@
+"""Merge/quicksort on a large synthetic list: exercises recursion depth and
+list allocation churn rather than raw arithmetic. Uses stdlib `random` only.
+"""
+
+import random
+
+
+def quicksort(items: list[int]) -> list[int]:
+    if len(items) <= 1:
+        return items
+    pivot = items[len(items) // 2]
+    lesser = [x for x in items if x < pivot]
+    equal = [x for x in items if x == pivot]
+    greater = [x for x in items if x > pivot]
+    return quicksort(lesser) + equal + quicksort(greater)
+
+
+def merge_sort(items: list[int]) -> list[int]:
+    if len(items) <= 1:
+        return items
+    mid = len(items) // 2
+    left = merge_sort(items[:mid])
+    right = merge_sort(items[mid:])
+    return _merge(left, right)
+
+
+def _merge(left: list[int], right: list[int]) -> list[int]:
+    merged: list[int] = []
+    i = j = 0
+    while i < len(left) and j < len(right):
+        if left[i] <= right[j]:
+            merged.append(left[i])
+            i += 1
+        else:
+            merged.append(right[j])
+            j += 1
+    merged.extend(left[i:])
+    merged.extend(right[j:])
+    return merged
+
+
+def is_sorted(items: list[int]) -> bool:
+    return all(items[i] <= items[i + 1] for i in range(len(items) - 1))
+
+
+def main() -> None:
+    rng = random.Random(42)
+    data = [rng.randint(0, 1_000_000) for _ in range(20_000)]
+
+    quick_result = quicksort(list(data))
+    merge_result = merge_sort(list(data))
+
+    print(f"input size = {len(data)}")
+    print(f"quicksort sorted correctly = {is_sorted(quick_result)}")
+    print(f"merge_sort sorted correctly = {is_sorted(merge_result)}")
+    print(f"results match = {quick_result == merge_result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/monolith/demos/loadtest_corpus/sandbox/recursive_fibonacci.sample
+++ b/projects/monolith/demos/loadtest_corpus/sandbox/recursive_fibonacci.sample
@@ -1,0 +1,46 @@
+"""Naive recursive Fibonacci: deliberately exponential (no memoization) to
+exercise deep call-stack recursion and function-call overhead rather than
+loop or array throughput. Also includes a memoized variant for comparison.
+"""
+
+import time
+
+
+def fib_naive(n: int) -> int:
+    if n < 2:
+        return n
+    return fib_naive(n - 1) + fib_naive(n - 2)
+
+
+def fib_memo(n: int, cache: dict[int, int] | None = None) -> int:
+    if cache is None:
+        cache = {}
+    if n < 2:
+        return n
+    if n in cache:
+        return cache[n]
+    result = fib_memo(n - 1, cache) + fib_memo(n - 2, cache)
+    cache[n] = result
+    return result
+
+
+def fib_sequence_memo(count: int) -> list[int]:
+    cache: dict[int, int] = {}
+    return [fib_memo(i, cache) for i in range(count)]
+
+
+def main() -> None:
+    naive_n = 27
+    start = time.perf_counter()
+    naive_result = fib_naive(naive_n)
+    naive_elapsed = time.perf_counter() - start
+
+    sequence = fib_sequence_memo(40)
+
+    print(f"fib_naive({naive_n}) = {naive_result} in {naive_elapsed:.3f}s")
+    print(f"fib_memo sequence (first 40) tail = {sequence[-5:]}")
+    print(f"sum of memoized sequence = {sum(sequence)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/monolith/demos/loadtest_corpus/sandbox/regex_text_processing.sample
+++ b/projects/monolith/demos/loadtest_corpus/sandbox/regex_text_processing.sample
@@ -1,0 +1,90 @@
+"""Regex/text-processing pass over a synthetically generated corpus of log
+lines: exercises Python's `re` module and string handling rather than
+numeric or array workloads.
+"""
+
+import re
+import random
+
+_LEVELS = ["INFO", "WARN", "ERROR", "DEBUG"]
+_SERVICES = ["monolith", "semgrep", "sandbox", "goosecracker", "chat"]
+_MESSAGES = [
+    "request completed in {ms}ms",
+    "connection reset by peer on attempt {n}",
+    "cache miss for key user:{n}",
+    "retrying after backoff of {ms}ms",
+    "scheduled job finished with status ok",
+]
+
+_LOG_PATTERN = re.compile(
+    r"^(?P<level>INFO|WARN|ERROR|DEBUG)\s+"
+    r"\[(?P<service>[a-z\-]+)\]\s+"
+    r"(?P<message>.+)$"
+)
+_MS_PATTERN = re.compile(r"(\d+)ms")
+_KEY_PATTERN = re.compile(r"key (\w+):(\d+)")
+
+
+def generate_log_lines(count: int, rng: random.Random) -> list[str]:
+    lines = []
+    for _ in range(count):
+        level = rng.choice(_LEVELS)
+        service = rng.choice(_SERVICES)
+        template = rng.choice(_MESSAGES)
+        message = template.format(ms=rng.randint(1, 5000), n=rng.randint(1, 9999))
+        lines.append(f"{level} [{service}] {message}")
+    return lines
+
+
+def parse_lines(lines: list[str]) -> list[dict]:
+    parsed = []
+    for line in lines:
+        match = _LOG_PATTERN.match(line)
+        if match:
+            parsed.append(match.groupdict())
+    return parsed
+
+
+def extract_latencies(lines: list[str]) -> list[int]:
+    latencies = []
+    for line in lines:
+        for match in _MS_PATTERN.finditer(line):
+            latencies.append(int(match.group(1)))
+    return latencies
+
+
+def extract_cache_keys(lines: list[str]) -> list[tuple[str, int]]:
+    keys = []
+    for line in lines:
+        for match in _KEY_PATTERN.finditer(line):
+            keys.append((match.group(1), int(match.group(2))))
+    return keys
+
+
+def count_by_level(parsed: list[dict]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for entry in parsed:
+        level = entry["level"]
+        counts[level] = counts.get(level, 0) + 1
+    return counts
+
+
+def main() -> None:
+    rng = random.Random(7)
+    lines = generate_log_lines(8_000, rng)
+
+    parsed = parse_lines(lines)
+    latencies = extract_latencies(lines)
+    keys = extract_cache_keys(lines)
+    counts = count_by_level(parsed)
+
+    avg_latency = sum(latencies) / len(latencies) if latencies else 0.0
+
+    print(f"generated {len(lines)} lines, parsed {len(parsed)}")
+    print(f"latency samples = {len(latencies)}, avg = {avg_latency:.1f}ms")
+    print(f"cache key samples = {len(keys)}")
+    print(f"counts by level = {counts}")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/monolith/demos/loadtest_corpus/semgrep/golang.sample
+++ b/projects/monolith/demos/loadtest_corpus/semgrep/golang.sample
@@ -1,0 +1,180 @@
+// Synthetic Go HTTP service used only as load-test scan input.
+//
+// This file is never built or executed. It exists purely as corpus content
+// POSTed to the fc-invoke semgrep workload, sized and shaped to exercise a
+// genuine interprocedural taint path: the query parameter reaches the
+// dangerous exec.Command sink only after passing through two helper
+// functions, which requires Semgrep Pro's cross-function analysis (OSS
+// single-function taint tracking does not follow the chain that far).
+package loadtest
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Server bundles the handlers registered below. Purely illustrative; never
+// instantiated by real code.
+type Server struct {
+	db *sql.DB
+}
+
+// NewServer is a benign constructor, no taint involved.
+func NewServer(db *sql.DB) *Server {
+	return &Server{db: db}
+}
+
+// convertHandler is the SOURCE: the "target" query param is fully
+// attacker-controlled. It flows: convertHandler -> prepareConversion ->
+// runConversion -> exec.Command("sh", "-c", ...). Two hops of indirection.
+func (s *Server) convertHandler(w http.ResponseWriter, r *http.Request) {
+	target := r.URL.Query().Get("target")
+	output, err := prepareConversion(target)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	fmt.Fprintln(w, output)
+}
+
+// prepareConversion is the first hop: just forwards the tainted value.
+func prepareConversion(target string) (string, error) {
+	return runConversion(target)
+}
+
+// runConversion is the sink: builds and runs a shell command with the
+// caller-controlled target string.
+func runConversion(target string) (string, error) {
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("convert %s output.png", target))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// lookupHandler exercises a second Pro rule: string-concatenated SQL built
+// from a query parameter, a classic injection sink independent of the exec
+// path above.
+func (s *Server) lookupHandler(w http.ResponseWriter, r *http.Request) {
+	userID := r.URL.Query().Get("user_id")
+	rows, err := s.queryUser(userID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		if scanErr := rows.Scan(&name); scanErr == nil {
+			fmt.Fprintln(w, name)
+		}
+	}
+}
+
+// queryUser builds a query via string concatenation from tainted input.
+func (s *Server) queryUser(userID string) (*sql.Rows, error) {
+	query := "SELECT name FROM users WHERE id = " + userID
+	return s.db.Query(query)
+}
+
+// healthHandler is benign: no user input, no dangerous sinks.
+func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintln(w, "ok")
+}
+
+// statsHandler is benign: aggregates in-memory counters only.
+func (s *Server) statsHandler(w http.ResponseWriter, r *http.Request) {
+	stats := computeStats()
+	fmt.Fprintf(w, "requests=%d uptime=%s\n", stats.requests, stats.uptime)
+}
+
+type serverStats struct {
+	requests int
+	uptime   time.Duration
+}
+
+var startedAt = time.Now()
+var requestCounter = 0
+
+func computeStats() serverStats {
+	requestCounter++
+	return serverStats{
+		requests: requestCounter,
+		uptime:   time.Since(startedAt),
+	}
+}
+
+// parsePageParams is a benign helper: validated pagination, not taint.
+func parsePageParams(r *http.Request) (limit, offset int) {
+	limit = 20
+	offset = 0
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 && parsed <= 100 {
+			limit = parsed
+		}
+	}
+	if v := r.URL.Query().Get("offset"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed >= 0 {
+			offset = parsed
+		}
+	}
+	return limit, offset
+}
+
+// listHandler is benign: uses parsed, bounded pagination only.
+func (s *Server) listHandler(w http.ResponseWriter, r *http.Request) {
+	limit, offset := parsePageParams(r)
+	for i := offset; i < offset+limit; i++ {
+		fmt.Fprintf(w, "item-%d\n", i)
+	}
+}
+
+// sanitizeName is a benign helper used by unrelated code paths.
+func sanitizeName(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	return strings.ToLower(trimmed)
+}
+
+// retryWithBackoff is a benign generic retry helper, no taint.
+func retryWithBackoff(attempts int, fn func() error) error {
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		if err := fn(); err != nil {
+			lastErr = err
+			time.Sleep(time.Duration(i+1) * 10 * time.Millisecond)
+			continue
+		}
+		return nil
+	}
+	return lastErr
+}
+
+// RegisterRoutes wires the handlers above onto a mux. Never called from
+// real code; illustrative only.
+func (s *Server) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/convert", s.convertHandler)
+	mux.HandleFunc("/lookup", s.lookupHandler)
+	mux.HandleFunc("/health", s.healthHandler)
+	mux.HandleFunc("/stats", s.statsHandler)
+	mux.HandleFunc("/list", s.listHandler)
+}
+
+func main() {
+	db, err := sql.Open("postgres", "postgres://localhost/loadtest")
+	if err != nil {
+		log.Fatal(err)
+	}
+	srv := NewServer(db)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	log.Println("listening on :8080")
+	log.Fatal(http.ListenAndServe(":8080", mux))
+}

--- a/projects/monolith/demos/loadtest_corpus/semgrep/javascript.sample
+++ b/projects/monolith/demos/loadtest_corpus/semgrep/javascript.sample
@@ -1,0 +1,164 @@
+/**
+ * Synthetic Express/TypeScript service used only as load-test scan input.
+ *
+ * This file is never compiled or executed. It exists purely as corpus
+ * content POSTed to the fc-invoke semgrep workload, shaped to exercise a
+ * genuine interprocedural taint path: the request parameter reaches the
+ * dangerous child_process.exec sink only after passing through two helper
+ * functions, requiring Semgrep Pro's cross-function analysis (OSS
+ * single-function taint tracking does not follow the chain that far).
+ */
+
+import * as childProcess from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import express, { type Request, type Response } from "express";
+
+const app = express();
+app.use(express.json());
+
+interface ThumbnailRequest {
+  source: string;
+  size: string;
+}
+
+/** Benign helper: validates a requested thumbnail size against an allowlist. */
+function normalizeSize(size: string): string {
+  const allowed = new Set(["small", "medium", "large"]);
+  return allowed.has(size) ? size : "medium";
+}
+
+/**
+ * First hop: forwards the caller-controlled source path into the shell
+ * helper below. This function performs no sanitization itself.
+ */
+function prepareThumbnail(source: string, size: string): string {
+  return runThumbnailTool(source, size);
+}
+
+/** Second hop: the dangerous sink. exec() with an unsanitized string. */
+function runThumbnailTool(source: string, size: string): string {
+  const cmd = `convert ${source} -resize ${size} /tmp/out.jpg`;
+  let output = "";
+  childProcess.exec(cmd, (err, stdout) => {
+    output = stdout ?? "";
+  });
+  return output;
+}
+
+/**
+ * SOURCE: req.body.source is fully attacker-controlled.
+ * Flow: handler -> prepareThumbnail -> runThumbnailTool -> exec(). Two hops
+ * of indirection between source and sink.
+ */
+app.post("/thumbnail", (req: Request, res: Response) => {
+  const body = req.body as ThumbnailRequest;
+  const size = normalizeSize(body.size);
+  const result = prepareThumbnail(body.source, size);
+  res.json({ result });
+});
+
+/**
+ * A second, independent taint path: a query-param-driven path traversal via
+ * fs.readFile(path.join(base, userPath)). Different vulnerability class
+ * (traversal, not command injection) so this exercises a second Pro rule.
+ */
+app.get("/download", (req: Request, res: Response) => {
+  const userPath = String(req.query.file ?? "");
+  const resolved = resolveDownloadPath(userPath);
+  fs.readFile(resolved, (err, data) => {
+    if (err) {
+      res.status(404).send("not found");
+      return;
+    }
+    res.send(data);
+  });
+});
+
+/** Intermediate hop for the traversal path: still no sanitization. */
+function resolveDownloadPath(userPath: string): string {
+  const base = "/var/data/exports";
+  return path.join(base, userPath);
+}
+
+/** Benign endpoint: static health check, no user input at all. */
+app.get("/health", (_req: Request, res: Response) => {
+  res.json({ status: "ok", ts: Date.now() });
+});
+
+interface StatsCounter {
+  requests: number;
+  startedAt: number;
+}
+
+const stats: StatsCounter = { requests: 0, startedAt: Date.now() };
+
+/** Benign helper: pure in-memory counter increment. */
+function recordRequest(): void {
+  stats.requests += 1;
+}
+
+/** Benign endpoint: reports in-memory stats, no taint. */
+app.get("/stats", (_req: Request, res: Response) => {
+  recordRequest();
+  res.json({
+    requests: stats.requests,
+    uptimeMs: Date.now() - stats.startedAt,
+  });
+});
+
+/** Benign helper: bounded pagination parsing, values are numeric-clamped. */
+function parsePagination(req: Request): { limit: number; offset: number } {
+  const rawLimit = Number(req.query.limit ?? 20);
+  const rawOffset = Number(req.query.offset ?? 0);
+  const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(rawLimit, 1), 100) : 20;
+  const offset = Number.isFinite(rawOffset) ? Math.max(rawOffset, 0) : 0;
+  return { limit, offset };
+}
+
+/** Benign endpoint: uses only the clamped pagination values above. */
+app.get("/items", (req: Request, res: Response) => {
+  const { limit, offset } = parsePagination(req);
+  const items = Array.from({ length: limit }, (_, i) => `item-${offset + i}`);
+  res.json({ items });
+});
+
+/** Benign helper: simple retry wrapper used by internal background jobs. */
+async function retry<T>(fn: () => Promise<T>, attempts = 3): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      await new Promise((resolve) => setTimeout(resolve, 10 * (i + 1)));
+    }
+  }
+  throw lastErr;
+}
+
+/** Benign helper: formats a byte count for display, no dynamic execution. */
+function formatBytes(bytes: number): string {
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(1)}${units[unitIndex]}`;
+}
+
+app.get("/disk-usage", (_req: Request, res: Response) => {
+  const bytesUsed = 1024 * 1024 * 42;
+  res.json({ formatted: formatBytes(bytesUsed) });
+});
+
+export function startServer(port: number): void {
+  app.listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`listening on ${port}`);
+  });
+}
+
+export default app;

--- a/projects/monolith/demos/loadtest_corpus/semgrep/kubernetes.sample
+++ b/projects/monolith/demos/loadtest_corpus/semgrep/kubernetes.sample
@@ -1,0 +1,114 @@
+# Synthetic Kubernetes manifest used only as load-test scan input.
+#
+# This manifest is never applied to any cluster (GitOps applies only files
+# under projects/*/deploy/). It exists purely as corpus content POSTed to the
+# fc-invoke semgrep workload, deliberately combining several misconfigurations
+# that Semgrep Pro's Kubernetes rule pack flags structurally (no taint
+# tracking needed): privileged mode, a hostPath mount, a root-capable
+# security context, privilege escalation allowed, and missing resource
+# limits.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loadtest-worker
+  namespace: loadtest
+  labels:
+    app: loadtest-worker
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: loadtest-worker
+  template:
+    metadata:
+      labels:
+        app: loadtest-worker
+    spec:
+      # Missing serviceAccountName pin and automountServiceAccountToken
+      # control, on top of the container-level issues below.
+      containers:
+        - name: worker
+          image: ghcr.io/example/loadtest-worker:latest
+          imagePullPolicy: Always
+          securityContext:
+            # Privileged containers can access the host's devices directly,
+            # bypassing most container isolation.
+            privileged: true
+            # Root-capable filesystem and no read-only root.
+            runAsNonRoot: false
+            runAsUser: 0
+            readOnlyRootFilesystem: false
+            # Allows a compromised process to gain more privileges than its
+            # parent, e.g. via setuid binaries.
+            allowPrivilegeEscalation: true
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - NET_ADMIN
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          env:
+            - name: WORKER_MODE
+              value: "batch"
+            - name: LOG_LEVEL
+              value: "info"
+          volumeMounts:
+            # Mounting the host's root filesystem into the container is a
+            # container-breakout vector when combined with privileged: true.
+            - name: host-root
+              mountPath: /host
+            - name: docker-sock
+              mountPath: /var/run/docker.sock
+          # No resources block at all: no requests, no limits. A runaway
+          # process can starve every other pod on the node.
+      volumes:
+        - name: host-root
+          hostPath:
+            path: /
+            type: Directory
+        - name: docker-sock
+          hostPath:
+            path: /var/run/docker.sock
+            type: Socket
+      hostNetwork: true
+      hostPID: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: loadtest-debug-pod
+  namespace: loadtest
+  labels:
+    app: loadtest-debug
+spec:
+  containers:
+    - name: debug
+      image: busybox:latest
+      command: ["sleep", "infinity"]
+      securityContext:
+        privileged: true
+        allowPrivilegeEscalation: true
+      volumeMounts:
+        - name: var-run
+          mountPath: /var/run
+  volumes:
+    - name: var-run
+      hostPath:
+        path: /var/run
+        type: Directory
+  restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loadtest-worker
+  namespace: loadtest
+spec:
+  selector:
+    app: loadtest-worker
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: ClusterIP

--- a/projects/monolith/demos/loadtest_corpus/semgrep/python.sample
+++ b/projects/monolith/demos/loadtest_corpus/semgrep/python.sample
@@ -1,0 +1,178 @@
+"""Synthetic Flask/FastAPI service used only as load-test scan input.
+
+This file is never imported or executed. It exists purely as corpus content
+POSTed to the fc-invoke semgrep workload so the load test exercises a
+realistic Python file size and a genuine interprocedural taint path: Semgrep
+Pro's cross-function analysis is required to connect the request parameter to
+the dangerous sink through the two intervening helper calls below. Plain OSS
+Semgrep (single-function taint) does not follow the call chain far enough to
+flag this.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import APIRouter, FastAPI, Request
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI()
+router = APIRouter(prefix="/reports")
+
+
+@dataclass
+class ReportConfig:
+    name: str
+    export_format: str
+    filters: dict[str, Any]
+
+
+def _normalize_name(raw: str) -> str:
+    """Benign helper: trims and lowercases a report name."""
+    return raw.strip().lower().replace(" ", "_")
+
+
+def _cache_key(config: ReportConfig) -> str:
+    """Benign helper: builds a stable cache key from the config."""
+    blob = json.dumps({"name": config.name, "format": config.export_format}, sort_keys=True)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _load_cached_report(key: str) -> dict | None:
+    """Benign helper: looks up a cached report by key (no I/O in this stub)."""
+    cache: dict[str, dict] = {}
+    return cache.get(key)
+
+
+def _build_export_command(export_target: str) -> str:
+    """First hop: forwards the caller-controlled target into a shell helper.
+
+    This function itself does nothing dangerous; it just passes the value
+    along, which is exactly the shape that defeats single-function taint
+    tracking and requires interprocedural analysis to catch.
+    """
+    return _run_export_shell(export_target)
+
+
+def _run_export_shell(export_target: str) -> str:
+    """Second hop: the dangerous sink. shell=True with an untrusted string."""
+    cmd = f"tar czf /tmp/export.tgz {export_target}"
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    return result.stdout
+
+
+@router.post("/export")
+async def export_report(request: Request):
+    """SOURCE: the export_target query/body param is fully attacker-controlled.
+
+    export_target flows: request -> export_report -> _build_export_command
+    -> _run_export_shell -> subprocess.run(..., shell=True). Two hops of
+    indirection between source and sink.
+    """
+    body = await request.json()
+    export_target = body.get("export_target", "")
+    output = _build_export_command(export_target)
+    return {"output": output}
+
+
+@router.get("/render")
+async def render_report(request: Request):
+    """A second, independent taint path via a request header instead of body.
+
+    header -> _dispatch_render -> os.system. Different sink family
+    (os.system vs subprocess.run) so this exercises a second Pro rule.
+    """
+    header_value = request.headers.get("x-render-target", "")
+    return {"ok": _dispatch_render(header_value)}
+
+
+def _dispatch_render(render_target: str) -> bool:
+    """Intermediate hop for the header-sourced path."""
+    return _execute_render(render_target)
+
+
+def _execute_render(render_target: str) -> bool:
+    """Sink for the header-sourced path: os.system with tainted input."""
+    os.system(f"wkhtmltopdf {render_target} /tmp/out.pdf")
+    return True
+
+
+@router.get("/list")
+async def list_reports(limit: int = 20, offset: int = 0) -> list[dict]:
+    """Benign endpoint: no taint, just pagination bookkeeping."""
+    limit = max(1, min(limit, 100))
+    offset = max(0, offset)
+    return [{"id": i, "name": f"report-{i}"} for i in range(offset, offset + limit)]
+
+
+def _validate_filters(filters: dict[str, Any]) -> dict[str, Any]:
+    """Benign helper: strips unknown filter keys."""
+    allowed = {"status", "owner", "created_after"}
+    return {k: v for k, v in filters.items() if k in allowed}
+
+
+def _summarize(reports: list[dict]) -> dict:
+    """Benign helper: aggregates counts by status."""
+    counts: dict[str, int] = {}
+    for r in reports:
+        status = r.get("status", "unknown")
+        counts[status] = counts.get(status, 0) + 1
+    return counts
+
+
+@router.post("/config")
+async def save_config(config: ReportConfig) -> dict:
+    """Benign endpoint: builds a cache key, no dangerous sink involved."""
+    key = _cache_key(config)
+    cached = _load_cached_report(key)
+    if cached is not None:
+        return cached
+    filters = _validate_filters(config.filters)
+    return {"key": key, "name": _normalize_name(config.name), "filters": filters}
+
+
+class ReportScheduler:
+    """Benign class: periodic housekeeping, no taint or shell calls."""
+
+    def __init__(self) -> None:
+        self._last_run = 0.0
+        self._interval_s = 300.0
+
+    def due(self) -> bool:
+        return (time.time() - self._last_run) >= self._interval_s
+
+    def mark_run(self) -> None:
+        self._last_run = time.time()
+
+    def run_once(self) -> dict:
+        self.mark_run()
+        logger.info("scheduled report sweep completed")
+        return {"status": "ok", "ran_at": self._last_run}
+
+
+def _retry(fn, attempts: int = 3):
+    """Benign generic retry wrapper used by internal jobs, not the API."""
+    last_exc: Exception | None = None
+    for attempt in range(attempts):
+        try:
+            return fn()
+        except Exception as exc:  # noqa: BLE001
+            last_exc = exc
+            time.sleep(0.01 * (attempt + 1))
+    if last_exc:
+        raise last_exc
+
+
+def register(app_: FastAPI) -> None:
+    app_.include_router(router)
+
+
+register(app)

--- a/projects/monolith/demos/loadtest_corpus/semgrep/rust.sample
+++ b/projects/monolith/demos/loadtest_corpus/semgrep/rust.sample
@@ -1,0 +1,172 @@
+//! Synthetic axum service used only as load-test scan input.
+//!
+//! This file is never compiled or executed. It exists purely as corpus
+//! content POSTed to the fc-invoke semgrep workload, shaped to exercise a
+//! genuine interprocedural taint path: the query parameter reaches the
+//! dangerous `Command::new("sh").arg("-c")` sink only after passing through
+//! two helper functions, requiring Semgrep Pro's cross-function analysis
+//! (OSS single-function taint tracking does not follow the chain that far).
+
+use std::collections::HashMap;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use axum::extract::Query;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct ConvertParams {
+    target: String,
+}
+
+#[derive(Serialize)]
+struct ConvertResponse {
+    output: String,
+}
+
+/// SOURCE: the `target` query parameter is fully attacker-controlled.
+/// Flow: convert_handler -> prepare_conversion -> run_conversion ->
+/// Command::new("sh").arg("-c"). Two hops of indirection between source
+/// and sink.
+async fn convert_handler(Query(params): Query<ConvertParams>) -> impl IntoResponse {
+    let output = prepare_conversion(&params.target);
+    Json(ConvertResponse { output })
+}
+
+/// First hop: forwards the tainted value without sanitizing it.
+fn prepare_conversion(target: &str) -> String {
+    run_conversion(target)
+}
+
+/// Second hop: the dangerous sink. Builds a shell command string from
+/// caller-controlled input and executes it via `sh -c`.
+fn run_conversion(target: &str) -> String {
+    let shell_cmd = format!("convert {} output.png", target);
+    let result = Command::new("sh").arg("-c").arg(shell_cmd).output();
+    match result {
+        Ok(out) => String::from_utf8_lossy(&out.stdout).to_string(),
+        Err(err) => format!("error: {err}"),
+    }
+}
+
+#[derive(Deserialize)]
+struct LookupParams {
+    user_id: String,
+}
+
+#[derive(Serialize)]
+struct LookupResponse {
+    query: String,
+}
+
+/// A second, independent taint path: a query parameter concatenated
+/// directly into a SQL string, a classic injection sink independent of the
+/// exec path above.
+async fn lookup_handler(Query(params): Query<LookupParams>) -> impl IntoResponse {
+    let query = build_lookup_query(&params.user_id);
+    Json(LookupResponse { query })
+}
+
+/// Builds a SQL query via string concatenation from tainted input.
+fn build_lookup_query(user_id: &str) -> String {
+    format!("SELECT name FROM users WHERE id = {}", user_id)
+}
+
+/// Benign endpoint: static health check, no user input.
+async fn health_handler() -> impl IntoResponse {
+    Json(serde_json::json!({ "status": "ok" }))
+}
+
+struct StatsCounter {
+    requests: u64,
+    started_at: Instant,
+}
+
+impl StatsCounter {
+    fn new() -> Self {
+        Self {
+            requests: 0,
+            started_at: Instant::now(),
+        }
+    }
+
+    /// Benign helper: pure in-memory counter increment.
+    fn record(&mut self) {
+        self.requests += 1;
+    }
+
+    fn uptime(&self) -> Duration {
+        self.started_at.elapsed()
+    }
+}
+
+#[derive(Deserialize)]
+struct PageParams {
+    limit: Option<u32>,
+    offset: Option<u32>,
+}
+
+/// Benign helper: bounded pagination parsing, values are numeric-clamped.
+fn clamp_pagination(params: &PageParams) -> (u32, u32) {
+    let limit = params.limit.unwrap_or(20).clamp(1, 100);
+    let offset = params.offset.unwrap_or(0);
+    (limit, offset)
+}
+
+/// Benign endpoint: uses only the clamped pagination values above.
+async fn list_handler(Query(params): Query<PageParams>) -> impl IntoResponse {
+    let (limit, offset) = clamp_pagination(&params);
+    let items: Vec<String> = (offset..offset + limit)
+        .map(|i| format!("item-{i}"))
+        .collect();
+    Json(items)
+}
+
+/// Benign helper: retry wrapper used by internal background jobs, no taint.
+fn retry_with_backoff<F, T, E>(mut attempts: u32, mut f: F) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+{
+    loop {
+        match f() {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                attempts -= 1;
+                if attempts == 0 {
+                    return Err(err);
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        }
+    }
+}
+
+/// Benign helper: normalizes free-text tags, no dynamic execution.
+fn normalize_tags(raw: &HashMap<String, String>) -> Vec<String> {
+    let mut tags: Vec<String> = raw
+        .values()
+        .map(|v| v.trim().to_lowercase())
+        .filter(|v| !v.is_empty())
+        .collect();
+    tags.sort();
+    tags.dedup();
+    tags
+}
+
+fn build_router() -> Router {
+    Router::new()
+        .route("/convert", get(convert_handler))
+        .route("/lookup", get(lookup_handler))
+        .route("/health", get(health_handler))
+        .route("/items", get(list_handler))
+}
+
+#[tokio::main]
+async fn main() {
+    let app = build_router();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}

--- a/projects/monolith/demos/loadtest_corpus_test.py
+++ b/projects/monolith/demos/loadtest_corpus_test.py
@@ -1,0 +1,43 @@
+"""Tests for the load-test corpus loader.
+
+Covers the shape and size bounds the load-test harness (Task 5) relies on:
+five semgrep-pack entries with plausible file sizes and extensions, a handful
+of varied sandbox scripts, and a clear error for an unknown workload.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from demos.loadtest_corpus import load_corpus
+
+_EXPECTED_SEMGREP_NAMES = {"python", "golang", "javascript", "kubernetes", "rust"}
+_EXPECTED_EXTENSIONS = {"py", "go", "ts", "yaml", "rs"}
+
+
+def test_semgrep_corpus_covers_all_five_packs():
+    entries = load_corpus("semgrep")
+    names = {e["name"] for e in entries}
+    assert names == _EXPECTED_SEMGREP_NAMES
+
+    for entry in entries:
+        line_count = len(entry["content"].splitlines())
+        assert 100 <= line_count <= 400, (entry["name"], line_count)
+
+        extension = entry["path"].rsplit(".", 1)[-1]
+        assert extension in _EXPECTED_EXTENSIONS, (entry["name"], entry["path"])
+
+
+def test_sandbox_corpus_present_and_bounded():
+    entries = load_corpus("sandbox")
+    assert 5 <= len(entries) <= 8
+
+    for entry in entries:
+        assert entry["content"].strip()
+        line_count = len(entry["content"].splitlines())
+        assert 30 <= line_count <= 200, (entry["name"], line_count)
+
+
+def test_unknown_workload_raises():
+    with pytest.raises(ValueError):
+        load_corpus("not-a-real-workload")

--- a/projects/monolith/demos/loadtest_test.py
+++ b/projects/monolith/demos/loadtest_test.py
@@ -1,0 +1,233 @@
+"""Tests for the workload-parametric load-test drain (demos/loadtest.py).
+
+These exercise the pure logic with no real DB and no fc-invoke: ``_invoke`` is
+tested against a fake ``httpx.AsyncClient``, the workload registry payload
+builders are asserted directly, and the drain runs against an injected fake
+``_invoke`` and an in-memory ``FakeLoadStore`` for a fraction of a second.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import demos.loadtest as loadtest
+
+
+class _FakeResponse:
+    def __init__(self, status_code, json_body, headers):
+        self.status_code = status_code
+        self._json = json_body
+        self.headers = headers
+        self.text = ""
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import httpx
+
+            raise httpx.HTTPStatusError(
+                "err",
+                request=None,
+                response=self,  # type: ignore[arg-type]
+            )
+
+
+class _FakeAsyncClient:
+    """Minimal stand-in for httpx.AsyncClient used by ``_invoke``."""
+
+    def __init__(self, response, **_kwargs):
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def post(self, url, json=None, headers=None):  # noqa: A002
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_invoke_parses_resource_headers(monkeypatch):
+    resp = _FakeResponse(
+        200,
+        {"findings": [], "errors": []},
+        {
+            "X-Fc-Cpu-Ms": "842",
+            "X-Fc-Peak-Rss-Mib": "310",
+            "X-Fc-Queue-Wait-Ms": "5",
+        },
+    )
+    monkeypatch.setattr(loadtest, "FC_INVOKE_URL", "http://fc")
+    monkeypatch.setattr(
+        loadtest.httpx, "AsyncClient", lambda **kw: _FakeAsyncClient(resp, **kw)
+    )
+
+    body, meta, error = await loadtest._invoke("semgrep", {"files": []}, 95.0)
+
+    assert error is None
+    assert body == {"findings": [], "errors": []}
+    assert meta == {"cpu_ms": 842, "peak_rss_mib": 310, "queue_wait_ms": 5}
+
+
+@pytest.mark.asyncio
+async def test_invoke_missing_headers_are_none(monkeypatch):
+    resp = _FakeResponse(200, {"stdout": "hi"}, {})
+    monkeypatch.setattr(loadtest, "FC_INVOKE_URL", "http://fc")
+    monkeypatch.setattr(
+        loadtest.httpx, "AsyncClient", lambda **kw: _FakeAsyncClient(resp, **kw)
+    )
+
+    body, meta, error = await loadtest._invoke("sandbox", {"code": "x"}, 40.0)
+
+    assert error is None
+    assert body == {"stdout": "hi"}
+    assert meta == {"cpu_ms": None, "peak_rss_mib": None, "queue_wait_ms": None}
+
+
+def test_semgrep_registry_builds_files_payload():
+    item = {"name": "python", "path": "corpus/app.py", "content": "print(1)"}
+    payload = loadtest.WORKLOADS["semgrep"]["build_payload"](item)
+    assert payload == {"files": [{"path": "corpus/app.py", "content": "print(1)"}]}
+
+
+def test_sandbox_registry_builds_code_payload():
+    item = {"name": "hello", "content": "print(1)"}
+    payload = loadtest.WORKLOADS["sandbox"]["build_payload"](item)
+    assert payload == {"code": "print(1)"}
+
+
+class FakeLoadStore(loadtest.LoadStore):
+    """In-memory store: captures recorded rows and the finalize summary."""
+
+    def __init__(self, run_id="run-1", workload="semgrep"):
+        super().__init__(run_id, workload)
+        self.rows: list[dict] = []
+        self.summary: dict | None = None
+
+    async def record(self, row: dict) -> None:
+        self.rows.append(row)
+
+    async def flush(self) -> None:  # no DB
+        return None
+
+    async def finalize(self, run_id: str) -> dict:
+        self.summary = loadtest.build_summary(
+            self.workload, self.rows, self._sampler_series
+        )
+        return self.summary
+
+
+@pytest.mark.asyncio
+async def test_drain_records_rows_with_meta():
+    async def fake_invoke(workload, payload, timeout):
+        return (
+            {"findings": [{"check_id": "x"}], "errors": []},
+            {"cpu_ms": 800, "peak_rss_mib": 300, "queue_wait_ms": 2},
+            None,
+        )
+
+    async def fake_sampler(stop_event):
+        return []
+
+    store = FakeLoadStore(run_id="run-1", workload="semgrep")
+
+    await loadtest.run_load_test(
+        "run-1",
+        "semgrep",
+        store,
+        duration_s=1,
+        client_concurrency=4,
+        invoke=fake_invoke,
+        sampler=fake_sampler,
+    )
+
+    assert store.rows, "expected recorded scan rows"
+    for row in store.rows:
+        assert row["status"] == "ok"
+        assert row["cpu_ms"] == 800
+        assert row["peak_rss_mib"] == 300
+        assert row["result_count"] == 1
+
+    assert store.summary is not None
+    for key in (
+        "total_scans",
+        "errors",
+        "wall_s",
+        "throughput_per_s",
+        "latency_ms",
+        "queue_wait_ms",
+        "per_scan_cpu_ms",
+        "per_scan_peak_rss_mib",
+        "per_lang",
+        "daemon",
+        "extrapolation",
+    ):
+        assert key in store.summary
+    # No sampler series -> daemon footprint is derived, node stats omitted.
+    assert store.summary["daemon"]["source"] == "derived"
+
+
+@pytest.mark.asyncio
+async def test_drain_records_error_rows_without_raising():
+    async def failing_invoke(workload, payload, timeout):
+        return {}, {}, "HTTP 500: boom"
+
+    async def fake_sampler(stop_event):
+        return []
+
+    store = FakeLoadStore(workload="sandbox")
+    await loadtest.run_load_test(
+        "run-2",
+        "sandbox",
+        store,
+        duration_s=1,
+        client_concurrency=2,
+        invoke=failing_invoke,
+        sampler=fake_sampler,
+    )
+
+    assert store.rows
+    assert all(r["status"] == "error" for r in store.rows)
+    assert store.summary["errors"] == len(store.rows)
+    # Sandbox summary reports exit-code distribution, not finding counts.
+    assert "sandbox_exit" in store.summary
+
+
+@pytest.mark.asyncio
+async def test_run_guard_returns_existing_when_running(monkeypatch):
+    """The start endpoint short-circuits to an in-flight run without dispatching."""
+    import demos.firecracker_api as fc
+
+    monkeypatch.setattr(
+        fc, "_running_load_run", lambda: {"id": "existing-run", "workload": "semgrep"}
+    )
+
+    def _should_not_run(*_a, **_k):  # pragma: no cover - guard must short-circuit
+        raise AssertionError("dispatch must not happen when a run is active")
+
+    monkeypatch.setattr(fc, "_agent_is_busy", _should_not_run)
+    monkeypatch.setattr(fc, "_insert_load_run", _should_not_run)
+
+    result = await fc.start_load_test("semgrep")
+
+    assert result == {"run_id": "existing-run", "already_running": True}
+
+
+@pytest.mark.asyncio
+async def test_run_guard_refuses_when_agent_busy(monkeypatch):
+    """An active agent run makes the start endpoint refuse with HTTP 409."""
+    import demos.firecracker_api as fc
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(fc, "_running_load_run", lambda: None)
+    monkeypatch.setattr(fc, "_agent_is_busy", lambda: True)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await fc.start_load_test("sandbox")
+    assert excinfo.value.status_code == 409

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.92
+      targetRevision: 0.285.93
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/LoadTestPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/LoadTestPanel.svelte
@@ -1,0 +1,1217 @@
+<script>
+  // Fixed-duration load test drain over the fc-invoke daemon for one
+  // workload (semgrep or sandbox). Three peer views: Live (1s poll while
+  // running), Summary (once status is "done"), and Receipts (a lazily
+  // fetched, paginated table of individual scans with a row drill-down).
+  // Field names below are quoted from the backend as read, not guessed:
+  //   - demos/firecracker_api.py _load_run_rollup(): run_id, workload,
+  //     status, elapsed_s, total_scans, errors, throughput_per_s,
+  //     in_flight_estimate, latency_p50, latency_p95, per_lang_counts,
+  //     cpu_ms_mean, peak_rss_mib_mean, summary (set once status=="done")
+  //   - demos/loadtest.py build_summary(): total_scans, errors, wall_s,
+  //     throughput_per_s, latency_ms{p50,p95,max}, queue_wait_ms{p50,p95},
+  //     per_scan_cpu_ms{p50,p95}, per_scan_peak_rss_mib{p50,p95}, per_lang,
+  //     daemon{pod_cpu_m,pod_rss_mib,source}, node{cpu_m,rss_mib},
+  //     extrapolation{per_node_throughput_per_s,scans_per_core_s,
+  //     vm_seconds,note}
+  //   - demos/firecracker_api.py _load_scans_page(): total, offset, limit,
+  //     scans[]{id,seq,name,status,latency_ms,queue_wait_ms,cpu_ms,
+  //     peak_rss_mib,result_count}
+  //   - demos/firecracker_api.py _load_scan_detail(): adds result, error
+  //   - demos/loadtest.py DAEMON_CONCURRENCY=15, run duration_s=120 (see
+  //     _dispatch_drain in firecracker_api.py)
+  let { workload } = $props();
+
+  const RUN_DURATION_S = 120;
+  const DAEMON_CONCURRENCY = 15;
+  const POLL_MS = 1000;
+  const HARD_TIMEOUT_MS = 150_000;
+  const SCANS_PAGE_SIZE = 50;
+
+  let runId = $state(null);
+  let rollup = $state(null);
+  let starting = $state(false);
+  let startError = $state(null);
+  let busyNotice = $state(false);
+  let timedOut = $state(null);
+
+  // "live" | "summary" | "receipts". Independent of poll state: the user can
+  // flip to Receipts while a run is still live, and it will not be disturbed
+  // by the 1s live poll.
+  let view = $state("live");
+
+  let pollHandle = null;
+  let pollStart = 0;
+
+  // Receipts state: fetched lazily, only on first open / explicit paginate /
+  // row click. Never touched by the live poll.
+  let scans = $state([]);
+  let scansTotal = $state(0);
+  let scansOffset = $state(0);
+  let scansLoading = $state(false);
+  let scansError = $state(null);
+  let scansFetchedFor = $state(null); // run_id this page was fetched for
+  let selectedScan = $state(null);
+  let selectedScanLoading = $state(false);
+  let selectedScanError = $state(null);
+
+  async function postJson(path, body) {
+    const res = await fetch(path, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body ?? {}),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const err = new Error(data?.error || data?.detail || `HTTP ${res.status}`);
+      err.status = res.status;
+      throw err;
+    }
+    return data;
+  }
+
+  async function getJson(path) {
+    const res = await fetch(path);
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(data?.error || data?.detail || `HTTP ${res.status}`);
+    }
+    return data;
+  }
+
+  function stopPolling() {
+    if (pollHandle) clearTimeout(pollHandle);
+    pollHandle = null;
+  }
+
+  async function pollOnce(id) {
+    try {
+      const data = await getJson(`/api/demos/firecracker/load-test/${id}`);
+      if (runId !== id) return; // run changed mid-flight
+      rollup = data;
+    } catch (e) {
+      if (runId !== id) return;
+      startError = e?.message ?? String(e);
+      stopPolling();
+      return;
+    }
+
+    if (rollup?.status !== "running") {
+      stopPolling();
+      return;
+    }
+
+    if (performance.now() - pollStart >= HARD_TIMEOUT_MS) {
+      timedOut = id;
+      stopPolling();
+      return;
+    }
+
+    pollHandle = setTimeout(() => pollOnce(id), POLL_MS);
+  }
+
+  function beginPolling(id) {
+    stopPolling();
+    pollStart = performance.now();
+    timedOut = null;
+    pollOnce(id);
+  }
+
+  async function startRun() {
+    if (starting || rollup?.status === "running") return;
+    starting = true;
+    startError = null;
+    busyNotice = false;
+    try {
+      const data = await postJson(`/api/demos/firecracker/load-test/${workload}`, {});
+      runId = data.run_id;
+      // already_running is not an error: adopt the existing run and poll it.
+      resetReceipts();
+      view = "live";
+      beginPolling(runId);
+    } catch (e) {
+      if (e?.status === 409) {
+        busyNotice = true;
+      } else {
+        startError = e?.message ?? String(e);
+      }
+    } finally {
+      starting = false;
+    }
+  }
+
+  function resetReceipts() {
+    scans = [];
+    scansTotal = 0;
+    scansOffset = 0;
+    scansFetchedFor = null;
+    scansError = null;
+    selectedScan = null;
+    selectedScanError = null;
+  }
+
+  async function openReceipts() {
+    view = "receipts";
+    if (scansFetchedFor !== runId) {
+      await fetchScansPage(0);
+    }
+  }
+
+  async function fetchScansPage(offset) {
+    if (!runId) return;
+    scansLoading = true;
+    scansError = null;
+    try {
+      const data = await getJson(
+        `/api/demos/firecracker/load-test/${runId}/scans?offset=${offset}&limit=${SCANS_PAGE_SIZE}`,
+      );
+      scans = data.scans ?? [];
+      scansTotal = data.total ?? 0;
+      scansOffset = data.offset ?? offset;
+      scansFetchedFor = runId;
+    } catch (e) {
+      scansError = e?.message ?? String(e);
+    } finally {
+      scansLoading = false;
+    }
+  }
+
+  function nextPage() {
+    if (scansOffset + SCANS_PAGE_SIZE >= scansTotal) return;
+    fetchScansPage(scansOffset + SCANS_PAGE_SIZE);
+  }
+
+  function prevPage() {
+    if (scansOffset <= 0) return;
+    fetchScansPage(Math.max(0, scansOffset - SCANS_PAGE_SIZE));
+  }
+
+  async function selectScan(id) {
+    selectedScan = null;
+    selectedScanError = null;
+    selectedScanLoading = true;
+    try {
+      selectedScan = await getJson(
+        `/api/demos/firecracker/load-test/${runId}/scans/${id}`,
+      );
+    } catch (e) {
+      selectedScanError = e?.message ?? String(e);
+    } finally {
+      selectedScanLoading = false;
+    }
+  }
+
+  function severityClass(sev) {
+    const s = (sev ?? "").toLowerCase();
+    if (s === "error" || s === "high" || s === "critical") return "sev--high";
+    if (s === "warning" || s === "warn" || s === "medium") return "sev--medium";
+    return "sev--low";
+  }
+
+  $effect(() => {
+    return () => stopPolling();
+  });
+
+  let isRunning = $derived(rollup?.status === "running");
+  let isDone = $derived(rollup?.status === "done");
+  let hasScans = $derived((rollup?.total_scans ?? 0) > 0);
+  let progressPct = $derived.by(() => {
+    const elapsed = rollup?.elapsed_s ?? 0;
+    return Math.max(0, Math.min(100, (elapsed / RUN_DURATION_S) * 100));
+  });
+  let scansPage = $derived(
+    scansTotal > 0 ? Math.floor(scansOffset / SCANS_PAGE_SIZE) + 1 : 0,
+  );
+  let scansPageCount = $derived(Math.max(1, Math.ceil(scansTotal / SCANS_PAGE_SIZE)));
+
+  function fmt(n, digits = 1) {
+    return n == null ? "-" : Number(n).toFixed(digits);
+  }
+</script>
+
+<div class="load-test">
+  <div class="lt-header">
+    <p class="lt-blurb">
+      Fixed 2 minute drain against the fc-invoke daemon at concurrency
+      {DAEMON_CONCURRENCY}, oversubscribed by the client so the daemon stays
+      saturated for the whole run.
+    </p>
+    <button
+      class="run-button"
+      class:run-button--running={isRunning}
+      onclick={startRun}
+      disabled={starting || isRunning}
+    >
+      {#if starting}
+        <span class="spinner" aria-hidden="true"></span> Starting
+      {:else if isRunning}
+        <span class="spinner" aria-hidden="true"></span> Running
+      {:else}
+        Start load test
+      {/if}
+    </button>
+  </div>
+
+  {#if busyNotice}
+    <div class="notice notice--warn" role="alert">
+      An agent run is active, try again shortly.
+    </div>
+  {/if}
+
+  {#if startError}
+    <div class="notice notice--error" role="alert">{startError}</div>
+  {/if}
+
+  {#if timedOut}
+    <div class="notice notice--warn" role="alert">
+      Stopped polling after 150s without the run finishing. It may still be
+      running server-side; reopen the page or check SigNoz.
+    </div>
+  {/if}
+
+  {#if rollup}
+    <nav class="lt-tabs" aria-label="Load test view">
+      <button
+        type="button"
+        class="lt-tab"
+        class:active={view === "live"}
+        onclick={() => (view = "live")}
+      >
+        Live
+      </button>
+      <button
+        type="button"
+        class="lt-tab"
+        class:active={view === "summary"}
+        onclick={() => (view = "summary")}
+        disabled={!isDone}
+      >
+        Summary
+      </button>
+      {#if hasScans}
+        <button
+          type="button"
+          class="lt-tab"
+          class:active={view === "receipts"}
+          onclick={openReceipts}
+        >
+          See Receipts
+        </button>
+      {/if}
+    </nav>
+
+    {#if view === "live"}
+      <div class="lt-live">
+        <div class="throughput-hero">
+          <span class="throughput-value">{fmt(rollup.throughput_per_s, 2)}</span>
+          <span class="throughput-unit">scans/s</span>
+        </div>
+
+        <div class="progress-track" aria-hidden="true">
+          <div class="progress-fill" style={`width: ${progressPct}%;`}></div>
+        </div>
+        <div class="progress-label">
+          {fmt(rollup.elapsed_s, 0)}s / {RUN_DURATION_S}s
+          {#if isRunning}<span class="pulse-dot" aria-hidden="true"></span>{/if}
+        </div>
+
+        <div class="stat-grid">
+          <div class="stat">
+            <span class="stat-label">total scans</span>
+            <span class="stat-value">{rollup.total_scans ?? 0}</span>
+          </div>
+          <div class="stat">
+            <span class="stat-label">in flight (est.)</span>
+            <span class="stat-value">{rollup.in_flight_estimate ?? 0}</span>
+          </div>
+          <div class="stat">
+            <span class="stat-label">errors</span>
+            <span class="stat-value" class:stat-value--bad={(rollup.errors ?? 0) > 0}
+              >{rollup.errors ?? 0}</span
+            >
+          </div>
+          <div class="stat">
+            <span class="stat-label">latency p50</span>
+            <span class="stat-value">{fmt(rollup.latency_p50, 0)}ms</span>
+          </div>
+          <div class="stat">
+            <span class="stat-label">latency p95</span>
+            <span class="stat-value">{fmt(rollup.latency_p95, 0)}ms</span>
+          </div>
+          <div class="stat">
+            <span class="stat-label">mean cpu</span>
+            <span class="stat-value">{fmt(rollup.cpu_ms_mean, 0)}ms</span>
+          </div>
+          <div class="stat">
+            <span class="stat-label">mean peak rss</span>
+            <span class="stat-value">{fmt(rollup.peak_rss_mib_mean, 0)} MiB</span>
+          </div>
+        </div>
+
+        {#if rollup.per_lang_counts && Object.keys(rollup.per_lang_counts).length > 0}
+          <div class="lang-rows">
+            {#each Object.entries(rollup.per_lang_counts) as [name, count]}
+              <div class="lang-row">
+                <span class="lang-name">{name}</span>
+                <span class="lang-count">{count}</span>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {:else if view === "summary"}
+      {#if rollup.summary}
+        {@const s = rollup.summary}
+        <div class="lt-summary">
+          <div class="extrap-card">
+            <span class="extrap-label">extrapolation</span>
+            <div class="extrap-figures">
+              <div class="extrap-figure">
+                <span class="extrap-value">{fmt(s.extrapolation?.per_node_throughput_per_s, 2)}</span>
+                <span class="extrap-unit">scans/s per node</span>
+              </div>
+              <div class="extrap-figure">
+                <span class="extrap-value">{fmt(s.extrapolation?.scans_per_core_s, 3)}</span>
+                <span class="extrap-unit">scans/core/s</span>
+              </div>
+            </div>
+            <p class="extrap-note">{s.extrapolation?.note}</p>
+          </div>
+
+          <div class="summary-section">
+            <span class="section-title">daemon + node footprint</span>
+            <div class="stat-grid">
+              <div class="stat">
+                <span class="stat-label">daemon cpu (mean/max)</span>
+                <span class="stat-value"
+                  >{fmt(s.daemon?.pod_cpu_m?.mean, 0)} / {fmt(s.daemon?.pod_cpu_m?.max, 0)}m</span
+                >
+              </div>
+              <div class="stat">
+                <span class="stat-label">daemon rss (mean/max)</span>
+                <span class="stat-value"
+                  >{fmt(s.daemon?.pod_rss_mib?.mean, 0)} / {fmt(s.daemon?.pod_rss_mib?.max, 0)} MiB</span
+                >
+              </div>
+              <div class="stat">
+                <span class="stat-label">daemon source</span>
+                <span class="stat-value">{s.daemon?.source ?? "-"}</span>
+              </div>
+              {#if s.node}
+                <div class="stat">
+                  <span class="stat-label">node cpu (mean/max)</span>
+                  <span class="stat-value"
+                    >{fmt(s.node?.cpu_m?.mean, 0)} / {fmt(s.node?.cpu_m?.max, 0)}m</span
+                  >
+                </div>
+                <div class="stat">
+                  <span class="stat-label">node rss (mean/max)</span>
+                  <span class="stat-value"
+                    >{fmt(s.node?.rss_mib?.mean, 0)} / {fmt(s.node?.rss_mib?.max, 0)} MiB</span
+                  >
+                </div>
+              {/if}
+            </div>
+          </div>
+
+          <div class="summary-section">
+            <span class="section-title">latency + per-scan resources</span>
+            <div class="stat-grid">
+              <div class="stat">
+                <span class="stat-label">latency p50/p95/max</span>
+                <span class="stat-value"
+                  >{fmt(s.latency_ms?.p50, 0)} / {fmt(s.latency_ms?.p95, 0)} / {fmt(s.latency_ms?.max, 0)}ms</span
+                >
+              </div>
+              <div class="stat">
+                <span class="stat-label">queue wait p50/p95</span>
+                <span class="stat-value"
+                  >{fmt(s.queue_wait_ms?.p50, 0)} / {fmt(s.queue_wait_ms?.p95, 0)}ms</span
+                >
+              </div>
+              <div class="stat">
+                <span class="stat-label">per-scan cpu p50/p95</span>
+                <span class="stat-value"
+                  >{fmt(s.per_scan_cpu_ms?.p50, 0)} / {fmt(s.per_scan_cpu_ms?.p95, 0)}ms</span
+                >
+              </div>
+              <div class="stat">
+                <span class="stat-label">per-scan peak rss p50/p95</span>
+                <span class="stat-value"
+                  >{fmt(s.per_scan_peak_rss_mib?.p50, 0)} / {fmt(s.per_scan_peak_rss_mib?.p95, 0)} MiB</span
+                >
+              </div>
+              {#if s.result_count}
+                <div class="stat">
+                  <span class="stat-label">result count p50/p95/max</span>
+                  <span class="stat-value"
+                    >{fmt(s.result_count?.p50, 1)} / {fmt(s.result_count?.p95, 1)} / {fmt(s.result_count?.max, 0)}</span
+                  >
+                </div>
+              {/if}
+              {#if s.sandbox_exit}
+                <div class="stat">
+                  <span class="stat-label">exit 0 / nonzero</span>
+                  <span class="stat-value"
+                    >{s.sandbox_exit.ok_count ?? 0} / {s.sandbox_exit.nonzero_count ?? 0}</span
+                  >
+                </div>
+              {/if}
+              <div class="stat">
+                <span class="stat-label">total scans / errors</span>
+                <span class="stat-value">{s.total_scans ?? 0} / {s.errors ?? 0}</span>
+              </div>
+            </div>
+          </div>
+
+          {#if s.per_lang && Object.keys(s.per_lang).length > 0}
+            <div class="summary-section">
+              <span class="section-title">per language</span>
+              <div class="lang-rows">
+                {#each Object.entries(s.per_lang) as [name, stats]}
+                  <div class="lang-row">
+                    <span class="lang-name">{name}</span>
+                    <span class="lang-count">{stats.count}</span>
+                    <span class="lang-extra"
+                      >p50 {fmt(stats.p50_ms, 0)}ms · cpu p50 {fmt(stats.p50_cpu_ms, 0)}ms</span
+                    >
+                  </div>
+                {/each}
+              </div>
+            </div>
+          {/if}
+        </div>
+      {:else}
+        <p class="result-empty">Summary is not ready yet.</p>
+      {/if}
+    {:else if view === "receipts"}
+      <div class="lt-receipts">
+        {#if selectedScan}
+          <button type="button" class="back-link" onclick={() => (selectedScan = null)}>
+            &larr; back to scans
+          </button>
+          {#if selectedScanLoading}
+            <p class="result-empty">Loading...</p>
+          {:else if selectedScanError}
+            <div class="notice notice--error" role="alert">{selectedScanError}</div>
+          {:else}
+            <div class="scan-detail">
+              <div class="result-grid">
+                <span class="result-key">scan</span>
+                <span class="result-val">#{selectedScan.seq} · {selectedScan.name}</span>
+              </div>
+              <div class="result-grid">
+                <span class="result-key">status</span>
+                <span class="result-val" class:result-val--bad={selectedScan.status === "error"}
+                  >{selectedScan.status}</span
+                >
+              </div>
+              <div class="result-grid">
+                <span class="result-key">latency / queue / cpu / rss</span>
+                <span class="result-val"
+                  >{selectedScan.latency_ms ?? "-"}ms / {selectedScan.queue_wait_ms ?? "-"}ms
+                  / {selectedScan.cpu_ms ?? "-"}ms / {selectedScan.peak_rss_mib ?? "-"} MiB</span
+                >
+              </div>
+
+              {#if selectedScan.error}
+                <div class="notice notice--error" role="alert">{selectedScan.error}</div>
+              {/if}
+
+              {#if workload === "semgrep"}
+                {#if selectedScan.result?.findings?.length}
+                  <ul class="findings">
+                    {#each selectedScan.result.findings as f}
+                      <li class="finding">
+                        <span class="finding-sev {severityClass(f.severity)}"
+                          >{f.severity}</span
+                        >
+                        <span class="finding-loc"
+                          >{f.path}:{f.line}{f.col ? `:${f.col}` : ""}</span
+                        >
+                        <span class="finding-rule">{f.rule_id}</span>
+                        <span class="finding-msg">{f.message}</span>
+                      </li>
+                    {/each}
+                  </ul>
+                {:else}
+                  <p class="result-empty">No findings.</p>
+                {/if}
+                {#if selectedScan.result?.errors?.length}
+                  <div class="result-block">
+                    <span class="body-label">scan errors</span>
+                    <pre class="body-text body-text--error">{selectedScan.result.errors.join(
+                        "\n",
+                      )}</pre>
+                  </div>
+                {/if}
+              {:else}
+                <div class="result-grid">
+                  <span class="result-key">exit code</span>
+                  <span
+                    class="result-val"
+                    class:result-val--bad={selectedScan.result?.exit_code !== 0}
+                    >{selectedScan.result?.exit_code}</span
+                  >
+                  {#if selectedScan.result?.truncated}
+                    <span class="row-tag">truncated</span>
+                  {/if}
+                </div>
+                <div class="result-grid">
+                  <span class="result-key">duration</span>
+                  <span class="result-val">{selectedScan.result?.duration_ms ?? "-"}ms</span>
+                </div>
+                {#if selectedScan.result?.stdout}
+                  <div class="result-block">
+                    <span class="body-label">stdout</span>
+                    <pre class="body-text">{selectedScan.result.stdout}</pre>
+                  </div>
+                {/if}
+                {#if selectedScan.result?.stderr}
+                  <div class="result-block">
+                    <span class="body-label">stderr</span>
+                    <pre class="body-text body-text--error">{selectedScan.result.stderr}</pre>
+                  </div>
+                {/if}
+              {/if}
+            </div>
+          {/if}
+        {:else}
+          {#if scansLoading}
+            <p class="result-empty">Loading scans...</p>
+          {:else if scansError}
+            <div class="notice notice--error" role="alert">{scansError}</div>
+          {:else}
+            <table class="scans-table">
+              <thead>
+                <tr>
+                  <th>seq</th>
+                  <th>name</th>
+                  <th>status</th>
+                  <th>latency</th>
+                  <th>cpu</th>
+                  <th>peak rss</th>
+                  <th>results</th>
+                </tr>
+              </thead>
+              <tbody>
+                {#each scans as scan (scan.id)}
+                  <tr class="scan-row" onclick={() => selectScan(scan.id)}>
+                    <td>{scan.seq}</td>
+                    <td class="scan-name">{scan.name}</td>
+                    <td>
+                      <span class:result-val--bad={scan.status === "error"}
+                        >{scan.status}</span
+                      >
+                    </td>
+                    <td>{scan.latency_ms ?? "-"}ms</td>
+                    <td>{scan.cpu_ms ?? "-"}ms</td>
+                    <td>{scan.peak_rss_mib ?? "-"} MiB</td>
+                    <td>{scan.result_count ?? "-"}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+
+            <div class="pager">
+              <button type="button" onclick={prevPage} disabled={scansOffset <= 0}>
+                Prev
+              </button>
+              <span class="pager-label">page {scansPage} of {scansPageCount}</span>
+              <button
+                type="button"
+                onclick={nextPage}
+                disabled={scansOffset + SCANS_PAGE_SIZE >= scansTotal}
+              >
+                Next
+              </button>
+            </div>
+          {/if}
+        {/if}
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .load-test {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .lt-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    flex-wrap: wrap;
+  }
+
+  .lt-blurb {
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--text-dim);
+    margin: 0;
+    max-width: 32rem;
+  }
+
+  .run-button {
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: #fff; /* nosemgrep: svelte-hardcoded-color-in-style */
+    background: var(--accent);
+    border: none;
+    border-radius: 6px;
+    padding: 9px 20px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+    transition: opacity 0.1s ease;
+  }
+
+  .run-button:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  .run-button:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .run-button--running {
+    background: var(--text-dim);
+  }
+
+  .spinner {
+    width: 11px;
+    height: 11px;
+    border: 2px solid rgba(255, 255, 255, 0.5);
+    border-top-color: #fff; /* nosemgrep: svelte-hardcoded-color-in-style */
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .notice {
+    border-radius: 6px;
+    padding: 10px 14px;
+    font-size: 13px;
+    font-weight: 500;
+  }
+
+  .notice--error {
+    color: #fff; /* nosemgrep: svelte-hardcoded-color-in-style */
+    background: var(--danger);
+  }
+
+  .notice--warn {
+    color: var(--ink);
+    background: color-mix(in srgb, var(--loadtest-highlight) 18%, var(--surface));
+    border: 1px solid color-mix(in srgb, var(--loadtest-highlight) 40%, var(--line));
+  }
+
+  .lt-tabs {
+    display: flex;
+    gap: 4px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .lt-tab {
+    font-family: inherit;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 8px 12px;
+    margin-bottom: -1px;
+    cursor: pointer;
+  }
+
+  .lt-tab:hover:not(:disabled) {
+    color: var(--text-dim);
+  }
+
+  .lt-tab:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .lt-tab.active {
+    color: var(--ink);
+    border-bottom-color: var(--accent);
+  }
+
+  .lt-live,
+  .lt-summary,
+  .lt-receipts {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--surface);
+    padding: 18px 20px;
+  }
+
+  .throughput-hero {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+
+  .throughput-value {
+    font-size: 44px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--ink);
+    line-height: 1;
+  }
+
+  .throughput-unit {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .progress-track {
+    height: 8px;
+    border-radius: 999px;
+    background: var(--paper);
+    border: 1px solid var(--line);
+    overflow: hidden;
+  }
+
+  .progress-fill {
+    height: 100%;
+    background: var(--loadtest-progress);
+    transition: width 0.3s ease;
+  }
+
+  .progress-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-faint);
+  }
+
+  .pulse-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--accent);
+    animation: pulse 1.2s ease-in-out infinite;
+    flex-shrink: 0;
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 0.25;
+      transform: scale(0.85);
+    }
+    50% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  .stat-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+    gap: 12px 20px;
+  }
+
+  .stat {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .stat-label {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-faint);
+  }
+
+  .stat-value {
+    font-size: 15px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: var(--ink);
+  }
+
+  .stat-value--bad {
+    color: var(--danger);
+  }
+
+  .lang-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    border-top: 1px solid var(--line);
+    padding-top: 10px;
+  }
+
+  .lang-row {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    font-size: 12px;
+  }
+
+  .lang-name {
+    font-weight: 600;
+    color: var(--ink);
+    min-width: 6rem;
+  }
+
+  .lang-count {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-dim);
+  }
+
+  .lang-extra {
+    color: var(--text-faint);
+    font-size: 11px;
+  }
+
+  .extrap-card {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    border: 1px solid color-mix(in srgb, var(--loadtest-highlight) 40%, var(--line));
+    background: color-mix(in srgb, var(--loadtest-highlight) 10%, var(--surface));
+    border-radius: 8px;
+    padding: 16px 18px;
+  }
+
+  .extrap-label {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--loadtest-highlight);
+  }
+
+  .extrap-figures {
+    display: flex;
+    gap: 28px;
+    flex-wrap: wrap;
+  }
+
+  .extrap-figure {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .extrap-value {
+    font-size: 28px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--ink);
+    line-height: 1;
+  }
+
+  .extrap-unit {
+    font-size: 11px;
+    color: var(--text-faint);
+  }
+
+  .extrap-note {
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--text-dim);
+    margin: 0;
+  }
+
+  .summary-section {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    border-top: 1px solid var(--line);
+    padding-top: 14px;
+  }
+
+  .section-title {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-faint);
+  }
+
+  .result-empty {
+    font-size: 13px;
+    color: var(--text-faint);
+    margin: 0;
+  }
+
+  .scans-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12.5px;
+  }
+
+  .scans-table th {
+    text-align: left;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-faint);
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .scans-table td {
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--line);
+    font-variant-numeric: tabular-nums;
+    color: var(--ink);
+  }
+
+  .scan-name {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-variant-numeric: normal;
+  }
+
+  .scan-row {
+    cursor: pointer;
+  }
+
+  .scan-row:hover {
+    background: var(--paper);
+  }
+
+  .pager {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .pager button {
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--ink);
+    background: var(--paper);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 5px 12px;
+    cursor: pointer;
+  }
+
+  .pager button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .pager-label {
+    font-size: 11px;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .back-link {
+    align-self: flex-start;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--accent);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+  }
+
+  .scan-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .result-grid {
+    display: flex;
+    gap: 10px;
+    align-items: baseline;
+    font-size: 13px;
+  }
+
+  .result-key {
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 11px;
+    color: var(--text-faint);
+  }
+
+  .result-val {
+    font-variant-numeric: tabular-nums;
+    color: var(--ink);
+  }
+
+  .result-val--bad {
+    color: var(--danger);
+    font-weight: 600;
+  }
+
+  .result-block {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .body-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-faint);
+  }
+
+  .body-text {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12.5px;
+    color: var(--ink);
+    background: var(--paper);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 10px 12px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 14rem;
+    overflow-y: auto;
+  }
+
+  .body-text--error {
+    color: var(--danger);
+  }
+
+  .row-tag {
+    font-size: 9px;
+    color: var(--text-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    border: 1px solid var(--line);
+    border-radius: 3px;
+    padding: 0 4px;
+    white-space: nowrap;
+  }
+
+  .findings {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 16rem;
+    overflow-y: auto;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .finding {
+    display: grid;
+    grid-template-columns: max-content max-content 1fr;
+    gap: 6px 10px;
+    align-items: baseline;
+    font-size: 12.5px;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .finding-sev {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 2px 6px;
+    border-radius: 4px;
+    border: 1px solid var(--line);
+    grid-row: 1;
+  }
+
+  .sev--high {
+    background: color-mix(in srgb, var(--danger) 14%, var(--surface));
+    color: var(--danger);
+    border-color: color-mix(in srgb, var(--danger) 35%, var(--line));
+  }
+
+  .sev--medium {
+    background: color-mix(in srgb, var(--sev-medium) 12%, var(--surface));
+    color: var(--sev-medium);
+    border-color: color-mix(in srgb, var(--sev-medium) 30%, var(--line));
+  }
+
+  .sev--low {
+    background: var(--paper);
+    color: var(--text-dim);
+  }
+
+  .finding-loc {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-dim);
+    grid-row: 1;
+  }
+
+  .finding-rule {
+    font-weight: 600;
+    color: var(--text-faint);
+    grid-column: 3;
+    grid-row: 1;
+  }
+
+  .finding-msg {
+    grid-column: 1 / -1;
+    color: var(--ink);
+  }
+
+  @media (max-width: 640px) {
+    .stat-grid {
+      grid-template-columns: 1fr 1fr;
+    }
+    .extrap-figures {
+      gap: 16px;
+    }
+    .scans-table {
+      font-size: 11px;
+    }
+    .finding {
+      grid-template-columns: max-content 1fr;
+    }
+    .finding-rule {
+      grid-column: 1 / -1;
+      grid-row: 2;
+    }
+    .finding-msg {
+      grid-row: 3;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pulse-dot,
+    .spinner {
+      animation: none;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/lib/private/components/demos/RunPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/RunPanel.svelte
@@ -6,8 +6,25 @@
   // clean Grimoire palette (inherited --paper/--ink/etc custom properties
   // from the page wrapper), not the old brutalist heavy-border look.
   import TraceWaterfall from "./TraceWaterfall.svelte";
+  import LoadTestPanel from "./LoadTestPanel.svelte";
 
   let { project } = $props();
+
+  // Sub-tab: python and semgrep projects offer a Single/Load Test switch;
+  // goose does not (an active agent run and a load test both hold node-4
+  // capacity, so the backend refuses to run them together, and the demo
+  // simply doesn't offer the load-test path for goose at all). Resets to
+  // "single" whenever the active project changes so switching tabs on the
+  // page never leaves a stale sub-tab selected.
+  let subTab = $state("single");
+
+  $effect(() => {
+    project.key;
+    subTab = "single";
+  });
+
+  let showsLoadTestTab = $derived(project.key === "python" || project.key === "semgrep");
+  let loadTestWorkload = $derived(project.key === "python" ? "sandbox" : "semgrep");
 
   // Inputs, seeded from the project's sample so Run works with zero edits,
   // but everything stays editable.
@@ -173,6 +190,30 @@
 </script>
 
 <div class="run-panel">
+  {#if showsLoadTestTab}
+    <nav class="sub-tabs" aria-label="Run mode">
+      <button
+        type="button"
+        class="sub-tab"
+        class:active={subTab === "single"}
+        onclick={() => (subTab = "single")}
+      >
+        {project.key === "python" ? "Single Run" : "Single Scan"}
+      </button>
+      <button
+        type="button"
+        class="sub-tab"
+        class:active={subTab === "load"}
+        onclick={() => (subTab = "load")}
+      >
+        Load Test
+      </button>
+    </nav>
+  {/if}
+
+  {#if showsLoadTestTab && subTab === "load"}
+    <LoadTestPanel workload={loadTestWorkload} />
+  {:else}
   <div class="input-area">
     {#if project.key === "python"}
       <label class="field-label" for="python-code">code.py</label>
@@ -343,6 +384,7 @@
   {/if}
 
   <TraceWaterfall {traceId} />
+  {/if}
 </div>
 
 <style>
@@ -350,6 +392,36 @@
     display: flex;
     flex-direction: column;
     gap: 20px;
+  }
+
+  .sub-tabs {
+    display: flex;
+    gap: 4px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .sub-tab {
+    font-family: inherit;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 8px 12px;
+    margin-bottom: -1px;
+    cursor: pointer;
+  }
+
+  .sub-tab:hover {
+    color: var(--text-dim);
+  }
+
+  .sub-tab.active {
+    color: var(--ink);
+    border-bottom-color: var(--accent);
   }
 
   .input-area {

--- a/projects/monolith/frontend/src/lib/private/demos/theme.css
+++ b/projects/monolith/frontend/src/lib/private/demos/theme.css
@@ -25,4 +25,14 @@
   --svc-goose: #a86a1f; /* goose-coding: the agent inside */
   --svc-semgrep: #8a5a9a; /* semgrep scan */
   --svc-default: #6b7280; /* any other/unknown service */
+
+  /* Load test panel: a warm highlight for the extrapolation card (the most
+   * important number on the summary view) and a progress-bar fill distinct
+   * from --accent so the live progress bar reads separately from buttons. */
+  --loadtest-highlight: #b5762a;
+  --loadtest-progress: #3f7a5c;
+
+  /* Medium-severity finding color, shared by RunPanel and LoadTestPanel's
+   * receipts drill-down (both render the same semgrep findings markup). */
+  --sev-medium: #8a6100;
 }


### PR DESCRIPTION
## What

PR 2 of the load-test demo (plan `docs/plans/2026-07-09-semgrep-load-test.md`). Builds on the merged PR 1 daemon changes (concurrency 15, per-scan `X-Fc-*` resource headers, both live on node-4). Adds a **Load Test** sub-tab to the private Firecracker demos page that drains a corpus through the semgrep or sandbox fc-invoke workload as fast as the daemon allows for a fixed 2-minute run, with live counters, a resource/extrapolation summary, and a "See Receipts" per-scan drill-down.

One **workload-parametric** harness drives both workloads (no duplication).

### Corpus (`demos/loadtest_corpus/`)
- 5 Semgrep Pro interprocedural-taint files (python, go, ts, k8s, rust; 114-180 lines), each a source reaching a sink through helper hops so only Pro cross-function analysis connects them.
- 7 varied sandbox Python scripts (numeric loop, quicksort, regex, pandas groupby, numpy matmul, json round-trip, fib) to spread the latency distribution.
- Stored as inert `.sample` files sent with virtual paths, so they never trip our own CI semgrep.

### Backend (`demos/loadtest.py`, `firecracker_api.py`, `cluster/kubernetes.py`)
- Workload registry (endpoint + payload-builder + result-parser) + an `_invoke` that reads the `X-Fc-*` headers per scan.
- Detached asyncio drain: client concurrency 20 over-subscribes the daemon's 15 so its semaphore never idles (drain as fast as the daemon allows).
- Buffered `LoadStore`: batch multi-row inserts; a `percentile_cont` rollup keeps the 1s live poll cheap.
- Resource sampler: fc-invoke pod + node-4 CPU/RSS via `metrics.k8s.io` (best-effort, derived fallback). Summary includes per-scan + aggregate + daemon/node footprint and a per-node -> fleet **extrapolation** block.
- Tables `demo.load_run` / `demo.load_scan` (workload-generic). Endpoints: start (with one-run + agent-busy guards), live status, paginated scans, single-scan detail.

### Frontend
- Single / Load Test sub-tab under both the Sandbox and Semgrep tabs; live counters; summary with the extrapolation front-and-center; "See Receipts" peer tab lazy-loading the per-scan table with row drill-down (findings for semgrep, stdout/exit for sandbox).

### Safety
- Private-tier only (demos is absent from the public backend glob).
- Daemon 26Gi limit is sized for one load-test workload; the start endpoint refuses while a goose agent run is `RUNNING`, and the load tests self-serialize.
- RBAC: added `metrics.k8s.io` pods get/list for the daemon-footprint sampler.

## Testing
- 8 backend unit tests (drain records rows+meta, error rows don't raise, header parsing, registry payloads, both guards) with a hand-rolled httpx fake (no new dep); corpus + migration tests. `pnpm build` verified clean. Full `bazel test` in CI.

## Chart
- `monolith` chart bumped 0.285.92 -> 0.285.93 (migration + RBAC + backend + frontend deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)