### PR TITLE
chore(monolith): re-bump charts after version collision dropped PR #3386's bumps

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.52
+version: 0.89.54
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.52
+      targetRevision: 0.89.54
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.122
+version: 0.285.124
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.122
+      targetRevision: 0.285.124
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Main's "Push images" is failing: monolith-public 0.89.52 (and monolith 0.285.122) were already published when bdd21a22d landed, because PR #3386's bump hunks were silently emptied during rebase-merge after PR #3385 claimed the same versions 2 seconds earlier (the documented collision-drop class).

This re-bumps both charts so the ADR tooling/011 baked docs manifests deploy. Prevention (strict required checks + guard hardening) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)