### PR TITLE
docs: refresh README structure to match repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ projects/             # All services, operators, websites, colocated with deploy
 ├── inference/        #   On-cluster vLLM (Qwen3.6) + llama.cpp embeddings
 ├── operators/        #   Custom Kubernetes operators
 ├── sextant/          #   State-machine code generator for operators
+├── embervm/          #   BEAM orchestrator for Firecracker workload execution
 └── home-cluster/     #   Auto-generated ArgoCD root kustomization
 bazel/                # Build infrastructure (rules, tools, images, semgrep)
 buck2/                # Reusable Buck2 image/helm/apko rules (consumable as a cell)


### PR DESCRIPTION
Weekly structure-docs refresh. What changed and why:

- Added `embervm/` to the repo layout tree. The project has a deployed ArgoCD application (chart v0.1.2) and its own `docs/decisions/embervm/` ADR directory. The COVERAGE_ALLOWLIST comment on that entry explicitly says to promote it to the README when its chart wires to ArgoCD, which it now has.

No other changes. All other README claims checked and still accurate:
- Systems links all resolve.
- Infrastructure table GPU row matches `projects/inference/deploy/values.yaml` (Qwen3.6-35B-A3B + voyage-4-nano).
- Applications list paths all exist.
- Mechanical check (`check_readme_structure.py`) passes on both the old and new README.

Note: the `COVERAGE_ALLOWLIST` entry for `embervm` in `bazel/tools/format/readme_structure/check_readme_structure.py` is now stale (it can be dropped or the comment updated) but that is out of scope for this README-only PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqVk8NYgCsoP4pTqWsUzsa)_