### PR TITLE
chore(deps): drop unused direct uuid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "obsidian-headless": "^0.0.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "uuid": "^11.1.1",
     "ws": "^8.19.0"
   },
   "devDependencies": {
@@ -22,7 +21,6 @@
     "@types/node": "^22.19.7",
     "@types/react": "^18.3.27",
     "@types/react-dom": "^18.3.7",
-    "@types/uuid": "^10.0.0",
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^4.7.0",
     "autoprefixer": "^10.4.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,9 +85,6 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-      uuid:
-        specifier: ^11.1.1
-        version: 11.1.1
       ws:
         specifier: '>=8.21.0 <9'
         version: 8.21.0
@@ -116,9 +113,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.7
         version: 18.3.7(@types/react@18.3.27)
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -1315,9 +1309,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/uuid@10.0.0':
-    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -3145,10 +3136,6 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@11.1.1:
-    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
-    hasBin: true
-
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
@@ -4321,8 +4308,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/uuid@10.0.0': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
 
@@ -6269,8 +6254,6 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
-
-  uuid@11.1.1: {}
 
   uuid@14.0.1: {}
 

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.116
+version: 0.89.117
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.116
+      targetRevision: 0.89.117
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.195
+version: 0.285.196
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.195
+      targetRevision: 0.285.196
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

Removes \`uuid\` (and its \`@types/uuid\` companion) from the root \`package.json\`. It was a **direct dependency imported nowhere** in the codebase (the only textual match is a URL-path comment in \`HikesMap.svelte\`).

\`uuid\` remains available **transitively via mermaid** (resolves to 14.0.1), so nothing that actually uses it breaks. Dropping the phantom direct pin also removes the reason dependabot kept trying to reconcile our \`^11\` against mermaid's newer range (closes the churn behind #3443, which is closed in favor of this).

## Chart bumps

Dropping the pin moves mermaid's transitive \`uuid\` 11 -> 14 in the backend and public-frontend bundles, which rebuilds those images. Included as isolated commits:
- \`monolith\` 0.285.195 -> 0.285.196
- \`monolith-public\` 0.89.116 -> 0.89.117

## Risk

Low. No runtime import of \`uuid\` exists, functional behavior is unchanged; this is a lockfile/bundle cleanup that also happens to advance a transitive dep mermaid already wanted.

Supersedes #3443.