### PR TITLE
fix(demos): cap load-test elapsed label at the run duration

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.100
+version: 0.285.101
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.100
+      targetRevision: 0.285.101
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/LoadTestPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/LoadTestPanel.svelte
@@ -319,7 +319,10 @@
           <div class="progress-fill" style={`width: ${progressPct}%;`}></div>
         </div>
         <div class="progress-label">
-          {fmt(rollup.elapsed_s, 0)}s / {RUN_DURATION_S}s
+          <!-- elapsed_s is the run row's wall clock (finished_at - started_at),
+               which includes the drain grace + finalize, so it can exceed the
+               configured duration; cap the display like the bar above. -->
+          {fmt(Math.min(rollup.elapsed_s ?? 0, RUN_DURATION_S), 0)}s / {RUN_DURATION_S}s
           {#if isRunning}<span class="pulse-dot" aria-hidden="true"></span>{/if}
         </div>
 


### PR DESCRIPTION
One-liner: a finished load test showed `62s / 60s` because `elapsed_s` is the run row's wall clock (`finished_at - started_at`), which includes the 10s drain grace + finalize. The progress bar already clamps to 100%; this clamps the label the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxK2P3pkLWxfHMjFgvnpPE