### PR TITLE
feat(embervm): R1 Phase 0 hardening (retention, PVC alert, demo scan honesty)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -290,10 +290,53 @@ Task 14b does semgrep + the fc-invoke concurrency rebalance + finding-equality.
   idempotent under op replay (the future `read_from` replica path); safe today
   because R0 projects each op exactly once. Commented at the projection.
 - Over-budget parked tasks can outlive their `expires_at` (queued-task TTL is not
-  enforced; `compact` only prunes terminal rows).
+  enforced; `compact` only prunes terminal rows). CLOSED in R1 Phase 0, see D-R1.0.4
+  (the dispatcher now expires a popped over-TTL queued task before dispatch).
 - `gb_seconds = peak_rss_mib x wall` under-bills vs a Firecracker VM's reserved
   `memMib`; the raw per-task `peak_rss_mib`/`cpu_ms`/`wall_ms` are stored in the op
   payload so the formula can be rebased later without losing history.
 - A daemon that never populates `UsageStats` bills zero (proto3 defaults);
   mitigated by a log-once warning on all-zero success usage and a non-zero
   assertion in the metering test.
+
+## R1 Phase 0: op-log retention and compaction (ADR embervm/002, chart bump)
+
+### D-R1.0.1 TTLs are enforced at READ time, independent of the sweeper
+- `TaskStore.get_result/2` and the submit dedupe path both filter a stored result
+  whose `expires_at` is past the injected clock, replying `{:ok, nil}` (a 404 at the
+  router). Correctness never waits on a sweep: a result 404s the instant its TTL
+  lapses. The filter lives in the store (where the clock is injected), so the op-log
+  `load_result/2` behaviour signature is unchanged.
+
+### D-R1.0.2 Dedupe keys on the SAME expiry signal, evicting the stale projection
+- An idempotency-key hit on a TERMINAL task whose result has expired treats the task
+  as absent and resubmits fresh, so "GET result 404s" and "resubmit runs fresh" stay
+  consistent. In-flight (non-terminal) duplicate suppression is preserved absolutely.
+  A fresh resubmit under a colliding key first calls the new `OpLog.evict_task/2`
+  (a projection prune, `DELETE FROM tasks`, results cascade via the FK; NOT an op),
+  so the fresh `:submitted` append does not trip the unique `(workload, key)` index.
+  The old task's ops stay in the journal until horizon compaction.
+
+### D-R1.0.3 Scheduled bounded-batch sweep + ops-journal prefix marker
+- A supervised `Embervm.OpLog.Compactor` (default hourly, values-configurable) loops
+  `compact/2` until `done`; each batch is a discrete call to the op-log's single
+  writer, so appends interleave between batches (the 5ms-append-budget guard).
+  `compact/2` is now ONE bounded batch (portable `DELETE ... WHERE rowid IN (SELECT
+  ... LIMIT ?)`, since Exqlite lacks `DELETE ... LIMIT`) returning per-table counts
+  plus the marker and `done`. The ops journal is prefix-compacted behind a durable
+  `compacted_through_seq` marker (a `meta` row): the marker advances only to a seq
+  where every op at or below it is older than the 30-day journal horizon AND not
+  owned by a live task, is monotonic (never decreases), and deletion is always a true
+  prefix. `read_from/2` below the marker returns `{:error, {:compacted, marker}}`,
+  distinct from an empty log, so a future replayer knows to load the projection
+  snapshot instead. The 30-day journal horizon and the 7-day terminal-task retention
+  are DISTINCT config (the journal carries request payloads; older audit is SigNoz).
+
+### D-R1.0.4 Dispatcher-side queued-task expiry (closes the D12 gap)
+- Added `{:queued, :expire} => :failed_permanent` to the FSM and `TaskStore.expire/2`
+  (reusing the existing `:failed` op with reason `expired`, no new op kind, no schema
+  change). The dispatcher, right after popping a queued task and BEFORE reserving a
+  VM, expires any task past its `expires_at` and skips dispatch, so an over-budget
+  parked task never runs after its deadline and never burns a primed VM. Expiry does
+  NOT dead-letter (it is not a processing failure; `failed_permanent` is terminal and
+  sufficient). This CLOSES the D12 "queued-task TTL not enforced" known gap.

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.23
+version: 0.1.24

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -46,6 +46,13 @@ spec:
               value: {{ .Values.service.port | quote }}
             - name: EMBERVM_OPLOG_PATH
               value: /var/lib/embervm/oplog.db
+            # Op-log retention (ADR embervm/002): the scheduled sweeper's cadence
+            # and the ops-journal prefix-compaction horizon. Seconds/days in values
+            # are converted to the ms the runtime parses.
+            - name: EMBERVM_OPLOG_SWEEP_INTERVAL_MS
+              value: {{ mul .Values.opLog.sweepIntervalSeconds 1000 | quote }}
+            - name: EMBERVM_OPLOG_JOURNAL_HORIZON_MS
+              value: {{ mul .Values.opLog.journalHorizonDays 86400 1000 | quote }}
             # Node identity + address for Embervm.NodeRegistry (Task 9). The
             # registry takes a LIST internally; v1 wires exactly one node from
             # these two values.

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -40,6 +40,15 @@ opLog:
   persistentVolume: true
   storageClass: longhorn
   size: 2Gi
+  # How often the supervised sweeper runs bounded-batch compaction (ADR
+  # embervm/002). Correctness (result TTLs) is enforced at read time, so this only
+  # governs how promptly reclaimed space is freed; hourly is ample for a 2Gi PVC.
+  sweepIntervalSeconds: 3600
+  # Age past which an append-only op is eligible for ops-journal prefix compaction,
+  # provided its task is not still live. Distinct from the 7-day terminal-task
+  # retention: this bounds the journal (which carries request payloads); older
+  # audit lives in SigNoz.
+  journalHorizonDays: 30
 
 # The single node daemon the control plane talks to (v1: exactly one). Address is
 # resolved in-cluster; the registry takes a list so multi-node needs no reshape.

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -46,7 +46,7 @@ defmodule Embervm.Application do
       # rest_for_one chain costs nothing.
       {Registry, keys: :duplicate, name: Embervm.TaskWaiters},
       Embervm.SyncWait,
-      {Embervm.OpLog.SQLite, path: oplog_path()},
+      {Embervm.OpLog.SQLite, path: oplog_path(), journal_horizon_ms: journal_horizon_ms()},
       # TaskStore fires on_metered after a :succeeded/:failed op with usage lands,
       # so Embervm.Metering charges the quota cache off the same durable write.
       {Embervm.TaskStore, [on_metered: &Embervm.Metering.on_metered/1]},
@@ -119,6 +119,13 @@ defmodule Embervm.Application do
       # during downtime are skipped, not replayed. After the watcher (reads the
       # catalog's triggers) and TaskStore (submits into it).
       Embervm.Trigger.Cron,
+      # The op-log sweeper (ADR embervm/002): scheduled bounded-batch compaction of
+      # the durable projection tables + ops-journal prefix. Placed LATE, right before
+      # Bandit: it depends ONLY on the op-log (which starts early), so under
+      # :rest_for_one a Compactor crash restarts only Bandit, the minimum blast
+      # radius. It adds no writer (each batch is a call to the op-log's single
+      # writer). Correctness (read-time TTLs) does not depend on it; it reclaims disk.
+      {Embervm.OpLog.Compactor, op_log: Embervm.OpLog.SQLite, interval_ms: sweep_interval_ms()},
       # Bandit + the router last: its handlers call Auth, TaskStore, SyncWait, and
       # the dispatcher's admit? gate, so the HTTP surface must not accept requests
       # until all are up.
@@ -149,6 +156,29 @@ defmodule Embervm.Application do
       nil -> nil
       "" -> nil
       path -> path
+    end
+  end
+
+  # The op-log sweeper cadence (EMBERVM_OPLOG_SWEEP_INTERVAL_MS, the chart wires
+  # this from values.opLog.sweepIntervalSeconds x 1000); default hourly. Distinct
+  # from the journal horizon below: this is HOW OFTEN we sweep, that is HOW OLD an
+  # op must be before it is eligible.
+  defp sweep_interval_ms do
+    case trimmed_env("EMBERVM_OPLOG_SWEEP_INTERVAL_MS") do
+      "" -> 3_600_000
+      raw -> String.to_integer(raw)
+    end
+  end
+
+  # The ops-journal prefix-compaction horizon (EMBERVM_OPLOG_JOURNAL_HORIZON_MS,
+  # the chart wires this from values.opLog.journalHorizonDays x 86_400_000);
+  # default 30 days. An op younger than this (or owned by a live task) is never
+  # compacted. Distinct from the terminal-task 7-day retention baked into the
+  # op-log; this bounds the append-only journal, that bounds the tasks projection.
+  defp journal_horizon_ms do
+    case trimmed_env("EMBERVM_OPLOG_JOURNAL_HORIZON_MS") do
+      "" -> 30 * 24 * 60 * 60 * 1000
+      raw -> String.to_integer(raw)
     end
   end
 

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -419,7 +419,35 @@ defmodule Embervm.Dispatcher do
 
   # Commit one task to a worker: reserve the VM (warm), drive queued->assigned->
   # running through the FSM, bump counters, spawn the assign worker, then recurse.
+  #
+  # First, TTL check (ADR embervm/002): a task popped past its `expires_at` is
+  # expired to failed_permanent and NEVER dispatched (no VM reserved, no primed VM
+  # consumed), then the loop continues draining. This runs BEFORE reserve_vm so an
+  # expired task cannot burn a primed VM. Wall clock, to match the wall-time
+  # `expires_at` the submit stamped.
   defp commit(state, wl, entry, node_id, mode, snapshot_ref, task_id, pr) do
+    if expired?(state, task_id) do
+      _ = safe(fn -> Embervm.TaskStore.expire(state.task_store, task_id) end)
+      release_depth(state, wl, pr)
+      state = Map.update!(state, :queued_ids, &MapSet.delete(&1, task_id))
+      drain_loop(state, wl, entry)
+    else
+      commit_dispatch(state, wl, entry, node_id, mode, snapshot_ref, task_id, pr)
+    end
+  end
+
+  # Whether the task's `expires_at` (wall-time ms, or nil for no TTL) has passed.
+  # Reads the ETS hot set (the dispatch hot path never touches the durable store);
+  # a task missing from ETS (a race) is treated as not-expired so the assign path's
+  # own not_found handling decides its fate.
+  defp expired?(state, task_id) do
+    case safe_call(fn -> Embervm.TaskStore.get(state.task_store, task_id) end) do
+      {:ok, {:ok, %{expires_at: exp}}} when is_integer(exp) -> state.wall_clock.() > exp
+      _ -> false
+    end
+  end
+
+  defp commit_dispatch(state, wl, entry, node_id, mode, snapshot_ref, task_id, pr) do
     {state, vm_id} = reserve_vm(state, node_id, wl, mode)
 
     with {:ok, {:ok, _}} <- safe_call(fn -> Embervm.TaskStore.assign(state.task_store, task_id) end),

--- a/projects/embervm/control/lib/embervm/op_log.ex
+++ b/projects/embervm/control/lib/embervm/op_log.ex
@@ -71,7 +71,16 @@ defmodule Embervm.OpLog do
   @type server :: GenServer.server()
 
   @callback append(server(), Op.t()) :: {:ok, seq :: pos_integer()} | {:error, term()}
-  @callback read_from(server(), seq :: non_neg_integer()) :: {:ok, [Op.t()]} | {:error, term()}
+  # Reads every op strictly after `seq` in ascending seq order. Because the ops
+  # journal is now prefix-compacted (ADR embervm/002), a caller asking for a
+  # `seq` that has already fallen below the durable `compacted_through_seq`
+  # marker gets `{:error, {:compacted, marker}}`, DISTINCT from `{:ok, []}` (an
+  # empty-but-intact log): the requested history is gone, replaced by projected
+  # state, so a replayer starting there must instead consult `compacted_through/1`
+  # and rebuild from the projection snapshot (`load_tasks/1`) rather than assume
+  # it saw the whole log. A `seq >= marker` behaves as before.
+  @callback read_from(server(), seq :: non_neg_integer()) ::
+              {:ok, [Op.t()]} | {:error, {:compacted, non_neg_integer()}} | {:error, term()}
   @callback load_tasks(server()) :: {:ok, [map()]} | {:error, term()}
   # Reads one task's stored result from the durable `results` projection, or
   # {:ok, nil} when there is none (never ran, or the TTL sweeper reaped it).
@@ -103,7 +112,33 @@ defmodule Embervm.OpLog do
   @callback list_usage(server(), opts :: keyword()) ::
               {:ok, %{items: [map()], total: non_neg_integer(), limit: term(), offset: non_neg_integer()}}
               | {:error, term()}
+  # Runs ONE bounded compaction batch as of `now_ms` and returns the counts it
+  # deleted plus the current ops-journal marker and whether the sweep is drained.
+  # `results_deleted`/`tasks_compacted`/`ops_compacted` are rows removed from
+  # each table THIS batch; `compacted_through` is the (possibly advanced) durable
+  # `compacted_through_seq` marker; `done` is false when any table hit the batch
+  # ceiling (more rows remain, call again). The scheduled sweeper
+  # (`Embervm.OpLog.Compactor`) loops until `done`, so appends interleave between
+  # batches (the 5ms-append-budget guard). GC does not emit ops.
   @callback compact(server(), now_ms :: integer()) ::
-              {:ok, %{results_deleted: non_neg_integer(), tasks_compacted: non_neg_integer()}}
+              {:ok,
+               %{
+                 results_deleted: non_neg_integer(),
+                 tasks_compacted: non_neg_integer(),
+                 ops_compacted: non_neg_integer(),
+                 compacted_through: non_neg_integer(),
+                 done: boolean()
+               }}
               | {:error, term()}
+  # The durable ops-journal prefix marker: every op with `seq <= this` has been
+  # (or is eligible to be) compacted away and is available only as projected
+  # state. Absent (never compacted) reads as 0. See `read_from/2`.
+  @callback compacted_through(server()) :: {:ok, non_neg_integer()} | {:error, term()}
+  # Prunes ONE task's projection rows (the `tasks` row and, via ON DELETE CASCADE,
+  # its `results` row) WITHOUT emitting an op. Used by the submit dedupe path when
+  # a terminal task's result has expired: the projection must be cleared so a fresh
+  # resubmit under the same idempotency key does not collide on the unique
+  # `(workload, idempotency_key)` index. The task's immutable `ops` remain in the
+  # journal until horizon compaction; only the projection is pruned early.
+  @callback evict_task(server(), task_id :: String.t()) :: :ok | {:error, term()}
 end

--- a/projects/embervm/control/lib/embervm/op_log/compactor.ex
+++ b/projects/embervm/control/lib/embervm/op_log/compactor.ex
@@ -1,0 +1,113 @@
+defmodule Embervm.OpLog.Compactor do
+  @moduledoc """
+  The scheduled op-log sweeper (ADR embervm/002 rule 2 + rule 3): a supervised
+  GenServer that periodically drives `Embervm.OpLog.SQLite.compact/2` to reclaim
+  space, then logs one structured summary line.
+
+  It owns NO SQLite connection and adds NO second writer. Every batch is a
+  discrete `GenServer.call` to the op-log's single-writer process, so appends
+  queued on that mailbox interleave BETWEEN batches by construction: the sweep is
+  a loop of bounded batches, not one long transaction, which is what keeps a large
+  reclamation from head-of-line-blocking the 5ms append budget. Correctness never
+  depends on this cadence (TTLs are enforced at read time in `Embervm.TaskStore`);
+  the sweeper only reclaims disk.
+
+  It is placed LATE in the application's `:rest_for_one` tree (right before Bandit)
+  because it depends only on the op-log, which starts early: a Compactor crash
+  restarts only Bandit, the minimum blast radius.
+  """
+
+  use GenServer
+  require Logger
+
+  # Default cadence: hourly. The application wires this from
+  # EMBERVM_OPLOG_SWEEP_INTERVAL_MS (chart values.opLog.sweepIntervalSeconds).
+  @default_interval_ms 3_600_000
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    state = %{
+      op_log: Keyword.get(opts, :op_log, Embervm.OpLog.SQLite),
+      interval_ms: Keyword.get(opts, :interval_ms, @default_interval_ms)
+    }
+
+    schedule_sweep(state)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    run_sweep(state)
+    schedule_sweep(state)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # One sweep: loop compact/2 until the op-log reports `done: true`, accumulating
+  # per-table totals, then log one summary. `now_ms` is injected ONCE per sweep so
+  # every batch prunes against the same instant (a task cannot straddle the
+  # retention/horizon cutoff between batches). Each batch is a separate call, so
+  # appends interleave. A compact error aborts the loop and logs what was reclaimed
+  # so far; the next scheduled sweep retries.
+  defp run_sweep(state) do
+    now_ms = System.system_time(:millisecond)
+    totals = %{results_deleted: 0, tasks_compacted: 0, ops_compacted: 0, compacted_through: 0}
+    sweep_loop(state, now_ms, totals)
+  end
+
+  defp sweep_loop(state, now_ms, totals) do
+    case Embervm.OpLog.SQLite.compact(state.op_log, now_ms) do
+      {:ok, batch} ->
+        totals = %{
+          results_deleted: totals.results_deleted + batch.results_deleted,
+          tasks_compacted: totals.tasks_compacted + batch.tasks_compacted,
+          ops_compacted: totals.ops_compacted + batch.ops_compacted,
+          # The marker is monotonic and reported per batch; the last batch's value
+          # is the authoritative post-sweep marker.
+          compacted_through: batch.compacted_through
+        }
+
+        if batch.done do
+          log_summary(state, totals)
+        else
+          sweep_loop(state, now_ms, totals)
+        end
+
+      {:error, reason} ->
+        Logger.warning("embervm op-log sweep aborted: #{inspect(reason)}; reclaimed=#{inspect(totals)}")
+    end
+  end
+
+  defp log_summary(state, totals) do
+    db_size =
+      case Embervm.OpLog.SQLite.db_size(state.op_log) do
+        {:ok, size} -> size
+        {:error, _} -> nil
+      end
+
+    Logger.info(
+      "embervm op-log sweep complete " <>
+        inspect(
+          results_deleted: totals.results_deleted,
+          tasks_compacted: totals.tasks_compacted,
+          ops_compacted: totals.ops_compacted,
+          compacted_through: totals.compacted_through,
+          db_size_bytes: db_size
+        )
+    )
+  end
+
+  defp schedule_sweep(state) do
+    Process.send_after(self(), :sweep, state.interval_ms)
+    state
+  end
+end

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -4,9 +4,17 @@ defmodule Embervm.OpLog.SQLite do
   GenServer owning one `Exqlite.Sqlite3` connection. Every append is one
   transaction that writes the immutable `ops` row and write-through projects
   it into the mutable `tasks`/`results` tables the dispatcher's ETS rebuild
-  (Task 7) reads on boot. The op-log itself (the `ops` table) is append-only
-  and is never rewritten by a projection; `compact/2` only prunes the
-  projection tables (expired results, terminal tasks past retention).
+  (Task 7) reads on boot. `compact/2` prunes the projection tables (expired
+  results, terminal tasks past retention) AND prefix-compacts the `ops` journal
+  itself (ADR embervm/002): ops are deleted from the front behind a durable
+  `compacted_through_seq` marker (a row in the `meta` table). The marker only
+  advances to a seq such that every op at or below it is older than the journal
+  horizon (default 30 days) AND not owned by a live (non-terminal) task, so the
+  deletion is always a true prefix (`seq <= marker`) and ops for in-flight work
+  are never removed regardless of age. A future replayer (a `ra` replica, the R6
+  watch) that starts below the marker learns that history is available only as
+  projected state, not as ops: `read_from/2` returns `{:error, {:compacted, _}}`
+  there rather than an empty log. GC never emits an op.
 
   WAL is chosen for local durability on the pod's PVC: readers never block
   the writer and vice versa, though in R0 we still serialize all access
@@ -24,9 +32,23 @@ defmodule Embervm.OpLog.SQLite do
   alias Exqlite.Sqlite3
 
   @terminal_states ["succeeded", "failed_permanent", "dead_lettered"]
+  # The complementary set: states a task can still leave, so its ops must never be
+  # prefix-compacted regardless of age. Used by the marker computation below.
+  @live_states ["queued", "assigned", "running", "failed_retryable"]
   # Seven days in milliseconds: default age (from last update) at which a
-  # terminal task is eligible for compaction.
+  # terminal task is eligible for compaction. This is the TERMINAL-TASK retention
+  # window and is DISTINCT from the ops-journal horizon below.
   @default_retention_ms 7 * 24 * 60 * 60 * 1000
+  # Thirty days in milliseconds: default age past which an op is eligible for
+  # prefix compaction, PROVIDED its task is not still live. The ops journal is
+  # the on-box book of record for recovery and recent audit; older audit is
+  # delegated to SigNoz (ADR embervm/002). DISTINCT from @default_retention_ms.
+  @default_journal_horizon_ms 30 * 24 * 60 * 60 * 1000
+  # Rows deleted per table per compact/2 batch: bounds how long the single writer
+  # holds the connection so appends queued behind it never blow the 5ms budget.
+  @default_compact_batch_size 500
+  # The meta key the durable ops-journal prefix marker lives at; absent reads 0.
+  @marker_key "compacted_through_seq"
 
   @ddl [
     """
@@ -88,6 +110,17 @@ defmodule Embervm.OpLog.SQLite do
       updated_at INTEGER NOT NULL,
       PRIMARY KEY (principal, day)
     )
+    """,
+    # Durable single-row scalars for the op-log. Today it holds only the
+    # ops-journal prefix marker (`compacted_through_seq`): the newest op seq that
+    # has been prefix-compacted away, part of the durable OpLog contract so a
+    # future replayer knows history below it is projected state, not ops. Absent
+    # reads as 0.
+    """
+    CREATE TABLE IF NOT EXISTS meta (
+      key TEXT PRIMARY KEY,
+      value INTEGER
+    )
     """
   ]
 
@@ -144,18 +177,47 @@ defmodule Embervm.OpLog.SQLite do
     GenServer.call(server, {:compact, now_ms})
   end
 
+  @impl Embervm.OpLog
+  def compacted_through(server \\ __MODULE__) do
+    GenServer.call(server, :compacted_through)
+  end
+
+  @impl Embervm.OpLog
+  def evict_task(server \\ __MODULE__, task_id) do
+    GenServer.call(server, {:evict_task, task_id})
+  end
+
+  # The op-log's database file size in bytes, for the sweeper's disk-usage log
+  # field (ADR embervm/002 rule 4). Reads the connection's own path from state so
+  # the Compactor never needs to know it; the WAL/SHM sidecars are not counted
+  # (the main db is what the retention policy bounds).
+  @spec db_size(GenServer.server()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def db_size(server \\ __MODULE__) do
+    GenServer.call(server, :db_size)
+  end
+
   # -- GenServer callbacks ------------------------------------------------
 
   @impl true
   def init(opts) do
     path = Keyword.get(opts, :path) || default_path()
     retention_ms = Keyword.get(opts, :retention_ms, @default_retention_ms)
+    journal_horizon_ms = Keyword.get(opts, :journal_horizon_ms, @default_journal_horizon_ms)
+    compact_batch_size = Keyword.get(opts, :compact_batch_size, @default_compact_batch_size)
 
     with {:ok, conn} <- Sqlite3.open(path),
          :ok <- apply_pragmas(conn),
          :ok <- apply_ddl(conn) do
       Logger.info("embervm op-log opened at #{path}")
-      {:ok, %{conn: conn, path: path, retention_ms: retention_ms}}
+
+      {:ok,
+       %{
+         conn: conn,
+         path: path,
+         retention_ms: retention_ms,
+         journal_horizon_ms: journal_horizon_ms,
+         compact_batch_size: compact_batch_size
+       }}
     else
       {:error, reason} -> {:stop, {:open_failed, reason}}
     end
@@ -196,7 +258,25 @@ defmodule Embervm.OpLog.SQLite do
   end
 
   def handle_call({:compact, now_ms}, _from, state) do
-    {:reply, do_compact(state.conn, now_ms, state.retention_ms), state}
+    {:reply, do_compact(state.conn, now_ms, state), state}
+  end
+
+  def handle_call(:compacted_through, _from, state) do
+    {:reply, {:ok, read_marker(state.conn)}, state}
+  end
+
+  def handle_call({:evict_task, task_id}, _from, state) do
+    {:reply, do_evict_task(state.conn, task_id), state}
+  end
+
+  def handle_call(:db_size, _from, state) do
+    reply =
+      case File.stat(state.path) do
+        {:ok, %File.Stat{size: size}} -> {:ok, size}
+        {:error, reason} -> {:error, reason}
+      end
+
+    {:reply, reply, state}
   end
 
   # -- append + projection -------------------------------------------------
@@ -439,17 +519,29 @@ defmodule Embervm.OpLog.SQLite do
 
   # -- reads ---------------------------------------------------------------
 
+  # A caller asking for a `seq` below the durable prefix marker is asking for
+  # history that has been compacted away (it lives only as projected state now),
+  # which MUST be distinguishable from an empty-but-intact log so a replayer does
+  # not silently assume it saw the whole journal. `read_from/2` reads ops STRICTLY
+  # after `seq`, so any `seq >= marker` still sees every surviving op; only a
+  # `seq < marker` could miss compacted ops, hence the guard. See ADR embervm/002.
   defp do_read_from(conn, seq) do
-    sql = """
-    SELECT seq, ts, tenant, principal, workload, task_id, kind, payload_json
-    FROM ops WHERE seq > ? ORDER BY seq ASC
-    """
+    marker = read_marker(conn)
 
-    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
-         :ok <- Sqlite3.bind(stmt, [seq]) do
-      ops = collect_ops(conn, stmt, [])
-      :ok = Sqlite3.release(conn, stmt)
-      {:ok, ops}
+    if seq < marker do
+      {:error, {:compacted, marker}}
+    else
+      sql = """
+      SELECT seq, ts, tenant, principal, workload, task_id, kind, payload_json
+      FROM ops WHERE seq > ? ORDER BY seq ASC
+      """
+
+      with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+           :ok <- Sqlite3.bind(stmt, [seq]) do
+        ops = collect_ops(conn, stmt, [])
+        :ok = Sqlite3.release(conn, stmt)
+        {:ok, ops}
+      end
     end
   end
 
@@ -650,21 +742,46 @@ defmodule Embervm.OpLog.SQLite do
 
   # -- compaction ------------------------------------------------------------
 
-  # Prunes only the mutable projection tables. The ops table is the durable
-  # audit log and is never rewritten here; ops-table rotation/archival is a
-  # documented follow-on, not part of this seam.
-  defp do_compact(conn, now_ms, retention_ms) do
-    with {:ok, results_deleted} <- delete_expired_results(conn, now_ms),
-         {:ok, tasks_compacted} <- delete_terminal_tasks(conn, now_ms, retention_ms) do
-      {:ok, %{results_deleted: results_deleted, tasks_compacted: tasks_compacted}}
+  # ONE bounded batch (ADR embervm/002): at most `compact_batch_size` deletions
+  # per table so the single writer never holds the connection long enough to blow
+  # the 5ms append budget (the scheduled Compactor loops until `done`, and each
+  # batch is a discrete GenServer call, so queued appends interleave between them).
+  # Prunes the projection tables (expired results, terminal tasks past retention)
+  # AND prefix-compacts the ops journal behind the durable marker. `done` is true
+  # only when every table came in under the batch ceiling (nothing left to sweep).
+  defp do_compact(conn, now_ms, state) do
+    batch = state.compact_batch_size
+
+    with {:ok, results_deleted} <- delete_expired_results(conn, now_ms, batch),
+         {:ok, tasks_compacted} <- delete_terminal_tasks(conn, now_ms, state.retention_ms, batch),
+         {:ok, ops_compacted, marker} <- compact_ops(conn, now_ms, state.journal_horizon_ms, batch) do
+      done =
+        results_deleted < batch and tasks_compacted < batch and ops_compacted < batch
+
+      {:ok,
+       %{
+         results_deleted: results_deleted,
+         tasks_compacted: tasks_compacted,
+         ops_compacted: ops_compacted,
+         compacted_through: marker,
+         done: done
+       }}
     end
   end
 
-  defp delete_expired_results(conn, now_ms) do
-    sql = "DELETE FROM results WHERE expires_at IS NOT NULL AND expires_at < ?"
+  # Bounded DELETE via the portable rowid-subquery form: Exqlite's bundled SQLite
+  # is not built with SQLITE_ENABLE_UPDATE_DELETE_LIMIT, so `DELETE ... LIMIT` is
+  # unavailable; `DELETE ... WHERE rowid IN (SELECT rowid ... LIMIT ?)` bounds the
+  # batch on any build.
+  defp delete_expired_results(conn, now_ms, batch) do
+    sql = """
+    DELETE FROM results WHERE rowid IN (
+      SELECT rowid FROM results WHERE expires_at IS NOT NULL AND expires_at < ? LIMIT ?
+    )
+    """
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
-         :ok <- Sqlite3.bind(stmt, [now_ms]),
+         :ok <- Sqlite3.bind(stmt, [now_ms, batch]),
          :done <- Sqlite3.step(conn, stmt),
          :ok <- Sqlite3.release(conn, stmt),
          {:ok, changed} <- Sqlite3.changes(conn) do
@@ -672,17 +789,151 @@ defmodule Embervm.OpLog.SQLite do
     end
   end
 
-  defp delete_terminal_tasks(conn, now_ms, retention_ms) do
+  defp delete_terminal_tasks(conn, now_ms, retention_ms, batch) do
     cutoff = now_ms - retention_ms
     placeholders = @terminal_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
-    sql = "DELETE FROM tasks WHERE state IN (#{placeholders}) AND updated_at < ?"
+
+    sql = """
+    DELETE FROM tasks WHERE rowid IN (
+      SELECT rowid FROM tasks WHERE state IN (#{placeholders}) AND updated_at < ? LIMIT ?
+    )
+    """
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
-         :ok <- Sqlite3.bind(stmt, @terminal_states ++ [cutoff]),
+         :ok <- Sqlite3.bind(stmt, @terminal_states ++ [cutoff, batch]),
          :done <- Sqlite3.step(conn, stmt),
          :ok <- Sqlite3.release(conn, stmt),
          {:ok, changed} <- Sqlite3.changes(conn) do
       {:ok, changed}
+    end
+  end
+
+  # Advance the durable ops-journal prefix marker (monotonic, prefix-safe,
+  # horizon-bounded), then batch-delete `ops WHERE seq <= marker`.
+  #
+  # The marker may only reach a seq such that EVERY op at or below it is (a) older
+  # than the horizon AND (b) not owned by a live (non-terminal) task. We find the
+  # smallest seq that must stay BLOCKED (the first op that is either recent OR owned
+  # by a live task); the highest safely-compactable candidate is one below it. With
+  # no blocker at all, the whole log is compactable up to MAX(seq). The marker never
+  # decreases (`max(current, candidate)`), so a shrinking horizon or a task going
+  # live again can never un-compact already-projected history.
+  defp compact_ops(conn, now_ms, journal_horizon_ms, batch) do
+    cutoff = now_ms - journal_horizon_ms
+    current = read_marker(conn)
+
+    with {:ok, blocker} <- blocker_seq(conn, cutoff),
+         {:ok, candidate} <- marker_candidate(conn, blocker) do
+      new_marker = max(current, candidate)
+
+      with :ok <- write_marker(conn, new_marker),
+           {:ok, deleted} <- delete_ops_prefix(conn, new_marker, batch) do
+        {:ok, deleted, new_marker}
+      end
+    end
+  end
+
+  # The smallest seq that must NOT be compacted: the first op that is either newer
+  # than the horizon (ts >= cutoff) or owned by a live (non-terminal) task. NULL
+  # means no op is blocked, so the whole log is eligible.
+  defp blocker_seq(conn, cutoff) do
+    live_placeholders = @live_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
+
+    sql = """
+    SELECT MIN(seq) FROM ops
+    WHERE ts >= ?
+       OR task_id IN (SELECT task_id FROM tasks WHERE state IN (#{live_placeholders}))
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [cutoff] ++ @live_states) do
+      result =
+        case Sqlite3.step(conn, stmt) do
+          {:row, [seq]} -> {:ok, seq}
+          :done -> {:ok, nil}
+          {:error, reason} -> {:error, reason}
+        end
+
+      :ok = Sqlite3.release(conn, stmt)
+      result
+    end
+  end
+
+  # No blocker -> the whole log is compactable up to its max seq (0 for an empty
+  # log). Otherwise everything strictly below the first blocked op is compactable.
+  defp marker_candidate(_conn, blocker) when is_integer(blocker), do: {:ok, blocker - 1}
+
+  defp marker_candidate(conn, nil) do
+    with {:ok, stmt} <- Sqlite3.prepare(conn, "SELECT MAX(seq) FROM ops") do
+      result =
+        case Sqlite3.step(conn, stmt) do
+          {:row, [nil]} -> {:ok, 0}
+          {:row, [seq]} -> {:ok, seq}
+          :done -> {:ok, 0}
+          {:error, reason} -> {:error, reason}
+        end
+
+      :ok = Sqlite3.release(conn, stmt)
+      result
+    end
+  end
+
+  defp delete_ops_prefix(conn, marker, batch) do
+    sql = """
+    DELETE FROM ops WHERE rowid IN (
+      SELECT rowid FROM ops WHERE seq <= ? LIMIT ?
+    )
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [marker, batch]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt),
+         {:ok, changed} <- Sqlite3.changes(conn) do
+      {:ok, changed}
+    end
+  end
+
+  # Reads the durable prefix marker (`meta.compacted_through_seq`); absent -> 0.
+  defp read_marker(conn) do
+    with {:ok, stmt} <- Sqlite3.prepare(conn, "SELECT value FROM meta WHERE key = ?"),
+         :ok <- Sqlite3.bind(stmt, [@marker_key]) do
+      result =
+        case Sqlite3.step(conn, stmt) do
+          {:row, [value]} -> value
+          _ -> 0
+        end
+
+      :ok = Sqlite3.release(conn, stmt)
+      result
+    else
+      _ -> 0
+    end
+  end
+
+  defp write_marker(conn, value) do
+    sql = """
+    INSERT INTO meta (key, value) VALUES (?, ?)
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [@marker_key, value]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # Projection prune (no op emitted): drops one task's `tasks` row; its `results`
+  # row cascades (FK ON DELETE CASCADE, foreign_keys=ON). The dedupe path calls this
+  # before a fresh resubmit under a colliding idempotency key.
+  defp do_evict_task(conn, task_id) do
+    with {:ok, stmt} <- Sqlite3.prepare(conn, "DELETE FROM tasks WHERE task_id = ?"),
+         :ok <- Sqlite3.bind(stmt, [task_id]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
     end
   end
 

--- a/projects/embervm/control/lib/embervm/task_state.ex
+++ b/projects/embervm/control/lib/embervm/task_state.ex
@@ -41,7 +41,8 @@ defmodule Embervm.TaskState do
     :fail_permanent,
     :retry,
     :dead_letter,
-    :redrive
+    :redrive,
+    :expire
   ]
 
   # The transition table. Every legal (state, event) pair the control plane
@@ -53,8 +54,16 @@ defmodule Embervm.TaskState do
   # leaves a terminal state, which is why it is enumerated explicitly rather
   # than folded into `:retry` (retry increments the attempt counter and only
   # applies to `:failed_retryable`; redrive RESETS the counter, see TaskStore).
+  #
+  # `:expire` (ADR embervm/002) moves a `:queued` task whose `expires_at` has
+  # passed straight to `:failed_permanent`: the dispatcher fires it when it pops a
+  # task past its TTL, so an over-budget parked task never dispatches after its
+  # deadline (closing the D12 queued-task-TTL gap). Only `:queued` needs it (only
+  # queued tasks are popped for dispatch); it does NOT dead-letter (expiry is not a
+  # processing failure).
   @transitions %{
     {:queued, :assign} => :assigned,
+    {:queued, :expire} => :failed_permanent,
     {:assigned, :start} => :running,
     {:assigned, :fail_retryable} => :failed_retryable,
     {:assigned, :fail_permanent} => :failed_permanent,
@@ -84,6 +93,7 @@ defmodule Embervm.TaskState do
           | :retry
           | :dead_letter
           | :redrive
+          | :expire
 
   @spec states() :: [state()]
   def states, do: @states

--- a/projects/embervm/control/lib/embervm/task_store.ex
+++ b/projects/embervm/control/lib/embervm/task_store.ex
@@ -208,6 +208,21 @@ defmodule Embervm.TaskStore do
   end
 
   @doc """
+  Expires a queued task whose `expires_at` has passed: `queued -> failed_permanent`
+  with reason `expired`, appending the existing `:failed` op (no new op kind, no
+  schema change). The dispatcher calls this when it pops a queued task past its TTL,
+  so an over-budget parked task never dispatches after its deadline (ADR embervm/002,
+  closing the D12 queued-task-TTL gap). Fails `:illegal_transition` for any task not
+  currently `:queued` (only queued tasks are popped for dispatch). Expiry is not a
+  processing failure, so it does NOT chain into the dead-letter queue: `failed_permanent`
+  is terminal and sufficient.
+  """
+  @spec expire(GenServer.server(), String.t()) :: {:ok, map()} | {:error, term()}
+  def expire(store \\ __MODULE__, task_id) do
+    GenServer.call(store, {:expire, task_id})
+  end
+
+  @doc """
   Reassigns every in-flight task (`assigned` or `running`) as a retryable
   transport failure and returns how many were reassigned. This is the
   at-least-once path `Embervm.NodeRegistry` calls when a node goes down: a task
@@ -335,10 +350,55 @@ defmodule Embervm.TaskStore do
 
     case idempotency_key && :ets.lookup(state.idem, {workload, idempotency_key}) do
       [{_key, existing_task_id}] ->
-        {:reply, {:ok, :existing, existing_task_id}, state}
+        dedupe_or_resubmit(attrs, workload, idempotency_key, existing_task_id, state)
 
       _ ->
         do_submit(attrs, workload, idempotency_key, state)
+    end
+  end
+
+  # An idempotency-key ETS hit. In-flight (non-terminal) duplicate suppression is
+  # ABSOLUTE: a still-queued/assigned/running/failed_retryable existing task means
+  # the resubmit is a duplicate of live work, so return :existing unchanged. For a
+  # TERMINAL existing task, dedupe holds only while its result is still serveable:
+  # we key the dedupe on the SAME read-time expiry signal as get_result/2 (ADR
+  # embervm/002 rule 1), so "the GET 404s" and "the resubmit runs fresh" stay
+  # consistent. When the cached result is gone (never had one, or past its TTL) the
+  # task is treated as ABSENT: evict its stale projection row (so the fresh
+  # :submitted append does not collide on the unique (workload, key) index), drop
+  # its ETS entries, and submit anew.
+  defp dedupe_or_resubmit(attrs, workload, idempotency_key, existing_task_id, state) do
+    case fetch_task(state, existing_task_id) do
+      {:ok, %{state: task_state}} ->
+        cond do
+          task_state not in TaskState.terminal_states() ->
+            {:reply, {:ok, :existing, existing_task_id}, state}
+
+          match?({:ok, result} when is_map(result), live_result(state, existing_task_id)) ->
+            {:reply, {:ok, :existing, existing_task_id}, state}
+
+          true ->
+            fresh_resubmit(attrs, workload, idempotency_key, existing_task_id, state)
+        end
+
+      {:error, _reason} ->
+        # ETS lost the id (a compaction/eviction race): submit fresh.
+        do_submit(attrs, workload, idempotency_key, state)
+    end
+  end
+
+  # Prune the stale existing task's durable projection row (results cascade) and its
+  # ETS entries, then submit fresh under the same key. The old task's immutable ops
+  # stay in the journal until horizon compaction; only the projection is pruned early.
+  defp fresh_resubmit(attrs, workload, idempotency_key, old_task_id, state) do
+    case Embervm.OpLog.SQLite.evict_task(state.op_log, old_task_id) do
+      :ok ->
+        :ets.delete(state.tasks, old_task_id)
+        :ets.delete(state.idem, {workload, idempotency_key})
+        do_submit(attrs, workload, idempotency_key, state)
+
+      {:error, _reason} = error ->
+        {:reply, error, state}
     end
   end
 
@@ -429,7 +489,7 @@ defmodule Embervm.TaskStore do
   end
 
   def handle_call({:get_result, task_id}, _from, state) do
-    {:reply, Embervm.OpLog.SQLite.load_result(state.op_log, task_id), state}
+    {:reply, live_result(state, task_id), state}
   end
 
   def handle_call({:get_request, task_id}, _from, state) do
@@ -511,6 +571,18 @@ defmodule Embervm.TaskStore do
 
         {:error, _reason} = error ->
           {:reply, error, state}
+      end
+    else
+      {:error, _reason} = error -> {:reply, error, state}
+    end
+  end
+
+  def handle_call({:expire, task_id}, _from, state) do
+    with {:ok, task} <- fetch_task(state, task_id),
+         {:ok, next} <- TaskState.transition(task.state, :expire) do
+      case append_and_update(state, task, :failed, next, %{state: next, reason: :expired}) do
+        {:ok, updated} -> {:reply, {:ok, updated}, state}
+        {:error, _reason} = error -> {:reply, error, state}
       end
     else
       {:error, _reason} = error -> {:reply, error, state}
@@ -729,6 +801,23 @@ defmodule Embervm.TaskStore do
     end
 
     :ok
+  end
+
+  # Read-time result TTL (ADR embervm/002 rule 1): loads the stored result and
+  # treats one whose integer `expires_at` is already past (against the injected
+  # clock) as absent, replying {:ok, nil}. This makes GET /v1/tasks/{id}/result
+  # 404 the moment the TTL lapses, independent of whether the sweeper has run, and
+  # is the SAME signal the submit dedupe path keys on so the two stay consistent.
+  # The clock lives here in the store, so the filter stays here rather than in the
+  # op-log's load_result (whose behaviour signature is unchanged).
+  defp live_result(state, task_id) do
+    case Embervm.OpLog.SQLite.load_result(state.op_log, task_id) do
+      {:ok, %{expires_at: expires_at} = result} when is_integer(expires_at) ->
+        if expires_at < state.clock.(), do: {:ok, nil}, else: {:ok, result}
+
+      other ->
+        other
+    end
   end
 
   defp fetch_task(state, task_id) do

--- a/projects/embervm/control/test/embervm/dispatcher_test.exs
+++ b/projects/embervm/control/test/embervm/dispatcher_test.exs
@@ -467,6 +467,39 @@ defmodule Embervm.DispatcherTest do
     assert Dispatcher.stats(ctx.name).denials.quota > 0
   end
 
+  # -- queued-task expiry at dispatch (ADR embervm/002) ----------------------
+
+  test "a queued task popped past its expires_at is expired, not dispatched (no VM consumed)" do
+    {:ok, assigns} = Agent.start_link(fn -> 0 end)
+
+    count_assign = fn _ch, _req ->
+      Agent.update(assigns, &(&1 + 1))
+      {:ok, success_resp()}
+    end
+
+    # wall_clock is well past the task's expires_at, so at pop time the task is
+    # expired to failed_permanent and never assigned; the primed VM is untouched.
+    ctx = start_stack(assign_fun: count_assign, wall_clock: fn -> 2_000_000 end)
+    put_catalog(ctx, "wl-x", cap: 10)
+    put_facts(ctx, "wl-x", free: 1)
+    Dispatcher.deposit(ctx.name, "node-4", "wl-x", "vm-1")
+
+    {:ok, :created, tid} =
+      TaskStore.submit(ctx.store, %{
+        tenant: "t",
+        principal: "p1",
+        workload: "wl-x",
+        expires_at: 1_000,
+        request: %{path: "/", headers: %{}, body_b64: Base.encode64("")}
+      })
+
+    assert eventually(fn -> state_of(ctx, tid) == :failed_permanent end)
+    # Never dispatched: no assign call, so the primed VM was not consumed.
+    Process.sleep(50)
+    assert Agent.get(assigns, & &1) == 0
+    assert Map.get(Dispatcher.stats(ctx.name).inventory, {"node-4", "wl-x"}) == 1
+  end
+
   defp open_gate(agent), do: Agent.update(agent, fn _ -> true end)
 
   # An assign_fun that blocks (holding the task in-flight) until the gate opens,

--- a/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
@@ -246,6 +246,238 @@ defmodule Embervm.OpLog.SQLiteTest do
     :ok = GenServer.stop(server)
   end
 
+  # -- retention + prefix compaction (ADR embervm/002) -----------------------
+
+  test "evict_task deletes the task projection row and cascades its result", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :submitted,
+        tenant: "t1",
+        principal: "p1",
+        workload: "wl-ev",
+        task_id: "task-ev",
+        ts: 100,
+        payload: %{idempotency_key: "ev-key"}
+      })
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :succeeded,
+        tenant: "t1",
+        task_id: "task-ev",
+        ts: 101,
+        payload: %{status_code: 200, body: "r", size_bytes: 1, truncated: false, expires_at: 9_999}
+      })
+
+    # Present before eviction.
+    assert {:ok, %{status_code: 200}} = SQLite.load_result(server, "task-ev")
+    {:ok, tasks} = SQLite.load_tasks(server)
+    assert Enum.any?(tasks, &(&1.task_id == "task-ev"))
+
+    assert :ok = SQLite.evict_task(server, "task-ev")
+
+    # Task row gone AND its result cascaded (FK ON DELETE CASCADE).
+    {:ok, tasks2} = SQLite.load_tasks(server)
+    refute Enum.any?(tasks2, &(&1.task_id == "task-ev"))
+    assert {:ok, nil} = SQLite.load_result(server, "task-ev")
+
+    # The immutable submitted op is untouched (only the projection was pruned).
+    {:ok, ops} = SQLite.read_from(server, 0)
+    assert Enum.any?(ops, &(&1.kind == :submitted and &1.task_id == "task-ev"))
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "compacted_through starts at 0 and advances after horizon compaction", %{path: path} do
+    # journal_horizon_ms 0: every op is immediately past the horizon, so a fully
+    # terminal log compacts its whole prefix.
+    server = start_server(path, journal_horizon_ms: 0)
+
+    assert {:ok, 0} = SQLite.compacted_through(server)
+
+    # A complete terminal task (submitted -> succeeded), all ops old (ts 100/101).
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :submitted,
+        tenant: "t1",
+        principal: "p1",
+        workload: "wl-c",
+        task_id: "task-c",
+        ts: 100,
+        payload: %{}
+      })
+
+    {:ok, last_seq} =
+      SQLite.append(server, %Op{
+        kind: :succeeded,
+        tenant: "t1",
+        task_id: "task-c",
+        ts: 101,
+        payload: %{status_code: 200, body: "", size_bytes: 0, truncated: false, expires_at: nil}
+      })
+
+    # now well past ts, horizon 0: the whole prefix is eligible; task is terminal.
+    {:ok, res} = SQLite.compact(server, 10_000)
+    assert res.compacted_through == last_seq
+    assert res.ops_compacted == 2
+    assert {:ok, ^last_seq} = SQLite.compacted_through(server)
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "marker never advances past a live task's ops nor past the horizon", %{path: path} do
+    server = start_server(path, journal_horizon_ms: 1_000)
+
+    # Task L: submitted then assigned, still LIVE (non-terminal). Old ts.
+    {:ok, live_submit_seq} =
+      SQLite.append(server, %Op{
+        kind: :submitted,
+        tenant: "t1",
+        principal: "p1",
+        workload: "wl-l",
+        task_id: "task-l",
+        ts: 100,
+        payload: %{}
+      })
+
+    {:ok, _} =
+      SQLite.append(server, %Op{kind: :assigned, tenant: "t1", task_id: "task-l", ts: 101, payload: %{}})
+
+    # Task D: fully terminal, also old.
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :submitted,
+        tenant: "t1",
+        principal: "p1",
+        workload: "wl-d",
+        task_id: "task-d",
+        ts: 102,
+        payload: %{}
+      })
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :succeeded,
+        tenant: "t1",
+        task_id: "task-d",
+        ts: 103,
+        payload: %{status_code: 200, body: "", size_bytes: 0, truncated: false, expires_at: nil}
+      })
+
+    # A RECENT op (ts 10_000), within the horizon at now=10_500 (cutoff 9_500).
+    {:ok, _} =
+      SQLite.append(server, %Op{kind: :denied, tenant: "t1", ts: 10_000, payload: %{}})
+
+    # cutoff = 10_500 - 1_000 = 9_500. The live task's submitted op (seq
+    # live_submit_seq) is the smallest blocked seq (owned by a non-terminal task),
+    # so the marker can only reach live_submit_seq - 1.
+    {:ok, res} = SQLite.compact(server, 10_500)
+    assert res.compacted_through == live_submit_seq - 1
+
+    # The live task's ops and the recent op are all still readable.
+    {:ok, ops} = SQLite.read_from(server, live_submit_seq - 1)
+    kinds = Enum.map(ops, & &1.kind)
+    assert :assigned in kinds
+    assert :denied in kinds
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "read_from below the marker errors as {:compacted, marker}, at/above returns ops", %{path: path} do
+    server = start_server(path, journal_horizon_ms: 0)
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :submitted,
+        tenant: "t1",
+        principal: "p1",
+        workload: "wl-r",
+        task_id: "task-r",
+        ts: 100,
+        payload: %{}
+      })
+
+    {:ok, last_seq} =
+      SQLite.append(server, %Op{
+        kind: :succeeded,
+        tenant: "t1",
+        task_id: "task-r",
+        ts: 101,
+        payload: %{status_code: 200, body: "", size_bytes: 0, truncated: false, expires_at: nil}
+      })
+
+    {:ok, res} = SQLite.compact(server, 10_000)
+    marker = res.compacted_through
+    assert marker == last_seq
+
+    # A seq below the marker is compacted-away history, distinguishable from empty.
+    assert {:error, {:compacted, ^marker}} = SQLite.read_from(server, marker - 1)
+
+    # At the marker: intact (empty here, since everything <= marker is gone), NOT
+    # an error.
+    assert {:ok, []} = SQLite.read_from(server, marker)
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "compaction is bounded: a small batch_size finishes across successive calls", %{path: path} do
+    # batch_size 2, horizon 0: with 5 fully-terminal single-op-ish tasks whose ops
+    # all qualify, one compact/2 deletes at most 2 ops and reports done:false until
+    # the prefix is drained.
+    server = start_server(path, journal_horizon_ms: 0, compact_batch_size: 2)
+
+    # Five standalone audit ops (no task ownership blocks compaction), all old.
+    for i <- 1..5 do
+      {:ok, _} = SQLite.append(server, %Op{kind: :denied, tenant: "t1", ts: 100 + i, payload: %{}})
+    end
+
+    # First batch: 2 ops, not done.
+    {:ok, b1} = SQLite.compact(server, 10_000)
+    assert b1.ops_compacted == 2
+    assert b1.done == false
+    assert b1.compacted_through == 5
+
+    # Second batch: 2 more, still not done.
+    {:ok, b2} = SQLite.compact(server, 10_000)
+    assert b2.ops_compacted == 2
+    assert b2.done == false
+
+    # Third batch: last 1, now done (under the ceiling on every table).
+    {:ok, b3} = SQLite.compact(server, 10_000)
+    assert b3.ops_compacted == 1
+    assert b3.done == true
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "latency guard: an append between two compact batches lands and is present", %{path: path} do
+    # batch_size 1 forces multiple batches; because each compact/2 is a discrete
+    # GenServer call, an append issued between them is processed and its op survives
+    # (it is a fresh op, above the compacted prefix).
+    server = start_server(path, journal_horizon_ms: 0, compact_batch_size: 1)
+
+    for i <- 1..3 do
+      {:ok, _} = SQLite.append(server, %Op{kind: :denied, tenant: "t1", ts: 100 + i, payload: %{}})
+    end
+
+    {:ok, b1} = SQLite.compact(server, 10_000)
+    assert b1.done == false
+
+    # Interleaved append (a live op, ts newer): completes and is durable.
+    {:ok, mid_seq} =
+      SQLite.append(server, %Op{kind: :drain, tenant: "t1", ts: 20_000, payload: %{}})
+
+    {:ok, _b2} = SQLite.compact(server, 10_000)
+
+    # The interleaved op is still present (it is above the compacted prefix).
+    {:ok, ops} = SQLite.read_from(server, 0)
+    assert Enum.any?(ops, &(&1.seq == mid_seq and &1.kind == :drain))
+
+    :ok = GenServer.stop(server)
+  end
+
   # -- usage projection (Task 12) --------------------------------------------
 
   # ts on the same UTC day so both charges land in one (principal, day) row.

--- a/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
@@ -472,7 +472,11 @@ defmodule Embervm.OpLog.SQLiteTest do
     {:ok, _b2} = SQLite.compact(server, 10_000)
 
     # The interleaved op is still present (it is above the compacted prefix).
-    {:ok, ops} = SQLite.read_from(server, 0)
+    # Read from the marker, not seq 0: compaction advanced the prefix past the
+    # seed ops, so read_from(0) correctly errors {:compacted, marker}; the live
+    # interleaved op lives above the marker and read_from(marker) returns it.
+    {:ok, marker} = SQLite.compacted_through(server)
+    {:ok, ops} = SQLite.read_from(server, marker)
     assert Enum.any?(ops, &(&1.seq == mid_seq and &1.kind == :drain))
 
     :ok = GenServer.stop(server)

--- a/projects/embervm/control/test/embervm/task_state_test.exs
+++ b/projects/embervm/control/test/embervm/task_state_test.exs
@@ -11,6 +11,7 @@ defmodule Embervm.TaskStateTest do
 
   @legal %{
     {:queued, :assign} => :assigned,
+    {:queued, :expire} => :failed_permanent,
     {:assigned, :start} => :running,
     {:assigned, :fail_retryable} => :failed_retryable,
     {:assigned, :fail_permanent} => :failed_permanent,
@@ -23,7 +24,12 @@ defmodule Embervm.TaskStateTest do
   }
 
   test "exhaustive transition table: every (state, event) pair matches the documented outcome" do
-    assert map_size(@legal) == 10
+    # 11 legal edges now: the R0 ten plus {:queued, :expire} (ADR embervm/002).
+    assert map_size(@legal) == 11
+    # :expire is enumerated as an event, so the cartesian walk below covers every
+    # (state, :expire) pair (only the queued one is legal).
+    assert :expire in TaskState.events()
+    assert length(TaskState.events()) == 9
 
     for state <- TaskState.states(), event <- TaskState.events() do
       case Map.fetch(@legal, {state, event}) do

--- a/projects/embervm/control/test/embervm/task_store_test.exs
+++ b/projects/embervm/control/test/embervm/task_store_test.exs
@@ -347,6 +347,143 @@ defmodule Embervm.TaskStoreTest do
     assert ets_task.attempt == 1
   end
 
+  # -- read-time result TTL + dedupe expiry (ADR embervm/002) ----------------
+
+  # A clock we can move: get_result/dedupe read state.clock.() at call time, so a
+  # controllable clock lets one test observe "before expiry -> served, after ->
+  # 404" deterministically without sleeping.
+  defp movable_clock(initial) do
+    {:ok, agent} = Agent.start_link(fn -> initial end)
+    fun = fn -> Agent.get(agent, & &1) end
+    set = fn v -> Agent.update(agent, fn _ -> v end) end
+    {fun, set}
+  end
+
+  test "get_result 404s (returns nil) once the result is past its injected expiry", %{path: path} do
+    {clock, set_clock} = movable_clock(1_000)
+    {_op_log, store} = start_pair(path, clock: clock)
+
+    {:ok, :created, task_id} =
+      TaskStore.submit(store, %{tenant: "t1", principal: "p1", workload: "wl-a"})
+
+    {:ok, _} = TaskStore.assign(store, task_id)
+    {:ok, _} = TaskStore.start(store, task_id)
+
+    # Result expires at 5_000.
+    {:ok, _} =
+      TaskStore.succeed(store, task_id, %{
+        status_code: 200,
+        body: "DATA",
+        size_bytes: 4,
+        truncated: false,
+        expires_at: 5_000
+      })
+
+    # Clock 4_999 < expiry: served.
+    set_clock.(4_999)
+    assert {:ok, %{status_code: 200, body: "DATA"}} = TaskStore.get_result(store, task_id)
+
+    # Clock 5_001 > expiry: 404, even though no sweep ran.
+    set_clock.(5_001)
+    assert {:ok, nil} = TaskStore.get_result(store, task_id)
+  end
+
+  test "dedupe returns :existing for an in-flight (non-terminal) duplicate", %{path: path} do
+    {_op_log, store} = start_pair(path)
+
+    attrs = %{tenant: "t1", principal: "p1", workload: "wl-a", idempotency_key: "inflight-1"}
+
+    {:ok, :created, id1} = TaskStore.submit(store, attrs)
+    # Move it in-flight (assigned): still non-terminal, so dedupe must suppress.
+    {:ok, _} = TaskStore.assign(store, id1)
+
+    {:ok, :existing, id2} = TaskStore.submit(store, attrs)
+    assert id1 == id2
+  end
+
+  test "dedupe resubmits fresh for a terminal task whose result has expired", %{path: path} do
+    {clock, set_clock} = movable_clock(1_000)
+    {op_log, store} = start_pair(path, clock: clock)
+
+    attrs = %{tenant: "t1", principal: "p1", workload: "wl-a", idempotency_key: "exp-1"}
+
+    {:ok, :created, id1} = TaskStore.submit(store, attrs)
+    {:ok, _} = TaskStore.assign(store, id1)
+    {:ok, _} = TaskStore.start(store, id1)
+
+    {:ok, _} =
+      TaskStore.succeed(store, id1, %{
+        status_code: 200,
+        body: "OLD",
+        size_bytes: 3,
+        truncated: false,
+        expires_at: 5_000
+      })
+
+    # Past the result TTL: dedupe treats the task as absent and runs a fresh submit.
+    set_clock.(6_000)
+    {:ok, :created, id2} = TaskStore.submit(store, attrs)
+    refute id2 == id1
+
+    # The old projection row is gone (evicted), so the fresh :submitted did not
+    # collide on the unique (workload, key) index, and its result is cleared.
+    assert {:ok, nil} = TaskStore.get_result(store, id1)
+    {:ok, task2} = TaskStore.get(store, id2)
+    assert task2.state == :queued
+
+    # Two :submitted ops now exist in the immutable journal (old + fresh), proving
+    # eviction pruned only the projection, not the ops.
+    {:ok, ops} = SQLite.read_from(op_log, 0)
+    assert Enum.count(ops, &(&1.kind == :submitted)) == 2
+  end
+
+  test "dedupe still returns :existing for a terminal task whose result is still live", %{path: path} do
+    {clock, _set} = movable_clock(1_000)
+    {_op_log, store} = start_pair(path, clock: clock)
+
+    attrs = %{tenant: "t1", principal: "p1", workload: "wl-a", idempotency_key: "live-1"}
+
+    {:ok, :created, id1} = TaskStore.submit(store, attrs)
+    {:ok, _} = TaskStore.assign(store, id1)
+    {:ok, _} = TaskStore.start(store, id1)
+
+    # Result expires far in the future relative to the (fixed 1_000) clock.
+    {:ok, _} =
+      TaskStore.succeed(store, id1, %{
+        status_code: 200,
+        body: "LIVE",
+        size_bytes: 4,
+        truncated: false,
+        expires_at: 1_000_000
+      })
+
+    {:ok, :existing, id2} = TaskStore.submit(store, attrs)
+    assert id1 == id2
+  end
+
+  test "expire transitions a queued task to failed_permanent with reason expired", %{path: path} do
+    {op_log, store} = start_pair(path)
+
+    {:ok, :created, task_id} =
+      TaskStore.submit(store, %{tenant: "t1", principal: "p1", workload: "wl-a"})
+
+    {:ok, expired} = TaskStore.expire(store, task_id)
+    assert expired.state == :failed_permanent
+
+    # Not chained into dead-letter: terminal at failed_permanent.
+    {:ok, ets_task} = TaskStore.get(store, task_id)
+    assert ets_task.state == :failed_permanent
+
+    # Recorded via the existing :failed op kind with reason expired, no new op kind.
+    {:ok, ops} = SQLite.read_from(op_log, 0)
+    failed = Enum.find(ops, &(&1.kind == :failed and &1.task_id == task_id))
+    assert failed.payload["reason"] == "expired"
+
+    # Expiring a non-queued task is an illegal transition.
+    assert {:error, {:illegal_transition, :failed_permanent, :expire}} =
+             TaskStore.expire(store, task_id)
+  end
+
   # -- Task 11 dispatcher seams ----------------------------------------------
 
   test "get_request returns the guest-request envelope stored in the submitted op", %{path: path} do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.23
+      targetRevision: 0.1.24
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -8,6 +8,10 @@ opLog:
   # Deployment is Recreate + 1 replica because SQLite is single-writer and the
   # volume is RWO.
   size: 2Gi
+  # Op-log retention (ADR embervm/002): hourly bounded-batch sweep; ops-journal
+  # prefix compaction past a 30-day horizon (older audit is in SigNoz).
+  sweepIntervalSeconds: 3600
+  journalHorizonDays: 30
 
 # TokenReview allow-list: ServiceAccount usernames permitted to submit tasks
 # (Task 8). Empty means deny-all (fail-closed). In R0 the only entry is the

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.108
+version: 0.89.109
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.108
+      targetRevision: 0.89.109
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.188
+version: 0.285.189
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/demos/firecracker_api.py
+++ b/projects/monolith/demos/firecracker_api.py
@@ -126,12 +126,14 @@ async def run_semgrep(body: SemgrepRequest) -> dict:
     """Scan supplied files with Semgrep in the fc-invoke workload.
 
     The scan path does not report its own timing, so duration_ms is the wall
-    time measured around the call here.
+    time measured around the call here. Passes ``dedupe=False`` so the demo
+    always runs a genuinely fresh scan instead of hitting the idempotency
+    result-store cache (the webhook/PR scan path keeps the default dedupe).
     """
     with _tracer.start_as_current_span("demo.semgrep", context=Context()):
         trace_id = _current_trace_id()
         started = perf_counter()
-        result = await scan_files(body.files)
+        result = await scan_files(body.files, dedupe=False)
         elapsed_ms = (perf_counter() - started) * 1000
 
     return {

--- a/projects/monolith/demos/firecracker_api_test.py
+++ b/projects/monolith/demos/firecracker_api_test.py
@@ -52,7 +52,7 @@ def test_python_returns_run_shape_with_trace_id(monkeypatch):
 
 
 def test_semgrep_returns_findings_shape_with_trace_id(monkeypatch):
-    async def fake_scan(files):
+    async def fake_scan(files, dedupe=True):
         assert files == [{"path": "a.py", "content": "x = 1"}]
         return {
             "findings": [{"path": "a.py", "line": 1, "rule_id": "r", "message": "m"}],
@@ -71,6 +71,26 @@ def test_semgrep_returns_findings_shape_with_trace_id(monkeypatch):
     assert body["errors"] == []
     assert isinstance(body["duration_ms"], (int, float))
     assert _HEX32.match(body["trace_id"])
+
+
+def test_semgrep_demo_bypasses_idempotency_dedupe(monkeypatch):
+    """The demo single-scan handler must pass dedupe=False so it always runs a
+    genuinely fresh scan instead of reading a cached prior result via the
+    EmberVM Idempotency-Key path (Task 4, R1)."""
+    captured = {}
+
+    async def fake_scan(files, dedupe=True):
+        captured["dedupe"] = dedupe
+        return {"findings": [], "errors": []}
+
+    monkeypatch.setattr(fc, "scan_files", fake_scan)
+
+    resp = _client().post(
+        "/api/demos/firecracker/semgrep",
+        json={"files": [{"path": "a.py", "content": "x = 1"}]},
+    )
+    assert resp.status_code == 200
+    assert captured["dedupe"] is False
 
 
 def test_goose_submit_returns_thread_id_with_trace_id(monkeypatch):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.188
+      targetRevision: 0.285.189
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/RunPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/RunPanel.svelte
@@ -26,6 +26,12 @@
   let showsLoadTestTab = $derived(project.key === "python" || project.key === "semgrep");
   let loadTestWorkload = $derived(project.key === "python" ? "sandbox" : "semgrep");
 
+  // Backend-measured timing label. Only the semgrep demo now bypasses the
+  // idempotency dedupe (dedupe=false), so its timing is a genuine fresh scan;
+  // the python sandbox tab still reports a plain invocation time, so the label
+  // stays honest per project rather than saying "fresh scan" for everything.
+  let latencyLabel = $derived(project.key === "semgrep" ? "fresh scan" : "invocation");
+
   // Inputs, seeded from the project's sample so Run works with zero edits,
   // but everything stays editable.
   let pythonCode = $state(project.sample.code ?? "");
@@ -293,7 +299,7 @@
       </span>
       {#if result?.duration_ms != null}
         <span class="latency-item">
-          <span class="latency-label">invocation</span>
+          <span class="latency-label">{latencyLabel}</span>
           <span class="latency-value">{result.duration_ms}ms</span>
         </span>
       {/if}

--- a/projects/monolith/semgrep_scan/client.py
+++ b/projects/monolith/semgrep_scan/client.py
@@ -104,13 +104,17 @@ async def _post_invoke(workload: str, files: list[dict], read_timeout: float) ->
         return {"error": f"semgrep scan failed: {exc}"}
 
 
-async def _post_embervm(files: list[dict], read_timeout: float) -> dict:
+async def _post_embervm(
+    files: list[dict], read_timeout: float, dedupe: bool = True
+) -> dict:
     """POST a diff scan to EmberVM's ``semgrep`` Workload; the EmberVM counterpart
     of ``_post_invoke``. Submits synchronously (``?wait=true``) so the guest's
     ScanResult comes back inline (EmberVM forwards the guest response verbatim, so
     the shape matches fc-invoke), with an Idempotency-Key from the content hash so
-    a webhook redelivery dedupes to the same task. Same error shape as
-    ``_post_invoke`` (a dict with a single ``error`` key on failure).
+    a webhook redelivery dedupes to the same task, unless ``dedupe`` is False (the
+    demo single-scan path), in which case the header is omitted so a fresh scan
+    always runs. Same error shape as ``_post_invoke`` (a dict with a single
+    ``error`` key on failure).
     """
     if not EMBERVM_URL:
         return {"error": "EMBERVM_URL is not configured"}
@@ -119,7 +123,9 @@ async def _post_embervm(files: list[dict], read_timeout: float) -> dict:
 
     timeout = httpx.Timeout(read_timeout, connect=SEMGREP_CONNECT_TIMEOUT)
     payload = {"files": files}
-    headers = {**auth_headers(), "Idempotency-Key": _content_key(files)}
+    headers = auth_headers()
+    if dedupe:
+        headers["Idempotency-Key"] = _content_key(files)
 
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
@@ -191,7 +197,7 @@ async def _shadow_scan(files: list[dict], fc_result: dict) -> None:
         logger.exception("semgrep shadow comparison failed")
 
 
-async def scan_files(files: list[dict]) -> dict:
+async def scan_files(files: list[dict], dedupe: bool = True) -> dict:
     """POST file contents to the semgrep diff workload and return findings.
 
     Each entry in ``files`` needs a ``path`` (repo-relative, used to pick rules
@@ -204,9 +210,16 @@ async def scan_files(files: list[dict]) -> dict:
     ``shadow`` serves from fc-invoke and mirrors to EmberVM asynchronously for
     finding-count comparison, with no user-facing effect. The caller contract
     (response/error shape, timeouts) is identical across modes.
+
+    ``dedupe`` (default True) controls whether the EmberVM path attaches the
+    Idempotency-Key header, so a webhook redelivery of the same diff collapses
+    to the same task. The demo single-scan handler passes ``dedupe=False`` so
+    every demo run is a genuinely fresh scan rather than a cached prior result.
+    Only the EmberVM dispatch path carries this header; fc-invoke has no
+    equivalent, so ``dedupe`` has no effect on the ``fc-invoke``/``shadow`` modes.
     """
     if SEMGREP_DISPATCH == "embervm":
-        return await _post_embervm(files, SEMGREP_READ_TIMEOUT)
+        return await _post_embervm(files, SEMGREP_READ_TIMEOUT, dedupe=dedupe)
 
     result = await _post_invoke("semgrep", files, SEMGREP_READ_TIMEOUT)
 

--- a/projects/monolith/semgrep_scan/client_test.py
+++ b/projects/monolith/semgrep_scan/client_test.py
@@ -110,6 +110,22 @@ async def test_embervm_mode_posts_to_submit_api_with_idempotency_key():
 
 
 @pytest.mark.asyncio
+async def test_embervm_mode_dedupe_false_omits_idempotency_key():
+    """The demo single-scan path passes dedupe=False so a fresh scan always
+    runs instead of hitting the idempotency result-store cache."""
+    _FakeClient.routes = {
+        "/v1/workloads/semgrep/tasks": _Resp({"findings": [], "errors": []})
+    }
+    monkeypatch_dispatch("embervm")
+
+    await client.scan_files(_FILES, dedupe=False)
+
+    assert len(_FakeClient.posts) == 1
+    post = _FakeClient.posts[0]
+    assert "Idempotency-Key" not in post["headers"]
+
+
+@pytest.mark.asyncio
 async def test_shadow_serves_fc_invoke_and_mirrors_to_embervm():
     _FakeClient.routes = {
         "/invoke/semgrep": _Resp({"findings": [{"rule_id": "r"}], "errors": []}),

--- a/projects/platform/signoz-addons/alerts/templates/embervm-oplog-pvc-usage.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/embervm-oplog-pvc-usage.yaml
@@ -1,0 +1,141 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: embervm-oplog-pvc-usage-alert
+  labels:
+    signoz.io/alert: "true"
+  annotations:
+    signoz.io/alert-name: "EmberVM Op-Log PVC Usage"
+    signoz.io/severity: "warning"
+    signoz.io/notification-channels: "incidentio"
+# Watermark alert for the EmberVM op-log PVC (ADR embervm/002, rule 4): fires weeks
+# out at 80% usage instead of letting the PVC exhaust and take down submit.
+# kubeletstats has no direct percent-used metric, so this computes it via a v5
+# formula query over k8s.volume.available (A) and k8s.volume.capacity (B):
+# percent_used = (B - A) / B * 100. There is no PVC-name label in kubeletstats;
+# the embervm namespace has exactly one PVC (the op-log volume, noded uses nvme
+# hostPath not a PVC), so k8s.namespace.name + k8s.volume.type uniquely selects it.
+data:
+  alert.json: |
+    {
+      "alert": "EmberVM Op-Log PVC Usage",
+      "alertType": "METRIC_BASED_ALERT",
+      "ruleType": "threshold_rule",
+      "version": "v5",
+      "broadcastToAll": false,
+      "disabled": false,
+      "evalWindow": "15m0s",
+      "frequency": "5m0s",
+      "severity": "warning",
+      "labels": {
+        "category": "storage",
+        "environment": "production",
+        "service": "embervm"
+      },
+      "annotations": {
+        "summary": "EmberVM op-log PVC usage exceeded 80% in namespace {{ "{{" }} $labels.k8s_namespace_name {{ "}}" }}",
+        "description": "EmberVM op-log PVC (embervm-embervm-oplog) has exceeded 80% usage. Both remediations are values-configurable in the embervm chart: raise opLog.journalHorizonDays (shorten the ops-journal retention so compaction reclaims more) or raise opLog.size (grow the PVC). See ADR embervm/002."
+      },
+      "condition": {
+        "compositeQuery": {
+          "queryType": "builder",
+          "panelType": "graph",
+          "unit": "percent",
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "disabled": true,
+                "aggregations": [
+                  {
+                    "timeAggregation": "avg",
+                    "spaceAggregation": "sum",
+                    "metricName": "k8s.volume.available"
+                  }
+                ],
+                "filter": {
+                  "expression": "k8s.namespace.name = 'embervm' AND k8s.volume.type = 'persistentVolumeClaim'"
+                },
+                "groupBy": [
+                  {
+                    "name": "k8s.namespace.name",
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
+                  },
+                  {
+                    "name": "k8s.pod.name",
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
+                  }
+                ],
+                "order": [],
+                "disabled": true
+              }
+            },
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "B",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "disabled": true,
+                "aggregations": [
+                  {
+                    "timeAggregation": "avg",
+                    "spaceAggregation": "sum",
+                    "metricName": "k8s.volume.capacity"
+                  }
+                ],
+                "filter": {
+                  "expression": "k8s.namespace.name = 'embervm' AND k8s.volume.type = 'persistentVolumeClaim'"
+                },
+                "groupBy": [
+                  {
+                    "name": "k8s.namespace.name",
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
+                  },
+                  {
+                    "name": "k8s.pod.name",
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
+                  }
+                ],
+                "order": [],
+                "disabled": true
+              }
+            },
+            {
+              "type": "builder_formula",
+              "spec": {
+                "name": "C",
+                "expression": "(B - A) / B * 100",
+                "legend": "percent used"
+              }
+            }
+          ]
+        },
+        "selectedQueryName": "C",
+        "op": "1",
+        "target": 80,
+        "matchType": "3",
+        "targetUnit": "",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "warning",
+              "target": 80,
+              "targetUnit": "",
+              "matchType": "3",
+              "op": "1",
+              "channels": ["incidentio"]
+            }
+          ]
+        }
+      },
+      "preferredChannels": ["incidentio"]
+    }


### PR DESCRIPTION
EmberVM R1 **PR-1** (plan `docs/plans/2026-07-14-embervm-r1-zip-lane-spec-and-plan.md`, Phase 0). Lands the R0 hardening before any zip-lane code. Tasks 1, 2, 4 (Task 3 durability/rollback drills are PR-2, after this deploys).

## Task 1: Op-log retention and compaction (ADR embervm/002)
Implements the retention policy R0 shipped the mechanism for but never scheduled or enforced.
- **Read-time result TTL**: `GET /v1/tasks/{id}/result` 404s past `expires_at` independent of sweeping; idempotency dedupe treats a terminal task whose result has expired as absent (resubmit runs fresh), while in-flight duplicates are still suppressed. Fresh-resubmit evicts the old projection row (`evict_task`, result cascades) and its ETS entries before re-submitting under the same key.
- **Scheduled sweep** (`Embervm.OpLog.Compactor`, hourly default): loops `compact/2` in bounded batches (500/statement, portable `rowid IN (SELECT ... LIMIT ?)`) so appends interleave between batches (5ms budget guard); logs per-table row counts + db file size.
- **Ops-journal prefix compaction**: durable `compacted_through_seq` marker in a new `meta` table, advanced monotonically to the prefix boundary (`min blocking seq - 1`) where blocking = newer-than-horizon OR owned by a live task; `read_from` below the marker returns `{:error, {:compacted, marker}}`. Journal horizon (30d) is DISTINCT config from the 7d terminal-task retention.
- **Dispatcher-side queued expiry** (closes ADR 002 open question 1 / the D12 gap): new `:expire` FSM event; a popped task past `expires_at` transitions to `failed_permanent` (reason `expired`) before a VM is reserved, never dispatching.
- New knobs `opLog.sweepIntervalSeconds=3600` / `opLog.journalHorizonDays=30` in chart + deploy values; embervm chart bumped 0.1.23 -> 0.1.24.

## Task 2: PVC watermark alert
SigNoz metric alert at 80% usage on the EmberVM op-log PVC (warn, `incidentio` channel), via the signoz-alerts template seam. Percent-used computed as a v5 `builder_formula` over `k8s.volume.available`/`k8s.volume.capacity` filtered to the embervm PVC. No chart bump (signoz-alerts is HEAD-tracked). Alert body names the runbook action (raise `opLog.journalHorizonDays` or `opLog.size`).

## Task 4: Demo single-scan cache honesty
The firecracker demo semgrep single-scan now passes `dedupe=false` to the scan client, which omits the `Idempotency-Key` header so a genuine fresh scan runs each time (the ~20ms figure was a dedupe result-store read). Webhook/PR scan paths keep the default `dedupe=true`. Frontend timing label is per-project (`fresh scan` for semgrep, `invocation` elsewhere). monolith 0.285.188->189 and monolith-public 0.89.108->109 (shared image).

## Review
One comprehensive review over the full diff (repo policy: one per merged PR). Confirmed the marker prefix-safety/monotonicity, dedupe-vs-in-flight logic, read-time TTL independence, batched-compaction interleave, dispatcher expiry (no primed-VM leak), the PVC formula schema against the proven dashboard, and dedupe defaults. One defect found and fixed (shared frontend label). DECISIONS.md updated, D12 queued-TTL gap marked closed.

## Verification notes (post-deploy)
- No local test loop; ExUnit/pytest run in CI.
- PVC alert dry-run (threshold-0 -> incidentio, then restore) and confirming noded's nvme hostPath carries no `k8s.volume.*` series are live-SigNoz checks to run after sync.
- Hourly sweep log line + a manually-inserted expired result 404ing before any sweep are the Task 1 in-cluster acceptance checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)