### PR TITLE
feat(embervm): dual-arch apko image + chart wiring + ArgoCD app (PR-A deploy)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -501,7 +501,11 @@ apko.translate_lock(
     name = "whatsapp_lock",
     lock = "//projects/monolith/whatsapp:apko.lock.json",
 )
-use_repo(apko, "fc_invoke_lock", "git_mirror_lock", "grimoire_frontend_lock", "harness_lock", "monolith_frontend_lock", "rootfs_builder_lock", "sandbox_guest_lock", "semgrep_guest_lock", "visual_chromium_lock", "whatsapp_lock")
+apko.translate_lock(
+    name = "embervm_lock",
+    lock = "//projects/embervm/image:apko.lock.json",
+)
+use_repo(apko, "embervm_lock", "fc_invoke_lock", "git_mirror_lock", "grimoire_frontend_lock", "harness_lock", "monolith_frontend_lock", "rootfs_builder_lock", "sandbox_guest_lock", "semgrep_guest_lock", "visual_chromium_lock", "whatsapp_lock")
 
 # Download multiarch archives (binaries from zip files)
 multiarch_http_archive = use_repo_rule("//bazel/tools/http:multiarch_http_archive.bzl", "multiarch_http_archive")

--- a/bazel/erlang/repositories.bzl
+++ b/bazel/erlang/repositories.bzl
@@ -47,10 +47,14 @@ exports_files(["bin/elixir"], visibility = ["//visibility:public"])
 
 def _erlang_impl(_ctx):
     http_archive(
+        # OTP version MUST match the apko image's Wolfi erlang-27 (27.3.4.2)
+        # exactly: an include_erts:false release pins exact OTP app versions in
+        # its .boot, so a build/runtime patch mismatch fails the pod at boot. If
+        # Wolfi's erlang-27 bumps, re-pin both this and the image package together.
         name = "otp_ubuntu2204_amd64",
-        urls = ["https://builds.hex.pm/builds/otp/ubuntu-22.04/OTP-27.3.4.14.tar.gz"],
-        sha256 = "0045c32b7c41b1924d68c9d51958aab609a09447a79298c42bd87bdded0827e7",
-        strip_prefix = "OTP-27.3.4.14",
+        urls = ["https://builds.hex.pm/builds/otp/ubuntu-22.04/OTP-27.3.4.2.tar.gz"],
+        sha256 = "32c3ee239855556350f9700cf942a0a70b60228a277f314397a709e992345dfc",
+        strip_prefix = "OTP-27.3.4.2",
         build_file_content = _OTP_BUILD,
     )
     http_archive(

--- a/bazel/images/BUILD
+++ b/bazel/images/BUILD
@@ -29,6 +29,8 @@ multirun(
     commands = [
         "//bazel/tools/hf2oci:image.push",
         "//bazel/tools/image:image.push",
+        "//projects/embervm/chart:chart.push",
+        "//projects/embervm/image:image.push",
         "//projects/firecracker/git-mirror/chart:chart.push",
         "//projects/firecracker/git-mirror:image.push",
         "//projects/firecracker/goosecracker/guest-init:image.push",

--- a/projects/embervm/chart/BUILD
+++ b/projects/embervm/chart/BUILD
@@ -1,0 +1,13 @@
+load("//bazel/helm:defs.bzl", "helm_chart")
+
+# EmberVM control-plane chart. The control-plane image tag is pinned into
+# values.image at build time from the image's .info provider (CI rebuilds the
+# image with a stamped tag; the chart version bump is what ArgoCD pulls).
+helm_chart(
+    name = "chart",
+    images = {
+        "image": "//projects/embervm/image:image.info",
+    },
+    publish = True,
+    visibility = ["//overlays:__subpackages__"],
+)

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.0
+version: 0.1.1

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -63,7 +63,14 @@ spec:
           volumeMounts:
             - name: oplog
               mountPath: /var/lib/embervm
+            # The OTP release writes runtime scratch (extracted vm.args, boot
+            # files) to RELEASE_TMP=/tmp; the rootfs is read-only, so /tmp is a
+            # writable emptyDir. RELEASE_TMP is set in the image env (apko.yaml).
+            - name: tmp
+              mountPath: /tmp
       volumes:
         - name: oplog
           persistentVolumeClaim:
             claimName: {{ include "embervm.fullname" . }}-oplog
+        - name: tmp
+          emptyDir: {}

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
         {{- include "embervm.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "embervm.serviceAccountName" . }}
+      {{- if .Values.imagePullSecret.enabled }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret.name }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/projects/embervm/chart/templates/image-pull-secret.yaml
+++ b/projects/embervm/chart/templates/image-pull-secret.yaml
@@ -1,0 +1,17 @@
+{{- /*
+GHCR pull credentials (dockerconfigjson) synced from 1Password, so the kubelet
+can pull the private control-plane image. embervm runs in its own namespace, so
+it creates its own secret (fc-invoke reuses the monolith namespace's).
+*/}}
+{{- if and .Values.imagePullSecret.enabled .Values.imagePullSecret.create }}
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: {{ .Values.imagePullSecret.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "embervm.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.imagePullSecret.onepassword.itemPath | quote }}
+{{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -11,6 +11,16 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+# GHCR pull credentials. The control-plane image is private, and embervm runs in
+# its own namespace (unlike fc-invoke, which reuses the monolith namespace's
+# secret), so it creates its own OnePasswordItem-synced dockerconfigjson.
+imagePullSecret:
+  enabled: true
+  create: true
+  name: ghcr-imagepull-secret
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/ghcr-read-permissions"
+
 # Control-plane resources sized small to start (SigNoz 7-day-peak resizing later).
 # CPU is a request only (no limit) per the repo convention; memory request == limit.
 resources:

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.0
+      targetRevision: 0.1.1
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: embervm
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
+    - repoURL: ghcr.io/jomcgi/homelab/charts
+      chart: embervm
+      targetRevision: 0.1.0
+      helm:
+        valueFiles:
+          - $values/projects/embervm/deploy/values.yaml
+    # Git repo for environment-specific values.
+    - repoURL: https://github.com/jomcgi/homelab.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    # Own namespace; nothing monolith-coupled.
+    namespace: embervm
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/projects/embervm/deploy/kustomization.yaml
+++ b/projects/embervm/deploy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - application.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -1,0 +1,10 @@
+# Cluster-specific overrides for the EmberVM control plane. The image tag is
+# pinned into the chart at build time (helm_chart images=), so it is not set
+# here. Defaults in the chart are sized small to start (SigNoz 7-day-peak
+# resizing later).
+opLog:
+  storageClass: longhorn
+  # A PVC provides DURABILITY for the SQLite op-log, not availability: the
+  # Deployment is Recreate + 1 replica because SQLite is single-writer and the
+  # volume is RWO.
+  size: 2Gi

--- a/projects/embervm/image/BUILD
+++ b/projects/embervm/image/BUILD
@@ -1,0 +1,14 @@
+load("//bazel/tools/oci:apko_image.bzl", "apko_image")
+
+# EmberVM control-plane image: the Wolfi + erlang-27 base (apko.yaml) with the
+# control-plane OTP release layered at /opt/embervm. The release is
+# architecture-independent .beam (include_erts:false), so it is a regular tar
+# used for both arches; apko resolves erlang-27 per arch. Entrypoint (from
+# apko.yaml) is /opt/embervm/bin/embervm start.
+apko_image(
+    name = "image",
+    config = "apko.yaml",
+    contents = "@embervm_lock//:contents",
+    repository = "ghcr.io/jomcgi/homelab/projects/embervm/image",
+    tars = ["//projects/embervm/control:release_tar"],
+)

--- a/projects/embervm/image/apko.lock.json
+++ b/projects/embervm/image/apko.lock.json
@@ -1,0 +1,601 @@
+{
+  "version": "v1",
+  "config": {
+    "name": "apko.yaml",
+    "checksum": "sha256-q0UigOyAi9KZRIl8BQcSUQSnOj8fhClWWC3DCISdCmE="
+  },
+  "contents": {
+    "keyring": [
+      {
+        "name": "packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "url": "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"
+      }
+    ],
+    "build_repositories": [],
+    "runtime_repositories": [],
+    "repositories": [
+      {
+        "name": "packages.wolfi.dev/os/x86_64",
+        "url": "https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz",
+        "architecture": "x86_64"
+      },
+      {
+        "name": "packages.wolfi.dev/os/aarch64",
+        "url": "https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz",
+        "architecture": "aarch64"
+      }
+    ],
+    "packages": [
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1932",
+          "checksum": "sha1-mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+        },
+        "data": {
+          "range": "bytes=1933-13952",
+          "checksum": "sha256-5jOBVeXTWJEbL+Cnxj5Nu4klEL4SEB7IDMzT96rbkkA="
+        },
+        "checksum": "Q1mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20260413-r0.apk",
+        "version": "20260413-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7872",
+          "checksum": "sha1-KyCdEL20IKE+B7DKW97GLXu2QLM="
+        },
+        "data": {
+          "range": "bytes=7873-137518",
+          "checksum": "sha256-foyxNKCWc3UQM3Kq5on+Gt/2d+HlzCUl+1lqiaviWE8="
+        },
+        "checksum": "Q1KyCdEL20IKE+B7DKW97GLXu2QLM="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9951",
+          "checksum": "sha1-v4FvRKA29cOT2WtAXaWZBCzRXaU="
+        },
+        "data": {
+          "range": "bytes=9952-105490",
+          "checksum": "sha256-ExYZSr5G/sH+fzFe+TjVUTTj/GQ1Qbjx8MMEh+6ZxE0="
+        },
+        "checksum": "Q1v4FvRKA29cOT2WtAXaWZBCzRXaU="
+      },
+      {
+        "name": "glibc-locale-posix",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13015",
+          "checksum": "sha1-npirsSp9Qt3Aa1n8CaC2i99nv8A="
+        },
+        "data": {
+          "range": "bytes=13016-89758",
+          "checksum": "sha256-qXzcGBEELIJays9BPEo77JB6Qr5gMKFbZteJHEuthAI="
+        },
+        "checksum": "Q1npirsSp9Qt3Aa1n8CaC2i99nv8A="
+      },
+      {
+        "name": "glibc",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13257",
+          "checksum": "sha1-XSTHGW6PUOUepKQvlUCPEpu+my0="
+        },
+        "data": {
+          "range": "bytes=13258-3077429",
+          "checksum": "sha256-C538Z51QWuZPy/fxQGBCBbpulG8dVbn1OeaW+JsKoXQ="
+        },
+        "checksum": "Q1XSTHGW6PUOUepKQvlUCPEpu+my0="
+      },
+      {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13051",
+          "checksum": "sha1-Dc94e4JF2fG8/SX4PWCAtLjItu4="
+        },
+        "data": {
+          "range": "bytes=13052-147283",
+          "checksum": "sha256-oI72DIuJLqlUM/LSFYKdgbxsaYUZgfThezkV95CHQPk="
+        },
+        "checksum": "Q1Dc94e4JF2fG8/SX4PWCAtLjItu4="
+      },
+      {
+        "name": "libxcrypt",
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.5.2-r3.apk",
+        "version": "4.5.2-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8536",
+          "checksum": "sha1-I0YlF5JXljMqn3nnsq4AWUw6X/8="
+        },
+        "data": {
+          "range": "bytes=8537-106099",
+          "checksum": "sha256-mzRytDzhPafMZpD3kpn03C6x2XCNuG0nZ1F3Bjo+Jx4="
+        },
+        "checksum": "Q1I0YlF5JXljMqn3nnsq4AWUw6X/8="
+      },
+      {
+        "name": "libcrypt1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13067",
+          "checksum": "sha1-/MS3Zb1Y/+sboqr3bltHEFCEkqE="
+        },
+        "data": {
+          "range": "bytes=13068-14685",
+          "checksum": "sha256-ePacrwddp1Us3l5Rg2i8ieOZi17FUQjiVMtw2syPQBE="
+        },
+        "checksum": "Q1/MS3Zb1Y/+sboqr3bltHEFCEkqE="
+      },
+      {
+        "name": "busybox",
+        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.37.0-r61.apk",
+        "version": "1.37.0-r61",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10913",
+          "checksum": "sha1-Dc1coU0swhMsnFh4BnVin4Y/z6U="
+        },
+        "data": {
+          "range": "bytes=10914-430452",
+          "checksum": "sha256-Lp5skr4+yaxDhdl+G39Z7VC8YLLcwNh+fGvRe0T6bj0="
+        },
+        "checksum": "Q1Dc1coU0swhMsnFh4BnVin4Y/z6U="
+      },
+      {
+        "name": "zlib",
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.2-r3.apk",
+        "version": "1.3.2-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8782",
+          "checksum": "sha1-d+xgnhv2qmmnyUpkIEMLv/Ccfts="
+        },
+        "data": {
+          "range": "bytes=8783-70985",
+          "checksum": "sha256-GtMaz7tc+6/gw51/jRq2trQH8bshZpL66etBeg87OHE="
+        },
+        "checksum": "Q1d+xgnhv2qmmnyUpkIEMLv/Ccfts="
+      },
+      {
+        "name": "libstdc++",
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9949",
+          "checksum": "sha1-0G/kziut8KEYt22cLifRa9QA+HQ="
+        },
+        "data": {
+          "range": "bytes=9950-1261924",
+          "checksum": "sha256-+PxUlxtKRnSh9H8NjtevLTb3x4S8Bl3jFaJMzHYEGlg="
+        },
+        "checksum": "Q10G/kziut8KEYt22cLifRa9QA+HQ="
+      },
+      {
+        "name": "libcrypto3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.6.3-r3.apk",
+        "version": "3.6.3-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10990",
+          "checksum": "sha1-8czJwPp28PlmrUy6evlca3lfXlk="
+        },
+        "data": {
+          "range": "bytes=10991-2439998",
+          "checksum": "sha256-Gtu+CyjMO2oH9qFjvJKo2t0zE0aDLG2dwtmDVnll8/4="
+        },
+        "checksum": "Q18czJwPp28PlmrUy6evlca3lfXlk="
+      },
+      {
+        "name": "ncurses-terminfo-base",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.6.20260711-r0.apk",
+        "version": "6.6.20260711-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10344",
+          "checksum": "sha1-pVN+YvFtG69jaMZJt1Tqh20wICg="
+        },
+        "data": {
+          "range": "bytes=10345-117892",
+          "checksum": "sha256-60tsu38al1Llm+/RtctrJ6trjIy+aNm+CwLwZSIN3C0="
+        },
+        "checksum": "Q1pVN+YvFtG69jaMZJt1Tqh20wICg="
+      },
+      {
+        "name": "ncurses",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.6.20260711-r0.apk",
+        "version": "6.6.20260711-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10489",
+          "checksum": "sha1-oPiv8opB0FpEKDHei2gycB7Lcsk="
+        },
+        "data": {
+          "range": "bytes=10490-621030",
+          "checksum": "sha256-tq1Y6IreKkDvbO6vHEb/+oysUnBVBfw7uPrxYQ9s3oQ="
+        },
+        "checksum": "Q1oPiv8opB0FpEKDHei2gycB7Lcsk="
+      },
+      {
+        "name": "erlang-27",
+        "url": "https://packages.wolfi.dev/os/x86_64/erlang-27-27.3.4.2-r0.apk",
+        "version": "27.3.4.2-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-3584",
+          "checksum": "sha1-rJdBe8yrCE2eeSuWmqBVnFaho5Y="
+        },
+        "data": {
+          "range": "bytes=3585-55274638",
+          "checksum": "sha256-nolWnrLMGP3mMiTiRKWQdzagj1wl44H42OhTEoEZnyw="
+        },
+        "checksum": "Q1rJdBe8yrCE2eeSuWmqBVnFaho5Y="
+      },
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1962",
+          "checksum": "sha1-FcjlR8BAUcyRjMQxsc/f5gWSv8I="
+        },
+        "data": {
+          "range": "bytes=1963-13980",
+          "checksum": "sha256-jYse4NUqE3SQbsor532PGqEhuLikUOl38/yf1PJA1nY="
+        },
+        "checksum": "Q1FcjlR8BAUcyRjMQxsc/f5gWSv8I="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20260413-r0.apk",
+        "version": "20260413-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7907",
+          "checksum": "sha1-YLGEH8o/PNCjR8sxoxh//AGpOgQ="
+        },
+        "data": {
+          "range": "bytes=7908-137552",
+          "checksum": "sha256-1NKuKrCJxco8aTxdlzNkEjM/4HyDXmO6sGOfSTiu8aE="
+        },
+        "checksum": "Q1YLGEH8o/PNCjR8sxoxh//AGpOgQ="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/aarch64/libgcc-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9968",
+          "checksum": "sha1-0/N/tQIIDrAIbJ8QA8/iMB2bmfU="
+        },
+        "data": {
+          "range": "bytes=9969-86427",
+          "checksum": "sha256-ECrE4xEgBQV3df1UklKqzMzpglmWfjLg9FsjCGK05lc="
+        },
+        "checksum": "Q10/N/tQIIDrAIbJ8QA8/iMB2bmfU="
+      },
+      {
+        "name": "glibc-locale-posix",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13058",
+          "checksum": "sha1-BIBCJGNefQ6OZhfH+yQAL1S3/bM="
+        },
+        "data": {
+          "range": "bytes=13059-89800",
+          "checksum": "sha256-CY8DYMdTEZQDdr0V9mSZy6OO+DzjhmSBZSD4dF/nK5s="
+        },
+        "checksum": "Q1BIBCJGNefQ6OZhfH+yQAL1S3/bM="
+      },
+      {
+        "name": "glibc",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13295",
+          "checksum": "sha1-iNjpwJYrlEf1vRh127vhMVvg6TI="
+        },
+        "data": {
+          "range": "bytes=13296-2235744",
+          "checksum": "sha256-K/MWiiI44ynr5ZGr3okL8Axmy+4VArr8y5zH6DYDRuk="
+        },
+        "checksum": "Q1iNjpwJYrlEf1vRh127vhMVvg6TI="
+      },
+      {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13092",
+          "checksum": "sha1-vqCKIZcxA7Bw0Sdk31ANMcX7SkE="
+        },
+        "data": {
+          "range": "bytes=13093-125752",
+          "checksum": "sha256-S1pHeMAxoXQpYYtqlbDdPoKu7tt5flTCAms4yNZv6NI="
+        },
+        "checksum": "Q1vqCKIZcxA7Bw0Sdk31ANMcX7SkE="
+      },
+      {
+        "name": "libxcrypt",
+        "url": "https://packages.wolfi.dev/os/aarch64/libxcrypt-4.5.2-r3.apk",
+        "version": "4.5.2-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8572",
+          "checksum": "sha1-ghgqrJg4iSn9gnlkDzpWMPFaymg="
+        },
+        "data": {
+          "range": "bytes=8573-104313",
+          "checksum": "sha256-XizRWLvfUizHwKzjGLYIFKzfDDehNmTY9yPgDFlLPS4="
+        },
+        "checksum": "Q1ghgqrJg4iSn9gnlkDzpWMPFaymg="
+      },
+      {
+        "name": "libcrypt1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13111",
+          "checksum": "sha1-Lc5RMEoBlR4TAJtUNiw9hlafq2g="
+        },
+        "data": {
+          "range": "bytes=13112-14724",
+          "checksum": "sha256-miwdByMJn6F2TDvzLLhMazBsP7eTM9okMUmceXVUaxM="
+        },
+        "checksum": "Q1Lc5RMEoBlR4TAJtUNiw9hlafq2g="
+      },
+      {
+        "name": "busybox",
+        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.37.0-r61.apk",
+        "version": "1.37.0-r61",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10947",
+          "checksum": "sha1-EeHjQ8oI9CX5Am00/gUwayfeglc="
+        },
+        "data": {
+          "range": "bytes=10948-429972",
+          "checksum": "sha256-TdoIXtUKXr9KtXVi4OBLcI3jzrea4+YQha1GxArzayI="
+        },
+        "checksum": "Q1EeHjQ8oI9CX5Am00/gUwayfeglc="
+      },
+      {
+        "name": "zlib",
+        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3.2-r3.apk",
+        "version": "1.3.2-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8828",
+          "checksum": "sha1-YxX5T6R79BRPOcEnMqh9dQy7E3c="
+        },
+        "data": {
+          "range": "bytes=8829-60677",
+          "checksum": "sha256-ij7mAZJowteCp2WSpbbgRHBrOgQgSAOzkQJnpjb2xoQ="
+        },
+        "checksum": "Q1YxX5T6R79BRPOcEnMqh9dQy7E3c="
+      },
+      {
+        "name": "libstdc++",
+        "url": "https://packages.wolfi.dev/os/aarch64/libstdc++-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9975",
+          "checksum": "sha1-UknHYoUowwYP/yjIaxIFq8CaEUg="
+        },
+        "data": {
+          "range": "bytes=9976-1178043",
+          "checksum": "sha256-LFku50w/HG35xaMJmM1fWes2JiJR31JYex1BzQNfwrk="
+        },
+        "checksum": "Q1UknHYoUowwYP/yjIaxIFq8CaEUg="
+      },
+      {
+        "name": "libcrypto3",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.6.3-r3.apk",
+        "version": "3.6.3-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11026",
+          "checksum": "sha1-IhlZQ3XyVyqnes8zsNjtdfcdEO0="
+        },
+        "data": {
+          "range": "bytes=11027-2210037",
+          "checksum": "sha256-Z8qrYFVxk9L0+ZpEpIV/yFNFZwBgRHR+W4OPv/UJY1k="
+        },
+        "checksum": "Q1IhlZQ3XyVyqnes8zsNjtdfcdEO0="
+      },
+      {
+        "name": "ncurses-terminfo-base",
+        "url": "https://packages.wolfi.dev/os/aarch64/ncurses-terminfo-base-6.6.20260711-r0.apk",
+        "version": "6.6.20260711-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10384",
+          "checksum": "sha1-6+HnF1MKAZrzENYuZRr+HKSWVuQ="
+        },
+        "data": {
+          "range": "bytes=10385-117921",
+          "checksum": "sha256-GOWZ0l3saEcM7aImny2HZgZhd3+ZzqKysdeCLp6CXeY="
+        },
+        "checksum": "Q16+HnF1MKAZrzENYuZRr+HKSWVuQ="
+      },
+      {
+        "name": "ncurses",
+        "url": "https://packages.wolfi.dev/os/aarch64/ncurses-6.6.20260711-r0.apk",
+        "version": "6.6.20260711-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10529",
+          "checksum": "sha1-TP/JXcCHBS6Gfb3SkDCabTzHruc="
+        },
+        "data": {
+          "range": "bytes=10530-612436",
+          "checksum": "sha256-O1lVAWdkPhehiONLyZpP5QdKXksYlg8LFZ8+vQX/ZNs="
+        },
+        "checksum": "Q1TP/JXcCHBS6Gfb3SkDCabTzHruc="
+      },
+      {
+        "name": "erlang-27",
+        "url": "https://packages.wolfi.dev/os/aarch64/erlang-27-27.3.4.2-r0.apk",
+        "version": "27.3.4.2-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-3610",
+          "checksum": "sha1-5f2woIWkSSZjBbafV1dB5+9+iXg="
+        },
+        "data": {
+          "range": "bytes=3611-55329431",
+          "checksum": "sha256-YBtIqBi3v4pVH+nzNWO3Itlv7Pw1iwTxPXGQDAeuedk="
+        },
+        "checksum": "Q15f2woIWkSSZjBbafV1dB5+9+iXg="
+      }
+    ]
+  }
+}

--- a/projects/embervm/image/apko.yaml
+++ b/projects/embervm/image/apko.yaml
@@ -1,0 +1,41 @@
+# Runtime image for the EmberVM control plane. Wolfi base providing erlang-27
+# (the ERTS + OTP apps the include_erts:false release boots against), busybox
+# (the release start script is /bin/sh), and ca-certificates. The control-plane
+# OTP release is layered at /opt/embervm per-arch-independently (see BUILD); the
+# .beam bytecode is architecture-independent, so one release serves both arches
+# and apko resolves erlang-27 per arch.
+#
+# erlang-27 is pinned to 27.3.4.2-r0 to EXACTLY match the build OTP
+# (bazel/erlang/repositories.bzl): an include_erts:false release pins exact OTP
+# app versions in its .boot script, so a build/runtime patch mismatch crash-loops
+# the pod at boot. Re-pin both together when Wolfi bumps erlang-27.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - ca-certificates-bundle
+    - busybox
+    - erlang-27=27.3.4.2-r0
+
+archs:
+  - x86_64
+  - aarch64
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  # A UTF-8 locale keeps Elixir from warning and mangling non-ASCII.
+  LANG: C.UTF-8
+  LC_ALL: C.UTF-8
+  # No Erlang distribution (single-node control plane); avoids epmd and a
+  # resolvable-hostname requirement.
+  RELEASE_DISTRIBUTION: none
+  # The release writes its runtime scratch (extracted vm.args, pids) here. The
+  # pod runs read-only-rootfs as uid 65532, so RELEASE_TMP MUST point at a
+  # writable emptyDir the chart mounts (/tmp); the default (the root-owned
+  # release dir) is not writable.
+  RELEASE_TMP: /tmp
+
+entrypoint:
+  command: /opt/embervm/bin/embervm start

--- a/projects/home-cluster/kustomization.yaml
+++ b/projects/home-cluster/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - ../../projects/embervm/deploy
   - ../../projects/firecracker/git-mirror/deploy
   - ../../projects/firecracker/substrate/deploy
   - ../../projects/inference/deploy


### PR DESCRIPTION
Completes **PR-A**: builds the control-plane image and wires the chart to ArgoCD so the first EmberVM control-plane pod comes up (Tasks 1+2 of the [R0 plan](docs/plans/2026-07-12-embervm-r0-tasks-spec-and-plan.md)).

Builds on the merged foundation (proven prebuilt OTP+Elixir toolchain, node.proto, CRD, chart content, Elixir skeleton).

## Changes
- **ERTS match**: pinned build OTP to `27.3.4.2` to exactly match Wolfi `erlang-27` (`27.3.4.2-r0`). An `include_erts:false` release pins exact OTP app versions in its `.boot`, so a build/runtime patch mismatch crash-loops the pod at boot — this alignment prevents that.
- **`projects/embervm/image/`**: dual-arch apko image (`erlang-27` base + the arch-independent release layered at `/opt/embervm`), `apko.lock.json`, env `RELEASE_DISTRIBUTION=none` + `RELEASE_TMP=/tmp`, entrypoint `/opt/embervm/bin/embervm start`.
- **Chart**: `helm_chart` pins the image tag; the deployment mounts a writable `/tmp` emptyDir for `RELEASE_TMP` (rootfs is read-only, runs uid 65532).
- **`deploy/`**: ArgoCD Application (namespace `embervm`, multi-source OCI chart + `$values`), kustomization; home-cluster root regenerated.

## Verification
- Chart renders cleanly (6 objects) with `helm template` incl. the `/tmp` volume.
- CI builds the dual-arch image + publishes the chart on merge; then ArgoCD syncs and `/healthz` should return 200. The release-boots-and-serves check happens post-merge on the live pod (the ERTS match is the known risk; verified live after deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)