### PR TITLE
feat(inference): enable vLLM automatic prefix caching via FlashInfer

### DIFF
--- a/projects/inference/deploy/Chart.yaml
+++ b/projects/inference/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inference
 description: A Helm chart for LLM inference (vLLM LLM serving + llama.cpp CPU embeddings)
 type: application
-version: 2.5.4
+version: 2.5.5
 appVersion: "b5270"
 keywords:
   - llm

--- a/projects/inference/deploy/templates/deployment.yaml
+++ b/projects/inference/deploy/templates/deployment.yaml
@@ -40,6 +40,11 @@ spec:
         - name: llama-server
           image: "{{ .Values.image.vllm.repository }}:{{ .Values.image.vllm.tag }}"
           imagePullPolicy: {{ .Values.image.vllm.pullPolicy }}
+          env:
+            {{- range $k, $v := .Values.vllm.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           command: ["/bin/sh", "-c"]

--- a/projects/inference/deploy/values.yaml
+++ b/projects/inference/deploy/values.yaml
@@ -218,6 +218,17 @@ vllm:
     - "8"
     - "--kv-cache-dtype"
     - "fp8"
+    # FlashInfer (below) supports fp8 KV cache + automatic prefix caching
+    # together on CUDA; the default FlashAttention-2 backend silently disables
+    # APC when kv-cache-dtype is fp8. Multi-turn chat re-prefills full history
+    # today and goose agents share an identical tool-def prefix, so this is a
+    # real TTFT win at no extra VRAM cost (APC reuses the existing KV pool).
+    - "--enable-prefix-caching"
+  # Selects the FlashInfer attention backend (see extraArgs comment above).
+  # FlashInfer ships in the official vllm/vllm-openai:v0.19.1 image already,
+  # so no image rebuild is needed.
+  env:
+    VLLM_ATTENTION_BACKEND: FLASHINFER
 
 runtimeClassName: nvidia
 


### PR DESCRIPTION
fp8 KV cache auto-disables automatic prefix caching (APC) on the default FlashAttention-2 backend (confirmed live: `enable_prefix_caching=False`, 0% hit rate). This switches the attention backend to FlashInfer (supports fp8 KV cache + APC together on CUDA) and enables prefix caching, keeping fp8 KV cache and the existing `vllm/vllm-openai:v0.19.1` image (FlashInfer already ships in it, no rebuild).

## Changes

- `projects/inference/deploy/values.yaml`: `--enable-prefix-caching` in `vllm.extraArgs`, plus `vllm.env` map setting `VLLM_ATTENTION_BACKEND: FLASHINFER`.
- `projects/inference/deploy/templates/deployment.yaml`: `env:` block ranging over `.Values.vllm.env`.
- `projects/inference/deploy/Chart.yaml`: `2.5.4 -> 2.5.5` (this project deploys via `targetRevision: HEAD`, so only `Chart.yaml` needs bumping).

## Deploy note

`strategy: Recreate` means the rollout causes a **brief inference outage**. Merging now with an eye on the rollout, per Joe's go-ahead. Rollback path: revert this commit, or fall back to `--enforce-eager` / trim `gpuMemoryUtilization` 0.95 -> 0.93 if FlashInfer's workspace buffer doesn't fit the 24GB 4090.

## Why this is a new PR

Forward-port of #3220 onto the rewritten public `main` (original branch orphaned by the history clear). #3220 will be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDzvRX7kgCq61tF1hR5mXj)_