### PR TITLE
fix(fc-invoke): revert semgrep mcp flag to --pro, intrafile unsupported

### DIFF
--- a/projects/firecracker/semgrep/guest-init/internal/scandriver/driver.go
+++ b/projects/firecracker/semgrep/guest-init/internal/scandriver/driver.go
@@ -1,6 +1,6 @@
 // Package scandriver drives the warm offline-Pro semgrep scan-server: a child
-// process (osemgrep-pro mcp --experimental --pro-intrafile) that speaks
-// newline-delimited JSON over its stdio, one request -> one response.
+// process (osemgrep-pro mcp --experimental --pro) that speaks newline-delimited
+// JSON over its stdio, one request -> one response.
 //
 // It replaces the former resident `semgrep lsp` + LSP JSON-RPC client. The old
 // path could only run OSS analysis (semgrep lsp ignores SEMGREP_CORE_BIN and
@@ -38,16 +38,17 @@ type Driver struct {
 // Start launches the scan-server and blocks until it prints exactly one
 // {"ready":true} line (per-language parsers warmed, rules compiled) — the point
 // at which the host may snapshot the VM. bin is the osemgrep-pro path; it is
-// invoked as `osemgrep-pro mcp --experimental --pro-intrafile --session-id fc`.
+// invoked as `osemgrep-pro mcp --experimental --pro --session-id fc`.
 // --experimental is REQUIRED: without it, `mcp` falls back to the Python MCP
-// server. --pro-intrafile (not --pro) scopes Pro analysis to cross-function
-// taint WITHIN one file: every scan request is a single file, so full
-// interfile machinery has nothing to connect and only adds per-scan cost
-// (python p50 was engine-bound at ~1.2s under --pro). The child's lifetime is
+// server. --pro is the ONLY engine flag mcp accepts: --pro-intrafile is a
+// `semgrep scan` flag and mcp rejects it with "unknown option", which kills
+// the scan-server before ready and crashloops every semgrep guest (verified
+// live 2026-07-10; the pod still passes readiness because that gates on the
+// daemon healthz, not per-workload warm-base success). The child's lifetime is
 // bound to ctx (cancel -> the process is killed). rulesDir and settingsFile
 // are exported to the child as SEMGREP_SCAN_RULES and SEMGREP_SETTINGS_FILE.
 func Start(ctx context.Context, bin, rulesDir, settingsFile string) (*Driver, error) {
-	cmd := exec.CommandContext(ctx, bin, "mcp", "--experimental", "--pro-intrafile", "--session-id", "fc")
+	cmd := exec.CommandContext(ctx, bin, "mcp", "--experimental", "--pro", "--session-id", "fc")
 	cmd.Env = append(os.Environ(),
 		"SEMGREP_SCAN_RULES="+rulesDir,
 		"SEMGREP_SETTINGS_FILE="+settingsFile,

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.57
+version: 0.4.58

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.57
+      targetRevision: 0.4.58
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## What

Emergency revert of the `--pro-intrafile` flag from #3356. The `mcp` subcommand rejects it:

```
semgrep mcp: unknown option --pro-intrafile
scan-server exited before ready: EOF
```

Every semgrep guest crashloops before `/shim/ready`; all semgrep invokes time out (60s). Pod readiness did NOT catch it (gates on daemon healthz, not per-workload warm-base success). Sandbox and agent workloads unaffected.

Keeps concurrency 16 + 36Gi from #3356 (sandbox measured 58/s there, up from 52.4). Driver comment now documents that `--pro` is the only engine flag mcp accepts.

## Verification
- After rollout: semgrep load test recovers to >=15.8/s with 0 errors, python receipt shows result_count 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxK2P3pkLWxfHMjFgvnpPE