### PR TITLE
feat(monolith): restore dispatch to embervm (dispatch-recovery fixed)

### DIFF
--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -153,7 +153,7 @@ chat:
 # EmberVM's sandbox Workload (live + verified). Revert to fc-invoke (one value +
 # rollout) if it regresses. fc-invoke's sandbox path stays deployed as fallback.
 sandbox:
-  dispatch: "fc-invoke"
+  dispatch: "embervm"
 
 semgrep:
   fcInvokeUrl: "http://fc-invoke.monolith.svc.cluster.local:8080"
@@ -167,7 +167,7 @@ semgrep:
   # verified returning identical PRO findings. Revert to "fc-invoke" (one value +
   # rollout) if a real PR diff regresses. fc-invoke's scan path stays deployed as
   # the instant fallback until R1/R2 formally deprecates it.
-  dispatch: "fc-invoke"
+  dispatch: "embervm"
   # Route B shadow project (Route B vs SMS comparison): self-hosted scans report
   # here instead of jomcgi/homelab, so they land in a separate Semgrep project.
   # UNSET this single value at cutover to report to the real project.


### PR DESCRIPTION
Restores the EmberVM cutover for both live paths (`semgrep.dispatch` per-PR scan
and `sandbox.dispatch` python demo) now that dispatch is restart-resilient.

The dispatch-recovery bug (control-plane restart orphaned the node's primed VM
pool -> :no_capacity deadlock) is fixed by adoption (PR #3517, embervm 0.1.25,
live): a restarted control plane rebuilds its inventory from the node's reported
primed_vm_ids. fc-invoke stays deployed as the one-value rollback.

Values-only via the `$values` git HEAD source, no chart bump. After deploy I
verify a scan dispatches AND survives a control-plane restart (the drill-A repro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)