### PR TITLE
fix(embervm): apply workload invokePath by default (Task 14a follow-up)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -136,6 +136,25 @@ Task 14b does semgrep + the fc-invoke concurrency rebalance + finding-equality.
   images.bzl limitation (silent clobber on shared-prefix keys) is a latent footgun
   worth a general fix (deep-merge the fragment) as a separate follow-up.
 
+### D14a.7 LIVE VM ACHIEVED, and the invokePath precedence bug it surfaced (chart 0.1.17)
+- **A real python task ran in a Firecracker microVM through the controller**
+  (chart 0.1.16): `POST /v1/workloads/sandbox/tasks?wait=true` with `{"code":
+  "print(6*7)"}` returned `{"stdout":"42\n","exit_code":0,"duration_ms":16}`, 200
+  OK. Chain verified: init container baked the ext4, BaseBuilder cold-booted +
+  snapshotted a real VM (status.snapshotRef=sandbox__..., BaseReady+BaseBuilt),
+  PoolManager primed a floor VM (primedFloorSatisfied=true), and the dispatched
+  Assign restored a VM and round-tripped the guest /invoke.
+- **Bug surfaced:** the FIRST submit dead-lettered (guest 404) because the Router
+  baked `path: "/"` into every submitted request, and the dispatcher prefers the
+  stored request path (`req_env["path"] || invoke_path`), so the workload's
+  `invokePath: /invoke` was dead unless the client sent `X-Ember-Guest-Path`. The
+  intended precedence is request-header > workload invokePath > "/". Fix: the
+  Router records a path ONLY when `X-Ember-Guest-Path` is set, so the dispatcher's
+  fallback to the catalog `invoke_path` works. Only a real end-to-end invocation
+  could catch this (router + dispatcher were unit-tested in isolation).
+- Also disabled the `echo` sample workload (its BuildBase failed in a tight loop
+  now that BaseBuilder is active; sandbox is the real watcher/RBAC exercise).
+
 ### D14a.5 Live-verify, not CI-verify
 - CI cannot run a real VM (no KVM in RBE). 14a is verified live AFTER merge+sync:
   the init container bakes the ext4, the Workload goes Ready with a snapshotRef

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.16
+version: 0.1.17

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -119,8 +119,14 @@ podSecurityContext:
 # status on in-cluster (see chart/templates/sample-workload.yaml). This is a
 # self-test, not a production workload: turn it off once Task 14 lands the
 # real semgrep/sandbox workload CRs.
+# The gated `echo` self-test workload is now DISABLED: the real `sandbox`
+# workload (Task 14) is a live task-class Workload the watcher catalogs and the
+# BaseBuilder actually builds, so it serves the watcher/RBAC round-trip that echo
+# was a placeholder for. Left enabled, echo's image is not provisioned, so
+# BaseBuilder retries its BuildBase in a tight loop and floods the logs with
+# FAILED_PRECONDITION. Re-enable only for isolated watcher testing.
 sampleWorkload:
-  enabled: true
+  enabled: false
   name: echo
 
 # The first REAL EmberVM workload (Task 14): the python sandbox. A task-class

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -409,18 +409,23 @@ defmodule Embervm.Router do
   # fields are included so op-log JSON never carries a null (nested nils are not
   # stripped by the encoder).
   defp build_request_env(conn, body) do
-    base = %{path: guest_path(conn), headers: guest_headers(conn), body_b64: Base.encode64(body)}
+    base = %{headers: guest_headers(conn), body_b64: Base.encode64(body)}
+
+    # Only record a guest path when X-Ember-Guest-Path is EXPLICITLY set, so the
+    # dispatcher falls back to the workload's `invokePath` (the intended default).
+    # Baking "/" here made invokePath dead: the dispatcher prefers the stored
+    # request path (`req_env["path"] || invoke_path`), so a "/" default always won
+    # and 404'd a guest that only serves /invoke.
+    base =
+      case header_value(conn, @path_header) do
+        nil -> base
+        path -> Map.put(base, :path, path)
+      end
 
     case header_value(conn, "content-type") do
       nil -> base
       ct -> Map.put(base, :content_type, ct)
     end
-  end
-
-  defp guest_path(conn) do
-    # Default is the workload's spec.source.invokePath; hard-coded `/` until the
-    # Task 5 catalog exists. X-Ember-Guest-Path overrides per submit.
-    header_value(conn, @path_header) || "/"
   end
 
   defp guest_headers(conn) do

--- a/projects/embervm/control/test/embervm/router_test.exs
+++ b/projects/embervm/control/test/embervm/router_test.exs
@@ -94,6 +94,25 @@ defmodule Embervm.RouterTest do
     assert view["attempt"] == 1
   end
 
+  test "a submit without X-Ember-Guest-Path stores NO path, so the workload invokePath applies" do
+    wl = unique("wl")
+    task_id = json(req(:post, "/v1/workloads/#{wl}/tasks", auth("good"), "x").body)["task_id"]
+
+    {:ok, env} = TaskStore.get_request(task_id)
+    # No "path" key: the dispatcher's `req_env["path"] || invoke_path` then falls
+    # back to the workload's invokePath (e.g. /invoke), not a hard-coded "/".
+    refute Map.has_key?(env, "path")
+  end
+
+  test "X-Ember-Guest-Path is recorded and overrides the workload invokePath" do
+    wl = unique("wl")
+    headers = auth("good") ++ [{"x-ember-guest-path", "/custom"}]
+    task_id = json(req(:post, "/v1/workloads/#{wl}/tasks", headers, "x").body)["task_id"]
+
+    {:ok, env} = TaskStore.get_request(task_id)
+    assert env["path"] == "/custom"
+  end
+
   test "Idempotency-Key dedupes a resubmit to the same task" do
     wl = unique("wl")
     key = unique("idem")

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.16
+      targetRevision: 0.1.17
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Fix: workload invokePath was dead code

The first real end-to-end guest invocation (a python task in a live Firecracker microVM) dead-lettered with a guest 404. Root cause: the Router baked `path: "/"` into every submitted request envelope, and the dispatcher prefers the stored request path (`req_env["path"] || invoke_path`), so the workload's `invokePath: /invoke` never applied unless the client sent an `X-Ember-Guest-Path` header. The sandbox shim only serves `/invoke` (and `/shim/ready`), so `/` 404s.

**Fix:** the Router records a guest path **only** when `X-Ember-Guest-Path` is explicitly set, restoring the intended precedence: per-request header > workload `invokePath` > `/`. The dispatcher's existing `|| invoke_path` fallback then uses the catalog value.

**Verified live** (chart 0.1.16): `POST /v1/workloads/sandbox/tasks?wait=true {"code":"print(6*7)"}` returned `{"stdout":"42\n","exit_code":0,"duration_ms":16}` with the manual override; this makes it work without it. Regression tests added (stored env omits `path` by default; records it when the header is set).

Also disables the `echo` sample workload — its `BuildBase` now fails in a tight loop (BaseBuilder is active, echo has no provisioned image), flooding logs; the real `sandbox` workload serves the watcher/RBAC round-trip echo was a placeholder for.

### Milestone
This completes the first live EmberVM microVM: a python sandbox running real code through the control plane. Full chain evidence in DECISIONS.md (D14a.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)