### PR TITLE
fix(loom): scale the unbuilt transform worker to zero

### DIFF
--- a/projects/loom/deploy/values.yaml
+++ b/projects/loom/deploy/values.yaml
@@ -94,3 +94,10 @@ ui:
 # manages.
 networkPolicy:
   enabled: false
+
+# Transform workers are a not-yet-built Loom component (README: "transform service
+# not built"); the upstream chart declares a worker Deployment but publishes no
+# loom-worker image (ghcr.io/weave-hand/loom-worker is absent). Scale it to zero
+# so it does not ImagePullBackOff. Re-enable when upstream ships the worker.
+worker:
+  replicas: 0


### PR DESCRIPTION
The 0.0.0-edge chart declares a loom-worker Deployment, but the Transform-worker service is a not-yet-built Loom component (README: "transform service not built") and no `loom-worker` image is published — the pod ImagePullBackOffs. Scale it to zero; loom's built path (ingest → engine → query-api) is unaffected. Config-only, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)