### PR TITLE
feat(embervm): /v1/nodes introspection + close MISS adoption window

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.25
+version: 0.1.26

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -293,6 +293,18 @@ defmodule Embervm.Dispatcher do
     {:noreply, finish_worker(state, pid, outcome, :flush)}
   end
 
+  # A miss worker reports the vm_id it just primed. Stamp it into the worker's meta
+  # so known_vm_ids counts it immediately, closing the window where adopt_inventory
+  # would see the node reporting a just-primed miss VM as primed and re-adopt it
+  # (the VM is single-use and about to be assigned by this same worker). Ignored if
+  # the worker already finished (pid gone).
+  def handle_info({:vm_primed, pid, vm_id}, state) do
+    case Map.get(state.workers, pid) do
+      nil -> {:noreply, state}
+      meta -> {:noreply, put_in(state.workers[pid], %{meta | vm_id: vm_id})}
+    end
+  end
+
   # A worker died without reporting (it always sends {:assign_done, ...} in the
   # normal path, so a bare DOWN is an abnormal exit): treat as a transport
   # failure so the task retries at-least-once, exactly as a downed node would.
@@ -603,6 +615,12 @@ defmodule Embervm.Dispatcher do
       node_id: node_id,
       mode: mode,
       vm_id: vm_id,
+      # The dispatcher pid, so a MISS worker can report the vm_id it primes back
+      # here the instant it has one (see ensure_vm): that closes the window where
+      # a just-primed miss VM is reported primed by the node but invisible to
+      # known_vm_ids (meta.vm_id still nil), which adopt_inventory would otherwise
+      # briefly re-adopt.
+      owner: owner,
       snapshot_ref: snapshot_ref,
       invoke_path: entry.invoke_path,
       timeout_ms: entry.timeout_ms,
@@ -756,8 +774,15 @@ defmodule Embervm.Dispatcher do
       end
 
     case result do
-      {:ok, %PrimeResponse{vm_id: vm_id}} -> {:ok, vm_id}
-      {:error, reason} -> {:error, :prime_failed, reason}
+      {:ok, %PrimeResponse{vm_id: vm_id}} ->
+        # Tell the dispatcher the vm_id we just primed so it lands in this worker's
+        # meta immediately; until then adopt_inventory cannot see this in-flight
+        # miss VM (the node reports it primed) and could briefly re-adopt it.
+        send(ctx.owner, {:vm_primed, self(), vm_id})
+        {:ok, vm_id}
+
+      {:error, reason} ->
+        {:error, :prime_failed, reason}
     end
   end
 

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -12,6 +12,8 @@ defmodule Embervm.Router do
     * `GET  /v1/tasks/:id/result`      the stored result (until its TTL).
     * `GET  /v1/workloads/:name/dead-letters`  paged DLQ listing.
     * `POST /v1/tasks/:id/redrive`     re-queue a dead-lettered task (audited).
+    * `GET  /v1/nodes`                 read-only node health + dispatcher snapshot
+      (operational introspection: capacity facts, inventory, denials).
     * `GET  /healthz`                  unauthenticated liveness/readiness.
 
   ## Task envelope
@@ -78,6 +80,10 @@ defmodule Embervm.Router do
 
   get "/v1/usage" do
     handle_usage(conn)
+  end
+
+  get "/v1/nodes" do
+    handle_nodes(conn)
   end
 
   post "/v1/tasks/:id/redrive" do
@@ -363,6 +369,77 @@ defmodule Embervm.Router do
       task_count: row.task_count,
       updated_at: row.updated_at
     }
+  end
+
+  # Read-only operational introspection. Added after the R0 dispatch-recovery
+  # drill, which was slow to diagnose precisely because there was no way to see
+  # live NodeRegistry/Dispatcher state (the release is not distributed, so no IEx
+  # remote, and there was no debug endpoint). Returns each configured node's health
+  # and capacity facts (including primed_vm_ids, the seam of the adoption fix) plus
+  # the dispatcher's queue/inventory/denial snapshot. Behind the same /v1 auth as
+  # every other route; a slow/failed status call degrades to an empty snapshot
+  # rather than failing the request.
+  defp handle_nodes(conn) do
+    send_json(conn, 200, %{nodes: nodes_snapshot(), dispatch: dispatch_snapshot()})
+  end
+
+  defp nodes_snapshot do
+    Embervm.NodeRegistry.status()
+    |> Enum.map(fn {node_id, s} ->
+      %{
+        node_id: node_id,
+        health: s.health,
+        draining: s.draining,
+        dispatchable: s.dispatchable,
+        connected: s.connected,
+        address: s.address,
+        facts: node_facts_view(s.facts)
+      }
+    end)
+  rescue
+    _ -> []
+  catch
+    _, _ -> []
+  end
+
+  defp node_facts_view(nil), do: nil
+
+  defp node_facts_view(f) do
+    %{
+      live_vms: Map.get(f, :live_vms),
+      max_live_vms: Map.get(f, :max_live_vms),
+      mem_headroom_mib: Map.get(f, :mem_headroom_mib),
+      updated_at: Map.get(f, :updated_at),
+      workloads:
+        for {wl, wc} <- Map.get(f, :workloads, %{}), into: %{} do
+          {wl,
+           %{
+             free_primed_slots: Map.get(wc, :free_primed_slots),
+             base_state: Map.get(wc, :base_state),
+             snapshot_ref: Map.get(wc, :snapshot_ref),
+             primed_vm_ids: Map.get(wc, :primed_vm_ids, [])
+           }}
+        end
+    }
+  end
+
+  defp dispatch_snapshot do
+    s = Embervm.Dispatcher.stats()
+
+    %{
+      denials: s.denials,
+      warm_hits: s.warm_hits,
+      misses: s.misses,
+      queued: s.queued,
+      workers: s.workers,
+      queue_depth: s.queue_depth,
+      # inventory is keyed by {node_id, workload}; stringify the tuple key for JSON.
+      inventory: for({{node, wl}, len} <- s.inventory, into: %{}, do: {"#{node}/#{wl}", len})
+    }
+  rescue
+    _ -> nil
+  catch
+    _, _ -> nil
   end
 
   defp handle_redrive(conn, task_id) do

--- a/projects/embervm/control/test/embervm/dispatcher_test.exs
+++ b/projects/embervm/control/test/embervm/dispatcher_test.exs
@@ -185,6 +185,38 @@ defmodule Embervm.DispatcherTest do
     assert Dispatcher.stats(ctx.name).inventory[{"node-4", "wl-a"}] == 1
   end
 
+  test "a miss worker's just-primed vm is not re-adopted while its assign is in flight" do
+    gate = new_gate()
+    parent = self()
+
+    ctx =
+      start_stack(
+        prime_fun: fn _ch, _req -> {:ok, %PrimeResponse{vm_id: "vm-miss-1"}} end,
+        assign_fun: fn _ch, _req ->
+          send(parent, :at_assign)
+          wait_open(gate)
+          {:ok, success_resp()}
+        end
+      )
+
+    put_catalog(ctx, "wl-a", cap: 10)
+    # The node reports vm-miss-1 primed (the window between the worker priming it
+    # and the node dropping it on assign); inventory is empty so the task misses
+    # and primes it.
+    put_facts(ctx, "wl-a", free: 1, primed_ids: ["vm-miss-1"], live: 0, max: 8)
+
+    _tid = submit(ctx, "wl-a", "p1")
+    assert_receive :at_assign, 2000
+
+    # The worker is blocked at assign; ensure_vm sent {:vm_primed} before it, so
+    # this sweep (enqueued after that message) sees meta.vm_id set and adoption
+    # must SKIP vm-miss-1 rather than re-adopt the in-flight miss VM into inventory.
+    Dispatcher.sweep(ctx.name)
+    refute Map.has_key?(Dispatcher.stats(ctx.name).inventory, {"node-4", "wl-a"})
+
+    open_gate(gate)
+  end
+
   test "miss path primes then assigns, counted as a miss" do
     ctx = start_stack()
     put_catalog(ctx, "wl-a", cap: 10)

--- a/projects/embervm/control/test/embervm/router_test.exs
+++ b/projects/embervm/control/test/embervm/router_test.exs
@@ -72,6 +72,18 @@ defmodule Embervm.RouterTest do
     assert resp.body == "ok"
   end
 
+  test "/v1/nodes needs auth and returns a node + dispatch snapshot" do
+    assert req(:get, "/v1/nodes").status == 401
+
+    resp = req(:get, "/v1/nodes", auth("good"))
+    assert resp.status == 200
+    body = json(resp.body)
+    # Read-only operational introspection: both sections present and shaped, even
+    # with no node wired in the test app (nodes empty, dispatch snapshot present).
+    assert is_list(body["nodes"])
+    assert is_map(body["dispatch"])
+  end
+
   # -- submit ----------------------------------------------------------------
 
   test "async submit returns 202 and creates a queued task backed by the op-log" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.25
+      targetRevision: 0.1.26
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Two operability follow-ups to the dispatch-recovery fix (#3517), per Joe's pick:

**1. `GET /v1/nodes`** (read-only, `/v1`-authed): each configured node's health +
capacity facts (including `primed_vm_ids`) and the dispatcher's queue/inventory/
denial snapshot. The R0 dispatch bug was slow to diagnose precisely because there
was no live view of NodeRegistry/Dispatcher state (release not distributed → no
IEx remote, no debug endpoint). Degrades to an empty snapshot on a slow/failed
status call rather than failing the request.

**2. Close the MISS adoption window**: a miss worker now reports the `vm_id` it
primes back to the dispatcher (`{:vm_primed}`), stamped into the worker meta
immediately. Before, a just-primed miss VM was reported primed by the node but
invisible to `known_vm_ids` (meta.vm_id nil until completion), so
`adopt_inventory` could briefly re-adopt an in-flight single-use VM (self-corrected
on next use; now prevented).

Tests: `/v1/nodes` auth + snapshot shape; a miss worker's just-primed vm is not
re-adopted mid-assign (deterministic via an assign-signalling gate). Bumps embervm
chart 0.1.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)