### PR TITLE
fix(embervm): thread guest-init path into serving cold-boot (R3 drill fix)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.56
+version: 0.1.57

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.56
+      targetRevision: 0.1.57
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -258,8 +258,15 @@ const nicIfaceID = "eth0"
 // why the serving IP is pinned across bank/relight (D-R3.4.1).
 func (d *Driver) bootArgsFor(cb coldBootSpec) string {
 	args := d.cfg.KernelBootArgs
-	if d.cfg.HarnessInit != "" {
-		args += " init=" + d.cfg.HarnessInit
+	// Prefer the per-boot harness init (the serving cold-boot resolves it from the
+	// runtime image it boots) over the driver-global, which is empty on the daemon
+	// driver. Without init= the kernel finds no init and drops to /bin/sh.
+	harnessInit := cb.harnessInit
+	if harnessInit == "" {
+		harnessInit = d.cfg.HarnessInit
+	}
+	if harnessInit != "" {
+		args += " init=" + harnessInit
 	}
 	if nic := cb.nic; nic != nil {
 		iface := nic.IfaceName
@@ -575,6 +582,14 @@ type coldBootSpec struct {
 	vcpus      int
 	memMib     int
 	nic        *substrate.NICSpec
+	// harnessInit, when non-empty, is the guest-init path emitted as init=<path> on
+	// the kernel command line for THIS cold boot, overriding the driver-global
+	// cfg.HarnessInit. The serving cold-boot (ClaimServing) resolves it per call from
+	// the runtime image whose rootfs it boots (img.HarnessInit), because the daemon's
+	// driver-global HarnessInit is empty: without it the kernel finds no init and
+	// falls back to /bin/sh, so the shim never runs and the guest is reaped. Empty for
+	// task/session boots, which keep the driver-global (byte-unchanged).
+	harnessInit string
 	// handlerDiskPath, when non-empty, is a per-workload handler artifact (the
 	// verified zip bytes noded wrote host-side at BuildBase) attached as a SECOND
 	// read-only drive on a serving cold boot (D-R3.11.2). The guest reads the zip
@@ -705,10 +720,11 @@ func (d *Driver) ClaimServing(ctx context.Context, rootfsPath, harnessInit strin
 	if nic.HostDevName == "" {
 		return substrate.Handle{}, fmt.Errorf("driver: ClaimServing requires a host tap device")
 	}
-	// harnessInit currently rides driver-global cfg.HarnessInit (the serving rootfs
-	// boots the same shim init as every other guest); the parameter is carried so a
-	// per-image init override can be threaded later without a signature change.
-	_ = harnessInit
+	// The daemon driver's global HarnessInit is empty; the serving rootfs boots the
+	// same guest-init as every other guest, but that path lives in the runtime image
+	// config (img.HarnessInit), resolved by startServingFresh and passed here. Thread
+	// it into the boot so the kernel runs the guest-init (which reads the serving-port
+	// and handler-disk boot-args) instead of falling back to /bin/sh.
 	vcpus = orDefault(vcpus, d.cfg.VCPUs)
 	memMib = orDefault(memMib, d.cfg.MemMib)
 	nicCopy := nic
@@ -717,6 +733,7 @@ func (d *Driver) ClaimServing(ctx context.Context, rootfsPath, harnessInit strin
 		vcpus:           vcpus,
 		memMib:          memMib,
 		nic:             &nicCopy,
+		harnessInit:     harnessInit,
 		handlerDiskPath: handlerDiskPath,
 		handlerZipBytes: handlerZipBytes,
 	})

--- a/projects/embervm/noded/fcvm/driver/driver_test.go
+++ b/projects/embervm/noded/fcvm/driver/driver_test.go
@@ -354,6 +354,23 @@ func TestBootArgsForServingNIC(t *testing.T) {
 		t.Fatalf("bootArgsFor(empty) = %q, want %q", got, want)
 	}
 
+	// A per-boot harnessInit overrides the driver-global init= (the serving cold-boot
+	// resolves the guest-init path from the runtime image it boots).
+	if override := d.bootArgsFor(coldBootSpec{harnessInit: "/usr/bin/ember-guest-init"}); override != "console=ttyS0 init=/usr/bin/ember-guest-init" {
+		t.Fatalf("bootArgsFor(harnessInit override) = %q, want per-boot init=", override)
+	}
+
+	// Regression guard for the serving cold-boot bug: with the driver-global HarnessInit
+	// EMPTY (as on the daemon driver), a per-boot harnessInit MUST still emit init= or
+	// the kernel drops to /bin/sh and the shim never runs.
+	dNoGlobal := New(Config{KernelBootArgs: "console=ttyS0"}, &fakeLauncher{}, nil)
+	if none := dNoGlobal.bootArgsFor(coldBootSpec{}); none != "console=ttyS0" {
+		t.Fatalf("bootArgsFor(no global, no per-boot) = %q, want no init=", none)
+	}
+	if serving := dNoGlobal.bootArgsFor(coldBootSpec{harnessInit: "/init"}); serving != "console=ttyS0 init=/init" {
+		t.Fatalf("bootArgsFor(no global, per-boot init) = %q, want init=/init", serving)
+	}
+
 	// Serving NIC with no ServingPort (0): appends the ip= directive with a dotted
 	// netmask and NO ember.serving_port= token (the zero-guard: a serving VM whose
 	// port is unset stays on the vsock path).


### PR DESCRIPTION
## What

Third bug surfaced by the R3 live serving gate drill (under the base-provisioning fix #3567 and the sector-pad fix #3568). With the handler disk now readable, the serving guest boots far enough to reveal it has **no `init=`**: the kernel tries `rdinit=/init`, then `/sbin/init`, `/etc/init`, `/bin/init`, and finally `/bin/sh` ("can't access tty"), so the ember guest-init never runs, the shim never binds, `/shim/ready` never answers, and noded reaps the VM → edge 504.

## Root cause

`ClaimServing` received the resolved harness-init path (`img.HarnessInit`, passed by `startServingFresh`) but dropped it (`_ = harnessInit`) and relied on the driver-global `cfg.HarnessInit`, which is **empty** on the daemon driver, so `bootArgsFor` emitted no `init=`.

- BuildBase works because it boots via the per-image init (`img.HarnessInit`).
- Task/session VMs work because they **restore a snapshot** rather than cold-booting.
- Serving-fresh is the only cold-boot path that needs, and was missing, the per-boot init.

## Fix

Thread the per-boot `harnessInit` through `coldBootSpec` and prefer it in `bootArgsFor` (falling back to the driver-global). Task/session boots pass no per-boot init and are byte-unchanged. Test asserts the per-boot init overrides/supplies `init=` even when the driver-global is empty.

## Verification

Confirmed live on node-4: the cold-boot attaches the correct 0.1.56 runtime rootfs + padded handler.zip + NIC with correct boot-args, but the kernel cmdline had no `init=` and fell to `/bin/sh`. Re-drill after merge.

Chart bumped to 0.1.57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)