### PR TITLE
fix(chat): never suppress a direct @mention in an ambient channel

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.132
+version: 0.285.133
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/attention.py
+++ b/projects/monolith/chat/attention.py
@@ -35,6 +35,13 @@ SEND_GATE_ENABLED = os.environ.get("AMBIENT_SEND_GATE", "1") != "0"
 class AttentionResult:
     engage: bool
     confidence: float
+    # True when this engage is an explicit summons (a hard @mention, a reply to
+    # Bosun, or a caller-supplied ``directed`` signal), as opposed to a soft
+    # ambient interjection the classifier chose to join. The caller uses this to
+    # keep an explicit summons on the live (never-suppressed) reply path even in
+    # an ambient channel: someone who @-mentioned Bosun is waiting on an answer,
+    # so the no_reply tool and the post-generation send-gate must not eat it.
+    explicit: bool = False
 
 
 async def evaluate(
@@ -65,7 +72,7 @@ async def evaluate(
     # non-Discord channels use; it keeps should_respond off the hot path when
     # bot_user is None (WhatsApp has no Discord user object).
     if directed:
-        return AttentionResult(True, 1.0)
+        return AttentionResult(True, 1.0, explicit=True)
 
     from chat.bot import should_respond  # mention/reply detection (lazy to avoid cycle)
 
@@ -73,7 +80,7 @@ async def evaluate(
     # engaged (they set directed instead); guard the Discord-only check so a
     # WhatsApp adapter never hits should_respond's <@id> mention parsing.
     if bot_user is not None and should_respond(message, bot_user):
-        return AttentionResult(True, 1.0)
+        return AttentionResult(True, 1.0, explicit=True)
     if not is_ambient:
         return AttentionResult(False, 0.0)
     # Ambient channel: classify.

--- a/projects/monolith/chat/attention_test.py
+++ b/projects/monolith/chat/attention_test.py
@@ -36,6 +36,27 @@ class TestExplicitTrigger:
         )
         assert result.engage is True
         assert result.confidence == 1.0
+        # A hard @mention is an explicit summons: the caller keeps it on the
+        # live, never-suppressed reply path even in an ambient channel.
+        assert result.explicit is True
+        caller.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mention_in_ambient_channel_is_explicit(self):
+        # The bug this guards: a direct @mention inside an ambient channel must
+        # still be flagged explicit so the no_reply tool / send-gate cannot eat
+        # it (the mention short-circuits before the classifier either way).
+        message = _make_message(mentions=[_BOT_USER])
+        caller = AsyncMock()
+        result = await evaluate(
+            message,
+            "only jump in when @-mentioned",
+            _BOT_USER,
+            is_ambient=True,
+            _caller=caller,
+        )
+        assert result.engage is True
+        assert result.explicit is True
         caller.assert_not_called()
 
 
@@ -62,6 +83,9 @@ class TestAmbientClassification:
         )
         assert result.engage is True
         assert result.confidence == 0.9
+        # A soft classifier engage is NOT an explicit summons, so it stays on
+        # the suppressible ambient path (no_reply tool / send-gate can veto it).
+        assert result.explicit is False
         caller.assert_called_once()
 
     @pytest.mark.asyncio
@@ -313,6 +337,9 @@ class TestDirectedSeam:
         )
         assert result.engage is True
         assert result.confidence == 1.0
+        # A caller-supplied directedness signal (reply-to-bot / trigger-name) is
+        # also an explicit summons.
+        assert result.explicit is True
         caller.assert_not_called()
 
     @pytest.mark.asyncio

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -946,7 +946,10 @@ class ChatBot(discord.Client):
                     await self._engage_agent(message)
                 else:
                     await self._process_message(
-                        message, force_respond=True, directive=directive
+                        message,
+                        force_respond=True,
+                        explicit=result.explicit,
+                        directive=directive,
                     )
                 return
 
@@ -1767,16 +1770,23 @@ class ChatBot(discord.Client):
         self,
         message: discord.Message,
         force_respond: bool = False,
+        explicit: bool = False,
         directive: str | None = None,
     ) -> None:
         """Process a message that this pod has locked.
 
         ``force_respond`` skips the ``should_respond`` gate so an ambient
         engage that the depth classify routed to chat (ADR 035 Phase 4) still
-        gets a reply even though it's not a mention/reply. ``directive`` is the
-        channel directive already fetched by ``on_message`` for the pre-gate,
-        threaded through to the post-generation send-gate so it is not read from
-        the DB a second time; only the ambient (force_respond) path passes it.
+        gets a reply even though it's not a mention/reply. ``explicit`` marks an
+        ambient engage that is actually a hard summons (a direct @mention or a
+        reply to Bosun): it keeps the reply on the live, never-suppressed path
+        even though ``force_respond`` routed it here, so the no_reply tool and
+        the post-generation send-gate cannot silently eat an answer someone is
+        waiting on. (A soft ambient interjection leaves ``explicit`` False and
+        stays suppressible.) ``directive`` is the channel directive already
+        fetched by ``on_message`` for the pre-gate, threaded through to the
+        post-generation send-gate so it is not read from the DB a second time;
+        only the ambient (force_respond) path passes it.
         """
         msg_id = str(message.id)
         channel_id = str(message.channel.id)
@@ -1828,7 +1838,10 @@ class ChatBot(discord.Client):
                     message,
                     attachments,
                     with_buttons=not force_respond,
-                    live=not force_respond,
+                    # An explicit summons is always live (never suppressed),
+                    # even on the ambient force_respond path: the mention set
+                    # engage=1.0, so a person is waiting on an answer.
+                    live=(not force_respond) or explicit,
                     directive=directive,
                 )
         except Exception:

--- a/projects/monolith/chat/bot_embeddable_content_test.py
+++ b/projects/monolith/chat/bot_embeddable_content_test.py
@@ -303,3 +303,63 @@ class TestProcessMessageEarlyReturn:
 
         # save_message should have been called (message was stored)
         mock_store.save_message.assert_called()
+
+
+class TestExplicitSummonsIsLive:
+    """An explicit summons (a direct @mention / reply to Bosun) routed to the
+    ambient chat path must be marked live=True so the no_reply tool and the
+    post-generation send-gate cannot silently eat it (the ep-236 regression)."""
+
+    def _make_msg(self):
+        msg = MagicMock()
+        msg.id = 7
+        msg.content = "<@1> the site is cool, true or false?"
+        msg.attachments = []
+        msg.author.bot = False
+        msg.author.id = 42
+        msg.author.display_name = "TestUser"
+        msg.channel.id = 99
+        msg.mentions = []
+        msg.reference = None
+        msg.reply = AsyncMock(return_value=MagicMock(id=200))
+        msg.channel.typing = MagicMock(return_value=_async_cm())
+        return msg
+
+    def _make_store(self):
+        store = AsyncMock()
+        store.save_message = AsyncMock()
+        store.mark_completed = MagicMock()
+        return store
+
+    async def _run(self, *, force_respond: bool, explicit: bool):
+        bot = _make_bot()
+        msg = self._make_msg()
+        mock_store = self._make_store()
+        stream = AsyncMock(return_value=(None, "", None))
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+            patch("chat.bot.download_image_attachments", AsyncMock(return_value=[])),
+            patch.object(bot, "_stream_response", stream),
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot._process_message(
+                msg, force_respond=force_respond, explicit=explicit
+            )
+        return stream
+
+    @pytest.mark.asyncio
+    async def test_explicit_ambient_engage_is_live(self):
+        stream = await self._run(force_respond=True, explicit=True)
+        stream.assert_called_once()
+        assert stream.call_args.kwargs["live"] is True
+
+    @pytest.mark.asyncio
+    async def test_soft_ambient_engage_stays_suppressible(self):
+        stream = await self._run(force_respond=True, explicit=False)
+        stream.assert_called_once()
+        assert stream.call_args.kwargs["live"] is False

--- a/projects/monolith/chat/bot_on_message_test.py
+++ b/projects/monolith/chat/bot_on_message_test.py
@@ -511,7 +511,11 @@ class TestAttentionGate:
             patch("chat.bot.attention_log.log_decision", MagicMock()),
             patch(
                 "chat.bot.attention.evaluate",
-                AsyncMock(return_value=SimpleNamespace(engage=True, confidence=0.9)),
+                AsyncMock(
+                    return_value=SimpleNamespace(
+                        engage=True, confidence=0.9, explicit=False
+                    )
+                ),
             ),
             patch(
                 "chat.bot.attention.needs_agent", AsyncMock(return_value=False)
@@ -524,7 +528,9 @@ class TestAttentionGate:
             patch.object(bot, "start_agent_flow", AsyncMock()) as mock_start_flow,
             patch.object(bot, "_process_message", AsyncMock()) as mock_proc,
         ):
-            mock_evaluate.return_value = SimpleNamespace(engage=True, confidence=0.9)
+            mock_evaluate.return_value = SimpleNamespace(
+                engage=True, confidence=0.9, explicit=False
+            )
             mock_session_cls.return_value.__enter__ = MagicMock(
                 return_value=MagicMock()
             )
@@ -535,10 +541,65 @@ class TestAttentionGate:
             assert mock_evaluate.call_args.kwargs.get("recently_tagged") is True
             mock_needs_agent.assert_called_once()
             # The directive fetched for the pre-gate is threaded through to the
-            # post-generation send-gate rather than re-read from the DB.
-            mock_proc.assert_called_once_with(message, force_respond=True, directive="")
+            # post-generation send-gate rather than re-read from the DB. A soft
+            # classifier engage is not an explicit summons, so explicit=False and
+            # the reply stays suppressible.
+            mock_proc.assert_called_once_with(
+                message, force_respond=True, explicit=False, directive=""
+            )
             mock_engage_agent.assert_not_called()
             mock_start_flow.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_explicit_ambient_engage_marks_reply_live(self):
+        """A direct @mention in an ambient channel that routes to chat is an
+        explicit summons: on_message threads explicit=True into _process_message
+        so the no_reply tool / send-gate cannot silently eat an answer someone is
+        waiting on (the ep-236 regression)."""
+        bot = _make_bot()
+
+        message = _make_message(content="<@1> the site is cool, true or false?")
+        message.reference = None
+        message.guild = None
+        message.channel = MagicMock(spec=discord.TextChannel)
+        message.channel.id = 99
+
+        mock_store = _make_store()
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+            patch("chat.bot.acl.ambient_channels", return_value={"99"}),
+            patch("chat.bot.directives.get_active", return_value="only @-mentions"),
+            patch("chat.bot.directives.get_active_version", return_value=4),
+            patch("chat.bot.attention_log.log_decision", MagicMock()),
+            patch("chat.bot.attention.needs_agent", AsyncMock(return_value=False)),
+            patch.object(bot, "_recently_tagged", MagicMock(return_value=False)),
+            patch(
+                "chat.bot.attention.evaluate",
+                AsyncMock(
+                    return_value=SimpleNamespace(
+                        engage=True, confidence=1.0, explicit=True
+                    )
+                ),
+            ),
+            patch.object(bot, "_engage_agent", AsyncMock()) as mock_engage_agent,
+            patch.object(bot, "_process_message", AsyncMock()) as mock_proc,
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot.on_message(message)
+
+            mock_proc.assert_called_once_with(
+                message,
+                force_respond=True,
+                explicit=True,
+                directive="only @-mentions",
+            )
+            mock_engage_agent.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_mention_in_ambient_channel_without_grant_gets_refusal(self):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.132
+      targetRevision: 0.285.133
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

A direct `@mention` (or reply to Bosun) in an **ambient-granted** channel engaged correctly at confidence 1.0, but was then handed to the ambient chat path with `force_respond=True`, which sets `live=False`. Both silence gates, the `no_reply` tool (`bot.py`) and the post-generation send-gate (PR #3399), only fire when `not live`. So an explicit summons became suppressible: Bosun could silently decline to answer a message where a user explicitly @-mentioned it with a direct question.

The attention gate already *knew* it was a hard mention (`evaluate` returns 1.0 via `should_respond`), but that fact was discarded downstream, so a 1.0 summons and a soft "maybe chime in" reached the suppressor identically.

### Evidence (episodes 236/237, gaming channel `1375032589093703680`)

- **ep 236**: Ochinchin: `<@bosun> The site is cool but... true or false` → engaged **conf 1.0** → `reply_message_id` null, **zero reply**.
- **ep 237**: bjeambusher: "good call brosun, he didn't want you to reply anyway" → Bosun read the sarcasm as a literal instruction and invoked `no_reply` again.

Diagnostics also confirmed this is **not** a broad guard over-fire: ambient engage volume is normal (17/day), the two-gate's target channel still replied to 20/21 engages, and the send-gate had 0 suppressions in the sampled pod. The defect is scope, not calibration: the silence gates are correct for *unsolicited* interjections but must never eat an *explicit summons*.

## Fix (Option A)

- `AttentionResult.explicit` exposes the explicit-summons signal (True for a hard mention, a reply to Bosun, and the caller-supplied `directed` seam).
- `on_message` threads `explicit` into `_process_message`.
- `_process_message` computes `live = (not force_respond) or explicit`.

An explicit summons stays on the ambient engage path (its reply id is still linked back to the engage row for /improve-ambient) but is marked `live`, so `no_reply` and the send-gate cannot eat it. A soft classifier engage keeps `explicit=False` and stays suppressible, unchanged.

## Tests

- `attention_test`: mentions/directed flagged `explicit=True`; soft classify engage `explicit=False`.
- `bot_on_message_test`: `on_message` threads `explicit` through to `_process_message` (both soft and explicit variants).
- `bot_embeddable_content_test`: `_process_message(explicit=True)` → `_stream_response(live=True)`; `explicit=False` → `live=False`.
- Existing `bot_streaming_test` already asserts `live=True` is never suppressed by the send-gate or the empty/no_reply path.

Chart bumped to 0.285.133 (prompt/gate edits deploy via the monolith image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)