### PR TITLE
feat(embervm): node registry consuming daemon health stream (Task 9)

### DIFF
--- a/bazel/erlang/BUILD
+++ b/bazel/erlang/BUILD
@@ -77,10 +77,14 @@ genrule(
         "//projects/embervm/control:srcs",
         "//projects/embervm/control:mix.exs",
         "@hex_archive//file",
+        # Generated node.proto Elixir stub, staged into control/lib/ by mix_test.sh
+        # so prod lib/ code referencing Embervm.Node.V1.* (Task 9's NodeRegistry)
+        # compiles in the general test lane. Nothing generated is checked in.
+        "//projects/embervm/proto/embervm/node/v1:node_elixir_src",
         ":hex_tarballs",
     ],
     outs = ["mix_test_smoke.txt"],
-    cmd = "$(location mix_test.sh) \"$(location @otp_ubuntu2204_amd64//:Install)\" \"$(location @elixir_1_18_4//:bin/elixir)\" \"$(location //projects/embervm/control:mix.exs)\" \"$@\" \"$(location @hex_archive//file)\" $(locations :hex_tarballs)",
+    cmd = "$(location mix_test.sh) \"$(location @otp_ubuntu2204_amd64//:Install)\" \"$(location @elixir_1_18_4//:bin/elixir)\" \"$(location //projects/embervm/control:mix.exs)\" \"$@\" \"$(location @hex_archive//file)\" \"$(location //projects/embervm/proto/embervm/node/v1:node_elixir_src)\" $(locations :hex_tarballs)",
     tags = ["no-remote-cache"],
     tools = ["mix_test.sh"],
 )

--- a/bazel/erlang/mix_release.sh
+++ b/bazel/erlang/mix_release.sh
@@ -12,8 +12,8 @@
 # pattern).
 #
 # Args: $1 OTP Install script, $2 elixir bin/elixir anchor, $3 control mix.exs
-#       anchor, $4 output tar, $5 hex.ez archive, $6.. hex dependency tarballs
-#       (may be empty).
+#       anchor, $4 output tar, $5 hex.ez archive, $6 generated node.pb.ex,
+#       $7.. hex dependency tarballs (may be empty).
 set -euo pipefail
 
 install_script="$1"
@@ -21,7 +21,8 @@ elixir_anchor="$2"
 mixexs="$3"
 out="$4"
 hex_ez="$5"
-shift 5
+node_pb_ex="$6"
+shift 6
 # Remaining args ("$@") are hex dependency tarballs.
 
 case "$out" in
@@ -31,6 +32,10 @@ esac
 case "$hex_ez" in
 /*) ;;
 *) hex_ez="$(pwd)/$hex_ez" ;;
+esac
+case "$node_pb_ex" in
+/*) ;;
+*) node_pb_ex="$(pwd)/$node_pb_ex" ;;
 esac
 
 otp_src="$(cd "$(dirname "$install_script")" && pwd)"
@@ -51,6 +56,13 @@ trap 'rm -rf "$work"' EXIT
 cp -RL "$otp_src"/. "$work/otp/"
 cp -RL "$elixir_src"/. "$work/elixir/"
 cp -RL "$control_src"/. "$work/control/"
+
+# Inject the generated node.proto Elixir stub into the app (mix globs lib/**), so
+# Embervm.NodeRegistry (which references Embervm.Node.V1.*) compiles into the
+# release. Build product kept out of committed control/; staged here exactly as
+# mix_test.sh and the round-trip test stage it.
+mkdir -p "$work/control/lib/embervm/node/v1"
+cp "$node_pb_ex" "$work/control/lib/embervm/node/v1/node.pb.ex"
 
 # Unpack each hex dependency tarball into deps/<name>/ (see mix_test.sh for the
 # path-dep rationale). exqlite compiles its bundled sqlite3.c here (force_build in

--- a/bazel/erlang/mix_test.sh
+++ b/bazel/erlang/mix_test.sh
@@ -5,8 +5,8 @@
 # 1's toolchain (bin/erl was proved by otp_smoke).
 #
 # Args: $1 OTP Install script, $2 elixir bin/elixir anchor, $3 control mix.exs
-#       anchor, $4 output marker, $5 hex.ez archive, $6.. hex dependency tarballs
-#       (may be empty).
+#       anchor, $4 output marker, $5 hex.ez archive, $6 generated node.pb.ex,
+#       $7.. hex dependency tarballs (may be empty).
 set -euo pipefail
 
 install_script="$1"
@@ -14,7 +14,8 @@ elixir_anchor="$2"
 mixexs="$3"
 out="$4"
 hex_ez="$5"
-shift 5
+node_pb_ex="$6"
+shift 6
 # Remaining args ("$@") are hex dependency tarballs.
 
 # Absolutize the output before we cd away (Bazel passes it execroot-relative).
@@ -25,6 +26,10 @@ esac
 case "$hex_ez" in
 /*) ;;
 *) hex_ez="$(pwd)/$hex_ez" ;;
+esac
+case "$node_pb_ex" in
+/*) ;;
+*) node_pb_ex="$(pwd)/$node_pb_ex" ;;
 esac
 
 otp_src="$(cd "$(dirname "$install_script")" && pwd)"
@@ -47,6 +52,14 @@ trap 'rm -rf "$work"' EXIT
 cp -RL "$otp_src"/. "$work/otp/"
 cp -RL "$elixir_src"/. "$work/elixir/"
 cp -RL "$control_src"/. "$work/control/"
+
+# Inject the generated node.proto Elixir stub into the app (mix globs lib/**).
+# It is a build product kept out of the committed control/ (see the proto codegen
+# genrule), so prod lib/ code that references Embervm.Node.V1.* (Task 9's
+# NodeRegistry) only compiles once it is staged here, the same injection the
+# round-trip test and the release build use.
+mkdir -p "$work/control/lib/embervm/node/v1"
+cp "$node_pb_ex" "$work/control/lib/embervm/node/v1/node.pb.ex"
 
 # Unpack each hex dependency tarball into deps/<name>/. Hex tarballs nest the
 # source inside contents.tar.gz; the control mix.exs consumes each as a `path:`

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.10
+version: 0.1.11

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -40,9 +40,20 @@ spec:
               value: {{ .Values.service.port | quote }}
             - name: EMBERVM_OPLOG_PATH
               value: /var/lib/embervm/oplog.db
+            # Node identity + address for Embervm.NodeRegistry (Task 9). The
+            # registry takes a LIST internally; v1 wires exactly one node from
+            # these two values.
+            - name: EMBERVM_NODE_ID
+              value: {{ .Values.node.id | quote }}
             {{- if .Values.node.address }}
             - name: EMBERVM_NODE_ADDRESS
               value: {{ .Values.node.address | quote }}
+            {{- else if .Values.noded.enabled }}
+            # No explicit node.address override: derive the in-cluster noded
+            # Service DNS from the release name (survives a release rename, per
+            # the Helm service-name convention) rather than hardcoding it.
+            - name: EMBERVM_NODE_ADDRESS
+              value: {{ printf "%s.%s.svc.cluster.local:%d" (include "embervm.noded.fullname" .) .Release.Namespace (int .Values.noded.grpcPort) | quote }}
             {{- end }}
             {{- if .Values.auth.allowedServiceAccounts }}
             # TokenReview allow-list: ServiceAccount usernames permitted to

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -43,11 +43,27 @@ opLog:
 
 # The single node daemon the control plane talks to (v1: exactly one). Address is
 # resolved in-cluster; the registry takes a list so multi-node needs no reshape.
+#
+# SINGLE-NODE ONLY while noded is a Deployment (replicas: 1) behind a ClusterIP
+# Service: the derived address resolves to the one pod. A DaemonSet across
+# multiple firecracker nodes cannot be served this way (a ClusterIP fans a single
+# stream out to a random pod); that requires a HEADLESS noded Service +
+# EndpointSlice discovery in the control plane, feeding the same list seam. See
+# Embervm.Application.configured_nodes/0.
 node:
-  # embervm-noded is a later PR (Task 4); this is the address the NodeRegistry
-  # dials once it exists.
+  # Correlation id the control plane configures for this daemon (echoed in
+  # WatchNodeRequest.node_id and used as the NodeRegistry's capacity-table key).
+  # The daemon reports its own node id in NodeStatus regardless; this is a label.
+  # noded is node-pinned to node-4 (homelab.io/firecracker=true).
+  id: node-4
+  # gRPC address the NodeRegistry dials. Empty means "derive the in-cluster
+  # embervm-noded Service DNS from the release" (see deployment.yaml); set this
+  # only to point the control plane at a daemon outside this release.
   address: ""
   # Static bearer token secret (1Password-provisioned) gating the daemon gRPC.
+  # Deferred to Task 11: noded currently runs open (noded.bearerTokenSecret.enabled
+  # false, mesh policy is the layer), so the registry dials plaintext with no
+  # metadata in v1.
   bearerTokenSecret: ""
 
 # TokenReview auth allow-list: ServiceAccount usernames permitted to submit tasks.

--- a/projects/embervm/control/BUILD
+++ b/projects/embervm/control/BUILD
@@ -32,10 +32,15 @@ genrule(
         ":srcs",
         "mix.exs",
         "@hex_archive//file",
+        # Generated node.proto Elixir stub, staged into control/lib/ by
+        # mix_release.sh so Embervm.NodeRegistry (Task 9) enters the release.
+        # Promoting the gRPC deps to prod (mix.exs) + baking this stub is why the
+        # release image digest changes and this PR bumps the chart.
+        "//projects/embervm/proto/embervm/node/v1:node_elixir_src",
         "//bazel/erlang:hex_tarballs",
     ],
     outs = ["embervm-release.tar"],
-    cmd = "$(location //bazel/erlang:mix_release.sh) \"$(location @otp_ubuntu2204_amd64//:Install)\" \"$(location @elixir_1_18_4//:bin/elixir)\" \"$(location mix.exs)\" \"$@\" \"$(location @hex_archive//file)\" $(locations //bazel/erlang:hex_tarballs)",
+    cmd = "$(location //bazel/erlang:mix_release.sh) \"$(location @otp_ubuntu2204_amd64//:Install)\" \"$(location @elixir_1_18_4//:bin/elixir)\" \"$(location mix.exs)\" \"$@\" \"$(location @hex_archive//file)\" \"$(location //projects/embervm/proto/embervm/node/v1:node_elixir_src)\" $(locations //bazel/erlang:hex_tarballs)",
     tools = ["//bazel/erlang:mix_release.sh"],
     visibility = ["//projects/embervm:__subpackages__"],
 )

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -54,6 +54,14 @@ defmodule Embervm.Application do
       # tolerates the catalog table not existing yet), so their relative order
       # here is not load-bearing.
       Embervm.WorkloadWatcher,
+      # The node registry (Task 9): one supervised gRPC stream per configured node
+      # daemon, consuming WatchNode into the Embervm.NodeCapacity ETS table the
+      # dispatcher (Task 11) reads, and reassigning a downed node's in-flight tasks
+      # via Embervm.TaskStore. Placed after TaskStore (its reassignment path calls
+      # it) and after WorkloadWatcher; it dials the daemon directly over its own
+      # Mint gRPC connection, so it does not depend on the Finch pool. With no node
+      # wired (empty address), it supervises an empty node list and does nothing.
+      {Embervm.NodeRegistry, nodes: configured_nodes()},
       # Bandit + the router last: its handlers call Auth, TaskStore, and
       # SyncWait, so the HTTP surface must not accept requests until all are up.
       {Bandit, plug: Embervm.Router, scheme: :http, port: port}
@@ -83,6 +91,43 @@ defmodule Embervm.Application do
       nil -> nil
       "" -> nil
       path -> path
+    end
+  end
+
+  # The configured node daemons the registry consumes WatchNode from. v1 wires
+  # exactly one, from chart values (EMBERVM_NODE_ID + EMBERVM_NODE_ADDRESS); the
+  # registry interface takes a LIST so multi-node needs no reshaping here. An
+  # empty address (no daemon wired yet) yields an empty list, so the registry
+  # supervises nothing rather than crash-looping on a bad dial. The id falls back
+  # to the address when unset, purely for correlation labels.
+  #
+  # THIS STATIC-VALUES SOURCE IS SINGLE-NODE ONLY. It is correct today because
+  # noded is one node-pinned Deployment (replicas: 1) behind a ClusterIP Service,
+  # so the one address resolves to the one pod. It is NOT compatible with a
+  # DaemonSet: a ClusterIP Service load-balances a single stream to one arbitrary
+  # pod (the registry would see "one node" while N-1 daemons stay invisible, and
+  # read capacity from the wrong pod), and values cannot enumerate churning pod
+  # IPs. The multi-node source is endpoint discovery: a HEADLESS noded Service
+  # (clusterIP: None) plus an EndpointSlice/Pod watch that opens a stream per pod
+  # and ages one out when its pod drains. That swap changes ONLY this function
+  # (it produces the same [%{id, address}] list); Embervm.NodeRegistry, its ETS
+  # projection, age-out, and reassignment are unchanged. Land it when noded
+  # actually becomes a DaemonSet.
+  defp configured_nodes do
+    address = trimmed_env("EMBERVM_NODE_ADDRESS")
+    id = trimmed_env("EMBERVM_NODE_ID")
+
+    cond do
+      address == "" -> []
+      id == "" -> [%{id: address, address: address}]
+      true -> [%{id: id, address: address}]
+    end
+  end
+
+  defp trimmed_env(name) do
+    case System.get_env(name) do
+      nil -> ""
+      value -> String.trim(value)
     end
   end
 

--- a/projects/embervm/control/lib/embervm/node_capacity.ex
+++ b/projects/embervm/control/lib/embervm/node_capacity.ex
@@ -1,0 +1,91 @@
+defmodule Embervm.NodeCapacity do
+  @moduledoc """
+  Pure ETS accessor for the node capacity facts the control plane learns from
+  each daemon's `WatchNode` stream: NO process of its own. `Embervm.NodeRegistry`
+  owns the table's lifecycle (creates it on init, writes a node's facts on every
+  `NodeStatus`, deletes them the instant the node stops being dispatchable), and
+  this module is just the read/write surface both the registry and readers
+  (Task 11's dispatcher) call against a table name, never a PID.
+
+  This mirrors `Embervm.WorkloadCatalog` exactly, and for the same reason: the
+  dispatch hot path (Task 11) must read `free_primed_slots` per workload per node
+  in O(1) without serializing through a `GenServer.call` to the registry, so it
+  hits this `read_concurrency: true` table directly.
+
+  ## fail-closed by construction
+
+  The registry only ever `put/3`s a node whose health is `:healthy` AND whose
+  daemon is not `draining`; every degraded state (`:starting`, `:unknown`,
+  `:down`, or a draining daemon) `drop/2`s the row. So the table's contents ARE
+  the set of dispatchable nodes: a reader that finds no row for a node (or an
+  empty table) is looking at the correct, safe answer with no extra
+  interpretation. "No capacity facts means no dispatch" is the empty read, not a
+  branch a reader has to remember to write.
+  """
+
+  @table :embervm_node_capacity
+
+  @doc "The ETS table name every function defaults to when none is given."
+  @spec table() :: atom()
+  def table, do: @table
+
+  @doc """
+  Creates the capacity table. `:set` (one row per node id), `:public` (Task 11's
+  dispatcher reads it directly, outside the owning process), `:named_table`
+  (looked up by atom name, not PID), `read_concurrency: true` (writes happen only
+  on a status change or a health transition; reads happen on every dispatch
+  decision).
+  """
+  @spec create(atom()) :: atom()
+  def create(table \\ @table) do
+    :ets.new(table, [:set, :public, :named_table, read_concurrency: true])
+  end
+
+  @doc """
+  Writes one dispatchable node's capacity facts, keyed by its (daemon-reported)
+  node id. Only called by the registry for a node it has already decided is
+  dispatchable, so a row's mere presence is the dispatchable signal.
+  """
+  @spec put(atom(), String.t(), map()) :: true
+  def put(table \\ @table, node_id, facts) do
+    :ets.insert(table, {node_id, facts})
+  end
+
+  @doc "Removes a node's capacity facts (it is no longer dispatchable)."
+  @spec drop(atom(), String.t()) :: true
+  def drop(table \\ @table, node_id) do
+    :ets.delete(table, node_id)
+  end
+
+  @doc """
+  All dispatchable nodes' capacity facts, in no particular order. Empty when no
+  node is currently dispatchable (the fail-closed default). Returns `[]` rather
+  than raising when the table does not exist yet (the registry has not booted, or
+  is between a crash and its restart), so a reader is never blocked on the
+  registry's lifecycle.
+  """
+  @spec all(atom()) :: [map()]
+  def all(table \\ @table) do
+    if :ets.whereis(table) == :undefined do
+      []
+    else
+      :ets.select(table, [{{:_, :"$1"}, [], [:"$1"]}])
+    end
+  end
+
+  @doc """
+  One node's capacity facts by node id, or `:error` if that node is not currently
+  dispatchable (or the table does not exist yet).
+  """
+  @spec fetch(atom(), String.t()) :: {:ok, map()} | :error
+  def fetch(table \\ @table, node_id) do
+    if :ets.whereis(table) == :undefined do
+      :error
+    else
+      case :ets.lookup(table, node_id) do
+        [{^node_id, facts}] -> {:ok, facts}
+        [] -> :error
+      end
+    end
+  end
+end

--- a/projects/embervm/control/lib/embervm/node_capacity.ex
+++ b/projects/embervm/control/lib/embervm/node_capacity.ex
@@ -42,8 +42,10 @@ defmodule Embervm.NodeCapacity do
   end
 
   @doc """
-  Writes one dispatchable node's capacity facts, keyed by its (daemon-reported)
-  node id. Only called by the registry for a node it has already decided is
+  Writes one dispatchable node's capacity facts, keyed by the CONFIGURED node id
+  (the registry's stable per-node key, used identically by `drop/2` and
+  `fetch/2`); the daemon-reported id is carried inside the facts map as
+  `:node_id`. Only called by the registry for a node it has already decided is
   dispatchable, so a row's mere presence is the dispatchable signal.
   """
   @spec put(atom(), String.t(), map()) :: true

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -1,0 +1,620 @@
+defmodule Embervm.NodeRegistry do
+  @moduledoc """
+  The control plane's single source of node truth. Holds one supervised gRPC
+  connection per configured node daemon (`embervm-noded`), consumes each
+  daemon's server-streamed `WatchNode` heartbeat, and projects the `NodeStatus`
+  facts into the `Embervm.NodeCapacity` ETS table the dispatcher (Task 11) reads
+  O(1).
+
+  The daemon is the health authority: it reports its own capacity (free primed
+  slots per workload, base build state, memory/cpu headroom, live/max VMs,
+  draining). This module never second-guesses those numbers; its whole job is to
+  keep a fresh copy of them and to decide, from stream liveness alone, whether a
+  node is still trustworthy.
+
+  ## consuming a blocking server-stream (the watcher discipline)
+
+  `NodeService.Stub.watch_node/2` returns an Enumerable whose iteration BLOCKS
+  for the stream's multi-second-to-minutes lifetime. Running that inside this
+  GenServer would freeze every capacity read behind it, so, exactly as
+  `Embervm.WorkloadWatcher` does for the K8s watch, each node's stream runs in a
+  `spawn_monitor`'d streamer process that forwards every `NodeStatus` back as a
+  message tagged with its own pid. The GenServer keeps sole ownership of the ETS
+  table, the per-node health state, and all reconnect decisions (a serialized,
+  crash-isolated state machine). A streamer crash surfaces as a `:DOWN` handled
+  like any other disconnect; it never takes the registry down. Events from a
+  superseded streamer (a reconnect race) are dropped so stale facts can never
+  overwrite fresh ones.
+
+  ## age-out is a TIMER, not the stream
+
+  The spec requires a node to age to `unknown` after 5s and `down` after 15s of
+  silence, and this must hold even when the stream SILENTLY WEDGES (the TCP
+  connection stays open but no `NodeStatus` arrives), which a blocking consumer
+  cannot observe on its own. So age-out is driven by a periodic tick in this
+  GenServer against a per-node `last_status_at` timestamp, entirely decoupled
+  from stream liveness:
+
+    * every `NodeStatus` stamps `last_status_at` and marks the node `:healthy`;
+    * a ~1s tick recomputes each node's health from `now - last_status_at`;
+    * crossing into `:down` fires the reassignment path ONCE and tears the
+      (possibly wedged) streamer down so a fresh connection is attempted, which
+      is the only way to recover from a silent wedge (a wedged stream never ends
+      on its own).
+
+  ## fail-closed
+
+  A node's capacity facts are written to `Embervm.NodeCapacity` ONLY while it is
+  `:healthy` and its daemon reports `draining: false`. Any degraded state
+  (`:starting` before the first status, `:unknown`, `:down`) and any `draining`
+  status immediately deletes the node's row. The `draining` flag therefore stops
+  new assignments the instant it is observed (the daemon's own drain grace still
+  lets in-flight Assigns finish; only a hard `:down` reassigns them). "No
+  capacity facts means no dispatch" is enforced by the table being empty, not by
+  the dispatcher checking a flag.
+
+  ## the multi-node seam
+
+  `start_link/1` takes `:nodes`, a LIST of `%{id, address}` specs. v1 configures
+  exactly one (from chart values), but every internal structure is keyed by node
+  id and every loop iterates the list, so multi-node needs no reshaping here,
+  only more entries in the list. There is deliberately no cross-node placement
+  logic in R0; that is the dispatcher's job (Task 11).
+  """
+
+  use GenServer
+  require Logger
+
+  alias Embervm.NodeCapacity
+
+  alias Embervm.Node.V1.{NodeService, NodeStatus, WatchNodeRequest, WorkloadCapacity}
+
+  @unknown_after_ms 5_000
+  @down_after_ms 15_000
+  @age_check_ms 1_000
+
+  # Reconnect backoff, same shape as Embervm.WorkloadWatcher: a healthy
+  # long-lived stream close reconnects immediately (reset to base); a fast or
+  # errored close backs off exponentially so a wedged/flapping daemon is not
+  # hammered.
+  @base_backoff_ms 1_000
+  @max_backoff_ms 30_000
+  @min_watch_ms 1_000
+
+  # -- Client API ------------------------------------------------------------
+
+  # :name defaults to __MODULE__ for the application's supervised singleton;
+  # tests pass name: nil to run several PID-addressed instances concurrently
+  # (the same idiom as the other GenServers in this app).
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc """
+  All currently dispatchable nodes' capacity facts (a direct read of the
+  `Embervm.NodeCapacity` table). Empty when no node is healthy. This is the read
+  Task 11's dispatcher makes; it does not go through this GenServer.
+  """
+  @spec capacity(atom()) :: [map()]
+  def capacity(table \\ NodeCapacity.table()) do
+    NodeCapacity.all(table)
+  end
+
+  @doc """
+  A snapshot of every configured node's health and last-known facts, for
+  operational visibility (a `kubectl exec` IEx query verifies the live daemon
+  connection this way) and tests. Unlike `capacity/1` this includes degraded
+  nodes, so an operator can see WHY a node is not dispatchable.
+  """
+  @spec status(GenServer.server()) :: %{String.t() => map()}
+  def status(server \\ __MODULE__) do
+    GenServer.call(server, :status)
+  end
+
+  @doc """
+  Applies one `NodeStatus` as if it arrived from the given node's current stream.
+  Test/operational seam: production status flows in from the streamer process,
+  but this lets a test drive the projection + fail-closed logic synchronously
+  without spawning a streamer. Unknown node ids are ignored.
+  """
+  @spec inject_status(GenServer.server(), String.t(), NodeStatus.t()) :: :ok
+  def inject_status(server, node_id, %NodeStatus{} = status) do
+    GenServer.call(server, {:inject_status, node_id, status})
+  end
+
+  @doc """
+  Forces one synchronous age-out evaluation across all nodes (the same code the
+  periodic timer runs). Tests drive age-out deterministically through this with
+  an injected clock; in production the timer fires it every #{@age_check_ms}ms.
+  """
+  @spec tick(GenServer.server()) :: :ok
+  def tick(server \\ __MODULE__) do
+    GenServer.call(server, :tick)
+  end
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    table = Keyword.get(opts, :table, NodeCapacity.table())
+    nodes = Keyword.get(opts, :nodes, [])
+    # Injected seams (defaults are the real gRPC + wall clock + task store):
+    connect_fun = Keyword.get(opts, :connect_fun, &default_connect/1)
+    watch_fun = Keyword.get(opts, :watch_fun, &default_watch/3)
+    disconnect_fun = Keyword.get(opts, :disconnect_fun, &default_disconnect/1)
+    clock = Keyword.get(opts, :clock, &default_clock/0)
+    reassign_fun = Keyword.get(opts, :reassign_fun, &default_reassign/1)
+    unknown_after = Keyword.get(opts, :unknown_after_ms, @unknown_after_ms)
+    down_after = Keyword.get(opts, :down_after_ms, @down_after_ms)
+    age_check = Keyword.get(opts, :age_check_ms, @age_check_ms)
+    base_backoff = Keyword.get(opts, :base_backoff_ms, @base_backoff_ms)
+    max_backoff = Keyword.get(opts, :max_backoff_ms, @max_backoff_ms)
+    min_watch = Keyword.get(opts, :min_watch_ms, @min_watch_ms)
+    # watch_startup drives the informer from init; tests set it false and drive
+    # inject_status/1 + tick/1 explicitly so no background stream or timer fires.
+    watch_startup = Keyword.get(opts, :watch_startup, true)
+
+    NodeCapacity.create(table)
+
+    now = clock.()
+
+    node_runtime =
+      for %{id: id, address: address} <- nodes, into: %{} do
+        {id,
+         %{
+           configured_id: id,
+           address: address,
+           # {pid, ref} of the live streamer, or nil when no stream is open.
+           streamer: nil,
+           backoff_ms: base_backoff,
+           # Monotonic ms the current stream opened, to tell a healthy long-lived
+           # close (reconnect now) from a suspect fast close (back off).
+           watch_started_at: now,
+           # Monotonic ms of the last NodeStatus. nil until the first arrives; the
+           # age baseline before then is started_at, so a daemon that never
+           # answers still ages starting -> unknown -> down.
+           last_status_at: nil,
+           started_at: now,
+           health: :starting,
+           draining: false
+         }}
+      end
+
+    state = %{
+      table: table,
+      clock: clock,
+      connect_fun: connect_fun,
+      watch_fun: watch_fun,
+      disconnect_fun: disconnect_fun,
+      reassign_fun: reassign_fun,
+      unknown_after_ms: unknown_after,
+      down_after_ms: down_after,
+      age_check_ms: age_check,
+      base_backoff_ms: base_backoff,
+      max_backoff_ms: max_backoff,
+      min_watch_ms: min_watch,
+      node_runtime: node_runtime,
+      # pid -> node_id for the CURRENT streamer of each node, so an event tagged
+      # with a superseded streamer's pid is dropped (never in this map).
+      streamers: %{}
+    }
+
+    if watch_startup do
+      {:ok, state, {:continue, :start}}
+    else
+      {:ok, state}
+    end
+  end
+
+  # Open every node's stream and arm the age-out timer once the process is fully
+  # initialized (continue runs after init returns, before any external message).
+  @impl true
+  def handle_continue(:start, state) do
+    state =
+      Enum.reduce(Map.keys(state.node_runtime), state, fn node_id, acc ->
+        start_streamer(acc, node_id)
+      end)
+
+    schedule_age_check(state)
+    {:noreply, state}
+  end
+
+  # A NodeStatus from the CURRENT streamer of some node. Events from a superseded
+  # streamer (not in state.streamers) are dropped so stale facts cannot overwrite
+  # fresh ones or resurrect a node we already tore down.
+  @impl true
+  def handle_info({:node_status, pid, status}, state) do
+    case Map.get(state.streamers, pid) do
+      nil -> {:noreply, state}
+      node_id -> {:noreply, apply_status(state, node_id, status)}
+    end
+  end
+
+  # A streamer finished (stream closed cleanly or errored). Decide the next move
+  # for its node: reconnect immediately on a healthy long-lived close, back off
+  # otherwise. Ignored if the pid is no longer the current streamer.
+  def handle_info({:watch_result, pid, result}, state) do
+    case Map.get(state.streamers, pid) do
+      nil ->
+        {:noreply, state}
+
+      node_id ->
+        state = forget_streamer(state, pid, node_id)
+        {:noreply, handle_watch_end(state, node_id, result)}
+    end
+  end
+
+  # A streamer died WITHOUT reporting a result (it always sends one in the normal
+  # path, so a bare DOWN is an abnormal exit or a deliberate kill from the
+  # down-edge wedge recovery). Treat as a watch error and reconnect with backoff.
+  # A DOWN from a superseded streamer (not the current one) is expected on
+  # supersession and ignored.
+  def handle_info({:DOWN, _ref, :process, pid, reason}, state) do
+    case Map.get(state.streamers, pid) do
+      nil ->
+        {:noreply, state}
+
+      node_id ->
+        state = forget_streamer(state, pid, node_id)
+        {:noreply, handle_watch_end(state, node_id, {:error, {:streamer_down, reason}})}
+    end
+  end
+
+  # Reconnect timer fired for a node whose stream is currently closed.
+  def handle_info({:reconnect, node_id}, state) do
+    rt = state.node_runtime[node_id]
+
+    if rt && is_nil(rt.streamer) do
+      {:noreply, start_streamer(state, node_id)}
+    else
+      {:noreply, state}
+    end
+  end
+
+  # Periodic age-out evaluation, then re-arm the timer.
+  def handle_info(:age_check, state) do
+    state = evaluate_ages(state)
+    schedule_age_check(state)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl true
+  def handle_call(:status, _from, state) do
+    snapshot =
+      for {node_id, rt} <- state.node_runtime, into: %{} do
+        facts =
+          case NodeCapacity.fetch(state.table, node_id) do
+            {:ok, f} -> f
+            :error -> nil
+          end
+
+        {node_id,
+         %{
+           configured_id: rt.configured_id,
+           address: rt.address,
+           health: rt.health,
+           draining: rt.draining,
+           dispatchable: not is_nil(facts),
+           facts: facts,
+           connected: not is_nil(rt.streamer)
+         }}
+      end
+
+    {:reply, snapshot, state}
+  end
+
+  def handle_call({:inject_status, node_id, status}, _from, state) do
+    if Map.has_key?(state.node_runtime, node_id) do
+      {:reply, :ok, apply_status(state, node_id, status)}
+    else
+      {:reply, :ok, state}
+    end
+  end
+
+  def handle_call(:tick, _from, state) do
+    {:reply, :ok, evaluate_ages(state)}
+  end
+
+  # Best-effort: stop orphaned streamers from outliving the GenServer holding
+  # their gRPC connections open. Not load-bearing (a dead owner's streamers exit
+  # when their monitored owner dies anyway), just tidy.
+  @impl true
+  def terminate(_reason, state) do
+    for {pid, _node_id} <- state.streamers, do: Process.exit(pid, :shutdown)
+    :ok
+  end
+
+  # -- status projection ------------------------------------------------------
+
+  # A fresh NodeStatus: stamp last_status_at, mark healthy, record draining, and
+  # publish or retract the node's capacity facts by whether it is dispatchable.
+  # Marking healthy here also resets the down-edge, so a node that recovers and
+  # later goes down again fires reassignment afresh.
+  defp apply_status(state, node_id, %NodeStatus{} = status) do
+    now = state.clock.()
+    rt = %{state.node_runtime[node_id] | last_status_at: now, health: :healthy, draining: status.draining}
+    state = put_in(state.node_runtime[node_id], rt)
+    refresh_capacity(state, node_id, status)
+  end
+
+  # A node is dispatchable iff its stream is healthy AND its daemon is not
+  # draining. Only then are its facts in the capacity table; every other case
+  # deletes the row (fail-closed). The table is keyed by the CONFIGURED node id
+  # (the node_runtime key, stable and known in every path); the daemon-reported
+  # id is carried inside the facts map for the dispatcher's correlation.
+  defp refresh_capacity(state, node_id, %NodeStatus{} = status) do
+    rt = state.node_runtime[node_id]
+
+    if rt.health == :healthy and not rt.draining do
+      NodeCapacity.put(state.table, node_id, facts_from_status(status, node_id, state.clock.()))
+    else
+      NodeCapacity.drop(state.table, node_id)
+    end
+
+    state
+  end
+
+  # Retract a node's capacity facts. Keyed by the configured node id, the same
+  # key refresh_capacity writes under, so degradation always deletes the row a
+  # prior status published.
+  defp retract_capacity(state, node_id) do
+    NodeCapacity.drop(state.table, node_id)
+    state
+  end
+
+  defp facts_from_status(%NodeStatus{} = s, configured_id, now) do
+    workloads =
+      for %WorkloadCapacity{} = wc <- s.workloads, into: %{} do
+        {wc.workload,
+         %{
+           free_primed_slots: wc.free_primed_slots,
+           snapshot_ref: wc.snapshot_ref,
+           base_state: wc.base_state
+         }}
+      end
+
+    %{
+      node_id: s.node_id,
+      configured_id: configured_id,
+      workloads: workloads,
+      mem_headroom_mib: s.mem_headroom_mib,
+      cpu_headroom_millicores: s.cpu_headroom_millicores,
+      live_vms: s.live_vms,
+      max_live_vms: s.max_live_vms,
+      draining: false,
+      updated_at: now
+    }
+  end
+
+  # -- age-out state machine --------------------------------------------------
+
+  # Recompute every node's health from time-since-last-status and act on any
+  # transition. This is the sole age-out authority, decoupled from stream
+  # liveness so a silently wedged stream still ages out.
+  defp evaluate_ages(state) do
+    now = state.clock.()
+
+    Enum.reduce(Map.keys(state.node_runtime), state, fn node_id, acc ->
+      evaluate_node_age(acc, node_id, now)
+    end)
+  end
+
+  defp evaluate_node_age(state, node_id, now) do
+    rt = state.node_runtime[node_id]
+    baseline = rt.last_status_at || rt.started_at
+    elapsed = now - baseline
+
+    new_health =
+      cond do
+        elapsed >= state.down_after_ms -> :down
+        elapsed >= state.unknown_after_ms -> :unknown
+        is_nil(rt.last_status_at) -> :starting
+        true -> :healthy
+      end
+
+    if new_health == rt.health do
+      state
+    else
+      apply_health_transition(state, node_id, rt.health, new_health)
+    end
+  end
+
+  # Health changed for a node. Update the runtime, keep the capacity table
+  # fail-closed (only :healthy-and-not-draining keeps a row; here we never enter
+  # from a fresh status so a non-healthy target always retracts), and on the edge
+  # INTO :down fire reassignment once and tear the streamer down to force a fresh
+  # connection (silent-wedge recovery).
+  defp apply_health_transition(state, node_id, _old_health, :healthy) do
+    # A tick can only compute :healthy when last_status_at is recent, which means
+    # apply_status already published facts; nothing to do but record it.
+    put_in(state, [:node_runtime, node_id, :health], :healthy)
+  end
+
+  defp apply_health_transition(state, node_id, old_health, new_health) do
+    state = put_in(state, [:node_runtime, node_id, :health], new_health)
+    state = retract_capacity(state, node_id)
+
+    if new_health == :down and old_health != :down do
+      handle_node_down(state, node_id)
+    else
+      state
+    end
+  end
+
+  # The node crossed into :down. Reassign its in-flight tasks (at-least-once, via
+  # the existing Retry policy) exactly once, and kill the current streamer if any
+  # so a wedged connection is dropped. The streamer is left registered so its
+  # ensuing :DOWN drives a backoff reconnect through handle_watch_end (forgetting
+  # it here would make the :DOWN a no-op and strand the node with no reconnect).
+  # When the streamer is already closed (nil), a reconnect is already pending from
+  # the last watch end, so there is nothing to do.
+  defp handle_node_down(state, node_id) do
+    Logger.warning("embervm node registry: node #{node_id} is DOWN (stream silent > #{state.down_after_ms}ms)")
+
+    try do
+      state.reassign_fun.(node_id)
+    rescue
+      e -> Logger.error("embervm node registry: reassign for #{node_id} raised: #{inspect(e)}")
+    end
+
+    case state.node_runtime[node_id].streamer do
+      {pid, _ref} -> Process.exit(pid, :kill)
+      nil -> :ok
+    end
+
+    state
+  end
+
+  # -- streamer lifecycle -----------------------------------------------------
+
+  # Spawn the monitored streamer that owns the blocking watch for one node.
+  # spawn_monitor (not link): a streamer crash surfaces as a :DOWN handled as a
+  # disconnect, never escalating to this GenServer. The streamer connects,
+  # forwards each NodeStatus tagged with its own pid, and always reports a final
+  # result even if the watch raises.
+  defp start_streamer(state, node_id) do
+    rt = state.node_runtime[node_id]
+    owner = self()
+    address = rt.address
+    configured_id = rt.configured_id
+    connect_fun = state.connect_fun
+    watch_fun = state.watch_fun
+    disconnect_fun = state.disconnect_fun
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        streamer = self()
+
+        result =
+          case connect_fun.(address) do
+            {:ok, channel} ->
+              try do
+                watch_fun.(channel, configured_id, fn status ->
+                  send(owner, {:node_status, streamer, status})
+                end)
+              catch
+                kind, reason -> {:error, {kind, reason}}
+              after
+                disconnect_fun.(channel)
+              end
+
+            {:error, reason} ->
+              {:error, {:connect, reason}}
+          end
+
+        send(owner, {:watch_result, streamer, result})
+      end)
+
+    rt = %{rt | streamer: {pid, ref}, watch_started_at: state.clock.()}
+
+    state
+    |> put_in([:node_runtime, node_id], rt)
+    |> put_in([:streamers, pid], node_id)
+  end
+
+  # Clear a streamer from the current-streamer index and the node runtime. Safe
+  # to call for a pid already forgotten (idempotent), which happens when the
+  # down-edge kill and the subsequent :DOWN both run.
+  defp forget_streamer(state, pid, node_id) do
+    state = %{state | streamers: Map.delete(state.streamers, pid)}
+
+    case state.node_runtime[node_id] do
+      %{streamer: {^pid, _ref}} = rt ->
+        put_in(state.node_runtime[node_id], %{rt | streamer: nil})
+
+      _ ->
+        state
+    end
+  end
+
+  # A watch ended for a node; decide how to resume. A healthy, long-lived clean
+  # close reconnects immediately (the daemon's normal stream refresh); a fast or
+  # errored close backs off exponentially first (hot-loop guard against a daemon
+  # that accepts then instantly closes, or a flapping mesh path).
+  defp handle_watch_end(state, node_id, result) do
+    rt = state.node_runtime[node_id]
+    clean = match?({:ok, :closed}, result)
+    long_lived = clean and state.clock.() - rt.watch_started_at >= state.min_watch_ms
+
+    if long_lived do
+      state
+      |> put_in([:node_runtime, node_id, :backoff_ms], state.base_backoff_ms)
+      |> start_streamer(node_id)
+    else
+      Logger.warning(
+        "embervm node registry: node #{node_id} stream ended (#{inspect(result)}), reconnect in #{rt.backoff_ms}ms"
+      )
+
+      schedule_reconnect(state, node_id)
+    end
+  end
+
+  # Arm a reconnect timer for one node and double its backoff (capped) for the
+  # next consecutive failure. A successful long-lived stream resets it to base.
+  defp schedule_reconnect(state, node_id) do
+    rt = state.node_runtime[node_id]
+    Process.send_after(self(), {:reconnect, node_id}, rt.backoff_ms)
+    next = min(rt.backoff_ms * 2, state.max_backoff_ms)
+    put_in(state, [:node_runtime, node_id, :backoff_ms], next)
+  end
+
+  defp schedule_age_check(state) do
+    Process.send_after(self(), :age_check, state.age_check_ms)
+  end
+
+  # -- default (production) seams --------------------------------------------
+
+  # Plaintext h2c to the noded Service over the Mint adapter (no TLS, no castore;
+  # the daemon listens on the pod network gated by mesh policy). This is the
+  # pattern the Task 3 Mint round-trip proved.
+  defp default_connect(address) do
+    GRPC.Stub.connect(address, adapter: GRPC.Client.Adapters.Mint)
+  end
+
+  defp default_disconnect(channel) do
+    _ = GRPC.Stub.disconnect(channel)
+    :ok
+  end
+
+  # Open WatchNode and forward each NodeStatus via emit. Returns {:ok, :closed}
+  # when the server ends the stream cleanly, or {:error, reason} on any transport
+  # or stream error, mirroring Embervm.WorkloadWatcher's watch contract so
+  # handle_watch_end treats both watches identically.
+  defp default_watch(channel, node_id, emit) do
+    case NodeService.Stub.watch_node(channel, %WatchNodeRequest{node_id: node_id}) do
+      {:ok, stream} ->
+        Enum.reduce_while(stream, {:ok, :closed}, fn
+          {:ok, %NodeStatus{} = status}, acc ->
+            emit.(status)
+            {:cont, acc}
+
+          {:error, reason}, _acc ->
+            {:halt, {:error, reason}}
+        end)
+
+      {:error, reason} ->
+        {:error, {:watch, reason}}
+    end
+  end
+
+  # The production reassignment path: a node going down means every task it held
+  # in-flight must be retried (at-least-once; we cannot know whether the guest
+  # completed). In v1 there is exactly one node, so every in-flight task IS on
+  # this node; Embervm.TaskStore.reassign_in_flight/0 fails each through the
+  # existing Retry policy (transport class -> failed_retryable, then the
+  # dispatcher's retry moves it back to queued). Inert until Task 11 actually
+  # dispatches (nothing is ever in-flight before then), but wired and correct.
+  defp default_reassign(node_id) do
+    Logger.warning("embervm node registry: reassigning in-flight tasks from downed node #{node_id}")
+    Embervm.TaskStore.reassign_in_flight()
+    :ok
+  end
+
+  defp default_clock, do: System.monotonic_time(:millisecond)
+end

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -448,12 +448,20 @@ defmodule Embervm.NodeRegistry do
   end
 
   # The node crossed into :down. Reassign its in-flight tasks (at-least-once, via
-  # the existing Retry policy) exactly once, and kill the current streamer if any
-  # so a wedged connection is dropped. The streamer is left registered so its
-  # ensuing :DOWN drives a backoff reconnect through handle_watch_end (forgetting
-  # it here would make the :DOWN a no-op and strand the node with no reconnect).
+  # the existing Retry policy) exactly once, then drop the current streamer if any
+  # so a wedged connection is torn down and reconnected.
+  #
+  # Ordering matters: we FORGET the streamer's pid before killing it, so a
+  # NodeStatus the streamer enqueued concurrently with this down-transition (a
+  # straggler still in our mailbox behind the age tick) is dropped by the
+  # handle_info pid guard rather than applied, which would otherwise resurrect the
+  # node to :healthy and republish capacity for a node we just declared down and
+  # reassigned. Because the pid is forgotten, the kill's ensuing :DOWN is ignored,
+  # so we schedule the backoff reconnect here explicitly instead of relying on it.
+  #
   # When the streamer is already closed (nil), a reconnect is already pending from
-  # the last watch end, so there is nothing to do.
+  # the last watch end (nil is only ever reached via forget_streamer, which is
+  # always immediately followed by handle_watch_end), so there is nothing to do.
   defp handle_node_down(state, node_id) do
     Logger.warning("embervm node registry: node #{node_id} is DOWN (stream silent > #{state.down_after_ms}ms)")
 
@@ -464,11 +472,14 @@ defmodule Embervm.NodeRegistry do
     end
 
     case state.node_runtime[node_id].streamer do
-      {pid, _ref} -> Process.exit(pid, :kill)
-      nil -> :ok
-    end
+      {pid, _ref} ->
+        state = forget_streamer(state, pid, node_id)
+        Process.exit(pid, :kill)
+        schedule_reconnect(state, node_id)
 
-    state
+      nil ->
+        state
+    end
   end
 
   # -- streamer lifecycle -----------------------------------------------------

--- a/projects/embervm/control/lib/embervm/task_store.ex
+++ b/projects/embervm/control/lib/embervm/task_store.ex
@@ -134,6 +134,25 @@ defmodule Embervm.TaskStore do
     GenServer.call(store, {:redrive, task_id})
   end
 
+  @doc """
+  Reassigns every in-flight task (`assigned` or `running`) as a retryable
+  transport failure and returns how many were reassigned. This is the
+  at-least-once path `Embervm.NodeRegistry` calls when a node goes down: a task
+  that was on the node when its daemon stopped answering must be retried because
+  we cannot know whether the guest completed. Each task flows through the exact
+  same `Embervm.Retry` classification as any other transport failure (`:transport`
+  is retryable by default), so a task with budget left becomes `failed_retryable`
+  (the dispatcher's `retry/2` later moves it back to `queued`) and one whose
+  budget is exhausted becomes `failed_permanent` and is dead-lettered, no
+  special node-down code path. In v1 there is exactly one node, so "in-flight" is
+  precisely "on the downed node"; multi-node filtering by assigned node is Task
+  11's concern once tasks record where they were dispatched.
+  """
+  @spec reassign_in_flight(GenServer.server()) :: {:ok, non_neg_integer()}
+  def reassign_in_flight(store \\ __MODULE__) do
+    GenServer.call(store, {:reassign_in_flight, :transport})
+  end
+
   # -- GenServer callbacks ---------------------------------------------------
 
   @impl true
@@ -359,6 +378,20 @@ defmodule Embervm.TaskStore do
     end
   end
 
+  def handle_call({:reassign_in_flight, reason}, _from, state) do
+    in_flight =
+      :ets.foldl(
+        fn {_id, task}, acc ->
+          if task.state in [:assigned, :running], do: [task | acc], else: acc
+        end,
+        [],
+        state.tasks
+      )
+
+    Enum.each(in_flight, fn task -> reassign_one(state, task, reason) end)
+    {:reply, {:ok, length(in_flight)}, state}
+  end
+
   # -- submit helpers --------------------------------------------------------
 
   defp do_submit(attrs, workload, idempotency_key, state) do
@@ -481,6 +514,33 @@ defmodule Embervm.TaskStore do
   defp reply_after_fail(state, task, :fail_retryable, prior_attempt, cfg) do
     backoff = Embervm.Retry.backoff_ms(prior_attempt, cfg)
     {:reply, {:ok, task, backoff}, state}
+  end
+
+  # Reassigns one in-flight task as a failure of `reason` (see
+  # reassign_in_flight/1). Mirrors the {:fail, ...} handler's classify ->
+  # transition -> append path, including the permanent-failure dead-letter chain,
+  # but discards the reply/backoff (the caller reassigns a whole batch and only
+  # needs the count). Best-effort per task: an op-log append error for one task is
+  # logged-by-omission and does not abort the batch, since a downed node's other
+  # tasks must still be reassigned.
+  defp reassign_one(state, task, reason) do
+    cfg = cfg_for(task.workload)
+    event = Embervm.Retry.classify(reason, task.attempt, cfg)
+    next = TaskState.transition!(task.state, event)
+
+    case append_and_update(state, task, :failed, next, %{state: next, reason: reason}) do
+      {:ok, updated} when event == :fail_permanent ->
+        case TaskState.transition(updated.state, :dead_letter) do
+          {:ok, dl} -> append_and_update(state, updated, :dead_lettered, dl, %{})
+          {:error, _} -> :ok
+        end
+
+      {:ok, _updated} ->
+        :ok
+
+      {:error, _reason} ->
+        :ok
+    end
   end
 
   defp fetch_task(state, task_id) do

--- a/projects/embervm/control/mix.exs
+++ b/projects/embervm/control/mix.exs
@@ -71,24 +71,26 @@ defmodule Embervm.MixProject do
       {:mint, path: "deps/mint", override: true},
       {:nimble_options, path: "deps/nimble_options", override: true},
       {:nimble_pool, path: "deps/nimble_pool", override: true},
-      # node.proto gRPC client (Task 3): protobuf is both the wire runtime and the
-      # source of the generated Embervm.Node.V1.* stubs (which `use GRPC.Service`
-      # / `use GRPC.Stub`); grpc -> grpc_core -> {googleapis, jason, protobuf,
-      # telemetry} is the client stack. The Mint transport reuses the already-
-      # pinned mint (grpc's gun transport is optional and not pulled), so no
-      # gun/cowlib/cowboy server subtree enters. See bazel/erlang/repositories.bzl.
+      # node.proto gRPC client (Task 3 codegen; Task 9 consumer): protobuf is both
+      # the wire runtime and the source of the generated Embervm.Node.V1.* stubs
+      # (which `use GRPC.Service` / `use GRPC.Stub`); grpc -> grpc_core ->
+      # {googleapis, jason, protobuf, telemetry} is the client stack. The Mint
+      # transport reuses the already-pinned mint (grpc's gun transport is optional
+      # and not pulled), so no gun/cowlib/cowboy server subtree enters. See
+      # bazel/erlang/repositories.bzl.
       #
-      # `only: :test` for now: Task 3 ships codegen + the cross-language round-trip
-      # test but no lib/ code calls the node client yet, so keeping these out of
-      # :prod leaves the release image (release_tar) byte-identical and this PR
-      # non-deploying. Task 4 (the dispatcher) promotes them to prod deps and
-      # bumps the chart when the client actually enters the release. Prod control
-      # code encodes JSON via OTP's built-in :json, not jason.
-      {:protobuf, path: "deps/protobuf", only: :test, override: true},
-      {:grpc, path: "deps/grpc", only: :test, override: true},
-      {:grpc_core, path: "deps/grpc_core", only: :test, override: true},
-      {:googleapis, path: "deps/googleapis", only: :test, override: true},
-      {:jason, path: "deps/jason", only: :test, override: true}
+      # Prod scope as of Task 9: Embervm.NodeRegistry consumes the WatchNode stream
+      # in lib/, so these enter the release. The generated node.pb.ex is staged
+      # into lib/embervm/node/v1/ at build time by bazel/erlang/mix_test.sh and
+      # mix_release.sh (never committed; see the proto codegen genrule), the same
+      # injection the round-trip test uses. Promoting these off `only: :test`
+      # changes the release image digest, so this PR bumps the chart. All pure
+      # Elixir/Erlang, no new NIF, so the amd64-only image is unaffected.
+      {:protobuf, path: "deps/protobuf", override: true},
+      {:grpc, path: "deps/grpc", override: true},
+      {:grpc_core, path: "deps/grpc_core", override: true},
+      {:googleapis, path: "deps/googleapis", override: true},
+      {:jason, path: "deps/jason", override: true}
     ]
   end
 end

--- a/projects/embervm/control/test/embervm/node_registry_test.exs
+++ b/projects/embervm/control/test/embervm/node_registry_test.exs
@@ -222,4 +222,52 @@ defmodule Embervm.NodeRegistryTest do
     # The clean close drove a reconnect: connect_fun was called at least twice.
     eventually(fn -> Agent.get(connects, & &1) >= 2 end, 100)
   end
+
+  test "a wedged real streamer (emit then silent) ages to down, reassigns, kills, and reconnects" do
+    {:ok, connects} = Agent.start_link(fn -> 0 end)
+    on_exit(fn -> if Process.alive?(connects), do: Agent.stop(connects) end)
+    test_pid = self()
+
+    connect_fun = fn _address ->
+      Agent.update(connects, &(&1 + 1))
+      {:ok, :fake_channel}
+    end
+
+    # Emit one status, then block forever: the stream stays OPEN with no further
+    # data (a silent wedge), which the blocking-consumer cannot observe. Only the
+    # owner's age-out timer can catch it.
+    watch_fun = fn :fake_channel, node_id, emit ->
+      emit.(node_status(node_id: node_id))
+
+      receive do
+        :never -> {:ok, :closed}
+      end
+    end
+
+    {_reg, table} =
+      start_registry(
+        watch_startup: true,
+        connect_fun: connect_fun,
+        watch_fun: watch_fun,
+        disconnect_fun: fn :fake_channel -> :ok end,
+        reassign_fun: fn id -> send(test_pid, {:reassigned, id}) end,
+        # Small age-out windows and backoff so the wedge is detected and the kill
+        # + reconnect happen quickly, with plenty of polling margin below.
+        unknown_after_ms: 30,
+        down_after_ms: 60,
+        age_check_ms: 15,
+        base_backoff_ms: 10,
+        max_backoff_ms: 10
+      )
+
+    # The first (soon-wedged) streamer connected and published its status.
+    eventually(fn -> NodeRegistry.capacity(table) != [] end, 200)
+
+    # The age-out timer catches the silent wedge and fires the reassignment path,
+    # even though the streamer process is alive and blocked (not crashed).
+    assert_receive {:reassigned, "node-4"}, 2_000
+
+    # The wedged streamer was killed and a fresh connection opened (recovery).
+    eventually(fn -> Agent.get(connects, & &1) >= 2 end, 200)
+  end
 end

--- a/projects/embervm/control/test/embervm/node_registry_test.exs
+++ b/projects/embervm/control/test/embervm/node_registry_test.exs
@@ -1,0 +1,225 @@
+defmodule Embervm.NodeRegistryTest do
+  # Task 9 acceptance: the node registry consumes a daemon's WatchNode NodeStatus
+  # stream into fail-closed capacity ETS, ages a silent node out (unknown@5s,
+  # down@15s under an injected clock), reassigns a downed node's in-flight tasks,
+  # and drops all facts the instant a daemon reports draining.
+  #
+  # Most cases drive the projection + age-out state machine synchronously through
+  # the inject_status/1 + tick/1 seams with an injected clock, so there is no
+  # real time or streamer process to race. One case exercises the real
+  # spawn_monitor streamer path with an injected connect_fun/watch_fun (no real
+  # gRPC; the wire-correctness of the stubs is covered by the Task 3 round-trip
+  # test), proving connect -> emit -> ETS publish -> reconnect-on-drop.
+  use ExUnit.Case, async: true
+
+  alias Embervm.NodeRegistry
+  alias Embervm.Node.V1.{NodeStatus, WorkloadCapacity}
+
+  # -- helpers ---------------------------------------------------------------
+
+  # A controllable monotonic clock backed by an Agent: the registry reads it for
+  # every timestamp, and the test advances it to drive age-out deterministically.
+  defp new_clock do
+    {:ok, pid} = Agent.start_link(fn -> 0 end)
+    on_exit(fn -> if Process.alive?(pid), do: Agent.stop(pid) end)
+    clock = fn -> Agent.get(pid, & &1) end
+    advance = fn ms -> Agent.update(pid, &(&1 + ms)) end
+    {clock, advance}
+  end
+
+  defp unique_table, do: :"nc_test_#{System.unique_integer([:positive])}"
+
+  # Start a registry with test-friendly defaults; opts override any of them.
+  defp start_registry(opts) do
+    table = Keyword.get(opts, :table, unique_table())
+
+    defaults = [
+      name: nil,
+      table: table,
+      nodes: [%{id: "node-4", address: "node-4.test:9090"}],
+      watch_startup: false
+    ]
+
+    {:ok, pid} = NodeRegistry.start_link(Keyword.merge(defaults, opts))
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+    {pid, table}
+  end
+
+  defp node_status(opts \\ []) do
+    %NodeStatus{
+      node_id: Keyword.get(opts, :node_id, "node-4"),
+      workloads:
+        Keyword.get(opts, :workloads, [
+          %WorkloadCapacity{
+            workload: "echo",
+            free_primed_slots: Keyword.get(opts, :free_primed_slots, 3),
+            snapshot_ref: "snap-echo",
+            base_state: :BASE_BUILD_STATE_READY
+          }
+        ]),
+      mem_headroom_mib: 2048,
+      cpu_headroom_millicores: 0,
+      live_vms: Keyword.get(opts, :live_vms, 0),
+      max_live_vms: 8,
+      draining: Keyword.get(opts, :draining, false),
+      build_error: ""
+    }
+  end
+
+  defp eventually(_fun, 0), do: flunk("condition never became true")
+
+  defp eventually(fun, tries) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(10)
+      eventually(fun, tries - 1)
+    end
+  end
+
+  # -- capacity projection ---------------------------------------------------
+
+  test "a healthy NodeStatus publishes dispatchable capacity facts" do
+    {clock, _advance} = new_clock()
+    {reg, table} = start_registry(clock: clock)
+
+    :ok = NodeRegistry.inject_status(reg, "node-4", node_status(free_primed_slots: 3))
+
+    assert [facts] = NodeRegistry.capacity(table)
+    assert facts.node_id == "node-4"
+    assert facts.workloads["echo"].free_primed_slots == 3
+    assert facts.workloads["echo"].base_state == :BASE_BUILD_STATE_READY
+    assert facts.max_live_vms == 8
+
+    snapshot = NodeRegistry.status(reg)
+    assert snapshot["node-4"].health == :healthy
+    assert snapshot["node-4"].dispatchable
+  end
+
+  test "a draining NodeStatus stops new assignments immediately (fail-closed, zero facts)" do
+    {clock, _advance} = new_clock()
+    {reg, table} = start_registry(clock: clock)
+
+    :ok = NodeRegistry.inject_status(reg, "node-4", node_status())
+    assert [_facts] = NodeRegistry.capacity(table)
+
+    # Draining must retract capacity the instant it is observed, even though the
+    # stream is still healthy.
+    :ok = NodeRegistry.inject_status(reg, "node-4", node_status(draining: true))
+    assert NodeRegistry.capacity(table) == []
+
+    snapshot = NodeRegistry.status(reg)
+    assert snapshot["node-4"].health == :healthy
+    assert snapshot["node-4"].draining
+    refute snapshot["node-4"].dispatchable
+  end
+
+  # -- age-out + reassignment ------------------------------------------------
+
+  test "capacity ages out: unknown at 5s (facts retracted), down at 15s (reassign fires once)" do
+    {clock, advance} = new_clock()
+    test_pid = self()
+    reassign_fun = fn node_id -> send(test_pid, {:reassigned, node_id}) end
+    {reg, table} = start_registry(clock: clock, reassign_fun: reassign_fun)
+
+    :ok = NodeRegistry.inject_status(reg, "node-4", node_status())
+    assert [_facts] = NodeRegistry.capacity(table)
+
+    # 5s of silence -> unknown: facts retracted, but NOT yet a reassignment.
+    advance.(5_000)
+    :ok = NodeRegistry.tick(reg)
+    assert NodeRegistry.capacity(table) == []
+    assert NodeRegistry.status(reg)["node-4"].health == :unknown
+    refute_receive {:reassigned, _}, 50
+
+    # 15s of silence -> down: the reassignment path fires exactly once.
+    advance.(10_000)
+    :ok = NodeRegistry.tick(reg)
+    assert NodeRegistry.status(reg)["node-4"].health == :down
+    assert_receive {:reassigned, "node-4"}
+
+    # A further tick while still down must not re-fire reassignment.
+    advance.(5_000)
+    :ok = NodeRegistry.tick(reg)
+    refute_receive {:reassigned, _}, 50
+  end
+
+  test "a fresh NodeStatus after down recovers the node to healthy and republishes facts" do
+    {clock, advance} = new_clock()
+    test_pid = self()
+    {reg, table} = start_registry(clock: clock, reassign_fun: fn id -> send(test_pid, {:reassigned, id}) end)
+
+    :ok = NodeRegistry.inject_status(reg, "node-4", node_status())
+    advance.(15_000)
+    :ok = NodeRegistry.tick(reg)
+    assert NodeRegistry.status(reg)["node-4"].health == :down
+    assert_receive {:reassigned, "node-4"}
+
+    # Daemon comes back: a new status re-marks the node healthy and republishes.
+    :ok = NodeRegistry.inject_status(reg, "node-4", node_status(free_primed_slots: 5))
+    assert [facts] = NodeRegistry.capacity(table)
+    assert facts.workloads["echo"].free_primed_slots == 5
+    assert NodeRegistry.status(reg)["node-4"].health == :healthy
+  end
+
+  test "a never-answering daemon ages starting -> unknown -> down from registry start" do
+    {clock, advance} = new_clock()
+    test_pid = self()
+    {reg, table} = start_registry(clock: clock, reassign_fun: fn id -> send(test_pid, {:reassigned, id}) end)
+
+    # No status ever injected. Starts :starting with no facts.
+    assert NodeRegistry.capacity(table) == []
+    assert NodeRegistry.status(reg)["node-4"].health == :starting
+
+    advance.(5_000)
+    :ok = NodeRegistry.tick(reg)
+    assert NodeRegistry.status(reg)["node-4"].health == :unknown
+
+    advance.(10_000)
+    :ok = NodeRegistry.tick(reg)
+    assert NodeRegistry.status(reg)["node-4"].health == :down
+    assert_receive {:reassigned, "node-4"}
+  end
+
+  # -- real streamer wiring --------------------------------------------------
+
+  test "a real spawn_monitor streamer connects, publishes facts, and reconnects on clean drop" do
+    {:ok, connects} = Agent.start_link(fn -> 0 end)
+    on_exit(fn -> if Process.alive?(connects), do: Agent.stop(connects) end)
+
+    connect_fun = fn _address ->
+      Agent.update(connects, &(&1 + 1))
+      {:ok, :fake_channel}
+    end
+
+    # Emit one status, then close cleanly so the registry reconnects (a second
+    # connect). Real (wall) clock here so watch/backoff timers behave normally.
+    watch_fun = fn :fake_channel, node_id, emit ->
+      emit.(node_status(node_id: node_id))
+      {:ok, :closed}
+    end
+
+    {_reg, table} =
+      start_registry(
+        watch_startup: true,
+        connect_fun: connect_fun,
+        watch_fun: watch_fun,
+        disconnect_fun: fn :fake_channel -> :ok end,
+        # Small backoff so the reconnect fires quickly; large age-out so the
+        # real-time ticks do not race the assertions.
+        base_backoff_ms: 10,
+        max_backoff_ms: 10,
+        age_check_ms: 60_000,
+        unknown_after_ms: 60_000,
+        down_after_ms: 60_000
+      )
+
+    # The streamer connected and its emitted status reached the capacity table.
+    eventually(fn -> NodeRegistry.capacity(table) != [] end, 100)
+    assert [facts] = NodeRegistry.capacity(table)
+    assert facts.node_id == "node-4"
+
+    # The clean close drove a reconnect: connect_fun was called at least twice.
+    eventually(fn -> Agent.get(connects, & &1) >= 2 end, 100)
+  end
+end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.10
+      targetRevision: 0.1.11
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/proto/embervm/node/v1/BUILD
+++ b/projects/embervm/proto/embervm/node/v1/BUILD
@@ -100,5 +100,12 @@ genrule(
           "\"$(location :node_proto)\" " +
           "\"$@\"",
     tools = ["//bazel/erlang:gen_elixir.sh"],
-    visibility = ["//projects/embervm:__subpackages__"],
+    # //bazel/erlang also consumes this: mix_test_smoke (the general test lane)
+    # stages node.pb.ex into control/lib/ so prod code referencing the stubs
+    # compiles there, alongside the control:release_tar consumer under
+    # //projects/embervm. Both need to see this generated source.
+    visibility = [
+        "//bazel/erlang:__pkg__",
+        "//projects/embervm:__subpackages__",
+    ],
 )


### PR DESCRIPTION
## What

EmberVM R0 **Task 9**: the first PR that makes the Elixir control plane actually talk to the Go node daemon (`embervm-noded`) over gRPC. A new `Embervm.NodeRegistry` consumes the daemon's server-streamed `WatchNode` heartbeat as the control plane's single source of node truth, projecting each `NodeStatus` into a fail-closed `Embervm.NodeCapacity` ETS table the dispatcher (Task 11) will read O(1).

## Design (approach (a): mirror the WorkloadWatcher)

- **Blocking stream in a monitored streamer.** `NodeService.Stub.watch_node/2` blocks its caller for the stream's lifetime, so each node's stream runs in a `spawn_monitor`'d process that forwards each `NodeStatus` tagged with its own pid (superseded-streamer stragglers dropped). The GenServer owns the ETS table + all reconnect decisions, exactly the `WorkloadWatcher` discipline.
- **Age-out is a timer, not the stream.** A ~1s tick against per-node `last_status_at` drives `unknown`@5s and `down`@15s. This is decoupled from stream liveness so a **silently wedged** stream (TCP open, no data) still ages out; crossing into `down` fires reassignment once and tears the wedged streamer down to force a fresh connection.
- **Fail-closed by construction.** A node's facts are in `NodeCapacity` only while it is `:healthy` and `draining: false`; every degraded state and any `draining=true` deletes the row. "No capacity facts = no dispatch" is the empty read, not a reader-side branch. Draining stops new assignments immediately.
- **Reassignment via the existing Retry policy.** A downed node's in-flight tasks re-enter the pipeline through `TaskStore.reassign_in_flight/1`, which fails each as a retryable transport failure (at-least-once). Inert until Task 11 actually dispatches.

## Build wiring (why the chart bumps)

- Promotes the `grpc`/`grpc_core`/`protobuf`/`googleapis`/`jason` closure from `only: :test` to **prod** in `control/mix.exs`.
- Stages the generated `node.pb.ex` into `control/lib/` in the general test lane (`mix_test.sh`) and the release (`mix_release.sh`), the same injection the round-trip test uses. Nothing generated is checked in.
- Both change the release image digest, so the chart is bumped **0.1.10 -> 0.1.11** (Chart.yaml + application.yaml together).

## Chart / deploy

- Derives `EMBERVM_NODE_ADDRESS` from the in-cluster `embervm-noded` Service DNS (survives a release rename): `embervm-embervm-noded.embervm.svc.cluster.local:9090`.
- **Auth deferred** (confirmed): noded still runs open (`bearerTokenSecret.enabled: false`, mesh policy is the layer), so the registry dials plaintext h2c with no metadata. Enable in Task 11.
- **Multi-node seam documented** (confirmed): the static-values node source is single-node only, correct while noded is a `Deployment` + `ClusterIP`. A DaemonSet would need a headless Service + EndpointSlice discovery feeding the same list seam, which is documented on `configured_nodes/0`. No discovery code this PR.

## Acceptance

`node_registry_test.exs` (ExUnit, injected clock + seams):
- healthy status publishes dispatchable facts; **draining -> zero facts** immediately
- capacity **ages out**: unknown@5s (facts retracted, no reassign), down@15s (**reassignment fires once**), recovery on a fresh status
- a never-answering daemon ages `starting -> unknown -> down`
- the real `spawn_monitor` streamer path: connect -> publish -> reconnect-on-drop (no real gRPC; wire-correctness is covered by the Task 3 round-trip test)

## Scope

Health-stream registry + capacity ETS only. The BaseBuilder (Task 10) and primed-pool dispatcher (Task 11) are deferred; submit stays async-only until Task 11.

## Verify after merge

Control-plane pod's registry connects to noded and its ETS shows node-4 healthy with `maxLiveVms=8` / zero primed slots (kubectl exec + IEx `Embervm.NodeRegistry.status/0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)