### PR TITLE
fix(embervm): pad zip archive block file to a 512-byte sector

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.30
+version: 0.1.31

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.30
+      targetRevision: 0.1.31
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -446,6 +446,19 @@ func (s *Server) fetchArchiveToBlockFile(ctx context.Context, baseKey, archiveUR
 		_ = os.Remove(blockPath)
 		return "", status.Errorf(codes.FailedPrecondition, "noded: zip archive sha256 mismatch: got %s want %s", gotSha256, wantSha256)
 	}
+	// Firecracker's virtio-blk sizes a device as floor(fileSize/512) sectors, so a
+	// block file whose length is not a 512-byte multiple is truncated at the guest,
+	// cutting off the tail of the archive (a zip's end-of-central-directory record
+	// lives at the very end). Pad the file up to the next sector so the guest sees
+	// every archive byte. The sha256 above is over the archive bytes only, and the
+	// guest shim trims the trailing zero padding back off (runtimes/python/shim.py
+	// _archive_bytes locates the real zip end).
+	if pad := (512 - n%512) % 512; pad > 0 {
+		if err := os.Truncate(blockPath, n+pad); err != nil {
+			_ = os.Remove(blockPath)
+			return "", status.Errorf(codes.FailedPrecondition, "noded: pad archive block file to sector: %v", err)
+		}
+	}
 	return blockPath, nil
 }
 

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -46,6 +46,10 @@ type fakeDriver struct {
 	// was there during the build and gone after (cleanup).
 	lastClaim     substrate.ClaimSpec
 	archiveExists bool
+	// archiveSize is the on-disk size of the attached archive block file at claim
+	// time, so a test can prove noded pads it to a 512-byte sector (Firecracker
+	// virtio-blk floors the device to whole sectors and would else truncate it).
+	archiveSize int64
 }
 
 func (f *fakeDriver) Claim(_ context.Context, spec substrate.ClaimSpec) (substrate.Handle, error) {
@@ -58,10 +62,19 @@ func (f *fakeDriver) Claim(_ context.Context, spec substrate.ClaimSpec) (substra
 	f.live++
 	f.lastClaim = spec
 	if spec.ExtraDrivePath != "" {
-		_, err := os.Stat(spec.ExtraDrivePath)
+		fi, err := os.Stat(spec.ExtraDrivePath)
 		f.archiveExists = err == nil
+		if err == nil {
+			f.archiveSize = fi.Size()
+		}
 	}
 	return substrate.Handle{ThreadID: spec.ThreadID, ID: "vm-" + spec.ThreadID, Node: "node-4"}, nil
+}
+
+func (f *fakeDriver) archiveSizeAtClaim() int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.archiveSize
 }
 
 func (f *fakeDriver) claimSpec() substrate.ClaimSpec {
@@ -582,6 +595,46 @@ func TestBuildBaseZipHappyPath(t *testing.T) {
 	}
 	if build.snapshots != 1 {
 		t.Errorf("idempotent zip build re-snapshotted: snapshots = %d, want 1", build.snapshots)
+	}
+}
+
+// TestBuildBaseZipPadsToSector: an archive whose length is not a 512-byte
+// multiple is padded UP to the next sector on the block file, so Firecracker's
+// virtio-blk (which floors the device to whole sectors) presents every archive
+// byte to the guest rather than truncating the tail.
+func TestBuildBaseZipPadsToSector(t *testing.T) {
+	// 700 bytes: not a 512 multiple, so an unpadded device would floor to 512 and
+	// cut off the last 188 bytes (a zip's end-of-central-directory record).
+	archive := append([]byte("PK\x03\x04"), bytes.Repeat([]byte("x"), 696)...)
+	if len(archive)%512 == 0 {
+		t.Fatalf("test archive %d bytes is already sector-aligned; pick a non-multiple", len(archive))
+	}
+	s, build, url := newZipTestServer(t, archive, 0)
+
+	_, err := s.BuildBase(context.Background(), &nodev1.BuildBaseRequest{
+		Trace:     &nodev1.Trace{Workload: "ziphandler"},
+		ReadyPath: "/shim/ready",
+		Resources: &nodev1.ResourceSpec{Vcpus: 1, MemMib: 512},
+		Source: &nodev1.BuildBaseRequest_Zip{Zip: &nodev1.ZipSource{
+			RuntimeImageRef: "runtime-python:1",
+			ArchiveUrl:      url,
+			ArchiveSha256:   sha256Hex(archive),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("BuildBase zip: %v", err)
+	}
+
+	got := build.archiveSizeAtClaim()
+	want := int64((len(archive) + 511) / 512 * 512)
+	if got != want {
+		t.Errorf("archive block file size at claim = %d, want %d (sector-padded from %d)", got, want, len(archive))
+	}
+	if got%512 != 0 {
+		t.Errorf("archive block file size %d is not a 512-byte multiple", got)
+	}
+	if got < int64(len(archive)) {
+		t.Errorf("archive block file size %d truncates the %d-byte archive", got, len(archive))
 	}
 }
 


### PR DESCRIPTION
The live echo round-trip's shim diagnostic pinpointed this: `archive device
/dev/vdb bytes=1024 eocd=-1`. The echo zip is 1078 bytes, but Firecracker's
virtio-blk sizes a device as `floor(fileSize/512)` sectors, so a 1078-byte block
file becomes a **1024-byte device** — the last 54 bytes, including the entire zip
end-of-central-directory record, are truncated off the guest's view.

Fix: pad the block file up to the next 512-byte sector after the sha256 check (the
sha is over the archive bytes only; the guest shim's EOCD-trim, shipped in 0.1.30,
strips the trailing zeros). This is the noded half of the pair; both are needed.
Go test asserts a non-aligned archive is sector-padded at claim time. Bumps 0.1.31.

After deploy I re-run the live echo (this should finally complete the round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)