### PR TITLE
feat(monolith): cut Route B semgrep reporting over to the real project

### DIFF
--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -154,7 +154,14 @@ semgrep:
   # Route B shadow project (Route B vs SMS comparison): self-hosted scans report
   # here instead of jomcgi/homelab, so they land in a separate Semgrep project.
   # UNSET this single value at cutover to report to the real project.
-  shadowProject: "jomcgi/homelab-selfhosted"
+  # CUT OVER 2026-07-11: Route B now reports to the REAL jomcgi/homelab project
+  # (empty -> report.py _reported_repository returns the real repo). The shadow
+  # project recorded scan findingsCounts but the App's "See findings" view is
+  # gated on a GitHub SCM integration a synthetic shadow repo cannot have, so
+  # findings never showed. The connected real project indexes them (Route B vs SMS
+  # distinguishable by scan environment "homelab-fc-invoke"). Re-set to
+  # "jomcgi/homelab-selfhosted" to revert to the shadow.
+  shadowProject: ""
   # Semgrep AppSec Platform token for the Route B CI-reporting relay. The vault
   # item exposes the field SEMGREP_API_TOKEN, mirrored into the
   # monolith-semgrep-app Secret and injected as the SEMGREP_APP_TOKEN env var


### PR DESCRIPTION
## What

Unset `SEMGREP_SHADOW_PROJECT` so self-hosted (Route B / fc-invoke) scans report to the real `jomcgi/homelab` Semgrep project instead of the `jomcgi/homelab-selfhosted` shadow.

## Why

The shadow project recorded each scan's `findingsCounts` (e.g. 250 on the full `main` scan) but **could not surface the findings** in the App's "See findings" view. That view is gated on a GitHub **SCM integration**, which a synthetic shadow repo can't have (`scmType: UNSPECIFIED`). The real project is SCM-connected (`SCM_TYPE_GITHUB`), so Route B's findings will index and be viewable, alongside SMS's, distinguishable by scan environment (`homelab-fc-invoke`) and scan type.

Values-only change, applied by ArgoCD via the `$values` git ref, no chart bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)