### PR TITLE
fix(demos): shorten load-test window to 60s

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.96
+version: 0.285.97
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/demos/firecracker_api.py
+++ b/projects/monolith/demos/firecracker_api.py
@@ -493,7 +493,7 @@ async def start_load_test(workload: str) -> dict:
     }
     run_id = await asyncio.to_thread(_insert_load_run, workload, config)
 
-    task = asyncio.create_task(_dispatch_drain(run_id, workload, 120))
+    task = asyncio.create_task(_dispatch_drain(run_id, workload, 60))
     _RUNNING_DRAINS.add(task)
     task.add_done_callback(_RUNNING_DRAINS.discard)
 

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.96
+      targetRevision: 0.285.97
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/LoadTestPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/LoadTestPanel.svelte
@@ -26,7 +26,7 @@
   let noun = $derived(workload === "sandbox" ? "run" : "scan");
   let nounPlural = $derived(workload === "sandbox" ? "runs" : "scans");
 
-  const RUN_DURATION_S = 120;
+  const RUN_DURATION_S = 60;
   const DAEMON_CONCURRENCY = 6;
   const POLL_MS = 1000;
   const HARD_TIMEOUT_MS = 150_000;
@@ -236,7 +236,7 @@
 <div class="load-test">
   <div class="lt-header">
     <p class="lt-blurb">
-      Fixed 2 minute drain against the fc-invoke daemon at concurrency
+      Fixed 60 second drain against the fc-invoke daemon at concurrency
       {DAEMON_CONCURRENCY}, oversubscribed by the client so the daemon stays
       saturated for the whole run.
     </p>


### PR DESCRIPTION
Drops the fixed load-test drain from 2 minutes to 60s (2m is too long for a demo). Backend dispatch duration 120->60, frontend RUN_DURATION_S + blurb copy. Monolith chart 0.285.96 -> 0.285.97.

Note: a separate Fable investigation is underway into why sustained throughput tops out ~5/s (effective concurrency settles at ~2 despite the cap); that root-cause fix will land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)