### PR TITLE
feat(embervm): lift noded maxLiveVMs to 16 for function headroom

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -48,3 +48,13 @@ usageAdmins:
 tracing:
   endpoint: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4317"
   serviceName: embervm-control
+
+# Node capacity override (cluster-specific; the chart default of 8 is a
+# conservative backstop). node-4 is a ~62Gi box (27% used), and the two platform
+# pools alone (semgrep floor 4 + sandbox floor 4) consume all 8 default slots,
+# leaving zero room for a zip-lane function workload (R1) to prime/miss. Lift the
+# backstop to 16 so functions (og-image and peers, cap 4 each) have headroom; at
+# ~1.5Gi/VM that is ~24Gi worst case, well within budget. This only raises the
+# runaway backstop, not any pool floor.
+noded:
+  maxLiveVMs: 16


### PR DESCRIPTION
The live echo round-trip's `GET /v1/nodes` showed the zip-lane invoke blocked by
capacity, not a zip bug: `live_vms: 8 == max_live_vms: 8`, all consumed by the
semgrep (floor 4) + sandbox (floor 4) primed pools. echo-fn (base READY) has no
slot to prime/miss → `no_capacity` denials, tasks parked.

node-4 is a ~62Gi box at 27% memory use, so `maxLiveVMs=8` is an artificial
backstop, not a resource limit. Lift it to 16 (cluster override in deploy values,
so no chart bump) to give function workloads headroom (og-image and peers cap 4
each, ~1.5Gi/VM → ~24Gi worst case). Raises only the backstop, not any pool floor.

Unblocks the live echo invoke; the R1 plan flagged this "node-4 arithmetic" risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)