### PR TITLE
fix(embervm): stateful cold-boot base resolution + DSN host (R4 drill fixes)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.77
+version: 0.1.78

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -586,18 +586,21 @@ defmodule Embervm.StatefulManager do
   defp rendezvous_pick([], _key), do: nil
   defp rendezvous_pick(facts, key), do: Enum.max_by(facts, fn fact -> :erlang.phash2({key, fact.configured_id}, 4_294_967_296) end)
 
-  # The cold-boot source: the node's serving_image_ref for the workload (the
-  # same built-handler-artifact seam serving cold boots use, per the task spec:
-  # a stateful workload's base is built via the same BaseBuilder path, flagged
-  # serving-class-alike). Empty when the node has not built one yet; the daemon
-  # then fails the RPC loudly rather than booting an empty rootfs.
+  # The cold-boot source: the node's base SNAPSHOT ref for the workload. A
+  # stateful workload is an image-lane, opaque-L4 guest (e.g. Postgres): its base
+  # is built by the same BaseBuilder path but produces NO serving handler artifact
+  # (that is a zip-serving-only mechanism, D-R3.11.2), so serving_image_ref is
+  # always empty here. The daemon cold-boots the rootfs behind the base snapshot
+  # key instead (resolving it via its base registry, not the serving-image
+  # inventory). Empty when the node has not built the base yet; the daemon then
+  # fails the RPC loudly rather than booting an empty rootfs.
   defp boot_image_ref(state, node_id, workload) do
     case NodeCapacity.fetch(state.capacity_table, node_id) do
       {:ok, fact} ->
         fact
         |> Map.get(:workloads, %{})
         |> Map.get(workload, %{})
-        |> Map.get(:serving_image_ref)
+        |> Map.get(:snapshot_ref)
 
       :error ->
         nil

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -134,7 +134,10 @@ defmodule Embervm.StatefulManagerTest do
       max_live_vms: 4,
       live_vms: 0,
       workloads: %{
-        "wl-a" => %{base_state: :BASE_BUILD_STATE_READY, snapshot_ref: "snap-a", serving_image_ref: "base-a"}
+        # snapshot_ref is the cold-boot source for a stateful workload: an
+        # image-lane guest has no serving handler artifact, so boot_image_ref is
+        # the base snapshot key the daemon resolves against its base registry.
+        "wl-a" => %{base_state: :BASE_BUILD_STATE_READY, snapshot_ref: "snap-a"}
       },
       stateful_vms: Keyword.get(opts, :stateful_vms, []),
       stateful_bundles: Keyword.get(opts, :stateful_bundles, []),

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.77
+      targetRevision: 0.1.78
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -314,7 +314,18 @@ func (d *Driver) bootArgsFor(cb coldBootSpec) string {
 	// content is opaque to the daemon). Only emitted when a volume is attached;
 	// every other boot class carries neither token.
 	if cb.volumeDiskPath != "" {
-		args += fmt.Sprintf(" ember.volume_dev=%s ember.volume_mount=%s", statefulVolumeDevice, cb.volumeMount)
+		// Drives land on /dev/vd{a,b,c...} in ATTACH ORDER: rootfs is always vda.
+		// A serving-style stateful boot attaches the read-only handler as drive 2
+		// (vdb), pushing the writable volume to drive 3 (vdc). An image-lane
+		// stateful boot (opaque-L4, e.g. Postgres) has NO handler drive, so the
+		// volume is drive 2 and lands on vdb. Signal the ACTUAL device so guest-init
+		// mounts the right one; a fixed /dev/vdc would be a nonexistent device on
+		// the handler-less path.
+		volumeDev := statefulVolumeDeviceNoHandler
+		if cb.handlerDiskPath != "" {
+			volumeDev = statefulVolumeDevice
+		}
+		args += fmt.Sprintf(" ember.volume_dev=%s ember.volume_mount=%s", volumeDev, cb.volumeMount)
 	}
 	// MMDS-lite over boot-args (R4, D-R4.PR-7.1): a stateful workload's first-boot
 	// secrets (e.g. a Postgres superuser password) ride the kernel cmdline as
@@ -392,16 +403,25 @@ func mmdsEnvKeyNames(mmdsEnv map[string]string) []string {
 // next, is /dev/vdb). guest-init exports this to the shim as EMBER_HANDLER_ZIP.
 const handlerDiskDevice = "/dev/vdb"
 
-// statefulVolumeDevice is the guest block-device path Firecracker assigns to a
-// stateful VM's writable volume drive (R4). A stateful boot_image_ref always
-// carries a handler artifact (mirroring the serving cold-boot lane: rootfs is
-// drive 1 / /dev/vda, the read-only handler is drive 2 / /dev/vdb), and the
-// writable volume is attached LAST as drive 3, landing on /dev/vdc. guest-init
-// reads ember.volume_dev from /proc/cmdline and mounts exactly this device; the
-// host never mounts it. Fixed rather than derived because ClaimStateful always
-// attaches all three drives together (unlike serving, which may cold-boot with
-// no handler for the image lane), so the position never varies.
-const statefulVolumeDevice = "/dev/vdc"
+// statefulVolumeDevice / statefulVolumeDeviceNoHandler are the guest block-device
+// paths Firecracker assigns to a stateful VM's writable volume drive (R4),
+// selected by whether a drive-2 handler artifact is present. Drives land on
+// /dev/vd{a,b,c...} in ATTACH ORDER. rootfs is always drive 1 / /dev/vda.
+//
+//   - WITH a handler (a serving-style stateful boot, if one ever carries a zip
+//     handler): handler is drive 2 / /dev/vdb, so the writable volume is drive 3
+//     and lands on /dev/vdc.
+//   - WITHOUT a handler (an image-lane, opaque-L4 stateful guest like Postgres):
+//     there is no drive 2, so the writable volume is drive 2 and lands on
+//     /dev/vdb.
+//
+// guest-init reads ember.volume_dev from /proc/cmdline and mounts exactly the
+// signalled device; the host never mounts it. The device is derived (not fixed)
+// because the handler drive's presence shifts the volume's position by one.
+const (
+	statefulVolumeDevice          = "/dev/vdc"
+	statefulVolumeDeviceNoHandler = "/dev/vdb"
+)
 
 // sectorSizeBytes is Firecracker's block-device sector size. A drive backing file
 // must be a whole multiple of it or FC floors the exposed device to the nearest

--- a/projects/embervm/noded/fcvm/driver/driver_test.go
+++ b/projects/embervm/noded/fcvm/driver/driver_test.go
@@ -438,6 +438,40 @@ func TestBootArgsForServingNIC(t *testing.T) {
 	}
 }
 
+// TestBootArgsForStatefulVolumeDevice covers the R4 image-lane fix: the writable
+// volume's device letter follows the ACTUAL drive attach order. Without a handler
+// drive (an image-lane, opaque-L4 stateful guest like Postgres) the volume is
+// drive 2 and lands on /dev/vdb; with a handler drive present the handler is drive
+// 2 (/dev/vdb) and the volume shifts to drive 3 (/dev/vdc). A fixed device would
+// signal a nonexistent block device on the handler-less path and guest-init would
+// mount nothing.
+func TestBootArgsForStatefulVolumeDevice(t *testing.T) {
+	d := New(Config{KernelBootArgs: "console=ttyS0"}, &fakeLauncher{}, nil)
+
+	// No handler drive: volume is drive 2 -> /dev/vdb.
+	noHandler := d.bootArgsFor(coldBootSpec{
+		volumeDiskPath: "/disks/vol/scratch-postgres.img",
+		volumeMount:    "/data",
+	})
+	if !strings.Contains(noHandler, "ember.volume_dev=/dev/vdb ember.volume_mount=/data") {
+		t.Fatalf("bootArgsFor(volume, no handler) = %q, want ember.volume_dev=/dev/vdb", noHandler)
+	}
+	if strings.Contains(noHandler, "ember.handler_disk") {
+		t.Fatalf("bootArgsFor(volume, no handler) = %q, want no handler tokens", noHandler)
+	}
+
+	// With a handler drive: handler is drive 2 (/dev/vdb), volume shifts to /dev/vdc.
+	withHandler := d.bootArgsFor(coldBootSpec{
+		handlerDiskPath: "/disks/bases/wl/handler.zip",
+		handlerZipBytes: 2048,
+		volumeDiskPath:  "/disks/vol/scratch-postgres.img",
+		volumeMount:     "/data",
+	})
+	if !strings.Contains(withHandler, "ember.volume_dev=/dev/vdc ember.volume_mount=/data") {
+		t.Fatalf("bootArgsFor(volume, with handler) = %q, want ember.volume_dev=/dev/vdc", withHandler)
+	}
+}
+
 // TestBootArgsForMmdsEnv covers the R4 D-R4.PR-7.1 MMDS-lite seam: mmdsEnv
 // entries are rendered as sorted, base64url-encoded ember.env.<KEY>= tokens; an
 // invalid key is skipped; an empty/nil map emits nothing (so RELIGHT, which

--- a/projects/embervm/noded/server/stateful.go
+++ b/projects/embervm/noded/server/stateful.go
@@ -212,16 +212,18 @@ func (s *Server) coldBootStateful(ctx context.Context, req *nodev1.StartStateful
 	if bootImageRef == "" {
 		return nil, status.Error(codes.InvalidArgument, "noded: boot_image_ref required")
 	}
-	// Resolve against the SAME serving-images inventory a serving cold boot
-	// uses (D-R3.11.2): boot_image_ref names a built base key, not a static
-	// runtime image ref.
-	simg, ok := s.servingImage.get(bootImageRef)
-	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "noded: boot image %q not provisioned on this node (no cold-boot handler artifact built)", bootImageRef)
+	// boot_image_ref names a built base SNAPSHOT key. A stateful workload is an
+	// image-lane, opaque-L4 guest (e.g. Postgres): its base is NOT a serving
+	// handler-artifact base (that is a zip-serving-only mechanism, D-R3.11.2), so
+	// it lives in the base registry, not the serving-images inventory. Resolve it
+	// there and cold-boot the runtime rootfs behind it with NO drive-2 handler.
+	base, ok := s.bases.get(bootImageRef)
+	if !ok || base.state != nodev1.BaseBuildState_BASE_BUILD_STATE_READY {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: boot image %q is not a ready base on this node", bootImageRef)
 	}
-	img, ok := s.cfg.Images[simg.runtimeImageRef]
+	img, ok := s.cfg.Images[base.imageDigest]
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "noded: runtime image %q for boot image %q not provisioned on this node", simg.runtimeImageRef, bootImageRef)
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: runtime image %q for boot image %q not provisioned on this node", base.imageDigest, bootImageRef)
 	}
 	harnessInit := img.HarnessInit
 	if harnessInit == "" {
@@ -271,7 +273,10 @@ func (s *Server) coldBootStateful(ctx context.Context, req *nodev1.StartStateful
 	if len(mmdsEnv) > 0 {
 		s.logger.Info("noded: stateful cold boot carrying mmds_env", "workload", workload, "keys", mmdsEnvKeyNamesSorted(mmdsEnv))
 	}
-	h, err := s.statefulDriver.ClaimStateful(ctx, img.RootfsPath, harnessInit, int(res.GetVcpus()), int(res.GetMemMib()), nic, simg.handlerPath, simg.sizeBytes, s.volumes.VolumePath(workload), req.GetVolumeMount(), mmdsEnv)
+	// No handler artifact for an image-lane stateful base (drive 2 is omitted; the
+	// writable volume attaches as drive 2 -> /dev/vdb, which the driver signals to
+	// the guest dynamically). Pass an empty handler path / zero size.
+	h, err := s.statefulDriver.ClaimStateful(ctx, img.RootfsPath, harnessInit, int(res.GetVcpus()), int(res.GetMemMib()), nic, "", 0, s.volumes.VolumePath(workload), req.GetVolumeMount(), mmdsEnv)
 	if err != nil {
 		s.servingNet.ReleaseTap(ctx, ip)
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: cold-boot stateful vm: %v", err)

--- a/projects/embervm/noded/server/stateful_test.go
+++ b/projects/embervm/noded/server/stateful_test.go
@@ -176,22 +176,18 @@ func newStatefulTestServer(t *testing.T) (*Server, *fakeServingNet, *fakeStatefu
 		},
 		Driver:         statefulVMDriverAdapter{fsd},
 		ServingNet:     fsn,
-		ServingDriver:  newFakeServingDriver(dir), // stateful boot resolves against servingImage inventory
+		ServingDriver:  newFakeServingDriver(dir), // required by the serving lane; stateful boot resolves against the base registry
 		StatefulDriver: fsd,
 		VolumeRoot:     volumeRoot,
 		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
 	s.memHeadroom = func() uint64 { return 0 }
-	// Seed a built serving image "img-a" the same way a real BuildBase would
-	// have populated it; StartStateful resolves boot_image_ref against the
-	// SAME inventory a serving cold boot uses (D-R3.11.2).
-	s.servingImage.add(servingImageEntry{
-		baseKey:         "img-a",
-		workload:        "wl-state",
-		handlerPath:     "/disks/bases/img-a/handler.zip",
-		runtimeImageRef: "img-a",
-		sizeBytes:       2048,
-	})
+	// Seed a READY base "img-a" the way a real BuildBase would have. An image-lane
+	// stateful boot resolves boot_image_ref against the BASE registry (not the
+	// serving-image inventory: an opaque-L4 guest has no handler artifact), then
+	// cold-boots the runtime rootfs behind base.imageDigest ("img-a" is in cfg
+	// Images above) with no drive-2 handler.
+	s.bases.readyBuild("img-a", "wl-state", "img-a", "/shim/ready", 2048)
 	return s, fsn, fsd
 }
 

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.147
+version: 0.89.148
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.147
+      targetRevision: 0.89.148
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.222
+version: 0.285.223
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -145,7 +145,7 @@ spec:
                   name: {{ include "monolith.fullname" . }}-scratch-postgres
                   key: POSTGRES_PASSWORD
             - name: SCRATCH_POSTGRES_DSN
-              value: "postgresql://postgres:$(SCRATCH_PG_PASSWORD)@embervm-serving.{{ .Values.scratchPostgres.embervmNamespace }}.svc:{{ .Values.scratchPostgres.listenPort }}/scratch"
+              value: "postgresql://postgres:$(SCRATCH_PG_PASSWORD)@{{ .Values.scratchPostgres.servingService }}.{{ .Values.scratchPostgres.embervmNamespace }}.svc:{{ .Values.scratchPostgres.listenPort }}/scratch"
             {{- end }}
             {{- if .Values.semgrep.shadowProject }}
             # Route B shadow project: the relay reports App scans under this name

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -816,8 +816,13 @@ scratchPostgres:
   # exposed on (must match the embervm chart's scratchPostgres.listenPort).
   listenPort: 5400
   # The embervm namespace the serving Service lives in (the DSN host is
-  # embervm-serving.<namespace>.svc).
+  # <servingService>.<embervmNamespace>.svc).
   embervmNamespace: embervm
+  # The embervm serving Service NAME. Helm prepends the release name to chart
+  # service names, so the embervm chart's `serving` Service is actually
+  # `embervm-embervm-serving` (release `embervm` + `embervm.fullname`). This is
+  # NOT `embervm-serving`; a wrong host silently NXDOMAINs the DSN at runtime.
+  servingService: embervm-embervm-serving
   onepassword:
     # 1Password item path whose POSTGRES_PASSWORD field syncs into the
     # <fullname>-scratch-postgres Secret in the MONOLITH namespace. Must be the

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.222
+      targetRevision: 0.285.223
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Two bugs the live R4 drill surfaced when waking scratch-postgres.

## 1. Stateful cold boot never resolves its base (`boot_image_ref required`)

noded's \`coldBootStateful\` resolved \`boot_image_ref\` against the **serving-image** inventory, which is only populated for serving-class **zip-lane** builds (\`req.GetServing() && archive != nil\`). A stateful workload is an **image-lane, opaque-L4** guest (Postgres): its base lands in the base registry and has no cold-boot handler artifact, so noded rejected every wake and the control plane had no \`serving_image_ref\` to send.

**Fix (Option B):**
- control plane \`boot_image_ref\` reads the base \`snapshot_ref\` (already reported per workload) instead of the always-empty \`serving_image_ref\`.
- noded \`coldBootStateful\` resolves against the base registry -> \`imageDigest\` -> \`cfg.Images\`, cold-booting the rootfs with **no drive-2 handler**.
- the driver signals the **actual** volume device: with no handler drive the writable volume is drive 2 (\`/dev/vdb\`), not \`/dev/vdc\`; the fixed \`/dev/vdc\` was a nonexistent device on the handler-less path (guest-init would mount nothing).

## 2. `SCRATCH_POSTGRES_DSN` host is wrong

The DSN hardcoded \`embervm-serving.<ns>.svc\`, but Helm release-prefixes the service to \`embervm-embervm-serving\` (the exact gotcha CLAUDE.md warns about). \`run_python\`'s DSN would NXDOMAIN. Made the serving host a documented value defaulting to the correct name.

## Verified
- Live drill proved base build + snapshot + secret delivery + CRD all work; this is the wake-path fix.
- Tests updated: noded seeds the base registry (not servingImage); control-plane fixture uses \`snapshot_ref\` as the boot source.
- Chart bumps: embervm 0.1.78, monolith 0.285.223, monolith-public 0.89.148.

After merge + sync I'll re-run the wake drill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)