### PR TITLE
fix(monolith): stop miscounting completed pods as unhealthy + reap CronWorkflow pods

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.130
+version: 0.285.131
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -53,6 +53,14 @@ spec:
       secondsAfterCompletion: 3600
       secondsAfterSuccess: 3600
       secondsAfterFailure: 86400
+    # Delete pods as soon as the workflow succeeds instead of letting them sit
+    # for the full ttlStrategy window (1h). The Workflow object still lingers
+    # per ttlStrategy for status visibility; only the finished pods are reaped
+    # promptly, so completed CronWorkflow pods do not accumulate in the
+    # namespace. Failed workflows keep their pods (OnWorkflowSuccess only) so a
+    # failure remains debuggable until secondsAfterFailure (24h) expires.
+    podGC:
+      strategy: OnWorkflowSuccess
     templates:
       - name: run
         container:

--- a/projects/monolith/cluster/summarize.py
+++ b/projects/monolith/cluster/summarize.py
@@ -219,8 +219,16 @@ def _row_unhealthy(kind: str, row: dict) -> bool:
     if kind == "pods":
         if row.get("reason"):
             return True
-        if row.get("phase") not in ("Running", "Succeeded", None):
+        phase = row.get("phase")
+        if phase not in ("Running", "Succeeded", None):
             return True
+        # A Succeeded pod has terminated all its containers, so it reports
+        # ready=0/N by design. That is a completed Job/CronWorkflow pod, not an
+        # unhealthy one, so the readiness check below (which flags any x/y with
+        # x != y) must not apply to it. Without this guard every finished batch
+        # pod is miscounted as unhealthy.
+        if phase == "Succeeded":
+            return False
         ready = row.get("ready")
         return bool(ready and ready.split("/")[0] != ready.split("/")[1])
     if kind in ("deployments", "statefulsets", "daemonsets", "replicasets"):

--- a/projects/monolith/cluster/summarize_test.py
+++ b/projects/monolith/cluster/summarize_test.py
@@ -81,6 +81,13 @@ class TestUnhealthy:
             "pods", {"phase": "Running", "reason": "CrashLoopBackOff"}
         )
 
+    def test_succeeded_pod_is_healthy(self):
+        # A completed Job/CronWorkflow pod reports ready=0/1 (containers
+        # terminated); it must not be flagged as unhealthy.
+        assert not summarize._row_unhealthy(
+            "pods", {"phase": "Succeeded", "ready": "0/1"}
+        )
+
     def test_partial_deployment_is_unhealthy(self):
         assert summarize._row_unhealthy("deployments", {"ready": "1/3"})
 
@@ -120,6 +127,25 @@ class TestBuildHealth:
                     "status": {
                         "phase": "Running",
                         "containerStatuses": [{"ready": True, "restartCount": 0}],
+                    },
+                }
+            ]
+        }
+        out = summarize.build_health(resources)
+        assert out["healthy"] is True
+        assert out["unhealthy"] == {}
+
+    def test_completed_batch_pod_is_healthy(self):
+        # Real Succeeded-pod shape: containers terminated, so ready is False.
+        # This is the path that previously miscounted every finished
+        # Job/CronWorkflow pod as unhealthy.
+        resources = {
+            "pods": [
+                {
+                    "metadata": {"name": "cron-1783792800"},
+                    "status": {
+                        "phase": "Succeeded",
+                        "containerStatuses": [{"ready": False, "restartCount": 0}],
                     },
                 }
             ]

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.130
+      targetRevision: 0.285.131
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

The cluster health dashboard reported ~44 "unhealthy" items, but a `kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded` returned **zero** pods. Nothing was actually broken.

Root cause is in our own `k8s-health-summary` classifier. `cluster/summarize._row_unhealthy` whitelists a `Succeeded` phase, then immediately applies a readiness check that flags any ready count `x/y` where `x != y`:

```python
if row.get("phase") not in ("Running", "Succeeded", None):
    return True
ready = row.get("ready")
return bool(ready and ready.split("/")[0] != ready.split("/")[1])  # fires on Succeeded pods
```

A completed pod has terminated containers, so it reports `ready=0/N` by design. Every finished Job/CronWorkflow pod (33 Argo CronWorkflows, install-time Jobs, debug pods) was therefore miscounted as unhealthy.

## Fix

1. **`summarize.py`**: return healthy for `phase == Succeeded` before the readiness check. Unit + `build_health` regression tests using the real Succeeded-pod object shape (`ready: False` containers).
2. **`cronworkflows.yaml`**: add `podGC: { strategy: OnWorkflowSuccess }` so finished pods are reaped promptly rather than lingering the full 1h `ttlStrategy` window. The Workflow object still persists per `ttlStrategy` for status visibility; failed workflows keep their pods until `secondsAfterFailure` (24h) for debugging.

Chart bumped to 0.285.131.

## Verification
- `helm template` renders `podGC` under every CronWorkflow, exit 0.
- Format + semgrep + conventional-commit hooks pass locally.
- Tests run in BuildBuddy CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)