### PR TITLE
build(frontend): rename vite output dir to dist to stop clobbering BUILD

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.47
+version: 0.89.48
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.47
+      targetRevision: 0.89.48
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.107
+version: 0.285.108
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.107
+      targetRevision: 0.285.108
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/BUILD
+++ b/projects/monolith/frontend/BUILD
@@ -67,7 +67,10 @@ js_run_binary(
     srcs = [":src"],
     args = ["build"],
     chdir = package_name(),
-    out_dirs = ["build"],
+    # Out dir is "dist", not "build": svelte.config.js defaults there so a
+    # local vite build cannot collide with this BUILD file on macOS's
+    # case-insensitive filesystem. build_tar remaps it to /app/build.
+    out_dirs = ["dist"],
     tool = ":vite",
     visibility = ["//projects/monolith:__pkg__"],
 )

--- a/projects/monolith/frontend/svelte.config.js
+++ b/projects/monolith/frontend/svelte.config.js
@@ -7,9 +7,11 @@ const config = {
   kit: {
     // Output dir is env-parametrized so the public build (:build_public) can
     // emit to a distinct directory and avoid colliding with :build's output in
-    // the same Bazel package. Defaults to "build" for the normal build.
+    // the same Bazel package. Defaults to "dist", never "build": on a
+    // case-insensitive filesystem (macOS) an output dir named "build" collides
+    // with this package's tracked Bazel BUILD file and deletes it.
     adapter: adapter({
-      out: process.env.SVELTE_OUT_DIR || "build",
+      out: process.env.SVELTE_OUT_DIR || "dist",
       // Build-time gzip + brotli of static assets (/_app/*.js, CSS). These are
       // served by adapter-node's sirv layer BEFORE the SvelteKit handler, so the
       // hooks.server.js compression hook never sees them; precompress is how the

--- a/projects/monolith/frontend/vite.config.js
+++ b/projects/monolith/frontend/vite.config.js
@@ -15,9 +15,10 @@ export default defineConfig({
     target: "es2022",
   },
   ssr: {
-    // The runtime image ships only the SvelteKit `build/` output — there is
-    // no node_modules. Any package imported by SSR-rendered code must be
-    // bundled into the server chunks, not externalized.
+    // The runtime image ships only the SvelteKit output dir (remapped to
+    // /app/build at image time); there is no node_modules. Any package
+    // imported by SSR-rendered code must be bundled into the server chunks,
+    // not externalized.
     noExternal: [
       "@dagrejs/dagre",
       "d3-quadtree",


### PR DESCRIPTION
## What

Renames the SvelteKit adapter output dir from \`build\` to \`dist\` (the default in svelte.config.js plus the Bazel \`:build\` target's \`out_dirs\`).

## Why

On macOS's case-insensitive filesystem an output dir named \`build\` collides with the tracked Bazel \`BUILD\` file in the same package, so any local \`vite build\` deletes it. This bit two agent sessions this week.

Runtime is unchanged: \`build_tar\` / \`build_tar_public\` already remap the output to \`/app/build\` at image time, so \`apko.yaml\`'s \`node build/index.js\` keeps working. \`:build_public\` already used its own \`SVELTE_OUT_DIR\`. \`dist/\` is already gitignored at the frontend and repo level.

Charts bumped (frontend files are image inputs): monolith 0.285.108, monolith-public 0.89.48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)