### PR TITLE
fix(monolith): unwrap semgrep_scan envelope in webhook

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.70
+version: 0.89.71
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.70
+      targetRevision: 0.89.71
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.151
+version: 0.285.152
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.151
+      targetRevision: 0.285.152
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/semgrep_scan/perf_webhook.py
+++ b/projects/monolith/semgrep_scan/perf_webhook.py
@@ -83,9 +83,12 @@ def _verify_signature(body: bytes, signature_header: str | None) -> None:
 
 
 def _extract_scan_id(payload: dict) -> int | None:
-    # The semgrep_scan object carries the scan id as "id", but tolerate a few
-    # likely shapes (a "scan_id" alias, or a nested "scan": {"id": ...}) so a
-    # minor payload-shape difference does not silently drop the capture.
+    # Semgrep delivers the scan event wrapped in an envelope:
+    # {"semgrep_scan": {"id": ..., ...}} (confirmed live). Unwrap it, then read
+    # the id, tolerating a "scan_id" alias or a nested "scan": {"id": ...} too so
+    # a minor shape change does not silently drop the capture.
+    if isinstance(payload.get("semgrep_scan"), dict):
+        payload = payload["semgrep_scan"]
     raw = payload.get("id")
     if raw is None:
         raw = payload.get("scan_id")

--- a/projects/monolith/semgrep_scan/perf_webhook_test.py
+++ b/projects/monolith/semgrep_scan/perf_webhook_test.py
@@ -192,3 +192,13 @@ def test_bad_signature_still_rejected_even_from_semgrep_ip(client):
         },
     )
     assert resp.status_code == 401
+
+
+def test_extract_scan_id_unwraps_semgrep_scan_envelope():
+    from semgrep_scan.perf_webhook import _extract_scan_id
+
+    # The real delivered shape: {"semgrep_scan": {"id": ...}}
+    assert _extract_scan_id({"semgrep_scan": {"id": 193379272}}) == 193379272
+    assert _extract_scan_id({"semgrep_scan": {"scan_id": "77"}}) == 77
+    # top-level id still works
+    assert _extract_scan_id({"id": 5}) == 5


### PR DESCRIPTION
The last piece of the webhook chain. Confirmed live that Semgrep delivers scan-completion webhooks as an envelope `{"semgrep_scan": {...id...}}`, not the scan fields at top level, so `_extract_scan_id` returned None and the capture was dropped. Unwraps the `semgrep_scan` key before reading the id.

With this, the full findings-independent path works: unsigned scan webhook from a Semgrep IP -> accepted -> envelope unwrapped -> scan_id -> fetch-verified -> managed row captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)