### PR TITLE
fix(embervm): self-heal noded-restart channel wedge + serve handlers over GET

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.62
+version: 0.1.63

--- a/projects/embervm/control/lib/embervm/node_channel.ex
+++ b/projects/embervm/control/lib/embervm/node_channel.ex
@@ -78,6 +78,39 @@ defmodule Embervm.NodeChannel do
     GenServer.cast(server, {:invalidate, node_id, channel})
   end
 
+  @doc """
+  Whether `error` means the CHANNEL's transport is dead (so the cached channel
+  must be invalidated and re-dialed), as opposed to a server-returned gRPC status
+  that rode a HEALTHY channel (which must NOT tear the shared channel down, per
+  D-R2.7.2).
+
+  The subtle case this exists for: when a noded pod is replaced, its old
+  connection breaks, and the Mint gRPC adapter surfaces that as a
+  `%GRPC.RPCError{status: 2}` (UNKNOWN) whose message is a transport failure
+  ("...the connection is closed"), NOT as a raw `Mint.TransportError`. Callers that
+  treat every `%GRPC.RPCError{}` as a healthy-channel status therefore never
+  invalidate, and the node wedges (all Prime/StartServing/Assign fail with
+  "connection is closed" until the control plane restarts). This predicate catches
+  that wrapped shape as well as raw transport errors, so every call site can decide
+  invalidation consistently.
+  """
+  @spec transport_dead?(term()) :: boolean()
+  def transport_dead?(%GRPC.RPCError{status: 2, message: msg}) when is_binary(msg),
+    do: connection_closed_msg?(msg)
+
+  def transport_dead?(%GRPC.RPCError{}), do: false
+  def transport_dead?(:closed), do: true
+  # Mint's transport error, matched structurally so this module needs no compile-time
+  # dependency on the Mint struct definition.
+  def transport_dead?(%{__struct__: Mint.TransportError}), do: true
+  def transport_dead?({:error, reason}), do: transport_dead?(reason)
+  def transport_dead?(_), do: false
+
+  defp connection_closed_msg?(msg) do
+    m = String.downcase(msg)
+    String.contains?(m, "connection is closed") or String.contains?(m, "connection closed")
+  end
+
   # -- GenServer callbacks ---------------------------------------------------
 
   @impl true

--- a/projects/embervm/control/lib/embervm/pool_manager.ex
+++ b/projects/embervm/control/lib/embervm/pool_manager.ex
@@ -112,6 +112,7 @@ defmodule Embervm.PoolManager do
       dispatcher: Keyword.get(opts, :dispatcher, Embervm.Dispatcher),
       clock: Keyword.get(opts, :clock, &default_mono/0),
       channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
+      invalidate_fun: Keyword.get(opts, :invalidate_fun, &Embervm.NodeChannel.invalidate/2),
       prime_fun: Keyword.get(opts, :prime_fun, &default_prime/2),
       deposit_fun: Keyword.get(opts, :deposit_fun, &Embervm.Dispatcher.deposit/4),
       status_writer: Keyword.get(opts, :status_writer, &Embervm.K8s.patch_workload_status/3),
@@ -281,6 +282,7 @@ defmodule Embervm.PoolManager do
   defp start_prime_worker(state, node_id, wl, snapshot_ref) do
     owner = self()
     channel_fun = state.channel_fun
+    invalidate_fun = state.invalidate_fun
     prime_fun = state.prime_fun
 
     {pid, ref} =
@@ -290,11 +292,19 @@ defmodule Embervm.PoolManager do
             {:ok, channel} ->
               req = %PrimeRequest{trace: %Trace{workload: wl}, snapshot_ref: snapshot_ref || ""}
 
-              try do
-                prime_fun.(channel, req)
-              catch
-                kind, reason -> {:error, {kind, reason}}
-              end
+              res =
+                try do
+                  prime_fun.(channel, req)
+                catch
+                  kind, reason -> {:error, {kind, reason}}
+                end
+
+              # A transport death (a replaced noded pod's broken connection, wrapped
+              # by the Mint adapter as an RPCError) must tear the cached channel down
+              # so the NEXT refill tick re-dials; otherwise every Prime reuses the dead
+              # channel and the node wedges (Embervm.NodeChannel.transport_dead?/1).
+              maybe_invalidate_prime(res, invalidate_fun, node_id, channel)
+              res
 
             {:error, reason} ->
               {:error, {:connect, reason}}
@@ -466,4 +476,14 @@ defmodule Embervm.PoolManager do
   defp default_prime(channel, %PrimeRequest{} = req) do
     Embervm.Node.V1.NodeService.Stub.prime(channel, req)
   end
+
+  # Tear the shared channel down when a Prime failed because the channel's transport
+  # is dead, so the next refill tick re-dials to the (Service-DNS) node address. A
+  # server status leaves the channel up; only transport_dead?/1 shapes invalidate.
+  defp maybe_invalidate_prime({:error, reason}, invalidate_fun, node_id, channel) do
+    if Embervm.NodeChannel.transport_dead?(reason), do: invalidate_fun.(node_id, channel)
+    :ok
+  end
+
+  defp maybe_invalidate_prime(_result, _invalidate_fun, _node_id, _channel), do: :ok
 end

--- a/projects/embervm/control/lib/embervm/serving_manager.ex
+++ b/projects/embervm/control/lib/embervm/serving_manager.ex
@@ -158,6 +158,7 @@ defmodule Embervm.ServingManager do
       # Daemon serving-verb seams (injected for tests; production dials the real
       # NodeService stub over the shared NodeChannel).
       channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
+      invalidate_fun: Keyword.get(opts, :invalidate_fun, &Embervm.NodeChannel.invalidate/2),
       start_serving_fun: Keyword.get(opts, :start_serving_fun, &default_start_serving/2),
       # workload -> [{from, req, principal}] parked behind an in-flight wake, so
       # concurrent misses share ONE StartServing (single-flight). The first miss
@@ -958,7 +959,21 @@ defmodule Embervm.ServingManager do
 
   defp safe_start_serving(state, node_id, req) do
     with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
-      state.start_serving_fun.(channel, req)
+      case state.start_serving_fun.(channel, req) do
+        {:error, reason} = err ->
+          # A wake that failed because the channel's transport is dead (a replaced
+          # noded pod, wrapped by the Mint adapter as an RPCError) must tear the cached
+          # channel down so the NEXT miss re-dials; else serving stays wedged on that
+          # node until the control plane restarts (Embervm.NodeChannel.transport_dead?/1).
+          if Embervm.NodeChannel.transport_dead?(reason) do
+            _ = state.invalidate_fun.(node_id, channel)
+          end
+
+          err
+
+        other ->
+          other
+      end
     end
   rescue
     e -> {:error, {:start_serving_raised, e}}

--- a/projects/embervm/control/lib/embervm/session.ex
+++ b/projects/embervm/control/lib/embervm/session.ex
@@ -391,11 +391,21 @@ defmodule Embervm.Session do
   end
 
   # Only a TRANSPORT fault means the shared node channel is bad and must be torn
-  # down. A server-returned gRPC status (%GRPC.RPCError{}) rode a HEALTHY channel to
-  # get here, so invalidating it would needlessly disconnect every other session
-  # sharing that channel (D-R2.7.2). Leave the channel up on any server status;
-  # invalidate only on a raw transport error (Mint.TransportError, :closed, etc.).
-  defp maybe_invalidate(_ctx, _channel, %GRPC.RPCError{}), do: :ok
+  # down. A real server-returned gRPC status rode a HEALTHY channel to get here, so
+  # invalidating it would needlessly disconnect every other session sharing that
+  # channel (D-R2.7.2). BUT the Mint adapter WRAPS a transport death (a replaced noded
+  # pod's broken connection) as a %GRPC.RPCError{status: 2} "...the connection is
+  # closed": treating that as a healthy-channel status is what wedged the node on a
+  # noded pod restart, so invalidate when transport_dead?/1 recognises the wrapped
+  # shape. Any non-RPCError reason (raw transport error, closed socket) stays
+  # invalidate-always, unchanged.
+  defp maybe_invalidate(ctx, channel, %GRPC.RPCError{} = reason) do
+    if Embervm.NodeChannel.transport_dead?(reason) do
+      _ = ctx.invalidate_fun.(ctx.node_id, channel)
+    end
+
+    :ok
+  end
 
   defp maybe_invalidate(ctx, channel, _reason) do
     _ = ctx.invalidate_fun.(ctx.node_id, channel)

--- a/projects/embervm/control/test/embervm/node_channel_test.exs
+++ b/projects/embervm/control/test/embervm/node_channel_test.exs
@@ -94,4 +94,41 @@ defmodule Embervm.NodeChannelTest do
 
     assert {:error, :unknown_node} = NodeChannel.get(pid, "not-configured-#{System.unique_integer([:positive])}")
   end
+
+  describe "transport_dead?/1" do
+    test "a transport death WRAPPED as an RPCError (status 2, connection closed) is dead" do
+      # The exact shape the Mint gRPC adapter synthesises when a replaced noded pod's
+      # connection breaks: an UNKNOWN(2) RPCError whose message is a transport failure.
+      # Misclassifying this as a healthy-channel status is what wedged the node.
+      err = %GRPC.RPCError{
+        status: 2,
+        message: "error occurred while receiving data: {:error, \"the connection is closed\"}"
+      }
+
+      assert NodeChannel.transport_dead?(err)
+    end
+
+    test "a real server-returned gRPC status rode a HEALTHY channel (not dead)" do
+      # FAILED_PRECONDITION / RESOURCE_EXHAUSTED etc. are server verdicts: the channel
+      # is fine and must NOT be torn down (D-R2.7.2).
+      refute NodeChannel.transport_dead?(%GRPC.RPCError{status: 9, message: "snapshot lost"})
+      refute NodeChannel.transport_dead?(%GRPC.RPCError{status: 8, message: "cap reached"})
+      # An UNKNOWN(2) that is NOT a connection-closed message is also left as a status.
+      refute NodeChannel.transport_dead?(%GRPC.RPCError{status: 2, message: "boom"})
+    end
+
+    test "raw transport errors are dead" do
+      assert NodeChannel.transport_dead?(:closed)
+      assert NodeChannel.transport_dead?({:error, :closed})
+      # Mint's transport error is matched structurally (by __struct__), so the map form
+      # exercises the same clause without a compile-time dependency on the Mint struct.
+      assert NodeChannel.transport_dead?(%{__struct__: Mint.TransportError, reason: :closed})
+    end
+
+    test "unrelated reasons are not dead" do
+      refute NodeChannel.transport_dead?(:timeout)
+      refute NodeChannel.transport_dead?({:error, :whatever})
+      refute NodeChannel.transport_dead?(:some_atom)
+    end
+  end
 end

--- a/projects/embervm/control/test/embervm/pool_manager_test.exs
+++ b/projects/embervm/control/test/embervm/pool_manager_test.exs
@@ -26,10 +26,13 @@ defmodule Embervm.PoolManagerTest do
     {:ok, primes} = Agent.start_link(fn -> [] end)
     {:ok, status} = Agent.start_link(fn -> [] end)
 
-    prime_fun = fn _ch, %PrimeRequest{trace: %Trace{workload: wl}} ->
+    default_prime_fun = fn _ch, %PrimeRequest{trace: %Trace{workload: wl}} ->
       Agent.update(primes, &[wl | &1])
       {:ok, %PrimeResponse{vm_id: "vm-#{System.unique_integer([:positive])}"}}
     end
+
+    prime_fun = Keyword.get(opts, :prime_fun, default_prime_fun)
+    invalidate_fun = Keyword.get(opts, :invalidate_fun, fn _node, _chan -> :ok end)
 
     status_writer = fn _ns, name, map ->
       Agent.update(status, &[{name, map} | &1])
@@ -45,6 +48,7 @@ defmodule Embervm.PoolManagerTest do
           depth_table: depth_table,
           clock: fn -> 1_000_000 end,
           channel_fun: fn _ -> {:ok, :ch} end,
+          invalidate_fun: invalidate_fun,
           prime_fun: prime_fun,
           deposit_fun: fn _srv, _node, _wl, _vm -> :ok end,
           status_writer: status_writer,
@@ -84,6 +88,43 @@ defmodule Embervm.PoolManagerTest do
   defp prime_counts(ctx) do
     Process.sleep(50)
     ctx.primes |> Agent.get(& &1) |> Enum.frequencies()
+  end
+
+  test "a transport-dead Prime invalidates the channel so the next tick re-dials" do
+    # Regression for the noded-pod-restart wedge: a Prime failing because the channel's
+    # transport is dead (wrapped by the Mint adapter as an RPCError) must tear the
+    # cached channel down; otherwise every refill reuses the dead channel forever.
+    test_pid = self()
+    dead = %GRPC.RPCError{status: 2, message: "error occurred while receiving data: the connection is closed"}
+
+    ctx =
+      start_pool(
+        prime_fun: fn _ch, _req -> {:error, dead} end,
+        invalidate_fun: fn node_id, chan -> send(test_pid, {:invalidated, node_id, chan}) end
+      )
+
+    put_catalog(ctx, "wl", 1)
+    put_facts(ctx, [{"wl", 0}], max: 10)
+    :ok = PoolManager.refill(ctx.pool)
+
+    assert_receive {:invalidated, "node-4", :ch}, 1_000
+  end
+
+  test "a server-status Prime failure leaves the channel up (no needless invalidate)" do
+    test_pid = self()
+    server_err = %GRPC.RPCError{status: 9, message: "snapshot lost"}
+
+    ctx =
+      start_pool(
+        prime_fun: fn _ch, _req -> {:error, server_err} end,
+        invalidate_fun: fn node_id, chan -> send(test_pid, {:invalidated, node_id, chan}) end
+      )
+
+    put_catalog(ctx, "wl", 1)
+    put_facts(ctx, [{"wl", 0}], max: 10)
+    :ok = PoolManager.refill(ctx.pool)
+
+    refute_receive {:invalidated, _, _}, 300
   end
 
   test "floor-first: primes each workload up to its floor" do

--- a/projects/embervm/control/test/embervm/serving_manager_test.exs
+++ b/projects/embervm/control/test/embervm/serving_manager_test.exs
@@ -63,6 +63,7 @@ defmodule Embervm.ServingManagerTest do
         catalog_table: cat_table,
         clock: Keyword.get(opts, :clock, fn -> 1_000 end),
         channel_fun: fn _node -> {:ok, :ch} end,
+        invalidate_fun: Keyword.get(opts, :invalidate_fun, fn _node, _chan -> :ok end),
         start_serving_fun: start_serving_fun,
         reconcile_interval_ms: 0,
         id_fun: id_seq(suffix)
@@ -201,6 +202,44 @@ defmodule Embervm.ServingManagerTest do
     Agent.update(fail?, fn _ -> false end)
     assert {:ok, %{ip: "10.99.0.5", port: 8080}} = ServingManager.miss(ctx.mgr, "wl-a", req(), "serving:wl-a")
     assert ServingStore.published_endpoints(ctx.store, "wl-a") == [%{ip: "10.99.0.5", port: 8080}]
+  end
+
+  test "a transport-dead wake invalidates the channel so the next miss re-dials" do
+    # Regression for the noded-pod-restart wedge: a StartServing failing because the
+    # channel's transport is dead (wrapped as an RPCError) must tear the cached channel
+    # down, else serving stays wedged on that node until the control plane restarts.
+    test_pid = self()
+    dead = %GRPC.RPCError{status: 2, message: "error occurred while receiving data: the connection is closed"}
+
+    ctx =
+      start_stack(
+        start_serving_fun: fn _ch, _req -> {:error, dead} end,
+        invalidate_fun: fn node_id, chan -> send(test_pid, {:invalidated, node_id, chan}) end,
+        wake_max: 100
+      )
+
+    serving_workload(ctx, "wl-a")
+    serving_node(ctx, "node-4")
+
+    assert {:error, {:wake_failed, _}} = ServingManager.miss(ctx.mgr, "wl-a", req(), "serving:wl-a")
+    assert_receive {:invalidated, "node-4", :ch}, 1_000
+  end
+
+  test "a server-status wake failure leaves the channel up (no needless invalidate)" do
+    test_pid = self()
+
+    ctx =
+      start_stack(
+        start_serving_fun: fn _ch, _req -> {:error, %GRPC.RPCError{status: 9, message: "snapshot lost"}} end,
+        invalidate_fun: fn node_id, chan -> send(test_pid, {:invalidated, node_id, chan}) end,
+        wake_max: 100
+      )
+
+    serving_workload(ctx, "wl-a")
+    serving_node(ctx, "node-4")
+
+    assert {:error, {:wake_failed, _}} = ServingManager.miss(ctx.mgr, "wl-a", req(), "serving:wl-a")
+    refute_receive {:invalidated, _, _}, 300
   end
 
   # -- straggler -------------------------------------------------------------

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.62
+      targetRevision: 0.1.63
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/python/shim.py
+++ b/projects/embervm/runtimes/python/shim.py
@@ -359,12 +359,26 @@ def _encode_body(body: Any, is_b64: bool) -> bytes:
 def make_request_handler(
     state: ShimState,
     invoke_path: str,
+    *,
+    serving: bool = False,
 ) -> type[BaseHTTPRequestHandler]:
     """Build the BaseHTTPRequestHandler class serving the frozen contract.
 
     All handler/ready state lives in `state`, mutated by a successful hydrate.
     Before hydration /shim/ready reports 503 and any POST to the invoke path is
     503; /shim/healthz is 200 throughout so noded's Prime probe answers.
+
+    Two dispatch modes share this handler:
+
+    - Task/session (vsock, ``serving=False``): the guest is an RPC endpoint. The
+      handler is invoked ONLY on ``POST`` to ``invoke_path``; every other
+      method/path is 404. This is byte-unchanged from the frozen contract.
+    - Serving (TCP, ``serving=True``): the guest is a WEB SERVER, so it owns its
+      own routing. Every request whose path is not one of the reserved ``/shim/*``
+      contract paths is passed to the handler with its real method/path/query, so a
+      browser ``GET /...?title=...`` (an OG-image card, say) reaches the handler.
+      The reserved ``/shim/*`` namespace stays owned by the shim (health, ready,
+      hydrate); it is never routed to the handler.
     """
 
     class ShimHTTPRequestHandler(BaseHTTPRequestHandler):
@@ -381,7 +395,10 @@ def make_request_handler(
             # not chunked (noded's vsock transport rejects chunked framing).
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
-            if body:
+            # A HEAD response carries the headers (Content-Length included) but no
+            # body, per RFC 7231; serving mode invokes the handler to compute those
+            # headers, then suppresses the body here.
+            if body and self.command != "HEAD":
                 self.wfile.write(body)
 
         def do_GET(self) -> None:  # noqa: N802 (http.server naming)
@@ -395,17 +412,69 @@ def make_request_handler(
                 else:
                     self._send(503, {}, b"shim not ready: not hydrated")
                 return
+            # Serving mode: the guest is a web server, so a GET to any non-reserved
+            # path invokes the handler (a browser fetching an OG-image card, say).
+            # Task/session mode never serves a handler over GET: 404.
+            if serving:
+                self._serving_invoke()
+                return
             self._send(404, {}, b"not found")
 
         def do_POST(self) -> None:  # noqa: N802 (http.server naming)
             path = self.path.split("?", 1)[0]
-            query = self.path.split("?", 1)[1] if "?" in self.path else ""
             if path == HYDRATE_PATH:
                 self._handle_hydrate()
+                return
+            # Serving mode routes any non-reserved path to the handler; task/session
+            # mode invokes ONLY the exact invoke_path (the frozen RPC contract).
+            if serving:
+                self._serving_invoke()
                 return
             if path != invoke_path:
                 self._send(404, {}, b"not found")
                 return
+            self._invoke_handler()
+
+        # Serving mode: the web-app handler owns its routes and may use any verb.
+        # Each maps to the same handler dispatch; the reserved /shim/* namespace is
+        # guarded inside _serving_invoke. GET/POST are handled above (they also carry
+        # the task/session contract); these cover the rest of a REST surface.
+        def do_PUT(self) -> None:  # noqa: N802
+            self._serving_only()
+
+        def do_DELETE(self) -> None:  # noqa: N802
+            self._serving_only()
+
+        def do_PATCH(self) -> None:  # noqa: N802
+            self._serving_only()
+
+        def do_HEAD(self) -> None:  # noqa: N802
+            self._serving_only()
+
+        def do_OPTIONS(self) -> None:  # noqa: N802
+            self._serving_only()
+
+        def _serving_only(self) -> None:
+            # A non-GET/POST verb only makes sense in serving mode; task/session mode
+            # answers 405 (the RPC contract is POST-to-invoke_path only).
+            if serving:
+                self._serving_invoke()
+            else:
+                self._send(405, {}, b"method not allowed")
+
+        def _serving_invoke(self) -> None:
+            # The /shim/* namespace is the shim's contract surface (health, ready,
+            # hydrate), never the app's, so it is never routed to the handler even in
+            # serving mode: a stray /shim/* here is a 404, not a handler call.
+            path = self.path.split("?", 1)[0]
+            if path.startswith("/shim/"):
+                self._send(404, {}, b"not found")
+                return
+            self._invoke_handler()
+
+        def _invoke_handler(self) -> None:
+            path = self.path.split("?", 1)[0]
+            query = self.path.split("?", 1)[1] if "?" in self.path else ""
             if not state.is_ready() or state.handler is None:
                 self._send(503, {}, b"shim not ready")
                 return
@@ -547,7 +616,9 @@ def build_server(
     (reached over the guest's tap NIC) and never binds vsock; the vsock path is
     byte-unchanged when serving_port is None.
     """
-    request_handler_cls = make_request_handler(state, invoke_path)
+    request_handler_cls = make_request_handler(
+        state, invoke_path, serving=serving_port is not None
+    )
     if serving_port is not None:
         return ThreadingHTTPServer(("0.0.0.0", serving_port), request_handler_cls)  # noqa: S104
     port = int(os.environ.get("EMBER_HTTP_PORT", str(GUEST_HTTP_PORT)))

--- a/projects/embervm/runtimes/python/shim_test.py
+++ b/projects/embervm/runtimes/python/shim_test.py
@@ -677,3 +677,122 @@ def test_cold_boot_hydrate_missing_byte_count_raises(tmp_path, monkeypatch):
     monkeypatch.delenv(shim.HANDLER_ZIP_BYTES_ENV, raising=False)
     with pytest.raises(ValueError):
         shim._cold_boot_hydrate(state)
+
+
+# ---------------------------------------------------------------------------
+# Serving mode: the guest is a web server, so the handler owns its routes and
+# any method/path (browser GET included) reaches it, while /shim/* stays reserved.
+# ---------------------------------------------------------------------------
+
+
+def _run_serving_server(state, invoke_path="/invoke"):
+    """Start a TCP server whose handler is in SERVING mode (serving=True)."""
+    cls = shim.make_request_handler(state, invoke_path, serving=True)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+# A handler that echoes the request method + path so a test can prove the real
+# request context (not a fixed /invoke) reached it.
+_ECHO_METHOD_PATH = (
+    b"def handle(event, context):\n"
+    b"    return {'statusCode': 200, 'body': event['httpMethod'] + ' ' + event['path']}\n"
+)
+
+
+def _serving_state_ready(tmp_path, monkeypatch, handler_src=_ECHO_METHOD_PATH):
+    monkeypatch.setattr(shim, "UNPACK_DIR", str(tmp_path / "ember-app"))
+    state = _new_state()
+    shim.hydrate(state, _zip_bytes({"app.py": handler_src}))
+    assert state.is_ready()
+    return state
+
+
+def test_serving_get_any_path_invokes_handler(tmp_path, monkeypatch, isolated_imports):
+    # The core Fix-B behaviour: in serving mode a browser-style GET to an app path
+    # (NOT /invoke) reaches the handler, carrying the real method + path.
+    state = _serving_state_ready(tmp_path, monkeypatch)
+    server, _t = _run_serving_server(state)
+    try:
+        conn = HTTPConnection("127.0.0.1", server.server_port)
+        conn.request("GET", "/og-image?title=hi")
+        resp = conn.getresponse()
+        assert resp.status == 200
+        assert resp.read() == b"GET /og-image"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_serving_post_any_path_invokes_handler(tmp_path, monkeypatch, isolated_imports):
+    state = _serving_state_ready(tmp_path, monkeypatch)
+    server, _t = _run_serving_server(state)
+    try:
+        conn = HTTPConnection("127.0.0.1", server.server_port)
+        conn.request("POST", "/whatever", body=b"x")
+        resp = conn.getresponse()
+        assert resp.status == 200
+        assert resp.read() == b"POST /whatever"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_serving_reserves_shim_namespace(tmp_path, monkeypatch, isolated_imports):
+    # /shim/healthz stays the shim's (200), and an unknown /shim/* is a 404, never
+    # routed to the handler even in serving mode.
+    state = _serving_state_ready(tmp_path, monkeypatch)
+    server, _t = _run_serving_server(state)
+    try:
+        conn = HTTPConnection("127.0.0.1", server.server_port)
+        conn.request("GET", shim.HEALTHZ_PATH)
+        assert conn.getresponse().status == 200
+
+        conn = HTTPConnection("127.0.0.1", server.server_port)
+        conn.request("GET", "/shim/bogus")
+        assert conn.getresponse().status == 404
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_non_serving_get_is_404_unchanged(tmp_path, monkeypatch, isolated_imports):
+    # Task/session (non-serving) mode is byte-unchanged: a GET to an app path (or to
+    # /invoke) is 404; only POST /invoke invokes the handler.
+    state = _serving_state_ready(tmp_path, monkeypatch)
+    server, _t = _run_server(state)  # non-serving
+    try:
+        conn = HTTPConnection("127.0.0.1", server.server_port)
+        conn.request("GET", "/invoke")
+        assert conn.getresponse().status == 404
+
+        conn = HTTPConnection("127.0.0.1", server.server_port)
+        conn.request("POST", "/invoke", body=b"x")
+        resp = conn.getresponse()
+        assert resp.status == 200
+        assert resp.read() == b"POST /invoke"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_serving_head_has_no_body_but_content_length(
+    tmp_path, monkeypatch, isolated_imports
+):
+    # HEAD invokes the handler (to compute headers incl. Content-Length) but returns
+    # no body, per RFC 7231.
+    state = _serving_state_ready(tmp_path, monkeypatch)
+    server, _t = _run_serving_server(state)
+    try:
+        conn = HTTPConnection("127.0.0.1", server.server_port)
+        conn.request("HEAD", "/og-image")
+        resp = conn.getresponse()
+        assert resp.status == 200
+        # Content-Length reflects the (suppressed) body "HEAD /og-image".
+        assert resp.getheader("Content-Length") == str(len(b"HEAD /og-image"))
+        assert resp.read() == b""
+    finally:
+        server.shutdown()
+        server.server_close()


### PR DESCRIPTION
Two independent serving-tier robustness fixes surfaced by the R3 DNAT live drill (PR #3577), both prerequisites for a public og-image serving tier. Neither was caused by the DNAT change; the drill just exercised the paths that expose them.

## A) noded pod restart no longer wedges the node

**Bug:** When a noded pod is replaced, its old gRPC connection breaks and the Mint adapter surfaces that as `%GRPC.RPCError{status: 2, message: "...the connection is closed"}`, **not** a raw transport error. The control plane's invalidation logic treated every `%GRPC.RPCError{}` as a healthy-channel server status (D-R2.7.2) and never invalidated the cached channel (`persistent_term`, keyed by node), so every `Prime`/`StartServing`/`Assign` reused the dead channel. Result: after a routine noded pod restart, **all** workloads on that node fail with `"the connection is closed"` until a manual control-plane restart. (Observed live: the R3 restart drill needed a control-plane bounce to recover.)

**Fix:** a shared `NodeChannel.transport_dead?/1` that recognizes the transport death wrapped as `%GRPC.RPCError{status: 2}` with a connection-closed message (and raw transport errors), but returns false for genuine server statuses. Invalidate on it at the three under-invalidating call sites — `session.ex`, `pool_manager.ex` (Prime worker), `serving_manager.ex` (`safe_start_serving`) — so the next call re-dials the stable Service-DNS node address. Since all paths share the channel, the ~1s PoolManager loop heals the whole node automatically. `dispatcher.ex` already invalidates unconditionally (unchanged). Strictly additive: never invalidates less than before, and still leaves the channel up on healthy-channel server statuses.

## B) serving VMs answer any method, not just `POST /invoke`

**Bug:** the shim invoked the handler only on `POST` to `invoke_path`, so a browser `GET` to a serving VM 404'd (a task-lane RPC concept applied to what is really a web server). og-image "serving" as a browser-fetchable image URL therefore did not work.

**Fix:** in serving mode (`serving_port` set) the guest is a web server that owns its routes: every request whose path is not the reserved `/shim/*` contract namespace routes to the handler with its real method/path/query, for any verb. Task/session (vsock) mode is byte-unchanged (`POST invoke_path` only). `HEAD` returns headers with `Content-Length` but no body (RFC 7231).

## Tests

- `transport_dead?/1` classification (wrapped RPCError = dead; status 9/8 and status-2-non-transport = alive; raw transport dead; unrelated alive).
- `pool_manager` + `serving_manager`: invalidate-on-transport-dead vs no-invalidate-on-server-status.
- shim serving-mode GET/POST/HEAD dispatch, `/shim/*` reservation, and non-serving mode unchanged. **Full shim suite (54 tests) green locally.**

An Opus review traced every dispatch path and invalidation site and found no material bugs (one HEAD-body spec note, fixed here).

Chart `0.1.62 -> 0.1.63`. After merge + deploy I will re-run the two-part drill: delete the noded pod and confirm the node self-recovers with **no** control-plane restart, and a browser-style `GET` to og-image serving returns 200 image/png (a fresh cold boot picks up the new shim). Public flip stays gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)