### PR TITLE
fix(git-mirror): raise memory limit to 1Gi to stop fetch OOM

### DIFF
--- a/projects/firecracker/git-mirror/chart/Chart.yaml
+++ b/projects/firecracker/git-mirror/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: git-mirror
 description: Hot git mirror for Firecracker agent workspaces on node-4. Keeps bare clones warm via a supervisor loop; serves git:// (port 9418) with a pre-receive hook restricting writes to refs/agents/**.
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "0.1.0"
 maintainers:
   - name: jomcgi

--- a/projects/firecracker/git-mirror/chart/values.yaml
+++ b/projects/firecracker/git-mirror/chart/values.yaml
@@ -85,14 +85,19 @@ securityContext:
     drop:
       - ALL
 
-# Resource sizing: git-daemon + a refresh loop are lightweight. CPU request only
-# (no limit per repo convention); memory request = limit.
+# Resource sizing: git-daemon is lightweight, but the refresh loop's `git fetch`
+# / index-pack (and the periodic `git gc --auto`) hold delta bases in memory
+# proportional to the repo. homelab.git alone is ~215Mi on disk (167Mi pack), so
+# a 256Mi limit OOM-killed every fetch (exit 137) and froze the mirror 10 days
+# behind main, silently serving a stale tree to agent workspaces. 1Gi gives
+# index-pack/gc ~5x the pack size in headroom. CPU request only (no limit per
+# repo convention); memory request = limit.
 resources:
   requests:
     cpu: 100m
-    memory: 256Mi
+    memory: 1Gi
   limits:
-    memory: 256Mi
+    memory: 1Gi
 
 serviceAccount:
   create: false

--- a/projects/firecracker/git-mirror/deploy/application.yaml
+++ b/projects/firecracker/git-mirror/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: git-mirror
-      targetRevision: 0.1.8
+      targetRevision: 0.1.9
       helm:
         releaseName: git-mirror
         valueFiles:


### PR DESCRIPTION
## Problem

The git mirror (`git-mirror`, ADR 041) has been **frozen 10 days behind `main`** — its `refs/heads/main` was stuck at a 2026-07-02 commit while `origin/main` moved on. Because goosecracker agent workspaces hydrate from this mirror, every agent run has been working against a **10-day-stale homelab tree** (a silent correctness bug), and it also blocks pointing the semgrep PR-diff gather at the mirror.

## Root cause

The mirror's memory **limit is 256Mi** (request=limit, no burst). `git fetch` / `index-pack` (and the periodic `git gc --auto`) hold delta bases in memory proportional to the repo, and `homelab.git` is **~215Mi on disk (167Mi pack)**. The refresh-loop fetch OOM-killed the container:

```
LastState: terminated, reason: OOMKilled, exitCode 137
```

so `main` never advanced. A **single-branch `main`-only fetch OOM'd too**, which proves this is a memory ceiling, not a refspec-size problem (narrowing `+refs/heads/*` would not have helped).

## Fix

Raise the memory request+limit to **1Gi** (~5x the pack size), keeping the request=limit convention. No refspec or logic change.

## Verification
- `helm template` renders the deployment with `memory: 1Gi` on both request and limit.
- After rollout: confirm the refresh loop advances `refs/heads/main` to current `origin/main` and stops OOM-restarting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dcykrf2Gao6v7iMkHrx5V3