### PR TITLE
feat(embervm): task submit api with tokenreview auth

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.5
+version: 0.1.6

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -44,6 +44,13 @@ spec:
             - name: EMBERVM_NODE_ADDRESS
               value: {{ .Values.node.address | quote }}
             {{- end }}
+            {{- if .Values.auth.allowedServiceAccounts }}
+            # TokenReview allow-list: ServiceAccount usernames permitted to
+            # submit tasks. Empty means deny-all (fail-closed) in the control
+            # plane, so the env is only set when the list is non-empty.
+            - name: EMBERVM_ALLOWED_SERVICE_ACCOUNTS
+              value: {{ join "," .Values.auth.allowedServiceAccounts | quote }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -32,9 +32,21 @@ defmodule Embervm.Application do
     port = http_port()
 
     children = [
+      # The sync-wait waiter registry + park-count ETS owner come FIRST: every
+      # terminal task-state write in TaskStore calls Embervm.SyncWait.notify,
+      # which dispatches through this registry, so it must already exist. Both
+      # are dependency-free and effectively never crash, so leading the
+      # rest_for_one chain costs nothing.
+      {Registry, keys: :duplicate, name: Embervm.TaskWaiters},
+      Embervm.SyncWait,
       {Embervm.OpLog.SQLite, path: oplog_path()},
       {Embervm.TaskStore, []},
-      {Finch, name: Embervm.Finch},
+      # Finch (the shared HTTP pool, TLS-pinned to the K8s CA in-cluster) before
+      # Embervm.Auth, whose TokenReview reviewer dials the API server over it.
+      Embervm.K8s.finch_child_spec(),
+      {Embervm.Auth, allowed: allowed_service_accounts()},
+      # Bandit + the router last: its handlers call Auth, TaskStore, and
+      # SyncWait, so the HTTP surface must not accept requests until all are up.
       {Bandit, plug: Embervm.Router, scheme: :http, port: port}
     ]
 
@@ -62,6 +74,23 @@ defmodule Embervm.Application do
       nil -> nil
       "" -> nil
       path -> path
+    end
+  end
+
+  # The TokenReview allow-list: ServiceAccount usernames permitted to submit
+  # tasks, from EMBERVM_ALLOWED_SERVICE_ACCOUNTS (comma-separated), wired by the
+  # chart from values.auth.allowedServiceAccounts. An empty list means deny-all
+  # (fail-closed); Embervm.Auth logs a loud warning in that case.
+  defp allowed_service_accounts do
+    case System.get_env("EMBERVM_ALLOWED_SERVICE_ACCOUNTS") do
+      nil ->
+        []
+
+      raw ->
+        raw
+        |> String.split(",", trim: true)
+        |> Enum.map(&String.trim/1)
+        |> Enum.reject(&(&1 == ""))
     end
   end
 end

--- a/projects/embervm/control/lib/embervm/auth.ex
+++ b/projects/embervm/control/lib/embervm/auth.ex
@@ -1,0 +1,196 @@
+defmodule Embervm.Auth do
+  @moduledoc """
+  Bearer-token authentication for the submit API, porting the fc-invoke
+  TokenReview pattern (auth/reviewer.go + auth/cache.go) to the BEAM.
+
+  A token is authenticated by a Kubernetes `TokenReview` (via `Embervm.K8s`),
+  then checked against an allow-list of ServiceAccount usernames from values.
+  Successful reviews are cached keyed by `sha256(token)` with a 60s TTL and
+  collapsed by singleflight, because without caching a saturating submit rate
+  becomes an equal rate of TokenReview calls against the API server. That is the
+  exact failure the fc-invoke 5-QPS TokenReview incident (PR #3352) taught us to
+  design out: there the client-side rate limiter silently capped throughput
+  upstream of every span but auth. We have no client-go limiter here (Finch has
+  no hidden QPS bucket), so the cache is purely to spare the API server; the cap
+  it removes is real all the same.
+
+  ## Why the network review runs off the GenServer
+
+  This GenServer serializes its `handle_call/3`, which is exactly what makes the
+  singleflight free: two concurrent misses for the same token cannot both start a
+  review, because the second sees the first already recorded as in-flight. But
+  the review itself is a network round-trip, so it MUST NOT run inside the call
+  handler, or one slow miss would block every other token's cache hit behind it
+  (re-creating the incident in a new place). Instead the handler spawns a short
+  process to run the review and reply via `{:review_done, ...}`, so the GenServer
+  stays responsive and only the waiters for that one token block.
+
+  ## What is and is not cached
+
+  Only ALLOWED principals are cached. A transient review error is never cached (a
+  just-fixed token must re-check immediately). An authenticated-but-not-allowed
+  token is not cached either: the allow-list is tiny and the denial is cheap to
+  recompute, and not caching denials keeps the cache a pure success set (a
+  rejected-token flood cannot grow it), matching the fc-invoke posture.
+  """
+  use GenServer
+  require Logger
+
+  @default_ttl_ms 60_000
+  @max_entries 4096
+
+  # -- Client API ----------------------------------------------------------
+
+  # :name defaults to __MODULE__ for the supervised singleton; tests that need
+  # several isolated instances alive at once pass name: nil for an unnamed,
+  # PID-addressed process (mirroring OpLog.SQLite / TaskStore).
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc """
+  Authenticates `token`, returning `{:ok, principal}` for an allow-listed
+  ServiceAccount or `{:error, reason}` (`:unauthenticated`, `:forbidden`, or a
+  transport reason). Blocks the caller only for a cache miss on this token;
+  cache hits for other tokens are served concurrently.
+  """
+  @spec authenticate(GenServer.server(), String.t()) ::
+          {:ok, String.t()} | {:error, term()}
+  def authenticate(server \\ __MODULE__, token) do
+    GenServer.call(server, {:authenticate, token}, :infinity)
+  end
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    state = %{
+      cache: %{},
+      inflight: %{},
+      ttl_ms: Keyword.get(opts, :ttl_ms, @default_ttl_ms),
+      clock: Keyword.get(opts, :clock, &default_clock/0),
+      reviewer: Keyword.get(opts, :reviewer, &Embervm.K8s.review_token/1),
+      allowed: MapSet.new(Keyword.get(opts, :allowed, [])),
+      max_entries: Keyword.get(opts, :max_entries, @max_entries)
+    }
+
+    if MapSet.size(state.allowed) == 0 do
+      Logger.warning(
+        "embervm auth allow-list is EMPTY: every submit will be denied (fail-closed). " <>
+          "Populate values.auth.allowedServiceAccounts."
+      )
+    end
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call({:authenticate, token}, from, state) do
+    key = hash(token)
+    now = state.clock.()
+
+    case lookup(state, key, now) do
+      {:ok, principal} ->
+        {:reply, {:ok, principal}, state}
+
+      :miss ->
+        {:noreply, start_or_join_flight(state, key, token, from)}
+    end
+  end
+
+  @impl true
+  def handle_info({:review_done, key, token, result}, state) do
+    {froms, inflight} = Map.pop(state.inflight, key, [])
+    {reply, state} = resolve(%{state | inflight: inflight}, key, token, result)
+    Enum.each(froms, fn from -> GenServer.reply(from, reply) end)
+    {:noreply, state}
+  end
+
+  # -- singleflight core -----------------------------------------------------
+
+  # Serial handle_call gives the singleflight lock for free: if `key` is already
+  # in flight we just add this caller to its waiter list; otherwise we record it
+  # in flight and spawn the network review, which reports back via handle_info.
+  defp start_or_join_flight(state, key, token, from) do
+    case Map.get(state.inflight, key) do
+      nil ->
+        server = self()
+
+        spawn(fn ->
+          # Catch EVERYTHING (raise/throw/exit): the reviewer runs a network
+          # call, and if it dies without reporting back, the parked callers block
+          # on their :infinity GenServer.call forever. A caught crash becomes a
+          # non-cached error reply instead.
+          result =
+            try do
+              state.reviewer.(token)
+            catch
+              kind, reason -> {:error, {:review_crashed, kind, reason}}
+            end
+
+          send(server, {:review_done, key, token, result})
+        end)
+
+        %{state | inflight: Map.put(state.inflight, key, [from])}
+
+      froms ->
+        %{state | inflight: Map.put(state.inflight, key, [from | froms])}
+    end
+  end
+
+  # Turns a raw reviewer result into the caller reply and (for an allow-listed
+  # principal only) a fresh cache entry. Re-reads the clock so the TTL is dated
+  # from when the review actually completed, not when it was enqueued.
+  defp resolve(state, _key, _token, {:error, reason}) do
+    {{:error, reason}, state}
+  end
+
+  defp resolve(state, key, _token, {:ok, username}) do
+    if MapSet.member?(state.allowed, username) do
+      now = state.clock.()
+      {{:ok, username}, store(state, key, username, now)}
+    else
+      {{:error, :forbidden}, state}
+    end
+  end
+
+  # -- cache -----------------------------------------------------------------
+
+  defp lookup(state, key, now) do
+    case Map.get(state.cache, key) do
+      {principal, expires_at} when expires_at > now -> {:ok, principal}
+      _ -> :miss
+    end
+  end
+
+  # Store an allow-listed principal, keeping the cache bounded at max_entries.
+  # Refreshing an existing key never grows the map; a genuinely new key at
+  # capacity first sweeps expired entries, and only if that still leaves the map
+  # full is the new entry dropped (correctness is unaffected: the token is simply
+  # re-reviewed on its next request).
+  defp store(state, key, principal, now) do
+    entry = {principal, now + state.ttl_ms}
+
+    cache =
+      cond do
+        Map.has_key?(state.cache, key) or map_size(state.cache) < state.max_entries ->
+          Map.put(state.cache, key, entry)
+
+        true ->
+          swept = :maps.filter(fn _k, {_p, exp} -> exp > now end, state.cache)
+          if map_size(swept) < state.max_entries, do: Map.put(swept, key, entry), else: swept
+      end
+
+    %{state | cache: cache}
+  end
+
+  defp hash(token) do
+    :crypto.hash(:sha256, token) |> Base.encode16(case: :lower)
+  end
+
+  defp default_clock, do: System.system_time(:millisecond)
+end

--- a/projects/embervm/control/lib/embervm/k8s.ex
+++ b/projects/embervm/control/lib/embervm/k8s.ex
@@ -1,0 +1,124 @@
+defmodule Embervm.K8s do
+  @moduledoc """
+  Minimal in-cluster Kubernetes API client over Finch/Mint. R0 needs exactly two
+  calls: the `TokenReview` POST here (submit-API auth, Task 8) and the Workload
+  CRD list+watch (Task 5, added alongside the watcher). Hand-rolling over Finch
+  rather than pulling a full `k8s` hex library is deliberate: that library drags a
+  large transitive closure, and closure-completeness is the whole risk the
+  bandit/plug/finch de-risk PR set out to bound. Two endpoints do not justify it.
+
+  ## In-cluster config
+
+  We dial `https://kubernetes.default.svc:443` by its DNS NAME, not the
+  `KUBERNETES_SERVICE_HOST` IP: the apiserver serving cert always carries
+  `kubernetes.default.svc` as a SAN, so TLS hostname verification against the
+  pod's mounted `ca.crt` passes cleanly, whereas connecting by ClusterIP would
+  depend on the IP being in the SAN. The bearer credential is the pod's own
+  ServiceAccount token, RE-READ from disk on every call so the hourly projected
+  token rotation is picked up with no restart (the auth cache keeps this call
+  rate near zero, so per-call file reads cost nothing).
+
+  The Finch pool's TLS is configured by `finch_child_spec/0`: when the SA CA file
+  is present (in-cluster) the default pool verifies the peer against it; when it
+  is absent (local `mix`, ExUnit) the plain default pool is used, which is why the
+  loopback HTTP smoke and the request tests need no cluster.
+  """
+  require Logger
+
+  @sa_dir "/var/run/secrets/kubernetes.io/serviceaccount"
+  @token_file "#{@sa_dir}/token"
+  @ca_file "#{@sa_dir}/ca.crt"
+  @tokenreview_path "/apis/authentication.k8s.io/v1/tokenreviews"
+  @receive_timeout 5_000
+
+  @doc """
+  The Finch child spec for the control plane's shared HTTP pool. In-cluster it
+  pins the default pool to verify TLS against the SA CA bundle; elsewhere it is a
+  plain pool. TLS transport opts are ignored for plaintext (loopback) requests,
+  so one pool safely serves both the K8s calls and the health/loopback smoke.
+  """
+  @spec finch_child_spec() :: Supervisor.child_spec() | {module(), keyword()}
+  def finch_child_spec do
+    pools =
+      case File.exists?(@ca_file) do
+        true ->
+          %{
+            default: %{
+              conn_opts: [transport_opts: [verify: :verify_peer, cacertfile: @ca_file]]
+            }
+          }
+
+        false ->
+          %{}
+      end
+
+    {Finch, name: Embervm.Finch, pools: pools}
+  end
+
+  @doc """
+  Submits `token` to the Kubernetes `TokenReview` API and returns the
+  authenticated ServiceAccount username. This is the raw reviewer `Embervm.Auth`
+  wraps with caching + singleflight; it does NO caching itself and applies NO
+  allow-list (that is the Auth layer's job). Requires `create` on
+  `tokenreviews.authentication.k8s.io` (granted in the chart RBAC).
+  """
+  @spec review_token(String.t()) :: {:ok, String.t()} | {:error, term()}
+  def review_token(token) do
+    body =
+      :json.encode(%{
+        "apiVersion" => "authentication.k8s.io/v1",
+        "kind" => "TokenReview",
+        "spec" => %{"token" => token}
+      })
+      |> :erlang.iolist_to_binary()
+
+    with {:ok, sa_token} <- read_sa_token(),
+         url = api_url(@tokenreview_path),
+         headers = [
+           {"authorization", "Bearer " <> sa_token},
+           {"content-type", "application/json"},
+           {"accept", "application/json"}
+         ],
+         req = Finch.build(:post, url, headers, body),
+         {:ok, %Finch.Response{status: status, body: resp_body}} <-
+           Finch.request(req, Embervm.Finch, receive_timeout: @receive_timeout) do
+      parse_review(status, resp_body)
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # TokenReview create returns 201 (some clusters 200); anything else is an
+  # API-server error we surface without trusting the token.
+  defp parse_review(status, body) when status in [200, 201] do
+    decoded = :json.decode(body)
+    review_status = Map.get(decoded, "status", %{})
+
+    if Map.get(review_status, "authenticated", false) do
+      username = get_in(review_status, ["user", "username"])
+
+      case username do
+        nil -> {:error, :no_username}
+        name -> {:ok, name}
+      end
+    else
+      {:error, :unauthenticated}
+    end
+  end
+
+  defp parse_review(status, _body) do
+    {:error, {:apiserver_status, status}}
+  end
+
+  defp read_sa_token do
+    case File.read(@token_file) do
+      {:ok, token} -> {:ok, String.trim(token)}
+      {:error, reason} -> {:error, {:sa_token_unreadable, reason}}
+    end
+  end
+
+  defp api_url(path) do
+    port = System.get_env("KUBERNETES_SERVICE_PORT_HTTPS") || "443"
+    "https://kubernetes.default.svc:#{port}#{path}"
+  end
+end

--- a/projects/embervm/control/lib/embervm/op_log.ex
+++ b/projects/embervm/control/lib/embervm/op_log.ex
@@ -56,6 +56,7 @@ defmodule Embervm.OpLog do
     :failed,
     :retried,
     :dead_lettered,
+    :redrive,
     :denied,
     :base_built,
     :primed,
@@ -72,6 +73,16 @@ defmodule Embervm.OpLog do
   @callback append(server(), Op.t()) :: {:ok, seq :: pos_integer()} | {:error, term()}
   @callback read_from(server(), seq :: non_neg_integer()) :: {:ok, [Op.t()]} | {:error, term()}
   @callback load_tasks(server()) :: {:ok, [map()]} | {:error, term()}
+  # Reads one task's stored result from the durable `results` projection, or
+  # {:ok, nil} when there is none (never ran, or the TTL sweeper reaped it).
+  # This is the result-store read the submit API (Task 8) serves `GET
+  # /v1/tasks/{id}/result` from; it is a projection read, NOT the ops log, so
+  # it does not violate "the API never exposes op-log internals". The stored
+  # copy may be truncated to the workload's resultMaxBytes (the `truncated`
+  # flag says so); sync callers get the full untruncated response a different
+  # way (streamed straight through at request time, never via this store).
+  @callback load_result(server(), task_id :: String.t()) ::
+              {:ok, map() | nil} | {:error, term()}
   @callback compact(server(), now_ms :: integer()) ::
               {:ok, %{results_deleted: non_neg_integer(), tasks_compacted: non_neg_integer()}}
               | {:error, term()}

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -104,6 +104,11 @@ defmodule Embervm.OpLog.SQLite do
   end
 
   @impl Embervm.OpLog
+  def load_result(server \\ __MODULE__, task_id) do
+    GenServer.call(server, {:load_result, task_id})
+  end
+
+  @impl Embervm.OpLog
   def compact(server \\ __MODULE__, now_ms) do
     GenServer.call(server, {:compact, now_ms})
   end
@@ -145,6 +150,10 @@ defmodule Embervm.OpLog.SQLite do
 
   def handle_call(:load_tasks, _from, state) do
     {:reply, do_load_tasks(state.conn), state}
+  end
+
+  def handle_call({:load_result, task_id}, _from, state) do
+    {:reply, do_load_result(state.conn, task_id), state}
   end
 
   def handle_call({:compact, now_ms}, _from, state) do
@@ -287,6 +296,22 @@ defmodule Embervm.OpLog.SQLite do
     update_task_state(conn, op.task_id, "dead_lettered", op.ts)
   end
 
+  # Redrive re-queues a dead-lettered task and RESETS the attempt counter to 0
+  # (SQL is 0-based; ETS surfaces it 1-based), so the redriven task gets a full
+  # fresh retry budget rather than starting already-exhausted. The `redrive`
+  # op is the audit record of the manual intervention, distinct from automatic
+  # `retried` ops.
+  defp project(conn, %Op{kind: :redrive} = op, _seq) do
+    sql = "UPDATE tasks SET state='queued', attempt=0, updated_at=? WHERE task_id=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [op.ts, op.task_id]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
   # Audit-only kinds: no task/result projection.
   defp project(_conn, %Op{kind: kind}, _seq)
        when kind in [:denied, :base_built, :primed, :vm_destroyed, :quota_enforced, :drain] do
@@ -370,6 +395,40 @@ defmodule Embervm.OpLog.SQLite do
       tasks = collect_tasks(conn, stmt, [])
       :ok = Sqlite3.release(conn, stmt)
       {:ok, tasks}
+    end
+  end
+
+  defp do_load_result(conn, task_id) do
+    sql = """
+    SELECT status_code, body, size_bytes, truncated, created_at, expires_at
+    FROM results WHERE task_id=?
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [task_id]) do
+      result =
+        case Sqlite3.step(conn, stmt) do
+          {:row, [status_code, body, size_bytes, truncated, created_at, expires_at]} ->
+            {:ok,
+             %{
+               task_id: task_id,
+               status_code: status_code,
+               body: body,
+               size_bytes: size_bytes,
+               truncated: truncated == 1,
+               created_at: created_at,
+               expires_at: expires_at
+             }}
+
+          :done ->
+            {:ok, nil}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+
+      :ok = Sqlite3.release(conn, stmt)
+      result
     end
   end
 

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -1,31 +1,402 @@
 defmodule Embervm.Router do
   @moduledoc """
-  The control-plane HTTP router, served by Bandit (see `Embervm.Application`).
+  The control-plane HTTP router (Bandit-hosted, see `Embervm.Application`): the
+  submit API and the health endpoint.
 
-  R0 skeleton: this replaces the dependency-free `:gen_tcp` health endpoint with
-  a real `Plug.Router` so the submit API (Task 8) has a router to grow into. In
-  this PR it answers only `GET /healthz` with `200 ok`; the `/v1/...` task routes
-  land in Task 8 as additional clauses here (or a forwarded sub-router). The
-  process contract is unchanged from the old `Embervm.Health`: a supervised child
-  listening on the configured port, answering the same health path the chart's
-  readiness/liveness probes hit.
+  ## Surface (Task 8)
 
-  Bandit + Plug are the first HTTP dependencies in the control-plane closure; this
-  router existing and serving in-cluster is the deploy-time proof that the whole
-  Bandit/Plug/Finch/Mint hex closure builds and boots (the Task 8 de-risk).
+    * `POST /v1/workloads/:name/tasks` submit a task. Async by default (`202` +
+      task_id); `?wait=true` parks the request until the task is terminal or the
+      sync timeout elapses (a parked BEAM process, per `Embervm.SyncWait`).
+    * `GET  /v1/tasks/:id`             task state + metadata (from ETS).
+    * `GET  /v1/tasks/:id/result`      the stored result (until its TTL).
+    * `GET  /v1/workloads/:name/dead-letters`  paged DLQ listing.
+    * `POST /v1/tasks/:id/redrive`     re-queue a dead-lettered task (audited).
+    * `GET  /healthz`                  unauthenticated liveness/readiness.
+
+  ## Task envelope
+
+  A task IS one HTTP request to the guest. Method is always POST for the task
+  class. The submit body is forwarded to the guest VERBATIM, which is why this
+  route does NOT run `Plug.Parsers`: parsing would consume/transform the body.
+  The guest path defaults to the workload's `spec.source.invokePath` (hard-coded
+  `/` until Task 5 wires the catalog), overridable per submit with
+  `X-Ember-Guest-Path`. Request headers prefixed `X-Ember-Guest-` are stripped of
+  the prefix and forwarded; no other caller header reaches the guest. The whole
+  envelope is captured into the durable `submitted` record so the dispatcher
+  (Task 11) can rebuild the guest request; nothing dispatches yet, so in this
+  phase submitted tasks simply sit `queued`.
+
+  ## Auth
+
+  Every `/v1` path requires a bearer token authenticated by `Embervm.Auth`
+  (TokenReview + allow-list, cached). The reviewer is resolved from application
+  env so request tests can inject a fake without a live API server; production
+  uses the supervised `Embervm.Auth`. `/healthz` is unauthenticated.
   """
   use Plug.Router
 
+  require Logger
+
+  alias Embervm.{SyncWait, TaskState, TaskStore}
+
+  # Single tenant in v1 (the `homelab` tenant); the column is still carried on
+  # every record so multi-tenant is a data change, not a schema change.
+  @tenant "homelab"
+  # 8 MiB, matching the daemon Assign body cap.
+  @max_body 8_388_608
+  @guest_header_prefix "x-ember-guest-"
+  @path_header "x-ember-guest-path"
+  # Default task-record lifetime; Task 5 will source this from the workload's
+  # invocation.resultTtlSeconds once the catalog exists.
+  @default_task_ttl_ms 86_400_000
+
   plug(:match)
+  plug(:fetch_query)
+  plug(:authenticate)
   plug(:dispatch)
 
   get "/healthz" do
-    conn
-    |> put_resp_content_type("text/plain")
-    |> send_resp(200, "ok")
+    conn |> put_resp_content_type("text/plain") |> send_resp(200, "ok")
+  end
+
+  post "/v1/workloads/:name/tasks" do
+    handle_submit(conn, name)
+  end
+
+  get "/v1/tasks/:id" do
+    handle_get_task(conn, id)
+  end
+
+  get "/v1/tasks/:id/result" do
+    handle_get_result(conn, id)
+  end
+
+  get "/v1/workloads/:name/dead-letters" do
+    handle_dead_letters(conn, name)
+  end
+
+  post "/v1/tasks/:id/redrive" do
+    handle_redrive(conn, id)
   end
 
   match _ do
     send_resp(conn, 404, "")
   end
+
+  # -- plugs -----------------------------------------------------------------
+
+  defp fetch_query(conn, _opts), do: fetch_query_params(conn)
+
+  # Auth is scoped to /v1: /healthz stays open for the kubelet probes.
+  defp authenticate(%Plug.Conn{path_info: ["v1" | _]} = conn, _opts), do: do_authenticate(conn)
+  defp authenticate(conn, _opts), do: conn
+
+  defp do_authenticate(conn) do
+    authenticator = Application.get_env(:embervm, :authenticator, Embervm.Auth)
+
+    with {:ok, token} <- bearer_token(conn),
+         {:ok, principal} <- authenticator.authenticate(token) do
+      assign(conn, :principal, principal)
+    else
+      {:error, :no_token} ->
+        halt_json(conn, 401, %{error: "missing bearer token", retryable: false})
+
+      {:error, :forbidden} ->
+        halt_json(conn, 403, %{error: "service account not permitted", retryable: false})
+
+      {:error, _reason} ->
+        halt_json(conn, 401, %{error: "authentication failed", retryable: true})
+    end
+  end
+
+  # -- submit ----------------------------------------------------------------
+
+  defp handle_submit(conn, workload) do
+    principal = conn.assigns.principal
+
+    case read_capped_body(conn) do
+      {:ok, body, conn} ->
+        attrs = %{
+          tenant: @tenant,
+          principal: principal,
+          workload: workload,
+          idempotency_key: header_value(conn, "idempotency-key"),
+          expires_at: now_ms() + @default_task_ttl_ms,
+          request: build_request_env(conn, body)
+        }
+
+        case TaskStore.submit(store(), attrs) do
+          {:ok, _created_or_existing, task_id} ->
+            respond_submit(conn, task_id, principal)
+
+          {:error, reason} ->
+            Logger.error("embervm submit failed: #{inspect(reason)}")
+            send_json(conn, 500, %{error: "submit failed", retryable: true})
+        end
+
+      {:error, :too_large} ->
+        send_json(conn, 413, %{error: "request body exceeds 8 MiB", retryable: false})
+    end
+  end
+
+  defp respond_submit(conn, task_id, principal) do
+    if sync?(conn) do
+      sync_respond(conn, task_id, principal)
+    else
+      send_json(conn, 202, %{task_id: task_id, state: state_string(task_id)})
+    end
+  end
+
+  # Sync submit: reserve a park slot (fail-closed 429 past the per-principal cap),
+  # then park until terminal or timeout. On wake, re-read TaskStore for the
+  # AUTHORITATIVE state: the permanent-failure path notifies on failed_permanent
+  # before chaining to dead_lettered, so the woken state may be intermediate; the
+  # re-read (serialized behind TaskStore's in-flight transition) always sees the
+  # settled state.
+  defp sync_respond(conn, task_id, principal) do
+    cap = Application.get_env(:embervm, :sync_park_cap, 512)
+    timeout = Application.get_env(:embervm, :sync_timeout_ms, 90_000)
+
+    case SyncWait.reserve(principal, cap) do
+      :ok ->
+        try do
+          case SyncWait.await(task_id, timeout, fn -> terminal_check(task_id) end) do
+            {:terminal, _state} -> respond_terminal(conn, task_id)
+            :timeout -> send_json(conn, 202, %{task_id: task_id, state: state_string(task_id)})
+          end
+        after
+          SyncWait.release(principal)
+        end
+
+      {:error, :park_cap_exceeded} ->
+        send_json(conn, 429, %{
+          error: "sync wait cap exceeded for principal",
+          task_id: task_id,
+          retryable: true
+        })
+    end
+  end
+
+  defp terminal_check(task_id) do
+    case TaskStore.get(store(), task_id) do
+      {:ok, %{state: state}} ->
+        if TaskState.terminal?(state), do: {:terminal, state}, else: :pending
+
+      _ ->
+        :pending
+    end
+  end
+
+  # In R0 there is no dispatcher, so this is only reached in tests that drive a
+  # task terminal directly. When Task 11 lands, the dispatcher hands the LIVE
+  # untruncated guest response to the parked caller; until then, a succeeded task
+  # is answered from the stored (possibly truncated) result copy.
+  defp respond_terminal(conn, task_id) do
+    case TaskStore.get(store(), task_id) do
+      {:ok, %{state: :succeeded}} ->
+        case TaskStore.get_result(store(), task_id) do
+          {:ok, %{status_code: code, body: body, truncated: truncated}} ->
+            conn
+            |> put_resp_header("x-ember-truncated", to_string(truncated))
+            |> send_guest_result(code, body)
+
+          {:ok, nil} ->
+            send_json(conn, 200, %{task_id: task_id, state: "succeeded"})
+
+          {:error, _} ->
+            send_json(conn, 500, %{error: "result read failed", task_id: task_id, retryable: true})
+        end
+
+      {:ok, %{state: state}} ->
+        send_json(conn, 502, %{
+          error: "task did not succeed",
+          task_id: task_id,
+          state: to_string(state),
+          retryable: false
+        })
+
+      :error ->
+        send_json(conn, 404, %{error: "task not found", task_id: task_id, retryable: false})
+    end
+  end
+
+  # -- reads -----------------------------------------------------------------
+
+  defp handle_get_task(conn, task_id) do
+    case TaskStore.get(store(), task_id) do
+      {:ok, task} -> send_json(conn, 200, task_view(task))
+      :error -> send_json(conn, 404, %{error: "task not found", task_id: task_id, retryable: false})
+    end
+  end
+
+  defp handle_get_result(conn, task_id) do
+    case TaskStore.get_result(store(), task_id) do
+      {:ok, %{status_code: code, body: body, truncated: truncated}} ->
+        conn
+        |> put_resp_header("x-ember-truncated", to_string(truncated))
+        |> send_guest_result(code, body)
+
+      {:ok, nil} ->
+        send_json(conn, 404, %{
+          error: "no result (task never ran or the result TTL expired)",
+          task_id: task_id,
+          retryable: false
+        })
+
+      {:error, _} ->
+        send_json(conn, 500, %{error: "result read failed", task_id: task_id, retryable: true})
+    end
+  end
+
+  defp handle_dead_letters(conn, workload) do
+    limit = conn |> int_param("limit", 50) |> clamp(1, 500)
+    offset = conn |> int_param("offset", 0) |> max(0)
+
+    {:ok, page} = TaskStore.list_dead_letters(store(), workload, limit: limit, offset: offset)
+
+    send_json(conn, 200, %{
+      workload: workload,
+      items: Enum.map(page.items, &task_view/1),
+      total: page.total,
+      limit: page.limit,
+      offset: page.offset
+    })
+  end
+
+  defp handle_redrive(conn, task_id) do
+    case TaskStore.redrive(store(), task_id) do
+      {:ok, task} ->
+        send_json(conn, 200, task_view(task))
+
+      {:error, {:not_found, _}} ->
+        send_json(conn, 404, %{error: "task not found", task_id: task_id, retryable: false})
+
+      {:error, {:illegal_transition, _, _}} ->
+        send_json(conn, 409, %{
+          error: "task is not dead-lettered; only dead-lettered tasks can be redriven",
+          task_id: task_id,
+          retryable: false
+        })
+
+      {:error, _reason} ->
+        send_json(conn, 500, %{error: "redrive failed", task_id: task_id, retryable: true})
+    end
+  end
+
+  # -- request helpers -------------------------------------------------------
+
+  defp bearer_token(conn) do
+    case get_req_header(conn, "authorization") do
+      ["Bearer " <> token | _] -> {:ok, token}
+      ["bearer " <> token | _] -> {:ok, token}
+      _ -> {:error, :no_token}
+    end
+  end
+
+  # Reads the body with an 8 MiB cap: read_body returns {:more, ...} when the
+  # body exceeds :length, which we map to 413 rather than silently truncating.
+  defp read_capped_body(conn) do
+    case read_body(conn, length: @max_body, read_length: @max_body) do
+      {:ok, body, conn} -> {:ok, body, conn}
+      {:more, _partial, _conn} -> {:error, :too_large}
+      {:error, _} = error -> error
+    end
+  end
+
+  # The guest-request envelope stored verbatim for the dispatcher. Only present
+  # fields are included so op-log JSON never carries a null (nested nils are not
+  # stripped by the encoder).
+  defp build_request_env(conn, body) do
+    base = %{path: guest_path(conn), headers: guest_headers(conn), body_b64: Base.encode64(body)}
+
+    case header_value(conn, "content-type") do
+      nil -> base
+      ct -> Map.put(base, :content_type, ct)
+    end
+  end
+
+  defp guest_path(conn) do
+    # Default is the workload's spec.source.invokePath; hard-coded `/` until the
+    # Task 5 catalog exists. X-Ember-Guest-Path overrides per submit.
+    header_value(conn, @path_header) || "/"
+  end
+
+  defp guest_headers(conn) do
+    conn.req_headers
+    |> Enum.filter(fn {k, _v} ->
+      String.starts_with?(k, @guest_header_prefix) and k != @path_header
+    end)
+    |> Map.new(fn {k, v} -> {String.replace_prefix(k, @guest_header_prefix, ""), v} end)
+  end
+
+  defp header_value(conn, name) do
+    case get_req_header(conn, name) do
+      [value | _] -> value
+      [] -> nil
+    end
+  end
+
+  defp sync?(conn), do: Map.get(conn.query_params, "wait") == "true"
+
+  defp int_param(conn, name, default) do
+    case Map.get(conn.query_params, name) do
+      nil ->
+        default
+
+      raw ->
+        case Integer.parse(raw) do
+          {n, _} -> n
+          :error -> default
+        end
+    end
+  end
+
+  defp clamp(n, lo, hi), do: n |> max(lo) |> min(hi)
+
+  # -- responses -------------------------------------------------------------
+
+  defp task_view(task) do
+    %{
+      task_id: task.task_id,
+      workload: task.workload,
+      principal: task.principal,
+      state: to_string(task.state),
+      attempt: task.attempt,
+      submitted_at: task.submitted_at,
+      updated_at: task.updated_at
+    }
+  end
+
+  defp state_string(task_id) do
+    case TaskStore.get(store(), task_id) do
+      {:ok, %{state: state}} -> to_string(state)
+      :error -> "unknown"
+    end
+  end
+
+  defp send_guest_result(conn, status_code, body) do
+    conn
+    |> put_resp_content_type("application/octet-stream")
+    |> send_resp(status_code, body || "")
+  end
+
+  defp send_json(conn, status, map) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(status, encode_json(map))
+  end
+
+  defp halt_json(conn, status, map) do
+    conn |> send_json(status, map) |> halt()
+  end
+
+  defp encode_json(map), do: map |> :json.encode() |> :erlang.iolist_to_binary()
+
+  # The submit API reads/writes only through TaskStore (ETS + result store),
+  # never the op-log internals. The store is resolvable from app env for symmetry
+  # with the authenticator, defaulting to the supervised singleton.
+  defp store, do: Application.get_env(:embervm, :task_store, Embervm.TaskStore)
+
+  defp now_ms, do: System.system_time(:millisecond)
 end

--- a/projects/embervm/control/lib/embervm/sync_wait.ex
+++ b/projects/embervm/control/lib/embervm/sync_wait.ex
@@ -57,7 +57,10 @@ defmodule Embervm.SyncWait do
   @doc "Releases a park slot previously `reserve/2`d; clamps at zero."
   @spec release(String.t()) :: :ok
   def release(principal) do
-    :ets.update_counter(@counts, principal, {2, -1, 0, 0})
+    # The {principal, 0} default makes a release for a key that does not exist
+    # yet (a release with no prior reserve) create it at 0 rather than raise;
+    # combined with the {2, -1, 0, 0} clamp the count can never go negative.
+    :ets.update_counter(@counts, principal, {2, -1, 0, 0}, {principal, 0})
     :ok
   end
 

--- a/projects/embervm/control/lib/embervm/sync_wait.ex
+++ b/projects/embervm/control/lib/embervm/sync_wait.ex
@@ -1,0 +1,117 @@
+defmodule Embervm.SyncWait do
+  @moduledoc """
+  Sync-submit parking: `POST /v1/workloads/{name}/tasks?wait=true` blocks the
+  caller until the task reaches a terminal state (or its timeout), rather than
+  returning 202 immediately. The spec requires a PARKED BEAM process, not a poll
+  loop, and a per-principal cap on how many parked waiters one principal may hold
+  (default 512), 429-ing beyond it (the miss-path wake-rate abuse guard).
+
+  Two primitives, both operating from the REQUEST process so the block never
+  serializes through a GenServer:
+
+    * a `Registry` (`Embervm.TaskWaiters`, duplicate keys) the request process
+      registers itself in under the `task_id`; `TaskStore` calls `notify/2` on
+      every terminal transition, which `Registry.dispatch`es a message to each
+      parked waiter for that task.
+    * a named public ETS counter table (`:embervm_park_counts`, one row per
+      principal) reserved/released around the park so the cap is enforced with a
+      single atomic `:ets.update_counter`, no lock.
+
+  This GenServer's ONLY job is to own the ETS table's lifecycle (create it on
+  init, so it dies with the supervision subtree). It handles no calls on the hot
+  path. The `Registry` is a sibling child in the supervision tree.
+  """
+  use GenServer
+
+  @registry Embervm.TaskWaiters
+  @counts :embervm_park_counts
+
+  # -- Client API ----------------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Reserves one park slot for `principal`, failing closed at `cap`. Returns `:ok`
+  when the reservation succeeds (the caller MUST `release/1` it when done), or
+  `{:error, :park_cap_exceeded}` when `principal` already holds `cap` parked
+  waiters. The increment and the over-cap rollback are two atomic counter ops, so
+  concurrent reservers cannot both slip past the cap.
+  """
+  @spec reserve(String.t(), pos_integer()) :: :ok | {:error, :park_cap_exceeded}
+  def reserve(principal, cap) do
+    count = :ets.update_counter(@counts, principal, {2, 1}, {principal, 0})
+
+    if count > cap do
+      # Roll our own increment back out; another reserver may sit at the cap,
+      # which is correct (they hold a real slot, we do not).
+      :ets.update_counter(@counts, principal, {2, -1, 0, 0})
+      {:error, :park_cap_exceeded}
+    else
+      :ok
+    end
+  end
+
+  @doc "Releases a park slot previously `reserve/2`d; clamps at zero."
+  @spec release(String.t()) :: :ok
+  def release(principal) do
+    :ets.update_counter(@counts, principal, {2, -1, 0, 0})
+    :ok
+  end
+
+  @doc """
+  Parks the calling process until a terminal `notify/2` for `task_id` arrives or
+  `timeout_ms` elapses. `already_terminal?` is a 0-arity function re-checked
+  AFTER registration to close the race where the task settled between submit and
+  registration: if it returns `{:terminal, state}` the parked wait is skipped.
+  Always unregisters before returning so a keep-alive-reused request process does
+  not leak a stale waiter registration.
+  """
+  @spec await(String.t(), non_neg_integer(), (-> {:terminal, atom()} | :pending)) ::
+          {:terminal, atom()} | :timeout
+  def await(task_id, timeout_ms, already_terminal?) do
+    {:ok, _} = Registry.register(@registry, task_id, nil)
+
+    try do
+      case already_terminal?.() do
+        {:terminal, state} ->
+          {:terminal, state}
+
+        :pending ->
+          receive do
+            {:task_terminal, ^task_id, state} -> {:terminal, state}
+          after
+            timeout_ms -> :timeout
+          end
+      end
+    after
+      Registry.unregister(@registry, task_id)
+    end
+  end
+
+  @doc """
+  Wakes every process parked on `task_id` with its terminal `state`. Called by
+  `TaskStore` after a terminal write-through append; a no-op when nobody is
+  parked (the common case), so it is cheap to call on every terminal transition.
+  """
+  @spec notify(String.t(), atom()) :: :ok
+  def notify(task_id, state) do
+    Registry.dispatch(@registry, task_id, fn entries ->
+      for {pid, _} <- entries, do: send(pid, {:task_terminal, task_id, state})
+    end)
+
+    :ok
+  end
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(_opts) do
+    # Named + public so request processes hit it directly; write_concurrency
+    # because reserve/release from many request processes race on distinct keys.
+    :ets.new(@counts, [:set, :public, :named_table, write_concurrency: true])
+    {:ok, %{}}
+  end
+end

--- a/projects/embervm/control/lib/embervm/task_state.ex
+++ b/projects/embervm/control/lib/embervm/task_state.ex
@@ -33,10 +33,26 @@ defmodule Embervm.TaskState do
 
   @terminal_states [:succeeded, :failed_permanent, :dead_lettered]
 
-  @events [:assign, :start, :succeed, :fail_retryable, :fail_permanent, :retry, :dead_letter]
+  @events [
+    :assign,
+    :start,
+    :succeed,
+    :fail_retryable,
+    :fail_permanent,
+    :retry,
+    :dead_letter,
+    :redrive
+  ]
 
   # The transition table. Every legal (state, event) pair the control plane
   # allows; anything not a key here is illegal by construction.
+  #
+  # `:redrive` is the DLQ escape hatch (Task 8): a dead-lettered task is
+  # terminal to the automatic pipeline, but an operator (or the redrive API)
+  # can move it back to `:queued` for another run. It is the ONLY event that
+  # leaves a terminal state, which is why it is enumerated explicitly rather
+  # than folded into `:retry` (retry increments the attempt counter and only
+  # applies to `:failed_retryable`; redrive RESETS the counter, see TaskStore).
   @transitions %{
     {:queued, :assign} => :assigned,
     {:assigned, :start} => :running,
@@ -46,7 +62,8 @@ defmodule Embervm.TaskState do
     {:running, :fail_retryable} => :failed_retryable,
     {:running, :fail_permanent} => :failed_permanent,
     {:failed_retryable, :retry} => :queued,
-    {:failed_permanent, :dead_letter} => :dead_lettered
+    {:failed_permanent, :dead_letter} => :dead_lettered,
+    {:dead_lettered, :redrive} => :queued
   }
 
   @type state ::
@@ -59,7 +76,14 @@ defmodule Embervm.TaskState do
           | :dead_lettered
 
   @type event ::
-          :assign | :start | :succeed | :fail_retryable | :fail_permanent | :retry | :dead_letter
+          :assign
+          | :start
+          | :succeed
+          | :fail_retryable
+          | :fail_permanent
+          | :retry
+          | :dead_letter
+          | :redrive
 
   @spec states() :: [state()]
   def states, do: @states

--- a/projects/embervm/control/lib/embervm/task_store.ex
+++ b/projects/embervm/control/lib/embervm/task_store.ex
@@ -47,7 +47,14 @@ defmodule Embervm.TaskStore do
   @doc """
   Submits a new task, or returns the existing one if `idempotency_key` was
   already seen for this workload. `attrs` is `%{tenant, principal, workload,
-  idempotency_key \\ nil, expires_at \\ nil}`.
+  idempotency_key \\ nil, expires_at \\ nil, request \\ nil}`.
+
+  `request` is the opaque guest-request envelope (path, content_type, guest
+  headers, base64 body) the submit API (Task 8) captures verbatim. It is stored
+  in the `submitted` op's payload, NOT projected into any column, so the durable
+  record is complete for the dispatcher (Task 11) to build its `AssignRequest`
+  from: an async 202 must not drop the body it accepted just because nothing
+  dispatches it yet.
   """
   @spec submit(GenServer.server(), map()) ::
           {:ok, :created, String.t()} | {:ok, :existing, String.t()} | {:error, term()}
@@ -92,6 +99,39 @@ defmodule Embervm.TaskStore do
   @spec get(GenServer.server(), String.t()) :: {:ok, map()} | :error
   def get(store \\ __MODULE__, task_id) do
     GenServer.call(store, {:get, task_id})
+  end
+
+  @doc """
+  Reads a task's stored result (until its TTL) from the durable result store,
+  returning `{:ok, map}`, `{:ok, nil}` (no result yet or TTL-reaped), or
+  `{:error, reason}`. Serves `GET /v1/tasks/{id}/result`; this is a result-store
+  read, never the ops log.
+  """
+  @spec get_result(GenServer.server(), String.t()) :: {:ok, map() | nil} | {:error, term()}
+  def get_result(store \\ __MODULE__, task_id) do
+    GenServer.call(store, {:get_result, task_id})
+  end
+
+  @doc """
+  Lists dead-lettered tasks for `workload`, newest first, paged by `:limit`
+  (default 50) and `:offset` (default 0). Serves `GET
+  /v1/workloads/{name}/dead-letters` from the ETS hot set (bounded and rare, so
+  a full scan is acceptable), never the op-log.
+  """
+  @spec list_dead_letters(GenServer.server(), String.t(), keyword()) :: {:ok, map()}
+  def list_dead_letters(store \\ __MODULE__, workload, opts \\ []) do
+    GenServer.call(store, {:list_dead_letters, workload, opts})
+  end
+
+  @doc """
+  Re-queues a dead-lettered task (`dead_lettered -> queued`), resetting its
+  attempt counter to 1 (a full fresh retry budget) and appending an audited
+  `redrive` op. Serves `POST /v1/tasks/{id}/redrive`. Fails `:illegal_transition`
+  for a task that is not dead-lettered.
+  """
+  @spec redrive(GenServer.server(), String.t()) :: {:ok, map()} | {:error, term()}
+  def redrive(store \\ __MODULE__, task_id) do
+    GenServer.call(store, {:redrive, task_id})
   end
 
   # -- GenServer callbacks ---------------------------------------------------
@@ -264,6 +304,61 @@ defmodule Embervm.TaskStore do
     end
   end
 
+  def handle_call({:get_result, task_id}, _from, state) do
+    {:reply, Embervm.OpLog.SQLite.load_result(state.op_log, task_id), state}
+  end
+
+  def handle_call({:list_dead_letters, workload, opts}, _from, state) do
+    limit = Keyword.get(opts, :limit, 50)
+    offset = Keyword.get(opts, :offset, 0)
+
+    all =
+      :ets.foldl(
+        fn {_id, task}, acc ->
+          if task.workload == workload and task.state == :dead_lettered do
+            [task | acc]
+          else
+            acc
+          end
+        end,
+        [],
+        state.tasks
+      )
+      |> Enum.sort_by(& &1.submitted_at, :desc)
+
+    page = all |> Enum.drop(offset) |> Enum.take(limit)
+    {:reply, {:ok, %{items: page, total: length(all), limit: limit, offset: offset}}, state}
+  end
+
+  def handle_call({:redrive, task_id}, _from, state) do
+    with {:ok, task} <- fetch_task(state, task_id),
+         {:ok, next} <- TaskState.transition(task.state, :redrive) do
+      ts = state.clock.()
+
+      op = %Op{
+        kind: :redrive,
+        tenant: task.tenant,
+        principal: task.principal,
+        workload: task.workload,
+        task_id: task_id,
+        ts: ts,
+        payload: %{}
+      }
+
+      case Embervm.OpLog.SQLite.append(state.op_log, op) do
+        {:ok, _seq} ->
+          updated = %{task | state: next, attempt: 1, updated_at: ts}
+          :ets.insert(state.tasks, {task_id, updated})
+          {:reply, {:ok, updated}, state}
+
+        {:error, _reason} = error ->
+          {:reply, error, state}
+      end
+    else
+      {:error, _reason} = error -> {:reply, error, state}
+    end
+  end
+
   # -- submit helpers --------------------------------------------------------
 
   defp do_submit(attrs, workload, idempotency_key, state) do
@@ -278,7 +373,11 @@ defmodule Embervm.TaskStore do
       workload: workload,
       task_id: task_id,
       ts: ts,
-      payload: %{idempotency_key: idempotency_key, expires_at: expires_at}
+      payload: %{
+        idempotency_key: idempotency_key,
+        expires_at: expires_at,
+        request: Map.get(attrs, :request)
+      }
     }
 
     case Embervm.OpLog.SQLite.append(state.op_log, op) do
@@ -347,6 +446,14 @@ defmodule Embervm.TaskStore do
       {:ok, _seq} ->
         updated = %{task | state: next_state, updated_at: ts}
         :ets.insert(state.tasks, {task.task_id, updated})
+        # Wake any sync-submit caller parked on this task the moment it settles
+        # terminal (succeeded or dead_lettered). No-op when nobody is parked, so
+        # it is safe to call on every transition; guarded to terminal states so
+        # intermediate assign/start transitions do not spuriously wake waiters.
+        if TaskState.terminal?(next_state) do
+          Embervm.SyncWait.notify(task.task_id, next_state)
+        end
+
         {:ok, updated}
 
       {:error, reason} ->

--- a/projects/embervm/control/test/embervm/auth_test.exs
+++ b/projects/embervm/control/test/embervm/auth_test.exs
@@ -1,0 +1,130 @@
+defmodule Embervm.AuthTest do
+  @moduledoc """
+  Exercises the TokenReview caching + singleflight reviewer with an injected
+  fake reviewer (no live API server), covering the properties the fc-invoke
+  incident hardened: cache hits avoid the reviewer, concurrent misses for one
+  token collapse to a single review, failures are never cached, the allow-list
+  is enforced, and a slow miss for one token does not block a cached hit for
+  another.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.Auth
+
+  # A reviewer whose call count is observable, so "how many times did the network
+  # review actually run" is directly assertable. `map` is token -> {:ok, user} |
+  # {:error, reason}; `delay_ms` optionally stalls each call to widen races.
+  defp counting_reviewer(map, delay_ms \\ 0) do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    fun = fn token ->
+      Agent.update(counter, &(&1 + 1))
+      if delay_ms > 0, do: Process.sleep(delay_ms)
+      Map.get(map, token, {:error, :unauthenticated})
+    end
+
+    {fun, counter}
+  end
+
+  defp start_auth(reviewer, opts \\ []) do
+    {:ok, pid} =
+      Auth.start_link(
+        [name: nil, reviewer: reviewer, allowed: ["system:serviceaccount:embervm:embervm"]] ++
+          opts
+      )
+
+    pid
+  end
+
+  test "authenticates an allow-listed principal and caches it (one review for two calls)" do
+    {reviewer, counter} =
+      counting_reviewer(%{"tok" => {:ok, "system:serviceaccount:embervm:embervm"}})
+
+    auth = start_auth(reviewer)
+
+    assert {:ok, "system:serviceaccount:embervm:embervm"} = Auth.authenticate(auth, "tok")
+    assert {:ok, "system:serviceaccount:embervm:embervm"} = Auth.authenticate(auth, "tok")
+    assert Agent.get(counter, & &1) == 1
+  end
+
+  test "authenticated-but-not-allow-listed is forbidden and not cached" do
+    {reviewer, counter} = counting_reviewer(%{"tok" => {:ok, "system:serviceaccount:other:sa"}})
+    auth = start_auth(reviewer)
+
+    assert {:error, :forbidden} = Auth.authenticate(auth, "tok")
+    assert {:error, :forbidden} = Auth.authenticate(auth, "tok")
+    # Denials are not cached: the reviewer runs each time.
+    assert Agent.get(counter, & &1) == 2
+  end
+
+  test "transient review failures are never cached" do
+    {reviewer, counter} = counting_reviewer(%{"tok" => {:error, :unauthenticated}})
+    auth = start_auth(reviewer)
+
+    assert {:error, :unauthenticated} = Auth.authenticate(auth, "tok")
+    assert {:error, :unauthenticated} = Auth.authenticate(auth, "tok")
+    assert Agent.get(counter, & &1) == 2
+  end
+
+  test "concurrent misses for the same token collapse to a single review (singleflight)" do
+    {reviewer, counter} =
+      counting_reviewer(%{"tok" => {:ok, "system:serviceaccount:embervm:embervm"}}, 50)
+
+    auth = start_auth(reviewer)
+
+    results =
+      1..20
+      |> Task.async_stream(fn _ -> Auth.authenticate(auth, "tok") end, max_concurrency: 20)
+      |> Enum.map(fn {:ok, r} -> r end)
+
+    assert Enum.all?(results, &(&1 == {:ok, "system:serviceaccount:embervm:embervm"}))
+    # All 20 concurrent misses shared ONE review.
+    assert Agent.get(counter, & &1) == 1
+  end
+
+  test "a slow miss for one token does not block a cached hit for another" do
+    {reviewer, _counter} =
+      counting_reviewer(
+        %{
+          "slow" => {:ok, "system:serviceaccount:embervm:embervm"},
+          "fast" => {:ok, "system:serviceaccount:embervm:embervm"}
+        },
+        200
+      )
+
+    auth = start_auth(reviewer)
+
+    # Prime "fast" so it is a cache hit.
+    assert {:ok, _} = Auth.authenticate(auth, "fast")
+
+    # Start a slow miss for "slow" in the background, then a hit for "fast" must
+    # return well before the slow review completes.
+    slow = Task.async(fn -> Auth.authenticate(auth, "slow") end)
+    {micros, {:ok, _}} = :timer.tc(fn -> Auth.authenticate(auth, "fast") end)
+
+    assert micros < 100_000, "cached hit blocked behind the slow miss (#{micros}us)"
+    assert {:ok, _} = Task.await(slow)
+  end
+
+  test "cache entries expire after the TTL" do
+    {reviewer, counter} =
+      counting_reviewer(%{"tok" => {:ok, "system:serviceaccount:embervm:embervm"}})
+
+    {:ok, clock} = Agent.start_link(fn -> 0 end)
+    clock_fun = fn -> Agent.get(clock, & &1) end
+    auth = start_auth(reviewer, ttl_ms: 1_000, clock: clock_fun)
+
+    assert {:ok, _} = Auth.authenticate(auth, "tok")
+    assert Agent.get(counter, & &1) == 1
+
+    # Still inside the TTL window: served from cache.
+    Agent.update(clock, fn _ -> 999 end)
+    assert {:ok, _} = Auth.authenticate(auth, "tok")
+    assert Agent.get(counter, & &1) == 1
+
+    # Past the TTL: re-reviewed.
+    Agent.update(clock, fn _ -> 1_001 end)
+    assert {:ok, _} = Auth.authenticate(auth, "tok")
+    assert Agent.get(counter, & &1) == 2
+  end
+end

--- a/projects/embervm/control/test/embervm/router_test.exs
+++ b/projects/embervm/control/test/embervm/router_test.exs
@@ -1,0 +1,214 @@
+defmodule Embervm.RouterTest do
+  @moduledoc """
+  Request tests for the submit API, driving the LIVE Bandit instance the
+  application boots (over the Embervm.Finch pool on loopback) with an injected
+  fake authenticator, so no live Kubernetes API server is needed. `async: false`
+  because these mutate global application env (the authenticator + sync knobs)
+  and share the one running control-plane instance; unique workloads and
+  idempotency keys keep tasks from colliding across tests.
+  """
+  use ExUnit.Case, async: false
+
+  alias Embervm.TaskStore
+
+  @allowed "system:serviceaccount:embervm:embervm"
+
+  defmodule FakeAuth do
+    @allowed "system:serviceaccount:embervm:embervm"
+    def authenticate("good"), do: {:ok, @allowed}
+    def authenticate("good2"), do: {:ok, "principal-2"}
+    def authenticate("forbidden"), do: {:error, :forbidden}
+    def authenticate(_), do: {:error, :unauthenticated}
+  end
+
+  setup do
+    Application.put_env(:embervm, :authenticator, FakeAuth)
+
+    on_exit(fn ->
+      Application.delete_env(:embervm, :authenticator)
+      Application.delete_env(:embervm, :sync_park_cap)
+      Application.delete_env(:embervm, :sync_timeout_ms)
+    end)
+
+    :ok
+  end
+
+  defp unique(prefix), do: "#{prefix}-#{System.unique_integer([:positive, :monotonic])}"
+
+  defp req(method, path, headers \\ [], body \\ "") do
+    {:ok, resp} =
+      Finch.build(method, "http://127.0.0.1:8080#{path}", headers, body)
+      |> Finch.request(Embervm.Finch)
+
+    resp
+  end
+
+  defp auth(token), do: [{"authorization", "Bearer " <> token}]
+
+  defp json(body), do: :json.decode(body)
+
+  # -- auth ------------------------------------------------------------------
+
+  test "a /v1 request without a token is 401" do
+    resp = req(:post, "/v1/workloads/#{unique("wl")}/tasks")
+    assert resp.status == 401
+  end
+
+  test "an unauthenticated token is 401" do
+    resp = req(:post, "/v1/workloads/#{unique("wl")}/tasks", auth("nope"), "x")
+    assert resp.status == 401
+  end
+
+  test "an authenticated but non-allow-listed token is 403" do
+    resp = req(:post, "/v1/workloads/#{unique("wl")}/tasks", auth("forbidden"), "x")
+    assert resp.status == 403
+  end
+
+  test "/healthz needs no auth" do
+    resp = req(:get, "/healthz")
+    assert resp.status == 200
+    assert resp.body == "ok"
+  end
+
+  # -- submit ----------------------------------------------------------------
+
+  test "async submit returns 202 and creates a queued task backed by the op-log" do
+    wl = unique("wl")
+    resp = req(:post, "/v1/workloads/#{wl}/tasks", auth("good"), "source-file-bytes")
+
+    assert resp.status == 202
+    body = json(resp.body)
+    assert body["state"] == "queued"
+    task_id = body["task_id"]
+    assert is_binary(task_id)
+
+    # The queued task is durable (write-through op-log projection surfaced via
+    # the ETS hot set): GET reflects it.
+    got = req(:get, "/v1/tasks/#{task_id}", auth("good"))
+    assert got.status == 200
+    view = json(got.body)
+    assert view["state"] == "queued"
+    assert view["workload"] == wl
+    assert view["attempt"] == 1
+  end
+
+  test "Idempotency-Key dedupes a resubmit to the same task" do
+    wl = unique("wl")
+    key = unique("idem")
+    headers = auth("good") ++ [{"idempotency-key", key}]
+
+    a = req(:post, "/v1/workloads/#{wl}/tasks", headers, "body")
+    b = req(:post, "/v1/workloads/#{wl}/tasks", headers, "body")
+
+    assert a.status == 202
+    assert b.status == 202
+    assert json(a.body)["task_id"] == json(b.body)["task_id"]
+  end
+
+  test "a body over 8 MiB is rejected 413" do
+    wl = unique("wl")
+    big = :binary.copy("a", 8_388_609)
+    resp = req(:post, "/v1/workloads/#{wl}/tasks", auth("good"), big)
+    assert resp.status == 413
+  end
+
+  # -- reads -----------------------------------------------------------------
+
+  test "GET unknown task is 404" do
+    resp = req(:get, "/v1/tasks/#{unique("nope")}", auth("good"))
+    assert resp.status == 404
+  end
+
+  test "GET result is 404 before any result exists" do
+    wl = unique("wl")
+    task_id = json(req(:post, "/v1/workloads/#{wl}/tasks", auth("good"), "x").body)["task_id"]
+
+    resp = req(:get, "/v1/tasks/#{task_id}/result", auth("good"))
+    assert resp.status == 404
+  end
+
+  # -- sync ------------------------------------------------------------------
+
+  test "sync submit returns the stored guest result when the task is already terminal" do
+    wl = unique("wl")
+    key = unique("idem")
+    headers = auth("good") ++ [{"idempotency-key", key}]
+
+    # Create the task, then drive it to success directly (no dispatcher in R0).
+    task_id = json(req(:post, "/v1/workloads/#{wl}/tasks", headers, "x").body)["task_id"]
+    {:ok, _} = TaskStore.assign(task_id)
+    {:ok, _} = TaskStore.start(task_id)
+
+    {:ok, _} =
+      TaskStore.succeed(task_id, %{
+        status_code: 201,
+        body: "FINDINGS",
+        size_bytes: 8,
+        truncated: false
+      })
+
+    # A sync submit with the same idempotency key resolves to the existing,
+    # now-terminal task; the already-terminal re-check returns its result without
+    # a real park.
+    resp = req(:post, "/v1/workloads/#{wl}/tasks?wait=true", headers, "x")
+    assert resp.status == 201
+    assert resp.body == "FINDINGS"
+  end
+
+  test "sync submit is 429 when the principal's park cap is exhausted" do
+    Application.put_env(:embervm, :sync_park_cap, 0)
+    wl = unique("wl")
+
+    resp = req(:post, "/v1/workloads/#{wl}/tasks?wait=true", auth("good"), "x")
+    assert resp.status == 429
+    assert json(resp.body)["retryable"] == true
+  end
+
+  test "sync submit times out to 202 while work is still in flight" do
+    Application.put_env(:embervm, :sync_timeout_ms, 60)
+    wl = unique("wl")
+
+    resp = req(:post, "/v1/workloads/#{wl}/tasks?wait=true", auth("good"), "x")
+    assert resp.status == 202
+    assert json(resp.body)["state"] == "queued"
+  end
+
+  # -- DLQ + redrive ---------------------------------------------------------
+
+  test "dead-letter listing and redrive round-trip" do
+    wl = unique("wl")
+
+    {:ok, :created, task_id} =
+      TaskStore.submit(%{tenant: "homelab", principal: @allowed, workload: wl})
+
+    {:ok, _} = TaskStore.assign(task_id)
+    # guest4xx is always permanent, so this dead-letters in one step.
+    {:ok, dl} = TaskStore.fail(task_id, :guest4xx)
+    assert dl.state == :dead_lettered
+
+    listed = req(:get, "/v1/workloads/#{wl}/dead-letters", auth("good"))
+    assert listed.status == 200
+    body = json(listed.body)
+    assert body["total"] == 1
+    assert [item] = body["items"]
+    assert item["task_id"] == task_id
+    assert item["state"] == "dead_lettered"
+
+    redriven = req(:post, "/v1/tasks/#{task_id}/redrive", auth("good"))
+    assert redriven.status == 200
+    assert json(redriven.body)["state"] == "queued"
+
+    got = req(:get, "/v1/tasks/#{task_id}", auth("good"))
+    assert json(got.body)["state"] == "queued"
+    # Attempt counter was reset to a fresh budget.
+    assert json(got.body)["attempt"] == 1
+  end
+
+  test "redrive of a non-dead-lettered task is 409" do
+    wl = unique("wl")
+    {:ok, :created, task_id} = TaskStore.submit(%{tenant: "homelab", principal: @allowed, workload: wl})
+
+    resp = req(:post, "/v1/tasks/#{task_id}/redrive", auth("good"))
+    assert resp.status == 409
+  end
+end

--- a/projects/embervm/control/test/embervm/router_test.exs
+++ b/projects/embervm/control/test/embervm/router_test.exs
@@ -106,9 +106,19 @@ defmodule Embervm.RouterTest do
   end
 
   test "a body over 8 MiB is rejected 413" do
+    # An over-cap POST is answered 413 BEFORE the server reads the whole body,
+    # which leaves the HTTP/1.1 connection with an undrained tail. Reusing that
+    # pooled connection for a later request would misframe and hang it, so this
+    # abnormal request runs against its OWN throwaway Finch pool that no other
+    # test shares; the app's shared Embervm.Finch pool is never poisoned.
+    start_supervised!({Finch, name: __MODULE__.BigBodyFinch})
     wl = unique("wl")
     big = :binary.copy("a", 8_388_609)
-    resp = req(:post, "/v1/workloads/#{wl}/tasks", auth("good"), big)
+
+    {:ok, resp} =
+      Finch.build(:post, "http://127.0.0.1:8080/v1/workloads/#{wl}/tasks", auth("good"), big)
+      |> Finch.request(__MODULE__.BigBodyFinch)
+
     assert resp.status == 413
   end
 

--- a/projects/embervm/control/test/embervm/sync_wait_test.exs
+++ b/projects/embervm/control/test/embervm/sync_wait_test.exs
@@ -1,0 +1,79 @@
+defmodule Embervm.SyncWaitTest do
+  @moduledoc """
+  Exercises the sync-submit parking primitives against the application's global
+  waiter registry and park-count table (both booted by the supervision tree).
+  Keys are made unique per test so these stay `async` despite the shared tables.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.SyncWait
+
+  defp unique(prefix), do: "#{prefix}-#{System.unique_integer([:positive, :monotonic])}"
+
+  defp wait_until(fun, tries \\ 200)
+  defp wait_until(_fun, 0), do: flunk("condition never became true")
+
+  defp wait_until(fun, tries) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(5)
+      wait_until(fun, tries - 1)
+    end
+  end
+
+  test "reserve enforces the per-principal cap; release frees a slot" do
+    p = unique("principal")
+
+    assert :ok = SyncWait.reserve(p, 2)
+    assert :ok = SyncWait.reserve(p, 2)
+    assert {:error, :park_cap_exceeded} = SyncWait.reserve(p, 2)
+
+    assert :ok = SyncWait.release(p)
+    assert :ok = SyncWait.reserve(p, 2)
+  end
+
+  test "release clamps at zero and never goes negative" do
+    p = unique("principal")
+    assert :ok = SyncWait.release(p)
+    assert :ok = SyncWait.release(p)
+    # After spurious releases the count is still 0, so a fresh reserve at cap 1
+    # succeeds exactly once.
+    assert :ok = SyncWait.reserve(p, 1)
+    assert {:error, :park_cap_exceeded} = SyncWait.reserve(p, 1)
+  end
+
+  test "await wakes on a terminal notify with the settled state" do
+    t = unique("task")
+    parent = self()
+
+    spawn(fn ->
+      send(parent, {:result, SyncWait.await(t, 1_000, fn -> :pending end)})
+    end)
+
+    # Wait until the waiter has registered, then notify.
+    wait_until(fn -> Registry.lookup(Embervm.TaskWaiters, t) != [] end)
+    SyncWait.notify(t, :succeeded)
+
+    assert_receive {:result, {:terminal, :succeeded}}, 1_000
+  end
+
+  test "await times out when nothing settles" do
+    t = unique("task")
+    assert :timeout = SyncWait.await(t, 40, fn -> :pending end)
+  end
+
+  test "await short-circuits when the task is already terminal (submit/settle race)" do
+    t = unique("task")
+    # No notify is ever sent; the re-check after registration catches the task
+    # that settled between submit and registration.
+    assert {:terminal, :dead_lettered} =
+             SyncWait.await(t, 5_000, fn -> {:terminal, :dead_lettered} end)
+  end
+
+  test "await unregisters the waiter on return (no leak for a reused process)" do
+    t = unique("task")
+    assert :timeout = SyncWait.await(t, 20, fn -> :pending end)
+    assert Registry.lookup(Embervm.TaskWaiters, t) == []
+  end
+end

--- a/projects/embervm/control/test/embervm/task_state_test.exs
+++ b/projects/embervm/control/test/embervm/task_state_test.exs
@@ -18,11 +18,12 @@ defmodule Embervm.TaskStateTest do
     {:running, :fail_retryable} => :failed_retryable,
     {:running, :fail_permanent} => :failed_permanent,
     {:failed_retryable, :retry} => :queued,
-    {:failed_permanent, :dead_letter} => :dead_lettered
+    {:failed_permanent, :dead_letter} => :dead_lettered,
+    {:dead_lettered, :redrive} => :queued
   }
 
   test "exhaustive transition table: every (state, event) pair matches the documented outcome" do
-    assert map_size(@legal) == 9
+    assert map_size(@legal) == 10
 
     for state <- TaskState.states(), event <- TaskState.events() do
       case Map.fetch(@legal, {state, event}) do

--- a/projects/embervm/control/test/embervm/task_store_test.exs
+++ b/projects/embervm/control/test/embervm/task_store_test.exs
@@ -244,4 +244,58 @@ defmodule Embervm.TaskStoreTest do
     {:ok, ops} = SQLite.read_from(op_log, 0)
     assert Enum.count(ops, &(&1.kind == :submitted)) == 1
   end
+
+  test "get_result returns the stored result, then nil for an unknown task", %{path: path} do
+    {_op_log, store} = start_pair(path)
+
+    {:ok, :created, task_id} =
+      TaskStore.submit(store, %{tenant: "t1", principal: "p1", workload: "wl-a"})
+
+    {:ok, _} = TaskStore.assign(store, task_id)
+    {:ok, _} = TaskStore.start(store, task_id)
+
+    {:ok, _} =
+      TaskStore.succeed(store, task_id, %{
+        status_code: 201,
+        body: "FINDINGS",
+        size_bytes: 8,
+        truncated: false
+      })
+
+    assert {:ok, %{status_code: 201, body: "FINDINGS", truncated: false}} =
+             TaskStore.get_result(store, task_id)
+
+    assert {:ok, nil} = TaskStore.get_result(store, "does-not-exist")
+  end
+
+  test "redrive re-queues a dead-lettered task, resets attempt, and survives restart", %{
+    path: path
+  } do
+    {op_log, store} = start_pair(path)
+
+    {:ok, :created, task_id} =
+      TaskStore.submit(store, %{tenant: "t1", principal: "p1", workload: "wl-a"})
+
+    # Drive to dead-lettered via a permanent (guest4xx) failure.
+    {:ok, _} = TaskStore.assign(store, task_id)
+    {:ok, dl} = TaskStore.fail(store, task_id, :guest4xx)
+    assert dl.state == :dead_lettered
+
+    {:ok, redriven} = TaskStore.redrive(store, task_id)
+    assert redriven.state == :queued
+    assert redriven.attempt == 1
+
+    # Redriving a task that is not dead-lettered is an illegal transition.
+    assert {:error, {:illegal_transition, :queued, :redrive}} =
+             TaskStore.redrive(store, task_id)
+
+    # The reset persists: a fresh TaskStore rebuilt from the op-log sees queued
+    # at attempt 1, proving the :redrive projection wrote through durably.
+    :ok = GenServer.stop(store)
+    {:ok, store2} = TaskStore.start_link(op_log: op_log, name: nil)
+
+    {:ok, rebuilt} = TaskStore.get(store2, task_id)
+    assert rebuilt.state == :queued
+    assert rebuilt.attempt == 1
+  end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.5
+      targetRevision: 0.1.6
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -8,3 +8,13 @@ opLog:
   # Deployment is Recreate + 1 replica because SQLite is single-writer and the
   # volume is RWO.
   size: 2Gi
+
+# TokenReview allow-list: ServiceAccount usernames permitted to submit tasks
+# (Task 8). Empty means deny-all (fail-closed). In R0 the only entry is the
+# control plane's own ServiceAccount, which lets an operator round-trip a live
+# TokenReview-authed submit with `kubectl create token embervm -n embervm`; the
+# real consumer SAs (the monolith semgrep scanner) are added at the Task 14/15
+# side-by-side/shadow cutover, not here.
+auth:
+  allowedServiceAccounts:
+    - system:serviceaccount:embervm:embervm

--- a/projects/embervm/docs/api.yaml
+++ b/projects/embervm/docs/api.yaml
@@ -1,0 +1,159 @@
+# EmberVM submit API (Task 8, invocation front-end). Hand-written contract; this
+# is what the monolith scan client (Task 15) programs against. Served by the
+# control plane on :8080 behind the cluster Service; every /v1 path requires a
+# bearer token authenticated by Kubernetes TokenReview against the allow-list.
+openapi: 3.1.0
+info:
+  title: EmberVM Submit API
+  version: v1
+  description: >-
+    Durable, fair, retried task execution over the Firecracker fleet. A task is
+    one HTTP request to a guest: the submit body is forwarded verbatim as the
+    guest request body. R0 has no dispatcher yet, so submitted tasks sit queued;
+    the async submit + task/result/DLQ surface is the stable contract.
+servers:
+  - url: http://embervm.embervm.svc.cluster.local:8080
+security:
+  - bearerAuth: []
+paths:
+  /healthz:
+    get:
+      summary: Liveness/readiness probe (unauthenticated).
+      security: []
+      responses:
+        "200":
+          description: OK.
+          content:
+            text/plain:
+              schema: { type: string, example: ok }
+  /v1/workloads/{name}/tasks:
+    post:
+      summary: Submit a task to a workload.
+      parameters:
+        - { name: name, in: path, required: true, schema: { type: string } }
+        - name: wait
+          in: query
+          required: false
+          schema: { type: boolean }
+          description: >-
+            When true, park the request until the task reaches a terminal state
+            or the sync timeout elapses, then return the guest response directly.
+            When false/absent, return 202 immediately with the task id.
+      requestBody:
+        description: >-
+          Forwarded verbatim as the guest request body (max 8 MiB). Content-Type
+          is forwarded. Headers prefixed X-Ember-Guest- are stripped of the
+          prefix and forwarded to the guest; no other caller header reaches it.
+        required: false
+        content:
+          application/octet-stream:
+            schema: { type: string, format: binary }
+      parameters_headers_note: >-
+        X-Ember-Guest-Path overrides the guest path (default spec.source.invokePath).
+        Idempotency-Key dedupes a resubmit to the existing task for its result TTL.
+      responses:
+        "202":
+          description: Accepted (async), or sync wait timed out with work still in flight.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskRef" }
+        "200":
+          description: Sync wait completed; body is the guest response (untruncated).
+        "413": { description: Body exceeds 8 MiB. }
+        "429":
+          description: Per-principal sync-wait park cap exceeded.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401": { description: Missing or invalid bearer token. }
+        "403": { description: Authenticated ServiceAccount not in the allow-list. }
+        "502": { description: Sync wait settled non-successfully (dead-lettered). }
+  /v1/tasks/{id}:
+    get:
+      summary: Task state and metadata.
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: Task view.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskView" }
+        "404": { description: No such task. }
+  /v1/tasks/{id}/result:
+    get:
+      summary: Stored task result (until its TTL).
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: >-
+            The stored guest response body, at the guest status code. The
+            X-Ember-Truncated header is true when the stored copy was capped at
+            the workload resultMaxBytes.
+        "404": { description: No result (task never ran or the TTL expired). }
+  /v1/workloads/{name}/dead-letters:
+    get:
+      summary: Paged dead-letter queue listing for a workload.
+      parameters:
+        - { name: name, in: path, required: true, schema: { type: string } }
+        - { name: limit, in: query, schema: { type: integer, default: 50, minimum: 1, maximum: 500 } }
+        - { name: offset, in: query, schema: { type: integer, default: 0, minimum: 0 } }
+      responses:
+        "200":
+          description: DLQ page (newest first).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/DeadLetterPage" }
+  /v1/tasks/{id}/redrive:
+    post:
+      summary: Re-queue a dead-lettered task (attempt counter reset, audited).
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: Redriven; task is queued again.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskView" }
+        "404": { description: No such task. }
+        "409": { description: Task is not dead-lettered. }
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    TaskRef:
+      type: object
+      properties:
+        task_id: { type: string }
+        state: { type: string }
+    TaskView:
+      type: object
+      properties:
+        task_id: { type: string }
+        workload: { type: string }
+        principal: { type: string }
+        state:
+          type: string
+          enum: [queued, assigned, running, succeeded, failed_retryable, failed_permanent, dead_lettered]
+        attempt: { type: integer }
+        submitted_at: { type: integer, description: epoch ms }
+        updated_at: { type: integer, description: epoch ms }
+    DeadLetterPage:
+      type: object
+      properties:
+        workload: { type: string }
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/TaskView" }
+        total: { type: integer }
+        limit: { type: integer }
+        offset: { type: integer }
+    Error:
+      type: object
+      properties:
+        error: { type: string }
+        task_id: { type: string }
+        retryable: { type: boolean }


### PR DESCRIPTION
## What (Task 8, invocation front-end)

The caller-facing HTTP surface for EmberVM, a separate module from placement (v1 invariant). Served by the Bandit-hosted `Embervm.Router`.

- `POST /v1/workloads/{name}/tasks` — async `202` + task_id, or `?wait=true` parks the request until the task is terminal or the sync timeout elapses.
- `GET /v1/tasks/{id}` and `/result`, `GET /v1/workloads/{name}/dead-letters` (paged DLQ), `POST /v1/tasks/{id}/redrive`.
- OpenAPI contract at `projects/embervm/docs/api.yaml` (what the Task 15 monolith client programs against).

## Task envelope

A task **is one HTTP request to the guest**. The submit body is forwarded verbatim (the route runs no `Plug.Parsers`); the guest path defaults to `spec.source.invokePath` (hard-coded `/` until Task 5's catalog), overridable via `X-Ember-Guest-Path`; `X-Ember-Guest-*` headers are stripped of the prefix and forwarded. The whole envelope is captured into the durable `submitted` record so the Task 11 dispatcher loses nothing (an async 202 must not drop the body it accepted).

## TokenReview auth (the fc-invoke 5-QPS lesson)

`Embervm.Auth` ports the fc-invoke pattern to the BEAM: bearer → TokenReview (`Embervm.K8s` over Finch/Mint) → allow-list, with a `sha256(token) → principal` cache at 60s TTL and **singleflight**. The GenServer's serial `handle_call` *is* the singleflight lock; the network review runs in a spawned process replying via `handle_info`, so **a slow miss for one token never blocks a cached hit for another** (the exact shape of the fc-invoke 5-QPS TokenReview incident, PR #3352). Failures and denials are never cached. Allow-list from `values.auth.allowedServiceAccounts` (empty = deny-all, fail-closed). K8s client dials `kubernetes.default.svc` by DNS name so TLS verifies cleanly against the SA `ca.crt`; the SA token is re-read per call so hourly rotation needs no restart.

## Sync wait

`Embervm.SyncWait`: a parked BEAM process (a duplicate `Registry` for wake dispatch + an ETS counter for the per-principal park cap), **not a poll loop**. Excess sync submits past the cap are rejected `429`. `TaskStore` wakes waiters on terminal write-through; on wake the router re-reads `TaskStore` for the authoritative state.

## Supporting changes

- `TaskState`: `dead_lettered -> redrive -> queued`.
- Op-log: new `:redrive` kind (projects `state=queued`, attempt reset) + a `load_result` reader (behaviour callback + SQLite impl).
- `TaskStore`: `get_result`, `list_dead_letters`, `redrive`, and terminal-transition waiter notify.
- Chart bumped `0.1.5 -> 0.1.6` with the allow-list env; RBAC already grants `tokenreviews create`.

## Tests

New `auth_test` (cache hit / singleflight collapse / TTL / allow-list deny / failure-not-cached / slow-miss-doesn't-block-hit), `sync_wait_test` (cap, wake, timeout, race short-circuit, no-leak), `router_test` (auth 401/403, async 202 + queued record, idempotency, 413, sync already-terminal result, 429 park cap, sync timeout→202, DLQ+redrive), plus `task_store_test` result/redrive-restart durability and the updated FSM exhaustive test.

Reviewed by an independent Opus pass before push (no defects). In R0 there is no dispatcher yet, so submitted tasks sit `queued`; that is the deploy-verification target.

Part of EmberVM R0 Phase 1 (`docs/plans/2026-07-12-embervm-r0-tasks-spec-and-plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)