### PR TITLE
feat(embervm): R5 group networking + member lifecycle (Tasks 4-5)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.83
+version: 0.1.84

--- a/projects/embervm/chart/templates/noded-deployment.yaml
+++ b/projects/embervm/chart/templates/noded-deployment.yaml
@@ -127,6 +127,13 @@ spec:
                   fieldPath: status.podIP
             - name: EMBERVM_NODED_MAX_LIVE_VMS
               value: {{ .Values.noded.maxLiveVMs | quote }}
+            # R5 composite-group supernet: noded carves a /24 per group out of this
+            # supernet and VALIDATES each control-plane-assigned group cidr is a /24
+            # wholly within it. Distinct from the serving 172.31/12 tap space so the
+            # two classes never share address space. Mirrors how the serving subnet
+            # is a daemon config knob (defaulted in config.go, overridable here).
+            - name: EMBERVM_NODED_COMPOSITE_SUPERNET
+              value: {{ .Values.noded.compositeSupernet | quote }}
             # Per-invoke FC bundle snapshots and the fixed vsock dir the snapshot
             # embeds both derive from nvmeRoot so the scratch disk is one knob.
             - name: EMBERVM_NODED_SNAPSHOT_ROOT

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -554,6 +554,15 @@ noded:
   # real concurrency; this only stops a runaway from exhausting the node.
   maxLiveVMs: 8
 
+  # R5 composite-group supernet: noded carves a per-group /24 out of this supernet
+  # for each composite-workload group and VALIDATES the control-plane-assigned group
+  # cidr is a /24 wholly within it (and non-overlapping with an existing group
+  # bridge). Distinct from the serving tap space (172.31/12, a daemon default) and
+  # verified against the cluster pod CIDR (10.0/8) before the live drill, so the
+  # three do not collide. The bridges live in noded's pod netns and die with the pod;
+  # the durable truth is the on-disk group_networks/<gid>/config.json record.
+  compositeSupernet: 10.101.0.0/16
+
   # Static bearer token gating the gRPC surface. Disabled here (daemon runs open +
   # warns; Cilium/Linkerd policy is the layer). A 1Password-provisioned secret is
   # wired in a later PR when the control plane dials the daemon (Task 11).

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.83
+      targetRevision: 0.1.84
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/cmd/main.go
+++ b/projects/embervm/noded/cmd/main.go
@@ -103,6 +103,17 @@ func run(logger *slog.Logger) error {
 		logger.Warn("serving: EMBERVM_NODED_POD_IP unset; serving endpoints report node-internal tap IPs and DNAT is disabled")
 	}
 
+	// The composite-group network Manager (R5) owns per-group bridges, deterministic
+	// member addressing, the inter-group isolation (a dedicated embervm_group nft
+	// table, so it never collides with the serving forward/serving_dnat chains), and
+	// the entry-member pod-IP DNAT (the same D-R3.11.4 lane). It carves a /24 per
+	// group out of the composite supernet and denies composite->serving toward the
+	// serving bridge. A malformed supernet fails startup loudly.
+	groupNet, err := serving.NewGroupManager(serving.ExecRunner{}, cfg.CompositeSupernet, cfg.ServingBridge, cfg.PodIP, cfg.ServingPortBase)
+	if err != nil {
+		return err
+	}
+
 	srv := server.New(server.Options{
 		Config: cfg,
 		Driver: restoreDriver,
@@ -128,6 +139,11 @@ func run(logger *slog.Logger) error {
 		VolumeRoot:                 cfg.VolumeRoot,
 		StatefulProbeInterval:      cfg.StatefulProbeInterval,
 		StatefulUnhealthyThreshold: cfg.StatefulUnhealthyThreshold,
+		// The composite-group network Manager (R5) and the same restore driver for
+		// the durable on-disk group-network records (group_networks/<gid>/config.json,
+		// a sibling of the bases/sessions/serving/stateful bundle dirs).
+		GroupNet:     groupNet,
+		GroupRecords: restoreDriver,
 	})
 	// Report node-local base snapshots left by a prior incarnation so the control
 	// plane reconciles rather than rebuilding.
@@ -143,10 +159,20 @@ func run(logger *slog.Logger) error {
 	// ensure VolumeRoot exists; the durable volumes themselves need no in-memory
 	// seeding (volume.Manager reads VolumeRoot fresh off disk on every NodeStatus).
 	srv.ReconcileStatefulFromDisk()
+	// Report node-local group-network records left by a prior incarnation so the
+	// control plane reconciles group networks from node truth (the bridges died with
+	// the prior pod; the durable records survive and the control plane re-issues
+	// CreateGroupNetwork to rebuild each bridge, Task 7).
+	srv.ReconcileGroupNetworksFromDisk()
 	// Create the serving bridge and install the ingress-only nftables posture before
 	// serving any StartServing. Idempotent across restarts (existing bridge tolerated).
 	if err := servingNet.EnsureNetwork(ctx); err != nil {
 		return fmt.Errorf("serving network setup: %w", err)
+	}
+	// Enable forwarding and install the composite-group isolation nftables posture
+	// (initially the empty-group / post-adoption table) before any CreateGroupNetwork.
+	if err := groupNet.EnsureNetwork(ctx); err != nil {
+		return fmt.Errorf("group network setup: %w", err)
 	}
 
 	var serverOpts []grpc.ServerOption

--- a/projects/embervm/noded/cmd/main.go
+++ b/projects/embervm/noded/cmd/main.go
@@ -144,6 +144,14 @@ func run(logger *slog.Logger) error {
 		// a sibling of the bases/sessions/serving/stateful bundle dirs).
 		GroupNet:     groupNet,
 		GroupRecords: restoreDriver,
+		// The same restore driver serves the R5 member lifecycle (ClaimGroupMember
+		// cold boot on the group bridge + SnapshotGroupMember/RestoreGroupMember under
+		// group/<set_id>/<member>/). The member RELIGHT clock resync defaults to the
+		// real vsock-backed groupclock (port-1024 length-prefixed JSON); no explicit
+		// GroupClock is set here.
+		GroupDriver:             restoreDriver,
+		GroupProbeInterval:      cfg.StatefulProbeInterval,
+		GroupUnhealthyThreshold: cfg.StatefulUnhealthyThreshold,
 	})
 	// Report node-local base snapshots left by a prior incarnation so the control
 	// plane reconciles rather than rebuilding.
@@ -164,6 +172,11 @@ func run(logger *slog.Logger) error {
 	// the prior pod; the durable records survive and the control plane re-issues
 	// CreateGroupNetwork to rebuild each bridge, Task 7).
 	srv.ReconcileGroupNetworksFromDisk()
+	// Report node-local BANKED group member bundles left by a prior incarnation,
+	// grouped by set dir, so the control plane reconciles banked-group inventory from
+	// node truth (live members died with the prior pod; the on-disk bundle sets
+	// survive and the control plane resolves each group to relightable-or-fresh).
+	srv.ReconcileGroupBundlesFromDisk()
 	// Create the serving bridge and install the ingress-only nftables posture before
 	// serving any StartServing. Idempotent across restarts (existing bridge tolerated).
 	if err := servingNet.EnsureNetwork(ctx); err != nil {

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -154,6 +154,21 @@ type Config struct {
 	// serving HTTP-probe knobs. Default 5s / 3.
 	StatefulProbeInterval      time.Duration
 	StatefulUnhealthyThreshold int
+
+	// CompositeSupernet is the values-declared supernet the control plane carves a
+	// per-group /24 out of for each composite-workload group (R5). CreateGroupNetwork
+	// VALIDATES the control-plane-assigned cidr is a /24 wholly within this supernet
+	// (and non-overlapping with an existing group bridge). Default 10.101.0.0/16
+	// (distinct from the serving 172.31/12 space and the 10.0/8 pod CIDR is verified
+	// against the cluster before the live drill). A malformed supernet fails
+	// GroupManager construction loudly. Env EMBERVM_NODED_COMPOSITE_SUPERNET.
+	CompositeSupernet string
+	// GroupProbeInterval / GroupUnhealthyThreshold configure the TCP-connect
+	// health-probe loop for live group member VMs (R5), mirroring the stateful
+	// knobs. Carried now so Task 5's member lifecycle needs no config reshape;
+	// unused in Task 4. Default 5s / 3.
+	GroupProbeInterval      time.Duration
+	GroupUnhealthyThreshold int
 }
 
 // Load resolves configuration from the environment, applying defaults for all
@@ -190,6 +205,10 @@ func Load() (Config, error) {
 		VolumeRoot:                 os.Getenv("EMBERVM_NODED_VOLUME_ROOT"),
 		StatefulProbeInterval:      5 * time.Second,
 		StatefulUnhealthyThreshold: atoiDefault("EMBERVM_NODED_STATEFUL_UNHEALTHY_THRESHOLD", 3),
+
+		CompositeSupernet:       getenvDefault("EMBERVM_NODED_COMPOSITE_SUPERNET", "10.101.0.0/16"),
+		GroupProbeInterval:      5 * time.Second,
+		GroupUnhealthyThreshold: atoiDefault("EMBERVM_NODED_GROUP_UNHEALTHY_THRESHOLD", 3),
 	}
 
 	if c.Node == "" {
@@ -222,6 +241,9 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 	if err := parseDuration("EMBERVM_NODED_STATEFUL_PROBE_INTERVAL", &c.StatefulProbeInterval); err != nil {
+		return Config{}, err
+	}
+	if err := parseDuration("EMBERVM_NODED_GROUP_PROBE_INTERVAL", &c.GroupProbeInterval); err != nil {
 		return Config{}, err
 	}
 	if v := os.Getenv("EMBERVM_NODED_ARCHIVE_MAX_BYTES"); v != "" {

--- a/projects/embervm/noded/config/config_test.go
+++ b/projects/embervm/noded/config/config_test.go
@@ -67,6 +67,35 @@ func TestLoadDefaults(t *testing.T) {
 	if c.ServingUnhealthyThreshold != 3 {
 		t.Errorf("ServingUnhealthyThreshold = %d, want 3", c.ServingUnhealthyThreshold)
 	}
+	// Default composite supernet is 10.101.0.0/16 (distinct from the serving space).
+	if c.CompositeSupernet != "10.101.0.0/16" {
+		t.Errorf("CompositeSupernet = %q, want 10.101.0.0/16", c.CompositeSupernet)
+	}
+	if c.GroupProbeInterval != 5*time.Second {
+		t.Errorf("GroupProbeInterval = %v, want 5s", c.GroupProbeInterval)
+	}
+	if c.GroupUnhealthyThreshold != 3 {
+		t.Errorf("GroupUnhealthyThreshold = %d, want 3", c.GroupUnhealthyThreshold)
+	}
+}
+
+func TestLoadCompositeSupernetOverride(t *testing.T) {
+	t.Setenv("EMBERVM_NODED_COMPOSITE_SUPERNET", "10.150.0.0/16")
+	t.Setenv("EMBERVM_NODED_GROUP_PROBE_INTERVAL", "7s")
+	t.Setenv("EMBERVM_NODED_GROUP_UNHEALTHY_THRESHOLD", "4")
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.CompositeSupernet != "10.150.0.0/16" {
+		t.Errorf("CompositeSupernet = %q", c.CompositeSupernet)
+	}
+	if c.GroupProbeInterval != 7*time.Second {
+		t.Errorf("GroupProbeInterval = %v", c.GroupProbeInterval)
+	}
+	if c.GroupUnhealthyThreshold != 4 {
+		t.Errorf("GroupUnhealthyThreshold = %d", c.GroupUnhealthyThreshold)
+	}
 }
 
 func TestLoadServingOverrides(t *testing.T) {

--- a/projects/embervm/noded/fcvm/driver/BUILD
+++ b/projects/embervm/noded/fcvm/driver/BUILD
@@ -23,6 +23,7 @@ go_test(
     name = "driver_test",
     srcs = [
         "driver_test.go",
+        "group_test.go",
         "gueststats_test.go",
         "provisioner_test.go",
     ],

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -1546,6 +1546,216 @@ func (d *Driver) ScanGroupNetworks() []substrate.GroupNetworkRecord {
 	return out
 }
 
+// ---- Group member snapshot mechanics (R5) -----------------------------------
+//
+// A composite-group member VM banks to a self-contained bundle exactly like a
+// session/serving/stateful VM (memfile + snapfile, no archive backing file), but
+// the bundle layout is group/<set_id>/<member_name>/ so the control plane can
+// address a whole RELIGHTABLE SET by set_id and the daemon reports member bundles
+// GROUPED BY set dir (ScanGroupBundleSets). A member bundle carries NO sidecar: the
+// member's pinned tap/MAC/IP are DETERMINISTIC from (group_instance_id, member_name,
+// member_index) via Task 4's addressing, so a relight re-derives the pinned world
+// from the request identity rather than reading it back, and there is no generation
+// ledger for a member the way a stateful volume has one. The pinned world (tap name
+// + MAC + IP) MUST be recreated identically BEFORE the resume, because the guest's
+// eth0 keeps the address baked at fresh boot and a snapshot resume never re-runs
+// kernel init (the D-R3.4.1 pin, applied to a member's group bridge).
+
+// GroupSetsDir is the parent directory holding all banked GROUP member bundles,
+// under the group/ prefix of the snapshot root (a sibling of bases/, sessions/,
+// serving/, and stateful/). The daemon rescans exactly this dir on start via
+// ScanGroupBundleSets. Callers own its 0700 permission and daemon-ownership.
+func (d *Driver) GroupSetsDir() string { return filepath.Join(d.cfg.SnapshotRoot, "group") }
+
+// groupMemberDir is the bundle directory for one banked member snapshot, keyed by
+// the opaque set_id and the member_name: group/<set_id>/<member_name>/.
+func (d *Driver) groupMemberDir(setID, memberName string) string {
+	return filepath.Join(d.GroupSetsDir(), setID, memberName)
+}
+
+func (d *Driver) groupMemberSnapfile(setID, memberName string) string {
+	return filepath.Join(d.groupMemberDir(setID, memberName), "snapfile")
+}
+
+func (d *Driver) groupMemberMemfile(setID, memberName string) string {
+	return filepath.Join(d.groupMemberDir(setID, memberName), "memfile")
+}
+
+// ClaimGroupMember cold-boots a composite-group member microVM (R5) from a
+// per-member rootfs WITH the given tap NIC on the group bridge (exactly as
+// ClaimServing) PLUS the member's first-boot env delivered via the MMDS-lite
+// boot-args seam (D-R4.PR-7.1), and NO handler artifact and NO writable volume (a
+// group member is a plain NIC guest). It mirrors ClaimServing's shape precisely
+// (same NIC requirement, same harness-init threading, same coldBoot reuse) with the
+// addition of mmdsEnv. env is only meaningful on a FRESH cold boot; a RELIGHT
+// resumes a memory snapshot via RestoreGroupMember and never re-reads boot-args, so
+// the resumed member keeps its BIRTH env.
+func (d *Driver) ClaimGroupMember(ctx context.Context, rootfsPath, harnessInit string, vcpus, memMib int, nic substrate.NICSpec, env map[string]string) (substrate.Handle, error) {
+	if nic.HostDevName == "" {
+		return substrate.Handle{}, fmt.Errorf("driver: ClaimGroupMember requires a host tap device")
+	}
+	vcpus = orDefault(vcpus, d.cfg.VCPUs)
+	memMib = orDefault(memMib, d.cfg.MemMib)
+	nicCopy := nic
+	return d.coldBoot(ctx, newID("grpm"), coldBootSpec{
+		rootfsPath:  rootfsPath,
+		vcpus:       vcpus,
+		memMib:      memMib,
+		nic:         &nicCopy,
+		harnessInit: harnessInit,
+		mmdsEnv:     env,
+	})
+}
+
+// SnapshotGroupMember pauses a live member VM and writes a self-contained member
+// bundle (memfile + snapfile) under group/<set_id>/<member_name>/. It does NOT
+// resume: the caller Releases the VM immediately after (StopGroupMember BANK
+// destroys). It mirrors SnapshotSession exactly (no sidecar: a member's pinned
+// world is derivable, not banked). On any failure after the handle is confirmed the
+// VM is torn down (a bank is destructive), so a failed bank never leaves a live/
+// paused handle behind for the server to misreport as capacity.
+func (d *Driver) SnapshotGroupMember(ctx context.Context, h substrate.Handle, setID, memberName string) (substrate.SnapshotRef, error) {
+	if setID == "" || memberName == "" {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: SnapshotGroupMember requires a set_id and member_name")
+	}
+	inst := d.get(h.ID)
+	if inst == nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: snapshot-group-member of unknown handle %q", h.ID)
+	}
+	banked := false
+	defer func() {
+		if !banked {
+			_ = d.Release(ctx, h)
+		}
+	}()
+	if err := os.MkdirAll(d.groupMemberDir(setID, memberName), 0o700); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: mkdir group member bundle: %w", err)
+	}
+	snapPath := d.groupMemberSnapfile(setID, memberName)
+	memPath := d.groupMemberMemfile(setID, memberName)
+	snapTmp := snapPath + ".tmp"
+	memTmp := memPath + ".tmp"
+
+	if err := inst.client.Pause(ctx); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: pause group member: %w", err)
+	}
+	if err := inst.client.CreateSnapshot(ctx, fcclient.SnapshotCreate{SnapshotPath: snapTmp, MemFilePath: memTmp}); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: create group member snapshot: %w", err)
+	}
+	// Publish memfile before snapfile (a restore reads the snapfile to locate the
+	// memfile), then the snapfile LAST so a rescan that finds a snapfile always
+	// finds a complete bundle (the same publish-last discipline every other class
+	// uses so a half-written bundle is skipped).
+	if err := os.Rename(memTmp, memPath); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: publish group member memfile: %w", err)
+	}
+	if err := os.Rename(snapTmp, snapPath); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: publish group member snapfile: %w", err)
+	}
+	banked = true
+	return substrate.SnapshotRef{
+		ID:        filepath.Join("group", setID, memberName),
+		Node:      d.cfg.Node,
+		Arch:      d.cfg.Arch,
+		SizeBytes: bundleSize(snapPath, memPath),
+	}, nil
+}
+
+// RestoreGroupMember launches a fresh Firecracker process and loads a banked member
+// bundle (group/<set_id>/<member_name>/), resuming it so the guest continues exactly
+// where it was banked, WITH the NIC it captured at bank time. It mirrors
+// RestoreServing. The caller has already recreated the host tap (same name + MAC)
+// and configured the pinned IP on the group bridge BEFORE this runs (the pinned
+// world is derived from the group + member + index, not read from a sidecar), so the
+// resumed guest's baked eth0 still routes. A missing bundle is an error the caller
+// maps to FAILED_PRECONDITION (the bundle is NEVER deleted on a failed restore: a
+// lost member must surface loudly).
+func (d *Driver) RestoreGroupMember(ctx context.Context, setID, memberName string) (substrate.Handle, error) {
+	if setID == "" || memberName == "" {
+		return substrate.Handle{}, fmt.Errorf("driver: RestoreGroupMember requires a set_id and member_name")
+	}
+	snapPath := d.groupMemberSnapfile(setID, memberName)
+	if _, err := os.Stat(snapPath); err != nil {
+		return substrate.Handle{}, fmt.Errorf("driver: group member bundle missing for group/%s/%s: %w", setID, memberName, err)
+	}
+	threadID := newID("grpm")
+	return d.loadInto(ctx, threadID, snapPath, d.groupMemberMemfile(setID, memberName), "restore.sock")
+}
+
+// RemoveGroupMemberBundle deletes a banked member snapshot's on-disk bundle
+// (group/<set_id>/<member_name>/). It is the member EvictSnapshot-equivalent
+// mechanic. Idempotent: a missing bundle is not an error.
+func (d *Driver) RemoveGroupMemberBundle(setID, memberName string) error {
+	if setID == "" || memberName == "" {
+		return fmt.Errorf("driver: RemoveGroupMemberBundle requires a set_id and member_name")
+	}
+	if err := os.RemoveAll(d.groupMemberDir(setID, memberName)); err != nil {
+		return fmt.Errorf("driver: remove group member bundle: %w", err)
+	}
+	return nil
+}
+
+// ScanGroupBundleSets globs group/*/*/snapfile on startup and returns each set dir
+// with the per-member bundles found under it, so a restarted daemon reports what
+// banked group warmth survives GROUPED BY set. The daemon makes NO completeness
+// judgment (whether a set has every member it needs to relight is the control
+// plane's to decide); it reports refs grouped by the set dir it wrote them under. A
+// member dir without a snapfile is half-written or mid-evict and is skipped; a set
+// dir with no complete member bundle is omitted entirely.
+func (d *Driver) ScanGroupBundleSets() []substrate.GroupBundleSetInfo {
+	root := d.GroupSetsDir()
+	setEntries, err := os.ReadDir(root)
+	if err != nil {
+		return nil // no group dir yet (fresh node): nothing to rescan
+	}
+	out := make([]substrate.GroupBundleSetInfo, 0, len(setEntries))
+	for _, se := range setEntries {
+		if !se.IsDir() {
+			continue
+		}
+		setID := se.Name()
+		memberEntries, merr := os.ReadDir(filepath.Join(root, setID))
+		if merr != nil {
+			continue
+		}
+		members := make([]substrate.GroupBundleMemberInfo, 0, len(memberEntries))
+		var createdMs int64
+		for _, me := range memberEntries {
+			if !me.IsDir() {
+				continue
+			}
+			memberName := me.Name()
+			snapPath := d.groupMemberSnapfile(setID, memberName)
+			fi, serr := os.Stat(snapPath)
+			if serr != nil {
+				continue // half-written or evicting: skip
+			}
+			if ms := fi.ModTime().UnixMilli(); ms > createdMs {
+				createdMs = ms
+			}
+			size := fi.Size()
+			if mfi, err := os.Stat(d.groupMemberMemfile(setID, memberName)); err == nil {
+				size += mfi.Size()
+			}
+			members = append(members, substrate.GroupBundleMemberInfo{
+				MemberName:  memberName,
+				SnapshotRef: filepath.Join("group", setID, memberName),
+				SizeBytes:   size,
+			})
+		}
+		if len(members) == 0 {
+			continue // a set dir with no complete member bundle is not reported
+		}
+		sort.Slice(members, func(i, j int) bool { return members[i].MemberName < members[j].MemberName })
+		out = append(out, substrate.GroupBundleSetInfo{
+			SetID:           setID,
+			Members:         members,
+			CreatedAtUnixMs: createdMs,
+		})
+	}
+	return out
+}
+
 // Exec is provided by the in-VM harness over the wrapper channel (Phase 2); the
 // FC-direct driver does not run processes in the guest from the host.
 func (d *Driver) Exec(_ context.Context, _ substrate.Handle, _ substrate.Request) (substrate.Stream, error) {

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -14,6 +14,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -1439,6 +1440,108 @@ func (d *Driver) ScanStatefulBundles() []substrate.StatefulBundleInfo {
 			SizeBytes:       size,
 			CreatedAtUnixMs: createdMs,
 		})
+	}
+	return out
+}
+
+// ---- Group networks (R5) ---------------------------------------------------
+//
+// A composite group's per-instance bridge lives in noded's pod netns and dies
+// with the pod, so the DURABLE truth is a small on-disk record. These methods own
+// that record under group_networks/<group_instance_id>/config.json (a sibling of
+// bases/, sessions/, serving/, and stateful/ under the snapshot root). The daemon
+// writes it on CreateGroupNetwork, removes it on DeleteGroupNetwork, and rescans
+// it on start (ScanGroupNetworks) to re-seed NodeStatus.group_networks. The bridge
+// itself is NOT persisted (it is netns state); the record is what lets the control
+// plane re-issue an idempotent CreateGroupNetwork to rebuild the bridge.
+
+// GroupNetworksDir is the parent directory holding all on-disk group-network
+// records, under the group_networks/ prefix of the snapshot root. The daemon
+// rescans exactly this dir on start via ScanGroupNetworks.
+func (d *Driver) GroupNetworksDir() string {
+	return filepath.Join(d.cfg.SnapshotRoot, "group_networks")
+}
+
+// groupNetworkRecordPath is the config.json path for one group-network record,
+// keyed by the opaque group_instance_id.
+func (d *Driver) groupNetworkRecordPath(groupInstanceID string) string {
+	return filepath.Join(d.GroupNetworksDir(), groupInstanceID, "config.json")
+}
+
+// WriteGroupNetworkRecord persists a group-network record atomically (write a
+// temp file, then rename), so a rescan never reads a half-written config.json. It
+// is idempotent: re-writing the same record for the same group_instance_id
+// overwrites in place (CreateGroupNetwork is idempotent, so a re-issue re-writes
+// the identical record). The dir is 0700 (daemon-owned).
+func (d *Driver) WriteGroupNetworkRecord(rec substrate.GroupNetworkRecord) error {
+	if rec.GroupInstanceID == "" {
+		return fmt.Errorf("driver: WriteGroupNetworkRecord requires a group_instance_id")
+	}
+	dir := filepath.Dir(d.groupNetworkRecordPath(rec.GroupInstanceID))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("driver: mkdir group network record dir: %w", err)
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("driver: marshal group network record: %w", err)
+	}
+	path := d.groupNetworkRecordPath(rec.GroupInstanceID)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("driver: write group network record: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("driver: publish group network record: %w", err)
+	}
+	return nil
+}
+
+// RemoveGroupNetworkRecord deletes a group-network record dir from disk
+// (idempotent: a missing record is not an error). Called on DeleteGroupNetwork.
+func (d *Driver) RemoveGroupNetworkRecord(groupInstanceID string) error {
+	if groupInstanceID == "" {
+		return fmt.Errorf("driver: RemoveGroupNetworkRecord requires a group_instance_id")
+	}
+	dir := filepath.Dir(d.groupNetworkRecordPath(groupInstanceID))
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("driver: remove group network record: %w", err)
+	}
+	return nil
+}
+
+// ScanGroupNetworks globs group_networks/*/config.json on startup and returns
+// each valid record, so a restarted daemon re-seeds its group-network inventory
+// and reports it in NodeStatus.group_networks. A record dir without a readable,
+// parseable config.json is skipped (half-written or corrupt); a fresh node with
+// no group_networks dir yields nil. The bridges these records name no longer
+// exist (they died with the prior pod), so the control plane re-issues
+// CreateGroupNetwork to rebuild them; this rescan is purely the durable-truth
+// re-seed.
+func (d *Driver) ScanGroupNetworks() []substrate.GroupNetworkRecord {
+	root := d.GroupNetworksDir()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil // no group_networks dir yet (fresh node): nothing to rescan
+	}
+	out := make([]substrate.GroupNetworkRecord, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		raw, err := os.ReadFile(d.groupNetworkRecordPath(e.Name()))
+		if err != nil {
+			continue // no config.json yet (mid-write) or unreadable: skip
+		}
+		var rec substrate.GroupNetworkRecord
+		if err := json.Unmarshal(raw, &rec); err != nil {
+			continue // corrupt record: skip
+		}
+		if rec.GroupInstanceID == "" {
+			// A record whose dir name is the id but whose body omitted it: recover
+			// the id from the dir name so the rescan is robust to an older writer.
+			rec.GroupInstanceID = e.Name()
+		}
+		out = append(out, rec)
 	}
 	return out
 }

--- a/projects/embervm/noded/fcvm/driver/driver_test.go
+++ b/projects/embervm/noded/fcvm/driver/driver_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -677,5 +678,126 @@ func TestServingSnapshotRoundTrip(t *testing.T) {
 	}
 	if _, err := d.RestoreServing(ctx, "servref-1"); err == nil {
 		t.Fatal("restore of an evicted serving bundle should error")
+	}
+}
+
+// TestDriverGroupMemberSnapshotRestoreRoundTrip proves the R5 member bank/relight
+// mechanic on the real driver: cold-boot a member on a group NIC (ClaimGroupMember),
+// snapshot it into a self-contained bundle under group/<set_id>/<member_name>/
+// (SnapshotGroupMember, no resume, so the caller destroys), then relight a fresh VM
+// from that bundle (RestoreGroupMember). The bundle carries NO sidecar (the pinned
+// world is derivable). RemoveGroupMemberBundle reclaims it and a subsequent relight
+// fails.
+func TestDriverGroupMemberSnapshotRestoreRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	d := testDriver(t)
+
+	h, err := d.ClaimGroupMember(ctx, "/rootfs/member", "/init", 1, 256,
+		substrate.NICSpec{HostDevName: "emgt0a1b2c", GuestMAC: "02:00:00:00:00:01", IP: "10.101.1.10", GatewayIP: "10.101.1.1", PrefixLen: 24}, map[string]string{"EMBER_GROUP_ROLE": "worker"})
+	if err != nil {
+		t.Fatalf("ClaimGroupMember: %v", err)
+	}
+	ref, err := d.SnapshotGroupMember(ctx, h, "set-abc", "worker-0")
+	if err != nil {
+		t.Fatalf("SnapshotGroupMember: %v", err)
+	}
+	wantRef := "group/set-abc/worker-0"
+	if ref.ID != wantRef || ref.Node != "node-4" || ref.Arch != "amd64" || ref.SizeBytes == 0 {
+		t.Fatalf("unexpected member ref: %+v (want ID %q)", ref, wantRef)
+	}
+	// The bundle lives under group/<set_id>/<member>/, never sessions/ or a per-thread dir.
+	if _, err := os.Stat(d.groupMemberSnapfile("set-abc", "worker-0")); err != nil {
+		t.Fatalf("member bundle snapfile missing under group/set-abc/worker-0: %v", err)
+	}
+	// No sidecar: a member's pinned world is derivable, not banked.
+	if _, err := os.Stat(filepath.Join(d.groupMemberDir("set-abc", "worker-0"), "ip")); !os.IsNotExist(err) {
+		t.Errorf("a member bundle must carry no ip sidecar (pinned world is derivable), stat err=%v", err)
+	}
+	// SnapshotGroupMember does not resume; the caller destroys.
+	if err := d.Release(ctx, h); err != nil {
+		t.Fatalf("Release banked member: %v", err)
+	}
+
+	h2, err := d.RestoreGroupMember(ctx, "set-abc", "worker-0")
+	if err != nil {
+		t.Fatalf("RestoreGroupMember: %v", err)
+	}
+	if h2.ID == "" || h2.ID == h.ID {
+		t.Fatalf("relit member should have a fresh id, got %q (was %q)", h2.ID, h.ID)
+	}
+	if err := d.Release(ctx, h2); err != nil {
+		t.Fatalf("Release relit member: %v", err)
+	}
+
+	if err := d.RemoveGroupMemberBundle("set-abc", "worker-0"); err != nil {
+		t.Fatalf("RemoveGroupMemberBundle: %v", err)
+	}
+	if _, err := d.RestoreGroupMember(ctx, "set-abc", "worker-0"); err == nil {
+		t.Fatal("relight of an evicted member bundle should error")
+	}
+	// Idempotent evict.
+	if err := d.RemoveGroupMemberBundle("set-abc", "worker-0"); err != nil {
+		t.Fatalf("idempotent RemoveGroupMemberBundle: %v", err)
+	}
+}
+
+// TestDriverClaimGroupMemberRequiresTap proves ClaimGroupMember refuses a NIC with
+// no host tap (a member is always on the group bridge).
+func TestDriverClaimGroupMemberRequiresTap(t *testing.T) {
+	d := testDriver(t)
+	if _, err := d.ClaimGroupMember(context.Background(), "/rootfs/x", "/init", 1, 128, substrate.NICSpec{}, nil); err == nil {
+		t.Fatal("ClaimGroupMember without a host tap should error")
+	}
+}
+
+// TestDriverScanGroupBundleSets proves the startup rescan globs group/*/*/snapfile
+// and returns each set with its per-member bundles GROUPED BY set dir, skipping a
+// half-written member (a member dir with no snapfile).
+func TestDriverScanGroupBundleSets(t *testing.T) {
+	ctx := context.Background()
+	d := testDriver(t)
+
+	// Bank two members under one set and one under another.
+	bank := func(setID, member string) {
+		h, err := d.ClaimGroupMember(ctx, "/rootfs/member", "/init", 1, 128,
+			substrate.NICSpec{HostDevName: "emgt-" + member, IP: "10.101.1.10"}, nil)
+		if err != nil {
+			t.Fatalf("ClaimGroupMember %s/%s: %v", setID, member, err)
+		}
+		if _, err := d.SnapshotGroupMember(ctx, h, setID, member); err != nil {
+			t.Fatalf("SnapshotGroupMember %s/%s: %v", setID, member, err)
+		}
+		_ = d.Release(ctx, h)
+	}
+	bank("set-1", "worker-0")
+	bank("set-1", "worker-1")
+	bank("set-2", "leader")
+
+	// A half-written member dir (no snapfile) under set-1 must be skipped.
+	if err := os.MkdirAll(d.groupMemberDir("set-1", "ghost"), 0o700); err != nil {
+		t.Fatalf("mkdir ghost: %v", err)
+	}
+
+	sets := d.ScanGroupBundleSets()
+	if len(sets) != 2 {
+		t.Fatalf("ScanGroupBundleSets found %d sets, want 2: %+v", len(sets), sets)
+	}
+	bySet := map[string][]string{}
+	for _, s := range sets {
+		for _, m := range s.Members {
+			bySet[s.SetID] = append(bySet[s.SetID], m.MemberName)
+			if m.SnapshotRef != filepath.Join("group", s.SetID, m.MemberName) {
+				t.Errorf("member ref = %q want group/%s/%s", m.SnapshotRef, s.SetID, m.MemberName)
+			}
+			if m.SizeBytes == 0 {
+				t.Errorf("member %s/%s reported zero size", s.SetID, m.MemberName)
+			}
+		}
+	}
+	if len(bySet["set-1"]) != 2 {
+		t.Errorf("set-1 members = %v want [worker-0 worker-1] (ghost skipped)", bySet["set-1"])
+	}
+	if len(bySet["set-2"]) != 1 {
+		t.Errorf("set-2 members = %v want [leader]", bySet["set-2"])
 	}
 }

--- a/projects/embervm/noded/fcvm/driver/group_test.go
+++ b/projects/embervm/noded/fcvm/driver/group_test.go
@@ -1,0 +1,105 @@
+package driver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
+)
+
+// TestGroupNetworkRecordRoundTrip asserts a written record is rescanned back
+// verbatim, a removed record disappears, and a fresh node (no dir) scans to nil.
+func TestGroupNetworkRecordRoundTrip(t *testing.T) {
+	d := testDriver(t)
+
+	// Fresh node: no group_networks dir yet, scan yields nil.
+	if got := d.ScanGroupNetworks(); got != nil {
+		t.Errorf("fresh-node scan = %v, want nil", got)
+	}
+
+	recA := substrate.GroupNetworkRecord{
+		GroupInstanceID: "grp-A",
+		BridgeName:      "emgAAAAAA",
+		SubnetCIDR:      "10.101.1.0/24",
+		GatewayIP:       "10.101.1.1",
+		CreatedAtUnixMs: 1700000000000,
+	}
+	recB := substrate.GroupNetworkRecord{
+		GroupInstanceID: "grp-B",
+		BridgeName:      "emgBBBBBB",
+		SubnetCIDR:      "10.101.2.0/24",
+		GatewayIP:       "10.101.2.1",
+		CreatedAtUnixMs: 1700000001000,
+	}
+	if err := d.WriteGroupNetworkRecord(recA); err != nil {
+		t.Fatalf("WriteGroupNetworkRecord(A): %v", err)
+	}
+	if err := d.WriteGroupNetworkRecord(recB); err != nil {
+		t.Fatalf("WriteGroupNetworkRecord(B): %v", err)
+	}
+
+	got := d.ScanGroupNetworks()
+	byID := map[string]substrate.GroupNetworkRecord{}
+	for _, r := range got {
+		byID[r.GroupInstanceID] = r
+	}
+	if len(byID) != 2 {
+		t.Fatalf("scan returned %d records, want 2: %v", len(byID), got)
+	}
+	if byID["grp-A"] != recA {
+		t.Errorf("grp-A round-trip mismatch:\n got %+v\nwant %+v", byID["grp-A"], recA)
+	}
+	if byID["grp-B"] != recB {
+		t.Errorf("grp-B round-trip mismatch:\n got %+v\nwant %+v", byID["grp-B"], recB)
+	}
+
+	// Removing grp-A leaves only grp-B.
+	if err := d.RemoveGroupNetworkRecord("grp-A"); err != nil {
+		t.Fatalf("RemoveGroupNetworkRecord(A): %v", err)
+	}
+	got = d.ScanGroupNetworks()
+	if len(got) != 1 || got[0].GroupInstanceID != "grp-B" {
+		t.Errorf("after removing A, scan = %v", got)
+	}
+	// Removing again is idempotent.
+	if err := d.RemoveGroupNetworkRecord("grp-A"); err != nil {
+		t.Errorf("idempotent remove: %v", err)
+	}
+}
+
+// TestScanGroupNetworksSkipsCorrupt asserts a record dir with no or malformed
+// config.json is skipped, and a body missing the id recovers it from the dir name.
+func TestScanGroupNetworksSkipsCorrupt(t *testing.T) {
+	d := testDriver(t)
+	root := d.GroupNetworksDir()
+
+	// A dir with a malformed config.json is skipped.
+	corrupt := filepath.Join(root, "grp-corrupt")
+	if err := os.MkdirAll(corrupt, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(corrupt, "config.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A dir with NO config.json is skipped.
+	if err := os.MkdirAll(filepath.Join(root, "grp-empty"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// A valid record whose body OMITS the id: recovered from the dir name.
+	noID := filepath.Join(root, "grp-noid")
+	if err := os.MkdirAll(noID, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(noID, "config.json"), []byte(`{"subnetCidr":"10.101.9.0/24"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := d.ScanGroupNetworks()
+	if len(got) != 1 {
+		t.Fatalf("scan = %v, want exactly the recovered grp-noid", got)
+	}
+	if got[0].GroupInstanceID != "grp-noid" || got[0].SubnetCIDR != "10.101.9.0/24" {
+		t.Errorf("id recovery from dir name failed: %+v", got[0])
+	}
+}

--- a/projects/embervm/noded/groupclock/BUILD
+++ b/projects/embervm/noded/groupclock/BUILD
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "groupclock",
+    srcs = [
+        "clock.go",
+        "vsock.go",
+    ],
+    importpath = "github.com/jomcgi/homelab/projects/embervm/noded/groupclock",
+    visibility = ["//projects/embervm/noded:__subpackages__"],
+    deps = ["//projects/embervm/noded/vsockproto"],
+)
+
+go_test(
+    name = "groupclock_test",
+    srcs = ["clock_test.go"],
+    embed = [":groupclock"],
+)

--- a/projects/embervm/noded/groupclock/clock.go
+++ b/projects/embervm/noded/groupclock/clock.go
@@ -1,0 +1,151 @@
+// Package groupclock implements the HOST side of the R5 composite-group
+// clock-resync handshake against a member guest's control agent.
+//
+// A relit member guest resumes from a memory snapshot whose wall clock is frozen at
+// the bank instant, so the daemon must re-set it before the member serves. PR-1
+// froze the contract and PR-2 ships the guest agent: the agent listens on a
+// dedicated vsock port (vsockproto.GroupClockAgentPort, 1024) and speaks
+// LENGTH-PREFIXED JSON FRAMES, a 4-byte big-endian length prefix followed by the
+// JSON body. The request is {"cmd":"sync_clock","epoch_ns":<int64>} and the
+// response is {"clock_realtime_ns":<int64>}: the guest sets CLOCK_REALTIME to the
+// host's epoch_ns and reads it straight back so the host can verify the set landed.
+//
+// This is a DELIBERATELY separate lane from the old task/session HTTP clock resync
+// (server.resyncGuestClock, which POSTs epoch-MILLIS to http://vsock/shim/clock):
+// that path is best-effort and never fails a relight, whereas a member relight FAILS
+// (FAILED_PRECONDITION) when the read-back clock is more than one second off the
+// host's, because a group member with a bad clock is not safe to serve.
+//
+// The frame codec and the clock source are behind small interfaces so the whole
+// verify path is table-tested without a real guest (a fake conn scripting the
+// response frame, a fake now): the guest-side codec in PR-2 is the mirror image and
+// must match this wire format exactly.
+package groupclock
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+// maxClockSkew is the tolerance the read-back clock must fall within: a relight
+// whose guest clock, after the resync, differs from the host's epoch-at-send by more
+// than this fails (FAILED_PRECONDITION). One second is the committed R5 bound.
+const maxClockSkew = time.Second
+
+// maxFrameLen caps a response frame so a misbehaving or hostile guest cannot make
+// the host allocate an unbounded buffer off a giant length prefix. The clock
+// response is a few dozen bytes; 64 KiB is generous headroom while still bounded.
+const maxFrameLen = 64 << 10
+
+// syncClockRequest is the length-prefixed JSON request frame the host writes: the
+// literal command name and the host's wall clock in epoch nanoseconds.
+type syncClockRequest struct {
+	Cmd     string `json:"cmd"`
+	EpochNs int64  `json:"epoch_ns"`
+}
+
+// syncClockResponse is the length-prefixed JSON response frame the guest agent
+// writes back after setting CLOCK_REALTIME: the clock it now reads, in epoch
+// nanoseconds, so the host can verify the set landed within tolerance.
+type syncClockResponse struct {
+	ClockRealtimeNs int64 `json:"clock_realtime_ns"`
+}
+
+// syncClockCmd is the frozen command literal (the guest agent dispatches on it).
+const syncClockCmd = "sync_clock"
+
+// Dialer opens a byte stream to the member guest's clock-agent vsock port. In
+// production a vsockDialer performs the Firecracker CONNECT handshake to
+// GroupClockAgentPort; a test injects a fake returning a scripted conn. Keeping the
+// dial behind this seam is what lets the verify path be exercised without a guest.
+type Dialer interface {
+	// DialClockAgent connects to the member guest's clock agent reachable via the
+	// per-VM vsock UDS at udsPath and returns a raw bidirectional byte stream.
+	DialClockAgent(ctx context.Context, udsPath string) (net.Conn, error)
+}
+
+// Resync performs the sync_clock handshake against the member guest's control agent
+// and verifies the read-back clock is within one second of the host's epoch at send.
+// It dials the clock-agent vsock port, writes the length-prefixed sync_clock request
+// carrying now.UnixNano(), reads the length-prefixed response, and returns an error
+// (with the observed delta) when the read-back exceeds the tolerance. Any transport,
+// framing, or JSON error is returned so the caller fails the relight: unlike the old
+// best-effort HTTP resync, a member relight must not proceed on an unverified clock.
+func Resync(ctx context.Context, dialer Dialer, udsPath string, now func() time.Time) error {
+	conn, err := dialer.DialClockAgent(ctx, udsPath)
+	if err != nil {
+		return fmt.Errorf("groupclock: dial clock agent: %w", err)
+	}
+	defer conn.Close()
+	if dl, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(dl)
+	}
+
+	hostEpochNs := now().UnixNano()
+	if err := writeFrame(conn, syncClockRequest{Cmd: syncClockCmd, EpochNs: hostEpochNs}); err != nil {
+		return fmt.Errorf("groupclock: write sync_clock request: %w", err)
+	}
+
+	var resp syncClockResponse
+	if err := readFrame(conn, &resp); err != nil {
+		return fmt.Errorf("groupclock: read sync_clock response: %w", err)
+	}
+
+	delta := time.Duration(resp.ClockRealtimeNs-hostEpochNs) * time.Nanosecond
+	if delta < 0 {
+		delta = -delta
+	}
+	if delta > maxClockSkew {
+		return fmt.Errorf("groupclock: guest clock read-back %v off host (limit %v)", delta, maxClockSkew)
+	}
+	return nil
+}
+
+// writeFrame encodes v as JSON and writes it prefixed with a 4-byte big-endian
+// length, the frozen wire format. It is exported-shaped (a small pure helper) so the
+// codec is table-tested against readFrame round-trips.
+func writeFrame(w io.Writer, v any) error {
+	body, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("groupclock: marshal frame: %w", err)
+	}
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(body)))
+	if _, err := w.Write(lenBuf[:]); err != nil {
+		return fmt.Errorf("groupclock: write frame length: %w", err)
+	}
+	if _, err := w.Write(body); err != nil {
+		return fmt.Errorf("groupclock: write frame body: %w", err)
+	}
+	return nil
+}
+
+// readFrame reads a 4-byte big-endian length prefix, then that many body bytes, and
+// unmarshals the JSON body into v. A length past maxFrameLen is refused so a bad
+// prefix cannot force an unbounded allocation.
+func readFrame(r io.Reader, v any) error {
+	var lenBuf [4]byte
+	if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
+		return fmt.Errorf("groupclock: read frame length: %w", err)
+	}
+	n := binary.BigEndian.Uint32(lenBuf[:])
+	if n == 0 {
+		return fmt.Errorf("groupclock: empty frame")
+	}
+	if n > maxFrameLen {
+		return fmt.Errorf("groupclock: frame length %d exceeds cap %d", n, maxFrameLen)
+	}
+	body := make([]byte, n)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return fmt.Errorf("groupclock: read frame body: %w", err)
+	}
+	if err := json.Unmarshal(body, v); err != nil {
+		return fmt.Errorf("groupclock: unmarshal frame: %w", err)
+	}
+	return nil
+}

--- a/projects/embervm/noded/groupclock/clock_test.go
+++ b/projects/embervm/noded/groupclock/clock_test.go
@@ -1,0 +1,164 @@
+package groupclock
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// fakeConn is a net.Conn whose reads drain a scripted buffer and whose writes are
+// captured, so a test can assert the request frame the host sent and script the
+// response frame the "guest" returns. Deadlines are recorded but not enforced.
+type fakeConn struct {
+	readBuf  *bytes.Reader
+	writeBuf bytes.Buffer
+	closed   bool
+	readErr  error
+}
+
+func (c *fakeConn) Read(p []byte) (int, error) {
+	if c.readErr != nil {
+		return 0, c.readErr
+	}
+	return c.readBuf.Read(p)
+}
+func (c *fakeConn) Write(p []byte) (int, error)      { return c.writeBuf.Write(p) }
+func (c *fakeConn) Close() error                     { c.closed = true; return nil }
+func (c *fakeConn) LocalAddr() net.Addr              { return nil }
+func (c *fakeConn) RemoteAddr() net.Addr             { return nil }
+func (c *fakeConn) SetDeadline(time.Time) error      { return nil }
+func (c *fakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *fakeConn) SetWriteDeadline(time.Time) error { return nil }
+
+// fakeDialer returns a scripted fakeConn (or a dial error).
+type fakeDialer struct {
+	conn    *fakeConn
+	dialErr error
+}
+
+func (d *fakeDialer) DialClockAgent(context.Context, string) (net.Conn, error) {
+	if d.dialErr != nil {
+		return nil, d.dialErr
+	}
+	return d.conn, nil
+}
+
+// frameOf encodes v as the length-prefixed JSON wire frame the guest agent would
+// return, so a test can script a response.
+func frameOf(t *testing.T, v any) []byte {
+	t.Helper()
+	body, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var buf bytes.Buffer
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(body)))
+	buf.Write(lenBuf[:])
+	buf.Write(body)
+	return buf.Bytes()
+}
+
+// TestFrameRoundTrip proves writeFrame and readFrame agree on the wire format (a
+// 4-byte big-endian length prefix + JSON body), the same format the guest mirrors.
+func TestFrameRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	req := syncClockRequest{Cmd: syncClockCmd, EpochNs: 1234567890}
+	if err := writeFrame(&buf, req); err != nil {
+		t.Fatalf("writeFrame: %v", err)
+	}
+	// The first four bytes are the big-endian length of the JSON body.
+	raw := buf.Bytes()
+	n := binary.BigEndian.Uint32(raw[:4])
+	if int(n) != len(raw)-4 {
+		t.Errorf("length prefix %d does not match body length %d", n, len(raw)-4)
+	}
+	var got syncClockRequest
+	if err := readFrame(bytes.NewReader(raw), &got); err != nil {
+		t.Fatalf("readFrame: %v", err)
+	}
+	if got.Cmd != "sync_clock" || got.EpochNs != 1234567890 {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+}
+
+// TestResyncSuccess proves a guest that echoes a clock within one second verifies,
+// and that the host sent the frozen sync_clock request carrying its epoch_ns.
+func TestResyncSuccess(t *testing.T) {
+	now := time.Unix(1_700_000_000, 500)
+	// Guest returns a clock 200ms ahead: within the one-second tolerance.
+	resp := syncClockResponse{ClockRealtimeNs: now.UnixNano() + int64(200*time.Millisecond)}
+	conn := &fakeConn{readBuf: bytes.NewReader(frameOf(t, resp))}
+	dialer := &fakeDialer{conn: conn}
+
+	if err := Resync(context.Background(), dialer, "/uds", func() time.Time { return now }); err != nil {
+		t.Fatalf("Resync should succeed within tolerance: %v", err)
+	}
+	// Assert the request frame the host wrote: length prefix + {"cmd":"sync_clock",...}.
+	written := conn.writeBuf.Bytes()
+	var sent syncClockRequest
+	if err := readFrame(bytes.NewReader(written), &sent); err != nil {
+		t.Fatalf("decode host request frame: %v", err)
+	}
+	if sent.Cmd != "sync_clock" {
+		t.Errorf("host sent cmd %q want sync_clock", sent.Cmd)
+	}
+	if sent.EpochNs != now.UnixNano() {
+		t.Errorf("host sent epoch_ns %d want %d (epoch NANOS, not millis)", sent.EpochNs, now.UnixNano())
+	}
+	if !conn.closed {
+		t.Error("Resync should close the conn")
+	}
+}
+
+// TestResyncFailsWhenClockTooFarOff proves a read-back more than one second off the
+// host's epoch fails the call, with the delta surfaced in the error.
+func TestResyncFailsWhenClockTooFarOff(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	// Guest returns a clock 3 seconds behind: outside the one-second tolerance.
+	resp := syncClockResponse{ClockRealtimeNs: now.UnixNano() - int64(3*time.Second)}
+	conn := &fakeConn{readBuf: bytes.NewReader(frameOf(t, resp))}
+	dialer := &fakeDialer{conn: conn}
+
+	err := Resync(context.Background(), dialer, "/uds", func() time.Time { return now })
+	if err == nil {
+		t.Fatal("Resync should fail when the read-back clock is more than 1s off")
+	}
+}
+
+// TestResyncDialError proves a dial failure surfaces as an error (fails the relight).
+func TestResyncDialError(t *testing.T) {
+	dialer := &fakeDialer{dialErr: errors.New("connection refused")}
+	err := Resync(context.Background(), dialer, "/uds", time.Now)
+	if err == nil {
+		t.Fatal("a dial error must fail Resync")
+	}
+}
+
+// TestResyncReadError proves a transport/framing read error (the timeout / no-agent
+// case) surfaces as an error rather than silently passing.
+func TestResyncReadError(t *testing.T) {
+	conn := &fakeConn{readBuf: bytes.NewReader(nil), readErr: io.ErrUnexpectedEOF}
+	dialer := &fakeDialer{conn: conn}
+	err := Resync(context.Background(), dialer, "/uds", time.Now)
+	if err == nil {
+		t.Fatal("a read error (no response frame) must fail Resync")
+	}
+}
+
+// TestReadFrameRejectsOversizeLength proves a bogus giant length prefix is refused
+// rather than triggering an unbounded allocation.
+func TestReadFrameRejectsOversizeLength(t *testing.T) {
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], maxFrameLen+1)
+	var got syncClockResponse
+	if err := readFrame(bytes.NewReader(lenBuf[:]), &got); err == nil {
+		t.Fatal("readFrame should reject a length past the cap")
+	}
+}

--- a/projects/embervm/noded/groupclock/vsock.go
+++ b/projects/embervm/noded/groupclock/vsock.go
@@ -1,0 +1,63 @@
+package groupclock
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/vsockproto"
+)
+
+// VsockDialer performs the Firecracker host-initiated vsock CONNECT handshake to a
+// member guest's clock-agent port (vsockproto.GroupClockAgentPort) and returns the
+// raw byte stream, exactly the handshake vsockhttp.Transport uses for the guest HTTP
+// port but targeting port 1024 and yielding a plain stream (not an HTTP transport,
+// because the clock agent speaks length-prefixed JSON frames, not HTTP). Firecracker
+// maps vsock ports to per-VM UDS paths on the host: the host dials the base UDS,
+// writes "CONNECT <port>\n", and the device layer replies "OK <port>\n" before it
+// routes the connection to the guest listener.
+type VsockDialer struct{}
+
+var _ Dialer = VsockDialer{}
+
+// DialClockAgent dials the per-VM vsock UDS at udsPath and performs the CONNECT
+// handshake for GroupClockAgentPort, returning the connection ready to carry the
+// length-prefixed clock frames. Any bytes the handshake reader pre-buffered past the
+// OK line are preserved by wrapping the conn (a clock response can, in principle,
+// arrive coalesced with the OK line on the same read).
+func (VsockDialer) DialClockAgent(ctx context.Context, udsPath string) (net.Conn, error) {
+	d := &net.Dialer{}
+	conn, err := d.DialContext(ctx, "unix", udsPath)
+	if err != nil {
+		return nil, fmt.Errorf("groupclock: dial uds %s: %w", udsPath, err)
+	}
+	if dl, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(dl)
+	}
+	if _, err := fmt.Fprintf(conn, "CONNECT %d\n", vsockproto.GroupClockAgentPort); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("groupclock: write CONNECT: %w", err)
+	}
+	br := bufio.NewReader(conn)
+	status, err := br.ReadString('\n')
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("groupclock: read CONNECT reply: %w", err)
+	}
+	if !strings.HasPrefix(status, "OK") {
+		_ = conn.Close()
+		return nil, fmt.Errorf("groupclock: clock agent port not reachable: %q", strings.TrimSpace(status))
+	}
+	return &bufConn{Conn: conn, r: br}, nil
+}
+
+// bufConn serves bytes the CONNECT-handshake reader buffered past the OK line before
+// falling through to the underlying conn, so a coalesced response frame is not lost.
+type bufConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func (b *bufConn) Read(p []byte) (int, error) { return b.r.Read(p) }

--- a/projects/embervm/noded/server/BUILD
+++ b/projects/embervm/noded/server/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "server",
     srcs = [
         "group.go",
+        "group_member.go",
         "group_registry.go",
         "registry.go",
         "server.go",
@@ -16,6 +17,7 @@ go_library(
     visibility = ["//projects/embervm/noded:__subpackages__"],
     deps = [
         "//projects/embervm/noded/config",
+        "//projects/embervm/noded/groupclock",
         "//projects/embervm/noded/serving",
         "//projects/embervm/noded/substrate",
         "//projects/embervm/noded/volume",
@@ -30,6 +32,7 @@ go_library(
 go_test(
     name = "server_test",
     srcs = [
+        "group_member_test.go",
         "group_test.go",
         "server_test.go",
         "serving_test.go",

--- a/projects/embervm/noded/server/BUILD
+++ b/projects/embervm/noded/server/BUILD
@@ -3,6 +3,8 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "server",
     srcs = [
+        "group.go",
+        "group_registry.go",
         "registry.go",
         "server.go",
         "serving.go",
@@ -28,6 +30,7 @@ go_library(
 go_test(
     name = "server_test",
     srcs = [
+        "group_test.go",
         "server_test.go",
         "serving_test.go",
         "stateful_test.go",
@@ -35,6 +38,7 @@ go_test(
     embed = [":server"],
     deps = [
         "//projects/embervm/noded/config",
+        "//projects/embervm/noded/serving",
         "//projects/embervm/noded/substrate",
         "//projects/embervm/noded/volume",
         "//projects/embervm/proto/embervm/node/v1:nodev1",

--- a/projects/embervm/noded/server/group.go
+++ b/projects/embervm/noded/server/group.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"os"
+	"sort"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -176,10 +177,99 @@ func (s *Server) groupNetworksStatus() []*nodev1.GroupNetwork {
 	return out
 }
 
+// ReconcileGroupBundlesFromDisk scans the group/ bundle dir (via the driver's
+// ScanGroupBundleSets) and re-seeds the banked-group-bundle inventory so a restarted
+// daemon reports what banked group warmth survives, GROUPED BY set. A daemon restart
+// kills every LIVE member (they died with the pod, the standing single-node
+// availability posture); only the on-disk bundle sets survive, and the control plane
+// resolves each group to relightable (a complete set) or fresh-bootable from these
+// reports (the daemon makes NO completeness judgment). A member bundle carries no
+// group_instance_id on disk (the set dir names only the set_id + member), so the
+// group binding is left empty for the control plane to rebind by adoption.
+func (s *Server) ReconcileGroupBundlesFromDisk() {
+	if s.groupDriver == nil {
+		return
+	}
+	root := s.groupDriver.GroupSetsDir()
+	if root != "" {
+		if err := os.MkdirAll(root, 0o700); err != nil {
+			s.logger.Warn("noded: create group bundle dir", "root", root, "err", err)
+		} else if err := os.Chmod(root, 0o700); err != nil {
+			s.logger.Warn("noded: chmod group bundle dir 0700", "root", root, "err", err)
+		}
+	}
+	sets := s.groupDriver.ScanGroupBundleSets()
+	seeded := 0
+	for _, set := range sets {
+		for _, m := range set.Members {
+			s.groupBundles.add(groupBundleEntry{
+				setID:           set.SetID,
+				memberName:      m.MemberName,
+				snapshotRef:     m.SnapshotRef,
+				sizeBytes:       m.SizeBytes,
+				createdAtUnixMs: set.CreatedAtUnixMs,
+			})
+			seeded++
+		}
+	}
+	if seeded > 0 {
+		s.logger.Info("noded: reconciled existing group bundle sets", "sets", len(sets), "members", seeded)
+		s.signalChange()
+	}
+}
+
+// groupBundleSetsStatus projects the banked-group-bundle inventory into
+// NodeStatus.group_bundle_sets, grouping the per-member bundles by their set_id. The
+// daemon reports refs grouped by the set dir it wrote them under and makes NO
+// completeness judgment (whether a set has every member it needs to relight is the
+// control plane's to decide).
+func (s *Server) groupBundleSetsStatus() []*nodev1.GroupBundleSet {
+	if s.groupBundles == nil {
+		return nil
+	}
+	entries := s.groupBundles.snapshot()
+	// Group by set_id, preserving each set's group binding + created time.
+	type setAgg struct {
+		groupInstanceID string
+		createdAtUnixMs int64
+		members         []*nodev1.GroupBundleMember
+	}
+	bySet := make(map[string]*setAgg)
+	for _, e := range entries {
+		agg, ok := bySet[e.setID]
+		if !ok {
+			agg = &setAgg{}
+			bySet[e.setID] = agg
+		}
+		if e.groupInstanceID != "" {
+			agg.groupInstanceID = e.groupInstanceID
+		}
+		if e.createdAtUnixMs > agg.createdAtUnixMs {
+			agg.createdAtUnixMs = e.createdAtUnixMs
+		}
+		agg.members = append(agg.members, &nodev1.GroupBundleMember{
+			MemberName:  e.memberName,
+			SnapshotRef: e.snapshotRef,
+			SizeBytes:   uint64(e.sizeBytes),
+		})
+	}
+	out := make([]*nodev1.GroupBundleSet, 0, len(bySet))
+	for setID, agg := range bySet {
+		sort.Slice(agg.members, func(i, j int) bool { return agg.members[i].GetMemberName() < agg.members[j].GetMemberName() })
+		out = append(out, &nodev1.GroupBundleSet{
+			SetId:           setID,
+			GroupInstanceId: agg.groupInstanceID,
+			Members:         agg.members,
+			CreatedAtUnixMs: agg.createdAtUnixMs,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].GetSetId() < out[j].GetSetId() })
+	return out
+}
+
 // groupMemberVmsStatus projects the live group-member registry into
-// NodeStatus.group_member_vms. Empty in Task 4 (no live members yet); Task 5's
-// StartGroupMember fills the registry and this reports each member's group
-// identity and TCP-connect health verdict.
+// NodeStatus.group_member_vms, reporting each member's group identity and TCP-connect
+// health verdict.
 func (s *Server) groupMemberVmsStatus() []*nodev1.GroupMemberVm {
 	if s.groupMembers == nil {
 		return nil

--- a/projects/embervm/noded/server/group.go
+++ b/projects/embervm/noded/server/group.go
@@ -1,0 +1,200 @@
+package server
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
+)
+
+// CreateGroupNetwork stands up the per-group bridge for group_instance_id on the
+// control-plane-assigned /24, installs the inter-group isolation posture (the
+// composite<->composite and composite->serving forward DROPs, in the dedicated
+// embervm_group table so they never collide with serving_dnat/forward), writes
+// the durable on-disk record, and returns (bridge_name, gateway_ip). It is
+// IDEMPOTENT per group_instance_id (D-R3.11.4): a re-issue for the same group with
+// the same cidr returns the existing bridge without disturbing it, so the control
+// plane can safely re-issue before a relight or an adoption-time rebind. A cidr
+// that is not a /24 within the supernet, or that overlaps a DIFFERENT group's /24,
+// is refused FAILED_PRECONDITION per the proto.
+func (s *Server) CreateGroupNetwork(ctx context.Context, req *nodev1.CreateGroupNetworkRequest) (*nodev1.CreateGroupNetworkResponse, error) {
+	if s.groupNet == nil {
+		return nil, status.Error(codes.Unimplemented, "noded: group networking not configured")
+	}
+	if s.isDraining() {
+		return nil, status.Error(codes.Unavailable, "noded: draining")
+	}
+	groupInstanceID := req.GetGroupInstanceId()
+	if groupInstanceID == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: group_instance_id required")
+	}
+	cidr := req.GetCidr()
+	if cidr == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: cidr required")
+	}
+
+	bridge, gatewayIP, err := s.groupNet.CreateGroupNetwork(ctx, groupInstanceID, cidr)
+	if err != nil {
+		// A validation/overlap failure is a client-side precondition (bad or
+		// colliding cidr), mapped to FAILED_PRECONDITION per the proto.
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: create group network %q: %v", groupInstanceID, err)
+	}
+
+	// Persist the durable on-disk record. The bridge dies with the pod; this record
+	// is what a restart rescans (and what the control plane re-issues against). A
+	// write failure tears the just-created bridge back down so we never advertise a
+	// group whose durable truth was not recorded (a rescan would then not rebuild
+	// it, an inconsistency worse than failing the create).
+	if s.groupRecords != nil {
+		rec := substrate.GroupNetworkRecord{
+			GroupInstanceID: groupInstanceID,
+			BridgeName:      bridge,
+			SubnetCIDR:      cidr,
+			GatewayIP:       gatewayIP,
+			CreatedAtUnixMs: time.Now().UnixMilli(),
+		}
+		if werr := s.groupRecords.WriteGroupNetworkRecord(rec); werr != nil {
+			_ = s.groupNet.DeleteGroupNetwork(ctx, groupInstanceID)
+			return nil, status.Errorf(codes.Internal, "noded: persist group network record for %q: %v", groupInstanceID, werr)
+		}
+	}
+
+	s.signalChange()
+	return &nodev1.CreateGroupNetworkResponse{
+		BridgeName: bridge,
+		GatewayIp:  gatewayIP,
+	}, nil
+}
+
+// DeleteGroupNetwork tears the group bridge, its nftables rules, and its on-disk
+// record down. It REFUSES FAILED_PRECONDITION when any live member VM is still
+// attached to the group (deleting the bridge would yank a live member's NIC); the
+// control plane must stop every member first. It is otherwise idempotent: deleting
+// an unknown group returns OK (the desired end-state already holds).
+func (s *Server) DeleteGroupNetwork(ctx context.Context, req *nodev1.DeleteGroupNetworkRequest) (*nodev1.DeleteGroupNetworkResponse, error) {
+	if s.groupNet == nil {
+		return nil, status.Error(codes.Unimplemented, "noded: group networking not configured")
+	}
+	groupInstanceID := req.GetGroupInstanceId()
+	if groupInstanceID == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: group_instance_id required")
+	}
+
+	// Idempotent no-op on an unknown group (never held or already deleted).
+	if !s.groupNet.Has(groupInstanceID) {
+		// Still remove any stray record so a half-deleted group cannot be re-adopted.
+		if s.groupRecords != nil {
+			_ = s.groupRecords.RemoveGroupNetworkRecord(groupInstanceID)
+		}
+		return &nodev1.DeleteGroupNetworkResponse{}, nil
+	}
+
+	// Attached-member refusal: a live member on this group's bridge blocks the
+	// delete. The registry is filled by Task 5's StartGroupMember; in Task 4 it is
+	// empty, so this never fires yet, but the guard is wired now so Task 5's members
+	// are protected the moment they exist.
+	if s.groupMembers.hasMembers(groupInstanceID) {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: group %q has %d live member(s) still attached; stop them before deleting the network", groupInstanceID, s.groupMembers.memberCount(groupInstanceID))
+	}
+
+	if err := s.groupNet.DeleteGroupNetwork(ctx, groupInstanceID); err != nil {
+		return nil, status.Errorf(codes.Internal, "noded: delete group network %q: %v", groupInstanceID, err)
+	}
+	// Remove the durable record LAST: the bridge is gone, so a rescan must not
+	// re-seed this group. Best-effort (the network is already torn down; a stale
+	// record only re-adopts a dead group, which the control plane reconciles).
+	if s.groupRecords != nil {
+		if rerr := s.groupRecords.RemoveGroupNetworkRecord(groupInstanceID); rerr != nil {
+			s.logger.Warn("noded: remove group network record", "group", groupInstanceID, "err", rerr)
+		}
+	}
+	s.signalChange()
+	return &nodev1.DeleteGroupNetworkResponse{}, nil
+}
+
+// ReconcileGroupNetworksFromDisk scans the group_networks/ record dir (via the
+// driver's ScanGroupNetworks) and re-seeds the group-network manager so a
+// restarted daemon reports what group networks the durable records describe, and
+// EnsureNetwork rebuilds the isolation table over them. The BRIDGES themselves do
+// NOT survive a restart (they died in the prior pod's netns, D-R3.11.4), so the
+// control plane re-issues an idempotent CreateGroupNetwork to rebuild each bridge
+// (Task 7 sequences this); this rescan is purely the durable-truth re-seed that
+// makes NodeStatus.group_networks reflect the surviving records. A malformed
+// record is skipped and logged.
+func (s *Server) ReconcileGroupNetworksFromDisk() {
+	if s.groupNet == nil || s.groupRecords == nil {
+		return
+	}
+	root := s.groupRecords.GroupNetworksDir()
+	if root != "" {
+		if err := os.MkdirAll(root, 0o700); err != nil {
+			s.logger.Warn("noded: create group networks dir", "root", root, "err", err)
+		} else if err := os.Chmod(root, 0o700); err != nil {
+			s.logger.Warn("noded: chmod group networks dir 0700", "root", root, "err", err)
+		}
+	}
+	records := s.groupRecords.ScanGroupNetworks()
+	seeded := 0
+	for _, rec := range records {
+		if err := s.groupNet.AdoptGroupNetwork(rec.GroupInstanceID, rec.SubnetCIDR, rec.CreatedAtUnixMs); err != nil {
+			s.logger.Warn("noded: adopt group network record", "group", rec.GroupInstanceID, "err", err)
+			continue
+		}
+		seeded++
+	}
+	if seeded > 0 {
+		s.logger.Info("noded: reconciled existing group networks", "count", seeded)
+		s.signalChange()
+	}
+}
+
+// groupNetworksStatus projects the held group-network inventory into
+// NodeStatus.group_networks, stamping each with the live member_count (0 until
+// Task 5 fills the member registry). Reported so a restarted control plane
+// reconciles group networks from node truth and the DeleteGroupNetwork backstop
+// has a member count to read.
+func (s *Server) groupNetworksStatus() []*nodev1.GroupNetwork {
+	if s.groupNet == nil {
+		return nil
+	}
+	nets := s.groupNet.List()
+	out := make([]*nodev1.GroupNetwork, 0, len(nets))
+	for _, n := range nets {
+		out = append(out, &nodev1.GroupNetwork{
+			GroupInstanceId: n.GroupInstanceID,
+			Cidr:            n.CIDR,
+			Bridge:          n.Bridge,
+			MemberCount:     uint32(s.groupMembers.memberCount(n.GroupInstanceID)),
+		})
+	}
+	return out
+}
+
+// groupMemberVmsStatus projects the live group-member registry into
+// NodeStatus.group_member_vms. Empty in Task 4 (no live members yet); Task 5's
+// StartGroupMember fills the registry and this reports each member's group
+// identity and TCP-connect health verdict.
+func (s *Server) groupMemberVmsStatus() []*nodev1.GroupMemberVm {
+	if s.groupMembers == nil {
+		return nil
+	}
+	live := s.groupMembers.snapshot()
+	out := make([]*nodev1.GroupMemberVm, 0, len(live))
+	for _, e := range live {
+		out = append(out, &nodev1.GroupMemberVm{
+			VmId:            e.vmID,
+			GroupInstanceId: e.groupInstanceID,
+			MemberName:      e.memberName,
+			Ip:              e.ip,
+			Healthy:         e.healthy,
+			LastProbeUnixMs: e.lastProbeUnixMs,
+		})
+	}
+	return out
+}

--- a/projects/embervm/noded/server/group_member.go
+++ b/projects/embervm/noded/server/group_member.go
@@ -1,0 +1,375 @@
+package server
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/groupclock"
+	"github.com/jomcgi/homelab/projects/embervm/noded/serving"
+	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
+)
+
+// realGroupClock is the production groupClock: it resyncs a relit member guest's
+// wall clock over the port-1024 length-prefixed JSON agent channel (the frozen R5
+// contract) using the host wall clock, and verifies the read-back within one second.
+// It wraps groupclock.Resync with a real VsockDialer; tests inject a fake groupClock
+// instead so the resync path is exercised without a guest.
+type realGroupClock struct{}
+
+func (realGroupClock) Resync(ctx context.Context, udsPath string) error {
+	return groupclock.Resync(ctx, groupclock.VsockDialer{}, udsPath, time.Now)
+}
+
+// StartGroupMember boots (FRESH) or resumes (RELIGHT) exactly one composite-group
+// member on its group bridge. FRESH cold-boots the member's image rootfs on the
+// pinned tap with its first-boot env delivered via the MMDS-lite boot-args seam
+// (env is FRESH-only) and TCP-health-gates {ip, health_port}. RELIGHT recreates the
+// member's pinned tap world (same tap name + MAC + IP the member had at bank time,
+// the D-R3.4.1 pin on the group bridge), resumes the banked bundle, runs the
+// clock-resync handshake against the guest control agent over vsock port 1024, fails
+// the call (FAILED_PRECONDITION, with the delta in the error) when the read-back
+// clock is more than one second off, and only then TCP-health-gates. A member VM
+// counts against max_live_vms and is EXCLUDED from primed_vm_ids.
+func (s *Server) StartGroupMember(ctx context.Context, req *nodev1.StartGroupMemberRequest) (*nodev1.StartGroupMemberResponse, error) {
+	if s.groupNet == nil || s.groupDriver == nil {
+		return nil, status.Error(codes.Unimplemented, "noded: group member lifecycle not configured")
+	}
+	if s.isDraining() {
+		return nil, status.Error(codes.Unavailable, "noded: draining")
+	}
+	if s.cfg.MaxLiveVMs > 0 && s.liveVMCount() >= s.cfg.MaxLiveVMs {
+		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.cfg.MaxLiveVMs)
+	}
+	groupInstanceID := req.GetGroupInstanceId()
+	if groupInstanceID == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: group_instance_id required")
+	}
+	if !s.groupNet.Has(groupInstanceID) {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: group network %q does not exist on this node", groupInstanceID)
+	}
+	memberName := req.GetMemberName()
+	if memberName == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: member_name required")
+	}
+	healthPort := req.GetHealthPort()
+	if healthPort == 0 {
+		return nil, status.Error(codes.InvalidArgument, "noded: health_port required")
+	}
+	pinnedIP := net.ParseIP(req.GetIp())
+	if pinnedIP == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "noded: ip %q is not a valid address", req.GetIp())
+	}
+
+	switch req.GetMode() {
+	case nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_FRESH:
+		return s.startGroupMemberFresh(ctx, req, groupInstanceID, memberName, pinnedIP, healthPort)
+	case nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_RELIGHT:
+		return s.startGroupMemberRelight(ctx, req, groupInstanceID, memberName, pinnedIP, healthPort)
+	default:
+		return nil, status.Error(codes.InvalidArgument, "noded: StartGroupMember mode must be FRESH or RELIGHT")
+	}
+}
+
+// startGroupMemberFresh cold-boots a member from its image source on the pinned tap.
+// It resolves the FRESH source (a built base + its runtime image, exactly like a
+// stateful boot_image_ref: a NIC cold boot cannot resume a vsock-only base memory
+// snapshot, D-R3.4.2), pins the member tap on the group bridge, cold-boots with the
+// first-boot env carried, and health-gates {ip, health_port}. A readiness failure
+// reaps the VM and removes the tap.
+func (s *Server) startGroupMemberFresh(ctx context.Context, req *nodev1.StartGroupMemberRequest, groupInstanceID, memberName string, pinnedIP net.IP, healthPort uint32) (*nodev1.StartGroupMemberResponse, error) {
+	source := req.GetSource()
+	if source == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: source required for FRESH")
+	}
+	rootfsPath, harnessInit, err := s.resolveGroupMemberBoot(source)
+	if err != nil {
+		return nil, err
+	}
+
+	tap, ip, err := s.pinGroupMemberTap(ctx, groupInstanceID, memberName, req.GetMemberIndex(), pinnedIP)
+	if err != nil {
+		return nil, err
+	}
+
+	res := req.GetResources()
+	nic := substrate.NICSpec{
+		HostDevName: tap,
+		GuestMAC:    s.groupMemberMAC(groupInstanceID, memberName, req.GetMemberIndex()),
+		IP:          ip.String(),
+		GatewayIP:   s.groupNet.GatewayIP(groupInstanceID).String(),
+		PrefixLen:   s.groupNet.PrefixLen(groupInstanceID),
+		IfaceName:   "eth0",
+		ServingPort: healthPort,
+	}
+	// MMDS-lite (D-R4.PR-7.1): env rides a FRESH cold boot ONLY; a RELIGHT never
+	// reaches this path (it resumes a memory snapshot), so env cannot leak onto a
+	// relight by construction. SECURITY: log only key names, never values (env may
+	// carry a first-boot secret), mirroring the stateful path.
+	env := req.GetEnv()
+	if len(env) > 0 {
+		s.logger.Info("noded: group member fresh boot carrying env", "group", groupInstanceID, "member", memberName, "keys", mmdsEnvKeyNamesSorted(env))
+	}
+	h, err := s.groupDriver.ClaimGroupMember(ctx, rootfsPath, harnessInit, int(res.GetVcpus()), int(res.GetMemMib()), nic, env)
+	if err != nil {
+		s.groupNet.RemoveMemberTap(ctx, groupInstanceID, tap, ip)
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: cold-boot group member: %v", err)
+	}
+	return s.finishGroupMemberStart(ctx, h, groupInstanceID, memberName, req.GetMemberIndex(), tap, ip, healthPort, false, s.cfg.BootReadyTimeout)
+}
+
+// startGroupMemberRelight recreates the member's pinned tap world, resumes the banked
+// bundle, runs the clock-resync handshake (failing the call if the read-back clock is
+// off by more than one second), and health-gates. The bundle is resolved from the
+// snapshot_ref (group/<set_id>/<member_name>): the ref names the set and member, so
+// the daemon re-derives the bundle path from it. On a failed restore the bundle is
+// NEVER deleted (a lost member surfaces loudly).
+func (s *Server) startGroupMemberRelight(ctx context.Context, req *nodev1.StartGroupMemberRequest, groupInstanceID, memberName string, pinnedIP net.IP, healthPort uint32) (*nodev1.StartGroupMemberResponse, error) {
+	ref := req.GetSnapshotRef()
+	if ref == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: snapshot_ref required for RELIGHT")
+	}
+	setID, refMember, ok := parseGroupMemberRef(ref)
+	if !ok {
+		return nil, status.Errorf(codes.InvalidArgument, "noded: snapshot_ref %q is not a group/<set_id>/<member> ref", ref)
+	}
+	if refMember != memberName {
+		return nil, status.Errorf(codes.InvalidArgument, "noded: snapshot_ref %q member %q does not match request member %q", ref, refMember, memberName)
+	}
+
+	// Recreate the pinned world FIRST (same tap name + MAC + IP), because the resumed
+	// guest keeps its baked eth0 and a snapshot restore never re-runs kernel init:
+	// the tap MUST exist before the resume or the guest's NIC black-holes.
+	tap, ip, err := s.pinGroupMemberTap(ctx, groupInstanceID, memberName, req.GetMemberIndex(), pinnedIP)
+	if err != nil {
+		return nil, err
+	}
+	h, err := s.groupDriver.RestoreGroupMember(ctx, setID, memberName)
+	if err != nil {
+		s.groupNet.RemoveMemberTap(ctx, groupInstanceID, tap, ip)
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: relight group member %q: %v", ref, err)
+	}
+
+	// Clock resync BEFORE the health gate: a bad clock must fail the relight early,
+	// over the port-1024 length-prefixed JSON agent channel (NOT the old HTTP
+	// /shim/clock path). A read-back more than one second off fails the call.
+	uds := s.driver.VsockUDSPath(h.ThreadID)
+	clockCtx, cancelClock := context.WithTimeout(ctx, s.cfg.RestoreReadyTimeout)
+	clockErr := s.groupClock.Resync(clockCtx, uds)
+	cancelClock()
+	if clockErr != nil {
+		s.reapGroupMember(h, groupInstanceID, tap, ip)
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: group member %q clock resync failed: %v", ref, clockErr)
+	}
+
+	return s.finishGroupMemberStart(ctx, h, groupInstanceID, memberName, req.GetMemberIndex(), tap, ip, healthPort, true, s.cfg.RestoreReadyTimeout)
+}
+
+// finishGroupMemberStart is the shared tail of both member start paths: TCP-health-
+// gate {ip, health_port}, register the live member, and start its probe. On a
+// readiness failure it reaps the VM and removes the tap, returning
+// FAILED_PRECONDITION (no half-alive member is ever published).
+func (s *Server) finishGroupMemberStart(ctx context.Context, h substrate.Handle, groupInstanceID, memberName string, memberIndex uint32, tap string, ip net.IP, healthPort uint32, wasRelight bool, readyBudget time.Duration) (*nodev1.StartGroupMemberResponse, error) {
+	if err := s.waitStatefulReady(ctx, ip, healthPort, readyBudget); err != nil {
+		s.reapGroupMember(h, groupInstanceID, tap, ip)
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: group member not ready over tap: %v", err)
+	}
+	probe := serving.StartTCPProbe(s.newGroupTCPProber(), ip, healthPort)
+	s.groupMembers.add(&groupMemberEntry{
+		vmID:            h.ID,
+		groupInstanceID: groupInstanceID,
+		memberName:      memberName,
+		memberIndex:     memberIndex,
+		ip:              ip,
+		tap:             tap,
+		port:            healthPort,
+		handle:          h,
+		probe:           probe,
+	})
+	s.signalChange()
+	return &nodev1.StartGroupMemberResponse{
+		VmId:       h.ID,
+		Ip:         ip.String(),
+		WasRelight: wasRelight,
+	}, nil
+}
+
+// StopGroupMember tears down one live member VM. BANK pauses it, snapshots it under
+// group/<set_id>/<member_name>/, records the banked bundle, destroys the VM, and
+// returns {snapshot_ref, size_bytes}. DESTROY tears the VM down with no snapshot.
+// Either mode removes the member tap and releases its pinned IP. A concurrent stop
+// on the same vm_id is refused FAILED_PRECONDITION.
+func (s *Server) StopGroupMember(ctx context.Context, req *nodev1.StopGroupMemberRequest) (*nodev1.StopGroupMemberResponse, error) {
+	if s.groupNet == nil || s.groupDriver == nil {
+		return nil, status.Error(codes.Unimplemented, "noded: group member lifecycle not configured")
+	}
+	vmID := req.GetVmId()
+	switch req.GetMode() {
+	case nodev1.StopGroupMemberMode_STOP_GROUP_MEMBER_MODE_BANK:
+		return s.stopGroupMemberBank(ctx, req, vmID)
+	case nodev1.StopGroupMemberMode_STOP_GROUP_MEMBER_MODE_DESTROY:
+		return s.stopGroupMemberDestroy(ctx, vmID)
+	default:
+		return nil, status.Error(codes.InvalidArgument, "noded: StopGroupMember mode must be BANK or DESTROY")
+	}
+}
+
+// stopGroupMemberBank pauses a live member and snapshots it into the caller-supplied
+// set directory (group/<set_id>/<member_name>/), records the banked bundle, destroys
+// the VM, and removes its tap. The per-member pause->snapshot timing is measured and
+// logged for the closure gate (noded owns its OWN per-member timing; the pause-spread
+// across a SET is the control plane's, which orchestrates the per-member bank calls).
+func (s *Server) stopGroupMemberBank(ctx context.Context, req *nodev1.StopGroupMemberRequest, vmID string) (*nodev1.StopGroupMemberResponse, error) {
+	setID := req.GetSetId()
+	memberName := req.GetMemberName()
+	if setID == "" || memberName == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: set_id and member_name required for BANK")
+	}
+	e, ok := s.groupMembers.beginStop(vmID)
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: group member %q not bankable (unknown or a stop is already in flight)", vmID)
+	}
+	if memberName != e.memberName {
+		// The bank writes under the caller-supplied member_name; guard against a
+		// request that names a different member than the live VM (a set-dir mixup).
+		e.mu.Lock()
+		e.inFlight = false
+		e.mu.Unlock()
+		return nil, status.Errorf(codes.InvalidArgument, "noded: member_name %q does not match live member %q for vm %q", memberName, e.memberName, vmID)
+	}
+	e.probe.Stop()
+	// SnapshotGroupMember pauses (no cross-VM barrier: standing decision 10) then
+	// writes the snapshot; the daemon issues NO guest-agent command between the pause
+	// decision and the snapshot, so the bank never races an in-flight agent command.
+	pauseStart := time.Now()
+	ref, err := s.groupDriver.SnapshotGroupMember(ctx, e.handle, setID, memberName)
+	bankDuration := time.Since(pauseStart)
+	if err != nil {
+		// A bank is destructive: SnapshotGroupMember tore the VM down on failure, so
+		// drop the dead entry and remove its tap rather than misreport capacity.
+		s.groupMembers.remove(vmID)
+		s.groupNet.RemoveMemberTap(ctx, e.groupInstanceID, e.tap, e.ip)
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: bank group member %q: %v", vmID, err)
+	}
+	if removed := s.groupMembers.remove(vmID); removed != nil {
+		s.reapGroupMember(removed.handle, removed.groupInstanceID, removed.tap, removed.ip)
+	}
+	s.logger.Info("noded: banked group member", "group", e.groupInstanceID, "set", setID, "member", memberName, "ref", ref.ID, "pause_to_snapshot_ms", bankDuration.Milliseconds())
+	s.groupBundles.add(groupBundleEntry{
+		setID:           setID,
+		memberName:      memberName,
+		groupInstanceID: e.groupInstanceID,
+		snapshotRef:     ref.ID,
+		sizeBytes:       ref.SizeBytes,
+		createdAtUnixMs: time.Now().UnixMilli(),
+	})
+	s.signalChange()
+	return &nodev1.StopGroupMemberResponse{SnapshotRef: ref.ID, SizeBytes: uint64(ref.SizeBytes)}, nil
+}
+
+// stopGroupMemberDestroy tears a member VM down with no snapshot, removes its tap,
+// and releases its pinned IP. Idempotent: an unknown vm_id returns OK.
+func (s *Server) stopGroupMemberDestroy(ctx context.Context, vmID string) (*nodev1.StopGroupMemberResponse, error) {
+	// Serialize against a concurrent stop the same way BANK does, so a DESTROY racing
+	// a BANK (or another DESTROY) on one vm_id cannot double-reap.
+	e, ok := s.groupMembers.beginStop(vmID)
+	if !ok {
+		// Unknown id is an idempotent no-op; a stop already in flight is refused.
+		if s.groupMembers.get(vmID) == nil {
+			return &nodev1.StopGroupMemberResponse{}, nil
+		}
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: group member %q stop already in flight", vmID)
+	}
+	if removed := s.groupMembers.remove(vmID); removed != nil {
+		removed.probe.Stop()
+		s.reapGroupMember(removed.handle, removed.groupInstanceID, removed.tap, removed.ip)
+		s.signalChange()
+	}
+	return &nodev1.StopGroupMemberResponse{}, nil
+}
+
+// reapGroupMember tears a member VM down (release the FC process + bundle) and
+// removes its tap + pinned IP from the group bridge. Best-effort, mirroring
+// reapStateful minus the volume detach (a member has no writable volume).
+func (s *Server) reapGroupMember(h substrate.Handle, groupInstanceID, tap string, ip net.IP) {
+	s.reap(h, func() {})
+	if s.groupNet != nil {
+		s.groupNet.RemoveMemberTap(context.Background(), groupInstanceID, tap, ip)
+	}
+}
+
+// pinGroupMemberTap pins a member's NIC world on the group bridge (derive + verify
+// against the request IP, reserve the IP, create the tap), mapping the manager's
+// errors to the right gRPC codes. Shared by FRESH and RELIGHT.
+func (s *Server) pinGroupMemberTap(ctx context.Context, groupInstanceID, memberName string, memberIndex uint32, pinnedIP net.IP) (tap string, ip net.IP, err error) {
+	tap, _, terr := s.groupNet.EnsureMemberTap(ctx, groupInstanceID, memberName, memberIndex, pinnedIP)
+	if terr != nil {
+		return "", nil, status.Errorf(codes.FailedPrecondition, "noded: pin group member tap: %v", terr)
+	}
+	return tap, pinnedIP, nil
+}
+
+// groupMemberMAC derives a member's deterministic MAC via the manager's read-only
+// addressing (no reservation), for the NIC spec. A derivation error leaves the MAC
+// empty (FC then assigns one), which never happens for a group already validated by
+// EnsureMemberTap above, so this is a safe convenience.
+func (s *Server) groupMemberMAC(groupInstanceID, memberName string, memberIndex uint32) string {
+	_, mac, _, err := s.groupNet.MemberAddressingFor(groupInstanceID, memberName, memberIndex)
+	if err != nil {
+		return ""
+	}
+	return mac
+}
+
+// resolveGroupMemberBoot resolves a FRESH member source to its bootable rootfs +
+// harness init, exactly like the stateful cold-boot source resolution: the source
+// names a built base (a NIC cold boot cannot resume a vsock-only base memory
+// snapshot, D-R3.4.2), whose imageDigest resolves to a provisioned runtime image.
+func (s *Server) resolveGroupMemberBoot(source string) (rootfsPath, harnessInit string, err error) {
+	base, ok := s.bases.get(source)
+	if !ok || base.state != nodev1.BaseBuildState_BASE_BUILD_STATE_READY {
+		return "", "", status.Errorf(codes.FailedPrecondition, "noded: group member source %q is not a ready base on this node", source)
+	}
+	img, ok := s.cfg.Images[base.imageDigest]
+	if !ok {
+		return "", "", status.Errorf(codes.FailedPrecondition, "noded: runtime image %q for source %q not provisioned on this node", base.imageDigest, source)
+	}
+	harnessInit = img.HarnessInit
+	if harnessInit == "" {
+		harnessInit = s.cfg.HarnessInit
+	}
+	return img.RootfsPath, harnessInit, nil
+}
+
+// parseGroupMemberRef splits a group member snapshot_ref (group/<set_id>/<member>)
+// into (set_id, member_name). It returns ok=false for any ref that is not exactly
+// three path segments led by "group".
+func parseGroupMemberRef(ref string) (setID, memberName string, ok bool) {
+	parts := splitPath(ref)
+	if len(parts) != 3 || parts[0] != "group" || parts[1] == "" || parts[2] == "" {
+		return "", "", false
+	}
+	return parts[1], parts[2], true
+}
+
+// splitPath splits a slash-separated ref into its non-empty-leading segments. It is a
+// tiny local helper (not filepath.Split, which peels only the last element) so the
+// three-segment group ref parses without pulling path semantics that would treat a
+// trailing slash specially.
+func splitPath(ref string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(ref); i++ {
+		if ref[i] == '/' {
+			out = append(out, ref[start:i])
+			start = i + 1
+		}
+	}
+	out = append(out, ref[start:])
+	return out
+}

--- a/projects/embervm/noded/server/group_member.go
+++ b/projects/embervm/noded/server/group_member.go
@@ -285,11 +285,12 @@ func (s *Server) stopGroupMemberDestroy(ctx context.Context, vmID string) (*node
 		}
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: group member %q stop already in flight", vmID)
 	}
-	if removed := s.groupMembers.remove(vmID); removed != nil {
-		removed.probe.Stop()
-		s.reapGroupMember(removed.handle, removed.groupInstanceID, removed.tap, removed.ip)
-		s.signalChange()
-	}
+	// beginStop returned the entry marked in-flight; drop it from the registry and
+	// reap it (the entry is the authoritative handle/tap/ip to tear down).
+	s.groupMembers.remove(vmID)
+	e.probe.Stop()
+	s.reapGroupMember(e.handle, e.groupInstanceID, e.tap, e.ip)
+	s.signalChange()
 	return &nodev1.StopGroupMemberResponse{}, nil
 }
 

--- a/projects/embervm/noded/server/group_member_test.go
+++ b/projects/embervm/noded/server/group_member_test.go
@@ -1,0 +1,517 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/config"
+	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
+)
+
+// fakeGroupMemberDriver cold-boots and banks/relights member VMs in memory, recording
+// the env each FRESH boot carried and the set/member each bank wrote under, mirroring
+// fakeStatefulDriver's shape.
+type fakeGroupMemberDriver struct {
+	mu           sync.Mutex
+	live         int
+	claims       int
+	lastEnv      map[string]string
+	banked       map[string]bool // "set/member" -> banked
+	failClaim    error
+	groupSetsDir string
+}
+
+func newFakeGroupMemberDriver(dir string) *fakeGroupMemberDriver {
+	return &fakeGroupMemberDriver{banked: map[string]bool{}, groupSetsDir: dir + "/group"}
+}
+
+func (f *fakeGroupMemberDriver) ClaimGroupMember(_ context.Context, _ string, _ string, _ int, _ int, _ substrate.NICSpec, env map[string]string) (substrate.Handle, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failClaim != nil {
+		return substrate.Handle{}, f.failClaim
+	}
+	f.claims++
+	f.live++
+	f.lastEnv = env
+	return substrate.Handle{ID: "grpm-vm-" + strconv.Itoa(f.claims), ThreadID: "t-" + strconv.Itoa(f.claims), Node: "node-4"}, nil
+}
+
+func (f *fakeGroupMemberDriver) SnapshotGroupMember(_ context.Context, _ substrate.Handle, setID, memberName string) (substrate.SnapshotRef, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ref := "group/" + setID + "/" + memberName
+	f.banked[setID+"/"+memberName] = true
+	return substrate.SnapshotRef{ID: ref, SizeBytes: 5120}, nil
+}
+
+func (f *fakeGroupMemberDriver) RestoreGroupMember(_ context.Context, setID, memberName string) (substrate.Handle, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if !f.banked[setID+"/"+memberName] {
+		return substrate.Handle{}, status.Errorf(codes.FailedPrecondition, "no such banked member %s/%s", setID, memberName)
+	}
+	f.live++
+	return substrate.Handle{ID: "relit-" + setID + "-" + memberName, ThreadID: "t-relit", Node: "node-4"}, nil
+}
+
+func (f *fakeGroupMemberDriver) RemoveGroupMemberBundle(setID, memberName string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.banked, setID+"/"+memberName)
+	return nil
+}
+
+func (f *fakeGroupMemberDriver) ScanGroupBundleSets() []substrate.GroupBundleSetInfo {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	bySet := map[string][]substrate.GroupBundleMemberInfo{}
+	for key := range f.banked {
+		// key is "set/member".
+		var setID, member string
+		for i := 0; i < len(key); i++ {
+			if key[i] == '/' {
+				setID, member = key[:i], key[i+1:]
+				break
+			}
+		}
+		bySet[setID] = append(bySet[setID], substrate.GroupBundleMemberInfo{
+			MemberName:  member,
+			SnapshotRef: "group/" + setID + "/" + member,
+			SizeBytes:   5120,
+		})
+	}
+	out := make([]substrate.GroupBundleSetInfo, 0, len(bySet))
+	for setID, members := range bySet {
+		out = append(out, substrate.GroupBundleSetInfo{SetID: setID, Members: members, CreatedAtUnixMs: 1})
+	}
+	return out
+}
+
+func (f *fakeGroupMemberDriver) GroupSetsDir() string { return f.groupSetsDir }
+
+// groupMemberVMDriverAdapter makes fakeGroupMemberDriver satisfy the task vmDriver
+// seam so the node cap + reap path see member VMs, mirroring statefulVMDriverAdapter.
+type groupMemberVMDriverAdapter struct {
+	*fakeGroupMemberDriver
+}
+
+func (a groupMemberVMDriverAdapter) Claim(_ context.Context, _ substrate.ClaimSpec) (substrate.Handle, error) {
+	return substrate.Handle{}, status.Error(codes.Unimplemented, "unused")
+}
+
+func (a groupMemberVMDriverAdapter) Release(_ context.Context, _ substrate.Handle) error {
+	a.fakeGroupMemberDriver.mu.Lock()
+	if a.fakeGroupMemberDriver.live > 0 {
+		a.fakeGroupMemberDriver.live--
+	}
+	a.fakeGroupMemberDriver.mu.Unlock()
+	return nil
+}
+func (a groupMemberVMDriverAdapter) RemoveBundle(_ string) error         { return nil }
+func (a groupMemberVMDriverAdapter) VsockUDSPath(threadID string) string { return "/tmp/" + threadID }
+func (a groupMemberVMDriverAdapter) Stats(_ substrate.Handle) (substrate.GuestStats, error) {
+	return substrate.GuestStats{}, nil
+}
+
+func (a groupMemberVMDriverAdapter) LiveCount() int {
+	a.fakeGroupMemberDriver.mu.Lock()
+	defer a.fakeGroupMemberDriver.mu.Unlock()
+	return a.fakeGroupMemberDriver.live
+}
+
+// fakeGroupClock scripts the clock-resync outcome: err set means the read-back was
+// out of tolerance (or a timeout), nil means verified within one second. It records
+// that Resync was called so a test can assert the resync ran on RELIGHT (and never
+// on FRESH).
+type fakeGroupClock struct {
+	mu      sync.Mutex
+	calls   int
+	err     error
+	lastUDS string
+}
+
+func (c *fakeGroupClock) Resync(_ context.Context, uds string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	c.lastUDS = uds
+	return c.err
+}
+
+// newGroupMemberTestServer wires a Server with the full group member lifecycle
+// (network + member driver + clock), a ready base "src-a" the FRESH source resolves
+// against, and short ready timeouts.
+func newGroupMemberTestServer(t *testing.T) (*Server, *fakeGroupNet, *fakeGroupMemberDriver, *fakeGroupClock) {
+	t.Helper()
+	dir := t.TempDir()
+	gn := newFakeGroupNet()
+	gr := newFakeGroupRecords(t.TempDir())
+	gmd := newFakeGroupMemberDriver(dir)
+	clock := &fakeGroupClock{}
+	s := New(Options{
+		Config: config.Config{
+			Arch: "amd64", Node: "node-4", MaxLiveVMs: 8, SnapshotRoot: dir,
+			BootReadyTimeout:    2 * time.Second,
+			RestoreReadyTimeout: 2 * time.Second,
+			Images:              map[string]config.Image{"img-a": {RootfsPath: "/rootfs/a"}},
+		},
+		Driver:       groupMemberVMDriverAdapter{gmd},
+		Transport:    &fakeTransport{},
+		GroupNet:     gn,
+		GroupRecords: gr,
+		GroupDriver:  gmd,
+		GroupClock:   clock,
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	s.memHeadroom = func() uint64 { return 0 }
+	// A ready base "src-a" the FRESH source resolves to (image-lane: source names a
+	// base whose imageDigest is a provisioned runtime image, exactly like stateful).
+	s.bases.readyBuild("src-a", "wl-grp", "img-a", "/shim/ready", 2048)
+	// Stand up the group network so StartGroupMember's existence check passes.
+	if _, err := s.CreateGroupNetwork(context.Background(), &nodev1.CreateGroupNetworkRequest{
+		GroupInstanceId: "grp-A", Cidr: "10.101.1.0/24",
+	}); err != nil {
+		t.Fatalf("CreateGroupNetwork: %v", err)
+	}
+	return s, gn, gmd, clock
+}
+
+// startFreshMember FRESH-boots a member against a ready loopback TCP endpoint.
+func startFreshMember(t *testing.T, s *Server, port uint32, member string, index uint32) *nodev1.StartGroupMemberResponse {
+	t.Helper()
+	resp, err := s.StartGroupMember(context.Background(), &nodev1.StartGroupMemberRequest{
+		Mode:            nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_FRESH,
+		GroupInstanceId: "grp-A",
+		MemberName:      member,
+		MemberIndex:     index,
+		Ip:              "127.0.0.1",
+		Source:          "src-a",
+		HealthPort:      port,
+		Env:             map[string]string{"EMBER_GROUP_ROLE": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("StartGroupMember(fresh): %v", err)
+	}
+	return resp
+}
+
+// TestStartGroupMemberFreshBootsOnGroupBridge proves a FRESH member cold-boots on the
+// group bridge (tap pinned), health-gates, carries its env, is reported in
+// group_member_vms, and bumps the network's member_count. No clock resync on FRESH.
+func TestStartGroupMemberFreshBootsOnGroupBridge(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, gn, gmd, clock := newGroupMemberTestServer(t)
+
+	resp := startFreshMember(t, s, port, "worker-0", 0)
+	if resp.GetVmId() == "" {
+		t.Error("no vm_id returned")
+	}
+	if resp.GetIp() != "127.0.0.1" {
+		t.Errorf("ip = %q want the pinned 127.0.0.1", resp.GetIp())
+	}
+	if resp.GetWasRelight() {
+		t.Error("a FRESH boot must report was_relight=false")
+	}
+	if gmd.claims != 1 {
+		t.Errorf("ClaimGroupMember calls = %d want 1", gmd.claims)
+	}
+	if gmd.lastEnv["EMBER_GROUP_ROLE"] != "worker" {
+		t.Errorf("env not threaded into the FRESH boot: %v", gmd.lastEnv)
+	}
+	if !gn.taps["worker-0"] {
+		t.Error("member tap was not pinned on the group bridge")
+	}
+	if clock.calls != 0 {
+		t.Errorf("FRESH boot must NOT clock-resync (calls=%d)", clock.calls)
+	}
+
+	ns := s.nodeStatus()
+	if len(ns.GetGroupMemberVms()) != 1 {
+		t.Fatalf("group_member_vms = %d want 1", len(ns.GetGroupMemberVms()))
+	}
+	m := ns.GetGroupMemberVms()[0]
+	if m.GetGroupInstanceId() != "grp-A" || m.GetMemberName() != "worker-0" || !m.GetHealthy() {
+		t.Errorf("member status = %+v", m)
+	}
+	// member_count on the network must reflect the live member.
+	if len(ns.GetGroupNetworks()) != 1 || ns.GetGroupNetworks()[0].GetMemberCount() != 1 {
+		t.Errorf("group network member_count = %v want 1", ns.GetGroupNetworks())
+	}
+}
+
+// TestStartGroupMemberFreshHealthGateFailureReaps proves a member that never health-
+// gates is reaped and its tap removed, and no member is published.
+func TestStartGroupMemberFreshHealthGateFailure(t *testing.T) {
+	s, gn, _, _ := newGroupMemberTestServer(t)
+	// Use a port with no listener so the health-gate times out.
+	_, err := s.StartGroupMember(context.Background(), &nodev1.StartGroupMemberRequest{
+		Mode:            nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_FRESH,
+		GroupInstanceId: "grp-A", MemberName: "worker-0", MemberIndex: 0,
+		Ip: "127.0.0.1", Source: "src-a", HealthPort: 1, // port 1: nothing listens
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("health-gate failure: got %v want FailedPrecondition", err)
+	}
+	if len(gn.removedTaps) == 0 {
+		t.Error("a failed member start must remove its tap")
+	}
+	if len(s.nodeStatus().GetGroupMemberVms()) != 0 {
+		t.Error("no member should be published on a health-gate failure")
+	}
+}
+
+// TestStartGroupMemberRelightResyncsClockAndPinsWorld proves a RELIGHT recreates the
+// SAME pinned tap world (same member + index), resumes the bundle, runs the clock
+// resync BEFORE the health gate, and reports was_relight=true.
+func TestStartGroupMemberRelightResyncsClockAndPinsWorld(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, gn, _, clock := newGroupMemberTestServer(t)
+
+	fresh := startFreshMember(t, s, port, "worker-0", 0)
+	bankResp, err := s.StopGroupMember(context.Background(), &nodev1.StopGroupMemberRequest{
+		VmId: fresh.GetVmId(), Mode: nodev1.StopGroupMemberMode_STOP_GROUP_MEMBER_MODE_BANK,
+		SetId: "set-1", MemberName: "worker-0",
+	})
+	if err != nil {
+		t.Fatalf("StopGroupMember(bank): %v", err)
+	}
+
+	// Reset the pin-call record so we can assert the relight re-pins the same world.
+	gn.mu.Lock()
+	gn.ensureCalls = nil
+	gn.mu.Unlock()
+
+	relit, err := s.StartGroupMember(context.Background(), &nodev1.StartGroupMemberRequest{
+		Mode:            nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_RELIGHT,
+		GroupInstanceId: "grp-A", MemberName: "worker-0", MemberIndex: 0,
+		Ip: "127.0.0.1", SnapshotRef: bankResp.GetSnapshotRef(), HealthPort: port,
+	})
+	if err != nil {
+		t.Fatalf("StartGroupMember(relight): %v", err)
+	}
+	if !relit.GetWasRelight() {
+		t.Error("a verified relight must report was_relight=true")
+	}
+	if clock.calls != 1 {
+		t.Errorf("relight must clock-resync exactly once (calls=%d)", clock.calls)
+	}
+	// Pinned-world reconstruction: the relight re-pinned the SAME member + index.
+	gn.mu.Lock()
+	defer gn.mu.Unlock()
+	if len(gn.ensureCalls) != 1 || gn.ensureCalls[0].member != "worker-0" || gn.ensureCalls[0].index != 0 {
+		t.Errorf("relight did not re-pin the same member/index: %+v", gn.ensureCalls)
+	}
+	if gn.ensureCalls[0].wantIP != "127.0.0.1" {
+		t.Errorf("relight pinned a different IP: %q", gn.ensureCalls[0].wantIP)
+	}
+}
+
+// TestStartGroupMemberRelightClockFailureFailsCall proves a clock resync that reports
+// a read-back more than one second off FAILS the relight (FAILED_PRECONDITION) and
+// reaps the VM.
+func TestStartGroupMemberRelightClockFailure(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, gn, _, clock := newGroupMemberTestServer(t)
+	fresh := startFreshMember(t, s, port, "worker-0", 0)
+	bankResp, err := s.StopGroupMember(context.Background(), &nodev1.StopGroupMemberRequest{
+		VmId: fresh.GetVmId(), Mode: nodev1.StopGroupMemberMode_STOP_GROUP_MEMBER_MODE_BANK,
+		SetId: "set-1", MemberName: "worker-0",
+	})
+	if err != nil {
+		t.Fatalf("bank: %v", err)
+	}
+
+	clock.err = errors.New("guest clock read-back 3s off host (limit 1s)")
+	prevRemoved := len(gn.removedTaps)
+	_, err = s.StartGroupMember(context.Background(), &nodev1.StartGroupMemberRequest{
+		Mode:            nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_RELIGHT,
+		GroupInstanceId: "grp-A", MemberName: "worker-0", MemberIndex: 0,
+		Ip: "127.0.0.1", SnapshotRef: bankResp.GetSnapshotRef(), HealthPort: port,
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("clock resync failure: got %v want FailedPrecondition", err)
+	}
+	if len(gn.removedTaps) <= prevRemoved {
+		t.Error("a failed relight must remove its tap")
+	}
+	if len(s.nodeStatus().GetGroupMemberVms()) != 0 {
+		t.Error("no member should be published on a clock-resync failure")
+	}
+}
+
+// TestStopGroupMemberBankWritesSetDirLayout proves BANK snapshots under the caller-
+// supplied set dir, records the bundle grouped by set, and returns the ref+size.
+func TestStopGroupMemberBankWritesSetDirLayout(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, _, gmd, _ := newGroupMemberTestServer(t)
+	fresh := startFreshMember(t, s, port, "worker-0", 0)
+
+	bankResp, err := s.StopGroupMember(context.Background(), &nodev1.StopGroupMemberRequest{
+		VmId: fresh.GetVmId(), Mode: nodev1.StopGroupMemberMode_STOP_GROUP_MEMBER_MODE_BANK,
+		SetId: "set-1", MemberName: "worker-0",
+	})
+	if err != nil {
+		t.Fatalf("bank: %v", err)
+	}
+	if bankResp.GetSnapshotRef() != "group/set-1/worker-0" {
+		t.Errorf("bank ref = %q want group/set-1/worker-0", bankResp.GetSnapshotRef())
+	}
+	if bankResp.GetSizeBytes() == 0 {
+		t.Error("bank should report a size")
+	}
+	if !gmd.banked["set-1/worker-0"] {
+		t.Error("driver did not bank under set-1/worker-0")
+	}
+	// The banked bundle is reported grouped by set in NodeStatus.
+	ns := s.nodeStatus()
+	if len(ns.GetGroupBundleSets()) != 1 {
+		t.Fatalf("group_bundle_sets = %d want 1", len(ns.GetGroupBundleSets()))
+	}
+	set := ns.GetGroupBundleSets()[0]
+	if set.GetSetId() != "set-1" || len(set.GetMembers()) != 1 || set.GetMembers()[0].GetMemberName() != "worker-0" {
+		t.Errorf("bundle set = %+v", set)
+	}
+	// The live member is gone (banked destroys it).
+	if len(ns.GetGroupMemberVms()) != 0 {
+		t.Error("a banked member must no longer be live")
+	}
+}
+
+// TestStopGroupMemberDestroy proves DESTROY tears the member down with no snapshot.
+func TestStopGroupMemberDestroy(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, gn, gmd, _ := newGroupMemberTestServer(t)
+	fresh := startFreshMember(t, s, port, "worker-0", 0)
+
+	resp, err := s.StopGroupMember(context.Background(), &nodev1.StopGroupMemberRequest{
+		VmId: fresh.GetVmId(), Mode: nodev1.StopGroupMemberMode_STOP_GROUP_MEMBER_MODE_DESTROY,
+	})
+	if err != nil {
+		t.Fatalf("destroy: %v", err)
+	}
+	if resp.GetSnapshotRef() != "" || resp.GetSizeBytes() != 0 {
+		t.Errorf("DESTROY must produce no snapshot: %+v", resp)
+	}
+	if len(gmd.banked) != 0 {
+		t.Error("DESTROY must not bank anything")
+	}
+	if len(gn.removedTaps) == 0 {
+		t.Error("DESTROY must remove the member tap")
+	}
+	if len(s.nodeStatus().GetGroupMemberVms()) != 0 {
+		t.Error("member should be gone after destroy")
+	}
+	// Idempotent: destroying an unknown vm is OK.
+	if _, err := s.StopGroupMember(context.Background(), &nodev1.StopGroupMemberRequest{
+		VmId: "ghost", Mode: nodev1.StopGroupMemberMode_STOP_GROUP_MEMBER_MODE_DESTROY,
+	}); err != nil {
+		t.Errorf("destroy of an unknown vm should be idempotent OK: %v", err)
+	}
+}
+
+// TestStopGroupMemberConcurrentStopRefused proves a second in-flight stop on the same
+// vm_id is refused (the concurrent-stop refusal per vm_id).
+func TestStopGroupMemberConcurrentStopRefused(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, _, _, _ := newGroupMemberTestServer(t)
+	fresh := startFreshMember(t, s, port, "worker-0", 0)
+
+	// Manually mark the member in-flight (as a first stop would), then a second stop
+	// must be refused.
+	e := s.groupMembers.get(fresh.GetVmId())
+	if e == nil {
+		t.Fatal("member not registered")
+	}
+	if _, ok := s.groupMembers.beginStop(fresh.GetVmId()); !ok {
+		t.Fatal("first beginStop should succeed")
+	}
+	_, err := s.StopGroupMember(context.Background(), &nodev1.StopGroupMemberRequest{
+		VmId: fresh.GetVmId(), Mode: nodev1.StopGroupMemberMode_STOP_GROUP_MEMBER_MODE_BANK,
+		SetId: "set-1", MemberName: "worker-0",
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("second concurrent stop: got %v want FailedPrecondition", err)
+	}
+}
+
+// TestStartGroupMemberRelightUnknownBundleFails proves a relight of an unknown ref
+// fails (FAILED_PRECONDITION) and never deletes the bundle (a lost member surfaces).
+func TestStartGroupMemberRelightUnknownBundleFails(t *testing.T) {
+	s, _, _, _ := newGroupMemberTestServer(t)
+	_, err := s.StartGroupMember(context.Background(), &nodev1.StartGroupMemberRequest{
+		Mode:            nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_RELIGHT,
+		GroupInstanceId: "grp-A", MemberName: "worker-0", MemberIndex: 0,
+		Ip: "127.0.0.1", SnapshotRef: "group/set-x/worker-0", HealthPort: 8080,
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("relight of unknown bundle: got %v want FailedPrecondition", err)
+	}
+}
+
+// TestGroupMemberVerbsUnimplementedWithoutDriver proves a Server without a group
+// member driver returns Unimplemented (builds without group support untouched).
+func TestGroupMemberVerbsUnimplementedWithoutDriver(t *testing.T) {
+	s := New(Options{
+		Config:    config.Config{Arch: "amd64", Node: "node-4", SnapshotRoot: t.TempDir()},
+		Driver:    &fakeDriver{},
+		Transport: &fakeTransport{},
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if _, err := s.StartGroupMember(context.Background(), &nodev1.StartGroupMemberRequest{GroupInstanceId: "g", MemberName: "m", HealthPort: 1, Ip: "127.0.0.1"}); status.Code(err) != codes.Unimplemented {
+		t.Errorf("StartGroupMember without a driver should be Unimplemented, got %v", err)
+	}
+	if _, err := s.StopGroupMember(context.Background(), &nodev1.StopGroupMemberRequest{VmId: "v"}); status.Code(err) != codes.Unimplemented {
+		t.Errorf("StopGroupMember without a driver should be Unimplemented, got %v", err)
+	}
+}
+
+// TestReconcileGroupBundlesFromDisk proves the boot rescan re-seeds the banked-group
+// inventory (grouped by set) so a restarted daemon reports surviving warmth; live
+// members do NOT survive a restart.
+func TestReconcileGroupBundlesFromDisk(t *testing.T) {
+	dir := t.TempDir()
+	gmd := newFakeGroupMemberDriver(dir)
+	gmd.banked["set-1/worker-0"] = true
+	gmd.banked["set-1/worker-1"] = true
+	gmd.banked["set-2/leader"] = true
+
+	s := New(Options{
+		Config:       config.Config{Arch: "amd64", Node: "node-4", SnapshotRoot: dir},
+		Driver:       groupMemberVMDriverAdapter{gmd},
+		Transport:    &fakeTransport{},
+		GroupNet:     newFakeGroupNet(),
+		GroupRecords: newFakeGroupRecords(t.TempDir()),
+		GroupDriver:  gmd,
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	s.memHeadroom = func() uint64 { return 0 }
+	s.ReconcileGroupBundlesFromDisk()
+
+	ns := s.nodeStatus()
+	if len(ns.GetGroupBundleSets()) != 2 {
+		t.Fatalf("rescan found %d bundle sets want 2", len(ns.GetGroupBundleSets()))
+	}
+	// No live members after a restart.
+	if len(ns.GetGroupMemberVms()) != 0 {
+		t.Error("no live members should survive a restart")
+	}
+	bySet := map[string]int{}
+	for _, set := range ns.GetGroupBundleSets() {
+		bySet[set.GetSetId()] = len(set.GetMembers())
+	}
+	if bySet["set-1"] != 2 || bySet["set-2"] != 1 {
+		t.Errorf("bundle set membership wrong: %v", bySet)
+	}
+}

--- a/projects/embervm/noded/server/group_registry.go
+++ b/projects/embervm/noded/server/group_registry.go
@@ -36,11 +36,67 @@ type groupNetwork interface {
 	// List projects every held group network for NodeStatus assembly.
 	List() []serving.GroupNetworkInfo
 	// MemberAddressingFor derives the deterministic (tap, mac, ip) for a member
-	// without reserving the IP (read-only; Task 5 uses the reserving variant).
+	// without reserving the IP (read-only; the reserving/creating variant is
+	// EnsureMemberTap).
 	MemberAddressingFor(groupInstanceID, memberName string, memberIndex uint32) (tap, mac string, ip net.IP, err error)
+	// EnsureMemberTap pins a member's NIC world on the group bridge (derive + verify
+	// against the request IP, reserve the IP, create + attach the tap) and returns
+	// the (tap, mac). Used by BOTH FRESH boot and RELIGHT resume: a relight recreates
+	// the SAME tap/MAC/IP the member had at bank time (the pinned-world reconstruction).
+	EnsureMemberTap(ctx context.Context, groupInstanceID, memberName string, memberIndex uint32, wantIP net.IP) (tap, mac string, err error)
+	// RemoveMemberTap deletes a member's tap and releases its pinned IP (idempotent),
+	// the symmetric teardown for EnsureMemberTap.
+	RemoveMemberTap(ctx context.Context, groupInstanceID, tap string, ip net.IP)
+	// GatewayIP is the group's .1 gateway (the member's default route); nil if absent.
+	GatewayIP(groupInstanceID string) net.IP
+	// PrefixLen is the group's /24 prefix length (24); 0 if the group is absent.
+	PrefixLen(groupInstanceID string) int
 	// EntryEndpoint projects a group entry member's (tap IP, guest port) into the
 	// reported endpoint (pod IP + DNAT port when enabled, else the tap unchanged).
 	EntryEndpoint(entryIP net.IP, guestPort uint32) (string, uint32)
+}
+
+// groupMemberDriver is the subset of the fcvm driver the R5 member lifecycle needs
+// on top of vmDriver: cold-boot a member VM WITH a tap NIC on the group bridge and
+// its first-boot env (FRESH), bank a live member to a self-contained bundle under
+// group/<set_id>/<member_name>/ (BANK), resume from a banked member bundle (RELIGHT),
+// remove a banked member bundle, and rescan banked group bundle SETS on start. The
+// real *driver.Driver satisfies it; tests inject a fake. A separate seam (like
+// statefulDriver) so a Server built without group support still compiles and a
+// reviewer sees exactly which driver mechanics the member path reuses.
+type groupMemberDriver interface {
+	// ClaimGroupMember cold-boots a member VM from a per-member rootfs WITH the given
+	// tap NIC on the group bridge and its first-boot env (MMDS-lite over boot-args).
+	// No handler artifact and no writable volume: a member is a plain NIC guest.
+	ClaimGroupMember(ctx context.Context, rootfsPath, harnessInit string, vcpus, memMib int, nic substrate.NICSpec, env map[string]string) (substrate.Handle, error)
+	// SnapshotGroupMember pauses a live member VM and writes a self-contained member
+	// bundle under group/<set_id>/<member_name>/; does not resume (the caller Releases).
+	SnapshotGroupMember(ctx context.Context, h substrate.Handle, setID, memberName string) (substrate.SnapshotRef, error)
+	// RestoreGroupMember launches a fresh VM from a banked member bundle and resumes
+	// it, WITH the NIC captured at bank time. The caller has already recreated the
+	// pinned tap world before calling this.
+	RestoreGroupMember(ctx context.Context, setID, memberName string) (substrate.Handle, error)
+	// RemoveGroupMemberBundle deletes a banked member bundle from disk (idempotent).
+	RemoveGroupMemberBundle(setID, memberName string) error
+	// ScanGroupBundleSets globs the group bundle dir on startup and returns each set
+	// dir with the per-member bundles found under it, GROUPED BY set (no completeness
+	// judgment; that is the control plane's).
+	ScanGroupBundleSets() []substrate.GroupBundleSetInfo
+	// GroupSetsDir is the directory holding banked group member bundles, rescanned
+	// on start.
+	GroupSetsDir() string
+}
+
+// groupClock is the host-side clock-resync seam the RELIGHT path uses to re-set a
+// resumed member guest's wall clock over the port-1024 length-prefixed JSON agent
+// channel and VERIFY the read-back within one second. The real groupclock.Resync
+// (with a groupclock.VsockDialer) satisfies it; tests inject a fake scripting
+// success / >1s failure / timeout without a real guest.
+type groupClock interface {
+	// Resync dials the member guest's clock agent, sends the host epoch, reads the
+	// clock back, and returns an error (failing the relight) when the read-back is
+	// more than one second off the host's epoch at send.
+	Resync(ctx context.Context, udsPath string) error
 }
 
 // groupRecordStore is the on-disk group-network record seam: write a record on
@@ -67,14 +123,21 @@ type groupMemberEntry struct {
 	vmID            string
 	groupInstanceID string
 	memberName      string
+	memberIndex     uint32
 	ip              net.IP
+	// tap is the member's host tap device on the group bridge (derived from the
+	// group + member), kept so teardown deletes the exact device without re-deriving.
+	tap string
+	// port is the guest TCP port the member health-gates and probes on (health_port).
+	port uint32
+	// handle is the live Firecracker handle, for bank/destroy/reap.
+	handle substrate.Handle
 	// isEntry marks the group's entry member (the one exposed via the entry DNAT).
 	isEntry bool
-	// probe is the running TCP-connect health-probe loop for this member (set by
-	// Task 5). nil in Task 4 (no live members yet).
+	// probe is the running TCP-connect health-probe loop for this member.
 	probe *serving.ProbeHandle
 
-	mu       sync.Mutex // guards inFlight (Task 5's stop serialization)
+	mu       sync.Mutex // guards inFlight (the per-vm stop serialization)
 	inFlight bool
 }
 
@@ -108,6 +171,34 @@ func (r *groupMemberRegistry) remove(id string) *groupMemberEntry {
 	e := r.members[id]
 	delete(r.members, id)
 	return e
+}
+
+// get returns the entry for a vm_id (nil if absent).
+func (r *groupMemberRegistry) get(id string) *groupMemberEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.members[id]
+}
+
+// beginStop marks a member VM busy for a StopGroupMember, mirroring
+// statefulRegistry.beginStop. It returns (entry, true) only when the id names a
+// known live member with no stop already in flight; a concurrent stop on the same
+// vm_id gets (nil, false), which the handler maps to FAILED_PRECONDITION. This is
+// the concurrent-stop refusal per vm_id.
+func (r *groupMemberRegistry) beginStop(id string) (*groupMemberEntry, bool) {
+	r.mu.Lock()
+	e, ok := r.members[id]
+	r.mu.Unlock()
+	if !ok {
+		return nil, false
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.inFlight {
+		return nil, false
+	}
+	e.inFlight = true
+	return e, true
 }
 
 // memberCount is the number of live members currently attached to a group's
@@ -165,10 +256,63 @@ func (r *groupMemberRegistry) snapshot() []groupMemberView {
 	return out
 }
 
-// count is the number of live member VMs (for NodeStatus live_vms summing once
-// Task 5 lands; 0 in Task 4).
+// count is the number of live member VMs (for NodeStatus live_vms summing).
 func (r *groupMemberRegistry) count() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return len(r.members)
+}
+
+// ---- banked group bundle inventory ------------------------------------------
+
+// groupBundleEntry is one member's banked snapshot within a group bundle set on
+// disk (R5), stored under group/<set_id>/<member_name>/. Seeded from disk on start
+// (ScanGroupBundleSets) and updated on a member bank. The daemon reports these
+// GROUPED BY set_id and makes NO completeness judgment (the control plane decides
+// whether a set has every member it needs to relight).
+type groupBundleEntry struct {
+	setID           string
+	memberName      string
+	groupInstanceID string
+	snapshotRef     string
+	sizeBytes       int64
+	createdAtUnixMs int64
+}
+
+// groupBundleRegistry is the in-memory banked-group-bundle inventory, keyed by the
+// opaque per-member snapshot_ref (group/<set_id>/<member_name>). Seeded from disk on
+// start and updated on bank; the NodeStatus projection groups entries by set_id.
+type groupBundleRegistry struct {
+	mu    sync.Mutex
+	snaps map[string]*groupBundleEntry
+}
+
+func newGroupBundleRegistry() *groupBundleRegistry {
+	return &groupBundleRegistry{snaps: make(map[string]*groupBundleEntry)}
+}
+
+// add records a banked group member bundle (from a bank or a startup rescan).
+func (r *groupBundleRegistry) add(e groupBundleEntry) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := e
+	r.snaps[e.snapshotRef] = &cp
+}
+
+// remove deletes a snapshot_ref from the inventory (idempotent).
+func (r *groupBundleRegistry) remove(ref string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.snaps, ref)
+}
+
+// snapshot returns a copy of every banked group bundle entry.
+func (r *groupBundleRegistry) snapshot() []groupBundleEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]groupBundleEntry, 0, len(r.snaps))
+	for _, e := range r.snaps {
+		out = append(out, *e)
+	}
+	return out
 }

--- a/projects/embervm/noded/server/group_registry.go
+++ b/projects/embervm/noded/server/group_registry.go
@@ -1,0 +1,174 @@
+package server
+
+import (
+	"context"
+	"net"
+	"sync"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/serving"
+	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
+)
+
+// groupNetwork is the host composite-group networking seam the server depends on:
+// per-group bridge create/teardown, deterministic member addressing, inter-group
+// isolation, and the entry-member DNAT. The real *serving.GroupManager satisfies
+// it; tests inject a fake. It is a SEPARATE seam from servingNetwork (a group owns
+// one bridge PER INSTANCE, not a single shared bridge) so a Server built without
+// group support (older tests) still compiles: a nil groupNet leaves
+// CreateGroupNetwork/DeleteGroupNetwork returning Unimplemented and
+// NodeStatus.group_networks empty.
+type groupNetwork interface {
+	// EnsureNetwork enables IPv4 forwarding and applies the (initially empty, or
+	// post-adoption) group nftables posture once on daemon start.
+	EnsureNetwork(ctx context.Context) error
+	// CreateGroupNetwork validates the /24 (within the supernet, non-overlapping),
+	// creates the per-group bridge, installs the inter-group isolation, and returns
+	// (bridge, gateway). Idempotent per group_instance_id.
+	CreateGroupNetwork(ctx context.Context, groupInstanceID, cidr string) (bridge, gatewayIP string, err error)
+	// DeleteGroupNetwork tears down a group's bridge and drops it from the ruleset.
+	// The attached-member refusal is enforced by the CALLER before this runs.
+	DeleteGroupNetwork(ctx context.Context, groupInstanceID string) error
+	// AdoptGroupNetwork re-seeds one group from an on-disk record on boot, without
+	// touching the bridge (EnsureNetwork rebuilds the table once afterwards).
+	AdoptGroupNetwork(groupInstanceID, cidr string, createdAtUnixMs int64) error
+	// Has reports whether a group network is currently held.
+	Has(groupInstanceID string) bool
+	// List projects every held group network for NodeStatus assembly.
+	List() []serving.GroupNetworkInfo
+	// MemberAddressingFor derives the deterministic (tap, mac, ip) for a member
+	// without reserving the IP (read-only; Task 5 uses the reserving variant).
+	MemberAddressingFor(groupInstanceID, memberName string, memberIndex uint32) (tap, mac string, ip net.IP, err error)
+	// EntryEndpoint projects a group entry member's (tap IP, guest port) into the
+	// reported endpoint (pod IP + DNAT port when enabled, else the tap unchanged).
+	EntryEndpoint(entryIP net.IP, guestPort uint32) (string, uint32)
+}
+
+// groupRecordStore is the on-disk group-network record seam: write a record on
+// create, remove it on delete, and rescan records on boot. The real
+// *driver.Driver satisfies it; tests inject a fake. Separate from groupNetwork so
+// the durable-truth persistence is testable independently of the live networking.
+type groupRecordStore interface {
+	// WriteGroupNetworkRecord persists a group-network record atomically.
+	WriteGroupNetworkRecord(rec substrate.GroupNetworkRecord) error
+	// RemoveGroupNetworkRecord deletes a group's on-disk record (idempotent).
+	RemoveGroupNetworkRecord(groupInstanceID string) error
+	// ScanGroupNetworks returns every valid on-disk record for the boot rescan.
+	ScanGroupNetworks() []substrate.GroupNetworkRecord
+	// GroupNetworksDir is the directory holding the records, ensured on start.
+	GroupNetworksDir() string
+}
+
+// groupMemberEntry is one LIVE composite-group member microVM the daemon
+// supervises (R5). It is Task 5 that ADDS entries here (via StartGroupMember);
+// Task 4 only needs the registry to EXIST and to answer memberCount (0 until Task
+// 5) and the attached-member check for DeleteGroupNetwork. The shape mirrors
+// statefulEntry so Task 5 can extend it with a probe, generation-free.
+type groupMemberEntry struct {
+	vmID            string
+	groupInstanceID string
+	memberName      string
+	ip              net.IP
+	// isEntry marks the group's entry member (the one exposed via the entry DNAT).
+	isEntry bool
+	// probe is the running TCP-connect health-probe loop for this member (set by
+	// Task 5). nil in Task 4 (no live members yet).
+	probe *serving.ProbeHandle
+
+	mu       sync.Mutex // guards inFlight (Task 5's stop serialization)
+	inFlight bool
+}
+
+// groupMemberRegistry is the daemon's inventory of LIVE composite-group member
+// microVMs, keyed by the opaque vm_id. Kept DISTINCT from every other class
+// registry so a member VM is never reported in primed_vm_ids, session_vms,
+// serving_vms, or stateful_vms (a member VM is never in the task pool), while
+// still counting against the node live-VM cap via the shared driver's LiveCount.
+// In Task 4 it is created empty and only READ (memberCount, attached-member
+// check); Task 5 fills it.
+type groupMemberRegistry struct {
+	mu      sync.Mutex
+	members map[string]*groupMemberEntry
+}
+
+func newGroupMemberRegistry() *groupMemberRegistry {
+	return &groupMemberRegistry{members: make(map[string]*groupMemberEntry)}
+}
+
+// add registers a live member VM (Task 5).
+func (r *groupMemberRegistry) add(e *groupMemberEntry) {
+	r.mu.Lock()
+	r.members[e.vmID] = e
+	r.mu.Unlock()
+}
+
+// remove deletes a vm_id and returns its entry (nil if absent).
+func (r *groupMemberRegistry) remove(id string) *groupMemberEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e := r.members[id]
+	delete(r.members, id)
+	return e
+}
+
+// memberCount is the number of live members currently attached to a group's
+// bridge, read by nodeStatus (per-group member_count) and by the
+// DeleteGroupNetwork attached-member refusal.
+func (r *groupMemberRegistry) memberCount(groupInstanceID string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := 0
+	for _, e := range r.members {
+		if e.groupInstanceID == groupInstanceID {
+			n++
+		}
+	}
+	return n
+}
+
+// hasMembers reports whether any live member is attached to a group (the
+// DeleteGroupNetwork backstop).
+func (r *groupMemberRegistry) hasMembers(groupInstanceID string) bool {
+	return r.memberCount(groupInstanceID) > 0
+}
+
+// groupMemberView is a lock-free, read-only projection of a groupMemberEntry, for
+// NodeStatus.group_member_vms (Task 5 populates the health verdict).
+type groupMemberView struct {
+	vmID            string
+	groupInstanceID string
+	memberName      string
+	ip              string
+	healthy         bool
+	lastProbeUnixMs int64
+}
+
+// snapshot returns a copy of every live member VM, for NodeStatus.group_member_vms.
+// Empty in Task 4; Task 5's live members flow through here.
+func (r *groupMemberRegistry) snapshot() []groupMemberView {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]groupMemberView, 0, len(r.members))
+	for _, e := range r.members {
+		v := groupMemberView{
+			vmID:            e.vmID,
+			groupInstanceID: e.groupInstanceID,
+			memberName:      e.memberName,
+			ip:              e.ip.String(),
+		}
+		if e.probe != nil {
+			res := e.probe.Result()
+			v.healthy = res.Healthy
+			v.lastProbeUnixMs = res.LastProbeUnixMs
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// count is the number of live member VMs (for NodeStatus live_vms summing once
+// Task 5 lands; 0 in Task 4).
+func (r *groupMemberRegistry) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.members)
+}

--- a/projects/embervm/noded/server/group_test.go
+++ b/projects/embervm/noded/server/group_test.go
@@ -1,0 +1,350 @@
+package server
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/config"
+	"github.com/jomcgi/homelab/projects/embervm/noded/serving"
+	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
+)
+
+// fakeGroupNet is an in-memory groupNetwork. It tracks held groups (id -> cidr)
+// and records the create/delete calls so a handler test can assert idempotency and
+// the attached-member refusal without real bridges.
+type fakeGroupNet struct {
+	mu         sync.Mutex
+	groups     map[string]string // id -> cidr
+	createErr  error
+	createN    int
+	deleteN    int
+	ensureN    int
+	adoptCalls []string
+}
+
+func newFakeGroupNet() *fakeGroupNet {
+	return &fakeGroupNet{groups: map[string]string{}}
+}
+
+func (f *fakeGroupNet) EnsureNetwork(context.Context) error {
+	f.mu.Lock()
+	f.ensureN++
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeGroupNet) CreateGroupNetwork(_ context.Context, id, cidr string) (string, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.createErr != nil {
+		return "", "", f.createErr
+	}
+	if existing, ok := f.groups[id]; ok {
+		if existing != cidr {
+			return "", "", status.Errorf(codes.FailedPrecondition, "group %q exists with a different cidr", id)
+		}
+		return "emg-" + id, "10.101.1.1", nil // idempotent hit: no create count bump
+	}
+	f.createN++
+	f.groups[id] = cidr
+	return "emg-" + id, "10.101.1.1", nil
+}
+
+func (f *fakeGroupNet) DeleteGroupNetwork(_ context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleteN++
+	delete(f.groups, id)
+	return nil
+}
+
+func (f *fakeGroupNet) AdoptGroupNetwork(id, cidr string, _ int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.adoptCalls = append(f.adoptCalls, id)
+	f.groups[id] = cidr
+	return nil
+}
+
+func (f *fakeGroupNet) Has(id string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.groups[id]
+	return ok
+}
+
+func (f *fakeGroupNet) List() []serving.GroupNetworkInfo {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]serving.GroupNetworkInfo, 0, len(f.groups))
+	for id, cidr := range f.groups {
+		out = append(out, serving.GroupNetworkInfo{
+			GroupInstanceID: id,
+			Bridge:          "emg-" + id,
+			CIDR:            cidr,
+			GatewayIP:       "10.101.1.1",
+		})
+	}
+	return out
+}
+
+func (f *fakeGroupNet) MemberAddressingFor(id, member string, index uint32) (string, string, net.IP, error) {
+	return "emgt-" + member, "02:00:00:00:00:01", net.ParseIP("10.101.1.10"), nil
+}
+
+func (f *fakeGroupNet) EntryEndpoint(ip net.IP, port uint32) (string, uint32) {
+	return ip.String(), port
+}
+
+// fakeGroupRecords is an in-memory groupRecordStore.
+type fakeGroupRecords struct {
+	mu       sync.Mutex
+	records  map[string]substrate.GroupNetworkRecord
+	writeN   int
+	removeN  int
+	writeErr error
+	dir      string
+}
+
+func newFakeGroupRecords(dir string) *fakeGroupRecords {
+	return &fakeGroupRecords{records: map[string]substrate.GroupNetworkRecord{}, dir: dir}
+}
+
+func (f *fakeGroupRecords) WriteGroupNetworkRecord(rec substrate.GroupNetworkRecord) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	f.writeN++
+	f.records[rec.GroupInstanceID] = rec
+	return nil
+}
+
+func (f *fakeGroupRecords) RemoveGroupNetworkRecord(id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.removeN++
+	delete(f.records, id)
+	return nil
+}
+
+func (f *fakeGroupRecords) ScanGroupNetworks() []substrate.GroupNetworkRecord {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]substrate.GroupNetworkRecord, 0, len(f.records))
+	for _, r := range f.records {
+		out = append(out, r)
+	}
+	return out
+}
+
+func (f *fakeGroupRecords) GroupNetworksDir() string { return f.dir }
+
+// newGroupTestServer builds a Server wired with the group seams (no gRPC dial; the
+// handlers are called in-process).
+func newGroupTestServer(t *testing.T, gn *fakeGroupNet, gr *fakeGroupRecords) *Server {
+	t.Helper()
+	s := New(Options{
+		Config:       config.Config{Arch: "amd64", Node: "node-4", SnapshotRoot: t.TempDir()},
+		Driver:       &fakeDriver{},
+		Transport:    &fakeTransport{},
+		GroupNet:     gn,
+		GroupRecords: gr,
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	s.memHeadroom = func() uint64 { return 0 }
+	return s
+}
+
+// TestCreateGroupNetworkPersistsAndReports asserts a create issues one create +
+// one record write and shows up in NodeStatus.group_networks with member_count 0.
+func TestCreateGroupNetworkPersistsAndReports(t *testing.T) {
+	gn := newFakeGroupNet()
+	gr := newFakeGroupRecords(t.TempDir())
+	s := newGroupTestServer(t, gn, gr)
+
+	resp, err := s.CreateGroupNetwork(context.Background(), &nodev1.CreateGroupNetworkRequest{
+		GroupInstanceId: "grp-A",
+		Cidr:            "10.101.1.0/24",
+	})
+	if err != nil {
+		t.Fatalf("CreateGroupNetwork: %v", err)
+	}
+	if resp.GetBridgeName() != "emg-grp-A" || resp.GetGatewayIp() != "10.101.1.1" {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+	if gn.createN != 1 || gr.writeN != 1 {
+		t.Errorf("createN=%d writeN=%d, want 1/1", gn.createN, gr.writeN)
+	}
+
+	ns := s.nodeStatus()
+	if len(ns.GetGroupNetworks()) != 1 {
+		t.Fatalf("group_networks = %v", ns.GetGroupNetworks())
+	}
+	g := ns.GetGroupNetworks()[0]
+	if g.GetGroupInstanceId() != "grp-A" || g.GetCidr() != "10.101.1.0/24" || g.GetMemberCount() != 0 {
+		t.Errorf("group network status = %+v", g)
+	}
+	// group_member_vms and group_bundle_sets are present-but-empty in Task 4.
+	if len(ns.GetGroupMemberVms()) != 0 || len(ns.GetGroupBundleSets()) != 0 {
+		t.Errorf("group members/bundle sets should be empty in Task 4")
+	}
+}
+
+// TestCreateGroupNetworkIdempotent asserts a re-issue with the same cidr writes the
+// record again (idempotent overwrite) but the underlying create is a no-op hit.
+func TestCreateGroupNetworkIdempotent(t *testing.T) {
+	gn := newFakeGroupNet()
+	gr := newFakeGroupRecords(t.TempDir())
+	s := newGroupTestServer(t, gn, gr)
+	req := &nodev1.CreateGroupNetworkRequest{GroupInstanceId: "grp-A", Cidr: "10.101.1.0/24"}
+	if _, err := s.CreateGroupNetwork(context.Background(), req); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if _, err := s.CreateGroupNetwork(context.Background(), req); err != nil {
+		t.Fatalf("idempotent re-create: %v", err)
+	}
+	if gn.createN != 1 {
+		t.Errorf("idempotent re-create bumped createN to %d, want 1", gn.createN)
+	}
+}
+
+// TestCreateGroupNetworkValidationError asserts a manager validation/overlap error
+// maps to FAILED_PRECONDITION and writes NO record.
+func TestCreateGroupNetworkValidationError(t *testing.T) {
+	gn := newFakeGroupNet()
+	gn.createErr = status.Error(codes.FailedPrecondition, "bad cidr")
+	gr := newFakeGroupRecords(t.TempDir())
+	s := newGroupTestServer(t, gn, gr)
+	_, err := s.CreateGroupNetwork(context.Background(), &nodev1.CreateGroupNetworkRequest{
+		GroupInstanceId: "grp-A", Cidr: "10.200.1.0/24",
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("want FailedPrecondition, got %v", err)
+	}
+	if gr.writeN != 0 {
+		t.Errorf("no record should be written on a validation failure, got writeN=%d", gr.writeN)
+	}
+}
+
+// TestCreateGroupNetworkRecordWriteRollback asserts that if the record write fails,
+// the just-created network is torn back down (no half-created group).
+func TestCreateGroupNetworkRecordWriteRollback(t *testing.T) {
+	gn := newFakeGroupNet()
+	gr := newFakeGroupRecords(t.TempDir())
+	gr.writeErr = status.Error(codes.Internal, "disk full")
+	s := newGroupTestServer(t, gn, gr)
+	_, err := s.CreateGroupNetwork(context.Background(), &nodev1.CreateGroupNetworkRequest{
+		GroupInstanceId: "grp-A", Cidr: "10.101.1.0/24",
+	})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("want Internal, got %v", err)
+	}
+	if gn.deleteN != 1 {
+		t.Errorf("a record-write failure must roll back the network (deleteN=%d, want 1)", gn.deleteN)
+	}
+}
+
+// TestDeleteGroupNetworkRefusesWhenAttached asserts a live member blocks the
+// delete with FAILED_PRECONDITION and leaves the network + record intact.
+func TestDeleteGroupNetworkRefusesWhenAttached(t *testing.T) {
+	gn := newFakeGroupNet()
+	gr := newFakeGroupRecords(t.TempDir())
+	s := newGroupTestServer(t, gn, gr)
+	if _, err := s.CreateGroupNetwork(context.Background(), &nodev1.CreateGroupNetworkRequest{
+		GroupInstanceId: "grp-A", Cidr: "10.101.1.0/24",
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Simulate a live member (what Task 5 will add).
+	s.groupMembers.add(&groupMemberEntry{
+		vmID:            "m1",
+		groupInstanceID: "grp-A",
+		memberName:      "worker-0",
+		ip:              net.ParseIP("10.101.1.10"),
+	})
+
+	_, err := s.DeleteGroupNetwork(context.Background(), &nodev1.DeleteGroupNetworkRequest{GroupInstanceId: "grp-A"})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("delete with an attached member must be FailedPrecondition, got %v", err)
+	}
+	if !gn.Has("grp-A") {
+		t.Error("the network must remain after a refused delete")
+	}
+	if gn.deleteN != 0 {
+		t.Errorf("no teardown should have run (deleteN=%d)", gn.deleteN)
+	}
+
+	// After the member leaves, delete succeeds and removes the record.
+	s.groupMembers.remove("m1")
+	if _, err := s.DeleteGroupNetwork(context.Background(), &nodev1.DeleteGroupNetworkRequest{GroupInstanceId: "grp-A"}); err != nil {
+		t.Fatalf("delete after member left: %v", err)
+	}
+	if gn.Has("grp-A") {
+		t.Error("network still held after delete")
+	}
+	if gr.removeN == 0 {
+		t.Error("record not removed on delete")
+	}
+}
+
+// TestDeleteGroupNetworkIdempotent asserts deleting an unknown group is a no-op OK.
+func TestDeleteGroupNetworkIdempotent(t *testing.T) {
+	gn := newFakeGroupNet()
+	gr := newFakeGroupRecords(t.TempDir())
+	s := newGroupTestServer(t, gn, gr)
+	if _, err := s.DeleteGroupNetwork(context.Background(), &nodev1.DeleteGroupNetworkRequest{GroupInstanceId: "ghost"}); err != nil {
+		t.Errorf("deleting an unknown group should be a no-op OK, got %v", err)
+	}
+}
+
+// TestReconcileGroupNetworksFromDisk asserts the boot rescan adopts every valid
+// record into the manager.
+func TestReconcileGroupNetworksFromDisk(t *testing.T) {
+	gn := newFakeGroupNet()
+	dir := t.TempDir()
+	gr := newFakeGroupRecords(dir)
+	gr.records["grp-A"] = substrate.GroupNetworkRecord{GroupInstanceID: "grp-A", SubnetCIDR: "10.101.1.0/24"}
+	gr.records["grp-B"] = substrate.GroupNetworkRecord{GroupInstanceID: "grp-B", SubnetCIDR: "10.101.2.0/24"}
+	s := newGroupTestServer(t, gn, gr)
+
+	s.ReconcileGroupNetworksFromDisk()
+	if len(gn.adoptCalls) != 2 {
+		t.Fatalf("adopted %d groups, want 2: %v", len(gn.adoptCalls), gn.adoptCalls)
+	}
+	if !gn.Has("grp-A") || !gn.Has("grp-B") {
+		t.Error("both records should be adopted into the manager")
+	}
+}
+
+// TestGroupVerbsUnimplementedWithoutManager asserts that a Server built without a
+// group manager returns Unimplemented (task/serving-only builds untouched).
+func TestGroupVerbsUnimplementedWithoutManager(t *testing.T) {
+	s := New(Options{
+		Config:    config.Config{Arch: "amd64", Node: "node-4", SnapshotRoot: t.TempDir()},
+		Driver:    &fakeDriver{},
+		Transport: &fakeTransport{},
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if _, err := s.CreateGroupNetwork(context.Background(), &nodev1.CreateGroupNetworkRequest{GroupInstanceId: "g", Cidr: "10.101.1.0/24"}); status.Code(err) != codes.Unimplemented {
+		t.Errorf("CreateGroupNetwork without a manager should be Unimplemented, got %v", err)
+	}
+	if _, err := s.DeleteGroupNetwork(context.Background(), &nodev1.DeleteGroupNetworkRequest{GroupInstanceId: "g"}); status.Code(err) != codes.Unimplemented {
+		t.Errorf("DeleteGroupNetwork without a manager should be Unimplemented, got %v", err)
+	}
+	// NodeStatus must still assemble with empty group fields.
+	ns := s.nodeStatus()
+	if len(ns.GetGroupNetworks()) != 0 {
+		t.Errorf("group_networks should be empty without a manager")
+	}
+}

--- a/projects/embervm/noded/server/group_test.go
+++ b/projects/embervm/noded/server/group_test.go
@@ -22,17 +22,28 @@ import (
 // and records the create/delete calls so a handler test can assert idempotency and
 // the attached-member refusal without real bridges.
 type fakeGroupNet struct {
-	mu         sync.Mutex
-	groups     map[string]string // id -> cidr
-	createErr  error
-	createN    int
-	deleteN    int
-	ensureN    int
-	adoptCalls []string
+	mu           sync.Mutex
+	groups       map[string]string // id -> cidr
+	createErr    error
+	createN      int
+	deleteN      int
+	ensureN      int
+	adoptCalls   []string
+	taps         map[string]bool // member -> tap created
+	removedTaps  []string
+	ensureTapErr error
+	ensureCalls  []ensureTapCall
+}
+
+// ensureTapCall records one EnsureMemberTap invocation for pinned-world assertions.
+type ensureTapCall struct {
+	member string
+	index  uint32
+	wantIP string
 }
 
 func newFakeGroupNet() *fakeGroupNet {
-	return &fakeGroupNet{groups: map[string]string{}}
+	return &fakeGroupNet{groups: map[string]string{}, taps: map[string]bool{}}
 }
 
 func (f *fakeGroupNet) EnsureNetwork(context.Context) error {
@@ -98,8 +109,32 @@ func (f *fakeGroupNet) List() []serving.GroupNetworkInfo {
 }
 
 func (f *fakeGroupNet) MemberAddressingFor(id, member string, index uint32) (string, string, net.IP, error) {
-	return "emgt-" + member, "02:00:00:00:00:01", net.ParseIP("10.101.1.10"), nil
+	return "emgt-" + member, "02:00:00:00:00:01", net.ParseIP("127.0.0.1"), nil
 }
+
+// EnsureMemberTap hands out the loopback IP as the "pinned" address (so the server's
+// real TCP health-gate reaches the test's local endpoint) and records the pin call
+// so a test can assert the pinned-world reconstruction on relight (same member +
+// index re-pinned). ensureTapErr, when set, makes it fail (the pin-failure path).
+func (f *fakeGroupNet) EnsureMemberTap(_ context.Context, id, member string, index uint32, wantIP net.IP) (string, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.ensureTapErr != nil {
+		return "", "", f.ensureTapErr
+	}
+	f.taps[member] = true
+	f.ensureCalls = append(f.ensureCalls, ensureTapCall{member: member, index: index, wantIP: wantIP.String()})
+	return "emgt-" + member, "02:00:00:00:00:01", nil
+}
+
+func (f *fakeGroupNet) RemoveMemberTap(_ context.Context, id, tap string, ip net.IP) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.removedTaps = append(f.removedTaps, tap)
+}
+
+func (f *fakeGroupNet) GatewayIP(id string) net.IP { return net.IPv4(10, 101, 1, 1) }
+func (f *fakeGroupNet) PrefixLen(id string) int    { return 24 }
 
 func (f *fakeGroupNet) EntryEndpoint(ip net.IP, port uint32) (string, uint32) {
 	return ip.String(), port

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -197,6 +197,21 @@ type Server struct {
 	// (R4). Overridable in tests, mirroring newProber.
 	newTCPProber func() *serving.TCPProber
 
+	// groupNet owns the host composite-group networking (per-group bridges, member
+	// addressing, inter-group isolation, entry DNAT). nil disables the R5 group
+	// verbs: CreateGroupNetwork/DeleteGroupNetwork then return Unimplemented and
+	// NodeStatus.group_networks is empty. In production a *serving.GroupManager
+	// satisfies it.
+	groupNet groupNetwork
+	// groupRecords owns the durable on-disk group-network records (the adoption
+	// source of truth). nil (alongside a nil groupNet) disables the group verbs. In
+	// production the same *driver.Driver satisfies it.
+	groupRecords groupRecordStore
+	// groupMembers is the live composite-group member registry. Created empty in
+	// Task 4 (only read for member_count and the DeleteGroupNetwork attached-member
+	// refusal); Task 5's StartGroupMember fills it.
+	groupMembers *groupMemberRegistry
+
 	drainingMu sync.RWMutex
 	draining   bool
 
@@ -242,6 +257,14 @@ type Options struct {
 	// serving probe knobs but for opaque L4 TCP CONNECT instead of HTTP GET.
 	StatefulProbeInterval      time.Duration
 	StatefulUnhealthyThreshold int
+	// GroupNet and GroupRecords serve the R5 composite-group verbs
+	// (CreateGroupNetwork/DeleteGroupNetwork, and Task 5's member lifecycle). Both
+	// nil (the default) leaves the group verbs returning Unimplemented, so a Server
+	// built without group support still compiles and every other class is
+	// untouched. In production a *serving.GroupManager satisfies GroupNet and the
+	// same *driver.Driver satisfies GroupRecords.
+	GroupNet     groupNetwork
+	GroupRecords groupRecordStore
 }
 
 // New builds a Server. Driver and Transport must not be nil.
@@ -269,6 +292,9 @@ func New(opts Options) *Server {
 		statefulVMs:     newStatefulRegistry(),
 		statefulBundles: newStatefulBundleRegistry(),
 		statefulDriver:  opts.StatefulDriver,
+		groupNet:        opts.GroupNet,
+		groupRecords:    opts.GroupRecords,
+		groupMembers:    newGroupMemberRegistry(),
 		subs:            make(map[chan struct{}]struct{}),
 	}
 	// VolumeRoot may be set directly on Options (mirroring how cmd/main.go wires
@@ -1205,7 +1231,11 @@ func (s *Server) nodeStatus() *nodev1.NodeStatus {
 	// serving (all four classes Claim through the same driver, so its LiveCount
 	// already sums them; naming the invariant here mirrors the session/serving
 	// comment above).
-	live := taskLive + len(sessionVMs) + len(servingVMs) + len(statefulVMs)
+	// Group member VMs count against the node live-VM total alongside every other
+	// class (all Claim through the same driver). Empty in Task 4; Task 5 fills the
+	// member registry.
+	groupMemberVMs := s.groupMemberVmsStatus()
+	live := taskLive + len(sessionVMs) + len(servingVMs) + len(statefulVMs) + len(groupMemberVMs)
 	snaps := s.sessionSnapshotsStatus()
 	freeBytes, usedBytes := s.snapshotDiskUsage()
 	return &nodev1.NodeStatus{
@@ -1227,6 +1257,10 @@ func (s *Server) nodeStatus() *nodev1.NodeStatus {
 		StatefulVms:           statefulVMs,
 		StatefulBundles:       s.statefulBundlesStatus(),
 		Volumes:               s.volumesStatus(),
+		GroupNetworks:         s.groupNetworksStatus(),
+		GroupMemberVms:        groupMemberVMs,
+		// group_bundle_sets stays empty-but-present in Task 4; the group bank
+		// inventory (grouped by set dir) lands with Task 5's member bank.
 	}
 }
 

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -196,6 +196,9 @@ type Server struct {
 	// newTCPProber builds the per-VM TCP-connect health prober from config
 	// (R4). Overridable in tests, mirroring newProber.
 	newTCPProber func() *serving.TCPProber
+	// newGroupTCPProber builds the per-member TCP-connect health prober (R5).
+	// Overridable in tests, mirroring newTCPProber.
+	newGroupTCPProber func() *serving.TCPProber
 
 	// groupNet owns the host composite-group networking (per-group bridges, member
 	// addressing, inter-group isolation, entry DNAT). nil disables the R5 group
@@ -207,10 +210,23 @@ type Server struct {
 	// source of truth). nil (alongside a nil groupNet) disables the group verbs. In
 	// production the same *driver.Driver satisfies it.
 	groupRecords groupRecordStore
-	// groupMembers is the live composite-group member registry. Created empty in
-	// Task 4 (only read for member_count and the DeleteGroupNetwork attached-member
-	// refusal); Task 5's StartGroupMember fills it.
+	// groupMembers is the live composite-group member registry, filled by
+	// StartGroupMember and drained by StopGroupMember. It counts against the node
+	// live-VM cap (via the shared driver's LiveCount) and is EXCLUDED from
+	// primed_vm_ids and every other class registry.
 	groupMembers *groupMemberRegistry
+	// groupDriver serves the R5 member-class driver mechanics (cold boot with a NIC
+	// on the group bridge, bank/relight under group/<set_id>/<member>/). nil
+	// (alongside a nil groupNet) disables the member verbs, which then return
+	// Unimplemented. In production the same *driver.Driver satisfies it.
+	groupDriver groupMemberDriver
+	// groupBundles is the banked-group-bundle inventory, seeded from disk on start
+	// (ScanGroupBundleSets) and updated on a member bank; reported grouped by set_id.
+	groupBundles *groupBundleRegistry
+	// groupClock is the host-side clock-resync seam a member RELIGHT uses over the
+	// port-1024 length-prefixed JSON agent channel. nil falls back to the real
+	// groupclock.Resync; overridable in tests.
+	groupClock groupClock
 
 	drainingMu sync.RWMutex
 	draining   bool
@@ -265,6 +281,18 @@ type Options struct {
 	// same *driver.Driver satisfies GroupRecords.
 	GroupNet     groupNetwork
 	GroupRecords groupRecordStore
+	// GroupDriver serves the R5 member lifecycle (StartGroupMember/StopGroupMember).
+	// nil (the default) leaves the member verbs returning Unimplemented, so a Server
+	// built without group support still compiles. In production the same
+	// *driver.Driver satisfies GroupDriver.
+	GroupDriver groupMemberDriver
+	// GroupClock is the host-side member clock-resync seam. nil uses the real
+	// groupclock.Resync over a VsockDialer; tests inject a fake.
+	GroupClock groupClock
+	// GroupProbeInterval / GroupUnhealthyThreshold configure the per-member TCP
+	// health probe loop (defaults applied when zero), mirroring the stateful knobs.
+	GroupProbeInterval      time.Duration
+	GroupUnhealthyThreshold int
 }
 
 // New builds a Server. Driver and Transport must not be nil.
@@ -295,6 +323,9 @@ func New(opts Options) *Server {
 		groupNet:        opts.GroupNet,
 		groupRecords:    opts.GroupRecords,
 		groupMembers:    newGroupMemberRegistry(),
+		groupDriver:     opts.GroupDriver,
+		groupBundles:    newGroupBundleRegistry(),
+		groupClock:      opts.GroupClock,
 		subs:            make(map[chan struct{}]struct{}),
 	}
 	// VolumeRoot may be set directly on Options (mirroring how cmd/main.go wires
@@ -315,6 +346,15 @@ func New(opts Options) *Server {
 	statefulProbeInterval := opts.StatefulProbeInterval
 	statefulProbeThreshold := opts.StatefulUnhealthyThreshold
 	s.newTCPProber = func() *serving.TCPProber { return serving.NewTCPProber(statefulProbeInterval, statefulProbeThreshold) }
+	groupProbeInterval := opts.GroupProbeInterval
+	groupProbeThreshold := opts.GroupUnhealthyThreshold
+	s.newGroupTCPProber = func() *serving.TCPProber { return serving.NewTCPProber(groupProbeInterval, groupProbeThreshold) }
+	// The R5 member RELIGHT clock resync defaults to the real vsock-backed groupclock
+	// (port-1024 length-prefixed JSON, host-wall-clock source) unless a test injects a
+	// fake. A member relight FAILS when the read-back is more than one second off.
+	if s.groupClock == nil {
+		s.groupClock = &realGroupClock{}
+	}
 	s.memHeadroom = readMemHeadroomMib
 	// Re-seed the serving-images inventory from disk so a daemon restart re-discovers
 	// the cold-boot handler artifacts it built before (mirroring the banked-snapshot
@@ -1259,8 +1299,7 @@ func (s *Server) nodeStatus() *nodev1.NodeStatus {
 		Volumes:               s.volumesStatus(),
 		GroupNetworks:         s.groupNetworksStatus(),
 		GroupMemberVms:        groupMemberVMs,
-		// group_bundle_sets stays empty-but-present in Task 4; the group bank
-		// inventory (grouped by set dir) lands with Task 5's member bank.
+		GroupBundleSets:       s.groupBundleSetsStatus(),
 	}
 }
 

--- a/projects/embervm/noded/serving/BUILD
+++ b/projects/embervm/noded/serving/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "serving",
     srcs = [
         "alloc.go",
+        "group.go",
         "net.go",
         "probe.go",
         "probe_tcp.go",
@@ -16,6 +17,7 @@ go_test(
     name = "serving_test",
     srcs = [
         "alloc_test.go",
+        "group_test.go",
         "net_test.go",
         "probe_test.go",
     ],

--- a/projects/embervm/noded/serving/group.go
+++ b/projects/embervm/noded/serving/group.go
@@ -178,12 +178,15 @@ type groupEntry struct {
 // current set of group bridges and the entry-member DNAT set:
 //
 //   - a group_forward filter chain that accepts established/related (so entry-path
-//     return traffic and reply packets flow), then DROPS every ordered pair of
-//     distinct group bridges (bridge A in, bridge B out): this is the
-//     composite<->composite isolation, and enumerating BOTH ordered pairs covers
-//     both directions. It also DROPS every group-bridge-in / serving-bridge-out
-//     pair (composite->serving). Members thus have NO L3 egress beyond their own
-//     group bridge plus the entry path (task-class zero-egress posture at L3);
+//     return traffic and reply packets flow), then, PER BRIDGE, DROPS every NEW
+//     packet leaving that bridge to anywhere else (iifname "emgX" oifname != "emgX"
+//     ct state new drop): this is the primary ZERO-EGRESS denial (standing decision
+//     4), keeping intra-group member<->member forwarding but denying other groups,
+//     the serving bridge, AND external/CNI egress. It ALSO redundantly DROPS every
+//     ordered pair of distinct group bridges (composite<->composite) and every
+//     group-bridge-in / serving-bridge-out pair (composite->serving), kept for
+//     readability though subsumed by the per-bridge egress drop. Members thus have
+//     NO L3 egress beyond their own group bridge plus the entry path;
 //   - when podIP is set (the deployed D-R3.11.4 posture), a group_dnat prerouting
 //     nat chain with one rule per group's ENTRY member rewriting podIP:vmPort ->
 //     entryTapIP:guestPort, the exact serving_dnat lane reused. When podIP is
@@ -204,9 +207,24 @@ func nftGroupRuleset(bridges []string, servingBridge, podIP string, entries []gr
 	// any reply to an accepted flow), evaluated before the drops so isolation only
 	// ever bites NEW cross-boundary forwarding.
 	fmt.Fprintf(&b, "add rule inet %s %s ct state established,related accept\n", nftGroupTable, nftGroupForwardChain)
+	// Per-bridge ZERO-EGRESS denial (standing decision 4: members have no egress
+	// beyond their own group and the entry path). For each group bridge, drop every
+	// NEW packet whose input iface is that bridge and whose output iface is NOT the
+	// same bridge: this keeps intra-group member<->member forwarding (iif==oif==emgX)
+	// but denies a member reaching ANYWHERE else (other groups, the serving bridge,
+	// AND the external/CNI overlay). It SUBSUMES the explicit cross-group and
+	// group->serving drops below; those are kept as belt-and-braces so the isolation
+	// intent stays legible in the rendered ruleset. The entry-DNAT lane is unaffected:
+	// an inbound entry packet has iif=<pod iface>, not a group bridge, so it never
+	// matches this drop, and its DNAT'd forward (oif=emgX) plus the established reply
+	// flow through the accept above.
+	for _, br := range sortedBridges {
+		fmt.Fprintf(&b, "add rule inet %s %s iifname \"%s\" oifname != \"%s\" ct state new drop\n", nftGroupTable, nftGroupForwardChain, br, br)
+	}
 	// composite<->composite: drop every ordered pair of DISTINCT group bridges.
 	// Enumerating ordered pairs (A->B and B->A both appear) covers both directions
-	// with a single, deterministic loop.
+	// with a single, deterministic loop. Redundant with the per-bridge egress drop
+	// above (kept for readability).
 	for _, in := range sortedBridges {
 		for _, out := range sortedBridges {
 			if in == out {

--- a/projects/embervm/noded/serving/group.go
+++ b/projects/embervm/noded/serving/group.go
@@ -603,6 +603,66 @@ func (m *GroupManager) ReleaseMember(groupInstanceID string, ip net.IP) {
 	g.alloc.release(ip)
 }
 
+// EnsureMemberTap pins a member's NIC world on the group bridge: it derives the
+// deterministic (tap, mac, ip) for (member_name, member_index), verifies the derived
+// IP matches the control-plane-supplied wantIP (a mismatch means the control plane
+// and the daemon disagree on the pinned address, which must fail LOUDLY rather than
+// silently boot on a different IP), reserves the IP in the group allocator, and
+// creates + attaches the tap device to the group bridge. It is used by BOTH the
+// FRESH boot and the RELIGHT resume: for a relight it recreates the SAME tap name,
+// MAC, and IP the member had at bank time (the D-R3.4.1 pin applied to the group
+// bridge), because the resumed guest keeps its baked eth0 and a snapshot restore
+// never re-runs kernel init. On any tap-create failure the partial tap and the
+// reserved IP are rolled back so a failed StartGroupMember leaks neither. It returns
+// the (tap, mac) so the caller can build the NIC spec; the IP is wantIP unchanged.
+func (m *GroupManager) EnsureMemberTap(ctx context.Context, groupInstanceID, memberName string, memberIndex uint32, wantIP net.IP) (tap, mac string, err error) {
+	m.mu.Lock()
+	g, ok := m.groups[groupInstanceID]
+	bridge := ""
+	if ok {
+		bridge = g.bridge
+	}
+	m.mu.Unlock()
+	if !ok {
+		return "", "", fmt.Errorf("serving: group %q not found", groupInstanceID)
+	}
+	derivedIP, err := groupMemberIP(g.cidr, memberIndex)
+	if err != nil {
+		return "", "", err
+	}
+	if wantIP != nil && !derivedIP.Equal(wantIP) {
+		return "", "", fmt.Errorf("serving: group %q member %q index %d derives IP %v but the request pinned %v", groupInstanceID, memberName, memberIndex, derivedIP, wantIP)
+	}
+	if rerr := g.alloc.reserve(derivedIP); rerr != nil {
+		return "", "", rerr
+	}
+	tap = groupTapName(groupInstanceID, memberName)
+	mac = groupMemberMAC(groupInstanceID, memberName)
+	for _, argv := range tapSetupArgs(tap, bridge) {
+		if _, rerr := m.runner.Run(ctx, argv[0], argv[1:]...); rerr != nil {
+			// Roll back: delete whatever tap fragment exists, release the IP.
+			_, _ = m.runner.Run(ctx, "ip", tapTeardownArgs(tap)[1:]...)
+			g.alloc.release(derivedIP)
+			return "", "", rerr
+		}
+	}
+	return tap, mac, nil
+}
+
+// RemoveMemberTap deletes a member's tap device and releases its pinned IP back to
+// the group allocator (idempotent at the ip layer: deleting an absent tap is
+// tolerated). It is the symmetric teardown for EnsureMemberTap, called on a member
+// bank, destroy, or a failed start's rollback. It takes the derived tap name and the
+// pinned IP directly (the caller already holds both from the start path), so it never
+// needs to re-derive or look the group up beyond the allocator release.
+func (m *GroupManager) RemoveMemberTap(ctx context.Context, groupInstanceID, tap string, ip net.IP) {
+	if _, err := m.runner.Run(ctx, "ip", tapTeardownArgs(tap)[1:]...); err != nil {
+		// A missing tap is fine (already gone); keep teardown best-effort.
+		_ = err
+	}
+	m.ReleaseMember(groupInstanceID, ip)
+}
+
 // GatewayIP returns a group's gateway IP (the .1 of its /24), for composing a
 // member's default route. Nil if the group is not held.
 func (m *GroupManager) GatewayIP(groupInstanceID string) net.IP {

--- a/projects/embervm/noded/serving/group.go
+++ b/projects/embervm/noded/serving/group.go
@@ -1,0 +1,707 @@
+package serving
+
+// Group (R5, composite-workload) networking is the multi-member sibling of the
+// serving network above. Where serving owns ONE per-node bridge shared by every
+// serving VM, a composite group owns ONE bridge PER GROUP INSTANCE: the subnet is
+// the group's identity fabric, so members address each other by deterministic,
+// pinned IPs on their own /24 and no member of group A can reach group B's subnet
+// or the serving bridge. This file adds:
+//
+//   - per-group bridge create/teardown (one bridge per group_instance_id),
+//   - /24-in-supernet validation and overlap refusal against the live bridge set,
+//   - deterministic member addressing (index -> .10+i IP, derived MAC, pinned tap
+//     name per (group_instance_id, member_name)),
+//   - the inter-group nftables isolation (composite<->composite BOTH directions,
+//     composite->serving) in a SEPARATE table so it never collides with the
+//     serving forward/serving_dnat chains,
+//   - the entry-path DNAT for the entry member (the exact D-R3.11.4 pod-IP lane
+//     the serving network uses, reused verbatim).
+//
+// Everything privileged is exec'd through the same Runner seam and every rule /
+// argv batch is a pure function so it is table-tested without root, matching
+// net.go's discipline.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// nftGroupTable is the DEDICATED nftables table for the composite-group posture.
+// It is SEPARATE from nftTable (embervm_serving) so the group forward-isolation
+// and entry-DNAT chains can never collide with, flush, or be flushed by the
+// serving forward / serving_dnat chains: the two tables are torn down and rebuilt
+// independently. Both live in noded's own pod netns.
+const nftGroupTable = "embervm_group"
+
+// nftGroupForwardChain is the forward-hook chain that enforces inter-group
+// isolation. It runs at the SAME forward hook as the serving table's forward
+// chain; nftables evaluates every registered chain at a hook, and a drop in ANY
+// chain drops the packet, so the group DROP rules compose with (never fight) the
+// serving posture. The chain drops: any packet whose input iface is one group
+// bridge and output iface is ANOTHER group bridge (composite<->composite, both
+// directions fall out of the all-pairs rule set), and any packet from a group
+// bridge out to the serving bridge (composite->serving). Established/related is
+// accepted first so the entry-path DNAT return traffic is never caught.
+const nftGroupForwardChain = "group_forward"
+
+// nftGroupDNATChain is the prerouting nat chain that exposes each group's ENTRY
+// member as noded's routable pod IP + a per-entry port, the exact D-R3.11.4 lane
+// the serving_dnat chain uses (podIP:port -> tapIP:guestPort). Only the entry
+// member of a group gets a rule here; non-entry members are bridge-internal only.
+const nftGroupDNATChain = "group_dnat"
+
+// groupMemberBaseOffset is the host offset of member index 0 within the group
+// /24: member i is assigned .10 + i (the committed R5 addressing rule). The .1 is
+// the bridge gateway and .2..9 are reserved headroom (future per-group infra: a
+// DNS shim, a sidecar) so member addressing starts at a stable, legible .10.
+const groupMemberBaseOffset = 10
+
+// groupIfnameMax is the Linux network-interface name length limit. Bridge and tap
+// names are hash-derived and truncated to stay strictly under it (see
+// groupBridgeName / groupTapName), so a long opaque group_instance_id or
+// member_name can never overflow the kernel's IFNAMSIZ-1 budget.
+const groupIfnameMax = 15
+
+// groupBridgeName derives the deterministic per-group bridge device name from the
+// opaque group_instance_id: "emg" + the first 6 hex chars of sha256(id). That is
+// 9 chars, well under the 15-char ifname limit, and collision-safe in practice
+// (24 bits of hash over the handful of groups a node holds). Deterministic so a
+// re-issued CreateGroupNetwork for the same group_instance_id resolves the SAME
+// bridge (idempotency), and so teardown/adoption need only the id.
+func groupBridgeName(groupInstanceID string) string {
+	sum := sha256.Sum256([]byte(groupInstanceID))
+	return "emg" + hex.EncodeToString(sum[:])[:6]
+}
+
+// groupTapName derives the deterministic member tap device name from the pair
+// (group_instance_id, member_name): "emgt" + the first 6 hex chars of
+// sha256(group_instance_id\x00member_name). That is 10 chars, under the 15-char
+// ifname limit, and pinned per member so a relight re-creates the SAME tap. The
+// group id is folded in so two groups' identically-named members ("worker-0" in
+// group A and in group B) never derive the same tap name.
+func groupTapName(groupInstanceID, memberName string) string {
+	sum := sha256.Sum256([]byte(groupInstanceID + "\x00" + memberName))
+	return "emgt" + hex.EncodeToString(sum[:])[:6]
+}
+
+// groupMemberMAC derives a deterministic, locally-administered unicast MAC for a
+// member from the pair (group_instance_id, member_name): the first octet is
+// 0x02 (locally-administered bit set, multicast bit clear) and the remaining
+// five octets are the leading bytes of sha256(group_instance_id\x00member_name).
+// Deterministic so a relight (which keeps the guest's baked NIC) and a fresh boot
+// agree, and folding the group id in keeps two groups' same-named members
+// distinct. Returned as the canonical colon-separated lower-case string.
+func groupMemberMAC(groupInstanceID, memberName string) string {
+	sum := sha256.Sum256([]byte(groupInstanceID + "\x00" + memberName))
+	return fmt.Sprintf("02:%02x:%02x:%02x:%02x:%02x", sum[0], sum[1], sum[2], sum[3], sum[4])
+}
+
+// groupMemberIP returns the pinned host IP for a member INDEX within a group /24:
+// network base + (groupMemberBaseOffset + index). It errors when the resulting
+// address falls outside the network's usable host range (a member index past the
+// subnet, or a subnet too small), so a bad index fails at StartGroupMember rather
+// than configuring a bogus tap. Pure and recomputable anywhere (a relight
+// re-derives the same IP from the same index).
+func groupMemberIP(network *net.IPNet, index uint32) (net.IP, error) {
+	if network == nil {
+		return nil, fmt.Errorf("serving: nil group network")
+	}
+	base := network.IP.To4()
+	if base == nil {
+		return nil, fmt.Errorf("serving: group network %v is not IPv4", network)
+	}
+	offset := uint64(groupMemberBaseOffset) + uint64(index)
+	ip := addOffset(base, offset)
+	if !network.Contains(ip) {
+		return nil, fmt.Errorf("serving: group member index %d (host offset %d) is outside network %v", index, offset, network)
+	}
+	// The broadcast address (all host bits set) is never a usable member IP.
+	if ip.Equal(broadcastIP(network)) {
+		return nil, fmt.Errorf("serving: group member index %d resolves to the broadcast address of %v", index, network)
+	}
+	return ip, nil
+}
+
+// addOffset returns base + offset as a 4-byte IPv4 (big-endian add). Offsets are
+// small (member index within a /24), so a carry never escapes the 32-bit space
+// for any real group subnet.
+func addOffset(base net.IP, offset uint64) net.IP {
+	v4 := cloneIP(base)
+	val := uint64(v4[0])<<24 | uint64(v4[1])<<16 | uint64(v4[2])<<8 | uint64(v4[3])
+	val += offset
+	return net.IP{byte(val >> 24), byte(val >> 16), byte(val >> 8), byte(val)}
+}
+
+// groupBridgeSetupArgs returns the ordered argv batches that create one group
+// bridge, assign it the group gateway IP (the .1 of the group /24), and bring it
+// up. It is the group counterpart of bridgeSetupArgs, kept as its own pure
+// function so a reviewer sees the group bridge lifecycle explicitly; the caller
+// execs each batch in order and treats "already exists" as idempotent.
+func groupBridgeSetupArgs(bridge, gatewayIP string, prefixLen int) [][]string {
+	return [][]string{
+		{"ip", "link", "add", "name", bridge, "type", "bridge"},
+		{"ip", "addr", "add", fmt.Sprintf("%s/%d", gatewayIP, prefixLen), "dev", bridge},
+		{"ip", "link", "set", bridge, "up"},
+	}
+}
+
+// groupBridgeTeardownArgs returns the argv to delete a group bridge device.
+// Deleting the bridge detaches (and orphans) any tap still mastered by it, but
+// the delete path only runs after the member-attached refusal, so a live member
+// never has its bridge yanked. Pure for table testing.
+func groupBridgeTeardownArgs(bridge string) []string {
+	return []string{"ip", "link", "del", bridge}
+}
+
+// groupEntry is one group's ENTRY-member DNAT projection: the entry member's tap
+// IP + guest port, and the deterministic per-entry port on noded's pod IP that
+// maps to it. Only the entry member of a group is exposed on the pod IP; every
+// other member is reachable only from inside the group bridge. vmPort is
+// precomputed and stored so the ruleset generator stays a pure function of the
+// entry set and the entries sort deterministically by vmPort.
+type groupEntry struct {
+	tapIP     string
+	guestPort uint32
+	vmPort    uint32
+}
+
+// nftGroupRuleset returns the `nft -f -` ruleset text for the composite-group
+// posture as a self-contained, idempotent script over the DEDICATED
+// embervm_group table (flush-then-define of ONLY that table, so it never touches
+// embervm_serving or any other host firewall state). It installs, given the FULL
+// current set of group bridges and the entry-member DNAT set:
+//
+//   - a group_forward filter chain that accepts established/related (so entry-path
+//     return traffic and reply packets flow), then DROPS every ordered pair of
+//     distinct group bridges (bridge A in, bridge B out): this is the
+//     composite<->composite isolation, and enumerating BOTH ordered pairs covers
+//     both directions. It also DROPS every group-bridge-in / serving-bridge-out
+//     pair (composite->serving). Members thus have NO L3 egress beyond their own
+//     group bridge plus the entry path (task-class zero-egress posture at L3);
+//   - when podIP is set (the deployed D-R3.11.4 posture), a group_dnat prerouting
+//     nat chain with one rule per group's ENTRY member rewriting podIP:vmPort ->
+//     entryTapIP:guestPort, the exact serving_dnat lane reused. When podIP is
+//     empty (local/test) no DNAT chain is emitted.
+//
+// It is a pure function of (bridges, servingBridge, podIP, entries) so the exact
+// ruleset is asserted as data. bridges is sorted internally so the generated
+// script is deterministic regardless of caller map order.
+func nftGroupRuleset(bridges []string, servingBridge, podIP string, entries []groupEntry) string {
+	sortedBridges := append([]string(nil), bridges...)
+	sort.Strings(sortedBridges)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "add table inet %s\n", nftGroupTable)
+	fmt.Fprintf(&b, "flush table inet %s\n", nftGroupTable)
+	fmt.Fprintf(&b, "add chain inet %s %s { type filter hook forward priority 0; policy accept; }\n", nftGroupTable, nftGroupForwardChain)
+	// Established/related return traffic is always allowed (entry-path replies and
+	// any reply to an accepted flow), evaluated before the drops so isolation only
+	// ever bites NEW cross-boundary forwarding.
+	fmt.Fprintf(&b, "add rule inet %s %s ct state established,related accept\n", nftGroupTable, nftGroupForwardChain)
+	// composite<->composite: drop every ordered pair of DISTINCT group bridges.
+	// Enumerating ordered pairs (A->B and B->A both appear) covers both directions
+	// with a single, deterministic loop.
+	for _, in := range sortedBridges {
+		for _, out := range sortedBridges {
+			if in == out {
+				continue
+			}
+			fmt.Fprintf(&b, "add rule inet %s %s iifname \"%s\" oifname \"%s\" drop\n", nftGroupTable, nftGroupForwardChain, in, out)
+		}
+	}
+	// composite->serving: drop any packet from a group bridge out to the serving
+	// bridge (members must never reach the serving subnet). Only emitted when a
+	// serving bridge name is configured.
+	if servingBridge != "" {
+		for _, in := range sortedBridges {
+			fmt.Fprintf(&b, "add rule inet %s %s iifname \"%s\" oifname \"%s\" drop\n", nftGroupTable, nftGroupForwardChain, in, servingBridge)
+		}
+	}
+	if podIP != "" {
+		fmt.Fprintf(&b, "add chain inet %s %s { type nat hook prerouting priority dstnat; policy accept; }\n", nftGroupTable, nftGroupDNATChain)
+		sortedEntries := append([]groupEntry(nil), entries...)
+		sort.Slice(sortedEntries, func(i, j int) bool { return sortedEntries[i].vmPort < sortedEntries[j].vmPort })
+		for _, e := range sortedEntries {
+			fmt.Fprintf(&b, "add rule inet %s %s ip daddr %s tcp dport %d dnat ip to %s:%d\n",
+				nftGroupTable, nftGroupDNATChain, podIP, e.vmPort, e.tapIP, e.guestPort)
+		}
+	}
+	return b.String()
+}
+
+// nftGroupTeardownArgs returns the argv to remove the dedicated group table
+// entirely (scoped: only our table). Provided for teardown symmetry with
+// nftTeardownArgs; `nft delete table` errors on an absent table, so a caller must
+// tolerate that. The GroupManager does not use it in the happy path (it rebuilds
+// the whole table on every create/delete), but it names the scoped-teardown
+// contract. Pure for table testing.
+func nftGroupTeardownArgs() []string {
+	return []string{"nft", "delete", "table", "inet", nftGroupTable}
+}
+
+// groupNet is one live per-group network the GroupManager holds: its bridge, its
+// /24, the gateway (.1), a per-group IP allocator (member IPs are index-pinned,
+// so the allocator is used only to reserve/track, mirroring the serving pin
+// path), and the entry-member DNAT entry (at most one per group). It is created
+// by CreateGroupNetwork and removed by DeleteGroupNetwork.
+type groupNet struct {
+	groupInstanceID string
+	bridge          string
+	cidr            *net.IPNet
+	gatewayIP       net.IP
+	prefixLen       int
+	alloc           *ipAllocator
+	createdAtUnixMs int64
+	// entry is the entry-member DNAT projection (podIP:vmPort -> tapIP:guestPort),
+	// set once the entry member is live and its endpoint is DNAT'd. nil until then.
+	entry *groupEntry
+}
+
+// GroupNetworkInfo is a read-only projection of one live group network, for the
+// server's NodeStatus.group_networks assembly and for adoption. member_count is
+// filled by the caller from the live member registry (0 until Task 5 populates
+// live members), so this struct carries only what the manager owns.
+type GroupNetworkInfo struct {
+	GroupInstanceID string
+	Bridge          string
+	CIDR            string
+	GatewayIP       string
+	CreatedAtUnixMs int64
+}
+
+// GroupManager owns the host composite-group networking: the per-group bridges,
+// their /24 allocations within the values-declared composite supernet, the
+// inter-group nftables isolation, and the entry-member DNAT. It is the group
+// analogue of the serving Manager, but keyed by group_instance_id (a registry of
+// per-group networks) rather than a single shared bridge. It is safe for
+// concurrent use: a single mutex guards the group map AND serializes the nft
+// apply (the whole embervm_group table is regenerated from the current group set
+// on every create/delete), so two concurrent CreateGroupNetwork/DeleteGroupNetwork
+// calls cannot interleave ruleset writes.
+type GroupManager struct {
+	runner        Runner
+	supernet      *net.IPNet
+	servingBridge string
+	// podIP is noded's routable pod IP for the entry-member DNAT projection; empty
+	// disables entry DNAT (reports the tap IP) exactly as the serving Manager does.
+	podIP string
+	// portBase is the base of the deterministic per-entry DNAT port space (shared
+	// derivation with serving: vmPort = portBase + hostOffset within the composite
+	// supernet). Each group's entry IP is a distinct address in the supernet, so
+	// the derived ports do not collide across groups.
+	portBase int
+
+	mu     sync.Mutex
+	groups map[string]*groupNet
+}
+
+// NewGroupManager builds a GroupManager over the composite supernet CIDR. A
+// malformed supernet is an error so a misconfiguration fails loudly at startup.
+// servingBridge is the serving-class bridge name the isolation rules deny
+// composite->serving toward (empty means no serving bridge is configured and that
+// rule is omitted). podIP/portBase parameterise the entry-member DNAT exactly as
+// the serving Manager: empty podIP disables it (local/test).
+func NewGroupManager(runner Runner, supernetCIDR, servingBridge, podIP string, portBase int) (*GroupManager, error) {
+	if runner == nil {
+		runner = ExecRunner{}
+	}
+	_, supernet, err := net.ParseCIDR(supernetCIDR)
+	if err != nil {
+		return nil, fmt.Errorf("serving: invalid composite supernet %q: %w", supernetCIDR, err)
+	}
+	if supernet.IP.To4() == nil {
+		return nil, fmt.Errorf("serving: composite supernet %q is not IPv4", supernetCIDR)
+	}
+	return &GroupManager{
+		runner:        runner,
+		supernet:      supernet,
+		servingBridge: servingBridge,
+		podIP:         podIP,
+		portBase:      portBase,
+		groups:        make(map[string]*groupNet),
+	}, nil
+}
+
+// Supernet reports the composite supernet CIDR string (for logging / diagnostics).
+func (m *GroupManager) Supernet() string {
+	if m == nil || m.supernet == nil {
+		return ""
+	}
+	return m.supernet.String()
+}
+
+// validateGroupCIDR parses cidr and returns its *net.IPNet after checking it is a
+// /24 wholly inside the composite supernet. The control plane assigns the /24; the
+// daemon VALIDATES it. A non-/24, a non-IPv4, or a range not contained by the
+// supernet is an error the caller maps to FAILED_PRECONDITION per the proto.
+func (m *GroupManager) validateGroupCIDR(cidr string) (*net.IPNet, error) {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, fmt.Errorf("serving: invalid group cidr %q: %w", cidr, err)
+	}
+	base := ipnet.IP.To4()
+	if base == nil {
+		return nil, fmt.Errorf("serving: group cidr %q is not IPv4", cidr)
+	}
+	ones, bits := ipnet.Mask.Size()
+	if ones != 24 || bits != 32 {
+		return nil, fmt.Errorf("serving: group cidr %q must be a /24", cidr)
+	}
+	// Containment: both the network address and the broadcast address of the /24
+	// must fall inside the supernet (a /24 straddling the supernet edge is refused).
+	if !m.supernet.Contains(base) || !m.supernet.Contains(broadcastIP(ipnet)) {
+		return nil, fmt.Errorf("serving: group cidr %q is not within composite supernet %v", cidr, m.supernet)
+	}
+	return ipnet, nil
+}
+
+// CreateGroupNetwork validates cidr (a /24 within the supernet, non-overlapping
+// with an existing group bridge), creates the per-group bridge, and installs the
+// inter-group isolation + entry-DNAT scaffolding by regenerating the whole
+// embervm_group table. It is IDEMPOTENT per group_instance_id: a re-issue for a
+// group that already exists with the SAME cidr returns the existing
+// (bridge, gateway) without touching the bridge (so the control plane can safely
+// re-issue before a relight or an adoption-time rebind). A re-issue with a
+// DIFFERENT cidr, or a cidr that overlaps a DIFFERENT group's /24, is refused
+// (overlapErr, which the caller maps to FAILED_PRECONDITION). It returns the
+// bridge name and the group gateway IP.
+func (m *GroupManager) CreateGroupNetwork(ctx context.Context, groupInstanceID, cidr string) (bridge, gatewayIP string, err error) {
+	if groupInstanceID == "" {
+		return "", "", fmt.Errorf("serving: group_instance_id required")
+	}
+	ipnet, err := m.validateGroupCIDR(cidr)
+	if err != nil {
+		return "", "", err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Idempotency: an existing group with the SAME /24 is a no-op hit. A different
+	// /24 for the same id is a conflict (the control plane must delete first).
+	if existing, ok := m.groups[groupInstanceID]; ok {
+		if existing.cidr.String() != ipnet.String() {
+			return "", "", fmt.Errorf("serving: group %q already exists with cidr %v, cannot recreate as %v", groupInstanceID, existing.cidr, ipnet)
+		}
+		return existing.bridge, existing.gatewayIP.String(), nil
+	}
+
+	// Overlap refusal: a NEW group's /24 must not overlap any OTHER live group's
+	// /24 (two bridges cannot own overlapping address space on the same node).
+	for id, g := range m.groups {
+		if id == groupInstanceID {
+			continue
+		}
+		if cidrOverlaps(ipnet, g.cidr) {
+			return "", "", fmt.Errorf("serving: group cidr %v overlaps existing group %q cidr %v", ipnet, id, g.cidr)
+		}
+	}
+
+	gwIP := nextIP(ipnet.IP.To4()) // network + 1 == the .1 gateway
+	prefixLen, _ := ipnet.Mask.Size()
+	bridgeName := groupBridgeName(groupInstanceID)
+
+	// Create the bridge idempotently (tolerate an already-present device on a
+	// re-entry after a partial prior create).
+	for _, argv := range groupBridgeSetupArgs(bridgeName, gwIP.String(), prefixLen) {
+		if _, rerr := m.runner.Run(ctx, argv[0], argv[1:]...); rerr != nil {
+			if isAlreadyExists(rerr) {
+				continue
+			}
+			// Roll back the bridge fragment so a failed create leaks no half-bridge.
+			_, _ = m.runner.Run(ctx, "ip", groupBridgeTeardownArgs(bridgeName)[1:]...)
+			return "", "", rerr
+		}
+	}
+
+	g := &groupNet{
+		groupInstanceID: groupInstanceID,
+		bridge:          bridgeName,
+		cidr:            ipnet,
+		gatewayIP:       gwIP,
+		prefixLen:       prefixLen,
+		alloc:           newIPAllocator(ipnet, gwIP),
+	}
+	m.groups[groupInstanceID] = g
+
+	// Regenerate the whole group table so the new bridge is covered by the
+	// isolation rules immediately. On failure, undo the map insert and the bridge.
+	if aerr := m.applyRulesetLocked(ctx); aerr != nil {
+		delete(m.groups, groupInstanceID)
+		_, _ = m.runner.Run(ctx, "ip", groupBridgeTeardownArgs(bridgeName)[1:]...)
+		return "", "", aerr
+	}
+	return bridgeName, gwIP.String(), nil
+}
+
+// AdoptGroupNetwork re-seeds one group into the in-memory registry from an
+// on-disk record WITHOUT touching the bridge or the ruleset (a boot rescan
+// already found the record; EnsureNetwork rebuilds the table once at the end). It
+// is idempotent and validates the recorded cidr the same way CreateGroupNetwork
+// does; a malformed record is skipped (returned as an error the caller logs). Used
+// only by the daemon-start rescan path.
+func (m *GroupManager) AdoptGroupNetwork(groupInstanceID, cidr string, createdAtUnixMs int64) error {
+	ipnet, err := m.validateGroupCIDR(cidr)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.groups[groupInstanceID]; ok {
+		return nil
+	}
+	gwIP := nextIP(ipnet.IP.To4())
+	prefixLen, _ := ipnet.Mask.Size()
+	m.groups[groupInstanceID] = &groupNet{
+		groupInstanceID: groupInstanceID,
+		bridge:          groupBridgeName(groupInstanceID),
+		cidr:            ipnet,
+		gatewayIP:       gwIP,
+		prefixLen:       prefixLen,
+		alloc:           newIPAllocator(ipnet, gwIP),
+		createdAtUnixMs: createdAtUnixMs,
+	}
+	return nil
+}
+
+// EnsureNetwork enables IPv4 forwarding and applies the group ruleset ONCE from
+// the current (post-adoption) group set on daemon start, mirroring the serving
+// Manager's EnsureNetwork. It does NOT create bridges: group bridges are created
+// on CreateGroupNetwork (and die with the pod), so on a fresh start there are no
+// group bridges to rebuild and the ruleset is the empty-group posture; after an
+// adoption rescan it covers whatever groups the on-disk records re-seeded. The
+// bridges those adopted records name no longer exist (they died with the prior
+// pod), so the control plane re-issues CreateGroupNetwork to rebuild them; this
+// only makes the table present and forwarding enabled.
+func (m *GroupManager) EnsureNetwork(ctx context.Context) error {
+	if _, err := m.runner.Run(ctx, "sysctl", "-w", "net.ipv4.ip_forward=1"); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.applyRulesetLocked(ctx)
+}
+
+// DeleteGroupNetwork tears down a group's bridge, drops it from the isolation
+// ruleset (by regenerating the table without it), and removes its in-memory
+// record. The caller (the server handler) enforces the ATTACHED-MEMBER refusal
+// BEFORE calling this: a group with a live member on its bridge must not be
+// deleted (FAILED_PRECONDITION), because deleting the bridge would yank the live
+// member's NIC. It is idempotent: deleting an unknown group is a no-op success
+// (the desired end-state already holds).
+func (m *GroupManager) DeleteGroupNetwork(ctx context.Context, groupInstanceID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	g, ok := m.groups[groupInstanceID]
+	if !ok {
+		return nil
+	}
+	// Delete the bridge first (a missing bridge is tolerated: it died with a prior
+	// pod, or a partial create left none), then regenerate the ruleset without it.
+	if _, err := m.runner.Run(ctx, "ip", groupBridgeTeardownArgs(g.bridge)[1:]...); err != nil {
+		// A not-found bridge is fine; other errors are best-effort (the record is
+		// going away regardless, and a restart rebuilds a clean table).
+		_ = err
+	}
+	delete(m.groups, groupInstanceID)
+	return m.applyRulesetLocked(ctx)
+}
+
+// Has reports whether a group network is currently held (for the server handler's
+// idempotency / existence checks).
+func (m *GroupManager) Has(groupInstanceID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.groups[groupInstanceID]
+	return ok
+}
+
+// BridgeFor returns the bridge name of a held group, or "" if absent.
+func (m *GroupManager) BridgeFor(groupInstanceID string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if g, ok := m.groups[groupInstanceID]; ok {
+		return g.bridge
+	}
+	return ""
+}
+
+// List returns a projection of every held group network, for NodeStatus assembly.
+func (m *GroupManager) List() []GroupNetworkInfo {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]GroupNetworkInfo, 0, len(m.groups))
+	for _, g := range m.groups {
+		out = append(out, GroupNetworkInfo{
+			GroupInstanceID: g.groupInstanceID,
+			Bridge:          g.bridge,
+			CIDR:            g.cidr.String(),
+			GatewayIP:       g.gatewayIP.String(),
+			CreatedAtUnixMs: g.createdAtUnixMs,
+		})
+	}
+	return out
+}
+
+// MemberAddressing returns the deterministic (tap, mac, ip) for a member of a
+// group by (member_name, member_index), reserving the member IP in the group's
+// allocator so a duplicate index/IP within the group is refused. It is the entry
+// point Task 5's StartGroupMember uses to pin a member's NIC; exposed now (with
+// its determinism table-tested) so the addressing contract is frozen before
+// member lifecycle lands. A group that is not held, or an index outside the /24,
+// is an error. The reservation is released via ReleaseMember.
+func (m *GroupManager) MemberAddressing(groupInstanceID, memberName string, memberIndex uint32) (tap, mac string, ip net.IP, err error) {
+	m.mu.Lock()
+	g, ok := m.groups[groupInstanceID]
+	m.mu.Unlock()
+	if !ok {
+		return "", "", nil, fmt.Errorf("serving: group %q not found", groupInstanceID)
+	}
+	ip, err = groupMemberIP(g.cidr, memberIndex)
+	if err != nil {
+		return "", "", nil, err
+	}
+	if rerr := g.alloc.reserve(ip); rerr != nil {
+		return "", "", nil, rerr
+	}
+	return groupTapName(groupInstanceID, memberName), groupMemberMAC(groupInstanceID, memberName), ip, nil
+}
+
+// MemberAddressingFor derives the deterministic (tap, mac, ip) for a member
+// WITHOUT reserving the IP (a pure derivation, for a relight re-pin or a
+// read-only lookup). It errors only on an unknown group or an out-of-range index.
+func (m *GroupManager) MemberAddressingFor(groupInstanceID, memberName string, memberIndex uint32) (tap, mac string, ip net.IP, err error) {
+	m.mu.Lock()
+	g, ok := m.groups[groupInstanceID]
+	m.mu.Unlock()
+	if !ok {
+		return "", "", nil, fmt.Errorf("serving: group %q not found", groupInstanceID)
+	}
+	ip, err = groupMemberIP(g.cidr, memberIndex)
+	if err != nil {
+		return "", "", nil, err
+	}
+	return groupTapName(groupInstanceID, memberName), groupMemberMAC(groupInstanceID, memberName), ip, nil
+}
+
+// ReleaseMember returns a member IP to its group's allocator (idempotent). Used by
+// Task 5's member teardown; provided now so the reserve in MemberAddressing has a
+// symmetric release.
+func (m *GroupManager) ReleaseMember(groupInstanceID string, ip net.IP) {
+	m.mu.Lock()
+	g, ok := m.groups[groupInstanceID]
+	m.mu.Unlock()
+	if !ok {
+		return
+	}
+	g.alloc.release(ip)
+}
+
+// GatewayIP returns a group's gateway IP (the .1 of its /24), for composing a
+// member's default route. Nil if the group is not held.
+func (m *GroupManager) GatewayIP(groupInstanceID string) net.IP {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if g, ok := m.groups[groupInstanceID]; ok {
+		return g.gatewayIP
+	}
+	return nil
+}
+
+// PrefixLen returns a group's /24 prefix length (24), for a member's static IP
+// mask. Zero if the group is not held.
+func (m *GroupManager) PrefixLen(groupInstanceID string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if g, ok := m.groups[groupInstanceID]; ok {
+		return g.prefixLen
+	}
+	return 0
+}
+
+// EnsureEntryDNAT installs (or refreshes) the entry-member DNAT rule for a group,
+// exposing the entry member's tap as podIP:vmPort (the D-R3.11.4 lane). It is a
+// no-op when DNAT is disabled (empty podIP). The derived port is
+// portBase + hostOffset(entryIP within the supernet); a derivation error is
+// returned so the caller reaps rather than publishing an unreachable entry. Only
+// the ENTRY member of a group is passed here (Task 5 decides which member is the
+// entry); non-entry members are never DNAT'd. It regenerates the whole group
+// table so the rule composes with the isolation drops.
+func (m *GroupManager) EnsureEntryDNAT(ctx context.Context, groupInstanceID string, entryIP net.IP, guestPort uint32) error {
+	if m.podIP == "" {
+		return nil
+	}
+	vmPort, err := PortForIP(m.portBase, m.supernet, entryIP)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	g, ok := m.groups[groupInstanceID]
+	if !ok {
+		return fmt.Errorf("serving: group %q not found", groupInstanceID)
+	}
+	g.entry = &groupEntry{tapIP: entryIP.String(), guestPort: guestPort, vmPort: vmPort}
+	return m.applyRulesetLocked(ctx)
+}
+
+// RemoveEntryDNAT drops a group's entry-member DNAT rule and re-applies the table
+// (best-effort: a re-apply error is swallowed, the entry is going away and a
+// restart rebuilds a clean table). No-op when DNAT is disabled or the group is
+// absent.
+func (m *GroupManager) RemoveEntryDNAT(ctx context.Context, groupInstanceID string) {
+	if m.podIP == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	g, ok := m.groups[groupInstanceID]
+	if !ok {
+		return
+	}
+	g.entry = nil
+	_ = m.applyRulesetLocked(ctx)
+}
+
+// EntryEndpoint projects a group entry member's (tap IP, guest port) into the
+// endpoint the daemon REPORTS for the entry: (podIP, vmPort) when DNAT is
+// enabled, else the tap IP + guest port unchanged (local/test fallback). Mirrors
+// the serving Manager's Endpoint.
+func (m *GroupManager) EntryEndpoint(entryIP net.IP, guestPort uint32) (string, uint32) {
+	if m.podIP == "" {
+		return entryIP.String(), guestPort
+	}
+	vmPort, err := PortForIP(m.portBase, m.supernet, entryIP)
+	if err != nil {
+		return entryIP.String(), guestPort
+	}
+	return m.podIP, vmPort
+}
+
+// applyRulesetLocked regenerates the whole group ruleset from the current group
+// set (bridges + entry DNAT entries) and applies it via `nft -f <file>`. Caller
+// holds m.mu.
+func (m *GroupManager) applyRulesetLocked(ctx context.Context) error {
+	bridges := make([]string, 0, len(m.groups))
+	entries := make([]groupEntry, 0, len(m.groups))
+	for _, g := range m.groups {
+		bridges = append(bridges, g.bridge)
+		if g.entry != nil {
+			entries = append(entries, *g.entry)
+		}
+	}
+	return applyRuleset(ctx, m.runner, nftGroupRuleset(bridges, m.servingBridge, m.podIP, entries))
+}
+
+// cidrOverlaps reports whether two IPv4 networks share any address (either
+// contains the other's network base). For same-size /24s this is exact; for
+// mixed sizes the containment test in either direction covers a nesting overlap.
+func cidrOverlaps(a, b *net.IPNet) bool {
+	return a.Contains(b.IP) || b.Contains(a.IP)
+}

--- a/projects/embervm/noded/serving/group_test.go
+++ b/projects/embervm/noded/serving/group_test.go
@@ -464,3 +464,88 @@ func TestGroupManagerCreateRollsBackOnBridgeFailure(t *testing.T) {
 		t.Error("group must not be held after a failed create")
 	}
 }
+
+// TestEnsureMemberTapPinsWorldAndRecreatesIdentically asserts EnsureMemberTap
+// creates + attaches the member tap on the group bridge with the deterministic tap
+// name and MAC, verifies the derived IP matches the request, and that a second call
+// (a relight after ReleaseMember) recreates the SAME tap/MAC/IP: the pinned-world
+// reconstruction the D-R3.4.1 pin requires on the group bridge.
+func TestEnsureMemberTapPinsWorldAndRecreatesIdentically(t *testing.T) {
+	fr := &fakeRunner{}
+	m, err := NewGroupManager(fr, "10.101.0.0/16", "", "", 40000)
+	if err != nil {
+		t.Fatalf("NewGroupManager: %v", err)
+	}
+	if _, _, err := m.CreateGroupNetwork(context.Background(), "grp-A", "10.101.1.0/24"); err != nil {
+		t.Fatalf("CreateGroupNetwork: %v", err)
+	}
+	wantIP := net.ParseIP("10.101.1.10") // index 0 -> .10
+	tap, mac, err := m.EnsureMemberTap(context.Background(), "grp-A", "worker-0", 0, wantIP)
+	if err != nil {
+		t.Fatalf("EnsureMemberTap: %v", err)
+	}
+	if tap != groupTapName("grp-A", "worker-0") || mac != groupMemberMAC("grp-A", "worker-0") {
+		t.Errorf("tap/mac not the deterministic derivation: tap=%q mac=%q", tap, mac)
+	}
+	// The tap must have been created and attached to the group bridge.
+	bridge := groupBridgeName("grp-A")
+	var sawAdd, sawMaster bool
+	for _, c := range fr.argvStrings() {
+		if c == "ip tuntap add dev "+tap+" mode tap" {
+			sawAdd = true
+		}
+		if c == "ip link set "+tap+" master "+bridge {
+			sawMaster = true
+		}
+	}
+	if !sawAdd || !sawMaster {
+		t.Errorf("member tap not created+attached to the group bridge; calls: %v", fr.argvStrings())
+	}
+
+	// Release (as a bank would) then re-pin (as a relight would): identical world.
+	m.RemoveMemberTap(context.Background(), "grp-A", tap, wantIP)
+	tap2, mac2, err := m.EnsureMemberTap(context.Background(), "grp-A", "worker-0", 0, wantIP)
+	if err != nil {
+		t.Fatalf("EnsureMemberTap (relight): %v", err)
+	}
+	if tap2 != tap || mac2 != mac {
+		t.Errorf("relight recreated a DIFFERENT world: tap %q->%q mac %q->%q", tap, tap2, mac, mac2)
+	}
+}
+
+// TestEnsureMemberTapRejectsMismatchedIP asserts a request IP that disagrees with
+// the deterministic derivation fails loudly (never boots on a different IP).
+func TestEnsureMemberTapRejectsMismatchedIP(t *testing.T) {
+	m, err := NewGroupManager(&fakeRunner{}, "10.101.0.0/16", "", "", 40000)
+	if err != nil {
+		t.Fatalf("NewGroupManager: %v", err)
+	}
+	if _, _, err := m.CreateGroupNetwork(context.Background(), "grp-A", "10.101.1.0/24"); err != nil {
+		t.Fatalf("CreateGroupNetwork: %v", err)
+	}
+	// index 0 derives .10, but the request claims .99: a mismatch must fail.
+	if _, _, err := m.EnsureMemberTap(context.Background(), "grp-A", "worker-0", 0, net.ParseIP("10.101.1.99")); err == nil {
+		t.Fatal("a request IP that disagrees with the derivation must fail")
+	}
+}
+
+// TestEnsureMemberTapRollsBackOnTapFailure asserts a tap-create failure releases the
+// reserved IP so a retry (or a different member) can still use the address space.
+func TestEnsureMemberTapRollsBackOnTapFailure(t *testing.T) {
+	fr := &fakeRunner{failOn: map[string]error{"ip tuntap": errors.New("boom")}}
+	m, err := NewGroupManager(fr, "10.101.0.0/16", "", "", 40000)
+	if err != nil {
+		t.Fatalf("NewGroupManager: %v", err)
+	}
+	if _, _, err := m.CreateGroupNetwork(context.Background(), "grp-A", "10.101.1.0/24"); err != nil {
+		t.Fatalf("CreateGroupNetwork: %v", err)
+	}
+	if _, _, err := m.EnsureMemberTap(context.Background(), "grp-A", "worker-0", 0, net.ParseIP("10.101.1.10")); err == nil {
+		t.Fatal("tap create failure should surface")
+	}
+	// The IP must be free again: a retry succeeds (failOn cleared).
+	fr.failOn = nil
+	if _, _, err := m.EnsureMemberTap(context.Background(), "grp-A", "worker-0", 0, net.ParseIP("10.101.1.10")); err != nil {
+		t.Fatalf("retry after rollback should succeed: %v", err)
+	}
+}

--- a/projects/embervm/noded/serving/group_test.go
+++ b/projects/embervm/noded/serving/group_test.go
@@ -1,0 +1,466 @@
+package serving
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+)
+
+// TestGroupBridgeSetupArgs asserts the ordered argv batches for a group bridge.
+func TestGroupBridgeSetupArgs(t *testing.T) {
+	got := groupBridgeSetupArgs("emg0a1b2c", "10.101.5.1", 24)
+	want := [][]string{
+		{"ip", "link", "add", "name", "emg0a1b2c", "type", "bridge"},
+		{"ip", "addr", "add", "10.101.5.1/24", "dev", "emg0a1b2c"},
+		{"ip", "link", "set", "emg0a1b2c", "up"},
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("groupBridgeSetupArgs:\n got %v\nwant %v", got, want)
+	}
+	if td := groupBridgeTeardownArgs("emg0a1b2c"); fmt.Sprint(td) != fmt.Sprint([]string{"ip", "link", "del", "emg0a1b2c"}) {
+		t.Fatalf("groupBridgeTeardownArgs: got %v", td)
+	}
+}
+
+// TestGroupNameDerivationDeterministicAndBounded asserts the bridge/tap/MAC
+// derivations are stable for the same inputs, distinct across groups for the same
+// member name, and within the 15-char ifname limit.
+func TestGroupNameDerivationDeterministicAndBounded(t *testing.T) {
+	gid := "grp-instance-aaaa-bbbb-cccc"
+	// Determinism: same inputs -> same outputs.
+	if a, b := groupBridgeName(gid), groupBridgeName(gid); a != b {
+		t.Fatalf("groupBridgeName not deterministic: %q != %q", a, b)
+	}
+	if a, b := groupTapName(gid, "worker-0"), groupTapName(gid, "worker-0"); a != b {
+		t.Fatalf("groupTapName not deterministic: %q != %q", a, b)
+	}
+	if a, b := groupMemberMAC(gid, "worker-0"), groupMemberMAC(gid, "worker-0"); a != b {
+		t.Fatalf("groupMemberMAC not deterministic: %q != %q", a, b)
+	}
+
+	// ifname length safety.
+	if br := groupBridgeName(gid); len(br) > groupIfnameMax {
+		t.Errorf("bridge name %q exceeds ifname limit %d", br, groupIfnameMax)
+	}
+	if tap := groupTapName(gid, "a-very-long-member-name-that-would-overflow"); len(tap) > groupIfnameMax {
+		t.Errorf("tap name %q exceeds ifname limit %d", tap, groupIfnameMax)
+	}
+
+	// Bridge prefix + tap prefix so a reader can spot the class at a glance.
+	if br := groupBridgeName(gid); !strings.HasPrefix(br, "emg") {
+		t.Errorf("bridge name %q missing emg prefix", br)
+	}
+	if tap := groupTapName(gid, "worker-0"); !strings.HasPrefix(tap, "emgt") {
+		t.Errorf("tap name %q missing emgt prefix", tap)
+	}
+
+	// A locally-administered unicast MAC (first octet 0x02).
+	if mac := groupMemberMAC(gid, "worker-0"); !strings.HasPrefix(mac, "02:") {
+		t.Errorf("MAC %q is not locally-administered (02: prefix)", mac)
+	}
+
+	// Two DIFFERENT groups' identically-named members must NOT collide on tap or MAC.
+	other := "grp-instance-dddd-eeee-ffff"
+	if groupTapName(gid, "worker-0") == groupTapName(other, "worker-0") {
+		t.Error("tap names collide across groups for the same member name")
+	}
+	if groupMemberMAC(gid, "worker-0") == groupMemberMAC(other, "worker-0") {
+		t.Error("MACs collide across groups for the same member name")
+	}
+	// Different members within a group must differ.
+	if groupTapName(gid, "worker-0") == groupTapName(gid, "worker-1") {
+		t.Error("tap names collide across members within a group")
+	}
+}
+
+// TestGroupMemberIP asserts the .10+i addressing rule, its determinism, and its
+// out-of-range refusal.
+func TestGroupMemberIP(t *testing.T) {
+	_, net24, _ := net.ParseCIDR("10.101.7.0/24")
+	cases := []struct {
+		index uint32
+		want  string
+	}{
+		{0, "10.101.7.10"},
+		{1, "10.101.7.11"},
+		{5, "10.101.7.15"},
+	}
+	for _, c := range cases {
+		ip, err := groupMemberIP(net24, c.index)
+		if err != nil {
+			t.Fatalf("groupMemberIP(%d): %v", c.index, err)
+		}
+		if ip.String() != c.want {
+			t.Errorf("groupMemberIP(%d) = %s want %s", c.index, ip, c.want)
+		}
+		// Determinism: same inputs, same IP.
+		if ip2, _ := groupMemberIP(net24, c.index); !ip.Equal(ip2) {
+			t.Errorf("groupMemberIP(%d) not deterministic", c.index)
+		}
+	}
+	// An index past the /24 host range is refused (10 + 250 = .260 overflows the /24).
+	if _, err := groupMemberIP(net24, 250); err == nil {
+		t.Error("groupMemberIP for an out-of-range index should error")
+	}
+}
+
+// TestNftGroupRulesetIsolation asserts the inter-group forward DROPs: every
+// ordered pair of distinct group bridges (composite<->composite, both directions)
+// and every group-bridge -> serving-bridge (composite->serving), plus the
+// established/related accept, all in the DEDICATED embervm_group table (never the
+// serving table).
+func TestNftGroupRulesetIsolation(t *testing.T) {
+	rs := nftGroupRuleset([]string{"emgAAAAAA", "emgBBBBBB"}, "embervm-serv0", "", nil)
+
+	// Dedicated table, own forward chain, established accept.
+	for _, w := range []string{
+		"add table inet embervm_group",
+		"flush table inet embervm_group",
+		"add chain inet embervm_group group_forward { type filter hook forward priority 0; policy accept; }",
+		"add rule inet embervm_group group_forward ct state established,related accept",
+	} {
+		if !strings.Contains(rs, w) {
+			t.Errorf("group ruleset missing:\n  %q\nfull:\n%s", w, rs)
+		}
+	}
+
+	// composite<->composite BOTH directions.
+	for _, w := range []string{
+		"add rule inet embervm_group group_forward iifname \"emgAAAAAA\" oifname \"emgBBBBBB\" drop",
+		"add rule inet embervm_group group_forward iifname \"emgBBBBBB\" oifname \"emgAAAAAA\" drop",
+	} {
+		if !strings.Contains(rs, w) {
+			t.Errorf("group ruleset missing inter-group drop:\n  %q\nfull:\n%s", w, rs)
+		}
+	}
+
+	// composite->serving for each group bridge.
+	for _, w := range []string{
+		"add rule inet embervm_group group_forward iifname \"emgAAAAAA\" oifname \"embervm-serv0\" drop",
+		"add rule inet embervm_group group_forward iifname \"emgBBBBBB\" oifname \"embervm-serv0\" drop",
+	} {
+		if !strings.Contains(rs, w) {
+			t.Errorf("group ruleset missing composite->serving drop:\n  %q\nfull:\n%s", w, rs)
+		}
+	}
+
+	// It must NOT touch the serving table or its chains (no collision).
+	if strings.Contains(rs, "embervm_serving") || strings.Contains(rs, "serving_dnat") {
+		t.Errorf("group ruleset must not reference the serving table/chains:\n%s", rs)
+	}
+	// With no pod IP there is no DNAT chain.
+	if strings.Contains(rs, "group_dnat") {
+		t.Errorf("empty-podIP group ruleset must have no DNAT chain:\n%s", rs)
+	}
+	// flush after add-table for first-apply idempotency.
+	if strings.Index(rs, "flush table") < strings.Index(rs, "add table") {
+		t.Error("group ruleset: flush must come after add table")
+	}
+}
+
+// TestNftGroupRulesetEntryDNAT asserts the entry-member DNAT lane renders (podIP)
+// and that a single group with no serving bridge configured omits the
+// composite->serving rule.
+func TestNftGroupRulesetEntryDNAT(t *testing.T) {
+	entries := []groupEntry{{tapIP: "10.101.7.10", guestPort: 8080, vmPort: 41802}}
+	rs := nftGroupRuleset([]string{"emgAAAAAA"}, "", "10.42.0.9", entries)
+	for _, w := range []string{
+		"add chain inet embervm_group group_dnat { type nat hook prerouting priority dstnat; policy accept; }",
+		"add rule inet embervm_group group_dnat ip daddr 10.42.0.9 tcp dport 41802 dnat ip to 10.101.7.10:8080",
+	} {
+		if !strings.Contains(rs, w) {
+			t.Errorf("group entry-DNAT ruleset missing:\n  %q\nfull:\n%s", w, rs)
+		}
+	}
+	// A single group has no other group to isolate against, and no serving bridge
+	// configured, so there must be NO drop rules at all here.
+	if strings.Contains(rs, "drop") {
+		t.Errorf("single-group, no-serving ruleset must have no drop rules:\n%s", rs)
+	}
+}
+
+// TestNftGroupRulesetDeterministic asserts the ruleset is a pure function of the
+// bridge/entry SET (sorted internally), so map iteration order never changes it.
+func TestNftGroupRulesetDeterministic(t *testing.T) {
+	a := nftGroupRuleset([]string{"emgBBBBBB", "emgAAAAAA"}, "serv0", "", nil)
+	b := nftGroupRuleset([]string{"emgAAAAAA", "emgBBBBBB"}, "serv0", "", nil)
+	if a != b {
+		t.Errorf("nftGroupRuleset not order-independent:\n--- a ---\n%s\n--- b ---\n%s", a, b)
+	}
+}
+
+func TestNftGroupTeardownArgs(t *testing.T) {
+	got := nftGroupTeardownArgs()
+	want := []string{"nft", "delete", "table", "inet", "embervm_group"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("nftGroupTeardownArgs: got %v want %v", got, want)
+	}
+}
+
+// TestGroupManagerCIDRValidation covers the /24-in-supernet rule and overlap
+// refusal.
+func TestGroupManagerCIDRValidation(t *testing.T) {
+	m, err := NewGroupManager(&fakeRunner{}, "10.101.0.0/16", "embervm-serv0", "", 40000)
+	if err != nil {
+		t.Fatalf("NewGroupManager: %v", err)
+	}
+	// A valid /24 inside the supernet is accepted and yields the .1 gateway.
+	br, gw, err := m.CreateGroupNetwork(context.Background(), "grp-A", "10.101.1.0/24")
+	if err != nil {
+		t.Fatalf("CreateGroupNetwork(grp-A): %v", err)
+	}
+	if gw != "10.101.1.1" {
+		t.Errorf("gateway = %s want 10.101.1.1", gw)
+	}
+	if br != groupBridgeName("grp-A") {
+		t.Errorf("bridge = %s want %s", br, groupBridgeName("grp-A"))
+	}
+
+	// A non-/24 is refused.
+	if _, _, err := m.CreateGroupNetwork(context.Background(), "grp-bad-prefix", "10.101.2.0/25"); err == nil {
+		t.Error("a /25 group cidr should be refused")
+	}
+	// A /24 OUTSIDE the supernet is refused.
+	if _, _, err := m.CreateGroupNetwork(context.Background(), "grp-outside", "10.200.1.0/24"); err == nil {
+		t.Error("a group cidr outside the supernet should be refused")
+	}
+	// A /24 overlapping grp-A's is refused (same range, different id).
+	if _, _, err := m.CreateGroupNetwork(context.Background(), "grp-overlap", "10.101.1.0/24"); err == nil {
+		t.Error("an overlapping group cidr should be refused")
+	}
+}
+
+// TestGroupManagerCreateIdempotent asserts a re-issue with the same cidr is a
+// no-op hit (same bridge/gateway, no extra bridge-create calls), and a re-issue
+// with a DIFFERENT cidr for the same id is refused.
+func TestGroupManagerCreateIdempotent(t *testing.T) {
+	fr := &fakeRunner{}
+	m, err := NewGroupManager(fr, "10.101.0.0/16", "", "", 40000)
+	if err != nil {
+		t.Fatalf("NewGroupManager: %v", err)
+	}
+	br1, gw1, err := m.CreateGroupNetwork(context.Background(), "grp-A", "10.101.1.0/24")
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	callsAfterFirst := len(fr.calls)
+
+	br2, gw2, err := m.CreateGroupNetwork(context.Background(), "grp-A", "10.101.1.0/24")
+	if err != nil {
+		t.Fatalf("idempotent re-create: %v", err)
+	}
+	if br1 != br2 || gw1 != gw2 {
+		t.Errorf("idempotent re-create changed identity: (%s,%s) vs (%s,%s)", br1, gw1, br2, gw2)
+	}
+	// A re-issue must NOT run any new ip/nft commands (no bridge re-create).
+	if len(fr.calls) != callsAfterFirst {
+		t.Errorf("idempotent re-create ran %d extra commands, want 0", len(fr.calls)-callsAfterFirst)
+	}
+
+	// Same id, different cidr => conflict.
+	if _, _, err := m.CreateGroupNetwork(context.Background(), "grp-A", "10.101.2.0/24"); err == nil {
+		t.Error("re-creating grp-A with a different cidr should conflict")
+	}
+}
+
+// TestGroupManagerDeleteAndBridgeCommands asserts a create issues the bridge
+// setup and a delete issues the bridge teardown, and that delete is idempotent.
+func TestGroupManagerDeleteAndBridgeCommands(t *testing.T) {
+	fr := &fakeRunner{}
+	m, err := NewGroupManager(fr, "10.101.0.0/16", "", "", 40000)
+	if err != nil {
+		t.Fatalf("NewGroupManager: %v", err)
+	}
+	br, _, err := m.CreateGroupNetwork(context.Background(), "grp-A", "10.101.1.0/24")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	sawAdd := false
+	for _, c := range fr.calls {
+		if strings.Join(c, " ") == fmt.Sprintf("ip link add name %s type bridge", br) {
+			sawAdd = true
+		}
+	}
+	if !sawAdd {
+		t.Errorf("create did not issue the bridge add; calls: %v", fr.argvStrings())
+	}
+
+	if err := m.DeleteGroupNetwork(context.Background(), "grp-A"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if m.Has("grp-A") {
+		t.Error("group still held after delete")
+	}
+	sawDel := false
+	for _, c := range fr.calls {
+		if strings.Join(c, " ") == fmt.Sprintf("ip link del %s", br) {
+			sawDel = true
+		}
+	}
+	if !sawDel {
+		t.Errorf("delete did not issue the bridge teardown; calls: %v", fr.argvStrings())
+	}
+	// Idempotent: deleting again is a no-op success.
+	if err := m.DeleteGroupNetwork(context.Background(), "grp-A"); err != nil {
+		t.Errorf("second delete should be a no-op, got %v", err)
+	}
+}
+
+// TestGroupManagerMemberAddressing asserts the reserving derivation pins IPs
+// per-group, refuses a duplicate, and is deterministic.
+func TestGroupManagerMemberAddressing(t *testing.T) {
+	m, err := NewGroupManager(&fakeRunner{}, "10.101.0.0/16", "", "", 40000)
+	if err != nil {
+		t.Fatalf("NewGroupManager: %v", err)
+	}
+	if _, _, err := m.CreateGroupNetwork(context.Background(), "grp-A", "10.101.1.0/24"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	tap, mac, ip, err := m.MemberAddressing("grp-A", "worker-0", 0)
+	if err != nil {
+		t.Fatalf("MemberAddressing: %v", err)
+	}
+	if ip.String() != "10.101.1.10" {
+		t.Errorf("member 0 ip = %s want 10.101.1.10", ip)
+	}
+	if tap != groupTapName("grp-A", "worker-0") || mac != groupMemberMAC("grp-A", "worker-0") {
+		t.Errorf("member addressing not deterministic with the pure derivers")
+	}
+	// Re-reserving the SAME index (its IP is held) conflicts.
+	if _, _, _, err := m.MemberAddressing("grp-A", "worker-0", 0); err == nil {
+		t.Error("re-reserving a held member IP should conflict")
+	}
+	// Releasing frees it for reuse.
+	m.ReleaseMember("grp-A", ip)
+	if _, _, _, err := m.MemberAddressing("grp-A", "worker-0", 0); err != nil {
+		t.Errorf("MemberAddressing after release: %v", err)
+	}
+	// The read-only variant never reserves (callable twice).
+	if _, _, _, err := m.MemberAddressingFor("grp-A", "worker-9", 9); err != nil {
+		t.Fatalf("MemberAddressingFor: %v", err)
+	}
+	if _, _, _, err := m.MemberAddressingFor("grp-A", "worker-9", 9); err != nil {
+		t.Errorf("MemberAddressingFor should not reserve (callable twice): %v", err)
+	}
+	// An unknown group errors.
+	if _, _, _, err := m.MemberAddressing("nope", "worker-0", 0); err == nil {
+		t.Error("MemberAddressing on an unknown group should error")
+	}
+}
+
+// TestGroupManagerEntryDNAT asserts EnsureEntryDNAT installs the group's entry
+// rule (with the derived port) and RemoveEntryDNAT drops it, both re-applying the
+// group table.
+func TestGroupManagerEntryDNAT(t *testing.T) {
+	fr := &fakeRunner{}
+	m, err := NewGroupManager(fr, "10.101.0.0/16", "embervm-serv0", "10.42.0.9", 40000)
+	if err != nil {
+		t.Fatalf("NewGroupManager: %v", err)
+	}
+	if _, _, err := m.CreateGroupNetwork(context.Background(), "grp-A", "10.101.1.0/24"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	entryIP := net.ParseIP("10.101.1.10")
+	if err := m.EnsureEntryDNAT(context.Background(), "grp-A", entryIP, 8080); err != nil {
+		t.Fatalf("EnsureEntryDNAT: %v", err)
+	}
+	last := lastNftContent(t, fr)
+	if !strings.Contains(last, "group_dnat ip daddr 10.42.0.9") || !strings.Contains(last, "dnat ip to 10.101.1.10:8080") {
+		t.Errorf("entry-DNAT rule not installed:\n%s", last)
+	}
+	// The endpoint projection reports podIP + the derived port.
+	gotIP, gotPort := m.EntryEndpoint(entryIP, 8080)
+	wantPort, _ := PortForIP(40000, m.supernet, entryIP)
+	if gotIP != "10.42.0.9" || gotPort != wantPort {
+		t.Errorf("EntryEndpoint = %s:%d want 10.42.0.9:%d", gotIP, gotPort, wantPort)
+	}
+
+	m.RemoveEntryDNAT(context.Background(), "grp-A")
+	if last := lastNftContent(t, fr); strings.Contains(last, "dnat ip to 10.101.1.10:8080") {
+		t.Errorf("RemoveEntryDNAT should have dropped the rule:\n%s", last)
+	}
+}
+
+// TestGroupManagerEntryDNATDisabled asserts that with no pod IP EnsureEntryDNAT is
+// a no-op (endpoint reports the tap IP unchanged).
+func TestGroupManagerEntryDNATDisabled(t *testing.T) {
+	fr := &fakeRunner{}
+	m, err := NewGroupManager(fr, "10.101.0.0/16", "", "", 40000)
+	if err != nil {
+		t.Fatalf("NewGroupManager: %v", err)
+	}
+	if _, _, err := m.CreateGroupNetwork(context.Background(), "grp-A", "10.101.1.0/24"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	before := countNftApplies(fr)
+	if err := m.EnsureEntryDNAT(context.Background(), "grp-A", net.ParseIP("10.101.1.10"), 8080); err != nil {
+		t.Fatalf("EnsureEntryDNAT: %v", err)
+	}
+	if countNftApplies(fr) != before {
+		t.Errorf("EnsureEntryDNAT with no pod IP should apply nothing")
+	}
+	ip, port := m.EntryEndpoint(net.ParseIP("10.101.1.10"), 8080)
+	if ip != "10.101.1.10" || port != 8080 {
+		t.Errorf("EntryEndpoint(off) = %s:%d want the tap 10.101.1.10:8080", ip, port)
+	}
+}
+
+// TestGroupManagerAdoptRoundTrip asserts a group adopted from a record is held,
+// listed, and validated the same way create validates.
+func TestGroupManagerAdoptRoundTrip(t *testing.T) {
+	m, err := NewGroupManager(&fakeRunner{}, "10.101.0.0/16", "", "", 40000)
+	if err != nil {
+		t.Fatalf("NewGroupManager: %v", err)
+	}
+	if err := m.AdoptGroupNetwork("grp-A", "10.101.3.0/24", 1234); err != nil {
+		t.Fatalf("AdoptGroupNetwork: %v", err)
+	}
+	if !m.Has("grp-A") {
+		t.Error("adopted group not held")
+	}
+	list := m.List()
+	if len(list) != 1 || list[0].GroupInstanceID != "grp-A" || list[0].CIDR != "10.101.3.0/24" {
+		t.Errorf("List after adopt = %+v", list)
+	}
+	if list[0].GatewayIP != "10.101.3.1" || list[0].CreatedAtUnixMs != 1234 {
+		t.Errorf("adopted group fields wrong: %+v", list[0])
+	}
+	// Adopting again is idempotent.
+	if err := m.AdoptGroupNetwork("grp-A", "10.101.3.0/24", 1234); err != nil {
+		t.Errorf("re-adopt should be idempotent: %v", err)
+	}
+	// A malformed record is rejected.
+	if err := m.AdoptGroupNetwork("grp-bad", "not-a-cidr", 0); err == nil {
+		t.Error("adopting a malformed record should error")
+	}
+}
+
+// TestNewGroupManagerRejectsBadSupernet asserts a malformed supernet fails loudly.
+func TestNewGroupManagerRejectsBadSupernet(t *testing.T) {
+	for _, sn := range []string{"nope", "::1/64", ""} {
+		if _, err := NewGroupManager(&fakeRunner{}, sn, "", "", 40000); err == nil {
+			t.Errorf("NewGroupManager(%q) should error", sn)
+		}
+	}
+}
+
+// TestGroupManagerCreateRollsBackOnBridgeFailure asserts a bridge-create failure
+// leaves no group held and no ruleset applied for it.
+func TestGroupManagerCreateRollsBackOnBridgeFailure(t *testing.T) {
+	fr := &fakeRunner{failOn: map[string]error{
+		"ip link": errors.New("boom"),
+	}}
+	m, err := NewGroupManager(fr, "10.101.0.0/16", "", "", 40000)
+	if err != nil {
+		t.Fatalf("NewGroupManager: %v", err)
+	}
+	if _, _, err := m.CreateGroupNetwork(context.Background(), "grp-A", "10.101.1.0/24"); err == nil {
+		t.Fatal("create should fail when the bridge add fails")
+	}
+	if m.Has("grp-A") {
+		t.Error("group must not be held after a failed create")
+	}
+}

--- a/projects/embervm/noded/serving/group_test.go
+++ b/projects/embervm/noded/serving/group_test.go
@@ -127,6 +127,19 @@ func TestNftGroupRulesetIsolation(t *testing.T) {
 		}
 	}
 
+	// Per-bridge ZERO-EGRESS denial (standing decision 4): each bridge drops every
+	// NEW packet leaving it to anywhere other than itself (other groups, serving, AND
+	// external/CNI). This is the primary egress denial; the cross-group and
+	// composite->serving drops below are redundant belt-and-braces.
+	for _, w := range []string{
+		"add rule inet embervm_group group_forward iifname \"emgAAAAAA\" oifname != \"emgAAAAAA\" ct state new drop",
+		"add rule inet embervm_group group_forward iifname \"emgBBBBBB\" oifname != \"emgBBBBBB\" ct state new drop",
+	} {
+		if !strings.Contains(rs, w) {
+			t.Errorf("group ruleset missing per-bridge zero-egress drop:\n  %q\nfull:\n%s", w, rs)
+		}
+	}
+
 	// composite<->composite BOTH directions.
 	for _, w := range []string{
 		"add rule inet embervm_group group_forward iifname \"emgAAAAAA\" oifname \"emgBBBBBB\" drop",
@@ -162,23 +175,28 @@ func TestNftGroupRulesetIsolation(t *testing.T) {
 }
 
 // TestNftGroupRulesetEntryDNAT asserts the entry-member DNAT lane renders (podIP)
-// and that a single group with no serving bridge configured omits the
-// composite->serving rule.
+// and that a LONE group (single bridge, no peer groups, no serving bridge) STILL
+// emits its own per-bridge zero-egress drop: the egress denial must not depend on
+// the presence of other bridges (standing decision 4). It also asserts the ONLY
+// drop is that per-bridge egress rule (no cross-group / composite->serving rules
+// when there is no peer group and no serving bridge).
 func TestNftGroupRulesetEntryDNAT(t *testing.T) {
 	entries := []groupEntry{{tapIP: "10.101.7.10", guestPort: 8080, vmPort: 41802}}
 	rs := nftGroupRuleset([]string{"emgAAAAAA"}, "", "10.42.0.9", entries)
 	for _, w := range []string{
 		"add chain inet embervm_group group_dnat { type nat hook prerouting priority dstnat; policy accept; }",
 		"add rule inet embervm_group group_dnat ip daddr 10.42.0.9 tcp dport 41802 dnat ip to 10.101.7.10:8080",
+		// The lone group's own egress denial: present even with no peers/serving.
+		"add rule inet embervm_group group_forward iifname \"emgAAAAAA\" oifname != \"emgAAAAAA\" ct state new drop",
 	} {
 		if !strings.Contains(rs, w) {
 			t.Errorf("group entry-DNAT ruleset missing:\n  %q\nfull:\n%s", w, rs)
 		}
 	}
-	// A single group has no other group to isolate against, and no serving bridge
-	// configured, so there must be NO drop rules at all here.
-	if strings.Contains(rs, "drop") {
-		t.Errorf("single-group, no-serving ruleset must have no drop rules:\n%s", rs)
+	// The per-bridge egress drop is the ONLY drop for a lone group (no cross-group
+	// pair, no composite->serving). Assert exactly one "drop" in the forward chain.
+	if n := strings.Count(rs, " drop\n"); n != 1 {
+		t.Errorf("lone group must emit exactly one drop (its own egress denial), got %d:\n%s", n, rs)
 	}
 }
 

--- a/projects/embervm/noded/substrate/substrate.go
+++ b/projects/embervm/noded/substrate/substrate.go
@@ -194,6 +194,39 @@ type GroupNetworkRecord struct {
 	CreatedAtUnixMs int64 `json:"createdAtUnixMs"`
 }
 
+// GroupBundleMemberInfo is one member's banked snapshot discovered within a group
+// bundle set on disk (R5), returned by the driver's startup rescan
+// (ScanGroupBundleSets). The member subdir name is the member_name; the ref is the
+// opaque per-member bundle handle (group/<set_id>/<member_name>). A member bundle
+// carries NO sidecar: the member IP is DETERMINISTIC from the group + member +
+// index (Task 4's addressing), so a relight re-derives it rather than reading it
+// back, and there is no generation ledger for a member the way a stateful volume
+// has one.
+type GroupBundleMemberInfo struct {
+	// MemberName is the member subdir name within the set dir.
+	MemberName string
+	// SnapshotRef is the opaque per-member bundle handle (group/<set_id>/<member>).
+	SnapshotRef string
+	// SizeBytes is the member bundle's on-disk size (snapfile + memfile).
+	SizeBytes int64
+}
+
+// GroupBundleSetInfo is the per-member banked snapshots the driver's startup rescan
+// (ScanGroupBundleSets) found grouped under one set directory (group/<set_id>/), so
+// the server re-seeds its banked-group inventory after a restart and reports it in
+// NodeStatus.group_bundle_sets. The daemon reports refs GROUPED BY the set dir it
+// wrote them under; it makes NO completeness judgment (whether the set has every
+// member it needs to relight is the control plane's to decide, exactly as the proto
+// contract states).
+type GroupBundleSetInfo struct {
+	// SetID is the opaque set directory name (group/<set_id>/).
+	SetID string
+	// Members are the per-member bundles found under the set dir.
+	Members []GroupBundleMemberInfo
+	// CreatedAtUnixMs is the set dir's on-disk modification time, for reporting.
+	CreatedAtUnixMs int64
+}
+
 // Substrate is the core the driver satisfies: acquire an isolated env, run work
 // in it, return/destroy it. Exec is unused by the FC-direct driver (work arrives
 // over vsock HTTP), but the interface keeps the driver honest about the seam.

--- a/projects/embervm/noded/substrate/substrate.go
+++ b/projects/embervm/noded/substrate/substrate.go
@@ -170,6 +170,30 @@ type StatefulBundleInfo struct {
 	CreatedAtUnixMs int64
 }
 
+// GroupNetworkRecord is one discovered on-disk group-network record (R5),
+// returned by the driver's startup rescan (ScanGroupNetworks) so the server
+// re-seeds its group-network inventory after a restart. The record is the DURABLE
+// truth for a group network: the bridge itself lives in noded's pod netns and
+// dies with the pod (D-R3.11.4), so the on-disk config.json under
+// group_networks/<group_instance_id>/ is what a restarted daemon (and, via
+// NodeStatus, the control plane) reconciles from. CreateGroupNetwork is idempotent
+// precisely so the control plane can re-issue it to rebuild the bridge a rescanned
+// record names.
+type GroupNetworkRecord struct {
+	// GroupInstanceID is the control-plane group-instance identity (the record dir
+	// name and the bridge idempotency key).
+	GroupInstanceID string `json:"groupInstanceId"`
+	// BridgeName is the daemon-derived bridge device name (deterministic from the
+	// group_instance_id), recorded so a rescan reports it without re-deriving.
+	BridgeName string `json:"bridgeName"`
+	// SubnetCIDR is the group's /24 within the composite supernet.
+	SubnetCIDR string `json:"subnetCidr"`
+	// GatewayIP is the bridge's .1 address on the /24 (the members' default route).
+	GatewayIP string `json:"gatewayIp"`
+	// CreatedAtUnixMs is when the group network was first created, for reporting.
+	CreatedAtUnixMs int64 `json:"createdAtUnixMs"`
+}
+
 // Substrate is the core the driver satisfies: acquire an isolated env, run work
 // in it, return/destroy it. Exec is unused by the FC-direct driver (work arrives
 // over vsock HTTP), but the interface keeps the driver honest about the seam.

--- a/projects/embervm/noded/vsockproto/proto.go
+++ b/projects/embervm/noded/vsockproto/proto.go
@@ -30,4 +30,12 @@ const (
 	// guest's shim HTTP server over vsock. This is the frozen guest contract port
 	// (ADR 030); the transport dials it via the Firecracker CONNECT handshake.
 	GuestHTTPPort uint32 = 1027
+	// GroupClockAgentPort is the dedicated vsock port a composite-group member
+	// guest's control agent listens on for the R5 sync_clock handshake (PR-1's
+	// GROUP_GUEST_AGENT_VSOCK_PORT). It is a length-prefixed JSON request/response
+	// channel (4-byte big-endian length + JSON), DISTINCT from the task-delivery
+	// HTTP port (1027) and the egress port (1025); the daemon dials it ONLY on a
+	// RELIGHT resume to re-set the resumed guest's wall clock. This constant is the
+	// host mirror of the frozen guest contract and must match it exactly.
+	GroupClockAgentPort uint32 = 1024
 )


### PR DESCRIPTION
EmberVM R5, composite-workload groups. Two tasks on this branch:

## Task 4 (already committed, `51226775a`)
Per-group bridges, pinned member addressing, inter-group nftables isolation, entry DNAT.

## Task 5: member lifecycle with pinned-world resume and clock resync
Makes a group instance physically real: boot on the group bridge, bank to a set directory, resume into an identical world with a correct clock.

**Driver (`fcvm/driver`)**
- `ClaimGroupMember` (FRESH cold boot on a group NIC + first-boot env, no handler/volume), `RestoreGroupMember` (RELIGHT resume), `SnapshotGroupMember` (bank to `group/<set_id>/<member_name>/`, no sidecar), `RemoveGroupMemberBundle`, `ScanGroupBundleSets` (globs `group/*/*/snapfile`, grouped by set dir, no completeness judgment).

**Clock resync (`groupclock`, host side)**
- New frozen-contract lane: vsock port 1024, length-prefixed JSON frames (4-byte big-endian length + JSON), request `{"cmd":"sync_clock","epoch_ns":<int64>}`, response `{"clock_realtime_ns":<int64>}`. NOT the old HTTP `/shim/clock` epoch-millis path.
- `Resync` dials the clock agent (CONNECT handshake to port 1024), sends host `time.Now().UnixNano()`, reads back, and FAILS the relight (FAILED_PRECONDITION with the delta) when the read-back is more than one second off. Codec + clock behind interfaces, table-tested without a guest.

**Server handlers**
- `StartGroupMember` FRESH (resolve source base -> runtime rootfs, pin tap on the group bridge, cold boot with env FRESH-only, TCP health-gate `{ip, health_port}`) and RELIGHT (recreate the SAME tap/MAC/IP pinned world, resume, clock-resync-verify BEFORE the health gate, health-gate). Members count against `max_live_vms`, excluded from `primed_vm_ids`.
- `StopGroupMember` BANK (per-member pause->snapshot timing measured + logged for the closure gate) and DESTROY; concurrent-stop refusal per vm_id.
- Per-member TCP health probe into `NodeStatus.group_member_vms` + `group_networks.member_count`; `ScanGroupBundleSets` into boot rescan + `NodeStatus.group_bundle_sets`.

**Member IP on relight: re-derived, not sidecar.** Task 4's addressing is deterministic from (group, member, index), and the RELIGHT request carries all three plus the pinned IP, which `EnsureMemberTap` verifies against the derivation. No sidecar; the bundle stays a pure memory image.

**Tests**: groupclock codec round-trip + resync success/>1s-failure/dial-error/read-error; serving `EnsureMemberTap` pinned-world reconstruction + IP-mismatch refusal + rollback; driver member bank/relight round-trip + `ScanGroupBundleSets`; server FRESH/RELIGHT (clock resync on relight only, pinned-world re-pin), health-gate failure reap, bank set-dir layout, destroy, concurrent-stop refusal, probe reporting, rescan.

## Live drill (scaffolded, POST-MERGE)
On deployed noded: a grpcurl FRESH boot of the Task 3 server image on a group bridge health-gates; a BANK then RELIGHT round-trips with the guest's clock verified within one second of the host's. The clock-verify tolerance is enforced in `groupclock.Resync` (documented above) and the drill confirms it against a real guest agent (PR-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hRr3Xsj74f6BzB47RUvRE