### PR TITLE
perf(demos): fix load-test throughput (concurrency 6 + cpu reservation) and live-view lag

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.53
+version: 0.4.54

--- a/projects/firecracker/substrate/chart/values.yaml
+++ b/projects/firecracker/substrate/chart/values.yaml
@@ -150,7 +150,16 @@ workloads:
     # that peak plus guest-OS overhead with headroom, still a 25% cut from 2048.
     vcpus: 1
     memMib: 1536
-    concurrency: 15
+    # Concurrency is bounded by PHYSICAL cores, not logical. node-4 is 8 physical
+    # cores + hyperthreading = 16 logical. A CPU-bound 1-vcpu scan gets real
+    # parallelism only up to 8 (one physical core each); past that, VMs land on HT
+    # siblings where compute-bound work gets ~no extra throughput and scheduler
+    # contention INVERTS it (measured: ~40 scans/s at 8 concurrent collapsing to
+    # ~5/s at 15). 6 leaves ~2 physical cores for the daemon + co-tenants
+    # (clickhouse/signoz), which keeps us reliably left of the collapse cliff even
+    # when a co-tenant momentarily grabs a core. See the cpu request below, which
+    # weight-protects these 6 cores under contention.
+    concurrency: 6
     egressEnabled: false
     warmBase: true
     readyPath: /shim/ready
@@ -192,35 +201,38 @@ workloads:
     # 512Mi keeps ~2x headroom over the heaviest observed run.
     vcpus: 1
     memMib: 512
-    # Raised 2 -> 15 for the sandbox load test (peer to the semgrep load test).
-    # CPU-bound like semgrep, so useful concurrency tracks node-4 cores (~15);
-    # at 512Mi that is ~7.5Gi, well inside the 26Gi limit below. Load tests run
-    # one workload at a time, so this never stacks with the semgrep 22.5Gi peak.
-    concurrency: 15
+    # Same physical-core bound as semgrep (see its comment): 6 concurrent 1-vcpu
+    # VMs on node-4's 8 physical cores, leaving ~2 for the daemon + co-tenants.
+    # Measured: sandbox throughput peaks ~40-50/s at 6-8 concurrent and collapses
+    # to ~5/s at 15 (HT-sibling contention), so 6 is the reliable operating point.
+    concurrency: 6
     egressEnabled: false
     warmBase: true
     readyPath: /shim/ready
     sessioned: false
     requestTimeout: 30s
 
-# The limit must hold the capped peak of every workload's guests plus the
-# daemon. A load test drives ONE workload to its concurrency cap: semgrep
-# 15 * 1536Mi = ~22.5Gi, or sandbox 15 * 512Mi = ~7.5Gi (a global one-run guard
-# in the monolith serializes load tests, so these two never stack). The agent
-# (goose) workload is idle in practice during a load test, and the monolith
-# guard refuses to start a load test while an agent run is active, so the honest
-# peak is semgrep (~22.5Gi) + ~1Gi daemon overhead. 26Gi covers that with margin
-# and keeps the daemon's burst ceiling low, which leaves node-4 headroom (16c /
-# 62Gi, ~35Gi free) for critical tenants (inference, clickhouse) rather than
-# over-reserving for a coexistence that does not happen. The request stays a
-# small floor (2Gi), so this ceiling is only realized during a load test, not
-# reserved. Firecracker guests are child processes in this cgroup, so they count
-# against this limit, not the request; in the rare case an agent run lands
-# mid-test and breaches the cgroup, oom_score_adj makes a guest die first, never
-# the daemon and never a node-critical tenant (ADR platform/010).
+# Memory limit holds the capped peak of every workload's guests plus the daemon.
+# A load test drives ONE workload to concurrency 6: semgrep 6 * 1536Mi = ~9Gi or
+# sandbox 6 * 512Mi = ~3Gi (a monolith one-run guard serializes load tests, so
+# they never stack). Even with a concurrent agent run (2 * 4096Mi = 8Gi) plus
+# ~1Gi daemon overhead the peak is ~18Gi, so 26Gi keeps comfortable margin.
+# Firecracker guests are child processes in this cgroup, so they count against
+# this limit; oom_score_adj makes a guest die first if it is ever breached, never
+# the daemon or a node-critical tenant (ADR platform/010).
+#
+# The CPU REQUEST is load-bearing, not a floor. The guest VMs are 1 vcpu each and
+# CPU-bound; at concurrency 6 a load test wants ~6 physical cores. cpu.weight is
+# proportional to the request, so a tiny request (the old 50m) let co-tenants
+# (clickhouse/signoz) out-compete the VMs for cores under contention, sliding the
+# throughput cliff left (measured: the collapse knee moved 8 -> 6 as tenants
+# woke). Requesting 6000m (matched to concurrency) both reserves the cores
+# schedulably and gives the cgroup weight to hold its 6 physical cores under
+# contention. Keep this EQUAL to concurrency: reserving fewer cores than VMs
+# reintroduces the collapse. node-4 has ~6.5 cores of request headroom for this.
 resources:
   requests:
-    cpu: 50m
+    cpu: 6000m
     memory: 2Gi
   limits:
     memory: 26Gi

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.53
+      targetRevision: 0.4.54
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.95
+version: 0.285.96
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/demos/loadtest.py
+++ b/projects/monolith/demos/loadtest.py
@@ -55,6 +55,11 @@ SAMPLE_NODE = "node-4"
 # Auto-flush the scan buffer once it reaches this many rows (one INSERT).
 _FLUSH_THRESHOLD = 200
 
+# Also flush at least this often so the 1s live poll sees fresh rows promptly
+# instead of only at 200-row batch boundaries (which, at tens of scans/s, is a
+# multi-second lag where the live view looks frozen right after kickoff).
+_FLUSH_INTERVAL_S = 1.0
+
 # Grace window past the drain deadline for in-flight invokes to finish before
 # stragglers are cancelled. A normal scan is ~1s, so this lets legitimately
 # in-flight scans complete while bounding a wedged run (the run row is the
@@ -174,17 +179,25 @@ class LoadStore:
         self._all_rows: list[dict] = []
         self._sampler_series: list[dict] = []
         self._lock = asyncio.Lock()
+        self._last_flush = time.monotonic()
 
     def set_sampler_series(self, series: list[dict]) -> None:
         self._sampler_series = series
 
     async def record(self, row: dict) -> None:
-        """Append a scan row; flush the buffer to Postgres when it fills."""
+        """Append a scan row; flush the buffer to Postgres when it fills or ages.
+
+        Flushes on either the size threshold or the time interval, so the 1s live
+        poll sees rows within ~1s of a run starting, not only once 200 rows have
+        accumulated.
+        """
         async with self._lock:
             self._all_rows.append(row)
             self._buffer.append(row)
-            if len(self._buffer) >= _FLUSH_THRESHOLD:
+            due = (time.monotonic() - self._last_flush) >= _FLUSH_INTERVAL_S
+            if len(self._buffer) >= _FLUSH_THRESHOLD or due:
                 batch, self._buffer = self._buffer, []
+                self._last_flush = time.monotonic()
                 await asyncio.to_thread(self._flush_batch, batch)
 
     async def flush(self) -> None:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.95
+      targetRevision: 0.285.96
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/LoadTestPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/LoadTestPanel.svelte
@@ -22,8 +22,12 @@
   //     _dispatch_drain in firecracker_api.py)
   let { workload } = $props();
 
+  // Sandbox executes scripts ("runs"); semgrep scans files ("scans").
+  let noun = $derived(workload === "sandbox" ? "run" : "scan");
+  let nounPlural = $derived(workload === "sandbox" ? "runs" : "scans");
+
   const RUN_DURATION_S = 120;
-  const DAEMON_CONCURRENCY = 15;
+  const DAEMON_CONCURRENCY = 6;
   const POLL_MS = 1000;
   const HARD_TIMEOUT_MS = 150_000;
   const SCANS_PAGE_SIZE = 50;
@@ -304,7 +308,7 @@
       <div class="lt-live">
         <div class="throughput-hero">
           <span class="throughput-value">{fmt(rollup.throughput_per_s, 2)}</span>
-          <span class="throughput-unit">scans/s</span>
+          <span class="throughput-unit">{nounPlural}/s</span>
         </div>
 
         <div class="progress-track" aria-hidden="true">
@@ -317,7 +321,7 @@
 
         <div class="stat-grid">
           <div class="stat">
-            <span class="stat-label">total scans</span>
+            <span class="stat-label">total {nounPlural}</span>
             <span class="stat-value">{rollup.total_scans ?? 0}</span>
           </div>
           <div class="stat">
@@ -368,11 +372,11 @@
             <div class="extrap-figures">
               <div class="extrap-figure">
                 <span class="extrap-value">{fmt(s.extrapolation?.per_node_throughput_per_s, 2)}</span>
-                <span class="extrap-unit">scans/s per node</span>
+                <span class="extrap-unit">{nounPlural}/s per node</span>
               </div>
               <div class="extrap-figure">
                 <span class="extrap-value">{fmt(s.extrapolation?.scans_per_core_s, 3)}</span>
-                <span class="extrap-unit">scans/core/s</span>
+                <span class="extrap-unit">{nounPlural}/core/s</span>
               </div>
             </div>
             <p class="extrap-note">{s.extrapolation?.note}</p>
@@ -415,7 +419,7 @@
           </div>
 
           <div class="summary-section">
-            <span class="section-title">latency + per-scan resources</span>
+            <span class="section-title">latency + per-{noun} resources</span>
             <div class="stat-grid">
               <div class="stat">
                 <span class="stat-label">latency p50/p95/max</span>
@@ -430,13 +434,13 @@
                 >
               </div>
               <div class="stat">
-                <span class="stat-label">per-scan cpu p50/p95</span>
+                <span class="stat-label">per-{noun} cpu p50/p95</span>
                 <span class="stat-value"
                   >{fmt(s.per_scan_cpu_ms?.p50, 0)} / {fmt(s.per_scan_cpu_ms?.p95, 0)}ms</span
                 >
               </div>
               <div class="stat">
-                <span class="stat-label">per-scan peak rss p50/p95</span>
+                <span class="stat-label">per-{noun} peak rss p50/p95</span>
                 <span class="stat-value"
                   >{fmt(s.per_scan_peak_rss_mib?.p50, 0)} / {fmt(s.per_scan_peak_rss_mib?.p95, 0)} MiB</span
                 >
@@ -458,7 +462,7 @@
                 </div>
               {/if}
               <div class="stat">
-                <span class="stat-label">total scans / errors</span>
+                <span class="stat-label">total {nounPlural} / errors</span>
                 <span class="stat-value">{s.total_scans ?? 0} / {s.errors ?? 0}</span>
               </div>
             </div>
@@ -497,7 +501,7 @@
           {:else}
             <div class="scan-detail">
               <div class="result-grid">
-                <span class="result-key">scan</span>
+                <span class="result-key">{noun}</span>
                 <span class="result-val">#{selectedScan.seq} · {selectedScan.name}</span>
               </div>
               <div class="result-grid">


### PR DESCRIPTION
## What

Follow-up to the load-test demo, driven by real profiling of live runs.

### The big one: throughput was self-inflicted by over-concurrency
Both semgrep and sandbox flatlined at ~5 scans/s with ~4s latency. Profiling showed it's **not** COW contention, a lock, or the scan engine, and nothing is cgroup-CPU-throttled. Root cause: **node-4 is 8 physical cores + hyperthreading (16 logical)**. A CPU-bound 1-vcpu VM gets real parallelism only up to 8; past that, VMs land on HT siblings and throughput *inverts* under scheduler contention. Concurrency 15 sat deep in the collapsed regime.

Measured (concurrency sweep on the live daemon): ~40-52 scans/s at 6-8 concurrent, collapsing to ~5/s at 15.

- `semgrep.concurrency` + `sandbox.concurrency`: **15 -> 6** (physical cores minus ~2 for the daemon + co-tenants, keeping us reliably left of the sharp collapse cliff).
- Daemon `requests.cpu`: **50m -> 6000m**. The near-zero request gave the cgroup negligible `cpu.weight`, so co-tenants (clickhouse/signoz) out-competed the VMs for physical cores and slid the cliff left (the knee moved 8 -> 6 between runs as tenants woke). Reserving 6000m (matched to concurrency) both reserves the cores schedulably and gives the cgroup weight to hold its 6 physical cores under contention. Fits node-4's ~6.5-core request headroom.

Expected: throughput ~5/s -> ~30-47/s (6-9x), per-invoke latency ~4000ms -> ~130ms (~30x).

### Live-view lag
The buffered store only flushed to Postgres at 200-row batches, so the 1s live poll saw zeros for the first ~15s. Added a **1s time-based flush** so rows land promptly. (The frontend already polls at 1s.)

### Sandbox terminology
The UI said "scans" for the sandbox, which runs scripts. Added a workload-aware noun: "runs" for sandbox, "scans" for semgrep (throughput unit, totals, per-N resources, extrapolation, drill-down). Also fixed the stale "concurrency 15" header copy to read from the (now 6) constant.

## Charts
- fc-invoke `0.4.53 -> 0.4.54`, monolith `0.285.95 -> 0.285.96`.

## Testing
`pnpm build` clean, backend syntax + `helm template` verified (cpu 6000m, concurrency 6). Full suite in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)