### PR TITLE
feat(dr-jobs): track notification state on the vacancy row + wire WhatsApp

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.103
+version: 0.89.104
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.103
+      targetRevision: 0.89.104
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.182
+version: 0.285.183
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260713000000_dr_jobs_notified_columns.sql
+++ b/projects/monolith/chart/migrations/20260713000000_dr_jobs_notified_columns.sql
@@ -1,0 +1,18 @@
+-- dr-jobs notification state moves onto the vacancy row itself, so "was this
+-- posting announced?" becomes a column check rather than cross-system
+-- archaeology (scrape log -> outbox retention -> channel history). One nullable
+-- timestamp per channel: NULL means pending, a set value means delivered. A
+-- failed enqueue leaves the column NULL and the next hourly scrape retries
+-- (self-healing), replacing the old fire-and-forget notify() path that failed
+-- silently in the DATABASE_URL-only Argo job pod.
+ALTER TABLE dr_jobs.nhs_vacancies
+    ADD COLUMN notified_discord  timestamptz,
+    ADD COLUMN notified_whatsapp timestamptz;
+
+-- Backfill every existing row as already-notified so the switchover does not
+-- dump the current backlog into the chat (the data-model equivalent of the old
+-- seed-run digest suppression). Only postings scraped after this migration keep
+-- NULL columns and are therefore announced.
+UPDATE dr_jobs.nhs_vacancies
+    SET notified_discord = now(),
+        notified_whatsapp = now();

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:VF7OgHSrWAghs3m7Vf3nD/M20ip6ftykO5kbsCSmCmY=
+h1:6qLgWttoLT/GPpDZ6LSnJhpPtUo0sCMU/7hwy13CMTY=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -128,3 +128,4 @@ h1:VF7OgHSrWAghs3m7Vf3nD/M20ip6ftykO5kbsCSmCmY=
 20260711220000_chat_safeguards.sql h1:LE/nBwV/o6eyfSylKV2PKoj6/jluuDqs0dHKOLCHdWM=
 20260712000000_home_cluster_snapshot.sql h1:+9RRavaWXjyzk5iRiUSwBkZfdOPjKtuHNP4ywZLwMzs=
 20260712233000_semgrep_perf_cohort.sql h1:v8wnTdvoa85AVnyJG1BxEUDY74OBIG4IcuICmDBOjJw=
+20260713000000_dr_jobs_notified_columns.sql h1:xzxvvjmCXQ164L4yIrfzCOPTr8qg5EWDk7FPcS2vtH4=

--- a/projects/monolith/chat/api.py
+++ b/projects/monolith/chat/api.py
@@ -44,6 +44,9 @@ from chat.whatsapp_session import enqueue_message_sync as enqueue_whatsapp_messa
 from chat.whatsapp_session import (
     group_jid_for_session as whatsapp_group_jid_for_session,
 )
+from chat.whatsapp_session import (
+    household_group_jids as whatsapp_household_group_jids,
+)
 
 __all__ = [
     "Plan",
@@ -80,4 +83,5 @@ __all__ = [
     "pardon_user",
     "whatsapp_checklist_final",
     "whatsapp_group_jid_for_session",
+    "whatsapp_household_group_jids",
 ]

--- a/projects/monolith/chat/whatsapp_session.py
+++ b/projects/monolith/chat/whatsapp_session.py
@@ -32,7 +32,12 @@ from datetime import datetime, timezone
 from sqlmodel import Session, select
 
 from app.db import get_engine
-from chat.models import GoosecrackerSession, GoosecrackerSteering, WhatsappOutbox
+from chat.models import (
+    GoosecrackerSession,
+    GoosecrackerSteering,
+    WhatsappGroup,
+    WhatsappOutbox,
+)
 from chat.whatsapp_outbox import (
     enqueue_edit,
     enqueue_message,
@@ -474,6 +479,24 @@ def enqueue_message_sync(group_jid: str, content: str) -> None:
     with Session(get_engine()) as session:
         enqueue_message(session, group_jid, content=content)
         session.commit()
+
+
+def household_group_jids() -> list[str]:
+    """Return the JIDs of enabled household-tier WhatsApp groups.
+
+    Cross-domain digests (e.g. dr-jobs) deliver by group JID. The JID is PII and
+    lives only in the DB (``chat.whatsapp_group``), never in git, so callers read
+    it here rather than from a config value. Synchronous; call via
+    ``asyncio.to_thread``. Mirrors how the morning digest fans out over groups.
+    """
+    with Session(get_engine()) as session:
+        rows = session.exec(
+            select(WhatsappGroup.group_jid).where(
+                WhatsappGroup.enabled == True,  # noqa: E712 - SQL boolean, not `is`
+                WhatsappGroup.tier == "household",
+            )
+        ).all()
+    return list(rows)
 
 
 def group_jid_for_session(session_key: str) -> str:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.182
+      targetRevision: 0.285.183
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/dr_jobs/jobs.py
+++ b/projects/monolith/dr_jobs/jobs.py
@@ -6,9 +6,13 @@ to a worker thread (asyncio.to_thread) so it never blocks the scheduler event
 loop, mirroring hikes.scrape_walks_handler. The scheduler passes a session, but
 the DB work uses its own session inside the thread.
 
-When the upsert inserts genuinely new vacancies (and the run was not the initial
-seed of an empty table), the handler posts a one-message Discord digest to the
-dr-jobs channel so the partner is pinged the day a post appears.
+Notification state lives on the vacancy row (``notified_discord`` /
+``notified_whatsapp``), so "was this posting announced?" is a column check, not
+cross-system archaeology. After the upsert the handler claims un-notified,
+still-open rows, enqueues one digest per channel directly to the outbox, and
+stamps the column only on a successful enqueue, so a failed send is retried next
+run (self-healing). Rows inserted on the initial seed of an empty table are born
+already-stamped, so the switchover never dumps the existing backlog.
 """
 
 import asyncio
@@ -26,9 +30,12 @@ logger = logging.getLogger("dr_jobs")
 # Client-level ceiling; per-request timeouts in scraper.py are tighter.
 SCRAPE_TIMEOUT_SECS = 60.0
 
-# Discord channel for the new-jobs digest (same server as the monolith bot).
-# notify() enqueues to the outbox; the leader's bot posts it. The bot must be a
-# member of this channel's server (the operative boundary; no app allow-list).
+# Discord channel for the new-jobs digest (guild/server 1501965852042330302,
+# channel #anna-jobs 1516663194699960382). We enqueue straight to
+# chat.discord_outbox; the leader's bot drains and posts it. The bot being a
+# member of the channel's server is the operative boundary (no app allow-list).
+# Enqueuing directly (not via agent.notify) is what keeps the DATABASE_URL-only
+# Argo job pod able to notify at all.
 DISCORD_CHANNEL_ID = os.environ.get("DR_JOBS_DISCORD_CHANNEL_ID", "1516663194699960382")
 
 # Cap the digest so a large batch (or first real scrape after a long gap) cannot
@@ -114,9 +121,51 @@ def _persist(vacancies: list[dict]) -> tuple[list[dict], int, bool]:
             # without a session.add in the loop.
 
         if new_rows:
+            if was_seed:
+                # Backlog on an empty-table deploy is born already-notified so
+                # the first scrape does not dump every existing posting into the
+                # chat. Symmetric with the migration's backfill of prod rows.
+                for row in new_rows:
+                    row.notified_discord = now
+                    row.notified_whatsapp = now
             session.add_all(new_rows)
         session.commit()
     return new_vacancies, updated, was_seed
+
+
+def _pending(session, column, today: date) -> list[models.Vacancy]:
+    """Vacancies not yet notified on ``column`` and not past their closing date.
+
+    An open closing date (or none) keeps a posting eligible; a closed one is
+    skipped so a retry cannot resurrect a stale listing.
+    """
+    from sqlmodel import or_, select
+
+    return list(
+        session.exec(
+            select(models.Vacancy).where(
+                column.is_(None),
+                or_(
+                    models.Vacancy.closing_date.is_(None),
+                    models.Vacancy.closing_date >= today,
+                ),
+            )
+        ).all()
+    )
+
+
+def _digest_dicts(rows: list[models.Vacancy]) -> list[dict]:
+    """Minimal dicts (title/town/closing_date) that build_digest consumes."""
+    return [
+        {"title": r.title, "town": r.town, "closing_date": r.closing_date} for r in rows
+    ]
+
+
+def _stamp(rows: list[models.Vacancy], attr: str, when: datetime) -> None:
+    """Mark ``rows`` notified on ``attr``; they are session-tracked and flush on
+    the caller's commit."""
+    for row in rows:
+        setattr(row, attr, when)
 
 
 def _fmt_closing(value: date | None) -> str:
@@ -143,15 +192,73 @@ def build_digest(new_vacancies: list[dict]) -> str:
     return "\n".join(lines)
 
 
-async def _send_digest(new_vacancies: list[dict]) -> None:
-    """Post the new-jobs digest to Discord. Never raises (a notify failure must
-    not fail an otherwise-successful scrape)."""
-    try:
-        from agent.api import notify
+def _notify_pending_sync() -> None:
+    """Claim un-notified, still-open vacancies and deliver one digest per channel.
 
-        await notify(build_digest(new_vacancies), channel=DISCORD_CHANNEL_ID)
-    except Exception:  # noqa: BLE001 - best-effort side channel
-        logger.warning("dr_jobs: failed to post new-jobs Discord digest", exc_info=True)
+    Source of truth is the row: ``notified_<channel> IS NULL`` plus an open
+    closing date means pending. On a successful enqueue we stamp the column, so a
+    failed send leaves it NULL and the next hourly run retries. Channels are
+    independent (a WhatsApp failure never blocks Discord) and each commits on its
+    own, so one channel's stamp is durable even if the other raises. Runs off the
+    event loop via asyncio.to_thread.
+    """
+    from chat.api import (
+        enqueue_message,
+        enqueue_whatsapp_message,
+        whatsapp_household_group_jids,
+    )
+    from sqlmodel import Session
+
+    from app.db import get_engine
+
+    now = datetime.now(timezone.utc)
+    today = now.date()
+
+    with Session(get_engine()) as session:
+        # --- Discord (enqueue uses this session; caller commits) ---
+        try:
+            pending = _pending(session, models.Vacancy.notified_discord, today)
+            if pending:
+                enqueue_message(
+                    session,
+                    DISCORD_CHANNEL_ID,
+                    content=build_digest(_digest_dicts(pending)),
+                )
+                _stamp(pending, "notified_discord", now)
+                session.commit()
+                logger.info(
+                    "dr_jobs: enqueued Discord digest for %d vacancies", len(pending)
+                )
+        except Exception:  # noqa: BLE001 - best-effort; NULL column retries
+            session.rollback()
+            logger.warning(
+                "dr_jobs: Discord digest enqueue failed; will retry next run",
+                exc_info=True,
+            )
+
+        # --- WhatsApp (enqueue self-commits per group; enqueue-then-stamp so a
+        # failure leaves NULL rather than a silent miss) ---
+        try:
+            pending = _pending(session, models.Vacancy.notified_whatsapp, today)
+            jids = whatsapp_household_group_jids() if pending else []
+            if pending and jids:
+                digest = build_digest(_digest_dicts(pending))
+                for jid in jids:
+                    enqueue_whatsapp_message(jid, digest)
+                _stamp(pending, "notified_whatsapp", now)
+                session.commit()
+                logger.info(
+                    "dr_jobs: enqueued WhatsApp digest for %d vacancies to %d group(s)",
+                    len(pending),
+                    len(jids),
+                )
+            # No enabled household group -> leave NULL, retry once one exists.
+        except Exception:  # noqa: BLE001 - best-effort; NULL column retries
+            session.rollback()
+            logger.warning(
+                "dr_jobs: WhatsApp digest enqueue failed; will retry next run",
+                exc_info=True,
+            )
 
 
 async def scrape_nhs_handler(session) -> datetime | None:
@@ -183,8 +290,9 @@ async def scrape_nhs_handler(session) -> datetime | None:
         stats,
     )
 
-    # Suppress the digest on the initial backfill (every row is "new" then).
-    if new_vacancies and not was_seed:
-        await _send_digest(new_vacancies)
+    # Notification is driven by the row's notified_* columns, not this run's
+    # inserts: seed rows were stamped in _persist, so this only ever announces
+    # genuinely-new, still-open postings, and retries any prior failed send.
+    await asyncio.to_thread(_notify_pending_sync)
 
     return None

--- a/projects/monolith/dr_jobs/jobs_test.py
+++ b/projects/monolith/dr_jobs/jobs_test.py
@@ -9,7 +9,7 @@ JobId is what counts as "new".
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from sqlmodel import Session, SQLModel, create_engine, select
@@ -88,6 +88,121 @@ class TestPersist:
         jobs._persist([_vac("A")])
         with Session(engine) as s:
             assert s.get(Vacancy, "A").first_seen_at == first_seen
+
+
+def _insert(engine, job_id, *, closing, notified_discord=None, notified_whatsapp=None):
+    """Insert a single vacancy with explicit notification state (bypasses the
+    seed logic so a row can be born pending)."""
+    with Session(engine) as s:
+        v = Vacancy(**_vac(job_id, closing=closing))
+        v.notified_discord = notified_discord
+        v.notified_whatsapp = notified_whatsapp
+        s.add(v)
+        s.commit()
+
+
+@pytest.fixture(name="captured")
+def captured_fixture(monkeypatch):
+    """Capture the direct-to-outbox enqueue calls _notify_pending_sync makes.
+
+    The function does ``from chat.api import ...`` at call time, so patching the
+    chat.api attributes (not a local name) is what the local import picks up.
+    """
+    calls = {"discord": [], "whatsapp": []}
+    monkeypatch.setattr(
+        "chat.api.enqueue_message",
+        lambda session, channel_id, *, content=None, **_: calls["discord"].append(
+            (channel_id, content)
+        ),
+    )
+    monkeypatch.setattr(
+        "chat.api.enqueue_whatsapp_message",
+        lambda jid, content: calls["whatsapp"].append((jid, content)),
+    )
+    monkeypatch.setattr("chat.api.whatsapp_household_group_jids", lambda: ["g@g.us"])
+    return calls
+
+
+class TestSeedStamping:
+    def test_seed_rows_born_notified(self, engine):
+        # Every row on an empty-table seed is stamped so the switchover cannot
+        # dump the backlog into the chat.
+        jobs._persist([_vac("A")])
+        with Session(engine) as s:
+            a = s.get(Vacancy, "A")
+            assert a.notified_discord is not None
+            assert a.notified_whatsapp is not None
+
+    def test_nonseed_new_row_left_pending(self, engine):
+        jobs._persist([_vac("SEED")])  # seed run stamps SEED
+        jobs._persist([_vac("SEED"), _vac("A")])  # A is a new, non-seed insert
+        with Session(engine) as s:
+            a = s.get(Vacancy, "A")
+            assert a.notified_discord is None
+            assert a.notified_whatsapp is None
+
+
+class TestNotifyPending:
+    def test_enqueues_and_stamps_open_pending(self, engine, captured):
+        _insert(engine, "A", closing=date.today() + timedelta(days=5))
+        jobs._notify_pending_sync()
+        assert len(captured["discord"]) == 1
+        channel, content = captured["discord"][0]
+        assert channel == jobs.DISCORD_CHANNEL_ID
+        assert "1 new NHS Scotland" in content
+        assert captured["whatsapp"] == [("g@g.us", content)]
+        with Session(engine) as s:
+            a = s.get(Vacancy, "A")
+            assert a.notified_discord is not None
+            assert a.notified_whatsapp is not None
+
+    def test_skips_closed_vacancy(self, engine, captured):
+        _insert(engine, "A", closing=date.today() - timedelta(days=1))
+        jobs._notify_pending_sync()
+        assert captured["discord"] == []
+        assert captured["whatsapp"] == []
+        with Session(engine) as s:
+            assert s.get(Vacancy, "A").notified_discord is None
+
+    def test_does_not_renotify_already_stamped(self, engine, captured):
+        stamp = datetime.now(timezone.utc)
+        _insert(
+            engine,
+            "A",
+            closing=date.today() + timedelta(days=5),
+            notified_discord=stamp,
+            notified_whatsapp=stamp,
+        )
+        jobs._notify_pending_sync()
+        assert captured["discord"] == []
+        assert captured["whatsapp"] == []
+
+    def test_whatsapp_no_group_leaves_it_pending(self, engine, captured, monkeypatch):
+        # Discord still fires; WhatsApp stays NULL until a group is configured.
+        monkeypatch.setattr("chat.api.whatsapp_household_group_jids", lambda: [])
+        _insert(engine, "A", closing=date.today() + timedelta(days=5))
+        jobs._notify_pending_sync()
+        assert len(captured["discord"]) == 1
+        assert captured["whatsapp"] == []
+        with Session(engine) as s:
+            a = s.get(Vacancy, "A")
+            assert a.notified_discord is not None
+            assert a.notified_whatsapp is None
+
+    def test_discord_failure_isolated_and_retryable(
+        self, engine, captured, monkeypatch
+    ):
+        def boom(*_a, **_k):
+            raise RuntimeError("outbox down")
+
+        monkeypatch.setattr("chat.api.enqueue_message", boom)
+        _insert(engine, "A", closing=date.today() + timedelta(days=5))
+        jobs._notify_pending_sync()  # must not raise
+        with Session(engine) as s:
+            a = s.get(Vacancy, "A")
+            assert a.notified_discord is None  # left NULL -> retried next run
+            assert a.notified_whatsapp is not None  # WhatsApp still delivered
+        assert len(captured["whatsapp"]) == 1
 
 
 class TestBuildDigest:

--- a/projects/monolith/dr_jobs/models.py
+++ b/projects/monolith/dr_jobs/models.py
@@ -36,3 +36,11 @@ class Vacancy(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-fac
     first_seen_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     last_seen_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     scraped_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    # Per-channel notification state (source of truth for the new-jobs digest).
+    # NULL = pending, a timestamp = delivered. The scrape claims NULL+open rows,
+    # enqueues one digest per channel, and stamps only on a successful enqueue,
+    # so a failed send is retried next run. Seed/backfilled rows are born stamped
+    # so the switchover never dumps the existing backlog. See dr_jobs/jobs.py and
+    # migration 20260713000000_dr_jobs_notified_columns.sql.
+    notified_discord: datetime | None = None
+    notified_whatsapp: datetime | None = None


### PR DESCRIPTION
## Why

You asked "are our dr-jobs notifications working?" They are **not** (silently, again). Diagnosis from prod:

- `chat.discord_outbox` **retains all posted rows** (733 rows, Jun 22 to Jul 13, none pending), yet has **zero rows ever** for the anna-jobs channel `1516663194699960382`, on any channel no message ever mentions "anaesthetic" / "NHS Scotland".
- Two jobs were first-seen **after** the #2888 fix (262960 on Jun 29, 260912 on Jul 2), so each should have produced a digest.
- Root cause: the digest routes through `agent.notify()`, which needs more than `DATABASE_URL` to succeed in the Argo job pod. `_send_digest` swallows the exception, the scrape reports `Succeeded`, and the inserted row is never retried. Same class as #2888, one layer deeper. The changelog jobs never broke because they enqueue **directly** to the outbox.

## What

Make the vacancy row the source of truth for notification state, so "did it notify?" is a column check instead of cross-system archaeology.

- **Schema:** `dr_jobs.nhs_vacancies` gains `notified_discord` / `notified_whatsapp` (`timestamptz`, NULL = pending). Migration backfills existing rows to `now()` so the switchover does not dump the backlog into chat (data-model equivalent of the old seed suppression).
- **Claim-and-stamp:** the hourly scrape selects `notified_<channel> IS NULL AND` still-open, enqueues **one digest per channel directly to the outbox** (DB-only, so the job pod can always notify), and stamps the column only on a successful enqueue. A failed send leaves NULL and the next run retries (self-healing). Channels are independent: WhatsApp failing never blocks Discord.
- **WhatsApp wired:** delivered to enabled household-tier groups resolved from `chat.whatsapp_group` via a new `chat.api.whatsapp_household_group_jids()` accessor (JID stays in the DB, never in git).
- **Seed path:** rows born on an empty-table seed run are stamped already-notified, so a fresh deploy never dumps its first scrape.

## Health check after this ships
```sql
SELECT count(*) FROM dr_jobs.nhs_vacancies
WHERE notified_discord IS NULL AND closing_date >= current_date;
```
Should be ~0 within an hour of any scrape.

## Notes
- Chart bumped (monolith 0.285.183 + coupled monolith-public 0.89.104); `atlas.sum` regenerated (only the new line added).
- Tests cover seed-stamping, claim/skip-closed, no-renotify, WhatsApp-no-group, and Discord-failure isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)