### PR TITLE
test: temp semgrep perf e2e probe (do not merge)

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -5569,3 +5569,22 @@ semgrep_target_test(
     rules = ["//bazel/semgrep/rules:python_rules"],
     target = ":gen_orchestrator_bundle",
 )
+
+semgrep_test(
+    name = "perf_e2e_probe_semgrep_test",
+    srcs = ["perf_e2e_probe.py"],
+    exclude_rules = [
+        "avoid-sqlalchemy-text",
+        "sqlmodel-datetime-without-factory",
+        "tainted-fastapi-http-request-httpx",
+        "tainted-path-traversal-pillow-fastapi",
+        "tainted-path-traversal-stdlib-fastapi",
+    ],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+py_library(
+    name = "monolith",
+    srcs = ["perf_e2e_probe.py"],
+    visibility = ["//:__subpackages__"],
+)

--- a/projects/monolith/perf_e2e_probe.py
+++ b/projects/monolith/perf_e2e_probe.py
@@ -1,0 +1,13 @@
+"""Temporary probe to validate the semgrep scan-perf comparison pipeline end to
+end. It deliberately introduces a finding so the Semgrep managed scan of this
+PR becomes discoverable via the findings API (first_seen_scan_id), which is the
+only way the harvest can see it. This PR exists only to trigger a homelab scan
+and a managed scan on the same ref; it is closed without merging.
+"""
+
+import subprocess
+
+
+def probe(cmd: str) -> None:
+    # Deliberate dangerous-exec finding for the end-to-end validation.
+    subprocess.Popen(cmd, shell=True)


### PR DESCRIPTION
Temporary PR to validate the scan-perf comparison pipeline end to end. Introduces a deliberate finding so the managed scan is discoverable via the findings API. Will be closed without merging once a matched pair is confirmed on /perf.