### PR TITLE
fix(semgrep): keep homelab perf as request->scan-complete, only managed to wall

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.89
+version: 0.89.90
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.89
+      targetRevision: 0.89.90
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.170
+version: 0.285.171
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.170
+      targetRevision: 0.285.171
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/semgrep_scan/perf_harvest.py
+++ b/projects/monolith/semgrep_scan/perf_harvest.py
@@ -126,12 +126,12 @@ def scan_to_row(scan: dict) -> ScanPerf | None:
     branch = scan.get("branch", "")
     started = _parse_dt(scan.get("startedAt"))
     completed = _parse_dt(scan.get("completedAt"))
-    # Aligned comparison basis: the managed scan's startedAt->completedAt WALL,
-    # to match Route B's request->post wall (perf_store.update_perf_total_time).
-    # Semgrep's own `totalTime` is engine-only (~40-45% of this wall: it strips
-    # their queue/checkout/upload), so comparing it to our engine time flattered
-    # us; wall-vs-wall is the honest full-request-to-result comparison. Fall back
-    # to totalTime only when a timestamp is missing.
+    # Comparison basis: the managed scan's startedAt->completedAt window (their
+    # whole scan job). Semgrep's own `totalTime` is engine-only (~40-45% of this
+    # window: it strips their queue/checkout/upload), which understated their real
+    # turnaround against Route B's request-to-scan-complete time
+    # (scan_execution_duration). start->end is the comparable whole-scan-job
+    # number. Fall back to totalTime only when a timestamp is missing.
     if started is not None and completed is not None:
         total_time = (completed - started).total_seconds()
     else:

--- a/projects/monolith/semgrep_scan/perf_store.py
+++ b/projects/monolith/semgrep_scan/perf_store.py
@@ -86,24 +86,3 @@ def upsert_scan_perf(session: Session, row: ScanPerf) -> None:
         session.add(existing)
 
     session.commit()
-
-
-def update_perf_total_time(session: Session, scan_id: int, total_time: float) -> None:
-    """Overwrite only ``total_time`` for an existing perf row, by ``scan_id``.
-
-    Route B's aligned runtime is the request->post wall time (webhook receipt to
-    commit-status posted), which is only known AFTER report.py has already
-    written the perf row with the engine scan_execution_duration. This lets the
-    webhook stamp the wall time onto that row without disturbing the other
-    columns (a full upsert would copy every _UPDATE_FIELD from a partial row and
-    blank them). No-op if the row is absent (e.g. the perf write was skipped).
-    The App-reported total_time stays the engine time; only this comparison row
-    moves to wall, so both sides of the dashboard are request->post vs
-    startedAt->completedAt.
-    """
-    existing = session.exec(select(ScanPerf).where(ScanPerf.scan_id == scan_id)).first()
-    if existing is None:
-        return
-    existing.total_time = total_time
-    session.add(existing)
-    session.commit()

--- a/projects/monolith/semgrep_scan/perf_store_test.py
+++ b/projects/monolith/semgrep_scan/perf_store_test.py
@@ -9,12 +9,7 @@ import pytest
 from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
-from semgrep_scan.perf_store import (
-    ScanPerf,
-    _merge_decision,
-    update_perf_total_time,
-    upsert_scan_perf,
-)
+from semgrep_scan.perf_store import ScanPerf, _merge_decision, upsert_scan_perf
 
 
 def test_merge_decision_no_existing_row_inserts():
@@ -69,32 +64,6 @@ def test_upsert_inserts_new_row(session):
     assert rows[0].scan_id == 1
     assert rows[0].environment == "route-b"
     assert rows[0].total_time == 12.5
-
-
-def test_update_perf_total_time_overwrites_only_total_time(session):
-    # Route B wall-time alignment: report.py wrote the engine time; the webhook
-    # stamps the request->post wall onto only total_time, leaving other columns.
-    upsert_scan_perf(
-        session,
-        ScanPerf(
-            scan_id=7,
-            environment="route-b",
-            total_time=3.0,
-            findings_total=4,
-            branch="feat/x",
-        ),
-    )
-    update_perf_total_time(session, scan_id=7, total_time=21.6)
-
-    row = session.exec(select(ScanPerf).where(ScanPerf.scan_id == 7)).one()
-    assert row.total_time == 21.6
-    assert row.findings_total == 4  # untouched
-    assert row.branch == "feat/x"  # untouched
-
-
-def test_update_perf_total_time_noop_when_absent(session):
-    update_perf_total_time(session, scan_id=999, total_time=5.0)
-    assert session.exec(select(ScanPerf).where(ScanPerf.scan_id == 999)).first() is None
 
 
 def test_upsert_updates_existing_row_in_place(session):

--- a/projects/monolith/semgrep_scan/router.py
+++ b/projects/monolith/semgrep_scan/router.py
@@ -361,23 +361,6 @@ async def _post_commit_status(
         )
 
 
-def _persist_perf_wall_time(scan_id: int, wall_time: float) -> None:
-    """Stamp the Route B perf row's aligned runtime (request->post wall time).
-
-    Runs in a worker thread (never on the event loop) with its own fresh session,
-    per the monolith async-handler rule. report.py wrote the row with the engine
-    scan_execution_duration; this overwrites only total_time with the full wall so
-    the perf dashboard compares wall-vs-wall against managed startedAt->completedAt.
-    """
-    from sqlmodel import Session
-
-    from app.db import get_engine
-    from semgrep_scan.perf_store import update_perf_total_time
-
-    with Session(get_engine()) as session:
-        update_perf_total_time(session, scan_id, wall_time)
-
-
 async def _scan_and_report(payload: dict[str, Any], received: float) -> None:
     """Background job: gather changed files, scan on fc-invoke, report to the App.
 
@@ -485,19 +468,6 @@ async def _scan_and_report(payload: dict[str, Any], received: float) -> None:
             )
             status_ms = (time.monotonic() - t_status) * 1000
             scan_pr_wall_time = time.monotonic() - received
-            # Align the Route B perf row to the request->post wall (webhook
-            # receipt -> commit status posted): report.py wrote it with the
-            # engine scan_execution_duration, but the perf dashboard compares
-            # wall-vs-wall against managed startedAt->completedAt. Off the event
-            # loop (own session) per the monolith async-handler rule; best-effort.
-            try:
-                await asyncio.to_thread(
-                    _persist_perf_wall_time, int(scan_id), scan_pr_wall_time
-                )
-            except Exception:
-                logger.exception(
-                    "semgrep webhook: failed to align Route B perf wall time"
-                )
             logger.info(
                 "semgrep webhook: reported %s#%s scan_id=%s findings=%s "
                 "scan_execution_duration=%.2fs scan_pr_wall_time=%.2fs project=%s "


### PR DESCRIPTION
Correction to #3453. Homelab's Route B number (`scan_execution_duration` — from the fc-invoke scan request to us completing the scan) is the intended "our scan" measurement and stays unchanged. Only the **managed** side needed aligning: Semgrep's `totalTime` is engine-only (~40–45% of that scan's `startedAt→completedAt` window), which understated their real turnaround — so `perf_harvest` uses `startedAt→completedAt` (kept from #3453).

Reverts #3453's Route B `pr_wall_time` stamping (`_persist_perf_wall_time`, `update_perf_total_time` + tests); the perf row keeps `scan_execution_duration`. The concurrent PR gather stays.

Backfill: managed only, from stored start/end. Homelab rows untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dcykrf2Gao6v7iMkHrx5V3