### PR TITLE
fix(monolith): firecracker flagship chip copy vs frozen fc-invoke

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.141
+version: 0.89.142
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.141
+      targetRevision: 0.89.142
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.216
+version: 0.285.217
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.216
+      targetRevision: 0.285.217
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
+++ b/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
@@ -68,11 +68,12 @@
             </p>
           {:else if app.slug === "firecracker"}
             <p>
-              fc-invoke serves <code>POST /invoke/&#123;workload&#125;</code>:
-              boot a workload once, freeze it, restore the snapshot for every
+              Boot a workload once, freeze it, restore the snapshot for every
               request. The guest never holds a real secret; an egress proxy
               swaps placeholder tokens for credentials at the network hop.
-              Watch a microVM restore from disk in <b>{sandboxRestoreMs}ms</b>.
+              <b>EmberVM</b> runs this substrate today: one-shot tasks, stateful
+              sessions, and warm HTTP serving. Watch a microVM restore from
+              disk in <b>{sandboxRestoreMs}ms</b>.
               <a class="more" href="/app/firecracker">watch it restore &rarr;</a>
             </p>
           {/if}


### PR DESCRIPTION
The homepage FLAGSHIP chip led with "fc-invoke serves POST /invoke" while the AGENT PLATFORM callout below states fc-invoke is frozen. The chip now leads with the boot/freeze/restore technique and names EmberVM as the substrate running it today (tasks, sessions, warm serving). Demo link and measured 22ms restore stay. Bumps monolith 0.285.217 + monolith-public 0.89.142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)