### PR TITLE
test: verify semgrep webhook capture (do not merge)

### DIFF
--- a/projects/monolith/semgrep_scan/perf_webhook.py
+++ b/projects/monolith/semgrep_scan/perf_webhook.py
@@ -132,3 +132,6 @@ async def semgrep_scan_webhook(
         return {"status": "ignored", "reason": "no scan id"}
     background_tasks.add_task(_capture_scan, scan_id)
     return {"status": "accepted", "scan_id": scan_id}
+
+
+# webhook live-check: temporary no-op comment to trigger a scan (PR will be closed)


### PR DESCRIPTION
Temporary PR: triggers a real Semgrep managed scan (and our homelab scan) so we can confirm the /webhooks/semgrep endpoint captures the managed scan runtime end-to-end. Will be closed without merging.