### PR TITLE
fix(argocd): ignore Gateway-API server defaults on SSA HTTPRoutes

### DIFF
--- a/projects/mcp/context-forge-gateway/deploy/application.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/application.yaml
@@ -17,6 +17,21 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: mcp
+  # ServerSideApply=true (below) makes ArgoCD diff against a server-side-apply
+  # dry-run, which includes the Gateway-API-populated defaults on the HTTPRoute
+  # (parentRefs.group/kind, backendRefs.group/kind/weight). git omits those, so
+  # they read as permanent drift, leaving this app OutOfSync-but-Healthy. The
+  # cluster owns those fields, so tell ArgoCD to ignore them. (Non-SSA apps use
+  # ArgoCD's normalizer, which already drops these, so they never drift.)
+  ignoreDifferences:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jqPathExpressions:
+        - '.spec.parentRefs[].group'
+        - '.spec.parentRefs[].kind'
+        - '.spec.rules[].backendRefs[].group'
+        - '.spec.rules[].backendRefs[].kind'
+        - '.spec.rules[].backendRefs[].weight'
   syncPolicy:
     automated:
       prune: true

--- a/projects/platform/argocd/application.yaml
+++ b/projects/platform/argocd/application.yaml
@@ -20,6 +20,21 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd
+  # ServerSideApply=true (below) makes ArgoCD diff against a server-side-apply
+  # dry-run, which includes the Gateway-API-populated defaults on HTTPRoutes
+  # (parentRefs.group/kind, backendRefs.group/kind/weight). git omits those, so
+  # they read as permanent drift, leaving this app OutOfSync-but-Healthy. The
+  # cluster owns those fields, so tell ArgoCD to ignore them. (Non-SSA apps use
+  # ArgoCD's normalizer, which already drops these, so they never drift.)
+  ignoreDifferences:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jqPathExpressions:
+        - '.spec.parentRefs[].group'
+        - '.spec.parentRefs[].kind'
+        - '.spec.rules[].backendRefs[].group'
+        - '.spec.rules[].backendRefs[].kind'
+        - '.spec.rules[].backendRefs[].weight'
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Problem

`argocd` and `context-forge-gateway` sit permanently `OutOfSync` (but `Healthy`). A hard refresh does not clear it, and `kubectl diff` of the rendered HTTPRoute against live is clean.

## Root cause

Both apps set `ServerSideApply=true`. With SSA, ArgoCD computes its diff from a server-side-apply dry-run, whose result includes the Gateway-API-populated default fields on the HTTPRoute:

- `spec.parentRefs[].group` = `gateway.networking.k8s.io`, `.kind` = `Gateway`
- `spec.rules[].backendRefs[].group` = `""`, `.kind` = `Service`, `.weight` = `1`

git omits those fields, so ArgoCD reports permanent drift. Apps **without** SSA (e.g. `monolith-public`, whose identical routes carry the same live defaults) use ArgoCD's built-in normalizer, which drops these, so they stay Synced. That asymmetry is the whole bug.

## Fix

Add `ignoreDifferences` for those five server-populated paths to both Application manifests. This is the idiomatic ArgoCD remediation for cluster-owned fields and clears the false OutOfSync without disabling SSA (both apps need SSA for large-CRD / annotation-size reasons).

## Verification
- Confirmed live: the diff is exactly and only those five defaulted fields (structured deep-diff of git render vs live spec).
- Confirmed `monolith-public` (non-SSA) has the same live defaults yet is Synced.
- Post-merge: both apps should report Synced once the root app-of-apps applies the updated Application specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)