### PR TITLE
fix(embervm): node envoy probes use tcpSocket not loopback-admin httpGet

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.48
+version: 0.1.49

--- a/projects/embervm/chart/templates/serving-envoy-daemonset.yaml
+++ b/projects/embervm/chart/templates/serving-envoy-daemonset.yaml
@@ -67,19 +67,19 @@ spec:
             - name: stats
               containerPort: {{ .Values.servingEnvoy.statsPort }}
           readinessProbe:
-            # Envoy's admin /ready reports listener + worker readiness. Admin is
-            # loopback-only, so the probe runs inside the pod against 127.0.0.1.
-            httpGet:
-              path: /ready
-              port: {{ .Values.servingEnvoy.adminPort }}
-              host: 127.0.0.1
+            # Probe the data listener, not the admin /ready. Admin binds loopback
+            # (127.0.0.1) for security, but a kubelet httpGet probe dials from the
+            # kubelet's namespace, so host 127.0.0.1 hits the node's loopback, not
+            # the pod's, and never reaches Envoy's admin. A tcpSocket probe on the
+            # main listener (0.0.0.0) is reachable at the pod IP and confirms Envoy
+            # is up and accepting connections, with no admin exposure or curl dep.
+            tcpSocket:
+              port: {{ .Values.servingEnvoy.listenerPort }}
             initialDelaySeconds: 2
             periodSeconds: 5
           livenessProbe:
-            httpGet:
-              path: /ready
-              port: {{ .Values.servingEnvoy.adminPort }}
-              host: 127.0.0.1
+            tcpSocket:
+              port: {{ .Values.servingEnvoy.listenerPort }}
             initialDelaySeconds: 5
             periodSeconds: 10
           resources:

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.48
+      targetRevision: 0.1.49
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.86
+version: 0.4.87

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.86
+      targetRevision: 0.4.87
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/operators/oci-model-cache/deploy/application.yaml
+++ b/projects/operators/oci-model-cache/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: oci-model-cache-operator
-      targetRevision: 0.2.4
+      targetRevision: 0.2.5
       helm:
         valueFiles:
           - $values/projects/operators/oci-model-cache/deploy/values.yaml

--- a/projects/operators/oci-model-cache/helm/oci-model-cache-operator/Chart.yaml
+++ b/projects/operators/oci-model-cache/helm/oci-model-cache-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: oci-model-cache-operator
 description: A Helm chart for the OCI Model Cache Operator - caches HuggingFace models as OCI artifacts
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: "latest"
 keywords:
   - oci


### PR DESCRIPTION
The R3 node Envoy DaemonSet (PR-3) crash-looped: 0/1 ready, SIGTERM every ~30s.

**Root cause:** the liveness/readiness probes were `httpGet /ready` with `host: 127.0.0.1` against the admin port. A kubelet `httpGet` probe dials from the kubelet's own network namespace, so `127.0.0.1` resolves to the *node's* loopback, not the pod's, and never reaches Envoy's loopback-bound admin. Three failed liveness probes → kill → restart, forever. (The CDS "initial fetch timed out" in the Envoy log is expected and harmless: no snapshot to serve until PR-4's publisher pushes one.)

**Fix:** probe the main data listener (`0.0.0.0:10000`) with a `tcpSocket` probe. Reachable at the pod IP, confirms Envoy is up and accepting connections, keeps admin loopback-only (no exposure), and needs no curl binary in the distroless Envoy image.

Chart bumped 0.1.48 → 0.1.49. Verified `helm template` renders the `tcpSocket` probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)