### PR TITLE
fix(monolith): disable qwen hybrid thinking in chat agents

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.126
+version: 0.285.127
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/cluster_agent.py
+++ b/projects/monolith/chat/cluster_agent.py
@@ -65,6 +65,10 @@ def create_cluster_agent() -> Agent[ClusterDeps]:
             extra_body={
                 "top_k": 20,
                 "presence_penalty": 1.5,
+                # qwen3.6 is a hybrid thinking model: without this the whole
+                # generation lands in vLLM's reasoning field, content comes
+                # back null, and the SSE stream emits an empty answer.
+                "chat_template_kwargs": {"enable_thinking": False},
             },
         ),
     )

--- a/projects/monolith/chat/explorer.py
+++ b/projects/monolith/chat/explorer.py
@@ -49,6 +49,10 @@ def create_explorer_agent() -> Agent[ExplorerDeps]:
             extra_body={
                 "top_k": 20,
                 "presence_penalty": 1.5,
+                # qwen3.6 is a hybrid thinking model: without this the whole
+                # generation lands in vLLM's reasoning field, content comes
+                # back null, and the SSE stream emits an empty answer.
+                "chat_template_kwargs": {"enable_thinking": False},
             },
         ),
     )

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.126
+      targetRevision: 0.285.127
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Both chat agents (explorer and the new cluster chat) streamed empty answers: qwen3.6 hybrid puts everything in vLLM's reasoning field with content null unless thinking is disabled per request. Adds chat_template_kwargs.enable_thinking=false to both agents' model settings. Probed live: content populates with the flag, null without. Includes monolith chart bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)