### PR TITLE
fix(semgrep-full): run osemgrep-pro scan directly (offline interfile)

### DIFF
--- a/projects/firecracker/semgrep/guest-init/internal/fullscan/fullscan.go
+++ b/projects/firecracker/semgrep/guest-init/internal/fullscan/fullscan.go
@@ -74,8 +74,25 @@ func Scan(ctx context.Context, req vsockproto.ScanRequest, runner Runner) (vsock
 // from that finding.
 func SemgrepRunner(rulesDir string) Runner {
 	return func(ctx context.Context, treeDir string) ([]byte, error) {
-		cmd := exec.CommandContext(ctx, "semgrep", "scan", "--experimental", "--pro",
-			"--config", rulesDir, "--json", "--metrics=off", "--disable-version-check", treeDir)
+		// Invoke the baked offline-Pro engine (osemgrep-pro, the OCaml CLI) DIRECTLY
+		// rather than the python `semgrep scan --pro`. pysemgrep looks for the pro
+		// core at its own bundled path and, not finding it, tries to DOWNLOAD it
+		// from semgrep.dev (semgrep install-semgrep-pro), which fails in the
+		// egress-less guest (DNS failure -> exit 2). pysemgrep is also a different
+		// version (1.165) than the baked engine (1.161), so satisfying its
+		// version-stamp check would drive a mismatched core. osemgrep-pro is the
+		// same self-contained binary the warm mcp scan-server uses: it has a `scan`
+		// subcommand and the interfile engine built in, so `osemgrep-pro scan --pro`
+		// does whole-tree interfile analysis offline with no download and no
+		// pysemgrep coupling. Offline Pro unlock + metrics/version-check-off come
+		// from the env guestboot.SetupEnv set (SEMGREP_SETTINGS_FILE, HOME,
+		// SEMGREP_SEND_METRICS=off, SEMGREP_ENABLE_VERSION_CHECK=0).
+		bin := os.Getenv("OSEMGREP_PRO_BIN")
+		if bin == "" {
+			bin = "/opt/semgrep/osemgrep-pro"
+		}
+		cmd := exec.CommandContext(ctx, bin, "scan", "--pro",
+			"--config", rulesDir, "--metrics=off", "--json", treeDir)
 		cmd.Stderr = os.Stderr
 		return cmd.Output()
 	}

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.60
+version: 0.4.61

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.60
+      targetRevision: 0.4.61
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## Why

The interfile acceptance probe failed. `semgrep scan --pro` (the **python** pysemgrep CLI) could not find a Pro engine at its bundled path, so it tried to **download** one from `semgrep.dev` (`install-semgrep-pro`). The `semgrep-full` guest has no egress, so DNS fails and semgrep exits 2:

```
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='semgrep.dev', port=443): ... Failed to resolve 'semgrep.dev'
```

pysemgrep in the image is **1.165.0** but the baked Pro engine is **1.161.0**, so satisfying pysemgrep's version-stamp check would drive a mismatched core anyway.

## Fix

Invoke the self-contained `osemgrep-pro` binary directly (`osemgrep-pro scan --pro --config /etc/semgrep/rules --json <tree>`). This is the **same engine** the warm mcp scan-server already uses offline. Verified from the image that osemgrep-pro exposes a `scan` subcommand and the interfile engine (`interfile_languages_used`, `-timeout_for_interfile_analysis`). No download, no pysemgrep version coupling, offline Pro unlock via the existing settings file.

## Verify

After rollout, re-run the 2-file cross-file taint probe against `/invoke/semgrep-full`. Expect the taint finding on the cross-file sink and `interfile_languages_used` non-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)