### PR TITLE
fix(monolith): retry fetch until totalTime populates (webhook race)

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.71
+version: 0.4.72

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.71
+      targetRevision: 0.4.72
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.71
+version: 0.89.73
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.71
+      targetRevision: 0.89.73
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.152
+version: 0.285.154
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.152
+      targetRevision: 0.285.154
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/semgrep_scan/perf_webhook.py
+++ b/projects/monolith/semgrep_scan/perf_webhook.py
@@ -33,6 +33,7 @@ import hmac
 import json
 import logging
 import os
+import time
 
 from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request
 
@@ -100,16 +101,30 @@ def _extract_scan_id(payload: dict) -> int | None:
         return None
 
 
-def _managed_row_for(scan_id: int):
+def _managed_row_for(scan_id: int, attempts: int = 8, delay_s: float = 8.0):
     """Fetch the scan record and return a ScanPerf row iff it is a managed scan,
     else None. Reuses the harvest's fetch + classify so managed scans are
     captured identically; our own scans (env UNSPECIFIED) classify to None and
-    are skipped here (report.py is authoritative for those)."""
+    are skipped here (report.py is authoritative for those).
+
+    The completion webhook races the API: totalTime can still read 0 for a few
+    seconds after the scan completes. Since a real scan is never genuinely 0s,
+    retry the fetch until total_time is populated (a 0-finding managed scan is
+    invisible to the findings harvest, so nothing else would ever correct a 0)."""
     from semgrep_scan.perf_harvest import fetch_scan, scan_to_row
 
     token = os.environ.get("SEMGREP_APP_TOKEN", "")
-    scan = fetch_scan(scan_id, token)
-    return scan_to_row(scan) if scan else None
+    row = None
+    for attempt in range(attempts):
+        scan = fetch_scan(scan_id, token)
+        row = scan_to_row(scan) if scan else None
+        # Not a managed scan (or not found): stop, nothing to wait for.
+        if row is None:
+            return None
+        if row.total_time > 0 or attempt == attempts - 1:
+            return row
+        time.sleep(delay_s)
+    return row
 
 
 def _capture_scan(scan_id: int) -> None:

--- a/projects/monolith/semgrep_scan/perf_webhook_test.py
+++ b/projects/monolith/semgrep_scan/perf_webhook_test.py
@@ -202,3 +202,33 @@ def test_extract_scan_id_unwraps_semgrep_scan_envelope():
     assert _extract_scan_id({"semgrep_scan": {"scan_id": "77"}}) == 77
     # top-level id still works
     assert _extract_scan_id({"id": 5}) == 5
+
+
+def test_managed_row_for_retries_until_totaltime_populated(monkeypatch):
+    # The completion webhook races the API: totalTime reads 0 briefly. The
+    # fetch should retry until it is populated (a real scan is never 0s).
+    from semgrep_scan import perf_harvest, perf_webhook
+
+    calls = {"n": 0}
+
+    def fake_fetch(scan_id, token):
+        calls["n"] += 1
+        tt = 0.0 if calls["n"] == 1 else 42.0
+        return {
+            "id": str(scan_id),
+            "environment": "SCAN_ENVIRONMENT_MANAGED_SCANS",
+            "isFullScan": False,
+            "branch": "main",
+            "commit": "c",
+            "totalTime": tt,
+            "findingsCounts": {"total": "0"},
+            "cliVersion": "1.1",
+            "startedAt": None,
+            "completedAt": None,
+        }
+
+    monkeypatch.setattr(perf_harvest, "fetch_scan", fake_fetch)
+    monkeypatch.setattr(perf_webhook.time, "sleep", lambda s: None)
+    row = perf_webhook._managed_row_for(123, attempts=3, delay_s=0)
+    assert row.total_time == 42.0
+    assert calls["n"] == 2  # retried exactly once past the initial 0


### PR DESCRIPTION
The webhook capture now works end-to-end (unsigned scan event from Semgrep IP -> IP-gate -> envelope unwrap -> scan_id -> fetch -> managed row). But the completion webhook races the API: totalTime read 0 for a few seconds, so the first capture stored 0.0s (and a 0-finding managed scan is invisible to the harvest, so nothing corrects it). Retry the fetch until total_time is non-zero (bounded). 🤖 Generated with [Claude Code](https://claude.com/claude-code)