### PR TITLE
fix(signoz): restore GitOps alerting (register orphaned app + fix stale alertType)

### DIFF
--- a/projects/platform/argocd/argocd-httpcheck-alert.yaml
+++ b/projects/platform/argocd/argocd-httpcheck-alert.yaml
@@ -13,7 +13,7 @@ data:
   alert.json: |
     {
       "alert": "ArgoCD Unreachable",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/longhorn/longhorn-httpcheck-alert.yaml
+++ b/projects/platform/longhorn/longhorn-httpcheck-alert.yaml
@@ -13,7 +13,7 @@ data:
   alert.json: |
     {
       "alert": "Longhorn Unreachable",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz-addons/alerts/kustomization.yaml
+++ b/projects/platform/signoz-addons/alerts/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ./alerts
-  - ./dashboard-sidecar
+  - application.yaml

--- a/projects/platform/signoz-addons/alerts/templates/_slo.tpl
+++ b/projects/platform/signoz-addons/alerts/templates/_slo.tpl
@@ -53,7 +53,7 @@ data:
   alert.json: |
     {
       "alert": {{ printf "%s SLO Burn Rate High" $slo.name | quote }},
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,
@@ -138,7 +138,7 @@ data:
   alert.json: |
     {
       "alert": {{ printf "%s SLO Budget Exhausted" $slo.name | quote }},
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz-addons/alerts/templates/argocd-app-degraded.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/argocd-app-degraded.yaml
@@ -12,7 +12,7 @@ data:
   alert.json: |
     {
       "alert": "ArgoCD App Degraded",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz-addons/alerts/templates/argocd-app-missing.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/argocd-app-missing.yaml
@@ -12,7 +12,7 @@ data:
   alert.json: |
     {
       "alert": "ArgoCD App Missing",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz-addons/alerts/templates/argocd-app-outofsync.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/argocd-app-outofsync.yaml
@@ -12,7 +12,7 @@ data:
   alert.json: |
     {
       "alert": "ArgoCD App OutOfSync",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz-addons/alerts/templates/argocd-app-suspended.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/argocd-app-suspended.yaml
@@ -12,7 +12,7 @@ data:
   alert.json: |
     {
       "alert": "ArgoCD App Suspended",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz-addons/alerts/templates/hubble-invoke-http.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/hubble-invoke-http.yaml
@@ -31,7 +31,7 @@ data:
   alert.json: |
     {
       "alert": "fc-invoke L7 5xx Rate",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz-addons/alerts/templates/hubble-policy-drops.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/hubble-policy-drops.yaml
@@ -12,7 +12,7 @@ data:
   alert.json: |
     {
       "alert": "Hubble CiliumNetworkPolicy Drops",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz-addons/alerts/templates/node-disk-pressure.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/node-disk-pressure.yaml
@@ -12,7 +12,7 @@ data:
   alert.json: |
     {
       "alert": "Node Disk Pressure",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz-addons/alerts/templates/node-memory-pressure.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/node-memory-pressure.yaml
@@ -12,7 +12,7 @@ data:
   alert.json: |
     {
       "alert": "Node Memory Pressure",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz-addons/alerts/templates/node-not-ready.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/node-not-ready.yaml
@@ -12,7 +12,7 @@ data:
   alert.json: |
     {
       "alert": "Node Not Ready",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz-addons/alerts/templates/node-pid-pressure.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/node-pid-pressure.yaml
@@ -12,7 +12,7 @@ data:
   alert.json: |
     {
       "alert": "Node PID Pressure",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz-addons/alerts/templates/pod-oomkilled.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/pod-oomkilled.yaml
@@ -12,7 +12,7 @@ data:
   alert.json: |
     {
       "alert": "Pod OOMKilled",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz-addons/alerts/templates/pod-pending.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/pod-pending.yaml
@@ -12,7 +12,7 @@ data:
   alert.json: |
     {
       "alert": "Pod Stuck Pending",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz-addons/alerts/templates/pod-restart-rate.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/pod-restart-rate.yaml
@@ -12,7 +12,7 @@ data:
   alert.json: |
     {
       "alert": "Pod High Restart Rate",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz/jomcgi-dev-httpcheck-alert.yaml
+++ b/projects/platform/signoz/jomcgi-dev-httpcheck-alert.yaml
@@ -13,7 +13,7 @@ data:
   alert.json: |
     {
       "alert": "jomcgi.dev Unreachable",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,

--- a/projects/platform/signoz/signoz-httpcheck-alert.yaml
+++ b/projects/platform/signoz/signoz-httpcheck-alert.yaml
@@ -13,7 +13,7 @@ data:
   alert.json: |
     {
       "alert": "SigNoz Unreachable",
-      "alertType": "METRICS_BASED_ALERT",
+      "alertType": "METRIC_BASED_ALERT",
       "ruleType": "threshold_rule",
       "version": "v5",
       "broadcastToAll": false,


### PR DESCRIPTION
Two independent, pre-existing bugs together disabled **all** GitOps-managed SigNoz alerting. Found while verifying the `/invoke` L7 alert from #3484 (ADR networking/003 #2), whose companion alert was inert because of both. The `/invoke` L7 policy itself deployed fine; this restores the alert half (and the whole alert suite).

## Bug A: `signoz-alerts` app never registered (dormant since 2026-03-10)
The `signoz-alerts` Application (13 alert ConfigMaps: node/pod/argocd health, the Hubble policy-drop alert from #3482, the `/invoke` 5xx alert from #3484, SLO burns) was never wired into the ArgoCD root: `alerts/` had no `kustomization.yaml` and `signoz-addons/kustomization.yaml` listed only `./dashboard-sidecar`. The `66459c05e` "flatten chart, extract addons" refactor moved the chart out but never re-registered it, so **none of these 13 ConfigMaps have ever deployed**.

**Fix:** add `alerts/kustomization.yaml` (mirroring the working `dashboard-sidecar` sibling) + `./alerts` to `signoz-addons/kustomization.yaml`. Verified `kubectl kustomize projects/home-cluster` now emits the `signoz-alerts` Application.

## Bug B: stale `alertType` enum — all alerts 400-rejected
SigNoz's alert API renamed the enum `METRICS_BASED_ALERT` → `METRIC_BASED_ALERT` (singular). Every alert ConfigMap in the repo (19 occurrences / 17 files) carried the old value, so the dashboard-sidecar's sync to `api/v1/rules` was rejected every reconcile:

```
alertType: unsupported value "METRICS_BASED_ALERT";
must be one of "METRIC_BASED_ALERT", "TRACES_BASED_ALERT", ...
```

This hit even the 4 alerts that *were* registered (the httpcheck alerts in the signoz/argocd/longhorn apps), confirmed live in the sidecar logs minutes before this PR.

**Fix:** rename all 19 occurrences (chart templates, `_slo.tpl`, and the standalone httpcheck alerts). The httpcheck alert uses the identical v5 `builder_query` structure as the chart alerts, and the sidecar's *only* complaint was `alertType`, so this is the sole schema drift.

## Combined effect
No GitOps-managed SigNoz alert was loading. After this merges: ArgoCD creates `signoz-alerts` → 13 ConfigMaps (all `METRIC_BASED_ALERT`) → the sidecar loads them into SigNoz. All apps touched are git-path (`targetRevision: HEAD`), no chart bumps.

## Verification
- `helm template` of the alerts chart: 13 ConfigMaps, all `METRIC_BASED_ALERT`, all valid JSON (incl. `hubble-invoke-http-5xx-alert`).
- Post-merge (I will do this): watch `signoz-dashboard-sidecar` logs for "Reconciling alert ConfigMaps" count jumping to ~17 with **zero** "Failed to sync alert" errors, then confirm rules appear in SigNoz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)