### PR TITLE
feat(signoz): Hubble policy-drop alert + scrape job

### DIFF
--- a/projects/platform/signoz-addons/alerts/templates/hubble-policy-drops.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/hubble-policy-drops.yaml
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubble-policy-drops-alert
+  labels:
+    signoz.io/alert: "true"
+  annotations:
+    signoz.io/alert-name: "Hubble CiliumNetworkPolicy Drops"
+    signoz.io/severity: "warning"
+    signoz.io/notification-channels: "incidentio"
+data:
+  alert.json: |
+    {
+      "alert": "Hubble CiliumNetworkPolicy Drops",
+      "alertType": "METRICS_BASED_ALERT",
+      "ruleType": "threshold_rule",
+      "version": "v5",
+      "broadcastToAll": false,
+      "disabled": false,
+      "evalWindow": "5m0s",
+      "frequency": "1m0s",
+      "severity": "warning",
+      "labels": {
+        "category": "network",
+        "environment": "production"
+      },
+      "annotations": {
+        "summary": "Cilium is dropping traffic due to a NetworkPolicy denial",
+        "description": "hubble_drop_total{reason=\"POLICY_DENIED\"} increased in the last 5 minutes, meaning a CiliumNetworkPolicy is denying traffic (protocol {{ "{{" }} $labels.protocol {{ "}}" }}). This metric has no source/destination workload labels; investigate with `hubble observe --verdict DROPPED` to find what is being blocked."
+      },
+      "condition": {
+        "compositeQuery": {
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
+                  {
+                    "timeAggregation": "increase",
+                    "spaceAggregation": "sum",
+                    "metricName": "hubble_drop_total"
+                  }
+                ],
+                "filter": {
+                  "expression": "reason = 'POLICY_DENIED'"
+                },
+                "groupBy": [
+                  {
+                    "name": "protocol",
+                    "fieldDataType": "string",
+                    "fieldContext": "tag"
+                  },
+                  {
+                    "name": "reason",
+                    "fieldDataType": "string",
+                    "fieldContext": "tag"
+                  }
+                ],
+                "order": [],
+                "disabled": false
+              }
+            }
+          ],
+          "panelType": "graph",
+          "queryType": "builder"
+        },
+        "selectedQueryName": "A",
+        "op": "1",
+        "target": 0,
+        "matchType": "1",
+        "targetUnit": "",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "warning",
+              "target": 0,
+              "targetUnit": "",
+              "matchType": "1",
+              "op": "1",
+              "channels": ["incidentio"]
+            }
+          ]
+        }
+      },
+      "preferredChannels": ["incidentio"]
+    }

--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -82,6 +82,37 @@ k8s-infra:
                     labels:
                       service: monolith-postgres
 
+        # Prometheus scraper for Cilium Hubble metrics (node-local flow metrics)
+        # Cilium agent pods expose Hubble metrics on port 9965; scrape them
+        # directly via pod service discovery rather than the headless Service.
+        prometheus/hubble:
+          config:
+            scrape_configs:
+              - job_name: "hubble"
+                scrape_interval: 15s
+                kubernetes_sd_configs:
+                  - role: pod
+                    namespaces:
+                      names: ["kube-system"]
+                relabel_configs:
+                  # Keep only Cilium agent pods
+                  - source_labels: [__meta_kubernetes_pod_label_k8s_app]
+                    action: keep
+                    regex: cilium
+                  # Skip pods that are not yet Running
+                  - source_labels: [__meta_kubernetes_pod_phase]
+                    action: keep
+                    regex: Running
+                  # Scrape the Hubble metrics port on each pod IP
+                  - source_labels: [__meta_kubernetes_pod_ip]
+                    target_label: __address__
+                    replacement: "$1:9965"
+                  # Propagate k8s context labels for filtering in SigNoz
+                  - source_labels: [__meta_kubernetes_namespace]
+                    target_label: k8s_namespace_name
+                  - source_labels: [__meta_kubernetes_pod_name]
+                    target_label: k8s_pod_name
+
         # =============================================================================
         # Synthetic HTTP Health Checks
         # Monitors all public domains for availability and response time
@@ -154,6 +185,7 @@ k8s-infra:
             receivers:
               - prometheus/dcgm
               - prometheus/cnpg
+              - prometheus/hubble
               - httpcheck/k8s-services
               - httpcheck/cloudflare-pages
             processors:


### PR DESCRIPTION
Implements **capability #1** of ADR networking/003: the cheapest, standalone Cilium observability win, a safety net for the egress default-deny gates we started running with the Cilium migration.

## What

- **Scrape job** (`projects/platform/signoz/values-prod.yaml`): a `prometheus/hubble` receiver scraping Cilium's Hubble metrics from the `cilium-agent` pods (`kube-system`, `k8s-app=cilium`) on `:9965`, wired into the `metrics/scraper` pipeline. Modeled on the `prometheus/linkerd-proxy` job removed in the Cilium migration, same SigNoz slot, now fed by Hubble.
- **Policy-drop alert** (`projects/platform/signoz-addons/alerts/templates/hubble-policy-drops.yaml`): fires when `hubble_drop_total{reason="POLICY_DENIED"}` increases, meaning a CiliumNetworkPolicy is dropping traffic. Routes to `incidentio`.

## Why the filter is load-bearing

Captured live from the cluster: `hubble_drop_total` carries heavy baseline noise (`STALE_OR_UNROUTABLE_IP` ~72k, plus `INVALID_IDENTITY`, `UNSUPPORTED_L2/L3_PROTOCOL`, `VLAN_FILTERED`). Alerting on raw drops would page constantly. The alert filters to `reason = 'POLICY_DENIED'` only (currently zero, correctly, nothing is being denied), so it fires exactly when a policy black-holes traffic. The metric has no source/destination workload labels, so the alert says "policy is dropping traffic, investigate with `hubble observe --verdict DROPPED`" rather than naming the workload, which is the right scope for a safety net.

## Notes

- No chart bump: both SigNoz Applications sync from the git path at HEAD.
- The `httpV2` L7 golden-signal alerts are deliberately **not** here, they require an L7 CiliumNetworkPolicy per surface to emit any series, so they live in the policy-hardening plan.
- The topology-endpoint decommission (also in the observability plan) is being split into its own follow-up PR: it turned out to touch a live Argo CronWorkflow and the public-tier contract tests, a larger refactor independent of this safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)