### PR TITLE
fix(embervm): op-log stores payloads as ETF blobs so binary bodies persist

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -340,3 +340,36 @@ Task 14b does semgrep + the fc-invoke concurrency rebalance + finding-equality.
   parked task never runs after its deadline and never burns a primed VM. Expiry does
   NOT dead-letter (it is not a processing failure; `failed_permanent` is terminal and
   sufficient). This CLOSES the D12 "queued-task TTL not enforced" known gap.
+
+## R1 Phase 2: FaaS consumer (og-image surfaced an op-log durability bug)
+
+### D-R1.2.1 Op payloads are stored as ETF blobs, not JSON (binary-body crash fix)
+- **Found:** registering the first binary-returning function (og-image, Task 12)
+  crashed the control plane. The guest produced a valid PNG, but
+  `Embervm.OpLog.SQLite.encode_payload/1` JSON-encoded the `:succeeded` op payload
+  (which embeds the result `body`), and `:json.encode/1` rejects a non-UTF-8 binary
+  with `{:invalid_byte, 137}` (137 = 0x89, PNG's first byte). That crashed the
+  `OpLog.SQLite` GenServer, cascaded to `TaskStore`, and briefly restarted the
+  control-plane router (self-healed by the supervisor in ~15s; semgrep/sandbox
+  unaffected; the monolith's smoke gate saw a transport error and rolled the
+  registration back, so no poison-pill CR persisted). The `:submitted` request-body
+  path had the same latent exposure (a binary request body would crash identically).
+- **Did instead (Joe's call among 3 options):** store the op payload as an Erlang
+  External Term Format binary (`:erlang.term_to_binary/1`), bound as an Exqlite
+  `{:blob, _}`, replacing `:json.encode/1`. ETF round-trips ANY term, so a binary
+  body persists byte-exact. `decode_payload/1` disambiguates by first byte (ETF
+  version tag 131 vs JSON `{` = 123), so rows written before the upgrade still
+  decode via the JSON branch during the 30-day journal retention overlap. A
+  `stringify/1` normalizer coerces the `binary_to_term` result (atom keys) into the
+  exact string-keyed shape `:json.decode/1` yielded, so every reader (the
+  dispatcher's request envelope via `load_request`, replay via `read_from`) is
+  unchanged. Also wrapped the `results.body` bind as `{:blob, _}` (was a plain
+  binary bound as TEXT) so the projected result row stores a PNG byte-exact too.
+- **Cost accepted:** the `ops.payload_json` column no longer holds JSON, so SQL
+  JSON-function queryability of op payloads is lost. Nothing queries it that way
+  (verified: only plain `SELECT payload_json`), and the payloads are this node's own
+  trusted data, so `binary_to_term/1` on read is safe.
+- **Tests:** ExUnit covers a binary result body round-trip (append -> `read_from` +
+  `load_result`, survives reopen), a binary request body via `load_request`, and a
+  legacy JSON row still decoding to string keys (upgrade compatibility).
+- **Approved:** yes (Joe picked the ETF-blob option; flagged here for post-impl review).

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.34
+version: 0.1.35

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -315,6 +315,8 @@ defmodule Embervm.OpLog.SQLite do
              op.workload,
              op.task_id,
              Atom.to_string(op.kind),
+             # An ETF {:blob, _}, not JSON, so a binary body persists byte-exact
+             # (see encode_payload/1).
              encode_payload(op.payload)
            ]),
          :done <- Sqlite3.step(conn, stmt),
@@ -384,7 +386,9 @@ defmodule Embervm.OpLog.SQLite do
              Sqlite3.bind(stmt, [
                op.task_id,
                Map.fetch!(payload, :status_code),
-               Map.get(payload, :body),
+               # {:blob, _} forces BLOB binding so a non-UTF-8 body (a PNG) is
+               # stored byte-exact; a plain binary would bind as TEXT.
+               blob(Map.get(payload, :body)),
                Map.fetch!(payload, :size_bytes),
                bool_to_int(Map.get(payload, :truncated, false)),
                op.ts,
@@ -621,9 +625,10 @@ defmodule Embervm.OpLog.SQLite do
   # lives only in the immutable ops log (payload_json), never a projected
   # column, so this selects the earliest submitted op for the task (the
   # ops_task_id_idx index makes it cheap) and pulls the `request` member out of
-  # the decoded payload. Keys come back as strings (:json.decode never restores
-  # atoms), which the dispatcher expects. {:ok, nil} for an unknown task or a
-  # submitted op that carried no request (an older record).
+  # the decoded payload. Keys come back as strings (decode_payload normalizes both
+  # the legacy JSON and the new ETF-blob forms to string keys), which the
+  # dispatcher expects. {:ok, nil} for an unknown task or a submitted op that
+  # carried no request (an older record).
   defp do_load_request(conn, task_id) do
     sql = """
     SELECT payload_json FROM ops
@@ -1016,29 +1021,52 @@ defmodule Embervm.OpLog.SQLite do
   defp bool_to_int(false), do: 0
   defp bool_to_int(nil), do: 0
 
-  # -- JSON -------------------------------------------------------------
+  # Wrap a binary as an Exqlite {:blob, _} so it binds via sqlite3_bind_blob and
+  # stores byte-exact (a plain binary binds as TEXT). nil (a bodyless result)
+  # passes through as a NULL bind.
+  defp blob(nil), do: nil
+  defp blob(bin) when is_binary(bin), do: {:blob, bin}
 
-  # Normalizes a payload map before encoding: drops nil-valued keys and
-  # stringifies atom values, so :json.encode/1 never sees an atom it can't
-  # represent and decode/1 round-trips to plain strings/numbers/maps only.
-  # Keys are already expected to be atoms or strings; :json.encode/1 handles
-  # atom keys directly, so only values need normalizing here.
+  # -- payload codec ----------------------------------------------------
+
+  # Op payloads are stored as an Erlang External Term Format binary
+  # (:erlang.term_to_binary/1), bound as a {:blob, _} so SQLite keeps the exact
+  # bytes. This replaces the previous :json.encode/1: JSON cannot represent a
+  # non-UTF-8 binary, so a task whose result (or request) body was binary (e.g.
+  # a PNG, first byte 0x89 = 137) crashed the writer with {:invalid_byte, 137}
+  # and cascaded a control-plane restart. ETF round-trips ANY term, so a binary
+  # body persists byte-exact. Payloads are this node's own trusted data (never
+  # untrusted external input), so binary_to_term/1 on read is safe here.
   defp encode_payload(payload) when is_map(payload) do
-    payload
-    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
-    |> Map.new(fn {k, v} -> {k, normalize_value(v)} end)
-    |> :json.encode()
-    |> :erlang.iolist_to_binary()
+    {:blob, :erlang.term_to_binary(payload)}
   end
 
-  # nil is already dropped by encode_payload/1 before this runs; booleans are
-  # atoms too but :json.encode/1 handles true/false natively so they pass through.
-  defp normalize_value(v) when is_atom(v) and not is_boolean(v), do: Atom.to_string(v)
-  defp normalize_value(v), do: v
+  # An ETF blob begins with the version byte 131; legacy rows written before this
+  # change are JSON objects beginning with "{" (123). The first byte disambiguates
+  # the two formats during the retention overlap, so old and new rows both read
+  # back correctly. binary_to_term/1 restores the original atom-keyed map, which
+  # `stringify/1` coerces into the string-keyed shape :json.decode/1 produced, so
+  # every reader (the dispatcher's request envelope, replay) is unchanged.
+  defp decode_payload(<<131, _::binary>> = term) do
+    term |> :erlang.binary_to_term() |> stringify()
+  end
 
   defp decode_payload(json) when is_binary(json) do
     :json.decode(json)
   end
+
+  # Coerces a binary_to_term result into the exact shape :json.decode/1 yields
+  # for a legacy row: string keys, non-boolean atom values stringified, and
+  # nil-valued map keys dropped (encode used to reject them before JSON encoding).
+  # Binaries, numbers, booleans and lists pass through, so a binary body survives
+  # intact while staying contract-compatible with the JSON path for all readers.
+  defp stringify(map) when is_map(map) do
+    for {k, v} <- map, not is_nil(v), into: %{}, do: {to_string(k), stringify(v)}
+  end
+
+  defp stringify(list) when is_list(list), do: Enum.map(list, &stringify/1)
+  defp stringify(v) when is_atom(v) and not is_boolean(v), do: Atom.to_string(v)
+  defp stringify(v), do: v
 
   # Guest response headers (a string->string map) ride the `results.headers` column
   # as a JSON object. An empty/absent map is stored as NULL so old rows and

--- a/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
@@ -9,6 +9,7 @@ defmodule Embervm.OpLog.SQLiteTest do
 
   alias Embervm.OpLog.Op
   alias Embervm.OpLog.SQLite
+  alias Exqlite.Sqlite3
 
   setup do
     path = Path.join(System.tmp_dir!(), "embervm_oplog_test_#{System.unique_integer([:positive, :monotonic])}.db")
@@ -695,5 +696,130 @@ defmodule Embervm.OpLog.SQLiteTest do
     assert [%{principal: "p2"}] = p1.items
 
     :ok = GenServer.stop(server)
+  end
+
+  # -- binary payloads (op payloads are ETF blobs, not JSON) -----------------
+
+  test "a binary (non-UTF-8) result body round-trips instead of crashing the writer",
+       %{path: path} do
+    server = start_server(path)
+    # First byte 0x89 (137) is exactly the byte that crashed the old JSON encoder
+    # ({:invalid_byte, 137}) and cascaded a control-plane restart; the body also
+    # carries a NUL and 0xFF so any UTF-8-assuming path would corrupt it.
+    png = <<0x89, "PNG", 13, 10, 26, 10, 0, 1, 2, 0xFA, 0xFF>>
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :submitted,
+        tenant: "t1",
+        principal: "p1",
+        workload: "og-image",
+        task_id: "task-bin",
+        ts: 100,
+        payload: %{idempotency_key: "k", expires_at: nil}
+      })
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :succeeded,
+        tenant: "t1",
+        task_id: "task-bin",
+        ts: 101,
+        payload: %{
+          status_code: 200,
+          body: png,
+          size_bytes: byte_size(png),
+          truncated: false,
+          headers: %{"Content-Type" => "image/png"},
+          expires_at: 9_999
+        }
+      })
+
+    # The immutable ops journal keeps the exact bytes and the string-keyed shape.
+    {:ok, ops} = SQLite.read_from(server, 0)
+    succeeded = Enum.find(ops, &(&1.kind == :succeeded))
+    assert succeeded.payload["body"] == png
+    assert succeeded.payload["status_code"] == 200
+    assert succeeded.payload["headers"] == %{"Content-Type" => "image/png"}
+
+    # The projected result row also carries the binary body back verbatim.
+    {:ok, result} = SQLite.load_result(server, "task-bin")
+    assert result.body == png
+    assert result.status_code == 200
+
+    # Durable across a reopen (persisted on disk as an ETF blob).
+    :ok = GenServer.stop(server)
+    server2 = start_server(path)
+    {:ok, ops2} = SQLite.read_from(server2, 0)
+    assert Enum.find(ops2, &(&1.kind == :succeeded)).payload["body"] == png
+    :ok = GenServer.stop(server2)
+  end
+
+  test "a binary request body round-trips through load_request", %{path: path} do
+    server = start_server(path)
+    raw = <<0x89, 0, 0xFF, "req-bytes", 200>>
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :submitted,
+        tenant: "t1",
+        principal: "p1",
+        workload: "og-image",
+        task_id: "task-req",
+        ts: 100,
+        payload: %{
+          idempotency_key: "k",
+          expires_at: nil,
+          request: %{
+            method: "POST",
+            path: "/invoke",
+            body: raw,
+            headers: %{"Content-Type" => "application/octet-stream"}
+          }
+        }
+      })
+
+    {:ok, request} = SQLite.load_request(server, "task-req")
+    # Keys come back as strings (the dispatcher's contract) and the binary body
+    # survives intact through the nested map.
+    assert request["method"] == "POST"
+    assert request["body"] == raw
+    assert request["headers"] == %{"Content-Type" => "application/octet-stream"}
+    :ok = GenServer.stop(server)
+  end
+
+  test "a legacy JSON payload row still decodes to string keys (upgrade compatibility)",
+       %{path: path} do
+    # Seed the schema with a real (ETF) op, stop, then inject a row whose
+    # payload_json is a JSON object the way a pre-upgrade build wrote it. On
+    # reopen, decode_payload must read it via the JSON branch (first byte "{" =
+    # 123, not the ETF version byte 131), so tasks in flight across the upgrade
+    # are not lost.
+    server = start_server(path)
+
+    {:ok, _} =
+      SQLite.append(server, %Op{kind: :denied, tenant: "t1", ts: 1, payload: %{reason: "seed"}})
+
+    :ok = GenServer.stop(server)
+
+    {:ok, conn} = Sqlite3.open(path)
+    json = ~s({"status_code":200,"body":"legacy","size_bytes":6})
+
+    {:ok, stmt} =
+      Sqlite3.prepare(
+        conn,
+        "INSERT INTO ops (ts,tenant,principal,workload,task_id,kind,payload_json) VALUES (?,?,?,?,?,?,?)"
+      )
+
+    :ok = Sqlite3.bind(stmt, [2, "t1", "p1", "wl", "task-legacy", "succeeded", json])
+    :done = Sqlite3.step(conn, stmt)
+    :ok = Sqlite3.release(conn, stmt)
+    :ok = Sqlite3.close(conn)
+
+    server2 = start_server(path)
+    {:ok, ops} = SQLite.read_from(server2, 0)
+    legacy = Enum.find(ops, &(&1.task_id == "task-legacy"))
+    assert legacy.payload == %{"status_code" => 200, "body" => "legacy", "size_bytes" => 6}
+    :ok = GenServer.stop(server2)
   end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.34
+      targetRevision: 0.1.35
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## What / why

The first binary-returning FaaS function (og-image, R1 Task 12) crashed the EmberVM control plane. The guest produced a valid PNG, but `Embervm.OpLog.SQLite.encode_payload/1` JSON-encoded the `:succeeded` op payload (which embeds the result `body`), and `:json.encode/1` rejects a non-UTF-8 binary with `{:invalid_byte, 137}` (137 = `0x89`, PNG's first byte). That crashed the `OpLog.SQLite` GenServer, cascaded to `TaskStore`, and briefly restarted the control-plane router.

Severity was contained: the BEAM supervisor self-healed the tree in ~15s, semgrep/sandbox were unaffected, and the monolith's smoke gate saw the transport error and rolled the registration back (no poison-pill CR persisted). The `:submitted` request-body path had the same latent exposure.

## Fix (Joe's call among 3 options: ETF blob)

- Store the op payload as an Erlang External Term Format binary (`:erlang.term_to_binary/1`) bound as an Exqlite `{:blob, _}`, replacing `:json.encode/1`. ETF round-trips any term, so a binary body persists byte-exact.
- `decode_payload/1` disambiguates by first byte (ETF version tag `131` vs JSON `{` = `123`), so rows written **before** the upgrade still decode via the JSON branch during the 30-day journal retention overlap.
- A `stringify/1` normalizer coerces the `binary_to_term` result (atom keys) into the exact string-keyed shape `:json.decode/1` yielded, so every reader (`load_request`, `read_from` replay) is unchanged.
- Also wrap the `results.body` bind as `{:blob, _}` (was a plain binary bound as TEXT) so the projected result row stores a PNG byte-exact too.

## Cost accepted

`ops.payload_json` no longer holds JSON, so SQL JSON-function queryability of op payloads is lost. Verified nothing queries it that way (only plain `SELECT payload_json`), and payloads are this node's own trusted data (so `binary_to_term/1` on read is safe).

## Tests

ExUnit (`op_log/sqlite_test.exs`): a binary result body round-trips (append -> `read_from` + `load_result`, survives reopen), a binary request body via `load_request`, and a legacy JSON row still decodes to string keys (upgrade compatibility).

Decision recorded in `DECISIONS.md` (D-R1.2.1). Chart bumped `0.1.34 -> 0.1.35`.

## Follow-up

Once live, re-run the og-image Task 12 acceptance (register -> `GET /functions/og-image` returns a valid PNG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)