### PR TITLE
fix(embervm): mount /proc in guest-init for serving boot-arg reads (R3 drill fix)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.57
+version: 0.1.58

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.57
+      targetRevision: 0.1.58
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/python/guest-init/cmd/main.go
+++ b/projects/embervm/runtimes/python/guest-init/cmd/main.go
@@ -76,6 +76,11 @@ func run(logger *slog.Logger) error {
 	// backs every microVM restored from the one warm-base snapshot.
 	mountTmpfsTmp(logger)
 
+	// Mount /proc so the serving cold-boot boot-arg readers below can read
+	// /proc/cmdline; a raw FC boot leaves /proc unmounted. Must precede
+	// setServingPortEnv / setHandlerDiskEnv, which no-op without it.
+	mountProc(logger)
+
 	// A raw Firecracker boot hands PID 1 no environment (the kernel ignores the
 	// OCI image config), so the frozen-contract defaults the apko image bakes
 	// (EMBER_HANDLER etc.) are not present. Set PATH plus the zip-lane defaults

--- a/projects/embervm/runtimes/python/guest-init/cmd/mount_linux.go
+++ b/projects/embervm/runtimes/python/guest-init/cmd/mount_linux.go
@@ -23,3 +23,19 @@ func mountTmpfsTmp(logger *slog.Logger) {
 	}
 	logger.Info("mounted tmpfs on /tmp")
 }
+
+// mountProc mounts a procfs on /proc. A raw Firecracker boot hands PID 1 no
+// mounted /proc (there is no initramfs or init system to do it), so without
+// this /proc/cmdline is absent and the serving-port / handler-disk boot-arg
+// translation (setServingPortEnv / setHandlerDiskEnv) silently no-ops, leaving
+// a serving cold boot stuck on the vsock path with no handler. Task/session and
+// build boots never read the cmdline (they use vsock defaults + a /shim/hydrate
+// POST), which is why this was latent until serving needed it. Best-effort: an
+// already-mounted or failed /proc is logged, not fatal.
+func mountProc(logger *slog.Logger) {
+	if err := unix.Mount("proc", "/proc", "proc", 0, ""); err != nil {
+		logger.Warn("proc mount on /proc failed", "err", err)
+		return
+	}
+	logger.Info("mounted proc on /proc")
+}

--- a/projects/embervm/runtimes/python/guest-init/cmd/mount_other.go
+++ b/projects/embervm/runtimes/python/guest-init/cmd/mount_other.go
@@ -7,3 +7,6 @@ import "log/slog"
 // mountTmpfsTmp is a no-op off Linux; the guest is always Linux, this stub only
 // keeps the package building for host (e.g. darwin) builds.
 func mountTmpfsTmp(*slog.Logger) {}
+
+// mountProc is a no-op off Linux (see mountTmpfsTmp); the guest is always Linux.
+func mountProc(*slog.Logger) {}


### PR DESCRIPTION
## What

Fourth bug from the R3 live serving gate drill, under #3567 (base provisioning), #3568 (sector-pad), #3569 (init=). With guest-init now launched (init= fix), the shim still came up on **vsock, awaiting hydrate** despite `ember.serving_port=8080 ember.handler_disk=/dev/vdb` on the kernel cmdline.

## Root cause

guest-init reads `/proc/cmdline` to translate those tokens into `EMBER_SERVING_PORT` / `EMBER_HANDLER_ZIP`, but a raw Firecracker boot leaves `/proc` **unmounted** (no initramfs/init system). `os.ReadFile("/proc/cmdline")` failed → both setters silently no-op'd → shim stayed on the vsock default with no handler. Latent because task/session/build boots use vsock defaults + a `/shim/hydrate` POST and never read the cmdline.

## Fix

Mount a procfs on `/proc` in guest-init (`mountProc`) before the boot-arg readers. Best-effort, Linux-only with a no-op stub off Linux, mirroring `mountTmpfsTmp`. The cmdline parser and env-var names were already correct.

## Verification

Live on node-4: guest-init exec'd the shim, but the shim logged `serving on vsock port 1027 (awaiting hydrate)` and `setHandlerDiskEnv`'s success log never appeared → `/proc/cmdline` unreadable. Re-drill after merge, expecting TCP:8080 serving + handler import off `/dev/vdb`.

Chart bumped to 0.1.58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)