### PR TITLE
feat(skills): add improve-safeguards trust-ledger correctness loop

### DIFF
--- a/.claude/skills/improve-safeguards/SKILL.md
+++ b/.claude/skills/improve-safeguards/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: improve-safeguards
+description: >
+  Correctness feedback loop over Bosun's trust & safety ledger (ADR chat/003):
+  review moderation decisions, especially the near-boundary and cross-lane
+  ones, and judge each as a false positive (a benign message flagged, worst
+  when it locked a user out), a false negative (real abuse scored clean), or a
+  correct call, then open evidence-backed PRs tuning the responsible lever (a
+  heuristic pattern, the LLM intent prompt, a signal weight, or the lockout
+  threshold) and flag mislabeled rows for a human pardon/relabel. Use when
+  asked to "improve the safeguards", "/improve-safeguards", "was that lockout
+  right", "why did Bosun ignore/brig <person>", "is the trust ledger
+  over-flagging", or "false positive/negative in moderation". Sister to
+  improve-ambient (engagement fluidity) and improve-recipes (agent-run
+  mechanics); this one owns the ledger's correctness. The heuristic/LLM/weight/
+  threshold levers are human-reviewed here; the shadow random forest retrains
+  itself out of band (chat/safeguards_train_job.py).
+---
+
+# improve-safeguards
+
+On-demand feedback loop for Bosun's trust ledger. Gathers moderation decisions
+from Postgres and S3, classifies the questionable ones against a fixed taxonomy,
+and drafts PRs editing the responsible lever, each with evidence tied to specific
+decisions.
+
+The ledger (ADR chat/003, `projects/monolith/chat/safeguards.py`) has three
+scoring lanes but no correction lane: the heuristics and the LLM screen mint the
+labels, and the random forest trains to imitate them, so nothing discovers a
+false positive the heuristics themselves produce. The only ground-truth signal
+today is the manual `pardon` (reactive: someone must notice a wrong lockout).
+This skill is the missing supervision.
+
+## 1. Unit of analysis: the moderation decision
+
+One decision is one `chat.moderation_event` row (`event_id` is its id). `gather`
+enriches each with the message it scored (join `chat.messages` on the Discord
+id), the user's current `chat.user_trust` row, and two review flags:
+
+- **near_boundary**: `score_after` landed within `_BOUNDARY_BAND` (default 15)
+  of the lockout threshold (default 40). The classifier's least-certain zone: a
+  wrong call here is one signal away from a lockout.
+- **cross_lane_disagreement**: the heuristic/LLM verdict (`label`) and the
+  shadow forest (`rf_score`) disagree (a positive label with a low rf, or a
+  clean label with a high one). The ambiguous calls most worth a human read.
+
+`kind` distinguishes the lanes: `signal` (heuristic hit), `llm_intent` (LLM
+screen), `clean_sample` (sampled benign, label 0), `lockout` (crossed below the
+threshold), `pardon`/`enforcement` (markers).
+
+## 2. Taxonomy v1
+
+Fixed vocabulary so runs are comparable over time. `taxonomy_version: 1`. Adding
+a mode means bumping the version in this file by PR.
+
+Correctness verdicts (one per decision):
+
+- **false-positive**: a benign message was flagged (`signal`/`llm_intent`), or
+  worse, it contributed to a `lockout`. The highest-stakes error: a wrongly
+  locked user is silently ignored and brig-reacted. Map to the pattern/prompt
+  that fired.
+- **false-negative**: a `clean_sample` (or unflagged message) whose content, on
+  read, is real red-team behaviour the lanes missed. Map to a pattern/prompt
+  gap.
+- **over-penalty**: correctly flagged, but the `delta` was too harsh for the
+  severity (a mild probe scored like a hard injection). Map to a weight.
+- **near-miss-boundary**: the direction was right but the score landed fragile
+  near the threshold in a way that a normal follow-up would wrongly tip. Map to
+  a weight or the threshold. Informational unless it clusters.
+- **mislabeled-training**: the row's `label` is wrong and will poison the forest
+  regardless of enforcement. Map to a label correction (pardon/relabel), NOT a
+  code edit.
+- **correct-flag** / **correct-clean** (positive): the call was right. Recorded
+  so the before/after aggregates have a denominator.
+- **env-failure**: a ledger/DB fault, out of scope. Reported, never diffed.
+
+## 3. Lever routing table
+
+| Verdict / cause                                                   | Lever                        | File / mechanism                                                              |
+| ---------------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------- |
+| false-positive from an over-broad regex                          | heuristic pattern            | `chat/safeguards.py` `_INJECTION_PATTERNS` / `_PROBE_PATTERN` / `_RESOURCE_ABUSE_PATTERN` |
+| false-positive from the LLM over-flagging                        | LLM intent prompt            | `chat/safeguards.py` `score_intent()` prompt                                  |
+| false-negative (a real tell no pattern catches)                  | heuristic pattern OR LLM prompt | `chat/safeguards.py`                                                        |
+| over-penalty / near-miss-boundary                                | signal weight or threshold   | `chat/safeguards.py` `_W_*` constants, `_DEFAULT_LOCKOUT_THRESHOLD`           |
+| mislabeled-training (label wrong, poisons the forest)            | label correction             | `monolith-chat-trust-pardon` MCP (human-run), NOT a code edit                 |
+| forest miscalibrated (rf_score consistently wrong)              | forest lane                  | report only; the forest retrains itself (`chat/safeguards_train_job.py`)       |
+
+The heuristics and threshold gate whether the ledger flags at all; the LLM
+prompt shapes the fuzzy calls the regexes miss; the weights shape how hard a
+confirmed hit bites. A false positive that traces to one person's style, not a
+pattern flaw, is not a code edit: note it (the owner is already exempt; a
+per-user exemption is a ledger data change, not a lever here).
+
+## 4. Enforcement-posture signal (the number that matters most)
+
+The ledger ships in `live` mode (enforcing) by default. The single most
+important aggregate is the **false-positive lockout rate**: confirmed-wrong
+lockouts / total lockouts in the window. A rising rate is the signal to soften a
+weight, raise the boundary margin, or recommend flipping `SAFEGUARDS_MODE` back
+to `observe` until the lanes are tuned. Report it every run, even when no code
+lever changes. A rising `pardon` count is the same signal seen from the human
+side.
+
+## 5. Methodology
+
+1. **Window.** Defaults to "since the last commit touching the lever file"
+   (`chat/safeguards.py`), overridable with `--since <ISO8601>` or a single
+   `event_id` for a targeted "was that call right" analysis:
+
+   ```bash
+   git log -1 --format=%cI origin/main -- projects/monolith/chat/safeguards.py
+   ```
+
+   The previous generation's window is between the prior two such commits; use
+   it for the before/after aggregates in the PR body.
+2. **Gather.** Run `gather --since <window>`. Skip decisions whose `has_eval` is
+   already true at the current `taxonomy_version`.
+3. **Rank.** Deep-read the worst K first: every `lockout` and `pardon`, then
+   `cross_lane_disagreement`, then `near_boundary`, then a sample of
+   `clean_sample` rows to hunt false negatives, then any `has_resource_abuse`
+   hit while that pattern is young. A confidently clean, unremarkable decision
+   does not need a deep-read.
+4. **Deep-read.** `fetch-decision <event_id>` for the scored message, the
+   channel slice around it (banter vs a genuine probe), the user's recent ledger
+   history (a lone hit vs a serial pattern), and reactions. Read it, judge the
+   verdict against the taxonomy, and write the eval via `put-eval`.
+5. **Map and ship.** Map each confirmed verdict to its lever (section 3). Edit
+   only the responsible lever, and for `mislabeled-training` flag the row for a
+   human pardon/relabel instead.
+
+**Minimum evidence.** Fewer than about 5 reviewable decisions in the window:
+report-only, no PR ("not enough evidence yet"). A single named `event_id` is
+always a valid targeted analysis.
+
+**Regression guard.** Before tightening a pattern to kill a false positive,
+confirm the change still fires on the true positives in the window (and add a
+paired test in `safeguards_test.py`). Before broadening one to catch a false
+negative, confirm it does not start firing on the benign messages already in the
+window. The `safeguards_test.py` paired positive/negative tests are the
+contract; every pattern edit updates them.
+
+## 6. Write scope
+
+PRs may edit `chat/safeguards.py` (patterns, the LLM prompt, weights, the
+threshold) with a paired `safeguards_test.py` update. Every diff hunk cites at
+least one `event_id`; an edit that cannot cite a specific decision is dropped.
+Label corrections are FLAGGED for a human `monolith-chat-trust-pardon`, never
+performed here (Postgres is read-only). Sanity-check before opening the PR:
+
+```bash
+python3 -c "import ast; ast.parse(open('projects/monolith/chat/safeguards.py').read())"
+```
+
+Bump the monolith chart in the same PR (safeguards ships with the monolith
+image): `bazel/tools/git/bump-chart.sh projects/monolith`.
+
+## 7. PR body template
+
+Three sections, in order (sibling-identical shape):
+
+1. **Before/after aggregates.** This window vs the previous generation:
+   verdict histogram (false-positive / false-negative / correct-* / ...), the
+   **false-positive lockout rate**, the `pardon` count, and the cross-lane
+   disagreement rate, computed from the eval JSON and the gathered records.
+2. **Per-edit evidence rows.** For each diff hunk: `event_id`, kind, the message
+   excerpt, the signals (heuristic names, delta, score_after, label, rf_score),
+   the verdict, and which diff line addresses it.
+3. **Out of scope, observed.** Anything the evidence points at outside the code
+   levers (a per-person exemption, an enforcement-posture change, a forest
+   retrain, or an upstream fault).
+
+## 8. Guardrails
+
+- Postgres access is strictly read-only (SELECT only).
+- S3 writes are limited to the `safeguards-evals/` key prefix; never touch any
+  other object, and never `sessions.db` or other buckets.
+- The skill never mutates the ledger. A pardon/relabel is a human MCP action it
+  recommends, not one it performs.
+- `env-failure` (a DB fault, a ledger outage) is reported, never diffed.
+- Do not tune a lever to work around one person; the owner exemption and any
+  per-user handling are ledger data, not a pattern edit.
+
+## 9. Invocation
+
+Optional argument: a lookback window, or one `event_id` for a targeted "was that
+call right" analysis.
+
+Find the monolith pod. There is no pod named "backend": the API lives in the
+`backend` CONTAINER of the `monolith-*` pod (alongside linkerd-proxy and
+frontend):
+
+```bash
+kubectl get pods -n monolith -o name | grep '^pod/monolith-' | grep -v pg | grep -v atlas | grep -v searxng | head -1
+```
+
+Run a subcommand by piping the helper script over stdin into the pod's venv
+python (note the `-c backend` container selector):
+
+```bash
+kubectl exec -i -n monolith <pod> -c backend -- env \
+  PYTHONPATH=/projects/monolith/main.runfiles/_main/projects/monolith \
+  /projects/monolith/main.runfiles/_main/projects/monolith/.main/bin/python3 - \
+  gather --since 2026-07-11T00:00:00Z \
+  < .claude/skills/improve-safeguards/scripts/improve_safeguards_tool.py
+```
+
+`fetch-decision` is the same shape with the subcommand and an event id:
+
+```bash
+kubectl exec -i -n monolith <pod> -c backend -- env \
+  PYTHONPATH=/projects/monolith/main.runfiles/_main/projects/monolith \
+  /projects/monolith/main.runfiles/_main/projects/monolith/.main/bin/python3 - \
+  fetch-decision <event_id> \
+  < .claude/skills/improve-safeguards/scripts/improve_safeguards_tool.py
+```
+
+`put-eval` takes the eval JSON base64-encoded as an argv argument (the script
+itself is piped in over stdin, so there is no second stdin channel):
+
+```bash
+kubectl exec -i -n monolith <pod> -c backend -- env \
+  PYTHONPATH=/projects/monolith/main.runfiles/_main/projects/monolith \
+  /projects/monolith/main.runfiles/_main/projects/monolith/.main/bin/python3 - \
+  put-eval <event_id> <base64-encoded-eval-json> \
+  < .claude/skills/improve-safeguards/scripts/improve_safeguards_tool.py
+```
+
+## eval JSON contract
+
+Written per decision via `put-eval <event_id> <base64-payload>` to
+`s3://artifacts/safeguards-evals/<event_id>.json`. Required keys:
+
+- `event_id`
+- `guild_id`, `channel_id`, `user_id`
+- `kind`
+- `taxonomy_version`
+- `verdict`: one of the section 2 modes
+- `confidence`: 0.0-1.0
+- `rationale`
+- `signals`: `{heuristic_signals, delta, score_after, label, rf_score,
+  near_boundary, cross_lane_disagreement}`
+- `lever`: `heuristic` | `llm-prompt` | `weight` | `threshold` |
+  `label-correction` | null (null when the verdict is correct)
+- `classified_at`: ISO timestamp, from `date -u`
+- `levers_ref`: git SHA of `origin/main` for `chat/safeguards.py` at classify
+  time
+
+## After merge
+
+Pattern/prompt/weight/threshold edits ship with the MONOLITH image: the merged
+PR's chart bump rolls them out. A flagged label correction takes effect when a
+human runs `monolith-chat-trust-pardon`. The next `/improve-safeguards` run's
+before/after aggregates (especially the false-positive lockout rate) are the
+verdict on whether the change worked.

--- a/.claude/skills/improve-safeguards/scripts/improve_safeguards_tool.py
+++ b/.claude/skills/improve-safeguards/scripts/improve_safeguards_tool.py
@@ -1,0 +1,407 @@
+"""improve-safeguards in-pod helper. Piped over stdin into the monolith backend pod.
+
+Subcommands (argv after ``python3 -``):
+  gather --since <ISO8601>        NDJSON moderation-decision records to stdout
+  fetch-decision <event_id>       message + channel context + the user's recent
+                                  moderation history + reactions (JSON)
+  put-eval <event_id> <b64>       base64 eval JSON as argv[3]
+                                  -> s3://artifacts/safeguards-evals/<event_id>.json
+
+A "decision" is one ``chat.moderation_event`` row: the trust ledger's record of
+one observation (ADR chat/003). ``kind`` is one of ``signal`` (a heuristic hit),
+``llm_intent`` (the LLM screen flagged it), ``clean_sample`` (a sampled benign
+message, label 0), ``lockout`` (score crossed below the threshold), or
+``pardon``/``enforcement`` (markers). Each gathered decision is enriched with the
+message content it scored (join ``chat.messages`` on the Discord id), the user's
+current ledger row, and two review flags:
+
+  near_boundary            score_after landed within +/- _BOUNDARY_BAND of the
+                           lockout threshold: the classifier's least-certain
+                           zone, where a false call is one signal away.
+  cross_lane_disagreement  the heuristic/LLM verdict (``label``) and the shadow
+                           forest (``rf_score``) disagree: a positive label with
+                           a low rf_score, or a clean label with a high one. The
+                           ambiguous calls most worth a human read.
+
+The audit asks, per decision: was this the RIGHT call? A ``lockout`` (a
+user-visible soft-ignore) that should not have fired is a false positive and the
+worst outcome; a ``clean_sample`` whose message actually reads as abuse is a
+false negative. Both are in the worst set regardless of any score.
+
+put-eval takes its payload as a base64-encoded argv, not stdin: the script
+itself is piped in over stdin (there is no second stdin channel to carry the
+payload once that pipe is consumed). Callers must base64-encode the eval JSON
+document and pass it as the third argument.
+
+Postgres access is read-only (SELECT only). S3 writes are limited to the
+``safeguards-evals/`` key prefix in the artifacts bucket. The skill never
+mutates the ledger: a label correction (pardon/relabel) is a separate,
+human-run MCP action, not something this tool performs.
+
+eval JSON contract (written by put-eval, one key per decision under
+``safeguards-evals/``):
+
+  {
+    "event_id": <int>,
+    "guild_id": "<discord guild id>",
+    "channel_id": "<discord channel id>",
+    "user_id": "<discord user id>",
+    "kind": "signal" | "llm_intent" | "clean_sample" | "lockout" | ...,
+    "taxonomy_version": <int>,
+    "verdict": "false-positive" | "false-negative" | "correct-flag"
+               | "correct-clean" | "over-penalty" | "near-miss-boundary"
+               | "mislabeled-training" | "env-failure",
+    "confidence": 0.0-1.0,
+    "rationale": "...",
+    "signals": {
+      "heuristic_signals": ["override_instructions", ...],
+      "delta": -25.0,
+      "score_after": 75.0,
+      "label": 1,
+      "rf_score": 0.12,
+      "near_boundary": false,
+      "cross_lane_disagreement": true
+    },
+    "lever": "heuristic" | "llm-prompt" | "weight" | "threshold"
+             | "label-correction" | null,
+    "classified_at": "<ISO8601, from date -u>",
+    "levers_ref": "<git SHA of chat/safeguards.py at classify time>"
+  }
+"""
+
+import base64
+import json
+import logging
+import os
+import sys
+
+from sqlalchemy import text
+
+from app.db import get_engine
+from artifact import s3
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("improve-safeguards")
+
+_EVAL_PREFIX = "safeguards-evals/"
+
+# Lockout threshold mirror. The ledger reads SAFEGUARDS_LOCKOUT_THRESHOLD at
+# runtime (default 40); mirror that here so near_boundary tracks the live gate.
+_THRESHOLD = float(os.environ.get("SAFEGUARDS_LOCKOUT_THRESHOLD", "40"))
+# A score_after within this many points of the threshold is "near boundary":
+# the classifier's least-certain zone, where a wrong call is one signal away.
+_BOUNDARY_BAND = float(os.environ.get("SAFEGUARDS_BOUNDARY_BAND", "15"))
+# Forest disagreement cutoffs: a positive label with rf below _RF_LOW, or a
+# clean label with rf at/above _RF_HIGH, is a cross-lane disagreement.
+_RF_LOW = 0.4
+_RF_HIGH = 0.8
+# How many prior moderation events to show for the user in fetch-decision.
+_USER_HISTORY = 30
+# Channel context slice (minutes either side of the scored message).
+_CONTEXT_MINUTES = 15
+
+
+# One row per moderation decision in the window, joined to the message it scored
+# and the user's current ledger row. LEFT JOIN messages: enforcement/lockout
+# markers and pre-message rows may not resolve a message, and a decision is
+# still worth surfacing without its text.
+_GATHER_SQL = """
+SELECT e.id AS event_id,
+       e.created_at,
+       e.guild_id,
+       e.channel_id,
+       e.user_id,
+       e.message_id,
+       e.kind,
+       e.signal,
+       e.detail,
+       e.delta,
+       e.score_after,
+       e.label,
+       e.rf_score,
+       e.rf_model_version,
+       m.username,
+       m.is_bot,
+       LEFT(m.content, 2000) AS content,
+       t.score AS trust_score,
+       t.signal_count AS trust_signal_count,
+       t.lockout_count AS trust_lockout_count
+FROM chat.moderation_event e
+LEFT JOIN chat.messages m
+       ON m.discord_message_id = e.message_id
+      AND m.channel_id = e.channel_id
+LEFT JOIN chat.user_trust t
+       ON t.guild_id = e.guild_id
+      AND t.user_id = e.user_id
+WHERE e.created_at >= :since
+ORDER BY e.created_at, e.id
+"""
+
+
+def _bucket_evals():
+    """List keys already written under safeguards-evals/ -> event_id set.
+
+    One paginated listing so gather can flag decisions already eval'd (and at
+    which taxonomy_version) without a per-decision HEAD.
+    """
+    client = s3._client()
+    have = set()
+    token = None
+    while True:
+        kwargs = {"Bucket": s3._bucket(), "Prefix": _EVAL_PREFIX}
+        if token:
+            kwargs["ContinuationToken"] = token
+        resp = client.list_objects_v2(**kwargs)
+        for obj in resp.get("Contents", []):
+            leaf = obj["Key"][len(_EVAL_PREFIX) :]
+            if leaf.endswith(".json"):
+                have.add(leaf[: -len(".json")])
+        if not resp.get("IsTruncated"):
+            return have
+        token = resp.get("NextContinuationToken")
+
+
+def _near_boundary(score_after):
+    if score_after is None:
+        return False
+    return abs(float(score_after) - _THRESHOLD) <= _BOUNDARY_BAND
+
+
+def _cross_lane(label, rf_score):
+    if rf_score is None or label is None:
+        return False
+    rf = float(rf_score)
+    if int(label) == 1 and rf < _RF_LOW:
+        return True
+    if int(label) == 0 and rf >= _RF_HIGH:
+        return True
+    return False
+
+
+def gather(since):
+    have = _bucket_evals()
+    client = s3._client()
+    with get_engine().connect() as conn:
+        rows = conn.execute(text(_GATHER_SQL), {"since": since}).mappings()
+        for row in rows:
+            rec = dict(row)
+            rec["created_at"] = str(rec["created_at"])
+            rec["delta"] = float(rec["delta"]) if rec["delta"] is not None else None
+            rec["score_after"] = (
+                float(rec["score_after"]) if rec["score_after"] is not None else None
+            )
+            rec["rf_score"] = (
+                float(rec["rf_score"]) if rec["rf_score"] is not None else None
+            )
+            rec["label"] = int(rec["label"]) if rec["label"] is not None else None
+            rec["is_bot"] = bool(rec["is_bot"]) if rec["is_bot"] is not None else None
+            rec["trust_score"] = (
+                float(rec["trust_score"]) if rec["trust_score"] is not None else None
+            )
+            # Split the comma-joined heuristic signal names for readability.
+            rec["heuristic_signals"] = (
+                [s for s in str(rec["signal"]).split(",") if s]
+                if rec.get("signal")
+                else []
+            )
+            rec["near_boundary"] = _near_boundary(rec["score_after"])
+            rec["cross_lane_disagreement"] = _cross_lane(rec["label"], rec["rf_score"])
+            # Worst-set flags for ranking: a wrong lockout is user-visible and
+            # the highest-stakes false positive; disagreements and near-boundary
+            # calls are the ambiguous zone; a resource_abuse hit is new and
+            # worth confirming while the pattern is young.
+            rec["is_lockout"] = rec["kind"] == "lockout"
+            rec["is_pardon"] = rec["kind"] == "pardon"
+            rec["has_resource_abuse"] = "resource_abuse" in rec["heuristic_signals"]
+            sid = str(rec["event_id"])
+            rec["has_eval"] = sid in have
+            rec["eval_taxonomy_version"] = None
+            if rec["has_eval"]:
+                try:
+                    body = client.get_object(
+                        Bucket=s3._bucket(), Key=f"{_EVAL_PREFIX}{sid}.json"
+                    )["Body"].read()
+                    rec["eval_taxonomy_version"] = json.loads(body).get(
+                        "taxonomy_version"
+                    )
+                except Exception:
+                    logger.exception("gather: reading eval for %s failed", sid)
+            print(json.dumps(rec, default=str))
+
+
+_FETCH_EVENT_SQL = """
+SELECT id, created_at, guild_id, channel_id, user_id, message_id, kind, signal,
+       detail, delta, score_after, label, rf_score, rf_model_version,
+       features_json
+FROM chat.moderation_event
+WHERE id = :event_id
+"""
+
+# The message this decision scored, plus a slice of the channel around it so the
+# deep-read sees what the user was actually doing (banter vs a genuine probe).
+_FETCH_CONTEXT_SQL = """
+SELECT discord_message_id, user_id, username, is_bot,
+       LEFT(content, 2000) AS content, created_at
+FROM chat.messages
+WHERE channel_id = :channel_id
+  AND created_at >= :at - make_interval(mins => :window)
+  AND created_at <= :at + make_interval(mins => :window)
+ORDER BY created_at, id
+"""
+
+# The user's recent ledger history: how this decision fits their trajectory (a
+# lone hit on a clean user vs the tenth strike on a serial red-teamer).
+_FETCH_HISTORY_SQL = """
+SELECT id, created_at, kind, signal, delta, score_after, label, rf_score
+FROM chat.moderation_event
+WHERE guild_id = :guild_id
+  AND user_id = :user_id
+ORDER BY created_at DESC, id DESC
+LIMIT :limit
+"""
+
+# Reactions on the scored message (a peer's reaction to a message Bosun
+# flagged/ignored is a weak ground-truth signal).
+_FETCH_REACTIONS_SQL = """
+SELECT message_id, emoji, reactor_id, action, created_at
+FROM chat.reaction_event
+WHERE channel_id = :channel_id
+  AND message_id = CAST(:message_id AS text)
+ORDER BY created_at, id
+"""
+
+_FETCH_TRUST_SQL = """
+SELECT guild_id, user_id, score, score_updated_at, signal_count, lockout_count,
+       last_signal_at
+FROM chat.user_trust
+WHERE guild_id = :guild_id AND user_id = :user_id
+"""
+
+
+def fetch_decision(event_id):
+    with get_engine().connect() as conn:
+        ev = (
+            conn.execute(text(_FETCH_EVENT_SQL), {"event_id": event_id})
+            .mappings()
+            .first()
+        )
+        if ev is None:
+            print(json.dumps({"error": "no such event", "event_id": event_id}))
+            sys.exit(2)
+        at = ev["created_at"]
+        context = (
+            conn.execute(
+                text(_FETCH_CONTEXT_SQL),
+                {
+                    "channel_id": ev["channel_id"],
+                    "at": at,
+                    "window": _CONTEXT_MINUTES,
+                },
+            )
+            .mappings()
+            .all()
+        )
+        history = (
+            conn.execute(
+                text(_FETCH_HISTORY_SQL),
+                {
+                    "guild_id": ev["guild_id"],
+                    "user_id": ev["user_id"],
+                    "limit": _USER_HISTORY,
+                },
+            )
+            .mappings()
+            .all()
+        )
+        reactions = (
+            conn.execute(
+                text(_FETCH_REACTIONS_SQL),
+                {"channel_id": ev["channel_id"], "message_id": ev["message_id"]},
+            )
+            .mappings()
+            .all()
+        )
+        trust = (
+            conn.execute(
+                text(_FETCH_TRUST_SQL),
+                {"guild_id": ev["guild_id"], "user_id": ev["user_id"]},
+            )
+            .mappings()
+            .first()
+        )
+    evd = dict(ev)
+    try:
+        evd["features"] = json.loads(evd.pop("features_json") or "[]")
+    except (TypeError, ValueError):
+        evd["features"] = []
+    out = {
+        "event": {k: (str(v) if k == "created_at" else v) for k, v in evd.items()},
+        "threshold": _THRESHOLD,
+        "near_boundary": _near_boundary(ev["score_after"]),
+        "cross_lane_disagreement": _cross_lane(ev["label"], ev["rf_score"]),
+        "context_minutes": _CONTEXT_MINUTES,
+        "channel_context": [dict(r) for r in context],
+        "user_history": [dict(r) for r in history],
+        "reactions": [dict(r) for r in reactions],
+        "user_trust": dict(trust) if trust else None,
+    }
+    print(json.dumps(out, default=str))
+
+
+_EVAL_REQUIRED = {
+    "event_id",
+    "guild_id",
+    "channel_id",
+    "user_id",
+    "kind",
+    "taxonomy_version",
+    "verdict",
+    "confidence",
+    "rationale",
+    "signals",
+    "lever",
+    "classified_at",
+    "levers_ref",
+}
+
+
+def put_eval(event_id, payload_b64):
+    # event_id is an integer PK; coerce so a crafted (e.g. slash-bearing) id can
+    # never build an S3 key outside the safeguards-evals/ prefix.
+    try:
+        event_id = int(event_id)
+    except (TypeError, ValueError):
+        print(json.dumps({"error": "event_id must be an integer"}))
+        sys.exit(2)
+    doc = json.loads(base64.b64decode(payload_b64))
+    missing = _EVAL_REQUIRED - set(doc)
+    if missing:
+        print(json.dumps({"error": f"missing keys: {sorted(missing)}"}))
+        sys.exit(2)
+    if str(doc["event_id"]) != str(event_id):
+        print(json.dumps({"error": "event_id mismatch"}))
+        sys.exit(2)
+    key = f"{_EVAL_PREFIX}{event_id}.json"
+    s3._client().put_object(
+        Bucket=s3._bucket(),
+        Key=key,
+        Body=json.dumps(doc, indent=1).encode(),
+        ContentType="application/json",
+    )
+    print(json.dumps({"ok": True, "key": key}))
+
+
+def main():
+    cmd = sys.argv[1]
+    if cmd == "gather":
+        gather(sys.argv[sys.argv.index("--since") + 1])
+    elif cmd == "fetch-decision":
+        fetch_decision(sys.argv[2])
+    elif cmd == "put-eval":
+        put_eval(sys.argv[2], sys.argv[3])
+    else:
+        print(json.dumps({"error": f"unknown subcommand {cmd}"}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

The trust & safety ledger (ADR chat/003, PR #3395) shipped enforcing (`SAFEGUARDS_MODE` defaults to `live`), but it has **three scoring lanes and no correction lane**:

- the heuristics + LLM screen mint the training labels, and the shadow forest trains to *imitate* them, so it can't discover a false positive the heuristics themselves produce (the ADR names this bootstrap circularity);
- the only human ground-truth signal is the manual `pardon`, which is reactive (someone has to *notice* a wrongful lockout first);
- nothing reviews **false negatives** (real abuse scored clean) or **near-boundary** decisions (scores hovering around the lockout threshold), which is where a classifier is wrong most often.

A wrongly-locked user is silently ignored and brig-reacted, so a false positive is user-visible and damaging with nothing to catch it. This skill is the missing supervision, sister to `improve-ambient` (engagement fluidity) and `improve-recipes` (agent-run mechanics).

## What

`.claude/skills/improve-safeguards/` — a `SKILL.md` and an in-pod `scripts/improve_safeguards_tool.py` (same shape as the sisters: `kubectl exec` the helper over stdin into the monolith backend container).

- **gather** — NDJSON of `chat.moderation_event` decisions in a window, each enriched with the scored message (`chat.messages` join), the user's `chat.user_trust` row, and two flags: `near_boundary` (score within a band of the threshold) and `cross_lane_disagreement` (heuristic/LLM `label` vs shadow `rf_score`).
- **fetch-decision** — deep-read context for one decision: the message, a channel slice around it (banter vs a genuine probe), the user's recent ledger history, reactions.
- **put-eval** — writes the classification to `s3://artifacts/safeguards-evals/<event_id>.json`.

Taxonomy v1: `false-positive` / `false-negative` / `over-penalty` / `near-miss-boundary` / `mislabeled-training` / `correct-flag` / `correct-clean` / `env-failure`. Levers route to `chat/safeguards.py` (patterns, the `score_intent` prompt, `_W_*` weights, the threshold); `mislabeled-training` is flagged for a human `monolith-chat-trust-pardon` rather than a code edit.

The headline aggregate is the **false-positive lockout rate**, the number that decides whether to keep enforcing or dial the threshold back.

## Guardrails

- Postgres access is read-only (SELECT only); S3 writes limited to `safeguards-evals/`.
- The skill never mutates the ledger; a pardon/relabel is a human MCP action it recommends.
- Fewer than ~5 reviewable decisions in the window: report-only (a single `event_id` is always a valid targeted analysis).
- No chart bump: skill files are session tooling, not shipped in an image.

## Notes

- Design is deliberately sibling-identical to `improve-ambient` (SKILL.md structure, tool subcommand shape, eval-contract style, the `CAST(:x AS text)` / psycopg binding gotchas).
- A design ADR (chat/003 has the ledger; this would be a small `chat/00N` for the loop, mirroring `improve-ambient`'s ADR chat/001) is a reasonable follow-up if we want the rationale recorded separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)