### PR TITLE
chore(monolith): drop dead _collect_queues dashboard collector

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.104
+version: 0.89.105
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.104
+      targetRevision: 0.89.105
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.184
+version: 0.285.185
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.184
+      targetRevision: 0.285.185
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/home/dashboard.py
+++ b/projects/monolith/home/dashboard.py
@@ -1,10 +1,9 @@
 """Dashboard aggregation for the private landing page.
 
-Fans out to cluster health, firing alerts, GitHub PR/CI status, knowledge
-review queues and task rollups, scheduler job health, and today's calendar
-events. Each collector is fail-soft: a failure in one section is caught and
-reported as {"error": str(exc)} for that section only, so a single flaky
-upstream (SigNoz, GitHub, the K8s API) never blanks the whole dashboard.
+Fans out to cluster health, firing alerts, GitHub PR/CI status, and today's
+calendar events. Each collector is fail-soft: a failure in one section is
+caught and reported as {"error": str(exc)} for that section only, so a single
+flaky upstream (SigNoz, GitHub, the K8s API) never blanks the whole dashboard.
 
 Private-tier only (registered in home.register, not home.register_public):
 the GitHub token, SigNoz alerts and cluster health rollup are not meant for
@@ -162,38 +161,6 @@ async def _collect_alerts(session) -> dict:
     return await fetch_alerts_live()
 
 
-async def _collect_queues(session) -> dict:
-    """Knowledge review-queue counts, task rollups, and scheduler job health."""
-    from knowledge.api import (
-        count_gaps_review_queue,
-        count_notes_review_queue,
-        list_tasks_daily,
-        list_tasks_weekly,
-    )
-    from scheduler.api import list_jobs
-
-    jobs = [
-        {
-            "name": job.name,
-            "last_status": job.last_status,
-            "last_run_at": job.last_run_at,
-            "next_run_at": job.next_run_at,
-        }
-        for job in list_jobs(session)
-    ]
-    # Failing/stuck jobs first: a job with a non-ok last_status (including
-    # never-run, last_status is None) sorts ahead of healthy ones.
-    jobs.sort(key=lambda j: 0 if j["last_status"] != "ok" else 1)
-
-    return {
-        "notes_review_queue": count_notes_review_queue(session),
-        "gaps_review_queue": count_gaps_review_queue(session),
-        "tasks_daily": list_tasks_daily(session),
-        "tasks_weekly": list_tasks_weekly(session),
-        "scheduler_jobs": jobs,
-    }
-
-
 async def _collect_today(session) -> dict:
     """Today's calendar events (same-domain, home.schedule)."""
     from home.schedule import get_today_events
@@ -208,12 +175,11 @@ async def build_dashboard(session) -> dict:
     {"error": str(exc)} for that section rather than failing the whole
     response.
     """
-    names = ("health", "alerts", "github", "queues", "today")
+    names = ("health", "alerts", "github", "today")
     results = await asyncio.gather(
         _collect_health(session),
         _collect_alerts(session),
         _collect_github(),
-        _collect_queues(session),
         _collect_today(session),
         return_exceptions=True,
     )

--- a/projects/monolith/home/dashboard_test.py
+++ b/projects/monolith/home/dashboard_test.py
@@ -34,19 +34,6 @@ async def test_build_dashboard_isolates_a_failing_section():
             AsyncMock(return_value={"open_prs": [], "recent_merges": []}),
         ),
         patch.object(
-            dashboard,
-            "_collect_queues",
-            AsyncMock(
-                return_value={
-                    "notes_review_queue": 0,
-                    "gaps_review_queue": 0,
-                    "tasks_daily": [],
-                    "tasks_weekly": [],
-                    "scheduler_jobs": [],
-                }
-            ),
-        ),
-        patch.object(
             dashboard, "_collect_today", AsyncMock(return_value={"events": []})
         ),
     ):
@@ -55,7 +42,6 @@ async def test_build_dashboard_isolates_a_failing_section():
     assert result["health"] == {"error": "k8s down"}
     assert result["alerts"] == {"firing": []}
     assert result["github"] == {"open_prs": [], "recent_merges": []}
-    assert result["queues"]["notes_review_queue"] == 0
     assert result["today"] == {"events": []}
     assert "cached_at" in result
 
@@ -75,25 +61,12 @@ async def test_build_dashboard_all_sections_healthy():
             AsyncMock(return_value={"open_prs": [], "recent_merges": []}),
         ),
         patch.object(
-            dashboard,
-            "_collect_queues",
-            AsyncMock(
-                return_value={
-                    "notes_review_queue": 2,
-                    "gaps_review_queue": 1,
-                    "tasks_daily": [],
-                    "tasks_weekly": [],
-                    "scheduler_jobs": [],
-                }
-            ),
-        ),
-        patch.object(
             dashboard, "_collect_today", AsyncMock(return_value={"events": []})
         ),
     ):
         result = await dashboard.build_dashboard(session=MagicMock())
 
-    for section in ("health", "alerts", "github", "queues", "today"):
+    for section in ("health", "alerts", "github", "today"):
         assert "error" not in result[section]
 
 
@@ -114,19 +87,6 @@ async def test_build_dashboard_multiple_sections_fail_independently():
             AsyncMock(return_value={"open_prs": [], "recent_merges": []}),
         ),
         patch.object(
-            dashboard,
-            "_collect_queues",
-            AsyncMock(
-                return_value={
-                    "notes_review_queue": 0,
-                    "gaps_review_queue": 0,
-                    "tasks_daily": [],
-                    "tasks_weekly": [],
-                    "scheduler_jobs": [],
-                }
-            ),
-        ),
-        patch.object(
             dashboard, "_collect_today", AsyncMock(return_value={"events": []})
         ),
     ):
@@ -135,7 +95,6 @@ async def test_build_dashboard_multiple_sections_fail_independently():
     assert "error" in result["health"]
     assert "error" in result["alerts"]
     assert "error" not in result["github"]
-    assert "error" not in result["queues"]
     assert "error" not in result["today"]
 
 

--- a/projects/monolith/home/tests/bdd_api_test.py
+++ b/projects/monolith/home/tests/bdd_api_test.py
@@ -19,7 +19,7 @@ class TestDashboardAPI:
         r = httpx.get(f"{live_server}/api/home/dashboard")
         assert r.status_code == 200
         data = r.json()
-        for section in ("health", "alerts", "github", "queues", "today"):
+        for section in ("health", "alerts", "github", "today"):
             assert section in data
         assert "cached_at" in data
 


### PR DESCRIPTION
Follow-up cleanup to the cluster-ops relayout (#3492). That PR removed the private dashboard's **Queues** card, but left `build_dashboard`'s `_collect_queues` section computed on every 60s refresh and never rendered.

## Change
- Remove `_collect_queues`, its wiring in `build_dashboard`, and the `queues` section from the payload.
- Update `dashboard_test.py` (drop the `_collect_queues` mocks + `queues` assertions).
- `knowledge.api.count_notes_review_queue` / `count_gaps_review_queue` **stay** — still used by the `/review` endpoint in `knowledge/router.py`. This only drops the unused dashboard consumer.

## Deploy notes
`home/dashboard.py` is in the shared `_BACKEND_SRCS` glob (private `app/main.py` and public `app/main_public.py` build from the same source closure), so **both** backend images change — monolith (`0.285.185`) and monolith-public (`0.89.105`) bump together. This is the opposite of #3492, which was frontend-only under the `:src_public` exclusion.

Local `ruff format --check` + `ruff check` pass on both Python files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)