### PR TITLE
fix(embervm): kebabcase rootfs-builder initContainer names (RFC 1123)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.28
+version: 0.1.29

--- a/projects/embervm/chart/templates/noded-deployment.yaml
+++ b/projects/embervm/chart/templates/noded-deployment.yaml
@@ -54,7 +54,10 @@ spec:
         {{- range $name, $wl := .Values.workloads }}
         {{- $top := index $.Values $name }}
         {{- if and $top $top.guestImage $top.guestImage.repository }}
-        - name: build-{{ $name }}-rootfs
+        # kebabcase the workload key: it doubles as this initContainer's name, an
+        # RFC 1123 label that must be lowercase (the camelCase key runtimePython
+        # would render build-runtimePython-rootfs, which the apiserver rejects).
+        - name: build-{{ $name | kebabcase }}-rootfs
           image: "{{ $.Values.rootfsBuilder.image.repository }}:{{ $.Values.rootfsBuilder.image.tag }}"
           command: ["/bin/bash", "/scripts/build-base-rootfs.sh"]
           env:

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.28
+      targetRevision: 0.1.29
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Deploy-blocking hotfix. PR-4's `runtimePython` workload key rendered a
rootfs-builder initContainer named `build-runtimePython-rootfs`, which the
apiserver rejects (names must be lowercase RFC 1123 labels). `helm template`
renders it fine, so CI's Manifest-diff passed, but `kubectl apply` fails,
blocking the entire `embervm-embervm-noded` Deployment from updating (embervm
stuck OutOfSync at 0.1.28).

Fix: `build-{{ $name | kebabcase }}-rootfs` — `runtimePython` → `runtime-python`;
`semgrep`/`sandbox` unaffected. Verified via `helm template`. Bumps embervm 0.1.29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)