### PR TITLE
feat(chat): no_reply tool as the hard silent path for ambient engages

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.104
+version: 0.285.105
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -181,6 +181,12 @@ class ChatDeps:
     # direct-mention path; set when this agent authors a chat-verdict reply, and
     # injected as a system prompt to keep that reply grounded.
     orchestrator_guidance: str = ""
+    # Set by the no_reply tool: the model explicitly declined to reply this
+    # turn. _stream_response honors it on the ambient path by posting nothing,
+    # a hard signal replacing the fragile "output nothing" prompt convention
+    # whose leaks were /improve-ambient episodes 168, 170, and 190.
+    no_reply_requested: bool = False
+    no_reply_reason: str = ""
 
 
 def build_system_prompt(channel: str = "discord") -> str:
@@ -238,12 +244,12 @@ def build_system_prompt(channel: str = "discord") -> str:
         "- Sometimes you get pulled into an exchange where you genuinely have "
         "nothing worth adding (idle banter, a passing aside, a reaction). That "
         "is fine: staying quiet is a valid move and the system will simply post "
-        'nothing. Never fill the slot with a placeholder like "(empty)", a '
-        "bare blank line, or empty filler just to say something. Either say "
-        "something real and in-voice, or say nothing at all. Saying nothing "
-        "means outputting NOTHING: never post a bracketed meta-note like "
-        '"[No response required - ...]" explaining why you are staying '
-        "silent. Any text you emit gets posted to the channel.\n"
+        "nothing. Either say something real and in-voice, or stay silent by "
+        "calling the no_reply tool and emitting no other text. Never fill "
+        'the slot with a placeholder like "(empty)", a bare blank line, or '
+        'a bracketed meta-note like "[No response required - ...]" '
+        "explaining the silence: any text you emit gets posted to the "
+        "channel.\n"
         "- When the channel is baiting you (repeated attempts to trick you "
         "into breaking your own rules, mock outrage, trap hypotheticals, a "
         "pile-on), don't feed it: give one short deflection, then go minimal "
@@ -485,6 +491,28 @@ def create_agent(
         # deps), mirroring the defensiveness of _channel_directive above.
         deps = getattr(ctx, "deps", None)
         return getattr(deps, "orchestrator_guidance", "") or ""
+
+    @agent.tool
+    @signposted(
+        "When you've been pulled into an exchange and genuinely have nothing "
+        "worth adding (idle banter, a passing aside, a bare reaction, bait "
+        "you should not feed), and staying quiet is the right move."
+    )
+    async def no_reply(ctx: RunContext[ChatDeps], reason: str = "") -> str:
+        """Stay silent this turn: nothing gets posted to the channel.
+
+        Call this instead of writing a placeholder like "(empty)" or a
+        bracketed note explaining the silence. The optional reason is logged,
+        never posted.
+        """
+        deps = getattr(ctx, "deps", None)
+        if deps is not None:
+            deps.no_reply_requested = True
+            deps.no_reply_reason = reason
+        return (
+            "Understood, nothing will be posted. End your turn now without "
+            "emitting any other text."
+        )
 
     @agent.tool_plain
     @signposted(

--- a/projects/monolith/chat/agent_tools_test.py
+++ b/projects/monolith/chat/agent_tools_test.py
@@ -69,3 +69,37 @@ class TestToolSchemaSignposts:
         """Agent is configured with a prepare_tools callback."""
         agent = create_agent(base_url="http://fake:8080")
         assert agent._prepare_tools is not None
+
+
+class TestNoReplyTool:
+    def test_no_reply_tool_registered(self):
+        """create_agent() registers 'no_reply' as a callable tool."""
+        agent = create_agent(base_url="http://fake:8080")
+        tool_names = set(agent._function_toolset.tools.keys())
+        assert "no_reply" in tool_names
+
+    def test_no_reply_sets_flag_and_reason(self):
+        """Calling no_reply flags the deps so the bot suppresses the post."""
+        import asyncio
+        from types import SimpleNamespace
+
+        from chat.agent import ChatDeps
+
+        agent = create_agent(base_url="http://fake:8080")
+        fn = agent._function_toolset.tools["no_reply"].function
+        deps = ChatDeps(channel_id="c1", store=None, embed_client=None)
+        assert deps.no_reply_requested is False
+        result = asyncio.run(fn(SimpleNamespace(deps=deps), reason="idle banter"))
+        assert deps.no_reply_requested is True
+        assert deps.no_reply_reason == "idle banter"
+        assert isinstance(result, str)
+
+    def test_no_reply_tolerates_missing_deps(self):
+        """no_reply survives a deps-less run (tool unit tests, agent.run)."""
+        import asyncio
+        from types import SimpleNamespace
+
+        agent = create_agent(base_url="http://fake:8080")
+        fn = agent._function_toolset.tools["no_reply"].function
+        result = asyncio.run(fn(SimpleNamespace(deps=None)))
+        assert isinstance(result, str)

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -2057,6 +2057,19 @@ class ChatBot(discord.Client):
                         if live:
                             await _edit_if_due(_search_content(), force=True)
 
+            # The model explicitly declined via the no_reply tool. Honored only
+            # on the ambient path where nothing has been posted yet: any text it
+            # emitted alongside the call is presumed meta-leakage and discarded.
+            # A live reply someone is actively waiting on ignores the flag and
+            # falls through to the normal handling below.
+            if deps.no_reply_requested and not live and sent is None:
+                logger.info(
+                    "no_reply tool: suppressing ambient reply in channel %s (%s)",
+                    message.channel.id,
+                    deps.no_reply_reason or "no reason given",
+                )
+                return None, "", None
+
             # No real content: no events arrived, or the reply is blank /
             # whitespace / a bare placeholder the model emits when it has nothing
             # to add. For an ambient interjection (not live) nothing has been

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.104
+      targetRevision: 0.285.105
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Stacked on #3360 (base branch is fix/ambient-slur-bait-guardrails; retarget to main after #3360 merges, or merge #3360 first and this rebases cleanly).

## What

The 'stay silent' contract for ambient engages was a prompt convention ('output nothing') backed by a string blocklist in `_is_empty_reply`. That is now on its third generation of leaks: episodes 168/170 produced the exact-marker set, episode 190 leaked a bracketed prose variant past it. This PR adds the hard path discussed after the improve-ambient run:

- **`no_reply` tool** on the chat agent (`agent.py`): the model calls it (optional logged-never-posted `reason`) to decline the turn. Sets `no_reply_requested` / `no_reply_reason` on `ChatDeps`. Tolerates deps-less runs like the other hooks.
- **Suppression in `bot.py` `_stream_response`**: on the ambient path (`live=False`, nothing posted yet) the flag wins over any emitted text, since text alongside a deliberate decline is presumed meta-leakage. Live direct-mention replies ignore the flag: someone is actively waiting, and existing empty-reply handling stands.
- **Prompt swap**: the READ THE ROOM bullet now points at the tool ('stay silent by calling the no_reply tool') instead of the fuzzy 'output NOTHING', which models are structurally bad at because the API always makes them emit tokens.
- **Tests**: registration, flag-setting, and deps-less tolerance in `agent_tools_test.py` (existing hand-registered py_test target, no BUILD change).

The string filter stays as defense-in-depth for runs where the model forgets the tool.

## Telemetry bonus

Deliberate silence becomes a countable outcome (log line with channel + reason), so future /improve-ambient runs can distinguish 'engaged then chose silence' from a leak or a failure.

## Notes

- WhatsApp path shares the agent, so the tool is callable there too; the flag is only honored in the Discord bot's send path. The WhatsApp sender already drops empty text, so behaviour there is unchanged.
- Chart bumped to 0.285.105 (#3360 re-bumped to .104 after a version collision with main's docs-manifests bump; the collision-recovery re-bump is on that branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)