### PR TITLE
fix(embervm): scratch-postgres idleBankSeconds 600->120 (bank wins the race)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.81
+version: 0.1.82

--- a/projects/embervm/chart/templates/workload-scratch-postgres.yaml
+++ b/projects/embervm/chart/templates/workload-scratch-postgres.yaml
@@ -50,8 +50,11 @@ spec:
     # Guest path the volume is mounted at (guest-init mkfs+mounts a blank device;
     # PGDATA lives at <mount>/pgdata).
     volumeMountPath: /data
-    # Bank after 10 minutes idle; a live connection is never severed.
-    idleBankSeconds: 600
+    # Bank after 2 minutes idle; a live connection is never severed. Short so the
+    # bank COMPLETES inside a consumer's quiet window before its next background
+    # write reconnects (a longer idle let the bank race-and-abort against Loom's
+    # periodic control-plane commits); scratch-tier data makes a prompt bank cheap.
+    idleBankSeconds: 120
     # Version-convergence bound (1 week): the instance rides its birth image
     # until this expires; convergence is destroy-and-cold-boot against the volume.
     maxLifetimeSeconds: 604800

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.81
+      targetRevision: 0.1.82
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Live drill with Loom cut over: scratch-postgres reached 'banking' at ~20min idle then reverted to serving because Loom's periodic control-plane commits reconnect right as the 10min bank completes, aborting it. Shortened idleBankSeconds to 2min so the bank completes inside the quiet window. Scratch-tier data makes a prompt bank cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)