### PR TITLE
fix(embervm): report only cold-bootable serving images (skip stale bases)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.60
+version: 0.1.61

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.60
+      targetRevision: 0.1.61
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1270,6 +1270,24 @@ func (s *Server) workloadCapacities(primed map[string][]string) []*nodev1.Worklo
 	// never snapshot_ref. A workload may have both (a base snapshot for the task lane
 	// AND a serving image for the serving lane); they are independent facts.
 	for _, si := range s.servingImage.snapshot() {
+		// Only report a serving image whose runtime rootfs is STILL provisioned on
+		// this node. A serving cold boot attaches that runtime rootfs as drive 1
+		// (startServingFresh resolves si.runtimeImageRef against s.cfg.Images), so a
+		// base built against a since-superseded runtime image, whose rootfs is gone
+		// after the node rolled, is not cold-bootable. Old serving bases are not GC'd,
+		// so after a runtime roll multiple serving bases coexist per workload, and the
+		// snapshot() map order is nondeterministic; reporting a stale one makes the
+		// control plane place a wake on it and get FAILED_PRECONDITION "runtime image
+		// ... not provisioned" (a transient post-roll 503). Filtering to
+		// provisioned-runtime bases keeps the reported serving_image_ref always
+		// cold-bootable; if a workload has ONLY stale bases, it reports none and the
+		// control plane rebuilds. Base GC of the stale bundles is a separate follow-up
+		// (D-R3.11.3); this makes them harmless to placement. When more than one base
+		// is provisioned (a brief runtime transition), any is cold-bootable, so the
+		// residual nondeterminism cannot cause a 503.
+		if _, ok := s.cfg.Images[si.runtimeImageRef]; !ok {
+			continue
+		}
 		c := get(si.workload)
 		c.ServingImageRef = si.baseKey
 	}

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -1040,6 +1040,45 @@ func TestBuildBaseZipServingWritesHandlerArtifact(t *testing.T) {
 	})
 }
 
+// TestWorkloadCapacitiesSkipsStaleServingImage: workloadCapacities reports only a
+// serving image whose runtime rootfs is STILL provisioned in cfg.Images. A base
+// built against a since-superseded runtime (its rootfs pruned when the node rolled)
+// is not cold-bootable, so it must not be offered to serving placement, otherwise
+// the control plane wakes onto it and gets FAILED_PRECONDITION "runtime image ...
+// not provisioned" (the transient post-roll 503, D-R3.11.3). Old serving bases are
+// not GC'd, so multiple coexist per workload and the registry map order is
+// nondeterministic; the filter makes the reported ref always cold-bootable.
+func TestWorkloadCapacitiesSkipsStaleServingImage(t *testing.T) {
+	s := New(Options{
+		Config: config.Config{
+			Arch: "amd64", Node: "node-4", SnapshotRoot: t.TempDir(),
+			BootReadyTimeout: time.Second,
+			// Only the current runtime is provisioned; runtime-python:1 was pruned.
+			Images: map[string]config.Image{"runtime-python:2": {RootfsPath: "/runtime2.ext4"}},
+		},
+		Driver:        &fakeDriver{},
+		ServingDriver: newFakeServingDriver(t.TempDir()),
+		Transport:     &fakeTransport{},
+		Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	// A stale serving base (runtime-python:1, gone) and the current one (runtime-python:2).
+	s.servingImage.add(servingImageEntry{baseKey: "wl__stale", workload: "wl", handlerPath: "/h1", runtimeImageRef: "runtime-python:1"})
+	s.servingImage.add(servingImageEntry{baseKey: "wl__current", workload: "wl", handlerPath: "/h2", runtimeImageRef: "runtime-python:2"})
+
+	var wl *nodev1.WorkloadCapacity
+	for _, c := range s.workloadCapacities(map[string][]string{}) {
+		if c.GetWorkload() == "wl" {
+			wl = c
+		}
+	}
+	if wl == nil {
+		t.Fatal("no capacity reported for workload wl")
+	}
+	if got := wl.GetServingImageRef(); got != "wl__current" {
+		t.Fatalf("serving_image_ref = %q, want wl__current (the provisioned-runtime base; the stale wl__stale must never be reported)", got)
+	}
+}
+
 func TestParseMemHeadroomMib(t *testing.T) {
 	cases := []struct {
 		maxRaw, curRaw string


### PR DESCRIPTION
## What

Fixes the transient post-roll 503 recorded as a follow-up in D-R3.11.3. After each runtime roll, noded keeps the old serving bases (not GC'd) alongside the new one, so multiple serving bases coexist per workload. `workloadCapacities` looped over all of them assigning `ServingImageRef` from a **nondeterministic map order**, so it could report a **stale** base whose runtime rootfs was pruned when the node rolled. The control plane then placed a wake on it and noded returned `FAILED_PRECONDITION "runtime image ... not provisioned"`, the 503 that appeared on the first drill after every roll.

## Fix

Report a serving image only when its runtime rootfs is still provisioned in `cfg.Images` (what `startServingFresh` resolves for drive 1), so the reported `serving_image_ref` is always cold-bootable. A workload with only stale bases reports none and the control plane rebuilds. Residual nondeterminism among multiple *provisioned* bases is harmless (all are cold-bootable). Unit test asserts the stale base is never reported.

Base GC of the stale bundles is a separate follow-up (D-R3.11.3).

Bumps embervm chart to 0.1.61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)