### PR TITLE
feat(bump-chart): bump monolith-public together with monolith

### DIFF
--- a/bazel/tools/git/bump-chart.sh
+++ b/bazel/tools/git/bump-chart.sh
@@ -31,6 +31,11 @@ set -euo pipefail
 
 REPOSITORY="${BUMP_CHART_REPOSITORY:-oci://ghcr.io/jomcgi/homelab/charts}"
 
+# Absolute path to this script, resolved BEFORE any cd, so the coupled-chart
+# self-invocation at the end works regardless of the caller's CWD.
+SELF="$0"
+[[ "$SELF" = /* ]] || SELF="$(pwd)/$SELF"
+
 usage() {
 	grep '^#' "$0" | sed 's/^# \{0,1\}//' | sed -n '2,20p' >&2
 	exit 1
@@ -228,3 +233,33 @@ echo "Bumped ${CHART_NAME}: ${LOCAL_VERSION} -> ${NEW_VERSION} (base ${BASE_VERS
 echo "  ${CHART_YAML}"
 echo "  ${APP_YAML}"
 echo "Commit with: git commit -m \"chore(${CHART_NAME}): bump chart to ${NEW_VERSION}\""
+
+# --- Coupled charts --------------------------------------------------------
+# Some charts pin the SAME image and MUST bump together: monolith-public serves
+# from monolith's backend image, so a monolith change that rebuilds the image
+# also drifts monolith-public's pinned digest. Bumping monolith alone passes
+# local checks but fails the Push images guard on the public tier's stale pin (a
+# wasted CI round-trip). Bump the coupled tier(s) too, each via a fresh
+# self-invocation so it computes its OWN version base and runs its OWN
+# registry/PR checks. BUMP_CHART_NO_COUPLING stops the child from recursing.
+coupled_projects() {
+	# Keyed on the bumped chart's `name:`. Tests inject a coupling for a fake
+	# chart via BUMP_CHART_COUPLED_<name> (hyphens in <name> become underscores).
+	local name="$1" override_var="BUMP_CHART_COUPLED_${1//-/_}"
+	if [[ -n "${!override_var:-}" ]]; then
+		printf '%s\n' "${!override_var}"
+		return
+	fi
+	case "$name" in
+	monolith) echo "projects/monolith-public" ;;
+	esac
+}
+
+if [[ "${BUMP_CHART_NO_COUPLING:-}" != "1" ]]; then
+	while IFS= read -r coupled; do
+		[[ -n "$coupled" ]] || continue
+		echo ""
+		echo "Coupling: ${coupled} shares ${CHART_NAME}'s image; bumping it too."
+		BUMP_CHART_NO_COUPLING=1 bash "$SELF" "$coupled"
+	done < <(coupled_projects "$CHART_NAME")
+fi

--- a/bazel/tools/git/bump-chart_test.sh
+++ b/bazel/tools/git/bump-chart_test.sh
@@ -176,6 +176,64 @@ set -e
 assert_eq "t8 exit code" 0 "$rc"
 assert_eq "t8 ignores equal/older claim" 0.1.1 "$(chart_version "$ROOT")"
 
+# --- Test 9: a coupled chart is bumped alongside the primary ----------------
+# monolith and monolith-public pin the same image, so bumping one must bump the
+# other. Modeled here with foo coupled to a second chart (bar) via the
+# BUMP_CHART_COUPLED_foo test hook. Both must land a fresh patch bump.
+ROOT="$TMP/t9"
+setup_project "$ROOT" 0.1.0 0.1.0
+mkdir -p "$ROOT/projects/bar/chart" "$ROOT/projects/bar/deploy"
+cat >"$ROOT/projects/bar/chart/Chart.yaml" <<-EOF
+	apiVersion: v2
+	name: bar
+	version: 0.1.0
+EOF
+cat >"$ROOT/projects/bar/deploy/application.yaml" <<-EOF
+	apiVersion: argoproj.io/v1alpha1
+	kind: Application
+	spec:
+	  sources:
+	    - repoURL: ghcr.io/jomcgi/homelab/charts
+	      chart: bar
+	      targetRevision: 0.1.0
+	    - repoURL: https://github.com/jomcgi/homelab
+	      targetRevision: HEAD
+	      ref: values
+EOF
+set +e
+BUMP_CHART_REPO_ROOT="$ROOT" \
+	BUMP_CHART_SKIP_REGISTRY_CHECK=1 \
+	BUMP_CHART_SKIP_PR_CHECK=1 \
+	BUMP_CHART_MAIN_VERSION=0.1.0 \
+	BUMP_CHART_COUPLED_foo="projects/bar" \
+	bash "$SCRIPT" projects/foo >"$TMP/out" 2>&1
+rc=$?
+set -e
+bar_version() { grep '^version:' "$ROOT/projects/bar/chart/Chart.yaml" | awk '{print $2}'; }
+bar_tr() { grep -E 'targetRevision: [0-9]' "$ROOT/projects/bar/deploy/application.yaml" | awk '{print $2}'; }
+assert_eq "t9 exit code" 0 "$rc"
+assert_eq "t9 primary (foo) bumped" 0.1.1 "$(chart_version "$ROOT")"
+assert_eq "t9 coupled (bar) chart bumped" 0.1.1 "$(bar_version)"
+assert_eq "t9 coupled (bar) targetRevision bumped" 0.1.1 "$(bar_tr)"
+grep -q "Coupling: projects/bar" "$TMP/out" || {
+	echo "FAIL: t9 expected coupling message" >&2
+	FAILURES=$((FAILURES + 1))
+}
+
+# --- Test 10: an uncoupled chart bumps only itself (no recursion/leakage) ---
+# Without a coupling entry the script must bump exactly one chart, and must not
+# emit a coupling line. Guards against the coupling firing for the wrong chart.
+ROOT="$TMP/t10"
+setup_project "$ROOT" 0.1.0 0.1.0
+MAIN_VERSION_OVERRIDE=0.1.0
+rc=$(run_bump "$ROOT")
+assert_eq "t10 exit code" 0 "$rc"
+assert_eq "t10 chart bumped" 0.1.1 "$(chart_version "$ROOT")"
+if grep -q "Coupling:" "$TMP/out"; then
+	echo "FAIL: t10 uncoupled chart must not emit a coupling line" >&2
+	FAILURES=$((FAILURES + 1))
+fi
+
 if [[ "$FAILURES" -gt 0 ]]; then
 	echo "${FAILURES} test(s) failed" >&2
 	exit 1


### PR DESCRIPTION
## What

`bump-chart.sh projects/monolith` now also bumps `projects/monolith-public`, because the two charts pin the **same backend image**. A monolith code change rebuilds that image, drifting monolith-public's pinned digest; bumping only monolith passes local checks but fails the `Push images` guard on the public tier's stale pin (a wasted CI round-trip the author had to diagnose and fix by hand, e.g. #3419).

## How

- After the primary bump, the script reads a coupling map (keyed on chart `name:`) and, for each coupled project, runs a **fresh self-invocation** (`BUMP_CHART_NO_COUPLING=1 bash "$SELF" <project>`). The coupled bump therefore computes its **own** version base from `origin/main` and runs its **own** registry + open-PR collision checks - it is a full independent bump, not a copied version number.
- Coupling is testable: `BUMP_CHART_COUPLED_<name>` injects a coupling for a fake chart. `BUMP_CHART_NO_COUPLING` stops the child from recursing.
- Currently one entry: `monolith -> projects/monolith-public`.

## Why not a CI check instead

Investigated that first. The `Push images` guard already reports *all* drifted charts in one run (multirun `jobs=0` runs every command to completion), so aggregation there was redundant. The actual recurring mistake is forgetting the second bump at authoring time - fixing it in the tool is local, verifiable, and prevents the CI round-trip entirely.

## Tests

`bump-chart_test.sh`:
- t9: coupled chart (bar) is bumped alongside the primary (foo), Chart.yaml + targetRevision
- t10: an uncoupled chart bumps only itself, no coupling line emitted

Verified locally (all 10 pass) and end-to-end against the real `monolith` chart (bumped both monolith and monolith-public from their separate origin/main bases), reverted.

Tooling-only change; no chart deploys, so no chart bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)