### PR TITLE
feat(monolith): split semgrep webhook timing into scan_execution_duration + scan_pr_wall_time

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.120
+version: 0.285.121
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.120
+      targetRevision: 0.285.121
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/semgrep_scan/report.py
+++ b/projects/monolith/semgrep_scan/report.py
@@ -339,13 +339,21 @@ def _build_ci_scan_results(
     return ci_scan_results, len(findings)
 
 
-def _build_ci_scan_complete(findings_count: int) -> Any:
+def _build_ci_scan_complete(
+    findings_count: int, scan_execution_duration: Optional[float] = None
+) -> Any:
     """Assemble the ``out.CiScanComplete`` payload POSTed to ``/complete``.
 
     Only the fields the App needs to finalize a diff scan are populated; error
     lists and parse-rate stats are empty (we did not run the parser here, the
     guest did). ``exit_code`` is the CLI hint (non-zero when there are findings);
     the App applies its own policy to decide blocking.
+
+    ``scan_execution_duration`` (seconds) is the engine scan time measured by the
+    webhook around the fc-invoke call; it populates ``stats.total_time`` so the
+    App's scan-time column reflects the real engine duration instead of a
+    hardcoded 0. ``None`` (e.g. dry-run callers that never timed a scan) falls
+    back to 0.0.
     """
     import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 
@@ -356,7 +364,7 @@ def _build_ci_scan_complete(findings_count: int) -> Any:
         stats=out.CiScanCompleteStats(
             findings=findings_count,
             errors=[],
-            total_time=0.0,
+            total_time=float(scan_execution_duration or 0.0),
             unsupported_exts={},
             lockfile_scan_info={},
             parse_rate={},
@@ -539,6 +547,7 @@ async def report_pr_scan(
     raw_cli_output: dict[str, Any] | str,
     project_id: Optional[str] = None,
     repo_url: Optional[str] = None,
+    scan_execution_duration: Optional[float] = None,
     dry_run: bool = False,
 ) -> dict[str, Any]:
     """Report an fc-invoke PR scan to the Semgrep App, built from cli_output.
@@ -549,7 +558,9 @@ async def report_pr_scan(
     returns the App's block decision. Every request carries an explicit
     ``Authorization: Bearer $SEMGREP_APP_TOKEN`` header. ``raw_cli_output`` may be
     the already-parsed cli_output ``dict`` (the real fc-invoke client shape) or the
-    raw JSON ``str``.
+    raw JSON ``str``. ``scan_execution_duration`` (seconds), when passed, is the
+    engine scan time the webhook measured around fc-invoke; it is reported as the
+    App scan's ``total_time`` (else the App shows 0 for a self-reported scan).
 
     On ANY failure after the scan is opened it POSTs ``/error`` in the exception
     path so the App never wedges the PR check on an open scan. ``SEMGREP_APP_TOKEN``
@@ -595,7 +606,7 @@ async def report_pr_scan(
         return result
 
     result["findings_reported"] = findings_count
-    complete = _build_ci_scan_complete(findings_count)
+    complete = _build_ci_scan_complete(findings_count, scan_execution_duration)
 
     project_metadata = _build_project_metadata(
         repo=repo,

--- a/projects/monolith/semgrep_scan/report_test.py
+++ b/projects/monolith/semgrep_scan/report_test.py
@@ -138,7 +138,7 @@ def _mock_response(payload: dict) -> mock.Mock:
     return resp
 
 
-def _run_scan(dry_run: bool = False):
+def _run_scan(dry_run: bool = False, scan_execution_duration: float | None = 1.25):
     return asyncio.run(
         report.report_pr_scan(
             repo="jomcgi/homelab",
@@ -149,9 +149,17 @@ def _run_scan(dry_run: bool = False):
             raw_cli_output=_CLI_OUTPUT,
             project_id="3263658",
             repo_url="https://github.com/jomcgi/homelab",
+            scan_execution_duration=scan_execution_duration,
             dry_run=dry_run,
         )
     )
+
+
+def test_ci_scan_complete_total_time_from_duration():
+    """total_time carries the passed engine duration, and None falls back to 0.0
+    (dry-run / legacy callers that never timed a scan)."""
+    assert report._build_ci_scan_complete(3, 2.5).stats.total_time == 2.5
+    assert report._build_ci_scan_complete(0, None).stats.total_time == 0.0
 
 
 def test_report_pr_scan_dry_run_does_no_network():
@@ -249,9 +257,11 @@ def test_report_pr_scan_uploads_with_bearer_auth_on_every_request():
         results_call["json"]["findings"][0]["match_based_id"] == _EXPECTED_FINGERPRINT
     )
 
-    # /complete: scan_id in URL + a CiScanComplete body.
+    # /complete: scan_id in URL + a CiScanComplete body. total_time carries the
+    # measured engine duration (_run_scan passes 1.25s), not the old hardcoded 0.
     assert complete_call["url"].endswith("/api/agent/scans/555/complete")
     assert complete_call["json"]["stats"]["findings"] == _EXPECTED_FINDINGS
+    assert complete_call["json"]["stats"]["total_time"] == 1.25
 
 
 def test_report_pr_scan_closes_scan_on_upload_failure():

--- a/projects/monolith/semgrep_scan/router.py
+++ b/projects/monolith/semgrep_scan/router.py
@@ -218,8 +218,9 @@ async def _post_commit_status(
 ) -> None:
     """POST a GitHub commit status to the REAL repo's PR head sha, best-effort.
 
-    Route B is in a VALIDATION (non-gating) phase, so we surface findings + latency
-    as our own commit status on the real repo (a PAT with repo scope can post
+    Route B is in a VALIDATION (non-gating) phase, so we surface findings +
+    scan_pr_wall_time as our own commit status on the real repo (a PAT with repo
+    scope can post
     statuses even though it cannot create Check Runs, which is why we use statuses
     and not a Check Run). The status is posted to ``{real_repo}`` (from the webhook
     ``repository.full_name``), NOT the shadow project the App report used.
@@ -251,13 +252,28 @@ async def _post_commit_status(
         )
 
 
-async def _scan_and_report(payload: dict[str, Any]) -> None:
+async def _scan_and_report(payload: dict[str, Any], received: float) -> None:
     """Background job: gather changed files, scan on fc-invoke, report to the App.
 
     Runs after the fast 200 so GitHub's delivery never blocks on the scan. Wrapped
     end-to-end in try/except: a failure here is logged, never crashes the app (an
     unhandled exception in a FastAPI BackgroundTask would otherwise surface as a
     500 for a response we already sent).
+
+    ``received`` is the ``time.monotonic()`` stamp taken at webhook receipt, so
+    the wall-time metric spans the whole PR check the developer waits on (gather +
+    scan + report + status post), not just the engine.
+
+    Two headline timing metrics are logged (both ``scan_*`` so they group in
+    SigNoz), plus per-segment debug fields:
+
+    - ``scan_execution_duration`` (s): the fc-invoke engine scan ONLY. Also sent
+      to the App as the scan's ``total_time``.
+    - ``scan_pr_wall_time`` (s): webhook receipt -> developer-visible commit
+      status posted. The whole PR check, minus only the GitHub-send-to-us hop we
+      cannot clock here. Also shown in the commit-status description.
+    - ``gather_ms`` / ``report_ms`` / ``status_ms``: secondary per-segment spans
+      so a bad ``scan_pr_wall_time`` can be attributed without a headline metric.
     """
     try:
         pull_request = payload.get("pull_request", {})
@@ -280,7 +296,9 @@ async def _scan_and_report(payload: dict[str, Any]) -> None:
             )
             return
 
+        t_gather = time.monotonic()
         files = await _gather_files(repo, int(pr_number), head_sha)
+        gather_ms = (time.monotonic() - t_gather) * 1000
         if not files:
             logger.info(
                 "semgrep webhook: no scannable changed files for %s#%s, nothing to do",
@@ -289,12 +307,12 @@ async def _scan_and_report(payload: dict[str, Any]) -> None:
             )
             return
 
-        # Wall-clock timer around the scan + report: the in-cluster (SigNoz-
-        # queryable, via the structured log below) latency signal for comparing
-        # Route B against SMS.
-        started = time.monotonic()
-
+        # scan_execution_duration: the engine scan ONLY (fc-invoke round trip),
+        # measured on its own so it is both the App total_time and a clean
+        # "how fast is our scanner" signal, independent of gather/report/status.
+        t_scan = time.monotonic()
         scan = await scan_files(files)
+        scan_execution_duration = time.monotonic() - t_scan
         if not isinstance(scan, dict) or scan.get("error"):
             logger.error(
                 "semgrep webhook: fc-invoke scan failed for %s#%s: %s",
@@ -304,6 +322,7 @@ async def _scan_and_report(payload: dict[str, Any]) -> None:
             )
             return
 
+        t_report = time.monotonic()
         result = await report_pr_scan(
             repo=repo,
             branch=head_ref,
@@ -312,42 +331,60 @@ async def _scan_and_report(payload: dict[str, Any]) -> None:
             base_ref=base_sha or None,
             raw_cli_output=scan.get("raw_cli_output"),
             repo_url=repo_url,
+            scan_execution_duration=scan_execution_duration,
         )
-        latency = time.monotonic() - started
+        report_ms = (time.monotonic() - t_report) * 1000
 
         scan_id = result.get("scan_id")
         findings = result.get("findings_reported")
         project = result.get("project", repo)
         org = result.get("org", "jomcgi")
 
+        # Wall time up to just before the developer-visible status post. The
+        # status body cannot contain its own post latency, so the description
+        # shows this (receipt -> result ready); the log records the full
+        # scan_pr_wall_time (including the post) after it returns.
+        wall_pre_status = time.monotonic() - received
+
         if result.get("ok") and scan_id:
-            logger.info(
-                "semgrep webhook: reported %s#%s scan_id=%s findings=%s "
-                "latency=%.2fs project=%s",
-                repo,
-                pr_number,
-                scan_id,
-                findings,
-                latency,
-                project,
-            )
             # VALIDATION phase: non-gating, always "success". At cutover this maps
             # result["app_block_override"] -> "failure" else "success".
+            t_status = time.monotonic()
             await _post_commit_status(
                 repo=repo,
                 head_sha=head_sha,
                 state="success",
-                description=f"{findings} findings, {latency:.1f}s",
+                description=f"{findings} findings, {wall_pre_status:.1f}s",
                 target_url=_app_scan_url(org, project, scan_id),
+            )
+            status_ms = (time.monotonic() - t_status) * 1000
+            scan_pr_wall_time = time.monotonic() - received
+            logger.info(
+                "semgrep webhook: reported %s#%s scan_id=%s findings=%s "
+                "scan_execution_duration=%.2fs scan_pr_wall_time=%.2fs project=%s "
+                "gather_ms=%.0f report_ms=%.0f status_ms=%.0f",
+                repo,
+                pr_number,
+                scan_id,
+                findings,
+                scan_execution_duration,
+                scan_pr_wall_time,
+                project,
+                gather_ms,
+                report_ms,
+                status_ms,
             )
         else:
             error = result.get("error")
+            scan_pr_wall_time = time.monotonic() - received
             logger.error(
-                "semgrep webhook: App report failed for %s#%s: %s (latency=%.2fs)",
+                "semgrep webhook: App report failed for %s#%s: %s "
+                "(scan_execution_duration=%.2fs scan_pr_wall_time=%.2fs)",
                 repo,
                 pr_number,
                 error,
-                latency,
+                scan_execution_duration,
+                scan_pr_wall_time,
             )
             # Report failed (no scan_id / not ok): surface it as an error status
             # with no target_url (there is no App scan to link to).
@@ -377,6 +414,9 @@ async def semgrep_webhook(
     3. For a scannable action, dispatch ``_scan_and_report`` as a background task
        and return 200 immediately; the scan never blocks the response.
     """
+    # Stamp receipt as early as possible: scan_pr_wall_time is measured from here
+    # to the commit-status post, i.e. the whole PR check the developer waits on.
+    received = time.monotonic()
     body = await request.body()
     _verify_signature(body, x_hub_signature_256)
 
@@ -396,5 +436,5 @@ async def semgrep_webhook(
     if action not in _SCAN_ACTIONS:
         return {"status": "ignored", "reason": f"action={action}"}
 
-    background_tasks.add_task(_scan_and_report, payload)
+    background_tasks.add_task(_scan_and_report, payload, received)
     return {"status": "accepted", "action": action}

--- a/projects/monolith/semgrep_scan/router_test.py
+++ b/projects/monolith/semgrep_scan/router_test.py
@@ -262,6 +262,10 @@ def test_scan_and_report_happy_path(client):
     assert kwargs["pr_id"] == "4242"
     assert kwargs["base_ref"] == "basesha456"
     assert kwargs["raw_cli_output"] == {"results": []}
+    # The engine scan duration is measured and threaded through so the App gets a
+    # real total_time (a non-negative float, not the old hardcoded 0).
+    assert isinstance(kwargs["scan_execution_duration"], float)
+    assert kwargs["scan_execution_duration"] >= 0.0
 
 
 def test_scan_error_short_circuits_report(client):


### PR DESCRIPTION
## Why

The self-hosted Semgrep webhook logged a single `latency=` field that **started after file gather and stopped before the commit-status post**, so it measured an inner slice that flattered the scanner and hid the real developer wait. Separately, the App scan's `total_time` was **hardcoded to `0.0`** (`report.py`), so the Semgrep dashboard scan-time column was meaningless for Route B.

Verified against the live Semgrep API: scan `193207468` (PR #3377) records `findingsCounts.total=6` but `totalTime: 0.0`, while `completedAt - startedAt = 0.85s`, confirming both the bug and that the real timing existed only in our logs.

## What

Two headline metrics, both `scan_*` so they group in SigNoz:

- **`scan_execution_duration`** (s): the fc-invoke engine scan **only**. Also sent to the App as `CiScanCompleteStats.total_time`, so the dashboard shows the real engine duration instead of 0.
- **`scan_pr_wall_time`** (s): webhook receipt to developer-visible commit status posted, i.e. the **whole PR check the developer waits on** (gather + scan + report + status), minus only the GitHub-send-to-us hop we cannot clock in process. Also shown in the commit-status description.

Plus `gather_ms` / `report_ms` / `status_ms` as secondary per-segment debug fields so a bad `scan_pr_wall_time` can be attributed without a headline metric.

The commit-status description shows wall time up to just before the post (the status body cannot contain its own post latency); the log records the full `scan_pr_wall_time` after the post returns.

## Deploy

Includes the monolith chart bump (0.285.121) so the change deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)