### PR TITLE
fix(demos): report per-scan fc-invoke wall time, not the queue

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.97
+version: 0.285.98
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/demos/firecracker_api.py
+++ b/projects/monolith/demos/firecracker_api.py
@@ -304,10 +304,23 @@ def _load_run_rollup(run_id: str) -> dict | None:
                 SELECT
                     count(*) AS total_scans,
                     count(*) FILTER (WHERE status = 'error') AS errors,
-                    percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_ms)
-                        AS latency_p50,
-                    percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms)
-                        AS latency_p95,
+                    -- The headline "latency" is the fc-invoke WALL per scan
+                    -- (restore + guest exec), i.e. client wall minus the time
+                    -- spent waiting for a daemon slot. Under a saturating drain
+                    -- the raw client wall is dominated by that semaphore queue
+                    -- (clients / throughput), which measures oversubscription,
+                    -- not the daemon. Subtracting queue_wait shows the real
+                    -- per-scan cost; the queue is reported separately below.
+                    percentile_cont(0.5) WITHIN GROUP (
+                        ORDER BY greatest(latency_ms - coalesce(queue_wait_ms, 0), 0)
+                    ) AS latency_p50,
+                    percentile_cont(0.95) WITHIN GROUP (
+                        ORDER BY greatest(latency_ms - coalesce(queue_wait_ms, 0), 0)
+                    ) AS latency_p95,
+                    percentile_cont(0.5) WITHIN GROUP (ORDER BY queue_wait_ms)
+                        AS queue_p50,
+                    percentile_cont(0.95) WITHIN GROUP (ORDER BY queue_wait_ms)
+                        AS queue_p95,
                     avg(cpu_ms) AS cpu_ms_mean,
                     avg(peak_rss_mib) AS peak_rss_mib_mean,
                     extract(epoch FROM (
@@ -358,6 +371,8 @@ def _load_run_rollup(run_id: str) -> dict | None:
         "in_flight_estimate": in_flight,
         "latency_p50": float(agg.latency_p50) if agg.latency_p50 is not None else None,
         "latency_p95": float(agg.latency_p95) if agg.latency_p95 is not None else None,
+        "queue_p50": float(agg.queue_p50) if agg.queue_p50 is not None else None,
+        "queue_p95": float(agg.queue_p95) if agg.queue_p95 is not None else None,
         "per_lang_counts": {r.name: r.c for r in per_lang},
         "cpu_ms_mean": float(agg.cpu_ms_mean) if agg.cpu_ms_mean is not None else None,
         "peak_rss_mib_mean": (

--- a/projects/monolith/demos/loadtest.py
+++ b/projects/monolith/demos/loadtest.py
@@ -330,7 +330,13 @@ def build_summary(workload: str, rows: list[dict], sampler_series: list[dict]) -
     run_wall_s = observed_wall if observed_wall and observed_wall > 0 else wall_s
     throughput = (total / run_wall_s) if run_wall_s and run_wall_s > 0 else 0.0
 
-    lat_vals = [float(v) for v in latencies]
+    # Headline latency is the fc-invoke WALL per scan (client wall minus the
+    # time spent queued for a daemon slot): the real per-scan cost, not the
+    # oversubscription queue. The queue is reported separately in queue_wait_ms.
+    def _exec_ms(r: dict) -> float:
+        return max(float(r["latency_ms"]) - float(r.get("queue_wait_ms") or 0), 0.0)
+
+    lat_vals = [_exec_ms(r) for r in rows if r.get("latency_ms") is not None]
     queue_vals = [
         float(r["queue_wait_ms"]) for r in rows if r.get("queue_wait_ms") is not None
     ]
@@ -343,9 +349,7 @@ def build_summary(workload: str, rows: list[dict], sampler_series: list[dict]) -
     names = {r.get("name") for r in rows if r.get("name") is not None}
     for name in names:
         group = [r for r in rows if r.get("name") == name]
-        g_lat = sorted(
-            float(r["latency_ms"]) for r in group if r.get("latency_ms") is not None
-        )
+        g_lat = sorted(_exec_ms(r) for r in group if r.get("latency_ms") is not None)
         g_cpu = sorted(float(r["cpu_ms"]) for r in group if r.get("cpu_ms") is not None)
         per_lang[name] = {
             "count": len(group),

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.97
+      targetRevision: 0.285.98
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/LoadTestPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/LoadTestPanel.svelte
@@ -335,12 +335,16 @@
             >
           </div>
           <div class="stat">
-            <span class="stat-label">latency p50</span>
+            <span class="stat-label">{noun} time p50</span>
             <span class="stat-value">{fmt(rollup.latency_p50, 0)}ms</span>
           </div>
           <div class="stat">
-            <span class="stat-label">latency p95</span>
+            <span class="stat-label">{noun} time p95</span>
             <span class="stat-value">{fmt(rollup.latency_p95, 0)}ms</span>
+          </div>
+          <div class="stat">
+            <span class="stat-label">queue wait p50</span>
+            <span class="stat-value">{fmt(rollup.queue_p50, 0)}ms</span>
           </div>
           <div class="stat">
             <span class="stat-label">mean cpu</span>
@@ -422,7 +426,7 @@
             <span class="section-title">latency + per-{noun} resources</span>
             <div class="stat-grid">
               <div class="stat">
-                <span class="stat-label">latency p50/p95/max</span>
+                <span class="stat-label">{noun} time p50/p95/max</span>
                 <span class="stat-value"
                   >{fmt(s.latency_ms?.p50, 0)} / {fmt(s.latency_ms?.p95, 0)} / {fmt(s.latency_ms?.max, 0)}ms</span
                 >


### PR DESCRIPTION
The load-test 'latency' showed client wall, which under a saturating drain (20 clients vs a ~6-slot daemon) is dominated by semaphore queue-wait: for semgrep, p50 3176ms was ~2067ms queue + ~858ms actual scan. That measures oversubscription, not the daemon.

Now the headline latency is the fc-invoke WALL per scan = client wall - queue_wait (the real restore+scan cost), with queue-wait surfaced as its own stat. Semgrep's ~0.9s real scan cost becomes legible instead of reading as a 3s problem; sandbox is ~130-650ms. Backend: rollup + build_summary compute latency as greatest(latency_ms - coalesce(queue_wait_ms,0), 0); added queue_p50/p95. Frontend: relabelled to '{scan|run} time' + a 'queue wait' stat. Monolith chart 0.285.98.

Verified live post-auth-fix (PR #3352): sandbox 30/s, semgrep 6/s with real per-scan cost ~858ms cpu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)