### PR TITLE
feat(embervm): propagate caller trace context (demo waterfalls show EmberVM spans)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -274,6 +274,17 @@ Task 14b does semgrep + the fc-invoke concurrency rebalance + finding-equality.
   cap-16 absolute throughput) are the remaining enterprise-grade evidence, deferred
   as unnecessary for personal use; run them if EmberVM ever takes external traffic.
 
+### D13.3 Distributed trace propagation (caller trace joins EmberVM spans, 0.1.22)
+- EmberVM now restores the CALLER's W3C traceparent so its dispatch/guest_exec
+  spans nest under the caller's trace (the monolith demos page's httpx is
+  OTel-instrumented and auto-injects traceparent). Async submit means the context
+  rides the DURABLE op-log, not the live process: Router captures the traceparent
+  into the submitted request envelope; the dispatcher restores it
+  (`:otel_propagator_text_map.extract`, guarded) before opening the dispatch span.
+  The demos waterfall query (`WHERE traceID = trace_id`, service-agnostic) then
+  shows EmberVM's spans alongside the monolith's with no frontend change. Falls
+  back to the dispatcher's own context for trace-less submits (cron/retries).
+
 ## D12 known gaps accepted for R0 (documented, not fixed)
 - The `usage` projection ACCUMULATES (the only projection that does), so it is not
   idempotent under op replay (the future `read_from` replica path); safe today

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.21
+version: 0.1.22

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -605,10 +605,14 @@ defmodule Embervm.Dispatcher do
   # classifies the result into a terminal outcome. Returns a 2- or 3-tuple the
   # GenServer applies to the FSM.
   defp run_assign(ctx, channel_fun, invalidate_fun, assign_fun, prime_fun, get_request_fun) do
-    # Attach the dispatcher's OTel context so this worker's spans nest under the
-    # dispatch trace (Task 13), then open the top dispatch span. `pool_hit` marks
-    # the warm (primed) vs miss (prime-then-assign) path, per the span-attr spec.
-    _ = OpenTelemetry.Ctx.attach(Map.get(ctx, :otel_ctx, :undefined))
+    req_env = fetch_request(get_request_fun, ctx.task_id)
+
+    # Restore the CALLER's trace context (the traceparent the submit carried, e.g.
+    # the demos page whose httpx is OTel-instrumented) so the dispatch/guest_exec
+    # spans join the caller's trace and appear in its waterfall. Falls back to the
+    # dispatcher's own context (cron, retries, or a submit with no trace). Then
+    # open the top dispatch span; `pool_hit` marks warm vs miss.
+    _ = restore_trace_ctx(req_env, ctx)
 
     Tracer.with_span "embervm.dispatch", %{
       attributes: %{
@@ -619,13 +623,32 @@ defmodule Embervm.Dispatcher do
         "ember.pool_hit" => ctx.mode == :warm
       }
     } do
-      do_run_assign(ctx, channel_fun, invalidate_fun, assign_fun, prime_fun, get_request_fun)
+      do_run_assign(ctx, req_env, channel_fun, invalidate_fun, assign_fun, prime_fun)
     end
   end
 
-  defp do_run_assign(ctx, channel_fun, invalidate_fun, assign_fun, prime_fun, get_request_fun) do
-    req_env = fetch_request(get_request_fun, ctx.task_id)
+  # Prefer the caller's W3C traceparent (propagated through the op-log's submitted
+  # request env) so EmberVM's spans nest under the caller's trace; else the
+  # dispatcher's captured context.
+  defp restore_trace_ctx(req_env, ctx) do
+    case Map.get(req_env, "traceparent") do
+      tp when is_binary(tp) and tp != "" ->
+        # Guarded: a propagator hiccup must never crash the assign worker; worst
+        # case the spans export un-nested (a separate trace), never a lost task.
+        try do
+          :otel_propagator_text_map.extract([{"traceparent", tp}])
+        rescue
+          _ -> :ok
+        catch
+          _, _ -> :ok
+        end
 
+      _ ->
+        OpenTelemetry.Ctx.attach(Map.get(ctx, :otel_ctx, :undefined))
+    end
+  end
+
+  defp do_run_assign(ctx, req_env, channel_fun, invalidate_fun, assign_fun, prime_fun) do
     case channel_fun.(ctx.node_id) do
       {:ok, channel} ->
         with {:ok, vm_id} <- ensure_vm(ctx, channel, prime_fun) do

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -422,6 +422,17 @@ defmodule Embervm.Router do
         path -> Map.put(base, :path, path)
       end
 
+    # Capture the W3C traceparent (Task 13 distributed tracing): stored in the
+    # submitted op so the dispatcher can restore the CALLER's trace context and
+    # nest the dispatch/guest_exec spans under it, joining the caller's trace (the
+    # demos waterfall). Async submit means the dispatch happens off-request, so
+    # the context must ride the durable op-log, not the live process context.
+    base =
+      case header_value(conn, "traceparent") do
+        nil -> base
+        tp -> Map.put(base, :traceparent, tp)
+      end
+
     case header_value(conn, "content-type") do
       nil -> base
       ct -> Map.put(base, :content_type, ct)

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.21
+      targetRevision: 0.1.22
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
EmberVM restores the caller's W3C traceparent (auto-injected by the monolith's instrumented httpx) so its dispatch/guest_exec spans join the caller's trace. Async submit -> the context rides the op-log (Router captures -> dispatcher restores). The demos waterfall query is service-agnostic, so EmberVM's spans now appear alongside the monolith's with NO frontend/monolith change. Guarded; trace-less submits fall back to the dispatcher context. Chart 0.1.22.