### PR TITLE
feat(semgrep): per-cohort speedup segmentation on the perf dashboard

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.92
+version: 0.89.93
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.92
+      targetRevision: 0.89.93
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.173
+version: 0.285.174
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.173
+      targetRevision: 0.285.174
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/perf/+page.server.js
+++ b/projects/monolith/frontend/src/routes/private/perf/+page.server.js
@@ -9,6 +9,7 @@ export async function load({ fetch }) {
       return {
         comparisons: [],
         aggregates: null,
+        cohorts: null,
         distributions: null,
         windowStart: null,
         counts: null,
@@ -19,6 +20,7 @@ export async function load({ fetch }) {
     return {
       comparisons: body.comparisons ?? [],
       aggregates: body.aggregates ?? null,
+      cohorts: body.cohorts ?? null,
       distributions: body.distributions ?? null,
       windowStart: body.window_start ?? null,
       counts: body.counts ?? null,

--- a/projects/monolith/frontend/src/routes/private/perf/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/perf/+page.svelte
@@ -186,6 +186,66 @@
         {/each}
       </section>
 
+      {#if data.cohorts && data.cohorts.total_pairs > 0}
+        <section class="card cohorts">
+          <h2 class="section-label">Speedup by diff cohort</h2>
+          <p class="cohort-note">
+            {data.cohorts.total_pairs} matched PR pair{data.cohorts.total_pairs ===
+            1
+              ? ""
+              : "s"} segmented by diff shape &mdash; which cohorts are at parity vs
+            a major speedup.
+          </p>
+          <div class="cohort-grid">
+            {#each [["By changed files", data.cohorts.by_files], ["By changed lines", data.cohorts.by_lines], ["By language", data.cohorts.by_language]] as [title, groups]}
+              {#if groups && groups.length}
+                <div class="cohort-block">
+                  <h3 class="cohort-title">{title}</h3>
+                  <table class="cohort-table">
+                    <thead>
+                      <tr>
+                        <th>cohort</th>
+                        <th class="num">n</th>
+                        <th class="num">homelab</th>
+                        <th class="num">managed</th>
+                        <th class="num">speedup</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {#each groups as g}
+                        {@const sp = speedupLabel(g.speedup)}
+                        <tr>
+                          <td>{g.label}</td>
+                          <td class="num mono">{g.pairs}</td>
+                          <td class="num mono"
+                            >{formatDuration(g.homelab_median) ?? "-"}</td
+                          >
+                          <td class="num mono"
+                            >{formatDuration(g.managed_median) ?? "-"}</td
+                          >
+                          <td class="num mono">
+                            {#if sp}
+                              <span
+                                class="speedup"
+                                class:speedup--ok={sp.tone === "ok"}
+                                class:speedup--bad={sp.tone === "bad"}
+                                >{sp.text}</span
+                              >
+                            {:else}
+                              <span class="dim">&ndash;</span>
+                            {/if}
+                          </td>
+                        </tr>
+                      {/each}
+                    </tbody>
+                  </table>
+                </div>
+              {/if}
+            {/each}
+          </div>
+        </section>
+      {/if}
+
       <details class="detail">
         <summary class="detail-summary">
           Individual comparisons ({matchedComparisons.length} matched)
@@ -625,5 +685,53 @@
 
   .speedup--bad {
     color: var(--bad);
+  }
+
+  /* ── Cohort segmentation ── */
+  .cohorts {
+    margin-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .cohort-note {
+    margin: 0 0 8px;
+    font-size: 12px;
+    color: var(--ink-2);
+  }
+
+  .cohort-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 20px 28px;
+  }
+
+  .cohort-title {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--ink-2);
+    margin: 0 0 6px;
+  }
+
+  .cohort-table {
+    width: 100%;
+  }
+
+  .cohort-table thead th {
+    padding: 0 12px 6px 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .cohort-table tbody td {
+    padding: 5px 12px 5px 0;
+    border-bottom: 1px solid var(--line);
+    white-space: nowrap;
+  }
+
+  .cohort-table tbody tr:last-child td {
+    border-bottom: none;
   }
 </style>

--- a/projects/monolith/semgrep_scan/perf_compare.py
+++ b/projects/monolith/semgrep_scan/perf_compare.py
@@ -135,6 +135,20 @@ def _make_row(rb_row: Optional[dict], sms_row: Optional[dict], match_kind: str) 
         if rb_row is not None and sms_row is not None
         else None,
         "match_kind": match_kind,
+        # Diff cohort comes from the route-b row (the pair inherits it by commit);
+        # None when there is no route-b side or it was not backfilled.
+        "cohort": _cohort(rb_row),
+    }
+
+
+def _cohort(rb_row: Optional[dict]) -> Optional[dict]:
+    """The diff-shape cohort carried on a route-b row, or None."""
+    if rb_row is None or rb_row.get("file_count") is None:
+        return None
+    return {
+        "file_count": rb_row.get("file_count"),
+        "changed_lines": rb_row.get("changed_lines"),
+        "languages": rb_row.get("languages") or {},
     }
 
 
@@ -279,6 +293,112 @@ def build_aggregates(comparisons: list[dict]) -> dict:
             "findings_agree": sum(1 for rb, sms in findings_sides if rb == sms),
         }
     return out
+
+
+# (min, max_inclusive_or_None, label) buckets for cohort segmentation.
+_FILE_BUCKETS = [
+    (1, 1, "1 file"),
+    (2, 4, "2-4"),
+    (5, 9, "5-9"),
+    (10, 19, "10-19"),
+    (20, None, "20+"),
+]
+_LINE_BUCKETS = [
+    (0, 49, "<50"),
+    (50, 199, "50-199"),
+    (200, 499, "200-499"),
+    (500, None, "500+"),
+]
+
+
+def _bucket_label(value: int, buckets: list[tuple]) -> str | None:
+    for lo, hi, label in buckets:
+        if value >= lo and (hi is None or value <= hi):
+            return label
+    return None
+
+
+def _dominant_language(languages: dict) -> str | None:
+    """The language with the most changed lines in a cohort, or None."""
+    if not languages:
+        return None
+    return max(languages.items(), key=lambda kv: kv[1])[0]
+
+
+def _cohort_group(pairs: list[dict], key_fn) -> list[dict]:
+    """Group matched pairs by ``key_fn(pair)`` and summarise each group's speedup."""
+    groups: dict[str, list[dict]] = {}
+    for pair in pairs:
+        label = key_fn(pair)
+        if label is None:
+            continue
+        groups.setdefault(label, []).append(pair)
+    out = []
+    for label, group in groups.items():
+        homelab_median = _median([p["route_b"]["total_time"] for p in group])
+        managed_median = _median([p["sms"]["total_time"] for p in group])
+        out.append(
+            {
+                "label": label,
+                "pairs": len(group),
+                "homelab_median": homelab_median,
+                "managed_median": managed_median,
+                "speedup": (managed_median / homelab_median)
+                if homelab_median and homelab_median > 0
+                else None,
+            }
+        )
+    return out
+
+
+def build_cohort_aggregates(comparisons: list[dict]) -> dict:
+    """Segment matched PR pairs by diff shape so the page shows which cohorts are
+    at parity vs a major speedup.
+
+    Only two-sided PR pairs (not full scans) that carry a cohort and a speedup
+    count. Groups by changed-file-count bucket, changed-lines bucket, and dominant
+    language (the language with the most changed lines in the diff).
+    """
+    pairs = [
+        p
+        for p in comparisons
+        if p.get("route_b")
+        and p.get("sms")
+        and not p.get("is_full_scan")
+        and p.get("cohort")
+        and p.get("speedup") is not None
+    ]
+
+    def _ordered(items: list[dict], buckets: list[tuple]) -> list[dict]:
+        order = {label: i for i, (_, _, label) in enumerate(buckets)}
+        return sorted(items, key=lambda x: order.get(x["label"], 999))
+
+    by_files = _ordered(
+        _cohort_group(
+            pairs, lambda p: _bucket_label(p["cohort"]["file_count"], _FILE_BUCKETS)
+        ),
+        _FILE_BUCKETS,
+    )
+    by_lines = _ordered(
+        _cohort_group(
+            pairs,
+            lambda p: _bucket_label(
+                p["cohort"].get("changed_lines") or 0, _LINE_BUCKETS
+            ),
+        ),
+        _LINE_BUCKETS,
+    )
+    by_language = sorted(
+        _cohort_group(pairs, lambda p: _dominant_language(p["cohort"]["languages"])),
+        key=lambda x: x["pairs"],
+        reverse=True,
+    )
+    return {
+        "by_files": by_files,
+        "by_lines": by_lines,
+        "by_language": by_language,
+        "total_pairs": len(pairs),
+    }
 
 
 def build_distributions(route_b: list[dict], sms: list[dict]) -> dict:

--- a/projects/monolith/semgrep_scan/perf_compare_test.py
+++ b/projects/monolith/semgrep_scan/perf_compare_test.py
@@ -12,6 +12,7 @@ import pytest
 
 from semgrep_scan.perf_compare import (
     build_aggregates,
+    build_cohort_aggregates,
     build_comparisons,
     build_distributions,
 )
@@ -421,3 +422,76 @@ def test_distributions_empty_input_has_stable_shape():
                 "min": None,
                 "max": None,
             }
+
+
+# ── build_cohort_aggregates ──────────────────────
+
+
+def _cohort_pair(file_count, changed_lines, languages, homelab_t, managed_t):
+    return {
+        "is_full_scan": False,
+        "route_b": {"total_time": homelab_t},
+        "sms": {"total_time": managed_t},
+        "speedup": managed_t / homelab_t,
+        "cohort": {
+            "file_count": file_count,
+            "changed_lines": changed_lines,
+            "languages": languages,
+        },
+    }
+
+
+def test_build_cohort_aggregates_segments_by_files_lines_language():
+    comps = [
+        _cohort_pair(1, 10, {"python": 10}, 3.0, 45.0),
+        _cohort_pair(2, 30, {"python": 30}, 4.0, 44.0),
+        _cohort_pair(8, 300, {"go": 300}, 20.0, 60.0),
+    ]
+    out = build_cohort_aggregates(comps)
+    assert out["total_pairs"] == 3
+
+    by_files = {g["label"]: g["pairs"] for g in out["by_files"]}
+    assert by_files == {"1 file": 1, "2-4": 1, "5-9": 1}
+
+    by_lines = {g["label"]: g["pairs"] for g in out["by_lines"]}
+    assert by_lines == {"<50": 2, "200-499": 1}
+
+    by_lang = {g["label"]: g["pairs"] for g in out["by_language"]}
+    assert by_lang == {"python": 2, "go": 1}
+
+    one_file = next(g for g in out["by_files"] if g["label"] == "1 file")
+    assert one_file["speedup"] == 45.0 / 3.0
+
+
+def test_build_cohort_aggregates_ignores_pairs_without_cohort_or_full_scans():
+    comps = [
+        {
+            "is_full_scan": False,
+            "route_b": {"total_time": 3.0},
+            "sms": {"total_time": 40.0},
+            "speedup": 13.3,
+            "cohort": None,
+        },
+        {
+            "is_full_scan": True,
+            "route_b": {"total_time": 200.0},
+            "sms": {"total_time": 400.0},
+            "speedup": 2.0,
+            "cohort": {
+                "file_count": 5,
+                "changed_lines": 100,
+                "languages": {"python": 100},
+            },
+        },
+        {
+            "is_full_scan": False,
+            "route_b": None,
+            "sms": {"total_time": 40.0},
+            "speedup": None,
+            "cohort": None,
+        },
+    ]
+    out = build_cohort_aggregates(comps)
+    assert out["total_pairs"] == 0
+    assert out["by_files"] == []
+    assert out["by_language"] == []

--- a/projects/monolith/semgrep_scan/perf_router.py
+++ b/projects/monolith/semgrep_scan/perf_router.py
@@ -15,6 +15,7 @@ from sqlmodel import Session, select
 from app.db import get_session
 from semgrep_scan.perf_compare import (
     build_aggregates,
+    build_cohort_aggregates,
     build_comparisons,
     build_distributions,
 )
@@ -40,6 +41,9 @@ def _row_to_dict(row: ScanPerf) -> dict:
         "total_time": row.total_time,
         "findings_total": row.findings_total,
         "scan_completed_at": row.scan_completed_at,
+        "file_count": row.file_count,
+        "changed_lines": row.changed_lines,
+        "languages": row.languages,
     }
 
 
@@ -47,6 +51,7 @@ def _empty_response() -> dict:
     return {
         "comparisons": [],
         "aggregates": build_aggregates([]),
+        "cohorts": build_cohort_aggregates([]),
         "distributions": build_distributions([], []),
         "window_start": None,
         "counts": {"homelab": 0, "managed": 0},
@@ -86,6 +91,7 @@ async def get_perf(
     return {
         "comparisons": comparisons,
         "aggregates": build_aggregates(comparisons),
+        "cohorts": build_cohort_aggregates(comparisons),
         "distributions": build_distributions(homelab, managed),
         "window_start": window_start,
         "counts": {"homelab": len(homelab), "managed": len(managed)},


### PR DESCRIPTION
Adds the cohort view to `/private/perf`. `build_cohort_aggregates` groups matched PR pairs by **changed-file-count bucket, changed-lines bucket, and dominant language**, computing per-cohort median homelab/managed times and speedup. The router serves it as `cohorts`; the page renders a "Speedup by diff cohort" card so we can see which diff shapes are at parity vs a major speedup.

Consumes the cohort columns collected in #3456 (route-b rows; pairs inherit by `commit_sha`). Pure aggregation over the existing `/api/semgrep/perf` payload — no new query.

Follows: #3455 (semgrep-hi), #3456 (cohort data + GH-API backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dcykrf2Gao6v7iMkHrx5V3