### PR TITLE
feat(monolith): aggregate-first scan perf page + pre-homelab cutoff

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.62
+version: 0.89.63
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.62
+      targetRevision: 0.89.63
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.141
+version: 0.285.142
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.141
+      targetRevision: 0.285.142
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/private/+layout.svelte
@@ -37,30 +37,33 @@
 {@render children()}
 
 <style>
+  /* A subtle, borderless text link. Variables use fallbacks so it reads
+     correctly on both the dashboard theme (--ink-*, --font-ui, --accent) and
+     the older brutalist theme (--fg-*, --font) without a boxed look. */
   .back-to-dashboard {
     position: fixed;
-    top: 0.5rem;
-    left: 0.5rem;
+    top: 0.9rem;
+    left: 1.1rem;
     z-index: 1000;
-    font-family: var(--font);
-    font-size: 0.65rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--fg-tertiary);
-    background: var(--bg);
-    border: 0.06rem solid var(--border);
-    padding: 0.25rem 0.5rem;
+    font-family: var(--font-ui, var(--font));
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    color: var(--ink-3, var(--fg-tertiary));
+    background: transparent;
+    border: none;
+    padding: 4px 2px;
     text-decoration: none;
     transition: color 0.15s ease;
   }
 
   .back-to-dashboard:hover {
-    color: var(--fg);
+    color: var(--accent, var(--fg));
   }
 
   .back-to-dashboard:focus-visible {
-    outline: 1.5px solid var(--fg);
+    outline: 1.5px solid var(--accent, var(--fg));
     outline-offset: 2px;
+    border-radius: 4px;
   }
 </style>

--- a/projects/monolith/frontend/src/routes/private/perf/+page.server.js
+++ b/projects/monolith/frontend/src/routes/private/perf/+page.server.js
@@ -6,15 +6,31 @@ export async function load({ fetch }) {
       signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) {
-      return { comparisons: [], note: "", counts: null, error: res.status };
+      return {
+        comparisons: [],
+        aggregates: null,
+        windowStart: null,
+        note: "",
+        counts: null,
+        error: res.status,
+      };
     }
     const body = await res.json();
     return {
       comparisons: body.comparisons ?? [],
+      aggregates: body.aggregates ?? null,
+      windowStart: body.window_start ?? null,
       note: body.coverage_note ?? "",
       counts: body.counts ?? null,
     };
   } catch (e) {
-    return { comparisons: [], note: "", counts: null, error: "unavailable" };
+    return {
+      comparisons: [],
+      aggregates: null,
+      windowStart: null,
+      note: "",
+      counts: null,
+      error: "unavailable",
+    };
   }
 }

--- a/projects/monolith/frontend/src/routes/private/perf/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/perf/+page.svelte
@@ -24,9 +24,11 @@
     return `https://github.com/jomcgi/homelab/pull/${n}`;
   }
 
-  function formatTime(seconds) {
+  // Seconds under two minutes, minutes above (full scans run into the minutes).
+  function formatDuration(seconds) {
     if (seconds == null) return null;
-    return `${seconds.toFixed(1)}s`;
+    if (seconds < 120) return `${seconds.toFixed(1)}s`;
+    return `${(seconds / 60).toFixed(1)}m`;
   }
 
   function formatDate(iso) {
@@ -40,6 +42,13 @@
     return `${month} ${day} ${h}:${min}`;
   }
 
+  function formatDay(iso) {
+    if (!iso) return null;
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return null;
+    return `${d.toLocaleString("en-US", { month: "short" })} ${d.getDate()}`;
+  }
+
   // Best-available completion date across both sides for the Date column.
   function rowDate(row) {
     return (
@@ -50,16 +59,26 @@
 
   function speedupLabel(speedup) {
     if (speedup == null) return null;
-    if (speedup > 1.02) return { text: `${speedup.toFixed(1)}x faster`, tone: "ok" };
-    if (speedup < 0.98) return { text: `${(1 / speedup).toFixed(1)}x slower`, tone: "bad" };
-    return { text: "even", tone: "neutral" };
+    if (speedup > 1.02)
+      return { text: `${speedup.toFixed(1)}x faster`, tone: "ok" };
+    if (speedup < 0.98)
+      return { text: `${(1 / speedup).toFixed(1)}x slower`, tone: "bad" };
+    return { text: "about even", tone: "neutral" };
   }
 
-  function findingsLabel(row) {
-    const rb = row.route_b?.findings_total;
-    const sms = row.sms?.findings_total;
-    return { rb: rb ?? null, sms: sms ?? null };
-  }
+  // ── View state ───────────────────────────────
+
+  const buckets = [
+    { key: "pr", label: "Pull request scans" },
+    { key: "full", label: "Full scans (main)" },
+  ];
+
+  // The window has opened once at least one homelab scan exists. Before that
+  // every managed scan is pre-homelab and excluded, so there is nothing valid
+  // to compare and the aggregates are empty.
+  let windowOpen = $derived(
+    !data.error && (data.counts?.homelab ?? 0) > 0 && data.aggregates != null,
+  );
 </script>
 
 <svelte:head><title>Scan perf · private.jomcgi.dev</title></svelte:head>
@@ -67,119 +86,169 @@
 <div class="shell day">
   <div class="dash">
     <header class="masthead">
-      <div class="masthead-words">
-        <h1 class="greeting">Semgrep scan performance<span class="greeting-mark">.</span></h1>
-        {#if data.counts}
-          <p class="masthead-sub">
-            {data.counts.route_b ?? 0} Route B scans, {data.counts.sms ?? 0} managed scans
-          </p>
-        {/if}
-        {#if data.note}
-          <p class="masthead-note">{data.note}</p>
-        {/if}
-      </div>
+      <h1 class="greeting">
+        Semgrep scan performance<span class="greeting-mark">.</span>
+      </h1>
+      <p class="masthead-lead">homelab (self-hosted) vs Semgrep managed scans</p>
+      {#if data.counts}
+        <p class="masthead-sub">
+          {data.counts.homelab ?? 0} homelab scans, {data.counts.managed ?? 0} managed
+          scans{#if data.windowStart}
+            &nbsp;in window since {formatDay(data.windowStart)}{/if}
+        </p>
+      {/if}
+      {#if data.note}
+        <p class="masthead-note">{data.note}</p>
+      {/if}
     </header>
 
     {#if data.error}
       <p class="unavail">perf data unavailable</p>
-    {/if}
-
-    {#if !data.error && data.comparisons.length === 0}
+    {:else if !windowOpen}
       <section class="card card--empty">
-        <h2 class="section-label">No comparison data yet</h2>
+        <h2 class="section-label">Waiting for the first homelab scan</h2>
         <p class="unavail">
-          Comparisons populate over time as Route B and Semgrep Managed Scans
-          complete against the same commits.
+          The comparison window opens with the first homelab scan. Aggregates
+          and matched pairs appear as homelab and Semgrep managed scans run
+          against the same pull requests and commits.
         </p>
       </section>
-    {:else if data.comparisons.length > 0}
-      <section class="card card--table">
-        <div class="table-wrap">
-          <table>
-            <thead>
-              <tr>
-                <th>Ref / Commit</th>
-                <th>Type</th>
-                <th class="num">Route B</th>
-                <th class="num">SMS</th>
-                <th class="num">Speedup</th>
-                <th class="num">Findings</th>
-                <th>Match</th>
-                <th>Date</th>
-              </tr>
-            </thead>
-            <tbody>
-              {#each data.comparisons as row}
-                {@const sha = shortSha(row.commit_sha)}
-                {@const pr = prNumber(row.scan_ref)}
-                {@const speedup = speedupLabel(row.speedup)}
-                {@const findings = findingsLabel(row)}
-                <tr>
-                  <td>
-                    <div class="ref-cell">
-                      {#if sha}
-                        <a
-                          class="mono ref-link"
-                          href={commitUrl(row.commit_sha)}
-                          target="_blank"
-                          rel="noopener"
-                        >{sha}</a>
-                      {:else}
-                        <span class="mono">{row.scan_ref}</span>
-                      {/if}
-                      {#if pr}
-                        <a
-                          class="pr-chip"
-                          href={prUrl(pr)}
-                          target="_blank"
-                          rel="noopener"
-                        >PR #{pr}</a>
-                      {/if}
-                    </div>
-                  </td>
-                  <td>
-                    <span class="badge" class:badge--full={row.is_full_scan}>
-                      {row.is_full_scan ? "full" : "PR"}
-                    </span>
-                  </td>
-                  <td class="num mono">
-                    {#if row.route_b}
-                      {formatTime(row.route_b.total_time)}
-                    {:else}
-                      <span class="dim">no counterpart</span>
-                    {/if}
-                  </td>
-                  <td class="num mono">
-                    {#if row.sms}
-                      {formatTime(row.sms.total_time)}
-                    {:else}
-                      <span class="dim">no counterpart</span>
-                    {/if}
-                  </td>
-                  <td class="num mono">
-                    {#if speedup}
-                      <span
-                        class="speedup"
-                        class:speedup--ok={speedup.tone === "ok"}
-                        class:speedup--bad={speedup.tone === "bad"}
-                      >{speedup.text}</span>
-                    {:else}
-                      <span class="dim">&ndash;</span>
-                    {/if}
-                  </td>
-                  <td class="num mono">
-                    <span class:dim={findings.rb == null}>{findings.rb ?? "-"}</span>
-                    <span class="dim"> / </span>
-                    <span class:dim={findings.sms == null}>{findings.sms ?? "-"}</span>
-                  </td>
-                  <td><span class="dim">{row.match_kind}</span></td>
-                  <td class="mono">{rowDate(row) ?? "-"}</td>
-                </tr>
-              {/each}
-            </tbody>
-          </table>
-        </div>
+    {:else}
+      <section class="agg-grid">
+        {#each buckets as bucket}
+          {@const agg = data.aggregates[bucket.key] ?? { pairs: 0 }}
+          {@const speedup = speedupLabel(agg.speedup)}
+          <div class="card agg-card">
+            <h2 class="section-label">{bucket.label}</h2>
+            {#if agg.pairs > 0}
+              <div
+                class="agg-headline"
+                class:agg-headline--ok={speedup?.tone === "ok"}
+                class:agg-headline--bad={speedup?.tone === "bad"}
+              >
+                {speedup ? speedup.text : "-"}
+              </div>
+              <div class="agg-medians">
+                <div class="agg-median">
+                  <span class="agg-median-label">homelab median</span>
+                  <span class="mono agg-median-value"
+                    >{formatDuration(agg.homelab_median)}</span
+                  >
+                </div>
+                <div class="agg-median-vs">vs</div>
+                <div class="agg-median">
+                  <span class="agg-median-label">managed median</span>
+                  <span class="mono agg-median-value"
+                    >{formatDuration(agg.managed_median)}</span
+                  >
+                </div>
+              </div>
+              <p class="agg-foot">
+                {agg.pairs} matched pair{agg.pairs === 1 ? "" : "s"}
+              </p>
+            {:else}
+              <p class="unavail agg-empty">No matched pairs yet</p>
+            {/if}
+          </div>
+        {/each}
       </section>
+
+      <details class="detail">
+        <summary class="detail-summary">
+          Individual comparisons ({data.comparisons.length})
+        </summary>
+        <div class="card card--table">
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Ref / Commit</th>
+                  <th>Type</th>
+                  <th class="num">Homelab</th>
+                  <th class="num">Managed</th>
+                  <th class="num">Speedup</th>
+                  <th class="num">Findings</th>
+                  <th>Match</th>
+                  <th>Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                {#each data.comparisons as row}
+                  {@const sha = shortSha(row.commit_sha)}
+                  {@const pr = prNumber(row.scan_ref)}
+                  {@const speedup = speedupLabel(row.speedup)}
+                  <tr>
+                    <td>
+                      <div class="ref-cell">
+                        {#if sha}
+                          <a
+                            class="mono ref-link"
+                            href={commitUrl(row.commit_sha)}
+                            target="_blank"
+                            rel="noopener">{sha}</a
+                          >
+                        {:else}
+                          <span class="mono">{row.scan_ref}</span>
+                        {/if}
+                        {#if pr}
+                          <a
+                            class="pr-chip"
+                            href={prUrl(pr)}
+                            target="_blank"
+                            rel="noopener">PR #{pr}</a
+                          >
+                        {/if}
+                      </div>
+                    </td>
+                    <td>
+                      <span class="badge" class:badge--full={row.is_full_scan}>
+                        {row.is_full_scan ? "full" : "PR"}
+                      </span>
+                    </td>
+                    <td class="num mono">
+                      {#if row.route_b}
+                        {formatDuration(row.route_b.total_time)}
+                      {:else}
+                        <span class="dim">no counterpart</span>
+                      {/if}
+                    </td>
+                    <td class="num mono">
+                      {#if row.sms}
+                        {formatDuration(row.sms.total_time)}
+                      {:else}
+                        <span class="dim">no counterpart</span>
+                      {/if}
+                    </td>
+                    <td class="num mono">
+                      {#if speedup}
+                        <span
+                          class="speedup"
+                          class:speedup--ok={speedup.tone === "ok"}
+                          class:speedup--bad={speedup.tone === "bad"}
+                          >{speedup.text}</span
+                        >
+                      {:else}
+                        <span class="dim">&ndash;</span>
+                      {/if}
+                    </td>
+                    <td class="num mono">
+                      <span class:dim={row.route_b?.findings_total == null}
+                        >{row.route_b?.findings_total ?? "-"}</span
+                      >
+                      <span class="dim"> / </span>
+                      <span class:dim={row.sms?.findings_total == null}
+                        >{row.sms?.findings_total ?? "-"}</span
+                      >
+                    </td>
+                    <td><span class="dim">{row.match_kind}</span></td>
+                    <td class="mono">{rowDate(row) ?? "-"}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </details>
     {/if}
   </div>
 </div>
@@ -224,17 +293,23 @@
     color: var(--accent);
   }
 
-  .masthead-sub {
-    margin: 8px 0 0;
+  .masthead-lead {
+    margin: 6px 0 0;
     font-size: 14px;
     color: var(--ink-2);
   }
 
+  .masthead-sub {
+    margin: 8px 0 0;
+    font-size: 13px;
+    color: var(--ink-3);
+  }
+
   .masthead-note {
-    margin: 4px 0 0;
+    margin: 6px 0 0;
     font-size: 12px;
     color: var(--ink-3);
-    max-width: 720px;
+    max-width: 760px;
   }
 
   .card {
@@ -249,6 +324,101 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
+  }
+
+  /* ── Aggregate cards ── */
+  .agg-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+    margin-bottom: 20px;
+  }
+
+  .agg-card {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .agg-headline {
+    font-family: var(--font-display);
+    font-size: 30px;
+    font-weight: 460;
+    letter-spacing: -0.01em;
+    line-height: 1;
+    color: var(--ink);
+  }
+
+  .agg-headline--ok {
+    color: var(--ok);
+  }
+
+  .agg-headline--bad {
+    color: var(--bad);
+  }
+
+  .agg-medians {
+    display: flex;
+    align-items: flex-end;
+    gap: 16px;
+  }
+
+  .agg-median {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .agg-median-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--ink-3);
+  }
+
+  .agg-median-value {
+    font-size: 18px;
+    color: var(--ink);
+  }
+
+  .agg-median-vs {
+    font-size: 12px;
+    color: var(--ink-3);
+    padding-bottom: 3px;
+  }
+
+  .agg-foot {
+    margin: 0;
+    font-size: 12px;
+    color: var(--ink-3);
+  }
+
+  .agg-empty {
+    margin: 0;
+  }
+
+  /* ── Collapsed detail ── */
+  .detail {
+    margin-top: 4px;
+  }
+
+  .detail-summary {
+    cursor: pointer;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--ink-3);
+    padding: 6px 0;
+    user-select: none;
+  }
+
+  .detail-summary:hover {
+    color: var(--ink-2);
+  }
+
+  .detail[open] .detail-summary {
+    margin-bottom: 10px;
   }
 
   .section-label {

--- a/projects/monolith/semgrep_scan/perf_compare.py
+++ b/projects/monolith/semgrep_scan/perf_compare.py
@@ -198,3 +198,56 @@ def build_comparisons(route_b: list[dict], sms: list[dict]) -> list[dict]:
     undated = [row for row in result if _best_date(row) is None]
     dated.sort(key=_best_date, reverse=True)
     return dated + undated
+
+
+def _median(values: list[float]) -> float | None:
+    """Median of a non-empty list, or None if empty."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    n = len(ordered)
+    mid = n // 2
+    if n % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2
+
+
+def build_aggregates(comparisons: list[dict]) -> dict:
+    """Summarise matched comparisons into per-type aggregates.
+
+    Only two-sided rows (both homelab and managed ran) count: a one-sided row
+    is not a comparison. Buckets by scan type ("pr" vs "full") since PR and
+    full-scan runtimes differ by an order of magnitude and must not be pooled.
+    ``speedup`` is managed_median / homelab_median (greater than 1 means
+    homelab is faster). Returns a stable shape even for empty buckets so the
+    page can render placeholders.
+    """
+    buckets: dict[str, list[dict]] = {"pr": [], "full": []}
+    for row in comparisons:
+        if row.get("route_b") and row.get("sms"):
+            buckets["full" if row.get("is_full_scan") else "pr"].append(row)
+
+    out: dict[str, dict] = {}
+    for key, pairs in buckets.items():
+        if not pairs:
+            out[key] = {
+                "pairs": 0,
+                "homelab_median": None,
+                "managed_median": None,
+                "speedup": None,
+            }
+            continue
+        homelab_median = _median([p["route_b"]["total_time"] for p in pairs])
+        managed_median = _median([p["sms"]["total_time"] for p in pairs])
+        speedup = (
+            managed_median / homelab_median
+            if homelab_median and homelab_median > 0
+            else None
+        )
+        out[key] = {
+            "pairs": len(pairs),
+            "homelab_median": homelab_median,
+            "managed_median": managed_median,
+            "speedup": speedup,
+        }
+    return out

--- a/projects/monolith/semgrep_scan/perf_compare_test.py
+++ b/projects/monolith/semgrep_scan/perf_compare_test.py
@@ -10,7 +10,7 @@ import datetime
 
 import pytest
 
-from semgrep_scan.perf_compare import build_comparisons
+from semgrep_scan.perf_compare import build_aggregates, build_comparisons
 
 UTC = datetime.timezone.utc
 
@@ -260,3 +260,85 @@ def test_commit_match_ignores_empty_commit_sha():
     # empty commit_sha/scan_ref never key a match; both fall through to one-sided
     assert all(row["match_kind"] == "one-sided" for row in result)
     assert len(result) == 2
+
+
+# ── build_aggregates ─────────────────────────────
+
+
+def _pair(is_full: bool, rb_time: float, sms_time: float) -> dict:
+    """A matched (two-sided) comparison row, the only kind aggregates count."""
+    return {
+        "commit_sha": "c",
+        "scan_ref": "r",
+        "is_full_scan": is_full,
+        "branch": "main",
+        "route_b": {
+            "scan_id": 1,
+            "total_time": rb_time,
+            "findings_total": 0,
+            "scan_completed_at": None,
+        },
+        "sms": {
+            "scan_id": 2,
+            "total_time": sms_time,
+            "findings_total": 0,
+            "scan_completed_at": None,
+        },
+        "speedup": None,
+        "match_kind": "commit",
+    }
+
+
+def test_aggregates_medians_and_speedup_per_bucket():
+    comparisons = [
+        _pair(False, 10.0, 30.0),
+        _pair(False, 20.0, 40.0),
+        _pair(True, 100.0, 400.0),
+    ]
+    agg = build_aggregates(comparisons)
+    # PR bucket: medians 15 and 35, speedup 35/15
+    assert agg["pr"]["pairs"] == 2
+    assert agg["pr"]["homelab_median"] == 15.0
+    assert agg["pr"]["managed_median"] == 35.0
+    assert agg["pr"]["speedup"] == pytest.approx(35.0 / 15.0)
+    # full bucket: single pair
+    assert agg["full"]["pairs"] == 1
+    assert agg["full"]["speedup"] == pytest.approx(4.0)
+
+
+def test_aggregates_ignore_one_sided_rows():
+    one_sided = {
+        "commit_sha": "c",
+        "scan_ref": "r",
+        "is_full_scan": False,
+        "branch": "main",
+        "route_b": {
+            "scan_id": 1,
+            "total_time": 5.0,
+            "findings_total": 0,
+            "scan_completed_at": None,
+        },
+        "sms": None,
+        "speedup": None,
+        "match_kind": "one-sided",
+    }
+    agg = build_aggregates([one_sided])
+    assert agg["pr"]["pairs"] == 0
+    assert agg["pr"]["speedup"] is None
+
+
+def test_aggregates_empty_input_has_stable_shape():
+    agg = build_aggregates([])
+    for key in ("pr", "full"):
+        assert agg[key] == {
+            "pairs": 0,
+            "homelab_median": None,
+            "managed_median": None,
+            "speedup": None,
+        }
+
+
+def test_aggregates_speedup_guards_zero_homelab_time():
+    agg = build_aggregates([_pair(False, 0.0, 30.0)])
+    assert agg["pr"]["pairs"] == 1
+    assert agg["pr"]["speedup"] is None

--- a/projects/monolith/semgrep_scan/perf_router.py
+++ b/projects/monolith/semgrep_scan/perf_router.py
@@ -9,11 +9,19 @@ no ClusterRole/RBAC change is needed.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func
 from sqlmodel import Session, select
 
 from app.db import get_session
-from semgrep_scan.perf_compare import build_comparisons
+from semgrep_scan.perf_compare import build_aggregates, build_comparisons
 from semgrep_scan.perf_store import ScanPerf
+
+_COVERAGE_NOTE = (
+    "Comparisons start at the first homelab scan (earlier managed scans have no "
+    "homelab counterpart and would be invalid cross-era comparisons, so they are "
+    "excluded). Managed scan coverage is best-effort: only scans that left an "
+    "open finding are visible via the Semgrep API."
+)
 
 router = APIRouter(prefix="/api/semgrep", tags=["semgrep-perf"])
 
@@ -31,30 +39,49 @@ def _row_to_dict(row: ScanPerf) -> dict:
     }
 
 
+def _empty_response() -> dict:
+    return {
+        "comparisons": [],
+        "aggregates": build_aggregates([]),
+        "window_start": None,
+        "counts": {"homelab": 0, "managed": 0},
+        "coverage_note": _COVERAGE_NOTE,
+    }
+
+
 @router.get("/perf")
 async def get_perf(
     session: Session = Depends(get_session),
     limit: int = Query(300, ge=1, le=1000),
 ) -> dict:
-    # NULLS LAST so any undated row never crowds out dated rows past the LIMIT
-    # (route-b rows now carry scan_completed_at, but stay defensive for any
-    # residual or legacy NULL-dated rows).
+    # Cutoff: the first homelab (route-b) scan. Every scan before it (all the
+    # historical managed scans that predate homelab) is an invalid cross-era
+    # comparison, so exclude both sides before that instant. With no homelab
+    # scans yet, the comparison window has not opened: return an empty payload.
+    window_start = session.exec(
+        select(func.min(ScanPerf.scan_completed_at)).where(
+            ScanPerf.environment == "route-b"
+        )
+    ).one()
+    if window_start is None:
+        return _empty_response()
+
+    # NULLS LAST so any undated row never crowds out dated rows past the LIMIT.
     rows = session.exec(
         select(ScanPerf)
+        .where(ScanPerf.scan_completed_at >= window_start)
         .order_by(ScanPerf.scan_completed_at.desc().nullslast())
         .limit(limit)
     ).all()
 
-    route_b = [_row_to_dict(r) for r in rows if r.environment == "route-b"]
-    sms = [_row_to_dict(r) for r in rows if r.environment == "managed-scans"]
-    comparisons = build_comparisons(route_b, sms)
+    homelab = [_row_to_dict(r) for r in rows if r.environment == "route-b"]
+    managed = [_row_to_dict(r) for r in rows if r.environment == "managed-scans"]
+    comparisons = build_comparisons(homelab, managed)
 
     return {
         "comparisons": comparisons,
-        "coverage_note": (
-            "Route B coverage is complete (captured at scan time). SMS coverage "
-            "is best-effort: only Managed Scans that left an open finding are "
-            "visible via the Semgrep API."
-        ),
-        "counts": {"route_b": len(route_b), "sms": len(sms)},
+        "aggregates": build_aggregates(comparisons),
+        "window_start": window_start,
+        "counts": {"homelab": len(homelab), "managed": len(managed)},
+        "coverage_note": _COVERAGE_NOTE,
     }

--- a/projects/monolith/semgrep_scan/perf_router_test.py
+++ b/projects/monolith/semgrep_scan/perf_router_test.py
@@ -61,7 +61,10 @@ def test_empty_db_returns_empty_comparisons(client):
     assert resp.status_code == 200
     body = resp.json()
     assert body["comparisons"] == []
-    assert body["counts"] == {"route_b": 0, "sms": 0}
+    assert body["counts"] == {"homelab": 0, "managed": 0}
+    assert body["window_start"] is None
+    assert body["aggregates"]["pr"]["pairs"] == 0
+    assert body["aggregates"]["full"]["pairs"] == 0
     assert body["coverage_note"]
 
 
@@ -98,7 +101,7 @@ def test_matched_pair_returns_one_comparison_with_both_sides(session, client):
     assert resp.status_code == 200
     body = resp.json()
 
-    assert body["counts"] == {"route_b": 1, "sms": 1}
+    assert body["counts"] == {"homelab": 1, "managed": 1}
     assert len(body["comparisons"]) == 1
 
     comparison = body["comparisons"][0]
@@ -109,3 +112,53 @@ def test_matched_pair_returns_one_comparison_with_both_sides(session, client):
     assert comparison["route_b"]["total_time"] == 5.0
     assert comparison["sms"]["total_time"] == 25.0
     assert comparison["speedup"] == 5.0
+
+    # A full-scan matched pair aggregates into the "full" bucket.
+    assert body["window_start"] is not None
+    assert body["aggregates"]["full"]["pairs"] == 1
+    assert body["aggregates"]["full"]["speedup"] == 5.0
+    assert body["aggregates"]["pr"]["pairs"] == 0
+
+
+def test_pre_homelab_managed_scans_are_excluded(session, client):
+    # A managed scan that predates the first homelab scan is an invalid
+    # cross-era comparison and must be excluded from the window entirely.
+    before = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    session.add(
+        ScanPerf(
+            scan_id=10,
+            environment="managed-scans",
+            is_full_scan=True,
+            branch="main",
+            scan_ref="refs/heads/main",
+            commit_sha="old999",
+            total_time=99.0,
+            findings_total=0,
+            scan_completed_at=before,
+        )
+    )
+    session.add(
+        ScanPerf(
+            scan_id=11,
+            environment="route-b",
+            is_full_scan=True,
+            branch="main",
+            scan_ref="refs/heads/main",
+            commit_sha="new111",
+            total_time=5.0,
+            findings_total=0,
+            scan_completed_at=T0,
+        )
+    )
+    session.commit()
+
+    body = client.get("/api/semgrep/perf").json()
+    # Only the homelab scan is in window; the pre-homelab managed scan is gone.
+    assert body["counts"] == {"homelab": 1, "managed": 0}
+    scan_ids = [
+        side["scan_id"]
+        for row in body["comparisons"]
+        for side in (row["route_b"], row["sms"])
+        if side is not None
+    ]
+    assert 10 not in scan_ids


### PR DESCRIPTION
Follow-up to #3416 addressing feedback on the `/private/perf` page.

## Changes

1. **Aggregate-first.** The page now leads with per-scan-type summary cards (Pull request scans / Full scans): median **homelab** runtime vs median **managed** runtime and the overall speedup. The individual comparison table is collapsed behind a `details` toggle.
2. **Pre-homelab cutoff.** Every scan dated before the first homelab scan is excluded from both the table and the aggregates. Historical managed scans predate homelab and have no valid counterpart, so comparing against them would be an invalid cross-era comparison. The comparison window opens with the first homelab scan; until then the page shows a "waiting for the first homelab scan" state.
3. **Rename "Route B" -> "homelab"** throughout the page copy (the internal `environment` value stays `route-b`).
4. **Subtle back link.** The shared private back button was styled with the brutalist theme's variables, so it rendered as a boxed, uppercase button that clashed on the dashboard theme. Restyled as a borderless, theme-adaptive text link (fallback vars keep it correct on both themes).

## Tests
- `build_aggregates`: per-bucket medians/speedup, one-sided rows ignored, empty shape, zero-time guard.
- Router: new response shape (`aggregates`, `window_start`, `counts.homelab/managed`) and a cutoff test asserting a pre-homelab managed scan is excluded.

## Note
With 0 homelab scans currently, the page correctly shows the empty-window state (all 166 managed scans are pre-homelab). Matched pairs and aggregates fill in as homelab and managed scans run against the same PRs going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)