### PR TITLE
fix(monolith-public): set EMBERVM_URL for public faas invocation (unblocks og-image 502)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.124
+version: 0.89.125
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -218,6 +218,16 @@ web:
         secretKeyRef:
           name: monolith-public-writer-db
           key: uri
+    # EmberVM control-plane URL for the public FaaS invocation router
+    # (jomcgi.dev/functions/<name>, R1 Task 13). In-cluster service URL literal
+    # (NOT a secret, NOT a code default); the public tier submits to EmberVM as
+    # its own allow-listed SA. In-cluster egress is permitted by the Cilium
+    # policy. embervm_client raises (-> 502) if this is unset, so it must be here
+    # explicitly: this chart uses the homelab-library deployment helper, which
+    # does NOT derive EMBERVM_URL from semgrep.embervmUrl the way the monolith
+    # chart does.
+    - name: EMBERVM_URL
+      value: "http://embervm-embervm.embervm.svc.cluster.local:8080"
     - name: CHAT_PUBLIC_CHAR_CAP
       value: "8000"
     - name: CHAT_PUBLIC_MAX_TURNS

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.124
+      targetRevision: 0.89.125
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/values.yaml
+++ b/projects/monolith-public/deploy/values.yaml
@@ -41,14 +41,10 @@ imgproxy:
   extraHostnames:
     - private.jomcgi.dev
 
-# EmberVM URL for the public FaaS invocation router (Task 13). The public tier
-# runs no semgrep, but the chart derives the EMBERVM_URL env from
-# `semgrep.embervmUrl` (the single knob), so the /functions/<name> public router
-# reaches the EmberVM control plane at the same in-cluster address the private
-# tier uses. In-cluster egress is allowed by the Cilium policy below, and the
-# public tier submits as its own SA (allow-listed in embervm/deploy/values.yaml).
-semgrep:
-  embervmUrl: "http://embervm-embervm.embervm.svc.cluster.local:8080"
+# NOTE: EMBERVM_URL for the public FaaS invocation router (Task 13) is set as an
+# explicit web-component env in the chart values (chart/values.yaml), NOT via a
+# semgrep.embervmUrl knob: this chart uses the homelab-library deployment helper,
+# which has no such derivation (that mapping exists only in the monolith chart).
 
 # Phase 5e cutover: serve the public hostname from this isolated service.
 cfIngress:


### PR DESCRIPTION
Live test of `jomcgi.dev/functions/og-image` returned 502: the public web pod had no `EMBERVM_URL`, so `embervm_client.submit` raised `EmberVMTransportError`. The monolith-public chart uses the homelab-library deployment helper, which does NOT derive `EMBERVM_URL` from `semgrep.embervmUrl` (that mapping is only in the monolith chart), so the earlier deploy-value was silently ignored. Set it as an explicit web-component env; drop the dead knob. Bump 0.89.124 -> 0.89.125. Verified via helm template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)