### PR TITLE
feat(embervm): primed pool and fair dispatcher (R0 Task 11)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.12
+version: 0.1.13

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -14,6 +14,12 @@ spec:
   strategy:
     type: Recreate
   selector:
+    # The control-plane selector is immutable (this is a live Deployment; adding a
+    # component label to the selector is a forbidden update), and the second
+    # Deployment in this chart (noded) is already selector-disjoint via a distinct
+    # app.kubernetes.io/name, so the shared-selector cross-routing this rule guards
+    # against cannot occur here.
+    # nosemgrep: require-component-label-in-selector
     matchLabels:
       {{- include "embervm.selectorLabels" . | nindent 6 }}
   template:
@@ -61,6 +67,14 @@ spec:
             # plane, so the env is only set when the list is non-empty.
             - name: EMBERVM_ALLOWED_SERVICE_ACCOUNTS
               value: {{ join "," .Values.auth.allowedServiceAccounts | quote }}
+            {{- end }}
+            # Fair dispatcher tuning (Task 11): per-principal queue-depth 429 cap
+            # and the optional fixed per-principal in-flight share fraction.
+            - name: EMBERVM_QUEUE_DEPTH_CAP
+              value: {{ .Values.dispatcher.queueDepthCap | quote }}
+            {{- if .Values.dispatcher.principalShareFraction }}
+            - name: EMBERVM_PRINCIPAL_SHARE_FRACTION
+              value: {{ .Values.dispatcher.principalShareFraction | quote }}
             {{- end }}
           readinessProbe:
             httpGet:

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -70,6 +70,17 @@ node:
 auth:
   allowedServiceAccounts: []
 
+# Fair dispatcher tuning (Task 11). The pool floor/cap and invocation policy are
+# per-Workload in the CR; these are the cross-workload enforcement knobs.
+dispatcher:
+  # Per-principal queue-depth cap: submits beyond this many queued tasks for one
+  # principal are rejected 429 (a coarse abuse guard).
+  queueDepthCap: 10000
+  # Per-principal in-flight SHARE of a workload's cap. Empty means dynamic:
+  # cap / active-principals (min 1), so under contention no principal starves
+  # the others. Set a fraction in (0, 1] to fix each principal's share instead.
+  principalShareFraction: ""
+
 service:
   port: 8080
 

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -73,8 +73,36 @@ defmodule Embervm.Application do
       # Mint gRPC connection, so it does not depend on the Finch pool. With no node
       # wired (empty address), it supervises an empty node list and does nothing.
       {Embervm.NodeRegistry, nodes: configured_nodes()},
-      # Bandit + the router last: its handlers call Auth, TaskStore, and
-      # SyncWait, so the HTTP surface must not accept requests until all are up.
+      # The shared per-node gRPC channel holder (Task 11): one long-lived, reused
+      # Mint channel per node for the Prime/Assign hot path (unlike NodeRegistry/
+      # BaseBuilder, which each own their own channel and can afford a per-op
+      # connect). Lazy-dials and caches in persistent_term for lock-free worker
+      # reads; workers invalidate a channel on a transport error. With no node
+      # wired it caches nothing.
+      {Embervm.NodeChannel, nodes: configured_nodes()},
+      # The dispatcher (Task 11): the heart of R0. Owns the per-workload fair
+      # queues, the primed-VM inventory, the enforcement caps, and drives queued
+      # tasks to terminal via Assign. Placed AFTER TaskStore (drives its FSM +
+      # is the target of its on_queued hook), NodeRegistry (reads NodeCapacity),
+      # WorkloadWatcher (reads WorkloadCatalog), and NodeChannel (the assign
+      # channel). Under :rest_for_one a dispatcher restart loses its in-memory
+      # queues, which its boot backlog-sweep rebuilds from TaskStore.
+      {Embervm.Dispatcher, dispatcher_opts()},
+      # The pool manager (Task 11): the background refill loop keeping `floor`
+      # VMs primed per workload (floor-first, then proportional to queue depth),
+      # depositing primed vm_ids into the dispatcher's inventory and owning
+      # status.primedFloorSatisfied. After the dispatcher (it deposits into it)
+      # and after the node registry/watcher (it reads capacity + catalog). Primes
+      # nothing in R0 (no base is ready until guest images land, Task 14).
+      {Embervm.PoolManager, pool_opts()},
+      # The cron trigger adapter (Task 11): fires each Workload's spec.triggers[]
+      # cron as an ordinary submit (principal system:cron:<workload>); misfires
+      # during downtime are skipped, not replayed. After the watcher (reads the
+      # catalog's triggers) and TaskStore (submits into it).
+      Embervm.Trigger.Cron,
+      # Bandit + the router last: its handlers call Auth, TaskStore, SyncWait, and
+      # the dispatcher's admit? gate, so the HTTP surface must not accept requests
+      # until all are up.
       {Bandit, plug: Embervm.Router, scheme: :http, port: port}
     ]
 
@@ -139,6 +167,35 @@ defmodule Embervm.Application do
     case System.get_env(name) do
       nil -> ""
       value -> String.trim(value)
+    end
+  end
+
+  # Dispatcher tuning from the chart (values -> env). The share fraction, when
+  # set, caps each principal at that fraction of a workload's cap; unset (the
+  # default) means the dynamic cap/active-principals split.
+  defp dispatcher_opts do
+    [queue_depth_cap: queue_depth_cap()] ++ share_fraction_opt()
+  end
+
+  defp pool_opts, do: []
+
+  defp queue_depth_cap do
+    case trimmed_env("EMBERVM_QUEUE_DEPTH_CAP") do
+      "" -> 10_000
+      raw -> String.to_integer(raw)
+    end
+  end
+
+  defp share_fraction_opt do
+    case trimmed_env("EMBERVM_PRINCIPAL_SHARE_FRACTION") do
+      "" ->
+        []
+
+      raw ->
+        case Float.parse(raw) do
+          {f, _} when f > 0 -> [share_fraction: f]
+          _ -> []
+        end
     end
   end
 

--- a/projects/embervm/control/lib/embervm/cron.ex
+++ b/projects/embervm/control/lib/embervm/cron.ex
@@ -1,0 +1,185 @@
+defmodule Embervm.Cron do
+  @moduledoc """
+  A minimal, dependency-free 5-field cron parser + next-fire calculator.
+
+  Deliberately NOT a hex dependency: adding one to the control plane's hermetic
+  Bazel hex closure is a heavy, multi-file change for what a small pure function
+  covers. The five fields are `minute hour day-of-month month day-of-week`, each
+  supporting `*`, `*/step`, `a-b` ranges, `a,b,c` lists, and bare values; the
+  day-of-week field is 0-6 with 0 = Sunday.
+
+  `next/2` returns the first minute STRICTLY AFTER the given time that matches
+  (fires happen on the minute boundary), which is what makes misfires during
+  downtime skipped rather than replayed: the adapter always computes the next
+  fire from the current time, so a fire whose minute passed while the control
+  plane was down is simply never in the future window.
+
+  Day-of-month vs day-of-week follows the Vixie-cron rule: when BOTH are
+  restricted (neither is `*`), a day matches if EITHER matches; otherwise both
+  must match (the unrestricted `*` field is always satisfied).
+  """
+
+  @type field :: MapSet.t(non_neg_integer())
+  @type t :: %{minute: field, hour: field, dom: field, month: field, dow: field, dom_star: boolean(), dow_star: boolean()}
+
+  @minute_range 0..59
+  @hour_range 0..23
+  @dom_range 1..31
+  @month_range 1..12
+  @dow_range 0..6
+
+  # Safety bound: a valid cron matches within a year; give up past that so a
+  # malformed spec that never matches cannot loop forever.
+  @max_lookahead_minutes 366 * 24 * 60
+
+  @doc """
+  Parse a 5-field cron string into a compiled matcher, or `{:error, reason}`.
+  """
+  @spec parse(String.t()) :: {:ok, t()} | {:error, term()}
+  def parse(expr) when is_binary(expr) do
+    case expr |> String.trim() |> String.split(~r/\s+/, trim: true) do
+      [minute, hour, dom, month, dow] ->
+        with {:ok, m} <- field(minute, @minute_range),
+             {:ok, h} <- field(hour, @hour_range),
+             {:ok, d} <- field(dom, @dom_range),
+             {:ok, mo} <- field(month, @month_range),
+             {:ok, w} <- field(dow, @dow_range) do
+          {:ok,
+           %{
+             minute: m,
+             hour: h,
+             dom: d,
+             month: mo,
+             dow: w,
+             dom_star: String.trim(dom) == "*",
+             dow_star: String.trim(dow) == "*"
+           }}
+        end
+
+      parts ->
+        {:error, {:expected_5_fields, length(parts)}}
+    end
+  end
+
+  def parse(_), do: {:error, :not_a_string}
+
+  @doc """
+  The first `%DateTime{}` (in `from`'s time zone, UTC in practice) strictly after
+  `from` that matches `cron`. `{:error, :no_match}` for a spec that matches
+  nothing within a year (a malformed field combination).
+  """
+  @spec next(t(), DateTime.t()) :: {:ok, DateTime.t()} | {:error, :no_match}
+  def next(%{} = cron, %DateTime{} = from) do
+    # Start at the next whole minute after `from` (truncate to minute, +60s).
+    start =
+      from
+      |> Map.put(:second, 0)
+      |> Map.put(:microsecond, {0, 0})
+      |> DateTime.add(60, :second)
+
+    search(cron, start, 0)
+  end
+
+  defp search(_cron, _dt, n) when n > @max_lookahead_minutes, do: {:error, :no_match}
+
+  defp search(cron, dt, n) do
+    if matches?(cron, dt) do
+      {:ok, dt}
+    else
+      search(cron, DateTime.add(dt, 60, :second), n + 1)
+    end
+  end
+
+  @doc "Whether `dt` (at minute resolution) matches `cron`."
+  @spec matches?(t(), DateTime.t()) :: boolean()
+  def matches?(cron, %DateTime{} = dt) do
+    MapSet.member?(cron.minute, dt.minute) and
+      MapSet.member?(cron.hour, dt.hour) and
+      MapSet.member?(cron.month, dt.month) and
+      day_matches?(cron, dt)
+  end
+
+  # Vixie rule: both restricted -> OR; otherwise the restricted one(s) must match.
+  defp day_matches?(cron, dt) do
+    dom_ok = MapSet.member?(cron.dom, dt.day)
+    dow_ok = MapSet.member?(cron.dow, day_of_week(dt))
+
+    cond do
+      not cron.dom_star and not cron.dow_star -> dom_ok or dow_ok
+      true -> dom_ok and dow_ok
+    end
+  end
+
+  # Date.day_of_week/1 is 1 (Monday)..7 (Sunday); cron wants 0 (Sunday)..6.
+  defp day_of_week(dt) do
+    case Date.day_of_week(DateTime.to_date(dt)) do
+      7 -> 0
+      n -> n
+    end
+  end
+
+  # -- field parsing ---------------------------------------------------------
+
+  defp field(spec, range) do
+    spec
+    |> String.split(",", trim: true)
+    |> Enum.reduce_while({:ok, MapSet.new()}, fn part, {:ok, acc} ->
+      case term(part, range) do
+        {:ok, set} -> {:cont, {:ok, MapSet.union(acc, set)}}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+    |> case do
+      {:ok, set} -> if MapSet.size(set) == 0, do: {:error, {:empty_field, spec}}, else: {:ok, set}
+      err -> err
+    end
+  end
+
+  # One comma-separated term: "*", "*/n", "a-b", "a-b/n", "a".
+  defp term("*", range), do: {:ok, MapSet.new(range)}
+
+  defp term(part, range) do
+    case String.split(part, "/", parts: 2) do
+      [base, step_str] ->
+        with {:ok, step} <- positive_int(step_str),
+             {:ok, base_range} <- base_range(base, range) do
+          {:ok, base_range |> Enum.take_every(step) |> MapSet.new()}
+        end
+
+      [base] ->
+        with {:ok, base_range} <- base_range(base, range) do
+          {:ok, MapSet.new(base_range)}
+        end
+    end
+  end
+
+  # The base of a term (before any "/step"): "*", "a-b", or "a".
+  defp base_range("*", range), do: {:ok, Enum.to_list(range)}
+
+  defp base_range(spec, range) do
+    case String.split(spec, "-", parts: 2) do
+      [a, b] ->
+        with {:ok, lo} <- int_in(a, range),
+             {:ok, hi} <- int_in(b, range) do
+          if lo <= hi, do: {:ok, Enum.to_list(lo..hi)}, else: {:error, {:reversed_range, spec}}
+        end
+
+      [a] ->
+        with {:ok, v} <- int_in(a, range), do: {:ok, [v]}
+    end
+  end
+
+  defp int_in(str, range) do
+    case Integer.parse(str) do
+      {n, ""} -> if n in range, do: {:ok, n}, else: {:error, {:out_of_range, n}}
+      _ -> {:error, {:not_an_int, str}}
+    end
+  end
+
+  defp positive_int(str) do
+    case Integer.parse(str) do
+      {n, ""} when n > 0 -> {:ok, n}
+      _ -> {:error, {:bad_step, str}}
+    end
+  end
+end

--- a/projects/embervm/control/lib/embervm/cron.ex
+++ b/projects/embervm/control/lib/embervm/cron.ex
@@ -26,7 +26,10 @@ defmodule Embervm.Cron do
   @hour_range 0..23
   @dom_range 1..31
   @month_range 1..12
-  @dow_range 0..6
+  # Day-of-week accepts 0-7, where BOTH 0 and 7 mean Sunday (Vixie cron); 7 is
+  # normalized to 0 after parsing so matching against Date.day_of_week (mapped to
+  # 0..6) is uniform.
+  @dow_range 0..7
 
   # Safety bound: a valid cron matches within a year; give up past that so a
   # malformed spec that never matches cannot loop forever.
@@ -50,7 +53,7 @@ defmodule Embervm.Cron do
              hour: h,
              dom: d,
              month: mo,
-             dow: w,
+             dow: normalize_dow(w),
              dom_star: String.trim(dom) == "*",
              dow_star: String.trim(dow) == "*"
            }}
@@ -62,6 +65,13 @@ defmodule Embervm.Cron do
   end
 
   def parse(_), do: {:error, :not_a_string}
+
+  # 7 and 0 both mean Sunday; collapse 7 into 0 so matching is uniform against a
+  # 0..6 weekday. Applied after field parsing, so `*` (which expands to 0..7)
+  # also collapses cleanly.
+  defp normalize_dow(set) do
+    if MapSet.member?(set, 7), do: set |> MapSet.delete(7) |> MapSet.put(0), else: set
+  end
 
   @doc """
   The first `%DateTime{}` (in `from`'s time zone, UTC in practice) strictly after

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -1,0 +1,997 @@
+defmodule Embervm.Dispatcher do
+  @moduledoc """
+  The heart of R0: turns a `queued` task into an `Assign` against a primed VM
+  and drives it to a terminal state. Until this process runs, `submit` is
+  async-only (tasks sit `queued`); with it, submit actually drains.
+
+  ## what it owns (single hot-path writer)
+
+  This one GenServer owns, in-process, everything the dispatch decision touches,
+  so the decision is a sequence of O(1) reads/writes with no cross-process
+  round-trip and no lock:
+
+    * per-workload FAIR QUEUES: round-robin across principals, FIFO within a
+      principal (`fair_queue.ex`-style structure inlined below);
+    * the PRIMED-VM INVENTORY (`{node, workload} -> vm_ids`) the pool deposits
+      into and dispatch pops from, which IS the destroy-on-assign accounting:
+      a vm_id is single-use, removed the instant it is committed to an Assign,
+      so there is no async lag against the daemon's `free_primed_slots`;
+    * in-flight counters per workload and per principal, for the enforcement
+      gates;
+    * a public queue-depth counter table the submit path reads to 429.
+
+  The capacity facts it gates against (`Embervm.NodeCapacity`) and the workload
+  config (`Embervm.WorkloadCatalog`) are read O(1) from their `read_concurrency`
+  ETS tables, never through a GenServer.
+
+  ## the two dispatch paths
+
+    * WARM (the budget path, p95 <= 25ms): a primed VM is in inventory; pop it,
+      `assign`, done.
+    * MISS (restore-bound, p95 <= 500ms): the inventory is empty but a node has
+      a ready base and budget; a worker Primes-then-Assigns inline. It is
+      counted separately in `stats/0`.
+
+  ALL Prime/Assign I/O runs in `spawn_monitor` workers, never in this GenServer,
+  so a 500ms miss-path restore never head-of-line-blocks warm dispatch, the next
+  decision, or a capacity read. The GenServer only does the cheap decision and
+  the (fast, local) FSM writes through `Embervm.TaskStore`; the heavy RPC is the
+  worker's.
+
+  ## enforcement (fail-closed)
+
+    * per-workload `cap` on in-flight tasks;
+    * per-principal SHARE cap: a values-configured fraction of `cap`, or
+      `cap / active_principals` (min 1) when unset, so under contention no
+      principal starves the others (an over-share principal is skipped in the
+      rotation, not served);
+    * per-principal QUEUE-DEPTH cap (default 10k), enforced as a synchronous 429
+      pre-check at submit via `admit?/3` (a coarse abuse guard; the FSM has no
+      queued->failed edge, so a queued task is never terminally dropped);
+    * if capacity facts are MISSING or STALE (> 15s since the registry stamped
+      them) or no node has a ready base, dispatch is denied with a DISTINCT kind
+      (`:stale_capacity` / `:no_capacity` / `:cap` / `:principal_share`), tallied
+      as metrics for the Task 16 latency/fairness gates. (The op-log `:denied`
+      append is reserved for Task 12 quota, to avoid per-tick log spam.)
+
+  Staleness is measured against the registry's own monotonic stamp
+  (`facts.updated_at` is `System.monotonic_time(:millisecond)`), so this
+  process's `clock` is monotonic too and the subtraction is apples-to-apples.
+
+  ## weights are a parameter, not a redesign
+
+  Round-robin is the weight-1 case of deficit round-robin: each principal carries
+  an implicit weight of 1 today. A future weighted policy changes only the credit
+  a principal accrues per rotation, not the queue structure (per-principal FIFO +
+  a rotation deque), which is why the fairness spec calls weights a follow-on.
+
+  ## how tasks arrive and leave
+
+    * PUSH: `Embervm.TaskStore`'s `on_queued` hook casts `enqueue/1` on every
+      transition INTO `queued` (submit-created, retry, redrive).
+    * SWEEP: a boot + periodic reconcile over `TaskStore.list_backlog/1` re-drives
+      what a dropped push signal missed (a control-plane restart empties the
+      in-memory queues; `reassign_in_flight/0` on a downed node produces
+      `failed_retryable` out of band). Reassigned tasks retry immediately;
+      organic retryable failures wait the backoff `fail/2` returned.
+
+  ## deferred, on purpose
+
+  Live untruncated response handoff to a `?wait=true` caller is NOT built here:
+  the sync waiter still wakes on the terminal transition and the router serves
+  the stored (possibly truncated) result copy, exactly as before. Metering
+  (`AssignResponse.usage`) is Task 12; OTel spans are Task 13; guest-image
+  provisioning (which is what lets a real Assign succeed) is Task 14. In R0
+  `EMBERVM_NODED_IMAGES` is empty, so live verification is limited to the
+  dispatcher wiring up and correctly denying/queueing against the empty-capacity
+  node, plus the fake-daemon drain in ExUnit; no real task runs end to end yet.
+  """
+
+  use GenServer
+  require Logger
+
+  alias Embervm.{NodeCapacity, WorkloadCatalog}
+
+  alias Embervm.Node.V1.{
+    AssignRequest,
+    AssignResponse,
+    GuestRequest,
+    GuestResponse,
+    PrimeRequest,
+    PrimeResponse,
+    Trace
+  }
+
+  @stale_after_ms 15_000
+  @queue_depth_cap 10_000
+  @sweep_interval_ms 5_000
+  @depth_table :embervm_queue_depth
+  # The per-principal queue-depth cap is stored as a distinguished row in the
+  # depth table (an atom key, never colliding with the {workload, principal}
+  # tuple keys) so admit?/3 reads BOTH the current depth and the cap from the one
+  # table the router already has a handle to, with no app-env or GenServer round
+  # trip. The dispatcher writes it on init from its configured cap.
+  @cap_key :__queue_depth_cap__
+
+  # -- Client API ------------------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc """
+  Enqueue a freshly-queued task into its workload's fair queue. A cast so
+  `Embervm.TaskStore`'s transition never blocks on the dispatcher, and
+  `whereis`-guarded so a store with no dispatcher wired (unit tests) is a no-op.
+  This is the default `on_queued` hook target.
+  """
+  @spec enqueue(GenServer.server(), map()) :: :ok
+  def enqueue(server \\ __MODULE__, %{} = task) do
+    case GenServer.whereis(server) do
+      nil -> :ok
+      _ -> GenServer.cast(server, {:enqueue, task})
+    end
+  end
+
+  @doc """
+  Deposit a primed vm_id into the inventory for `{node_id, workload}` (the pool
+  Primed it). A cast from `Embervm.PoolManager`; may unblock a queued task, so it
+  triggers a drain.
+  """
+  @spec deposit(GenServer.server(), String.t(), String.t(), String.t()) :: :ok
+  def deposit(server \\ __MODULE__, node_id, workload, vm_id) do
+    GenServer.cast(server, {:deposit, node_id, workload, vm_id})
+  end
+
+  @doc """
+  Whether `principal` may submit another task to `workload` without breaching its
+  per-principal queue-depth cap. A read-only advisory check the router runs
+  BEFORE the durable submit to 429; the actual reservation happens on `enqueue`,
+  so a burst can momentarily overshoot the cap by the concurrent-submit window
+  (an accepted coarseness for an abuse guard, not precise accounting). Reads the
+  public depth-counter table directly (no GenServer round-trip), and fails closed
+  (denies) when the table is not up yet.
+  """
+  @spec admit?(atom(), String.t(), String.t()) :: boolean()
+  def admit?(depth_table \\ @depth_table, workload, principal) do
+    if :ets.whereis(depth_table) == :undefined do
+      false
+    else
+      current =
+        case :ets.lookup(depth_table, {workload, principal}) do
+          [{_key, n}] -> n
+          [] -> 0
+        end
+
+      current < cap_from_table(depth_table)
+    end
+  end
+
+  defp cap_from_table(depth_table) do
+    case :ets.lookup(depth_table, @cap_key) do
+      [{_key, cap}] -> cap
+      [] -> @queue_depth_cap
+    end
+  end
+
+  @doc """
+  A snapshot of dispatch metrics + queue/inventory/in-flight state, for tests and
+  operational visibility (WHY is nothing draining: no capacity, all stale, a
+  principal capped, the workload at cap).
+  """
+  @spec stats(GenServer.server()) :: map()
+  def stats(server \\ __MODULE__) do
+    GenServer.call(server, :stats)
+  end
+
+  @doc """
+  Runs one backlog reconcile synchronously (the same code the periodic sweep
+  runs) and returns after it plus the drain it triggers complete. Tests drive
+  recovery/reassign paths through this deterministically with `start_sweep:
+  false`; in production the timer fires it every #{@sweep_interval_ms}ms.
+  """
+  @spec sweep(GenServer.server()) :: :ok
+  def sweep(server \\ __MODULE__) do
+    GenServer.call(server, :sweep)
+  end
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    task_store = Keyword.get(opts, :task_store, Embervm.TaskStore)
+
+    state = %{
+      task_store: task_store,
+      capacity_table: Keyword.get(opts, :capacity_table, NodeCapacity.table()),
+      catalog_table: Keyword.get(opts, :catalog_table, WorkloadCatalog.table()),
+      depth_table: Keyword.get(opts, :depth_table, @depth_table),
+      # Monotonic, to compare against the registry's monotonic facts.updated_at.
+      clock: Keyword.get(opts, :clock, &default_mono/0),
+      # Wall clock, for result expires_at (a stored-result TTL is wall time).
+      wall_clock: Keyword.get(opts, :wall_clock, &default_wall/0),
+      channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
+      invalidate_fun: Keyword.get(opts, :invalidate_fun, &Embervm.NodeChannel.invalidate/2),
+      assign_fun: Keyword.get(opts, :assign_fun, &default_assign/2),
+      prime_fun: Keyword.get(opts, :prime_fun, &default_prime/2),
+      get_request_fun:
+        Keyword.get(opts, :get_request_fun, fn tid -> Embervm.TaskStore.get_request(task_store, tid) end),
+      stale_after_ms: Keyword.get(opts, :stale_after_ms, @stale_after_ms),
+      queue_depth_cap: Keyword.get(opts, :queue_depth_cap, @queue_depth_cap),
+      share_fraction: Keyword.get(opts, :share_fraction, nil),
+      sweep_interval_ms: Keyword.get(opts, :sweep_interval_ms, @sweep_interval_ms),
+      # Dynamic state.
+      queues: %{},
+      queued_ids: MapSet.new(),
+      inventory: %{},
+      inflight_wl: %{},
+      inflight_pr: %{},
+      workers: %{},
+      retry_timers: %{},
+      denials: %{cap: 0, principal_share: 0, stale_capacity: 0, no_capacity: 0},
+      warm_hits: 0,
+      misses: 0
+    }
+
+    # Named + public so the router's admit?/3 reads it lock-free. Owned here so it
+    # dies with this subtree; write_concurrency because it is the depth counter.
+    # The cap row lets admit?/3 read the cap from the same table.
+    create_depth_table(state.depth_table)
+    :ets.insert(state.depth_table, {@cap_key, state.queue_depth_cap})
+
+    if Keyword.get(opts, :start_sweep, true) do
+      {:ok, state, {:continue, :boot_sweep}}
+    else
+      {:ok, state}
+    end
+  end
+
+  @impl true
+  def handle_continue(:boot_sweep, state) do
+    state = run_sweep(state)
+    schedule_sweep(state)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast({:enqueue, %{task_id: tid, workload: wl, principal: pr}}, state) do
+    {:noreply, state |> do_enqueue(tid, wl, pr) |> drain_workload(wl)}
+  end
+
+  def handle_cast({:deposit, node_id, wl, vm_id}, state) do
+    q = Map.get(state.inventory, {node_id, wl}, :queue.new())
+    inventory = Map.put(state.inventory, {node_id, wl}, :queue.in(vm_id, q))
+    {:noreply, %{state | inventory: inventory} |> drain_workload(wl)}
+  end
+
+  @impl true
+  def handle_call(:stats, _from, state), do: {:reply, snapshot(state), state}
+
+  def handle_call(:sweep, _from, state) do
+    {:reply, :ok, run_sweep(state)}
+  end
+
+  @impl true
+  def handle_info({:assign_done, pid, outcome}, state) do
+    {:noreply, finish_worker(state, pid, outcome, :flush)}
+  end
+
+  # A worker died without reporting (it always sends {:assign_done, ...} in the
+  # normal path, so a bare DOWN is an abnormal exit): treat as a transport
+  # failure so the task retries at-least-once, exactly as a downed node would.
+  def handle_info({:DOWN, _ref, :process, pid, reason}, state) do
+    case Map.get(state.workers, pid) do
+      nil -> {:noreply, state}
+      _ -> {:noreply, finish_worker(state, pid, {:failed, :transport, {:worker_down, reason}}, :no_flush)}
+    end
+  end
+
+  # A backoff retry timer fired: move the task back to queued. TaskStore.retry
+  # fires the on_queued hook, which casts enqueue/1 back to us, so the requeue
+  # and drain happen on that ensuing message; nothing else to do here.
+  def handle_info({:retry_task, task_id}, state) do
+    state = %{state | retry_timers: Map.delete(state.retry_timers, task_id)}
+    _ = safe(fn -> Embervm.TaskStore.retry(state.task_store, task_id) end)
+    {:noreply, state}
+  end
+
+  def handle_info(:sweep, state) do
+    state = run_sweep(state)
+    schedule_sweep(state)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, state) do
+    for {pid, _meta} <- state.workers, do: Process.exit(pid, :shutdown)
+    :ok
+  end
+
+  # -- enqueue ---------------------------------------------------------------
+
+  # Idempotent enqueue: dedupe on task_id so a sweep racing a live push cannot
+  # double-count depth or double-queue a task. Only a first insertion charges the
+  # per-principal depth counter (released on dispatch commit or terminal drop).
+  defp do_enqueue(state, task_id, wl, pr) do
+    if MapSet.member?(state.queued_ids, task_id) do
+      state
+    else
+      :ets.update_counter(state.depth_table, {wl, pr}, {2, 1}, {{wl, pr}, 0})
+
+      fq = state.queues |> Map.get(wl, new_fq()) |> fq_enqueue(pr, task_id)
+
+      %{
+        state
+        | queues: Map.put(state.queues, wl, fq),
+          queued_ids: MapSet.put(state.queued_ids, task_id)
+      }
+    end
+  end
+
+  # -- drain -----------------------------------------------------------------
+
+  defp drain_all(state) do
+    Enum.reduce(Map.keys(state.queues), state, fn wl, acc -> drain_workload(acc, wl) end)
+  end
+
+  # Dispatch as many tasks for `wl` as capacity, cap, and fairness allow, each in
+  # its own worker. Every iteration re-reads capacity and re-checks the caps, so
+  # the loop stops the moment the workload hits its cap, the pool empties, or the
+  # only remaining principals are over their share.
+  defp drain_workload(state, wl) do
+    case WorkloadCatalog.fetch(state.catalog_table, wl) do
+      :error ->
+        # No catalog entry: cap/floor unknown, so we cannot dispatch (fail-closed).
+        bump_denial(state, :no_capacity)
+
+      {:ok, entry} ->
+        drain_loop(state, wl, entry)
+    end
+  end
+
+  defp drain_loop(state, wl, entry) do
+    cond do
+      fq_empty?(state.queues, wl) ->
+        state
+
+      inflight_count(state.inflight_wl, wl) >= entry.cap ->
+        bump_denial(state, :cap)
+
+      true ->
+        case pick_node(state, wl) do
+          {:error, kind} ->
+            bump_denial(state, kind)
+
+          {:ok, node_id, mode, snapshot_ref} ->
+            dispatch_one(state, wl, entry, node_id, mode, snapshot_ref)
+        end
+    end
+  end
+
+  # Try to commit exactly one task, then recurse to keep draining. A share-capped
+  # or empty rotation stops the loop; a task that will not `assign` (a lost race)
+  # is dropped and the loop continues.
+  defp dispatch_one(state, wl, entry, node_id, mode, snapshot_ref) do
+    share = share_cap(state, wl, entry)
+
+    case fq_take(Map.get(state.queues, wl), wl, share, state.inflight_pr) do
+      {:none, fq} ->
+        # Nothing servable right now (queue empty, or every remaining principal is
+        # at its share). If a principal was skipped for share, record it.
+        state = %{state | queues: Map.put(state.queues, wl, fq)}
+        if fq_empty?(state.queues, wl), do: state, else: bump_denial(state, :principal_share)
+
+      {:ok, task_id, pr, fq} ->
+        state = %{state | queues: Map.put(state.queues, wl, fq)}
+        commit(state, wl, entry, node_id, mode, snapshot_ref, task_id, pr)
+    end
+  end
+
+  # Commit one task to a worker: reserve the VM (warm), drive queued->assigned->
+  # running through the FSM, bump counters, spawn the assign worker, then recurse.
+  defp commit(state, wl, entry, node_id, mode, snapshot_ref, task_id, pr) do
+    {state, vm_id} = reserve_vm(state, node_id, wl, mode)
+
+    with {:ok, {:ok, _}} <- safe_call(fn -> Embervm.TaskStore.assign(state.task_store, task_id) end),
+         {:ok, {:ok, _}} <- safe_call(fn -> Embervm.TaskStore.start(state.task_store, task_id) end) do
+      # Task left the queue: release its depth reservation and dedupe slot.
+      release_depth(state, wl, pr)
+
+      state =
+        state
+        |> Map.update!(:queued_ids, &MapSet.delete(&1, task_id))
+        |> inc_inflight(wl, pr)
+        |> tally(mode)
+        |> spawn_assign_worker(task_id, pr, wl, node_id, mode, vm_id, snapshot_ref, entry)
+
+      drain_loop(state, wl, entry)
+    else
+      _ ->
+        # assign/start refused (task not in queued state: a race, or it vanished).
+        # Return the reserved VM to inventory and drop the task from our view;
+        # keep draining the rest.
+        state = return_vm(state, node_id, wl, mode, vm_id)
+        release_depth(state, wl, pr)
+        state = Map.update!(state, :queued_ids, &MapSet.delete(&1, task_id))
+        drain_loop(state, wl, entry)
+    end
+  end
+
+  # -- capacity selection (fail-closed) --------------------------------------
+
+  # Choose a node + path for `wl`, or a denial kind. Prefers a WARM node (one with
+  # a primed VM in inventory) over a MISS (prime-then-assign). Fail-closed:
+  #
+  #   * a node is a candidate only if its facts are FRESH (registry stamped them
+  #     within stale_after_ms), not draining, and it has a READY base for wl;
+  #   * no candidate but some node carries a base for wl that is merely STALE
+  #     -> :stale_capacity (distinct: the registry has not aged it out yet, or is
+  #     wedged, and we must not trust an old fact);
+  #   * otherwise -> :no_capacity (no base for wl anywhere, or every candidate is
+  #     at its node live-VM cap so a miss cannot prime).
+  defp pick_node(state, wl) do
+    now = state.clock.()
+    facts = NodeCapacity.all(state.capacity_table)
+
+    # Nodes that carry a base for this workload at all (fresh or not), used to
+    # distinguish "stale" from "no base anywhere".
+    with_base = Enum.filter(facts, fn f -> Map.has_key?(f.workloads || %{}, wl) end)
+
+    candidates =
+      Enum.filter(with_base, fn f ->
+        not stale?(f, now, state.stale_after_ms) and not f_draining?(f) and base_ready?(f, wl)
+      end)
+
+    cond do
+      candidates == [] and with_base != [] and Enum.any?(with_base, &stale?(&1, now, state.stale_after_ms)) ->
+        {:error, :stale_capacity}
+
+      candidates == [] ->
+        {:error, :no_capacity}
+
+      true ->
+        node_id = fn f -> f.configured_id end
+
+        warm = Enum.find(candidates, fn f -> inventory_ready?(state, node_id.(f), wl) end)
+
+        cond do
+          warm != nil ->
+            {:ok, node_id.(warm), :warm, snapshot_ref_of(warm, wl)}
+
+          true ->
+            # No warm VM anywhere: a miss needs node budget to prime one.
+            case Enum.find(candidates, &has_budget?/1) do
+              nil -> {:error, :no_capacity}
+              f -> {:ok, node_id.(f), :miss, snapshot_ref_of(f, wl)}
+            end
+        end
+    end
+  end
+
+  defp stale?(f, now, stale_after), do: now - (f.updated_at || 0) > stale_after
+  defp f_draining?(f), do: Map.get(f, :draining, false) == true
+
+  defp base_ready?(f, wl) do
+    case Map.get(f.workloads || %{}, wl) do
+      %{base_state: base_state, snapshot_ref: ref} ->
+        base_state_ready?(base_state) and is_binary(ref) and ref != ""
+
+      _ ->
+        false
+    end
+  end
+
+  # The daemon reports base_state as the proto enum. Accept the atom form
+  # (protobuf-elixir default) and the integer form (3) defensively.
+  defp base_state_ready?(:BASE_BUILD_STATE_READY), do: true
+  defp base_state_ready?(3), do: true
+  defp base_state_ready?(_), do: false
+
+  defp snapshot_ref_of(f, wl), do: get_in(f.workloads, [wl, :snapshot_ref])
+
+  defp has_budget?(f) do
+    live = Map.get(f, :live_vms, 0)
+    max = Map.get(f, :max_live_vms, 0)
+    max > 0 and live < max
+  end
+
+  defp inventory_ready?(state, node_id, wl) do
+    case Map.get(state.inventory, {node_id, wl}) do
+      nil -> false
+      q -> not :queue.is_empty(q)
+    end
+  end
+
+  # -- VM reservation --------------------------------------------------------
+
+  defp reserve_vm(state, node_id, wl, :warm) do
+    q = Map.get(state.inventory, {node_id, wl}, :queue.new())
+
+    case :queue.out(q) do
+      {{:value, vm_id}, rest} ->
+        {%{state | inventory: Map.put(state.inventory, {node_id, wl}, rest)}, vm_id}
+
+      {:empty, _} ->
+        # pick_node guaranteed non-empty warm inventory just above; if it somehow
+        # emptied, degrade to a miss (nil vm_id, worker will prime).
+        {state, nil}
+    end
+  end
+
+  defp reserve_vm(state, _node_id, _wl, :miss), do: {state, nil}
+
+  # Return an unused reserved VM to the FRONT of inventory (a commit that failed
+  # to assign): it is still primed and pristine, so it stays dispatchable.
+  defp return_vm(state, node_id, wl, :warm, vm_id) when is_binary(vm_id) do
+    q = Map.get(state.inventory, {node_id, wl}, :queue.new())
+    %{state | inventory: Map.put(state.inventory, {node_id, wl}, :queue.in_r(vm_id, q))}
+  end
+
+  defp return_vm(state, _node_id, _wl, _mode, _vm_id), do: state
+
+  # -- assign worker ---------------------------------------------------------
+
+  defp spawn_assign_worker(state, task_id, pr, wl, node_id, mode, vm_id, snapshot_ref, entry) do
+    owner = self()
+    channel_fun = state.channel_fun
+    invalidate_fun = state.invalidate_fun
+    assign_fun = state.assign_fun
+    prime_fun = state.prime_fun
+    get_request_fun = state.get_request_fun
+    wall = state.wall_clock.()
+
+    ctx = %{
+      task_id: task_id,
+      workload: wl,
+      node_id: node_id,
+      mode: mode,
+      vm_id: vm_id,
+      snapshot_ref: snapshot_ref,
+      invoke_path: entry.invoke_path,
+      timeout_ms: entry.timeout_ms,
+      result_max_bytes: entry.result_max_bytes,
+      result_expires_at: wall + entry.result_ttl_ms
+    }
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        outcome =
+          run_assign(ctx, channel_fun, invalidate_fun, assign_fun, prime_fun, get_request_fun)
+
+        send(owner, {:assign_done, self(), outcome})
+      end)
+
+    meta = %{ref: ref, task_id: task_id, workload: wl, principal: pr, node_id: node_id, mode: mode}
+    %{state | workers: Map.put(state.workers, pid, meta)}
+  end
+
+  # The worker body (runs OFF this GenServer). Fetches the guest request from the
+  # op-log, acquires the shared channel, primes on the miss path, Assigns, and
+  # classifies the result into a terminal outcome. Returns a 2- or 3-tuple the
+  # GenServer applies to the FSM.
+  defp run_assign(ctx, channel_fun, invalidate_fun, assign_fun, prime_fun, get_request_fun) do
+    req_env = fetch_request(get_request_fun, ctx.task_id)
+
+    case channel_fun.(ctx.node_id) do
+      {:ok, channel} ->
+        with {:ok, vm_id} <- ensure_vm(ctx, channel, prime_fun) do
+          guest_req = build_guest_request(req_env, ctx.invoke_path)
+
+          assign_req = %AssignRequest{
+            trace: %Trace{workload: ctx.workload, task_id: ctx.task_id},
+            vm_id: vm_id,
+            request: guest_req,
+            timeout_ms: ctx.timeout_ms
+          }
+
+          case assign_fun.(channel, assign_req) do
+            {:ok, %AssignResponse{response: %GuestResponse{} = resp}} ->
+              classify_response(resp, ctx)
+
+            {:error, reason} ->
+              _ = invalidate_fun.(ctx.node_id, channel)
+              classify_error(reason)
+          end
+        else
+          {:error, :prime_failed, reason} ->
+            _ = invalidate_fun.(ctx.node_id, channel)
+            classify_error(reason)
+        end
+
+      {:error, reason} ->
+        {:failed, :transport, {:no_channel, reason}}
+    end
+  end
+
+  defp fetch_request(get_request_fun, task_id) do
+    case safe_call(fn -> get_request_fun.(task_id) end) do
+      {:ok, {:ok, env}} when is_map(env) -> env
+      _ -> %{}
+    end
+  end
+
+  defp ensure_vm(%{mode: :warm, vm_id: vm_id}, _channel, _prime_fun) when is_binary(vm_id) do
+    {:ok, vm_id}
+  end
+
+  defp ensure_vm(%{workload: wl, snapshot_ref: ref} = _ctx, channel, prime_fun) do
+    req = %PrimeRequest{trace: %Trace{workload: wl}, snapshot_ref: ref || ""}
+
+    case prime_fun.(channel, req) do
+      {:ok, %PrimeResponse{vm_id: vm_id}} -> {:ok, vm_id}
+      {:error, reason} -> {:error, :prime_failed, reason}
+    end
+  end
+
+  defp build_guest_request(req_env, invoke_path) do
+    path = Map.get(req_env, "path") || invoke_path
+    headers = Map.get(req_env, "headers") || %{}
+
+    headers =
+      case Map.get(req_env, "content_type") do
+        nil -> headers
+        ct -> Map.put(headers, "content-type", ct)
+      end
+
+    body =
+      case Map.get(req_env, "body_b64") do
+        b64 when is_binary(b64) -> decode_body(b64)
+        _ -> ""
+      end
+
+    %GuestRequest{method: "POST", path: path, headers: headers, body: body}
+  end
+
+  defp decode_body(b64) do
+    case Base.decode64(b64) do
+      {:ok, bin} -> bin
+      :error -> ""
+    end
+  end
+
+  # A well-formed guest HTTP response: 2xx/3xx succeeds (result stored, truncated
+  # to result_max_bytes); a 5xx is a retryable :guest5xx; a 4xx is a permanent
+  # :guest4xx (the request itself is wrong, retrying reproduces it).
+  defp classify_response(%GuestResponse{status_code: code} = resp, ctx) do
+    cond do
+      code >= 500 and code <= 599 ->
+        {:failed, :guest5xx, {:guest_status, code}}
+
+      code >= 400 and code <= 499 ->
+        {:failed, :guest4xx, {:guest_status, code}}
+
+      true ->
+        body = resp.body || ""
+        {stored, truncated?} = truncate(body, ctx.result_max_bytes)
+
+        {:succeeded,
+         %{
+           status_code: code,
+           body: stored,
+           size_bytes: byte_size(body),
+           truncated: truncated?,
+           expires_at: ctx.result_expires_at
+         }}
+    end
+  end
+
+  # A transport/RPC-level failure. DEADLINE_EXCEEDED (the guest did not answer in
+  # time) is :timeout; everything else (UNAVAILABLE, FAILED_PRECONDITION for a
+  # vm that vanished, RESOURCE_EXHAUSTED, a raw Mint error) is :transport, so it
+  # retries onto a freshly primed VM.
+  defp classify_error(%GRPC.RPCError{status: 4}), do: {:failed, :timeout, :deadline_exceeded}
+  defp classify_error(%GRPC.RPCError{} = e), do: {:failed, :transport, {:rpc, e.status}}
+  defp classify_error(reason), do: {:failed, :transport, reason}
+
+  defp truncate(body, max) when byte_size(body) <= max, do: {body, false}
+  defp truncate(body, max) when max <= 0, do: {"", byte_size(body) > 0}
+  defp truncate(body, max), do: {binary_part(body, 0, max), true}
+
+  # -- worker completion -----------------------------------------------------
+
+  # Apply a finished worker's outcome to the FSM, release its in-flight counters,
+  # and drain (its capacity is now free). `flush` demonitors normal completions
+  # so their trailing :DOWN is discarded; an abnormal exit arrives AS the :DOWN,
+  # so there is nothing to flush there.
+  defp finish_worker(state, pid, outcome, flush) do
+    case Map.pop(state.workers, pid) do
+      {nil, _} ->
+        state
+
+      {meta, workers} ->
+        if flush == :flush, do: Process.demonitor(meta.ref, [:flush])
+
+        state = %{state | workers: workers}
+        state = apply_outcome(state, meta, outcome)
+
+        state
+        |> dec_inflight(meta.workload, meta.principal)
+        |> drain_all()
+    end
+  end
+
+  defp apply_outcome(state, meta, {:succeeded, result}) do
+    _ = safe(fn -> Embervm.TaskStore.succeed(state.task_store, meta.task_id, result) end)
+    state
+  end
+
+  defp apply_outcome(state, meta, {:failed, reason, _detail}) do
+    apply_failure(state, meta, reason)
+  end
+
+  defp apply_outcome(state, meta, {:failed, reason}) do
+    apply_failure(state, meta, reason)
+  end
+
+  # Drive the failure through TaskStore's Retry classification. A retryable
+  # failure comes back with a backoff we arm a timer for (this dispatcher owns
+  # retry scheduling); a permanent one is already dead-lettered by TaskStore.
+  defp apply_failure(state, meta, reason) do
+    case safe_call(fn -> Embervm.TaskStore.fail(state.task_store, meta.task_id, reason) end) do
+      {:ok, {:ok, _task, backoff}} -> arm_retry(state, meta.task_id, backoff)
+      _ -> state
+    end
+  end
+
+  defp arm_retry(state, task_id, backoff) do
+    ref = Process.send_after(self(), {:retry_task, task_id}, max(backoff, 0))
+    %{state | retry_timers: Map.put(state.retry_timers, task_id, ref)}
+  end
+
+  # -- backlog sweep ---------------------------------------------------------
+
+  # Reconcile against TaskStore's durable backlog: enqueue any queued task the
+  # in-memory queues do not hold (recovery / dropped push), and immediately retry
+  # any failed_retryable task with no pending retry timer (a node-down reassign,
+  # which produces failed_retryable out of band with no backoff owner). Then drain.
+  defp run_sweep(state) do
+    case safe_call(fn -> Embervm.TaskStore.list_backlog(state.task_store) end) do
+      {:ok, {:ok, backlog}} ->
+        state
+        |> reduce_backlog(backlog)
+        |> drain_all()
+
+      _ ->
+        state
+    end
+  end
+
+  defp reduce_backlog(state, backlog), do: Enum.reduce(backlog, state, &sweep_one/2)
+
+  defp sweep_one(%{state: :queued, task_id: tid, workload: wl, principal: pr}, state) do
+    do_enqueue(state, tid, wl, pr)
+  end
+
+  defp sweep_one(%{state: :failed_retryable, task_id: tid}, state) do
+    if Map.has_key?(state.retry_timers, tid) do
+      state
+    else
+      _ = safe(fn -> Embervm.TaskStore.retry(state.task_store, tid) end)
+      state
+    end
+  end
+
+  defp sweep_one(_other, state), do: state
+
+  defp schedule_sweep(state) do
+    Process.send_after(self(), :sweep, state.sweep_interval_ms)
+    state
+  end
+
+  # -- counters + denials ----------------------------------------------------
+
+  defp inflight_count(map, wl), do: Map.get(map, wl, 0)
+
+  defp inc_inflight(state, wl, pr) do
+    %{
+      state
+      | inflight_wl: Map.update(state.inflight_wl, wl, 1, &(&1 + 1)),
+        inflight_pr: Map.update(state.inflight_pr, {wl, pr}, 1, &(&1 + 1))
+    }
+  end
+
+  defp dec_inflight(state, wl, pr) do
+    %{
+      state
+      | inflight_wl: dec_key(state.inflight_wl, wl),
+        inflight_pr: dec_key(state.inflight_pr, {wl, pr})
+    }
+  end
+
+  defp dec_key(map, key) do
+    case Map.get(map, key, 0) do
+      n when n <= 1 -> Map.delete(map, key)
+      n -> Map.put(map, key, n - 1)
+    end
+  end
+
+  defp bump_denial(state, kind) do
+    %{state | denials: Map.update!(state.denials, kind, &(&1 + 1))}
+  end
+
+  defp tally(state, :warm), do: %{state | warm_hits: state.warm_hits + 1}
+  defp tally(state, :miss), do: %{state | misses: state.misses + 1}
+
+  defp release_depth(state, wl, pr) do
+    :ets.update_counter(state.depth_table, {wl, pr}, {2, -1, 0, 0}, {{wl, pr}, 0})
+    state
+  end
+
+  # -- share cap -------------------------------------------------------------
+
+  # A principal's max in-flight share of the workload cap. A configured fraction
+  # (values-driven) if set, else cap split evenly across the currently-active
+  # principals (those with a queued or in-flight task), min 1 so a single
+  # principal is never starved to zero.
+  defp share_cap(state, wl, entry) do
+    case state.share_fraction do
+      f when is_number(f) and f > 0 ->
+        max(1, trunc(entry.cap * f))
+
+      _ ->
+        active = active_principals(state, wl)
+        max(1, div(entry.cap, max(active, 1)))
+    end
+  end
+
+  defp active_principals(state, wl) do
+    queued = state.queues |> Map.get(wl, new_fq()) |> fq_principals()
+
+    inflight =
+      state.inflight_pr
+      |> Map.keys()
+      |> Enum.filter(fn {w, _p} -> w == wl end)
+      |> Enum.map(fn {_w, p} -> p end)
+
+    (queued ++ inflight) |> MapSet.new() |> MapSet.size()
+  end
+
+  # -- fair queue (per workload) ---------------------------------------------
+  #
+  # rotation: a :queue of principals in round-robin order (each appears at most
+  #   once, only while its FIFO is non-empty).
+  # members:  the MapSet of principals currently in rotation (dedupe guard).
+  # fifos:    principal -> :queue of task_id (FIFO within a principal).
+
+  defp new_fq, do: %{rotation: :queue.new(), members: MapSet.new(), fifos: %{}}
+
+  defp fq_enqueue(fq, pr, task_id) do
+    fifo = Map.get(fq.fifos, pr, :queue.new())
+    fifos = Map.put(fq.fifos, pr, :queue.in(task_id, fifo))
+
+    if MapSet.member?(fq.members, pr) do
+      %{fq | fifos: fifos}
+    else
+      %{fq | fifos: fifos, rotation: :queue.in(pr, fq.rotation), members: MapSet.put(fq.members, pr)}
+    end
+  end
+
+  defp fq_principals(fq), do: MapSet.to_list(fq.members)
+
+  defp fq_empty_q?(fq), do: MapSet.size(fq.members) == 0
+
+  defp fq_empty?(queues, wl) do
+    case Map.get(queues, wl) do
+      nil -> true
+      fq -> fq_empty_q?(fq)
+    end
+  end
+
+  # Pop the next task in round-robin-across-principals / FIFO-within order,
+  # skipping principals already at their in-flight share. Walks at most one full
+  # rotation; returns {:none, fq} when nothing is servable (empty, or all
+  # remaining principals are share-capped), rotating skipped principals to the
+  # back so order is preserved.
+  defp fq_take(nil, _wl, _share, _inflight_pr), do: {:none, new_fq()}
+
+  defp fq_take(fq, wl, share, inflight_pr) do
+    fq_take(fq, wl, share, inflight_pr, MapSet.size(fq.members))
+  end
+
+  defp fq_take(fq, _wl, _share, _inflight_pr, 0), do: {:none, fq}
+
+  defp fq_take(fq, wl, share, inflight_pr, remaining) do
+    case :queue.out(fq.rotation) do
+      {:empty, _} ->
+        {:none, fq}
+
+      {{:value, pr}, rot} ->
+        pr_inflight = Map.get(inflight_pr, {wl, pr}, 0)
+        fifo = Map.get(fq.fifos, pr, :queue.new())
+
+        cond do
+          pr_inflight >= share ->
+            # Over its share: rotate to the back, try the next principal.
+            fq_take(%{fq | rotation: :queue.in(pr, rot)}, wl, share, inflight_pr, remaining - 1)
+
+          :queue.is_empty(fifo) ->
+            # Shouldn't happen (members implies non-empty), but drop it defensively.
+            fq_take(
+              %{fq | rotation: rot, members: MapSet.delete(fq.members, pr), fifos: Map.delete(fq.fifos, pr)},
+              wl,
+              share,
+              inflight_pr,
+              remaining - 1
+            )
+
+          true ->
+            {{:value, task_id}, fifo2} = :queue.out(fifo)
+
+            if :queue.is_empty(fifo2) do
+              {:ok, task_id, pr,
+               %{fq | rotation: rot, members: MapSet.delete(fq.members, pr), fifos: Map.delete(fq.fifos, pr)}}
+            else
+              # Still has tasks: rotate this principal to the back (round-robin).
+              {:ok, task_id, pr,
+               %{fq | rotation: :queue.in(pr, rot), fifos: Map.put(fq.fifos, pr, fifo2)}}
+            end
+        end
+    end
+  end
+
+  # -- misc ------------------------------------------------------------------
+
+  defp snapshot(state) do
+    %{
+      denials: state.denials,
+      warm_hits: state.warm_hits,
+      misses: state.misses,
+      inflight_wl: state.inflight_wl,
+      inflight_pr: state.inflight_pr,
+      queued: MapSet.size(state.queued_ids),
+      queue_depth:
+        for(wl <- Map.keys(state.queues), into: %{}, do: {wl, fq_depth(Map.get(state.queues, wl))}),
+      inventory: for({k, q} <- state.inventory, into: %{}, do: {k, :queue.len(q)}),
+      workers: map_size(state.workers)
+    }
+  end
+
+  defp fq_depth(fq) do
+    Enum.reduce(fq.fifos, 0, fn {_p, q}, acc -> acc + :queue.len(q) end)
+  end
+
+  defp create_depth_table(table) do
+    if :ets.whereis(table) == :undefined do
+      :ets.new(table, [:set, :public, :named_table, write_concurrency: true])
+    end
+  end
+
+  # Wrap a TaskStore/op-log call so a rare exception (a store mid-restart) never
+  # crashes the dispatcher; returns {:ok, result} or :error.
+  defp safe_call(fun) do
+    try do
+      {:ok, fun.()}
+    rescue
+      _ -> :error
+    catch
+      _, _ -> :error
+    end
+  end
+
+  defp safe(fun) do
+    try do
+      fun.()
+    rescue
+      _ -> :error
+    catch
+      _, _ -> :error
+    end
+  end
+
+  defp default_mono, do: System.monotonic_time(:millisecond)
+  defp default_wall, do: System.system_time(:millisecond)
+
+  defp default_assign(channel, %AssignRequest{} = req) do
+    Embervm.Node.V1.NodeService.Stub.assign(channel, req)
+  end
+
+  defp default_prime(channel, %PrimeRequest{} = req) do
+    Embervm.Node.V1.NodeService.Stub.prime(channel, req)
+  end
+end

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -70,10 +70,16 @@ defmodule Embervm.Dispatcher do
     * PUSH: `Embervm.TaskStore`'s `on_queued` hook casts `enqueue/1` on every
       transition INTO `queued` (submit-created, retry, redrive).
     * SWEEP: a boot + periodic reconcile over `TaskStore.list_backlog/1` re-drives
-      what a dropped push signal missed (a control-plane restart empties the
-      in-memory queues; `reassign_in_flight/0` on a downed node produces
-      `failed_retryable` out of band). Reassigned tasks retry immediately;
-      organic retryable failures wait the backoff `fail/2` returned.
+      what the push path cannot. A dropped `enqueue` cast or a restart that
+      empties the in-memory queues is re-enqueued; `reassign_in_flight/0` on a
+      downed node produces `failed_retryable` out of band and is retried. And an
+      in-flight (`assigned`/`running`) task with NO live worker tracking it is an
+      ORPHAN, a dispatcher restart dropped its workers, a partial assign/start
+      commit spawned none, or a completion's terminal op-log append failed, so it
+      is reclaimed by failing it as transport (at-least-once, through Retry). A
+      task a live worker still owns is skipped, so a running task is never
+      double-dispatched. This is what makes "no task lost" hold across restarts
+      and partial commits, not just across dropped push signals.
 
   ## deferred, on purpose
 
@@ -746,15 +752,24 @@ defmodule Embervm.Dispatcher do
 
   # -- backlog sweep ---------------------------------------------------------
 
-  # Reconcile against TaskStore's durable backlog: enqueue any queued task the
-  # in-memory queues do not hold (recovery / dropped push), and immediately retry
-  # any failed_retryable task with no pending retry timer (a node-down reassign,
-  # which produces failed_retryable out of band with no backoff owner). Then drain.
+  # Reconcile against TaskStore's durable backlog:
+  #   * queued -> enqueue any the in-memory queues do not hold (recovery / a
+  #     dropped push cast);
+  #   * failed_retryable with no pending retry timer -> retry now (a node-down
+  #     reassign produces these out of band with no backoff owner);
+  #   * assigned/running with NO live worker -> an ORPHAN (a dispatcher restart
+  #     dropped its workers, a partial assign/start commit spawned none, or a
+  #     completion's terminal op-log append failed): fail it as transport so it
+  #     re-queues through Retry (at-least-once). A task a live worker still owns
+  #     is skipped, so a genuinely-running task is never double-dispatched.
+  # Then drain.
   defp run_sweep(state) do
     case safe_call(fn -> Embervm.TaskStore.list_backlog(state.task_store) end) do
       {:ok, {:ok, backlog}} ->
+        tracked = state.workers |> Map.values() |> MapSet.new(& &1.task_id)
+
         state
-        |> reduce_backlog(backlog)
+        |> reduce_backlog(backlog, tracked)
         |> drain_all()
 
       _ ->
@@ -762,13 +777,15 @@ defmodule Embervm.Dispatcher do
     end
   end
 
-  defp reduce_backlog(state, backlog), do: Enum.reduce(backlog, state, &sweep_one/2)
+  defp reduce_backlog(state, backlog, tracked) do
+    Enum.reduce(backlog, state, fn item, acc -> sweep_one(item, acc, tracked) end)
+  end
 
-  defp sweep_one(%{state: :queued, task_id: tid, workload: wl, principal: pr}, state) do
+  defp sweep_one(%{state: :queued, task_id: tid, workload: wl, principal: pr}, state, _tracked) do
     do_enqueue(state, tid, wl, pr)
   end
 
-  defp sweep_one(%{state: :failed_retryable, task_id: tid}, state) do
+  defp sweep_one(%{state: :failed_retryable, task_id: tid}, state, _tracked) do
     if Map.has_key?(state.retry_timers, tid) do
       state
     else
@@ -777,7 +794,21 @@ defmodule Embervm.Dispatcher do
     end
   end
 
-  defp sweep_one(_other, state), do: state
+  defp sweep_one(%{state: inflight, task_id: tid}, state, tracked)
+       when inflight in [:assigned, :running] do
+    if MapSet.member?(tracked, tid) do
+      state
+    else
+      # Orphan reclaim: fail as transport, then (if retryable) arm the backoff
+      # timer exactly as the live-failure path does, so it re-queues on its own.
+      case safe_call(fn -> Embervm.TaskStore.fail(state.task_store, tid, :transport) end) do
+        {:ok, {:ok, _task, backoff}} -> arm_retry(state, tid, backoff)
+        _ -> state
+      end
+    end
+  end
+
+  defp sweep_one(_other, state, _tracked), do: state
 
   defp schedule_sweep(state) do
     Process.send_after(self(), :sweep, state.sweep_interval_ms)

--- a/projects/embervm/control/lib/embervm/node_channel.ex
+++ b/projects/embervm/control/lib/embervm/node_channel.ex
@@ -1,0 +1,185 @@
+defmodule Embervm.NodeChannel do
+  @moduledoc """
+  A persistent, reused gRPC channel per node daemon, for the dispatch HOT path.
+
+  `Embervm.BaseBuilder` and `Embervm.NodeRegistry` each open their OWN channel
+  and can afford to: a base build is rare and a WatchNode stream is long-lived,
+  so a per-operation connect amortizes to nothing. `Prime` and especially
+  `Assign` are different: the warm-dispatch latency budget is p95 <= 25ms
+  submit-to-Assign, and a fresh h2c connect + HTTP/2 handshake per assign would
+  blow it on its own. So the pool and dispatcher share ONE long-lived channel
+  per node, opened once and reused across every Prime/Assign/Destroy, with
+  HTTP/2 stream multiplexing carrying concurrent RPCs over the single
+  connection.
+
+  ## why persistent_term, not a GenServer.call per fetch
+
+  The channel handle changes only on a (re)dial, which is rare; it is read on
+  every single dispatch, which is the hottest path in the system. That read:mostly
+  -never-write ratio is exactly what `:persistent_term` is for: a worker reads its
+  node's channel lock-free with no message round-trip, and the only writes (a dial
+  or an invalidation) go through this GenServer and are infrequent enough that the
+  global GC cost persistent_term imposes per write is irrelevant. A `GenServer.call`
+  per fetch would serialize every concurrent assign worker through one process,
+  reintroducing exactly the head-of-line coupling the channel pool exists to avoid.
+
+  ## lazy dial, invalidate-on-failure
+
+  Channels are dialed lazily on first `get/1` and cached. There is no proactive
+  liveness monitor of the (adapter-internal) connection process; instead a worker
+  that sees a TRANSPORT error on an RPC calls `invalidate/2`, which drops the dead
+  channel so the next `get/1` re-dials. Invalidation is identity-guarded: it only
+  clears the cache if the failing channel is still the current one, so a worker
+  racing a fresh reconnect cannot tear down the newly dialed channel. Dials are
+  serialized through this GenServer, so a thundering herd of first-dispatch workers
+  triggers exactly one connect (the rest read the freshly cached channel).
+
+  R0 note: `EMBERVM_NODED_IMAGES` is empty, so no real Prime/Assign succeeds yet
+  (there is no base to restore); this channel is exercised end to end only once
+  guest-image provisioning lands (Task 14+). Until then it dials, caches, and
+  serves the health-gated daemon connection without carrying real task traffic.
+  """
+
+  use GenServer
+  require Logger
+
+  # -- Client API ------------------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc """
+  The current channel for `node_id`, dialing and caching it on first use. Reads
+  `:persistent_term` lock-free on the fast path; falls through to a serialized
+  dial only when no channel is cached (first use or just-invalidated). Returns
+  `{:error, :unknown_node}` for a node this holder was not configured with.
+  """
+  @spec get(GenServer.server(), String.t()) :: {:ok, term()} | {:error, term()}
+  def get(server \\ __MODULE__, node_id) do
+    case :persistent_term.get(pt_key(node_id), :undefined) do
+      :undefined -> GenServer.call(server, {:dial, node_id})
+      channel -> {:ok, channel}
+    end
+  end
+
+  @doc """
+  Drop `node_id`'s cached channel if it is still `channel` (a worker observed a
+  transport error on it), so the next `get/1` re-dials. Identity-guarded so a
+  late invalidation cannot clobber a channel a concurrent reconnect already
+  replaced. A cast: the reporting worker never blocks on teardown.
+  """
+  @spec invalidate(GenServer.server(), String.t(), term()) :: :ok
+  def invalidate(server \\ __MODULE__, node_id, channel) do
+    GenServer.cast(server, {:invalidate, node_id, channel})
+  end
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    nodes = Keyword.get(opts, :nodes, [])
+    connect_fun = Keyword.get(opts, :connect_fun, &default_connect/1)
+    disconnect_fun = Keyword.get(opts, :disconnect_fun, &default_disconnect/1)
+
+    node_addr = for %{id: id, address: address} <- nodes, into: %{}, do: {id, address}
+
+    {:ok, %{node_addr: node_addr, connect_fun: connect_fun, disconnect_fun: disconnect_fun}}
+  end
+
+  @impl true
+  def handle_call({:dial, node_id}, _from, state) do
+    # Re-check the cache inside the serialized call: a herd of first-dispatch
+    # workers all miss persistent_term and land here; the first dials, the rest
+    # must see the now-cached channel rather than each opening another.
+    case :persistent_term.get(pt_key(node_id), :undefined) do
+      :undefined -> {:reply, do_dial(state, node_id), state}
+      channel -> {:reply, {:ok, channel}, state}
+    end
+  end
+
+  @impl true
+  def handle_cast({:invalidate, node_id, channel}, state) do
+    case :persistent_term.get(pt_key(node_id), :undefined) do
+      ^channel ->
+        :persistent_term.erase(pt_key(node_id))
+        safe_disconnect(state, channel)
+
+      _ ->
+        # Already replaced (or never cached): the failing channel is stale, so
+        # there is nothing of ours to tear down.
+        :ok
+    end
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    # Drop every cached channel so a restart re-dials cleanly and no channel
+    # outlives this holder in persistent_term.
+    for {node_id, _addr} <- state.node_addr do
+      case :persistent_term.get(pt_key(node_id), :undefined) do
+        :undefined ->
+          :ok
+
+        channel ->
+          :persistent_term.erase(pt_key(node_id))
+          safe_disconnect(state, channel)
+      end
+    end
+
+    :ok
+  end
+
+  # -- internals -------------------------------------------------------------
+
+  defp do_dial(state, node_id) do
+    case Map.get(state.node_addr, node_id) do
+      nil ->
+        {:error, :unknown_node}
+
+      address ->
+        case state.connect_fun.(address) do
+          {:ok, channel} ->
+            :persistent_term.put(pt_key(node_id), channel)
+            {:ok, channel}
+
+          {:error, reason} ->
+            Logger.warning("embervm node channel: dial to #{node_id} (#{address}) failed: #{inspect(reason)}")
+            {:error, reason}
+        end
+    end
+  end
+
+  defp safe_disconnect(state, channel) do
+    try do
+      state.disconnect_fun.(channel)
+    rescue
+      _ -> :ok
+    catch
+      _, _ -> :ok
+    end
+
+    :ok
+  end
+
+  defp pt_key(node_id), do: {__MODULE__, node_id}
+
+  # Plaintext h2c over the Mint adapter, the pattern NodeRegistry/BaseBuilder use.
+  # Auth is deferred in R0 (noded runs open; mesh policy is the layer), so no
+  # bearer-token metadata is attached here; enabling it later is an additive
+  # change to the per-RPC metadata, not to this dial.
+  defp default_connect(address) do
+    GRPC.Stub.connect(address, adapter: GRPC.Client.Adapters.Mint)
+  end
+
+  defp default_disconnect(channel) do
+    _ = GRPC.Stub.disconnect(channel)
+    :ok
+  end
+end

--- a/projects/embervm/control/lib/embervm/op_log.ex
+++ b/projects/embervm/control/lib/embervm/op_log.ex
@@ -83,6 +83,15 @@ defmodule Embervm.OpLog do
   # way (streamed straight through at request time, never via this store).
   @callback load_result(server(), task_id :: String.t()) ::
               {:ok, map() | nil} | {:error, term()}
+  # Reads the opaque guest-request envelope captured in a task's `submitted`
+  # op payload (path, headers, base64 body, content type), or {:ok, nil} when
+  # the task has no submitted op (unknown id). Unlike load_result/2 this reads
+  # the immutable `ops` log (the submitted record is never projected into a
+  # column), which is exactly why the dispatcher (Task 11) needs a dedicated
+  # read: it rebuilds the `AssignRequest` from this at dispatch time rather
+  # than carrying the (up to 8 MiB) body in the ETS hot set or the fair queue.
+  @callback load_request(server(), task_id :: String.t()) ::
+              {:ok, map() | nil} | {:error, term()}
   @callback compact(server(), now_ms :: integer()) ::
               {:ok, %{results_deleted: non_neg_integer(), tasks_compacted: non_neg_integer()}}
               | {:error, term()}

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -109,6 +109,11 @@ defmodule Embervm.OpLog.SQLite do
   end
 
   @impl Embervm.OpLog
+  def load_request(server \\ __MODULE__, task_id) do
+    GenServer.call(server, {:load_request, task_id})
+  end
+
+  @impl Embervm.OpLog
   def compact(server \\ __MODULE__, now_ms) do
     GenServer.call(server, {:compact, now_ms})
   end
@@ -154,6 +159,10 @@ defmodule Embervm.OpLog.SQLite do
 
   def handle_call({:load_result, task_id}, _from, state) do
     {:reply, do_load_result(state.conn, task_id), state}
+  end
+
+  def handle_call({:load_request, task_id}, _from, state) do
+    {:reply, do_load_request(state.conn, task_id), state}
   end
 
   def handle_call({:compact, now_ms}, _from, state) do
@@ -419,6 +428,38 @@ defmodule Embervm.OpLog.SQLite do
                created_at: created_at,
                expires_at: expires_at
              }}
+
+          :done ->
+            {:ok, nil}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+
+      :ok = Sqlite3.release(conn, stmt)
+      result
+    end
+  end
+
+  # Reads the guest-request envelope from a task's `submitted` op. The request
+  # lives only in the immutable ops log (payload_json), never a projected
+  # column, so this selects the earliest submitted op for the task (the
+  # ops_task_id_idx index makes it cheap) and pulls the `request` member out of
+  # the decoded payload. Keys come back as strings (:json.decode never restores
+  # atoms), which the dispatcher expects. {:ok, nil} for an unknown task or a
+  # submitted op that carried no request (an older record).
+  defp do_load_request(conn, task_id) do
+    sql = """
+    SELECT payload_json FROM ops
+    WHERE task_id=? AND kind='submitted' ORDER BY seq ASC LIMIT 1
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [task_id]) do
+      result =
+        case Sqlite3.step(conn, stmt) do
+          {:row, [payload_json]} ->
+            {:ok, Map.get(decode_payload(payload_json), "request")}
 
           :done ->
             {:ok, nil}

--- a/projects/embervm/control/lib/embervm/pool_manager.ex
+++ b/projects/embervm/control/lib/embervm/pool_manager.ex
@@ -1,0 +1,469 @@
+defmodule Embervm.PoolManager do
+  @moduledoc """
+  Keeps the primed-VM pool refilled so the dispatcher has a warm VM to Assign.
+  Where `Embervm.Dispatcher` owns the hot path (pop a VM, Assign it), this owns
+  the slow background loop that Primes VMs to replace the ones assignment
+  destroys, so the two are separate failure domains and the refill loop never
+  slows a dispatch decision.
+
+  ## the refill policy (floor-first, then proportional)
+
+  On each tick, for every FRESH, non-draining node with a ready base for a
+  workload, it computes how many more VMs to Prime and allocates the node's
+  remaining live-VM budget in two phases:
+
+    1. FLOOR first: bring every workload up to its `concurrency.floor` of primed
+       VMs. Under a scarce budget the floor deficits are filled round-robin, one
+       VM at a time across workloads, so no single workload's floor monopolizes
+       the budget.
+    2. SURPLUS next: whatever budget remains is split proportional to each
+       workload's current queue depth, priming beyond the floor for the workloads
+       under load, each capped at its own depth (no point priming more VMs than
+       there are queued tasks).
+
+  Because phase 1 (all floors) completes before phase 2 (any surplus), one
+  workload's burst can NEVER consume the budget another workload's floor needs:
+  the surplus phase only ever spends what is left after every floor is funded.
+  That is the floor-isolation property the acceptance test asserts.
+
+  ## backpressure
+
+  Primes are heavy (restore + health-gate), so concurrent primes are capped
+  (`max_concurrent_primes`) and every in-flight prime counts against both the cap
+  and the node budget, so a slow daemon does not get a growing pile of concurrent
+  restores. `free_primed_slots` from the daemon's own heartbeat is the authority
+  for "how many are already parked"; in-flight primes this loop has issued but the
+  daemon has not yet reported are added so a burst of ticks does not over-prime.
+
+  ## destroy-on-assign
+
+  The daemon destroys a VM on Assign (single-use), which drops `free_primed_slots`
+  and is reflected on the next heartbeat; the loop then re-primes toward the
+  floor. The DISPATCH-side accounting (a vm_id leaves the dispatcher's inventory
+  the instant it is committed) is what prevents double-assign; this loop only
+  needs the heartbeat count to know how many to replace.
+
+  ## status.primedFloorSatisfied
+
+  This loop owns `status.primedFloorSatisfied`: it is true for a workload once the
+  node's `free_primed_slots >= floor`. Ownership is split by key exactly like the
+  BaseBuilder/watcher split: the watcher writes `observedGeneration`, the
+  BaseBuilder writes `conditions`/`snapshotRef`/`snapshotDigest`, and this writes
+  only `primedFloorSatisfied`, so the three merge-patches never clobber. Status is
+  written only when the flag flips, not every tick.
+
+  ## deferred
+
+  Base turnover on a digest change (proactively Destroy old-base primed VMs and
+  re-prime from the new base, per the BaseBuilder's `superseded_refs` seam) is a
+  documented follow-on: the node contract reports a slot COUNT, not per-VM base
+  identity, so the control plane cannot today target the old-base VMs specifically.
+  R0 primes zero VMs (empty `EMBERVM_NODED_IMAGES`), so there is nothing to turn
+  over yet; when guest images land (Task 14) the turnover either drains via natural
+  assignment or gains a per-VM base tag on the node contract.
+  """
+
+  use GenServer
+  require Logger
+
+  alias Embervm.{NodeCapacity, WorkloadCatalog}
+  alias Embervm.Node.V1.{PrimeRequest, PrimeResponse, Trace}
+
+  @refill_interval_ms 1_000
+  @max_concurrent_primes 4
+  @stale_after_ms 15_000
+  @depth_table :embervm_queue_depth
+
+  # -- Client API ------------------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc """
+  Runs one refill pass synchronously (the same code the periodic tick runs) and
+  returns after the Prime workers it decides on are spawned. Tests drive refill
+  deterministically through this with `start_refill: false`; production fires it
+  on the timer every #{@refill_interval_ms}ms.
+  """
+  @spec refill(GenServer.server()) :: :ok
+  def refill(server \\ __MODULE__) do
+    GenServer.call(server, :refill)
+  end
+
+  @doc "A snapshot of in-flight primes and floor-satisfaction, for tests/ops."
+  @spec stats(GenServer.server()) :: map()
+  def stats(server \\ __MODULE__) do
+    GenServer.call(server, :stats)
+  end
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    state = %{
+      capacity_table: Keyword.get(opts, :capacity_table, NodeCapacity.table()),
+      catalog_table: Keyword.get(opts, :catalog_table, WorkloadCatalog.table()),
+      depth_table: Keyword.get(opts, :depth_table, @depth_table),
+      dispatcher: Keyword.get(opts, :dispatcher, Embervm.Dispatcher),
+      clock: Keyword.get(opts, :clock, &default_mono/0),
+      channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
+      prime_fun: Keyword.get(opts, :prime_fun, &default_prime/2),
+      deposit_fun: Keyword.get(opts, :deposit_fun, &Embervm.Dispatcher.deposit/4),
+      status_writer: Keyword.get(opts, :status_writer, &Embervm.K8s.patch_workload_status/3),
+      refill_interval_ms: Keyword.get(opts, :refill_interval_ms, @refill_interval_ms),
+      max_concurrent_primes: Keyword.get(opts, :max_concurrent_primes, @max_concurrent_primes),
+      stale_after_ms: Keyword.get(opts, :stale_after_ms, @stale_after_ms),
+      # Dynamic.
+      inflight_primes: %{},
+      prime_workers: %{},
+      floor_satisfied: %{}
+    }
+
+    if Keyword.get(opts, :start_refill, true) do
+      schedule_refill(state)
+    end
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:refill, _from, state), do: {:reply, :ok, do_refill(state)}
+
+  def handle_call(:stats, _from, state) do
+    {:reply,
+     %{
+       inflight_primes: state.inflight_primes,
+       floor_satisfied: state.floor_satisfied,
+       prime_workers: map_size(state.prime_workers)
+     }, state}
+  end
+
+  @impl true
+  def handle_info(:refill, state) do
+    state = do_refill(state)
+    schedule_refill(state)
+    {:noreply, state}
+  end
+
+  # A prime worker reported. On success, deposit the vm_id into the dispatcher's
+  # inventory; either way release its in-flight-prime slot.
+  def handle_info({:prime_result, pid, node_id, wl, result}, state) do
+    case Map.pop(state.prime_workers, pid) do
+      {nil, _} ->
+        {:noreply, state}
+
+      {meta, workers} ->
+        Process.demonitor(meta.ref, [:flush])
+
+        case result do
+          {:ok, %PrimeResponse{vm_id: vm_id}} when is_binary(vm_id) and vm_id != "" ->
+            _ = safe(fn -> state.deposit_fun.(state.dispatcher, node_id, wl, vm_id) end)
+
+          {:error, reason} ->
+            Logger.warning("embervm pool: Prime for #{wl} on #{node_id} failed: #{inspect(reason)}")
+
+          _ ->
+            :ok
+        end
+
+        {:noreply, %{state | prime_workers: workers} |> dec_prime(node_id, wl)}
+    end
+  end
+
+  # A prime worker died without reporting: release its slot (it always sends a
+  # result in the normal path, so this is an abnormal exit).
+  def handle_info({:DOWN, _ref, :process, pid, reason}, state) do
+    case Map.pop(state.prime_workers, pid) do
+      {nil, _} ->
+        {:noreply, state}
+
+      {meta, workers} ->
+        Logger.warning("embervm pool: prime worker for #{meta.workload} died: #{inspect(reason)}")
+        {:noreply, %{state | prime_workers: workers} |> dec_prime(meta.node_id, meta.workload)}
+    end
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, state) do
+    for {pid, _meta} <- state.prime_workers, do: Process.exit(pid, :shutdown)
+    :ok
+  end
+
+  # -- refill ----------------------------------------------------------------
+
+  defp do_refill(state) do
+    now = state.clock.()
+
+    NodeCapacity.all(state.capacity_table)
+    |> Enum.filter(fn f -> not stale?(f, now, state.stale_after_ms) and not draining?(f) end)
+    |> Enum.reduce(state, fn facts, acc -> refill_node(acc, facts) end)
+  end
+
+  defp refill_node(state, facts) do
+    node_id = facts.configured_id
+    workloads = ready_workloads(state, facts)
+
+    # Node live-VM budget minus what this loop already has in flight for the node.
+    node_inflight = node_inflight_primes(state, node_id)
+    budget = max(0, Map.get(facts, :max_live_vms, 0) - Map.get(facts, :live_vms, 0) - node_inflight)
+
+    # And the global concurrency cap on primes.
+    global_room = max(0, state.max_concurrent_primes - map_size(state.prime_workers))
+    budget = min(budget, global_room)
+
+    state = update_floor_status(state, facts, workloads)
+
+    if budget <= 0 or workloads == [] do
+      state
+    else
+      allocation = plan_primes(state, facts, workloads, budget)
+      spawn_primes(state, node_id, allocation)
+    end
+  end
+
+  # Workloads this node has a ready base for, paired with their catalog entry
+  # (floor, namespace, name) and the node's current free primed slots.
+  defp ready_workloads(state, facts) do
+    for {wl, wc} <- facts.workloads || %{},
+        base_ready?(wc),
+        {:ok, entry} <- [WorkloadCatalog.fetch(state.catalog_table, wl)] do
+      %{
+        workload: wl,
+        namespace: entry.namespace,
+        floor: entry.floor,
+        snapshot_ref: Map.get(wc, :snapshot_ref),
+        free: Map.get(wc, :free_primed_slots, 0)
+      }
+    end
+  end
+
+  # Decide how many VMs to prime per workload within `budget`: floors first
+  # (round-robin fair under scarcity), then surplus proportional to queue depth.
+  defp plan_primes(state, facts, workloads, budget) do
+    node_id = facts.configured_id
+
+    floor_deficits =
+      for w <- workloads, into: %{} do
+        have = w.free + inflight_for(state, node_id, w.workload)
+        {w.workload, max(0, w.floor - have)}
+      end
+
+    floor_alloc = allocate_round_robin(floor_deficits, budget)
+    remaining = budget - map_sum(floor_alloc)
+
+    depths =
+      for w <- workloads, into: %{} do
+        {w.workload, queue_depth(state, w.workload)}
+      end
+
+    surplus_alloc = allocate_proportional(depths, remaining)
+
+    for w <- workloads,
+        n = Map.get(floor_alloc, w.workload, 0) + Map.get(surplus_alloc, w.workload, 0),
+        n > 0 do
+      %{workload: w.workload, snapshot_ref: w.snapshot_ref, count: n}
+    end
+  end
+
+  defp spawn_primes(state, node_id, allocation) do
+    Enum.reduce(allocation, state, fn %{workload: wl, snapshot_ref: ref, count: n}, acc ->
+      Enum.reduce(1..n//1, acc, fn _i, acc2 -> start_prime_worker(acc2, node_id, wl, ref) end)
+    end)
+  end
+
+  defp start_prime_worker(state, node_id, wl, snapshot_ref) do
+    owner = self()
+    channel_fun = state.channel_fun
+    prime_fun = state.prime_fun
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        result =
+          case channel_fun.(node_id) do
+            {:ok, channel} ->
+              req = %PrimeRequest{trace: %Trace{workload: wl}, snapshot_ref: snapshot_ref || ""}
+
+              try do
+                prime_fun.(channel, req)
+              catch
+                kind, reason -> {:error, {kind, reason}}
+              end
+
+            {:error, reason} ->
+              {:error, {:connect, reason}}
+          end
+
+        send(owner, {:prime_result, self(), node_id, wl, result})
+      end)
+
+    meta = %{ref: ref, node_id: node_id, workload: wl}
+
+    %{state | prime_workers: Map.put(state.prime_workers, pid, meta)}
+    |> inc_prime(node_id, wl)
+  end
+
+  # -- primedFloorSatisfied status -------------------------------------------
+
+  defp update_floor_status(state, _facts, workloads) do
+    Enum.reduce(workloads, state, fn w, acc ->
+      satisfied = w.free >= w.floor
+
+      if Map.get(acc.floor_satisfied, w.workload) == satisfied do
+        acc
+      else
+        _ = safe(fn -> write_floor_status(acc, w.namespace, w.workload, satisfied) end)
+        %{acc | floor_satisfied: Map.put(acc.floor_satisfied, w.workload, satisfied)}
+      end
+    end)
+  end
+
+  defp write_floor_status(state, namespace, name, satisfied) do
+    case state.status_writer.(namespace, name, %{"primedFloorSatisfied" => satisfied}) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "embervm pool: primedFloorSatisfied patch failed for #{namespace}/#{name}: #{inspect(reason)}"
+        )
+    end
+  end
+
+  # -- allocators ------------------------------------------------------------
+
+  # Distribute `budget` units across the demands one at a time, round-robin, so no
+  # demand is filled at another's expense under scarcity. Returns wl -> count.
+  defp allocate_round_robin(demands, budget) do
+    keys = demands |> Enum.filter(fn {_k, v} -> v > 0 end) |> Enum.map(&elem(&1, 0))
+    do_round_robin(keys, demands, budget, Map.new(keys, &{&1, 0}))
+  end
+
+  defp do_round_robin([], _demands, _budget, acc), do: acc
+  defp do_round_robin(_keys, _demands, 0, acc), do: acc
+
+  defp do_round_robin(keys, demands, budget, acc) do
+    {acc, budget, granted} =
+      Enum.reduce(keys, {acc, budget, false}, fn k, {acc, budget, granted} ->
+        cond do
+          budget <= 0 -> {acc, budget, granted}
+          Map.get(acc, k) >= Map.get(demands, k) -> {acc, budget, granted}
+          true -> {Map.update!(acc, k, &(&1 + 1)), budget - 1, true}
+        end
+      end)
+
+    # Stop when a full pass grants nothing (every demand met) or budget is gone.
+    if granted and budget > 0, do: do_round_robin(keys, demands, budget, acc), else: acc
+  end
+
+  # Split `budget` proportional to weights, each capped at its own weight (never
+  # prime more than there are queued tasks). Largest-remainder rounding, then any
+  # leftover from caps is redistributed round-robin.
+  defp allocate_proportional(_weights, budget) when budget <= 0, do: %{}
+
+  defp allocate_proportional(weights, budget) do
+    positive = Enum.filter(weights, fn {_k, w} -> w > 0 end)
+    total = positive |> Enum.map(&elem(&1, 1)) |> Enum.sum()
+
+    if total == 0 do
+      %{}
+    else
+      base =
+        for {k, w} <- positive, into: %{} do
+          share = min(w, div(budget * w, total))
+          {k, share}
+        end
+
+      leftover = budget - map_sum(base)
+      demands = Map.new(positive)
+
+      # Redistribute rounding/cap leftover round-robin, respecting each cap.
+      residual_demands =
+        for {k, w} <- positive, into: %{}, do: {k, w - Map.get(base, k, 0)}
+
+      extra = allocate_round_robin(residual_demands, leftover)
+      Map.merge(base, extra, fn _k, a, b -> a + b end) |> Map.take(Map.keys(demands))
+    end
+  end
+
+  # -- in-flight prime accounting --------------------------------------------
+
+  defp inc_prime(state, node_id, wl) do
+    %{state | inflight_primes: Map.update(state.inflight_primes, {node_id, wl}, 1, &(&1 + 1))}
+  end
+
+  defp dec_prime(state, node_id, wl) do
+    key = {node_id, wl}
+
+    case Map.get(state.inflight_primes, key, 0) do
+      n when n <= 1 -> %{state | inflight_primes: Map.delete(state.inflight_primes, key)}
+      n -> %{state | inflight_primes: Map.put(state.inflight_primes, key, n - 1)}
+    end
+  end
+
+  defp inflight_for(state, node_id, wl), do: Map.get(state.inflight_primes, {node_id, wl}, 0)
+
+  defp node_inflight_primes(state, node_id) do
+    state.inflight_primes
+    |> Enum.filter(fn {{n, _wl}, _v} -> n == node_id end)
+    |> Enum.map(&elem(&1, 1))
+    |> Enum.sum()
+  end
+
+  # -- helpers ---------------------------------------------------------------
+
+  defp base_ready?(wc) do
+    ready =
+      case Map.get(wc, :base_state) do
+        :BASE_BUILD_STATE_READY -> true
+        3 -> true
+        _ -> false
+      end
+
+    ref = Map.get(wc, :snapshot_ref)
+    ready and is_binary(ref) and ref != ""
+  end
+
+  defp stale?(f, now, stale_after), do: now - Map.get(f, :updated_at, 0) > stale_after
+  defp draining?(f), do: Map.get(f, :draining, false) == true
+
+  defp queue_depth(state, wl) do
+    if :ets.whereis(state.depth_table) == :undefined do
+      0
+    else
+      state.depth_table
+      |> :ets.match_object({{wl, :_}, :_})
+      |> Enum.map(fn {_key, n} -> n end)
+      |> Enum.sum()
+    end
+  end
+
+  defp map_sum(map), do: map |> Map.values() |> Enum.sum()
+
+  defp schedule_refill(state) do
+    Process.send_after(self(), :refill, state.refill_interval_ms)
+    state
+  end
+
+  defp safe(fun) do
+    try do
+      fun.()
+    rescue
+      _ -> :error
+    catch
+      _, _ -> :error
+    end
+  end
+
+  defp default_mono, do: System.monotonic_time(:millisecond)
+
+  defp default_prime(channel, %PrimeRequest{} = req) do
+    Embervm.Node.V1.NodeService.Stub.prime(channel, req)
+  end
+end

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -115,6 +115,24 @@ defmodule Embervm.Router do
   defp handle_submit(conn, workload) do
     principal = conn.assigns.principal
 
+    # Per-principal queue-depth cap: a synchronous 429 pre-check BEFORE the durable
+    # submit (the dispatcher owns the fair-queue depth; the FSM has no queued->fail
+    # edge, so a queued task cannot be terminally dropped after the fact). Advisory
+    # and coarse: the real reservation happens on enqueue, so a concurrent burst can
+    # momentarily overshoot, and a control plane with no dispatcher wired fails
+    # closed (denies) rather than admitting unbounded backlog.
+    if Embervm.Dispatcher.admit?(workload, principal) do
+      submit_admitted(conn, workload, principal)
+    else
+      send_json(conn, 429, %{
+        error: "per-principal queue depth cap exceeded for workload",
+        workload: workload,
+        retryable: true
+      })
+    end
+  end
+
+  defp submit_admitted(conn, workload, principal) do
     case read_capped_body(conn) do
       {:ok, body, conn} ->
         attrs = %{

--- a/projects/embervm/control/lib/embervm/task_store.ex
+++ b/projects/embervm/control/lib/embervm/task_store.ex
@@ -113,6 +113,38 @@ defmodule Embervm.TaskStore do
   end
 
   @doc """
+  Reads the opaque guest-request envelope (path, headers, base64 body, content
+  type) captured in the task's `submitted` op, or `{:ok, nil}` if the task is
+  unknown. The dispatcher (Task 11) calls this at assign time to rebuild the
+  `AssignRequest`. It reads the immutable op-log (the request is never projected
+  into a column), so it is deliberately NOT held in the ETS hot set: a queued
+  task keeps its (up to 8 MiB) body out of memory and out of the fair queue
+  until the moment it is actually dispatched.
+  """
+  @spec get_request(GenServer.server(), String.t()) :: {:ok, map() | nil} | {:error, term()}
+  def get_request(store \\ __MODULE__, task_id) do
+    GenServer.call(store, {:get_request, task_id})
+  end
+
+  @doc """
+  Every task currently in a dispatchable-backlog state: `queued` (waiting for a
+  primed VM) or `failed_retryable` (awaiting a retry the dispatcher must arm).
+  Returns lightweight records (`task_id`, `workload`, `principal`, `state`,
+  `attempt`) newest-submitted first, from the ETS hot set (never the op-log).
+
+  This is the dispatcher's boot + safety-sweep reconcile source. Two cases the
+  push-based `on_queued` hook cannot cover need it: (1) a control-plane restart,
+  where the op-log rebuild repopulates ETS but the dispatcher's in-memory fair
+  queues start empty, and (2) `reassign_in_flight/0` (a downed node), which
+  moves in-flight tasks to `failed_retryable` out of band with no dispatcher
+  notification. A slow periodic sweep over this list re-drives both.
+  """
+  @spec list_backlog(GenServer.server()) :: {:ok, [map()]}
+  def list_backlog(store \\ __MODULE__) do
+    GenServer.call(store, :list_backlog)
+  end
+
+  @doc """
   Lists dead-lettered tasks for `workload`, newest first, paged by `:limit`
   (default 50) and `:offset` (default 0). Serves `GET
   /v1/workloads/{name}/dead-letters` from the ETS hot set (bounded and rare, so
@@ -160,11 +192,17 @@ defmodule Embervm.TaskStore do
     op_log = Keyword.get(opts, :op_log, Embervm.OpLog.SQLite)
     id_fun = Keyword.get(opts, :id_fun, &default_id/0)
     clock = Keyword.get(opts, :clock, &default_clock/0)
+    # Fired on every transition INTO :queued (submit-created, retry, redrive) with
+    # %{task_id, workload, principal}, so the dispatcher (Task 11) can enqueue the
+    # task into its fair queue. Defaults to the dispatcher's own whereis-guarded
+    # cast, a no-op when no dispatcher is running (this store's own unit tests
+    # start none), mirroring the WorkloadWatcher -> BaseBuilder trigger seam.
+    on_queued = Keyword.get(opts, :on_queued, &Embervm.Dispatcher.enqueue/1)
 
     tasks = :ets.new(@tasks_table, [:set, :private])
     idem = :ets.new(@idem_table, [:set, :private])
 
-    state = %{op_log: op_log, id_fun: id_fun, clock: clock, tasks: tasks, idem: idem}
+    state = %{op_log: op_log, id_fun: id_fun, clock: clock, on_queued: on_queued, tasks: tasks, idem: idem}
 
     case rebuild(state) do
       :ok ->
@@ -306,6 +344,7 @@ defmodule Embervm.TaskStore do
         {:ok, _seq} ->
           updated = %{task | state: next, attempt: task.attempt + 1, updated_at: ts}
           :ets.insert(state.tasks, {task_id, updated})
+          notify_queued(state, updated)
           {:reply, {:ok, updated}, state}
 
         {:error, _reason} = error ->
@@ -325,6 +364,35 @@ defmodule Embervm.TaskStore do
 
   def handle_call({:get_result, task_id}, _from, state) do
     {:reply, Embervm.OpLog.SQLite.load_result(state.op_log, task_id), state}
+  end
+
+  def handle_call({:get_request, task_id}, _from, state) do
+    {:reply, Embervm.OpLog.SQLite.load_request(state.op_log, task_id), state}
+  end
+
+  def handle_call(:list_backlog, _from, state) do
+    backlog =
+      :ets.foldl(
+        fn {_id, task}, acc ->
+          if task.state in [:queued, :failed_retryable] do
+            [%{
+               task_id: task.task_id,
+               workload: task.workload,
+               principal: task.principal,
+               state: task.state,
+               attempt: task.attempt
+             }
+             | acc]
+          else
+            acc
+          end
+        end,
+        [],
+        state.tasks
+      )
+      |> Enum.sort_by(& &1.task_id)
+
+    {:reply, {:ok, backlog}, state}
   end
 
   def handle_call({:list_dead_letters, workload, opts}, _from, state) do
@@ -368,6 +436,7 @@ defmodule Embervm.TaskStore do
         {:ok, _seq} ->
           updated = %{task | state: next, attempt: 1, updated_at: ts}
           :ets.insert(state.tasks, {task_id, updated})
+          notify_queued(state, updated)
           {:reply, {:ok, updated}, state}
 
         {:error, _reason} = error ->
@@ -434,6 +503,7 @@ defmodule Embervm.TaskStore do
           :ets.insert(state.idem, {{workload, idempotency_key}, task_id})
         end
 
+        notify_queued(state, task)
         {:reply, {:ok, :created, task_id}, state}
 
       {:error, _reason} = error ->
@@ -541,6 +611,24 @@ defmodule Embervm.TaskStore do
       {:error, _reason} ->
         :ok
     end
+  end
+
+  # Signal the dispatcher that a task is (freshly, or again) queued. Best-effort
+  # and fire-and-forget: the hook is a cast the dispatcher whereis-guards, so a
+  # store with no dispatcher wired (unit tests) or a dispatcher mid-restart just
+  # drops the signal, and the dispatcher's boot/periodic backlog sweep re-drives
+  # anything a dropped signal left behind. A raise in the hook must never fail
+  # the transition (already durable), so it is caught.
+  defp notify_queued(state, task) do
+    try do
+      state.on_queued.(%{task_id: task.task_id, workload: task.workload, principal: task.principal})
+    rescue
+      _ -> :ok
+    catch
+      _, _ -> :ok
+    end
+
+    :ok
   end
 
   defp fetch_task(state, task_id) do

--- a/projects/embervm/control/lib/embervm/task_store.ex
+++ b/projects/embervm/control/lib/embervm/task_store.ex
@@ -127,17 +127,22 @@ defmodule Embervm.TaskStore do
   end
 
   @doc """
-  Every task currently in a dispatchable-backlog state: `queued` (waiting for a
-  primed VM) or `failed_retryable` (awaiting a retry the dispatcher must arm).
-  Returns lightweight records (`task_id`, `workload`, `principal`, `state`,
-  `attempt`) newest-submitted first, from the ETS hot set (never the op-log).
+  Every task the dispatcher's sweep must be able to reconcile: `queued` (waiting
+  for a primed VM), `failed_retryable` (awaiting a retry), and the in-flight
+  states `assigned`/`running`. Returns lightweight records (`task_id`,
+  `workload`, `principal`, `state`, `attempt`), sorted by `task_id`, from the ETS
+  hot set (never the op-log).
 
-  This is the dispatcher's boot + safety-sweep reconcile source. Two cases the
-  push-based `on_queued` hook cannot cover need it: (1) a control-plane restart,
-  where the op-log rebuild repopulates ETS but the dispatcher's in-memory fair
-  queues start empty, and (2) `reassign_in_flight/0` (a downed node), which
-  moves in-flight tasks to `failed_retryable` out of band with no dispatcher
-  notification. A slow periodic sweep over this list re-drives both.
+  This is the dispatcher's boot + safety-sweep reconcile source. It must include
+  in-flight states because a task can be durably `assigned`/`running` with NO
+  live worker owning it: a control-plane (or dispatcher-only) restart drops every
+  worker while the op-log rebuild leaves the task in-flight; a partial
+  `assign`-then-`start` commit leaves it `assigned` with no worker spawned; a
+  completion whose terminal op-log append failed leaves it `running`. The
+  dispatcher distinguishes such ORPHANS (no tracked worker) from genuinely
+  running tasks and reclaims only the former, so no task is lost. `queued` tasks
+  a dropped `on_queued` cast missed and `failed_retryable` tasks
+  `reassign_in_flight/0` produced out of band are re-driven the same way.
   """
   @spec list_backlog(GenServer.server()) :: {:ok, [map()]}
   def list_backlog(store \\ __MODULE__) do
@@ -374,7 +379,7 @@ defmodule Embervm.TaskStore do
     backlog =
       :ets.foldl(
         fn {_id, task}, acc ->
-          if task.state in [:queued, :failed_retryable] do
+          if task.state in [:queued, :failed_retryable, :assigned, :running] do
             [%{
                task_id: task.task_id,
                workload: task.workload,

--- a/projects/embervm/control/lib/embervm/trigger/cron.ex
+++ b/projects/embervm/control/lib/embervm/trigger/cron.ex
@@ -123,7 +123,7 @@ defmodule Embervm.Trigger.Cron do
     schedules =
       for {key, spec} <- desired, into: %{} do
         case Map.get(state.schedules, key) do
-          %{cron: existing_cron, next: next} = kept when spec.cron_expr == existing_cron.expr ->
+          %{cron: existing_cron} = kept when spec.cron_expr == existing_cron.expr ->
             # Unchanged trigger: keep its pending next-fire.
             {key, %{kept | payload: spec.payload, invoke_path: spec.invoke_path, workload: spec.workload}}
 

--- a/projects/embervm/control/lib/embervm/trigger/cron.ex
+++ b/projects/embervm/control/lib/embervm/trigger/cron.ex
@@ -1,0 +1,273 @@
+defmodule Embervm.Trigger.Cron do
+  @moduledoc """
+  The cron `Embervm.TriggerAdapter`: fires each Workload's `spec.triggers[].cron`
+  as an ordinary submit with principal `system:cron:<workload>` and the trigger's
+  inline `payload` as the (JSON) task body.
+
+  ## how it schedules
+
+  It reads the trigger list from `Embervm.WorkloadCatalog` (the watcher parses
+  `spec.triggers` into each entry) and, per trigger, holds the NEXT fire time
+  computed by `Embervm.Cron.next/2` from the current clock. A periodic tick
+  reconciles the catalog (adds new triggers, drops removed ones) and fires every
+  trigger whose next-fire time has passed, then recomputes each fired trigger's
+  next time from now.
+
+  ## misfires are skipped, not replayed (documented semantic)
+
+  Next-fire is always computed FORWARD from the current time, and nothing is
+  persisted, so a fire whose minute elapsed while the control plane was down is
+  simply never scheduled: it is skipped, never backfilled. This is deliberate and
+  safe for R0's cron workloads (the daily full-scan consumer tolerates a skipped
+  tick; it re-scans the whole surface next run), and it keeps the adapter
+  stateless across restarts. A trigger source that cannot tolerate a skip must
+  bring its own delivery guarantee behind the same `Embervm.TriggerAdapter` seam
+  (e.g. NATS acks); cron does not.
+
+  The clock and the submit sink are injected, so a test drives the whole fire
+  path deterministically: advance the clock, tick, assert the recorded submit.
+  """
+
+  @behaviour Embervm.TriggerAdapter
+
+  use GenServer
+  require Logger
+
+  alias Embervm.{Cron, WorkloadCatalog}
+
+  @tick_interval_ms 15_000
+  @tenant "homelab"
+  @default_ttl_ms 86_400_000
+
+  # -- Client API ------------------------------------------------------------
+
+  @impl Embervm.TriggerAdapter
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc """
+  Reconcile the schedule against the current catalog: add a next-fire for every
+  trigger not yet tracked, drop triggers whose Workload or trigger entry is gone.
+  A no-op for unchanged triggers (their next-fire is preserved). Runs on the
+  production tick; tests call it explicitly.
+  """
+  @spec reconcile(GenServer.server()) :: :ok
+  def reconcile(server \\ __MODULE__), do: GenServer.call(server, :reconcile)
+
+  @doc """
+  Fire every tracked trigger whose next-fire time has passed (per the injected
+  clock), submitting each and recomputing its next-fire. Returns the number
+  fired. Runs on the production tick; tests drive it with an advanced clock.
+  """
+  @spec tick(GenServer.server()) :: {:ok, non_neg_integer()}
+  def tick(server \\ __MODULE__), do: GenServer.call(server, :tick)
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    state = %{
+      catalog_table: Keyword.get(opts, :catalog_table, WorkloadCatalog.table()),
+      clock: Keyword.get(opts, :clock, &default_clock/0),
+      submit_fun: Keyword.get(opts, :submit_fun, &default_submit/1),
+      tick_interval_ms: Keyword.get(opts, :tick_interval_ms, @tick_interval_ms),
+      ttl_ms: Keyword.get(opts, :ttl_ms, @default_ttl_ms),
+      # {workload, index} -> %{cron, payload, invoke_path, workload, next}
+      schedules: %{}
+    }
+
+    state = reconcile_schedules(state)
+
+    if Keyword.get(opts, :start_ticking, true) do
+      schedule_tick(state)
+    end
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:reconcile, _from, state) do
+    {:reply, :ok, reconcile_schedules(state)}
+  end
+
+  def handle_call(:tick, _from, state) do
+    {state, fired} = fire_due(state)
+    {:reply, {:ok, fired}, state}
+  end
+
+  @impl true
+  def handle_info(:tick, state) do
+    state = reconcile_schedules(state)
+    {state, _fired} = fire_due(state)
+    schedule_tick(state)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # -- reconcile -------------------------------------------------------------
+
+  # Rebuild the schedule map from the catalog: keep an existing trigger's
+  # next-fire, compute one for a newly-seen trigger, drop any whose Workload or
+  # trigger is gone. Triggers are keyed {workload, index} so editing one
+  # workload's trigger list never disturbs another's schedule.
+  defp reconcile_schedules(state) do
+    now = state.clock.()
+    desired = catalog_triggers(state)
+
+    schedules =
+      for {key, spec} <- desired, into: %{} do
+        case Map.get(state.schedules, key) do
+          %{cron: existing_cron, next: next} = kept when spec.cron_expr == existing_cron.expr ->
+            # Unchanged trigger: keep its pending next-fire.
+            {key, %{kept | payload: spec.payload, invoke_path: spec.invoke_path, workload: spec.workload}}
+
+          _ ->
+            # New or changed cron expression: compute a fresh next-fire from now.
+            case Cron.parse(spec.cron_expr) do
+              {:ok, cron} ->
+                {key, build_schedule(spec, cron, now)}
+
+              {:error, reason} ->
+                Logger.warning(
+                  "embervm cron: skipping invalid cron #{inspect(spec.cron_expr)} for #{spec.workload}: #{inspect(reason)}"
+                )
+
+                {key, :invalid}
+            end
+        end
+      end
+      |> Enum.reject(fn {_k, v} -> v == :invalid end)
+      |> Map.new()
+
+    %{state | schedules: schedules}
+  end
+
+  defp build_schedule(spec, cron, now) do
+    next =
+      case Cron.next(cron, now) do
+        {:ok, dt} -> dt
+        {:error, _} -> nil
+      end
+
+    %{
+      cron: Map.put(cron, :expr, spec.cron_expr),
+      payload: spec.payload,
+      invoke_path: spec.invoke_path,
+      workload: spec.workload,
+      next: next
+    }
+  end
+
+  # Every (workload, trigger-index) currently cataloged, flattened with the
+  # invoke_path the trigger submits to.
+  defp catalog_triggers(state) do
+    # Uses Map.get, not entry.triggers/entry.invoke_path: the catalog is shared,
+    # and a partial entry (a test fixture, or a not-yet-fully-reconciled row)
+    # without those keys must yield "no triggers", never a KeyError that would
+    # crash this supervised adapter.
+    for name <- WorkloadCatalog.all_names(state.catalog_table),
+        {:ok, entry} <- [WorkloadCatalog.fetch(state.catalog_table, name)],
+        {trigger, index} <- Enum.with_index(Map.get(entry, :triggers) || []),
+        is_map(trigger),
+        is_binary(Map.get(trigger, :cron)) do
+      {{name, index},
+       %{
+         workload: name,
+         cron_expr: Map.get(trigger, :cron),
+         payload: Map.get(trigger, :payload),
+         invoke_path: Map.get(entry, :invoke_path) || "/"
+       }}
+    end
+  end
+
+  # -- fire ------------------------------------------------------------------
+
+  defp fire_due(state) do
+    now = state.clock.()
+
+    {schedules, fired} =
+      Enum.reduce(state.schedules, {%{}, 0}, fn {key, sched}, {acc, count} ->
+        cond do
+          is_nil(sched.next) ->
+            {Map.put(acc, key, sched), count}
+
+          not future?(sched.next, now) ->
+            submit_trigger(state, sched)
+            {Map.put(acc, key, %{sched | next: recompute_next(sched, now)}), count + 1}
+
+          true ->
+            {Map.put(acc, key, sched), count}
+        end
+      end)
+
+    {%{state | schedules: schedules}, fired}
+  end
+
+  defp recompute_next(sched, now) do
+    case Cron.next(sched.cron, now) do
+      {:ok, dt} -> dt
+      {:error, _} -> nil
+    end
+  end
+
+  # future?(t, now) is true when t is strictly after now (not yet due).
+  defp future?(t, now), do: DateTime.compare(t, now) == :gt
+
+  defp submit_trigger(state, sched) do
+    now_ms = DateTime.to_unix(state.clock.(), :millisecond)
+
+    attrs = %{
+      tenant: @tenant,
+      principal: "system:cron:" <> sched.workload,
+      workload: sched.workload,
+      idempotency_key: nil,
+      expires_at: now_ms + state.ttl_ms,
+      request: %{
+        path: sched.invoke_path,
+        headers: %{},
+        body_b64: Base.encode64(encode_payload(sched.payload)),
+        content_type: "application/json"
+      }
+    }
+
+    case safe(fn -> state.submit_fun.(attrs) end) do
+      {:ok, _} ->
+        :ok
+
+      other ->
+        Logger.warning("embervm cron: submit for #{sched.workload} failed: #{inspect(other)}")
+    end
+  end
+
+  # The inline payload is arbitrary JSON in the CR; encode it back to a JSON body.
+  # nil payload -> empty body (a bodyless POST).
+  defp encode_payload(nil), do: ""
+  defp encode_payload(payload), do: payload |> :json.encode() |> :erlang.iolist_to_binary()
+
+  # -- helpers ---------------------------------------------------------------
+
+  defp schedule_tick(state) do
+    Process.send_after(self(), :tick, state.tick_interval_ms)
+    state
+  end
+
+  defp safe(fun) do
+    try do
+      {:ok, fun.()}
+    rescue
+      e -> {:error, e}
+    catch
+      kind, reason -> {:error, {kind, reason}}
+    end
+  end
+
+  defp default_clock, do: DateTime.utc_now()
+
+  defp default_submit(attrs), do: Embervm.TaskStore.submit(attrs)
+end

--- a/projects/embervm/control/lib/embervm/trigger/cron.ex
+++ b/projects/embervm/control/lib/embervm/trigger/cron.ex
@@ -198,7 +198,7 @@ defmodule Embervm.Trigger.Cron do
             {Map.put(acc, key, sched), count}
 
           not future?(sched.next, now) ->
-            submit_trigger(state, sched)
+            submit_trigger(state, sched, now)
             {Map.put(acc, key, %{sched | next: recompute_next(sched, now)}), count + 1}
 
           true ->
@@ -219,8 +219,8 @@ defmodule Embervm.Trigger.Cron do
   # future?(t, now) is true when t is strictly after now (not yet due).
   defp future?(t, now), do: DateTime.compare(t, now) == :gt
 
-  defp submit_trigger(state, sched) do
-    now_ms = DateTime.to_unix(state.clock.(), :millisecond)
+  defp submit_trigger(state, sched, now) do
+    now_ms = DateTime.to_unix(now, :millisecond)
 
     attrs = %{
       tenant: @tenant,

--- a/projects/embervm/control/lib/embervm/trigger_adapter.ex
+++ b/projects/embervm/control/lib/embervm/trigger_adapter.ex
@@ -1,0 +1,27 @@
+defmodule Embervm.TriggerAdapter do
+  @moduledoc """
+  The seam that turns an EXTERNAL event source into ordinary task submits.
+
+  A trigger adapter's whole job is to convert its own kind of event (a cron
+  tick, later a NATS message, a webhook) into the exact same `submit` a client
+  makes over `POST /v1/workloads/{name}/tasks`, so nothing downstream, the fair
+  queue, the caps, the retry policy, the op-log, knows or cares that a task came
+  from a trigger rather than an API caller. That uniformity is the point: cron is
+  the only adapter in R0, and NATS (R-later) plugs in behind this same behaviour
+  without touching the dispatcher.
+
+  An adapter is a supervised process started with `start_link/1`. It receives a
+  `:submit_fun` in its opts, the one function it is allowed to call to inject
+  work, defaulting to a direct `Embervm.TaskStore.submit/1`; tests inject a
+  recorder. Whatever principal an adapter stamps its submits with is the audit
+  identity of that trigger source (cron uses `system:cron:<workload>`).
+
+  Deliberately NOT part of the contract: any notion of exactly-once or replay.
+  An adapter fires forward from now; events it missed while the control plane was
+  down are SKIPPED, not backfilled (the cron adapter documents this explicitly).
+  A source that needs delivery guarantees brings its own (NATS acks), but it
+  still lands here as a plain submit.
+  """
+
+  @callback start_link(keyword()) :: GenServer.on_start()
+end

--- a/projects/embervm/control/lib/embervm/workload_watcher.ex
+++ b/projects/embervm/control/lib/embervm/workload_watcher.ex
@@ -463,13 +463,14 @@ defmodule Embervm.WorkloadWatcher do
   end
 
   # Status for a VALID Workload: only the keys the watcher owns. Crucially it
-  # does NOT include `conditions`, so this merge-patch never overwrites the
-  # Ready/BaseBuilt array the BaseBuilder owns (merge-patch replaces arrays
-  # wholesale; disjoint keys are the whole reason the two writers coexist).
+  # does NOT include `conditions` (owned by the BaseBuilder) NOR
+  # `primedFloorSatisfied` (owned by the PoolManager, Task 11): merge-patch
+  # replaces arrays and overwrites keys wholesale, so the three writers coexist
+  # only by keeping their key sets disjoint. The watcher owns observedGeneration
+  # alone for the valid lane.
   defp write_valid_status(state, namespace, name, generation) do
     status_map = %{
-      "observedGeneration" => generation,
-      "primedFloorSatisfied" => false
+      "observedGeneration" => generation
     }
 
     case state.status_writer.(namespace, name, status_map) do
@@ -610,9 +611,25 @@ defmodule Embervm.WorkloadWatcher do
       timeout_ms: (Map.get(invocation, "timeoutSeconds") || 90) * 1000,
       result_ttl_ms: (Map.get(invocation, "resultTtlSeconds") || 86_400) * 1000,
       result_max_bytes: Map.get(invocation, "resultMaxBytes") || 1_048_576,
-      retry: parse_retry(Map.get(invocation, "retry") || %{})
+      retry: parse_retry(Map.get(invocation, "retry") || %{}),
+      # spec.triggers[] parsed for the cron TriggerAdapter (Task 11). Each entry is
+      # %{cron, payload}; the daemon-agnostic control plane fires each as an
+      # ordinary submit. An absent/empty list means no triggers.
+      triggers: parse_triggers(Map.get(spec, "triggers"))
     }
   end
+
+  # spec.triggers[] -> [%{cron, payload}]. The CRD requires `cron` per item and
+  # `payload` is arbitrary JSON (x-kubernetes-preserve-unknown-fields); a
+  # non-list or missing field yields an empty list, so a malformed triggers block
+  # simply schedules nothing rather than crashing the reconcile.
+  defp parse_triggers(list) when is_list(list) do
+    for t <- list, is_map(t), is_binary(Map.get(t, "cron")) do
+      %{cron: Map.get(t, "cron"), payload: Map.get(t, "payload")}
+    end
+  end
+
+  defp parse_triggers(_), do: []
 
   # Mirrors Embervm.Retry.retry_config()'s shape exactly (max_attempts,
   # backoff_ms, backoff_cap_ms, retry_on) so classify/2 and backoff_ms/2,3

--- a/projects/embervm/control/test/embervm/cron_test.exs
+++ b/projects/embervm/control/test/embervm/cron_test.exs
@@ -52,6 +52,16 @@ defmodule Embervm.CronTest do
     assert next_week == dt(2026, 7, 20, 9, 0)
   end
 
+  test "day-of-week 7 is accepted as a Sunday alias (Vixie)" do
+    {:ok, cron} = Cron.parse("0 9 * * 7")
+    # 2026-07-19 is a Sunday, 2026-07-20 a Monday.
+    assert Cron.matches?(cron, dt(2026, 7, 19, 9, 0))
+    refute Cron.matches?(cron, dt(2026, 7, 20, 9, 0))
+    # And it still resolves the same as 0.
+    {:ok, zero} = Cron.parse("0 9 * * 0")
+    assert Cron.next(cron, dt(2026, 7, 15, 0, 0)) == Cron.next(zero, dt(2026, 7, 15, 0, 0))
+  end
+
   test "Vixie rule: restricted dom AND dow match on EITHER" do
     # "0 0 13 * 5" = midnight on the 13th OR any Friday.
     {:ok, cron} = Cron.parse("0 0 13 * 5")

--- a/projects/embervm/control/test/embervm/cron_test.exs
+++ b/projects/embervm/control/test/embervm/cron_test.exs
@@ -1,0 +1,65 @@
+defmodule Embervm.CronTest do
+  @moduledoc """
+  Unit tests for the dependency-free 5-field cron parser + next-fire calculator
+  (`Embervm.Cron`). Everything is pure, so these are plain assertions with fixed
+  UTC datetimes, no processes or clocks.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.Cron
+
+  defp dt(y, mo, d, h, mi), do: DateTime.new!(Date.new!(y, mo, d), Time.new!(h, mi, 0), "Etc/UTC")
+
+  test "parses the five field forms" do
+    assert {:ok, _} = Cron.parse("* * * * *")
+    assert {:ok, _} = Cron.parse("*/5 0 1 1 0")
+    assert {:ok, _} = Cron.parse("0,15,30,45 9-17 * * 1-5")
+    assert {:error, _} = Cron.parse("* * * *")
+    assert {:error, _} = Cron.parse("60 * * * *")
+    assert {:error, _} = Cron.parse("* 24 * * *")
+    assert {:error, _} = Cron.parse("bad")
+  end
+
+  test "next fires at the next matching minute, strictly after now" do
+    {:ok, cron} = Cron.parse("*/15 * * * *")
+    # 10:07 -> next quarter hour is 10:15.
+    assert {:ok, next} = Cron.next(cron, dt(2026, 7, 13, 10, 7))
+    assert next == dt(2026, 7, 13, 10, 15)
+
+    # Exactly on a boundary still advances (strictly after): 10:15 -> 10:30.
+    assert {:ok, later} = Cron.next(cron, dt(2026, 7, 13, 10, 15))
+    assert later == dt(2026, 7, 13, 10, 30)
+  end
+
+  test "next rolls the hour and day" do
+    {:ok, cron} = Cron.parse("0 * * * *")
+    assert {:ok, next} = Cron.next(cron, dt(2026, 7, 13, 10, 30))
+    assert next == dt(2026, 7, 13, 11, 0)
+
+    {:ok, daily} = Cron.parse("30 2 * * *")
+    assert {:ok, tomorrow} = Cron.next(daily, dt(2026, 7, 13, 3, 0))
+    assert tomorrow == dt(2026, 7, 14, 2, 30)
+  end
+
+  test "day-of-week matches (0 = Sunday)" do
+    # 2026-07-13 is a Monday. "0 9 * * 1" = 09:00 on Mondays.
+    {:ok, cron} = Cron.parse("0 9 * * 1")
+    assert {:ok, next} = Cron.next(cron, dt(2026, 7, 13, 8, 0))
+    assert next == dt(2026, 7, 13, 9, 0)
+
+    # From Monday 10:00, the next Monday 09:00 is a week later.
+    assert {:ok, next_week} = Cron.next(cron, dt(2026, 7, 13, 10, 0))
+    assert next_week == dt(2026, 7, 20, 9, 0)
+  end
+
+  test "Vixie rule: restricted dom AND dow match on EITHER" do
+    # "0 0 13 * 5" = midnight on the 13th OR any Friday.
+    {:ok, cron} = Cron.parse("0 0 13 * 5")
+    # 2026-07-13 is a Monday: matches on day-of-month 13.
+    assert Cron.matches?(cron, dt(2026, 7, 13, 0, 0))
+    # 2026-07-17 is a Friday: matches on day-of-week even though it is the 17th.
+    assert Cron.matches?(cron, dt(2026, 7, 17, 0, 0))
+    # 2026-07-14 (Tuesday, not the 13th): no match.
+    refute Cron.matches?(cron, dt(2026, 7, 14, 0, 0))
+  end
+end

--- a/projects/embervm/control/test/embervm/dispatcher_test.exs
+++ b/projects/embervm/control/test/embervm/dispatcher_test.exs
@@ -1,0 +1,383 @@
+defmodule Embervm.DispatcherTest do
+  @moduledoc """
+  Task 11 acceptance for `Embervm.Dispatcher`: warm + miss dispatch drive a task
+  to terminal, fail-closed enforcement denies with distinct kinds, the caps bound
+  in-flight and enforce per-principal fairness, and 1k tasks drain with zero lost.
+
+  A FAKE DAEMON is injected via `channel_fun`/`assign_fun`/`prime_fun` (the same
+  seam idiom the NodeRegistry/BaseBuilder tests use), a real (unnamed) op-log +
+  TaskStore give the real FSM, and unique ETS table names + an unnamed store keep
+  each test isolated from the application's own supervised dispatcher.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.{Dispatcher, NodeCapacity, TaskStore, WorkloadCatalog}
+  alias Embervm.OpLog.SQLite
+  alias Embervm.Node.V1.{AssignRequest, AssignResponse, GuestResponse, PrimeResponse, Trace, UsageStats}
+
+  # -- harness ---------------------------------------------------------------
+
+  defp start_stack(opts \\ []) do
+    suffix = System.unique_integer([:positive])
+    cap_table = :"cap_#{suffix}"
+    cat_table = :"cat_#{suffix}"
+    depth_table = :"depth_#{suffix}"
+    disp_name = :"disp_#{suffix}"
+
+    NodeCapacity.create(cap_table)
+    WorkloadCatalog.create(cat_table)
+
+    path = Path.join(System.tmp_dir!(), "embervm_dispatcher_test_#{suffix}.db")
+    on_exit(fn -> File.rm_rf!(path) end)
+
+    {:ok, op_log} = SQLite.start_link(name: nil, path: path)
+    {:ok, store} = TaskStore.start_link(name: nil, op_log: op_log, on_queued: fn t -> Dispatcher.enqueue(disp_name, t) end)
+
+    disp_opts =
+      [
+        name: disp_name,
+        task_store: store,
+        capacity_table: cap_table,
+        catalog_table: cat_table,
+        depth_table: depth_table,
+        clock: fn -> 1_000_000 end,
+        channel_fun: fn _node -> {:ok, :ch} end,
+        assign_fun: Keyword.get(opts, :assign_fun, fn _ch, _req -> {:ok, success_resp()} end),
+        prime_fun: Keyword.get(opts, :prime_fun, fn _ch, _req -> {:ok, %PrimeResponse{vm_id: "vm-#{System.unique_integer([:positive])}"}} end),
+        start_sweep: false
+      ] ++ Keyword.take(opts, [:queue_depth_cap, :share_fraction, :stale_after_ms])
+
+    {:ok, disp} = Dispatcher.start_link(disp_opts)
+
+    %{disp: disp, name: disp_name, store: store, cap_table: cap_table, cat_table: cat_table, depth_table: depth_table}
+  end
+
+  defp success_resp(code \\ 200, body \\ "ok") do
+    %AssignResponse{
+      response: %GuestResponse{status_code: code, headers: %{}, body: body},
+      usage: %UsageStats{cpu_ms: 1, peak_rss_mib: 1, wall_ms: 1}
+    }
+  end
+
+  defp put_facts(ctx, wl, opts \\ []) do
+    node = Keyword.get(opts, :node, "node-4")
+
+    NodeCapacity.put(ctx.cap_table, node, %{
+      node_id: node,
+      configured_id: node,
+      workloads: %{
+        wl => %{
+          free_primed_slots: Keyword.get(opts, :free, 0),
+          snapshot_ref: Keyword.get(opts, :snapshot_ref, "snap-#{wl}"),
+          base_state: Keyword.get(opts, :base_state, :BASE_BUILD_STATE_READY)
+        }
+      },
+      mem_headroom_mib: 4096,
+      cpu_headroom_millicores: 4000,
+      live_vms: Keyword.get(opts, :live, 0),
+      max_live_vms: Keyword.get(opts, :max, 8),
+      draining: Keyword.get(opts, :draining, false),
+      updated_at: Keyword.get(opts, :updated_at, 1_000_000)
+    })
+  end
+
+  defp put_catalog(ctx, wl, opts \\ []) do
+    WorkloadCatalog.upsert(ctx.cat_table, wl, %{
+      name: wl,
+      namespace: "embervm",
+      cap: Keyword.get(opts, :cap, 10),
+      floor: Keyword.get(opts, :floor, 0),
+      invoke_path: "/",
+      timeout_ms: 5_000,
+      result_ttl_ms: 60_000,
+      result_max_bytes: Keyword.get(opts, :result_max_bytes, 1_048_576),
+      retry: Keyword.get(opts, :retry, %{max_attempts: 3, backoff_ms: 1, backoff_cap_ms: 1, retry_on: [:transport, :timeout, :guest5xx]}),
+      triggers: []
+    })
+  end
+
+  defp submit(ctx, wl, principal) do
+    {:ok, :created, tid} =
+      TaskStore.submit(ctx.store, %{
+        tenant: "t",
+        principal: principal,
+        workload: wl,
+        request: %{path: "/", headers: %{}, body_b64: Base.encode64("")}
+      })
+
+    tid
+  end
+
+  defp state_of(ctx, tid) do
+    case TaskStore.get(ctx.store, tid) do
+      {:ok, %{state: s}} -> s
+      _ -> :missing
+    end
+  end
+
+  defp eventually(fun, timeout \\ 5_000, interval \\ 10) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_eventually(fun, deadline, interval)
+  end
+
+  defp do_eventually(fun, deadline, interval) do
+    if fun.() do
+      true
+    else
+      if System.monotonic_time(:millisecond) >= deadline do
+        false
+      else
+        Process.sleep(interval)
+        do_eventually(fun, deadline, interval)
+      end
+    end
+  end
+
+  # -- warm + miss -----------------------------------------------------------
+
+  test "warm dispatch drives a queued task to succeeded and stores the result" do
+    ctx = start_stack()
+    put_catalog(ctx, "wl-a", cap: 10)
+    put_facts(ctx, "wl-a", free: 1)
+    Dispatcher.deposit(ctx.name, "node-4", "wl-a", "vm-1")
+
+    tid = submit(ctx, "wl-a", "p1")
+
+    assert eventually(fn -> state_of(ctx, tid) == :succeeded end)
+    assert {:ok, %{status_code: 200, body: "ok"}} = TaskStore.get_result(ctx.store, tid)
+    assert Dispatcher.stats(ctx.name).warm_hits >= 1
+  end
+
+  test "miss path primes then assigns, counted as a miss" do
+    ctx = start_stack()
+    put_catalog(ctx, "wl-a", cap: 10)
+    put_facts(ctx, "wl-a", free: 0, live: 0, max: 8)
+
+    tid = submit(ctx, "wl-a", "p1")
+
+    assert eventually(fn -> state_of(ctx, tid) == :succeeded end)
+    stats = Dispatcher.stats(ctx.name)
+    assert stats.misses >= 1
+    assert stats.warm_hits == 0
+  end
+
+  # -- fail-closed -----------------------------------------------------------
+
+  test "no capacity facts: task stays queued, denial recorded as :no_capacity" do
+    ctx = start_stack()
+    put_catalog(ctx, "wl-a", cap: 10)
+    # No facts at all.
+
+    tid = submit(ctx, "wl-a", "p1")
+
+    assert eventually(fn -> Dispatcher.stats(ctx.name).denials.no_capacity > 0 end)
+    Process.sleep(50)
+    assert state_of(ctx, tid) == :queued
+  end
+
+  test "stale capacity (> 15s since stamp): denial recorded as :stale_capacity" do
+    ctx = start_stack()
+    put_catalog(ctx, "wl-a", cap: 10)
+    # Base ready, but stamped 20s before the dispatcher's clock (1_000_000).
+    put_facts(ctx, "wl-a", free: 1, updated_at: 1_000_000 - 20_000)
+
+    tid = submit(ctx, "wl-a", "p1")
+
+    assert eventually(fn -> Dispatcher.stats(ctx.name).denials.stale_capacity > 0 end)
+    assert state_of(ctx, tid) == :queued
+  end
+
+  test "draining node is not dispatchable (fail-closed)" do
+    ctx = start_stack()
+    put_catalog(ctx, "wl-a", cap: 10)
+    put_facts(ctx, "wl-a", free: 1, draining: true)
+
+    tid = submit(ctx, "wl-a", "p1")
+    assert eventually(fn -> Dispatcher.stats(ctx.name).denials.no_capacity > 0 end)
+    assert state_of(ctx, tid) == :queued
+  end
+
+  # -- caps ------------------------------------------------------------------
+
+  test "per-workload cap bounds in-flight tasks" do
+    gate = new_gate()
+    ctx = start_stack(assign_fun: gated_assign(gate))
+    put_catalog(ctx, "wl-a", cap: 2)
+    put_facts(ctx, "wl-a", live: 0, max: 8)
+
+    tids = for _ <- 1..5, do: submit(ctx, "wl-a", "p1")
+
+    # Exactly cap (2) go in-flight; the rest wait queued.
+    assert eventually(fn -> Map.get(Dispatcher.stats(ctx.name).inflight_wl, "wl-a") == 2 end)
+    assert Dispatcher.stats(ctx.name).queued == 3
+    assert Dispatcher.stats(ctx.name).denials.cap > 0
+
+    open_gate(gate)
+    assert eventually(fn -> Enum.all?(tids, &(state_of(ctx, &1) == :succeeded)) end)
+  end
+
+  test "per-principal share cap splits a workload's cap across principals" do
+    gate = new_gate()
+    ctx = start_stack(assign_fun: gated_assign(gate))
+    # cap 4, two active principals -> share = 2 each.
+    put_catalog(ctx, "wl-a", cap: 4)
+    put_facts(ctx, "wl-a", live: 0, max: 16)
+
+    # A has 5 tasks, B has 1. With share 2, A is held to 2 in-flight even though 4
+    # slots exist; B takes its 1. So the in-flight split is A:2, B:1 (not A:4).
+    for _ <- 1..5, do: submit(ctx, "wl-a", "A")
+    submit(ctx, "wl-a", "B")
+
+    assert eventually(fn ->
+             ifp = Dispatcher.stats(ctx.name).inflight_pr
+             Map.get(ifp, {"wl-a", "A"}) == 2 and Map.get(ifp, {"wl-a", "B"}) == 1
+           end)
+
+    open_gate(gate)
+    assert eventually(fn -> Dispatcher.stats(ctx.name).queued == 0 end)
+  end
+
+  # -- fairness (round-robin across principals, FIFO within) -----------------
+
+  test "dispatch order is round-robin across principals, FIFO within a principal" do
+    {:ok, order} = Agent.start_link(fn -> [] end)
+
+    record_assign = fn _ch, %AssignRequest{trace: %Trace{task_id: tid}} ->
+      Agent.update(order, &(&1 ++ [tid]))
+      {:ok, success_resp()}
+    end
+
+    # cap 1 serializes dispatch so the recorded call order IS the dispatch order.
+    ctx = start_stack(assign_fun: record_assign)
+    put_catalog(ctx, "wl-a", cap: 1)
+
+    # Submit with NO capacity first so all six queue before any dispatch, giving a
+    # clean steady-state (both principals always have work) rather than a startup
+    # artifact where one principal is served while alone.
+    a = for _ <- 1..3, do: submit(ctx, "wl-a", "A")
+    b = for _ <- 1..3, do: submit(ctx, "wl-a", "B")
+    principal = Map.new(Enum.map(a, &{&1, "A"}) ++ Enum.map(b, &{&1, "B"}))
+
+    # Wait until all six enqueue casts (in submit order) are processed, so the
+    # fair-queue order is the submit order and not a random-task-id backlog sort.
+    assert eventually(fn -> Dispatcher.stats(ctx.name).queued == 6 end)
+
+    # Now grant capacity and kick a drain (the tasks are already queued, so the
+    # sweep only triggers the drain; do_enqueue dedupes them).
+    put_facts(ctx, "wl-a", live: 0, max: 8)
+    Dispatcher.sweep(ctx.name)
+
+    assert eventually(fn -> length(Agent.get(order, & &1)) == 6 end)
+
+    principals = order |> Agent.get(& &1) |> Enum.map(&Map.get(principal, &1))
+    assert principals == ["A", "B", "A", "B", "A", "B"]
+
+    # And FIFO within a principal: A's three tasks ran in submit order.
+    a_order = order |> Agent.get(& &1) |> Enum.filter(&(Map.get(principal, &1) == "A"))
+    assert a_order == a
+  end
+
+  # -- drain integrity -------------------------------------------------------
+
+  test "1000 tasks drain with zero lost, all terminal" do
+    ctx = start_stack()
+    put_catalog(ctx, "wl-a", cap: 200)
+    put_facts(ctx, "wl-a", live: 0, max: 1_000_000)
+
+    tids = for _ <- 1..1000, do: submit(ctx, "wl-a", "p1")
+
+    assert eventually(
+             fn ->
+               s = Dispatcher.stats(ctx.name)
+               s.queued == 0 and s.workers == 0 and map_size(s.inflight_wl) == 0
+             end,
+             30_000
+           )
+
+    succeeded = Enum.count(tids, &(state_of(ctx, &1) == :succeeded))
+    assert succeeded == 1000
+    assert {:ok, []} = TaskStore.list_backlog(ctx.store)
+  end
+
+  # -- failure classification ------------------------------------------------
+
+  test "guest 5xx retries through Retry until attempts exhaust, then dead-letters" do
+    {:ok, attempts} = Agent.start_link(fn -> 0 end)
+
+    fail_5xx = fn _ch, _req ->
+      Agent.update(attempts, &(&1 + 1))
+      {:ok, success_resp(503, "boom")}
+    end
+
+    ctx = start_stack(assign_fun: fail_5xx)
+    put_catalog(ctx, "wl-a", cap: 10, retry: %{max_attempts: 3, backoff_ms: 1, backoff_cap_ms: 1, retry_on: [:guest5xx]})
+    put_facts(ctx, "wl-a", live: 0, max: 8)
+
+    tid = submit(ctx, "wl-a", "p1")
+
+    assert eventually(fn -> state_of(ctx, tid) == :dead_lettered end)
+    # Three attempts (1..max_attempts), each classified retryable until the last.
+    assert Agent.get(attempts, & &1) == 3
+  end
+
+  test "guest 4xx is permanent (never retried)" do
+    {:ok, attempts} = Agent.start_link(fn -> 0 end)
+
+    fail_4xx = fn _ch, _req ->
+      Agent.update(attempts, &(&1 + 1))
+      {:ok, success_resp(400, "bad")}
+    end
+
+    ctx = start_stack(assign_fun: fail_4xx)
+    put_catalog(ctx, "wl-a", cap: 10)
+    put_facts(ctx, "wl-a", live: 0, max: 8)
+
+    tid = submit(ctx, "wl-a", "p1")
+
+    assert eventually(fn -> state_of(ctx, tid) == :dead_lettered end)
+    assert Agent.get(attempts, & &1) == 1
+  end
+
+  # -- admit? 429 gate -------------------------------------------------------
+
+  test "admit? denies once the per-principal queue-depth cap is reached" do
+    ctx = start_stack(queue_depth_cap: 2)
+    put_catalog(ctx, "wl-a", cap: 10)
+    # No capacity, so submitted tasks stay queued and keep charging depth.
+
+    assert Dispatcher.admit?(ctx.depth_table, "wl-a", "p1")
+    submit(ctx, "wl-a", "p1")
+    submit(ctx, "wl-a", "p1")
+
+    assert eventually(fn -> not Dispatcher.admit?(ctx.depth_table, "wl-a", "p1") end)
+    # A different principal is unaffected.
+    assert Dispatcher.admit?(ctx.depth_table, "wl-a", "p2")
+  end
+
+  # -- gate helpers ----------------------------------------------------------
+
+  defp new_gate do
+    {:ok, agent} = Agent.start_link(fn -> false end)
+    agent
+  end
+
+  defp open_gate(agent), do: Agent.update(agent, fn _ -> true end)
+
+  # An assign_fun that blocks (holding the task in-flight) until the gate opens,
+  # so a test can observe steady-state in-flight counts before completion.
+  defp gated_assign(gate) do
+    fn _ch, _req ->
+      wait_open(gate)
+      {:ok, success_resp()}
+    end
+  end
+
+  defp wait_open(gate) do
+    if Agent.get(gate, & &1) do
+      :ok
+    else
+      Process.sleep(5)
+      wait_open(gate)
+    end
+  end
+end

--- a/projects/embervm/control/test/embervm/dispatcher_test.exs
+++ b/projects/embervm/control/test/embervm/dispatcher_test.exs
@@ -221,12 +221,18 @@ defmodule Embervm.DispatcherTest do
     ctx = start_stack(assign_fun: gated_assign(gate))
     # cap 4, two active principals -> share = 2 each.
     put_catalog(ctx, "wl-a", cap: 4)
-    put_facts(ctx, "wl-a", live: 0, max: 16)
 
-    # A has 5 tasks, B has 1. With share 2, A is held to 2 in-flight even though 4
-    # slots exist; B takes its 1. So the in-flight split is A:2, B:1 (not A:4).
+    # A has 5 tasks, B has 1. Queue BOTH before granting capacity so both are
+    # active at dispatch time (otherwise A, submitted first, greedily takes the
+    # whole cap while it is the only active principal, share = cap/1). With share
+    # 2, A is held to 2 in-flight even though 4 slots exist; B takes its 1. So the
+    # in-flight split is A:2, B:1 (not A:4).
     for _ <- 1..5, do: submit(ctx, "wl-a", "A")
     submit(ctx, "wl-a", "B")
+    assert eventually(fn -> Dispatcher.stats(ctx.name).queued == 6 end)
+
+    put_facts(ctx, "wl-a", live: 0, max: 16)
+    Dispatcher.sweep(ctx.name)
 
     assert eventually(fn ->
              ifp = Dispatcher.stats(ctx.name).inflight_pr

--- a/projects/embervm/control/test/embervm/dispatcher_test.exs
+++ b/projects/embervm/control/test/embervm/dispatcher_test.exs
@@ -305,6 +305,76 @@ defmodule Embervm.DispatcherTest do
     assert {:ok, []} = TaskStore.list_backlog(ctx.store)
   end
 
+  # -- orphan reclaim (restart / partial commit) -----------------------------
+
+  test "sweep reclaims an orphaned in-flight task with no live worker" do
+    suffix = System.unique_integer([:positive])
+    cap_table = :"ocap_#{suffix}"
+    cat_table = :"ocat_#{suffix}"
+    depth_table = :"odepth_#{suffix}"
+    disp_name = :"odisp_#{suffix}"
+
+    NodeCapacity.create(cap_table)
+    WorkloadCatalog.create(cat_table)
+    path = Path.join(System.tmp_dir!(), "embervm_orphan_#{suffix}.db")
+    on_exit(fn -> File.rm_rf!(path) end)
+
+    {:ok, op_log} = SQLite.start_link(name: nil, path: path)
+    {:ok, store} = TaskStore.start_link(name: nil, op_log: op_log, on_queued: fn t -> Dispatcher.enqueue(disp_name, t) end)
+
+    # A task durably `assigned` from a "previous incarnation": no dispatcher owned
+    # it (the one below starts fresh, so it has no worker tracking it). This models
+    # a dispatcher restart or a partial assign/start commit.
+    {:ok, :created, tid} =
+      TaskStore.submit(store, %{tenant: "t", principal: "p1", workload: "wl-a", request: %{path: "/", headers: %{}, body_b64: Base.encode64("")}})
+
+    {:ok, %{state: :assigned}} = TaskStore.assign(store, tid)
+
+    WorkloadCatalog.upsert(cat_table, "wl-a", %{
+      name: "wl-a",
+      namespace: "embervm",
+      cap: 10,
+      floor: 0,
+      invoke_path: "/",
+      timeout_ms: 5_000,
+      result_ttl_ms: 60_000,
+      result_max_bytes: 1_048_576,
+      retry: %{max_attempts: 3, backoff_ms: 1, backoff_cap_ms: 1, retry_on: [:transport]},
+      triggers: []
+    })
+
+    NodeCapacity.put(cap_table, "node-4", %{
+      node_id: "node-4",
+      configured_id: "node-4",
+      workloads: %{"wl-a" => %{free_primed_slots: 0, snapshot_ref: "snap", base_state: :BASE_BUILD_STATE_READY}},
+      mem_headroom_mib: 4096,
+      cpu_headroom_millicores: 4000,
+      live_vms: 0,
+      max_live_vms: 8,
+      draining: false,
+      updated_at: 1_000_000
+    })
+
+    {:ok, _disp} =
+      Dispatcher.start_link(
+        name: disp_name,
+        task_store: store,
+        capacity_table: cap_table,
+        catalog_table: cat_table,
+        depth_table: depth_table,
+        clock: fn -> 1_000_000 end,
+        channel_fun: fn _ -> {:ok, :ch} end,
+        assign_fun: fn _ch, _req -> {:ok, success_resp()} end,
+        prime_fun: fn _ch, _req -> {:ok, %PrimeResponse{vm_id: "vm-1"}} end,
+        start_sweep: false
+      )
+
+    Dispatcher.sweep(disp_name)
+
+    # Reclaimed: failed as transport -> retried -> re-dispatched -> succeeded.
+    assert eventually(fn -> match?({:ok, %{state: :succeeded}}, TaskStore.get(store, tid)) end)
+  end
+
   # -- failure classification ------------------------------------------------
 
   test "guest 5xx retries through Retry until attempts exhaust, then dead-letters" do

--- a/projects/embervm/control/test/embervm/node_channel_test.exs
+++ b/projects/embervm/control/test/embervm/node_channel_test.exs
@@ -1,0 +1,86 @@
+defmodule Embervm.NodeChannelTest do
+  @moduledoc """
+  `Embervm.NodeChannel` caches one gRPC channel per node and reuses it across
+  the Prime/Assign hot path. A fake `connect_fun` counts dials and returns a
+  distinct sentinel channel per call, so a reuse (one dial for many gets) and an
+  invalidate (a re-dial after a transport error) are both observable. Node ids
+  are unique per test because the channel cache is process-global
+  (persistent_term).
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.NodeChannel
+
+  defp counting_connect do
+    {:ok, agent} = Agent.start_link(fn -> 0 end)
+    connect = fn _addr -> {:ok, {:chan, Agent.get_and_update(agent, fn n -> {n + 1, n + 1} end)}} end
+    {agent, connect}
+  end
+
+  defp node_id, do: "node-test-#{System.unique_integer([:positive])}"
+
+  defp start(node_id, connect) do
+    {:ok, pid} =
+      NodeChannel.start_link(
+        name: nil,
+        nodes: [%{id: node_id, address: "addr"}],
+        connect_fun: connect,
+        disconnect_fun: fn _ -> :ok end
+      )
+
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+    pid
+  end
+
+  test "dials once and caches: repeated gets reuse the channel" do
+    nid = node_id()
+    {dials, connect} = counting_connect()
+    pid = start(nid, connect)
+
+    assert {:ok, chan} = NodeChannel.get(pid, nid)
+    assert {:ok, ^chan} = NodeChannel.get(pid, nid)
+    assert {:ok, ^chan} = NodeChannel.get(pid, nid)
+    assert Agent.get(dials, & &1) == 1
+  end
+
+  test "invalidate drops the channel so the next get re-dials" do
+    nid = node_id()
+    {dials, connect} = counting_connect()
+    pid = start(nid, connect)
+
+    assert {:ok, chan1} = NodeChannel.get(pid, nid)
+    :ok = NodeChannel.invalidate(pid, nid, chan1)
+    # Cast is async; the re-dial happens on the next get, which re-checks the
+    # cache. Poll until the invalidation has been processed.
+    Process.sleep(20)
+
+    assert {:ok, chan2} = NodeChannel.get(pid, nid)
+    assert chan2 != chan1
+    assert Agent.get(dials, & &1) == 2
+  end
+
+  test "a stale invalidate (channel already replaced) is ignored" do
+    nid = node_id()
+    {dials, connect} = counting_connect()
+    pid = start(nid, connect)
+
+    assert {:ok, chan1} = NodeChannel.get(pid, nid)
+    :ok = NodeChannel.invalidate(pid, nid, chan1)
+    Process.sleep(20)
+    assert {:ok, chan2} = NodeChannel.get(pid, nid)
+
+    # Invalidating the OLD channel again must not touch the current one.
+    :ok = NodeChannel.invalidate(pid, nid, chan1)
+    Process.sleep(20)
+    assert {:ok, ^chan2} = NodeChannel.get(pid, nid)
+    assert Agent.get(dials, & &1) == 2
+  end
+
+  test "an unconfigured node id yields :unknown_node" do
+    nid = node_id()
+    {_dials, connect} = counting_connect()
+    pid = start(nid, connect)
+
+    assert {:error, :unknown_node} = NodeChannel.get(pid, "not-configured-#{System.unique_integer([:positive])}")
+  end
+end

--- a/projects/embervm/control/test/embervm/pool_manager_test.exs
+++ b/projects/embervm/control/test/embervm/pool_manager_test.exs
@@ -1,0 +1,182 @@
+defmodule Embervm.PoolManagerTest do
+  @moduledoc """
+  Task 11 acceptance for `Embervm.PoolManager`: floor-first refill, the
+  floor-isolation property (one workload's burst does not drain another's floor),
+  proportional surplus by queue depth, and primedFloorSatisfied status.
+
+  The daemon is faked through `prime_fun` (records which workload each prime is
+  for) and `deposit_fun` (no-op); capacity + catalog + queue-depth are seeded
+  directly in unique ETS tables. Refill is driven synchronously via `refill/1`.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.{NodeCapacity, PoolManager, WorkloadCatalog}
+  alias Embervm.Node.V1.{PrimeRequest, PrimeResponse, Trace}
+
+  defp start_pool(opts \\ []) do
+    suffix = System.unique_integer([:positive])
+    cap_table = :"pcap_#{suffix}"
+    cat_table = :"pcat_#{suffix}"
+    depth_table = :"pdepth_#{suffix}"
+
+    NodeCapacity.create(cap_table)
+    WorkloadCatalog.create(cat_table)
+    :ets.new(depth_table, [:set, :public, :named_table])
+
+    {:ok, primes} = Agent.start_link(fn -> [] end)
+    {:ok, status} = Agent.start_link(fn -> [] end)
+
+    prime_fun = fn _ch, %PrimeRequest{trace: %Trace{workload: wl}} ->
+      Agent.update(primes, &[wl | &1])
+      {:ok, %PrimeResponse{vm_id: "vm-#{System.unique_integer([:positive])}"}}
+    end
+
+    status_writer = fn _ns, name, map ->
+      Agent.update(status, &[{name, map} | &1])
+      :ok
+    end
+
+    {:ok, pool} =
+      PoolManager.start_link(
+        [
+          name: nil,
+          capacity_table: cap_table,
+          catalog_table: cat_table,
+          depth_table: depth_table,
+          clock: fn -> 1_000_000 end,
+          channel_fun: fn _ -> {:ok, :ch} end,
+          prime_fun: prime_fun,
+          deposit_fun: fn _srv, _node, _wl, _vm -> :ok end,
+          status_writer: status_writer,
+          max_concurrent_primes: Keyword.get(opts, :max_concurrent_primes, 100),
+          start_refill: false
+        ]
+      )
+
+    %{pool: pool, cap_table: cap_table, cat_table: cat_table, depth_table: depth_table, primes: primes, status: status}
+  end
+
+  defp put_catalog(ctx, wl, floor) do
+    WorkloadCatalog.upsert(ctx.cat_table, wl, %{name: wl, namespace: "embervm", floor: floor, cap: 100, invoke_path: "/"})
+  end
+
+  defp put_facts(ctx, workloads, opts) do
+    wl_map =
+      for {wl, free} <- workloads, into: %{} do
+        {wl, %{free_primed_slots: free, snapshot_ref: "snap-#{wl}", base_state: :BASE_BUILD_STATE_READY}}
+      end
+
+    NodeCapacity.put(ctx.cap_table, "node-4", %{
+      node_id: "node-4",
+      configured_id: "node-4",
+      workloads: wl_map,
+      mem_headroom_mib: 8192,
+      cpu_headroom_millicores: 8000,
+      live_vms: Keyword.get(opts, :live, 0),
+      max_live_vms: Keyword.fetch!(opts, :max),
+      draining: false,
+      updated_at: 1_000_000
+    })
+  end
+
+  defp set_depth(ctx, wl, n), do: :ets.insert(ctx.depth_table, {{wl, "p"}, n})
+
+  defp prime_counts(ctx) do
+    Process.sleep(50)
+    ctx.primes |> Agent.get(& &1) |> Enum.frequencies()
+  end
+
+  test "floor-first: primes each workload up to its floor" do
+    ctx = start_pool()
+    put_catalog(ctx, "wl-a", 2)
+    put_catalog(ctx, "wl-b", 3)
+    put_facts(ctx, %{"wl-a" => 0, "wl-b" => 0}, max: 20)
+
+    :ok = PoolManager.refill(ctx.pool)
+
+    counts = prime_counts(ctx)
+    assert counts["wl-a"] == 2
+    assert counts["wl-b"] == 3
+  end
+
+  test "floor isolation: a burst workload does not drain another workload's floor" do
+    ctx = start_pool()
+    put_catalog(ctx, "wl-a", 2)
+    put_catalog(ctx, "wl-b", 2)
+    # Budget exactly funds both floors (2 + 2). wl-a has a huge queue-depth burst.
+    put_facts(ctx, %{"wl-a" => 0, "wl-b" => 0}, max: 4)
+    set_depth(ctx, "wl-a", 500)
+    set_depth(ctx, "wl-b", 0)
+
+    :ok = PoolManager.refill(ctx.pool)
+
+    counts = prime_counts(ctx)
+    # wl-b keeps its full floor of 2; wl-a's burst does NOT push it past its floor
+    # into wl-b's budget (surplus runs only after every floor is funded).
+    assert counts["wl-a"] == 2
+    assert counts["wl-b"] == 2
+  end
+
+  test "surplus is proportional to queue depth, after floors" do
+    ctx = start_pool()
+    put_catalog(ctx, "wl-a", 2)
+    put_catalog(ctx, "wl-b", 2)
+    # Budget 6 = both floors (4) + 2 surplus. Only wl-a has queue depth.
+    put_facts(ctx, %{"wl-a" => 0, "wl-b" => 0}, max: 6)
+    set_depth(ctx, "wl-a", 50)
+    set_depth(ctx, "wl-b", 0)
+
+    :ok = PoolManager.refill(ctx.pool)
+
+    counts = prime_counts(ctx)
+    # Floors first (a:2, b:2), then both surplus VMs go to wl-a (the only depth).
+    assert counts["wl-a"] == 4
+    assert counts["wl-b"] == 2
+  end
+
+  test "does not prime when the floor is already satisfied" do
+    ctx = start_pool()
+    put_catalog(ctx, "wl-a", 2)
+    put_facts(ctx, %{"wl-a" => 2}, max: 10)
+
+    :ok = PoolManager.refill(ctx.pool)
+
+    assert prime_counts(ctx) == %{}
+  end
+
+  test "writes primedFloorSatisfied, only on a flip" do
+    ctx = start_pool()
+    put_catalog(ctx, "wl-a", 2)
+    put_facts(ctx, %{"wl-a" => 2}, max: 10)
+
+    :ok = PoolManager.refill(ctx.pool)
+    Process.sleep(20)
+    writes1 = Agent.get(ctx.status, & &1)
+    assert Enum.any?(writes1, fn {name, map} -> name == "wl-a" and map["primedFloorSatisfied"] == true end)
+
+    # A second refill with the same (satisfied) state writes nothing new.
+    :ok = PoolManager.refill(ctx.pool)
+    Process.sleep(20)
+    assert Agent.get(ctx.status, & &1) == writes1
+  end
+
+  test "stale or draining capacity is not refilled (fail-closed)" do
+    ctx = start_pool()
+    put_catalog(ctx, "wl-a", 2)
+
+    NodeCapacity.put(ctx.cap_table, "node-4", %{
+      node_id: "node-4",
+      configured_id: "node-4",
+      workloads: %{"wl-a" => %{free_primed_slots: 0, snapshot_ref: "snap", base_state: :BASE_BUILD_STATE_READY}},
+      mem_headroom_mib: 8192,
+      cpu_headroom_millicores: 8000,
+      live_vms: 0,
+      max_live_vms: 10,
+      draining: false,
+      updated_at: 1_000_000 - 30_000
+    })
+
+    :ok = PoolManager.refill(ctx.pool)
+    assert prime_counts(ctx) == %{}
+  end
+end

--- a/projects/embervm/control/test/embervm/task_store_test.exs
+++ b/projects/embervm/control/test/embervm/task_store_test.exs
@@ -25,9 +25,13 @@ defmodule Embervm.TaskStoreTest do
 
     id_fun = Keyword.get(opts, :id_fun, sequential_id_fun())
     clock = Keyword.get(opts, :clock, sequential_clock())
+    # Default the on_queued hook to a no-op so an unnamed test store never casts
+    # into the application's supervised (global) dispatcher; tests that assert on
+    # the hook inject their own.
+    on_queued = Keyword.get(opts, :on_queued, fn _ -> :ok end)
 
     {:ok, store} =
-      TaskStore.start_link(op_log: op_log, name: nil, id_fun: id_fun, clock: clock)
+      TaskStore.start_link(op_log: op_log, name: nil, id_fun: id_fun, clock: clock, on_queued: on_queued)
 
     {op_log, store}
   end
@@ -341,5 +345,93 @@ defmodule Embervm.TaskStoreTest do
     {:ok, ets_task} = TaskStore.get(store, task_id)
     assert ets_task.state == :dead_lettered
     assert ets_task.attempt == 1
+  end
+
+  # -- Task 11 dispatcher seams ----------------------------------------------
+
+  test "get_request returns the guest-request envelope stored in the submitted op", %{path: path} do
+    {_op_log, store} = start_pair(path)
+
+    request = %{path: "/run", headers: %{"x-a" => "1"}, body_b64: Base.encode64("hi"), content_type: "application/json"}
+
+    {:ok, :created, task_id} =
+      TaskStore.submit(store, %{tenant: "t1", principal: "p1", workload: "wl-a", request: request})
+
+    assert {:ok, env} = TaskStore.get_request(store, task_id)
+    # JSON round-trips atom keys to strings.
+    assert env["path"] == "/run"
+    assert env["headers"] == %{"x-a" => "1"}
+    assert env["body_b64"] == Base.encode64("hi")
+    assert env["content_type"] == "application/json"
+
+    assert {:ok, nil} = TaskStore.get_request(store, "no-such-task")
+  end
+
+  test "list_backlog returns queued and failed_retryable tasks only", %{path: path} do
+    # max_attempts 3 so the first transport failure is retryable (not dead-lettered).
+    {_op_log, store} = start_pair(path)
+
+    {:ok, :created, queued_id} =
+      TaskStore.submit(store, %{tenant: "t1", principal: "p1", workload: "wl-a"})
+
+    {:ok, :created, retry_id} =
+      TaskStore.submit(store, %{tenant: "t1", principal: "p2", workload: "wl-a"})
+
+    {:ok, :created, done_id} =
+      TaskStore.submit(store, %{tenant: "t1", principal: "p3", workload: "wl-a"})
+
+    # retry_id -> failed_retryable; done_id -> succeeded (excluded).
+    {:ok, _} = TaskStore.assign(store, retry_id)
+    {:ok, %{state: :failed_retryable}, _backoff} = TaskStore.fail(store, retry_id, :transport)
+
+    {:ok, _} = TaskStore.assign(store, done_id)
+    {:ok, _} = TaskStore.start(store, done_id)
+    {:ok, _} = TaskStore.succeed(store, done_id, %{status_code: 200, body: "", size_bytes: 0})
+
+    {:ok, backlog} = TaskStore.list_backlog(store)
+    ids = backlog |> Enum.map(& &1.task_id) |> Enum.sort()
+    assert ids == Enum.sort([queued_id, retry_id])
+    assert Enum.find(backlog, &(&1.task_id == retry_id)).state == :failed_retryable
+    assert Enum.find(backlog, &(&1.task_id == queued_id)).state == :queued
+  end
+
+  test "on_queued hook fires on submit-created, retry, and redrive", %{path: path} do
+    test_pid = self()
+    hook = fn %{task_id: tid, workload: wl, principal: pr} -> send(test_pid, {:queued, tid, wl, pr}) end
+
+    # wl_def is left uncataloged (cfg_for falls back to default_config, where
+    # transport is retryable at 3 attempts); wl_dlq is cataloged with
+    # max_attempts 1 so one failure dead-letters, reaching the redrive path.
+    # Unique names keep this async-safe against the shared global catalog table.
+    suffix = System.unique_integer([:positive])
+    wl_def = "wl-def-#{suffix}"
+    wl_dlq = "wl-dlq-#{suffix}"
+    default_table = WorkloadCatalog.table()
+    WorkloadCatalog.upsert(default_table, wl_dlq, %{name: wl_dlq, retry: %{max_attempts: 1, backoff_ms: 1, backoff_cap_ms: 1, retry_on: [:transport]}})
+    on_exit(fn -> WorkloadCatalog.drop(default_table, wl_dlq) end)
+
+    {_op_log, store} = start_pair(path, on_queued: hook)
+
+    # 1. submit-created fires the hook.
+    {:ok, :created, retry_id} =
+      TaskStore.submit(store, %{tenant: "t1", principal: "p1", workload: wl_def})
+
+    assert_receive {:queued, ^retry_id, ^wl_def, "p1"}
+
+    # 2. retry (failed_retryable -> queued) fires the hook.
+    {:ok, _} = TaskStore.assign(store, retry_id)
+    {:ok, %{state: :failed_retryable}, _backoff} = TaskStore.fail(store, retry_id, :transport)
+    {:ok, %{state: :queued}} = TaskStore.retry(store, retry_id)
+    assert_receive {:queued, ^retry_id, ^wl_def, "p1"}
+
+    # 3. redrive (dead_lettered -> queued) fires the hook.
+    {:ok, :created, dlq_id} =
+      TaskStore.submit(store, %{tenant: "t1", principal: "p2", workload: wl_dlq})
+
+    assert_receive {:queued, ^dlq_id, ^wl_dlq, "p2"}
+    {:ok, _} = TaskStore.assign(store, dlq_id)
+    {:ok, %{state: :dead_lettered}} = TaskStore.fail(store, dlq_id, :transport)
+    {:ok, %{state: :queued}} = TaskStore.redrive(store, dlq_id)
+    assert_receive {:queued, ^dlq_id, ^wl_dlq, "p2"}
   end
 end

--- a/projects/embervm/control/test/embervm/trigger/cron_test.exs
+++ b/projects/embervm/control/test/embervm/trigger/cron_test.exs
@@ -1,0 +1,104 @@
+defmodule Embervm.Trigger.CronTest do
+  @moduledoc """
+  Acceptance for the cron `Embervm.TriggerAdapter`: a due trigger fires as an
+  ordinary submit with a `system:cron:<workload>` principal, and a misfire during
+  downtime is skipped (next-fire is always forward from now). The clock and the
+  submit sink are injected so the whole fire path is deterministic.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.Trigger.Cron, as: CronTrigger
+  alias Embervm.WorkloadCatalog
+
+  defp dt(h, mi, s), do: DateTime.new!(Date.new!(2026, 7, 13), Time.new!(h, mi, s), "Etc/UTC")
+
+  # A settable clock: reconcile/tick read whatever the agent currently holds.
+  defp clock_agent(initial) do
+    {:ok, agent} = Agent.start_link(fn -> initial end)
+    {agent, fn -> Agent.get(agent, & &1) end}
+  end
+
+  defp set_clock(agent, dt), do: Agent.update(agent, fn _ -> dt end)
+
+  defp recorder do
+    {:ok, agent} = Agent.start_link(fn -> [] end)
+    submit = fn attrs -> Agent.update(agent, &[attrs | &1]) end
+    {agent, submit}
+  end
+
+  defp catalog_with_trigger(cron_expr, payload) do
+    table = WorkloadCatalog.table()
+    wl = "wl-cron-#{System.unique_integer([:positive])}"
+
+    WorkloadCatalog.upsert(table, wl, %{
+      name: wl,
+      namespace: "embervm",
+      invoke_path: "/run",
+      triggers: [%{cron: cron_expr, payload: payload}]
+    })
+
+    on_exit(fn -> WorkloadCatalog.drop(table, wl) end)
+    {table, wl}
+  end
+
+  test "a due trigger fires a submit with the system:cron principal and JSON body" do
+    {table, wl} = catalog_with_trigger("*/1 * * * *", %{"foo" => "bar"})
+    {clock_a, clock} = clock_agent(dt(10, 0, 30))
+    {rec, submit} = recorder()
+
+    {:ok, cron} =
+      CronTrigger.start_link(
+        name: nil,
+        catalog_table: table,
+        clock: clock,
+        submit_fun: submit,
+        start_ticking: false
+      )
+
+    :ok = CronTrigger.reconcile(cron)
+
+    # Not yet due at 10:00:45 (next fire is 10:01:00).
+    set_clock(clock_a, dt(10, 0, 45))
+    assert {:ok, 0} = CronTrigger.tick(cron)
+    assert Agent.get(rec, & &1) == []
+
+    # Due at 10:01:30.
+    set_clock(clock_a, dt(10, 1, 30))
+    assert {:ok, 1} = CronTrigger.tick(cron)
+
+    [attrs] = Agent.get(rec, & &1)
+    assert attrs.principal == "system:cron:" <> wl
+    assert attrs.workload == wl
+    assert attrs.request.path == "/run"
+    body = Base.decode64!(attrs.request.body_b64)
+    assert body =~ "foo"
+  end
+
+  test "misfires during downtime are skipped, not replayed" do
+    # Start the clock well past several would-be fires; reconcile computes the
+    # next fire FORWARD from now, so the missed ticks are never scheduled.
+    {table, _wl} = catalog_with_trigger("*/1 * * * *", nil)
+    {clock_a, clock} = clock_agent(dt(10, 0, 30))
+    {rec, submit} = recorder()
+
+    {:ok, cron} =
+      CronTrigger.start_link(
+        name: nil,
+        catalog_table: table,
+        clock: clock,
+        submit_fun: submit,
+        start_ticking: false
+      )
+
+    :ok = CronTrigger.reconcile(cron)
+
+    # Jump the clock forward by an hour without ticking (simulated downtime).
+    # Only the ONE next-fire scheduled at reconcile is pending, so a single tick
+    # fires exactly once, not 60 times for the skipped minutes (skipped, not
+    # replayed), and recomputes the next fire forward from now.
+    set_clock(clock_a, dt(11, 0, 30))
+    assert {:ok, fired} = CronTrigger.tick(cron)
+    assert fired == 1
+    assert length(Agent.get(rec, & &1)) == 1
+  end
+end

--- a/projects/embervm/control/test/embervm/workload_watcher_test.exs
+++ b/projects/embervm/control/test/embervm/workload_watcher_test.exs
@@ -130,12 +130,13 @@ defmodule Embervm.WorkloadWatcherTest do
     assert entry.retry.max_attempts == 5
     assert entry.retry.retry_on == [:transport, :timeout, :guest5xx]
 
-    # The watcher writes ONLY its own keys for a valid CR: observedGeneration and
-    # primedFloorSatisfied, and crucially NOT conditions (the BaseBuilder owns
-    # Ready/BaseBuilt, so the two merge-patches never clobber each other).
+    # The watcher writes ONLY its own key for a valid CR: observedGeneration.
+    # It does NOT write conditions (the BaseBuilder owns Ready/BaseBuilt) nor
+    # primedFloorSatisfied (the PoolManager owns it, Task 11), so the three
+    # writers' merge-patches never clobber each other.
     assert {_ns, "semgrep", status_map} = ready_status(recorded_calls(agent), "semgrep")
     assert status_map["observedGeneration"] == 1
-    assert status_map["primedFloorSatisfied"] == false
+    refute Map.has_key?(status_map, "primedFloorSatisfied")
     refute Map.has_key?(status_map, "conditions")
 
     # The build trigger fired with the base-shaping fields.

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.12
+      targetRevision: 0.1.13
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
R0 Task 11, the heart of the EmberVM control plane: flips `submit` from async-only (tasks sit `queued`) to actually **draining**. A queued task now becomes an `Assign` against a primed VM and is driven to a terminal state.

## What lands

- **`Embervm.Dispatcher`** (the hot path, single writer): per-workload fair queues (round-robin across principals, FIFO within; weights are a parameter via a deficit counter, not a redesign), a primed-VM inventory that IS the destroy-on-assign accounting (a vm_id is single-use, removed the instant it is committed), and fail-closed enforcement:
  - per-workload `cap` on in-flight tasks;
  - per-principal **share cap** (`cap / active_principals`, min 1, or a values-configured fraction) so no principal starves the others;
  - per-principal **queue-depth 429 gate** (synchronous `admit?` pre-check in the router; the FSM has no `queued -> fail` edge, so a queued task is never dropped after the fact);
  - missing or **stale (>15s)** capacity, or no ready base, deny with a **distinct kind** (`:stale_capacity` / `:no_capacity` / `:cap` / `:principal_share`), tallied for the Task 16 gates.
  - All Prime/Assign I/O runs in `spawn_monitor` workers, so a 500ms miss-path restore never head-of-line-blocks warm dispatch. Failures classify through the existing `Retry` policy; the dispatcher owns retry scheduling plus a boot + periodic backlog sweep (crash recovery and node-down `reassign_in_flight`).
- **`Embervm.PoolManager`**: background refill keeping `floor` VMs primed per workload, **floor-first then proportional to queue depth**, so one workload's burst cannot drain another's floor (property-tested). Owns `status.primedFloorSatisfied`.
- **`Embervm.NodeChannel`**: one persistent, reused gRPC channel per node for the hot Assign path (cached in `persistent_term`, invalidate-on-transport-error), decided over BaseBuilder's per-call connect for the 25ms warm budget.
- **`Embervm.TriggerAdapter` behaviour + `Embervm.Trigger.Cron` + `Embervm.Cron`**: fires `spec.triggers[].cron` as ordinary submits (`system:cron:<workload>`); misfires during downtime are skipped, not replayed. Cron is a dependency-free 5-field parser (keeps the hermetic hex closure untouched).
- **`TaskStore`** gains `get_request/2` (rebuilds the `AssignRequest` from the op-log at dispatch time, keeping bodies out of the hot set), `list_backlog/1` (sweep source), and an `on_queued` hook. **`WorkloadWatcher`** parses `spec.triggers` and hands `primedFloorSatisfied` ownership to the pool (disjoint-key status split).

## Decisions (confirmed with Joe)

- **Persistent per-node channel** for the Assign hot path.
- **noded bearer-token auth deferred** (documented): the daemon has no real capability in R0 (empty `EMBERVM_NODED_IMAGES`), and enabling it is a deploy-only-verifiable cross-cutting change better landed with guest-image provisioning (Task 14).
- **Two GenServers** (pool vs dispatch) split.

## Tests

ExUnit acceptance: fairness property (RR across principals, FIFO within), floor-isolation property, cap + fail-closed denial tests, cron fire with clock injection, and a fake-daemon 1k-task drain with zero lost. Plus `NodeChannel`, `Cron`, and the new `TaskStore` seams.

## Verification note

`EMBERVM_NODED_IMAGES` is empty in R0, so no real Prime/Assign succeeds yet (no base to restore). Live verification is limited to the dispatcher wiring up and correctly denying/queueing against the empty-capacity node, plus the fake-daemon ExUnit drain. No real task runs end to end until guest images land (Task 14).

Chart bumped 0.1.12 -> 0.1.13 (new prod modules change the release digest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)