### PR TITLE
fix(frontend): homepage and showcase voice pass, dead docs link, contrast

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.46
+version: 0.89.47
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.46
+      targetRevision: 0.89.47
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.106
+version: 0.285.107
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.106
+      targetRevision: 0.285.107
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/fcstory/FcScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/fcstory/FcScrollStory.svelte
@@ -382,7 +382,7 @@
             >.
           </h2>
           <p>
-            The VM was never the slow part. What costs real time is waiting
+            The slow part is waiting
             for a useful guest: kernel up, agent listening, toolchain warm.
             Measured cold, that wait is
             <span class="num big">{coldWait.ms.toLocaleString()}&nbsp;ms</span
@@ -402,7 +402,7 @@
           </p>
         </div>
         <div class="caption" bind:this={capRestoreEl}>
-          <h2>A request doesn't boot anything. It <em>restores</em>.</h2>
+          <h2>A request <em>restores</em>.</h2>
           <p>
             The bytes map from disk straight back into memory and the guest
             resumes mid-thought. The readiness wait that cost
@@ -574,8 +574,7 @@
     <p>
       This button replays one of the {restores.length} recorded runs at its true
       speed. No cluster is touched: the timings below were captured from the live
-      daemon and baked into this page. Blink and you miss it, which is the entire
-      point.
+      daemon and baked into this page. Blink and you miss it.
     </p>
     <ReplayWidget {restores} {PHASE_HUMAN} />
   </section>

--- a/projects/monolith/frontend/src/routes/public/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/+page.svelte
@@ -165,7 +165,7 @@
       <Sticker color="var(--paper)" rotate={-3} class="sticker-bio">A LITTLE ABOUT ME</Sticker>
       <p class="bio-sub">
         I'm Joe, from Scotland, living in Vancouver.<br />
-        Care<em>mad</em> about developer experience.
+        Monorepo enthusiast. Care<em>mad</em> about developer experience.
       </p>
     </div>
   </div>

--- a/projects/monolith/frontend/src/routes/public/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/+page.svelte
@@ -165,11 +165,9 @@
       <Sticker color="var(--paper)" rotate={-3} class="sticker-bio">A LITTLE ABOUT ME</Sticker>
       <p class="bio-sub">
         I'm Joe, from Scotland, living in Vancouver.<br />
-        Monorepo enthusiast. Lover of <a href="https://brutalistwebsites.com/" class="bio-link">brutalist websites</a>.<br />
         Care<em>mad</em> about developer experience.
       </p>
     </div>
-    <h2 class="bio-headline">Boring infrastructure<br />is a feature.</h2>
   </div>
 </section>
 
@@ -326,26 +324,13 @@
   .bio-panel {
     background: var(--accent);
     border-bottom: 2px solid var(--ink);
-    padding: 56px 0;
+    padding: 40px 0;
     position: relative;
     overflow: hidden;
   }
 
   .bio-content {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 48px;
-    align-items: center;
     max-width: 1360px;
-  }
-
-  .bio-headline {
-    font-family: var(--serif);
-    font-style: italic;
-    font-size: clamp(32px, 3.8vw, 56px);
-    font-weight: 400;
-    line-height: 1.05;
-    letter-spacing: -0.02em;
   }
 
   .bio-sub {
@@ -374,23 +359,12 @@
   }
 
   /* ── Responsive ──────────────────────────── */
-  @media (max-width: 1100px) {
-    .bio-content {
-      grid-template-columns: 1fr;
-      gap: 20px;
-    }
-  }
-
   @media (max-width: 768px) {
     .hero {
       padding: 56px 0 64px;
     }
     .bio-panel {
-      padding: 56px 0;
-    }
-    .bio-content {
-      grid-template-columns: 1fr;
-      gap: 20px;
+      padding: 32px 0;
     }
     :global(.sticker-hero) {
       display: none !important;

--- a/projects/monolith/frontend/src/routes/public/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/+page.svelte
@@ -340,17 +340,6 @@
     color: var(--ink-2);
   }
 
-  .bio-link {
-    text-decoration-line: underline;
-    text-decoration-color: var(--ink-3);
-    text-underline-offset: 3px;
-    transition: text-decoration-color 160ms ease;
-  }
-
-  .bio-link:hover {
-    text-decoration-color: var(--coral);
-  }
-
   .bio-left {
     display: flex;
     flex-direction: column;

--- a/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
+++ b/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
@@ -64,19 +64,17 @@
           </div>
           {#if app.slug === "grimoire"}
             <p>
-              A D&amp;D campaign manager where knowledge is granted, not
-              global: the same monster or NPC renders full stats for the DM,
-              redacted stats for a player who has fought it, or just a name
-              for one who has only heard rumours. Same corpus, same entity,
-              different view per grant.
+              A D&amp;D campaign manager built on grants: the same monster
+              renders full stats for the DM, redacted stats for a player who
+              has fought it, and just a name for one who has only heard
+              rumours.
               <a class="more" href="/app/grimoire">play &rarr;</a>
             </p>
           {:else if app.slug === "firecracker"}
             <p>
-              Watch a microVM restore from disk in <b>{sandboxRestoreMs}ms</b>,
-              scroll-scrubbed against the daemon's own trace data: boot once,
-              freeze it, then restore forever. Every number on the page is a
-              real measurement, not a made-up demo figure.
+              Watch a microVM restore from disk in <b>{sandboxRestoreMs}ms</b>.
+              Boot once, freeze it, restore forever; every number on the page
+              comes from the daemon's own tracing.
               <a class="more" href="/app/firecracker">watch it restore &rarr;</a>
             </p>
           {/if}
@@ -93,9 +91,11 @@
           to first model call), reverse-proxy over vsock into the microVM. The guest never holds
           a real secret; an egress proxy swaps placeholder tokens for credentials at the network
           hop. Coding agents and Semgrep scans run as peers on the same substrate.
-          <a class="more" href="/app/firecracker">how &rarr;</a>
-          <a class="more" href="/docs/agents">docs &rarr;</a>
         </p>
+        <div class="clinks">
+          <a class="more" href="/app/firecracker">how &rarr;</a>
+          <a class="more" href="/docs/projects/firecracker">docs &rarr;</a>
+        </div>
       </div>
       <div class="callout">
         <div class="chead">
@@ -128,8 +128,10 @@
           Five custom Bazel rulesets build every image dual-arch and pin digests into versioned
           OCI Helm charts; ArgoCD reconciles the cluster from the repo. <b>280+ chart
           versions</b> so far.
-          <a class="more" href="/docs/contributing">the pipeline &rarr;</a>
         </p>
+        <div class="clinks">
+          <a class="more" href="/docs/contributing">the pipeline &rarr;</a>
+        </div>
       </div>
     </div>
   </div>
@@ -144,12 +146,12 @@
   .rack-eyebrow {
     display: inline-block;
     font-family: var(--mono);
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 700;
     letter-spacing: 0.14em;
     text-transform: uppercase;
-    color: var(--ink);
-    background: var(--blue);
+    color: var(--accent);
+    background: var(--ink);
     padding: 4px 10px;
     margin: 0;
   }
@@ -298,6 +300,11 @@
   }
   .more:hover {
     background: var(--accent);
+  }
+  .clinks {
+    display: flex;
+    gap: 14px;
+    margin-top: 10px;
   }
   @media (max-width: 820px) {
     .rack-grid {

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
@@ -19,7 +19,7 @@
     {
       status: "Planned",
       title: "Evidence-grounded verification",
-      body: "A trailing job re-checks every extracted stat against the source passages, correcting what it can ground and nulling what it cannot.",
+      body: "A trailing job re-checks every extracted stat against its source passage, corrects it or nulls it.",
     },
     {
       status: "Planned",
@@ -34,7 +34,7 @@
     {
       status: "Designed",
       title: "Live-play tools",
-      body: "DM advice capture and a live session view, so the grimoire is useful mid-encounter and not just between sessions.",
+      body: "DM advice capture and a live session view for use mid-encounter.",
     },
     {
       status: "Long term",
@@ -64,8 +64,8 @@
       <span class="kn">demo</span>
     </div>
     <p class="block-lede">
-      Knowledge is granted, not global. The same entity renders differently
-      for each player character depending on the scope their DM has granted.
+      The same entity renders differently
+      for each player character, depending on the scope their DM has granted.
       The creature below is invented for this demo; the real corpus works the
       same way.
     </p>
@@ -104,9 +104,8 @@
       </article>
     </div>
     <p class="block-note">
-      One visibility predicate implements this everywhere: entity lookups,
-      search results, and the reader's "entities on this page" chips all
-      project through the same grant check.
+      One visibility predicate covers entity lookups, search results, and the
+      reader's "entities on this page" chips.
     </p>
   </section>
 
@@ -132,8 +131,7 @@
 
   <p class="foot-note">
     The library is free to browse. The interactive tools sit behind a quick
-    human check to keep bots out, and the whole app stays out of search
-    engines.
+    human check to keep bots out.
   </p>
 </div>
 


### PR DESCRIPTION
## What

Copy, UX, and link fixes across the homepage and the two showcase pages, applying the writing rules (no em-dashes, no antithesis, no arrow chains, no consequence narration).

**Homepage**
- Dead "docs" link on the AGENT PLATFORM card repointed from /docs/agents (404) to the real /docs/projects/firecracker page
- GRIMOIRE and FIRECRACKER featured cards rewritten without the antithesis constructions
- About band: brutalist-websites link and "Boring infrastructure is a feature." headline cut; band collapsed to a slim single-column strip; dead CSS removed
- Stats eyebrow chip inverted to cream-on-black at 14px (was low-contrast dark-on-blue at 12px)
- Card links pulled out of paragraph flow into their own row

**Grimoire landing**
- "Knowledge is granted, not global." deleted (the mechanism sentence stands alone)
- Visibility-predicate sentence tightened; roadmap items de-flourished
- Stale footer claim removed: the landing page IS indexable since #3363, so "the whole app stays out of search engines" was wrong

**Firecracker explainer**
- "The VM was never the slow part..." and "A request doesn't boot anything. It restores." recast as positive claims
- "which is the entire point" tail cut

Charts bumped: monolith 0.285.107, monolith-public 0.89.47.

Reviewed by an Opus pass (verdict: ship; one dead-CSS fixup). vitest 449/449 locally; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)