### PR TITLE
feat(semgrep): shadow project + route-b/semgrep commit status for SMS comparison

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.116
+version: 0.285.117
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -90,6 +90,13 @@ spec:
             - name: FC_INVOKE_URL
               value: {{ .Values.semgrep.fcInvokeUrl | quote }}
             {{- end }}
+            {{- if .Values.semgrep.shadowProject }}
+            # Route B shadow project: the relay reports App scans under this name
+            # instead of the real repo, keeping self-hosted scans in a separate
+            # Semgrep project from SMS for comparison. Unset at cutover.
+            - name: SEMGREP_SHADOW_PROJECT
+              value: {{ .Values.semgrep.shadowProject | quote }}
+            {{- end }}
             {{- if .Values.goosecracker.tiers }}
             - name: GOOSECRACKER_TIERS
               value: {{ .Values.goosecracker.tiers | toJson | quote }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -724,6 +724,13 @@ chat:
 # deploy/values.yaml; never hardcode it in a template.
 semgrep:
   fcInvokeUrl: ""
+  # Shadow project override (Route B vs SMS comparison): when set, the relay
+  # reports its App scans under THIS project name instead of the real repo, so
+  # Route B (self-hosted) scans land in a SEPARATE Semgrep project from SMS's
+  # jomcgi/homelab project. Injected as SEMGREP_SHADOW_PROJECT; empty (the
+  # cutover state) makes Route B report to the real project. Plain value, not a
+  # secret.
+  shadowProject: ""
   # Semgrep AppSec Platform reporting (Route B, self-hosted CI reporting): the
   # relay (semgrep_scan/report.py) uploads fc-invoke findings using pysemgrep's
   # own client, authenticated by SEMGREP_APP_TOKEN. Set onepassword.itemPath in

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.116
+      targetRevision: 0.285.117
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -151,6 +151,10 @@ chat:
 # semgrep_scan MCP tool: the in-cluster fc-invoke daemon endpoint.
 semgrep:
   fcInvokeUrl: "http://fc-invoke.monolith.svc.cluster.local:8080"
+  # Route B shadow project (Route B vs SMS comparison): self-hosted scans report
+  # here instead of jomcgi/homelab, so they land in a separate Semgrep project.
+  # UNSET this single value at cutover to report to the real project.
+  shadowProject: "jomcgi/homelab-selfhosted"
   # Semgrep AppSec Platform token for the Route B CI-reporting relay. The vault
   # item exposes the field SEMGREP_API_TOKEN, mirrored into the
   # monolith-semgrep-app Secret and injected as the SEMGREP_APP_TOKEN env var

--- a/projects/monolith/semgrep_scan/report.py
+++ b/projects/monolith/semgrep_scan/report.py
@@ -386,6 +386,22 @@ def _build_scan_metadata() -> Any:
     )
 
 
+def _reported_repository(repo: str) -> str:
+    """Resolve the ``repository`` name the App scan lands under.
+
+    When ``SEMGREP_SHADOW_PROJECT`` is set and non-empty we report under that
+    SHADOW project name (e.g. ``jomcgi/homelab-selfhosted``) instead of the real
+    ``repo``, so Route B (self-hosted) scans land in a SEPARATE Semgrep project
+    from SMS's ``jomcgi/homelab`` project and the two can be compared side by
+    side. Unset (the cutover state) falls back to the real ``repo`` so Route B
+    reports to the real project with no code change.
+    """
+    shadow = os.environ.get("SEMGREP_SHADOW_PROJECT")
+    if shadow and shadow.strip():
+        return shadow.strip()
+    return repo
+
+
 def _build_project_metadata(
     *,
     repo: str,
@@ -401,12 +417,16 @@ def _build_project_metadata(
     We build it directly (rather than via ``semgrep.meta`` git helpers) because
     the monolith is not running inside the scanned git checkout; all the PR facts
     come from the webhook payload the caller passes in.
+
+    The ``repository`` value comes from ``_reported_repository(repo)``: with
+    ``SEMGREP_SHADOW_PROJECT`` set it is the shadow project name, not the real
+    ``repo``, so these scans land in a separate Semgrep project for comparison.
     """
     import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 
     payload: dict[str, Any] = {
         "scan_environment": SCAN_ENVIRONMENT,
-        "repository": repo,
+        "repository": _reported_repository(repo),
         "repo_url": repo_url,
         "branch": branch,
         "commit": commit,
@@ -540,6 +560,14 @@ async def report_pr_scan(
     ``/complete`` POSTs entirely. Used by tests and any caller that wants to
     assemble the payload without touching the live App.
     """
+    # The repository the App scan lands under (the shadow project when
+    # SEMGREP_SHADOW_PROJECT is set, else the real repo), surfaced so the webhook
+    # can build the App scan URL for its commit status. ``org`` is the owner
+    # segment of the reported project (jomcgi for jomcgi/homelab-selfhosted); the
+    # App scan URL is scoped by org, not by repo.
+    reported_project = _reported_repository(repo)
+    org = reported_project.split("/", 1)[0] if "/" in reported_project else "jomcgi"
+
     result: dict[str, Any] = {
         "ok": False,
         "dry_run": dry_run,
@@ -549,6 +577,10 @@ async def report_pr_scan(
         "app_block_reason": "",
         "app_blocking_match_based_ids": [],
         "error": None,
+        # The Semgrep project + org the scan was reported under (shadow-aware), so
+        # the caller can build the App scan URL without re-reading the env.
+        "project": reported_project,
+        "org": org,
     }
 
     commit_date_iso = datetime.fromtimestamp(int(time.time())).isoformat()

--- a/projects/monolith/semgrep_scan/report_test.py
+++ b/projects/monolith/semgrep_scan/report_test.py
@@ -294,6 +294,56 @@ def test_report_pr_scan_closes_scan_on_upload_failure():
     assert any(u.endswith("/api/agent/scans/777/error") for u in posted)
 
 
+def test_shadow_project_overrides_reported_repository():
+    """With SEMGREP_SHADOW_PROJECT set, the project_metadata repository is the
+    SHADOW project (so Route B scans land in a separate Semgrep project), NOT the
+    real repo. Unset -> the real repo. Also asserts report_pr_scan surfaces the
+    reported project + org in its return dict."""
+    with mock.patch.dict(
+        "os.environ", {"SEMGREP_SHADOW_PROJECT": "jomcgi/homelab-selfhosted"}
+    ):
+        pm = report._build_project_metadata(
+            repo="jomcgi/homelab",
+            branch="feat/test",
+            commit="0" * 40,
+            pr_id="42",
+            base_ref=None,
+            project_id=None,
+            repo_url=None,
+        )
+        assert pm.to_json()["repository"] == "jomcgi/homelab-selfhosted"
+        # dry_run surfaces the reported project + derived org without any network.
+        result = _run_scan(dry_run=True)
+        assert result["project"] == "jomcgi/homelab-selfhosted"
+        assert result["org"] == "jomcgi"
+
+
+def test_unset_shadow_project_uses_real_repo():
+    """Unset (or empty) SEMGREP_SHADOW_PROJECT falls back to the real repo, the
+    cutover state where Route B reports to the real project."""
+    with mock.patch.dict("os.environ", {}, clear=False):
+        os.environ.pop("SEMGREP_SHADOW_PROJECT", None)
+        pm = report._build_project_metadata(
+            repo="jomcgi/homelab",
+            branch="feat/test",
+            commit="0" * 40,
+            pr_id="42",
+            base_ref=None,
+            project_id=None,
+            repo_url=None,
+        )
+        assert pm.to_json()["repository"] == "jomcgi/homelab"
+        result = _run_scan(dry_run=True)
+        assert result["project"] == "jomcgi/homelab"
+        assert result["org"] == "jomcgi"
+
+
+def test_empty_shadow_project_uses_real_repo():
+    """An empty/whitespace SEMGREP_SHADOW_PROJECT is treated as unset."""
+    with mock.patch.dict("os.environ", {"SEMGREP_SHADOW_PROJECT": "  "}):
+        assert report._reported_repository("jomcgi/homelab") == "jomcgi/homelab"
+
+
 def test_missing_token_surfaces_structured_error_not_process_death():
     """With no SEMGREP_APP_TOKEN the CREATE cannot build auth; the relay must
     return a structured error (never raise into the caller / kill the process)."""

--- a/projects/monolith/semgrep_scan/router.py
+++ b/projects/monolith/semgrep_scan/router.py
@@ -34,7 +34,9 @@ import hashlib
 import hmac
 import logging
 import os
+import time
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request
@@ -185,6 +187,70 @@ async def _gather_files(repo: str, pr_number: int, head_sha: str) -> list[dict]:
     return files
 
 
+# The commit-status context string GitHub shows on the PR. Namespaced so it is
+# obviously the self-hosted Route B signal and never collides with SMS's native
+# Semgrep check.
+_STATUS_CONTEXT = "route-b/semgrep"
+
+
+def _app_scan_url(org: str, project: str, scan_id: Any) -> str:
+    """Best-effort App URL for a Route B scan, for the status ``target_url``.
+
+    The App scans live under an org-scoped project slug. We url-encode the project
+    (it contains a ``/``, e.g. ``jomcgi/homelab-selfhosted``) so it is one path
+    segment. ASSUMPTION: this ``.../projects/{project}/scans/{scan_id}`` shape is
+    the shadow-project scan URL; it is a convenience link, not load-bearing, so a
+    format drift only breaks the click-through, never the scan itself.
+    """
+    return (
+        f"https://semgrep.dev/orgs/{org}/projects/"
+        f"{quote(project, safe='')}/scans/{scan_id}"
+    )
+
+
+async def _post_commit_status(
+    *,
+    repo: str,
+    head_sha: str,
+    state: str,
+    description: str,
+    target_url: str | None,
+) -> None:
+    """POST a GitHub commit status to the REAL repo's PR head sha, best-effort.
+
+    Route B is in a VALIDATION (non-gating) phase, so we surface findings + latency
+    as our own commit status on the real repo (a PAT with repo scope can post
+    statuses even though it cannot create Check Runs, which is why we use statuses
+    and not a Check Run). The status is posted to ``{real_repo}`` (from the webhook
+    ``repository.full_name``), NOT the shadow project the App report used.
+
+    A status failure must NEVER crash the scan job, so the whole POST is wrapped in
+    try/except and only logged. GitHub caps ``description`` at 140 chars.
+    """
+    try:
+        body: dict[str, Any] = {
+            "state": state,
+            "context": _STATUS_CONTEXT,
+            "description": description[:140],
+        }
+        if target_url:
+            body["target_url"] = target_url
+        async with httpx.AsyncClient(timeout=httpx.Timeout(_GITHUB_TIMEOUT)) as client:
+            resp = await client.post(
+                f"{_GITHUB_API}/repos/{repo}/statuses/{head_sha}",
+                headers=_github_headers(),
+                json=body,
+            )
+            resp.raise_for_status()
+    except Exception:
+        logger.exception(
+            "semgrep webhook: failed to post %s commit status to %s@%s",
+            _STATUS_CONTEXT,
+            repo,
+            head_sha,
+        )
+
+
 async def _scan_and_report(payload: dict[str, Any]) -> None:
     """Background job: gather changed files, scan on fc-invoke, report to the App.
 
@@ -223,6 +289,11 @@ async def _scan_and_report(payload: dict[str, Any]) -> None:
             )
             return
 
+        # Wall-clock timer around the scan + report: the in-cluster (SigNoz-
+        # queryable, via the structured log below) latency signal for comparing
+        # Route B against SMS.
+        started = time.monotonic()
+
         scan = await scan_files(files)
         if not isinstance(scan, dict) or scan.get("error"):
             logger.error(
@@ -242,20 +313,50 @@ async def _scan_and_report(payload: dict[str, Any]) -> None:
             raw_cli_output=scan.get("raw_cli_output"),
             repo_url=repo_url,
         )
-        if result.get("ok"):
+        latency = time.monotonic() - started
+
+        scan_id = result.get("scan_id")
+        findings = result.get("findings_reported")
+        project = result.get("project", repo)
+        org = result.get("org", "jomcgi")
+
+        if result.get("ok") and scan_id:
             logger.info(
-                "semgrep webhook: reported %s#%s scan_id=%s findings=%s",
+                "semgrep webhook: reported %s#%s scan_id=%s findings=%s "
+                "latency=%.2fs project=%s",
                 repo,
                 pr_number,
-                result.get("scan_id"),
-                result.get("findings_reported"),
+                scan_id,
+                findings,
+                latency,
+                project,
+            )
+            # VALIDATION phase: non-gating, always "success". At cutover this maps
+            # result["app_block_override"] -> "failure" else "success".
+            await _post_commit_status(
+                repo=repo,
+                head_sha=head_sha,
+                state="success",
+                description=f"{findings} findings, {latency:.1f}s",
+                target_url=_app_scan_url(org, project, scan_id),
             )
         else:
+            error = result.get("error")
             logger.error(
-                "semgrep webhook: App report failed for %s#%s: %s",
+                "semgrep webhook: App report failed for %s#%s: %s (latency=%.2fs)",
                 repo,
                 pr_number,
-                result.get("error"),
+                error,
+                latency,
+            )
+            # Report failed (no scan_id / not ok): surface it as an error status
+            # with no target_url (there is no App scan to link to).
+            await _post_commit_status(
+                repo=repo,
+                head_sha=head_sha,
+                state="error",
+                description=f"report failed: {error}",
+                target_url=None,
             )
     except Exception:
         logger.exception("semgrep webhook: background scan/report crashed")

--- a/projects/monolith/semgrep_scan/router_test.py
+++ b/projects/monolith/semgrep_scan/router_test.py
@@ -138,11 +138,14 @@ def test_unsupported_action_is_noop(client):
 # --- Changed-files fetch -> scan -> report (all mocked) --------------------
 
 
-def _fake_github_client(files_pages, contents):
-    """Build a stand-in httpx.AsyncClient whose .get answers the two endpoints.
+def _fake_github_client(files_pages, contents, *, status_calls=None, post_raises=False):
+    """Build a stand-in httpx.AsyncClient answering GitHub's GET + status POST.
 
     ``files_pages`` is the list returned by GET .../pulls/{n}/files (single page);
     ``contents`` maps a path to its decoded text (base64-encoded in the response).
+    ``status_calls`` (optional list) captures each commit-status POST as
+    ``{"url": ..., "json": ...}``. ``post_raises=True`` makes the status POST
+    explode, to prove a status failure never crashes the scan job.
     """
     import base64
 
@@ -178,6 +181,13 @@ def _fake_github_client(files_pages, contents):
                 }
             )
 
+        async def post(self, url, headers=None, json=None):
+            if status_calls is not None:
+                status_calls.append({"url": url, "json": json})
+            if post_raises:
+                raise RuntimeError("status POST exploded")
+            return _Resp({})
+
     return _Client()
 
 
@@ -193,13 +203,22 @@ def test_scan_and_report_happy_path(client):
         "svc/handler.go": "package main\n",
     }
     scan_result = {"raw_cli_output": {"results": []}}
-    report_result = {"ok": True, "scan_id": 99, "findings_reported": 0}
+    report_result = {
+        "ok": True,
+        "scan_id": 99,
+        "findings_reported": 3,
+        "project": "jomcgi/homelab-selfhosted",
+        "org": "jomcgi",
+    }
+    status_calls: list[dict] = []
 
     with (
         mock.patch.object(
             webhook.httpx,
             "AsyncClient",
-            return_value=_fake_github_client(files_pages, contents),
+            return_value=_fake_github_client(
+                files_pages, contents, status_calls=status_calls
+            ),
         ),
         mock.patch.object(
             webhook, "scan_files", new=mock.AsyncMock(return_value=scan_result)
@@ -213,6 +232,18 @@ def test_scan_and_report_happy_path(client):
         resp = _post(client, _pr_payload("synchronize"))
         assert resp.status_code == 200
         assert resp.json().get("status") == "accepted"
+
+    # A route-b/semgrep commit status was posted to the REAL repo's head sha, with
+    # a success state and a description carrying the findings count.
+    assert len(status_calls) == 1
+    status = status_calls[0]
+    assert status["url"].endswith("/repos/jomcgi/homelab/statuses/headsha123")
+    assert status["json"]["context"] == "route-b/semgrep"
+    assert status["json"]["state"] == "success"
+    assert "3 findings" in status["json"]["description"]
+    # target_url links to the SHADOW project scan in the App (url-encoded slug).
+    assert "jomcgi%2Fhomelab-selfhosted" in status["json"]["target_url"]
+    assert status["json"]["target_url"].endswith("/scans/99")
 
     # Only scannable, non-removed files were scanned (README skipped, deleted .py
     # skipped), each with its fetched content.
@@ -255,6 +286,80 @@ def test_scan_error_short_circuits_report(client):
 
     # A scan error must not reach report_pr_scan.
     report.assert_not_awaited()
+
+
+def test_commit_status_failure_does_not_crash_scan_job(client):
+    """A failing commit-status POST must be swallowed (logged, not raised): the
+    background scan job completes without propagating the error."""
+    files_pages = [{"filename": "app/main.py", "status": "modified"}]
+    contents = {"app/main.py": "print('hi')\n"}
+    report_result = {
+        "ok": True,
+        "scan_id": 42,
+        "findings_reported": 1,
+        "project": "jomcgi/homelab-selfhosted",
+        "org": "jomcgi",
+    }
+
+    with (
+        mock.patch.object(
+            webhook.httpx,
+            "AsyncClient",
+            return_value=_fake_github_client(files_pages, contents, post_raises=True),
+        ),
+        mock.patch.object(
+            webhook,
+            "scan_files",
+            new=mock.AsyncMock(return_value={"raw_cli_output": {"results": []}}),
+        ),
+        mock.patch.object(
+            webhook,
+            "report_pr_scan",
+            new=mock.AsyncMock(return_value=report_result),
+        ),
+    ):
+        # TestClient runs the BackgroundTask synchronously; if the status failure
+        # were not swallowed this POST would surface a 500.
+        resp = _post(client, _pr_payload("opened"))
+        assert resp.status_code == 200
+        assert resp.json().get("status") == "accepted"
+
+
+def test_report_failure_posts_error_status(client):
+    """When report_pr_scan returns not-ok (no scan_id), the webhook posts an
+    error-state status with the failure in the description and no target_url."""
+    files_pages = [{"filename": "app/main.py", "status": "modified"}]
+    contents = {"app/main.py": "print('hi')\n"}
+    report_result = {"ok": False, "scan_id": None, "error": "App exploded"}
+    status_calls: list[dict] = []
+
+    with (
+        mock.patch.object(
+            webhook.httpx,
+            "AsyncClient",
+            return_value=_fake_github_client(
+                files_pages, contents, status_calls=status_calls
+            ),
+        ),
+        mock.patch.object(
+            webhook,
+            "scan_files",
+            new=mock.AsyncMock(return_value={"raw_cli_output": {"results": []}}),
+        ),
+        mock.patch.object(
+            webhook,
+            "report_pr_scan",
+            new=mock.AsyncMock(return_value=report_result),
+        ),
+    ):
+        resp = _post(client, _pr_payload("opened"))
+        assert resp.status_code == 200
+
+    assert len(status_calls) == 1
+    status = status_calls[0]
+    assert status["json"]["state"] == "error"
+    assert "App exploded" in status["json"]["description"]
+    assert "target_url" not in status["json"]
 
 
 def test_no_scannable_files_skips_scan(client):


### PR DESCRIPTION
Makes Route B runnable on every PR diff scan with clean metrics to compare against SMS, without a second GitHub org.

## What
- **Shadow project**: `SEMGREP_SHADOW_PROJECT` (set to `jomcgi/homelab-selfhosted`) overrides the reported `repository`, so Route B scans land in a SEPARATE Semgrep project from SMS's `jomcgi/homelab`. Semgrep auto-creates the project on first scan. Unset it at cutover to report to the real project.
- **Per-PR comparison status**: the webhook posts a `route-b/semgrep` commit status on the PR head sha (`state=success` for now; validation, non-gating) with `description="{findings} findings, {latency:.1f}s"` and a `target_url` to the Route B scan in the App. Renders on the PR next to SMS's native check. Uses the PAT (statuses work with a PAT; Check Runs would need a GitHub App).
- **Latency signal**: the success log now includes `latency=…s project=…` (SigNoz-queryable; no OTEL helper existed to reuse).

Real repo (status target) and shadow project (App report) are kept distinct. Status POST is fail-safe (never crashes the scan job).

23 tests pass. Chart 0.285.117. Still parallel to SMS (non-gating).

## Result
Every PR gets: an SMS scan (`homelab` project + native check) and a Route B scan (`homelab-selfhosted` project + `route-b/semgrep` status), so findings + latency compare side by side on the dashboards and on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)