### PR TITLE
feat(cilium): L7 POST /invoke enforcement + httpV2 metric + 5xx alert (ADR networking/003 #2)

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.80
+version: 0.4.81

--- a/projects/firecracker/substrate/chart/templates/cilium-policy.yaml
+++ b/projects/firecracker/substrate/chart/templates/cilium-policy.yaml
@@ -39,6 +39,33 @@ spec:
         - ports:
             - port: {{ .Values.service.port | quote }}
               protocol: TCP
+          # L7 HTTP allow-list (ADR networking/003 #2). Narrows monolith-namespace
+          # callers from "any request on this port" to exactly the real invoke
+          # surface: POST /invoke/<workload>[/<session>]. Cilium matches `path` as an
+          # RE2 regex over the full request path, so `/invoke/.*` covers both the
+          # one-segment (/invoke/sandbox, /invoke/semgrep) and two-segment
+          # (/invoke/agent/{session}) forms plus any query string. `.` matches `/` in
+          # RE2, which is why a single `.*` spans the optional session segment.
+          #
+          # Applying rules.http redirects these flows through the per-node Envoy,
+          # which is also what makes Hubble emit the httpv2 metrics the companion
+          # SigNoz alert (signoz-addons/alerts/.../hubble-invoke-http.yaml) reads.
+          #
+          # Allow-list semantics: anything not listed is DENIED. Every in-cluster
+          # caller was verified to use POST /invoke/... only (sandbox, goosecracker
+          # runner, semgrep_scan, demos/loadtest); none GETs /healthz over the
+          # Service. The kubelet /healthz probe arrives via the separate
+          # `fromEntities: host, health` rule below (no toPorts, so all ports/paths
+          # allowed for those identities) and is unaffected by this L7 narrowing.
+          #
+          # Shadowing (ADR "L4 shadows L7" gotcha): no L4-only allow covers this port
+          # for the monolith source identity, this is the only toPorts on this rule,
+          # and the host/health rule is a different source identity, so the L7 filter
+          # is not shadowed and genuinely enforces.
+          rules:
+            http:
+              - method: "POST"
+                path: "/invoke/.*"
     {{- end }}
     # kubelet liveness/readiness probes originate from the node host. Linkerd
     # auto-authorized these; once an ingress rule makes the endpoint

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.80
+      targetRevision: 0.4.81
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/platform/cilium/bootstrap/cilium-helmchart.yaml
+++ b/projects/platform/cilium/bootstrap/cilium-helmchart.yaml
@@ -62,5 +62,13 @@ spec:
       enabled: true
       relay:
         enabled: true
+      # httpV2 emits nothing until an L7 CiliumNetworkPolicy redirects a surface
+      # through Envoy (ADR networking/003 #2); inert until the /invoke L7 rule
+      # lands. This list MUST match ../values.yaml or a node reboot reverts it.
       metrics:
-        enabled: ["dns", "drop", "tcp", "flow"]
+        enabled:
+          - dns
+          - drop
+          - tcp
+          - flow
+          - "httpV2:sourceContext=workload;destinationContext=workload;labelsContext=source_namespace,destination_namespace"

--- a/projects/platform/cilium/values.yaml
+++ b/projects/platform/cilium/values.yaml
@@ -42,5 +42,16 @@ cilium:
     relay:
       enabled: true
     # UI off; SigNoz remains the dashboard. Keep flow buffer modest.
+    # httpV2 emits nothing until an L7 CiliumNetworkPolicy redirects a surface
+    # through Envoy (ADR networking/003 #2); it is inert until Task A1 lands the
+    # /invoke L7 rule. httpV2 (not v1 http) folds status onto
+    # hubble_httpv2_requests_total, which the error-rate alert reads. Context is
+    # workload+namespace only: no path/URL label (PII + cardinality). This list
+    # MUST match bootstrap/cilium-helmchart.yaml or a node reboot reverts it.
     metrics:
-      enabled: ["dns", "drop", "tcp", "flow"]
+      enabled:
+        - dns
+        - drop
+        - tcp
+        - flow
+        - "httpV2:sourceContext=workload;destinationContext=workload;labelsContext=source_namespace,destination_namespace"

--- a/projects/platform/signoz-addons/alerts/templates/hubble-invoke-http.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/hubble-invoke-http.yaml
@@ -1,0 +1,109 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubble-invoke-http-5xx-alert
+  labels:
+    signoz.io/alert: "true"
+  annotations:
+    signoz.io/alert-name: "fc-invoke L7 5xx Rate"
+    signoz.io/severity: "warning"
+    signoz.io/notification-channels: "incidentio"
+# Golden-signal error-rate alert for the /invoke surface (ADR networking/003 #2).
+# This series (hubble_httpv2_requests_total) exists ONLY because the substrate
+# CiliumNetworkPolicy now applies an L7 rule to POST /invoke/.*, redirecting that
+# surface through the per-node Envoy so Hubble parses it. No L7 policy -> no httpv2
+# series -> this alert is inert. It ships in the same PR as that policy.
+#
+# Low-QPS control path, so this is an ABSOLUTE sustained-5xx count, not a fraction:
+# a 5xx ratio would spike to 100% on a single failed request, and the repo has no
+# formula-query alert to model a two-series ratio on. Filter uses only labels we are
+# certain of: destination_namespace (explicitly requested via the httpV2
+# labelsContext) and the built-in httpV2 `status`. fc-invoke is currently the only
+# surface with an L7 policy, so destination_namespace='monolith' uniquely selects it
+# today; once a second surface gets an L7 policy (Task A2), tighten this to the
+# fc-invoke destination-workload label (confirm its exact key via a live scrape of
+# :9965 /metrics first, per ADR Risk row 5).
+#
+# Threshold is a starting point to tune against a baseline window: transient guest
+# boot failures return 502/503 occasionally, so target>5 over 10m aims to catch a
+# sustained fault (guest broken, policy misrouting) without paging on one blip.
+data:
+  alert.json: |
+    {
+      "alert": "fc-invoke L7 5xx Rate",
+      "alertType": "METRICS_BASED_ALERT",
+      "ruleType": "threshold_rule",
+      "version": "v5",
+      "broadcastToAll": false,
+      "disabled": false,
+      "evalWindow": "10m0s",
+      "frequency": "1m0s",
+      "severity": "warning",
+      "labels": {
+        "category": "network",
+        "environment": "production"
+      },
+      "annotations": {
+        "summary": "fc-invoke /invoke is returning sustained 5xx responses",
+        "description": "hubble_httpv2_requests_total for the monolith namespace shows more than 5 responses with status {{ "{{" }} $labels.status {{ "}}" }} (>=500) in the last 10 minutes. Only the /invoke L7 surface emits httpv2 today, so this is the fc-invoke daemon failing invocations (guest boot failure, upstream error, or a policy misroute). Investigate with `kubectl logs -n monolith deploy/fc-invoke` and `hubble observe --verdict DROPPED`."
+      },
+      "condition": {
+        "compositeQuery": {
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
+                  {
+                    "timeAggregation": "increase",
+                    "spaceAggregation": "sum",
+                    "metricName": "hubble_httpv2_requests_total"
+                  }
+                ],
+                "filter": {
+                  "expression": "destination_namespace = 'monolith' AND status >= '500'"
+                },
+                "groupBy": [
+                  {
+                    "name": "destination_namespace",
+                    "fieldDataType": "string",
+                    "fieldContext": "tag"
+                  },
+                  {
+                    "name": "status",
+                    "fieldDataType": "string",
+                    "fieldContext": "tag"
+                  }
+                ],
+                "order": [],
+                "disabled": false
+              }
+            }
+          ],
+          "panelType": "graph",
+          "queryType": "builder"
+        },
+        "selectedQueryName": "A",
+        "op": "1",
+        "target": 5,
+        "matchType": "1",
+        "targetUnit": "",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "warning",
+              "target": 5,
+              "targetUnit": "",
+              "matchType": "1",
+              "op": "1",
+              "channels": ["incidentio"]
+            }
+          ]
+        }
+      },
+      "preferredChannels": ["incidentio"]
+    }


### PR DESCRIPTION
Implements **capability #2** of ADR [networking/003](../blob/main/docs/decisions/networking/003-cilium-capability-adoption.md) for its first surface (`/invoke`), per `docs/plans/2026-07-13-cilium-policy-hardening.md` Part A (Tasks A0 + A1).

## What

- **A0 (inert):** add `httpV2` to `hubble.metrics.enabled` in `platform/cilium` values **and** the mirrored bootstrap HelmChart (kept identical, or a node reboot reverts the set). `httpV2` folds HTTP status onto `hubble_httpv2_requests_total` (the error-rate alert needs it); context is workload+namespace only, no path/URL label. Emits nothing until an L7 policy exists.
- **A1 (enforcement + observability):** add an L7 HTTP allow-list `POST /invoke/.*` to the existing fc-invoke `CiliumNetworkPolicy`, plus a companion SigNoz alert on sustained 5xx.

## Why this is low-risk

`ciliumPolicy.enabled` is **already `true`** for substrate, so the L3/L4 ingress policy is already live and pods are Ready. This change does **not** flip enforcement on; it only *narrows* the monolith caller's allowed methods/paths on `:8080`.

Blast radius = "a monolith→fc-invoke request that is not `POST /invoke/*` gets dropped." Every in-cluster caller was enumerated and all use `POST /invoke/<workload>` exclusively:
| Caller | Path |
| --- | --- |
| `sandbox/client.py` | `POST /invoke/sandbox` |
| `goosecracker/runner.py` | `POST /invoke/agent/{session}` |
| `semgrep_scan/client.py` | `POST /invoke/{semgrep,semgrep-hi,semgrep-full}` |
| `demos/loadtest.py` | `POST /invoke/{workload}` |

The kubelet `GET /healthz` probe rides the separate, untouched `fromEntities: host, health` rule (no `toPorts`). No L4 allow shadows the L7 rule (monolith is a distinct source identity from host/health).

## Correctness notes

- Path is `/invoke/.*` (RE2 regex, `.` matches `/`), covering both one-segment and two-segment (`/invoke/agent/{session}`) forms. The plan's placeholder `/invoke` was wrong: the real surface is `/invoke/{workload}`.
- **Alert shape deviates from the plan's "fraction":** ships as an **absolute sustained-5xx count** (`> 5` over 10m), not a ratio. Rationale: low-QPS control path (a ratio spikes to 100% on one failed request), and the repo has no formula-query alert to model a two-series ratio on. Trivially tunable.
- **Post-merge verification (ADR Risk row 5):** the `hubble_httpv2_requests_total` series does not exist until this policy syncs and redirects `/invoke` through Envoy. After merge I will live-scrape `:9965 /metrics` to confirm the exact label keys and tighten the alert to the fc-invoke destination-workload label (needed once Task A2 adds a second L7 surface).

## Deploy shapes
- `platform/cilium` + `signoz-addons/alerts` are git-path apps (`targetRevision: HEAD`), no bump.
- `fc-invoke` is a pinned OCI chart: bumped `0.4.80 → 0.4.81`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)