### PR TITLE
feat(embervm): turn over serving bases on runtime roll (reject stale relights + GC)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.63
+version: 0.1.64

--- a/projects/embervm/control/lib/embervm/serving_manager.ex
+++ b/projects/embervm/control/lib/embervm/serving_manager.ex
@@ -389,18 +389,41 @@ defmodule Embervm.ServingManager do
     end
   end
 
-  # A banked instance for the workload whose snapshot a node still reports: the
-  # freshest wins. Returns {:ok, instance, node_id} or :none.
+  # A banked instance for the workload whose snapshot a node still reports AND whose
+  # base lineage is still current: the freshest wins. Returns {:ok, instance, node_id}
+  # or :none. The lineage check (D-R3.11.3 follow-up) rejects a snapshot born from a
+  # SUPERSEDED base: after a runtime roll the node reports a new serving_image_ref, and
+  # relighting an old-lineage snapshot would resume the old rootfs/handler (old code).
+  # A skipped stale instance is swept/evicted separately; here we just refuse to relight
+  # it, so the wake falls through to a cold boot on the current base.
   defp pick_bankable_instance(state, workload) do
     ServingStore.list(state.store, workload)
     |> Enum.filter(&(&1.state == :banked))
     |> Enum.sort_by(& &1.updated_at, :desc)
     |> Enum.find_value(:none, fn instance ->
       case ServingPlacement.node_for_relight(instance, state.capacity_table) do
-        {:ok, node_id} -> {:ok, instance, node_id}
-        {:error, :snapshot_lost} -> false
+        {:ok, node_id} ->
+          if lineage_current?(state.capacity_table, node_id, instance) do
+            {:ok, instance, node_id}
+          else
+            false
+          end
+
+        {:error, :snapshot_lost} ->
+          false
       end
     end)
+  end
+
+  # Whether a banked instance's base lineage still matches the node's CURRENT
+  # serving_image_ref for the workload. Fail-OPEN when the node reports no current ref
+  # yet (nil/empty): the new base is not built, so the existing snapshot stays
+  # relightable for warmth rather than forcing a cold boot with no base to boot from.
+  defp lineage_current?(capacity_table, node_id, instance) do
+    case ServingPlacement.current_serving_image_ref(capacity_table, node_id, instance.workload) do
+      ref when is_binary(ref) and ref != "" -> ref == instance.base_snapshot_ref
+      _ -> true
+    end
   end
 
   defp relight_request(entry, instance) do

--- a/projects/embervm/control/lib/embervm/serving_placement.ex
+++ b/projects/embervm/control/lib/embervm/serving_placement.ex
@@ -101,6 +101,31 @@ defmodule Embervm.ServingPlacement do
     end
   end
 
+  @doc """
+  The serving_image_ref a `node_id` currently reports for `workload` (the cold-boot
+  handler artifact of the node's CURRENT-runtime serving base), or `nil` when the
+  node is absent from the capacity table or reports no ref for the workload yet.
+
+  This is the turnover key (D-R3.11.3 follow-up): a banked serving snapshot's
+  `base_snapshot_ref` records the ref it was BORN from, so comparing it to this
+  current ref tells whether a relight would resume a stale rootfs/handler (old code
+  after a runtime roll). A `nil`/empty current ref means the new base is not built
+  yet, so callers fail OPEN (keep the snapshot relightable for warmth).
+  """
+  @spec current_serving_image_ref(atom(), term(), String.t()) :: String.t() | nil
+  def current_serving_image_ref(capacity_table \\ NodeCapacity.table(), node_id, workload) do
+    case NodeCapacity.fetch(capacity_table, node_id) do
+      {:ok, fact} ->
+        fact
+        |> Map.get(:workloads, %{})
+        |> Map.get(workload, %{})
+        |> Map.get(:serving_image_ref)
+
+      :error ->
+        nil
+    end
+  end
+
   # -- internals -------------------------------------------------------------
 
   # Serving-capable: the node reports a serving subnet (the same predicate the

--- a/projects/embervm/control/lib/embervm/serving_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/serving_sweeper.ex
@@ -248,6 +248,7 @@ defmodule Embervm.ServingSweeper do
       |> arm_idle_banks(now)
       |> sweep_lifetime(now)
       |> sweep_banked_ttl(now)
+      |> sweep_stale_lineage(now)
       |> write_serving_status()
     end
   end
@@ -780,6 +781,40 @@ defmodule Embervm.ServingSweeper do
           acc
       end
     end)
+  end
+
+  # -- stale-base lineage GC (D-R3.11.3 follow-up) ---------------------------
+
+  # Evict banked snapshots born from a SUPERSEDED base: after a runtime roll the node
+  # reports a new serving_image_ref, so a snapshot whose base_snapshot_ref no longer
+  # matches would relight OLD code. pick_bankable_instance already refuses to relight
+  # these; this pass reclaims them so they do not squat node disk indefinitely (the
+  # accumulation the R3 serving drill surfaced). Only a NON-EMPTY current ref that
+  # DIFFERS marks staleness: an absent ref means the new base is not built yet, so the
+  # snapshot is kept (fail-open, matching the relight lineage check). Live instances
+  # are untouched (only :banked rows), and the node's evict guard already refuses to
+  # remove a snapshot a live VM was relit from.
+  defp sweep_stale_lineage(state, _now) do
+    ServingStore.all(state.store)
+    |> Enum.filter(&(&1.state == :banked))
+    |> Enum.reduce(state, fn instance, acc ->
+      if stale_lineage?(acc.capacity_table, instance) do
+        evict_banked(acc, instance, :stale_base)
+      else
+        acc
+      end
+    end)
+  end
+
+  defp stale_lineage?(capacity_table, instance) do
+    case Embervm.ServingPlacement.current_serving_image_ref(
+           capacity_table,
+           instance.node_id,
+           instance.workload
+         ) do
+      ref when is_binary(ref) and ref != "" -> ref != instance.base_snapshot_ref
+      _ -> false
+    end
   end
 
   # -- forced roll -----------------------------------------------------------

--- a/projects/embervm/control/test/embervm/serving_manager_test.exs
+++ b/projects/embervm/control/test/embervm/serving_manager_test.exs
@@ -375,4 +375,78 @@ defmodule Embervm.ServingManagerTest do
     {:ok, still} = ServingStore.get(ctx.store, "srv-disc")
     assert still.state == :starting
   end
+
+  # -- stale-lineage relight reject (D-R3.11.3 follow-up) --------------------
+
+  # Seed a banked instance born from `base_snapshot_ref`, whose snapshot the node
+  # reports as `snapshot_ref` (so node_for_relight resolves it).
+  defp seed_banked(ctx, id, base_snapshot_ref, snapshot_ref) do
+    {:ok, _} =
+      ServingStore.start(ctx.store, %{
+        instance_id: id,
+        tenant: "homelab",
+        principal: "serving:wl-a",
+        workload: "wl-a",
+        node_id: "node-4",
+        vm_id: "vm-#{id}",
+        ip: "10.99.0.9",
+        port: 8080,
+        base_snapshot_ref: base_snapshot_ref
+      })
+
+    {:ok, _} = ServingStore.publish(ctx.store, id, "10.99.0.9", 8080, :started)
+    {:ok, _} = ServingStore.unpublish(ctx.store, id, :bank)
+    {:ok, _} = ServingStore.mark(ctx.store, id, :bank)
+
+    {:ok, _} =
+      ServingStore.transition(ctx.store, id, :bank_ready, :serving_banked,
+        %{snapshot_ref: snapshot_ref, size_bytes: 10, generation: 1},
+        %{snapshot_ref: snapshot_ref, snapshot_size_bytes: 10, generation: 1, vm_id: nil}
+      )
+
+    id
+  end
+
+  defp recording_start_fun do
+    {:ok, srcs} = Agent.start_link(fn -> [] end)
+
+    fun = fn _ch, req ->
+      Agent.update(srcs, &[elem(req.source, 0) | &1])
+      {:ok, %StartServingResponse{vm_id: "vm-woke", ip: "10.99.0.5", port: 8080}}
+    end
+
+    {fun, srcs}
+  end
+
+  test "a STALE-lineage banked instance is NOT relit: the wake cold-boots the current base" do
+    {fun, srcs} = recording_start_fun()
+    ctx = start_stack(start_serving_fun: fun)
+    serving_workload(ctx, "wl-a")
+    # Node reports the CURRENT serving_image_ref "base-a" (see serving_node) AND the
+    # stale snapshot; the banked instance was born from a SUPERSEDED base "base-OLD".
+    serving_node(ctx, "node-4",
+      serving_snapshots: [%{snapshot_ref: "serving/s-old", workload: "wl-a", size_bytes: 10, created_at_unix_ms: 1}]
+    )
+
+    seed_banked(ctx, "srv-old", "base-OLD", "serving/s-old")
+
+    assert {:ok, %{ip: "10.99.0.5", port: 8080}} = ServingManager.miss(ctx.mgr, "wl-a", req(), "serving:wl-a")
+    # The wake was a COLD boot (:fresh), not a relight of the stale snapshot.
+    assert Agent.get(srcs, & &1) == [:fresh]
+  end
+
+  test "a CURRENT-lineage banked instance IS relit (the reject is lineage-specific)" do
+    {fun, srcs} = recording_start_fun()
+    ctx = start_stack(start_serving_fun: fun)
+    serving_workload(ctx, "wl-a")
+    serving_node(ctx, "node-4",
+      serving_snapshots: [%{snapshot_ref: "serving/s-cur", workload: "wl-a", size_bytes: 10, created_at_unix_ms: 1}]
+    )
+
+    # base_snapshot_ref matches the node's current serving_image_ref "base-a".
+    seed_banked(ctx, "srv-cur", "base-a", "serving/s-cur")
+
+    assert {:ok, _} = ServingManager.miss(ctx.mgr, "wl-a", req(), "serving:wl-a")
+    assert Agent.get(srcs, & &1) == [:relight]
+  end
 end

--- a/projects/embervm/control/test/embervm/serving_placement_test.exs
+++ b/projects/embervm/control/test/embervm/serving_placement_test.exs
@@ -97,4 +97,21 @@ defmodule Embervm.ServingPlacementTest do
     instance = %{node_id: "node-dead", snapshot_ref: "serving/s-1"}
     assert ServingPlacement.node_for_relight(instance, t) == {:error, :snapshot_lost}
   end
+
+  # -- current_serving_image_ref (turnover key) ------------------------------
+
+  describe "current_serving_image_ref/3" do
+    test "returns the node's current serving_image_ref for the workload", %{t: t} do
+      put_serving_node(t, "node-4", workloads: ready_workload("base:new"))
+      assert ServingPlacement.current_serving_image_ref(t, "node-4", "wl-a") == "base:new"
+    end
+
+    test "is nil for an absent node, an unknown workload, or a node reporting no ref", %{t: t} do
+      put_serving_node(t, "node-4", workloads: ready_workload("base:new"))
+      assert ServingPlacement.current_serving_image_ref(t, "node-dead", "wl-a") == nil
+      assert ServingPlacement.current_serving_image_ref(t, "node-4", "wl-unknown") == nil
+      put_serving_node(t, "node-5", workloads: %{"wl-a" => %{base_state: :BASE_BUILD_STATE_READY}})
+      assert ServingPlacement.current_serving_image_ref(t, "node-5", "wl-a") == nil
+    end
+  end
 end

--- a/projects/embervm/control/test/embervm/serving_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/serving_sweeper_test.exs
@@ -447,6 +447,91 @@ defmodule Embervm.ServingSweeperTest do
     assert instance.terminal_reason == "idle_ttl"
   end
 
+  # -- stale-base lineage GC (D-R3.11.3 follow-up) ---------------------------
+
+  # A node that reports a CURRENT serving_image_ref for the workload (a runtime roll
+  # rebuilt the base to a new key).
+  defp serving_node_with_image(ctx, node_id, workload, serving_image_ref) do
+    NodeCapacity.put(ctx.cap_table, node_id, %{
+      configured_id: node_id,
+      node_id: node_id,
+      serving_subnet_cidr: "10.99.0.0/24",
+      max_live_vms: 8,
+      live_vms: 0,
+      workloads: %{
+        workload => %{base_state: :BASE_BUILD_STATE_READY, serving_image_ref: serving_image_ref}
+      },
+      serving_vms: [],
+      serving_snapshots: []
+    })
+  end
+
+  # A banked instance born from base_snapshot_ref (its lineage) with snapshot_ref.
+  defp banked_instance(ctx, id, workload, base_snapshot_ref, snapshot_ref) do
+    {:ok, _} =
+      ServingStore.start(ctx.store, %{
+        instance_id: id,
+        tenant: "homelab",
+        principal: "system:serving:#{workload}",
+        workload: workload,
+        node_id: "node-4",
+        vm_id: "vm-#{id}",
+        ip: "10.99.0.5",
+        port: 8080,
+        base_snapshot_ref: base_snapshot_ref
+      })
+
+    {:ok, _} = ServingStore.publish(ctx.store, id, "10.99.0.5", 8080, :started)
+    {:ok, _} = ServingStore.unpublish(ctx.store, id, :bank)
+    {:ok, _} = ServingStore.mark(ctx.store, id, :bank)
+
+    {:ok, _} =
+      ServingStore.transition(ctx.store, id, :bank_ready, :serving_banked,
+        %{snapshot_ref: snapshot_ref, size_bytes: 10, generation: 1},
+        %{snapshot_ref: snapshot_ref, snapshot_size_bytes: 10, generation: 1, vm_id: nil}
+      )
+
+    id
+  end
+
+  test "stale-lineage GC evicts a banked snapshot whose base is superseded, keeps the current one" do
+    ctx = start_stack()
+    serving_workload(ctx, "wl-a", %{banked_ttl_seconds: 1_000_000})
+    # The node now reports the CURRENT base "base:new" (a runtime roll rebuilt it).
+    serving_node_with_image(ctx, "node-4", "wl-a", "base:new")
+
+    banked_instance(ctx, "srv-old", "wl-a", "base:old", "snap-old")
+    banked_instance(ctx, "srv-new", "wl-a", "base:new", "snap-new")
+
+    set_scrape(ctx, {:ok, %{}})
+    ServingSweeper.sweep(ctx.sweeper)
+
+    # The stale-lineage snapshot is evicted with reason stale_base.
+    {:ok, stale} = ServingStore.get(ctx.store, "srv-old")
+    assert stale.state == :evicted
+    assert stale.terminal_reason == "stale_base"
+
+    # The current-lineage snapshot survives (not evicted, still relightable).
+    {:ok, current} = ServingStore.get(ctx.store, "srv-new")
+    assert current.state == :banked
+  end
+
+  test "stale-lineage GC fails open when the node reports no current serving_image_ref yet" do
+    ctx = start_stack()
+    serving_workload(ctx, "wl-a", %{banked_ttl_seconds: 1_000_000})
+    # The node reports NO serving_image_ref for the workload (new base not built yet).
+    serving_node(ctx, "node-4")
+
+    banked_instance(ctx, "srv-1", "wl-a", "base:old", "snap-1")
+
+    set_scrape(ctx, {:ok, %{}})
+    ServingSweeper.sweep(ctx.sweeper)
+
+    # Kept, not evicted: with no current ref to compare against, warmth wins.
+    {:ok, instance} = ServingStore.get(ctx.store, "srv-1")
+    assert instance.state == :banked
+  end
+
   # -- forced roll -----------------------------------------------------------
 
   test "forced roll drains + destroys live instances and evicts banked ones" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.63
+      targetRevision: 0.1.64
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
The D-R3.11.3 serving-base turnover follow-up, and the **last prerequisite for a public og-image serving tier**. Surfaced by the R3 drill: after PR #3578 shipped the serving-GET shim, a browser `GET` still 404'd live because serving wakes kept **relighting old banked snapshots** whose old shim/rootfs is frozen into their RAM image (POST worked because the pre-fix shim served POST). Stale bases + banked snapshots also accumulated on node disk with no turnover.

## What

Cold-boot placement was already correct (`node_for_create` only picks a node reporting a current `serving_image_ref`). The gap was the **relight decision** and **GC**:

- **`serving_manager.pick_bankable_instance`** now rejects a relight whose banked lineage (`base_snapshot_ref`, the `serving_image_ref` it was born from) no longer matches the node's **current** `serving_image_ref` for the workload, so the wake falls through to a cold boot on the current base. **Fail-open** when the node reports no current ref yet (new base not built): warmth wins, no stranding.
- **`serving_sweeper`** gains a `sweep_stale_lineage` pass (runs on the existing 30s tick) that `evict_banked`s snapshots whose lineage is superseded, reclaiming them. Only `:banked` rows, only a **non-empty differing** ref; live/published instances and the noded evict-guard are untouched.
- **`serving_placement.current_serving_image_ref/3`** is the shared lineage lookup (`NodeCapacity.fetch` → `workloads[wl].serving_image_ref`).

The relight and sweep checks are symmetric fail-open: a snapshot is evicted **iff** it would also be rejected for relight, so there is no window where the sweeper removes a still-relightable snapshot.

## Scope note

Stale serving **base dirs** (the memfiles) are **not** GC'd here — that rides the snapshot-to-S3 distribution arc as a deliberate follow-on. This PR reclaims the per-instance banked **snapshots** and, crucially, stops old-code relights.

## Tests

- `current_serving_image_ref/3` (value / nil for absent node, unknown workload, no ref).
- `pick_bankable_instance`: a stale-lineage banked instance is **not** relit (wake cold-boots, `[:fresh]`); a current-lineage one **is** relit (`[:relight]`) — the reject is lineage-specific.
- `sweep_stale_lineage`: evicts the superseded snapshot (`terminal_reason == "stale_base"`), keeps the current one, and fails open when the node reports no current ref.

An Opus review verified the fail-open symmetry, the `find_value` control flow, no-double-evict ordering, the `:evicted` FSM edge, idempotency, and the test seed helpers: no material issues.

Chart `0.1.63 -> 0.1.64`. After deploy I will re-run the live drill: a wake **cold-boots** the current base so a browser `GET` returns 200 image/png (Fix B finally live), and the stale banked snapshots get swept. Then all three fixes are live-verified and I will come back for the public (Part B) flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)