### PR TITLE
feat(monolith): add all-scan percentiles and findings parity to /private/perf

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.146
+version: 0.285.147
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.146
+      targetRevision: 0.285.147
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/private/+layout.svelte
@@ -1,4 +1,5 @@
 <script>
+  import "$lib/private/dashboard-theme.css";
   import { page } from "$app/stores";
 
   let { children } = $props();
@@ -31,42 +32,38 @@
 </script>
 
 {#if showBack}
-  <a class="back-to-dashboard" href="/">&larr; dashboard</a>
+  <a class="back-to-dashboard shell day" href="/">&larr; dashboard</a>
 {/if}
 
 {@render children()}
 
 <style>
-  /* A quiet pill. Variables use fallbacks so it reads correctly on both the
-     dashboard theme (--ink-*, --font-ui, --accent, --card-bg, --line) and the
-     older brutalist theme (--fg-*, --font). */
+  /* A quiet text link. This renders OUTSIDE any page's .shell, so it
+     carries "shell day" itself: dashboard-theme.css's .shell class only
+     defines custom properties, making the day palette resolve here without
+     inheriting any page styling. */
   .back-to-dashboard {
     position: fixed;
-    top: 0.9rem;
-    left: 1.1rem;
+    top: 1.1rem;
+    left: 1.2rem;
     z-index: 1000;
-    font-family: var(--font-ui, var(--font));
-    font-size: 12px;
-    font-weight: 600;
-    letter-spacing: 0.03em;
-    color: var(--ink-2, var(--fg-secondary));
-    background: var(--card-bg, transparent);
-    border: 1px solid var(--line, var(--fg-tertiary));
-    border-radius: 999px;
-    padding: 4px 12px;
+    font-family: var(--font-ui);
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    color: var(--ink-2);
     text-decoration: none;
-    transition:
-      color 0.15s ease,
-      border-color 0.15s ease;
+    padding: 4px 2px;
+    transition: color 0.15s ease;
   }
 
   .back-to-dashboard:hover {
-    color: var(--accent, var(--fg));
-    border-color: var(--accent, var(--fg));
+    color: var(--accent);
   }
 
   .back-to-dashboard:focus-visible {
-    outline: 1.5px solid var(--accent, var(--fg));
+    outline: 1.5px solid var(--accent);
     outline-offset: 2px;
+    border-radius: 4px;
   }
 </style>

--- a/projects/monolith/frontend/src/routes/private/perf/+page.server.js
+++ b/projects/monolith/frontend/src/routes/private/perf/+page.server.js
@@ -9,6 +9,7 @@ export async function load({ fetch }) {
       return {
         comparisons: [],
         aggregates: null,
+        distributions: null,
         windowStart: null,
         counts: null,
         error: res.status,
@@ -18,6 +19,7 @@ export async function load({ fetch }) {
     return {
       comparisons: body.comparisons ?? [],
       aggregates: body.aggregates ?? null,
+      distributions: body.distributions ?? null,
       windowStart: body.window_start ?? null,
       counts: body.counts ?? null,
     };
@@ -25,6 +27,7 @@ export async function load({ fetch }) {
     return {
       comparisons: [],
       aggregates: null,
+      distributions: null,
       windowStart: null,
       counts: null,
       error: "unavailable",

--- a/projects/monolith/frontend/src/routes/private/perf/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/perf/+page.svelte
@@ -140,10 +140,36 @@
                 </div>
               </div>
               <p class="agg-foot">
-                {agg.pairs} matched pair{agg.pairs === 1 ? "" : "s"}
+                {agg.pairs} matched pair{agg.pairs === 1 ? "" : "s"}{#if agg.findings_pairs > 0}
+                  <span class="sub-sep">&middot;</span> findings agree on {agg.findings_agree}/{agg.findings_pairs}{/if}
               </p>
             {:else}
               <p class="unavail agg-empty">No matched pairs yet</p>
+            {/if}
+            {#if data.distributions?.[bucket.key]}
+              {@const dist = data.distributions[bucket.key]}
+              <table class="dist">
+                <thead>
+                  <tr>
+                    <th class="dist-side">all scans</th>
+                    <th class="num">n</th>
+                    <th class="num">p50</th>
+                    <th class="num">p90</th>
+                    <th class="num">max</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {#each [["homelab", dist.homelab], ["managed", dist.managed]] as [side, d]}
+                    <tr>
+                      <td class="dist-side">{side}</td>
+                      <td class="num mono">{d.n}</td>
+                      <td class="num mono">{formatDuration(d.p50) ?? "-"}</td>
+                      <td class="num mono">{formatDuration(d.p90) ?? "-"}</td>
+                      <td class="num mono">{formatDuration(d.max) ?? "-"}</td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
             {/if}
           </div>
         {/each}
@@ -389,6 +415,32 @@
 
   .agg-empty {
     margin: 0;
+  }
+
+  /* Compact all-scans distribution table inside the aggregate cards. Cell
+     rules are scoped to beat the shared comparison-table selectors below. */
+  .dist {
+    width: auto;
+    margin-top: 4px;
+    border-top: 1px solid var(--line);
+  }
+
+  .dist thead th {
+    padding: 10px 14px 4px 0;
+    border-bottom: none;
+    letter-spacing: 0.1em;
+  }
+
+  .dist tbody td {
+    padding: 2px 14px 2px 0;
+    border-bottom: none;
+    white-space: nowrap;
+  }
+
+  .dist .dist-side {
+    text-align: left;
+    font-size: 12px;
+    color: var(--ink-2);
   }
 
   /* ── Collapsed detail ── */

--- a/projects/monolith/semgrep_scan/perf_compare.py
+++ b/projects/monolith/semgrep_scan/perf_compare.py
@@ -212,6 +212,21 @@ def _median(values: list[float]) -> float | None:
     return (ordered[mid - 1] + ordered[mid]) / 2
 
 
+def _percentile(values: list[float], q: float) -> float | None:
+    """Linear-interpolated percentile (q in [0, 1]), or None if empty."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    pos = q * (len(ordered) - 1)
+    lo = int(pos)
+    frac = pos - lo
+    if frac == 0:
+        return ordered[lo]
+    return ordered[lo] + (ordered[lo + 1] - ordered[lo]) * frac
+
+
 def build_aggregates(comparisons: list[dict]) -> dict:
     """Summarise matched comparisons into per-type aggregates.
 
@@ -219,8 +234,11 @@ def build_aggregates(comparisons: list[dict]) -> dict:
     is not a comparison. Buckets by scan type ("pr" vs "full") since PR and
     full-scan runtimes differ by an order of magnitude and must not be pooled.
     ``speedup`` is managed_median / homelab_median (greater than 1 means
-    homelab is faster). Returns a stable shape even for empty buckets so the
-    page can render placeholders.
+    homelab is faster). ``findings_pairs``/``findings_agree`` count pairs
+    where both sides reported a findings total, and how many of those totals
+    match exactly (a results-parity signal alongside the speed numbers).
+    Returns a stable shape even for empty buckets so the page can render
+    placeholders.
     """
     buckets: dict[str, list[dict]] = {"pr": [], "full": []}
     for row in comparisons:
@@ -235,6 +253,8 @@ def build_aggregates(comparisons: list[dict]) -> dict:
                 "homelab_median": None,
                 "managed_median": None,
                 "speedup": None,
+                "findings_pairs": 0,
+                "findings_agree": 0,
             }
             continue
         homelab_median = _median([p["route_b"]["total_time"] for p in pairs])
@@ -244,10 +264,47 @@ def build_aggregates(comparisons: list[dict]) -> dict:
             if homelab_median and homelab_median > 0
             else None
         )
+        findings_sides = [
+            (p["route_b"]["findings_total"], p["sms"]["findings_total"])
+            for p in pairs
+            if p["route_b"]["findings_total"] is not None
+            and p["sms"]["findings_total"] is not None
+        ]
         out[key] = {
             "pairs": len(pairs),
             "homelab_median": homelab_median,
             "managed_median": managed_median,
             "speedup": speedup,
+            "findings_pairs": len(findings_sides),
+            "findings_agree": sum(1 for rb, sms in findings_sides if rb == sms),
         }
+    return out
+
+
+def build_distributions(route_b: list[dict], sms: list[dict]) -> dict:
+    """Runtime distributions over ALL scans in the window, not just matched
+    pairs. Matched-pair medians answer "same work, who was faster"; these
+    answer "what does each side's runtime look like overall", which matters
+    while managed coverage is sparse (only scans that left an open finding
+    are visible via the Semgrep API, so most homelab scans have no pair).
+
+    Shape: {"pr"|"full": {"homelab"|"managed": {n, p50, p90, min, max}}}.
+    Rows without a total_time are excluded from n and the stats.
+    """
+    out: dict[str, dict] = {}
+    for bucket_key, is_full in (("pr", False), ("full", True)):
+        out[bucket_key] = {}
+        for side_key, rows in (("homelab", route_b), ("managed", sms)):
+            times = [
+                r["total_time"]
+                for r in rows
+                if bool(r["is_full_scan"]) == is_full and r["total_time"] is not None
+            ]
+            out[bucket_key][side_key] = {
+                "n": len(times),
+                "p50": _percentile(times, 0.5),
+                "p90": _percentile(times, 0.9),
+                "min": min(times) if times else None,
+                "max": max(times) if times else None,
+            }
     return out

--- a/projects/monolith/semgrep_scan/perf_compare_test.py
+++ b/projects/monolith/semgrep_scan/perf_compare_test.py
@@ -10,7 +10,11 @@ import datetime
 
 import pytest
 
-from semgrep_scan.perf_compare import build_aggregates, build_comparisons
+from semgrep_scan.perf_compare import (
+    build_aggregates,
+    build_comparisons,
+    build_distributions,
+)
 
 UTC = datetime.timezone.utc
 
@@ -335,6 +339,8 @@ def test_aggregates_empty_input_has_stable_shape():
             "homelab_median": None,
             "managed_median": None,
             "speedup": None,
+            "findings_pairs": 0,
+            "findings_agree": 0,
         }
 
 
@@ -342,3 +348,76 @@ def test_aggregates_speedup_guards_zero_homelab_time():
     agg = build_aggregates([_pair(False, 0.0, 30.0)])
     assert agg["pr"]["pairs"] == 1
     assert agg["pr"]["speedup"] is None
+
+
+def test_aggregates_findings_parity():
+    agree = _pair(False, 10.0, 30.0)
+    agree["route_b"]["findings_total"] = 7
+    agree["sms"]["findings_total"] = 7
+    disagree = _pair(False, 10.0, 30.0)
+    disagree["route_b"]["findings_total"] = 7
+    disagree["sms"]["findings_total"] = 9
+    unknown = _pair(False, 10.0, 30.0)
+    unknown["route_b"]["findings_total"] = None
+
+    agg = build_aggregates([agree, disagree, unknown])
+
+    assert agg["pr"]["pairs"] == 3
+    # the pair with a None findings side does not count toward parity
+    assert agg["pr"]["findings_pairs"] == 2
+    assert agg["pr"]["findings_agree"] == 1
+
+
+# ── build_distributions ──────────────────────────
+
+
+def test_distributions_bucket_by_type_and_side():
+    homelab = [
+        _row(1, total_time=1.0),
+        _row(2, total_time=2.0),
+        _row(3, total_time=3.0),
+        _row(4, is_full_scan=True, total_time=300.0),
+    ]
+    managed = [_row(5, total_time=40.0), _row(6, total_time=60.0)]
+
+    dist = build_distributions(homelab, managed)
+
+    assert dist["pr"]["homelab"]["n"] == 3
+    assert dist["pr"]["homelab"]["p50"] == 2.0
+    assert dist["pr"]["homelab"]["min"] == 1.0
+    assert dist["pr"]["homelab"]["max"] == 3.0
+    # p90 over [1,2,3]: linear interpolation at pos 1.8 -> 2.8
+    assert dist["pr"]["homelab"]["p90"] == pytest.approx(2.8)
+    assert dist["pr"]["managed"]["n"] == 2
+    assert dist["pr"]["managed"]["p50"] == 50.0
+    assert dist["full"]["homelab"]["n"] == 1
+    assert dist["full"]["homelab"]["p50"] == 300.0
+    assert dist["full"]["managed"] == {
+        "n": 0,
+        "p50": None,
+        "p90": None,
+        "min": None,
+        "max": None,
+    }
+
+
+def test_distributions_skip_rows_without_total_time():
+    homelab = [_row(1, total_time=None), _row(2, total_time=5.0)]
+
+    dist = build_distributions(homelab, [])
+
+    assert dist["pr"]["homelab"]["n"] == 1
+    assert dist["pr"]["homelab"]["p50"] == 5.0
+
+
+def test_distributions_empty_input_has_stable_shape():
+    dist = build_distributions([], [])
+    for bucket in ("pr", "full"):
+        for side in ("homelab", "managed"):
+            assert dist[bucket][side] == {
+                "n": 0,
+                "p50": None,
+                "p90": None,
+                "min": None,
+                "max": None,
+            }

--- a/projects/monolith/semgrep_scan/perf_router.py
+++ b/projects/monolith/semgrep_scan/perf_router.py
@@ -13,7 +13,11 @@ from sqlalchemy import func
 from sqlmodel import Session, select
 
 from app.db import get_session
-from semgrep_scan.perf_compare import build_aggregates, build_comparisons
+from semgrep_scan.perf_compare import (
+    build_aggregates,
+    build_comparisons,
+    build_distributions,
+)
 from semgrep_scan.perf_store import ScanPerf
 
 _COVERAGE_NOTE = (
@@ -43,6 +47,7 @@ def _empty_response() -> dict:
     return {
         "comparisons": [],
         "aggregates": build_aggregates([]),
+        "distributions": build_distributions([], []),
         "window_start": None,
         "counts": {"homelab": 0, "managed": 0},
         "coverage_note": _COVERAGE_NOTE,
@@ -81,6 +86,7 @@ async def get_perf(
     return {
         "comparisons": comparisons,
         "aggregates": build_aggregates(comparisons),
+        "distributions": build_distributions(homelab, managed),
         "window_start": window_start,
         "counts": {"homelab": len(homelab), "managed": len(managed)},
         "coverage_note": _COVERAGE_NOTE,


### PR DESCRIPTION
Follow-up to #3423:

- **Percentiles over all scans**: new `build_distributions` aggregates n / p50 / p90 / min / max of `total_time` over every scan in the window (not just matched pairs), per bucket (PR / full) per side (homelab / managed). Rendered as a compact table in each aggregate card, so the unmatched homelab scans now contribute data.
- **Findings parity**: `build_aggregates` now reports `findings_pairs` / `findings_agree` (pairs where both sides reported findings totals, and how many match exactly). Rendered as "findings agree on N/M" next to the pair count.
- **Back-to-dashboard link fix**: the link renders outside any page's `.shell`, so the dashboard theme variables never resolved and it fell back to the global mono font (the source of the odd look). The link now carries `shell day` itself (that class only defines custom properties), so it renders in the proper UI typeface and palette.
- Tests for the new aggregation functions; chart bump 0.285.147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)