### PR TITLE
fix(embervm): node envoy RDS initial_fetch_timeout so the listener binds

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.49
+version: 0.1.50

--- a/projects/embervm/chart/templates/serving-envoy-configmap.yaml
+++ b/projects/embervm/chart/templates/serving-envoy-configmap.yaml
@@ -92,6 +92,13 @@ data:
                       config_source:
                         resource_api_version: V3
                         ads: {}
+                        # Without a timeout the listener warms forever (never binds)
+                        # until the first RDS push, so the pod fails its port probe
+                        # before the control plane is even live. A short timeout lets
+                        # the listener bind with an empty route table (404 until the
+                        # publisher pushes routes), so the node Envoy is ready as soon
+                        # as its process starts, decoupled from the control plane.
+                        initial_fetch_timeout: 5s
                       route_config_name: embervm-serving
                     http_filters:
                       - name: envoy.filters.http.router

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.49
+      targetRevision: 0.1.50
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Follow-up to the probe fix (#3560). The node Envoy pod still crash-looped after the probe change, and the live diagnosis showed `connect: connection refused` on the listener port: **nothing was listening on 10000**.

**Root cause:** the serving listener routes via dynamic RDS over ADS, and Envoy keeps a listener *warming* (never binds the port) until it receives the initial route config. With no snapshot pushed (the control-plane publisher is PR-4, not live yet), RDS never arrives, so the listener never binds, so any port probe fails and the pod restarts forever.

**Fix:** add `initial_fetch_timeout: 5s` to the RDS `config_source`. Envoy then activates the listener with an empty route table (404 until routes arrive) after the timeout, so the node Envoy is ready as soon as its process starts, decoupled from the control plane, which is the ADR embervm/001 data-plane-survives-control-plane-absence posture. The publisher populates routes when PR-4 goes live.

Chart bumped 0.1.49 → 0.1.50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)