### PR TITLE
feat(monolith-public): enable Cilium egress network policy (public tier)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.100
+version: 0.89.101
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.100
+      targetRevision: 0.89.101
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/values.yaml
+++ b/projects/monolith-public/deploy/values.yaml
@@ -47,14 +47,16 @@ cfIngress:
     enabled: true
     hostname: jomcgi.dev
 
-# Cilium ingress restrictions (ADR platform/012). Post-cutover follow-up: flip
-# the INGRESS gate on (gateway -> frontend, frontend -> web) now that Cilium is
-# the live CNI. The EGRESS gate stays off deliberately: the off-cluster
-# default-deny + Turnstile FQDN allow flips in a separate tested follow-up so an
-# unproven egress deny is not stacked on the CNI swap. See the chart's
-# templates/cilium-policy.yaml rationale.
+# Cilium network policy (ADR platform/012). Both gates are on:
+#   ingress: gateway -> frontend, frontend -> web (flipped during the window).
+#   egress:  off-cluster default-deny with the single sanctioned Turnstile FQDN
+#            (challenges.cloudflare.com), all in-cluster allowed, DNS via the L7
+#            proxy. Flipped in a tested follow-up: hubble showed the only
+#            off-cluster egress is web -> Turnstile; frontend/imgproxy reach
+#            nothing off-cluster (imgproxy sources from in-cluster SeaweedFS).
+# See the chart's templates/cilium-policy.yaml rationale.
 ciliumPolicy:
   ingress:
     enabled: true
   egress:
-    enabled: false
+    enabled: true


### PR DESCRIPTION
## Public-tier egress gate, the tested follow-up from the Cilium migration (ADR platform/012)

Flips `ciliumPolicy.egress.enabled` on. This was deliberately deferred at the cutover window so an unproven default-deny-egress wouldn't be stacked on the irreversible CNI swap.

### The policy
- **web (backend):** default-deny off-cluster, all in-cluster allowed (`cluster`+`host`+`remote-node`), DNS via the L7 proxy (port 53 carved out of the broad allow so an L4 rule can't shadow the DNS proxy), and the single sanctioned FQDN `challenges.cloudflare.com:443` (Turnstile).
- **frontend / imgproxy:** in-cluster only, no off-cluster egress.

### Tested before enabling (hubble observe under generated traffic)
| Component | Off-cluster egress found | 
|-----------|--------------------------|
| web | only `104.18.95.41:443` (Cloudflare = Turnstile siteverify) — covered by `toFQDNs` |
| frontend | none (SSR code has no external `fetch()`) |
| imgproxy | none (source S3 = `seaweedfs-s3.seaweedfs.svc`, in-cluster) |

### Post-merge verification plan
Watch `hubble observe --verdict DROPPED` on the public tier while firing a Turnstile call and loading pages; confirm the Turnstile egress is FORWARDED (not blocked by a DNS-proxy miss) and nothing legitimate drops. Revert immediately if it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)