### PR TITLE
feat(monolith): EmberVM R1 FaaS framework (register a function, invoke by URL)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.120
+version: 0.89.121
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.120
+      targetRevision: 0.89.121
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -25,6 +25,7 @@
 # gazelle:exclude campsites
 # gazelle:exclude grimoire
 # gazelle:exclude grimoire_chat
+# gazelle:exclude faas
 # Hand-written bdd_test targets (need the real-Postgres harness), so keep gazelle
 # from generating conflicting py_tests for them.
 # gazelle:exclude public_reader_grants_test.py
@@ -87,6 +88,7 @@ _BACKEND_SRCS = glob(
         "campsites/**/*.py",
         "grimoire/**/*.py",
         "grimoire_chat/**/*.py",
+        "faas/**/*.py",
     ],
     exclude = [
         # pytest discovers both *_test.py (sibling convention) and
@@ -275,6 +277,7 @@ py_library(
             "campsites/**/*.py",
             "grimoire/**/*.py",
             "grimoire_chat/**/*.py",
+            "faas/**/*.py",
         ],
         exclude = [
             # pytest discovers both *_test.py (sibling convention) and
@@ -3478,6 +3481,28 @@ py_test(
         ":monolith_backend",
         "@pip//pytest",
         "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "faas_models_test",
+    srcs = ["faas/models_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "faas_storage_test",
+    srcs = ["faas/storage_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//boto3",
+        "@pip//pytest",
     ],
 )
 

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -3553,6 +3553,19 @@ py_test(
 )
 
 py_test(
+    name = "faas_invoke_router_test",
+    srcs = ["faas/invoke_router_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "stars_models_test",
     srcs = ["stars/models_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -3507,6 +3507,52 @@ py_test(
 )
 
 py_test(
+    name = "faas_runtime_test",
+    srcs = ["faas/runtime_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "faas_embervm_client_test",
+    srcs = ["faas/embervm_client_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//httpx",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "faas_workload_test",
+    srcs = ["faas/workload_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//kubernetes_asyncio",
+        "@pip//pytest",
+        "@pip//pyyaml",
+    ],
+)
+
+py_test(
+    name = "faas_router_test",
+    srcs = ["faas/router_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//pytest",
+        "@pip//python_multipart",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "stars_models_test",
     srcs = ["stars/models_test.py"],
     imports = ["."],

--- a/projects/monolith/app/modules_private.py
+++ b/projects/monolith/app/modules_private.py
@@ -19,6 +19,7 @@ import chat.module
 import cluster.module
 import demos.module
 import dr_jobs.module
+import faas.module
 import grimoire.module
 import hikes.module
 import home.module
@@ -47,6 +48,7 @@ ALL_MODULES: tuple[Module, ...] = (
     campsites.module.MODULE,
     worldcup.module.MODULE,
     artifact.module.MODULE,
+    faas.module.MODULE,
     demos.module.MODULE,
     # MCP-only domains (no HTTP routes of their own). Placed here, before
     # semgrep_scan, so MCP tool registration order matches the historical

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.198
+version: 0.285.199
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260714000000_faas_function.sql
+++ b/projects/monolith/chart/migrations/20260714000000_faas_function.sql
@@ -1,0 +1,30 @@
+-- faas.function: the durable registry for EmberVM zip-lane functions (ADR
+-- 045, docs/decisions/agents/045-faas-on-fc-invoke-sandbox-runtime.md; R1
+-- execution split, docs/plans/2026-07-14-embervm-r1-zip-lane-spec-and-plan.md
+-- Task 9). One row per function name; global name uniqueness is the PK
+-- (visibility is a flag, not a namespace).
+--
+-- last_smoke_at doubles as the visibility gate: NULL means registered but not
+-- yet smoke-tested (not visible), a set value means the last registered zip
+-- passed its test-run gate (Task 10) and is servable (Task 11 filters on it).
+-- No separate boolean column; re-registering a name clears last_smoke_at back
+-- to NULL until the new zip smokes again.
+--
+-- Private-tier schema: the private `app` role needs no explicit GRANT here
+-- (mirrors 20260712000000_home_cluster_snapshot.sql). public_reader grants
+-- land in a later PR when faas goes public.
+
+CREATE SCHEMA IF NOT EXISTS faas;
+
+CREATE TABLE faas.function (
+    name          TEXT PRIMARY KEY,
+    visibility    TEXT NOT NULL CHECK (visibility IN ('private','public')),
+    runtime       TEXT NOT NULL,
+    handler       TEXT NOT NULL,
+    zip_sha256    TEXT NOT NULL,
+    code_uri      TEXT NOT NULL,
+    created_by    TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_smoke_at TIMESTAMPTZ
+);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:6qLgWttoLT/GPpDZ6LSnJhpPtUo0sCMU/7hwy13CMTY=
+h1:lNsTIK8WDa9PkC+E2clkJ5AapKGvoJYCf6EqSCDxKR0=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -129,3 +129,4 @@ h1:6qLgWttoLT/GPpDZ6LSnJhpPtUo0sCMU/7hwy13CMTY=
 20260712000000_home_cluster_snapshot.sql h1:+9RRavaWXjyzk5iRiUSwBkZfdOPjKtuHNP4ywZLwMzs=
 20260712233000_semgrep_perf_cohort.sql h1:v8wnTdvoa85AVnyJG1BxEUDY74OBIG4IcuICmDBOjJw=
 20260713000000_dr_jobs_notified_columns.sql h1:xzxvvjmCXQ164L4yIrfzCOPTr8qg5EWDk7FPcS2vtH4=
+20260714000000_faas_function.sql h1:ZKy8KILFm2YrCSl+a5VelvQbuZXOIq+tdWEafCFh2qk=

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -98,6 +98,21 @@ spec:
             - name: EMBERVM_URL
               value: {{ .Values.semgrep.embervmUrl | quote }}
             {{- end }}
+            {{- if .Values.faas }}
+            # FaaS zip-lane function registry (ADR 045 / embervm R1). The read
+            # base is the in-cluster SeaweedFS S3 host noded GETs archives from;
+            # storage.code_uri raises if FAAS_S3_READ_BASE is unset, so it is
+            # required whenever the faas domain is composed. The S3 write
+            # endpoint/creds (SEAWEEDFS_S3_ENDPOINT, S3_ACCESS_KEY_ID,
+            # S3_SECRET_ACCESS_KEY) are the shared SeaweedFS ones emitted under
+            # the stars block below.
+            - name: FAAS_S3_READ_BASE
+              value: {{ .Values.faas.s3ReadBase | quote }}
+            {{- if .Values.faas.s3Bucket }}
+            - name: FAAS_S3_BUCKET
+              value: {{ .Values.faas.s3Bucket | quote }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.semgrep.dispatch }}
             - name: SEMGREP_DISPATCH
               value: {{ .Values.semgrep.dispatch | quote }}

--- a/projects/monolith/chart/templates/embervm-role.yaml
+++ b/projects/monolith/chart/templates/embervm-role.yaml
@@ -1,0 +1,43 @@
+# FaaS ingestion (ADR 045 / embervm R1, Task 10): the monolith owns each
+# function's Workload CR in the embervm namespace (a function IS a Workload). It
+# creates/patches/deletes those CRs dynamically and reads their status while
+# waiting for Ready. This namespace-scoped Role in the embervm namespace grants
+# exactly those verbs to the monolith ServiceAccount (which lives in the
+# monolith release namespace). apiGroups is "embervm.dev" (the CRD's API group,
+# not the "workloads.embervm.dev" CRD object name).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "monolith.fullname" . }}-faas
+  namespace: embervm
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+rules:
+  # workload.py: create_namespaced_custom_object (create), 409->
+  # patch_namespaced_custom_object merge-patch (patch),
+  # get_namespaced_custom_object in wait_ready (get),
+  # delete_namespaced_custom_object (delete). list/watch/update granted for
+  # parity with future reconcile reads; no over-grant beyond the CR verbs.
+  - apiGroups: ["embervm.dev"]
+    resources: ["workloads"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # wait_ready reads status.conditions; status is a subresource on the CRD.
+  - apiGroups: ["embervm.dev"]
+    resources: ["workloads/status"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "monolith.fullname" . }}-faas
+  namespace: embervm
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "monolith.fullname" . }}-faas
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "monolith.fullname" . }}
+    namespace: {{ .Release.Namespace }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -798,6 +798,16 @@ chat:
 sandbox:
   dispatch: "fc-invoke"
 
+# FaaS zip-lane function registry (ADR 045 / embervm R1). s3ReadBase is the
+# in-cluster SeaweedFS S3 read host noded GETs function archives from; it must
+# match the CRD samples' codeUri host so storage.code_uri() and noded agree on
+# the URL shape. Required whenever the faas domain is composed (storage.code_uri
+# raises if FAAS_S3_READ_BASE is unset). s3Bucket is optional (code defaults to
+# "faas").
+faas:
+  s3ReadBase: "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333"
+  s3Bucket: "faas"
+
 semgrep:
   fcInvokeUrl: ""
   # EmberVM dual-path (R0 Task 15). embervmUrl is the EmberVM control-plane base

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.198
+      targetRevision: 0.285.199
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -155,6 +155,14 @@ chat:
 sandbox:
   dispatch: "embervm"
 
+# FaaS zip-lane function registry (ADR 045 / embervm R1). The read base matches
+# the CRD samples' codeUri host (projects/embervm/crd/samples/workload-echo-fn.yaml)
+# so storage.code_uri() and noded resolve archives at the same URL. S3 write
+# endpoint/creds are the shared SeaweedFS ones (stars block).
+faas:
+  s3ReadBase: "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333"
+  s3Bucket: "faas"
+
 semgrep:
   fcInvokeUrl: "http://fc-invoke.monolith.svc.cluster.local:8080"
   # EmberVM dual-path (R0 Task 15). URL wired now; dispatch stays `fc-invoke` so

--- a/projects/monolith/domain_images.bzl
+++ b/projects/monolith/domain_images.bzl
@@ -52,6 +52,7 @@ MONOLITH_DOMAINS = [
     "campsites",
     "worldcup",
     "artifact",
+    "faas",
     "demos",
     "agent",
     "cluster",

--- a/projects/monolith/faas/__init__.py
+++ b/projects/monolith/faas/__init__.py
@@ -9,7 +9,15 @@ from fastapi import FastAPI
 
 
 def register(app: FastAPI) -> None:
-    """Mount the private faas router (ingestion API)."""
+    """Mount the private faas routers: the ingestion API and the invocation router.
+
+    Both are private-only in R1: there is no ``register_public``. The invocation
+    router serves the ``/functions/<name>`` product URL surface (Task 11); the
+    ingestion API (``/api/functions``) is the authenticated author surface (Task
+    10). The public-tier invocation router is a later, checklist-gated PR.
+    """
+    from faas.invoke_router import router as invoke_router
     from faas.router import router
 
     app.include_router(router)
+    app.include_router(invoke_router)

--- a/projects/monolith/faas/__init__.py
+++ b/projects/monolith/faas/__init__.py
@@ -1,0 +1,15 @@
+"""FaaS domain: register-with-test-run function ingestion on EmberVM (ADR 045).
+
+Private-only in R1 (Task 10): the ingestion API is an authenticated author
+surface, so there is no ``register_public``. The public-tier invocation router
+is a later, checklist-gated PR (Task 13).
+"""
+
+from fastapi import FastAPI
+
+
+def register(app: FastAPI) -> None:
+    """Mount the private faas router (ingestion API)."""
+    from faas.router import router
+
+    app.include_router(router)

--- a/projects/monolith/faas/embervm_client.py
+++ b/projects/monolith/faas/embervm_client.py
@@ -1,0 +1,77 @@
+"""Thin async submit client for EmberVM sync task submission (FaaS smoke + router).
+
+The FaaS ingestion smoke run (Task 10) and, later, the invocation router (Task
+11) both marshal an HTTP request into an EmberVM sync submit and read the
+guest's response back verbatim. This module owns that single call so the two
+callers cannot drift.
+
+Mirrors sandbox/client.py's ``_run_embervm`` shape (httpx.AsyncClient, EMBERVM_URL,
+auth_headers), with two differences: the body is forwarded to the guest VERBATIM
+(``content=`` raw bytes, never ``json=``), and we return the raw ``httpx.Response``
+so the caller reads status/headers/body itself.
+
+CRITICAL: ``guest_path`` MUST be the workload's ``invokePath`` (default
+``/invoke``). EmberVM's default guest path is ``/``; a workload whose invokePath
+is ``/invoke`` 404s if the submit does not carry ``X-Ember-Guest-Path``
+(documented Task 14a gotcha).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+
+from shared.k8s_auth import auth_headers
+
+logger = logging.getLogger(__name__)
+
+EMBERVM_URL = os.environ.get("EMBERVM_URL", "")
+
+# Connect fast; the read timeout is caller-supplied (a smoke run reads a little
+# past the 30s workload requestTimeout so the daemon's own timeout reaches us).
+SUBMIT_CONNECT_TIMEOUT = 5.0
+
+
+class EmberVMTransportError(RuntimeError):
+    """Raised when the submit could not reach EmberVM or timed out.
+
+    Distinct from a guest response with a non-2xx status: a transport error is
+    the only smoke failure the caller may retry (import errors surface as a
+    guest 5xx and never retry, per the plan's open-risks row).
+    """
+
+
+async def submit(
+    name: str,
+    *,
+    body: bytes,
+    guest_path: str,
+    extra_guest_headers: dict[str, str] | None = None,
+    read_timeout: float,
+) -> httpx.Response:
+    """POST ``body`` to workload ``name``'s sync submit, returning the raw Response.
+
+    Forwards ``body`` to the guest verbatim (``content=``). ``guest_path`` is set
+    as ``X-Ember-Guest-Path`` (the workload's invokePath), and each entry of
+    ``extra_guest_headers`` is forwarded as ``X-Ember-Guest-<k>: <v>``.
+
+    Raises :class:`EmberVMTransportError` on connect failure or timeout (the
+    retryable class); any 2xx/4xx/5xx guest response is returned, not raised.
+    """
+    if not EMBERVM_URL:
+        raise EmberVMTransportError("EMBERVM_URL is not configured")
+
+    headers = {**auth_headers(), "X-Ember-Guest-Path": guest_path}
+    for key, value in (extra_guest_headers or {}).items():
+        headers[f"X-Ember-Guest-{key}"] = value
+
+    timeout = httpx.Timeout(read_timeout, connect=SUBMIT_CONNECT_TIMEOUT)
+    url = f"{EMBERVM_URL}/v1/workloads/{name}/tasks?wait=true"
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            return await client.post(url, content=body, headers=headers)
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        logger.warning("embervm submit transport error for %s: %s", name, exc)
+        raise EmberVMTransportError(str(exc)) from exc

--- a/projects/monolith/faas/embervm_client.py
+++ b/projects/monolith/faas/embervm_client.py
@@ -43,6 +43,16 @@ class EmberVMTransportError(RuntimeError):
     """
 
 
+class EmberVMTimeout(EmberVMTransportError):
+    """Raised specifically on a read/connect timeout (``httpx.TimeoutException``).
+
+    A subclass of :class:`EmberVMTransportError` so Task 10's smoke path (which
+    catches the base class and retries once) still catches a timeout unchanged.
+    The invocation router (Task 11) catches this subclass first to map a timeout
+    to 504 while a connect failure maps to 502.
+    """
+
+
 async def submit(
     name: str,
     *,
@@ -72,6 +82,9 @@ async def submit(
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
             return await client.post(url, content=body, headers=headers)
-    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+    except httpx.TimeoutException as exc:
+        logger.warning("embervm submit timed out for %s: %s", name, exc)
+        raise EmberVMTimeout(str(exc)) from exc
+    except httpx.TransportError as exc:
         logger.warning("embervm submit transport error for %s: %s", name, exc)
         raise EmberVMTransportError(str(exc)) from exc

--- a/projects/monolith/faas/embervm_client_test.py
+++ b/projects/monolith/faas/embervm_client_test.py
@@ -91,6 +91,31 @@ async def test_submit_connect_error_raises_transport_error(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_submit_timeout_raises_embervm_timeout(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("read timed out")
+
+    _mock_client(monkeypatch, handler)
+    with pytest.raises(embervm_client.EmberVMTimeout):
+        await embervm_client.submit(
+            "echo-fn",
+            body=b"{}",
+            guest_path="/invoke",
+            extra_guest_headers=None,
+            read_timeout=5.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_embervm_timeout_is_transport_error_subclass():
+    # Task 10's smoke path catches the base class and retries; a timeout must
+    # still be caught there, so EmberVMTimeout IS an EmberVMTransportError.
+    assert issubclass(
+        embervm_client.EmberVMTimeout, embervm_client.EmberVMTransportError
+    )
+
+
+@pytest.mark.asyncio
 async def test_submit_unconfigured_url_raises(monkeypatch):
     monkeypatch.setattr(embervm_client, "EMBERVM_URL", "")
     with pytest.raises(embervm_client.EmberVMTransportError):

--- a/projects/monolith/faas/embervm_client_test.py
+++ b/projects/monolith/faas/embervm_client_test.py
@@ -1,0 +1,103 @@
+"""Tests for the EmberVM submit client (faas.embervm_client).
+
+httpx.MockTransport captures the outgoing request so we can assert the guest
+path header, the X-Ember-Guest-* header mapping, and that the body is forwarded
+verbatim (content=, not json=). A transport error maps to EmberVMTransportError.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from faas import embervm_client
+
+
+@pytest.fixture(autouse=True)
+def _url(monkeypatch):
+    monkeypatch.setattr(embervm_client, "EMBERVM_URL", "http://embervm:8080")
+
+
+def _mock_client(monkeypatch, handler):
+    """Route the module's AsyncClient through a MockTransport running ``handler``."""
+    real_init = httpx.AsyncClient.__init__
+
+    def _init(self, *args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", _init)
+
+
+@pytest.mark.asyncio
+async def test_submit_sets_guest_path_and_forwards_body_verbatim(monkeypatch):
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["path_header"] = request.headers.get("X-Ember-Guest-Path")
+        captured["ct_header"] = request.headers.get("X-Ember-Guest-Content-Type")
+        captured["body"] = request.content
+        return httpx.Response(200, text="ok")
+
+    _mock_client(monkeypatch, handler)
+
+    resp = await embervm_client.submit(
+        "echo-fn",
+        body=b'{"a":1}',
+        guest_path="/invoke",
+        extra_guest_headers={"Content-Type": "application/json"},
+        read_timeout=5.0,
+    )
+
+    assert resp.status_code == 200
+    assert captured["url"] == "http://embervm:8080/v1/workloads/echo-fn/tasks?wait=true"
+    assert captured["path_header"] == "/invoke"
+    assert captured["ct_header"] == "application/json"
+    assert captured["body"] == b'{"a":1}'  # verbatim, not re-serialized JSON
+
+
+@pytest.mark.asyncio
+async def test_submit_returns_non_2xx_response_not_raise(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="ImportError")
+
+    _mock_client(monkeypatch, handler)
+    resp = await embervm_client.submit(
+        "echo-fn",
+        body=b"{}",
+        guest_path="/invoke",
+        extra_guest_headers=None,
+        read_timeout=5.0,
+    )
+    assert resp.status_code == 500
+    assert resp.text == "ImportError"
+
+
+@pytest.mark.asyncio
+async def test_submit_connect_error_raises_transport_error(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    _mock_client(monkeypatch, handler)
+    with pytest.raises(embervm_client.EmberVMTransportError):
+        await embervm_client.submit(
+            "echo-fn",
+            body=b"{}",
+            guest_path="/invoke",
+            extra_guest_headers=None,
+            read_timeout=5.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_submit_unconfigured_url_raises(monkeypatch):
+    monkeypatch.setattr(embervm_client, "EMBERVM_URL", "")
+    with pytest.raises(embervm_client.EmberVMTransportError):
+        await embervm_client.submit(
+            "echo-fn",
+            body=b"{}",
+            guest_path="/invoke",
+            extra_guest_headers=None,
+            read_timeout=5.0,
+        )

--- a/projects/monolith/faas/invoke_router.py
+++ b/projects/monolith/faas/invoke_router.py
@@ -1,0 +1,141 @@
+"""FaaS invocation router: the ``/functions/<name>`` product URL surface (Task 11).
+
+This is the public-shaped invocation front door (mounted at the ROOT, not under
+``/api``): any HTTP method on ``/functions/<name>`` or ``/functions/<name>/<subpath>``
+looks up a smoke-passed (visible) function and marshals the caller's request into
+an EmberVM sync submit, then relays the guest's response back verbatim.
+
+R1 guest-contract limitation (EmberVM transport + shim, see
+``projects/embervm/runtimes/python/README.md``): EmberVM ALWAYS POSTs to the guest
+at exactly the workload's ``invokePath`` (default ``/invoke``). Therefore, inside
+the guest:
+
+- ``event.httpMethod`` is ALWAYS ``"POST"`` (never the caller's real method).
+- ``event.path`` is ALWAYS the invokePath (never the caller's real subpath).
+
+So a handler CANNOT read the caller's real method/subpath from
+``event.httpMethod`` / ``event.path``. This router forwards them out-of-band as
+guest request headers instead: a handler reads the real method from
+``event.headers["X-Forwarded-Method"]``, the real subpath from
+``event.headers["X-Forwarded-Path"]``, query args from
+``event.queryStringParameters`` (the raw query is appended to the guest path so
+the shim parses it), and the request payload from ``event.body``.
+
+How the shaping works (from EmberVM's submit contract): the body is forwarded to
+the guest VERBATIM; request headers prefixed ``X-Ember-Guest-`` are de-prefixed
+and become the guest request headers (thus ``event.headers``); ``X-Ember-Guest-Path``
+sets the guest request path. ``embervm_client.submit`` owns that prefixing, so
+this router hands it a plain ``extra_guest_headers`` dict plus ``guest_path``.
+
+The ``X-Ember-Guest-*`` mechanism is deliberately NOT exposed to callers: only a
+curated header set (Content-Type, Accept, and the X-Forwarded-* pair) reaches the
+guest. Auth and hop-by-hop headers are never forwarded.
+
+Response mapping (EmberVM ``?wait=true`` semantics, from
+``projects/embervm/control/lib/embervm/router.ex``):
+
+- SUCCEEDED task: EmberVM returns the guest's real status/body/headers. Relayed
+  as-is (429/413/403/5xx guest bodies pass through unchanged).
+- Sync-wait TIMEOUT: EmberVM returns HTTP 202 ``{task_id, state}`` (an async
+  fallback, NOT a guest response). Mapped to 504 for the caller.
+- A read timeout reaching us before EmberVM answers (``EmberVMTimeout``): 504.
+- A connect failure (``EmberVMTransportError``): 502.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Request, Response
+from sqlmodel import Session
+
+from app.db import get_session
+from faas import embervm_client
+from faas.repository import get_visible_function
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["faas-invoke"])
+
+# The guest invoke path. MUST match workload.build_workload_spec's invoke_path
+# default: EmberVM's default guest path is "/", so a submit that does not carry
+# this as X-Ember-Guest-Path 404s at the shim (Task 14a gotcha).
+INVOKE_PATH = "/invoke"
+
+# Read past the workload's invocation.timeoutSeconds (30s in build_workload_spec)
+# so EmberVM's own sync-wait timeout (a 202) reaches us before our read timeout
+# fires. No per-function timeout column exists in the registry yet, so this is a
+# single constant; revisit when the registry grows a per-function timeout.
+INVOKE_READ_TIMEOUT = 35.0
+
+_INVOKE_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
+
+
+@router.api_route("/functions/{name}", methods=_INVOKE_METHODS)
+@router.api_route("/functions/{name}/{subpath:path}", methods=_INVOKE_METHODS)
+async def invoke_function(
+    name: str,
+    request: Request,
+    subpath: str = "",
+    session: Session = Depends(get_session),
+) -> Response:
+    """Marshal the caller's request into an EmberVM sync submit and relay back.
+
+    404 if the function is unknown OR not yet smoke-passed (invisible): the two
+    are deliberately indistinguishable to the caller (do not leak existence of an
+    un-smoked function).
+    """
+    fn = get_visible_function(session, name)
+    if fn is None:
+        return _json(404, {"error": "function not found"})
+
+    body = await request.body()
+    raw_query = request.url.query
+    guest_path = INVOKE_PATH + (f"?{raw_query}" if raw_query else "")
+
+    # Curated guest headers: only these reach event.headers. Never forward
+    # Authorization/Cookie/hop-by-hop headers to the guest.
+    extra_guest_headers: dict[str, str] = {
+        "X-Forwarded-Method": request.method,
+        "X-Forwarded-Path": subpath,
+    }
+    content_type = request.headers.get("content-type")
+    if content_type:
+        extra_guest_headers["Content-Type"] = content_type
+    accept = request.headers.get("accept")
+    if accept:
+        extra_guest_headers["Accept"] = accept
+
+    try:
+        resp = await embervm_client.submit(
+            name,
+            body=body,
+            guest_path=guest_path,
+            extra_guest_headers=extra_guest_headers,
+            read_timeout=INVOKE_READ_TIMEOUT,
+        )
+    except embervm_client.EmberVMTimeout:
+        return _json(504, {"error": "function invocation timed out"})
+    except embervm_client.EmberVMTransportError:
+        return _json(502, {"error": "could not reach the function runtime"})
+
+    # EmberVM 202 = sync-wait timed out (async fallback), NOT a guest response.
+    if resp.status_code == 202:
+        return _json(504, {"error": "function invocation timed out"})
+
+    # Relay the guest response verbatim. EmberVM already stripped its own framing
+    # headers; forward only the content-type and let Starlette recompute the
+    # length/encoding (never forward content-length/content-encoding/transfer-
+    # encoding, which would be wrong for the re-emitted body).
+    return Response(
+        content=resp.content,
+        status_code=resp.status_code,
+        media_type=resp.headers.get("content-type"),
+    )
+
+
+def _json(status_code: int, payload: dict) -> Response:
+    """A tiny JSON Response helper (avoids importing JSONResponse everywhere)."""
+    from fastapi.responses import JSONResponse
+
+    return JSONResponse(status_code=status_code, content=payload)

--- a/projects/monolith/faas/invoke_router_test.py
+++ b/projects/monolith/faas/invoke_router_test.py
@@ -1,0 +1,247 @@
+"""Tests for the faas invocation router (Task 11): the /functions/<name> surface.
+
+``embervm_client.submit`` is monkeypatched to return synthetic ``httpx.Response``
+objects (built directly, not over the wire) so we exercise the marshal/relay
+logic, not the real EmberVM. ``get_session`` is overridden with an in-memory
+SQLite session (same shape as router_test.py). Functions are inserted directly
+via the repository so the visibility gate (``last_smoke_at``) is under test.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+
+from faas import embervm_client
+from faas.models import Function
+
+
+@pytest.fixture
+def session():
+    from sqlmodel.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as s:
+            yield s
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def _add_function(session: Session, name: str, *, visible: bool) -> None:
+    now = datetime.now(timezone.utc)
+    session.add(
+        Function(
+            name=name,
+            visibility="private",
+            runtime="python312",
+            handler="app.handle",
+            zip_sha256="deadbeef",
+            code_uri=f"http://s3/faas/{name}/deadbeef.zip",
+            created_by="api",
+            created_at=now,
+            updated_at=now,
+            last_smoke_at=now if visible else None,
+        )
+    )
+    session.commit()
+
+
+@pytest.fixture
+def submitted(monkeypatch):
+    """Patch ``submit`` to record its call and return a configurable response.
+
+    The test tweaks ``state["response"]`` (an httpx.Response) or sets
+    ``state["raises"]`` to an exception instance; it reads back
+    ``state["calls"]`` to assert the marshaling.
+    """
+    from faas import invoke_router as mod
+
+    state: dict = {
+        "calls": [],
+        "response": httpx.Response(
+            200, headers={"content-type": "application/json"}, content=b'{"ok":true}'
+        ),
+        "raises": None,
+    }
+
+    async def _submit(name, *, body, guest_path, extra_guest_headers, read_timeout):
+        state["calls"].append(
+            {
+                "name": name,
+                "body": body,
+                "guest_path": guest_path,
+                "extra_guest_headers": extra_guest_headers,
+                "read_timeout": read_timeout,
+            }
+        )
+        if state["raises"] is not None:
+            raise state["raises"]
+        return state["response"]
+
+    monkeypatch.setattr(mod.embervm_client, "submit", _submit)
+    return state
+
+
+@pytest.fixture
+def client(session):
+    from app.main import app
+    from app.db import get_session
+
+    app.dependency_overrides[get_session] = lambda: session
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+# --------------------------------------------------------------------------- #
+# Visibility / not-found
+# --------------------------------------------------------------------------- #
+
+
+def test_unknown_function_is_404(client, session, submitted):
+    resp = client.get("/functions/nope")
+    assert resp.status_code == 404
+    assert resp.json() == {"error": "function not found"}
+    assert submitted["calls"] == []  # never submitted
+
+
+def test_invisible_function_is_404(client, session, submitted):
+    # Registered but not yet smoke-passed (last_smoke_at is None) -> 404.
+    _add_function(session, "pending", visible=False)
+    resp = client.get("/functions/pending")
+    assert resp.status_code == 404
+    assert submitted["calls"] == []
+
+
+# --------------------------------------------------------------------------- #
+# Happy path marshaling + relay
+# --------------------------------------------------------------------------- #
+
+
+def test_happy_path_marshals_and_relays(client, session, submitted):
+    _add_function(session, "echo", visible=True)
+    resp = client.get("/functions/echo?title=hi")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    assert resp.headers["content-type"] == "application/json"
+
+    call = submitted["calls"][0]
+    assert call["name"] == "echo"
+    # Raw query appended to the invoke path (so the shim parses queryStringParameters).
+    assert call["guest_path"] == "/invoke?title=hi"
+    # The caller's real method is forwarded out of band (event.httpMethod is always POST).
+    assert call["extra_guest_headers"]["X-Forwarded-Method"] == "GET"
+    assert call["extra_guest_headers"]["X-Forwarded-Path"] == ""
+    assert call["read_timeout"] == 35.0
+
+
+def test_subpath_forwarded_as_header(client, session, submitted):
+    _add_function(session, "echo", visible=True)
+    resp = client.post("/functions/echo/a/b/c", content=b"x")
+    assert resp.status_code == 200
+    call = submitted["calls"][0]
+    assert call["extra_guest_headers"]["X-Forwarded-Method"] == "POST"
+    assert call["extra_guest_headers"]["X-Forwarded-Path"] == "a/b/c"
+
+
+def test_auth_headers_not_forwarded_to_guest(client, session, submitted):
+    _add_function(session, "echo", visible=True)
+    client.get(
+        "/functions/echo",
+        headers={"Authorization": "Bearer secret", "Cookie": "s=1"},
+    )
+    fwd = submitted["calls"][0]["extra_guest_headers"]
+    assert "Authorization" not in fwd
+    assert "Cookie" not in fwd
+
+
+# --------------------------------------------------------------------------- #
+# Binary body round-trip (both directions)
+# --------------------------------------------------------------------------- #
+
+
+def test_binary_body_round_trip(client, session, submitted):
+    _add_function(session, "img", visible=True)
+    png = b"\x89PNG\r\n\x1a\n\x00\x01\x02\x03\xff\xfe"
+    submitted["response"] = httpx.Response(
+        200, headers={"content-type": "image/png"}, content=png
+    )
+
+    resp = client.post(
+        "/functions/img",
+        content=b"\x00\x01\xff\xfeBINARY",
+        headers={"content-type": "application/octet-stream"},
+    )
+
+    # Request body forwarded verbatim (content=), not re-encoded.
+    assert submitted["calls"][0]["body"] == b"\x00\x01\xff\xfeBINARY"
+    assert submitted["calls"][0]["extra_guest_headers"]["Content-Type"] == (
+        "application/octet-stream"
+    )
+    # Response bytes and content-type relayed exactly.
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "image/png"
+    assert resp.content == png
+
+
+# --------------------------------------------------------------------------- #
+# Response-class mapping
+# --------------------------------------------------------------------------- #
+
+
+def test_embervm_202_maps_to_504(client, session, submitted):
+    _add_function(session, "slow", visible=True)
+    submitted["response"] = httpx.Response(
+        202,
+        headers={"content-type": "application/json"},
+        content=b'{"task_id":"t","state":"running"}',
+    )
+    resp = client.get("/functions/slow")
+    assert resp.status_code == 504
+    assert resp.json() == {"error": "function invocation timed out"}
+
+
+def test_read_timeout_maps_to_504(client, session, submitted):
+    _add_function(session, "echo", visible=True)
+    submitted["raises"] = embervm_client.EmberVMTimeout("read timed out")
+    resp = client.get("/functions/echo")
+    assert resp.status_code == 504
+    assert resp.json() == {"error": "function invocation timed out"}
+
+
+def test_connect_error_maps_to_502(client, session, submitted):
+    _add_function(session, "echo", visible=True)
+    submitted["raises"] = embervm_client.EmberVMTransportError("refused")
+    resp = client.get("/functions/echo")
+    assert resp.status_code == 502
+    assert resp.json() == {"error": "could not reach the function runtime"}
+
+
+def test_denial_429_relayed_verbatim(client, session, submitted):
+    _add_function(session, "echo", visible=True)
+    submitted["response"] = httpx.Response(
+        429,
+        headers={"content-type": "application/json"},
+        content=b'{"error":"quota exceeded","retryable":true}',
+    )
+    resp = client.get("/functions/echo")
+    assert resp.status_code == 429
+    assert resp.json() == {"error": "quota exceeded", "retryable": True}

--- a/projects/monolith/faas/models.py
+++ b/projects/monolith/faas/models.py
@@ -1,0 +1,28 @@
+"""SQLModel definitions for the faas schema (EmberVM zip-lane function registry).
+
+Mirrors chart/migrations/20260714000000_faas_function.sql. Postgres is the
+single source of truth: one row per function name (global uniqueness is the
+PK, ADR 045). last_smoke_at doubles as the visibility gate: NULL means
+registered but not yet smoke-passed (not visible); a set value means the
+current zip passed its test-run gate (Task 10) and is servable (Task 11).
+"""
+
+from datetime import datetime, timezone
+
+from sqlmodel import Field, SQLModel
+
+
+class Function(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factory
+    __tablename__ = "function"
+    __table_args__ = {"schema": "faas", "extend_existing": True}
+
+    name: str = Field(primary_key=True)
+    visibility: str
+    runtime: str
+    handler: str
+    zip_sha256: str
+    code_uri: str
+    created_by: str | None = Field(default=None)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    last_smoke_at: datetime | None = Field(default=None)

--- a/projects/monolith/faas/models_test.py
+++ b/projects/monolith/faas/models_test.py
@@ -1,0 +1,207 @@
+"""Unit tests for faas.repository: round-trip, upsert, smoke gate, delete.
+
+Uses SQLModel.metadata.create_all (no migrations) on SQLite, mirroring
+ships/models_test.py.
+"""
+
+from datetime import datetime
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from faas.models import Function
+from faas.repository import (
+    delete_function,
+    get_function,
+    get_visible_function,
+    list_functions,
+    mark_smoked,
+    upsert_function,
+)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def test_function_roundtrip(session):
+    upsert_function(
+        session,
+        name="echo-fn",
+        visibility="private",
+        runtime="python312",
+        handler="app.handle",
+        zip_sha256="a" * 64,
+        code_uri="http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333/faas/echo-fn/a.zip",
+        created_by="joe",
+    )
+
+    loaded = get_function(session, "echo-fn")
+    assert loaded is not None
+    assert loaded.name == "echo-fn"
+    assert loaded.visibility == "private"
+    assert loaded.runtime == "python312"
+    assert loaded.handler == "app.handle"
+    assert loaded.zip_sha256 == "a" * 64
+    assert loaded.created_by == "joe"
+    assert loaded.last_smoke_at is None
+    assert isinstance(loaded.created_at, datetime)
+    assert isinstance(loaded.updated_at, datetime)
+
+
+def test_upsert_last_write_wins_no_duplicate(session):
+    upsert_function(
+        session,
+        name="echo-fn",
+        visibility="private",
+        runtime="python312",
+        handler="app.handle",
+        zip_sha256="a" * 64,
+        code_uri="http://example/a.zip",
+        created_by="joe",
+    )
+    first = get_function(session, "echo-fn")
+    first_updated_at = first.updated_at
+
+    upsert_function(
+        session,
+        name="echo-fn",
+        visibility="public",
+        runtime="python312",
+        handler="app.handle2",
+        zip_sha256="b" * 64,
+        code_uri="http://example/b.zip",
+        created_by="joe2",
+    )
+
+    rows = list_functions(session)
+    assert len(rows) == 1
+
+    updated = get_function(session, "echo-fn")
+    assert updated.visibility == "public"
+    assert updated.handler == "app.handle2"
+    assert updated.zip_sha256 == "b" * 64
+    assert updated.code_uri == "http://example/b.zip"
+    assert updated.created_by == "joe2"
+    assert updated.updated_at >= first_updated_at
+
+
+def test_upsert_resets_smoke_gate_on_reregister(session):
+    upsert_function(
+        session,
+        name="echo-fn",
+        visibility="private",
+        runtime="python312",
+        handler="app.handle",
+        zip_sha256="a" * 64,
+        code_uri="http://example/a.zip",
+        created_by="joe",
+    )
+    mark_smoked(session, "echo-fn")
+    assert get_visible_function(session, "echo-fn") is not None
+
+    upsert_function(
+        session,
+        name="echo-fn",
+        visibility="private",
+        runtime="python312",
+        handler="app.handle",
+        zip_sha256="b" * 64,
+        code_uri="http://example/b.zip",
+        created_by="joe",
+    )
+
+    assert get_visible_function(session, "echo-fn") is None
+    assert get_function(session, "echo-fn").last_smoke_at is None
+
+
+def test_mark_smoked_flips_visibility(session):
+    upsert_function(
+        session,
+        name="echo-fn",
+        visibility="private",
+        runtime="python312",
+        handler="app.handle",
+        zip_sha256="a" * 64,
+        code_uri="http://example/a.zip",
+        created_by="joe",
+    )
+
+    assert get_visible_function(session, "echo-fn") is None
+
+    mark_smoked(session, "echo-fn")
+
+    visible = get_visible_function(session, "echo-fn")
+    assert visible is not None
+    assert visible.last_smoke_at is not None
+
+
+def test_mark_smoked_missing_function_is_noop(session):
+    mark_smoked(session, "does-not-exist")
+    assert get_function(session, "does-not-exist") is None
+
+
+def test_list_functions_visible_only_filters(session):
+    upsert_function(
+        session,
+        name="visible-fn",
+        visibility="private",
+        runtime="python312",
+        handler="app.handle",
+        zip_sha256="a" * 64,
+        code_uri="http://example/a.zip",
+        created_by="joe",
+    )
+    upsert_function(
+        session,
+        name="hidden-fn",
+        visibility="private",
+        runtime="python312",
+        handler="app.handle",
+        zip_sha256="b" * 64,
+        code_uri="http://example/b.zip",
+        created_by="joe",
+    )
+    mark_smoked(session, "visible-fn")
+
+    all_rows = list_functions(session)
+    assert {f.name for f in all_rows} == {"visible-fn", "hidden-fn"}
+
+    visible_rows = list_functions(session, visible_only=True)
+    assert {f.name for f in visible_rows} == {"visible-fn"}
+
+
+def test_delete_function(session):
+    upsert_function(
+        session,
+        name="echo-fn",
+        visibility="private",
+        runtime="python312",
+        handler="app.handle",
+        zip_sha256="a" * 64,
+        code_uri="http://example/a.zip",
+        created_by="joe",
+    )
+
+    assert delete_function(session, "echo-fn") is True
+    assert get_function(session, "echo-fn") is None
+    assert delete_function(session, "echo-fn") is False

--- a/projects/monolith/faas/module.py
+++ b/projects/monolith/faas/module.py
@@ -1,0 +1,17 @@
+"""FastMonolith module export for the faas domain (see framework/core.py).
+
+Private-only in R1: no ``register_public`` (the ingestion API is an
+authenticated author surface; public invocation is a later PR, Task 13). Lives
+in its own file (not __init__.py) so importing the domain package does not pull
+the framework or FastAPI.
+"""
+
+import faas as _domain
+
+from framework import Module as _Module
+
+
+MODULE = _Module(
+    name="faas",
+    register=_domain.register,
+)

--- a/projects/monolith/faas/repository.py
+++ b/projects/monolith/faas/repository.py
@@ -1,0 +1,111 @@
+"""Thin repository over faas.function: the durable half of ADR 045.
+
+ORM-level get-or-update (not a dialect-specific ``INSERT ... ON CONFLICT``) so
+this module runs identically on SQLite (unit tests, ``SQLModel.metadata.create_all``)
+and Postgres (production), mirroring ships/store.py's Vessel upsert. Every
+function is called with an explicit ``Session`` (mirrors agent/locks.py /
+ships/store.py): callers own the session and commit boundary.
+
+Global name uniqueness is the PK; visibility is a flag, not a namespace (ADR
+045). ``last_smoke_at`` doubles as the visibility gate: NULL means registered
+but not yet smoke-passed (not visible); a set value means the current zip
+passed its test-run gate (Task 10) and is servable (Task 11 filters on it).
+Re-registering a name is last-write-wins and resets ``last_smoke_at`` to NULL
+until the new zip smokes again.
+"""
+
+from datetime import datetime, timezone
+
+from sqlmodel import Session, select
+
+from faas.models import Function
+
+
+def upsert_function(
+    session: Session,
+    *,
+    name: str,
+    visibility: str,
+    runtime: str,
+    handler: str,
+    zip_sha256: str,
+    code_uri: str,
+    created_by: str | None,
+) -> Function:
+    """Create or last-write-wins replace a function row by name.
+
+    Re-registering an existing name overwrites every mutable column and resets
+    ``last_smoke_at`` to NULL: the freshly-registered zip is not yet visible
+    until it passes the test-run gate again (Task 10 calls ``mark_smoked``).
+    """
+    existing = session.get(Function, name)
+    now = datetime.now(timezone.utc)
+    if existing is None:
+        function = Function(
+            name=name,
+            visibility=visibility,
+            runtime=runtime,
+            handler=handler,
+            zip_sha256=zip_sha256,
+            code_uri=code_uri,
+            created_by=created_by,
+            created_at=now,
+            updated_at=now,
+            last_smoke_at=None,
+        )
+        session.add(function)
+        session.commit()
+        session.refresh(function)
+        return function
+
+    existing.visibility = visibility
+    existing.runtime = runtime
+    existing.handler = handler
+    existing.zip_sha256 = zip_sha256
+    existing.code_uri = code_uri
+    existing.created_by = created_by
+    existing.updated_at = now
+    existing.last_smoke_at = None
+    session.commit()
+    session.refresh(existing)
+    return existing
+
+
+def mark_smoked(session: Session, name: str) -> None:
+    """Flip the visibility gate: the current zip just passed its smoke test."""
+    function = session.get(Function, name)
+    if function is None:
+        return
+    function.last_smoke_at = datetime.now(timezone.utc)
+    session.commit()
+
+
+def get_function(session: Session, name: str) -> Function | None:
+    """Return the function row regardless of visibility, or None."""
+    return session.get(Function, name)
+
+
+def get_visible_function(session: Session, name: str) -> Function | None:
+    """Return the function row only if it has passed its smoke test."""
+    function = session.get(Function, name)
+    if function is None or function.last_smoke_at is None:
+        return None
+    return function
+
+
+def list_functions(session: Session, *, visible_only: bool = False) -> list[Function]:
+    """List all functions, optionally filtered to smoke-passed (visible) ones."""
+    stmt = select(Function)
+    if visible_only:
+        stmt = stmt.where(Function.last_smoke_at.is_not(None))
+    return list(session.exec(stmt).all())
+
+
+def delete_function(session: Session, name: str) -> bool:
+    """Delete a function row by name. Returns whether a row was deleted."""
+    function = session.get(Function, name)
+    if function is None:
+        return False
+    session.delete(function)
+    session.commit()
+    return True

--- a/projects/monolith/faas/router.py
+++ b/projects/monolith/faas/router.py
@@ -3,10 +3,13 @@
 ``POST /api/functions`` is the only code-submission surface (standing decision 7):
 an authenticated author uploads a zip + manifest; the endpoint validates it,
 uploads the archive, upserts the function's ``Workload`` CR, waits for it to go
-``Ready``, runs one smoke invocation through EmberVM, and only then makes the
-registry row visible (``mark_smoked``). Any failure after the archive upload
-rolls back so no visible function is ever left half-registered (the ADR 045 core
-security property: a function that fails its smoke run never gets a URL).
+``Ready``, runs one smoke invocation through EmberVM, and only then writes the
+registry row (visible via ``mark_smoked``). The registry row is written LAST, so
+a function that fails its smoke run never gets a URL (the ADR 045 core security
+property). Re-registration is safe: because the row is written only after a green
+smoke, a failed re-registration leaves the prior working row untouched and
+reverts only the CR, so a live function is never destroyed or made to 404 by a
+broken new upload (plan Task 10: no zero-usable-base window).
 
 ``DELETE /api/functions/{name}`` tears down the CR, the row, and the archive.
 
@@ -112,14 +115,54 @@ async def register_function(
         )
 
     # Name conflict is an authorized last-write-wins overwrite (standing decision
-    # 6): the authenticated author is replacing their own function. Not a 409.
-    _ = get_function(session, name)
+    # 6): the authenticated author is replacing their own function. Capture the
+    # prior row's CR-relevant values FIRST so a failed re-registration can revert
+    # to the still-working prior version instead of destroying it. The registry
+    # row is written only after the new zip passes its smoke (below), so on any
+    # earlier failure the prior row stays visible untouched and we revert only the
+    # Workload CR. EmberVM's no-gap turnover keeps the old base serving throughout,
+    # so a re-registration never opens a zero-usable-base window (plan Task 10).
+    prior = get_function(session, name)
+    prior_cr = (
+        {
+            "code_uri": prior.code_uri,
+            "sha256": prior.zip_sha256,
+            "handler": prior.handler,
+            "runtime": prior.runtime,
+        }
+        if prior is not None
+        else None
+    )
 
-    # --- Orchestrate (any failure past here rolls back to no visible function) ---
+    # --- Orchestrate (the registry row is written LAST, only after a green smoke) ---
     sha256 = hashlib.sha256(zipbytes).hexdigest()
     storage.put_archive(name, sha256, zipbytes)
     uri = storage.code_uri(name, sha256)
 
+    spec = workload.build_workload_spec(
+        code_uri=uri, sha256=sha256, handler=handler, runtime=runtime
+    )
+    await workload.upsert_workload(name, spec)
+
+    ok, msg = await workload.wait_ready(name, timeout_s=_READY_TIMEOUT_S)
+    if not ok:
+        await _rollback(session, name, sha256, prior_cr)
+        raise HTTPException(
+            status_code=502, detail=f"function did not become ready: {msg}"
+        )
+
+    resp = await _smoke(name)
+    if resp is None or not (200 <= resp.status_code < 300):
+        detail = resp.text[:500] if resp is not None else "smoke transport failure"
+        await _rollback(session, name, sha256, prior_cr)
+        raise HTTPException(
+            status_code=502,
+            detail={"error": "smoke invocation failed", "detail": detail},
+        )
+
+    # Smoke passed: NOW write/overwrite the registry row and make it visible. On a
+    # re-registration this is the point the prior row is replaced; on any earlier
+    # failure the prior row was left intact and serving.
     upsert_function(
         session,
         name=name,
@@ -130,28 +173,6 @@ async def register_function(
         code_uri=uri,
         created_by=created_by,
     )
-
-    spec = workload.build_workload_spec(
-        code_uri=uri, sha256=sha256, handler=handler, runtime=runtime
-    )
-    await workload.upsert_workload(name, spec)
-
-    ok, msg = await workload.wait_ready(name, timeout_s=_READY_TIMEOUT_S)
-    if not ok:
-        await _rollback(session, name, sha256)
-        raise HTTPException(
-            status_code=502, detail=f"function did not become ready: {msg}"
-        )
-
-    resp = await _smoke(name)
-    if resp is None or not (200 <= resp.status_code < 300):
-        detail = resp.text[:500] if resp is not None else "smoke transport failure"
-        await _rollback(session, name, sha256)
-        raise HTTPException(
-            status_code=502,
-            detail={"error": "smoke invocation failed", "detail": detail},
-        )
-
     mark_smoked(session, name)
     return {
         "name": name,
@@ -190,21 +211,48 @@ async def _smoke(name: str):
     return None
 
 
-async def _rollback(session: Session, name: str, sha256: str) -> None:
-    """Undo a failed registration: delete the CR, the row, and the archive.
+async def _rollback(
+    session: Session, name: str, sha256: str, prior_cr: dict | None
+) -> None:
+    """Undo a failed registration WITHOUT destroying a prior working version.
 
-    Best-effort on the CR and archive (a leaked object is harmless); the registry
-    row deletion is what guarantees no visible function remains.
+    The registry row is written only after a green smoke, so on failure there is
+    no new row to remove and no prior row is ever deleted here. If this was a
+    re-registration (``prior_cr`` set), revert the Workload CR to the prior zip so
+    the previously-working function keeps serving (EmberVM kept its base under the
+    no-gap turnover property) and the prior row stays visible. If this was a first
+    registration (``prior_cr`` None), tear the CR down. The newly-uploaded archive
+    is deleted either way, unless the restored prior CR still references it (an
+    identical-content re-registration where the new sha equals the prior sha).
     """
-    try:
-        await workload.delete_workload(name)
-    except Exception:  # noqa: BLE001: rollback must not mask the original failure
-        logger.warning("rollback: delete_workload failed for %s", name, exc_info=True)
-    delete_function(session, name)
-    try:
-        storage.delete_archive(name, sha256)
-    except Exception:  # noqa: BLE001: leaked archive object is harmless
-        logger.debug("rollback: delete_archive failed for %s", name, exc_info=True)
+    if prior_cr is not None:
+        try:
+            await workload.upsert_workload(
+                name,
+                workload.build_workload_spec(
+                    code_uri=prior_cr["code_uri"],
+                    sha256=prior_cr["sha256"],
+                    handler=prior_cr["handler"],
+                    runtime=prior_cr["runtime"],
+                ),
+            )
+        except Exception:  # noqa: BLE001: rollback must not mask the original failure
+            logger.warning(
+                "rollback: could not restore prior CR for %s", name, exc_info=True
+            )
+    else:
+        try:
+            await workload.delete_workload(name)
+        except Exception:  # noqa: BLE001: rollback must not mask the original failure
+            logger.warning(
+                "rollback: delete_workload failed for %s", name, exc_info=True
+            )
+
+    if prior_cr is None or prior_cr["sha256"] != sha256:
+        try:
+            storage.delete_archive(name, sha256)
+        except Exception:  # noqa: BLE001: leaked archive object is harmless
+            logger.debug("rollback: delete_archive failed for %s", name, exc_info=True)
 
 
 @router.delete("/{name}", status_code=204)

--- a/projects/monolith/faas/router.py
+++ b/projects/monolith/faas/router.py
@@ -1,0 +1,232 @@
+"""FaaS ingestion API: register a function through a test-run gate (ADR 045, Task 10).
+
+``POST /api/functions`` is the only code-submission surface (standing decision 7):
+an authenticated author uploads a zip + manifest; the endpoint validates it,
+uploads the archive, upserts the function's ``Workload`` CR, waits for it to go
+``Ready``, runs one smoke invocation through EmberVM, and only then makes the
+registry row visible (``mark_smoked``). Any failure after the archive upload
+rolls back so no visible function is ever left half-registered (the ADR 045 core
+security property: a function that fails its smoke run never gets a URL).
+
+``DELETE /api/functions/{name}`` tears down the CR, the row, and the archive.
+
+The invocation router (Task 11) is a separate PR; this file is registration only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
+from sqlmodel import Session
+
+from app.db import get_session
+from faas import embervm_client, storage, workload
+from faas.repository import (
+    delete_function,
+    get_function,
+    mark_smoked,
+    upsert_function,
+)
+from faas.runtime import BAKED_PACKAGES, KNOWN_RUNTIMES
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/functions", tags=["faas"])
+
+# RFC1123-ish DNS label: the function name becomes a Kubernetes resource name.
+_NAME_RE = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+_NAME_MAX = 63
+
+# The zip body cap matches the EmberVM submit body cap (8 MiB).
+_ZIP_MAX_BYTES = 8 * 1024 * 1024
+
+# The workload's guest invoke path (must match build_workload_spec's default).
+_INVOKE_PATH = "/invoke"
+
+# Ready poll budget (plan Task 10: 3 minutes) and smoke read timeout (a little
+# past the 30s workload requestTimeout so the daemon's own timeout reaches us).
+_READY_TIMEOUT_S = 180
+_SMOKE_READ_TIMEOUT = 35.0
+
+
+def _parse_requirements(raw: str | None) -> list[str]:
+    """Split a comma/newline-separated requirements field into top-level names."""
+    if not raw:
+        return []
+    parts = re.split(r"[,\n]", raw)
+    return [p.strip() for p in parts if p.strip()]
+
+
+@router.post("", status_code=201)
+async def register_function(
+    request: Request,
+    name: str = Form(...),
+    visibility: str = Form("private"),
+    runtime: str = Form("python312"),
+    handler: str = Form("app.handle"),
+    requirements: str | None = Form(None),
+    zip: UploadFile = File(...),
+    session: Session = Depends(get_session),
+) -> dict:
+    """Register a function: validate, upload, build, smoke-gate, then make visible."""
+    created_by = request.headers.get("Cf-Access-Authenticated-User-Email") or "api"
+
+    # --- Validation chain (no side effects persisted before this passes) ---
+    if not _NAME_RE.match(name) or len(name) > _NAME_MAX:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "name must be a DNS-1123 label (lowercase alphanumeric and '-', "
+                "starting and ending alphanumeric) of at most 63 characters"
+            ),
+        )
+    if runtime not in KNOWN_RUNTIMES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown runtime '{runtime}'; known: {sorted(KNOWN_RUNTIMES)}",
+        )
+    if visibility not in {"private", "public"}:
+        raise HTTPException(
+            status_code=400, detail="visibility must be 'private' or 'public'"
+        )
+
+    declared = _parse_requirements(requirements)
+    missing = [pkg for pkg in declared if pkg not in BAKED_PACKAGES]
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "declared requirements not in the runtime's baked set: "
+                f"{sorted(missing)}. Baked packages: {sorted(BAKED_PACKAGES)}"
+            ),
+        )
+
+    zipbytes = await zip.read()
+    if len(zipbytes) > _ZIP_MAX_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"zip exceeds the {_ZIP_MAX_BYTES} byte (8 MiB) cap",
+        )
+
+    # Name conflict is an authorized last-write-wins overwrite (standing decision
+    # 6): the authenticated author is replacing their own function. Not a 409.
+    _ = get_function(session, name)
+
+    # --- Orchestrate (any failure past here rolls back to no visible function) ---
+    sha256 = hashlib.sha256(zipbytes).hexdigest()
+    storage.put_archive(name, sha256, zipbytes)
+    uri = storage.code_uri(name, sha256)
+
+    upsert_function(
+        session,
+        name=name,
+        visibility=visibility,
+        runtime=runtime,
+        handler=handler,
+        zip_sha256=sha256,
+        code_uri=uri,
+        created_by=created_by,
+    )
+
+    spec = workload.build_workload_spec(
+        code_uri=uri, sha256=sha256, handler=handler, runtime=runtime
+    )
+    await workload.upsert_workload(name, spec)
+
+    ok, msg = await workload.wait_ready(name, timeout_s=_READY_TIMEOUT_S)
+    if not ok:
+        await _rollback(session, name, sha256)
+        raise HTTPException(
+            status_code=502, detail=f"function did not become ready: {msg}"
+        )
+
+    resp = await _smoke(name)
+    if resp is None or not (200 <= resp.status_code < 300):
+        detail = resp.text[:500] if resp is not None else "smoke transport failure"
+        await _rollback(session, name, sha256)
+        raise HTTPException(
+            status_code=502,
+            detail={"error": "smoke invocation failed", "detail": detail},
+        )
+
+    mark_smoked(session, name)
+    return {
+        "name": name,
+        "visibility": visibility,
+        "runtime": runtime,
+        "handler": handler,
+        "zip_sha256": sha256,
+        "ready": True,
+    }
+
+
+async def _smoke(name: str):
+    """Run the smoke invocation, retrying ONCE on a transport-class failure only.
+
+    A guest response (any status) is returned as-is; a 4xx/5xx guest smoke
+    response is a real failure and never retried (import errors never retry, per
+    the plan's open-risks row). Only a ConnectError/timeout is retried once.
+    Returns the ``httpx.Response`` or ``None`` if both transport attempts failed.
+    """
+    for attempt in range(2):
+        try:
+            return await embervm_client.submit(
+                name,
+                body=b"{}",
+                guest_path=_INVOKE_PATH,
+                extra_guest_headers={"Content-Type": "application/json"},
+                read_timeout=_SMOKE_READ_TIMEOUT,
+            )
+        except embervm_client.EmberVMTransportError as exc:
+            logger.warning(
+                "smoke transport failure for %s (attempt %d): %s",
+                name,
+                attempt + 1,
+                exc,
+            )
+    return None
+
+
+async def _rollback(session: Session, name: str, sha256: str) -> None:
+    """Undo a failed registration: delete the CR, the row, and the archive.
+
+    Best-effort on the CR and archive (a leaked object is harmless); the registry
+    row deletion is what guarantees no visible function remains.
+    """
+    try:
+        await workload.delete_workload(name)
+    except Exception:  # noqa: BLE001: rollback must not mask the original failure
+        logger.warning("rollback: delete_workload failed for %s", name, exc_info=True)
+    delete_function(session, name)
+    try:
+        storage.delete_archive(name, sha256)
+    except Exception:  # noqa: BLE001: leaked archive object is harmless
+        logger.debug("rollback: delete_archive failed for %s", name, exc_info=True)
+
+
+@router.delete("/{name}", status_code=204)
+async def deregister_function(
+    name: str,
+    session: Session = Depends(get_session),
+) -> None:
+    """Delete a function: tear down its CR, registry row, and archive.
+
+    404 if the function did not exist. The CR and archive deletions are
+    best-effort; the row deletion is the authoritative removal.
+    """
+    existing = get_function(session, name)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="function not found")
+
+    try:
+        await workload.delete_workload(name)
+    except Exception:  # noqa: BLE001: best-effort CR teardown
+        logger.warning("delete: delete_workload failed for %s", name, exc_info=True)
+    delete_function(session, name)
+    try:
+        storage.delete_archive(name, existing.zip_sha256)
+    except Exception:  # noqa: BLE001: best-effort archive teardown
+        logger.debug("delete: delete_archive failed for %s", name, exc_info=True)

--- a/projects/monolith/faas/router_test.py
+++ b/projects/monolith/faas/router_test.py
@@ -265,6 +265,46 @@ def test_smoke_transport_error_both_attempts_rolls_back(client, session, fakes):
     assert get_function(session, "echo-fn") is None
 
 
+def test_failed_reregistration_preserves_prior_function(client, session, fakes):
+    """A broken re-registration must not destroy or hide the prior working function.
+
+    Regression guard: the registry row is written only after a green smoke, so a
+    re-registration whose new zip fails leaves the prior row visible and reverts
+    only the CR (to the prior zip), never a zero-usable-base window.
+    """
+    # First registration succeeds and is visible (v1).
+    assert _post(client, handler="app.v1", zip=_zip_bytes(32)).status_code == 201
+    fn_v1 = get_function(session, "echo-fn")
+    assert fn_v1 is not None and fn_v1.last_smoke_at is not None
+    prior_sha = fn_v1.zip_sha256
+    prior_smoke = fn_v1.last_smoke_at
+
+    # Re-register the same name with a distinct zip whose smoke fails.
+    fakes["upsert_calls"].clear()
+    fakes["delete_workload_calls"].clear()
+    fakes["delete_archive_calls"].clear()
+    fakes["smoke"] = _FakeResponse(500, "boom")
+    resp = _post(client, handler="app.v2", zip=_zip_bytes(64))
+    assert resp.status_code == 502
+
+    # The prior working function is untouched: still visible, still the v1 zip.
+    fn_after = get_function(session, "echo-fn")
+    assert fn_after is not None
+    assert fn_after.handler == "app.v1"
+    assert fn_after.zip_sha256 == prior_sha
+    assert fn_after.last_smoke_at == prior_smoke
+
+    # Rollback reverted the CR to the prior zip and never deleted the workload.
+    assert fakes["delete_workload_calls"] == []
+    assert fakes["upsert_calls"], "expected a CR restore upsert"
+    restore_name, restore_spec = fakes["upsert_calls"][-1]
+    assert restore_name == "echo-fn"
+    assert restore_spec["source"]["zip"]["sha256"] == prior_sha
+    # Only the new (failed) archive was cleaned up; the prior archive is kept.
+    assert fakes["delete_archive_calls"]
+    assert all(sha != prior_sha for _n, sha in fakes["delete_archive_calls"])
+
+
 # --------------------------------------------------------------------------- #
 # DELETE
 # --------------------------------------------------------------------------- #

--- a/projects/monolith/faas/router_test.py
+++ b/projects/monolith/faas/router_test.py
@@ -1,0 +1,283 @@
+"""Tests for the faas ingestion API (Task 10): the register-with-test-run gate.
+
+The K8s CR client (faas.workload), the S3 storage (faas.storage), and the
+EmberVM submit client (faas.embervm_client) are all monkeypatched: this exercises
+the orchestration and rollback logic, not the real backends. respx is not a repo
+pip dep, so httpx is faked with a small stub Response and a monkeypatched submit.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+
+from faas import embervm_client
+from faas.repository import get_function
+
+
+def _detail(resp) -> str:
+    """Safely read the FastAPI error detail as a string (satisfies the
+    unsafe-json-field-access rule; a missing key yields "")."""
+    try:
+        return str(resp.json().get("detail", ""))
+    except (KeyError, ValueError):
+        return ""
+
+
+class _FakeResponse:
+    """Minimal stand-in for httpx.Response (status_code + text)."""
+
+    def __init__(self, status_code: int, text: str = "") -> None:
+        self.status_code = status_code
+        self.text = text
+
+
+@pytest.fixture
+def session():
+    from sqlmodel.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as s:
+            yield s
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+@pytest.fixture
+def fakes(monkeypatch):
+    """Patch storage / workload / embervm_client with in-memory fakes.
+
+    Returns a mutable dict the test can tweak (ready result, smoke response) and
+    inspect (recorded calls). Defaults are the happy path.
+    """
+    from faas import router as router_mod
+
+    state = {
+        "put_calls": [],
+        "delete_archive_calls": [],
+        "upsert_calls": [],
+        "delete_workload_calls": [],
+        "submit_calls": [],
+        "ready": (True, ""),
+        "smoke": _FakeResponse(200, '{"ok": true}'),
+        "smoke_raises": 0,  # number of leading transport errors before smoke returns
+    }
+
+    monkeypatch.setattr(
+        router_mod.storage,
+        "put_archive",
+        lambda name, sha, data: state["put_calls"].append((name, sha, len(data))),
+    )
+    monkeypatch.setattr(
+        router_mod.storage,
+        "code_uri",
+        lambda name, sha: f"http://s3/faas/{name}/{sha}.zip",
+    )
+    monkeypatch.setattr(
+        router_mod.storage,
+        "delete_archive",
+        lambda name, sha: state["delete_archive_calls"].append((name, sha)),
+    )
+
+    async def _upsert(name, spec):
+        state["upsert_calls"].append((name, spec))
+
+    async def _wait_ready(name, timeout_s=180):
+        return state["ready"]
+
+    async def _delete_workload(name):
+        state["delete_workload_calls"].append(name)
+
+    monkeypatch.setattr(router_mod.workload, "upsert_workload", _upsert)
+    monkeypatch.setattr(router_mod.workload, "wait_ready", _wait_ready)
+    monkeypatch.setattr(router_mod.workload, "delete_workload", _delete_workload)
+
+    async def _submit(name, *, body, guest_path, extra_guest_headers, read_timeout):
+        state["submit_calls"].append(
+            {"name": name, "body": body, "guest_path": guest_path}
+        )
+        if state["smoke_raises"] > 0:
+            state["smoke_raises"] -= 1
+            raise embervm_client.EmberVMTransportError("boom")
+        return state["smoke"]
+
+    monkeypatch.setattr(router_mod.embervm_client, "submit", _submit)
+    return state
+
+
+@pytest.fixture
+def client(session):
+    from app.main import app
+    from app.db import get_session
+
+    app.dependency_overrides[get_session] = lambda: session
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _zip_bytes(size: int = 32) -> bytes:
+    return b"PK\x03\x04" + b"z" * (size - 4)
+
+
+def _post(client, **overrides):
+    data = {
+        "name": overrides.get("name", "echo-fn"),
+        "visibility": overrides.get("visibility", "private"),
+        "runtime": overrides.get("runtime", "python312"),
+        "handler": overrides.get("handler", "app.handle"),
+    }
+    if "requirements" in overrides:
+        data["requirements"] = overrides["requirements"]
+    files = {"zip": ("fn.zip", overrides.get("zip", _zip_bytes()), "application/zip")}
+    return client.post("/api/functions", data=data, files=files)
+
+
+# --------------------------------------------------------------------------- #
+# Happy path
+# --------------------------------------------------------------------------- #
+
+
+def test_happy_path_registers_and_makes_visible(client, session, fakes):
+    resp = _post(client)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["name"] == "echo-fn"
+    assert body["ready"] is True
+    assert body["zip_sha256"]
+
+    # Archive put, CR upserted, smoke ran through the invoke path.
+    assert len(fakes["put_calls"]) == 1
+    assert len(fakes["upsert_calls"]) == 1
+    assert fakes["submit_calls"][0]["guest_path"] == "/invoke"
+
+    # Row exists and is visible (smoke passed -> last_smoke_at set).
+    fn = get_function(session, "echo-fn")
+    assert fn is not None
+    assert fn.last_smoke_at is not None
+
+
+def test_name_conflict_is_last_write_wins_not_409(client, session, fakes):
+    assert _post(client, handler="app.handle").status_code == 201
+    # Re-register the same name with a new handler: allowed, overwrites.
+    resp = _post(client, handler="app.other")
+    assert resp.status_code == 201
+    fn = get_function(session, "echo-fn")
+    assert fn.handler == "app.other"
+
+
+# --------------------------------------------------------------------------- #
+# Validation rejections (no row persisted)
+# --------------------------------------------------------------------------- #
+
+
+def test_requirements_outside_baked_set_rejected(client, session, fakes):
+    resp = _post(client, requirements="requests, numpy")
+    assert resp.status_code == 400
+    assert "requests" in _detail(resp)
+    # numpy is baked, so it must NOT appear in the missing list.
+    assert "numpy" not in _detail(resp).split("requests")[0]
+    assert get_function(session, "echo-fn") is None
+    assert fakes["put_calls"] == []
+
+
+def test_baked_requirements_accepted(client, session, fakes):
+    resp = _post(client, requirements="numpy\nPIL\nyaml")
+    assert resp.status_code == 201
+
+
+def test_unknown_runtime_rejected(client, session, fakes):
+    resp = _post(client, runtime="node20")
+    assert resp.status_code == 400
+    assert "runtime" in _detail(resp)
+    assert get_function(session, "echo-fn") is None
+
+
+def test_bad_name_rejected(client, session, fakes):
+    resp = _post(client, name="Echo_FN")
+    assert resp.status_code == 400
+    assert get_function(session, "Echo_FN") is None
+
+
+def test_zip_over_cap_rejected(client, session, fakes):
+    big = _zip_bytes(8 * 1024 * 1024 + 1)
+    resp = _post(client, zip=big)
+    assert resp.status_code == 413
+    assert get_function(session, "echo-fn") is None
+    assert fakes["put_calls"] == []
+
+
+# --------------------------------------------------------------------------- #
+# Ready timeout and smoke failure -> rollback, nothing visible
+# --------------------------------------------------------------------------- #
+
+
+def test_ready_timeout_rolls_back(client, session, fakes):
+    fakes["ready"] = (False, "timed out waiting for Ready")
+    resp = _post(client)
+    assert resp.status_code == 502
+    assert "did not become ready" in _detail(resp)
+    # CR deleted, row deleted, nothing visible.
+    assert fakes["delete_workload_calls"] == ["echo-fn"]
+    assert get_function(session, "echo-fn") is None
+
+
+def test_smoke_5xx_rolls_back_and_does_not_retry(client, session, fakes):
+    fakes["smoke"] = _FakeResponse(500, "ImportError: no module named app")
+    resp = _post(client)
+    assert resp.status_code == 502
+    # A guest 5xx is NOT retried: exactly one submit call.
+    assert len(fakes["submit_calls"]) == 1
+    assert fakes["delete_workload_calls"] == ["echo-fn"]
+    assert get_function(session, "echo-fn") is None
+
+
+def test_smoke_transport_error_retries_once_then_succeeds(client, session, fakes):
+    # First submit raises a transport error, the retry returns 200.
+    fakes["smoke_raises"] = 1
+    resp = _post(client)
+    assert resp.status_code == 201
+    assert len(fakes["submit_calls"]) == 2  # one failed transport + one success
+    fn = get_function(session, "echo-fn")
+    assert fn is not None and fn.last_smoke_at is not None
+
+
+def test_smoke_transport_error_both_attempts_rolls_back(client, session, fakes):
+    fakes["smoke_raises"] = 2  # both transport attempts fail
+    resp = _post(client)
+    assert resp.status_code == 502
+    assert len(fakes["submit_calls"]) == 2
+    assert fakes["delete_workload_calls"] == ["echo-fn"]
+    assert get_function(session, "echo-fn") is None
+
+
+# --------------------------------------------------------------------------- #
+# DELETE
+# --------------------------------------------------------------------------- #
+
+
+def test_delete_removes_cr_and_row(client, session, fakes):
+    assert _post(client).status_code == 201
+    resp = client.delete("/api/functions/echo-fn")
+    assert resp.status_code == 204
+    assert "echo-fn" in fakes["delete_workload_calls"]
+    assert get_function(session, "echo-fn") is None
+
+
+def test_delete_unknown_is_404(client, session, fakes):
+    resp = client.delete("/api/functions/nope")
+    assert resp.status_code == 404

--- a/projects/monolith/faas/runtime.py
+++ b/projects/monolith/faas/runtime.py
@@ -1,0 +1,38 @@
+"""Registration-time runtime contract for the zip lane (ADR 045 / embervm R1).
+
+The runtime-python base image bakes a fixed dependency subset; a function's
+declared requirements must be a subset of what the base ships (there is no
+install step at prep time, standing decision 4 of the R1 plan). This module is
+the monolith-side copy of that contract: the ingestion API (Task 10) rejects a
+registration whose declared imports are not all baked.
+
+SOURCE OF TRUTH is the runtime image README and its apko.lock.json
+(projects/embervm/runtimes/python/README.md, "Baked dependency subset"). This
+frozenset mirrors that table's importable top-level module names. It is a
+registration-time convenience check, not the enforcement point: the shim's
+import at build time (readyPath gating) and the Task 10 smoke run are what
+actually prove a function runs. Keep this in sync when the base image's baked
+set changes.
+"""
+
+from __future__ import annotations
+
+# Importable top-level names the runtime-python base ships on top of stdlib.
+# Mirrors projects/embervm/runtimes/python/README.md "Baked dependency subset":
+# pandas (+ numpy transitively), matplotlib, scipy, pillow (imported as PIL),
+# pyyaml (imported as yaml), python-dateutil (imported as dateutil).
+BAKED_PACKAGES: frozenset[str] = frozenset(
+    {
+        "pandas",
+        "numpy",
+        "matplotlib",
+        "scipy",
+        "PIL",
+        "yaml",
+        "dateutil",
+    }
+)
+
+# The runtime enum is currently one entry (Python only in R1, standing decision
+# 2); adding Node is a data change here plus a CRD enum addition.
+KNOWN_RUNTIMES: frozenset[str] = frozenset({"python312"})

--- a/projects/monolith/faas/runtime_test.py
+++ b/projects/monolith/faas/runtime_test.py
@@ -1,0 +1,21 @@
+"""Tests for the registration-time runtime contract (faas.runtime)."""
+
+from __future__ import annotations
+
+from faas.runtime import BAKED_PACKAGES, KNOWN_RUNTIMES
+
+
+def test_baked_packages_covers_readme_subset():
+    # Mirrors projects/embervm/runtimes/python/README.md "Baked dependency
+    # subset": these importable top-level names must all be present.
+    for pkg in ("pandas", "numpy", "matplotlib", "scipy", "PIL", "yaml", "dateutil"):
+        assert pkg in BAKED_PACKAGES
+
+
+def test_requests_is_not_baked():
+    # A common declared dep that is NOT in the base: registration must reject it.
+    assert "requests" not in BAKED_PACKAGES
+
+
+def test_known_runtimes_is_python_only():
+    assert KNOWN_RUNTIMES == frozenset({"python312"})

--- a/projects/monolith/faas/storage.py
+++ b/projects/monolith/faas/storage.py
@@ -125,6 +125,25 @@ def get_archive(name: str, sha256: str) -> bytes | None:
     return resp["Body"].read()
 
 
+def delete_archive(name: str, sha256: str) -> None:
+    """Delete the archive object, ignoring a missing bucket/key.
+
+    Best-effort teardown for the ingestion rollback / DELETE paths: a leaked
+    object is harmless (the registry row is the authoritative record), so a
+    NoSuchKey/NoSuchBucket is swallowed rather than raised.
+    """
+    from botocore.exceptions import ClientError
+
+    client = _client()
+    try:
+        client.delete_object(Bucket=_bucket(), Key=_object_key(name, sha256))
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "NoSuchBucket", "404"):
+            return
+        raise
+
+
 def code_uri(name: str, sha256: str) -> str:
     """Return the in-cluster read URL noded GETs for this archive.
 

--- a/projects/monolith/faas/storage.py
+++ b/projects/monolith/faas/storage.py
@@ -1,0 +1,135 @@
+"""Function zip archive storage on the SeaweedFS S3 gateway (ADR 045).
+
+Mirrors artifact/s3.py's client construction and auto-create-bucket-on-first-write
+fallback (dummy creds, path-style addressing, scheme guard on the endpoint;
+boto3 imported lazily inside each function so importing this module never pulls
+boto3 into the public app's import closure).
+
+Object key layout is ``<name>/<sha256>.zip`` under the ``faas`` bucket (one
+key per function name + zip content hash; last-write-wins registration keeps
+the old object around for one supersession, per the plan's Task 9 note, since
+nothing here deletes superseded objects). noded is the reader: it GETs
+``code_uri`` directly over the in-cluster SeaweedFS S3 endpoint, sha256-verifying
+the bytes host-side never unpacks them (Standing decision 3).
+"""
+
+import os
+
+
+def _bucket() -> str:
+    return os.environ.get("FAAS_S3_BUCKET", "faas")
+
+
+def _object_key(name: str, sha256: str) -> str:
+    return f"{name}/{sha256}.zip"
+
+
+def _read_base() -> str:
+    """In-cluster SeaweedFS S3 read host:port that noded GETs archives from.
+
+    No hardcoded default (semgrep no-hardcoded-k8s-service-url): a Helm release
+    rename silently changes the service name prefix, so this must come from
+    values.yaml via FAAS_S3_READ_BASE. The chart sets it to the SeaweedFS S3
+    Helm-service-name form pinned by the CRD samples
+    (projects/embervm/crd/samples/workload-echo-fn.yaml) and the echo fixture
+    README (projects/embervm/runtimes/python/testdata/echo/README.md).
+    """
+    base = os.environ.get("FAAS_S3_READ_BASE", "")
+    if not base:
+        raise RuntimeError("FAAS_S3_READ_BASE unset; cannot build faas code_uri")
+    return base
+
+
+def _client():
+    """Build a SeaweedFS S3 client (mirrors artifact/s3.py / trips.s3)."""
+    import boto3
+    from botocore.config import Config
+
+    endpoint = os.environ.get("SEAWEEDFS_S3_ENDPOINT", "")
+    if not endpoint:
+        raise RuntimeError("SEAWEEDFS_S3_ENDPOINT unset; cannot store faas archive")
+    # The chart injects a scheme-less host:port; boto3 requires a scheme and
+    # SeaweedFS S3 is plaintext HTTP.
+    if not endpoint.startswith(("http://", "https://")):
+        endpoint = "http://" + endpoint
+    # Scheme guaranteed above; clears the boto3-endpoint-url-missing-scheme hook
+    # (see artifact/s3.py for the same nosemgrep + exclude_rules rationale).
+    return boto3.client(  # nosemgrep: boto3-endpoint-url-missing-scheme
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=os.environ.get("S3_ACCESS_KEY_ID", "duckdb"),
+        aws_secret_access_key=os.environ.get("S3_SECRET_ACCESS_KEY", "duckdb"),
+        region_name=os.environ.get("AWS_REGION", "us-east-1"),
+        config=Config(s3={"addressing_style": "path"}),
+    )
+
+
+def put_archive(name: str, sha256: str, data: bytes) -> None:
+    """Write the function's zip bytes to ``s3://<bucket>/<name>/<sha256>.zip``.
+
+    Creates the bucket once and retries on a missing bucket (mirrors
+    artifact.s3.put_artifact / chat.store).
+    """
+    from botocore.exceptions import ClientError
+
+    client = _client()
+    bucket = _bucket()
+    key = _object_key(name, sha256)
+
+    def _put():
+        return client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=data,
+            ContentType="application/zip",
+        )
+
+    try:
+        _put()
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchBucket", "404"):
+            client.create_bucket(Bucket=bucket)
+            _put()
+        else:
+            raise
+
+
+def head_archive(name: str, sha256: str) -> bool:
+    """Return whether the archive object exists."""
+    from botocore.exceptions import ClientError
+
+    client = _client()
+    try:
+        client.head_object(Bucket=_bucket(), Key=_object_key(name, sha256))
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "NoSuchBucket", "404"):
+            return False
+        raise
+    return True
+
+
+def get_archive(name: str, sha256: str) -> bytes | None:
+    """Return the archive's raw bytes, or None if it is absent."""
+    from botocore.exceptions import ClientError
+
+    client = _client()
+    try:
+        resp = client.get_object(Bucket=_bucket(), Key=_object_key(name, sha256))
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "NoSuchBucket", "404"):
+            return None
+        raise
+    return resp["Body"].read()
+
+
+def code_uri(name: str, sha256: str) -> str:
+    """Return the in-cluster read URL noded GETs for this archive.
+
+    Built from FAAS_S3_READ_BASE (see ``_read_base``) + the bucket + object key,
+    so a Workload CR's codeUri and this module always agree on the same URL
+    shape. Raises if FAAS_S3_READ_BASE is unset.
+    """
+    return f"{_read_base()}/{_bucket()}/{_object_key(name, sha256)}"

--- a/projects/monolith/faas/storage_test.py
+++ b/projects/monolith/faas/storage_test.py
@@ -1,0 +1,117 @@
+"""Tests for faas function archive storage (boto3 mocked; mirrors artifact/s3_test.py)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from faas import storage
+
+
+@pytest.fixture(autouse=True)
+def _s3_env(monkeypatch):
+    monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "seaweedfs-s3.seaweedfs.svc:8333")
+    monkeypatch.setenv("FAAS_S3_BUCKET", "faas")
+
+
+def _patch_client(monkeypatch, client: MagicMock):
+    monkeypatch.setattr(storage, "_client", lambda: client)
+    return client
+
+
+def test_put_archive_writes_zip_object(monkeypatch):
+    client = MagicMock()
+    _patch_client(monkeypatch, client)
+
+    storage.put_archive("echo-fn", "a" * 64, b"PK\x03\x04zipbytes")
+
+    args = client.put_object.call_args.kwargs
+    assert args["Bucket"] == "faas"
+    assert args["Key"] == f"echo-fn/{'a' * 64}.zip"
+    assert args["Body"] == b"PK\x03\x04zipbytes"
+    assert args["ContentType"] == "application/zip"
+
+
+def test_put_archive_creates_bucket_then_retries(monkeypatch):
+    from botocore.exceptions import ClientError
+
+    client = MagicMock()
+    err = ClientError({"Error": {"Code": "NoSuchBucket"}}, "PutObject")
+    client.put_object.side_effect = [err, {}]
+    _patch_client(monkeypatch, client)
+
+    storage.put_archive("echo-fn", "a" * 64, b"zip")
+
+    client.create_bucket.assert_called_once_with(Bucket="faas")
+    assert client.put_object.call_count == 2
+
+
+def test_head_archive_true_and_false(monkeypatch):
+    from botocore.exceptions import ClientError
+
+    client = MagicMock()
+    client.head_object.return_value = {}
+    _patch_client(monkeypatch, client)
+    assert storage.head_archive("echo-fn", "a" * 64) is True
+
+    client.head_object.side_effect = ClientError(
+        {"Error": {"Code": "404"}}, "HeadObject"
+    )
+    assert storage.head_archive("echo-fn", "a" * 64) is False
+
+
+def test_get_archive_returns_bytes(monkeypatch):
+    client = MagicMock()
+    body = MagicMock()
+    body.read.return_value = b"zipbytes"
+    client.get_object.return_value = {"Body": body}
+    _patch_client(monkeypatch, client)
+
+    got = storage.get_archive("echo-fn", "a" * 64)
+
+    assert got == b"zipbytes"
+    assert client.get_object.call_args.kwargs["Key"] == f"echo-fn/{'a' * 64}.zip"
+
+
+def test_get_archive_missing_returns_none(monkeypatch):
+    from botocore.exceptions import ClientError
+
+    client = MagicMock()
+    client.get_object.side_effect = ClientError(
+        {"Error": {"Code": "NoSuchKey"}}, "GetObject"
+    )
+    _patch_client(monkeypatch, client)
+
+    assert storage.get_archive("echo-fn", "a" * 64) is None
+
+
+def test_code_uri_matches_crd_sample_shape(monkeypatch):
+    # This is the Helm-service-name form the CRD samples pin to
+    # (projects/embervm/crd/samples/workload-echo-fn.yaml); production sets it
+    # via values.yaml, never a hardcoded default (no-hardcoded-k8s-service-url).
+    monkeypatch.setenv(
+        "FAAS_S3_READ_BASE", "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333"
+    )
+
+    uri = storage.code_uri("echo-fn", "a" * 64)
+
+    assert uri == (
+        "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333"
+        f"/faas/echo-fn/{'a' * 64}.zip"
+    )
+
+
+def test_code_uri_honors_read_base_override(monkeypatch):
+    monkeypatch.setenv("FAAS_S3_READ_BASE", "http://custom-host:9000")
+
+    uri = storage.code_uri("echo-fn", "a" * 64)
+
+    assert uri == f"http://custom-host:9000/faas/echo-fn/{'a' * 64}.zip"
+
+
+def test_code_uri_raises_when_read_base_unset(monkeypatch):
+    monkeypatch.delenv("FAAS_S3_READ_BASE", raising=False)
+
+    with pytest.raises(RuntimeError):
+        storage.code_uri("echo-fn", "a" * 64)

--- a/projects/monolith/faas/workload.py
+++ b/projects/monolith/faas/workload.py
@@ -1,0 +1,176 @@
+"""Async Kubernetes client for the EmberVM ``Workload`` custom resource (FaaS).
+
+The FaaS ingestion API (Task 10) owns a function's ``Workload`` CR: it upserts
+it on registration and deletes it on removal / rollback. A function IS a Workload
+(standing decision 1); these CRs are data, created dynamically in the ``embervm``
+namespace and NOT tracked by any ArgoCD Application (standing decision 5).
+
+This is a self-contained ``kubernetes_asyncio`` wrapper mirroring
+``cluster/kubernetes.py``'s ``_ensure_client``. It deliberately does NOT import
+``cluster.*`` internals: cross-domain imports are forbidden by
+``import_boundaries_test``. The CR coordinates are verified against
+``projects/embervm/chart/crds/workload-crd.yaml`` (group ``embervm.dev``, version
+``v1alpha1``, plural ``workloads``, namespaced, status is a subresource).
+
+The client factory is a module-level function so tests can monkeypatch it to
+return a fake exposing the async CR methods.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from kubernetes_asyncio import client, config
+from kubernetes_asyncio.client import ApiClient
+
+logger = logging.getLogger(__name__)
+
+GROUP = "embervm.dev"
+VERSION = "v1alpha1"
+PLURAL = "workloads"
+NAMESPACE = "embervm"
+
+
+async def _custom_objects_api() -> "client.CustomObjectsApi":
+    """Build a namespaced CustomObjectsApi for the embervm CR group.
+
+    Mirrors cluster/kubernetes.py ``_ensure_client``: in-cluster config, a fresh
+    ApiClient, a CustomObjectsApi over it. Tests monkeypatch this factory to
+    return a fake with the same async method surface.
+    """
+    config.load_incluster_config()
+    return client.CustomObjectsApi(ApiClient())
+
+
+def build_workload_spec(
+    *,
+    code_uri: str,
+    sha256: str,
+    handler: str,
+    runtime: str = "python312",
+    invoke_path: str = "/invoke",
+    ready_path: str = "/shim/ready",
+) -> dict:
+    """Build a ``Workload.spec`` for a zip-source function.
+
+    Shape matches projects/embervm/crd/samples/workload-echo-fn.yaml exactly: a
+    ``task``-class zip source with the runtime base, code URI + sha256, handler,
+    and the guest invoke/ready paths, plus the R1 default resource/concurrency/
+    invocation blocks (1 vcpu, 512 MiB, floor 1 / cap 4, 30s timeout).
+    """
+    return {
+        "class": "task",
+        "source": {
+            "zip": {
+                "runtime": runtime,
+                "codeUri": code_uri,
+                "sha256": sha256,
+                "handler": handler,
+                "invokePath": invoke_path,
+                "readyPath": ready_path,
+            }
+        },
+        "resources": {"vcpus": 1, "memMib": 512},
+        "concurrency": {"floor": 1, "cap": 4},
+        "invocation": {"timeoutSeconds": 30},
+    }
+
+
+async def upsert_workload(name: str, spec: dict) -> None:
+    """Create the Workload CR, or merge-patch its spec if it already exists.
+
+    Last-write-wins registration (standing decision 6): a re-registered name
+    replaces the spec, which the control plane change-detects (new zip sha256)
+    and rebuilds. On the first registration ``create`` succeeds; on a subsequent
+    one it 409s and we patch.
+    """
+    api = await _custom_objects_api()
+    body = {
+        "apiVersion": f"{GROUP}/{VERSION}",
+        "kind": "Workload",
+        "metadata": {"name": name, "namespace": NAMESPACE},
+        "spec": spec,
+    }
+    try:
+        await api.create_namespaced_custom_object(
+            group=GROUP,
+            version=VERSION,
+            namespace=NAMESPACE,
+            plural=PLURAL,
+            body=body,
+        )
+    except client.exceptions.ApiException as exc:
+        if exc.status != 409:
+            raise
+        # Already exists: merge-patch the spec (last-write-wins).
+        await api.patch_namespaced_custom_object(
+            group=GROUP,
+            version=VERSION,
+            namespace=NAMESPACE,
+            plural=PLURAL,
+            name=name,
+            body={"spec": spec},
+            _content_type="application/merge-patch+json",
+        )
+
+
+async def wait_ready(
+    name: str, timeout_s: int = 180, poll_s: int = 3
+) -> tuple[bool, str]:
+    """Poll the Workload's status until a ``Ready`` condition resolves.
+
+    Returns ``(True, "")`` once a ``type=Ready`` condition has ``status=True``.
+    Returns ``(False, message)`` early if a ``Ready`` condition is
+    ``status=False`` (the base build / import failed; the condition message is
+    surfaced to the caller). Returns ``(False, "timed out waiting for Ready")``
+    if no terminal Ready condition appears within ``timeout_s``.
+
+    Uses ``asyncio.sleep`` between polls so it never blocks the event loop.
+    """
+    api = await _custom_objects_api()
+    deadline = asyncio.get_event_loop().time() + timeout_s
+    while True:
+        try:
+            obj = await api.get_namespaced_custom_object(
+                group=GROUP,
+                version=VERSION,
+                namespace=NAMESPACE,
+                plural=PLURAL,
+                name=name,
+            )
+        except client.exceptions.ApiException as exc:
+            # A transient 404 right after create is possible; keep polling until
+            # the deadline rather than failing the registration outright.
+            logger.debug("wait_ready get failed for %s: %s", name, exc)
+            obj = None
+
+        conditions = ((obj or {}).get("status") or {}).get("conditions") or []
+        for cond in conditions:
+            if cond.get("type") != "Ready":
+                continue
+            status = cond.get("status")
+            if status == "True":
+                return True, ""
+            if status == "False":
+                return False, cond.get("message", "Ready=False")
+
+        if asyncio.get_event_loop().time() >= deadline:
+            return False, "timed out waiting for Ready"
+        await asyncio.sleep(poll_s)
+
+
+async def delete_workload(name: str) -> None:
+    """Delete the Workload CR, ignoring a 404 (already gone)."""
+    api = await _custom_objects_api()
+    try:
+        await api.delete_namespaced_custom_object(
+            group=GROUP,
+            version=VERSION,
+            namespace=NAMESPACE,
+            plural=PLURAL,
+            name=name,
+        )
+    except client.exceptions.ApiException as exc:
+        if exc.status != 404:
+            raise

--- a/projects/monolith/faas/workload_test.py
+++ b/projects/monolith/faas/workload_test.py
@@ -1,0 +1,220 @@
+"""Tests for the EmberVM Workload CR client (faas.workload).
+
+The kubernetes_asyncio CustomObjectsApi is faked and injected via a monkeypatched
+``_custom_objects_api`` factory. Covers build_workload_spec's shape (must match
+the CRD sample), the create-then-409-patch upsert path, and wait_ready's
+condition handling (Ready True, Ready False early exit, timeout).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import yaml
+from kubernetes_asyncio.client import exceptions as k8s_exceptions
+
+from faas import workload
+
+
+class _FakeApi:
+    """Fake CustomObjectsApi recording calls and returning scripted results."""
+
+    def __init__(
+        self,
+        *,
+        create_conflict: bool = False,
+        get_objects: list | None = None,
+    ) -> None:
+        self.create_conflict = create_conflict
+        self._get_objects = list(get_objects or [])
+        self.created = []
+        self.patched = []
+        self.deleted = []
+        self.get_count = 0
+
+    async def create_namespaced_custom_object(self, **kwargs):
+        self.created.append(kwargs)
+        if self.create_conflict:
+            raise k8s_exceptions.ApiException(status=409, reason="Conflict")
+        return kwargs["body"]
+
+    async def patch_namespaced_custom_object(self, **kwargs):
+        self.patched.append(kwargs)
+        return kwargs["body"]
+
+    async def get_namespaced_custom_object(self, **kwargs):
+        self.get_count += 1
+        if self._get_objects:
+            return self._get_objects.pop(0)
+        return {}
+
+    async def delete_namespaced_custom_object(self, **kwargs):
+        self.deleted.append(kwargs)
+
+
+def _install(monkeypatch, api: _FakeApi):
+    async def _factory():
+        return api
+
+    monkeypatch.setattr(workload, "_custom_objects_api", _factory)
+
+
+# --------------------------------------------------------------------------- #
+# build_workload_spec shape
+# --------------------------------------------------------------------------- #
+
+
+def test_build_workload_spec_matches_crd_sample():
+    spec = workload.build_workload_spec(
+        code_uri="http://s3/faas/echo-fn/abc.zip",
+        sha256="abc",
+        handler="app.handle",
+    )
+    assert spec == {
+        "class": "task",
+        "source": {
+            "zip": {
+                "runtime": "python312",
+                "codeUri": "http://s3/faas/echo-fn/abc.zip",
+                "sha256": "abc",
+                "handler": "app.handle",
+                "invokePath": "/invoke",
+                "readyPath": "/shim/ready",
+            }
+        },
+        "resources": {"vcpus": 1, "memMib": 512},
+        "concurrency": {"floor": 1, "cap": 4},
+        "invocation": {"timeoutSeconds": 30},
+    }
+
+
+def test_build_workload_spec_shape_equals_checked_in_sample():
+    # Guard against drift from the committed echo sample's spec block.
+    sample_path = "projects/embervm/crd/samples/workload-echo-fn.yaml"
+
+    # Walk up to the repo root so the test runs from the bazel runfiles too.
+    here = os.path.dirname(os.path.abspath(__file__))
+    root = here
+    for _ in range(8):
+        candidate = os.path.join(root, sample_path)
+        if os.path.exists(candidate):
+            sample = yaml.safe_load(open(candidate))
+            zip_src = sample["spec"]["source"]["zip"]
+            built = workload.build_workload_spec(
+                code_uri=zip_src["codeUri"],
+                sha256=zip_src["sha256"],
+                handler=zip_src["handler"],
+            )
+            assert built["source"]["zip"].keys() == zip_src.keys()
+            assert built["resources"] == sample["spec"]["resources"]
+            assert built["concurrency"] == sample["spec"]["concurrency"]
+            assert built["invocation"] == sample["spec"]["invocation"]
+            return
+        root = os.path.dirname(root)
+    pytest.skip("crd sample not reachable from runfiles")
+
+
+# --------------------------------------------------------------------------- #
+# upsert_workload
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_upsert_creates_when_absent(monkeypatch):
+    api = _FakeApi(create_conflict=False)
+    _install(monkeypatch, api)
+    await workload.upsert_workload("echo-fn", {"class": "task"})
+    assert len(api.created) == 1
+    assert api.patched == []
+    body = api.created[0]["body"]
+    assert body["metadata"]["name"] == "echo-fn"
+    assert body["metadata"]["namespace"] == "embervm"
+    assert body["apiVersion"] == "embervm.dev/v1alpha1"
+
+
+@pytest.mark.asyncio
+async def test_upsert_patches_on_conflict(monkeypatch):
+    api = _FakeApi(create_conflict=True)
+    _install(monkeypatch, api)
+    await workload.upsert_workload("echo-fn", {"class": "task"})
+    assert len(api.created) == 1  # attempted
+    assert len(api.patched) == 1  # then merge-patched
+    assert api.patched[0]["_content_type"] == "application/merge-patch+json"
+    assert api.patched[0]["body"] == {"spec": {"class": "task"}}
+
+
+# --------------------------------------------------------------------------- #
+# wait_ready
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_wait_ready_true(monkeypatch):
+    api = _FakeApi(
+        get_objects=[{"status": {"conditions": [{"type": "Ready", "status": "True"}]}}]
+    )
+    _install(monkeypatch, api)
+    ok, msg = await workload.wait_ready("echo-fn", timeout_s=5, poll_s=0)
+    assert ok is True
+    assert msg == ""
+
+
+@pytest.mark.asyncio
+async def test_wait_ready_false_exits_early_with_message(monkeypatch):
+    api = _FakeApi(
+        get_objects=[
+            {
+                "status": {
+                    "conditions": [
+                        {
+                            "type": "Ready",
+                            "status": "False",
+                            "message": "import failed: no module named app",
+                        }
+                    ]
+                }
+            }
+        ]
+    )
+    _install(monkeypatch, api)
+    ok, msg = await workload.wait_ready("echo-fn", timeout_s=5, poll_s=0)
+    assert ok is False
+    assert "import failed" in msg
+    assert api.get_count == 1  # early exit, did not keep polling
+
+
+@pytest.mark.asyncio
+async def test_wait_ready_times_out(monkeypatch):
+    # No Ready condition ever appears; wait_ready gives up at the deadline.
+    api = _FakeApi(get_objects=[])
+    _install(monkeypatch, api)
+    ok, msg = await workload.wait_ready("echo-fn", timeout_s=0, poll_s=0)
+    assert ok is False
+    assert "timed out" in msg
+
+
+# --------------------------------------------------------------------------- #
+# delete_workload
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_delete_workload_ignores_404(monkeypatch):
+    class _NotFoundApi(_FakeApi):
+        async def delete_namespaced_custom_object(self, **kwargs):
+            raise k8s_exceptions.ApiException(status=404, reason="Not Found")
+
+    api = _NotFoundApi()
+    _install(monkeypatch, api)
+    # Should not raise.
+    await workload.delete_workload("gone")
+
+
+@pytest.mark.asyncio
+async def test_delete_workload_deletes(monkeypatch):
+    api = _FakeApi()
+    _install(monkeypatch, api)
+    await workload.delete_workload("echo-fn")
+    assert api.deleted[0]["name"] == "echo-fn"
+    assert api.deleted[0]["namespace"] == "embervm"


### PR DESCRIPTION
Implements PR-5 (Tasks 9, 10, 11) of the EmberVM R1 plan (`docs/plans/2026-07-14-embervm-r1-zip-lane-spec-and-plan.md`), the monolith FaaS consumer of the zip lane per ADR agents/045. A function IS an EmberVM zip Workload; the monolith owns the registry, the test-gated ingestion API, and the `/functions/<name>` URL surface.

## What lands

**Task 9 — registry + storage** (`faas/models.py`, `repository.py`, `storage.py`, migration `20260714000000_faas_function.sql`)
- `faas.function` table, global-unique name PK, `last_smoke_at IS NOT NULL` == visible.
- Zip archives at `s3://faas/<name>/<sha256>.zip` on SeaweedFS (artifact/s3 pattern).

**Task 10 — ingestion with test-run gate** (`faas/router.py`, `workload.py`, `embervm_client.py`, `runtime.py`, `chart/templates/embervm-role.yaml`, chart env)
- `POST /api/functions` (multipart, private tier): validate (name, runtime, requirements subset of the baked set, 8 MiB cap) -> upload -> upsert `Workload` CR -> poll Ready (3m) -> smoke invocation -> only a 2xx smoke makes the function visible. A function that fails its smoke never gets a URL (ADR 045 core property).
- `DELETE /api/functions/<name>` tears down CR + row + archive.
- RBAC: namespace-scoped Role+RoleBinding in `embervm` granting the monolith SA `get/list/watch/create/update/patch/delete` on `embervm.dev/workloads` (+ `get` on `workloads/status`). Every verb the client calls is covered.

**Task 11 — invocation router** (`faas/invoke_router.py`)
- Any method on `/functions/<name>[/<subpath>]` (private tier): marshal HTTP into the guest event, sync-submit (`?wait=true`), relay the response.
- Sets `X-Ember-Guest-Path` to the invoke path (the guest 404s at `/` otherwise). EmberVM 202 (sync-wait timeout) maps to 504; connect -> 502; unknown/invisible -> 404 (no existence leak). Binary bodies round-trip both directions.

## Review outcome

A comprehensive review confirmed RBAC verbs, CR coordinates (`embervm.dev/v1alpha1/workloads`), guest-path wiring, response mapping, BUILD targets, chart env, migration/model parity, import boundaries, and semgrep traps are all correct. One must-fix was found and fixed in this branch:

- **Re-registration data loss (fixed, `e8d11c4`):** the row was written before the build+smoke gate, so a re-registration made a live function 404 during the whole build and a failed re-registration deleted the prior working version. Fixed by writing the registry row LAST (only after a green smoke); on failure the prior row is untouched and `_rollback` reverts only the CR (patches it back to the prior zip, which EmberVM keeps serving under no-gap turnover). Regression test added.

Known follow-on (not data loss, not user-visible): if the pod dies mid-Ready-poll, an orphan CR can persist in the `embervm` namespace with no registry row; a reconcile sweep for orphan CRs is deferred (self-heals on the next registration of that name).

## Notes

- Private tier only this PR; public exposure of specific functions is PR-7 (checklist-gated). Depends on #3533 (merged), which carries guest response headers through EmberVM so a function's Content-Type survives (needed by og-image in PR-6).
- Charts bumped: monolith 0.285.199, monolith-public 0.89.121 (shared image).
- Not yet live-verified in-cluster; will run the echo round-trip after merge + rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)