### PR TITLE
feat(monolith): R2 PR-6 sessioned run_python on the embervm session class

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -623,3 +623,36 @@ Task 9 choices where the plan was silent. Flagged for post-impl review.
   not a new tracing layer). Timer/API-driven bank/create/evict have no caller trace, so
   they are root spans (consistent with the dispatcher's prime/auth spans). The Task 11
   gates (relight p95, bank p95, state-persistence) are derivable from spans alone.
+
+## R2 Phase 3: sandbox consumer (PR-6, embervm 0.1.41 + monolith 0.285.204 + public 0.89.129)
+
+Task 10 choices where the plan was silent (sessioned run_python across guest + chart
++ monolith). Flagged for post-impl review.
+
+### D-R2.6.1 Guest frame protocol: 4-byte big-endian length prefix + JSON body
+- Both directions. `io.ReadFull` reassembles partial reads; a >16 MiB length is rejected
+  (not allocated). Chosen over newline-delimiting so snippet output containing newlines
+  or NULs cannot corrupt framing.
+
+### D-R2.6.2 Per-snippet timeout is PARENT-enforced; only a timeout resets the namespace
+- The Go parent times the response-frame read (not the child), because a mid-exec
+  interrupt could leave the shared namespace half-mutated. On timeout the parent SIGKILLs
+  the child's process group and lazily restarts on the next request (that response carries
+  session_reset). A snippet EXCEPTION (a typo/error) does NOT reset: state survives.
+- session_reset is OR-folded from two sources: the guest sets it whenever it started a
+  fresh child (first request or post-timeout); the monolith client sets it on a 410
+  transparent re-create. Either surfaces as `session_reset: true`.
+
+### D-R2.6.3 One-shot is byte-identical: additive omitempty fields + one guarded branch
+- handler.go adds `Mode`/`SessionReset` as `omitempty` and a single early
+  `if req.Mode == ModeSession` branch; the entire one-shot path below is untouched, so the
+  shared sandbox guest still serves the task class + the deprecated fc-invoke path
+  byte-for-byte when `mode` is absent (guest tests prove both the behavior and the response
+  JSON still omits `session_reset`).
+
+### D-R2.6.4 sandbox-session reuses the sandbox rootfs; client read timeout 45s
+- The session workload's image ref equals sandbox's, so the node resolves the same rootfs
+  via EMBERVM_NODED_IMAGES (no new noded image entry). `SANDBOX_SESSION_READ_TIMEOUT` = 45s
+  (vs 35s one-shot) so a cold-banked relight completes within the read window. Also
+  registered `sandbox_client_test` (previously had NO py_test target, so it was not running
+  in CI) alongside the new `sandbox_session_test`.

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.40
+version: 0.1.41

--- a/projects/embervm/chart/templates/workload-sandbox-session.yaml
+++ b/projects/embervm/chart/templates/workload-sandbox-session.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.sandboxSessionWorkload.enabled }}
+# The sandbox-session workload (EmberVM R2, ADR embervm/001): the sessioned
+# variant of the python sandbox and R2's named first consumer. It shares the
+# SAME guest image and Bazel-pinned digest as the one-shot `sandbox` workload
+# above (both derive from .Values.sandbox.guestImage, so the pins always match
+# and the rootfs-builder bakes one image for both). The only differences are
+# class=session and the spec.session lifecycle block: a session VM survives an
+# invoke (SessionAssign, not Assign), is banked to a node snapshot when idle,
+# and is relit on the next invoke, so an agent's run_python state accretes
+# across turns.
+#
+# Node-4 disk arithmetic (documented so it is bounded, never discovered, per
+# ADR 002 rule 4). memMib is 2048 (2 GiB): a full memory snapshot per bank is
+# worst-case ~2 GiB. maxSessions is 8 (live + banked combined). The worst case
+# is every session banked at once, so the snapshot dir holds up to
+#   maxSessions x memMib = 8 x 2 GiB = 16 GiB
+# of session bundles, PLUS up to `cap` (4) live VMs' 2 GiB each = 8 GiB of RAM.
+# Both live on the node-4 NVMe scratch alongside the task-class pools; the
+# Task 9 watermark alert (80%) and LRU eviction are the backstop if the trend
+# approaches that ceiling. Shrink maxSessions or bankedTtlSeconds via values if
+# it does.
+apiVersion: embervm.dev/v1alpha1
+kind: Workload
+metadata:
+  name: {{ .Values.sandboxSessionWorkload.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # Apply after the CRD (wave 0) establishes, like the sandbox workload.
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  class: session
+  source:
+    image:
+      # SAME pin as the one-shot sandbox workload: one guest image serves both
+      # the task class and the session class (the kernel mode is opt-in per
+      # request via {"mode":"session"}, so the image is byte-identical).
+      ref: "{{ .Values.sandbox.guestImage.repository }}:{{ .Values.sandbox.guestImage.tag }}"
+      port: {{ .Values.sandboxSessionWorkload.port }}
+      readyPath: {{ .Values.sandboxSessionWorkload.readyPath | quote }}
+      invokePath: {{ .Values.sandboxSessionWorkload.invokePath | quote }}
+  resources:
+    vcpus: {{ .Values.sandboxSessionWorkload.vcpus }}
+    memMib: {{ .Values.sandboxSessionWorkload.memMib }}
+  concurrency:
+    # For a session workload: floor is the pristine pool kept warm for fast
+    # create, cap is the max number of LIVE session VMs (banked sessions hold
+    # only disk, bounded separately by session.maxSessions).
+    floor: {{ .Values.sandboxSessionWorkload.floor }}
+    cap: {{ .Values.sandboxSessionWorkload.cap }}
+  session:
+    idleBankSeconds: {{ .Values.sandboxSessionWorkload.session.idleBankSeconds }}
+    maxLifetimeSeconds: {{ .Values.sandboxSessionWorkload.session.maxLifetimeSeconds }}
+    bankedTtlSeconds: {{ .Values.sandboxSessionWorkload.session.bankedTtlSeconds }}
+    maxSessions: {{ .Values.sandboxSessionWorkload.session.maxSessions }}
+    invokeQueueCap: {{ .Values.sandboxSessionWorkload.session.invokeQueueCap }}
+{{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -167,6 +167,44 @@ sandboxWorkload:
   cap: 16
   timeoutSeconds: 30
 
+# The sandbox-session workload (EmberVM R2, ADR embervm/001): the sessioned
+# variant of the sandbox, R2's named first consumer (sessioned run_python). Same
+# guest image + Bazel-pinned digest as `sandbox` above (both derive from
+# .Values.sandbox.guestImage), so one baked rootfs serves both; the kernel mode
+# is opt-in per request. class=session with a spec.session block.
+#
+# Node-4 disk arithmetic (bounded, not discovered; ADR 002 rule 4): memMib 2048
+# means a full bank snapshot is ~2 GiB; maxSessions 8 (live + banked) caps the
+# snapshot dir at 8 x 2 GiB = 16 GiB worst case, plus up to cap (4) live VMs at
+# 2 GiB RAM each. The Task 9 watermark alert + LRU eviction are the backstop.
+sandboxSessionWorkload:
+  enabled: true
+  name: sandbox-session
+  # Same frozen guest shim contract as the one-shot sandbox: vsock 1027,
+  # /shim/ready, /invoke. The session mode is selected by the request body
+  # ({"mode":"session"}), not a different path.
+  port: 1027
+  readyPath: /shim/ready
+  invokePath: /invoke
+  vcpus: 1
+  memMib: 2048
+  # floor: pristine VMs kept warm for fast session create. cap: max live
+  # session VMs. Small on purpose (see the disk arithmetic above).
+  floor: 1
+  cap: 4
+  session:
+    # Bank an idle session (no in-flight, no queued invoke) after 2 minutes.
+    idleBankSeconds: 120
+    # Version-convergence bound: a session rides its birth base until this
+    # expires (6h), then the next invoke 410s onto the current base.
+    maxLifetimeSeconds: 21600
+    # GC a banked snapshot untouched this long (here, the full 6h lifetime).
+    bankedTtlSeconds: 21600
+    # Max sessions (live + banked) for this workload.
+    maxSessions: 8
+    # Max invokes queued behind the one in-flight invoke per session.
+    invokeQueueCap: 4
+
 # The semgrep workload (Task 14b): EmberVM's named first consumer, side-by-side
 # with fc-invoke's semgrep path (which is halved 16->8 in the substrate chart to
 # make room). Same frozen guest contract as fc-invoke (vsock 1027, /shim/ready,

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.40
+      targetRevision: 0.1.41
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/firecracker/sandbox/guest-init/cmd/BUILD
+++ b/projects/firecracker/sandbox/guest-init/cmd/BUILD
@@ -19,10 +19,10 @@ go_library(
         "//projects/firecracker/substrate/vsockproto",
     ] + select({
         "@rules_go//go/platform:android": [
-            "@org_golang_x_sys//unix:go_default_library",
+            "@org_golang_x_sys//unix",
         ],
         "@rules_go//go/platform:linux": [
-            "@org_golang_x_sys//unix:go_default_library",
+            "@org_golang_x_sys//unix",
         ],
         "//conditions:default": [],
     }),

--- a/projects/firecracker/sandbox/guest-init/cmd/BUILD
+++ b/projects/firecracker/sandbox/guest-init/cmd/BUILD
@@ -3,6 +3,8 @@ load("@rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "cmd_lib",
     srcs = [
+        "clock_linux.go",
+        "clock_other.go",
         "main.go",
         "mount_linux.go",
         "mount_other.go",
@@ -17,10 +19,10 @@ go_library(
         "//projects/firecracker/substrate/vsockproto",
     ] + select({
         "@rules_go//go/platform:android": [
-            "@org_golang_x_sys//unix",
+            "@org_golang_x_sys//unix:go_default_library",
         ],
         "@rules_go//go/platform:linux": [
-            "@org_golang_x_sys//unix",
+            "@org_golang_x_sys//unix:go_default_library",
         ],
         "//conditions:default": [],
     }),

--- a/projects/firecracker/sandbox/guest-init/cmd/clock_linux.go
+++ b/projects/firecracker/sandbox/guest-init/cmd/clock_linux.go
@@ -1,0 +1,20 @@
+//go:build linux
+
+package main
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// setWallClock sets the guest's wall clock (CLOCK_REALTIME) to epochMs. It is
+// the /shim/clock target the node calls after a session relight (EmberVM R2
+// Task 4): a banked guest's monotonic-frozen clock lags real time by however
+// long it was suspended, and time-dependent snippet code would see the stale
+// value without this resync. Best-effort by contract: the caller (the shim
+// handler) turns a failure into a 500 that the node logs and moves past,
+// rather than failing the relight. Requires CAP_SYS_TIME, which the guest-init
+// PID 1 (root) holds; it runs BEFORE privileges are dropped per snippet.
+func setWallClock(epochMs int64) error {
+	ts := unix.NsecToTimespec(epochMs * int64(1_000_000))
+	return unix.ClockSettime(unix.CLOCK_REALTIME, &ts)
+}

--- a/projects/firecracker/sandbox/guest-init/cmd/clock_other.go
+++ b/projects/firecracker/sandbox/guest-init/cmd/clock_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package main
+
+import "fmt"
+
+// setWallClock is unsupported off Linux; the guest is always Linux, this stub
+// only keeps the package building for host (e.g. darwin) builds. Returning an
+// error keeps the /shim/clock endpoint honest on a non-Linux host.
+func setWallClock(int64) error {
+	return fmt.Errorf("setWallClock is only supported on linux")
+}

--- a/projects/firecracker/sandbox/guest-init/cmd/main.go
+++ b/projects/firecracker/sandbox/guest-init/cmd/main.go
@@ -74,7 +74,24 @@ func run(logger *slog.Logger) error {
 	}
 	logger.Info("shim HTTP server listening", "port", vsockproto.GuestHTTPPort)
 
-	srv := shim.NewServer(handler.Handle, shim.WithReady(ready.Load))
+	// WithClock installs POST /shim/clock so the node can resync this guest's
+	// wall clock after a session relight (EmberVM R2 Task 4). Best-effort: a
+	// set failure is a 500 the node logs and moves past, never a relight
+	// failure. The sandbox guest serves both the one-shot task class and
+	// sessioned run_python from the same binary, so the endpoint is always
+	// present here (harmless for one-shot callers, which never POST it).
+	srv := shim.NewServer(
+		handler.Handle,
+		shim.WithReady(ready.Load),
+		shim.WithClock(func(epochMs int64) error {
+			if err := setWallClock(epochMs); err != nil {
+				logger.Warn("guest clock resync failed", "epoch_ms", epochMs, "err", err)
+				return err // nosemgrep: no-bare-error-return
+			}
+			logger.Info("guest clock resynced", "epoch_ms", epochMs)
+			return nil
+		}),
+	)
 
 	// Serve in a goroutine so ctx cancellation (SIGTERM) can close the server
 	// gracefully rather than blocking indefinitely on Accept.

--- a/projects/firecracker/sandbox/guest-init/internal/handler/BUILD
+++ b/projects/firecracker/sandbox/guest-init/internal/handler/BUILD
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "handler",
-    srcs = ["handler.go"],
+    srcs = [
+        "handler.go",
+        "kernel.go",
+    ],
     importpath = "github.com/jomcgi/homelab/projects/firecracker/sandbox/guest-init/internal/handler",
     visibility = ["//projects/firecracker/sandbox/guest-init:__subpackages__"],
     deps = [
@@ -12,7 +15,10 @@ go_library(
 
 go_test(
     name = "handler_test",
-    srcs = ["handler_test.go"],
+    srcs = [
+        "handler_test.go",
+        "kernel_test.go",
+    ],
     embed = [":handler"],
     deps = [
         "//projects/firecracker/substrate/shim",

--- a/projects/firecracker/sandbox/guest-init/internal/handler/handler.go
+++ b/projects/firecracker/sandbox/guest-init/internal/handler/handler.go
@@ -66,11 +66,25 @@ type ExecFile struct {
 }
 
 // ExecRequest is the /invoke/sandbox request body.
+//
+// Mode selects the execution model. When empty (the default) the request is a
+// one-shot: Code runs as main.py in a fresh, discarded per-invoke workdir with
+// no state carried to the next call. This is the byte-identical task-class and
+// deprecated-fc-invoke contract; the field is omitempty so an unset Mode never
+// changes the wire shape a one-shot caller sends. When Mode == "session" the
+// request is served by the persistent kernel (kernel.go): Code runs in one
+// long-lived python3 child whose module namespace and /tmp/session workdir
+// accrete across calls (EmberVM R2 sessioned run_python, ADR embervm/001).
 type ExecRequest struct {
 	Code           string     `json:"code"`
 	Files          []ExecFile `json:"files,omitempty"`
 	TimeoutSeconds int        `json:"timeout_seconds,omitempty"`
+	Mode           string     `json:"mode,omitempty"`
 }
+
+// ModeSession is the ExecRequest.Mode value that routes a request to the
+// persistent session kernel instead of the one-shot path.
+const ModeSession = "session"
 
 // ExecResult is the /invoke/sandbox response body. Timeout, a nonzero exit
 // code, and output truncation are all represented here rather than as
@@ -84,6 +98,11 @@ type ExecResult struct {
 	DurationMs int64      `json:"duration_ms"`
 	Truncated  bool       `json:"truncated,omitempty"`
 	Error      string     `json:"error,omitempty"`
+	// SessionReset is set only in session mode: it reports that the persistent
+	// namespace was lost before or during this snippet (a fresh child was
+	// started for it), so variables, imports, and files from prior snippets are
+	// gone. The one-shot path never sets it (omitempty keeps its wire shape).
+	SessionReset bool `json:"session_reset,omitempty"`
 }
 
 // Handle is the shim.Handler for the sandbox workload: decode one
@@ -99,6 +118,13 @@ func Handle(ctx context.Context, r *shim.Request) (*shim.Response, error) {
 	}
 	if strings.TrimSpace(req.Code) == "" {
 		return badRequest("code is required")
+	}
+
+	// Session mode routes to the persistent kernel; the one-shot path below is
+	// untouched and stays byte-identical for an absent Mode (the task class and
+	// the deprecated fc-invoke path both send no Mode).
+	if req.Mode == ModeSession {
+		return handleSession(req)
 	}
 
 	workdir, err := os.MkdirTemp("/tmp", "sandbox-exec-")

--- a/projects/firecracker/sandbox/guest-init/internal/handler/kernel.go
+++ b/projects/firecracker/sandbox/guest-init/internal/handler/kernel.go
@@ -1,0 +1,452 @@
+package handler
+
+// kernel.go implements the session (kernel) execution mode for the sandbox
+// guest (EmberVM R2, ADR embervm/001). Where the one-shot path (handler.go)
+// runs each snippet as a fresh, discarded python3 process, session mode keeps
+// ONE persistent python3 child alive and executes every snippet in its shared
+// module namespace under a stable /tmp/session workdir, so variables, imports,
+// and files accrete across an agent's turns.
+//
+// Protocol: the Go parent and the python child speak a length-prefixed frame
+// protocol over the child's stdin/stdout. Each frame is a 4-byte big-endian
+// uint32 length followed by exactly that many JSON bytes. The parent writes a
+// request frame ({"code": ...}); the child executes it and writes back a
+// response frame ({stdout, stderr, exit_code, files, ...}). stderr on the
+// child is left connected to the parent's stderr for crash diagnostics and is
+// NOT part of the protocol stream. Length-prefix framing (not newline
+// delimiting) is what makes the reader robust to partial reads and to snippet
+// output that itself contains newlines or NULs.
+//
+// Timeout: the PARENT owns the per-snippet wall-clock. It cannot be enforced
+// inside the child, because a mid-exec interrupt could leave the shared
+// namespace half-mutated; so on timeout the parent KILLS the child (its whole
+// process group) and lazily restarts it on the next request. The namespace is
+// lost, which is reported as SessionReset on that response. This is exactly
+// the "a snippet timeout kills and restarts the child" rule in the plan, and
+// it keeps the loop unwedgeable: one runaway snippet costs its own state, not
+// the server.
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/jomcgi/homelab/projects/firecracker/substrate/shim"
+)
+
+const (
+	// sessionWorkdir is the stable working directory the persistent child cds
+	// into. Unlike the one-shot per-invoke workdir it is NEVER removed between
+	// snippets: files written in one snippet are visible to the next and are
+	// returned as changed-file output. It lives on the /tmp tmpfs (RAM), so it
+	// is captured in a session bank snapshot along with the child's memory.
+	sessionWorkdir = "/tmp/session"
+
+	// maxFrameBytes caps a single protocol frame. Both directions honor it: the
+	// child truncates its captured stdout/stderr and drops oversized files (the
+	// same caps as one-shot) so its response frame stays well under this, and
+	// the parent refuses to read a frame claiming to be larger (a corrupt or
+	// hostile child must not be able to make the parent allocate unbounded).
+	maxFrameBytes = 16 << 20
+)
+
+// sessionKernel is the single persistent python child for this guest. One
+// microVM serves exactly one session (the control plane binds a session to a
+// VM and serializes its invokes), so a package-level singleton guarded by mu
+// is the whole concurrency model: mu also serializes any two session requests
+// that race, which the daemon guard already prevents but which must never
+// corrupt the frame stream if it did not.
+var sessionKernel = &kernel{}
+
+type kernel struct {
+	mu    sync.Mutex
+	cmd   *exec.Cmd
+	stdin io.WriteCloser
+	// r wraps the child stdout; buffered so a frame that arrives in several
+	// vsock/pipe reads is reassembled correctly (partial-read robustness).
+	r *bufio.Reader
+}
+
+// kernelRequest is one request frame written to the child.
+type kernelRequest struct {
+	Code string `json:"code"`
+}
+
+// kernelResponse is one response frame read from the child. It mirrors the
+// one-shot ExecResult fields the caller consumes; DurationMs and SessionReset
+// are filled in by the parent, not the child.
+type kernelResponse struct {
+	Stdout    string     `json:"stdout"`
+	Stderr    string     `json:"stderr"`
+	ExitCode  int        `json:"exit_code"`
+	Files     []ExecFile `json:"files"`
+	Truncated bool       `json:"truncated"`
+	Error     string     `json:"error"`
+}
+
+// handleSession serves one session-mode request against the persistent kernel.
+// It returns the same ExecResult shape as the one-shot path plus SessionReset
+// when the shared namespace was lost. Only a transport-level failure it cannot
+// recover from returns a non-nil error (mapped to 502 by the shim); a python
+// error, a nonzero exit, or a timeout are results, exactly as one-shot.
+func handleSession(req ExecRequest) (*shim.Response, error) {
+	timeout := defaultTimeout
+	if req.TimeoutSeconds > 0 {
+		timeout = time.Duration(req.TimeoutSeconds) * time.Second
+	}
+	if timeout > maxTimeout {
+		timeout = maxTimeout
+	}
+
+	result, err := sessionKernel.run(req.Code, timeout)
+	if err != nil {
+		return nil, err // nosemgrep: no-bare-error-return
+	}
+	body, marshalErr := json.Marshal(result)
+	if marshalErr != nil {
+		return nil, fmt.Errorf("handler: marshal session result: %w", marshalErr)
+	}
+	return &shim.Response{Status: http.StatusOK, Body: body}, nil
+}
+
+// run executes one snippet. It lazily (re)starts the child, sends the code
+// frame, and waits up to timeout for the response frame. On timeout, or on any
+// framing/transport error, it kills the child so the next call starts fresh
+// and reports SessionReset. A started boolean tracks whether THIS call had to
+// start the child (the very first session request, or the request right after
+// a reset): that is also reported as SessionReset because a fresh child has an
+// empty namespace, so the model never assumes carried state it does not have.
+func (k *kernel) run(code string, timeout time.Duration) (ExecResult, error) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	started, err := k.ensureChild()
+	if err != nil {
+		return ExecResult{}, fmt.Errorf("handler: start session child: %w", err)
+	}
+
+	start := time.Now()
+	resp, runErr := k.exchange(code, timeout)
+	duration := time.Since(start)
+	if runErr != nil {
+		// Kill so the next request starts a clean child; the namespace is gone.
+		k.kill()
+		if isTimeout(runErr) {
+			return ExecResult{
+				ExitCode:     -1,
+				Error:        fmt.Sprintf("timed out after %ds", int(timeout.Seconds())),
+				DurationMs:   duration.Milliseconds(),
+				SessionReset: true,
+			}, nil
+		}
+		// A framing or transport failure: report it, reset next time.
+		return ExecResult{
+			ExitCode:     -1,
+			Error:        fmt.Sprintf("session child failed: %v", runErr),
+			DurationMs:   duration.Milliseconds(),
+			SessionReset: true,
+		}, nil
+	}
+
+	return ExecResult{
+		Stdout:       resp.Stdout,
+		Stderr:       resp.Stderr,
+		ExitCode:     resp.ExitCode,
+		Files:        resp.Files,
+		Truncated:    resp.Truncated,
+		Error:        resp.Error,
+		DurationMs:   duration.Milliseconds(),
+		SessionReset: started,
+	}, nil
+}
+
+// ensureChild starts the persistent python child if it is not already running.
+// It returns whether it started a NEW child on this call (reported to the
+// caller as SessionReset: a new child has an empty namespace). Caller holds mu.
+func (k *kernel) ensureChild() (bool, error) {
+	if k.cmd != nil && k.cmd.Process != nil {
+		return false, nil
+	}
+
+	if err := os.MkdirAll(sessionWorkdir, 0o755); err != nil {
+		return false, fmt.Errorf("mkdir %s: %w", sessionWorkdir, err)
+	}
+
+	cmd := exec.Command("python3", "-u", "-c", kernelScript)
+	cmd.Dir = sessionWorkdir
+	// Same explicit environment the one-shot path sets (a raw Firecracker boot
+	// hands PID 1 nothing), with HOME/TMPDIR pinned INSIDE the session workdir
+	// so tempfile use and any $HOME writes accrete under the banked tmpfs.
+	cmd.Env = []string{
+		"PATH=/usr/bin:/bin:/usr/local/bin",
+		"HOME=" + sessionWorkdir,
+		"MPLBACKEND=Agg",
+		"PYTHONUNBUFFERED=1",
+		"TMPDIR=" + sessionWorkdir,
+		"MPLCONFIGDIR=" + MPLConfigDir,
+		"PYTHONPATH=/opt/sandbox",
+	}
+	cmd.Stderr = os.Stderr // crash diagnostics only; NOT the protocol stream.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if dropPrivileges {
+		cmd.SysProcAttr.Credential = &syscall.Credential{Uid: sandboxUID, Gid: sandboxGID}
+		// The child owns its whole workdir so uid 65532 can write into it.
+		if err := chownTree(sessionWorkdir); err != nil {
+			return false, fmt.Errorf("chown %s: %w", sessionWorkdir, err)
+		}
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return false, fmt.Errorf("stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return false, fmt.Errorf("stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return false, fmt.Errorf("start python child: %w", err)
+	}
+
+	k.cmd = cmd
+	k.stdin = stdin
+	k.r = bufio.NewReaderSize(stdout, 64<<10)
+	return true, nil
+}
+
+// exchange writes one request frame and reads one response frame, enforcing
+// timeout on the READ (the snippet's wall clock). A timeout returns a sentinel
+// the caller distinguishes with isTimeout. Caller holds mu.
+func (k *kernel) exchange(code string, timeout time.Duration) (kernelResponse, error) {
+	reqBody, err := json.Marshal(kernelRequest{Code: code})
+	if err != nil {
+		return kernelResponse{}, fmt.Errorf("marshal request: %w", err)
+	}
+	if err := writeFrame(k.stdin, reqBody); err != nil {
+		return kernelResponse{}, fmt.Errorf("write request frame: %w", err)
+	}
+
+	type frameResult struct {
+		body []byte
+		err  error
+	}
+	done := make(chan frameResult, 1)
+	go func() {
+		body, readErr := readFrame(k.r)
+		done <- frameResult{body: body, err: readErr}
+	}()
+
+	select {
+	case <-time.After(timeout):
+		return kernelResponse{}, errTimeout
+	case fr := <-done:
+		if fr.err != nil {
+			return kernelResponse{}, fmt.Errorf("read response frame: %w", fr.err)
+		}
+		var resp kernelResponse
+		if err := json.Unmarshal(fr.body, &resp); err != nil {
+			return kernelResponse{}, fmt.Errorf("unmarshal response frame: %w", err)
+		}
+		return resp, nil
+	}
+}
+
+// kill terminates the child and its process group and clears kernel state so
+// the next request starts a fresh child. Caller holds mu. Safe to call when no
+// child is running.
+func (k *kernel) kill() {
+	if k.cmd != nil && k.cmd.Process != nil {
+		_ = syscall.Kill(-k.cmd.Process.Pid, syscall.SIGKILL)
+		_, _ = k.cmd.Process.Wait()
+	}
+	if k.stdin != nil {
+		_ = k.stdin.Close()
+	}
+	k.cmd = nil
+	k.stdin = nil
+	k.r = nil
+}
+
+// errTimeout is the sentinel returned by exchange on a read timeout.
+var errTimeout = fmt.Errorf("session snippet timed out")
+
+func isTimeout(err error) bool { return err == errTimeout } //nolint:errorlint // sentinel identity
+
+// writeFrame writes a length-prefixed frame: a 4-byte big-endian length
+// followed by body.
+func writeFrame(w io.Writer, body []byte) error {
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(body)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err // nosemgrep: no-bare-error-return
+	}
+	if _, err := w.Write(body); err != nil {
+		return err // nosemgrep: no-bare-error-return
+	}
+	return nil
+}
+
+// readFrame reads one length-prefixed frame. io.ReadFull reassembles a frame
+// that arrives across several underlying reads (the partial-read robustness
+// the vsock/pipe transport requires); a frame larger than maxFrameBytes is
+// rejected rather than allocated.
+func readFrame(r io.Reader) ([]byte, error) {
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err // nosemgrep: no-bare-error-return
+	}
+	n := binary.BigEndian.Uint32(hdr[:])
+	if n > maxFrameBytes {
+		return nil, fmt.Errorf("frame length %d exceeds cap %d", n, maxFrameBytes)
+	}
+	body := make([]byte, n)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return nil, err // nosemgrep: no-bare-error-return
+	}
+	return body, nil
+}
+
+// kernelScript is the python exec-loop that runs as the persistent child. It
+// reads length-prefixed request frames on stdin, executes each snippet's code
+// in a SHARED module namespace (a single dict reused across snippets, so
+// assignments and imports persist) with cwd already at the session workdir,
+// captures stdout/stderr under the same caps as the one-shot handler, snapshots
+// files that changed since the previous snippet, and writes a response frame on
+// stdout. Its own stderr is the process's real stderr (crash diagnostics), so
+// captured snippet stderr is redirected in-process and never pollutes the frame
+// stream. A single bad snippet is caught and returned as a result; the loop
+// never dies on user code.
+const kernelScript = `
+import base64, io, json, os, struct, sys, traceback, contextlib
+
+STDOUT_CAP = 512 * 1024
+STDERR_CAP = 128 * 1024
+PER_FILE_CAP = 2 * 1024 * 1024
+TOTAL_FILE_CAP = 5 * 1024 * 1024
+
+# The real fds: framing is on these, snippet output is captured separately.
+_in = sys.stdin.buffer
+_out = sys.stdout.buffer
+
+def read_frame():
+    hdr = _read_exact(4)
+    if hdr is None:
+        return None
+    (n,) = struct.unpack(">I", hdr)
+    return _read_exact(n)
+
+def _read_exact(n):
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = _in.read(n - len(buf))
+        if not chunk:
+            return None
+        buf.extend(chunk)
+    return bytes(buf)
+
+def write_frame(obj):
+    body = json.dumps(obj).encode("utf-8")
+    _out.write(struct.pack(">I", len(body)))
+    _out.write(body)
+    _out.flush()
+
+def snapshot_files():
+    # Path -> (size, mtime_ns) for every regular file under cwd, so the next
+    # snapshot can tell what a snippet changed. main.py has no meaning here.
+    seen = {}
+    for root, _dirs, names in os.walk("."):
+        for name in names:
+            p = os.path.join(root, name)
+            try:
+                st = os.stat(p)
+            except OSError:
+                continue
+            if os.path.isfile(p):
+                seen[os.path.relpath(p, ".")] = (st.st_size, st.st_mtime_ns)
+    return seen
+
+def collect_changed(before):
+    after = snapshot_files()
+    files = []
+    total = 0
+    truncated = False
+    for rel, meta in after.items():
+        if before.get(rel) == meta:
+            continue
+        size = meta[0]
+        if size > PER_FILE_CAP:
+            truncated = True
+            continue
+        if total + size > TOTAL_FILE_CAP:
+            truncated = True
+            continue
+        try:
+            with open(rel, "rb") as f:
+                data = f.read()
+        except OSError:
+            continue
+        total += len(data)
+        files.append({"path": rel.replace(os.sep, "/"),
+                      "content_b64": base64.b64encode(data).decode("ascii")})
+    return files, truncated
+
+# The one shared namespace reused for every snippet: this is what makes state
+# persist. __name__ is __main__ so scripts behave like a normal top-level run.
+NS = {"__name__": "__main__", "__builtins__": __builtins__}
+
+def run_snippet(code):
+    out = io.StringIO()
+    err = io.StringIO()
+    exit_code = 0
+    error = ""
+    before = snapshot_files()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        try:
+            compiled = compile(code, "<session>", "exec")
+            exec(compiled, NS)
+        except SystemExit as e:
+            try:
+                exit_code = int(e.code) if e.code is not None else 0
+            except (TypeError, ValueError):
+                exit_code = 1
+        except BaseException:
+            exit_code = 1
+            traceback.print_exc()
+    so = out.getvalue()
+    se = err.getvalue()
+    truncated = False
+    if len(so) > STDOUT_CAP:
+        so = so[:STDOUT_CAP]
+        truncated = True
+    if len(se) > STDERR_CAP:
+        se = se[:STDERR_CAP]
+        truncated = True
+    files, files_truncated = collect_changed(before)
+    return {"stdout": so, "stderr": se, "exit_code": exit_code,
+            "files": files, "truncated": truncated or files_truncated,
+            "error": error}
+
+def main():
+    while True:
+        frame = read_frame()
+        if frame is None:
+            return
+        try:
+            req = json.loads(frame.decode("utf-8"))
+            resp = run_snippet(req.get("code", ""))
+        except Exception as e:  # framing/decoding fault: report, keep looping
+            resp = {"stdout": "", "stderr": "", "exit_code": -1,
+                    "files": [], "truncated": False,
+                    "error": "kernel: %s" % e}
+        write_frame(resp)
+
+main()
+`

--- a/projects/firecracker/sandbox/guest-init/internal/handler/kernel_test.go
+++ b/projects/firecracker/sandbox/guest-init/internal/handler/kernel_test.go
@@ -1,0 +1,253 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/jomcgi/homelab/projects/firecracker/substrate/shim"
+)
+
+// callSession drives one session-mode request through Handle. Each test resets
+// the package singleton first so kernels never leak between tests.
+func callSession(t *testing.T, code string, timeoutSeconds int) ExecResult {
+	t.Helper()
+	req := ExecRequest{Code: code, Mode: ModeSession, TimeoutSeconds: timeoutSeconds}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	resp, err := Handle(context.Background(), &shim.Request{Path: "/invoke/sandbox", Body: bytes.NewReader(body)})
+	if err != nil {
+		t.Fatalf("Handle returned unexpected error: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.Status, http.StatusOK)
+	}
+	return decodeResult(t, resp)
+}
+
+// resetKernel kills any running child and clears the singleton so a test starts
+// from a known-empty namespace.
+func resetKernel(t *testing.T) {
+	t.Helper()
+	sessionKernel.mu.Lock()
+	sessionKernel.kill()
+	sessionKernel.mu.Unlock()
+	t.Cleanup(func() {
+		sessionKernel.mu.Lock()
+		sessionKernel.kill()
+		sessionKernel.mu.Unlock()
+	})
+}
+
+// TestOneShotUnaffectedByModeField proves the byte-identical one-shot guarantee:
+// with Mode absent, Handle runs the classic per-invoke path. This is the same
+// assertion the task-class and deprecated fc-invoke callers rely on.
+func TestOneShotUnaffectedByModeField(t *testing.T) {
+	requirePython(t)
+	// No Mode field at all: classic one-shot.
+	resp, err := call(t, ExecRequest{Code: "print('one shot')"})
+	if err != nil {
+		t.Fatalf("Handle error: %v", err)
+	}
+	result := decodeResult(t, resp)
+	if strings.TrimSpace(result.Stdout) != "one shot" {
+		t.Errorf("stdout = %q, want %q", result.Stdout, "one shot")
+	}
+	if result.SessionReset {
+		t.Error("one-shot result must never set session_reset")
+	}
+}
+
+// TestOneShotResultOmitsSessionReset guards the wire shape: a one-shot result
+// JSON must not contain the session_reset key (omitempty), so a one-shot
+// caller's response is byte-for-byte what it was before session mode existed.
+func TestOneShotResultOmitsSessionReset(t *testing.T) {
+	body, err := json.Marshal(ExecResult{Stdout: "x", ExitCode: 0})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(body), "session_reset") {
+		t.Errorf("one-shot ExecResult JSON must omit session_reset; got %s", body)
+	}
+}
+
+// TestSessionStatePersistsAcrossSnippets is the headline behavior: a variable
+// defined in one snippet is readable in the next through the shared namespace.
+func TestSessionStatePersistsAcrossSnippets(t *testing.T) {
+	requirePython(t)
+	resetKernel(t)
+
+	first := callSession(t, "x = 41", 5)
+	if first.ExitCode != 0 {
+		t.Fatalf("first snippet exit = %d (err %q)", first.ExitCode, first.Error)
+	}
+	if !first.SessionReset {
+		t.Error("the first snippet starts a fresh child; session_reset should be true")
+	}
+
+	second := callSession(t, "print(x + 1)", 5)
+	if second.ExitCode != 0 {
+		t.Fatalf("second snippet exit = %d (err %q)", second.ExitCode, second.Error)
+	}
+	if strings.TrimSpace(second.Stdout) != "42" {
+		t.Errorf("stdout = %q, want %q (state did not persist)", second.Stdout, "42")
+	}
+	if second.SessionReset {
+		t.Error("second snippet reused the live child; session_reset should be false")
+	}
+}
+
+// TestSessionFilesPersistAcrossSnippets proves the /tmp/session workdir persists
+// and changed files are returned.
+func TestSessionFilesPersistAcrossSnippets(t *testing.T) {
+	requirePython(t)
+	resetKernel(t)
+
+	callSession(t, "open('note.txt', 'w').write('hello')", 5)
+	read := callSession(t, "print(open('note.txt').read())", 5)
+	if strings.TrimSpace(read.Stdout) != "hello" {
+		t.Errorf("stdout = %q, want %q (file did not persist)", read.Stdout, "hello")
+	}
+}
+
+// TestSessionChangedFileReturned proves a file written in a snippet comes back
+// in that snippet's Files manifest.
+func TestSessionChangedFileReturned(t *testing.T) {
+	requirePython(t)
+	resetKernel(t)
+
+	res := callSession(t, "open('out.txt', 'w').write('generated')", 5)
+	var found bool
+	for _, f := range res.Files {
+		if f.Path != "out.txt" {
+			continue
+		}
+		found = true
+		data, decErr := base64.StdEncoding.DecodeString(f.ContentB64)
+		if decErr != nil {
+			t.Fatalf("decode: %v", decErr)
+		}
+		if string(data) != "generated" {
+			t.Errorf("out.txt = %q, want %q", data, "generated")
+		}
+	}
+	if !found {
+		t.Error("generated file out.txt not returned in session mode")
+	}
+}
+
+// TestSessionTimeoutResetsChild proves a snippet timeout kills the child (so the
+// loop is not wedged) and reports session_reset, and that the NEXT snippet sees
+// an empty namespace (the reset actually happened).
+func TestSessionTimeoutResetsChild(t *testing.T) {
+	requirePython(t)
+	resetKernel(t)
+
+	// Seed state, then time a snippet out.
+	callSession(t, "marker = 'kept'", 5)
+	timedOut := callSession(t, "import time; time.sleep(30)", 1)
+	if timedOut.ExitCode != -1 {
+		t.Errorf("timed-out exit = %d, want -1", timedOut.ExitCode)
+	}
+	if !strings.Contains(timedOut.Error, "timed out") {
+		t.Errorf("error = %q, want a timeout", timedOut.Error)
+	}
+	if !timedOut.SessionReset {
+		t.Error("a snippet timeout must report session_reset (child was killed)")
+	}
+
+	// The next snippet runs against a fresh child: marker is gone (NameError),
+	// and this snippet itself is reported as a reset (it started the new child).
+	afterReset := callSession(t, "print('marker' in dir())", 5)
+	if !afterReset.SessionReset {
+		t.Error("the snippet after a reset starts a new child; session_reset should be true")
+	}
+	if strings.TrimSpace(afterReset.Stdout) != "False" {
+		t.Errorf("stdout = %q, want False (state should be gone after reset)", afterReset.Stdout)
+	}
+}
+
+// TestSessionSnippetErrorKeepsChild proves a snippet that raises does NOT kill
+// the child (only a timeout/transport fault does): state survives a caught
+// exception, so an agent's typo does not wipe its whole session.
+func TestSessionSnippetErrorKeepsChild(t *testing.T) {
+	requirePython(t)
+	resetKernel(t)
+
+	callSession(t, "y = 7", 5)
+	errored := callSession(t, "raise ValueError('boom')", 5)
+	if errored.ExitCode != 1 {
+		t.Errorf("errored exit = %d, want 1", errored.ExitCode)
+	}
+	if !strings.Contains(errored.Stderr, "ValueError") {
+		t.Errorf("stderr = %q, want a ValueError traceback", errored.Stderr)
+	}
+	if errored.SessionReset {
+		t.Error("a snippet exception must NOT reset the session; the child lives on")
+	}
+
+	survived := callSession(t, "print(y)", 5)
+	if strings.TrimSpace(survived.Stdout) != "7" {
+		t.Errorf("stdout = %q, want 7 (state should survive a snippet exception)", survived.Stdout)
+	}
+}
+
+// TestFrameRoundTrip exercises the length-prefixed framing directly, including a
+// PARTIAL read (the header and body split across reads) to prove readFrame
+// reassembles from an io.Reader that returns short reads.
+func TestFrameRoundTrip(t *testing.T) {
+	payload := []byte(`{"code":"print(1)"}`)
+	var buf bytes.Buffer
+	if err := writeFrame(&buf, payload); err != nil {
+		t.Fatalf("writeFrame: %v", err)
+	}
+
+	// A reader that yields one byte at a time is the worst-case partial read.
+	got, err := readFrame(&oneByteReader{data: buf.Bytes()})
+	if err != nil {
+		t.Fatalf("readFrame: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("frame = %q, want %q", got, payload)
+	}
+}
+
+// TestReadFrameRejectsOversized proves a frame claiming more than maxFrameBytes
+// is refused rather than allocated, so a corrupt child cannot exhaust memory.
+func TestReadFrameRejectsOversized(t *testing.T) {
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], maxFrameBytes+1)
+	_, err := readFrame(bytes.NewReader(hdr[:]))
+	if err == nil {
+		t.Fatal("expected an error for an oversized frame length")
+	}
+	if !strings.Contains(err.Error(), "exceeds cap") {
+		t.Errorf("error = %q, want it to mention the cap", err)
+	}
+}
+
+// oneByteReader returns at most one byte per Read, forcing io.ReadFull to loop.
+type oneByteReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *oneByteReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	p[0] = r.data[r.pos]
+	r.pos++
+	return 1, nil
+}

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.83
+version: 0.4.84

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.83
+      targetRevision: 0.4.84
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/firecracker/substrate/shim/server.go
+++ b/projects/firecracker/substrate/shim/server.go
@@ -2,6 +2,7 @@ package shim
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -49,6 +50,20 @@ func WithReady(fn func() bool) Option {
 	}
 }
 
+// WithClock installs a handler for POST /shim/clock. The endpoint sets the
+// guest wall clock from a posted epoch-ms body ({"epoch_ms": <int>}); it is
+// the resync target the node calls after a session relight (EmberVM R2 Task 4)
+// so a restored guest's clock does not lag the wall time by however long it was
+// banked. Best-effort by contract: when no clock handler is installed the route
+// is absent and a caller's POST 404s, which the node treats as "guest without
+// the endpoint, skip and log" rather than an error. fn receives the requested
+// epoch ms and returns an error only if the set genuinely failed.
+func WithClock(fn func(epochMs int64) error) Option {
+	return func(s *Server) {
+		s.clock = fn
+	}
+}
+
 // Server is an HTTP server that dispatches /invoke requests to a Handler and
 // exposes a /shim/* control surface. It serves over any net.Listener (vsock
 // in production, TCP/UDS in tests), making it fully testable without
@@ -57,6 +72,7 @@ type Server struct {
 	h     Handler
 	chain Chain
 	ready func() bool
+	clock func(epochMs int64) error
 	srv   *http.Server
 }
 
@@ -96,6 +112,12 @@ func (s *Server) mux() *http.ServeMux {
 			w.WriteHeader(http.StatusServiceUnavailable)
 		}
 	})
+	// POST /shim/clock is registered only when a clock handler is installed, so
+	// a guest without one leaves the route absent and the node's post-relight
+	// resync 404s harmlessly (best-effort, EmberVM R2 Task 4).
+	if s.clock != nil {
+		mux.HandleFunc("POST /shim/clock", s.clockHandler)
+	}
 	mux.HandleFunc("/invoke", s.invokeHandler)
 	mux.HandleFunc("/invoke/", s.invokeHandler)
 	return mux
@@ -128,6 +150,28 @@ func (s *Server) invokeHandler(w http.ResponseWriter, r *http.Request) {
 	if resp != nil {
 		_, _ = w.Write(resp.Body)
 	}
+}
+
+// clockHandler decodes {"epoch_ms": <int>} and calls the installed clock
+// function. A malformed body is 400; a non-positive epoch is 400 (a clock set
+// to the epoch is never intended); a set failure is 500. Success is 204.
+func (s *Server) clockHandler(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		EpochMs int64 `json:"epoch_ms"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, fmt.Sprintf("bad clock request: %s", err), http.StatusBadRequest)
+		return
+	}
+	if body.EpochMs <= 0 {
+		http.Error(w, "epoch_ms must be positive", http.StatusBadRequest)
+		return
+	}
+	if err := s.clock(body.EpochMs); err != nil {
+		http.Error(w, fmt.Sprintf("set clock failed: %s", err), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // Serve accepts and handles HTTP connections on ln until ln is closed. It

--- a/projects/firecracker/substrate/shim/server_test.go
+++ b/projects/firecracker/substrate/shim/server_test.go
@@ -83,6 +83,73 @@ func TestServerHealthzAndReady(t *testing.T) {
 	})
 }
 
+// TestClockEndpoint verifies POST /shim/clock: it is absent (404) without a
+// clock handler, calls the handler with the posted epoch on a valid body,
+// rejects a non-positive epoch (400) and a malformed body (400), and surfaces a
+// handler failure as 500.
+func TestClockEndpoint(t *testing.T) {
+	noop := func(_ context.Context, _ *Request) (*Response, error) {
+		return &Response{Status: http.StatusOK}, nil
+	}
+
+	t.Run("absent without a clock handler", func(t *testing.T) {
+		srv := NewServer(noop)
+		req := httptest.NewRequest(http.MethodPost, "/shim/clock", strings.NewReader(`{"epoch_ms":1}`))
+		w := httptest.NewRecorder()
+		srv.mux().ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("got %d, want 404 (no clock handler installed)", w.Code)
+		}
+	})
+
+	t.Run("calls the handler with the posted epoch", func(t *testing.T) {
+		var got int64
+		srv := NewServer(noop, WithClock(func(epochMs int64) error {
+			got = epochMs
+			return nil
+		}))
+		req := httptest.NewRequest(http.MethodPost, "/shim/clock", strings.NewReader(`{"epoch_ms":1700000000000}`))
+		w := httptest.NewRecorder()
+		srv.mux().ServeHTTP(w, req)
+		if w.Code != http.StatusNoContent {
+			t.Errorf("got %d, want 204", w.Code)
+		}
+		if got != 1700000000000 {
+			t.Errorf("clock fn got %d, want 1700000000000", got)
+		}
+	})
+
+	t.Run("rejects a non-positive epoch", func(t *testing.T) {
+		srv := NewServer(noop, WithClock(func(int64) error { return nil }))
+		req := httptest.NewRequest(http.MethodPost, "/shim/clock", strings.NewReader(`{"epoch_ms":0}`))
+		w := httptest.NewRecorder()
+		srv.mux().ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("got %d, want 400", w.Code)
+		}
+	})
+
+	t.Run("rejects a malformed body", func(t *testing.T) {
+		srv := NewServer(noop, WithClock(func(int64) error { return nil }))
+		req := httptest.NewRequest(http.MethodPost, "/shim/clock", strings.NewReader("not json"))
+		w := httptest.NewRecorder()
+		srv.mux().ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("got %d, want 400", w.Code)
+		}
+	})
+
+	t.Run("surfaces a set failure as 500", func(t *testing.T) {
+		srv := NewServer(noop, WithClock(func(int64) error { return fmt.Errorf("nope") }))
+		req := httptest.NewRequest(http.MethodPost, "/shim/clock", strings.NewReader(`{"epoch_ms":1}`))
+		w := httptest.NewRecorder()
+		srv.mux().ServeHTTP(w, req)
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("got %d, want 500", w.Code)
+		}
+	})
+}
+
 // TestServerUnknownPath404 verifies that requests to unregistered paths
 // receive a 404 response.
 func TestServerUnknownPath404(t *testing.T) {

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.128
+version: 0.89.129
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.128
+      targetRevision: 0.89.129
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1059,6 +1059,35 @@ py_test(
     ],
 )
 
+# sandbox is gazelle-excluded, so its py_tests are hand-registered.
+py_test(
+    name = "sandbox_client_test",
+    srcs = ["sandbox/client_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
+# Sessioned run_python (EmberVM R2): create-reuse-close, the 410 transparent
+# re-create + session_reset flag, and the token-never-logged guard. Uses an
+# in-memory SQLite for the sandbox.session table, so it needs sqlmodel.
+py_test(
+    name = "sandbox_session_test",
+    srcs = ["sandbox/session_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//sqlmodel",
+    ],
+)
+
 py_test(
     name = "integration_test",
     size = "medium",

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.203
+version: 0.285.204
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260715010000_sandbox_session.sql
+++ b/projects/monolith/chart/migrations/20260715010000_sandbox_session.sql
@@ -1,0 +1,36 @@
+-- sandbox.session: maps a caller-chosen handle to EmberVM session credentials
+-- (EmberVM R2, ADR embervm/001; sessioned run_python, plan Task 10). The
+-- monolith's run_python tool takes an optional opaque `session` handle; the
+-- first use with a handle creates an EmberVM session (POST
+-- /v1/workloads/sandbox-session/sessions) and stores its id + capability token
+-- here, and later uses look the row up to reuse the same live/banked session so
+-- variables, files, and warm imports accrete across an agent's turns.
+--
+-- token IS A SECRET: it is the per-session capability that authenticates every
+-- invoke to this session (verified by hash, constant-time, on the EmberVM
+-- side). It is never logged by the client and this table is PRIVATE-TIER ONLY:
+-- no public_reader GRANT lands here, and nothing on the public origin reads
+-- sandbox.session. A leaked token grants invoke access to exactly one session
+-- (bounded by its max lifetime), nothing more.
+--
+-- expires_at mirrors the EmberVM session's max-lifetime deadline; a row whose
+-- session has 410'd (expired/evicted/failed) is transparently replaced on the
+-- next use (last-write-wins by handle), so stale rows are self-healing and no
+-- separate reaper is required.
+--
+-- Private-tier schema: the private `app` role needs no explicit GRANT here
+-- (mirrors 20260712000000_home_cluster_snapshot.sql and
+-- 20260714000000_faas_function.sql).
+
+CREATE SCHEMA IF NOT EXISTS sandbox;
+
+CREATE TABLE sandbox.session (
+    handle     TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    token      TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ
+);
+
+COMMENT ON COLUMN sandbox.session.token IS
+    'SECRET: EmberVM per-session capability token. Never log it; private-tier only.';

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:AWwoioFk8FYkZN05TfsyUGAIpaD7UlHDs7N+u60VopM=
+h1:aoGwae9PHNdRGjlgQirs4OkZtdZRnrvh8+ifZYRUsQc=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -131,3 +131,4 @@ h1:AWwoioFk8FYkZN05TfsyUGAIpaD7UlHDs7N+u60VopM=
 20260713000000_dr_jobs_notified_columns.sql h1:xzxvvjmCXQ164L4yIrfzCOPTr8qg5EWDk7FPcS2vtH4=
 20260714000000_faas_function.sql h1:ZKy8KILFm2YrCSl+a5VelvQbuZXOIq+tdWEafCFh2qk=
 20260715000000_faas_public_reader_grant.sql h1:aWN3QjqYyVlTgShG2/0goPL/CG0r9v9KhrZO0U7EG0Y=
+20260715010000_sandbox_session.sql h1:v1Z8WHlyyOitOqC6KlozQkm6Fhq5j3BW74IAFEiad0A=

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -123,6 +123,13 @@ spec:
             - name: SANDBOX_DISPATCH
               value: {{ .Values.sandbox.dispatch | quote }}
             {{- end }}
+            {{- if .Values.sandbox.sessionWorkload }}
+            # The EmberVM session-class workload backing sessioned run_python
+            # (R2, ADR embervm/001). Sessions are created under this workload;
+            # the one-shot task class stays on `sandbox`. Reuses EMBERVM_URL.
+            - name: SANDBOX_SESSION_WORKLOAD
+              value: {{ .Values.sandbox.sessionWorkload | quote }}
+            {{- end }}
             {{- if .Values.semgrep.shadowProject }}
             # Route B shadow project: the relay reports App scans under this name
             # instead of the real repo, keeping self-hosted scans in a separate

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -797,6 +797,10 @@ chat:
 # embervm (EmberVM's sandbox Workload). Reuses semgrep.embervmUrl -> EMBERVM_URL.
 sandbox:
   dispatch: "fc-invoke"
+  # The EmberVM session-class workload backing sessioned run_python (R2, ADR
+  # embervm/001). Sessions are created here; the one-shot task class stays on
+  # `sandbox`. Empty falls back to the client default ("sandbox-session").
+  sessionWorkload: "sandbox-session"
 
 # FaaS zip-lane function registry (ADR 045 / embervm R1). s3ReadBase is the
 # in-cluster SeaweedFS S3 read host noded GETs function archives from; it must

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -952,7 +952,9 @@ def create_agent(
         "chart. Prefer it over starting an agent thread when the goal is an "
         "output, not a change."
     )
-    async def run_python(ctx: RunContext[ChatDeps], code: str) -> str:
+    async def run_python(
+        ctx: RunContext[ChatDeps], code: str, session: str | None = None
+    ) -> str:
         """Run a short Python script in an isolated sandbox and return its output. No network.
 
         To hand back a chart or file, save it with a plain relative filename
@@ -963,8 +965,15 @@ def create_agent(
         For tabular data, use the baked helper: `from sandbox_tools import
         render_table` then render_table(headers, rows, title=None) writes a
         styled table.png for you.
+
+        Pass a stable session handle (any short string you reuse across calls)
+        to keep variables, imports, and files warm across calls instead of
+        starting cold each time. State is best-effort and may reset if the
+        session goes idle, is evicted, or a snippet times out; when it resets
+        the output says so, and you must re-run any setup the later code needs.
+        Omit session for a clean one-shot run.
         """
-        result = await run_python_in_sandbox(code)
+        result = await run_python_in_sandbox(code, session=session)
         if result.get("error"):
             return f"sandbox error: {result['error']}"
         for f in result.get("files", []):
@@ -975,6 +984,11 @@ def create_agent(
             except (KeyError, ValueError):
                 continue
         parts = []
+        if result.get("session_reset"):
+            parts.append(
+                "[session was reset: prior variables, imports, and files are "
+                "gone; re-run any setup this code depends on]"
+            )
         if result.get("stdout"):
             parts.append(result["stdout"])
         if result.get("stderr"):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.203
+      targetRevision: 0.285.204
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/sandbox/client.py
+++ b/projects/monolith/sandbox/client.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+from datetime import datetime, timezone
 
 import httpx
 
@@ -26,21 +27,39 @@ FC_INVOKE_URL = os.environ.get("FC_INVOKE_URL", "")
 EMBERVM_URL = os.environ.get("EMBERVM_URL", "")
 SANDBOX_DISPATCH = os.environ.get("SANDBOX_DISPATCH", "fc-invoke")
 
+# The EmberVM session-class workload backing sessioned run_python (R2, plan
+# Task 10). Sessions are created under this workload; the one-shot task class
+# stays on `sandbox`. Injected from Helm values so the name is never hardcoded
+# to a specific release wiring.
+SANDBOX_SESSION_WORKLOAD = os.environ.get("SANDBOX_SESSION_WORKLOAD", "sandbox-session")
+
 SANDBOX_CONNECT_TIMEOUT = 5.0
 # Guest wall-clock cap is 25s inside a 30s workload requestTimeout; read a
 # little past that so the daemon's timeout error reaches us intact.
 SANDBOX_READ_TIMEOUT = 35.0
+# A relight of a banked session adds restore latency before the guest runs, so
+# a session invoke reads a little longer than a one-shot to let a cold-banked
+# session relight and still return within the read window.
+SANDBOX_SESSION_READ_TIMEOUT = 45.0
 
 
-async def run_python_in_sandbox(code: str, files: list[dict] | None = None) -> dict:
-    """POST code (and optional input files) to the fc-invoke sandbox workload.
+async def run_python_in_sandbox(
+    code: str, files: list[dict] | None = None, session: str | None = None
+) -> dict:
+    """POST code (and optional input files) to the sandbox workload.
 
     Returns the daemon's structured response on success: ``stdout``,
     ``stderr``, ``exit_code``, ``files`` (base64-encoded), ``duration_ms``,
     and ``truncated``. On failure, a dict with a single ``error`` key.
+
+    When ``session`` is a non-empty handle, the run is served by the EmberVM
+    session class (R2): state persists best-effort across calls that share the
+    handle. The first use of a handle creates a session; later uses reuse it; a
+    session that has been reset (expired, evicted, or failed) is transparently
+    re-created and the response carries ``session_reset: True`` so the caller
+    knows prior state was lost. When ``session`` is absent the behavior is the
+    one-shot task class, exactly as before (no state, no session table touch).
     """
-    if not FC_INVOKE_URL:
-        return {"error": "FC_INVOKE_URL is not configured"}
     if not code or not code.strip():
         return {"error": "no code provided"}
 
@@ -48,6 +67,11 @@ async def run_python_in_sandbox(code: str, files: list[dict] | None = None) -> d
     if files:
         payload["files"] = files
 
+    if session:
+        return await _run_session(session, payload)
+
+    if not FC_INVOKE_URL:
+        return {"error": "FC_INVOKE_URL is not configured"}
     if SANDBOX_DISPATCH == "embervm":
         return await _run_embervm(payload)
     return await _run_fc_invoke(payload)
@@ -120,3 +144,232 @@ async def _run_embervm(payload: dict) -> dict:
     except Exception as exc:  # noqa: BLE001: surface any failure as structured error
         logger.exception("sandbox execution failed")
         return {"error": f"sandbox execution failed: {exc}"}
+
+
+# ---------------------------------------------------------------------------
+# Sessioned run_python (EmberVM R2, ADR embervm/001; plan Task 10).
+#
+# A session is a long-lived logical sandbox whose in-VM state (variables, files,
+# warm imports) persists across invokes. The monolith maps a caller-chosen
+# handle to an EmberVM session id + capability token in sandbox.session; the
+# token is a SECRET and is NEVER logged here. On a 410 (the session expired,
+# was evicted, or failed) the handle is transparently re-created and the caller
+# is told with session_reset=True that prior state was lost.
+# ---------------------------------------------------------------------------
+
+
+def _session_headers() -> dict:
+    """Management-auth headers (this pod's SA token) for session create/delete."""
+    return auth_headers()
+
+
+def _db_session():
+    """Open a short DB session for the handle mapping (private-tier only).
+
+    Imported lazily so importing sandbox.client off-cluster (or in the guest
+    contract tests) never pulls SQLModel or the DB engine.
+    """
+    from app.db import get_engine  # noqa: PLC0415
+    from sqlmodel import Session  # noqa: PLC0415
+
+    return Session(get_engine())
+
+
+async def _create_embervm_session() -> dict:
+    """POST a new EmberVM session; return {session_id, token, expires_at} or {error}."""
+    if not EMBERVM_URL:
+        return {"error": "EMBERVM_URL is not configured"}
+    timeout = httpx.Timeout(
+        SANDBOX_SESSION_READ_TIMEOUT, connect=SANDBOX_CONNECT_TIMEOUT
+    )
+    url = f"{EMBERVM_URL}/v1/workloads/{SANDBOX_SESSION_WORKLOAD}/sessions"
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(url, headers=_session_headers())
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.ConnectError as exc:
+        logger.exception("embervm session create connection failed")
+        return {"error": f"could not reach embervm: {exc}"}
+    except httpx.HTTPStatusError as exc:
+        logger.exception("embervm session create returned an error status")
+        return {
+            "error": (
+                f"embervm session create HTTP {exc.response.status_code}: "
+                f"{exc.response.text[:500]}"
+            )
+        }
+    except Exception as exc:  # noqa: BLE001: surface any failure as structured error
+        logger.exception("embervm session create failed")
+        return {"error": f"session create failed: {exc}"}
+
+    if not data.get("session_id") or not data.get("session_token"):
+        # Never log the token; log only that the shape was wrong.
+        logger.error("embervm session create response missing id or token")
+        return {"error": "session create returned an unexpected response"}
+    return {
+        "session_id": data["session_id"],
+        "token": data["session_token"],
+        "expires_at": data.get("expires_at"),
+    }
+
+
+def _parse_expires_at(expires_at):
+    """EmberVM returns expires_at as epoch ms; store it as an aware datetime."""
+    if not expires_at:
+        return None
+    try:
+        return datetime.fromtimestamp(int(expires_at) / 1000, tz=timezone.utc)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+async def create_session(handle: str) -> dict:
+    """Create an EmberVM session and bind it to handle in sandbox.session.
+
+    Returns {"session_id": ...} on success (never the token) or {"error": ...}.
+    Last-write-wins: re-creating an existing handle rebinds it to a fresh
+    session (the transparent-recreate path relies on this).
+    """
+    from sandbox.repository import upsert_session_row  # noqa: PLC0415
+
+    created = await _create_embervm_session()
+    if created.get("error"):
+        return created
+    with _db_session() as db:
+        upsert_session_row(
+            db,
+            handle=handle,
+            session_id=created["session_id"],
+            token=created["token"],
+            expires_at=_parse_expires_at(created.get("expires_at")),
+        )
+    return {"session_id": created["session_id"]}
+
+
+async def _invoke_embervm_session(session_id: str, token: str, payload: dict) -> dict:
+    """POST a session invoke; return the guest exec dict, or {"__status__": 410}.
+
+    A 410 is returned as a sentinel so the caller can transparently re-create
+    rather than surfacing the raw error; every other HTTP error is a normal
+    structured error dict. The session token is sent as the bearer credential
+    and is NEVER logged.
+    """
+    if not EMBERVM_URL:
+        return {"error": "EMBERVM_URL is not configured"}
+    body = {**payload, "mode": "session"}
+    headers = {"Authorization": f"Bearer {token}"}
+    timeout = httpx.Timeout(
+        SANDBOX_SESSION_READ_TIMEOUT, connect=SANDBOX_CONNECT_TIMEOUT
+    )
+    url = f"{EMBERVM_URL}/v1/sessions/{session_id}/invoke"
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(url, json=body, headers=headers)
+            if resp.status_code == 410:
+                return {"__status__": 410}
+            resp.raise_for_status()
+            return resp.json()
+    except httpx.ConnectError as exc:
+        logger.exception("embervm session invoke connection failed")
+        return {"error": f"could not reach embervm: {exc}"}
+    except httpx.HTTPStatusError as exc:
+        logger.exception("embervm session invoke returned an error status")
+        return {
+            "error": (
+                f"embervm session invoke HTTP {exc.response.status_code}: "
+                f"{exc.response.text[:500]}"
+            )
+        }
+    except Exception as exc:  # noqa: BLE001: surface any failure as structured error
+        logger.exception("embervm session invoke failed")
+        return {"error": f"session invoke failed: {exc}"}
+
+
+async def invoke_session(
+    handle: str, code: str, files: list[dict] | None = None
+) -> dict:
+    """Run code in the session bound to handle, creating or re-creating as needed.
+
+    Create-on-first-use, reuse thereafter, and transparent re-create on a 410
+    (the session expired, was evicted, or failed). When a re-create happens the
+    returned dict carries session_reset=True so the model knows the accreted
+    state (variables, files, imports) was lost and must be re-established.
+    """
+    if not code or not code.strip():
+        return {"error": "no code provided"}
+    payload: dict = {"code": code}
+    if files:
+        payload["files"] = files
+    return await _run_session(handle, payload)
+
+
+async def _run_session(handle: str, payload: dict) -> dict:
+    """Core sessioned dispatch: look up the handle, invoke, recreate on 410."""
+    from sandbox.repository import get_session_row  # noqa: PLC0415
+
+    reset = False
+    with _db_session() as db:
+        row = get_session_row(db, handle)
+    if row is None:
+        created = await create_session(handle)
+        if created.get("error"):
+            return created
+        reset = True  # a fresh session has empty state
+        with _db_session() as db:
+            row = get_session_row(db, handle)
+        if row is None:
+            return {"error": "session row vanished after create"}
+
+    result = await _invoke_embervm_session(row.session_id, row.token, payload)
+    if result.get("__status__") == 410:
+        # The session is terminal; re-create transparently and invoke once more.
+        created = await create_session(handle)
+        if created.get("error"):
+            return created
+        reset = True
+        with _db_session() as db:
+            fresh = get_session_row(db, handle)
+        if fresh is None:
+            return {"error": "session row vanished after re-create"}
+        result = await _invoke_embervm_session(fresh.session_id, fresh.token, payload)
+        if result.get("__status__") == 410:
+            # A brand-new session should never 410 immediately; surface it.
+            return {"error": "session was terminal immediately after re-create"}
+
+    if result.get("error"):
+        return result
+    # The guest itself may report a reset (a snippet timeout killed the child);
+    # OR-fold it with a control-plane recreate so either cause is reported.
+    result["session_reset"] = bool(result.get("session_reset")) or reset
+    return result
+
+
+async def close_session(handle: str) -> dict:
+    """Destroy the EmberVM session bound to handle and drop the mapping row.
+
+    Idempotent: an unknown handle or an already-terminal session both return
+    {"closed": True}. The DELETE uses management auth (this pod's SA token).
+    """
+    from sandbox.repository import delete_session_row, get_session_row  # noqa: PLC0415
+
+    with _db_session() as db:
+        row = get_session_row(db, handle)
+    if row is None:
+        return {"closed": True}
+
+    if EMBERVM_URL:
+        timeout = httpx.Timeout(SANDBOX_READ_TIMEOUT, connect=SANDBOX_CONNECT_TIMEOUT)
+        url = f"{EMBERVM_URL}/v1/sessions/{row.session_id}"
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.delete(url, headers=_session_headers())
+                # 200 destroyed, 404 already gone: both fine.
+                if resp.status_code not in (200, 404):
+                    resp.raise_for_status()
+        except Exception:  # noqa: BLE001: best-effort destroy; still drop the row
+            logger.exception("embervm session destroy failed; dropping mapping anyway")
+
+    with _db_session() as db:
+        delete_session_row(db, handle)
+    return {"closed": True}

--- a/projects/monolith/sandbox/mcp.py
+++ b/projects/monolith/sandbox/mcp.py
@@ -5,6 +5,10 @@ the supplied code (and optional input files) to the in-cluster ``fc-invoke``
 ``sandbox`` workload (ADR agents/044) and returns the structured execution
 result. The daemon URL is injected from Helm values as ``FC_INVOKE_URL`` and
 is never hardcoded here.
+
+With an optional ``session`` handle the run is served by the EmberVM session
+class (R2, ADR embervm/001): state persists best-effort across calls sharing
+the handle, and a reset is surfaced as ``session_reset`` in the response.
 """
 
 from __future__ import annotations
@@ -14,15 +18,28 @@ from sandbox.client import run_python_in_sandbox
 
 
 @mcp.tool
-async def run_python(code: str, files: list[dict] | None = None) -> dict:
+async def run_python(
+    code: str, files: list[dict] | None = None, session: str | None = None
+) -> dict:
     """Run a short Python 3.12 script in an isolated, zero-egress sandbox.
 
-    The sandbox is a one-shot Firecracker microVM: nothing persists between
-    calls, there is no network access at all, and the run is killed after
-    about 25 seconds of wall-clock time. Use it for exact computation
+    By default the sandbox is a one-shot Firecracker microVM: nothing persists
+    between calls, there is no network access at all, and the run is killed
+    after about 25 seconds of wall-clock time. Use it for exact computation
     (arithmetic, date math, unit conversions, statistics, simulations),
     parsing or crunching pasted data, or generating a quick chart, rather
     than estimating an answer from memory.
+
+    Optional stateful sessions: pass a stable session handle (any short string
+    of your choosing, reused across calls) to keep one long-lived interpreter
+    warm so variables, imported modules, and files written to the working
+    directory carry over from one call to the next, instead of starting cold
+    each snippet. State is best-effort: it persists across turns but MAY be
+    reset if the session sits idle too long, is evicted under disk pressure, or
+    a snippet times out. When that happens the response carries session_reset
+    true and the interpreter is empty again, so re-run any setup (imports,
+    variable definitions, files) the later code depends on. There is still no
+    network in a session. Omit session for the classic one-shot run.
 
     Available besides the Python 3.12 standard library: numpy, pandas,
     scipy, matplotlib (headless "Agg" backend, save figures to files rather
@@ -46,13 +63,18 @@ async def run_python(code: str, files: list[dict] | None = None) -> dict:
         files: Optional input files to write into the working directory
             before running code. Each entry needs a path (relative
             filename) and content_b64 (its content, base64-encoded).
+        session: Optional session handle. Absent runs one-shot (no state).
+            Present keeps state warm across calls that reuse the same handle,
+            best-effort (see above).
 
     Returns:
         On success, the daemon's structured result: stdout, stderr,
         exit_code, duration_ms, truncated (whether any output was cut off to
         stay under the response size cap), and files (any regular files
         present in the working directory after the run that weren't given as
-        input, base64-encoded under content_b64 next to their path). On
-        failure, a dict with a single error key describing what went wrong.
+        input, base64-encoded under content_b64 next to their path). In session
+        mode, session_reset is true when the persisted state was lost before
+        this run. On failure, a dict with a single error key describing what
+        went wrong.
     """
-    return await run_python_in_sandbox(code, files=files)
+    return await run_python_in_sandbox(code, files=files, session=session)

--- a/projects/monolith/sandbox/models.py
+++ b/projects/monolith/sandbox/models.py
@@ -1,0 +1,31 @@
+"""SQLModel definition for the sandbox.session table (EmberVM R2, ADR embervm/001).
+
+Mirrors chart/migrations/20260715010000_sandbox_session.sql. Postgres is the
+single source of truth: one row per caller handle, mapping it to an EmberVM
+session id and its per-session capability token so sessioned run_python reuses
+the same session across turns.
+
+token is a SECRET (the capability that authenticates every invoke). It is never
+logged and this table is private-tier only; no public_reader GRANT exists.
+
+expires_at is the EmberVM session's max-lifetime deadline supplied by the create
+API (not a server-generated insert timestamp), so it has no default_factory: it
+is NULL until the API value is stored. The class-level nosemgrep covers the
+sqlmodel-datetime-without-factory rule for that intentional nullable field.
+"""
+
+from datetime import datetime, timezone
+
+from sqlmodel import Field, SQLModel
+
+
+class SandboxSession(SQLModel, table=True):  # nosemgrep
+    __tablename__ = "session"
+    __table_args__ = {"schema": "sandbox", "extend_existing": True}
+
+    handle: str = Field(primary_key=True)
+    session_id: str
+    # SECRET: EmberVM per-session capability token. Never log it.
+    token: str
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    expires_at: datetime | None = Field(default=None)

--- a/projects/monolith/sandbox/repository.py
+++ b/projects/monolith/sandbox/repository.py
@@ -1,0 +1,68 @@
+"""Thin repository over sandbox.session: the handle -> EmberVM session mapping.
+
+ORM-level upsert (not a dialect-specific INSERT ... ON CONFLICT) so it runs
+identically on SQLite (unit tests, SQLModel.metadata.create_all) and Postgres
+(production), mirroring faas/repository.py. Callers own the Session and commit
+boundary.
+
+The token stored here is a SECRET (the per-session capability). This module
+never logs it; callers must not either.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlmodel import Session
+
+from sandbox.models import SandboxSession
+
+
+def get_session_row(session: Session, handle: str) -> SandboxSession | None:
+    """Return the session row for a handle, or None if none is mapped."""
+    return session.get(SandboxSession, handle)
+
+
+def upsert_session_row(
+    session: Session,
+    *,
+    handle: str,
+    session_id: str,
+    token: str,
+    expires_at: datetime | None,
+) -> SandboxSession:
+    """Create or last-write-wins replace the session credentials for a handle.
+
+    Re-mapping a handle (the transparent re-create after a 410) overwrites the
+    id, token, and expiry so a stale terminal session is self-healing: the next
+    use rebinds the handle to the fresh session with no separate reaper.
+    """
+    existing = session.get(SandboxSession, handle)
+    if existing is None:
+        row = SandboxSession(
+            handle=handle,
+            session_id=session_id,
+            token=token,
+            expires_at=expires_at,
+        )
+        session.add(row)
+        session.commit()
+        session.refresh(row)
+        return row
+
+    existing.session_id = session_id
+    existing.token = token
+    existing.expires_at = expires_at
+    session.commit()
+    session.refresh(existing)
+    return existing
+
+
+def delete_session_row(session: Session, handle: str) -> bool:
+    """Delete the mapping for a handle. Returns whether a row was deleted."""
+    row = session.get(SandboxSession, handle)
+    if row is None:
+        return False
+    session.delete(row)
+    session.commit()
+    return True

--- a/projects/monolith/sandbox/session_test.py
+++ b/projects/monolith/sandbox/session_test.py
@@ -1,0 +1,239 @@
+"""Tests for sessioned run_python (client.py session surface, EmberVM R2).
+
+Hermetic: httpx.AsyncClient is a fake that records each request and returns a
+scripted response, and the sandbox.session table is an in-memory SQLite engine
+(SQLModel.metadata.create_all), so create-reuse-close, the 410 transparent
+re-create + session_reset flag, and "the token is never logged" are all asserted
+without a cluster.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+
+import pytest
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+from sandbox import client
+from sandbox.models import SandboxSession  # noqa: F401  (registers the table)
+
+# A fake token used only to prove the client never logs it (see
+# test_token_never_logged); not a real credential.
+SECRET_TOKEN = "tok-super-secret-value-do-not-log"  # nosemgrep: no-hardcoded-secret
+
+
+class _Resp:
+    def __init__(self, status_code=200, data=None, text=""):
+        self.status_code = status_code
+        self._data = data or {}
+        self.text = text
+
+    def raise_for_status(self):
+        # No scripted test drives a non-410 error status through
+        # raise_for_status, so a plain exception is enough and avoids
+        # constructing a real httpx.Response for the error path.
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._data
+
+
+class _FakeClient:
+    # Queue of (method, response) the fake replays in order; each entry also
+    # records the request it saw for assertions.
+    script: list = []
+    seen: list = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def _record(self, method, url, json=None, headers=None):
+        _FakeClient.seen.append(
+            {"method": method, "url": url, "json": json, "headers": headers or {}}
+        )
+        if not _FakeClient.script:
+            raise AssertionError(f"unexpected {method} {url}; script exhausted")
+        return _FakeClient.script.pop(0)
+
+    async def post(self, url, json=None, headers=None):
+        return await self._record("POST", url, json=json, headers=headers)
+
+    async def delete(self, url, headers=None):
+        return await self._record("DELETE", url, headers=headers)
+
+
+@pytest.fixture(autouse=True)
+def _wired(monkeypatch):
+    _FakeClient.script = []
+    _FakeClient.seen = []
+    monkeypatch.setattr(client.httpx, "AsyncClient", _FakeClient)
+    monkeypatch.setattr(client, "EMBERVM_URL", "http://ev")
+    monkeypatch.setattr(client, "SANDBOX_SESSION_WORKLOAD", "sandbox-session")
+
+    # StaticPool + a single shared connection keeps the in-memory DB alive
+    # across the several _db_session() opens one invoke makes (each open is a
+    # fresh connection; without StaticPool it would be a fresh empty DB).
+    # SQLite has no schemas, so strip the Postgres schema qualifier before
+    # create_all and restore it after (mirrors faas/models_test.py).
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+
+        @contextlib.contextmanager
+        def fake_db():
+            with Session(engine) as s:
+                yield s
+
+        monkeypatch.setattr(client, "_db_session", fake_db)
+        yield
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def _create_resp(session_id="s-abc", token=SECRET_TOKEN):
+    return _Resp(
+        status_code=201,
+        data={
+            "session_id": session_id,
+            "session_token": token,
+            "expires_at": 1700000000000,
+        },
+    )
+
+
+def _exec_resp(stdout, session_reset=False):
+    return _Resp(
+        status_code=200,
+        data={"stdout": stdout, "exit_code": 0, "session_reset": session_reset},
+    )
+
+
+@pytest.mark.asyncio
+async def test_first_use_creates_then_invokes():
+    _FakeClient.script = [_create_resp(), _exec_resp("42\n")]
+    result = await client.invoke_session("h1", "print(6*7)")
+    assert result["stdout"] == "42\n"
+    # A fresh session has empty state, so the first use reports a reset.
+    assert result["session_reset"] is True
+    # First call created, second invoked with the session token as bearer.
+    create_req, invoke_req = _FakeClient.seen
+    assert create_req["url"] == "http://ev/v1/workloads/sandbox-session/sessions"
+    assert invoke_req["url"] == "http://ev/v1/sessions/s-abc/invoke"
+    assert invoke_req["headers"]["Authorization"] == f"Bearer {SECRET_TOKEN}"
+    assert invoke_req["json"]["mode"] == "session"
+
+
+@pytest.mark.asyncio
+async def test_second_use_reuses_without_recreating():
+    _FakeClient.script = [_create_resp(), _exec_resp("first\n")]
+    await client.invoke_session("h2", "x = 1")
+    # Second use: only an invoke, no new create, and no reset.
+    _FakeClient.seen = []
+    _FakeClient.script = [_exec_resp("second\n")]
+    result = await client.invoke_session("h2", "print(x)")
+    assert result["stdout"] == "second\n"
+    assert result["session_reset"] is False
+    assert len(_FakeClient.seen) == 1
+    assert _FakeClient.seen[0]["url"] == "http://ev/v1/sessions/s-abc/invoke"
+
+
+@pytest.mark.asyncio
+async def test_410_transparently_recreates_and_flags_reset():
+    # Bind the handle first.
+    _FakeClient.script = [_create_resp(session_id="s-old"), _exec_resp("ok\n")]
+    await client.invoke_session("h3", "y = 1")
+
+    # Next invoke 410s; the client re-creates (new id) and invokes again.
+    _FakeClient.seen = []
+    _FakeClient.script = [
+        _Resp(status_code=410, data={"reason": "expired"}),
+        _create_resp(session_id="s-new"),
+        _exec_resp("recovered\n"),
+    ]
+    result = await client.invoke_session("h3", "print('after')")
+    assert result["stdout"] == "recovered\n"
+    assert result["session_reset"] is True
+    urls = [r["url"] for r in _FakeClient.seen]
+    assert urls == [
+        "http://ev/v1/sessions/s-old/invoke",
+        "http://ev/v1/workloads/sandbox-session/sessions",
+        "http://ev/v1/sessions/s-new/invoke",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_close_destroys_and_drops_row():
+    _FakeClient.script = [_create_resp(session_id="s-close"), _exec_resp("ok\n")]
+    await client.invoke_session("h4", "z = 1")
+
+    _FakeClient.seen = []
+    _FakeClient.script = [_Resp(status_code=200)]
+    result = await client.close_session("h4")
+    assert result == {"closed": True}
+    assert _FakeClient.seen[0]["method"] == "DELETE"
+    assert _FakeClient.seen[0]["url"] == "http://ev/v1/sessions/s-close"
+
+    # The row is gone: the next invoke must create a fresh session.
+    _FakeClient.seen = []
+    _FakeClient.script = [_create_resp(session_id="s-fresh"), _exec_resp("new\n")]
+    again = await client.invoke_session("h4", "print(1)")
+    assert again["session_reset"] is True
+    assert (
+        _FakeClient.seen[0]["url"] == "http://ev/v1/workloads/sandbox-session/sessions"
+    )
+
+
+@pytest.mark.asyncio
+async def test_close_unknown_handle_is_idempotent():
+    result = await client.close_session("never-created")
+    assert result == {"closed": True}
+    # Nothing was sent to EmberVM for an unknown handle.
+    assert _FakeClient.seen == []
+
+
+@pytest.mark.asyncio
+async def test_token_never_logged(caplog):
+    _FakeClient.script = [_create_resp(), _exec_resp("ok\n")]
+    with caplog.at_level(logging.DEBUG, logger="sandbox.client"):
+        await client.invoke_session("h5", "print(1)")
+    for record in caplog.records:
+        assert SECRET_TOKEN not in record.getMessage()
+
+
+@pytest.mark.asyncio
+async def test_one_shot_path_untouched_when_session_absent(monkeypatch):
+    # With no session handle, run_python_in_sandbox must NOT touch the session
+    # surface: it routes to the fc-invoke/embervm one-shot path exactly as before.
+    called = {"fc": False}
+
+    async def fake_fc(payload):
+        called["fc"] = True
+        return {"stdout": "one-shot\n", "exit_code": 0}
+
+    monkeypatch.setattr(client, "_run_fc_invoke", fake_fc)
+    monkeypatch.setattr(client, "FC_INVOKE_URL", "http://fc")
+    monkeypatch.setattr(client, "SANDBOX_DISPATCH", "fc-invoke")
+    result = await client.run_python_in_sandbox("print(1)")
+    assert result["stdout"] == "one-shot\n"
+    assert called["fc"] is True
+    assert "session_reset" not in result


### PR DESCRIPTION
**PR-6 (Task 10) of EmberVM R2 Sessions**: the named first consumer. `run_python` gains an optional session so an agent's variables, files, and warm imports persist across turns instead of re-executing from zero. Spans the Go guest, the embervm chart, and the monolith. Opus-reviewed (one BUILD-label fix applied; everything else clean).

## What (3 codebases, 1716 lines)
- **Guest (Go)**: `handler.go` gets a guarded `mode: session` branch (one-shot BYTE-IDENTICAL when absent, proven by tests); `kernel.go` is a persistent python3 child with a 4-byte-length-prefixed JSON frame protocol, a shared `/tmp/session` namespace, and a parent-enforced per-snippet timeout that SIGKILLs the process group + restarts (a timeout resets state, a snippet exception does not). `POST /shim/clock` sets the guest wall clock (Task 4's resync target).
- **Chart**: `workload-sandbox-session.yaml` (class: session, same guest image/pin as sandbox, 1 vcpu / 2048 MiB, floor 1 / cap 4, idleBank 120 / maxLifetime 21600 / maxSessions 8), with the node-4 disk arithmetic documented.
- **Monolith**: `client.py` create/invoke/close_session; `sandbox.session` table (token is a SECRET, private-tier only, never logged); `run_python` MCP + concierge tools gain a `session` handle (create-on-first-use, reuse, transparent 410 re-create with `session_reset: true`). Also registered the previously-unwired `sandbox_client_test`.

## Review fix
`cmd/BUILD` used a legacy `@...//unix:go_default_library` label (found nowhere else); reverted to the bare label all siblings use.

## Decisions (DECISIONS.md D-R2.6.1-4)
Frame protocol; parent-enforced timeout + OR-folded session_reset; one-shot byte-identity; rootfs reuse + 45s read timeout.

Bumps embervm 0.1.41 + monolith 0.285.204 + monolith-public 0.89.129. No local test loop; Go guest tests + pytest + migration + renders verified in CI.

## Live acceptance (post-merge, Task 10)
Two `run_python` calls with the same session handle, call 2 reads a variable + a file defined in call 1, with an idle-bank + relight forced between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)