### PR TITLE
fix(monolith-public): pin Turnstile egress to Cloudflare CIDRs, not toFQDNs

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.109
+version: 0.89.110
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/templates/cilium-policy.yaml
+++ b/projects/monolith-public/chart/templates/cilium-policy.yaml
@@ -17,7 +17,8 @@
 #     intended to flip ON during the maintenance window.
 #
 #   ciliumPolicy.egress.enabled  - the default-deny-OFF-cluster lockdown plus
-#     the single sanctioned Turnstile FQDN allow. Recommended to flip ON in a
+#     the single sanctioned Turnstile allow (Cloudflare siteverify), IP-pinned
+#     via toCIDRSet to Cloudflare's published ranges. Recommended to flip ON in a
 #     tested follow-up AFTER the window (watch flows with `hubble observe`), so
 #     an unproven egress deny is not stacked onto the irreversible CNI swap.
 #
@@ -112,54 +113,35 @@ spec:
       {{- include "monolith-public.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: web
   egress:
-    # DNS via the Cilium DNS proxy. This MUST be the ONLY rule that matches port
-    # 53 to kube-dns: the broad in-cluster allow below deliberately EXCLUDES 53,
-    # because a broad L4 allow covering 53 would nullify this rule's L7 dns
-    # portion (Cilium resolves overlapping rules toward the more permissive L4,
-    # so an L4-only allow shadows a matching L7 rule). If that happened, the DNS
-    # proxy would never learn challenges.cloudflare.com's IP and the toFQDNs
-    # allow below (which fails closed) would block Turnstile. Verify with
-    # `hubble observe` at rollout.
-    - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
-            k8s:k8s-app: kube-dns
-      toPorts:
-        - ports:
-            - port: "53"
-              protocol: ANY
-          rules:
-            dns:
-              - matchPattern: "*"
-    # All in-cluster egress EXCEPT port 53 (carved out via the two ranges so DNS
-    # is served solely by the L7 proxy above). `cluster` covers pod endpoints
-    # (Postgres RO/RW, inference, embeddings, SeaweedFS); `host` + `remote-node`
-    # cover host-networked in-cluster dependencies that the `cluster` entity does
-    # not (the Linkerd EgressNetwork only denied OFF-cluster, so node-local
-    # traffic was allowed and must stay allowed here).
+    # All in-cluster egress (Postgres RO/RW, vLLM inference, embeddings,
+    # SeaweedFS S3) PLUS DNS, resolved at plain L4 through this same rule.
+    # `cluster` covers pod endpoints; `host` + `remote-node` cover host-networked
+    # in-cluster dependencies the `cluster` entity does not (the Linkerd
+    # EgressNetwork only denied OFF-cluster, so node-local traffic must stay
+    # allowed). Note: there is deliberately NO toFQDNs rule anywhere in this
+    # policy, so Cilium does NOT redirect the backend's DNS through the L7 proxy.
+    # That keeps kube-dns resolution off the cilium-agent DNS-proxy path (one
+    # fewer dependency for every in-cluster lookup the pod makes) and matches the
+    # frontend/imgproxy egress shape. The Turnstile allow below is IP-pinned
+    # (toCIDRSet), which needs no DNS-proxy learning, so no L7 DNS rule is needed.
     - toEntities:
         - cluster
         - host
         - remote-node
-      toPorts:
-        - ports:
-            - port: "1"
-              endPort: 52
-              protocol: TCP
-            - port: "54"
-              endPort: 65535
-              protocol: TCP
-            - port: "1"
-              endPort: 52
-              protocol: UDP
-            - port: "54"
-              endPort: 65535
-              protocol: UDP
-    # THE ONE SANCTIONED OFF-CLUSTER EGRESS (ADR 005, Public Chat V3). Turnstile
-    # siteverify. This is the only external host the public tier may reach; do
-    # not broaden it to a wildcard. Replaces the allow-turnstile-egress TLSRoute.
-    - toFQDNs:
-        - matchName: "challenges.cloudflare.com"
+    # THE ONE SANCTIONED OFF-CLUSTER EGRESS (ADR 005, Public Chat V3): Cloudflare
+    # Turnstile siteverify (challenges.cloudflare.com) on 443. This is the only
+    # external destination the public tier may reach; do not broaden the ports or
+    # add other CIDRs. Pinned to Cloudflare's published IP ranges (toCIDRSet)
+    # rather than a toFQDNs hostname match: Turnstile's DNS TTL is ~42s over a
+    # large rotating anycast pool, and a toFQDNs allow only opens the exact IPs
+    # the DNS proxy last observed for that TTL, so live siteverify connections
+    # were intermittently policy-DROPPED and failed CLOSED -> 5xx. The CIDR set is
+    # Cloudflare-only and stable; source of truth + provenance is the
+    # ciliumPolicy.egress.turnstileCidrs list in chart/values.yaml.
+    - toCIDRSet:
+        {{- range .Values.ciliumPolicy.egress.turnstileCidrs }}
+        - cidr: {{ . | quote }}
+        {{- end }}
       toPorts:
         - ports:
             - port: "443"

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -593,3 +593,35 @@ ciliumPolicy:
     enabled: false
   egress:
     enabled: false
+    # Cloudflare's published IP ranges, the toCIDRSet allow for the ONE
+    # sanctioned off-cluster egress from the backend "web" pod: Turnstile
+    # siteverify (challenges.cloudflare.com) on port 443. Pinned as CIDRs rather
+    # than a toFQDNs hostname match because Turnstile's ~42s DNS TTL over a
+    # rotating anycast pool made the toFQDNs allow race and intermittently DROP
+    # live connections, failing siteverify closed -> 5xx. Cloudflare-only, so the
+    # off-cluster posture stays tight. Source of truth: https://www.cloudflare.com/ips-v4
+    # and https://www.cloudflare.com/ips-v6 (last synced 2026-07-14; refresh here
+    # if Cloudflare updates the ranges).
+    turnstileCidrs:
+      - "173.245.48.0/20"
+      - "103.21.244.0/22"
+      - "103.22.200.0/22"
+      - "103.31.4.0/22"
+      - "141.101.64.0/18"
+      - "108.162.192.0/18"
+      - "190.93.240.0/20"
+      - "188.114.96.0/20"
+      - "197.234.240.0/22"
+      - "198.41.128.0/17"
+      - "162.158.0.0/15"
+      - "104.16.0.0/13"
+      - "104.24.0.0/14"
+      - "172.64.0.0/13"
+      - "131.0.72.0/22"
+      - "2400:cb00::/32"
+      - "2606:4700::/32"
+      - "2803:f800::/32"
+      - "2405:b500::/32"
+      - "2405:8100::/32"
+      - "2a06:98c0::/29"
+      - "2c0f:f248::/32"

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.109
+      targetRevision: 0.89.110
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/values.yaml
+++ b/projects/monolith-public/deploy/values.yaml
@@ -49,11 +49,12 @@ cfIngress:
 
 # Cilium network policy (ADR platform/012). Both gates are on:
 #   ingress: gateway -> frontend, frontend -> web (flipped during the window).
-#   egress:  off-cluster default-deny with the single sanctioned Turnstile FQDN
-#            (challenges.cloudflare.com), all in-cluster allowed, DNS via the L7
-#            proxy. Flipped in a tested follow-up: hubble showed the only
-#            off-cluster egress is web -> Turnstile; frontend/imgproxy reach
-#            nothing off-cluster (imgproxy sources from in-cluster SeaweedFS).
+#   egress:  off-cluster default-deny with the single sanctioned Turnstile allow
+#            (challenges.cloudflare.com siteverify, IP-pinned to Cloudflare's
+#            published ranges via toCIDRSet), all in-cluster allowed, DNS at L4.
+#            Flipped in a tested follow-up: hubble showed the only off-cluster
+#            egress is web -> Turnstile; frontend/imgproxy reach nothing
+#            off-cluster (imgproxy sources from in-cluster SeaweedFS).
 # See the chart's templates/cilium-policy.yaml rationale.
 ciliumPolicy:
   ingress:


### PR DESCRIPTION
## Problem

Post-Cilium, the public tier's egress lockdown (`ciliumPolicy.egress.enabled: true`, live ~30h) allowed its one sanctioned off-cluster host, `challenges.cloudflare.com` (Turnstile siteverify), via a `toFQDNs` match.

Cilium's `toFQDNs` is IP-based: the DNS proxy only opens the firewall for the exact IPs it just saw in a DNS answer, for that record's TTL. Turnstile's TTL is **~42s** over a large rotating Cloudflare anycast pool. Live siteverify connections whose allow-entry expired (or that reused a keep-alive to a now-unlisted IP) were intermittently **policy-DROPPED**, and siteverify fails **closed** -> intermittent **5xx** on the public chat path. Verified live: the node's FQDN cache held only expired (`TTL=0`) IPv6 `connection` entries for the host.

## Fix

Replace the `toFQDNs` allow with a `toCIDRSet` allow of Cloudflare's published IP ranges on port 443. Stable, Cloudflare-only, no DNS-proxy dependency.

Bonus: with no `toFQDNs` rule left on the pod, Cilium stops redirecting the backend's DNS through the L7 proxy, so kube-dns resolution for its in-cluster deps (Postgres, inference, embeddings, SeaweedFS) no longer rides the cilium-agent DNS-proxy path. The `web-egress` policy now matches the `frontend`/`imgproxy` egress shape plus the single CIDR allow; the L7 DNS rule and the port-53 carve-out are gone.

CIDRs synced from `cloudflare.com/ips-v4` + `/ips-v6` on 2026-07-14, kept as the `ciliumPolicy.egress.turnstileCidrs` SSOT in `chart/values.yaml` (refresh there if Cloudflare updates them).

## Scope note

This fixes the **public chat / Turnstile** 5xx path. It does **not** address the trips-page or MCP 5xx: trips serving is fully in-cluster (no off-cluster egress), and MCP runs from the private `monolith` ns which has no Cilium egress policy. Separately confirmed the MCP 502 is the CF-fronted path, not the backend, so that's a gateway/tunnel-layer issue tracked apart from this.

## Verification

- `helm template` renders the `web-egress` CNP with the 22 Cloudflare CIDRs on 443 and no `toFQDNs`/L7-DNS rule.
- Chart bumped 0.89.109 -> 0.89.110 (Chart.yaml + application.yaml targetRevision together).
- Post-merge: watch `hubble observe` for the web pod egress to Cloudflare on 443 forwarded (not dropped), and confirm a public-chat turn completes siteverify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)