### PR TITLE
feat(embervm): R2 PR-1 session contract layer (proto verbs, op-log schema, CRD class)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -432,3 +432,37 @@ Task 14b does semgrep + the fc-invoke concurrency rebalance + finding-equality.
   pod only would be tighter. **FLAG FOR JOE:** say if you want the scoped-projected
   hardening now; deferred as a follow-up given the no-RBAC blast radius.
 - **Approved:** proceeding under the "/loop, move fast" latitude; flagged for review.
+
+## R2 Phase 0: contract layer (PR-1, embervm 0.1.36)
+
+Implementation choices where the R2 plan was silent (contract PR; no behavior
+change, nothing calls the new session verbs yet). Flagged for post-impl review.
+
+### D-R2.0.1 `session_id` is a first-class `Op` struct field, not a payload key
+- The op-log `Op` struct gains a nullable `session_id` alongside `task_id`, mapping
+  1:1 to the new `ops.session_id` column; session ops carry `task_id: nil` and
+  vice versa. Cleaner than burying the id in the ETF payload, and it lets the
+  compaction blocker query pin a live session's ops by column (indexed) exactly
+  like a live task's.
+
+### D-R2.0.2 `session_created` projects state directly to `running`
+- The plan's FSM lists `creating -> running`, but a create is an assignment from an
+  already-primed pristine VM, so the durable projection records `running` on
+  `session_created`. The transient `creating` is a control-plane-process concern
+  (the parked create caller), not a durable state; a future PR can persist it via
+  the op payload's optional `:state` override if needed.
+
+### D-R2.0.3 The `SESSIONS` printer column is backed by a `status.sessionsSummary` string
+- A Kubernetes additionalPrinterColumns entry cannot format an object, so the
+  control plane writes both the structured `status.sessions {live,banked}` (for
+  machine reads) and a `status.sessionsSummary` string (e.g. "3 live / 2 banked")
+  that the `SESSIONS` column renders. Structured object stays authoritative.
+
+### D-R2.0.4 Base eviction is a fed-refcount seam, not a poll; counts fail safe
+- BaseBuilder holds `base_refs` per superseded ref and exposes `report_base_refs/3`
+  (PoolManager will report `:primed` counts, SessionStore `:sessions` counts, both
+  in PR-4). `evictable?` withholds eviction until EVERY owner has reported a known
+  (non-nil) zero: an unknown/nil count NEVER evicts. In this contract PR no base is
+  actually evicted (no reporters wired yet); the mechanism + property test land now
+  so PR-4 only adds the two reporters. This is the ADR 003 orphaned-base cleanup,
+  fail-safe by construction (a live session's base cannot be dropped).

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.35
+version: 0.1.36

--- a/projects/embervm/chart/crds/workload-crd.yaml
+++ b/projects/embervm/chart/crds/workload-crd.yaml
@@ -46,6 +46,10 @@ spec:
         - name: Snapshot
           type: string
           jsonPath: .status.snapshotRef
+        - name: Sessions
+          type: string
+          description: Live/banked session counts (session class only).
+          jsonPath: .status.sessionsSummary
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp
@@ -195,13 +199,68 @@ spec:
                   properties:
                     floor:
                       type: integer
-                      description: Primed-pool floor (VMs kept warm per workload).
+                      description: >-
+                        Primed-pool floor (pristine VMs kept warm per workload).
+                        For the session class, the floor is the pristine pool
+                        kept warm for fast session CREATE (create is assignment
+                        from a primed VM); for the task class it is warm task
+                        capacity.
                       minimum: 0
                       default: 0
                     cap:
                       type: integer
-                      description: Hard max in-flight tasks. Must be >= floor.
+                      description: >-
+                        Hard max in-flight. Must be >= floor. For the task class,
+                        max in-flight tasks; for the session class, max LIVE
+                        session VMs (banked sessions hold only disk, not a live
+                        VM, and do not count against the cap).
                       minimum: 1
+                session:
+                  type: object
+                  description: >-
+                    Session-class lifecycle policy (R2). REQUIRED when
+                    spec.class is `session` and forbidden otherwise; the watcher
+                    enforces that cross-field rule with a status condition (the
+                    OpenAPI schema cannot express class-conditional requiredness).
+                    A session is a long-lived logical sandbox banked to a node
+                    snapshot when idle and relit on the next invoke.
+                  properties:
+                    idleBankSeconds:
+                      type: integer
+                      description: >-
+                        Idle time (no in-flight, no queued invoke) after which a
+                        live session is banked to a snapshot and its VM released.
+                      minimum: 10
+                      default: 300
+                    maxLifetimeSeconds:
+                      type: integer
+                      description: >-
+                        Hard lifetime cap. A session rides its birth base version
+                        until this expires (the version-convergence bound); after
+                        it, the next invoke 410s and a fresh session lands on the
+                        current base.
+                      minimum: 60
+                      default: 86400
+                    bankedTtlSeconds:
+                      type: integer
+                      description: >-
+                        GC a banked snapshot untouched this long. Defaults to
+                        maxLifetimeSeconds when unset (the watcher applies that
+                        default; the schema leaves it absent so the watcher can
+                        see it was omitted).
+                      minimum: 60
+                    maxSessions:
+                      type: integer
+                      description: Max sessions (live + banked) for this workload.
+                      minimum: 1
+                      default: 16
+                    invokeQueueCap:
+                      type: integer
+                      description: >-
+                        Max invokes queued behind the one in-flight invoke per
+                        session before new invokes are rejected with 429.
+                      minimum: 1
+                      default: 4
                 invocation:
                   type: object
                   description: Task execution policy. All fields defaulted.
@@ -299,6 +358,24 @@ spec:
                   description: Resolved OCI image digest the base was built from.
                 primedFloorSatisfied:
                   type: boolean
+                sessions:
+                  type: object
+                  description: >-
+                    Session-class counts written by the control plane (session
+                    workloads only). Absent for the task class.
+                  properties:
+                    live:
+                      type: integer
+                      description: Sessions currently holding a live VM.
+                    banked:
+                      type: integer
+                      description: Sessions suspended to a node snapshot.
+                sessionsSummary:
+                  type: string
+                  description: >-
+                    Human-readable "live/banked" rendering of `sessions`, for the
+                    SESSIONS printer column (a printer column cannot format an
+                    object). Written by the control plane alongside `sessions`.
                 conditions:
                   type: array
                   items:

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -661,7 +661,10 @@ defmodule Embervm.BaseBuilder do
   # push any superseded ref onto the turnover list (Task 11 seam), and reset
   # backoff.
   defp apply_result(state, w, built_sig, {:ok, %BuildBaseResponse{} = resp}) do
-    turned_over? = w.snapshot_ref && w.snapshot_ref != resp.snapshot_ref
+    # Strict boolean (not `&&`): a first build has w.snapshot_ref == nil, and
+    # `nil && _` returns nil, which the strict `and` on the base_refs guard below
+    # rejects with BadBooleanError. `!=` always yields a boolean.
+    turned_over? = w.snapshot_ref != nil and w.snapshot_ref != resp.snapshot_ref
 
     superseded =
       if turned_over?, do: [w.snapshot_ref | w.superseded_refs], else: w.superseded_refs

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -104,7 +104,15 @@ defmodule Embervm.BaseBuilder do
   use GenServer
   require Logger
 
-  alias Embervm.Node.V1.{BuildBaseRequest, BuildBaseResponse, NodeService, ResourceSpec, Trace, ZipSource}
+  alias Embervm.Node.V1.{
+    BuildBaseRequest,
+    BuildBaseResponse,
+    EvictSnapshotRequest,
+    NodeService,
+    ResourceSpec,
+    Trace,
+    ZipSource
+  }
 
   # Backoff for a failed build: exponential from 1s, capped at the spec's 10m.
   @base_backoff_ms 1_000
@@ -169,6 +177,23 @@ defmodule Embervm.BaseBuilder do
   end
 
   @doc """
+  Report current refcounts against a superseded base snapshot ref for a
+  workload, so the BaseBuilder can decide when it is safe to evict (R2 base
+  refcounting, ADR embervm/001 standing decision 5). Callers report the counts
+  they own: the PoolManager reports `:primed` (primed pristine VMs still on the
+  old base), the SessionStore reports `:sessions` (non-terminal sessions still
+  pinned to the old base as their birth lineage). A superseded base is destroyed
+  (via EvictSnapshot) ONLY once BOTH are reported as zero; until then it stays
+  restorable so a live or banked session can always relight from its birth base.
+  Unknown/absent refs are ignored (the ref was never superseded, or already
+  evicted). A synchronous call so a test can assert eviction ordering.
+  """
+  @spec report_base_refs(GenServer.server(), String.t(), keyword()) :: :ok
+  def report_base_refs(server \\ __MODULE__, ref, counts) do
+    GenServer.call(server, {:report_base_refs, ref, counts})
+  end
+
+  @doc """
   A snapshot of every tracked Workload's build state, for tests and operational
   visibility. Includes queue/building state per node so an operator can see WHY
   a base is not built yet.
@@ -194,6 +219,11 @@ defmodule Embervm.BaseBuilder do
     build_fun = Keyword.get(opts, :build_fun, &default_build/2)
     connect_fun = Keyword.get(opts, :connect_fun, &default_connect/1)
     disconnect_fun = Keyword.get(opts, :disconnect_fun, &default_disconnect/1)
+    # R2: the EvictSnapshot seam for destroying a fully-drained superseded base
+    # (the ADR embervm/003 eviction verb, landed early). Defaults to the real
+    # NodeService.Stub.evict_snapshot/2 over a per-call channel; tests inject a
+    # fake to assert eviction fires exactly when both refcounts hit zero.
+    evict_fun = Keyword.get(opts, :evict_fun, &default_evict/2)
     status_writer = Keyword.get(opts, :status_writer, &Embervm.K8s.patch_workload_status/3)
     clock = Keyword.get(opts, :clock, fn -> System.system_time(:millisecond) end)
     base_backoff = Keyword.get(opts, :base_backoff_ms, @base_backoff_ms)
@@ -225,6 +255,7 @@ defmodule Embervm.BaseBuilder do
       build_fun: build_fun,
       connect_fun: connect_fun,
       disconnect_fun: disconnect_fun,
+      evict_fun: evict_fun,
       runtime_images: runtime_images,
       status_writer: status_writer,
       clock: clock,
@@ -245,6 +276,10 @@ defmodule Embervm.BaseBuilder do
   end
 
   @impl true
+  def handle_call({:report_base_refs, ref, counts}, _from, state) do
+    {:reply, :ok, apply_base_refs(state, ref, counts)}
+  end
+
   def handle_call(:status, _from, state) do
     workloads =
       for {name, w} <- state.workloads, into: %{} do
@@ -256,6 +291,7 @@ defmodule Embervm.BaseBuilder do
            snapshot_digest: w.snapshot_digest,
            built: w.built_signature != nil and w.built_signature == signature(w),
            superseded_refs: w.superseded_refs,
+           base_refs: w.base_refs,
            backoff_ms: w.backoff_ms
          }}
       end
@@ -386,6 +422,15 @@ defmodule Embervm.BaseBuilder do
       snapshot_ref: nil,
       snapshot_digest: nil,
       superseded_refs: [],
+      # R2 refcounting: per-superseded-ref refcount tracking, keyed by snapshot
+      # ref. A superseded base is destroyed (via EvictSnapshot) ONLY when zero
+      # primed VMs AND zero non-terminal sessions reference it. Both counts start
+      # nil (unknown) and are reported by the PoolManager (primed) and the
+      # SessionStore (sessions); eviction fires only once BOTH are known-and-zero,
+      # so a base is never evicted while a session still rides its birth version
+      # (standing decision 5). Multiple superseded bases coexist here, each
+      # TTL-bounded by its referencing sessions' maxLifetimeSeconds.
+      base_refs: %{},
       backoff_ms: nil,
       retry_timer: nil
     }
@@ -616,10 +661,26 @@ defmodule Embervm.BaseBuilder do
   # push any superseded ref onto the turnover list (Task 11 seam), and reset
   # backoff.
   defp apply_result(state, w, built_sig, {:ok, %BuildBaseResponse{} = resp}) do
+    turned_over? = w.snapshot_ref && w.snapshot_ref != resp.snapshot_ref
+
     superseded =
-      if w.snapshot_ref && w.snapshot_ref != resp.snapshot_ref,
-        do: [w.snapshot_ref | w.superseded_refs],
-        else: w.superseded_refs
+      if turned_over?, do: [w.snapshot_ref | w.superseded_refs], else: w.superseded_refs
+
+    # On turnover, start refcounting the freshly-superseded base. Counts begin
+    # unknown (nil); eviction is withheld until the PoolManager and SessionStore
+    # report both as zero (report_base_refs/3). A ref already tracked keeps its
+    # reported counts.
+    base_refs =
+      if turned_over? and not Map.has_key?(w.base_refs, w.snapshot_ref) do
+        Map.put(w.base_refs, w.snapshot_ref, %{
+          node_id: w.node_id,
+          primed: nil,
+          sessions: nil,
+          evicted: false
+        })
+      else
+        w.base_refs
+      end
 
     w = %{
       w
@@ -627,12 +688,116 @@ defmodule Embervm.BaseBuilder do
         snapshot_ref: resp.snapshot_ref,
         snapshot_digest: resp.image_digest,
         superseded_refs: superseded,
+        base_refs: base_refs,
         backoff_ms: nil,
         retry_timer: nil
     }
 
     state = put_in(state.workloads[w.name], w)
     write_base_status(state, w, :built)
+  end
+
+  # -- base refcounting + eviction (R2) ---------------------------------------
+
+  # Update the reported refcounts for one superseded base ref and, if it is now
+  # fully drained (zero primed AND zero sessions, both known), evict it. Finds
+  # the workload that recorded the ref; a ref we do not track (never superseded,
+  # or already evicted) is a no-op. This is the ONLY place a superseded base is
+  # destroyed, and only via the EvictSnapshot verb.
+  defp apply_base_refs(state, ref, counts) do
+    case workload_for_ref(state, ref) do
+      nil ->
+        state
+
+      name ->
+        w = state.workloads[name]
+        entry = Map.get(w.base_refs, ref)
+        updated = merge_refcounts(entry, counts)
+        w = put_in(w.base_refs[ref], updated)
+        state = put_in(state.workloads[name], w)
+        maybe_evict_base(state, name, ref)
+    end
+  end
+
+  defp workload_for_ref(state, ref) do
+    Enum.find_value(state.workloads, fn {name, w} ->
+      if not Map.get(w.base_refs[ref] || %{}, :evicted, true) and Map.has_key?(w.base_refs, ref),
+        do: name,
+        else: nil
+    end)
+  end
+
+  defp merge_refcounts(entry, counts) do
+    entry
+    |> maybe_put_count(:primed, Keyword.get(counts, :primed))
+    |> maybe_put_count(:sessions, Keyword.get(counts, :sessions))
+  end
+
+  defp maybe_put_count(entry, _key, nil), do: entry
+  defp maybe_put_count(entry, key, value) when is_integer(value), do: Map.put(entry, key, value)
+
+  # A superseded base is evictable only when BOTH refcounts are known and zero.
+  # A nil (unreported) count is treated as "still referenced": eviction is
+  # withheld until every owner has spoken, so a base is never destroyed under a
+  # session that has not yet been counted (fail-safe).
+  defp evictable?(%{primed: 0, sessions: 0, evicted: false}), do: true
+  defp evictable?(_), do: false
+
+  defp maybe_evict_base(state, name, ref) do
+    w = state.workloads[name]
+    entry = w.base_refs[ref]
+
+    if evictable?(entry) do
+      # Mark evicted synchronously (so a second report cannot double-evict), drop
+      # the ref from the turnover list, and fire EvictSnapshot in a spawned worker
+      # so the blocking RPC never freezes this GenServer.
+      w = %{
+        w
+        | base_refs: Map.put(w.base_refs, ref, %{entry | evicted: true}),
+          superseded_refs: List.delete(w.superseded_refs, ref)
+      }
+
+      state = put_in(state.workloads[name], w)
+      spawn_evict(state, entry.node_id, ref)
+      state
+    else
+      state
+    end
+  end
+
+  # Spawn a fire-and-forget eviction worker. EvictSnapshot is idempotent (an
+  # unknown ref is OK), so a lost result or a retry is harmless; failures are
+  # logged, not retried here (the next report, or the banked-TTL GC, is the
+  # backstop). Not monitored: a crash cannot un-evict the already-marked ref.
+  defp spawn_evict(state, node_id, ref) do
+    address = state.node_addr[node_id]
+    connect_fun = state.connect_fun
+    disconnect_fun = state.disconnect_fun
+    evict_fun = state.evict_fun
+
+    spawn(fn ->
+      result =
+        case connect_fun.(address) do
+          {:ok, channel} ->
+            try do
+              evict_fun.(channel, ref)
+            catch
+              kind, reason -> {:error, {kind, reason}}
+            after
+              disconnect_fun.(channel)
+            end
+
+          {:error, reason} ->
+            {:error, {:connect, reason}}
+        end
+
+      case result do
+        {:ok, _} -> :ok
+        other -> Logger.warning("embervm base builder: EvictSnapshot #{ref} failed: #{inspect(other)}")
+      end
+    end)
+
+    :ok
   end
 
   # A failed build: keep any existing base (Ready stays True if one is recorded),
@@ -781,6 +946,15 @@ defmodule Embervm.BaseBuilder do
 
   defp default_build(channel, %BuildBaseRequest{} = request) do
     NodeService.Stub.build_base(channel, request)
+  end
+
+  # EvictSnapshot the superseded base ref. Trace carries no workload (a base
+  # eviction is not a per-workload task op); the ref is the whole payload.
+  defp default_evict(channel, ref) do
+    NodeService.Stub.evict_snapshot(channel, %EvictSnapshotRequest{
+      trace: %Trace{},
+      snapshot_ref: ref
+    })
   end
 
   # A gRPC-level failure (e.g. FAILED_PRECONDITION for an image the daemon does

--- a/projects/embervm/control/lib/embervm/op_log.ex
+++ b/projects/embervm/control/lib/embervm/op_log.ex
@@ -30,6 +30,7 @@ defmodule Embervm.OpLog do
               principal: nil,
               workload: nil,
               task_id: nil,
+              session_id: nil,
               ts: nil,
               payload: %{}
 
@@ -40,6 +41,10 @@ defmodule Embervm.OpLog do
             principal: String.t() | nil,
             workload: String.t() | nil,
             task_id: String.t() | nil,
+            # Set on session_* ops (nil on task ops); the durable `ops.session_id`
+            # column, added additively. A session op owns its `sessions`
+            # projection row the way a task op owns its `tasks` row.
+            session_id: String.t() | nil,
             ts: integer(),
             payload: map()
           }
@@ -62,7 +67,20 @@ defmodule Embervm.OpLog do
     :primed,
     :vm_destroyed,
     :quota_enforced,
-    :drain
+    :drain,
+    # Session lifecycle (R2). Additive to the closed enum; sessions are durable,
+    # ordered, and auditable exactly like tasks (ADR embervm/001) and project
+    # into the `sessions` table (see Embervm.OpLog.SQLite). session_invoked
+    # carries usage only (no request/response bodies) and upserts the same
+    # (principal, day) usage projection tasks do, the D12.1 pattern.
+    :session_created,
+    :session_invoked,
+    :session_banked,
+    :session_relit,
+    :session_expired,
+    :session_evicted,
+    :session_destroyed,
+    :session_failed
   ]
 
   @spec kinds() :: [atom()]
@@ -82,6 +100,11 @@ defmodule Embervm.OpLog do
   @callback read_from(server(), seq :: non_neg_integer()) ::
               {:ok, [Op.t()]} | {:error, {:compacted, non_neg_integer()}} | {:error, term()}
   @callback load_tasks(server()) :: {:ok, [map()]} | {:error, term()}
+  # Loads every session row from the durable `sessions` projection (R2), for the
+  # SessionStore's boot/adoption rebuild (Task 5/8): the ETS hot set of sessions
+  # is reconstructed from this exactly as the task index is from load_tasks/1. A
+  # projection read, never the raw ops log.
+  @callback load_sessions(server()) :: {:ok, [map()]} | {:error, term()}
   # Reads one task's stored result from the durable `results` projection, or
   # {:ok, nil} when there is none (never ran, or the TTL sweeper reaped it).
   # This is the result-store read the submit API (Task 8) serves `GET
@@ -125,6 +148,7 @@ defmodule Embervm.OpLog do
                %{
                  results_deleted: non_neg_integer(),
                  tasks_compacted: non_neg_integer(),
+                 sessions_compacted: non_neg_integer(),
                  ops_compacted: non_neg_integer(),
                  compacted_through: non_neg_integer(),
                  done: boolean()

--- a/projects/embervm/control/lib/embervm/op_log/compactor.ex
+++ b/projects/embervm/control/lib/embervm/op_log/compactor.ex
@@ -60,7 +60,14 @@ defmodule Embervm.OpLog.Compactor do
   # so far; the next scheduled sweep retries.
   defp run_sweep(state) do
     now_ms = System.system_time(:millisecond)
-    totals = %{results_deleted: 0, tasks_compacted: 0, ops_compacted: 0, compacted_through: 0}
+    totals = %{
+      results_deleted: 0,
+      tasks_compacted: 0,
+      sessions_compacted: 0,
+      ops_compacted: 0,
+      compacted_through: 0
+    }
+
     sweep_loop(state, now_ms, totals)
   end
 
@@ -70,6 +77,7 @@ defmodule Embervm.OpLog.Compactor do
         totals = %{
           results_deleted: totals.results_deleted + batch.results_deleted,
           tasks_compacted: totals.tasks_compacted + batch.tasks_compacted,
+          sessions_compacted: totals.sessions_compacted + batch.sessions_compacted,
           ops_compacted: totals.ops_compacted + batch.ops_compacted,
           # The marker is monotonic and reported per batch; the last batch's value
           # is the authoritative post-sweep marker.
@@ -99,6 +107,7 @@ defmodule Embervm.OpLog.Compactor do
         inspect(
           results_deleted: totals.results_deleted,
           tasks_compacted: totals.tasks_compacted,
+          sessions_compacted: totals.sessions_compacted,
           ops_compacted: totals.ops_compacted,
           compacted_through: totals.compacted_through,
           db_size_bytes: db_size

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -35,6 +35,13 @@ defmodule Embervm.OpLog.SQLite do
   # The complementary set: states a task can still leave, so its ops must never be
   # prefix-compacted regardless of age. Used by the marker computation below.
   @live_states ["queued", "assigned", "running", "failed_retryable"]
+
+  # Session lifecycle states (R2), mirroring the task retention discipline. A
+  # non-terminal (live) session pins its ops against prefix compaction and is
+  # never pruned by the retention sweep, exactly as a live task does; a terminal
+  # session prunes past retention and releases its ops for compaction.
+  @session_terminal_states ["expired", "evicted", "destroyed", "failed"]
+  @session_live_states ["creating", "running", "banking", "banked", "relighting"]
   # Seven days in milliseconds: default age (from last update) at which a
   # terminal task is eligible for compaction. This is the TERMINAL-TASK retention
   # window and is DISTINCT from the ops-journal horizon below.
@@ -59,6 +66,7 @@ defmodule Embervm.OpLog.SQLite do
       principal TEXT,
       workload TEXT,
       task_id TEXT,
+      session_id TEXT,
       kind TEXT NOT NULL,
       payload_json TEXT NOT NULL DEFAULT '{}'
     )
@@ -112,6 +120,36 @@ defmodule Embervm.OpLog.SQLite do
       PRIMARY KEY (principal, day)
     )
     """,
+    # Session projection (R2): the durable lifecycle + lineage row per session,
+    # write-through projected from the session_* ops (see project/2). The lineage
+    # fields (base_snapshot_ref, base_digest, generation, snapshot_ref) are schema
+    # from the first banked byte (ADR embervm/001 standing decision 4/5): a session
+    # is pinned to its birth base and records its parent lineage forever, and
+    # `generation` increments on every bank. token_sha256 is the sha256 of the
+    # per-session capability token (the plaintext token is never stored). A
+    # non-terminal session pins its ops against compaction and is never pruned by
+    # retention, exactly like a live task.
+    """
+    CREATE TABLE IF NOT EXISTS sessions (
+      session_id TEXT PRIMARY KEY,
+      tenant TEXT NOT NULL,
+      principal TEXT,
+      workload TEXT,
+      state TEXT NOT NULL,
+      node_id TEXT,
+      base_snapshot_ref TEXT,
+      base_digest TEXT,
+      generation INTEGER NOT NULL DEFAULT 0,
+      snapshot_ref TEXT,
+      snapshot_size_bytes INTEGER,
+      token_sha256 TEXT,
+      created_at INTEGER NOT NULL,
+      last_invoke_at INTEGER,
+      expires_at INTEGER,
+      updated_at INTEGER NOT NULL,
+      terminal_reason TEXT
+    )
+    """,
     # Durable single-row scalars for the op-log. Today it holds only the
     # ops-journal prefix marker (`compacted_through_seq`): the newest op seq that
     # has been prefix-compacted away, part of the durable OpLog contract so a
@@ -156,6 +194,11 @@ defmodule Embervm.OpLog.SQLite do
   @impl Embervm.OpLog
   def load_tasks(server \\ __MODULE__) do
     GenServer.call(server, :load_tasks)
+  end
+
+  @impl Embervm.OpLog
+  def load_sessions(server \\ __MODULE__) do
+    GenServer.call(server, :load_sessions)
   end
 
   @impl Embervm.OpLog
@@ -247,6 +290,10 @@ defmodule Embervm.OpLog.SQLite do
     {:reply, do_load_tasks(state.conn), state}
   end
 
+  def handle_call(:load_sessions, _from, state) do
+    {:reply, do_load_sessions(state.conn), state}
+  end
+
   def handle_call({:load_result, task_id}, _from, state) do
     {:reply, do_load_result(state.conn, task_id), state}
   end
@@ -302,8 +349,8 @@ defmodule Embervm.OpLog.SQLite do
 
   defp insert_op(conn, %Op{} = op) do
     sql = """
-    INSERT INTO ops (ts, tenant, principal, workload, task_id, kind, payload_json)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO ops (ts, tenant, principal, workload, task_id, session_id, kind, payload_json)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     """
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
@@ -314,6 +361,7 @@ defmodule Embervm.OpLog.SQLite do
              op.principal,
              op.workload,
              op.task_id,
+             op.session_id,
              Atom.to_string(op.kind),
              # An ETF {:blob, _}, not JSON, so a binary body persists byte-exact
              # (see encode_payload/1).
@@ -444,10 +492,131 @@ defmodule Embervm.OpLog.SQLite do
     end
   end
 
+  # -- session projection (R2) ----------------------------------------------
+  #
+  # Write-through onto the `sessions` table, the same discipline as tasks: the
+  # op row is already written (insert_op above), and this projects its effect.
+  # session_created inserts the lineage-bearing row; bank/relight/invoke update
+  # the relevant columns; the terminal kinds set a terminal state + reason.
+
+  defp project(conn, %Op{kind: :session_created} = op, _seq) do
+    payload = op.payload
+
+    sql = """
+    INSERT INTO sessions
+      (session_id, tenant, principal, workload, state, node_id,
+       base_snapshot_ref, base_digest, generation, snapshot_ref, snapshot_size_bytes,
+       token_sha256, created_at, last_invoke_at, expires_at, updated_at, terminal_reason)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, NULL, ?, ?, NULL, ?, ?, NULL)
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <-
+           Sqlite3.bind(stmt, [
+             op.session_id,
+             op.tenant,
+             op.principal,
+             op.workload,
+             # Create yields an immediately-live session (assigned from the primed
+             # pool); the transient FSM "creating" is a process concern, so the
+             # durable projected state defaults to "running" unless scripted.
+             Map.get(payload, :state, "running"),
+             Map.get(payload, :node_id),
+             Map.get(payload, :base_snapshot_ref),
+             Map.get(payload, :base_digest),
+             Map.get(payload, :token_sha256),
+             op.ts,
+             Map.get(payload, :expires_at),
+             op.ts
+           ]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # session_invoked: usage + last_invoke, NO state change and NO request/response
+  # bodies in the payload (at-most-once, data minimization). Charges the same
+  # (principal, day) usage projection tasks do (D12.1), in this same transaction.
+  defp project(conn, %Op{kind: :session_invoked} = op, _seq) do
+    sql = "UPDATE sessions SET last_invoke_at=?, updated_at=? WHERE session_id=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [op.ts, op.ts, op.session_id]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      project_usage(conn, op)
+    end
+  end
+
+  # session_banked: the VM is snapshotted and destroyed. Records the new snapshot
+  # ref + size and bumps generation (every bank increments it, the lineage rule).
+  defp project(conn, %Op{kind: :session_banked} = op, _seq) do
+    payload = op.payload
+
+    sql = """
+    UPDATE sessions
+    SET state='banked', snapshot_ref=?, snapshot_size_bytes=?, generation=?, updated_at=?
+    WHERE session_id=?
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <-
+           Sqlite3.bind(stmt, [
+             Map.get(payload, :snapshot_ref),
+             Map.get(payload, :size_bytes),
+             Map.get(payload, :generation, 0),
+             op.ts,
+             op.session_id
+           ]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # session_relit: restored to a live VM from its banked snapshot; back to running.
+  defp project(conn, %Op{kind: :session_relit} = op, _seq) do
+    sql = "UPDATE sessions SET state='running', updated_at=? WHERE session_id=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [op.ts, op.session_id]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  defp project(conn, %Op{kind: :session_expired} = op, _seq),
+    do: terminate_session(conn, op, "expired")
+
+  defp project(conn, %Op{kind: :session_evicted} = op, _seq),
+    do: terminate_session(conn, op, "evicted")
+
+  defp project(conn, %Op{kind: :session_destroyed} = op, _seq),
+    do: terminate_session(conn, op, "destroyed")
+
+  defp project(conn, %Op{kind: :session_failed} = op, _seq),
+    do: terminate_session(conn, op, "failed")
+
   # Audit-only kinds: no task/result projection.
   defp project(_conn, %Op{kind: kind}, _seq)
        when kind in [:denied, :base_built, :primed, :vm_destroyed, :quota_enforced, :drain] do
     :ok
+  end
+
+  # A terminal session transition: set the terminal state + a machine-readable
+  # reason (defaulting to the state itself when the payload omits one).
+  defp terminate_session(conn, %Op{} = op, state) do
+    reason = to_string(Map.get(op.payload, :reason, state))
+    sql = "UPDATE sessions SET state=?, terminal_reason=?, updated_at=? WHERE session_id=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [state, reason, op.ts, op.session_id]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
   end
 
   defp update_task_state(conn, task_id, state, ts) do
@@ -539,7 +708,7 @@ defmodule Embervm.OpLog.SQLite do
       {:error, {:compacted, marker}}
     else
       sql = """
-      SELECT seq, ts, tenant, principal, workload, task_id, kind, payload_json
+      SELECT seq, ts, tenant, principal, workload, task_id, session_id, kind, payload_json
       FROM ops WHERE seq > ? ORDER BY seq ASC
       """
 
@@ -554,7 +723,7 @@ defmodule Embervm.OpLog.SQLite do
 
   defp collect_ops(conn, stmt, acc) do
     case Sqlite3.step(conn, stmt) do
-      {:row, [seq, ts, tenant, principal, workload, task_id, kind, payload_json]} ->
+      {:row, [seq, ts, tenant, principal, workload, task_id, session_id, kind, payload_json]} ->
         op = %Op{
           seq: seq,
           ts: ts,
@@ -562,6 +731,7 @@ defmodule Embervm.OpLog.SQLite do
           principal: principal,
           workload: workload,
           task_id: task_id,
+          session_id: session_id,
           kind: String.to_existing_atom(kind),
           payload: decode_payload(payload_json)
         }
@@ -583,6 +753,70 @@ defmodule Embervm.OpLog.SQLite do
       tasks = collect_tasks(conn, stmt, [])
       :ok = Sqlite3.release(conn, stmt)
       {:ok, tasks}
+    end
+  end
+
+  defp do_load_sessions(conn) do
+    sql = """
+    SELECT session_id, tenant, principal, workload, state, node_id,
+           base_snapshot_ref, base_digest, generation, snapshot_ref, snapshot_size_bytes,
+           token_sha256, created_at, last_invoke_at, expires_at, updated_at, terminal_reason
+    FROM sessions
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql) do
+      sessions = collect_sessions(conn, stmt, [])
+      :ok = Sqlite3.release(conn, stmt)
+      {:ok, sessions}
+    end
+  end
+
+  defp collect_sessions(conn, stmt, acc) do
+    case Sqlite3.step(conn, stmt) do
+      {:row,
+       [
+         session_id,
+         tenant,
+         principal,
+         workload,
+         state,
+         node_id,
+         base_snapshot_ref,
+         base_digest,
+         generation,
+         snapshot_ref,
+         snapshot_size_bytes,
+         token_sha256,
+         created_at,
+         last_invoke_at,
+         expires_at,
+         updated_at,
+         terminal_reason
+       ]} ->
+        session = %{
+          session_id: session_id,
+          tenant: tenant,
+          principal: principal,
+          workload: workload,
+          state: state,
+          node_id: node_id,
+          base_snapshot_ref: base_snapshot_ref,
+          base_digest: base_digest,
+          generation: generation,
+          snapshot_ref: snapshot_ref,
+          snapshot_size_bytes: snapshot_size_bytes,
+          token_sha256: token_sha256,
+          created_at: created_at,
+          last_invoke_at: last_invoke_at,
+          expires_at: expires_at,
+          updated_at: updated_at,
+          terminal_reason: terminal_reason
+        }
+
+        collect_sessions(conn, stmt, [session | acc])
+
+      :done ->
+        Enum.reverse(acc)
     end
   end
 
@@ -763,18 +997,45 @@ defmodule Embervm.OpLog.SQLite do
 
     with {:ok, results_deleted} <- delete_expired_results(conn, now_ms, batch),
          {:ok, tasks_compacted} <- delete_terminal_tasks(conn, now_ms, state.retention_ms, batch),
+         {:ok, sessions_compacted} <- delete_terminal_sessions(conn, now_ms, state.retention_ms, batch),
          {:ok, ops_compacted, marker} <- compact_ops(conn, now_ms, state.journal_horizon_ms, batch) do
       done =
-        results_deleted < batch and tasks_compacted < batch and ops_compacted < batch
+        results_deleted < batch and tasks_compacted < batch and sessions_compacted < batch and
+          ops_compacted < batch
 
       {:ok,
        %{
          results_deleted: results_deleted,
          tasks_compacted: tasks_compacted,
+         sessions_compacted: sessions_compacted,
          ops_compacted: ops_compacted,
          compacted_through: marker,
          done: done
        }}
+    end
+  end
+
+  # Prune terminal session projection rows past the 7-day retention, the same
+  # cutoff and bounded-batch discipline as terminal tasks. A non-terminal session
+  # is never pruned (its state is not in @session_terminal_states), and its ops
+  # remain pinned against compaction by blocker_seq. Bounded via the rowid
+  # subquery form (DELETE ... LIMIT is unavailable on the bundled SQLite).
+  defp delete_terminal_sessions(conn, now_ms, retention_ms, batch) do
+    cutoff = now_ms - retention_ms
+    placeholders = @session_terminal_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
+
+    sql = """
+    DELETE FROM sessions WHERE rowid IN (
+      SELECT rowid FROM sessions WHERE state IN (#{placeholders}) AND updated_at < ? LIMIT ?
+    )
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, @session_terminal_states ++ [cutoff, batch]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt),
+         {:ok, changed} <- Sqlite3.changes(conn) do
+      {:ok, changed}
     end
   end
 
@@ -843,19 +1104,24 @@ defmodule Embervm.OpLog.SQLite do
   end
 
   # The smallest seq that must NOT be compacted: the first op that is either newer
-  # than the horizon (ts >= cutoff) or owned by a live (non-terminal) task. NULL
-  # means no op is blocked, so the whole log is eligible.
+  # than the horizon (ts >= cutoff), owned by a live (non-terminal) task, OR owned
+  # by a live (non-terminal) session. The session clause is the R2 never-compact-a-
+  # live-session rule: a non-terminal session pins its ops exactly as a live task
+  # does, so its lineage/lifecycle history stays replayable until it terminates.
+  # NULL means no op is blocked, so the whole log is eligible.
   defp blocker_seq(conn, cutoff) do
     live_placeholders = @live_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
+    session_live_placeholders = @session_live_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
 
     sql = """
     SELECT MIN(seq) FROM ops
     WHERE ts >= ?
        OR task_id IN (SELECT task_id FROM tasks WHERE state IN (#{live_placeholders}))
+       OR session_id IN (SELECT session_id FROM sessions WHERE state IN (#{session_live_placeholders}))
     """
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
-         :ok <- Sqlite3.bind(stmt, [cutoff] ++ @live_states) do
+         :ok <- Sqlite3.bind(stmt, [cutoff] ++ @live_states ++ @session_live_states) do
       result =
         case Sqlite3.step(conn, stmt) do
           {:row, [seq]} -> {:ok, seq}
@@ -978,12 +1244,41 @@ defmodule Embervm.OpLog.SQLite do
   # live column set first and only adds what is missing. Fresh AND upgraded DBs both
   # end with the same shape; old result rows keep headers NULL, read back as %{}.
   defp apply_migrations(conn) do
+    with :ok <- migrate_results_headers(conn),
+         :ok <- migrate_ops_session_id(conn) do
+      :ok
+    end
+  end
+
+  defp migrate_results_headers(conn) do
     with {:ok, cols} <- table_columns(conn, "results") do
       if "headers" in cols do
         :ok
       else
         Sqlite3.execute(conn, "ALTER TABLE results ADD COLUMN headers TEXT")
       end
+    end
+  end
+
+  # R2: the additive nullable `ops.session_id` column plus its index. A fresh DB
+  # already built the column from the CREATE TABLE (and skips the ALTER), so this
+  # only fires on a DB created before R2; the ALTER-after-DDL guard is the
+  # D-R1.2.1 precedent. The index is created here (not in @ddl) so it always runs
+  # AFTER the column exists on both fresh and upgraded DBs. `sessions` itself is a
+  # whole new table, so `CREATE TABLE IF NOT EXISTS` in @ddl handles both cases;
+  # no ALTER is needed for it.
+  defp migrate_ops_session_id(conn) do
+    with {:ok, cols} <- table_columns(conn, "ops"),
+         :ok <- add_column_if_missing(conn, cols, "session_id", "ALTER TABLE ops ADD COLUMN session_id TEXT") do
+      Sqlite3.execute(conn, "CREATE INDEX IF NOT EXISTS ops_session_id_idx ON ops(session_id)")
+    end
+  end
+
+  defp add_column_if_missing(conn, cols, column, alter_sql) do
+    if column in cols do
+      :ok
+    else
+      Sqlite3.execute(conn, alter_sql)
     end
   end
 

--- a/projects/embervm/control/lib/embervm/workload_watcher.ex
+++ b/projects/embervm/control/lib/embervm/workload_watcher.ex
@@ -426,8 +426,8 @@ defmodule Embervm.WorkloadWatcher do
       spec = Map.get(cr, "spec") || %{}
 
       case validate(spec) do
-        {:ok, floor, cap} ->
-          entry = catalog_entry(name, namespace, spec, floor, cap)
+        {:ok, class, floor, cap, session_cfg} ->
+          entry = catalog_entry(name, namespace, spec, class, floor, cap, session_cfg)
           WorkloadCatalog.upsert(state.table, name, entry)
 
           # A valid Workload's Ready/BaseBuilt conditions are owned by the
@@ -552,25 +552,72 @@ defmodule Embervm.WorkloadWatcher do
 
   # -- validation ----------------------------------------------------------
 
-  # Returns {:ok, fields} with just the pieces catalog_entry/3 needs, or
+  # Returns {:ok, class, floor, cap, session_cfg} with just the pieces
+  # catalog_entry needs (session_cfg is nil for the task class), or
   # {:error, reason_code, message} for a status condition. The CRD schema
   # (workload-crd.yaml) enforces shape (required fields, enums, min/max) at
-  # admission; what's left for the watcher is the cross-field/semantic rules
-  # the OpenAPI schema cannot express (class allow-list beyond the enum,
-  # oneOf source lane, cap >= floor).
+  # admission; what's left for the watcher is the cross-field/semantic rules the
+  # OpenAPI schema cannot express (class allow-list beyond the enum, the oneOf
+  # source lane, cap >= floor, and the class-conditional session block).
   defp validate(spec) do
-    with :ok <- validate_class(spec),
+    with {:ok, class} <- validate_class(spec),
          :ok <- validate_source(spec),
-         {:ok, floor, cap} <- validate_concurrency(spec) do
-      {:ok, floor, cap}
+         {:ok, floor, cap} <- validate_concurrency(spec),
+         {:ok, session_cfg} <- validate_session(spec, class) do
+      {:ok, class, floor, cap, session_cfg}
     end
   end
 
-  defp validate_class(%{"class" => "task"}), do: :ok
+  defp validate_class(%{"class" => "task"}), do: {:ok, "task"}
+  defp validate_class(%{"class" => "session"}), do: {:ok, "session"}
 
   defp validate_class(spec) do
     {:error, "ClassUnsupported",
-     "class #{inspect(Map.get(spec, "class"))} is reserved for a later rung; only task is valid in v1alpha1"}
+     "class #{inspect(Map.get(spec, "class"))} is reserved for a later rung; only task and session are valid in v1alpha1"}
+  end
+
+  # The session block is REQUIRED for the session class and FORBIDDEN for the
+  # task class (the class-conditional requiredness the OpenAPI schema cannot
+  # express). Each mismatch is a precise Ready=False, never a crash (R0 posture).
+  # Session config numeric fields are re-defaulted here (mirroring the CRD) so
+  # this code has no silent dependency on apiserver defaulting having run.
+  @session_defaults %{
+    idle_bank_seconds: 300,
+    max_lifetime_seconds: 86_400,
+    max_sessions: 16,
+    invoke_queue_cap: 4
+  }
+
+  defp validate_session(spec, "task") do
+    case Map.get(spec, "session") do
+      nil -> {:ok, nil}
+      _ -> {:error, "SessionSpecUnexpected", "spec.session is only valid for class session, not task"}
+    end
+  end
+
+  defp validate_session(spec, "session") do
+    case Map.get(spec, "session") do
+      s when is_map(s) ->
+        {:ok, parse_session(s)}
+
+      _ ->
+        {:error, "SessionSpecMissing", "class session requires a spec.session block"}
+    end
+  end
+
+  # bankedTtlSeconds defaults to maxLifetimeSeconds when omitted (the plan's
+  # rule), which is why it is not defaulted in the CRD schema: the watcher needs
+  # to see the omission to apply that class-coupled default.
+  defp parse_session(s) do
+    max_lifetime = Map.get(s, "maxLifetimeSeconds") || @session_defaults.max_lifetime_seconds
+
+    %{
+      idle_bank_seconds: Map.get(s, "idleBankSeconds") || @session_defaults.idle_bank_seconds,
+      max_lifetime_seconds: max_lifetime,
+      banked_ttl_seconds: Map.get(s, "bankedTtlSeconds") || max_lifetime,
+      max_sessions: Map.get(s, "maxSessions") || @session_defaults.max_sessions,
+      invoke_queue_cap: Map.get(s, "invokeQueueCap") || @session_defaults.invoke_queue_cap
+    }
   end
 
   # The CRD schema enforces the structural oneOf (exactly one of image|zip) at
@@ -639,7 +686,7 @@ defmodule Embervm.WorkloadWatcher do
   # reflects whatever the apiserver already defaulted at admission;
   # re-defaulting here just means this code has no silent dependency on that
   # having happened.
-  defp catalog_entry(name, namespace, spec, floor, cap) do
+  defp catalog_entry(name, namespace, spec, class, floor, cap, session_cfg) do
     resources = Map.get(spec, "resources") || %{}
     invocation = Map.get(spec, "invocation") || %{}
     source = parse_source(spec)
@@ -647,7 +694,11 @@ defmodule Embervm.WorkloadWatcher do
     %{
       name: name,
       namespace: namespace,
-      class: "task",
+      class: class,
+      # Session-class lifecycle config (nil for the task class), carried so the
+      # SessionManager/SessionStore (later PRs) read idle-bank/lifetime/caps from
+      # the catalog exactly as the dispatcher reads task caps.
+      session: session_cfg,
       # Zip-lane source (nil for the image lane), carried so the BaseBuilder can
       # map it to a proto ZipSource. The image lane leaves it nil.
       zip: source.zip,

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -479,4 +479,105 @@ defmodule Embervm.BaseBuilderTest do
     st = BaseBuilder.status(builder)
     refute Map.has_key?(st.workloads, "b")
   end
+
+  # -- base refcounting + eviction (R2) ---------------------------------------
+
+  # Drives a base turnover (snap1 -> snap2) and then feeds refcounts against the
+  # superseded snap1 via report_base_refs/3, asserting that EvictSnapshot fires
+  # exactly once, and only when BOTH primed and session refcounts are zero.
+  defp turnover_to_snap2(builder, agent) do
+    # gen1 -> snap1.
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 1, image_ref: "imgA"}))
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap1"}, latest(agent, "w")) end)
+
+    # gen2 with a DIFFERENT image -> a new signature -> snap2, superseding snap1.
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 2, image_ref: "imgB"}))
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap2"}, latest(agent, "w")) end)
+  end
+
+  test "a superseded base is not evicted while sessions reference it, and evicts on drain" do
+    agent = start_recorder()
+    test_pid = self()
+
+    # Each build returns a snapshot ref derived from the image so gen1/gen2 differ.
+    build_fun = fn :fake_channel, req ->
+      ref = if req.image_ref == "imgA", do: "snap1", else: "snap2"
+      {:ok, resp(ref)}
+    end
+
+    evict_fun = fn :fake_channel, ref ->
+      send(test_pid, {:evicted, ref})
+      {:ok, %Embervm.Node.V1.EvictSnapshotResponse{}}
+    end
+
+    builder =
+      start_builder(
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        evict_fun: evict_fun
+      )
+
+    turnover_to_snap2(builder, agent)
+
+    # snap1 is now a tracked superseded base with unknown refcounts.
+    st = BaseBuilder.status(builder)
+    assert Map.has_key?(st.workloads["w"].base_refs, "snap1")
+
+    # Report primed:0 alone: sessions still unknown (nil) -> NOT evictable.
+    :ok = BaseBuilder.report_base_refs(builder, "snap1", primed: 0)
+    refute_receive {:evicted, "snap1"}, 100
+
+    # Report sessions:2 -> still referenced, NOT evicted.
+    :ok = BaseBuilder.report_base_refs(builder, "snap1", sessions: 2)
+    refute_receive {:evicted, "snap1"}, 100
+
+    # Sessions drain to 0 -> now both counts are known-and-zero -> evict fires.
+    :ok = BaseBuilder.report_base_refs(builder, "snap1", sessions: 0)
+    assert_receive {:evicted, "snap1"}, 1_000
+
+    # The ref is marked evicted and dropped from the turnover list.
+    st2 = BaseBuilder.status(builder)
+    assert st2.workloads["w"].base_refs["snap1"].evicted == true
+    refute "snap1" in st2.workloads["w"].superseded_refs
+  end
+
+  test "eviction fires only once even under repeated zero reports" do
+    agent = start_recorder()
+    test_pid = self()
+
+    build_fun = fn :fake_channel, req ->
+      ref = if req.image_ref == "imgA", do: "snap1", else: "snap2"
+      {:ok, resp(ref)}
+    end
+
+    evict_fun = fn :fake_channel, ref ->
+      send(test_pid, {:evicted, ref})
+      {:ok, %Embervm.Node.V1.EvictSnapshotResponse{}}
+    end
+
+    builder =
+      start_builder(
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        evict_fun: evict_fun
+      )
+
+    turnover_to_snap2(builder, agent)
+
+    :ok = BaseBuilder.report_base_refs(builder, "snap1", primed: 0, sessions: 0)
+    assert_receive {:evicted, "snap1"}, 1_000
+
+    # A duplicate zero report after eviction does not re-evict (evicted guard).
+    :ok = BaseBuilder.report_base_refs(builder, "snap1", primed: 0, sessions: 0)
+    refute_receive {:evicted, "snap1"}, 100
+  end
+
+  test "reporting refs for an unknown ref is a harmless no-op" do
+    agent = start_recorder()
+    builder = start_builder(status_writer: recording_status_writer(agent))
+
+    # No turnover has happened; snapX is not tracked. Must not crash or evict.
+    assert :ok = BaseBuilder.report_base_refs(builder, "snapX", primed: 0, sessions: 0)
+    assert Process.alive?(builder)
+  end
 end

--- a/projects/embervm/control/test/embervm/op_log/session_projection_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/session_projection_test.exs
@@ -1,0 +1,304 @@
+defmodule Embervm.OpLog.SessionProjectionTest do
+  @moduledoc """
+  Exercises the R2 session records, lineage projection, and retention discipline
+  on the SQLite op-log backend directly (each test opens its own GenServer over a
+  fresh temp file, so it can stop/restart the process to simulate crash recovery,
+  the same idiom as sqlite_test.exs). Covers:
+
+    * projection rebuild from a scripted session op sequence reproduces exact
+      session states (create -> invoke -> bank -> relight, and each terminal kind);
+    * the (principal, day) usage projection accumulates from session_invoked ops
+      identically to task compute (D12.1);
+    * retention never prunes a non-terminal session, prunes a terminal one past
+      the 7-day window;
+    * the ops-journal prefix marker never advances past a LIVE session's ops;
+    * a kill/restart rebuilds session state exactly from the durable projection.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.OpLog.Op
+  alias Embervm.OpLog.SQLite
+
+  setup do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "embervm_oplog_session_test_#{System.unique_integer([:positive, :monotonic])}.db"
+      )
+
+    on_exit(fn -> File.rm_rf!(path) end)
+    %{path: path}
+  end
+
+  defp start_server(path, extra_opts \\ []) do
+    opts = Keyword.merge([path: path, name: nil], extra_opts)
+    {:ok, pid} = SQLite.start_link(opts)
+    pid
+  end
+
+  defp created_op(session_id, principal, ts, extra \\ %{}) do
+    %Op{
+      kind: :session_created,
+      tenant: "t1",
+      principal: principal,
+      workload: "sandbox-session",
+      session_id: session_id,
+      ts: ts,
+      payload:
+        Map.merge(
+          %{
+            node_id: "node-4",
+            base_snapshot_ref: "base:sha256:abc",
+            base_digest: "sha256:abc",
+            token_sha256: "hash-#{session_id}",
+            expires_at: ts + 21_600_000
+          },
+          extra
+        )
+    }
+  end
+
+  defp session_by_id(server) do
+    {:ok, sessions} = SQLite.load_sessions(server)
+    Map.new(sessions, &{&1.session_id, &1})
+  end
+
+  test "a scripted create -> invoke -> bank -> relight sequence projects exact state", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, created_op("s-1", "p1", 100))
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :session_banked,
+        tenant: "t1",
+        principal: "p1",
+        workload: "sandbox-session",
+        session_id: "s-1",
+        ts: 200,
+        payload: %{
+          snapshot_ref: "sessions/s-1",
+          size_bytes: 2_147_483_648,
+          generation: 1,
+          parent_base_ref: "base:sha256:abc"
+        }
+      })
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :session_relit,
+        tenant: "t1",
+        principal: "p1",
+        workload: "sandbox-session",
+        session_id: "s-1",
+        ts: 300,
+        payload: %{snapshot_ref: "sessions/s-1", generation: 1, relight_ms: 420}
+      })
+
+    s = session_by_id(server)["s-1"]
+
+    # Relit -> running; lineage recorded from create; generation set at bank.
+    assert s.state == "running"
+    assert s.base_snapshot_ref == "base:sha256:abc"
+    assert s.base_digest == "sha256:abc"
+    assert s.generation == 1
+    assert s.snapshot_ref == "sessions/s-1"
+    assert s.snapshot_size_bytes == 2_147_483_648
+    assert s.token_sha256 == "hash-s-1"
+    assert s.created_at == 100
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "each terminal kind projects its terminal state and reason", %{path: path} do
+    server = start_server(path)
+
+    for {sid, kind, expected_state} <- [
+          {"s-exp", :session_expired, "expired"},
+          {"s-evi", :session_evicted, "evicted"},
+          {"s-des", :session_destroyed, "destroyed"},
+          {"s-fai", :session_failed, "failed"}
+        ] do
+      {:ok, _} = SQLite.append(server, created_op(sid, "p1", 100))
+
+      {:ok, _} =
+        SQLite.append(server, %Op{
+          kind: kind,
+          tenant: "t1",
+          principal: "p1",
+          workload: "sandbox-session",
+          session_id: sid,
+          ts: 500,
+          payload: %{reason: expected_state}
+        })
+
+      s = session_by_id(server)[sid]
+      assert s.state == expected_state
+      assert s.terminal_reason == expected_state
+    end
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "session_invoked accumulates the (principal, day) usage projection like a task", %{path: path} do
+    server = start_server(path)
+
+    day5 = 5 * 86_400_000
+    {:ok, _} = SQLite.append(server, created_op("s-u", "p1", day5))
+
+    stats = %{cpu_ms: 2000, peak_rss_mib: 1024, wall_ms: 4000}
+    usage = Map.merge(stats, Embervm.Usage.billed(stats))
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :session_invoked,
+        tenant: "t1",
+        principal: "p1",
+        workload: "sandbox-session",
+        session_id: "s-u",
+        ts: day5 + 10,
+        payload: %{status_code: 200, usage: usage}
+      })
+
+    {:ok, page} = SQLite.list_usage(server, since_day: 0)
+    row = Enum.find(page.items, &(&1.principal == "p1"))
+
+    # 2000ms -> 2.0 vcpu-s; (1024/1024)*(4000/1000) -> 4.0 gb-s.
+    assert row.vcpu_seconds == 2.0
+    assert row.gb_seconds == 4.0
+    assert row.task_count == 1
+
+    # last_invoke_at advanced; state unchanged by an invoke.
+    s = session_by_id(server)["s-u"]
+    assert s.last_invoke_at == day5 + 10
+    assert s.state == "running"
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "retention never prunes a non-terminal session and prunes a terminal one past the window", %{path: path} do
+    # retention_ms 7 days (default). now far past both sessions' updated_at.
+    server = start_server(path)
+
+    # Live session, old.
+    {:ok, _} = SQLite.append(server, created_op("s-live", "p1", 100))
+
+    # Terminal session, old.
+    {:ok, _} = SQLite.append(server, created_op("s-term", "p1", 100))
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :session_destroyed,
+        tenant: "t1",
+        principal: "p1",
+        workload: "sandbox-session",
+        session_id: "s-term",
+        ts: 200,
+        payload: %{reason: "destroyed"}
+      })
+
+    # now = 100 + 8 days: both rows are older than the 7-day retention, but only
+    # the terminal one is eligible.
+    eight_days = 8 * 24 * 60 * 60 * 1000
+    {:ok, res} = SQLite.compact(server, 100 + eight_days)
+    assert res.sessions_compacted == 1
+
+    ids = session_by_id(server) |> Map.keys() |> Enum.sort()
+    assert ids == ["s-live"]
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "the ops-journal marker never advances past a live session's ops", %{path: path} do
+    server = start_server(path, journal_horizon_ms: 0)
+
+    # A LIVE (running) session: its create op must pin the prefix.
+    {:ok, live_seq} = SQLite.append(server, created_op("s-live", "p1", 100))
+
+    # A standalone old audit op AFTER it (so the whole log would otherwise be
+    # compactable at horizon 0).
+    {:ok, _} = SQLite.append(server, %Op{kind: :denied, tenant: "t1", ts: 101, payload: %{}})
+
+    {:ok, res} = SQLite.compact(server, 10_000)
+
+    # The marker can only reach live_seq - 1 (the live session's create op is the
+    # smallest blocked seq).
+    assert res.compacted_through == live_seq - 1
+
+    # After the session terminates, the whole prefix becomes eligible.
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :session_destroyed,
+        tenant: "t1",
+        principal: "p1",
+        workload: "sandbox-session",
+        session_id: "s-live",
+        ts: 102,
+        payload: %{reason: "destroyed"}
+      })
+
+    {:ok, res2} = SQLite.compact(server, 10_000)
+    {:ok, max_seq} = SQLite.compacted_through(server)
+    assert res2.compacted_through == max_seq
+    assert max_seq >= live_seq
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "kill/restart rebuilds live and terminal session state from the projection", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, created_op("s-a", "p1", 100))
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :session_banked,
+        tenant: "t1",
+        principal: "p1",
+        workload: "sandbox-session",
+        session_id: "s-a",
+        ts: 200,
+        payload: %{snapshot_ref: "sessions/s-a", size_bytes: 1024, generation: 1}
+      })
+
+    {:ok, _} = SQLite.append(server, created_op("s-b", "p1", 300))
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :session_failed,
+        tenant: "t1",
+        principal: "p1",
+        workload: "sandbox-session",
+        session_id: "s-b",
+        ts: 400,
+        payload: %{reason: "snapshot_lost"}
+      })
+
+    :ok = GenServer.stop(server)
+
+    server2 = start_server(path)
+    by_id = session_by_id(server2)
+
+    assert by_id["s-a"].state == "banked"
+    assert by_id["s-a"].generation == 1
+    assert by_id["s-a"].snapshot_ref == "sessions/s-a"
+
+    assert by_id["s-b"].state == "failed"
+    assert by_id["s-b"].terminal_reason == "snapshot_lost"
+
+    :ok = GenServer.stop(server2)
+  end
+
+  test "a fresh DB reports session_id on session ops through read_from", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, created_op("s-r", "p1", 100))
+    {:ok, ops} = SQLite.read_from(server, 0)
+    created = Enum.find(ops, &(&1.kind == :session_created))
+
+    assert created.session_id == "s-r"
+    assert created.task_id == nil
+
+    :ok = GenServer.stop(server)
+  end
+end

--- a/projects/embervm/control/test/embervm/workload_watcher_test.exs
+++ b/projects/embervm/control/test/embervm/workload_watcher_test.exs
@@ -197,7 +197,8 @@ defmodule Embervm.WorkloadWatcherTest do
     table = unique_table()
     agent = start_recorder()
     base = start_base_recorder()
-    cr = valid_cr(%{"spec" => %{"class" => "session"}})
+    # `serving` is still reserved for a later rung (session became valid in R2).
+    cr = valid_cr(%{"spec" => %{"class" => "serving"}})
     lister = fn -> {:ok, [cr]} end
     watcher = start_watcher(lister, recording_status_writer(agent), table, base_seams(agent: base))
 
@@ -212,6 +213,106 @@ defmodule Embervm.WorkloadWatcherTest do
     assert Agent.get(base, & &1.reconciled) == []
     assert "semgrep" in Agent.get(base, & &1.forgotten)
 
+    assert Process.alive?(watcher)
+  end
+
+  # -- session class (R2) -----------------------------------------------------
+
+  # A valid session CR: an image source plus the required spec.session block.
+  defp session_cr(overrides \\ %{}) do
+    base = %{
+      "metadata" => %{"name" => "sandbox-session", "namespace" => "embervm", "generation" => 1},
+      "spec" => %{
+        "class" => "session",
+        "source" => %{"image" => %{"ref" => "sandbox", "port" => 1027}},
+        "resources" => %{"vcpus" => 1, "memMib" => 2048},
+        "concurrency" => %{"floor" => 1, "cap" => 4},
+        "session" => %{
+          "idleBankSeconds" => 120,
+          "maxLifetimeSeconds" => 21_600,
+          "maxSessions" => 8,
+          "invokeQueueCap" => 4
+        }
+      }
+    }
+
+    deep_merge(base, overrides)
+  end
+
+  test "session class: a valid session CR is cataloged with class and session config" do
+    table = unique_table()
+    agent = start_recorder()
+    lister = fn -> {:ok, [session_cr()]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert {:ok, entry} = WorkloadCatalog.fetch(table, "sandbox-session")
+    assert entry.class == "session"
+    assert entry.cap == 4
+    assert entry.floor == 1
+    assert entry.session.idle_bank_seconds == 120
+    assert entry.session.max_lifetime_seconds == 21_600
+    # bankedTtlSeconds omitted -> defaults to maxLifetimeSeconds.
+    assert entry.session.banked_ttl_seconds == 21_600
+    assert entry.session.max_sessions == 8
+    assert entry.session.invoke_queue_cap == 4
+
+    # A valid CR: the watcher writes only observedGeneration (no conditions).
+    assert {_ns, "sandbox-session", status_map} = ready_status(recorded_calls(agent), "sandbox-session")
+    assert status_map["observedGeneration"] == 1
+    refute Map.has_key?(status_map, "conditions")
+  end
+
+  test "session class: session block defaults apply when fields are omitted" do
+    table = unique_table()
+    agent = start_recorder()
+    # An empty session block: every numeric field falls back to its default.
+    # (deep_merge would keep the populated fields, so replace the block outright.)
+    cr = put_in(session_cr(), ["spec", "session"], %{})
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert {:ok, entry} = WorkloadCatalog.fetch(table, "sandbox-session")
+    assert entry.session.idle_bank_seconds == 300
+    assert entry.session.max_lifetime_seconds == 86_400
+    assert entry.session.banked_ttl_seconds == 86_400
+    assert entry.session.max_sessions == 16
+    assert entry.session.invoke_queue_cap == 4
+  end
+
+  test "session class missing spec.session is Ready=False/SessionSpecMissing, not cataloged" do
+    table = unique_table()
+    agent = start_recorder()
+    cr = session_cr()
+    cr = Map.update!(cr, "spec", &Map.delete(&1, "session"))
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert WorkloadCatalog.fetch(table, "sandbox-session") == :error
+
+    assert {_ns, "sandbox-session", status_map} = ready_status(recorded_calls(agent), "sandbox-session")
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "SessionSpecMissing"}] = status_map["conditions"]
+    assert Process.alive?(watcher)
+  end
+
+  test "task class carrying a spec.session block is Ready=False/SessionSpecUnexpected" do
+    table = unique_table()
+    agent = start_recorder()
+    cr = valid_cr(%{"spec" => %{"session" => %{"idleBankSeconds" => 120}}})
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert WorkloadCatalog.fetch(table, "semgrep") == :error
+
+    assert {_ns, "semgrep", status_map} = ready_status(recorded_calls(agent), "semgrep")
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "SessionSpecUnexpected"}] = status_map["conditions"]
     assert Process.alive?(watcher)
   end
 

--- a/projects/embervm/crd/samples/workload-session.yaml
+++ b/projects/embervm/crd/samples/workload-session.yaml
@@ -1,0 +1,42 @@
+# Sample session-class Workload (R2, ADR embervm/001). A session is a long-lived
+# logical sandbox whose in-VM state (files, variables, a warm interpreter)
+# persists across invocations: it is banked (suspended to a node snapshot) when
+# idle and relit on the next request. This is the definition surface only; a
+# session INSTANCE is execution state in the op-log, never a Kubernetes object.
+# For the session class, concurrency.cap is max LIVE session VMs and
+# concurrency.floor is the pristine pool kept warm for fast create. Living
+# documentation of the session surface, mirroring workload-echo.yaml. Not a
+# production deploy (those live under projects/embervm/deploy/).
+apiVersion: embervm.dev/v1alpha1
+kind: Workload
+metadata:
+  name: sandbox-session
+  namespace: embervm
+spec:
+  class: session
+  source:
+    image:
+      ref: ghcr.io/jomcgi/homelab/projects/embervm/guests/sandbox:latest
+      port: 1027
+      readyPath: /shim/ready
+      invokePath: /invoke
+  resources:
+    vcpus: 1
+    memMib: 2048
+  concurrency:
+    # floor: pristine VMs kept warm for fast session create.
+    floor: 1
+    # cap: max live session VMs (banked sessions hold only disk).
+    cap: 4
+  session:
+    # Bank an idle session (no in-flight, no queued invoke) after 2 minutes.
+    idleBankSeconds: 120
+    # Version-convergence bound: a session rides its birth base until this
+    # expires, then the next invoke 410s onto the current base.
+    maxLifetimeSeconds: 21600
+    # GC a banked snapshot untouched this long (here, the full lifetime).
+    bankedTtlSeconds: 21600
+    # Max sessions (live + banked) for this workload.
+    maxSessions: 8
+    # Max invokes queued behind the one in-flight invoke per session.
+    invokeQueueCap: 4

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.35
+      targetRevision: 0.1.36
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/proto/embervm/node/v1/fakenode/main.go
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/main.go
@@ -62,11 +62,66 @@ func (fakeServer) Destroy(_ context.Context, _ *nodev1.DestroyRequest) (*nodev1.
 	return &nodev1.DestroyResponse{}, nil
 }
 
+// SessionAssign echoes the request body and path back like Assign, but proves
+// deliver-without-destroy by echoing the session_id it was handed into a
+// response header the client asserts on (the VM "survives", so the session id
+// is still meaningful). suspect is left false (a clean round trip).
+func (fakeServer) SessionAssign(_ context.Context, req *nodev1.SessionAssignRequest) (*nodev1.SessionAssignResponse, error) {
+	return &nodev1.SessionAssignResponse{
+		Response: &nodev1.GuestResponse{
+			StatusCode: 200,
+			Headers: map[string]string{
+				"x-echo-path":  req.GetRequest().GetPath(),
+				"x-session-id": req.GetSessionId(),
+			},
+			Body: req.GetRequest().GetBody(),
+		},
+		Usage:   &nodev1.UsageStats{CpuMs: 4, PeakRssMib: 5, WallMs: 6},
+		Suspect: false,
+	}, nil
+}
+
+// Bank derives a snapshot_ref from the session_id so the client can prove the
+// request field crossed the wire, and returns a fixed size.
+func (fakeServer) Bank(_ context.Context, req *nodev1.BankRequest) (*nodev1.BankResponse, error) {
+	return &nodev1.BankResponse{
+		SnapshotRef: "sessions/" + req.GetSessionId(),
+		SizeBytes:   2048,
+	}, nil
+}
+
+// Relight derives a vm_id from the snapshot_ref so the client can prove the
+// restore request crossed the wire intact.
+func (fakeServer) Relight(_ context.Context, req *nodev1.RelightRequest) (*nodev1.RelightResponse, error) {
+	return &nodev1.RelightResponse{VmId: "vm:" + req.GetSnapshotRef()}, nil
+}
+
+// EvictSnapshot is idempotent and returns an empty response for any ref.
+func (fakeServer) EvictSnapshot(_ context.Context, _ *nodev1.EvictSnapshotRequest) (*nodev1.EvictSnapshotResponse, error) {
+	return &nodev1.EvictSnapshotResponse{}, nil
+}
+
 func (fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusRequest) (*nodev1.NodeStatus, error) {
 	return &nodev1.NodeStatus{
 		NodeId:     req.GetNodeId(),
 		LiveVms:    1,
 		MaxLiveVms: 10,
+		// Session facts (R2): deterministic, so the client can assert the new
+		// repeated/scalar status fields round-trip.
+		SessionVms: []*nodev1.SessionVm{
+			{VmId: "vm-s1", SessionId: "s-sess1", Workload: "sandbox-session"},
+		},
+		SessionSnapshots: []*nodev1.SessionSnapshot{
+			{
+				SnapshotRef:     "sessions/s-sess2",
+				SessionId:       "s-sess2",
+				Workload:        "sandbox-session",
+				SizeBytes:       4096,
+				CreatedAtUnixMs: 1_700_000_000_000,
+			},
+		},
+		SnapshotDiskFreeBytes: 9_000_000_000,
+		SnapshotDiskUsedBytes: 1_000_000_000,
 	}, nil
 }
 

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -92,6 +92,58 @@ service NodeService {
   // plane startup reconciliation (existing base snapshots + parked VMs are
   // reported so the control plane reconciles rather than rebuilding).
   rpc GetNodeStatus(GetNodeStatusRequest) returns (NodeStatus);
+
+  // -- Session verbs (R2) ----------------------------------------------------
+  //
+  // These four verbs are the stateful-session lifecycle vocabulary, ADDITIVE to
+  // the task-class contract above (Assign, Prime, Destroy are byte-for-byte
+  // unchanged). A session is a long-lived logical sandbox whose in-VM state
+  // survives across invocations: SessionAssign delivers a request WITHOUT
+  // destroying the VM (the opposite of Assign's destroy tail); Bank pauses and
+  // snapshots the VM to node disk and destroys it; Relight restores a VM from a
+  // session snapshot; EvictSnapshot reclaims the snapshot's disk. Refs stay
+  // opaque strings exactly as elsewhere: no snapshot file path, no Firecracker
+  // concept crosses this seam. Session VMs count against max_live_vms like any
+  // other live VM. Concurrency (one in-flight invoke per session; caps across
+  // sessions) is owned by the control plane, not the daemon; the daemon's
+  // per-vm guard is only a backstop.
+
+  // SessionAssign delivers exactly one HTTP-semantics request (same GuestRequest
+  // message, same 8 MiB body cap) to a LIVE session vm_id over vsock and returns
+  // the guest response plus usage stats. Unlike Assign, the VM SURVIVES: this is
+  // the deliver-without-destroy verb sessions are built on. FAILED_PRECONDITION
+  // on an unknown vm_id, a task-class vm_id (single-use, not a session), or a
+  // vm_id in the middle of a Bank. DEADLINE_EXCEEDED on a guest timeout leaves
+  // the VM alive but flagged suspect in the response (suspect=true); the control
+  // plane decides whether to destroy it, because a session guest in an unknown
+  // mid-request state must not silently accrete more state.
+  rpc SessionAssign(SessionAssignRequest) returns (SessionAssignResponse);
+
+  // Bank pauses a live session VM, writes a full snapshot (memory image + rootfs
+  // delta, the same self-contained bundle format bases use), destroys the VM,
+  // and returns the opaque snapshot_ref plus its size. It is how an idle session
+  // releases live capacity while retaining state on disk. FAILED_PRECONDITION if
+  // a SessionAssign is in flight on that vm_id (the control plane serializes
+  // anyway; this is the daemon backstop), or if the vm_id is unknown or
+  // task-class. The snapshot_ref is a fact the control plane records and later
+  // passes to Relight or EvictSnapshot.
+  rpc Bank(BankRequest) returns (BankResponse);
+
+  // Relight restores a VM from a session snapshot_ref (the deliver-without-
+  // destroy counterpart of Prime for sessions), waits for guest readiness (the
+  // same vsockhttp WaitReady mechanics as Prime), and returns a fresh vm_id.
+  // FAILED_PRECONDITION if the ref is unknown or unrestorable. On a failed
+  // restore the snapshot is NEVER deleted (a lost session must surface loudly,
+  // not silently relight as a blank VM): the control plane decides whether to
+  // retry or fail the session.
+  rpc Relight(RelightRequest) returns (RelightResponse);
+
+  // EvictSnapshot deletes a session snapshot bundle from node disk to reclaim
+  // capacity. Idempotent: an unknown ref returns OK (the desired end-state, gone,
+  // already holds). Refuses (FAILED_PRECONDITION) while a live VM was relit from
+  // that ref and still runs. This is the ADR embervm/003 eviction verb landed
+  // early, shaped so base eviction later reuses it unchanged.
+  rpc EvictSnapshot(EvictSnapshotRequest) returns (EvictSnapshotResponse);
 }
 
 // Trace carries the cross-cutting identifiers every RPC threads for tracing and
@@ -254,6 +306,77 @@ message DestroyRequest {
 
 message DestroyResponse {}
 
+// ---- Session verbs (R2) ----------------------------------------------------
+
+// SessionAssignRequest is Assign's deliver-without-destroy sibling: same
+// GuestRequest envelope and timeout semantics, but the vm_id names a LIVE
+// session VM the daemon must leave running after the response. session_id is
+// opaque to the daemon (it stores and echoes it in status so control-plane
+// adoption can rebind a live VM to its session after a restart); the daemon
+// derives no behavior from it.
+message SessionAssignRequest {
+  Trace trace = 1;
+  string vm_id = 2;
+  GuestRequest request = 3;
+  // timeout_ms bounds the guest round-trip. On expiry the daemon returns
+  // DEADLINE_EXCEEDED and leaves the VM ALIVE (unlike Assign), flagging it
+  // suspect in the response so the control plane can decide to destroy it.
+  uint32 timeout_ms = 4;
+  // session_id is the control plane's opaque session identity, echoed in
+  // NodeStatus.session_vms so a restarted control plane adopts rather than
+  // orphans. The daemon never interprets it.
+  string session_id = 5;
+}
+
+message SessionAssignResponse {
+  GuestResponse response = 1;
+  UsageStats usage = 2;
+  // suspect is set true when the guest round-trip hit DEADLINE_EXCEEDED (or the
+  // vsock transport otherwise faulted) but the VM was left alive; the control
+  // plane reads it to decide whether to destroy the session VM. False on a
+  // clean response.
+  bool suspect = 3;
+}
+
+// BankRequest pauses, snapshots, and destroys a live session VM. session_id is
+// carried (opaque to the daemon) so the produced snapshot's inventory entry can
+// be tied back to its session for adoption.
+message BankRequest {
+  Trace trace = 1;
+  string vm_id = 2;
+  string session_id = 3;
+}
+
+message BankResponse {
+  // snapshot_ref is the OPAQUE handle to the banked session snapshot bundle on
+  // node disk. The control plane records it and later passes it to Relight or
+  // EvictSnapshot. NOT a file path.
+  string snapshot_ref = 1;
+  uint64 size_bytes = 2;
+}
+
+// RelightRequest restores a VM from a session snapshot. session_id is opaque to
+// the daemon, echoed in NodeStatus.session_vms for adoption once the VM is live.
+message RelightRequest {
+  Trace trace = 1;
+  string snapshot_ref = 2;
+  string session_id = 3;
+}
+
+message RelightResponse {
+  // vm_id names the freshly restored, ready session VM. Opaque; the control
+  // plane holds it and passes it to SessionAssign, Bank, or Destroy.
+  string vm_id = 1;
+}
+
+// EvictSnapshotRequest deletes one session snapshot bundle from node disk.
+message EvictSnapshotRequest {
+  Trace trace = 1;
+  string snapshot_ref = 2;
+}
+
+message EvictSnapshotResponse {}
+
 // ---- Node status -----------------------------------------------------------
 
 message WatchNodeRequest {
@@ -299,6 +422,32 @@ enum BaseBuildState {
   BASE_BUILD_STATE_FAILED = 4;    // last BuildBase failed (see build_error)
 }
 
+// SessionVm is one LIVE session VM the node currently holds: the daemon reports
+// it (with the opaque session_id it was given at SessionAssign/Relight) so a
+// restarted control plane ADOPTS the running session instead of orphaning it,
+// exactly the primed-pool adoption fix (PR #3517) applied to session state.
+// Session VMs are reported here and NOT in WorkloadCapacity.primed_vm_ids (a
+// session VM must never be adopted into the single-use task pool).
+message SessionVm {
+  string vm_id = 1;
+  string session_id = 2;
+  string workload = 3;
+}
+
+// SessionSnapshot is one BANKED session snapshot bundle on node disk. The daemon
+// rescans its sessions snapshot dir on start and reports what it finds so the
+// control plane reconciles banked-session inventory from node truth (a banked
+// session survives a daemon restart; a live one does not). size_bytes and
+// created_at_unix_ms feed disk-watermark eviction and TTL GC at the control
+// plane.
+message SessionSnapshot {
+  string snapshot_ref = 1;
+  string session_id = 2;
+  string workload = 3;
+  uint64 size_bytes = 4;
+  int64 created_at_unix_ms = 5;
+}
+
 // NodeStatus is the whole capacity fact set: per-workload primed slots and base
 // states, node-level memory/cpu headroom, and the draining flag. A draining
 // daemon reports draining=true and the control plane stops new assignments
@@ -318,4 +467,22 @@ message NodeStatus {
   // build_error carries the last BuildBase failure string for any workload in
   // BASE_BUILD_STATE_FAILED, surfaced into the Workload CR condition message.
   string build_error = 8;
+
+  // -- Session facts (R2, additive) ------------------------------------------
+  // These four fields let a restarted control plane adopt session state (live
+  // VMs and banked snapshots) from node truth rather than orphaning it, and let
+  // the eviction/watermark policy see snapshot-disk pressure. All are optional/
+  // repeated and wire-compatible with a daemon that never sets them.
+
+  // session_vms lists every LIVE session VM this node holds. Disjoint from every
+  // WorkloadCapacity.primed_vm_ids (a session VM is never in the task pool).
+  repeated SessionVm session_vms = 9;
+  // session_snapshots is the banked-snapshot inventory scanned from the sessions
+  // snapshot dir on disk. The source of truth for what banked sessions survive.
+  repeated SessionSnapshot session_snapshots = 10;
+  // snapshot_disk_free_bytes / snapshot_disk_used_bytes report the sessions
+  // snapshot dir's filesystem usage so the control plane's LRU eviction can fire
+  // on a low-watermark crossing and the watermark alert can trip.
+  uint64 snapshot_disk_free_bytes = 11;
+  uint64 snapshot_disk_used_bytes = 12;
 }

--- a/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
+++ b/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
@@ -16,14 +16,18 @@ defmodule Embervm.NodeRoundtripTest do
 
   alias Embervm.Node.V1.{
     AssignRequest,
+    BankRequest,
     BuildBaseRequest,
     DestroyRequest,
+    EvictSnapshotRequest,
     GetNodeStatusRequest,
     GuestRequest,
     NodeService,
     NodeStatus,
     PrimeRequest,
+    RelightRequest,
     ResourceSpec,
+    SessionAssignRequest,
     Trace,
     WatchNodeRequest
   }
@@ -76,6 +80,63 @@ defmodule Embervm.NodeRoundtripTest do
     {:ok, ns} = NodeService.Stub.get_node_status(ch, %GetNodeStatusRequest{node_id: "node-4"})
     assert ns.node_id == "node-4"
     assert ns.max_live_vms == 10
+  end
+
+  test "session verbs round-trip across the wire (R2 additive contract)", %{channel: ch} do
+    # SessionAssign: deliver-without-destroy. The fake echoes the body/path AND
+    # the session_id (into a header) so we prove the new session_id field crossed.
+    {:ok, sa} =
+      NodeService.Stub.session_assign(ch, %SessionAssignRequest{
+        vm_id: "vm-s1",
+        request: %GuestRequest{method: "POST", path: "/invoke", body: "state"},
+        timeout_ms: 1_000,
+        session_id: "s-abc"
+      })
+
+    assert sa.response.status_code == 200
+    assert sa.response.body == "state"
+    assert sa.response.headers["x-echo-path"] == "/invoke"
+    assert sa.response.headers["x-session-id"] == "s-abc"
+    assert sa.usage.wall_ms == 6
+    assert sa.suspect == false
+
+    # Bank: derives the snapshot_ref from the session_id.
+    {:ok, bank} = NodeService.Stub.bank(ch, %BankRequest{vm_id: "vm-s1", session_id: "s-abc"})
+    assert bank.snapshot_ref == "sessions/s-abc"
+    assert bank.size_bytes == 2048
+
+    # Relight: derives the vm_id from the snapshot_ref.
+    {:ok, relit} =
+      NodeService.Stub.relight(ch, %RelightRequest{
+        snapshot_ref: "sessions/s-abc",
+        session_id: "s-abc"
+      })
+
+    assert relit.vm_id == "vm:sessions/s-abc"
+
+    # EvictSnapshot: idempotent, returns an empty response.
+    assert {:ok, _} =
+             NodeService.Stub.evict_snapshot(ch, %EvictSnapshotRequest{
+               snapshot_ref: "sessions/s-abc"
+             })
+  end
+
+  test "NodeStatus reports session facts (R2 additive fields)", %{channel: ch} do
+    {:ok, ns} = NodeService.Stub.get_node_status(ch, %GetNodeStatusRequest{node_id: "node-4"})
+
+    assert [vm] = ns.session_vms
+    assert vm.vm_id == "vm-s1"
+    assert vm.session_id == "s-sess1"
+    assert vm.workload == "sandbox-session"
+
+    assert [snap] = ns.session_snapshots
+    assert snap.snapshot_ref == "sessions/s-sess2"
+    assert snap.session_id == "s-sess2"
+    assert snap.size_bytes == 4096
+    assert snap.created_at_unix_ms == 1_700_000_000_000
+
+    assert ns.snapshot_disk_free_bytes == 9_000_000_000
+    assert ns.snapshot_disk_used_bytes == 1_000_000_000
   end
 
   test "WatchNode server-streams heartbeats in order", %{channel: ch} do


### PR DESCRIPTION
**PR-1 (contract layer) of EmberVM R2 Sessions** (`docs/plans/2026-07-15-embervm-r2-sessions-spec-and-plan.md`, Tasks 1-3). Additive, NO behavior change: nothing calls the new session verbs yet. Built by an Opus implementer, reviewed clean by an Opus reviewer (no correctness/migration/refcount/proto issues).

## What
- **Task 1 (proto):** additive `SessionAssign`/`Bank`/`Relight`/`EvictSnapshot` RPCs (deliver-without-destroy / pause-snapshot-destroy / restore / idempotent-delete) + `NodeStatus` session facts (fields 9-12). Go+Elixir stubs regenerated; fakenode + roundtrip test extended. `Assign` and all R0/R1 messages byte-for-byte unchanged.
- **Task 2 (op-log):** 8 `session_*` op kinds; `ops.session_id` (guarded ALTER-after-DDL); `sessions` projection table with full lineage schema (`base_snapshot_ref, base_digest, generation, snapshot_ref, token_sha256, ...`); write-through discipline; `session_invoked` carries usage only + upserts `(principal,day)` in the same txn; retention prunes terminal sessions past 7d, the compaction marker never passes a live session's ops (R1 property extended). ETF payloads (D-R1.2.1).
- **Task 3 (CRD):** `class: session` accepted with a required `spec.session` block (idleBank/maxLifetime/bankedTtl/maxSessions/invokeQueueCap); `status.sessions {live,banked}` + `SESSIONS` printer column; BaseBuilder refcounting so a superseded base is destroyed only at zero primed VMs AND zero non-terminal sessions (fail-safe: unknown counts never evict). Sample session CR.

## Decisions (DECISIONS.md D-R2.0.1-4, flagged for review)
session_id as an Op-struct field; `session_created` projects to `running`; SESSIONS column backed by a `sessionsSummary` string; base eviction a fed-refcount seam wired in PR-4.

Bump embervm 0.1.35 -> 0.1.36. No local test loop; Elixir/Go/proto verified in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)