### PR TITLE
feat(embervm): image source build-to-snapshot pipeline (R0 Task 10)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.11
+version: 0.1.12

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -46,6 +46,17 @@ defmodule Embervm.Application do
       # Embervm.Auth, whose TokenReview reviewer dials the API server over it.
       Embervm.K8s.finch_child_spec(),
       {Embervm.Auth, allowed: allowed_service_accounts()},
+      # The base builder (Task 10): drives the node daemon's BuildBase RPC on
+      # Workload admission / spec change and writes status.snapshotRef +
+      # Ready/BaseBuilt conditions. Placed BEFORE the WorkloadWatcher on purpose:
+      # the watcher's boot LIST casts each valid Workload into the builder, so
+      # the builder must already be up to receive them, and under :rest_for_one a
+      # builder restart also restarts the watcher, whose re-LIST re-drives the
+      # (idempotent) reconcile. It writes status over the Finch pool above and
+      # dials the daemon over its own Mint gRPC connection (per build), so it
+      # depends on Finch but not on the watcher or node registry. Empty node
+      # config (no daemon wired) means it holds descriptors and builds nothing.
+      {Embervm.BaseBuilder, nodes: configured_nodes()},
       # The Workload informer (Task 5): LISTs then WATCHes Workload CRs over the
       # Finch pool above and writes Embervm.WorkloadCatalog, which
       # TaskStore.cfg_for/1 reads. Placed after Finch (its watch streams over

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -592,14 +592,24 @@ defmodule Embervm.BaseBuilder do
         w = %{w | retry_timer: nil}
         state = put_in(state.workloads[name], w)
 
-        if w.built_signature == signature(w) and w.snapshot_ref != nil do
-          # The desired base got built by some other path meanwhile; nothing to do.
-          state
-        else
-          state
-          |> enqueue(w.node_id, name)
-          |> write_base_status(w, :building)
-          |> maybe_start_build(w.node_id)
+        cond do
+          w.built_signature == signature(w) and w.snapshot_ref != nil ->
+            # The desired base got built by some other path meanwhile; nothing to do.
+            state
+
+          already_targeting?(state, w.node_id, name, signature(w)) ->
+            # A build for the current signature is already queued or in flight
+            # (a reconcile beat this stale timer message to it, or the timer
+            # double-fired). Re-driving would enqueue a redundant heavy build,
+            # so no-op. Same guard reconcile_desc uses, mirroring the streamer
+            # guard in Embervm.NodeRegistry's reconnect handler.
+            state
+
+          true ->
+            state
+            |> enqueue(w.node_id, name)
+            |> write_base_status(w, :building)
+            |> maybe_start_build(w.node_id)
         end
     end
   end

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -1,0 +1,709 @@
+defmodule Embervm.BaseBuilder do
+  @moduledoc """
+  Turns a `Workload`'s OCI image into a pristine base snapshot by driving the
+  node daemon's `BuildBase` RPC, then reports the result back into the
+  Workload's `status` subresource (`snapshotRef`, `snapshotDigest`, and the
+  `Ready`/`BaseBuilt` conditions).
+
+  This is the first control-plane component that DRIVES the node daemon (issues
+  a mutating RPC and reconciles its result into CR status), where
+  `Embervm.NodeRegistry` only CONSUMES node truth. Building a base is the
+  on-ramp that makes a Workload eligible to ever run: a Workload never becomes
+  `Ready` without a restorable base.
+
+  ## trigger: the watcher hands us admissions and spec changes
+
+  `Embervm.WorkloadWatcher` is already the informer that sees every Workload
+  admission, spec change, and deletion. Rather than open a second watch, it
+  calls `reconcile/2` (a cast) for every valid Workload it reconciles and
+  `forget/2` for every invalid or deleted one. Those are `whereis`-guarded
+  no-ops when this server is not running, so the watcher's own unit tests (which
+  start no BaseBuilder) are unaffected, and a BaseBuilder crash cannot take the
+  watcher down. Because the supervision tree starts this process BEFORE the
+  watcher under `:rest_for_one`, a BaseBuilder restart also restarts the
+  watcher, whose boot LIST re-casts every Workload into the fresh builder: the
+  reconcile is idempotent, so re-driving is free and self-healing (no separate
+  boot sweep needed).
+
+  ## per-node serialization
+
+  A base build is heavy (pull, bake, cold boot, health-gate, snapshot), so
+  builds are serialized PER NODE: at most one build runs on a node at a time and
+  concurrent admissions queue behind it. Serialization is structural, not a
+  lock: each node has a FIFO `queue` and a single `building` slot, and the next
+  queued build starts only when the current one finishes. The blocking
+  `BuildBase` call runs in a `spawn_monitor`'d worker (the NodeRegistry streamer
+  discipline) so it never freezes this GenServer, which owns the queues, the
+  per-workload build state, and every status-write decision.
+
+  In R0 there is exactly one node and every Workload's base is built on it (its
+  single `status.snapshotRef` is that node's base handle). Multi-node base
+  fan-out (a base per node a Workload may be primed on, with per-node snapshot
+  refs) is the dispatcher's concern (Task 11); the per-node keying here means it
+  needs more queue entries, not a reshape.
+
+  ## change detection is on the spec signature, not the resolved digest
+
+  A tag-pinned `image_ref` is resolved to a digest by the DAEMON at build time,
+  so the control plane cannot compare digests before a build. Instead it detects
+  change on a "base signature" derived from the spec fields that actually shape
+  the base: `image_ref`, resources (`vcpus`, `mem_mib`), the guest contract
+  (`guest_port`, `ready_path`), and `init_env`. A rebuild is triggered iff the
+  signature differs from the one the recorded base was built from. Tag drift
+  (same `image_ref` string, new upstream digest) does NOT rebuild: deploys are
+  explicit CR updates, not tag drift. The digest the daemon resolves comes back
+  in the response and is recorded in `status.snapshotDigest` for auditability.
+
+  The daemon's own `BuildBase` idempotency (keyed on the resolved digest plus
+  the `workload_revision` we send, the CR's `generation`) is the correctness
+  backstop: re-driving a build we already made returns the existing snapshot
+  with `already_built: true`, cheaply, so the signature map here is a
+  latency optimization, not a source of truth we must persist across restarts.
+
+  ## failure, backoff, and the Ready gate
+
+  A failed build sets `BaseBuilt=False` with the daemon's error string in the
+  condition message and retries with exponential backoff (capped at 10m). The
+  `Ready` condition is derived purely from whether a restorable base exists
+  (`snapshotRef` present), so:
+
+    * first build in progress or failed -> no base -> `Ready=False`;
+    * a rebuild (signature change) in progress or failed while an OLD base is
+      still recorded -> `Ready=True` (the old base still serves; no dispatch
+      gap), `BaseBuilt=False`.
+
+  `status.snapshotRef` is only ever ADVANCED to a base the daemon has already
+  confirmed built, never to an in-progress one, which is what makes the
+  acceptance property hold: at any point, the `snapshotRef` in status names a
+  restorable base.
+
+  ## turnover on a digest change (a documented seam, not built here)
+
+  When a rebuild produces a new snapshot, the old snapshot ref is recorded in
+  the workload's `superseded_refs` for Task 11's PoolManager to reconcile:
+  proactively destroy the old-base primed VMs and re-prime from the new base,
+  destroying the old base file only after zero primed VMs reference it. There is
+  no pool in R0, so this module only emits the new `snapshotRef` and records the
+  old one; it does not destroy or re-prime anything.
+
+  ## status write coordination with the watcher
+
+  Status is patched with a JSON merge-patch, which REPLACES arrays wholesale, so
+  two writers touching `conditions` would clobber each other. Ownership is split
+  by key: this module owns `conditions` (`Ready` + `BaseBuilt`), `snapshotRef`,
+  and `snapshotDigest` for valid task Workloads; the watcher owns
+  `observedGeneration` and `primedFloorSatisfied` (disjoint keys, no lost
+  update) and keeps `conditions` only for the invalid-CR validation lane, which
+  never reaches this module.
+  """
+
+  use GenServer
+  require Logger
+
+  alias Embervm.Node.V1.{BuildBaseRequest, BuildBaseResponse, NodeService, ResourceSpec, Trace}
+
+  # Backoff for a failed build: exponential from 1s, capped at the spec's 10m.
+  @base_backoff_ms 1_000
+  @max_backoff_ms 600_000
+
+  # -- Client API ------------------------------------------------------------
+
+  # :name defaults to __MODULE__ for the application's supervised singleton;
+  # tests pass name: nil to run PID-addressed instances concurrently (the same
+  # idiom as the other GenServers in this app).
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @typedoc """
+  The build descriptor the watcher hands us for a valid Workload: the spec
+  fields that shape a base plus the identity needed to write status back.
+  """
+  @type desc :: %{
+          required(:name) => String.t(),
+          required(:namespace) => String.t(),
+          required(:generation) => integer() | nil,
+          required(:image_ref) => String.t(),
+          required(:guest_port) => integer() | nil,
+          required(:ready_path) => String.t(),
+          required(:vcpus) => integer() | nil,
+          required(:mem_mib) => integer() | nil,
+          required(:init_env) => %{String.t() => String.t()}
+        }
+
+  @doc """
+  Reconcile one Workload's desired base against what has been built. A cast so
+  the watcher never blocks on a build. A `whereis`-guarded no-op when this
+  server is not running (the watcher's own unit tests start no BaseBuilder, and
+  the trigger fails open: the watcher's boot re-LIST re-drives us anyway).
+  """
+  @spec reconcile(GenServer.server(), desc()) :: :ok
+  def reconcile(server \\ __MODULE__, desc) do
+    cast_if_alive(server, {:reconcile, desc})
+  end
+
+  @doc """
+  Drop a Workload the watcher no longer considers a valid build target (it was
+  deleted, or an edit made it invalid). Cancels any pending retry and removes it
+  from its node queue; a build already in flight is left to finish and its
+  result discarded (the workload is gone from state). `whereis`-guarded like
+  `reconcile/2`.
+  """
+  @spec forget(GenServer.server(), String.t()) :: :ok
+  def forget(server \\ __MODULE__, name) do
+    cast_if_alive(server, {:forget, name})
+  end
+
+  @doc """
+  A snapshot of every tracked Workload's build state, for tests and operational
+  visibility. Includes queue/building state per node so an operator can see WHY
+  a base is not built yet.
+  """
+  @spec status(GenServer.server()) :: map()
+  def status(server \\ __MODULE__) do
+    GenServer.call(server, :status)
+  end
+
+  defp cast_if_alive(server, msg) do
+    case GenServer.whereis(server) do
+      nil -> :ok
+      _pid -> GenServer.cast(server, msg)
+    end
+  end
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    nodes = Keyword.get(opts, :nodes, [])
+    # Injected seams (defaults are the real gRPC + K8s status patch + wall clock):
+    build_fun = Keyword.get(opts, :build_fun, &default_build/2)
+    connect_fun = Keyword.get(opts, :connect_fun, &default_connect/1)
+    disconnect_fun = Keyword.get(opts, :disconnect_fun, &default_disconnect/1)
+    status_writer = Keyword.get(opts, :status_writer, &Embervm.K8s.patch_workload_status/3)
+    clock = Keyword.get(opts, :clock, fn -> System.system_time(:millisecond) end)
+    base_backoff = Keyword.get(opts, :base_backoff_ms, @base_backoff_ms)
+    max_backoff = Keyword.get(opts, :max_backoff_ms, @max_backoff_ms)
+
+    node_ids = Enum.map(nodes, & &1.id)
+
+    node_addr = for %{id: id, address: address} <- nodes, into: %{}, do: {id, address}
+
+    node_runtime =
+      for id <- node_ids, into: %{} do
+        {id, %{building: nil, queue: [], worker: nil}}
+      end
+
+    state = %{
+      node_ids: node_ids,
+      node_addr: node_addr,
+      nodes: node_runtime,
+      workloads: %{},
+      # pid -> %{node_id, name, signature} for the CURRENT build worker, so a
+      # result from a superseded worker (or for a since-changed spec) is dropped.
+      workers: %{},
+      build_fun: build_fun,
+      connect_fun: connect_fun,
+      disconnect_fun: disconnect_fun,
+      status_writer: status_writer,
+      clock: clock,
+      base_backoff_ms: base_backoff,
+      max_backoff_ms: max_backoff
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_cast({:reconcile, desc}, state) do
+    {:noreply, reconcile_desc(state, desc)}
+  end
+
+  def handle_cast({:forget, name}, state) do
+    {:noreply, forget_workload(state, name)}
+  end
+
+  @impl true
+  def handle_call(:status, _from, state) do
+    workloads =
+      for {name, w} <- state.workloads, into: %{} do
+        {name,
+         %{
+           node_id: w.node_id,
+           image_ref: w.image_ref,
+           snapshot_ref: w.snapshot_ref,
+           snapshot_digest: w.snapshot_digest,
+           built: w.built_signature != nil and w.built_signature == signature(w),
+           superseded_refs: w.superseded_refs,
+           backoff_ms: w.backoff_ms
+         }}
+      end
+
+    nodes =
+      for {id, n} <- state.nodes, into: %{} do
+        {id, %{building: n.building, queued: n.queue, connected: n.worker != nil}}
+      end
+
+    {:reply, %{workloads: workloads, nodes: nodes}, state}
+  end
+
+  # A build worker reported its result. Drop it if the pid is not our current
+  # worker (defensive; builds are serial so this is rare), then apply.
+  @impl true
+  def handle_info({:build_result, pid, result}, state) do
+    case Map.get(state.workers, pid) do
+      nil -> {:noreply, state}
+      meta -> {:noreply, finish_build(state, pid, meta, result)}
+    end
+  end
+
+  # A worker died WITHOUT reporting a result (it always sends one in the normal
+  # path, so a bare DOWN is an abnormal exit). Treat as a build error.
+  def handle_info({:DOWN, _ref, :process, pid, reason}, state) do
+    case Map.get(state.workers, pid) do
+      nil -> {:noreply, state}
+      meta -> {:noreply, finish_build(state, pid, meta, {:error, {:worker_down, reason}})}
+    end
+  end
+
+  # A backoff retry timer fired for a failed build.
+  def handle_info({:retry, name}, state) do
+    {:noreply, retry_workload(state, name)}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # Best-effort: stop orphaned build workers from outliving the GenServer that
+  # owns their gRPC connections. Not load-bearing (a monitored worker exits when
+  # its owner dies anyway), just tidy.
+  @impl true
+  def terminate(_reason, state) do
+    for {pid, _meta} <- state.workers, do: Process.exit(pid, :shutdown)
+    :ok
+  end
+
+  # -- reconcile ---------------------------------------------------------------
+
+  # Store/update a Workload's desired base and, if the desired signature differs
+  # from what has been built (or is being built), enqueue a build. No node
+  # configured yet means we cannot build: record the intent and report it.
+  defp reconcile_desc(state, %{name: name} = desc) do
+    prev = Map.get(state.workloads, name)
+    node_id = placement(state, prev)
+
+    w = merge_desc(prev, desc, node_id)
+    state = put_in(state.workloads[name], w)
+
+    cond do
+      node_id == nil ->
+        # No node wired (empty config, e.g. CI): hold the desc and report why.
+        write_base_status(state, w, {:pending, :no_node})
+
+      w.built_signature == signature(w) and w.snapshot_ref != nil ->
+        # Desired base already built and recorded: idempotent no-op. (The watcher
+        # separately writes observedGeneration for a generation-only change.)
+        state
+
+      already_targeting?(state, node_id, name, signature(w)) ->
+        # A build for this exact signature is already queued or in flight.
+        state
+
+      true ->
+        state
+        |> cancel_pending_retry(name)
+        |> enqueue(node_id, name)
+        |> write_base_status(w, :building)
+        |> maybe_start_build(node_id)
+    end
+  end
+
+  # Cancel a workload's pending backoff-retry timer (if any) when a build is
+  # about to be enqueued by another path, so the timer cannot later fire and
+  # enqueue a redundant second build for the same target.
+  defp cancel_pending_retry(state, name) do
+    case Map.get(state.workloads, name) do
+      %{retry_timer: ref} when ref != nil ->
+        cancel_timer(ref)
+        put_in(state.workloads[name].retry_timer, nil)
+
+      _ ->
+        state
+    end
+  end
+
+  # Placement: in R0 every Workload's base is built on the single configured
+  # node; a Workload keeps whichever node it was first placed on. Returns nil
+  # when no node is configured. Multi-node placement is Task 11's job.
+  defp placement(_state, %{node_id: node_id}) when is_binary(node_id), do: node_id
+  defp placement(state, _prev), do: List.first(state.node_ids)
+
+  # Fold a fresh desc into the workload's build state, preserving the built base
+  # (built_signature/snapshot_ref/digest/superseded) across spec edits so a
+  # rebuild-in-progress keeps serving the old base.
+  defp merge_desc(nil, desc, node_id) do
+    %{
+      name: desc.name,
+      namespace: desc.namespace,
+      generation: desc.generation,
+      node_id: node_id,
+      image_ref: desc.image_ref,
+      guest_port: desc.guest_port,
+      ready_path: desc.ready_path,
+      vcpus: desc.vcpus,
+      mem_mib: desc.mem_mib,
+      init_env: desc.init_env || %{},
+      built_signature: nil,
+      snapshot_ref: nil,
+      snapshot_digest: nil,
+      superseded_refs: [],
+      backoff_ms: nil,
+      retry_timer: nil
+    }
+  end
+
+  defp merge_desc(prev, desc, node_id) do
+    %{
+      prev
+      | namespace: desc.namespace,
+        generation: desc.generation,
+        node_id: node_id,
+        image_ref: desc.image_ref,
+        guest_port: desc.guest_port,
+        ready_path: desc.ready_path,
+        vcpus: desc.vcpus,
+        mem_mib: desc.mem_mib,
+        init_env: desc.init_env || %{}
+    }
+  end
+
+  # The base signature: the spec fields that actually shape the base. A rebuild
+  # is triggered iff this differs from the signature the recorded base was built
+  # from. Deliberately excludes concurrency/invocation/retry (they do not change
+  # the base VM), so a cap-only edit never rebuilds.
+  defp signature(w) do
+    {w.image_ref, w.vcpus, w.mem_mib, w.guest_port, w.ready_path, w.init_env}
+  end
+
+  # Is a build for this signature already queued or in flight on the node? Avoids
+  # enqueuing a duplicate while an identical build is pending.
+  defp already_targeting?(state, node_id, name, sig) do
+    n = state.nodes[node_id]
+    building_this = n.building == name and worker_signature(state, node_id) == sig
+    queued = name in n.queue
+    building_this or queued
+  end
+
+  defp worker_signature(state, node_id) do
+    case state.nodes[node_id].worker do
+      {pid, _ref} -> get_in(state.workers, [pid, :signature])
+      nil -> nil
+    end
+  end
+
+  defp enqueue(state, node_id, name) do
+    update_in(state.nodes[node_id].queue, fn q -> if name in q, do: q, else: q ++ [name] end)
+  end
+
+  # -- forget ------------------------------------------------------------------
+
+  defp forget_workload(state, name) do
+    case Map.get(state.workloads, name) do
+      nil ->
+        state
+
+      w ->
+        cancel_timer(w.retry_timer)
+
+        state
+        |> update_in([:workloads], &Map.delete(&1, name))
+        |> dequeue_everywhere(name)
+    end
+  end
+
+  defp dequeue_everywhere(state, name) do
+    update_in(state.nodes, fn nodes ->
+      for {id, n} <- nodes, into: %{}, do: {id, %{n | queue: List.delete(n.queue, name)}}
+    end)
+  end
+
+  # -- serial build execution --------------------------------------------------
+
+  # If the node is idle and its queue is non-empty, pop the next Workload and
+  # start its build. Skips (and drops) any queued name whose Workload was
+  # forgotten while it waited.
+  defp maybe_start_build(state, node_id) do
+    n = state.nodes[node_id]
+
+    cond do
+      n.building != nil ->
+        state
+
+      n.queue == [] ->
+        state
+
+      true ->
+        [name | rest] = n.queue
+        state = put_in(state.nodes[node_id].queue, rest)
+
+        case Map.get(state.workloads, name) do
+          nil -> maybe_start_build(state, node_id)
+          w -> start_worker(state, node_id, w)
+        end
+    end
+  end
+
+  # Spawn the monitored worker that owns the blocking BuildBase call for one
+  # Workload. spawn_monitor (not link): a worker crash surfaces as a :DOWN we
+  # treat as a build error, never escalating to this GenServer.
+  defp start_worker(state, node_id, w) do
+    owner = self()
+    address = state.node_addr[node_id]
+    build_fun = state.build_fun
+    connect_fun = state.connect_fun
+    disconnect_fun = state.disconnect_fun
+    request = build_request(w)
+    sig = signature(w)
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        me = self()
+
+        result =
+          case connect_fun.(address) do
+            {:ok, channel} ->
+              try do
+                build_fun.(channel, request)
+              catch
+                kind, reason -> {:error, {kind, reason}}
+              after
+                disconnect_fun.(channel)
+              end
+
+            {:error, reason} ->
+              {:error, {:connect, reason}}
+          end
+
+        send(owner, {:build_result, me, result})
+      end)
+
+    state
+    |> put_in([:nodes, node_id, :building], w.name)
+    |> put_in([:nodes, node_id, :worker], {pid, ref})
+    |> put_in([:workers, pid], %{node_id: node_id, name: w.name, signature: sig})
+  end
+
+  defp build_request(w) do
+    %BuildBaseRequest{
+      trace: %Trace{workload: w.name},
+      image_ref: w.image_ref,
+      workload_revision: to_string(w.generation || 0),
+      guest_port: w.guest_port || 0,
+      ready_path: w.ready_path,
+      resources: %ResourceSpec{vcpus: w.vcpus || 0, mem_mib: w.mem_mib || 0},
+      init_env: w.init_env
+    }
+  end
+
+  # A build finished. Clear the node's building slot and worker index, apply the
+  # result to the Workload's state and status (unless it was forgotten or its
+  # spec changed under us), then start the next queued build on that node.
+  defp finish_build(state, pid, %{node_id: node_id, name: name, signature: built_sig}, result) do
+    state =
+      state
+      |> update_in([:workers], &Map.delete(&1, pid))
+      |> put_in([:nodes, node_id, :building], nil)
+      |> put_in([:nodes, node_id, :worker], nil)
+
+    state =
+      case Map.get(state.workloads, name) do
+        nil ->
+          # Forgotten while building: discard the result.
+          state
+
+        w ->
+          if signature(w) == built_sig do
+            apply_result(state, w, built_sig, result)
+          else
+            # Spec changed under us: this result is for a stale signature. Discard
+            # it and re-enqueue the current desired build.
+            state
+            |> enqueue(node_id, name)
+            |> write_base_status(w, :building)
+          end
+      end
+
+    maybe_start_build(state, node_id)
+  end
+
+  # A successful build: record the new base, advance status.snapshotRef (the
+  # first time the acceptance property's "always restorable" ref is set/moved),
+  # push any superseded ref onto the turnover list (Task 11 seam), and reset
+  # backoff.
+  defp apply_result(state, w, built_sig, {:ok, %BuildBaseResponse{} = resp}) do
+    superseded =
+      if w.snapshot_ref && w.snapshot_ref != resp.snapshot_ref,
+        do: [w.snapshot_ref | w.superseded_refs],
+        else: w.superseded_refs
+
+    w = %{
+      w
+      | built_signature: built_sig,
+        snapshot_ref: resp.snapshot_ref,
+        snapshot_digest: resp.image_digest,
+        superseded_refs: superseded,
+        backoff_ms: nil,
+        retry_timer: nil
+    }
+
+    state = put_in(state.workloads[w.name], w)
+    write_base_status(state, w, :built)
+  end
+
+  # A failed build: keep any existing base (Ready stays True if one is recorded),
+  # report the daemon error, and schedule a backed-off retry.
+  defp apply_result(state, w, _built_sig, {:error, reason}) do
+    message = format_build_error(reason)
+
+    Logger.warning("embervm base builder: BuildBase for #{w.namespace}/#{w.name} failed: #{message}")
+
+    next_backoff = min((w.backoff_ms || state.base_backoff_ms) * backoff_factor(w), state.max_backoff_ms)
+    timer = Process.send_after(self(), {:retry, w.name}, next_backoff)
+
+    w = %{w | backoff_ms: next_backoff, retry_timer: timer}
+    state = put_in(state.workloads[w.name], w)
+    write_base_status(state, w, {:failed, message})
+  end
+
+  # Backoff doubles from the base on each consecutive failure. The first failure
+  # (backoff_ms nil) starts at the base; thereafter it doubles the last value.
+  defp backoff_factor(%{backoff_ms: nil}), do: 1
+  defp backoff_factor(_), do: 2
+
+  defp retry_workload(state, name) do
+    case Map.get(state.workloads, name) do
+      nil ->
+        state
+
+      w ->
+        w = %{w | retry_timer: nil}
+        state = put_in(state.workloads[name], w)
+
+        if w.built_signature == signature(w) and w.snapshot_ref != nil do
+          # The desired base got built by some other path meanwhile; nothing to do.
+          state
+        else
+          state
+          |> enqueue(w.node_id, name)
+          |> write_base_status(w, :building)
+          |> maybe_start_build(w.node_id)
+        end
+    end
+  end
+
+  # -- status writing ----------------------------------------------------------
+
+  # Build and patch the two conditions this module owns. Ready is derived purely
+  # from whether a restorable base exists (snapshot_ref present); BaseBuilt
+  # tracks the DESIRED base. Only a :built result writes snapshotRef/Digest, so a
+  # build-in-progress or failure never clears an existing (still restorable) ref.
+  defp write_base_status(state, w, phase) do
+    ready = ready_condition(state, w)
+    base_built = base_built_condition(state, phase)
+
+    status_map =
+      %{"conditions" => [ready, base_built]}
+      |> maybe_put_snapshot(w, phase)
+
+    case state.status_writer.(w.namespace, w.name, status_map) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        # Visibility-only: a status-write failure must not crash the loop or lose
+        # the build state (already recorded above); log and swallow.
+        Logger.warning(
+          "embervm base builder: status patch failed for #{w.namespace}/#{w.name}: #{inspect(reason)}"
+        )
+    end
+
+    state
+  end
+
+  defp maybe_put_snapshot(status_map, w, :built) do
+    status_map
+    |> Map.put("snapshotRef", w.snapshot_ref || "")
+    |> Map.put("snapshotDigest", w.snapshot_digest || "")
+  end
+
+  defp maybe_put_snapshot(status_map, _w, _phase), do: status_map
+
+  defp ready_condition(state, w) do
+    if w.snapshot_ref do
+      condition(state, "Ready", "True", "BaseReady", "a restorable base snapshot is available")
+    else
+      condition(state, "Ready", "False", "BaseNotBuilt", "base snapshot not built yet")
+    end
+  end
+
+  defp base_built_condition(state, :building) do
+    condition(state, "BaseBuilt", "False", "BaseBuilding", "base build in progress")
+  end
+
+  defp base_built_condition(state, :built) do
+    condition(state, "BaseBuilt", "True", "BaseBuilt", "base snapshot built and recorded")
+  end
+
+  defp base_built_condition(state, {:failed, message}) do
+    condition(state, "BaseBuilt", "False", "BuildFailed", message)
+  end
+
+  defp base_built_condition(state, {:pending, :no_node}) do
+    condition(state, "BaseBuilt", "Unknown", "NoNodeAvailable", "no node daemon is configured to build the base")
+  end
+
+  defp condition(state, type, status, reason, message) do
+    %{
+      "type" => type,
+      "status" => status,
+      "reason" => reason,
+      "message" => message,
+      "lastTransitionTime" => iso8601(state.clock.())
+    }
+  end
+
+  defp iso8601(ms) do
+    ms
+    |> DateTime.from_unix!(:millisecond)
+    |> DateTime.to_iso8601()
+  end
+
+  defp cancel_timer(nil), do: :ok
+  defp cancel_timer(ref), do: Process.cancel_timer(ref)
+
+  # -- default (production) seams ---------------------------------------------
+
+  # Plaintext h2c to the noded Service over the Mint adapter, opened per build
+  # (builds are infrequent and serialized). Same pattern as Embervm.NodeRegistry.
+  defp default_connect(address) do
+    GRPC.Stub.connect(address, adapter: GRPC.Client.Adapters.Mint)
+  end
+
+  defp default_disconnect(channel) do
+    _ = GRPC.Stub.disconnect(channel)
+    :ok
+  end
+
+  defp default_build(channel, %BuildBaseRequest{} = request) do
+    NodeService.Stub.build_base(channel, request)
+  end
+
+  # A gRPC-level failure (e.g. FAILED_PRECONDITION for an image the daemon does
+  # not know, which is every image in R0 until guest-image provisioning lands)
+  # arrives as a GRPC.RPCError; surface its message verbatim in the condition.
+  defp format_build_error(%GRPC.RPCError{message: message}), do: message
+  defp format_build_error(reason), do: inspect(reason)
+end

--- a/projects/embervm/control/lib/embervm/workload_watcher.ex
+++ b/projects/embervm/control/lib/embervm/workload_watcher.ex
@@ -112,6 +112,12 @@ defmodule Embervm.WorkloadWatcher do
     lister = Keyword.get(opts, :lister, &Embervm.K8s.list_workloads/0)
     watcher_fun = Keyword.get(opts, :watcher_fun, &Embervm.K8s.watch_workloads/2)
     status_writer = Keyword.get(opts, :status_writer, &Embervm.K8s.patch_workload_status/3)
+    # The base-builder trigger seams (Task 10): a valid CR is handed to the
+    # BaseBuilder to drive its base build; an invalid or deleted one is
+    # forgotten. Both default to whereis-guarded no-ops when the builder is not
+    # running, so this watcher's own unit tests need not start one.
+    base_reconcile_fun = Keyword.get(opts, :base_reconcile_fun, &Embervm.BaseBuilder.reconcile/1)
+    base_forget_fun = Keyword.get(opts, :base_forget_fun, &Embervm.BaseBuilder.forget/1)
     clock = Keyword.get(opts, :clock, fn -> System.system_time(:millisecond) end)
     base_backoff = Keyword.get(opts, :base_backoff_ms, @base_backoff_ms)
     max_backoff = Keyword.get(opts, :max_backoff_ms, @max_backoff_ms)
@@ -125,6 +131,8 @@ defmodule Embervm.WorkloadWatcher do
       lister: lister,
       watcher_fun: watcher_fun,
       status_writer: status_writer,
+      base_reconcile_fun: base_reconcile_fun,
+      base_forget_fun: base_forget_fun,
       clock: clock,
       base_backoff: base_backoff,
       max_backoff: max_backoff,
@@ -320,7 +328,12 @@ defmodule Embervm.WorkloadWatcher do
   defp apply_event(state, %{"type" => "DELETED"} = event) do
     obj = Map.get(event, "object") || %{}
     name = get_in(obj, ["metadata", "name"])
-    if name, do: WorkloadCatalog.drop(state.table, name)
+
+    if name do
+      WorkloadCatalog.drop(state.table, name)
+      state.base_forget_fun.(name)
+    end
+
     advance_rv(state, obj)
   end
 
@@ -390,7 +403,10 @@ defmodule Embervm.WorkloadWatcher do
       |> Enum.reject(&is_nil/1)
 
     (WorkloadCatalog.all_names(state.table) -- seen)
-    |> Enum.each(&WorkloadCatalog.drop(state.table, &1))
+    |> Enum.each(fn name ->
+      WorkloadCatalog.drop(state.table, name)
+      state.base_forget_fun.(name)
+    end)
 
     if rv, do: %{state | resource_version: rv}, else: state
   end
@@ -414,22 +430,23 @@ defmodule Embervm.WorkloadWatcher do
           entry = catalog_entry(name, namespace, spec, floor, cap)
           WorkloadCatalog.upsert(state.table, name, entry)
 
-          # Valid in R0 is never Ready=True: the base builder that would make
-          # a snapshot ready is Task 10, not this watcher. Reporting False
-          # here is the honest status, not a placeholder bug.
-          write_status(
-            state,
-            namespace,
-            name,
-            generation,
-            ready_condition(state, "False", "BaseNotBuilt", "base snapshot not built yet (Task 10)")
-          )
+          # A valid Workload's Ready/BaseBuilt conditions are owned by the
+          # BaseBuilder (Task 10): it drives the base build and writes those
+          # conditions plus snapshotRef/snapshotDigest. The watcher writes only
+          # its own disjoint keys here (observedGeneration, primedFloorSatisfied)
+          # so the two merge-patches never clobber each other's conditions
+          # array, and hands the build descriptor to the builder.
+          write_valid_status(state, namespace, name, generation)
+          state.base_reconcile_fun.(build_desc(name, namespace, generation, spec, entry))
 
         {:error, reason_code, message} ->
           # Never serve an invalid CR: drop it from the catalog (it may have
           # been valid before an edit made it invalid) rather than leaving a
-          # stale entry that no longer matches spec.
+          # stale entry that no longer matches spec. Forget any base build for it
+          # too (a valid->invalid edit must stop building and clear its state);
+          # the watcher owns the Ready condition for the invalid lane.
           WorkloadCatalog.drop(state.table, name)
+          state.base_forget_fun.(name)
           write_status(state, namespace, name, generation, ready_condition(state, "False", reason_code, message))
       end
 
@@ -443,6 +460,47 @@ defmodule Embervm.WorkloadWatcher do
 
         get_in(cr, ["metadata", "name"])
     end
+  end
+
+  # Status for a VALID Workload: only the keys the watcher owns. Crucially it
+  # does NOT include `conditions`, so this merge-patch never overwrites the
+  # Ready/BaseBuilt array the BaseBuilder owns (merge-patch replaces arrays
+  # wholesale; disjoint keys are the whole reason the two writers coexist).
+  defp write_valid_status(state, namespace, name, generation) do
+    status_map = %{
+      "observedGeneration" => generation,
+      "primedFloorSatisfied" => false
+    }
+
+    case state.status_writer.(namespace, name, status_map) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "embervm workload watcher: status patch failed for #{namespace}/#{name}: #{inspect(reason)}"
+        )
+    end
+  end
+
+  # The build descriptor handed to the BaseBuilder for a valid Workload: the spec
+  # fields that shape the base plus the identity to write status back under.
+  # init_env is read from source.image.initEnv (the frozen guest contract's
+  # baked env); the rest reuse the already-parsed catalog entry.
+  defp build_desc(name, namespace, generation, spec, entry) do
+    init_env = get_in(spec, ["source", "image", "initEnv"]) || %{}
+
+    %{
+      name: name,
+      namespace: namespace,
+      generation: generation,
+      image_ref: entry.image_ref,
+      guest_port: entry.port,
+      ready_path: entry.ready_path,
+      vcpus: entry.vcpus,
+      mem_mib: entry.mem_mib,
+      init_env: init_env
+    }
   end
 
   defp write_status(state, namespace, name, generation, condition) do

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -303,6 +303,39 @@ defmodule Embervm.BaseBuilderTest do
     assert Agent.get(count, & &1) == 0
   end
 
+  test "a stale retry message while a build is in flight does not enqueue a second build" do
+    agent = start_recorder()
+    test_pid = self()
+    {:ok, count} = Agent.start_link(fn -> 0 end)
+
+    build_fun = fn :fake_channel, req ->
+      Agent.update(count, &(&1 + 1))
+      send(test_pid, {:building, req.trace.workload, self()})
+
+      receive do
+        {:go, result} -> result
+      end
+    end
+
+    builder = start_builder(status_writer: recording_status_writer(agent), build_fun: build_fun)
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+    assert_receive {:building, "w", worker}, 1_000
+
+    # Simulate a stale backoff timer firing (its {:retry, name} message racing a
+    # build already in flight for the current signature). It must be a no-op, not
+    # a second enqueue.
+    send(builder, {:retry, "w"})
+    Process.sleep(30)
+
+    send(worker, {:go, {:ok, resp("snap1")}})
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap1"}, latest(agent, "w")) end)
+
+    # Exactly one build ran despite the stale retry.
+    Process.sleep(30)
+    assert Agent.get(count, & &1) == 1
+  end
+
   # -- forget -----------------------------------------------------------------
 
   test "forgetting a workload mid-queue drops it without building" do

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -1,0 +1,337 @@
+defmodule Embervm.BaseBuilderTest do
+  @moduledoc """
+  Task 10 acceptance: `Embervm.BaseBuilder` drives the node daemon's `BuildBase`
+  RPC on Workload admission and reconciles the result into CR status.
+
+  A FAKE DAEMON is injected the same way `Embervm.NodeRegistry`'s tests inject a
+  `watch_fun`: `connect_fun`/`disconnect_fun` return a sentinel channel and
+  `build_fun` stands in for `NodeService.Stub.build_base/2`, returning `{:ok,
+  %BuildBaseResponse{}}` on success or `{:error, %GRPC.RPCError{}}` on failure
+  (FAILED_PRECONDITION for an unknown image is every image in R0). The build
+  runs in a real spawned worker, so observations are made through
+  `assert_eventually`/`assert_receive` rather than assuming synchronous timing.
+
+  Each test uses an unnamed (`name: nil`) builder so tests run async with no
+  shared state and never touch the application's own supervised BaseBuilder.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.BaseBuilder
+  alias Embervm.Node.V1.BuildBaseResponse
+
+  @node %{id: "node-4", address: "node-4:9090"}
+
+  # -- helpers ----------------------------------------------------------------
+
+  defp start_recorder do
+    {:ok, agent} = Agent.start_link(fn -> [] end)
+    agent
+  end
+
+  defp recorded(agent), do: Agent.get(agent, & &1)
+
+  defp recording_status_writer(agent) do
+    fn namespace, name, status_map ->
+      Agent.update(agent, fn calls -> calls ++ [{namespace, name, status_map}] end)
+      :ok
+    end
+  end
+
+  # Newest status write for a workload name.
+  defp latest(agent, name) do
+    recorded(agent)
+    |> Enum.filter(fn {_ns, n, _} -> n == name end)
+    |> List.last()
+    |> case do
+      nil -> nil
+      {_ns, _n, status_map} -> status_map
+    end
+  end
+
+  defp condition(status_map, type) do
+    (status_map["conditions"] || []) |> Enum.find(&(&1["type"] == type))
+  end
+
+  defp desc(overrides \\ %{}) do
+    Map.merge(
+      %{
+        name: "w",
+        namespace: "embervm",
+        generation: 1,
+        image_ref: "imgA",
+        guest_port: 8080,
+        ready_path: "/shim/ready",
+        vcpus: 1,
+        mem_mib: 256,
+        init_env: %{}
+      },
+      overrides
+    )
+  end
+
+  defp resp(snapshot_ref, digest \\ "sha256:deadbeef") do
+    %BuildBaseResponse{snapshot_ref: snapshot_ref, image_digest: digest, base_size_bytes: 1, arch: "amd64"}
+  end
+
+  defp start_builder(opts) do
+    {:ok, pid} =
+      BaseBuilder.start_link(
+        [
+          name: nil,
+          nodes: Keyword.get(opts, :nodes, [@node]),
+          connect_fun: fn _addr -> {:ok, :fake_channel} end,
+          disconnect_fun: fn :fake_channel -> :ok end
+        ] ++ opts
+      )
+
+    pid
+  end
+
+  defp assert_eventually(fun, timeout_ms \\ 2_000, interval_ms \\ 10) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_eventually(fun, deadline, interval_ms)
+  end
+
+  defp do_eventually(fun, deadline, interval_ms) do
+    cond do
+      fun.() ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("condition was not met within the timeout")
+
+      true ->
+        Process.sleep(interval_ms)
+        do_eventually(fun, deadline, interval_ms)
+    end
+  end
+
+  # -- admission -> BuildBase -> status write ---------------------------------
+
+  test "a valid admission drives BuildBase and writes a built base into status" do
+    agent = start_recorder()
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("snap1", "sha256:abc")} end
+
+    builder =
+      start_builder(status_writer: recording_status_writer(agent), build_fun: build_fun)
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+
+    assert_eventually(fn ->
+      case latest(agent, "w") do
+        nil -> false
+        s -> s["snapshotRef"] == "snap1"
+      end
+    end)
+
+    status_map = latest(agent, "w")
+    assert status_map["snapshotRef"] == "snap1"
+    assert status_map["snapshotDigest"] == "sha256:abc"
+    assert %{"status" => "True", "reason" => "BaseReady"} = condition(status_map, "Ready")
+    assert %{"status" => "True", "reason" => "BaseBuilt"} = condition(status_map, "BaseBuilt")
+  end
+
+  test "an already-built base is not rebuilt on a redundant reconcile (idempotent)" do
+    agent = start_recorder()
+    {:ok, count} = Agent.start_link(fn -> 0 end)
+
+    build_fun = fn :fake_channel, _req ->
+      Agent.update(count, &(&1 + 1))
+      {:ok, resp("snap1")}
+    end
+
+    builder = start_builder(status_writer: recording_status_writer(agent), build_fun: build_fun)
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap1"}, latest(agent, "w")) end)
+
+    # Same spec again: no new build (the signature is unchanged and a base exists).
+    :ok = BaseBuilder.reconcile(builder, desc())
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 2}))
+    Process.sleep(50)
+
+    assert Agent.get(count, & &1) == 1
+  end
+
+  # -- failure -> BaseBuilt=False + daemon error + backoff --------------------
+
+  test "a failed build reports the daemon error and retries with backoff, never becoming Ready" do
+    agent = start_recorder()
+    {:ok, attempts} = Agent.start_link(fn -> 0 end)
+
+    # FAILED_PRECONDITION is what the real daemon returns for an unknown image
+    # (every image in R0). The first two attempts fail; the third succeeds, to
+    # prove the backoff retry actually re-drives the build.
+    build_fun = fn :fake_channel, _req ->
+      n = Agent.get_and_update(attempts, fn n -> {n + 1, n + 1} end)
+
+      if n < 3 do
+        {:error, %GRPC.RPCError{status: 9, message: "no image source for imgA"}}
+      else
+        {:ok, resp("snap1")}
+      end
+    end
+
+    builder =
+      start_builder(
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        base_backoff_ms: 5,
+        max_backoff_ms: 20
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+
+    # The first failure surfaces the daemon message and keeps the workload
+    # un-Ready (no base exists).
+    assert_eventually(fn ->
+      case latest(agent, "w") do
+        nil -> false
+        s -> match?(%{"reason" => "BuildFailed"}, condition(s, "BaseBuilt"))
+      end
+    end)
+
+    failed = latest(agent, "w")
+    assert %{"status" => "False", "message" => "no image source for imgA"} = condition(failed, "BaseBuilt")
+    assert %{"status" => "False", "reason" => "BaseNotBuilt"} = condition(failed, "Ready")
+
+    # Backoff retried until the (scripted) success, proving the retry loop runs.
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap1"}, latest(agent, "w")) end)
+    assert Agent.get(attempts, & &1) >= 3
+  end
+
+  # -- serialization ----------------------------------------------------------
+
+  test "builds are serialized per node: a second admission waits for the first" do
+    agent = start_recorder()
+    test_pid = self()
+
+    # Each build announces itself and its worker pid, then blocks until the test
+    # releases it. If builds were concurrent, both would announce immediately.
+    build_fun = fn :fake_channel, req ->
+      send(test_pid, {:building, req.trace.workload, self()})
+
+      receive do
+        {:go, result} -> result
+      end
+    end
+
+    builder = start_builder(status_writer: recording_status_writer(agent), build_fun: build_fun)
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{name: "a"}))
+    :ok = BaseBuilder.reconcile(builder, desc(%{name: "b"}))
+
+    # "a" starts; "b" must NOT start while "a" is in flight.
+    assert_receive {:building, "a", worker_a}, 1_000
+    refute_receive {:building, "b", _}, 200
+
+    # Releasing "a" lets "b" start: proof of serial-per-node execution.
+    send(worker_a, {:go, {:ok, resp("snap-a")}})
+    assert_receive {:building, "b", worker_b}, 1_000
+    send(worker_b, {:go, {:ok, resp("snap-b")}})
+
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap-b"}, latest(agent, "b")) end)
+  end
+
+  # -- digest-change turnover (the acceptance property) -----------------------
+
+  test "a digest change rebuilds and turns over the base with no zero-base window" do
+    agent = start_recorder()
+
+    build_fun = fn :fake_channel, req ->
+      case req.image_ref do
+        "imgA" -> {:ok, resp("snap1", "sha256:aaa")}
+        "imgB" -> {:ok, resp("snap2", "sha256:bbb")}
+      end
+    end
+
+    builder = start_builder(status_writer: recording_status_writer(agent), build_fun: build_fun)
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{image_ref: "imgA"}))
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap1"}, latest(agent, "w")) end)
+
+    first_success_count = length(recorded(agent))
+
+    # New image ref (a "digest change") triggers a rebuild to snap2.
+    :ok = BaseBuilder.reconcile(builder, desc(%{image_ref: "imgB", generation: 2}))
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap2"}, latest(agent, "w")) end)
+
+    # PROPERTY: from the first built base onward, every status write keeps the
+    # workload Ready (a restorable base always exists) and never clears
+    # snapshotRef to "". The old base is never dropped before the new one lands.
+    writes_after_first = Enum.drop(recorded(agent), first_success_count - 1)
+
+    for {_ns, "w", status_map} <- writes_after_first do
+      assert %{"status" => "True"} = condition(status_map, "Ready")
+
+      if Map.has_key?(status_map, "snapshotRef") do
+        assert status_map["snapshotRef"] in ["snap1", "snap2"]
+      end
+    end
+
+    # The old base is recorded for the pool to turn over (Task 11 seam), and the
+    # current snapshot has advanced to the new base.
+    st = BaseBuilder.status(builder)
+    assert st.workloads["w"].snapshot_ref == "snap2"
+    assert st.workloads["w"].superseded_refs == ["snap1"]
+  end
+
+  # -- no node configured -----------------------------------------------------
+
+  test "with no node configured, no build is attempted and status reports NoNodeAvailable" do
+    agent = start_recorder()
+    {:ok, count} = Agent.start_link(fn -> 0 end)
+
+    build_fun = fn :fake_channel, _req ->
+      Agent.update(count, &(&1 + 1))
+      {:ok, resp("snap1")}
+    end
+
+    builder = start_builder(nodes: [], status_writer: recording_status_writer(agent), build_fun: build_fun)
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+
+    assert_eventually(fn ->
+      case latest(agent, "w") do
+        nil -> false
+        s -> match?(%{"reason" => "NoNodeAvailable"}, condition(s, "BaseBuilt"))
+      end
+    end)
+
+    assert %{"status" => "Unknown"} = condition(latest(agent, "w"), "BaseBuilt")
+    assert Agent.get(count, & &1) == 0
+  end
+
+  # -- forget -----------------------------------------------------------------
+
+  test "forgetting a workload mid-queue drops it without building" do
+    agent = start_recorder()
+    test_pid = self()
+
+    build_fun = fn :fake_channel, req ->
+      send(test_pid, {:building, req.trace.workload, self()})
+
+      receive do
+        {:go, result} -> result
+      end
+    end
+
+    builder = start_builder(status_writer: recording_status_writer(agent), build_fun: build_fun)
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{name: "a"}))
+    :ok = BaseBuilder.reconcile(builder, desc(%{name: "b"}))
+
+    assert_receive {:building, "a", worker_a}, 1_000
+
+    # Forget "b" while it is queued behind "a": it must never build.
+    :ok = BaseBuilder.forget(builder, "b")
+    send(worker_a, {:go, {:ok, resp("snap-a")}})
+
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap-a"}, latest(agent, "a")) end)
+    refute_receive {:building, "b", _}, 200
+
+    st = BaseBuilder.status(builder)
+    refute Map.has_key?(st.workloads, "b")
+  end
+end

--- a/projects/embervm/control/test/embervm/workload_watcher_test.exs
+++ b/projects/embervm/control/test/embervm/workload_watcher_test.exs
@@ -39,18 +39,46 @@ defmodule Embervm.WorkloadWatcherTest do
     end
   end
 
+  # Injected base-builder trigger seams so the watcher tests never touch the
+  # application's real supervised Embervm.BaseBuilder (which boots in `mix test`).
+  # Records reconcile descriptors and forgotten names into an agent for
+  # assertions. Defaults keep the trigger inert for tests that only care about
+  # cataloging/status.
+  defp base_seams(opts \\ []) do
+    agent = Keyword.get(opts, :agent)
+
+    reconcile = fn desc ->
+      if agent, do: Agent.update(agent, fn s -> %{s | reconciled: s.reconciled ++ [desc]} end)
+      :ok
+    end
+
+    forget = fn name ->
+      if agent, do: Agent.update(agent, fn s -> %{s | forgotten: s.forgotten ++ [name]} end)
+      :ok
+    end
+
+    [base_reconcile_fun: reconcile, base_forget_fun: forget]
+  end
+
+  defp start_base_recorder do
+    {:ok, agent} = Agent.start_link(fn -> %{reconciled: [], forgotten: []} end)
+    agent
+  end
+
   # watch_startup: false means init spawns no streamer and arms no timer: every
   # reconcile is driven explicitly through reconcile_now/1, exactly as these
   # LIST-reconcile tests want. The informer/watch path is exercised separately
   # in the "watch stream" describe block below via an injected watcher_fun.
-  defp start_watcher(lister, status_writer, table) do
+  defp start_watcher(lister, status_writer, table, extra \\ []) do
     {:ok, pid} =
       WorkloadWatcher.start_link(
-        name: nil,
-        table: table,
-        lister: lister,
-        status_writer: status_writer,
-        watch_startup: false
+        [
+          name: nil,
+          table: table,
+          lister: lister,
+          status_writer: status_writer,
+          watch_startup: false
+        ] ++ Keyword.merge(base_seams(), extra)
       )
 
     pid
@@ -83,11 +111,12 @@ defmodule Embervm.WorkloadWatcherTest do
     Enum.filter(calls, fn {_ns, n, _status} -> n == name end) |> List.last()
   end
 
-  test "add: a valid CR is cataloged with parsed retry, status reports Ready=False/BaseNotBuilt" do
+  test "add: a valid CR is cataloged, writes watcher-owned status, and triggers the base builder" do
     table = unique_table()
     agent = start_recorder()
+    base = start_base_recorder()
     lister = fn -> {:ok, [valid_cr()]} end
-    watcher = start_watcher(lister, recording_status_writer(agent), table)
+    watcher = start_watcher(lister, recording_status_writer(agent), table, base_seams(agent: base))
 
     :ok = WorkloadWatcher.reconcile_now(watcher)
 
@@ -101,9 +130,23 @@ defmodule Embervm.WorkloadWatcherTest do
     assert entry.retry.max_attempts == 5
     assert entry.retry.retry_on == [:transport, :timeout, :guest5xx]
 
+    # The watcher writes ONLY its own keys for a valid CR: observedGeneration and
+    # primedFloorSatisfied, and crucially NOT conditions (the BaseBuilder owns
+    # Ready/BaseBuilt, so the two merge-patches never clobber each other).
     assert {_ns, "semgrep", status_map} = ready_status(recorded_calls(agent), "semgrep")
     assert status_map["observedGeneration"] == 1
-    assert [%{"type" => "Ready", "status" => "False", "reason" => "BaseNotBuilt"}] = status_map["conditions"]
+    assert status_map["primedFloorSatisfied"] == false
+    refute Map.has_key?(status_map, "conditions")
+
+    # The build trigger fired with the base-shaping fields.
+    assert [desc] = Agent.get(base, & &1.reconciled)
+    assert desc.name == "semgrep"
+    assert desc.namespace == "embervm"
+    assert desc.generation == 1
+    assert desc.image_ref == "x"
+    assert desc.guest_port == 8080
+    assert desc.vcpus == 1
+    assert desc.mem_mib == 256
   end
 
   test "update: a changed generation and retry.maxAttempts updates the catalog entry" do
@@ -152,16 +195,21 @@ defmodule Embervm.WorkloadWatcherTest do
   test "invalid class: not cataloged, status reports Ready=False/ClassUnsupported, GenServer survives" do
     table = unique_table()
     agent = start_recorder()
+    base = start_base_recorder()
     cr = valid_cr(%{"spec" => %{"class" => "session"}})
     lister = fn -> {:ok, [cr]} end
-    watcher = start_watcher(lister, recording_status_writer(agent), table)
+    watcher = start_watcher(lister, recording_status_writer(agent), table, base_seams(agent: base))
 
     :ok = WorkloadWatcher.reconcile_now(watcher)
 
     assert WorkloadCatalog.fetch(table, "semgrep") == :error
 
+    # The watcher owns the Ready condition for the invalid lane, and forgets any
+    # base build for a now-invalid Workload (never triggers a build for it).
     assert {_ns, "semgrep", status_map} = ready_status(recorded_calls(agent), "semgrep")
     assert [%{"type" => "Ready", "status" => "False", "reason" => "ClassUnsupported"}] = status_map["conditions"]
+    assert Agent.get(base, & &1.reconciled) == []
+    assert "semgrep" in Agent.get(base, & &1.forgotten)
 
     assert Process.alive?(watcher)
   end
@@ -284,6 +332,8 @@ defmodule Embervm.WorkloadWatcherTest do
           # watch-end handler runs the resync LIST. (A :block episode would fire
           # the event but never end, so the resync would never trigger.) The
           # close is fast, so it goes through the backoff timer; keep that tiny.
+          base_reconcile_fun: fn _ -> :ok end,
+          base_forget_fun: fn _ -> :ok end,
           watcher_fun: scripted_watcher([{[error_event()], {:ok, :closed}}]),
           base_backoff_ms: 10,
           max_backoff_ms: 20,
@@ -311,6 +361,8 @@ defmodule Embervm.WorkloadWatcherTest do
           status_writer: recording_status_writer(agent),
           # First watch attempt errors; the second blocks (open). With a tiny
           # backoff the resync fires fast enough to assert without slowing CI.
+          base_reconcile_fun: fn _ -> :ok end,
+          base_forget_fun: fn _ -> :ok end,
           watcher_fun: scripted_watcher([{[], {:error, :boom}}, {[], :block}]),
           base_backoff_ms: 10,
           max_backoff_ms: 20,
@@ -356,6 +408,8 @@ defmodule Embervm.WorkloadWatcherTest do
           table: table,
           lister: lister,
           status_writer: recording_status_writer(agent),
+          base_reconcile_fun: fn _ -> :ok end,
+          base_forget_fun: fn _ -> :ok end,
           watcher_fun:
             scripted_watcher([{[], {:ok, :closed}}, {[added_event(named_cr("sandbox"))], :block}]),
           # min_watch_ms: 0 makes the (instant) fake close count as a healthy
@@ -383,12 +437,14 @@ defmodule Embervm.WorkloadWatcherTest do
     lister = fn -> {:ok, list_crs, "100"} end
 
     WorkloadWatcher.start_link(
-      name: nil,
-      table: table,
-      lister: lister,
-      status_writer: recording_status_writer(agent),
-      watcher_fun: scripted_watcher(episodes),
-      watch_startup: true
+      [
+        name: nil,
+        table: table,
+        lister: lister,
+        status_writer: recording_status_writer(agent),
+        watcher_fun: scripted_watcher(episodes),
+        watch_startup: true
+      ] ++ base_seams()
     )
   end
 

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.11
+      targetRevision: 0.1.12
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## EmberVM R0, Task 10: the BaseBuilder control loop

`Embervm.BaseBuilder` is the first control-plane component that **drives** the node daemon (Task 9's NodeRegistry only *consumes* node truth). On Workload admission or spec change it drives the noded `BuildBase` RPC and reconciles the result into the Workload's `status` subresource, turning a `source: image` Workload into a pristine base snapshot. Building a base is the on-ramp that makes a Workload eligible to run: it never becomes `Ready` without a restorable base.

### What it does
- **Serialized per node.** A per-node FIFO queue with a single `building` slot; the heavy blocking `BuildBase` runs in a `spawn_monitor`'d worker (the NodeRegistry streamer discipline) so it never freezes the GenServer that owns the queue and every status-write decision. Concurrent admissions queue.
- **Failure -> backoff, never Ready without a base.** A failed build sets `BaseBuilt=False` with the daemon's error string in the condition message and retries with exponential backoff (cap 10m). `Ready` is derived purely from whether a restorable base exists, so a first-build failure keeps the Workload un-Ready.
- **Digest-change turnover with no zero-base window.** A change to the base signature (image ref, resources, guest contract, `initEnv`) triggers a rebuild. The old `snapshotRef` keeps serving until the new base is confirmed, then status advances and the old ref is recorded in `superseded_refs` for Task 11's pool to reconcile (destroy old-base primed VMs, re-prime from the new base). No pool is built here (documented seam). Property: `status.snapshotRef` is always restorable.
- **Digest recorded, not tag drift.** Tag-pinned refs resolve to a digest on the daemon at build time; the resolved digest lands in `status.snapshotDigest`. Deploys are explicit CR updates, so tag drift alone does not rebuild.

### Status coordination (the crux)
`patch_workload_status` uses a JSON merge-patch, which replaces arrays wholesale, so two writers touching `conditions` would clobber. **Ownership is split by key**: the BaseBuilder owns `conditions[Ready, BaseBuilt]` + `snapshotRef` + `snapshotDigest` for valid task Workloads; the `WorkloadWatcher` stops writing `conditions` for valid CRs and writes only its disjoint keys (`observedGeneration`, `primedFloorSatisfied`), keeping the `Ready` condition only for the invalid validation lane. The watcher hands each valid CR to the builder via a `whereis`-guarded `reconcile` cast and `forget`s invalid/deleted ones. (Server-Side Apply was the considered alternative; the ownership split avoids a CRD change and the apply-patch machinery.)

Supervised **before** the watcher under `:rest_for_one`, so a builder restart cascades a watcher restart whose boot LIST re-casts every Workload; reconcile is idempotent (signature dedup + the daemon's own `already_built`), so re-driving is free and self-healing.

### Acceptance
ExUnit with a **fake daemon** (injected `build_fun`/`connect_fun`, the NodeRegistry seam style):
- admission -> BuildBase -> status write (built base);
- failure -> `BaseBuilt=False` + daemon error message + backoff retry, never Ready;
- builds serialized per node (second admission waits for the first);
- digest-change turnover leaves no zero-base window (property: every status write after the first base keeps `Ready=True` and never clears `snapshotRef`);
- no-node and forget-mid-queue paths.

### Notes
- **No CRD change**: `snapshotRef`, `snapshotDigest`, and the `BaseBuilt` condition type already exist in `chart/crds/workload-crd.yaml`.
- **Chart bumped 0.1.11 -> 0.1.12**: the new prod module changes the release image digest.
- **Honest live-verify**: `EMBERVM_NODED_IMAGES` is empty in R0, so the live path writes `BaseBuilt=False` with the daemon's `FAILED_PRECONDITION` error into the sample Workload's status. A green base waits on guest-image provisioning (Task 14+). This PR does not claim a working snapshot.
- The primed pool + dispatcher are **Task 11**; submit stays async-only until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)