### PR TITLE
fix(embervm): shim reads zip by EOCD, tolerating block-device padding

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.29
+version: 0.1.30

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.29
+      targetRevision: 0.1.30
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/python/shim.py
+++ b/projects/embervm/runtimes/python/shim.py
@@ -141,7 +141,9 @@ def _archive_bytes(device_path: str) -> bytes:
     eocd = raw.rfind(b"PK\x05\x06")
     # Diagnostic (device size + where the zip actually ends) so a bad attach or
     # unexpected padding is legible in the guest console, not an opaque BadZipFile.
-    sys.stderr.write(f"ember-shim: archive device {device_path} bytes={len(raw)} eocd={eocd}\n")
+    sys.stderr.write(
+        f"ember-shim: archive device {device_path} bytes={len(raw)} eocd={eocd}\n"
+    )
     sys.stderr.flush()
     if eocd < 0:
         raise ValueError(

--- a/projects/embervm/runtimes/python/shim.py
+++ b/projects/embervm/runtimes/python/shim.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import base64
 import importlib
+import io
 import json
 import os
 import socket
@@ -123,6 +124,35 @@ def _is_within(base: str, target: str) -> bool:
     return target_real == base_real or target_real.startswith(base_real + os.sep)
 
 
+def _archive_bytes(device_path: str) -> bytes:
+    """Read the zip from device_path, trimmed to the archive's true end.
+
+    The archive arrives on a raw block device (Task 6) whose size is rounded UP to
+    a sector boundary, so it carries trailing zero padding past the zip's real end.
+    zipfile locates the End-Of-Central-Directory record by scanning backward from
+    the device end; that padding makes it declare "File is not a zip file". So read
+    the raw bytes and cut at the true end: the last EOCD signature (PK\\x05\\x06)
+    plus its 22-byte record and any archive comment. A plain zip file (the tests)
+    is returned whole; a padded block device is trimmed. zipfile then parses an
+    exact, padding-free archive.
+    """
+    with open(device_path, "rb") as f:
+        raw = f.read()
+    eocd = raw.rfind(b"PK\x05\x06")
+    # Diagnostic (device size + where the zip actually ends) so a bad attach or
+    # unexpected padding is legible in the guest console, not an opaque BadZipFile.
+    sys.stderr.write(f"ember-shim: archive device {device_path} bytes={len(raw)} eocd={eocd}\n")
+    sys.stderr.flush()
+    if eocd < 0:
+        raise ValueError(
+            f"archive device {device_path!r} holds no zip end-of-central-directory record"
+        )
+    # The EOCD record is 22 bytes; its last 2 bytes are the comment length. The
+    # archive ends after the record plus that comment.
+    comment_len = int.from_bytes(raw[eocd + 20 : eocd + 22], "little")
+    return raw[: eocd + 22 + comment_len]
+
+
 def unpack_archive(device_path: str, dest: str) -> str:
     """Unpack the zip at device_path into dest and return dest.
 
@@ -131,7 +161,7 @@ def unpack_archive(device_path: str, dest: str) -> str:
     guest-side only; the host never sees the expanded tree.
     """
     os.makedirs(dest, exist_ok=True)
-    with zipfile.ZipFile(device_path) as zf:
+    with zipfile.ZipFile(io.BytesIO(_archive_bytes(device_path))) as zf:
         for member in zf.namelist():
             # Directory entries end in "/"; skip explicit creation, the file
             # writes below make parents as needed.

--- a/projects/embervm/runtimes/python/shim_test.py
+++ b/projects/embervm/runtimes/python/shim_test.py
@@ -44,6 +44,30 @@ def test_unpack_extracts_members(tmp_path):
     assert (dest / "pkg" / "mod.py").read_bytes() == b"y = 2\n"
 
 
+def test_unpack_tolerates_block_device_padding(tmp_path):
+    # The archive arrives on a raw block device whose size is rounded up to a
+    # sector, so the zip is followed by trailing zero padding. zipfile's backward
+    # EOCD scan chokes on that ("File is not a zip file"); the shim must trim to
+    # the archive's true end. Simulate it by appending zeros past the zip.
+    archive = tmp_path / "app.zip"
+    _write_zip(str(archive), {"app.py": b"z = 3\n"})
+    padded = tmp_path / "vdb.img"
+    raw = archive.read_bytes()
+    padded.write_bytes(raw + b"\x00" * (512 - len(raw) % 512))
+    dest = tmp_path / "out"
+
+    shim.unpack_archive(str(padded), str(dest))
+
+    assert (dest / "app.py").read_bytes() == b"z = 3\n"
+
+
+def test_archive_bytes_errors_when_no_eocd(tmp_path):
+    junk = tmp_path / "vdb.img"
+    junk.write_bytes(b"\x00" * 4096)
+    with pytest.raises(ValueError, match="end-of-central-directory"):
+        shim._archive_bytes(str(junk))
+
+
 def test_unpack_rejects_zip_slip(tmp_path):
     # A member with a traversal path must abort the whole unpack, never writing
     # outside dest.


### PR DESCRIPTION
The live echo round-trip (the real end-to-end test of the zip lane) surfaced this:
the runtime-python shim opened the raw archive **block device** directly with
`zipfile.ZipFile`, which fails `BadZipFile: File is not a zip file`. The device is
sized past the zip's real end (block-device rounding), and `zipfile` locates the
End-Of-Central-Directory by scanning backward from the device end, so the trailing
bytes break it. This only reproduces on a real Firecracker boot, so CI + the
fake-daemon integration test (which tests marshaling, not the block-device read)
could not catch it.

Fix (shim-only): read the raw bytes, find the last EOCD signature, and hand
`zipfile` exactly the archive via a `BytesIO`. Robust to padding, size-reporting
quirks, and alignment. Adds a guest-console diagnostic (device size + EOCD offset)
and tests for a padded device and a no-EOCD device. Bumps embervm 0.1.30.

After deploy I re-run the live echo round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)