### PR TITLE
fix(embervm): session invoke falls back to workload invokePath

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -712,3 +712,26 @@ Task 10 choices where the plan was silent (sessioned run_python across guest + c
   until this fix deploys and the drill re-runs green. The closure never claimed the gates
   passed live (it flagged the drill as pending), so it is not false, but the plan Closure
   section should gain a "post-ship fix" note once the drill is green. Flagged for Joe.
+
+### D-R2.7.3 Session invoke forwarded guest path "/" (shim serves only /invoke) -> 404; fixed to fall back to invokePath
+- The re-run drill (post D-R2.7.2) showed create->first-invoke now REACHES the guest
+  (the control-plane adoption fix worked: the 404 body was Go's `404 page not found`, not
+  the Elixir router's JSON, and the session SURVIVED the invoke = the guest's 4xx treated
+  as the guest's answer). But every invoke 404'd: the session invoke handler baked the
+  guest path to "/" when no `X-Ember-Guest-Path` header was set, and the sandbox shim's mux
+  serves ONLY `/invoke` (+`/invoke/`), so "/" hit the ServeMux default 404. This is the
+  SAME R1 baked-path trap the router's own comment warns about (baking "/" makes invokePath
+  dead), reintroduced on the session path. The real monolith client sets no guest-path
+  header either, so the session invoke was never wired end to end.
+- FIX (control-plane only, mirrors the R1/task default): `guest_path/1` returns nil when
+  `X-Ember-Guest-Path` is absent (was "/"); the Session process defaults a nil req path to
+  the workload's `invokePath` (`run_invoke`: `Map.get(ctx.req, :path) || ctx.invoke_path`).
+  `invoke_path` is threaded from the catalog entry through `start_session_process` (covers
+  both create and relight/adoption restart) with a "/invoke" default in `Session.init`. An
+  EXPLICIT X-Ember-Guest-Path still overrides. Tests: bare-invoke-forwards-invokePath +
+  explicit-path-overrides (Elixir). Bumps the embervm chart to 0.1.43.
+- LESSON (recurring, now twice in R2): the sandbox shim mux is FIXED at /invoke regardless
+  of the workload spec, so any path the control plane forwards MUST resolve to the
+  workload's invokePath. Two integration seams (registry adoption D-R2.7.2, guest path
+  D-R2.7.3) were both invisible to every unit test because each side was faked; only the
+  live drill drove a real control-plane -> gRPC -> shim -> guest invoke. Flagged for Joe.

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.42
+version: 0.1.43

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -682,10 +682,10 @@ defmodule Embervm.Router do
   end
 
   defp guest_path(conn) do
-    case header_value(conn, @path_header) do
-      nil -> "/"
-      path -> path
-    end
+    # Only an EXPLICIT X-Ember-Guest-Path sets the guest path; absent, return nil so
+    # the session process falls back to the workload's invokePath (the shim serves
+    # only /invoke, so a baked "/" default 404s the guest, the R1 baked-path trap).
+    header_value(conn, @path_header)
   end
 
   # GET /v1/sessions/:id (management OR session token). The management-auth plug is

--- a/projects/embervm/control/lib/embervm/session.ex
+++ b/projects/embervm/control/lib/embervm/session.ex
@@ -115,6 +115,10 @@ defmodule Embervm.Session do
       # round-trip timeout, and (PR-4) the idle-bank delay.
       queue_cap: Keyword.fetch!(opts, :queue_cap),
       timeout_ms: Keyword.get(opts, :timeout_ms, 90_000),
+      # The guest path a bare invoke (no explicit X-Ember-Guest-Path) is forwarded
+      # to. Defaults to the shim's only route, /invoke; the create/restart paths pass
+      # the workload's configured invokePath so a custom path is honored.
+      invoke_path: Keyword.get(opts, :invoke_path, "/invoke"),
       idle_bank_ms: Keyword.get(opts, :idle_bank_ms, nil),
       session_store: Keyword.get(opts, :session_store, Embervm.SessionStore),
       # The SessionManager this process calls back to for a bank (node-global policy
@@ -285,6 +289,7 @@ defmodule Embervm.Session do
     workload = state.workload
     principal = state.principal
     timeout_ms = state.timeout_ms
+    invoke_path = state.invoke_path
     channel_fun = state.channel_fun
     invalidate_fun = state.invalidate_fun
     assign_fun = state.assign_fun
@@ -324,6 +329,7 @@ defmodule Embervm.Session do
             session_id: session_id,
             workload: workload,
             timeout_ms: timeout_ms,
+            invoke_path: invoke_path,
             req: req,
             channel_fun: channel_fun,
             invalidate_fun: invalidate_fun,
@@ -345,7 +351,10 @@ defmodule Embervm.Session do
       {:ok, channel} ->
         guest_req = %GuestRequest{
           method: Map.get(ctx.req, :method, "POST"),
-          path: Map.get(ctx.req, :path, "/"),
+          # Default the guest path to the workload's invokePath (the shim serves
+          # ONLY /invoke; a "/" default 404s the guest, the R1 baked-path trap). An
+          # EXPLICIT X-Ember-Guest-Path (req.path non-nil) still overrides.
+          path: Map.get(ctx.req, :path) || ctx.invoke_path,
           headers: Map.get(ctx.req, :headers, %{}),
           body: Map.get(ctx.req, :body, "")
         }

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -509,6 +509,10 @@ defmodule Embervm.SessionManager do
         vm_id: vm_id,
         queue_cap: entry.session.invoke_queue_cap,
         timeout_ms: entry.timeout_ms,
+        # The guest path a bare invoke falls back to (the shim serves only the
+        # workload's invokePath; a "/" default 404s the guest). Both the create and
+        # the relight/adoption restart paths reach here with the catalog entry.
+        invoke_path: Map.get(entry, :invoke_path) || "/invoke",
         # Arm the idle-bank timer (Task 7): a live session with zero in-flight and
         # zero queued invokes for this long calls back to bank/2. Zero disables it.
         idle_bank_ms: entry.session.idle_bank_seconds * 1000,

--- a/projects/embervm/control/test/embervm/session_bank_relight_test.exs
+++ b/projects/embervm/control/test/embervm/session_bank_relight_test.exs
@@ -147,7 +147,7 @@ defmodule Embervm.SessionBankRelightTest do
       namespace: "embervm",
       class: "session",
       image_ref: "img@sha256:abc",
-      invoke_path: "/",
+      invoke_path: Keyword.get(opts, :invoke_path, "/"),
       timeout_ms: 90_000,
       cap: Keyword.get(opts, :cap, 8),
       floor: 1,
@@ -403,6 +403,51 @@ defmodule Embervm.SessionBankRelightTest do
 
     assert {:error, :closed} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"})
     assert_receive {:invalidated, _, _}, 200
+  end
+
+  test "a bare invoke (no explicit path) forwards the workload's invokePath to the guest" do
+    test_pid = self()
+
+    capture_assign = fn _ch, req ->
+      send(test_pid, {:guest_path, req.request.path})
+
+      {:ok,
+       %SessionAssignResponse{
+         response: %GuestResponse{status_code: 200, headers: %{}, body: req.request.body},
+         usage: %UsageStats{cpu_ms: 1, peak_rss_mib: 1, wall_ms: 1},
+         suspect: false
+       }}
+    end
+
+    ctx = start_stack(assign_fun: capture_assign)
+    # The shim serves only /invoke; a bare invoke must forward THAT, not "/".
+    put_workload(ctx, "wl", invoke_path: "/invoke")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+
+    {:ok, _} = SessionManager.invoke(ctx.mgr, created.session_id, %{body: "x"})
+    assert_receive {:guest_path, "/invoke"}
+  end
+
+  test "an explicit request path overrides the workload invokePath" do
+    test_pid = self()
+
+    capture_assign = fn _ch, req ->
+      send(test_pid, {:guest_path, req.request.path})
+
+      {:ok,
+       %SessionAssignResponse{
+         response: %GuestResponse{status_code: 200, headers: %{}, body: req.request.body},
+         usage: %UsageStats{cpu_ms: 1, peak_rss_mib: 1, wall_ms: 1},
+         suspect: false
+       }}
+    end
+
+    ctx = start_stack(assign_fun: capture_assign)
+    put_workload(ctx, "wl", invoke_path: "/invoke")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+
+    {:ok, _} = SessionManager.invoke(ctx.mgr, created.session_id, %{path: "/custom", body: "x"})
+    assert_receive {:guest_path, "/custom"}
   end
 
   # -- adoption matrix -------------------------------------------------------

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.42
+      targetRevision: 0.1.43
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Second seam the live drill caught (after #3551)
The re-run drill showed the D-R2.7.2 adoption fix worked: create → first-invoke now **reaches the guest** (404 body was Go's `404 page not found`, not the Elixir router's JSON, and the session **survived** the invoke — the control plane correctly treats a guest 4xx as the guest's answer). But every invoke 404'd.

## Root cause
The session invoke handler baked the guest path to `/` when no `X-Ember-Guest-Path` header was set, but the sandbox shim's mux serves **only** `/invoke` (+`/invoke/`) — everything else is the ServeMux default 404. Same R1 baked-path trap the router's own comment warns about (`baking "/" made invokePath dead`), reintroduced on the session path. The real monolith client sets no guest-path header either, so session invoke was never wired end to end.

## Fix (control-plane only, mirrors the R1/task default)
- `guest_path/1` returns `nil` when `X-Ember-Guest-Path` is absent (was `/`).
- The Session defaults a nil req path to the workload's `invokePath` (`run_invoke`: `req path || ctx.invoke_path`), threaded from the catalog entry through `start_session_process` (covers create + relight/adoption restart) with a `/invoke` default in `Session.init`.
- An explicit `X-Ember-Guest-Path` still overrides.

## Tests
Elixir: bare-invoke-forwards-invokePath + explicit-path-overrides.

DECISIONS.md **D-R2.7.3**. Bumps the embervm chart to **0.1.43**.

After merge + rollout I'll re-run the drill; this should carry Gates 1/2 to green (state persistence + relight). Both R2 seams (registry adoption, guest path) were invisible to unit tests because each side was faked — only the live drill drove a real control-plane → gRPC → shim → guest invoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)