### PR TITLE
feat(bump-chart): skip versions already claimed by open PRs

### DIFF
--- a/bazel/tools/git/bump-chart.sh
+++ b/bazel/tools/git/bump-chart.sh
@@ -5,7 +5,10 @@
 # `targetRevision:` in <project>/deploy/application.yaml together, computing
 # the new number from the version at origin/main tip (not the local checkout),
 # so concurrent sessions cannot pick the same number twice. Optionally verifies
-# the candidate version is not already published to the OCI registry.
+# the candidate version is not already published to the OCI registry NOR already
+# claimed by another open PR (a version two PRs pick from the same tip does not
+# textually conflict on rebase - git auto-merges identical hunks - so it would
+# otherwise slip through to a loud "already published" failure at merge time).
 #
 # Usage:
 #   bazel/tools/git/bump-chart.sh <projects/<svc>[/chart]> [options]
@@ -18,6 +21,9 @@
 #
 # Environment:
 #   BUMP_CHART_SKIP_REGISTRY_CHECK=1  skip the OCI registry existence probe
+#   BUMP_CHART_SKIP_PR_CHECK=1       skip the open-PR claimed-version scan
+#   BUMP_CHART_CLAIMED_VERSIONS=...  inject the open-PR claimed set (newline or
+#                                    space separated); bypasses the gh scan (tests)
 #   BUMP_CHART_MAIN_VERSION=X.Y.Z    override the origin/main version (tests)
 #   BUMP_CHART_REPO_ROOT=/path       override the repo root (tests)
 #   BUMP_CHART_REPOSITORY=oci://...  override the chart registry
@@ -139,19 +145,60 @@ else
 	NEW_VERSION=$(increment "$BASE_VERSION" "$BUMP_KIND")
 fi
 
-# Best-effort registry probe: if the candidate is already published (another
-# session got there first), keep incrementing the patch until a free number is
-# found. A probe failure is treated as "free" (network flake must not block).
-if [[ "${BUMP_CHART_SKIP_REGISTRY_CHECK:-}" != "1" ]] && command -v helm >/dev/null 2>&1; then
-	for _ in $(seq 1 20); do
-		if helm show chart "${REPOSITORY}/${CHART_NAME}" --version "$NEW_VERSION" >/dev/null 2>&1; then
-			echo "Version ${NEW_VERSION} already published in the registry; trying the next patch."
-			NEW_VERSION=$(increment "$NEW_VERSION" "patch")
-		else
-			break
-		fi
-	done
+# Best-effort scan of the semver versions THIS chart's Chart.yaml already carries
+# on OTHER open PR branches. Two PRs that bump from the same origin/main tip pick
+# the SAME number; on rebase git sees an identical hunk on both sides and
+# auto-merges it (no conflict), so the duplicate reaches main and only trips the
+# loud "already published" guard at merge time. Reading each open PR's claimed
+# version here lets us skip a number a pending PR already took, before the
+# collision lands. gh/API failures yield no claims: a flaky network must never
+# block a bump.
+open_pr_versions() {
+	local self branches br v
+	self="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+	branches="$(gh pr list --state open --json headRefName --jq '.[].headRefName' 2>/dev/null || true)"
+	while IFS= read -r br; do
+		[[ -n "$br" && "$br" != "$self" ]] || continue
+		# Read Chart.yaml as it exists on that PR branch (raw, so no base64 decode).
+		v="$(gh api "repos/{owner}/{repo}/contents/${CHART_YAML}?ref=${br}" \
+			-H "Accept: application/vnd.github.raw" 2>/dev/null |
+			grep '^version:' | head -1 | awk '{print $2}' | tr -d '"' || true)"
+		[[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && printf '%s\n' "$v"
+	done <<<"$branches"
+}
+
+# Explicit injection wins (tests); otherwise scan live unless disabled or gh is
+# unavailable (mirrors the helm guard on the registry probe below).
+if [[ -n "${BUMP_CHART_CLAIMED_VERSIONS+x}" ]]; then
+	CLAIMED_VERSIONS="${BUMP_CHART_CLAIMED_VERSIONS}"
+elif [[ "${BUMP_CHART_SKIP_PR_CHECK:-}" != "1" ]] && command -v gh >/dev/null 2>&1; then
+	CLAIMED_VERSIONS="$(open_pr_versions)"
+else
+	CLAIMED_VERSIONS=""
 fi
+
+registry_has() {
+	[[ "${BUMP_CHART_SKIP_REGISTRY_CHECK:-}" != "1" ]] && command -v helm >/dev/null 2>&1 || return 1
+	helm show chart "${REPOSITORY}/${CHART_NAME}" --version "$1" >/dev/null 2>&1
+}
+
+pr_claims() {
+	[[ -n "$CLAIMED_VERSIONS" ]] && grep -qxF "$1" <<<"$CLAIMED_VERSIONS"
+}
+
+# Keep incrementing the patch until a number that is neither published nor
+# claimed by an open PR is found. A probe failure is treated as "free".
+for _ in $(seq 1 40); do
+	if registry_has "$NEW_VERSION"; then
+		echo "Version ${NEW_VERSION} already published in the registry; trying the next patch."
+		NEW_VERSION=$(increment "$NEW_VERSION" "patch")
+	elif pr_claims "$NEW_VERSION"; then
+		echo "Version ${NEW_VERSION} already claimed by an open PR; trying the next patch."
+		NEW_VERSION=$(increment "$NEW_VERSION" "patch")
+	else
+		break
+	fi
+done
 
 # The application.yaml must contain exactly one semver targetRevision (the OCI
 # chart pin); git refs like `targetRevision: HEAD` or `main` are untouched.

--- a/bazel/tools/git/bump-chart_test.sh
+++ b/bazel/tools/git/bump-chart_test.sh
@@ -59,6 +59,7 @@ run_bump() {
 	set +e
 	BUMP_CHART_REPO_ROOT="$root" \
 		BUMP_CHART_SKIP_REGISTRY_CHECK=1 \
+		BUMP_CHART_SKIP_PR_CHECK=1 \
 		BUMP_CHART_MAIN_VERSION="${MAIN_VERSION_OVERRIDE:?}" \
 		bash "$SCRIPT" projects/foo "$@" >"$TMP/out" 2>&1
 	echo $?
@@ -136,6 +137,44 @@ rc=$(run_bump "$ROOT")
 assert_eq "t6 exit code" 0 "$rc"
 assert_eq "t6 chart version" 0.3.1 "$(chart_version "$ROOT")"
 assert_eq "t6 targetRevision healed" 0.3.1 "$(semver_tr "$ROOT")"
+
+# --- Test 7: skip a version an open PR already claimed ----------------------
+# Natural next patch is 0.1.1, but two open PRs already claim 0.1.1 and 0.1.2
+# (injected). The bump must skip both and land on 0.1.3, so two concurrent PRs
+# never pick the same number (the collision git's rebase would silently merge).
+ROOT="$TMP/t7"
+setup_project "$ROOT" 0.1.0 0.1.0
+set +e
+BUMP_CHART_REPO_ROOT="$ROOT" \
+	BUMP_CHART_SKIP_REGISTRY_CHECK=1 \
+	BUMP_CHART_MAIN_VERSION=0.1.0 \
+	BUMP_CHART_CLAIMED_VERSIONS=$'0.1.1\n0.1.2' \
+	bash "$SCRIPT" projects/foo >"$TMP/out" 2>&1
+rc=$?
+set -e
+assert_eq "t7 exit code" 0 "$rc"
+assert_eq "t7 skips claimed versions" 0.1.3 "$(chart_version "$ROOT")"
+assert_eq "t7 targetRevision skips too" 0.1.3 "$(semver_tr "$ROOT")"
+grep -q "already claimed by an open PR" "$TMP/out" || {
+	echo "FAIL: t7 expected 'already claimed by an open PR' message" >&2
+	FAILURES=$((FAILURES + 1))
+}
+
+# --- Test 8: a claimed version equal to the base is irrelevant --------------
+# An open PR sitting at an OLDER/equal version (0.1.0, e.g. an un-bumped branch)
+# must not push our bump around: only claims on the candidate matter.
+ROOT="$TMP/t8"
+setup_project "$ROOT" 0.1.0 0.1.0
+set +e
+BUMP_CHART_REPO_ROOT="$ROOT" \
+	BUMP_CHART_SKIP_REGISTRY_CHECK=1 \
+	BUMP_CHART_MAIN_VERSION=0.1.0 \
+	BUMP_CHART_CLAIMED_VERSIONS="0.1.0" \
+	bash "$SCRIPT" projects/foo >"$TMP/out" 2>&1
+rc=$?
+set -e
+assert_eq "t8 exit code" 0 "$rc"
+assert_eq "t8 ignores equal/older claim" 0.1.1 "$(chart_version "$ROOT")"
 
 if [[ "$FAILURES" -gt 0 ]]; then
 	echo "${FAILURES} test(s) failed" >&2


### PR DESCRIPTION
## Why

`bump-chart.sh` numbers from the origin/main tip, but two PRs branched from the **same** tip both compute the same next patch. That collision does **not** surface as a git conflict: on rebase, git sees an identical `version:` hunk on both sides and auto-merges it, so the duplicate reaches main and only trips the loud "already published" registry guard at merge time (or, pre-guard #3388, silently dropped the loser's bump). The git layer is structurally blind to "same version, different content".

This is the Option C follow-up to today's two chart-collision rebases.

## What

Widen the existing registry-existence probe to also reject a candidate another **open PR** already claims:

- `open_pr_versions` lists open PRs (`gh pr list`) and reads each branch's `Chart.yaml` `version:` via the contents API (raw, no base64 decode), collecting the semver each has bumped to.
- The selection loop skips any number that is **published OR claimed**, incrementing the patch until free.

Detection moves from **post-merge** (a registry failure needing a follow-up re-bump) to **author time**, before the collision lands.

Best-effort and non-blocking, mirroring the registry probe:
- guarded by `command -v gh`; a gh/API failure yields no claims (a flaky network never blocks a bump)
- the current branch is excluded (no self-collision on `--force`)
- `BUMP_CHART_SKIP_PR_CHECK=1` disables it; `BUMP_CHART_CLAIMED_VERSIONS` injects the claimed set for hermetic tests

## Verified live

With main at `0.285.136` and open PR `claude/bosun-trust-safety-safeguards-ultjz2` already claiming `0.285.137`:

```
Version 0.285.137 already claimed by an open PR; trying the next patch.
Bumped monolith: 0.285.136 -> 0.285.138
```

## Tests

- `t7`: two claimed patches (0.1.1, 0.1.2) are skipped to land on 0.1.3, with the "already claimed" message asserted.
- `t8`: an equal/older claim (0.1.0) is ignored (only claims on the candidate matter).
- Existing t1–t6 set `BUMP_CHART_SKIP_PR_CHECK=1` to stay hermetic. Full suite (22 assertions) passes locally.

No chart bump: this is build tooling, not a chart/deploy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)