### PR TITLE
perf(monolith): run Semgrep App report off the event loop

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.57
+version: 0.89.58
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.57
+      targetRevision: 0.89.58
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.133
+version: 0.285.134
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.133
+      targetRevision: 0.285.134
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/semgrep_scan/report.py
+++ b/projects/monolith/semgrep_scan/report.py
@@ -84,6 +84,7 @@ THE THREE-ENDPOINT FLOW (verified against pinned 1.168.0 ``app/scans.py``):
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -550,6 +551,46 @@ def _report_failure(scan_id: int, exit_code: int) -> None:
 
 
 async def report_pr_scan(
+    *,
+    repo: str,
+    branch: str,
+    commit: str,
+    pr_id: str | None = None,
+    base_ref: Optional[str] = None,
+    raw_cli_output: dict[str, Any] | str,
+    project_id: Optional[str] = None,
+    repo_url: Optional[str] = None,
+    scan_execution_duration: Optional[float] = None,
+    dry_run: bool = False,
+    is_full_scan: bool = False,
+) -> dict[str, Any]:
+    """Report an fc-invoke scan to the Semgrep App (non-blocking async wrapper).
+
+    The actual work (mapping cli_output into ``out.Finding`` objects and the
+    synchronous CREATE / ``/results`` / ``/complete`` ``httpx`` POSTs) is CPU- and
+    sync-IO-bound and does NOT await, so running it inline on the event loop would
+    block it, briefly for a PR diff, longer for a whole-repo full scan (hundreds
+    of findings + a ~224 KiB payload). Run it in a worker thread so the API pod's
+    event loop keeps serving live requests. The thread never touches loop objects
+    (plain env reads + sync httpx), so it is safe.
+    """
+    return await asyncio.to_thread(
+        _report_pr_scan_blocking,
+        repo=repo,
+        branch=branch,
+        commit=commit,
+        pr_id=pr_id,
+        base_ref=base_ref,
+        raw_cli_output=raw_cli_output,
+        project_id=project_id,
+        repo_url=repo_url,
+        scan_execution_duration=scan_execution_duration,
+        dry_run=dry_run,
+        is_full_scan=is_full_scan,
+    )
+
+
+def _report_pr_scan_blocking(
     *,
     repo: str,
     branch: str,


### PR DESCRIPTION
## Why

`report_pr_scan` is `async def` but contains **no awaits**: it maps cli_output into `out.Finding` objects (CPU) and does the CREATE / `/results` / `/complete` uploads with **synchronous** `httpx.post`. So awaiting it blocks the event loop for the entire report.

That's negligible for a single-file PR diff, but the daily whole-repo baseline scan builds ~250 findings from a ~224 KiB payload plus 3 network round-trips, all on the API pod that serves live website + MCP traffic. This is the "keep the API pod fast" concern raised on the schedule design.

## Fix

Move the body to a synchronous `_report_pr_scan_blocking`; `report_pr_scan` becomes a thin async wrapper that runs it via `asyncio.to_thread`. The event loop stays responsive during the report (full scan and every PR scan). The thread only touches env reads + sync httpx, no loop objects, so it's safe.

The scheduling architecture is unchanged: CronWorkflow → tiny job pod → API-pod trigger endpoint → gather + daemon scan + report. Only the report step stops stalling the loop. (Isolating the whole job to the workflow pod isn't viable: `monolith-workflows` is unmeshed and the fc-invoke daemon is Linkerd-locked to the monolith's mesh identity, so the daemon call must originate from the meshed API pod.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)