### PR TITLE
fix(embervm): route guest-kernel logs to /dev/console (make visibility real)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -771,3 +771,23 @@ Task 10 choices where the plan was silent (sessioned run_python across guest + c
   session_reset decision, to the serial console noded captures) to DIAGNOSE the separate,
   within-version `session_reset=true`-but-state-survived anomaly (gate 9). Not a fix yet:
   the logging is the tooling to root-cause it on the next drill.
+
+### D-R2.7.5 klog now writes to /dev/console (was inert on stderr); rootfs reaper DEFERRED to offsite ADR 003, not built node-local
+- The child-lifecycle klog shipped in #3553 wrote to guest-init os.Stderr, which does NOT
+  reach the VM serial console (only the kernel ring buffer does), so it never showed in
+  `kubectl logs ...noded` -- confirmed inert. Fixed: open /dev/console (the console=ttyS0
+  serial device noded pipes to its stdout; guest-init is root in prod so it can), fall back
+  to stderr for tests. Now the generation/pid/session_reset logs are actually observable.
+- **Rootfs reaper (the "TTL flush") deliberately NOT built node-local now.** The rootfs file
+  is SHARED across workloads (sandbox + sandbox-session resolve to ONE guest digest -> ONE
+  rootfs-<tag>.ext4), so a safe reaper must prove NO base AND NO session of ANY workload
+  references a digest before deleting it -- get it wrong and you delete a rootfs a live
+  session needs, re-introducing the exact D-R2.7.4 corruption (the highest-severity class in
+  this subsystem). That cross-workload refcount is free in the offsite immutable-store model
+  (object store refcounts by content hash), so a node-local reaper is both risky and
+  throwaway. RECOMMENDATION for Joe: fold the reaper into the offsite session-snapshot
+  distribution work (ADR 003 ExportBase/RestoreBase generalized to sessions); if node-local
+  disk pressure bites before then, an AGE-based sweep (delete rootfs-*.ext4 older than
+  max(maxLifetimeSeconds, bankedTtlSeconds)+margin and not the current digest) is a safe
+  stopgap because every session born on an older rootfs has hit its TTL and 410'd. Disk grows
+  ~2GiB/deploy until then; fine for a not-in-use system.

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.44
+version: 0.1.45

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.44
+      targetRevision: 0.1.45
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/firecracker/sandbox/guest-init/internal/handler/kernel.go
+++ b/projects/firecracker/sandbox/guest-init/internal/handler/kernel.go
@@ -248,12 +248,26 @@ func (k *kernel) ensureChild() (bool, error) {
 // VM serial console (ttyS0); noded pipes the Firecracker process output to its own
 // stdout, so these land in `kubectl logs deploy/embervm-embervm-noded`. Keep the
 // prefix stable and greppable: "guest-kernel".
-func klog(event string, kv ...any) {
-	fmt.Fprintf(os.Stderr, "guest-kernel event=%s", event)
-	for i := 0; i+1 < len(kv); i += 2 {
-		fmt.Fprintf(os.Stderr, " %v=%v", kv[i], kv[i+1])
+// klogSink is where guest-kernel structured logs go. guest-init's os.Stderr is NOT
+// wired to the VM serial console (only the kernel ring buffer is), so a stderr log
+// never reaches `kubectl logs deploy/embervm-embervm-noded` -- confirmed inert when
+// #3553 first shipped these logs. /dev/console IS the serial console (the guest
+// boots console=ttyS0, and noded pipes the Firecracker process output to its own
+// stdout), and guest-init runs as root in production so it can open it. Fall back to
+// stderr (tests, or if /dev/console is unavailable) so klog is always safe to call.
+var klogSink io.Writer = func() io.Writer {
+	if f, err := os.OpenFile("/dev/console", os.O_WRONLY, 0); err == nil {
+		return f
 	}
-	fmt.Fprintln(os.Stderr)
+	return os.Stderr
+}()
+
+func klog(event string, kv ...any) {
+	fmt.Fprintf(klogSink, "guest-kernel event=%s", event)
+	for i := 0; i+1 < len(kv); i += 2 {
+		fmt.Fprintf(klogSink, " %v=%v", kv[i], kv[i+1])
+	}
+	fmt.Fprintln(klogSink)
 }
 
 // exchange writes one request frame and reads one response frame, enforcing

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.85
+version: 0.4.86

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.85
+      targetRevision: 0.4.86
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.132
+version: 0.89.133
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.132
+      targetRevision: 0.89.133
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.207
+version: 0.285.208
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.207
+      targetRevision: 0.285.208
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
The child-lifecycle logging shipped in #3553 was **inert**: it wrote to guest-init `os.Stderr`, which isn't wired to the VM serial console (only the kernel ring buffer is), so it never reached `kubectl logs ...noded`. This opens `/dev/console` instead (the `console=ttyS0` serial device noded pipes to its stdout; guest-init runs as root in prod), falling back to stderr for tests. The generation/pid/`session_reset` logs are now observable for future R2.x/R3 guest debugging.

Also records **D-R2.7.5**: the rootfs reaper (the "TTL flush") is deliberately **not** built node-local — the rootfs file is shared across workloads, so a wrong reaper would delete a rootfs a live session needs (re-introducing the D-R2.7.4 corruption). Folded into the offsite ADR 003 work; an age-based sweep is noted as a safe stopgap if disk pressure bites first.

Bumps embervm 0.1.45 + monolith 0.285.208 + monolith-public 0.89.133 + fc-invoke 0.4.86 (shared sandbox guest fan-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)