### PR TITLE
fix(cilium): add bootstrap:true + k3s CNI settings (pre-window correction)

### DIFF
--- a/projects/platform/cilium/bootstrap/cilium-helmchart.yaml
+++ b/projects/platform/cilium/bootstrap/cilium-helmchart.yaml
@@ -35,8 +35,13 @@ spec:
     # k8sServiceHost/Port omitted on purpose (see ../values.yaml): kube-proxy
     # routes the kubernetes Service, and 127.0.0.1 would be wrong on the agent.
     # cni.exclusive: false lets Cilium coexist with k3s CNI config management.
+    # confPath/binPath point at k3s's real CNI dirs (from `k3s crictl info`):
+    # Cilium's defaults (/etc/cni/net.d, /opt/cni/bin) are dirs k3s never reads,
+    # so without these the node comes up with no usable CNI after the flip.
     cni:
       exclusive: false
+      confPath: /var/lib/rancher/k3s/agent/etc/cni/net.d
+      binPath: /var/lib/rancher/k3s/data/cni
 
     ipam:
       mode: cluster-pool

--- a/projects/platform/cilium/bootstrap/cilium-helmchart.yaml
+++ b/projects/platform/cilium/bootstrap/cilium-helmchart.yaml
@@ -20,10 +20,23 @@ spec:
   repo: https://helm.cilium.io
   version: 1.19.5
   targetNamespace: kube-system
+  # bootstrap: true is REQUIRED for a CNI installed through the k3s
+  # helm-controller. It runs the Helm install Job on the HOST network with
+  # control-plane node selection and tolerations (NodeNotReady,
+  # NetworkUnavailable, uninitialized, Etcd, control-plane), so the install can
+  # run BEFORE any CNI exists. Without it the install Job is unschedulable (no
+  # pod networking is available yet) and the cluster comes up with no CNI at all.
+  # failurePolicy: abort fails loudly instead of retry-looping a broken install.
+  bootstrap: true
+  failurePolicy: abort
   valuesContent: |-
     kubeProxyReplacement: false
-    k8sServiceHost: 127.0.0.1
-    k8sServicePort: 6443
+
+    # k8sServiceHost/Port omitted on purpose (see ../values.yaml): kube-proxy
+    # routes the kubernetes Service, and 127.0.0.1 would be wrong on the agent.
+    # cni.exclusive: false lets Cilium coexist with k3s CNI config management.
+    cni:
+      exclusive: false
 
     ipam:
       mode: cluster-pool

--- a/projects/platform/cilium/values.yaml
+++ b/projects/platform/cilium/values.yaml
@@ -14,8 +14,13 @@ cilium:
 
   # Coexist with k3s's own CNI config management rather than taking the CNI conf
   # directory exclusively (k3s writes and owns it). Recommended for k3s+Cilium.
+  # confPath/binPath point at k3s's real CNI dirs (from `k3s crictl info`):
+  # Cilium's defaults (/etc/cni/net.d, /opt/cni/bin) are dirs k3s never reads, so
+  # without these overrides a node comes up with no usable CNI after the flip.
   cni:
     exclusive: false
+    confPath: /var/lib/rancher/k3s/agent/etc/cni/net.d
+    binPath: /var/lib/rancher/k3s/data/cni
 
   ipam:
     mode: cluster-pool

--- a/projects/platform/cilium/values.yaml
+++ b/projects/platform/cilium/values.yaml
@@ -5,8 +5,17 @@
 # under the `cilium:` subchart key to reach the upstream chart's values.
 cilium:
   kubeProxyReplacement: false # keep k3s kube-proxy (deferred item)
-  k8sServiceHost: 127.0.0.1 # k3s: reach apiserver during bootstrap
-  k8sServicePort: 6443
+
+  # k8sServiceHost/Port intentionally NOT set. With kubeProxyReplacement=false,
+  # kube-proxy already routes the in-cluster kubernetes Service, so cilium-agent
+  # (hostNetwork) reaches the apiserver through it on every node. A literal
+  # 127.0.0.1 would be correct on servers but WRONG on the node-4 agent, which
+  # has no local apiserver.
+
+  # Coexist with k3s's own CNI config management rather than taking the CNI conf
+  # directory exclusively (k3s writes and owns it). Recommended for k3s+Cilium.
+  cni:
+    exclusive: false
 
   ipam:
     mode: cluster-pool


### PR DESCRIPTION
Pre-flight for the Cilium cutover window found the merged bootstrap manifest would **wedge the cluster**: the k3s helm-controller install Job for a CNI needs `spec.bootstrap: true` to run on the host network before any CNI exists. Without it the Job is unschedulable and the cluster comes up with no CNI.

- Add `bootstrap: true` + `failurePolicy: abort` to the bootstrap HelmChart CR
- Drop `k8sServiceHost/Port` (127.0.0.1 is wrong on the node-4 agent; unnecessary with kubeProxyReplacement=false since kube-proxy routes the kubernetes Service)
- `cni.exclusive: false` so Cilium coexists with k3s CNI config management

Validated against the k3s helm-controller CRD docs (Cilium is the canonical bootstrap example) and the Cilium k3s install guide. Render-verified: `cni-exclusive: "false"` present, `k8s-service-host` gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)