### PR TITLE
feat(monolith): public-tier faas invocation for public functions (R1 Task 13)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -376,23 +376,26 @@ Task 14b does semgrep + the fc-invoke concurrency rebalance + finding-equality.
 
 ## R1 Phase 2: public tier (Task 13)
 
-### D-R1.3.1 Public FaaS rate-limit is an EmberVM per-principal quota, not a Cloudflare-edge rule
+### D-R1.3.1 Public FaaS rate-limit = Envoy gateway rate-limit + EmberVM quota (defense in depth)
 - **Spec said (Task 13):** "Rate limiting at the Cloudflare edge for `/functions/*`
   (per ADR 045 risk table)."
-- **Did instead:** the repo's `cloudflare-gateway` is Envoy Gateway + a cloudflared
-  tunnel (ingress routing), NOT the Cloudflare WAF/rate-limit product, so a CF-edge
-  per-IP rule is not expressible in-repo (it is a dashboard/API action). Instead the
-  backstop is an EmberVM per-principal DAILY vCPU-second quota: all public
-  `jomcgi.dev/functions/<name>` traffic submits as the single `monolith-public`
-  ServiceAccount, so one budget (`3600` vCPU-s/day, ~72k og-image invokes) caps the
-  entire public surface, and the function pool cap (4 concurrent VMs) bounds burst.
-  Set in `embervm/deploy/values.yaml` `quota.dailyVcpuSecondsPerPrincipal`.
-- **Why acceptable:** this is a homelab; the quota + pool cap give real backpressure
-  against runaway abuse without a CF WAF plan. A true per-IP/per-second edge rule (or
-  an Envoy `BackendTrafficPolicy` local rate limit scoped to `/functions/*`) is the
-  recorded follow-up if public abuse actually appears.
-- **FLAG FOR JOE:** if you want a hard per-IP edge limit now, it needs a Cloudflare
-  dashboard rule (out of repo) or an Envoy BackendTrafficPolicy PR.
+- **Clarification found mid-implementation:** the repo's `cloudflare-gateway` is Envoy
+  Gateway + a cloudflared tunnel, NOT the Cloudflare WAF product, so a CF-*WAF* per-IP
+  rule is a dashboard action (out of repo). BUT the Envoy gateway IS the public
+  origin's edge and DOES support in-repo rate limiting via the `cf-ingress.rate-limit`
+  BackendTrafficPolicy helper (already used for the `-public` frontend route at
+  100/min).
+- **Did:** TWO layers. (1) A dedicated `/functions/` HTTPRoute (mirroring `/img`)
+  carries its own `cf-ingress.rate-limit` BackendTrafficPolicy at 120/min
+  (`cfIngress.public.functionsRateLimit`), an Envoy Local limit at the gateway edge.
+  (2) An EmberVM per-principal DAILY vCPU-second quota (`3600`/day, ~72k og-image
+  invokes) on the single `monolith-public` SA that all public traffic submits as,
+  plus the function pool cap (4 concurrent VMs). The gateway limit is the coarse burst
+  cap; the quota is the daily abuse cap; the pool cap bounds concurrency.
+- **Caveat:** the Envoy Local limit is per-gateway and shared across clients (not
+  per-IP), matching the existing frontend limit; a true per-IP rule would need a CF
+  dashboard rule or a client-selector on the policy. Acceptable for a homelab
+  low-volume OG-image surface. **FLAG FOR JOE:** say if you want per-IP granularity.
 
 ### D-R1.3.2 Public tier calls EmberVM directly (not a proxy to the private tier)
 - monolith-public mounts `register_public` -> `invoke_router_public`, which resolves

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -373,3 +373,39 @@ Task 14b does semgrep + the fc-invoke concurrency rebalance + finding-equality.
   `load_result`, survives reopen), a binary request body via `load_request`, and a
   legacy JSON row still decoding to string keys (upgrade compatibility).
 - **Approved:** yes (Joe picked the ETF-blob option; flagged here for post-impl review).
+
+## R1 Phase 2: public tier (Task 13)
+
+### D-R1.3.1 Public FaaS rate-limit is an EmberVM per-principal quota, not a Cloudflare-edge rule
+- **Spec said (Task 13):** "Rate limiting at the Cloudflare edge for `/functions/*`
+  (per ADR 045 risk table)."
+- **Did instead:** the repo's `cloudflare-gateway` is Envoy Gateway + a cloudflared
+  tunnel (ingress routing), NOT the Cloudflare WAF/rate-limit product, so a CF-edge
+  per-IP rule is not expressible in-repo (it is a dashboard/API action). Instead the
+  backstop is an EmberVM per-principal DAILY vCPU-second quota: all public
+  `jomcgi.dev/functions/<name>` traffic submits as the single `monolith-public`
+  ServiceAccount, so one budget (`3600` vCPU-s/day, ~72k og-image invokes) caps the
+  entire public surface, and the function pool cap (4 concurrent VMs) bounds burst.
+  Set in `embervm/deploy/values.yaml` `quota.dailyVcpuSecondsPerPrincipal`.
+- **Why acceptable:** this is a homelab; the quota + pool cap give real backpressure
+  against runaway abuse without a CF WAF plan. A true per-IP/per-second edge rule (or
+  an Envoy `BackendTrafficPolicy` local rate limit scoped to `/functions/*`) is the
+  recorded follow-up if public abuse actually appears.
+- **FLAG FOR JOE:** if you want a hard per-IP edge limit now, it needs a Cloudflare
+  dashboard rule (out of repo) or an Envoy BackendTrafficPolicy PR.
+
+### D-R1.3.2 Public tier calls EmberVM directly (not a proxy to the private tier)
+- monolith-public mounts `register_public` -> `invoke_router_public`, which resolves
+  `get_public_function` (smoke-passed AND `visibility=public`) and calls EmberVM
+  directly, exactly like the private router but with the stricter lookup. This needs:
+  (a) the `monolith-public` SA added to EmberVM's `allowedServiceAccounts`; (b)
+  `EMBERVM_URL` on the public pods (via the chart's `semgrep.embervmUrl` knob); (c) a
+  `public_reader` GRANT on `faas.function` (the row-level `visibility=public` filter
+  in the query is the security boundary, not the grant); (d) faas added to the public
+  image glob with `router.py`/`storage.py`/`workload.py`/`functions/**` pruned so the
+  ingestion/write path stays out of the public binary (`main_public_imports_test`
+  enforces it). Chosen over a public->private proxy because a proxy would still need
+  the visibility filter AND the grant on the public side (a private function must not
+  leak), plus an extra hop; direct is fewer moving parts and matches the private tier.
+- **Approved:** proceeding under the "/loop, move fast, not in active use" latitude;
+  flagged here for post-impl review.

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -33,6 +33,12 @@ auth:
     # monolith already uses to call fc-invoke. Added now so the dual-path code is
     # ready to authenticate the moment the flag flips; no traffic until then.
     - system:serviceaccount:monolith:monolith
+    # The PUBLIC tier (Task 13): monolith-public runs in its own namespace as its
+    # own fullname-prefixed SA, so jomcgi.dev/functions/<name> submits as this
+    # principal. All public FaaS traffic shares this one SA, so the daily quota
+    # below caps the entire public surface (the in-repo backpressure backstop in
+    # lieu of a Cloudflare-edge rate limit; see monolith DECISIONS.md D-R1.3.1).
+    - system:serviceaccount:monolith-public:monolith-public
 
 # Metering, audit, and quotas (Task 12). Quota is left OFF in R0 (opt-in, empty =
 # no enforcement): per-principal daily vCPU-second budgets are set alongside the
@@ -42,6 +48,17 @@ auth:
 # usage at GET /v1/usage?principal=; everyone else is self-scoped.
 usageAdmins:
   - system:serviceaccount:embervm:embervm-embervm
+
+# Public FaaS rate-limit backstop (Task 13, DECISIONS.md D-R1.3.1). All public
+# jomcgi.dev/functions/<name> traffic submits as the single monolith-public SA,
+# so a daily vCPU-second budget on that one principal caps the whole public
+# surface. og-image bills ~0.05 vCPU-s/invoke, so 3600/day is ~72k invokes/day;
+# the function pool cap (4 concurrent VMs) bounds burst. The private monolith SA
+# stays unlimited (omitted from the map). Raise/lower this as real public traffic
+# warrants; a burst-per-second edge rule is the follow-up if abuse appears.
+quota:
+  dailyVcpuSecondsPerPrincipal:
+    "system:serviceaccount:monolith-public:monolith-public": 3600
 
 # OpenTelemetry tracing to SigNoz (Task 13), OTLP/gRPC on 4317 (the same
 # collector fc-invoke exports to). Turns on the exporter via config/runtime.exs.

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.122
+version: 0.89.123
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/templates/httproute-public.yaml
+++ b/projects/monolith-public/chart/templates/httproute-public.yaml
@@ -84,9 +84,47 @@ spec:
       timeouts:
         request: 60s
 ---
+# /functions/ -> the public FaaS invocation backend (Task 13, ADR agents/045).
+# A backend-served API surface (like /img -> imgproxy), NOT a SvelteKit page:
+# external OG-image scrapers fetch jomcgi.dev/functions/og-image directly, so it
+# routes straight to the -web backend on its OWN HTTPRoute rather than through the
+# frontend SSR. The backend mounts ONLY the public invocation router here (no
+# /api/functions ingestion), and it resolves only visibility=public functions
+# (get_public_function), so a private function 404s. Its own route (separate from
+# the page route) carries a dedicated rate-limit below.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "monolith-public.fullname" . }}-functions
+  labels:
+    ingress-tier: {{ .Values.cfIngress.public.tier }}
+    {{- include "monolith-public.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ .Values.cfIngress.public.gateway.name }}
+      namespace: {{ .Values.cfIngress.public.gateway.namespace }}
+  hostnames:
+    - {{ .Values.cfIngress.public.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /functions/
+      backendRefs:
+        - name: {{ include "monolith-public.fullname" . }}-web
+          port: {{ .Values.web.service.port | int }}
+      timeouts:
+        request: 60s
+---
 {{- $rlParams := dict
   "name" (printf "%s-public" (include "monolith-public.fullname" .))
   "rateLimit" .Values.cfIngress.public.rateLimit
 }}
 {{- include "cf-ingress.rate-limit" $rlParams }}
+---
+{{- $fnRlParams := dict
+  "name" (printf "%s-functions" (include "monolith-public.fullname" .))
+  "rateLimit" .Values.cfIngress.public.functionsRateLimit
+}}
+{{- include "cf-ingress.rate-limit" $fnRlParams }}
 {{- end }}

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -595,6 +595,14 @@ cfIngress:
     rateLimit:
       requests: 100
       unit: Minute
+    # Rate limit for the public FaaS invocation route (/functions/*, Task 13).
+    # Envoy Local (per-gateway, shared across clients) coarse burst cap, layered
+    # ON TOP of the EmberVM per-principal daily quota (the real abuse backstop;
+    # DECISIONS.md D-R1.3.1). og-image is low-volume (one fetch per social share),
+    # so 120/min is generous; lower it if abuse appears.
+    functionsRateLimit:
+      requests: 120
+      unit: Minute
 
 # CiliumNetworkPolicy gates (ADR platform/012). templates/cilium-policy.yaml is
 # the Cilium translation of the Linkerd policy chain; both gates default off so

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.122
+      targetRevision: 0.89.123
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/values.yaml
+++ b/projects/monolith-public/deploy/values.yaml
@@ -41,6 +41,15 @@ imgproxy:
   extraHostnames:
     - private.jomcgi.dev
 
+# EmberVM URL for the public FaaS invocation router (Task 13). The public tier
+# runs no semgrep, but the chart derives the EMBERVM_URL env from
+# `semgrep.embervmUrl` (the single knob), so the /functions/<name> public router
+# reaches the EmberVM control plane at the same in-cluster address the private
+# tier uses. In-cluster egress is allowed by the Cilium policy below, and the
+# public tier submits as its own SA (allow-listed in embervm/deploy/values.yaml).
+semgrep:
+  embervmUrl: "http://embervm-embervm.embervm.svc.cluster.local:8080"
+
 # Phase 5e cutover: serve the public hostname from this isolated service.
 cfIngress:
   public:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -483,6 +483,17 @@ _PUBLIC_PRUNE_EXCLUDE = [
     # public binary; the read path (public/router_public/library/models/
     # visibility plus the extract/ingest helpers it calls) ships.
     "grimoire/jobs.py",
+    # FaaS: only the public invocation path ships. The ingestion API (router.py)
+    # is the authenticated private-tier author surface (no /api on public); the
+    # write path (storage.py = S3, workload.py = K8s CR CRUD) is private-only; the
+    # guest function code (functions/**, e.g. og_image/app.py) runs inside the
+    # microVM, never in the monolith. register_public imports only
+    # invoke_router_public -> invoke_router -> repository/embervm_client/models,
+    # none of which pull the pruned files (main_public_imports_test enforces it).
+    "faas/router.py",
+    "faas/storage.py",
+    "faas/workload.py",
+    "faas/functions/**/*.py",
 ]
 
 py_library(
@@ -510,6 +521,13 @@ py_library(
             # (main_public_imports_test enforces this).
             "grimoire/**/*.py",
             "grimoire_chat/**/*.py",
+            # FaaS public invocation tier: only the invoke path ships (Task 13).
+            # register_public mounts invoke_router_public, which pulls
+            # invoke_router (shared relay) + repository + embervm_client + models.
+            # The ingestion API (router.py) and the write path (storage.py,
+            # workload.py) plus the guest function code (functions/**) are pruned
+            # below; main_public_imports_test enforces they stay out of the closure.
+            "faas/**/*.py",
         ],
         exclude = _PUBLIC_PRUNE_EXCLUDE,
     ),  # keep
@@ -570,6 +588,13 @@ py_venv_binary(
             "campsites/**/*.py",
             "grimoire/**/*.py",
             "grimoire_chat/**/*.py",
+            # FaaS public invocation tier: only the invoke path ships (Task 13).
+            # register_public mounts invoke_router_public, which pulls
+            # invoke_router (shared relay) + repository + embervm_client + models.
+            # The ingestion API (router.py) and the write path (storage.py,
+            # workload.py) plus the guest function code (functions/**) are pruned
+            # below; main_public_imports_test enforces they stay out of the closure.
+            "faas/**/*.py",
         ],
         exclude = _PUBLIC_PRUNE_EXCLUDE,
     ),  # keep
@@ -3555,6 +3580,19 @@ py_test(
 py_test(
     name = "faas_invoke_router_test",
     srcs = ["faas/invoke_router_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "faas_invoke_router_public_test",
+    srcs = ["faas/invoke_router_public_test.py"],
     imports = ["."],
     deps = [
         ":monolith_backend",

--- a/projects/monolith/app/main_public_routes_test.py
+++ b/projects/monolith/app/main_public_routes_test.py
@@ -89,6 +89,18 @@ def test_each_public_domain_has_a_route():
         )
 
 
+def test_public_faas_invocation_mounted():
+    # The public FaaS product surface (Task 13) must be mounted, and only the
+    # invocation router (no /api/functions ingestion on the public tier).
+    paths = _paths()
+    assert any(p.startswith("/functions") for p in paths), (
+        "expected the public /functions/<name> invocation router to be mounted"
+    )
+    assert not any(p.startswith("/api/functions") for p in paths), (
+        "the ingestion API (/api/functions) must NOT be mounted on the public tier"
+    )
+
+
 def test_healthz_present():
     assert "/healthz" in _paths()
 
@@ -133,6 +145,13 @@ ALLOWED_PREFIXES = (
     # kept off the public HTTPRoute (the frontend is the sole public origin). The
     # write router is NOT mounted here (the public tier stays read-only).
     "/internal/artifact",
+    # Public FaaS invocation surface (Task 13): jomcgi.dev/functions/<name> for
+    # visibility=public functions only. This is the ONE public route that is not
+    # under /api (it is the product URL, per ADR agents/045); the ingestion API
+    # (/api/functions) is deliberately NOT mounted on the public tier (register vs
+    # register_public). The router filters visibility=public, so a private
+    # function 404s here (faas/invoke_router_public_test.py asserts it).
+    "/functions",
     "/healthz",
     # Deep health probe (DB reachable + public_reader can query). Reached via the
     # frontend /health same-origin proxy; not a private surface.

--- a/projects/monolith/app/modules_public.py
+++ b/projects/monolith/app/modules_public.py
@@ -14,6 +14,7 @@ import artifact.module
 import campsites.module
 import chat_public.module
 import dr_jobs.module
+import faas.module
 import grimoire.module
 import grimoire_chat.module
 import hikes.module
@@ -39,4 +40,5 @@ PUBLIC_MODULES: tuple[Module, ...] = (
     artifact.module.MODULE,
     grimoire.module.MODULE,
     grimoire_chat.module.MODULE,
+    faas.module.MODULE,
 )

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.200
+version: 0.285.201
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260715000000_faas_public_reader_grant.sql
+++ b/projects/monolith/chart/migrations/20260715000000_faas_public_reader_grant.sql
@@ -1,0 +1,21 @@
+-- Grant public_reader read access to faas.function so the PUBLIC tier
+-- (monolith-public) can resolve public functions for jomcgi.dev/functions/<name>
+-- (R1 Task 13, ADR agents/045). The faas schema shipped
+-- (20260714000000_faas_function.sql) without a public grant because R1 started
+-- private-only; the public invocation router now reads the registry as
+-- public_reader, so without this grant every public /functions/<name> request
+-- would 500 with "permission denied for schema faas" and the router would turn
+-- that into a 502/404. See docs/runbooks/public-tier-checklist.md item 1.
+--
+-- SECURITY: the grant is table-wide (public_reader can SELECT every row), but the
+-- public invocation router filters to visibility='public' AND last_smoke_at IS
+-- NOT NULL in the query (faas.repository.get_public_function), so a private or
+-- un-smoked function is never resolvable on the public origin. The grant is
+-- necessary but not sufficient; the row-level filter is the security boundary
+-- (checklist item 4). ALTER DEFAULT PRIVILEGES covers a future table this schema
+-- adds so the grant does not silently rot (mirrors the trips grant).
+
+GRANT USAGE ON SCHEMA faas TO public_reader;
+GRANT SELECT ON ALL TABLES IN SCHEMA faas TO public_reader;
+ALTER DEFAULT PRIVILEGES IN SCHEMA faas
+    GRANT SELECT ON TABLES TO public_reader;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:lNsTIK8WDa9PkC+E2clkJ5AapKGvoJYCf6EqSCDxKR0=
+h1:AWwoioFk8FYkZN05TfsyUGAIpaD7UlHDs7N+u60VopM=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -130,3 +130,4 @@ h1:lNsTIK8WDa9PkC+E2clkJ5AapKGvoJYCf6EqSCDxKR0=
 20260712233000_semgrep_perf_cohort.sql h1:v8wnTdvoa85AVnyJG1BxEUDY74OBIG4IcuICmDBOjJw=
 20260713000000_dr_jobs_notified_columns.sql h1:xzxvvjmCXQ164L4yIrfzCOPTr8qg5EWDk7FPcS2vtH4=
 20260714000000_faas_function.sql h1:ZKy8KILFm2YrCSl+a5VelvQbuZXOIq+tdWEafCFh2qk=
+20260715000000_faas_public_reader_grant.sql h1:aWN3QjqYyVlTgShG2/0goPL/CG0r9v9KhrZO0U7EG0Y=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.200
+      targetRevision: 0.285.201
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/faas/__init__.py
+++ b/projects/monolith/faas/__init__.py
@@ -21,3 +21,19 @@ def register(app: FastAPI) -> None:
 
     app.include_router(router)
     app.include_router(invoke_router)
+
+
+def register_public(app: FastAPI) -> None:
+    """Mount ONLY the public-tier invocation router (Task 13).
+
+    The public origin serves ``/functions/<name>`` for ``visibility=public``
+    functions only (``invoke_router_public``). It deliberately does NOT mount the
+    ingestion API (``/api/functions``): registration is the authenticated
+    private-tier author surface (standing decision 7), and the public tier has no
+    ``/api`` ingress at all (public-tier checklist item 2). This closure must not
+    import ``faas.router``/``faas.storage``/``faas.workload`` (the private write
+    path); ``main_public_imports_test`` enforces that.
+    """
+    from faas.invoke_router_public import router as invoke_public_router
+
+    app.include_router(invoke_public_router)

--- a/projects/monolith/faas/functions/og_image/register.py
+++ b/projects/monolith/faas/functions/og_image/register.py
@@ -42,10 +42,11 @@ FUNCTION_NAME = "og-image"
 RUNTIME = "python312"
 HANDLER = "app.handle"
 REQUIREMENTS = "PIL"
-# Registered private in this PR; Task 13 (public tier) flips it to public. A
+# PUBLIC as of Task 13: og-image is served at jomcgi.dev/functions/og-image. A
 # visibility change is intentionally NOT an idempotent no-op (the server's
-# short-circuit compares visibility), so that re-register re-smokes and re-gates.
-VISIBILITY = "private"
+# short-circuit compares visibility), so re-registering a currently-private
+# og-image with this manifest re-smokes and re-gates it as public.
+VISIBILITY = "public"
 
 _APP_PY = Path(__file__).with_name("app.py")
 

--- a/projects/monolith/faas/invoke_router.py
+++ b/projects/monolith/faas/invoke_router.py
@@ -88,7 +88,19 @@ async def invoke_function(
     fn = get_visible_function(session, name)
     if fn is None:
         return _json(404, {"error": "function not found"})
+    return await relay_to_function(name, request, subpath)
 
+
+async def relay_to_function(name: str, request: Request, subpath: str) -> Response:
+    """Marshal ``request`` into an EmberVM sync submit for ``name`` and relay back.
+
+    Split out of ``invoke_function`` so the public-tier router
+    (``invoke_router_public``) reuses the identical marshaling and response
+    mapping and cannot drift from the private path. The caller is responsible for
+    the visibility lookup BEFORE calling this (the private router admits any
+    smoke-passed function; the public router admits only ``visibility=public``),
+    so this function assumes the function is already authorized to serve.
+    """
     body = await request.body()
     raw_query = request.url.query
     guest_path = INVOKE_PATH + (f"?{raw_query}" if raw_query else "")

--- a/projects/monolith/faas/invoke_router_public.py
+++ b/projects/monolith/faas/invoke_router_public.py
@@ -15,10 +15,10 @@ Security posture (ADR agents/045; public-tier checklist):
 - Public callers invoke pre-vetted functions only; there is deliberately NO
   ``/api/functions`` ingestion surface on the public tier (registration is the
   authenticated private-tier author surface, standing decision 7).
-- Public traffic submits to EmberVM as the single ``monolith-public`` service
-  account, so EmberVM's per-principal daily quota caps the entire public surface,
-  and the function pool cap bounds concurrency (the backpressure backstop in lieu
-  of an in-repo Cloudflare-edge rate limit; see DECISIONS.md D-R1.3.1).
+- Public traffic is rate-limited at two layers (DECISIONS.md D-R1.3.1): a gateway
+  Envoy Local limit on the ``/functions/`` HTTPRoute (120/min), plus EmberVM's
+  per-principal daily quota on the single ``monolith-public`` service account all
+  public traffic submits as, with the function pool cap bounding concurrency.
 """
 
 from __future__ import annotations

--- a/projects/monolith/faas/invoke_router_public.py
+++ b/projects/monolith/faas/invoke_router_public.py
@@ -1,0 +1,57 @@
+"""Public-tier FaaS invocation router: ``jomcgi.dev/functions/<name>`` (Task 13).
+
+The public counterpart of ``invoke_router.py``. It is mounted ONLY on the public
+tier (monolith-public) via ``register_public``, and differs from the private
+router in exactly one way: the lookup is ``get_public_function`` (smoke-passed AND
+``visibility=public``), so a private (or un-smoked) function 404s on the public
+origin and is never invokable there. The marshaling, EmberVM submit, and response
+relay are shared with the private router via ``relay_to_function`` so the two
+cannot drift.
+
+Security posture (ADR agents/045; public-tier checklist):
+- Only ``visibility=public`` functions are reachable here (the row-level filter is
+  in ``get_public_function``; the ``public_reader`` grant is table-wide, so the
+  filter is load-bearing, not the grant).
+- Public callers invoke pre-vetted functions only; there is deliberately NO
+  ``/api/functions`` ingestion surface on the public tier (registration is the
+  authenticated private-tier author surface, standing decision 7).
+- Public traffic submits to EmberVM as the single ``monolith-public`` service
+  account, so EmberVM's per-principal daily quota caps the entire public surface,
+  and the function pool cap bounds concurrency (the backpressure backstop in lieu
+  of an in-repo Cloudflare-edge rate limit; see DECISIONS.md D-R1.3.1).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Request, Response
+from sqlmodel import Session
+
+from app.db import get_session
+from faas.invoke_router import _INVOKE_METHODS, _json, relay_to_function
+from faas.repository import get_public_function
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["faas-invoke-public"])
+
+
+@router.api_route("/functions/{name}", methods=_INVOKE_METHODS)
+@router.api_route("/functions/{name}/{subpath:path}", methods=_INVOKE_METHODS)
+async def invoke_public_function(
+    name: str,
+    request: Request,
+    subpath: str = "",
+    session: Session = Depends(get_session),
+) -> Response:
+    """Serve a public function, or 404 for an unknown/private/un-smoked name.
+
+    The 404 is deliberately indistinguishable across "no such function", "private
+    function", and "not yet smoke-passed": the public origin must not leak the
+    existence of a private or un-vetted function.
+    """
+    fn = get_public_function(session, name)
+    if fn is None:
+        return _json(404, {"error": "function not found"})
+    return await relay_to_function(name, request, subpath)

--- a/projects/monolith/faas/invoke_router_public_test.py
+++ b/projects/monolith/faas/invoke_router_public_test.py
@@ -1,0 +1,139 @@
+"""Tests for the PUBLIC faas invocation router (Task 13).
+
+The public router (``invoke_router_public``) differs from the private one in
+exactly one way: it resolves via ``get_public_function`` (smoke-passed AND
+``visibility=public``). The load-bearing property under test is the SECURITY one:
+a private function, even a smoke-passed one, must 404 on the public origin and
+never reach EmberVM. The marshaling/relay is shared with the private router
+(``relay_to_function``) and covered by ``invoke_router_test.py``; here we only
+assert the visibility gate and that a public function still serves.
+
+``embervm_client.submit`` is patched on ``faas.invoke_router`` (where
+``relay_to_function`` lives, so the public router's relay goes through it) to a
+synthetic response. A fresh FastAPI app mounts only the public router, mirroring
+what ``register_public`` does on the public tier.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from datetime import datetime, timezone
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+
+from faas.models import Function
+
+
+@pytest.fixture
+def session():
+    from sqlmodel.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as s:
+            yield s
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def _add_function(
+    session: Session, name: str, *, visibility: str, smoked: bool
+) -> None:
+    now = datetime.now(timezone.utc)
+    session.add(
+        Function(
+            name=name,
+            visibility=visibility,
+            runtime="python312",
+            handler="app.handle",
+            zip_sha256="deadbeef",
+            code_uri=f"http://s3/faas/{name}/deadbeef.zip",
+            created_by="api",
+            created_at=now,
+            updated_at=now,
+            last_smoke_at=now if smoked else None,
+        )
+    )
+    session.commit()
+
+
+@pytest.fixture
+def submitted(monkeypatch):
+    """Patch ``submit`` on faas.invoke_router (where relay_to_function lives)."""
+    from faas import invoke_router as mod
+
+    state: dict = {
+        "calls": [],
+        "response": httpx.Response(
+            200, headers={"content-type": "image/png"}, content=b"\x89PNG..."
+        ),
+    }
+
+    async def _submit(name, *, body, guest_path, extra_guest_headers, read_timeout):
+        state["calls"].append({"name": name, "guest_path": guest_path})
+        return state["response"]
+
+    monkeypatch.setattr(mod.embervm_client, "submit", _submit)
+    return state
+
+
+@pytest.fixture
+def client(session):
+    from app.db import get_session
+    from faas.invoke_router_public import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_session] = lambda: session
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_public_function_serves(client, session, submitted):
+    _add_function(session, "og-image", visibility="public", smoked=True)
+    resp = client.get("/functions/og-image?title=hi")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "image/png"
+    assert submitted["calls"][0]["name"] == "og-image"
+    assert submitted["calls"][0]["guest_path"] == "/invoke?title=hi"
+
+
+def test_private_function_is_404_on_public_and_never_submits(
+    client, session, submitted
+):
+    # SECURITY: a smoke-passed PRIVATE function must not be invokable publicly.
+    _add_function(session, "secret", visibility="private", smoked=True)
+    resp = client.get("/functions/secret")
+    assert resp.status_code == 404
+    assert resp.json() == {"error": "function not found"}
+    assert submitted["calls"] == []  # never reached EmberVM
+
+
+def test_unsmoked_public_function_is_404(client, session, submitted):
+    # A public function that has not passed its smoke gate is not yet visible.
+    _add_function(session, "pending", visibility="public", smoked=False)
+    resp = client.get("/functions/pending")
+    assert resp.status_code == 404
+    assert submitted["calls"] == []
+
+
+def test_unknown_function_is_404(client, session, submitted):
+    resp = client.get("/functions/nope")
+    assert resp.status_code == 404
+    assert submitted["calls"] == []

--- a/projects/monolith/faas/module.py
+++ b/projects/monolith/faas/module.py
@@ -1,9 +1,11 @@
 """FastMonolith module export for the faas domain (see framework/core.py).
 
-Private-only in R1: no ``register_public`` (the ingestion API is an
-authenticated author surface; public invocation is a later PR, Task 13). Lives
-in its own file (not __init__.py) so importing the domain package does not pull
-the framework or FastAPI.
+The private tier mounts the full surface (``register``: the ingestion API +
+private invocation router). The public tier mounts ONLY the public invocation
+router (``register_public``: ``/functions/<name>`` for ``visibility=public``),
+never the ``/api/functions`` ingestion surface (Task 13, standing decision 7).
+Lives in its own file (not __init__.py) so importing the domain package does not
+pull the framework or FastAPI.
 """
 
 import faas as _domain
@@ -14,4 +16,5 @@ from framework import Module as _Module
 MODULE = _Module(
     name="faas",
     register=_domain.register,
+    register_public=_domain.register_public,
 )

--- a/projects/monolith/faas/repository.py
+++ b/projects/monolith/faas/repository.py
@@ -93,6 +93,25 @@ def get_visible_function(session: Session, name: str) -> Function | None:
     return function
 
 
+def get_public_function(session: Session, name: str) -> Function | None:
+    """Return the function row only if it is smoke-passed AND visibility=public.
+
+    The public-tier invocation router (Task 13) filters on BOTH conditions in the
+    query: a private function (or an un-smoked one) is invisible on the public
+    origin and 404s, so the public tier can never invoke a private function even
+    though ``public_reader`` can SELECT the whole ``faas.function`` table (the
+    grant is table-wide; the row-level filter is here). See the public-tier
+    checklist item 4 (grant is necessary but not sufficient; the query must
+    filter).
+    """
+    function = session.get(Function, name)
+    if function is None or function.last_smoke_at is None:
+        return None
+    if function.visibility != "public":
+        return None
+    return function
+
+
 def list_functions(session: Session, *, visible_only: bool = False) -> list[Function]:
     """List all functions, optionally filtered to smoke-passed (visible) ones."""
     stmt = select(Function)


### PR DESCRIPTION
## What

Serve `jomcgi.dev/functions/<name>` for `visibility=public` functions, and flip **og-image** public. Task 13 of the EmberVM R1 plan. The public tier calls EmberVM directly with a stricter lookup; registration stays private-only (no `/api` on the public origin).

## Public-tier checklist (docs/runbooks/public-tier-checklist.md)

1. **public_reader grant** — migration `20260715000000_faas_public_reader_grant.sql` grants SELECT on `faas.function`. ✅
2. **No `/api` on public** — `register_public` mounts only the invocation router, never `/api/functions`. ✅
3. **gazelle-exclude vs public binary** — faas added to the public glob with `router.py`/`storage.py`/`workload.py`/`functions/**` pruned; `main_public_imports_test` enforces the closure. ✅
4. **visibility filtering** — `get_public_function` filters `visibility=public AND last_smoke_at IS NOT NULL` in the query, so the table-wide grant never leaks a private/un-smoked function (test asserts a private function 404s and never submits). ✅
5. **Both chart bumps** — monolith `0.285.201` + monolith-public `0.89.123`. ✅

## Changes

- `faas/invoke_router.py`: extract `relay_to_function` (shared marshal/submit/relay) so the public router can't drift from the private one.
- `faas/invoke_router_public.py` (new): public router via `get_public_function`, mounted only by `register_public`.
- `faas/repository.py`: `get_public_function`. `module.py`/`__init__.py`: `register_public`. `app/modules_public.py`: faas in `PUBLIC_MODULES`.
- Infra: monolith-public `EMBERVM_URL` (via `semgrep.embervmUrl`; in-cluster egress allowed by Cilium); `monolith-public` SA added to EmberVM `allowedServiceAccounts` + a **daily vCPU-second quota** as the public rate-limit backstop.
- `og_image/register.py`: `VISIBILITY=public`.

## Decisions (flagged for review — DECISIONS.md)

- **D-R1.3.1**: the repo's `cloudflare-gateway` is Envoy + cloudflared (not the CF WAF), so a CF-edge per-IP rate limit isn't in-repo. Backstop is an EmberVM per-principal daily quota (all public traffic = one `monolith-public` SA) + the pool cap. A true per-IP edge rule is a follow-up if abuse appears. **If you want a hard edge limit now, say so.**
- **D-R1.3.2**: public tier calls EmberVM directly (not a proxy to private), because a proxy would still need the visibility filter + grant on the public side plus an extra hop.

## Post-deploy verification (Task 13 acceptance)

After rollout + re-registering og-image public: `curl https://jomcgi.dev/functions/og-image?title=...` returns a 200 PNG; a private function 404s on the public origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)