### PR TITLE
fix(monolith): don't flag in-flight batch pods as unhealthy

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.85
+version: 0.89.87
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.85
+      targetRevision: 0.89.87
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.166
+version: 0.285.168
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/cluster/summarize.py
+++ b/projects/monolith/cluster/summarize.py
@@ -55,6 +55,11 @@ def _pod_status(obj: dict) -> dict:
             "ready": f"{ready}/{len(containers)}" if containers else None,
             "restarts": restarts or None,
             "reason": waiting,
+            # restartPolicy distinguishes run-to-completion pods (Jobs, Argo
+            # Workflow steps: Never/OnFailure) from long-running ones (Always).
+            # The health rollup uses it so an in-flight batch pod is not judged
+            # by a readiness invariant it is never meant to satisfy.
+            "restart_policy": (obj.get("spec") or {}).get("restartPolicy"),
         }
     )
 
@@ -217,6 +222,16 @@ def filter_logs(
 
 def _row_unhealthy(kind: str, row: dict) -> bool:
     if kind == "pods":
+        # Run-to-completion pods (Jobs, Argo Workflow / CronWorkflow steps:
+        # restartPolicy Never/OnFailure) are not meant to become Ready and churn
+        # through Pending -> ContainerCreating -> Running (with a wait sidecar
+        # that keeps ready at x/N, x != N) before exiting. Judged by the
+        # long-running checks below they always look unhealthy while in flight,
+        # so a per-minute health snapshot almost always catches one mid-run and
+        # reports the cluster unhealthy. Only a terminal Failed is unhealthy; a
+        # pending/initializing/running/succeeded batch pod is doing its job.
+        if row.get("restart_policy") in ("Never", "OnFailure"):
+            return row.get("phase") == "Failed"
         if row.get("reason"):
             return True
         phase = row.get("phase")

--- a/projects/monolith/cluster/summarize_test.py
+++ b/projects/monolith/cluster/summarize_test.py
@@ -88,6 +88,39 @@ class TestUnhealthy:
             "pods", {"phase": "Succeeded", "ready": "0/1"}
         )
 
+    def test_inflight_batch_pod_is_healthy(self):
+        # An Argo Workflow / Job pod (restartPolicy Never) that is mid-run reports
+        # ready=x/N (x != N) with a wait sidecar and never becomes Ready. It must
+        # not be flagged just for being in flight, else a per-minute snapshot
+        # constantly reports the cluster unhealthy.
+        assert not summarize._row_unhealthy(
+            "pods", {"phase": "Running", "ready": "0/2", "restart_policy": "Never"}
+        )
+
+    def test_pending_batch_pod_is_healthy(self):
+        assert not summarize._row_unhealthy(
+            "pods",
+            {
+                "phase": "Pending",
+                "reason": "ContainerCreating",
+                "restart_policy": "Never",
+            },
+        )
+
+    def test_failed_batch_pod_is_unhealthy(self):
+        # A terminal failure IS worth surfacing (failed Workflow pods are kept by
+        # podGC OnWorkflowSuccess, so they persist rather than flicker).
+        assert summarize._row_unhealthy(
+            "pods", {"phase": "Failed", "restart_policy": "Never"}
+        )
+
+    def test_running_unready_long_lived_pod_still_unhealthy(self):
+        # A Deployment pod (restartPolicy Always) stuck unready keeps the old
+        # behaviour: it is meant to be Ready, so x/N with x != N is unhealthy.
+        assert summarize._row_unhealthy(
+            "pods", {"phase": "Running", "ready": "0/1", "restart_policy": "Always"}
+        )
+
     def test_partial_deployment_is_unhealthy(self):
         assert summarize._row_unhealthy("deployments", {"ready": "1/3"})
 
@@ -146,6 +179,30 @@ class TestBuildHealth:
                     "status": {
                         "phase": "Succeeded",
                         "containerStatuses": [{"ready": False, "restartCount": 0}],
+                    },
+                }
+            ]
+        }
+        out = summarize.build_health(resources)
+        assert out["healthy"] is True
+        assert out["unhealthy"] == {}
+
+
+    def test_inflight_workflow_pod_is_healthy_end_to_end(self):
+        # Real in-flight Argo Workflow pod shape: restartPolicy Never, Running,
+        # main container not yet ready alongside the wait sidecar (ready 0/2).
+        # Exercises restart_policy extraction from spec through build_health.
+        resources = {
+            "pods": [
+                {
+                    "metadata": {"name": "knowledge-ingest-1783894500"},
+                    "spec": {"restartPolicy": "Never"},
+                    "status": {
+                        "phase": "Running",
+                        "containerStatuses": [
+                            {"ready": False, "restartCount": 0},
+                            {"ready": False, "restartCount": 0},
+                        ],
                     },
                 }
             ]

--- a/projects/monolith/cluster/summarize_test.py
+++ b/projects/monolith/cluster/summarize_test.py
@@ -187,7 +187,6 @@ class TestBuildHealth:
         assert out["healthy"] is True
         assert out["unhealthy"] == {}
 
-
     def test_inflight_workflow_pod_is_healthy_end_to_end(self):
         # Real in-flight Argo Workflow pod shape: restartPolicy Never, Running,
         # main container not yet ready alongside the wait sidecar (ready 0/2).

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.166
+      targetRevision: 0.285.168
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Symptom

The private dashboard intermittently shows a `monolith-workflows/<job>-<ts>` pod as an unhealthy workload (e.g. `knowledge-ingest-...`, `chat-drain-reminders-...`), even though the workflow **Succeeded** and its pod is gone.

## Root cause

`_row_unhealthy` applied a readiness invariant to every pod: `ready x/N` with `x != N` is unhealthy. That holds for Deployment/StatefulSet pods (meant to stay Ready) but is category-wrong for **run-to-completion** pods (Jobs, Argo Workflow / CronWorkflow steps: `restartPolicy: Never/OnFailure`). Those run a `main` + `wait` sidecar and exit without ever reaching `N/N`, so a pod caught mid-run always looks unhealthy.

The old live-per-request scan hit this only fleetingly. The new per-minute `home.cluster_snapshot` (PR #3451) almost always catches one of the many short-lived CronWorkflows in flight and **freezes** the cluster as "unhealthy" for up to 60s. Reproduced live: the snapshot showed `chat-drain-reminders` (0/2) and `observability-stats-rollup` (1/2), both `Running age=0m`.

## Fix

- `_pod_status` surfaces `restartPolicy`.
- `_row_unhealthy` treats a run-to-completion pod (`Never`/`OnFailure`) as unhealthy **only when terminally `Failed`** (failed Workflow pods are kept by `podGC: OnWorkflowSuccess`, so surfacing them is correct and not flickery). Long-running pods (`Always`) keep the existing readiness check.

Fixes both consumers of `build_health`: the dashboard health widget and the `k8s-health-summary` MCP tool. Backward compatible (a row without `restart_policy` falls through to the old logic).

## Tests

Added: in-flight batch pod healthy, pending/ContainerCreating batch pod healthy, failed batch pod unhealthy, long-lived unready pod still unhealthy, and an end-to-end `build_health` case with a real in-flight workflow pod shape (validates `restartPolicy` extraction from `spec`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)