### PR TITLE
feat(semgrep): GitHub PR webhook that fires the App-reporting relay

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -811,6 +811,22 @@ py_test(
 )
 
 py_test(
+    name = "semgrep_router_test",
+    srcs = ["semgrep_scan/router_test.py"],
+    imports = ["."],
+    # gazelle:exclude semgrep_scan means this py_test is hand-added, not generated.
+    # Drives the async webhook via FastAPI TestClient (BackgroundTasks run inline
+    # after the response), mocking scan_files / report_pr_scan / httpx so no live
+    # GitHub, fc-invoke, or Semgrep App is touched.
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "sandbox_mcp_test",
     srcs = ["sandbox/mcp_test.py"],
     imports = ["."],

--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -20,6 +20,7 @@ import hikes
 import home
 import knowledge
 import scheduler
+import semgrep_scan
 import ships
 import stars
 import trips
@@ -284,6 +285,9 @@ campsites.register(app)
 worldcup.register(app)
 artifact.register(app)
 demos.register(app)
+# GitHub PR webhook -> fc-invoke scan -> Semgrep App relay (Phase 2). Registers
+# POST /webhooks/github/semgrep; HMAC-verified, no cf-access on that path.
+semgrep_scan.register(app)
 app.mount("/mcp", _mcp_app)
 
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.115
+version: 0.285.116
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -171,6 +171,31 @@ spec:
                 secretKeyRef:
                   name: {{ include "monolith.fullname" . }}-semgrep-app
                   key: SEMGREP_API_TOKEN
+            # HMAC secret for the GitHub PR webhook (semgrep_scan/router.py, Phase
+            # 2). GitHub signs the request body with it; the handler fails closed
+            # if it is unset. Lives in the SAME semgrep vault item as the App token
+            # (field GITHUB_SEMGREP_WEBHOOK_SECRET), mirrored into this Secret; Joe
+            # sets the identical value in the GitHub hook config. Optional so an
+            # older vault item without the field does not block the pod (the
+            # webhook then 401s every request, which is the fail-closed default).
+            - name: GITHUB_SEMGREP_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "monolith.fullname" . }}-semgrep-app
+                  key: GITHUB_SEMGREP_WEBHOOK_SECRET
+                  optional: true
+            {{- if .Values.chat.enabled }}
+            # Real GitHub API token for the webhook's changed-file fetch. The
+            # monolith's own GITHUB_TOKEN env is a kloak: placeholder (guest
+            # egress swap), useless for a direct API call, so we wire the REAL
+            # token (monolith-chat-secrets key GITHUB_TOKEN, the same one
+            # git-mirror uses) under a distinct env name the webhook reads.
+            - name: GITHUB_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "monolith.fullname" . }}-chat-secrets
+                  key: GITHUB_TOKEN
+            {{- end }}
             {{- end }}
             {{- if .Values.whatsapp.enabled }}
             # WhatsApp inbound bearer token (ADR 039 spec section 2). The monolith

--- a/projects/monolith/chart/templates/httproute-private.yaml
+++ b/projects/monolith/chart/templates/httproute-private.yaml
@@ -86,4 +86,33 @@ spec:
   "team" .Values.cfIngress.private.team
 }}
 {{- include "cf-ingress.security-policy" $spParams }}
+---
+# GitHub Semgrep webhook route — a SEPARATE HTTPRoute on the same private gateway
+# and hostname, carrying ONLY the webhook path and routed to the FastAPI backend
+# port. It is deliberately its own route so the cf-access SecurityPolicy above
+# (which targets the -private route as a whole) does NOT apply to it: GitHub
+# bypasses Cloudflare Access at the edge via an IP-allowlist Bypass policy and
+# sends no Access JWT, so any SecurityPolicy on this path would reject every real
+# delivery. The request is instead gated by the handler's HMAC verification. No
+# SecurityPolicy targets this route.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "monolith.fullname" . }}-github-webhook
+  labels:
+    ingress-tier: {{ .Values.cfIngress.private.tier }}
+spec:
+  parentRefs:
+    - name: {{ .Values.cfIngress.private.gateway.name }}
+      namespace: {{ .Values.cfIngress.private.gateway.namespace }}
+  hostnames:
+    - {{ .Values.cfIngress.private.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /webhooks/github/semgrep
+      backendRefs:
+        - name: {{ include "monolith.fullname" . }}
+          port: {{ .Values.service.apiPort | int }}
 {{- end }}

--- a/projects/monolith/chart/templates/onepassworditem-semgrep-app.yaml
+++ b/projects/monolith/chart/templates/onepassworditem-semgrep-app.yaml
@@ -1,4 +1,14 @@
 {{- if .Values.semgrep.onepassword.itemPath }}
+# Semgrep vault item mirrored into the monolith-semgrep-app Secret (each vault
+# field becomes a Secret key). Fields consumed by the backend:
+#   SEMGREP_API_TOKEN            - the Semgrep App token (Phase 1 relay), exposed
+#                                  to the pod as SEMGREP_APP_TOKEN.
+#   GITHUB_SEMGREP_WEBHOOK_SECRET - the HMAC secret GitHub signs PR webhook bodies
+#                                  with (Phase 2, semgrep_scan/router.py). Add this
+#                                  field to the vault item and set the identical
+#                                  value in the GitHub hook config. Injected as an
+#                                  optional secret env; while absent the webhook
+#                                  fails closed (401s every request).
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.115
+      targetRevision: 0.285.116
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/semgrep_scan/__init__.py
+++ b/projects/monolith/semgrep_scan/__init__.py
@@ -13,4 +13,21 @@ This package is deliberately NOT named ``semgrep``: a top-level ``semgrep``
 package on ``sys.path`` would shadow the pip ``semgrep`` distribution, making
 pysemgrep's internal modules (``semgrep.app.scans`` etc.) that ``report`` imports
 unresolvable. Keeping our name distinct lets both coexist.
+
+- ``router``: the GitHub PR webhook (Phase 2) that fires the scan + App relay on a
+  real ``pull_request`` event. Registered on the app like every other domain.
 """
+
+from fastapi import FastAPI
+
+
+def register(app: FastAPI) -> None:
+    """Register the semgrep webhook router with the app.
+
+    Import is local so the module (and its pysemgrep-dependent transitive imports)
+    is only pulled in when the app actually wires the router, mirroring the other
+    domains' registration.
+    """
+    from semgrep_scan.router import router
+
+    app.include_router(router)

--- a/projects/monolith/semgrep_scan/router.py
+++ b/projects/monolith/semgrep_scan/router.py
@@ -1,0 +1,299 @@
+"""GitHub PR webhook that fires the fc-invoke -> Semgrep App reporting relay.
+
+This is Phase 2 of self-hosted Semgrep CI reporting. GitHub POSTs a
+``pull_request`` webhook here on every PR open/synchronize/reopen; we verify its
+HMAC signature (fail-closed), acknowledge fast with a 200, and run the scan in a
+background task so GitHub's delivery timeout is never held on the (slow) scan.
+
+The background job gathers the PR's changed files, scans them on our own
+Firecracker VM via ``client.scan_files`` (POST to the fc-invoke ``/invoke/semgrep``
+daemon), then relays the resulting cli_output to the Semgrep AppSec Platform via
+``report.report_pr_scan`` (Phase 1, live-proven), which posts the native PR check.
+
+AUTH SURFACE (two independent secrets, both fail-closed):
+- ``GITHUB_SEMGREP_WEBHOOK_SECRET``: the HMAC secret GitHub signs the request body
+  with (``X-Hub-Signature-256: sha256=<hex>``). Unset -> every request is 401; we
+  never accept an unsigned or unverifiable webhook.
+- ``GITHUB_API_TOKEN``: a real GitHub token used to call the GitHub REST API (list
+  changed files, fetch file contents). This is NOT the monolith's ``GITHUB_TOKEN``
+  env, which is a ``kloak:`` placeholder swapped at the guest egress proxy and is
+  useless for a direct API call; the chart wires the real token
+  (``monolith-chat-secrets`` key ``GITHUB_TOKEN``, the same one git-mirror uses)
+  into this env name.
+
+The webhook path (``/webhooks/github/semgrep``) is reachable through the private
+HTTPRoute WITHOUT a Cloudflare Access SecurityPolicy: GitHub bypasses Access at
+the Cloudflare edge via an IP-allowlist Bypass policy, so its JWT-less request
+would be rejected by a SecurityPolicy. The HMAC check above is the real gate.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+import os
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request
+
+from semgrep_scan.client import scan_files
+from semgrep_scan.report import report_pr_scan
+
+logger = logging.getLogger("monolith.semgrep.webhook")
+
+router = APIRouter(prefix="/webhooks/github", tags=["semgrep-webhook"])
+
+# PR actions worth scanning: a fresh PR, a new push to an open PR, and a reopen.
+# Everything else (labeled, closed, review requests, ...) is acked with no work.
+_SCAN_ACTIONS = {"opened", "synchronize", "reopened"}
+
+# File extensions the fc-invoke semgrep guest has rules for. A changed file with
+# any other extension (or a deletion) is skipped: fetching + scanning it would be
+# wasted work the guest has no rules to match against.
+_SCANNABLE_EXTS = (".py", ".go", ".js", ".jsx", ".ts", ".tsx", ".rs")
+
+# GitHub API base + the User-Agent it requires on every request.
+_GITHUB_API = "https://api.github.com"
+_USER_AGENT = "homelab-semgrep-webhook"
+
+# Bounded page count so a pathological PR with thousands of files cannot make the
+# background job page forever. 100 items/page * 30 pages = 3000 files is plenty.
+_MAX_FILE_PAGES = 30
+_GITHUB_TIMEOUT = 30.0
+
+
+def _verify_signature(body: bytes, signature_header: str | None) -> None:
+    """Verify GitHub's ``X-Hub-Signature-256`` over the raw body, fail-closed.
+
+    GitHub signs the exact request body with HMAC-SHA256 keyed on the shared
+    secret and sends ``sha256=<hexdigest>``. We recompute and constant-time
+    compare. An unset secret denies every request (never accept an unverifiable
+    webhook), as does a missing or mismatched signature. Raises 401 on any
+    failure; returns None on success.
+    """
+    secret = os.environ.get("GITHUB_SEMGREP_WEBHOOK_SECRET", "")
+    if not secret:
+        raise HTTPException(status_code=401, detail="webhook secret not configured")
+    if not signature_header or not signature_header.startswith("sha256="):
+        raise HTTPException(status_code=401, detail="missing signature")
+    expected = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    presented = signature_header[len("sha256=") :]
+    if not hmac.compare_digest(presented, expected):
+        raise HTTPException(status_code=401, detail="invalid signature")
+
+
+def _github_headers() -> dict[str, str]:
+    """Auth + content headers for the GitHub REST API.
+
+    Uses ``GITHUB_API_TOKEN`` (the REAL token wired from monolith-chat-secrets),
+    NOT the ``kloak:`` placeholder in ``GITHUB_TOKEN``. Missing token raises so the
+    background job logs a clear cause rather than 401-ing silently on every call.
+    """
+    token = os.environ.get("GITHUB_API_TOKEN", "")
+    if not token:
+        raise RuntimeError("GITHUB_API_TOKEN is not set; cannot call the GitHub API")
+    return {
+        "Authorization": f"Bearer {token}",
+        "User-Agent": _USER_AGENT,
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def _is_scannable(path: str) -> bool:
+    """Whether ``path`` has an extension the fc-invoke semgrep guest scans."""
+    return path.endswith(_SCANNABLE_EXTS)
+
+
+async def _list_changed_files(
+    client: httpx.AsyncClient, repo: str, pr_number: int
+) -> list[str]:
+    """Return the scannable, non-removed changed-file paths for a PR (paginated).
+
+    GET /repos/{repo}/pulls/{n}/files, 100 per page, following pages until a short
+    page or the page cap. Only files whose ``status`` is not ``removed`` and whose
+    extension is scannable are kept: a deleted file has no head content to fetch,
+    and an unscannable extension has no rules.
+    """
+    paths: list[str] = []
+    for page in range(1, _MAX_FILE_PAGES + 1):
+        resp = await client.get(
+            f"{_GITHUB_API}/repos/{repo}/pulls/{pr_number}/files",
+            headers=_github_headers(),
+            params={"per_page": 100, "page": page},
+        )
+        resp.raise_for_status()
+        batch = resp.json()
+        if not batch:
+            break
+        for entry in batch:
+            path = entry.get("filename", "")
+            status = entry.get("status", "")
+            if status == "removed" or not _is_scannable(path):
+                continue
+            paths.append(path)
+        if len(batch) < 100:
+            break
+    return paths
+
+
+async def _fetch_file_content(
+    client: httpx.AsyncClient, repo: str, path: str, head_sha: str
+) -> str | None:
+    """Fetch one file's text at ``head_sha`` via the contents API, or None.
+
+    GET /repos/{repo}/contents/{path}?ref={head_sha} returns base64 ``content``;
+    we decode it to text. Returns None (and logs) on any failure so one unreadable
+    file (e.g. a symlink or a too-large blob the contents API declines to inline)
+    never aborts the whole scan.
+    """
+    try:
+        resp = await client.get(
+            f"{_GITHUB_API}/repos/{repo}/contents/{path}",
+            headers=_github_headers(),
+            params={"ref": head_sha},
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        encoded = payload.get("content")
+        if not encoded or payload.get("encoding") != "base64":
+            return None
+        return base64.b64decode(encoded).decode("utf-8", errors="replace")
+    except Exception:
+        logger.exception("failed to fetch content for %s@%s", path, head_sha)
+        return None
+
+
+async def _gather_files(repo: str, pr_number: int, head_sha: str) -> list[dict]:
+    """Build the ``[{path, content}]`` scan input for a PR's changed files.
+
+    Lists the scannable changed files then fetches each one's head content. A file
+    whose content cannot be fetched is dropped. Shares one AsyncClient across all
+    the GitHub calls.
+    """
+    files: list[dict] = []
+    timeout = httpx.Timeout(_GITHUB_TIMEOUT)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        paths = await _list_changed_files(client, repo, pr_number)
+        for path in paths:
+            content = await _fetch_file_content(client, repo, path, head_sha)
+            if content is not None:
+                files.append({"path": path, "content": content})
+    return files
+
+
+async def _scan_and_report(payload: dict[str, Any]) -> None:
+    """Background job: gather changed files, scan on fc-invoke, report to the App.
+
+    Runs after the fast 200 so GitHub's delivery never blocks on the scan. Wrapped
+    end-to-end in try/except: a failure here is logged, never crashes the app (an
+    unhandled exception in a FastAPI BackgroundTask would otherwise surface as a
+    500 for a response we already sent).
+    """
+    try:
+        pull_request = payload.get("pull_request", {})
+        repository = payload.get("repository", {})
+        repo = repository.get("full_name", "")
+        repo_url = repository.get("html_url") or None
+        pr_number = payload.get("number") or pull_request.get("number")
+        head = pull_request.get("head", {})
+        base = pull_request.get("base", {})
+        head_ref = head.get("ref", "")
+        head_sha = head.get("sha", "")
+        base_sha = base.get("sha", "")
+
+        if not (repo and pr_number and head_sha):
+            logger.warning(
+                "semgrep webhook: incomplete PR payload (repo=%r pr=%r head=%r)",
+                repo,
+                pr_number,
+                head_sha,
+            )
+            return
+
+        files = await _gather_files(repo, int(pr_number), head_sha)
+        if not files:
+            logger.info(
+                "semgrep webhook: no scannable changed files for %s#%s, nothing to do",
+                repo,
+                pr_number,
+            )
+            return
+
+        scan = await scan_files(files)
+        if not isinstance(scan, dict) or scan.get("error"):
+            logger.error(
+                "semgrep webhook: fc-invoke scan failed for %s#%s: %s",
+                repo,
+                pr_number,
+                (scan or {}).get("error") if isinstance(scan, dict) else scan,
+            )
+            return
+
+        result = await report_pr_scan(
+            repo=repo,
+            branch=head_ref,
+            commit=head_sha,
+            pr_id=str(pr_number),
+            base_ref=base_sha or None,
+            raw_cli_output=scan.get("raw_cli_output"),
+            repo_url=repo_url,
+        )
+        if result.get("ok"):
+            logger.info(
+                "semgrep webhook: reported %s#%s scan_id=%s findings=%s",
+                repo,
+                pr_number,
+                result.get("scan_id"),
+                result.get("findings_reported"),
+            )
+        else:
+            logger.error(
+                "semgrep webhook: App report failed for %s#%s: %s",
+                repo,
+                pr_number,
+                result.get("error"),
+            )
+    except Exception:
+        logger.exception("semgrep webhook: background scan/report crashed")
+
+
+@router.post("/semgrep")
+async def semgrep_webhook(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    x_hub_signature_256: str | None = Header(default=None),
+    x_github_event: str | None = Header(default=None),
+) -> dict:
+    """GitHub PR webhook entrypoint: verify, filter, fast-ack, background-scan.
+
+    1. Verify the HMAC signature over the raw body (fail-closed; 401 on any miss).
+    2. Ignore non-``pull_request`` events (including ``ping``) and unsupported
+       actions with a 200 no-op, so GitHub sees a healthy hook and does not retry.
+    3. For a scannable action, dispatch ``_scan_and_report`` as a background task
+       and return 200 immediately; the scan never blocks the response.
+    """
+    body = await request.body()
+    _verify_signature(body, x_hub_signature_256)
+
+    # Non-PR events (ping, push, issue, ...) are acknowledged with no work.
+    if x_github_event != "pull_request":
+        return {"status": "ignored", "reason": f"event={x_github_event}"}
+
+    try:
+        payload = await request.json()
+    except Exception:
+        # A pull_request event with an unparseable body is acked (not retried) but
+        # not acted on; a genuine GitHub delivery is always valid JSON.
+        logger.warning("semgrep webhook: pull_request event with unparseable body")
+        return {"status": "ignored", "reason": "unparseable body"}
+
+    action = payload.get("action", "")
+    if action not in _SCAN_ACTIONS:
+        return {"status": "ignored", "reason": f"action={action}"}
+
+    background_tasks.add_task(_scan_and_report, payload)
+    return {"status": "accepted", "action": action}

--- a/projects/monolith/semgrep_scan/router_test.py
+++ b/projects/monolith/semgrep_scan/router_test.py
@@ -1,0 +1,276 @@
+"""Tests for the GitHub PR webhook (semgrep_scan/router.py, Phase 2).
+
+Covers the security surface and the happy-path dispatch, all hermetic (no live
+GitHub, no fc-invoke, no Semgrep App):
+
+- HMAC verify, fail-closed: a valid signature is accepted; a bad, missing, or
+  unsigned request is 401; an UNSET secret is 401 (never accept).
+- Event filter: a non-``pull_request`` event (and a ``ping``) is a 200 no-op; an
+  unsupported ``action`` is a 200 no-op. Neither dispatches the scan.
+- Dispatch path: a valid ``opened`` PR event runs the background job, which lists
+  the PR's changed files, fetches only the scannable ones at the head sha, calls
+  ``scan_files`` then ``report_pr_scan``. The GitHub API (httpx), ``scan_files``,
+  and ``report_pr_scan`` are all mocked; we assert ``report_pr_scan`` is called
+  with the right PR metadata and that only scannable extensions are scanned.
+
+FastAPI's TestClient runs BackgroundTasks synchronously after the response, so
+asserting on the mocks right after the POST returns exercises the background job.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from unittest import mock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from semgrep_scan import router as webhook
+
+_SECRET = "test-webhook-secret"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """A TestClient over just the webhook router with the HMAC secret set."""
+    monkeypatch.setenv("GITHUB_SEMGREP_WEBHOOK_SECRET", _SECRET)
+    monkeypatch.setenv("GITHUB_API_TOKEN", "gh-test-token")
+    app = FastAPI()
+    app.include_router(webhook.router)
+    return TestClient(app)
+
+
+def _sign(body: bytes, secret: str = _SECRET) -> str:
+    """Compute the ``sha256=<hex>`` header GitHub would send for ``body``."""
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _pr_payload(action: str = "opened") -> dict:
+    return {
+        "action": action,
+        "number": 4242,
+        "repository": {
+            "full_name": "jomcgi/homelab",
+            "html_url": "https://github.com/jomcgi/homelab",
+        },
+        "pull_request": {
+            "number": 4242,
+            "head": {"ref": "feat/thing", "sha": "headsha123"},
+            "base": {"ref": "main", "sha": "basesha456"},
+        },
+    }
+
+
+def _post(client, payload, *, event="pull_request", secret=_SECRET, sign=True):
+    body = json.dumps(payload).encode("utf-8")
+    headers = {"X-GitHub-Event": event, "Content-Type": "application/json"}
+    if sign:
+        headers["X-Hub-Signature-256"] = _sign(body, secret)
+    return client.post("/webhooks/github/semgrep", content=body, headers=headers)
+
+
+# --- HMAC verification (fail-closed) ---------------------------------------
+
+
+def test_valid_signature_accepted_and_dispatches(client):
+    with (
+        mock.patch.object(
+            webhook, "_gather_files", new=mock.AsyncMock(return_value=[])
+        ),
+        mock.patch.object(webhook, "scan_files", new=mock.AsyncMock()) as scan,
+    ):
+        resp = _post(client, _pr_payload("opened"))
+    assert resp.status_code == 200
+    assert resp.json().get("status") == "accepted"
+    # No files gathered -> early return, scan never runs (nothing to scan).
+    scan.assert_not_awaited()
+
+
+def test_bad_signature_rejected(client):
+    resp = _post(client, _pr_payload(), secret="wrong-secret")
+    assert resp.status_code == 401
+
+
+def test_missing_signature_rejected(client):
+    resp = _post(client, _pr_payload(), sign=False)
+    assert resp.status_code == 401
+
+
+def test_unset_secret_rejected(client, monkeypatch):
+    # An unset secret must deny every request, even a well-formed one.
+    monkeypatch.delenv("GITHUB_SEMGREP_WEBHOOK_SECRET", raising=False)
+    resp = _post(client, _pr_payload())
+    assert resp.status_code == 401
+
+
+# --- Event / action filter (200 no-op, no dispatch) ------------------------
+
+
+def test_ping_event_is_noop(client):
+    with mock.patch.object(webhook, "_scan_and_report") as job:
+        resp = _post(client, {"zen": "hi"}, event="ping")
+    assert resp.status_code == 200
+    assert resp.json().get("status") == "ignored"
+    job.assert_not_called()
+
+
+def test_non_pull_request_event_is_noop(client):
+    with mock.patch.object(webhook, "_scan_and_report") as job:
+        resp = _post(client, {"ref": "refs/heads/main"}, event="push")
+    assert resp.status_code == 200
+    assert resp.json().get("status") == "ignored"
+    job.assert_not_called()
+
+
+def test_unsupported_action_is_noop(client):
+    with mock.patch.object(webhook, "_scan_and_report") as job:
+        resp = _post(client, _pr_payload("closed"))
+    assert resp.status_code == 200
+    assert resp.json().get("status") == "ignored"
+    job.assert_not_called()
+
+
+# --- Changed-files fetch -> scan -> report (all mocked) --------------------
+
+
+def _fake_github_client(files_pages, contents):
+    """Build a stand-in httpx.AsyncClient whose .get answers the two endpoints.
+
+    ``files_pages`` is the list returned by GET .../pulls/{n}/files (single page);
+    ``contents`` maps a path to its decoded text (base64-encoded in the response).
+    """
+    import base64
+
+    class _Resp:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._data
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, headers=None, params=None):
+            if url.endswith("/files"):
+                # Page 1 returns the files; any later page returns empty (stop).
+                page = (params or {}).get("page", 1)
+                return _Resp(files_pages if page == 1 else [])
+            # contents endpoint: /repos/{repo}/contents/{path}
+            path = url.split("/contents/", 1)[1]
+            text = contents[path]
+            return _Resp(
+                {
+                    "content": base64.b64encode(text.encode("utf-8")).decode("ascii"),
+                    "encoding": "base64",
+                }
+            )
+
+    return _Client()
+
+
+def test_scan_and_report_happy_path(client):
+    files_pages = [
+        {"filename": "app/main.py", "status": "modified"},
+        {"filename": "svc/handler.go", "status": "added"},
+        {"filename": "README.md", "status": "modified"},  # unscannable ext
+        {"filename": "old/gone.py", "status": "removed"},  # deleted -> skip
+    ]
+    contents = {
+        "app/main.py": "print('hi')\n",
+        "svc/handler.go": "package main\n",
+    }
+    scan_result = {"raw_cli_output": {"results": []}}
+    report_result = {"ok": True, "scan_id": 99, "findings_reported": 0}
+
+    with (
+        mock.patch.object(
+            webhook.httpx,
+            "AsyncClient",
+            return_value=_fake_github_client(files_pages, contents),
+        ),
+        mock.patch.object(
+            webhook, "scan_files", new=mock.AsyncMock(return_value=scan_result)
+        ) as scan,
+        mock.patch.object(
+            webhook,
+            "report_pr_scan",
+            new=mock.AsyncMock(return_value=report_result),
+        ) as report,
+    ):
+        resp = _post(client, _pr_payload("synchronize"))
+        assert resp.status_code == 200
+        assert resp.json().get("status") == "accepted"
+
+    # Only scannable, non-removed files were scanned (README skipped, deleted .py
+    # skipped), each with its fetched content.
+    scan.assert_awaited_once()
+    scanned = scan.await_args.args[0]
+    scanned_paths = sorted(f["path"] for f in scanned)
+    assert scanned_paths == ["app/main.py", "svc/handler.go"]
+    assert all("content" in f for f in scanned)
+
+    # report_pr_scan gets the PR metadata from the payload.
+    report.assert_awaited_once()
+    kwargs = report.await_args.kwargs
+    assert kwargs["repo"] == "jomcgi/homelab"
+    assert kwargs["branch"] == "feat/thing"
+    assert kwargs["commit"] == "headsha123"
+    assert kwargs["pr_id"] == "4242"
+    assert kwargs["base_ref"] == "basesha456"
+    assert kwargs["raw_cli_output"] == {"results": []}
+
+
+def test_scan_error_short_circuits_report(client):
+    files_pages = [{"filename": "app/main.py", "status": "modified"}]
+    contents = {"app/main.py": "print('hi')\n"}
+
+    with (
+        mock.patch.object(
+            webhook.httpx,
+            "AsyncClient",
+            return_value=_fake_github_client(files_pages, contents),
+        ),
+        mock.patch.object(
+            webhook,
+            "scan_files",
+            new=mock.AsyncMock(return_value={"error": "fc-invoke down"}),
+        ),
+        mock.patch.object(webhook, "report_pr_scan", new=mock.AsyncMock()) as report,
+    ):
+        resp = _post(client, _pr_payload("opened"))
+        assert resp.status_code == 200
+
+    # A scan error must not reach report_pr_scan.
+    report.assert_not_awaited()
+
+
+def test_no_scannable_files_skips_scan(client):
+    files_pages = [{"filename": "docs/README.md", "status": "modified"}]
+
+    with (
+        mock.patch.object(
+            webhook.httpx,
+            "AsyncClient",
+            return_value=_fake_github_client(files_pages, {}),
+        ),
+        mock.patch.object(webhook, "scan_files", new=mock.AsyncMock()) as scan,
+        mock.patch.object(webhook, "report_pr_scan", new=mock.AsyncMock()) as report,
+    ):
+        resp = _post(client, _pr_payload("opened"))
+        assert resp.status_code == 200
+
+    scan.assert_not_awaited()
+    report.assert_not_awaited()


### PR DESCRIPTION
Phase 2 of self-hosted Semgrep CI reporting: wires the live-proven relay to real PRs. Parallel to SMS (no cutover yet).

## Flow
GitHub `pull_request` (opened/synchronize/reopened) → `POST /webhooks/github/semgrep` → HMAC-verify `X-Hub-Signature-256` (fail-closed) → 200 ACK + background task → fetch changed files via GitHub API → `scan_files` (fc-invoke) → `report_pr_scan` (proven relay) → scan on the App.

## Pieces
- **HTTPRoute** `monolith-github-webhook`: SEPARATE private route for `/webhooks/github/semgrep` → apiPort, NO cf-access SecurityPolicy (the shared `monolith-private` route is JWT-gated; GitHub bypasses Access at the edge via IP-allowlist). HMAC is the real gate.
- **Handler** `semgrep_scan/router.py`: GitHub HMAC (recompute over raw body, constant-time compare, 401 on unset/missing/mismatch), event filter, fast ACK + background scan.
- **Secrets**: new `GITHUB_SEMGREP_WEBHOOK_SECRET` (fail-closed if absent), `GITHUB_API_TOKEN` rewired to the real `monolith-chat-secrets` token.
- Router registered in `app/main.py`. 10 hermetic tests pass. Chart 0.285.116.

## Post-merge (Joe)
Add `GITHUB_SEMGREP_WEBHOOK_SECRET` to 1Password (semgrep-mcp item) + register the GitHub `pull_request` hook at `https://private.jomcgi.dev/webhooks/github/semgrep` with the same secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)