### PR TITLE
fix(embervm): wire session create->first-invoke via lazy VM adoption

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -675,3 +675,40 @@ Task 10 choices where the plan was silent (sessioned run_python across guest + c
   holds, condition 2 (agent-sandbox upstream traction) still open. Goosecracker remains
   the last fc-invoke consumer; its migration onto the session class is the R2.x follow-on
   that triggers retiring the fc-invoke substrate.
+
+### D-R2.7.2 Session invoke was broken in prod (registry gap); fixed by lazy adoption on first SessionAssign
+- **The live drill (D-R2.7.1) caught a real bug the CI-green mechanisms all missed:** every
+  first invoke on a freshly created session returned 502 and the session went `failed`.
+  ROOT CAUSE: session create primes/claims its VM through the shared warm pool, so noded's
+  `Prime` lands it in the TASK registry (`s.vms`); but `SessionAssign` only accepts VMs from
+  the disjoint SESSION registry (`s.sessionVMs`), which until now was populated ONLY by
+  `Relight`. So the create -> first-invoke path was never wired: SessionAssign hit "unknown
+  session VM" -> FAILED_PRECONDITION (status 9) -> control plane 502 + failed the session.
+  Tasks work because task `Assign` reads the same `s.vms` that `Prime` writes; sessions had
+  no equivalent bridge. Every unit test passed because each side was tested against its own
+  fake; nothing drove a real control-plane -> gRPC -> noded session invoke end to end. This
+  is exactly the integration seam a mock hides, and the reason the live drill was worth running.
+- **FIX (Option C, simplest of three):** `SessionAssign` ADOPTS a primed VM from the task
+  registry into the session registry on the first invoke (`Server.adoptPrimedSession` +
+  `vmRegistry.claimForSession`), gated by a WORKLOAD MATCH (a session may only adopt a VM
+  primed from its own class:session base; the request's `trace.workload` must equal the
+  primed VM's workload). The registry comment already anticipated this ("add registers a
+  freshly relit OR primed-into-session VM"), so it is the intended seam. Rejected Option A/B
+  (a new create-time noded verb + proto + control-plane round-trip): more surface, an extra
+  round-trip at create, no benefit since the physical VM is already a session VM and only its
+  bookkeeping was wrong. Rejected the unguarded adopt: it would let a task-class primed vm_id
+  be hijacked as a session (broke `TestSessionAssignTaskClassVMRejected`); the workload guard
+  restores that invariant as defense-in-depth (the control plane never names a foreign vm_id,
+  but noded enforces it anyway).
+- **Two secondaries fixed in the same PR:** (1) `Session.run_invoke` invalidated the SHARED
+  node channel on ANY invoke error, including a server-returned `%GRPC.RPCError{}` that rode a
+  healthy channel; tearing it down would disconnect every other session multiplexed on it.
+  Now `maybe_invalidate/3` invalidates ONLY on a transport fault, never on a server gRPC
+  status. (2) `NodeChannel` had no `handle_info/2`, so the linked Mint connection's normal
+  `{:EXIT, _, :normal}` on every channel teardown logged a spurious `no_handle_info` error
+  report; added a swallowing clause. Both are hygiene, not the root cause.
+- **Honesty note on the closure:** ADR 001 marks R2 "Shipped 2026-07-15" (D-R2.7.1). The drill
+  showed the invoke path was functionally broken at that moment, so the label was optimistic
+  until this fix deploys and the drill re-runs green. The closure never claimed the gates
+  passed live (it flagged the drill as pending), so it is not false, but the plan Closure
+  section should gain a "post-ship fix" note once the drill is green. Flagged for Joe.

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.41
+version: 0.1.42

--- a/projects/embervm/control/lib/embervm/node_channel.ex
+++ b/projects/embervm/control/lib/embervm/node_channel.ex
@@ -119,6 +119,17 @@ defmodule Embervm.NodeChannel do
   end
 
   @impl true
+  def handle_info(_msg, state) do
+    # The Mint connection process this GenServer dials is LINKED to it, so when
+    # invalidate/terminate disconnects a channel, a normal-reason {:EXIT, pid,
+    # :normal} is delivered here. It is expected and benign: invalidate already
+    # erased and disconnected the channel, and the next get/1 re-dials. Swallow it
+    # (and any other stray info) rather than let it hit the default handle_info and
+    # log a spurious no_handle_info error report on every channel teardown.
+    {:noreply, state}
+  end
+
+  @impl true
   def terminate(_reason, state) do
     # Drop every cached channel so a restart re-dials cleanly and no channel
     # outlives this holder in persistent_term.

--- a/projects/embervm/control/lib/embervm/session.ex
+++ b/projects/embervm/control/lib/embervm/session.ex
@@ -372,13 +372,25 @@ defmodule Embervm.Session do
              }, Embervm.Usage.from_proto(usage)}
 
           {:error, reason} ->
-            _ = ctx.invalidate_fun.(ctx.node_id, channel)
+            maybe_invalidate(ctx, channel, reason)
             {:error, classify_error(reason)}
         end
 
       {:error, reason} ->
         {:error, {:no_channel, reason}}
     end
+  end
+
+  # Only a TRANSPORT fault means the shared node channel is bad and must be torn
+  # down. A server-returned gRPC status (%GRPC.RPCError{}) rode a HEALTHY channel to
+  # get here, so invalidating it would needlessly disconnect every other session
+  # sharing that channel (D-R2.7.2). Leave the channel up on any server status;
+  # invalidate only on a raw transport error (Mint.TransportError, :closed, etc.).
+  defp maybe_invalidate(_ctx, _channel, %GRPC.RPCError{}), do: :ok
+
+  defp maybe_invalidate(ctx, channel, _reason) do
+    _ = ctx.invalidate_fun.(ctx.node_id, channel)
+    :ok
   end
 
   defp classify_error(%GRPC.RPCError{status: 4}), do: :deadline_exceeded

--- a/projects/embervm/control/test/embervm/session_bank_relight_test.exs
+++ b/projects/embervm/control/test/embervm/session_bank_relight_test.exs
@@ -76,7 +76,7 @@ defmodule Embervm.SessionBankRelightTest do
       channel_fun: fn _node -> {:ok, :ch} end,
       assign_fun: assign_fun,
       destroy_fun: fn _ch, vm -> send(test_pid, {:destroyed, vm}) && {:ok, %{}} end,
-      invalidate_fun: fn _node, _ch -> :ok end
+      invalidate_fun: Keyword.get(opts, :invalidate_fun, fn _node, _ch -> :ok end)
     ]
 
     mgr_opts =
@@ -367,6 +367,42 @@ defmodule Embervm.SessionBankRelightTest do
     assert session.terminal_reason == "snapshot_lost"
     # The lost snapshot was evicted.
     assert_received {:evicted, _ref}
+  end
+
+  test "a server-returned gRPC status on invoke does NOT invalidate the shared node channel" do
+    test_pid = self()
+
+    ctx =
+      start_stack(
+        # A FAILED_PRECONDITION from the daemon rode a HEALTHY channel to get here.
+        assign_fun: fn _ch, _req -> {:error, %GRPC.RPCError{status: 9, message: "boom"}} end,
+        invalidate_fun: fn node, ch -> send(test_pid, {:invalidated, node, ch}) && :ok end
+      )
+
+    put_workload(ctx, "wl")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+
+    assert {:error, {:rpc, 9}} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"})
+    # The shared channel must NOT be torn down on a server status (D-R2.7.2): doing
+    # so would disconnect every other session multiplexed on that channel.
+    refute_receive {:invalidated, _, _}, 200
+  end
+
+  test "a transport error on invoke DOES invalidate the shared node channel" do
+    test_pid = self()
+
+    ctx =
+      start_stack(
+        # A raw transport fault (not a %GRPC.RPCError{}) means the channel is bad.
+        assign_fun: fn _ch, _req -> {:error, :closed} end,
+        invalidate_fun: fn node, ch -> send(test_pid, {:invalidated, node, ch}) && :ok end
+      )
+
+    put_workload(ctx, "wl")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+
+    assert {:error, :closed} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"})
+    assert_receive {:invalidated, _, _}, 200
   end
 
   # -- adoption matrix -------------------------------------------------------

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.41
+      targetRevision: 0.1.42
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/registry.go
+++ b/projects/embervm/noded/server/registry.go
@@ -77,6 +77,38 @@ func (r *vmRegistry) claimForAssign(id string) (*vmEntry, bool) {
 	return e, true
 }
 
+// claimForSession atomically REMOVES a primed VM from the task registry so it can
+// be adopted into the session registry on a session's first SessionAssign. The
+// create path primes/claims a session's VM through the shared warm pool, so it
+// lands here in the task registry (Prime always adds here); the first SessionAssign
+// promotes it out of this registry and into the session registry (see
+// Server.adoptPrimedSession). Returns (nil,false) when the id is unknown or not
+// primed (already assigned, destroyed, or already adopted), which SessionAssign
+// maps to FAILED_PRECONDITION. It also requires the primed VM's workload to MATCH
+// the adopting session's workload: a session may only adopt a VM primed from its own
+// (class:session) base, so a task-class primed vm_id can never be hijacked as a
+// session VM (defense in depth; the control plane never names a foreign vm_id). An
+// empty workload never matches a real VM, so it always rejects. Unlike claimForAssign
+// this DELETES the entry: the VM is leaving the task registry entirely to live as a
+// session VM, so it must never be reported as a primed task slot again.
+func (r *vmRegistry) claimForSession(id, workload string) (*vmEntry, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e, ok := r.vms[id]
+	if !ok {
+		return nil, false
+	}
+	e.mu.Lock()
+	if e.state != vmPrimed || e.workload != workload {
+		e.mu.Unlock()
+		return nil, false
+	}
+	e.state = vmAssigned
+	e.mu.Unlock()
+	delete(r.vms, id)
+	return e, true
+}
+
 // remove deletes an id from the map and returns its entry (nil if absent). Used
 // by Assign's single-use teardown and by Destroy's idempotent reap.
 func (r *vmRegistry) remove(id string) *vmEntry {

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -674,6 +674,36 @@ func (s *Server) liveVMCount() int {
 
 // ---- Session verbs (R2) ----------------------------------------------------
 
+// adoptPrimedSession promotes a primed VM from the task registry into the session
+// registry on a session's FIRST invoke. The session-create path primes/claims the
+// VM through the shared warm pool (Prime always lands it in the task registry), so
+// something has to move it into the session registry before SessionAssign can serve
+// it; doing that lazily on first invoke (rather than via a separate create-time
+// verb) keeps create a single round-trip and mirrors how Relight registers a relit
+// VM. It returns the new session entry with the in-flight guard ALREADY held (so a
+// racing second SessionAssign gets rejected until this one finishes), or (nil,false)
+// when vmID is not a primed task VM (unknown, already assigned/adopted, destroyed),
+// which SessionAssign maps to FAILED_PRECONDITION. The physical VM is already a
+// session-base VM (restored from the session workload's base, running the persistent
+// kernel); only its registry bookkeeping changes.
+func (s *Server) adoptPrimedSession(vmID, sessionID, workload string) (*sessionEntry, bool) {
+	ve, ok := s.vms.claimForSession(vmID, workload)
+	if !ok {
+		return nil, false
+	}
+	se := &sessionEntry{
+		vmID:        ve.id,
+		sessionID:   sessionID,
+		workload:    workload,
+		snapshotRef: ve.snapshotRef,
+		handle:      ve.handle,
+		inFlight:    true, // held for the SessionAssign that triggered this adoption
+	}
+	s.sessionVMs.add(se)
+	s.signalChange() // the VM moved primed -> session-live; refresh NodeStatus
+	return se, true
+}
+
 // SessionAssign delivers exactly one HTTP task to a LIVE session vm_id over vsock
 // and returns the guest response plus usage WITHOUT destroying the VM (the
 // opposite of Assign's single-use destroy tail: a session survives across
@@ -686,10 +716,18 @@ func (s *Server) SessionAssign(ctx context.Context, req *nodev1.SessionAssignReq
 	vmID := req.GetVmId()
 	e, ok := s.sessionVMs.beginInFlight(vmID)
 	if !ok {
-		// Unknown session VM, or an op already in flight on it (a concurrent
-		// SessionAssign or an in-progress Bank). Task-class VMs live in a different
-		// registry and are never found here.
-		return nil, status.Errorf(codes.FailedPrecondition, "noded: session vm %q not assignable (unknown, task-class, mid-bank, or a call is already in flight)", vmID)
+		// Not (yet) in the session registry. A freshly CREATED session's VM was
+		// primed/claimed through the shared warm pool, so it still lives in the task
+		// registry on its FIRST invoke; adopt it into the session registry now
+		// (mirroring how Relight registers a relit VM). A relit session's VM is
+		// already here, so this branch only runs once per session's lifetime. A
+		// genuinely unknown, already-adopted, mid-bank, or in-flight vm_id still
+		// fails FAILED_PRECONDITION.
+		adopted, ok2 := s.adoptPrimedSession(vmID, req.GetSessionId(), req.GetTrace().GetWorkload())
+		if !ok2 {
+			return nil, status.Errorf(codes.FailedPrecondition, "noded: session vm %q not assignable (unknown, task-class, mid-bank, or a call is already in flight)", vmID)
+		}
+		e = adopted
 	}
 	// The VM SURVIVES: clear the in-flight guard on return, never reap.
 	defer e.endInFlight()

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -420,6 +420,15 @@ func seedBase(s *Server, snapshotRef, workload string) {
 	s.bases.readyBuild(snapshotRef, workload, "img@sha256:deadbeef", "/shim/ready", 2048)
 }
 
+func contains(ids []string, id string) bool {
+	for _, s := range ids {
+		if s == id {
+			return true
+		}
+	}
+	return false
+}
+
 // TestPrimeAssignAutoDestroy is the core lifecycle: Prime parks a VM, Assign
 // delivers one task and returns the echoed guest response plus usage, and the VM
 // is destroyed exactly once after the response.
@@ -1123,6 +1132,91 @@ func TestSessionAssignTaskClassVMRejected(t *testing.T) {
 	}
 	if _, releases, _, _ := drv.counts(); releases != 0 {
 		t.Errorf("SessionAssign on a task VM reaped it: releases=%d, want 0", releases)
+	}
+}
+
+// TestSessionAssignAdoptsPrimedVM: a session's FIRST invoke arrives with its VM
+// still in the TASK registry, because create primes/claims through the shared warm
+// pool (Prime always lands a VM there). SessionAssign must ADOPT the primed VM of a
+// MATCHING workload into the session registry and serve the invoke; the VM then
+// SURVIVES as a session VM for subsequent invokes. This is the create->first-invoke
+// path the live drill found unwired (it returned FAILED_PRECONDITION -> 502).
+func TestSessionAssignAdoptsPrimedVM(t *testing.T) {
+	drv := &fakeDriver{}
+	tr := &fakeTransport{}
+	client, srv := newSessionTestServer(t, drv, tr, 8)
+	seedBase(srv, "sess__base01", "sandbox-session")
+	ctx := context.Background()
+
+	pr, err := client.Prime(ctx, &nodev1.PrimeRequest{SnapshotRef: "sess__base01"})
+	if err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	vmID := pr.GetVmId()
+
+	// Precondition: the primed VM is a primed TASK slot, not yet a session VM.
+	if primed, _ := srv.vms.capacity(); !contains(primed["sandbox-session"], vmID) {
+		t.Fatalf("primed VM %q not in the task registry before adoption", vmID)
+	}
+
+	// First invoke adopts (workload matches); second uses the normal session path.
+	for i := 0; i < 2; i++ {
+		resp, err := client.SessionAssign(ctx, &nodev1.SessionAssignRequest{
+			VmId:      vmID,
+			SessionId: "s-adopt",
+			Trace:     &nodev1.Trace{Workload: "sandbox-session"},
+			Request:   &nodev1.GuestRequest{Method: "POST", Path: "/invoke", Body: []byte("hi")},
+			TimeoutMs: 1000,
+		})
+		if err != nil {
+			t.Fatalf("SessionAssign %d (adopt): %v", i, err)
+		}
+		if got := string(resp.GetResponse().GetBody()); got != "ok:hi" {
+			t.Errorf("SessionAssign %d body = %q, want ok:hi", i, got)
+		}
+	}
+
+	// Postcondition: the VM left the task registry (never a primed slot again) and
+	// survived as one live session VM.
+	if primed, _ := srv.vms.capacity(); contains(primed["sandbox-session"], vmID) {
+		t.Errorf("adopted VM still reported as a primed task slot")
+	}
+	if _, releases, _, _ := drv.counts(); releases != 0 {
+		t.Errorf("adoption destroyed the VM: releases=%d, want 0", releases)
+	}
+	if got := drv.LiveCount(); got != 1 {
+		t.Errorf("LiveCount = %d, want 1 (one surviving session VM)", got)
+	}
+}
+
+// TestSessionAssignAdoptWorkloadMismatchRejected: a primed VM of a DIFFERENT
+// workload than the session is never hijacked as a session VM. The adopt guard
+// requires the primed VM's workload to equal the session's, so a mismatch stays
+// FAILED_PRECONDITION and leaves the primed VM untouched.
+func TestSessionAssignAdoptWorkloadMismatchRejected(t *testing.T) {
+	drv := &fakeDriver{}
+	tr := &fakeTransport{}
+	client, srv := newSessionTestServer(t, drv, tr, 8)
+	seedBase(srv, "other__base01", "other-workload")
+	ctx := context.Background()
+
+	pr, err := client.Prime(ctx, &nodev1.PrimeRequest{SnapshotRef: "other__base01"})
+	if err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	_, err = client.SessionAssign(ctx, &nodev1.SessionAssignRequest{
+		VmId:      pr.GetVmId(),
+		SessionId: "s-mismatch",
+		Trace:     &nodev1.Trace{Workload: "sandbox-session"}, // != the VM's workload
+		Request:   &nodev1.GuestRequest{Body: []byte("x")},
+		TimeoutMs: 1000,
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("code = %v, want FailedPrecondition (workload mismatch)", status.Code(err))
+	}
+	// The primed VM was NOT adopted or destroyed: still a primed task slot.
+	if primed, _ := srv.vms.capacity(); !contains(primed["other-workload"], pr.GetVmId()) {
+		t.Errorf("mismatched-workload primed VM was consumed by a failed adopt")
 	}
 }
 


### PR DESCRIPTION
## What the live drill caught
Running the R2 functional gate drill against the deployed stack showed **every first invoke on a freshly created session returned 502 and the session went `failed`** (Gate 6 token isolation passed; Gates 1/2 could not because invoke itself failed).

## Root cause
Session create primes/claims its VM through the shared warm pool, so noded's `Prime` lands it in the **task** registry (`s.vms`). But `SessionAssign` only accepts VMs from the disjoint **session** registry (`s.sessionVMs`), which until now was populated **only by `Relight`**. The create → first-invoke bridge was never wired: `SessionAssign` hit "unknown session VM" → `FAILED_PRECONDITION` (status 9) → control plane 502 → failed the session. Tasks work because task `Assign` reads the same `s.vms` that `Prime` writes.

Every unit test passed because each side was tested against its own fake; nothing drove a real control-plane → gRPC → noded session invoke end to end. Classic mock-hidden integration seam, and exactly why the live drill was worth running.

## Fix (Option C, simplest of three)
`SessionAssign` **adopts** a primed VM from the task registry into the session registry on the first invoke (`adoptPrimedSession` + `vmRegistry.claimForSession`), gated by a **workload match** so a task-class primed `vm_id` can never be hijacked as a session (preserves `TestSessionAssignTaskClassVMRejected`). The registry comment already anticipated this seam ("add registers a freshly relit **or primed-into-session** VM"). Rejected a new create-time noded verb (Option A/B): more surface + an extra round-trip, no benefit since the VM is physically already a session VM.

## Secondaries the drill surfaced
- `Session.run_invoke` invalidated the **shared** node channel on any invoke error, including a server-returned `%GRPC.RPCError{}` that rode a healthy channel (would disconnect every other session on it). Now `maybe_invalidate` tears down only on a transport fault.
- `NodeChannel` had no `handle_info/2`, so the linked Mint connection's normal `{:EXIT, _, :normal}` on every teardown logged a spurious `no_handle_info` error report. Added a swallowing clause.

## Tests
- Go: `TestSessionAssignAdoptsPrimedVM` (adopt + survive), `TestSessionAssignAdoptWorkloadMismatchRejected`.
- Elixir: server-status-does-not-invalidate-channel + transport-error-does.

DECISIONS.md **D-R2.7.2**. Bumps the embervm chart to **0.1.42**.

After merge + rollout I'll re-run the live drill to confirm Gates 1/2 go green, then note the post-ship fix in the R2 plan Closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)