### PR TITLE
fix(embervm): add blkid to scratch-postgres image (R4 drill, first-boot volume)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.79
+version: 0.1.80

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.79
+      targetRevision: 0.1.80
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/postgres/apko.lock.json
+++ b/projects/embervm/runtimes/postgres/apko.lock.json
@@ -2,7 +2,7 @@
   "version": "v1",
   "config": {
     "name": "apko.yaml",
-    "checksum": "sha256-6V2D7mbugAr2Gi1YZFi6sodPBFp8BTNhAndDG/e7se8="
+    "checksum": "sha256-QiZ444l4R2J+JSK5xRhw95k5XbTV90D24r/atH7KSc8="
   },
   "contents": {
     "keyring": [
@@ -66,6 +66,25 @@
         "checksum": "Q1KyCdEL20IKE+B7DKW97GLXu2QLM="
       },
       {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13051",
+          "checksum": "sha1-Dc94e4JF2fG8/SX4PWCAtLjItu4="
+        },
+        "data": {
+          "range": "bytes=13052-147283",
+          "checksum": "sha256-oI72DIuJLqlUM/LSFYKdgbxsaYUZgfThezkV95CHQPk="
+        },
+        "checksum": "Q1Dc94e4JF2fG8/SX4PWCAtLjItu4="
+      },
+      {
         "name": "libgcc",
         "url": "https://packages.wolfi.dev/os/x86_64/libgcc-16.1.0-r4.apk",
         "version": "16.1.0-r4",
@@ -123,23 +142,42 @@
         "checksum": "Q1XSTHGW6PUOUepKQvlUCPEpu+my0="
       },
       {
-        "name": "ld-linux",
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.43-r11.apk",
-        "version": "2.43-r11",
+        "name": "libblkid",
+        "url": "https://packages.wolfi.dev/os/x86_64/libblkid-2.42.2-r0.apk",
+        "version": "2.42.2-r0",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-13051",
-          "checksum": "sha1-Dc94e4JF2fG8/SX4PWCAtLjItu4="
+          "range": "bytes=0-8824",
+          "checksum": "sha1-pbMNc7Ew1CUyk7LcZmNFWp2KoYA="
         },
         "data": {
-          "range": "bytes=13052-147283",
-          "checksum": "sha256-oI72DIuJLqlUM/LSFYKdgbxsaYUZgfThezkV95CHQPk="
+          "range": "bytes=8825-869406",
+          "checksum": "sha256-th0Ey1wCWxtA9qAvUR4LRGUZypymk/pmMLUb4FJPdNM="
         },
-        "checksum": "Q1Dc94e4JF2fG8/SX4PWCAtLjItu4="
+        "checksum": "Q1pbMNc7Ew1CUyk7LcZmNFWp2KoYA="
+      },
+      {
+        "name": "blkid",
+        "url": "https://packages.wolfi.dev/os/x86_64/blkid-2.42.2-r0.apk",
+        "version": "2.42.2-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8834",
+          "checksum": "sha1-0c9dRykwWWoiB4Gp7ZHlzGde7gY="
+        },
+        "data": {
+          "range": "bytes=8835-280820",
+          "checksum": "sha256-1B9EnjCOFn2uaw7NyvL+NoE7P++MmpA3dv8OiJnSAGM="
+        },
+        "checksum": "Q10c9dRykwWWoiB4Gp7ZHlzGde7gY="
       },
       {
         "name": "libxcrypt",
@@ -235,25 +273,6 @@
           "checksum": "sha256-myR9OUT2SCo+fg3sHHdzEJ3ZS06462aQke0zAS9WZao="
         },
         "checksum": "Q11hxIEw4QVSeajx+FDtDuspATbx0="
-      },
-      {
-        "name": "libblkid",
-        "url": "https://packages.wolfi.dev/os/x86_64/libblkid-2.42.2-r0.apk",
-        "version": "2.42.2-r0",
-        "architecture": "x86_64",
-        "signature": {
-          "range": "",
-          "checksum": ""
-        },
-        "control": {
-          "range": "bytes=0-8824",
-          "checksum": "sha1-pbMNc7Ew1CUyk7LcZmNFWp2KoYA="
-        },
-        "data": {
-          "range": "bytes=8825-869406",
-          "checksum": "sha256-th0Ey1wCWxtA9qAvUR4LRGUZypymk/pmMLUb4FJPdNM="
-        },
-        "checksum": "Q1pbMNc7Ew1CUyk7LcZmNFWp2KoYA="
       },
       {
         "name": "libuuid",
@@ -1073,6 +1092,44 @@
         "checksum": "Q1vqCKIZcxA7Bw0Sdk31ANMcX7SkE="
       },
       {
+        "name": "libblkid",
+        "url": "https://packages.wolfi.dev/os/aarch64/libblkid-2.42.2-r0.apk",
+        "version": "2.42.2-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8868",
+          "checksum": "sha1-pkJjz48IE4Vtve4m7uV4JcVFURQ="
+        },
+        "data": {
+          "range": "bytes=8869-849899",
+          "checksum": "sha256-mYbNtygDeUHC6YYTzW91KBeSwpRYzAsEIh009hmUQQE="
+        },
+        "checksum": "Q1pkJjz48IE4Vtve4m7uV4JcVFURQ="
+      },
+      {
+        "name": "blkid",
+        "url": "https://packages.wolfi.dev/os/aarch64/blkid-2.42.2-r0.apk",
+        "version": "2.42.2-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8864",
+          "checksum": "sha1-lU7lU6SEBGXpxAkifj+1oGjXFpQ="
+        },
+        "data": {
+          "range": "bytes=8865-287314",
+          "checksum": "sha256-7EwBf6XTbrRz4WswUQlg6ykRmxpfYPZ/R8X/sSOYeqE="
+        },
+        "checksum": "Q1lU7lU6SEBGXpxAkifj+1oGjXFpQ="
+      },
+      {
         "name": "libxcrypt",
         "url": "https://packages.wolfi.dev/os/aarch64/libxcrypt-4.5.2-r3.apk",
         "version": "4.5.2-r3",
@@ -1166,25 +1223,6 @@
           "checksum": "sha256-3Kd9CvEGlZdUnFtsd5lX7evI81I6WiegKvRin/ecfCk="
         },
         "checksum": "Q1RPohLtRuz+j00s45d/ZEGo84Zp0="
-      },
-      {
-        "name": "libblkid",
-        "url": "https://packages.wolfi.dev/os/aarch64/libblkid-2.42.2-r0.apk",
-        "version": "2.42.2-r0",
-        "architecture": "aarch64",
-        "signature": {
-          "range": "",
-          "checksum": ""
-        },
-        "control": {
-          "range": "bytes=0-8868",
-          "checksum": "sha1-pkJjz48IE4Vtve4m7uV4JcVFURQ="
-        },
-        "data": {
-          "range": "bytes=8869-849899",
-          "checksum": "sha256-mYbNtygDeUHC6YYTzW91KBeSwpRYzAsEIh009hmUQQE="
-        },
-        "checksum": "Q1pkJjz48IE4Vtve4m7uV4JcVFURQ="
       },
       {
         "name": "libuuid",

--- a/projects/embervm/runtimes/postgres/apko.yaml
+++ b/projects/embervm/runtimes/postgres/apko.yaml
@@ -14,8 +14,14 @@ contents:
     # /usr/libexec/postgresql to cover the versioned layout.
     - postgresql-16
     - postgresql-16-client
-    # mkfs.ext4 / blkid for the stateful volume (guest-init mkfs-if-blank + mount).
+    # mkfs.ext4 for the stateful volume (guest-init formats a blank volume ext4).
     - e2fsprogs
+    # blkid for the mkfs-if-blank probe: guest-init runs `blkid` to detect an
+    # existing filesystem signature before formatting, so a populated volume is
+    # never reformatted. e2fsprogs does NOT ship blkid (it lives in this dedicated
+    # Wolfi package), and the guest mounts via the unix.Mount syscall (no `mount`
+    # binary needed), so blkid is the only extra volume tool required.
+    - blkid
 
 archs:
   - x86_64


### PR DESCRIPTION
Fourth bug from the live R4 drill — the first-boot volume path.

The cold boot now works end-to-end up to the volume: base resolves, mmds_env password delivered, `ember.volume_dev=/dev/vdb` correctly signaled (the dynamic-device fix), guest boots `ember-postgres-init`. Then it fails:

```
ember-postgres-init exited with error: probe volume device /dev/vdb:
blkid /dev/vdb: exec: "blkid": executable file not found in $PATH
```

guest-init runs `blkid` for its **mkfs-if-blank** safety probe (never reformat a populated volume), but the image only had `e2fsprogs`, which does **not** ship `blkid`. Added the dedicated Wolfi `blkid` package (mounting uses the `unix.Mount` syscall, so no `mount` binary is needed). Regenerated the apko lock (100 packages). Chart bump: embervm 0.1.80.

After merge + rollout I'll re-run the wake — this should reach `mkfs.ext4` → `initdb` → serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)