### PR TITLE
fix(monolith-public): mount SA token so public faas auths to EmberVM (401 fix)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -412,3 +412,23 @@ Task 14b does semgrep + the fc-invoke concurrency rebalance + finding-equality.
   leak), plus an extra hop; direct is fewer moving parts and matches the private tier.
 - **Approved:** proceeding under the "/loop, move fast, not in active use" latitude;
   flagged here for post-impl review.
+
+### D-R1.3.3 The public pod gets an identity-only SA token (was tokenless) for EmberVM auth
+- **Found live:** after routing + EMBERVM_URL were fixed, the public URL returned 401
+  `{"error":"missing bearer token"}`. The public tier deliberately runs tokenless
+  (`serviceAccount.automount: false`, a hardening choice: a public page needs no K8s
+  API), so `auth_headers()` had no token to send and EmberVM's TokenReview rejected an
+  anonymous submit.
+- **Did:** flipped `serviceAccount.automount: true` so the web pod mounts its SA
+  token. This is the FIRST public path that must authenticate to an in-cluster service
+  (EmberVM), and the token is IDENTITY-ONLY: the `monolith-public` SA has ZERO RBAC
+  (verified: no Role/ClusterRoleBindings), so the token grants no K8s API power. It
+  only proves "I am monolith-public" to EmberVM's allow-list, which is the exact
+  capability the `/functions` surface already exposes (quota-capped). So no new
+  attack surface: a leaked token can only do what the public URL already does.
+- **Caveat / follow-up:** `automount` is SA-scoped, so the frontend/imgproxy pods
+  (same SA, also no RBAC) now also mount the token though they do not use it. A
+  per-component audience-scoped **projected** serviceAccountToken volume on the web
+  pod only would be tighter. **FLAG FOR JOE:** say if you want the scoped-projected
+  hardening now; deferred as a follow-up given the no-RBAC blast radius.
+- **Approved:** proceeding under the "/loop, move fast" latitude; flagged for review.

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.125
+version: 0.89.126
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -1,6 +1,7 @@
 # Read-only public service (ADR 004 Phase 5). Isolation via
-# templates/cilium-policy.yaml (ADR platform/012), no K8s API access
-# (automountServiceAccountToken false), connects to
+# templates/cilium-policy.yaml (ADR platform/012). The SA token is mounted for
+# the FaaS invocation router to authenticate to EmberVM (identity-only; the SA
+# has no K8s RBAC, see serviceAccount below), and it connects to
 # monolith-pg-ro as public_reader. The image tag is pinned by the Bazel
 # helm_images_values pipeline at build time; do not set a digest here.
 #
@@ -36,8 +37,15 @@ securityContext:
 
 serviceAccount:
   create: true
-  # The public pod needs no Kubernetes API access, so do not mount a token.
-  automount: false
+  # Mount the SA token: the public FaaS invocation router (Task 13) authenticates
+  # to the in-cluster EmberVM control plane with this pod's SA token (EmberVM does
+  # a TokenReview against its allow-list). This is an IDENTITY-ONLY token: the
+  # monolith-public SA has ZERO Kubernetes RBAC (no Role/ClusterRoleBindings), so
+  # the token grants no K8s API power, it only proves "I am monolith-public" to
+  # EmberVM (which the /functions surface already trusts, quota-capped). A
+  # per-component audience-scoped projected token is a hardening follow-up
+  # (DECISIONS.md D-R1.3.3).
+  automount: true
   annotations: {}
   name: ""
 

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.125
+      targetRevision: 0.89.126
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
Live test returned 401 `{"error":"missing bearer token"}`: the public tier runs tokenless (`serviceAccount.automount: false`), so the invocation router had no SA token for EmberVM's TokenReview. Flip `automount: true`. IDENTITY-ONLY token: the `monolith-public` SA has zero RBAC (verified), so no K8s API power, only EmberVM allow-list identity (the exact capability /functions already exposes, quota-capped). Scoped projected token is a follow-up (D-R1.3.3). Bump 0.89.125 -> 0.89.126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)