### PR TITLE
fix(fc-shim): Content-Length for large invoke responses (unblocks full scan)

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.66
+version: 0.4.67

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.66
+      targetRevision: 0.4.67
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/firecracker/substrate/shim/server.go
+++ b/projects/firecracker/substrate/shim/server.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 )
 
 // Request carries the inbound /invoke call to a workload Handler. Path is the
@@ -113,6 +114,15 @@ func (s *Server) invokeHandler(w http.ResponseWriter, r *http.Request) {
 	status := http.StatusOK
 	if resp != nil && resp.Status != 0 {
 		status = resp.Status
+	}
+	// Set an explicit Content-Length so the response is fixed-length framed, not
+	// chunked. WriteHeader commits the response before the body is written, so
+	// without this Go falls back to chunked transfer-encoding; a large body (a
+	// whole-repo scan result is hundreds of KiB) chunked over the vsock transport
+	// surfaced as "malformed chunked encoding" resets on the daemon side. The body
+	// is a known-size []byte, so a Content-Length is always available and correct.
+	if resp != nil {
+		w.Header().Set("Content-Length", strconv.Itoa(len(resp.Body)))
 	}
 	w.WriteHeader(status)
 	if resp != nil {


### PR DESCRIPTION
## Why

The whole-repo `semgrep-full` scan **completes successfully** (243 findings over 649 files) but its ~224 KiB result fails to reach the daemon:

```
invoke: stream response body ... err="malformed chunked encoding"
vsock: error reading from backing stream ... ConnectionReset
```

The shim's `invokeHandler` calls `WriteHeader` before writing the body, so Go frames the response with **chunked** transfer-encoding. A large chunked body over the custom vsock HTTP transport resets on the daemon-side `io.Copy`.

## Fix

The response body is a known-size `[]byte`, so set an explicit `Content-Length` before `WriteHeader`. Go then uses fixed-length framing instead of chunked. Applies to every workload and is correct for the existing small responses too.

## Verify

Re-run the baseline seed; the full-scan result should reach the App (a full scan on `main` for `jomcgi/homelab-selfhosted`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)