### PR TITLE
fix(semgrep-full): scope baseline to non-test files + bound scan memory

### DIFF
--- a/projects/firecracker/semgrep/guest-init/internal/fullscan/fullscan.go
+++ b/projects/firecracker/semgrep/guest-init/internal/fullscan/fullscan.go
@@ -81,8 +81,13 @@ func Scan(ctx context.Context, req vsockproto.ScanRequest, runner Runner) (vsock
 // metrics/version-check-off come from the env guestboot.SetupEnv set.
 func SemgrepRunner(rulesDir string) Runner {
 	return func(ctx context.Context, treeDir string) ([]byte, error) {
+		// --max-memory bounds the interfile analysis budget. Without it, semgrep
+		// defaults to 90% of the cgroup memory limit (the guest's memMib), so an
+		// 8Gi guest would let it grow to ~7.2Gi and risk OOM. 5000 MiB measured
+		// comfortable for the ~680-file non-test tree (peak ~6Gi total, well under
+		// the 8Gi guest) while leaving the engine headroom.
 		cmd := exec.CommandContext(ctx, "semgrep", "scan", "--pro",
-			"--config", rulesDir, "--metrics=off", "--json", treeDir)
+			"--config", rulesDir, "--max-memory", "5000", "--metrics=off", "--json", treeDir)
 		cmd.Stderr = os.Stderr
 		return cmd.Output()
 	}

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.65
+version: 0.4.66

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.65
+      targetRevision: 0.4.66
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.55
+version: 0.89.56
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.55
+      targetRevision: 0.89.56
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.129
+version: 0.285.130
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.129
+      targetRevision: 0.285.130
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/semgrep_scan/full_scan.py
+++ b/projects/monolith/semgrep_scan/full_scan.py
@@ -31,6 +31,31 @@ logger = logging.getLogger("monolith.semgrep.full_scan")
 
 _GITHUB_TIMEOUT = 30.0
 
+# Path patterns excluded from the whole-repo baseline scan. This mirrors the
+# Semgrep App's own "Path ignores" for the SMS project (tests, generated,
+# minified), so the self-hosted full scan covers the SAME source set as SMS and
+# the two projects compare like-for-like. It also roughly halves the file count
+# (1336 -> ~680 here), keeping the interfile scan inside the semgrep-full guest's
+# memory and time budget.
+_BASELINE_EXCLUDE_SUFFIXES = (
+    "_test.py",
+    "_test.go",
+    ".test.js",
+    ".test.ts",
+    ".test.tsx",
+    ".min.js",
+    "_pb2.py",
+)
+_BASELINE_EXCLUDE_DIRS = ("/testdata/", "/tests/", "/__mocks__/", "/node_modules/")
+
+
+def _excluded_from_baseline(path: str) -> bool:
+    """True if path is a test/generated/minified file the baseline scan skips."""
+    if path.endswith(_BASELINE_EXCLUDE_SUFFIXES):
+        return True
+    slashed = "/" + path
+    return any(d in slashed for d in _BASELINE_EXCLUDE_DIRS)
+
 
 async def _resolve_commit_sha(client: httpx.AsyncClient, repo: str, ref: str) -> str:
     """Resolve ``ref`` (e.g. ``main``) to its current commit sha via the REST API.
@@ -113,7 +138,9 @@ async def gather_main_files(repo: str, ref: str = "main") -> list[dict]:
         paths = [
             entry.get("path", "")
             for entry in tree_response.get("tree", [])
-            if entry.get("type") == "blob" and _is_scannable(entry.get("path", ""))
+            if entry.get("type") == "blob"
+            and _is_scannable(entry.get("path", ""))
+            and not _excluded_from_baseline(entry.get("path", ""))
         ]
 
         for path in paths:

--- a/projects/monolith/semgrep_scan/full_scan_test.py
+++ b/projects/monolith/semgrep_scan/full_scan_test.py
@@ -98,6 +98,28 @@ async def test_gather_main_files_filters_to_scannable_blobs():
         assert f["content"] == contents[f["path"]]
 
 
+def test_excluded_from_baseline():
+    """Tests, generated, and minified files are excluded from the baseline scan
+    (matching the SMS project path-ignores), source files are kept."""
+    excluded = [
+        "projects/monolith/semgrep_scan/full_scan_test.py",
+        "projects/firecracker/semgrep/guest-init/cmd/main_test.go",
+        "projects/monolith/frontend/foo.test.ts",
+        "projects/monolith/frontend/vendor.min.js",
+        "projects/monolith/grimoire/schema_pb2.py",
+        "projects/monolith/semgrep_scan/testdata/real_cli_output.py",
+    ]
+    kept = [
+        "projects/monolith/semgrep_scan/full_scan.py",
+        "projects/firecracker/semgrep/guest-init/cmd/main.go",
+        "projects/monolith/frontend/src/app.ts",
+    ]
+    for p in excluded:
+        assert full_scan._excluded_from_baseline(p), p
+    for p in kept:
+        assert not full_scan._excluded_from_baseline(p), p
+
+
 @pytest.mark.asyncio
 async def test_gather_main_files_logs_warning_on_truncated_tree(caplog):
     contents = {"projects/monolith/semgrep_scan/full_scan.py": "x = 1\n"}


### PR DESCRIPTION
## Why

Seeding the full baseline (proven working end-to-end) surfaced two scale issues, both **measured** in a debug pod running the guest image (fast loop, no redeploy):

| | full (1336 files) | non-test (~680 files) |
|---|---|---|
| body size | 11.2 MiB → **HTTP 413** (daemon 8 MiB cap) | 5.2 MiB (under cap) |
| wall time | 630s (> 600s guest timeout) | **338s** |
| peak RSS | ~6 GiB (cgroup-capped) | ~6 GiB with `--max-memory 5000` |
| interfile | Python | **Go, Python, TypeScript** |

## Fix

- **Exclude tests/generated/minified** from the gather (`_excluded_from_baseline`), mirroring the SMS project's own Path-ignores. This keeps the body under the daemon cap, halves the scan load to fit the existing 8 GiB / 600s guest, and makes the self-hosted baseline cover the **same source set as SMS** for a like-for-like comparison.
- **`--max-memory 5000`** on the guest scan. Without it semgrep budgets 90% of the guest cgroup (7.2 GiB of 8 GiB) and risks OOM; 5000 MiB measured comfortable (peak ~6 GiB).

No daemon body-cap or footprint change needed, the reduced scope fits the current sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)