### PR TITLE
feat(embervm): list-then-watch informer for the Workload watcher

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.7
+version: 0.1.8

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -46,12 +46,13 @@ defmodule Embervm.Application do
       # Embervm.Auth, whose TokenReview reviewer dials the API server over it.
       Embervm.K8s.finch_child_spec(),
       {Embervm.Auth, allowed: allowed_service_accounts()},
-      # The Workload reconciler (Task 5): lists Workload CRs over the Finch
-      # pool above and writes Embervm.WorkloadCatalog, which TaskStore.cfg_for/1
-      # reads. Placed after Finch (needs it) and after TaskStore in the
-      # supervision list; TaskStore does not depend on the watcher being up
-      # (WorkloadCatalog.retry_config/1 tolerates the catalog table not
-      # existing yet), so their relative order here is not load-bearing.
+      # The Workload informer (Task 5): LISTs then WATCHes Workload CRs over the
+      # Finch pool above and writes Embervm.WorkloadCatalog, which
+      # TaskStore.cfg_for/1 reads. Placed after Finch (its watch streams over
+      # that pool) and after TaskStore in the supervision list; TaskStore does
+      # not depend on the watcher being up (WorkloadCatalog.retry_config/1
+      # tolerates the catalog table not existing yet), so their relative order
+      # here is not load-bearing.
       Embervm.WorkloadWatcher,
       # Bandit + the router last: its handlers call Auth, TaskStore, and
       # SyncWait, so the HTTP surface must not accept requests until all are up.

--- a/projects/embervm/control/lib/embervm/k8s.ex
+++ b/projects/embervm/control/lib/embervm/k8s.ex
@@ -1,12 +1,12 @@
 defmodule Embervm.K8s do
   @moduledoc """
   Minimal in-cluster Kubernetes API client over Finch/Mint. R0 needs exactly
-  three calls: the `TokenReview` POST here (submit-API auth, Task 8) and the
-  Workload CRD list + status-patch (Task 5, `Embervm.WorkloadWatcher`'s
-  reconciler). Hand-rolling over Finch rather than pulling a full `k8s` hex
+  four calls: the `TokenReview` POST here (submit-API auth, Task 8) and the
+  Workload CRD list + watch + status-patch (Task 5, `Embervm.WorkloadWatcher`'s
+  informer). Hand-rolling over Finch rather than pulling a full `k8s` hex
   library is deliberate: that library drags a large transitive closure, and
   closure-completeness is the whole risk the bandit/plug/finch de-risk PR set
-  out to bound. Three endpoints do not justify it.
+  out to bound. Four endpoints do not justify it.
 
   `do_request/4` is the shared low-level helper every public call builds on:
   it re-reads the SA token, sets the auth/accept headers, optionally sets
@@ -38,6 +38,21 @@ defmodule Embervm.K8s do
   @tokenreview_path "/apis/authentication.k8s.io/v1/tokenreviews"
   @workloads_path "/apis/embervm.dev/v1alpha1/workloads"
   @receive_timeout 5_000
+
+  # Watch tuning. The apiserver serves watches from its cache, so the steady-
+  # state cost of a held watch is near zero regardless of how many Workloads
+  # exist. `timeoutSeconds` asks the apiserver to close the stream itself after
+  # ~5 min (a normal, healthy close the watcher simply re-establishes), which
+  # bounds how long any one connection lives and gives the apiserver a natural
+  # point to rebalance. `@watch_receive_timeout` sits ABOVE that server budget
+  # so that on a healthy-but-idle stream the server-side close always fires
+  # first; the client-side receive timeout only trips on a genuinely wedged
+  # connection (no bookmarks, no close), which is exactly when we want to give
+  # up and reconnect. `allowWatchBookmarks` makes the apiserver periodically
+  # emit BOOKMARK events carrying a fresh resourceVersion, so a long-idle watch
+  # still advances the RV we would resume from after a disconnect.
+  @watch_timeout_seconds 300
+  @watch_receive_timeout 310_000
 
   @doc """
   The Finch child spec for the control plane's shared HTTP pool. In-cluster it
@@ -89,24 +104,136 @@ defmodule Embervm.K8s do
 
   @doc """
   Lists every `Workload` custom resource cluster-wide (the ClusterRole grants
-  `list` across namespaces, not scoped to one). Poll-based, not a streaming
-  watch: `Embervm.WorkloadWatcher` calls this on a timer, so the list-level
-  `resourceVersion` is ignored entirely, there is nothing to resume from.
-  Returns the raw `items` array (binary-keyed CR maps, exactly as the API
-  server encodes them) so the watcher does its own validation/shaping.
+  `list` across namespaces, not scoped to one). This is the reconcile leg of
+  `Embervm.WorkloadWatcher`'s list-then-watch informer: it runs on boot, and
+  again on any watch invalidation (a 410 Expired, a parse/transport error) to
+  re-establish current truth before resuming the watch.
+
+  Requested with `resourceVersion=0`, which tells the apiserver "serve this
+  from your watch cache, any recent version is fine" rather than doing a
+  quorum read against etcd, so even a frequent resync is cheap. Returns the
+  raw `items` array (binary-keyed CR maps, exactly as the apiserver encodes
+  them) AND the collection-level `metadata.resourceVersion`: that RV is where
+  the subsequent watch resumes, so the two must come from the same list
+  response, which is why they are returned together here rather than fetched
+  separately.
   """
-  @spec list_workloads() :: {:ok, [map()]} | {:error, term()}
+  @spec list_workloads() :: {:ok, [map()], String.t() | nil} | {:error, term()}
   def list_workloads do
-    case do_request(:get, @workloads_path, nil, nil) do
+    case do_request(:get, @workloads_path <> "?resourceVersion=0", nil, nil) do
       {:ok, 200, resp_body} ->
         decoded = :json.decode(resp_body)
-        {:ok, Map.get(decoded, "items", [])}
+        items = Map.get(decoded, "items", [])
+        rv = get_in(decoded, ["metadata", "resourceVersion"])
+        {:ok, items, rv}
 
       {:ok, status, _resp_body} ->
         {:error, {:apiserver_status, status}}
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  @doc """
+  Opens a streaming watch on the `Workload` collection from `resource_version`
+  and invokes `on_event` once per delta as it arrives. This is the steady-state
+  leg of the informer: after the initial LIST establishes the catalog, the
+  watch delivers only what changed, served from the apiserver's cache.
+
+  The call is SYNCHRONOUS: `Finch.stream/5` blocks the calling process for the
+  whole lifetime of the stream, so the watcher must run this in a dedicated
+  process, never inside the GenServer that owns the catalog (that would freeze
+  every catalog read for the stream's lifetime). Returns:
+
+    * `{:ok, :closed}` when the stream ends cleanly (the normal path: the
+      apiserver closed it at `timeoutSeconds`, or after emitting a terminal
+      ERROR event). The caller decides whether to resume-watch or resync-LIST
+      based on the events it saw (an ERROR event means the RV expired).
+    * `{:error, reason}` on a non-200 status or a transport error, which the
+      caller treats as "resync with backoff".
+
+  `on_event` receives each event as a binary-keyed map
+  (`%{"type" => "ADDED"|"MODIFIED"|"DELETED"|"BOOKMARK"|"ERROR", "object" =>
+  ...}`), exactly as the apiserver frames it. It is invoked from THIS process
+  (the streamer), so implementations hand the event off to the owning
+  GenServer (a `send`) rather than mutating shared state directly.
+  """
+  @spec watch_workloads(String.t() | nil, (map() -> any())) :: {:ok, :closed} | {:error, term()}
+  def watch_workloads(resource_version, on_event) do
+    query =
+      URI.encode_query([
+        {"watch", "1"},
+        {"allowWatchBookmarks", "true"},
+        {"timeoutSeconds", Integer.to_string(@watch_timeout_seconds)},
+        {"resourceVersion", resource_version || "0"}
+      ])
+
+    with {:ok, sa_token} <- read_sa_token() do
+      headers = [{"authorization", "Bearer " <> sa_token}, {"accept", "application/json"}]
+      req = Finch.build(:get, api_url(@workloads_path <> "?" <> query), headers, "")
+      acc0 = %{status: nil, buffer: "", on_event: on_event}
+
+      result =
+        Finch.stream(req, Embervm.Finch, acc0, &watch_reducer/2, receive_timeout: @watch_receive_timeout)
+
+      # Finch.stream/5 returns {:ok, acc} on a completed stream, or the THREE-
+      # element {:error, exception, acc} on a transport error mid-stream (NOT a
+      # 2-tuple: matching {:error, reason} alone would CaseClause-crash on every
+      # disconnect). The acc carries the last-seen HTTP status; a non-200 there
+      # means the watch establishment itself was rejected (the apiserver sent an
+      # error object, not the NDJSON stream), which we surface as a resync.
+      case result do
+        {:ok, %{status: 200}} -> {:ok, :closed}
+        {:ok, %{status: status}} -> {:error, {:apiserver_status, status}}
+        {:error, reason, _acc} -> {:error, reason}
+      end
+    end
+  end
+
+  # Finch.stream/5 reducer. Threads a small acc holding the HTTP status, a
+  # frame buffer, and the caller's on_event. We only parse the body once the
+  # status is 200: a non-200 watch response carries a JSON error object, not
+  # the NDJSON event stream, and must not be fed to the event path.
+  defp watch_reducer({:status, status}, acc), do: %{acc | status: status}
+  defp watch_reducer({:headers, _headers}, acc), do: acc
+  defp watch_reducer({:trailers, _trailers}, acc), do: acc
+
+  defp watch_reducer({:data, data}, %{status: 200} = acc) do
+    {lines, rest} = frame_ndjson(acc.buffer, data)
+    Enum.each(lines, &dispatch_watch_line(&1, acc.on_event))
+    %{acc | buffer: rest}
+  end
+
+  defp watch_reducer({:data, _data}, acc), do: acc
+
+  @doc false
+  # Splits `buffer <> chunk` into complete newline-terminated lines plus the
+  # trailing incomplete remainder (to be prepended to the next chunk). A watch
+  # stream is newline-delimited JSON and TCP chunk boundaries fall anywhere, so
+  # a single JSON event can straddle two `:data` frames; this reassembles them.
+  # Exposed (rather than private) so it can be unit-tested directly, since the
+  # streaming path itself needs a live apiserver.
+  @spec frame_ndjson(binary(), binary()) :: {[binary()], binary()}
+  def frame_ndjson(buffer, chunk) do
+    parts = String.split(buffer <> chunk, "\n")
+    {complete, [remainder]} = Enum.split(parts, length(parts) - 1)
+    {complete, remainder}
+  end
+
+  # Blank lines (a stream's trailing newline) carry no event; skip them. A line
+  # that fails to decode is skipped rather than raised on: the apiserver writes
+  # one complete JSON object per line, so a decode failure would signal a
+  # framing bug we do not want to crash the streamer over mid-flight.
+  defp dispatch_watch_line("", _on_event), do: :ok
+
+  defp dispatch_watch_line(line, on_event) do
+    try do
+      on_event.(:json.decode(line))
+    catch
+      kind, reason ->
+        Logger.warning("embervm k8s watch: skipping undecodable event line: #{inspect({kind, reason})}")
+        :ok
     end
   end
 

--- a/projects/embervm/control/lib/embervm/workload_watcher.ex
+++ b/projects/embervm/control/lib/embervm/workload_watcher.ex
@@ -1,25 +1,57 @@
 defmodule Embervm.WorkloadWatcher do
   @moduledoc """
-  Reconciles the `Workload` custom resources in the cluster into
-  `Embervm.WorkloadCatalog`'s ETS table, and writes each CR's `status`
-  subresource back to reflect what the control plane concluded.
+  Keeps `Embervm.WorkloadCatalog`'s ETS table in sync with the `Workload`
+  custom resources in the cluster, and writes each CR's `status` subresource
+  back to reflect what the control plane concluded.
 
-  This is a periodic LIST + reconcile loop, not a streaming K8s watch. That
-  is a deliberate choice, not a placeholder for a future upgrade: Workload
-  CRs are low-churn declarative config (an operator edits one occasionally,
-  nothing programmatic mutates spec), the only in-process reader of the
-  catalog is `Embervm.TaskStore.cfg_for/1` at failure-classification time (not
-  a hot dispatch path with sub-second staleness requirements), and a poll-
-  based reconciler is trivially testable (inject a canned `lister`, call
-  `reconcile_now/1`, assert the catalog) where a long-lived watch stream with
-  resourceVersion bookkeeping and reconnect/resync logic is not. If churn or
-  staleness requirements change later, swapping the `:lister` for a genuine
-  watch is an internal implementation change behind the same public API.
+  ## list-then-watch (an informer)
 
-  Invariant: a reconcile pass NEVER crashes the process, no matter how
-  malformed one CR is, and NEVER wipes the catalog on a transient list
-  failure (fail-open: the last-known-good catalog is served until the next
-  successful list). The watcher writes status ONLY, never spec.
+  This is a Kubernetes informer, not a periodic poll: LIST to establish
+  current truth, then WATCH for deltas. Concretely:
+
+    * On boot (and on any resync) it does ONE LIST, which fully reconciles the
+      catalog (add/update every CR, sweep any it no longer sees) and records
+      the collection `resourceVersion`.
+    * It then opens a streaming WATCH from that RV. Each delta (ADDED,
+      MODIFIED, DELETED, BOOKMARK) is applied incrementally; the RV advances on
+      every event so a later reconnect resumes exactly where it left off.
+    * When the stream ends cleanly (the apiserver closes watches after a few
+      minutes by design) it simply re-watches from the last RV. No relist.
+    * When the RV has aged out of the apiserver's history (a 410 Expired,
+      delivered as a terminal ERROR event), or on any transport/parse error,
+      it resyncs: a fresh LIST (which also catches any deletes missed while
+      disconnected, because the reconcile sweeps names the LIST no longer
+      returns) followed by a new watch. Transport errors back off
+      exponentially so a wedged apiserver is not hammered.
+
+  This replaced an earlier periodic LIST loop. The public surface is
+  unchanged: `Embervm.WorkloadCatalog` + `Embervm.TaskStore.cfg_for/1` read the
+  same ETS table, so this is purely an internals swap. The motivation is
+  apiserver load: a full LIST every interval couples steady-state cost to the
+  poll cadence (we already saw a 429 on the boot LIST), whereas a watch is
+  served from the apiserver's cache at near-zero incremental cost no matter how
+  many Workloads exist.
+
+  ## why the watch runs in a separate process
+
+  `Embervm.K8s.watch_workloads/2` is synchronous: `Finch.stream/5` blocks its
+  caller for the stream's entire multi-minute lifetime. If that ran inside this
+  GenServer, every catalog read would serialize behind it and freeze. So the
+  GenServer spawns a monitored streamer process that owns the blocking call and
+  forwards each event back as a message; the GenServer keeps sole ownership of
+  the ETS table, the RV, and all reconnect decisions (a serialized,
+  crash-isolated state machine). A streamer crash is reported as a watch error
+  and handled like any other disconnect; it never takes the GenServer down.
+
+  ## invariants
+
+    * A reconcile pass NEVER crashes the process, no matter how malformed one
+      CR is (each CR is reconciled inside a try/catch), and NEVER wipes the
+      catalog on a transient LIST failure (fail-open: the last-known-good
+      catalog is served until the next successful LIST).
+    * The watcher writes `status` ONLY, never `spec`.
+    * Only events from the CURRENT streamer mutate state; a straggler event or
+      result from a superseded streamer is ignored, so the RV never regresses.
   """
 
   use GenServer
@@ -28,7 +60,15 @@ defmodule Embervm.WorkloadWatcher do
   alias Embervm.WorkloadCatalog
 
   @default_table :embervm_workloads
-  @default_interval_ms 15_000
+  @base_backoff_ms 1_000
+  @max_backoff_ms 30_000
+  # A healthy watch lives for the apiserver's full `timeoutSeconds` (~5 min);
+  # a watch that ends far sooner is a signal of trouble, not a normal cycle. So
+  # only a watch that stayed open at least this long earns an IMMEDIATE
+  # re-watch on clean close. A faster close is treated as suspect and backs off
+  # first, which turns a pathological "apiserver accepts then instantly closes"
+  # into bounded exponential backoff instead of a hot reconnect loop.
+  @min_watch_ms 1_000
 
   @retry_on_map %{
     "transport" => :transport,
@@ -50,11 +90,14 @@ defmodule Embervm.WorkloadWatcher do
   end
 
   @doc """
-  Forces one reconcile pass synchronously and waits for it to finish. Tests
-  drive the watcher entirely through this (with `reconcile_interval_ms: nil`
-  so no timer fires on its own); in production it is also a safe operational
-  nudge (e.g. after a CR edit, to reconcile without waiting up to the full
-  interval).
+  Forces one LIST + full reconcile synchronously and waits for it to finish.
+  Tests drive the reconcile path entirely through this (with
+  `watch_startup: false` so no streamer runs and no timer fires). In production
+  it is also a safe operational nudge (reconcile now rather than waiting for
+  the next watch event), and it does not disturb the running watch: it neither
+  starts nor stops a streamer, it only re-runs the reconcile against a fresh
+  LIST. It intentionally leaves the resume RV untouched when the injected
+  lister returns no RV (the test path), so it never rewinds a live watch.
   """
   @spec reconcile_now(GenServer.server()) :: :ok
   def reconcile_now(server \\ __MODULE__) do
@@ -67,70 +110,299 @@ defmodule Embervm.WorkloadWatcher do
   def init(opts) do
     table = Keyword.get(opts, :table, @default_table)
     lister = Keyword.get(opts, :lister, &Embervm.K8s.list_workloads/0)
+    watcher_fun = Keyword.get(opts, :watcher_fun, &Embervm.K8s.watch_workloads/2)
     status_writer = Keyword.get(opts, :status_writer, &Embervm.K8s.patch_workload_status/3)
-    interval_ms = Keyword.get(opts, :reconcile_interval_ms, @default_interval_ms)
     clock = Keyword.get(opts, :clock, fn -> System.system_time(:millisecond) end)
+    base_backoff = Keyword.get(opts, :base_backoff_ms, @base_backoff_ms)
+    max_backoff = Keyword.get(opts, :max_backoff_ms, @max_backoff_ms)
+    min_watch = Keyword.get(opts, :min_watch_ms, @min_watch_ms)
+    watch_startup = Keyword.get(opts, :watch_startup, true)
 
     WorkloadCatalog.create(table)
 
     state = %{
       table: table,
       lister: lister,
+      watcher_fun: watcher_fun,
       status_writer: status_writer,
-      interval_ms: interval_ms,
-      clock: clock
+      clock: clock,
+      base_backoff: base_backoff,
+      max_backoff: max_backoff,
+      min_watch_ms: min_watch,
+      backoff_ms: base_backoff,
+      # Monotonic ms when the current watch was opened, used to tell a healthy
+      # long-lived close (resume immediately) from a suspect fast close (back
+      # off). Set on every start_streamer.
+      watch_started_at: 0,
+      # The resume point for the watch: the collection RV from the last LIST,
+      # advanced by every applied event. nil means "start from the watch
+      # cache" (resourceVersion=0). Tests that only exercise reconcile_now
+      # leave it nil forever, which is fine.
+      resource_version: nil,
+      # {pid, monitor_ref} of the live streamer, or nil when no watch is open.
+      streamer: nil,
+      # Set true when a watch delivered a terminal ERROR (RV expired): the next
+      # watch end must resync via LIST rather than blindly re-watching a
+      # resourceVersion the apiserver no longer knows.
+      needs_relist: false
     }
 
-    # An immediate first reconcile is the relist-on-boot path: whatever the
-    # cluster's Workload state is at startup, the catalog reflects it before
-    # any task can fail against a stale (empty) config. Skipped entirely when
-    # interval_ms is nil (tests drive reconciles explicitly instead).
-    if interval_ms, do: send(self(), :reconcile)
+    # watch_startup drives the informer from init; tests set it false and drive
+    # reconcile_now/1 explicitly so no background watch or timer ever fires.
+    if watch_startup, do: send(self(), :start)
 
     {:ok, state}
   end
 
+  # Boot: LIST + reconcile, then open the watch. A failed boot LIST retries
+  # with backoff before any watch is attempted (a watch needs a valid RV).
   @impl true
-  def handle_info(:reconcile, state) do
-    do_reconcile(state)
-    if state.interval_ms, do: Process.send_after(self(), :reconcile, state.interval_ms)
-    {:noreply, state}
+  def handle_info(:start, state), do: {:noreply, relist_then_watch(state)}
+
+  # Backoff timer fired: resync (LIST + reconcile) and re-open the watch.
+  def handle_info(:resync, state), do: {:noreply, relist_then_watch(state)}
+
+  # Backoff timer fired: re-open the watch WITHOUT a resync (the RV is still
+  # valid; the prior close was just suspiciously fast).
+  def handle_info(:rewatch, state), do: {:noreply, start_streamer(state)}
+
+  # One watch delta from the CURRENT streamer. Events from a superseded
+  # streamer (a reconnect race) are dropped so a stale event cannot rewind the
+  # catalog or the RV.
+  def handle_info({:watch_event, pid, event}, %{streamer: {spid, _ref}} = state) when pid == spid do
+    {:noreply, apply_event(state, event)}
   end
+
+  def handle_info({:watch_event, _pid, _event}, state), do: {:noreply, state}
+
+  # The current streamer finished (stream closed or errored). Decide the next
+  # move: resume-watch on a clean close, resync on an expired RV or error.
+  def handle_info({:watch_result, pid, result}, %{streamer: {spid, _ref}} = state) when pid == spid do
+    {:noreply, handle_watch_end(result, %{state | streamer: nil})}
+  end
+
+  def handle_info({:watch_result, _pid, _result}, state), do: {:noreply, state}
+
+  # The current streamer died WITHOUT reporting a result (it always sends one
+  # in the normal path, so a bare DOWN here means an abnormal exit). Treat it
+  # as a watch error and resync with backoff. A DOWN from a superseded streamer
+  # (ref no longer matches) is expected and ignored.
+  def handle_info({:DOWN, ref, :process, _pid, reason}, %{streamer: {_spid, sref}} = state)
+      when ref == sref do
+    {:noreply, handle_watch_end({:error, {:streamer_down, reason}}, %{state | streamer: nil})}
+  end
+
+  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state), do: {:noreply, state}
 
   @impl true
   def handle_call(:reconcile_now, _from, state) do
-    do_reconcile(state)
+    # Fail-open on a LIST error: keep the last-known-good catalog either way.
+    state =
+      case do_list_reconcile(state) do
+        {:ok, s} -> s
+        {:error, s} -> s
+      end
+
     {:reply, :ok, state}
+  end
+
+  # Best-effort: stop an orphaned streamer from outliving the GenServer holding
+  # a pooled connection open. Not load-bearing for correctness (a send to a
+  # dead GenServer is a no-op and the apiserver closes the stream at
+  # timeoutSeconds anyway), just tidy.
+  @impl true
+  def terminate(_reason, %{streamer: {pid, _ref}}) do
+    Process.exit(pid, :shutdown)
+    :ok
+  end
+
+  def terminate(_reason, _state), do: :ok
+
+  # -- informer state machine --------------------------------------------------
+
+  # LIST + full reconcile, then (on success) open a watch from the resulting
+  # RV. On a LIST failure, keep the prior catalog (fail-open) and retry with
+  # backoff. This is the single entry point for both boot and every resync.
+  defp relist_then_watch(state) do
+    case do_list_reconcile(state) do
+      {:ok, state} -> start_streamer(%{state | backoff_ms: state.base_backoff})
+      {:error, state} -> schedule(:resync, state)
+    end
+  end
+
+  # Spawn the streamer that owns the blocking watch. spawn_monitor (not link):
+  # a streamer crash surfaces as a DOWN we handle as a disconnect, and never
+  # escalates to this GenServer. The streamer forwards each event tagged with
+  # its own pid (so superseded-streamer events are droppable) and always
+  # reports a final result, even if the watch call itself raises.
+  defp start_streamer(state) do
+    owner = self()
+    rv = state.resource_version
+    watcher_fun = state.watcher_fun
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        streamer = self()
+
+        result =
+          try do
+            watcher_fun.(rv, fn event -> send(owner, {:watch_event, streamer, event}) end)
+          catch
+            kind, reason -> {:error, {kind, reason}}
+          end
+
+        send(owner, {:watch_result, streamer, result})
+      end)
+
+    %{state | streamer: {pid, ref}, needs_relist: false, watch_started_at: now_ms()}
+  end
+
+  # A watch ended; decide how to resume. Four cases, gated on two axes: was the
+  # close clean-and-long-lived (healthy) vs fast/errored, and does the RV need
+  # a fresh LIST (an ERROR-flagged resync, a nil RV, or a non-clean end) vs is
+  # it still valid to re-watch from.
+  #
+  #   healthy + valid RV  → resume the watch immediately (the ~5-min server
+  #                         timeout path; reset backoff).
+  #   healthy + must list → resync now (RV expired on a long-lived watch).
+  #   fast/error + list   → back off, then resync.
+  #   fast clean + valid  → back off, then RE-watch (no relist). This is the
+  #                         hot-loop guard: an apiserver that accepts then
+  #                         instantly closes backs off instead of spinning.
+  defp handle_watch_end(result, state) do
+    clean = match?({:ok, :closed}, result)
+    long_lived = clean and now_ms() - state.watch_started_at >= state.min_watch_ms
+    must_relist = state.needs_relist or is_nil(state.resource_version) or not clean
+
+    cond do
+      long_lived and not must_relist ->
+        start_streamer(%{state | backoff_ms: state.base_backoff})
+
+      long_lived ->
+        Logger.info("embervm workload watcher: resyncing (watch RV invalid or expired)")
+        relist_then_watch(%{state | backoff_ms: state.base_backoff})
+
+      must_relist ->
+        Logger.warning(
+          "embervm workload watcher: watch ended (#{inspect(result)}), resync in #{state.backoff_ms}ms"
+        )
+
+        schedule(:resync, state)
+
+      true ->
+        Logger.warning(
+          "embervm workload watcher: watch closed immediately, re-watch in #{state.backoff_ms}ms"
+        )
+
+        schedule(:rewatch, state)
+    end
+  end
+
+  # Arm a backoff timer for the next reconnect attempt (:resync relists first,
+  # :rewatch does not) and double the backoff (capped) for the next consecutive
+  # failure. A success resets backoff to base (see relist_then_watch /
+  # start_streamer / the healthy branch above).
+  defp schedule(msg, state) do
+    Process.send_after(self(), msg, state.backoff_ms)
+    %{state | backoff_ms: min(state.backoff_ms * 2, state.max_backoff)}
+  end
+
+  defp now_ms, do: System.monotonic_time(:millisecond)
+
+  # -- event application -------------------------------------------------------
+
+  defp apply_event(state, %{"type" => type} = event) when type in ["ADDED", "MODIFIED"] do
+    obj = Map.get(event, "object") || %{}
+    catalog_cr(state, obj)
+    advance_rv(state, obj)
+  end
+
+  defp apply_event(state, %{"type" => "DELETED"} = event) do
+    obj = Map.get(event, "object") || %{}
+    name = get_in(obj, ["metadata", "name"])
+    if name, do: WorkloadCatalog.drop(state.table, name)
+    advance_rv(state, obj)
+  end
+
+  # BOOKMARK carries only a fresh resourceVersion (empty object otherwise): it
+  # exists precisely so an idle watch keeps advancing the RV we would resume
+  # from, so applying it means updating the RV and nothing else.
+  defp apply_event(state, %{"type" => "BOOKMARK"} = event) do
+    advance_rv(state, Map.get(event, "object") || %{})
+  end
+
+  # ERROR is terminal: the apiserver emits it (typically a 410 Expired Status
+  # object) and closes the stream. Flag a resync so the ensuing watch-end takes
+  # the LIST path instead of re-watching an RV the apiserver has forgotten. Do
+  # NOT advance the RV from the error object.
+  defp apply_event(state, %{"type" => "ERROR"} = event) do
+    Logger.info(
+      "embervm workload watcher: watch ERROR event, will resync: #{inspect(Map.get(event, "object"))}"
+    )
+
+    %{state | needs_relist: true}
+  end
+
+  defp apply_event(state, _event), do: state
+
+  # Advance the resume RV to this object's resourceVersion. Guarded so a delta
+  # missing an RV (or a malformed object) leaves the last good RV in place
+  # rather than nilling it out.
+  defp advance_rv(state, obj) do
+    case get_in(obj, ["metadata", "resourceVersion"]) do
+      rv when is_binary(rv) and rv != "" -> %{state | resource_version: rv}
+      _ -> state
+    end
   end
 
   # -- reconcile ---------------------------------------------------------------
 
-  defp do_reconcile(state) do
+  # LIST the whole collection and reconcile the catalog to match. Accepts the
+  # injected lister returning either {:ok, items, rv} (production
+  # Embervm.K8s.list_workloads/0) or {:ok, items} (test listers that do not
+  # model RV); the latter leaves the resume RV untouched so reconcile_now never
+  # rewinds a live watch.
+  defp do_list_reconcile(state) do
     case state.lister.() do
       {:error, reason} ->
-        # Fail-open: a transient list error (apiserver hiccup, network blip)
+        # Fail-open: a transient LIST error (apiserver hiccup, network blip)
         # must never wipe the last-known-good catalog. TaskStore keeps
         # classifying failures against whatever config it already has.
         Logger.warning("embervm workload watcher: list failed, keeping prior catalog: #{inspect(reason)}")
-        :ok
+        {:error, state}
 
       {:ok, crs} ->
-        seen = Enum.map(crs, fn cr -> reconcile_one(state, cr) end)
+        {:ok, reconcile_full(state, crs, nil)}
 
-        (WorkloadCatalog.all_names(state.table) -- seen)
-        |> Enum.each(&WorkloadCatalog.drop(state.table, &1))
-
-        :ok
+      {:ok, crs, rv} ->
+        {:ok, reconcile_full(state, crs, rv)}
     end
   end
 
-  # Reconciles exactly one CR and returns its name (so the caller can build
-  # the "seen" set for deletion sweeping) whether or not the CR was valid.
-  # Wrapped in try/catch: ONE malformed CR (missing metadata, a spec shaped
-  # nothing like the CRD schema) must never crash this loop or the GenServer
-  # itself, since a bad CR sitting in the cluster would otherwise permanently
-  # wedge reconciliation for every OTHER, valid Workload too.
-  defp reconcile_one(state, cr) do
+  # Reconcile every CR in a LIST, then sweep any cataloged name the LIST no
+  # longer returns (this is how the informer recovers deletes it may have
+  # missed while disconnected). Records the collection RV as the new resume
+  # point when the lister supplied one.
+  defp reconcile_full(state, crs, rv) do
+    seen =
+      crs
+      |> Enum.map(&catalog_cr(state, &1))
+      |> Enum.reject(&is_nil/1)
+
+    (WorkloadCatalog.all_names(state.table) -- seen)
+    |> Enum.each(&WorkloadCatalog.drop(state.table, &1))
+
+    if rv, do: %{state | resource_version: rv}, else: state
+  end
+
+  # Reconciles exactly one CR (validate → catalog upsert-or-drop → status
+  # write) and returns its name, so a full reconcile can build the "seen" set
+  # for delete-sweeping, whether or not the CR was valid. Wrapped in try/catch:
+  # ONE malformed CR (missing metadata, a spec shaped nothing like the CRD
+  # schema) must never crash the loop or the GenServer itself, since a bad CR
+  # sitting in the cluster would otherwise permanently wedge reconciliation for
+  # every OTHER, valid Workload too.
+  defp catalog_cr(state, cr) do
     try do
       name = get_in(cr, ["metadata", "name"])
       namespace = get_in(cr, ["metadata", "namespace"])
@@ -165,7 +437,7 @@ defmodule Embervm.WorkloadWatcher do
     catch
       kind, reason ->
         Logger.warning(
-          "embervm workload watcher: reconcile_one crashed on a malformed CR, skipping: " <>
+          "embervm workload watcher: catalog_cr crashed on a malformed CR, skipping: " <>
             inspect({kind, reason})
         )
 
@@ -256,9 +528,10 @@ defmodule Embervm.WorkloadWatcher do
   # Builds the catalog entry from a spec already known-valid by validate/1
   # (image is a map, cap/floor already checked). Every optional field applies
   # its CRD-documented default here too, mirroring (not depending on) the
-  # apiserver's own OpenAPI defaulting, since a CR observed via LIST reflects
-  # whatever the apiserver already defaulted at admission; re-defaulting here
-  # just means this code has no silent dependency on that having happened.
+  # apiserver's own OpenAPI defaulting, since a CR observed via LIST/WATCH
+  # reflects whatever the apiserver already defaulted at admission;
+  # re-defaulting here just means this code has no silent dependency on that
+  # having happened.
   defp catalog_entry(name, namespace, spec, floor, cap) do
     image = get_in(spec, ["source", "image"])
     resources = Map.get(spec, "resources") || %{}

--- a/projects/embervm/control/test/embervm/k8s_test.exs
+++ b/projects/embervm/control/test/embervm/k8s_test.exs
@@ -1,0 +1,44 @@
+defmodule Embervm.K8sTest do
+  @moduledoc """
+  Unit tests for the parts of `Embervm.K8s` that are testable without a live
+  apiserver: the NDJSON line framing that reassembles watch events across TCP
+  chunk boundaries. The streaming/auth/request plumbing itself is exercised
+  in-cluster (the deploy-verify step), not here.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.K8s
+
+  describe "frame_ndjson/2" do
+    test "splits complete lines and returns no remainder when the chunk ends on a newline" do
+      assert {["a", "b"], ""} = K8s.frame_ndjson("", "a\nb\n")
+    end
+
+    test "keeps a trailing partial line as the remainder" do
+      assert {["a"], "b"} = K8s.frame_ndjson("", "a\nb")
+    end
+
+    test "prepends the prior buffer so a line split across two chunks reassembles" do
+      # First chunk ends mid-line; its remainder is fed back in as the buffer.
+      {lines1, rest1} = K8s.frame_ndjson("", ~s({"type":"ADD))
+      assert lines1 == []
+      assert rest1 == ~s({"type":"ADD)
+
+      {lines2, rest2} = K8s.frame_ndjson(rest1, ~s(ED"}\n))
+      assert lines2 == [~s({"type":"ADDED"})]
+      assert rest2 == ""
+    end
+
+    test "handles multiple complete lines in one chunk with a trailing partial" do
+      assert {["one", "two"], "thr"} = K8s.frame_ndjson("", "one\ntwo\nthr")
+    end
+
+    test "an empty chunk with a buffered partial yields no lines and preserves the buffer" do
+      assert {[], "partial"} = K8s.frame_ndjson("partial", "")
+    end
+
+    test "a blank line survives framing (the caller skips it, not the framer)" do
+      assert {["", "x"], ""} = K8s.frame_ndjson("", "\nx\n")
+    end
+  end
+end

--- a/projects/embervm/control/test/embervm/workload_watcher_test.exs
+++ b/projects/embervm/control/test/embervm/workload_watcher_test.exs
@@ -3,11 +3,13 @@ defmodule Embervm.WorkloadWatcherTest do
   Exercises `Embervm.WorkloadWatcher`'s reconcile loop end to end: a canned
   `lister` stands in for `Embervm.K8s.list_workloads/0`, an `Agent`-backed
   `status_writer` stands in for `Embervm.K8s.patch_workload_status/3` and
-  records every call for assertions, and `reconcile_interval_ms: nil` means
-  no timer ever fires on its own, every reconcile is driven explicitly via
-  `reconcile_now/1`. Every test uses a unique table name and an unnamed
-  (`name: nil`) watcher process so tests run fully async with zero shared
-  state, and never touch the application's own supervised watcher/table.
+  records every call for assertions, and `watch_startup: false` means the
+  informer opens no watch and arms no timer, so every reconcile is driven
+  explicitly via `reconcile_now/1`. The list-then-watch path itself is covered
+  in the "watch stream" describe block with an injected `watcher_fun`. Every
+  test uses a unique table name and an unnamed (`name: nil`) watcher process so
+  tests run fully async with zero shared state, and never touch the
+  application's own supervised watcher/table.
   """
   use ExUnit.Case, async: true
 
@@ -37,6 +39,10 @@ defmodule Embervm.WorkloadWatcherTest do
     end
   end
 
+  # watch_startup: false means init spawns no streamer and arms no timer: every
+  # reconcile is driven explicitly through reconcile_now/1, exactly as these
+  # LIST-reconcile tests want. The informer/watch path is exercised separately
+  # in the "watch stream" describe block below via an injected watcher_fun.
   defp start_watcher(lister, status_writer, table) do
     {:ok, pid} =
       WorkloadWatcher.start_link(
@@ -44,7 +50,7 @@ defmodule Embervm.WorkloadWatcherTest do
         table: table,
         lister: lister,
         status_writer: status_writer,
-        reconcile_interval_ms: nil
+        watch_startup: false
       )
 
     pid
@@ -213,5 +219,245 @@ defmodule Embervm.WorkloadWatcherTest do
     assert {:ok, after_error} = WorkloadCatalog.fetch(table, "semgrep")
     assert after_error == before
     assert Process.alive?(watcher)
+  end
+
+  # -- watch stream (list-then-watch informer) ------------------------------
+
+  # These exercise the informer's state machine (event application + the
+  # resume-watch vs resync-LIST decision) WITHOUT a live apiserver, by
+  # injecting a scripted `watcher_fun` in place of Embervm.K8s.watch_workloads/2
+  # and a 3-tuple `lister` in place of Embervm.K8s.list_workloads/0. The watch
+  # runs in a real spawned streamer process (that is the part we want under
+  # test), so observations are made through `assert_eventually`, which polls the
+  # catalog rather than assuming a fixed message ordering.
+  describe "watch stream" do
+    test "boot LIST catalogs, then a watch ADDED catalogs a second workload" do
+      table = unique_table()
+      agent = start_recorder()
+      {:ok, watcher_pid} = start_informer(table, agent, [valid_cr()], [{[added_event(named_cr("sandbox"))], :block}])
+
+      assert_eventually(fn -> match?({:ok, _}, WorkloadCatalog.fetch(table, "semgrep")) end)
+      assert_eventually(fn -> match?({:ok, _}, WorkloadCatalog.fetch(table, "sandbox")) end)
+      assert Process.alive?(watcher_pid)
+    end
+
+    test "watch MODIFIED updates an existing catalog entry" do
+      table = unique_table()
+      agent = start_recorder()
+      modified = named_cr("semgrep", %{"spec" => %{"invocation" => %{"retry" => %{"maxAttempts" => 9}}}})
+      {:ok, _pid} = start_informer(table, agent, [valid_cr()], [{[modified_event(modified)], :block}])
+
+      assert_eventually(fn ->
+        match?({:ok, %{retry: %{max_attempts: 9}}}, WorkloadCatalog.fetch(table, "semgrep"))
+      end)
+    end
+
+    test "watch DELETED drops the workload from the catalog" do
+      table = unique_table()
+      agent = start_recorder()
+      {:ok, _pid} = start_informer(table, agent, [valid_cr()], [{[deleted_event(valid_cr())], :block}])
+
+      assert_eventually(fn -> WorkloadCatalog.fetch(table, "semgrep") == :error end)
+    end
+
+    test "a terminal ERROR event triggers a resync LIST (recovering a delete missed while disconnected)" do
+      table = unique_table()
+      agent = start_recorder()
+      # Boot LIST returns semgrep; the watch delivers only an ERROR (RV
+      # expired) and closes. The resync LIST returns an EMPTY collection, so
+      # the reconcile sweep must drop semgrep even though no DELETED event was
+      # ever seen. That is the "catch deletes missed while disconnected" path.
+      {:ok, lister_agent} = Agent.start_link(fn -> [valid_cr()] end)
+
+      lister = fn ->
+        crs = Agent.get_and_update(lister_agent, fn crs -> {crs, []} end)
+        {:ok, crs, "100"}
+      end
+
+      {:ok, _pid} =
+        WorkloadWatcher.start_link(
+          name: nil,
+          table: table,
+          lister: lister,
+          status_writer: recording_status_writer(agent),
+          # The ERROR event flags a resync; the stream must then CLOSE so the
+          # watch-end handler runs the resync LIST. (A :block episode would fire
+          # the event but never end, so the resync would never trigger.) The
+          # close is fast, so it goes through the backoff timer; keep that tiny.
+          watcher_fun: scripted_watcher([{[error_event()], {:ok, :closed}}]),
+          base_backoff_ms: 10,
+          max_backoff_ms: 20,
+          watch_startup: true
+        )
+
+      assert_eventually(fn -> WorkloadCatalog.fetch(table, "semgrep") == :error end)
+    end
+
+    test "a watch error backs off then resyncs; the watcher survives and re-lists" do
+      table = unique_table()
+      agent = start_recorder()
+      {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+      lister = fn ->
+        Agent.update(calls, &(&1 + 1))
+        {:ok, [valid_cr()], "100"}
+      end
+
+      {:ok, watcher_pid} =
+        WorkloadWatcher.start_link(
+          name: nil,
+          table: table,
+          lister: lister,
+          status_writer: recording_status_writer(agent),
+          # First watch attempt errors; the second blocks (open). With a tiny
+          # backoff the resync fires fast enough to assert without slowing CI.
+          watcher_fun: scripted_watcher([{[], {:error, :boom}}, {[], :block}]),
+          base_backoff_ms: 10,
+          max_backoff_ms: 20,
+          watch_startup: true
+        )
+
+      # Two LISTs prove the cycle: the boot LIST, then the post-error resync.
+      assert_eventually(fn -> Agent.get(calls, & &1) >= 2 end)
+      assert Process.alive?(watcher_pid)
+    end
+
+    test "a BOOKMARK event is absorbed without disrupting subsequent deltas" do
+      table = unique_table()
+      agent = start_recorder()
+      # A BOOKMARK (RV-only, empty object) must be applied silently; the ADDED
+      # that follows in the same stream still catalogs, proving the BOOKMARK
+      # clause neither crashes the watcher nor swallows later events.
+      episode = [{[bookmark_event("150"), added_event(named_cr("sandbox"))], :block}]
+      {:ok, watcher_pid} = start_informer(table, agent, [valid_cr()], episode)
+
+      assert_eventually(fn -> match?({:ok, _}, WorkloadCatalog.fetch(table, "sandbox")) end)
+      assert Process.alive?(watcher_pid)
+    end
+
+    test "a clean watch close resumes the watch without re-listing" do
+      table = unique_table()
+      agent = start_recorder()
+      {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+      lister = fn ->
+        Agent.update(calls, &(&1 + 1))
+        {:ok, [valid_cr()], "100"}
+      end
+
+      # First watch closes cleanly with no events; the second catalogs a new
+      # workload ("sandbox") then blocks. A clean close must RESUME the watch
+      # (start a new streamer) WITHOUT a resync LIST, so once "sandbox" appears
+      # we know the second streamer ran, and the lister must still have been
+      # called exactly once (the boot LIST) — a resync would have made it two.
+      {:ok, watcher_pid} =
+        WorkloadWatcher.start_link(
+          name: nil,
+          table: table,
+          lister: lister,
+          status_writer: recording_status_writer(agent),
+          watcher_fun:
+            scripted_watcher([{[], {:ok, :closed}}, {[added_event(named_cr("sandbox"))], :block}]),
+          # min_watch_ms: 0 makes the (instant) fake close count as a healthy
+          # long-lived close, so it takes the immediate-rewatch branch rather
+          # than the fast-close backoff branch. That is the path under test.
+          min_watch_ms: 0,
+          watch_startup: true
+        )
+
+      # Positive signal that the re-watch fired (rather than racing a fixed
+      # sleep): the second episode's ADDED lands in the catalog. Only then is
+      # the "no relist" assertion meaningful.
+      assert_eventually(fn -> match?({:ok, _}, WorkloadCatalog.fetch(table, "sandbox")) end)
+      assert Agent.get(calls, & &1) == 1
+      assert Process.alive?(watcher_pid)
+    end
+  end
+
+  # -- watch-test helpers ---------------------------------------------------
+
+  # Starts a real informer (watch_startup: true) with a boot LIST returning
+  # `list_crs` (as a 3-tuple carrying an RV, like the production lister) and an
+  # injected watcher_fun scripted with `episodes`.
+  defp start_informer(table, agent, list_crs, episodes) do
+    lister = fn -> {:ok, list_crs, "100"} end
+
+    WorkloadWatcher.start_link(
+      name: nil,
+      table: table,
+      lister: lister,
+      status_writer: recording_status_writer(agent),
+      watcher_fun: scripted_watcher(episodes),
+      watch_startup: true
+    )
+  end
+
+  # A programmable stand-in for Embervm.K8s.watch_workloads/2. Backed by an
+  # Agent holding a queue of episodes; each call pops one. An episode is
+  # `{events, result}` where result is `{:ok, :closed}` / `{:error, reason}`, OR
+  # `{events, :block}` which fires the events then blocks forever (an open,
+  # idle watch) so the watcher does not spin re-watching an exhausted script.
+  # When the queue empties, further calls block too.
+  defp scripted_watcher(episodes) do
+    {:ok, queue} = Agent.start_link(fn -> episodes end)
+
+    fn _rv, on_event ->
+      episode =
+        Agent.get_and_update(queue, fn
+          [ep | rest] -> {ep, rest}
+          [] -> {:block, []}
+        end)
+
+      case episode do
+        :block ->
+          Process.sleep(:infinity)
+
+        {events, :block} ->
+          Enum.each(events, on_event)
+          Process.sleep(:infinity)
+
+        {events, result} ->
+          Enum.each(events, on_event)
+          result
+      end
+    end
+  end
+
+  defp named_cr(name, overrides \\ %{}) do
+    valid_cr(deep_merge(%{"metadata" => %{"name" => name}}, overrides))
+  end
+
+  defp added_event(cr), do: %{"type" => "ADDED", "object" => cr}
+  defp modified_event(cr), do: %{"type" => "MODIFIED", "object" => cr}
+  defp deleted_event(cr), do: %{"type" => "DELETED", "object" => cr}
+  defp bookmark_event(rv), do: %{"type" => "BOOKMARK", "object" => %{"metadata" => %{"resourceVersion" => rv}}}
+
+  defp error_event do
+    %{
+      "type" => "ERROR",
+      "object" => %{"kind" => "Status", "apiVersion" => "v1", "code" => 410, "reason" => "Expired"}
+    }
+  end
+
+  # Polls `fun` until it returns truthy or the timeout elapses. Used because the
+  # watch path applies events through real inter-process messages, so the exact
+  # moment a delta lands in the catalog is not synchronous with the test.
+  defp assert_eventually(fun, timeout_ms \\ 2_000, interval_ms \\ 10) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_eventually(fun, deadline, interval_ms)
+  end
+
+  defp do_eventually(fun, deadline, interval_ms) do
+    cond do
+      fun.() ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("condition was not met within the timeout")
+
+      true ->
+        Process.sleep(interval_ms)
+        do_eventually(fun, deadline, interval_ms)
+    end
   end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.7
+      targetRevision: 0.1.8
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## What

Swaps `Embervm.WorkloadWatcher` from a periodic LIST poll to a Kubernetes **list-then-watch informer**, behind the unchanged `WorkloadCatalog` / `TaskStore.cfg_for/1` read surface.

Follows up on #3480, which built the watcher as a periodic reconciler with a note that a true watch was an internal swap behind the same API. This is that swap. Motivation: the periodic full-LIST couples steady-state apiserver load to the poll cadence (we already saw a 429 on the boot LIST), whereas a watch is served from the apiserver's cache at near-zero incremental cost.

## How

- **LIST → reconcile** on boot and on every resync, recording the collection `resourceVersion`; **WATCH** from that RV for deltas (ADDED / MODIFIED / DELETED / BOOKMARK), applied incrementally.
- **Clean close** (the apiserver's ~5 min `timeoutSeconds`) re-watches from the last RV, no relist.
- **410 Expired** (a terminal ERROR event) or any transport/parse error **resyncs** via a fresh LIST, which also sweeps deletes missed while disconnected. Errors back off exponentially.
- The blocking `Finch.stream/5` runs in a `spawn_monitor`'d **streamer process**; the GenServer keeps sole ownership of the ETS catalog, the RV, and all reconnect decisions, and **drops events from any superseded streamer** so the RV never regresses.
- **Hot-loop guard**: a min-watch-duration gate means only long-lived closes re-watch immediately; a suspiciously fast close backs off first, so an apiserver that accepts-then-instantly-closes cannot spin the reconnect loop.
- `Embervm.K8s.list_workloads/0` now serves from the watch cache (`resourceVersion=0`) and returns the collection RV; new `watch_workloads/2` streams NDJSON with chunk-boundary framing (`frame_ndjson/2`).

## Correctness notes (deploy-only-verifiable class)

- `Finch.stream/5` in finch 0.23.0 returns the **3-tuple** `{:error, exception, acc}` on error (verified against the pinned source); handled explicitly so a disconnect does not `CaseClause`-crash.
- RBAC already grants `get/list/watch` on `workloads` (provisioned in #3480), so no chart RBAC change was needed.

## Tests

- Existing LIST-reconcile tests retained (driven via `reconcile_now/1` with `watch_startup: false`).
- New informer state-machine tests via an injected scripted `watcher_fun`: watch ADDED/MODIFIED/DELETED, BOOKMARK absorption, ERROR-triggers-resync (recovering a delete missed while disconnected), watch-error backoff+resync, and clean-close-resumes-without-relist.
- New `k8s_test.exs` unit-tests the NDJSON framing across chunk boundaries.

One Opus code-review pass over the full diff found no correctness bugs in the GenServer/streamer protocol, RV tracking, reconnect state machine, or Finch reducer; its one test-stability note (a bare `Process.sleep`) is addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)