### PR TITLE
feat(semgrep): route large PR diffs to a 6-vCPU semgrep-hi workload

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.75
+version: 0.4.76

--- a/projects/firecracker/substrate/chart/values.yaml
+++ b/projects/firecracker/substrate/chart/values.yaml
@@ -165,6 +165,31 @@ workloads:
     readyPath: /shim/ready
     sessioned: false
     requestTimeout: 90s
+  # semgrep-hi: the heavy multi-file diff route. Same warm mcp scan-server as
+  # `semgrep` (single-file engine, but it parallelizes a multi-file batch over
+  # target files), sized up to 6 vcpu + more memory so a large PR diff is matched
+  # in parallel instead of serially on one core. Measured (debug-pod sweep): a
+  # batch of N heavy files scales ~min(N, cores) - 6 vcpu does 8 heavy files in
+  # ~10.6s vs ~38.9s at 1 vcpu (~3.7x). It carries a ~0.9s/scan fixed thread-pool
+  # overhead that makes it a NET LOSS below ~5 files, so the monolith routes only
+  # large diffs here (semgrep_scan/router.py _HEAVY_ROUTE_MIN_FILES); small diffs
+  # stay on `semgrep`. concurrency:1 - big multi-file PRs are rare and this
+  # reserves 6 of node-4's 16 cores, so one at a time (queue the rare overlap).
+  # memMib 6144 covers a many-heavy-file parallel batch with headroom; a giant
+  # diff that still OOMs dies as a contained 503 (the per-VM memMib is the hard
+  # ceiling), never touching the node.
+  semgrep-hi:
+    image: semgrep-guest
+    rootfsPath: /disks/nvme-02/fc-invoke/semgrep/rootfs.ext4
+    harnessInit: /usr/local/bin/semgrep-guest-init
+    vcpus: 6
+    memMib: 6144
+    concurrency: 1
+    egressEnabled: false
+    warmBase: true
+    readyPath: /shim/ready
+    sessioned: false
+    requestTimeout: 90s
   # The semgrep-full workload (ADR tooling/011): a whole-repo INTERFILE scan. Same
   # semgrep-guest image as `semgrep`, but its lean init (harnessInit below) skips
   # the warm mcp scan-server and instead runs `semgrep scan --pro` as a subprocess
@@ -238,8 +263,9 @@ workloads:
 # A load test drives ONE workload to concurrency 16: semgrep 16 * 1536Mi = ~24Gi
 # or sandbox 16 * 512Mi = ~8Gi (a monolith one-run guard serializes load tests,
 # so they never stack). Even with a concurrent agent run (2 * 4096Mi = 8Gi), a
-# scheduled semgrep-full run (1 * 8192Mi = 8Gi), and ~1Gi daemon overhead the
-# worst case is ~41Gi, so 44Gi keeps margin (node-4 has 64Gi). This is a cgroup
+# scheduled semgrep-full run (1 * 8192Mi = 8Gi), a heavy-diff semgrep-hi run
+# (1 * 6144Mi = 6Gi), and ~1Gi daemon overhead the worst case is ~47Gi, so 50Gi
+# keeps margin (node-4 has 64Gi). This is a cgroup
 # CAP, not a request (that stays 2Gi below), so raising it does not overcommit
 # node scheduling; it only raises the OOM ceiling. semgrep-full is concurrency 1
 # and scheduled, so it rarely coincides with a manual load-test burst, but the
@@ -261,7 +287,7 @@ resources:
     cpu: 6000m
     memory: 2Gi
   limits:
-    memory: 44Gi
+    memory: 50Gi
 
 # Firecracker substrate paths on node-4. Driving real microVMs (privileged +
 # these host mounts) is gated behind `firecracker.enabled`; until then the

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.75
+      targetRevision: 0.4.76
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.90
+version: 0.89.91
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.90
+      targetRevision: 0.89.91
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.171
+version: 0.285.172
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.171
+      targetRevision: 0.285.172
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/semgrep_scan/client.py
+++ b/projects/monolith/semgrep_scan/client.py
@@ -93,6 +93,20 @@ async def scan_files(files: list[dict]) -> dict:
     return await _post_invoke("semgrep", files, SEMGREP_READ_TIMEOUT)
 
 
+async def scan_files_hi(files: list[dict]) -> dict:
+    """POST a large PR diff to the semgrep-hi fc-invoke workload and return findings.
+
+    Same wire shape and response as ``scan_files``, but targets ``/invoke/semgrep-hi``:
+    the warm mcp scan-server sized to 6 vCPU so a many-file diff is matched in
+    parallel over cores instead of serially on one. The monolith routes only large
+    diffs here (``router._HEAVY_ROUTE_MIN_FILES``); small diffs use ``scan_files``,
+    which is faster for them (semgrep-hi carries a fixed thread-pool overhead). Uses
+    the same read timeout as ``scan_files`` (a heavy diff scan is still seconds, and
+    parallelism keeps it under the daemon's 90s workload timeout).
+    """
+    return await _post_invoke("semgrep-hi", files, SEMGREP_READ_TIMEOUT)
+
+
 async def scan_files_full(files: list[dict]) -> dict:
     """POST the whole repo's file contents to the semgrep-full fc-invoke workload.
 

--- a/projects/monolith/semgrep_scan/router.py
+++ b/projects/monolith/semgrep_scan/router.py
@@ -42,7 +42,7 @@ from urllib.parse import quote
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request
 
-from semgrep_scan.client import scan_files
+from semgrep_scan.client import scan_files, scan_files_hi
 from semgrep_scan.report import report_pr_scan
 
 logger = logging.getLogger("monolith.semgrep.webhook")
@@ -165,6 +165,13 @@ _GITHUB_TIMEOUT = 30.0
 # gather collapses it toward one round trip. The bound keeps a large PR from
 # opening hundreds of sockets or tripping GitHub secondary rate limits.
 _GATHER_CONCURRENCY = 8
+# Route diffs with at least this many changed files to the heavier semgrep-hi
+# workload (6 vCPU, parallel multi-file match) instead of the warm 1-vCPU
+# `semgrep`. Measured crossover (debug-pod sweep): semgrep-hi carries a fixed
+# ~0.9s/scan thread-pool overhead that makes it a net loss below ~5 files, and a
+# clear win above (8 heavy files: ~10.6s vs ~38.9s at 1 vCPU). Tune from the
+# per-cohort perf data once collected.
+_HEAVY_ROUTE_MIN_FILES = 5
 
 
 def _verify_signature(body: bytes, signature_header: str | None) -> None:
@@ -420,7 +427,11 @@ async def _scan_and_report(payload: dict[str, Any], received: float) -> None:
         # measured on its own so it is both the App total_time and a clean
         # "how fast is our scanner" signal, independent of gather/report/status.
         t_scan = time.monotonic()
-        scan = await scan_files(files)
+        # Route large multi-file diffs to the heavier semgrep-hi workload (6 vCPU,
+        # parallel match); small diffs stay on the warm 1-vCPU `semgrep`, which is
+        # faster for them. Both share the same wire shape and response.
+        heavy = len(files) >= _HEAVY_ROUTE_MIN_FILES
+        scan = await (scan_files_hi(files) if heavy else scan_files(files))
         scan_execution_duration = time.monotonic() - t_scan
         if not isinstance(scan, dict) or scan.get("error"):
             logger.error(

--- a/projects/monolith/semgrep_scan/router_test.py
+++ b/projects/monolith/semgrep_scan/router_test.py
@@ -219,6 +219,44 @@ def _fake_github_client(files_pages, contents, *, status_calls=None, post_raises
     return _Client()
 
 
+def test_large_diff_routes_to_semgrep_hi(client):
+    # A PR touching >= _HEAVY_ROUTE_MIN_FILES scannable files routes to the heavier
+    # semgrep-hi workload; scan_files (the small-diff route) is not called.
+    files_pages = [
+        {"filename": f"pkg/mod{i}.py", "status": "modified"} for i in range(5)
+    ]
+    contents = {f"pkg/mod{i}.py": "x = 1\n" for i in range(5)}
+    report_result = {
+        "ok": True,
+        "scan_id": 101,
+        "findings_reported": 0,
+        "project": "jomcgi/homelab-selfhosted",
+        "org": "jomcgi",
+    }
+    with (
+        mock.patch.object(
+            webhook.httpx,
+            "AsyncClient",
+            return_value=_fake_github_client(files_pages, contents),
+        ),
+        mock.patch.object(webhook, "scan_files", new=mock.AsyncMock()) as scan,
+        mock.patch.object(
+            webhook,
+            "scan_files_hi",
+            new=mock.AsyncMock(return_value={"raw_cli_output": {"results": []}}),
+        ) as scan_hi,
+        mock.patch.object(
+            webhook, "report_pr_scan", new=mock.AsyncMock(return_value=report_result)
+        ),
+    ):
+        resp = _post(client, _pr_payload("synchronize"))
+        assert resp.status_code == 200
+
+    scan_hi.assert_awaited_once()
+    scan.assert_not_awaited()
+    assert len(scan_hi.await_args.args[0]) == 5
+
+
 def test_scan_and_report_happy_path(client):
     files_pages = [
         {"filename": "app/main.py", "status": "modified"},


### PR DESCRIPTION
The warm 1-vCPU `semgrep` workload matches a multi-file batch serially on one core, so large PR diffs are the slow tail (#3392-class: ~20s engine on 1 vCPU). This adds **`semgrep-hi`** — same warm mcp scan-server + shared semgrep rootfs, sized to **6 vCPU / 6144 MiB / concurrency 1** — so the batch is matched in parallel over cores.

Measured (debug-pod sweep): 8 heavy files **~10.6s at 6 vCPU vs ~38.9s at 1 vCPU (~3.7x)**. It carries a ~0.9s fixed thread-pool overhead that makes it a net loss below ~5 files, so the monolith routes only large diffs there.

- `substrate/chart/values.yaml`: `semgrep-hi` workload (reuses semgrep's rootfs + guest image, like `semgrep-full` — no new builder/pin); pod cap `44Gi → 50Gi` for its 6Gi worst-case (~47Gi total).
- `client.py`: `scan_files_hi → /invoke/semgrep-hi`.
- `router.py`: route to `scan_files_hi` when a diff touches `>= _HEAVY_ROUTE_MIN_FILES` (5) files; small diffs stay on `semgrep`.

Threshold is a sweep-derived starting point; tune from the per-cohort perf data (coming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dcykrf2Gao6v7iMkHrx5V3