### PR TITLE
chore(charts): republish drifted fc-invoke, monolith, monolith-public digests

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.69
+version: 0.4.70

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.69
+      targetRevision: 0.4.70
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.60
+version: 0.89.61
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.60
+      targetRevision: 0.89.61
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.138
+version: 0.285.139
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.138
+      targetRevision: 0.285.139
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Why

Three charts on main are published but carry drifted pinned image digests (images were rebuilt without a chart bump), so the missed-bump guard fails the **Push images** action on *every* open PR (Push images checks all charts, not just the ones a PR touches):

- `fc-invoke` 0.4.69
- `monolith` 0.285.136
- `monolith-public` 0.89.58

This blocks #3414 and #3395 (and anything else) from going green. Matches the recurring digest-republish maintenance in main's history.

## What

Version-only republish bumps (via `bazel/tools/git/bump-chart.sh`, which auto-skips versions already claimed by open PRs):

- `fc-invoke` -> 0.4.70
- `monolith` -> 0.285.139
- `monolith-public` -> 0.89.61

Once merged, main is clean and the feature PRs pass Push images after rebase + re-bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)