### PR TITLE
fix(semgrep-full): non-fatal pro-engine shim (guest no longer panics)

### DIFF
--- a/projects/firecracker/semgrep/guest-init/cmd-full/main.go
+++ b/projects/firecracker/semgrep/guest-init/cmd-full/main.go
@@ -57,12 +57,10 @@ func run(logger *slog.Logger) error {
 
 	// Reconstruct the pro-engine "install" layout (binary + version stamp) the
 	// scan CLI insists on, in a tmpfs dir on PATH. Without this the CLI reports
-	// "Semgrep Pro is either uninstalled or out of date" and exits 2. The returned
-	// path is the pro binary to invoke the scan from (inside the shim dir).
-	proBin, err := guestboot.SetupProEngine(logger)
-	if err != nil {
-		return err
-	}
+	// "Semgrep Pro is either uninstalled or out of date" and exits 2. Best-effort
+	// and non-fatal (it is PID 1: a returned error would panic the microVM), so it
+	// returns the pro binary path to invoke the scan from and logs any setup miss.
+	proBin := guestboot.SetupProEngine(logger)
 
 	rulesDir := guestboot.EnvOr("SEMGREP_SCAN_RULES", guestboot.DefaultRulesDir)
 	logger.Info("starting full-scan (osemgrep-pro scan --pro) init", "rules", rulesDir, "proBin", proBin)

--- a/projects/firecracker/semgrep/guest-init/internal/guestboot/guestboot.go
+++ b/projects/firecracker/semgrep/guest-init/internal/guestboot/guestboot.go
@@ -8,12 +8,9 @@
 package guestboot
 
 import (
-	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 )
 
 const (
@@ -88,6 +85,17 @@ func EnvOr(key, def string) string {
 // "install" layout the full-scan CLI expects.
 const proShimDir = "/tmp/sgbin"
 
+// proEngineVersion is the version written into the pro-installed-by.txt stamp.
+// osemgrep-pro's "is Pro installed" check compares this to its own CLI version,
+// which equals the baked engine's version (the engine IS the CLI). The engine is
+// pinned by digest (bazel/semgrep/third_party/semgrep_experimental), so this
+// literal must be kept in sync with that engine's version when the digest bumps.
+// A mismatch surfaces as a readable "Semgrep Pro is out of date" scan error, not
+// a crash. We do NOT derive it by running the binary: osemgrep-pro rejects the
+// bare -pro_version core flag when invoked as the CLI (it kernel-panicked the
+// guest when treated as fatal).
+const proEngineVersion = "1.161.0"
+
 // SetupProEngine makes the baked offline-Pro engine discoverable to
 // `osemgrep-pro scan --pro`. That command (like pysemgrep) refuses to run unless
 // the Pro core looks INSTALLED: a semgrep-core-proprietary binary sitting next to
@@ -97,15 +105,23 @@ const proShimDir = "/tmp/sgbin"
 // date" and exits. We reconstruct the layout in a tmpfs dir on PATH: symlinks for
 // semgrep-core, semgrep-core-proprietary, and osemgrep-pro (all to the baked
 // binaries), so both PATH-based and argv[0]-dir-based resolution land here, plus
-// the stamp. The stamp is the engine's OWN -pro_version output (the engine is the
-// CLI, so there is no version drift to guess at). Returns the pro binary path to
-// invoke the scan from (inside the shim dir). Prepends the shim dir to PATH.
-func SetupProEngine(logger *slog.Logger) (string, error) {
+// a pro-installed-by.txt stamp (proEngineVersion). Returns the pro binary path to
+// invoke the scan from (inside the shim dir) and prepends the shim dir to PATH.
+//
+// Best-effort and NON-FATAL: it never returns an error, because this init is the
+// guest PID 1 and any error it returned would exit(1) and kernel-panic the whole
+// microVM (Attempted to kill init). If a step fails, it is logged and the scan is
+// left to fail with a readable engine error instead of taking the guest down. It
+// deliberately does not exec the engine (osemgrep-pro rejects the bare
+// -pro_version flag as the CLI, which is what panicked an earlier attempt).
+func SetupProEngine(logger *slog.Logger) string {
 	proBin := EnvOr("OSEMGREP_PRO_BIN", DefaultOsemgrepPro)
 	coreBin := filepath.Join(filepath.Dir(proBin), "semgrep-core")
+	shimBin := filepath.Join(proShimDir, "osemgrep-pro")
 
 	if err := os.MkdirAll(proShimDir, 0o755); err != nil {
-		return "", fmt.Errorf("pro shim mkdir: %w", err)
+		logger.Error("pro shim mkdir failed; falling back to baked binary", "err", err)
+		return proBin
 	}
 	links := map[string]string{
 		"semgrep-core":             coreBin,
@@ -116,24 +132,16 @@ func SetupProEngine(logger *slog.Logger) (string, error) {
 		dst := filepath.Join(proShimDir, name)
 		_ = os.Remove(dst)
 		if err := os.Symlink(target, dst); err != nil {
-			return "", fmt.Errorf("pro shim symlink %s: %w", name, err)
+			logger.Error("pro shim symlink failed", "name", name, "err", err)
 		}
 	}
 
-	// pro-installed-by.txt records the installing version. Use the engine's own
-	// -pro_version (the method pysemgrep uses to read it), so the stamp always
-	// matches the baked engine exactly.
-	out, err := exec.Command(proBin, "-pro_version").Output()
-	if err != nil {
-		return "", fmt.Errorf("pro_version: %w", err)
-	}
-	stamp := strings.TrimSpace(string(out))
 	stampPath := filepath.Join(proShimDir, "pro-installed-by.txt")
-	if err := os.WriteFile(stampPath, []byte(stamp+"\n"), 0o644); err != nil {
-		return "", fmt.Errorf("pro stamp write: %w", err)
+	if err := os.WriteFile(stampPath, []byte(proEngineVersion+"\n"), 0o644); err != nil {
+		logger.Error("pro stamp write failed", "err", err)
 	}
 
 	os.Setenv("PATH", proShimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	logger.Info("pro engine install shim ready", "dir", proShimDir, "version", stamp)
-	return filepath.Join(proShimDir, "osemgrep-pro"), nil
+	logger.Info("pro engine install shim ready", "dir", proShimDir, "version", proEngineVersion)
+	return shimBin
 }

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.62
+version: 0.4.63

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.62
+      targetRevision: 0.4.63
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## Why

The pro-install shim from the previous PR **kernel-panicked the guest**. `SetupProEngine` ran `osemgrep-pro -pro_version` to derive the stamp version, but osemgrep-pro rejects that bare core flag when invoked as the CLI, so the exec errored, `SetupProEngine` returned the error, and the PID-1 init `exit(1)`'d:

```
Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000100
invoke: no guest available ... timed out waiting for guest ready (503)
```

## Fix

`SetupProEngine` is now **best-effort and non-fatal**: it never returns an error (a PID-1 error panics the whole microVM), logs any step miss, and no longer execs the engine. The version stamp uses a `proEngineVersion` const (`1.161.0`, kept in sync with the digest-pinned engine); a wrong value would now surface as a readable "Semgrep Pro is out of date" scan error instead of taking the guest down.

## Verify

Re-run the 2-file cross-file taint probe. The guest should boot cleanly; expect the interfile taint finding on the cross-file sink + `interfile_languages_used` non-empty. If the stamp version is wrong, expect a readable "out of date" error (not a 503).

🤖 Generated with [Claude Code](https://claude.com/claude-code)