### PR TITLE
fix(monolith): revert dispatch to fc-invoke — EmberVM dispatch wedges on control-plane restart

### DIFF
--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -153,7 +153,7 @@ chat:
 # EmberVM's sandbox Workload (live + verified). Revert to fc-invoke (one value +
 # rollout) if it regresses. fc-invoke's sandbox path stays deployed as fallback.
 sandbox:
-  dispatch: "embervm"
+  dispatch: "fc-invoke"
 
 semgrep:
   fcInvokeUrl: "http://fc-invoke.monolith.svc.cluster.local:8080"
@@ -167,7 +167,7 @@ semgrep:
   # verified returning identical PRO findings. Revert to "fc-invoke" (one value +
   # rollout) if a real PR diff regresses. fc-invoke's scan path stays deployed as
   # the instant fallback until R1/R2 formally deprecates it.
-  dispatch: "embervm"
+  dispatch: "fc-invoke"
   # Route B shadow project (Route B vs SMS comparison): self-hosted scans report
   # here instead of jomcgi/homelab, so they land in a separate Semgrep project.
   # UNSET this single value at cutover to report to the real project.


### PR DESCRIPTION
## What

Reverts both EmberVM-dispatched live paths back to the `fc-invoke` fallback:
- `semgrep.dispatch`: per-PR semgrep diff scan
- `sandbox.dispatch`: python sandbox demo (firecracker demos page)

## Why (R0 durability drill finding)

Drill A (control-plane crash durability) confirmed op-log **data** durability:
the SQLite op-log + WAL survived an unclean SIGKILL, replaying 148 KB of
un-checkpointed WAL into the main DB on reopen, restartCount=0, no corruption.

But it exposed a **dispatch-recovery regression**: after any control-plane
restart (unclean *or* graceful), EmberVM accepts tasks into the durable op-log
but never dispatches them to the node. No microVM boots; synchronous scans hit
the 90s read timeout and error. Verified across two restarts (SIGKILL + clean),
each with ~105s of noded watching and zero VM boots.

Likely a WatchNode stream-lifecycle / boot-ordering bug: the control-plane logs
`GRPC.Client.Connection stopping as requested` at boot when noded is already
running, and the NodeRegistry's fail-closed capacity never repopulates, so the
Dispatcher parks every task. The original boot worked only because noded came up
*after* the control-plane (econnrefused → retry → stream establishes).

Rollback lever itself is proven (drill B): flipping this value reroutes the live
scan path in ~40s with no chart bump. Keep prod on fc-invoke until the dispatch
bug is fixed in the EmberVM control plane.

Values-only change via the `$values` git HEAD source, so no chart bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)