### PR TITLE
fix(monolith-public): serve trip images as deterministic WebP

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.118
+version: 0.89.119
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -521,8 +521,19 @@ imgproxy:
     # Lowered from 85/88/90/92/95: at these levels WebP is visually near
     # indistinguishable for photos while shipping meaningfully fewer bytes; the
     # large display/full presets stay a little higher since they are viewed big.
+    #
+    # format:webp is pinned on every preset so the delivered format does NOT
+    # depend on the request's Accept header. This is deliberate: with runtime
+    # WebP auto-negotiation, imgproxy sets Vary: Accept, and Cloudflare (non-
+    # Enterprise) ignores Vary: Accept and caches a SINGLE variant per URL. A
+    # non-WebP fetch (a link-preview bot, a crawler) could win the 1-year-
+    # immutable cache slot and then serve the larger JPEG to every WebP-capable
+    # browser for a year. Pinning WebP output makes each URL a single canonical
+    # variant so the edge caches it unambiguously. WebP is universally supported
+    # (Safari 14+), so dropping negotiation costs nothing here. See the retired
+    # IMGPROXY_ENABLE_WEBP_DETECTION note below.
     - name: IMGPROXY_PRESETS
-      value: "thumb=resize:fit:300:300/quality:78,gallery=resize:fit:600:600/quality:80,preview=resize:fit:1200:1200/quality:82,display=resize:fit:1920:1080/quality:82,full=quality:90"
+      value: "thumb=resize:fit:300:300/quality:78/format:webp,gallery=resize:fit:600:600/quality:80/format:webp,preview=resize:fit:1200:1200/quality:82/format:webp,display=resize:fit:1920:1080/quality:82/format:webp,full=quality:90/format:webp"
     # Reject any URL whose processing options are not one of the named presets
     # above. Combined with ALLOWED_SOURCES this is the resize allow-list.
     - name: IMGPROXY_ONLY_PRESETS
@@ -538,14 +549,19 @@ imgproxy:
     # by the preset quality:NN, so it did nothing but mislead.)
     - name: IMGPROXY_QUALITY
       value: "82"
-    # WebP auto-negotiation (Accept: image/webp). AVIF detection is deliberately
-    # NOT enabled: at the preset quality levels above, imgproxy's AVIF encode comes
-    # out LARGER than WebP at both gallery (37KB vs 28KB) and display (186KB vs
-    # 128KB) sizes, because AVIF's quality scale is far more aggressive (a "90"
-    # on AVIF is near-lossless). Making AVIF a net win needs per-format quality
-    # (AVIF ~55-63 vs WebP ~80) plus a visual-QA pass, tracked as a follow-up.
-    - name: IMGPROXY_ENABLE_WEBP_DETECTION
-      value: "true"
+    # WebP auto-negotiation is intentionally NOT enabled. It makes the output
+    # depend on Accept: image/webp, which forces a Vary: Accept response header;
+    # Cloudflare (non-Enterprise) ignores Vary: Accept and pins one variant per
+    # URL for the 1-year TTL, so a stray non-WebP fetch could cache-pin the
+    # larger JPEG for every browser. Instead we pin format:webp in every preset
+    # (see IMGPROXY_PRESETS above): output no longer depends on Accept, imgproxy
+    # emits no Vary, and the edge caches one canonical WebP per URL.
+    #
+    # AVIF stays off for a second reason: at these quality levels imgproxy's AVIF
+    # encode came out LARGER than WebP (gallery 37KB vs 28KB, display 186KB vs
+    # 128KB) because AVIF's quality scale is far more aggressive (a "90" is near-
+    # lossless). A net-win AVIF needs per-format quality (AVIF ~55-63 vs WebP ~80)
+    # plus a visual-QA pass; tracked as a follow-up.
     - name: IMGPROXY_STRIP_METADATA
       value: "true"
     - name: IMGPROXY_MAX_SRC_RESOLUTION

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.118
+      targetRevision: 0.89.119
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
## Problem

Trip images loaded slowly. Diagnosis (live, against jomcgi.dev): the Cloudflare edge cache is **healthy** (HIT, 1-year immutable, ~100ms from edge), but it was serving the wrong variant.

A real signed gallery URL returned a **61 KB JPEG even under `Accept: image/webp`**, while origin (cache-busted) served **46 KB WebP**. Cause: imgproxy's runtime WebP negotiation sets `Vary: Accept`, and Cloudflare (non-Enterprise) ignores `Vary: Accept`, caching a single variant per URL. A non-WebP fetch (link-preview bot, crawler) won the 1-year cache slot, pinning the ~33%-larger JPEG for every modern browser. On pages that load hundreds of photos, that compounds into the slowness.

This is a cache **variant/key** bug, not a miss or an expiry, so a cache-warming job would not have helped.

## Fix (Option A)

- Pin `format:webp` on every imgproxy preset (`thumb`/`gallery`/`preview`/`display`/`full`).
- Remove `IMGPROXY_ENABLE_WEBP_DETECTION`.

Output no longer depends on `Accept`, so imgproxy emits no `Vary`, and the edge caches one canonical WebP per URL. WebP is universally supported (Safari 14+), so dropping negotiation costs nothing. Signed URLs are byte-identical (presets resolve server-side by name), so no re-signing is needed.

## Required manual step after merge

The already-cached JPEGs are pinned for a year under identical URLs, so they must be **purged from Cloudflare once** (`/img/*` on jomcgi.dev) for the WebP variants to repopulate. Until purged, previously-viewed images keep serving the old JPEG.

## Verification

- `helm template` renders cleanly; presets carry `format:webp`, no `Vary`-inducing detection flag.
- No tests assert on the old preset string or the detection flag.
- Post-merge: purge `/img/*`, then `curl -H 'Accept: image/webp' <signed URL>` should return `content-type: image/webp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)