### PR TITLE
feat(chat): brig emoji when a locked-out lurker would have been engaged

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.70
+version: 0.4.71

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.70
+      targetRevision: 0.4.71
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.63
+version: 0.89.64
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.63
+      targetRevision: 0.89.64
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.142
+version: 0.285.143
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -894,11 +894,14 @@ class ChatBot(discord.Client):
                 return
 
         # Trust safeguards (ADR chat/003): heuristic signals update the
-        # per-user ledger on every message, before any LLM spend. A locked-out
-        # author gets no engagement at all: no attention classify, no reply,
-        # no agent run. When they address the bot directly, the brig emoji on
-        # their message says "seen, but suppressed"; a locked-out user lurking
-        # in ambient chat is simply ignored. observe_message fails open, so a
+        # per-user ledger on every message, before any reply, agent run, or
+        # message storage. A locked-out author never gets a reply. The brig
+        # emoji on their message says "seen, but suppressed": it lands when they
+        # address the bot directly, and also when the attention classifier would
+        # have engaged them in an ambient channel. That ambient case runs the
+        # classify (one LLM call) but nothing downstream, so a gated lurker can
+        # tell Bosun would have replied; a locked user whose ambient message the
+        # classifier ignores stays silent. observe_message fails open, so a
         # ledger error can never block normal chat.
         guild_id = message.guild.id if message.guild else None
         addressed = should_respond(message, self.user)
@@ -923,13 +926,38 @@ class ChatBot(discord.Client):
             verdict = safeguards.Verdict(addressed=addressed)
         if verdict.locked_out:
             reacted = False
-            if addressed:
+            # Addressed messages always warrant the brig emoji. For an
+            # unaddressed (lurking) message, run ONLY the attention classify in
+            # an ambient channel: if it would have engaged, the emoji still
+            # lands, but no reply, agent run, or storage follows. This
+            # deliberately relaxes the zero-spend-when-locked property to a
+            # single classify so a gated user can see they were heard.
+            should_mark = addressed
+            if not should_mark and await self._resolve_ambient(
+                guild_id, channel_id, message
+            ):
+                directive = await asyncio.to_thread(directives.get_active, channel_id)
+                recently_tagged = await asyncio.to_thread(
+                    self._recently_tagged, channel_id, msg_id
+                )
+                try:
+                    result = await attention.evaluate(
+                        message,
+                        directive,
+                        self.user,
+                        True,
+                        recently_tagged=recently_tagged,
+                    )
+                    should_mark = result.engage
+                except Exception:
+                    logger.exception("safeguards: locked-out ambient classify failed")
+            if should_mark:
                 try:
                     await message.add_reaction(safeguards.LOCKOUT_EMOJI)
                     reacted = True
                 except Exception:
                     logger.exception("safeguards: lockout reaction failed")
-            if addressed or verdict.signals:
+            if addressed or verdict.signals or reacted:
                 try:
                     await asyncio.to_thread(
                         safeguards.log_enforcement, safeguards_payload, reacted
@@ -963,28 +991,7 @@ class ChatBot(discord.Client):
         # conversation stays in-monolith (see needs_agent below), so
         # server-wide "mentions always engage" no longer needs a heavy guest
         # run to be safe to extend.
-        try:
-            ambient = await asyncio.to_thread(acl.ambient_channels, guild_id)
-            # A Discord thread is its own channel with its own id, distinct from
-            # its parent. Ambient grants are scoped to the parent channel, so a
-            # thread inherits ambient from its parent: check the parent id too
-            # when this is a thread. Agent/artifact threads never reach here
-            # (they return above), so this only opens ordinary user threads
-            # under a granted channel. channel_id stays the thread id, so the
-            # directive lookup, recent-tag check, and decision log all key off
-            # the thread's own history.
-            is_ambient = channel_id in ambient
-            if not is_ambient and isinstance(message.channel, discord.Thread):
-                parent_id = message.channel.parent_id
-                is_ambient = parent_id is not None and str(parent_id) in ambient
-        except Exception:
-            # Best-effort: if the grants read fails (DB blip), treat the channel
-            # as non-ambient and fall through to normal handling rather than
-            # dropping the message. Fail closed (no ambient engage on error).
-            logger.exception(
-                "attention: ambient lookup failed; treating as non-ambient"
-            )
-            is_ambient = False
+        is_ambient = await self._resolve_ambient(guild_id, channel_id, message)
         if is_ambient:
             directive = await asyncio.to_thread(directives.get_active, channel_id)
             recently_tagged = await asyncio.to_thread(
@@ -1032,6 +1039,35 @@ class ChatBot(discord.Client):
                 return
 
         await self._process_message(message)
+
+    async def _resolve_ambient(
+        self, guild_id, channel_id: str, message: discord.Message
+    ) -> bool:
+        """True if this channel has an ambient grant.
+
+        A Discord thread is its own channel with its own id, distinct from its
+        parent. Ambient grants are scoped to the parent channel, so a thread
+        inherits ambient from its parent: the parent id is checked too when this
+        is a thread. Agent/artifact threads never reach the ambient gate (they
+        return earlier in on_message), so this only opens ordinary user threads
+        under a granted channel.
+
+        Fails closed (non-ambient) on a grants-read error (DB blip), so a
+        failure never spuriously engages nor strands the message.
+        """
+        try:
+            ambient = await asyncio.to_thread(acl.ambient_channels, guild_id)
+        except Exception:
+            logger.exception(
+                "attention: ambient lookup failed; treating as non-ambient"
+            )
+            return False
+        if channel_id in ambient:
+            return True
+        if isinstance(message.channel, discord.Thread):
+            parent_id = message.channel.parent_id
+            return parent_id is not None and str(parent_id) in ambient
+        return False
 
     async def _persist_reaction_signal(
         self, payload: discord.RawReactionActionEvent, action: str

--- a/projects/monolith/chat/bot_safeguards_test.py
+++ b/projects/monolith/chat/bot_safeguards_test.py
@@ -96,7 +96,8 @@ class TestLockoutEnforcement:
         mock_ambient.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_locked_out_unaddressed_is_silently_ignored(self):
+    async def test_locked_out_unaddressed_non_ambient_is_silently_ignored(self):
+        """A lurking message in a non-ambient channel: no classify, no emoji."""
         bot = _make_bot()
         message = _make_message("lurking quietly")
         mock_store = _make_store()
@@ -111,6 +112,8 @@ class TestLockoutEnforcement:
                 return_value=Verdict(locked_out=True, score=10.0),
             ),
             patch("chat.bot.safeguards.log_enforcement", MagicMock()) as mock_log,
+            patch("chat.bot.acl.ambient_channels", MagicMock(return_value=set())),
+            patch("chat.bot.attention.evaluate", AsyncMock()) as mock_eval,
             patch.object(bot, "_process_message", AsyncMock()) as mock_proc,
         ):
             mock_session_cls.return_value.__enter__ = MagicMock(
@@ -119,6 +122,88 @@ class TestLockoutEnforcement:
             mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
             await bot.on_message(message)
 
+        message.add_reaction.assert_not_called()
+        mock_log.assert_not_called()
+        mock_proc.assert_not_called()
+        # Non-ambient: the classifier is never even consulted.
+        mock_eval.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_locked_out_ambient_would_engage_gets_brig_emoji(self):
+        """A lurking message the classifier would engage in an ambient channel
+        still earns the brig emoji: the gated user sees Bosun would have replied,
+        but no reply, agent, or storage follows."""
+        bot = _make_bot()
+        message = _make_message("something bosun would jump on")
+        mock_store = _make_store()
+        p_engine, p_session, p_store = _lock_patches(mock_store)
+
+        with (
+            p_engine,
+            p_session as mock_session_cls,
+            p_store,
+            patch(
+                "chat.bot.safeguards.observe_message",
+                return_value=Verdict(locked_out=True, score=10.0),
+            ),
+            patch("chat.bot.safeguards.log_enforcement", MagicMock()) as mock_log,
+            patch("chat.bot.acl.ambient_channels", MagicMock(return_value={"99"})),
+            patch("chat.bot.directives.get_active", MagicMock(return_value=None)),
+            patch.object(bot, "_recently_tagged", MagicMock(return_value=False)),
+            patch(
+                "chat.bot.attention.evaluate",
+                AsyncMock(return_value=MagicMock(engage=True)),
+            ) as mock_eval,
+            patch.object(bot, "_process_message", AsyncMock()) as mock_proc,
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot.on_message(message)
+
+        mock_eval.assert_awaited_once()
+        message.add_reaction.assert_awaited_once()
+        assert message.add_reaction.call_args.args[0] == "⚓"
+        mock_log.assert_called_once()
+        assert mock_log.call_args.args[1] is True  # reacted
+        # Emoji only: no reply, no agent run.
+        mock_proc.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_locked_out_ambient_would_ignore_stays_silent(self):
+        """A lurking message the classifier would ignore stays fully silent,
+        even in an ambient channel: no emoji, no reply, no enforcement log."""
+        bot = _make_bot()
+        message = _make_message("ordinary lurking chatter")
+        mock_store = _make_store()
+        p_engine, p_session, p_store = _lock_patches(mock_store)
+
+        with (
+            p_engine,
+            p_session as mock_session_cls,
+            p_store,
+            patch(
+                "chat.bot.safeguards.observe_message",
+                return_value=Verdict(locked_out=True, score=10.0),
+            ),
+            patch("chat.bot.safeguards.log_enforcement", MagicMock()) as mock_log,
+            patch("chat.bot.acl.ambient_channels", MagicMock(return_value={"99"})),
+            patch("chat.bot.directives.get_active", MagicMock(return_value=None)),
+            patch.object(bot, "_recently_tagged", MagicMock(return_value=False)),
+            patch(
+                "chat.bot.attention.evaluate",
+                AsyncMock(return_value=MagicMock(engage=False)),
+            ) as mock_eval,
+            patch.object(bot, "_process_message", AsyncMock()) as mock_proc,
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot.on_message(message)
+
+        mock_eval.assert_awaited_once()
         message.add_reaction.assert_not_called()
         mock_log.assert_not_called()
         mock_proc.assert_not_called()

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.142
+      targetRevision: 0.285.143
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

Extends the Bosun trust-safety lockout signal (ADR chat/003, PR #3395) so a locked-out (low-trust) user gets the anchor/brig emoji ⚓ not only when they **address** the bot directly, but also when their **ambient** message is one the attention classifier **would have engaged**. Previously that ambient case was suppressed silently, so a gated user had no way to tell Bosun would have replied.

## How

- In the locked-out branch of `on_message`, for an unaddressed message in an ambient-granted channel, run **only** the attention classify (`attention.evaluate`). If it would engage, land the same ⚓. No reply, agent run, or message storage follows.
- Extracted the ambient-channel resolution into `_resolve_ambient` so the locked-out path and the normal ambient path share one fail-closed implementation (no drift).
- Enforcement logging now fires whenever a reaction was placed (`addressed or signals or reacted`), so the new ambient reactions are recorded.

## Tradeoff (deliberate)

This relaxes ADR chat/003's "zero LLM spend when locked out" guarantee to **one classify call** per ambient message from a locked-out user. The expensive parts (reply generation, agent runs, send-gate) stay off. Rolled out everywhere immediately per decision.

## Tests

`bot_safeguards_test.py`:
- ambient + classifier would-engage -> ⚓, no reply, enforcement logged
- ambient + classifier would-ignore -> fully silent
- non-ambient lurker -> classifier never consulted, silent (renamed existing test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)