### PR TITLE
feat(chat): log lockout-suppressed ambient engages for /improve-ambient

### DIFF
--- a/.claude/skills/improve-ambient/scripts/improve_ambient_tool.py
+++ b/.claude/skills/improve-ambient/scripts/improve_ambient_tool.py
@@ -36,7 +36,9 @@ in-channel reply, disambiguating the silent paths that a null
 ``reply_message_id`` alone cannot. One of ``agent_thread`` (routed to the goose
 guest), ``no_reply`` (the model chose silence), ``send_gate`` (the
 post-generation gate vetoed the drafted reply), ``empty_reply`` (no content),
-or null when a reply was sent. Records from before the column existed are null
+``locked_out`` (the author is trust-locked-out, so a would-be engage was
+suppressed to a brig emoji; ADR chat/003), or null when a reply was sent.
+Records from before the column existed are null
 even when suppressed, so scope any rate over it to the current window.
 The agent-thread match is likewise a nearest-in-time heuristic
 (``_AGENT_WINDOW_MINUTES``): ``claude_agent.agent_threads`` carries no channel

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.65
+version: 0.89.66
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.65
+      targetRevision: 0.89.66
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.144
+version: 0.285.145
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/attention_log.py
+++ b/projects/monolith/chat/attention_log.py
@@ -95,6 +95,10 @@ WITHHELD_AGENT_THREAD = "agent_thread"
 WITHHELD_NO_REPLY = "no_reply"
 WITHHELD_SEND_GATE = "send_gate"
 WITHHELD_EMPTY_REPLY = "empty_reply"
+# The classifier would have engaged, but the author is trust-locked-out (ADR
+# chat/003): the engage was suppressed to a brig emoji, never sent. Logged so
+# /improve-ambient can measure how often lockout withholds reply-worthy ambient.
+WITHHELD_LOCKED_OUT = "locked_out"
 
 
 def set_withheld_reason(

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -949,6 +949,30 @@ class ChatBot(discord.Client):
                         recently_tagged=recently_tagged,
                     )
                     should_mark = result.engage
+                    # Log the classifier's call (mirrors the normal ambient
+                    # path, so ignore rows are sampled the same way). On an
+                    # engage, stamp withheld_reason=locked_out: without it a
+                    # suppressed engage is invisible to /improve-ambient, which
+                    # can then never see how often lockout blocks a reply-worthy
+                    # message.
+                    directive_version = await asyncio.to_thread(
+                        directives.get_active_version, channel_id
+                    )
+                    await asyncio.to_thread(
+                        attention_log.log_decision,
+                        channel_id,
+                        msg_id,
+                        "engage" if result.engage else "ignore",
+                        result.confidence,
+                        directive_version,
+                    )
+                    if result.engage:
+                        await asyncio.to_thread(
+                            attention_log.set_withheld_reason,
+                            channel_id,
+                            msg_id,
+                            attention_log.WITHHELD_LOCKED_OUT,
+                        )
                 except Exception:
                     logger.exception("safeguards: locked-out ambient classify failed")
             if should_mark:

--- a/projects/monolith/chat/bot_safeguards_test.py
+++ b/projects/monolith/chat/bot_safeguards_test.py
@@ -149,11 +149,16 @@ class TestLockoutEnforcement:
             patch("chat.bot.safeguards.log_enforcement", MagicMock()) as mock_log,
             patch("chat.bot.acl.ambient_channels", MagicMock(return_value={"99"})),
             patch("chat.bot.directives.get_active", MagicMock(return_value=None)),
+            patch("chat.bot.directives.get_active_version", MagicMock(return_value=3)),
             patch.object(bot, "_recently_tagged", MagicMock(return_value=False)),
             patch(
                 "chat.bot.attention.evaluate",
-                AsyncMock(return_value=MagicMock(engage=True)),
+                AsyncMock(return_value=MagicMock(engage=True, confidence=0.9)),
             ) as mock_eval,
+            patch("chat.bot.attention_log.log_decision", MagicMock()) as mock_decision,
+            patch(
+                "chat.bot.attention_log.set_withheld_reason", MagicMock()
+            ) as mock_withheld,
             patch.object(bot, "_process_message", AsyncMock()) as mock_proc,
         ):
             mock_session_cls.return_value.__enter__ = MagicMock(
@@ -167,6 +172,12 @@ class TestLockoutEnforcement:
         assert message.add_reaction.call_args.args[0] == "⚓"
         mock_log.assert_called_once()
         assert mock_log.call_args.args[1] is True  # reacted
+        # The classifier's engage is logged and stamped so /improve-ambient can
+        # see lockout suppressed a reply-worthy message.
+        mock_decision.assert_called_once()
+        assert mock_decision.call_args.args[2] == "engage"
+        mock_withheld.assert_called_once()
+        assert mock_withheld.call_args.args[2] == "locked_out"
         # Emoji only: no reply, no agent run.
         mock_proc.assert_not_called()
 
@@ -190,11 +201,16 @@ class TestLockoutEnforcement:
             patch("chat.bot.safeguards.log_enforcement", MagicMock()) as mock_log,
             patch("chat.bot.acl.ambient_channels", MagicMock(return_value={"99"})),
             patch("chat.bot.directives.get_active", MagicMock(return_value=None)),
+            patch("chat.bot.directives.get_active_version", MagicMock(return_value=3)),
             patch.object(bot, "_recently_tagged", MagicMock(return_value=False)),
             patch(
                 "chat.bot.attention.evaluate",
-                AsyncMock(return_value=MagicMock(engage=False)),
+                AsyncMock(return_value=MagicMock(engage=False, confidence=0.1)),
             ) as mock_eval,
+            patch("chat.bot.attention_log.log_decision", MagicMock()) as mock_decision,
+            patch(
+                "chat.bot.attention_log.set_withheld_reason", MagicMock()
+            ) as mock_withheld,
             patch.object(bot, "_process_message", AsyncMock()) as mock_proc,
         ):
             mock_session_cls.return_value.__enter__ = MagicMock(
@@ -207,6 +223,11 @@ class TestLockoutEnforcement:
         message.add_reaction.assert_not_called()
         mock_log.assert_not_called()
         mock_proc.assert_not_called()
+        # The ignore is still logged (mirrors the normal path), but nothing is
+        # stamped withheld: there was no engage to suppress.
+        mock_decision.assert_called_once()
+        assert mock_decision.call_args.args[2] == "ignore"
+        mock_withheld.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_reaction_failure_still_suppresses_reply(self):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.144
+      targetRevision: 0.285.145
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

Follow-up to #3419. When a trust-locked-out user posts an **ambient** message the attention classifier would have engaged, Bosun suppresses it to a brig emoji (⚓) and sends no reply. That suppressed engage was invisible to `/improve-ambient` (which reads `attention_decision` rows), so the loop could not measure how often lockout blocks a reply-worthy message, i.e. tell an over-aggressive threshold from a well-calibrated one.

## How

- New `WITHHELD_LOCKED_OUT = "locked_out"` constant in `attention_log`.
- The locked-out ambient path now logs the classifier's decision (`log_decision`, mirroring the normal path so `ignore` rows sample identically) and, on an `engage`, stamps `withheld_reason=locked_out`.
- **No migration**: `attention_decision.withheld_reason` is deliberately unconstrained (free-form TEXT), and `/improve-ambient` passes unknown reasons through untouched. Documented the new reason in the improve-ambient tool docstring.

## Tests

`bot_safeguards_test.py`:
- ambient would-engage -> logs `engage` + stamps `locked_out`, still emoji-only (no reply)
- ambient would-ignore -> logs `ignore`, nothing stamped withheld, stays silent

## Charts

Both `monolith` (0.285.145) and `monolith-public` (0.89.66) bumped, since the code change rebuilds the image both tiers pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)