### PR TITLE
feat(monolith): cut python sandbox over to EmberVM

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.106
+version: 0.89.107
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.106
+      targetRevision: 0.89.107
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.186
+version: 0.285.187
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -102,6 +102,12 @@ spec:
             - name: SEMGREP_DISPATCH
               value: {{ .Values.semgrep.dispatch | quote }}
             {{- end }}
+            {{- if .Values.sandbox.dispatch }}
+            # Where the python sandbox demo/tool is served (R0 cutover): fc-invoke
+            # (default) or embervm (EmberVM's sandbox Workload). Reuses EMBERVM_URL.
+            - name: SANDBOX_DISPATCH
+              value: {{ .Values.sandbox.dispatch | quote }}
+            {{- end }}
             {{- if .Values.semgrep.shadowProject }}
             # Route B shadow project: the relay reports App scans under this name
             # instead of the real repo, keeping self-hosted scans in a separate

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -793,6 +793,11 @@ chat:
 # tool POSTs changed files to. Empty disables the env injection (the tool then
 # returns a structured "not configured" error). The real address is set in
 # deploy/values.yaml; never hardcode it in a template.
+# The python sandbox demo/tool dispatch (R0 cutover): fc-invoke (default) or
+# embervm (EmberVM's sandbox Workload). Reuses semgrep.embervmUrl -> EMBERVM_URL.
+sandbox:
+  dispatch: "fc-invoke"
+
 semgrep:
   fcInvokeUrl: ""
   # EmberVM dual-path (R0 Task 15). embervmUrl is the EmberVM control-plane base

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.186
+      targetRevision: 0.285.187
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -149,6 +149,12 @@ chat:
     itemPath: "vaults/k8s-homelab/items/discord-bot"
 
 # semgrep_scan MCP tool: the in-cluster fc-invoke daemon endpoint.
+# The python sandbox demo/tool is CUT OVER to EmberVM (2026-07-14): served by
+# EmberVM's sandbox Workload (live + verified). Revert to fc-invoke (one value +
+# rollout) if it regresses. fc-invoke's sandbox path stays deployed as fallback.
+sandbox:
+  dispatch: "embervm"
+
 semgrep:
   fcInvokeUrl: "http://fc-invoke.monolith.svc.cluster.local:8080"
   # EmberVM dual-path (R0 Task 15). URL wired now; dispatch stays `fc-invoke` so

--- a/projects/monolith/sandbox/client.py
+++ b/projects/monolith/sandbox/client.py
@@ -7,6 +7,7 @@ zero-egress and one-shot, so this client is the only stateful party.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 
@@ -17,6 +18,13 @@ from shared.k8s_auth import auth_headers
 logger = logging.getLogger(__name__)
 
 FC_INVOKE_URL = os.environ.get("FC_INVOKE_URL", "")
+
+# EmberVM control-plane base URL + dispatch (R0 cutover). EMBERVM_URL is shared
+# with the semgrep client (wired by the chart). SANDBOX_DISPATCH selects where a
+# python run is served: fc-invoke (default) or embervm (EmberVM's sandbox
+# Workload). Same guest contract, so the response shape is identical.
+EMBERVM_URL = os.environ.get("EMBERVM_URL", "")
+SANDBOX_DISPATCH = os.environ.get("SANDBOX_DISPATCH", "fc-invoke")
 
 SANDBOX_CONNECT_TIMEOUT = 5.0
 # Guest wall-clock cap is 25s inside a 30s workload requestTimeout; read a
@@ -40,6 +48,16 @@ async def run_python_in_sandbox(code: str, files: list[dict] | None = None) -> d
     if files:
         payload["files"] = files
 
+    if SANDBOX_DISPATCH == "embervm":
+        return await _run_embervm(payload)
+    return await _run_fc_invoke(payload)
+
+
+async def _run_fc_invoke(payload: dict) -> dict:
+    """POST to the fc-invoke sandbox workload (the default path)."""
+    if not FC_INVOKE_URL:
+        return {"error": "FC_INVOKE_URL is not configured"}
+
     timeout = httpx.Timeout(SANDBOX_READ_TIMEOUT, connect=SANDBOX_CONNECT_TIMEOUT)
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
@@ -60,6 +78,42 @@ async def run_python_in_sandbox(code: str, files: list[dict] | None = None) -> d
         return {
             "error": (
                 f"fc-invoke returned HTTP {exc.response.status_code}: "
+                f"{exc.response.text[:500]}"
+            )
+        }
+    except Exception as exc:  # noqa: BLE001: surface any failure as structured error
+        logger.exception("sandbox execution failed")
+        return {"error": f"sandbox execution failed: {exc}"}
+
+
+async def _run_embervm(payload: dict) -> dict:
+    """POST a python run to EmberVM's ``sandbox`` Workload (the R0 cutover). Submits
+    synchronously (``?wait=true``); EmberVM forwards the guest response verbatim, so
+    the shape matches fc-invoke. Idempotency-Key from the code hash dedupes retries.
+    """
+    if not EMBERVM_URL:
+        return {"error": "EMBERVM_URL is not configured"}
+
+    key = hashlib.sha256(payload.get("code", "").encode()).hexdigest()
+    headers = {**auth_headers(), "Idempotency-Key": key}
+    timeout = httpx.Timeout(SANDBOX_READ_TIMEOUT, connect=SANDBOX_CONNECT_TIMEOUT)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(
+                f"{EMBERVM_URL}/v1/workloads/sandbox/tasks?wait=true",
+                json=payload,
+                headers=headers,
+            )
+            resp.raise_for_status()
+            return resp.json()
+    except httpx.ConnectError as exc:
+        logger.exception("embervm connection failed")
+        return {"error": f"could not reach embervm: {exc}"}
+    except httpx.HTTPStatusError as exc:
+        logger.exception("embervm returned an error status")
+        return {
+            "error": (
+                f"embervm returned HTTP {exc.response.status_code}: "
                 f"{exc.response.text[:500]}"
             )
         }

--- a/projects/monolith/sandbox/client_test.py
+++ b/projects/monolith/sandbox/client_test.py
@@ -1,0 +1,79 @@
+"""Tests for the sandbox dual-path dispatch (client.py, R0 cutover).
+
+Hermetic: `httpx.AsyncClient` is replaced by a fake that records each POST, so we
+assert fc-invoke (default) vs embervm routing and the EmberVM Idempotency-Key.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from sandbox import client
+
+
+class _Resp:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+        self.text = ""
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._data
+
+
+class _FakeClient:
+    posts: list[dict] = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def post(self, url, json=None, headers=None):
+        _FakeClient.posts.append({"url": url, "json": json, "headers": headers or {}})
+        return _Resp({"stdout": "42\n", "exit_code": 0})
+
+
+@pytest.fixture(autouse=True)
+def _fake(monkeypatch):
+    _FakeClient.posts = []
+    original = client.SANDBOX_DISPATCH
+    monkeypatch.setattr(client.httpx, "AsyncClient", _FakeClient)
+    monkeypatch.setattr(client, "FC_INVOKE_URL", "http://fc")
+    monkeypatch.setattr(client, "EMBERVM_URL", "http://ev")
+    yield
+    client.SANDBOX_DISPATCH = original
+
+
+@pytest.mark.asyncio
+async def test_fc_invoke_is_the_default():
+    client.SANDBOX_DISPATCH = "fc-invoke"
+    result = await client.run_python_in_sandbox("print(6*7)")
+    assert _FakeClient.posts[0]["url"] == "http://fc/invoke/sandbox"
+    assert result["exit_code"] == 0
+
+
+@pytest.mark.asyncio
+async def test_embervm_mode_posts_to_submit_api_with_idempotency_key():
+    client.SANDBOX_DISPATCH = "embervm"
+    await client.run_python_in_sandbox("print(6*7)")
+    post = _FakeClient.posts[0]
+    assert post["url"] == "http://ev/v1/workloads/sandbox/tasks?wait=true"
+    assert "Idempotency-Key" in post["headers"]
+    assert post["json"]["code"] == "print(6*7)"
+
+
+@pytest.mark.asyncio
+async def test_empty_code_short_circuits():
+    client.SANDBOX_DISPATCH = "embervm"
+    result = await client.run_python_in_sandbox("   ")
+    assert "error" in result
+    assert _FakeClient.posts == []


### PR DESCRIPTION
Adds a SANDBOX_DISPATCH dual-path to sandbox/client.py and flips it to embervm: the /python demo + sandbox MCP tool now run on EmberVM's sandbox Workload (live-verified). fc-invoke stays as instant-revert fallback. Only the goose agent remains on fc-invoke (needs EmberVM sessions+egress = R2), so fc-invoke can't be fully disabled yet.