### PR TITLE
fix(semgrep-full): reconstruct pro-engine install layout for osemgrep-pro scan

### DIFF
--- a/projects/firecracker/semgrep/guest-init/cmd-full/main.go
+++ b/projects/firecracker/semgrep/guest-init/cmd-full/main.go
@@ -49,17 +49,26 @@ func run(logger *slog.Logger) error {
 	guestboot.SetProcessEnv()
 
 	// SetupEnv writes the offline Pro settings file and exports SEMGREP_SETTINGS_FILE
-	// / HOME; `semgrep scan --pro` needs these for the offline Pro unlock exactly
-	// as the warm scan-server does.
+	// / HOME; `osemgrep-pro scan --pro` needs these for the offline Pro unlock
+	// exactly as the warm scan-server does.
 	if _, err := guestboot.SetupEnv(logger); err != nil {
 		return err
 	}
 
+	// Reconstruct the pro-engine "install" layout (binary + version stamp) the
+	// scan CLI insists on, in a tmpfs dir on PATH. Without this the CLI reports
+	// "Semgrep Pro is either uninstalled or out of date" and exits 2. The returned
+	// path is the pro binary to invoke the scan from (inside the shim dir).
+	proBin, err := guestboot.SetupProEngine(logger)
+	if err != nil {
+		return err
+	}
+
 	rulesDir := guestboot.EnvOr("SEMGREP_SCAN_RULES", guestboot.DefaultRulesDir)
-	logger.Info("starting full-scan (semgrep scan --pro) init", "rules", rulesDir)
+	logger.Info("starting full-scan (osemgrep-pro scan --pro) init", "rules", rulesDir, "proBin", proBin)
 
 	h := handler.NewFull(func(req vsockproto.ScanRequest) (vsockproto.ScanResult, error) {
-		return fullscan.Scan(ctx, req, fullscan.SemgrepRunner(rulesDir))
+		return fullscan.Scan(ctx, req, fullscan.SemgrepRunner(rulesDir, proBin))
 	})
 
 	ln, err := scanserver.ListenVsock(vsockproto.GuestHTTPPort)

--- a/projects/firecracker/semgrep/guest-init/internal/fullscan/fullscan.go
+++ b/projects/firecracker/semgrep/guest-init/internal/fullscan/fullscan.go
@@ -67,31 +67,23 @@ func Scan(ctx context.Context, req vsockproto.ScanRequest, runner Runner) (vsock
 	return res, nil
 }
 
-// SemgrepRunner runs the python `semgrep scan --pro` CLI over treeDir and
-// returns stdout (cli_output JSON). rulesDir is the --config path
-// (SEMGREP_SCAN_RULES). The exact flags/env that make the CLI locate the
-// proprietary core offline are verified post-deploy in a later task; adjust
-// from that finding.
-func SemgrepRunner(rulesDir string) Runner {
+// SemgrepRunner runs `osemgrep-pro scan --pro` over treeDir and returns stdout
+// (cli_output JSON). rulesDir is the --config path (SEMGREP_SCAN_RULES). proBin
+// is the pro engine to invoke: the caller passes the shim path from
+// guestboot.SetupProEngine so the CLI finds the reconstructed pro-engine install
+// layout (binary + version stamp) alongside it.
+func SemgrepRunner(rulesDir, proBin string) Runner {
 	return func(ctx context.Context, treeDir string) ([]byte, error) {
-		// Invoke the baked offline-Pro engine (osemgrep-pro, the OCaml CLI) DIRECTLY
-		// rather than the python `semgrep scan --pro`. pysemgrep looks for the pro
-		// core at its own bundled path and, not finding it, tries to DOWNLOAD it
-		// from semgrep.dev (semgrep install-semgrep-pro), which fails in the
-		// egress-less guest (DNS failure -> exit 2). pysemgrep is also a different
-		// version (1.165) than the baked engine (1.161), so satisfying its
-		// version-stamp check would drive a mismatched core. osemgrep-pro is the
-		// same self-contained binary the warm mcp scan-server uses: it has a `scan`
-		// subcommand and the interfile engine built in, so `osemgrep-pro scan --pro`
-		// does whole-tree interfile analysis offline with no download and no
-		// pysemgrep coupling. Offline Pro unlock + metrics/version-check-off come
-		// from the env guestboot.SetupEnv set (SEMGREP_SETTINGS_FILE, HOME,
-		// SEMGREP_SEND_METRICS=off, SEMGREP_ENABLE_VERSION_CHECK=0).
-		bin := os.Getenv("OSEMGREP_PRO_BIN")
-		if bin == "" {
-			bin = "/opt/semgrep/osemgrep-pro"
-		}
-		cmd := exec.CommandContext(ctx, bin, "scan", "--pro",
+		// Invoke the baked offline-Pro engine (osemgrep-pro) directly rather than
+		// the python `semgrep scan --pro`, which tries to DOWNLOAD the pro engine
+		// from semgrep.dev (fails in the egress-less guest) and couples to a
+		// different pysemgrep version. osemgrep-pro is the same self-contained
+		// binary the warm mcp scan-server uses, with a `scan` subcommand and the
+		// interfile engine built in. proBin is the shim path from
+		// guestboot.SetupProEngine so the CLI finds the pro-engine install layout
+		// it requires. Offline Pro unlock + metrics/version-check-off come from the
+		// env guestboot.SetupEnv set.
+		cmd := exec.CommandContext(ctx, proBin, "scan", "--pro",
 			"--config", rulesDir, "--metrics=off", "--json", treeDir)
 		cmd.Stderr = os.Stderr
 		return cmd.Output()

--- a/projects/firecracker/semgrep/guest-init/internal/guestboot/guestboot.go
+++ b/projects/firecracker/semgrep/guest-init/internal/guestboot/guestboot.go
@@ -8,8 +8,12 @@
 package guestboot
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 )
 
 const (
@@ -78,4 +82,58 @@ func EnvOr(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// proShimDir is the tmpfs directory where SetupProEngine builds the pro-engine
+// "install" layout the full-scan CLI expects.
+const proShimDir = "/tmp/sgbin"
+
+// SetupProEngine makes the baked offline-Pro engine discoverable to
+// `osemgrep-pro scan --pro`. That command (like pysemgrep) refuses to run unless
+// the Pro core looks INSTALLED: a semgrep-core-proprietary binary sitting next to
+// semgrep-core, plus a pro-installed-by.txt version stamp recording the version
+// that installed it. Our engine is baked at /opt/semgrep (read-only rootfs), not
+// in that layout, so the CLI reports "Semgrep Pro is either uninstalled or out of
+// date" and exits. We reconstruct the layout in a tmpfs dir on PATH: symlinks for
+// semgrep-core, semgrep-core-proprietary, and osemgrep-pro (all to the baked
+// binaries), so both PATH-based and argv[0]-dir-based resolution land here, plus
+// the stamp. The stamp is the engine's OWN -pro_version output (the engine is the
+// CLI, so there is no version drift to guess at). Returns the pro binary path to
+// invoke the scan from (inside the shim dir). Prepends the shim dir to PATH.
+func SetupProEngine(logger *slog.Logger) (string, error) {
+	proBin := EnvOr("OSEMGREP_PRO_BIN", DefaultOsemgrepPro)
+	coreBin := filepath.Join(filepath.Dir(proBin), "semgrep-core")
+
+	if err := os.MkdirAll(proShimDir, 0o755); err != nil {
+		return "", fmt.Errorf("pro shim mkdir: %w", err)
+	}
+	links := map[string]string{
+		"semgrep-core":             coreBin,
+		"semgrep-core-proprietary": proBin,
+		"osemgrep-pro":             proBin,
+	}
+	for name, target := range links {
+		dst := filepath.Join(proShimDir, name)
+		_ = os.Remove(dst)
+		if err := os.Symlink(target, dst); err != nil {
+			return "", fmt.Errorf("pro shim symlink %s: %w", name, err)
+		}
+	}
+
+	// pro-installed-by.txt records the installing version. Use the engine's own
+	// -pro_version (the method pysemgrep uses to read it), so the stamp always
+	// matches the baked engine exactly.
+	out, err := exec.Command(proBin, "-pro_version").Output()
+	if err != nil {
+		return "", fmt.Errorf("pro_version: %w", err)
+	}
+	stamp := strings.TrimSpace(string(out))
+	stampPath := filepath.Join(proShimDir, "pro-installed-by.txt")
+	if err := os.WriteFile(stampPath, []byte(stamp+"\n"), 0o644); err != nil {
+		return "", fmt.Errorf("pro stamp write: %w", err)
+	}
+
+	os.Setenv("PATH", proShimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	logger.Info("pro engine install shim ready", "dir", proShimDir, "version", stamp)
+	return filepath.Join(proShimDir, "osemgrep-pro"), nil
 }

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.61
+version: 0.4.62

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.61
+      targetRevision: 0.4.62
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## Why

Second interfile-probe failure. `osemgrep-pro scan --pro` now runs (loads 1285 Pro rules) but exits 2 with:

```
Semgrep Pro is either uninstalled or it is out of date.
Try installing Semgrep Pro (`semgrep install-semgrep-pro`).
```

Like pysemgrep, the scan CLI refuses to run unless the Pro core looks **installed**: a `semgrep-core-proprietary` binary next to `semgrep-core`, plus a `pro-installed-by.txt` version stamp (confirmed from the image's own `install.py`). Our engine is baked at `/opt/semgrep` on a **read-only** rootfs, not in that layout. Semgrep deliberately refuses version-drifted engines, so faking it is out; but running `osemgrep-pro` directly keeps the engine and CLI self-consistent (both 1.161).

## Fix

`guestboot.SetupProEngine` reconstructs the install layout in a tmpfs dir (`/tmp/sgbin`) on PATH: symlinks for `semgrep-core`, `semgrep-core-proprietary`, and `osemgrep-pro` (all to the baked binaries, so PATH- and argv0-dir-based resolution both land there), plus `pro-installed-by.txt` set to the engine's own `-pro_version` output (no drift, no hardcoded version). `cmd-full` invokes the scan from the shim path.

## Verify

Re-run the 2-file cross-file taint probe against `/invoke/semgrep-full`. Expect the taint finding on `pkg/b.py` and `interfile_languages_used` non-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)