### PR TITLE
perf(monolith): run the dashboard cluster snapshot as an Argo CronWorkflow

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.84
+version: 0.89.85
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.84
+      targetRevision: 0.89.85
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -127,6 +127,25 @@ def observability_stats_rollup() -> None:
     logger.info("observability-stats-rollup: done")
 
 
+@app.command("home-cluster-snapshot-refresh")
+def home_cluster_snapshot_refresh() -> None:
+    """Snapshot the cluster health rollup + firing alerts as a one-shot.
+
+    One-shot form of the retired in-process refresh. refresh_cluster_snapshot
+    scans deployments/statefulsets/daemonsets/pods/ArgoCD-apps via the in-cluster
+    K8s API, so this job runs under the dedicated least-privilege monolith-stats
+    SA (same as observability-stats-rollup), and fetches firing SigNoz alerts
+    (SIGNOZ_URL + SIGNOZ_API_KEY). It upserts one home.cluster_snapshot row so the
+    dashboard read path is a single-row lookup instead of a live per-request scan.
+    Fail-soft per section; the writer opens its own session."""
+    from home.cluster_snapshot import refresh_cluster_snapshot
+
+    configure_logging()
+    logger.info("home-cluster-snapshot-refresh: starting")
+    asyncio.run(refresh_cluster_snapshot())
+    logger.info("home-cluster-snapshot-refresh: done")
+
+
 @app.command("hikes-scrape-walks")
 def hikes_scrape_walks() -> None:
     """Run the full WalkHighlands corpus scrape as a one-shot.

--- a/projects/monolith/app/jobs_main_test.py
+++ b/projects/monolith/app/jobs_main_test.py
@@ -29,6 +29,15 @@ def test_worldcup_sim_dispatches_to_refresh_handler():
     handler.assert_awaited_once()
 
 
+def test_cluster_snapshot_refresh_dispatches_to_refresh():
+    refresh = mock.AsyncMock(return_value=None)
+    with mock.patch("home.cluster_snapshot.refresh_cluster_snapshot", new=refresh):
+        result = runner.invoke(jobs_main.app, ["home-cluster-snapshot-refresh"])
+
+    assert result.exit_code == 0, result.output
+    refresh.assert_awaited_once()
+
+
 def test_no_args_lists_commands():
     result = runner.invoke(jobs_main.app, [])
     # no_args_is_help exits non-zero and prints the command list.

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.165
+version: 0.285.166
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -291,6 +291,17 @@ spec:
                   key: OWNER_DISCORD_USER_ID
             - name: SIGNOZ_URL
               value: {{ .Values.agent.signoz.url | quote }}
+            # SIGNOZ_API_KEY authenticates the dashboard's firing-alerts fetch.
+            # The signoz-api-key Secret is cloned from the signoz namespace by
+            # Kyverno; optional so a not-yet-cloned key degrades to an
+            # unauthenticated 401 (the prior behaviour) rather than wedging pod
+            # startup on a missing secret.
+            - name: SIGNOZ_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: signoz-api-key
+                  key: api-key
+                  optional: true
             {{- end }}
             {{- if .Values.stars }}
             - name: SEAWEEDFS_S3_ENDPOINT

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -373,6 +373,34 @@ jobs:
           memory: 256Mi
         limits:
           memory: 256Mi
+    # home.cluster_snapshot_refresh: scans the cluster health rollup (deployments,
+    # statefulsets, daemonsets, pods, ArgoCD apps via the in-cluster K8s API) plus
+    # firing SigNoz alerts, and upserts one home.cluster_snapshot row so the
+    # private dashboard reads a single row instead of doing a live ~235-resource
+    # scan on every request. Cluster reads run under the dedicated least-privilege
+    # monolith-stats SA (same as observability-stats-rollup). SIGNOZ_API_KEY is the
+    # 1Password key cloned into monolith-workflows by Kyverno. Every minute, to
+    # match the frontend's 60s refresh.
+    - name: home-cluster-snapshot-refresh
+      replaces: home.cluster_snapshot_refresh
+      args: ["home-cluster-snapshot-refresh"]
+      schedule: "* * * * *"
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 120
+      suspend: false
+      serviceAccountName: monolith-stats
+      env:
+        SIGNOZ_URL: "http://signoz.signoz.svc.cluster.local:8080/app/signoz"
+      secretEnv:
+        SIGNOZ_API_KEY:
+          secretName: signoz-api-key
+          key: api-key
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
     # chat.summary_generation: per-user + per-channel LLM summaries. LLM-only
     # (Qwen via LLAMA_CPP_URL), no Discord bot needed, so it is a clean cutover.
     # Daily (was 86400s); generous deadline since it loops users/channels with

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.165
+      targetRevision: 0.285.166
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/home/__init__.py
+++ b/projects/monolith/home/__init__.py
@@ -23,24 +23,12 @@ def register_public(app: FastAPI) -> None:
 def on_startup_jobs(session) -> None:
     from scheduler.api import register_job
     from home.schedule import calendar_poll_handler
-    from home.cluster_snapshot import cluster_snapshot_refresh_handler
 
     register_job(
         session,
         name="home.calendar_poll",
         interval_secs=900,
         handler=lambda _: calendar_poll_handler(),
-        ttl_secs=120,
-    )
-
-    # Refresh the cluster health + firing-alerts snapshot off-request so the
-    # dashboard read path stays a single-row lookup instead of a live
-    # ~235-resource K8s scan. Cadence matches the frontend's 60s refresh.
-    register_job(
-        session,
-        name="home.cluster_snapshot_refresh",
-        interval_secs=60,
-        handler=lambda _: cluster_snapshot_refresh_handler(),
         ttl_secs=120,
     )
 

--- a/projects/monolith/home/cluster_snapshot.py
+++ b/projects/monolith/home/cluster_snapshot.py
@@ -103,12 +103,6 @@ async def refresh_cluster_snapshot() -> None:
     logger.info("cluster snapshot refreshed (scanned=%s)", health.get("scanned"))
 
 
-async def cluster_snapshot_refresh_handler() -> None:
-    """Scheduler handler for the cluster snapshot refresh."""
-    await refresh_cluster_snapshot()
-    return None
-
-
 def read_cluster_snapshot(session: Session) -> dict | None:
     """Return the stored snapshot, or None when the caller should live-scan.
 

--- a/projects/monolith/home/schedule_calendar_handler_test.py
+++ b/projects/monolith/home/schedule_calendar_handler_test.py
@@ -71,74 +71,53 @@ class TestCalendarPollHandler:
 # ---------------------------------------------------------------------------
 
 
-def _calls_by_name(mock_register):
-    """Map each register_job(...) call to its job name kwarg.
-
-    on_startup_jobs registers more than one job, so tests select the call they
-    mean by name instead of relying on call_args (which is only the last call).
-    """
-    return {call.kwargs["name"]: call for call in mock_register.call_args_list}
-
-
 class TestOnStartupJobs:
-    def test_registers_calendar_and_cluster_snapshot_jobs(self):
-        """on_startup_jobs() registers both the calendar poll and the cluster
-        health snapshot refresh."""
+    def test_calls_register_job_once(self):
+        """on_startup_jobs() calls register_job() exactly once."""
         mock_session = MagicMock()
         with patch("scheduler.api.register_job") as mock_register:
             on_startup_jobs(mock_session)
-        assert mock_register.call_count == 2
-        names = {call.kwargs["name"] for call in mock_register.call_args_list}
-        assert names == {"home.calendar_poll", "home.cluster_snapshot_refresh"}
+        mock_register.assert_called_once()
 
-    def test_passes_session_to_every_register_job(self):
-        """on_startup_jobs() forwards its session as the first positional arg to
-        every registration."""
+    def test_passes_session_to_register_job(self):
+        """on_startup_jobs() forwards its session argument as the first positional arg."""
         mock_session = MagicMock()
         with patch("scheduler.api.register_job") as mock_register:
             on_startup_jobs(mock_session)
-        for call in mock_register.call_args_list:
-            assert call.args[0] is mock_session
+        positional_args, _ = mock_register.call_args
+        assert positional_args[0] is mock_session
 
-    def test_calendar_job_interval_and_ttl(self):
-        """Calendar poll runs every 900 seconds (15 minutes) with a 120s TTL."""
+    def test_job_name_is_home_calendar_poll(self):
+        """The registered job name is 'home.calendar_poll'."""
         mock_session = MagicMock()
         with patch("scheduler.api.register_job") as mock_register:
             on_startup_jobs(mock_session)
-        cal = _calls_by_name(mock_register)["home.calendar_poll"]
-        assert cal.kwargs["interval_secs"] == 900
-        assert cal.kwargs["ttl_secs"] == 120
+        _, kwargs = mock_register.call_args
+        assert kwargs["name"] == "home.calendar_poll"
 
-    def test_cluster_snapshot_job_interval_and_ttl(self):
-        """The cluster snapshot refresh runs every 60 seconds with a 120s TTL."""
+    def test_interval_secs_is_900(self):
+        """Calendar poll runs every 900 seconds (15 minutes)."""
         mock_session = MagicMock()
         with patch("scheduler.api.register_job") as mock_register:
             on_startup_jobs(mock_session)
-        snap = _calls_by_name(mock_register)["home.cluster_snapshot_refresh"]
-        assert snap.kwargs["interval_secs"] == 60
-        assert snap.kwargs["ttl_secs"] == 120
+        _, kwargs = mock_register.call_args
+        assert kwargs["interval_secs"] == 900
+
+    def test_ttl_secs_is_120(self):
+        """Calendar poll job TTL is 120 seconds."""
+        mock_session = MagicMock()
+        with patch("scheduler.api.register_job") as mock_register:
+            on_startup_jobs(mock_session)
+        _, kwargs = mock_register.call_args
+        assert kwargs["ttl_secs"] == 120
 
     @pytest.mark.asyncio
-    async def test_calendar_handler_delegates_to_calendar_poll_handler(self):
-        """The calendar job's handler wraps calendar_poll_handler."""
+    async def test_handler_delegates_to_calendar_poll_handler(self):
+        """The registered handler wraps calendar_poll_handler."""
         mock_session = MagicMock()
         with patch("scheduler.api.register_job") as mock_register:
             on_startup_jobs(mock_session)
-        cal = _calls_by_name(mock_register)["home.calendar_poll"]
+        _, kwargs = mock_register.call_args
         with patch("home.schedule.poll_calendar", new_callable=AsyncMock):
-            result = await cal.kwargs["handler"](mock_session)
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_cluster_snapshot_handler_delegates_to_refresh(self):
-        """The snapshot job's handler wraps refresh_cluster_snapshot."""
-        mock_session = MagicMock()
-        with patch("scheduler.api.register_job") as mock_register:
-            on_startup_jobs(mock_session)
-        snap = _calls_by_name(mock_register)["home.cluster_snapshot_refresh"]
-        with patch(
-            "home.cluster_snapshot.refresh_cluster_snapshot", new_callable=AsyncMock
-        ) as mock_refresh:
-            result = await snap.kwargs["handler"](mock_session)
-        mock_refresh.assert_awaited_once()
+            result = await kwargs["handler"](mock_session)
         assert result is None

--- a/projects/monolith/home/tests/bdd_public_test.py
+++ b/projects/monolith/home/tests/bdd_public_test.py
@@ -16,8 +16,9 @@ class TestPublicFunctions:
         assert isinstance(result, list)
 
     @covers_public("home.on_startup_jobs")
-    def test_on_startup_jobs_registers_jobs(self, session):
+    def test_on_startup_jobs_registers_job(self, session):
         with patch("scheduler.api.register_job") as mock_register:
             home.on_startup_jobs(session)
-        names = {call.kwargs["name"] for call in mock_register.call_args_list}
-        assert names == {"home.calendar_poll", "home.cluster_snapshot_refresh"}
+        mock_register.assert_called_once()
+        _, kwargs = mock_register.call_args
+        assert kwargs["name"] == "home.calendar_poll"

--- a/projects/platform/argo-workflows/templates/monolith-stats-rbac.yaml
+++ b/projects/platform/argo-workflows/templates/monolith-stats-rbac.yaml
@@ -27,9 +27,10 @@ rules:
   - apiGroups: [""]
     resources: ["nodes/proxy"]
     verbs: ["get"]
-  # count_deployments.
+  # count_deployments, plus the home.cluster_snapshot health rollup which lists
+  # statefulsets and daemonsets alongside deployments to flag not-ready ones.
   - apiGroups: ["apps"]
-    resources: ["deployments"]
+    resources: ["deployments", "statefulsets", "daemonsets"]
     verbs: ["get", "list"]
   # count_argocd_applications + get_argocd_app_status. Read-only: no patch
   # (stats never triggers a sync).

--- a/projects/platform/kyverno/templates/clone-signoz-api-key-policy.yaml
+++ b/projects/platform/kyverno/templates/clone-signoz-api-key-policy.yaml
@@ -1,0 +1,70 @@
+# Cross-namespace replication of the SigNoz API key.
+#
+# The signoz-dashboard-sidecar provisions a 1Password-backed `signoz-api-key`
+# Secret (single key `api-key`) in the `signoz` namespace. Two consumers outside
+# that namespace need it to authenticate to the SigNoz `/api/v1/rules` endpoint
+# for the dashboard's firing-alerts section:
+#
+#   - the monolith API pod (ns `monolith`), for the live fallback path, and
+#   - the home.cluster_snapshot_refresh CronWorkflow (ns `monolith-workflows`),
+#     which snapshots firing alerts alongside cluster health.
+#
+# K8s Secrets are namespace-scoped, so Kyverno clones the Secret into both target
+# namespaces and keeps them in sync (synchronize: true) if the key rotates.
+# generateExisting backfills the already-existing namespaces on first apply.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: clone-signoz-api-key
+  annotations:
+    policies.kyverno.io/title: Clone signoz-api-key into monolith + monolith-workflows
+    policies.kyverno.io/category: Secret Management
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: |
+      Replicates the 1Password-backed signoz-api-key Secret from the signoz
+      namespace into the monolith and monolith-workflows namespaces (synchronized)
+      so the API pod and the cluster-snapshot CronWorkflow can authenticate to the
+      SigNoz alerts API without a per-namespace 1Password round-trip.
+spec:
+  background: true
+  rules:
+    - name: clone-signoz-api-key-to-monolith
+      # Kyverno 1.13 defaults this server-side; declare it so ArgoCD desired
+      # state matches live and the app does not sit permanently OutOfSync.
+      skipBackgroundRequests: true
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - monolith
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: signoz-api-key
+        namespace: monolith
+        synchronize: true
+        generateExisting: true
+        clone:
+          namespace: signoz
+          name: signoz-api-key
+    - name: clone-signoz-api-key-to-monolith-workflows
+      skipBackgroundRequests: true
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - monolith-workflows
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: signoz-api-key
+        namespace: monolith-workflows
+        synchronize: true
+        generateExisting: true
+        clone:
+          namespace: signoz
+          name: signoz-api-key


### PR DESCRIPTION
## Why

Follow-up to #3450. That PR added the `home.cluster_snapshot` table + read path but wired the refresh via `register_job`/`on_startup_jobs` — a **retired** mechanism. The in-process scheduler was removed (`app/main.py`); all scheduled work now runs as Argo CronWorkflows in `monolith-workflows`. So the refresh never ran, the snapshot row stayed empty, and the dashboard silently fell back to the live per-request 235-resource scan (verified in prod: no regression, but no speedup either).

## What

Wire the refresh as a CronWorkflow, mirroring `observability-stats-rollup` (which already scans cluster resources under a dedicated SA and snapshots to Postgres):

- **`app/jobs_main.py`**: `home-cluster-snapshot-refresh` command → `refresh_cluster_snapshot()`.
- **`chart/values.yaml`**: CronWorkflow, `* * * * *` (matches the frontend's 60s refresh), `serviceAccountName: monolith-stats`.
- **`home/__init__.py` + the two `on_startup_jobs` tests**: drop the dead `register_job` wiring, restoring `on_startup_jobs` to calendar-only.

### Also fixes firing alerts (opted-in scope)

The alerts section 401s because the monolith has `SIGNOZ_URL` but no `SIGNOZ_API_KEY` (pre-existing, independent of the snapshot). The `signoz-api-key` secret already exists in the `signoz` namespace and authenticates (verified HTTP 200 against `/api/v1/rules`):

- **`platform/kyverno`**: clone `signoz-api-key` from `signoz` into `monolith` (API live-fallback) and `monolith-workflows` (the CronWorkflow), the same pattern already used for the pg + clickhouse secrets.
- **`chart/templates/deployment.yaml`**: inject `SIGNOZ_API_KEY` (`optional: true`, so a not-yet-cloned key degrades to the prior 401 rather than wedging pod startup).
- **`platform/argo-workflows`**: the health rollup lists statefulsets + daemonsets too, so grant `monolith-stats` get/list on them (it already has pods/deployments/argocd-apps). Read-only; the scan's per-kind fail-soft tolerates the RBAC landing slightly after the job.

## Rollout / safety

- Platform charts deploy **path-based** (`targetRevision: HEAD`), so no version bump; monolith + public bump (0.285.166 / 0.89.85) to ship the CronWorkflow + jobs image.
- Validated locally: `helm template` renders the CronWorkflow (`schedules: ["* * * * *"]`, `monolith-stats` SA, `SIGNOZ_API_KEY` from the cloned secret) and both platform charts.
- No new migration (the table shipped in #3450). No new secret material in Git (reuses the 1Password-backed key via Kyverno).

🤖 Generated with [Claude Code](https://claude.com/claude-code)