### PR TITLE
fix(monolith): declutter /private/perf copy and fix low-contrast chrome

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.145
+version: 0.285.146
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.145
+      targetRevision: 0.285.146
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/private/+layout.svelte
@@ -37,9 +37,9 @@
 {@render children()}
 
 <style>
-  /* A subtle, borderless text link. Variables use fallbacks so it reads
-     correctly on both the dashboard theme (--ink-*, --font-ui, --accent) and
-     the older brutalist theme (--fg-*, --font) without a boxed look. */
+  /* A quiet pill. Variables use fallbacks so it reads correctly on both the
+     dashboard theme (--ink-*, --font-ui, --accent, --card-bg, --line) and the
+     older brutalist theme (--fg-*, --font). */
   .back-to-dashboard {
     position: fixed;
     top: 0.9rem;
@@ -49,21 +49,24 @@
     font-size: 12px;
     font-weight: 600;
     letter-spacing: 0.03em;
-    color: var(--ink-3, var(--fg-tertiary));
-    background: transparent;
-    border: none;
-    padding: 4px 2px;
+    color: var(--ink-2, var(--fg-secondary));
+    background: var(--card-bg, transparent);
+    border: 1px solid var(--line, var(--fg-tertiary));
+    border-radius: 999px;
+    padding: 4px 12px;
     text-decoration: none;
-    transition: color 0.15s ease;
+    transition:
+      color 0.15s ease,
+      border-color 0.15s ease;
   }
 
   .back-to-dashboard:hover {
     color: var(--accent, var(--fg));
+    border-color: var(--accent, var(--fg));
   }
 
   .back-to-dashboard:focus-visible {
     outline: 1.5px solid var(--accent, var(--fg));
     outline-offset: 2px;
-    border-radius: 4px;
   }
 </style>

--- a/projects/monolith/frontend/src/routes/private/perf/+page.server.js
+++ b/projects/monolith/frontend/src/routes/private/perf/+page.server.js
@@ -10,7 +10,6 @@ export async function load({ fetch }) {
         comparisons: [],
         aggregates: null,
         windowStart: null,
-        note: "",
         counts: null,
         error: res.status,
       };
@@ -20,7 +19,6 @@ export async function load({ fetch }) {
       comparisons: body.comparisons ?? [],
       aggregates: body.aggregates ?? null,
       windowStart: body.window_start ?? null,
-      note: body.coverage_note ?? "",
       counts: body.counts ?? null,
     };
   } catch (e) {
@@ -28,7 +26,6 @@ export async function load({ fetch }) {
       comparisons: [],
       aggregates: null,
       windowStart: null,
-      note: "",
       counts: null,
       error: "unavailable",
     };

--- a/projects/monolith/frontend/src/routes/private/perf/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/perf/+page.svelte
@@ -92,13 +92,13 @@
       <p class="masthead-lead">homelab (self-hosted) vs Semgrep managed scans</p>
       {#if data.counts}
         <p class="masthead-sub">
-          {data.counts.homelab ?? 0} homelab scans, {data.counts.managed ?? 0} managed
-          scans{#if data.windowStart}
-            &nbsp;in window since {formatDay(data.windowStart)}{/if}
+          <span class="mono">{data.counts.homelab ?? 0}</span> homelab
+          <span class="sub-sep">&middot;</span>
+          <span class="mono">{data.counts.managed ?? 0}</span> managed{#if data.windowStart}
+            <span class="sub-sep">&middot;</span> since {formatDay(
+              data.windowStart,
+            )}{/if}
         </p>
-      {/if}
-      {#if data.note}
-        <p class="masthead-note">{data.note}</p>
       {/if}
     </header>
 
@@ -107,11 +107,7 @@
     {:else if !windowOpen}
       <section class="card card--empty">
         <h2 class="section-label">Waiting for the first homelab scan</h2>
-        <p class="unavail">
-          The comparison window opens with the first homelab scan. Aggregates
-          and matched pairs appear as homelab and Semgrep managed scans run
-          against the same pull requests and commits.
-        </p>
+        <p class="unavail">Comparisons appear after the first homelab scan.</p>
       </section>
     {:else}
       <section class="agg-grid">
@@ -302,14 +298,12 @@
   .masthead-sub {
     margin: 8px 0 0;
     font-size: 13px;
-    color: var(--ink-3);
+    color: var(--ink-2);
   }
 
-  .masthead-note {
-    margin: 6px 0 0;
-    font-size: 12px;
+  .sub-sep {
     color: var(--ink-3);
-    max-width: 760px;
+    padding: 0 2px;
   }
 
   .card {
@@ -373,7 +367,7 @@
     font-size: 11px;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: var(--ink-3);
+    color: var(--ink-2);
   }
 
   .agg-median-value {
@@ -390,7 +384,7 @@
   .agg-foot {
     margin: 0;
     font-size: 12px;
-    color: var(--ink-3);
+    color: var(--ink-2);
   }
 
   .agg-empty {


### PR DESCRIPTION
Cleans up the /private/perf comparison page per feedback:

- Removes the coverage-note paragraph (wall of text) from the masthead and the dead `note` field from the server load
- Compresses the counts line to `11 homelab · 2 managed · since Jul 11`
- Trims the pre-window empty state to one sentence
- Raises subtext contrast (masthead sub, median labels, matched-pair count) from ink-3 to ink-2
- Restyles the shared private-tier back-to-dashboard link as a quiet pill (affects all private pages that show it)
- Chart bump 0.285.146

🤖 Generated with [Claude Code](https://claude.com/claude-code)