### PR TITLE
test: observe semgrep_scan webhook (do not merge)

### DIFF
--- a/projects/monolith/semgrep_scan/perf_webhook.py
+++ b/projects/monolith/semgrep_scan/perf_webhook.py
@@ -222,3 +222,4 @@ async def semgrep_scan_webhook(
 # live-check 2: trigger a managed scan to observe the semgrep_scan webhook (PR closed after)
 # live-check 3: verify unsigned semgrep_scan webhook capture
 # live-check 4: full unsigned webhook capture
+# live-check 5: verify real runtime capture

--- a/projects/monolith/semgrep_scan/perf_webhook.py
+++ b/projects/monolith/semgrep_scan/perf_webhook.py
@@ -221,3 +221,4 @@ async def semgrep_scan_webhook(
 
 # live-check 2: trigger a managed scan to observe the semgrep_scan webhook (PR closed after)
 # live-check 3: verify unsigned semgrep_scan webhook capture
+# live-check 4: full unsigned webhook capture

--- a/projects/monolith/semgrep_scan/perf_webhook.py
+++ b/projects/monolith/semgrep_scan/perf_webhook.py
@@ -217,3 +217,6 @@ async def semgrep_scan_webhook(
         return {"status": "ignored", "reason": "no scan id"}
     background_tasks.add_task(_capture_scan, scan_id)
     return {"status": "accepted", "scan_id": scan_id}
+
+
+# live-check 2: trigger a managed scan to observe the semgrep_scan webhook (PR closed after)

--- a/projects/monolith/semgrep_scan/perf_webhook.py
+++ b/projects/monolith/semgrep_scan/perf_webhook.py
@@ -220,3 +220,4 @@ async def semgrep_scan_webhook(
 
 
 # live-check 2: trigger a managed scan to observe the semgrep_scan webhook (PR closed after)
+# live-check 3: verify unsigned semgrep_scan webhook capture


### PR DESCRIPTION
Temporary: triggers a real managed scan so we can see whether Semgrep fires a semgrep_scan webhook on completion (the new inbound logging will show it). Closed after.