### PR TITLE
fix(embervm): persist/restore base image ref + GC superseded bases (R4 drill)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.78
+version: 0.1.79

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.78
+      targetRevision: 0.1.79
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -458,6 +458,12 @@ func (s *Server) driveBuild(ctx context.Context, req *nodev1.BuildBaseRequest, b
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: build base %q: %v", baseKey, err)
 	}
 	s.bases.readyBuild(baseKey, workload, imageDigest, readyPath, sizeBytes)
+	// Persist the runtime image ref alongside the snapshot so a daemon restart can
+	// restore it (ReconcileBasesFromDisk). The base dir name is <workload>__<sig>
+	// and does NOT encode the runtime image, but a stateful cold boot resolves the
+	// rootfs via base.imageDigest -> cfg.Images, so a base adopted from disk without
+	// it is unbootable. Best-effort: a missing ref file just forces a rebuild.
+	s.writeBaseImageRef(baseKey, imageDigest)
 
 	// Serving base (R3, D-R3.11.2): additionally persist a cold-boot-readable handler
 	// artifact from the SAME verified archive bytes noded already holds, so a serving
@@ -1397,6 +1403,17 @@ func (s *Server) workloadCapacities(primed map[string][]string) []*nodev1.Worklo
 		return c
 	}
 	for _, b := range s.bases.snapshot() {
+		// A READY base is only reportable if its runtime image is still provisioned:
+		// the control plane places a stateful cold boot on snapshot_ref and the daemon
+		// resolves it via imageDigest -> cfg.Images, so advertising a base built against
+		// a superseded image (or an in-memory entry whose disk snapshot was GC'd) would
+		// place a wake that fails FAILED_PRECONDITION. BUILDING/FAILED are reported as-is
+		// so the control plane sees progress. Mirrors the serving-image filter below.
+		if b.state == nodev1.BaseBuildState_BASE_BUILD_STATE_READY {
+			if _, ok := s.cfg.Images[b.imageDigest]; !ok {
+				continue
+			}
+		}
 		c := get(b.workload)
 		c.SnapshotRef = b.snapshotRef
 		c.BaseState = b.state
@@ -1564,7 +1581,7 @@ func (s *Server) ReconcileBasesFromDisk() {
 		}
 		return
 	}
-	n := 0
+	n, gc := 0, 0
 	for _, ent := range entries {
 		if !ent.IsDir() {
 			continue
@@ -1576,6 +1593,19 @@ func (s *Server) ReconcileBasesFromDisk() {
 			// A dir without a snapfile is a half-written or unrelated bundle; skip.
 			continue
 		}
+		// Restore the runtime image ref persisted at build (writeBaseImageRef). A base
+		// whose ref file is missing (built before this was persisted) or whose runtime
+		// image is no longer provisioned (a superseded image tag after a deploy) is not
+		// cold-bootable: a stateful cold boot resolves the rootfs via imageDigest ->
+		// cfg.Images. GC it here so superseded snapshots do not accumulate on node NVMe
+		// (D-R3.11.3) and are never reported to the control plane.
+		imageRef := s.readBaseImageRef(baseKey)
+		if _, provisioned := s.cfg.Images[imageRef]; imageRef == "" || !provisioned {
+			if err := os.RemoveAll(filepath.Join(root, baseKey)); err == nil {
+				gc++
+			}
+			continue
+		}
 		memfile := filepath.Join(root, baseKey, "memfile")
 		var size int64 = fi.Size()
 		if mfi, err := os.Stat(memfile); err == nil {
@@ -1584,16 +1614,38 @@ func (s *Server) ReconcileBasesFromDisk() {
 		s.bases.register(baseEntry{
 			snapshotRef: baseKey,
 			workload:    workloadFromBaseKey(baseKey),
+			imageDigest: imageRef,
 			readyPath:   defaultReadyPath,
 			sizeBytes:   size,
 			state:       nodev1.BaseBuildState_BASE_BUILD_STATE_READY,
 		})
 		n++
 	}
-	if n > 0 {
-		s.logger.Info("noded: reconciled existing base snapshots", "count", n)
+	if n > 0 || gc > 0 {
+		s.logger.Info("noded: reconciled base snapshots", "adopted", n, "gc_superseded", gc)
 		s.signalChange()
 	}
+}
+
+// writeBaseImageRef persists a base's runtime image ref next to its snapshot so a
+// daemon restart can restore base.imageDigest (the base dir name does not encode
+// it). Best-effort: a write failure just means the base is GC'd and rebuilt on the
+// next reconcile.
+func (s *Server) writeBaseImageRef(baseKey, imageRef string) {
+	path := filepath.Join(s.cfg.SnapshotRoot, "bases", baseKey, "imageref")
+	if err := os.WriteFile(path, []byte(imageRef), 0o644); err != nil {
+		s.logger.Warn("noded: persist base imageref", "base", baseKey, "err", err)
+	}
+}
+
+// readBaseImageRef reads the persisted runtime image ref for a base, or "" if the
+// file is absent (a base built before persistence, or a partial write).
+func (s *Server) readBaseImageRef(baseKey string) string {
+	b, err := os.ReadFile(filepath.Join(s.cfg.SnapshotRoot, "bases", baseKey, "imageref"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
 }
 
 // ReconcileSessionsFromDisk scans the sessions snapshot dir for banked session

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -1762,3 +1762,55 @@ var (
 	_ sessionDriver = (*fakeDriver)(nil)
 	_ transport     = (*fakeTransport)(nil)
 )
+
+// TestReconcileBasesFromDiskRestoresRefAndGCsSuperseded proves the base
+// disk-reconcile restores each base's runtime image ref from the persisted
+// imageref file (so a stateful cold boot resolves the rootfs after a daemon
+// restart) and GCs bases whose ref is missing or no longer provisioned
+// (D-R3.11.3), so superseded snapshots neither accumulate on node NVMe nor get
+// advertised to the control plane as bootable.
+func TestReconcileBasesFromDiskRestoresRefAndGCsSuperseded(t *testing.T) {
+	dir := t.TempDir()
+	s := New(Options{
+		Config: config.Config{
+			Arch: "amd64", Node: "node-4", MaxLiveVMs: 4, SnapshotRoot: dir,
+			Images: map[string]config.Image{"img-current": {RootfsPath: "/rootfs/cur"}},
+		},
+	})
+
+	basesDir := filepath.Join(dir, "bases")
+	writeReconcileBase(t, basesDir, "wl-a__current", "img-current") // provisioned -> adopted
+	writeReconcileBase(t, basesDir, "wl-a__stale", "img-old")       // superseded ref -> GC'd
+	writeReconcileBase(t, basesDir, "wl-b__noref", "")              // no imageref -> GC'd
+
+	s.ReconcileBasesFromDisk()
+
+	got, ok := s.bases.get("wl-a__current")
+	if !ok || got.imageDigest != "img-current" || got.state != nodev1.BaseBuildState_BASE_BUILD_STATE_READY {
+		t.Fatalf("current base = %+v ok=%v; want adopted READY with imageDigest img-current", got, ok)
+	}
+	for _, gcKey := range []string{"wl-a__stale", "wl-b__noref"} {
+		if _, ok := s.bases.get(gcKey); ok {
+			t.Errorf("base %q should have been GC'd from the registry", gcKey)
+		}
+		if _, err := os.Stat(filepath.Join(basesDir, gcKey)); !os.IsNotExist(err) {
+			t.Errorf("base dir %q should have been removed from disk", gcKey)
+		}
+	}
+}
+
+func writeReconcileBase(t *testing.T, basesDir, baseKey, ref string) {
+	t.Helper()
+	d := filepath.Join(basesDir, baseKey)
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, "snapfile"), []byte("snap"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if ref != "" {
+		if err := os.WriteFile(filepath.Join(d, "imageref"), []byte(ref), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Third bug from the live R4 drill, in the restart-adoption path.

## The bug
noded's `ReconcileBasesFromDisk` adopted on-disk bases with an **empty `imageDigest`** — the runtime image ref was never persisted (a base dir is `<workload>__<sig>`, which doesn't encode it). Fine until the cold-boot fix routed stateful boots through the base registry; then a wake after a daemon restart failed with `runtime image "" for boot image ... not provisioned`. Same root gap also meant **no base GC**: 220 GB of superseded snapshots had piled up on node NVMe (no TTL, `D-R3.11.3`).

## The fix
- **Persist** the runtime image ref to `bases/<key>/imageref` at build time.
- **Restore** it on reconcile; a base whose ref is missing or no longer provisioned is **GC'd** (removed from disk + not registered) — superseded snapshots neither accumulate nor get advertised.
- **Report filter**: NodeStatus reports only READY bases whose runtime image is still provisioned (mirrors the serving-image filter), so the CP never places a wake on an unbootable base.

Test: `ReconcileBasesFromDisk` restores the ref for a provisioned base and GCs both a superseded-ref and a ref-less base (registry + disk).

Already flushed the existing 213 stale bases manually (~204 GB reclaimed); this stops re-accumulation. Chart bump: embervm 0.1.79. After merge + rollout I'll re-run the wake drill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)