### PR TITLE
fix(monolith): hide finished tasks from the daily/weekly views

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.81
+version: 0.89.82
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.81
+      targetRevision: 0.89.82
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.162
+version: 0.285.163
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.162
+      targetRevision: 0.285.163
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from datetime import date, datetime, timedelta, timezone
 
 from sqlalchemy import func, not_, or_
@@ -23,6 +24,12 @@ logger = logging.getLogger(__name__)
 # are too generic to be meaningful.
 MIN_SEARCH_SCORE = 0.4
 _CHUNK_LEN_RAMP = 100  # chars at which the length penalty reaches 1.0
+
+# Terminal task statuses. A task in one of these is finished and should drop
+# out of the daily/weekly "what's on my plate" views (and the MCP tools that
+# back them). patch_task also uses this set to stamp/clear task-completed on
+# transition, so keeping one definition avoids the two drifting apart.
+_DONE_STATUSES = frozenset({"done", "cancelled"})
 
 # Note types that participate in the knowledge graph. Notes whose type
 # is NULL or not in this set are dropped from the graph response — they
@@ -545,6 +552,7 @@ class KnowledgeStore:
         self,
         *,
         statuses: list[str] | None = None,
+        exclude_statuses: Iterable[str] | None = None,
         due_before: str | None = None,
         due_after: str | None = None,
         sizes: list[str] | None = None,
@@ -576,6 +584,12 @@ class KnowledgeStore:
                 continue
 
             if statuses is not None and status not in statuses:
+                continue
+
+            # Exclude-list runs after the allowlist so callers can pass an
+            # empty/blank status through (unlike an allowlist, which would
+            # silently drop unknown statuses) while still dropping terminal ones.
+            if exclude_statuses is not None and status in exclude_statuses:
                 continue
 
             if due_before is not None and (due is None or due > due_before):
@@ -667,17 +681,25 @@ class KnowledgeStore:
         return results
 
     def list_tasks_daily(self) -> list[dict]:
-        """Tasks due today or overdue."""
+        """Tasks due today or overdue, excluding finished (done/cancelled) ones."""
         today = date.today().isoformat()
-        return self.list_tasks(due_before=today, include_someday=False)
+        return self.list_tasks(
+            due_before=today,
+            include_someday=False,
+            exclude_statuses=_DONE_STATUSES,
+        )
 
     def list_tasks_weekly(self) -> list[dict]:
-        """Tasks due this week (Monday through Sunday)."""
+        """Tasks due this week (Monday through Sunday), excluding finished ones."""
         today = date.today()
         # Find end of current week (Sunday).
         days_until_sunday = 6 - today.weekday()
         end_of_week = (today + timedelta(days=days_until_sunday)).isoformat()
-        return self.list_tasks(due_before=end_of_week, include_someday=False)
+        return self.list_tasks(
+            due_before=end_of_week,
+            include_someday=False,
+            exclude_statuses=_DONE_STATUSES,
+        )
 
     def patch_task(self, note_id: str, fields: dict) -> None:
         """Update JSONB extra fields on a task note.
@@ -699,7 +721,7 @@ class KnowledgeStore:
         extra = dict(note.extra or {})
 
         # Detect status transitions for auto-completing.
-        done_statuses = {"done", "cancelled"}
+        done_statuses = _DONE_STATUSES
         old_status = extra.get("status", "")
         new_status = fields.get("status", old_status)
 

--- a/projects/monolith/knowledge/tasks_store_test.py
+++ b/projects/monolith/knowledge/tasks_store_test.py
@@ -143,6 +143,17 @@ class TestListTasks:
         ids = {t["note_id"] for t in tasks}
         assert ids == {"t1", "t2"}
 
+    def test_exclude_statuses_drops_listed_and_keeps_blank(self, session):
+        _make_task(session, "t1", status="todo")
+        _make_task(session, "t2", status="done")
+        _make_task(session, "t3", status="cancelled")
+        _make_task(session, "t4", status="")  # blank status must survive
+
+        store = KnowledgeStore(session)
+        tasks = store.list_tasks(exclude_statuses={"done", "cancelled"})
+        ids = {t["note_id"] for t in tasks}
+        assert ids == {"t1", "t4"}
+
     def test_returns_task_fields(self, session):
         _make_task(
             session,
@@ -167,6 +178,31 @@ class TestListTasks:
         assert task["size"] == "medium"
         assert task["blocked_by"] == ["t0"]
         assert task["task_completed"] is None
+
+
+class TestDailyWeeklyHideFinished:
+    """The daily/weekly views (and the MCP tools behind them) must not show
+    tasks that are already done or cancelled, however overdue they are."""
+
+    def test_daily_hides_done_and_cancelled_but_keeps_open_overdue(self, session):
+        # All overdue (due long before today), so due_before is satisfied.
+        _make_task(session, "open", status="todo", due="2020-01-01")
+        _make_task(session, "finished", status="done", due="2020-01-01")
+        _make_task(session, "dropped", status="cancelled", due="2020-01-01")
+
+        store = KnowledgeStore(session)
+        tasks = store.list_tasks_daily()
+        ids = {t["note_id"] for t in tasks}
+        assert ids == {"open"}
+
+    def test_weekly_hides_done_and_cancelled(self, session):
+        _make_task(session, "open", status="todo", due="2020-01-01")
+        _make_task(session, "finished", status="done", due="2020-01-01")
+
+        store = KnowledgeStore(session)
+        tasks = store.list_tasks_weekly()
+        ids = {t["note_id"] for t in tasks}
+        assert ids == {"open"}
 
 
 class TestPatchTask:


### PR DESCRIPTION
## What

Completed (`done` / `cancelled`) tasks were lingering in the private dashboard's main task view. They should drop out once finished.

## Root cause

`KnowledgeStore.list_tasks_daily` / `list_tasks_weekly` (`knowledge/store.py`) filtered out `someday` tasks but never the terminal statuses, so any done/cancelled task with a past due date stayed in the list forever. This is the shared read path behind both the dashboard queue section and the `get-daily-tasks` / `get-weekly-tasks` MCP tools, so both surfaces showed the stale rows (confirmed live: `get-daily-tasks` was returning 7 tasks, all `status: done`).

## Fix

- Added an `exclude_statuses` param to `list_tasks()`. It runs *after* the existing status allowlist, so a caller can still let blank/unknown-status tasks through (an allowlist would have silently dropped them) while dropping only the terminal ones.
- `list_tasks_daily` / `list_tasks_weekly` now pass `exclude_statuses=_DONE_STATUSES` (`{"done","cancelled"}`).
- Promoted the done/cancelled set to a module constant `_DONE_STATUSES`, reused by `patch_task` (which previously had its own local copy) so the two definitions cannot drift.
- Fixed at the backend read path (not the Svelte view) so the MCP tools benefit too; the frontend's transient strikethrough styling for just-checked tasks is unaffected.

## Tests

- `test_exclude_statuses_drops_listed_and_keeps_blank` — exclude drops done/cancelled, keeps blank-status.
- `TestDailyWeeklyHideFinished` — daily and weekly hide done/cancelled while keeping open overdue tasks.

## Deploy

Chart bumps for `monolith` (0.285.163) and coupled `monolith-public` (0.89.82), done via `bump-chart.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)