### PR TITLE
fix(embervm): dynamic base-id for host-networked serving Envoy (R3 drill fix)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.59
+version: 0.1.60

--- a/projects/embervm/chart/templates/serving-envoy-daemonset.yaml
+++ b/projects/embervm/chart/templates/serving-envoy-daemonset.yaml
@@ -70,6 +70,14 @@ spec:
             - $(NODE_NAME)
             - --service-cluster
             - {{ include "embervm.servingEnvoy.fullname" . }}
+            # Allocate a free hot-restart base id at startup instead of the default 0.
+            # This pod is hostNetwork (to reach the node-local serving bridge), so it
+            # shares node-4's abstract socket namespace with every other Envoy on the
+            # node (e.g. the CNI / gateway data plane); two processes at base_id=0
+            # collide on the domain socket ("unable to bind domain socket with
+            # base_id=0, errno=98"), crash-looping this Envoy. Dynamic base id avoids
+            # the collision without hardcoding a per-node id.
+            - --use-dynamic-base-id
           env:
             - name: NODE_NAME
               valueFrom:

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.59
+      targetRevision: 0.1.60
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## What

Follow-up to the hostNetwork fix (#3571). The host-networked serving Envoy crash-looped (CrashLoopBackOff, 7 restarts):

```
unable to bind domain socket with base_id=0, errno=98 (see --base-id option)
```

## Root cause

Envoy's `base_id` keys a per-process hot-restart shared-memory / domain-socket region and defaults to 0. A pod netns isolates it, but a **hostNetwork** pod shares node-4's abstract socket namespace with every other Envoy on the node (the CNI / gateway data plane), so two Envoys at `base_id=0` collide.

## Fix

Add `--use-dynamic-base-id` so this Envoy allocates a free base id at startup, avoiding the collision without hardcoding a per-node id. Supported since Envoy 1.15 (image is v1.31).

## Verification

Live: the host-networked Envoy pod reported `hostNet:true, podIP=<node-4 host IP>` but CrashLoopBackOff with the base_id=0 bind error. Re-drill after merge, expecting the Envoy to stay up and the first end-to-end 200.

Chart bumped to 0.1.60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)