### PR TITLE
fix(embervm): op-log volume optional (unblock first pod from Longhorn)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.1
+version: 0.1.2

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -74,7 +74,13 @@ spec:
               mountPath: /tmp
       volumes:
         - name: oplog
+          {{- if .Values.opLog.persistentVolume }}
           persistentVolumeClaim:
             claimName: {{ include "embervm.fullname" . }}-oplog
+          {{- else }}
+          # No durable op-log yet (Task 6); the health-only skeleton writes
+          # nothing here, so an emptyDir avoids a storage dependency.
+          emptyDir: {}
+          {{- end }}
         - name: tmp
           emptyDir: {}

--- a/projects/embervm/chart/templates/pvc.yaml
+++ b/projects/embervm/chart/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.opLog.persistentVolume }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -11,3 +12,4 @@ spec:
   resources:
     requests:
       storage: {{ .Values.opLog.size }}
+{{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -30,10 +30,14 @@ resources:
   limits:
     memory: 512Mi
 
-# The op-log PVC. Longhorn, RWO, single replica: a PVC provides DURABILITY, not
-# availability. SQLite is single-writer and the Deployment uses the Recreate
-# strategy so a rolling update never runs two writers against one RWO volume.
+# The op-log volume. persistentVolume is FALSE until the SQLite op-log lands
+# (Task 6): the R0 skeleton is a dependency-free health server that writes nothing
+# durable, so it uses an emptyDir and does not depend on Longhorn. When the op-log
+# ships, flip persistentVolume to true to get the RWO Longhorn PVC below (which
+# provides DURABILITY, not availability: SQLite is single-writer and the Deployment
+# is Recreate so a rolling update never runs two writers against one RWO volume).
 opLog:
+  persistentVolume: false
   storageClass: longhorn
   size: 2Gi
 


### PR DESCRIPTION
The first control-plane pod (PR #3463) stuck in ContainerCreating: its Longhorn RWO op-log PVC couldn't attach (node-2 longhorn-engine v1.8.1 not deployed/not ready). The R0 skeleton is a dependency-free health server with no SQLite op-log yet (Task 6), so it needs no durable volume. Gate persistence behind `opLog.persistentVolume` (default false → emptyDir); Task 6 flips it true for the real PVC. Bump 0.1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)