### PR TITLE
fix(embervm): digest-version base rootfs (stop restore corruption) + child-lifecycle logging

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -735,3 +735,39 @@ Task 10 choices where the plan was silent (sessioned run_python across guest + c
   workload's invokePath. Two integration seams (registry adoption D-R2.7.2, guest path
   D-R2.7.3) were both invisible to every unit test because each side was faked; only the
   live drill drove a real control-plane -> gRPC -> shim -> guest invoke. Flagged for Joe.
+
+### D-R2.7.4 Session restore corrupted the guest FS (rootfs rebuilt in place); fixed by digest-versioning the rootfs file. Reaper is the flagged follow-on.
+- The re-run drill (8/9) exposed EXT4 corruption on restored guests
+  (`__ext4_find_entry ... checksumming directory block`, `comm python3`). ROOT CAUSE
+  (mapped): base MEMORY snapshots are per-digest (`snapshots/bases/<baseKey>/`), but the
+  read-only rootfs (vda) they reference is a SINGLE fixed file per workload
+  (`workloads.<name>.rootfsPath`). The FC memfile embeds the rootfs HOST PATH, not its
+  bytes, and restore (`driver.loadInto`) issues only LoadSnapshot, never re-PutDrive. The
+  rootfs-builder `mv -f`s that fixed file IN PLACE on any guest-digest change, so a chart
+  roll swaps the bytes under every banked session snapshot born on the old rootfs -> the
+  restored guest's page-cache ext4 metadata no longer matches on-disk blocks -> corruption.
+  Confirmed cross-version: it hit sessions banked pre-roll, relit post-roll. This is the
+  split-brain [[feedback]]: the control plane refcounts the birth base (base_builder.ex) but
+  the physical rootfs file is overwritten blind to that refcount.
+- FIX (tactical, CHART-ONLY, no Go change): digest-version the rootfs file. New helper
+  `embervm.noded.rootfsPath` renders `<dir>/rootfs-<guest-tag>.ext4`, used by BOTH the
+  rootfs-builder `BASE_ROOTFS_PATH` and the `EMBERVM_NODED_IMAGES[ref].rootfsPath` (one
+  source, so the built file and the path noded attaches are byte-identical -- the riskiest
+  coupling). The builder skips-if-the-digest-file-exists and NEVER overwrites/deletes other
+  `rootfs-*.ext4`. Because each guest version is now an immutable file and the memfile embeds
+  a stable per-digest path, restore re-attaches the correct (still-present) rootfs with NO
+  driver change. Rejected the full Go plan (record birth rootfs in baseEntry + re-PutDrive on
+  restore): unnecessary once the embedded path is immutable-by-construction. This is the
+  node-local form of the offsite versioned-store design (ADR 003), same invariant on nvme.
+- **FOLLOW-ON, flagged for Joe (the "TTL for flushing" half):** old `rootfs-*.ext4` files now
+  accumulate (~2GB each per deploy) until reaped. The reaper needs the refcount wiring:
+  when `base_builder.ex maybe_evict_base` fires EvictSnapshot for a superseded base (primed=0
+  AND sessions=0), also delete that digest's rootfs file (extend `RemoveBaseBundle`, which
+  exists but is unwired, to cover the rootfs path). Deferred: disk growth is slow and this is
+  not in active use. The strategic version is offsite S3/OCI export (ADR 003), where
+  immutability + TTL are free. Also deferred: a defensive `base_superseded` 410 if a birth
+  rootfs is ever missing on restore (belt-and-suspenders once the reaper can race a relight).
+- Also in this PR: guest-kernel child-lifecycle logging (generation counter + pid + the
+  session_reset decision, to the serial console noded captures) to DIAGNOSE the separate,
+  within-version `session_reset=true`-but-state-survived anomaly (gate 9). Not a fix yet:
+  the logging is the tooling to root-cause it on the next drill.

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.43
+version: 0.1.44

--- a/projects/embervm/chart/templates/_helpers.tpl
+++ b/projects/embervm/chart/templates/_helpers.tpl
@@ -51,3 +51,19 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- define "embervm.noded.serviceAccountName" -}}
 {{- include "embervm.noded.fullname" . -}}
 {{- end -}}
+
+{{/*
+Per-guest-digest rootfs path: <dir>/rootfs-<tag>.ext4, so each pinned guest-image
+version bakes its OWN read-only rootfs file instead of overwriting one fixed path.
+The Firecracker memfile embeds this host path (restore re-attaches it, never
+re-issuing PutDrive), so a chart roll that rebuilt the fixed file in place used to
+swap the bytes under every banked session snapshot -> EXT4 corruption on restore.
+Digest-naming makes the artifact immutable per version; old files persist until an
+(external) reaper drains them. Input: (dict "wl" $wl "top" $top). MUST be used by
+BOTH the rootfs-builder BASE_ROOTFS_PATH and the EMBERVM_NODED_IMAGES rootfsPath so
+the built file and the path noded attaches are byte-identical.
+*/}}
+{{- define "embervm.noded.rootfsPath" -}}
+{{- $suffix := .top.guestImage.tag | toString | replace ":" "-" | replace "@" "-" | replace "/" "-" -}}
+{{- printf "%s-%s.ext4" (trimSuffix ".ext4" .wl.rootfsPath) $suffix -}}
+{{- end -}}

--- a/projects/embervm/chart/templates/noded-deployment.yaml
+++ b/projects/embervm/chart/templates/noded-deployment.yaml
@@ -64,7 +64,7 @@ spec:
             - name: GUEST_IMAGE
               value: "{{ $top.guestImage.repository }}:{{ $top.guestImage.tag }}"
             - name: BASE_ROOTFS_PATH
-              value: {{ $wl.rootfsPath | quote }}
+              value: {{ include "embervm.noded.rootfsPath" (dict "wl" $wl "top" $top) | quote }}
             - name: ROOTFS_SIZE
               value: {{ $.Values.rootfsBuilder.rootfsSize | quote }}
             {{- if $.Values.imagePullSecret.enabled }}
@@ -155,7 +155,7 @@ spec:
               {{- $top := index $.Values $name }}
               {{- if and $top $top.guestImage $top.guestImage.repository }}
               {{- $ref := printf "%s:%s" $top.guestImage.repository $top.guestImage.tag }}
-              {{- $_ := set $imgs $ref (dict "rootfsPath" $wl.rootfsPath "harnessInit" $wl.harnessInit) }}
+              {{- $_ := set $imgs $ref (dict "rootfsPath" (include "embervm.noded.rootfsPath" (dict "wl" $wl "top" $top)) "harnessInit" $wl.harnessInit) }}
               {{- end }}
               {{- end }}
               value: {{ $imgs | toJson | quote }}

--- a/projects/embervm/chart/templates/noded-rootfs-builder-configmap.yaml
+++ b/projects/embervm/chart/templates/noded-rootfs-builder-configmap.yaml
@@ -22,15 +22,20 @@ data:
     : "${BASE_ROOTFS_PATH:?BASE_ROOTFS_PATH required}"
     size="${ROOTFS_SIZE:-2G}"
     base_dir="$(dirname "$BASE_ROOTFS_PATH")"
-    marker="$base_dir/.guest-ref"
     mkdir -p "$base_dir"
-    # Idempotent: skip the multi-GB rebuild when the base already matches the
-    # deployed guest image (pod restarts with an unchanged image are common).
-    if [ -f "$BASE_ROOTFS_PATH" ] && [ -f "$marker" ] && [ "$(cat "$marker")" = "$GUEST_IMAGE" ]; then
-      echo "base rootfs already current for $GUEST_IMAGE"
+    # BASE_ROOTFS_PATH is now DIGEST-VERSIONED (rootfs-<guest-tag>.ext4), so each
+    # guest image version has its OWN immutable file. Skip if this version's file
+    # already exists (a pod restart on an unchanged image, or a co-scheduled builder
+    # for a workload that shares this guest image). CRUCIAL: never overwrite or delete
+    # any other rootfs-*.ext4 here -- a banked session snapshot embeds the host path
+    # of the rootfs it was born on, so clobbering it corrupts that session's restore
+    # (the EXT4 checksum bug). Old versions are reaped out-of-band once no base or
+    # session references them; this builder only ever ADDS the current version.
+    if [ -f "$BASE_ROOTFS_PATH" ]; then
+      echo "base rootfs already present for this guest version: $BASE_ROOTFS_PATH"
       exit 0
     fi
-    echo "building base rootfs from $GUEST_IMAGE"
+    echo "building base rootfs from $GUEST_IMAGE -> $BASE_ROOTFS_PATH"
     rm -rf /work/root "$BASE_ROOTFS_PATH.tmp"
     mkdir -p /work/root
     # Pull the guest filesystem for THIS node's architecture (the builder image
@@ -43,6 +48,5 @@ data:
     crane export --platform "$platform" "$GUEST_IMAGE" - | tar -x -C /work/root
     mkfs.ext4 -q -F -L embervmbase -d /work/root "$BASE_ROOTFS_PATH.tmp" "$size"
     mv -f "$BASE_ROOTFS_PATH.tmp" "$BASE_ROOTFS_PATH"
-    echo "$GUEST_IMAGE" > "$marker"
     echo "base rootfs built at $BASE_ROOTFS_PATH ($size)"
 {{- end }}

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.43
+      targetRevision: 0.1.44
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/firecracker/sandbox/guest-init/internal/handler/kernel.go
+++ b/projects/firecracker/sandbox/guest-init/internal/handler/kernel.go
@@ -67,9 +67,15 @@ const (
 var sessionKernel = &kernel{}
 
 type kernel struct {
-	mu    sync.Mutex
-	cmd   *exec.Cmd
-	stdin io.WriteCloser
+	mu  sync.Mutex
+	cmd *exec.Cmd
+	// generation counts how many python children this kernel has started over its
+	// lifetime. It is the observability lever for the snapshot/restore question:
+	// if a relit VM logs a HIGHER generation than the bank captured, the guest-init
+	// spawned a fresh child on resume (state came from tmpfs/disk, not the child's
+	// memory); if it logs the SAME generation, the snapshotted child was reused.
+	generation int
+	stdin      io.WriteCloser
 	// r wraps the child stdout; buffered so a frame that arrives in several
 	// vsock/pipe reads is reassembled correctly (partial-read robustness).
 	r *bufio.Reader
@@ -132,6 +138,11 @@ func (k *kernel) run(code string, timeout time.Duration) (ExecResult, error) {
 	if err != nil {
 		return ExecResult{}, fmt.Errorf("handler: start session child: %w", err)
 	}
+	// The session_reset signal the caller sees, correlated with the child generation
+	// that served THIS snippet. On a relit VM the first invoke logs this: started=true
+	// + a bumped generation means the snapshotted child was NOT reused (the R2
+	// state-fidelity question); started=false means it was.
+	klog("session_invoke", "generation", k.generation, "started", started, "code_len", len(code))
 
 	start := time.Now()
 	resp, runErr := k.exchange(code, timeout)
@@ -173,7 +184,16 @@ func (k *kernel) run(code string, timeout time.Duration) (ExecResult, error) {
 // caller as SessionReset: a new child has an empty namespace). Caller holds mu.
 func (k *kernel) ensureChild() (bool, error) {
 	if k.cmd != nil && k.cmd.Process != nil {
+		klog("session_child_reuse", "generation", k.generation, "pid", k.cmd.Process.Pid)
 		return false, nil
+	}
+
+	// About to start a NEW child: record WHY the prior one was not reusable, so a
+	// post-restore fresh spawn is attributable (cmd_nil = kernel state was reset;
+	// process_nil = the child handle lost its OS process across resume).
+	reason := "process_nil"
+	if k.cmd == nil {
+		reason = "cmd_nil"
 	}
 
 	if err := os.MkdirAll(sessionWorkdir, 0o755); err != nil {
@@ -219,7 +239,21 @@ func (k *kernel) ensureChild() (bool, error) {
 	k.cmd = cmd
 	k.stdin = stdin
 	k.r = bufio.NewReaderSize(stdout, 64<<10)
+	k.generation++
+	klog("session_child_start", "generation", k.generation, "pid", cmd.Process.Pid, "reason", reason)
 	return true, nil
+}
+
+// klog writes one structured line to stderr, which the guest kernel wires to the
+// VM serial console (ttyS0); noded pipes the Firecracker process output to its own
+// stdout, so these land in `kubectl logs deploy/embervm-embervm-noded`. Keep the
+// prefix stable and greppable: "guest-kernel".
+func klog(event string, kv ...any) {
+	fmt.Fprintf(os.Stderr, "guest-kernel event=%s", event)
+	for i := 0; i+1 < len(kv); i += 2 {
+		fmt.Fprintf(os.Stderr, " %v=%v", kv[i], kv[i+1])
+	}
+	fmt.Fprintln(os.Stderr)
 }
 
 // exchange writes one request frame and reads one response frame, enforcing

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.84
+version: 0.4.85

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.84
+      targetRevision: 0.4.85
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.130
+version: 0.89.131
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.130
+      targetRevision: 0.89.131
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.205
+version: 0.285.206
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.205
+      targetRevision: 0.285.206
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What the drill caught (8/9)
The re-run R2 drill proved state persistence across bank/relight works, but the guest serial console (noded captures it) showed **EXT4 corruption on restored guests**: `__ext4_find_entry ... checksumming directory block, comm python3`.

## Root cause
Base **memory** snapshots are per-digest (`snapshots/bases/<baseKey>/`), but the read-only **rootfs** (`vda`) they reference is a **single fixed file per workload**. The Firecracker memfile embeds the rootfs **host path** (restore issues only `LoadSnapshot`, never re-`PutDrive`), and the rootfs-builder does `mv -f` over that fixed path on any guest-digest change. So a chart roll swaps the bytes under every banked session snapshot born on the old rootfs → the restored guest's cached ext4 metadata no longer matches on-disk blocks. Confirmed cross-version (hit sessions banked pre-roll, relit post-roll). The control plane refcounts the birth base, but the physical file was overwritten blind to that refcount — a split-brain.

## Fix (tactical, chart-only, no Go change)
Digest-version the rootfs file. New helper `embervm.noded.rootfsPath` renders `<dir>/rootfs-<guest-tag>.ext4`, used by **both** the rootfs-builder `BASE_ROOTFS_PATH` **and** `EMBERVM_NODED_IMAGES[ref].rootfsPath` (one source → the built file and the path noded attaches are byte-identical, the riskiest coupling). The builder skips-if-present per digest and **never overwrites or deletes** another `rootfs-*.ext4`. Each guest version is now immutable and the memfile embeds a stable per-digest path, so restore re-attaches the correct (still-present) rootfs with no driver change. Node-local form of the offsite versioned-store design (ADR 003).

## Follow-on (flagged, deferred)
Old `rootfs-*.ext4` accumulate (~2GB each per deploy) until reaped. Wire the reaper into `base_builder.ex maybe_evict_base` → `EvictSnapshot` (extend the unwired `RemoveBaseBundle` to the rootfs path) once a base's refs drain. Slow disk growth, not in active use. Strategic version = offsite S3/OCI export + TTL.

## Also: session_reset diagnostic logging
Guest kernel now logs child lifecycle (generation counter + pid + the `session_reset` decision) to the serial console noded captures — the tooling to root-cause the separate, within-version `session_reset=true`-but-state-survived anomaly (gate 9) on the next drill. Not a fix yet.

DECISIONS.md **D-R2.7.4**. Bumps embervm 0.1.44 + monolith 0.285.206 + monolith-public 0.89.131 + fc-invoke 0.4.85 (shared sandbox guest fan-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)