### PR TITLE
feat(cilium): enable ingress network policies (monolith-public + fc-invoke)

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.78
+version: 0.4.79

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.78
+      targetRevision: 0.4.79
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/firecracker/substrate/deploy/values.yaml
+++ b/projects/firecracker/substrate/deploy/values.yaml
@@ -28,7 +28,7 @@ auth:
 # Cilium authorization for the /invoke route (ADR platform/012), on top of the
 # daemon's own TokenReview control (defence in depth).
 ciliumPolicy:
-  enabled: false
+  enabled: true
   fromNamespaces:
     - monolith
 

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.89.98
+version: 0.89.99
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.98
+      targetRevision: 0.89.99
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/values.yaml
+++ b/projects/monolith-public/deploy/values.yaml
@@ -46,3 +46,15 @@ cfIngress:
   public:
     enabled: true
     hostname: jomcgi.dev
+
+# Cilium ingress restrictions (ADR platform/012). Post-cutover follow-up: flip
+# the INGRESS gate on (gateway -> frontend, frontend -> web) now that Cilium is
+# the live CNI. The EGRESS gate stays off deliberately: the off-cluster
+# default-deny + Turnstile FQDN allow flips in a separate tested follow-up so an
+# unproven egress deny is not stacked on the CNI swap. See the chart's
+# templates/cilium-policy.yaml rationale.
+ciliumPolicy:
+  ingress:
+    enabled: true
+  egress:
+    enabled: false


### PR DESCRIPTION
## Step 1 of the Cilium post-cutover follow-ups (ADR platform/012)

Now that Cilium is the live CNI on all 4 nodes, flip the **ingress** policy gates
that were staged inert in Track 1:

- **monolith-public** (`ciliumPolicy.ingress.enabled: true`): frontend ingress restricted to the Envoy gateway namespace; web (backend) ingress restricted to the frontend pod. Replaces the removed Linkerd Server/AuthorizationPolicy chain.
- **fc-invoke / substrate** (`ciliumPolicy.enabled: true`): `/invoke` ingress restricted to the `monolith` namespace, defence-in-depth behind the daemon's TokenReview allow-list.

Both allow `host`+`health` entities so kubelet/health probes keep pods Ready.

### Deliberately NOT in this PR
- **Egress gates** stay off (off-cluster default-deny + Turnstile FQDN allow flips in a separate tested follow-up, so an unproven egress deny is not stacked on the CNI swap).
- No node reboots, no Linkerd-ref cleanup, no Cilium ArgoCD auto-sync (separate follow-ups).

### Verification plan (before merge)
Watch `hubble observe` for drops to the frontend/web/fc-invoke endpoints; confirm the only legitimate callers are the gateway ns, the frontend pod, and the monolith ns respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)