### PR TITLE
feat(semgrep): collect per-cohort diff stats for the perf comparison

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.91
+version: 0.89.92
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.91
+      targetRevision: 0.89.92
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -897,6 +897,17 @@ py_test(
 )
 
 py_test(
+    name = "semgrep_cohorts_test",
+    srcs = ["semgrep_scan/cohorts_test.py"],
+    imports = ["."],
+    # gazelle:exclude semgrep_scan means this py_test is hand-added, not generated.
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "semgrep_perf_compare_test",
     srcs = ["semgrep_scan/perf_compare_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.172
+version: 0.285.173
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260712233000_semgrep_perf_cohort.sql
+++ b/projects/monolith/chart/migrations/20260712233000_semgrep_perf_cohort.sql
@@ -1,0 +1,11 @@
+-- Cohort metadata for the Route B vs Semgrep Managed perf comparison: the shape
+-- of the scanned diff (changed-file count, changed lines, per-language
+-- breakdown) so the dashboard can segment speedup by cohort and show which diff
+-- shapes are at parity vs a major speedup. Populated on route-b rows (a matched
+-- pair inherits the cohort by commit_sha), computed live from the PR's
+-- /pulls/{n}/files stats and backfilled for historical rows via the GitHub API.
+-- Nullable: existing rows stay NULL until backfilled.
+ALTER TABLE semgrep.scan_perf
+    ADD COLUMN IF NOT EXISTS file_count    INTEGER,
+    ADD COLUMN IF NOT EXISTS changed_lines INTEGER,
+    ADD COLUMN IF NOT EXISTS languages     JSONB;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:A8c46PYq1bB1DfHkGQBP/K1fRKY8PzySTy6oxIByK/A=
+h1:VF7OgHSrWAghs3m7Vf3nD/M20ip6ftykO5kbsCSmCmY=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -127,3 +127,4 @@ h1:A8c46PYq1bB1DfHkGQBP/K1fRKY8PzySTy6oxIByK/A=
 20260711210000_semgrep_scan_perf.sql h1:jgmMxdoWDd+eDAWLEI6uS5e8Vyr36VIj+74r6D/Svn0=
 20260711220000_chat_safeguards.sql h1:LE/nBwV/o6eyfSylKV2PKoj6/jluuDqs0dHKOLCHdWM=
 20260712000000_home_cluster_snapshot.sql h1:+9RRavaWXjyzk5iRiUSwBkZfdOPjKtuHNP4ywZLwMzs=
+20260712233000_semgrep_perf_cohort.sql h1:v8wnTdvoa85AVnyJG1BxEUDY74OBIG4IcuICmDBOjJw=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.172
+      targetRevision: 0.285.173
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/semgrep_scan/cohorts.py
+++ b/projects/monolith/semgrep_scan/cohorts.py
@@ -1,0 +1,66 @@
+"""Diff cohort extraction: the shape of a scanned PR diff (changed-file count,
+changed lines, per-language breakdown) for the perf comparison's per-cohort
+speedup segmentation.
+
+Shared by the live webhook (from the ``/pulls/{n}/files`` stats it already
+fetches) and the GitHub-API backfill, so both compute the identical numbers from
+the identical source. ``changed_lines`` is ``additions + deletions`` (the diff
+size) rather than "lines in file", precisely because that is what both paths get
+straight from the ``/pulls/{n}/files`` endpoint.
+"""
+
+from __future__ import annotations
+
+# Scannable extension -> language label (the fc-invoke semgrep guest's rule
+# languages). Keep in sync with router._SCANNABLE_EXTS.
+_EXT_LANG: dict[str, str] = {
+    ".py": "python",
+    ".go": "go",
+    ".jsx": "javascript",
+    ".js": "javascript",
+    ".tsx": "typescript",
+    ".ts": "typescript",
+    ".rs": "rust",
+}
+
+
+def language_for(path: str) -> str | None:
+    """The scan language for ``path`` by extension, or None if unscannable.
+
+    Longer extensions are checked first (``.jsx`` before ``.js``) so a ``.jsx``
+    file is not mislabeled by the ``.js`` suffix match.
+    """
+    for ext, lang in _EXT_LANG.items():
+        if path.endswith(ext):
+            return lang
+    return None
+
+
+def diff_cohort(entries: list[dict]) -> dict:
+    """Cohort metadata from GitHub ``/pulls/{n}/files`` entries.
+
+    Each entry is a file dict with ``filename``, ``status`` and the diff stats
+    ``additions``/``deletions``. Only scannable, non-removed files count (the set
+    actually scanned). Returns ``{file_count, changed_lines, languages}`` where
+    ``languages`` maps language -> changed lines.
+    """
+    file_count = 0
+    changed_lines = 0
+    languages: dict[str, int] = {}
+    for entry in entries:
+        if entry.get("status") == "removed":
+            continue
+        lang = language_for(entry.get("filename", ""))
+        if lang is None:
+            continue
+        lines = int(entry.get("additions", 0) or 0) + int(
+            entry.get("deletions", 0) or 0
+        )
+        file_count += 1
+        changed_lines += lines
+        languages[lang] = languages.get(lang, 0) + lines
+    return {
+        "file_count": file_count,
+        "changed_lines": changed_lines,
+        "languages": languages,
+    }

--- a/projects/monolith/semgrep_scan/cohorts_test.py
+++ b/projects/monolith/semgrep_scan/cohorts_test.py
@@ -1,0 +1,51 @@
+"""Unit tests for semgrep_scan.cohorts.diff_cohort (pure, no I/O)."""
+
+import pytest
+
+from semgrep_scan.cohorts import diff_cohort, language_for
+
+
+def _entry(filename, additions=0, deletions=0, status="modified"):
+    return {
+        "filename": filename,
+        "additions": additions,
+        "deletions": deletions,
+        "status": status,
+    }
+
+
+def test_language_for_maps_extensions():
+    assert language_for("app/main.py") == "python"
+    assert language_for("svc/h.go") == "go"
+    assert language_for("web/c.jsx") == "javascript"
+    assert language_for("web/c.js") == "javascript"
+    assert language_for("web/c.tsx") == "typescript"
+    assert language_for("web/c.ts") == "typescript"
+    assert language_for("core/lib.rs") == "rust"
+    assert language_for("README.md") is None
+
+
+def test_diff_cohort_counts_scannable_changed_lines_by_language():
+    entries = [
+        _entry("app/main.py", additions=10, deletions=2),
+        _entry("app/util.py", additions=3, deletions=0),
+        _entry("svc/handler.go", additions=5, deletions=5),
+        _entry("README.md", additions=100, deletions=100),  # unscannable -> skip
+        _entry("old/gone.py", status="removed"),  # removed -> skip
+    ]
+    cohort = diff_cohort(entries)
+    assert cohort["file_count"] == 3
+    assert cohort["changed_lines"] == 25  # 12 + 3 + 10
+    assert cohort["languages"] == {"python": 15, "go": 10}
+
+
+def test_diff_cohort_empty():
+    assert diff_cohort([]) == {
+        "file_count": 0,
+        "changed_lines": 0,
+        "languages": {},
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/projects/monolith/semgrep_scan/perf_store.py
+++ b/projects/monolith/semgrep_scan/perf_store.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
+from sqlalchemy import JSON, Column
 from sqlmodel import Field, Session, SQLModel, select
 
 
@@ -34,6 +35,15 @@ class ScanPerf(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-fa
     cli_version: str = ""
     scan_started_at: Optional[datetime] = None
     scan_completed_at: Optional[datetime] = None
+
+    # Cohort metadata (diff shape) for per-cohort speedup segmentation. Populated
+    # on route-b rows (a matched pair inherits it by commit_sha); languages is
+    # {language: changed_lines}. See semgrep_scan/cohorts.py.
+    file_count: Optional[int] = None
+    changed_lines: Optional[int] = None
+    languages: Optional[dict] = Field(
+        default=None, sa_column=Column(JSON, nullable=True)
+    )
 
 
 def _merge_decision(existing_env: str | None, new_env: str) -> str:
@@ -63,6 +73,9 @@ _UPDATE_FIELDS = (
     "cli_version",
     "scan_started_at",
     "scan_completed_at",
+    "file_count",
+    "changed_lines",
+    "languages",
 )
 
 

--- a/projects/monolith/semgrep_scan/report.py
+++ b/projects/monolith/semgrep_scan/report.py
@@ -561,6 +561,7 @@ async def report_pr_scan(
     project_id: Optional[str] = None,
     repo_url: Optional[str] = None,
     scan_execution_duration: Optional[float] = None,
+    cohort: Optional[dict] = None,
     dry_run: bool = False,
     is_full_scan: bool = False,
 ) -> dict[str, Any]:
@@ -585,6 +586,7 @@ async def report_pr_scan(
         project_id=project_id,
         repo_url=repo_url,
         scan_execution_duration=scan_execution_duration,
+        cohort=cohort,
         dry_run=dry_run,
         is_full_scan=is_full_scan,
     )
@@ -601,6 +603,7 @@ def _report_pr_scan_blocking(
     project_id: Optional[str] = None,
     repo_url: Optional[str] = None,
     scan_execution_duration: Optional[float] = None,
+    cohort: Optional[dict] = None,
     dry_run: bool = False,
     is_full_scan: bool = False,
 ) -> dict[str, Any]:
@@ -741,6 +744,11 @@ def _report_pr_scan_blocking(
                         cli_version=_sg_cli_version,
                         scan_started_at=_perf_now - timedelta(seconds=_perf_dur),
                         scan_completed_at=_perf_now,
+                        # Diff cohort (route-b only; a matched pair inherits it by
+                        # commit_sha). None for full scans / when unavailable.
+                        file_count=(cohort or {}).get("file_count"),
+                        changed_lines=(cohort or {}).get("changed_lines"),
+                        languages=(cohort or {}).get("languages"),
                     ),
                 )
         except Exception:

--- a/projects/monolith/semgrep_scan/router.py
+++ b/projects/monolith/semgrep_scan/router.py
@@ -43,6 +43,7 @@ import httpx
 from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request
 
 from semgrep_scan.client import scan_files, scan_files_hi
+from semgrep_scan.cohorts import diff_cohort
 from semgrep_scan.report import report_pr_scan
 
 logger = logging.getLogger("monolith.semgrep.webhook")
@@ -142,6 +143,104 @@ async def trigger_harvest(repo: str = "jomcgi/homelab") -> dict:
     return {"status": "started", "repo": repo}
 
 
+# Guards against overlapping cohort backfills.
+_cohort_backfill_in_flight = False
+_cohort_backfill_tasks: set[asyncio.Task] = set()
+
+
+async def _backfill_cohorts(repo: str) -> dict:
+    """Backfill diff-cohort metadata onto route-b perf rows that lack it.
+
+    For each route-b row whose ``scan_ref`` is a ``refs/pull/{N}/merge`` and whose
+    ``file_count`` is NULL, fetch the PR's ``/pulls/{N}/files`` (the same endpoint
+    and the same ``diff_cohort`` the live webhook uses) and stamp the cohort. DB
+    reads/writes go through worker threads (own sessions) per the async-handler
+    rule; the GitHub calls are async. Best-effort per row.
+    """
+    import re
+
+    from sqlmodel import Session, select
+
+    from app.db import get_engine
+    from semgrep_scan.perf_store import ScanPerf
+
+    def _needing() -> list[tuple[int, str]]:
+        with Session(get_engine()) as session:
+            rows = session.exec(
+                select(ScanPerf).where(
+                    ScanPerf.environment == "route-b",
+                    ScanPerf.file_count.is_(None),  # type: ignore[union-attr]
+                )
+            ).all()
+            return [(r.scan_id, r.scan_ref) for r in rows]
+
+    def _persist(scan_id: int, cohort: dict) -> None:
+        with Session(get_engine()) as session:
+            row = session.exec(
+                select(ScanPerf).where(ScanPerf.scan_id == scan_id)
+            ).first()
+            if row is None:
+                return
+            row.file_count = cohort["file_count"]
+            row.changed_lines = cohort["changed_lines"]
+            row.languages = cohort["languages"]
+            session.add(row)
+            session.commit()
+
+    rows = await asyncio.to_thread(_needing)
+    pr_re = re.compile(r"refs/pull/(\d+)/merge")
+    updated = skipped = 0
+    async with httpx.AsyncClient(timeout=httpx.Timeout(_GITHUB_TIMEOUT)) as client:
+        for scan_id, scan_ref in rows:
+            match = pr_re.match(scan_ref or "")
+            if not match:
+                skipped += 1
+                continue
+            try:
+                entries = await _list_changed_files(client, repo, int(match.group(1)))
+                await asyncio.to_thread(_persist, scan_id, diff_cohort(entries))
+                updated += 1
+            except Exception:
+                logger.exception("cohort backfill failed for scan %s", scan_id)
+                skipped += 1
+    logger.info(
+        "cohort backfill: updated=%d skipped=%d of %d route-b rows",
+        updated,
+        skipped,
+        len(rows),
+    )
+    return {"updated": updated, "skipped": skipped, "total": len(rows)}
+
+
+@internal_router.post("/backfill-cohorts")
+async def trigger_cohort_backfill(repo: str = "jomcgi/homelab") -> dict:
+    """Fire the one-time cohort backfill (GitHub API) as a background task.
+
+    Internal only. Populates the diff-cohort columns on historical route-b rows
+    from each PR's ``/pulls/{N}/files``; new rows get the cohort live in the
+    webhook. Idempotent (only touches rows with a NULL file_count).
+    """
+    global _cohort_backfill_in_flight
+    if _cohort_backfill_in_flight:
+        return {"status": "already-running", "repo": repo}
+
+    async def _run() -> None:
+        global _cohort_backfill_in_flight
+        _cohort_backfill_in_flight = True
+        try:
+            await _backfill_cohorts(repo)
+        except Exception:
+            logger.exception("trigger_cohort_backfill crashed for %s", repo)
+        finally:
+            _cohort_backfill_in_flight = False
+
+    task = asyncio.create_task(_run())
+    _cohort_backfill_tasks.add(task)
+    task.add_done_callback(_cohort_backfill_tasks.discard)
+    logger.info("trigger_cohort_backfill: launched cohort backfill for %s", repo)
+    return {"status": "started", "repo": repo}
+
+
 # PR actions worth scanning: a fresh PR, a new push to an open PR, and a reopen.
 # Everything else (labeled, closed, review requests, ...) is acked with no work.
 _SCAN_ACTIONS = {"opened", "synchronize", "reopened"}
@@ -219,15 +318,17 @@ def _is_scannable(path: str) -> bool:
 
 async def _list_changed_files(
     client: httpx.AsyncClient, repo: str, pr_number: int
-) -> list[str]:
-    """Return the scannable, non-removed changed-file paths for a PR (paginated).
+) -> list[dict]:
+    """Return the scannable, non-removed changed-file ENTRIES for a PR (paginated).
 
-    GET /repos/{repo}/pulls/{n}/files, 100 per page, following pages until a short
-    page or the page cap. Only files whose ``status`` is not ``removed`` and whose
-    extension is scannable are kept: a deleted file has no head content to fetch,
-    and an unscannable extension has no rules.
+    Each entry is the GitHub file object (``filename``, ``status``, ``additions``,
+    ``deletions``): callers need the path to fetch content AND the diff stats for
+    cohort metadata. GET /repos/{repo}/pulls/{n}/files, 100 per page, following
+    pages until a short page or the page cap. Only files whose ``status`` is not
+    ``removed`` and whose extension is scannable are kept: a deleted file has no
+    head content to fetch, and an unscannable extension has no rules.
     """
-    paths: list[str] = []
+    entries: list[dict] = []
     for page in range(1, _MAX_FILE_PAGES + 1):
         resp = await client.get(
             f"{_GITHUB_API}/repos/{repo}/pulls/{pr_number}/files",
@@ -243,10 +344,10 @@ async def _list_changed_files(
             status = entry.get("status", "")
             if status == "removed" or not _is_scannable(path):
                 continue
-            paths.append(path)
+            entries.append(entry)
         if len(batch) < 100:
             break
-    return paths
+    return entries
 
 
 async def _fetch_file_content(
@@ -276,16 +377,21 @@ async def _fetch_file_content(
         return None
 
 
-async def _gather_files(repo: str, pr_number: int, head_sha: str) -> list[dict]:
-    """Build the ``[{path, content}]`` scan input for a PR's changed files.
+async def _gather_files(
+    repo: str, pr_number: int, head_sha: str
+) -> tuple[list[dict], dict]:
+    """Build the ``[{path, content}]`` scan input plus the diff cohort for a PR.
 
-    Lists the scannable changed files then fetches each one's head content. A file
-    whose content cannot be fetched is dropped. Shares one AsyncClient across all
-    the GitHub calls.
+    Lists the scannable changed-file entries, computes the cohort (file count,
+    changed lines, per-language breakdown) from their diff stats, then fetches
+    each file's head content. A file whose content cannot be fetched is dropped
+    from the scan input but still counts toward the cohort (it was part of the
+    diff). Shares one AsyncClient across all the GitHub calls.
     """
     timeout = httpx.Timeout(_GITHUB_TIMEOUT)
     async with httpx.AsyncClient(timeout=timeout) as client:
-        paths = await _list_changed_files(client, repo, pr_number)
+        entries = await _list_changed_files(client, repo, pr_number)
+        cohort = diff_cohort(entries)
 
         # Fetch changed-file contents concurrently (bounded). asyncio.gather
         # preserves the input order, so files stay in changed-file order; a file
@@ -299,8 +405,10 @@ async def _gather_files(repo: str, pr_number: int, head_sha: str) -> list[dict]:
                 return None
             return {"path": path, "content": content}
 
-        fetched = await asyncio.gather(*(_fetch(path) for path in paths))
-    return [f for f in fetched if f is not None]
+        fetched = await asyncio.gather(
+            *(_fetch(entry["filename"]) for entry in entries)
+        )
+    return [f for f in fetched if f is not None], cohort
 
 
 # The commit-status context string GitHub shows on the PR. Namespaced so it is
@@ -413,7 +521,7 @@ async def _scan_and_report(payload: dict[str, Any], received: float) -> None:
             return
 
         t_gather = time.monotonic()
-        files = await _gather_files(repo, int(pr_number), head_sha)
+        files, cohort = await _gather_files(repo, int(pr_number), head_sha)
         gather_ms = (time.monotonic() - t_gather) * 1000
         if not files:
             logger.info(
@@ -452,6 +560,7 @@ async def _scan_and_report(payload: dict[str, Any], received: float) -> None:
             raw_cli_output=scan.get("raw_cli_output"),
             repo_url=repo_url,
             scan_execution_duration=scan_execution_duration,
+            cohort=cohort,
         )
         report_ms = (time.monotonic() - t_report) * 1000
 

--- a/projects/monolith/semgrep_scan/router_test.py
+++ b/projects/monolith/semgrep_scan/router_test.py
@@ -108,7 +108,9 @@ def _post(client, payload, *, event="pull_request", secret=_SECRET, sign=True):
 def test_valid_signature_accepted_and_dispatches(client):
     with (
         mock.patch.object(
-            webhook, "_gather_files", new=mock.AsyncMock(return_value=[])
+            webhook,
+            "_gather_files",
+            new=mock.AsyncMock(return_value=([], {})),
         ),
         mock.patch.object(webhook, "scan_files", new=mock.AsyncMock()) as scan,
     ):


### PR DESCRIPTION
Segments the Route B vs Semgrep-managed comparison by **diff shape** so we can see which cohorts are at parity vs a major speedup — the same per-customer segmentation Semgrep runs, now collected in homelab for the experiment.

Cohort = **changed-file count, changed lines, per-language breakdown**, from the PR's `/pulls/{n}/files` diff stats.

- **Migration:** nullable `file_count` / `changed_lines` / `languages` (JSONB) on `semgrep.scan_perf`.
- **`cohorts.py`:** shared `diff_cohort(entries)` — `changed_lines = additions+deletions`, so the live path and the backfill compute the identical number from the identical endpoint.
- **Live capture:** `_list_changed_files` now returns the file entries; `_gather_files` returns `(files, cohort)`, threaded through `report_pr_scan` onto the route-b row (a matched pair inherits it by `commit_sha`).
- **GH-API backfill:** `POST /internal/semgrep/backfill-cohorts` stamps historical route-b rows from `/pulls/{N}/files` (PR # from the `refs/pull/N/merge` scan_ref). Idempotent, reuses `_list_changed_files` + `diff_cohort`.

Dashboard cohort display is a follow-up; this collects the data. I'll trigger the backfill once it's live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dcykrf2Gao6v7iMkHrx5V3