### PR TITLE
fix(fc-invoke): remove client-go 5 QPS auth throttle capping invoke throughput

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.54
+version: 0.4.55

--- a/projects/firecracker/substrate/cluster/auth/BUILD
+++ b/projects/firecracker/substrate/cluster/auth/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "auth",
     srcs = [
         "auth.go",
+        "cache.go",
         "reviewer.go",
     ],
     importpath = "github.com/jomcgi/homelab/projects/firecracker/substrate/cluster/auth",
@@ -16,11 +17,15 @@ go_library(
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//codes",
         "@io_opentelemetry_go_otel//propagation",
+        "@org_golang_x_sync//singleflight",
     ],
 )
 
 go_test(
     name = "auth_test",
-    srcs = ["auth_test.go"],
+    srcs = [
+        "auth_test.go",
+        "cache_test.go",
+    ],
     embed = [":auth"],
 )

--- a/projects/firecracker/substrate/cluster/auth/cache.go
+++ b/projects/firecracker/substrate/cluster/auth/cache.go
@@ -1,0 +1,122 @@
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// defaultReviewTTL bounds how long a successful TokenReview is trusted before it
+// is re-checked with the API server. The callers are a small, fixed set of
+// ServiceAccounts whose projected tokens rotate hourly, so a short TTL yields a
+// near-100% cache hit rate under a saturating invoke load while keeping the
+// window in which a just-revoked token still passes small.
+const defaultReviewTTL = 60 * time.Second
+
+// maxCacheEntries bounds memory if many distinct tokens are seen (token
+// rotation, or a spray of distinct bad tokens). Only SUCCESSFUL reviews are
+// cached, so a rejected-token flood cannot grow the map.
+const maxCacheEntries = 4096
+
+type cacheEntry struct {
+	username string
+	expires  time.Time
+}
+
+// cachingReviewer memoizes successful TokenReviews keyed by a hash of the token.
+// Without it, a saturating invoke rate becomes an equal rate of TokenReview
+// calls against the API server, which client-go rate-limits (the default 5 QPS
+// bucket was the fc-invoke throughput ceiling) and which needlessly loads the
+// control plane. Failures are never cached: a transient API error or a genuine
+// rejection must re-check on the next request.
+type cachingReviewer struct {
+	inner Reviewer
+	ttl   time.Duration
+	now   func() time.Time // injectable for tests
+	group singleflight.Group
+
+	mu      sync.Mutex
+	entries map[string]cacheEntry
+}
+
+func newCachingReviewer(inner Reviewer, ttl time.Duration) *cachingReviewer {
+	return &cachingReviewer{
+		inner:   inner,
+		ttl:     ttl,
+		now:     time.Now,
+		entries: make(map[string]cacheEntry),
+	}
+}
+
+// hashToken avoids holding raw bearer tokens as map keys; the sha256 is
+// sufficient to key the cache and never leaves the process.
+func hashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+func (c *cachingReviewer) lookup(key string, now time.Time) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[key]
+	if !ok {
+		return "", false
+	}
+	if now.After(e.expires) {
+		delete(c.entries, key)
+		return "", false
+	}
+	return e.username, true
+}
+
+func (c *cachingReviewer) store(key, username string, now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Bound memory: when at capacity and inserting a new key, sweep expired
+	// entries first; if still full, skip the insert (correctness is unaffected,
+	// the token is simply re-reviewed next time).
+	if _, exists := c.entries[key]; !exists && len(c.entries) >= maxCacheEntries {
+		for k, e := range c.entries {
+			if now.After(e.expires) {
+				delete(c.entries, k)
+			}
+		}
+		if len(c.entries) >= maxCacheEntries {
+			return
+		}
+	}
+	c.entries[key] = cacheEntry{username: username, expires: now.Add(c.ttl)}
+}
+
+// Review returns a cached username when the token was recently validated,
+// otherwise performs one TokenReview via the inner reviewer. A burst of
+// concurrent first-time requests for the same token is collapsed into a single
+// inner call by singleflight, so a cold cache under load does not stampede the
+// API server.
+func (c *cachingReviewer) Review(ctx context.Context, token string) (string, error) {
+	key := hashToken(token)
+	if username, ok := c.lookup(key, c.now()); ok {
+		return username, nil
+	}
+	v, err, _ := c.group.Do(key, func() (any, error) {
+		// A concurrent caller may have populated the cache while this call queued
+		// on the singleflight lock; re-check before hitting the API server.
+		if username, ok := c.lookup(key, c.now()); ok {
+			return username, nil
+		}
+		username, reviewErr := c.inner.Review(ctx, token)
+		if reviewErr != nil {
+			return "", reviewErr
+		}
+		c.store(key, username, c.now())
+		return username, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
+}

--- a/projects/firecracker/substrate/cluster/auth/cache.go
+++ b/projects/firecracker/substrate/cluster/auth/cache.go
@@ -102,6 +102,10 @@ func (c *cachingReviewer) Review(ctx context.Context, token string) (string, err
 	if username, ok := c.lookup(key, c.now()); ok {
 		return username, nil
 	}
+	// The shared inner call runs under the ctx of whichever caller won the
+	// singleflight slot; if that caller cancels mid-flight, co-flight waiters see
+	// its cancellation as an error. That error is not cached and maps to a
+	// retryable 401, and auth calls are short, so the coupling is benign here.
 	v, err, _ := c.group.Do(key, func() (any, error) {
 		// A concurrent caller may have populated the cache while this call queued
 		// on the singleflight lock; re-check before hitting the API server.

--- a/projects/firecracker/substrate/cluster/auth/cache_test.go
+++ b/projects/firecracker/substrate/cluster/auth/cache_test.go
@@ -1,0 +1,109 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countingReviewer records how many times the inner Review is invoked and can
+// be told to fail or to block until released (for the singleflight test).
+type countingReviewer struct {
+	calls   atomic.Int64
+	user    string
+	err     error
+	release chan struct{} // if non-nil, Review blocks until closed
+}
+
+func (c *countingReviewer) Review(_ context.Context, _ string) (string, error) {
+	c.calls.Add(1)
+	if c.release != nil {
+		<-c.release
+	}
+	return c.user, c.err
+}
+
+func TestCachingReviewer_HitAvoidsSecondCall(t *testing.T) {
+	inner := &countingReviewer{user: "system:serviceaccount:monolith:app"}
+	c := newCachingReviewer(inner, time.Minute)
+
+	for i := 0; i < 5; i++ {
+		got, err := c.Review(context.Background(), "tok")
+		if err != nil {
+			t.Fatalf("Review: %v", err)
+		}
+		if got != inner.user {
+			t.Fatalf("username = %q, want %q", got, inner.user)
+		}
+	}
+	if n := inner.calls.Load(); n != 1 {
+		t.Fatalf("inner called %d times, want 1 (cache should serve the rest)", n)
+	}
+}
+
+func TestCachingReviewer_TTLExpiryRereviews(t *testing.T) {
+	inner := &countingReviewer{user: "u"}
+	c := newCachingReviewer(inner, time.Minute)
+	base := time.Unix(1_000_000, 0)
+	c.now = func() time.Time { return base }
+
+	if _, err := c.Review(context.Background(), "tok"); err != nil {
+		t.Fatal(err)
+	}
+	// Still within TTL: served from cache.
+	c.now = func() time.Time { return base.Add(59 * time.Second) }
+	if _, err := c.Review(context.Background(), "tok"); err != nil {
+		t.Fatal(err)
+	}
+	if n := inner.calls.Load(); n != 1 {
+		t.Fatalf("within TTL inner called %d times, want 1", n)
+	}
+	// Past TTL: re-reviews.
+	c.now = func() time.Time { return base.Add(61 * time.Second) }
+	if _, err := c.Review(context.Background(), "tok"); err != nil {
+		t.Fatal(err)
+	}
+	if n := inner.calls.Load(); n != 2 {
+		t.Fatalf("after TTL inner called %d times, want 2", n)
+	}
+}
+
+func TestCachingReviewer_FailuresNotCached(t *testing.T) {
+	inner := &countingReviewer{err: errors.New("token not authenticated")}
+	c := newCachingReviewer(inner, time.Minute)
+
+	for i := 0; i < 3; i++ {
+		if _, err := c.Review(context.Background(), "bad"); err == nil {
+			t.Fatal("expected error")
+		}
+	}
+	if n := inner.calls.Load(); n != 3 {
+		t.Fatalf("inner called %d times, want 3 (failures must not be cached)", n)
+	}
+}
+
+func TestCachingReviewer_SingleflightCollapsesConcurrent(t *testing.T) {
+	inner := &countingReviewer{user: "u", release: make(chan struct{})}
+	c := newCachingReviewer(inner, time.Minute)
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_, _ = c.Review(context.Background(), "tok")
+		}()
+	}
+	// Give the goroutines time to funnel into singleflight, then release.
+	time.Sleep(20 * time.Millisecond)
+	close(inner.release)
+	wg.Wait()
+
+	if got := inner.calls.Load(); got != 1 {
+		t.Fatalf("inner called %d times for %d concurrent same-token requests, want 1", got, n)
+	}
+}

--- a/projects/firecracker/substrate/cluster/auth/reviewer.go
+++ b/projects/firecracker/substrate/cluster/auth/reviewer.go
@@ -34,11 +34,22 @@ func NewClusterReviewer() (Reviewer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("in-cluster config: %w", err)
 	}
+	// client-go's default client-side rate limiter is 5 QPS / burst 10. Since
+	// every /invoke does one TokenReview, that default bucket silently capped the
+	// daemon's whole throughput at ~5 invokes/s (a saturating drain queued for
+	// seconds in this limiter, upstream of the concurrency semaphore and every
+	// span but auth_tokenreview). Raise it well above the invoke rate; the
+	// caching wrapper below keeps the actual TokenReview call rate near zero, so
+	// this is headroom for cache misses (hourly token rotation), not sustained
+	// API-server load.
+	restCfg.QPS = 100
+	restCfg.Burst = 200
 	clientset, err := kubernetes.NewForConfig(restCfg)
 	if err != nil {
 		return nil, fmt.Errorf("kubernetes client: %w", err)
 	}
-	return &clusterReviewer{reviews: clientset.AuthenticationV1().TokenReviews()}, nil
+	cluster := &clusterReviewer{reviews: clientset.AuthenticationV1().TokenReviews()}
+	return newCachingReviewer(cluster, defaultReviewTTL), nil
 }
 
 // Review submits token to the TokenReview API and returns the authenticated

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.54
+      targetRevision: 0.4.55
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## Root cause (Fable investigation)

The load-test demo's ~5 scans/s ceiling with ~4s latency, unmoved by any concurrency-cap change, was **client-go's default client-side rate limiter**. Every `/invoke` is TokenReview-gated by the auth middleware, whose clientset was built from `rest.InClusterConfig()` with **no QPS/Burst set** — so client-go applied its default **5 QPS / burst 10** token bucket. That bucket sits upstream of the concurrency semaphore and outside the `fc_invoke` span, so every in-trace instrument (queue_wait, guest CPU, VM count) looked clean while the wait happened in `auth_tokenreview`.

Decisive evidence:
- Daemon stderr, verbatim during drains: `"Waited before sending request" delay="3.61s" reason="client-side throttling ... tokenreviews"` (max observed 7.15s).
- SigNoz spans (3085 invokes): `auth_tokenreview` p50 **3186ms** / p95 3895ms, while `fc_invoke` (entire post-auth pipeline) p50 185ms, `snapshot_restore` 22ms, `guest_exec` 122ms. Uncontended TokenReview is 1-2ms, so ~100% of the 3.2s was queueing in the limiter.
- Arithmetic reproduces every prior measurement exactly: ceiling = QPS = 5/s; latency at 20 clients = 20/5 = 4.0s; K=6 burst fits burst-10 so measures true capacity (29/s); K=20 exhausts the bucket -> 9/s.

This also explains earlier mis-diagnoses: the "hyperthreading cliff" at K>8 was the burst-10 allowance running out, not physical cores.

## Fix
1. `NewClusterReviewer`: set `restCfg.QPS = 100`, `restCfg.Burst = 200` (headroom well above the invoke rate).
2. New `cachingReviewer` (`cache.go`): memoizes successful TokenReviews by sha256(token) with a 60s TTL and singleflight-collapsed concurrent misses. Callers are a fixed set of SAs with hourly-rotated tokens, so hit rate is ~100% and the API server is removed from the hot path (mirrors kube-apiserver's own authn token cache). Failures are never cached.

Expected: ceiling moves from 5/s to true daemon capacity (~30/s+ sandbox, ~15/s+ semgrep, guest_exec-bound), and the `Waited before sending request ... tokenreviews` log lines vanish.

## Follow-up (separate)
With the real bottleneck gone, the concurrency cap (currently 6) and daemon cpu request (6000m) — both set against the now-disproven HT-cliff diagnosis — should be re-measured and re-tuned against the true ceiling. Not in this PR.

## Testing
`cache_test.go`: hit avoids second call, TTL expiry re-reviews, failures not cached, singleflight collapses 20 concurrent same-token requests to 1 inner call. `GOOS=linux go build` + `go vet` pass; full suite in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)