### PR TITLE
fix(semgrep): align Route B perf to wall-vs-wall + concurrent PR gather

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.88
+version: 0.89.89
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.88
+      targetRevision: 0.89.89
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.169
+version: 0.285.170
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.169
+      targetRevision: 0.285.170
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/semgrep_scan/perf_harvest.py
+++ b/projects/monolith/semgrep_scan/perf_harvest.py
@@ -124,6 +124,18 @@ def scan_to_row(scan: dict) -> ScanPerf | None:
 
     findings_counts = scan.get("findingsCounts") or {}
     branch = scan.get("branch", "")
+    started = _parse_dt(scan.get("startedAt"))
+    completed = _parse_dt(scan.get("completedAt"))
+    # Aligned comparison basis: the managed scan's startedAt->completedAt WALL,
+    # to match Route B's request->post wall (perf_store.update_perf_total_time).
+    # Semgrep's own `totalTime` is engine-only (~40-45% of this wall: it strips
+    # their queue/checkout/upload), so comparing it to our engine time flattered
+    # us; wall-vs-wall is the honest full-request-to-result comparison. Fall back
+    # to totalTime only when a timestamp is missing.
+    if started is not None and completed is not None:
+        total_time = (completed - started).total_seconds()
+    else:
+        total_time = float(scan.get("totalTime") or 0)
     return ScanPerf(
         scan_id=int(scan["id"]),
         environment=env,
@@ -132,11 +144,11 @@ def scan_to_row(scan: dict) -> ScanPerf | None:
         branch=branch,
         scan_ref=branch,  # SMS has no separate PR ref field
         commit_sha=scan.get("commit", ""),
-        total_time=float(scan.get("totalTime") or 0),
+        total_time=total_time,
         findings_total=int(findings_counts.get("total") or 0),
         cli_version=scan.get("cliVersion", ""),
-        scan_started_at=_parse_dt(scan.get("startedAt")),
-        scan_completed_at=_parse_dt(scan.get("completedAt")),
+        scan_started_at=started,
+        scan_completed_at=completed,
     )
 
 

--- a/projects/monolith/semgrep_scan/perf_harvest_test.py
+++ b/projects/monolith/semgrep_scan/perf_harvest_test.py
@@ -71,7 +71,9 @@ def test_scan_to_row_managed_scan():
     assert row.branch == "main"
     assert row.scan_ref == "main"
     assert row.commit_sha == "abc123"
-    assert row.total_time == 12.75
+    # total_time is the startedAt->completedAt WALL (10:00:00 -> 10:00:13 = 13s),
+    # the aligned comparison basis, not Semgrep's engine-only totalTime (12.75).
+    assert row.total_time == 13.0
     assert row.findings_total == 3
     assert row.cli_version == "1.90.0"
     assert row.scan_started_at is not None
@@ -84,13 +86,27 @@ def test_scan_to_row_unspecified_returns_none():
 
 
 def test_scan_to_row_missing_findings_counts_and_total_time():
+    # With no timestamps AND no totalTime, total_time falls back to 0.0. The wall
+    # is preferred when both timestamps are present (see test above), so drop them
+    # here to exercise the fallback path.
     scan = _managed_scan()
     scan.pop("findingsCounts")
+    scan.pop("startedAt")
+    scan.pop("completedAt")
     scan["totalTime"] = None
     row = scan_to_row(scan)
     assert row is not None
     assert row.findings_total == 0
     assert row.total_time == 0.0
+
+
+def test_scan_to_row_falls_back_to_total_time_without_timestamps():
+    # No wall available (missing completedAt) -> use Semgrep's engine totalTime.
+    scan = _managed_scan()
+    scan.pop("completedAt")
+    row = scan_to_row(scan)
+    assert row is not None
+    assert row.total_time == 12.75
 
 
 @pytest.fixture(name="session")

--- a/projects/monolith/semgrep_scan/perf_store.py
+++ b/projects/monolith/semgrep_scan/perf_store.py
@@ -86,3 +86,24 @@ def upsert_scan_perf(session: Session, row: ScanPerf) -> None:
         session.add(existing)
 
     session.commit()
+
+
+def update_perf_total_time(session: Session, scan_id: int, total_time: float) -> None:
+    """Overwrite only ``total_time`` for an existing perf row, by ``scan_id``.
+
+    Route B's aligned runtime is the request->post wall time (webhook receipt to
+    commit-status posted), which is only known AFTER report.py has already
+    written the perf row with the engine scan_execution_duration. This lets the
+    webhook stamp the wall time onto that row without disturbing the other
+    columns (a full upsert would copy every _UPDATE_FIELD from a partial row and
+    blank them). No-op if the row is absent (e.g. the perf write was skipped).
+    The App-reported total_time stays the engine time; only this comparison row
+    moves to wall, so both sides of the dashboard are request->post vs
+    startedAt->completedAt.
+    """
+    existing = session.exec(select(ScanPerf).where(ScanPerf.scan_id == scan_id)).first()
+    if existing is None:
+        return
+    existing.total_time = total_time
+    session.add(existing)
+    session.commit()

--- a/projects/monolith/semgrep_scan/perf_store_test.py
+++ b/projects/monolith/semgrep_scan/perf_store_test.py
@@ -9,7 +9,12 @@ import pytest
 from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
-from semgrep_scan.perf_store import ScanPerf, _merge_decision, upsert_scan_perf
+from semgrep_scan.perf_store import (
+    ScanPerf,
+    _merge_decision,
+    update_perf_total_time,
+    upsert_scan_perf,
+)
 
 
 def test_merge_decision_no_existing_row_inserts():
@@ -64,6 +69,32 @@ def test_upsert_inserts_new_row(session):
     assert rows[0].scan_id == 1
     assert rows[0].environment == "route-b"
     assert rows[0].total_time == 12.5
+
+
+def test_update_perf_total_time_overwrites_only_total_time(session):
+    # Route B wall-time alignment: report.py wrote the engine time; the webhook
+    # stamps the request->post wall onto only total_time, leaving other columns.
+    upsert_scan_perf(
+        session,
+        ScanPerf(
+            scan_id=7,
+            environment="route-b",
+            total_time=3.0,
+            findings_total=4,
+            branch="feat/x",
+        ),
+    )
+    update_perf_total_time(session, scan_id=7, total_time=21.6)
+
+    row = session.exec(select(ScanPerf).where(ScanPerf.scan_id == 7)).one()
+    assert row.total_time == 21.6
+    assert row.findings_total == 4  # untouched
+    assert row.branch == "feat/x"  # untouched
+
+
+def test_update_perf_total_time_noop_when_absent(session):
+    update_perf_total_time(session, scan_id=999, total_time=5.0)
+    assert session.exec(select(ScanPerf).where(ScanPerf.scan_id == 999)).first() is None
 
 
 def test_upsert_updates_existing_row_in_place(session):

--- a/projects/monolith/semgrep_scan/router.py
+++ b/projects/monolith/semgrep_scan/router.py
@@ -159,6 +159,12 @@ _USER_AGENT = "homelab-semgrep-webhook"
 # background job page forever. 100 items/page * 30 pages = 3000 files is plenty.
 _MAX_FILE_PAGES = 30
 _GITHUB_TIMEOUT = 30.0
+# Max concurrent GitHub contents fetches when gathering a PR's changed files.
+# The per-file fetches are independent WAN round trips, so a serial loop made
+# gather scale linearly with diff size (SigNoz: up to 63s on big PRs); a bounded
+# gather collapses it toward one round trip. The bound keeps a large PR from
+# opening hundreds of sockets or tripping GitHub secondary rate limits.
+_GATHER_CONCURRENCY = 8
 
 
 def _verify_signature(body: bytes, signature_header: str | None) -> None:
@@ -270,15 +276,24 @@ async def _gather_files(repo: str, pr_number: int, head_sha: str) -> list[dict]:
     whose content cannot be fetched is dropped. Shares one AsyncClient across all
     the GitHub calls.
     """
-    files: list[dict] = []
     timeout = httpx.Timeout(_GITHUB_TIMEOUT)
     async with httpx.AsyncClient(timeout=timeout) as client:
         paths = await _list_changed_files(client, repo, pr_number)
-        for path in paths:
-            content = await _fetch_file_content(client, repo, path, head_sha)
-            if content is not None:
-                files.append({"path": path, "content": content})
-    return files
+
+        # Fetch changed-file contents concurrently (bounded). asyncio.gather
+        # preserves the input order, so files stay in changed-file order; a file
+        # whose content cannot be fetched is dropped.
+        sem = asyncio.Semaphore(_GATHER_CONCURRENCY)
+
+        async def _fetch(path: str) -> dict | None:
+            async with sem:
+                content = await _fetch_file_content(client, repo, path, head_sha)
+            if content is None:
+                return None
+            return {"path": path, "content": content}
+
+        fetched = await asyncio.gather(*(_fetch(path) for path in paths))
+    return [f for f in fetched if f is not None]
 
 
 # The commit-status context string GitHub shows on the PR. Namespaced so it is
@@ -344,6 +359,23 @@ async def _post_commit_status(
             repo,
             head_sha,
         )
+
+
+def _persist_perf_wall_time(scan_id: int, wall_time: float) -> None:
+    """Stamp the Route B perf row's aligned runtime (request->post wall time).
+
+    Runs in a worker thread (never on the event loop) with its own fresh session,
+    per the monolith async-handler rule. report.py wrote the row with the engine
+    scan_execution_duration; this overwrites only total_time with the full wall so
+    the perf dashboard compares wall-vs-wall against managed startedAt->completedAt.
+    """
+    from sqlmodel import Session
+
+    from app.db import get_engine
+    from semgrep_scan.perf_store import update_perf_total_time
+
+    with Session(get_engine()) as session:
+        update_perf_total_time(session, scan_id, wall_time)
 
 
 async def _scan_and_report(payload: dict[str, Any], received: float) -> None:
@@ -453,6 +485,19 @@ async def _scan_and_report(payload: dict[str, Any], received: float) -> None:
             )
             status_ms = (time.monotonic() - t_status) * 1000
             scan_pr_wall_time = time.monotonic() - received
+            # Align the Route B perf row to the request->post wall (webhook
+            # receipt -> commit status posted): report.py wrote it with the
+            # engine scan_execution_duration, but the perf dashboard compares
+            # wall-vs-wall against managed startedAt->completedAt. Off the event
+            # loop (own session) per the monolith async-handler rule; best-effort.
+            try:
+                await asyncio.to_thread(
+                    _persist_perf_wall_time, int(scan_id), scan_pr_wall_time
+                )
+            except Exception:
+                logger.exception(
+                    "semgrep webhook: failed to align Route B perf wall time"
+                )
             logger.info(
                 "semgrep webhook: reported %s#%s scan_id=%s findings=%s "
                 "scan_execution_duration=%.2fs scan_pr_wall_time=%.2fs project=%s "


### PR DESCRIPTION
## Align measurements — request→post vs startedAt→completedAt

The `/private/perf` board compared our engine-only `scan_execution_duration` against Semgrep's `totalTime`. Measured `scan_perf` data shows managed `totalTime` is only **~40–45% of that scan's own `startedAt→completedAt` window** — it strips their queue/checkout/upload. So the board was engine-vs-engine, but our number *also* hid our GitHub gather + report, flattering us and not matching developer-felt latency (`dfc98d30`: our engine 19.9s vs their engine 58.0s = 2.9x, but their wall was 136.0s).

Align **both** sides to the full request-to-result **wall**:
- **Managed:** `perf_harvest.scan_to_row` uses `completedAt − startedAt` (falls back to `totalTime` only if a timestamp is missing).
- **Route B:** the webhook stamps `scan_pr_wall_time` (receipt → status posted) onto the perf row via the new `update_perf_total_time`, *after* report.py wrote the engine time. App-reported `total_time` stays engine; only the comparison row moves to wall. The write runs in a worker thread (own session) per the monolith async-handler rule.

## Concurrent PR gather (perf improvement)

`_gather_files` fetched each changed file serially, so gather scaled linearly with diff size (SigNoz: up to 63s on big PRs). Replaced with a bounded `asyncio.gather` (semaphore 8); order and drop-on-failure preserved.

## Post-merge (once live)
Backfill existing rows: managed from stored timestamps, Route B wall from SigNoz `scan_pr_wall_time` logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dcykrf2Gao6v7iMkHrx5V3