### PR TITLE
feat(chat): two-gate ambient defense (group-address pre-gate + post-generation send-gate)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.128
+version: 0.285.129
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/attention.py
+++ b/projects/monolith/chat/attention.py
@@ -6,6 +6,16 @@ base engagement policy (refined, not gated, by the channel directive) and
 engages only above ATTENTION_THRESHOLD. Recently-tagged threads/channels get a
 lower threshold so the bot leans into relevant follow-ups. Everywhere else,
 ignore. The classifier holds no tools and fails closed (ignore) on any error.
+
+The pre-gate above only ever sees the trigger message, so it cannot catch a
+reply that turns out to barge in, double down after a brush-off, or invent
+facts. ``should_send`` is a second, disconnected post-generation gate
+(improve-ambient): a fresh classify that reads the channel directive, the recent
+interaction, and the DRAFTED reply, and vetoes an ambient send that a real
+person would not have wanted. It fails OPEN (send) so a classify blip degrades
+to today's behaviour rather than silently eating replies, and is scoped to the
+ambient chat path only (a live reply someone is waiting on is never gated, and
+heavy agent runs are gated pre-generation, not after the microVM has run).
 """
 
 import json
@@ -16,6 +26,9 @@ from dataclasses import dataclass
 logger = logging.getLogger(__name__)
 ATTENTION_THRESHOLD = float(os.environ.get("ATTENTION_THRESHOLD", "0.5"))
 _RECENT_TAG_THRESHOLD = float(os.environ.get("ATTENTION_RECENT_TAG_THRESHOLD", "0.35"))
+# The post-generation send-gate is on by default; set AMBIENT_SEND_GATE=0 to
+# disable it (and skip its extra classify call) without a redeploy.
+SEND_GATE_ENABLED = os.environ.get("AMBIENT_SEND_GATE", "1") != "0"
 
 
 @dataclass
@@ -75,16 +88,22 @@ async def evaluate(
             "You are Bosun, a friendly bot hanging out in this Discord channel. "
             "You are one voice among friends, not a reply guy: join in when there "
             "is a real opening, and otherwise let people talk. Engage (true) if "
-            "the message addresses you, greets you, asks a question, is trying to "
-            "get your attention, or clearly invites your take, or if it states "
-            "something checkable that would genuinely benefit from a web search or "
-            "fact-check. Ignore (false) if it is aimed at another specific person "
-            "(not you), is pure noise or a bare reaction, is a link, image, or "
-            "media share posted without a question or a request for your take, is "
-            "people thinking out loud to each other, or tells you to stop, says "
-            "you talk too much, or otherwise signals you are not wanted right now. "
-            "When a message is not addressed to you and you are unsure whether it "
-            "actually wants a reply, stay quiet.\n"
+            "the message addresses you by name, greets you, asks YOU a question, "
+            "is trying to get your attention, or clearly invites your take, or if "
+            "it states something checkable that would genuinely benefit from a web "
+            "search or fact-check. Ignore (false) if it is aimed at another "
+            "specific person, or at the other people in the channel rather than "
+            "you - including friends sorting out plans among themselves ('you lot "
+            "around for a game?', 'wanna play tonight?') or catching up with each "
+            "other ('how have you been?') - is pure noise or a bare reaction, is "
+            "a link, image, or media share posted without a question or a request "
+            "for your take, is people thinking out loud to each other, or tells "
+            "you to stop, says you talk too much, or otherwise signals you are "
+            "not wanted right now. A message being phrased as a question is NOT on "
+            "its own a reason to engage when it is plainly directed at the other "
+            "people here rather than at you. When a message is not addressed to "
+            "you and you are unsure whether it actually wants a reply, stay "
+            "quiet.\n"
             + (
                 "You were recently mentioned in this channel, so lean even harder "
                 "toward engaging on the follow-up.\n"
@@ -110,6 +129,73 @@ async def evaluate(
     except Exception:
         logger.exception("attention: classify failed; failing closed (ignore)")
         return AttentionResult(False, 0.0)
+
+
+async def should_send(
+    directive: str,
+    conversation: str,
+    trigger: str,
+    reply: str,
+    *,
+    _caller=None,
+) -> bool:
+    """Post-generation send-gate for an ambient chat reply. See module docstring.
+
+    A second, disconnected classify: given the channel ``directive``, the recent
+    ``conversation``, the ``trigger`` message being replied to, and Bosun's
+    ``reply`` as already drafted, decide whether sending it improves the channel
+    or Bosun should stay silent. This is an independent critic reading the
+    finished artifact, not the drafter's own second thought, so it catches
+    reply-quality misfires the pre-gate (which only sees the trigger) cannot:
+    barging into a conversation nobody asked Bosun to join, piling on after a
+    brush-off, or inventing facts/names/links.
+
+    Fails OPEN (returns True) on any error or when disabled, so a classify blip
+    degrades to today's behaviour rather than silently swallowing a reply.
+    ``_caller`` is an injectable llm-caller for tests.
+    """
+    if not SEND_GATE_ENABLED:
+        return True
+    try:
+        caller = _caller
+        if caller is None:
+            from chat.summarizer import build_llm_caller
+
+            caller = build_llm_caller()
+        prompt = (
+            "You are the send-gate for Bosun, a bot in a Discord channel among "
+            "friends. Bosun has DRAFTED a reply to the latest message. Your only "
+            "job is to decide whether sending it right now improves the "
+            "conversation, or whether Bosun should stay silent. Be willing to "
+            "veto. Answer send=false if the reply: barges into a conversation the "
+            "humans are having with each other and did not ask Bosun to join; "
+            "piles on after someone signalled they don't want it (a brush-off, "
+            "'stop', 'you talk too much', hostility); states specific facts, "
+            "events, names, links, or numbers Bosun cannot actually know or that "
+            "read as invented; is off Bosun's voice, padded, or long for what was "
+            "asked; or adds nothing a person would miss. Answer send=true only if "
+            "a real person in this channel would be glad Bosun sent it. When "
+            "unsure, prefer send=false.\n"
+            + (
+                "Channel guidance (weigh this heavily): " + directive + "\n"
+                if directive
+                else ""
+            )
+            + "Recent conversation:\n"
+            + (conversation or "")[:2000]
+            + "\nLatest message Bosun is replying to: "
+            + (trigger or "")[:500]
+            + "\nBosun's drafted reply: "
+            + (reply or "")[:1000]
+            + '\nReply with ONLY a JSON object: {"send": true|false}. '
+            "No prose, no markdown."
+        )
+        raw = await caller(prompt)
+        data = json.loads(_extract_json(raw))
+        return bool(data.get("send", True))
+    except Exception:
+        logger.exception("attention: send-gate failed; failing open (send)")
+        return True
 
 
 async def needs_agent(message, *, _caller=None) -> bool:

--- a/projects/monolith/chat/attention_test.py
+++ b/projects/monolith/chat/attention_test.py
@@ -10,7 +10,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from chat.attention import ATTENTION_THRESHOLD, evaluate, needs_agent
+import chat.attention as attention_mod
+from chat.attention import ATTENTION_THRESHOLD, evaluate, needs_agent, should_send
 
 
 def _make_message(content: str = "hey", mentions=None, reference=None):
@@ -139,6 +140,83 @@ class TestRecentTagWeighting:
         assert result.engage is True
         assert result.confidence == 1.0
         caller.assert_not_called()
+
+
+class TestEngagePromptGroupAddressed:
+    """Pre-gate refinement (improve-ambient eps 224/227/233): a question aimed
+    at the friend group ('you lot around for a game?', 'how have you been?') is
+    not on its own an engage signal."""
+
+    @pytest.mark.asyncio
+    async def test_prompt_covers_group_addressed_and_question_caveat(self):
+        message = _make_message(content="you boys around for any games today?")
+        caller = AsyncMock(return_value='{"engage": false, "confidence": 0.2}')
+        await evaluate(message, "", _BOT_USER, is_ambient=True, _caller=caller)
+        prompt = caller.call_args[0][0].lower()
+        # group-addressed coordination / catching up is an ignore case
+        assert "the other people in the channel rather than" in prompt
+        assert "sorting out plans among themselves" in prompt
+        assert "catching up with each other" in prompt
+        # a bare question aimed at others is not sufficient to engage
+        assert "phrased as a question is not on its own a reason to engage" in prompt
+
+
+class TestSendGate:
+    """Post-generation send-gate (improve-ambient): a disconnected classify that
+    reads the drafted reply and vetoes an ambient send that would misfire.
+    Fails open; skipped when disabled."""
+
+    @pytest.mark.asyncio
+    async def test_send_true_passes(self):
+        caller = AsyncMock(return_value='{"send": true}')
+        assert await should_send("d", "convo", "trigger", "reply", _caller=caller)
+        caller.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_false_vetoes(self):
+        caller = AsyncMock(return_value='{"send": false}')
+        assert (
+            await should_send("d", "convo", "trigger", "reply", _caller=caller) is False
+        )
+
+    @pytest.mark.asyncio
+    async def test_fails_open_on_caller_error(self):
+        caller = AsyncMock(side_effect=RuntimeError("model unreachable"))
+        assert await should_send("d", "convo", "trigger", "reply", _caller=caller)
+
+    @pytest.mark.asyncio
+    async def test_missing_key_defaults_to_send(self):
+        caller = AsyncMock(return_value="{}")
+        assert await should_send("d", "convo", "trigger", "reply", _caller=caller)
+
+    @pytest.mark.asyncio
+    async def test_extracts_json_from_surrounding_prose(self):
+        caller = AsyncMock(return_value='hold on {"send": false} ok')
+        assert (
+            await should_send("d", "convo", "trigger", "reply", _caller=caller) is False
+        )
+
+    @pytest.mark.asyncio
+    async def test_disabled_returns_true_without_calling(self, monkeypatch):
+        monkeypatch.setattr(attention_mod, "SEND_GATE_ENABLED", False)
+        caller = AsyncMock()
+        assert await should_send("d", "convo", "trigger", "reply", _caller=caller)
+        caller.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_prompt_includes_directive_conversation_and_reply(self):
+        caller = AsyncMock(return_value='{"send": true}')
+        await should_send(
+            "hang back here",
+            "Wobblington: wanna play minecraft?",
+            "wanna play minecraft?",
+            "Sure thing. You hosting?",
+            _caller=caller,
+        )
+        prompt = caller.call_args[0][0]
+        assert "hang back here" in prompt
+        assert "wanna play minecraft?" in prompt
+        assert "Sure thing. You hosting?" in prompt
 
 
 class TestNeedsAgent:

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -945,7 +945,9 @@ class ChatBot(discord.Client):
                 if await attention.needs_agent(message):
                     await self._engage_agent(message)
                 else:
-                    await self._process_message(message, force_respond=True)
+                    await self._process_message(
+                        message, force_respond=True, directive=directive
+                    )
                 return
 
         await self._process_message(message)
@@ -1762,13 +1764,19 @@ class ChatBot(discord.Client):
             store.mark_completed(msg_id)
 
     async def _process_message(
-        self, message: discord.Message, force_respond: bool = False
+        self,
+        message: discord.Message,
+        force_respond: bool = False,
+        directive: str | None = None,
     ) -> None:
         """Process a message that this pod has locked.
 
         ``force_respond`` skips the ``should_respond`` gate so an ambient
         engage that the depth classify routed to chat (ADR 035 Phase 4) still
-        gets a reply even though it's not a mention/reply.
+        gets a reply even though it's not a mention/reply. ``directive`` is the
+        channel directive already fetched by ``on_message`` for the pre-gate,
+        threaded through to the post-generation send-gate so it is not read from
+        the DB a second time; only the ambient (force_respond) path passes it.
         """
         msg_id = str(message.id)
         channel_id = str(message.channel.id)
@@ -1821,6 +1829,7 @@ class ChatBot(discord.Client):
                     attachments,
                     with_buttons=not force_respond,
                     live=not force_respond,
+                    directive=directive,
                 )
         except Exception:
             logger.exception("Failed to respond to message %s", msg_id)
@@ -1892,6 +1901,7 @@ class ChatBot(discord.Client):
         *,
         with_buttons: bool = True,
         live: bool = True,
+        directive: str | None = None,
     ) -> tuple[discord.Message | None, str, str | None]:
         """Build context and stream the PydanticAI agent response.
 
@@ -2147,13 +2157,12 @@ class ChatBot(discord.Client):
             # on after a brush-off, or invent facts - failures the pre-gate cannot
             # see because it only had the trigger. Ambient only (nothing posted
             # yet, so it can be silently held); a live reply someone is waiting on
-            # is never gated. Fails open. Skipped entirely when disabled.
+            # is never gated. The directive is threaded in from on_message (which
+            # already fetched it for the pre-gate), so there is no second DB read
+            # here. Fails open. Skipped entirely when disabled.
             if attention.SEND_GATE_ENABLED and not live and sent is None:
-                directive = await asyncio.to_thread(
-                    directives.get_active, str(message.channel.id)
-                )
                 if not await attention.should_send(
-                    directive, context, message.content or "", response_text
+                    directive or "", context, message.content or "", response_text
                 ):
                     logger.info(
                         "send-gate: suppressing ambient reply in channel %s",

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -2141,6 +2141,26 @@ class ChatBot(discord.Client):
                     sent = await message.reply(fallback)
                 return sent, fallback, None
 
+            # Post-generation send-gate (improve-ambient): a second, disconnected
+            # classify reads the channel directive + recent interaction + the
+            # drafted reply and vetoes an ambient send that would barge in, pile
+            # on after a brush-off, or invent facts - failures the pre-gate cannot
+            # see because it only had the trigger. Ambient only (nothing posted
+            # yet, so it can be silently held); a live reply someone is waiting on
+            # is never gated. Fails open. Skipped entirely when disabled.
+            if attention.SEND_GATE_ENABLED and not live and sent is None:
+                directive = await asyncio.to_thread(
+                    directives.get_active, str(message.channel.id)
+                )
+                if not await attention.should_send(
+                    directive, context, message.content or "", response_text
+                ):
+                    logger.info(
+                        "send-gate: suppressing ambient reply in channel %s",
+                        message.channel.id,
+                    )
+                    return None, "", None
+
             # Ensure a reply was sent. AgentRunResultEvent alone never calls
             # _ensure_sent, so sent may still be None here.
             await _ensure_sent(response_text)

--- a/projects/monolith/chat/bot_on_message_test.py
+++ b/projects/monolith/chat/bot_on_message_test.py
@@ -534,7 +534,9 @@ class TestAttentionGate:
             mock_recently_tagged.assert_called_once_with("99", str(message.id))
             assert mock_evaluate.call_args.kwargs.get("recently_tagged") is True
             mock_needs_agent.assert_called_once()
-            mock_proc.assert_called_once_with(message, force_respond=True)
+            # The directive fetched for the pre-gate is threaded through to the
+            # post-generation send-gate rather than re-read from the DB.
+            mock_proc.assert_called_once_with(message, force_respond=True, directive="")
             mock_engage_agent.assert_not_called()
             mock_start_flow.assert_not_called()
 

--- a/projects/monolith/chat/bot_streaming_test.py
+++ b/projects/monolith/chat/bot_streaming_test.py
@@ -769,6 +769,9 @@ class TestAmbientNonStreaming:
             patch("chat.bot.get_engine"),
             patch("chat.bot.Session") as mock_session_cls,
             patch("chat.bot.MessageStore", return_value=mock_store),
+            # Ambient replies now pass a post-generation send-gate; allow it here
+            # so this test stays focused on the single-message posting mechanics.
+            patch("chat.bot.attention.should_send", AsyncMock(return_value=True)),
         ):
             ctx = MagicMock()
             mock_session_cls.return_value.__enter__ = MagicMock(return_value=ctx)
@@ -781,6 +784,69 @@ class TestAmbientNonStreaming:
         message.reply.assert_called_once()
         posted = message.reply.call_args_list[0][0][0]
         assert posted == "Nah, fable's holding up fine."
+
+    @pytest.mark.asyncio
+    async def test_ambient_send_gate_veto_stays_silent(self):
+        """live=False: when the post-generation send-gate vetoes the drafted
+        reply, nothing is posted and the call returns silent (like no_reply)."""
+        bot = _make_bot()
+        message = _make_message(content="you boys around for any games today?")
+        mock_store = _make_store()
+
+        events = [
+            _text_delta("I'm around. "),
+            _text_delta("What's the plan?"),
+        ]
+        bot.agent.run_stream_events = MagicMock(return_value=_async_iter(events))
+
+        gate = AsyncMock(return_value=False)
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+            patch("chat.bot.attention.should_send", gate),
+        ):
+            ctx = MagicMock()
+            mock_session_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            sent, text, _thinking = await bot._stream_response(
+                message, None, with_buttons=False, live=False, directive="hang back"
+            )
+
+        # Vetoed: silent return, nothing posted, directive threaded to the gate.
+        assert sent is None
+        assert text == ""
+        message.reply.assert_not_called()
+        gate.assert_awaited_once()
+        assert gate.call_args[0][0] == "hang back"
+
+    @pytest.mark.asyncio
+    async def test_live_reply_never_hits_send_gate(self):
+        """live=True (a reply someone is waiting on) is never gated: the send-gate
+        classify is not even called."""
+        bot = _make_bot()
+        message = _make_message(content="hey bot")
+        mock_store = _make_store()
+
+        events = [_text_delta("Hello "), _text_delta("there.")]
+        bot.agent.run_stream_events = MagicMock(return_value=_async_iter(events))
+
+        gate = AsyncMock(return_value=False)
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+            patch("chat.bot.attention.should_send", gate),
+        ):
+            ctx = MagicMock()
+            mock_session_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            sent, text, _thinking = await bot._stream_response(
+                message, None, with_buttons=True, live=True
+            )
+
+        gate.assert_not_called()
+        assert text == "Hello there."
         assert "Thinking" not in posted
         assert "Searching" not in posted
         # No progressive/in-place edits in ambient mode.

--- a/projects/monolith/chat/bot_streaming_test.py
+++ b/projects/monolith/chat/bot_streaming_test.py
@@ -784,6 +784,11 @@ class TestAmbientNonStreaming:
         message.reply.assert_called_once()
         posted = message.reply.call_args_list[0][0][0]
         assert posted == "Nah, fable's holding up fine."
+        assert "Thinking" not in posted
+        assert "Searching" not in posted
+        # No progressive/in-place edits in ambient mode.
+        sent.edit.assert_not_called()
+        assert text == "Nah, fable's holding up fine."
 
     @pytest.mark.asyncio
     async def test_ambient_send_gate_veto_stays_silent(self):
@@ -847,11 +852,6 @@ class TestAmbientNonStreaming:
 
         gate.assert_not_called()
         assert text == "Hello there."
-        assert "Thinking" not in posted
-        assert "Searching" not in posted
-        # No progressive/in-place edits in ambient mode.
-        sent.edit.assert_not_called()
-        assert text == "Nah, fable's holding up fine."
 
     @pytest.mark.asyncio
     async def test_ambient_placeholder_reply_is_suppressed(self):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.128
+      targetRevision: 0.285.129
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## /improve-ambient window: since `fc441e15b` (2026-07-11 05:49Z), 13 episodes, 9 classified

One dominant failure, tightly clustered in the gaming channel `1290668195249917968`: **Bosun barges into human-to-human social coordination and gets openly rejected.** The 11:24-11:34 run:

| ep | trigger (human -> group) | Bosun reply | signal |
|----|----|----|----|
| 224 | "You boys around for any games today?" | "I'm around. What's the plan?" | 👎🏻 |
| 225 | "Get fucked" | "😂 take it easy. still down to play" | kept going |
| 226 | "Has Joe just replaced himself with bosun?" | "...You boys playing anything tonight?" | re-invited itself |
| 227 | "Wanna play some minecraft?" | "You hosting or hopping into an existing world?" | dead |
| 233 | "How has it been? I saw there was some in Possil/Springburn" | fabricated a riot, called Brian "Ross" | 🤔 |

### Why the naive routing fails (and what this PR does instead)

The three-level rule says *concentrated in one channel -> channel directive*. But this channel **already has a maximal manual directive** (v2: *"only jump in when someone @-mentions you or clearly asks you by name... let the humans carry the conversation"*), and the gate fired at **0.9-1.0 anyway**. Reason (see `attention.py` `evaluate()`): the directive is injected as soft *"adjust the above"* guidance under a base policy that engages on any *"question"* and only ignores messages *"aimed at another specific **person** (not you)"*. A question aimed at the **friend group** ("you boys", "wanna play minecraft") trips engage and slips past ignore. The directive lever is saturated; the fix has to be in the two levers that can move. The autopilot corroborates: 4+ other channels' auto-directives have independently converged on "only when directly addressed, not group banter" — the whole fleet is compensating for the same base-policy gap.

## Change (both levers, per Joe's call to merge A + B)

**A. Pre-gate** (`attention.evaluate` prompt): group-addressed coordination and catching-up become explicit ignore cases; a bare question is no longer sufficient to engage when plainly aimed at other people. Stops the obvious barge-ins before a generation is wasted. Cites eps 224/227/233.

**B. Post-generation send-gate** (`attention.should_send` + `bot._stream_response`): a second, **disconnected** classify reads `directive + recent interaction + the drafted reply` and vetoes an ambient send that would barge in, pile on after a brush-off, or invent facts. This is the only lever that can catch eps 226/233, whose damage was entirely in the **reply** — the pre-gate is structurally blind to output. It is an independent critic, complementary to the in-band `no_reply` tool (the drafter's own choice).

### Design decisions
- **Scoped to the ambient chat path.** Vetoing a chat reply wastes one cheap in-monolith generation; vetoing after a heavy guest microVM would waste the VM. All five observed failures were chat replies.
- **Fails open** (send on classify error). The pre-gate already fails closed; if both failed closed, one blip would mute Bosun. `AMBIENT_SEND_GATE=0` disables it (and its extra call) without a redeploy.
- **Binary veto only** for v1 (no revise/shorten loop).

## Evidence -> diff
- `attention.py` group-address ignore clause + "question is not on its own a reason" caveat <- eps 224, 227, 233
- `attention.should_send` + `bot.py` send-gate wiring <- eps 226 (doubling-down), 233 (fabrication) — reply-quality misses the pre-gate can't see

## Tests
`attention_test.py`: `TestSendGate` (pass/veto/fail-open/disabled/JSON-in-prose/prompt-content) and `TestEngagePromptGroupAddressed` (pre-gate prompt now carries the group-address clauses).

## Out of scope, observed
Eps 228-231 (ScotScottMcA) became an agent run that crashed with `Unterminated string starting at line 1 column 7269` and delivered nothing. That is an **agent-run/infra failure owned by improve-recipes**, reported not diffed.

All 9 episodes classified to `s3://artifacts/ambient-evals/`. The next `/improve-ambient` run's before/after aggregates are the verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)