### PR TITLE
ci: bump heavy build actions to 120GB disk

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -91,7 +91,7 @@ actions:
     resource_requests:
       cpu: "6"
       memory: "10GB"
-      disk: "60GB"
+      disk: "120GB"
     triggers:
       push:
         branches:
@@ -153,7 +153,7 @@ actions:
     resource_requests:
       cpu: "6"
       memory: "10GB"
-      disk: "60GB"
+      disk: "120GB"
     triggers:
       push:
         branches:
@@ -194,7 +194,7 @@ actions:
     resource_requests:
       cpu: "6"
       memory: "10GB"
-      disk: "60GB"
+      disk: "120GB"
     triggers:
       push:
         branches:

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.149
+version: 0.89.151
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.149
+      targetRevision: 0.89.151
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.224
+version: 0.285.226
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.224
+      targetRevision: 0.285.226
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Bumps the Test, BDD-future, and Push-images BuildBuddy actions from 60GB to 120GB disk. These three build the full image set; the runner was hitting 99%+ disk ("No space left on device") once the EmberVM R5 k3s guest images add their vendored dual-arch airgap tarballs to `push_all`. Unblocks PR #3612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)