### PR TITLE
feat(monolith): embervm dual-path scan dispatch with shadow mode (Task 15)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -218,6 +218,33 @@ Task 14b does semgrep + the fc-invoke concurrency rebalance + finding-equality.
 - "Key transitions at info" is a lighter follow-on (the formatter + denial warn is
   the core structured-logging value).
 
+## Task 15: monolith EmberVM dual-path scan dispatch (monolith 0.285.186, embervm 0.1.20)
+
+### D15.1 Dual-path client + shadow mode, DORMANT behind the default flag
+- `projects/monolith/semgrep_scan/client.py` gains an EmberVM path and a
+  `SEMGREP_DISPATCH` flag (`fc-invoke` default | `embervm` | `shadow`). `embervm`
+  serves the per-PR diff from EmberVM's semgrep Workload (submit API, `?wait=true`,
+  Idempotency-Key from the content hash). `shadow` serves fc-invoke and mirrors to
+  EmberVM asynchronously (fire-and-forget, never affecting the served scan),
+  comparing finding-count/status and tallying `shadow_stats` + a structured warn on
+  divergence (the Task 16 gate signal). Only the `semgrep` DIFF workload is routed
+  (EmberVM has no semgrep-full/hi in R0); those stay on fc-invoke.
+- Shipped DORMANT: deploy values wire `embervmUrl` but keep `dispatch: fc-invoke`,
+  so the served path is unchanged. Flip to `shadow` to start the divergence soak,
+  then `embervm` at cutover. The monolith SA (`system:serviceaccount:monolith:
+  monolith`, already an fc-invoke caller) is added to EmberVM's auth allow-list now
+  so the flip authenticates immediately; no traffic until then.
+- Tests: `client_test.py` (globbed into the monolith py_test via `semgrep_scan/**`;
+  semgrep_scan is `gazelle:exclude`d, so NO new BUILD target) covers all three
+  modes, the Idempotency-Key, and shadow divergence/error tallying with a fake
+  httpx client.
+- **FLAGGED (external, not doable in-session): Task 16.** The shadow SOAK
+  (>= 48h or >= 200 real PR scans, divergence rate 0) and the six acceptance gates
+  (throughput/latency load test, kill -9 durability drill, fairness, enforcement,
+  rollback drill) require real elapsed time + a load harness. The code to RUN the
+  soak is now in place (flip `dispatch: shadow`); gathering the evidence + the
+  cutover flip is the remaining Task 16 work.
+
 ## D12 known gaps accepted for R0 (documented, not fixed)
 - The `usage` projection ACCUMULATES (the only projection that does), so it is not
   idempotent under op replay (the future `read_from` replica path); safe today

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.19
+version: 0.1.20

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.19
+      targetRevision: 0.1.20
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -24,6 +24,11 @@ auth:
   # the Task 14/15 cutover.
   allowedServiceAccounts:
     - system:serviceaccount:embervm:embervm-embervm
+    # The monolith ServiceAccount (Task 15): admits the monolith's semgrep_scan
+    # client when SEMGREP_DISPATCH is flipped to embervm/shadow. Same SA the
+    # monolith already uses to call fc-invoke. Added now so the dual-path code is
+    # ready to authenticate the moment the flag flips; no traffic until then.
+    - system:serviceaccount:monolith:monolith
 
 # Metering, audit, and quotas (Task 12). Quota is left OFF in R0 (opt-in, empty =
 # no enforcement): per-principal daily vCPU-second budgets are set alongside the

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.105
+version: 0.89.106
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.105
+      targetRevision: 0.89.106
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.185
+version: 0.285.186
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -90,6 +90,18 @@ spec:
             - name: FC_INVOKE_URL
               value: {{ .Values.semgrep.fcInvokeUrl | quote }}
             {{- end }}
+            {{- if .Values.semgrep.embervmUrl }}
+            # EmberVM control-plane URL + dispatch mode (R0 Task 15). The per-PR
+            # semgrep diff scan can be served from EmberVM's semgrep Workload, or
+            # shadow-mirrored to it, selected by SEMGREP_DISPATCH. Default
+            # `fc-invoke` keeps the served path unchanged until cutover.
+            - name: EMBERVM_URL
+              value: {{ .Values.semgrep.embervmUrl | quote }}
+            {{- end }}
+            {{- if .Values.semgrep.dispatch }}
+            - name: SEMGREP_DISPATCH
+              value: {{ .Values.semgrep.dispatch | quote }}
+            {{- end }}
             {{- if .Values.semgrep.shadowProject }}
             # Route B shadow project: the relay reports App scans under this name
             # instead of the real repo, keeping self-hosted scans in a separate

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -795,6 +795,14 @@ chat:
 # deploy/values.yaml; never hardcode it in a template.
 semgrep:
   fcInvokeUrl: ""
+  # EmberVM dual-path (R0 Task 15). embervmUrl is the EmberVM control-plane base
+  # URL; dispatch selects where the per-PR semgrep DIFF scan is served:
+  #   fc-invoke : serve from fc-invoke (default, unchanged).
+  #   embervm   : serve from EmberVM's semgrep Workload.
+  #   shadow    : serve from fc-invoke, mirror to EmberVM async for comparison.
+  # Empty embervmUrl or default dispatch keeps the served path on fc-invoke.
+  embervmUrl: ""
+  dispatch: "fc-invoke"
   # Shadow project override (Route B vs SMS comparison): when set, the relay
   # reports its App scans under THIS project name instead of the real repo, so
   # Route B (self-hosted) scans land in a SEPARATE Semgrep project from SMS's

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.185
+      targetRevision: 0.285.186
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -151,6 +151,11 @@ chat:
 # semgrep_scan MCP tool: the in-cluster fc-invoke daemon endpoint.
 semgrep:
   fcInvokeUrl: "http://fc-invoke.monolith.svc.cluster.local:8080"
+  # EmberVM dual-path (R0 Task 15). URL wired now; dispatch stays `fc-invoke` so
+  # the served scan path is UNCHANGED (the EmberVM/shadow code is dormant). Flip
+  # to `shadow` to start the divergence soak, then `embervm` at cutover (Task 16).
+  embervmUrl: "http://embervm-embervm.embervm.svc.cluster.local:8080"
+  dispatch: "fc-invoke"
   # Route B shadow project (Route B vs SMS comparison): self-hosted scans report
   # here instead of jomcgi/homelab, so they land in a separate Semgrep project.
   # UNSET this single value at cutover to report to the real project.

--- a/projects/monolith/semgrep_scan/client.py
+++ b/projects/monolith/semgrep_scan/client.py
@@ -13,6 +13,8 @@ reach through the FastMCP tool wrapper to run a scan.
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import logging
 import os
 
@@ -23,6 +25,26 @@ from shared.k8s_auth import auth_headers
 logger = logging.getLogger(__name__)
 
 FC_INVOKE_URL = os.environ.get("FC_INVOKE_URL", "")
+
+# EmberVM control-plane base URL (Task 15). The per-PR diff scan (``scan_files``)
+# can be routed to EmberVM's ``semgrep`` Workload instead of fc-invoke, selected by
+# SEMGREP_DISPATCH. EmberVM has only the ``semgrep`` diff workload in R0, so the
+# whole-repo (``semgrep-full``) and heavy-diff (``semgrep-hi``) paths stay on
+# fc-invoke regardless of the flag.
+EMBERVM_URL = os.environ.get("EMBERVM_URL", "")
+
+# Dispatch mode for the per-PR semgrep diff scan (ADR + R0 Task 15):
+#   fc-invoke : serve from fc-invoke (default, unchanged behaviour).
+#   embervm   : serve from EmberVM's semgrep Workload.
+#   shadow    : serve from fc-invoke AND mirror to EmberVM asynchronously,
+#               comparing finding-count/status and logging divergence with no
+#               user-facing effect (the reversible-cutover soak per the plan).
+SEMGREP_DISPATCH = os.environ.get("SEMGREP_DISPATCH", "fc-invoke")
+
+# Shadow divergence counters, queryable for the Task 16 acceptance gate. Process-
+# local (reset on restart); the per-divergence structured log is the durable
+# record in SigNoz.
+shadow_stats = {"total": 0, "match": 0, "diverged": 0, "embervm_error": 0}
 
 # Separate connect/read timeouts: a fast connect surfaces a down daemon quickly,
 # while a generous read budget (a bit over the daemon ScanTimeout) lets a large
@@ -82,15 +104,118 @@ async def _post_invoke(workload: str, files: list[dict], read_timeout: float) ->
         return {"error": f"semgrep scan failed: {exc}"}
 
 
+async def _post_embervm(files: list[dict], read_timeout: float) -> dict:
+    """POST a diff scan to EmberVM's ``semgrep`` Workload; the EmberVM counterpart
+    of ``_post_invoke``. Submits synchronously (``?wait=true``) so the guest's
+    ScanResult comes back inline (EmberVM forwards the guest response verbatim, so
+    the shape matches fc-invoke), with an Idempotency-Key from the content hash so
+    a webhook redelivery dedupes to the same task. Same error shape as
+    ``_post_invoke`` (a dict with a single ``error`` key on failure).
+    """
+    if not EMBERVM_URL:
+        return {"error": "EMBERVM_URL is not configured"}
+    if not files:
+        return {"error": "no files provided to scan"}
+
+    timeout = httpx.Timeout(read_timeout, connect=SEMGREP_CONNECT_TIMEOUT)
+    payload = {"files": files}
+    headers = {**auth_headers(), "Idempotency-Key": _content_key(files)}
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(
+                f"{EMBERVM_URL}/v1/workloads/semgrep/tasks?wait=true",
+                json=payload,
+                headers=headers,
+            )
+            resp.raise_for_status()
+            return resp.json()
+    except httpx.ConnectError as exc:
+        logger.exception("embervm connection failed")
+        return {"error": f"could not reach embervm: {exc}"}
+    except httpx.HTTPStatusError as exc:
+        logger.exception("embervm returned an error status")
+        return {
+            "error": (
+                f"embervm returned HTTP {exc.response.status_code}: "
+                f"{exc.response.text[:500]}"
+            )
+        }
+    except Exception as exc:  # noqa: BLE001: surface any failure as structured error
+        logger.exception("embervm semgrep scan failed")
+        return {"error": f"embervm semgrep scan failed: {exc}"}
+
+
+def _content_key(files: list[dict]) -> str:
+    """A stable idempotency key from the scan's file contents (path + content),
+    order-independent, so a webhook redelivery of the same diff dedupes to the
+    same EmberVM task."""
+    digest = hashlib.sha256()
+    for f in sorted(files, key=lambda e: e.get("path", "")):
+        digest.update(f.get("path", "").encode())
+        digest.update(b"\0")
+        digest.update(f.get("content", "").encode())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _finding_count(result: dict) -> int:
+    findings = result.get("findings")
+    return len(findings) if isinstance(findings, list) else -1
+
+
+async def _shadow_scan(files: list[dict], fc_result: dict) -> None:
+    """Fire-and-forget shadow (Task 15): run the same diff on EmberVM, compare
+    finding-count and error status to the served fc-invoke result, and log any
+    divergence. NEVER raises: a shadow failure must not affect the served scan."""
+    try:
+        shadow_stats["total"] += 1
+        ev_result = await _post_embervm(files, SEMGREP_READ_TIMEOUT)
+
+        if "error" in ev_result:
+            shadow_stats["embervm_error"] += 1
+            logger.warning(
+                "semgrep shadow: embervm path errored: %s", ev_result["error"]
+            )
+            return
+
+        fc_n, ev_n = _finding_count(fc_result), _finding_count(ev_result)
+        if fc_n == ev_n:
+            shadow_stats["match"] += 1
+        else:
+            shadow_stats["diverged"] += 1
+            logger.warning(
+                "semgrep shadow: finding-count divergence fc=%d embervm=%d", fc_n, ev_n
+            )
+    except Exception:  # noqa: BLE001: shadow must never affect the served path
+        logger.exception("semgrep shadow comparison failed")
+
+
 async def scan_files(files: list[dict]) -> dict:
-    """POST file contents to the fc-invoke semgrep workload and return findings.
+    """POST file contents to the semgrep diff workload and return findings.
 
     Each entry in ``files`` needs a ``path`` (repo-relative, used to pick rules
     and report locations) and a ``content`` (the whole current file text). On
     success returns the daemon response: a ``findings`` list plus an ``errors``
     list. On failure returns a dict with a single ``error`` key.
+
+    Dispatch is selected by ``SEMGREP_DISPATCH`` (Task 15): ``fc-invoke`` (default)
+    serves from fc-invoke; ``embervm`` serves from EmberVM's semgrep Workload;
+    ``shadow`` serves from fc-invoke and mirrors to EmberVM asynchronously for
+    finding-count comparison, with no user-facing effect. The caller contract
+    (response/error shape, timeouts) is identical across modes.
     """
-    return await _post_invoke("semgrep", files, SEMGREP_READ_TIMEOUT)
+    if SEMGREP_DISPATCH == "embervm":
+        return await _post_embervm(files, SEMGREP_READ_TIMEOUT)
+
+    result = await _post_invoke("semgrep", files, SEMGREP_READ_TIMEOUT)
+
+    if SEMGREP_DISPATCH == "shadow" and EMBERVM_URL and files and "error" not in result:
+        # Mirror asynchronously; do NOT await (no added latency, no user effect).
+        # The event loop keeps the pending task alive until it completes.
+        asyncio.ensure_future(_shadow_scan(files, result))
+
+    return result
 
 
 async def scan_files_hi(files: list[dict]) -> dict:

--- a/projects/monolith/semgrep_scan/client_test.py
+++ b/projects/monolith/semgrep_scan/client_test.py
@@ -1,0 +1,179 @@
+"""Tests for the dual-path semgrep dispatch (client.py, Task 15).
+
+Hermetic: no live fc-invoke or EmberVM. `httpx.AsyncClient` is replaced by a fake
+that records each POST and returns a scripted response routed by URL, so we assert
+which backend each dispatch mode calls, that the EmberVM path carries an
+Idempotency-Key, and that shadow mode serves fc-invoke while mirroring to EmberVM
+and tallying divergence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from semgrep_scan import client
+
+
+class _Resp:
+    def __init__(self, data, status=200):
+        self._data = data
+        self.status_code = status
+        self.text = "err"
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "error",
+                request=httpx.Request("POST", "http://x"),
+                response=httpx.Response(self.status_code),
+            )
+
+    def json(self):
+        return self._data
+
+
+class _FakeClient:
+    posts: list[dict] = []
+    routes: dict[str, _Resp] = {}
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def post(self, url, json=None, headers=None):
+        _FakeClient.posts.append({"url": url, "json": json, "headers": headers or {}})
+        for fragment, resp in _FakeClient.routes.items():
+            if fragment in url:
+                return resp
+        return _Resp({"findings": [], "errors": []})
+
+
+@pytest.fixture(autouse=True)
+def _fake(monkeypatch):
+    _FakeClient.posts = []
+    _FakeClient.routes = {}
+    original_dispatch = client.SEMGREP_DISPATCH
+    monkeypatch.setattr(client.httpx, "AsyncClient", _FakeClient)
+    monkeypatch.setattr(client, "FC_INVOKE_URL", "http://fc")
+    monkeypatch.setattr(client, "EMBERVM_URL", "http://ev")
+    client.shadow_stats.update(total=0, match=0, diverged=0, embervm_error=0)
+    yield
+    # SEMGREP_DISPATCH is set directly by tests (below); restore it so a mode
+    # never leaks into another test.
+    client.SEMGREP_DISPATCH = original_dispatch
+
+
+_FILES = [{"path": "a.py", "content": "import subprocess\n"}]
+
+
+async def _drain():
+    """Await any fire-and-forget shadow task scheduled on the loop."""
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    if pending:
+        await asyncio.gather(*pending)
+
+
+@pytest.mark.asyncio
+async def test_fc_invoke_is_the_default():
+    _FakeClient.routes = {
+        "/invoke/semgrep": _Resp({"findings": [{"rule_id": "r"}], "errors": []})
+    }
+    monkeypatch_dispatch("fc-invoke")
+
+    result = await client.scan_files(_FILES)
+
+    assert [p["url"] for p in _FakeClient.posts] == ["http://fc/invoke/semgrep"]
+    assert len(result["findings"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_embervm_mode_posts_to_submit_api_with_idempotency_key():
+    _FakeClient.routes = {
+        "/v1/workloads/semgrep/tasks": _Resp({"findings": [], "errors": []})
+    }
+    monkeypatch_dispatch("embervm")
+
+    await client.scan_files(_FILES)
+
+    assert len(_FakeClient.posts) == 1
+    post = _FakeClient.posts[0]
+    assert post["url"] == "http://ev/v1/workloads/semgrep/tasks?wait=true"
+    assert "Idempotency-Key" in post["headers"]
+
+
+@pytest.mark.asyncio
+async def test_shadow_serves_fc_invoke_and_mirrors_to_embervm():
+    _FakeClient.routes = {
+        "/invoke/semgrep": _Resp({"findings": [{"rule_id": "r"}], "errors": []}),
+        "/v1/workloads/semgrep/tasks": _Resp(
+            {"findings": [{"rule_id": "r"}], "errors": []}
+        ),
+    }
+    monkeypatch_dispatch("shadow")
+
+    served = await client.scan_files(_FILES)
+    await _drain()
+
+    # Served result is the fc-invoke one.
+    assert len(served["findings"]) == 1
+    # Both backends were hit (serving + shadow mirror).
+    urls = [p["url"] for p in _FakeClient.posts]
+    assert "http://fc/invoke/semgrep" in urls
+    assert "http://ev/v1/workloads/semgrep/tasks?wait=true" in urls
+    # Equal finding counts => a match, no divergence.
+    assert client.shadow_stats["total"] == 1
+    assert client.shadow_stats["match"] == 1
+    assert client.shadow_stats["diverged"] == 0
+
+
+@pytest.mark.asyncio
+async def test_shadow_tallies_divergence_when_counts_differ():
+    _FakeClient.routes = {
+        "/invoke/semgrep": _Resp({"findings": [{"rule_id": "r"}], "errors": []}),
+        "/v1/workloads/semgrep/tasks": _Resp({"findings": [], "errors": []}),
+    }
+    monkeypatch_dispatch("shadow")
+
+    await client.scan_files(_FILES)
+    await _drain()
+
+    assert client.shadow_stats["diverged"] == 1
+    assert client.shadow_stats["match"] == 0
+
+
+@pytest.mark.asyncio
+async def test_shadow_embervm_error_does_not_affect_served_result():
+    _FakeClient.routes = {
+        "/invoke/semgrep": _Resp({"findings": [{"rule_id": "r"}], "errors": []}),
+        "/v1/workloads/semgrep/tasks": _Resp({"error": "boom"}, status=502),
+    }
+    monkeypatch_dispatch("shadow")
+
+    served = await client.scan_files(_FILES)
+    await _drain()
+
+    assert len(served["findings"]) == 1
+    assert client.shadow_stats["embervm_error"] == 1
+
+
+def test_content_key_is_order_independent():
+    a = [{"path": "a.py", "content": "x"}, {"path": "b.py", "content": "y"}]
+    b = [{"path": "b.py", "content": "y"}, {"path": "a.py", "content": "x"}]
+    assert client._content_key(a) == client._content_key(b)
+    c = [{"path": "a.py", "content": "z"}, {"path": "b.py", "content": "y"}]
+    assert client._content_key(a) != client._content_key(c)
+
+
+# -- helper: set the module-level dispatch constant (restored by the fixture) --
+
+
+def monkeypatch_dispatch(mode: str):
+    client.SEMGREP_DISPATCH = mode


### PR DESCRIPTION
## Task 15: reversible cutover — the monolith learns to speak EmberVM behind a flag

`semgrep_scan/client.py` gains a `SEMGREP_DISPATCH` flag (`fc-invoke` default | `embervm` | `shadow`):
- **embervm**: serve the per-PR diff from EmberVM's `semgrep` Workload (submit API, `?wait=true`, `Idempotency-Key` from the content hash so webhook redeliveries dedupe to the same task). Response shape matches fc-invoke (EmberVM forwards the guest `ScanResult` verbatim).
- **shadow**: serve fc-invoke and **mirror to EmberVM asynchronously** (fire-and-forget, never affecting the served scan), comparing finding-count/status and tallying `shadow_stats` + a structured `warn` on divergence (the Task 16 gate signal).
- Only the `semgrep` diff workload routes; `semgrep-full`/`semgrep-hi` stay on fc-invoke (no EmberVM equivalent in R0).

### Shipped dormant (safe)
Deploy values wire `embervmUrl` but keep `dispatch: fc-invoke`, so the **served path is unchanged**. The monolith SA (`system:serviceaccount:monolith:monolith`, already an fc-invoke caller) is added to EmberVM's auth allow-list now so a flip authenticates immediately; **no traffic until you flip the flag**.

### Tests
`client_test.py` (globbed into the monolith py_test via `semgrep_scan/**`; that dir is `gazelle:exclude`d, so no new BUILD target) covers all three modes, the Idempotency-Key, and shadow divergence/error tallying with a fake httpx client.

### Flagged: Task 16 (external time)
The shadow **soak** (>=48h or >=200 real PR scans, divergence 0) and six acceptance gates (throughput/latency load test, `kill -9` durability drill, fairness, enforcement, rollback drill) need real elapsed time + a load harness. This PR lands the machinery to run the soak (flip `dispatch: shadow`); the evidence + cutover flip is the remaining work. Recorded in DECISIONS.md (D15.1).

Charts: monolith 0.285.186, monolith-public 0.89.106 (coupled image), embervm 0.1.20 (allow-list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)