### PR TITLE
fix(embervm): correct submit-API allow-list to the real SA name

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -16,5 +16,11 @@ opLog:
 # real consumer SAs (the monolith semgrep scanner) are added at the Task 14/15
 # side-by-side/shadow cutover, not here.
 auth:
+  # The control plane's own ServiceAccount is Helm-fullname-prefixed
+  # (<release>-<chart> = embervm-embervm), so the principal TokenReview returns
+  # is system:serviceaccount:embervm:embervm-embervm, not :embervm. This lets an
+  # operator round-trip a live submit with `kubectl create token embervm-embervm
+  # -n embervm`. Real consumer SAs (the monolith semgrep scanner) are added at
+  # the Task 14/15 cutover.
   allowedServiceAccounts:
-    - system:serviceaccount:embervm:embervm
+    - system:serviceaccount:embervm:embervm-embervm


### PR DESCRIPTION
One-line deploy-values fix. The control-plane SA is fullname-prefixed `embervm-embervm`, so TokenReview returns `system:serviceaccount:embervm:embervm-embervm`, but the allow-list listed `:embervm`. Verified live in-cluster: a valid SA token authenticated then hit 403 "service account not permitted" purely from this mismatch; the rest of the TokenReview + singleflight + allow-list pipeline works. deploy/values.yaml is the git $values source (read from HEAD), so no chart bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)