### PR TITLE
fix(monolith-public): allow gateway->backend for /functions (unblocks public og-image)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.123
+version: 0.89.124
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/templates/cilium-policy.yaml
+++ b/projects/monolith-public/chart/templates/cilium-policy.yaml
@@ -63,9 +63,13 @@ spec:
 {{- end }}
 {{- if .Values.web.enabled }}
 ---
-# The backend ("web") is reachable ONLY by the frontend SSR pod (in-cluster,
-# via API_BASE / CHAT_API_BASE). The gateway never reaches the backend directly
-# (there is no /api ingress rule). Replaces the allow-web-clients
+# The backend ("web") is reachable by the frontend SSR pod (in-cluster, via
+# API_BASE / CHAT_API_BASE) AND, for the public FaaS invocation surface only, by
+# the Cloudflare/Envoy gateway (R1 Task 13). The gateway only ROUTES /functions/*
+# to the backend (its own dedicated HTTPRoute; every other path goes to the
+# frontend), and the backend mounts only public read-only routes
+# (main_public_routes_test enforces it), so this L4 allow exposes nothing beyond
+# the pre-vetted public functions. Replaces the allow-web-clients
 # AuthorizationPolicy + the web-clients MeshTLSAuthentication (the frontend's
 # own mesh identity).
 apiVersion: cilium.io/v2
@@ -84,6 +88,16 @@ spec:
         - matchLabels:
             {{- include "monolith-public.selectorLabels" . | nindent 12 }}
             app.kubernetes.io/component: frontend
+      toPorts:
+        - ports:
+            - port: {{ .Values.web.containerPort | quote }}
+              protocol: TCP
+    # The Envoy gateway reaches the backend directly for /functions/<name> only
+    # (Task 13): its HTTPRoute routes just that path prefix here, so no /api
+    # traffic arrives from the gateway. Mirrors the frontend-ingress gateway rule.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
       toPorts:
         - ports:
             - port: {{ .Values.web.containerPort | quote }}

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.123
+      targetRevision: 0.89.124
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
Live test of `jomcgi.dev/functions/og-image` returned 503 (Envoy upstream connect timeout): the `web-ingress` CiliumNetworkPolicy admits only the frontend pod, so the gateway could not reach `monolith-public-web` for the new `/functions/*` HTTPRoute. Adds an `envoy-gateway-system -> web` L4 allow (mirrors the frontend-ingress gateway rule). Safe: the gateway routes only `/functions/*` to the backend, which serves only public routes. Bump 0.89.123 -> 0.89.124. Verified via helm template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)