### PR TITLE
fix(embervm): scratch-postgres first-boot on read-only rootfs (R4 drill, batched)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.80
+version: 0.1.81

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.80
+      targetRevision: 0.1.81
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/postgres/apko.lock.json
+++ b/projects/embervm/runtimes/postgres/apko.lock.json
@@ -2,7 +2,7 @@
   "version": "v1",
   "config": {
     "name": "apko.yaml",
-    "checksum": "sha256-QiZ444l4R2J+JSK5xRhw95k5XbTV90D24r/atH7KSc8="
+    "checksum": "sha256-V9fyfOhciH0j6pxtqya1q4UhgPsy8fc2U/zQKlv3t/w="
   },
   "contents": {
     "keyring": [

--- a/projects/embervm/runtimes/postgres/apko.yaml
+++ b/projects/embervm/runtimes/postgres/apko.yaml
@@ -51,9 +51,18 @@ environment:
   PGDATA: /data/pgdata
 
 paths:
-  # The postgres home + a place for the local socket; PGDATA itself lives on the
-  # mounted volume (guest-init creates /data/pgdata and chowns it to postgres).
+  # The postgres home; PGDATA itself lives on the mounted volume (guest-init
+  # creates /data/pgdata and chowns it to postgres).
   - path: /var/lib/postgresql
+    type: directory
+    uid: 70
+    gid: 70
+    permissions: 0o750
+  # The stateful volume mount point (CR volumeMountPath). guest-init mounts the
+  # writable volume here (unix.Mount), but the rootfs is read-only, so the mount
+  # directory MUST already exist in the image: mkdir on a read-only rootfs fails.
+  # Must match the CR's volumeMountPath and the PGDATA parent (/data/pgdata).
+  - path: /data
     type: directory
     uid: 70
     gid: 70

--- a/projects/embervm/runtimes/postgres/guest-init/cmd/postgres_linux.go
+++ b/projects/embervm/runtimes/postgres/guest-init/cmd/postgres_linux.go
@@ -117,6 +117,11 @@ func postgresCommand(ctx context.Context, pgdata string) *exec.Cmd {
 		"-D", pgdata,
 		"-p", strconv.Itoa(pgPort),
 		"-c", "listen_addresses=*",
+		// Put the unix socket on the writable tmpfs. The rootfs is read-only and
+		// the compiled default (/run/postgresql) does not exist there, so postgres
+		// would fail to create its socket; /tmp is a tmpfs and matches the PGHOST
+		// the bootstrap createdb connects on.
+		"-c", "unix_socket_directories=/tmp",
 		"-c", "fsync=on",
 		"-c", "shared_buffers=128MB",
 	)
@@ -127,10 +132,13 @@ func postgresCommand(ctx context.Context, pgdata string) *exec.Cmd {
 	return cmd
 }
 
-// runInitdb initializes PGDATA as the postgres user with scram-sha-256 auth and
-// the superuser password from `password`, delivered via a --pwfile so the
-// secret never appears in argv (visible in /proc). The pwfile lives on the
-// tmpfs and is removed immediately after.
+// runInitdb initializes PGDATA as the postgres user with the superuser password
+// from `password`, delivered via a --pwfile so the secret never appears in argv
+// (visible in /proc). The pwfile lives on the tmpfs and is removed immediately
+// after. TCP auth is scram (the network boundary); the local unix socket is
+// trust: the guest is a single-tenant, isolated microVM where the only local
+// callers are guest-init's own bootstrap (initdb/createdb), so a password on the
+// in-VM socket buys nothing and would only make the bootstrap createdb fail.
 func runInitdb(logger *slog.Logger, pgdata, password string) error {
 	pwfile := "/tmp/.pgpw"
 	if err := os.WriteFile(pwfile, []byte(password), 0o600); err != nil {
@@ -145,7 +153,7 @@ func runInitdb(logger *slog.Logger, pgdata, password string) error {
 		"-D", pgdata,
 		"-U", postgresUser,
 		"--auth-host=scram-sha-256",
-		"--auth-local=scram-sha-256",
+		"--auth-local=trust",
 		"--pwfile", pwfile,
 		"-E", "UTF8",
 	)
@@ -167,9 +175,9 @@ func runInitdb(logger *slog.Logger, pgdata, password string) error {
 func configurePostgres(pgdata string) error {
 	hba := filepath.Join(pgdata, "pg_hba.conf")
 	// Append: scram over TCP from anywhere (the tap NIC is only reachable from
-	// the node Envoy). initdb already wrote local + host scram lines for
-	// 127.0.0.1/::1; this widens host to all IPv4/IPv6 so the Envoy-forwarded
-	// connection (from the pod network) authenticates.
+	// the node Envoy). initdb already wrote a trust local line plus host scram
+	// lines for 127.0.0.1/::1; this widens host to all IPv4/IPv6 so the
+	// Envoy-forwarded connection (from the pod network) authenticates with scram.
 	rule := "\n# EmberVM scratch-postgres (R4): scram for cluster-internal TCP.\nhost all all 0.0.0.0/0 scram-sha-256\nhost all all ::/0 scram-sha-256\n"
 	f, err := os.OpenFile(hba, os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
@@ -189,7 +197,8 @@ func ensureScratchDatabase(logger *slog.Logger) error {
 	cmd := exec.Command("createdb", "scratch")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	// createdb connects over the local socket (peer/scram) as postgres.
+	// createdb connects over the trust local socket (in /tmp, matching the
+	// server's unix_socket_directories) as the postgres superuser, no password.
 	cmd.Env = append(os.Environ(), "PGHOST=/tmp", "PGPORT="+strconv.Itoa(pgPort))
 	dropToPostgres(cmd)
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Three first-boot bugs the live R4 drill surfaced (batched to save rebuild cycles), all from the guest booting a **read-only rootfs**. The cold boot now gets: base resolves → mmds_env → `/dev/vdb` → guest boots → `blkid` → `mkfs.ext4` → **then** these:

1. **`/data` mountpoint missing** — `mkdir /data: read-only file system`. The mount dir must pre-exist in the image; baked `/data` (owner postgres) into apko.
2. **socket dir** — `postgres` used the compiled default `unix_socket_directories` (`/run/postgresql`, absent/unwritable on ro rootfs) so it couldn't create its socket, and the bootstrap `createdb` connects on `/tmp`. Set `unix_socket_directories=/tmp` (tmpfs).
3. **local auth** — `initdb --auth-local=scram-sha-256` made the bootstrap `createdb` need a password it isn't given. The guest is a single-tenant isolated microVM, so the in-VM socket is `trust`; TCP stays scram (the real boundary).

Regenerated the apko lock (100 pkgs). Chart bump embervm 0.1.81. After rollout I'll re-drill — this should reach `initdb` → `createdb scratch` → first TCP accept → a working datastore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)