### PR TITLE
chore(semgrep): ignore rule self-test fixtures and vendored OCaml in scans

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -14,3 +14,14 @@ projects/monolith/frontend/src/lib/public/docs/docs-manifest.json
 # not our source to lint, and their upstream copyright notices must stay verbatim
 # (the stale-copyright-year rule false-positives on them).
 projects/firecracker/goosecracker/guest/vendor/impeccable/
+
+# Our own Semgrep rule definitions and their test fixtures: these files
+# intentionally contain the patterns the rules match (eval/exec, raw SQL,
+# subprocess, etc.) as match targets, so the Pro registry rules false-positive
+# on them. The rules are validated by main_semgrep_test, not by scanning them.
+bazel/semgrep/rules/
+bazel/semgrep/tests/
+
+# Vendored OCaml sources (semgrep_src overlay): upstream third-party code, not
+# ours to lint; the OCaml portability rules flag its CRLF/line-reading style.
+bazel/ocaml/semgrep_src/


### PR DESCRIPTION
Adds `.semgrepignore` entries so future Semgrep scans stop re-flagging files that can only ever be false positives:

- `bazel/semgrep/rules/` + `bazel/semgrep/tests/` — our own rule definitions and their fixtures intentionally contain the very patterns the rules match (eval/exec, raw SQL, subprocess). They are validated by `main_semgrep_test`, not by being scanned.
- `bazel/ocaml/semgrep_src/` — vendored third-party OCaml; the OCaml portability rules flag its line-reading style.

The current finding instances were already triaged to ignored via the Semgrep API; this prevents newly-added fixtures from reintroducing the same noise. Config-only, no chart bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)