### PR TITLE
feat(embervm): R2 PR-5 session tracing, status counts, snapshot disk alert

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -593,3 +593,33 @@ choices where the plan was silent. Flagged for post-impl review.
   request volume), negligible for a homelab; a periodic prune of empty-window keys is
   a recorded follow-on, not done. **FLAG FOR JOE** only if principal cardinality ever
   grows unbounded.
+
+## R2 Phase 3: operability (PR-5, embervm 0.1.40)
+
+Task 9 choices where the plan was silent. Flagged for post-impl review.
+
+### D-R2.5.1 Snapshot-disk alert reuses existing hostmetrics, no new Elixir metric export
+- The noded exports no snapshot-disk metric and the snapshot scratch is a hostPath (not
+  a PVC), so the op-log alert's kubeletstats `k8s.volume` metric cannot see it. Rather
+  than add an OTel METRICS SDK to the Elixir control plane (a fragile multi-place
+  hermetic-hex + MODULE.bazel change, disproportionate for an alert), the alert is
+  sourced from the already-scraped k8s-infra hostmetrics `system.filesystem.usage`
+  gauge, filtered to node-4's NVMe mountpoint that holds `embervm-noded/snapshots`.
+  Zero new export; whole-scratch usage (bases + snapshots share it) is the right
+  exhaustion axis. Alert notifies via `incidentio` (the only channel registered in
+  signoz-alerts; the plan's "homelab channel" maps to it, same as every other embervm
+  alert). No chart bump: the alerts chart is git-HEAD-synced, not OCI-pinned.
+
+### D-R2.5.2 status.sessions counts written on the sweep tick, change-detected
+- The control plane patches `status.sessions {live,banked}` + `sessionsSummary` on the
+  existing 30s sweep tick, debounced per workload against a written-counts map (the
+  PoolManager `primedFloorSatisfied` pattern), never per-transition. Disjoint status
+  keys so it does not collide with pool/base status writes.
+
+### D-R2.5.3 Session spans nest via a threaded traceparent, not OTel process context
+- OTel process context does not cross `GenServer.call`/`spawn`, so the invoke root span
+  is opened at the router and its W3C traceparent threaded through the plain `req` map
+  (`session_trace.ex`, reusing the dispatcher's `:otel_tracer.from_remote_span` idiom,
+  not a new tracing layer). Timer/API-driven bank/create/evict have no caller trace, so
+  they are root spans (consistent with the dispatcher's prime/auth spans). The Task 11
+  gates (relight p95, bank p95, state-persistence) are derivable from spans alone.

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.39
+version: 0.1.40

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -39,8 +39,9 @@ defmodule Embervm.Router do
   use Plug.Router
 
   require Logger
+  require OpenTelemetry.Tracer, as: Tracer
 
-  alias Embervm.{SyncWait, TaskState, TaskStore}
+  alias Embervm.{SessionTrace, SyncWait, TaskState, TaskStore}
 
   # Single tenant in v1 (the `homelab` tenant); the column is still carried on
   # every record so multi-tenant is a data change, not a schema change.
@@ -584,19 +585,36 @@ defmodule Embervm.Router do
   # task-envelope allow-list + 8 MiB cap via the SessionManager, and returns the
   # guest response VERBATIM including headers.
   defp handle_session_invoke(conn, session_id) do
-    with {:ok, token} <- bearer_token(conn),
-         {:ok, _session} <- verify_session_token(session_id, token) do
-      proxy_invoke(conn, session_id)
-    else
-      {:error, :no_token} ->
-        halt_json(conn, 401, %{error: "missing session token", retryable: false})
+    # Restore the CALLER's trace context (the traceparent their httpx/OTel client
+    # carried), then open the session-invoke ROOT span so `auth`, `queue_wait`,
+    # `relight`, and `guest_exec` all nest under it AND under the caller's trace
+    # (the R0 "guilty phase must never be uninstrumented" rule, Task 9). Same
+    # `from_remote_span` idiom the dispatcher uses; see Embervm.SessionTrace.
+    SessionTrace.restore_parent(header_value(conn, "traceparent"))
 
-      {:error, :terminal} ->
-        # A valid token on a terminal session: 410 with the recorded reason.
-        session_gone(conn, session_id)
+    Tracer.with_span "embervm.session.invoke", %{
+      attributes: %{"ember.session_id" => session_id}
+    } do
+      with {:ok, token} <- bearer_token(conn),
+           {:ok, session} <- verify_session_token_span(session_id, token) do
+        Tracer.set_attributes(%{
+          "ember.workload" => Map.get(session, :workload),
+          "ember.principal" => Map.get(session, :principal),
+          "ember.session_state" => to_string(Map.get(session, :state))
+        })
 
-      {:error, _} ->
-        halt_json(conn, 403, %{error: "invalid session token", session_id: session_id, retryable: false})
+        proxy_invoke(conn, session_id)
+      else
+        {:error, :no_token} ->
+          halt_json(conn, 401, %{error: "missing session token", retryable: false})
+
+        {:error, :terminal} ->
+          # A valid token on a terminal session: 410 with the recorded reason.
+          session_gone(conn, session_id)
+
+        {:error, _} ->
+          halt_json(conn, 403, %{error: "invalid session token", session_id: session_id, retryable: false})
+      end
     end
   end
 
@@ -607,7 +625,12 @@ defmodule Embervm.Router do
           method: "POST",
           path: guest_path(conn),
           headers: guest_headers(conn),
-          body: body
+          body: body,
+          # Serialize the invoke ROOT span so the downstream queue_wait/relight/
+          # guest_exec spans (which run in other processes across GenServer.call and
+          # spawn boundaries, where the OTel process context does not follow) nest
+          # under it. nil when tracing is off (CI). See Embervm.SessionTrace.
+          traceparent: SessionTrace.current_traceparent()
         }
 
         case session_manager().invoke(session_manager_server(), session_id, req) do
@@ -729,6 +752,15 @@ defmodule Embervm.Router do
   # `{:ok, session} | {:error, :terminal | :unauthorized | :not_found}`.
   defp verify_session_token(session_id, token) do
     session_store().verify_token(session_store_server(), session_id, token)
+  end
+
+  # The `auth` child span (Task 9): the session-token verify is the invoke's auth
+  # phase, kept as its own span so the Task 11 gates can attribute auth latency
+  # (mirrors the dispatcher's embervm.auth span for TokenReview).
+  defp verify_session_token_span(session_id, token) do
+    Tracer.with_span "embervm.session.auth", %{attributes: %{"ember.session_id" => session_id}} do
+      verify_session_token(session_id, token)
+    end
   end
 
   defp session_gone(conn, session_id) do

--- a/projects/embervm/control/lib/embervm/session.ex
+++ b/projects/embervm/control/lib/embervm/session.ex
@@ -67,8 +67,10 @@ defmodule Embervm.Session do
 
   use GenServer, restart: :transient
   require Logger
+  require OpenTelemetry.Tracer, as: Tracer
 
   alias Embervm.Node.V1.{GuestRequest, GuestResponse, SessionAssignRequest, SessionAssignResponse, Trace}
+  alias Embervm.SessionTrace
 
   # -- Client API ------------------------------------------------------------
 
@@ -152,7 +154,10 @@ defmodule Embervm.Session do
   end
 
   defp enqueue(state, from, req) do
-    %{state | queue: :queue.in({from, req}, state.queue)}
+    # Stamp the enqueue time (native units) so the worker can emit a `queue_wait`
+    # span covering park -> dispatch (Task 9: the FIFO wait is a latency phase the
+    # Task 11 gates must read from spans).
+    %{state | queue: :queue.in({from, req, :opentelemetry.timestamp()}, state.queue)}
   end
 
   @impl true
@@ -261,8 +266,8 @@ defmodule Embervm.Session do
   # timer so a sustained idle period banks.
   defp maybe_start_next(%{worker: nil} = state) do
     case :queue.out(state.queue) do
-      {{:value, {from, req}}, rest} ->
-        {pid, ref} = spawn_invoke_worker(state, req)
+      {{:value, {from, req, enqueued_at}}, rest} ->
+        {pid, ref} = spawn_invoke_worker(state, req, enqueued_at)
         %{state | queue: rest, worker: {pid, ref, from}}
 
       {:empty, _} ->
@@ -272,30 +277,59 @@ defmodule Embervm.Session do
 
   defp maybe_start_next(state), do: state
 
-  defp spawn_invoke_worker(state, req) do
+  defp spawn_invoke_worker(state, req, enqueued_at) do
     owner = self()
     node_id = state.node_id
     vm_id = state.vm_id
     session_id = state.session_id
     workload = state.workload
+    principal = state.principal
     timeout_ms = state.timeout_ms
     channel_fun = state.channel_fun
     invalidate_fun = state.invalidate_fun
     assign_fun = state.assign_fun
 
     spawn_monitor(fn ->
+      # Restore the invoke ROOT span (carried on the req from the router) as the
+      # remote parent so this worker's phase spans nest under the caller's trace.
+      SessionTrace.restore_parent(Map.get(req, :traceparent))
+
+      # queue_wait: park -> dispatch. Emitted with an explicit start_time = enqueue
+      # so the span reflects the real FIFO wait (this worker only starts once the
+      # session is free), ending now as the guest_exec begins.
+      Tracer.with_span "embervm.session.queue_wait",
+                       %{
+                         start_time: enqueued_at,
+                         attributes: %{
+                           "ember.session_id" => session_id,
+                           "ember.workload" => workload,
+                           "ember.principal" => principal
+                         }
+                       } do
+        :ok
+      end
+
       outcome =
-        run_invoke(%{
-          node_id: node_id,
-          vm_id: vm_id,
-          session_id: session_id,
-          workload: workload,
-          timeout_ms: timeout_ms,
-          req: req,
-          channel_fun: channel_fun,
-          invalidate_fun: invalidate_fun,
-          assign_fun: assign_fun
-        })
+        Tracer.with_span "embervm.session.guest_exec",
+                         %{
+                           attributes: %{
+                             "ember.session_id" => session_id,
+                             "ember.workload" => workload,
+                             "ember.principal" => principal
+                           }
+                         } do
+          run_invoke(%{
+            node_id: node_id,
+            vm_id: vm_id,
+            session_id: session_id,
+            workload: workload,
+            timeout_ms: timeout_ms,
+            req: req,
+            channel_fun: channel_fun,
+            invalidate_fun: invalidate_fun,
+            assign_fun: assign_fun
+          })
+        end
 
       send(owner, {:invoke_done, self(), outcome})
     end)
@@ -384,7 +418,7 @@ defmodule Embervm.Session do
   end
 
   defp drain_queue_as_failed(state) do
-    for {from, _req} <- :queue.to_list(state.queue) do
+    for {from, _req, _enqueued_at} <- :queue.to_list(state.queue) do
       GenServer.reply(from, {:error, :failed})
     end
   end

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -51,8 +51,9 @@ defmodule Embervm.SessionManager do
 
   use GenServer
   require Logger
+  require OpenTelemetry.Tracer, as: Tracer
 
-  alias Embervm.{NodeCapacity, SessionPlacement, SessionState, SessionStore, WorkloadCatalog}
+  alias Embervm.{NodeCapacity, SessionPlacement, SessionState, SessionStore, SessionTrace, WorkloadCatalog}
 
   alias Embervm.Node.V1.{
     BankRequest,
@@ -219,7 +220,15 @@ defmodule Embervm.SessionManager do
       # The registry sweep (adoption) and the TTL/eviction sweep cadences. Distinct
       # timers; both clock-injected and disable-able for tests (interval 0 = off).
       reconcile_interval_ms: Keyword.get(opts, :reconcile_interval_ms, 0),
-      sweep_interval_ms: Keyword.get(opts, :sweep_interval_ms, 0)
+      sweep_interval_ms: Keyword.get(opts, :sweep_interval_ms, 0),
+      # status.sessions {live,banked} + sessionsSummary writer (Task 9). Written on
+      # the sweep tick, DEBOUNCED: only patched when a session workload's live/banked
+      # pair differs from the last-written pair (workload -> {live, banked}), the same
+      # change-detection the PoolManager uses for primedFloorSatisfied. Disjoint status
+      # keys (`sessions`/`sessionsSummary`) so it never clobbers the watcher/pool/base
+      # writers' keys (the merge-patch coexistence rule).
+      status_writer: Keyword.get(opts, :status_writer, &Embervm.K8s.patch_workload_status/3),
+      session_status_written: %{}
     }
 
     # session_opts always carry a manager reference so the per-session idle timer can
@@ -329,19 +338,50 @@ defmodule Embervm.SessionManager do
   # -- create ----------------------------------------------------------------
 
   defp do_create(state, workload, principal) do
-    with {:ok, entry} <- fetch_session_workload(state, workload),
-         :ok <- check_session_cap(state, workload, entry),
-         :ok <- check_workload_cap(state, workload, entry),
-         :ok <- check_quota(state, principal),
-         {:ok, node_id, snapshot_ref} <- pick_node(state, workload),
-         {:ok, vm_id} <- claim_or_prime(state, node_id, workload, snapshot_ref) do
-      register_and_start(state, workload, principal, entry, node_id, vm_id)
-    else
-      {:error, reason} ->
-        audit_denial(state, principal, workload, reason)
-        {:error, {:denied, reason}}
+    # The create span (Task 9): a lifecycle span carrying `ember.pool_hit` (warm
+    # claim vs prime miss), set from within claim_or_prime. Root span (create is
+    # management-auth API-driven, no guest caller trace to nest under).
+    Tracer.with_span "embervm.session.create",
+                     %{
+                       attributes: %{
+                         "ember.workload" => workload,
+                         "ember.principal" => principal
+                       }
+                     } do
+      result =
+        with {:ok, entry} <- fetch_session_workload(state, workload),
+             :ok <- check_session_cap(state, workload, entry),
+             :ok <- check_workload_cap(state, workload, entry),
+             :ok <- check_quota(state, principal),
+             {:ok, node_id, snapshot_ref} <- pick_node(state, workload),
+             {:ok, vm_id} <- claim_or_prime(state, node_id, workload, snapshot_ref) do
+          register_and_start(state, workload, principal, entry, node_id, vm_id)
+        else
+          {:error, reason} ->
+            audit_denial(state, principal, workload, reason)
+            {:error, {:denied, reason}}
+        end
+
+      log_create_result(result, workload, principal)
+      result
     end
   end
+
+  # Structured create log (Task 9): success at info, denial at warn, both keyed
+  # with session_id (when minted)/workload/principal for consistent lifecycle logs.
+  defp log_create_result({:ok, %{session_id: session_id}}, workload, principal) do
+    Logger.info("embervm session created", session_id: session_id, workload: workload, principal: principal)
+  end
+
+  defp log_create_result({:error, {:denied, reason}}, workload, principal) do
+    Logger.warning("embervm session create denied",
+      workload: workload,
+      principal: principal,
+      reason: inspect(reason)
+    )
+  end
+
+  defp log_create_result(_other, _workload, _principal), do: :ok
 
   defp fetch_session_workload(state, workload) do
     case WorkloadCatalog.fetch(state.catalog_table, workload) do
@@ -395,9 +435,13 @@ defmodule Embervm.SessionManager do
   defp claim_or_prime(state, node_id, workload, snapshot_ref) do
     case state.claim_fun.(state.dispatcher, node_id, workload) do
       {:ok, vm_id} ->
+        # A warm claim from the primed pool: pool_hit=true (parity with the
+        # dispatcher's warm-dispatch marking).
+        Tracer.set_attributes(%{"ember.pool_hit" => true})
         {:ok, vm_id}
 
       :miss ->
+        Tracer.set_attributes(%{"ember.pool_hit" => false})
         prime(state, node_id, snapshot_ref)
     end
   end
@@ -670,13 +714,26 @@ defmodule Embervm.SessionManager do
     generation = (session.generation || 0) + 1
 
     spawn(fn ->
+      # A lifecycle span (Task 9). Idle-bank has no caller trace, so it is a root
+      # span (like the dispatcher's embervm.prime); the Task 11 bank-p95 gate reads
+      # it. snapshot_bytes is set on success.
       outcome =
-        with {:ok, channel} <- safe_channel(channel_fun, node_id),
-             {:ok, %BankResponse{snapshot_ref: ref, size_bytes: size}} when is_binary(ref) and ref != "" <-
-               safe_bank(bank_fun, channel, workload, session_id, vm_id) do
-          {:ok, ref, size, generation, parent_base_ref}
-        else
-          other -> {:error, other}
+        Tracer.with_span "embervm.session.bank",
+                         %{
+                           attributes: %{
+                             "ember.session_id" => session_id,
+                             "ember.workload" => workload,
+                             "ember.generation" => generation
+                           }
+                         } do
+          with {:ok, channel} <- safe_channel(channel_fun, node_id),
+               {:ok, %BankResponse{snapshot_ref: ref, size_bytes: size}} when is_binary(ref) and ref != "" <-
+                 safe_bank(bank_fun, channel, workload, session_id, vm_id) do
+            Tracer.set_attributes(%{"ember.snapshot_bytes" => size})
+            {:ok, ref, size, generation, parent_base_ref}
+          else
+            other -> {:error, other}
+          end
         end
 
       send(owner, {:bank_done, session_id, node_id, outcome})
@@ -722,7 +779,13 @@ defmodule Embervm.SessionManager do
             %{snapshot_ref: ref, snapshot_size_bytes: size, generation: generation, node_id: node_id, vm_id: nil}
           )
 
-        Logger.info("embervm session banked", session_id: session_id, node_id: node_id)
+        Logger.info("embervm session banked",
+          session_id: session_id,
+          node_id: node_id,
+          workload: workload_of(state, session_id),
+          principal: principal_of(state, session_id),
+          snapshot_bytes: size
+        )
         state = clear_bank_failures(state, session_id)
         relight_parked_after_bank(state, session_id)
 
@@ -908,28 +971,55 @@ defmodule Embervm.SessionManager do
     relight_fun = state.relight_fun
     clock = state.clock
     session_id = session.session_id
+    # The relight nests under the ROOT span of the invoke that triggered it: the
+    # first parked caller's carried traceparent (concurrent invokes to one banked
+    # session share this one relight). nil when tracing is off.
+    traceparent = first_waiter_traceparent(state, session_id)
 
     spawn(fn ->
-      outcome =
-        case SessionPlacement.node_for_relight(session, capacity_table) do
-          {:ok, node_id} ->
-            t0 = clock.()
+      SessionTrace.restore_parent(traceparent)
 
-            with {:ok, channel} <- safe_channel(channel_fun, node_id),
-                 {:ok, %RelightResponse{vm_id: vm_id}} when is_binary(vm_id) and vm_id != "" <-
-                   safe_relight(relight_fun, channel, session) do
-              {:ok, node_id, vm_id, clock.() - t0}
-            else
-              {:error, reason} -> classify_relight_error(reason)
-              other -> classify_relight_error({:relight_failed, other})
-            end
+      Tracer.with_span "embervm.session.relight",
+                       %{
+                         attributes: %{
+                           "ember.session_id" => session_id,
+                           "ember.workload" => session.workload,
+                           "ember.principal" => session.principal,
+                           "ember.generation" => session.generation || 0
+                         }
+                       } do
+        outcome =
+          case SessionPlacement.node_for_relight(session, capacity_table) do
+            {:ok, node_id} ->
+              t0 = clock.()
 
-          {:error, :snapshot_lost} ->
-            {:error, :snapshot_lost}
-        end
+              with {:ok, channel} <- safe_channel(channel_fun, node_id),
+                   {:ok, %RelightResponse{vm_id: vm_id}} when is_binary(vm_id) and vm_id != "" <-
+                     safe_relight(relight_fun, channel, session) do
+                relight_ms = clock.() - t0
+                Tracer.set_attributes(%{"ember.relight_ms" => relight_ms})
+                {:ok, node_id, vm_id, relight_ms}
+              else
+                {:error, reason} -> classify_relight_error(reason)
+                other -> classify_relight_error({:relight_failed, other})
+              end
 
-      send(owner, {:relight_done, session_id, outcome})
+            {:error, :snapshot_lost} ->
+              {:error, :snapshot_lost}
+          end
+
+        send(owner, {:relight_done, session_id, outcome})
+      end
     end)
+  end
+
+  # The traceparent carried on the FIRST parked invoke for `session_id` (they share
+  # the relight), or nil when the ledger is empty / tracing is off.
+  defp first_waiter_traceparent(state, session_id) do
+    case Map.get(state.relighting, session_id, []) do
+      [{_from, req} | _] -> Map.get(req, :traceparent)
+      _ -> nil
+    end
   end
 
   defp safe_relight(relight_fun, channel, session) do
@@ -992,7 +1082,12 @@ defmodule Embervm.SessionManager do
 
         case start_session_from_row(state, %{session | node_id: node_id, vm_id: vm_id}, node_id, vm_id) do
           {:ok, pid} ->
-            Logger.info("embervm session relit", session_id: session_id, relight_ms: relight_ms)
+            Logger.info("embervm session relit",
+              session_id: session_id,
+              workload: session.workload,
+              principal: session.principal,
+              relight_ms: relight_ms
+            )
             drain_relight_into_process(state, session_id, pid)
 
           {:error, reason} ->
@@ -1227,6 +1322,60 @@ defmodule Embervm.SessionManager do
     |> sweep_expiry(now)
     |> sweep_banked_ttl(now)
     |> sweep_disk_pressure()
+    |> write_session_status()
+  end
+
+  # -- status.sessions counts (Task 9) ---------------------------------------
+
+  # Write status.sessions {live,banked} + sessionsSummary for every session-class
+  # workload, DEBOUNCED: only patch a workload whose live/banked pair changed since
+  # its last write. Runs on the sweep tick (not on every transition), so the K8s API
+  # is touched at most once per session workload per sweep, never per transition.
+  # Disjoint status keys, so the merge-patch never clobbers the watcher/pool writers.
+  defp write_session_status(state) do
+    session_workloads(state)
+    |> Enum.reduce(state, fn %{workload: workload, namespace: namespace}, acc ->
+      counts = SessionStore.counts(acc.session_store, workload)
+      pair = {counts.live, counts.banked}
+
+      if Map.get(acc.session_status_written, workload) == pair do
+        acc
+      else
+        _ = patch_session_status(acc, namespace, workload, counts)
+        %{acc | session_status_written: Map.put(acc.session_status_written, workload, pair)}
+      end
+    end)
+  end
+
+  # Every cataloged session-class workload with its namespace, for the status write.
+  # A catalog with no session workloads yields [], so this is a no-op on task-only
+  # clusters.
+  defp session_workloads(state) do
+    for name <- WorkloadCatalog.all_names(state.catalog_table),
+        {:ok, %{class: "session", namespace: namespace}} <- [WorkloadCatalog.fetch(state.catalog_table, name)],
+        is_binary(namespace) do
+      %{workload: name, namespace: namespace}
+    end
+  end
+
+  defp patch_session_status(state, namespace, name, counts) do
+    status_map = %{
+      "sessions" => %{"live" => counts.live, "banked" => counts.banked},
+      "sessionsSummary" => "#{counts.live} live / #{counts.banked} banked"
+    }
+
+    case state.status_writer.(namespace, name, status_map) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        # Visibility-only: a status-write failure must never crash the sweep.
+        Logger.warning("embervm session status patch failed for #{namespace}/#{name}: #{inspect(reason)}")
+    end
+  rescue
+    e -> Logger.warning("embervm session status patch raised for #{namespace}/#{name}: #{inspect(e)}")
+  catch
+    _, _ -> :ok
   end
 
   # Max-lifetime expiry (independent of the invoke-time check): any non-terminal
@@ -1258,7 +1407,12 @@ defmodule Embervm.SessionManager do
         %{}
       )
 
-    Logger.info("embervm session expired", session_id: session.session_id)
+    Logger.info("embervm session expired",
+      session_id: session.session_id,
+      workload: session.workload,
+      principal: session.principal
+    )
+
     state
   end
 
@@ -1347,7 +1501,13 @@ defmodule Embervm.SessionManager do
         %{}
       )
 
-    Logger.warning("embervm session evicted", session_id: session.session_id, reason: reason)
+    Logger.warning("embervm session evicted",
+      session_id: session.session_id,
+      workload: session.workload,
+      principal: session.principal,
+      reason: reason
+    )
+
     state
   end
 
@@ -1361,19 +1521,24 @@ defmodule Embervm.SessionManager do
 
   defp evict_snapshot_on_node(state, node_id, snapshot_ref, _reported_id)
        when is_binary(node_id) and is_binary(snapshot_ref) do
-    with {:ok, channel} <- state.channel_fun.(node_id) do
-      req = %EvictSnapshotRequest{trace: %Trace{}, snapshot_ref: snapshot_ref}
+    # A lifecycle span (Task 9): reclaiming a snapshot bundle from node disk. Root
+    # span (eviction is sweep/adoption-driven, no caller trace).
+    Tracer.with_span "embervm.session.evict",
+                     %{attributes: %{"ember.node_id" => node_id}} do
+      with {:ok, channel} <- state.channel_fun.(node_id) do
+        req = %EvictSnapshotRequest{trace: %Trace{}, snapshot_ref: snapshot_ref}
 
-      try do
-        state.evict_fun.(channel, req)
-      rescue
-        _ -> :error
-      catch
-        _, _ -> :error
+        try do
+          state.evict_fun.(channel, req)
+        rescue
+          _ -> :error
+        catch
+          _, _ -> :error
+        end
       end
-    end
 
-    :ok
+      :ok
+    end
   end
 
   defp evict_snapshot_on_node(_state, _node_id, _ref, _reported), do: :ok
@@ -1404,6 +1569,22 @@ defmodule Embervm.SessionManager do
   defp get_session!(state, session_id) do
     {:ok, session} = SessionStore.get(state.session_store, session_id)
     session
+  end
+
+  # Best-effort workload/principal lookups for consistent structured-log keys
+  # (Task 9). nil when the row is gone (a log key, never load-bearing).
+  defp workload_of(state, session_id) do
+    case SessionStore.get(state.session_store, session_id) do
+      {:ok, %{workload: workload}} -> workload
+      _ -> nil
+    end
+  end
+
+  defp principal_of(state, session_id) do
+    case SessionStore.get(state.session_store, session_id) do
+      {:ok, %{principal: principal}} -> principal
+      _ -> nil
+    end
   end
 
   defp schedule(_msg, interval) when interval <= 0, do: :ok
@@ -1447,6 +1628,12 @@ defmodule Embervm.SessionManager do
         %{reason: :destroyed},
         %{}
       )
+
+    Logger.info("embervm session destroyed",
+      session_id: session.session_id,
+      workload: session.workload,
+      principal: session.principal
+    )
 
     {reply, state}
   end

--- a/projects/embervm/control/lib/embervm/session_trace.ex
+++ b/projects/embervm/control/lib/embervm/session_trace.ex
@@ -1,0 +1,112 @@
+defmodule Embervm.SessionTrace do
+  @moduledoc """
+  W3C-traceparent plumbing for the session invoke/bank/relight spans (R2, Task 9).
+
+  A session invoke fans across several BEAM processes: the router opens the root
+  span, the per-session process owns the FIFO (the `queue_wait` phase), the invoke
+  worker runs the `SessionAssign` (the `guest_exec` phase), and the manager's
+  relight worker runs the `relight` phase. OTel span context lives in the process
+  dictionary, so it does NOT cross a `GenServer.call` or a `spawn`. Rather than
+  invent a new tracing layer, this module reuses the EXACT idiom the dispatcher
+  already uses to nest its spans under a caller's trace (`:otel_tracer.from_remote_span`
+  fed from a parsed W3C `traceparent`): the root span is serialized to a traceparent
+  string, threaded through the plain `req` map, and restored as the remote parent in
+  each downstream worker so every phase span nests under the one session-invoke root.
+
+  This is intentionally the same shape as `Embervm.Dispatcher.restore_trace_ctx/2`
+  and `parse_traceparent/1` (which stay private to the dispatcher's async op-log
+  path); the session path is synchronous and carries the parent inline, so the
+  helper is shared here rather than duplicated.
+  """
+
+  # current_span_ctx/0 and set_current_span/1 are OpenTelemetry.Tracer MACROS, so
+  # the module must be required even though it is called fully-qualified.
+  require OpenTelemetry.Tracer
+
+  @traceparent_key "traceparent"
+
+  @doc """
+  The W3C `traceparent` for the CURRENTLY active span, or `nil` when no span is
+  recording (tracing off, e.g. CI with no exporter). Sampled flag is forced to
+  `01`: we only ever serialize a span we just opened and are recording under, so a
+  downstream worker restoring it should sample the same trace.
+  """
+  @spec current_traceparent() :: String.t() | nil
+  def current_traceparent do
+    case OpenTelemetry.Tracer.current_span_ctx() do
+      :undefined ->
+        nil
+
+      span_ctx ->
+        trace_hex = OpenTelemetry.Span.hex_trace_id(span_ctx)
+        span_hex = OpenTelemetry.Span.hex_span_id(span_ctx)
+
+        if all_zero?(trace_hex) or all_zero?(span_hex) do
+          nil
+        else
+          "00-#{trace_hex}-#{span_hex}-01"
+        end
+    end
+  rescue
+    # A trace hiccup must never break the invoke path: no traceparent just means
+    # the downstream span is a root instead of a child.
+    _ -> nil
+  catch
+    _, _ -> nil
+  end
+
+  @doc """
+  Restore `traceparent` (a W3C string, or nil) as the current process's remote
+  parent span so a subsequently-opened span nests under it. A nil/malformed
+  traceparent is a no-op (the next span becomes a root). Guarded: a trace hiccup
+  never crashes the caller (mirrors `Dispatcher.restore_trace_ctx/2`).
+  """
+  @spec restore_parent(String.t() | nil) :: :ok
+  def restore_parent(traceparent) do
+    case parse_traceparent(traceparent) do
+      {trace_id, span_id, flags} ->
+        try do
+          remote = :otel_tracer.from_remote_span(trace_id, span_id, flags)
+          OpenTelemetry.Tracer.set_current_span(remote)
+          :ok
+        rescue
+          _ -> :ok
+        catch
+          _, _ -> :ok
+        end
+
+      :error ->
+        :ok
+    end
+  end
+
+  @doc "The header/key under which the root traceparent rides the `req` map."
+  @spec key() :: String.t()
+  def key, do: @traceparent_key
+
+  # Parse a W3C `traceparent` (`<ver>-<32hex trace>-<16hex span>-<2hex flags>`)
+  # into integer ids, or :error for anything malformed/absent. Same parser shape
+  # as the dispatcher's private one.
+  @spec parse_traceparent(String.t() | nil) ::
+          {non_neg_integer(), non_neg_integer(), non_neg_integer()} | :error
+  def parse_traceparent(tp) when is_binary(tp) do
+    case String.split(tp, "-") do
+      [_ver, trace_hex, span_hex, flags_hex]
+      when byte_size(trace_hex) == 32 and byte_size(span_hex) == 16 ->
+        with {trace_id, ""} <- Integer.parse(trace_hex, 16),
+             {span_id, ""} <- Integer.parse(span_hex, 16),
+             {flags, ""} <- Integer.parse(flags_hex, 16) do
+          {trace_id, span_id, flags}
+        else
+          _ -> :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  def parse_traceparent(_), do: :error
+
+  defp all_zero?(hex), do: String.trim(hex, "0") == ""
+end

--- a/projects/embervm/control/test/embervm/session_bank_relight_test.exs
+++ b/projects/embervm/control/test/embervm/session_bank_relight_test.exs
@@ -98,7 +98,14 @@ defmodule Embervm.SessionBankRelightTest do
         # Timers off by default: tests drive reconcile/1 + sweep/1 explicitly.
         reconcile_interval_ms: 0,
         sweep_interval_ms: 0
-      ] ++ Keyword.take(opts, [:disk_low_watermark_bytes, :wake_max, :wake_window_ms, :bank_concurrency])
+      ] ++
+        Keyword.take(opts, [
+          :disk_low_watermark_bytes,
+          :wake_max,
+          :wake_window_ms,
+          :bank_concurrency,
+          :status_writer
+        ])
 
     {:ok, mgr} = SessionManager.start_link(mgr_opts)
 
@@ -549,5 +556,55 @@ defmodule Embervm.SessionBankRelightTest do
 
   defp snap_fact(session_id) do
     %{snapshot_ref: "snap-#{session_id}", session_id: session_id, workload: "wl", size_bytes: 2_000, created_at_unix_ms: 0}
+  end
+
+  # -- status.sessions counts (Task 9) ---------------------------------------
+
+  describe "status.sessions counts" do
+    test "the sweep writes {live,banked} + summary for a session workload" do
+      test_pid = self()
+
+      writer = fn ns, name, status_map ->
+        send(test_pid, {:status, ns, name, status_map})
+        :ok
+      end
+
+      ctx = start_stack(status_writer: writer)
+      put_workload(ctx, "wl")
+      {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+
+      :ok = SessionManager.sweep(ctx.mgr)
+
+      assert_receive {:status, "embervm", "wl",
+                      %{"sessions" => %{"live" => 1, "banked" => 0}, "sessionsSummary" => "1 live / 0 banked"}}
+
+      # Bank it: the next sweep reflects live -> banked.
+      :ok = force_idle_bank(ctx, created.session_id)
+      :ok = SessionManager.sweep(ctx.mgr)
+
+      assert_receive {:status, "embervm", "wl",
+                      %{"sessions" => %{"live" => 0, "banked" => 1}, "sessionsSummary" => "0 live / 1 banked"}}
+    end
+
+    test "the write is DEBOUNCED: an unchanged count does not re-patch" do
+      test_pid = self()
+
+      writer = fn ns, name, status_map ->
+        send(test_pid, {:status, ns, name, status_map})
+        :ok
+      end
+
+      ctx = start_stack(status_writer: writer)
+      put_workload(ctx, "wl")
+      {:ok, _created} = SessionManager.create(ctx.mgr, "wl", "p1")
+
+      :ok = SessionManager.sweep(ctx.mgr)
+      assert_receive {:status, "embervm", "wl", %{"sessions" => %{"live" => 1, "banked" => 0}}}
+
+      # A second sweep with the SAME counts must not write again (change-detected,
+      # like the PoolManager's primedFloorSatisfied debounce).
+      :ok = SessionManager.sweep(ctx.mgr)
+      refute_receive {:status, "embervm", "wl", _}, 50
+    end
   end
 end

--- a/projects/embervm/control/test/embervm/session_trace_test.exs
+++ b/projects/embervm/control/test/embervm/session_trace_test.exs
@@ -1,0 +1,54 @@
+defmodule Embervm.SessionTraceTest do
+  @moduledoc """
+  Unit coverage for the W3C-traceparent plumbing that nests the session invoke/
+  bank/relight spans (Task 9). No OTel exporter runs in CI (traces_exporter: :none),
+  so `current_traceparent/0` returns nil (no recording span) and these tests pin the
+  pure parsing + the never-crash guards; the actual span nesting is an integration
+  property verified live in SigNoz per the acceptance criteria.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.SessionTrace
+
+  describe "parse_traceparent/1" do
+    test "parses a well-formed W3C traceparent into integer ids" do
+      tp = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+      assert {trace_id, span_id, flags} = SessionTrace.parse_traceparent(tp)
+      assert trace_id == 0x4BF92F3577B34DA6A3CE929D0E0E4736
+      assert span_id == 0x00F067AA0BA902B7
+      assert flags == 1
+    end
+
+    test "rejects malformed / wrong-length / non-hex / nil traceparents" do
+      assert SessionTrace.parse_traceparent(nil) == :error
+      assert SessionTrace.parse_traceparent("") == :error
+      assert SessionTrace.parse_traceparent("not-a-traceparent") == :error
+      # trace id too short
+      assert SessionTrace.parse_traceparent("00-abcd-00f067aa0ba902b7-01") == :error
+      # non-hex span id
+      assert SessionTrace.parse_traceparent("00-4bf92f3577b34da6a3ce929d0e0e4736-zzzzzzzzzzzzzzzz-01") == :error
+    end
+  end
+
+  describe "current_traceparent/0" do
+    test "is nil when no span is recording (the CI/no-exporter case)" do
+      assert SessionTrace.current_traceparent() == nil
+    end
+  end
+
+  describe "restore_parent/1" do
+    test "is a no-op (never raises) for nil and malformed traceparents" do
+      assert SessionTrace.restore_parent(nil) == :ok
+      assert SessionTrace.restore_parent("garbage") == :ok
+      assert SessionTrace.restore_parent("") == :ok
+    end
+
+    test "accepts a well-formed traceparent without raising" do
+      assert SessionTrace.restore_parent("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01") == :ok
+    end
+  end
+
+  test "key/0 is the traceparent map key" do
+    assert SessionTrace.key() == "traceparent"
+  end
+end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.39
+      targetRevision: 0.1.40
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/platform/signoz-addons/alerts/templates/embervm-snapshot-disk-usage.yaml
+++ b/projects/platform/signoz-addons/alerts/templates/embervm-snapshot-disk-usage.yaml
@@ -1,0 +1,136 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: embervm-snapshot-disk-usage-alert
+  labels:
+    signoz.io/alert: "true"
+  annotations:
+    signoz.io/alert-name: "EmberVM Session Snapshot Disk Usage"
+    signoz.io/severity: "warning"
+    signoz.io/notification-channels: "incidentio"
+# Watermark alert for the EmberVM session snapshot disk (R2 Task 9; ADR embervm/002
+# rule 4: disk cost is watched by a watermark, never discovered). Session banks write
+# a full ~memMib snapshot per session to the noded NVMe scratch under
+# <nvmeRoot>/embervm-noded/snapshots; the whole scratch is bounded by
+# maxSessions x memMib. noded exports no Prometheus/OTel metric, and the scratch is a
+# hostPath (not a PVC, so the op-log PVC alert's kubeletstats k8s.volume metric does
+# not see it). Instead this reuses the k8s-infra hostmetrics receiver's already-scraped
+# system.filesystem.usage gauge (state=used/free/reserved, per node + mountpoint),
+# filtered to node-4's /disks/nvme-02 scratch, and computes percent-used via a v5
+# formula: percent_used = used / total * 100 (A = usage{state=used}, B = usage over all
+# states = total capacity, C = A/B*100). Mirrors the op-log PVC alert's shape; fires at
+# 80% weeks before the scratch exhausts and wedges banking.
+data:
+  alert.json: |
+    {
+      "alert": "EmberVM Session Snapshot Disk Usage",
+      "alertType": "METRIC_BASED_ALERT",
+      "ruleType": "threshold_rule",
+      "version": "v5",
+      "broadcastToAll": false,
+      "disabled": false,
+      "evalWindow": "15m0s",
+      "frequency": "5m0s",
+      "severity": "warning",
+      "labels": {
+        "category": "storage",
+        "environment": "production",
+        "service": "embervm"
+      },
+      "annotations": {
+        "summary": "EmberVM session snapshot disk usage exceeded 80% on node {{ "{{" }} $labels.k8s_node_name {{ "}}" }}",
+        "description": "The EmberVM noded NVMe scratch (/disks/nvme-02, holding session snapshot bundles under embervm-noded/snapshots) has exceeded 80% usage. Session banks write a full ~memMib snapshot each, so the footprint is bounded by maxSessions x memMib. Levers, all values-configurable per session workload in the embervm chart: lower session.maxSessions (fewer concurrent live+banked sessions), lower session.bankedTtlSeconds (GC idle banked snapshots sooner), or set the snapshot-disk low watermark (EMBERVM_SESSION_DISK_LOW_WATERMARK_BYTES) to arm LRU disk-pressure eviction. See ADR embervm/002."
+      },
+      "condition": {
+        "compositeQuery": {
+          "queryType": "builder",
+          "panelType": "graph",
+          "unit": "percent",
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "disabled": true,
+                "aggregations": [
+                  {
+                    "timeAggregation": "avg",
+                    "spaceAggregation": "sum",
+                    "metricName": "system.filesystem.usage"
+                  }
+                ],
+                "filter": {
+                  "expression": "k8s.node.name = 'node-4' AND mountpoint = '/disks/nvme-02' AND state = 'used'"
+                },
+                "groupBy": [
+                  {
+                    "name": "k8s.node.name",
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
+                  }
+                ],
+                "order": [],
+                "disabled": true
+              }
+            },
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "B",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "disabled": true,
+                "aggregations": [
+                  {
+                    "timeAggregation": "avg",
+                    "spaceAggregation": "sum",
+                    "metricName": "system.filesystem.usage"
+                  }
+                ],
+                "filter": {
+                  "expression": "k8s.node.name = 'node-4' AND mountpoint = '/disks/nvme-02'"
+                },
+                "groupBy": [
+                  {
+                    "name": "k8s.node.name",
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
+                  }
+                ],
+                "order": [],
+                "disabled": true
+              }
+            },
+            {
+              "type": "builder_formula",
+              "spec": {
+                "name": "C",
+                "expression": "A / B * 100",
+                "legend": "percent used"
+              }
+            }
+          ]
+        },
+        "selectedQueryName": "C",
+        "op": "1",
+        "target": 80,
+        "matchType": "3",
+        "targetUnit": "",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "warning",
+              "target": 80,
+              "targetUnit": "",
+              "matchType": "3",
+              "op": "1",
+              "channels": ["incidentio"]
+            }
+          ]
+        }
+      },
+      "preferredChannels": ["incidentio"]
+    }


### PR DESCRIPTION
**PR-5 (Task 9) of EmberVM R2 Sessions**: operability. Makes the new bank/relight/queue-wait latency phases and the snapshot-disk exhaustion axis visible before the consumer (PR-6) depends on them. Additive. Opus-reviewed clean (every OTel API name verified against `opentelemetry_api`).

## What
- `session_trace.ex`: W3C-traceparent carrier reusing the dispatcher's `:otel_tracer.from_remote_span` idiom (OTel context does not cross GenServer.call/spawn, so the root span's traceparent is threaded through the req map).
- Spans: `embervm.session.invoke` root + `auth`/`queue_wait` (backdated to enqueue)/`guest_exec` children; `bank` (ember.snapshot_bytes), `relight` (ember.relight_ms/generation), `create` (ember.pool_hit), `evict` lifecycle spans. The Task 11 gates (relight/bank p95, state-persistence) are derivable from spans alone.
- Structured lifecycle/denial/eviction logs, consistently keyed.
- `status.sessions {live,banked}` + `sessionsSummary` written on the sweep tick, change-detected per workload (never per-transition).
- SigNoz snapshot-disk 80% watermark alert (`METRIC_BASED_ALERT`), sourced from existing k8s-infra hostmetrics (no new Elixir metric export), notifying incidentio.

## Decisions (DECISIONS.md D-R2.5.1-3)
Alert reuses hostmetrics (no OTel metrics SDK in Elixir); status counts debounced on the sweep; spans nest via a threaded traceparent.

Bump embervm 0.1.40. No local test loop; Elixir compile + alert render verified in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)