### PR TITLE
chore(fc-invoke): bump chart to 0.4.68 to republish drifted image digests

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.67
+version: 0.4.68

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.67
+      targetRevision: 0.4.68
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## What

One-line re-bump of the fc-invoke (firecracker/substrate) chart, `0.4.67 -> 0.4.68`, via `bazel/tools/git/bump-chart.sh`.

## Why

The global `Push images` missed-bump guard is failing on **every** open PR with:

> ERROR: fc-invoke 0.4.67 is already published, but its pinned image digests differ from the published chart (an image was rebuilt).

fc-invoke's image rebuilds to a different digest than 0.4.67 pinned (an image dependency drifted after 0.4.67 was published). Because the guard validates all charts, this blocks unrelated PRs (three stacked semgrep-digest bot PRs could never go green). Re-bumping republishes the chart with the current digests and clears the guard for everyone.

No template/values changes, deploy is a no-op digest refresh.