### PR TITLE
chore(monolith): rollback drill B1 — semgrep.dispatch → fc-invoke

### DIFF
--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -167,7 +167,7 @@ semgrep:
   # verified returning identical PRO findings. Revert to "fc-invoke" (one value +
   # rollout) if a real PR diff regresses. fc-invoke's scan path stays deployed as
   # the instant fallback until R1/R2 formally deprecates it.
-  dispatch: "embervm"
+  dispatch: "fc-invoke"
   # Route B shadow project (Route B vs SMS comparison): self-hosted scans report
   # here instead of jomcgi/homelab, so they land in a separate Semgrep project.
   # UNSET this single value at cutover to report to the real project.


### PR DESCRIPTION
R0 durability/rollback drill (authorized live op). Flips the per-PR semgrep diff
scan from EmberVM back to fc-invoke to prove the documented one-value rollback
lever works on the live scan path.

- Values-only change, read via the \$values git HEAD source (see application.yaml),
  so no chart bump is required.
- fc-invoke and EmberVM return identical PRO findings; the observable is which
  backend serves the scan (EmberVM op-log grows only on the embervm path).
- Immediately followed by drill B2, which flips back to \`embervm\`, restoring prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)