### PR TITLE
feat(embervm): fork fc-invoke node layer into embervm-noded gRPC daemon (R0 Task 4)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -510,7 +510,11 @@ apko.translate_lock(
     name = "embervm_lock",
     lock = "//projects/embervm/image:apko.lock.json",
 )
-use_repo(apko, "embervm_lock", "fc_invoke_lock", "git_mirror_lock", "grimoire_frontend_lock", "harness_lock", "monolith_frontend_lock", "rootfs_builder_lock", "sandbox_guest_lock", "semgrep_guest_lock", "visual_chromium_lock", "whatsapp_lock")
+apko.translate_lock(
+    name = "embervm_noded_lock",
+    lock = "//projects/embervm/noded/image:apko.lock.json",
+)
+use_repo(apko, "embervm_lock", "embervm_noded_lock", "fc_invoke_lock", "git_mirror_lock", "grimoire_frontend_lock", "harness_lock", "monolith_frontend_lock", "rootfs_builder_lock", "sandbox_guest_lock", "semgrep_guest_lock", "visual_chromium_lock", "whatsapp_lock")
 
 # Download multiarch archives (binaries from zip files)
 multiarch_http_archive = use_repo_rule("//bazel/tools/http:multiarch_http_archive.bzl", "multiarch_http_archive")

--- a/bazel/images/BUILD
+++ b/bazel/images/BUILD
@@ -31,6 +31,7 @@ multirun(
         "//bazel/tools/image:image.push",
         "//projects/embervm/chart:chart.push",
         "//projects/embervm/image:image.push",
+        "//projects/embervm/noded/image:image.push",
         "//projects/firecracker/git-mirror/chart:chart.push",
         "//projects/firecracker/git-mirror:image.push",
         "//projects/firecracker/goosecracker/guest-init:image.push",

--- a/projects/embervm/chart/BUILD
+++ b/projects/embervm/chart/BUILD
@@ -7,6 +7,7 @@ helm_chart(
     name = "chart",
     images = {
         "image": "//projects/embervm/image:image.info",
+        "noded.image": "//projects/embervm/noded/image:image.info",
     },
     publish = True,
     visibility = ["//overlays:__subpackages__"],

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.9
+version: 0.1.10

--- a/projects/embervm/chart/templates/_helpers.tpl
+++ b/projects/embervm/chart/templates/_helpers.tpl
@@ -20,3 +20,34 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "embervm.serviceAccountName" -}}
 {{- include "embervm.fullname" . -}}
 {{- end -}}
+
+{{/*
+The node daemon (embervm-noded) is a SECOND Deployment in this one chart/release.
+It uses a DISTINCT app.kubernetes.io/name ("<name>-noded") so its selector is
+disjoint from the control plane's: the control-plane Deployment's selector is
+already live and immutable, so it cannot gain a component label without a
+delete+recreate. The noded selector additionally carries a component label to
+disambiguate self-documentingly (and satisfy the selector-component lint).
+*/}}
+{{- define "embervm.noded.name" -}}
+{{- printf "%s-noded" (include "embervm.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "embervm.noded.fullname" -}}
+{{- printf "%s-noded" (include "embervm.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "embervm.noded.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "embervm.noded.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: noded
+{{- end -}}
+
+{{- define "embervm.noded.labels" -}}
+{{ include "embervm.noded.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "embervm.noded.serviceAccountName" -}}
+{{- include "embervm.noded.fullname" . -}}
+{{- end -}}

--- a/projects/embervm/chart/templates/noded-deployment.yaml
+++ b/projects/embervm/chart/templates/noded-deployment.yaml
@@ -1,0 +1,129 @@
+{{- if .Values.noded.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "embervm.noded.fullname" . }}
+  labels:
+    {{- include "embervm.noded.labels" . | nindent 4 }}
+spec:
+  # Single replica: the daemon is node-affine (FC guests are node-bound) and owns
+  # node-4's KVM device + nvme scratch. Recreate, never run two against one node.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "embervm.noded.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "embervm.noded.labels" . | nindent 8 }}
+    spec:
+      # Safe-rollout drain: give the daemon time to finish in-flight Assigns on
+      # SIGTERM before Kubernetes SIGKILLs it. Set above the daemon's own drain
+      # budget (EMBERVM_NODED_DRAIN_TIMEOUT below) so grace always outlasts drain,
+      # mirroring fc-invoke (grace = drain + 30s).
+      terminationGracePeriodSeconds: {{ add .Values.noded.drain.timeoutSeconds 30 }}
+      serviceAccountName: {{ include "embervm.noded.serviceAccountName" . }}
+      {{- if .Values.imagePullSecret.enabled }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret.name }}
+      {{- end }}
+      priorityClassName: {{ .Values.noded.priorityClassName }}
+      nodeSelector:
+        {{- toYaml .Values.noded.nodeSelector | nindent 8 }}
+      {{- with .Values.noded.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      # Driving Firecracker needs root + the host KVM device and the nvme scratch
+      # dir (the firecracker binary + guest kernel are baked into the image at
+      # /opt/fc). Privileged is required for the per-instance vsock mount namespaces.
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+      containers:
+        - name: noded
+          image: "{{ .Values.noded.image.repository }}:{{ .Values.noded.image.tag }}"
+          imagePullPolicy: {{ .Values.noded.image.pullPolicy }}
+          securityContext:
+            privileged: true
+          ports:
+            - name: grpc
+              containerPort: {{ .Values.noded.grpcPort }}
+              protocol: TCP
+            - name: health
+              containerPort: {{ .Values.noded.healthPort }}
+              protocol: TCP
+          env:
+            - name: EMBERVM_NODED_LISTEN_ADDR
+              value: ":{{ .Values.noded.grpcPort }}"
+            - name: EMBERVM_NODED_HEALTH_ADDR
+              value: ":{{ .Values.noded.healthPort }}"
+            # The daemon self-identifies from the Downward API so snapshot node-
+            # pinning is correct wherever it lands.
+            - name: EMBERVM_NODED_NODE
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: EMBERVM_NODED_MAX_LIVE_VMS
+              value: {{ .Values.noded.maxLiveVMs | quote }}
+            # Per-invoke FC bundle snapshots and the fixed vsock dir the snapshot
+            # embeds both derive from nvmeRoot so the scratch disk is one knob.
+            - name: EMBERVM_NODED_SNAPSHOT_ROOT
+              value: {{ printf "%s/embervm-noded/snapshots" .Values.noded.firecracker.nvmeRoot | quote }}
+            - name: EMBERVM_NODED_CANONICAL_VSOCK_DIR
+              value: {{ printf "%s/embervm-noded-vsock" .Values.noded.firecracker.nvmeRoot | quote }}
+            - name: EMBERVM_NODED_GUEST_OOM_SCORE_ADJ
+              value: {{ .Values.noded.firecracker.guestOomScoreAdj | quote }}
+            - name: EMBERVM_NODED_BOOT_READY_TIMEOUT
+              value: {{ .Values.noded.firecracker.bootReadyTimeout | quote }}
+            {{- with .Values.noded.firecracker.kernelBootArgs }}
+            - name: EMBERVM_NODED_KERNEL_BOOT_ARGS
+              value: {{ . | quote }}
+            {{- end }}
+            - name: EMBERVM_NODED_DRAIN_TIMEOUT
+              value: "{{ .Values.noded.drain.timeoutSeconds }}s"
+            # Node-side image identity table (image_ref -> rootfsPath[,harnessInit]),
+            # rendered as JSON. Empty until the control plane provisions guest images
+            # (Task 11+); BuildBase for an unknown image fails FAILED_PRECONDITION.
+            - name: EMBERVM_NODED_IMAGES
+              value: {{ .Values.noded.images | toJson | quote }}
+            {{- if .Values.noded.bearerTokenSecret.enabled }}
+            # Static bearer token gating the gRPC surface. When unset the daemon
+            # runs open and warns; a Cilium/Linkerd policy is defence-in-depth.
+            - name: EMBERVM_NODED_BEARER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.noded.bearerTokenSecret.name }}
+                  key: {{ .Values.noded.bearerTokenSecret.key }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.noded.resources | nindent 12 }}
+          volumeMounts:
+            - name: dev-kvm
+              mountPath: /dev/kvm
+            - name: nvme
+              mountPath: {{ .Values.noded.firecracker.nvmeRoot }}
+      volumes:
+        - name: dev-kvm
+          hostPath:
+            path: /dev/kvm
+            type: CharDevice
+        - name: nvme
+          hostPath:
+            path: {{ .Values.noded.firecracker.nvmeRoot }}
+            type: Directory
+{{- end }}

--- a/projects/embervm/chart/templates/noded-service.yaml
+++ b/projects/embervm/chart/templates/noded-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.noded.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "embervm.noded.fullname" . }}
+  labels:
+    {{- include "embervm.noded.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "embervm.noded.selectorLabels" . | nindent 4 }}
+  ports:
+    # gRPC NodeService the control plane dials (Task 11 wires the dispatcher to
+    # <fullname>.<namespace>.svc.cluster.local:{{ .Values.noded.grpcPort }}).
+    - name: grpc
+      port: {{ .Values.noded.grpcPort }}
+      targetPort: grpc
+{{- end }}

--- a/projects/embervm/chart/templates/noded-serviceaccount.yaml
+++ b/projects/embervm/chart/templates/noded-serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.noded.enabled }}
+# The node daemon needs no Kubernetes API access (no TokenReview, no CR watch):
+# its gRPC surface is gated by a static bearer token, not the apiserver. So this
+# ServiceAccount carries no RBAC - it exists only to give the privileged pod a
+# non-default identity and to attach the GHCR image-pull secret.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "embervm.noded.serviceAccountName" . }}
+  labels:
+    {{- include "embervm.noded.labels" . | nindent 4 }}
+{{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -73,3 +73,73 @@ podSecurityContext:
 sampleWorkload:
   enabled: true
   name: echo
+
+# embervm-noded: the node daemon (gRPC NodeService) that owns Firecracker microVM
+# lifecycle on node-4. A SECOND Deployment in this chart, privileged and node-
+# pinned, forked from the fc-invoke node layer (ADR embervm/001). It coexists with
+# fc-invoke on node-4; this release primes ZERO VMs (the control-plane dispatcher
+# is Task 11), so its steady footprint is just the daemon.
+noded:
+  enabled: true
+  image:
+    # Pinned at build time by helm_chart(images={"noded.image": ".../noded/image:image.info"}).
+    repository: ghcr.io/jomcgi/homelab/projects/embervm/noded/image
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  # gRPC port the control plane dials; health port for kubelet probes.
+  grpcPort: 9090
+  healthPort: 8080
+
+  # node-4 pinning: the lone Firecracker node (homelab.io/firecracker=true).
+  nodeSelector:
+    homelab.io/firecracker: "true"
+  tolerations: []
+  # Disposable tier (ADR platform/010): microVM workloads must die before
+  # inference or the database under memory pressure, so lowest priority.
+  priorityClassName: homelab-disposable
+
+  # Node-level backstop cap on concurrently live microVMs. The control plane owns
+  # real concurrency; this only stops a runaway from exhausting the node.
+  maxLiveVMs: 8
+
+  # Static bearer token gating the gRPC surface. Disabled here (daemon runs open +
+  # warns; Cilium/Linkerd policy is the layer). A 1Password-provisioned secret is
+  # wired in a later PR when the control plane dials the daemon (Task 11).
+  bearerTokenSecret:
+    enabled: false
+    name: ""
+    key: token
+
+  # Firecracker substrate on node-4. The firecracker binary + guest kernel are
+  # baked into the image at /opt/fc, so the node only provides /dev/kvm and the
+  # nvme scratch dir (see projects/platform/firecracker-node).
+  firecracker:
+    nvmeRoot: /disks/nvme-02
+    guestOomScoreAdj: 1000
+    bootReadyTimeout: 60s
+    # Shared base rootfs is booted READ-ONLY (root=/dev/vda ro): every mutable
+    # guest path is a tmpfs, so one read-only rootfs file backs every microVM.
+    kernelBootArgs: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda ro"
+
+  # Node-side image identity table (image_ref -> {rootfsPath[, harnessInit]}),
+  # rendered to EMBERVM_NODED_IMAGES. Empty until the control plane provisions
+  # guest images (Task 11+); BuildBase for an unknown image fails FAILED_PRECONDITION.
+  images: {}
+
+  # Graceful-drain budget: on SIGTERM the daemon waits up to this long for in-
+  # flight Assigns before exiting. terminationGracePeriodSeconds is set above it
+  # (grace = drain + 30s), so a rollout never drops a running task.
+  drain:
+    timeoutSeconds: 60
+
+  # 256Mi req / 2Gi limit: fits the node-4 coexistence budget alongside fc-invoke
+  # (2Gi req / 50Gi limit). This release primes ZERO VMs (the dispatcher is Task
+  # 11), so the daemon idles well under 256Mi; the 2Gi ceiling covers the daemon
+  # plus ~1 future primed 1Gi VM. Grow the limit when the real pool lands.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 2Gi

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.9
+      targetRevision: 0.1.10
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/cmd/BUILD
+++ b/projects/embervm/noded/cmd/BUILD
@@ -1,0 +1,28 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "cmd_lib",
+    srcs = [
+        "auth.go",
+        "main.go",
+    ],
+    importpath = "github.com/jomcgi/homelab/projects/embervm/noded/cmd",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//projects/embervm/noded/config",
+        "//projects/embervm/noded/fcvm/driver",
+        "//projects/embervm/noded/server",
+        "//projects/embervm/noded/vsockhttp",
+        "//projects/embervm/proto/embervm/node/v1:nodev1",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//status",
+    ],
+)
+
+go_binary(
+    name = "noded",
+    embed = [":cmd_lib"],
+    visibility = ["//projects/embervm/noded:__subpackages__"],
+)

--- a/projects/embervm/noded/cmd/auth.go
+++ b/projects/embervm/noded/cmd/auth.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"crypto/subtle"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// bearerPrefix is the scheme in the gRPC "authorization" metadata value the
+// daemon expects: "Bearer <token>".
+const bearerPrefix = "Bearer "
+
+// checkBearer validates the incoming call's authorization metadata against the
+// configured static token in constant time. It is the portable, mesh-independent
+// gate (v1 auth per the node.proto contract); a Cilium/Linkerd policy layers on
+// top. The upgrade path to mTLS/SPIFFE is additive and does not touch this.
+func checkBearer(ctx context.Context, token string) error {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "noded: missing call metadata")
+	}
+	vals := md.Get("authorization")
+	if len(vals) == 0 {
+		return status.Error(codes.Unauthenticated, "noded: missing authorization")
+	}
+	got := strings.TrimPrefix(vals[0], bearerPrefix)
+	if subtle.ConstantTimeCompare([]byte(got), []byte(token)) != 1 {
+		return status.Error(codes.Unauthenticated, "noded: invalid bearer token")
+	}
+	return nil
+}
+
+// unaryAuthInterceptor gates every unary RPC on the bearer token.
+func unaryAuthInterceptor(token string) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if err := checkBearer(ctx, token); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+// streamAuthInterceptor gates every streaming RPC (WatchNode) on the bearer token.
+func streamAuthInterceptor(token string) grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := checkBearer(ss.Context(), token); err != nil {
+			return err
+		}
+		return handler(srv, ss)
+	}
+}

--- a/projects/embervm/noded/cmd/main.go
+++ b/projects/embervm/noded/cmd/main.go
@@ -1,0 +1,204 @@
+// Command embervm-noded is the EmberVM node daemon: the gRPC NodeService server
+// that owns Firecracker microVM lifecycle on one node (node-4). It is the fork of
+// fc-invoke's node layer (ADR embervm/001, fork-not-extend), reshaped behind the
+// embervm.node.v1 contract. The control plane (Elixir) drives it: BuildBase turns
+// a guest image into a base snapshot, Prime restores a pristine VM and parks it,
+// Assign delivers one vsock HTTP task then destroys the VM, and WatchNode streams
+// capacity facts. The daemon owns NO concurrency policy and NO durable state
+// beyond node-local snapshot files; on start it reports existing bases so the
+// control plane reconciles instead of rebuilding.
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"google.golang.org/grpc"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/config"
+	"github.com/jomcgi/homelab/projects/embervm/noded/fcvm/driver"
+	"github.com/jomcgi/homelab/projects/embervm/noded/server"
+	"github.com/jomcgi/homelab/projects/embervm/noded/vsockhttp"
+)
+
+func main() {
+	// Handle the "__fcmount" re-exec FIRST: launching a microVM with per-instance
+	// vsock isolation re-execs this binary in a fresh mount namespace, bind-mounts
+	// the bundle dir, then execs firecracker (never returning). It is a no-op for a
+	// normal daemon start, so it must run before any other startup work.
+	driver.ExecMountTrampoline()
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(logger)
+
+	if err := run(logger); err != nil {
+		logger.Error("embervm-noded exited with error", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run(logger *slog.Logger) error {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	logger.Info("embervm-noded starting",
+		"listen", cfg.ListenAddr, "health", cfg.HealthAddr,
+		"node", cfg.Node, "arch", cfg.Arch,
+		"maxLiveVMs", cfg.MaxLiveVMs, "images", len(cfg.Images))
+
+	self, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	// One transport shared across every VM: stateless, a fresh vsock connection
+	// per RoundTrip (keep-alives disabled), so no two microVMs share a connection.
+	transport := vsockhttp.NewTransport()
+
+	// The shared restore driver serves Prime/Assign/Destroy: it only ever restores
+	// from a base snapshot, so its rootfs/sizing are irrelevant (the snapshot has
+	// them baked). Its in-memory live map is the authority for LiveCount.
+	restoreDriver := newDriver(cfg, self, driverExtras{})
+
+	// Per-build drivers cold-boot one image's rootfs at its sizing, then snapshot;
+	// they are discarded after the base is written (the base lives on disk).
+	newBuild := func(spec server.BuildDriverSpec) server.BuildDriver {
+		return newDriver(cfg, self, driverExtras{
+			rootfsPath:  spec.RootfsPath,
+			harnessInit: spec.HarnessInit,
+			vcpus:       spec.VCPUs,
+			memMib:      spec.MemMib,
+		})
+	}
+
+	srv := server.New(server.Options{
+		Config:         cfg,
+		Driver:         restoreDriver,
+		Transport:      transport,
+		NewBuildDriver: newBuild,
+		Logger:         logger,
+	})
+	// Report node-local base snapshots left by a prior incarnation so the control
+	// plane reconciles rather than rebuilding.
+	srv.ReconcileBasesFromDisk()
+
+	var serverOpts []grpc.ServerOption
+	if cfg.BearerToken != "" {
+		serverOpts = append(serverOpts,
+			grpc.UnaryInterceptor(unaryAuthInterceptor(cfg.BearerToken)),
+			grpc.StreamInterceptor(streamAuthInterceptor(cfg.BearerToken)),
+		)
+		logger.Info("bearer-token auth enabled")
+	} else {
+		logger.Warn("bearer-token auth DISABLED: EMBERVM_NODED_BEARER_TOKEN is unset, so the gRPC surface is open to any in-cluster client (rely on Cilium/Linkerd policy)")
+	}
+	gs := grpc.NewServer(serverOpts...)
+	nodev1.RegisterNodeServiceServer(gs, srv)
+
+	lis, err := net.Listen("tcp", cfg.ListenAddr)
+	if err != nil {
+		return err
+	}
+
+	// Plain-HTTP /healthz for kubelet probes (a privileged single-replica pod does
+	// not warrant gRPC health-checking machinery).
+	health := &http.Server{
+		Addr:              cfg.HealthAddr,
+		Handler:           healthHandler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		logger.Info("health endpoint listening", "addr", cfg.HealthAddr)
+		if err := health.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("health server failed", "err", err)
+		}
+	}()
+
+	errCh := make(chan error, 1)
+	go func() {
+		logger.Info("gRPC NodeService listening", "addr", cfg.ListenAddr)
+		errCh <- gs.Serve(lis)
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		// Drain: stop advertising capacity, stop accepting new RPCs, and let
+		// in-flight Assigns finish. Each Assign holds its microVM until it returns,
+		// so GracefulStop draining handlers == draining running tasks (the fc-invoke
+		// HTTP-Shutdown lesson). The pod's terminationGracePeriodSeconds is set
+		// above DrainTimeout so Kubernetes never SIGKILLs mid-drain.
+		logger.Info("shutdown signal received; draining", "budget", cfg.DrainTimeout)
+		srv.SetDraining()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = health.Shutdown(shutdownCtx)
+
+		done := make(chan struct{})
+		go func() { gs.GracefulStop(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(cfg.DrainTimeout):
+			logger.Warn("drain budget exceeded; forcing stop", "budget", cfg.DrainTimeout)
+			gs.Stop()
+		}
+		return nil
+	}
+}
+
+// driverExtras carries the per-driver cold-boot fields (empty for the shared
+// restore driver, populated for a build driver).
+type driverExtras struct {
+	rootfsPath  string
+	harnessInit string
+	vcpus       int
+	memMib      int
+}
+
+// newDriver builds an fcvm driver bound to the node's substrate paths. Cold-boot
+// fields (rootfs, sizing, harness init) are set only for build drivers; the
+// restore driver leaves them zero because restore ignores them.
+func newDriver(cfg config.Config, self string, x driverExtras) *driver.Driver {
+	return driver.New(driver.Config{
+		KernelImagePath:   cfg.KernelImagePath,
+		KernelBootArgs:    cfg.KernelBootArgs,
+		RootfsPath:        x.rootfsPath,
+		RootfsReadOnly:    true,
+		CanonicalVsockDir: cfg.CanonicalVsockDir,
+		HarnessInit:       x.harnessInit,
+		VCPUs:             x.vcpus,
+		MemMib:            x.memMib,
+		SnapshotRoot:      cfg.SnapshotRoot,
+		Node:              cfg.Node,
+		Arch:              cfg.Arch,
+	}, &driver.ExecLauncher{
+		Bin:             cfg.BinPath,
+		OOMScoreAdj:     cfg.GuestOomScoreAdj,
+		VsockBindTarget: cfg.CanonicalVsockDir,
+		Self:            self,
+	}, nil)
+}
+
+// healthHandler answers 200 on /healthz for kubelet probes.
+func healthHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	return mux
+}

--- a/projects/embervm/noded/config/BUILD
+++ b/projects/embervm/noded/config/BUILD
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "config",
+    srcs = ["config.go"],
+    importpath = "github.com/jomcgi/homelab/projects/embervm/noded/config",
+    visibility = ["//projects/embervm/noded:__subpackages__"],
+)
+
+go_test(
+    name = "config_test",
+    srcs = ["config_test.go"],
+    embed = [":config"],
+)

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -1,0 +1,217 @@
+// Package config loads embervm-noded's daemon configuration from the
+// environment. It is the node daemon's counterpart to fc-invoke's catalog
+// loader, reshaped for the fork: there is NO workload table here. Concurrency,
+// egress posture, and warm-pool sizing are the control plane's concern now and
+// arrive per-call over the gRPC contract; the daemon reads only node-side
+// substrate paths, a node-level backstop cap, and a small image->rootfs identity
+// table (the one thing the gRPC BuildBase request deliberately does not carry:
+// "Node-side image identity (rootfs path, harness init) is daemon configuration").
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"time"
+)
+
+// Image is the node-side identity of one guest image the daemon can build a base
+// for. The gRPC BuildBase request names the image by ref; the daemon resolves
+// that ref to the on-disk rootfs an init container (rootfs-builder) baked, plus
+// the guest's PID-1 init path. This is NOT the retired fc-invoke workload catalog
+// (no concurrency/egress/warmBase/sessioned knobs) - only image identity.
+type Image struct {
+	// RootfsPath is the host path to this image's base rootfs ext4, booted
+	// read-only (every mutable guest path is a tmpfs captured in the snapshot).
+	RootfsPath string `json:"rootfsPath"`
+	// HarnessInit is the in-guest PID-1 path the kernel boots into for this
+	// image. Empty falls back to the daemon-global HarnessInit.
+	HarnessInit string `json:"harnessInit"`
+}
+
+// Config is the fully-resolved embervm-noded daemon configuration.
+type Config struct {
+	// ListenAddr is the gRPC listen address. Default ":9090".
+	ListenAddr string
+	// HealthAddr is the plain-HTTP /healthz listen address for kubelet probes
+	// (gRPC health-checking a privileged single-replica pod is more moving parts
+	// than a 20-line HTTP handler). Default ":8080".
+	HealthAddr string
+	// Node identifies the Kubernetes node this daemon is pinned to (injected via
+	// the Downward API as EMBERVM_NODED_NODE / spec.nodeName). Reported as
+	// node_id in NodeStatus and stamped into snapshot node-pinning.
+	Node string
+	// Arch is the host CPU architecture; FC guests are arch-affine. Defaults to
+	// runtime.GOARCH when EMBERVM_NODED_ARCH is unset.
+	Arch string
+	// BearerToken, when set, gates every gRPC call: the caller must present
+	// "authorization: Bearer <token>" in call metadata. Empty runs the daemon
+	// open and logs a startup warning (mirrors fc-invoke's fail-loud-not-silent
+	// posture); a Cilium/Linkerd policy is the defence-in-depth layer on top.
+	BearerToken string
+
+	// MaxLiveVMs is the node-level backstop cap on concurrently live microVMs
+	// (primed + assigning). The control plane owns real concurrency; this only
+	// stops a runaway from exhausting the node. Prime returns RESOURCE_EXHAUSTED
+	// at the cap. Default 8. Zero or negative means unbounded (no backstop).
+	MaxLiveVMs int
+
+	// SnapshotRoot is the directory holding FC bundle + base snapshots on the
+	// NVMe scratch disk. Maps to the driver's SnapshotRoot.
+	SnapshotRoot string
+	// BinPath is the firecracker binary (baked into the image at /opt/fc).
+	BinPath string
+	// KernelImagePath is the guest kernel (baked at /opt/fc), shared by every VM.
+	KernelImagePath string
+	// KernelBootArgs are appended to the kernel command line on cold boot. Empty
+	// uses the driver's default.
+	KernelBootArgs string
+	// HarnessInit is the daemon-global in-guest PID-1 init path, used when an
+	// Image entry does not override it.
+	HarnessInit string
+	// CanonicalVsockDir is the fixed dir whose vsock.sock the base snapshot
+	// embeds; the launcher bind-mounts each microVM's bundle over it per instance
+	// so concurrent restores each get their own host-reachable socket.
+	CanonicalVsockDir string
+	// GuestOomScoreAdj is written to each firecracker child's oom_score_adj so a
+	// guest, never the daemon, is the kernel's first OOM victim. Default 1000.
+	GuestOomScoreAdj int
+
+	// BootReadyTimeout bounds the readiness poll after a COLD boot (BuildBase).
+	BootReadyTimeout time.Duration
+	// RestoreReadyTimeout bounds the readiness poll after a WARM restore (Prime).
+	// A restored guest is already warm; this short budget only covers WaitReady
+	// retrying past the Firecracker post-restore vsock RX-queue race. Default 2s.
+	RestoreReadyTimeout time.Duration
+	// DrainTimeout bounds graceful shutdown: on SIGTERM the daemon stops
+	// accepting new RPCs and waits up to this long for in-flight Assigns to
+	// finish. The pod's terminationGracePeriodSeconds must exceed it. Default 60s.
+	DrainTimeout time.Duration
+
+	// EgressSidecarAddr is the pod-local egress-proxy sidecar TCP address. The
+	// task class gets no NIC and egress is disabled, so this is unused today but
+	// carried so a future egress-enabled workload needs no config reshape.
+	// Default "127.0.0.1:8888".
+	EgressSidecarAddr string
+
+	// Images maps a gRPC BuildBase image_ref to its node-side identity. Parsed
+	// from EMBERVM_NODED_IMAGES (inline JSON object) or _FILE (path, precedence).
+	// Empty is valid: BuildBase for an unknown image fails FAILED_PRECONDITION,
+	// which is correct until the control plane provisions images (Task 11+).
+	Images map[string]Image
+}
+
+// Load resolves configuration from the environment, applying defaults for all
+// optional fields. It errors only on values that are present but malformed.
+func Load() (Config, error) {
+	c := Config{
+		ListenAddr:          getenvDefault("EMBERVM_NODED_LISTEN_ADDR", ":9090"),
+		HealthAddr:          getenvDefault("EMBERVM_NODED_HEALTH_ADDR", ":8080"),
+		Node:                os.Getenv("EMBERVM_NODED_NODE"),
+		Arch:                os.Getenv("EMBERVM_NODED_ARCH"),
+		BearerToken:         os.Getenv("EMBERVM_NODED_BEARER_TOKEN"),
+		MaxLiveVMs:          atoiDefault("EMBERVM_NODED_MAX_LIVE_VMS", 8),
+		SnapshotRoot:        os.Getenv("EMBERVM_NODED_SNAPSHOT_ROOT"),
+		BinPath:             getenvDefault("EMBERVM_NODED_FIRECRACKER_BIN", "/opt/fc/firecracker"),
+		KernelImagePath:     getenvDefault("EMBERVM_NODED_KERNEL_IMAGE", "/opt/fc/vmlinux.container"),
+		KernelBootArgs:      os.Getenv("EMBERVM_NODED_KERNEL_BOOT_ARGS"),
+		HarnessInit:         getenvDefault("EMBERVM_NODED_HARNESS_INIT", "/usr/local/bin/fc-shim-init"),
+		CanonicalVsockDir:   getenvDefault("EMBERVM_NODED_CANONICAL_VSOCK_DIR", "/disks/nvme-02/embervm-noded-vsock"),
+		GuestOomScoreAdj:    atoiDefault("EMBERVM_NODED_GUEST_OOM_SCORE_ADJ", 1000),
+		BootReadyTimeout:    60 * time.Second,
+		RestoreReadyTimeout: 2 * time.Second,
+		DrainTimeout:        60 * time.Second,
+		EgressSidecarAddr:   getenvDefault("EMBERVM_NODED_EGRESS_SIDECAR_ADDR", "127.0.0.1:8888"),
+	}
+
+	if c.Node == "" {
+		c.Node = os.Getenv("NODE_NAME")
+	}
+	if c.Arch == "" {
+		c.Arch = runtime.GOARCH
+	}
+
+	if err := parseDuration("EMBERVM_NODED_BOOT_READY_TIMEOUT", &c.BootReadyTimeout); err != nil {
+		return Config{}, err
+	}
+	if err := parseDuration("EMBERVM_NODED_RESTORE_READY_TIMEOUT", &c.RestoreReadyTimeout); err != nil {
+		return Config{}, err
+	}
+	if err := parseDuration("EMBERVM_NODED_DRAIN_TIMEOUT", &c.DrainTimeout); err != nil {
+		return Config{}, err
+	}
+
+	images, err := loadImages()
+	if err != nil {
+		return Config{}, err
+	}
+	c.Images = images
+
+	return c, nil
+}
+
+// loadImages parses the image identity table from EMBERVM_NODED_IMAGES_FILE (if
+// set, takes precedence) or EMBERVM_NODED_IMAGES (inline JSON object). An absent
+// or empty source yields an empty map without error.
+func loadImages() (map[string]Image, error) {
+	var raw []byte
+	source := "EMBERVM_NODED_IMAGES"
+	if filePath := os.Getenv("EMBERVM_NODED_IMAGES_FILE"); filePath != "" {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("reading EMBERVM_NODED_IMAGES_FILE %q: %w", filePath, err)
+		}
+		raw = data
+		source = "file " + filePath
+	} else if inline := os.Getenv("EMBERVM_NODED_IMAGES"); inline != "" {
+		raw = []byte(inline)
+	}
+	if len(raw) == 0 {
+		return map[string]Image{}, nil
+	}
+	var table map[string]Image
+	if err := json.Unmarshal(raw, &table); err != nil {
+		return nil, fmt.Errorf("parsing images JSON from %s: %w", source, err)
+	}
+	if table == nil {
+		return map[string]Image{}, nil
+	}
+	return table, nil
+}
+
+// getenvDefault returns the named env var, or def when unset or empty.
+func getenvDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// atoiDefault returns the named env var parsed as an int, or def when unset or
+// unparseable.
+func atoiDefault(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+// parseDuration overrides *dst with the named env var parsed as a duration. An
+// unset var leaves *dst unchanged; a malformed value is an error so a
+// misconfiguration fails loudly at startup.
+func parseDuration(key string, dst *time.Duration) error {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return fmt.Errorf("invalid %s %q: %w", key, v, err)
+	}
+	*dst = d
+	return nil
+}

--- a/projects/embervm/noded/config/config_test.go
+++ b/projects/embervm/noded/config/config_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLoadDefaults(t *testing.T) {
+	// t.Setenv clears everything else via a clean slate per key; unset the ones
+	// that would leak from the runner by setting them empty.
+	for _, k := range []string{
+		"EMBERVM_NODED_LISTEN_ADDR", "EMBERVM_NODED_HEALTH_ADDR", "EMBERVM_NODED_NODE",
+		"NODE_NAME", "EMBERVM_NODED_ARCH", "EMBERVM_NODED_BEARER_TOKEN",
+		"EMBERVM_NODED_MAX_LIVE_VMS", "EMBERVM_NODED_IMAGES", "EMBERVM_NODED_IMAGES_FILE",
+		"EMBERVM_NODED_BOOT_READY_TIMEOUT", "EMBERVM_NODED_RESTORE_READY_TIMEOUT",
+		"EMBERVM_NODED_DRAIN_TIMEOUT",
+	} {
+		t.Setenv(k, "")
+	}
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.ListenAddr != ":9090" {
+		t.Errorf("ListenAddr = %q, want :9090", c.ListenAddr)
+	}
+	if c.HealthAddr != ":8080" {
+		t.Errorf("HealthAddr = %q, want :8080", c.HealthAddr)
+	}
+	if c.MaxLiveVMs != 8 {
+		t.Errorf("MaxLiveVMs = %d, want 8", c.MaxLiveVMs)
+	}
+	if c.BinPath != "/opt/fc/firecracker" {
+		t.Errorf("BinPath = %q, want /opt/fc/firecracker", c.BinPath)
+	}
+	if c.KernelImagePath != "/opt/fc/vmlinux.container" {
+		t.Errorf("KernelImagePath = %q, want /opt/fc/vmlinux.container", c.KernelImagePath)
+	}
+	if c.GuestOomScoreAdj != 1000 {
+		t.Errorf("GuestOomScoreAdj = %d, want 1000", c.GuestOomScoreAdj)
+	}
+	if c.BootReadyTimeout != 60*time.Second {
+		t.Errorf("BootReadyTimeout = %v, want 60s", c.BootReadyTimeout)
+	}
+	if c.RestoreReadyTimeout != 2*time.Second {
+		t.Errorf("RestoreReadyTimeout = %v, want 2s", c.RestoreReadyTimeout)
+	}
+	if c.Arch == "" {
+		t.Error("Arch should default to runtime.GOARCH, got empty")
+	}
+	if len(c.Images) != 0 {
+		t.Errorf("Images = %v, want empty", c.Images)
+	}
+}
+
+func TestLoadImagesInline(t *testing.T) {
+	t.Setenv("EMBERVM_NODED_IMAGES_FILE", "")
+	t.Setenv("EMBERVM_NODED_IMAGES", `{"ghcr.io/x/echo:1":{"rootfsPath":"/disks/nvme-02/echo/rootfs.ext4","harnessInit":"/usr/local/bin/echo-init"}}`)
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	img, ok := c.Images["ghcr.io/x/echo:1"]
+	if !ok {
+		t.Fatalf("image not parsed: %v", c.Images)
+	}
+	if img.RootfsPath != "/disks/nvme-02/echo/rootfs.ext4" {
+		t.Errorf("RootfsPath = %q", img.RootfsPath)
+	}
+	if img.HarnessInit != "/usr/local/bin/echo-init" {
+		t.Errorf("HarnessInit = %q", img.HarnessInit)
+	}
+}
+
+func TestLoadImagesFilePrecedence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "images.json")
+	if err := os.WriteFile(path, []byte(`{"img:2":{"rootfsPath":"/from/file"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("EMBERVM_NODED_IMAGES_FILE", path)
+	t.Setenv("EMBERVM_NODED_IMAGES", `{"img:2":{"rootfsPath":"/from/inline"}}`)
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := c.Images["img:2"].RootfsPath; got != "/from/file" {
+		t.Errorf("file should take precedence over inline, got %q", got)
+	}
+}
+
+func TestLoadRejectsBadDuration(t *testing.T) {
+	t.Setenv("EMBERVM_NODED_DRAIN_TIMEOUT", "not-a-duration")
+	if _, err := Load(); err == nil {
+		t.Error("Load should reject a malformed duration")
+	}
+}
+
+func TestLoadRejectsBadImagesJSON(t *testing.T) {
+	t.Setenv("EMBERVM_NODED_IMAGES_FILE", "")
+	t.Setenv("EMBERVM_NODED_IMAGES", `{not json`)
+	if _, err := Load(); err == nil {
+		t.Error("Load should reject malformed images JSON")
+	}
+}

--- a/projects/embervm/noded/egress/BUILD
+++ b/projects/embervm/noded/egress/BUILD
@@ -1,0 +1,16 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "egress",
+    srcs = ["forwarder.go"],
+    importpath = "github.com/jomcgi/homelab/projects/embervm/noded/egress",
+    visibility = ["//projects/embervm/noded:__subpackages__"],
+    deps = ["//projects/embervm/noded/vsockproto"],
+)
+
+go_test(
+    name = "egress_test",
+    srcs = ["forwarder_test.go"],
+    embed = [":egress"],
+    deps = ["//projects/embervm/noded/vsockproto"],
+)

--- a/projects/embervm/noded/egress/forwarder.go
+++ b/projects/embervm/noded/egress/forwarder.go
@@ -1,0 +1,77 @@
+// Package egress forwards a guest's vsock egress connections to a pod-local
+// egress-proxy sidecar (ADR 023 phase 6a). The daemon holds no secrets and
+// never parses the bytes (a raw tunnel): the secret-holding proxy is a separate
+// process reached only over localhost, preserving the blast-radius split even
+// though the daemon parses guest control frames. This is plain
+// allowlist-forward only; the secret-swap catalog and CA are a later phase.
+package egress
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/vsockproto"
+)
+
+// egressListenPath is the host unix socket Firecracker bridges the guest's
+// egress-port connections to.
+func egressListenPath(udsPath string) string {
+	return fmt.Sprintf("%s_%d", udsPath, vsockproto.EgressPort)
+}
+
+// ServeEgress forwards a guest's vsock egress connections to the co-located
+// egress-proxy sidecar (ADR 023). The daemon holds no secrets and never parses
+// the bytes (a raw tunnel): the secret-holding proxy is a separate process
+// reached only over localhost, preserving the blast-radius split even though the
+// daemon parses guest control frames. Each guest connection (one per outbound
+// request the guest's HTTP client opens) gets its own tunnel to sidecarAddr.
+// Returns nil on ctx cancellation.
+func ServeEgress(ctx context.Context, logger *slog.Logger, udsPath, sidecarAddr string) error {
+	path := egressListenPath(udsPath)
+	_ = os.Remove(path)
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		return fmt.Errorf("egress: listen %s: %w", path, err)
+	}
+	defer func() {
+		_ = ln.Close()
+		_ = os.Remove(path)
+	}()
+
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	for {
+		guestConn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("egress: accept: %w", err)
+		}
+		go tunnelToSidecar(logger, guestConn, sidecarAddr)
+	}
+}
+
+// tunnelToSidecar dials the sidecar and copies bytes both ways until either side
+// closes; closing both conns then unblocks the other copy.
+func tunnelToSidecar(logger *slog.Logger, guestConn net.Conn, sidecarAddr string) {
+	defer guestConn.Close()
+	up, err := net.Dial("tcp", sidecarAddr)
+	if err != nil {
+		logger.Warn("egress: dial sidecar", "addr", sidecarAddr, "err", err)
+		return
+	}
+	defer up.Close()
+
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(up, guestConn); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(guestConn, up); done <- struct{}{} }()
+	<-done
+}

--- a/projects/embervm/noded/egress/forwarder_test.go
+++ b/projects/embervm/noded/egress/forwarder_test.go
@@ -1,0 +1,132 @@
+package egress
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/vsockproto"
+)
+
+// startEchoSidecar starts a fake egress-proxy sidecar: a TCP listener that
+// echoes every byte back on each accepted connection. It returns the listen
+// address and a cleanup func. This stands in for the real sidecar so the tunnel
+// can be exercised over plain in-process sockets (no Firecracker, no vsock).
+func startEchoSidecar(t *testing.T) (addr string, stop func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("echo sidecar listen: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				_, _ = io.Copy(c, c)
+			}(conn)
+		}
+	}()
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+// TestServeEgressTunnelsBidirectionally asserts that a guest connection to
+// <uds>_<EgressPort> is tunnelled bidirectionally to the sidecar: bytes written
+// by the guest reach the (echo) sidecar and its reply is copied back to the
+// guest. The udsPath is a plain unix socket path standing in for the FC vsock
+// UDS; ServeEgress listens on the derived egress path exactly as it would in
+// production.
+func TestServeEgressTunnelsBidirectionally(t *testing.T) {
+	sidecarAddr, stopSidecar := startEchoSidecar(t)
+	defer stopSidecar()
+
+	// The base UDS path the driver would return for a thread; ServeEgress
+	// listens on "<uds>_<EgressPort>".
+	udsPath := filepath.Join(t.TempDir(), "vsock.sock")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- ServeEgress(ctx, slog.Default(), udsPath, sidecarAddr)
+	}()
+
+	listenPath := egressListenPath(udsPath)
+	guest := dialWithRetry(t, listenPath)
+	defer guest.Close()
+
+	want := []byte("hello sidecar")
+	if _, err := guest.Write(want); err != nil {
+		t.Fatalf("guest write: %v", err)
+	}
+	if err := guest.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	got := make([]byte, len(want))
+	if _, err := io.ReadFull(guest, got); err != nil {
+		t.Fatalf("guest read echo: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("echo mismatch: got %q want %q", got, want)
+	}
+
+	// Cancelling the context stops the accept loop and returns nil.
+	cancel()
+	select {
+	case err := <-serveErr:
+		if err != nil {
+			t.Fatalf("ServeEgress returned error on ctx cancel: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ServeEgress did not return after ctx cancel")
+	}
+}
+
+// TestEgressListenPath pins the derived listen path so the guest-side funnel and
+// the host forwarder agree on the same socket name.
+func TestEgressListenPath(t *testing.T) {
+	got := egressListenPath("/run/vsock.sock")
+	want := "/run/vsock.sock_" + itoa(int(vsockproto.EgressPort))
+	if got != want {
+		t.Fatalf("egressListenPath = %q, want %q", got, want)
+	}
+}
+
+// dialWithRetry dials the unix socket, retrying briefly so the test does not
+// race ServeEgress's Listen call.
+func dialWithRetry(t *testing.T, path string) net.Conn {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		conn, err := net.Dial("unix", path)
+		if err == nil {
+			return conn
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("dial %s: %v", path, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// itoa is a tiny local int-to-string to avoid importing strconv just for the
+// path assertion.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/projects/embervm/noded/fcvm/driver/BUILD
+++ b/projects/embervm/noded/fcvm/driver/BUILD
@@ -1,0 +1,31 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "driver",
+    srcs = [
+        "driver.go",
+        "gueststats.go",
+        "launcher.go",
+        "mountns_linux.go",
+        "mountns_other.go",
+        "provisioner.go",
+    ],
+    importpath = "github.com/jomcgi/homelab/projects/embervm/noded/fcvm/driver",
+    visibility = ["//projects/embervm/noded:__subpackages__"],
+    deps = [
+        "//projects/embervm/noded/fcvm/fcclient",
+        "//projects/embervm/noded/substrate",
+        "@io_opentelemetry_go_otel//:otel",
+    ],
+)
+
+go_test(
+    name = "driver_test",
+    srcs = [
+        "driver_test.go",
+        "gueststats_test.go",
+        "provisioner_test.go",
+    ],
+    embed = [":driver"],
+    deps = ["//projects/embervm/noded/substrate"],
+)

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -1,0 +1,580 @@
+// Package driver is the FC-direct Snapshotable executor (ADR 022, Phase 1). It
+// drives Firecracker processes and their snapshot API directly to boot a
+// microVM, pause -> CreateSnapshot -> resume, and LoadSnapshot + resume a fresh
+// microVM that continues exactly where the snapshot was taken.
+//
+// Storage follows the E2B bundle layout: a directory per thread under the
+// snapshot root, holding the FC API socket plus the snapfile + memfile that make
+// up a full snapshot. Snapshots are node/arch-bound (FC validates CPU on
+// restore), so the driver stamps every handle and ref with its node + arch.
+package driver
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/fcvm/fcclient"
+	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
+	"go.opentelemetry.io/otel"
+)
+
+// tracer spans the cold-boot phases (rootfs provision, firecracker boot) so the
+// cold-start cost is visible per phase in SigNoz (ADR 026 measurement).
+var tracer = otel.Tracer("embervm-noded/driver")
+
+// Config holds the node-4 substrate paths and microVM sizing.
+type Config struct {
+	// KernelImagePath is the guest kernel (kata vmlinux.container on node-4).
+	KernelImagePath string
+	// KernelBootArgs are appended to the kernel command line on cold boot.
+	KernelBootArgs string
+	// RootfsPath is the host path to a shared/static rootfs, used only when no
+	// BaseRootfsPath is set (e.g. the kata rootfs for a heartbeat smoke test).
+	RootfsPath string
+	// BaseRootfsPath is the read-only base rootfs image (the flattened harness
+	// image). When set, each thread gets its own writable rootfs derived from it.
+	BaseRootfsPath string
+	// RootfsReadOnly attaches the rootfs drive read-only on cold boot. Used by the
+	// warm-base scanner pattern: when every mutable path in the guest is a tmpfs
+	// (RAM, captured in the snapshot memfile), the rootfs is never written, so one
+	// shared read-only rootfs file can back every microVM restored from a single
+	// warm base without per-thread provisioning or corruption.
+	RootfsReadOnly bool
+	// CanonicalVsockDir, when set, is the fixed directory whose vsock.sock the base
+	// snapshot embeds. Cold boot binds the guest's vsock there (so the snapshot
+	// captures that path), and the launcher bind-mounts each VM's bundle dir over it
+	// per instance, so concurrent restores from one base each get their own
+	// host-reachable vsock socket. Pairs with ExecLauncher.VsockBindTarget. Empty
+	// keeps the per-thread vsock path (the legacy per-thread, no-warm-base behaviour).
+	CanonicalVsockDir string
+	// Provisioner selects the per-thread rootfs strategy (ADR 026): "copy" (the
+	// default CopyProvisioner full file copy) or "devmapper" (DevmapperProvisioner
+	// copy-on-write thin-snapshot). An empty value means "copy".
+	Provisioner string
+	// ThinPool is the devmapper thin-pool name the DevmapperProvisioner snapshots
+	// into (e.g. "devpool"); ignored by the copy provisioner.
+	ThinPool string
+	// HarnessInit, when set, is appended to the kernel command line as
+	// init=<path> so the guest boots straight into fc-agent-init (raw FC boot
+	// ignores the OCI entrypoint).
+	HarnessInit string
+	// VCPUs and MemMib size the guest.
+	VCPUs  int
+	MemMib int
+	// SnapshotRoot is the directory holding per-thread bundles (/disks/nvme-02).
+	SnapshotRoot string
+	// Node and Arch pin where snapshots may be restored.
+	Node string
+	Arch string
+}
+
+func (c Config) withDefaults() Config {
+	if c.VCPUs == 0 {
+		c.VCPUs = 1
+	}
+	if c.MemMib == 0 {
+		c.MemMib = 1024
+	}
+	if c.KernelBootArgs == "" {
+		c.KernelBootArgs = "console=ttyS0 reboot=k panic=1 pci=off"
+	}
+	return c
+}
+
+// Process is a running Firecracker process.
+type Process interface {
+	Kill() error
+	Wait() error
+	// Pid returns the OS process id of the firecracker process, or 0 if it has
+	// not started. Used to read the process's /proc resource counters for
+	// per-invocation stats before teardown.
+	Pid() int
+}
+
+// Launcher starts a Firecracker process whose API socket is at socketPath and
+// returns once the socket accepts connections.
+type Launcher interface {
+	Launch(ctx context.Context, vmID, socketPath string) (Process, error)
+}
+
+// fcAPI is the subset of the Firecracker client the driver uses, kept as an
+// interface so tests can supply a fake. *fcclient.Client satisfies it.
+type fcAPI interface {
+	PutMachineConfig(ctx context.Context, m fcclient.MachineConfig) error
+	PutBootSource(ctx context.Context, b fcclient.BootSource) error
+	PutDrive(ctx context.Context, d fcclient.Drive) error
+	PutVsock(ctx context.Context, v fcclient.Vsock) error
+	Start(ctx context.Context) error
+	Pause(ctx context.Context) error
+	Resume(ctx context.Context) error
+	CreateSnapshot(ctx context.Context, s fcclient.SnapshotCreate) error
+	LoadSnapshot(ctx context.Context, s fcclient.SnapshotLoad) error
+}
+
+// Driver implements substrate.Substrate and substrate.Snapshotable for FC-direct.
+type Driver struct {
+	cfg         Config
+	launcher    Launcher
+	newClient   func(socketPath string) fcAPI
+	provisioner RootfsProvisioner // nil => use cfg.RootfsPath (shared/static)
+
+	mu   sync.Mutex
+	live map[string]*instance // handle ID -> instance
+}
+
+type instance struct {
+	handle substrate.Handle
+	proc   Process
+	client fcAPI
+	dir    string
+	sock   string
+}
+
+var (
+	_ substrate.Substrate    = (*Driver)(nil)
+	_ substrate.Snapshotable = (*Driver)(nil)
+)
+
+// New builds a Driver. launcher must not be nil. If newClient is nil the real
+// fcclient is used.
+func New(cfg Config, launcher Launcher, newClient func(socketPath string) fcAPI) *Driver {
+	if newClient == nil {
+		newClient = func(sock string) fcAPI { return fcclient.New(sock) }
+	}
+	d := &Driver{
+		cfg:       cfg.withDefaults(),
+		launcher:  launcher,
+		newClient: newClient,
+		live:      make(map[string]*instance),
+	}
+	if cfg.BaseRootfsPath != "" {
+		if cfg.Provisioner == "devmapper" {
+			d.provisioner = &DevmapperProvisioner{
+				Pool:     cfg.ThinPool,
+				Base:     cfg.BaseRootfsPath,
+				StateDir: cfg.SnapshotRoot,
+			}
+		} else {
+			d.provisioner = &CopyProvisioner{Base: cfg.BaseRootfsPath}
+		}
+	}
+	return d
+}
+
+// SetProvisioner overrides the rootfs provisioner (tests inject a fake).
+func (d *Driver) SetProvisioner(p RootfsProvisioner) { d.provisioner = p }
+
+func newID(prefix string) string {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return prefix + "-" + hex.EncodeToString(b[:])
+}
+
+// threadDir is the bundle directory for a thread.
+func (d *Driver) threadDir(threadID string) string {
+	return filepath.Join(d.cfg.SnapshotRoot, threadID)
+}
+
+func (d *Driver) snapfilePath(threadID string) string {
+	return filepath.Join(d.threadDir(threadID), "snapfile")
+}
+
+func (d *Driver) memfilePath(threadID string) string {
+	return filepath.Join(d.threadDir(threadID), "memfile")
+}
+
+// guestCID is the vsock context id assigned to every microVM. CIDs 0-2 are
+// reserved (2 is the host), so guests start at 3. The controller reaches a guest
+// by listening on the per-thread UDS, not by CID, so a fixed value is fine.
+const guestCID = 3
+
+// bootVsockPath is the vsock UDS path firecracker binds at cold boot. With a
+// CanonicalVsockDir it is that fixed dir's vsock.sock (so the base snapshot embeds
+// a stable path the launcher can bind-mount per instance); otherwise it is the
+// per-thread host path. The launcher's per-instance bind-mount makes the canonical
+// path resolve to VsockUDSPath(threadID) on the host either way.
+func (d *Driver) bootVsockPath(threadID string) string {
+	if d.cfg.CanonicalVsockDir != "" {
+		return filepath.Join(d.cfg.CanonicalVsockDir, "vsock.sock")
+	}
+	return d.VsockUDSPath(threadID)
+}
+
+// VsockUDSPath is the host unix-domain socket backing a thread's vsock device.
+// Firecracker multiplexes guest connections onto "<uds>_<port>", so the control
+// server listens on VsockUDSPath(threadID)+"_"+ControlPort. The path is
+// deterministic from the bundle dir, so the reconcile loop can reach a live
+// microVM's control channel without the driver handing back extra state.
+func (d *Driver) VsockUDSPath(threadID string) string {
+	return filepath.Join(d.threadDir(threadID), "vsock.sock")
+}
+
+// removeStaleVsockUDS unlinks any leftover vsock unix-domain socket before a
+// (re)launch. Firecracker *binds* the vsock UDS on PUT /vsock, and bind() fails
+// with EADDRINUSE when the path already exists. A thread's bundle dir lives on
+// the persistent snapshot disk, so a vsock.sock from a previous incarnation
+// survives a daemon/pod restart and makes orphan recovery loop on a 400 until it
+// exhausts retries and marks the thread FAILED. The launcher already clears the
+// API socket; the vsock UDS and its per-port children (<uds>_<port>, created once
+// the guest connects) are not, so clear them here.
+func (d *Driver) removeStaleVsockUDS(threadID string) {
+	vsock := d.VsockUDSPath(threadID)
+	_ = os.Remove(vsock)
+	matches, err := filepath.Glob(vsock + "_*")
+	if err != nil {
+		return
+	}
+	for _, m := range matches {
+		_ = os.Remove(m)
+	}
+}
+
+// bootArgs is the kernel command line. When HarnessInit is set it appends
+// init=<path> so the guest boots straight into fc-agent-init (raw FC boot does
+// not honour the OCI image entrypoint).
+func (d *Driver) bootArgs() string {
+	args := d.cfg.KernelBootArgs
+	if d.cfg.HarnessInit != "" {
+		args += " init=" + d.cfg.HarnessInit
+	}
+	return args
+}
+
+// baseDir is the bundle directory for a warm base, keyed by an opaque base key
+// (one per repo env-image version). Bases live under bases/ so they are never
+// confused with per-thread bundles and survive thread GC.
+func (d *Driver) baseDir(key string) string {
+	return filepath.Join(d.cfg.SnapshotRoot, "bases", key)
+}
+
+func (d *Driver) baseSnapfile(key string) string { return filepath.Join(d.baseDir(key), "snapfile") }
+func (d *Driver) baseMemfile(key string) string  { return filepath.Join(d.baseDir(key), "memfile") }
+
+// loadInto launches a fresh Firecracker process for threadID and restores it
+// from the given snapfile + memfile (File backend, resume). Used by both
+// thread-snapshot restore and warm-base restore.
+func (d *Driver) loadInto(ctx context.Context, threadID, snapPath, memPath, sockName string) (substrate.Handle, error) {
+	dir := d.threadDir(threadID)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return substrate.Handle{}, fmt.Errorf("driver: mkdir bundle: %w", err)
+	}
+	sock := filepath.Join(dir, sockName)
+	_ = os.Remove(sock)
+	// A restored snapshot re-binds the vsock UDS from its embedded config; clear
+	// any stale socket first so the resume does not fail on EADDRINUSE.
+	d.removeStaleVsockUDS(threadID)
+	vmID := newID("vm")
+
+	proc, err := d.launcher.Launch(ctx, vmID, sock)
+	if err != nil {
+		return substrate.Handle{}, fmt.Errorf("driver: launch firecracker for restore: %w", err)
+	}
+	client := d.newClient(sock)
+	if err := client.LoadSnapshot(ctx, fcclient.SnapshotLoad{
+		SnapshotPath: snapPath,
+		MemBackend:   &fcclient.MemBackend{BackendType: "File", BackendPath: memPath},
+		ResumeVM:     true,
+	}); err != nil {
+		return d.abort(proc, err)
+	}
+	h := substrate.Handle{ThreadID: threadID, ID: vmID, Node: d.cfg.Node}
+	d.track(&instance{handle: h, proc: proc, client: client, dir: dir, sock: sock})
+	return h, nil
+}
+
+// Claim boots a microVM. With a BaseSnapshotRef it restores from that warm base
+// for an instant ready start; otherwise it cold-boots from the kernel + rootfs.
+func (d *Driver) Claim(ctx context.Context, spec substrate.ClaimSpec) (substrate.Handle, error) {
+	if spec.Arch != "" && d.cfg.Arch != "" && spec.Arch != d.cfg.Arch {
+		return substrate.Handle{}, fmt.Errorf("driver: arch mismatch: spec %q != node %q (snapshots non-portable)", spec.Arch, d.cfg.Arch)
+	}
+	threadID := spec.ThreadID
+	if threadID == "" {
+		threadID = newID("thread")
+	}
+
+	// Warm-base start: restore the new thread from a base bundle for an instant
+	// ready start, skipping boot + harness init.
+	if spec.BaseSnapshotRef.ID != "" {
+		ref := spec.BaseSnapshotRef
+		if ref.Arch != "" && d.cfg.Arch != "" && ref.Arch != d.cfg.Arch {
+			return substrate.Handle{}, fmt.Errorf("driver: base arch mismatch: ref %q != node %q", ref.Arch, d.cfg.Arch)
+		}
+		snap := d.baseSnapfile(ref.ID)
+		if _, err := os.Stat(snap); err != nil {
+			return substrate.Handle{}, fmt.Errorf("driver: base bundle missing for %q: %w", ref.ID, err)
+		}
+		return d.loadInto(ctx, threadID, snap, d.baseMemfile(ref.ID), "api.sock")
+	}
+
+	dir := d.threadDir(threadID)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return substrate.Handle{}, fmt.Errorf("driver: mkdir bundle: %w", err)
+	}
+	// Clear a stale vsock UDS left by a prior incarnation so PUT /vsock can bind
+	// (see removeStaleVsockUDS): the bundle dir persists across daemon restarts.
+	d.removeStaleVsockUDS(threadID)
+	sock := filepath.Join(dir, "api.sock")
+	vmID := newID("vm")
+
+	proc, err := d.launcher.Launch(ctx, vmID, sock)
+	if err != nil {
+		return substrate.Handle{}, fmt.Errorf("driver: launch firecracker: %w", err)
+	}
+	client := d.newClient(sock)
+
+	// Each thread gets its own writable rootfs (from the base image) so threads
+	// never share or corrupt one disk. With no provisioner, fall back to the
+	// shared/static rootfs (e.g. a kata rootfs smoke test).
+	rootfsPath := d.cfg.RootfsPath
+	if d.provisioner != nil {
+		// provision_rootfs is the cold-start cost ADR 026 targets (the full-copy
+		// CopyProvisioner today; a CoW provisioner later). Its own span makes the
+		// before/after directly visible in SigNoz.
+		pctx, pspan := tracer.Start(ctx, "provision_rootfs")
+		rootfsPath, err = d.provisioner.Provision(pctx, threadID, dir)
+		pspan.End()
+		if err != nil {
+			return d.abort(proc, err)
+		}
+	}
+
+	// firecracker_boot: configure the microVM and Start it (the kernel boot + the
+	// guest fc-agent-init handshake complete asynchronously after Start returns,
+	// so they are not in this span).
+	_, bspan := tracer.Start(ctx, "firecracker_boot")
+	bootErr := func() error {
+		if err := client.PutMachineConfig(ctx, fcclient.MachineConfig{VCPUCount: d.cfg.VCPUs, MemSizeMib: d.cfg.MemMib}); err != nil {
+			return err
+		}
+		if err := client.PutBootSource(ctx, fcclient.BootSource{KernelImagePath: d.cfg.KernelImagePath, BootArgs: d.bootArgs()}); err != nil {
+			return err
+		}
+		if err := client.PutDrive(ctx, fcclient.Drive{DriveID: "rootfs", PathOnHost: rootfsPath, IsRootDevice: true, IsReadOnly: d.cfg.RootfsReadOnly}); err != nil {
+			return err
+		}
+		// The vsock device is the guest's only channel to the controller (task
+		// delivery, idle signal, egress proxy). It must be configured before Start.
+		if err := client.PutVsock(ctx, fcclient.Vsock{GuestCID: guestCID, UDSPath: d.bootVsockPath(threadID)}); err != nil {
+			return err
+		}
+		return client.Start(ctx)
+	}()
+	bspan.End()
+	if bootErr != nil {
+		return d.abort(proc, bootErr)
+	}
+
+	h := substrate.Handle{ThreadID: threadID, ID: vmID, Node: d.cfg.Node}
+	d.track(&instance{handle: h, proc: proc, client: client, dir: dir, sock: sock})
+	return h, nil
+}
+
+// Snapshot pauses the microVM, writes a full snapshot bundle, and resumes it so
+// the handle stays usable. Snapshot create is off the user-facing hot path.
+func (d *Driver) Snapshot(ctx context.Context, h substrate.Handle) (substrate.SnapshotRef, error) {
+	inst := d.get(h.ID)
+	if inst == nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: snapshot of unknown handle %q", h.ID)
+	}
+	snapPath := d.snapfilePath(h.ThreadID)
+	memPath := d.memfilePath(h.ThreadID)
+
+	if err := inst.client.Pause(ctx); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: pause: %w", err)
+	}
+	if err := inst.client.CreateSnapshot(ctx, fcclient.SnapshotCreate{SnapshotPath: snapPath, MemFilePath: memPath}); err != nil {
+		// Best-effort resume so a snapshot failure does not strand the VM paused.
+		_ = inst.client.Resume(ctx)
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: create snapshot: %w", err)
+	}
+	if err := inst.client.Resume(ctx); err != nil {
+		// Resume failed: the VM is stranded paused. Tear it down so a dead handle
+		// is not leaked into `live`; the thread re-inits from Postgres on the next
+		// reconcile (snapshots are never load-bearing).
+		_ = d.Release(ctx, h)
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: resume after snapshot: %w", err)
+	}
+
+	ref := substrate.SnapshotRef{
+		ID:        newID("snap"),
+		ThreadID:  h.ThreadID,
+		Node:      d.cfg.Node,
+		Arch:      d.cfg.Arch,
+		SizeBytes: bundleSize(snapPath, memPath),
+	}
+	return ref, nil
+}
+
+// Restore launches a fresh Firecracker process and loads the snapshot bundle for
+// the ref's thread, resuming it. The microVM continues exactly where it paused;
+// the new handle keeps the stable ThreadID but gets a fresh microVM id.
+func (d *Driver) Restore(ctx context.Context, ref substrate.SnapshotRef) (substrate.Handle, error) {
+	if ref.Arch != "" && d.cfg.Arch != "" && ref.Arch != d.cfg.Arch {
+		return substrate.Handle{}, fmt.Errorf("driver: arch mismatch on restore: ref %q != node %q", ref.Arch, d.cfg.Arch)
+	}
+	if ref.Node != "" && d.cfg.Node != "" && ref.Node != d.cfg.Node {
+		return substrate.Handle{}, fmt.Errorf("driver: node mismatch on restore: ref %q != node %q", ref.Node, d.cfg.Node)
+	}
+	threadID := ref.ThreadID
+	if threadID == "" {
+		return substrate.Handle{}, errors.New("driver: restore requires a ThreadID on the ref")
+	}
+	snapPath := d.snapfilePath(threadID)
+	if _, err := os.Stat(snapPath); err != nil {
+		return substrate.Handle{}, fmt.Errorf("driver: snapshot bundle missing for thread %q: %w", threadID, err)
+	}
+	return d.loadInto(ctx, threadID, snapPath, d.memfilePath(threadID), "restore.sock")
+}
+
+// SnapshotBase captures a warmed microVM into a shared base bundle keyed by
+// baseKey (one per repo env-image version). New threads restore from it for an
+// instant ready start. Like Snapshot it pauses, writes, and resumes.
+func (d *Driver) SnapshotBase(ctx context.Context, h substrate.Handle, baseKey string) (substrate.SnapshotRef, error) {
+	inst := d.get(h.ID)
+	if inst == nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: snapshot-base of unknown handle %q", h.ID)
+	}
+	if err := os.MkdirAll(d.baseDir(baseKey), 0o750); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: mkdir base bundle: %w", err)
+	}
+	snapPath := d.baseSnapfile(baseKey)
+	memPath := d.baseMemfile(baseKey)
+	// Write to temp paths and rename into place. A rebuild must NOT overwrite the
+	// live snapfile/memfile in place: another thread may be restoring from them
+	// (the File mem-backend mmaps the memfile), and overwriting a mapped file is a
+	// SIGBUS foot-gun. rename(2) swaps the directory entry to a new inode while any
+	// in-flight restore keeps the old (now-unlinked) one.
+	snapTmp := snapPath + ".tmp"
+	memTmp := memPath + ".tmp"
+
+	if err := inst.client.Pause(ctx); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: pause: %w", err)
+	}
+	if err := inst.client.CreateSnapshot(ctx, fcclient.SnapshotCreate{SnapshotPath: snapTmp, MemFilePath: memTmp}); err != nil {
+		_ = inst.client.Resume(ctx)
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: create base snapshot: %w", err)
+	}
+	if err := inst.client.Resume(ctx); err != nil {
+		_ = d.Release(ctx, h)
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: resume after base snapshot: %w", err)
+	}
+	// Publish memfile before snapfile: a restore reads the snapfile to locate the
+	// memfile, so the memfile must already be in place when the snapfile appears.
+	if err := os.Rename(memTmp, memPath); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: publish base memfile: %w", err)
+	}
+	if err := os.Rename(snapTmp, snapPath); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: publish base snapfile: %w", err)
+	}
+	return substrate.SnapshotRef{
+		ID:        baseKey,
+		Node:      d.cfg.Node,
+		Arch:      d.cfg.Arch,
+		Base:      true,
+		SizeBytes: bundleSize(snapPath, memPath),
+	}, nil
+}
+
+// RemoveBaseBundle deletes a warm base's on-disk bundle (when a base is
+// superseded by a newer env-image version).
+func (d *Driver) RemoveBaseBundle(baseKey string) error {
+	if baseKey == "" {
+		return fmt.Errorf("driver: RemoveBaseBundle requires a baseKey")
+	}
+	if err := os.RemoveAll(d.baseDir(baseKey)); err != nil {
+		return fmt.Errorf("driver: remove base bundle: %w", err)
+	}
+	return nil
+}
+
+// Exec is provided by the in-VM harness over the wrapper channel (Phase 2); the
+// FC-direct driver does not run processes in the guest from the host.
+func (d *Driver) Exec(_ context.Context, _ substrate.Handle, _ substrate.Request) (substrate.Stream, error) {
+	return nil, errors.New("driver: Exec is handled by the in-VM harness (Phase 2), not the host driver")
+}
+
+// Release kills the microVM process and removes its API socket. The snapshot
+// bundle is left in place (Release returns/destroys the live env, not its
+// snapshots; GC reclaims bundles separately).
+func (d *Driver) Release(_ context.Context, h substrate.Handle) error {
+	d.mu.Lock()
+	inst, ok := d.live[h.ID]
+	if ok {
+		delete(d.live, h.ID)
+	}
+	d.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("driver: release of unknown handle %q", h.ID)
+	}
+	killErr := inst.proc.Kill()
+	_ = os.Remove(inst.sock)
+	if killErr != nil {
+		return fmt.Errorf("driver: kill firecracker: %w", killErr)
+	}
+	return nil
+}
+
+func (d *Driver) abort(proc Process, cause error) (substrate.Handle, error) {
+	_ = proc.Kill()
+	return substrate.Handle{}, cause
+}
+
+func (d *Driver) track(inst *instance) {
+	d.mu.Lock()
+	d.live[inst.handle.ID] = inst
+	d.mu.Unlock()
+}
+
+func (d *Driver) get(id string) *instance {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.live[id]
+}
+
+// RemoveBundle deletes a thread's on-disk snapshot bundle directory (GC/reclaim).
+// It is a no-op if the directory is already gone.
+func (d *Driver) RemoveBundle(threadID string) error {
+	if threadID == "" {
+		return fmt.Errorf("driver: RemoveBundle requires a threadID")
+	}
+	// Release the provisioner's out-of-dir resources first (a CoW thin device +
+	// its pool allocation); the COW data lives in the pool, not the bundle dir, so
+	// RemoveAll alone would leak the dm device and its thin id. The VM process is
+	// already killed (Release ran before reclaim), so the device is free.
+	if d.provisioner != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), teardownTimeout)
+		defer cancel()
+		if err := d.provisioner.Teardown(ctx, threadID); err != nil {
+			return fmt.Errorf("driver: teardown rootfs for %q: %w", threadID, err)
+		}
+	}
+	dir := d.threadDir(threadID)
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("driver: remove bundle %q: %w", dir, err)
+	}
+	return nil
+}
+
+// LiveCount reports how many microVMs the driver is currently supervising.
+func (d *Driver) LiveCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.live)
+}
+
+func bundleSize(paths ...string) int64 {
+	var total int64
+	for _, p := range paths {
+		if fi, err := os.Stat(p); err == nil {
+			total += fi.Size()
+		}
+	}
+	return total
+}

--- a/projects/embervm/noded/fcvm/driver/driver_test.go
+++ b/projects/embervm/noded/fcvm/driver/driver_test.go
@@ -1,0 +1,269 @@
+package driver
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
+)
+
+// fakeLauncher stands up a fake Firecracker API server on each requested socket,
+// so the driver's real fcclient drives a realistic API. CreateSnapshot writes
+// the snapfile + memfile to disk so the bundle layout and Restore's existence
+// checks are exercised end to end.
+type fakeLauncher struct {
+	mu       sync.Mutex
+	launched int
+}
+
+type fakeProcess struct {
+	srv    *http.Server
+	killed bool
+	pid    int
+}
+
+func (p *fakeProcess) Kill() error { p.killed = true; return p.srv.Close() }
+func (p *fakeProcess) Wait() error { return nil }
+func (p *fakeProcess) Pid() int    { return p.pid }
+
+func (l *fakeLauncher) Launch(_ context.Context, _ string, socketPath string) (Process, error) {
+	l.mu.Lock()
+	l.launched++
+	l.mu.Unlock()
+	_ = os.Remove(socketPath)
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, err
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/snapshot/create", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &body)
+		// Persist the bundle files the controller asked for.
+		if sp, ok := body["snapshot_path"].(string); ok {
+			_ = os.WriteFile(sp, []byte("snap"), 0o600)
+		}
+		if mp, ok := body["mem_file_path"].(string); ok {
+			_ = os.WriteFile(mp, []byte("mem-image-bytes"), 0o600)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+	return &fakeProcess{srv: srv}, nil
+}
+
+// shortTempDir returns a temp dir under /tmp with a short path. The fake
+// launcher binds a unix socket inside it, and macOS caps sun_path at 104 bytes,
+// which t.TempDir()'s long /var/folders/... paths exceed (bind: invalid
+// argument). On node-4 the snapshot root is the short /disks/nvme-02, so this is
+// a test-only portability shim.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	d, err := os.MkdirTemp("/tmp", "fc")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(d) })
+	return d
+}
+
+func testDriver(t *testing.T) *Driver {
+	t.Helper()
+	return New(Config{
+		KernelImagePath: "/opt/kata/vmlinux",
+		RootfsPath:      "/dev/mapper/thread",
+		SnapshotRoot:    shortTempDir(t),
+		Node:            "node-4",
+		Arch:            "amd64",
+	}, &fakeLauncher{}, nil)
+}
+
+func TestDriverClaimBootsMicroVM(t *testing.T) {
+	d := testDriver(t)
+	h, err := d.Claim(context.Background(), substrate.ClaimSpec{ThreadID: "t1", Repo: "homelab"})
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if h.ThreadID != "t1" || h.ID == "" || h.Node != "node-4" {
+		t.Fatalf("unexpected handle: %+v", h)
+	}
+	if d.LiveCount() != 1 {
+		t.Fatalf("LiveCount = %d, want 1", d.LiveCount())
+	}
+}
+
+// TestDriverClaimClearsStaleVsockUDS reproduces the orphan-recovery failure
+// after a pod roll: a thread's bundle dir persists on the snapshot disk, so a
+// vsock.sock left by the dead incarnation makes Firecracker's PUT /vsock bind
+// fail with EADDRINUSE, looping the reconcile claim until it marks the thread
+// FAILED. Claim must unlink the stale UDS (and its per-port children) first. The
+// fake launcher does not bind the vsock UDS, so we assert the unlink directly:
+// without it, Claim never touches vsock.sock and the seeded file survives.
+func TestDriverClaimClearsStaleVsockUDS(t *testing.T) {
+	d := testDriver(t)
+	dir := d.threadDir("t-orphan")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir thread dir: %v", err)
+	}
+	stale := d.VsockUDSPath("t-orphan")
+	staleChild := stale + "_1024"
+	for _, p := range []string{stale, staleChild} {
+		if err := os.WriteFile(p, nil, 0o600); err != nil {
+			t.Fatalf("seed stale socket %s: %v", p, err)
+		}
+	}
+
+	if _, err := d.Claim(context.Background(), substrate.ClaimSpec{ThreadID: "t-orphan"}); err != nil {
+		t.Fatalf("Claim over a stale vsock UDS: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale vsock.sock should have been removed before bind, stat err=%v", err)
+	}
+	if _, err := os.Stat(staleChild); !os.IsNotExist(err) {
+		t.Fatalf("stale vsock.sock_1024 should have been removed, stat err=%v", err)
+	}
+}
+
+// TestDriverSnapshotRestoreContinuity is the Phase 1 done-criterion in unit
+// form: boot -> snapshot -> release the original microVM -> restore a fresh
+// microVM that keeps the stable ThreadID (continues, not a new identity).
+func TestDriverSnapshotRestoreContinuity(t *testing.T) {
+	ctx := context.Background()
+	d := testDriver(t)
+
+	h, err := d.Claim(ctx, substrate.ClaimSpec{ThreadID: "t-stable"})
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	ref, err := d.Snapshot(ctx, h)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if ref.ThreadID != "t-stable" || ref.Node != "node-4" || ref.Arch != "amd64" {
+		t.Fatalf("unexpected ref: %+v", ref)
+	}
+	if ref.SizeBytes == 0 {
+		t.Fatalf("snapshot SizeBytes should reflect the on-disk bundle")
+	}
+
+	if err := d.Release(ctx, h); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if d.LiveCount() != 0 {
+		t.Fatalf("LiveCount after release = %d, want 0", d.LiveCount())
+	}
+
+	h2, err := d.Restore(ctx, ref)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if h2.ThreadID != "t-stable" {
+		t.Fatalf("restored ThreadID = %q, want t-stable", h2.ThreadID)
+	}
+	if h2.ID == h.ID {
+		t.Fatalf("restored microVM should have a fresh id; both %q", h2.ID)
+	}
+	if d.LiveCount() != 1 {
+		t.Fatalf("LiveCount after restore = %d, want 1", d.LiveCount())
+	}
+}
+
+func TestDriverRestoreRejectsArchMismatch(t *testing.T) {
+	d := testDriver(t)
+	_, err := d.Restore(context.Background(), substrate.SnapshotRef{ThreadID: "x", Arch: "arm64", Node: "node-4"})
+	if err == nil {
+		t.Fatal("restore should reject an arch-mismatched snapshot (non-portable)")
+	}
+}
+
+func TestDriverClaimRejectsArchMismatch(t *testing.T) {
+	d := testDriver(t)
+	_, err := d.Claim(context.Background(), substrate.ClaimSpec{Arch: "arm64"})
+	if err == nil {
+		t.Fatal("claim should reject an arch-mismatched spec")
+	}
+}
+
+func TestDriverReleaseUnknownHandleErrors(t *testing.T) {
+	d := testDriver(t)
+	if err := d.Release(context.Background(), substrate.Handle{ID: "nope"}); err == nil {
+		t.Fatal("release of unknown handle should error")
+	}
+}
+
+func TestDriverRestoreMissingBundleErrors(t *testing.T) {
+	d := testDriver(t)
+	// No snapshot ever taken for this thread.
+	_, err := d.Restore(context.Background(), substrate.SnapshotRef{ThreadID: "ghost", Node: "node-4", Arch: "amd64"})
+	if err == nil {
+		t.Fatal("restore with no bundle on disk should error")
+	}
+}
+
+// TestDriverWarmBaseStartReusesBaseBundle proves Phase 4's warm-base path: snap
+// a warmed VM to a base bundle, then a new thread claims from that base for an
+// instant ready start (a fresh microVM keyed by its own thread id).
+func TestDriverWarmBaseStartReusesBaseBundle(t *testing.T) {
+	ctx := context.Background()
+	d := testDriver(t)
+
+	warm, err := d.Claim(ctx, substrate.ClaimSpec{ThreadID: "warm"})
+	if err != nil {
+		t.Fatalf("Claim warm: %v", err)
+	}
+	baseRef, err := d.SnapshotBase(ctx, warm, "base-homelab-amd64")
+	if err != nil {
+		t.Fatalf("SnapshotBase: %v", err)
+	}
+	if !baseRef.Base || baseRef.ID != "base-homelab-amd64" || baseRef.SizeBytes == 0 {
+		t.Fatalf("unexpected base ref: %+v", baseRef)
+	}
+	if err := d.Release(ctx, warm); err != nil {
+		t.Fatalf("Release warm: %v", err)
+	}
+
+	// New thread starts from the base.
+	h, err := d.Claim(ctx, substrate.ClaimSpec{
+		ThreadID:        "fresh",
+		BaseSnapshotRef: substrate.SnapshotRef{ID: "base-homelab-amd64", Arch: "amd64", Base: true},
+	})
+	if err != nil {
+		t.Fatalf("Claim from base: %v", err)
+	}
+	if h.ThreadID != "fresh" {
+		t.Fatalf("base-started thread id = %q, want fresh", h.ThreadID)
+	}
+	if d.LiveCount() != 1 {
+		t.Fatalf("LiveCount = %d, want 1", d.LiveCount())
+	}
+}
+
+func TestDriverClaimFromMissingBaseErrors(t *testing.T) {
+	d := testDriver(t)
+	_, err := d.Claim(context.Background(), substrate.ClaimSpec{
+		ThreadID:        "x",
+		BaseSnapshotRef: substrate.SnapshotRef{ID: "ghost-base", Arch: "amd64", Base: true},
+	})
+	if err == nil {
+		t.Fatal("claim from a non-existent base bundle should error")
+	}
+}
+
+func TestDriverExecNotHostProvided(t *testing.T) {
+	d := testDriver(t)
+	if _, err := d.Exec(context.Background(), substrate.Handle{}, substrate.Request{}); err == nil {
+		t.Fatal("Exec should report it is handled by the in-VM harness")
+	}
+}

--- a/projects/embervm/noded/fcvm/driver/gueststats.go
+++ b/projects/embervm/noded/fcvm/driver/gueststats.go
@@ -1,0 +1,109 @@
+package driver
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
+)
+
+// userHZ is the kernel clock-tick rate that /proc/<pid>/stat's utime/stime are
+// counted in. It is 100 on effectively every Linux build (USER_HZ), including
+// the daemon's container, so we treat it as a constant rather than paying a cgo
+// sysconf(_SC_CLK_TCK) call. This makes CPU resolution ~10ms, coarse for a
+// sub-20ms python run but fine for the semgrep/agent scans this is used to
+// right-size.
+const userHZ = 100
+
+// Stats reads the guest's firecracker process resource counters from /proc and
+// returns them as whole-invocation totals (see substrate.GuestStats). It is
+// meant to be called once, just before Release kills the process: /proc/<pid>
+// disappears with the process, so a later read would fail. Best-effort by
+// contract; the caller records the values on a span and continues on error.
+func (d *Driver) Stats(h substrate.Handle) (substrate.GuestStats, error) {
+	inst := d.get(h.ID)
+	if inst == nil {
+		return substrate.GuestStats{}, fmt.Errorf("driver: stats of unknown handle %q", h.ID)
+	}
+	pid := inst.proc.Pid()
+	if pid <= 0 {
+		return substrate.GuestStats{}, fmt.Errorf("driver: stats: no pid for handle %q", h.ID)
+	}
+	return readProcStats(pid)
+}
+
+// readProcStats reads /proc/<pid>/stat and /proc/<pid>/status for one pid and
+// returns the parsed CPU and peak-RSS totals.
+func readProcStats(pid int) (substrate.GuestStats, error) {
+	statData, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return substrate.GuestStats{}, fmt.Errorf("driver: read proc stat: %w", err)
+	}
+	cpuMs, err := parseProcStatCPUMillis(statData)
+	if err != nil {
+		return substrate.GuestStats{}, err
+	}
+	statusData, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		return substrate.GuestStats{}, fmt.Errorf("driver: read proc status: %w", err)
+	}
+	rssMib, err := parseProcStatusPeakRSSMib(statusData)
+	if err != nil {
+		return substrate.GuestStats{}, err
+	}
+	return substrate.GuestStats{CPUMillis: cpuMs, PeakRSSMib: rssMib}, nil
+}
+
+// parseProcStatCPUMillis extracts utime+stime (thread-group totals, so summed
+// across every vCPU + VMM thread) from a /proc/<pid>/stat line and converts
+// clock ticks to milliseconds.
+//
+// The comm field (field 2) is wrapped in parens and may itself contain spaces
+// or parens, so we split AFTER the last ')': the remaining fields start at
+// field 3 (state), making utime (field 14) index 11 and stime (field 15) index
+// 12 of the remainder.
+func parseProcStatCPUMillis(data []byte) (int64, error) {
+	s := string(data)
+	rparen := strings.LastIndexByte(s, ')')
+	if rparen < 0 || rparen+2 > len(s) {
+		return 0, fmt.Errorf("driver: malformed proc stat: no comm field")
+	}
+	fields := strings.Fields(s[rparen+1:])
+	// Need up to field 15 (stime) => index 12 of the post-comm fields.
+	if len(fields) < 13 {
+		return 0, fmt.Errorf("driver: malformed proc stat: only %d fields after comm", len(fields))
+	}
+	utime, err := strconv.ParseInt(fields[11], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("driver: parse utime: %w", err)
+	}
+	stime, err := strconv.ParseInt(fields[12], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("driver: parse stime: %w", err)
+	}
+	return (utime + stime) * 1000 / userHZ, nil
+}
+
+// parseProcStatusPeakRSSMib extracts the VmHWM (peak resident set high-water
+// mark) line from /proc/<pid>/status, reported in kB, and returns it in MiB
+// (rounded down). VmHWM is kernel-maintained, so this needs no sampling loop.
+func parseProcStatusPeakRSSMib(data []byte) (int64, error) {
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, "VmHWM:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		// "VmHWM:" <number> "kB"
+		if len(fields) < 2 {
+			return 0, fmt.Errorf("driver: malformed VmHWM line: %q", line)
+		}
+		kb, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("driver: parse VmHWM: %w", err)
+		}
+		return kb / 1024, nil
+	}
+	return 0, fmt.Errorf("driver: no VmHWM line in proc status")
+}

--- a/projects/embervm/noded/fcvm/driver/gueststats_test.go
+++ b/projects/embervm/noded/fcvm/driver/gueststats_test.go
@@ -1,0 +1,77 @@
+package driver
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestParseProcStatCPUMillis(t *testing.T) {
+	// utime=55, stime=12 (fields 14,15) => 67 ticks => 670ms at USER_HZ=100.
+	line := []byte("1234 (firecracker) S 1 1234 1234 0 -1 4194304 100 0 0 0 55 12 0 0 20 0 5 0 100\n")
+	got, err := parseProcStatCPUMillis(line)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got != 670 {
+		t.Errorf("cpu_ms = %d, want 670", got)
+	}
+}
+
+func TestParseProcStatCPUMillisCommWithSpacesAndParens(t *testing.T) {
+	// The comm field can contain spaces and parens; parsing must key on the LAST
+	// ')', not the first, so utime/stime are still read correctly.
+	line := []byte("1234 ((odd) fire cracker) R 1 1234 1234 0 -1 4194304 7 0 0 0 30 10 0 0 20 0 4 0 9\n")
+	got, err := parseProcStatCPUMillis(line)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got != 400 { // (30+10)*10
+		t.Errorf("cpu_ms = %d, want 400", got)
+	}
+}
+
+func TestParseProcStatCPUMillisMalformed(t *testing.T) {
+	if _, err := parseProcStatCPUMillis([]byte("no parens here")); err == nil {
+		t.Error("want error on a line with no comm parens, got nil")
+	}
+	if _, err := parseProcStatCPUMillis([]byte("1 (x) S 1 2 3")); err == nil {
+		t.Error("want error when there are too few fields after comm, got nil")
+	}
+}
+
+func TestParseProcStatusPeakRSSMib(t *testing.T) {
+	status := []byte("Name:\tfirecracker\nState:\tS (sleeping)\nVmPeak:\t 600000 kB\nVmHWM:\t 524288 kB\nVmRSS:\t 400000 kB\n")
+	got, err := parseProcStatusPeakRSSMib(status)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got != 512 { // 524288 kB / 1024
+		t.Errorf("peak_rss_mib = %d, want 512", got)
+	}
+}
+
+func TestParseProcStatusPeakRSSMibMissing(t *testing.T) {
+	if _, err := parseProcStatusPeakRSSMib([]byte("Name:\tfirecracker\nVmRSS:\t 4 kB\n")); err == nil {
+		t.Error("want error when VmHWM line is absent, got nil")
+	}
+}
+
+// TestReadProcStatsSelf exercises the full /proc read against this test
+// process on linux, proving the file paths and parsing agree with a real
+// kernel. Skipped off linux (no /proc).
+func TestReadProcStatsSelf(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("proc stats only available on linux")
+	}
+	stats, err := readProcStats(os.Getpid())
+	if err != nil {
+		t.Fatalf("readProcStats(self): %v", err)
+	}
+	if stats.PeakRSSMib <= 0 {
+		t.Errorf("peak_rss_mib = %d, want > 0 for a running process", stats.PeakRSSMib)
+	}
+	if stats.CPUMillis < 0 { // may be 0 at 10ms granularity for a fast test
+		t.Errorf("cpu_ms = %d, want >= 0", stats.CPUMillis)
+	}
+}

--- a/projects/embervm/noded/fcvm/driver/launcher.go
+++ b/projects/embervm/noded/fcvm/driver/launcher.go
@@ -1,0 +1,141 @@
+package driver
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+// ExecLauncher launches real Firecracker processes. It is the production
+// Launcher; tests inject a fake. fc-agentd owns FC process supervision (crash
+// cleanup, orphan reaping), mirroring E2B's patterns.
+type ExecLauncher struct {
+	// Bin is the firecracker binary (/opt/kata/bin/firecracker on node-4).
+	Bin string
+	// ReadyTimeout bounds how long Launch waits for the API socket to accept
+	// connections before giving up.
+	ReadyTimeout time.Duration
+	// OOMScoreAdj, when > 0, is written to the launched Firecracker process's
+	// /proc/<pid>/oom_score_adj so the guest is the kernel's first OOM victim
+	// under memory pressure, never the daemon (the guests share the daemon's
+	// cgroup because they are child processes, not pods). Best-effort: a write
+	// failure is logged, not fatal.
+	OOMScoreAdj int
+	// VsockBindTarget, when set, launches firecracker in its own mount namespace
+	// with the VM's bundle dir bind-mounted over this canonical vsock dir (the path
+	// the base snapshot embeds). This gives every microVM restored from one warm
+	// base its own host-reachable vsock socket. Empty preserves the plain launch
+	// (fc-agentd's cold-boot path). Requires Self to be set.
+	VsockBindTarget string
+	// Self is the path to the current executable, which must handle the "__fcmount"
+	// trampoline subcommand (via ExecMountTrampoline). Required iff VsockBindTarget
+	// is set.
+	Self string
+}
+
+type execProcess struct {
+	cmd *exec.Cmd
+}
+
+func (p *execProcess) Kill() error {
+	if p.cmd.Process == nil {
+		return nil
+	}
+	killErr := p.cmd.Process.Kill()
+	// Always reap the child, even when Kill reports it already exited (a crashed
+	// or panicked VM): without a Wait the dead process lingers as a zombie. Wait
+	// is the sole reaper, so it is safe to call once here.
+	_ = p.cmd.Wait()
+	return killErr
+}
+
+func (p *execProcess) Wait() error { return p.cmd.Wait() }
+
+// Pid returns the OS pid of the firecracker process, or 0 before Start.
+func (p *execProcess) Pid() int {
+	if p.cmd == nil || p.cmd.Process == nil {
+		return 0
+	}
+	return p.cmd.Process.Pid
+}
+
+// Launch starts firecracker with its API socket at socketPath and blocks until
+// the socket is connectable (or the timeout/context fires).
+func (l *ExecLauncher) Launch(ctx context.Context, vmID, socketPath string) (Process, error) {
+	if l.Bin == "" {
+		return nil, fmt.Errorf("driver: ExecLauncher.Bin is empty")
+	}
+	_ = os.Remove(socketPath)
+
+	var cmd *exec.Cmd
+	if l.VsockBindTarget != "" {
+		// Per-instance vsock isolation: re-exec our own __fcmount trampoline in a
+		// fresh mount namespace, bind-mounting this VM's bundle dir (the api socket's
+		// dir) over the canonical vsock dir embedded in the base snapshot, then exec
+		// firecracker. See ExecMountTrampoline.
+		if l.Self == "" {
+			return nil, fmt.Errorf("driver: ExecLauncher.Self required when VsockBindTarget is set")
+		}
+		bindSrc := filepath.Dir(socketPath)
+		cmd = exec.Command(l.Self, "__fcmount", bindSrc, l.VsockBindTarget, l.Bin, "--api-sock", socketPath, "--id", vmID)
+		setUnshareMountNS(cmd)
+	} else {
+		cmd = exec.Command(l.Bin, "--api-sock", socketPath, "--id", vmID)
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("driver: start firecracker: %w", err)
+	}
+	proc := &execProcess{cmd: cmd}
+
+	if l.OOMScoreAdj > 0 {
+		if err := setOOMScoreAdj(cmd.Process.Pid, l.OOMScoreAdj); err != nil {
+			// Best-effort hardening; the cap still bounds memory if this fails.
+			slog.Warn("driver: set firecracker oom_score_adj",
+				"vm", vmID, "pid", cmd.Process.Pid, "score", l.OOMScoreAdj, "err", err)
+		}
+	}
+
+	timeout := l.ReadyTimeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	if err := waitForSocket(ctx, socketPath, timeout); err != nil {
+		_ = proc.Kill()
+		return nil, err
+	}
+	return proc, nil
+}
+
+// setOOMScoreAdj writes score to /proc/<pid>/oom_score_adj, biasing the kernel
+// OOM killer to pick this process first. Valid range is -1000..1000; the daemon
+// must have permission (fc-agentd runs privileged on node-4).
+func setOOMScoreAdj(pid, score int) error {
+	path := fmt.Sprintf("/proc/%d/oom_score_adj", pid)
+	return os.WriteFile(path, []byte(strconv.Itoa(score)), 0o644)
+}
+
+func waitForSocket(ctx context.Context, socketPath string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		conn, err := net.DialTimeout("unix", socketPath, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("driver: firecracker API socket %q not ready after %s", socketPath, timeout)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/projects/embervm/noded/fcvm/driver/mountns_linux.go
+++ b/projects/embervm/noded/fcvm/driver/mountns_linux.go
@@ -1,0 +1,56 @@
+//go:build linux
+
+package driver
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// setUnshareMountNS makes the launched process start in a fresh mount namespace,
+// so the bind-mount the __fcmount trampoline performs is private to that VM.
+func setUnshareMountNS(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Unshareflags |= syscall.CLONE_NEWNS
+}
+
+// ExecMountTrampoline handles a re-exec of the form
+//
+//	<self> __fcmount <bindSrc> <bindTgt> <fcbin> <fcargs...>
+//
+// It runs in a fresh mount namespace (the parent launch set CLONE_NEWNS), makes
+// mount propagation private so the bind never leaks to the host, bind-mounts
+// bindSrc over bindTgt, then execs firecracker. Firecracker's vsock UDS — embedded
+// in the base snapshot as <bindTgt>/vsock.sock — therefore lands in bindSrc (this
+// VM's per-instance bundle dir, host-visible), giving every microVM restored from
+// one warm base its own host-reachable vsock socket. On success it never returns
+// (exec replaces the process); the caller invokes it at process start and it is a
+// no-op unless argv[1] is "__fcmount".
+func ExecMountTrampoline() {
+	if len(os.Args) < 5 || os.Args[1] != "__fcmount" {
+		return
+	}
+	bindSrc, bindTgt, fcbin := os.Args[2], os.Args[3], os.Args[4]
+	rest := os.Args[5:]
+	if err := syscall.Mount("", "/", "", syscall.MS_REC|syscall.MS_PRIVATE, ""); err != nil {
+		fmt.Fprintf(os.Stderr, "fcmount: make / private: %v\n", err)
+		os.Exit(90)
+	}
+	if err := os.MkdirAll(bindTgt, 0o750); err != nil {
+		fmt.Fprintf(os.Stderr, "fcmount: mkdir %s: %v\n", bindTgt, err)
+		os.Exit(91)
+	}
+	if err := syscall.Mount(bindSrc, bindTgt, "", syscall.MS_BIND, ""); err != nil {
+		fmt.Fprintf(os.Stderr, "fcmount: bind %s -> %s: %v\n", bindSrc, bindTgt, err)
+		os.Exit(92)
+	}
+	argv := append([]string{fcbin}, rest...)
+	if err := syscall.Exec(fcbin, argv, os.Environ()); err != nil {
+		fmt.Fprintf(os.Stderr, "fcmount: exec %s: %v\n", fcbin, err)
+		os.Exit(93)
+	}
+}

--- a/projects/embervm/noded/fcvm/driver/mountns_other.go
+++ b/projects/embervm/noded/fcvm/driver/mountns_other.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package driver
+
+import "os/exec"
+
+// setUnshareMountNS is a no-op off Linux; per-instance vsock mount namespaces only
+// run on node-4. This keeps the package building on the darwin CI path.
+func setUnshareMountNS(*exec.Cmd) {}
+
+// ExecMountTrampoline is a no-op off Linux (the daemon only runs the trampoline on
+// node-4); keeps the package building for host builds.
+func ExecMountTrampoline() {}

--- a/projects/embervm/noded/fcvm/driver/provisioner.go
+++ b/projects/embervm/noded/fcvm/driver/provisioner.go
@@ -1,0 +1,372 @@
+package driver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sync"
+	"time"
+)
+
+// RootfsProvisioner gives each thread its own writable rootfs derived from a
+// read-only base image, so threads never share or corrupt one disk. The default
+// impl is a file copy ("full snapshots first"); DevmapperProvisioner is the
+// copy-on-write impl (ADR 026) that replaces the full copy with a devmapper
+// thin-snapshot of the base, behind the same interface.
+type RootfsProvisioner interface {
+	// Provision creates the thread's rootfs under dir and returns its host path.
+	Provision(ctx context.Context, threadID, dir string) (string, error)
+	// Teardown releases any out-of-dir resources the provisioner created for the
+	// thread (a CoW device + its pool allocation), called when the thread's
+	// bundle is reclaimed. It must be idempotent: reclaim may run more than once
+	// and the device may already be gone. A file-copy provisioner has nothing to
+	// release (RemoveBundle's RemoveAll deletes the file), so its Teardown is a
+	// no-op.
+	Teardown(ctx context.Context, threadID string) error
+}
+
+// CopyProvisioner copies a base rootfs image to a per-thread file. Simple and
+// correct; the cost is a full copy + full disk per thread, which
+// DevmapperProvisioner (ADR 026) replaces with a thin-snapshot.
+type CopyProvisioner struct {
+	// Base is the read-only base rootfs image (a flattened harness image).
+	Base string
+}
+
+// Provision copies Base to dir/rootfs.ext4.
+func (p *CopyProvisioner) Provision(_ context.Context, _, dir string) (string, error) {
+	if p.Base == "" {
+		return "", fmt.Errorf("driver: CopyProvisioner.Base is empty")
+	}
+	dst := filepath.Join(dir, "rootfs.ext4")
+	if err := copyFile(p.Base, dst); err != nil {
+		return "", fmt.Errorf("driver: provision rootfs: %w", err)
+	}
+	return dst, nil
+}
+
+// Teardown is a no-op: the per-thread rootfs file lives in the bundle dir, which
+// RemoveBundle deletes wholesale.
+func (p *CopyProvisioner) Teardown(_ context.Context, _ string) error { return nil }
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// ---------------------------------------------------------------------------
+// DevmapperProvisioner (ADR 026): copy-on-write rootfs via devmapper thin-pool.
+// ---------------------------------------------------------------------------
+
+// dmNameRE bounds a thread id (or base signature) to a safe device-mapper name
+// component.
+var dmNameRE = regexp.MustCompile(`[^A-Za-z0-9_-]`)
+
+// Reserved thin device-id bands. The pool is SHARED with containerd's devmapper
+// snapshotter, whose ids start at 0 and increment per image snapshot; it never
+// reaches the millions. fc-agentd allocates from a high, disjoint band so its
+// ids can never collide with containerd's (a collision would corrupt the other
+// daemon's device). Thin ids are 24-bit (max 16,777,215), so these stay well
+// inside the range while leaving containerd the whole low end.
+const (
+	baseDevIDStart   = 3_000_000 // base thin devices (one per base-image version)
+	threadDevIDStart = 3_100_000 // per-thread snapshots, reused via the free list
+)
+
+// teardownTimeout bounds a single dmsetup teardown so a wedged pool op cannot
+// stall the reconcile loop indefinitely.
+const teardownTimeout = 30 * time.Second
+
+// dmThinState is the persisted allocation table. It lives next to the bundles on
+// the nvme disk (the same durable medium as the pool's own metadata), so the
+// daemon recovers its device-id bookkeeping across restarts.
+type dmThinState struct {
+	// BaseSig identifies the loaded base by file size+mtime; a new base image
+	// (harness bump) changes it and triggers a reload under a fresh id.
+	BaseSig     string         `json:"base_sig"`
+	BaseDevID   int            `json:"base_dev_id"`
+	BaseSectors int64          `json:"base_sectors"`
+	BaseLoaded  bool           `json:"base_loaded"`
+	NextBaseID  int            `json:"next_base_id"`
+	NextThread  int            `json:"next_thread_id"`
+	FreeThread  []int          `json:"free_thread_ids"`
+	Active      map[string]int `json:"active"` // threadID -> thin dev id
+}
+
+// DevmapperProvisioner provisions each thread a copy-on-write rootfs as a
+// devmapper thin-snapshot of a base thin device (ADR 026). The base image is
+// loaded into a thin device once (a one-time ~3GB write); every thread then gets
+// an instant thin-snapshot of it, so per-thread rootfs creation drops from a
+// ~2s full copy to milliseconds and per-thread disk drops to only the written
+// delta. It drives the pool through the `dmsetup` CLI (in the runtime image),
+// with udev sync disabled because the container has no udev daemon — libdevmapper
+// then creates the /dev/mapper nodes directly.
+type DevmapperProvisioner struct {
+	// Pool is the thin-pool name (a /dev/mapper entry, e.g. "devpool").
+	Pool string
+	// Base is the read-only base rootfs image baked by the rootfs-builder.
+	Base string
+	// StateDir holds the persisted allocation table (the snapshot root).
+	StateDir string
+
+	mu    sync.Mutex
+	state dmThinState
+	// loaded guards one-time state load from disk.
+	loaded bool
+}
+
+func (p *DevmapperProvisioner) poolPath() string { return filepath.Join("/dev/mapper", p.Pool) }
+
+func (p *DevmapperProvisioner) statePath() string {
+	return filepath.Join(p.StateDir, "dm-thin-state.json")
+}
+
+func dmName(prefix, id string) string {
+	return prefix + dmNameRE.ReplaceAllString(id, "_")
+}
+
+// loadState reads the persisted allocation table once. A missing file is a fresh
+// start, not an error.
+func (p *DevmapperProvisioner) loadState() error {
+	if p.loaded {
+		return nil
+	}
+	b, err := os.ReadFile(p.statePath())
+	switch {
+	case err == nil:
+		if uerr := json.Unmarshal(b, &p.state); uerr != nil {
+			return fmt.Errorf("driver: dm state corrupt: %w", uerr)
+		}
+	case os.IsNotExist(err):
+		// fresh
+	default:
+		return fmt.Errorf("driver: read dm state: %w", err)
+	}
+	if p.state.Active == nil {
+		p.state.Active = map[string]int{}
+	}
+	if p.state.NextBaseID == 0 {
+		p.state.NextBaseID = baseDevIDStart
+	}
+	if p.state.NextThread == 0 {
+		p.state.NextThread = threadDevIDStart
+	}
+	p.loaded = true
+	return nil
+}
+
+// saveState atomically persists the allocation table.
+func (p *DevmapperProvisioner) saveState() error {
+	b, err := json.MarshalIndent(&p.state, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := p.statePath() + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, p.statePath())
+}
+
+// dmsetup runs a dmsetup subcommand with udev sync disabled (no udev in the
+// container) and returns combined output on error for diagnosis.
+func dmsetup(ctx context.Context, args ...string) error {
+	cmd := exec.CommandContext(ctx, "dmsetup", args...)
+	cmd.Env = append(os.Environ(), "DM_DISABLE_UDEV=1")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("dmsetup %v: %w: %s", args, err, string(out))
+	}
+	return nil
+}
+
+// poolMessage sends a thin-pool message (create_thin / create_snap / delete).
+func (p *DevmapperProvisioner) poolMessage(ctx context.Context, msg string) error {
+	return dmsetup(ctx, "message", p.Pool, "0", msg)
+}
+
+// activateThin creates a live dm device named name backed by thin dev id over
+// the pool (table: "0 <sectors> thin <pool> <id>").
+func (p *DevmapperProvisioner) activateThin(ctx context.Context, name string, devID int, sectors int64) error {
+	table := fmt.Sprintf("0 %d thin %s %d", sectors, p.poolPath(), devID)
+	return dmsetup(ctx, "create", name, "--table", table)
+}
+
+// removeDev tears down a live dm device, tolerating "already gone". --retry
+// rides out the brief busy window after the VM process exits.
+func (p *DevmapperProvisioner) removeDev(ctx context.Context, name string) error {
+	if err := dmsetup(ctx, "info", name); err != nil {
+		return nil // not present; nothing to remove
+	}
+	return dmsetup(ctx, "remove", "--retry", name)
+}
+
+// baseSig identifies the base image by size+mtime so a rebuilt base reloads, and
+// returns its size in 512-byte sectors.
+func baseSig(path string) (string, int64, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return "", 0, err
+	}
+	// Round sectors UP so the device always holds the whole image even if the file
+	// is not a 512-multiple (ext4 images are, but ceil is strictly safe: a short
+	// device would fail the base copy on the trailing bytes).
+	return fmt.Sprintf("%d-%d", fi.Size(), fi.ModTime().UnixNano()), (fi.Size() + 511) / 512, nil
+}
+
+// ensureBase loads the base image into a base thin device exactly once per base
+// version (the caller holds the lock). The base is activated only long enough to
+// copy the image in, then deactivated; its data persists in the pool under
+// BaseDevID and every thread snapshots it without re-activating it.
+func (p *DevmapperProvisioner) ensureBase(ctx context.Context) error {
+	sig, sectors, err := baseSig(p.Base)
+	if err != nil {
+		return fmt.Errorf("driver: stat base rootfs: %w", err)
+	}
+	if p.state.BaseLoaded && p.state.BaseSig == sig {
+		return nil
+	}
+
+	devID := p.state.NextBaseID
+	if err := p.poolMessage(ctx, fmt.Sprintf("create_thin %d", devID)); err != nil {
+		return fmt.Errorf("driver: create base thin dev: %w", err)
+	}
+	name := dmName("fcbase-", sig)
+	if err := p.activateThin(ctx, name, devID, sectors); err != nil {
+		return fmt.Errorf("driver: activate base thin dev: %w", err)
+	}
+	// Copy the base image into the activated thin device, then deactivate it. The
+	// blocks now live in the pool under devID; snapshots share them copy-on-write.
+	copyErr := copyToDevice(filepath.Join("/dev/mapper", name), p.Base)
+	_ = p.removeDev(ctx, name)
+	if copyErr != nil {
+		return fmt.Errorf("driver: load base image into thin dev: %w", copyErr)
+	}
+
+	p.state.BaseSig = sig
+	p.state.BaseDevID = devID
+	p.state.BaseSectors = sectors
+	p.state.BaseLoaded = true
+	p.state.NextBaseID = devID + 1
+	return p.saveState()
+}
+
+// copyToDevice writes a file's contents to a block device and flushes to disk.
+func copyToDevice(dev, src string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dev, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	if err := out.Sync(); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// allocThreadID returns a thin dev id for a new thread, reusing a freed id when
+// one is available. The caller holds the lock.
+func (p *DevmapperProvisioner) allocThreadID() int {
+	if n := len(p.state.FreeThread); n > 0 {
+		id := p.state.FreeThread[n-1]
+		p.state.FreeThread = p.state.FreeThread[:n-1]
+		return id
+	}
+	id := p.state.NextThread
+	p.state.NextThread++
+	return id
+}
+
+// Provision creates a thin-snapshot of the base for the thread and activates it,
+// returning the /dev/mapper path firecracker uses as the rootfs drive.
+func (p *DevmapperProvisioner) Provision(ctx context.Context, threadID, _ string) (string, error) {
+	if p.Base == "" {
+		return "", fmt.Errorf("driver: DevmapperProvisioner.Base is empty")
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.loadState(); err != nil {
+		return "", err
+	}
+	if err := p.ensureBase(ctx); err != nil {
+		return "", err
+	}
+
+	name := dmName("fcthr-", threadID)
+	// Reuse the existing allocation if the thread is re-provisioned (idempotent).
+	if existing, ok := p.state.Active[threadID]; ok {
+		if err := dmsetup(ctx, "info", name); err == nil {
+			return filepath.Join("/dev/mapper", name), nil
+		}
+		// id recorded but device gone (restart): rebuild the device from the id.
+		if err := p.activateThin(ctx, name, existing, p.state.BaseSectors); err != nil {
+			return "", fmt.Errorf("driver: re-activate thread thin dev: %w", err)
+		}
+		return filepath.Join("/dev/mapper", name), nil
+	}
+
+	devID := p.allocThreadID()
+	if err := p.poolMessage(ctx, fmt.Sprintf("create_snap %d %d", devID, p.state.BaseDevID)); err != nil {
+		p.state.FreeThread = append(p.state.FreeThread, devID)
+		return "", fmt.Errorf("driver: create thread snapshot: %w", err)
+	}
+	if err := p.activateThin(ctx, name, devID, p.state.BaseSectors); err != nil {
+		_ = p.poolMessage(ctx, fmt.Sprintf("delete %d", devID))
+		p.state.FreeThread = append(p.state.FreeThread, devID)
+		return "", fmt.Errorf("driver: activate thread thin dev: %w", err)
+	}
+	p.state.Active[threadID] = devID
+	if err := p.saveState(); err != nil {
+		return "", err
+	}
+	return filepath.Join("/dev/mapper", name), nil
+}
+
+// Teardown deactivates the thread's CoW device and frees its thin dev id + pool
+// space. Idempotent: a thread with no recorded device is a no-op.
+func (p *DevmapperProvisioner) Teardown(ctx context.Context, threadID string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.loadState(); err != nil {
+		return err
+	}
+	devID, ok := p.state.Active[threadID]
+	if !ok {
+		return nil
+	}
+	if err := p.removeDev(ctx, dmName("fcthr-", threadID)); err != nil {
+		return fmt.Errorf("driver: remove thread thin dev: %w", err)
+	}
+	if err := p.poolMessage(ctx, fmt.Sprintf("delete %d", devID)); err != nil {
+		return fmt.Errorf("driver: delete thread thin dev id: %w", err)
+	}
+	delete(p.state.Active, threadID)
+	p.state.FreeThread = append(p.state.FreeThread, devID)
+	return p.saveState()
+}

--- a/projects/embervm/noded/fcvm/driver/provisioner_test.go
+++ b/projects/embervm/noded/fcvm/driver/provisioner_test.go
@@ -1,0 +1,154 @@
+package driver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
+)
+
+func TestCopyProvisionerCopiesBase(t *testing.T) {
+	base := filepath.Join(shortTempDir(t), "base.ext4")
+	if err := os.WriteFile(base, []byte("ROOTFS-BYTES"), 0o600); err != nil {
+		t.Fatalf("write base: %v", err)
+	}
+	dir := shortTempDir(t)
+
+	p := &CopyProvisioner{Base: base}
+	got, err := p.Provision(context.Background(), "t1", dir)
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if got != filepath.Join(dir, "rootfs.ext4") {
+		t.Fatalf("rootfs path = %q", got)
+	}
+	b, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatalf("read provisioned: %v", err)
+	}
+	if string(b) != "ROOTFS-BYTES" {
+		t.Fatalf("provisioned content = %q, want the base bytes", b)
+	}
+}
+
+func TestCopyProvisionerEmptyBaseErrors(t *testing.T) {
+	if _, err := (&CopyProvisioner{}).Provision(context.Background(), "t1", t.TempDir()); err == nil {
+		t.Fatal("empty Base should error")
+	}
+}
+
+// fakeProvisioner records calls and creates a stub rootfs file.
+type fakeProvisioner struct {
+	calls    atomic.Int32
+	threadID string
+	tornDown string
+	fail     error
+}
+
+func (f *fakeProvisioner) Provision(_ context.Context, threadID, dir string) (string, error) {
+	f.calls.Add(1)
+	f.threadID = threadID
+	if f.fail != nil {
+		return "", f.fail
+	}
+	path := filepath.Join(dir, "rootfs.ext4")
+	_ = os.WriteFile(path, []byte("stub"), 0o600)
+	return path, nil
+}
+
+func (f *fakeProvisioner) Teardown(_ context.Context, threadID string) error {
+	f.tornDown = threadID
+	return nil
+}
+
+func TestDriverClaimProvisionsPerThreadRootfs(t *testing.T) {
+	d := testDriver(t)
+	fp := &fakeProvisioner{}
+	d.SetProvisioner(fp)
+
+	h, err := d.Claim(context.Background(), substrate.ClaimSpec{ThreadID: "t-prov"})
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if fp.calls.Load() != 1 {
+		t.Fatalf("provisioner called %d times, want 1", fp.calls.Load())
+	}
+	if fp.threadID != "t-prov" {
+		t.Fatalf("provisioned for %q, want t-prov", fp.threadID)
+	}
+	if h.ThreadID != "t-prov" {
+		t.Fatalf("handle thread = %q", h.ThreadID)
+	}
+}
+
+func TestDriverClaimProvisionFailureAborts(t *testing.T) {
+	d := testDriver(t)
+	d.SetProvisioner(&fakeProvisioner{fail: errors.New("no space")})
+	if _, err := d.Claim(context.Background(), substrate.ClaimSpec{ThreadID: "t1"}); err == nil {
+		t.Fatal("Claim should fail when rootfs provisioning fails")
+	}
+	if d.LiveCount() != 0 {
+		t.Fatalf("a failed provision should not leave a live VM; LiveCount=%d", d.LiveCount())
+	}
+}
+
+func TestDevmapperAllocReusesFreedThinIDs(t *testing.T) {
+	p := &DevmapperProvisioner{StateDir: shortTempDir(t)}
+	if err := p.loadState(); err != nil {
+		t.Fatalf("loadState: %v", err)
+	}
+	a := p.allocThreadID()
+	b := p.allocThreadID()
+	if a != threadDevIDStart || b != threadDevIDStart+1 {
+		t.Fatalf("alloc = %d,%d; want %d,%d", a, b, threadDevIDStart, threadDevIDStart+1)
+	}
+	// Free a, then the next alloc must reuse it rather than grow the high-water.
+	p.state.FreeThread = append(p.state.FreeThread, a)
+	if reused := p.allocThreadID(); reused != a {
+		t.Fatalf("alloc after free = %d, want reused %d", reused, a)
+	}
+}
+
+func TestDevmapperStateRoundTrips(t *testing.T) {
+	dir := shortTempDir(t)
+	p := &DevmapperProvisioner{StateDir: dir}
+	if err := p.loadState(); err != nil {
+		t.Fatalf("loadState: %v", err)
+	}
+	p.state.Active["t-1"] = p.allocThreadID()
+	p.state.BaseLoaded = true
+	p.state.BaseSig = "sig-1"
+	if err := p.saveState(); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+	// A fresh provisioner over the same dir recovers the allocation table.
+	q := &DevmapperProvisioner{StateDir: dir}
+	if err := q.loadState(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if q.state.Active["t-1"] != threadDevIDStart || !q.state.BaseLoaded || q.state.BaseSig != "sig-1" {
+		t.Fatalf("recovered state = %+v", q.state)
+	}
+}
+
+func TestDMNameSanitizes(t *testing.T) {
+	if got := dmName("fcthr-", "t-ab/cd:12"); got != "fcthr-t-ab_cd_12" {
+		t.Fatalf("dmName = %q", got)
+	}
+}
+
+func TestBootArgsAppendsInit(t *testing.T) {
+	d := New(Config{
+		KernelBootArgs: "console=ttyS0",
+		HarnessInit:    "/usr/local/bin/fc-agent-init",
+		SnapshotRoot:   shortTempDir(t),
+		Node:           "node-4", Arch: "amd64",
+	}, &fakeLauncher{}, nil)
+	if got := d.bootArgs(); got != "console=ttyS0 init=/usr/local/bin/fc-agent-init" {
+		t.Fatalf("bootArgs = %q", got)
+	}
+}

--- a/projects/embervm/noded/fcvm/fcclient/BUILD
+++ b/projects/embervm/noded/fcvm/fcclient/BUILD
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "fcclient",
+    srcs = ["client.go"],
+    importpath = "github.com/jomcgi/homelab/projects/embervm/noded/fcvm/fcclient",
+    visibility = ["//projects/embervm/noded:__subpackages__"],
+)
+
+go_test(
+    name = "fcclient_test",
+    srcs = ["client_test.go"],
+    embed = [":fcclient"],
+)

--- a/projects/embervm/noded/fcvm/fcclient/client.go
+++ b/projects/embervm/noded/fcvm/fcclient/client.go
@@ -1,0 +1,168 @@
+// Package fcclient is a minimal Firecracker REST API client over the microVM's
+// unix domain API socket. It implements exactly the calls the snapshot/restore
+// controller needs (machine config, boot source, drives, vsock, start, pause,
+// resume, snapshot create/load), following the FC-direct approach ported from
+// e2b-dev/infra rather than pulling in the full firecracker-go-sdk.
+//
+// The Firecracker API speaks HTTP/1.1 over a unix socket and returns 204 No
+// Content on success, or a JSON {"fault_message": "..."} body on error.
+package fcclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+// Client talks to a single Firecracker process over its API socket.
+type Client struct {
+	http       *http.Client
+	socketPath string
+}
+
+// New returns a client bound to the Firecracker API socket at socketPath.
+func New(socketPath string) *Client {
+	return &Client{
+		socketPath: socketPath,
+		http: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					var d net.Dialer
+					return d.DialContext(ctx, "unix", socketPath)
+				},
+			},
+		},
+	}
+}
+
+// MachineConfig is the body of PUT /machine-config.
+type MachineConfig struct {
+	VCPUCount  int  `json:"vcpu_count"`
+	MemSizeMib int  `json:"mem_size_mib"`
+	SMT        bool `json:"smt"`
+}
+
+// BootSource is the body of PUT /boot-source.
+type BootSource struct {
+	KernelImagePath string `json:"kernel_image_path"`
+	BootArgs        string `json:"boot_args,omitempty"`
+	InitrdPath      string `json:"initrd_path,omitempty"`
+}
+
+// Drive is the body of PUT /drives/{drive_id}.
+type Drive struct {
+	DriveID      string `json:"drive_id"`
+	PathOnHost   string `json:"path_on_host"`
+	IsRootDevice bool   `json:"is_root_device"`
+	IsReadOnly   bool   `json:"is_read_only"`
+}
+
+// Vsock is the body of PUT /vsock. The controller uses a vsock device for the
+// in-VM wrapper's idle-signal channel (Phase 2).
+type Vsock struct {
+	GuestCID int    `json:"guest_cid"`
+	UDSPath  string `json:"uds_path"`
+}
+
+// MemBackend selects how a memory snapshot is restored. Backend "File" mmaps the
+// image and faults pages lazily (sub-second restore without UFFD); "Uffd" uses a
+// userfaultfd handler (Phase 6).
+type MemBackend struct {
+	BackendType string `json:"backend_type"`
+	BackendPath string `json:"backend_path"`
+}
+
+// SnapshotCreate is the body of PUT /snapshot/create.
+type SnapshotCreate struct {
+	SnapshotType string `json:"snapshot_type,omitempty"` // "Full" (default) or "Diff"
+	SnapshotPath string `json:"snapshot_path"`
+	MemFilePath  string `json:"mem_file_path"`
+}
+
+// SnapshotLoad is the body of PUT /snapshot/load.
+type SnapshotLoad struct {
+	SnapshotPath        string      `json:"snapshot_path"`
+	MemBackend          *MemBackend `json:"mem_backend,omitempty"`
+	EnableDiffSnapshots bool        `json:"enable_diff_snapshots,omitempty"`
+	ResumeVM            bool        `json:"resume_vm"`
+}
+
+// PutMachineConfig configures vCPUs and memory.
+func (c *Client) PutMachineConfig(ctx context.Context, m MachineConfig) error {
+	return c.do(ctx, http.MethodPut, "/machine-config", m)
+}
+
+// PutBootSource sets the guest kernel and boot args.
+func (c *Client) PutBootSource(ctx context.Context, b BootSource) error {
+	return c.do(ctx, http.MethodPut, "/boot-source", b)
+}
+
+// PutDrive attaches a block device (the devmapper rootfs).
+func (c *Client) PutDrive(ctx context.Context, d Drive) error {
+	return c.do(ctx, http.MethodPut, "/drives/"+d.DriveID, d)
+}
+
+// PutVsock attaches a vsock device for the wrapper channel.
+func (c *Client) PutVsock(ctx context.Context, v Vsock) error {
+	return c.do(ctx, http.MethodPut, "/vsock", v)
+}
+
+// Start boots the configured microVM (action InstanceStart).
+func (c *Client) Start(ctx context.Context) error {
+	return c.do(ctx, http.MethodPut, "/actions", map[string]string{"action_type": "InstanceStart"})
+}
+
+// Pause pauses the running microVM so a consistent snapshot can be taken.
+func (c *Client) Pause(ctx context.Context) error {
+	return c.do(ctx, http.MethodPatch, "/vm", map[string]string{"state": "Paused"})
+}
+
+// Resume resumes a paused microVM.
+func (c *Client) Resume(ctx context.Context) error {
+	return c.do(ctx, http.MethodPatch, "/vm", map[string]string{"state": "Resumed"})
+}
+
+// CreateSnapshot writes the snapfile + memfile for the (paused) microVM.
+func (c *Client) CreateSnapshot(ctx context.Context, s SnapshotCreate) error {
+	return c.do(ctx, http.MethodPut, "/snapshot/create", s)
+}
+
+// LoadSnapshot restores a microVM from a snapshot bundle into this (fresh,
+// not-yet-started) Firecracker process, optionally resuming it.
+func (c *Client) LoadSnapshot(ctx context.Context, s SnapshotLoad) error {
+	return c.do(ctx, http.MethodPut, "/snapshot/load", s)
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body any) error {
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			return fmt.Errorf("fcclient: encode %s %s: %w", method, path, err)
+		}
+	}
+	// The host is ignored (unix socket) but must be a valid URL.
+	req, err := http.NewRequestWithContext(ctx, method, "http://localhost"+path, &buf)
+	if err != nil {
+		return fmt.Errorf("fcclient: new request %s %s: %w", method, path, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("fcclient: %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return fmt.Errorf("fcclient: %s %s: status %d: %s", method, path, resp.StatusCode, bytes.TrimSpace(msg))
+}

--- a/projects/embervm/noded/fcvm/fcclient/client_test.go
+++ b/projects/embervm/noded/fcvm/fcclient/client_test.go
@@ -1,0 +1,181 @@
+package fcclient
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// fakeFC is an in-process Firecracker API stub listening on a unix socket. It
+// records every request so tests can assert the controller drives the API in
+// the right order with the right bodies.
+type fakeFC struct {
+	mu       sync.Mutex
+	requests []recordedReq
+	srv      *http.Server
+	failPath string // if set, return 400 for this path
+}
+
+type recordedReq struct {
+	Method string
+	Path   string
+	Body   map[string]any
+}
+
+func startFakeFC(t *testing.T) (*fakeFC, string) {
+	t.Helper()
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "fc.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	f := &fakeFC{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if b, _ := io.ReadAll(r.Body); len(b) > 0 {
+			_ = json.Unmarshal(b, &body)
+		}
+		f.mu.Lock()
+		f.requests = append(f.requests, recordedReq{Method: r.Method, Path: r.URL.Path, Body: body})
+		fail := f.failPath != "" && r.URL.Path == f.failPath
+		f.mu.Unlock()
+		if fail {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"fault_message":"boom"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	f.srv = &http.Server{Handler: mux}
+	go func() { _ = f.srv.Serve(ln) }()
+	t.Cleanup(func() { _ = f.srv.Close(); _ = os.Remove(sock) })
+	return f, sock
+}
+
+func (f *fakeFC) paths() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.requests))
+	for _, r := range f.requests {
+		out = append(out, r.Method+" "+r.Path)
+	}
+	return out
+}
+
+func TestClientBootSequence(t *testing.T) {
+	fake, sock := startFakeFC(t)
+	c := New(sock)
+	ctx := context.Background()
+
+	if err := c.PutMachineConfig(ctx, MachineConfig{VCPUCount: 1, MemSizeMib: 1024}); err != nil {
+		t.Fatalf("PutMachineConfig: %v", err)
+	}
+	if err := c.PutBootSource(ctx, BootSource{KernelImagePath: "/opt/kata/vmlinux", BootArgs: "console=ttyS0"}); err != nil {
+		t.Fatalf("PutBootSource: %v", err)
+	}
+	if err := c.PutDrive(ctx, Drive{DriveID: "rootfs", PathOnHost: "/dev/mapper/x", IsRootDevice: true}); err != nil {
+		t.Fatalf("PutDrive: %v", err)
+	}
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	got := fake.paths()
+	want := []string{"PUT /machine-config", "PUT /boot-source", "PUT /drives/rootfs", "PUT /actions"}
+	if len(got) != len(want) {
+		t.Fatalf("paths = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("path[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestClientSnapshotLifecycle(t *testing.T) {
+	fake, sock := startFakeFC(t)
+	c := New(sock)
+	ctx := context.Background()
+
+	if err := c.Pause(ctx); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	if err := c.CreateSnapshot(ctx, SnapshotCreate{SnapshotPath: "/snap/snapfile", MemFilePath: "/snap/memfile"}); err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	if err := c.Resume(ctx); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	// Pause and Resume both PATCH /vm; assert the state values differ.
+	var states []string
+	var snap recordedReq
+	for _, r := range fake.requests {
+		if r.Path == "/vm" {
+			states = append(states, r.Body["state"].(string))
+		}
+		if r.Path == "/snapshot/create" {
+			snap = r
+		}
+	}
+	if len(states) != 2 || states[0] != "Paused" || states[1] != "Resumed" {
+		t.Fatalf("vm states = %v, want [Paused Resumed]", states)
+	}
+	if snap.Body["snapshot_path"] != "/snap/snapfile" || snap.Body["mem_file_path"] != "/snap/memfile" {
+		t.Fatalf("snapshot body = %v", snap.Body)
+	}
+}
+
+func TestClientLoadSnapshotResume(t *testing.T) {
+	fake, sock := startFakeFC(t)
+	c := New(sock)
+	if err := c.LoadSnapshot(context.Background(), SnapshotLoad{
+		SnapshotPath: "/snap/snapfile",
+		MemBackend:   &MemBackend{BackendType: "File", BackendPath: "/snap/memfile"},
+		ResumeVM:     true,
+	}); err != nil {
+		t.Fatalf("LoadSnapshot: %v", err)
+	}
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	r := fake.requests[0]
+	if r.Path != "/snapshot/load" || r.Body["resume_vm"] != true {
+		t.Fatalf("load body = %+v", r)
+	}
+	mb, ok := r.Body["mem_backend"].(map[string]any)
+	if !ok || mb["backend_type"] != "File" {
+		t.Fatalf("mem_backend = %v", r.Body["mem_backend"])
+	}
+}
+
+func TestClientPropagatesAPIError(t *testing.T) {
+	fake, sock := startFakeFC(t)
+	fake.failPath = "/actions"
+	c := New(sock)
+	err := c.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error from failing /actions")
+	}
+	if !contains(err.Error(), "status 400") || !contains(err.Error(), "boom") {
+		t.Fatalf("error = %v, want status 400 + fault message", err)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/projects/embervm/noded/image/BUILD
+++ b/projects/embervm/noded/image/BUILD
@@ -1,0 +1,43 @@
+# gazelle:ignore
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("//bazel/tools/oci:apko_image.bzl", "apko_image")
+
+# embervm-noded daemon container image. Built as an apko image (Wolfi base) rather
+# than a distroless go_image because it drives Firecracker guests as child
+# processes, mirroring the fc-invoke daemon it forks. AMD64-ONLY: node-4 is the
+# lone Firecracker node and is amd64, and FC snapshots are arch-affine, so no
+# aarch64 variant is built (apko_image arm64 = False). The Go binary is
+# cross-compiled for linux/amd64 and layered at /usr/local/bin/embervm-noded (the
+# apko entrypoint); @kata_firecracker bakes firecracker + the guest kernel at
+# /opt/fc so the node needs no /opt/kata install.
+
+platform_transition_filegroup(
+    name = "noded_amd64_bin",
+    srcs = ["//projects/embervm/noded/cmd:noded"],
+    target_platform = "@rules_go//go/toolchain:linux_amd64",
+)
+
+tar(
+    name = "noded_tar_amd64",
+    srcs = [":noded_amd64_bin"],
+    mtree = [
+        "./usr/local/bin/embervm-noded type=file content=$(execpath :noded_amd64_bin) mode=0755 uid=0 gid=0",
+    ],
+)
+
+apko_image(
+    name = "image",
+    # amd64-only: node-4 is the sole FC node and is amd64; FC snapshots are
+    # arch-affine, so :image is a single-platform amd64 image, not an index.
+    arm64 = False,
+    config = "apko.yaml",
+    contents = "@embervm_noded_lock//:contents",
+    # :noded_tar is the Go binary (multiarch_tars appends _amd64); @kata_firecracker
+    # bakes the firecracker binary + guest kernel into /opt/fc.
+    multiarch_tars = [
+        ":noded_tar",
+        "@kata_firecracker//:tar",
+    ],
+    repository = "ghcr.io/jomcgi/homelab/projects/embervm/noded/image",
+)

--- a/projects/embervm/noded/image/BUILD
+++ b/projects/embervm/noded/image/BUILD
@@ -5,12 +5,15 @@ load("//bazel/tools/oci:apko_image.bzl", "apko_image")
 
 # embervm-noded daemon container image. Built as an apko image (Wolfi base) rather
 # than a distroless go_image because it drives Firecracker guests as child
-# processes, mirroring the fc-invoke daemon it forks. AMD64-ONLY: node-4 is the
-# lone Firecracker node and is amd64, and FC snapshots are arch-affine, so no
-# aarch64 variant is built (apko_image arm64 = False). The Go binary is
-# cross-compiled for linux/amd64 and layered at /usr/local/bin/embervm-noded (the
-# apko entrypoint); @kata_firecracker bakes firecracker + the guest kernel at
-# /opt/fc so the node needs no /opt/kata install.
+# processes, mirroring the fc-invoke daemon it forks. DUAL-ARCH, exactly like the
+# fc-invoke daemon image: the Go binary is cross-compiled per arch and layered at
+# /usr/local/bin/embervm-noded (the apko entrypoint), and @kata_firecracker bakes
+# firecracker + the guest kernel at /opt/fc so the node needs no /opt/kata install.
+# node-4 (amd64) is the only Firecracker node today so the aarch64 manifest is
+# unused, but building it keeps this on apko's proven multiarch_tars path (the
+# amd64-only + multiarch_tars combination is an untested apko_image code path that
+# fails to push a layer blob). noded carries no arch-specific artifact, so dual-
+# arch is free.
 
 platform_transition_filegroup(
     name = "noded_amd64_bin",
@@ -26,15 +29,26 @@ tar(
     ],
 )
 
+platform_transition_filegroup(
+    name = "noded_arm64_bin",
+    srcs = ["//projects/embervm/noded/cmd:noded"],
+    target_platform = "@rules_go//go/toolchain:linux_arm64",
+)
+
+tar(
+    name = "noded_tar_arm64",
+    srcs = [":noded_arm64_bin"],
+    mtree = [
+        "./usr/local/bin/embervm-noded type=file content=$(execpath :noded_arm64_bin) mode=0755 uid=0 gid=0",
+    ],
+)
+
 apko_image(
     name = "image",
-    # amd64-only: node-4 is the sole FC node and is amd64; FC snapshots are
-    # arch-affine, so :image is a single-platform amd64 image, not an index.
-    arm64 = False,
     config = "apko.yaml",
     contents = "@embervm_noded_lock//:contents",
-    # :noded_tar is the Go binary (multiarch_tars appends _amd64); @kata_firecracker
-    # bakes the firecracker binary + guest kernel into /opt/fc.
+    # :noded_tar is the Go binary (multiarch_tars appends _amd64/_arm64 per arch);
+    # @kata_firecracker bakes the firecracker binary + guest kernel into /opt/fc.
     multiarch_tars = [
         ":noded_tar",
         "@kata_firecracker//:tar",

--- a/projects/embervm/noded/image/apko.lock.json
+++ b/projects/embervm/noded/image/apko.lock.json
@@ -2,7 +2,7 @@
   "version": "v1",
   "config": {
     "name": "apko.yaml",
-    "checksum": "sha256-tKbJoqjw9IZTRjt8zO85qDK3Ial4/aL29gqCDO36uMk="
+    "checksum": "sha256-cpbBXsti3deDnDLcgqJo3XnOiNW5aipmVluF2Xeia+w="
   },
   "contents": {
     "keyring": [
@@ -18,6 +18,11 @@
         "name": "packages.wolfi.dev/os/x86_64",
         "url": "https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz",
         "architecture": "x86_64"
+      },
+      {
+        "name": "packages.wolfi.dev/os/aarch64",
+        "url": "https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz",
+        "architecture": "aarch64"
       }
     ],
     "packages": [
@@ -191,6 +196,177 @@
           "checksum": "sha256-Lp5skr4+yaxDhdl+G39Z7VC8YLLcwNh+fGvRe0T6bj0="
         },
         "checksum": "Q1Dc1coU0swhMsnFh4BnVin4Y/z6U="
+      },
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1962",
+          "checksum": "sha1-FcjlR8BAUcyRjMQxsc/f5gWSv8I="
+        },
+        "data": {
+          "range": "bytes=1963-13980",
+          "checksum": "sha256-jYse4NUqE3SQbsor532PGqEhuLikUOl38/yf1PJA1nY="
+        },
+        "checksum": "Q1FcjlR8BAUcyRjMQxsc/f5gWSv8I="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20260413-r0.apk",
+        "version": "20260413-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7907",
+          "checksum": "sha1-YLGEH8o/PNCjR8sxoxh//AGpOgQ="
+        },
+        "data": {
+          "range": "bytes=7908-137552",
+          "checksum": "sha256-1NKuKrCJxco8aTxdlzNkEjM/4HyDXmO6sGOfSTiu8aE="
+        },
+        "checksum": "Q1YLGEH8o/PNCjR8sxoxh//AGpOgQ="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/aarch64/libgcc-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9968",
+          "checksum": "sha1-0/N/tQIIDrAIbJ8QA8/iMB2bmfU="
+        },
+        "data": {
+          "range": "bytes=9969-86427",
+          "checksum": "sha256-ECrE4xEgBQV3df1UklKqzMzpglmWfjLg9FsjCGK05lc="
+        },
+        "checksum": "Q10/N/tQIIDrAIbJ8QA8/iMB2bmfU="
+      },
+      {
+        "name": "glibc-locale-posix",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13058",
+          "checksum": "sha1-BIBCJGNefQ6OZhfH+yQAL1S3/bM="
+        },
+        "data": {
+          "range": "bytes=13059-89800",
+          "checksum": "sha256-CY8DYMdTEZQDdr0V9mSZy6OO+DzjhmSBZSD4dF/nK5s="
+        },
+        "checksum": "Q1BIBCJGNefQ6OZhfH+yQAL1S3/bM="
+      },
+      {
+        "name": "glibc",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13295",
+          "checksum": "sha1-iNjpwJYrlEf1vRh127vhMVvg6TI="
+        },
+        "data": {
+          "range": "bytes=13296-2235744",
+          "checksum": "sha256-K/MWiiI44ynr5ZGr3okL8Axmy+4VArr8y5zH6DYDRuk="
+        },
+        "checksum": "Q1iNjpwJYrlEf1vRh127vhMVvg6TI="
+      },
+      {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13092",
+          "checksum": "sha1-vqCKIZcxA7Bw0Sdk31ANMcX7SkE="
+        },
+        "data": {
+          "range": "bytes=13093-125752",
+          "checksum": "sha256-S1pHeMAxoXQpYYtqlbDdPoKu7tt5flTCAms4yNZv6NI="
+        },
+        "checksum": "Q1vqCKIZcxA7Bw0Sdk31ANMcX7SkE="
+      },
+      {
+        "name": "libxcrypt",
+        "url": "https://packages.wolfi.dev/os/aarch64/libxcrypt-4.5.2-r3.apk",
+        "version": "4.5.2-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8572",
+          "checksum": "sha1-ghgqrJg4iSn9gnlkDzpWMPFaymg="
+        },
+        "data": {
+          "range": "bytes=8573-104313",
+          "checksum": "sha256-XizRWLvfUizHwKzjGLYIFKzfDDehNmTY9yPgDFlLPS4="
+        },
+        "checksum": "Q1ghgqrJg4iSn9gnlkDzpWMPFaymg="
+      },
+      {
+        "name": "libcrypt1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13111",
+          "checksum": "sha1-Lc5RMEoBlR4TAJtUNiw9hlafq2g="
+        },
+        "data": {
+          "range": "bytes=13112-14724",
+          "checksum": "sha256-miwdByMJn6F2TDvzLLhMazBsP7eTM9okMUmceXVUaxM="
+        },
+        "checksum": "Q1Lc5RMEoBlR4TAJtUNiw9hlafq2g="
+      },
+      {
+        "name": "busybox",
+        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.37.0-r61.apk",
+        "version": "1.37.0-r61",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10947",
+          "checksum": "sha1-EeHjQ8oI9CX5Am00/gUwayfeglc="
+        },
+        "data": {
+          "range": "bytes=10948-429972",
+          "checksum": "sha256-TdoIXtUKXr9KtXVi4OBLcI3jzrea4+YQha1GxArzayI="
+        },
+        "checksum": "Q1EeHjQ8oI9CX5Am00/gUwayfeglc="
       }
     ]
   }

--- a/projects/embervm/noded/image/apko.lock.json
+++ b/projects/embervm/noded/image/apko.lock.json
@@ -1,0 +1,197 @@
+{
+  "version": "v1",
+  "config": {
+    "name": "apko.yaml",
+    "checksum": "sha256-tKbJoqjw9IZTRjt8zO85qDK3Ial4/aL29gqCDO36uMk="
+  },
+  "contents": {
+    "keyring": [
+      {
+        "name": "packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "url": "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"
+      }
+    ],
+    "build_repositories": [],
+    "runtime_repositories": [],
+    "repositories": [
+      {
+        "name": "packages.wolfi.dev/os/x86_64",
+        "url": "https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz",
+        "architecture": "x86_64"
+      }
+    ],
+    "packages": [
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1932",
+          "checksum": "sha1-mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+        },
+        "data": {
+          "range": "bytes=1933-13952",
+          "checksum": "sha256-5jOBVeXTWJEbL+Cnxj5Nu4klEL4SEB7IDMzT96rbkkA="
+        },
+        "checksum": "Q1mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20260413-r0.apk",
+        "version": "20260413-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7872",
+          "checksum": "sha1-KyCdEL20IKE+B7DKW97GLXu2QLM="
+        },
+        "data": {
+          "range": "bytes=7873-137518",
+          "checksum": "sha256-foyxNKCWc3UQM3Kq5on+Gt/2d+HlzCUl+1lqiaviWE8="
+        },
+        "checksum": "Q1KyCdEL20IKE+B7DKW97GLXu2QLM="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9951",
+          "checksum": "sha1-v4FvRKA29cOT2WtAXaWZBCzRXaU="
+        },
+        "data": {
+          "range": "bytes=9952-105490",
+          "checksum": "sha256-ExYZSr5G/sH+fzFe+TjVUTTj/GQ1Qbjx8MMEh+6ZxE0="
+        },
+        "checksum": "Q1v4FvRKA29cOT2WtAXaWZBCzRXaU="
+      },
+      {
+        "name": "glibc-locale-posix",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13015",
+          "checksum": "sha1-npirsSp9Qt3Aa1n8CaC2i99nv8A="
+        },
+        "data": {
+          "range": "bytes=13016-89758",
+          "checksum": "sha256-qXzcGBEELIJays9BPEo77JB6Qr5gMKFbZteJHEuthAI="
+        },
+        "checksum": "Q1npirsSp9Qt3Aa1n8CaC2i99nv8A="
+      },
+      {
+        "name": "glibc",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13257",
+          "checksum": "sha1-XSTHGW6PUOUepKQvlUCPEpu+my0="
+        },
+        "data": {
+          "range": "bytes=13258-3077429",
+          "checksum": "sha256-C538Z51QWuZPy/fxQGBCBbpulG8dVbn1OeaW+JsKoXQ="
+        },
+        "checksum": "Q1XSTHGW6PUOUepKQvlUCPEpu+my0="
+      },
+      {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13051",
+          "checksum": "sha1-Dc94e4JF2fG8/SX4PWCAtLjItu4="
+        },
+        "data": {
+          "range": "bytes=13052-147283",
+          "checksum": "sha256-oI72DIuJLqlUM/LSFYKdgbxsaYUZgfThezkV95CHQPk="
+        },
+        "checksum": "Q1Dc94e4JF2fG8/SX4PWCAtLjItu4="
+      },
+      {
+        "name": "libxcrypt",
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.5.2-r3.apk",
+        "version": "4.5.2-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8536",
+          "checksum": "sha1-I0YlF5JXljMqn3nnsq4AWUw6X/8="
+        },
+        "data": {
+          "range": "bytes=8537-106099",
+          "checksum": "sha256-mzRytDzhPafMZpD3kpn03C6x2XCNuG0nZ1F3Bjo+Jx4="
+        },
+        "checksum": "Q1I0YlF5JXljMqn3nnsq4AWUw6X/8="
+      },
+      {
+        "name": "libcrypt1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13067",
+          "checksum": "sha1-/MS3Zb1Y/+sboqr3bltHEFCEkqE="
+        },
+        "data": {
+          "range": "bytes=13068-14685",
+          "checksum": "sha256-ePacrwddp1Us3l5Rg2i8ieOZi17FUQjiVMtw2syPQBE="
+        },
+        "checksum": "Q1/MS3Zb1Y/+sboqr3bltHEFCEkqE="
+      },
+      {
+        "name": "busybox",
+        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.37.0-r61.apk",
+        "version": "1.37.0-r61",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10913",
+          "checksum": "sha1-Dc1coU0swhMsnFh4BnVin4Y/z6U="
+        },
+        "data": {
+          "range": "bytes=10914-430452",
+          "checksum": "sha256-Lp5skr4+yaxDhdl+G39Z7VC8YLLcwNh+fGvRe0T6bj0="
+        },
+        "checksum": "Q1Dc1coU0swhMsnFh4BnVin4Y/z6U="
+      }
+    ]
+  }
+}

--- a/projects/embervm/noded/image/apko.yaml
+++ b/projects/embervm/noded/image/apko.yaml
@@ -5,10 +5,14 @@
 # @kata_firecracker bundle, so node-4 needs no /opt/kata install: it only provides
 # /dev/kvm and the nvme scratch dir (see projects/platform/firecracker-node).
 #
-# AMD64-ONLY: node-4 is the sole Firecracker node and is amd64, and FC snapshots
-# are arch-affine, so an aarch64 image no node could run would be dead weight.
-# This matches the embervm control image's amd64-only choice; if an arm64 FC node
-# ever joins, flip archs + apko_image(arm64=True) and rebuild the lock.
+# DUAL-ARCH, mirroring the fc-invoke daemon image this forks: the daemon binary is
+# pure Go (cross-compiles cleanly) and @kata_firecracker ships both arches, so the
+# image is a multi-arch index exactly like fc-invoke's. node-4 is amd64 and is the
+# only Firecracker node today, so the aarch64 manifest is currently unused, but
+# building it keeps this on the proven apko multiarch_tars path (the amd64-only +
+# multiarch_tars combination is an untested apko_image code path). Unlike the
+# embervm CONTROL image (amd64-only because exqlite ships an arch-specific NIF),
+# noded carries no arch-specific artifact, so dual-arch is free and lower-risk.
 #
 # LEAN by design: the daemon's driver boots one shared rootfs READ-ONLY per
 # microVM (the fc-invoke warm-base pattern, provisioner disabled), so it never
@@ -26,6 +30,7 @@ contents:
 
 archs:
   - x86_64
+  - aarch64
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/projects/embervm/noded/image/apko.yaml
+++ b/projects/embervm/noded/image/apko.yaml
@@ -1,0 +1,34 @@
+# Runtime image for the embervm-noded daemon. Wolfi base with ca-certificates
+# (TLS to the in-cluster apiserver / OTLP) and busybox (a shell for in-pod
+# debugging). The Go daemon binary is layered at /usr/local/bin/embervm-noded and
+# the firecracker binary + guest kernel are baked at /opt/fc from the
+# @kata_firecracker bundle, so node-4 needs no /opt/kata install: it only provides
+# /dev/kvm and the nvme scratch dir (see projects/platform/firecracker-node).
+#
+# AMD64-ONLY: node-4 is the sole Firecracker node and is amd64, and FC snapshots
+# are arch-affine, so an aarch64 image no node could run would be dead weight.
+# This matches the embervm control image's amd64-only choice; if an arm64 FC node
+# ever joins, flip archs + apko_image(arm64=True) and rebuild the lock.
+#
+# LEAN by design: the daemon's driver boots one shared rootfs READ-ONLY per
+# microVM (the fc-invoke warm-base pattern, provisioner disabled), so it never
+# execs dmsetup. The devmapper CoW provisioner (ADR 026) is dead code at runtime
+# here; if it is ever enabled for noded, add lvm2 + util-linux back (fc-invoke's
+# base carries them for that mode).
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - ca-certificates-bundle
+    - busybox
+
+archs:
+  - x86_64
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+entrypoint:
+  command: /usr/local/bin/embervm-noded

--- a/projects/embervm/noded/server/BUILD
+++ b/projects/embervm/noded/server/BUILD
@@ -1,0 +1,35 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "server",
+    srcs = [
+        "registry.go",
+        "server.go",
+    ],
+    importpath = "github.com/jomcgi/homelab/projects/embervm/noded/server",
+    visibility = ["//projects/embervm/noded:__subpackages__"],
+    deps = [
+        "//projects/embervm/noded/config",
+        "//projects/embervm/noded/substrate",
+        "//projects/embervm/proto/embervm/node/v1:nodev1",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)
+
+go_test(
+    name = "server_test",
+    srcs = ["server_test.go"],
+    embed = [":server"],
+    deps = [
+        "//projects/embervm/noded/config",
+        "//projects/embervm/noded/substrate",
+        "//projects/embervm/proto/embervm/node/v1:nodev1",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//credentials/insecure",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_grpc//test/bufconn",
+    ],
+)

--- a/projects/embervm/noded/server/registry.go
+++ b/projects/embervm/noded/server/registry.go
@@ -1,0 +1,239 @@
+package server
+
+import (
+	"sync"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
+)
+
+// vmState is the lifecycle of a primed microVM in the daemon's registry. Task
+// VMs are single-use: a VM is Primed until an Assign claims it, after which it is
+// Assigned and then destroyed (removed from the registry). There is no path back
+// to Primed - reuse across principals is forbidden by the contract.
+type vmState int
+
+const (
+	vmPrimed   vmState = iota // parked, pristine, unassigned
+	vmAssigned                // an Assign has claimed it; single-use in flight
+)
+
+// vmEntry is one live microVM the daemon supervises. Teardown is single-owned by
+// registry removal: Assign and Destroy both remove() the entry before reaping,
+// and the registry lock hands the non-nil entry to exactly one of them, so a
+// racing Destroy and the single-use Assign teardown can never double-Release one
+// VM (see Server.reap).
+type vmEntry struct {
+	id           string
+	workload     string
+	snapshotRef  string
+	handle       substrate.Handle
+	egressCancel func()
+
+	mu    sync.Mutex // guards state
+	state vmState
+}
+
+// vmRegistry is the daemon's inventory of primed/assigned microVMs, keyed by the
+// opaque vm_id the control plane holds. It is the authority for free-primed-slot
+// capacity and the single-use Assign transition.
+type vmRegistry struct {
+	mu  sync.Mutex
+	vms map[string]*vmEntry
+}
+
+func newVMRegistry() *vmRegistry {
+	return &vmRegistry{vms: make(map[string]*vmEntry)}
+}
+
+// add registers a freshly primed VM.
+func (r *vmRegistry) add(e *vmEntry) {
+	r.mu.Lock()
+	r.vms[e.id] = e
+	r.mu.Unlock()
+}
+
+// claimForAssign atomically transitions a primed VM to assigned and returns it.
+// It returns (nil,false) when the id is unknown or not primed, which is exactly
+// the "already-assigned or destroyed vm_id" case Assign must reject with
+// FAILED_PRECONDITION and NO side effects: the caller does nothing else on a
+// false result, so the VM is never touched and no second task can run. The entry
+// stays in the map so a racing Destroy can still find and reap it; Assign removes
+// it when its single use completes.
+func (r *vmRegistry) claimForAssign(id string) (*vmEntry, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e, ok := r.vms[id]
+	if !ok {
+		return nil, false
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.state != vmPrimed {
+		return nil, false
+	}
+	e.state = vmAssigned
+	return e, true
+}
+
+// remove deletes an id from the map and returns its entry (nil if absent). Used
+// by Assign's single-use teardown and by Destroy's idempotent reap.
+func (r *vmRegistry) remove(id string) *vmEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e := r.vms[id]
+	delete(r.vms, id)
+	return e
+}
+
+// capacity reports the count of PRIMED (unassigned) VMs per workload and the
+// total number of live VMs (primed + assigning). The control plane reads the
+// primed counts as free_primed_slots.
+func (r *vmRegistry) capacity() (primedPerWorkload map[string]uint32, live int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	primedPerWorkload = make(map[string]uint32)
+	for _, e := range r.vms {
+		e.mu.Lock()
+		if e.state == vmPrimed {
+			primedPerWorkload[e.workload]++
+		}
+		e.mu.Unlock()
+	}
+	return primedPerWorkload, len(r.vms)
+}
+
+// liveCount is the current number of supervised VMs, for the node-level backstop
+// cap check in Prime.
+func (r *vmRegistry) liveCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.vms)
+}
+
+// baseEntry records the daemon's knowledge of one built (or building/failed)
+// base snapshot, keyed by its snapshot_ref (== the driver base key). It is what
+// BuildBase records for idempotency and what WatchNode reports so the control
+// plane reconciles existing bases instead of rebuilding.
+type baseEntry struct {
+	snapshotRef string
+	workload    string
+	imageDigest string
+	sizeBytes   int64
+	readyPath   string
+	state       nodev1.BaseBuildState
+	buildErr    string
+}
+
+// baseRegistry tracks base build state per snapshot_ref. It survives across a VM
+// pool being drained (bases are node-local snapshot files, not tied to any live
+// VM) and is repopulated from disk on daemon start.
+type baseRegistry struct {
+	mu    sync.Mutex
+	bases map[string]*baseEntry
+}
+
+func newBaseRegistry() *baseRegistry {
+	return &baseRegistry{bases: make(map[string]*baseEntry)}
+}
+
+// get returns a copy of the base entry for a snapshot_ref.
+func (b *baseRegistry) get(ref string) (baseEntry, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	e, ok := b.bases[ref]
+	if !ok {
+		return baseEntry{}, false
+	}
+	return *e, true
+}
+
+// beginBuild marks a base BUILDING. It returns false if a build for this key is
+// already in progress (BUILDING), so BuildBase serializes per key without
+// blocking. A READY or FAILED entry is re-driven (a rebuild after failure, or a
+// forced rebuild) - the READY idempotency short-circuit is checked by the caller
+// before beginBuild.
+func (b *baseRegistry) beginBuild(ref, workload, readyPath string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if e, ok := b.bases[ref]; ok && e.state == nodev1.BaseBuildState_BASE_BUILD_STATE_BUILDING {
+		return false
+	}
+	b.bases[ref] = &baseEntry{
+		snapshotRef: ref,
+		workload:    workload,
+		readyPath:   readyPath,
+		state:       nodev1.BaseBuildState_BASE_BUILD_STATE_BUILDING,
+	}
+	return true
+}
+
+// readyBuild records a completed base build.
+func (b *baseRegistry) readyBuild(ref, workload, imageDigest, readyPath string, sizeBytes int64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.bases[ref] = &baseEntry{
+		snapshotRef: ref,
+		workload:    workload,
+		imageDigest: imageDigest,
+		sizeBytes:   sizeBytes,
+		readyPath:   readyPath,
+		state:       nodev1.BaseBuildState_BASE_BUILD_STATE_READY,
+	}
+}
+
+// failBuild records a failed base build with its error, surfaced in NodeStatus.
+func (b *baseRegistry) failBuild(ref, buildErr string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if e, ok := b.bases[ref]; ok {
+		e.state = nodev1.BaseBuildState_BASE_BUILD_STATE_FAILED
+		e.buildErr = buildErr
+		return
+	}
+	b.bases[ref] = &baseEntry{
+		snapshotRef: ref,
+		state:       nodev1.BaseBuildState_BASE_BUILD_STATE_FAILED,
+		buildErr:    buildErr,
+	}
+}
+
+// register records a base discovered on disk at startup (state READY) so the
+// control plane reconciles rather than rebuilding.
+func (b *baseRegistry) register(e baseEntry) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.bases[e.snapshotRef] = &baseEntry{
+		snapshotRef: e.snapshotRef,
+		workload:    e.workload,
+		imageDigest: e.imageDigest,
+		sizeBytes:   e.sizeBytes,
+		readyPath:   e.readyPath,
+		state:       e.state,
+	}
+}
+
+// snapshot returns a copy of all base entries, for building NodeStatus.
+func (b *baseRegistry) snapshot() []baseEntry {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]baseEntry, 0, len(b.bases))
+	for _, e := range b.bases {
+		out = append(out, *e)
+	}
+	return out
+}
+
+// firstBuildError returns the build error of any FAILED base (for the
+// NodeStatus.build_error field), or "".
+func (b *baseRegistry) firstBuildError() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, e := range b.bases {
+		if e.state == nodev1.BaseBuildState_BASE_BUILD_STATE_FAILED && e.buildErr != "" {
+			return e.buildErr
+		}
+	}
+	return ""
+}

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1,0 +1,741 @@
+// Package server implements the embervm.node.v1 NodeService: the gRPC face of
+// embervm-noded. It is the reshaped fork of fc-invoke's node/invoker - the same
+// single-use Firecracker lifecycle (cold boot -> health-gate -> snapshot; restore
+// -> park; deliver one vsock HTTP task -> destroy), re-cut behind the Task 3 gRPC
+// contract instead of an HTTP reverse proxy.
+//
+// What the fork drops from the invoker: the per-workload semaphore (concurrency
+// is the control plane's; the daemon keeps only a node-level max-live-VM
+// backstop), the warm-base auto-build-at-startup (base builds are BuildBase RPCs
+// now), path-based sessions, and the lazy HTTP response-streaming ownership
+// (Assign reads the guest body whole because the VM is destroyed immediately
+// after, so there is nothing to stream over).
+//
+// What the fork keeps: the fcvm driver's Claim/SnapshotBase/Release lifecycle,
+// the vsockhttp transport with its per-attempt WaitReady cap and short restore
+// budget, the read-only-rootfs + tmpfs guest conventions, and the egress
+// forwarder (present but unused: task VMs get no NIC, egress disabled).
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/config"
+	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
+)
+
+const (
+	// maxGuestResponseBytes caps how much of a guest response body the daemon
+	// buffers before destroying the VM. The submit API caps the request body at
+	// 8 MiB; responses are bounded generously here so a runaway guest cannot pin
+	// daemon memory.
+	maxGuestResponseBytes = 32 << 20
+	// defaultInvokePath is the guest path an Assign POSTs to when the request
+	// carries none. The contract defaults path to the workload invokePath; the
+	// daemon does not hold the workload table, so it uses the frozen guest
+	// convention and the control plane overrides per task.
+	defaultInvokePath = "/invoke"
+	// defaultAssignTimeout bounds a guest round-trip when the AssignRequest sets
+	// timeout_ms to zero.
+	defaultAssignTimeout = 90 * time.Second
+	// livenessInterval is how often WatchNode re-sends NodeStatus absent any
+	// material change. It is below the control plane's 5s "unknown" ageing window
+	// so a healthy node never looks stale.
+	livenessInterval = 2 * time.Second
+)
+
+// vmDriver is the subset of the fcvm driver the restore/assign/destroy paths
+// need. The real *driver.Driver satisfies it; tests inject a fake.
+type vmDriver interface {
+	// Claim restores a microVM from spec.BaseSnapshotRef (Prime always restores).
+	Claim(ctx context.Context, spec substrate.ClaimSpec) (substrate.Handle, error)
+	// Release kills the microVM process, reclaiming its memory.
+	Release(ctx context.Context, h substrate.Handle) error
+	// RemoveBundle deletes the microVM's on-disk bundle dir.
+	RemoveBundle(threadID string) error
+	// VsockUDSPath is the host UDS backing a thread's vsock device.
+	VsockUDSPath(threadID string) string
+	// Stats reads the guest's /proc counters; must be called while it is alive.
+	Stats(h substrate.Handle) (substrate.GuestStats, error)
+	// LiveCount is how many microVMs the driver is supervising (backstop cap).
+	LiveCount() int
+}
+
+// BuildDriver is the subset a BuildBase cold boot + snapshot needs. It is a
+// separate seam because each base build runs on a driver configured for that
+// image's rootfs and sizing (cold boot uses them; restore ignores them), whereas
+// the shared vmDriver only ever restores. Exported so the daemon entrypoint can
+// name it as the return type of the build-driver factory.
+type BuildDriver interface {
+	Claim(ctx context.Context, spec substrate.ClaimSpec) (substrate.Handle, error)
+	SnapshotBase(ctx context.Context, h substrate.Handle, baseKey string) (substrate.SnapshotRef, error)
+	Release(ctx context.Context, h substrate.Handle) error
+	RemoveBundle(threadID string) error
+	VsockUDSPath(threadID string) string
+}
+
+// transport is the host-side HTTP-over-vsock client (the forked vsockhttp
+// Transport). Tests inject a fake.
+type transport interface {
+	WaitReady(ctx context.Context, udsPath, readyPath string) error
+	Prime(ctx context.Context, udsPath string) error
+	RoundTrip(ctx context.Context, udsPath string, req *http.Request) (*http.Response, error)
+}
+
+// BuildDriverSpec parameterises a per-image cold-boot driver.
+type BuildDriverSpec struct {
+	RootfsPath  string
+	HarnessInit string
+	VCPUs       int
+	MemMib      int
+}
+
+// Server implements nodev1.NodeServiceServer.
+type Server struct {
+	nodev1.UnimplementedNodeServiceServer
+
+	cfg       config.Config
+	driver    vmDriver
+	transport transport
+	// newBuildDriver builds a cold-boot driver for one image's rootfs+sizing.
+	// nil disables BuildBase (used by tests that only exercise Prime/Assign).
+	newBuildDriver func(BuildDriverSpec) BuildDriver
+	logger         *slog.Logger
+
+	// memHeadroom reads free guest memory in MiB (cgroup v2, best-effort).
+	// Overridable in tests.
+	memHeadroom func() uint64
+
+	vms   *vmRegistry
+	bases *baseRegistry
+
+	drainingMu sync.RWMutex
+	draining   bool
+
+	subMu sync.Mutex
+	subs  map[chan struct{}]struct{}
+}
+
+// Options configures a Server.
+type Options struct {
+	Config         config.Config
+	Driver         vmDriver
+	Transport      transport
+	NewBuildDriver func(BuildDriverSpec) BuildDriver
+	Logger         *slog.Logger
+}
+
+// New builds a Server. Driver and Transport must not be nil.
+func New(opts Options) *Server {
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	s := &Server{
+		cfg:            opts.Config,
+		driver:         opts.Driver,
+		transport:      opts.Transport,
+		newBuildDriver: opts.NewBuildDriver,
+		logger:         logger,
+		vms:            newVMRegistry(),
+		bases:          newBaseRegistry(),
+		subs:           make(map[chan struct{}]struct{}),
+	}
+	s.memHeadroom = readMemHeadroomMib
+	return s
+}
+
+var _ nodev1.NodeServiceServer = (*Server)(nil)
+
+// ---- BuildBase -------------------------------------------------------------
+
+// BuildBase resolves the image to its node-side rootfs, cold-boots a guest,
+// health-gates it on the ready path, and snapshots it into a base bundle. It is
+// idempotent per (image_ref, workload_revision): a repeat call for an already
+// READY base returns the existing snapshot_ref without rebuilding.
+func (s *Server) BuildBase(ctx context.Context, req *nodev1.BuildBaseRequest) (*nodev1.BuildBaseResponse, error) {
+	if s.isDraining() {
+		return nil, status.Error(codes.Unavailable, "noded: draining")
+	}
+	if s.newBuildDriver == nil {
+		return nil, status.Error(codes.Unimplemented, "noded: base building not configured")
+	}
+	imageRef := req.GetImageRef()
+	if imageRef == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: image_ref required")
+	}
+	workload := req.GetTrace().GetWorkload()
+	img, ok := s.cfg.Images[imageRef]
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: image %q not provisioned on this node", imageRef)
+	}
+	baseKey := baseKeyFor(workload, imageRef, req.GetWorkloadRevision())
+	readyPath := req.GetReadyPath()
+	if readyPath == "" {
+		readyPath = defaultReadyPath
+	}
+
+	// Idempotency: an already-built base is a no-op hit.
+	if existing, ok := s.bases.get(baseKey); ok && existing.state == nodev1.BaseBuildState_BASE_BUILD_STATE_READY {
+		return &nodev1.BuildBaseResponse{
+			SnapshotRef:   existing.snapshotRef,
+			ImageDigest:   existing.imageDigest,
+			BaseSizeBytes: uint64(existing.sizeBytes),
+			Arch:          s.cfg.Arch,
+			AlreadyBuilt:  true,
+		}, nil
+	}
+	// Serialize builds per key. A concurrent duplicate is rejected rather than
+	// double-booting a build guest.
+	if !s.bases.beginBuild(baseKey, workload, readyPath) {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: base build already in progress for %q", baseKey)
+	}
+	s.signalChange()
+
+	harnessInit := img.HarnessInit
+	if harnessInit == "" {
+		harnessInit = s.cfg.HarnessInit
+	}
+	res := req.GetResources()
+	bd := s.newBuildDriver(BuildDriverSpec{
+		RootfsPath:  img.RootfsPath,
+		HarnessInit: harnessInit,
+		VCPUs:       int(res.GetVcpus()),
+		MemMib:      int(res.GetMemMib()),
+	})
+
+	sizeBytes, err := s.runBuild(ctx, bd, baseKey, readyPath)
+	if err != nil {
+		s.bases.failBuild(baseKey, err.Error())
+		s.signalChange()
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: build base %q: %v", baseKey, err)
+	}
+	// The control plane records the resolved image identity; without an OCI pull
+	// the ref IS the identity for R0 (deploys are digest-pinned upstream).
+	imageDigest := imageRef
+	s.bases.readyBuild(baseKey, workload, imageDigest, readyPath, sizeBytes)
+	s.signalChange()
+	return &nodev1.BuildBaseResponse{
+		SnapshotRef:   baseKey,
+		ImageDigest:   imageDigest,
+		BaseSizeBytes: uint64(sizeBytes),
+		Arch:          s.cfg.Arch,
+		AlreadyBuilt:  false,
+	}, nil
+}
+
+// runBuild cold-boots a build guest, waits for readiness, snapshots it into the
+// base bundle, and always discards the build VM (the base lives in the bundle).
+func (s *Server) runBuild(ctx context.Context, bd BuildDriver, baseKey, readyPath string) (int64, error) {
+	spec := substrate.ClaimSpec{Arch: s.cfg.Arch, ThreadID: newID("build")}
+	h, err := bd.Claim(ctx, spec)
+	if err != nil {
+		return 0, fmt.Errorf("cold boot: %w", err)
+	}
+	defer func() {
+		if rerr := bd.Release(context.Background(), h); rerr != nil {
+			s.logger.Warn("noded: release build guest", "base", baseKey, "err", rerr)
+		}
+		if rerr := bd.RemoveBundle(h.ThreadID); rerr != nil {
+			s.logger.Warn("noded: remove build bundle", "base", baseKey, "err", rerr)
+		}
+	}()
+
+	readyCtx, cancel := context.WithTimeout(ctx, s.cfg.BootReadyTimeout)
+	defer cancel()
+	if err := s.transport.WaitReady(readyCtx, bd.VsockUDSPath(h.ThreadID), readyPath); err != nil {
+		return 0, fmt.Errorf("guest readiness: %w", err)
+	}
+	ref, err := bd.SnapshotBase(ctx, h, baseKey)
+	if err != nil {
+		return 0, fmt.Errorf("snapshot: %w", err)
+	}
+	return ref.SizeBytes, nil
+}
+
+// ---- Prime -----------------------------------------------------------------
+
+// Prime restores one pristine VM from snapshot_ref, waits for the guest ready
+// path, and parks it idle. It enforces the node-level live-VM backstop cap.
+func (s *Server) Prime(ctx context.Context, req *nodev1.PrimeRequest) (*nodev1.PrimeResponse, error) {
+	if s.isDraining() {
+		return nil, status.Error(codes.Unavailable, "noded: draining")
+	}
+	ref := req.GetSnapshotRef()
+	if ref == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: snapshot_ref required")
+	}
+	if s.cfg.MaxLiveVMs > 0 && s.driver.LiveCount() >= s.cfg.MaxLiveVMs {
+		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.cfg.MaxLiveVMs)
+	}
+	base, ok := s.bases.get(ref)
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: unknown snapshot_ref %q", ref)
+	}
+	if base.state != nodev1.BaseBuildState_BASE_BUILD_STATE_READY {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: base %q not ready (state %s)", ref, base.state)
+	}
+	readyPath := base.readyPath
+	if readyPath == "" {
+		readyPath = defaultReadyPath
+	}
+
+	spec := substrate.ClaimSpec{
+		Arch:     s.cfg.Arch,
+		ThreadID: newID("vm"),
+		BaseSnapshotRef: substrate.SnapshotRef{
+			ID:   ref,
+			Node: s.cfg.Node,
+			Arch: s.cfg.Arch,
+			Base: true,
+		},
+	}
+	h, err := s.driver.Claim(ctx, spec)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: restore snapshot %q: %v", ref, err)
+	}
+	uds := s.driver.VsockUDSPath(h.ThreadID)
+
+	// Shake out Firecracker's post-restore vsock RX-queue race off the readiness
+	// path (best-effort), then health-gate on the short restore budget.
+	primeCtx, cancelPrime := context.WithTimeout(ctx, s.cfg.RestoreReadyTimeout)
+	if perr := s.transport.Prime(primeCtx, uds); perr != nil {
+		s.logger.Warn("noded: vsock prime did not complete; readiness poll will retry past the race", "vm", h.ID, "err", perr)
+	}
+	cancelPrime()
+
+	readyCtx, cancelReady := context.WithTimeout(ctx, s.cfg.RestoreReadyTimeout)
+	readyErr := s.transport.WaitReady(readyCtx, uds, readyPath)
+	cancelReady()
+	if readyErr != nil {
+		// A restore that never health-gates is discarded; the control plane
+		// degrades to a slower boot, never to incorrect behavior.
+		s.reap(h, func() {})
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: restored guest not ready: %v", readyErr)
+	}
+
+	s.vms.add(&vmEntry{
+		id:           h.ID,
+		workload:     base.workload,
+		snapshotRef:  ref,
+		handle:       h,
+		egressCancel: func() {},
+		state:        vmPrimed,
+	})
+	s.signalChange()
+	return &nodev1.PrimeResponse{VmId: h.ID}, nil
+}
+
+// ---- Assign ----------------------------------------------------------------
+
+// Assign delivers exactly one HTTP task to a primed vm_id over vsock, returns the
+// guest response plus usage stats, and DESTROYS the VM regardless of outcome.
+// Assign on an unknown/already-used vm_id fails FAILED_PRECONDITION with no side
+// effects.
+func (s *Server) Assign(ctx context.Context, req *nodev1.AssignRequest) (*nodev1.AssignResponse, error) {
+	vmID := req.GetVmId()
+	e, ok := s.vms.claimForAssign(vmID)
+	if !ok {
+		// Unknown or not primed: no VM is touched, no second task runs.
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: vm %q not assignable (unknown, already assigned, or destroyed)", vmID)
+	}
+	// Single-use: destroy the VM after this call regardless of outcome. Reap only
+	// if THIS defer is the one that removes the entry from the registry: an out-of-
+	// band Destroy racing this Assign may remove-and-reap first (killing the VM
+	// mid-round-trip, which just fails this Assign), and map removal under the
+	// registry lock guarantees exactly one caller gets the non-nil entry, so the VM
+	// is never Released twice.
+	defer func() {
+		if removed := s.vms.remove(vmID); removed != nil {
+			s.reap(removed.handle, removed.egressCancel)
+		}
+		s.signalChange()
+	}()
+
+	gr := req.GetRequest()
+	method := gr.GetMethod()
+	if method == "" {
+		method = http.MethodPost
+	}
+	path := gr.GetPath()
+	if path == "" {
+		path = defaultInvokePath
+	}
+	timeout := time.Duration(req.GetTimeoutMs()) * time.Millisecond
+	if timeout <= 0 {
+		timeout = defaultAssignTimeout
+	}
+	rtCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(rtCtx, method, "http://vsock"+path, bytes.NewReader(gr.GetBody()))
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "noded: build guest request: %v", err)
+	}
+	for k, v := range gr.GetHeaders() {
+		httpReq.Header.Set(k, v)
+	}
+
+	uds := s.driver.VsockUDSPath(e.handle.ThreadID)
+	t0 := time.Now()
+	resp, err := s.transport.RoundTrip(rtCtx, uds, httpReq)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || rtCtx.Err() == context.DeadlineExceeded {
+			return nil, status.Errorf(codes.DeadlineExceeded, "noded: guest did not respond within %s", timeout)
+		}
+		return nil, status.Errorf(codes.Unavailable, "noded: guest round-trip: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxGuestResponseBytes))
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "noded: read guest response: %v", err)
+	}
+	wallMs := time.Since(t0).Milliseconds()
+
+	// Sample the guest's whole-invocation /proc counters while it is still alive
+	// (the deferred reap kills it after this returns). Best-effort.
+	usage := &nodev1.UsageStats{WallMs: wallMs}
+	if stats, serr := s.driver.Stats(e.handle); serr == nil {
+		usage.CpuMs = stats.CPUMillis
+		usage.PeakRssMib = stats.PeakRSSMib
+	} else {
+		s.logger.Debug("noded: guest stats unavailable", "vm", vmID, "err", serr)
+	}
+
+	return &nodev1.AssignResponse{
+		Response: &nodev1.GuestResponse{
+			StatusCode: uint32(resp.StatusCode),
+			Headers:    flattenHeaders(resp.Header),
+			Body:       body,
+		},
+		Usage: usage,
+	}, nil
+}
+
+// ---- Destroy ---------------------------------------------------------------
+
+// Destroy reaps a primed or wedged VM out of band. Idempotent: an unknown or
+// already-destroyed vm_id returns OK (the desired end-state already holds).
+func (s *Server) Destroy(_ context.Context, req *nodev1.DestroyRequest) (*nodev1.DestroyResponse, error) {
+	if e := s.vms.remove(req.GetVmId()); e != nil {
+		s.reap(e.handle, e.egressCancel)
+		s.signalChange()
+	}
+	return &nodev1.DestroyResponse{}, nil
+}
+
+// ---- Node status -----------------------------------------------------------
+
+// GetNodeStatus is the unary snapshot of the capacity facts WatchNode streams.
+func (s *Server) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusRequest) (*nodev1.NodeStatus, error) {
+	ns := s.nodeStatus()
+	// Echo the caller's node_id when it set one, for its own correlation.
+	if id := req.GetNodeId(); id != "" {
+		ns.NodeId = id
+	}
+	return ns, nil
+}
+
+// WatchNode streams NodeStatus: an initial snapshot immediately, then on every
+// material change and at a liveness interval, until the client disconnects.
+func (s *Server) WatchNode(req *nodev1.WatchNodeRequest, stream grpc.ServerStreamingServer[nodev1.NodeStatus]) error {
+	send := func() error {
+		ns := s.nodeStatus()
+		if id := req.GetNodeId(); id != "" {
+			ns.NodeId = id
+		}
+		return stream.Send(ns)
+	}
+	if err := send(); err != nil {
+		return err
+	}
+	ch := s.subscribe()
+	defer s.unsubscribe(ch)
+	ticker := time.NewTicker(livenessInterval)
+	defer ticker.Stop()
+	ctx := stream.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err() // nosemgrep: no-bare-error-return
+		case <-ticker.C:
+			if err := send(); err != nil {
+				return err
+			}
+		case <-ch:
+			if err := send(); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// nodeStatus assembles the current capacity fact set.
+func (s *Server) nodeStatus() *nodev1.NodeStatus {
+	primed, live := s.vms.capacity()
+	caps := s.workloadCapacities(primed)
+	maxLive := s.cfg.MaxLiveVMs
+	if maxLive < 0 {
+		maxLive = 0
+	}
+	return &nodev1.NodeStatus{
+		NodeId:                s.cfg.Node,
+		Workloads:             caps,
+		MemHeadroomMib:        s.memHeadroom(),
+		CpuHeadroomMillicores: 0, // TODO(task11): report cgroup cpu headroom
+		LiveVms:               uint32(live),
+		MaxLiveVms:            uint32(maxLive),
+		Draining:              s.isDraining(),
+		BuildError:            s.bases.firstBuildError(),
+	}
+}
+
+// workloadCapacities merges primed-slot counts with base build state per
+// workload. Every workload that has a base OR primed VMs gets one entry.
+func (s *Server) workloadCapacities(primed map[string]uint32) []*nodev1.WorkloadCapacity {
+	byWorkload := make(map[string]*nodev1.WorkloadCapacity)
+	get := func(wl string) *nodev1.WorkloadCapacity {
+		c, ok := byWorkload[wl]
+		if !ok {
+			c = &nodev1.WorkloadCapacity{
+				Workload:  wl,
+				BaseState: nodev1.BaseBuildState_BASE_BUILD_STATE_NONE,
+			}
+			byWorkload[wl] = c
+		}
+		return c
+	}
+	for _, b := range s.bases.snapshot() {
+		c := get(b.workload)
+		c.SnapshotRef = b.snapshotRef
+		c.BaseState = b.state
+	}
+	for wl, n := range primed {
+		get(wl).FreePrimedSlots = n
+	}
+	out := make([]*nodev1.WorkloadCapacity, 0, len(byWorkload))
+	for _, c := range byWorkload {
+		out = append(out, c)
+	}
+	return out
+}
+
+// ---- drain + change notification -------------------------------------------
+
+// SetDraining marks the daemon draining so WatchNode reports draining=true and
+// new BuildBase/Prime calls are rejected. Called on SIGTERM before GracefulStop.
+func (s *Server) SetDraining() {
+	s.drainingMu.Lock()
+	s.draining = true
+	s.drainingMu.Unlock()
+	s.signalChange()
+}
+
+func (s *Server) isDraining() bool {
+	s.drainingMu.RLock()
+	defer s.drainingMu.RUnlock()
+	return s.draining
+}
+
+func (s *Server) subscribe() chan struct{} {
+	ch := make(chan struct{}, 1)
+	s.subMu.Lock()
+	s.subs[ch] = struct{}{}
+	s.subMu.Unlock()
+	return ch
+}
+
+func (s *Server) unsubscribe(ch chan struct{}) {
+	s.subMu.Lock()
+	delete(s.subs, ch)
+	s.subMu.Unlock()
+}
+
+// signalChange wakes every WatchNode subscriber to re-send NodeStatus. Non-
+// blocking: a subscriber already holding a pending signal is skipped (its next
+// send already reflects the latest state).
+func (s *Server) signalChange() {
+	s.subMu.Lock()
+	defer s.subMu.Unlock()
+	for ch := range s.subs {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// reap tears a VM down: stop egress, kill the process, remove the bundle. Callers
+// that can race (Assign's single-use teardown vs an out-of-band Destroy) both
+// remove the entry from the registry FIRST, and map removal under the registry
+// lock hands the non-nil entry to exactly one caller, so reap runs once per VM.
+// Best-effort: failures are logged, never returned.
+func (s *Server) reap(h substrate.Handle, egressCancel func()) {
+	if egressCancel != nil {
+		egressCancel()
+	}
+	if err := s.driver.Release(context.Background(), h); err != nil {
+		s.logger.Warn("noded: release vm", "vm", h.ID, "thread", h.ThreadID, "err", err)
+	}
+	if err := s.driver.RemoveBundle(h.ThreadID); err != nil {
+		s.logger.Warn("noded: remove bundle", "vm", h.ID, "thread", h.ThreadID, "err", err)
+	}
+}
+
+// ---- startup base reconciliation -------------------------------------------
+
+// ReconcileBasesFromDisk scans SnapshotRoot/bases for base bundles left by a
+// prior daemon incarnation and registers them READY, so the control plane
+// reconciles against existing snapshots instead of rebuilding. A base dir name is
+// the baseKey "<workload>__<sig>"; the workload prefix is recovered for the
+// capacity report. Missing dir or unreadable entries are ignored (fresh node).
+func (s *Server) ReconcileBasesFromDisk() {
+	root := filepath.Join(s.cfg.SnapshotRoot, "bases")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			s.logger.Warn("noded: scan base bundles", "root", root, "err", err)
+		}
+		return
+	}
+	n := 0
+	for _, ent := range entries {
+		if !ent.IsDir() {
+			continue
+		}
+		baseKey := ent.Name()
+		snapfile := filepath.Join(root, baseKey, "snapfile")
+		fi, err := os.Stat(snapfile)
+		if err != nil {
+			// A dir without a snapfile is a half-written or unrelated bundle; skip.
+			continue
+		}
+		memfile := filepath.Join(root, baseKey, "memfile")
+		var size int64 = fi.Size()
+		if mfi, err := os.Stat(memfile); err == nil {
+			size += mfi.Size()
+		}
+		s.bases.register(baseEntry{
+			snapshotRef: baseKey,
+			workload:    workloadFromBaseKey(baseKey),
+			readyPath:   defaultReadyPath,
+			sizeBytes:   size,
+			state:       nodev1.BaseBuildState_BASE_BUILD_STATE_READY,
+		})
+		n++
+	}
+	if n > 0 {
+		s.logger.Info("noded: reconciled existing base snapshots", "count", n)
+		s.signalChange()
+	}
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+// defaultReadyPath is the frozen guest-contract readiness path.
+const defaultReadyPath = "/shim/ready"
+
+// dmNameRE-style sanitiser for the workload component of a base key.
+var baseKeyUnsafe = regexp.MustCompile(`[^A-Za-z0-9_-]`)
+
+// baseKeyFor derives the deterministic, filesystem-safe base key (== the opaque
+// snapshot_ref) from the workload and the (image_ref, workload_revision)
+// idempotency inputs. The workload prefix is recoverable on startup for the
+// capacity report; the hash suffix keys the bundle per image+revision.
+func baseKeyFor(workload, imageRef, revision string) string {
+	sum := sha256.Sum256([]byte(imageRef + "\x00" + revision))
+	sig := hex.EncodeToString(sum[:])[:12]
+	wl := baseKeyUnsafe.ReplaceAllString(workload, "_")
+	if wl == "" {
+		wl = "wl"
+	}
+	return wl + "__" + sig
+}
+
+// workloadFromBaseKey recovers the workload prefix from a "<workload>__<sig>"
+// base key. A key without the separator yields "" (unknown workload).
+func workloadFromBaseKey(baseKey string) string {
+	if i := strings.LastIndex(baseKey, "__"); i > 0 {
+		return baseKey[:i]
+	}
+	return ""
+}
+
+// newID returns a per-claim unique bundle id.
+func newID(prefix string) string {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return prefix + "-" + hex.EncodeToString(b[:])
+}
+
+// flattenHeaders collapses an http.Header to the proto's map<string,string>,
+// joining multi-valued headers with commas.
+func flattenHeaders(h http.Header) map[string]string {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(h))
+	for k, v := range h {
+		out[k] = strings.Join(v, ",")
+	}
+	return out
+}
+
+// readMemHeadroomMib reports free guest memory in MiB from the cgroup v2 memory
+// controller (the pod cgroup that bounds the daemon and its child microVMs).
+// Best-effort: any error or an unlimited cgroup yields 0 (the max-live-VM cap is
+// the real backstop; headroom is an advisory hint until Task 11).
+func readMemHeadroomMib() uint64 {
+	maxRaw, err := os.ReadFile("/sys/fs/cgroup/memory.max")
+	if err != nil {
+		return 0
+	}
+	curRaw, err := os.ReadFile("/sys/fs/cgroup/memory.current")
+	if err != nil {
+		return 0
+	}
+	return parseMemHeadroomMib(string(maxRaw), string(curRaw))
+}
+
+// parseMemHeadroomMib computes (max-current) in MiB from cgroup v2 memory.max
+// and memory.current contents. "max" (unlimited) or a parse error yields 0.
+func parseMemHeadroomMib(maxRaw, curRaw string) uint64 {
+	maxStr := strings.TrimSpace(maxRaw)
+	if maxStr == "max" || maxStr == "" {
+		return 0
+	}
+	maxB, err := strconv.ParseInt(maxStr, 10, 64)
+	if err != nil {
+		return 0
+	}
+	curB, err := strconv.ParseInt(strings.TrimSpace(curRaw), 10, 64)
+	if err != nil {
+		return 0
+	}
+	if curB >= maxB {
+		return 0
+	}
+	return uint64(maxB-curB) / (1 << 20)
+}

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -1,0 +1,479 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/config"
+	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
+)
+
+// fakeDriver is an in-memory vmDriver + buildDriver that records the lifecycle
+// calls the server makes, so tests can assert "the VM was destroyed exactly
+// once" and "a rejected Assign had no side effects".
+type fakeDriver struct {
+	mu            sync.Mutex
+	claims        int
+	releases      int
+	removeBundles int
+	statsCalls    int
+	snapshots     int
+	live          int
+	failClaim     error
+}
+
+func (f *fakeDriver) Claim(_ context.Context, spec substrate.ClaimSpec) (substrate.Handle, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failClaim != nil {
+		return substrate.Handle{}, f.failClaim
+	}
+	f.claims++
+	f.live++
+	return substrate.Handle{ThreadID: spec.ThreadID, ID: "vm-" + spec.ThreadID, Node: "node-4"}, nil
+}
+
+func (f *fakeDriver) Release(_ context.Context, _ substrate.Handle) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.releases++
+	if f.live > 0 {
+		f.live--
+	}
+	return nil
+}
+
+func (f *fakeDriver) RemoveBundle(_ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.removeBundles++
+	return nil
+}
+
+func (f *fakeDriver) VsockUDSPath(threadID string) string { return "/tmp/" + threadID + ".sock" }
+
+func (f *fakeDriver) Stats(_ substrate.Handle) (substrate.GuestStats, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.statsCalls++
+	return substrate.GuestStats{CPUMillis: 5, PeakRSSMib: 64}, nil
+}
+
+func (f *fakeDriver) LiveCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.live
+}
+
+func (f *fakeDriver) SnapshotBase(_ context.Context, _ substrate.Handle, baseKey string) (substrate.SnapshotRef, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.snapshots++
+	return substrate.SnapshotRef{ID: baseKey, Base: true, SizeBytes: 4096}, nil
+}
+
+func (f *fakeDriver) counts() (claims, releases, removeBundles, statsCalls int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.claims, f.releases, f.removeBundles, f.statsCalls
+}
+
+// fakeTransport is an in-memory transport. RoundTrip echoes "ok:"+body unless
+// roundTripErr is set.
+type fakeTransport struct {
+	mu           sync.Mutex
+	roundTrips   int
+	waitReadyErr error
+	roundTripErr error
+}
+
+func (f *fakeTransport) WaitReady(_ context.Context, _, _ string) error { return f.waitReadyErr }
+func (f *fakeTransport) Prime(_ context.Context, _ string) error        { return nil }
+
+func (f *fakeTransport) RoundTrip(_ context.Context, _ string, req *http.Request) (*http.Response, error) {
+	f.mu.Lock()
+	f.roundTrips++
+	rtErr := f.roundTripErr
+	f.mu.Unlock()
+	if rtErr != nil {
+		return nil, rtErr
+	}
+	body, _ := io.ReadAll(req.Body)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"X-Echo": []string{"1"}},
+		Body:       io.NopCloser(bytes.NewReader([]byte("ok:" + string(body)))),
+	}, nil
+}
+
+func (f *fakeTransport) roundTripCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.roundTrips
+}
+
+// newTestServer wires the Server behind a real in-process gRPC dial (bufconn),
+// so tests exercise the wire path (marshalling, status codes) end to end.
+func newTestServer(t *testing.T, drv *fakeDriver, tr *fakeTransport, maxLive int) (nodev1.NodeServiceClient, *Server) {
+	t.Helper()
+	s := New(Options{
+		Config:    config.Config{Arch: "amd64", Node: "node-4", MaxLiveVMs: maxLive, SnapshotRoot: t.TempDir()},
+		Driver:    drv,
+		Transport: tr,
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	s.memHeadroom = func() uint64 { return 0 } // deterministic, no cgroup read
+
+	lis := bufconn.Listen(1 << 20)
+	gs := grpc.NewServer()
+	nodev1.RegisterNodeServiceServer(gs, s)
+	go func() { _ = gs.Serve(lis) }()
+	t.Cleanup(gs.Stop)
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dial bufconn: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return nodev1.NewNodeServiceClient(conn), s
+}
+
+func seedBase(s *Server, snapshotRef, workload string) {
+	s.bases.readyBuild(snapshotRef, workload, "img@sha256:deadbeef", "/shim/ready", 2048)
+}
+
+// TestPrimeAssignAutoDestroy is the core lifecycle: Prime parks a VM, Assign
+// delivers one task and returns the echoed guest response plus usage, and the VM
+// is destroyed exactly once after the response.
+func TestPrimeAssignAutoDestroy(t *testing.T) {
+	drv := &fakeDriver{}
+	tr := &fakeTransport{}
+	client, srv := newTestServer(t, drv, tr, 8)
+	seedBase(srv, "echo__deadbeef01", "echo")
+	ctx := context.Background()
+
+	pr, err := client.Prime(ctx, &nodev1.PrimeRequest{SnapshotRef: "echo__deadbeef01"})
+	if err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	if pr.GetVmId() == "" {
+		t.Fatal("Prime returned empty vm_id")
+	}
+	if got := drv.LiveCount(); got != 1 {
+		t.Fatalf("after Prime LiveCount = %d, want 1", got)
+	}
+
+	// NodeStatus reflects one free primed slot for echo, one live VM.
+	ns, err := client.GetNodeStatus(ctx, &nodev1.GetNodeStatusRequest{})
+	if err != nil {
+		t.Fatalf("GetNodeStatus: %v", err)
+	}
+	if ns.GetLiveVms() != 1 || ns.GetMaxLiveVms() != 8 {
+		t.Errorf("NodeStatus live=%d max=%d, want 1/8", ns.GetLiveVms(), ns.GetMaxLiveVms())
+	}
+	if got := freePrimed(ns, "echo"); got != 1 {
+		t.Errorf("echo free_primed_slots = %d, want 1", got)
+	}
+
+	ar, err := client.Assign(ctx, &nodev1.AssignRequest{
+		VmId:      pr.GetVmId(),
+		Request:   &nodev1.GuestRequest{Method: "POST", Path: "/invoke", Body: []byte("hi")},
+		TimeoutMs: 1000,
+	})
+	if err != nil {
+		t.Fatalf("Assign: %v", err)
+	}
+	if ar.GetResponse().GetStatusCode() != 200 {
+		t.Errorf("status = %d, want 200", ar.GetResponse().GetStatusCode())
+	}
+	if got := string(ar.GetResponse().GetBody()); got != "ok:hi" {
+		t.Errorf("body = %q, want ok:hi", got)
+	}
+	if ar.GetUsage().GetCpuMs() != 5 || ar.GetUsage().GetPeakRssMib() != 64 {
+		t.Errorf("usage = %+v, want cpu 5 rss 64", ar.GetUsage())
+	}
+
+	// Exactly one round-trip, and the VM torn down exactly once (release + bundle
+	// removal + one stats sample while alive).
+	if got := tr.roundTripCount(); got != 1 {
+		t.Errorf("round trips = %d, want 1", got)
+	}
+	claims, releases, removeBundles, statsCalls := drv.counts()
+	if claims != 1 || releases != 1 || removeBundles != 1 || statsCalls != 1 {
+		t.Errorf("driver counts claims=%d releases=%d removeBundles=%d stats=%d, want 1/1/1/1",
+			claims, releases, removeBundles, statsCalls)
+	}
+	if got := drv.LiveCount(); got != 0 {
+		t.Errorf("after Assign LiveCount = %d, want 0", got)
+	}
+
+	// Assign again on the now-destroyed vm_id: FAILED_PRECONDITION, no side effects.
+	_, err = client.Assign(ctx, &nodev1.AssignRequest{
+		VmId:    pr.GetVmId(),
+		Request: &nodev1.GuestRequest{Body: []byte("second")},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("Assign-after-destroy code = %v, want FailedPrecondition (err=%v)", status.Code(err), err)
+	}
+	if got := tr.roundTripCount(); got != 1 {
+		t.Errorf("round trips after rejected Assign = %d, want still 1 (no side effects)", got)
+	}
+	claims2, releases2, removeBundles2, _ := drv.counts()
+	if claims2 != 1 || releases2 != 1 || removeBundles2 != 1 {
+		t.Errorf("rejected Assign had side effects: claims=%d releases=%d removeBundles=%d, want 1/1/1",
+			claims2, releases2, removeBundles2)
+	}
+}
+
+// TestAssignUnknownVM rejects an Assign for a vm_id that was never primed, with
+// no driver interaction at all.
+func TestAssignUnknownVM(t *testing.T) {
+	drv := &fakeDriver{}
+	tr := &fakeTransport{}
+	client, _ := newTestServer(t, drv, tr, 8)
+
+	_, err := client.Assign(context.Background(), &nodev1.AssignRequest{
+		VmId:    "vm-nope",
+		Request: &nodev1.GuestRequest{Body: []byte("x")},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("code = %v, want FailedPrecondition", status.Code(err))
+	}
+	if claims, releases, removeBundles, _ := drv.counts(); claims+releases+removeBundles != 0 {
+		t.Errorf("unknown Assign touched the driver: claims=%d releases=%d removeBundles=%d", claims, releases, removeBundles)
+	}
+	if tr.roundTripCount() != 0 {
+		t.Errorf("unknown Assign round-tripped to a guest")
+	}
+}
+
+// TestAssignDeadlineDestroysVM: a guest that times out yields DEADLINE_EXCEEDED,
+// and the VM is still destroyed (single-use holds on every path).
+func TestAssignDeadlineDestroysVM(t *testing.T) {
+	drv := &fakeDriver{}
+	tr := &fakeTransport{roundTripErr: context.DeadlineExceeded}
+	client, srv := newTestServer(t, drv, tr, 8)
+	seedBase(srv, "echo__timeout01", "echo")
+	ctx := context.Background()
+
+	pr, err := client.Prime(ctx, &nodev1.PrimeRequest{SnapshotRef: "echo__timeout01"})
+	if err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	_, err = client.Assign(ctx, &nodev1.AssignRequest{
+		VmId:      pr.GetVmId(),
+		Request:   &nodev1.GuestRequest{Body: []byte("slow")},
+		TimeoutMs: 50,
+	})
+	if status.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("code = %v, want DeadlineExceeded (err=%v)", status.Code(err), err)
+	}
+	if _, releases, removeBundles, _ := drv.counts(); releases != 1 || removeBundles != 1 {
+		t.Errorf("timed-out Assign did not destroy the VM: releases=%d removeBundles=%d, want 1/1", releases, removeBundles)
+	}
+	if got := drv.LiveCount(); got != 0 {
+		t.Errorf("LiveCount after timeout = %d, want 0", got)
+	}
+}
+
+// TestPrimeUnknownSnapshot rejects a Prime for a snapshot_ref with no base.
+func TestPrimeUnknownSnapshot(t *testing.T) {
+	drv := &fakeDriver{}
+	client, _ := newTestServer(t, drv, &fakeTransport{}, 8)
+	_, err := client.Prime(context.Background(), &nodev1.PrimeRequest{SnapshotRef: "ghost__000000000000"})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("code = %v, want FailedPrecondition", status.Code(err))
+	}
+	if claims, _, _, _ := drv.counts(); claims != 0 {
+		t.Errorf("unknown Prime claimed a VM (claims=%d)", claims)
+	}
+}
+
+// TestPrimeCapExhausted rejects a Prime that would exceed the node backstop cap.
+func TestPrimeCapExhausted(t *testing.T) {
+	drv := &fakeDriver{}
+	client, srv := newTestServer(t, drv, &fakeTransport{}, 1)
+	seedBase(srv, "echo__cap0001", "echo")
+	ctx := context.Background()
+
+	if _, err := client.Prime(ctx, &nodev1.PrimeRequest{SnapshotRef: "echo__cap0001"}); err != nil {
+		t.Fatalf("first Prime: %v", err)
+	}
+	_, err := client.Prime(ctx, &nodev1.PrimeRequest{SnapshotRef: "echo__cap0001"})
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("second Prime code = %v, want ResourceExhausted", status.Code(err))
+	}
+}
+
+// TestDestroyIdempotent: Destroy reaps a primed VM once, and a repeat Destroy is
+// a no-op OK.
+func TestDestroyIdempotent(t *testing.T) {
+	drv := &fakeDriver{}
+	client, srv := newTestServer(t, drv, &fakeTransport{}, 8)
+	seedBase(srv, "echo__destroy01", "echo")
+	ctx := context.Background()
+
+	pr, err := client.Prime(ctx, &nodev1.PrimeRequest{SnapshotRef: "echo__destroy01"})
+	if err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	if _, err := client.Destroy(ctx, &nodev1.DestroyRequest{VmId: pr.GetVmId()}); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if _, releases, removeBundles, _ := drv.counts(); releases != 1 || removeBundles != 1 {
+		t.Errorf("Destroy did not reap: releases=%d removeBundles=%d, want 1/1", releases, removeBundles)
+	}
+	// Idempotent: repeat Destroy is OK with no extra teardown.
+	if _, err := client.Destroy(ctx, &nodev1.DestroyRequest{VmId: pr.GetVmId()}); err != nil {
+		t.Fatalf("second Destroy: %v", err)
+	}
+	if _, releases, _, _ := drv.counts(); releases != 1 {
+		t.Errorf("second Destroy re-reaped: releases=%d, want 1", releases)
+	}
+}
+
+// TestWatchNodeInitialStatus asserts WatchNode sends an initial NodeStatus
+// immediately on subscribe.
+func TestWatchNodeInitialStatus(t *testing.T) {
+	client, _ := newTestServer(t, &fakeDriver{}, &fakeTransport{}, 4)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	stream, err := client.WatchNode(ctx, &nodev1.WatchNodeRequest{NodeId: "node-4"})
+	if err != nil {
+		t.Fatalf("WatchNode: %v", err)
+	}
+	ns, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv initial: %v", err)
+	}
+	if ns.GetNodeId() != "node-4" {
+		t.Errorf("node_id = %q, want node-4", ns.GetNodeId())
+	}
+	if ns.GetMaxLiveVms() != 4 {
+		t.Errorf("max_live_vms = %d, want 4", ns.GetMaxLiveVms())
+	}
+}
+
+// TestBuildBaseIdempotent covers the cold-boot base build path with a fake build
+// driver: first call builds and snapshots, the second is an already_built no-op.
+func TestBuildBaseIdempotent(t *testing.T) {
+	drv := &fakeDriver{}
+	build := &fakeDriver{} // separate recorder for the build path
+	tr := &fakeTransport{}
+	s := New(Options{
+		Config: config.Config{
+			Arch: "amd64", Node: "node-4", SnapshotRoot: t.TempDir(),
+			BootReadyTimeout: time.Second,
+			Images:           map[string]config.Image{"img:1": {RootfsPath: "/rootfs.ext4"}},
+		},
+		Driver:         drv,
+		Transport:      tr,
+		NewBuildDriver: func(BuildDriverSpec) BuildDriver { return build },
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+
+	ctx := context.Background()
+	req := &nodev1.BuildBaseRequest{
+		Trace:            &nodev1.Trace{Workload: "echo"},
+		ImageRef:         "img:1",
+		WorkloadRevision: "r1",
+		ReadyPath:        "/shim/ready",
+		Resources:        &nodev1.ResourceSpec{Vcpus: 2, MemMib: 2048},
+	}
+	resp, err := s.BuildBase(ctx, req)
+	if err != nil {
+		t.Fatalf("BuildBase: %v", err)
+	}
+	if resp.GetSnapshotRef() == "" || resp.GetAlreadyBuilt() {
+		t.Fatalf("first build resp = %+v, want a ref and already_built=false", resp)
+	}
+	if build.snapshots != 1 {
+		t.Errorf("snapshots = %d, want 1", build.snapshots)
+	}
+
+	resp2, err := s.BuildBase(ctx, req)
+	if err != nil {
+		t.Fatalf("second BuildBase: %v", err)
+	}
+	if !resp2.GetAlreadyBuilt() || resp2.GetSnapshotRef() != resp.GetSnapshotRef() {
+		t.Errorf("second build resp = %+v, want already_built=true and same ref", resp2)
+	}
+	if build.snapshots != 1 {
+		t.Errorf("second build re-snapshotted: snapshots = %d, want 1", build.snapshots)
+	}
+}
+
+// TestBuildBaseUnknownImage rejects a build for an image the node has no rootfs for.
+func TestBuildBaseUnknownImage(t *testing.T) {
+	s := New(Options{
+		Config:         config.Config{Arch: "amd64", Node: "node-4", SnapshotRoot: t.TempDir()},
+		Driver:         &fakeDriver{},
+		Transport:      &fakeTransport{},
+		NewBuildDriver: func(BuildDriverSpec) BuildDriver { return &fakeDriver{} },
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	_, err := s.BuildBase(context.Background(), &nodev1.BuildBaseRequest{
+		Trace:    &nodev1.Trace{Workload: "echo"},
+		ImageRef: "not-provisioned:1",
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("code = %v, want FailedPrecondition", status.Code(err))
+	}
+}
+
+func TestParseMemHeadroomMib(t *testing.T) {
+	cases := []struct {
+		maxRaw, curRaw string
+		want           uint64
+	}{
+		{"max\n", "1048576\n", 0},        // unlimited
+		{"2097152\n", "1048576\n", 1},    // 2MiB - 1MiB = 1MiB
+		{"1048576", "2097152", 0},        // current over max
+		{"garbage", "1", 0},              // unparseable
+		{"104857600\n", "4194304\n", 96}, // 100MiB - 4MiB
+	}
+	for _, c := range cases {
+		if got := parseMemHeadroomMib(c.maxRaw, c.curRaw); got != c.want {
+			t.Errorf("parseMemHeadroomMib(%q,%q) = %d, want %d", c.maxRaw, c.curRaw, got, c.want)
+		}
+	}
+}
+
+// freePrimed extracts a workload's free_primed_slots from a NodeStatus.
+func freePrimed(ns *nodev1.NodeStatus, workload string) uint32 {
+	for _, c := range ns.GetWorkloads() {
+		if c.GetWorkload() == workload {
+			return c.GetFreePrimedSlots()
+		}
+	}
+	return 0
+}
+
+// ensure the fakes satisfy the seams the server uses.
+var (
+	_ vmDriver    = (*fakeDriver)(nil)
+	_ BuildDriver = (*fakeDriver)(nil)
+	_ transport   = (*fakeTransport)(nil)
+)

--- a/projects/embervm/noded/substrate/BUILD
+++ b/projects/embervm/noded/substrate/BUILD
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "substrate",
+    srcs = ["substrate.go"],
+    importpath = "github.com/jomcgi/homelab/projects/embervm/noded/substrate",
+    visibility = ["//projects/embervm/noded:__subpackages__"],
+)

--- a/projects/embervm/noded/substrate/substrate.go
+++ b/projects/embervm/noded/substrate/substrate.go
@@ -24,6 +24,12 @@ type ClaimSpec struct {
 	// ThreadID is the per-claim bundle identity that names the on-disk bundle dir
 	// and the vsock socket path. Empty means "assign a fresh one".
 	ThreadID string
+	// Repo and Branch scoped an agent workspace in the fc-invoke lineage. The
+	// task class has no workspace concept, so the forked driver ignores them; they
+	// are carried only so the inherited driver package (copied verbatim, including
+	// its tests) compiles unchanged. Do not read them in noded code.
+	Repo   string
+	Branch string
 	// BaseSnapshotRef, when set, requests a restore from a warmed base snapshot
 	// for an instant ready start instead of a cold boot.
 	BaseSnapshotRef SnapshotRef

--- a/projects/embervm/noded/substrate/substrate.go
+++ b/projects/embervm/noded/substrate/substrate.go
@@ -1,0 +1,106 @@
+// Package substrate is embervm-noded's forked, trimmed copy of the FC executor
+// seam types the driver depends on. It is a DELIBERATE FORK of the fc-invoke
+// substrate seam (ADR embervm/001 mandates fork-not-extend: embervm-noded shares
+// no Go packages with projects/firecracker), reduced to only the types the forked
+// fcvm driver and its gueststats use.
+//
+// Dropped on the fork relative to fc-invoke's seam: the HTTP-shaped NodeExecutor
+// (the daemon's northbound face is gRPC now, not an in-process HTTP interface),
+// the Workload JSON catalog (concurrency is the control plane's; the daemon reads
+// per-build resources off the gRPC BuildBase request, not a node-side catalog),
+// and the Suspendable/Persistent/State surface the task-class lifecycle never uses.
+package substrate
+
+import (
+	"context"
+	"io"
+	"time"
+)
+
+// ClaimSpec describes the isolated microVM a caller wants. A claim is satisfied
+// cold (boot fresh from the rootfs) or restored (from a base snapshot ref); which
+// path the driver takes is its own concern, keyed off BaseSnapshotRef.
+type ClaimSpec struct {
+	// ThreadID is the per-claim bundle identity that names the on-disk bundle dir
+	// and the vsock socket path. Empty means "assign a fresh one".
+	ThreadID string
+	// BaseSnapshotRef, when set, requests a restore from a warmed base snapshot
+	// for an instant ready start instead of a cold boot.
+	BaseSnapshotRef SnapshotRef
+	// Arch pins CPU architecture; Firecracker snapshots are non-portable and a
+	// mismatched restore fails closed.
+	Arch string
+}
+
+// Handle is an opaque reference to a claimed, live microVM. It is only valid
+// between Claim/Restore and Release.
+type Handle struct {
+	// ThreadID is the stable bundle identity backing this live microVM.
+	ThreadID string
+	// ID is the per-claim microVM instance identity, which changes across
+	// snapshot/restore even though ThreadID does not.
+	ID string
+	// Node is where the microVM is running; snapshots are node-affine.
+	Node string
+}
+
+// GuestStats is a host-side resource sample for one guest's firecracker process,
+// read from /proc just before the VM is torn down. Because each invocation is a
+// fresh single-use process, these are whole-invocation totals:
+//   - CPUMillis is total user+system CPU across every vCPU + VMM thread since
+//     Launch.
+//   - PeakRSSMib is the kernel's peak resident set (VmHWM) for the process, an
+//     upper bound on the VM's host memory footprint.
+type GuestStats struct {
+	CPUMillis  int64
+	PeakRSSMib int64
+}
+
+// Request is a unit of work to run inside a claimed environment. It exists only
+// to satisfy the Substrate interface's Exec signature; the FC-direct driver runs
+// no host-launched processes in the guest (work arrives over vsock HTTP).
+type Request struct {
+	Argv    []string
+	Env     map[string]string
+	Timeout time.Duration
+}
+
+// Stream carries the output of an Exec. Callers must Close it.
+type Stream interface {
+	io.ReadCloser
+}
+
+// SnapshotRef identifies a stored snapshot bundle (snapfile + memfile). It is a
+// value, not a handle: it survives the microVM and is restorable later.
+type SnapshotRef struct {
+	// ID is the snapshot identity; for a base it keys the bases/<ID> bundle dir
+	// under the snapshot root, and for a per-thread snapshot it is a fresh id.
+	ID string
+	// ThreadID is the thread this snapshot belongs to (empty for a base).
+	ThreadID string
+	// Node and Arch pin where the snapshot can be restored (non-portable).
+	Node string
+	Arch string
+	// SizeBytes is the on-disk bundle size, used for capacity reporting.
+	SizeBytes int64
+	// Base reports whether this is a warm base template rather than a per-thread
+	// idle snapshot.
+	Base bool
+}
+
+// Substrate is the core the driver satisfies: acquire an isolated env, run work
+// in it, return/destroy it. Exec is unused by the FC-direct driver (work arrives
+// over vsock HTTP), but the interface keeps the driver honest about the seam.
+type Substrate interface {
+	Claim(ctx context.Context, spec ClaimSpec) (Handle, error)
+	Exec(ctx context.Context, h Handle, req Request) (Stream, error)
+	Release(ctx context.Context, h Handle) error
+}
+
+// Snapshotable is the optional capability the FC-direct driver implements:
+// capture an environment to a restorable bundle, and restore a new live
+// environment from one.
+type Snapshotable interface {
+	Snapshot(ctx context.Context, h Handle) (SnapshotRef, error)
+	Restore(ctx context.Context, ref SnapshotRef) (Handle, error)
+}

--- a/projects/embervm/noded/vsockhttp/BUILD
+++ b/projects/embervm/noded/vsockhttp/BUILD
@@ -1,0 +1,15 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "vsockhttp",
+    srcs = ["transport.go"],
+    importpath = "github.com/jomcgi/homelab/projects/embervm/noded/vsockhttp",
+    visibility = ["//projects/embervm/noded:__subpackages__"],
+    deps = ["//projects/embervm/noded/vsockproto"],
+)
+
+go_test(
+    name = "vsockhttp_test",
+    srcs = ["transport_test.go"],
+    embed = [":vsockhttp"],
+)

--- a/projects/embervm/noded/vsockhttp/transport.go
+++ b/projects/embervm/noded/vsockhttp/transport.go
@@ -1,0 +1,269 @@
+// Package vsockhttp provides a host-side HTTP transport for communicating with
+// a guest shim server over Firecracker's vsock unix-domain socket bridge.
+//
+// Firecracker maps vsock ports to per-VM UDS paths on the host. To open a
+// host-initiated connection to a guest port the host dials the base UDS and
+// writes "CONNECT <port>\n"; the device layer forwards the connection to the
+// guest listener and replies "OK <port>\n". After that line the connection is
+// a plain bidirectional byte stream.
+//
+// Transport wraps that handshake inside a custom net/http DialContext so that
+// an ordinary *http.Client can speak HTTP/1.1 to the guest shim. Each
+// RoundTrip opens a fresh connection (keep-alives disabled) because each
+// microVM is single-use and should never share a connection with another.
+package vsockhttp
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/vsockproto"
+)
+
+// Transport performs HTTP request/response exchanges to a guest shim server
+// over a Firecracker vsock UDS. Each RoundTrip call opens a fresh connection;
+// connection reuse is disabled so separate microVMs never share state.
+type Transport struct {
+	directDial bool
+	dialer     *net.Dialer
+}
+
+// Option configures a Transport.
+type Option func(*Transport)
+
+// WithDirectDial returns an Option that skips the Firecracker CONNECT
+// handshake and dials the UDS directly as a plain HTTP server. This exists
+// solely for testing: the test backs the Transport with a shim.Server bound
+// to a plain unix listener that speaks HTTP immediately, without the
+// Firecracker device layer in between.
+func WithDirectDial() Option {
+	return func(t *Transport) {
+		t.directDial = true
+	}
+}
+
+// WithDialer returns an Option that substitutes d for the default net.Dialer.
+// Useful in tests that need to control dial timing or inject failures.
+func WithDialer(d *net.Dialer) Option {
+	return func(t *Transport) {
+		t.dialer = d
+	}
+}
+
+// NewTransport builds a Transport, applying any supplied options.
+func NewTransport(opts ...Option) *Transport {
+	t := &Transport{}
+	for _, o := range opts {
+		o(t)
+	}
+	return t
+}
+
+// RoundTrip sends req to the guest shim server reachable via the vsock UDS at
+// udsPath and returns its HTTP response. The caller is responsible for closing
+// the response body.
+//
+// In production mode (the default) RoundTrip performs the Firecracker
+// host-initiated vsock handshake before speaking HTTP: it dials udsPath,
+// writes "CONNECT <GuestHTTPPort>\n", and validates the "OK" reply. With
+// WithDirectDial the handshake is skipped, which allows test code to back the
+// Transport with a plain net.Listener.
+//
+// req.URL.Host is ignored; the dial always targets udsPath. Set the URL to
+// "http://vsock/..." as a clear placeholder.
+//
+// If ctx carries a deadline it is applied to the underlying connection so all
+// I/O is bounded.
+func (t *Transport) RoundTrip(ctx context.Context, udsPath string, req *http.Request) (*http.Response, error) {
+	d := t.dialer
+	if d == nil {
+		d = &net.Dialer{}
+	}
+
+	tr := &http.Transport{
+		DialContext: func(dialCtx context.Context, _, _ string) (net.Conn, error) {
+			return t.dialConn(dialCtx, d, udsPath)
+		},
+		DisableKeepAlives: true,
+	}
+	client := &http.Client{Transport: tr}
+
+	return client.Do(req.WithContext(ctx))
+}
+
+// WaitReady polls GET readyPath over the vsock transport until the guest shim
+// responds 200, or until ctx expires. readyPath defaults to "/shim/ready" when
+// empty. On timeout it returns a descriptive error wrapping ctx.Err().
+//
+// Any error from RoundTrip (such as a connection-refused while the guest is
+// still starting) is treated as "not ready yet" and causes a retry.
+//
+// Each attempt is bounded by its own short deadline (waitReadyAttempt), NOT the
+// outer ctx. This is load-bearing for warm restores: the first post-restore
+// vsock connection can wedge on Firecracker's RX-queue race, and its
+// CONNECT-reply read would otherwise block for the full outer deadline before
+// the retry loop ever runs. Capping per attempt abandons a wedged connection
+// quickly and reconnects, so WaitReady returns the instant the guest answers
+// (usually the first or second attempt) instead of hanging.
+func (t *Transport) WaitReady(ctx context.Context, udsPath, readyPath string) error {
+	if readyPath == "" {
+		readyPath = "/shim/ready"
+	}
+	for {
+		if err := t.readyAttempt(ctx, udsPath, readyPath); err == nil {
+			return nil
+		}
+		// Retriable: back off briefly, stop only when the outer ctx fires.
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("vsockhttp: timed out waiting for guest ready at %s: %w", readyPath, ctx.Err())
+		case <-time.After(waitReadyBackoff):
+		}
+	}
+}
+
+// waitReadyAttempt bounds a single readiness probe; a wedged post-restore
+// connection is abandoned after this and retried. waitReadyBackoff is the pause
+// between attempts once one has returned (fast failures should not spin).
+const (
+	waitReadyAttempt = 150 * time.Millisecond
+	waitReadyBackoff = 20 * time.Millisecond
+)
+
+// primeAttempt bounds a single prime probe. It is deliberately far tighter than
+// waitReadyAttempt: the whole point of priming is to abandon a wedged
+// post-restore connection FAST and re-roll, so the RX-queue race is shaken out
+// in tens of milliseconds rather than the ~150ms a readiness attempt would burn
+// on the same wedge. primeBackoff is the pause between probes.
+const (
+	primeAttempt = 30 * time.Millisecond
+	primeBackoff = 10 * time.Millisecond
+)
+
+// Prime forces the post-restore vsock path open BEFORE the readiness poll runs,
+// absorbing Firecracker's post-restore RX-queue race off the readiness path.
+//
+// A freshly restored guest can wedge its first host-initiated vsock connection
+// (see WaitReady for the mechanism). Prime repeatedly issues a cheap liveness
+// probe against the shim's /shim/healthz, each bounded by the tight primeAttempt
+// deadline, until one exchange completes or ctx fires. /shim/healthz answers 200
+// the moment the shim serves, so ANY completed HTTP exchange -- whatever its
+// status -- proves the vsock path drained. The connection is thrown away; Prime
+// exists only so the subsequent WaitReady and exec dials land on an already
+// drained queue and answer on their first attempt.
+//
+// Prime is best-effort: on ctx expiry it returns an error the caller may log and
+// ignore, since WaitReady still retries past the race as before. Callers should
+// bound ctx by the same short restore budget used for the readiness wait.
+func (t *Transport) Prime(ctx context.Context, udsPath string) error {
+	for {
+		if err := t.primeProbe(ctx, udsPath); err == nil {
+			return nil
+		}
+		// Retriable: back off briefly, stop only when the outer ctx fires.
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("vsockhttp: timed out priming vsock at %s: %w", udsPath, ctx.Err())
+		case <-time.After(primeBackoff):
+		}
+	}
+}
+
+// primeProbe performs one liveness probe bounded by primeAttempt (capped by the
+// outer ctx). It returns nil once an HTTP exchange completes, regardless of the
+// response status: a completed exchange means the vsock path is open.
+func (t *Transport) primeProbe(ctx context.Context, udsPath string) error {
+	attemptCtx, cancel := context.WithTimeout(ctx, primeAttempt)
+	defer cancel()
+	req, err := http.NewRequestWithContext(attemptCtx, http.MethodGet, "http://vsock/shim/healthz", nil)
+	if err != nil {
+		return fmt.Errorf("vsockhttp: build prime request: %w", err)
+	}
+	resp, err := t.RoundTrip(attemptCtx, udsPath, req)
+	if err != nil {
+		return err // nosemgrep: no-bare-error-return
+	}
+	_ = resp.Body.Close()
+	return nil
+}
+
+// readyAttempt performs one readiness probe bounded by waitReadyAttempt (capped
+// by the outer ctx). It returns nil only on a 200 response.
+func (t *Transport) readyAttempt(ctx context.Context, udsPath, readyPath string) error {
+	attemptCtx, cancel := context.WithTimeout(ctx, waitReadyAttempt)
+	defer cancel()
+	req, err := http.NewRequestWithContext(attemptCtx, http.MethodGet, "http://vsock"+readyPath, nil)
+	if err != nil {
+		return fmt.Errorf("vsockhttp: build ready request: %w", err)
+	}
+	resp, err := t.RoundTrip(attemptCtx, udsPath, req)
+	if err != nil {
+		return err // nosemgrep: no-bare-error-return
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("vsockhttp: guest not ready, status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// dialConn opens a raw connection to the guest shim at udsPath. In production
+// mode it performs the Firecracker host-initiated vsock CONNECT handshake. With
+// directDial (test mode) it returns the raw UDS connection directly.
+func (t *Transport) dialConn(ctx context.Context, d *net.Dialer, udsPath string) (net.Conn, error) {
+	conn, err := d.DialContext(ctx, "unix", udsPath)
+	if err != nil {
+		return nil, fmt.Errorf("vsockhttp: dial uds %s: %w", udsPath, err)
+	}
+
+	// Bound all subsequent I/O on this connection by the context deadline.
+	if dl, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(dl)
+	}
+
+	if t.directDial {
+		return conn, nil
+	}
+
+	// Firecracker host-initiated vsock handshake: write "CONNECT <port>\n",
+	// then read and validate the "OK <port>\n" reply. Only after the OK line
+	// does the device layer route the connection to the guest listener.
+	if _, err := fmt.Fprintf(conn, "CONNECT %d\n", vsockproto.GuestHTTPPort); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("vsockhttp: write CONNECT: %w", err)
+	}
+	br := bufio.NewReader(conn)
+	status, err := br.ReadString('\n')
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("vsockhttp: read CONNECT reply: %w", err)
+	}
+	if !strings.HasPrefix(status, "OK") {
+		_ = conn.Close()
+		return nil, fmt.Errorf("vsockhttp: guest HTTP port not reachable: %q", strings.TrimSpace(status))
+	}
+
+	// Wrap conn so any bytes the bufio.Reader pre-buffered past the OK line
+	// are served to net/http rather than being silently discarded.
+	return &bufConnWrapper{Conn: conn, r: br}, nil
+}
+
+// bufConnWrapper combines a net.Conn with a bufio.Reader so that bytes already
+// consumed into the reader's internal buffer are served first, before the
+// underlying conn is read directly. This preserves any bytes the reader may
+// have buffered past the CONNECT handshake "OK" line.
+type bufConnWrapper struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+// Read satisfies net.Conn by draining the bufio.Reader (which in turn reads
+// from the underlying conn when its buffer is empty).
+func (b *bufConnWrapper) Read(p []byte) (int, error) {
+	return b.r.Read(p)
+}

--- a/projects/embervm/noded/vsockhttp/transport_test.go
+++ b/projects/embervm/noded/vsockhttp/transport_test.go
@@ -1,0 +1,255 @@
+package vsockhttp
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// echoHandler echoes "ok:" prepended to the request body as a 200 response.
+// It is the workload handler used across these tests.
+func echoHandler(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok:" + string(body)))
+}
+
+// newShimMux builds a stdlib http.Handler that reproduces the guest shim
+// server's behaviour these tests rely on: POST /invoke echoes the body,
+// GET /shim/healthz always answers 200 (Prime probes this), and GET
+// /shim/ready answers 200 once ready reports true (nil ready means always
+// ready).
+func newShimMux(ready func() bool) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/invoke", echoHandler)
+	mux.HandleFunc("/shim/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/shim/ready", func(w http.ResponseWriter, _ *http.Request) {
+		if ready == nil || ready() {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	return mux
+}
+
+// startShimOnUDS starts a stdlib http.Server bound to a Unix-domain socket in
+// t's temp directory, backed by newShimMux(ready). The socket is created with
+// net.Listen so the server speaks plain HTTP with no Firecracker CONNECT
+// layer, making it suitable for use with WithDirectDial. The server is
+// stopped when t.Cleanup runs. It returns the UDS path. A nil ready means the
+// shim always reports ready.
+func startShimOnUDS(t *testing.T, ready func() bool) string {
+	t.Helper()
+	udsPath := t.TempDir() + "/shim.sock"
+	ln, err := net.Listen("unix", udsPath)
+	if err != nil {
+		t.Fatalf("listen unix %s: %v", udsPath, err)
+	}
+	srv := &http.Server{Handler: newShimMux(ready)}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return udsPath
+}
+
+// TestRoundTripOverUDS verifies that Transport.RoundTrip sends an HTTP POST to
+// a shim server over a Unix-domain socket and receives the echoed response
+// body.
+func TestRoundTripOverUDS(t *testing.T) {
+	udsPath := startShimOnUDS(t, nil)
+	tr := NewTransport(WithDirectDial())
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodPost, "http://vsock/invoke", strings.NewReader("hi"),
+	)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	resp, err := tr.RoundTrip(context.Background(), udsPath, req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != "ok:hi" {
+		t.Errorf("body = %q, want %q", string(got), "ok:hi")
+	}
+}
+
+// TestWaitReadyBecomesReady starts a shim server whose readiness flips to true
+// after 100 ms and asserts that WaitReady returns nil once the server is ready.
+func TestWaitReadyBecomesReady(t *testing.T) {
+	var ready atomic.Bool
+	time.AfterFunc(100*time.Millisecond, func() { ready.Store(true) })
+
+	udsPath := startShimOnUDS(t, func() bool { return ready.Load() })
+	tr := NewTransport(WithDirectDial())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := tr.WaitReady(ctx, udsPath, "/shim/ready"); err != nil {
+		t.Errorf("WaitReady: %v", err)
+	}
+}
+
+// TestWaitReadyTimeout asserts that WaitReady returns a non-nil error when the
+// context expires before the server ever reports ready.
+func TestWaitReadyTimeout(t *testing.T) {
+	// Server is permanently not ready.
+	udsPath := startShimOnUDS(t, func() bool { return false })
+	tr := NewTransport(WithDirectDial())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	if err := tr.WaitReady(ctx, udsPath, "/shim/ready"); err == nil {
+		t.Error("WaitReady: want non-nil error on timeout, got nil")
+	}
+}
+
+// hangFirstListener makes the FIRST accepted connection wedge (never serviced),
+// simulating the Firecracker post-restore vsock RX-queue race; every subsequent
+// connection is passed through to the real server.
+type hangFirstListener struct {
+	net.Listener
+	tripped atomic.Bool
+	stop    chan struct{}
+}
+
+func (l *hangFirstListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err // nosemgrep: no-bare-error-return
+	}
+	if l.tripped.CompareAndSwap(false, true) {
+		return &hangConn{Conn: c, stop: l.stop}, nil
+	}
+	return c, nil
+}
+
+// hangConn blocks on Read until stop is closed, so the server never reads the
+// request on the wedged first connection and the client's per-attempt deadline
+// must fire for it to make progress.
+type hangConn struct {
+	net.Conn
+	stop chan struct{}
+}
+
+func (c *hangConn) Read(_ []byte) (int, error) {
+	<-c.stop
+	return 0, io.EOF
+}
+
+// TestWaitReadyRetriesPastWedgedFirstConnection is the regression test for the
+// warm-restore latency bug: the first post-restore connection wedges, and
+// WaitReady must abandon it at the per-attempt deadline and reconnect, returning
+// well under the (generous) outer context rather than blocking on it.
+func TestWaitReadyRetriesPastWedgedFirstConnection(t *testing.T) {
+	udsPath := t.TempDir() + "/shim.sock"
+	base, err := net.Listen("unix", udsPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	stop := make(chan struct{})
+	defer close(stop)
+	ln := &hangFirstListener{Listener: base, stop: stop}
+	srv := &http.Server{Handler: newShimMux(func() bool { return true })}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	tr := NewTransport(WithDirectDial())
+	// Outer budget is deliberately generous: without the per-attempt cap the
+	// wedged first connection would block WaitReady for the full 5s.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	if err := tr.WaitReady(ctx, udsPath, "/shim/ready"); err != nil {
+		t.Fatalf("WaitReady: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("WaitReady took %v; the per-attempt cap should abandon the wedged connection and retry well under the 5s outer ctx", elapsed)
+	}
+}
+
+// TestPrimeShedsWedgedFirstConnection verifies that Prime absorbs the
+// post-restore RX-queue race off the readiness path: the first vsock connection
+// wedges, and Prime's tight per-attempt deadline abandons it and re-rolls,
+// completing well under the generous outer budget so the subsequent WaitReady
+// lands clean.
+func TestPrimeShedsWedgedFirstConnection(t *testing.T) {
+	udsPath := t.TempDir() + "/shim.sock"
+	base, err := net.Listen("unix", udsPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	stop := make(chan struct{})
+	defer close(stop)
+	ln := &hangFirstListener{Listener: base, stop: stop}
+	srv := &http.Server{Handler: newShimMux(func() bool { return true })}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	tr := NewTransport(WithDirectDial())
+	// Outer budget is deliberately generous: the value comes from Prime shedding
+	// the wedged first connection at its tight per-attempt cap, not from the ctx.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	if err := tr.Prime(ctx, udsPath); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("Prime took %v; the tight per-attempt cap should shed the wedged connection and re-roll fast", elapsed)
+	}
+}
+
+// TestPrimeTimesOutWhenNeverReachable asserts Prime returns a non-nil error when
+// the vsock path never opens before ctx expires, so the caller can log it and
+// fall through to WaitReady.
+func TestPrimeTimesOutWhenNeverReachable(t *testing.T) {
+	// A path with no listener: every dial fails, so no probe ever completes.
+	udsPath := t.TempDir() + "/absent.sock"
+	tr := NewTransport(WithDirectDial())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	if err := tr.Prime(ctx, udsPath); err == nil {
+		t.Error("Prime: want non-nil error when the vsock path never opens, got nil")
+	}
+}
+
+// TestRoundTripContextCancel verifies that a context cancelled before the call
+// causes RoundTrip to return promptly with an error.
+func TestRoundTripContextCancel(t *testing.T) {
+	udsPath := startShimOnUDS(t, nil)
+	tr := NewTransport(WithDirectDial())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the request is made
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://vsock/invoke", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	_, err = tr.RoundTrip(ctx, udsPath, req)
+	if err == nil {
+		t.Error("RoundTrip: want non-nil error on cancelled context, got nil")
+	}
+}

--- a/projects/embervm/noded/vsockproto/BUILD
+++ b/projects/embervm/noded/vsockproto/BUILD
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "vsockproto",
+    srcs = ["proto.go"],
+    importpath = "github.com/jomcgi/homelab/projects/embervm/noded/vsockproto",
+    visibility = ["//projects/embervm/noded:__subpackages__"],
+)

--- a/projects/embervm/noded/vsockproto/proto.go
+++ b/projects/embervm/noded/vsockproto/proto.go
@@ -1,0 +1,33 @@
+// Package vsockproto is embervm-noded's forked copy of the Firecracker vsock
+// addressing constants the host-side transport and egress forwarder need. It is
+// a DELIBERATE, minimal FORK of projects/firecracker/substrate/vsockproto (ADR
+// embervm/001: embervm-noded shares no Go packages with projects/firecracker).
+//
+// These port numbers ARE the frozen guest contract: the guest images embervm
+// runs listen on GuestHTTPPort for inbound task delivery and dial EgressPort for
+// tunnelled egress, exactly as the fc-invoke guests do. Because the contract is
+// frozen (embervm consumes the SAME guest images through the SAME wire), copying
+// the constants cannot drift; if the guest contract ever changes it changes in
+// lock-step on both sides by definition. Only the subset the KEEP packages
+// reference is carried here; the control-message and scan wire protocols do not
+// cross the noded boundary and are omitted.
+package vsockproto
+
+// Firecracker vsock addressing. The host is always context-id 2; guests get a
+// fixed id (the daemon reaches a guest by its per-thread host UDS, not by CID).
+// The guest dials these ports on the host.
+const (
+	// HostCID is the Firecracker-reserved host context id.
+	HostCID uint32 = 2
+	// GuestCID is the fixed guest context id every microVM is assigned.
+	GuestCID uint32 = 3
+	// EgressPort carries one tunnelled outbound HTTP request each, from the guest
+	// to the pod-local egress-proxy sidecar. Unused by the task class (task VMs
+	// get no NIC and egress is disabled), but kept so the forwarder compiles and
+	// a future egress-enabled workload needs no wire change.
+	EgressPort uint32 = 1025
+	// GuestHTTPPort carries the inbound HTTP request the daemon delivers to the
+	// guest's shim HTTP server over vsock. This is the frozen guest contract port
+	// (ADR 030); the transport dials it via the Firecracker CONNECT handshake.
+	GuestHTTPPort uint32 = 1027
+)


### PR DESCRIPTION
## What

EmberVM R0 Task 4: `embervm-noded`, a standalone Go daemon implementing the `embervm.node.v1` `NodeService` (the Task 3 stubs, PR #3488). It forks the fc-invoke node layer per ADR embervm/001 (fork-not-extend: **zero imports from `projects/firecracker`**) and reshapes it behind the gRPC contract. The daemon is the NodeService **server** and owns Firecracker lifecycle behind `BuildBase / Prime / Assign / Destroy / WatchNode / GetNodeStatus`.

## Reshape strategy (approved: Option A)

Copy the KEEP packages verbatim, fork a trimmed `substrate` seam, and replace the invoker with a gRPC server. The only fork that satisfies fork-not-extend without churning the live fc-invoke daemon.

- **Forked verbatim** (importpaths rewritten to `projects/embervm/noded/`): `fcvm/driver`, `fcvm/fcclient`, `vsockhttp` (keeps the 150ms per-attempt `WaitReady` + 2s restore-ready fix), `egress`, plus a trimmed `substrate` seam and a minimal `vsockproto` (the frozen guest-contract port constants only).
- **Reshaped, not copied**: the invoker becomes `server/` (the 6 RPCs) + `registry.go` (a `vm_id` PRIMED -> ASSIGNED -> destroyed state machine, single-use, teardown single-owned by registry removal so a racing `Destroy` never double-`Release`s a VM) + a base registry that reconciles from disk on startup.
- **Dropped on the fork**: HTTP ingress, path sessions, the workload JSON catalog, warm-base auto-build-at-startup, and the per-workload semaphore (concurrency is the control plane's; the daemon keeps only a node-level max-live-VM backstop).
- **Kept**: fcvm driver lifecycle, the vsock transport fixes, read-only-rootfs + tmpfs guest conventions, the egress forwarder (present but unused: task VMs get no NIC, egress disabled).

## Image + chart

- `projects/embervm/noded/image`: amd64-only apko image (Wolfi + busybox + ca-certs), Go binary at `/usr/local/bin/embervm-noded`, firecracker + guest kernel baked at `/opt/fc` via `@kata_firecracker`.
- `embervm-noded` is a **second, privileged, single-replica Deployment** in the embervm chart, pinned to `homelab.io/firecracker=true` (node-4), `Recreate`, drain grace = drain + 30s, **256Mi req / 2Gi limit** to fit the node-4 coexistence budget alongside fc-invoke (2Gi/50Gi). A distinct app name keeps its selector disjoint from the control plane's immutable one. Chart bumped 0.1.9 -> 0.1.10.

## Scope

This PR is the **daemon fork + image + chart only**. It primes **zero VMs** at rest; the control-plane dispatcher that calls it (Task 11) is deferred. Rendered locally with `helm template` (13 objects, clean).

## Tests

- Inherited `driver` / `vsockhttp` / `fcclient` tests carry over unchanged (the vsockhttp test is rewired off the `shim` package onto a stdlib HTTP server, since `shim` is not forked).
- A fake-driver gRPC integration test over `bufconn` covers **Prime -> Assign -> auto-destroy** and **Assign-after-destroy rejection (FAILED_PRECONDITION, no side effects)**, plus deadline-destroys-VM, cap-exhausted, idempotent Destroy, and BuildBase idempotency.

## Acceptance (post-merge, node-4)

- [ ] CI green including forked tests
- [ ] `embervm-noded` pod Ready on node-4 answering `WatchNode` (verify with grpcurl from the control-plane pod)
- [ ] zero VMs running
- [ ] fc-invoke untouched and still serving

🤖 Generated with [Claude Code](https://claude.com/claude-code)