### PR TITLE
feat(embervm): R2 PR-4 idle-bank, relight-on-invoke, placement, adoption

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -530,3 +530,48 @@ plan was silent. Flagged for post-impl review.
   path exists yet in PR-3 to rebind the process. `base_digest` at create is the image
   ref placeholder; PR-4 threads the BaseBuilder-resolved digest when relight lineage
   needs it.
+
+## R2 Phase 2: bank/relight, placement, adoption (PR-4)
+
+Tasks 7-8 (idle-bank/expiry/GC/eviction + relight-on-invoke/placement/adoption)
+choices where the plan was silent. Flagged for post-impl review.
+
+### D-R2.4.1 `banking`/`relighting` are ETS-only transient states, not durable ops
+- The op-log has no `session_banking`/`session_relighting` kind by design: it records
+  only COMPLETED lifecycle transitions (`session_banked`/`session_relit`). Entering
+  `banking`/`relighting` is an ETS-only move via a new `SessionStore.mark/3` (FSM edge,
+  no append); a crash mid-op heals from node inventory (the node reports either the
+  live VM or the completed snapshot, never both gone silently), not from the durable
+  log. Recovery edges `bank_abort` (banking->running) and `relight_abort`
+  (relighting->banked) are the ETS-only rollbacks on a transient RPC failure. Chosen
+  over adding two more op kinds, which would durably persist a state the FSM already
+  guarantees is transient and crash-healed.
+
+### D-R2.4.2 The bank runs async OFF the manager process (gate 3)
+- `SessionManager.bank/2` ADMITS synchronously (per-node concurrent-bank cap + disk
+  fail-closed gate + `mark(:bank)`), then spawns a worker for the Bank RPC and
+  completes the durable `session_banked` append on a `{:bank_done}` message. This keeps
+  the multi-second bank off the manager's message loop, so a bank never head-of-line-
+  blocks another session's routing (gate 3). The consequence: the per-session idle
+  process STOPS on admission and the three-consecutive-bank-failures counter lives in
+  the MANAGER (`bank_failures` map), not the (now-stopped) session process; three
+  strikes fails + destroys the VM, a strike under the limit restarts a session process.
+
+### D-R2.4.3 Adoption forces ETS state via a total `adopt_state/3`, never the FSM
+- Reconcile derives ETS purely from node truth and must be total over FSM-unbridgeable
+  limbo (e.g. a `banking` session whose node reports a live VM has no `banking->running`
+  FSM edge). `SessionStore.adopt_state/3` sets the ETS state directly (running/banked,
+  no op, never resurrects a terminal row) and `adopt_residency/4` rebinds the VM fact.
+  Reaping (mark failed) happens ONLY when the recorded node IS reporting and covers the
+  session as neither a VM nor a snapshot (authoritative vanish); a node absent from the
+  capacity table (a disconnect) leaves the session untouched (the #3517 reap-free rule).
+
+### D-R2.4.4 Mid-bank invokes park then relight; disk fail-closed is watermark-scoped
+- An invoke arriving while a session is `banking` parks in the relight ledger and is
+  relit once the bank completes (no cancel path; banking is short), matching the plan.
+  The disk fail-closed gate only bites when a snapshot-disk low watermark IS configured:
+  with none configured (eviction disabled) banking proceeds, since there is no disk
+  policy to fail closed against. The wake-rate limit is a per-principal sliding-window
+  counter (default 30/min); the FIRST banked-invoke consumes a token and relights,
+  excess ones 429 without a node hit. Mid-bank parked invokes are not re-wake-charged
+  (they arrived before the bank finished; the narrow window is not a burst lever).

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -575,3 +575,21 @@ choices where the plan was silent. Flagged for post-impl review.
   counter (default 30/min); the FIRST banked-invoke consumes a token and relights,
   excess ones 429 without a node hit. Mid-bank parked invokes are not re-wake-charged
   (they arrived before the bank finished; the narrow window is not a burst lever).
+
+### D-R2.4.5 Review fixes + one accepted follow-on (PR-4)
+- **Fixed (critical):** the bank/relight workers acquired the node channel with a bare
+  `channel_fun.(node_id)` in the `with` head; that is a `GenServer.call` which EXITS
+  (not returns) on a NodeChannel restart/dial-timeout, killing the worker before it
+  sent `{:bank_done}`/`{:relight_done}` and hanging every parked caller forever +
+  leaking the per-node bank slot. Wrapped in a `safe_channel/2` that traps the exit
+  into `{:error, {:channel_raised, _}}` so the worker always reports an outcome.
+- **Fixed (medium):** a periodic reconcile that landed mid-bank forced the session to
+  `running` (the node still reports the live VM during a bank), which then made
+  finish_bank's `session_banked` transition illegal and silently dropped. `adopt_one`
+  now skips a session the manager has in-flight in `state.banking`/`state.relighting`
+  (boot reconcile is unaffected: those maps are empty on a fresh process).
+- **Accepted (low, follow-on):** `wake_events` accumulates one key per distinct
+  relighting principal and is never pruned. Bounded by principal cardinality (not
+  request volume), negligible for a homelab; a periodic prune of empty-window keys is
+  a recorded follow-on, not done. **FLAG FOR JOE** only if principal cardinality ever
+  grows unbounded.

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.38
+version: 0.1.39

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -134,7 +134,7 @@ defmodule Embervm.Application do
       {Embervm.SessionStore, [on_metered: &Embervm.Metering.on_metered/1]},
       {Registry, keys: :unique, name: Embervm.SessionRegistry},
       {DynamicSupervisor, strategy: :one_for_one, name: Embervm.SessionSupervisor},
-      {Embervm.SessionManager, session_opts: session_opts()},
+      {Embervm.SessionManager, session_manager_opts()},
       # The op-log sweeper (ADR embervm/002): scheduled bounded-batch compaction of
       # the durable projection tables + ops-journal prefix. Placed LATE, right before
       # Bandit: it depends ONLY on the op-log (which starts early), so under
@@ -275,6 +275,68 @@ defmodule Embervm.Application do
   # in production (the session process uses its real NodeChannel/SessionAssign
   # defaults); tests inject fake daemon seams here.
   defp session_opts, do: []
+
+  # SessionManager config: the session-process seams plus the R2 policy knobs the
+  # chart wires from values (the reconcile/sweep cadences, the snapshot-disk low
+  # watermark for LRU eviction, and the per-principal wake-rate limit). Defaults keep
+  # the timers ON in production; a 0 disables the corresponding sweep.
+  defp session_manager_opts do
+    [
+      session_opts: session_opts(),
+      reconcile_interval_ms: session_reconcile_interval_ms(),
+      sweep_interval_ms: session_sweep_interval_ms(),
+      disk_low_watermark_bytes: session_disk_low_watermark_bytes()
+    ] ++ wake_opts()
+  end
+
+  # Adoption reconcile cadence (EMBERVM_SESSION_RECONCILE_INTERVAL_MS); default 10s,
+  # matching the registry sweep tempo so a restart's residency/limbo heal lands fast.
+  defp session_reconcile_interval_ms do
+    case trimmed_env("EMBERVM_SESSION_RECONCILE_INTERVAL_MS") do
+      "" -> 10_000
+      raw -> String.to_integer(raw)
+    end
+  end
+
+  # TTL/eviction sweep cadence (EMBERVM_SESSION_SWEEP_INTERVAL_MS); default 30s. This
+  # is the safety net for expiry/GC/disk-pressure; invoke-time expiry is the primary
+  # expiry check (ADR 002 rule 1), so this cadence is not correctness-critical.
+  defp session_sweep_interval_ms do
+    case trimmed_env("EMBERVM_SESSION_SWEEP_INTERVAL_MS") do
+      "" -> 30_000
+      raw -> String.to_integer(raw)
+    end
+  end
+
+  # Snapshot-disk low watermark in bytes (EMBERVM_SESSION_DISK_LOW_WATERMARK_BYTES).
+  # Unset disables disk-pressure eviction (nil): the watermark alert (Task 9) is the
+  # only signal until a value is configured. A configured value arms LRU eviction.
+  defp session_disk_low_watermark_bytes do
+    case trimmed_env("EMBERVM_SESSION_DISK_LOW_WATERMARK_BYTES") do
+      "" -> nil
+      raw -> String.to_integer(raw)
+    end
+  end
+
+  # Wake-rate limit (relight-triggering invokes per principal per window). Configured
+  # via EMBERVM_SESSION_WAKE_MAX + EMBERVM_SESSION_WAKE_WINDOW_MS; unset uses the
+  # SessionManager module defaults (30 / 60s). A max of 0 disables the limit.
+  defp wake_opts do
+    max =
+      case trimmed_env("EMBERVM_SESSION_WAKE_MAX") do
+        "" -> nil
+        raw -> String.to_integer(raw)
+      end
+
+    window =
+      case trimmed_env("EMBERVM_SESSION_WAKE_WINDOW_MS") do
+        "" -> nil
+        raw -> String.to_integer(raw)
+      end
+
+    [wake_max: max, wake_window_ms: window]
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+  end
 
   defp queue_depth_cap do
     case trimmed_env("EMBERVM_QUEUE_DEPTH_CAP") do

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -67,7 +67,7 @@ defmodule Embervm.NodeRegistry do
 
   alias Embervm.NodeCapacity
 
-  alias Embervm.Node.V1.{NodeService, NodeStatus, WatchNodeRequest, WorkloadCapacity}
+  alias Embervm.Node.V1.{NodeService, NodeStatus, SessionSnapshot, SessionVm, WatchNodeRequest, WorkloadCapacity}
 
   @unknown_after_ms 5_000
   @down_after_ms 15_000
@@ -393,9 +393,41 @@ defmodule Embervm.NodeRegistry do
       live_vms: s.live_vms,
       max_live_vms: s.max_live_vms,
       draining: false,
-      updated_at: now
+      updated_at: now,
+      # Session facts (R2): the node's LIVE session VMs and BANKED snapshot
+      # inventory, plus the sessions snapshot-dir disk usage. These are the source
+      # of truth Embervm.SessionManager reconciles its ETS residency + banked
+      # inventory against on boot and every sweep (adoption), and the disk numbers
+      # the LRU capacity-eviction policy reads. Empty/zero when a daemon never sets
+      # them (wire-compatible), which reads as "no session state, no disk pressure".
+      session_vms: session_vms_from_status(s),
+      session_snapshots: session_snapshots_from_status(s),
+      snapshot_disk_free_bytes: s.snapshot_disk_free_bytes,
+      snapshot_disk_used_bytes: s.snapshot_disk_used_bytes
     }
   end
+
+  defp session_vms_from_status(%NodeStatus{session_vms: vms}) when is_list(vms) do
+    for %SessionVm{} = v <- vms do
+      %{vm_id: v.vm_id, session_id: v.session_id, workload: v.workload}
+    end
+  end
+
+  defp session_vms_from_status(_s), do: []
+
+  defp session_snapshots_from_status(%NodeStatus{session_snapshots: snaps}) when is_list(snaps) do
+    for %SessionSnapshot{} = snap <- snaps do
+      %{
+        snapshot_ref: snap.snapshot_ref,
+        session_id: snap.session_id,
+        workload: snap.workload,
+        size_bytes: snap.size_bytes,
+        created_at_unix_ms: snap.created_at_unix_ms
+      }
+    end
+  end
+
+  defp session_snapshots_from_status(_s), do: []
 
   # -- age-out state machine --------------------------------------------------
 

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -632,6 +632,17 @@ defmodule Embervm.Router do
               retryable: true
             })
 
+          {:error, :wake_rate_limited} ->
+            # The per-principal wake-rate limit (relight-triggering invokes) tripped:
+            # 429 WITHOUT having touched the node (the asymmetric-cost relight was
+            # never issued). Retryable once the window drains.
+            send_json(conn, 429, %{
+              error: "session wake-rate limit exceeded",
+              reason: "wake_rate",
+              session_id: session_id,
+              retryable: true
+            })
+
           {:error, :not_found} ->
             send_json(conn, 404, %{error: "session not found", session_id: session_id, retryable: false})
 

--- a/projects/embervm/control/lib/embervm/session.ex
+++ b/projects/embervm/control/lib/embervm/session.ex
@@ -42,11 +42,27 @@ defmodule Embervm.Session do
   silently. The parked caller gets the error; every still-queued caller gets a
   `{:error, :failed}` (the router 410s them). This process then stops.
 
-  ## the idle timer seam (PR-4)
+  ## the idle-bank timer (Task 7)
 
-  The idle-bank timer (Task 7) is armed here but is inert in PR-3: this module
-  leaves the `idle_bank_ms` seam and a `:maybe_bank` message stub so PR-4 wires
-  the bank without reshaping the process. PR-3 never banks.
+  A live session with ZERO in-flight and ZERO queued invokes for `idle_bank_ms`
+  banks: releasing its live VM while retaining state on a node-disk snapshot. This
+  process owns ONLY the quiescence detection and the timer; when it fires on a
+  genuinely idle session it ASKS the manager to bank (`SessionManager.bank/2`) and,
+  if the manager ADMITS the bank (`:ok`), STOPS immediately, handing the whole bank
+  lifecycle (the RPC, the durable `session_banked` append, and failure recovery) to
+  the manager, which runs the RPC OFF its own process so a bank never head-of-line-
+  blocks other sessions' routing (gate 3). A banked session has no process.
+
+  If the manager REFUSES the bank (another bank in flight on the node, the disk
+  fail-closed gate, or the session already moved off running), this process re-arms
+  the timer and stays live. The timer is armed whenever the process goes quiescent
+  and cancelled whenever work arrives, so it only ever fires on a genuinely idle
+  session; an idle-bank that races an invoke re-checks quiescence and re-arms rather
+  than banks. `idle_bank_ms` nil/0 disables banking entirely (the session never
+  idle-banks; only expiry/destroy/relight-cycle ends it).
+
+  All timers use `Process.send_after` with an injectable `idle_bank_ms`, and tests
+  drive `:maybe_bank` directly for determinism.
   """
 
   use GenServer, restart: :transient
@@ -99,6 +115,10 @@ defmodule Embervm.Session do
       timeout_ms: Keyword.get(opts, :timeout_ms, 90_000),
       idle_bank_ms: Keyword.get(opts, :idle_bank_ms, nil),
       session_store: Keyword.get(opts, :session_store, Embervm.SessionStore),
+      # The SessionManager this process calls back to for a bank (node-global policy
+      # lives there). Defaults to the supervised singleton; the manager injects itself.
+      manager: Keyword.get(opts, :manager, Embervm.SessionManager),
+      bank_fun: Keyword.get(opts, :bank_fun, &default_bank_call/2),
       channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
       invalidate_fun: Keyword.get(opts, :invalidate_fun, &Embervm.NodeChannel.invalidate/2),
       assign_fun: Keyword.get(opts, :assign_fun, &default_session_assign/2),
@@ -106,10 +126,12 @@ defmodule Embervm.Session do
       # FIFO of {from, req} waiting their turn; the head runs when no worker is in
       # flight. `worker` is the {pid, ref, from} of the in-flight invoke, or nil.
       queue: :queue.new(),
-      worker: nil
+      worker: nil,
+      # The armed idle-bank timer ref (nil when disarmed).
+      idle_timer: nil
     }
 
-    {:ok, state}
+    {:ok, arm_idle_timer(state)}
   end
 
   @impl true
@@ -122,9 +144,15 @@ defmodule Embervm.Session do
     if :queue.len(state.queue) >= state.queue_cap do
       {:reply, {:error, :queue_full}, state}
     else
-      state = %{state | queue: :queue.in({from, req}, state.queue)}
+      # Work arrived: disarm the idle timer so a bank cannot start while a caller is
+      # queued or in flight (the bank re-arms once the session goes quiescent again).
+      state = state |> disarm_idle_timer() |> enqueue(from, req)
       {:noreply, maybe_start_next(state)}
     end
+  end
+
+  defp enqueue(state, from, req) do
+    %{state | queue: :queue.in({from, req}, state.queue)}
   end
 
   @impl true
@@ -159,15 +187,78 @@ defmodule Embervm.Session do
     fail_and_stop(state, {:worker_down, down_reason})
   end
 
-  # The idle-bank timer (PR-4). Inert in PR-3: no idle_bank_ms is set, so this is
-  # never scheduled; the clause exists so PR-4 wires banking without reshaping.
-  def handle_info(:maybe_bank, state), do: {:noreply, state}
+  # The idle-bank timer fired. ASK the manager to bank ONLY if still quiescent (no
+  # worker, empty queue); a stale timer (idle_timer already cleared) is ignored. On
+  # admission (:ok) the manager owns the bank from here, so this process STOPS. On a
+  # refusal it re-arms and stays live.
+  def handle_info(:maybe_bank, %{idle_timer: nil} = state), do: {:noreply, state}
+
+  def handle_info(:maybe_bank, state) do
+    state = %{state | idle_timer: nil}
+
+    if quiescent?(state) do
+      case ask_bank(state) do
+        :ok ->
+          # Admitted: the manager now owns the whole bank lifecycle. A banked session
+          # has no process, so stop. If the manager's async bank later FAILS, the
+          # manager restarts a session process from the durable row (adoption/relight),
+          # so nothing is lost by stopping here.
+          {:stop, :normal, state}
+
+        {:error, _reason} ->
+          {:noreply, arm_idle_timer(state)}
+      end
+    else
+      # Raced an invoke: re-arm and try again once idle.
+      {:noreply, arm_idle_timer(state)}
+    end
+  end
 
   def handle_info(_msg, state), do: {:noreply, state}
+
+  # -- idle-bank -------------------------------------------------------------
+
+  defp quiescent?(state), do: is_nil(state.worker) and :queue.is_empty(state.queue)
+
+  # Ask the manager to admit a bank. The manager owns the per-node bank cap, the disk
+  # fail-closed gate, the Bank RPC (run off its process), the durable session_banked
+  # append, and failure recovery. A raise/exit is treated as a refusal (re-arm).
+  defp ask_bank(state) do
+    state.bank_fun.(state.manager, state.session_id)
+  rescue
+    _ -> {:error, :bank_call_raised}
+  catch
+    _, _ -> {:error, :bank_call_raised}
+  end
+
+  # Arm the idle-bank timer if banking is enabled and it is not already armed. A nil
+  # or non-positive idle_bank_ms disables banking (the timer is never scheduled).
+  defp arm_idle_timer(%{idle_bank_ms: ms} = state) when is_integer(ms) and ms > 0 do
+    if state.idle_timer do
+      state
+    else
+      %{state | idle_timer: Process.send_after(self(), :maybe_bank, ms)}
+    end
+  end
+
+  defp arm_idle_timer(state), do: state
+
+  defp disarm_idle_timer(%{idle_timer: nil} = state), do: state
+
+  defp disarm_idle_timer(%{idle_timer: ref} = state) do
+    _ = Process.cancel_timer(ref)
+    %{state | idle_timer: nil}
+  end
+
+  defp default_bank_call(manager, session_id) do
+    Embervm.SessionManager.bank(manager, session_id)
+  end
 
   # -- invoke dispatch -------------------------------------------------------
 
   # Start the head of the queue if nothing is in flight; otherwise leave it queued.
+  # When the queue empties with no worker, the session is quiescent: arm the idle
+  # timer so a sustained idle period banks.
   defp maybe_start_next(%{worker: nil} = state) do
     case :queue.out(state.queue) do
       {{:value, {from, req}}, rest} ->
@@ -175,7 +266,7 @@ defmodule Embervm.Session do
         %{state | queue: rest, worker: {pid, ref, from}}
 
       {:empty, _} ->
-        state
+        arm_idle_timer(state)
     end
   end
 

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -671,7 +671,7 @@ defmodule Embervm.SessionManager do
 
     spawn(fn ->
       outcome =
-        with {:ok, channel} <- channel_fun.(node_id),
+        with {:ok, channel} <- safe_channel(channel_fun, node_id),
              {:ok, %BankResponse{snapshot_ref: ref, size_bytes: size}} when is_binary(ref) and ref != "" <-
                safe_bank(bank_fun, channel, workload, session_id, vm_id) do
           {:ok, ref, size, generation, parent_base_ref}
@@ -845,6 +845,20 @@ defmodule Embervm.SessionManager do
     kind, reason -> {:error, {:bank_raised, {kind, reason}}}
   end
 
+  # Acquiring a node channel is a GenServer.call that EXITS (not returns) if the
+  # NodeChannel is down or the dial times out. An exit thrown in a bank/relight
+  # worker's `with` head would kill the worker BEFORE it sends {:bank_done}/
+  # {:relight_done}, hanging every parked caller forever and leaking the per-node
+  # bank slot (the node could then never bank again). Trap it into an {:error, _}
+  # value so the worker always reports an outcome the manager can clean up.
+  defp safe_channel(channel_fun, node_id) do
+    channel_fun.(node_id)
+  rescue
+    e -> {:error, {:channel_raised, e}}
+  catch
+    kind, reason -> {:error, {:channel_raised, {kind, reason}}}
+  end
+
   # -- relight-on-invoke (Task 8) --------------------------------------------
 
   # First invoke on a banked session: apply the wake-rate limit, then either park +
@@ -901,7 +915,7 @@ defmodule Embervm.SessionManager do
           {:ok, node_id} ->
             t0 = clock.()
 
-            with {:ok, channel} <- channel_fun.(node_id),
+            with {:ok, channel} <- safe_channel(channel_fun, node_id),
                  {:ok, %RelightResponse{vm_id: vm_id}} when is_binary(vm_id) and vm_id != "" <-
                    safe_relight(relight_fun, channel, session) do
               {:ok, node_id, vm_id, clock.() - t0}
@@ -1103,6 +1117,15 @@ defmodule Embervm.SessionManager do
     sid = session.session_id
 
     cond do
+      # This manager has an in-flight bank/relight for the session: it owns the
+      # transition, so a periodic reconcile must NOT touch it. During a bank the node
+      # still reports the live VM, and forcing ETS to running here would make the
+      # pending finish_bank's session_banked transition illegal (and silently lost).
+      # On BOOT these maps are empty (fresh process), so boot adoption still fully
+      # heals every limbo; only the periodic sweep is guarded.
+      Map.has_key?(state.banking, sid) or Map.has_key?(state.relighting, sid) ->
+        state
+
       # The node reports a LIVE VM for this session: rebind it (residency + process),
       # regardless of whether ETS thinks it is running/banking/relighting.
       Map.has_key?(live_vms, sid) ->

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -52,10 +52,35 @@ defmodule Embervm.SessionManager do
   use GenServer
   require Logger
 
-  alias Embervm.{NodeCapacity, SessionStore, WorkloadCatalog}
-  alias Embervm.Node.V1.{PrimeRequest, PrimeResponse, Trace}
+  alias Embervm.{NodeCapacity, SessionPlacement, SessionState, SessionStore, WorkloadCatalog}
+
+  alias Embervm.Node.V1.{
+    BankRequest,
+    BankResponse,
+    EvictSnapshotRequest,
+    PrimeRequest,
+    PrimeResponse,
+    RelightRequest,
+    RelightResponse,
+    Trace
+  }
 
   @registry Embervm.SessionRegistry
+
+  # Per-node concurrent-bank cap: banking writes GiBs, so serialize per node like
+  # base builds (the node daemon also refuses a second concurrent bank, but the
+  # control plane must not even ISSUE a second one and stack the I/O).
+  @default_bank_concurrency 1
+
+  # Wake-rate limit: relight-triggering invokes per principal per window. A relight
+  # restores a full 2 GiB snapshot, so a burst of misses is an asymmetric-cost DoS
+  # lever; excess relights get 429 WITHOUT touching the node.
+  @default_wake_max 30
+  @default_wake_window_ms 60_000
+
+  # Three consecutive bank failures fail the session and destroy its VM: a session
+  # that cannot bank must not squat live capacity forever.
+  @bank_fail_limit 3
 
   # -- Client API ------------------------------------------------------------
 
@@ -99,6 +124,47 @@ defmodule Embervm.SessionManager do
     GenServer.call(server, {:destroy, session_id})
   end
 
+  @doc """
+  Banks an idle session (called by its `Embervm.Session` process when its idle
+  timer fires and it is quiescent). Enforces the per-node concurrent-bank cap and
+  the disk fail-closed gate here (node-global policy, serialized through this
+  process), runs the `Bank` RPC, and appends `session_banked` (generation+1). On
+  `:ok` the caller (the session process) stops itself: a banked session has no
+  process. Returns `:ok`, `{:error, :bank_busy}` (another bank in flight on the
+  node), `{:error, :disk_unknown}` (fail-closed: missing disk facts, stay live),
+  or `{:error, reason}` on a daemon failure (the session stays running, the caller
+  re-arms its timer and counts the failure).
+  """
+  @spec bank(GenServer.server(), String.t()) :: :ok | {:error, term()}
+  def bank(server \\ __MODULE__, session_id) do
+    GenServer.call(server, {:bank, session_id}, :infinity)
+  end
+
+  @doc """
+  Runs one adoption reconcile synchronously (the same code the boot continue and
+  the periodic sweep run) and returns after it completes. Reconciles the ETS
+  projection against every node's reported `session_vms` + `session_snapshots`:
+  rebinds live session VMs to fresh processes, heals `banking`/`relighting` limbo,
+  fails sessions whose VM AND snapshot both vanished, and evicts orphaned
+  snapshots. Tests drive adoption deterministically through this.
+  """
+  @spec reconcile(GenServer.server()) :: :ok
+  def reconcile(server \\ __MODULE__) do
+    GenServer.call(server, :reconcile, :infinity)
+  end
+
+  @doc """
+  Runs one capacity/TTL sweep synchronously: expires sessions past `expires_at`
+  (live -> destroy VM, banked -> EvictSnapshot), GCs banked sessions untouched past
+  `bankedTtlSeconds`, and evicts banked sessions LRU while any node is below its
+  snapshot-disk low watermark. Tests drive it deterministically; production fires
+  it on the sweeper timer.
+  """
+  @spec sweep(GenServer.server()) :: :ok
+  def sweep(server \\ __MODULE__) do
+    GenServer.call(server, :sweep, :infinity)
+  end
+
   # -- GenServer callbacks ---------------------------------------------------
 
   @impl true
@@ -117,13 +183,65 @@ defmodule Embervm.SessionManager do
       claim_fun: Keyword.get(opts, :claim_fun, &default_claim/3),
       channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
       prime_fun: Keyword.get(opts, :prime_fun, &default_prime/2),
+      # Daemon session verb seams (Bank/Relight/EvictSnapshot). Injected for tests;
+      # production dials the real NodeService stub over the shared NodeChannel.
+      bank_fun: Keyword.get(opts, :bank_fun, &default_bank/2),
+      relight_fun: Keyword.get(opts, :relight_fun, &default_relight/2),
+      evict_fun: Keyword.get(opts, :evict_fun, &default_evict/2),
       # Extra opts threaded into every started Embervm.Session (the daemon seams),
       # so a test can inject a fake session_assign into the spawned process.
       session_opts: Keyword.get(opts, :session_opts, []),
-      tenant: Keyword.get(opts, :tenant, "homelab")
+      tenant: Keyword.get(opts, :tenant, "homelab"),
+      # Per-node concurrent-bank cap: node_id -> count of banks in flight on it. A
+      # node at its cap refuses a new bank (the session stays live, re-arms its timer).
+      bank_concurrency: Keyword.get(opts, :bank_concurrency, @default_bank_concurrency),
+      bank_inflight: %{},
+      # session_id -> %{node_id: n} for banks currently running async, so a mid-bank
+      # invoke can park (relighting ledger) and be relit once the bank completes.
+      banking: %{},
+      # session_id -> consecutive bank-failure count. Lives HERE (not in the session
+      # process, which stops on admission) so three strikes across bank attempts fails
+      # the session. Cleared on a successful bank or a successful invoke-driven relight.
+      bank_failures: %{},
+      # Snapshot-disk low watermark (bytes): when a node's snapshot_disk_free_bytes
+      # is below this, disk-pressure eviction fires. nil = eviction disabled.
+      disk_low_watermark_bytes: Keyword.get(opts, :disk_low_watermark_bytes, nil),
+      # Wake-rate limit: max relight-triggering invokes per principal per window.
+      wake_max: Keyword.get(opts, :wake_max, @default_wake_max),
+      wake_window_ms: Keyword.get(opts, :wake_window_ms, @default_wake_window_ms),
+      # principal -> [relight timestamps within the window]. Sliding-window counter.
+      wake_events: %{},
+      # session_id -> [{from, req}] parked callers waiting on an in-flight relight,
+      # so concurrent invokes to one banked session share ONE relight instead of
+      # racing two. Also the crash-consistency ledger: a relight appends session_relit
+      # ONLY after the daemon returns a live vm_id, and until then these callers park.
+      relighting: %{},
+      # The registry sweep (adoption) and the TTL/eviction sweep cadences. Distinct
+      # timers; both clock-injected and disable-able for tests (interval 0 = off).
+      reconcile_interval_ms: Keyword.get(opts, :reconcile_interval_ms, 0),
+      sweep_interval_ms: Keyword.get(opts, :sweep_interval_ms, 0)
     }
 
-    {:ok, state}
+    # session_opts always carry a manager reference so the per-session idle timer can
+    # call back for a bank; a test-supplied :manager wins (an isolated harness).
+    state = %{state | session_opts: Keyword.put_new(state.session_opts, :manager, self())}
+
+    if state.reconcile_interval_ms > 0 or state.sweep_interval_ms > 0 do
+      {:ok, state, {:continue, :boot}}
+    else
+      {:ok, state}
+    end
+  end
+
+  # Boot: run one adoption reconcile against whatever the node registry has already
+  # populated, then arm the periodic reconcile + sweep timers. Reconcile runs first
+  # so the residency/limbo heal lands before the first sweep can evict on it.
+  @impl true
+  def handle_continue(:boot, state) do
+    state = do_reconcile(state)
+    schedule(:reconcile, state.reconcile_interval_ms)
+    schedule(:sweep, state.sweep_interval_ms)
+    {:noreply, state}
   end
 
   @impl true
@@ -136,14 +254,24 @@ defmodule Embervm.SessionManager do
     # the session process's own FIFO parks the caller. So we reply the pid to the
     # caller path via a spawned forwarder, keeping the manager responsive. Simpler:
     # forward synchronously from a short task so the manager is not the bottleneck.
-    route = resolve_route(state, session_id)
-
-    case route do
+    case resolve_route(state, session_id) do
       {:live, pid} ->
         # Forward off the manager so a long guest round-trip does not serialize other
         # sessions' routing through this one GenServer.
         _ = spawn_forward(pid, req, from)
         {:noreply, state}
+
+      # A banked session: this invoke is a lifecycle MISS. Park the caller and (if it
+      # is the first for this session) trigger a relight, subject to the per-principal
+      # wake-rate limit. Concurrent invokes to the same banked session share the one
+      # relight (they all park under relighting[session_id]).
+      {:relight, session} ->
+        {:noreply, park_and_relight(state, session, from, req)}
+
+      # A relight is already in flight for this session (started by an earlier
+      # invoke): just park behind it. Drained when the relight completes.
+      {:relighting, _session} ->
+        {:noreply, park_relighting(state, session_id, from, req)}
 
       {:error, _reason} = error ->
         {:reply, error, state}
@@ -151,8 +279,52 @@ defmodule Embervm.SessionManager do
   end
 
   def handle_call({:destroy, session_id}, _from, state) do
-    {:reply, do_destroy(state, session_id), state}
+    {reply, state} = do_destroy(state, session_id)
+    {:reply, reply, state}
   end
+
+  def handle_call({:bank, session_id}, _from, state) do
+    {reply, state} = do_bank(state, session_id)
+    {:reply, reply, state}
+  end
+
+  def handle_call(:reconcile, _from, state) do
+    {:reply, :ok, do_reconcile(state)}
+  end
+
+  def handle_call(:sweep, _from, state) do
+    {:reply, :ok, do_sweep(state)}
+  end
+
+  # The async result of an in-flight relight worker (spawned by park_and_relight):
+  # {:ok, node_id, vm_id, relight_ms} on a live restore, or {:error, reason}. On
+  # success, crash-consistently append session_relit (AFTER the daemon returned a
+  # live vm_id), start the session process, and drain the parked callers into it.
+  # On failure, fail the session (snapshot_lost -> 410) and 410 the parked callers.
+  @impl true
+  def handle_info({:relight_done, session_id, outcome}, state) do
+    {:noreply, finish_relight(state, session_id, outcome)}
+  end
+
+  # The async bank worker finished: complete the durable transition + failure
+  # recovery on this (serialized) process. See finish_bank.
+  def handle_info({:bank_done, session_id, node_id, outcome}, state) do
+    {:noreply, finish_bank(state, session_id, node_id, outcome)}
+  end
+
+  def handle_info(:reconcile, state) do
+    state = do_reconcile(state)
+    schedule(:reconcile, state.reconcile_interval_ms)
+    {:noreply, state}
+  end
+
+  def handle_info(:sweep, state) do
+    state = do_sweep(state)
+    schedule(:sweep, state.sweep_interval_ms)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
 
   # -- create ----------------------------------------------------------------
 
@@ -210,39 +382,11 @@ defmodule Embervm.SessionManager do
     end
   end
 
-  # PR-3 placement: the first fresh, non-draining, ready node with live-VM budget.
-  # `Embervm.SessionPlacement` (PR-4, Task 8) replaces this with rendezvous hashing
-  # over the ready node list; the interface (workload -> {node_id, snapshot_ref}) is
-  # the same, so that swap does not touch this module's create flow.
+  # Placement (Task 8): the front-end never inspects node facts. SessionPlacement
+  # owns the choice (rendezvous hash over ready nodes with budget) and returns the
+  # node + its base snapshot_ref (for Prime on a claim miss).
   defp pick_node(state, workload) do
-    NodeCapacity.all(state.capacity_table)
-    |> Enum.find_value({:error, :no_capacity}, fn f ->
-      wc = Map.get(f.workloads || %{}, workload)
-
-      cond do
-        wc == nil -> false
-        not base_ready?(wc) -> false
-        not has_budget?(f) -> false
-        true -> {:ok, f.configured_id, Map.get(wc, :snapshot_ref)}
-      end
-    end)
-  end
-
-  defp base_ready?(wc) do
-    ready =
-      case Map.get(wc, :base_state) do
-        :BASE_BUILD_STATE_READY -> true
-        3 -> true
-        _ -> false
-      end
-
-    ref = Map.get(wc, :snapshot_ref)
-    ready and is_binary(ref) and ref != ""
-  end
-
-  defp has_budget?(f) do
-    max = Map.get(f, :max_live_vms, 0)
-    max > 0 and Map.get(f, :live_vms, 0) < max
+    SessionPlacement.node_for_create(workload, state.capacity_table)
   end
 
   # Claim a primed VM from the dispatcher's inventory, or Prime one on a miss (the
@@ -321,6 +465,9 @@ defmodule Embervm.SessionManager do
         vm_id: vm_id,
         queue_cap: entry.session.invoke_queue_cap,
         timeout_ms: entry.timeout_ms,
+        # Arm the idle-bank timer (Task 7): a live session with zero in-flight and
+        # zero queued invokes for this long calls back to bank/2. Zero disables it.
+        idle_bank_ms: entry.session.idle_bank_seconds * 1000,
         session_store: state.session_store,
         # Register under the session id so the router/manager resolve the pid.
         name: {:via, Registry, {state.registry, session_id}}
@@ -336,22 +483,93 @@ defmodule Embervm.SessionManager do
     DynamicSupervisor.start_child(state.supervisor, spec)
   end
 
+  # Start (or restart) a session process from a durable session row + its catalog
+  # entry, used by relight and adoption (which have the row, not the create args).
+  # A catalog miss (workload deleted) is surfaced so the caller can fail the session
+  # rather than start a process with no config.
+  defp start_session_from_row(state, session, node_id, vm_id) do
+    case fetch_session_workload(state, session.workload) do
+      {:ok, entry} ->
+        start_session_process(state, session.session_id, session.workload, session.principal, entry, node_id, vm_id)
+
+      {:error, reason} ->
+        {:error, {:no_catalog_entry, reason}}
+    end
+  end
+
   # -- invoke routing --------------------------------------------------------
 
   defp resolve_route(state, session_id) do
     case SessionStore.get(state.session_store, session_id) do
+      # Invoke-time expiry (ADR 002 rule 1): expiry must NOT depend on sweep cadence.
+      # An invoke arriving on a running/banked session past its deadline expires it
+      # HERE (destroy VM / evict snapshot) and 410s the caller, so a session never
+      # serves an invoke past expires_at even between sweeps.
+      {:ok, %{state: st, expires_at: exp} = session}
+      when st in [:running, :banked] and is_integer(exp) ->
+        if exp <= state.clock.() do
+          _ = expire_session(state, session)
+          {:error, {:gone, "expired"}}
+        else
+          resolve_non_expired(state, session_id)
+        end
+
+      _ ->
+        resolve_non_expired(state, session_id)
+    end
+  end
+
+  # resolve_route's tail, after the invoke-time expiry check (kept separate so the
+  # expiry guard does not have to re-list every route arm). Re-reads the row (the
+  # expiry guard already fetched it, but a re-read keeps this arm total and simple).
+  defp resolve_non_expired(state, session_id) do
+    case SessionStore.get(state.session_store, session_id) do
       {:ok, %{state: :running} = _session} ->
         case Registry.lookup(state.registry, session_id) do
           [{pid, _}] -> {:live, pid}
-          # Running per the durable store but no process: a restart-limbo the PR-4
-          # adoption sweep rebinds. PR-3 has no adoption, so surface a transient
-          # error rather than pretend the VM is reachable.
+          # Running per the durable store but no process: a restart-limbo the
+          # adoption sweep rebinds. Surface a transient error rather than pretend the
+          # VM is reachable; the boot reconcile heals it to a live process shortly.
           [] -> {:error, {:not_ready, :running}}
+        end
+
+      # Banked: an invoke is a relight MISS. If a relight is already in flight
+      # (started by an earlier concurrent invoke), park behind it; otherwise this is
+      # the first invoke, which triggers the relight.
+      {:ok, %{state: :banked} = session} ->
+        if Map.has_key?(state.relighting, session_id) do
+          {:relighting, session}
+        else
+          {:relight, session}
+        end
+
+      {:ok, %{state: :relighting} = session} ->
+        # A relight the manager is driving (parked callers pending). Park behind it.
+        # A `relighting` durable state with NO in-flight relight in this process is a
+        # restart limbo the reconcile heals; treat as a transient not_ready so the
+        # caller retries after the heal rather than double-driving a relight.
+        if Map.has_key?(state.relighting, session_id) do
+          {:relighting, session}
+        else
+          {:error, {:not_ready, :relighting}}
+        end
+
+      # A bank is in flight: an invoke mid-bank PARKS and is relit after the bank
+      # completes (no cancel path; banking is short). Park in the relighting ledger;
+      # finish_bank relights the parked callers once the session is banked.
+      {:ok, %{state: :banking} = session} ->
+        if Map.has_key?(state.banking, session_id) do
+          {:relighting, session}
+        else
+          # A `banking` durable state with no in-flight bank in this process is a
+          # restart limbo the reconcile heals; transient not_ready so the caller
+          # retries after the heal.
+          {:error, {:not_ready, :banking}}
         end
 
       {:ok, %{state: session_state}} ->
         cond do
-          session_state in [:creating, :banking, :relighting] -> {:error, {:not_ready, session_state}}
+          session_state == :creating -> {:error, {:not_ready, :creating}}
           # terminal: 410 with the recorded reason.
           true -> {:error, {:gone, terminal_reason(state, session_id, session_state)}}
         end
@@ -384,35 +602,830 @@ defmodule Embervm.SessionManager do
     end)
   end
 
+  # -- bank (Task 7) ---------------------------------------------------------
+
+  # ADMIT a bank (synchronous, fast): enforce the per-node concurrent-bank cap and
+  # the disk fail-closed gate (node-global policy, serialized on this process), mark
+  # ETS `banking` (so a concurrent invoke parks), reserve the node's bank slot, and
+  # spawn the async bank WORKER (the RPC + durable append run OFF this process, so a
+  # multi-second bank never head-of-line-blocks another session's routing, gate 3).
+  # Replies `:ok` (admitted; the caller session process stops) or a refusal (the
+  # caller re-arms its timer and stays live).
+  defp do_bank(state, session_id) do
+    case SessionStore.get(state.session_store, session_id) do
+      {:ok, %{state: :running, node_id: node_id, vm_id: vm_id} = session}
+      when is_binary(node_id) and is_binary(vm_id) ->
+        cond do
+          bank_at_cap?(state, node_id) ->
+            {{:error, :bank_busy}, state}
+
+          not disk_ok_for_bank?(state, node_id) ->
+            # Fail-closed: with missing/over-watermark disk facts, do NOT bank onto a
+            # possibly-full disk. The session stays live and re-arms its timer.
+            {{:error, :disk_unknown}, state}
+
+          true ->
+            admit_bank(state, session, node_id, vm_id)
+        end
+
+      {:ok, _session} ->
+        # Not a bankable state (already banked/terminal/relighting): a benign race,
+        # the timer fired against a session that moved on. Refuse so the caller does
+        # NOT stop on a false admission; if the session truly moved to banked/terminal
+        # its process is already stopping anyway.
+        {{:error, :not_bankable}, state}
+
+      :error ->
+        {{:error, :not_found}, state}
+    end
+  end
+
+  defp admit_bank(state, session, node_id, vm_id) do
+    case SessionStore.mark(state.session_store, session.session_id, :bank) do
+      {:ok, _} ->
+        state =
+          state
+          |> incr_bank_inflight(node_id)
+          |> Map.update!(:banking, &Map.put(&1, session.session_id, %{node_id: node_id}))
+
+        spawn_bank_worker(state, session, node_id, vm_id)
+        {:ok, state}
+
+      {:error, reason} ->
+        {{:error, {:mark, reason}}, state}
+    end
+  end
+
+  # The async bank worker: Bank RPC on the node, then report the result back to the
+  # manager. It does NOT append the durable op itself (the manager serializes the
+  # store transition + inflight release on {:bank_done}), keeping the op-log's
+  # single-writer discipline and the failure-recovery decision on one process.
+  defp spawn_bank_worker(state, session, node_id, vm_id) do
+    owner = self()
+    channel_fun = state.channel_fun
+    bank_fun = state.bank_fun
+    session_id = session.session_id
+    workload = session.workload
+    parent_base_ref = session.base_snapshot_ref
+    generation = (session.generation || 0) + 1
+
+    spawn(fn ->
+      outcome =
+        with {:ok, channel} <- channel_fun.(node_id),
+             {:ok, %BankResponse{snapshot_ref: ref, size_bytes: size}} when is_binary(ref) and ref != "" <-
+               safe_bank(bank_fun, channel, workload, session_id, vm_id) do
+          {:ok, ref, size, generation, parent_base_ref}
+        else
+          other -> {:error, other}
+        end
+
+      send(owner, {:bank_done, session_id, node_id, outcome})
+    end)
+  end
+
+  # The async bank completed (a {:bank_done} message on the manager). Release the
+  # node's bank slot and the banking marker, then:
+  #   * on success: transition `banking -[bank_ready]-> banked` with the durable
+  #     session_banked op (generation+1, snapshot fact), clear the failure streak,
+  #     and if a mid-bank invoke parked, immediately relight it;
+  #   * on failure: mark ETS `banking -[bank_abort]-> running` (the VM is still alive,
+  #     no snapshot written), count the failure, and either restart a session process
+  #     (so it can serve invokes + retry) or, at three strikes, fail + destroy the VM.
+  defp finish_bank(state, session_id, node_id, outcome) do
+    state =
+      state
+      |> decr_bank_inflight(node_id)
+      |> Map.update!(:banking, &Map.delete(&1, session_id))
+
+    case SessionStore.get(state.session_store, session_id) do
+      # Destroyed/expired mid-bank: the durable state is already terminal. On a
+      # successful bank the produced snapshot is orphaned and adoption reaps it; drain
+      # any mid-bank parked callers gone. Never resurrect a terminal session.
+      {:ok, %{state: st}} when st in [:expired, :evicted, :destroyed, :failed] ->
+        drain_relight_waiters(state, session_id, {:error, {:gone, to_string(st)}})
+
+      _ ->
+        finish_bank_active(state, session_id, node_id, outcome)
+    end
+  end
+
+  defp finish_bank_active(state, session_id, node_id, outcome) do
+    case outcome do
+      {:ok, ref, size, generation, parent_base_ref} ->
+        _ =
+          SessionStore.transition(
+            state.session_store,
+            session_id,
+            :bank_ready,
+            :session_banked,
+            %{snapshot_ref: ref, size_bytes: size, generation: generation, parent_base_ref: parent_base_ref},
+            %{snapshot_ref: ref, snapshot_size_bytes: size, generation: generation, node_id: node_id, vm_id: nil}
+          )
+
+        Logger.info("embervm session banked", session_id: session_id, node_id: node_id)
+        state = clear_bank_failures(state, session_id)
+        relight_parked_after_bank(state, session_id)
+
+      {:error, reason} ->
+        handle_bank_failure(state, session_id, reason)
+    end
+  end
+
+  # A mid-bank invoke parked in the relighting ledger while the bank ran. Now the
+  # session is banked, relight it (subject to the wake-rate limit) and drain the
+  # parked callers into the relit process. No parked caller = nothing to do.
+  defp relight_parked_after_bank(state, session_id) do
+    case Map.get(state.relighting, session_id) do
+      nil ->
+        state
+
+      _waiters ->
+        case SessionStore.get(state.session_store, session_id) do
+          {:ok, %{state: :banked} = session} -> start_relight(state, session)
+          # Raced a destroy/expire: drain the waiters gone.
+          _ -> drain_relight_waiters(state, session_id, {:error, {:gone, "unavailable"}})
+        end
+    end
+  end
+
+  # A bank failed: ETS back to running, count the strike. Three strikes fail the
+  # session + destroy its VM; under the limit, restart a session process so the live
+  # VM keeps serving and its idle timer will retry the bank.
+  defp handle_bank_failure(state, session_id, reason) do
+    _ = SessionStore.mark(state.session_store, session_id, :bank_abort)
+    failures = Map.get(state.bank_failures, session_id, 0) + 1
+    Logger.warning("embervm session bank failed", session_id: session_id, reason: inspect(reason), consecutive: failures)
+
+    if failures >= @bank_fail_limit do
+      state = clear_bank_failures(state, session_id)
+
+      case SessionStore.get(state.session_store, session_id) do
+        {:ok, session} ->
+          fail_session_and_destroy(state, session)
+          # Any mid-bank parked callers: the session is failed now.
+          drain_relight_waiters(state, session_id, {:error, {:gone, "failed"}})
+
+        :error ->
+          state
+      end
+    else
+      state = %{state | bank_failures: Map.put(state.bank_failures, session_id, failures)}
+      restart_running_process(state, session_id)
+    end
+  end
+
+  # Restart a session process for a running session that lost its process (a failed
+  # bank: the process stopped on admission but the VM is still live). Idempotent: a
+  # session that already has a process is left alone.
+  defp restart_running_process(state, session_id) do
+    case SessionStore.get(state.session_store, session_id) do
+      {:ok, %{state: :running, node_id: node_id, vm_id: vm_id} = session}
+      when is_binary(node_id) and is_binary(vm_id) ->
+        case Registry.lookup(state.registry, session_id) do
+          [{_pid, _}] ->
+            state
+
+          [] ->
+            _ = start_session_from_row(state, session, node_id, vm_id)
+            state
+        end
+
+      _ ->
+        state
+    end
+  end
+
+  defp fail_session_and_destroy(state, session) do
+    _ = destroy_vm(state, session)
+    fail_session(state, session.session_id, :failed, "bank_failed_three_strikes")
+    state
+  end
+
+  defp clear_bank_failures(state, session_id) do
+    %{state | bank_failures: Map.delete(state.bank_failures, session_id)}
+  end
+
+  # A node is at its bank cap when the count of in-flight banks on it reaches the
+  # per-node concurrency limit (default 1).
+  defp bank_at_cap?(state, node_id) do
+    Map.get(state.bank_inflight, node_id, 0) >= state.bank_concurrency
+  end
+
+  # Disk is OK to bank when eviction is disabled (no watermark configured) OR the
+  # node reports snapshot_disk_free_bytes strictly ABOVE the low watermark. Missing
+  # disk facts (node absent from the capacity table, or a nil free-bytes field) are
+  # fail-closed: not OK. This never banks onto a disk we cannot prove has room.
+  defp disk_ok_for_bank?(%{disk_low_watermark_bytes: nil}, _node_id), do: true
+
+  defp disk_ok_for_bank?(state, node_id) do
+    case NodeCapacity.fetch(state.capacity_table, node_id) do
+      {:ok, fact} ->
+        free = Map.get(fact, :snapshot_disk_free_bytes)
+        is_integer(free) and free > state.disk_low_watermark_bytes
+
+      :error ->
+        false
+    end
+  end
+
+  defp incr_bank_inflight(state, node_id) do
+    %{state | bank_inflight: Map.update(state.bank_inflight, node_id, 1, &(&1 + 1))}
+  end
+
+  defp decr_bank_inflight(state, node_id) do
+    %{state | bank_inflight: Map.update(state.bank_inflight, node_id, 0, &max(&1 - 1, 0))}
+  end
+
+  defp safe_bank(bank_fun, channel, workload, session_id, vm_id) do
+    req = %BankRequest{trace: %Trace{workload: workload}, vm_id: vm_id, session_id: session_id}
+    bank_fun.(channel, req)
+  rescue
+    e -> {:error, {:bank_raised, e}}
+  catch
+    kind, reason -> {:error, {:bank_raised, {kind, reason}}}
+  end
+
+  # -- relight-on-invoke (Task 8) --------------------------------------------
+
+  # First invoke on a banked session: apply the wake-rate limit, then either park +
+  # start a relight, or 429 the caller without touching the node.
+  defp park_and_relight(state, session, from, req) do
+    principal = session.principal
+
+    if wake_allowed?(state, principal) do
+      state = record_wake(state, principal)
+      state = park_relighting(state, session.session_id, from, req)
+      start_relight(state, session)
+    else
+      audit_denial(state, principal, session.workload, :wake_rate)
+      GenServer.reply(from, {:error, :wake_rate_limited})
+      state
+    end
+  end
+
+  # Park a caller behind an in-flight relight for its session (FIFO within the
+  # session), draining them all into the fresh process once the relight lands.
+  defp park_relighting(state, session_id, from, req) do
+    waiters = Map.get(state.relighting, session_id, [])
+    %{state | relighting: Map.put(state.relighting, session_id, waiters ++ [{from, req}])}
+  end
+
+  # Kick off the relight: mark ETS banked -[relight]-> relighting (ETS-only, no op;
+  # crash-consistency requires session_relit land only AFTER the daemon returns a
+  # live vm_id, see finish_relight), then spawn a worker that Relights on the
+  # resident node and reports back.
+  defp start_relight(state, session) do
+    case SessionStore.mark(state.session_store, session.session_id, :relight) do
+      {:ok, _} ->
+        spawn_relight_worker(state, session)
+        state
+
+      {:error, _} ->
+        # Illegal (session moved off banked concurrently): drain any parked callers
+        # for it as not_ready so they retry.
+        drain_relight_waiters(state, session.session_id, {:error, {:not_ready, :banked}})
+    end
+  end
+
+  defp spawn_relight_worker(state, session) do
+    owner = self()
+    capacity_table = state.capacity_table
+    channel_fun = state.channel_fun
+    relight_fun = state.relight_fun
+    clock = state.clock
+    session_id = session.session_id
+
+    spawn(fn ->
+      outcome =
+        case SessionPlacement.node_for_relight(session, capacity_table) do
+          {:ok, node_id} ->
+            t0 = clock.()
+
+            with {:ok, channel} <- channel_fun.(node_id),
+                 {:ok, %RelightResponse{vm_id: vm_id}} when is_binary(vm_id) and vm_id != "" <-
+                   safe_relight(relight_fun, channel, session) do
+              {:ok, node_id, vm_id, clock.() - t0}
+            else
+              {:error, reason} -> classify_relight_error(reason)
+              other -> classify_relight_error({:relight_failed, other})
+            end
+
+          {:error, :snapshot_lost} ->
+            {:error, :snapshot_lost}
+        end
+
+      send(owner, {:relight_done, session_id, outcome})
+    end)
+  end
+
+  defp safe_relight(relight_fun, channel, session) do
+    req = %RelightRequest{
+      trace: %Trace{workload: session.workload},
+      snapshot_ref: session.snapshot_ref,
+      session_id: session.session_id
+    }
+
+    relight_fun.(channel, req)
+  rescue
+    e -> {:error, {:relight_raised, e}}
+  catch
+    kind, reason -> {:error, {:relight_raised, {kind, reason}}}
+  end
+
+  # A FAILED_PRECONDITION from Relight means the snapshot is unrestorable: the
+  # session is lost (snapshot_lost -> 410). Any other transport error is a retryable
+  # relight failure (the snapshot is NOT deleted on a failed restore, per the proto),
+  # surfaced as a generic error the parked caller sees; the session stays banked.
+  defp classify_relight_error(%GRPC.RPCError{status: 9}), do: {:error, :snapshot_lost}
+  defp classify_relight_error({:relight_failed, %GRPC.RPCError{status: 9}}), do: {:error, :snapshot_lost}
+  defp classify_relight_error(reason), do: {:error, {:relight, reason}}
+
+  # Relight completed. On success: append session_relit (NOW, after a live vm_id),
+  # move ETS to running with the fresh residency, start the process, and drain the
+  # parked callers into it. On snapshot_lost: fail the session, evict the snapshot,
+  # 410 the parked callers. On a transient relight error: leave the session banked
+  # and reply the error to parked callers (they may retry, re-relighting).
+  defp finish_relight(state, session_id, outcome) do
+    case SessionStore.get(state.session_store, session_id) do
+      # The session went terminal mid-relight (a concurrent destroy/expire): the
+      # relight's live VM, if any, is orphaned and adoption/next-sweep reaps it. Drain
+      # any parked callers gone and drop the ledger. Never start a process for a
+      # terminal session.
+      {:ok, %{state: st}} when st in [:expired, :evicted, :destroyed, :failed] ->
+        drain_relight_waiters(state, session_id, {:error, {:gone, to_string(st)}})
+
+      _ ->
+        finish_relight_active(state, session_id, outcome)
+    end
+  end
+
+  defp finish_relight_active(state, session_id, outcome) do
+    case outcome do
+      {:ok, node_id, vm_id, relight_ms} ->
+        session = get_session!(state, session_id)
+
+        _ =
+          SessionStore.transition(
+            state.session_store,
+            session_id,
+            :relight_ready,
+            :session_relit,
+            %{snapshot_ref: session.snapshot_ref, generation: session.generation, relight_ms: relight_ms},
+            %{node_id: node_id, vm_id: vm_id}
+          )
+
+        state = clear_bank_failures(state, session_id)
+
+        case start_session_from_row(state, %{session | node_id: node_id, vm_id: vm_id}, node_id, vm_id) do
+          {:ok, pid} ->
+            Logger.info("embervm session relit", session_id: session_id, relight_ms: relight_ms)
+            drain_relight_into_process(state, session_id, pid)
+
+          {:error, reason} ->
+            fail_session(state, session_id, :failed, "relit process start failed: #{inspect(reason)}")
+            drain_relight_waiters(state, session_id, {:error, :failed})
+        end
+
+      {:error, :snapshot_lost} ->
+        session = get_session!(state, session_id)
+        fail_session(state, session_id, :snapshot_lost, "snapshot_lost")
+        _ = evict_snapshot(state, session)
+        drain_relight_waiters(state, session_id, {:error, {:gone, "snapshot_lost"}})
+
+      {:error, reason} ->
+        # Transient (non-precondition) failure: the snapshot is intact (the proto
+        # never deletes it on a failed restore), so return ETS relighting -> banked
+        # (ETS-only, no op) and reply the error. A later invoke re-relights.
+        Logger.warning("embervm session relight failed", session_id: session_id, reason: inspect(reason))
+        _ = SessionStore.mark(state.session_store, session_id, :relight_abort)
+        drain_relight_waiters(state, session_id, {:error, {:relight_failed, reason}})
+    end
+  end
+
+  # Drain every parked caller for a relit session by forwarding its req into the
+  # fresh session process (FIFO order), then clear the relighting ledger. Each
+  # forward runs off the manager so a long guest round-trip does not serialize.
+  defp drain_relight_into_process(state, session_id, pid) do
+    waiters = Map.get(state.relighting, session_id, [])
+    for {from, req} <- waiters, do: spawn_forward(pid, req, from)
+    %{state | relighting: Map.delete(state.relighting, session_id)}
+  end
+
+  # Reply `reply` to every parked caller for a session (a failed/lost relight) and
+  # clear the ledger.
+  defp drain_relight_waiters(state, session_id, reply) do
+    waiters = Map.get(state.relighting, session_id, [])
+    for {from, _req} <- waiters, do: GenServer.reply(from, reply)
+    %{state | relighting: Map.delete(state.relighting, session_id)}
+  end
+
+  # -- wake-rate limit (Task 8) ----------------------------------------------
+
+  # A sliding-window per-principal relight count: allowed while the count of relight
+  # timestamps within the window is below wake_max. wake_max <= 0 disables the limit
+  # entirely (never rate-limit), matching "0 = off" config idioms; a positive limit
+  # is enforced.
+  defp wake_allowed?(%{wake_max: max}, _principal) when not is_integer(max) or max <= 0, do: true
+
+  defp wake_allowed?(state, principal) do
+    now = state.clock.()
+    recent = recent_wakes(state, principal, now)
+    length(recent) < state.wake_max
+  end
+
+  defp record_wake(state, principal) do
+    now = state.clock.()
+    recent = recent_wakes(state, principal, now)
+    %{state | wake_events: Map.put(state.wake_events, principal, [now | recent])}
+  end
+
+  defp recent_wakes(state, principal, now) do
+    cutoff = now - state.wake_window_ms
+
+    state.wake_events
+    |> Map.get(principal, [])
+    |> Enum.filter(&(&1 > cutoff))
+  end
+
+  # -- adoption (Task 8) -----------------------------------------------------
+
+  # Reconcile the ETS projection against every node's reported session inventory
+  # (the #3517 drill lesson applied to sessions: the node is the source of truth,
+  # the control plane adopts, NEVER reaps on a transient disconnect). For each
+  # non-terminal session:
+  #
+  #   * running/relighting/banking with a node-reported LIVE VM -> rebind residency
+  #     and (re)start the process bound to that vm_id. Heals a control-plane restart
+  #     (the durable state is running but the process is gone) and heals banking/
+  #     relighting limbo where the node actually holds a live VM.
+  #   * banked, or banking/relighting where the node reports the SNAPSHOT (not a VM)
+  #     -> heal ETS to banked (the bank/relight did not complete; the snapshot is the
+  #     truth). No process.
+  #   * neither a VM nor a snapshot reported for the session -> the VM and snapshot
+  #     both vanished (node death after a live-only session, or an out-of-band wipe):
+  #     mark it failed. This is the ONLY reaping, and only when node truth confirms
+  #     the state is gone, never on a transient absence of the whole node's facts.
+  #
+  # Then evict snapshots the node reports whose session row is terminal or absent.
+  #
+  # NEVER reap when a node's facts are simply missing (a disconnect): a session on a
+  # node not currently in the capacity table is left untouched, exactly the pool's
+  # additive-only rule.
+  defp do_reconcile(state) do
+    facts = NodeCapacity.all(state.capacity_table)
+    live_vms = index_session_vms(facts)
+    snapshots = index_session_snapshots(facts)
+
+    state =
+      SessionStore.all(state.session_store)
+      |> Enum.reject(&SessionState.terminal?(&1.state))
+      |> Enum.reduce(state, fn session, acc ->
+        adopt_one(acc, session, live_vms, snapshots)
+      end)
+
+    evict_orphan_snapshots(state, facts)
+  end
+
+  # vm session_id -> {node_id, vm_id}; snapshot session_id -> {node_id, snapshot_ref}.
+  defp index_session_vms(facts) do
+    for f <- facts, v <- Map.get(f, :session_vms, []) || [], into: %{} do
+      {v.session_id, {f.configured_id, v.vm_id}}
+    end
+  end
+
+  defp index_session_snapshots(facts) do
+    for f <- facts, s <- Map.get(f, :session_snapshots, []) || [], into: %{} do
+      {s.session_id, {f.configured_id, s.snapshot_ref}}
+    end
+  end
+
+  defp adopt_one(state, session, live_vms, snapshots) do
+    sid = session.session_id
+
+    cond do
+      # The node reports a LIVE VM for this session: rebind it (residency + process),
+      # regardless of whether ETS thinks it is running/banking/relighting.
+      Map.has_key?(live_vms, sid) ->
+        {node_id, vm_id} = Map.fetch!(live_vms, sid)
+        adopt_live(state, session, node_id, vm_id)
+
+      # No live VM, but the node reports its SNAPSHOT: it is banked (or a bank/relight
+      # that did not finish leaving only the snapshot). Heal ETS to banked.
+      Map.has_key?(snapshots, sid) ->
+        heal_to_banked(state, session, snapshots)
+
+      # A session the current node facts cover neither as a VM nor a snapshot. Only
+      # reap if the node whose id the session records IS reporting (its absence is
+      # then authoritative, the state truly vanished); if that node is not in the
+      # facts at all (a disconnect), leave the session untouched.
+      node_reporting?(state, session.node_id) ->
+        fail_session(state, sid, :failed, "vm_and_snapshot_vanished")
+        state
+
+      true ->
+        state
+    end
+  end
+
+  # Rebind a live session VM to a fresh process (idempotent). Forces ETS to running
+  # from node truth (a banking/relighting/creating limbo whose node actually holds a
+  # live VM), writes the residency fact + vm_id, and starts a process if none runs.
+  defp adopt_live(state, session, node_id, vm_id) do
+    SessionStore.adopt_state(state.session_store, session.session_id, :running)
+    SessionStore.adopt_residency(state.session_store, session.session_id, node_id, vm_id)
+
+    case Registry.lookup(state.registry, session.session_id) do
+      [{_pid, _}] ->
+        # Already has a process (adoption ran twice, or the process outlived a sweep):
+        # leave it. The residency/state heal above is idempotent.
+        state
+
+      [] ->
+        case start_session_from_row(state, %{session | node_id: node_id, vm_id: vm_id}, node_id, vm_id) do
+          {:ok, _pid} ->
+            Logger.info("embervm session adopted (live)", session_id: session.session_id, node_id: node_id)
+            state
+
+          {:error, reason} ->
+            Logger.warning("embervm session adopt-live start failed",
+              session_id: session.session_id,
+              reason: inspect(reason)
+            )
+
+            state
+        end
+    end
+  end
+
+  # A session the node reports only as a snapshot: it is banked. Force ETS to banked
+  # (idempotent) so a banking/relighting limbo whose bank/relight did not complete
+  # resolves to the truth (the snapshot exists, no VM), dropping residency so the
+  # next invoke routes as a relight miss.
+  defp heal_to_banked(state, %{state: :banked}, _snapshots), do: state
+
+  defp heal_to_banked(state, session, _snapshots) do
+    SessionStore.adopt_state(state.session_store, session.session_id, :banked)
+    Logger.info("embervm session adopted (banked)", session_id: session.session_id)
+    state
+  end
+
+  defp node_reporting?(state, node_id) when is_binary(node_id) do
+    match?({:ok, _}, NodeCapacity.fetch(state.capacity_table, node_id))
+  end
+
+  defp node_reporting?(_state, _node_id), do: false
+
+  # Evict snapshots a node reports whose session row is terminal or absent: the
+  # session is gone but its snapshot squats disk. EvictSnapshot is idempotent, so a
+  # double-evict is harmless.
+  defp evict_orphan_snapshots(state, facts) do
+    for f <- facts, snap <- Map.get(f, :session_snapshots, []) || [] do
+      case SessionStore.get(state.session_store, snap.session_id) do
+        {:ok, %{state: st}} when st in [:expired, :evicted, :destroyed, :failed] ->
+          _ = evict_snapshot_on_node(state, f.configured_id, snap.snapshot_ref, f.node_id)
+
+        :error ->
+          _ = evict_snapshot_on_node(state, f.configured_id, snap.snapshot_ref, f.node_id)
+
+        _ ->
+          :ok
+      end
+    end
+
+    state
+  end
+
+  # -- sweep: expiry, banked-TTL GC, disk-pressure eviction (Task 7) ---------
+
+  defp do_sweep(state) do
+    now = state.clock.()
+
+    state
+    |> sweep_expiry(now)
+    |> sweep_banked_ttl(now)
+    |> sweep_disk_pressure()
+  end
+
+  # Max-lifetime expiry (independent of the invoke-time check): any non-terminal
+  # session past expires_at is expired. Live -> destroy the VM; banked -> evict the
+  # snapshot. Appends session_expired either way.
+  defp sweep_expiry(state, now) do
+    SessionStore.all(state.session_store)
+    # Only running/banked have an :expire FSM edge; a transient banking/relighting/
+    # creating session settles within a sweep and is expired on the next pass.
+    |> Enum.filter(fn s -> s.state in [:running, :banked] end)
+    |> Enum.filter(fn s -> is_integer(s.expires_at) and s.expires_at <= now end)
+    |> Enum.reduce(state, fn session, acc -> expire_session(acc, session) end)
+  end
+
+  defp expire_session(state, session) do
+    if session.state == :banked do
+      _ = evict_snapshot(state, session)
+    else
+      _ = stop_session_process(state, session.session_id, session)
+    end
+
+    _ =
+      SessionStore.transition(
+        state.session_store,
+        session.session_id,
+        :expire,
+        :session_expired,
+        %{reason: :expired},
+        %{}
+      )
+
+    Logger.info("embervm session expired", session_id: session.session_id)
+    state
+  end
+
+  # Banked-TTL GC: a banked session untouched (last_invoke_at, or banked-at via
+  # updated_at) for longer than its workload's bankedTtlSeconds is evicted
+  # (session_evicted, reason idle_ttl).
+  defp sweep_banked_ttl(state, now) do
+    SessionStore.all(state.session_store)
+    |> Enum.filter(&(&1.state == :banked))
+    |> Enum.reduce(state, fn session, acc ->
+      case fetch_session_workload(acc, session.workload) do
+        {:ok, entry} ->
+          ttl_ms = entry.session.banked_ttl_seconds * 1000
+          last = session.last_invoke_at || session.updated_at || 0
+
+          if now - last >= ttl_ms do
+            evict_banked(acc, session, :idle_ttl)
+          else
+            acc
+          end
+
+        {:error, _} ->
+          acc
+      end
+    end)
+  end
+
+  # Disk-pressure eviction: for each node below its snapshot-disk low watermark,
+  # evict banked sessions LRU by last_invoke_at (NEVER live, NEVER non-session
+  # snapshots) until free bytes rise above the watermark. Each an audited
+  # session_evicted, reason disk_pressure. Disabled when no watermark is configured.
+  defp sweep_disk_pressure(%{disk_low_watermark_bytes: nil} = state), do: state
+
+  defp sweep_disk_pressure(state) do
+    NodeCapacity.all(state.capacity_table)
+    |> Enum.reduce(state, fn fact, acc -> evict_node_to_watermark(acc, fact) end)
+  end
+
+  defp evict_node_to_watermark(state, fact) do
+    free = Map.get(fact, :snapshot_disk_free_bytes)
+    watermark = state.disk_low_watermark_bytes
+
+    if is_integer(free) and free < watermark do
+      # Victims: this node's banked sessions, coldest first. We evict until the
+      # projected freed bytes lift us over the watermark (we cannot re-read node
+      # disk mid-sweep, so we project free += snapshot_size_bytes per eviction).
+      victims = banked_victims_on_node(state, fact.configured_id)
+      evict_until_watermark(state, victims, free, watermark)
+    else
+      state
+    end
+  end
+
+  # Banked sessions whose recorded node_id is this node, coldest last_invoke_at
+  # first. We LRU across the node's workloads (a per-workload banked_lru merged and
+  # re-sorted), so the globally coldest banked session on the pressured node goes
+  # first regardless of workload.
+  defp banked_victims_on_node(state, node_id) do
+    SessionStore.all(state.session_store)
+    |> Enum.filter(fn s -> s.state == :banked and s.node_id == node_id end)
+    |> Enum.sort_by(&(&1.last_invoke_at || 0), :asc)
+  end
+
+  defp evict_until_watermark(state, [], _free, _watermark), do: state
+
+  defp evict_until_watermark(state, _victims, free, watermark) when free >= watermark, do: state
+
+  defp evict_until_watermark(state, [session | rest], free, watermark) do
+    state = evict_banked(state, session, :disk_pressure)
+    projected_free = free + (session.snapshot_size_bytes || 0)
+    evict_until_watermark(state, rest, projected_free, watermark)
+  end
+
+  # Evict a banked session: EvictSnapshot on its node, append session_evicted with
+  # the reason. The session becomes terminal (evicted -> next invoke 410s).
+  defp evict_banked(state, session, reason) do
+    _ = evict_snapshot(state, session)
+
+    _ =
+      SessionStore.transition(
+        state.session_store,
+        session.session_id,
+        :evict,
+        :session_evicted,
+        %{reason: reason},
+        %{}
+      )
+
+    Logger.warning("embervm session evicted", session_id: session.session_id, reason: reason)
+    state
+  end
+
+  # -- snapshot eviction RPC -------------------------------------------------
+
+  defp evict_snapshot(state, %{node_id: node_id, snapshot_ref: ref}) when is_binary(node_id) and is_binary(ref) do
+    evict_snapshot_on_node(state, node_id, ref, node_id)
+  end
+
+  defp evict_snapshot(_state, _session), do: :ok
+
+  defp evict_snapshot_on_node(state, node_id, snapshot_ref, _reported_id)
+       when is_binary(node_id) and is_binary(snapshot_ref) do
+    with {:ok, channel} <- state.channel_fun.(node_id) do
+      req = %EvictSnapshotRequest{trace: %Trace{}, snapshot_ref: snapshot_ref}
+
+      try do
+        state.evict_fun.(channel, req)
+      rescue
+        _ -> :error
+      catch
+        _, _ -> :error
+      end
+    end
+
+    :ok
+  end
+
+  defp evict_snapshot_on_node(_state, _node_id, _ref, _reported), do: :ok
+
+  # -- shared fail path ------------------------------------------------------
+
+  # Fail a session terminally with a machine-readable reason (snapshot_lost, etc.).
+  # Best-effort; a store error is logged, not raised (adoption/relight callers must
+  # keep going).
+  defp fail_session(state, session_id, reason, detail) do
+    case SessionStore.transition(
+           state.session_store,
+           session_id,
+           :fail,
+           :session_failed,
+           %{reason: reason, detail: detail},
+           %{}
+         ) do
+      {:ok, _} ->
+        :ok
+
+      {:error, err} ->
+        Logger.warning("embervm session fail transition failed", session_id: session_id, error: inspect(err))
+        :error
+    end
+  end
+
+  defp get_session!(state, session_id) do
+    {:ok, session} = SessionStore.get(state.session_store, session_id)
+    session
+  end
+
+  defp schedule(_msg, interval) when interval <= 0, do: :ok
+  defp schedule(msg, interval), do: Process.send_after(self(), msg, interval)
+
   # -- destroy ---------------------------------------------------------------
 
   defp do_destroy(state, session_id) do
     case SessionStore.get(state.session_store, session_id) do
       {:ok, %{state: session_state}} when session_state in [:expired, :evicted, :destroyed, :failed] ->
-        {:ok, :already_terminal}
+        {{:ok, :already_terminal}, state}
 
       {:ok, session} ->
         destroy_live(state, session)
 
       :error ->
-        {:error, :not_found}
+        {{:error, :not_found}, state}
     end
   end
 
-  # Stop the session process (which owns and, on terminate, releases the VM), then
-  # record session_destroyed. A live session has a process; a banked one does not
-  # (its VM is already gone, only the snapshot remains, whose eviction is PR-4).
+  # Destroy a session: tear down whatever it holds. A live session (running/banking/
+  # relighting) has a process + VM, stopped and destroyed here; a banked session has
+  # only a snapshot, evicted here. Then record session_destroyed. Any parked relight
+  # waiters are drained gone (the session is being destroyed). Returns {reply, state}
+  # so the drained relighting ledger is threaded back.
   defp destroy_live(state, session) do
-    _ = stop_session_process(state, session.session_id, session)
+    if session.state == :banked do
+      _ = evict_snapshot(state, session)
+    else
+      _ = stop_session_process(state, session.session_id, session)
+    end
 
-    SessionStore.transition(
-      state.session_store,
-      session.session_id,
-      :destroy,
-      :session_destroyed,
-      %{reason: :destroyed},
-      %{}
-    )
+    state = drain_relight_waiters(state, session.session_id, {:error, {:gone, "destroyed"}})
+
+    reply =
+      SessionStore.transition(
+        state.session_store,
+        session.session_id,
+        :destroy,
+        :session_destroyed,
+        %{reason: :destroyed},
+        %{}
+      )
+
+    {reply, state}
   end
 
   # Terminate the session process and destroy its VM. We destroy the VM HERE (not in
@@ -483,6 +1496,18 @@ defmodule Embervm.SessionManager do
 
   defp default_prime(channel, %PrimeRequest{} = req) do
     Embervm.Node.V1.NodeService.Stub.prime(channel, req)
+  end
+
+  defp default_bank(channel, %BankRequest{} = req) do
+    Embervm.Node.V1.NodeService.Stub.bank(channel, req)
+  end
+
+  defp default_relight(channel, %RelightRequest{} = req) do
+    Embervm.Node.V1.NodeService.Stub.relight(channel, req)
+  end
+
+  defp default_evict(channel, %EvictSnapshotRequest{} = req) do
+    Embervm.Node.V1.NodeService.Stub.evict_snapshot(channel, req)
   end
 
   defp default_clock, do: System.system_time(:millisecond)

--- a/projects/embervm/control/lib/embervm/session_placement.ex
+++ b/projects/embervm/control/lib/embervm/session_placement.ex
@@ -1,0 +1,152 @@
+defmodule Embervm.SessionPlacement do
+  @moduledoc """
+  The session placement seam (R2, Task 8): the ONLY module that computes WHERE a
+  session lives. The invocation front-end (the router) and the lifecycle brain
+  (`Embervm.SessionManager`) call this and never inspect node capacity facts
+  themselves, keeping the R2 held invariant intact: the front-end is split from
+  placement, so R3 can later swap a proxied hit for an xDS-published route without
+  touching either caller (standing decision 7).
+
+  ## the two placement questions
+
+    * `node_for_create/2`: where does a NEW session's VM get placed? A rendezvous
+      hash of the session-id over the READY nodes with live-VM budget for the
+      workload. v1 has exactly one node, so the hash is trivially that node, but
+      the interface takes the registry's node list (via the capacity table) so
+      multi-node is a DATA change (more rows), not a code change. Because a session
+      id does not exist until create mints it, create passes the WORKLOAD and lets
+      placement pick a ready node deterministically; the caller then mints the id
+      pinned to that node's snapshot_ref (the node's base for the workload).
+
+    * `node_for_relight/2`: where does a BANKED session relight? NOT a fresh choice:
+      a node-local snapshot lives on exactly one node (standing decision 3), so the
+      session relights ONLY on the node that reports its snapshot. This reads the
+      session's recorded `node_id` and CONFIRMS the node currently reports that
+      session's snapshot in its inventory. If no ready node reports the snapshot
+      (node death, evicted out of band), relight is impossible and the caller fails
+      the session `snapshot_lost` -> 410 (loud, never a silent blank VM).
+
+  ## why placement is pure functions over the capacity table
+
+  Placement is a read over the `Embervm.NodeCapacity` ETS table (the registry's
+  fail-closed projection of node truth) plus the session row. It holds no state and
+  runs no process: a stale/empty capacity read simply yields "no node", which the
+  caller turns into a `:no_capacity` create denial or a `:snapshot_lost` relight
+  failure. Keeping it a pure module (not a GenServer) means the router and manager
+  can call it inline without a message round-trip, and it is trivially testable.
+  """
+
+  alias Embervm.NodeCapacity
+
+  @type node_choice :: {:ok, node_id :: String.t(), snapshot_ref :: String.t() | nil} | {:error, :no_capacity}
+
+  @doc """
+  Picks the node for a new session of `workload`: the rendezvous-hash winner among
+  the ready nodes that have this workload's base built AND live-VM budget. Returns
+  `{:ok, node_id, snapshot_ref}` (the node's base snapshot for the workload, passed
+  to Prime on a claim miss) or `{:error, :no_capacity}` when no node qualifies.
+
+  The rendezvous key is the WORKLOAD (a session id does not exist yet); with one
+  node this is deterministic anyway. When multi-node lands, hashing per-workload
+  spreads a workload's sessions' creates across nodes without central state.
+  """
+  @spec node_for_create(String.t(), atom()) :: node_choice()
+  def node_for_create(workload, capacity_table \\ NodeCapacity.table()) do
+    NodeCapacity.all(capacity_table)
+    |> Enum.filter(&eligible_for_workload?(&1, workload))
+    |> rendezvous_pick(workload)
+    |> case do
+      nil ->
+        {:error, :no_capacity}
+
+      fact ->
+        wc = Map.get(fact.workloads, workload)
+        {:ok, fact.configured_id, Map.get(wc, :snapshot_ref)}
+    end
+  end
+
+  @doc """
+  Resolves the node a BANKED `session` relights on: the session's recorded
+  `node_id`, CONFIRMED to be a ready node currently reporting the session's
+  `snapshot_ref` in its `session_snapshots` inventory. Returns `{:ok, node_id}` or
+  `{:error, :snapshot_lost}` when no ready node holds the snapshot (node death,
+  out-of-band eviction). Placement never picks a DIFFERENT node for a relight: a
+  node-local snapshot is restorable on exactly its owning node (standing decision 3).
+  """
+  @spec node_for_relight(map(), atom()) :: {:ok, String.t()} | {:error, :snapshot_lost}
+  def node_for_relight(session, capacity_table \\ NodeCapacity.table()) do
+    snapshot_ref = Map.get(session, :snapshot_ref)
+    node_id = Map.get(session, :node_id)
+
+    if is_binary(snapshot_ref) and snapshot_ref != "" and node_reports_snapshot?(capacity_table, node_id, snapshot_ref) do
+      {:ok, node_id}
+    else
+      {:error, :snapshot_lost}
+    end
+  end
+
+  # -- internals -------------------------------------------------------------
+
+  # A node is eligible for a new session of `workload` when it has the workload's
+  # base READY (a restorable snapshot_ref) AND live-VM budget below its node cap.
+  # Mirrors SessionManager's PR-3 inline pick_node, now owned here.
+  defp eligible_for_workload?(fact, workload) do
+    wc = Map.get(fact.workloads || %{}, workload)
+
+    cond do
+      is_nil(wc) -> false
+      not base_ready?(wc) -> false
+      not has_budget?(fact) -> false
+      true -> true
+    end
+  end
+
+  defp base_ready?(wc) do
+    ready =
+      case Map.get(wc, :base_state) do
+        :BASE_BUILD_STATE_READY -> true
+        3 -> true
+        _ -> false
+      end
+
+    ref = Map.get(wc, :snapshot_ref)
+    ready and is_binary(ref) and ref != ""
+  end
+
+  defp has_budget?(fact) do
+    max = Map.get(fact, :max_live_vms, 0)
+    max > 0 and Map.get(fact, :live_vms, 0) < max
+  end
+
+  # Rendezvous (highest-random-weight) hashing: the eligible node whose
+  # hash(key, node_id) is maximal. With one eligible node this is that node; with
+  # N it distributes `key`s across nodes and, crucially, is STABLE under node set
+  # changes (adding/removing a node only remaps the keys that hashed to it). Empty
+  # list yields nil (the caller denies :no_capacity).
+  defp rendezvous_pick([], _key), do: nil
+
+  defp rendezvous_pick(facts, key) do
+    Enum.max_by(facts, fn fact -> weight(key, fact.configured_id) end)
+  end
+
+  defp weight(key, node_id) do
+    :erlang.phash2({key, node_id}, 4_294_967_296)
+  end
+
+  # Whether a READY node with the given id currently reports `snapshot_ref` among
+  # its banked-snapshot inventory. A node absent from the (fail-closed) capacity
+  # table is not ready, so a session on a down node reads as snapshot_lost.
+  defp node_reports_snapshot?(_capacity_table, node_id, _snapshot_ref) when not is_binary(node_id), do: false
+
+  defp node_reports_snapshot?(capacity_table, node_id, snapshot_ref) do
+    case NodeCapacity.fetch(capacity_table, node_id) do
+      {:ok, fact} ->
+        fact
+        |> Map.get(:session_snapshots, [])
+        |> Enum.any?(fn snap -> Map.get(snap, :snapshot_ref) == snapshot_ref end)
+
+      :error ->
+        false
+    end
+  end
+end

--- a/projects/embervm/control/lib/embervm/session_state.ex
+++ b/projects/embervm/control/lib/embervm/session_state.ex
@@ -64,8 +64,10 @@ defmodule Embervm.SessionState do
     :create_ready,
     :bank,
     :bank_ready,
+    :bank_abort,
     :relight,
     :relight_ready,
+    :relight_abort,
     :expire,
     :evict,
     :destroy,
@@ -77,12 +79,20 @@ defmodule Embervm.SessionState do
   @transitions %{
     # Create: a claimed/primed VM is live.
     {:creating, :create_ready} => :running,
-    # Idle-bank (PR-4): running -> banking (bank RPC in flight) -> banked.
+    # Idle-bank: running -> banking (bank RPC in flight) -> banked. The bank_abort
+    # edge (banking -> running) is the ETS-only recovery when the Bank RPC fails: the
+    # VM is still alive, so the session returns to running (no durable op; the failed
+    # bank left no snapshot). banking is a transient, crash-healed-from-node state.
     {:running, :bank} => :banking,
     {:banking, :bank_ready} => :banked,
-    # Relight-on-invoke (PR-4): banked -> relighting (relight RPC in flight) -> running.
+    {:banking, :bank_abort} => :running,
+    # Relight-on-invoke: banked -> relighting (relight RPC in flight) -> running. The
+    # relight_abort edge (relighting -> banked) is the ETS-only recovery when a
+    # transient (non-precondition) relight failure leaves the snapshot intact: the
+    # session returns to banked and a later invoke re-relights.
     {:banked, :relight} => :relighting,
     {:relighting, :relight_ready} => :running,
+    {:relighting, :relight_abort} => :banked,
     # Max-lifetime expiry: a live or banked session past its deadline.
     {:running, :expire} => :expired,
     {:banked, :expire} => :expired,

--- a/projects/embervm/control/lib/embervm/session_store.ex
+++ b/projects/embervm/control/lib/embervm/session_store.ex
@@ -86,6 +86,22 @@ defmodule Embervm.SessionStore do
   end
 
   @doc """
+  Applies a TRANSIENT FSM edge to a session WITHOUT an op-log append: the ETS-only
+  move into a mid-operation state (`banking`, `relighting`) that a crash heals from
+  node inventory rather than from the durable log (there is no `session_banking`/
+  `session_relighting` op kind by design, standing decision: the durable log records
+  only completed lifecycle transitions). `event` must be a legal FSM edge from the
+  session's current state; an illegal edge is `{:error, {:illegal_transition, ...}}`.
+  Keeps residency + per-workload counts consistent, exactly like `transition/6`, but
+  never touches the op-log, so it must ONLY be used for states a later durable op
+  (`session_banked`/`session_relit`) or adoption will resolve.
+  """
+  @spec mark(GenServer.server(), String.t(), atom()) :: {:ok, map()} | {:error, term()}
+  def mark(store \\ __MODULE__, session_id, event) do
+    GenServer.call(store, {:mark, session_id, event})
+  end
+
+  @doc """
   Records a `session_invoked` op (usage only, NO request/response bodies) against a
   running session: a non-state-changing write-through (running -> running) so it is
   NOT an FSM transition. Bumps `last_invoke_at` and charges usage to the quota cache
@@ -137,6 +153,42 @@ defmodule Embervm.SessionStore do
   @spec counts(GenServer.server(), String.t()) :: %{live: non_neg_integer(), banked: non_neg_integer()}
   def counts(store \\ __MODULE__, workload) do
     GenServer.call(store, {:counts, workload})
+  end
+
+  @doc """
+  Every session in the hot set (a full ETS scan), for the adoption reconcile that
+  compares the durable projection against the node's reported inventory. Rare (boot
+  + every registry sweep), never on the invoke path.
+  """
+  @spec all(GenServer.server()) :: [map()]
+  def all(store \\ __MODULE__) do
+    GenServer.call(store, :all)
+  end
+
+  @doc """
+  Adoption: FORCE a session's ETS state to `new_state` (one of `running`/`banked`)
+  from authoritative node truth, bypassing the FSM (adoption is idempotent and
+  derived from what the node actually holds, so it must be total over limbo states
+  the FSM cannot bridge, e.g. a `banking` session whose node reports a live VM).
+  Updates residency + per-workload counts, drops residency for `banked`, and does
+  NOT append an op (the durable log already recorded the last completed transition;
+  adoption only re-derives the transient ETS view). A no-op for an unknown or
+  already-terminal session (never resurrects a terminal row). Returns `:ok`.
+  """
+  @spec adopt_state(GenServer.server(), String.t(), :running | :banked) :: :ok
+  def adopt_state(store \\ __MODULE__, session_id, new_state) do
+    GenServer.call(store, {:adopt_state, session_id, new_state})
+  end
+
+  @doc """
+  Adoption: rebind a session the node reports as a LIVE VM to `{node_id, vm_id}`,
+  writing the residency fact and the ETS row's `vm_id`/`node_id` WITHOUT an FSM
+  transition or an op-log append (residency is a lossy fact the node owns, not
+  durable state). A no-op for an unknown session. Returns `:ok`.
+  """
+  @spec adopt_residency(GenServer.server(), String.t(), String.t(), String.t()) :: :ok
+  def adopt_residency(store \\ __MODULE__, session_id, node_id, vm_id) do
+    GenServer.call(store, {:adopt_residency, session_id, node_id, vm_id})
   end
 
   @doc """
@@ -252,6 +304,10 @@ defmodule Embervm.SessionStore do
     do_transition(state, session_id, event, op_kind, payload, updates)
   end
 
+  def handle_call({:mark, session_id, event}, _from, state) do
+    do_mark(state, session_id, event)
+  end
+
   def handle_call({:record_invoke, session_id, usage}, _from, state) do
     do_record_invoke(state, session_id, usage)
   end
@@ -286,6 +342,48 @@ defmodule Embervm.SessionStore do
 
   def handle_call({:counts, workload}, _from, state) do
     {:reply, Map.get(state.counts, workload, %{live: 0, banked: 0}), state}
+  end
+
+  def handle_call(:all, _from, state) do
+    all = :ets.foldl(fn {_id, session}, acc -> [session | acc] end, [], state.sessions)
+    {:reply, all, state}
+  end
+
+  def handle_call({:adopt_state, session_id, new_state}, _from, state)
+      when new_state in [:running, :banked] do
+    case fetch(state, session_id) do
+      {:ok, %{state: cur}} when cur in [:expired, :evicted, :destroyed, :failed] ->
+        # Never resurrect a terminal session from a stale node fact.
+        {:reply, :ok, state}
+
+      {:ok, session} ->
+        if session.state == new_state do
+          {:reply, :ok, state}
+        else
+          ts = state.clock.()
+          updated = %{session | state: new_state, updated_at: ts}
+          :ets.insert(state.sessions, {session_id, updated})
+          state = bump_counts(state, session.state, new_state, session.workload)
+          state = apply_residency(state, session.state, updated)
+          {:reply, :ok, state}
+        end
+
+      {:error, _} ->
+        {:reply, :ok, state}
+    end
+  end
+
+  def handle_call({:adopt_residency, session_id, node_id, vm_id}, _from, state) do
+    case fetch(state, session_id) do
+      {:ok, session} ->
+        updated = %{session | node_id: node_id, vm_id: vm_id}
+        :ets.insert(state.sessions, {session_id, updated})
+        :ets.insert(state.residency, {session_id, {node_id, vm_id}})
+        {:reply, :ok, state}
+
+      {:error, _} ->
+        {:reply, :ok, state}
+    end
   end
 
   def handle_call({:list, workload, opts}, _from, state) do
@@ -385,6 +483,23 @@ defmodule Embervm.SessionStore do
         {:ok, updated, state} -> {:reply, {:ok, updated}, state}
         {:error, reason} -> {:reply, {:error, reason}, state}
       end
+    else
+      {:error, _reason} = error -> {:reply, error, state}
+    end
+  end
+
+  # Transient ETS-only FSM move (no op-log append): banking/relighting entry markers
+  # a later completion op or adoption resolves. Keeps residency + counts in step with
+  # the ETS state exactly like append_and_update, minus the durable write.
+  defp do_mark(state, session_id, event) do
+    with {:ok, session} <- fetch(state, session_id),
+         {:ok, next} <- SessionState.transition(session.state, event) do
+      ts = state.clock.()
+      updated = %{session | state: next, updated_at: ts}
+      :ets.insert(state.sessions, {session_id, updated})
+      state = bump_counts(state, session.state, next, session.workload)
+      state = apply_residency(state, session.state, updated)
+      {:reply, {:ok, updated}, state}
     else
       {:error, _reason} = error -> {:reply, error, state}
     end

--- a/projects/embervm/control/test/embervm/session_bank_relight_test.exs
+++ b/projects/embervm/control/test/embervm/session_bank_relight_test.exs
@@ -201,6 +201,20 @@ defmodule Embervm.SessionBankRelightTest do
     end
   end
 
+  defp wait_until(fun, tries \\ 200) do
+    cond do
+      fun.() ->
+        :ok
+
+      tries > 0 ->
+        Process.sleep(5)
+        wait_until(fun, tries - 1)
+
+      true ->
+        flunk("wait_until condition never became true")
+    end
+  end
+
   # -- idle-bank -------------------------------------------------------------
 
   test "idle-bank fires only when quiescent: banks an idle session, releasing its VM" do
@@ -256,14 +270,28 @@ defmodule Embervm.SessionBankRelightTest do
     put_workload(ctx, "wl")
     {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
 
-    # Each :maybe_bank admission fails; after three, the session is failed + destroyed.
+    # Each :maybe_bank admission STOPS the session process; a failed bank re-starts
+    # it with a FRESH pid (strikes 1-2) or, at three, fails + destroys it. Wait for
+    # the re-start (a new pid) before the next send so a strike is never dropped by
+    # racing a not-yet-restarted process. Deterministic, not a fixed sleep (which
+    # raced the async re-start once the store's clock became an Agent round-trip).
     for _ <- 1..3 do
-      case Registry.lookup(ctx.registry, created.session_id) do
-        [{pid, _}] -> send(pid, :maybe_bank)
-        [] -> :ok
-      end
+      old =
+        case Registry.lookup(ctx.registry, created.session_id) do
+          [{pid, _}] ->
+            send(pid, :maybe_bank)
+            pid
 
-      Process.sleep(20)
+          [] ->
+            nil
+        end
+
+      wait_until(fn ->
+        case Registry.lookup(ctx.registry, created.session_id) do
+          [{pid, _}] -> pid != old
+          [] -> match?({:ok, %{state: :failed}}, SessionStore.get(ctx.store, created.session_id))
+        end
+      end)
     end
 
     wait_state(ctx, created.session_id, :failed)

--- a/projects/embervm/control/test/embervm/session_bank_relight_test.exs
+++ b/projects/embervm/control/test/embervm/session_bank_relight_test.exs
@@ -495,9 +495,9 @@ defmodule Embervm.SessionBankRelightTest do
     advance(ctx.clock_pid, 1_000)
     {:ok, session_a} = SessionStore.get(ctx.store, a.session_id)
     # Record an invoke on a so its last_invoke_at is set (warmer than b's nil/0).
+    assert session_a.state == :running
     _ = SessionStore.record_invoke(ctx.store, a.session_id, %{cpu_ms: 1})
     :ok = force_idle_bank(ctx, a.session_id)
-    assert session_a.state == :running or true
 
     # Node reports both snapshots and a free-bytes BELOW the watermark (pressure).
     NodeCapacity.put(ctx.cap_table, "node-4",

--- a/projects/embervm/control/test/embervm/session_bank_relight_test.exs
+++ b/projects/embervm/control/test/embervm/session_bank_relight_test.exs
@@ -1,0 +1,521 @@
+defmodule Embervm.SessionBankRelightTest do
+  @moduledoc """
+  Task 7 + Task 8 acceptance for the bank/relight lifecycle, the placement seam, and
+  restart adoption. A FAKE DAEMON is injected via bank_fun / relight_fun / evict_fun
+  / claim_fun / channel_fun plus the session_opts assign fun, exactly the seam idiom
+  the PR-3 SessionManagerTest uses. A real (unnamed) op-log + SessionStore give the
+  real FSM and durable projection; unique ETS + a per-test supervisor/registry keep
+  tests isolated from the application's supervised subtree.
+
+  What a reviewer must scrutinise, each has a test:
+
+    * idle-bank quiescence: banks only when no invoke is in flight or queued;
+    * the three-strikes bank failure path (session -> failed + VM destroyed);
+    * relight-on-invoke: a parked invoke on a banked session is served after relight,
+      and session_relit appends only after a live vm_id (crash consistency);
+    * the wake-rate limit: excess relight-triggering invokes 429 without a node hit;
+    * snapshot_lost: an unrestorable snapshot -> failed + parked callers 410;
+    * the adoption matrix: restart with running/banking/banked/relighting each
+      converging to the right state, reap-free on a transient disconnect;
+    * LRU eviction: disk-pressure evicts the coldest banked sessions to the watermark;
+    * expiry (live + banked) and banked-TTL GC.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.{NodeCapacity, SessionManager, SessionStore, WorkloadCatalog}
+  alias Embervm.OpLog.SQLite
+
+  alias Embervm.Node.V1.{
+    BankResponse,
+    GuestResponse,
+    RelightResponse,
+    SessionAssignResponse,
+    UsageStats
+  }
+
+  # A clock the test controls: an Agent holding the current ms, so timer/TTL logic is
+  # deterministic. `advance/2` moves it forward.
+  defp start_clock(start \\ 1_000_000) do
+    {:ok, pid} = Agent.start_link(fn -> start end)
+    pid
+  end
+
+  defp now(clock_pid), do: Agent.get(clock_pid, & &1)
+  defp advance(clock_pid, ms), do: Agent.update(clock_pid, &(&1 + ms))
+
+  defp start_stack(opts \\ []) do
+    suffix = System.unique_integer([:positive])
+    cap_table = :"bcap_#{suffix}"
+    cat_table = :"bcat_#{suffix}"
+
+    NodeCapacity.create(cap_table)
+    WorkloadCatalog.create(cat_table)
+
+    path = Path.join(System.tmp_dir!(), "embervm_bankrelight_test_#{suffix}.db")
+    on_exit(fn -> File.rm_rf!(path) end)
+
+    {:ok, op_log} = SQLite.start_link(name: nil, path: path)
+    {:ok, store} = SessionStore.start_link(name: nil, op_log: op_log)
+
+    registry = :"breg_#{suffix}"
+    {:ok, _} = Registry.start_link(keys: :unique, name: registry)
+    {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+    clock_pid = Keyword.get(opts, :clock_pid, start_clock())
+    clock = fn -> now(clock_pid) end
+
+    test_pid = self()
+
+    assign_fun = Keyword.get(opts, :assign_fun, &default_assign/2)
+
+    session_opts = [
+      channel_fun: fn _node -> {:ok, :ch} end,
+      assign_fun: assign_fun,
+      destroy_fun: fn _ch, vm -> send(test_pid, {:destroyed, vm}) && {:ok, %{}} end,
+      invalidate_fun: fn _node, _ch -> :ok end
+    ]
+
+    mgr_opts =
+      [
+        name: nil,
+        session_store: store,
+        supervisor: sup,
+        registry: registry,
+        capacity_table: cap_table,
+        catalog_table: cat_table,
+        clock: clock,
+        channel_fun: fn _node -> {:ok, :ch} end,
+        claim_fun: fn _d, _n, _w -> {:ok, "vm-#{suffix}-#{System.unique_integer([:positive])}"} end,
+        prime_fun: fn _ch, _req -> {:error, :no_prime} end,
+        bank_fun: Keyword.get(opts, :bank_fun, &default_bank/2),
+        relight_fun: Keyword.get(opts, :relight_fun, &default_relight/2),
+        evict_fun: Keyword.get(opts, :evict_fun, fn _ch, req -> send(test_pid, {:evicted, req.snapshot_ref}) && {:ok, %{}} end),
+        session_opts: session_opts,
+        # Timers off by default: tests drive reconcile/1 + sweep/1 explicitly.
+        reconcile_interval_ms: 0,
+        sweep_interval_ms: 0
+      ] ++ Keyword.take(opts, [:disk_low_watermark_bytes, :wake_max, :wake_window_ms, :bank_concurrency])
+
+    {:ok, mgr} = SessionManager.start_link(mgr_opts)
+
+    %{
+      mgr: mgr,
+      store: store,
+      op_log: op_log,
+      cap_table: cap_table,
+      cat_table: cat_table,
+      registry: registry,
+      sup: sup,
+      clock_pid: clock_pid,
+      suffix: suffix
+    }
+  end
+
+  defp default_assign(_ch, req) do
+    {:ok,
+     %SessionAssignResponse{
+       response: %GuestResponse{status_code: 200, headers: %{}, body: req.request.body},
+       usage: %UsageStats{cpu_ms: 1, peak_rss_mib: 1, wall_ms: 1},
+       suspect: false
+     }}
+  end
+
+  defp default_bank(_ch, req) do
+    {:ok, %BankResponse{snapshot_ref: "snap-#{req.session_id}", size_bytes: 2_000}}
+  end
+
+  defp default_relight(_ch, _req) do
+    {:ok, %RelightResponse{vm_id: "vm-relit-#{System.unique_integer([:positive])}"}}
+  end
+
+  defp put_workload(ctx, wl, opts \\ []) do
+    NodeCapacity.put(ctx.cap_table, "node-4", node_fact(wl, opts))
+
+    WorkloadCatalog.upsert(ctx.cat_table, wl, %{
+      name: wl,
+      namespace: "embervm",
+      class: "session",
+      image_ref: "img@sha256:abc",
+      invoke_path: "/",
+      timeout_ms: 90_000,
+      cap: Keyword.get(opts, :cap, 8),
+      floor: 1,
+      session: %{
+        idle_bank_seconds: Keyword.get(opts, :idle_bank_seconds, 300),
+        max_lifetime_seconds: Keyword.get(opts, :max_lifetime_seconds, 3600),
+        banked_ttl_seconds: Keyword.get(opts, :banked_ttl_seconds, 3600),
+        max_sessions: Keyword.get(opts, :max_sessions, 16),
+        invoke_queue_cap: Keyword.get(opts, :queue_cap, 4)
+      }
+    })
+  end
+
+  defp node_fact(wl, opts) do
+    %{
+      node_id: "node-4",
+      configured_id: "node-4",
+      workloads: %{
+        wl => %{
+          free_primed_slots: 1,
+          snapshot_ref: "base-#{wl}",
+          base_state: :BASE_BUILD_STATE_READY,
+          primed_vm_ids: []
+        }
+      },
+      live_vms: Keyword.get(opts, :live, 0),
+      max_live_vms: Keyword.get(opts, :max, 8),
+      session_vms: Keyword.get(opts, :session_vms, []),
+      session_snapshots: Keyword.get(opts, :session_snapshots, []),
+      snapshot_disk_free_bytes: Keyword.get(opts, :free, 10_000_000),
+      snapshot_disk_used_bytes: 0,
+      draining: false,
+      updated_at: 0
+    }
+  end
+
+  # Drive a session's idle-bank timer synchronously: find its live process and send
+  # it :maybe_bank, then wait for the banked state to land (the manager's async bank
+  # worker completes on the manager process).
+  defp force_idle_bank(ctx, session_id) do
+    [{pid, _}] = Registry.lookup(ctx.registry, session_id)
+    send(pid, :maybe_bank)
+    wait_state(ctx, session_id, :banked)
+  end
+
+  defp wait_state(ctx, session_id, expected, tries \\ 100) do
+    case SessionStore.get(ctx.store, session_id) do
+      {:ok, %{state: ^expected}} ->
+        :ok
+
+      _ when tries > 0 ->
+        Process.sleep(5)
+        wait_state(ctx, session_id, expected, tries - 1)
+
+      _ ->
+        {:ok, s} = SessionStore.get(ctx.store, session_id)
+        flunk("session #{session_id} never reached #{expected}; stuck at #{s.state}")
+    end
+  end
+
+  # -- idle-bank -------------------------------------------------------------
+
+  test "idle-bank fires only when quiescent: banks an idle session, releasing its VM" do
+    ctx = start_stack()
+    put_workload(ctx, "wl")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+
+    :ok = force_idle_bank(ctx, created.session_id)
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :banked
+    assert session.generation == 1
+    assert session.snapshot_ref == "snap-#{created.session_id}"
+    # A banked session has no process.
+    assert Registry.lookup(ctx.registry, created.session_id) == []
+    # counts moved live -> banked.
+    assert SessionStore.counts(ctx.store, "wl") == %{live: 0, banked: 1}
+  end
+
+  test "idle-bank re-arms (does not bank) while an invoke is in flight" do
+    # A blocking assign keeps the session non-quiescent; :maybe_bank must NOT bank.
+    test_pid = self()
+
+    blocking_assign = fn _ch, req ->
+      send(test_pid, :assign_started)
+
+      receive do
+        :go -> {:ok, %SessionAssignResponse{response: %GuestResponse{status_code: 200, headers: %{}, body: req.request.body}, usage: %UsageStats{cpu_ms: 1, peak_rss_mib: 1, wall_ms: 1}, suspect: false}}
+      end
+    end
+
+    ctx = start_stack(assign_fun: blocking_assign)
+    put_workload(ctx, "wl")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+
+    caller = spawn(fn -> SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"}) end)
+    assert_receive :assign_started, 1_000
+
+    [{pid, _}] = Registry.lookup(ctx.registry, created.session_id)
+    send(pid, :maybe_bank)
+    Process.sleep(30)
+
+    # Still running (not banked): the in-flight invoke blocked the bank.
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :running
+
+    Process.exit(caller, :kill)
+  end
+
+  test "three consecutive bank failures fail the session and destroy its VM" do
+    fail_bank = fn _ch, _req -> {:error, %GRPC.RPCError{status: 13, message: "boom"}} end
+    ctx = start_stack(bank_fun: fail_bank)
+    put_workload(ctx, "wl")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+
+    # Each :maybe_bank admission fails; after three, the session is failed + destroyed.
+    for _ <- 1..3 do
+      case Registry.lookup(ctx.registry, created.session_id) do
+        [{pid, _}] -> send(pid, :maybe_bank)
+        [] -> :ok
+      end
+
+      Process.sleep(20)
+    end
+
+    wait_state(ctx, created.session_id, :failed)
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :failed
+    assert_received {:destroyed, _vm}
+  end
+
+  # -- relight-on-invoke -----------------------------------------------------
+
+  test "invoke on a banked session relights it and serves the parked caller" do
+    ctx = start_stack()
+    put_workload(ctx, "wl")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+    :ok = force_idle_bank(ctx, created.session_id)
+
+    # After bank, the node must report the snapshot so placement can relight it.
+    NodeCapacity.put(ctx.cap_table, "node-4", node_fact("wl", session_snapshots: [snap_fact(created.session_id)]))
+
+    {:ok, resp} = SessionManager.invoke(ctx.mgr, created.session_id, %{method: "POST", path: "/", headers: %{}, body: "after-relight"})
+    assert resp.status_code == 200
+    assert resp.body == "after-relight"
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :running
+    # A session_relit op landed (state back to running with a fresh VM).
+    assert [{_pid, _}] = Registry.lookup(ctx.registry, created.session_id)
+  end
+
+  test "the wake-rate limit 429s an excess relight-triggering invoke without a node hit" do
+    test_pid = self()
+    counting_relight = fn _ch, _req -> send(test_pid, :relight_called) && {:ok, %RelightResponse{vm_id: "vm-r"}} end
+
+    # wake_max 1: the first banked-invoke relights, the second (before it completes)
+    # 429s. We block the relight so both invokes race the same banked session.
+    ctx = start_stack(relight_fun: counting_relight, wake_max: 1)
+    put_workload(ctx, "wl")
+    {:ok, a} = SessionManager.create(ctx.mgr, "wl", "p1")
+    {:ok, b} = SessionManager.create(ctx.mgr, "wl", "p1")
+    :ok = force_idle_bank(ctx, a.session_id)
+    :ok = force_idle_bank(ctx, b.session_id)
+
+    NodeCapacity.put(ctx.cap_table, "node-4",
+      node_fact("wl", session_snapshots: [snap_fact(a.session_id), snap_fact(b.session_id)])
+    )
+
+    # First banked-invoke: allowed (consumes the single wake token), relights a.
+    {:ok, _} = SessionManager.invoke(ctx.mgr, a.session_id, %{body: "x"})
+    # Second: same principal, over the wake_max of 1 within the window -> 429.
+    assert {:error, :wake_rate_limited} = SessionManager.invoke(ctx.mgr, b.session_id, %{body: "y"})
+  end
+
+  test "an unrestorable snapshot fails the session and 410s the caller (snapshot_lost)" do
+    lost_relight = fn _ch, _req -> {:error, %GRPC.RPCError{status: 9, message: "unrestorable"}} end
+    ctx = start_stack(relight_fun: lost_relight)
+    put_workload(ctx, "wl")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+    :ok = force_idle_bank(ctx, created.session_id)
+
+    NodeCapacity.put(ctx.cap_table, "node-4", node_fact("wl", session_snapshots: [snap_fact(created.session_id)]))
+
+    assert {:error, {:gone, "snapshot_lost"}} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"})
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :failed
+    assert session.terminal_reason == "snapshot_lost"
+    # The lost snapshot was evicted.
+    assert_received {:evicted, _ref}
+  end
+
+  # -- adoption matrix -------------------------------------------------------
+
+  test "adoption rebinds a running session VM to a fresh process after a restart" do
+    ctx = start_stack()
+    put_workload(ctx, "wl")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+
+    # Simulate a control-plane restart: kill the session process so ETS says running
+    # but no process exists. The node still reports the live VM.
+    [{pid, _}] = Registry.lookup(ctx.registry, created.session_id)
+    {:ok, %{vm_id: vm_id}} = SessionStore.get(ctx.store, created.session_id)
+    DynamicSupervisor.terminate_child(ctx.sup, pid)
+    Process.sleep(10)
+    assert Registry.lookup(ctx.registry, created.session_id) == []
+
+    NodeCapacity.put(ctx.cap_table, "node-4",
+      node_fact("wl", session_vms: [%{vm_id: vm_id, session_id: created.session_id, workload: "wl"}])
+    )
+
+    :ok = SessionManager.reconcile(ctx.mgr)
+
+    # Rebound: a fresh process runs and the session is invokable.
+    assert [{_pid, _}] = Registry.lookup(ctx.registry, created.session_id)
+    {:ok, resp} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "z"})
+    assert resp.status_code == 200
+  end
+
+  test "adoption heals a banked session (node reports only the snapshot, no process)" do
+    ctx = start_stack()
+    put_workload(ctx, "wl")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+    :ok = force_idle_bank(ctx, created.session_id)
+
+    NodeCapacity.put(ctx.cap_table, "node-4", node_fact("wl", session_snapshots: [snap_fact(created.session_id)]))
+
+    :ok = SessionManager.reconcile(ctx.mgr)
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :banked
+    assert Registry.lookup(ctx.registry, created.session_id) == []
+  end
+
+  test "adoption fails a session whose VM AND snapshot both vanished (node reporting)" do
+    ctx = start_stack()
+    put_workload(ctx, "wl")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+
+    [{pid, _}] = Registry.lookup(ctx.registry, created.session_id)
+    DynamicSupervisor.terminate_child(ctx.sup, pid)
+    Process.sleep(10)
+
+    # The node is up but reports NO vm and NO snapshot for this session: authoritative
+    # vanish -> failed.
+    NodeCapacity.put(ctx.cap_table, "node-4", node_fact("wl", session_vms: [], session_snapshots: []))
+
+    :ok = SessionManager.reconcile(ctx.mgr)
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :failed
+    assert session.terminal_reason == "failed"
+  end
+
+  test "adoption NEVER reaps on a transient disconnect (node absent from the facts)" do
+    ctx = start_stack()
+    put_workload(ctx, "wl")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+
+    [{pid, _}] = Registry.lookup(ctx.registry, created.session_id)
+    DynamicSupervisor.terminate_child(ctx.sup, pid)
+    Process.sleep(10)
+
+    # The node is GONE from the capacity table (a disconnect, fail-closed drop): the
+    # session must be left untouched (reaping would wipe the fleet, the #3517 lesson).
+    NodeCapacity.drop(ctx.cap_table, "node-4")
+
+    :ok = SessionManager.reconcile(ctx.mgr)
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :running
+  end
+
+  test "adoption evicts an orphaned snapshot whose session row is terminal" do
+    ctx = start_stack()
+    put_workload(ctx, "wl")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+    {:ok, _} = SessionManager.destroy(ctx.mgr, created.session_id)
+
+    # The node still reports a snapshot for the destroyed session: it must be evicted.
+    NodeCapacity.put(ctx.cap_table, "node-4", node_fact("wl", session_snapshots: [snap_fact(created.session_id)]))
+
+    :ok = SessionManager.reconcile(ctx.mgr)
+    assert_received {:evicted, _ref}
+  end
+
+  # -- expiry, GC, eviction --------------------------------------------------
+
+  test "sweep expires a live session past its max lifetime (destroys the VM)" do
+    ctx = start_stack()
+    put_workload(ctx, "wl", max_lifetime_seconds: 1)
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+
+    advance(ctx.clock_pid, 2_000)
+    :ok = SessionManager.sweep(ctx.mgr)
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :expired
+    assert_received {:destroyed, _vm}
+  end
+
+  test "sweep expires a banked session past its max lifetime (evicts the snapshot)" do
+    ctx = start_stack()
+    put_workload(ctx, "wl", max_lifetime_seconds: 10)
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+    :ok = force_idle_bank(ctx, created.session_id)
+
+    advance(ctx.clock_pid, 20_000)
+    :ok = SessionManager.sweep(ctx.mgr)
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :expired
+    assert_received {:evicted, _ref}
+  end
+
+  test "invoke-time expiry 410s a session past its deadline without waiting for a sweep" do
+    ctx = start_stack()
+    put_workload(ctx, "wl", max_lifetime_seconds: 1)
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+
+    advance(ctx.clock_pid, 2_000)
+    assert {:error, {:gone, "expired"}} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"})
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :expired
+  end
+
+  test "banked-TTL GC evicts a banked session untouched past bankedTtlSeconds" do
+    ctx = start_stack()
+    put_workload(ctx, "wl", max_lifetime_seconds: 100_000, banked_ttl_seconds: 5)
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+    :ok = force_idle_bank(ctx, created.session_id)
+
+    advance(ctx.clock_pid, 10_000)
+    :ok = SessionManager.sweep(ctx.mgr)
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :evicted
+    assert session.terminal_reason == "idle_ttl"
+  end
+
+  test "disk-pressure eviction removes the coldest banked sessions LRU to the watermark" do
+    ctx = start_stack(disk_low_watermark_bytes: 5_000)
+    put_workload(ctx, "wl", banked_ttl_seconds: 100_000, max_lifetime_seconds: 100_000)
+
+    # Two banked sessions, each snapshot 2_000 bytes. a is invoked LATER than b, so b
+    # is colder (evicted first).
+    {:ok, a} = SessionManager.create(ctx.mgr, "wl", "p1")
+    {:ok, b} = SessionManager.create(ctx.mgr, "wl", "p1")
+
+    # Bank b first (older last_invoke via updated_at), then a. Both have nil
+    # last_invoke_at, so sort_by falls back to 0 for both; give a a later invoke to
+    # make it the warmer victim-last.
+    :ok = force_idle_bank(ctx, b.session_id)
+    advance(ctx.clock_pid, 1_000)
+    {:ok, session_a} = SessionStore.get(ctx.store, a.session_id)
+    # Record an invoke on a so its last_invoke_at is set (warmer than b's nil/0).
+    _ = SessionStore.record_invoke(ctx.store, a.session_id, %{cpu_ms: 1})
+    :ok = force_idle_bank(ctx, a.session_id)
+    assert session_a.state == :running or true
+
+    # Node reports both snapshots and a free-bytes BELOW the watermark (pressure).
+    NodeCapacity.put(ctx.cap_table, "node-4",
+      node_fact("wl", free: 3_000, session_snapshots: [snap_fact(a.session_id), snap_fact(b.session_id)])
+    )
+
+    :ok = SessionManager.sweep(ctx.mgr)
+
+    # b (coldest) is evicted; a (warmer, invoked) survives. One eviction lifts free
+    # 3_000 + 2_000 = 5_000 >= watermark, so a is spared.
+    {:ok, sb} = SessionStore.get(ctx.store, b.session_id)
+    {:ok, sa} = SessionStore.get(ctx.store, a.session_id)
+    assert sb.state == :evicted
+    assert sb.terminal_reason == "disk_pressure"
+    assert sa.state == :banked
+  end
+
+  defp snap_fact(session_id) do
+    %{snapshot_ref: "snap-#{session_id}", session_id: session_id, workload: "wl", size_bytes: 2_000, created_at_unix_ms: 0}
+  end
+end

--- a/projects/embervm/control/test/embervm/session_bank_relight_test.exs
+++ b/projects/embervm/control/test/embervm/session_bank_relight_test.exs
@@ -54,15 +54,19 @@ defmodule Embervm.SessionBankRelightTest do
     path = Path.join(System.tmp_dir!(), "embervm_bankrelight_test_#{suffix}.db")
     on_exit(fn -> File.rm_rf!(path) end)
 
+    # The clock must be shared by the store and the manager: the store stamps
+    # updated_at/last_invoke_at and the manager sweep compares against them, so a
+    # split clock (a real wall-clock in the store vs the test Agent in the sweep)
+    # makes now-last hugely negative and the TTL GC never fires. Create it FIRST.
+    clock_pid = Keyword.get(opts, :clock_pid, start_clock())
+    clock = fn -> now(clock_pid) end
+
     {:ok, op_log} = SQLite.start_link(name: nil, path: path)
-    {:ok, store} = SessionStore.start_link(name: nil, op_log: op_log)
+    {:ok, store} = SessionStore.start_link(name: nil, op_log: op_log, clock: clock)
 
     registry = :"breg_#{suffix}"
     {:ok, _} = Registry.start_link(keys: :unique, name: registry)
     {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
-
-    clock_pid = Keyword.get(opts, :clock_pid, start_clock())
-    clock = fn -> now(clock_pid) end
 
     test_pid = self()
 
@@ -496,7 +500,7 @@ defmodule Embervm.SessionBankRelightTest do
     {:ok, session_a} = SessionStore.get(ctx.store, a.session_id)
     # Record an invoke on a so its last_invoke_at is set (warmer than b's nil/0).
     assert session_a.state == :running
-    _ = SessionStore.record_invoke(ctx.store, a.session_id, %{cpu_ms: 1})
+    _ = SessionStore.record_invoke(ctx.store, a.session_id, %{cpu_ms: 1, peak_rss_mib: 1, wall_ms: 1})
     :ok = force_idle_bank(ctx, a.session_id)
 
     # Node reports both snapshots and a free-bytes BELOW the watermark (pressure).

--- a/projects/embervm/control/test/embervm/session_placement_test.exs
+++ b/projects/embervm/control/test/embervm/session_placement_test.exs
@@ -1,0 +1,114 @@
+defmodule Embervm.SessionPlacementTest do
+  @moduledoc """
+  Task 8 placement seam: node_for_create picks a ready node with budget over the
+  capacity table (rendezvous hash, trivially one node in v1), and node_for_relight
+  resolves ONLY to a node currently reporting the session's snapshot (a lost
+  snapshot => snapshot_lost). This is the reviewer-checked boundary: the router and
+  SessionManager call THIS module and never inspect node facts, so its correctness
+  is the whole placement contract.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.{NodeCapacity, SessionPlacement}
+
+  defp table do
+    t = :"placement_#{System.unique_integer([:positive])}"
+    NodeCapacity.create(t)
+    t
+  end
+
+  defp put_node(t, id, opts) do
+    NodeCapacity.put(t, id, %{
+      node_id: id,
+      configured_id: id,
+      workloads: %{
+        "wl" => %{
+          free_primed_slots: 1,
+          snapshot_ref: Keyword.get(opts, :snapshot_ref, "base-wl"),
+          base_state: Keyword.get(opts, :base_state, :BASE_BUILD_STATE_READY),
+          primed_vm_ids: []
+        }
+      },
+      live_vms: Keyword.get(opts, :live, 0),
+      max_live_vms: Keyword.get(opts, :max, 8),
+      session_vms: Keyword.get(opts, :session_vms, []),
+      session_snapshots: Keyword.get(opts, :session_snapshots, []),
+      snapshot_disk_free_bytes: Keyword.get(opts, :free, 1_000_000),
+      snapshot_disk_used_bytes: 0,
+      draining: false,
+      updated_at: 0
+    })
+  end
+
+  # -- create ---------------------------------------------------------------
+
+  test "node_for_create picks a ready node with budget and returns its base snapshot_ref" do
+    t = table()
+    put_node(t, "node-4", snapshot_ref: "base-wl")
+
+    assert {:ok, "node-4", "base-wl"} = SessionPlacement.node_for_create("wl", t)
+  end
+
+  test "node_for_create denies when the base is not ready" do
+    t = table()
+    put_node(t, "node-4", base_state: :BASE_BUILD_STATE_BUILDING)
+    assert {:error, :no_capacity} = SessionPlacement.node_for_create("wl", t)
+  end
+
+  test "node_for_create denies when the node is at its live-VM cap" do
+    t = table()
+    put_node(t, "node-4", live: 8, max: 8)
+    assert {:error, :no_capacity} = SessionPlacement.node_for_create("wl", t)
+  end
+
+  test "node_for_create denies when no node reports the workload" do
+    t = table()
+    assert {:error, :no_capacity} = SessionPlacement.node_for_create("other-wl", t)
+  end
+
+  test "node_for_create is deterministic (rendezvous hash) across eligible nodes" do
+    t = table()
+    put_node(t, "node-a", snapshot_ref: "base-a")
+    put_node(t, "node-b", snapshot_ref: "base-b")
+
+    {:ok, first, _} = SessionPlacement.node_for_create("wl", t)
+    # Stable across repeated calls (no randomness): the same workload key always maps
+    # to the same node until the node set changes.
+    for _ <- 1..5, do: assert({:ok, ^first, _} = SessionPlacement.node_for_create("wl", t))
+    assert first in ["node-a", "node-b"]
+  end
+
+  # -- relight --------------------------------------------------------------
+
+  test "node_for_relight resolves to the node reporting the session's snapshot" do
+    t = table()
+
+    put_node(t, "node-4",
+      session_snapshots: [%{snapshot_ref: "sess-snap-1", session_id: "s-1", workload: "wl", size_bytes: 10, created_at_unix_ms: 0}]
+    )
+
+    session = %{node_id: "node-4", snapshot_ref: "sess-snap-1"}
+    assert {:ok, "node-4"} = SessionPlacement.node_for_relight(session, t)
+  end
+
+  test "node_for_relight is snapshot_lost when no ready node reports the snapshot" do
+    t = table()
+    # Node up but NOT reporting this session's snapshot (evicted out of band).
+    put_node(t, "node-4", session_snapshots: [])
+
+    session = %{node_id: "node-4", snapshot_ref: "sess-snap-gone"}
+    assert {:error, :snapshot_lost} = SessionPlacement.node_for_relight(session, t)
+  end
+
+  test "node_for_relight is snapshot_lost when the recorded node is down (absent from the table)" do
+    t = table()
+    session = %{node_id: "node-dead", snapshot_ref: "sess-snap-1"}
+    assert {:error, :snapshot_lost} = SessionPlacement.node_for_relight(session, t)
+  end
+
+  test "node_for_relight is snapshot_lost with no snapshot_ref on the row" do
+    t = table()
+    put_node(t, "node-4", [])
+    assert {:error, :snapshot_lost} = SessionPlacement.node_for_relight(%{node_id: "node-4", snapshot_ref: nil}, t)
+  end
+end

--- a/projects/embervm/control/test/embervm/session_state_test.exs
+++ b/projects/embervm/control/test/embervm/session_state_test.exs
@@ -15,8 +15,10 @@ defmodule Embervm.SessionStateTest do
     {:creating, :create_ready} => :running,
     {:running, :bank} => :banking,
     {:banking, :bank_ready} => :banked,
+    {:banking, :bank_abort} => :running,
     {:banked, :relight} => :relighting,
     {:relighting, :relight_ready} => :running,
+    {:relighting, :relight_abort} => :banked,
     {:running, :expire} => :expired,
     {:banked, :expire} => :expired,
     {:banked, :evict} => :evicted,
@@ -32,8 +34,8 @@ defmodule Embervm.SessionStateTest do
   }
 
   test "exhaustive transition table: every (state, event) pair matches the documented outcome" do
-    assert map_size(@legal) == 17
-    assert length(SessionState.events()) == 9
+    assert map_size(@legal) == 19
+    assert length(SessionState.events()) == 11
     assert length(SessionState.states()) == 9
 
     for state <- SessionState.states(), event <- SessionState.events() do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.38
+      targetRevision: 0.1.39
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
**PR-4 (Tasks 7-8) of EmberVM R2 Sessions**: the headline economics. Idle sessions BANK (suspend to a snapshot, releasing the live VM); the next invoke RELIGHTS them with state intact. Plus the pure `SessionPlacement` boundary and restart adoption (the #3517 reap-free-on-disconnect lesson). Opus-implemented, Opus-reviewed.

## What (2257 lines)
- **Task 7**: idle-bank timer (fires only when quiescent, session process stops on bank); max-lifetime expiry (sweeper + invoke-time); banked-TTL GC; LRU disk-pressure eviction (coldest-first, never live, fail-closed on missing disk facts, watermark-scoped); per-node bank cap; three-strikes bank-failure → failed+destroy. Two-phase FSM with ETS-only `banking`/`relighting` transient states + abort edges.
- **Task 8**: `session_placement.ex` (rendezvous-hash create pick; relight resolves only to the snapshot-holding node); relight-on-invoke (park → relight → `session_relit` AFTER the live vm_id → drain); wake-rate limit (30/min/principal, 429 without a node hit); restart adoption (rebind live VMs, heal limbo from node truth, fail vanished, never reap on disconnect); snapshot-lost → failed + 410.

## Review fixes applied (DECISIONS.md D-R2.4.5)
- **Critical**: bank/relight workers acquired the node channel with a bare `channel_fun.(node_id)` in the `with` head — a `GenServer.call` EXIT (NodeChannel down/timeout) killed the worker before `{:bank_done}`/`{:relight_done}`, hanging parked callers forever + leaking the per-node bank slot. Wrapped in `safe_channel/2`.
- **Medium**: a reconcile mid-bank forced the session to `running`, dropping `finish_bank`'s `session_banked`. `adopt_one` now skips a session the manager has in-flight.

## Decisions (D-R2.4.1-5)
ETS-only transient states; async bank off the manager; total `adopt_state`; watermark-scoped fail-closed; mid-bank invokes park-then-relight. `wake_events` prune is a recorded low-priority follow-on.

Bump embervm 0.1.39. No local test loop; Elixir compile + bank/relight/adoption ExUnit verified in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)