### PR TITLE
fix(semgrep): send Semgrep/<version> User-Agent so the App accepts /results

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.114
+version: 0.285.115
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.114
+      targetRevision: 0.285.115
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/semgrep_scan/report.py
+++ b/projects/monolith/semgrep_scan/report.py
@@ -150,10 +150,16 @@ def _auth_headers() -> dict[str, str]:
         raise RuntimeError(
             "SEMGREP_APP_TOKEN is not set; cannot authenticate to the Semgrep App"
         )
+    from semgrep import __VERSION__
+
     return {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
         "Accept": "application/json",
+        # The App parses the semgrep version from the User-Agent and rejects the
+        # /results POST with 400 {"error":"Invalid Semgrep Version"} without it.
+        # This matches str(semgrep.app.session.UserAgent()) == "Semgrep/<ver>".
+        "User-Agent": f"Semgrep/{__VERSION__}",
     }
 
 

--- a/projects/monolith/semgrep_scan/report_test.py
+++ b/projects/monolith/semgrep_scan/report_test.py
@@ -226,9 +226,12 @@ def test_report_pr_scan_uploads_with_bearer_auth_on_every_request():
     assert len(calls) == 3
     create, results_call, complete_call = calls
 
-    # Every request carries an explicit Bearer header with the token.
+    # Every request carries an explicit Bearer header with the token, and a
+    # Semgrep/<version> User-Agent (the App rejects /results with 400
+    # "Invalid Semgrep Version" without it).
     for c in calls:
         assert c["headers"].get("Authorization") == f"Bearer {_FAKE_TOKEN}"
+        assert c["headers"].get("User-Agent", "").startswith("Semgrep/")
 
     # CREATE: correct URL + a CreateScanRequestV2 body (scan_metadata + project_metadata).
     assert create["url"].endswith("/api/cli/v2/scans")


### PR DESCRIPTION
The final fix that makes the relay land a scan on the Semgrep App.

## Bug
The App parses the semgrep version from the `User-Agent` request header (semgrep's own `AppSession` sets `User-Agent: Semgrep/<version>`). Our direct-`httpx` upload omitted it, so `/api/agent/scans/{id}/results` returned `400 {"error":"Invalid Semgrep Version"}` even though the scan was created and auth was accepted.

## Fix
Add `User-Agent: Semgrep/{__VERSION__}` to `_auth_headers()` (applied to every App request). Matches `str(semgrep.app.session.UserAgent())`.

## Proven live
With this header, the full relay against the deployed monolith returns `ok=true`, creating a real scan on the App (scan_id, findings reported, block decision returned, `error=null`). This is the end-to-end Phase 1 proof (Task 3) passing.

Test updated to assert every request carries the `Semgrep/` User-Agent alongside the Bearer header. 8/8 pass. Chart 0.285.115. Still dormant; SMS untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)