### PR TITLE
feat(embervm): R4 PR-1 stateful contract (proto, op-log, CRD)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.67
+version: 0.1.68

--- a/projects/embervm/chart/crds/workload-crd.yaml
+++ b/projects/embervm/chart/crds/workload-crd.yaml
@@ -54,6 +54,10 @@ spec:
           type: string
           description: Live/banked/published instance counts (serving class only).
           jsonPath: .status.servingSummary
+        - name: Stateful
+          type: string
+          description: Instance state and generation/bundle pairing (stateful class only).
+          jsonPath: .status.statefulSummary
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp
@@ -69,15 +73,19 @@ spec:
                 - class
                 - source
                 - resources
-                - concurrency
               properties:
                 class:
                   type: string
                   description: >-
-                    Isolation/lifecycle class. task, session, and serving are
-                    valid as of R3; stateful is reserved for a later rung and
-                    rejected by the watcher via a status condition, not by the
-                    API server, so a forward CR does not hard-fail admission.
+                    Isolation/lifecycle class. task, session, serving, and
+                    stateful are valid as of R4. The stateful class is a
+                    scale-to-zero singleton datastore (one long-lived microVM
+                    owning one writable volume, reachable over opaque L4 TCP).
+                    concurrency is required by the watcher for task/session/serving
+                    but forbidden for stateful (singleton by construction), which
+                    is why it is no longer a schema-level required field; the
+                    watcher enforces the per-class requiredness via a status
+                    condition (the same pattern as the session/serving blocks).
                   enum:
                     - task
                     - session
@@ -363,6 +371,98 @@ spec:
                         when unset (the watcher applies that), so a banked snapshot
                         never outlives what a live instance would.
                       minimum: 0
+                stateful:
+                  type: object
+                  description: >-
+                    Stateful-class volume and L4 policy (R4). REQUIRED when
+                    spec.class is `stateful` and forbidden otherwise; the watcher
+                    enforces that cross-field rule with a status condition. A
+                    stateful workload is a scale-to-zero SINGLETON: one long-lived
+                    microVM owning one writable volume (a raw file on node NVMe),
+                    reachable over opaque L4 TCP, that banks to disk when idle and
+                    wakes on the next inbound connection (ADR embervm/001: data on
+                    the volume, warmth in the snapshot). There is no maxInstances
+                    knob (singleton by construction) and spec.concurrency is
+                    forbidden on this class.
+                  required:
+                    - port
+                    - listenPort
+                    - volumeSizeGiB
+                  properties:
+                    port:
+                      type: integer
+                      description: >-
+                        The port the guest TCP server listens on inside the VM
+                        (e.g. 5432 for Postgres). Health is a TCP connect to this
+                        port (opaque L4, no health path).
+                      minimum: 1
+                      maximum: 65535
+                    listenPort:
+                      type: integer
+                      description: >-
+                        The node Envoy TCP listener port this workload is exposed
+                        on cluster-internally. Must fall inside the chart's
+                        values-declared stateful range (default 5400-5409) and be
+                        unique across stateful workloads; the watcher rejects an
+                        out-of-range or duplicate port with a status condition. The
+                        listener port is the workload identity on the wire
+                        (decision 5): TCP has no header to route on.
+                      minimum: 1
+                      maximum: 65535
+                    volumeSizeGiB:
+                      type: integer
+                      description: >-
+                        Sparse size cap of the workload's raw volume file, in GiB.
+                        IMMUTABLE in v1: the watcher rejects an edit with a status
+                        condition (volume resize is a recorded follow-on; the file
+                        is not resized).
+                      minimum: 1
+                    volumeMountPath:
+                      type: string
+                      description: >-
+                        Guest path the volume is mounted at (guest-init runs mkfs
+                        on a blank device then mounts here before the image init).
+                        The host never mounts the volume (decision 9).
+                      default: /data
+                    idleBankSeconds:
+                      type: integer
+                      description: >-
+                        Idle time (zero active connections and zero new-connection
+                        delta across the window, per the Task 9 TCP idle scrape)
+                        after which the instance is banked and its VM released. A
+                        live connection is never severed regardless of this timer
+                        (decision 7).
+                      minimum: 30
+                      default: 300
+                    maxLifetimeSeconds:
+                      type: integer
+                      description: >-
+                        Hard lifetime cap. A stateful instance rides its birth
+                        image until this expires; after it, convergence is destroy-
+                        and-cold-boot against the volume (a roll costs a WAL
+                        recovery, not data). The Task 9 forced roll is the operator
+                        lever.
+                      minimum: 60
+                      default: 86400
+                    bankedTtlSeconds:
+                      type: integer
+                      description: >-
+                        How long a banked stateful bundle may sit idle before it is
+                        garbage-collected off node disk (Task 9 banked-TTL sweep).
+                        The VOLUME is never GC'd (data outlives the bundle); only
+                        the memory-snapshot warmth is reclaimed.
+                      minimum: 0
+                      default: 604800
+                    wakeTimeoutSeconds:
+                      type: integer
+                      description: >-
+                        Deadline for a wake (relight or cold boot) to reach TCP
+                        readiness. Cold boots include WAL recovery and mkfs+initdb
+                        on first boot, so this is generous by design; a wake that
+                        exceeds it marks the instance failed and the next
+                        connection retries (subject to the wake-rate limit).
+                      minimum: 1
+                      default: 60
                 invocation:
                   type: object
                   description: Task execution policy. All fields defaulted.
@@ -503,6 +603,42 @@ spec:
                     `serving`, for the SERVING printer column (a printer column
                     cannot format an object). Written by the control plane
                     alongside `serving`.
+                stateful:
+                  type: object
+                  description: >-
+                    Stateful-class status written by the control plane (stateful
+                    workloads only). Absent for other classes. Reports the
+                    singleton instance's lifecycle state, the volume and banked-
+                    bundle generations (whose equality is the pair-validity test),
+                    and the volume's allocated bytes for the watermark.
+                  properties:
+                    state:
+                      type: string
+                      description: >-
+                        Instance lifecycle state (starting | serving | banking |
+                        banked | relighting | cold_booting | evicted | destroyed |
+                        failed), or absent when no instance exists yet.
+                    generation:
+                      type: integer
+                      description: The live/last volume generation the instance holds.
+                    bundleGeneration:
+                      type: integer
+                      description: >-
+                        The generation stamped into the banked bundle. When it
+                        equals `generation` the banked warmth is valid; a mismatch
+                        means the next wake cold-boots from the volume.
+                    volumeBytes:
+                      type: integer
+                      description: >-
+                        The volume file's allocated (on-disk) bytes, the watermark
+                        source against the declared volumeSizeGiB cap.
+                statefulSummary:
+                  type: string
+                  description: >-
+                    Human-readable "state gen=<n>/bundle=<n>" rendering of
+                    `stateful`, for the STATEFUL printer column (a printer column
+                    cannot format an object). Written by the control plane
+                    alongside `stateful`.
                 conditions:
                   type: array
                   items:

--- a/projects/embervm/control/lib/embervm/op_log.ex
+++ b/projects/embervm/control/lib/embervm/op_log.ex
@@ -32,6 +32,7 @@ defmodule Embervm.OpLog do
               task_id: nil,
               session_id: nil,
               serving_instance_id: nil,
+              stateful_instance_id: nil,
               ts: nil,
               payload: %{}
 
@@ -51,6 +52,12 @@ defmodule Embervm.OpLog do
             # way session_id was in R2. A serving op owns its `serving_instances`
             # projection row the way a session op owns its `sessions` row.
             serving_instance_id: String.t() | nil,
+            # Set on stateful_* ops (nil on every other op); the durable
+            # `ops.stateful_instance_id` column (R4), added additively the same
+            # way serving_instance_id was in R3. A stateful op owns its
+            # `stateful_instances` projection row. volume_* ops leave it nil (they
+            # own a `volumes` row keyed by workload, not an instance).
+            stateful_instance_id: String.t() | nil,
             ts: integer(),
             payload: map()
           }
@@ -105,7 +112,31 @@ defmodule Embervm.OpLog do
     :serving_evicted,
     :serving_destroyed,
     :serving_failed,
-    :serving_stats
+    :serving_stats,
+    # Stateful lifecycle (R4). Additive to the closed enum, mirroring the R3
+    # serving kinds: stateful instances and their volumes are durable, ordered,
+    # and auditable exactly like serving instances (ADR embervm/001) and project
+    # into the `stateful_instances` and `volumes` tables (see Embervm.OpLog.SQLite).
+    # volume_created/volume_deleted are the durable-data audit record keyed by
+    # workload (the volume outlives every instance by design). stateful_published/
+    # stateful_unpublished are the L4-endpoint-lifetime audit (who a connection
+    # reaches), distinct from the VM-lifecycle kinds. stateful_cold_booted carries
+    # a reason (generation_mismatch|no_bundle|ledger_unreadable|explicit) so every
+    # discarded-warmth event is reconstructable from the log alone; stateful_relit
+    # carries the matched generation. stateful_stats carries per-listener
+    # connection deltas from the idle-signal scrape (D-R3.2.1 shape at L4).
+    :volume_created,
+    :volume_deleted,
+    :stateful_started,
+    :stateful_published,
+    :stateful_unpublished,
+    :stateful_banked,
+    :stateful_relit,
+    :stateful_cold_booted,
+    :stateful_evicted,
+    :stateful_destroyed,
+    :stateful_failed,
+    :stateful_stats
   ]
 
   @spec kinds() :: [atom()]
@@ -135,6 +166,16 @@ defmodule Embervm.OpLog do
   # (Tasks 7/8), exactly mirroring load_sessions/1. A projection read, never
   # the raw ops log.
   @callback load_serving_instances(server()) :: {:ok, [map()]} | {:error, term()}
+  # Loads every stateful instance row from the durable `stateful_instances`
+  # projection (R4), for the StatefulStore's boot/adoption rebuild (Tasks 7/8),
+  # exactly mirroring load_serving_instances/1. A projection read, never the raw
+  # ops log.
+  @callback load_stateful_instances(server()) :: {:ok, [map()]} | {:error, term()}
+  # Loads every volume row from the durable `volumes` projection (R4): the
+  # per-workload durable-data facts (generation, sizes) the StatefulStore rebuilds
+  # its pair-validity view from on boot. A volume row lives until volume_deleted,
+  # outliving every instance by design. A projection read, never the raw ops log.
+  @callback load_volumes(server()) :: {:ok, [map()]} | {:error, term()}
   # Reads one task's stored result from the durable `results` projection, or
   # {:ok, nil} when there is none (never ran, or the TTL sweeper reaped it).
   # This is the result-store read the submit API (Task 8) serves `GET
@@ -180,6 +221,7 @@ defmodule Embervm.OpLog do
                  tasks_compacted: non_neg_integer(),
                  sessions_compacted: non_neg_integer(),
                  serving_instances_compacted: non_neg_integer(),
+                 stateful_instances_compacted: non_neg_integer(),
                  ops_compacted: non_neg_integer(),
                  compacted_through: non_neg_integer(),
                  done: boolean()

--- a/projects/embervm/control/lib/embervm/op_log/compactor.ex
+++ b/projects/embervm/control/lib/embervm/op_log/compactor.ex
@@ -65,6 +65,7 @@ defmodule Embervm.OpLog.Compactor do
       tasks_compacted: 0,
       sessions_compacted: 0,
       serving_instances_compacted: 0,
+      stateful_instances_compacted: 0,
       ops_compacted: 0,
       compacted_through: 0
     }
@@ -81,6 +82,8 @@ defmodule Embervm.OpLog.Compactor do
           sessions_compacted: totals.sessions_compacted + batch.sessions_compacted,
           serving_instances_compacted:
             totals.serving_instances_compacted + batch.serving_instances_compacted,
+          stateful_instances_compacted:
+            totals.stateful_instances_compacted + batch.stateful_instances_compacted,
           ops_compacted: totals.ops_compacted + batch.ops_compacted,
           # The marker is monotonic and reported per batch; the last batch's value
           # is the authoritative post-sweep marker.
@@ -112,6 +115,7 @@ defmodule Embervm.OpLog.Compactor do
           tasks_compacted: totals.tasks_compacted,
           sessions_compacted: totals.sessions_compacted,
           serving_instances_compacted: totals.serving_instances_compacted,
+          stateful_instances_compacted: totals.stateful_instances_compacted,
           ops_compacted: totals.ops_compacted,
           compacted_through: totals.compacted_through,
           db_size_bytes: db_size

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -60,6 +60,24 @@ defmodule Embervm.OpLog.SQLite do
     "banked",
     "relighting"
   ]
+
+  # Stateful instance lifecycle states (R4), mirroring the serving retention
+  # discipline exactly. A non-terminal (live) stateful instance pins its ops
+  # against prefix compaction and is never pruned by the retention sweep; a
+  # terminal instance prunes past retention. "cold_booting" is the fall-back boot
+  # path (a relight whose pair broke), live like "starting". The `volumes` table
+  # is NOT swept here at all: a volume row lives until volume_deleted, outliving
+  # every instance by design (data on the volume, warmth in the snapshot), so it
+  # has no terminal-state retention clause.
+  @stateful_terminal_states ["evicted", "destroyed", "failed"]
+  @stateful_live_states [
+    "starting",
+    "serving",
+    "banking",
+    "banked",
+    "relighting",
+    "cold_booting"
+  ]
   # Seven days in milliseconds: default age (from last update) at which a
   # terminal task is eligible for compaction. This is the TERMINAL-TASK retention
   # window and is DISTINCT from the ops-journal horizon below.
@@ -86,6 +104,7 @@ defmodule Embervm.OpLog.SQLite do
       task_id TEXT,
       session_id TEXT,
       serving_instance_id TEXT,
+      stateful_instance_id TEXT,
       kind TEXT NOT NULL,
       payload_json TEXT NOT NULL DEFAULT '{}'
     )
@@ -205,6 +224,54 @@ defmodule Embervm.OpLog.SQLite do
       terminal_reason TEXT
     )
     """,
+    # Stateful instance projection (R4): the durable lifecycle + endpoint + pairing
+    # row per stateful instance, write-through projected from the stateful_* ops
+    # (see project/2), mirroring serving_instances above. ip/port are the L4
+    # endpoint the daemon reported at StartStateful; cleared on bank/destroy (a
+    # relight re-reports and republishes). generation is the volume generation the
+    # live instance holds; snapshot_generation is the generation STAMPED into the
+    # banked bundle (the pair key): pair validity is snapshot_generation ==
+    # volumes.generation, recomputed on every sweep. A non-terminal instance pins
+    # its ops against compaction and is never pruned by retention.
+    """
+    CREATE TABLE IF NOT EXISTS stateful_instances (
+      instance_id TEXT PRIMARY KEY,
+      tenant TEXT NOT NULL,
+      principal TEXT,
+      workload TEXT,
+      state TEXT NOT NULL,
+      node_id TEXT,
+      vm_id TEXT,
+      ip TEXT,
+      port INTEGER,
+      generation INTEGER NOT NULL DEFAULT 0,
+      snapshot_ref TEXT,
+      snapshot_generation INTEGER,
+      snapshot_size_bytes INTEGER,
+      created_at INTEGER NOT NULL,
+      last_active_at INTEGER,
+      updated_at INTEGER NOT NULL,
+      terminal_reason TEXT
+    )
+    """,
+    # Volume projection (R4): the durable per-workload volume facts, keyed by
+    # workload (one raw file per stateful workload). generation is the on-disk
+    # ledger's current value (bumped on every writable attach); size_bytes is the
+    # declared sparse cap; allocated_bytes is the file's actual block usage (the
+    # watermark source). A volume row is created by volume_created and lives until
+    # volume_deleted, OUTLIVING every instance by design (ADR embervm/001: data on
+    # the volume, warmth in the snapshot). Retention never prunes a live volume row.
+    """
+    CREATE TABLE IF NOT EXISTS volumes (
+      workload TEXT PRIMARY KEY,
+      node_id TEXT,
+      generation INTEGER NOT NULL DEFAULT 0,
+      size_bytes INTEGER,
+      allocated_bytes INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+    """,
     # Durable single-row scalars for the op-log. Today it holds only the
     # ops-journal prefix marker (`compacted_through_seq`): the newest op seq that
     # has been prefix-compacted away, part of the durable OpLog contract so a
@@ -259,6 +326,16 @@ defmodule Embervm.OpLog.SQLite do
   @impl Embervm.OpLog
   def load_serving_instances(server \\ __MODULE__) do
     GenServer.call(server, :load_serving_instances)
+  end
+
+  @impl Embervm.OpLog
+  def load_stateful_instances(server \\ __MODULE__) do
+    GenServer.call(server, :load_stateful_instances)
+  end
+
+  @impl Embervm.OpLog
+  def load_volumes(server \\ __MODULE__) do
+    GenServer.call(server, :load_volumes)
   end
 
   @impl Embervm.OpLog
@@ -358,6 +435,14 @@ defmodule Embervm.OpLog.SQLite do
     {:reply, do_load_serving_instances(state.conn), state}
   end
 
+  def handle_call(:load_stateful_instances, _from, state) do
+    {:reply, do_load_stateful_instances(state.conn), state}
+  end
+
+  def handle_call(:load_volumes, _from, state) do
+    {:reply, do_load_volumes(state.conn), state}
+  end
+
   def handle_call({:load_result, task_id}, _from, state) do
     {:reply, do_load_result(state.conn, task_id), state}
   end
@@ -413,8 +498,8 @@ defmodule Embervm.OpLog.SQLite do
 
   defp insert_op(conn, %Op{} = op) do
     sql = """
-    INSERT INTO ops (ts, tenant, principal, workload, task_id, session_id, serving_instance_id, kind, payload_json)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO ops (ts, tenant, principal, workload, task_id, session_id, serving_instance_id, stateful_instance_id, kind, payload_json)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
@@ -427,6 +512,7 @@ defmodule Embervm.OpLog.SQLite do
              op.task_id,
              op.session_id,
              op.serving_instance_id,
+             op.stateful_instance_id,
              Atom.to_string(op.kind),
              # An ETF {:blob, _}, not JSON, so a binary body persists byte-exact
              # (see encode_payload/1).
@@ -832,6 +918,194 @@ defmodule Embervm.OpLog.SQLite do
     project_usage_serving(conn, op)
   end
 
+  # -- Stateful projections (R4) --------------------------------------------
+  # The durable model: ONE `stateful_instances` row per boot-lifecycle (created
+  # by stateful_started or stateful_cold_booted, retired by a terminal kind),
+  # over ONE `volumes` row per workload that OUTLIVES every instance (the data,
+  # created by volume_created, gone only on volume_deleted). Every attach (start,
+  # relight, cold boot) bumps the generation, recorded on both the instance and
+  # the volume so pair validity (a banked bundle's snapshot_generation ==
+  # volumes.generation) is a complete staleness test. Mirrors the serving
+  # projection shape; the divergences (a persistent volumes row, snapshot_generation
+  # as the pair key, cold_booted as a distinct insert) are the R4 contract.
+
+  # volume_created: the durable volume file now exists (or its facts refreshed).
+  # Upsert so a create-after-delete or a generation refresh re-establishes the row.
+  defp project(conn, %Op{kind: :volume_created} = op, _seq) do
+    payload = op.payload
+
+    sql = """
+    INSERT INTO volumes (workload, node_id, generation, size_bytes, allocated_bytes, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(workload) DO UPDATE SET
+      node_id = excluded.node_id,
+      generation = excluded.generation,
+      size_bytes = excluded.size_bytes,
+      allocated_bytes = excluded.allocated_bytes,
+      updated_at = excluded.updated_at
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <-
+           Sqlite3.bind(stmt, [
+             op.workload,
+             Map.get(payload, :node_id),
+             Map.get(payload, :generation, 0),
+             Map.get(payload, :size_bytes),
+             Map.get(payload, :allocated_bytes),
+             op.ts,
+             op.ts
+           ]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # volume_deleted: the durable data is gone (the only destructive data path).
+  defp project(conn, %Op{kind: :volume_deleted} = op, _seq) do
+    sql = "DELETE FROM volumes WHERE workload=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [op.workload]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # stateful_started: a fresh instance boots (FRESH first boot, or an explicit
+  # COLD boot creating a new lifecycle). Inserts the instance and bumps the
+  # volume generation to the attach's post-bump value.
+  defp project(conn, %Op{kind: :stateful_started} = op, _seq) do
+    with :ok <- insert_stateful_instance(conn, op, "starting") do
+      bump_volume_generation(conn, op)
+    end
+  end
+
+  # stateful_cold_booted: a WAKE that discarded warmth and cold-booted, a NEW
+  # instance replacing the retired banked one (the eviction of that bundle rides
+  # a paired stateful_evicted op). reason (generation_mismatch|no_bundle|
+  # ledger_unreadable|explicit) lives in the payload, so the discarded-warmth
+  # event is fully reconstructable from the op alone.
+  defp project(conn, %Op{kind: :stateful_cold_booted} = op, _seq) do
+    with :ok <- insert_stateful_instance(conn, op, "starting") do
+      bump_volume_generation(conn, op)
+    end
+  end
+
+  # stateful_published: the L4 endpoint is live in the fan-out; the instance is
+  # serving.
+  defp project(conn, %Op{kind: :stateful_published} = op, _seq) do
+    payload = op.payload
+    sql = "UPDATE stateful_instances SET state='serving', ip=?, port=?, updated_at=? WHERE instance_id=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <-
+           Sqlite3.bind(stmt, [
+             Map.get(payload, :ip),
+             Map.get(payload, :port),
+             op.ts,
+             op.stateful_instance_id
+           ]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # stateful_unpublished: the endpoint left the fan-out (the activator is
+  # installed in the same LDS/EDS update). Audit-only: the instance's VM is not
+  # necessarily gone (a bank or health-eject follows and sets the real state), so
+  # this only stamps updated_at and leaves the state, keeping boot rebuild's
+  # "there is a live VM, republish it" verdict correct.
+  defp project(conn, %Op{kind: :stateful_unpublished} = op, _seq) do
+    sql = "UPDATE stateful_instances SET updated_at=? WHERE instance_id=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [op.ts, op.stateful_instance_id]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # stateful_banked: the VM is paused, snapshotted, and destroyed. Records the
+  # bundle ref, the STAMPED generation (the pair key), and size; clears the
+  # endpoint (a wake re-reports it).
+  defp project(conn, %Op{kind: :stateful_banked} = op, _seq) do
+    payload = op.payload
+
+    sql = """
+    UPDATE stateful_instances
+    SET state='banked', snapshot_ref=?, snapshot_generation=?, snapshot_size_bytes=?,
+        ip=NULL, port=NULL, updated_at=?
+    WHERE instance_id=?
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <-
+           Sqlite3.bind(stmt, [
+             Map.get(payload, :snapshot_ref),
+             Map.get(payload, :generation),
+             Map.get(payload, :size_bytes),
+             op.ts,
+             op.stateful_instance_id
+           ]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # stateful_relit: a WARM wake resumed the banked bundle. Back to "starting"
+  # (not yet republished) with the fresh vm_id and the post-bump generation;
+  # clears the bundle fields because relight bumped the generation, spending the
+  # bundle (its stamped generation is now stale by construction, decision 2).
+  defp project(conn, %Op{kind: :stateful_relit} = op, _seq) do
+    payload = op.payload
+
+    sql = """
+    UPDATE stateful_instances
+    SET state='starting', node_id=?, vm_id=?, generation=?,
+        snapshot_ref=NULL, snapshot_generation=NULL, updated_at=?
+    WHERE instance_id=?
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <-
+           Sqlite3.bind(stmt, [
+             Map.get(payload, :node_id),
+             Map.get(payload, :vm_id),
+             Map.get(payload, :generation, 0),
+             op.ts,
+             op.stateful_instance_id
+           ]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      bump_volume_generation(conn, op)
+    end
+  end
+
+  defp project(conn, %Op{kind: :stateful_evicted} = op, _seq),
+    do: terminate_stateful(conn, op, "evicted")
+
+  defp project(conn, %Op{kind: :stateful_destroyed} = op, _seq),
+    do: terminate_stateful(conn, op, "destroyed")
+
+  defp project(conn, %Op{kind: :stateful_failed} = op, _seq),
+    do: terminate_stateful(conn, op, "failed")
+
+  # stateful_stats: connection-count usage ONLY, no stateful_instances row to
+  # touch. Carries {workload, cx_delta, window_ms} from the Task 9 idle-signal
+  # TCP scrape (opaque L4 counts connections, not requests), charged into the
+  # same usage.request_count column serving requests use (the L4 unit of work),
+  # so stateful_instance_id is NULL on this kind by construction and the
+  # (principal, day) accrual stays a pure function of the op.
+  defp project(conn, %Op{kind: :stateful_stats} = op, _seq) do
+    project_usage_stateful(conn, op)
+  end
+
   # Audit-only kinds: no task/result projection.
   defp project(_conn, %Op{kind: kind}, _seq)
        when kind in [:denied, :base_built, :primed, :vm_destroyed, :quota_enforced, :drain] do
@@ -861,6 +1135,74 @@ defmodule Embervm.OpLog.SQLite do
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
          :ok <- Sqlite3.bind(stmt, [state, reason, op.ts, op.serving_instance_id]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # Insert a fresh stateful_instances row (stateful_started / stateful_cold_booted).
+  # generation is the volume generation this attach booted with (the pair key
+  # baseline); the bundle fields are NULL until a later stateful_banked stamps them.
+  defp insert_stateful_instance(conn, %Op{} = op, state) do
+    payload = op.payload
+
+    sql = """
+    INSERT INTO stateful_instances
+      (instance_id, tenant, principal, workload, state, node_id, vm_id, ip, port,
+       generation, snapshot_ref, snapshot_generation, snapshot_size_bytes,
+       created_at, last_active_at, updated_at, terminal_reason)
+    VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, NULL, NULL, NULL, ?, NULL, ?, NULL)
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <-
+           Sqlite3.bind(stmt, [
+             op.stateful_instance_id,
+             op.tenant,
+             op.principal,
+             op.workload,
+             Map.get(payload, :state, state),
+             Map.get(payload, :node_id),
+             Map.get(payload, :vm_id),
+             Map.get(payload, :generation, 0),
+             op.ts,
+             op.ts
+           ]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # Bump the volume row's generation to the attach's post-bump value (every
+  # start/relight/cold-boot bumps the on-disk ledger, decision 2). No-op when the
+  # payload carries no generation. Keeps volumes.generation the authoritative
+  # "current" side of the pair check (bundle.snapshot_generation == this).
+  defp bump_volume_generation(conn, %Op{} = op) do
+    case Map.get(op.payload, :generation) do
+      nil ->
+        :ok
+
+      generation ->
+        sql = "UPDATE volumes SET generation=?, updated_at=? WHERE workload=?"
+
+        with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+             :ok <- Sqlite3.bind(stmt, [generation, op.ts, op.workload]),
+             :done <- Sqlite3.step(conn, stmt),
+             :ok <- Sqlite3.release(conn, stmt) do
+          :ok
+        end
+    end
+  end
+
+  # A terminal stateful-instance transition, mirroring terminate_serving/3.
+  defp terminate_stateful(conn, %Op{} = op, state) do
+    reason = to_string(Map.get(op.payload, :reason, state))
+    sql = "UPDATE stateful_instances SET state=?, terminal_reason=?, updated_at=? WHERE instance_id=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [state, reason, op.ts, op.stateful_instance_id]),
          :done <- Sqlite3.step(conn, stmt),
          :ok <- Sqlite3.release(conn, stmt) do
       :ok
@@ -960,6 +1302,37 @@ defmodule Embervm.OpLog.SQLite do
     end
   end
 
+  # stateful_stats usage: charge the connection delta into usage.request_count
+  # (the L4 unit of work), mirroring project_usage_serving/2. Skips a principal-less
+  # op exactly as the serving path does.
+  defp project_usage_stateful(_conn, %Op{principal: nil}), do: :ok
+
+  defp project_usage_stateful(conn, %Op{payload: payload} = op) do
+    cx_delta = Map.get(payload, :cx_delta, 0)
+
+    sql = """
+    INSERT INTO usage (principal, day, tenant, vcpu_seconds, gb_seconds, task_count, request_count, updated_at)
+    VALUES (?, ?, ?, 0, 0, 0, ?, ?)
+    ON CONFLICT(principal, day) DO UPDATE SET
+      request_count = request_count + excluded.request_count,
+      updated_at = excluded.updated_at
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <-
+           Sqlite3.bind(stmt, [
+             op.principal,
+             div(op.ts, @day_ms),
+             op.tenant,
+             cx_delta,
+             op.ts
+           ]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
   defp to_float(n) when is_number(n), do: n * 1.0
   defp to_float(_), do: 0.0
 
@@ -997,7 +1370,7 @@ defmodule Embervm.OpLog.SQLite do
       {:error, {:compacted, marker}}
     else
       sql = """
-      SELECT seq, ts, tenant, principal, workload, task_id, session_id, serving_instance_id, kind, payload_json
+      SELECT seq, ts, tenant, principal, workload, task_id, session_id, serving_instance_id, stateful_instance_id, kind, payload_json
       FROM ops WHERE seq > ? ORDER BY seq ASC
       """
 
@@ -1013,7 +1386,19 @@ defmodule Embervm.OpLog.SQLite do
   defp collect_ops(conn, stmt, acc) do
     case Sqlite3.step(conn, stmt) do
       {:row,
-       [seq, ts, tenant, principal, workload, task_id, session_id, serving_instance_id, kind, payload_json]} ->
+       [
+         seq,
+         ts,
+         tenant,
+         principal,
+         workload,
+         task_id,
+         session_id,
+         serving_instance_id,
+         stateful_instance_id,
+         kind,
+         payload_json
+       ]} ->
         op = %Op{
           seq: seq,
           ts: ts,
@@ -1023,6 +1408,7 @@ defmodule Embervm.OpLog.SQLite do
           task_id: task_id,
           session_id: session_id,
           serving_instance_id: serving_instance_id,
+          stateful_instance_id: stateful_instance_id,
           kind: String.to_existing_atom(kind),
           payload: decode_payload(payload_json)
         }
@@ -1171,6 +1557,104 @@ defmodule Embervm.OpLog.SQLite do
         }
 
         collect_serving_instances(conn, stmt, [instance | acc])
+
+      :done ->
+        Enum.reverse(acc)
+    end
+  end
+
+  defp do_load_stateful_instances(conn) do
+    sql = """
+    SELECT instance_id, tenant, principal, workload, state, node_id, vm_id, ip, port,
+           generation, snapshot_ref, snapshot_generation, snapshot_size_bytes,
+           created_at, last_active_at, updated_at, terminal_reason
+    FROM stateful_instances
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql) do
+      instances = collect_stateful_instances(conn, stmt, [])
+      :ok = Sqlite3.release(conn, stmt)
+      {:ok, instances}
+    end
+  end
+
+  defp collect_stateful_instances(conn, stmt, acc) do
+    case Sqlite3.step(conn, stmt) do
+      {:row,
+       [
+         instance_id,
+         tenant,
+         principal,
+         workload,
+         state,
+         node_id,
+         vm_id,
+         ip,
+         port,
+         generation,
+         snapshot_ref,
+         snapshot_generation,
+         snapshot_size_bytes,
+         created_at,
+         last_active_at,
+         updated_at,
+         terminal_reason
+       ]} ->
+        instance = %{
+          instance_id: instance_id,
+          tenant: tenant,
+          principal: principal,
+          workload: workload,
+          state: state,
+          node_id: node_id,
+          vm_id: vm_id,
+          ip: ip,
+          port: port,
+          generation: generation,
+          snapshot_ref: snapshot_ref,
+          snapshot_generation: snapshot_generation,
+          snapshot_size_bytes: snapshot_size_bytes,
+          created_at: created_at,
+          last_active_at: last_active_at,
+          updated_at: updated_at,
+          terminal_reason: terminal_reason
+        }
+
+        collect_stateful_instances(conn, stmt, [instance | acc])
+
+      :done ->
+        Enum.reverse(acc)
+    end
+  end
+
+  defp do_load_volumes(conn) do
+    sql = """
+    SELECT workload, node_id, generation, size_bytes, allocated_bytes, created_at, updated_at
+    FROM volumes
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql) do
+      volumes = collect_volumes(conn, stmt, [])
+      :ok = Sqlite3.release(conn, stmt)
+      {:ok, volumes}
+    end
+  end
+
+  defp collect_volumes(conn, stmt, acc) do
+    case Sqlite3.step(conn, stmt) do
+      {:row,
+       [workload, node_id, generation, size_bytes, allocated_bytes, created_at, updated_at]} ->
+        volume = %{
+          workload: workload,
+          node_id: node_id,
+          generation: generation,
+          size_bytes: size_bytes,
+          allocated_bytes: allocated_bytes,
+          created_at: created_at,
+          updated_at: updated_at
+        }
+
+        collect_volumes(conn, stmt, [volume | acc])
 
       :done ->
         Enum.reverse(acc)
@@ -1358,10 +1842,13 @@ defmodule Embervm.OpLog.SQLite do
          {:ok, sessions_compacted} <- delete_terminal_sessions(conn, now_ms, state.retention_ms, batch),
          {:ok, serving_instances_compacted} <-
            delete_terminal_serving_instances(conn, now_ms, state.retention_ms, batch),
+         {:ok, stateful_instances_compacted} <-
+           delete_terminal_stateful_instances(conn, now_ms, state.retention_ms, batch),
          {:ok, ops_compacted, marker} <- compact_ops(conn, now_ms, state.journal_horizon_ms, batch) do
       done =
         results_deleted < batch and tasks_compacted < batch and sessions_compacted < batch and
-          serving_instances_compacted < batch and ops_compacted < batch
+          serving_instances_compacted < batch and stateful_instances_compacted < batch and
+          ops_compacted < batch
 
       {:ok,
        %{
@@ -1369,6 +1856,7 @@ defmodule Embervm.OpLog.SQLite do
          tasks_compacted: tasks_compacted,
          sessions_compacted: sessions_compacted,
          serving_instances_compacted: serving_instances_compacted,
+         stateful_instances_compacted: stateful_instances_compacted,
          ops_compacted: ops_compacted,
          compacted_through: marker,
          done: done
@@ -1416,6 +1904,29 @@ defmodule Embervm.OpLog.SQLite do
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
          :ok <- Sqlite3.bind(stmt, @serving_terminal_states ++ [cutoff, batch]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt),
+         {:ok, changed} <- Sqlite3.changes(conn) do
+      {:ok, changed}
+    end
+  end
+
+  # Prune terminal stateful-instance projection rows past retention, mirroring
+  # delete_terminal_serving_instances/4. A non-terminal instance is never pruned,
+  # and its ops stay pinned by blocker_seq. The `volumes` table is deliberately
+  # NOT swept: a volume row lives until volume_deleted (data outlives instances).
+  defp delete_terminal_stateful_instances(conn, now_ms, retention_ms, batch) do
+    cutoff = now_ms - retention_ms
+    placeholders = @stateful_terminal_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
+
+    sql = """
+    DELETE FROM stateful_instances WHERE rowid IN (
+      SELECT rowid FROM stateful_instances WHERE state IN (#{placeholders}) AND updated_at < ? LIMIT ?
+    )
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, @stateful_terminal_states ++ [cutoff, batch]),
          :done <- Sqlite3.step(conn, stmt),
          :ok <- Sqlite3.release(conn, stmt),
          {:ok, changed} <- Sqlite3.changes(conn) do
@@ -1501,6 +2012,7 @@ defmodule Embervm.OpLog.SQLite do
     live_placeholders = @live_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
     session_live_placeholders = @session_live_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
     serving_live_placeholders = @serving_live_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
+    stateful_live_placeholders = @stateful_live_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
 
     sql = """
     SELECT MIN(seq) FROM ops
@@ -1510,13 +2022,17 @@ defmodule Embervm.OpLog.SQLite do
        OR serving_instance_id IN (
             SELECT instance_id FROM serving_instances WHERE state IN (#{serving_live_placeholders})
           )
+       OR stateful_instance_id IN (
+            SELECT instance_id FROM stateful_instances WHERE state IN (#{stateful_live_placeholders})
+          )
     """
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
          :ok <-
            Sqlite3.bind(
              stmt,
-             [cutoff] ++ @live_states ++ @session_live_states ++ @serving_live_states
+             [cutoff] ++
+               @live_states ++ @session_live_states ++ @serving_live_states ++ @stateful_live_states
            ) do
       result =
         case Sqlite3.step(conn, stmt) do
@@ -1643,7 +2159,8 @@ defmodule Embervm.OpLog.SQLite do
     with :ok <- migrate_results_headers(conn),
          :ok <- migrate_ops_session_id(conn),
          :ok <- migrate_ops_serving_instance_id(conn),
-         :ok <- migrate_usage_request_count(conn) do
+         :ok <- migrate_usage_request_count(conn),
+         :ok <- migrate_ops_stateful_instance_id(conn) do
       :ok
     end
   end
@@ -1706,6 +2223,29 @@ defmodule Embervm.OpLog.SQLite do
       else
         Sqlite3.execute(conn, "ALTER TABLE usage ADD COLUMN request_count INTEGER NOT NULL DEFAULT 0")
       end
+    end
+  end
+
+  # R4: the additive nullable `ops.stateful_instance_id` column plus its index,
+  # mirroring migrate_ops_serving_instance_id/1 exactly. A fresh DB already built
+  # the column from the CREATE TABLE (and skips the ALTER), so this only fires on
+  # a DB created before R4; the guard is the same D-R1.2.1/R2/R3 ALTER-after-DDL
+  # precedent. `stateful_instances` and `volumes` are whole new tables, so
+  # `CREATE TABLE IF NOT EXISTS` in @ddl handles both cases; no ALTER is needed
+  # for them.
+  defp migrate_ops_stateful_instance_id(conn) do
+    with {:ok, cols} <- table_columns(conn, "ops"),
+         :ok <-
+           add_column_if_missing(
+             conn,
+             cols,
+             "stateful_instance_id",
+             "ALTER TABLE ops ADD COLUMN stateful_instance_id TEXT"
+           ) do
+      Sqlite3.execute(
+        conn,
+        "CREATE INDEX IF NOT EXISTS ops_stateful_instance_id_idx ON ops(stateful_instance_id)"
+      )
     end
   end
 

--- a/projects/embervm/control/lib/embervm/workload_watcher.ex
+++ b/projects/embervm/control/lib/embervm/workload_watcher.ex
@@ -62,6 +62,11 @@ defmodule Embervm.WorkloadWatcher do
   @default_table :embervm_workloads
   @base_backoff_ms 1_000
   @max_backoff_ms 30_000
+  # The default stateful TCP listenPort range, matching the chart's values
+  # default (projects/embervm/chart, Task 6). Overridable via the
+  # :stateful_listen_range app env or a start_link opt so the chart value flows
+  # in and tests can inject a narrow range.
+  @default_stateful_listen_range 5400..5409
   # A healthy watch lives for the apiserver's full `timeoutSeconds` (~5 min);
   # a watch that ends far sooner is a signal of trouble, not a normal cycle. So
   # only a watch that stayed open at least this long earns an IMMEDIATE
@@ -123,11 +128,18 @@ defmodule Embervm.WorkloadWatcher do
     max_backoff = Keyword.get(opts, :max_backoff_ms, @max_backoff_ms)
     min_watch = Keyword.get(opts, :min_watch_ms, @min_watch_ms)
     watch_startup = Keyword.get(opts, :watch_startup, true)
+    # The values-declared stateful TCP listenPort range (Task 6 wires the chart
+    # value in via config; the default matches the chart default 5400-5409). The
+    # watcher validates every stateful workload's listenPort against it.
+    stateful_listen_range =
+      Keyword.get(opts, :stateful_listen_range) ||
+        Application.get_env(:embervm, :stateful_listen_range, @default_stateful_listen_range)
 
     WorkloadCatalog.create(table)
 
     state = %{
       table: table,
+      stateful_listen_range: stateful_listen_range,
       lister: lister,
       watcher_fun: watcher_fun,
       status_writer: status_writer,
@@ -426,8 +438,10 @@ defmodule Embervm.WorkloadWatcher do
       spec = Map.get(cr, "spec") || %{}
 
       case validate(state, name, spec) do
-        {:ok, class, floor, cap, session_cfg, serving_cfg} ->
-          entry = catalog_entry(name, namespace, spec, class, floor, cap, session_cfg, serving_cfg)
+        {:ok, class, floor, cap, session_cfg, serving_cfg, stateful_cfg} ->
+          entry =
+            catalog_entry(name, namespace, spec, class, floor, cap, session_cfg, serving_cfg, stateful_cfg)
+
           WorkloadCatalog.upsert(state.table, name, entry)
 
           # A valid Workload's Ready/BaseBuilt conditions are owned by the
@@ -568,20 +582,22 @@ defmodule Embervm.WorkloadWatcher do
   defp validate(state, name, spec) do
     with {:ok, class} <- validate_class(spec),
          :ok <- validate_source(spec),
-         {:ok, floor, cap} <- validate_concurrency(spec),
+         {:ok, floor, cap} <- validate_concurrency(spec, class),
          {:ok, session_cfg} <- validate_session(spec, class),
-         {:ok, serving_cfg} <- validate_serving(state, name, spec, class, cap) do
-      {:ok, class, floor, cap, session_cfg, serving_cfg}
+         {:ok, serving_cfg} <- validate_serving(state, name, spec, class, cap),
+         {:ok, stateful_cfg} <- validate_stateful(state, name, spec, class) do
+      {:ok, class, floor, cap, session_cfg, serving_cfg, stateful_cfg}
     end
   end
 
   defp validate_class(%{"class" => "task"}), do: {:ok, "task"}
   defp validate_class(%{"class" => "session"}), do: {:ok, "session"}
   defp validate_class(%{"class" => "serving"}), do: {:ok, "serving"}
+  defp validate_class(%{"class" => "stateful"}), do: {:ok, "stateful"}
 
   defp validate_class(spec) do
     {:error, "ClassUnsupported",
-     "class #{inspect(Map.get(spec, "class"))} is reserved for a later rung; only task, session, and serving are valid in v1alpha1"}
+     "class #{inspect(Map.get(spec, "class"))} is reserved for a later rung; only task, session, serving, and stateful are valid in v1alpha1"}
   end
 
   # The session block is REQUIRED for the session class and FORBIDDEN for the
@@ -596,7 +612,7 @@ defmodule Embervm.WorkloadWatcher do
     invoke_queue_cap: 4
   }
 
-  defp validate_session(spec, class) when class in ["task", "serving"] do
+  defp validate_session(spec, class) when class in ["task", "serving", "stateful"] do
     case Map.get(spec, "session") do
       nil -> {:ok, nil}
       _ -> {:error, "SessionSpecUnexpected", "spec.session is only valid for class session, not #{class}"}
@@ -651,7 +667,7 @@ defmodule Embervm.WorkloadWatcher do
     banked_ttl_seconds: 86_400
   }
 
-  defp validate_serving(_state, _name, spec, class, _cap) when class in ["task", "session"] do
+  defp validate_serving(_state, _name, spec, class, _cap) when class in ["task", "session", "stateful"] do
     case Map.get(spec, "serving") do
       nil -> {:ok, nil}
       _ -> {:error, "ServingSpecUnexpected", "spec.serving is only valid for class serving, not #{class}"}
@@ -743,6 +759,129 @@ defmodule Embervm.WorkloadWatcher do
     }
   end
 
+  # The stateful block is REQUIRED for the stateful class and FORBIDDEN for every
+  # other class (the class-conditional requiredness the OpenAPI schema cannot
+  # express), mirroring validate_serving/5. Three stateful-only cross-field rules
+  # beyond presence: listenPort must fall inside the chart's values-declared TCP
+  # range (state.stateful_listen_range), listenPort must be unique across live
+  # stateful workloads (one port, one workload, decision 5, checked against the
+  # LIVE catalog like the serving host-uniqueness rule), and volumeSizeGiB is
+  # immutable in v1 (an edit against an already-cataloged size is rejected).
+  @stateful_defaults %{
+    volume_mount_path: "/data",
+    idle_bank_seconds: 300,
+    max_lifetime_seconds: 86_400,
+    banked_ttl_seconds: 604_800,
+    wake_timeout_seconds: 60
+  }
+  # The minimum idleBankSeconds (decision: a too-eager bank thrashes wake/bank);
+  # the CRD schema also enforces this, re-checked here for the LIST/WATCH path.
+  @stateful_min_idle_bank_seconds 30
+
+  defp validate_stateful(_state, _name, spec, class) when class in ["task", "session", "serving"] do
+    case Map.get(spec, "stateful") do
+      nil -> {:ok, nil}
+      _ -> {:error, "StatefulSpecUnexpected", "spec.stateful is only valid for class stateful, not #{class}"}
+    end
+  end
+
+  defp validate_stateful(state, name, spec, "stateful") do
+    case Map.get(spec, "stateful") do
+      s when is_map(s) ->
+        with :ok <- validate_stateful_listen_port(state, name, s),
+             :ok <- validate_stateful_idle_bank(s),
+             :ok <- validate_stateful_volume_immutable(state, name, s) do
+          {:ok, parse_stateful(s)}
+        end
+
+      _ ->
+        {:error, "StatefulSpecMissing", "class stateful requires a spec.stateful block"}
+    end
+  end
+
+  # listenPort must be inside the values-declared range AND unique across every
+  # other live stateful workload. Out-of-range names the configured range in the
+  # condition (operator-actionable); a duplicate names the conflicting workload.
+  defp validate_stateful_listen_port(state, name, s) do
+    listen_port = Map.get(s, "listenPort")
+    range = state.stateful_listen_range
+
+    cond do
+      not is_integer(listen_port) ->
+        {:error, "InvalidStatefulSpec", "spec.stateful.listenPort is required and must be an integer"}
+
+      listen_port not in range ->
+        {:error, "StatefulListenPortOutOfRange",
+         "spec.stateful.listenPort #{listen_port} is outside the configured stateful range #{Enum.min(range)}-#{Enum.max(range)}"}
+
+      true ->
+        case stateful_listen_port_conflict(state, name, listen_port) do
+          nil -> :ok
+          other ->
+            {:error, "StatefulListenPortConflict",
+             "spec.stateful.listenPort #{listen_port} is already owned by workload #{inspect(other)}"}
+        end
+    end
+  end
+
+  defp stateful_listen_port_conflict(state, name, listen_port) do
+    state.table
+    |> WorkloadCatalog.all_names()
+    |> Enum.reject(&(&1 == name))
+    |> Enum.find(fn other_name ->
+      case WorkloadCatalog.fetch(state.table, other_name) do
+        {:ok, %{class: "stateful", stateful: %{listen_port: ^listen_port}}} -> true
+        _ -> false
+      end
+    end)
+  end
+
+  defp validate_stateful_idle_bank(s) do
+    case Map.get(s, "idleBankSeconds") do
+      nil ->
+        :ok
+
+      idle when is_integer(idle) and idle >= @stateful_min_idle_bank_seconds ->
+        :ok
+
+      idle ->
+        {:error, "InvalidStatefulSpec",
+         "spec.stateful.idleBankSeconds #{inspect(idle)} must be >= #{@stateful_min_idle_bank_seconds}"}
+    end
+  end
+
+  # volumeSizeGiB is immutable in v1 (resize is a recorded follow-on): an edit
+  # against an already-cataloged size is rejected so a resize attempt surfaces
+  # loudly rather than silently doing nothing (the volume file is not resized).
+  # Compared against the LIVE catalog entry (self, by name), so the first
+  # cataloging of a workload always passes and only a later size change trips.
+  defp validate_stateful_volume_immutable(state, name, s) do
+    new_size = Map.get(s, "volumeSizeGiB")
+
+    case WorkloadCatalog.fetch(state.table, name) do
+      {:ok, %{class: "stateful", stateful: %{volume_size_gib: existing}}}
+      when is_integer(existing) and existing != new_size ->
+        {:error, "StatefulVolumeSizeImmutable",
+         "spec.stateful.volumeSizeGiB is immutable (was #{existing}, got #{inspect(new_size)}); volume resize is not supported in v1"}
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp parse_stateful(s) do
+    %{
+      port: Map.get(s, "port"),
+      listen_port: Map.get(s, "listenPort"),
+      volume_size_gib: Map.get(s, "volumeSizeGiB"),
+      volume_mount_path: Map.get(s, "volumeMountPath") || @stateful_defaults.volume_mount_path,
+      idle_bank_seconds: Map.get(s, "idleBankSeconds") || @stateful_defaults.idle_bank_seconds,
+      max_lifetime_seconds: Map.get(s, "maxLifetimeSeconds") || @stateful_defaults.max_lifetime_seconds,
+      banked_ttl_seconds: Map.get(s, "bankedTtlSeconds") || @stateful_defaults.banked_ttl_seconds,
+      wake_timeout_seconds: Map.get(s, "wakeTimeoutSeconds") || @stateful_defaults.wake_timeout_seconds
+    }
+  end
+
   # The CRD schema enforces the structural oneOf (exactly one of image|zip) at
   # admission, but a CR observed via LIST/WATCH is trusted only as far as this
   # code re-checks it: enforce the same mutual exclusion here (both set, or
@@ -789,7 +928,18 @@ defmodule Embervm.WorkloadWatcher do
     end
   end
 
-  defp validate_concurrency(spec) do
+  # The stateful class is a SINGLETON by construction (decision 3): exactly one
+  # live VM, no maxInstances knob. spec.concurrency is condition-rejected, and the
+  # class's internal floor/cap are fixed at scale-to-zero singleton (0, 1) so the
+  # catalog entry keeps a uniform shape without a concurrency block.
+  defp validate_concurrency(spec, "stateful") do
+    case Map.get(spec, "concurrency") do
+      nil -> {:ok, 0, 1}
+      _ -> {:error, "ConcurrencyUnexpected", "spec.concurrency is not valid for class stateful (singleton by construction)"}
+    end
+  end
+
+  defp validate_concurrency(spec, _class) do
     cap = get_in(spec, ["concurrency", "cap"])
     floor = get_in(spec, ["concurrency", "floor"]) || 0
 
@@ -809,7 +959,7 @@ defmodule Embervm.WorkloadWatcher do
   # reflects whatever the apiserver already defaulted at admission;
   # re-defaulting here just means this code has no silent dependency on that
   # having happened.
-  defp catalog_entry(name, namespace, spec, class, floor, cap, session_cfg, serving_cfg) do
+  defp catalog_entry(name, namespace, spec, class, floor, cap, session_cfg, serving_cfg, stateful_cfg) do
     resources = Map.get(spec, "resources") || %{}
     invocation = Map.get(spec, "invocation") || %{}
     source = parse_source(spec)
@@ -818,6 +968,11 @@ defmodule Embervm.WorkloadWatcher do
       name: name,
       namespace: namespace,
       class: class,
+      # Stateful-class volume + L4 config (nil except for the stateful class),
+      # carried so the StatefulStore/TcpActivator (Tasks 7/8) read listenPort,
+      # port, volume sizing, and the idle/lifetime/ttl knobs from the catalog
+      # exactly as SessionStore/EndpointPublisher read their class config.
+      stateful: stateful_cfg,
       # Session-class lifecycle config (nil for the task class), carried so the
       # SessionManager/SessionStore (later PRs) read idle-bank/lifetime/caps from
       # the catalog exactly as the dispatcher reads task caps.

--- a/projects/embervm/control/test/embervm/op_log/stateful_projection_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/stateful_projection_test.exs
@@ -253,10 +253,13 @@ defmodule Embervm.OpLog.StatefulProjectionTest do
     vol = volume_by_workload(server)["scratch-postgres"]
     assert vol.generation == 3
 
-    # The cold-boot reason is reconstructable from the op-log alone.
+    # The cold-boot reason is reconstructable from the op-log alone. A payload
+    # read back through read_from is decoded with STRING keys (the durable
+    # payload_json round-trip), unlike the atom-keyed map the projection saw at
+    # append time, so assert on the string key.
     {:ok, ops} = SQLite.read_from(server, 0)
     cold = Enum.find(ops, &(&1.kind == :stateful_cold_booted))
-    assert cold.payload.reason == "generation_mismatch"
+    assert cold.payload["reason"] == "generation_mismatch"
     assert cold.stateful_instance_id == "st-3-wake"
 
     :ok = GenServer.stop(server)

--- a/projects/embervm/control/test/embervm/op_log/stateful_projection_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/stateful_projection_test.exs
@@ -1,0 +1,452 @@
+defmodule Embervm.OpLog.StatefulProjectionTest do
+  @moduledoc """
+  Exercises the R4 stateful-instance and volume records, the generation-pairing
+  audit, and retention discipline on the SQLite op-log backend directly,
+  mirroring serving_projection_test.exs (each test opens its own GenServer over a
+  fresh temp file, so it can stop/restart to simulate crash recovery). Covers:
+
+    * projection rebuild from a scripted stateful op sequence reproduces exact
+      stateful_instances states (start -> publish -> unpublish -> bank -> relight,
+      warm; and a full pair-mismatch cold-boot cycle);
+    * the volume row is created, its generation tracks every attach's bump, and
+      it OUTLIVES the instance (retention never prunes it, and it survives a
+      terminal instance);
+    * stateful_stats charges usage.request_count by cx_delta, principal from the
+      op, vcpu/gb/task_count untouched;
+    * retention never prunes a non-terminal stateful instance, prunes a terminal
+      one past the 7-day window, and never touches the volumes table;
+    * the ops-journal prefix marker never advances past a LIVE stateful
+      instance's ops;
+    * a kill/restart rebuilds stateful instance AND volume state exactly.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.OpLog.Op
+  alias Embervm.OpLog.SQLite
+
+  setup do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "embervm_oplog_stateful_test_#{System.unique_integer([:positive, :monotonic])}.db"
+      )
+
+    on_exit(fn -> File.rm_rf!(path) end)
+    %{path: path}
+  end
+
+  defp start_server(path, extra_opts \\ []) do
+    opts = Keyword.merge([path: path, name: nil], extra_opts)
+    {:ok, pid} = SQLite.start_link(opts)
+    pid
+  end
+
+  defp volume_created_op(ts, generation, extra \\ %{}) do
+    %Op{
+      kind: :volume_created,
+      tenant: "t1",
+      principal: "p1",
+      workload: "scratch-postgres",
+      ts: ts,
+      payload:
+        Map.merge(
+          %{node_id: "node-4", generation: generation, size_bytes: 10_737_418_240, allocated_bytes: 0},
+          extra
+        )
+    }
+  end
+
+  defp started_op(instance_id, ts, generation, extra \\ %{}) do
+    %Op{
+      kind: :stateful_started,
+      tenant: "t1",
+      principal: "p1",
+      workload: "scratch-postgres",
+      stateful_instance_id: instance_id,
+      ts: ts,
+      payload:
+        Map.merge(
+          %{node_id: "node-4", vm_id: "vm-#{instance_id}", generation: generation},
+          extra
+        )
+    }
+  end
+
+  defp instance_by_id(server) do
+    {:ok, instances} = SQLite.load_stateful_instances(server)
+    Map.new(instances, &{&1.instance_id, &1})
+  end
+
+  defp volume_by_workload(server) do
+    {:ok, volumes} = SQLite.load_volumes(server)
+    Map.new(volumes, &{&1.workload, &1})
+  end
+
+  test "a scripted start -> publish -> unpublish -> bank -> relight -> publish sequence projects exact state, warm",
+       %{path: path} do
+    server = start_server(path)
+
+    # Volume created first (generation 1), then the FRESH boot at generation 1.
+    {:ok, _} = SQLite.append(server, volume_created_op(90, 1))
+    {:ok, _} = SQLite.append(server, started_op("st-1", 100, 1))
+
+    i0 = instance_by_id(server)["st-1"]
+    assert i0.state == "starting"
+    assert i0.generation == 1
+    assert i0.snapshot_ref == nil
+    assert volume_by_workload(server)["scratch-postgres"].generation == 1
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :stateful_published,
+        tenant: "t1",
+        principal: "p1",
+        workload: "scratch-postgres",
+        stateful_instance_id: "st-1",
+        ts: 150,
+        payload: %{ip: "10.99.0.3", port: 5432}
+      })
+
+    i1 = instance_by_id(server)["st-1"]
+    assert i1.state == "serving"
+    assert i1.ip == "10.99.0.3"
+    assert i1.port == 5432
+
+    # Unpublish is audit-only: the VM still exists, so state stays "serving".
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :stateful_unpublished,
+        tenant: "t1",
+        principal: "p1",
+        workload: "scratch-postgres",
+        stateful_instance_id: "st-1",
+        ts: 200,
+        payload: %{reason: "idle_bank"}
+      })
+
+    assert instance_by_id(server)["st-1"].state == "serving"
+
+    # Bank stamps generation 1 into the bundle and clears the endpoint.
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :stateful_banked,
+        tenant: "t1",
+        principal: "p1",
+        workload: "scratch-postgres",
+        stateful_instance_id: "st-1",
+        ts: 250,
+        payload: %{snapshot_ref: "stateful/scratch-postgres", size_bytes: 16384, generation: 1}
+      })
+
+    banked = instance_by_id(server)["st-1"]
+    assert banked.state == "banked"
+    assert banked.snapshot_ref == "stateful/scratch-postgres"
+    assert banked.snapshot_generation == 1
+    assert banked.snapshot_size_bytes == 16384
+    assert banked.ip == nil
+    # Pair is valid: bundle's stamped generation == volume's current generation.
+    assert banked.snapshot_generation == volume_by_workload(server)["scratch-postgres"].generation
+
+    # A warm relight bumps the generation to 2, spends the bundle (clears the
+    # snapshot fields), and returns to "starting".
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :stateful_relit,
+        tenant: "t1",
+        principal: "p1",
+        workload: "scratch-postgres",
+        stateful_instance_id: "st-1",
+        ts: 300,
+        payload: %{node_id: "node-4", vm_id: "vm-st1-relit", generation: 2}
+      })
+
+    relit = instance_by_id(server)["st-1"]
+    assert relit.state == "starting"
+    assert relit.vm_id == "vm-st1-relit"
+    assert relit.generation == 2
+    assert relit.snapshot_ref == nil
+    assert relit.snapshot_generation == nil
+    # The attach bumped the volume generation too.
+    assert volume_by_workload(server)["scratch-postgres"].generation == 2
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :stateful_published,
+        tenant: "t1",
+        principal: "p1",
+        workload: "scratch-postgres",
+        stateful_instance_id: "st-1",
+        ts: 350,
+        payload: %{ip: "10.99.0.7", port: 5432}
+      })
+
+    republished = instance_by_id(server)["st-1"]
+    assert republished.state == "serving"
+    assert republished.ip == "10.99.0.7"
+    assert republished.created_at == 100
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "a pair-mismatch cold-boot cycle: bundle evicted, new cold-booted instance, data intact",
+       %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, volume_created_op(90, 1))
+    {:ok, _} = SQLite.append(server, started_op("st-1", 100, 1))
+
+    # Bank stamps generation 1.
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :stateful_banked,
+        tenant: "t1",
+        principal: "p1",
+        workload: "scratch-postgres",
+        stateful_instance_id: "st-1",
+        ts: 200,
+        payload: %{snapshot_ref: "stateful/scratch-postgres", size_bytes: 16384, generation: 1}
+      })
+
+    # An out-of-band COLD boot bumps the volume to generation 2 WITHOUT the
+    # banked bundle witnessing it: the pair is now broken. Modelled as a new
+    # instance's stateful_started at generation 2 (an explicit COLD).
+    {:ok, _} = SQLite.append(server, started_op("st-2-cold", 250, 2))
+
+    # The banked instance's bundle is now stale; the eager sweep evicts it
+    # (terminal for that instance) ...
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :stateful_evicted,
+        tenant: "t1",
+        principal: "p1",
+        workload: "scratch-postgres",
+        stateful_instance_id: "st-1",
+        ts: 260,
+        payload: %{reason: "pair_broken"}
+      })
+
+    # ... and a later wake that tried to relight falls back to a cold boot at
+    # generation 3, recording the reason for full log reconstructability.
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :stateful_cold_booted,
+        tenant: "t1",
+        principal: "p1",
+        workload: "scratch-postgres",
+        stateful_instance_id: "st-3-wake",
+        ts: 300,
+        payload: %{
+          node_id: "node-4",
+          vm_id: "vm-st3",
+          generation: 3,
+          reason: "generation_mismatch"
+        }
+      })
+
+    by_id = instance_by_id(server)
+    assert by_id["st-1"].state == "evicted"
+    assert by_id["st-1"].terminal_reason == "pair_broken"
+    assert by_id["st-3-wake"].state == "starting"
+    assert by_id["st-3-wake"].generation == 3
+
+    # The volume outlived every instance and tracks the latest attach generation.
+    vol = volume_by_workload(server)["scratch-postgres"]
+    assert vol.generation == 3
+
+    # The cold-boot reason is reconstructable from the op-log alone.
+    {:ok, ops} = SQLite.read_from(server, 0)
+    cold = Enum.find(ops, &(&1.kind == :stateful_cold_booted))
+    assert cold.payload.reason == "generation_mismatch"
+    assert cold.stateful_instance_id == "st-3-wake"
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "each terminal kind projects its terminal state and reason", %{path: path} do
+    server = start_server(path)
+
+    for {iid, kind, expected_state} <- [
+          {"st-evi", :stateful_evicted, "evicted"},
+          {"st-des", :stateful_destroyed, "destroyed"},
+          {"st-fai", :stateful_failed, "failed"}
+        ] do
+      {:ok, _} = SQLite.append(server, started_op(iid, 100, 1))
+
+      {:ok, _} =
+        SQLite.append(server, %Op{
+          kind: kind,
+          tenant: "t1",
+          principal: "p1",
+          workload: "scratch-postgres",
+          stateful_instance_id: iid,
+          ts: 500,
+          payload: %{reason: expected_state}
+        })
+
+      i = instance_by_id(server)[iid]
+      assert i.state == expected_state
+      assert i.terminal_reason == expected_state
+    end
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "stateful_stats charges usage.request_count by cx_delta, vcpu/gb/task untouched", %{path: path} do
+    server = start_server(path)
+
+    day5 = 5 * 86_400_000
+
+    for delta <- [4, 6] do
+      {:ok, _} =
+        SQLite.append(server, %Op{
+          kind: :stateful_stats,
+          tenant: "t1",
+          principal: "p1",
+          workload: "scratch-postgres",
+          stateful_instance_id: nil,
+          ts: day5 + delta,
+          payload: %{workload: "scratch-postgres", cx_delta: delta, window_ms: 5_000}
+        })
+    end
+
+    {:ok, page} = SQLite.list_usage(server, since_day: 0)
+    row = Enum.find(page.items, &(&1.principal == "p1"))
+
+    assert row.request_count == 10
+    assert row.vcpu_seconds == 0.0
+    assert row.gb_seconds == 0.0
+    assert row.task_count == 0
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "retention prunes a terminal instance but never a live one, and never the volume", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, volume_created_op(90, 1))
+    {:ok, _} = SQLite.append(server, started_op("st-live", 100, 1))
+    {:ok, _} = SQLite.append(server, started_op("st-term", 100, 1))
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :stateful_destroyed,
+        tenant: "t1",
+        principal: "p1",
+        workload: "scratch-postgres",
+        stateful_instance_id: "st-term",
+        ts: 200,
+        payload: %{reason: "forced_roll"}
+      })
+
+    eight_days = 8 * 24 * 60 * 60 * 1000
+    {:ok, res} = SQLite.compact(server, 100 + eight_days)
+    assert res.stateful_instances_compacted == 1
+
+    ids = instance_by_id(server) |> Map.keys() |> Enum.sort()
+    assert ids == ["st-live"]
+
+    # The volume is NEVER swept by retention: data outlives every instance.
+    assert Map.has_key?(volume_by_workload(server), "scratch-postgres")
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "the ops-journal marker never advances past a live stateful instance's ops", %{path: path} do
+    server = start_server(path, journal_horizon_ms: 0)
+
+    {:ok, live_seq} = SQLite.append(server, started_op("st-live", 100, 1))
+    {:ok, _} = SQLite.append(server, %Op{kind: :denied, tenant: "t1", ts: 101, payload: %{}})
+
+    {:ok, res} = SQLite.compact(server, 10_000)
+    assert res.compacted_through == live_seq - 1
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :stateful_destroyed,
+        tenant: "t1",
+        principal: "p1",
+        workload: "scratch-postgres",
+        stateful_instance_id: "st-live",
+        ts: 102,
+        payload: %{reason: "destroyed"}
+      })
+
+    {:ok, res2} = SQLite.compact(server, 10_000)
+    {:ok, max_seq} = SQLite.compacted_through(server)
+    assert res2.compacted_through == max_seq
+    assert max_seq >= live_seq
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "kill/restart rebuilds stateful instance and volume state from the projection", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, volume_created_op(90, 1))
+    {:ok, _} = SQLite.append(server, started_op("st-a", 100, 1))
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :stateful_banked,
+        tenant: "t1",
+        principal: "p1",
+        workload: "scratch-postgres",
+        stateful_instance_id: "st-a",
+        ts: 200,
+        payload: %{snapshot_ref: "stateful/scratch-postgres", size_bytes: 16384, generation: 1}
+      })
+
+    :ok = GenServer.stop(server)
+
+    server2 = start_server(path)
+    by_id = instance_by_id(server2)
+
+    assert by_id["st-a"].state == "banked"
+    assert by_id["st-a"].snapshot_generation == 1
+    assert by_id["st-a"].snapshot_ref == "stateful/scratch-postgres"
+    assert by_id["st-a"].ip == nil
+
+    vol = volume_by_workload(server2)["scratch-postgres"]
+    assert vol.generation == 1
+    assert vol.size_bytes == 10_737_418_240
+
+    :ok = GenServer.stop(server2)
+  end
+
+  test "a fresh DB reports stateful_instance_id on stateful ops through read_from, NULL on stats and volume ops",
+       %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, volume_created_op(90, 1))
+    {:ok, _} = SQLite.append(server, started_op("st-r", 100, 1))
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :stateful_stats,
+        tenant: "t1",
+        principal: "p1",
+        workload: "scratch-postgres",
+        stateful_instance_id: nil,
+        ts: 101,
+        payload: %{workload: "scratch-postgres", cx_delta: 1, window_ms: 5_000}
+      })
+
+    {:ok, ops} = SQLite.read_from(server, 0)
+
+    started = Enum.find(ops, &(&1.kind == :stateful_started))
+    assert started.stateful_instance_id == "st-r"
+    assert started.task_id == nil
+    assert started.session_id == nil
+    assert started.serving_instance_id == nil
+
+    stats = Enum.find(ops, &(&1.kind == :stateful_stats))
+    assert stats.stateful_instance_id == nil
+    assert stats.principal == "p1"
+
+    vol_op = Enum.find(ops, &(&1.kind == :volume_created))
+    assert vol_op.stateful_instance_id == nil
+    assert vol_op.workload == "scratch-postgres"
+
+    :ok = GenServer.stop(server)
+  end
+end

--- a/projects/embervm/control/test/embervm/workload_watcher_test.exs
+++ b/projects/embervm/control/test/embervm/workload_watcher_test.exs
@@ -197,9 +197,9 @@ defmodule Embervm.WorkloadWatcherTest do
     table = unique_table()
     agent = start_recorder()
     base = start_base_recorder()
-    # `stateful` is still reserved for a later rung (task/session/serving are
-    # all valid as of R3).
-    cr = valid_cr(%{"spec" => %{"class" => "stateful"}})
+    # `cluster` is reserved for a later rung (task/session/serving/stateful are
+    # all valid as of R4).
+    cr = valid_cr(%{"spec" => %{"class" => "cluster"}})
     lister = fn -> {:ok, [cr]} end
     watcher = start_watcher(lister, recording_status_writer(agent), table, base_seams(agent: base))
 
@@ -581,6 +581,207 @@ defmodule Embervm.WorkloadWatcherTest do
 
     assert {:ok, entry} = WorkloadCatalog.fetch(table, "sandbox-serving-2")
     assert entry.serving.host == "sandbox.serve.example.com"
+  end
+
+  # -- stateful class (R4) ----------------------------------------------------
+
+  # A valid stateful CR: an image source plus the required spec.stateful block,
+  # and NO concurrency block (singleton by construction).
+  defp stateful_cr(overrides \\ %{}) do
+    base = %{
+      "metadata" => %{"name" => "scratch-postgres", "namespace" => "embervm", "generation" => 1},
+      "spec" => %{
+        "class" => "stateful",
+        "source" => %{"image" => %{"ref" => "scratch-postgres", "port" => 1027}},
+        "resources" => %{"vcpus" => 1, "memMib" => 512},
+        "stateful" => %{
+          "port" => 5432,
+          # listenPort must fall inside the default range 5400..5409 (the guest
+          # port 5432 is distinct and unconstrained).
+          "listenPort" => 5401,
+          "volumeSizeGiB" => 10,
+          "volumeMountPath" => "/data",
+          "idleBankSeconds" => 600,
+          "maxLifetimeSeconds" => 604_800,
+          "bankedTtlSeconds" => 2_592_000,
+          "wakeTimeoutSeconds" => 60
+        }
+      }
+    }
+
+    deep_merge(base, overrides)
+  end
+
+  test "stateful class: a valid stateful CR is cataloged with class and stateful config, singleton floor/cap" do
+    table = unique_table()
+    agent = start_recorder()
+    lister = fn -> {:ok, [stateful_cr()]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert {:ok, entry} = WorkloadCatalog.fetch(table, "scratch-postgres")
+    assert entry.class == "stateful"
+    # Singleton by construction: no concurrency block, internal floor/cap 0/1.
+    assert entry.floor == 0
+    assert entry.cap == 1
+    assert entry.stateful.port == 5432
+    assert entry.stateful.listen_port == 5401
+    assert entry.stateful.volume_size_gib == 10
+    assert entry.stateful.volume_mount_path == "/data"
+    assert entry.stateful.idle_bank_seconds == 600
+    assert entry.stateful.max_lifetime_seconds == 604_800
+    assert entry.stateful.banked_ttl_seconds == 2_592_000
+    assert entry.stateful.wake_timeout_seconds == 60
+
+    assert {_ns, "scratch-postgres", status_map} = ready_status(recorded_calls(agent), "scratch-postgres")
+    assert status_map["observedGeneration"] == 1
+    refute Map.has_key?(status_map, "conditions")
+  end
+
+  test "stateful class: stateful block defaults apply when optional fields are omitted" do
+    table = unique_table()
+    agent = start_recorder()
+    # Only the required fields; every optional field falls back to its default.
+    cr =
+      put_in(stateful_cr(), ["spec", "stateful"], %{
+        "port" => 5432,
+        "listenPort" => 5400,
+        "volumeSizeGiB" => 5
+      })
+
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert {:ok, entry} = WorkloadCatalog.fetch(table, "scratch-postgres")
+    assert entry.stateful.volume_mount_path == "/data"
+    assert entry.stateful.idle_bank_seconds == 300
+    assert entry.stateful.max_lifetime_seconds == 86_400
+    assert entry.stateful.banked_ttl_seconds == 604_800
+    assert entry.stateful.wake_timeout_seconds == 60
+  end
+
+  test "stateful class missing spec.stateful is Ready=False/StatefulSpecMissing, not cataloged" do
+    table = unique_table()
+    agent = start_recorder()
+    cr = stateful_cr()
+    cr = Map.update!(cr, "spec", &Map.delete(&1, "stateful"))
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert WorkloadCatalog.fetch(table, "scratch-postgres") == :error
+
+    assert {_ns, "scratch-postgres", status_map} = ready_status(recorded_calls(agent), "scratch-postgres")
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "StatefulSpecMissing"}] = status_map["conditions"]
+    assert Process.alive?(watcher)
+  end
+
+  test "stateful class carrying a spec.concurrency block is Ready=False/ConcurrencyUnexpected" do
+    table = unique_table()
+    agent = start_recorder()
+    cr = stateful_cr(%{"spec" => %{"concurrency" => %{"cap" => 2}}})
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert WorkloadCatalog.fetch(table, "scratch-postgres") == :error
+
+    assert {_ns, "scratch-postgres", status_map} = ready_status(recorded_calls(agent), "scratch-postgres")
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "ConcurrencyUnexpected"}] = status_map["conditions"]
+    assert Process.alive?(watcher)
+  end
+
+  test "stateful class carrying a spec.serving block is Ready=False/ServingSpecUnexpected" do
+    table = unique_table()
+    agent = start_recorder()
+    cr = stateful_cr(%{"spec" => %{"serving" => %{"port" => 8080, "host" => "x.example.com"}}})
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert WorkloadCatalog.fetch(table, "scratch-postgres") == :error
+
+    assert {_ns, "scratch-postgres", status_map} = ready_status(recorded_calls(agent), "scratch-postgres")
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "ServingSpecUnexpected"}] = status_map["conditions"]
+    assert Process.alive?(watcher)
+  end
+
+  test "stateful class: a listenPort outside the configured range is Ready=False/StatefulListenPortOutOfRange" do
+    table = unique_table()
+    agent = start_recorder()
+    cr = put_in(stateful_cr(), ["spec", "stateful", "listenPort"], 9999)
+    lister = fn -> {:ok, [cr]} end
+    # Inject a narrow range so the test is independent of the default.
+    watcher = start_watcher(lister, recording_status_writer(agent), table, stateful_listen_range: 5400..5409)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert WorkloadCatalog.fetch(table, "scratch-postgres") == :error
+
+    assert {_ns, "scratch-postgres", status_map} = ready_status(recorded_calls(agent), "scratch-postgres")
+
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "StatefulListenPortOutOfRange"}] =
+             status_map["conditions"]
+
+    assert Process.alive?(watcher)
+  end
+
+  test "stateful class: two workloads on the same listenPort, the second is Ready=False/StatefulListenPortConflict" do
+    table = unique_table()
+    agent = start_recorder()
+
+    first = stateful_cr()
+    second = stateful_cr(%{"metadata" => %{"name" => "scratch-postgres-2"}})
+    lister = fn -> {:ok, [first, second]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    # The first-listed workload wins the listenPort and catalogs cleanly.
+    assert {:ok, _} = WorkloadCatalog.fetch(table, "scratch-postgres")
+    assert WorkloadCatalog.fetch(table, "scratch-postgres-2") == :error
+
+    assert {_ns, "scratch-postgres-2", status_map} = ready_status(recorded_calls(agent), "scratch-postgres-2")
+
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "StatefulListenPortConflict"}] =
+             status_map["conditions"]
+
+    assert Process.alive?(watcher)
+  end
+
+  test "stateful class: editing volumeSizeGiB is Ready=False/StatefulVolumeSizeImmutable" do
+    table = unique_table()
+    agent = start_recorder()
+
+    # First reconcile catalogs the workload at 10 GiB.
+    {:ok, lister_agent} = Agent.start_link(fn -> [stateful_cr()] end)
+    lister = fn -> {:ok, Agent.get(lister_agent, & &1)} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+    assert {:ok, entry} = WorkloadCatalog.fetch(table, "scratch-postgres")
+    assert entry.stateful.volume_size_gib == 10
+
+    # A later edit to 20 GiB is rejected against the cataloged entry; the entry
+    # is dropped (an invalid CR is never served) and the immutability condition
+    # is written.
+    Agent.update(lister_agent, fn _ -> [put_in(stateful_cr(), ["spec", "stateful", "volumeSizeGiB"], 20)] end)
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert WorkloadCatalog.fetch(table, "scratch-postgres") == :error
+
+    assert {_ns, "scratch-postgres", status_map} = ready_status(recorded_calls(agent), "scratch-postgres")
+
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "StatefulVolumeSizeImmutable"}] =
+             status_map["conditions"]
+
+    assert Process.alive?(watcher)
   end
 
   test "a malformed CR does not crash the watcher, and other valid CRs in the same list still catalog" do

--- a/projects/embervm/crd/samples/workload-stateful.yaml
+++ b/projects/embervm/crd/samples/workload-stateful.yaml
@@ -1,0 +1,54 @@
+# Sample stateful-class Workload (R4, ADR embervm/001). A stateful workload is a
+# scale-to-zero SINGLETON datastore: one long-lived microVM owning one writable
+# volume (a raw file on node NVMe), reachable over opaque L4 TCP, that banks to
+# disk when idle and wakes on the next inbound connection. The headline invariant
+# is the ADR 001 state split: data on the volume, warmth in the snapshot. There
+# is no maxInstances knob (singleton by construction) and spec.concurrency is
+# forbidden on this class. This is the definition surface only; a stateful
+# INSTANCE and its volume are execution state in the op-log, never a Kubernetes
+# object. Living documentation of the stateful surface, mirroring
+# workload-serving.yaml. Not a production deploy (those live under
+# projects/embervm/deploy/).
+apiVersion: embervm.dev/v1alpha1
+kind: Workload
+metadata:
+  name: scratch-postgres
+  namespace: embervm
+spec:
+  class: stateful
+  source:
+    image:
+      ref: ghcr.io/jomcgi/homelab/projects/embervm/guests/scratch-postgres:latest
+      port: 1027
+      readyPath: /shim/ready
+      invokePath: /invoke
+  resources:
+    vcpus: 1
+    memMib: 512
+  # No concurrency block: the stateful class is a singleton (exactly one live VM),
+  # so spec.concurrency is forbidden by the watcher.
+  stateful:
+    # The port the guest TCP server listens on inside the VM (Postgres = 5432).
+    # Health is a TCP connect to this port (opaque L4, no health path).
+    port: 5432
+    # The node Envoy TCP listener port this workload is exposed on cluster-
+    # internally. Must fall inside the chart's values-declared stateful range
+    # (default 5400-5409) and be unique across stateful workloads. Distinct from
+    # the guest port above: a client connects to embervm-serving:<listenPort>.
+    listenPort: 5400
+    # Sparse cap of the raw volume file, in GiB. Immutable in v1.
+    volumeSizeGiB: 10
+    # Guest path the volume is mounted at (guest-init mkfs+mounts a blank device).
+    volumeMountPath: /data
+    # Bank the instance after 10 minutes with no active connections and no new
+    # connections; a live connection is never severed regardless of this timer.
+    idleBankSeconds: 600
+    # Version-convergence bound: the instance rides its birth image until this
+    # expires; convergence is then destroy-and-cold-boot against the volume.
+    maxLifetimeSeconds: 604800
+    # A banked bundle untouched this long is GC'd off node disk; the VOLUME is
+    # never GC'd (data outlives the bundle).
+    bankedTtlSeconds: 2592000
+    # Wake deadline (relight or cold boot); generous because cold boots include
+    # WAL recovery and, on first boot, mkfs + initdb.
+    wakeTimeoutSeconds: 60

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.67
+      targetRevision: 0.1.68
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/proto/embervm/node/v1/fakenode/main.go
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/main.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 
 	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
 	"google.golang.org/grpc"
@@ -128,6 +129,58 @@ func (fakeServer) StopServing(_ context.Context, req *nodev1.StopServingRequest)
 	return &nodev1.StopServingResponse{}, nil
 }
 
+// StartStateful derives its response from mode so the client can assert every
+// stateful boot path crosses the wire. RELIGHT scripts the pairing outcome off
+// the relight_snapshot_ref content ("mismatch" -> generation_mismatch cold-boot
+// fallback, "noledger" -> ledger_unreadable, otherwise a warm relight), which is
+// how the round-trip test exercises each pairing branch against a stateless fake.
+// FRESH/COLD cold-boot from boot_image_ref and report a bumped generation.
+func (fakeServer) StartStateful(_ context.Context, req *nodev1.StartStatefulRequest) (*nodev1.StartStatefulResponse, error) {
+	if req.GetMode() == nodev1.StartStatefulMode_START_STATEFUL_MODE_RELIGHT {
+		ref := req.GetRelightSnapshotRef()
+		switch {
+		case strings.Contains(ref, "mismatch"):
+			return &nodev1.StartStatefulResponse{
+				VmId: "vm:" + ref, Ip: "10.99.0.3", Port: req.GetPort(),
+				Generation: 8, WasRelight: false, ColdBootReason: "generation_mismatch",
+			}, nil
+		case strings.Contains(ref, "noledger"):
+			return &nodev1.StartStatefulResponse{
+				VmId: "vm:" + ref, Ip: "10.99.0.3", Port: req.GetPort(),
+				Generation: 8, WasRelight: false, ColdBootReason: "ledger_unreadable",
+			}, nil
+		default:
+			return &nodev1.StartStatefulResponse{
+				VmId: "vm:" + ref, Ip: "10.99.0.3", Port: req.GetPort(),
+				Generation: 7, WasRelight: true, ColdBootReason: "",
+			}, nil
+		}
+	}
+	// FRESH or COLD: cold boot from the boot image ref, generation bumped.
+	return &nodev1.StartStatefulResponse{
+		VmId: "vm:" + req.GetBootImageRef(), Ip: "10.99.0.3", Port: req.GetPort(),
+		Generation: 1, WasRelight: false, ColdBootReason: "",
+	}, nil
+}
+
+// StopStateful returns a bundle ref, stamped generation, and size for BANK, and
+// zero values for DESTROY, so the client can assert both mode branches.
+func (fakeServer) StopStateful(_ context.Context, req *nodev1.StopStatefulRequest) (*nodev1.StopStatefulResponse, error) {
+	if req.GetMode() == nodev1.StopStatefulMode_STOP_STATEFUL_MODE_BANK {
+		return &nodev1.StopStatefulResponse{
+			SnapshotRef: "stateful/" + req.GetVmId(),
+			Generation:  7,
+			SizeBytes:   16384,
+		}, nil
+	}
+	return &nodev1.StopStatefulResponse{}, nil
+}
+
+// DeleteVolume is idempotent and returns an empty response for any workload.
+func (fakeServer) DeleteVolume(_ context.Context, _ *nodev1.DeleteVolumeRequest) (*nodev1.DeleteVolumeResponse, error) {
+	return &nodev1.DeleteVolumeResponse{}, nil
+}
+
 func (fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusRequest) (*nodev1.NodeStatus, error) {
 	return &nodev1.NodeStatus{
 		NodeId:     req.GetNodeId(),
@@ -170,6 +223,38 @@ func (fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusRequ
 			},
 		},
 		ServingSubnetCidr: "10.99.0.0/24",
+		// Stateful facts (R4): deterministic, so the client can assert the new
+		// repeated stateful status fields (VMs with generations, the one banked
+		// bundle, and the durable volume) round-trip.
+		StatefulVms: []*nodev1.StatefulVm{
+			{
+				VmId:            "vm-st1",
+				Workload:        "scratch-postgres",
+				Ip:              "10.99.0.3",
+				Port:            5432,
+				Healthy:         true,
+				Generation:      5,
+				LastProbeUnixMs: 1_700_000_003_000,
+			},
+		},
+		StatefulBundles: []*nodev1.StatefulBundle{
+			{
+				SnapshotRef:     "stateful/scratch-postgres",
+				Workload:        "scratch-postgres",
+				Generation:      5,
+				SizeBytes:       16384,
+				CreatedAtUnixMs: 1_700_000_004_000,
+			},
+		},
+		Volumes: []*nodev1.Volume{
+			{
+				Workload:       "scratch-postgres",
+				Generation:     5,
+				SizeBytes:      10_737_418_240,
+				AllocatedBytes: 536_870_912,
+				Attached:       true,
+			},
+		},
 	}, nil
 }
 

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -196,6 +196,82 @@ service NodeService {
   // any edge or proxy: the daemon does not know such a thing exists, and
   // ordering a drain before the bank call is entirely the control plane's job.
   rpc StopServing(StopServingRequest) returns (StopServingResponse);
+
+  // -- Stateful verbs (R4) ----------------------------------------------------
+  //
+  // These three verbs are the stateful-class lifecycle vocabulary, ADDITIVE to
+  // the task, session, and serving contracts above (every existing RPC and
+  // message is byte-for-byte unchanged). A stateful VM is a long-lived, SINGLETON
+  // microVM that owns exactly one WRITABLE block device (the workload's volume, a
+  // raw file on node NVMe) and answers OPAQUE L4 TCP on a tap NIC, unlike serving
+  // VMs which answer HTTP. It is the ADR embervm/001 state split made real: the
+  // volume owns the durable data, the memory snapshot only pre-pays cache warmth.
+  //
+  // The generation pairing is the load-bearing invariant. The daemon owns a
+  // per-workload on-disk generation ledger; EVERY writable attach (fresh, cold,
+  // relight) bumps it BEFORE the VM boots. A bank stamps the then-current
+  // generation into the bundle. StartStateful(RELIGHT) resumes the bundle ONLY
+  // when its stamped generation equals the volume's current generation; on any
+  // mismatch or an unreadable ledger the bundle is EVICTED and the daemon falls
+  // back to a cold boot from the volume (slower, never incorrect), reporting the
+  // reason. Warmth fails open (cold boot); data fails closed (a missing volume is
+  // FAILED_PRECONDITION, never silently recreated). The generation is metadata
+  // only: nothing here ever rewrites volume bytes outside the guest.
+  //
+  // Singleton by construction: the daemon refuses a second WRITABLE attach of the
+  // same volume with FAILED_PRECONDITION. There is no maxInstances knob; exactly
+  // one live VM per stateful workload, enforced where the data physically lives.
+  //
+  // The host NEVER mounts the volume. noded creates, sizes, attaches, and deletes
+  // the raw file; guest-init detects a blank device, runs mkfs, and mounts it at
+  // the declared path. A compromised daemon can destroy the bytes but gains no
+  // parsing surface over guest data (the ADR embervm/001 stateful isolation row).
+  //
+  // Health probing: the daemon probes TCP CONNECT (not HTTP GET, unlike serving)
+  // to each live stateful VM's {ip, port} on the existing probe cadence and
+  // thresholds, and reports healthy in NodeStatus.stateful_vms. As with serving,
+  // the daemon never acts on the verdict; the control plane owns everything
+  // downstream. Stateful VMs count against max_live_vms and are EXCLUDED from
+  // every WorkloadCapacity.primed_vm_ids (never in the task pool), exactly like
+  // session and serving VMs. Nothing Envoy-specific crosses this seam.
+
+  // StartStateful brings up the stateful VM with the workload's volume attached
+  // writable, attaching a tap NIC exactly as StartServing does, and health-gates
+  // by TCP CONNECT to {ip, port}. mode selects the boot path:
+  //   FRESH   cold-boot the image rootfs; create the volume sparse at
+  //           volume_size_bytes if absent (FAILED_PRECONDITION if absent and
+  //           create_if_missing is false).
+  //   RELIGHT resume the banked bundle (relight_snapshot_ref) iff its stamped
+  //           generation equals the volume's current generation; on mismatch or
+  //           an unreadable ledger, EVICT the bundle and fall back to a cold boot
+  //           from the volume, setting cold_boot_reason.
+  //   COLD    explicit cold boot from the existing volume (no bundle resume).
+  // Every mode bumps the generation BEFORE boot, so any attach the snapshot did
+  // not witness breaks the pair. A readiness timeout DESTROYS the VM and returns
+  // the error (no half-alive endpoint). Refuses FAILED_PRECONDITION on a second
+  // writable attach of a volume already attached (singleton enforcement).
+  rpc StartStateful(StartStatefulRequest) returns (StartStatefulResponse);
+
+  // StopStateful tears down a live stateful VM. mode = BANK PAUSES the VM (VCPUs
+  // stopped, the volume crash-consistent at the pause point), writes a full
+  // snapshot to the bundle dir under a stateful/ prefix STAMPED with the volume's
+  // current generation, destroys the VM, EVICTS any prior bundle for the workload
+  // (one banked bundle per workload), and returns {snapshot_ref, generation,
+  // size_bytes}. mode = DESTROY kills the VM with no snapshot; the next cold boot
+  // runs the database's own WAL recovery (the volume-owns-durability contract),
+  // so v1 attempts no guest-cooperative shutdown. BANK refuses FAILED_PRECONDITION
+  // if a stop of the same vm_id is already in flight. The volume file is never
+  // copied, hashed, or touched at bank time: the generation ledger is the entire
+  // pairing mechanism.
+  rpc StopStateful(StopStatefulRequest) returns (StopStatefulResponse);
+
+  // DeleteVolume removes a workload's volume file and its generation ledger. It
+  // is the ONLY destructive data verb, and it exists so deletion is an explicit,
+  // audited act (a CR deletion never reaches it; data outlives definitions).
+  // FAILED_PRECONDITION while the volume is attached to a live VM. Idempotent on
+  // an already-absent volume (the desired end-state, gone, already holds).
+  // Stateful bundles reuse EvictSnapshot (R2) unchanged; bundle refs are opaque.
+  rpc DeleteVolume(DeleteVolumeRequest) returns (DeleteVolumeResponse);
 }
 
 // Trace carries the cross-cutting identifiers every RPC threads for tracing and
@@ -532,6 +608,101 @@ message StopServingResponse {
   uint64 size_bytes = 2;
 }
 
+// ---- Stateful verbs (R4) ---------------------------------------------------
+
+enum StartStatefulMode {
+  START_STATEFUL_MODE_UNSPECIFIED = 0;
+  START_STATEFUL_MODE_FRESH = 1;    // cold-boot the image rootfs, create volume if absent
+  START_STATEFUL_MODE_RELIGHT = 2;  // resume the bundle iff the generation pair matches
+  START_STATEFUL_MODE_COLD = 3;     // explicit cold boot from the existing volume
+}
+
+message StartStatefulRequest {
+  Trace trace = 1;
+  StartStatefulMode mode = 2;
+  // boot_image_ref is the cold-boot source the daemon resolves to a bootable
+  // rootfs, used for FRESH, COLD, and the RELIGHT fallback. Same role as serving
+  // FreshSource.serving_image_ref: a NIC cold boot CANNOT resume the vsock-only
+  // base memory snapshot (D-R3.4.2), so this is DELIBERATELY NOT snapshot_ref.
+  // The daemon resolves it against its serving/stateful images inventory.
+  string boot_image_ref = 3;
+  // relight_snapshot_ref is the banked stateful bundle to resume, set for
+  // RELIGHT (empty otherwise). On a generation mismatch or unreadable ledger the
+  // daemon evicts it and cold-boots from boot_image_ref instead.
+  string relight_snapshot_ref = 4;
+  // Guest listen port; health is TCP CONNECT to {ip, port} (no ready_path: the
+  // stateful contract is opaque L4, decision 4).
+  uint32 port = 5;
+  // Volume contract. volume_size_bytes is the sparse cap the daemon creates the
+  // raw file at on FRESH (immutable per workload after creation). volume_mount is
+  // the guest mount path (from the CR's volumeMountPath) the daemon threads into
+  // the guest-init boot-args; the DEVICE path is daemon-internal and never
+  // crosses this seam. create_if_missing gates FRESH's volume creation.
+  uint64 volume_size_bytes = 6;
+  string volume_mount = 7;
+  bool create_if_missing = 8;
+  // Resource shape of the stateful VM (vcpus, mem), carried exactly as serving.
+  ResourceSpec resources = 9;
+  // mmds_env are first-boot environment values delivered to the guest via the
+  // MMDS seam (the secrets seam for first-boot DB credentials), exactly as
+  // existing verbs deliver init env. The daemon never persists or interprets them.
+  map<string, string> mmds_env = 10;
+}
+
+message StartStatefulResponse {
+  // vm_id names the live stateful VM. Opaque; the control plane holds it and
+  // passes it to StopStateful.
+  string vm_id = 1;
+  // ip/port are the ROUTABLE endpoint (noded pod IP + per-VM DNAT port, the
+  // D-R3.11.4 lane), matching serving; the tap IP stays node-internal.
+  string ip = 2;
+  uint32 port = 3;
+  // generation is the volume's current generation AFTER this attach's bump. The
+  // control plane records it as the live instance's generation and compares it
+  // to a bundle's stamped generation to decide pair validity.
+  uint64 generation = 4;
+  // was_relight is true when the call resumed a banked bundle (RELIGHT with a
+  // matched pair); false for every cold boot including a RELIGHT that fell back.
+  bool was_relight = 5;
+  // cold_boot_reason is set ONLY when a RELIGHT fell back to a cold boot, naming
+  // why the warmth was discarded: "generation_mismatch", "no_bundle",
+  // "ledger_unreadable". Empty for a successful relight or an explicit FRESH/COLD
+  // boot (an explicit cold boot is not a discarded relight, so it carries no
+  // reason). The control plane records it verbatim into the op-log.
+  string cold_boot_reason = 6;
+}
+
+enum StopStatefulMode {
+  STOP_STATEFUL_MODE_UNSPECIFIED = 0;
+  STOP_STATEFUL_MODE_BANK = 1;
+  STOP_STATEFUL_MODE_DESTROY = 2;
+}
+
+message StopStatefulRequest {
+  Trace trace = 1;
+  string vm_id = 2;
+  StopStatefulMode mode = 3;
+}
+
+message StopStatefulResponse {
+  // snapshot_ref, generation, and size_bytes are set only when mode was BANK;
+  // all are the zero value for DESTROY. generation is the volume generation
+  // stamped into the bundle, the pair key a later RELIGHT checks.
+  string snapshot_ref = 1;
+  uint64 generation = 2;
+  uint64 size_bytes = 3;
+}
+
+// DeleteVolumeRequest removes one workload's volume file and generation ledger.
+// The volume is per-workload (one raw file), so workload identifies it; no ref
+// or path crosses the seam.
+message DeleteVolumeRequest {
+  Trace trace = 1;
+  string workload = 2;
+}
+
+message DeleteVolumeResponse {}
+
 // ---- Node status -----------------------------------------------------------
 
 message WatchNodeRequest {
@@ -643,6 +814,51 @@ message ServingSnapshot {
   int64 created_at_unix_ms = 4;
 }
 
+// StatefulVm is one LIVE stateful VM the node currently holds, reported so a
+// restarted control plane adopts rather than orphans it and so the control plane
+// consumes the daemon's TCP-connect health verdict. generation is the volume
+// generation this VM was booted with (the pair key). Excluded from every
+// WorkloadCapacity.primed_vm_ids and from session_vms/serving_vms.
+message StatefulVm {
+  string vm_id = 1;
+  string workload = 2;
+  // ip/port are the ROUTABLE endpoint (noded pod IP + per-VM DNAT port), matching
+  // serving; the tap IP stays node-internal.
+  string ip = 3;
+  uint32 port = 4;
+  bool healthy = 5;
+  // generation is the volume generation the live VM holds (bumped at its attach).
+  uint64 generation = 6;
+  int64 last_probe_unix_ms = 7;
+}
+
+// StatefulBundle is the ONE banked stateful bundle for a workload on node disk,
+// stored under the stateful/ prefix of the bundle dir and STAMPED with the
+// volume generation it was paused at. The daemon rescans on start and reports it
+// so the control plane reconciles banked warmth and recomputes pair validity
+// (bundle generation vs the volume's current generation) from node truth.
+message StatefulBundle {
+  string snapshot_ref = 1;
+  string workload = 2;
+  uint64 generation = 3;
+  uint64 size_bytes = 4;
+  int64 created_at_unix_ms = 5;
+}
+
+// Volume is one workload's raw volume file on node NVMe, the durable data that
+// outlives every instance. generation is the ledger's current value (bumped on
+// every writable attach); allocated_bytes is the file's actual block usage (the
+// watermark source), size_bytes the declared sparse cap. attached is true while a
+// live VM holds the writable device. The host never reads the file's contents;
+// these are metadata facts only.
+message Volume {
+  string workload = 1;
+  uint64 generation = 2;
+  uint64 size_bytes = 3;
+  uint64 allocated_bytes = 4;
+  bool attached = 5;
+}
+
 // NodeStatus is the whole capacity fact set: per-workload primed slots and base
 // states, node-level memory/cpu headroom, and the draining flag. A draining
 // daemon reports draining=true and the control plane stops new assignments
@@ -698,4 +914,23 @@ message NodeStatus {
   // from, reported so the control plane can reason about address space without
   // ever performing allocation itself (allocation stays daemon-internal).
   string serving_subnet_cidr = 15;
+
+  // -- Stateful facts (R4, additive) ------------------------------------------
+  // These three fields report the stateful-class substrate: live singleton VMs
+  // (with their volume generation and TCP-connect health verdict), the one banked
+  // bundle per workload (stamped with its paired generation), and the durable
+  // volumes (with generations and block usage). All are optional/repeated and
+  // wire-compatible with a daemon that never sets them. The control plane derives
+  // pair validity (bundle generation vs volume generation) purely from these.
+
+  // stateful_vms lists every LIVE stateful VM this node holds. Disjoint from every
+  // WorkloadCapacity.primed_vm_ids, session_vms, and serving_vms.
+  repeated StatefulVm stateful_vms = 16;
+  // stateful_bundles is the banked-stateful-bundle inventory scanned from the
+  // stateful/ prefix of the bundle dir (at most one per workload).
+  repeated StatefulBundle stateful_bundles = 17;
+  // volumes is the raw-volume-file inventory (one per stateful workload) scanned
+  // from the volumes dir, the durable data the control plane never reads but must
+  // account for (generation for pairing, allocated_bytes for the watermark).
+  repeated Volume volumes = 18;
 }

--- a/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
+++ b/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
@@ -18,6 +18,7 @@ defmodule Embervm.NodeRoundtripTest do
     AssignRequest,
     BankRequest,
     BuildBaseRequest,
+    DeleteVolumeRequest,
     DestroyRequest,
     EvictSnapshotRequest,
     FreshSource,
@@ -31,7 +32,9 @@ defmodule Embervm.NodeRoundtripTest do
     ResourceSpec,
     SessionAssignRequest,
     StartServingRequest,
+    StartStatefulRequest,
     StopServingRequest,
+    StopStatefulRequest,
     Trace,
     WatchNodeRequest
   }
@@ -171,6 +174,124 @@ defmodule Embervm.NodeRoundtripTest do
 
     assert destroyed.snapshot_ref == ""
     assert destroyed.size_bytes == 0
+  end
+
+  test "stateful verbs round-trip across the wire (R4 additive contract)", %{channel: ch} do
+    # StartStateful FRESH: cold-boot the boot image ref, generation bumped to 1,
+    # no relight, no cold-boot reason. Proves the mode enum, boot_image_ref, and
+    # the volume/mmds fields cross the wire.
+    {:ok, fresh} =
+      NodeService.Stub.start_stateful(ch, %StartStatefulRequest{
+        trace: %Trace{workload: "scratch-postgres"},
+        mode: :START_STATEFUL_MODE_FRESH,
+        boot_image_ref: "pg-base",
+        port: 5432,
+        volume_size_bytes: 10 * 1024 * 1024 * 1024,
+        volume_mount: "/data",
+        create_if_missing: true,
+        resources: %ResourceSpec{vcpus: 1, mem_mib: 512},
+        mmds_env: %{"POSTGRES_PASSWORD" => "seeded"}
+      })
+
+    assert fresh.vm_id == "vm:pg-base"
+    assert fresh.ip == "10.99.0.3"
+    assert fresh.port == 5432
+    assert fresh.generation == 1
+    assert fresh.was_relight == false
+    assert fresh.cold_boot_reason == ""
+
+    # StartStateful RELIGHT, matched pair: resumes warm (was_relight true), no
+    # cold-boot reason. The fake scripts a warm relight for any ordinary ref.
+    {:ok, warm} =
+      NodeService.Stub.start_stateful(ch, %StartStatefulRequest{
+        mode: :START_STATEFUL_MODE_RELIGHT,
+        relight_snapshot_ref: "stateful/scratch-postgres",
+        boot_image_ref: "pg-base",
+        port: 5432
+      })
+
+    assert warm.vm_id == "vm:stateful/scratch-postgres"
+    assert warm.generation == 7
+    assert warm.was_relight == true
+    assert warm.cold_boot_reason == ""
+
+    # StartStateful RELIGHT, generation mismatch: the fake scripts a cold-boot
+    # fallback off the ref content, proving cold_boot_reason crosses the wire.
+    {:ok, mismatch} =
+      NodeService.Stub.start_stateful(ch, %StartStatefulRequest{
+        mode: :START_STATEFUL_MODE_RELIGHT,
+        relight_snapshot_ref: "stateful/mismatch",
+        boot_image_ref: "pg-base",
+        port: 5432
+      })
+
+    assert mismatch.was_relight == false
+    assert mismatch.cold_boot_reason == "generation_mismatch"
+
+    # StartStateful RELIGHT, unreadable ledger: the other cold-boot fallback branch.
+    {:ok, noledger} =
+      NodeService.Stub.start_stateful(ch, %StartStatefulRequest{
+        mode: :START_STATEFUL_MODE_RELIGHT,
+        relight_snapshot_ref: "stateful/noledger",
+        boot_image_ref: "pg-base",
+        port: 5432
+      })
+
+    assert noledger.was_relight == false
+    assert noledger.cold_boot_reason == "ledger_unreadable"
+
+    # StopStateful BANK: derives the bundle ref from vm_id and stamps the generation.
+    {:ok, banked} =
+      NodeService.Stub.stop_stateful(ch, %StopStatefulRequest{
+        vm_id: "vm-st1",
+        mode: :STOP_STATEFUL_MODE_BANK
+      })
+
+    assert banked.snapshot_ref == "stateful/vm-st1"
+    assert banked.generation == 7
+    assert banked.size_bytes == 16384
+
+    # StopStateful DESTROY: no snapshot produced.
+    {:ok, destroyed} =
+      NodeService.Stub.stop_stateful(ch, %StopStatefulRequest{
+        vm_id: "vm-st1",
+        mode: :STOP_STATEFUL_MODE_DESTROY
+      })
+
+    assert destroyed.snapshot_ref == ""
+    assert destroyed.generation == 0
+    assert destroyed.size_bytes == 0
+
+    # DeleteVolume: idempotent, returns an empty response.
+    assert {:ok, _} =
+             NodeService.Stub.delete_volume(ch, %DeleteVolumeRequest{workload: "scratch-postgres"})
+  end
+
+  test "NodeStatus reports stateful facts (R4 additive fields)", %{channel: ch} do
+    {:ok, ns} = NodeService.Stub.get_node_status(ch, %GetNodeStatusRequest{node_id: "node-4"})
+
+    assert [vm] = ns.stateful_vms
+    assert vm.vm_id == "vm-st1"
+    assert vm.workload == "scratch-postgres"
+    assert vm.ip == "10.99.0.3"
+    assert vm.port == 5432
+    assert vm.healthy == true
+    assert vm.generation == 5
+    assert vm.last_probe_unix_ms == 1_700_000_003_000
+
+    assert [bundle] = ns.stateful_bundles
+    assert bundle.snapshot_ref == "stateful/scratch-postgres"
+    assert bundle.workload == "scratch-postgres"
+    assert bundle.generation == 5
+    assert bundle.size_bytes == 16384
+    assert bundle.created_at_unix_ms == 1_700_000_004_000
+
+    assert [vol] = ns.volumes
+    assert vol.workload == "scratch-postgres"
+    assert vol.generation == 5
+    assert vol.size_bytes == 10_737_418_240
+    assert vol.allocated_bytes == 536_870_912
+    assert vol.attached == true
   end
 
   test "NodeStatus reports serving facts (R3 additive fields)", %{channel: ch} do


### PR DESCRIPTION
## EmberVM R4 PR-1: the stateful contract

First PR of the R4 (stateful, scale-to-zero singleton datastores) rung, per [the R4 plan](docs/plans/2026-07-16-embervm-r4-stateful-spec-and-plan.md). Contract-only: additive proto, op-log schema, and CRD. No behavior change (nothing consumes the new verbs yet). Covers plan Tasks 1, 2, 3.

### Task 1: node contract (`embervm.node.v1`)
- Additive `StartStateful` (FRESH/RELIGHT/COLD), `StopStateful` (BANK/DESTROY), `DeleteVolume` RPCs. RELIGHT resumes a banked bundle only when its stamped generation equals the volume's current generation, else evicts and cold-boots (`cold_boot_reason`). Warmth fails open, data fails closed.
- `NodeStatus` gains `stateful_vms`, `stateful_bundles`, `volumes` (fields 16-18).
- fakenode serves the verbs with scripted pairing outcomes (match / generation_mismatch / ledger_unreadable); the cross-language roundtrip test covers every branch.
- Task/session/serving verbs and messages byte-unchanged.

### Task 2: op-log records + projections
- Additive op kinds (`volume_created`..`stateful_stats`), the `stateful_instances` and `volumes` projection tables, and a nullable `ops.stateful_instance_id` column (guarded ALTER-after-DDL, mirroring R2/R3).
- Model: one instance row per boot-lifecycle over one volume row per workload that **outlives every instance** (never swept by retention). Every attach bumps the generation on both, so pair validity (`bundle.snapshot_generation == volume.generation`) is a complete staleness test. `stateful_cold_booted` records the discarded-warmth reason for full log reconstructability.
- Compaction: terminal instances prune past retention; the journal marker never advances past a live instance's ops.
- Projection-rebuild and full pair-mismatch-cycle tests included.

### Task 3: Workload CRD `class: stateful`
- Watcher accepts `class: stateful`, requires `spec.stateful`, rejects `spec.serving`/`spec.session`/`spec.concurrency` (singleton by construction, floor/cap fixed at 0/1). `listenPort` validated in the values-declared range (default 5400-5409) and for uniqueness; `volumeSizeGiB` immutable.
- `concurrency` moved out of the schema-`required` list (the watcher enforces per-class requiredness, exactly the session/serving-block pattern).
- Adds `status.stateful`, `statefulSummary`, the STATEFUL printer column, and a sample CR.

### Deploy
- embervm chart bumped 0.1.67 → 0.1.68 (the CRD change).

An independent review pass caught and fixed an out-of-range `listenPort` test fixture before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)