### PR TITLE
fix(monolith): semgrep webhook capture logging + inbound observability

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.66
+version: 0.89.68
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.66
+      targetRevision: 0.89.68
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.147
+version: 0.285.149
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.147
+      targetRevision: 0.285.149
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/semgrep_scan/perf_webhook.py
+++ b/projects/monolith/semgrep_scan/perf_webhook.py
@@ -61,7 +61,14 @@ def _verify_signature(body: bytes, signature_header: str | None) -> None:
 
 
 def _extract_scan_id(payload: dict) -> int | None:
+    # The semgrep_scan object carries the scan id as "id", but tolerate a few
+    # likely shapes (a "scan_id" alias, or a nested "scan": {"id": ...}) so a
+    # minor payload-shape difference does not silently drop the capture.
     raw = payload.get("id")
+    if raw is None:
+        raw = payload.get("scan_id")
+    if raw is None and isinstance(payload.get("scan"), dict):
+        raw = payload["scan"].get("id")
     try:
         return int(raw) if raw is not None else None
     except (ValueError, TypeError):
@@ -95,13 +102,18 @@ def _capture_scan(scan_id: int) -> None:
                 "semgrep scan webhook: scan %s not a managed scan, skipped", scan_id
             )
             return
+        # Read the values before the session closes: SQLAlchemy expires ORM
+        # attributes on commit, so accessing row.total_time after the `with`
+        # block would lazy-reload against a closed session and raise.
+        total_time = row.total_time
+        findings_total = row.findings_total
         with Session(get_engine()) as session:
             upsert_scan_perf(session, row)
         logger.info(
             "semgrep scan webhook: captured managed scan %s (%.1fs, %d findings)",
             scan_id,
-            row.total_time,
-            row.findings_total,
+            total_time,
+            findings_total,
         )
     except Exception:
         logger.exception("semgrep scan webhook: failed to capture scan %s", scan_id)
@@ -120,14 +132,37 @@ async def semgrep_scan_webhook(
     ``semgrep_finding`` events (JSON arrays) are acknowledged and ignored.
     """
     body = await request.body()
+    client_ip = request.headers.get("cf-connecting-ip") or (
+        request.client.host if request.client else "?"
+    )
+    # Observability: log every inbound delivery before verification so a real
+    # Semgrep scan webhook is visible even if it later 401s or is ignored (a
+    # 401 otherwise leaves no trace). Cheap: webhooks are low-frequency.
+    logger.info(
+        "semgrep webhook inbound: ip=%s bytes=%d has_sig=%s",
+        client_ip,
+        len(body),
+        bool(x_semgrep_signature_256),
+    )
     _verify_signature(body, x_semgrep_signature_256)
     try:
         payload = json.loads(body)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail="invalid json") from exc
     if not isinstance(payload, dict):
+        logger.info(
+            "semgrep webhook: non-dict payload (type=%s), ignored",
+            type(payload).__name__,
+        )
         return {"status": "ignored", "reason": "not a semgrep_scan object"}
     scan_id = _extract_scan_id(payload)
+    # Log the payload keys (not values) so we can see the real semgrep_scan
+    # shape and confirm which key carries the scan id.
+    logger.info(
+        "semgrep webhook payload: keys=%s scan_id=%s",
+        sorted(payload.keys()),
+        scan_id,
+    )
     if scan_id is None:
         return {"status": "ignored", "reason": "no scan id"}
     background_tasks.add_task(_capture_scan, scan_id)

--- a/projects/monolith/semgrep_scan/perf_webhook_test.py
+++ b/projects/monolith/semgrep_scan/perf_webhook_test.py
@@ -146,3 +146,12 @@ def test_managed_row_for_classifies_via_scan_record(monkeypatch):
         },
     )
     assert perf_webhook._managed_row_for(501) is None
+
+
+def test_extract_scan_id_tolerates_alias_and_nested_shapes():
+    from semgrep_scan.perf_webhook import _extract_scan_id
+
+    assert _extract_scan_id({"id": 5}) == 5
+    assert _extract_scan_id({"scan_id": "6"}) == 6
+    assert _extract_scan_id({"scan": {"id": 7}}) == 7
+    assert _extract_scan_id({"environment": "x"}) is None


### PR DESCRIPTION
Follow-up to #3421 (the Semgrep scan webhook).

## What / why
Verified the capture path live: a real managed PR scan (0 findings, invisible to the harvest) was captured by manually POSTing a signed webhook, producing a matched pair. But two issues surfaced:

1. **Logging bug** — `_capture_scan` read `row.total_time` *after* the session closed. SQLAlchemy expires ORM attributes on commit, so the success log lazy-reloaded against a closed session and raised. The row was written, but it logged a spurious "failed to capture". Fixed by reading the values before the `with Session` block.
2. **No visibility into real deliveries** — a 401 (or ignored) webhook leaves no log, so we couldn't tell "not arriving" from "arriving but ignored/rejected". Added an inbound log (source ip, bytes, has_sig) before verification, plus a payload-keys log after parse. This will show exactly what Semgrep sends for a real scan-completion event (the current open question: whether Semgrep delivers a `semgrep_scan` webhook for a 0-finding scan, and its payload shape).
3. **Hardened scan-id extraction** to tolerate a `scan_id` alias or nested `scan.id`.

Webhooks are low-frequency, so the added INFO logging is cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)