### PR TITLE
perf(monolith): serve dashboard health + alerts from a background snapshot

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.82
+version: 0.89.84
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.82
+      targetRevision: 0.89.84
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -701,6 +701,18 @@ py_test(
 )
 
 py_test(
+    name = "home_cluster_snapshot_test",
+    srcs = ["home/cluster_snapshot_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//sqlalchemy",
+    ],
+)
+
+py_test(
     name = "db_test",
     srcs = ["app/db_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.163
+version: 0.285.165
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260712000000_home_cluster_snapshot.sql
+++ b/projects/monolith/chart/migrations/20260712000000_home_cluster_snapshot.sql
@@ -1,0 +1,26 @@
+-- home.cluster_snapshot: single-row snapshot of the cluster health rollup and
+-- the firing SigNoz alerts shown on the private dashboard. Mirrors
+-- home.calendar_snapshot (20260622120000).
+--
+-- The dashboard used to recompute both sections on every request: a live scan
+-- of ~235 Kubernetes resources (pods, deployments, statefulsets, daemonsets,
+-- ArgoCD apps) across all namespaces, plus a SigNoz /api/v1/rules fetch, with
+-- no caching. A cold page load therefore blocked on the whole scan, up to the
+-- SSR timeout. A background job (home.cluster_snapshot_refresh) now runs the
+-- scan and fetch at a cadence and upserts this one row, so the request path is
+-- a single-row read.
+--
+-- Single row (id = 1). health and alerts are stored verbatim as the read path
+-- returns them (health is build_health() output; alerts is {"firing": [...]}).
+-- snapshot_at lets the read path detect a wedged refresher and fall back to a
+-- live scan rather than serve hours-stale "all healthy".
+
+CREATE SCHEMA IF NOT EXISTS home;
+
+CREATE TABLE home.cluster_snapshot (
+    id          SMALLINT PRIMARY KEY DEFAULT 1,
+    health      JSONB NOT NULL,
+    alerts      JSONB NOT NULL,
+    snapshot_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT cluster_snapshot_singleton CHECK (id = 1)
+);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:sA0HA8fC1fG9MfZxyUJQ4G5SHrcxZO2yn6oPEjCqHaM=
+h1:A8c46PYq1bB1DfHkGQBP/K1fRKY8PzySTy6oxIByK/A=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -126,3 +126,4 @@ h1:sA0HA8fC1fG9MfZxyUJQ4G5SHrcxZO2yn6oPEjCqHaM=
 20260711200000_attention_decision_withheld_reason.sql h1:eN7QR6aMeMKkqPHoiWMiv2pMrEGTTefhlqEvKdQl7fo=
 20260711210000_semgrep_scan_perf.sql h1:jgmMxdoWDd+eDAWLEI6uS5e8Vyr36VIj+74r6D/Svn0=
 20260711220000_chat_safeguards.sql h1:LE/nBwV/o6eyfSylKV2PKoj6/jluuDqs0dHKOLCHdWM=
+20260712000000_home_cluster_snapshot.sql h1:+9RRavaWXjyzk5iRiUSwBkZfdOPjKtuHNP4ywZLwMzs=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.163
+      targetRevision: 0.285.165
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/home/__init__.py
+++ b/projects/monolith/home/__init__.py
@@ -23,12 +23,24 @@ def register_public(app: FastAPI) -> None:
 def on_startup_jobs(session) -> None:
     from scheduler.api import register_job
     from home.schedule import calendar_poll_handler
+    from home.cluster_snapshot import cluster_snapshot_refresh_handler
 
     register_job(
         session,
         name="home.calendar_poll",
         interval_secs=900,
         handler=lambda _: calendar_poll_handler(),
+        ttl_secs=120,
+    )
+
+    # Refresh the cluster health + firing-alerts snapshot off-request so the
+    # dashboard read path stays a single-row lookup instead of a live
+    # ~235-resource K8s scan. Cadence matches the frontend's 60s refresh.
+    register_job(
+        session,
+        name="home.cluster_snapshot_refresh",
+        interval_secs=60,
+        handler=lambda _: cluster_snapshot_refresh_handler(),
         ttl_secs=120,
     )
 

--- a/projects/monolith/home/cluster_snapshot.py
+++ b/projects/monolith/home/cluster_snapshot.py
@@ -1,0 +1,157 @@
+"""Background snapshot of the cluster health rollup + firing SigNoz alerts.
+
+The private dashboard's ``health`` and ``alerts`` sections used to recompute on
+every request: a live scan of every pod/deployment/statefulset/daemonset/ArgoCD
+app across all namespaces (~235 objects), plus a SigNoz ``/api/v1/rules`` fetch,
+uncached. A cold page load blocked on the whole scan. This module moves that
+work to a scheduled job (``home.cluster_snapshot_refresh``) that upserts a
+single ``home.cluster_snapshot`` row, so the dashboard read path (see
+``home.dashboard``) becomes a one-row lookup.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy.exc import OperationalError, ProgrammingError
+from sqlmodel import Session, text
+
+logger = logging.getLogger(__name__)
+
+# Workload kinds scanned by the health rollup. Mirrors dashboard._HEALTH_KINDS
+# and cluster.mcp._HEALTH_KINDS.
+_HEALTH_KINDS = ("deployments", "statefulsets", "daemonsets", "pods", "applications")
+
+# Serve a stored snapshot up to this age. Older than this, the read path treats
+# the refresher as wedged and returns None so the caller falls back to a live
+# scan, rather than leave the dashboard showing hours-stale "all healthy". Set
+# well above the 60s refresh cadence so ordinary jitter never trips it.
+_STALE_FALLBACK_SECS = 600
+
+
+async def scan_health_live() -> dict:
+    """Run the live cluster health rollup (the expensive path).
+
+    Fail-soft per kind: a listing error for one kind logs and yields an empty
+    list for it rather than aborting the whole scan.
+    """
+    from cluster.api import KubernetesClient, build_health
+
+    k8s = KubernetesClient()
+    try:
+        resources: dict[str, list[dict]] = {}
+        for kind in _HEALTH_KINDS:
+            try:
+                resources[kind] = await k8s.list_resources(kind)
+            except Exception:
+                logger.exception("cluster snapshot: listing %s failed", kind)
+                resources[kind] = []
+        return build_health(resources)
+    finally:
+        await k8s.close()
+
+
+async def fetch_alerts_live() -> dict:
+    """Fetch firing SigNoz alert rules (the live path)."""
+    from agent.api import check_firing_alerts
+
+    return {"firing": await check_firing_alerts()}
+
+
+def _write_cluster_snapshot(health: dict, alerts: dict) -> None:
+    """Upsert the single snapshot row. Opens its own session so it can run in a
+    worker thread off the event loop."""
+    from app.db import get_engine
+
+    with Session(get_engine()) as session:
+        session.execute(
+            text(
+                """
+                INSERT INTO home.cluster_snapshot (id, health, alerts, snapshot_at)
+                VALUES (1, :health, :alerts, now())
+                ON CONFLICT (id) DO UPDATE
+                    SET health = EXCLUDED.health,
+                        alerts = EXCLUDED.alerts,
+                        snapshot_at = EXCLUDED.snapshot_at
+                """
+            ),
+            {"health": json.dumps(health), "alerts": json.dumps(alerts)},
+        )
+        session.commit()
+
+
+async def refresh_cluster_snapshot() -> None:
+    """Scan health + fetch alerts concurrently and upsert the snapshot row.
+
+    Fail-soft per section: if the health scan fails the alerts are still
+    persisted (and vice versa), each failed section stored as {"error": ...} so
+    a flaky SigNoz never blanks health and a K8s API blip never blanks alerts.
+    """
+    health, alerts = await asyncio.gather(
+        scan_health_live(), fetch_alerts_live(), return_exceptions=True
+    )
+    if isinstance(health, Exception):
+        logger.warning("cluster snapshot: health scan failed: %s", health)
+        health = {"error": str(health)}
+    if isinstance(alerts, Exception):
+        logger.warning("cluster snapshot: alerts fetch failed: %s", alerts)
+        alerts = {"error": str(alerts)}
+    await asyncio.to_thread(_write_cluster_snapshot, health, alerts)
+    logger.info("cluster snapshot refreshed (scanned=%s)", health.get("scanned"))
+
+
+async def cluster_snapshot_refresh_handler() -> None:
+    """Scheduler handler for the cluster snapshot refresh."""
+    await refresh_cluster_snapshot()
+    return None
+
+
+def read_cluster_snapshot(session: Session) -> dict | None:
+    """Return the stored snapshot, or None when the caller should live-scan.
+
+    Shape when present:
+        {"health": dict, "alerts": dict, "snapshot_at": iso str, "age_secs": float}
+
+    None is returned (meaning "fall back to a live scan") when the row is
+    absent (fresh deploy before the first refresh), too stale (a wedged
+    refresher, older than ``_STALE_FALLBACK_SECS``), or the table does not
+    exist (an unmigrated env, or the SQLite test fixtures which build tables
+    from SQLModel metadata rather than the raw-SQL migrations).
+    """
+    try:
+        row = session.execute(
+            text(
+                "SELECT health, alerts, snapshot_at "
+                "FROM home.cluster_snapshot WHERE id = 1"
+            )
+        ).first()
+    except (OperationalError, ProgrammingError):
+        session.rollback()
+        return None
+    if row is None:
+        return None
+
+    health, alerts, snapshot_at = row
+    # SQLite hands JSON/timestamps back as strings; Postgres parses them.
+    if isinstance(health, str):
+        health = json.loads(health)
+    if isinstance(alerts, str):
+        alerts = json.loads(alerts)
+    if isinstance(snapshot_at, str):
+        snapshot_at = datetime.fromisoformat(snapshot_at)
+    if snapshot_at.tzinfo is None:
+        snapshot_at = snapshot_at.replace(tzinfo=timezone.utc)
+
+    age_secs = (datetime.now(timezone.utc) - snapshot_at).total_seconds()
+    if age_secs > _STALE_FALLBACK_SECS:
+        return None
+
+    return {
+        "health": health,
+        "alerts": alerts,
+        "snapshot_at": snapshot_at.isoformat(),
+        "age_secs": age_secs,
+    }

--- a/projects/monolith/home/cluster_snapshot_test.py
+++ b/projects/monolith/home/cluster_snapshot_test.py
@@ -1,0 +1,207 @@
+"""Unit tests for home.cluster_snapshot: the background refresh (fail-soft per
+section) and the read path (fresh hit, absent/stale/missing-table fallback),
+plus the dashboard collectors that read it.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from home import cluster_snapshot, dashboard
+
+
+def _fake_session_returning(row):
+    """A session whose execute(...).first() returns the given row tuple/None."""
+    session = MagicMock()
+    session.execute.return_value.first.return_value = row
+    return session
+
+
+# ---------------------------------------------------------------------------
+# read_cluster_snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_read_returns_none_when_table_missing():
+    session = MagicMock()
+    session.execute.side_effect = OperationalError(
+        "SELECT ...", {}, Exception("no such table: home.cluster_snapshot")
+    )
+
+    assert cluster_snapshot.read_cluster_snapshot(session) is None
+    session.rollback.assert_called_once()
+
+
+def test_read_returns_none_when_row_absent():
+    session = _fake_session_returning(None)
+    assert cluster_snapshot.read_cluster_snapshot(session) is None
+
+
+def test_read_returns_parsed_snapshot_when_fresh():
+    now = datetime.now(timezone.utc)
+    session = _fake_session_returning(
+        (
+            {"healthy": True, "scanned": 235, "unhealthy": {}},
+            {"firing": []},
+            now,
+        )
+    )
+
+    snap = cluster_snapshot.read_cluster_snapshot(session)
+    assert snap is not None
+    assert snap["health"]["scanned"] == 235
+    assert snap["alerts"] == {"firing": []}
+    assert snap["age_secs"] < 5
+
+
+def test_read_parses_string_columns_from_sqlite_style_row():
+    """SQLite fixtures hand JSON/timestamps back as strings; parse them."""
+    now = datetime.now(timezone.utc)
+    session = _fake_session_returning(
+        (
+            json.dumps({"healthy": False, "unhealthy": {"pods": [{"name": "x"}]}}),
+            json.dumps({"firing": [{"name": "DiskFull"}]}),
+            now.isoformat(),
+        )
+    )
+
+    snap = cluster_snapshot.read_cluster_snapshot(session)
+    assert snap is not None
+    assert snap["health"]["healthy"] is False
+    assert snap["alerts"]["firing"][0]["name"] == "DiskFull"
+
+
+def test_read_returns_none_when_stale():
+    old = datetime.now(timezone.utc) - timedelta(
+        seconds=cluster_snapshot._STALE_FALLBACK_SECS + 60
+    )
+    session = _fake_session_returning(({"healthy": True}, {"firing": []}, old))
+
+    # A wedged refresher must not leave the dashboard showing stale "healthy".
+    assert cluster_snapshot.read_cluster_snapshot(session) is None
+
+
+# ---------------------------------------------------------------------------
+# refresh_cluster_snapshot: fail-soft per section
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_persists_both_sections_on_success():
+    write = MagicMock()
+    with (
+        patch.object(
+            cluster_snapshot,
+            "scan_health_live",
+            AsyncMock(return_value={"healthy": True, "scanned": 10, "unhealthy": {}}),
+        ),
+        patch.object(
+            cluster_snapshot,
+            "fetch_alerts_live",
+            AsyncMock(return_value={"firing": []}),
+        ),
+        patch.object(cluster_snapshot, "_write_cluster_snapshot", write),
+    ):
+        await cluster_snapshot.refresh_cluster_snapshot()
+
+    health, alerts = write.call_args.args
+    assert health["scanned"] == 10
+    assert alerts == {"firing": []}
+
+
+@pytest.mark.asyncio
+async def test_refresh_stores_error_marker_for_failing_health_but_keeps_alerts():
+    write = MagicMock()
+    with (
+        patch.object(
+            cluster_snapshot,
+            "scan_health_live",
+            AsyncMock(side_effect=RuntimeError("k8s down")),
+        ),
+        patch.object(
+            cluster_snapshot,
+            "fetch_alerts_live",
+            AsyncMock(return_value={"firing": [{"name": "DiskFull"}]}),
+        ),
+        patch.object(cluster_snapshot, "_write_cluster_snapshot", write),
+    ):
+        await cluster_snapshot.refresh_cluster_snapshot()
+
+    health, alerts = write.call_args.args
+    assert health == {"error": "k8s down"}
+    assert alerts["firing"][0]["name"] == "DiskFull"
+
+
+# ---------------------------------------------------------------------------
+# dashboard collectors read the snapshot, fall back to live when it is absent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collect_health_uses_snapshot_and_adds_freshness():
+    snap = {
+        "health": {"healthy": True, "scanned": 42, "unhealthy": {}},
+        "alerts": {"firing": []},
+        "snapshot_at": "2026-07-12T20:00:00+00:00",
+        "age_secs": 3.0,
+    }
+    live = AsyncMock()
+    with (
+        patch.object(cluster_snapshot, "read_cluster_snapshot", return_value=snap),
+        patch.object(cluster_snapshot, "scan_health_live", live),
+    ):
+        health = await dashboard._collect_health(MagicMock())
+
+    assert health["scanned"] == 42
+    assert health["snapshot_at"] == "2026-07-12T20:00:00+00:00"
+    live.assert_not_called()  # never touches the live scan on a fresh hit
+
+
+@pytest.mark.asyncio
+async def test_collect_health_falls_back_to_live_scan_when_no_snapshot():
+    live = AsyncMock(return_value={"healthy": True, "scanned": 7, "unhealthy": {}})
+    with (
+        patch.object(cluster_snapshot, "read_cluster_snapshot", return_value=None),
+        patch.object(cluster_snapshot, "scan_health_live", live),
+    ):
+        health = await dashboard._collect_health(MagicMock())
+
+    assert health["scanned"] == 7
+    live.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_collect_alerts_uses_snapshot_when_present():
+    snap = {
+        "health": {"healthy": True},
+        "alerts": {"firing": [{"name": "DiskFull"}]},
+        "snapshot_at": "2026-07-12T20:00:00+00:00",
+        "age_secs": 3.0,
+    }
+    live = AsyncMock()
+    with (
+        patch.object(cluster_snapshot, "read_cluster_snapshot", return_value=snap),
+        patch.object(cluster_snapshot, "fetch_alerts_live", live),
+    ):
+        alerts = await dashboard._collect_alerts(MagicMock())
+
+    assert alerts["firing"][0]["name"] == "DiskFull"
+    live.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_collect_alerts_falls_back_to_live_when_no_snapshot():
+    live = AsyncMock(return_value={"firing": [{"name": "Latency"}]})
+    with (
+        patch.object(cluster_snapshot, "read_cluster_snapshot", return_value=None),
+        patch.object(cluster_snapshot, "fetch_alerts_live", live),
+    ):
+        alerts = await dashboard._collect_alerts(MagicMock())
+
+    assert alerts["firing"][0]["name"] == "Latency"
+    live.assert_awaited_once()

--- a/projects/monolith/home/dashboard.py
+++ b/projects/monolith/home/dashboard.py
@@ -26,9 +26,6 @@ logger = logging.getLogger(__name__)
 GITHUB_REPO = "jomcgi/homelab"
 _GITHUB_CACHE_TTL_SECS = 60
 
-# Workload kinds scanned by the health rollup, mirrors cluster.mcp._HEALTH_KINDS.
-_HEALTH_KINDS = ("deployments", "statefulsets", "daemonsets", "pods", "applications")
-
 # Module-level cache: {"data": dict, "expires_at": float} or None until first fill.
 _github_cache: dict | None = None
 
@@ -132,30 +129,37 @@ async def _collect_github() -> dict:
     return data
 
 
-async def _collect_health() -> dict:
-    """Cluster health rollup, reusing the same internals as k8s_health_summary."""
-    from cluster.api import KubernetesClient, build_health
+async def _collect_health(session) -> dict:
+    """Cluster health rollup, served from the background snapshot when fresh.
 
-    k8s = KubernetesClient()
-    try:
-        resources: dict[str, list[dict]] = {}
-        for kind in _HEALTH_KINDS:
-            try:
-                resources[kind] = await k8s.list_resources(kind)
-            except Exception:
-                logger.exception("dashboard: listing %s failed", kind)
-                resources[kind] = []
-        return build_health(resources)
-    finally:
-        await k8s.close()
+    The scan itself (~235 resources across all namespaces) runs off-request in
+    home.cluster_snapshot_refresh, so the normal path here is a single-row read.
+    Falls back to a live scan only when no fresh snapshot exists: a fresh deploy
+    before the first refresh, a wedged refresher, or an unmigrated env.
+    """
+    from home.cluster_snapshot import read_cluster_snapshot, scan_health_live
+
+    snap = read_cluster_snapshot(session)
+    if snap is not None:
+        # Surface freshness without disturbing the {healthy, scanned, unhealthy}
+        # shape the frontend reads.
+        health = dict(snap["health"])
+        health["snapshot_at"] = snap["snapshot_at"]
+        return health
+    return await scan_health_live()
 
 
-async def _collect_alerts() -> dict:
-    """Firing SigNoz alert rules."""
-    from agent.api import check_firing_alerts
+async def _collect_alerts(session) -> dict:
+    """Firing SigNoz alert rules, served from the background snapshot when fresh.
 
-    firing = await check_firing_alerts()
-    return {"firing": firing}
+    Falls back to a live SigNoz fetch only when no fresh snapshot exists (see
+    _collect_health for when that happens)."""
+    from home.cluster_snapshot import fetch_alerts_live, read_cluster_snapshot
+
+    snap = read_cluster_snapshot(session)
+    if snap is not None:
+        return snap["alerts"]
+    return await fetch_alerts_live()
 
 
 async def _collect_queues(session) -> dict:
@@ -206,8 +210,8 @@ async def build_dashboard(session) -> dict:
     """
     names = ("health", "alerts", "github", "queues", "today")
     results = await asyncio.gather(
-        _collect_health(),
-        _collect_alerts(),
+        _collect_health(session),
+        _collect_alerts(session),
         _collect_github(),
         _collect_queues(session),
         _collect_today(session),

--- a/projects/monolith/home/schedule_calendar_handler_test.py
+++ b/projects/monolith/home/schedule_calendar_handler_test.py
@@ -71,53 +71,74 @@ class TestCalendarPollHandler:
 # ---------------------------------------------------------------------------
 
 
+def _calls_by_name(mock_register):
+    """Map each register_job(...) call to its job name kwarg.
+
+    on_startup_jobs registers more than one job, so tests select the call they
+    mean by name instead of relying on call_args (which is only the last call).
+    """
+    return {call.kwargs["name"]: call for call in mock_register.call_args_list}
+
+
 class TestOnStartupJobs:
-    def test_calls_register_job_once(self):
-        """on_startup_jobs() calls register_job() exactly once."""
+    def test_registers_calendar_and_cluster_snapshot_jobs(self):
+        """on_startup_jobs() registers both the calendar poll and the cluster
+        health snapshot refresh."""
         mock_session = MagicMock()
         with patch("scheduler.api.register_job") as mock_register:
             on_startup_jobs(mock_session)
-        mock_register.assert_called_once()
+        assert mock_register.call_count == 2
+        names = {call.kwargs["name"] for call in mock_register.call_args_list}
+        assert names == {"home.calendar_poll", "home.cluster_snapshot_refresh"}
 
-    def test_passes_session_to_register_job(self):
-        """on_startup_jobs() forwards its session argument as the first positional arg."""
+    def test_passes_session_to_every_register_job(self):
+        """on_startup_jobs() forwards its session as the first positional arg to
+        every registration."""
         mock_session = MagicMock()
         with patch("scheduler.api.register_job") as mock_register:
             on_startup_jobs(mock_session)
-        positional_args, _ = mock_register.call_args
-        assert positional_args[0] is mock_session
+        for call in mock_register.call_args_list:
+            assert call.args[0] is mock_session
 
-    def test_job_name_is_home_calendar_poll(self):
-        """The registered job name is 'home.calendar_poll'."""
+    def test_calendar_job_interval_and_ttl(self):
+        """Calendar poll runs every 900 seconds (15 minutes) with a 120s TTL."""
         mock_session = MagicMock()
         with patch("scheduler.api.register_job") as mock_register:
             on_startup_jobs(mock_session)
-        _, kwargs = mock_register.call_args
-        assert kwargs["name"] == "home.calendar_poll"
+        cal = _calls_by_name(mock_register)["home.calendar_poll"]
+        assert cal.kwargs["interval_secs"] == 900
+        assert cal.kwargs["ttl_secs"] == 120
 
-    def test_interval_secs_is_900(self):
-        """Calendar poll runs every 900 seconds (15 minutes)."""
+    def test_cluster_snapshot_job_interval_and_ttl(self):
+        """The cluster snapshot refresh runs every 60 seconds with a 120s TTL."""
         mock_session = MagicMock()
         with patch("scheduler.api.register_job") as mock_register:
             on_startup_jobs(mock_session)
-        _, kwargs = mock_register.call_args
-        assert kwargs["interval_secs"] == 900
-
-    def test_ttl_secs_is_120(self):
-        """Calendar poll job TTL is 120 seconds."""
-        mock_session = MagicMock()
-        with patch("scheduler.api.register_job") as mock_register:
-            on_startup_jobs(mock_session)
-        _, kwargs = mock_register.call_args
-        assert kwargs["ttl_secs"] == 120
+        snap = _calls_by_name(mock_register)["home.cluster_snapshot_refresh"]
+        assert snap.kwargs["interval_secs"] == 60
+        assert snap.kwargs["ttl_secs"] == 120
 
     @pytest.mark.asyncio
-    async def test_handler_delegates_to_calendar_poll_handler(self):
-        """The registered handler wraps calendar_poll_handler."""
+    async def test_calendar_handler_delegates_to_calendar_poll_handler(self):
+        """The calendar job's handler wraps calendar_poll_handler."""
         mock_session = MagicMock()
         with patch("scheduler.api.register_job") as mock_register:
             on_startup_jobs(mock_session)
-        _, kwargs = mock_register.call_args
+        cal = _calls_by_name(mock_register)["home.calendar_poll"]
         with patch("home.schedule.poll_calendar", new_callable=AsyncMock):
-            result = await kwargs["handler"](mock_session)
+            result = await cal.kwargs["handler"](mock_session)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_cluster_snapshot_handler_delegates_to_refresh(self):
+        """The snapshot job's handler wraps refresh_cluster_snapshot."""
+        mock_session = MagicMock()
+        with patch("scheduler.api.register_job") as mock_register:
+            on_startup_jobs(mock_session)
+        snap = _calls_by_name(mock_register)["home.cluster_snapshot_refresh"]
+        with patch(
+            "home.cluster_snapshot.refresh_cluster_snapshot", new_callable=AsyncMock
+        ) as mock_refresh:
+            result = await snap.kwargs["handler"](mock_session)
+        mock_refresh.assert_awaited_once()
         assert result is None

--- a/projects/monolith/home/tests/bdd_public_test.py
+++ b/projects/monolith/home/tests/bdd_public_test.py
@@ -16,9 +16,8 @@ class TestPublicFunctions:
         assert isinstance(result, list)
 
     @covers_public("home.on_startup_jobs")
-    def test_on_startup_jobs_registers_job(self, session):
+    def test_on_startup_jobs_registers_jobs(self, session):
         with patch("scheduler.api.register_job") as mock_register:
             home.on_startup_jobs(session)
-        mock_register.assert_called_once()
-        _, kwargs = mock_register.call_args
-        assert kwargs["name"] == "home.calendar_poll"
+        names = {call.kwargs["name"] for call in mock_register.call_args_list}
+        assert names == {"home.calendar_poll", "home.cluster_snapshot_refresh"}


### PR DESCRIPTION
## Problem

The private dashboard (`private.jomcgi.dev`) is sometimes slow to load. Root cause: `build_dashboard()` recomputes two expensive sections on **every request**, uncached:

- **health** — a live scan of ~235 Kubernetes resources (pods, deployments, statefulsets, daemonsets, ArgoCD apps) across all namespaces.
- **alerts** — a SigNoz `/api/v1/rules` fetch.

A cold page load blocks on the full scan (up to the 15s SSR timeout). The other three sections are already cheap or cached (`github` has a 60s TTL, `today`/calendar is a materialized snapshot).

## Fix

Move the health + alerts work off the request path, mirroring the existing **calendar snapshot** pattern already in this file (`home.calendar_snapshot` + `poll_calendar`):

- New `home.cluster_snapshot` single-row table (migration `20260712000000`).
- New scheduled job `home.cluster_snapshot_refresh` (60s cadence, matching the frontend's refresh) runs the scan + alerts fetch and upserts the row. **Fail-soft per section**: a health-scan failure still persists alerts (and vice versa), each failed half stored as `{"error": ...}`.
- `_collect_health` / `_collect_alerts` now read that one row. They fall back to a **live scan only when no fresh snapshot exists**: a fresh deploy before the first refresh, a wedged refresher (row older than 600s), or an unmigrated / SQLite-fixture env where the raw-SQL table is absent.

Result: the normal request path is a single-row read; the scan runs once per 60s in the background regardless of how many tabs are open (strictly less load than the old per-request-per-viewer scanning).

## Safety notes

- **No new RBAC**: the scan already ran from the API pod on every request; only *when* it runs moved.
- **Frontend contract unchanged**: health keeps `{healthy, scanned, unhealthy}`; a `snapshot_at` field is added (additive). Alerts keeps `{firing: [...]}`.
- **Staleness guard**: a dead refresher (row > 600s old) forces a live scan, so the dashboard never shows hours-stale "all healthy".

## Tests

`home/cluster_snapshot_test.py`: read-path fresh hit, absent/stale/missing-table fallback, string-column (SQLite) parsing, refresh fail-soft per section, and the two dashboard collectors reading the snapshot vs falling back to live.

## Follow-up

Chart bump (monolith + coupled public) will be added to this branch once sibling PR #3448 lands, to avoid a chart-version collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)