### PR TITLE
fix(argocd): route GitHub webhook via private.jomcgi.dev/webhooks/github/argocd

### DIFF
--- a/projects/platform/argocd/templates/httproute.yaml
+++ b/projects/platform/argocd/templates/httproute.yaml
@@ -29,4 +29,31 @@ updated to include /app/argocd.
 {{- include "cf-ingress.httproute" $routeParams }}
 ---
 {{- include "cf-ingress.security-policy" (dict "name" "argocd-private") }}
+---
+{{- /*
+GitHub push webhook ingress. GitHub POSTs to
+private.jomcgi.dev/webhooks/github/argocd (a clean, service-agnostic webhook
+namespace); the gateway rewrites that to argocd-server's real endpoint
+/app/argocd/api/webhook. That target is verified live: argocd-server honors
+server.rootpath=/app/argocd server-side, so /app/argocd/api/webhook returns 200
+while the bare /api/webhook 404s.
+
+Deliberately NO cf-ingress.security-policy on this route: GitHub bypasses
+Cloudflare Access at the edge via an IP-allowlist Bypass policy, so its request
+carries no Cf-Access-Jwt-Assertion. A cf-access SecurityPolicy would make the
+Envoy gateway reject the (JWT-less) webhook even though Cloudflare admitted it.
+Access control for this path is the edge IP allowlist; argocd treats the hook as
+a refresh trigger (no webhook secret configured, unsigned hooks are harmless).
+*/}}
+{{- $webhookParams := dict
+  "name" "argocd-github-webhook"
+  "tier" .Values.cfIngress.tier
+  "hostname" .Values.cfIngress.hostname
+  "pathPrefix" "/webhooks/github/argocd"
+  "rewritePrefix" "/app/argocd/api/webhook"
+  "serviceName" .Values.cfIngress.serviceName
+  "servicePort" .Values.cfIngress.servicePort
+  "gateway" .Values.cfIngress.gateway
+}}
+{{- include "cf-ingress.httproute" $webhookParams }}
 {{- end }}


### PR DESCRIPTION
## Problem

The repo's single GitHub webhook still targets the retired \`argocd.jomcgi.dev/api/webhook\` (hostname removed in PR #2534). Every delivery has been failing:

\`\`\`
push  502  "failed to connect to host"   (every delivery)
\`\`\`

ArgoCD has been running purely on its polling reconcile (~3 min), so GitOps still worked but lost instant-on-push sync. Confirmed via \`gh api repos/jomcgi/homelab/hooks/<id>/deliveries\`.

## Fix

Add an HTTPRoute on the \`private.jomcgi.dev\` gateway that accepts GitHub POSTs at a clean, service-agnostic path \`/webhooks/github/argocd\` and rewrites them to argocd-server's real endpoint \`/app/argocd/api/webhook\`.

- **Rewrite target verified live in-cluster**: \`/app/argocd/api/webhook\` returns 200 (argocd-server honors \`server.rootpath=/app/argocd\`); the bare \`/api/webhook\` 404s.
- **No cf-access SecurityPolicy on this route (deliberate)**: GitHub bypasses Cloudflare Access at the edge via an IP-allowlist Bypass policy, so its request carries no \`Cf-Access-Jwt-Assertion\`. Attaching JWT validation would make the Envoy gateway reject a webhook Cloudflare already admitted. Access control for this path is the edge IP allowlist.
- No chart bump: the argocd Application deploys from git \`HEAD\`, so this goes live on merge + sync.

## Follow-up (outside this PR)

- Repoint the GitHub hook URL to \`https://private.jomcgi.dev/webhooks/github/argocd\` (done separately once merged + synced).
- The Cloudflare Access destination + IP Bypass for \`/webhooks/github/argocd\` is already configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)