### PR TITLE
fix(embervm): flat top-level image keys so guest-image pin applies (Task 14a)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -122,6 +122,20 @@ Task 14b does semgrep + the fc-invoke concurrency rebalance + finding-equality.
   image changes, per the plan). The sandbox guest contract is used verbatim: vsock
   port 1027, `/shim/ready`, one python snippet per `/invoke`, `sandbox-guest-init`.
 
+### D14a.6 helm_images_values collides on shared-prefix dotted keys (chart 0.1.16 fix)
+- First live deploy (0.1.15) CrashLooped the rootfs-builder with `MANIFEST_UNKNOWN`
+  pulling `sandbox/guest:latest`: the Bazel image pin did not apply, leaving the
+  values default. ROOT CAUSE: `bazel/helm/images.bzl` emits one top-level YAML
+  block per dotted image key, so three keys sharing a prefix (`noded.image`,
+  `noded.sandbox.guestImage`, `noded.rootfsBuilder.image`) produce three duplicate
+  `noded:` keys that collapse to the last on parse, dropping the guest-image pin
+  AND clobbering `noded.image` itself back to `:latest`.
+- Fix: give each Bazel-pinned image a DISTINCT top-level key (`sandbox.guestImage`,
+  `rootfsBuilder.image`, flat top-level `workloads`), mirroring fc-invoke's proven
+  layout. `noded.image` stays the sole `noded.*` pinned key. The underlying
+  images.bzl limitation (silent clobber on shared-prefix keys) is a latent footgun
+  worth a general fix (deep-merge the fragment) as a separate follow-up.
+
 ### D14a.5 Live-verify, not CI-verify
 - CI cannot run a real VM (no KVM in RBE). 14a is verified live AFTER merge+sync:
   the init container bakes the ext4, the Workload goes Ready with a snapshotRef

--- a/projects/embervm/chart/BUILD
+++ b/projects/embervm/chart/BUILD
@@ -12,9 +12,13 @@ helm_chart(
         # rootfs by the noded rootfs-builder) and the rootfs-builder tool image,
         # digest-pinned from their .info providers so the guest contract is
         # unchanged. Their .info targets are public (apko_image), so cross-project
-        # references are allowed.
-        "noded.sandbox.guestImage": "//projects/firecracker/sandbox/guest:image.info",
-        "noded.rootfsBuilder.image": "//projects/firecracker/substrate/rootfs-builder:image.info",
+        # references are allowed. These MUST be DISTINCT top-level keys (not
+        # noded.*): helm_images_values emits one YAML block per dotted key, so two
+        # keys sharing a top-level prefix (e.g. noded.image + noded.sandbox.*)
+        # collapse to the last on parse (duplicate-key), dropping the others. Flat
+        # top-level keys mirror fc-invoke's proven layout.
+        "sandbox.guestImage": "//projects/firecracker/sandbox/guest:image.info",
+        "rootfsBuilder.image": "//projects/firecracker/substrate/rootfs-builder:image.info",
     },
     publish = True,
     visibility = ["//overlays:__subpackages__"],

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.15
+version: 0.1.16

--- a/projects/embervm/chart/templates/noded-deployment.yaml
+++ b/projects/embervm/chart/templates/noded-deployment.yaml
@@ -42,20 +42,20 @@ spec:
       securityContext:
         runAsUser: 0
         runAsGroup: 0
-      {{- if .Values.noded.workloads }}
+      {{- if .Values.workloads }}
       # Build each workload's base rootfs in-cluster from its pinned guest image
       # (crane export + mkfs.ext4 onto the nvme scratch), so node-4 never needs a
       # manual sudo rootfs placement. One builder per workload that declares a
-      # `noded.<name>.guestImage` block (Bazel pins its repository:tag from the
+      # top-level `<name>.guestImage` block (Bazel pins its repository:tag from the
       # guest image's .info provider); the builder bakes that guest's filesystem
       # into the workload's rootfsPath. Idempotent (a marker skips the multi-GB
       # rebuild when the guest ref is unchanged). Mirrors the fc-invoke pattern.
       initContainers:
-        {{- range $name, $wl := .Values.noded.workloads }}
-        {{- $top := index $.Values.noded $name }}
+        {{- range $name, $wl := .Values.workloads }}
+        {{- $top := index $.Values $name }}
         {{- if and $top $top.guestImage $top.guestImage.repository }}
         - name: build-{{ $name }}-rootfs
-          image: "{{ $.Values.noded.rootfsBuilder.image.repository }}:{{ $.Values.noded.rootfsBuilder.image.tag }}"
+          image: "{{ $.Values.rootfsBuilder.image.repository }}:{{ $.Values.rootfsBuilder.image.tag }}"
           command: ["/bin/bash", "/scripts/build-base-rootfs.sh"]
           env:
             - name: GUEST_IMAGE
@@ -63,7 +63,7 @@ spec:
             - name: BASE_ROOTFS_PATH
               value: {{ $wl.rootfsPath | quote }}
             - name: ROOTFS_SIZE
-              value: {{ $.Values.noded.rootfsBuilder.rootfsSize | quote }}
+              value: {{ $.Values.rootfsBuilder.rootfsSize | quote }}
             {{- if $.Values.imagePullSecret.enabled }}
             - name: DOCKER_CONFIG
               value: /ghcr
@@ -140,8 +140,8 @@ spec:
             # entries merge in as overrides. Empty (no workloads) => BuildBase denies.
             - name: EMBERVM_NODED_IMAGES
               {{- $imgs := deepCopy (.Values.noded.images | default dict) }}
-              {{- range $name, $wl := .Values.noded.workloads }}
-              {{- $top := index $.Values.noded $name }}
+              {{- range $name, $wl := .Values.workloads }}
+              {{- $top := index $.Values $name }}
               {{- if and $top $top.guestImage $top.guestImage.repository }}
               {{- $ref := printf "%s:%s" $top.guestImage.repository $top.guestImage.tag }}
               {{- $_ := set $imgs $ref (dict "rootfsPath" $wl.rootfsPath "harnessInit" $wl.harnessInit) }}
@@ -185,7 +185,7 @@ spec:
           hostPath:
             path: {{ .Values.noded.firecracker.nvmeRoot }}
             type: Directory
-        {{- if .Values.noded.workloads }}
+        {{- if .Values.workloads }}
         - name: rootfs-builder-script
           configMap:
             name: {{ include "embervm.noded.fullname" . }}-rootfs-builder

--- a/projects/embervm/chart/templates/noded-rootfs-builder-configmap.yaml
+++ b/projects/embervm/chart/templates/noded-rootfs-builder-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.noded.workloads }}
+{{- if .Values.workloads }}
 # Build script for the noded base-rootfs initContainers (Task 14). Kept in a
 # ConfigMap so it can be tuned without rebuilding the tools image. Each
 # per-workload rootfs-builder initContainer (see the range in

--- a/projects/embervm/chart/templates/workload-sandbox.yaml
+++ b/projects/embervm/chart/templates/workload-sandbox.yaml
@@ -17,8 +17,9 @@ spec:
   class: task
   source:
     image:
-      # Must match noded.sandbox.guestImage exactly (see noded-deployment.yaml).
-      ref: "{{ .Values.noded.sandbox.guestImage.repository }}:{{ .Values.noded.sandbox.guestImage.tag }}"
+      # Must match the top-level sandbox.guestImage exactly (the derived
+      # EMBERVM_NODED_IMAGES + rootfs-builder GUEST_IMAGE use the same value).
+      ref: "{{ .Values.sandbox.guestImage.repository }}:{{ .Values.sandbox.guestImage.tag }}"
       port: {{ .Values.sandboxWorkload.port }}
       readyPath: {{ .Values.sandboxWorkload.readyPath | quote }}
       invokePath: {{ .Values.sandboxWorkload.invokePath | quote }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -146,6 +146,40 @@ sandboxWorkload:
   cap: 4
   timeoutSeconds: 30
 
+# Guest-image rootfs provisioning (Task 14), laid out FLAT at top level (NOT
+# under `noded`) because helm_images_values (Bazel image pinning) emits one YAML
+# block per dotted key, so keys sharing a top-level prefix collide on parse. Each
+# Bazel-pinned image is therefore its own top-level key, mirroring fc-invoke.
+
+# Per-workload base-rootfs targets on the nvme scratch. The rootfs-builder writes
+# each guest's ext4 here and the noded EMBERVM_NODED_IMAGES table maps the guest
+# ref to it. Adding a workload here (with a matching top-level <name>.guestImage)
+# provisions its base and enables an initContainer that bakes it.
+workloads:
+  sandbox:
+    rootfsPath: /disks/nvme-02/embervm-noded/sandbox/rootfs.ext4
+    harnessInit: /usr/local/bin/sandbox-guest-init
+
+# The python sandbox guest image, Bazel-pinned (helm_chart images="sandbox.guestImage")
+# from the frozen fc-invoke sandbox guest's .info provider, so the guest contract
+# is unchanged (zero image changes, per the R0 plan). Consumed by the sandbox
+# rootfs-builder init container, the derived EMBERVM_NODED_IMAGES, and the sandbox
+# Workload CR (all three refs derive from here, so they always match).
+sandbox:
+  guestImage:
+    repository: ghcr.io/jomcgi/homelab/projects/firecracker/sandbox/guest
+    tag: latest
+
+# The rootfs-builder tool image (crane + e2fsprogs + bash) that bakes each
+# workload's guest OCI image into an ext4 base rootfs at pod init. Reuses the
+# fc-invoke rootfs-builder image; Bazel pins repository:tag from its .info.
+rootfsBuilder:
+  image:
+    repository: ghcr.io/jomcgi/homelab/projects/firecracker/substrate/rootfs-builder
+    tag: latest
+  # The sandbox base is small (python + libs); 2G leaves ample slack.
+  rootfsSize: 2G
+
 # embervm-noded: the node daemon (gRPC NodeService) that owns Firecracker microVM
 # lifecycle on node-4. A SECOND Deployment in this chart, privileged and node-
 # pinned, forked from the fc-invoke node layer (ADR embervm/001). It coexists with
@@ -195,38 +229,11 @@ noded:
     kernelBootArgs: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda ro"
 
   # Explicit node-side image identity overrides (image_ref -> {rootfsPath,
-  # harnessInit}). Normally empty: the table is DERIVED from noded.workloads +
-  # each workload's guestImage (see noded-deployment.yaml), so the ref matches the
-  # rootfs-builder and the Workload CR automatically. Entries here merge on top.
+  # harnessInit}). Normally empty: the table is DERIVED from the top-level
+  # `workloads` map + each workload's `<name>.guestImage` (see
+  # noded-deployment.yaml), so the ref matches the rootfs-builder and the Workload
+  # CR automatically. Entries here merge on top.
   images: {}
-
-  # The rootfs-builder tool image (crane + e2fsprogs + bash) that bakes each
-  # workload's guest OCI image into an ext4 base rootfs at pod init. Reuses the
-  # fc-invoke rootfs-builder image; Bazel pins repository:tag from its .info.
-  rootfsBuilder:
-    image:
-      repository: ghcr.io/jomcgi/homelab/projects/firecracker/substrate/rootfs-builder
-      tag: latest
-    # The sandbox base is small (python + libs); 2G leaves ample slack.
-    rootfsSize: 2G
-
-  # The python sandbox guest image, Bazel-pinned (helm_chart images=) from the
-  # frozen fc-invoke sandbox guest's .info provider, so the guest contract is
-  # unchanged (zero image changes, per the R0 plan). Consumed by the sandbox
-  # rootfs-builder init container and the sandbox Workload CR.
-  sandbox:
-    guestImage:
-      repository: ghcr.io/jomcgi/homelab/projects/firecracker/sandbox/guest
-      tag: latest
-
-  # Per-workload rootfs targets on the nvme scratch. The rootfs-builder writes
-  # each guest's ext4 here and EMBERVM_NODED_IMAGES maps the guest ref to it.
-  # Adding a workload here (with a matching noded.<name>.guestImage) provisions
-  # its base and enables an initContainer that bakes it.
-  workloads:
-    sandbox:
-      rootfsPath: /disks/nvme-02/embervm-noded/sandbox/rootfs.ext4
-      harnessInit: /usr/local/bin/sandbox-guest-init
 
   # Graceful-drain budget: on SIGTERM the daemon waits up to this long for in-
   # flight Assigns before exiting. terminationGracePeriodSeconds is set above it

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.15
+      targetRevision: 0.1.16
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Fix: sandbox guest-image pin was clobbered

The first live sandbox deploy (0.1.15, #3498) CrashLooped the noded rootfs-builder init container with `MANIFEST_UNKNOWN` pulling `sandbox/guest:latest`.

**Root cause:** `bazel/helm/images.bzl` emits one top-level YAML block per dotted image key. The three `noded.*` keys (`noded.image`, `noded.sandbox.guestImage`, `noded.rootfsBuilder.image`) produced **three duplicate `noded:` keys** in the generated values fragment, which collapse to the last on parse — dropping the guest-image pin (fell back to the `latest` default) and clobbering `noded.image` itself back to `:latest` too.

**Fix:** give each Bazel-pinned image a **distinct top-level key** (`sandbox.guestImage`, `rootfsBuilder.image`) and move the `workloads` map to top level, mirroring fc-invoke's proven layout. `noded.image` stays the sole `noded.*` pinned key. The derived `EMBERVM_NODED_IMAGES`, the rootfs-builder `GUEST_IMAGE`, and the Workload CR `ref` all read the flat keys, so they still match exactly.

Verified: control-plane `image` (already a distinct top-level key) pins correctly today; fc-invoke uses `sandbox.guestImage` + `rootfsBuilder.image` as top-level keys and pins correctly. Local `helm template` renders cleanly (tags show `latest` locally since Bazel pins only apply in CI).

Follow-up noted in DECISIONS.md: the images.bzl silent-clobber on shared-prefix keys deserves a general fix (deep-merge the fragment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)