### PR TITLE
fix(monolith): capture unsigned semgrep_scan webhooks (real scan runtimes)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.69
+version: 0.89.70
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.69
+      targetRevision: 0.89.70
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.150
+version: 0.285.151
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.150
+      targetRevision: 0.285.151
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/semgrep_scan/perf_webhook.py
+++ b/projects/monolith/semgrep_scan/perf_webhook.py
@@ -8,13 +8,18 @@ This webhook captures every managed scan's runtime for the perf comparison in
 near-real-time, findings-independent. The hourly harvest stays as a backstop
 for any delivery this misses.
 
-AUTH (fail-closed): Semgrep signs with ``SEMGREP_WEBHOOK_SECRET`` and sends
-``X-Semgrep-Signature-256: <hex>`` (HMAC-SHA256, hex, no prefix). Semgrep's docs
-compute the digest over the canonical ``json.dumps(payload, separators=(",",
-":"))`` rather than necessarily the exact bytes on the wire, so we accept a
-match against EITHER the raw body OR that canonical re-serialization. Both
-require the shared secret, so accepting either is safe and it removes a whole
-class of whitespace-mismatch silent-401s. An unset secret denies every request.
+AUTH (fail-closed, defense-in-depth): Semgrep signs ``semgrep_finding`` events
+with ``SEMGREP_WEBHOOK_SECRET`` (``X-Semgrep-Signature-256: <hex>``, HMAC-SHA256)
+but delivers ``semgrep_scan`` (scan-completion) events UNSIGNED. So:
+  - Signed request -> HMAC-verify (match against the raw body OR Semgrep's
+    canonical compact re-serialization; both need the secret).
+  - Unsigned request -> accept ONLY from Semgrep's egress IPs (CF-Connecting-IP,
+    set by Cloudflare and not client-spoofable since the origin is reachable only
+    via the CF tunnel), then rely on the API fetch in _capture_scan to verify the
+    scan is real. The webhook payload data is never trusted; we use it only for
+    the scan id and re-fetch the authoritative record.
+This captures the unsigned scan events (the ones carrying runtime) while never
+accepting an unverifiable, un-sourced request.
 
 The path ``/webhooks/semgrep`` is reachable through the private ingress via a
 Cloudflare Access IP-Bypass for Semgrep's egress IPs (Semgrep sends no Access
@@ -34,6 +39,23 @@ from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request
 logger = logging.getLogger("monolith.semgrep.perf_webhook")
 
 router = APIRouter(prefix="/webhooks/semgrep", tags=["semgrep-scan-webhook"])
+
+# Semgrep's documented egress IPs (observed as the webhook source: 52.34.137.110
+# and 52.35.248.246). Semgrep signs semgrep_finding events but delivers
+# semgrep_scan (scan completion) events UNSIGNED, so we cannot HMAC-verify those.
+# We instead accept an unsigned request only from these source IPs. CF-Connecting-IP
+# is set by Cloudflare and is not client-spoofable (the origin has no direct
+# internet exposure, only the CF tunnel reaches it), so it is a trustworthy gate.
+# The scan is then further verified by fetching its authoritative record from the
+# Semgrep API in _capture_scan (the webhook payload data is never trusted).
+_SEMGREP_WEBHOOK_IPS = frozenset(
+    {
+        "35.166.231.235",
+        "52.35.248.246",
+        "52.34.137.110",
+        "44.225.64.41",
+    }
+)
 
 
 def _verify_signature(body: bytes, signature_header: str | None) -> None:
@@ -144,7 +166,17 @@ async def semgrep_scan_webhook(
         len(body),
         bool(x_semgrep_signature_256),
     )
-    _verify_signature(body, x_semgrep_signature_256)
+    # Auth: a signed request (semgrep_finding events) is HMAC-verified. An
+    # unsigned request (semgrep_scan / scan-completion events, which Semgrep
+    # delivers without a signature) is accepted only from Semgrep's egress IPs;
+    # _capture_scan then fetch-verifies the scan against the Semgrep API, so the
+    # payload data is never trusted. Anything else is rejected (fail-closed).
+    if x_semgrep_signature_256:
+        _verify_signature(body, x_semgrep_signature_256)
+    elif client_ip not in _SEMGREP_WEBHOOK_IPS:
+        raise HTTPException(
+            status_code=401, detail="unsigned request from unrecognized source"
+        )
     try:
         payload = json.loads(body)
     except ValueError as exc:

--- a/projects/monolith/semgrep_scan/perf_webhook_test.py
+++ b/projects/monolith/semgrep_scan/perf_webhook_test.py
@@ -155,3 +155,40 @@ def test_extract_scan_id_tolerates_alias_and_nested_shapes():
     assert _extract_scan_id({"scan_id": "6"}) == 6
     assert _extract_scan_id({"scan": {"id": 7}}) == 7
     assert _extract_scan_id({"environment": "x"}) is None
+
+
+def test_unsigned_from_semgrep_ip_is_accepted(client):
+    # semgrep_scan (scan-completion) events arrive unsigned; accepted from a
+    # Semgrep egress IP (CF-Connecting-IP), then fetch-verified downstream.
+    body = json.dumps({"id": 42}).encode()
+    resp = client.post(
+        "/webhooks/semgrep",
+        content=body,
+        headers={"CF-Connecting-IP": "52.34.137.110"},
+    )
+    assert resp.status_code == 200
+    assert resp.json().get("scan_id") == 42
+
+
+def test_unsigned_from_unknown_ip_is_401(client):
+    body = json.dumps({"id": 42}).encode()
+    resp = client.post(
+        "/webhooks/semgrep",
+        content=body,
+        headers={"CF-Connecting-IP": "203.0.113.9"},
+    )
+    assert resp.status_code == 401
+
+
+def test_bad_signature_still_rejected_even_from_semgrep_ip(client):
+    # A present-but-wrong signature is rejected regardless of source IP.
+    body = json.dumps({"id": 42}).encode()
+    resp = client.post(
+        "/webhooks/semgrep",
+        content=body,
+        headers={
+            "X-Semgrep-Signature-256": "deadbeef",
+            "CF-Connecting-IP": "52.34.137.110",
+        },
+    )
+    assert resp.status_code == 401


### PR DESCRIPTION
The root cause the debug build surfaced: Semgrep signs `semgrep_finding` events but delivers `semgrep_scan` (scan-completion) events **unsigned** — confirmed live:
```
semgrep webhook inbound: ip=52.35.248.246 bytes=3077 has_sig=False
```
The fail-closed handler was 401ing every real scan webhook, so runtimes were never captured (only the signed Test event reached us, and it's a findings-array sample the handler correctly ignores).

## Fix (defense-in-depth, no weak spot)
- **Signed** request → HMAC-verify (unchanged; protects findings events).
- **Unsigned** request → accept **only** from Semgrep's egress IPs via `CF-Connecting-IP` (Cloudflare-set, not client-spoofable since the origin has no direct exposure), then `_capture_scan` **fetch-verifies** the scan against the Semgrep API. The payload data is never trusted — the webhook only supplies a scan_id we re-fetch.
- Three independent layers: CF tunnel + source-IP allowlist + API fetch-verification.

## Follow-up note
`CF-Connecting-IP` is trustworthy only because ingress is CF-tunnel-only. The observed Semgrep source IPs (52.34.137.110, 52.35.248.246) are in the documented egress set. You can optionally re-tighten the Cloudflare Access bypass from `Everyone` back to those four IPs now that we've confirmed them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)