### PR TITLE
fix(chat): send-gate honors name-addressed requests as explicit invitations

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.139
+version: 0.285.140
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/attention.py
+++ b/projects/monolith/chat/attention.py
@@ -183,6 +183,15 @@ async def should_send(
             "asked; or adds nothing a person would miss. Answer send=true only if "
             "a real person in this channel would be glad Bosun sent it. When "
             "unsure, prefer send=false.\n"
+            "EXCEPTION, explicit invitation: if the latest message directly "
+            "addresses Bosun by name or @mention with a request or question, the "
+            "human has asked Bosun to reply, so the barge-in, brush-off-context, "
+            "and when-unsure vetoes do NOT apply. Answer send=true unless the "
+            "drafted reply is harmful or hateful, or that same person told Bosun "
+            "to stop earlier in this exchange. A long computed result the person "
+            "explicitly asked for (requested digits, data, a table, a list) is "
+            "wanted content, not 'invented numbers', and must not be vetoed on "
+            "that ground.\n"
             + (
                 "Channel guidance (weigh this heavily): " + directive + "\n"
                 if directive

--- a/projects/monolith/chat/attention_test.py
+++ b/projects/monolith/chat/attention_test.py
@@ -242,6 +242,19 @@ class TestSendGate:
         assert "wanna play minecraft?" in prompt
         assert "Sure thing. You hosting?" in prompt
 
+    @pytest.mark.asyncio
+    async def test_prompt_carries_explicit_invitation_exception(self):
+        # /improve-ambient episode 243: "Bosun calc pi to 1000 decimal places
+        # then plot the distribution" was a name-addressed request whose drafted
+        # reply the send-gate wrongly vetoed. The prompt must tell the gate that
+        # an addressed request is an explicit invitation the barge-in and
+        # "invented numbers" vetoes do not apply to.
+        caller = AsyncMock(return_value='{"send": true}')
+        await should_send("d", "convo", "trigger", "reply", _caller=caller)
+        prompt = caller.call_args[0][0]
+        assert "explicit invitation" in prompt
+        assert "wanted content, not 'invented numbers'" in prompt
+
 
 class TestNeedsAgent:
     """ADR 035 Phase 4: the in-monolith depth classify (chat vs goose guest)."""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.139
+      targetRevision: 0.285.140
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Why Bosun went silent (episode 243)

A `/improve-ambient` targeted analysis of "why didn't Bosun reply to `Bosun calc pi to 1000 decimal places then plot the distribution of individual numbers`".

The reply was **drafted, then silently withheld by the post-generation send-gate** (`attention_decision.withheld_reason = send_gate`). The upstream stages were all correct:

- **Attention gate**: engaged, `attention_confidence 0.9` (Bjeu named Bosun and gave a clear task).
- **Routing** (`needs_agent`): kept it on the chat / `run_python` **sandbox** route (`became_agent=false`) - correct, a computed chart attaches inline, no goose needed.
- **Send-gate** (`attention.py:should_send`): vetoed. The preceding banter was adversarial ("trying to get it to OOM will drop your rating... he'll start ignoring you"), which the gate read as a barge-in/brush-off context, and the requested 1000 digits tripped the "specific numbers that read as invented" veto clause. But the human **explicitly asked**, so neither ground applies.

## Before/after aggregates (window since last lever commit)

- **send_gate rate: 2 / 111 engages (~1.8%)** - the gate is not broadly over-vetoing; this is a targeted logic gap, not a trend.
- Of **15 name-addressed "Bosun ..." triggers**, ep243 was the **only one withheld**. The other veto (ep241) was not addressed to Bosun and was plausibly correct.
- `withheld_reason` breakdown: `{null: 109, send_gate: 2}`.

## The fix (send-gate lever, global - route (a))

One clause added to the `should_send` prompt: when the latest message directly addresses Bosun by name or @mention with a request/question, it is an **explicit invitation** - the barge-in, brush-off-context, and when-unsure vetoes do not apply, and a long computed result the person asked for (digits, data, a table) is wanted content, not "invented numbers". The gate still withholds harmful/hateful replies and post-"stop" pile-ons, and still fails open. This only *narrows* when the gate vetoes.

Three-level routing rule: the gap is global (a send-gate logic hole, not channel- or person-specific), so it is a reviewed prompt edit, not a channel directive.

## Per-edit evidence

| Diff | episode | signals | addresses |
|---|---|---|---|
| `attention.py` explicit-invitation clause | **243** (ch `1290668195249917968`, author Bjeu) | conf 0.9, `became_agent=false`, `withheld_reason=send_gate`, 1 human follow-up ("fuck maybe my score is low" = read the silence as a snub) | the wrongful veto of an addressed request |

Eval written to `s3://artifacts/ambient-evals/243.json`.

## Out of scope, observed

- **Episode 231** (Scott, `@Bosun calculate Pi to 100 million digits... do not respond until accurate`): routed to **goose** (`became_agent=true`), ran ~7 min, **FAILED** (`Unterminated string ... char 7268`). Two gaps, both outside this lever: (1) unbounded pure-compute went to the heavyweight guest rather than being sandbox-run or declined (`improve-recipes` / `needs_agent`); (2) no up-front sanity bound rejects an absurd request before a 7-min run.
- **Resource-exhaustion / OOM-bait is not a trust-ledger signal.** PR #3395 (trust & safety ledger) scores prompt-injection / exfiltration / permission-fishing / mention-flooding, none of which match "calc pi to 100M digits". If compute abuse should decrement trust, that belongs in #3395's heuristic lane, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)