### PR TITLE
feat(cilium): adopt Cilium into ArgoCD auto-sync (ADR platform/012 Step 5)

### DIFF
--- a/projects/platform/cilium/application.yaml
+++ b/projects/platform/cilium/application.yaml
@@ -18,13 +18,40 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: kube-system
-  # MANUAL SYNC ONLY. `syncPolicy.automated` is deliberately omitted: Cilium must
-  # not self-install ahead of the human-run cutover window. The flannel -> Cilium
-  # datapath swap needs an out-of-band k3s server-flag change and node reboot
-  # (see projects/platform/cilium/bootstrap/README.md) that GitOps cannot drive.
-  # Track 2 of the migration enables sync by hand once the node bootstrap is done.
-  # See ADR platform/012 and docs/plans/2026-07-10-cilium-migration.md.
+  # Cilium is now GitOps-reconciled (ADR platform/012, migration plan Step 5).
+  # The bootstrap HelmChart CR in bootstrap/ stays the INSTALL seam (it provides
+  # the CNI before ArgoCD is reachable); ArgoCD adopts the release and reconciles
+  # ongoing config from here. Verified before enabling: the rendered chart values
+  # (version 1.19.5, image, and every datapath cilium-config key: WireGuard,
+  # node encryption, tunnel/vxlan, pod CIDR, kube-proxy-replacement=false,
+  # policy=default, cni-exclusive=false) match the live install, and the rendered
+  # resource set equals the tracked set, so adoption is metadata-only (no agent
+  # roll, nothing pruned).
+  ignoreDifferences:
+    # Cilium's chart generates the Hubble CA and mTLS certs at Helm template time
+    # (tls.auto.method=helm), so each render produces DIFFERENT random certs than
+    # the live (bootstrap-generated) ones. Without this, every sync would rotate
+    # Hubble's certs (Hubble observability churn; the eBPF datapath and WireGuard
+    # keys are unaffected). Ignore their data so the live certs are preserved.
+    - group: ""
+      kind: Secret
+      name: cilium-ca
+      jsonPointers:
+        - /data
+    - group: ""
+      kind: Secret
+      name: hubble-server-certs
+      jsonPointers:
+        - /data
+    - group: ""
+      kind: Secret
+      name: hubble-relay-client-certs
+      jsonPointers:
+        - /data
   syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=false
       # Cilium's bundled CRDs render large; server-side apply skips the 256 KiB


### PR DESCRIPTION
## Step 4 of the Cilium post-cutover follow-ups (ADR platform/012)

**DRAFT / held for review** per the "investigate the diff first, report before enabling" decision. Merging this enables auto-sync on the live CNI, so it should not merge without a go-ahead.

### What I found investigating the 100% OutOfSync app
The Cilium app showed *every* resource OutOfSync only because the live release was installed by the **bootstrap `HelmChart` CR** (classic helm repo), not ArgoCD. It is **not** a spec drift:
- Chart **1.19.5 == live**; DaemonSet image digest **== live**.
- Every datapath `cilium-config` key matches: WireGuard, node encryption, tunnel/vxlan, pod CIDR `10.42.0.0/16`, `kube-proxy-replacement=false`, `policy=default`, `cni-exclusive=false`, `identity=crd`.
- Rendered resource set (**31**) == ArgoCD-tracked set (**31**) → prune deletes nothing.

So the first reconcile is **metadata-only adoption** (ArgoCD tracking labels): no agent roll, no config change, nothing pruned.

### The one real caveat, handled here
Cilium's chart generates the Hubble CA + mTLS certs at Helm template time (`tls.auto.method=helm`), so each render produces *different* random certs than the live bootstrap-generated ones. Left alone, every sync would rotate Hubble's certs (Hubble observability churn; the eBPF datapath and WireGuard keys are independent and unaffected). This PR adds `ignoreDifferences` on `cilium-ca`, `hubble-server-certs`, `hubble-relay-client-certs` so the live certs are preserved.

### Recommended enabling procedure
Merge, then do the **first sync supervised**: `argocd app sync cilium` (or watch ArgoCD auto-reconcile) while watching `kubectl -n kube-system get pods -l k8s-app=cilium -w` to confirm no agent restarts. Bootstrap stays the install seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)