### PR TITLE
perf(fc-invoke): pro-intrafile engine mode, concurrency 16

### DIFF
--- a/projects/firecracker/semgrep/guest-init/internal/scandriver/driver.go
+++ b/projects/firecracker/semgrep/guest-init/internal/scandriver/driver.go
@@ -1,6 +1,6 @@
 // Package scandriver drives the warm offline-Pro semgrep scan-server: a child
-// process (osemgrep-pro mcp --experimental --pro) that speaks newline-delimited
-// JSON over its stdio, one request -> one response.
+// process (osemgrep-pro mcp --experimental --pro-intrafile) that speaks
+// newline-delimited JSON over its stdio, one request -> one response.
 //
 // It replaces the former resident `semgrep lsp` + LSP JSON-RPC client. The old
 // path could only run OSS analysis (semgrep lsp ignores SEMGREP_CORE_BIN and
@@ -38,13 +38,16 @@ type Driver struct {
 // Start launches the scan-server and blocks until it prints exactly one
 // {"ready":true} line (per-language parsers warmed, rules compiled) — the point
 // at which the host may snapshot the VM. bin is the osemgrep-pro path; it is
-// invoked as `osemgrep-pro mcp --experimental --pro --session-id fc`.
+// invoked as `osemgrep-pro mcp --experimental --pro-intrafile --session-id fc`.
 // --experimental is REQUIRED: without it, `mcp` falls back to the Python MCP
-// server. The child's lifetime is bound to ctx (cancel -> the process is
-// killed). rulesDir and settingsFile are exported to the child as
-// SEMGREP_SCAN_RULES and SEMGREP_SETTINGS_FILE.
+// server. --pro-intrafile (not --pro) scopes Pro analysis to cross-function
+// taint WITHIN one file: every scan request is a single file, so full
+// interfile machinery has nothing to connect and only adds per-scan cost
+// (python p50 was engine-bound at ~1.2s under --pro). The child's lifetime is
+// bound to ctx (cancel -> the process is killed). rulesDir and settingsFile
+// are exported to the child as SEMGREP_SCAN_RULES and SEMGREP_SETTINGS_FILE.
 func Start(ctx context.Context, bin, rulesDir, settingsFile string) (*Driver, error) {
-	cmd := exec.CommandContext(ctx, bin, "mcp", "--experimental", "--pro", "--session-id", "fc")
+	cmd := exec.CommandContext(ctx, bin, "mcp", "--experimental", "--pro-intrafile", "--session-id", "fc")
 	cmd.Env = append(os.Environ(),
 		"SEMGREP_SCAN_RULES="+rulesDir,
 		"SEMGREP_SETTINGS_FILE="+settingsFile,

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.56
+version: 0.4.57

--- a/projects/firecracker/substrate/chart/values.yaml
+++ b/projects/firecracker/substrate/chart/values.yaml
@@ -150,17 +150,16 @@ workloads:
     # that peak plus guest-OS overhead with headroom, still a 25% cut from 2048.
     vcpus: 1
     memMib: 1536
-    # node-4 is 8 physical cores + hyperthreading = 16 logical. Full parallelism
-    # for CPU-bound 1-vcpu scans holds up to 8 (one physical core each); HT
-    # siblings beyond that typically add a partial (~20-30%) gain, not another
-    # full core. NOTE: the earlier "collapse to ~5/s at 15" measurement that
-    # justified concurrency 6 was NOT an HT cliff: it was the client-go default
-    # 5 QPS auth-TokenReview throttle in the daemon (fixed on main), so the
-    # HT-collapse claim is unproven. 12 probes the HT upside while leaving 4
-    # logical cores for the daemon + co-tenants (clickhouse/signoz); re-measure
-    # via the demos load test before pushing further. See the cpu request
-    # below, which weight-protects the scan cores under contention.
-    concurrency: 12
+    # node-4 is 8 physical cores + hyperthreading = 16 logical. Measured at
+    # concurrency 12 (post auth-throttle fix): semgrep 15.8/s (+76% over 6),
+    # exec p50 ~flat, node peaking at 16.1 cores, so HT siblings DO contribute
+    # (the earlier "collapse at 15" datum was the client-go 5 QPS TokenReview
+    # throttle, not HT contention). 16 = all logical cores: node-4's co-tenants
+    # idle at ~0.4 cores and a load test is a 60s burst, so briefly out-weighing
+    # them is an accepted trade for absolute throughput. Past 16 there is no
+    # silicon left, only queue depth. See the cpu request below, which
+    # weight-protects the scan cores under contention.
+    concurrency: 16
     egressEnabled: false
     warmBase: true
     readyPath: /shim/ready
@@ -202,10 +201,10 @@ workloads:
     # 512Mi keeps ~2x headroom over the heaviest observed run.
     vcpus: 1
     memMib: 512
-    # Same core reasoning as semgrep (see its comment): the old "collapse at 15"
-    # datum was the auth throttle, not HT contention, so 12 probes the HT upside.
-    # Clean pre-throttle measurement: ~40-50 runs/s at 6-8 concurrent.
-    concurrency: 12
+    # Same core reasoning as semgrep (see its comment). Measured at 12:
+    # 52.4/s (+31% over 6), run p50 198ms. Short runs have non-CPU phases
+    # (restore, vsock I/O), so 16 also fills scheduler gaps.
+    concurrency: 16
     egressEnabled: false
     warmBase: true
     readyPath: /shim/ready
@@ -213,11 +212,11 @@ workloads:
     requestTimeout: 30s
 
 # Memory limit holds the capped peak of every workload's guests plus the daemon.
-# A load test drives ONE workload to concurrency 12: semgrep 12 * 1536Mi = ~18Gi
-# or sandbox 12 * 512Mi = ~6Gi (a monolith one-run guard serializes load tests,
+# A load test drives ONE workload to concurrency 16: semgrep 16 * 1536Mi = ~24Gi
+# or sandbox 16 * 512Mi = ~8Gi (a monolith one-run guard serializes load tests,
 # so they never stack). Even with a concurrent agent run (2 * 4096Mi = 8Gi) plus
-# ~1Gi daemon overhead the peak is ~27Gi, so 32Gi keeps comfortable margin
-# (node-4 has 64Gi).
+# ~1Gi daemon overhead the peak is ~33Gi, so 36Gi keeps margin (node-4 has
+# 64Gi and idles ~29Gi used).
 # Firecracker guests are child processes in this cgroup, so they count against
 # this limit; oom_score_adj makes a guest die first if it is ever breached, never
 # the daemon or a node-critical tenant (ADR platform/010).
@@ -227,15 +226,15 @@ workloads:
 # old 50m) let co-tenants (clickhouse/signoz) out-compete the VMs for cores
 # under contention. 6000m holds ~6 cores of weight under contention and stays
 # schedulable on node-4 (~91% requested already); it is deliberately BELOW the
-# new concurrency 12: there is no CPU limit, so load tests burst to all idle
+# concurrency 16: there is no CPU limit, so load tests burst to all idle
 # cores regardless, and the request only decides who wins when co-tenants are
-# busy. Raising it to 12000m would overcommit node-4's requests past 100%.
+# busy. Raising it further would overcommit node-4's requests past 100%.
 resources:
   requests:
     cpu: 6000m
     memory: 2Gi
   limits:
-    memory: 32Gi
+    memory: 36Gi
 
 # Firecracker substrate paths on node-4. Driving real microVMs (privileged +
 # these host mounts) is gated behind `firecracker.enabled`; until then the

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.56
+      targetRevision: 0.4.57
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.99
+version: 0.285.100
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/demos/firecracker_api.py
+++ b/projects/monolith/demos/firecracker_api.py
@@ -500,7 +500,7 @@ async def start_load_test(workload: str) -> dict:
     config = {
         "workload": workload,
         "daemon_concurrency": loadtest.DAEMON_CONCURRENCY,
-        "client_concurrency": 20,
+        "client_concurrency": 32,
         "vcpus": loadtest.VCPUS_PER_SCAN,
         "mem_mib": _WORKLOAD_MEM_MIB[workload],
         "node": loadtest.SAMPLE_NODE,

--- a/projects/monolith/demos/loadtest.py
+++ b/projects/monolith/demos/loadtest.py
@@ -4,8 +4,8 @@ Drains a corpus of example files through the fc-invoke daemon (semgrep or
 sandbox workload) as fast as the daemon's per-workload semaphore allows, for a
 fixed run duration. It:
 
-- oversubscribes the daemon (``client_concurrency`` = 20 > daemon concurrency
-  12) so the daemon's semaphore stays saturated and throughput is daemon-bound;
+- oversubscribes the daemon (``client_concurrency`` = 32 > daemon concurrency
+  16) so the daemon's semaphore stays saturated and throughput is daemon-bound;
 - buffers per-scan rows and writes them to ``demo.load_scan`` in batched
   multi-row INSERTs (via a sync engine off the event loop);
 - samples the fc-invoke pod and node-4 resource footprint every ~2s
@@ -44,11 +44,11 @@ logger = logging.getLogger(__name__)
 
 FC_INVOKE_URL = os.environ.get("FC_INVOKE_URL", "")
 
-# The daemon runs each workload at concurrency 12 on node-4, one vcpu per VM.
+# The daemon runs each workload at concurrency 16 on node-4, one vcpu per VM.
 # MUST match `workloads.{semgrep,sandbox}.concurrency` in
 # projects/firecracker/substrate/chart/values.yaml: this constant feeds the
 # scans/core/s extrapolation, so drift silently skews that number.
-DAEMON_CONCURRENCY = 12
+DAEMON_CONCURRENCY = 16
 VCPUS_PER_SCAN = 1
 FC_INVOKE_NAMESPACE = "monolith"
 # The fc-invoke pod name carries this prefix; pod-metrics lookup matches on it.
@@ -515,15 +515,15 @@ async def run_load_test(
     workload: str,
     store: LoadStore,
     duration_s: int = 120,
-    client_concurrency: int = 20,
+    client_concurrency: int = 32,
     corpus: list[dict] | None = None,
     sampler: Callable[[asyncio.Event], Awaitable[list[dict]]] | None = None,
     invoke: Callable[..., Awaitable[tuple[dict, dict, str | None]]] | None = None,
 ) -> None:
     """Drain ``corpus`` through the daemon for ``duration_s`` seconds.
 
-    ``client_concurrency`` (20) intentionally EXCEEDS the daemon's per-workload
-    concurrency (12), so the daemon's semaphore stays saturated and the drain
+    ``client_concurrency`` (32) intentionally EXCEEDS the daemon's per-workload
+    concurrency (16), so the daemon's semaphore stays saturated and the drain
     runs as fast as the daemon allows. Each of ``client_concurrency`` worker
     tasks loops until the deadline, pulling the next corpus item round-robin,
     invoking the daemon, timing wall latency, and recording the row. A resource

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.99
+      targetRevision: 0.285.100
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/LoadTestPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/LoadTestPanel.svelte
@@ -22,7 +22,7 @@
   //   - demos/firecracker_api.py _load_scans_page(): total, offset, limit,
   //     scans[]{id,seq,name,status,scan_ms,cpu_ms,peak_rss_mib,result_count}
   //   - demos/firecracker_api.py _load_scan_detail(): adds result, error
-  //   - demos/loadtest.py DAEMON_CONCURRENCY=12, run duration_s=60 (see
+  //   - demos/loadtest.py DAEMON_CONCURRENCY=16, run duration_s=60 (see
   //     _dispatch_drain in firecracker_api.py)
   let { workload } = $props();
 
@@ -31,7 +31,7 @@
   let nounPlural = $derived(workload === "sandbox" ? "runs" : "scans");
 
   const RUN_DURATION_S = 60;
-  const DAEMON_CONCURRENCY = 12;
+  const DAEMON_CONCURRENCY = 16;
   const POLL_MS = 1000;
   const HARD_TIMEOUT_MS = 150_000;
   const SCANS_PAGE_SIZE = 50;


### PR DESCRIPTION
## What

Follow-up to #3355, two more throughput levers:

1. **`--pro` -> `--pro-intrafile`** in the semgrep scan-server invocation (`scandriver/driver.go`). Every scan request is a single file, so interfile machinery has nothing to connect and only adds per-scan cost (python was engine-bound at ~1.2s p50 after the file-size fix). Intrafile mode keeps the cross-function taint the demo exists to show: both sample taint paths are single-file, two-hop. Guest image rebuild via chart bump.
2. **Concurrency 12 -> 16** (all logical cores) for semgrep + sandbox. Measured at 12: node-4 peaked at 16.1/16 cores with exec p50 flat, so HT siblings contribute; co-tenants idle at ~0.4 cores and a load test is a 60s burst, so briefly out-weighing them is the accepted trade for absolute throughput. Memory limit 32Gi -> 36Gi; client oversubscription 20 -> 32; DAEMON_CONCURRENCY constants synced.

## Risk

If the `mcp` subcommand rejects `--pro-intrafile`, the scan-server exits before ready and the pod wedges in Init (loud, instantly attributable). Rollback is a one-line revert + chart bump.

## Verification after rollout

- Wait for pod Ready (init rebuilds warm-base snapshots, takes minutes)
- Run semgrep + sandbox load tests; compare vs concurrency-12 baseline (15.8/s and 52.4/s)
- Drill into a python receipt: result_count must still be 2 (both taint findings fire under intrafile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxK2P3pkLWxfHMjFgvnpPE