### PR TITLE
fix(grimoire): demo follow-ups: reader mentions, scoped World graph, fast TOC, harness turnstile

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.43
+version: 0.89.44
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.43
+      targetRevision: 0.89.44
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.101
+version: 0.285.102
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.101
+      targetRevision: 0.285.102
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/grimoire/ChaptersNav.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/ChaptersNav.svelte
@@ -1,72 +1,86 @@
 <script>
   // Section list for the public reader. Mirrors the private tier's
   // ChaptersNav.svelte (see that file's docblock for the full rationale):
-  // fetches the book's section hierarchy once, then folds the flat
-  // {section_path, title, ...} rows into a two-level chapter/leaf tree via
-  // section-tree.js's buildSectionTree (pure, unit-tested separately).
+  // takes the book's already-fetched, already-nested section tree (see
+  // Reader.svelte, which fetches /sections once and builds the tree via
+  // section-tree.js's buildSectionTree for both mounts of this component) and
+  // renders it recursively, since the backend now groups by the full
+  // section_hierarchy breadcrumb rather than a fixed chapter/leaf split, so a
+  // node can nest arbitrarily deep (typically 1-4 levels).
   //
-  // Two variants, one fetch/highlight/tree implementation:
+  // Two variants, one highlight/render implementation:
   //  - "sidebar" (default reading surface, desktop >900px): the tree is
-  //    rendered as Reader.svelte's left TOC column. Chapter rows are
-  //    collapsible buttons (chevron, aria-expanded); every chapter starts
-  //    collapsed except the one containing the current section, which
+  //    rendered as Reader.svelte's left TOC column. Branch rows are
+  //    collapsible buttons (chevron, aria-expanded); every branch starts
+  //    collapsed except the ancestor chain of the current section, which
   //    auto-expands. Leaf rows carry no chunk-count number (removed per the
   //    showcase redesign: the count was noise, not a reading aid).
   //  - "dropdown" (mobile <=900px, where the sidebar is hidden): the same
   //    tree, same collapse behavior, in a floating panel behind a "Chapters"
   //    toggle button in the sticky bar.
   // Styled with the clean grimoire theme (--grim-* tokens).
-  import { apiFetch, chunkHref } from "$lib/public/grimoire/api.js";
-  import { buildSectionTree } from "$lib/public/grimoire/book/section-tree.js";
+  import { chunkHref } from "$lib/public/grimoire/api.js";
 
-  let { bookId, activeSectionPath = null, variant = "dropdown" } = $props();
+  let {
+    bookId,
+    tree = [],
+    loading = false,
+    error = "",
+    activeSectionPath = null,
+    variant = "dropdown",
+  } = $props();
 
   let open = $state(false);
-  let sections = $state([]);
-  let loading = $state(true);
-  let error = $state("");
-  // Chapter titles currently expanded. Recomputed (not just initialized)
-  // whenever the active section moves into a different chapter, so scrolling
-  // into a new chapter auto-opens it without clobbering a chapter the visitor
-  // opened by hand elsewhere in the tree.
+  // Node section_paths (the synthesized breadcrumb key, unique per node)
+  // currently expanded. Recomputed (not just initialized) whenever the active
+  // section moves into a different branch, so scrolling into a new branch
+  // auto-opens it without clobbering a branch the visitor opened by hand
+  // elsewhere in the tree.
   let expanded = $state(new Set());
   let rootEl;
 
-  const tree = $derived(buildSectionTree(sections));
-
-  $effect(() => {
-    load(bookId);
-  });
-
-  // Auto-expand the chapter containing the active section. Runs whenever
-  // activeSectionPath or the tree changes; adds (never removes) so a manual
-  // toggle elsewhere in the tree survives scroll-driven updates.
-  $effect(() => {
+  // A node is "active" when the reader's scroll-driven activeSectionPath (a
+  // raw chunk-level section_path) is one of the raw section_path values that
+  // rolled up into this node -- not string equality on the node's own
+  // synthesized breadcrumb (see library.list_sections' raw_section_paths).
+  function isActive(node) {
     const path = activeSectionPath;
-    if (!path) return;
-    const chapterTitle = path.includes("/") ? path.split("/")[0] : null;
-    if (!chapterTitle) return;
-    if (!expanded.has(chapterTitle)) {
-      expanded = new Set(expanded).add(chapterTitle);
-    }
-  });
-
-  async function load(id) {
-    loading = true;
-    error = "";
-    try {
-      sections = await apiFetch(`/books/${encodeURIComponent(id)}/sections`);
-    } catch (e) {
-      error = e.message;
-    } finally {
-      loading = false;
-    }
+    return !!path && (node.section?.raw_section_paths ?? []).includes(path);
   }
 
-  function toggleChapter(title) {
+  // Every ancestor branch of the currently-active leaf, so switching section
+  // auto-expands the full chain down to it (adds, never removes, so a manual
+  // toggle elsewhere in the tree survives scroll-driven updates).
+  function collectActiveAncestors(nodes, path, acc) {
+    for (const node of nodes) {
+      if (node.children.length === 0) {
+        if (isActive(node)) return true;
+        continue;
+      }
+      if (collectActiveAncestors(node.children, path, acc)) {
+        acc.add(node.section.section_path);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  $effect(() => {
+    if (!activeSectionPath) return;
+    const acc = new Set();
+    collectActiveAncestors(tree, activeSectionPath, acc);
+    if (acc.size === 0) return;
+    let next = expanded;
+    for (const path of acc) {
+      if (!next.has(path)) next = new Set(next).add(path);
+    }
+    if (next !== expanded) expanded = next;
+  });
+
+  function toggleBranch(path) {
     const next = new Set(expanded);
-    if (next.has(title)) next.delete(title);
-    else next.add(title);
+    if (next.has(path)) next.delete(path);
+    else next.add(path);
     expanded = next;
   }
 
@@ -77,6 +91,62 @@
     if (e.key === "Escape") open = false;
   }
 </script>
+
+{#snippet branch(nodes)}
+  <ul class="pub-chapters-list">
+    {#each nodes as node (node.section ? node.section.section_path : node.title)}
+      {#if node.children.length === 0}
+        <li>
+          <a
+            class="pub-chapters-row"
+            class:pub-chapters-row--h1={node.section?.depth === 0}
+            class:pub-chapters-row--active={isActive(node)}
+            href={chunkHref(bookId, node.section?.first_chunk_id)}
+            onclick={() => (open = false)}
+          >
+            <span class="pub-chapters-row-title">{node.title}</span>
+          </a>
+        </li>
+      {:else}
+        {@const nodePath = node.section?.section_path ?? node.title}
+        {@const isOpen = expanded.has(nodePath)}
+        <li>
+          <button
+            type="button"
+            class="pub-chapters-chapter"
+            aria-expanded={isOpen}
+            aria-controls={"pub-chapter-" + nodePath}
+            onclick={() => toggleBranch(nodePath)}
+          >
+            <svg
+              class="pub-chapters-chevron"
+              class:pub-chapters-chevron--open={isOpen}
+              width="10"
+              height="10"
+              viewBox="0 0 10 10"
+              aria-hidden="true"
+            >
+              <path
+                d="M2 1 L7 5 L2 9"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <span class="pub-chapters-row-title">{node.title}</span>
+          </button>
+          {#if isOpen}
+            <div class="pub-chapters-list--nested" id={"pub-chapter-" + nodePath}>
+              {@render branch(node.children)}
+            </div>
+          {/if}
+        </li>
+      {/if}
+    {/each}
+  </ul>
+{/snippet}
 
 <svelte:window onclick={onWindowClick} onkeydown={onWindowKeydown} />
 
@@ -103,75 +173,7 @@
       {:else if tree.length === 0}
         <p class="pub-chapters-status">This book has no chunks yet.</p>
       {:else}
-        <ul class="pub-chapters-list">
-          {#each tree as node (node.section ? node.section.section_path : node.title)}
-            {#if node.children.length === 0}
-              <li>
-                <a
-                  class="pub-chapters-row pub-chapters-row--h1"
-                  class:pub-chapters-row--active={node.section?.section_path ===
-                    activeSectionPath}
-                  href={chunkHref(bookId, node.section?.first_chunk_id)}
-                  onclick={() => (open = false)}
-                >
-                  <span class="pub-chapters-row-title">{node.title}</span>
-                </a>
-              </li>
-            {:else}
-              {@const isOpen = expanded.has(node.title)}
-              <li>
-                <button
-                  type="button"
-                  class="pub-chapters-chapter"
-                  aria-expanded={isOpen}
-                  aria-controls={"pub-chapter-" + node.title}
-                  onclick={() => toggleChapter(node.title)}
-                >
-                  <svg
-                    class="pub-chapters-chevron"
-                    class:pub-chapters-chevron--open={isOpen}
-                    width="10"
-                    height="10"
-                    viewBox="0 0 10 10"
-                    aria-hidden="true"
-                  >
-                    <path
-                      d="M2 1 L7 5 L2 9"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.6"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                  <span class="pub-chapters-row-title">{node.title}</span>
-                </button>
-                {#if isOpen}
-                  <ul
-                    class="pub-chapters-list pub-chapters-list--nested"
-                    id={"pub-chapter-" + node.title}
-                  >
-                    {#each node.children as child (child.section.section_path)}
-                      <li>
-                        <a
-                          class="pub-chapters-row"
-                          class:pub-chapters-row--active={child.section
-                            .section_path === activeSectionPath}
-                          href={chunkHref(bookId, child.section.first_chunk_id)}
-                          onclick={() => (open = false)}
-                        >
-                          <span class="pub-chapters-row-title"
-                            >{child.title}</span
-                          >
-                        </a>
-                      </li>
-                    {/each}
-                  </ul>
-                {/if}
-              </li>
-            {/if}
-          {/each}
-        </ul>
+        {@render branch(tree)}
       {/if}
     </div>
   {/if}

--- a/projects/monolith/frontend/src/lib/public/grimoire/ConstellationDock.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/ConstellationDock.svelte
@@ -12,14 +12,16 @@
   // type-colored link into World, focused on that entity. Escape closes.
   // Hidden entirely while the constellation is empty so it never occupies
   // space with nothing to show.
+  import { onDestroy } from "svelte";
   import { constellationStore } from "./constellation-store.js";
   import { worldHref } from "./api.js";
   import MiniConstellation from "./MiniConstellation.svelte";
 
   let state = $state({ nodes: [], ids: new Set(), edges: [] });
-  constellationStore.subscribe((s) => {
+  const unsubscribe = constellationStore.subscribe((s) => {
     state = s;
   });
+  onDestroy(unsubscribe);
 
   let expanded = $state(false);
 

--- a/projects/monolith/frontend/src/lib/public/grimoire/Reader.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/Reader.svelte
@@ -25,6 +25,7 @@
   import { renderChunk } from "$lib/public/grimoire/renderChunk.js";
   import { highlightMentions } from "$lib/public/grimoire/chat/mention-highlight.js";
   import ChaptersNav from "$lib/public/grimoire/ChaptersNav.svelte";
+  import { buildSectionTree } from "$lib/public/grimoire/book/section-tree.js";
 
   let {
     bookId,
@@ -43,6 +44,31 @@
   let bookMeta = $state({ displayName: bookId, chunkCount: null });
   let activeSeq = $state(initialItems[0]?.seq ?? null);
   let activeSectionPath = $state(initialItems[0]?.section_path ?? null);
+
+  // Section tree for both ChaptersNav mounts below (mobile dropdown + desktop
+  // sidebar): fetched and built ONCE here rather than once per mount, since
+  // the two instances would otherwise issue duplicate GETs and duplicate
+  // tree builds for identical data.
+  let sectionsLoading = $state(true);
+  let sectionsError = $state("");
+  let sections = $state([]);
+  const sectionTree = $derived(buildSectionTree(sections));
+
+  $effect(() => {
+    loadSections(bookId);
+  });
+
+  async function loadSections(id) {
+    sectionsLoading = true;
+    sectionsError = "";
+    try {
+      sections = await apiFetch(`/books/${encodeURIComponent(id)}/sections`);
+    } catch (e) {
+      sectionsError = e.message;
+    } finally {
+      sectionsLoading = false;
+    }
+  }
 
   // Reading-progress bar: scroll fraction of the content column, 0..1.
   // scaleX (not width) on a fixed-width track so the browser only ever
@@ -321,17 +347,31 @@
        900px, so this floating Chapters button is the only way to jump
        sections on a phone (the old sticky bar that used to host it is
        gone). Hidden on desktop via CSS (the sidebar replaces it there);
-       still mounts and fetches regardless of viewport, same as the sidebar
-       instance below -- a second cheap GET of /books/{bookId}/sections, not
-       worth a JS media-query gate. -->
+       still mounts regardless of viewport, but shares the one sections
+       fetch/tree above with the sidebar instance rather than each mount
+       fetching and building independently. -->
   <div class="pub-mobile-chapters">
-    <ChaptersNav {bookId} {activeSectionPath} variant="dropdown" />
+    <ChaptersNav
+      {bookId}
+      tree={sectionTree}
+      loading={sectionsLoading}
+      error={sectionsError}
+      {activeSectionPath}
+      variant="dropdown"
+    />
   </div>
 
   <div class="pub-layout">
     <aside class="pub-toc" aria-label="Sections">
       <p class="pub-toc-label">{bookMeta.displayName}</p>
-      <ChaptersNav {bookId} {activeSectionPath} variant="sidebar" />
+      <ChaptersNav
+        {bookId}
+        tree={sectionTree}
+        loading={sectionsLoading}
+        error={sectionsError}
+        {activeSectionPath}
+        variant="sidebar"
+      />
     </aside>
 
     <div class="pub-panel" bind:this={containerEl}>

--- a/projects/monolith/frontend/src/lib/public/grimoire/Reader.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/Reader.svelte
@@ -23,6 +23,7 @@
   // slim floating toggle, since the sticky bar itself is gone).
   import { apiFetch, bookAttribution } from "$lib/public/grimoire/api.js";
   import { renderChunk } from "$lib/public/grimoire/renderChunk.js";
+  import { highlightMentions } from "$lib/public/grimoire/chat/mention-highlight.js";
   import ChaptersNav from "$lib/public/grimoire/ChaptersNav.svelte";
 
   let {
@@ -121,6 +122,39 @@
       return blocks.slice(1);
     }
     return blocks;
+  }
+
+  // Chunk content is book text straight from the DB: it must be HTML-escaped
+  // before any {@html} render. Mirrors mention-highlight.js's own escapeHtml
+  // (that module isn't exported for reuse, its contract is "call on fresh
+  // renderMarkdown output only", so this is a deliberate small duplicate
+  // rather than reaching into its internals).
+  function escapeHtml(s) {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  // Backend entities are {id, name, entity_type, mention_text}; highlightMentions
+  // expects {id, title, kind: "entity", entity_type}. Also dedupes by name: a
+  // chunk can carry more than one mention row for the same entity (e.g. two
+  // mention_text spellings), and highlightMentions only needs one per name.
+  function touchedEntities(entities) {
+    if (!entities?.length) return [];
+    const seen = new Set();
+    const touched = [];
+    for (const e of entities) {
+      if (seen.has(e.name)) continue;
+      seen.add(e.name);
+      touched.push({ id: e.id, title: e.name, kind: "entity", entity_type: e.entity_type });
+    }
+    return touched;
+  }
+
+  // Mention-linkified HTML for one block of plain text, escaping first so
+  // book text can never inject markup (the {@html} XSS boundary), then
+  // wrapping any touched entity names in the same type-colored links the
+  // chat surface uses.
+  function markText(text, touched) {
+    return highlightMentions(escapeHtml(text ?? ""), touched);
   }
 
   async function loadMore() {
@@ -352,15 +386,26 @@
               {/if}
             </figure>
           {:else}
+            {@const touched = touchedEntities(row.item.entities)}
             {#each bodyBlocks(row.item) as block, bi (bi)}
               {#if block.type === "heading"}
-                <h3 class="pub-inline-heading">{block.text}</h3>
+                {#if touched.length}
+                  <h3 class="pub-inline-heading">{@html markText(block.text, touched)}</h3>
+                {:else}
+                  <h3 class="pub-inline-heading">{block.text}</h3>
+                {/if}
               {:else if block.type === "list"}
                 <ul class="pub-list">
                   {#each block.items as li, lii (lii)}
-                    <li>{li}</li>
+                    {#if touched.length}
+                      <li>{@html markText(li, touched)}</li>
+                    {:else}
+                      <li>{li}</li>
+                    {/if}
                   {/each}
                 </ul>
+              {:else if touched.length}
+                <p>{@html markText(block.text, touched)}</p>
               {:else}
                 <p>{block.text}</p>
               {/if}
@@ -537,6 +582,29 @@
 
   .pub-list li {
     margin-bottom: 6px;
+  }
+
+  /* Entity mentions (highlightMentions): matches the chat surface's .gmark
+     treatment (routes/public/app/grimoire/chat/+page.svelte) so a mention
+     reads the same whether it's in a reply or the book text. The color rides
+     in via the inline `color` style the module sets per anchor; the pill
+     background and underline both derive from it (currentColor) via
+     color-mix, so a new entity type never needs a new rule here. */
+  .pub-chunk :global(.gmark) {
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-thickness: 1.5px;
+    text-underline-offset: 2px;
+    border-radius: 4px;
+    padding: 0.5px 4px;
+    margin: 0 -1px;
+    background: color-mix(in srgb, currentColor 12%, transparent);
+    transition: background 120ms ease;
+  }
+
+  .pub-chunk :global(.gmark:hover),
+  .pub-chunk :global(.gmark:focus-visible) {
+    background: color-mix(in srgb, currentColor 20%, transparent);
   }
 
   .pub-anchor {

--- a/projects/monolith/frontend/src/lib/public/grimoire/api.js
+++ b/projects/monolith/frontend/src/lib/public/grimoire/api.js
@@ -85,11 +85,15 @@ export const exploreGraph = (scope, lens) =>
     `/explore/graph?scope=${encodeURIComponent(scope)}&lens=${encodeURIComponent(lens)}`,
   );
 
-// Focus entity + its 1-hop is_global neighbors, same {nodes, edges} shape as
-// exploreGraph, for click-to-expand ("wander") and the codex's relationship
-// list. Query param is `id`, not `entity_id` (see router_public.py).
-export const exploreEgo = (id) =>
-  apiFetch(`/explore/ego?id=${encodeURIComponent(id)}`);
+// Focus entity + its 1-hop is_global neighbors, same {nodes, edges,
+// lens_counts} shape as exploreGraph, for click-to-expand ("wander") and the
+// codex's relationship list. Query param is `id`, not `entity_id` (see
+// router_public.py). scope/lens narrow the neighbor set the same way they
+// narrow exploreGraph; the focus entity itself is always kept.
+export const exploreEgo = (id, scope = "everything", lens = "world") =>
+  apiFetch(
+    `/explore/ego?id=${encodeURIComponent(id)}&scope=${encodeURIComponent(scope)}&lens=${encodeURIComponent(lens)}`,
+  );
 
 // Six-degrees BFS between two entities -> {path: [{entity, via}, ...]}.
 // Wired here for completeness; no UI consumes it yet (deferred to a later

--- a/projects/monolith/frontend/src/lib/public/grimoire/book/section-tree.js
+++ b/projects/monolith/frontend/src/lib/public/grimoire/book/section-tree.js
@@ -1,50 +1,42 @@
-// Pure fold turning the flat /books/{id}/sections rows into a two-level tree
-// for the book reader's collapsible TOC.
+// Pure fold turning the flat /books/{id}/sections rows into an arbitrary-depth
+// tree for the book reader's collapsible TOC.
 //
-// Each row's section_path is either a bare leaf title ("Introduction", no
-// slash: pre-existing top-level rows, forewords, appendices) or a two-level
-// "Chapter/Leaf" path. Splitting is done on the FIRST slash only, so a leaf
-// title that itself contains a slash (e.g. "Traps/Pits") stays intact as one
-// child rather than being sliced again.
+// The backend now emits one row per DISTINCT node in the section-hierarchy
+// breadcrumb (chapter, sub-section, sub-sub-section, ...), not one row per
+// raw section_path leaf: a book whose section_path column fragments into
+// thousands of near-duplicate paths collapses back down to its real chapter
+// count once grouped by the shared breadcrumb prefix. Each row carries
+// `depth` (0 = top-level) and `parent_path` (the parent's own `section_path`
+// breadcrumb string, or null at depth 0), so nesting is a single left-to-right
+// walk keyed on parent_path rather than string-splitting section_path.
 //
-// Grouping is a single left-to-right fold over reading order, not a global
-// group-by: consecutive rows sharing the same chapter name merge into one
-// chapter node, but if a chapter name reappears later after other chapters
-// have interleaved, that later run starts a NEW node with the same title.
-// This deliberately mirrors the backend's own reading-order semantics
-// elsewhere in the corpus (first-appearance wins) rather than deduplicating
-// globally, which would silently reorder content that appears twice under
-// the same heading (rare, but seen in some anthology books).
+// Rows arrive in reading order (first appearance by seq), and a parent row
+// always precedes its children (the backend emits every ancestor node before
+// the chunk that deepens into it). A node with no directly-tagged chunks of
+// its own (e.g. a chapter heading with only sub-sectioned content) still gets
+// a `first_chunk_id` -- the earliest chunk anywhere beneath it -- so every row
+// is clickable.
+//
+// Each row also carries `raw_section_paths`: the distinct chunk-level
+// section_path values rolled up into that node. The reader's scroll-driven
+// activeSectionPath is one of those raw values, not this node's synthesized
+// breadcrumb string, so callers match on membership in that list rather than
+// equality on section_path (see ChaptersNav.svelte).
 export function buildSectionTree(flatSections) {
   const tree = [];
-  let currentChapter = null; // the open chapter node, if any
-  let currentChapterTitle = null;
+  const byPath = new Map(); // section_path -> tree node, for parent lookup
 
   for (const section of flatSections ?? []) {
-    const path = section.section_path ?? "";
-    const slashIndex = path.indexOf("/");
+    const node = { title: section.title, section, children: [] };
+    byPath.set(section.section_path, node);
 
-    if (slashIndex === -1) {
-      // Top-level leaf: closes any open chapter run.
-      tree.push({ title: section.title, section, children: [] });
-      currentChapter = null;
-      currentChapterTitle = null;
-      continue;
+    const parentPath = section.parent_path ?? null;
+    const parent = parentPath ? byPath.get(parentPath) : null;
+    if (parent) {
+      parent.children.push(node);
+    } else {
+      tree.push(node);
     }
-
-    const chapterTitle = path.slice(0, slashIndex);
-    const leafTitle = path.slice(slashIndex + 1);
-
-    if (!currentChapter || currentChapterTitle !== chapterTitle) {
-      currentChapter = { title: chapterTitle, section: null, children: [] };
-      currentChapterTitle = chapterTitle;
-      tree.push(currentChapter);
-    }
-    currentChapter.children.push({
-      title: leafTitle,
-      section,
-      children: [],
-    });
   }
 
   return tree;

--- a/projects/monolith/frontend/src/lib/public/grimoire/book/section-tree.test.js
+++ b/projects/monolith/frontend/src/lib/public/grimoire/book/section-tree.test.js
@@ -1,93 +1,74 @@
 import { describe, it, expect } from "vitest";
 import { buildSectionTree } from "./section-tree.js";
 
+// Rows mirror the backend's shape: one row per distinct breadcrumb node,
+// carrying section_path (the full " > "-joined breadcrumb), title (the
+// node's own last segment), depth, and parent_path (the parent's
+// section_path, or null at depth 0).
+function row(section_path, title, depth, parent_path = null) {
+  return {
+    section_path,
+    title,
+    depth,
+    parent_path,
+    first_chunk_id: "c-" + title,
+  };
+}
+
 describe("buildSectionTree", () => {
   it("returns an empty array for an empty list", () => {
     expect(buildSectionTree([])).toEqual([]);
   });
 
-  it("treats a path with no slash as a top-level leaf", () => {
-    const flat = [{ section_path: "Introduction", title: "Introduction" }];
+  it("treats a depth-0 row with no children as a top-level leaf", () => {
+    const flat = [row("Introduction", "Introduction", 0)];
     const tree = buildSectionTree(flat);
     expect(tree).toEqual([
-      {
-        title: "Introduction",
-        section: flat[0],
-        children: [],
-      },
+      { title: "Introduction", section: flat[0], children: [] },
     ]);
   });
 
-  it("nests a two-level path under its chapter", () => {
+  it("nests a depth-1 row under its depth-0 parent", () => {
     const flat = [
-      { section_path: "Chapter 1/Traps", title: "Traps" },
-      { section_path: "Chapter 1/Doors", title: "Doors" },
-    ];
-    const tree = buildSectionTree(flat);
-    expect(tree).toEqual([
-      {
-        title: "Chapter 1",
-        section: null,
-        children: [
-          { title: "Traps", section: flat[0], children: [] },
-          { title: "Doors", section: flat[1], children: [] },
-        ],
-      },
-    ]);
-  });
-
-  it("splits only on the FIRST slash, so a slash-bearing leaf title stays intact", () => {
-    const flat = [
-      { section_path: "Chapter 1/Traps/Pits", title: "Traps/Pits" },
-    ];
-    const tree = buildSectionTree(flat);
-    expect(tree).toEqual([
-      {
-        title: "Chapter 1",
-        section: null,
-        children: [{ title: "Traps/Pits", section: flat[0], children: [] }],
-      },
-    ]);
-  });
-
-  it("merges consecutive rows that share the same chapter into one node", () => {
-    const flat = [
-      { section_path: "Chapter 1/Traps", title: "Traps" },
-      { section_path: "Chapter 1/Doors", title: "Doors" },
-      { section_path: "Chapter 1/Locks", title: "Locks" },
+      row("Chapter 1", "Chapter 1", 0),
+      row("Chapter 1 > Traps", "Traps", 1, "Chapter 1"),
+      row("Chapter 1 > Doors", "Doors", 1, "Chapter 1"),
     ];
     const tree = buildSectionTree(flat);
     expect(tree).toHaveLength(1);
     expect(tree[0].title).toBe("Chapter 1");
-    expect(tree[0].children).toHaveLength(3);
+    expect(tree[0].children).toEqual([
+      { title: "Traps", section: flat[1], children: [] },
+      { title: "Doors", section: flat[2], children: [] },
+    ]);
   });
 
-  it("keeps non-consecutive duplicate chapter names as separate nodes (reading order wins)", () => {
+  it("nests three levels deep", () => {
     const flat = [
-      { section_path: "Chapter 1/Traps", title: "Traps" },
-      { section_path: "Chapter 2/Intro", title: "Intro" },
-      { section_path: "Chapter 1/Doors", title: "Doors" },
+      row("Chapter 1", "Chapter 1", 0),
+      row("Chapter 1 > Armor", "Armor", 1, "Chapter 1"),
+      row(
+        "Chapter 1 > Armor > Armor of Vulnerability",
+        "Armor of Vulnerability",
+        2,
+        "Chapter 1 > Armor",
+      ),
     ];
     const tree = buildSectionTree(flat);
-    expect(tree).toHaveLength(3);
-    expect(tree.map((n) => n.title)).toEqual([
-      "Chapter 1",
-      "Chapter 2",
-      "Chapter 1",
-    ]);
-    expect(tree[0].children).toEqual([
-      { title: "Traps", section: flat[0], children: [] },
-    ]);
-    expect(tree[2].children).toEqual([
-      { title: "Doors", section: flat[2], children: [] },
+    expect(tree).toHaveLength(1);
+    expect(tree[0].children).toHaveLength(1);
+    expect(tree[0].children[0].title).toBe("Armor");
+    expect(tree[0].children[0].children).toEqual([
+      { title: "Armor of Vulnerability", section: flat[2], children: [] },
     ]);
   });
 
   it("keeps reading order across a mix of top-level leaves and chapters", () => {
     const flat = [
-      { section_path: "Foreword", title: "Foreword" },
-      { section_path: "Chapter 1/Traps", title: "Traps" },
-      { section_path: "Afterword", title: "Afterword" },
+      row("Foreword", "Foreword", 0),
+      row("Chapter 1", "Chapter 1", 0),
+      row("Chapter 1 > Traps", "Traps", 1, "Chapter 1"),
+      row("Afterword", "Afterword", 0),
     ];
     const tree = buildSectionTree(flat);
     expect(tree.map((n) => n.title)).toEqual([
@@ -97,18 +78,18 @@ describe("buildSectionTree", () => {
     ]);
     expect(tree[0].section).toBe(flat[0]);
     expect(tree[0].children).toEqual([]);
-    expect(tree[2].section).toBe(flat[2]);
+    expect(tree[2].section).toBe(flat[3]);
   });
 
   it("handles a single flat section list with no nesting at all", () => {
-    const flat = [{ section_path: "Only Section", title: "Only Section" }];
+    const flat = [row("Only Section", "Only Section", 0)];
     expect(buildSectionTree(flat)).toEqual([
       { title: "Only Section", section: flat[0], children: [] },
     ]);
   });
 
-  it("treats a null/empty section_path as a top-level leaf", () => {
-    const flat = [{ section_path: null, title: "(no section)" }];
+  it("treats the (no section) placeholder as a depth-0 leaf", () => {
+    const flat = [row("(no section)", "(no section)", 0)];
     const tree = buildSectionTree(flat);
     expect(tree).toEqual([
       { title: "(no section)", section: flat[0], children: [] },

--- a/projects/monolith/frontend/src/lib/public/grimoire/explore/ExploreCodex.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/explore/ExploreCodex.svelte
@@ -101,8 +101,17 @@
     return entityType.replaceAll("_", " ");
   }
 
+  // entity_type is corpus-controlled; guard it before interpolating into a
+  // CSS custom-property name (same pattern as ConstellationDock's typeVar).
+  const TYPE_ALLOWLIST = /^[a-z_]+$/;
+
+  function typeVar(entityType, fallback) {
+    const type = TYPE_ALLOWLIST.test(entityType ?? "") ? entityType : "class";
+    return `var(--grim-type-${type}, ${fallback})`;
+  }
+
   function swatch(entityType) {
-    return `background: var(--grim-type-${entityType}, var(--grim-text-faint))`;
+    return `background: ${typeVar(entityType, "var(--grim-text-faint)")}`;
   }
 
   // Entity art (when the focus carries an image_chunk_id, added in Task 1) is
@@ -161,7 +170,7 @@
       {:else}
         <div
           class="monogram"
-          style={`--mono: var(--grim-type-${entity.entity_type}, var(--grim-text-faint))`}
+          style={`--mono: ${typeVar(entity.entity_type, "var(--grim-text-faint)")}`}
           aria-hidden="true"
         >
           {monogram}
@@ -186,7 +195,7 @@
                   {#if p.pre}<span class="rel-word">{p.pre}</span>{/if}<button
                     type="button"
                     class="rel-peer"
-                    style={`--peer: var(--grim-type-${r.peer.entity_type}, var(--grim-text-faint))`}
+                    style={`--peer: ${typeVar(r.peer.entity_type, "var(--grim-text-faint)")}`}
                     onclick={() => onselect?.(r.peer.id)}>{p.peer}</button
                   >{#if p.post}<span class="rel-word">{p.post}</span>{/if}
                 </p>

--- a/projects/monolith/frontend/src/lib/public/grimoire/world/EntitySearch.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/world/EntitySearch.svelte
@@ -5,6 +5,7 @@
   // selecting a result (mouse or keyboard) reports it up via `onselect(id)` so
   // the World page focuses that entity. Purely a control: it owns its own
   // fetching and dropdown state, never the graph.
+  import { onDestroy } from "svelte";
   import { listEntities } from "$lib/public/grimoire/api.js";
 
   let { onselect = null } = $props();
@@ -48,6 +49,11 @@
   let inputEl;
   let debounceTimer = null;
   let inFlight = null; // AbortController for the current request
+
+  onDestroy(() => {
+    clearTimeout(debounceTimer);
+    inFlight?.abort();
+  });
 
   // Group the flat results by entity_type for display, but keep a parallel
   // flat list (in group order) so arrow-key nav has a single linear index that

--- a/projects/monolith/frontend/src/lib/server/grimoire-read.js
+++ b/projects/monolith/frontend/src/lib/server/grimoire-read.js
@@ -20,6 +20,7 @@ function signReadItem(item) {
       section_path: item.section_path,
       kind: item.kind,
       content: item.content,
+      entities: item.entities ?? [],
     };
   }
   return {
@@ -29,6 +30,7 @@ function signReadItem(item) {
     kind: item.kind,
     content: item.content,
     image_url: signedGrimImgUrl(item.image_key, "display"),
+    entities: item.entities ?? [],
   };
 }
 

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/chat/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/chat/+page.svelte
@@ -88,7 +88,7 @@
   // a reloaded session seeds it from history on first mount only (see
   // onMount below) so remounting this page never re-seeds duplicate work.
   let constellation = $state({ nodes: [], ids: new Set(), edges: [] });
-  constellationStore.subscribe((s) => {
+  const unsubscribeConstellation = constellationStore.subscribe((s) => {
     constellation = s;
   });
 
@@ -297,7 +297,10 @@
   }
 
   $effect(() => {
-    return () => controller?.abort();
+    return () => {
+      controller?.abort();
+      unsubscribeConstellation();
+    };
   });
 </script>
 

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/world/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/world/+page.svelte
@@ -209,11 +209,18 @@
   // blank canvas, and sets `fellBackToFullEgo` so the UI can say so.
   // `fellBackFor` remembers the exact focusId+scope+lens key the fallback
   // already ran for, so re-rendering the same empty combo does not refetch.
+  //
+  // `egoRequestSeq` guards against out-of-order resolution: each effect run
+  // takes a ticket, and a run only applies its result (or its error) while
+  // its ticket is still the latest, so a slow older fetch can never
+  // overwrite the graph of a newer focus/scope/lens.
+  let egoRequestSeq = 0;
   $effect(() => {
     const id = focusId;
     const currentScope = scope;
     const currentLens = lens;
     if (id == null) return;
+    const requestId = ++egoRequestSeq;
     const comboKey = `${id}|${currentScope}|${currentLens}`;
     egoLoading = true;
     loadError = "";
@@ -223,6 +230,7 @@
           nodes: [],
           edges: [],
         };
+        if (requestId !== egoRequestSeq) return;
         const isNarrowed = currentScope !== "everything" || currentLens !== "world";
         const isEmpty = (res.nodes ?? []).length <= 1;
         if (isNarrowed && isEmpty && fellBackFor !== comboKey) {
@@ -231,6 +239,7 @@
             nodes: [],
             edges: [],
           };
+          if (requestId !== egoRequestSeq) return;
           applyEgo(id, full);
           fellBackToFullEgo = true;
           return;
@@ -239,10 +248,11 @@
         fellBackToFullEgo = false;
         applyEgo(id, res);
       } catch (e) {
+        if (requestId !== egoRequestSeq) return;
         loadError = e.message;
         ego = { nodes: [], edges: [] };
       } finally {
-        egoLoading = false;
+        if (requestId === egoRequestSeq) egoLoading = false;
       }
     })();
   });

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/world/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/world/+page.svelte
@@ -62,21 +62,31 @@
   // never wrongly disabled before we know.
   let lensCounts = $state({ world: 1, story: 1, quests: 1, rules: 1 });
 
+  // True when the current `ego` is the unfiltered fallback graph (fetched
+  // after a scope/lens combo returned an empty neighborhood), so the UI can
+  // say the view was widened. `fellBackFor` is the `focusId|scope|lens` key
+  // the fallback already ran for, guarding against re-fetching every time
+  // this same empty combination re-renders.
+  let fellBackToFullEgo = $state(false);
+  let fellBackFor = null;
+
   // Positions from the previous layout, handed to the canvas so a re-center
   // keeps shared nodes in place (seed) rather than hash-jumping them. The
   // canvas reports its settled positions back after each layout.
   let seedPositions = $state(null);
 
-  // The nodes/edges handed to the canvas. This is the raw ego neighborhood:
-  // the /explore/ego endpoint is scope/lens-agnostic (it returns only the
-  // focus's 1-hop is_global neighbors, with no per-node scope or lens
-  // membership and no lens_counts), so there is nothing to filter it by here.
-  // Scope + lens are kept as controls (they update the URL for continuity with
-  // the old Explore surface and a future ego-filtering endpoint), but by design
-  // an entity's immediate world is always shown whole rather than blanked
-  // because a neighbor sits in a different adventure or lens. If a scope-aware
-  // ego endpoint lands later, filter here and fall back to the full ego when
-  // the intersection is empty (never a blank canvas).
+  // The nodes/edges handed to the canvas. /explore/ego now takes scope/lens
+  // and narrows the neighbor set server-side (the focus entity itself is
+  // always kept, see explore.ego_subgraph), so `ego` IS the already-scoped
+  // graph; `displayGraph` just guards against a missing response shape.
+  //
+  // A scope/lens combo can legitimately leave a focus entity with zero
+  // visible neighbors (e.g. an NPC with no relationships inside the picked
+  // adventure). Rather than show a blank canvas, the $effect below falls
+  // back to the unfiltered ego (scope=everything, lens=world) and flips
+  // `fellBackToFullEgo` so the UI can say so; `fellBackFor` remembers which
+  // focus+scope+lens combination the fallback already ran for, so a repeat
+  // render of the same empty combo doesn't refetch in a loop.
   const displayGraph = $derived({
     nodes: ego.nodes ?? [],
     edges: ego.edges ?? [],
@@ -113,7 +123,7 @@
 
     const e = params.get("e");
     if (e) {
-      await focusEntity(e, { push: false });
+      focusEntity(e, { push: false });
     } else {
       await landOnFeatured();
     }
@@ -143,7 +153,7 @@
     const name = FEATURED[dayOfYear % FEATURED.length];
     const id = (await resolveByName(name)) ?? (await resolveFirstEntity());
     if (id != null) {
-      await focusEntity(id, { push: false });
+      focusEntity(id, { push: false });
     } else {
       egoLoading = false;
     }
@@ -172,38 +182,85 @@
     }
   }
 
-  // Focus an entity: fetch its ego, render it centered, report to the
-  // constellation, and (unless bootstrapping from the URL) push ?e= so
-  // back/forward and sharing land in the same state. Seeds shared node
-  // positions from the current layout so a re-center settles around the move.
-  async function focusEntity(id, { push = true } = {}) {
+  // Focus an entity: render it centered, report to the constellation, and
+  // (unless bootstrapping from the URL) push ?e= so back/forward and sharing
+  // land in the same state. Seeds shared node positions from the current
+  // layout so a re-center settles around the move. The actual ego fetch
+  // happens in the $effect below, which reacts to `focusId` alongside
+  // `scope`/`lens` so every trigger (search, node tap, scope/lens change)
+  // goes through one fetch path.
+  function focusEntity(id, { push = true } = {}) {
     if (id == null) return;
-    egoLoading = true;
-    loadError = "";
     // Capture positions of the outgoing layout to seed the incoming one.
     seedPositions = lastPositions;
     focusId = id;
     if (push) syncUrl();
-    try {
-      const res = (await exploreEgo(id)) ?? { nodes: [], edges: [] };
-      ego = res;
-      lensCounts = res.lens_counts ?? { world: 1, story: 1, quests: 1, rules: 1 };
-      // Trail: mark this entity touched and record its ego for the dock's
-      // cross-page constellation.
-      const node = (res.nodes ?? []).find((n) => n.id === id);
-      constellationStore.touch({
-        id,
-        title: node?.name ?? "",
-        kind: "entity",
-        entity_type: node?.entity_type,
-      });
-      constellationStore.recordEgo(id, res);
-    } catch (e) {
-      loadError = e.message;
-      ego = { nodes: [], edges: [] };
-    } finally {
-      egoLoading = false;
-    }
+  }
+
+  // Single driver for every ego fetch: reacts to focusId, scope, and lens,
+  // so a search/tap re-center and a scope/lens change while focused both
+  // funnel through the same path (no separate call sites re-fetching and no
+  // double-fetch when focusId changes for other reasons).
+  //
+  // If the scope/lens-narrowed result has no visible neighbors (a combo can
+  // legitimately leave a focus entity isolated, e.g. an NPC with no
+  // relationships inside the picked adventure), falls back to the
+  // unfiltered ego (scope=everything, lens=world) rather than showing a
+  // blank canvas, and sets `fellBackToFullEgo` so the UI can say so.
+  // `fellBackFor` remembers the exact focusId+scope+lens key the fallback
+  // already ran for, so re-rendering the same empty combo does not refetch.
+  $effect(() => {
+    const id = focusId;
+    const currentScope = scope;
+    const currentLens = lens;
+    if (id == null) return;
+    const comboKey = `${id}|${currentScope}|${currentLens}`;
+    egoLoading = true;
+    loadError = "";
+    (async () => {
+      try {
+        const res = (await exploreEgo(id, currentScope, currentLens)) ?? {
+          nodes: [],
+          edges: [],
+        };
+        const isNarrowed = currentScope !== "everything" || currentLens !== "world";
+        const isEmpty = (res.nodes ?? []).length <= 1;
+        if (isNarrowed && isEmpty && fellBackFor !== comboKey) {
+          fellBackFor = comboKey;
+          const full = (await exploreEgo(id, "everything", "world")) ?? {
+            nodes: [],
+            edges: [],
+          };
+          applyEgo(id, full);
+          fellBackToFullEgo = true;
+          return;
+        }
+        fellBackFor = comboKey;
+        fellBackToFullEgo = false;
+        applyEgo(id, res);
+      } catch (e) {
+        loadError = e.message;
+        ego = { nodes: [], edges: [] };
+      } finally {
+        egoLoading = false;
+      }
+    })();
+  });
+
+  // Shared tail of a successful ego fetch: sets state, records the trail
+  // touch, and reports to the constellation. Shared by both the direct
+  // fetch and the full-ego fallback above.
+  function applyEgo(id, res) {
+    ego = res;
+    lensCounts = res.lens_counts ?? { world: 1, story: 1, quests: 1, rules: 1 };
+    const node = (res.nodes ?? []).find((n) => n.id === id);
+    constellationStore.touch({
+      id,
+      title: node?.name ?? "",
+      kind: "entity",
+      entity_type: node?.entity_type,
+    });
+    constellationStore.recordEgo(id, res);
   }
 
   // The canvas reports its settled node positions here after each layout, so
@@ -309,6 +366,11 @@
           onselect={handleSelect}
           onpositions={onPositions}
         />
+        {#if fellBackToFullEgo}
+          <p class="fallback-note">
+            No neighbors in this scope/lens; showing the full world instead.
+          </p>
+        {/if}
         {#if legendTypes.length}
           <div class="legend">
             {#each legendTypes as t (t)}
@@ -479,6 +541,21 @@
 
   .world-main:not(.wide) .codex-dock :global(.codex.open) {
     transform: translateY(0);
+  }
+
+  .fallback-note {
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    max-width: 32ch;
+    background: color-mix(in srgb, var(--grim-surface) 80%, transparent);
+    backdrop-filter: blur(8px);
+    border: 1px solid var(--grim-line);
+    border-radius: 9px;
+    padding: 8px 12px;
+    font-size: 11.5px;
+    color: var(--grim-text-dim);
+    pointer-events: none;
   }
 
   .legend {

--- a/projects/monolith/frontend/visual/capture.mjs
+++ b/projects/monolith/frontend/visual/capture.mjs
@@ -15,11 +15,22 @@
 //     `/img/unsafe/...` (or `/img/<sig>/...`) when IMGPROXY keys are unset at
 //     mock boot; the adapter-node app does not serve `/img/**`, so without this
 //     those requests 404 and add noise / can stall networkidle.
-//   - Chat SSE endpoints (`/chat/message`, `/chat/session`) are aborted so the
-//     open stream never prevents `waitUntil: "networkidle"` from resolving;
-//     pages flagged `static_initial` are additionally loaded with
-//     `domcontentloaded` + a fixed settle so we capture their static initial
-//     state rather than hanging on a live stream.
+//   - Chat SSE message endpoints (`**/chat/message`, matching both the notes
+//     chat and the Grimoire chat proxy under `/app/grimoire/chat/message`)
+//     are aborted so an open stream never prevents `waitUntil: "networkidle"`
+//     from resolving; pages flagged `static_initial` are additionally loaded
+//     with `domcontentloaded` + a fixed settle so we capture their static
+//     initial state rather than hanging on a live stream.
+//   - Turnstile: the challenge script (`challenges.cloudflare.com/turnstile/
+//     v0/api.js`) is fulfilled with a stub `window.turnstile` that solves
+//     itself on render(), and the session-admission POSTs it triggers
+//     (`/chat/session`, the notes-chat gate stub's proxy; `/app/grimoire/
+//     chat/session`, the real Grimoire chat's proxy) are fulfilled with a
+//     synthetic `{ ok: true }` instead of hitting a real backend. This is
+//     what lets the World and Chat targets capture real gated content
+//     instead of the Turnstile gate itself (see serve.mjs for the paired
+//     TURNSTILE_SITE_KEY env var that makes the gate mount in the first
+//     place).
 // @playwright/test is imported DYNAMICALLY below, after PLAYWRIGHT_BROWSERS_PATH
 // is absolutized: Playwright reads that env when its module is first evaluated,
 // and a static import would be hoisted above the env fix.
@@ -38,6 +49,25 @@ const placeholderPng = readFileSync(
   join(HERE, "fixtures/basemap/placeholder.png"),
 );
 const FROZEN = Date.UTC(2026, 0, 1, 12, 0, 0); // deterministic wall clock
+// Stub for the Cloudflare Turnstile challenge script. Implements the subset of
+// the real window.turnstile API TurnstileGate.svelte calls: render() reports a
+// solve on the next microtask (so admission proceeds deterministically without
+// an actual widget or network round trip), remove()/reset() are no-ops so the
+// gate's unmount cleanup has something to call. widgetId counts up so repeated
+// renders (e.g. NEW CHAT re-gating) each get a distinct id, mirroring the real
+// widget registry closely enough for TurnstileGate's own-render-once guard.
+const TURNSTILE_STUB = `
+  let widgetId = 0;
+  window.turnstile = {
+    render(el, opts) {
+      const id = "visual-stub-" + widgetId++;
+      setTimeout(() => opts.callback("visual-test-token"), 0);
+      return id;
+    },
+    remove(id) {},
+    reset(id) {},
+  };
+`;
 // The public tier lives under /public in the route tree; the apex reroute that
 // strips that prefix is hostname-gated (jomcgi.dev) and does not fire on
 // 127.0.0.1, so we navigate the real /public/* routes directly. The render is
@@ -127,9 +157,30 @@ try {
         body: placeholderPng,
       }),
     );
-    // Chat SSE: abort so the open stream never blocks networkidle.
+    // Chat SSE: abort so the open stream never blocks networkidle. Matches
+    // both the notes chat and the Grimoire chat proxy (/app/grimoire/chat/
+    // message), since Playwright's ** glob spans slashes.
     await ctx.route("**/chat/message", (route) => route.abort());
-    await ctx.route("**/chat/session", (route) => route.abort());
+    // Turnstile challenge script: fulfill with the self-solving stub so the
+    // gate admits deterministically instead of loading the real widget.
+    await ctx.route(
+      "https://challenges.cloudflare.com/turnstile/v0/api.js*",
+      (route) =>
+        route.fulfill({
+          contentType: "application/javascript",
+          body: TURNSTILE_STUB,
+        }),
+    );
+    // Session-admission POSTs the stub's solve triggers: fulfill with a
+    // synthetic success (there is no backend behind the mock server to admit
+    // against). The glob matches both the notes-chat gate stub's proxy
+    // (/chat/session) and the real Grimoire chat's proxy (/app/grimoire/
+    // chat/session), since Playwright's ** spans slashes; both proxies want
+    // the identical fulfillment, so one rule covers both. Distinct from the
+    // **/chat/message glob above, so this never touches the SSE endpoints.
+    await ctx.route("**/chat/session", (route) =>
+      route.fulfill({ contentType: "application/json", body: '{"ok":true}' }),
+    );
 
     for (const page of targets.pages) {
       const p = await ctx.newPage();

--- a/projects/monolith/frontend/visual/fixtures/api/grimoire_adventures.json
+++ b/projects/monolith/frontend/visual/fixtures/api/grimoire_adventures.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "a1",
+    "book_id": "mm",
+    "book_display_name": "Curse of Strahd",
+    "name": "Death House",
+    "seq": 1,
+    "summary": "A haunted house luring travelers into Barovia.",
+    "level_range": "1-3",
+    "start_seq": 1,
+    "end_seq": 12,
+    "entity_count": 14
+  },
+  {
+    "id": "a2",
+    "book_id": "mm",
+    "book_display_name": "Curse of Strahd",
+    "name": "Into the Mists",
+    "seq": 2,
+    "summary": "Barovia's borders close behind the party.",
+    "level_range": "3-4",
+    "start_seq": 13,
+    "end_seq": 20,
+    "entity_count": 9
+  },
+  {
+    "id": "a3",
+    "book_id": "lmop",
+    "book_display_name": "Lost Mine of Phandelver",
+    "name": "Goblin Arrows",
+    "seq": 1,
+    "summary": "An ambush on the Triboar Trail draws the party toward Cragmaw Hideout.",
+    "level_range": "1-2",
+    "start_seq": 1,
+    "end_seq": 8,
+    "entity_count": 11
+  }
+]

--- a/projects/monolith/frontend/visual/fixtures/api/grimoire_explore_ego.json
+++ b/projects/monolith/frontend/visual/fixtures/api/grimoire_explore_ego.json
@@ -1,0 +1,31 @@
+{
+  "nodes": [
+    {
+      "id": "e3",
+      "entity_type": "npc",
+      "name": "Strahd von Zarovich",
+      "category": null,
+      "temporality": null,
+      "image_chunk_id": null
+    },
+    {
+      "id": "e4",
+      "entity_type": "location",
+      "name": "Castle Ravenloft",
+      "category": null,
+      "temporality": null
+    },
+    {
+      "id": "e6",
+      "entity_type": "deity",
+      "name": "The Raven Queen",
+      "category": null,
+      "temporality": null
+    }
+  ],
+  "edges": [
+    { "from": "e3", "to": "e4", "rel_type": "resides_in" },
+    { "from": "e3", "to": "e6", "rel_type": "cursed_by" }
+  ],
+  "lens_counts": { "world": 3, "story": 2, "quests": 1, "rules": 0 }
+}

--- a/projects/monolith/frontend/visual/fixtures/api/grimoire_sections.json
+++ b/projects/monolith/frontend/visual/fixtures/api/grimoire_sections.json
@@ -1,18 +1,46 @@
 [
   {
-    "section_path": "Chapter 1/Introduction",
+    "section_path": "Chapter 1",
+    "title": "Chapter 1",
+    "depth": 0,
+    "parent_path": null,
+    "chunk_count": 0,
+    "image_count": 0,
+    "first_chunk_id": "c1",
+    "latest_chunk_at": "2024-01-15T12:00:00Z",
+    "raw_section_paths": []
+  },
+  {
+    "section_path": "Chapter 1 > Introduction",
     "title": "Introduction",
+    "depth": 1,
+    "parent_path": "Chapter 1",
     "chunk_count": 3,
     "image_count": 1,
     "first_chunk_id": "c1",
-    "latest_chunk_at": "2024-01-15T12:00:00Z"
+    "latest_chunk_at": "2024-01-15T12:00:00Z",
+    "raw_section_paths": ["Chapter 1/Introduction"]
   },
   {
-    "section_path": "Chapter 2/Aberrations",
+    "section_path": "Chapter 2",
+    "title": "Chapter 2",
+    "depth": 0,
+    "parent_path": null,
+    "chunk_count": 0,
+    "image_count": 0,
+    "first_chunk_id": "c4",
+    "latest_chunk_at": "2024-01-15T12:00:00Z",
+    "raw_section_paths": []
+  },
+  {
+    "section_path": "Chapter 2 > Aberrations",
     "title": "Aberrations",
+    "depth": 1,
+    "parent_path": "Chapter 2",
     "chunk_count": 1,
     "image_count": 0,
     "first_chunk_id": "c4",
-    "latest_chunk_at": "2024-01-15T12:00:00Z"
+    "latest_chunk_at": "2024-01-15T12:00:00Z",
+    "raw_section_paths": ["Chapter 2/Aberrations"]
   }
 ]

--- a/projects/monolith/frontend/visual/mock-server.mjs
+++ b/projects/monolith/frontend/visual/mock-server.mjs
@@ -19,6 +19,8 @@ const ROUTES = [
   ["/api/grimoire/books/mm/read", "fixtures/api/grimoire_read.json"],
   ["/api/grimoire/books/mm/sections", "fixtures/api/grimoire_sections.json"],
   ["/api/grimoire/entities", "fixtures/api/grimoire_entities.json"],
+  ["/api/grimoire/adventures", "fixtures/api/grimoire_adventures.json"],
+  ["/api/grimoire/explore/ego", "fixtures/api/grimoire_explore_ego.json"],
 ];
 const PREFIX = [["/api/trips/trip/", "fixtures/api/trips_trip.json"]];
 

--- a/projects/monolith/frontend/visual/serve.mjs
+++ b/projects/monolith/frontend/visual/serve.mjs
@@ -43,6 +43,12 @@ export async function serve() {
       PORT: String(APP_PORT),
       API_BASE: `http://127.0.0.1:${MOCK_PORT}`,
       ORIGIN: `http://127.0.0.1:${APP_PORT}`,
+      // Dummy site key so TurnstileGate mounts the widget instead of
+      // rendering its "Chat is unavailable" fallback (no env var = no
+      // widget). The real Cloudflare script + admission POST are
+      // intercepted at the Playwright layer in capture.mjs, so this value
+      // never has to resolve to anything real.
+      TURNSTILE_SITE_KEY: "1x00000000000000000000AA",
     },
     stdio: "inherit",
   });

--- a/projects/monolith/frontend/visual/targets.json
+++ b/projects/monolith/frontend/visual/targets.json
@@ -31,11 +31,8 @@
       "path": "/app/grimoire/library",
       "static_initial": true
     },
-    {
-      "id": "grimoire-world",
-      "path": "/app/grimoire/world",
-      "static_initial": true
-    },
+    { "id": "grimoire-world", "path": "/app/grimoire/world" },
+    { "id": "grimoire-chat", "path": "/app/grimoire/chat" },
     { "id": "firecracker", "path": "/app/firecracker" },
     { "id": "docs", "path": "/docs" },
     { "id": "docs-slug", "path": "/docs/agents" },

--- a/projects/monolith/grimoire/explore.py
+++ b/projects/monolith/grimoire/explore.py
@@ -165,7 +165,12 @@ def scope_subgraph(session: Session, scope: str, lens: str) -> dict[str, Any]:
     return {"nodes": nodes, "edges": edges, "lens_counts": lens_counts}
 
 
-def ego_subgraph(session: Session, entity_id: str) -> dict[str, Any]:
+def ego_subgraph(
+    session: Session,
+    entity_id: str,
+    scope: str = "everything",
+    lens: str = "world",
+) -> dict[str, Any]:
     """Focus entity + its 1-hop neighbors, as the SAME ``{nodes, edges}``
     shape ``scope_subgraph`` returns, so the canvas can merge a click-to-
     expand ("wander") result straight into the current view.
@@ -174,6 +179,22 @@ def ego_subgraph(session: Session, entity_id: str) -> dict[str, Any]:
     non-public focus entity yields an empty graph, and any neighbor that
     isn't ``is_global`` (plus the edge to it) is dropped rather than shown,
     exactly like the private-entity-neighbor drop in that function.
+
+    ``scope``/``lens`` narrow the NEIGHBOR set to ``scope_entity_ids(session,
+    scope, lens)``, the same predicate ``scope_subgraph`` uses, so a World
+    page scoped to one adventure or lensed to "rules" only shows neighbors
+    that belong to that slice. The FOCUS node is always kept regardless of
+    scope/lens (an entity's own page never hides itself), matching the
+    is_global-only gate a caller gets with the defaults
+    ``scope="everything", lens="world"``... except "world" is NOT a no-op
+    lens (see lens_predicate), so callers wanting the old unfiltered
+    every-neighbor behavior should pass lens="everything" explicitly.
+
+    ``lens_counts`` is returned alongside, one count per lens over the
+    UNFILTERED is_global neighbor set (via ``scope_entity_ids`` restricted to
+    those neighbor ids), so the frontend's lens tabs can grey out lenses with
+    no entities in this ego neighborhood, the same UX ``scope_subgraph``'s
+    lens_counts gives the EXPLORE canvas.
 
     The focus node's card carries an extra ``image_chunk_id`` (earliest
     image-bearing chunk mentioning it, via
@@ -184,7 +205,11 @@ def ego_subgraph(session: Session, entity_id: str) -> dict[str, Any]:
     """
     focus = session.get(Entity, entity_id)
     if focus is None or not focus.is_global:
-        return {"nodes": [], "edges": []}
+        return {
+            "nodes": [],
+            "edges": [],
+            "lens_counts": {name: 0 for name in _LENS_NAMES},
+        }
 
     touching = session.exec(
         select(Relationship).where(
@@ -199,7 +224,7 @@ def ego_subgraph(session: Session, entity_id: str) -> dict[str, Any]:
         for r in touching
     }
     neighbor_ids.discard(entity_id)
-    neighbors_by_id = (
+    all_neighbors_by_id = (
         {
             e.id: e
             for e in session.exec(
@@ -209,6 +234,16 @@ def ego_subgraph(session: Session, entity_id: str) -> dict[str, Any]:
         if neighbor_ids
         else {}
     )
+
+    lens_counts = _ego_lens_counts(session, set(all_neighbors_by_id))
+
+    if scope == "everything" and lens == "world":
+        neighbors_by_id = all_neighbors_by_id
+    else:
+        scoped_ids = scope_entity_ids(session, scope, lens) & set(all_neighbors_by_id)
+        neighbors_by_id = {
+            eid: e for eid, e in all_neighbors_by_id.items() if eid in scoped_ids
+        }
 
     visible_ids = {entity_id, *neighbors_by_id}
     edges = [
@@ -224,7 +259,28 @@ def ego_subgraph(session: Session, entity_id: str) -> dict[str, Any]:
             )
             break
 
-    return {"nodes": nodes, "edges": edges}
+    return {"nodes": nodes, "edges": edges, "lens_counts": lens_counts}
+
+
+def _ego_lens_counts(session: Session, neighbor_ids: set[str]) -> dict[str, int]:
+    """Per-lens entity count over a fixed ego neighbor id set, the ego
+    analogue of ``_lens_counts``: that helper re-runs ``scope_entity_ids``
+    per lens over a whole scope, but an ego neighborhood is already a small,
+    bounded set of ids in hand, so this queries ``lens_predicate`` restricted
+    to ``neighbor_ids`` directly (one query per lens, never a full-corpus
+    scan) instead of re-deriving a roster from scratch."""
+    if not neighbor_ids:
+        return {name: 0 for name in _LENS_NAMES}
+    return {
+        name: len(
+            session.exec(
+                select(Entity.id).where(
+                    Entity.id.in_(neighbor_ids), lens_predicate(name)
+                )
+            ).all()
+        )
+        for name in _LENS_NAMES
+    }
 
 
 # Hop bound for shortest_path's BFS: a D&D corpus graph has a modest

--- a/projects/monolith/grimoire/library.py
+++ b/projects/monolith/grimoire/library.py
@@ -73,15 +73,6 @@ def _iso(dt: datetime | None) -> str | None:
     return coerced.isoformat() if coerced else None
 
 
-def _section_title(section_path: str | None) -> str:
-    """A short human label for a section: the last path segment, or a stable
-    placeholder for chunks with no section_path (front matter, stray blocks).
-    """
-    if not section_path:
-        return "(no section)"
-    return section_path.rsplit("/", 1)[-1].strip() or section_path
-
-
 def _kind(chunk: KnowledgeChunk) -> str:
     return "image" if chunk.image_ref else "text"
 
@@ -217,18 +208,52 @@ def _cover_chunk_by_book(session: Session) -> dict[str, str]:
     return {**fallback, **preferred}
 
 
-def list_sections(session: Session, book_id: str) -> list[dict[str, Any]]:
-    """Ordered section tree for one book.
+def _hierarchy_path(
+    section_hierarchy: str | None, section_path: str | None
+) -> list[str]:
+    """The ancestor breadcrumb for one chunk, shallowest first.
 
-    Sections are grouped by ``section_path`` in reading order (first appearance
-    by ``seq``), not alphabetically. ``first_chunk_id`` is the earliest chunk in
-    the section, so the reader can jump straight to the section start.
+    Prefers ``section_hierarchy`` (" > "-separated, e.g. "Chapter 3 > Armor >
+    Armor of Vulnerability"), which carries the full depth. Falls back to
+    ``section_path`` (split on "/") for chunks loaded before the backfill, so a
+    book with partial ``section_hierarchy`` coverage (e.g. monster-manual,
+    1222/2028) never loses a currently-reachable section. Chunks with neither
+    (front matter, stray blocks) get a stable single-node placeholder so they
+    still surface in the TOC rather than vanishing.
+    """
+    source = section_hierarchy or section_path
+    if not source:
+        return ["(no section)"]
+    sep = " > " if section_hierarchy else "/"
+    parts = [part.strip() for part in source.split(sep) if part.strip()]
+    return parts or ["(no section)"]
+
+
+def list_sections(session: Session, book_id: str) -> list[dict[str, Any]]:
+    """Ordered, nested section tree for one book.
+
+    Rows are grouped by their full ancestor breadcrumb (``section_hierarchy``,
+    falling back per-chunk to ``section_path``) rather than by the raw,
+    near-flat ``section_path`` column: for books with deep ``section_path``
+    fragmentation (e.g. a5e-srd's 4,182 distinct paths), grouping on the
+    shared breadcrumb prefix collapses the reader TOC back down to a few dozen
+    real chapters instead of thousands of top-level rows.
+
+    Returns one entry per DISTINCT breadcrumb node (chapter, sub-section,
+    etc.), each carrying its ``depth`` (0 = top-level) and ``parent_path``
+    (the joined breadcrumb of its parent, or null at depth 0) so the client
+    can nest without re-deriving structure. Order is first-appearance by
+    ``seq``, matching the pre-existing reading-order contract. ``first_chunk_id``
+    is the earliest chunk anywhere under that node (leaf or ancestor), so every
+    row -- including chapter headers with no chunks of their own -- has a
+    target the reader can jump to.
     """
     rows = session.execute(
         select(
             KnowledgeChunk.id,
             KnowledgeChunk.seq,
             KnowledgeChunk.section_path,
+            KnowledgeChunk.section_hierarchy,
             KnowledgeChunk.image_ref,
             KnowledgeChunk.created_at,
         )
@@ -236,30 +261,54 @@ def list_sections(session: Session, book_id: str) -> list[dict[str, Any]]:
         .order_by(KnowledgeChunk.seq, KnowledgeChunk.chunk_ref)
     ).all()
 
-    sections: dict[str | None, dict[str, Any]] = {}
-    order: list[str | None] = []
-    for chunk_id, _seq, section_path, image_ref, created_at in rows:
-        entry = sections.get(section_path)
-        if entry is None:
-            entry = {
-                "section_path": section_path,
-                "title": _section_title(section_path),
-                "chunk_count": 0,
-                "image_count": 0,
-                "first_chunk_id": chunk_id,
-                "latest_chunk_at": created_at,
-            }
-            sections[section_path] = entry
-            order.append(section_path)
-        entry["chunk_count"] += 1
-        if image_ref:
-            entry["image_count"] += 1
-        current = entry["latest_chunk_at"]
-        if created_at is not None and (current is None or created_at > current):
-            entry["latest_chunk_at"] = created_at
+    nodes: dict[tuple[str, ...], dict[str, Any]] = {}
+    order: list[tuple[str, ...]] = []
+    for chunk_id, _seq, section_path, section_hierarchy, image_ref, created_at in rows:
+        breadcrumb = tuple(_hierarchy_path(section_hierarchy, section_path))
+        # Every ancestor prefix gets its own node (so a chapter with no chunks
+        # of its own still appears and gets a first_chunk_id), but only the
+        # full breadcrumb's node counts this chunk/image toward its totals and
+        # collects the chunk's raw section_path (see raw_section_paths below).
+        for depth in range(len(breadcrumb)):
+            key = breadcrumb[: depth + 1]
+            entry = nodes.get(key)
+            if entry is None:
+                entry = {
+                    "section_path": " > ".join(key),
+                    "title": key[-1],
+                    "depth": depth,
+                    "parent_path": " > ".join(key[:-1]) if depth > 0 else None,
+                    "chunk_count": 0,
+                    "image_count": 0,
+                    "first_chunk_id": chunk_id,
+                    "latest_chunk_at": created_at,
+                    # The distinct raw section_path values (the chunk column,
+                    # scroll-highlight granularity) that roll up into this
+                    # node. Reader.svelte's activeSectionPath is a raw
+                    # section_path, not this node's synthesized breadcrumb
+                    # string, so the client matches against membership in this
+                    # list rather than equality on section_path.
+                    "raw_section_paths": set(),
+                }
+                nodes[key] = entry
+                order.append(key)
+            if key == breadcrumb:
+                entry["chunk_count"] += 1
+                entry["raw_section_paths"].add(section_path)
+                if image_ref:
+                    entry["image_count"] += 1
+            current = entry["latest_chunk_at"]
+            if created_at is not None and (current is None or created_at > current):
+                entry["latest_chunk_at"] = created_at
 
     return [
-        {**sections[key], "latest_chunk_at": _iso(sections[key]["latest_chunk_at"])}
+        {
+            **nodes[key],
+            "latest_chunk_at": _iso(nodes[key]["latest_chunk_at"]),
+            "raw_section_paths": sorted(
+                p for p in nodes[key]["raw_section_paths"] if p is not None
+            ),
+        }
         for key in order
     ]
 

--- a/projects/monolith/grimoire/library.py
+++ b/projects/monolith/grimoire/library.py
@@ -330,6 +330,41 @@ def _image_object_key(image_ref: str | None) -> str | None:
     return key or None
 
 
+def _global_mentions_by_chunk(
+    session: Session, chunk_ids: list[str]
+) -> dict[str, list[dict[str, Any]]]:
+    """is_global entity mentions for a set of chunks, ONE query grouped in
+    Python (not N+1 per chunk). Mirrors public.get_chunk_public's per-chunk
+    mention query (same fields, same is_global filter, same name order), just
+    batched across a whole reader page. Empty dict for an empty chunk_ids.
+    """
+    if not chunk_ids:
+        return {}
+    rows = session.exec(
+        select(
+            ChunkEntityMention.chunk_id,
+            Entity.id,
+            Entity.name,
+            Entity.entity_type,
+            ChunkEntityMention.mention_text,
+        )
+        .join(Entity, Entity.id == ChunkEntityMention.entity_id)
+        .where(ChunkEntityMention.chunk_id.in_(chunk_ids), Entity.is_global)
+        .order_by(Entity.name)
+    ).all()
+    by_chunk: dict[str, list[dict[str, Any]]] = {}
+    for chunk_id, entity_id, name, entity_type, mention_text in rows:
+        by_chunk.setdefault(chunk_id, []).append(
+            {
+                "id": entity_id,
+                "name": name,
+                "entity_type": entity_type,
+                "mention_text": mention_text,
+            }
+        )
+    return by_chunk
+
+
 def read_page(
     session: Session,
     book_id: str,
@@ -344,6 +379,11 @@ def read_page(
     key plus the caption as ``content``. Keyset paginated on ``seq`` exactly
     like ``list_chunks`` (cursor = last seq returned; NULL-seq boundary rows
     end the page rather than emitting a "None" cursor).
+
+    Each item also carries ``entities``: the is_global entity mentions on that
+    chunk (same fields as public.get_chunk_public's mention chips), so the
+    reader can linkify mentions inline. Fetched with one batched query across
+    the whole page (see _global_mentions_by_chunk), not per chunk.
     """
     limit = max(1, min(limit, MAX_READ_PAGE))
     query = select(KnowledgeChunk).where(KnowledgeChunk.book_id == book_id)
@@ -359,6 +399,7 @@ def read_page(
 
     has_more = len(rows) > limit
     rows = rows[:limit]
+    mentions_by_chunk = _global_mentions_by_chunk(session, [chunk.id for chunk in rows])
     items = [
         {
             "id": chunk.id,
@@ -367,6 +408,7 @@ def read_page(
             "kind": _kind(chunk),
             "content": chunk.content,
             "image_key": _image_object_key(chunk.image_ref),
+            "entities": mentions_by_chunk.get(chunk.id, []),
         }
         for chunk in rows
     ]

--- a/projects/monolith/grimoire/library_test.py
+++ b/projects/monolith/grimoire/library_test.py
@@ -61,13 +61,22 @@ def client_fixture(session):
 
 
 def _chunk(
-    session, *, book_id, chunk_ref, content, seq, section_path=None, image_ref=None
+    session,
+    *,
+    book_id,
+    chunk_ref,
+    content,
+    seq,
+    section_path=None,
+    section_hierarchy=None,
+    image_ref=None,
 ):
     row = KnowledgeChunk(
         book_id=book_id,
         chunk_ref=chunk_ref,
         content=content,
         section_path=section_path,
+        section_hierarchy=section_hierarchy,
         image_ref=image_ref,
         seq=seq,
     )
@@ -233,17 +242,97 @@ class TestCoverChunk:
 
 class TestSections:
     def test_ordered_by_reading_order(self, session, client):
+        """seed_book sets only section_path (no section_hierarchy), so every
+        chunk falls back to splitting it on "/", collapsing "Monsters/Aboleth"
+        and "Monsters/Beholder" under a shared "Monsters" chapter node."""
         seed = seed_book(session)
         body = client.get("/api/grimoire/books/mm/sections").json()
         assert [s["section_path"] for s in body] == [
-            "Monsters/Aboleth",
-            "Monsters/Beholder",
+            "Monsters",
+            "Monsters > Aboleth",
+            "Monsters > Beholder",
         ]
-        aboleth = body[0]
+        chapter, aboleth, beholder = body
+        assert chapter["depth"] == 0
+        assert chapter["parent_path"] is None
+        # The chapter node has no chunks tagged with its OWN full breadcrumb
+        # (nothing is section_path="Monsters" alone), but still gets a
+        # first_chunk_id (the earliest descendant chunk) so it's clickable.
+        assert chapter["chunk_count"] == 0
+        assert chapter["first_chunk_id"] == seed.c0.id
+
         assert aboleth["title"] == "Aboleth"
+        assert aboleth["depth"] == 1
+        assert aboleth["parent_path"] == "Monsters"
         assert aboleth["chunk_count"] == 3
         assert aboleth["image_count"] == 1
         assert aboleth["first_chunk_id"] == seed.c0.id
+        assert aboleth["raw_section_paths"] == ["Monsters/Aboleth"]
+
+        assert beholder["title"] == "Beholder"
+        assert beholder["first_chunk_id"] == seed.c3.id
+
+    def test_nests_from_section_hierarchy_when_present(self, session, client):
+        """A chunk with section_hierarchy set is grouped by its full breadcrumb
+        (split on " > "), not by section_path, and can nest deeper than two
+        levels."""
+        session.add(Book(id="deep", display_name="Deep Book"))
+        c0 = _chunk(
+            session,
+            book_id="deep",
+            chunk_ref="d0",
+            content="Vulnerability details.",
+            seq=0,
+            section_path="Chapter 3/Armor",
+            section_hierarchy="Chapter 3: Magic Items > Armor > Armor of Vulnerability",
+        )
+        body = client.get("/api/grimoire/books/deep/sections").json()
+        assert [s["section_path"] for s in body] == [
+            "Chapter 3: Magic Items",
+            "Chapter 3: Magic Items > Armor",
+            "Chapter 3: Magic Items > Armor > Armor of Vulnerability",
+        ]
+        leaf = body[2]
+        assert leaf["title"] == "Armor of Vulnerability"
+        assert leaf["depth"] == 2
+        assert leaf["parent_path"] == "Chapter 3: Magic Items > Armor"
+        assert leaf["first_chunk_id"] == c0.id
+        # raw_section_paths tracks the chunk-level column for the reader's
+        # scroll-highlight match, independent of the section_hierarchy nesting.
+        assert leaf["raw_section_paths"] == ["Chapter 3/Armor"]
+
+    def test_falls_back_per_chunk_when_hierarchy_missing(self, session, client):
+        """Within one book, chunks with section_hierarchy nest by breadcrumb
+        while chunks missing it (pre-backfill) fall back to section_path,
+        matching the mixed-coverage case (e.g. monster-manual, 1222/2028)."""
+        session.add(Book(id="mixed", display_name="Mixed Coverage"))
+        with_hierarchy = _chunk(
+            session,
+            book_id="mixed",
+            chunk_ref="m0",
+            content="Has hierarchy.",
+            seq=0,
+            section_path="Ch1/Intro",
+            section_hierarchy="Chapter 1 > Introduction",
+        )
+        without_hierarchy = _chunk(
+            session,
+            book_id="mixed",
+            chunk_ref="m1",
+            content="Missing hierarchy.",
+            seq=1,
+            section_path="Ch2/Setup",
+            section_hierarchy=None,
+        )
+        body = client.get("/api/grimoire/books/mixed/sections").json()
+        paths = [s["section_path"] for s in body]
+        assert "Chapter 1 > Introduction" in paths
+        assert "Ch2 > Setup" in paths
+        by_path = {s["section_path"]: s for s in body}
+        assert (
+            by_path["Chapter 1 > Introduction"]["first_chunk_id"] == with_hierarchy.id
+        )
+        assert by_path["Ch2 > Setup"]["first_chunk_id"] == without_hierarchy.id
 
 
 class TestListChunks:

--- a/projects/monolith/grimoire/router_public.py
+++ b/projects/monolith/grimoire/router_public.py
@@ -285,12 +285,17 @@ def explore_graph(
 
 @router.get("/explore/ego")
 def explore_ego(
-    id: str = Query(...), session: Session = Depends(get_session)
+    id: str = Query(...),
+    scope: str = Query(default="everything"),
+    lens: str = Query(default="world"),
+    session: Session = Depends(get_session),
 ) -> dict[str, Any]:
-    """Focus entity + its 1-hop is_global neighbors, same ``{nodes, edges}``
-    shape as /explore/graph, for click-to-expand ("wander"). See
+    """Focus entity + its 1-hop is_global neighbors, same ``{nodes, edges,
+    lens_counts}`` shape as /explore/graph, for click-to-expand ("wander").
+    ``scope``/``lens`` narrow the neighbor set the same way they narrow
+    /explore/graph; the focus node is always kept. See
     explore.ego_subgraph."""
-    return explore.ego_subgraph(session, id)
+    return explore.ego_subgraph(session, id, scope, lens)
 
 
 @router.get("/explore/path")

--- a/projects/monolith/grimoire/router_public_test.py
+++ b/projects/monolith/grimoire/router_public_test.py
@@ -643,11 +643,64 @@ class TestExploreEgo:
         assert {(e["from"], e["to"]) for e in body["edges"]} == {
             ("e-aboleth", "e-fireball")
         }
+        # Aboleth (creature -> lore) and Fireball (spell) are both in the
+        # neighborhood; "rules" unions spells in by entity_type, so the
+        # rules count is 1 (Fireball) and world's is 1 (Aboleth, lore).
+        assert body["lens_counts"] == {
+            "world": 1,
+            "story": 0,
+            "quests": 0,
+            "rules": 1,
+        }
 
     def test_missing_or_non_public_focus_returns_empty_graph(self, session, client):
         r = client.get("/api/grimoire/explore/ego?id=nope")
         assert r.status_code == 200
-        assert r.json() == {"nodes": [], "edges": []}
+        assert r.json() == {
+            "nodes": [],
+            "edges": [],
+            "lens_counts": {"world": 0, "story": 0, "quests": 0, "rules": 0},
+        }
+
+    def test_adventure_scope_drops_neighbor_outside_adventure_keeps_focus(
+        self, session, client
+    ):
+        # Aboleth is the focus and is never filtered out even though it has
+        # no adventure roster membership seeded here; Fireball (its only
+        # neighbor) is outside the adventure's roster, so an adventure scope
+        # should drop it while keeping Aboleth.
+        seed_corpus(session)  # e-aboleth --knows--> e-fireball
+        book = Book(id="cos", display_name="Curse of Strahd", copyrighted_content=False)
+        session.add(book)
+        adventure = Adventure(
+            id="cos-death-house",
+            book_id="cos",
+            name="Death House",
+            seq=0,
+            start_seq=0,
+        )
+        session.add(adventure)
+        session.commit()
+
+        r = client.get(
+            "/api/grimoire/explore/ego?id=e-aboleth&scope=adventure:cos-death-house"
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert {n["name"] for n in body["nodes"]} == {"Aboleth"}
+        assert body["edges"] == []
+
+    def test_lens_filters_ego_neighbors(self, session, client):
+        # Aboleth is a creature (category "lore", not a spell), so the
+        # "rules" lens (mechanics category, or entity_type spell) drops it
+        # as a neighbor even though the focus itself (Fireball, a spell) is
+        # always kept.
+        seed_corpus(session)  # e-aboleth --knows--> e-fireball
+        r = client.get("/api/grimoire/explore/ego?id=e-fireball&lens=rules")
+        assert r.status_code == 200
+        body = r.json()
+        assert {n["name"] for n in body["nodes"]} == {"Fireball"}
+        assert body["edges"] == []
 
 
 class TestExplorePath:

--- a/projects/monolith/grimoire/router_public_test.py
+++ b/projects/monolith/grimoire/router_public_test.py
@@ -331,7 +331,18 @@ class TestBooksAndSections:
         r = client.get("/api/grimoire/books/mm/sections")
         assert r.status_code == 200
         sections = r.json()
-        assert sections[0]["section_path"] == "Monsters/Aboleth"
+        # section_hierarchy is unset on this fixture, so list_sections falls
+        # back to splitting the raw section_path ("Monsters/Aboleth") into a
+        # two-level breadcrumb: a "Monsters" chapter node, then its "Aboleth"
+        # child, joined with " > " (the section_hierarchy separator).
+        assert [s["section_path"] for s in sections] == [
+            "Monsters",
+            "Monsters > Aboleth",
+        ]
+        assert sections[1]["title"] == "Aboleth"
+        assert sections[1]["depth"] == 1
+        assert sections[1]["parent_path"] == "Monsters"
+        assert sections[1]["raw_section_paths"] == ["Monsters/Aboleth"]
 
     def test_read_page_full_content(self, session, client):
         seed = seed_corpus(session)

--- a/projects/monolith/grimoire/router_public_test.py
+++ b/projects/monolith/grimoire/router_public_test.py
@@ -343,6 +343,41 @@ class TestBooksAndSections:
         assert page["items"][0]["content"] == seed.c0.content
         assert page["next_cursor"] is None
 
+    def test_read_page_includes_global_entity_mentions(self, session, client):
+        """Each item carries its is_global entity mentions (name, entity_type,
+        mention_text), batched across the page rather than per chunk."""
+        seed = seed_corpus(session)
+        r = client.get("/api/grimoire/books/mm/read")
+        assert r.status_code == 200
+        page = r.json()
+        c0_item = next(item for item in page["items"] if item["id"] == seed.c0.id)
+        assert {e["name"] for e in c0_item["entities"]} == {"Aboleth"}
+        assert c0_item["entities"][0]["entity_type"] == "creature"
+        assert c0_item["entities"][0]["mention_text"] == "Aboleth"
+        # A chunk with no mentions still gets an (empty) entities list.
+        c1_item = next(item for item in page["items"] if item["id"] == seed.c1.id)
+        assert c1_item["entities"] == []
+
+    def test_read_page_excludes_non_global_entity_mentions(self, session, client):
+        """A campaign-private entity (is_global=False) mentioned on a chunk
+        must NOT appear in the public reader's per-chunk entities."""
+        seed = seed_corpus(session)
+        session.add(
+            Entity(id="e-strahd", entity_type="npc", name="Strahd", is_global=False)
+        )
+        session.commit()
+        session.add(
+            ChunkEntityMention(
+                chunk_id=seed.c0.id, entity_id="e-strahd", mention_text="Strahd"
+            )
+        )
+        session.commit()
+        r = client.get("/api/grimoire/books/mm/read")
+        assert r.status_code == 200
+        page = r.json()
+        c0_item = next(item for item in page["items"] if item["id"] == seed.c0.id)
+        assert {e["name"] for e in c0_item["entities"]} == {"Aboleth"}
+
 
 class TestGetChunk:
     def test_no_campaign_or_as_required(self, session, client):


### PR DESCRIPTION
Fixes every documented follow-up from the showcase redesign (PR #3351) plus a newly diagnosed sidebar performance bug, ahead of the demo.

## What changed

- **Reader entity mentions are now links.** read_page batches one is_global entity query per page and Reader.svelte renders escaped chunk text through the same highlightMentions pipeline chat uses: type-colored, clickable into World.
- **World scope/lens tabs actually filter the graph.** /explore/ego takes scope and lens params (neighbors intersected with scope_entity_ids, focus always kept) and returns lens_counts. Empty narrowed egos fall back to the full ego with a visible note, never a blank canvas. Ego fetches are guarded against stale out-of-order responses.
- **Chapter sidebar no longer takes forever.** Root cause was data shape, not the DB (EXPLAIN: 11.9 ms, indexed): a5e-srd emitted 4,182 near-flat sections rendered as ~4,100 DOM rows, twice. list_sections now nests from section_hierarchy breadcrumbs (section_path fallback for partially-populated books) and Reader fetches sections once for both nav mounts. Roughly 100x payload and DOM reduction on the worst book.
- **Visual harness captures World and Chat for real.** Capture stubs the Turnstile script and admission endpoints (test code only, zero production changes), plus new adventures/ego fixtures and a grimoire-chat target.
- **Hygiene:** TYPE_ALLOWLIST guard on ExploreCodex CSS var interpolation, store unsubscribe on destroy in ConstellationDock and grimoire chat, debounce/abort cleanup in EntitySearch.

Charts bumped: monolith 0.285.102, monolith-public 0.89.44.

Whole-diff review completed pre-push; the one finding (ego fetch race) is fixed in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)