### PR TITLE
feat(embervm): live python sandbox microVM (Task 14a)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -86,7 +86,50 @@ Deviations here are intentional. Bugs are not deviations; they get fixed.
   accepts a bare `:forbidden` (principal unknown) for reviewers/fakes that do not
   surface it.
 
-### D12 known gaps accepted for R0 (documented, not fixed)
+## Task 14a: first live sandbox VM (chart 0.1.15)
+
+The plan's Task 14 lands semgrep + sandbox side-by-side with node-4 rebalancing.
+This is split: Task 14a gets ONE real python-sandbox microVM running end to end
+(the headline: prove EmberVM boots a real Firecracker VM through the controller),
+Task 14b does semgrep + the fc-invoke concurrency rebalance + finding-equality.
+
+### D14a.1 Split Task 14 into 14a (live sandbox) and 14b (full side-by-side)
+- **Why:** the gating risk is the first real Assign (rootfs provisioning, FC cold
+  boot, snapshot, vsock), not breadth. Getting one sandbox VM live de-risks the
+  whole chain with the smallest surface; semgrep + rebalancing is mechanical once
+  it works. 14a keeps a small footprint (floor 1, cap 4) that fits node-4's
+  headroom WITHOUT touching fc-invoke, so no coexistence-budget change is needed
+  yet (14b does the 16->8 fc-invoke halving for the full-cap run).
+
+### D14a.2 noded rootfs provisioning ported from fc-invoke (was missing)
+- noded had a complete Firecracker driver but NO rootfs provisioning: `EMBERVM_
+  NODED_IMAGES` pointed at a pre-baked ext4 that nothing produced. Added a
+  rootfs-builder initContainer + ConfigMap (crane export + mkfs.ext4 onto the
+  nvme scratch), ported from the proven fc-invoke pattern, reusing fc-invoke's
+  rootfs-builder tool image. Idempotent via a `.guest-ref` marker.
+
+### D14a.3 EMBERVM_NODED_IMAGES is DERIVED, not a hand-maintained map
+- The guest image_ref must match in three places (rootfs-builder GUEST_IMAGE, the
+  noded image table key, the Workload CR source.image.ref) or BuildBase fails
+  FAILED_PRECONDITION. Rather than hand-sync a static `noded.images` map key to
+  the Bazel-pinned ref, the deployment DERIVES the table from `noded.workloads` +
+  each workload's `noded.<name>.guestImage`, so one pinned value flows to all
+  three consumers. Explicit `noded.images` entries still merge as overrides.
+
+### D14a.4 Guest image digest-pinned via Bazel, contract frozen
+- `noded.sandbox.guestImage` and `noded.rootfsBuilder.image` are pinned by
+  `helm_chart(images=)` from the fc-invoke guests' public `.info` providers (zero
+  image changes, per the plan). The sandbox guest contract is used verbatim: vsock
+  port 1027, `/shim/ready`, one python snippet per `/invoke`, `sandbox-guest-init`.
+
+### D14a.5 Live-verify, not CI-verify
+- CI cannot run a real VM (no KVM in RBE). 14a is verified live AFTER merge+sync:
+  the init container bakes the ext4, the Workload goes Ready with a snapshotRef
+  (BaseBuilder cold-booted + snapshotted a real VM), the PoolManager primes a
+  floor VM, and a `/invoke` submit runs python end to end. Recorded here as the
+  acceptance evidence once observed.
+
+## D12 known gaps accepted for R0 (documented, not fixed)
 - The `usage` projection ACCUMULATES (the only projection that does), so it is not
   idempotent under op replay (the future `read_from` replica path); safe today
   because R0 projects each op exactly once. Commented at the projection.

--- a/projects/embervm/chart/BUILD
+++ b/projects/embervm/chart/BUILD
@@ -8,6 +8,13 @@ helm_chart(
     images = {
         "image": "//projects/embervm/image:image.info",
         "noded.image": "//projects/embervm/noded/image:image.info",
+        # Task 14: the frozen fc-invoke sandbox guest image (baked into a base
+        # rootfs by the noded rootfs-builder) and the rootfs-builder tool image,
+        # digest-pinned from their .info providers so the guest contract is
+        # unchanged. Their .info targets are public (apko_image), so cross-project
+        # references are allowed.
+        "noded.sandbox.guestImage": "//projects/firecracker/sandbox/guest:image.info",
+        "noded.rootfsBuilder.image": "//projects/firecracker/substrate/rootfs-builder:image.info",
     },
     publish = True,
     visibility = ["//overlays:__subpackages__"],

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.14
+version: 0.1.15

--- a/projects/embervm/chart/templates/noded-deployment.yaml
+++ b/projects/embervm/chart/templates/noded-deployment.yaml
@@ -42,6 +42,54 @@ spec:
       securityContext:
         runAsUser: 0
         runAsGroup: 0
+      {{- if .Values.noded.workloads }}
+      # Build each workload's base rootfs in-cluster from its pinned guest image
+      # (crane export + mkfs.ext4 onto the nvme scratch), so node-4 never needs a
+      # manual sudo rootfs placement. One builder per workload that declares a
+      # `noded.<name>.guestImage` block (Bazel pins its repository:tag from the
+      # guest image's .info provider); the builder bakes that guest's filesystem
+      # into the workload's rootfsPath. Idempotent (a marker skips the multi-GB
+      # rebuild when the guest ref is unchanged). Mirrors the fc-invoke pattern.
+      initContainers:
+        {{- range $name, $wl := .Values.noded.workloads }}
+        {{- $top := index $.Values.noded $name }}
+        {{- if and $top $top.guestImage $top.guestImage.repository }}
+        - name: build-{{ $name }}-rootfs
+          image: "{{ $.Values.noded.rootfsBuilder.image.repository }}:{{ $.Values.noded.rootfsBuilder.image.tag }}"
+          command: ["/bin/bash", "/scripts/build-base-rootfs.sh"]
+          env:
+            - name: GUEST_IMAGE
+              value: "{{ $top.guestImage.repository }}:{{ $top.guestImage.tag }}"
+            - name: BASE_ROOTFS_PATH
+              value: {{ $wl.rootfsPath | quote }}
+            - name: ROOTFS_SIZE
+              value: {{ $.Values.noded.rootfsBuilder.rootfsSize | quote }}
+            {{- if $.Values.imagePullSecret.enabled }}
+            - name: DOCKER_CONFIG
+              value: /ghcr
+            {{- end }}
+          volumeMounts:
+            - name: nvme
+              mountPath: {{ $.Values.noded.firecracker.nvmeRoot }}
+            - name: rootfs-builder-script
+              mountPath: /scripts
+              readOnly: true
+            - name: rootfs-builder-work
+              mountPath: /work
+            {{- if $.Values.imagePullSecret.enabled }}
+            - name: ghcr-creds
+              mountPath: /ghcr
+              readOnly: true
+            {{- end }}
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              memory: 512Mi
+        {{- end }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: noded
           image: "{{ .Values.noded.image.repository }}:{{ .Values.noded.image.tag }}"
@@ -84,11 +132,22 @@ spec:
             {{- end }}
             - name: EMBERVM_NODED_DRAIN_TIMEOUT
               value: "{{ .Values.noded.drain.timeoutSeconds }}s"
-            # Node-side image identity table (image_ref -> rootfsPath[,harnessInit]),
-            # rendered as JSON. Empty until the control plane provisions guest images
-            # (Task 11+); BuildBase for an unknown image fails FAILED_PRECONDITION.
+            # Node-side image identity table (image_ref -> {rootfsPath, harnessInit}),
+            # rendered as JSON. Derived from noded.workloads + each workload's pinned
+            # guestImage so the ref here MATCHES the rootfs-builder GUEST_IMAGE and the
+            # Workload CR's source.image.ref exactly (BuildBase looks this map up by
+            # that ref; a mismatch fails FAILED_PRECONDITION). Explicit noded.images
+            # entries merge in as overrides. Empty (no workloads) => BuildBase denies.
             - name: EMBERVM_NODED_IMAGES
-              value: {{ .Values.noded.images | toJson | quote }}
+              {{- $imgs := deepCopy (.Values.noded.images | default dict) }}
+              {{- range $name, $wl := .Values.noded.workloads }}
+              {{- $top := index $.Values.noded $name }}
+              {{- if and $top $top.guestImage $top.guestImage.repository }}
+              {{- $ref := printf "%s:%s" $top.guestImage.repository $top.guestImage.tag }}
+              {{- $_ := set $imgs $ref (dict "rootfsPath" $wl.rootfsPath "harnessInit" $wl.harnessInit) }}
+              {{- end }}
+              {{- end }}
+              value: {{ $imgs | toJson | quote }}
             {{- if .Values.noded.bearerTokenSecret.enabled }}
             # Static bearer token gating the gRPC surface. When unset the daemon
             # runs open and warns; a Cilium/Linkerd policy is defence-in-depth.
@@ -126,4 +185,20 @@ spec:
           hostPath:
             path: {{ .Values.noded.firecracker.nvmeRoot }}
             type: Directory
+        {{- if .Values.noded.workloads }}
+        - name: rootfs-builder-script
+          configMap:
+            name: {{ include "embervm.noded.fullname" . }}-rootfs-builder
+            defaultMode: 0755
+        - name: rootfs-builder-work
+          emptyDir: {}
+        {{- if .Values.imagePullSecret.enabled }}
+        - name: ghcr-creds
+          secret:
+            secretName: {{ .Values.imagePullSecret.name }}
+            items:
+              - key: .dockerconfigjson
+                path: config.json
+        {{- end }}
+        {{- end }}
 {{- end }}

--- a/projects/embervm/chart/templates/noded-rootfs-builder-configmap.yaml
+++ b/projects/embervm/chart/templates/noded-rootfs-builder-configmap.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.noded.workloads }}
+# Build script for the noded base-rootfs initContainers (Task 14). Kept in a
+# ConfigMap so it can be tuned without rebuilding the tools image. Each
+# per-workload rootfs-builder initContainer (see the range in
+# noded-deployment.yaml) runs this same script with its own GUEST_IMAGE and
+# BASE_ROOTFS_PATH, baking the guest filesystem into a read-only ext4 image the
+# workload's microVMs boot from. Ported from the fc-invoke rootfs-builder.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "embervm.noded.fullname" . }}-rootfs-builder
+  labels:
+    {{- include "embervm.noded.labels" . | nindent 4 }}
+data:
+  build-base-rootfs.sh: |
+    #!/bin/bash
+    # crane exports the guest filesystem for this node's architecture and
+    # mkfs.ext4 bakes it into an ext4 image on the mounted nvme disk, so no human
+    # on node-4 with sudo is needed to place a rootfs.
+    set -euo pipefail
+    : "${GUEST_IMAGE:?GUEST_IMAGE required}"
+    : "${BASE_ROOTFS_PATH:?BASE_ROOTFS_PATH required}"
+    size="${ROOTFS_SIZE:-2G}"
+    base_dir="$(dirname "$BASE_ROOTFS_PATH")"
+    marker="$base_dir/.guest-ref"
+    mkdir -p "$base_dir"
+    # Idempotent: skip the multi-GB rebuild when the base already matches the
+    # deployed guest image (pod restarts with an unchanged image are common).
+    if [ -f "$BASE_ROOTFS_PATH" ] && [ -f "$marker" ] && [ "$(cat "$marker")" = "$GUEST_IMAGE" ]; then
+      echo "base rootfs already current for $GUEST_IMAGE"
+      exit 0
+    fi
+    echo "building base rootfs from $GUEST_IMAGE"
+    rm -rf /work/root "$BASE_ROOTFS_PATH.tmp"
+    mkdir -p /work/root
+    # Pull the guest filesystem for THIS node's architecture (the builder image
+    # is multi-arch, so uname reflects the node); guest images are multi-arch.
+    case "$(uname -m)" in
+      x86_64) platform=linux/amd64 ;;
+      aarch64 | arm64) platform=linux/arm64 ;;
+      *) echo "unsupported arch $(uname -m)" >&2; exit 1 ;;
+    esac
+    crane export --platform "$platform" "$GUEST_IMAGE" - | tar -x -C /work/root
+    mkfs.ext4 -q -F -L embervmbase -d /work/root "$BASE_ROOTFS_PATH.tmp" "$size"
+    mv -f "$BASE_ROOTFS_PATH.tmp" "$BASE_ROOTFS_PATH"
+    echo "$GUEST_IMAGE" > "$marker"
+    echo "base rootfs built at $BASE_ROOTFS_PATH ($size)"
+{{- end }}

--- a/projects/embervm/chart/templates/workload-sandbox.yaml
+++ b/projects/embervm/chart/templates/workload-sandbox.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.sandboxWorkload.enabled }}
+# The first REAL EmberVM workload (Task 14): the python sandbox. Its guest image
+# ref is the SAME Bazel-pinned value the noded rootfs-builder bakes and
+# EMBERVM_NODED_IMAGES keys on, so BaseBuilder's BuildBase(ref) resolves on the
+# node. On admission the control plane cold-boots one VM from the baked rootfs,
+# snapshots it as the base (status.snapshotRef), the PoolManager primes `floor`
+# VMs, and a submit drives an Assign that runs one python snippet in a microVM.
+apiVersion: embervm.dev/v1alpha1
+kind: Workload
+metadata:
+  name: {{ .Values.sandboxWorkload.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # Apply after the CRD (wave 0) establishes, like the sample workload.
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  class: task
+  source:
+    image:
+      # Must match noded.sandbox.guestImage exactly (see noded-deployment.yaml).
+      ref: "{{ .Values.noded.sandbox.guestImage.repository }}:{{ .Values.noded.sandbox.guestImage.tag }}"
+      port: {{ .Values.sandboxWorkload.port }}
+      readyPath: {{ .Values.sandboxWorkload.readyPath | quote }}
+      invokePath: {{ .Values.sandboxWorkload.invokePath | quote }}
+  resources:
+    vcpus: {{ .Values.sandboxWorkload.vcpus }}
+    memMib: {{ .Values.sandboxWorkload.memMib }}
+  concurrency:
+    floor: {{ .Values.sandboxWorkload.floor }}
+    cap: {{ .Values.sandboxWorkload.cap }}
+  invocation:
+    timeoutSeconds: {{ .Values.sandboxWorkload.timeoutSeconds }}
+{{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -123,6 +123,29 @@ sampleWorkload:
   enabled: true
   name: echo
 
+# The first REAL EmberVM workload (Task 14): the python sandbox. A task-class
+# Workload whose guest image is baked into a base rootfs by the noded
+# rootfs-builder and cold-booted into a base snapshot on admission. See
+# templates/workload-sandbox.yaml. The image ref is sourced from
+# noded.sandbox.guestImage so it matches the rootfs-builder + node image table.
+sandboxWorkload:
+  enabled: true
+  name: sandbox
+  # The sandbox guest shim contract (projects/firecracker/sandbox): HTTP over
+  # vsock port 1027, ready at /shim/ready, one python snippet per /invoke.
+  port: 1027
+  readyPath: /shim/ready
+  invokePath: /invoke
+  vcpus: 1
+  memMib: 512
+  # Small footprint for the first live workload: a warm floor of 1 exercises the
+  # full base-build -> prime -> assign path; cap 4 bounds it well inside node-4's
+  # headroom alongside fc-invoke. Task 14b raises this and adds semgrep + the
+  # node-4 rebalancing for the full side-by-side.
+  floor: 1
+  cap: 4
+  timeoutSeconds: 30
+
 # embervm-noded: the node daemon (gRPC NodeService) that owns Firecracker microVM
 # lifecycle on node-4. A SECOND Deployment in this chart, privileged and node-
 # pinned, forked from the fc-invoke node layer (ADR embervm/001). It coexists with
@@ -171,10 +194,39 @@ noded:
     # guest path is a tmpfs, so one read-only rootfs file backs every microVM.
     kernelBootArgs: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda ro"
 
-  # Node-side image identity table (image_ref -> {rootfsPath[, harnessInit]}),
-  # rendered to EMBERVM_NODED_IMAGES. Empty until the control plane provisions
-  # guest images (Task 11+); BuildBase for an unknown image fails FAILED_PRECONDITION.
+  # Explicit node-side image identity overrides (image_ref -> {rootfsPath,
+  # harnessInit}). Normally empty: the table is DERIVED from noded.workloads +
+  # each workload's guestImage (see noded-deployment.yaml), so the ref matches the
+  # rootfs-builder and the Workload CR automatically. Entries here merge on top.
   images: {}
+
+  # The rootfs-builder tool image (crane + e2fsprogs + bash) that bakes each
+  # workload's guest OCI image into an ext4 base rootfs at pod init. Reuses the
+  # fc-invoke rootfs-builder image; Bazel pins repository:tag from its .info.
+  rootfsBuilder:
+    image:
+      repository: ghcr.io/jomcgi/homelab/projects/firecracker/substrate/rootfs-builder
+      tag: latest
+    # The sandbox base is small (python + libs); 2G leaves ample slack.
+    rootfsSize: 2G
+
+  # The python sandbox guest image, Bazel-pinned (helm_chart images=) from the
+  # frozen fc-invoke sandbox guest's .info provider, so the guest contract is
+  # unchanged (zero image changes, per the R0 plan). Consumed by the sandbox
+  # rootfs-builder init container and the sandbox Workload CR.
+  sandbox:
+    guestImage:
+      repository: ghcr.io/jomcgi/homelab/projects/firecracker/sandbox/guest
+      tag: latest
+
+  # Per-workload rootfs targets on the nvme scratch. The rootfs-builder writes
+  # each guest's ext4 here and EMBERVM_NODED_IMAGES maps the guest ref to it.
+  # Adding a workload here (with a matching noded.<name>.guestImage) provisions
+  # its base and enables an initContainer that bakes it.
+  workloads:
+    sandbox:
+      rootfsPath: /disks/nvme-02/embervm-noded/sandbox/rootfs.ext4
+      harnessInit: /usr/local/bin/sandbox-guest-init
 
   # Graceful-drain budget: on SIGTERM the daemon waits up to this long for in-
   # flight Assigns before exiting. terminationGracePeriodSeconds is set above it
@@ -182,13 +234,14 @@ noded:
   drain:
     timeoutSeconds: 60
 
-  # 256Mi req / 2Gi limit: fits the node-4 coexistence budget alongside fc-invoke
-  # (2Gi req / 50Gi limit). This release primes ZERO VMs (the dispatcher is Task
-  # 11), so the daemon idles well under 256Mi; the 2Gi ceiling covers the daemon
-  # plus ~1 future primed 1Gi VM. Grow the limit when the real pool lands.
+  # 256Mi req / 4Gi limit. The limit now covers the real sandbox pool (Task 14):
+  # cap 4 x 512Mi = 2Gi of live guest microVMs, plus the daemon (~256Mi), plus one
+  # transient cold-boot VM during a base build (512Mi) and FC restore/memfile
+  # overhead, with slack. Well inside node-4's headroom alongside fc-invoke
+  # (~41Gi worst case of 64Gi). Grow with the cap; Task 14b sizes for semgrep too.
   resources:
     requests:
       cpu: 100m
       memory: 256Mi
     limits:
-      memory: 2Gi
+      memory: 4Gi

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.14
+      targetRevision: 0.1.15
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Task 14a: the first live EmberVM microVM

Gets ONE real Firecracker microVM running the python sandbox guest end to end through the control plane, the R0 headline. Splits the plan's Task 14 so the gating risk (a real Assign: rootfs provisioning, FC cold boot, snapshot, vsock) is de-risked with the smallest surface; Task 14b adds semgrep + the fc-invoke rebalance for the full cap-16 side-by-side.

### What was missing
noded already has a complete Firecracker driver (cold boot, snapshot base, restore, assign, `/proc` usage sampling). The only gap was **rootfs provisioning**: `EMBERVM_NODED_IMAGES` pointed at a pre-baked ext4 that nothing produced.

### Changes
- **rootfs-builder initContainer + ConfigMap** ported from the proven fc-invoke pattern (crane export the guest OCI image + `mkfs.ext4` onto node-4's nvme scratch), idempotent via a `.guest-ref` marker. Reuses the fc-invoke rootfs-builder tool image.
- **`EMBERVM_NODED_IMAGES` is derived** from `noded.workloads` + each workload's pinned `guestImage`, so the image ref matches in all three places it must (rootfs-builder `GUEST_IMAGE`, the node image-table key, the Workload CR `source.image.ref`) — a mismatch fails `FAILED_PRECONDITION`.
- **Digest-pinned** the frozen fc-invoke sandbox guest + rootfs-builder images via `helm_chart(images=)` from their public `.info` providers (zero image changes; guest contract frozen).
- **`sandbox` Workload CR** (1 vcpu / 512 MiB, floor 1, cap 4, `/invoke`, vsock port 1027, 30s timeout) and noded memory limit 2Gi → 4Gi for the pool.

Small footprint (floor 1, cap 4) fits node-4 headroom without touching fc-invoke.

### Verification (live, post-merge)
CI has no KVM, so this is verified after ArgoCD sync via kubectl: the init container bakes the ext4, the Workload goes Ready with a `snapshotRef` (BaseBuilder cold-booted + snapshotted a real VM), the PoolManager primes a floor VM, and a `/invoke` submit runs python end to end. I'll record the evidence on the PR / in DECISIONS.md once observed.

Deviations recorded in `DECISIONS.md` (Task 14a section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)