### PR TITLE
feat(embervm): R2 PR-3 session lifecycle core (store, FSM, tokens, manager, API)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -500,3 +500,33 @@ calls the verbs yet; daemon mechanics only). Flagged for post-impl review.
   VMs are tracked in a SEPARATE `sessionRegistry` (never the task `vmRegistry`) and
   reported only in `NodeStatus.session_vms`, never in any `primed_vm_ids`. This is
   the isolation invariant: a session VM can never be adopted into the task pool.
+
+## R2 Phase 1: lifecycle core (PR-3, embervm 0.1.38)
+
+Tasks 5-6 (SessionStore/FSM/tokens + SessionManager/create/API) choices where the
+plan was silent. Flagged for post-impl review.
+
+### D-R2.2.1 Primed-VM claim goes through a new Dispatcher.claim/3 (single-writer inventory)
+- Create claims a primed pristine VM via a new `Dispatcher.claim/3` that atomically
+  pops a vm_id from the `{node, workload}` inventory (reusing `reserve_vm`),
+  serialized through the dispatcher, so a session claim and a task dispatch can never
+  pop the same single-use VM. On a claim miss SessionManager Primes inline (create
+  latency is not the per-invoke hot path). Chosen over reaching into the dispatcher's
+  private inventory (which would break the single-writer invariant).
+
+### D-R2.2.2 Placement is inline (first-ready-node-with-budget) until PR-4
+- SessionManager picks a node inline with a minimal first-ready-with-budget choice.
+  `SessionPlacement` (rendezvous hash) is PR-4/Task 8 with the same
+  `workload -> {node, snapshot_ref}` interface, so the swap will not touch create.
+
+### D-R2.2.3 session_invoked is a non-FSM write (record_invoke), not an FSM edge
+- `SessionStore.record_invoke/3` is running->running (rejects non-running) and charges
+  the usage projection (D12.1) like tasks, rather than forcing an FSM edge for every
+  invoke. An invoke is not a lifecycle transition; the FSM stays about bank/relight.
+
+### D-R2.2.4 Invoke on a running-but-processless session is 409 not_ready (PR-4 heals it)
+- A `running` session whose GenServer is absent (a control-plane-restart limbo that
+  PR-4 adoption will heal) returns `{:not_ready, :running}` -> 409, since no adoption
+  path exists yet in PR-3 to rebind the process. `base_digest` at create is the image
+  ref placeholder; PR-4 threads the BaseBuilder-resolved digest when relight lineage
+  needs it.

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.37
+version: 0.1.38

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -119,6 +119,22 @@ defmodule Embervm.Application do
       # during downtime are skipped, not replayed. After the watcher (reads the
       # catalog's triggers) and TaskStore (submits into it).
       Embervm.Trigger.Cron,
+      # Session lifecycle (R2). The SessionStore (ETS hot set over the durable
+      # `sessions` projection, rebuilt on boot) comes first; the SessionRegistry
+      # (session_id -> live Embervm.Session pid) and the SessionSupervisor
+      # (DynamicSupervisor for the per-live-session processes) next; the
+      # SessionManager (create/destroy/route brain) last, since it starts children
+      # into the supervisor and reads the store/registry. Placed AFTER Metering
+      # (create reads the quota table + budgets), the Dispatcher (create CLAIMs a
+      # primed VM from its inventory), and NodeChannel (the SessionAssign channel),
+      # and BEFORE the Router (its session handlers call the manager + store). Under
+      # :rest_for_one a SessionStore restart bounces the manager and Router, which
+      # rebuild from the durable projection. With no node wired, create denies
+      # :no_capacity and nothing runs, exactly like the dispatcher in R0.
+      {Embervm.SessionStore, [on_metered: &Embervm.Metering.on_metered/1]},
+      {Registry, keys: :unique, name: Embervm.SessionRegistry},
+      {DynamicSupervisor, strategy: :one_for_one, name: Embervm.SessionSupervisor},
+      {Embervm.SessionManager, session_opts: session_opts()},
       # The op-log sweeper (ADR embervm/002): scheduled bounded-batch compaction of
       # the durable projection tables + ops-journal prefix. Placed LATE, right before
       # Bandit: it depends ONLY on the op-log (which starts early), so under
@@ -254,6 +270,11 @@ defmodule Embervm.Application do
   end
 
   defp pool_opts, do: []
+
+  # Extra opts threaded into every Embervm.Session the SessionManager starts. Empty
+  # in production (the session process uses its real NodeChannel/SessionAssign
+  # defaults); tests inject fake daemon seams here.
+  defp session_opts, do: []
 
   defp queue_depth_cap do
     case trimmed_env("EMBERVM_QUEUE_DEPTH_CAP") do

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -196,6 +196,20 @@ defmodule Embervm.Dispatcher do
   end
 
   @doc """
+  Atomically claims one primed vm_id from `{node_id, workload}` inventory for a
+  session create (R2), removing it from the pool exactly as a warm dispatch does:
+  the vm_id is single-use, so removing it the instant it is committed to a session
+  is the same destroy-on-assign accounting a task claim gets. Returns
+  `{:ok, vm_id}` on a hit, or `:miss` when no primed VM is parked for that
+  `{node, workload}` (the caller then Primes one itself). Serialized through this
+  GenServer so a session claim and a task dispatch can never pop the same VM.
+  """
+  @spec claim(GenServer.server(), String.t(), String.t()) :: {:ok, String.t()} | :miss
+  def claim(server \\ __MODULE__, node_id, workload) do
+    GenServer.call(server, {:claim, node_id, workload})
+  end
+
+  @doc """
   Runs one backlog reconcile synchronously (the same code the periodic sweep
   runs) and returns after it plus the drain it triggers complete. Tests drive
   recovery/reassign paths through this deterministically with `start_sweep:
@@ -286,6 +300,13 @@ defmodule Embervm.Dispatcher do
 
   def handle_call(:sweep, _from, state) do
     {:reply, :ok, run_sweep(state)}
+  end
+
+  def handle_call({:claim, node_id, wl}, _from, state) do
+    case reserve_vm(state, node_id, wl, :warm) do
+      {new_state, vm_id} when is_binary(vm_id) -> {:reply, {:ok, vm_id}, new_state}
+      {new_state, nil} -> {:reply, :miss, new_state}
+    end
   end
 
   @impl true

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -90,6 +90,28 @@ defmodule Embervm.Router do
     handle_redrive(conn, id)
   end
 
+  # -- session routes (R2, front-end only; no placement logic here) ----------
+
+  post "/v1/workloads/:name/sessions" do
+    handle_create_session(conn, name)
+  end
+
+  get "/v1/workloads/:name/sessions" do
+    handle_list_sessions(conn, name)
+  end
+
+  post "/v1/sessions/:id/invoke" do
+    handle_session_invoke(conn, id)
+  end
+
+  get "/v1/sessions/:id" do
+    handle_get_session(conn, id)
+  end
+
+  delete "/v1/sessions/:id" do
+    handle_destroy_session(conn, id)
+  end
+
   match _ do
     send_resp(conn, 404, "")
   end
@@ -98,9 +120,30 @@ defmodule Embervm.Router do
 
   defp fetch_query(conn, _opts), do: fetch_query_params(conn)
 
-  # Auth is scoped to /v1: /healthz stays open for the kubelet probes.
-  defp authenticate(%Plug.Conn{path_info: ["v1" | _]} = conn, _opts), do: do_authenticate(conn)
+  # Auth is scoped to /v1: /healthz stays open for the kubelet probes. The session
+  # routes that take a SESSION token (invoke, and the session-token-or-management
+  # GET) authenticate in their handler, not here, because the bearer token they
+  # carry is a per-session capability, not a ServiceAccount token TokenReview would
+  # recognize. Running management auth on them would 401 every valid session token.
+  # So this plug runs management auth on every /v1 path EXCEPT those, which
+  # `session_token_route?/1` names explicitly (a closed allow-list, not a prefix,
+  # so a new management route is never accidentally opened).
+  defp authenticate(%Plug.Conn{path_info: ["v1" | _]} = conn, _opts) do
+    if session_token_route?(conn), do: conn, else: do_authenticate(conn)
+  end
+
   defp authenticate(conn, _opts), do: conn
+
+  # The routes whose bearer token is a SESSION token (verified in-handler against
+  # Embervm.SessionStore), NOT a management ServiceAccount token: POST
+  # /v1/sessions/:id/invoke (session token ONLY) and GET /v1/sessions/:id
+  # (management OR session token). Matched structurally on path_info so a query
+  # string or trailing content cannot smuggle a management route past the gate.
+  defp session_token_route?(%Plug.Conn{method: "POST", path_info: ["v1", "sessions", _id, "invoke"]}),
+    do: true
+
+  defp session_token_route?(%Plug.Conn{method: "GET", path_info: ["v1", "sessions", _id]}), do: true
+  defp session_token_route?(_conn), do: false
 
   defp do_authenticate(conn) do
     authenticator = Application.get_env(:embervm, :authenticator, Embervm.Auth)
@@ -461,6 +504,254 @@ defmodule Embervm.Router do
         send_json(conn, 500, %{error: "redrive failed", task_id: task_id, retryable: true})
     end
   end
+
+  # -- session handlers (R2) -------------------------------------------------
+
+  # POST /v1/workloads/:name/sessions (management auth). Delegates to the
+  # SessionManager, which owns capacity/quota/placement/claim. 201 with the token
+  # (returned ONCE), 429 for a capacity/quota denial, 403 for a class mismatch or
+  # unknown workload, 500 for an internal failure.
+  defp handle_create_session(conn, workload) do
+    principal = conn.assigns.principal
+
+    case session_manager().create(session_manager_server(), workload, principal) do
+      {:ok, created} ->
+        send_json(conn, 201, %{
+          session_id: created.session_id,
+          session_token: created.token,
+          expires_at: created.expires_at,
+          base_digest: created.base_digest,
+          state: to_string(Map.get(created, :state, :running))
+        })
+
+      {:error, {:denied, reason}} ->
+        create_denial(conn, workload, reason)
+
+      {:error, reason} ->
+        Logger.error("embervm create session failed: #{inspect(reason)}")
+        send_json(conn, 500, %{error: "create session failed", workload: workload, retryable: true})
+    end
+  end
+
+  # Structured, distinguishable create denials: capacity is 429 (retryable, the
+  # caller may retry when a session frees), class/workload errors are 403/404
+  # (non-retryable, the request is wrong). The reason string is machine-readable.
+  defp create_denial(conn, workload, reason) do
+    case reason do
+      r when r in [:session_cap, :workload_cap, :quota, :no_capacity] ->
+        send_json(conn, 429, %{
+          error: "session create denied",
+          reason: to_string(r),
+          workload: workload,
+          retryable: true
+        })
+
+      :unknown_workload ->
+        send_json(conn, 404, %{error: "unknown workload", reason: "unknown_workload", workload: workload, retryable: false})
+
+      :not_session_class ->
+        send_json(conn, 403, %{
+          error: "workload is not class session",
+          reason: "not_session_class",
+          workload: workload,
+          retryable: false
+        })
+
+      other ->
+        send_json(conn, 500, %{error: "session create failed", reason: inspect(other), workload: workload, retryable: true})
+    end
+  end
+
+  # GET /v1/workloads/:name/sessions (management auth): paged listing.
+  defp handle_list_sessions(conn, workload) do
+    limit = conn |> int_param("limit", 50) |> clamp(1, 500)
+    offset = conn |> int_param("offset", 0) |> max(0)
+
+    {:ok, page} = session_store().list(session_store_server(), workload, limit: limit, offset: offset)
+
+    send_json(conn, 200, %{
+      workload: workload,
+      items: Enum.map(page.items, &session_view/1),
+      total: page.total,
+      limit: page.limit,
+      offset: page.offset
+    })
+  end
+
+  # POST /v1/sessions/:id/invoke (SESSION TOKEN auth ONLY). The bearer token must
+  # authenticate THIS session id (a management token is rejected: it is not a
+  # session token, so the hash compare fails). Proxies the guest request under the
+  # task-envelope allow-list + 8 MiB cap via the SessionManager, and returns the
+  # guest response VERBATIM including headers.
+  defp handle_session_invoke(conn, session_id) do
+    with {:ok, token} <- bearer_token(conn),
+         {:ok, _session} <- verify_session_token(session_id, token) do
+      proxy_invoke(conn, session_id)
+    else
+      {:error, :no_token} ->
+        halt_json(conn, 401, %{error: "missing session token", retryable: false})
+
+      {:error, :terminal} ->
+        # A valid token on a terminal session: 410 with the recorded reason.
+        session_gone(conn, session_id)
+
+      {:error, _} ->
+        halt_json(conn, 403, %{error: "invalid session token", session_id: session_id, retryable: false})
+    end
+  end
+
+  defp proxy_invoke(conn, session_id) do
+    case read_capped_body(conn) do
+      {:ok, body, conn} ->
+        req = %{
+          method: "POST",
+          path: guest_path(conn),
+          headers: guest_headers(conn),
+          body: body
+        }
+
+        case session_manager().invoke(session_manager_server(), session_id, req) do
+          {:ok, %{status_code: code, headers: headers, body: resp_body}} ->
+            send_guest_result(conn, code, resp_body, headers)
+
+          {:error, {:gone, reason}} ->
+            send_json(conn, 410, %{error: "session gone", reason: to_string(reason), session_id: session_id, retryable: false})
+
+          {:error, {:not_ready, state}} ->
+            send_json(conn, 409, %{
+              error: "session not ready",
+              state: to_string(state),
+              session_id: session_id,
+              retryable: true
+            })
+
+          {:error, :queue_full} ->
+            send_json(conn, 429, %{
+              error: "session invoke queue is full",
+              session_id: session_id,
+              retryable: true
+            })
+
+          {:error, :not_found} ->
+            send_json(conn, 404, %{error: "session not found", session_id: session_id, retryable: false})
+
+          {:error, reason} ->
+            # A daemon transport/timeout failure: the session is now failed. 502 so
+            # the caller knows the invoke did not complete (at-most-once: it is NOT
+            # retried by the platform; the caller creates a fresh session).
+            send_json(conn, 502, %{error: "session invoke failed", reason: inspect(reason), session_id: session_id, retryable: false})
+        end
+
+      {:error, :too_large} ->
+        send_json(conn, 413, %{error: "request body exceeds 8 MiB", retryable: false})
+    end
+  end
+
+  defp guest_path(conn) do
+    case header_value(conn, @path_header) do
+      nil -> "/"
+      path -> path
+    end
+  end
+
+  # GET /v1/sessions/:id (management OR session token). The management-auth plug is
+  # skipped for this route, so authorize here: either a valid management bearer
+  # (TokenReview) OR the session's own token. Returns state, generation, base
+  # digest, timestamps, expires_at.
+  defp handle_get_session(conn, session_id) do
+    case authorize_session_read(conn, session_id) do
+      :ok ->
+        case session_store().get(session_store_server(), session_id) do
+          {:ok, session} -> send_json(conn, 200, session_view(session))
+          :error -> send_json(conn, 404, %{error: "session not found", session_id: session_id, retryable: false})
+        end
+
+      {:error, status, body} ->
+        send_json(conn, status, body)
+    end
+  end
+
+  # DELETE /v1/sessions/:id (management auth): destroy.
+  defp handle_destroy_session(conn, session_id) do
+    case session_manager().destroy(session_manager_server(), session_id) do
+      {:ok, _} -> send_json(conn, 200, %{session_id: session_id, state: "destroyed"})
+      {:error, :not_found} -> send_json(conn, 404, %{error: "session not found", session_id: session_id, retryable: false})
+      {:error, reason} -> send_json(conn, 500, %{error: "destroy failed", reason: inspect(reason), session_id: session_id, retryable: true})
+    end
+  end
+
+  # Session read is allowed for a valid management token OR the session's own token.
+  # Try the session token first (cheap, in-process hash compare), then fall back to
+  # a management TokenReview so an operator can read any session.
+  defp authorize_session_read(conn, session_id) do
+    case bearer_token(conn) do
+      {:ok, token} ->
+        case verify_session_token(session_id, token) do
+          {:ok, _} ->
+            :ok
+
+          {:error, :terminal} ->
+            # The token is this session's, but the session is terminal: reads of a
+            # terminal session are still allowed (state/reason are exactly what the
+            # caller needs), so authorize.
+            :ok
+
+          {:error, _} ->
+            authorize_management_read(conn, token)
+        end
+
+      {:error, :no_token} ->
+        {:error, 401, %{error: "missing bearer token", session_id: session_id, retryable: false}}
+    end
+  end
+
+  defp authorize_management_read(_conn, token) do
+    authenticator = Application.get_env(:embervm, :authenticator, Embervm.Auth)
+
+    case authenticator.authenticate(token) do
+      {:ok, _principal} -> :ok
+      _ -> {:error, 403, %{error: "not authorized to read session", retryable: false}}
+    end
+  end
+
+  # Verify a session token against Embervm.SessionStore, mapping to the handler's
+  # `{:ok, session} | {:error, :terminal | :unauthorized | :not_found}`.
+  defp verify_session_token(session_id, token) do
+    session_store().verify_token(session_store_server(), session_id, token)
+  end
+
+  defp session_gone(conn, session_id) do
+    reason =
+      case session_store().get(session_store_server(), session_id) do
+        {:ok, %{terminal_reason: r}} when is_binary(r) -> r
+        _ -> "gone"
+      end
+
+    send_json(conn, 410, %{error: "session gone", reason: reason, session_id: session_id, retryable: false})
+  end
+
+  defp session_view(session) do
+    %{
+      session_id: session.session_id,
+      workload: session.workload,
+      principal: session.principal,
+      state: to_string(session.state),
+      generation: session.generation,
+      base_digest: session.base_digest,
+      created_at: session.created_at,
+      last_invoke_at: session.last_invoke_at,
+      expires_at: session.expires_at,
+      updated_at: session.updated_at,
+      terminal_reason: session.terminal_reason
+    }
+  end
+
+  # Resolvable session modules/servers, symmetric with `store/0`: the concrete
+  # module (so a test can pass a fake) and the server name/pid it addresses.
+  defp session_manager, do: Application.get_env(:embervm, :session_manager, Embervm.SessionManager)
+  defp session_manager_server, do: Application.get_env(:embervm, :session_manager_server, Embervm.SessionManager)
+  defp session_store, do: Application.get_env(:embervm, :session_store_mod, Embervm.SessionStore)
+  defp session_store_server, do: Application.get_env(:embervm, :session_store, Embervm.SessionStore)
 
   # -- request helpers -------------------------------------------------------
 

--- a/projects/embervm/control/lib/embervm/session.ex
+++ b/projects/embervm/control/lib/embervm/session.ex
@@ -1,0 +1,326 @@
+defmodule Embervm.Session do
+  @moduledoc """
+  One supervised GenServer per LIVE session (under `Embervm.SessionSupervisor`, a
+  DynamicSupervisor), owning that session's invoke serialization and all daemon
+  calls for its VM. A BANKED session has NO process: its durable row is enough,
+  and PR-4's relight-on-invoke restarts a process from the row on the next hit.
+
+  ## one in-flight invoke, FIFO queue (standing decision 9)
+
+  Invokes to one session serialize FIFO through this process: an agent turn is
+  sequential by nature, so at most one `SessionAssign` is ever in flight for a
+  session. This process owns:
+
+    * a bounded FIFO queue of waiting callers (cap `invoke_queue_cap`, default 4);
+      a pile-up past the cap is rejected `{:error, :queue_full}` (the router 429s),
+      the session-scoped analog of the dispatcher's per-principal queue-depth cap;
+    * the in-flight invoke: exactly one caller's `SessionAssign` runs at a time,
+      in a `spawn_monitor` worker so the (up to `timeout_ms`) guest round-trip
+      never blocks this process from accepting/queuing the next caller or handling
+      a lifecycle message.
+
+  The caller blocks in `invoke/3` on a `GenServer.call` with `:infinity` timeout:
+  the router's own request process IS the parked BEAM process the spec wants, and
+  the reply is sent from the worker-completion handler once its turn runs. The
+  queue-cap check happens synchronously in the call handler BEFORE parking, so an
+  over-cap caller gets its 429 immediately rather than parking then timing out.
+
+  ## the invoke is a SessionAssign (deliver-without-destroy)
+
+  Unlike a task's `Assign` (which destroys the VM), a session invoke is a
+  `SessionAssign`: the guest handles the request and the VM SURVIVES for the next
+  invoke, accreting state. The guest response (status, headers, body) is returned
+  VERBATIM to the parked caller, carrying the guest's own headers (the R1 sync-wait
+  header carry). Usage rides the `session_invoked` op (D12.1), so session compute
+  is quota-visible exactly like task compute.
+
+  ## failure posture
+
+  A `DEADLINE_EXCEEDED` or transport error on `SessionAssign` (or a `suspect` VM
+  the daemon left alive but flagged) marks the session `failed` and destroys the
+  VM: a guest in an unknown mid-request state must not accrete further state
+  silently. The parked caller gets the error; every still-queued caller gets a
+  `{:error, :failed}` (the router 410s them). This process then stops.
+
+  ## the idle timer seam (PR-4)
+
+  The idle-bank timer (Task 7) is armed here but is inert in PR-3: this module
+  leaves the `idle_bank_ms` seam and a `:maybe_bank` message stub so PR-4 wires
+  the bank without reshaping the process. PR-3 never banks.
+  """
+
+  use GenServer, restart: :transient
+  require Logger
+
+  alias Embervm.Node.V1.{GuestRequest, GuestResponse, SessionAssignRequest, SessionAssignResponse, Trace}
+
+  # -- Client API ------------------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc """
+  Runs one invoke against the session's live VM, parking the caller FIFO behind
+  any in-flight/queued invoke. `req` is `%{method, path, headers, body}` (the
+  task-envelope allow-list already applied by the router). Returns
+  `{:ok, %{status_code, headers, body, usage}}` with the guest response verbatim,
+  `{:error, :queue_full}` (429) past the queue cap, or `{:error, reason}` on a
+  daemon failure (the session is then `failed`). `:infinity` GenServer timeout:
+  the router's request process is the parked waiter, bounded by the guest
+  `timeout_ms` per invoke, not by a fixed call timeout.
+  """
+  @spec invoke(GenServer.server(), map(), timeout()) :: {:ok, map()} | {:error, term()}
+  def invoke(server, req, _timeout \\ :infinity) do
+    GenServer.call(server, {:invoke, req}, :infinity)
+  end
+
+  @doc "The session id this process serves (for supervision/debug)."
+  @spec session_id(GenServer.server()) :: String.t()
+  def session_id(server), do: GenServer.call(server, :session_id)
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    state = %{
+      session_id: Keyword.fetch!(opts, :session_id),
+      workload: Keyword.fetch!(opts, :workload),
+      principal: Keyword.get(opts, :principal),
+      node_id: Keyword.fetch!(opts, :node_id),
+      vm_id: Keyword.fetch!(opts, :vm_id),
+      # Session config from the catalog entry: the invoke queue cap, the guest
+      # round-trip timeout, and (PR-4) the idle-bank delay.
+      queue_cap: Keyword.fetch!(opts, :queue_cap),
+      timeout_ms: Keyword.get(opts, :timeout_ms, 90_000),
+      idle_bank_ms: Keyword.get(opts, :idle_bank_ms, nil),
+      session_store: Keyword.get(opts, :session_store, Embervm.SessionStore),
+      channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
+      invalidate_fun: Keyword.get(opts, :invalidate_fun, &Embervm.NodeChannel.invalidate/2),
+      assign_fun: Keyword.get(opts, :assign_fun, &default_session_assign/2),
+      destroy_fun: Keyword.get(opts, :destroy_fun, &default_destroy/2),
+      # FIFO of {from, req} waiting their turn; the head runs when no worker is in
+      # flight. `worker` is the {pid, ref, from} of the in-flight invoke, or nil.
+      queue: :queue.new(),
+      worker: nil
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:session_id, _from, state), do: {:reply, state.session_id, state}
+
+  def handle_call({:invoke, req}, from, state) do
+    # Queue-cap is over WAITERS: the in-flight invoke does not count against the
+    # cap (it already left the queue), so `invoke_queue_cap` bounds how many callers
+    # may PILE UP behind the running one. A cap of 4 admits 4 waiters + 1 in flight.
+    if :queue.len(state.queue) >= state.queue_cap do
+      {:reply, {:error, :queue_full}, state}
+    else
+      state = %{state | queue: :queue.in({from, req}, state.queue)}
+      {:noreply, maybe_start_next(state)}
+    end
+  end
+
+  @impl true
+  def handle_info({:invoke_done, pid, outcome}, %{worker: {pid, ref, from}} = state) do
+    Process.demonitor(ref, [:flush])
+    state = %{state | worker: nil}
+
+    case outcome do
+      {:ok, result, usage} ->
+        # Record the invoke durably (usage rides the op, D12.1) BEFORE replying, so
+        # the caller never sees a response the op-log has not accounted. A store
+        # error does not fail the caller's response (the guest already did the work);
+        # it is logged and the response still goes back.
+        _ = record_invoke(state, usage)
+        GenServer.reply(from, {:ok, result})
+        {:noreply, maybe_start_next(state)}
+
+      {:error, reason} ->
+        # A daemon transport/timeout/suspect failure: the session is failed and its
+        # VM destroyed. Reply the error to this caller, drain the rest as :failed,
+        # and stop (a failed session has no process).
+        GenServer.reply(from, {:error, reason})
+        fail_and_stop(state, reason)
+    end
+  end
+
+  # A worker died without reporting (it always sends {:invoke_done, ...}): treat as
+  # a transport failure, same as a reported error.
+  def handle_info({:DOWN, ref, :process, pid, down_reason}, %{worker: {pid, ref, from}} = state) do
+    state = %{state | worker: nil}
+    GenServer.reply(from, {:error, {:worker_down, down_reason}})
+    fail_and_stop(state, {:worker_down, down_reason})
+  end
+
+  # The idle-bank timer (PR-4). Inert in PR-3: no idle_bank_ms is set, so this is
+  # never scheduled; the clause exists so PR-4 wires banking without reshaping.
+  def handle_info(:maybe_bank, state), do: {:noreply, state}
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # -- invoke dispatch -------------------------------------------------------
+
+  # Start the head of the queue if nothing is in flight; otherwise leave it queued.
+  defp maybe_start_next(%{worker: nil} = state) do
+    case :queue.out(state.queue) do
+      {{:value, {from, req}}, rest} ->
+        {pid, ref} = spawn_invoke_worker(state, req)
+        %{state | queue: rest, worker: {pid, ref, from}}
+
+      {:empty, _} ->
+        state
+    end
+  end
+
+  defp maybe_start_next(state), do: state
+
+  defp spawn_invoke_worker(state, req) do
+    owner = self()
+    node_id = state.node_id
+    vm_id = state.vm_id
+    session_id = state.session_id
+    workload = state.workload
+    timeout_ms = state.timeout_ms
+    channel_fun = state.channel_fun
+    invalidate_fun = state.invalidate_fun
+    assign_fun = state.assign_fun
+
+    spawn_monitor(fn ->
+      outcome =
+        run_invoke(%{
+          node_id: node_id,
+          vm_id: vm_id,
+          session_id: session_id,
+          workload: workload,
+          timeout_ms: timeout_ms,
+          req: req,
+          channel_fun: channel_fun,
+          invalidate_fun: invalidate_fun,
+          assign_fun: assign_fun
+        })
+
+      send(owner, {:invoke_done, self(), outcome})
+    end)
+  end
+
+  # The worker body (off this GenServer): acquire the shared channel, SessionAssign,
+  # and classify the result. A clean guest response (even a 4xx/5xx) is `{:ok, ...}`:
+  # unlike a task, a session invoke's guest error is the guest's answer, not a VM
+  # failure, so it does NOT fail the session (the caller decides). Only a transport
+  # error, a DEADLINE_EXCEEDED, or a daemon-flagged `suspect` VM fails the session.
+  defp run_invoke(ctx) do
+    case ctx.channel_fun.(ctx.node_id) do
+      {:ok, channel} ->
+        guest_req = %GuestRequest{
+          method: Map.get(ctx.req, :method, "POST"),
+          path: Map.get(ctx.req, :path, "/"),
+          headers: Map.get(ctx.req, :headers, %{}),
+          body: Map.get(ctx.req, :body, "")
+        }
+
+        assign_req = %SessionAssignRequest{
+          trace: %Trace{workload: ctx.workload},
+          vm_id: ctx.vm_id,
+          request: guest_req,
+          timeout_ms: ctx.timeout_ms,
+          session_id: ctx.session_id
+        }
+
+        case ctx.assign_fun.(channel, assign_req) do
+          {:ok, %SessionAssignResponse{suspect: true}} ->
+            _ = ctx.invalidate_fun.(ctx.node_id, channel)
+            {:error, :suspect}
+
+          {:ok, %SessionAssignResponse{response: %GuestResponse{} = resp, usage: usage}} ->
+            {:ok,
+             %{
+               status_code: resp.status_code,
+               headers: resp.headers || %{},
+               body: resp.body || ""
+             }, Embervm.Usage.from_proto(usage)}
+
+          {:error, reason} ->
+            _ = ctx.invalidate_fun.(ctx.node_id, channel)
+            {:error, classify_error(reason)}
+        end
+
+      {:error, reason} ->
+        {:error, {:no_channel, reason}}
+    end
+  end
+
+  defp classify_error(%GRPC.RPCError{status: 4}), do: :deadline_exceeded
+  defp classify_error(%GRPC.RPCError{} = e), do: {:rpc, e.status}
+  defp classify_error(reason), do: reason
+
+  # -- session-store side effects --------------------------------------------
+
+  # Record a successful invoke: append session_invoked with usage (no bodies), which
+  # upserts the usage projection in the same transaction (D12.1). Best-effort against
+  # the store; a store hiccup does not fail the already-served caller.
+  defp record_invoke(state, usage) do
+    Embervm.SessionStore.record_invoke(state.session_store, state.session_id, usage)
+  rescue
+    _ -> :error
+  catch
+    _, _ -> :error
+  end
+
+  # Fail the session (destroy the VM, append session_failed), drain queued callers
+  # as :failed, and stop this process. Called on any daemon-level invoke failure.
+  defp fail_and_stop(state, reason) do
+    _ = destroy_vm(state)
+
+    _ =
+      Embervm.SessionStore.transition(
+        state.session_store,
+        state.session_id,
+        :fail,
+        :session_failed,
+        %{reason: :failed, detail: inspect(reason)},
+        %{}
+      )
+
+    drain_queue_as_failed(state)
+    {:stop, :normal, %{state | queue: :queue.new()}}
+  end
+
+  defp drain_queue_as_failed(state) do
+    for {from, _req} <- :queue.to_list(state.queue) do
+      GenServer.reply(from, {:error, :failed})
+    end
+  end
+
+  defp destroy_vm(state) do
+    case state.channel_fun.(state.node_id) do
+      {:ok, channel} ->
+        try do
+          state.destroy_fun.(channel, state.vm_id)
+        rescue
+          _ -> :error
+        catch
+          _, _ -> :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  # -- defaults --------------------------------------------------------------
+
+  defp default_session_assign(channel, %SessionAssignRequest{} = req) do
+    Embervm.Node.V1.NodeService.Stub.session_assign(channel, req)
+  end
+
+  defp default_destroy(channel, vm_id) do
+    Embervm.Node.V1.NodeService.Stub.destroy(channel, %Embervm.Node.V1.DestroyRequest{vm_id: vm_id})
+  end
+end

--- a/projects/embervm/control/lib/embervm/session_id.ex
+++ b/projects/embervm/control/lib/embervm/session_id.ex
@@ -1,0 +1,95 @@
+defmodule Embervm.SessionId do
+  @moduledoc """
+  Session identity and per-session capability tokens (R2, Task 5).
+
+  Two independent secrets are minted per session:
+
+    * the session id, `s-` + a 26-char Crockford-base32 ULID. The ULID's leading
+      48 bits are the create timestamp (lexicographic-sortable, like the spec's
+      `s-<ULID>`), the trailing 80 bits are random. It is NOT secret: it appears
+      in URLs, logs, and the op-log. The random tail is only there so ids are
+      unguessable enough that a caller cannot enumerate other sessions by id (the
+      token, not the id, is the auth capability; this is defence in depth).
+    * the session token, 32 random bytes URL-safe-base64 encoded, returned to the
+      caller EXACTLY ONCE at create and never stored in plaintext: only its
+      sha256 lives in the store. `verify_token/2` recomputes the hash and compares
+      it CONSTANT-TIME against the stored hash, so a timing side channel cannot
+      leak how many leading bytes of a guessed token matched.
+
+  The token never enters the guest, MMDS, initEnv, or any snapshot: it exists
+  only as a hash in the control plane, so a compromised guest image cannot leak
+  it (standing decision 6, and the Task 5 threat model).
+  """
+
+  # Crockford base32 alphabet (no I, L, O, U), the ULID canonical encoding.
+  @crockford ~c"0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+  @doc """
+  A fresh session id: `s-` + a 26-char ULID whose 48-bit time prefix is
+  `now_ms`. `now_ms` is injected (never read here) so tests are deterministic and
+  ordering is testable.
+  """
+  @spec new(integer()) :: String.t()
+  def new(now_ms) when is_integer(now_ms) do
+    # 128-bit ULID = 48-bit time (ms since epoch) <> 80-bit randomness, encoded as
+    # 26 Crockford-base32 chars (5 bits each, 130 bits, top 2 bits are the padding
+    # the canonical ULID encoding drops to 0).
+    <<rand::80>> = :crypto.strong_rand_bytes(10)
+    int = Bitwise.bsl(now_ms, 80) + rand
+    "s-" <> encode_ulid(int)
+  end
+
+  @doc """
+  Mints a fresh capability token and its sha256. Returns `{token, token_sha256}`;
+  the caller returns `token` to the client exactly once and persists only
+  `token_sha256`.
+  """
+  @spec mint_token() :: {String.t(), String.t()}
+  def mint_token do
+    token = 32 |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)
+    {token, token_sha256(token)}
+  end
+
+  @doc "The lowercase-hex sha256 of a token, the form stored in `sessions.token_sha256`."
+  @spec token_sha256(String.t()) :: String.t()
+  def token_sha256(token) when is_binary(token) do
+    :crypto.hash(:sha256, token) |> Base.encode16(case: :lower)
+  end
+
+  @doc """
+  Whether `token` authenticates the session whose stored hash is `stored_sha256`.
+  Constant-time over the two hex hashes (`:crypto.hash_equals/2`), so a partial
+  match is indistinguishable in time from a total miss. Returns false for a nil
+  stored hash (a session that recorded none) so a token can never authenticate a
+  hashless row.
+  """
+  @spec verify_token(String.t(), String.t() | nil) :: boolean()
+  def verify_token(token, stored_sha256)
+      when is_binary(token) and is_binary(stored_sha256) do
+    # Compare the raw sha256 bytes, not the hex text: hash_equals wants equal-length
+    # binaries, and the raw digests are always 32 bytes even if a stored value were
+    # ever malformed hex (decode failure falls through to false below).
+    computed = :crypto.hash(:sha256, token)
+
+    case Base.decode16(stored_sha256, case: :lower) do
+      {:ok, stored} when byte_size(stored) == byte_size(computed) ->
+        :crypto.hash_equals(computed, stored)
+
+      _ ->
+        false
+    end
+  end
+
+  def verify_token(_token, _stored), do: false
+
+  # -- ULID encoding ---------------------------------------------------------
+
+  defp encode_ulid(int) do
+    # 26 base32 chars, most-significant first. Build the char list by shifting 5
+    # bits off the top each step; the top 2 of the 130 encoded bits are always 0.
+    for shift <- 125..0//-5, into: "" do
+      idx = int |> Bitwise.bsr(shift) |> Bitwise.band(0x1F)
+      <<Enum.at(@crockford, idx)>>
+    end
+  end
+end

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -1,0 +1,489 @@
+defmodule Embervm.SessionManager do
+  @moduledoc """
+  The session lifecycle brain (R2, Task 6): create-from-primed-pool, destroy, and
+  the placement seam, sitting between the front-end router and the per-session
+  `Embervm.Session` processes. The router NEVER computes where a session lives or
+  reserves capacity; it calls this module, which owns those decisions (the R2
+  held invariant: the invocation front-end is split from placement).
+
+  ## create (assignment from the primed pool)
+
+  Create rides the R0 primed-pool machinery, exactly like a task's warm dispatch:
+
+    1. reserve CAPACITY, fail-closed and in order (this GenServer serializes
+       creates so two concurrent creates cannot both slip past `maxSessions`):
+       the per-workload live+banked count against `session.maxSessions`, the live
+       count against `concurrency.cap`, and the principal's daily quota;
+    2. pick a node (`Embervm.SessionPlacement` lands in PR-4; PR-3 uses a minimal
+       ready-node-with-budget choice inline, noted below);
+    3. CLAIM a primed pristine VM from the dispatcher's inventory for the workload
+       (principal-bound at claim, the task-class assignment moment), or `Prime` one
+       on a pool miss;
+    4. append `session_created` (write-through, mints the id + token) and start the
+       session process under the DynamicSupervisor.
+
+  A create denial is a structured 429/403 with a distinguishable reason and an
+  audited op append (D12.2 cadence), returned to the router to shape the response.
+
+  ## invoke routing
+
+  `invoke/3` resolves the session by id, then:
+
+    * a LIVE session with a running process: forward to it (`Embervm.Session.invoke`),
+      which serializes FIFO and returns the guest response verbatim;
+    * a `creating`/`banking`/`relighting` session: PARK the caller (PR-4 relight
+      routing; PR-3 sessions are created directly `running`, so this is a rare
+      transient window). PR-3 returns `{:error, {:not_ready, state}}` which the
+      router 409s, rather than block, since no bank/relight path exists yet to
+      resolve it (noted);
+    * a TERMINAL session: `{:error, {:gone, reason}}` (the router 410s with the
+      recorded terminal reason);
+    * an unknown session: `{:error, :not_found}`.
+
+  ## destroy
+
+  `destroy/2` transitions the session to `destroyed`: it stops the session process
+  (which owns the VM) and, if the session held a banked snapshot, records the
+  intent to evict it (the EvictSnapshot RPC lands in PR-4; PR-3 destroys a LIVE
+  session's VM via its process). Idempotent-ish: destroying an already-terminal
+  session is a no-op success.
+  """
+
+  use GenServer
+  require Logger
+
+  alias Embervm.{NodeCapacity, SessionStore, WorkloadCatalog}
+  alias Embervm.Node.V1.{PrimeRequest, PrimeResponse, Trace}
+
+  @registry Embervm.SessionRegistry
+
+  # -- Client API ------------------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc """
+  Creates a session for `workload` on behalf of `principal`. Returns
+  `{:ok, %{session_id, token, expires_at, base_digest}}` (the token is returned
+  ONCE, here), or `{:error, {:denied, reason}}` for a capacity/quota denial
+  (`:session_cap`, `:workload_cap`, `:quota`, `:no_capacity`, `:unknown_workload`,
+  `:not_session_class`) that the router maps to a 429/403.
+  """
+  @spec create(GenServer.server(), String.t(), String.t()) :: {:ok, map()} | {:error, term()}
+  def create(server \\ __MODULE__, workload, principal) do
+    GenServer.call(server, {:create, workload, principal})
+  end
+
+  @doc """
+  Routes one invoke to a session. `req` is the task-envelope map
+  (`%{method, path, headers, body}`). Returns the session process's result, or a
+  routing error (`{:not_ready, state}`, `{:gone, reason}`, `:not_found`).
+  """
+  @spec invoke(GenServer.server(), String.t(), map()) :: {:ok, map()} | {:error, term()}
+  def invoke(server \\ __MODULE__, session_id, req) do
+    GenServer.call(server, {:route_invoke, session_id, req}, :infinity)
+  end
+
+  @doc """
+  Destroys a session (`* -> destroyed`): stops its process/VM and records
+  `session_destroyed`. Returns `{:ok, session}`, `{:error, :not_found}`, or
+  `{:ok, :already_terminal}` for an already-terminal session.
+  """
+  @spec destroy(GenServer.server(), String.t()) :: {:ok, term()} | {:error, term()}
+  def destroy(server \\ __MODULE__, session_id) do
+    GenServer.call(server, {:destroy, session_id})
+  end
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    state = %{
+      session_store: Keyword.get(opts, :session_store, SessionStore),
+      dispatcher: Keyword.get(opts, :dispatcher, Embervm.Dispatcher),
+      supervisor: Keyword.get(opts, :supervisor, Embervm.SessionSupervisor),
+      registry: Keyword.get(opts, :registry, @registry),
+      capacity_table: Keyword.get(opts, :capacity_table, NodeCapacity.table()),
+      catalog_table: Keyword.get(opts, :catalog_table, WorkloadCatalog.table()),
+      clock: Keyword.get(opts, :clock, &default_clock/0),
+      quota_table: Keyword.get(opts, :quota_table, Embervm.Metering.table()),
+      quota_config: Keyword.get(opts, :quota_config, Embervm.Metering.quota_config()),
+      # Injected for tests; production uses the real claim/prime/channel seams.
+      claim_fun: Keyword.get(opts, :claim_fun, &default_claim/3),
+      channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
+      prime_fun: Keyword.get(opts, :prime_fun, &default_prime/2),
+      # Extra opts threaded into every started Embervm.Session (the daemon seams),
+      # so a test can inject a fake session_assign into the spawned process.
+      session_opts: Keyword.get(opts, :session_opts, []),
+      tenant: Keyword.get(opts, :tenant, "homelab")
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call({:create, workload, principal}, _from, state) do
+    {:reply, do_create(state, workload, principal), state}
+  end
+
+  def handle_call({:route_invoke, session_id, req}, from, state) do
+    # Resolve the route on this process (fast), but do NOT block it on the invoke:
+    # the session process's own FIFO parks the caller. So we reply the pid to the
+    # caller path via a spawned forwarder, keeping the manager responsive. Simpler:
+    # forward synchronously from a short task so the manager is not the bottleneck.
+    route = resolve_route(state, session_id)
+
+    case route do
+      {:live, pid} ->
+        # Forward off the manager so a long guest round-trip does not serialize other
+        # sessions' routing through this one GenServer.
+        _ = spawn_forward(pid, req, from)
+        {:noreply, state}
+
+      {:error, _reason} = error ->
+        {:reply, error, state}
+    end
+  end
+
+  def handle_call({:destroy, session_id}, _from, state) do
+    {:reply, do_destroy(state, session_id), state}
+  end
+
+  # -- create ----------------------------------------------------------------
+
+  defp do_create(state, workload, principal) do
+    with {:ok, entry} <- fetch_session_workload(state, workload),
+         :ok <- check_session_cap(state, workload, entry),
+         :ok <- check_workload_cap(state, workload, entry),
+         :ok <- check_quota(state, principal),
+         {:ok, node_id, snapshot_ref} <- pick_node(state, workload),
+         {:ok, vm_id} <- claim_or_prime(state, node_id, workload, snapshot_ref) do
+      register_and_start(state, workload, principal, entry, node_id, vm_id)
+    else
+      {:error, reason} ->
+        audit_denial(state, principal, workload, reason)
+        {:error, {:denied, reason}}
+    end
+  end
+
+  defp fetch_session_workload(state, workload) do
+    case WorkloadCatalog.fetch(state.catalog_table, workload) do
+      {:ok, %{class: "session", session: session} = entry} when is_map(session) ->
+        {:ok, entry}
+
+      {:ok, _entry} ->
+        {:error, :not_session_class}
+
+      :error ->
+        {:error, :unknown_workload}
+    end
+  end
+
+  # live + banked < session.maxSessions (both hold a resource: a VM or disk).
+  defp check_session_cap(state, workload, %{session: session}) do
+    counts = SessionStore.counts(state.session_store, workload)
+
+    if counts.live + counts.banked < session.max_sessions do
+      :ok
+    else
+      {:error, :session_cap}
+    end
+  end
+
+  # live session VMs < concurrency.cap (banked sessions do not hold a live VM).
+  defp check_workload_cap(state, workload, %{cap: cap}) do
+    counts = SessionStore.counts(state.session_store, workload)
+
+    if counts.live < cap, do: :ok, else: {:error, :workload_cap}
+  end
+
+  defp check_quota(state, principal) do
+    if Embervm.Metering.within_quota?(principal, state.clock.(), state.quota_config, state.quota_table) do
+      :ok
+    else
+      {:error, :quota}
+    end
+  end
+
+  # PR-3 placement: the first fresh, non-draining, ready node with live-VM budget.
+  # `Embervm.SessionPlacement` (PR-4, Task 8) replaces this with rendezvous hashing
+  # over the ready node list; the interface (workload -> {node_id, snapshot_ref}) is
+  # the same, so that swap does not touch this module's create flow.
+  defp pick_node(state, workload) do
+    NodeCapacity.all(state.capacity_table)
+    |> Enum.find_value({:error, :no_capacity}, fn f ->
+      wc = Map.get(f.workloads || %{}, workload)
+
+      cond do
+        wc == nil -> false
+        not base_ready?(wc) -> false
+        not has_budget?(f) -> false
+        true -> {:ok, f.configured_id, Map.get(wc, :snapshot_ref)}
+      end
+    end)
+  end
+
+  defp base_ready?(wc) do
+    ready =
+      case Map.get(wc, :base_state) do
+        :BASE_BUILD_STATE_READY -> true
+        3 -> true
+        _ -> false
+      end
+
+    ref = Map.get(wc, :snapshot_ref)
+    ready and is_binary(ref) and ref != ""
+  end
+
+  defp has_budget?(f) do
+    max = Map.get(f, :max_live_vms, 0)
+    max > 0 and Map.get(f, :live_vms, 0) < max
+  end
+
+  # Claim a primed VM from the dispatcher's inventory, or Prime one on a miss (the
+  # dispatcher's own miss path, run inline here since create latency is not the
+  # per-invoke hot path). A Prime failure is a create denial, not a crash.
+  defp claim_or_prime(state, node_id, workload, snapshot_ref) do
+    case state.claim_fun.(state.dispatcher, node_id, workload) do
+      {:ok, vm_id} ->
+        {:ok, vm_id}
+
+      :miss ->
+        prime(state, node_id, snapshot_ref)
+    end
+  end
+
+  defp prime(state, node_id, snapshot_ref) do
+    with {:ok, channel} <- state.channel_fun.(node_id),
+         {:ok, %PrimeResponse{vm_id: vm_id}} when is_binary(vm_id) and vm_id != "" <-
+           safe_prime(state, channel, snapshot_ref) do
+      {:ok, vm_id}
+    else
+      _ -> {:error, :no_capacity}
+    end
+  end
+
+  defp safe_prime(state, channel, snapshot_ref) do
+    req = %PrimeRequest{trace: %Trace{}, snapshot_ref: snapshot_ref || ""}
+    state.prime_fun.(channel, req)
+  rescue
+    _ -> {:error, :prime_crashed}
+  catch
+    _, _ -> {:error, :prime_crashed}
+  end
+
+  # Append session_created (mints id + token), then start the session process. The
+  # store write is write-through and MUST land before the process exists so a crash
+  # between the two heals to a durable-but-processless session (which adoption in
+  # PR-4 rebinds). If the process fails to start, the durable session is orphaned as
+  # a live-but-unrouted row; PR-4 adoption rebinds it from NodeStatus, so we surface
+  # the create as failed rather than leave the caller a token to a dead process.
+  defp register_and_start(state, workload, principal, entry, node_id, vm_id) do
+    attrs = %{
+      tenant: state.tenant,
+      principal: principal,
+      workload: workload,
+      node_id: node_id,
+      vm_id: vm_id,
+      base_snapshot_ref: Map.get(entry, :image_ref),
+      base_digest: base_digest(entry),
+      expires_at: state.clock.() + entry.session.max_lifetime_seconds * 1000
+    }
+
+    case SessionStore.create(state.session_store, attrs) do
+      {:ok, %{session_id: session_id} = created} ->
+        case start_session_process(state, session_id, workload, principal, entry, node_id, vm_id) do
+          {:ok, _pid} ->
+            {:ok, created}
+
+          {:error, reason} ->
+            Logger.error("embervm session: process start failed for #{session_id}: #{inspect(reason)}")
+            {:error, {:denied, :process_start_failed}}
+        end
+
+      {:error, reason} ->
+        {:error, {:denied, {:store, reason}}}
+    end
+  end
+
+  defp start_session_process(state, session_id, workload, principal, entry, node_id, vm_id) do
+    child_opts =
+      [
+        session_id: session_id,
+        workload: workload,
+        principal: principal,
+        node_id: node_id,
+        vm_id: vm_id,
+        queue_cap: entry.session.invoke_queue_cap,
+        timeout_ms: entry.timeout_ms,
+        session_store: state.session_store,
+        # Register under the session id so the router/manager resolve the pid.
+        name: {:via, Registry, {state.registry, session_id}}
+      ] ++ state.session_opts
+
+    spec = %{
+      id: session_id,
+      start: {Embervm.Session, :start_link, [child_opts]},
+      restart: :transient,
+      type: :worker
+    }
+
+    DynamicSupervisor.start_child(state.supervisor, spec)
+  end
+
+  # -- invoke routing --------------------------------------------------------
+
+  defp resolve_route(state, session_id) do
+    case SessionStore.get(state.session_store, session_id) do
+      {:ok, %{state: :running} = _session} ->
+        case Registry.lookup(state.registry, session_id) do
+          [{pid, _}] -> {:live, pid}
+          # Running per the durable store but no process: a restart-limbo the PR-4
+          # adoption sweep rebinds. PR-3 has no adoption, so surface a transient
+          # error rather than pretend the VM is reachable.
+          [] -> {:error, {:not_ready, :running}}
+        end
+
+      {:ok, %{state: session_state}} ->
+        cond do
+          session_state in [:creating, :banking, :relighting] -> {:error, {:not_ready, session_state}}
+          # terminal: 410 with the recorded reason.
+          true -> {:error, {:gone, terminal_reason(state, session_id, session_state)}}
+        end
+
+      :error ->
+        {:error, :not_found}
+    end
+  end
+
+  defp terminal_reason(state, session_id, session_state) do
+    case SessionStore.get(state.session_store, session_id) do
+      {:ok, %{terminal_reason: reason}} when is_binary(reason) -> reason
+      _ -> to_string(session_state)
+    end
+  end
+
+  # Forward an invoke to the session process off the manager, replying to the
+  # original caller. A crash forwarding (process died mid-route) becomes an error
+  # reply rather than a hung caller.
+  defp spawn_forward(pid, req, from) do
+    spawn(fn ->
+      reply =
+        try do
+          Embervm.Session.invoke(pid, req)
+        catch
+          :exit, reason -> {:error, {:session_down, reason}}
+        end
+
+      GenServer.reply(from, reply)
+    end)
+  end
+
+  # -- destroy ---------------------------------------------------------------
+
+  defp do_destroy(state, session_id) do
+    case SessionStore.get(state.session_store, session_id) do
+      {:ok, %{state: session_state}} when session_state in [:expired, :evicted, :destroyed, :failed] ->
+        {:ok, :already_terminal}
+
+      {:ok, session} ->
+        destroy_live(state, session)
+
+      :error ->
+        {:error, :not_found}
+    end
+  end
+
+  # Stop the session process (which owns and, on terminate, releases the VM), then
+  # record session_destroyed. A live session has a process; a banked one does not
+  # (its VM is already gone, only the snapshot remains, whose eviction is PR-4).
+  defp destroy_live(state, session) do
+    _ = stop_session_process(state, session.session_id, session)
+
+    SessionStore.transition(
+      state.session_store,
+      session.session_id,
+      :destroy,
+      :session_destroyed,
+      %{reason: :destroyed},
+      %{}
+    )
+  end
+
+  # Terminate the session process and destroy its VM. We destroy the VM HERE (not in
+  # the process's terminate, which may not run on a hard kill) so a destroy always
+  # tears down the guest even if the process is wedged.
+  defp stop_session_process(state, session_id, session) do
+    case Registry.lookup(state.registry, session_id) do
+      [{pid, _}] ->
+        _ = DynamicSupervisor.terminate_child(state.supervisor, pid)
+        destroy_vm(state, session)
+
+      [] ->
+        # No process (already stopped or never started): still best-effort destroy
+        # the VM from the durable residency, so a destroy of a limbo session frees it.
+        destroy_vm(state, session)
+    end
+  end
+
+  defp destroy_vm(state, %{node_id: node_id, vm_id: vm_id}) when is_binary(node_id) and is_binary(vm_id) do
+    with {:ok, channel} <- state.channel_fun.(node_id) do
+      opts = state.session_opts
+
+      destroy_fun =
+        Keyword.get(opts, :destroy_fun, fn ch, id ->
+          Embervm.Node.V1.NodeService.Stub.destroy(ch, %Embervm.Node.V1.DestroyRequest{vm_id: id})
+        end)
+
+      try do
+        destroy_fun.(channel, vm_id)
+      rescue
+        _ -> :error
+      catch
+        _, _ -> :error
+      end
+    end
+
+    :ok
+  end
+
+  defp destroy_vm(_state, _session), do: :ok
+
+  # -- helpers ---------------------------------------------------------------
+
+  # Audit a create denial as one op-log append (D12.2 cadence). Capacity/quota
+  # denials are principal-attributable and request-bounded, so they are appended
+  # (unlike per-tick dispatch saturation). Reuses the metering denial reason space.
+  defp audit_denial(_state, principal, workload, reason) do
+    metering_reason =
+      case reason do
+        :quota -> :quota
+        other -> other
+      end
+
+    Embervm.Metering.record_denial(principal, workload, metering_reason)
+    :ok
+  end
+
+  defp base_digest(entry) do
+    # PR-3 has no BaseBuilder-resolved digest wired into the catalog entry for the
+    # session flow; use the image ref as the birth-base identity placeholder. PR-4
+    # threads the resolved base_digest from status once relight lineage needs it.
+    Map.get(entry, :image_ref) || ""
+  end
+
+  defp default_claim(dispatcher, node_id, workload) do
+    Embervm.Dispatcher.claim(dispatcher, node_id, workload)
+  end
+
+  defp default_prime(channel, %PrimeRequest{} = req) do
+    Embervm.Node.V1.NodeService.Stub.prime(channel, req)
+  end
+
+  defp default_clock, do: System.system_time(:millisecond)
+end

--- a/projects/embervm/control/lib/embervm/session_state.ex
+++ b/projects/embervm/control/lib/embervm/session_state.ex
@@ -1,0 +1,169 @@
+defmodule Embervm.SessionState do
+  @moduledoc """
+  The session lifecycle FSM, expressed as data, mirroring `Embervm.TaskState`: a
+  module-attribute map from `{state, event}` to the next state. `Embervm.SessionStore`
+  is the only caller that mutates session state, and every mutation goes through
+  `transition/2` or `transition!/2` first, so an illegal transition fails loudly
+  at the call site instead of corrupting ETS or the op-log with a state the FSM
+  never sanctions.
+
+  ## the lifecycle
+
+      creating -> running                  (create claimed a VM and it is live)
+      running  -> banking -> banked        (idle bank, PR-4)
+      banked   -> relighting -> running    (relight-on-invoke, PR-4)
+
+  Terminal states each carry a recorded reason (the op payload's `reason`), and
+  are reachable from MOST live states because a session can be destroyed,
+  expired, evicted, or failed at almost any point:
+
+    * `destroyed` (DELETE /v1/sessions/{id}): reachable from every non-terminal
+      state (the caller may destroy a session while it is creating, running,
+      banking, banked, or relighting).
+    * `failed` (a SessionAssign transport/DEADLINE_EXCEEDED error, an
+      unrestorable snapshot, or repeated bank failure): reachable from the live
+      states that touch the daemon (running, banking, relighting) and from
+      creating (a create that could not bring the VM up).
+    * `expired` (max-lifetime TTL): reachable from running and banked (a live or
+      banked session past `expires_at`).
+    * `evicted` (banked-TTL GC or disk-pressure eviction): reachable only from
+      `banked` (only a banked session holds an evictable snapshot).
+
+  `bank`/`relight` (the PR-4 idle-bank and relight-on-invoke events) are enumerated
+  here so the transition table is COMPLETE for the whole rung even though PR-3 only
+  drives `create_ready`/`destroy`/`fail`; leaving the edges undefined would make a
+  PR-4 bank raise. The `*_ready`/`*_failed` split mirrors the task FSM's
+  assign/start vs fail edges: an operation that reaches the daemon and comes back
+  has a distinct success and failure edge, and the failure edge lands on `failed`.
+  """
+
+  defmodule IllegalTransition do
+    defexception [:state, :event]
+
+    @impl true
+    def message(%{state: state, event: event}) do
+      "illegal session transition: #{inspect(state)} -/-> on #{inspect(event)}"
+    end
+  end
+
+  @states [
+    :creating,
+    :running,
+    :banking,
+    :banked,
+    :relighting,
+    :expired,
+    :evicted,
+    :destroyed,
+    :failed
+  ]
+
+  @terminal_states [:expired, :evicted, :destroyed, :failed]
+
+  @events [
+    :create_ready,
+    :bank,
+    :bank_ready,
+    :relight,
+    :relight_ready,
+    :expire,
+    :evict,
+    :destroy,
+    :fail
+  ]
+
+  # The transition table. Every legal (state, event) pair; anything not a key
+  # here is illegal by construction.
+  @transitions %{
+    # Create: a claimed/primed VM is live.
+    {:creating, :create_ready} => :running,
+    # Idle-bank (PR-4): running -> banking (bank RPC in flight) -> banked.
+    {:running, :bank} => :banking,
+    {:banking, :bank_ready} => :banked,
+    # Relight-on-invoke (PR-4): banked -> relighting (relight RPC in flight) -> running.
+    {:banked, :relight} => :relighting,
+    {:relighting, :relight_ready} => :running,
+    # Max-lifetime expiry: a live or banked session past its deadline.
+    {:running, :expire} => :expired,
+    {:banked, :expire} => :expired,
+    # Banked-TTL GC / disk-pressure eviction: only a banked session.
+    {:banked, :evict} => :evicted,
+    # Destroy (DELETE): from every non-terminal state.
+    {:creating, :destroy} => :destroyed,
+    {:running, :destroy} => :destroyed,
+    {:banking, :destroy} => :destroyed,
+    {:banked, :destroy} => :destroyed,
+    {:relighting, :destroy} => :destroyed,
+    # Fail (daemon transport/timeout, unrestorable snapshot, repeated bank failure):
+    # from every live state that touches the daemon.
+    {:creating, :fail} => :failed,
+    {:running, :fail} => :failed,
+    {:banking, :fail} => :failed,
+    {:relighting, :fail} => :failed
+  }
+
+  @type state ::
+          :creating
+          | :running
+          | :banking
+          | :banked
+          | :relighting
+          | :expired
+          | :evicted
+          | :destroyed
+          | :failed
+
+  @type event ::
+          :create_ready
+          | :bank
+          | :bank_ready
+          | :relight
+          | :relight_ready
+          | :expire
+          | :evict
+          | :destroy
+          | :fail
+
+  @spec states() :: [state()]
+  def states, do: @states
+
+  @spec events() :: [event()]
+  def events, do: @events
+
+  @spec terminal_states() :: [state()]
+  def terminal_states, do: @terminal_states
+
+  @spec terminal?(state()) :: boolean()
+  def terminal?(state), do: state in @terminal_states
+
+  @spec transition(state(), event()) ::
+          {:ok, state()} | {:error, {:illegal_transition, state(), event()}}
+  def transition(state, event) do
+    case Map.fetch(@transitions, {state, event}) do
+      {:ok, next} -> {:ok, next}
+      :error -> {:error, {:illegal_transition, state, event}}
+    end
+  end
+
+  @spec transition!(state(), event()) :: state()
+  def transition!(state, event) do
+    case transition(state, event) do
+      {:ok, next} ->
+        next
+
+      {:error, {:illegal_transition, state, event}} ->
+        raise IllegalTransition, state: state, event: event
+    end
+  end
+
+  @doc """
+  The op kind that records a given terminal state, for the write-through append.
+  A total map over the four terminal states; a non-terminal state raises (callers
+  only ask for terminal kinds).
+  """
+  @spec terminal_op_kind(state()) :: atom()
+  def terminal_op_kind(:expired), do: :session_expired
+  def terminal_op_kind(:evicted), do: :session_evicted
+  def terminal_op_kind(:destroyed), do: :session_destroyed
+  def terminal_op_kind(:failed), do: :session_failed
+end

--- a/projects/embervm/control/lib/embervm/session_store.ex
+++ b/projects/embervm/control/lib/embervm/session_store.ex
@@ -277,7 +277,7 @@ defmodule Embervm.SessionStore do
             true -> {:ok, session}
           end
 
-        :error ->
+        {:error, {:not_found, _}} ->
           {:error, :not_found}
       end
 

--- a/projects/embervm/control/lib/embervm/session_store.ex
+++ b/projects/embervm/control/lib/embervm/session_store.ex
@@ -1,0 +1,570 @@
+defmodule Embervm.SessionStore do
+  @moduledoc """
+  ETS hot set over the op-log's durable `sessions` projection (R2), mirroring
+  `Embervm.TaskStore`: every read the session hot path needs is O(1) against ETS,
+  while every write goes through the op-log FIRST and only lands in ETS once the
+  op-log confirms it is durable. That ordering, "op-log append succeeds, then and
+  only then update ETS", is the write-through invariant this module enforces: ETS
+  never shows a session in a state the op-log does not already agree with, and a
+  crash between the two never loses a transition (worst case ETS is briefly stale
+  until the next boot's rebuild replays it).
+
+  On `init/1` this rebuilds its ETS table from `OpLog.load_sessions/1`, the
+  recovery path: a fresh SessionStore against an existing op-log ends up with
+  exactly the state the durable projection recorded, no replay logic beyond "read
+  the projection". Adoption (PR-4, Task 8) layers the NODE's reported inventory on
+  top of this durable rebuild to heal residency and limbo states.
+
+  ## what it owns
+
+    * the session hot set (`session_id -> session map`), the projected durable row
+      plus the transient FSM state the SessionManager drives it through;
+    * per-workload live/banked COUNTS, derived on every write so the create-time
+      `maxSessions` gate is an O(1) read (never a table scan);
+    * residency facts (`session_id -> {node_id, vm_id}` for a LIVE session), the
+      lossy ETS the SessionManager and placement (PR-4) read to route an invoke to
+      the VM without touching the durable store. Rebuilt from adoption, so it is
+      allowed to be empty after a restart until the node reports.
+
+  ## the token capability
+
+  `verify_token/2` is the "who may hit this session" gate ADR embervm/001 names as
+  distinct from management auth: it looks the session up BY id, then compares the
+  presented token's sha256 CONSTANT-TIME against the stored hash (see
+  `Embervm.SessionId`). A token for session S authenticates ONLY S: the lookup is
+  by the id from the URL, so possession of S's token grants nothing on S'. A
+  terminal session rejects every token (the capability dies with the session).
+  """
+
+  use GenServer
+
+  alias Embervm.OpLog.Op
+  alias Embervm.{SessionId, SessionState}
+
+  @sessions_table :embervm_sessions
+  @residency_table :embervm_session_residency
+
+  # The live (non-terminal) session states, for the per-workload counts and the
+  # capacity gate. `banked` is counted separately because it holds disk, not a VM.
+  @live_states [:creating, :running, :banking, :relighting]
+
+  # -- Client API ------------------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc """
+  Creates a new session, minting its id and capability token. `attrs` is
+  `%{tenant, principal, workload, node_id, vm_id, base_snapshot_ref, base_digest,
+  expires_at}`. Appends `session_created` (write-through), inserts the ETS hot-set
+  row in `:running` (the create claimed a live VM), records the residency fact,
+  and returns `{:ok, %{session_id, token, expires_at, base_digest, ...}}`. The
+  plaintext token is returned ONLY here and never stored.
+  """
+  @spec create(GenServer.server(), map()) :: {:ok, map()} | {:error, term()}
+  def create(store \\ __MODULE__, attrs) do
+    GenServer.call(store, {:create, attrs})
+  end
+
+  @doc """
+  Applies an FSM transition to a session, appending the matching op write-through.
+  `event` is a `SessionState` event; `op_kind` and `payload` describe the op.
+  `updates` are extra fields merged into the ETS row (e.g. `snapshot_ref`,
+  `generation`, `node_id`, `vm_id`) AFTER the durable append succeeds. Terminal
+  transitions drop the residency fact and wake parked callers. Returns the updated
+  session or `{:error, reason}` (including `{:illegal_transition, ...}`).
+  """
+  @spec transition(GenServer.server(), String.t(), atom(), atom(), map(), map()) ::
+          {:ok, map()} | {:error, term()}
+  def transition(store \\ __MODULE__, session_id, event, op_kind, payload, updates) do
+    GenServer.call(store, {:transition, session_id, event, op_kind, payload, updates})
+  end
+
+  @doc """
+  Records a `session_invoked` op (usage only, NO request/response bodies) against a
+  running session: a non-state-changing write-through (running -> running) so it is
+  NOT an FSM transition. Bumps `last_invoke_at` and charges usage to the quota cache
+  and usage projection in the same op (D12.1). `usage` is `%{cpu_ms, peak_rss_mib,
+  wall_ms, ...}` or nil (charges nothing). Returns `{:ok, session}` or an error.
+  """
+  @spec record_invoke(GenServer.server(), String.t(), map() | nil) ::
+          {:ok, map()} | {:error, term()}
+  def record_invoke(store \\ __MODULE__, session_id, usage) do
+    GenServer.call(store, {:record_invoke, session_id, usage})
+  end
+
+  @doc "The session's hot-set row, or `:error` if unknown."
+  @spec get(GenServer.server(), String.t()) :: {:ok, map()} | :error
+  def get(store \\ __MODULE__, session_id) do
+    GenServer.call(store, {:get, session_id})
+  end
+
+  @doc """
+  The residency fact (`{node_id, vm_id}`) for a LIVE session, or `:error` if the
+  session is not live or unknown. A lossy ETS read (rebuilt by adoption), so the
+  caller must tolerate `:error` for a session the store believes live but whose
+  fact a restart has not yet re-learned.
+  """
+  @spec residency(GenServer.server(), String.t()) :: {:ok, {String.t(), String.t()}} | :error
+  def residency(store \\ __MODULE__, session_id) do
+    GenServer.call(store, {:residency, session_id})
+  end
+
+  @doc """
+  Whether `token` authenticates the session `session_id`: a constant-time hash
+  compare against the stored sha256, guarded by "the session exists and is not
+  terminal". Returns `{:ok, session}` for a valid token on a live session,
+  `{:error, :terminal}` for a valid token on a terminal one (so the caller can
+  410 with the recorded reason), `{:error, :unauthorized}` for a bad token, or
+  `{:error, :not_found}`.
+  """
+  @spec verify_token(GenServer.server(), String.t(), String.t()) ::
+          {:ok, map()} | {:error, :terminal | :unauthorized | :not_found}
+  def verify_token(store \\ __MODULE__, session_id, token) do
+    GenServer.call(store, {:verify_token, session_id, token})
+  end
+
+  @doc """
+  Live and banked counts for `workload` (`%{live, banked}`), the O(1) create-time
+  capacity read. Live is any non-terminal, non-banked session; banked is the
+  `banked` state. Reads the maintained per-workload counter, never a scan.
+  """
+  @spec counts(GenServer.server(), String.t()) :: %{live: non_neg_integer(), banked: non_neg_integer()}
+  def counts(store \\ __MODULE__, workload) do
+    GenServer.call(store, {:counts, workload})
+  end
+
+  @doc """
+  Pages sessions for `workload`, newest-created first, by `:limit` (default 50)
+  and `:offset` (default 0). A full ETS scan (bounded, listing is rare), never
+  the op-log; serves `GET /v1/workloads/{name}/sessions`.
+  """
+  @spec list(GenServer.server(), String.t(), keyword()) :: {:ok, map()}
+  def list(store \\ __MODULE__, workload, opts \\ []) do
+    GenServer.call(store, {:list, workload, opts})
+  end
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    op_log = Keyword.get(opts, :op_log, Embervm.OpLog.SQLite)
+    clock = Keyword.get(opts, :clock, &default_clock/0)
+    id_fun = Keyword.get(opts, :id_fun, nil)
+    # Fired AFTER a session_invoked/other op that carried usage lands durably,
+    # %{principal, ts, stats}, so Embervm.Metering charges the quota cache off the
+    # same write, exactly like TaskStore. No-op default (unit tests wire none).
+    on_metered = Keyword.get(opts, :on_metered, fn _event -> :ok end)
+
+    sessions = :ets.new(@sessions_table, [:set, :private])
+    residency = :ets.new(@residency_table, [:set, :private])
+
+    state = %{
+      op_log: op_log,
+      clock: clock,
+      id_fun: id_fun,
+      on_metered: on_metered,
+      sessions: sessions,
+      residency: residency,
+      # workload -> %{live, banked}, kept in step with the hot set on every write.
+      counts: %{}
+    }
+
+    case rebuild(state) do
+      {:ok, state} -> {:ok, state}
+      {:error, reason} -> {:stop, {:rebuild_failed, reason}}
+    end
+  end
+
+  # Rebuild: read every durable session row and populate the hot set + counts from
+  # scratch. No per-op replay: the projection already IS the current state. The
+  # residency table is NOT rebuilt here (it is a live-VM fact the node reports;
+  # adoption in PR-4 fills it) so a fresh boot has empty residency until the node
+  # is heard from, which is correct (the control plane must not assume a VM lives
+  # where a stale durable node_id says without the node confirming).
+  defp rebuild(state) do
+    case Embervm.OpLog.SQLite.load_sessions(state.op_log) do
+      {:ok, rows} ->
+        state =
+          Enum.reduce(rows, state, fn row, acc ->
+            session = row_to_session(row)
+            :ets.insert(acc.sessions, {session.session_id, session})
+            bump_counts(acc, nil, session.state, session.workload)
+          end)
+
+        {:ok, state}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp row_to_session(row) do
+    %{
+      session_id: row.session_id,
+      tenant: row.tenant,
+      principal: row.principal,
+      workload: row.workload,
+      state: state_from_string(row.state),
+      node_id: row.node_id,
+      vm_id: nil,
+      base_snapshot_ref: row.base_snapshot_ref,
+      base_digest: row.base_digest,
+      generation: row.generation || 0,
+      snapshot_ref: row.snapshot_ref,
+      snapshot_size_bytes: row.snapshot_size_bytes,
+      token_sha256: row.token_sha256,
+      created_at: row.created_at,
+      last_invoke_at: row.last_invoke_at,
+      expires_at: row.expires_at,
+      updated_at: row.updated_at,
+      terminal_reason: row.terminal_reason
+    }
+  end
+
+  # Explicit map (not String.to_existing_atom): fails loudly on an unknown string
+  # and documents the exact projection strings, exactly as TaskStore does.
+  @state_strings %{
+    "creating" => :creating,
+    "running" => :running,
+    "banking" => :banking,
+    "banked" => :banked,
+    "relighting" => :relighting,
+    "expired" => :expired,
+    "evicted" => :evicted,
+    "destroyed" => :destroyed,
+    "failed" => :failed
+  }
+
+  defp state_from_string(str), do: Map.fetch!(@state_strings, str)
+
+  @impl true
+  def handle_call({:create, attrs}, _from, state) do
+    do_create(attrs, state)
+  end
+
+  def handle_call({:transition, session_id, event, op_kind, payload, updates}, _from, state) do
+    do_transition(state, session_id, event, op_kind, payload, updates)
+  end
+
+  def handle_call({:record_invoke, session_id, usage}, _from, state) do
+    do_record_invoke(state, session_id, usage)
+  end
+
+  def handle_call({:get, session_id}, _from, state) do
+    {:reply, get_view(state, session_id), state}
+  end
+
+  def handle_call({:residency, session_id}, _from, state) do
+    case :ets.lookup(state.residency, session_id) do
+      [{^session_id, {node_id, vm_id}}] -> {:reply, {:ok, {node_id, vm_id}}, state}
+      [] -> {:reply, :error, state}
+    end
+  end
+
+  def handle_call({:verify_token, session_id, token}, _from, state) do
+    reply =
+      case fetch(state, session_id) do
+        {:ok, session} ->
+          cond do
+            not SessionId.verify_token(token, session.token_sha256) -> {:error, :unauthorized}
+            SessionState.terminal?(session.state) -> {:error, :terminal}
+            true -> {:ok, session}
+          end
+
+        :error ->
+          {:error, :not_found}
+      end
+
+    {:reply, reply, state}
+  end
+
+  def handle_call({:counts, workload}, _from, state) do
+    {:reply, Map.get(state.counts, workload, %{live: 0, banked: 0}), state}
+  end
+
+  def handle_call({:list, workload, opts}, _from, state) do
+    limit = Keyword.get(opts, :limit, 50)
+    offset = Keyword.get(opts, :offset, 0)
+
+    all =
+      :ets.foldl(
+        fn {_id, session}, acc ->
+          if session.workload == workload, do: [session | acc], else: acc
+        end,
+        [],
+        state.sessions
+      )
+      |> Enum.sort_by(& &1.created_at, :desc)
+
+    page = all |> Enum.drop(offset) |> Enum.take(limit)
+    {:reply, {:ok, %{items: page, total: length(all), limit: limit, offset: offset}}, state}
+  end
+
+  # -- create ----------------------------------------------------------------
+
+  defp do_create(attrs, state) do
+    ts = state.clock.()
+    session_id = mint_id(state, ts)
+    {token, token_sha256} = SessionId.mint_token()
+
+    payload = %{
+      node_id: Map.get(attrs, :node_id),
+      base_snapshot_ref: Map.get(attrs, :base_snapshot_ref),
+      base_digest: Map.get(attrs, :base_digest),
+      token_sha256: token_sha256,
+      expires_at: Map.get(attrs, :expires_at),
+      # The durable projection defaults session_created to "running" (the create
+      # already claimed a live VM); recorded explicitly for clarity.
+      state: "running"
+    }
+
+    op = %Op{
+      kind: :session_created,
+      tenant: Map.fetch!(attrs, :tenant),
+      principal: Map.get(attrs, :principal),
+      workload: Map.fetch!(attrs, :workload),
+      session_id: session_id,
+      ts: ts,
+      payload: payload
+    }
+
+    case Embervm.OpLog.SQLite.append(state.op_log, op) do
+      {:ok, _seq} ->
+        session = %{
+          session_id: session_id,
+          tenant: op.tenant,
+          principal: op.principal,
+          workload: op.workload,
+          state: :running,
+          node_id: Map.get(attrs, :node_id),
+          vm_id: Map.get(attrs, :vm_id),
+          base_snapshot_ref: Map.get(attrs, :base_snapshot_ref),
+          base_digest: Map.get(attrs, :base_digest),
+          generation: 0,
+          snapshot_ref: nil,
+          snapshot_size_bytes: nil,
+          token_sha256: token_sha256,
+          created_at: ts,
+          last_invoke_at: nil,
+          expires_at: Map.get(attrs, :expires_at),
+          updated_at: ts,
+          terminal_reason: nil
+        }
+
+        :ets.insert(state.sessions, {session_id, session})
+        put_residency(state, session)
+        state = bump_counts(state, nil, :running, session.workload)
+
+        reply = %{
+          session_id: session_id,
+          token: token,
+          expires_at: session.expires_at,
+          base_digest: session.base_digest,
+          state: :running
+        }
+
+        {:reply, {:ok, reply}, state}
+
+      {:error, _reason} = error ->
+        {:reply, error, state}
+    end
+  end
+
+  # -- transition ------------------------------------------------------------
+
+  defp do_transition(state, session_id, event, op_kind, payload, updates) do
+    with {:ok, session} <- fetch(state, session_id),
+         {:ok, next} <- SessionState.transition(session.state, event) do
+      case append_and_update(state, session, op_kind, next, payload, updates) do
+        {:ok, updated, state} -> {:reply, {:ok, updated}, state}
+        {:error, reason} -> {:reply, {:error, reason}, state}
+      end
+    else
+      {:error, _reason} = error -> {:reply, error, state}
+    end
+  end
+
+  # session_invoked is running -> running (no FSM edge): a durable usage/last_invoke
+  # write-through that does not move the state machine. Only a running session may
+  # record an invoke (a banked/relighting session is not serving); a non-running
+  # state is `{:error, :not_running}` so a race cannot journal an invoke against a
+  # session that already banked or failed.
+  defp do_record_invoke(state, session_id, usage) do
+    case fetch(state, session_id) do
+      {:ok, %{state: :running} = session} ->
+        ts = state.clock.()
+        payload = maybe_put_usage(%{}, usage)
+
+        op = %Op{
+          kind: :session_invoked,
+          tenant: session.tenant,
+          principal: session.principal,
+          workload: session.workload,
+          session_id: session_id,
+          ts: ts,
+          payload: payload
+        }
+
+        case Embervm.OpLog.SQLite.append(state.op_log, op) do
+          {:ok, _seq} ->
+            updated = %{session | last_invoke_at: ts, updated_at: ts}
+            :ets.insert(state.sessions, {session_id, updated})
+            notify_metered(state, updated, usage)
+            {:reply, {:ok, updated}, state}
+
+          {:error, _reason} = error ->
+            {:reply, error, state}
+        end
+
+      {:ok, _session} ->
+        {:reply, {:error, :not_running}, state}
+
+      {:error, _reason} = error ->
+        {:reply, error, state}
+    end
+  end
+
+  # Bill raw usage stats into an op payload alongside the computed vcpu/gb-seconds,
+  # matching TaskStore.maybe_put_usage; no :usage key for nil usage so the projection
+  # stays a no-op. session_invoked's payload carries usage ONLY (no bodies).
+  defp maybe_put_usage(payload, nil), do: payload
+
+  defp maybe_put_usage(payload, stats) when is_map(stats) do
+    Map.put(payload, :usage, Map.merge(stats, Embervm.Usage.billed(stats)))
+  end
+
+  # The write-through core: append to the op-log, and ONLY on {:ok, seq} update
+  # ETS. On append failure ETS is left untouched (as durable as the op-log agrees)
+  # and the error is returned. The `updates` map lets a bank/relight carry
+  # snapshot_ref/generation/node_id/vm_id into the row atomically with the state
+  # change. Terminal transitions record the reason, drop the residency fact, and
+  # (for usage-carrying payloads) fire the metering hook.
+  defp append_and_update(state, session, op_kind, next_state, payload, updates) do
+    ts = state.clock.()
+
+    op = %Op{
+      kind: op_kind,
+      tenant: session.tenant,
+      principal: session.principal,
+      workload: session.workload,
+      session_id: session.session_id,
+      ts: ts,
+      payload: payload
+    }
+
+    case Embervm.OpLog.SQLite.append(state.op_log, op) do
+      {:ok, _seq} ->
+        terminal_reason =
+          if SessionState.terminal?(next_state) do
+            to_string(Map.get(payload, :reason, next_state))
+          else
+            session.terminal_reason
+          end
+
+        updated =
+          session
+          |> Map.merge(updates)
+          |> Map.merge(%{state: next_state, updated_at: ts, terminal_reason: terminal_reason})
+
+        :ets.insert(state.sessions, {session.session_id, updated})
+        state = bump_counts(state, session.state, next_state, session.workload)
+        state = apply_residency(state, session.state, updated)
+        notify_metered(state, updated, Map.get(payload, :usage))
+
+        {:ok, updated, state}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # -- residency + counts ----------------------------------------------------
+
+  # A LIVE session with a node+vm is routable; keep its fact. A banked/terminal
+  # session has no VM: drop it. Called on every transition so the fact tracks the
+  # live/not-live boundary exactly.
+  defp apply_residency(state, _prior, session) do
+    if session.state in @live_states and is_binary(session.node_id) and is_binary(session.vm_id) do
+      :ets.insert(state.residency, {session.session_id, {session.node_id, session.vm_id}})
+    else
+      :ets.delete(state.residency, session.session_id)
+    end
+
+    state
+  end
+
+  defp put_residency(state, session) do
+    apply_residency(state, nil, session)
+  end
+
+  # Maintain the per-workload {live, banked} counters as a session moves between
+  # buckets. `prior` nil means "entering" (rebuild/create); otherwise decrement the
+  # prior bucket and increment the next. A terminal state is neither live nor
+  # banked, so it decrements without a matching increment.
+  defp bump_counts(state, prior, next, workload) do
+    counts = Map.get(state.counts, workload, %{live: 0, banked: 0})
+
+    counts =
+      counts
+      |> dec_bucket(bucket_of(prior))
+      |> inc_bucket(bucket_of(next))
+
+    %{state | counts: Map.put(state.counts, workload, counts)}
+  end
+
+  defp bucket_of(nil), do: nil
+  defp bucket_of(:banked), do: :banked
+  defp bucket_of(state) when state in @live_states, do: :live
+  defp bucket_of(_terminal), do: nil
+
+  defp inc_bucket(counts, nil), do: counts
+  defp inc_bucket(counts, bucket), do: Map.update!(counts, bucket, &(&1 + 1))
+
+  defp dec_bucket(counts, nil), do: counts
+  defp dec_bucket(counts, bucket), do: Map.update!(counts, bucket, &max(&1 - 1, 0))
+
+  # -- helpers ---------------------------------------------------------------
+
+  defp fetch(state, session_id) do
+    case :ets.lookup(state.sessions, session_id) do
+      [{^session_id, session}] -> {:ok, session}
+      [] -> {:error, {:not_found, session_id}}
+    end
+  end
+
+  defp get_view(state, session_id) do
+    case fetch(state, session_id) do
+      {:ok, session} -> {:ok, session}
+      {:error, _} -> :error
+    end
+  end
+
+  # Mint an id: an injected id_fun (tests) or a ULID over the create timestamp.
+  defp mint_id(%{id_fun: fun}, _ts) when is_function(fun, 0), do: fun.()
+  defp mint_id(%{id_fun: fun}, ts) when is_function(fun, 1), do: fun.(ts)
+  defp mint_id(_state, ts), do: SessionId.new(ts)
+
+  # Best-effort, caught, fire-and-forget: a raise or missing hook never fails the
+  # (already durable) transition, mirroring TaskStore.notify_metered.
+  defp notify_metered(_state, _session, nil), do: :ok
+
+  defp notify_metered(state, session, stats) when is_map(stats) do
+    try do
+      state.on_metered.(%{principal: session.principal, ts: session.updated_at, stats: stats})
+    rescue
+      _ -> :ok
+    catch
+      _, _ -> :ok
+    end
+
+    :ok
+  end
+
+  defp default_clock, do: System.system_time(:millisecond)
+end

--- a/projects/embervm/control/test/embervm/router_test.exs
+++ b/projects/embervm/control/test/embervm/router_test.exs
@@ -479,7 +479,7 @@ defmodule Embervm.RouterTest do
     ok = req(:post, "/v1/sessions/s-live/invoke", auth("sess-token-live"), "payload")
     assert ok.status == 200
     assert ok.body == "echoed"
-    assert Enum.any?(ok.resp_headers, fn {k, v} -> k == "content-type" and v =~ "text/plain" end)
+    assert Enum.any?(ok.headers, fn {k, v} -> k == "content-type" and v =~ "text/plain" end)
   end
 
   test "invoke on a terminal session (valid token) is 410 with the reason" do

--- a/projects/embervm/control/test/embervm/router_test.exs
+++ b/projects/embervm/control/test/embervm/router_test.exs
@@ -21,6 +21,48 @@ defmodule Embervm.RouterTest do
     def authenticate(_), do: {:error, :unauthenticated}
   end
 
+  # Fakes for the R2 session routes: the router resolves the session manager/store
+  # from app-env (the :session_manager / :session_store_mod keys), so a request test
+  # can drive the HTTP surface, and especially the SESSION-TOKEN auth boundary,
+  # without a live daemon or the supervised SessionManager.
+  defmodule FakeSessionManager do
+    def create(_srv, "wl-ok", _principal),
+      do: {:ok, %{session_id: "s-live", token: "sess-token-live", expires_at: 9_000_000, base_digest: "sha256:x", state: :running}}
+
+    def create(_srv, "wl-cap", _principal), do: {:error, {:denied, :session_cap}}
+    def create(_srv, "wl-task", _principal), do: {:error, {:denied, :not_session_class}}
+    def create(_srv, _wl, _principal), do: {:error, {:denied, :unknown_workload}}
+
+    def invoke(_srv, "s-live", _req), do: {:ok, %{status_code: 200, headers: %{"content-type" => "text/plain"}, body: "echoed"}}
+    def invoke(_srv, "s-queue", _req), do: {:error, :queue_full}
+    def invoke(_srv, _id, _req), do: {:error, :not_found}
+
+    def destroy(_srv, "s-live"), do: {:ok, :destroyed}
+    def destroy(_srv, _id), do: {:error, :not_found}
+  end
+
+  defmodule FakeSessionStore do
+    # s-live's token is "sess-token-live"; any other token is unauthorized.
+    def verify_token(_srv, "s-live", "sess-token-live"), do: {:ok, %{session_id: "s-live"}}
+    def verify_token(_srv, "s-live", _), do: {:error, :unauthorized}
+    def verify_token(_srv, "s-queue", "sess-token-queue"), do: {:ok, %{session_id: "s-queue"}}
+    def verify_token(_srv, "s-term", "sess-token-term"), do: {:error, :terminal}
+    def verify_token(_srv, _id, _token), do: {:error, :not_found}
+
+    def get(_srv, "s-live"),
+      do: {:ok, %{session_id: "s-live", workload: "wl-ok", principal: "p", state: :running, generation: 0, base_digest: "sha256:x", created_at: 1, last_invoke_at: nil, expires_at: 9_000_000, updated_at: 1, terminal_reason: nil}}
+
+    def get(_srv, "s-term"),
+      do: {:ok, %{session_id: "s-term", workload: "wl-ok", principal: "p", state: :destroyed, generation: 0, base_digest: "sha256:x", created_at: 1, last_invoke_at: nil, expires_at: 9_000_000, updated_at: 1, terminal_reason: "destroyed"}}
+
+    def get(_srv, _id), do: :error
+
+    def list(_srv, "wl-ok", _opts),
+      do: {:ok, %{items: [], total: 0, limit: 50, offset: 0}}
+
+    def list(_srv, _wl, _opts), do: {:ok, %{items: [], total: 0, limit: 50, offset: 0}}
+  end
+
   setup do
     Application.put_env(:embervm, :authenticator, FakeAuth)
 
@@ -30,9 +72,16 @@ defmodule Embervm.RouterTest do
       Application.delete_env(:embervm, :sync_timeout_ms)
       Application.delete_env(:embervm, :quota)
       Application.delete_env(:embervm, :usage_admins)
+      Application.delete_env(:embervm, :session_manager)
+      Application.delete_env(:embervm, :session_store_mod)
     end)
 
     :ok
+  end
+
+  defp with_session_fakes do
+    Application.put_env(:embervm, :session_manager, FakeSessionManager)
+    Application.put_env(:embervm, :session_store_mod, FakeSessionStore)
   end
 
   defp unique(prefix), do: "#{prefix}-#{System.unique_integer([:positive, :monotonic])}"
@@ -381,5 +430,109 @@ defmodule Embervm.RouterTest do
     body = json(resp.body)
     assert body["error"] =~ "quota"
     assert body["retryable"] == true
+  end
+
+  # -- session routes (R2) ---------------------------------------------------
+
+  test "POST /v1/workloads/:name/sessions creates a session and returns the token once (management auth)" do
+    with_session_fakes()
+
+    resp = req(:post, "/v1/workloads/wl-ok/sessions", auth("good"))
+    assert resp.status == 201
+    body = json(resp.body)
+    assert body["session_id"] == "s-live"
+    assert body["session_token"] == "sess-token-live"
+    assert body["state"] == "running"
+  end
+
+  test "session create requires management auth (401 without a token)" do
+    with_session_fakes()
+    assert req(:post, "/v1/workloads/wl-ok/sessions").status == 401
+  end
+
+  test "session create denials map to distinguishable statuses" do
+    with_session_fakes()
+
+    cap = req(:post, "/v1/workloads/wl-cap/sessions", auth("good"))
+    assert cap.status == 429
+    assert json(cap.body)["reason"] == "session_cap"
+
+    task = req(:post, "/v1/workloads/wl-task/sessions", auth("good"))
+    assert task.status == 403
+    assert json(task.body)["reason"] == "not_session_class"
+
+    unknown = req(:post, "/v1/workloads/wl-nope/sessions", auth("good"))
+    assert unknown.status == 404
+  end
+
+  test "invoke is gated on the SESSION token: a management token alone is rejected 403" do
+    with_session_fakes()
+
+    # A valid MANAGEMENT token ("good") is NOT this session's token: 403.
+    mgmt = req(:post, "/v1/sessions/s-live/invoke", auth("good"), "payload")
+    assert mgmt.status == 403
+
+    # No token at all: 401.
+    assert req(:post, "/v1/sessions/s-live/invoke", [], "x").status == 401
+
+    # The session's own token: the invoke proxies and returns the guest response.
+    ok = req(:post, "/v1/sessions/s-live/invoke", auth("sess-token-live"), "payload")
+    assert ok.status == 200
+    assert ok.body == "echoed"
+    assert Enum.any?(ok.resp_headers, fn {k, v} -> k == "content-type" and v =~ "text/plain" end)
+  end
+
+  test "invoke on a terminal session (valid token) is 410 with the reason" do
+    with_session_fakes()
+
+    resp = req(:post, "/v1/sessions/s-term/invoke", auth("sess-token-term"), "x")
+    assert resp.status == 410
+    assert json(resp.body)["reason"] == "destroyed"
+  end
+
+  test "invoke queue-full maps to 429" do
+    with_session_fakes()
+
+    # s-queue authorizes with its own token and the manager fake returns :queue_full.
+    resp = req(:post, "/v1/sessions/s-queue/invoke", auth("sess-token-queue"), "x")
+    assert resp.status == 429
+  end
+
+  test "GET /v1/sessions/:id accepts the session token OR a management token" do
+    with_session_fakes()
+
+    # Session token.
+    a = req(:get, "/v1/sessions/s-live", auth("sess-token-live"))
+    assert a.status == 200
+    assert json(a.body)["session_id"] == "s-live"
+
+    # Management token (TokenReview via FakeAuth "good").
+    b = req(:get, "/v1/sessions/s-live", auth("good"))
+    assert b.status == 200
+
+    # A bad token is 403.
+    assert req(:get, "/v1/sessions/s-live", auth("nope")).status == 403
+
+    # No token is 401.
+    assert req(:get, "/v1/sessions/s-live").status == 401
+  end
+
+  test "DELETE /v1/sessions/:id destroys (management auth)" do
+    with_session_fakes()
+
+    assert req(:delete, "/v1/sessions/s-live", auth("good")).status == 200
+    assert req(:delete, "/v1/sessions/s-nope", auth("good")).status == 404
+    # Management auth required.
+    assert req(:delete, "/v1/sessions/s-live").status == 401
+  end
+
+  test "GET /v1/workloads/:name/sessions lists (management auth)" do
+    with_session_fakes()
+
+    resp = req(:get, "/v1/workloads/wl-ok/sessions", auth("good"))
+    assert resp.status == 200
+    body = json(resp.body)
+    assert body["workload"] == "wl-ok"
+    assert body["items"] == []
   end
 end

--- a/projects/embervm/control/test/embervm/session_id_test.exs
+++ b/projects/embervm/control/test/embervm/session_id_test.exs
@@ -1,0 +1,66 @@
+defmodule Embervm.SessionIdTest do
+  @moduledoc """
+  Session id shape + the token mint/verify capability: constant-time verification,
+  a token authenticates exactly one hash, a tampered or wrong token is rejected,
+  and the stored form is a hash (never the plaintext).
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.SessionId
+
+  test "new/1 produces an s-<26-char ULID> id whose time prefix orders lexicographically" do
+    a = SessionId.new(1_000_000)
+    b = SessionId.new(2_000_000)
+
+    assert String.starts_with?(a, "s-")
+    assert String.length(a) == 28
+    # 26 base32 chars after the s- prefix.
+    assert String.length(String.replace_prefix(a, "s-", "")) == 26
+    # A later timestamp sorts after an earlier one (ULID time prefix).
+    assert a < b
+  end
+
+  test "ids are unique across many mints at the same timestamp (random tail)" do
+    ids = for _ <- 1..1000, do: SessionId.new(1_000_000)
+    assert length(Enum.uniq(ids)) == 1000
+  end
+
+  test "mint_token returns a url-safe token and its lowercase-hex sha256" do
+    {token, sha} = SessionId.mint_token()
+
+    # 32 random bytes, base64url no padding -> 43 chars, url-safe alphabet only.
+    assert String.match?(token, ~r/^[A-Za-z0-9_-]+$/)
+    assert sha == SessionId.token_sha256(token)
+    # sha256 hex is 64 lowercase hex chars.
+    assert String.match?(sha, ~r/^[0-9a-f]{64}$/)
+    # The plaintext token is never equal to its stored hash.
+    refute token == sha
+  end
+
+  test "verify_token accepts the right token and rejects a wrong or tampered one" do
+    {token, sha} = SessionId.mint_token()
+
+    assert SessionId.verify_token(token, sha)
+
+    # A different token (another session's) does not verify against this hash.
+    {other, _other_sha} = SessionId.mint_token()
+    refute SessionId.verify_token(other, sha)
+
+    # A tampered token (one byte flipped) does not verify.
+    tampered = flip_last_char(token)
+    refute SessionId.verify_token(tampered, sha)
+  end
+
+  test "verify_token rejects a nil or malformed stored hash (a hashless row grants nothing)" do
+    {token, _sha} = SessionId.mint_token()
+    refute SessionId.verify_token(token, nil)
+    refute SessionId.verify_token(token, "not-hex")
+    refute SessionId.verify_token(token, "ab")
+  end
+
+  defp flip_last_char(token) do
+    {head, <<last::utf8>>} = String.split_at(token, String.length(token) - 1)
+    replacement = if last == ?a, do: ?b, else: ?a
+    head <> <<replacement::utf8>>
+  end
+end

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -1,0 +1,333 @@
+defmodule Embervm.SessionManagerTest do
+  @moduledoc """
+  Task 6 acceptance for Embervm.SessionManager + Embervm.Session: create from the
+  primed pool (happy path + each denial), an invoke round-trip against a fake
+  SessionAssign, the per-session queue cap, token-gated invoke (a management token
+  is not a session token), and destroy from every non-terminal state.
+
+  A FAKE DAEMON is injected via claim_fun / channel_fun / prime_fun and the
+  session_opts' session_assign/destroy funs, exactly the seam idiom the dispatcher
+  test uses. A real (unnamed) op-log + SessionStore give the real FSM and durable
+  projection; unique ETS tables + a per-test DynamicSupervisor/Registry keep tests
+  isolated from the application's supervised session subtree.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.{NodeCapacity, SessionManager, SessionStore, WorkloadCatalog}
+  alias Embervm.OpLog.SQLite
+  alias Embervm.Node.V1.{GuestResponse, SessionAssignResponse, UsageStats}
+
+  # -- harness ---------------------------------------------------------------
+
+  defp start_stack(opts \\ []) do
+    suffix = System.unique_integer([:positive])
+    cap_table = :"scap_#{suffix}"
+    cat_table = :"scat_#{suffix}"
+
+    NodeCapacity.create(cap_table)
+    WorkloadCatalog.create(cat_table)
+
+    path = Path.join(System.tmp_dir!(), "embervm_sessionmgr_test_#{suffix}.db")
+    on_exit(fn -> File.rm_rf!(path) end)
+
+    {:ok, op_log} = SQLite.start_link(name: nil, path: path)
+    {:ok, store} = SessionStore.start_link(name: nil, op_log: op_log)
+
+    registry = :"sreg_#{suffix}"
+    {:ok, _registry_pid} = Registry.start_link(keys: :unique, name: registry)
+    {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+    # A test-controlled inbox lets a test observe the fake SessionAssign calls and
+    # decide the response per call. Default: echo the body at 200 with usage.
+    assign_fun = Keyword.get(opts, :assign_fun, &default_assign/2)
+
+    session_opts = [
+      channel_fun: fn _node -> {:ok, :ch} end,
+      assign_fun: assign_fun,
+      destroy_fun: Keyword.get(opts, :destroy_fun, fn _ch, _vm -> {:ok, %{}} end),
+      invalidate_fun: fn _node, _ch -> :ok end
+    ]
+
+    mgr_opts =
+      [
+        name: nil,
+        session_store: store,
+        supervisor: sup,
+        registry: registry,
+        capacity_table: cap_table,
+        catalog_table: cat_table,
+        clock: fn -> 5_000_000 end,
+        channel_fun: fn _node -> {:ok, :ch} end,
+        claim_fun: Keyword.get(opts, :claim_fun, fn _d, _n, _w -> {:ok, "vm-primed-#{suffix}"} end),
+        prime_fun: Keyword.get(opts, :prime_fun, fn _ch, _req -> {:error, :no_prime} end),
+        session_opts: session_opts
+      ] ++
+        Keyword.take(opts, [:quota_config, :quota_table])
+
+    {:ok, mgr} = SessionManager.start_link(mgr_opts)
+
+    %{
+      mgr: mgr,
+      store: store,
+      op_log: op_log,
+      cap_table: cap_table,
+      cat_table: cat_table,
+      registry: registry,
+      sup: sup
+    }
+  end
+
+  defp default_assign(_ch, req) do
+    {:ok,
+     %SessionAssignResponse{
+       response: %GuestResponse{
+         status_code: 200,
+         headers: %{"x-echo" => "1", "content-type" => "text/plain"},
+         body: req.request.body
+       },
+       usage: %UsageStats{cpu_ms: 10, peak_rss_mib: 32, wall_ms: 20},
+       suspect: false
+     }}
+  end
+
+  defp put_session_workload(ctx, wl, opts \\ []) do
+    NodeCapacity.put(ctx.cap_table, "node-4", %{
+      node_id: "node-4",
+      configured_id: "node-4",
+      workloads: %{
+        wl => %{
+          free_primed_slots: 1,
+          snapshot_ref: "snap-#{wl}",
+          base_state: :BASE_BUILD_STATE_READY,
+          primed_vm_ids: []
+        }
+      },
+      live_vms: Keyword.get(opts, :live, 0),
+      max_live_vms: Keyword.get(opts, :max, 8),
+      draining: false,
+      updated_at: 5_000_000
+    })
+
+    WorkloadCatalog.upsert(ctx.cat_table, wl, %{
+      name: wl,
+      namespace: "embervm",
+      class: Keyword.get(opts, :class, "session"),
+      image_ref: "img@sha256:abc",
+      invoke_path: "/",
+      timeout_ms: 90_000,
+      cap: Keyword.get(opts, :cap, 8),
+      floor: 1,
+      session:
+        Keyword.get(opts, :session, %{
+          idle_bank_seconds: 300,
+          max_lifetime_seconds: 3600,
+          banked_ttl_seconds: 3600,
+          max_sessions: Keyword.get(opts, :max_sessions, 16),
+          invoke_queue_cap: Keyword.get(opts, :queue_cap, 4)
+        })
+    })
+  end
+
+  # -- create ----------------------------------------------------------------
+
+  test "create happy path: claims a primed VM, mints a token, starts a live session" do
+    ctx = start_stack()
+    put_session_workload(ctx, "wl-a")
+
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-a", "p1")
+
+    assert String.starts_with?(created.session_id, "s-")
+    assert is_binary(created.token)
+    assert created.expires_at == 5_000_000 + 3600 * 1000
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :running
+    # A live session has a process registered under its id.
+    assert [{_pid, _}] = Registry.lookup(ctx.registry, created.session_id)
+  end
+
+  test "create denies unknown workload (404-shaped reason)" do
+    ctx = start_stack()
+    assert {:error, {:denied, :unknown_workload}} = SessionManager.create(ctx.mgr, "nope", "p1")
+  end
+
+  test "create denies a task-class workload" do
+    ctx = start_stack()
+    put_session_workload(ctx, "wl-task", class: "task")
+    assert {:error, {:denied, :not_session_class}} = SessionManager.create(ctx.mgr, "wl-task", "p1")
+  end
+
+  test "create denies at the session cap (live + banked >= maxSessions)" do
+    ctx = start_stack()
+    put_session_workload(ctx, "wl-cap", max_sessions: 1)
+
+    {:ok, _} = SessionManager.create(ctx.mgr, "wl-cap", "p1")
+    assert {:error, {:denied, :session_cap}} = SessionManager.create(ctx.mgr, "wl-cap", "p1")
+  end
+
+  test "create denies when no node has ready capacity" do
+    ctx = start_stack()
+    # Catalog present but no capacity facts: pick_node returns :no_capacity.
+    WorkloadCatalog.upsert(ctx.cat_table, "wl-nocap", %{
+      name: "wl-nocap",
+      namespace: "embervm",
+      class: "session",
+      image_ref: "img@sha256:abc",
+      invoke_path: "/",
+      timeout_ms: 90_000,
+      cap: 8,
+      floor: 1,
+      session: %{idle_bank_seconds: 300, max_lifetime_seconds: 3600, banked_ttl_seconds: 3600, max_sessions: 16, invoke_queue_cap: 4}
+    })
+
+    assert {:error, {:denied, :no_capacity}} = SessionManager.create(ctx.mgr, "wl-nocap", "p1")
+  end
+
+  test "create primes on a claim miss and fails to :no_capacity when prime fails" do
+    ctx = start_stack(claim_fun: fn _d, _n, _w -> :miss end, prime_fun: fn _ch, _req -> {:error, :boom} end)
+    put_session_workload(ctx, "wl-miss")
+
+    assert {:error, {:denied, :no_capacity}} = SessionManager.create(ctx.mgr, "wl-miss", "p1")
+  end
+
+  test "create quota fail-closed denies a principal over budget" do
+    quota_table = :"squota_#{System.unique_integer([:positive])}"
+    :ets.new(quota_table, [:set, :public, :named_table])
+    # Budget of 0 for p1 = hard stop; used(0) < 0 is false, so denied.
+    quota = %{budgets: %{"p1" => 0.0}, default: nil}
+
+    ctx = start_stack(quota_config: quota, quota_table: quota_table)
+    put_session_workload(ctx, "wl-q")
+
+    assert {:error, {:denied, :quota}} = SessionManager.create(ctx.mgr, "wl-q", "p1")
+    # A principal with no budget is allowed (opt-in quota).
+    assert {:ok, _} = SessionManager.create(ctx.mgr, "wl-q", "p2")
+  end
+
+  # -- invoke ----------------------------------------------------------------
+
+  test "invoke round-trips against the fake daemon, returning the guest response verbatim" do
+    ctx = start_stack()
+    put_session_workload(ctx, "wl-inv")
+
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-inv", "p1")
+
+    req = %{method: "POST", path: "/", headers: %{}, body: "hello"}
+    {:ok, resp} = SessionManager.invoke(ctx.mgr, created.session_id, req)
+
+    assert resp.status_code == 200
+    assert resp.body == "hello"
+    assert resp.headers["x-echo"] == "1"
+
+    # The invoke was recorded (last_invoke_at set, usage charged).
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert is_integer(session.last_invoke_at)
+  end
+
+  test "invoke on an unknown session is :not_found" do
+    ctx = start_stack()
+    assert {:error, :not_found} = SessionManager.invoke(ctx.mgr, "s-unknown", %{body: "x"})
+  end
+
+  test "invoke on a terminal session returns {:gone, reason}" do
+    ctx = start_stack()
+    put_session_workload(ctx, "wl-gone")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-gone", "p1")
+    {:ok, _} = SessionManager.destroy(ctx.mgr, created.session_id)
+
+    assert {:error, {:gone, "destroyed"}} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"})
+  end
+
+  test "the queue cap rejects pile-ups past invokeQueueCap with :queue_full" do
+    # A blocking assign_fun (never replies until told) lets us fill the queue: one
+    # invoke runs, `queue_cap` more wait, and the next is rejected.
+    test_pid = self()
+
+    blocking_assign = fn _ch, req ->
+      send(test_pid, {:assign_started, self()})
+
+      receive do
+        :go ->
+          {:ok,
+           %SessionAssignResponse{
+             response: %GuestResponse{status_code: 200, headers: %{}, body: req.request.body},
+             usage: %UsageStats{cpu_ms: 1, peak_rss_mib: 1, wall_ms: 1},
+             suspect: false
+           }}
+      end
+    end
+
+    ctx = start_stack(assign_fun: blocking_assign)
+    put_session_workload(ctx, "wl-full", queue_cap: 2)
+
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-full", "p1")
+
+    # Fire the in-flight invoke + 2 queued (fills the cap of 2 waiters).
+    callers =
+      for _ <- 1..3 do
+        spawn(fn ->
+          SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"})
+        end)
+      end
+
+    # Wait until the first invoke is actually in flight (worker started).
+    assert_receive {:assign_started, _worker}, 1_000
+
+    # Give the queued callers a moment to enqueue behind the in-flight one.
+    Process.sleep(50)
+
+    # The 4th invoke exceeds the cap (1 in-flight + 2 waiting): queue_full.
+    assert {:error, :queue_full} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "y"})
+
+    Enum.each(callers, fn pid -> Process.exit(pid, :kill) end)
+  end
+
+  test "a suspect/transport failure on invoke fails the session and 502s the caller" do
+    fail_assign = fn _ch, _req ->
+      {:ok, %SessionAssignResponse{response: nil, usage: nil, suspect: true}}
+    end
+
+    ctx = start_stack(assign_fun: fail_assign)
+    put_session_workload(ctx, "wl-fail")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-fail", "p1")
+
+    assert {:error, :suspect} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"})
+
+    # The session is now failed (a guest in unknown mid-request state is not reused).
+    Process.sleep(50)
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :failed
+    assert session.terminal_reason == "failed"
+  end
+
+  # -- destroy ---------------------------------------------------------------
+
+  test "destroy from running tears down the process and records session_destroyed" do
+    ctx = start_stack()
+    put_session_workload(ctx, "wl-d")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-d", "p1")
+
+    assert {:ok, _} = SessionManager.destroy(ctx.mgr, created.session_id)
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :destroyed
+
+    # The process is gone.
+    Process.sleep(20)
+    assert Registry.lookup(ctx.registry, created.session_id) == []
+  end
+
+  test "destroy of an already-terminal session is a no-op success" do
+    ctx = start_stack()
+    put_session_workload(ctx, "wl-d2")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-d2", "p1")
+    {:ok, _} = SessionManager.destroy(ctx.mgr, created.session_id)
+
+    assert {:ok, :already_terminal} = SessionManager.destroy(ctx.mgr, created.session_id)
+  end
+
+  test "destroy of an unknown session is :not_found" do
+    ctx = start_stack()
+    assert {:error, :not_found} = SessionManager.destroy(ctx.mgr, "s-nope")
+  end
+end

--- a/projects/embervm/control/test/embervm/session_state_test.exs
+++ b/projects/embervm/control/test/embervm/session_state_test.exs
@@ -1,0 +1,81 @@
+defmodule Embervm.SessionStateTest do
+  @moduledoc """
+  Exhaustively walks the (state, event) cartesian product against the session
+  FSM's transition table: every legal pair returns the documented next state, and
+  every illegal pair is rejected the same way (never silently accepted, never a
+  different error shape). Mirrors Embervm.TaskStateTest; the totality of the
+  illegal-transition rejection is what a bank/relight/destroy path relies on to
+  fail loudly instead of corrupting state.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.SessionState
+
+  @legal %{
+    {:creating, :create_ready} => :running,
+    {:running, :bank} => :banking,
+    {:banking, :bank_ready} => :banked,
+    {:banked, :relight} => :relighting,
+    {:relighting, :relight_ready} => :running,
+    {:running, :expire} => :expired,
+    {:banked, :expire} => :expired,
+    {:banked, :evict} => :evicted,
+    {:creating, :destroy} => :destroyed,
+    {:running, :destroy} => :destroyed,
+    {:banking, :destroy} => :destroyed,
+    {:banked, :destroy} => :destroyed,
+    {:relighting, :destroy} => :destroyed,
+    {:creating, :fail} => :failed,
+    {:running, :fail} => :failed,
+    {:banking, :fail} => :failed,
+    {:relighting, :fail} => :failed
+  }
+
+  test "exhaustive transition table: every (state, event) pair matches the documented outcome" do
+    assert map_size(@legal) == 17
+    assert length(SessionState.events()) == 9
+    assert length(SessionState.states()) == 9
+
+    for state <- SessionState.states(), event <- SessionState.events() do
+      case Map.fetch(@legal, {state, event}) do
+        {:ok, expected_next} ->
+          assert SessionState.transition(state, event) == {:ok, expected_next},
+                 "expected #{inspect({state, event})} -> {:ok, #{inspect(expected_next)}}"
+
+          assert SessionState.transition!(state, event) == expected_next
+
+        :error ->
+          assert SessionState.transition(state, event) ==
+                   {:error, {:illegal_transition, state, event}},
+                 "expected #{inspect({state, event})} to be illegal"
+
+          assert_raise SessionState.IllegalTransition, fn ->
+            SessionState.transition!(state, event)
+          end
+      end
+    end
+  end
+
+  test "no event leaves a terminal state (terminals are absorbing)" do
+    for state <- SessionState.terminal_states(), event <- SessionState.events() do
+      assert SessionState.transition(state, event) == {:error, {:illegal_transition, state, event}}
+    end
+  end
+
+  test "terminal?/1 is true only for the four terminal states" do
+    expected = MapSet.new([:expired, :evicted, :destroyed, :failed])
+
+    for state <- SessionState.states() do
+      assert SessionState.terminal?(state) == MapSet.member?(expected, state)
+    end
+
+    assert MapSet.new(SessionState.terminal_states()) == expected
+  end
+
+  test "terminal_op_kind/1 maps each terminal state to its op kind" do
+    assert SessionState.terminal_op_kind(:expired) == :session_expired
+    assert SessionState.terminal_op_kind(:evicted) == :session_evicted
+    assert SessionState.terminal_op_kind(:destroyed) == :session_destroyed
+    assert SessionState.terminal_op_kind(:failed) == :session_failed
+  end
+end

--- a/projects/embervm/control/test/embervm/session_store_test.exs
+++ b/projects/embervm/control/test/embervm/session_store_test.exs
@@ -1,0 +1,226 @@
+defmodule Embervm.SessionStoreTest do
+  @moduledoc """
+  Exercises Embervm.SessionStore against a real (unnamed) Embervm.OpLog.SQLite on
+  a fresh temp file per test, mirroring the TaskStore test idiom: each async test
+  gets an independent op-log + store pair. Proves the write-through discipline
+  (op-log before ETS), the token capability (right/wrong/terminal), the
+  per-workload counts, and boot-rebuild equivalence from the durable projection.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.OpLog.SQLite
+  alias Embervm.SessionStore
+
+  setup do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "embervm_sessionstore_test_#{System.unique_integer([:positive, :monotonic])}.db"
+      )
+
+    on_exit(fn -> File.rm_rf!(path) end)
+    %{path: path}
+  end
+
+  defp start_pair(path, opts \\ []) do
+    {:ok, op_log} = SQLite.start_link(path: path, name: nil)
+    clock = Keyword.get(opts, :clock, sequential_clock())
+    id_fun = Keyword.get(opts, :id_fun, sequential_id_fun())
+
+    {:ok, store} =
+      SessionStore.start_link(op_log: op_log, name: nil, clock: clock, id_fun: id_fun)
+
+    {op_log, store}
+  end
+
+  defp sequential_id_fun do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    fn ->
+      n = Agent.get_and_update(counter, fn n -> {n + 1, n + 1} end)
+      "s-test-#{n}"
+    end
+  end
+
+  defp sequential_clock do
+    {:ok, counter} = Agent.start_link(fn -> 1_000 end)
+    fn -> Agent.get_and_update(counter, fn n -> {n, n + 1} end) end
+  end
+
+  defp create(store, opts \\ []) do
+    SessionStore.create(store, %{
+      tenant: "homelab",
+      principal: Keyword.get(opts, :principal, "p1"),
+      workload: Keyword.get(opts, :workload, "wl-a"),
+      node_id: Keyword.get(opts, :node_id, "node-4"),
+      vm_id: Keyword.get(opts, :vm_id, "vm-1"),
+      base_snapshot_ref: "base:img@sha256:abc",
+      base_digest: "sha256:abc",
+      expires_at: Keyword.get(opts, :expires_at, 999_999)
+    })
+  end
+
+  # -- create ----------------------------------------------------------------
+
+  test "create mints an id + token, returns the token once, stores only its hash", %{path: path} do
+    {op_log, store} = start_pair(path)
+
+    {:ok, created} = create(store)
+
+    assert created.session_id == "s-test-1"
+    assert is_binary(created.token)
+    assert created.state == :running
+    assert created.base_digest == "sha256:abc"
+
+    {:ok, session} = SessionStore.get(store, created.session_id)
+    assert session.state == :running
+    assert session.token_sha256 == Embervm.SessionId.token_sha256(created.token)
+    # The plaintext token is NEVER stored.
+    refute session.token_sha256 == created.token
+
+    # The durable projection agrees (write-through: op before ETS).
+    {:ok, [row]} = SQLite.load_sessions(op_log)
+    assert row.session_id == "s-test-1"
+    assert row.state == "running"
+    assert row.token_sha256 == session.token_sha256
+    # The plaintext token is nowhere in the durable row.
+    refute row.token_sha256 == created.token
+  end
+
+  test "create records residency and the live count", %{path: path} do
+    {_op_log, store} = start_pair(path)
+
+    {:ok, created} = create(store, workload: "wl-x", node_id: "node-4", vm_id: "vm-9")
+
+    assert SessionStore.residency(store, created.session_id) == {:ok, {"node-4", "vm-9"}}
+    assert SessionStore.counts(store, "wl-x") == %{live: 1, banked: 0}
+  end
+
+  # -- token capability ------------------------------------------------------
+
+  test "verify_token accepts the session's own token and rejects another session's", %{path: path} do
+    {_op_log, store} = start_pair(path)
+
+    {:ok, a} = create(store, vm_id: "vm-a")
+    {:ok, b} = create(store, vm_id: "vm-b")
+
+    assert {:ok, _} = SessionStore.verify_token(store, a.session_id, a.token)
+    # b's token grants nothing on a (a token authenticates exactly one session id).
+    assert SessionStore.verify_token(store, a.session_id, b.token) == {:error, :unauthorized}
+    # An unknown session is :not_found.
+    assert SessionStore.verify_token(store, "s-nope", a.token) == {:error, :not_found}
+  end
+
+  test "verify_token rejects every token on a terminal session", %{path: path} do
+    {_op_log, store} = start_pair(path)
+
+    {:ok, a} = create(store)
+
+    {:ok, _} =
+      SessionStore.transition(store, a.session_id, :destroy, :session_destroyed, %{reason: :destroyed}, %{})
+
+    assert SessionStore.verify_token(store, a.session_id, a.token) == {:error, :terminal}
+  end
+
+  # -- transitions (write-through) -------------------------------------------
+
+  test "an illegal transition is rejected and leaves ETS + the op-log untouched", %{path: path} do
+    {op_log, store} = start_pair(path)
+
+    {:ok, a} = create(store)
+
+    # running -> relight is illegal (only banked can relight).
+    assert {:error, {:illegal_transition, :running, :relight}} =
+             SessionStore.transition(store, a.session_id, :relight, :session_relit, %{}, %{})
+
+    # State unchanged.
+    {:ok, session} = SessionStore.get(store, a.session_id)
+    assert session.state == :running
+
+    # Only the session_created op is in the journal (no session_relit appended).
+    {:ok, ops} = SQLite.read_from(op_log, 0)
+    kinds = Enum.map(ops, & &1.kind)
+    assert kinds == [:session_created]
+  end
+
+  test "a terminal transition records the reason and drops residency", %{path: path} do
+    {_op_log, store} = start_pair(path)
+
+    {:ok, a} = create(store, workload: "wl-t")
+    assert SessionStore.counts(store, "wl-t") == %{live: 1, banked: 0}
+
+    {:ok, updated} =
+      SessionStore.transition(store, a.session_id, :fail, :session_failed, %{reason: :failed}, %{})
+
+    assert updated.state == :failed
+    assert updated.terminal_reason == "failed"
+    assert SessionStore.residency(store, a.session_id) == :error
+    assert SessionStore.counts(store, "wl-t") == %{live: 0, banked: 0}
+  end
+
+  test "record_invoke bumps last_invoke_at and usage without moving state", %{path: path} do
+    {op_log, store} = start_pair(path)
+
+    {:ok, a} = create(store)
+    usage = %{cpu_ms: 100, peak_rss_mib: 64, wall_ms: 200}
+
+    {:ok, updated} = SessionStore.record_invoke(store, a.session_id, usage)
+    assert updated.state == :running
+    assert is_integer(updated.last_invoke_at)
+
+    # The usage projection accumulated (D12.1): vcpu_seconds = 100/1000.
+    {:ok, page} = SQLite.list_usage(op_log, principal: "p1", limit: :infinity)
+    [row] = page.items
+    assert_in_delta row.vcpu_seconds, 0.1, 0.0001
+
+    # A session_invoked op is in the journal, after session_created.
+    {:ok, ops} = SQLite.read_from(op_log, 0)
+    assert Enum.map(ops, & &1.kind) == [:session_created, :session_invoked]
+  end
+
+  test "record_invoke on a non-running session is rejected", %{path: path} do
+    {_op_log, store} = start_pair(path)
+
+    {:ok, a} = create(store)
+    {:ok, _} = SessionStore.transition(store, a.session_id, :destroy, :session_destroyed, %{reason: :destroyed}, %{})
+
+    assert SessionStore.record_invoke(store, a.session_id, %{cpu_ms: 1, peak_rss_mib: 1, wall_ms: 1}) ==
+             {:error, :not_running}
+  end
+
+  # -- boot rebuild ----------------------------------------------------------
+
+  test "a fresh store rebuilds ETS + counts exactly from the durable projection", %{path: path} do
+    {op_log, store} = start_pair(path)
+
+    {:ok, a} = create(store, workload: "wl-a", vm_id: "vm-a")
+    {:ok, b} = create(store, workload: "wl-a", vm_id: "vm-b")
+    {:ok, c} = create(store, workload: "wl-b", vm_id: "vm-c")
+
+    # Take one to a terminal state so the rebuild must reproduce a terminal row too.
+    {:ok, _} = SessionStore.transition(store, c.session_id, :fail, :session_failed, %{reason: :failed}, %{})
+
+    # A new store against the SAME op-log rebuilds from the projection alone.
+    {:ok, store2} = SessionStore.start_link(op_log: op_log, name: nil)
+
+    {:ok, sa} = SessionStore.get(store2, a.session_id)
+    {:ok, sb} = SessionStore.get(store2, b.session_id)
+    {:ok, sc} = SessionStore.get(store2, c.session_id)
+
+    assert sa.state == :running
+    assert sb.state == :running
+    assert sc.state == :failed
+    assert sc.terminal_reason == "failed"
+
+    # Counts reproduce: two live on wl-a, zero live on wl-b (its one session failed).
+    assert SessionStore.counts(store2, "wl-a") == %{live: 2, banked: 0}
+    assert SessionStore.counts(store2, "wl-b") == %{live: 0, banked: 0}
+
+    # Token hashes survive the rebuild (so a token minted pre-restart still verifies).
+    assert {:ok, _} = SessionStore.verify_token(store2, a.session_id, a.token)
+
+    # Residency is NOT rebuilt from the durable node_id (adoption's job, PR-4): a
+    # fresh boot has empty residency until the node reports.
+    assert SessionStore.residency(store2, a.session_id) == :error
+  end
+end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.37
+      targetRevision: 0.1.38
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/docs/api.yaml
+++ b/projects/embervm/docs/api.yaml
@@ -118,11 +118,110 @@ paths:
               schema: { $ref: "#/components/schemas/TaskView" }
         "404": { description: No such task. }
         "409": { description: Task is not dead-lettered. }
+  /v1/workloads/{name}/sessions:
+    post:
+      summary: Create a stateful session on a session-class workload (management auth).
+      description: >-
+        Assigns a primed pristine VM from the pool (principal-bound at claim) and
+        returns a per-session capability token EXACTLY ONCE. The invocation
+        front-end never computes placement; the control plane owns node choice.
+      parameters:
+        - { name: name, in: path, required: true, schema: { type: string } }
+      responses:
+        "201":
+          description: Session created. The session_token is returned only here.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SessionCreated" }
+        "403": { description: Workload is not class session, or the caller is not allow-listed. }
+        "404": { description: Unknown workload. }
+        "429":
+          description: >-
+            Create denied: session cap (live+banked >= maxSessions), workload cap
+            (live >= concurrency.cap), daily quota exhausted, or no ready capacity.
+            The reason field distinguishes them.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    get:
+      summary: Paged listing of a workload's sessions, newest first (management auth).
+      parameters:
+        - { name: name, in: path, required: true, schema: { type: string } }
+        - { name: limit, in: query, schema: { type: integer, default: 50, minimum: 1, maximum: 500 } }
+        - { name: offset, in: query, schema: { type: integer, default: 0, minimum: 0 } }
+      responses:
+        "200":
+          description: Session page.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SessionPage" }
+  /v1/sessions/{id}/invoke:
+    post:
+      summary: Invoke a session (SESSION TOKEN auth only; a management token is rejected).
+      description: >-
+        The bearer token MUST be this session's own capability token. The request
+        body is forwarded verbatim to the guest (max 8 MiB); X-Ember-Guest-Path
+        overrides the guest path and X-Ember-Guest-* headers are forwarded (prefix
+        stripped). The guest response is returned VERBATIM including its headers.
+        Sync-only, at-most-once, never retried by the platform.
+      security:
+        - sessionToken: []
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      requestBody:
+        required: false
+        content:
+          application/octet-stream:
+            schema: { type: string, format: binary }
+      responses:
+        "200": { description: The guest response, returned verbatim (any status the guest returns). }
+        "401": { description: Missing session token. }
+        "403": { description: Invalid session token (including a management token). }
+        "409": { description: Session not ready (creating/banking/relighting). }
+        "410":
+          description: Session is terminal (expired/evicted/destroyed/failed); create a fresh one.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "413": { description: Body exceeds 8 MiB. }
+        "429": { description: Per-session invoke queue is full. }
+        "502": { description: The invoke failed at the daemon; the session is now failed. }
+  /v1/sessions/{id}:
+    get:
+      summary: Session state and metadata (management OR the session's own token).
+      security:
+        - bearerAuth: []
+        - sessionToken: []
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: Session view.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SessionView" }
+        "401": { description: Missing bearer token. }
+        "403": { description: Not authorized to read this session. }
+        "404": { description: No such session. }
+    delete:
+      summary: Destroy a session (management auth); its VM and/or snapshot are reclaimed.
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        "200": { description: Destroyed (idempotent for an already-terminal session). }
+        "404": { description: No such session. }
 components:
   securitySchemes:
     bearerAuth:
       type: http
       scheme: bearer
+    sessionToken:
+      type: http
+      scheme: bearer
+      description: >-
+        A per-session capability token, minted at create and returned once. It
+        authenticates exactly one session id (verified by hash, constant-time) and
+        never enters the guest. Distinct from the management ServiceAccount bearer.
   schemas:
     TaskRef:
       type: object
@@ -156,4 +255,42 @@ components:
       properties:
         error: { type: string }
         task_id: { type: string }
+        session_id: { type: string }
+        reason: { type: string, description: Machine-readable denial/error reason. }
         retryable: { type: boolean }
+    SessionCreated:
+      type: object
+      properties:
+        session_id: { type: string, description: "s-<26-char ULID>." }
+        session_token:
+          type: string
+          description: The per-session capability token. Returned ONCE; store it as a secret.
+        expires_at: { type: integer, description: "Max-lifetime deadline, epoch ms." }
+        base_digest: { type: string, description: The birth base the session is pinned to. }
+        state: { type: string, enum: [running] }
+    SessionView:
+      type: object
+      properties:
+        session_id: { type: string }
+        workload: { type: string }
+        principal: { type: string }
+        state:
+          type: string
+          enum: [creating, running, banking, banked, relighting, expired, evicted, destroyed, failed]
+        generation: { type: integer, description: Increments on every bank (lineage). }
+        base_digest: { type: string }
+        created_at: { type: integer, description: epoch ms }
+        last_invoke_at: { type: integer, description: epoch ms }
+        expires_at: { type: integer, description: epoch ms }
+        updated_at: { type: integer, description: epoch ms }
+        terminal_reason: { type: string, description: Set once the session is terminal. }
+    SessionPage:
+      type: object
+      properties:
+        workload: { type: string }
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/SessionView" }
+        total: { type: integer }
+        limit: { type: integer }
+        offset: { type: integer }


### PR DESCRIPTION
**PR-3 (Tasks 5-6) of EmberVM R2 Sessions**: the Elixir control-plane brain. After this, create/invoke/destroy work end-to-end against a live session (driving the PR-2 daemon verbs). Opus-implemented, Opus-reviewed with NO correctness bugs found across all eight security/concurrency scrutiny areas.

## What (2980 lines)
- **Task 5**: `session_state.ex` (explicit FSM, illegal transitions RAISE, terminals absorbing); `session_id.ex` (`s-`+ULID ids; 32-byte urlsafe tokens, sha256-stored, constant-time `:crypto.hash_equals` compare, never enter the guest); `session_store.ex` (ETS hot set rebuilt from `load_sessions` on boot, write-through op-before-ETS).
- **Task 6**: `session.ex` (one GenServer per live session under a DynamicSupervisor, FIFO invoke queue with cap, one in-flight SessionAssign, idle-timer seam for PR-4); `session_manager.ex` (serialized create with capacity/quota gates, claim-from-primed-pool or Prime); `dispatcher.ex` `claim/3` (atomic single-writer VM claim); 5 API routes on the router (create/invoke/get/delete/list) front-end only; OpenAPI in `docs/api.yaml`.

## Auth
Invoke requires the SESSION token (management bearer → 403); management routes reject session tokens (closed structural allow-list, not a prefix). A token for S grants nothing on S'.

## Failure posture
Invoke on creating/banking/relighting parks the caller; terminal → 410 {reason}; a suspect/timeout/transport SessionAssign marks the session `failed`, destroys the VM, drains queued callers.

## Decisions (DECISIONS.md D-R2.2.1-4)
Dispatcher.claim/3 for the single-writer VM claim; inline placement until PR-4's SessionPlacement; record_invoke as a non-FSM write; running-but-processless → 409 (PR-4 adoption heals).

Bump embervm 0.1.38. No local test loop; Elixir compile + session ExUnit verified in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)