### PR TITLE
fix(embervm): point ArgoCD app at chart 0.1.2 (targetRevision drift)

### DIFF
--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.1
+      targetRevision: 0.1.2
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
The oplog-optional PR (#3464) published Chart 0.1.2 (emptyDir op-log) but its commit dropped the `bump-chart.sh` edit to `deploy/application.yaml`, so main pins Chart 0.1.2 while the ArgoCD Application still targets 0.1.1 (the PVC version). ArgoCD deployed 0.1.1 → pod stuck on the Longhorn attach. One-line fix: point `targetRevision` at the already-published 0.1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)