### PR TITLE
chore(monolith): rollback drill B2 — restore semgrep.dispatch → embervm

### DIFF
--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -167,7 +167,7 @@ semgrep:
   # verified returning identical PRO findings. Revert to "fc-invoke" (one value +
   # rollout) if a real PR diff regresses. fc-invoke's scan path stays deployed as
   # the instant fallback until R1/R2 formally deprecates it.
-  dispatch: "fc-invoke"
+  dispatch: "embervm"
   # Route B shadow project (Route B vs SMS comparison): self-hosted scans report
   # here instead of jomcgi/homelab, so they land in a separate Semgrep project.
   # UNSET this single value at cutover to report to the real project.


### PR DESCRIPTION
Completes the R0 rollback drill: flips the per-PR semgrep diff scan back to
EmberVM, restoring the production cutover state after B1 (#3512) proved the
fc-invoke rollback lever works on the live path.

- Values-only change via the \$values git HEAD source, no chart bump.
- Verification after rollout: a triggered scan creates a task in EmberVM's
  op-log and runs a microVM (the positive counterpart to B1's null result).

🤖 Generated with [Claude Code](https://claude.com/claude-code)