### PR TITLE
feat(monolith): schedule the semgrep full interfile baseline (Task 5)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.56
+version: 0.89.57
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.56
+      targetRevision: 0.89.57
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import logging
+import os
 
 import typer
 
@@ -413,6 +414,31 @@ def evict_artifact_sessions() -> None:
     logger.info("evict-artifact-sessions: starting")
     evict_stale_sessions_handler()
     logger.info("evict-artifact-sessions: done")
+
+
+@app.command("semgrep-full-scan-trigger")
+def semgrep_full_scan_trigger() -> None:
+    """Trigger the whole-repo Semgrep interfile baseline scan of main.
+
+    Deliberately lightweight: it POSTs the running API pod's internal endpoint,
+    which fires run_full_scan IN THAT process (where the semgrep package, the
+    Semgrep App + GitHub tokens, and a daemon-allowed ServiceAccount already
+    live). The heavy scan runs in the API pod, not this ephemeral job pod, so the
+    job needs no semgrep deps, no tokens, and no daemon access, just HTTP.
+    """
+    import httpx
+
+    configure_logging()
+    # Injected from Helm (the cron job's env), never hardcoded: a release rename
+    # changes the service DNS name, so a baked default would silently break.
+    url = os.environ.get("MONOLITH_INTERNAL_URL", "")
+    if not url:
+        raise RuntimeError("MONOLITH_INTERNAL_URL is not set")
+    logger.info("semgrep-full-scan-trigger: POST %s/internal/semgrep/full-scan", url)
+    resp = httpx.post(f"{url}/internal/semgrep/full-scan", timeout=30)
+    resp.raise_for_status()
+    body = resp.json()
+    logger.info("semgrep-full-scan-trigger: %s", body)
 
 
 if __name__ == "__main__":

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.131
+version: 0.285.132
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -646,6 +646,28 @@ jobs:
           memory: 256Mi
         limits:
           memory: 256Mi
+    # Self-hosted Semgrep (Route B) whole-repo interfile baseline scan of main
+    # (ADR tooling/011). This job only POSTs the API pod's internal trigger; the
+    # actual whole-repo interfile scan runs in the API pod against the semgrep-full
+    # fc-invoke workload (minutes), so the job pod is tiny and short-lived. Daily
+    # keeps the App baseline fresh; Forbid + the API-side in-flight guard prevent
+    # overlap with the single-concurrency semgrep-full workload.
+    - name: semgrep-full-scan
+      args: ["semgrep-full-scan-trigger"]
+      schedule: "0 5 * * *" # daily 05:00 UTC
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 120
+      suspend: false
+      env:
+        # The in-cluster API service the trigger POSTs; injected here (not baked
+        # in code) so a release rename cannot silently break the DNS name.
+        MONOLITH_INTERNAL_URL: "http://monolith.monolith.svc.cluster.local:8000"
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
 
 frontend:
   otelCollectorUrl: ""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.131
+      targetRevision: 0.285.132
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/semgrep_scan/__init__.py
+++ b/projects/monolith/semgrep_scan/__init__.py
@@ -28,6 +28,7 @@ def register(app: FastAPI) -> None:
     is only pulled in when the app actually wires the router, mirroring the other
     domains' registration.
     """
-    from semgrep_scan.router import router
+    from semgrep_scan.router import internal_router, router
 
     app.include_router(router)
+    app.include_router(internal_router)

--- a/projects/monolith/semgrep_scan/router.py
+++ b/projects/monolith/semgrep_scan/router.py
@@ -29,6 +29,7 @@ would be rejected by a SecurityPolicy. The HMAC check above is the real gate.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import hmac
@@ -47,6 +48,52 @@ from semgrep_scan.report import report_pr_scan
 logger = logging.getLogger("monolith.semgrep.webhook")
 
 router = APIRouter(prefix="/webhooks/github", tags=["semgrep-webhook"])
+
+# Internal, in-cluster-only trigger for the whole-repo baseline scan. It lives
+# under /internal (the CF-Access-gated catch-all route, NOT the Access-bypassed
+# /webhooks/github/semgrep path), so externally it is auth-gated; in-cluster the
+# scheduled jobs pod reaches it directly. It fires run_full_scan in THIS process
+# (which has the semgrep package loaded, the App/GitHub tokens, and a
+# daemon-allowed ServiceAccount), so the lightweight jobs pod needs none of that.
+internal_router = APIRouter(prefix="/internal/semgrep", tags=["semgrep-internal"])
+
+# Guards against overlapping whole-repo scans: a second trigger while one is in
+# flight is a no-op rather than a second (heavy, daemon-concurrency-1) scan.
+_full_scan_in_flight = False
+_full_scan_tasks: set[asyncio.Task] = set()
+
+
+@internal_router.post("/full-scan")
+async def trigger_full_scan(repo: str = "jomcgi/homelab") -> dict:
+    """Fire the whole-repo interfile baseline scan of ``repo``'s main branch as a
+    background task and return immediately. Internal only (see internal_router).
+
+    Runs semgrep_scan.full_scan.run_full_scan in-process: gather all of main,
+    scan on the semgrep-full workload, report a full scan to the Semgrep App. The
+    scan takes minutes, so it is never awaited on the request.
+    """
+    global _full_scan_in_flight
+    if _full_scan_in_flight:
+        return {"status": "already-running", "repo": repo}
+
+    async def _run() -> None:
+        global _full_scan_in_flight
+        _full_scan_in_flight = True
+        try:
+            from semgrep_scan.full_scan import run_full_scan
+
+            await run_full_scan(repo)
+        except Exception:
+            logger.exception("trigger_full_scan: run_full_scan crashed for %s", repo)
+        finally:
+            _full_scan_in_flight = False
+
+    task = asyncio.create_task(_run())
+    _full_scan_tasks.add(task)
+    task.add_done_callback(_full_scan_tasks.discard)
+    logger.info("trigger_full_scan: launched background full scan for %s", repo)
+    return {"status": "started", "repo": repo}
+
 
 # PR actions worth scanning: a fresh PR, a new push to an open PR, and a reopen.
 # Everything else (labeled, closed, review requests, ...) is acked with no work.

--- a/projects/monolith/semgrep_scan/router_test.py
+++ b/projects/monolith/semgrep_scan/router_test.py
@@ -44,6 +44,34 @@ def client(monkeypatch):
     return TestClient(app)
 
 
+def test_internal_full_scan_trigger_launches_and_guards(monkeypatch):
+    """POST /internal/semgrep/full-scan returns started and launches run_full_scan
+    in the background; a second call while one is in flight is a no-op."""
+    app = FastAPI()
+    app.include_router(webhook.internal_router)
+    c = TestClient(app)
+
+    calls: list[str] = []
+
+    async def _fake_run(repo):
+        calls.append(repo)
+
+    # Pin the module-level guard so the "already-running" branch is deterministic.
+    monkeypatch.setattr(webhook, "_full_scan_in_flight", True, raising=False)
+    resp = c.post("/internal/semgrep/full-scan")
+    assert resp.status_code == 200
+    assert resp.json().get("status") == "already-running"
+
+    monkeypatch.setattr(webhook, "_full_scan_in_flight", False, raising=False)
+    with mock.patch(
+        "semgrep_scan.full_scan.run_full_scan",
+        new=mock.AsyncMock(side_effect=_fake_run),
+    ):
+        resp = c.post("/internal/semgrep/full-scan?repo=jomcgi/homelab")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "started", "repo": "jomcgi/homelab"}
+
+
 def _sign(body: bytes, secret: str = _SECRET) -> str:
     """Compute the ``sha256=<hex>`` header GitHub would send for ``body``."""
     digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()


### PR DESCRIPTION
## What

Task 5 of ADR tooling/011: a daily Argo CronWorkflow (`semgrep-full-scan`, 05:00 UTC, `Forbid`) that refreshes the whole-repo interfile baseline.

The job pod is deliberately tiny: it only POSTs a new in-cluster endpoint `POST /internal/semgrep/full-scan` on the API pod, which runs `run_full_scan` **in that process**, where the semgrep package, the Semgrep App + GitHub tokens, and a daemon-allowed ServiceAccount already live. So the job needs no semgrep deps, no tokens, and no daemon access.

- **Endpoint** launches the scan as a background task with an in-flight guard (overlapping triggers no-op).
- `/internal` sits under the CF-Access-gated catch-all route, so it is not publicly reachable; in-cluster the job reaches it directly.
- API URL injected via Helm env (`MONOLITH_INTERNAL_URL`), not hardcoded (our own `no-hardcoded-k8s-service-url` rule caught the first attempt).

## Context

The interfile scan is already live and a baseline is seeded (250 findings on `main`). This just automates the refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)