### PR TITLE
fix(embervm): host-network the serving Envoy to reach node-local VMs (R3 drill fix)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.58
+version: 0.1.59

--- a/projects/embervm/chart/templates/serving-envoy-daemonset.yaml
+++ b/projects/embervm/chart/templates/serving-envoy-daemonset.yaml
@@ -30,10 +30,18 @@ spec:
         prometheus.io/port: {{ .Values.servingEnvoy.statsPort | quote }}
         prometheus.io/path: "/stats/prometheus"
     spec:
-      # POD networking (NOT hostNetwork): the serving-VM tap IPs are node-local
-      # routable from pods via the PR-2 bridge, so an Envoy in the pod network can
-      # dial them directly. hostNetwork is the recorded fallback ONLY if the drill
-      # shows the CNI blocks pod->bridge traffic; it is NOT preemptively set.
+      # HOST networking: the serving-VM tap IPs live on the node-local serving bridge
+      # (embervm-serv0, 172.31.0.0/24) that noded creates on the host. A pod-network
+      # Envoy cannot reach that bridge (the R3 live gate drill confirmed it: the VM was
+      # live+published and noded's host-side health probe reached it, but the Envoy's
+      # upstream connections to 172.31.0.x failed with connect errors), so the Envoy
+      # must share the node's netns to dial the VMs directly. This was the recorded
+      # fallback in the original pod-network design; the drill promoted it to the
+      # default. dnsPolicy ClusterFirstWithHostNet keeps cluster DNS working (a
+      # hostNetwork pod otherwise inherits the node resolv.conf) so the Envoy can still
+      # resolve and reach the xDS sidecar over the cluster network.
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       {{- with .Values.servingEnvoy.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.58
+      targetRevision: 0.1.59
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## What

Fifth and final gap from the R3 live serving gate drill. After the four boot-side fixes (#3567 base provisioning, #3568 sector-pad, #3569 init=, #3570 /proc mount), the serving cold boot fully works, the VM boots, serves TCP:8080 with the handler imported, passes noded's health gate, and the control plane publishes it (`live:1, published:1`). But the edge still 503s.

## Root cause

The serving-envoy DaemonSet ran on the **pod network** (10.42.x). The serving-VM tap IPs live on the **node-local serving bridge** (`embervm-serv0`, 172.31.0.0/24) that noded creates on node-4's host. noded's host-side health probe reaches the VM (that's why it's live+published), but a pod-network Envoy has no route to the node-local bridge, so its upstream connections fail:

```
cluster.serve|serving-og-image.membership_healthy: 1
cluster.serve|serving-og-image.upstream_cx_connect_fail: 4
cluster.serve|serving-og-image.external.upstream_rq_5xx: 12
```

## Fix

`hostNetwork: true` (+ `dnsPolicy: ClusterFirstWithHostNet` so cluster DNS still resolves the xDS sidecar) so the Envoy shares node-4's netns and dials the VMs directly on the bridge. The original DaemonSet comment recorded hostNetwork as the fallback "if the drill shows the CNI blocks pod->bridge traffic", the drill showed exactly that.

## Verification

Live on node-4: `serving-status` reached `live:1, published:1`, the shim logged `serving on TCP 0.0.0.0:8080 ... (ready)`, but Envoy `/stats` showed `upstream_cx_connect_fail` with a healthy membership. Re-drill after merge, expecting the first end-to-end 200.

Chart bumped to 0.1.59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)