### PR TITLE
feat(loom): cut Loom over to EmberVM scratch-postgres (scale-to-zero)

### DIFF
--- a/projects/loom/deploy/kustomization.yaml
+++ b/projects/loom/deploy/kustomization.yaml
@@ -10,5 +10,6 @@ resources:
   - image-pull-secret.yaml
   - serviceaccount.yaml
   - s3-credentials.yaml
+  - onepassworditem-scratch-postgres.yaml
   - httproute.yaml
   - application.yaml

--- a/projects/loom/deploy/onepassworditem-scratch-postgres.yaml
+++ b/projects/loom/deploy/onepassworditem-scratch-postgres.yaml
@@ -1,0 +1,14 @@
+# Syncs the EmberVM scratch-postgres connection (host/port/username/password/
+# dbname fields) from 1Password into a Secret in the loom namespace, so the loom
+# chart's external-Postgres mode (postgres.enabled=false) connects to the
+# scale-to-zero scratch-postgres datastore in the embervm namespace. A K8s Secret
+# cannot be read across namespaces, so loom syncs the item into its own namespace.
+# The synced Secret's keys (host, port, username, password, dbname) match the
+# chart's postgres.external.keys defaults.
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: loom-scratch-postgres
+  namespace: loom
+spec:
+  itemPath: vaults/k8s-homelab/items/scratch-postgres

--- a/projects/loom/deploy/values.yaml
+++ b/projects/loom/deploy/values.yaml
@@ -56,10 +56,16 @@ migrations:
   mode: onBoot
 
 postgres:
-  enabled: true
-  instances: 1
-  storage:
-    size: 3Gi
+  # Scale-to-zero external Postgres: the EmberVM R4 scratch-postgres datastore in
+  # the embervm namespace (wakes on an inbound connection, banks when idle). Set
+  # enabled=false to drop the bundled CNPG cluster (loom-pg); loom connects via
+  # the loom-scratch-postgres Secret (OnePasswordItem sync, keys host/port/
+  # username/password/dbname matching external.keys defaults). Loom's data is
+  # disposable demo data, recreated by migrations.mode=onBoot on first connect
+  # (which is itself what wakes the datastore).
+  enabled: false
+  external:
+    existingSecret: loom-scratch-postgres
 
 # Iceberg warehouse on the cluster SeaweedFS (s3://loom). The in-cluster S3
 # gateway runs without identities (anonymous), so the referenced secret


### PR DESCRIPTION
Migrates Loom off its bundled CNPG cluster onto the R4 **scale-to-zero scratch-postgres** datastore — the first real consumer of EmberVM stateful.

**Config-only, no version bump.** Loom rides the `0.0.0-edge` chart with values from git `HEAD`, and the chart already supports external Postgres (`postgres.enabled=false` + `external.existingSecret`), so this is purely `projects/loom/deploy/` changes:

- `postgres.enabled=false` drops the `loom-pg` CNPG cluster (its data is disposable demo data).
- `postgres.external.existingSecret: loom-scratch-postgres` + a new `OnePasswordItem` syncing the scratch-postgres connection (`host/port/username/password/dbname`) into the loom namespace — keys match the chart's `external.keys` defaults.
- `migrations.mode=onBoot` recreates Loom's schema in the `scratch` DB on first connect, which is itself what **wakes** the datastore.

**Behaviour:** Loom connects to `embervm-embervm-serving:5400`, banks ~20 min after its last query (Loom's 10 min pool idle_timeout + the CR's 600 s idleBankSeconds), and relights **warm** on the next request. No Loom code change.

**Proven first:** scratch-postgres was drilled live before this — wakes on connect, initdb's, serves, banks on idle, relights warm, and survives the bank cycle with data intact (7 bugs fixed to get there).

After merge I'll watch loom connect + migrate, confirm a bank→wake cycle, then the `loom-pg` prune completes the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)