### PR TITLE
feat(embervm): R5 PR-1 composite contract (proto group verbs + op-log records + CRD class)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.82
+version: 0.1.83

--- a/projects/embervm/chart/crds/workload-crd.yaml
+++ b/projects/embervm/chart/crds/workload-crd.yaml
@@ -7,12 +7,13 @@
 # bespoke API.
 #
 # v1 invariants held for later rungs (cheap now, expensive to retrofit):
-#   - spec.class is an enum reserving session|serving|stateful (R2/R3/R4); task,
-#     session, and serving are valid as of R3, stateful remains reserved.
+#   - spec.class is an enum: task|session|serving are valid as of R3, stateful as
+#     of R4, and composite as of R5 (the group class).
 #   - spec.source is a oneOf so the R1 zip/runtime-shim lane is a schema
 #     addition, not a reshape; only `image` is implemented.
-#   - spec.group (R5 composite groups) is deliberately RESERVED, not defined:
-#     when it lands it is a new optional block, so v1alpha1 CRs stay valid.
+#   - spec.group (R5 composite groups) is now DEFINED (it was reserved through
+#     R4): a new optional block required only for the composite class, so every
+#     pre-R5 v1alpha1 CR stays valid (the block is absent and forbidden for them).
 #   - status.snapshotRef carries no volumeGeneration in the task class (task VMs
 #     are single-use, no volumes); the R4 stateful class will pair a
 #     volumeGeneration with the snapshot. Recorded here so the field is expected.
@@ -58,6 +59,10 @@ spec:
           type: string
           description: Instance state and generation/bundle pairing (stateful class only).
           jsonPath: .status.statefulSummary
+        - name: Composite
+          type: string
+          description: Group state and live/degraded member counts (composite class only).
+          jsonPath: .status.groupSummary
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp
@@ -77,20 +82,26 @@ spec:
                 class:
                   type: string
                   description: >-
-                    Isolation/lifecycle class. task, session, serving, and
-                    stateful are valid as of R4. The stateful class is a
+                    Isolation/lifecycle class. task, session, serving, stateful,
+                    and composite are valid as of R5. The stateful class is a
                     scale-to-zero singleton datastore (one long-lived microVM
-                    owning one writable volume, reachable over opaque L4 TCP).
-                    concurrency is required by the watcher for task/session/serving
-                    but forbidden for stateful (singleton by construction), which
-                    is why it is no longer a schema-level required field; the
-                    watcher enforces the per-class requiredness via a status
-                    condition (the same pattern as the session/serving blocks).
+                    owning one writable volume, reachable over opaque L4 TCP). The
+                    composite class is the group class: a SET of member microVMs
+                    (each a role with one or more replicas) that live, bank,
+                    relight, and die as ONE unit, sharing a private subnet and
+                    reached through one declared entry member. concurrency is
+                    required by the watcher for task/session/serving but forbidden
+                    for stateful and composite (a composite's size is fixed by its
+                    member set, not a concurrency knob), which is why it is no
+                    longer a schema-level required field; the watcher enforces the
+                    per-class requiredness via a status condition (the same pattern
+                    as the session/serving/stateful blocks).
                   enum:
                     - task
                     - session
                     - serving
                     - stateful
+                    - composite
                 source:
                   type: object
                   description: >-
@@ -478,6 +489,205 @@ spec:
                         scratch tier only: the decoded value rides the guest
                         kernel command line for that one boot. Omit for a
                         workload with no first-boot secrets to deliver.
+                group:
+                  type: object
+                  description: >-
+                    Composite-group definition (R5). REQUIRED when spec.class is
+                    `composite` and forbidden otherwise; the watcher enforces that
+                    cross-field rule with a status condition (the OpenAPI schema
+                    cannot express class-conditional requiredness). A composite is
+                    a SET of member microVMs (each member a role with one or more
+                    replicas) that live, bank, relight, and die as ONE unit,
+                    sharing a private per-group subnet and reached through one
+                    declared entry member (ADR embervm/001). Warmth is banked/relit
+                    as a whole set atomically; a partial or unreadable set discards
+                    warmth and the whole group cold-boots (fresh boot). There is no
+                    maxInstances knob (the group size is fixed by the member set)
+                    and spec.concurrency is forbidden on this class.
+                  required:
+                    - members
+                    - entry
+                  properties:
+                    members:
+                      type: array
+                      description: >-
+                        The group's member roles. Each member expands to `replicas`
+                        VMs (an expanded member name is `<name>-<index>`, 0-based).
+                        Member names are DNS labels and unique across the block. The
+                        sum of replicas (the expanded member count) is capped by the
+                        chart's values-declared maxGroupSize (default 4); the watcher
+                        rejects an over-cap group with a status condition.
+                      minItems: 1
+                      items:
+                        type: object
+                        required:
+                          - name
+                          - source
+                          - healthPort
+                        properties:
+                          name:
+                            type: string
+                            description: >-
+                              DNS-label member name, unique within the group. The
+                              member's expanded replicas are named `<name>-<index>`.
+                            pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                            maxLength: 63
+                          role:
+                            type: string
+                            description: >-
+                              Free-form role label for the member (e.g. leader,
+                              worker), recorded for operator legibility; the control
+                              plane does not interpret it.
+                          startOrder:
+                            type: integer
+                            description: >-
+                              Relative boot order within the group (lower starts
+                              first). Members sharing a startOrder boot together.
+                            minimum: 0
+                            default: 0
+                          replicas:
+                            type: integer
+                            description: >-
+                              Number of VMs this member expands to (each named
+                              `<name>-<index>`). Counts against maxGroupSize.
+                            minimum: 1
+                            default: 1
+                          source:
+                            type: object
+                            description: >-
+                              Where this member's guest comes from. v1 supports the
+                              image lane only (a per-member OCI image), mirroring the
+                              top-level source.image contract.
+                            required:
+                              - image
+                            properties:
+                              image:
+                                type: object
+                                required:
+                                  - ref
+                                properties:
+                                  ref:
+                                    type: string
+                                    description: >-
+                                      OCI reference, digest-pinned or tag. A tag is
+                                      resolved to a digest at base-build time.
+                          resources:
+                            type: object
+                            description: >-
+                              Per-member VM sizing. Defaults to the top-level
+                              spec.resources when omitted (the watcher applies that).
+                            properties:
+                              vcpus:
+                                type: integer
+                                minimum: 1
+                                maximum: 8
+                              memMib:
+                                type: integer
+                                minimum: 128
+                                maximum: 16384
+                          healthPort:
+                            type: integer
+                            description: >-
+                              TCP port the daemon probes for this member's liveness
+                              (a TCP connect gates the member healthy). REQUIRED: the
+                              whole-group readiness edge (every member health-gated)
+                              cannot fire without it.
+                            minimum: 1
+                            maximum: 65535
+                          env:
+                            type: object
+                            description: >-
+                              Optional first-boot environment for this member's
+                              guest, a plain string map.
+                            additionalProperties:
+                              type: string
+                    entry:
+                      type: object
+                      description: >-
+                        The group's single ingress. `member` names the member (or an
+                        expanded replica name) whose `port` traffic reaches; the
+                        group is exposed cluster-internally on `listenPort`.
+                      required:
+                        - member
+                        - port
+                        - listenPort
+                      properties:
+                        member:
+                          type: string
+                          description: >-
+                            The entry member. Must name a declared member OR an
+                            expanded replica name (a member `agent` with replicas 2
+                            makes `agent`, `agent-0`, and `agent-1` all valid entry
+                            targets); the watcher rejects an entry naming no such
+                            member with a status condition.
+                        port:
+                          type: integer
+                          description: The port on the entry member traffic reaches.
+                          minimum: 1
+                          maximum: 65535
+                        listenPort:
+                          type: integer
+                          description: >-
+                            The node Envoy TCP listener port this group is exposed on
+                            cluster-internally. Must fall inside the chart's values-
+                            declared composite range (default 5410-5419) and be unique
+                            across composite workloads; the watcher rejects an out-of-
+                            range or duplicate port with a status condition.
+                          minimum: 1
+                          maximum: 65535
+                    secretRef:
+                      type: object
+                      description: >-
+                        Optional reference to a K8s Secret in this workload's OWN
+                        namespace supplying EMBER_GROUP_SECRET to every member. When
+                        set, the secret is STABLE across group instances (read from
+                        the Secret each boot); when omitted, EMBER_GROUP_SECRET is
+                        minted fresh per group instance. Cluster-internal scratch
+                        tier only.
+                      required:
+                        - name
+                        - key
+                      properties:
+                        name:
+                          type: string
+                          description: The Secret's name (same namespace as the workload).
+                        key:
+                          type: string
+                          description: The data key within the Secret to read.
+                    idleBankSeconds:
+                      type: integer
+                      description: >-
+                        Idle time (no in-flight/queued work across the whole group,
+                        per the idle-signal scrape) after which the WHOLE set is
+                        banked and its VMs released. A live connection is never
+                        severed regardless of this timer.
+                      minimum: 30
+                      default: 600
+                    maxLifetimeSeconds:
+                      type: integer
+                      description: >-
+                        Hard lifetime cap. The group rides its birth images until
+                        this expires; after it, convergence is destroy-and-fresh-boot
+                        of the whole set.
+                      minimum: 60
+                      default: 86400
+                    bankedTtlSeconds:
+                      type: integer
+                      description: >-
+                        How long a banked bundle SET may sit idle before it is
+                        garbage-collected off node disk. The set is GC'd as a unit
+                        (partial warmth is never retained).
+                      minimum: 0
+                      default: 604800
+                    wakeTimeoutSeconds:
+                      type: integer
+                      description: >-
+                        Deadline for a whole-group wake (relight or fresh boot) to
+                        reach readiness (every member health-gated). A wake that
+                        exceeds it marks the group failed and the next request
+                        retries.
+                      minimum: 1
+                      default: 120
                 invocation:
                   type: object
                   description: Task execution policy. All fields defaulted.
@@ -654,6 +864,61 @@ spec:
                     `stateful`, for the STATEFUL printer column (a printer column
                     cannot format an object). Written by the control plane
                     alongside `stateful`.
+                group:
+                  type: object
+                  description: >-
+                    Composite-group status written by the control plane (composite
+                    workloads only). Absent for other classes. Reports the whole-
+                    group lifecycle state, the live/degraded member counts, the
+                    banked bundle-set handle, and the group's private subnet. This
+                    status is WARMTH-ONLY: it reflects live execution state and
+                    EVAPORATES when the group is destroyed, expires (TTL), or fresh-
+                    boots (a discarded-warmth cold boot resets it); it is never a
+                    durable record (the op-log is the book of record). The member
+                    health it summarizes is CRASH-CONSISTENT PER VM only: each
+                    member's state is consistent within itself, never transactionally
+                    consistent across members (a bank snapshots each member VM
+                    independently, standing decisions 2 and 10).
+                  properties:
+                    state:
+                      type: string
+                      description: >-
+                        Whole-group lifecycle state (starting | running | degraded |
+                        banking | banked | relighting | fresh_booting | evicted |
+                        destroyed | failed), or absent when no instance exists yet.
+                        `degraded` means a member is unhealthy while the group stays
+                        up; the terminal `expired` state is reported as `destroyed`
+                        (expiry is a destroy with reason=expired).
+                    members:
+                      type: object
+                      description: >-
+                        Member health counts across the expanded set. Crash-
+                        consistent per VM only (never a cross-member transaction).
+                      properties:
+                        live:
+                          type: integer
+                          description: Members currently healthy.
+                        degraded:
+                          type: integer
+                          description: Members currently unhealthy while the group stays up.
+                    setId:
+                      type: string
+                      description: >-
+                        The banked bundle-SET handle (present only while banked). The
+                        whole set is one warmth unit: a partial or unreadable set is
+                        discarded and the group fresh-boots, so this is never a
+                        per-member handle.
+                    subnetCidr:
+                      type: string
+                      description: The group's private per-group subnet (the /29 its members share).
+                groupSummary:
+                  type: string
+                  description: >-
+                    Human-readable "state live/degraded" rendering of `group`, for
+                    the COMPOSITE printer column (a printer column cannot format an
+                    object). Written by the control plane alongside `group`. Warmth-
+                    only, exactly like `group` (it evaporates on destroy/TTL/fresh-
+                    boot).
                 conditions:
                   type: array
                   items:

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -162,6 +162,16 @@ spec:
                   fieldPath: status.podIP
             - name: EMBERVM_STATEFUL_ACTIVATOR_PORT_RANGE
               value: "{{ .Values.servingEnvoy.statefulTcpPortRange.start }}-{{ .Values.servingEnvoy.statefulTcpPortRange.end }}"
+            # Composite (R5) group entry range + size cap: the values-declared
+            # capacity the CRD watcher validates each composite workload's
+            # spec.group.entry.listenPort and expanded member count against. The
+            # watcher reads these from app env (falling back to the compile-time
+            # defaults 5410-5419 / 4 that match the chart defaults), so a no-chart
+            # `mix test` run still validates against the same range.
+            - name: EMBERVM_COMPOSITE_LISTEN_PORT_RANGE
+              value: "{{ .Values.servingEnvoy.compositeTcpPortRange.start }}-{{ .Values.servingEnvoy.compositeTcpPortRange.end }}"
+            - name: EMBERVM_MAX_GROUP_SIZE
+              value: {{ .Values.servingEnvoy.maxGroupSize | quote }}
             {{- end }}
             {{- if .Values.servingEnvoy.enabled }}
             # The node Envoy stats base URL (R3, Task 9): the ServingSweeper GETs

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -164,9 +164,11 @@ spec:
               value: "{{ .Values.servingEnvoy.statefulTcpPortRange.start }}-{{ .Values.servingEnvoy.statefulTcpPortRange.end }}"
             # Composite (R5) group entry range + size cap: the values-declared
             # capacity the CRD watcher validates each composite workload's
-            # spec.group.entry.listenPort and expanded member count against. The
-            # watcher reads these from app env (falling back to the compile-time
-            # defaults 5410-5419 / 4 that match the chart defaults), so a no-chart
+            # spec.group.entry.listenPort and expanded member count against.
+            # Embervm.Application.start/2 parses these env vars into the
+            # :composite_listen_range / :max_group_size app-env keys the watcher
+            # reads, falling back to the compile-time defaults 5410-5419 / 4 (which
+            # match the chart defaults) when absent or malformed, so a no-chart
             # `mix test` run still validates against the same range.
             - name: EMBERVM_COMPOSITE_LISTEN_PORT_RANGE
               value: "{{ .Values.servingEnvoy.compositeTcpPortRange.start }}-{{ .Values.servingEnvoy.compositeTcpPortRange.end }}"

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -181,6 +181,22 @@ servingEnvoy:
   statefulTcpPortRange:
     start: 5400
     end: 5409
+  # The R5 composite-group entry TCP listenerPort range, the group analogue of
+  # statefulTcpPortRange. Also CAPACITY (static GitOps config declaring which ports
+  # exist). The CRD watcher validates each composite workload's
+  # spec.group.entry.listenPort falls inside [start, end] and is unique across
+  # composite workloads; the control plane then publishes one dynamic tcp_proxy
+  # listener per composite group on its assigned port. Reachable cluster-internally
+  # only (ClusterIP), never at the edge. Distinct from statefulTcpPortRange so the
+  # two classes never collide on a port.
+  compositeTcpPortRange:
+    start: 5410
+    end: 5419
+  # Hard cap on a composite group's EXPANDED member count (sum of member replicas).
+  # The CRD watcher rejects a group whose members exceed this with a status
+  # condition. A capacity guardrail: a group is a set of live microVMs, so an
+  # unbounded member count is an unbounded resource claim.
+  maxGroupSize: 4
   # node-4 pinning: serving runs where Firecracker serving VMs run. A dedicated
   # serving label (not the noded homelab.io/firecracker label) so the two tiers can
   # diverge later; v1 both land on node-4.

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -38,6 +38,13 @@ defmodule Embervm.Application do
     Application.put_env(:embervm, :quota, quota_config())
     Application.put_env(:embervm, :usage_admins, usage_admins())
 
+    # Composite-group (R5) capacity from the chart env into app-env BEFORE the
+    # supervisor starts, so Embervm.WorkloadWatcher (reads them at init) sees an
+    # operator's override of compositeTcpPortRange / maxGroupSize. Absent or
+    # malformed env falls back to the watcher's own compile-time defaults (they are
+    # NOT put here in that case, so the watcher's Application.get_env default fires).
+    put_composite_group_config()
+
     children = [
       # The sync-wait waiter registry + park-count ETS owner come FIRST: every
       # terminal task-state write in TaskStore calls Embervm.SyncWait.notify,
@@ -643,6 +650,65 @@ defmodule Embervm.Application do
       end
     else
       []
+    end
+  end
+
+  # Composite-group capacity (R5): translate the chart env vars into the app-env
+  # keys Embervm.WorkloadWatcher reads. EMBERVM_COMPOSITE_LISTEN_PORT_RANGE is a
+  # "start-end" pair (e.g. "5410-5419"), parsed EXACTLY like
+  # stateful_activator_port_range/0 parses its range; EMBERVM_MAX_GROUP_SIZE is a
+  # positive integer. An absent or malformed value is left UNSET (put_env is
+  # skipped), so the watcher's own Application.get_env default fires (5410..5419 /
+  # 4) rather than a bad override taking hold. Only the R5 seam is wired here; the
+  # R4 :stateful_listen_range seam is deliberately left as-is.
+  defp put_composite_group_config do
+    case composite_listen_range_env() do
+      nil -> :ok
+      range -> Application.put_env(:embervm, :composite_listen_range, range)
+    end
+
+    case max_group_size_env() do
+      nil -> :ok
+      size -> Application.put_env(:embervm, :max_group_size, size)
+    end
+  end
+
+  # Parse "start-end" into a start..end Range, or nil when unset/malformed (so the
+  # watcher default fires). Mirrors stateful_activator_port_range/0's split+parse.
+  defp composite_listen_range_env do
+    case trimmed_env("EMBERVM_COMPOSITE_LISTEN_PORT_RANGE") do
+      "" ->
+        nil
+
+      raw ->
+        case String.split(raw, "-", parts: 2) do
+          [s, e] ->
+            with {start_port, ""} <- Integer.parse(String.trim(s)),
+                 {end_port, ""} <- Integer.parse(String.trim(e)),
+                 true <- start_port <= end_port do
+              start_port..end_port
+            else
+              _ -> nil
+            end
+
+          _ ->
+            nil
+        end
+    end
+  end
+
+  # Parse EMBERVM_MAX_GROUP_SIZE into a positive integer, or nil when unset/malformed
+  # (so the watcher default fires).
+  defp max_group_size_env do
+    case trimmed_env("EMBERVM_MAX_GROUP_SIZE") do
+      "" ->
+        nil
+
+      raw ->
+        case Integer.parse(raw) do
+          {size, ""} when size > 0 -> size
+          _ -> nil
+        end
     end
   end
 

--- a/projects/embervm/control/lib/embervm/op_log.ex
+++ b/projects/embervm/control/lib/embervm/op_log.ex
@@ -33,6 +33,7 @@ defmodule Embervm.OpLog do
               session_id: nil,
               serving_instance_id: nil,
               stateful_instance_id: nil,
+              group_instance_id: nil,
               ts: nil,
               payload: %{}
 
@@ -58,6 +59,13 @@ defmodule Embervm.OpLog do
             # `stateful_instances` projection row. volume_* ops leave it nil (they
             # own a `volumes` row keyed by workload, not an instance).
             stateful_instance_id: String.t() | nil,
+            # Set on group_* ops (nil on every other op); the durable
+            # `ops.group_instance_id` column (R5), added additively the same way
+            # stateful_instance_id was in R4. A group op owns its `group_instances`
+            # projection row (one per group) and, via the member refs it carries,
+            # its `group_members` rows. group_stats leaves it nil (it is
+            # workload-scoped, like serving_stats/stateful_stats).
+            group_instance_id: String.t() | nil,
             ts: integer(),
             payload: map()
           }
@@ -136,7 +144,44 @@ defmodule Embervm.OpLog do
     :stateful_evicted,
     :stateful_destroyed,
     :stateful_failed,
-    :stateful_stats
+    :stateful_stats,
+    # Composite-group lifecycle (R5). Additive to the closed enum, mirroring the R4
+    # stateful kinds: a composite group is a set of member microVMs that live, bank,
+    # relight, and die as ONE unit (ADR embervm/001) and project into the
+    # `group_instances` (one row per group) and `group_members` (one row per member)
+    # tables (see Embervm.OpLog.SQLite). group_net_created/group_net_deleted are the
+    # per-group private subnet audit (the group's own /29 the members share).
+    # group_member_started records each member VM coming up; group_running is the
+    # whole-group readiness edge (every member health-gated). group_published/
+    # group_unpublished are the entry-endpoint-lifetime audit (who traffic reaches),
+    # distinct from the member/group VM-lifecycle kinds. group_banked records the
+    # ENTIRE member set atomically in one append (decision 3's atomicity): the bundle
+    # set is one durable fact, never a member at a time. group_relit is a warm wake
+    # of the whole set; group_fresh_booted is a cold boot that discarded warmth,
+    # carrying a reason (no_set|partial_set|set_unreadable|clock_resync_failed|
+    # explicit) so every discarded-warmth event reconstructs from the log alone.
+    # group_set_evicted carries the reason and the member refs it discarded (the
+    # partner event to a later fresh boot). group_degraded records a member falling
+    # unhealthy while the group stays up (crash-consistency is per-VM, never across
+    # members). The terminal `expired` state has NO dedicated kind: it rides
+    # group_destroyed{reason: expired} (write-through discipline: expiry is a destroy
+    # with a reason). group_stats rides the R4 stats-sweep shape but bills PER MEMBER
+    # (a 3-member group bills 3 VMs' worth), upserted in the op's own transaction.
+    :group_created,
+    :group_net_created,
+    :group_net_deleted,
+    :group_member_started,
+    :group_running,
+    :group_published,
+    :group_unpublished,
+    :group_banked,
+    :group_relit,
+    :group_fresh_booted,
+    :group_set_evicted,
+    :group_degraded,
+    :group_destroyed,
+    :group_failed,
+    :group_stats
   ]
 
   @spec kinds() :: [atom()]
@@ -176,6 +221,17 @@ defmodule Embervm.OpLog do
   # its pair-validity view from on boot. A volume row lives until volume_deleted,
   # outliving every instance by design. A projection read, never the raw ops log.
   @callback load_volumes(server()) :: {:ok, [map()]} | {:error, term()}
+  # Loads every group-instance row from the durable `group_instances` projection
+  # (R5), for the future GroupStore's boot/adoption rebuild, exactly mirroring
+  # load_stateful_instances/1. One row per composite group. A projection read,
+  # never the raw ops log.
+  @callback load_group_instances(server()) :: {:ok, [map()]} | {:error, term()}
+  # Loads every group-member row from the durable `group_members` projection (R5):
+  # one row per (group instance, member name), the per-member lifecycle/health the
+  # GroupStore rebuilds its member view from on boot. A member row lives with its
+  # group instance (pruned when the group instance is). A projection read, never
+  # the raw ops log.
+  @callback load_group_members(server()) :: {:ok, [map()]} | {:error, term()}
   # Reads one task's stored result from the durable `results` projection, or
   # {:ok, nil} when there is none (never ran, or the TTL sweeper reaped it).
   # This is the result-store read the submit API (Task 8) serves `GET
@@ -222,6 +278,7 @@ defmodule Embervm.OpLog do
                  sessions_compacted: non_neg_integer(),
                  serving_instances_compacted: non_neg_integer(),
                  stateful_instances_compacted: non_neg_integer(),
+                 group_instances_compacted: non_neg_integer(),
                  ops_compacted: non_neg_integer(),
                  compacted_through: non_neg_integer(),
                  done: boolean()

--- a/projects/embervm/control/lib/embervm/op_log/compactor.ex
+++ b/projects/embervm/control/lib/embervm/op_log/compactor.ex
@@ -66,6 +66,7 @@ defmodule Embervm.OpLog.Compactor do
       sessions_compacted: 0,
       serving_instances_compacted: 0,
       stateful_instances_compacted: 0,
+      group_instances_compacted: 0,
       ops_compacted: 0,
       compacted_through: 0
     }
@@ -84,6 +85,8 @@ defmodule Embervm.OpLog.Compactor do
             totals.serving_instances_compacted + batch.serving_instances_compacted,
           stateful_instances_compacted:
             totals.stateful_instances_compacted + batch.stateful_instances_compacted,
+          group_instances_compacted:
+            totals.group_instances_compacted + batch.group_instances_compacted,
           ops_compacted: totals.ops_compacted + batch.ops_compacted,
           # The marker is monotonic and reported per batch; the last batch's value
           # is the authoritative post-sweep marker.
@@ -116,6 +119,7 @@ defmodule Embervm.OpLog.Compactor do
           sessions_compacted: totals.sessions_compacted,
           serving_instances_compacted: totals.serving_instances_compacted,
           stateful_instances_compacted: totals.stateful_instances_compacted,
+          group_instances_compacted: totals.group_instances_compacted,
           ops_compacted: totals.ops_compacted,
           compacted_through: totals.compacted_through,
           db_size_bytes: db_size

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -78,6 +78,27 @@ defmodule Embervm.OpLog.SQLite do
     "relighting",
     "cold_booting"
   ]
+
+  # Composite-group instance lifecycle states (R5), mirroring the stateful
+  # retention discipline exactly. A non-terminal (live) group instance pins its
+  # ops against prefix compaction and is never pruned by the retention sweep; a
+  # terminal instance prunes past retention (ADR embervm/002). "degraded" is a
+  # LIVE state (a member fell unhealthy but the group is still up), like
+  # "serving". "fresh_booting" is the cold-boot path (a wake that discarded
+  # warmth), live like "starting". The `expired` terminal state is folded into
+  # "destroyed" (it rides group_destroyed{reason: expired}), so it is not a
+  # distinct state here. `group_members` rows are NOT swept independently: they
+  # live and die with their group instance (pruned when it is).
+  @group_terminal_states ["evicted", "destroyed", "failed"]
+  @group_live_states [
+    "starting",
+    "running",
+    "degraded",
+    "banking",
+    "banked",
+    "relighting",
+    "fresh_booting"
+  ]
   # Seven days in milliseconds: default age (from last update) at which a
   # terminal task is eligible for compaction. This is the TERMINAL-TASK retention
   # window and is DISTINCT from the ops-journal horizon below.
@@ -105,6 +126,7 @@ defmodule Embervm.OpLog.SQLite do
       session_id TEXT,
       serving_instance_id TEXT,
       stateful_instance_id TEXT,
+      group_instance_id TEXT,
       kind TEXT NOT NULL,
       payload_json TEXT NOT NULL DEFAULT '{}'
     )
@@ -272,6 +294,63 @@ defmodule Embervm.OpLog.SQLite do
       updated_at INTEGER NOT NULL
     )
     """,
+    # Composite-group instance projection (R5): the durable lifecycle + entry-
+    # endpoint + set row per group instance, write-through projected from the
+    # group_* ops (see project/2), mirroring stateful_instances above. A composite
+    # group is a set of member microVMs that live/bank/relight/die as ONE unit
+    # (ADR embervm/001). subnet_cidr is the group's private /29 (recorded by
+    # group_net_created); entry_member/entry_port are the declared entry target,
+    # and listen_port is the node-Envoy TCP listener the group is exposed on
+    # cluster-internally (the group identity on the wire). set_id is the banked
+    # bundle-set handle stamped by group_banked (the whole-set warmth key); it is
+    # cleared on a fresh boot or set eviction that discarded warmth. entry_member/
+    # entry_port/listen_port are schema from the first row (the group's identity);
+    # set_id and terminal_reason fill in on the relevant transitions. A non-terminal
+    # instance pins its ops against compaction and is never pruned by retention.
+    """
+    CREATE TABLE IF NOT EXISTS group_instances (
+      instance_id TEXT PRIMARY KEY,
+      tenant TEXT NOT NULL,
+      principal TEXT,
+      workload TEXT,
+      state TEXT NOT NULL,
+      node_id TEXT,
+      subnet_cidr TEXT,
+      entry_member TEXT,
+      entry_port INTEGER,
+      listen_port INTEGER,
+      set_id TEXT,
+      created_at INTEGER NOT NULL,
+      last_active_at INTEGER,
+      updated_at INTEGER NOT NULL,
+      terminal_reason TEXT
+    )
+    """,
+    # Composite-group member projection (R5): one row per (group instance, member
+    # name), the per-member lifecycle/health/snapshot facts. This is the FIRST
+    # multi-row-per-instance projection (sessions/serving/stateful are one row per
+    # instance); the composite PK (instance_id, member_name) keys each member. vm_id/
+    # ip are the member VM's facts (reported at member start, cleared on bank);
+    # member_index is the expanded-replica ordinal (a member `agent` with replicas 2
+    # expands to agent-0, agent-1). snapshot_ref is the member's slice of the banked
+    # bundle set (stamped atomically for every member by ONE group_banked append).
+    # healthy tracks the per-VM health the group_degraded/group_running edges read.
+    # Member rows live and die with their group instance (retention prunes them when
+    # the instance is pruned).
+    """
+    CREATE TABLE IF NOT EXISTS group_members (
+      instance_id TEXT NOT NULL,
+      member_name TEXT NOT NULL,
+      member_index INTEGER,
+      vm_id TEXT,
+      ip TEXT,
+      state TEXT,
+      snapshot_ref TEXT,
+      healthy INTEGER NOT NULL DEFAULT 0,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (instance_id, member_name)
+    )
+    """,
     # Durable single-row scalars for the op-log. Today it holds only the
     # ops-journal prefix marker (`compacted_through_seq`): the newest op seq that
     # has been prefix-compacted away, part of the durable OpLog contract so a
@@ -336,6 +415,16 @@ defmodule Embervm.OpLog.SQLite do
   @impl Embervm.OpLog
   def load_volumes(server \\ __MODULE__) do
     GenServer.call(server, :load_volumes)
+  end
+
+  @impl Embervm.OpLog
+  def load_group_instances(server \\ __MODULE__) do
+    GenServer.call(server, :load_group_instances)
+  end
+
+  @impl Embervm.OpLog
+  def load_group_members(server \\ __MODULE__) do
+    GenServer.call(server, :load_group_members)
   end
 
   @impl Embervm.OpLog
@@ -443,6 +532,14 @@ defmodule Embervm.OpLog.SQLite do
     {:reply, do_load_volumes(state.conn), state}
   end
 
+  def handle_call(:load_group_instances, _from, state) do
+    {:reply, do_load_group_instances(state.conn), state}
+  end
+
+  def handle_call(:load_group_members, _from, state) do
+    {:reply, do_load_group_members(state.conn), state}
+  end
+
   def handle_call({:load_result, task_id}, _from, state) do
     {:reply, do_load_result(state.conn, task_id), state}
   end
@@ -498,8 +595,8 @@ defmodule Embervm.OpLog.SQLite do
 
   defp insert_op(conn, %Op{} = op) do
     sql = """
-    INSERT INTO ops (ts, tenant, principal, workload, task_id, session_id, serving_instance_id, stateful_instance_id, kind, payload_json)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO ops (ts, tenant, principal, workload, task_id, session_id, serving_instance_id, stateful_instance_id, group_instance_id, kind, payload_json)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
@@ -513,6 +610,7 @@ defmodule Embervm.OpLog.SQLite do
              op.session_id,
              op.serving_instance_id,
              op.stateful_instance_id,
+             op.group_instance_id,
              Atom.to_string(op.kind),
              # An ETF {:blob, _}, not JSON, so a binary body persists byte-exact
              # (see encode_payload/1).
@@ -1106,6 +1204,225 @@ defmodule Embervm.OpLog.SQLite do
     project_usage_stateful(conn, op)
   end
 
+  # -- composite-group projection (R5) --------------------------------------
+  #
+  # The durable model: ONE `group_instances` row per group boot-lifecycle (created
+  # by group_created, retired by a terminal kind) plus N `group_members` rows (one
+  # per expanded member). A composite group lives/banks/relights/dies as ONE unit
+  # (ADR embervm/001), so group_banked stamps the ENTIRE member set atomically in a
+  # single append (decision 3), and a fresh boot / set eviction that discards warmth
+  # records its reason so every discarded-warmth event reconstructs from the log
+  # alone. Mirrors the stateful projection block above; the one structural novelty
+  # is the multi-row `group_members` write on member/bank transitions.
+
+  # group_created: a fresh group instance row (the whole-group boot). entry_member/
+  # entry_port/listen_port are the group's identity (from the validated CR); state
+  # is "starting" until every member is up and the group_running edge lands.
+  defp project(conn, %Op{kind: :group_created} = op, _seq) do
+    payload = op.payload
+
+    sql = """
+    INSERT INTO group_instances
+      (instance_id, tenant, principal, workload, state, node_id, subnet_cidr,
+       entry_member, entry_port, listen_port, set_id,
+       created_at, last_active_at, updated_at, terminal_reason)
+    VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, NULL, ?, NULL, ?, NULL)
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <-
+           Sqlite3.bind(stmt, [
+             op.group_instance_id,
+             op.tenant,
+             op.principal,
+             op.workload,
+             Map.get(payload, :state, "starting"),
+             Map.get(payload, :node_id),
+             Map.get(payload, :entry_member),
+             Map.get(payload, :entry_port),
+             Map.get(payload, :listen_port),
+             op.ts,
+             op.ts
+           ]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # group_net_created: the group's private /29 subnet is up. Records subnet_cidr
+  # (the group's own address space its members share); audit-plus-fact, no state
+  # change.
+  defp project(conn, %Op{kind: :group_net_created} = op, _seq) do
+    sql = "UPDATE group_instances SET subnet_cidr=?, updated_at=? WHERE instance_id=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <-
+           Sqlite3.bind(stmt, [
+             Map.get(op.payload, :subnet_cidr),
+             op.ts,
+             op.group_instance_id
+           ]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # group_net_deleted: the group's subnet is torn down (the group is going away).
+  # Audit-only for the subnet fact; the terminal kind clears the instance state.
+  # Clears subnet_cidr so a rebuild never shows a live subnet on a torn-down group.
+  defp project(conn, %Op{kind: :group_net_deleted} = op, _seq) do
+    sql = "UPDATE group_instances SET subnet_cidr=NULL, updated_at=? WHERE instance_id=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [op.ts, op.group_instance_id]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # group_member_started: one member VM came up. Upserts its `group_members` row
+  # (member_name, member_index, vm_id, ip), state "starting", not yet healthy.
+  # UPSERT so a relight/fresh-boot re-start of the same member overwrites its prior
+  # row (a member row lives with the group, its facts refresh on each boot).
+  defp project(conn, %Op{kind: :group_member_started} = op, _seq) do
+    upsert_group_member(conn, op, "starting", healthy: false, clear_snapshot: true)
+  end
+
+  # group_running: the whole-group readiness edge (every member health-gated). The
+  # group instance moves to "running"; every member row flips healthy. last_active_at
+  # advances (the group is live and serving).
+  defp project(conn, %Op{kind: :group_running} = op, _seq) do
+    with :ok <- set_group_state(conn, op, "running", last_active: true) do
+      mark_all_members_healthy(conn, op.group_instance_id, true, op.ts)
+    end
+  end
+
+  # group_published: the entry endpoint is live in the fan-out (who traffic reaches).
+  # Records the listen_port the entry is exposed on; keeps the group "running"
+  # (published is the entry-lifetime audit, not a lifecycle change).
+  defp project(conn, %Op{kind: :group_published} = op, _seq) do
+    sql = "UPDATE group_instances SET listen_port=COALESCE(?, listen_port), updated_at=? WHERE instance_id=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <-
+           Sqlite3.bind(stmt, [
+             Map.get(op.payload, :listen_port),
+             op.ts,
+             op.group_instance_id
+           ]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # group_unpublished: the entry endpoint left the fan-out (a drain precedes a
+  # bank). Audit-only for the endpoint; the VM set is not necessarily gone, so this
+  # does not move the instance to a terminal state (the terminal kinds below do).
+  defp project(conn, %Op{kind: :group_unpublished} = op, _seq) do
+    set_group_state(conn, op, "banking")
+  end
+
+  # group_banked: the whole set is snapshotted and destroyed, recorded ATOMICALLY
+  # in one append (decision 3). Stamps set_id on the instance and each member's
+  # snapshot_ref from payload.members (the bundle-set audit: every discarded-warmth
+  # event reconstructs from this one row + its member rows). Clears each member's
+  # vm_id/ip (the VMs are gone) and moves the instance to "banked".
+  defp project(conn, %Op{kind: :group_banked} = op, _seq) do
+    payload = op.payload
+
+    sql = """
+    UPDATE group_instances
+    SET state='banked', set_id=?, updated_at=?
+    WHERE instance_id=?
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <-
+           Sqlite3.bind(stmt, [
+             Map.get(payload, :set_id),
+             op.ts,
+             op.group_instance_id
+           ]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt),
+         :ok <- bank_group_members(conn, op) do
+      :ok
+    end
+  end
+
+  # group_relit: a WARM wake resumed the banked set. Back to "starting" (not yet
+  # re-running) until the paired group_running edge lands with the fresh member
+  # endpoints; the members re-report via group_member_started, so this only moves
+  # the instance state and advances last_active_at.
+  defp project(conn, %Op{kind: :group_relit} = op, _seq) do
+    set_group_state(conn, op, "starting", last_active: true)
+  end
+
+  # group_fresh_booted: a wake that DISCARDED warmth and cold-booted the whole set
+  # (a NEW cold group boot). reason (no_set|partial_set|set_unreadable|
+  # clock_resync_failed|explicit) rides the payload so the discarded-warmth event is
+  # reconstructable from the log alone. Clears set_id (the warmth is spent) and
+  # returns to "starting"; members re-report fresh.
+  defp project(conn, %Op{kind: :group_fresh_booted} = op, _seq) do
+    sql = """
+    UPDATE group_instances
+    SET state='starting', set_id=NULL, updated_at=?
+    WHERE instance_id=?
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [op.ts, op.group_instance_id]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # group_set_evicted: the banked set is discarded (its warmth is stale/unreadable),
+  # the partner event to a later fresh boot. Records the reason and clears set_id so
+  # the next wake cold-boots. The instance stays live (banked -> starting is the
+  # relight/fresh path); this is the bundle-set audit, not a terminal transition.
+  defp project(conn, %Op{kind: :group_set_evicted} = op, _seq) do
+    sql = "UPDATE group_instances SET set_id=NULL, updated_at=? WHERE instance_id=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [op.ts, op.group_instance_id]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # group_degraded: a member fell unhealthy while the group stays up (crash-
+  # consistency is per-VM, never across members). Moves the instance to "degraded"
+  # (a LIVE state) and flips the named member's healthy flag off.
+  defp project(conn, %Op{kind: :group_degraded} = op, _seq) do
+    with :ok <- set_group_state(conn, op, "degraded") do
+      case Map.get(op.payload, :member_name) do
+        nil -> :ok
+        member -> set_member_health(conn, op.group_instance_id, member, false, op.ts)
+      end
+    end
+  end
+
+  defp project(conn, %Op{kind: :group_destroyed} = op, _seq),
+    do: terminate_group(conn, op, "destroyed")
+
+  defp project(conn, %Op{kind: :group_failed} = op, _seq),
+    do: terminate_group(conn, op, "failed")
+
+  # group_stats: per-member usage ONLY, no group_instances row to touch. A composite
+  # group bills every member's live-seconds (a 3-member group bills 3 VMs' worth),
+  # so group_instance_id is NULL on this kind by construction (workload-scoped, like
+  # stateful_stats) and the (principal, day) accrual stays a pure function of the op.
+  defp project(conn, %Op{kind: :group_stats} = op, _seq) do
+    project_usage_group(conn, op)
+  end
+
   # Audit-only kinds: no task/result projection.
   defp project(_conn, %Op{kind: kind}, _seq)
        when kind in [:denied, :base_built, :primed, :vm_destroyed, :quota_enforced, :drain] do
@@ -1208,6 +1525,167 @@ defmodule Embervm.OpLog.SQLite do
       :ok
     end
   end
+
+  # -- composite-group projection helpers (R5) ------------------------------
+
+  # Move a group instance to `state`, optionally advancing last_active_at (for the
+  # live-serving edges: group_running/group_relit). A no-op-shaped UPDATE keyed by
+  # instance_id, mirroring the serving/stateful state setters.
+  defp set_group_state(conn, %Op{} = op, state, opts \\ []) do
+    sql =
+      if Keyword.get(opts, :last_active, false) do
+        "UPDATE group_instances SET state=?, last_active_at=?, updated_at=? WHERE instance_id=?"
+      else
+        "UPDATE group_instances SET state=?, updated_at=? WHERE instance_id=?"
+      end
+
+    params =
+      if Keyword.get(opts, :last_active, false) do
+        [state, op.ts, op.ts, op.group_instance_id]
+      else
+        [state, op.ts, op.group_instance_id]
+      end
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, params),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # A terminal group-instance transition, mirroring terminate_stateful/3. The
+  # `expired` terminal state has no dedicated kind: it arrives as group_destroyed
+  # {reason: expired}, so the reason (defaulting to the state) carries it through.
+  defp terminate_group(conn, %Op{} = op, state) do
+    reason = to_string(Map.get(op.payload, :reason, state))
+    sql = "UPDATE group_instances SET state=?, terminal_reason=?, updated_at=? WHERE instance_id=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [state, reason, op.ts, op.group_instance_id]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # UPSERT one `group_members` row from a group_member_started op. The composite PK
+  # (instance_id, member_name) means a re-start of the same member (relight/fresh
+  # boot re-reports it) overwrites its prior facts. clear_snapshot resets the banked
+  # slice on a fresh member boot (the warmth is spent). healthy starts false; the
+  # group_running edge flips it.
+  defp upsert_group_member(conn, %Op{} = op, state, opts) do
+    payload = op.payload
+    healthy = if Keyword.get(opts, :healthy, false), do: 1, else: 0
+    clear_snapshot = Keyword.get(opts, :clear_snapshot, false)
+
+    snapshot_set = if clear_snapshot, do: "NULL", else: "snapshot_ref"
+
+    sql = """
+    INSERT INTO group_members
+      (instance_id, member_name, member_index, vm_id, ip, state, snapshot_ref, healthy, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?)
+    ON CONFLICT(instance_id, member_name) DO UPDATE SET
+      member_index = excluded.member_index,
+      vm_id = excluded.vm_id,
+      ip = excluded.ip,
+      state = excluded.state,
+      snapshot_ref = #{snapshot_set},
+      healthy = excluded.healthy,
+      updated_at = excluded.updated_at
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <-
+           Sqlite3.bind(stmt, [
+             op.group_instance_id,
+             Map.get(payload, :member_name),
+             Map.get(payload, :member_index),
+             Map.get(payload, :vm_id),
+             Map.get(payload, :ip),
+             state,
+             healthy,
+             op.ts
+           ]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # Flip every member row of a group to (un)healthy in one statement (the group_running
+  # readiness edge marks the whole set healthy).
+  defp mark_all_members_healthy(conn, instance_id, healthy, ts) do
+    flag = if healthy, do: 1, else: 0
+    sql = "UPDATE group_members SET healthy=?, updated_at=? WHERE instance_id=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [flag, ts, instance_id]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # Set one named member's health flag (group_degraded flips it off).
+  defp set_member_health(conn, instance_id, member_name, healthy, ts) do
+    flag = if healthy, do: 1, else: 0
+    sql = "UPDATE group_members SET healthy=?, updated_at=? WHERE instance_id=? AND member_name=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [flag, ts, instance_id, member_name]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # Stamp the banked bundle-set slice onto every member row ATOMICALLY (decision 3:
+  # the whole set is banked in ONE append). payload.members is a list of
+  # %{name, snapshot_ref} (atom or string keys, since the projection runs on the
+  # freshly-appended atom-keyed op); each member's snapshot_ref is recorded and its
+  # live VM facts (vm_id/ip) cleared (the VMs are gone). A member with no matching
+  # payload entry is left untouched. No-op when the payload carries no member list.
+  defp bank_group_members(conn, %Op{} = op) do
+    case Map.get(op.payload, :members) do
+      members when is_list(members) ->
+        Enum.reduce_while(members, :ok, fn member, :ok ->
+          name = member_field(member, :name)
+          snapshot_ref = member_field(member, :snapshot_ref)
+
+          sql = """
+          UPDATE group_members
+          SET snapshot_ref=?, vm_id=NULL, ip=NULL, state='banked', updated_at=?
+          WHERE instance_id=? AND member_name=?
+          """
+
+          result =
+            with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+                 :ok <- Sqlite3.bind(stmt, [snapshot_ref, op.ts, op.group_instance_id, name]),
+                 :done <- Sqlite3.step(conn, stmt),
+                 :ok <- Sqlite3.release(conn, stmt) do
+              :ok
+            end
+
+          case result do
+            :ok -> {:cont, :ok}
+            {:error, _} = err -> {:halt, err}
+          end
+        end)
+
+      _ ->
+        :ok
+    end
+  end
+
+  # A member payload entry may carry atom keys (the projection sees the freshly
+  # appended atom-keyed op) or string keys (a value rebuilt from the durable
+  # payload_json), so read either.
+  defp member_field(member, key) when is_map(member) do
+    Map.get(member, key) || Map.get(member, Atom.to_string(key))
+  end
+
+  defp member_field(_member, _key), do: nil
 
   defp update_task_state(conn, task_id, state, ts) do
     sql = "UPDATE tasks SET state=?, updated_at=? WHERE task_id=?"
@@ -1333,6 +1811,52 @@ defmodule Embervm.OpLog.SQLite do
     end
   end
 
+  # group_stats usage: accrue LIVE-SECONDS PER MEMBER into vcpu_seconds/gb_seconds
+  # (the compute unit, unlike serving/stateful stats which count L4/L7 units into
+  # request_count). A composite group bills every member's live-seconds: a 3-member
+  # group bills 3 VMs' worth. The payload carries the per-member live-seconds for one
+  # VM plus `member_count` (from the R4 stats-sweep shape, generalized), and the
+  # projection multiplies, so the "3 VMs' worth" is explicit and replay-deterministic.
+  # task_count is left untouched (a group is not a task). Skips a principal-less op
+  # exactly as the serving/stateful paths do. No-op when the op carried no usage.
+  defp project_usage_group(_conn, %Op{principal: nil}), do: :ok
+
+  defp project_usage_group(conn, %Op{payload: payload} = op) do
+    case Map.get(payload, :usage) do
+      usage when is_map(usage) ->
+        member_count = Map.get(payload, :member_count, 1)
+        vcpu_seconds = to_float(Map.get(usage, :vcpu_seconds, 0)) * member_count
+        gb_seconds = to_float(Map.get(usage, :gb_seconds, 0)) * member_count
+
+        sql = """
+        INSERT INTO usage (principal, day, tenant, vcpu_seconds, gb_seconds, task_count, request_count, updated_at)
+        VALUES (?, ?, ?, ?, ?, 0, 0, ?)
+        ON CONFLICT(principal, day) DO UPDATE SET
+          vcpu_seconds = vcpu_seconds + excluded.vcpu_seconds,
+          gb_seconds = gb_seconds + excluded.gb_seconds,
+          updated_at = excluded.updated_at
+        """
+
+        with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+             :ok <-
+               Sqlite3.bind(stmt, [
+                 op.principal,
+                 div(op.ts, @day_ms),
+                 op.tenant,
+                 vcpu_seconds,
+                 gb_seconds,
+                 op.ts
+               ]),
+             :done <- Sqlite3.step(conn, stmt),
+             :ok <- Sqlite3.release(conn, stmt) do
+          :ok
+        end
+
+      _ ->
+        :ok
+    end
+  end
+
   defp to_float(n) when is_number(n), do: n * 1.0
   defp to_float(_), do: 0.0
 
@@ -1370,7 +1894,7 @@ defmodule Embervm.OpLog.SQLite do
       {:error, {:compacted, marker}}
     else
       sql = """
-      SELECT seq, ts, tenant, principal, workload, task_id, session_id, serving_instance_id, stateful_instance_id, kind, payload_json
+      SELECT seq, ts, tenant, principal, workload, task_id, session_id, serving_instance_id, stateful_instance_id, group_instance_id, kind, payload_json
       FROM ops WHERE seq > ? ORDER BY seq ASC
       """
 
@@ -1396,6 +1920,7 @@ defmodule Embervm.OpLog.SQLite do
          session_id,
          serving_instance_id,
          stateful_instance_id,
+         group_instance_id,
          kind,
          payload_json
        ]} ->
@@ -1409,6 +1934,7 @@ defmodule Embervm.OpLog.SQLite do
           session_id: session_id,
           serving_instance_id: serving_instance_id,
           stateful_instance_id: stateful_instance_id,
+          group_instance_id: group_instance_id,
           kind: String.to_existing_atom(kind),
           payload: decode_payload(payload_json)
         }
@@ -1661,6 +2187,102 @@ defmodule Embervm.OpLog.SQLite do
     end
   end
 
+  defp do_load_group_instances(conn) do
+    sql = """
+    SELECT instance_id, tenant, principal, workload, state, node_id, subnet_cidr,
+           entry_member, entry_port, listen_port, set_id,
+           created_at, last_active_at, updated_at, terminal_reason
+    FROM group_instances
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql) do
+      instances = collect_group_instances(conn, stmt, [])
+      :ok = Sqlite3.release(conn, stmt)
+      {:ok, instances}
+    end
+  end
+
+  defp collect_group_instances(conn, stmt, acc) do
+    case Sqlite3.step(conn, stmt) do
+      {:row,
+       [
+         instance_id,
+         tenant,
+         principal,
+         workload,
+         state,
+         node_id,
+         subnet_cidr,
+         entry_member,
+         entry_port,
+         listen_port,
+         set_id,
+         created_at,
+         last_active_at,
+         updated_at,
+         terminal_reason
+       ]} ->
+        instance = %{
+          instance_id: instance_id,
+          tenant: tenant,
+          principal: principal,
+          workload: workload,
+          state: state,
+          node_id: node_id,
+          subnet_cidr: subnet_cidr,
+          entry_member: entry_member,
+          entry_port: entry_port,
+          listen_port: listen_port,
+          set_id: set_id,
+          created_at: created_at,
+          last_active_at: last_active_at,
+          updated_at: updated_at,
+          terminal_reason: terminal_reason
+        }
+
+        collect_group_instances(conn, stmt, [instance | acc])
+
+      :done ->
+        Enum.reverse(acc)
+    end
+  end
+
+  defp do_load_group_members(conn) do
+    sql = """
+    SELECT instance_id, member_name, member_index, vm_id, ip, state, snapshot_ref, healthy, updated_at
+    FROM group_members
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql) do
+      members = collect_group_members(conn, stmt, [])
+      :ok = Sqlite3.release(conn, stmt)
+      {:ok, members}
+    end
+  end
+
+  defp collect_group_members(conn, stmt, acc) do
+    case Sqlite3.step(conn, stmt) do
+      {:row, [instance_id, member_name, member_index, vm_id, ip, state, snapshot_ref, healthy, updated_at]} ->
+        member = %{
+          instance_id: instance_id,
+          member_name: member_name,
+          member_index: member_index,
+          vm_id: vm_id,
+          ip: ip,
+          state: state,
+          snapshot_ref: snapshot_ref,
+          # SQLite stores the flag as 0/1; surface it as a bool for the GroupStore.
+          healthy: healthy == 1,
+          updated_at: updated_at
+        }
+
+        collect_group_members(conn, stmt, [member | acc])
+
+      :done ->
+        Enum.reverse(acc)
+    end
+  end
+
   defp do_load_result(conn, task_id) do
     sql = """
     SELECT status_code, body, size_bytes, truncated, created_at, expires_at, headers
@@ -1844,11 +2466,13 @@ defmodule Embervm.OpLog.SQLite do
            delete_terminal_serving_instances(conn, now_ms, state.retention_ms, batch),
          {:ok, stateful_instances_compacted} <-
            delete_terminal_stateful_instances(conn, now_ms, state.retention_ms, batch),
+         {:ok, group_instances_compacted} <-
+           delete_terminal_group_instances(conn, now_ms, state.retention_ms, batch),
          {:ok, ops_compacted, marker} <- compact_ops(conn, now_ms, state.journal_horizon_ms, batch) do
       done =
         results_deleted < batch and tasks_compacted < batch and sessions_compacted < batch and
           serving_instances_compacted < batch and stateful_instances_compacted < batch and
-          ops_compacted < batch
+          group_instances_compacted < batch and ops_compacted < batch
 
       {:ok,
        %{
@@ -1857,6 +2481,7 @@ defmodule Embervm.OpLog.SQLite do
          sessions_compacted: sessions_compacted,
          serving_instances_compacted: serving_instances_compacted,
          stateful_instances_compacted: stateful_instances_compacted,
+         group_instances_compacted: group_instances_compacted,
          ops_compacted: ops_compacted,
          compacted_through: marker,
          done: done
@@ -1934,6 +2559,43 @@ defmodule Embervm.OpLog.SQLite do
     end
   end
 
+  # Prune terminal group-instance projection rows past retention, mirroring
+  # delete_terminal_stateful_instances/4. A non-terminal group is never pruned, and
+  # its ops stay pinned by blocker_seq. `group_members` has no FK cascade (it keys on
+  # instance_id but does not REFERENCE group_instances), so this deletes the pruned
+  # instances' member rows in the same batch: member rows live and die with their
+  # group instance, so an orphaned member row must never survive its instance.
+  defp delete_terminal_group_instances(conn, now_ms, retention_ms, batch) do
+    cutoff = now_ms - retention_ms
+    placeholders = @group_terminal_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
+
+    # Members of the instances about to be pruned, deleted FIRST so the member rows
+    # never outlive the instance row (the selection is the same terminal+aged set).
+    member_sql = """
+    DELETE FROM group_members WHERE instance_id IN (
+      SELECT instance_id FROM group_instances WHERE state IN (#{placeholders}) AND updated_at < ? LIMIT ?
+    )
+    """
+
+    instance_sql = """
+    DELETE FROM group_instances WHERE rowid IN (
+      SELECT rowid FROM group_instances WHERE state IN (#{placeholders}) AND updated_at < ? LIMIT ?
+    )
+    """
+
+    with {:ok, mstmt} <- Sqlite3.prepare(conn, member_sql),
+         :ok <- Sqlite3.bind(mstmt, @group_terminal_states ++ [cutoff, batch]),
+         :done <- Sqlite3.step(conn, mstmt),
+         :ok <- Sqlite3.release(conn, mstmt),
+         {:ok, stmt} <- Sqlite3.prepare(conn, instance_sql),
+         :ok <- Sqlite3.bind(stmt, @group_terminal_states ++ [cutoff, batch]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt),
+         {:ok, changed} <- Sqlite3.changes(conn) do
+      {:ok, changed}
+    end
+  end
+
   # Bounded DELETE via the portable rowid-subquery form: Exqlite's bundled SQLite
   # is not built with SQLITE_ENABLE_UPDATE_DELETE_LIMIT, so `DELETE ... LIMIT` is
   # unavailable; `DELETE ... WHERE rowid IN (SELECT rowid ... LIMIT ?)` bounds the
@@ -2000,19 +2662,22 @@ defmodule Embervm.OpLog.SQLite do
 
   # The smallest seq that must NOT be compacted: the first op that is either newer
   # than the horizon (ts >= cutoff), owned by a live (non-terminal) task, owned
-  # by a live (non-terminal) session, OR owned by a live (non-terminal) serving
-  # instance. The session clause is the R2 never-compact-a-live-session rule; the
-  # serving clause is its R3 mirror: a non-terminal serving instance pins its ops
-  # exactly as a live task or session does, so its lineage/lifecycle history
-  # stays replayable until it terminates. A serving_stats op carries no
-  # serving_instance_id (it is workload-scoped, see D-R3.2.1), so it is pinned
-  # only by the ts >= cutoff clause like any other audit-only op, never by this
-  # clause. NULL means no op is blocked, so the whole log is eligible.
+  # by a live (non-terminal) session, owned by a live (non-terminal) serving
+  # instance, owned by a live (non-terminal) stateful instance, OR owned by a live
+  # (non-terminal) group instance. The session clause is the R2 never-compact-a-
+  # live-session rule; the serving/stateful/group clauses are its R3/R4/R5 mirrors:
+  # a non-terminal instance pins its ops exactly as a live task or session does, so
+  # its lineage/lifecycle history stays replayable until it terminates. A
+  # serving_stats/stateful_stats/group_stats op carries no instance id (it is
+  # workload-scoped), so it is pinned only by the ts >= cutoff clause like any other
+  # audit-only op, never by this clause. NULL means no op is blocked, so the whole
+  # log is eligible.
   defp blocker_seq(conn, cutoff) do
     live_placeholders = @live_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
     session_live_placeholders = @session_live_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
     serving_live_placeholders = @serving_live_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
     stateful_live_placeholders = @stateful_live_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
+    group_live_placeholders = @group_live_states |> Enum.map(fn _ -> "?" end) |> Enum.join(", ")
 
     sql = """
     SELECT MIN(seq) FROM ops
@@ -2025,6 +2690,9 @@ defmodule Embervm.OpLog.SQLite do
        OR stateful_instance_id IN (
             SELECT instance_id FROM stateful_instances WHERE state IN (#{stateful_live_placeholders})
           )
+       OR group_instance_id IN (
+            SELECT instance_id FROM group_instances WHERE state IN (#{group_live_placeholders})
+          )
     """
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
@@ -2032,7 +2700,9 @@ defmodule Embervm.OpLog.SQLite do
            Sqlite3.bind(
              stmt,
              [cutoff] ++
-               @live_states ++ @session_live_states ++ @serving_live_states ++ @stateful_live_states
+               @live_states ++
+               @session_live_states ++
+               @serving_live_states ++ @stateful_live_states ++ @group_live_states
            ) do
       result =
         case Sqlite3.step(conn, stmt) do
@@ -2160,7 +2830,8 @@ defmodule Embervm.OpLog.SQLite do
          :ok <- migrate_ops_session_id(conn),
          :ok <- migrate_ops_serving_instance_id(conn),
          :ok <- migrate_usage_request_count(conn),
-         :ok <- migrate_ops_stateful_instance_id(conn) do
+         :ok <- migrate_ops_stateful_instance_id(conn),
+         :ok <- migrate_ops_group_instance_id(conn) do
       :ok
     end
   end
@@ -2245,6 +2916,29 @@ defmodule Embervm.OpLog.SQLite do
       Sqlite3.execute(
         conn,
         "CREATE INDEX IF NOT EXISTS ops_stateful_instance_id_idx ON ops(stateful_instance_id)"
+      )
+    end
+  end
+
+  # R5: the additive nullable `ops.group_instance_id` column plus its index,
+  # mirroring migrate_ops_stateful_instance_id/1 exactly. A fresh DB already built
+  # the column from the CREATE TABLE (and skips the ALTER), so this only fires on a
+  # DB created before R5; the guard is the same D-R1.2.1/R2/R3/R4 ALTER-after-DDL
+  # precedent. `group_instances` and `group_members` are whole new tables, so
+  # `CREATE TABLE IF NOT EXISTS` in @ddl handles both cases; no ALTER is needed for
+  # them.
+  defp migrate_ops_group_instance_id(conn) do
+    with {:ok, cols} <- table_columns(conn, "ops"),
+         :ok <-
+           add_column_if_missing(
+             conn,
+             cols,
+             "group_instance_id",
+             "ALTER TABLE ops ADD COLUMN group_instance_id TEXT"
+           ) do
+      Sqlite3.execute(
+        conn,
+        "CREATE INDEX IF NOT EXISTS ops_group_instance_id_idx ON ops(group_instance_id)"
       )
     end
   end

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -1824,7 +1824,11 @@ defmodule Embervm.OpLog.SQLite do
   defp project_usage_group(conn, %Op{payload: payload} = op) do
     case Map.get(payload, :usage) do
       usage when is_map(usage) ->
-        member_count = Map.get(payload, :member_count, 1)
+        # member_count is coerced the same defensive way the usage values go through
+        # to_float/1: a malformed op (e.g. a string member_count) must never raise an
+        # ArithmeticError inside the append transaction. A non-integer/absent count
+        # bills one member's worth.
+        member_count = to_pos_int(Map.get(payload, :member_count), 1)
         vcpu_seconds = to_float(Map.get(usage, :vcpu_seconds, 0)) * member_count
         gb_seconds = to_float(Map.get(usage, :gb_seconds, 0)) * member_count
 
@@ -1859,6 +1863,12 @@ defmodule Embervm.OpLog.SQLite do
 
   defp to_float(n) when is_number(n), do: n * 1.0
   defp to_float(_), do: 0.0
+
+  # Coerce a payload count to a POSITIVE integer, defaulting on anything else (a
+  # non-positive, non-integer, or absent value). Keeps a malformed op from raising
+  # inside the append transaction, mirroring to_float/1's total-function shape.
+  defp to_pos_int(n, _default) when is_integer(n) and n > 0, do: n
+  defp to_pos_int(_n, default), do: default
 
   defp existing_task_for_idempotency_key(_conn, _workload, nil), do: {:ok, nil}
 

--- a/projects/embervm/control/lib/embervm/workload_watcher.ex
+++ b/projects/embervm/control/lib/embervm/workload_watcher.ex
@@ -67,6 +67,16 @@ defmodule Embervm.WorkloadWatcher do
   # :stateful_listen_range app env or a start_link opt so the chart value flows
   # in and tests can inject a narrow range.
   @default_stateful_listen_range 5400..5409
+  # The default composite-group entry TCP listenPort range, matching the chart's
+  # values default (compositeTcpPortRange 5410-5419, R5). Overridable via the
+  # :composite_listen_range app env or a start_link opt, exactly like the stateful
+  # range; distinct from it so the two classes never collide on a port.
+  @default_composite_listen_range 5410..5419
+  # The default cap on a composite group's EXPANDED member count (sum of replicas),
+  # matching the chart's values default (maxGroupSize 4, R5). Overridable via the
+  # :max_group_size app env or a start_link opt. A capacity guardrail: a group is a
+  # set of live microVMs, so an unbounded member count is an unbounded resource claim.
+  @default_max_group_size 4
   # A healthy watch lives for the apiserver's full `timeoutSeconds` (~5 min);
   # a watch that ends far sooner is a signal of trouble, not a normal cycle. So
   # only a watch that stayed open at least this long earns an IMMEDIATE
@@ -135,11 +145,27 @@ defmodule Embervm.WorkloadWatcher do
       Keyword.get(opts, :stateful_listen_range) ||
         Application.get_env(:embervm, :stateful_listen_range, @default_stateful_listen_range)
 
+    # The values-declared composite entry listenPort range + expanded-member-count
+    # cap (R5), flowing in the same way stateful_listen_range does: a start_link opt
+    # (tests) or app env (the chart wires EMBERVM_COMPOSITE_LISTEN_PORT_RANGE /
+    # EMBERVM_MAX_GROUP_SIZE), falling back to the compile-time defaults that match
+    # the chart defaults. The watcher validates every composite workload's
+    # entry.listenPort against the range and its expanded member count against the cap.
+    composite_listen_range =
+      Keyword.get(opts, :composite_listen_range) ||
+        Application.get_env(:embervm, :composite_listen_range, @default_composite_listen_range)
+
+    max_group_size =
+      Keyword.get(opts, :max_group_size) ||
+        Application.get_env(:embervm, :max_group_size, @default_max_group_size)
+
     WorkloadCatalog.create(table)
 
     state = %{
       table: table,
       stateful_listen_range: stateful_listen_range,
+      composite_listen_range: composite_listen_range,
+      max_group_size: max_group_size,
       lister: lister,
       watcher_fun: watcher_fun,
       status_writer: status_writer,
@@ -438,9 +464,20 @@ defmodule Embervm.WorkloadWatcher do
       spec = Map.get(cr, "spec") || %{}
 
       case validate(state, name, spec) do
-        {:ok, class, floor, cap, session_cfg, serving_cfg, stateful_cfg} ->
+        {:ok, class, floor, cap, session_cfg, serving_cfg, stateful_cfg, group_cfg} ->
           entry =
-            catalog_entry(name, namespace, spec, class, floor, cap, session_cfg, serving_cfg, stateful_cfg)
+            catalog_entry(
+              name,
+              namespace,
+              spec,
+              class,
+              floor,
+              cap,
+              session_cfg,
+              serving_cfg,
+              stateful_cfg,
+              group_cfg
+            )
 
           WorkloadCatalog.upsert(state.table, name, entry)
 
@@ -570,23 +607,24 @@ defmodule Embervm.WorkloadWatcher do
 
   # -- validation ----------------------------------------------------------
 
-  # Returns {:ok, class, floor, cap, session_cfg, serving_cfg} with just the
-  # pieces catalog_entry needs (session_cfg/serving_cfg are nil except for
-  # their own class), or {:error, reason_code, message} for a status
-  # condition. The CRD schema (workload-crd.yaml) enforces shape (required
-  # fields, enums, min/max) at admission; what's left for the watcher is the
-  # cross-field/semantic rules the OpenAPI schema cannot express (class
-  # allow-list beyond the enum, the oneOf source lane, cap >= floor, the
-  # class-conditional session/serving blocks, the serving cap/maxInstances
-  # alias guard, and cross-CR duplicate-host rejection).
+  # Returns {:ok, class, floor, cap, session_cfg, serving_cfg, stateful_cfg,
+  # group_cfg} with just the pieces catalog_entry needs (each *_cfg is nil except
+  # for its own class), or {:error, reason_code, message} for a status condition.
+  # The CRD schema (workload-crd.yaml) enforces shape (required fields, enums,
+  # min/max) at admission; what's left for the watcher is the cross-field/semantic
+  # rules the OpenAPI schema cannot express (class allow-list beyond the enum, the
+  # oneOf source lane, cap >= floor, the class-conditional session/serving/stateful/
+  # group blocks, the serving cap/maxInstances alias guard, cross-CR duplicate-host/
+  # port rejection, and the composite member/entry/size cross-field checks).
   defp validate(state, name, spec) do
     with {:ok, class} <- validate_class(spec),
          :ok <- validate_source(spec),
          {:ok, floor, cap} <- validate_concurrency(spec, class),
          {:ok, session_cfg} <- validate_session(spec, class),
          {:ok, serving_cfg} <- validate_serving(state, name, spec, class, cap),
-         {:ok, stateful_cfg} <- validate_stateful(state, name, spec, class) do
-      {:ok, class, floor, cap, session_cfg, serving_cfg, stateful_cfg}
+         {:ok, stateful_cfg} <- validate_stateful(state, name, spec, class),
+         {:ok, group_cfg} <- validate_group(state, name, spec, class) do
+      {:ok, class, floor, cap, session_cfg, serving_cfg, stateful_cfg, group_cfg}
     end
   end
 
@@ -594,10 +632,11 @@ defmodule Embervm.WorkloadWatcher do
   defp validate_class(%{"class" => "session"}), do: {:ok, "session"}
   defp validate_class(%{"class" => "serving"}), do: {:ok, "serving"}
   defp validate_class(%{"class" => "stateful"}), do: {:ok, "stateful"}
+  defp validate_class(%{"class" => "composite"}), do: {:ok, "composite"}
 
   defp validate_class(spec) do
     {:error, "ClassUnsupported",
-     "class #{inspect(Map.get(spec, "class"))} is reserved for a later rung; only task, session, serving, and stateful are valid in v1alpha1"}
+     "class #{inspect(Map.get(spec, "class"))} is reserved for a later rung; only task, session, serving, stateful, and composite are valid in v1alpha1"}
   end
 
   # The session block is REQUIRED for the session class and FORBIDDEN for the
@@ -612,7 +651,7 @@ defmodule Embervm.WorkloadWatcher do
     invoke_queue_cap: 4
   }
 
-  defp validate_session(spec, class) when class in ["task", "serving", "stateful"] do
+  defp validate_session(spec, class) when class in ["task", "serving", "stateful", "composite"] do
     case Map.get(spec, "session") do
       nil -> {:ok, nil}
       _ -> {:error, "SessionSpecUnexpected", "spec.session is only valid for class session, not #{class}"}
@@ -667,7 +706,8 @@ defmodule Embervm.WorkloadWatcher do
     banked_ttl_seconds: 86_400
   }
 
-  defp validate_serving(_state, _name, spec, class, _cap) when class in ["task", "session", "stateful"] do
+  defp validate_serving(_state, _name, spec, class, _cap)
+       when class in ["task", "session", "stateful", "composite"] do
     case Map.get(spec, "serving") do
       nil -> {:ok, nil}
       _ -> {:error, "ServingSpecUnexpected", "spec.serving is only valid for class serving, not #{class}"}
@@ -778,7 +818,8 @@ defmodule Embervm.WorkloadWatcher do
   # the CRD schema also enforces this, re-checked here for the LIST/WATCH path.
   @stateful_min_idle_bank_seconds 30
 
-  defp validate_stateful(_state, _name, spec, class) when class in ["task", "session", "serving"] do
+  defp validate_stateful(_state, _name, spec, class)
+       when class in ["task", "session", "serving", "composite"] do
     case Map.get(spec, "stateful") do
       nil -> {:ok, nil}
       _ -> {:error, "StatefulSpecUnexpected", "spec.stateful is only valid for class stateful, not #{class}"}
@@ -889,6 +930,219 @@ defmodule Embervm.WorkloadWatcher do
     }
   end
 
+  # The group block is REQUIRED for the composite class and FORBIDDEN for every
+  # other class (the class-conditional requiredness the OpenAPI schema cannot
+  # express), mirroring validate_stateful/4. The composite-only cross-field rules
+  # beyond presence: member names are unique DNS labels, the expanded member count
+  # (sum of replicas) is within maxGroupSize, entry.member names a declared member
+  # or an expanded replica name, entry.listenPort falls inside the values-declared
+  # composite range AND is unique across live composite workloads (one port, one
+  # group, checked against the LIVE catalog like the stateful port rule).
+  @group_defaults %{
+    idle_bank_seconds: 600,
+    max_lifetime_seconds: 86_400,
+    banked_ttl_seconds: 604_800,
+    wake_timeout_seconds: 120
+  }
+  # The minimum idleBankSeconds (a too-eager bank thrashes wake/bank); the CRD
+  # schema also enforces this, re-checked here for the LIST/WATCH path.
+  @group_min_idle_bank_seconds 30
+
+  defp validate_group(_state, _name, spec, class)
+       when class in ["task", "session", "serving", "stateful"] do
+    case Map.get(spec, "group") do
+      nil -> {:ok, nil}
+      _ -> {:error, "GroupSpecUnexpected", "spec.group is only valid for class composite, not #{class}"}
+    end
+  end
+
+  defp validate_group(state, name, spec, "composite") do
+    case Map.get(spec, "group") do
+      g when is_map(g) ->
+        with {:ok, member_names} <- validate_group_members(g, state.max_group_size),
+             :ok <- validate_group_entry(g, member_names),
+             :ok <- validate_group_listen_port(state, name, g),
+             :ok <- validate_group_idle_bank(g) do
+          {:ok, parse_group(g)}
+        end
+
+      _ ->
+        {:error, "GroupSpecMissing", "class composite requires a spec.group block"}
+    end
+  end
+
+  # Member names must be present, unique DNS labels; the expanded member count (sum
+  # of replicas) must not exceed maxGroupSize. Returns the EXPANDED name set (every
+  # `<name>` plus, when replicas > 1, each `<name>-<index>`) so entry validation can
+  # accept an expanded replica name as the entry target.
+  defp validate_group_members(g, max_group_size) do
+    members = Map.get(g, "members")
+
+    cond do
+      not (is_list(members) and members != []) ->
+        {:error, "InvalidGroupSpec", "spec.group.members must be a non-empty list"}
+
+      not Enum.all?(members, &is_map/1) ->
+        {:error, "InvalidGroupSpec", "each spec.group.members entry must be an object"}
+
+      true ->
+        names = Enum.map(members, &Map.get(&1, "name"))
+
+        cond do
+          Enum.any?(names, &(not (is_binary(&1) and &1 != ""))) ->
+            {:error, "InvalidGroupSpec", "each spec.group.members entry requires a name"}
+
+          length(Enum.uniq(names)) != length(names) ->
+            {:error, "GroupMemberNameConflict", "spec.group.members names must be unique"}
+
+          true ->
+            expanded_count = Enum.reduce(members, 0, fn m, acc -> acc + member_replicas(m) end)
+
+            if expanded_count > max_group_size do
+              {:error, "GroupSizeExceeded",
+               "spec.group expanded member count #{expanded_count} exceeds the configured maxGroupSize #{max_group_size}"}
+            else
+              {:ok, expanded_member_names(members)}
+            end
+        end
+    end
+  end
+
+  defp member_replicas(m), do: Map.get(m, "replicas") || 1
+
+  # The valid entry targets: each declared member name, plus (for a member with
+  # replicas > 1) each expanded `<name>-<index>` (0-based). A replicas-1 member is
+  # addressable by its bare name only (there is no `-0` form), matching the CRD doc.
+  defp expanded_member_names(members) do
+    Enum.flat_map(members, fn m ->
+      name = Map.get(m, "name")
+      replicas = member_replicas(m)
+
+      if replicas > 1 do
+        [name | Enum.map(0..(replicas - 1), fn i -> "#{name}-#{i}" end)]
+      else
+        [name]
+      end
+    end)
+  end
+
+  # entry.member must name a declared member or an expanded replica name; entry.port
+  # is required (the CRD enforces its range, re-checked as an integer here).
+  defp validate_group_entry(g, member_names) do
+    entry = Map.get(g, "entry") || %{}
+    member = Map.get(entry, "member")
+    port = Map.get(entry, "port")
+
+    cond do
+      not (is_binary(member) and member != "") ->
+        {:error, "InvalidGroupSpec", "spec.group.entry.member is required"}
+
+      member not in member_names ->
+        {:error, "GroupEntryMemberUnknown",
+         "spec.group.entry.member #{inspect(member)} names no declared member or expanded replica"}
+
+      not is_integer(port) ->
+        {:error, "InvalidGroupSpec", "spec.group.entry.port is required and must be an integer"}
+
+      true ->
+        :ok
+    end
+  end
+
+  # entry.listenPort must be inside the values-declared composite range AND unique
+  # across every other live composite workload, mirroring the stateful listenPort
+  # rule. Out-of-range names the configured range; a duplicate names the conflict.
+  defp validate_group_listen_port(state, name, g) do
+    listen_port = get_in(g, ["entry", "listenPort"])
+    range = state.composite_listen_range
+
+    cond do
+      not is_integer(listen_port) ->
+        {:error, "InvalidGroupSpec", "spec.group.entry.listenPort is required and must be an integer"}
+
+      listen_port not in range ->
+        {:error, "GroupListenPortOutOfRange",
+         "spec.group.entry.listenPort #{listen_port} is outside the configured composite range #{Enum.min(range)}-#{Enum.max(range)}"}
+
+      true ->
+        case group_listen_port_conflict(state, name, listen_port) do
+          nil -> :ok
+          other ->
+            {:error, "GroupListenPortConflict",
+             "spec.group.entry.listenPort #{listen_port} is already owned by workload #{inspect(other)}"}
+        end
+    end
+  end
+
+  defp group_listen_port_conflict(state, name, listen_port) do
+    state.table
+    |> WorkloadCatalog.all_names()
+    |> Enum.reject(&(&1 == name))
+    |> Enum.find(fn other_name ->
+      case WorkloadCatalog.fetch(state.table, other_name) do
+        {:ok, %{class: "composite", group: %{entry: %{listen_port: ^listen_port}}}} -> true
+        _ -> false
+      end
+    end)
+  end
+
+  defp validate_group_idle_bank(g) do
+    case Map.get(g, "idleBankSeconds") do
+      nil ->
+        :ok
+
+      idle when is_integer(idle) and idle >= @group_min_idle_bank_seconds ->
+        :ok
+
+      idle ->
+        {:error, "InvalidGroupSpec",
+         "spec.group.idleBankSeconds #{inspect(idle)} must be >= #{@group_min_idle_bank_seconds}"}
+    end
+  end
+
+  # Parse the validated group block into the catalog shape. Members carry their
+  # per-member source/resources/health/env; entry carries the ingress; the timers
+  # apply their CRD-documented defaults here (no silent dependency on apiserver
+  # defaulting). secretRef is nil when absent (EMBER_GROUP_SECRET is minted per
+  # instance then).
+  defp parse_group(g) do
+    entry = Map.get(g, "entry") || %{}
+
+    %{
+      members: Enum.map(Map.get(g, "members") || [], &parse_group_member/1),
+      entry: %{
+        member: Map.get(entry, "member"),
+        port: Map.get(entry, "port"),
+        listen_port: Map.get(entry, "listenPort")
+      },
+      secret_ref: parse_group_secret_ref(Map.get(g, "secretRef")),
+      idle_bank_seconds: Map.get(g, "idleBankSeconds") || @group_defaults.idle_bank_seconds,
+      max_lifetime_seconds: Map.get(g, "maxLifetimeSeconds") || @group_defaults.max_lifetime_seconds,
+      banked_ttl_seconds: Map.get(g, "bankedTtlSeconds") || @group_defaults.banked_ttl_seconds,
+      wake_timeout_seconds: Map.get(g, "wakeTimeoutSeconds") || @group_defaults.wake_timeout_seconds
+    }
+  end
+
+  defp parse_group_member(m) do
+    %{
+      name: Map.get(m, "name"),
+      role: Map.get(m, "role"),
+      start_order: Map.get(m, "startOrder") || 0,
+      replicas: member_replicas(m),
+      image_ref: get_in(m, ["source", "image", "ref"]),
+      vcpus: get_in(m, ["resources", "vcpus"]),
+      mem_mib: get_in(m, ["resources", "memMib"]),
+      health_port: Map.get(m, "healthPort"),
+      env: Map.get(m, "env") || %{}
+    }
+  end
+
+  defp parse_group_secret_ref(nil), do: nil
+
+  defp parse_group_secret_ref(ref) when is_map(ref) do
+    %{name: Map.get(ref, "name"), key: Map.get(ref, "key")}
+  end
+
   # The CRD schema enforces the structural oneOf (exactly one of image|zip) at
   # admission, but a CR observed via LIST/WATCH is trusted only as far as this
   # code re-checks it: enforce the same mutual exclusion here (both set, or
@@ -946,6 +1200,18 @@ defmodule Embervm.WorkloadWatcher do
     end
   end
 
+  # The composite class's size is fixed by its member set (sum of replicas), not a
+  # concurrency knob, so spec.concurrency is condition-rejected exactly like the
+  # stateful class. The internal floor/cap are fixed at scale-to-zero group (0, 1
+  # group instance) so the catalog entry keeps a uniform shape without a concurrency
+  # block; the expanded member count is bounded separately by maxGroupSize.
+  defp validate_concurrency(spec, "composite") do
+    case Map.get(spec, "concurrency") do
+      nil -> {:ok, 0, 1}
+      _ -> {:error, "ConcurrencyUnexpected", "spec.concurrency is not valid for class composite (group size is fixed by the member set)"}
+    end
+  end
+
   defp validate_concurrency(spec, _class) do
     cap = get_in(spec, ["concurrency", "cap"])
     floor = get_in(spec, ["concurrency", "floor"]) || 0
@@ -966,7 +1232,18 @@ defmodule Embervm.WorkloadWatcher do
   # reflects whatever the apiserver already defaulted at admission;
   # re-defaulting here just means this code has no silent dependency on that
   # having happened.
-  defp catalog_entry(name, namespace, spec, class, floor, cap, session_cfg, serving_cfg, stateful_cfg) do
+  defp catalog_entry(
+         name,
+         namespace,
+         spec,
+         class,
+         floor,
+         cap,
+         session_cfg,
+         serving_cfg,
+         stateful_cfg,
+         group_cfg
+       ) do
     resources = Map.get(spec, "resources") || %{}
     invocation = Map.get(spec, "invocation") || %{}
     source = parse_source(spec)
@@ -980,6 +1257,11 @@ defmodule Embervm.WorkloadWatcher do
       # port, volume sizing, and the idle/lifetime/ttl knobs from the catalog
       # exactly as SessionStore/EndpointPublisher read their class config.
       stateful: stateful_cfg,
+      # Composite-class group config (nil except for the composite class), carried
+      # so the future GroupStore/GroupManager read the member set, entry, secretRef,
+      # and the idle/lifetime/ttl knobs from the catalog exactly as StatefulStore
+      # reads its class config.
+      group: group_cfg,
       # Session-class lifecycle config (nil for the task class), carried so the
       # SessionManager/SessionStore (later PRs) read idle-bank/lifetime/caps from
       # the catalog exactly as the dispatcher reads task caps.

--- a/projects/embervm/control/lib/embervm/workload_watcher.ex
+++ b/projects/embervm/control/lib/embervm/workload_watcher.ex
@@ -146,11 +146,12 @@ defmodule Embervm.WorkloadWatcher do
         Application.get_env(:embervm, :stateful_listen_range, @default_stateful_listen_range)
 
     # The values-declared composite entry listenPort range + expanded-member-count
-    # cap (R5), flowing in the same way stateful_listen_range does: a start_link opt
-    # (tests) or app env (the chart wires EMBERVM_COMPOSITE_LISTEN_PORT_RANGE /
-    # EMBERVM_MAX_GROUP_SIZE), falling back to the compile-time defaults that match
-    # the chart defaults. The watcher validates every composite workload's
-    # entry.listenPort against the range and its expanded member count against the cap.
+    # cap (R5): a start_link opt (tests) or the app-env keys Embervm.Application
+    # populates in start/2 from EMBERVM_COMPOSITE_LISTEN_PORT_RANGE /
+    # EMBERVM_MAX_GROUP_SIZE (the chart env), falling back to the compile-time
+    # defaults that match the chart defaults when the env is absent or malformed.
+    # The watcher validates every composite workload's entry.listenPort against the
+    # range and its expanded member count against the cap.
     composite_listen_range =
       Keyword.get(opts, :composite_listen_range) ||
         Application.get_env(:embervm, :composite_listen_range, @default_composite_listen_range)
@@ -1008,7 +1009,17 @@ defmodule Embervm.WorkloadWatcher do
     end
   end
 
-  defp member_replicas(m), do: Map.get(m, "replicas") || 1
+  # A member's replica count, clamped to at least 1. Guards the Elixir truthiness
+  # trap: `0 || 1` is `0` (0 is truthy), so a `replicas: 0` that slipped past CRD
+  # admission would under-count the expanded size here; an absent or non-positive
+  # value bills as one replica. Used by BOTH the size-cap sum and the expanded-name
+  # set so the two never disagree.
+  defp member_replicas(m) do
+    case Map.get(m, "replicas") do
+      n when is_integer(n) and n > 0 -> n
+      _ -> 1
+    end
+  end
 
   # The valid entry targets: each declared member name, plus (for a member with
   # replicas > 1) each expanded `<name>-<index>` (0-based). A replicas-1 member is

--- a/projects/embervm/control/test/embervm/op_log/group_projection_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/group_projection_test.exs
@@ -1,0 +1,459 @@
+defmodule Embervm.OpLog.GroupProjectionTest do
+  @moduledoc """
+  Exercises the R5 composite-group instance and member records, the bundle-set
+  audit, and retention discipline on the SQLite op-log backend directly,
+  mirroring stateful_projection_test.exs (each test opens its own GenServer over a
+  fresh temp file, so it can stop/restart to simulate crash recovery). Covers:
+
+    * projection rebuild from a scripted group op sequence reproduces exact
+      group_instances + group_members state across a full lifecycle
+      (create -> net_created -> member_started -> running -> published -> banked ->
+      set_evicted -> fresh_booted -> destroyed);
+    * group_banked stamps the WHOLE member set atomically in one append (decision 3);
+    * group_fresh_booted / group_set_evicted carry their reason for full log
+      reconstructability, and clear the banked set_id;
+    * group_degraded flips one member unhealthy while the group stays live;
+    * group_stats bills PER MEMBER (a 3-member group bills 3 VMs' worth) into
+      vcpu_seconds/gb_seconds, task/request untouched;
+    * retention never prunes a non-terminal group, prunes a terminal one past the
+      7-day window, and takes its member rows with it;
+    * the ops-journal prefix marker never advances past a LIVE group's ops;
+    * a kill/restart rebuilds group instance AND member state exactly.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.OpLog.Op
+  alias Embervm.OpLog.SQLite
+
+  setup do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "embervm_oplog_group_test_#{System.unique_integer([:positive, :monotonic])}.db"
+      )
+
+    on_exit(fn -> File.rm_rf!(path) end)
+    %{path: path}
+  end
+
+  defp start_server(path, extra_opts \\ []) do
+    opts = Keyword.merge([path: path, name: nil], extra_opts)
+    {:ok, pid} = SQLite.start_link(opts)
+    pid
+  end
+
+  defp created_op(instance_id, ts, extra \\ %{}) do
+    %Op{
+      kind: :group_created,
+      tenant: "t1",
+      principal: "p1",
+      workload: "demo-group",
+      group_instance_id: instance_id,
+      ts: ts,
+      payload:
+        Map.merge(
+          %{node_id: "node-4", entry_member: "leader", entry_port: 8080, listen_port: 5410},
+          extra
+        )
+    }
+  end
+
+  defp member_started_op(instance_id, ts, member_name, index, extra \\ %{}) do
+    %Op{
+      kind: :group_member_started,
+      tenant: "t1",
+      principal: "p1",
+      workload: "demo-group",
+      group_instance_id: instance_id,
+      ts: ts,
+      payload:
+        Map.merge(
+          %{member_name: member_name, member_index: index, vm_id: "vm-#{member_name}", ip: "10.80.0.#{index + 2}"},
+          extra
+        )
+    }
+  end
+
+  defp instance_by_id(server) do
+    {:ok, instances} = SQLite.load_group_instances(server)
+    Map.new(instances, &{&1.instance_id, &1})
+  end
+
+  defp members_by_name(server, instance_id) do
+    {:ok, members} = SQLite.load_group_members(server)
+
+    members
+    |> Enum.filter(&(&1.instance_id == instance_id))
+    |> Map.new(&{&1.member_name, &1})
+  end
+
+  test "a scripted create -> members -> running -> published -> banked -> set_evicted -> fresh_booted sequence projects exact state",
+       %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, created_op("g-1", 100))
+
+    i0 = instance_by_id(server)["g-1"]
+    assert i0.state == "starting"
+    assert i0.entry_member == "leader"
+    assert i0.entry_port == 8080
+    assert i0.listen_port == 5410
+    assert i0.set_id == nil
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :group_net_created,
+        tenant: "t1",
+        principal: "p1",
+        workload: "demo-group",
+        group_instance_id: "g-1",
+        ts: 110,
+        payload: %{subnet_cidr: "10.80.0.0/29"}
+      })
+
+    assert instance_by_id(server)["g-1"].subnet_cidr == "10.80.0.0/29"
+
+    # Three members come up (leader, worker-0, worker-1): the first multi-row
+    # projection. All start "starting" and unhealthy.
+    {:ok, _} = SQLite.append(server, member_started_op("g-1", 120, "leader", 0))
+    {:ok, _} = SQLite.append(server, member_started_op("g-1", 121, "worker-0", 1))
+    {:ok, _} = SQLite.append(server, member_started_op("g-1", 122, "worker-1", 2))
+
+    members = members_by_name(server, "g-1")
+    assert Map.keys(members) |> Enum.sort() == ["leader", "worker-0", "worker-1"]
+    assert members["leader"].state == "starting"
+    assert members["leader"].healthy == false
+    assert members["worker-1"].vm_id == "vm-worker-1"
+
+    # The whole-group readiness edge: instance -> running, every member healthy.
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :group_running,
+        tenant: "t1",
+        principal: "p1",
+        workload: "demo-group",
+        group_instance_id: "g-1",
+        ts: 130,
+        payload: %{}
+      })
+
+    running = instance_by_id(server)["g-1"]
+    assert running.state == "running"
+    assert running.last_active_at == 130
+    assert Enum.all?(members_by_name(server, "g-1"), fn {_n, m} -> m.healthy end)
+
+    # The entry endpoint is published (audit; stays running).
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :group_published,
+        tenant: "t1",
+        principal: "p1",
+        workload: "demo-group",
+        group_instance_id: "g-1",
+        ts: 140,
+        payload: %{listen_port: 5410}
+      })
+
+    assert instance_by_id(server)["g-1"].state == "running"
+
+    # Bank stamps the WHOLE set atomically in ONE append (decision 3): set_id on the
+    # instance, each member's snapshot_ref, member VMs cleared.
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :group_banked,
+        tenant: "t1",
+        principal: "p1",
+        workload: "demo-group",
+        group_instance_id: "g-1",
+        ts: 150,
+        payload: %{
+          set_id: "group/demo-group/set-1",
+          members: [
+            %{name: "leader", snapshot_ref: "group/demo-group/set-1/leader"},
+            %{name: "worker-0", snapshot_ref: "group/demo-group/set-1/worker-0"},
+            %{name: "worker-1", snapshot_ref: "group/demo-group/set-1/worker-1"}
+          ]
+        }
+      })
+
+    banked = instance_by_id(server)["g-1"]
+    assert banked.state == "banked"
+    assert banked.set_id == "group/demo-group/set-1"
+
+    banked_members = members_by_name(server, "g-1")
+    assert banked_members["leader"].snapshot_ref == "group/demo-group/set-1/leader"
+    assert banked_members["worker-1"].snapshot_ref == "group/demo-group/set-1/worker-1"
+    assert banked_members["leader"].vm_id == nil
+    assert banked_members["leader"].state == "banked"
+
+    # A set eviction discards the banked warmth (its reason rides the payload) and
+    # clears set_id; the instance stays live.
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :group_set_evicted,
+        tenant: "t1",
+        principal: "p1",
+        workload: "demo-group",
+        group_instance_id: "g-1",
+        ts: 160,
+        payload: %{reason: "set_unreadable", members: ["leader", "worker-0", "worker-1"]}
+      })
+
+    assert instance_by_id(server)["g-1"].set_id == nil
+
+    # A fresh boot (discarded warmth) returns to "starting" and records its reason.
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :group_fresh_booted,
+        tenant: "t1",
+        principal: "p1",
+        workload: "demo-group",
+        group_instance_id: "g-1",
+        ts: 170,
+        payload: %{reason: "set_unreadable"}
+      })
+
+    fresh = instance_by_id(server)["g-1"]
+    assert fresh.state == "starting"
+    assert fresh.set_id == nil
+
+    # The fresh-boot reason is reconstructable from the op-log alone (string keys on
+    # the durable payload_json round-trip).
+    {:ok, ops} = SQLite.read_from(server, 0)
+    fb = Enum.find(ops, &(&1.kind == :group_fresh_booted))
+    assert fb.payload["reason"] == "set_unreadable"
+    assert fb.group_instance_id == "g-1"
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "group_degraded flips one member unhealthy while the group stays live", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, created_op("g-d", 100))
+    {:ok, _} = SQLite.append(server, member_started_op("g-d", 110, "leader", 0))
+    {:ok, _} = SQLite.append(server, member_started_op("g-d", 111, "worker-0", 1))
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :group_running,
+        tenant: "t1",
+        principal: "p1",
+        workload: "demo-group",
+        group_instance_id: "g-d",
+        ts: 120,
+        payload: %{}
+      })
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :group_degraded,
+        tenant: "t1",
+        principal: "p1",
+        workload: "demo-group",
+        group_instance_id: "g-d",
+        ts: 130,
+        payload: %{member_name: "worker-0", reason: "health_probe_failed"}
+      })
+
+    assert instance_by_id(server)["g-d"].state == "degraded"
+
+    members = members_by_name(server, "g-d")
+    assert members["leader"].healthy == true
+    assert members["worker-0"].healthy == false
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "each terminal kind projects its terminal state and reason (expired rides destroyed)", %{path: path} do
+    server = start_server(path)
+
+    for {iid, kind, reason, expected_state} <- [
+          {"g-des", :group_destroyed, "destroyed", "destroyed"},
+          {"g-exp", :group_destroyed, "expired", "destroyed"},
+          {"g-fai", :group_failed, "failed", "failed"}
+        ] do
+      {:ok, _} = SQLite.append(server, created_op(iid, 100))
+
+      {:ok, _} =
+        SQLite.append(server, %Op{
+          kind: kind,
+          tenant: "t1",
+          principal: "p1",
+          workload: "demo-group",
+          group_instance_id: iid,
+          ts: 500,
+          payload: %{reason: reason}
+        })
+
+      i = instance_by_id(server)[iid]
+      assert i.state == expected_state
+      assert i.terminal_reason == reason
+    end
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "group_stats bills per member into vcpu/gb seconds, task/request untouched", %{path: path} do
+    server = start_server(path)
+
+    day5 = 5 * 86_400_000
+
+    # One 3-member group billing 2.0 vcpu-seconds / 4.0 gb-seconds per member for one
+    # window: the projection multiplies by member_count, so 3 members = 6.0 / 12.0.
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :group_stats,
+        tenant: "t1",
+        principal: "p1",
+        workload: "demo-group",
+        group_instance_id: nil,
+        ts: day5 + 1,
+        payload: %{member_count: 3, usage: %{vcpu_seconds: 2.0, gb_seconds: 4.0}, window_ms: 5_000}
+      })
+
+    {:ok, page} = SQLite.list_usage(server, since_day: 0)
+    row = Enum.find(page.items, &(&1.principal == "p1"))
+
+    assert row.vcpu_seconds == 6.0
+    assert row.gb_seconds == 12.0
+    assert row.task_count == 0
+    assert row.request_count == 0
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "retention prunes a terminal group and its members, never a live one", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, created_op("g-live", 100))
+    {:ok, _} = SQLite.append(server, member_started_op("g-live", 101, "leader", 0))
+    {:ok, _} = SQLite.append(server, created_op("g-term", 100))
+    {:ok, _} = SQLite.append(server, member_started_op("g-term", 101, "leader", 0))
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :group_destroyed,
+        tenant: "t1",
+        principal: "p1",
+        workload: "demo-group",
+        group_instance_id: "g-term",
+        ts: 200,
+        payload: %{reason: "forced_roll"}
+      })
+
+    eight_days = 8 * 24 * 60 * 60 * 1000
+    {:ok, res} = SQLite.compact(server, 100 + eight_days)
+    assert res.group_instances_compacted == 1
+
+    ids = instance_by_id(server) |> Map.keys() |> Enum.sort()
+    assert ids == ["g-live"]
+
+    # The pruned group's members went with it; the live group's members remain.
+    assert members_by_name(server, "g-term") == %{}
+    assert Map.has_key?(members_by_name(server, "g-live"), "leader")
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "the ops-journal marker never advances past a live group's ops", %{path: path} do
+    server = start_server(path, journal_horizon_ms: 0)
+
+    {:ok, live_seq} = SQLite.append(server, created_op("g-live", 100))
+    {:ok, _} = SQLite.append(server, %Op{kind: :denied, tenant: "t1", ts: 101, payload: %{}})
+
+    {:ok, res} = SQLite.compact(server, 10_000)
+    assert res.compacted_through == live_seq - 1
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :group_destroyed,
+        tenant: "t1",
+        principal: "p1",
+        workload: "demo-group",
+        group_instance_id: "g-live",
+        ts: 102,
+        payload: %{reason: "destroyed"}
+      })
+
+    {:ok, res2} = SQLite.compact(server, 10_000)
+    {:ok, max_seq} = SQLite.compacted_through(server)
+    assert res2.compacted_through == max_seq
+    assert max_seq >= live_seq
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "kill/restart rebuilds group instance and member state from the projection", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, created_op("g-a", 100))
+    {:ok, _} = SQLite.append(server, member_started_op("g-a", 110, "leader", 0))
+    {:ok, _} = SQLite.append(server, member_started_op("g-a", 111, "worker-0", 1))
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :group_banked,
+        tenant: "t1",
+        principal: "p1",
+        workload: "demo-group",
+        group_instance_id: "g-a",
+        ts: 200,
+        payload: %{
+          set_id: "group/demo-group/set-a",
+          members: [
+            %{name: "leader", snapshot_ref: "group/demo-group/set-a/leader"},
+            %{name: "worker-0", snapshot_ref: "group/demo-group/set-a/worker-0"}
+          ]
+        }
+      })
+
+    :ok = GenServer.stop(server)
+
+    server2 = start_server(path)
+    by_id = instance_by_id(server2)
+
+    assert by_id["g-a"].state == "banked"
+    assert by_id["g-a"].set_id == "group/demo-group/set-a"
+
+    members = members_by_name(server2, "g-a")
+    assert members["leader"].snapshot_ref == "group/demo-group/set-a/leader"
+    assert members["worker-0"].snapshot_ref == "group/demo-group/set-a/worker-0"
+    assert members["leader"].vm_id == nil
+
+    :ok = GenServer.stop(server2)
+  end
+
+  test "a fresh DB reports group_instance_id on group ops through read_from, NULL on stats",
+       %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, created_op("g-r", 100))
+
+    {:ok, _} =
+      SQLite.append(server, %Op{
+        kind: :group_stats,
+        tenant: "t1",
+        principal: "p1",
+        workload: "demo-group",
+        group_instance_id: nil,
+        ts: 101,
+        payload: %{member_count: 2, usage: %{vcpu_seconds: 1.0, gb_seconds: 1.0}}
+      })
+
+    {:ok, ops} = SQLite.read_from(server, 0)
+
+    created = Enum.find(ops, &(&1.kind == :group_created))
+    assert created.group_instance_id == "g-r"
+    assert created.task_id == nil
+    assert created.session_id == nil
+    assert created.serving_instance_id == nil
+    assert created.stateful_instance_id == nil
+
+    stats = Enum.find(ops, &(&1.kind == :group_stats))
+    assert stats.group_instance_id == nil
+    assert stats.principal == "p1"
+
+    :ok = GenServer.stop(server)
+  end
+end

--- a/projects/embervm/control/test/embervm/workload_watcher_test.exs
+++ b/projects/embervm/control/test/embervm/workload_watcher_test.exs
@@ -802,6 +802,313 @@ defmodule Embervm.WorkloadWatcherTest do
     assert {:ok, _entry} = WorkloadCatalog.fetch(table, "semgrep")
   end
 
+  # -- composite class (R5) ---------------------------------------------------
+
+  # A valid composite CR: an image source (the group base seed), the required
+  # spec.group block (a leader member + a 2-replica worker member, entry on the
+  # leader), and NO concurrency block (group size is fixed by the member set).
+  defp composite_cr(overrides \\ %{}) do
+    base = %{
+      "metadata" => %{"name" => "demo-group", "namespace" => "embervm", "generation" => 1},
+      "spec" => %{
+        "class" => "composite",
+        "source" => %{"image" => %{"ref" => "demo-group", "port" => 1027}},
+        "resources" => %{"vcpus" => 1, "memMib" => 512},
+        "group" => %{
+          "members" => [
+            %{
+              "name" => "leader",
+              "role" => "leader",
+              "startOrder" => 0,
+              "source" => %{"image" => %{"ref" => "demo-leader"}},
+              "healthPort" => 8080
+            },
+            %{
+              "name" => "worker",
+              "role" => "worker",
+              "startOrder" => 1,
+              "replicas" => 2,
+              "source" => %{"image" => %{"ref" => "demo-worker"}},
+              "healthPort" => 8080
+            }
+          ],
+          # entry.listenPort must fall inside the default composite range 5410..5419.
+          "entry" => %{"member" => "leader", "port" => 8080, "listenPort" => 5410},
+          "idleBankSeconds" => 600,
+          "maxLifetimeSeconds" => 86_400,
+          "bankedTtlSeconds" => 604_800,
+          "wakeTimeoutSeconds" => 120
+        }
+      }
+    }
+
+    deep_merge(base, overrides)
+  end
+
+  test "composite class: a valid composite CR is cataloged with class and group config, group floor/cap" do
+    table = unique_table()
+    agent = start_recorder()
+    lister = fn -> {:ok, [composite_cr()]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert {:ok, entry} = WorkloadCatalog.fetch(table, "demo-group")
+    assert entry.class == "composite"
+    # No concurrency block: internal floor/cap 0/1 (scale-to-zero group).
+    assert entry.floor == 0
+    assert entry.cap == 1
+    assert length(entry.group.members) == 2
+    assert Enum.map(entry.group.members, & &1.name) == ["leader", "worker"]
+    worker = Enum.find(entry.group.members, &(&1.name == "worker"))
+    assert worker.replicas == 2
+    assert worker.start_order == 1
+    assert worker.image_ref == "demo-worker"
+    assert worker.health_port == 8080
+    assert entry.group.entry.member == "leader"
+    assert entry.group.entry.port == 8080
+    assert entry.group.entry.listen_port == 5410
+    assert entry.group.idle_bank_seconds == 600
+    assert entry.group.max_lifetime_seconds == 86_400
+    assert entry.group.banked_ttl_seconds == 604_800
+    assert entry.group.wake_timeout_seconds == 120
+    assert entry.group.secret_ref == nil
+
+    assert {_ns, "demo-group", status_map} = ready_status(recorded_calls(agent), "demo-group")
+    assert status_map["observedGeneration"] == 1
+    refute Map.has_key?(status_map, "conditions")
+  end
+
+  test "composite class: group block timer defaults apply when omitted" do
+    table = unique_table()
+    agent = start_recorder()
+
+    cr =
+      put_in(composite_cr(), ["spec", "group"], %{
+        "members" => [
+          %{"name" => "solo", "source" => %{"image" => %{"ref" => "solo"}}, "healthPort" => 9000}
+        ],
+        "entry" => %{"member" => "solo", "port" => 9000, "listenPort" => 5411}
+      })
+
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert {:ok, entry} = WorkloadCatalog.fetch(table, "demo-group")
+    assert entry.group.idle_bank_seconds == 600
+    assert entry.group.max_lifetime_seconds == 86_400
+    assert entry.group.banked_ttl_seconds == 604_800
+    assert entry.group.wake_timeout_seconds == 120
+    # A replicas-omitted member defaults to 1.
+    assert Enum.at(entry.group.members, 0).replicas == 1
+  end
+
+  test "composite class with a stable secretRef parses name/key" do
+    table = unique_table()
+    agent = start_recorder()
+
+    cr =
+      put_in(composite_cr(), ["spec", "group", "secretRef"], %{
+        "name" => "group-secret",
+        "key" => "token"
+      })
+
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert {:ok, entry} = WorkloadCatalog.fetch(table, "demo-group")
+    assert entry.group.secret_ref == %{name: "group-secret", key: "token"}
+  end
+
+  test "composite class missing spec.group is Ready=False/GroupSpecMissing, not cataloged" do
+    table = unique_table()
+    agent = start_recorder()
+    cr = composite_cr()
+    cr = Map.update!(cr, "spec", &Map.delete(&1, "group"))
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert WorkloadCatalog.fetch(table, "demo-group") == :error
+
+    assert {_ns, "demo-group", status_map} = ready_status(recorded_calls(agent), "demo-group")
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "GroupSpecMissing"}] = status_map["conditions"]
+    assert Process.alive?(watcher)
+  end
+
+  test "composite class carrying a spec.concurrency block is Ready=False/ConcurrencyUnexpected" do
+    table = unique_table()
+    agent = start_recorder()
+    cr = composite_cr(%{"spec" => %{"concurrency" => %{"cap" => 2}}})
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert WorkloadCatalog.fetch(table, "demo-group") == :error
+
+    assert {_ns, "demo-group", status_map} = ready_status(recorded_calls(agent), "demo-group")
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "ConcurrencyUnexpected"}] = status_map["conditions"]
+    assert Process.alive?(watcher)
+  end
+
+  test "composite class carrying a spec.stateful block is Ready=False/StatefulSpecUnexpected" do
+    table = unique_table()
+    agent = start_recorder()
+    cr = composite_cr(%{"spec" => %{"stateful" => %{"port" => 5432, "listenPort" => 5401, "volumeSizeGiB" => 1}}})
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert WorkloadCatalog.fetch(table, "demo-group") == :error
+
+    assert {_ns, "demo-group", status_map} = ready_status(recorded_calls(agent), "demo-group")
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "StatefulSpecUnexpected"}] = status_map["conditions"]
+    assert Process.alive?(watcher)
+  end
+
+  test "a stateful CR carrying a spec.group block is Ready=False/GroupSpecUnexpected (symmetric cross-rejection)" do
+    table = unique_table()
+    agent = start_recorder()
+    cr = stateful_cr(%{"spec" => %{"group" => %{"members" => [], "entry" => %{}}}})
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert WorkloadCatalog.fetch(table, "scratch-postgres") == :error
+
+    assert {_ns, "scratch-postgres", status_map} = ready_status(recorded_calls(agent), "scratch-postgres")
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "GroupSpecUnexpected"}] = status_map["conditions"]
+    assert Process.alive?(watcher)
+  end
+
+  test "composite class: duplicate member names are Ready=False/GroupMemberNameConflict" do
+    table = unique_table()
+    agent = start_recorder()
+
+    cr =
+      put_in(composite_cr(), ["spec", "group", "members"], [
+        %{"name" => "dup", "source" => %{"image" => %{"ref" => "a"}}, "healthPort" => 8080},
+        %{"name" => "dup", "source" => %{"image" => %{"ref" => "b"}}, "healthPort" => 8080}
+      ])
+
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert WorkloadCatalog.fetch(table, "demo-group") == :error
+
+    assert {_ns, "demo-group", status_map} = ready_status(recorded_calls(agent), "demo-group")
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "GroupMemberNameConflict"}] = status_map["conditions"]
+    assert Process.alive?(watcher)
+  end
+
+  test "composite class: an entry naming a missing member is Ready=False/GroupEntryMemberUnknown" do
+    table = unique_table()
+    agent = start_recorder()
+    cr = put_in(composite_cr(), ["spec", "group", "entry", "member"], "ghost")
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert WorkloadCatalog.fetch(table, "demo-group") == :error
+
+    assert {_ns, "demo-group", status_map} = ready_status(recorded_calls(agent), "demo-group")
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "GroupEntryMemberUnknown"}] = status_map["conditions"]
+    assert Process.alive?(watcher)
+  end
+
+  test "composite class: an entry naming an expanded replica name is accepted" do
+    table = unique_table()
+    agent = start_recorder()
+    # `worker` has replicas 2, so `worker-1` is a valid entry target.
+    cr = put_in(composite_cr(), ["spec", "group", "entry", "member"], "worker-1")
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert {:ok, entry} = WorkloadCatalog.fetch(table, "demo-group")
+    assert entry.group.entry.member == "worker-1"
+  end
+
+  test "composite class: a listenPort outside the configured composite range is Ready=False/GroupListenPortOutOfRange" do
+    table = unique_table()
+    agent = start_recorder()
+    cr = put_in(composite_cr(), ["spec", "group", "entry", "listenPort"], 9999)
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table, composite_listen_range: 5410..5419)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert WorkloadCatalog.fetch(table, "demo-group") == :error
+
+    assert {_ns, "demo-group", status_map} = ready_status(recorded_calls(agent), "demo-group")
+
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "GroupListenPortOutOfRange"}] =
+             status_map["conditions"]
+
+    assert Process.alive?(watcher)
+  end
+
+  test "composite class: two groups on the same listenPort, the second is Ready=False/GroupListenPortConflict" do
+    table = unique_table()
+    agent = start_recorder()
+
+    first = composite_cr()
+    second = composite_cr(%{"metadata" => %{"name" => "demo-group-2"}})
+    lister = fn -> {:ok, [first, second]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    # One of the two wins (LIST order sets the tiebreak); the other is rejected.
+    cataloged = [
+      WorkloadCatalog.fetch(table, "demo-group"),
+      WorkloadCatalog.fetch(table, "demo-group-2")
+    ]
+
+    assert Enum.count(cataloged, &match?({:ok, _}, &1)) == 1
+
+    conflict =
+      recorded_calls(agent)
+      |> Enum.map(fn {_ns, _n, status} -> status end)
+      |> Enum.filter(&match?(%{"conditions" => [%{"reason" => "GroupListenPortConflict"}]}, &1))
+
+    assert conflict != []
+    assert Process.alive?(watcher)
+  end
+
+  test "composite class: an over-cap expanded member count is Ready=False/GroupSizeExceeded" do
+    table = unique_table()
+    agent = start_recorder()
+    # leader(1) + worker(replicas 4) = 5 expanded members, over a maxGroupSize of 4.
+    cr = put_in(composite_cr(), ["spec", "group", "members"], [
+      %{"name" => "leader", "source" => %{"image" => %{"ref" => "l"}}, "healthPort" => 8080},
+      %{"name" => "worker", "replicas" => 4, "source" => %{"image" => %{"ref" => "w"}}, "healthPort" => 8080}
+    ])
+
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table, max_group_size: 4)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert WorkloadCatalog.fetch(table, "demo-group") == :error
+
+    assert {_ns, "demo-group", status_map} = ready_status(recorded_calls(agent), "demo-group")
+    assert [%{"type" => "Ready", "status" => "False", "reason" => "GroupSizeExceeded"}] = status_map["conditions"]
+    assert Process.alive?(watcher)
+  end
+
   # -- zip-lane source (R1, ADR embervm/002) --------------------------------
 
   # A zip-lane CR: source.zip replaces source.image. The base drops the image

--- a/projects/embervm/crd/samples/workload-composite.yaml
+++ b/projects/embervm/crd/samples/workload-composite.yaml
@@ -1,0 +1,80 @@
+# Sample composite-class Workload (R5, ADR embervm/001). A composite workload is a
+# GROUP: a set of member microVMs (each a role with one or more replicas) that
+# live, bank, relight, and die as ONE unit, sharing a private per-group subnet and
+# reached through one declared entry member. The headline invariants are the ADR
+# 001 whole-set warmth rule (the bundle set banks and relights atomically; a
+# partial or unreadable set discards warmth and the whole group fresh-boots) and
+# crash-consistency PER VM only (a bank snapshots each member independently, never
+# a cross-member transaction). There is no maxInstances knob (the group size is
+# fixed by the member set) and spec.concurrency is forbidden on this class. This is
+# the definition surface only; a composite INSTANCE, its members, and its banked
+# bundle set are execution state in the op-log, never Kubernetes objects. Living
+# documentation of the composite surface, mirroring workload-stateful.yaml. Not a
+# production deploy (those live under projects/embervm/deploy/).
+apiVersion: embervm.dev/v1alpha1
+kind: Workload
+metadata:
+  name: demo-group
+  namespace: embervm
+spec:
+  class: composite
+  # The top-level source is the group's base-build seed (each member also declares
+  # its own source below). The image lane, exactly as every other class.
+  source:
+    image:
+      ref: ghcr.io/jomcgi/homelab/projects/embervm/guests/demo-group:latest
+      port: 1027
+      readyPath: /shim/ready
+      invokePath: /invoke
+  resources:
+    vcpus: 1
+    memMib: 512
+  # No concurrency block: a composite's size is fixed by its member set (sum of
+  # replicas), so spec.concurrency is forbidden by the watcher.
+  group:
+    members:
+      # The leader member: one VM, boots first (startOrder 0).
+      - name: leader
+        role: leader
+        startOrder: 0
+        replicas: 1
+        source:
+          image:
+            ref: ghcr.io/jomcgi/homelab/projects/embervm/guests/demo-leader:latest
+        resources:
+          vcpus: 1
+          memMib: 512
+        # TCP health gate: the member is healthy once a connect to this port
+        # succeeds. Required (the whole-group readiness edge needs it).
+        healthPort: 8080
+      # The worker member: two VMs (worker-0, worker-1), boot after the leader.
+      - name: worker
+        role: worker
+        startOrder: 1
+        replicas: 2
+        source:
+          image:
+            ref: ghcr.io/jomcgi/homelab/projects/embervm/guests/demo-worker:latest
+        resources:
+          vcpus: 1
+          memMib: 512
+        healthPort: 8080
+    # The group's single ingress: traffic reaches the leader member's port 8080,
+    # exposed cluster-internally on the node Envoy at listenPort 5410 (inside the
+    # values-declared composite range 5410-5419, unique across composite workloads).
+    entry:
+      member: leader
+      port: 8080
+      listenPort: 5410
+    # Bank the WHOLE set after 10 minutes idle; a live connection is never severed
+    # regardless of this timer.
+    idleBankSeconds: 600
+    # Version-convergence bound: the group rides its birth images until this
+    # expires; convergence is then destroy-and-fresh-boot of the whole set.
+    maxLifetimeSeconds: 86400
+    # A banked bundle SET untouched this long is GC'd off node disk as a unit
+    # (partial warmth is never retained).
+    bankedTtlSeconds: 604800
+    # Whole-group wake deadline (relight or fresh boot), generous because a fresh
+    # boot cold-starts every member.
+    wakeTimeoutSeconds: 120

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.82
+      targetRevision: 0.1.83
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/proto/embervm/node/v1/fakenode/BUILD
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/BUILD
@@ -13,6 +13,8 @@ go_library(
     deps = [
         "//projects/embervm/proto/embervm/node/v1:nodev1",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )
 

--- a/projects/embervm/proto/embervm/node/v1/fakenode/main.go
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/main.go
@@ -20,6 +20,8 @@ import (
 
 	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // watchNodeHeartbeats is how many NodeStatus messages WatchNode streams before
@@ -181,6 +183,60 @@ func (fakeServer) DeleteVolume(_ context.Context, _ *nodev1.DeleteVolumeRequest)
 	return &nodev1.DeleteVolumeResponse{}, nil
 }
 
+// CreateGroupNetwork derives the bridge_name and gateway_ip from the request so
+// the client can prove the fields crossed the wire, and scripts the CIDR-overlap
+// refusal off the cidr content ("overlap" -> FAILED_PRECONDITION), which is how
+// the round-trip test exercises the create-refusal branch against a stateless fake.
+func (fakeServer) CreateGroupNetwork(_ context.Context, req *nodev1.CreateGroupNetworkRequest) (*nodev1.CreateGroupNetworkResponse, error) {
+	if strings.Contains(req.GetCidr(), "overlap") {
+		return nil, status.Errorf(codes.FailedPrecondition, "cidr %q overlaps an existing group bridge", req.GetCidr())
+	}
+	return &nodev1.CreateGroupNetworkResponse{
+		BridgeName: "br-" + req.GetGroupInstanceId(),
+		GatewayIp:  "10.100.0.1",
+	}, nil
+}
+
+// DeleteGroupNetwork is idempotent and returns an empty response for any group.
+func (fakeServer) DeleteGroupNetwork(_ context.Context, _ *nodev1.DeleteGroupNetworkRequest) (*nodev1.DeleteGroupNetworkResponse, error) {
+	return &nodev1.DeleteGroupNetworkResponse{}, nil
+}
+
+// StartGroupMember derives its response from mode so the client can assert every
+// member boot path crosses the wire. RELIGHT scripts the clock-resync outcome off
+// the snapshot_ref content ("clockfail" -> FAILED_PRECONDITION with a clock-delta
+// detail, otherwise a verified warm relight), which is how the round-trip test
+// exercises the resync-failure branch against a stateless fake. FRESH cold-boots
+// from source and echoes the pinned ip.
+func (fakeServer) StartGroupMember(_ context.Context, req *nodev1.StartGroupMemberRequest) (*nodev1.StartGroupMemberResponse, error) {
+	if req.GetMode() == nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_RELIGHT {
+		ref := req.GetSnapshotRef()
+		if strings.Contains(ref, "clockfail") {
+			return nil, status.Errorf(codes.FailedPrecondition, "clock resync delta exceeds 1s for %q", ref)
+		}
+		return &nodev1.StartGroupMemberResponse{
+			VmId: "vm:" + ref, Ip: req.GetIp(), WasRelight: true,
+		}, nil
+	}
+	// FRESH: cold boot from the source, echo the pinned ip.
+	return &nodev1.StartGroupMemberResponse{
+		VmId: "vm:" + req.GetSource(), Ip: req.GetIp(), WasRelight: false,
+	}, nil
+}
+
+// StopGroupMember returns a per-member bundle ref under the caller-supplied set
+// dir and a size for BANK, and zero values for DESTROY, so the client can assert
+// both mode branches and that set_id/member_name crossed the wire.
+func (fakeServer) StopGroupMember(_ context.Context, req *nodev1.StopGroupMemberRequest) (*nodev1.StopGroupMemberResponse, error) {
+	if req.GetMode() == nodev1.StopGroupMemberMode_STOP_GROUP_MEMBER_MODE_BANK {
+		return &nodev1.StopGroupMemberResponse{
+			SnapshotRef: "group/" + req.GetSetId() + "/" + req.GetMemberName(),
+			SizeBytes:   5120,
+		}, nil
+	}
+	return &nodev1.StopGroupMemberResponse{}, nil
+}
+
 func (fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusRequest) (*nodev1.NodeStatus, error) {
 	return &nodev1.NodeStatus{
 		NodeId:     req.GetNodeId(),
@@ -253,6 +309,39 @@ func (fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusRequ
 				SizeBytes:      10_737_418_240,
 				AllocatedBytes: 536_870_912,
 				Attached:       true,
+			},
+		},
+		// Group facts (R5): deterministic, so the client can assert the new
+		// repeated group status fields round-trip. The bundle set is scripted
+		// PARTIAL on purpose (one member ref where a whole group would report
+		// several), proving the daemon reports refs grouped by set without judging
+		// completeness (that judgment is the control plane's).
+		GroupNetworks: []*nodev1.GroupNetwork{
+			{
+				GroupInstanceId: "grp-inst1",
+				Cidr:            "10.100.0.0/24",
+				Bridge:          "br-grp-inst1",
+				MemberCount:     2,
+			},
+		},
+		GroupMemberVms: []*nodev1.GroupMemberVm{
+			{
+				VmId:            "vm-g1",
+				GroupInstanceId: "grp-inst1",
+				MemberName:      "worker-0",
+				Ip:              "10.100.0.10",
+				Healthy:         true,
+				LastProbeUnixMs: 1_700_000_005_000,
+			},
+		},
+		GroupBundleSets: []*nodev1.GroupBundleSet{
+			{
+				SetId:           "set-abc",
+				GroupInstanceId: "grp-inst1",
+				Members: []*nodev1.GroupBundleMember{
+					{MemberName: "worker-0", SnapshotRef: "group/set-abc/worker-0", SizeBytes: 5120},
+				},
+				CreatedAtUnixMs: 1_700_000_006_000,
 			},
 		},
 	}, nil

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -272,6 +272,100 @@ service NodeService {
   // an already-absent volume (the desired end-state, gone, already holds).
   // Stateful bundles reuse EvictSnapshot (R2) unchanged; bundle refs are opaque.
   rpc DeleteVolume(DeleteVolumeRequest) returns (DeleteVolumeResponse);
+
+  // -- Group verbs (R5) -------------------------------------------------------
+  //
+  // These verbs are the composite-workload vocabulary, ADDITIVE to the task,
+  // session, serving, and stateful contracts above (every existing RPC and
+  // message is byte-for-byte unchanged). A group is a set of member VMs pinned
+  // to deterministic addresses on a private per-group bridge, the physical
+  // substrate a composite workload (many cooperating members addressing each
+  // other by stable name/IP) needs. The physical primitives are all on the node:
+  // a bridge, N pinned-address members attached to it, and a bundle SET (the
+  // per-member banked snapshots that resume the group as a unit). The daemon owns
+  // these primitives behind the verbs; NOTHING about what the members ARE crosses
+  // this seam. The contract is GENERIC group networking: the daemon knows a
+  // bridge, a CIDR, member names, indices, and addresses, and nothing about the
+  // application shape wired on top of it. Refs stay opaque strings exactly as
+  // elsewhere: no bridge device name detail, no snapshot file path, no netlink or
+  // nftables rule text crosses this seam beyond the reported facts.
+  //
+  // Membership is the control plane's, not the daemon's: the daemon never decides
+  // which members belong to a set. set_id (StopGroupMember) is caller-supplied and
+  // OPAQUE; the daemon groups the per-member snapshot refs it produces by the set
+  // directory it is told to write under, and reports them grouped, but the
+  // completeness judgment (is this set whole enough to relight) stays entirely in
+  // the control plane. Group member VMs count against max_live_vms like any other
+  // live VM, and are EXCLUDED from every WorkloadCapacity.primed_vm_ids (a member
+  // VM is never in the task pool), exactly like session, serving, and stateful VMs.
+  //
+  // Group bundles reuse EvictSnapshot (R2) unchanged: each per-member snapshot ref
+  // is evicted exactly like a session snapshot ref (the control plane evicts a set
+  // by evicting each of its member refs). The daemon offers no set-level eviction
+  // verb; set membership is the control plane's fact.
+  //
+  // Guest control agent contract (Task 3 implements it; stated here as the spec):
+  // a member guest runs a control agent listening on a dedicated vsock port
+  // (GROUP_GUEST_AGENT_VSOCK_PORT below) that speaks the D-R2.6.1 length-prefixed
+  // JSON frame convention (a 4-byte big-endian length prefix, then that many bytes
+  // of JSON). It answers exactly one request:
+  //   request  {"cmd":"sync_clock","epoch_ns":<int>}   host wall-clock at resume
+  //   response {"clock_realtime_ns":<int>}             guest CLOCK_REALTIME after
+  //                                                     it has set its clock
+  // On a RELIGHT resume, noded sends sync_clock with the current host epoch, the
+  // guest sets its clock and reads CLOCK_REALTIME back, and noded VERIFIES the
+  // read-back: it fails the StartGroupMember call (FAILED_PRECONDITION, a clock
+  // delta detail) if abs(clock_realtime_ns - epoch_ns) > 1s (standing decision 7).
+  // A resumed member with a clock more than one second off host time is a failed
+  // resume, never a live member.
+
+  // CreateGroupNetwork creates the private per-group bridge for
+  // {group_instance_id, cidr} plus the inter-group nftables deny that isolates
+  // this group's bridge from every other group's, and returns {bridge_name,
+  // gateway_ip} (the bridge's own address on the CIDR, the members' default
+  // gateway). Idempotent per group_instance_id: a repeat call for an
+  // already-created network returns the existing {bridge_name, gateway_ip}
+  // without recreating it. FAILED_PRECONDITION if the CIDR overlaps an existing
+  // group bridge's CIDR (address space is the daemon's to keep disjoint; the
+  // control plane must pick a non-overlapping range). The bridge and its deny
+  // rules are daemon-internal; only the two reported facts cross the seam.
+  rpc CreateGroupNetwork(CreateGroupNetworkRequest) returns (CreateGroupNetworkResponse);
+
+  // DeleteGroupNetwork tears the group bridge and its nftables rules down,
+  // reclaiming the CIDR. FAILED_PRECONDITION while any member VM is still
+  // attached to the bridge (the control plane stops every member first; this is
+  // the daemon backstop against tearing a live group's network out from under
+  // it). Idempotent on an already-absent network (the desired end-state, gone,
+  // already holds).
+  rpc DeleteGroupNetwork(DeleteGroupNetworkRequest) returns (DeleteGroupNetworkResponse);
+
+  // StartGroupMember boots or resumes exactly one member on its group bridge,
+  // attaching a tap NIC pinned to the member's DETERMINISTIC name/MAC/IP (all
+  // derived by the control plane from {group_instance_id, member_name,
+  // member_index} and passed in; the daemon pins the tap to the given ip, it does
+  // not allocate). mode selects the boot path:
+  //   FRESH   cold-boot the member's image rootfs (source) with the pinned tap,
+  //           deliver the env map via the MMDS-lite seam (FRESH-only, see below),
+  //           and TCP-health-gate {ip, health_port} before returning ready.
+  //   RELIGHT recreate the IDENTICAL tap world (same name/MAC/IP) and resume the
+  //           member's banked bundle (snapshot_ref), then perform the guest
+  //           control agent clock-resync handshake and FAIL the call if the
+  //           verified read-back delta exceeds one second (standing decision 7).
+  // Returns {vm_id, ip, was_relight}. FAILED_PRECONDITION on an unknown or
+  // unrestorable snapshot_ref (RELIGHT), a missing source (FRESH), or a
+  // clock-resync verification failure; on a failed RELIGHT the bundle is NEVER
+  // deleted (a lost member must surface loudly, not silently relight blank).
+  rpc StartGroupMember(StartGroupMemberRequest) returns (StartGroupMemberResponse);
+
+  // StopGroupMember tears down one live member VM. mode = BANK PAUSES the VM,
+  // writes a full snapshot under the caller-supplied set directory
+  // (group/<set_id>/<member>/), destroys the VM, and returns {snapshot_ref,
+  // size_bytes}. mode = DESTROY kills the VM with no snapshot. set_id is OPAQUE to
+  // the daemon: it is only the directory the member's snapshot is written under so
+  // the daemon can report member refs grouped by set; the daemon never decides
+  // set membership. BANK refuses FAILED_PRECONDITION if a stop of the same vm_id
+  // is already in flight (the daemon backstop; the control plane serializes too).
+  rpc StopGroupMember(StopGroupMemberRequest) returns (StopGroupMemberResponse);
 }
 
 // Trace carries the cross-cutting identifiers every RPC threads for tracing and
@@ -703,6 +797,129 @@ message DeleteVolumeRequest {
 
 message DeleteVolumeResponse {}
 
+// ---- Group verbs (R5) ------------------------------------------------------
+
+// GROUP_GUEST_AGENT_VSOCK_PORT is the dedicated vsock port a member guest's
+// control agent listens on for the sync_clock handshake (see the StartGroupMember
+// / group-verbs comment for the frame contract). It is a documented constant of
+// the frozen guest contract, distinct from the guest HTTP port; the daemon dials
+// it only on a RELIGHT resume.
+enum GroupGuestAgent {
+  GROUP_GUEST_AGENT_UNSPECIFIED = 0;
+  GROUP_GUEST_AGENT_VSOCK_PORT = 1024;
+}
+
+// CreateGroupNetworkRequest asks the daemon to stand up the per-group bridge for
+// group_instance_id on cidr. group_instance_id is the control plane's opaque
+// per-group-instance identity, the idempotency key for the bridge; cidr is the
+// address range the members' pinned IPs are drawn from (by the control plane, not
+// the daemon).
+message CreateGroupNetworkRequest {
+  Trace trace = 1;
+  string group_instance_id = 2;
+  string cidr = 3;
+}
+
+message CreateGroupNetworkResponse {
+  // bridge_name is the daemon-assigned name of the group bridge, reported as an
+  // opaque fact (the control plane never manipulates it, only records it). Stable
+  // across idempotent recreate calls for the same group_instance_id.
+  string bridge_name = 1;
+  // gateway_ip is the bridge's own address on the CIDR, the default gateway the
+  // members route through. Deterministic for the CIDR; reported so the control
+  // plane can compose member routes without knowing the daemon's allocation rule.
+  string gateway_ip = 2;
+}
+
+// DeleteGroupNetworkRequest tears down the bridge for group_instance_id.
+message DeleteGroupNetworkRequest {
+  Trace trace = 1;
+  string group_instance_id = 2;
+}
+
+message DeleteGroupNetworkResponse {}
+
+enum StartGroupMemberMode {
+  START_GROUP_MEMBER_MODE_UNSPECIFIED = 0;
+  START_GROUP_MEMBER_MODE_FRESH = 1;    // cold-boot the image rootfs on the pinned tap
+  START_GROUP_MEMBER_MODE_RELIGHT = 2;  // resume the bundle, then clock-resync verify
+}
+
+message StartGroupMemberRequest {
+  Trace trace = 1;
+  StartGroupMemberMode mode = 2;
+  // group_instance_id names the group whose bridge this member attaches to (its
+  // network must already exist via CreateGroupNetwork). member_name and
+  // member_index are the control-plane-assigned member identity the daemon uses
+  // to pin the tap deterministically (the tap name and MAC are derived from them);
+  // ip is the control-plane-assigned pinned address on the group CIDR the tap is
+  // configured with (the daemon pins to the given ip, it does not allocate).
+  string group_instance_id = 3;
+  string member_name = 4;
+  uint32 member_index = 5;
+  string ip = 6;
+  // source is the FRESH cold-boot source the daemon resolves to a bootable rootfs
+  // (same role as stateful boot_image_ref: a NIC cold boot cannot resume a
+  // vsock-only base memory snapshot, D-R3.4.2). Set for FRESH; empty for RELIGHT.
+  string source = 7;
+  // snapshot_ref is the banked member bundle to resume, set for RELIGHT (empty
+  // otherwise). Opaque; on a failed restore it is NEVER deleted (a lost member
+  // must surface loudly).
+  string snapshot_ref = 8;
+  // health_port is the guest TCP port the daemon health-gates by CONNECT to
+  // {ip, health_port} on FRESH before returning ready (opaque L4, matching the
+  // stateful contract; there is no ready_path).
+  uint32 health_port = 9;
+  // Resource shape of the member VM (vcpus, mem), carried exactly as serving and
+  // stateful.
+  ResourceSpec resources = 10;
+  // env are first-boot environment values delivered to the guest via the
+  // MMDS-lite seam, exactly as StartStateful.mmds_env: the same secrets/first-boot
+  // seam. It is FRESH-ONLY: a RELIGHT resume IGNORES this map and the resumed guest
+  // keeps its BIRTH env (the env was baked into the memory image at first boot).
+  // The platform-injected EMBER_GROUP_* keys are composed by the control plane,
+  // not the daemon; the daemon delivers whatever map it is handed and interprets
+  // none of it.
+  map<string, string> env = 11;
+}
+
+message StartGroupMemberResponse {
+  // vm_id names the live member VM. Opaque; the control plane holds it and passes
+  // it to StopGroupMember.
+  string vm_id = 1;
+  // ip is the member's pinned address on the group bridge (the same ip the request
+  // carried, echoed as the authoritative live fact).
+  string ip = 2;
+  // was_relight is true when the call resumed a banked bundle (a verified RELIGHT,
+  // clock-resync within one second); false for a FRESH cold boot.
+  bool was_relight = 3;
+}
+
+enum StopGroupMemberMode {
+  STOP_GROUP_MEMBER_MODE_UNSPECIFIED = 0;
+  STOP_GROUP_MEMBER_MODE_BANK = 1;
+  STOP_GROUP_MEMBER_MODE_DESTROY = 2;
+}
+
+message StopGroupMemberRequest {
+  Trace trace = 1;
+  string vm_id = 2;
+  StopGroupMemberMode mode = 3;
+  // set_id is the caller-supplied OPAQUE set directory the member's BANK snapshot
+  // is written under (group/<set_id>/<member>/). The daemon groups reported member
+  // refs by it but never decides membership. member_name names the member subdir.
+  string set_id = 4;
+  string member_name = 5;
+}
+
+message StopGroupMemberResponse {
+  // snapshot_ref and size_bytes are set only when mode was BANK; both are the zero
+  // value for DESTROY. snapshot_ref is the opaque per-member bundle handle the
+  // control plane records and later passes to EvictSnapshot (R2, reused unchanged).
+  string snapshot_ref = 1;
+  uint64 size_bytes = 2;
+}
+
 // ---- Node status -----------------------------------------------------------
 
 message WatchNodeRequest {
@@ -859,6 +1076,53 @@ message Volume {
   bool attached = 5;
 }
 
+// GroupNetwork is one per-group bridge the node currently holds, reported so a
+// restarted control plane reconciles group networks from node truth (a bridge
+// survives a daemon restart) and can see the CIDR each group occupies without
+// tracking allocation itself. member_count is the number of member VMs currently
+// attached to the bridge (the DeleteGroupNetwork backstop reads it).
+message GroupNetwork {
+  string group_instance_id = 1;
+  string cidr = 2;
+  string bridge = 3;
+  uint32 member_count = 4;
+}
+
+// GroupMemberVm is one LIVE group member VM the node currently holds, reported so
+// a restarted control plane adopts rather than orphans it and consumes the
+// daemon's TCP-connect health verdict. Excluded from every
+// WorkloadCapacity.primed_vm_ids, session_vms, serving_vms, and stateful_vms (a
+// member VM is never in the task pool).
+message GroupMemberVm {
+  string vm_id = 1;
+  string group_instance_id = 2;
+  string member_name = 3;
+  string ip = 4;
+  bool healthy = 5;
+  int64 last_probe_unix_ms = 6;
+}
+
+// GroupBundleMember is one member's banked snapshot within a group bundle set: the
+// opaque per-member ref and its size. Grouped under a GroupBundleSet by the set
+// directory the daemon was told to write it under.
+message GroupBundleMember {
+  string member_name = 1;
+  string snapshot_ref = 2;
+  uint64 size_bytes = 3;
+}
+
+// GroupBundleSet is the per-member banked snapshots the daemon found grouped under
+// one set directory (group/<set_id>/), reported so the control plane reconciles
+// banked-group inventory from node truth. The daemon reports refs GROUPED BY the
+// set dir it wrote them under; it makes NO completeness judgment (whether the set
+// has every member it needs to relight is the control plane's to decide).
+message GroupBundleSet {
+  string set_id = 1;
+  string group_instance_id = 2;
+  repeated GroupBundleMember members = 3;
+  int64 created_at_unix_ms = 4;
+}
+
 // NodeStatus is the whole capacity fact set: per-workload primed slots and base
 // states, node-level memory/cpu headroom, and the draining flag. A draining
 // daemon reports draining=true and the control plane stops new assignments
@@ -933,4 +1197,23 @@ message NodeStatus {
   // from the volumes dir, the durable data the control plane never reads but must
   // account for (generation for pairing, allocated_bytes for the watermark).
   repeated Volume volumes = 18;
+
+  // -- Group facts (R5, additive) ---------------------------------------------
+  // These three fields report the composite-workload substrate: the per-group
+  // bridges (with their CIDR and attached member count), the live member VMs (with
+  // their group identity and TCP-connect health verdict), and the banked bundle
+  // SETS (per-member refs grouped by set directory). All are optional/repeated and
+  // wire-compatible with a daemon that never sets them. The daemon reports refs
+  // grouped by set; the completeness judgment (is a set whole enough to relight)
+  // stays in the control plane.
+
+  // group_networks lists every per-group bridge this node currently holds.
+  repeated GroupNetwork group_networks = 19;
+  // group_member_vms lists every LIVE group member VM this node holds. Disjoint
+  // from every WorkloadCapacity.primed_vm_ids, session_vms, serving_vms, and
+  // stateful_vms.
+  repeated GroupMemberVm group_member_vms = 20;
+  // group_bundle_sets is the banked-group-bundle inventory scanned from the
+  // group/ prefix of the bundle dir, refs grouped by set directory.
+  repeated GroupBundleSet group_bundle_sets = 21;
 }

--- a/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
+++ b/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
@@ -18,6 +18,8 @@ defmodule Embervm.NodeRoundtripTest do
     AssignRequest,
     BankRequest,
     BuildBaseRequest,
+    CreateGroupNetworkRequest,
+    DeleteGroupNetworkRequest,
     DeleteVolumeRequest,
     DestroyRequest,
     EvictSnapshotRequest,
@@ -31,8 +33,10 @@ defmodule Embervm.NodeRoundtripTest do
     RelightSource,
     ResourceSpec,
     SessionAssignRequest,
+    StartGroupMemberRequest,
     StartServingRequest,
     StartStatefulRequest,
+    StopGroupMemberRequest,
     StopServingRequest,
     StopStatefulRequest,
     Trace,
@@ -267,6 +271,111 @@ defmodule Embervm.NodeRoundtripTest do
              NodeService.Stub.delete_volume(ch, %DeleteVolumeRequest{workload: "scratch-postgres"})
   end
 
+  test "group verbs round-trip across the wire (R5 additive contract)", %{channel: ch} do
+    # CreateGroupNetwork: derives bridge_name/gateway_ip from the request, proving
+    # the group_instance_id and cidr fields crossed the wire.
+    {:ok, net} =
+      NodeService.Stub.create_group_network(ch, %CreateGroupNetworkRequest{
+        trace: %Trace{workload: "composite"},
+        group_instance_id: "grp-inst1",
+        cidr: "10.100.0.0/24"
+      })
+
+    assert net.bridge_name == "br-grp-inst1"
+    assert net.gateway_ip == "10.100.0.1"
+
+    # CreateGroupNetwork refusal: the fake scripts a CIDR-overlap FAILED_PRECONDITION
+    # off the cidr content, proving the refusal status crosses the wire.
+    {:error, refused} =
+      NodeService.Stub.create_group_network(ch, %CreateGroupNetworkRequest{
+        group_instance_id: "grp-inst2",
+        cidr: "10.100.0.0/24-overlap"
+      })
+
+    assert refused.status == GRPC.Status.failed_precondition()
+
+    # StartGroupMember FRESH: cold-boots from source, echoes the pinned ip, no
+    # relight. Proves the mode enum, source, member identity, and env map cross.
+    {:ok, fresh} =
+      NodeService.Stub.start_group_member(ch, %StartGroupMemberRequest{
+        trace: %Trace{workload: "composite"},
+        mode: :START_GROUP_MEMBER_MODE_FRESH,
+        group_instance_id: "grp-inst1",
+        member_name: "worker-0",
+        member_index: 0,
+        ip: "10.100.0.10",
+        source: "worker-base",
+        health_port: 8080,
+        resources: %ResourceSpec{vcpus: 1, mem_mib: 256},
+        env: %{"EMBER_GROUP_SIZE" => "3"}
+      })
+
+    assert fresh.vm_id == "vm:worker-base"
+    assert fresh.ip == "10.100.0.10"
+    assert fresh.was_relight == false
+
+    # StartGroupMember RELIGHT, verified: resumes warm (was_relight true) once the
+    # clock-resync handshake verified within one second. The fake scripts a warm
+    # relight for any ordinary ref.
+    {:ok, warm} =
+      NodeService.Stub.start_group_member(ch, %StartGroupMemberRequest{
+        mode: :START_GROUP_MEMBER_MODE_RELIGHT,
+        group_instance_id: "grp-inst1",
+        member_name: "worker-0",
+        member_index: 0,
+        ip: "10.100.0.10",
+        snapshot_ref: "group/set-abc/worker-0"
+      })
+
+    assert warm.vm_id == "vm:group/set-abc/worker-0"
+    assert warm.ip == "10.100.0.10"
+    assert warm.was_relight == true
+
+    # StartGroupMember RELIGHT, clock-resync failure: the fake scripts a
+    # FAILED_PRECONDITION off the ref content, proving the resync-failure status
+    # crosses the wire (standing decision 7: a >1s delta fails the resume).
+    {:error, clockfail} =
+      NodeService.Stub.start_group_member(ch, %StartGroupMemberRequest{
+        mode: :START_GROUP_MEMBER_MODE_RELIGHT,
+        group_instance_id: "grp-inst1",
+        member_name: "worker-0",
+        ip: "10.100.0.10",
+        snapshot_ref: "group/set-abc/worker-0-clockfail"
+      })
+
+    assert clockfail.status == GRPC.Status.failed_precondition()
+
+    # StopGroupMember BANK: derives the per-member bundle ref from set_id/member_name.
+    {:ok, banked} =
+      NodeService.Stub.stop_group_member(ch, %StopGroupMemberRequest{
+        vm_id: "vm-g1",
+        mode: :STOP_GROUP_MEMBER_MODE_BANK,
+        set_id: "set-abc",
+        member_name: "worker-0"
+      })
+
+    assert banked.snapshot_ref == "group/set-abc/worker-0"
+    assert banked.size_bytes == 5120
+
+    # StopGroupMember DESTROY: no snapshot produced.
+    {:ok, destroyed} =
+      NodeService.Stub.stop_group_member(ch, %StopGroupMemberRequest{
+        vm_id: "vm-g1",
+        mode: :STOP_GROUP_MEMBER_MODE_DESTROY,
+        set_id: "set-abc",
+        member_name: "worker-0"
+      })
+
+    assert destroyed.snapshot_ref == ""
+    assert destroyed.size_bytes == 0
+
+    # DeleteGroupNetwork: idempotent, returns an empty response.
+    assert {:ok, _} =
+             NodeService.Stub.delete_group_network(ch, %DeleteGroupNetworkRequest{
+               group_instance_id: "grp-inst1"
+             })
+  end
+
   test "NodeStatus reports stateful facts (R4 additive fields)", %{channel: ch} do
     {:ok, ns} = NodeService.Stub.get_node_status(ch, %GetNodeStatusRequest{node_id: "node-4"})
 
@@ -292,6 +401,36 @@ defmodule Embervm.NodeRoundtripTest do
     assert vol.size_bytes == 10_737_418_240
     assert vol.allocated_bytes == 536_870_912
     assert vol.attached == true
+  end
+
+  test "NodeStatus reports group facts (R5 additive fields)", %{channel: ch} do
+    {:ok, ns} = NodeService.Stub.get_node_status(ch, %GetNodeStatusRequest{node_id: "node-4"})
+
+    assert [net] = ns.group_networks
+    assert net.group_instance_id == "grp-inst1"
+    assert net.cidr == "10.100.0.0/24"
+    assert net.bridge == "br-grp-inst1"
+    assert net.member_count == 2
+
+    assert [vm] = ns.group_member_vms
+    assert vm.vm_id == "vm-g1"
+    assert vm.group_instance_id == "grp-inst1"
+    assert vm.member_name == "worker-0"
+    assert vm.ip == "10.100.0.10"
+    assert vm.healthy == true
+    assert vm.last_probe_unix_ms == 1_700_000_005_000
+
+    # The bundle set is deliberately PARTIAL (one member ref), proving the daemon
+    # reports refs grouped by set dir and leaves the completeness judgment to the
+    # control plane.
+    assert [set] = ns.group_bundle_sets
+    assert set.set_id == "set-abc"
+    assert set.group_instance_id == "grp-inst1"
+    assert set.created_at_unix_ms == 1_700_000_006_000
+    assert [member] = set.members
+    assert member.member_name == "worker-0"
+    assert member.snapshot_ref == "group/set-abc/worker-0"
+    assert member.size_bytes == 5120
   end
 
   test "NodeStatus reports serving facts (R3 additive fields)", %{channel: ch} do


### PR DESCRIPTION
Rung R5 (composite workloads), PR-1 of 8: the **contract foundation**. Purely additive, no behavior change (nothing reads the new surfaces yet). Executes Tasks 1 and 2 of `docs/plans/2026-07-16-embervm-r5-composite-spec-and-plan.md`.

## Task 1: node contract group verbs and facts
- Additive RPCs on `embervm.node.v1.NodeService`: `CreateGroupNetwork`, `DeleteGroupNetwork`, `StartGroupMember` (FRESH|RELIGHT, env is FRESH-only), `StopGroupMember` (BANK|DESTROY, caller-supplied opaque `set_id`). Group set eviction reuses `EvictSnapshot` unchanged.
- `NodeStatus` fields 19-21: `group_networks`, `group_member_vms`, `group_bundle_sets` (wire-compatible, sub-messages mirror the R4 stateful facts).
- Guest control agent vsock contract documented in proto comments (dedicated port, `sync_clock` length-prefixed JSON frames, read-back rule: fail resume if clock delta > 1s). Task 3 implements it.
- fakenode serves all four verbs + status fields, scriptable to every outcome (fresh, relight, relight-clock-fail, bank, destroy, network create/delete/refusal, partial-set) with proto round-trip tests.

## Task 2: composite workload class, group records, bundle-set audit
- 15 additive `:group_*` op kinds; terminal `expired` rides `group_destroyed{reason: expired}`.
- New projection tables `group_instances` + `group_members` (first multi-row-per-instance projection), guarded ALTER-after-DDL `ops.group_instance_id` + index, registered in the migration chain.
- `group_banked` writes the full bundle set atomically in one append (all-members-or-none warmth invariant); `group_stats` bills usage per member; every group op kind has a projection clause; boot-rebuild load callbacks + retention + compaction extended.
- CRD `class: composite` + full `spec.group` block (members, entry, secretRef, timers), `status.group` + `COMPOSITE` printer column, warmth-only + crash-consistency-per-VM contracts in field docs. Symmetric class cross-rejection (composite rejects serving/session/stateful/concurrency, and those reject `spec.group`).
- `compositeTcpPortRange` (5410-5419) + `maxGroupSize` (4) in values, parsed from chart env into app-env at boot so operator overrides actually reach the watcher.
- Generic `workload-composite.yaml` sample (not k3s-shaped, that is Task 10).

## Review
Each task passed a two-stage review (spec compliance, then code quality). Three code-quality findings were fixed in `2e2ba4dd2` (real env->app-env wiring, member_count coercion, `replicas: 0` truthiness guard). Additive-only verified: no existing class contract, op kind, table, or CRD block changed breakingly; nothing k3s-shaped in the proto or CRD; no em-dashes.

No local tests (repo has no local loop); ExUnit + proto round-trip + helm render validated in CI. Chart bumped to 0.1.83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)