### PR TITLE
revert(inference): roll back vLLM FlashInfer prefix caching (engine crashloop)

### DIFF
--- a/projects/inference/deploy/Chart.yaml
+++ b/projects/inference/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inference
 description: A Helm chart for LLM inference (vLLM LLM serving + llama.cpp CPU embeddings)
 type: application
-version: 2.5.5
+version: 2.5.4
 appVersion: "b5270"
 keywords:
   - llm

--- a/projects/inference/deploy/templates/deployment.yaml
+++ b/projects/inference/deploy/templates/deployment.yaml
@@ -40,11 +40,6 @@ spec:
         - name: llama-server
           image: "{{ .Values.image.vllm.repository }}:{{ .Values.image.vllm.tag }}"
           imagePullPolicy: {{ .Values.image.vllm.pullPolicy }}
-          env:
-            {{- range $k, $v := .Values.vllm.env }}
-            - name: {{ $k }}
-              value: {{ $v | quote }}
-            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           command: ["/bin/sh", "-c"]

--- a/projects/inference/deploy/values.yaml
+++ b/projects/inference/deploy/values.yaml
@@ -218,17 +218,6 @@ vllm:
     - "8"
     - "--kv-cache-dtype"
     - "fp8"
-    # FlashInfer (below) supports fp8 KV cache + automatic prefix caching
-    # together on CUDA; the default FlashAttention-2 backend silently disables
-    # APC when kv-cache-dtype is fp8. Multi-turn chat re-prefills full history
-    # today and goose agents share an identical tool-def prefix, so this is a
-    # real TTFT win at no extra VRAM cost (APC reuses the existing KV pool).
-    - "--enable-prefix-caching"
-  # Selects the FlashInfer attention backend (see extraArgs comment above).
-  # FlashInfer ships in the official vllm/vllm-openai:v0.19.1 image already,
-  # so no image rebuild is needed.
-  env:
-    VLLM_ATTENTION_BACKEND: FLASHINFER
 
 runtimeClassName: nvidia
 


### PR DESCRIPTION
Reverts the FlashInfer/APC change (merged as #3380) because it crashloops the vLLM engine on our 4090.

## What happened

After merge, the `Recreate`-strategy rollout replaced the working pod, and the new pod fails engine init and crashloops (`0/1`, restarts climbing). The pod logs show FlashInfer is selected as intended, but engine init then dies in vLLM's **torch.compile / inductor `PiecewiseBackend`** compilation:

```
[cuda.py:334] Using FLASHINFER attention backend out of potential backends: ['FLASHINFER', 'TRITON_ATTN'].
...
[backends.py] compile -> piecewise_backend.py:265 compile_all_ranges -> compiler_manager.compile
RuntimeError: Engine core initialization failed. See root cause above.
```

Both pod instances crash identically at this step, so it's deterministic, not a transient. This is not the FlashInfer workspace-buffer OOM the PR anticipated; it's a compile-path incompatibility between the FlashInfer backend and the model's `torch.compile`/cudagraph init in `v0.19.1`.

Because inference is down cluster-wide during the crashloop (chat, goose, grimoire all depend on it), this is a straight rollback rather than a forward-fix, per Joe's "rollback if there's an issue" instruction.

## Restores

Original FlashAttention-2 config (no `VLLM_ATTENTION_BACKEND` env, no `--enable-prefix-caching`), Chart back to 2.5.4. ArgoCD tracks `targetRevision: HEAD`, so merging redeploys the working config immediately.

## Follow-up

APC is still worth pursuing. A forward-fix would pair FlashInfer with `--enforce-eager` (disables the failing torch.compile path) or try the `TRITON_ATTN` backend, validated in a low-traffic window before re-enabling. Not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDzvRX7kgCq61tF1hR5mXj)_