### PR TITLE
feat(embervm): semgrep side-by-side + node-4 rebalance (Task 14b)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -162,6 +162,34 @@ Task 14b does semgrep + the fc-invoke concurrency rebalance + finding-equality.
   floor VM, and a `/invoke` submit runs python end to end. Recorded here as the
   acceptance evidence once observed.
 
+## Task 14b: semgrep side-by-side + node-4 rebalance (embervm 0.1.18, fc-invoke 0.4.82)
+
+### D14b.1 Plan-literal rebalance (Joe's call): halve fc-invoke, embervm to cap-16
+- Chose the plan-literal Option B over a modest-cap Option A. fc-invoke semgrep +
+  sandbox concurrency 16->8 (substrate chart), its memory limit 50Gi->40Gi
+  (worst case ~47->~35Gi). embervm adds a semgrep Workload (1 vcpu/1536Mi, floor 4,
+  cap 16) and raises sandbox to floor 4/cap 16; noded memory limit 4Gi->36Gi. The
+  rootfs-builder + derived EMBERVM_NODED_IMAGES pick up semgrep automatically from
+  the top-level `workloads.semgrep` + `semgrep.guestImage` pin.
+- **Node-4 memory arithmetic (63.4GiB allocatable):** the daemon memory LIMITS are
+  cgroup OOM ceilings, NOT scheduling reservations (both daemons keep tiny
+  requests), so the ceilings may oversubscribe (fc-invoke 40Gi + embervm 36Gi =
+  76Gi) without overcommitting node scheduling. This is safe because real
+  simultaneous cap-16 peak never occurs during side-by-side: production PR scans
+  stay on fc-invoke, so embervm idles at its floor (semgrep 4x1536 + sandbox 4x512
+  = 8Gi steady); at cutover fc-invoke drains so only embervm peaks; and
+  oom_score_adj kills guests before the daemon/DB. The absolute cap-16 throughput
+  gate is a post-drain Task 16 run (the plan's per-slot-normalization clause).
+- **Deferred:** the fc-invoke semgrep concurrency (and the whole fc-invoke scan
+  path) is restored-or-deprecated at the Task 16 cutover, not here.
+
+### D14b.2 semgrep guest is private; reused the existing ghcr pull path
+- The semgrep guest image is proprietary (Pro engine + rules). embervm's chart
+  already sets imagePullSecret.enabled with a 1Password-synced ghcr dockerconfig,
+  and the noded rootfs-builder init container mounts it (DOCKER_CONFIG=/ghcr) when
+  that flag is on, so crane pulls the private guest with no new wiring (the public
+  sandbox guest simply did not need it).
+
 ## D12 known gaps accepted for R0 (documented, not fixed)
 - The `usage` projection ACCUMULATES (the only projection that does), so it is not
   idempotent under op replay (the future `read_from` replica path); safe today

--- a/projects/embervm/chart/BUILD
+++ b/projects/embervm/chart/BUILD
@@ -19,6 +19,8 @@ helm_chart(
         # top-level keys mirror fc-invoke's proven layout.
         "sandbox.guestImage": "//projects/firecracker/sandbox/guest:image.info",
         "rootfsBuilder.image": "//projects/firecracker/substrate/rootfs-builder:image.info",
+        # Task 14b: the frozen fc-invoke semgrep guest. Distinct top-level key.
+        "semgrep.guestImage": "//projects/firecracker/semgrep/guest:image.info",
     },
     publish = True,
     visibility = ["//overlays:__subpackages__"],

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.17
+version: 0.1.18

--- a/projects/embervm/chart/templates/workload-semgrep.yaml
+++ b/projects/embervm/chart/templates/workload-semgrep.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.semgrepWorkload.enabled }}
+# The semgrep workload (Task 14b): EmberVM's named first consumer, side-by-side
+# with the fc-invoke semgrep path. Its guest image ref is the SAME Bazel-pinned
+# value the noded rootfs-builder bakes and EMBERVM_NODED_IMAGES keys on, so
+# BaseBuilder's BuildBase(ref) resolves on the node. The frozen fc-invoke semgrep
+# guest is used verbatim (vsock 1027, /shim/ready, /invoke).
+apiVersion: embervm.dev/v1alpha1
+kind: Workload
+metadata:
+  name: {{ .Values.semgrepWorkload.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  class: task
+  source:
+    image:
+      # Must match the top-level semgrep.guestImage exactly (the derived
+      # EMBERVM_NODED_IMAGES + rootfs-builder GUEST_IMAGE use the same value).
+      ref: "{{ .Values.semgrep.guestImage.repository }}:{{ .Values.semgrep.guestImage.tag }}"
+      port: {{ .Values.semgrepWorkload.port }}
+      readyPath: {{ .Values.semgrepWorkload.readyPath | quote }}
+      invokePath: {{ .Values.semgrepWorkload.invokePath | quote }}
+  resources:
+    vcpus: {{ .Values.semgrepWorkload.vcpus }}
+    memMib: {{ .Values.semgrepWorkload.memMib }}
+  concurrency:
+    floor: {{ .Values.semgrepWorkload.floor }}
+    cap: {{ .Values.semgrepWorkload.cap }}
+  invocation:
+    timeoutSeconds: {{ .Values.semgrepWorkload.timeoutSeconds }}
+{{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -144,13 +144,28 @@ sandboxWorkload:
   invokePath: /invoke
   vcpus: 1
   memMib: 512
-  # Small footprint for the first live workload: a warm floor of 1 exercises the
-  # full base-build -> prime -> assign path; cap 4 bounds it well inside node-4's
-  # headroom alongside fc-invoke. Task 14b raises this and adds semgrep + the
-  # node-4 rebalancing for the full side-by-side.
-  floor: 1
-  cap: 4
+  # Task 14b full side-by-side: floor 4 / cap 16 matches the plan's sizing (and
+  # fc-invoke's pre-halving sandbox cap). See the node-4 memory arithmetic on
+  # noded.resources below.
+  floor: 4
+  cap: 16
   timeoutSeconds: 30
+
+# The semgrep workload (Task 14b): EmberVM's named first consumer, side-by-side
+# with fc-invoke's semgrep path (which is halved 16->8 in the substrate chart to
+# make room). Same frozen guest contract as fc-invoke (vsock 1027, /shim/ready,
+# /invoke), 1 vcpu / 1536Mi / 90s, floor 4 / cap 16.
+semgrepWorkload:
+  enabled: true
+  name: semgrep
+  port: 1027
+  readyPath: /shim/ready
+  invokePath: /invoke
+  vcpus: 1
+  memMib: 1536
+  floor: 4
+  cap: 16
+  timeoutSeconds: 90
 
 # Guest-image rootfs provisioning (Task 14), laid out FLAT at top level (NOT
 # under `noded`) because helm_images_values (Bazel image pinning) emits one YAML
@@ -165,6 +180,9 @@ workloads:
   sandbox:
     rootfsPath: /disks/nvme-02/embervm-noded/sandbox/rootfs.ext4
     harnessInit: /usr/local/bin/sandbox-guest-init
+  semgrep:
+    rootfsPath: /disks/nvme-02/embervm-noded/semgrep/rootfs.ext4
+    harnessInit: /usr/local/bin/semgrep-guest-init
 
 # The python sandbox guest image, Bazel-pinned (helm_chart images="sandbox.guestImage")
 # from the frozen fc-invoke sandbox guest's .info provider, so the guest contract
@@ -176,6 +194,14 @@ sandbox:
     repository: ghcr.io/jomcgi/homelab/projects/firecracker/sandbox/guest
     tag: latest
 
+# The semgrep guest image, Bazel-pinned (helm_chart images="semgrep.guestImage")
+# from the frozen fc-invoke semgrep guest's .info provider. Distinct top-level key
+# (never noded.*) so the image pin does not collide, per D14a.6.
+semgrep:
+  guestImage:
+    repository: ghcr.io/jomcgi/homelab/projects/firecracker/semgrep/guest
+    tag: latest
+
 # The rootfs-builder tool image (crane + e2fsprogs + bash) that bakes each
 # workload's guest OCI image into an ext4 base rootfs at pod init. Reuses the
 # fc-invoke rootfs-builder image; Bazel pins repository:tag from its .info.
@@ -183,8 +209,10 @@ rootfsBuilder:
   image:
     repository: ghcr.io/jomcgi/homelab/projects/firecracker/substrate/rootfs-builder
     tag: latest
-  # The sandbox base is small (python + libs); 2G leaves ample slack.
-  rootfsSize: 2G
+  # 4G covers the largest guest (semgrep: engine + rules + python); the sandbox
+  # base is smaller but a uniform size keeps the builder simple (matches
+  # fc-invoke's 4G). The ext4 is sparse, so an oversized fs costs little.
+  rootfsSize: 4G
 
 # embervm-noded: the node daemon (gRPC NodeService) that owns Firecracker microVM
 # lifecycle on node-4. A SECOND Deployment in this chart, privileged and node-
@@ -247,14 +275,24 @@ noded:
   drain:
     timeoutSeconds: 60
 
-  # 256Mi req / 4Gi limit. The limit now covers the real sandbox pool (Task 14):
-  # cap 4 x 512Mi = 2Gi of live guest microVMs, plus the daemon (~256Mi), plus one
-  # transient cold-boot VM during a base build (512Mi) and FC restore/memfile
-  # overhead, with slack. Well inside node-4's headroom alongside fc-invoke
-  # (~41Gi worst case of 64Gi). Grow with the cap; Task 14b sizes for semgrep too.
+  # 256Mi req / 36Gi limit (Task 14b full side-by-side). The limit is a cgroup
+  # OOM CEILING, not a scheduling reservation (the request stays 256Mi), so it
+  # does not overcommit node scheduling, exactly like fc-invoke's 50Gi cap.
+  #
+  # embervm worst case (both workloads at cap, no serialization):
+  #   semgrep 16 x 1536Mi = 24Gi + sandbox 16 x 512Mi = 8Gi + ~2Gi transient
+  #   base-build cold-boot + ~0.3Gi daemon ~= 34Gi -> 36Gi ceiling.
+  #
+  # node-4 has 63.4GiB allocatable. The two daemons' CEILINGS oversubscribe
+  # (fc-invoke halved ~40Gi + embervm 36Gi = 76Gi), which is SAFE because these
+  # are cgroup caps, not reservations: real simultaneous cap-16 peak never occurs
+  # during side-by-side (production PR scans stay on fc-invoke, so embervm idles at
+  # its floor: semgrep 4x1536 + sandbox 4x512 = 8Gi steady), and post-drain only
+  # embervm peaks (fc-invoke drained). oom_score_adj kills guests before the
+  # daemon/DB. The absolute cap-16 throughput run is a post-drain Task 16 gate.
   resources:
     requests:
       cpu: 100m
       memory: 256Mi
     limits:
-      memory: 4Gi
+      memory: 36Gi

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.17
+      targetRevision: 0.1.18
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.81
+version: 0.4.82

--- a/projects/firecracker/substrate/chart/values.yaml
+++ b/projects/firecracker/substrate/chart/values.yaml
@@ -159,7 +159,10 @@ workloads:
     # them is an accepted trade for absolute throughput. Past 16 there is no
     # silicon left, only queue depth. See the cpu request below, which
     # weight-protects the scan cores under contention.
-    concurrency: 16
+    # Halved 16 -> 8 for the EmberVM side-by-side (R0 Task 14b): node-4 now hosts
+    # both scan stacks, so fc-invoke yields half its semgrep slots to make room for
+    # embervm's semgrep pool. Restored (or fc-invoke deprecated) at cutover.
+    concurrency: 8
     egressEnabled: false
     warmBase: true
     readyPath: /shim/ready
@@ -252,7 +255,10 @@ workloads:
     # Same core reasoning as semgrep (see its comment). Measured at 12:
     # 52.4/s (+31% over 6), run p50 198ms. Short runs have non-CPU phases
     # (restore, vsock I/O), so 16 also fills scheduler gaps.
-    concurrency: 16
+    # Halved 16 -> 8 for the EmberVM side-by-side (R0 Task 14b), same reasoning as
+    # semgrep above: fc-invoke yields half its sandbox slots to node-4's new
+    # embervm sandbox pool. Restored (or fc-invoke deprecated) at cutover.
+    concurrency: 8
     egressEnabled: false
     warmBase: true
     readyPath: /shim/ready
@@ -260,12 +266,14 @@ workloads:
     requestTimeout: 30s
 
 # Memory limit holds the capped peak of every workload's guests plus the daemon.
-# A load test drives ONE workload to concurrency 16: semgrep 16 * 1536Mi = ~24Gi
-# or sandbox 16 * 512Mi = ~8Gi (a monolith one-run guard serializes load tests,
-# so they never stack). Even with a concurrent agent run (2 * 4096Mi = 8Gi), a
-# scheduled semgrep-full run (1 * 8192Mi = 8Gi), a heavy-diff semgrep-hi run
-# (1 * 6144Mi = 6Gi), and ~1Gi daemon overhead the worst case is ~47Gi, so 50Gi
-# keeps margin (node-4 has 64Gi). This is a cgroup
+# R0 Task 14b halved semgrep + sandbox concurrency 16 -> 8 to share node-4 with
+# the embervm scan stack, so the worst case drops accordingly: a load test now
+# drives ONE workload to concurrency 8 (semgrep 8 * 1536Mi = ~12Gi or sandbox
+# 8 * 512Mi = ~4Gi; a monolith one-run guard serializes load tests, so they never
+# stack). Even with a concurrent agent run (2 * 4096Mi = 8Gi), a scheduled
+# semgrep-full run (1 * 8192Mi = 8Gi), a heavy-diff semgrep-hi run (1 * 6144Mi =
+# 6Gi), and ~1Gi daemon overhead the worst case is ~35Gi, so 40Gi keeps margin
+# and yields ~10Gi of node OOM-ceiling budget to embervm. This is a cgroup
 # CAP, not a request (that stays 2Gi below), so raising it does not overcommit
 # node scheduling; it only raises the OOM ceiling. semgrep-full is concurrency 1
 # and scheduled, so it rarely coincides with a manual load-test burst, but the
@@ -287,7 +295,7 @@ resources:
     cpu: 6000m
     memory: 2Gi
   limits:
-    memory: 50Gi
+    memory: 40Gi
 
 # Firecracker substrate paths on node-4. Driving real microVMs (privileged +
 # these host mounts) is gated behind `firecracker.enabled`; until then the

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.81
+      targetRevision: 0.4.82
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## Task 14b: semgrep side-by-side with the fc-invoke scan fleet

Adds EmberVM's named first consumer (semgrep) alongside sandbox, running side-by-side with fc-invoke, and rebalances node-4 (plan-literal, per Joe).

### embervm (0.1.18)
- `semgrep` Workload: 1 vcpu / 1536 MiB, floor 4, cap 16, frozen fc-invoke semgrep guest (digest-pinned via a distinct top-level `semgrep.guestImage` key, per D14a.6). sandbox raised to floor 4 / cap 16.
- The rootfs-builder init container + derived `EMBERVM_NODED_IMAGES` pick semgrep up automatically from `workloads.semgrep` + the pin. The private semgrep guest pulls via the existing `imagePullSecret`/ghcr-creds path.
- noded memory limit 4Gi → 36Gi.

### fc-invoke (0.4.82)
- semgrep + sandbox concurrency **16 → 8** to share node-4; memory limit 50Gi → 40Gi (worst case ~47 → ~35Gi).

### Node-4 memory arithmetic (63.4 GiB allocatable)
The daemon limits are cgroup **OOM ceilings, not reservations** (both keep tiny requests), so fc-invoke 40Gi + embervm 36Gi = 76Gi ceilings oversubscribe **safely**: real cap-16 peak never coincides (production stays on fc-invoke → embervm idles at its 8Gi floor; cutover drains fc-invoke → only embervm peaks), and `oom_score_adj` kills guests before the daemon/DB. The absolute cap-16 throughput run is a post-drain Task 16 gate (the plan's per-slot-normalization clause).

**Production note:** this halves fc-invoke's live semgrep/sandbox scan concurrency. Reversible (revert restores 16). fc-invoke's scan path is restored-or-deprecated at the Task 16 cutover.

Deviations + full arithmetic in DECISIONS.md (D14b). Live-verified after merge: both workloads Ready with snapshotRefs + a semgrep finding-equality check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)