### PR TITLE
feat(monolith): capture managed scans via Semgrep scan webhook

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.64
+version: 0.89.65
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.64
+      targetRevision: 0.89.65
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -910,6 +910,19 @@ py_test(
 )
 
 py_test(
+    name = "semgrep_perf_webhook_test",
+    srcs = ["semgrep_scan/perf_webhook_test.py"],
+    imports = ["."],
+    # gazelle:exclude semgrep_scan means this py_test is hand-added, not generated.
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "sandbox_mcp_test",
     srcs = ["sandbox/mcp_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.143
+version: 0.285.144
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -191,6 +191,20 @@ spec:
                   name: {{ include "monolith.fullname" . }}-semgrep-app
                   key: GITHUB_SEMGREP_WEBHOOK_SECRET
                   optional: true
+            # HMAC secret for the Semgrep AppSec Platform scan webhook
+            # (semgrep_scan/perf_webhook.py). Semgrep signs the body with it
+            # (X-Semgrep-Signature-256) so we capture every managed scan's
+            # runtime findings-independently. Same semgrep vault item, field
+            # SEMGREP_WEBHOOK_SECRET; Joe sets the identical value in the Semgrep
+            # webhook config. Optional so an older vault item without the field
+            # does not block the pod (the webhook then 401s, the fail-closed
+            # default).
+            - name: SEMGREP_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "monolith.fullname" . }}-semgrep-app
+                  key: SEMGREP_WEBHOOK_SECRET
+                  optional: true
             {{- if .Values.chat.enabled }}
             # Real GitHub API token for the webhook's changed-file fetch. The
             # monolith's own GITHUB_TOKEN env is a kloak: placeholder (guest

--- a/projects/monolith/chart/templates/httproute-private.yaml
+++ b/projects/monolith/chart/templates/httproute-private.yaml
@@ -112,6 +112,13 @@ spec:
         - path:
             type: PathPrefix
             value: /webhooks/github/semgrep
+        # Semgrep AppSec Platform scan webhook (semgrep_scan/perf_webhook.py).
+        # Same no-SecurityPolicy treatment: Semgrep sends no Access JWT, so it
+        # reaches this route via a Cloudflare Access IP-Bypass for Semgrep's
+        # egress IPs and is gated only by the handler's HMAC verification.
+        - path:
+            type: PathPrefix
+            value: /webhooks/semgrep
       backendRefs:
         - name: {{ include "monolith.fullname" . }}
           port: {{ .Values.service.apiPort | int }}

--- a/projects/monolith/chart/templates/onepassworditem-semgrep-app.yaml
+++ b/projects/monolith/chart/templates/onepassworditem-semgrep-app.yaml
@@ -9,6 +9,11 @@
 #                                  value in the GitHub hook config. Injected as an
 #                                  optional secret env; while absent the webhook
 #                                  fails closed (401s every request).
+#   SEMGREP_WEBHOOK_SECRET       - the HMAC secret Semgrep signs its scan webhook
+#                                  bodies with (semgrep_scan/perf_webhook.py). Add
+#                                  this field and set the identical value in the
+#                                  Semgrep AppSec Platform webhook config. Optional
+#                                  env; while absent the webhook fails closed.
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.143
+      targetRevision: 0.285.144
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/semgrep_scan/__init__.py
+++ b/projects/monolith/semgrep_scan/__init__.py
@@ -31,8 +31,10 @@ def register(app: FastAPI) -> None:
     domains' registration.
     """
     from semgrep_scan.perf_router import router as perf_router
+    from semgrep_scan.perf_webhook import router as perf_webhook_router
     from semgrep_scan.router import internal_router, router
 
     app.include_router(router)
     app.include_router(internal_router)
     app.include_router(perf_router)
+    app.include_router(perf_webhook_router)

--- a/projects/monolith/semgrep_scan/perf_webhook.py
+++ b/projects/monolith/semgrep_scan/perf_webhook.py
@@ -1,0 +1,134 @@
+"""Semgrep AppSec Platform scan webhook -> semgrep.scan_perf.
+
+Semgrep POSTs a ``semgrep_scan`` object every time a scan completes, including
+scans with NO findings. That is the key property the findings-derived harvest
+lacks: the harvest can only discover a managed scan that left an open finding,
+so a clean scan (or a re-scan that surfaces nothing new) is invisible to it.
+This webhook captures every managed scan's runtime for the perf comparison in
+near-real-time, findings-independent. The hourly harvest stays as a backstop
+for any delivery this misses.
+
+AUTH (fail-closed): Semgrep signs with ``SEMGREP_WEBHOOK_SECRET`` and sends
+``X-Semgrep-Signature-256: <hex>`` (HMAC-SHA256, hex, no prefix). Semgrep's docs
+compute the digest over the canonical ``json.dumps(payload, separators=(",",
+":"))`` rather than necessarily the exact bytes on the wire, so we accept a
+match against EITHER the raw body OR that canonical re-serialization. Both
+require the shared secret, so accepting either is safe and it removes a whole
+class of whitespace-mismatch silent-401s. An unset secret denies every request.
+
+The path ``/webhooks/semgrep`` is reachable through the private ingress via a
+Cloudflare Access IP-Bypass for Semgrep's egress IPs (Semgrep sends no Access
+JWT); the route carries no SecurityPolicy, so this HMAC is the only gate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+
+from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request
+
+logger = logging.getLogger("monolith.semgrep.perf_webhook")
+
+router = APIRouter(prefix="/webhooks/semgrep", tags=["semgrep-scan-webhook"])
+
+
+def _verify_signature(body: bytes, signature_header: str | None) -> None:
+    """Verify Semgrep's ``X-Semgrep-Signature-256`` over the body, fail-closed.
+
+    Accepts an HMAC-SHA256 hex digest that matches either the raw body or its
+    canonical compact re-serialization. An unset secret, a missing header, or a
+    mismatch all raise 401 (never accept an unverifiable webhook).
+    """
+    secret = os.environ.get("SEMGREP_WEBHOOK_SECRET", "")
+    if not secret:
+        raise HTTPException(status_code=401, detail="webhook secret not configured")
+    if not signature_header:
+        raise HTTPException(status_code=401, detail="missing signature")
+    presented = signature_header.strip()
+    key = secret.encode("utf-8")
+    candidates = [hmac.new(key, body, hashlib.sha256).hexdigest()]
+    try:
+        canonical = json.dumps(json.loads(body), separators=(",", ":")).encode("utf-8")
+        candidates.append(hmac.new(key, canonical, hashlib.sha256).hexdigest())
+    except (ValueError, TypeError):
+        pass
+    if not any(hmac.compare_digest(presented, c) for c in candidates):
+        raise HTTPException(status_code=401, detail="invalid signature")
+
+
+def _extract_scan_id(payload: dict) -> int | None:
+    raw = payload.get("id")
+    try:
+        return int(raw) if raw is not None else None
+    except (ValueError, TypeError):
+        return None
+
+
+def _managed_row_for(scan_id: int):
+    """Fetch the scan record and return a ScanPerf row iff it is a managed scan,
+    else None. Reuses the harvest's fetch + classify so managed scans are
+    captured identically; our own scans (env UNSPECIFIED) classify to None and
+    are skipped here (report.py is authoritative for those)."""
+    from semgrep_scan.perf_harvest import fetch_scan, scan_to_row
+
+    token = os.environ.get("SEMGREP_APP_TOKEN", "")
+    scan = fetch_scan(scan_id, token)
+    return scan_to_row(scan) if scan else None
+
+
+def _capture_scan(scan_id: int) -> None:
+    """Off-request: pull the scan record and upsert it if managed. Best-effort;
+    a failure is logged and swallowed so a bad delivery never 500s the webhook."""
+    from sqlmodel import Session
+
+    from app.db import get_engine
+    from semgrep_scan.perf_store import upsert_scan_perf
+
+    try:
+        row = _managed_row_for(scan_id)
+        if row is None:
+            logger.info(
+                "semgrep scan webhook: scan %s not a managed scan, skipped", scan_id
+            )
+            return
+        with Session(get_engine()) as session:
+            upsert_scan_perf(session, row)
+        logger.info(
+            "semgrep scan webhook: captured managed scan %s (%.1fs, %d findings)",
+            scan_id,
+            row.total_time,
+            row.findings_total,
+        )
+    except Exception:
+        logger.exception("semgrep scan webhook: failed to capture scan %s", scan_id)
+
+
+@router.post("")
+@router.post("/")
+async def semgrep_scan_webhook(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    x_semgrep_signature_256: str | None = Header(default=None),
+) -> dict:
+    """Verify the signature, ack fast, and capture the scan off-request.
+
+    Only the ``semgrep_scan`` object (a JSON dict with an ``id``) is handled;
+    ``semgrep_finding`` events (JSON arrays) are acknowledged and ignored.
+    """
+    body = await request.body()
+    _verify_signature(body, x_semgrep_signature_256)
+    try:
+        payload = json.loads(body)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid json") from exc
+    if not isinstance(payload, dict):
+        return {"status": "ignored", "reason": "not a semgrep_scan object"}
+    scan_id = _extract_scan_id(payload)
+    if scan_id is None:
+        return {"status": "ignored", "reason": "no scan id"}
+    background_tasks.add_task(_capture_scan, scan_id)
+    return {"status": "accepted", "scan_id": scan_id}

--- a/projects/monolith/semgrep_scan/perf_webhook_test.py
+++ b/projects/monolith/semgrep_scan/perf_webhook_test.py
@@ -1,0 +1,148 @@
+"""Tests for the Semgrep scan webhook (semgrep_scan/perf_webhook.py).
+
+Focus on the security-critical, webhook-specific surface: HMAC verification
+(fail-closed) and payload parsing. The downstream capture reuses fetch_scan /
+scan_to_row / upsert_scan_perf, which are covered by the harvest + store tests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from semgrep_scan import perf_webhook
+
+HMAC_KEY = "test-webhook-secret-abcdef"
+
+
+@pytest.fixture(name="client")
+def client_fixture(monkeypatch):
+    monkeypatch.setenv("SEMGREP_WEBHOOK_SECRET", HMAC_KEY)
+    # Never touch the network / DB: the background capture is stubbed out.
+    monkeypatch.setattr(perf_webhook, "_capture_scan", lambda scan_id: None)
+    app = FastAPI()
+    app.include_router(perf_webhook.router)
+    return TestClient(app)
+
+
+def _sig(body: bytes, secret: str = HMAC_KEY) -> str:
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def test_valid_raw_body_signature_is_accepted(client):
+    body = json.dumps(
+        {"id": 42, "environment": "SCAN_ENVIRONMENT_MANAGED_SCANS"}
+    ).encode()
+    resp = client.post(
+        "/webhooks/semgrep",
+        content=body,
+        headers={"X-Semgrep-Signature-256": _sig(body)},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "accepted", "scan_id": 42}
+
+
+def test_valid_canonical_signature_is_accepted(client):
+    # Semgrep may sign the compact re-serialization, not the exact bytes sent.
+    payload = {"id": 7, "environment": "SCAN_ENVIRONMENT_MANAGED_SCANS"}
+    body = json.dumps(payload, indent=2).encode()  # pretty bytes on the wire
+    canonical = json.dumps(payload, separators=(",", ":")).encode()
+    resp = client.post(
+        "/webhooks/semgrep",
+        content=body,
+        headers={"X-Semgrep-Signature-256": _sig(canonical)},
+    )
+    assert resp.status_code == 200
+    assert resp.json().get("scan_id") == 7
+
+
+def test_invalid_signature_is_401(client):
+    body = json.dumps({"id": 1}).encode()
+    resp = client.post(
+        "/webhooks/semgrep",
+        content=body,
+        headers={"X-Semgrep-Signature-256": "deadbeef"},
+    )
+    assert resp.status_code == 401
+
+
+def test_missing_signature_is_401(client):
+    body = json.dumps({"id": 1}).encode()
+    resp = client.post("/webhooks/semgrep", content=body)
+    assert resp.status_code == 401
+
+
+def test_unset_secret_denies_every_request(monkeypatch):
+    monkeypatch.delenv("SEMGREP_WEBHOOK_SECRET", raising=False)
+    app = FastAPI()
+    app.include_router(perf_webhook.router)
+    client = TestClient(app)
+    body = json.dumps({"id": 1}).encode()
+    resp = client.post(
+        "/webhooks/semgrep",
+        content=body,
+        headers={"X-Semgrep-Signature-256": _sig(body)},
+    )
+    assert resp.status_code == 401
+
+
+def test_finding_array_payload_is_ignored(client):
+    # semgrep_finding events are JSON arrays; only semgrep_scan objects handled.
+    body = json.dumps([{"check_id": "x"}]).encode()
+    resp = client.post(
+        "/webhooks/semgrep",
+        content=body,
+        headers={"X-Semgrep-Signature-256": _sig(body)},
+    )
+    assert resp.status_code == 200
+    assert resp.json().get("status") == "ignored"
+
+
+def test_scan_object_without_id_is_ignored(client):
+    body = json.dumps({"environment": "SCAN_ENVIRONMENT_MANAGED_SCANS"}).encode()
+    resp = client.post(
+        "/webhooks/semgrep",
+        content=body,
+        headers={"X-Semgrep-Signature-256": _sig(body)},
+    )
+    assert resp.status_code == 200
+    assert resp.json().get("status") == "ignored"
+
+
+def test_managed_row_for_classifies_via_scan_record(monkeypatch):
+    # A managed scan record -> a row; a non-managed one -> None (skipped here).
+    managed = {
+        "id": "500",
+        "environment": "SCAN_ENVIRONMENT_MANAGED_SCANS",
+        "isFullScan": True,
+        "branch": "main",
+        "commit": "abc",
+        "totalTime": 400.0,
+        "findingsCounts": {"total": "3"},
+        "cliVersion": "1.168.0",
+        "startedAt": None,
+        "completedAt": None,
+    }
+    monkeypatch.setattr(perf_webhook, "_managed_row_for", perf_webhook._managed_row_for)
+    from semgrep_scan import perf_harvest
+
+    monkeypatch.setattr(perf_harvest, "fetch_scan", lambda scan_id, token: managed)
+    row = perf_webhook._managed_row_for(500)
+    assert row is not None
+    assert row.environment == "managed-scans"
+    assert row.total_time == 400.0
+
+    monkeypatch.setattr(
+        perf_harvest,
+        "fetch_scan",
+        lambda scan_id, token: {
+            **managed,
+            "environment": "SCAN_ENVIRONMENT_UNSPECIFIED",
+        },
+    )
+    assert perf_webhook._managed_row_for(501) is None


### PR DESCRIPTION
Closes the findings-dependency gap in the scan-perf comparison.

## Problem
The perf harvest discovers a managed scan only by sweeping findings for its `first_seen_scan_id`. A managed scan with **no findings** (the common case) - or a re-scan surfacing nothing new - is therefore invisible, and its runtime can't be retrieved. There is no list-scans API to fall back on.

## Fix
Semgrep's native `semgrep_scan` webhook fires on **every scan completion, including no-findings scans**, and the payload carries the scan id. This adds a `/webhooks/semgrep` endpoint that captures each managed scan's runtime in near-real-time, findings-independent. The hourly harvest stays as the **backstop for missed deliveries**.

- Fail-closed HMAC verification of `X-Semgrep-Signature-256` (HMAC-SHA256 hex) with `SEMGREP_WEBHOOK_SECRET`; accepts a match against either the raw body or Semgrep's canonical compact re-serialization.
- Reuses the harvest's `fetch_scan` + `scan_to_row` + `upsert_scan_perf`; our own scans (env UNSPECIFIED) are skipped (report.py owns those).
- Mirrors the GitHub webhook infra: dedicated no-SecurityPolicy HTTPRoute, secret from the semgrep 1Password item as optional env.

## Manual steps after merge
1. Add `SEMGREP_WEBHOOK_SECRET` to the semgrep 1Password vault item.
2. Semgrep -> Settings -> Integrations -> Add -> Webhook: URL `https://private.jomcgi.dev/webhooks/semgrep`, signing secret = same value.
3. Cloudflare Access bypass for the `/webhooks/semgrep` path (already configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)