### PR TITLE
feat(embervm): enable scratch-postgres datastore live for R4 drills

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.76
+version: 0.1.77

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.76
+      targetRevision: 0.1.77
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -75,3 +75,13 @@ tracing:
 # runaway backstop, not any pool floor.
 noded:
   maxLiveVMs: 16
+
+# EmberVM R4 scale-to-zero scratch-postgres (ADR embervm/001, D-R4.PR-11.1):
+# enabled with the k8s-homelab 1Password item whose POSTGRES_PASSWORD field syncs
+# into this namespace's Secret. listenPort (5400) + embervmNamespace default from
+# the chart. Enabling renders the OnePasswordItem and (embervm) the Workload CR /
+# (monolith) the SCRATCH_POSTGRES_DSN env for run_python sessions.
+scratchPostgres:
+  enabled: true
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/scratch-postgres"

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.146
+version: 0.89.147
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.146
+      targetRevision: 0.89.147
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.221
+version: 0.285.222
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.221
+      targetRevision: 0.285.222
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -430,3 +430,13 @@ agent:
     # sourced via secretKeyRef in the deployment (not a plain value here).
   signoz:
     url: "http://signoz.signoz.svc.cluster.local:8080/app/signoz"
+
+# EmberVM R4 scale-to-zero scratch-postgres (ADR embervm/001, D-R4.PR-11.1):
+# enabled with the k8s-homelab 1Password item whose POSTGRES_PASSWORD field syncs
+# into this namespace's Secret. listenPort (5400) + embervmNamespace default from
+# the chart. Enabling renders the OnePasswordItem and (embervm) the Workload CR /
+# (monolith) the SCRATCH_POSTGRES_DSN env for run_python sessions.
+scratchPostgres:
+  enabled: true
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/scratch-postgres"


### PR DESCRIPTION
Flips the `scratchPostgres` feature flag on in the embervm + monolith deploy values, pointing at the `k8s-homelab/scratch-postgres` 1Password item (POSTGRES_PASSWORD field). This syncs the Secret, registers the stateful Workload CR, and exposes SCRATCH_POSTGRES_DSN to run_python. Enables the R4 acceptance drills against a live scale-to-zero Postgres. Chart bumps: embervm 0.1.77, monolith 0.285.222, monolith-public 0.89.147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)