### PR TITLE
feat(embervm): R5 composite control-plane core (group store, ordered manager, entry publication)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.84
+version: 0.1.85

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -50,6 +50,14 @@ spec:
             - name: state-{{ $p }}
               containerPort: {{ $p }}
             {{- end }}
+            # The R5 composite (group) TCP activator binds this range on the pod so the
+            # node Envoy can reach the wake-on-connect fallback at podIP:<listenPort>
+            # (Task 7). Same range the node Envoy exposes as group-<port>.
+            {{- $gr := .Values.servingEnvoy.compositeTcpPortRange }}
+            {{- range $p := untilStep (int $gr.start) (int (add (int $gr.end) 1)) 1 }}
+            - name: group-{{ $p }}
+              containerPort: {{ $p }}
+            {{- end }}
             {{- end }}
           env:
             - name: EMBERVM_HTTP_PORT
@@ -174,6 +182,31 @@ spec:
               value: "{{ .Values.servingEnvoy.compositeTcpPortRange.start }}-{{ .Values.servingEnvoy.compositeTcpPortRange.end }}"
             - name: EMBERVM_MAX_GROUP_SIZE
               value: {{ .Values.servingEnvoy.maxGroupSize | quote }}
+            # The R5 composite (group) TCP activator port range: the values-declared
+            # range the activator physically binds on the pod (Task 7), so the node
+            # Envoy's group tcp_proxy fallback dials podIP:<listenPort>. Same range as
+            # the container ports above, mirroring EMBERVM_STATEFUL_ACTIVATOR_PORT_RANGE.
+            - name: EMBERVM_COMPOSITE_ACTIVATOR_PORT_RANGE
+              value: "{{ .Values.servingEnvoy.compositeTcpPortRange.start }}-{{ .Values.servingEnvoy.compositeTcpPortRange.end }}"
+            # The composite supernet the CONTROL PLANE allocates per-group /24s from
+            # (lowest-free) and the DNAT port base it re-derives each group's entry
+            # vmPort from. BOTH are the SAME chart values that feed noded's
+            # CompositeSupernet + ServingPortBase (noded.compositeSupernet /
+            # noded.servingPortBase, rendered into the noded env too), so the CP's
+            # subnet allocation and entry-endpoint port derivation stay in lockstep with
+            # the daemon. Rendering from the noded.* keys (not a second independently
+            # defaulted value) is the one-source-of-truth guard.
+            - name: EMBERVM_COMPOSITE_SUPERNET
+              value: {{ .Values.noded.compositeSupernet | quote }}
+            - name: EMBERVM_COMPOSITE_PORT_BASE
+              value: {{ .Values.noded.servingPortBase | quote }}
+            # The control-plane pod IP: the composite entry endpoint is published as
+            # {pod IP, vmPort} (the D-R3.11.4 DNAT lane), so the publisher needs the pod's
+            # own routable address.
+            - name: EMBERVM_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             {{- end }}
             {{- if .Values.servingEnvoy.enabled }}
             # The node Envoy stats base URL (R3, Task 9): the ServingSweeper GETs

--- a/projects/embervm/chart/templates/noded-deployment.yaml
+++ b/projects/embervm/chart/templates/noded-deployment.yaml
@@ -134,6 +134,13 @@ spec:
             # is a daemon config knob (defaulted in config.go, overridable here).
             - name: EMBERVM_NODED_COMPOSITE_SUPERNET
               value: {{ .Values.noded.compositeSupernet | quote }}
+            # The DNAT port base for the deterministic per-VM/entry port space
+            # (vmPort = base + hostOffset). Rendered from the SAME noded.servingPortBase
+            # value the control plane's EMBERVM_COMPOSITE_PORT_BASE renders from, so the
+            # CP's entry-endpoint port re-derivation stays in lockstep with the daemon's
+            # PortForIP. noded defaults this to 30000 when unset (config.go).
+            - name: EMBERVM_NODED_SERVING_PORT_BASE
+              value: {{ .Values.noded.servingPortBase | quote }}
             # Per-invoke FC bundle snapshots and the fixed vsock dir the snapshot
             # embeds both derive from nvmeRoot so the scratch disk is one knob.
             - name: EMBERVM_NODED_SNAPSHOT_ROOT

--- a/projects/embervm/chart/templates/serving-envoy-daemonset.yaml
+++ b/projects/embervm/chart/templates/serving-envoy-daemonset.yaml
@@ -97,6 +97,16 @@ spec:
             - name: state-{{ $p }}
               containerPort: {{ $p }}
             {{- end }}
+            # The R5 composite-group entry TCP port range: one container port per port
+            # in the values-declared range, so a dynamic LDS tcp_proxy listener the
+            # control plane publishes for a composite group on any of them is reachable
+            # through the pod. Named group-<port> for discovery; the serving Service
+            # exposes the same range. Mirrors the stateful range above.
+            {{- $gr := .Values.servingEnvoy.compositeTcpPortRange }}
+            {{- range $p := untilStep (int $gr.start) (int (add (int $gr.end) 1)) 1 }}
+            - name: group-{{ $p }}
+              containerPort: {{ $p }}
+            {{- end }}
           readinessProbe:
             # Probe the data listener, not the admin /ready. Admin binds loopback
             # (127.0.0.1) for security, but a kubelet httpGet probe dials from the

--- a/projects/embervm/chart/templates/serving-service.yaml
+++ b/projects/embervm/chart/templates/serving-service.yaml
@@ -36,4 +36,15 @@ spec:
       port: {{ $p }}
       targetPort: state-{{ $p }}
     {{- end }}
+    # The R5 composite-group entry TCP port range: one Service port per port in the
+    # values-declared range, each forwarding to the matching group-<port> container
+    # port on the node Envoy. A cluster pod connects to <serving-service>:<listenPort>
+    # and the node Envoy's dynamic tcp_proxy listener routes to the group's entry VM
+    # (or the composite activator on a miss). ClusterIP only, no edge exposure.
+    {{- $gr := .Values.servingEnvoy.compositeTcpPortRange }}
+    {{- range $p := untilStep (int $gr.start) (int (add (int $gr.end) 1)) 1 }}
+    - name: group-{{ $p }}
+      port: {{ $p }}
+      targetPort: group-{{ $p }}
+    {{- end }}
 {{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -562,6 +562,14 @@ noded:
   # three do not collide. The bridges live in noded's pod netns and die with the pod;
   # the durable truth is the on-disk group_networks/<gid>/config.json record.
   compositeSupernet: 10.101.0.0/16
+  # The base of noded's deterministic per-VM/entry DNAT port space:
+  # vmPort = servingPortBase + hostOffset(tapIP). This is the SINGLE source of truth
+  # for the port base: it is rendered into BOTH the noded env
+  # (EMBERVM_NODED_SERVING_PORT_BASE) and the control-plane env
+  # (EMBERVM_COMPOSITE_PORT_BASE), so the CP's entry-endpoint port re-derivation
+  # (which mirrors noded's PortForIP) can never drift from the daemon's. Default 30000
+  # (noded's own compile-time default), clear of noded's 8080/9090.
+  servingPortBase: 30000
 
   # Static bearer token gating the gRPC surface. Disabled here (daemon runs open +
   # warns; Cilium/Linkerd policy is the layer). A 1Password-provisioned secret is

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -781,7 +781,15 @@ defmodule Embervm.Application do
   # parked). The reconcile reuses the stateful reconcile cadence env by default so a
   # restart's group endpoint re-derivation lands on the same tempo.
   defp group_wake_manager_opts do
-    [reconcile_interval_ms: group_reconcile_interval_ms()] ++ group_wake_opts()
+    [
+      reconcile_interval_ms: group_reconcile_interval_ms(),
+      # The shared supernet + DNAT port base + pod IP the adoption reconcile re-derives
+      # the entry DNAT endpoint from (the SAME values group_manager_supervisor_opts
+      # threads into every GroupManager, so a republish equals the live publish).
+      supernet: composite_supernet_env(),
+      port_base: composite_port_base_env(),
+      pod_ip: trimmed_env("EMBERVM_POD_IP") |> nil_if_empty()
+    ] ++ group_wake_opts()
   end
 
   defp group_reconcile_interval_ms do

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -209,14 +209,38 @@ defmodule Embervm.Application do
       # republishes exactly the same endpoint without touching any VM. With no
       # stateful node wired, a wake denies :no_capacity.
       {Embervm.StatefulManager, stateful_manager_opts()},
-      # The L4 TCP activator (R4, Task 8): binds the values-declared stateful
-      # port range and dispatches an accepted connection to StatefulManager.wake/2
-      # (single-flighted there), then splices bytes bidirectionally between the
-      # client and the woken VM. Placed AFTER StatefulManager (it calls wake/2)
-      # and LAST among the stateful children: it is the front door, nothing
-      # depends on it being up. With an empty port range (the default; the chart
-      # wires EMBERVM_STATEFUL_ACTIVATOR_PORT_RANGE) it binds nothing, a clean
-      # no-op, exactly like PoolManager priming nothing with no base ready.
+      # The composite-group supervisor (R5): the DynamicSupervisor + Registry owning
+      # one Embervm.GroupManager process per LIVE group instance. The GroupWakeManager
+      # calls create_group/2 + wake_group/3 here on a wake-on-connect miss. Placed
+      # AFTER GroupStore + EndpointPublisher (a GroupManager mutates the store and asks
+      # the publisher to re-push) and BEFORE the GroupWakeManager + TcpActivator that
+      # drive it. The per-group config (supernet, port_base, pod_ip, node funs) is
+      # threaded via the :defaults opt from the chart env; with no composite supernet
+      # wired a create denies (a clean no-op).
+      {Embervm.GroupManager.Supervisor, group_manager_supervisor_opts()},
+      # The composite-group wake brain (R5, Task 7): the group counterpart of
+      # StatefulManager. It is the fallback endpoint of an empty group|<workload>
+      # cluster (a TCP connection the node Envoy routes to the TcpActivator on a
+      # composite entry.listenPort IS a group miss, resolved by the LOCAL ACCEPT
+      # PORT, decision 5), single-flights the wake (relight a complete banked set, or
+      # fresh-boot / create when the set is partial or absent, decision 8), publishes
+      # the entry endpoint via the EndpointPublisher, and resolves the parked
+      # connection so the activator splices bytes to the entry member. Placed AFTER
+      # GroupStore + EndpointPublisher + GroupManager.Supervisor (it drives them) and
+      # BEFORE TcpActivator (which calls wake/3). Its adoption reconcile runs on boot
+      # + timer, reconciling live members / bundle sets / networks from node facts so
+      # a control-plane restart republishes exactly the same entry endpoint without
+      # touching any VM. With no composite node wired, a wake denies :no_capacity.
+      {Embervm.GroupWakeManager, group_wake_manager_opts()},
+      # The L4 TCP activator (R4, Task 8; R5 composite): binds the values-declared
+      # stateful (5400-5409) AND composite (5410-5419) port ranges and dispatches an
+      # accepted connection to StatefulManager.wake/3 or GroupWakeManager.wake/3
+      # (single-flighted there) by the accept port's class, then splices bytes
+      # bidirectionally between the client and the woken VM/group entry. Placed AFTER
+      # StatefulManager + GroupWakeManager (it calls their wake/3) and LAST among the
+      # wake children: it is the front door, nothing depends on it being up. With an
+      # empty port range (the default; the chart wires the ranges) it binds nothing, a
+      # clean no-op.
       {Embervm.TcpActivator, tcp_activator_opts()},
       # The stateful lifecycle-economics sweeper (R4, Task 9): the L4 idle-to-bank /
       # max-lifetime / banked-TTL loop, the counterpart to Embervm.ServingSweeper. It
@@ -229,14 +253,6 @@ defmodule Embervm.Application do
       # wake path). With no stats_base wired (reuses EMBERVM_SERVING_STATS_BASE) every
       # tick fails open and banks nothing, mirroring ServingSweeper's no-op default.
       {Embervm.StatefulSweeper, stateful_sweeper_opts()},
-      # The composite-group supervisor (R5): the DynamicSupervisor + Registry owning
-      # one Embervm.GroupManager process per LIVE group instance. Task 7's activator
-      # calls create_group/2 here on a wake-on-connect miss. Placed AFTER GroupStore +
-      # EndpointPublisher (a GroupManager mutates the store and asks the publisher to
-      # re-push). The per-group config (supernet, port_base, pod_ip, node funs) is
-      # threaded via the :defaults opt from the chart env; with no composite supernet
-      # wired a create denies (a clean no-op).
-      {Embervm.GroupManager.Supervisor, group_manager_supervisor_opts()},
       # The op-log sweeper (ADR embervm/002): scheduled bounded-batch compaction of
       # the durable projection tables + ops-journal prefix. Placed LATE, right before
       # Bandit: it depends ONLY on the op-log (which starts early), so under
@@ -627,8 +643,36 @@ defmodule Embervm.Application do
   # (no point binding ports nothing is dialed on, and it keeps a plain
   # `mix test` / no-chart-values run from claiming a fixed port range on the
   # workstation or a shared CI executor).
+  # The activator binds BOTH the R4 stateful range (5400-5409) and the R5 composite
+  # range (5410-5419); a connection accepted on a port resolves the workload AND its
+  # class by the local accept port (decision 5) and routes to the stateful or group
+  # wake brain accordingly. The composite range binds only when the activator ip is
+  # wired (same gate as stateful: no point binding ports nothing dials on), and reads
+  # the SAME EMBERVM_COMPOSITE_LISTEN_PORT_RANGE the watcher + publisher use so the
+  # bound listeners match the rendered group-<listenPort> listeners.
   defp tcp_activator_opts do
-    [port_range: stateful_activator_port_range(), activator_ip: stateful_activator_ip()]
+    [
+      port_range: stateful_activator_port_range() ++ composite_activator_port_range(),
+      activator_ip: stateful_activator_ip()
+    ]
+  end
+
+  @default_composite_activator_port_start 5410
+  @default_composite_activator_port_end 5419
+
+  # The composite entry-listener ports the activator binds. Gated on the activator ip
+  # (a no-ip run binds nothing, so a plain `mix test` never claims fixed ports),
+  # reading EMBERVM_COMPOSITE_LISTEN_PORT_RANGE (the same value the watcher +
+  # publisher key on); unset defaults to 5410-5419.
+  defp composite_activator_port_range do
+    if stateful_activator_ip() do
+      case composite_listen_range_env() do
+        nil -> Enum.to_list(@default_composite_activator_port_start..@default_composite_activator_port_end)
+        range -> Enum.to_list(range)
+      end
+    else
+      []
+    end
   end
 
   @default_stateful_activator_port_start 5400
@@ -729,6 +773,31 @@ defmodule Embervm.Application do
         pod_ip: trimmed_env("EMBERVM_POD_IP") |> nil_if_empty()
       ]
     ]
+  end
+
+  # GroupWakeManager (R5, Task 7) config: the adoption reconcile cadence + the
+  # wake-rate/parked-cap knobs, mirroring StatefulManager. Defaults keep the
+  # reconcile timer ON in production; the module defaults the caps (10/min wake, 16
+  # parked). The reconcile reuses the stateful reconcile cadence env by default so a
+  # restart's group endpoint re-derivation lands on the same tempo.
+  defp group_wake_manager_opts do
+    [reconcile_interval_ms: group_reconcile_interval_ms()] ++ group_wake_opts()
+  end
+
+  defp group_reconcile_interval_ms do
+    case trimmed_env("EMBERVM_GROUP_RECONCILE_INTERVAL_MS") do
+      "" -> 10_000
+      raw -> String.to_integer(raw)
+    end
+  end
+
+  defp group_wake_opts do
+    [
+      wake_max: int_env_or_nil("EMBERVM_GROUP_WAKE_MAX"),
+      wake_window_ms: int_env_or_nil("EMBERVM_GROUP_WAKE_WINDOW_MS"),
+      park_cap: int_env_or_nil("EMBERVM_GROUP_PARK_CAP")
+    ]
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
   end
 
   # The composite supernet the CP allocates per-group /24s from. Shared source of

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -165,6 +165,13 @@ defmodule Embervm.Application do
       # the publisher (which re-derives the fan-out from the rebuilt projection). Like
       # ServingStore it depends only on the op-log (started far earlier).
       {Embervm.StatefulStore, []},
+      # Composite-group hot set (R5): the L4 composite counterpart of StatefulStore,
+      # placed BEFORE the EndpointPublisher, which reads its `entry_endpoint/2` for
+      # every composite workload's L4 cluster on its boot publish. Under :rest_for_one
+      # a GroupStore restart bounces the publisher (which re-derives the fan-out from
+      # the rebuilt `group_instances` + `group_members` projection). Depends only on
+      # the op-log (started far earlier).
+      {Embervm.GroupStore, []},
       {Embervm.EndpointPublisher, endpoint_publisher_opts()},
       # The activator (R3, Task 8): the serving miss brain. It is the fallback
       # endpoint of an empty serve|<workload> cluster (a request the node Envoy
@@ -222,6 +229,14 @@ defmodule Embervm.Application do
       # wake path). With no stats_base wired (reuses EMBERVM_SERVING_STATS_BASE) every
       # tick fails open and banks nothing, mirroring ServingSweeper's no-op default.
       {Embervm.StatefulSweeper, stateful_sweeper_opts()},
+      # The composite-group supervisor (R5): the DynamicSupervisor + Registry owning
+      # one Embervm.GroupManager process per LIVE group instance. Task 7's activator
+      # calls create_group/2 here on a wake-on-connect miss. Placed AFTER GroupStore +
+      # EndpointPublisher (a GroupManager mutates the store and asks the publisher to
+      # re-push). The per-group config (supernet, port_base, pod_ip, node funs) is
+      # threaded via the :defaults opt from the chart env; with no composite supernet
+      # wired a create denies (a clean no-op).
+      {Embervm.GroupManager.Supervisor, group_manager_supervisor_opts()},
       # The op-log sweeper (ADR embervm/002): scheduled bounded-batch compaction of
       # the durable projection tables + ops-journal prefix. Placed LATE, right before
       # Bandit: it depends ONLY on the op-log (which starts early), so under
@@ -696,6 +711,55 @@ defmodule Embervm.Application do
         end
     end
   end
+
+  # GroupManager.Supervisor (R5) config: the per-group defaults threaded into every
+  # Embervm.GroupManager the supervisor spawns. The composite supernet + port base are
+  # wired from the chart env and MUST be the SAME shared values that feed noded's
+  # CompositeSupernet + ServingPortBase (one chart value rendered into both pods), so
+  # the CP's subnet allocation and entry-DNAT-port re-derivation stay in lockstep with
+  # the daemon. pod_ip is the control-plane pod IP (the entry endpoint is published as
+  # {pod IP, vmPort}, the D-R3.11.4 lane). With no supernet wired the defaults carry
+  # the compile-time fallback (matching the chart defaults) so a no-chart `mix test`
+  # run still allocates from a sane /16.
+  defp group_manager_supervisor_opts do
+    [
+      defaults: [
+        supernet: composite_supernet_env(),
+        port_base: composite_port_base_env(),
+        pod_ip: trimmed_env("EMBERVM_POD_IP") |> nil_if_empty()
+      ]
+    ]
+  end
+
+  # The composite supernet the CP allocates per-group /24s from. Shared source of
+  # truth with noded (chart value noded.compositeSupernet rendered into BOTH pods).
+  # Defaults to the chart default 10.101.0.0/16 when unset so a no-chart run allocates
+  # from a sane /16.
+  defp composite_supernet_env do
+    case trimmed_env("EMBERVM_COMPOSITE_SUPERNET") do
+      "" -> "10.101.0.0/16"
+      raw -> raw
+    end
+  end
+
+  # The DNAT port base the CP re-derives the entry vmPort from. Shared source of truth
+  # with noded's ServingPortBase (chart value rendered into both pods). Defaults to
+  # 30000 (noded's own compile-time ServingPortBase default) when unset.
+  defp composite_port_base_env do
+    case trimmed_env("EMBERVM_COMPOSITE_PORT_BASE") do
+      "" ->
+        30_000
+
+      raw ->
+        case Integer.parse(raw) do
+          {base, ""} when base > 0 -> base
+          _ -> 30_000
+        end
+    end
+  end
+
+  defp nil_if_empty(""), do: nil
+  defp nil_if_empty(value), do: value
 
   # Parse EMBERVM_MAX_GROUP_SIZE into a positive integer, or nil when unset/malformed
   # (so the watcher default fires).

--- a/projects/embervm/control/lib/embervm/endpoint_publisher.ex
+++ b/projects/embervm/control/lib/embervm/endpoint_publisher.ex
@@ -91,7 +91,7 @@ defmodule Embervm.EndpointPublisher do
   # must be required even though it is called fully-qualified via the alias.
   require OpenTelemetry.Tracer, as: Tracer
 
-  alias Embervm.{NodeCapacity, ServingStore, StatefulStore, WorkloadCatalog}
+  alias Embervm.{GroupStore, NodeCapacity, ServingStore, StatefulStore, WorkloadCatalog}
 
   # Debounce window: coalesce a burst of fact changes into one PUT.
   @default_debounce_ms 50
@@ -120,6 +120,17 @@ defmodule Embervm.EndpointPublisher do
   # unique across stateful workloads by the WorkloadWatcher's validation), so two
   # stateful workloads never collide on a listener name either.
   @stateful_listener_prefix "state-"
+
+  # The cluster name for a COMPOSITE group's single L4 entry endpoint (R5). The
+  # `group|` prefix namespaces group clusters from serving (`serve|`) and stateful
+  # (`state|`) ones so a workload named the same in more than one class never
+  # collides on a cluster name; it is an opaque Envoy cluster name, never parsed.
+  @group_cluster_prefix "group|"
+  # The listener name prefix for a composite group's L4 TCP entry listener. The name
+  # is `group-<listen_port>` (the entry.listenPort disambiguates, unique across
+  # composite workloads by the WorkloadWatcher's validation), so two groups never
+  # collide on a listener name either.
+  @group_listener_prefix "group-"
 
   # -- Client API ------------------------------------------------------------
 
@@ -173,22 +184,34 @@ defmodule Embervm.EndpointPublisher do
     # fallback. A workload with NEITHER a live instance NOR a configured activator
     # emits nothing (see stateful_render/1), so a cold, un-wakeable stateful
     # workload contributes no empty-endpoints cluster the sidecar's validate rejects.
-    {stateful_clusters, listeners} = stateful_render(ctx)
+    {stateful_clusters, stateful_listeners} = stateful_render(ctx)
+
+    # Composite (L4) workloads (R5): for each composite-class workload, a listener +
+    # a cluster whose single endpoint is the live ENTRY member (GroupStore.entry_endpoint/2)
+    # OR the activator TCP fallback (banked OR no instance at all, for the LIFE of the
+    # CR, decision 8). Same cold-and-no-activator omission as stateful, so a group with
+    # no live entry and no activator contributes no empty-endpoints cluster. The
+    # rendered wire is byte-identical to R4 when there are no composite workloads (the
+    # clusters/listeners lists are empty), preserving the no-composite regression.
+    {group_clusters, group_listeners} = group_render(ctx)
+
+    listeners = stateful_listeners ++ group_listeners
 
     base = %{
       version: version,
-      # Serving clusters first, then stateful ones: the serving-only slice
-      # (stateful_clusters == []) is byte-identical to the pre-R4 document.
-      clusters: serving_clusters ++ stateful_clusters,
+      # Serving clusters first, then stateful, then composite: the serving-only slice
+      # (stateful + group clusters == []) is byte-identical to the pre-R4 document,
+      # and the serving+stateful slice (group clusters == []) is byte-identical to R4.
+      clusters: serving_clusters ++ stateful_clusters ++ group_clusters,
       routes: routes
     }
 
     # Only add the `listeners` key when there is at least one L4 listener to emit.
-    # A serving-only node (no stateful workloads, or none wakeable) therefore emits
-    # the EXACT map it emitted before R4, no `listeners` key at all. (The JSON
-    # encoder does not honour Go's struct-tag omitempty, so emitting `listeners: []`
-    # WOULD change the wire bytes; the Go struct's omitempty means the absent key
-    # decodes to a nil slice, which is what the serving-only path needs.)
+    # A serving-only node (no stateful/composite workloads, or none wakeable)
+    # therefore emits the EXACT map it emitted before R4, no `listeners` key at all.
+    # (The JSON encoder does not honour Go's struct-tag omitempty, so emitting
+    # `listeners: []` WOULD change the wire bytes; the Go struct's omitempty means the
+    # absent key decodes to a nil slice, which is what the serving-only path needs.)
     if listeners == [] do
       base
     else
@@ -206,6 +229,10 @@ defmodule Embervm.EndpointPublisher do
       # published_endpoint/1 (the single live endpoint or nil). Injected in tests;
       # production supervises the singleton Embervm.StatefulStore.
       stateful_store: Keyword.get(opts, :stateful_store, StatefulStore),
+      # The composite (L4) group hot-set store, read purely for composite workloads'
+      # entry_endpoint/2 (the single live entry endpoint or nil). Injected in tests;
+      # production supervises the singleton Embervm.GroupStore.
+      group_store: Keyword.get(opts, :group_store, GroupStore),
       catalog_table: Keyword.get(opts, :catalog_table, WorkloadCatalog.table()),
       capacity_table: Keyword.get(opts, :capacity_table, NodeCapacity.table()),
       # The PUT seam: (node_id, desired_map) -> :ok | {:error, reason}. Production
@@ -402,6 +429,7 @@ defmodule Embervm.EndpointPublisher do
     %{
       store: state.store,
       stateful_store: state.stateful_store,
+      group_store: state.group_store,
       catalog_table: state.catalog_table,
       activator_endpoint: state.activator_endpoint,
       activator_ip: state.activator_ip,
@@ -603,6 +631,82 @@ defmodule Embervm.EndpointPublisher do
        do: %{ip: ip, port: listen_port}
 
   defp activator_tcp_endpoint(_ctx, _listen_port), do: nil
+
+  # -- composite (L4) projection (R5) ----------------------------------------
+
+  # Render the L4 listeners + clusters for every composite-class catalog workload.
+  # Returns {clusters, listeners}. For each composite workload the endpoint is the
+  # single live ENTRY member (GroupStore.entry_endpoint/2) OR the activator TCP
+  # fallback at the group's entry.listenPort (banked OR no instance at all, decision
+  # 8: the activator is the fallback for the LIFE of the CR); a workload with NEITHER
+  # (cold AND no activator configured) emits nothing, so the sidecar never receives an
+  # empty-endpoints cluster. Both lists are catalog-ordered (the workloads are sorted),
+  # so the render is deterministic across rebuilds. Byte-identical to the R4 shape when
+  # there are no composite workloads (both lists empty).
+  defp group_render(ctx) do
+    group_catalog_entries(ctx.catalog_table)
+    |> Enum.reduce({[], []}, fn {workload, cfg}, {clusters, listeners} ->
+      case group_endpoint(ctx, workload, cfg.listen_port) do
+        nil ->
+          Logger.debug(
+            "embervm endpoint publisher: composite workload #{workload} has no running entry " <>
+              "and no activator_ip configured; emitting no listener/cluster (cannot wake yet)"
+          )
+
+          {clusters, listeners}
+
+        endpoint ->
+          cluster = %{
+            name: @group_cluster_prefix <> workload,
+            endpoints: [%{ip: endpoint.ip, port: endpoint.port}],
+            connect_timeout_ms: ctx.connect_timeout_ms
+          }
+
+          listen_port = cfg.listen_port
+
+          listener = %{
+            name: @group_listener_prefix <> Integer.to_string(listen_port),
+            port: listen_port,
+            cluster: @group_cluster_prefix <> workload
+          }
+
+          {clusters ++ [cluster], listeners ++ [listener]}
+      end
+    end)
+  end
+
+  # Every composite-class workload in the catalog paired with its entry config (for
+  # the entry listenPort), catalog-ordered by name so the render is deterministic. A
+  # composite entry with no entry.listenPort is skipped (it cannot form a listener);
+  # the WorkloadWatcher rejects such a spec, so this is defence-in-depth.
+  defp group_catalog_entries(catalog_table) do
+    WorkloadCatalog.all_names(catalog_table)
+    |> Enum.sort()
+    |> Enum.flat_map(fn name ->
+      case WorkloadCatalog.fetch(catalog_table, name) do
+        {:ok, %{class: "composite", group: %{entry: %{listen_port: lp} = entry}}} when is_integer(lp) ->
+          [{name, entry}]
+
+        _ ->
+          []
+      end
+    end)
+  end
+
+  # The endpoint the composite workload's L4 cluster should carry: the single live
+  # entry member if the group is running-and-entry-healthy, else the activator's
+  # fallback endpoint AT THIS WORKLOAD'S OWN entry.listenPort (the activator resolves
+  # the workload from the local accept port), else nil (cold and no activator_ip =>
+  # skipped upstream).
+  defp group_endpoint(ctx, workload, listen_port) do
+    case GroupStore.entry_endpoint(ctx.group_store, workload) do
+      %{ip: ip, port: port} when is_binary(ip) and ip != "" and is_integer(port) ->
+        %{ip: ip, port: port}
+
+      _ ->
+        activator_tcp_endpoint(ctx, listen_port)
+    end
+  end
 
   # -- version ---------------------------------------------------------------
 

--- a/projects/embervm/control/lib/embervm/group_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_manager.ex
@@ -459,7 +459,7 @@ defmodule Embervm.GroupManager do
               # The durable relit edge failed: abort back to banked and fall back to
               # fresh (the set is intact, but we cannot record the relight).
               _ = GroupStore.mark(state.store, instance.instance_id, :relight_abort)
-              fallback_fresh(state, instance, subnet_cidr, secret, group, {:relit_record_failed, reason})
+              fallback_fresh(state, instance, subnet_cidr, secret, group, plan, {:relit_record_failed, reason})
           end
         else
           {:error, reason} ->
@@ -467,7 +467,7 @@ defmodule Embervm.GroupManager do
             # FAILED_PRECONDITION, decision 7): abort back to banked, then evict the
             # whole set and fresh-boot in the same call. relight_abort is ETS-only.
             _ = GroupStore.mark(state.store, instance.instance_id, :relight_abort)
-            fallback_fresh(state, instance, subnet_cidr, secret, group, {:relight_failed, reason})
+            fallback_fresh(state, instance, subnet_cidr, secret, group, plan, {:relight_failed, reason})
         end
 
       {:error, reason} ->
@@ -486,13 +486,19 @@ defmodule Embervm.GroupManager do
   # parked caller is still blocked on the one wake_group call, so this holds the
   # connection across the fallback. group_fresh_booted{reason} records the discarded
   # warmth.
-  defp fallback_fresh(state, instance, subnet_cidr, secret, group, reason) do
+  defp fallback_fresh(state, instance, subnet_cidr, secret, group, plan, reason) do
     fresh_reason = fresh_reason_string(reason)
     # Free tap+IP for any member that DID resume before the relight aborted, so the
     # fresh re-pin does not collide on an occupied tap. Drains from the instance's
     # stored live member rows (member_started recorded each resumed member).
     _ = destroy_live_members(state)
-    _ = evict_set(state, instance)
+    # Evict the WHOLE banked set (all-or-nothing, decision 3): the per-member bundle
+    # refs come from the `plan` captured at wake start (wake_plan read the banked rows
+    # BEFORE any relight cleared them), NOT the current live rows, which the resume /
+    # destroy path has since mutated. Passing the plan is what makes the eviction
+    # complete: every member's bundle is EvictSnapshot'd, not just the one that never
+    # relit and so still carries its ref in the live rows.
+    _ = evict_set(state, instance, plan)
 
     with {:ok, _} <- GroupStore.mark(state.store, instance.instance_id, :fresh_boot),
          {:ok, _} <-
@@ -657,15 +663,18 @@ defmodule Embervm.GroupManager do
     end
   end
 
-  # Evict the banked set durably (group_set_evicted clears set_id + each member's
-  # snapshot_ref, no FSM edge; the fresh_booting move is the mark/2 in
-  # fallback_fresh) so a rebuild agrees the warmth is gone, and best-effort
-  # EvictSnapshot each member's bundle on the node (the snapshots must not leak).
-  defp evict_set(state, instance) do
-    members = GroupStore.members(state.store, instance.instance_id)
+  # Evict the WHOLE banked set (all-or-nothing, decision 3): durably (group_set_evicted
+  # clears set_id + every member's snapshot_ref in the store, no FSM edge; the
+  # fresh_booting move is the mark/2 in fallback_fresh) so a rebuild agrees the warmth
+  # is gone, AND best-effort EvictSnapshot every member's bundle on the node so no
+  # orphan snapshot leaks. The per-member refs come from `plan` (captured at wake
+  # start, before relight cleared the live rows' snapshot_refs), so the eviction is
+  # complete regardless of which members relit or were destroyed. A member with no
+  # captured ref (never banked) is simply skipped.
+  defp evict_set(state, instance, plan) do
     _ = GroupStore.evict_set(state.store, instance.instance_id, "relight_fallback")
 
-    for %{snapshot_ref: ref} <- members, is_binary(ref) and ref != "" do
+    for %{snapshot_ref: ref} <- plan, is_binary(ref) and ref != "" do
       _ = evict_snapshot(state, ref)
     end
 

--- a/projects/embervm/control/lib/embervm/group_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_manager.ex
@@ -1,0 +1,687 @@
+defmodule Embervm.GroupManager do
+  @moduledoc """
+  The composite-group control-plane brain: ONE supervised process per LIVE group
+  INSTANCE, owning that group's ordered create/start/bank/relight state machine.
+  This is the composite generalization of `Embervm.StatefulManager`, but where the
+  stateful manager is a SINGLE process single-flighting per-workload wakes, a group
+  is a SET of member VMs whose ordered lifecycle is heavy enough (role-ordered,
+  health-gated member starts across a private subnet) to own its own process. A
+  `DynamicSupervisor` (`Embervm.GroupManager.Supervisor`) + `Registry`
+  (`Embervm.GroupRegistry`, keyed by workload) spawn one GroupManager child per live
+  group; `Embervm.GroupManager.Supervisor.create_group/2` is the entrypoint Task 7's
+  activator calls on a wake-on-connect miss.
+
+  ## why per-instance, not one process
+
+  `StatefulManager` is one process because a stateful workload is a single VM with a
+  trivially-ordered lifecycle; single-flighting a per-workload wake there is cheap.
+  A composite group's create sequences N member starts across R role orders, each
+  health-gated, and drives per-member bank/relight loops. Doing that on one shared
+  process would head-of-line-block every other group's create behind one slow
+  member boot. So the group lifecycle lives on a per-instance process (the
+  `Embervm.Session` per-session precedent), and the supervisor/registry own
+  discovery + single-instance-per-workload.
+
+  ## the ordered create sequence (atomic: any member-start failure => failed)
+
+  `create_group/1` on the per-instance process:
+
+    1. records the group instance (`GroupStore.create/2`, the singleton gate);
+    2. assigns the group's private /24 (lowest-free, `GroupStore.held_subnets/1`)
+       and CreateGroupNetwork's it on the anchor node (re-issued idempotently before
+       any relight, since the bridge dies with the noded pod);
+    3. composes the deterministic member address plan (`.10 + i` over the flattened,
+       declaration-ordered, replica-expanded member list, MATCHING the watcher's
+       `expanded_member_names/1` AND noded's `groupMemberIP`);
+    4. starts members in ROLE ORDER: all members of `startOrder` 0 in PARALLEL,
+       health-gated (StartGroupMember returns only after noded health-gates
+       {ip, health_port}), THEN order 1, and so on;
+    5. publishes the entry endpoint (the entry member's DNAT `{pod IP, vmPort}`) and
+       moves the group to `running`.
+
+  A member start FAILURE during create tears the WHOLE group down to `failed` and
+  deletes the group network (create is ATOMIC; degradation only applies to
+  already-running groups, decision 11). There is no half-created group.
+
+  ## EMBER_GROUP_* env (decision 13, FRESH-only)
+
+  Each expanded member's FRESH boot env carries, on top of its declared `env`:
+
+    * `EMBER_GROUP_MEMBER` = the expanded member name (`agent-0`);
+    * `EMBER_GROUP_ROLE`   = the member's role;
+    * `EMBER_GROUP_IP`     = the member's pinned group-subnet IP;
+    * `EMBER_PEER_<NAME>`  = each peer's IP, `<NAME>` = the expanded peer name
+      UPPERCASED with `-` -> `_` (so `agent-0` -> `EMBER_PEER_AGENT_0`);
+    * `EMBER_GROUP_SECRET` = the group secret (from `secretRef`, or minted at
+      create).
+
+  The env is FRESH-only: a RELIGHT resumes each member's memory snapshot, so the
+  kernel never re-reads boot-args and the birth env is kept. The peer map is built
+  from the SAME deterministic address plan used to pin the taps, so a member's view
+  of its peers is exactly the addresses noded configured.
+
+  ## the entry endpoint (CP re-derives the DNAT port, Task 4 lockstep)
+
+  noded exposes a group's entry member as `podIP:vmPort` where
+  `vmPort = ServingPortBase + hostOffset(entryIP, compositeSupernet)` (the D-R3.11.4
+  lane, `noded/serving/net.go` `PortForIP` + `hostOffset`, installed by
+  `noded/serving/group.go` `EnsureEntryDNAT`). The daemon does NOT report that port
+  back (StartGroupMemberResponse echoes only `{vm_id, ip, was_relight}`), so the
+  control plane RE-DERIVES it here from the SAME shared `EMBERVM_COMPOSITE_PORT_BASE`
+  + `EMBERVM_COMPOSITE_SUPERNET` values that feed noded's `ServingPortBase` +
+  `CompositeSupernet`. This MUST stay in lockstep with noded's port derivation
+  (`noded/serving/net.go:PortForIP`); a change to either side breaks the entry
+  endpoint. The derived `{pod IP, vmPort}` is recorded on the GroupStore instance
+  (`entry_ip`/`entry_port_published`), so if Task 7 later has noded REPORT the entry
+  endpoint via NodeStatus, it just overwrites the same fact with no migration.
+  """
+
+  use GenServer
+  require Logger
+  import Bitwise
+
+  alias Embervm.{GroupState, GroupStore, NodeCapacity, WorkloadCatalog}
+
+  alias Embervm.Node.V1.{
+    CreateGroupNetworkRequest,
+    CreateGroupNetworkResponse,
+    DeleteGroupNetworkRequest,
+    StartGroupMemberRequest,
+    StartGroupMemberResponse,
+    ResourceSpec,
+    Trace
+  }
+
+  # The host offset of member index 0 within a group /24 (MATCHES noded's
+  # groupMemberBaseOffset in serving/group.go: member i is .10 + i; .1 is the
+  # gateway, .2..9 are reserved headroom). Kept in lockstep with the daemon.
+  @group_member_base_offset 10
+
+  # -- Client API (per-instance process) -------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc """
+  Drives the full ordered create sequence synchronously and returns
+  `{:ok, %{ip, port}}` (the entry endpoint the caller/activator resolves the parked
+  connection to) or `{:error, reason}` (the group is torn down to `failed` on any
+  member-start failure). Blocks until the group is running or failed.
+  """
+  @spec create_group(GenServer.server()) :: {:ok, map()} | {:error, term()}
+  def create_group(server) do
+    GenServer.call(server, :create_group, :infinity)
+  end
+
+  @doc "The group instance's current entry endpoint (or nil), for tests + straggler resolution."
+  @spec entry_endpoint(GenServer.server()) :: map() | nil
+  def entry_endpoint(server) do
+    GenServer.call(server, :entry_endpoint)
+  end
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    state = %{
+      instance_id: Keyword.fetch!(opts, :instance_id),
+      workload: Keyword.fetch!(opts, :workload),
+      principal: Keyword.fetch!(opts, :principal),
+      entry: Keyword.fetch!(opts, :entry),
+      node_id: Keyword.fetch!(opts, :node_id),
+      store: Keyword.get(opts, :store, GroupStore),
+      publisher: Keyword.get(opts, :publisher, Embervm.EndpointPublisher),
+      capacity_table: Keyword.get(opts, :capacity_table, NodeCapacity.table()),
+      tenant: Keyword.get(opts, :tenant, "homelab"),
+      supernet: Keyword.fetch!(opts, :supernet),
+      port_base: Keyword.fetch!(opts, :port_base),
+      pod_ip: Keyword.get(opts, :pod_ip),
+      # Daemon group-verb seams (injected for tests; production dials the real
+      # NodeService stub over the shared NodeChannel).
+      channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
+      create_group_network_fun:
+        Keyword.get(opts, :create_group_network_fun, &default_create_group_network/2),
+      delete_group_network_fun:
+        Keyword.get(opts, :delete_group_network_fun, &default_delete_group_network/2),
+      start_group_member_fun:
+        Keyword.get(opts, :start_group_member_fun, &default_start_group_member/2),
+      stop_group_member_fun:
+        Keyword.get(opts, :stop_group_member_fun, &default_stop_group_member/2),
+      get_secret_fun: Keyword.get(opts, :get_secret_fun, &Embervm.K8s.get_secret/2),
+      secret_fun: Keyword.get(opts, :secret_fun, &mint_secret/0),
+      clock: Keyword.get(opts, :clock, &default_clock/0)
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:create_group, _from, state) do
+    {reply, state} = do_create_group(state)
+    {:reply, reply, state}
+  end
+
+  def handle_call(:entry_endpoint, _from, state) do
+    endpoint =
+      case GroupStore.get(state.store, state.instance_id) do
+        {:ok, %{state: :running, entry_ip: ip, entry_port_published: port}}
+        when is_binary(ip) and is_integer(port) ->
+          %{ip: ip, port: port}
+
+        _ ->
+          nil
+      end
+
+    {:reply, endpoint, state}
+  end
+
+  # -- create sequence -------------------------------------------------------
+
+  defp do_create_group(state) do
+    entry_cfg = state.entry
+    group = Map.fetch!(entry_cfg, :group)
+
+    # 1. The deterministic member address plan (.10 + i over the flattened,
+    #    declaration-ordered, replica-expanded member list). Built BEFORE the network
+    #    so the CIDR + plan are consistent, and used for both the tap pin ip and the
+    #    peer-map env.
+    subnet_cidr = allocate_subnet(state)
+
+    plan = member_plan(group, subnet_cidr)
+
+    # 2. Record the group instance (the singleton gate) with its subnet + entry
+    #    identity + the sourced/minted secret.
+    secret = resolve_secret(state, entry_cfg, group)
+
+    create_attrs = %{
+      instance_id: state.instance_id,
+      tenant: state.tenant,
+      principal: state.principal,
+      workload: state.workload,
+      node_id: state.node_id,
+      subnet_cidr: subnet_cidr,
+      entry_member: group.entry.member,
+      entry_port: group.entry.port,
+      listen_port: group.entry.listen_port,
+      secret: secret
+    }
+
+    # The singleton gate FIRST, on its own: a refusal (another live instance already
+    # holds this workload's group + its subnet) must NOT trigger the teardown path,
+    # which would tear down the OTHER instance's network. Only a failure AFTER the
+    # instance is recorded is torn down to failed.
+    case GroupStore.create(state.store, create_attrs) do
+      {:ok, _instance} ->
+        do_create_sequence(state, subnet_cidr, plan, secret, group)
+
+      {:error, reason} ->
+        {{:error, reason}, state}
+    end
+  end
+
+  defp do_create_sequence(state, subnet_cidr, plan, secret, group) do
+    with {:ok, _net} <- create_network(state, subnet_cidr),
+         :ok <- GroupStore.net_created(state.store, state.instance_id, subnet_cidr) |> ok_or(),
+         # Role-ordered, health-gated member starts. Any failure short-circuits to the
+         # else and is torn down to failed (create is ATOMIC, decision 11).
+         :ok <- start_members_ordered(state, plan, secret, subnet_cidr) do
+      # Publish the entry endpoint (the entry member's DNAT projection) and move the
+      # group to running.
+      finish_create(state, plan, group)
+    else
+      {:error, reason} ->
+        teardown_failed(state, reason)
+        {{:error, reason}, state}
+    end
+  rescue
+    e ->
+      teardown_failed(state, {:create_crashed, e})
+      {{:error, {:create_crashed, e}}, state}
+  end
+
+  # Role-ordered member starts: group members by their startOrder ordinal, ascending;
+  # start all members of one order in PARALLEL, health-gate every one (the
+  # StartGroupMember RPC returns only after noded health-gates {ip, health_port}),
+  # and only proceed to the next order once every member of the current order
+  # succeeded. Order N never starts before all order N-1 members are healthy.
+  defp start_members_ordered(state, plan, secret, subnet_cidr) do
+    orders =
+      plan
+      |> Enum.group_by(& &1.start_order)
+      |> Enum.sort_by(fn {order, _} -> order end)
+
+    Enum.reduce_while(orders, :ok, fn {_order, members}, :ok ->
+      case start_order_parallel(state, members, plan, secret, subnet_cidr) do
+        :ok -> {:cont, :ok}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  # Start every member of one startOrder concurrently and await all. A single
+  # failure fails the whole order (and, via the caller, the whole create). Each task
+  # body is wrapped so a raised/exited member start becomes an {:error, _} result
+  # rather than a task exit that would take the GroupManager process down mid-create
+  # (the create is atomic: a failure must reach teardown_failed, not crash the owner).
+  defp start_order_parallel(state, members, plan, secret, subnet_cidr) do
+    members
+    |> Enum.map(fn member ->
+      Task.async(fn ->
+        try do
+          start_one_member(state, member, plan, secret, subnet_cidr)
+        rescue
+          e -> {:error, {:member_start_crashed, member.expanded_name, e}}
+        catch
+          kind, reason -> {:error, {:member_start_crashed, member.expanded_name, {kind, reason}}}
+        end
+      end)
+    end)
+    |> Enum.map(&Task.await(&1, :infinity))
+    |> Enum.find(:ok, &match?({:error, _}, &1))
+  end
+
+  defp start_one_member(state, member, plan, secret, subnet_cidr) do
+    req = %StartGroupMemberRequest{
+      trace: %Trace{workload: state.workload},
+      mode: :START_GROUP_MEMBER_MODE_FRESH,
+      group_instance_id: state.instance_id,
+      member_name: member.expanded_name,
+      member_index: member.index,
+      ip: member.ip,
+      source: member.image_ref || "",
+      snapshot_ref: "",
+      health_port: member.health_port || 0,
+      resources: %ResourceSpec{vcpus: member.vcpus || 1, mem_mib: member.mem_mib || 512},
+      env: member_env(member, plan, secret, state.workload, subnet_cidr)
+    }
+
+    case safe_start_group_member(state, req) do
+      {:ok, %StartGroupMemberResponse{vm_id: vm_id, ip: ip}} when is_binary(vm_id) and vm_id != "" ->
+        case GroupStore.member_started(state.store, state.instance_id, %{
+               member_name: member.expanded_name,
+               member_index: member.index,
+               vm_id: vm_id,
+               ip: ip
+             }) do
+          {:ok, _} -> :ok
+          {:error, reason} -> {:error, {:member_record_failed, member.expanded_name, reason}}
+        end
+
+      other ->
+        {:error, {:member_start_failed, member.expanded_name, other}}
+    end
+  end
+
+  # Publish the entry endpoint + move to running. The published endpoint is the entry
+  # member's DNAT projection: {pod IP, vmPort}, vmPort re-derived from the entry
+  # member's group-subnet IP (see the moduledoc's lockstep note).
+  defp finish_create(state, plan, group) do
+    entry_member = Enum.find(plan, &(&1.expanded_name == group.entry.member))
+
+    case entry_member do
+      nil ->
+        teardown_failed(state, {:entry_member_not_in_plan, group.entry.member})
+        {{:error, {:entry_member_not_in_plan, group.entry.member}}, state}
+
+      %{ip: entry_ip} ->
+        case entry_vm_port(state, entry_ip) do
+          {:ok, vm_port} ->
+            pod_ip = state.pod_ip || entry_ip
+
+            case GroupStore.publish(state.store, state.instance_id, pod_ip, vm_port) do
+              {:ok, _} ->
+                Embervm.EndpointPublisher.publish(state.publisher)
+                Logger.info("embervm group running", workload: state.workload, instance_id: state.instance_id)
+                {{:ok, %{ip: pod_ip, port: vm_port}}, state}
+
+              {:error, reason} ->
+                teardown_failed(state, {:publish_failed, reason})
+                {{:error, {:publish_failed, reason}}, state}
+            end
+
+          {:error, reason} ->
+            teardown_failed(state, {:entry_port_derivation, reason})
+            {{:error, {:entry_port_derivation, reason}}, state}
+        end
+    end
+  end
+
+  # Tear a partially-created group down to failed: fail the instance (durable), then
+  # best-effort DeleteGroupNetwork (the bridge must not leak). Create is atomic, so
+  # this leaves no half-group behind.
+  defp teardown_failed(state, reason) do
+    _ =
+      GroupStore.transition(
+        state.store,
+        state.instance_id,
+        :fail,
+        :group_failed,
+        %{reason: failure_reason_string(reason)},
+        %{}
+      )
+
+    _ = delete_network(state)
+    Embervm.EndpointPublisher.publish(state.publisher)
+    Logger.warning("embervm group create failed, torn down", workload: state.workload, reason: inspect(reason))
+    :ok
+  end
+
+  # -- member address plan (deterministic, lockstep with the watcher + noded) -
+
+  # The flattened, declaration-ordered, replica-expanded member list, each stamped
+  # with its global index i (0-based across the WHOLE list) and pinned IP `.10 + i`
+  # on the group /24. Mirrors WorkloadWatcher.expanded_member_names/1 (replicas > 1
+  # -> `<name>-<idx>` 0-based; replicas 1 -> bare name) AND noded's groupMemberIP
+  # (.10 + index). Each expanded member inherits its declared member's role, source,
+  # resources, health_port, env, and startOrder.
+  defp member_plan(group, subnet_cidr) do
+    base = subnet_base_tuple(subnet_cidr)
+
+    group.members
+    |> Enum.flat_map(&expand_member/1)
+    |> Enum.with_index()
+    |> Enum.map(fn {member, i} ->
+      Map.merge(member, %{index: i, ip: member_ip(base, @group_member_base_offset + i)})
+    end)
+  end
+
+  # Expand one declared member into its replica set: replicas > 1 -> `<name>-<idx>`
+  # (0-based); replicas 1 (or absent) -> the bare name. MATCHES the watcher's
+  # expanded_member_names/1 replica-expansion (minus the bare-name-also-listed quirk
+  # there, which is only for entry-target validation: the ADDRESS plan is the pure
+  # expanded set, one address per live member VM).
+  defp expand_member(member) do
+    replicas = member_replicas(member)
+    role = Map.get(member, :role)
+    start_order = Map.get(member, :start_order) || 0
+
+    common = %{
+      role: role,
+      start_order: start_order,
+      image_ref: Map.get(member, :image_ref),
+      vcpus: Map.get(member, :vcpus),
+      mem_mib: Map.get(member, :mem_mib),
+      health_port: Map.get(member, :health_port),
+      env: Map.get(member, :env) || %{}
+    }
+
+    if replicas > 1 do
+      Enum.map(0..(replicas - 1), fn idx ->
+        Map.put(common, :expanded_name, "#{member.name}-#{idx}")
+      end)
+    else
+      [Map.put(common, :expanded_name, member.name)]
+    end
+  end
+
+  # Clamp replicas to >= 1, guarding the Elixir truthiness trap (0 is truthy), EXACTLY
+  # as WorkloadWatcher.member_replicas/1 does, so the CP and the watcher agree on the
+  # expanded count.
+  defp member_replicas(member) do
+    case Map.get(member, :replicas) do
+      n when is_integer(n) and n > 0 -> n
+      _ -> 1
+    end
+  end
+
+  # -- EMBER_GROUP_* env compose (decision 13) -------------------------------
+
+  # The FRESH boot env for one expanded member: its declared env, plus the
+  # platform-injected EMBER_GROUP_* keys (member identity, role, ip, the peer map,
+  # and the group secret). Keys are string-keyed to match the proto map<string,string>.
+  defp member_env(member, plan, secret, _workload, _subnet_cidr) do
+    peer_env =
+      plan
+      |> Enum.reduce(%{}, fn peer, acc ->
+        Map.put(acc, "EMBER_PEER_#{peer_env_key(peer.expanded_name)}", peer.ip)
+      end)
+
+    base =
+      member.env
+      |> Enum.into(%{}, fn {k, v} -> {to_string(k), to_string(v)} end)
+
+    base
+    |> Map.merge(peer_env)
+    |> Map.merge(%{
+      "EMBER_GROUP_MEMBER" => member.expanded_name,
+      "EMBER_GROUP_ROLE" => to_string(member.role || ""),
+      "EMBER_GROUP_IP" => member.ip,
+      "EMBER_GROUP_SECRET" => secret || ""
+    })
+  end
+
+  # Uppercase the expanded member name and replace `-` with `_` for the EMBER_PEER_*
+  # env key (agent-0 -> AGENT_0). A DNS-label member name has only [a-z0-9-], so this
+  # yields a valid [A-Z0-9_] env-var suffix.
+  defp peer_env_key(name) do
+    name |> String.upcase() |> String.replace("-", "_")
+  end
+
+  # -- secret sourcing -------------------------------------------------------
+
+  # With spec.group.secretRef, read the referenced Secret key at create (stable
+  # across instances by construction). Without it, mint 32 bytes base64url (the
+  # secret_fun seam, injected in tests) recorded in the group_created op. Fail-open on
+  # a secret-read failure: proceed with an empty secret (the group's own readiness is
+  # the loud failure surface), matching the stateful mmds_env posture.
+  defp resolve_secret(state, entry_cfg, group) do
+    case Map.get(group, :secret_ref) do
+      %{name: name, key: key} when is_binary(name) and name != "" ->
+        namespace = Map.get(entry_cfg, :namespace)
+
+        case state.get_secret_fun.(namespace, name) do
+          {:ok, data} ->
+            Map.get(data, key) || ""
+
+          {:error, reason} ->
+            Logger.warning("embervm group: secretRef read failed, proceeding with empty secret (fail-open)",
+              workload: state.workload,
+              secret_ref: name,
+              reason: inspect(reason)
+            )
+
+            ""
+        end
+
+      _ ->
+        state.secret_fun.()
+    end
+  end
+
+  defp mint_secret do
+    32 |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)
+  end
+
+  # -- subnet allocation (lowest-free /24 from the composite supernet) --------
+
+  # Assign the LOWEST /24 within the supernet not currently held by a LIVE-or-BANKED
+  # group instance (GroupStore.held_subnets/1). Lowest-free is a pure function of live
+  # state (nothing extra to persist; the assigned CIDR is recorded in group_created so
+  # a rebuild reconstructs the held set) and reuses freed /24s so the /16 cannot be
+  # exhausted. The supernet is the SAME value noded validates group cidrs against, so
+  # every assigned /24 is a valid /24 wholly within it.
+  defp allocate_subnet(state) do
+    held = GroupStore.held_subnets(state.store)
+    {a, b, _c, _d} = parse_ip(supernet_base(state.supernet))
+
+    # A /16 supernet gives third octets 0..255; each /24 is a.b.<c>.0/24. Pick the
+    # lowest c whose /24 is not held. (A supernet larger than /16 would carry more
+    # candidates; v1's compositeSupernet is a /16, so the third octet enumerates the
+    # /24s.)
+    Enum.find_value(0..255, fn c ->
+      cidr = "#{a}.#{b}.#{c}.0/24"
+      if MapSet.member?(held, cidr), do: nil, else: cidr
+    end) || raise "embervm group: composite supernet #{state.supernet} exhausted (all /24s held)"
+  end
+
+  # -- entry DNAT port (CP re-derives; lockstep with noded PortForIP) ---------
+
+  # vmPort = port_base + hostOffset(entryIP, supernet), the EXACT derivation noded's
+  # serving/net.go PortForIP does (offset within the SUPERNET, not the group /24), so
+  # the CP's published {pod IP, vmPort} matches the daemon's installed DNAT rule.
+  # MUST stay in lockstep with noded/serving/net.go:PortForIP + hostOffset.
+  defp entry_vm_port(state, entry_ip) do
+    with {:ok, offset} <- host_offset(state.supernet, entry_ip) do
+      port = state.port_base + offset
+
+      if port >= 1 and port <= 65_535 do
+        {:ok, port}
+      else
+        {:error, {:port_out_of_range, port}}
+      end
+    end
+  end
+
+  # -- IP math ---------------------------------------------------------------
+
+  defp subnet_base(cidr), do: cidr |> String.split("/") |> hd()
+
+  defp supernet_base(cidr), do: cidr |> String.split("/") |> hd()
+
+  defp subnet_base_tuple(cidr), do: cidr |> subnet_base() |> parse_ip()
+
+  # The pinned member IP: network base + host offset (`.10 + i`). base is the /24
+  # network address tuple.
+  defp member_ip({a, b, c, _d}, offset) do
+    "#{a}.#{b}.#{c}.#{offset}"
+  end
+
+  defp member_ip(cidr, offset) when is_binary(cidr) do
+    member_ip(subnet_base_tuple(cidr), offset)
+  end
+
+  # hostOffset within the supernet: the ip's host part as a big-endian int, masked by
+  # the supernet prefix. Mirrors noded's hostOffset (serving/net.go). Errors when ip
+  # is not inside the supernet. v1 supernets are /16, so the offset is
+  # (third_octet << 8) | fourth_octet.
+  defp host_offset(supernet_cidr, ip) do
+    [net, prefix_str] = String.split(supernet_cidr, "/")
+    prefix = String.to_integer(prefix_str)
+    {na, nb, nc, nd} = parse_ip(net)
+    {ia, ib, ic, id} = parse_ip(ip)
+
+    net_int = ip_to_int({na, nb, nc, nd})
+    ip_int = ip_to_int({ia, ib, ic, id})
+    mask = mask_for(prefix)
+
+    if band(net_int, mask) == band(ip_int, mask) do
+      {:ok, ip_int |> band(bnot(mask)) |> band(0xFFFFFFFF)}
+    else
+      {:error, {:ip_outside_supernet, ip, supernet_cidr}}
+    end
+  end
+
+  defp ip_to_int({a, b, c, d}), do: bsl(a, 24) + bsl(b, 16) + bsl(c, 8) + d
+
+  defp mask_for(prefix) do
+    ones = bsl(0xFFFFFFFF, 32 - prefix)
+    band(ones, 0xFFFFFFFF)
+  end
+
+  defp parse_ip(ip) do
+    [a, b, c, d] = ip |> String.split(".") |> Enum.map(&String.to_integer/1)
+    {a, b, c, d}
+  end
+
+  # -- daemon seams ----------------------------------------------------------
+
+  defp create_network(state, cidr) do
+    req = %CreateGroupNetworkRequest{
+      trace: %Trace{workload: state.workload},
+      group_instance_id: state.instance_id,
+      cidr: cidr
+    }
+
+    with {:ok, channel} <- safe_channel(state, state.node_id) do
+      case state.create_group_network_fun.(channel, req) do
+        {:ok, %CreateGroupNetworkResponse{} = resp} -> {:ok, resp}
+        other -> {:error, {:create_network_failed, other}}
+      end
+    end
+  rescue
+    e -> {:error, {:create_network_raised, e}}
+  end
+
+  defp delete_network(state) do
+    req = %DeleteGroupNetworkRequest{trace: %Trace{workload: state.workload}, group_instance_id: state.instance_id}
+
+    with {:ok, channel} <- safe_channel(state, state.node_id) do
+      try do
+        state.delete_group_network_fun.(channel, req)
+      rescue
+        _ -> :error
+      catch
+        _, _ -> :error
+      end
+    end
+
+    :ok
+  end
+
+  defp safe_start_group_member(state, req) do
+    with {:ok, channel} <- safe_channel(state, state.node_id) do
+      state.start_group_member_fun.(channel, req)
+    end
+  rescue
+    e -> {:error, {:start_group_member_raised, e}}
+  catch
+    kind, reason -> {:error, {:start_group_member_raised, {kind, reason}}}
+  end
+
+  defp safe_channel(state, node_id) do
+    state.channel_fun.(node_id)
+  rescue
+    e -> {:error, {:channel_raised, e}}
+  catch
+    kind, reason -> {:error, {:channel_raised, {kind, reason}}}
+  end
+
+  defp default_create_group_network(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.create_group_network(channel, req)
+  end
+
+  defp default_delete_group_network(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.delete_group_network(channel, req)
+  end
+
+  defp default_start_group_member(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.start_group_member(channel, req)
+  end
+
+  defp default_stop_group_member(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.stop_group_member(channel, req)
+  end
+
+  # -- misc ------------------------------------------------------------------
+
+  defp ok_or({:ok, _}), do: :ok
+  defp ok_or({:error, _} = error), do: error
+
+  defp failure_reason_string(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp failure_reason_string({tag, _} = _reason) when is_atom(tag), do: Atom.to_string(tag)
+  defp failure_reason_string(reason), do: inspect(reason)
+
+  defp default_clock, do: System.system_time(:millisecond)
+
+  # -- convenience for catalog resolution (used by the supervisor) -----------
+
+  @doc false
+  @spec catalog_group(atom() | :ets.tid(), String.t()) :: {:ok, map()} | :error
+  def catalog_group(catalog_table, workload) do
+    case WorkloadCatalog.fetch(catalog_table, workload) do
+      {:ok, %{class: "composite", group: group} = entry} when is_map(group) ->
+        {:ok, Map.put(entry, :name, workload)}
+
+      _ ->
+        :error
+    end
+  end
+
+  @doc false
+  def group_state_module, do: GroupState
+end

--- a/projects/embervm/control/lib/embervm/group_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_manager.ex
@@ -89,6 +89,7 @@ defmodule Embervm.GroupManager do
     EvictSnapshotRequest,
     StartGroupMemberRequest,
     StartGroupMemberResponse,
+    StopGroupMemberRequest,
     ResourceSpec,
     Trace
   }
@@ -474,18 +475,26 @@ defmodule Embervm.GroupManager do
     end
   end
 
-  # The all-or-nothing fallback: evict the banked set (durable group_set_evicted,
-  # per-ref EvictSnapshot best-effort), transition banked -> fresh_booting ->
-  # creating, then run the SAME role-ordered fresh member starts a create does,
-  # re-issuing the network first (it may already be up from the relight attempt;
-  # CreateGroupNetwork is idempotent daemon-side). The parked caller is still
-  # blocked on the one wake_group call, so this holds the connection across the
-  # fallback. group_fresh_booted{reason} records why the warmth was discarded.
+  # The all-or-nothing fallback: DESTROY every already-resumed live member (a partial
+  # relight left member A's VM running, holding its pinned tap+IP in noded's group
+  # allocator; a fresh boot of the WHOLE plan would then collide on that IP via
+  # EnsureMemberTap's alloc.reserve, the exact case this fallback exists to handle),
+  # evict the banked set (durable group_set_evicted, per-ref EvictSnapshot best-
+  # effort), transition banked -> fresh_booting -> creating, then run the SAME role-
+  # ordered fresh member starts a create does, re-issuing the network (idempotent
+  # daemon-side; the taps/IPs it hangs off are now freed by the DESTROY drain). The
+  # parked caller is still blocked on the one wake_group call, so this holds the
+  # connection across the fallback. group_fresh_booted{reason} records the discarded
+  # warmth.
   defp fallback_fresh(state, instance, subnet_cidr, secret, group, reason) do
     fresh_reason = fresh_reason_string(reason)
+    # Free tap+IP for any member that DID resume before the relight aborted, so the
+    # fresh re-pin does not collide on an occupied tap. Drains from the instance's
+    # stored live member rows (member_started recorded each resumed member).
+    _ = destroy_live_members(state)
     _ = evict_set(state, instance)
 
-    with {:ok, _} <- GroupStore.mark(state.store, instance.instance_id, :fresh_boot) |> ok_or(),
+    with {:ok, _} <- GroupStore.mark(state.store, instance.instance_id, :fresh_boot),
          {:ok, _} <-
            GroupStore.transition(
              state.store,
@@ -582,9 +591,16 @@ defmodule Embervm.GroupManager do
             record_member_live(state, member, vm_id, ip)
 
           # A RELIGHT that the daemon could not verify (clock-resync out of bounds,
-          # decision 7, surfaces as was_relight=false or a FAILED_PRECONDITION): treat
-          # it as a relight failure so the whole set falls back to fresh. We never
-          # accept a half-resumed member.
+          # decision 7, surfaces as was_relight=false): the VM DID resume and is holding
+          # its pinned tap+IP, so RECORD it live first (so the fresh-fallback drain
+          # destroys it and frees the tap) THEN treat it as a relight failure so the
+          # whole set falls back to fresh. We never accept a half-resumed member as
+          # part of a live relit set, but we must not leak its tap either.
+          {:ok, %StartGroupMemberResponse{vm_id: vm_id, ip: ip, was_relight: false}}
+          when is_binary(vm_id) and vm_id != "" ->
+            _ = record_member_live(state, member, vm_id, ip)
+            {:error, {:member_relight_unverified, member.expanded_name}}
+
           {:ok, %StartGroupMemberResponse{was_relight: false}} ->
             {:error, {:member_relight_unverified, member.expanded_name}}
 
@@ -789,7 +805,13 @@ defmodule Embervm.GroupManager do
   # state (nothing extra to persist; the assigned CIDR is recorded in group_created so
   # a rebuild reconstructs the held set) and reuses freed /24s so the /16 cannot be
   # exhausted. The supernet is the SAME value noded validates group cidrs against, so
-  # every assigned /24 is a valid /24 wholly within it.
+  # every assigned /24 is a valid /24 wholly within it. Two concurrent creates for
+  # DIFFERENT workloads could momentarily read the same held set and pick the same /24
+  # (this is not serialized across GroupManager instances); that race is
+  # DAEMON-BACKSTOPPED: noded's CreateGroupNetwork refuses an overlapping CIDR
+  # (FAILED_PRECONDITION), so the loser's create fails and retries, which re-reads the
+  # now-updated held set and picks the next free /24. The CP allocation is an
+  # optimization over that backstop, not the sole guard.
   defp allocate_subnet(state) do
     held = GroupStore.held_subnets(state.store)
     {a, b, _c, _d} = parse_ip(supernet_base(state.supernet))
@@ -944,6 +966,44 @@ defmodule Embervm.GroupManager do
 
   defp default_evict_snapshot(channel, req) do
     Embervm.Node.V1.NodeService.Stub.evict_snapshot(channel, req)
+  end
+
+  # DESTROY every currently-live member VM of the instance (a partial relight that
+  # resumed some members before aborting), freeing each member's pinned tap+IP in
+  # noded's group allocator (StopGroupMember DESTROY -> RemoveMemberTap +
+  # ReleaseMember) so the fresh re-pin does not collide. Drains from the instance's
+  # stored member rows: a member with a live vm_id is one that came up. Best-effort
+  # per member (a failed DESTROY leaves its tap held, which the fresh boot's own
+  # collision surfaces loudly rather than being silently skipped here).
+  defp destroy_live_members(state) do
+    state.store
+    |> GroupStore.members(state.instance_id)
+    |> Enum.filter(fn m -> is_binary(m.vm_id) and m.vm_id != "" end)
+    |> Enum.each(fn m -> _ = destroy_one_member(state, m) end)
+
+    :ok
+  end
+
+  defp destroy_one_member(state, member) do
+    req = %StopGroupMemberRequest{
+      trace: %Trace{workload: state.workload},
+      vm_id: member.vm_id,
+      mode: :STOP_GROUP_MEMBER_MODE_DESTROY,
+      set_id: "",
+      member_name: member.member_name
+    }
+
+    with {:ok, channel} <- safe_channel(state, state.node_id) do
+      try do
+        state.stop_group_member_fun.(channel, req)
+      rescue
+        _ -> :error
+      catch
+        _, _ -> :error
+      end
+    end
+
+    :ok
   end
 
   # Best-effort EvictSnapshot of one member's banked bundle (group bundles reuse the

--- a/projects/embervm/control/lib/embervm/group_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_manager.ex
@@ -86,6 +86,7 @@ defmodule Embervm.GroupManager do
     CreateGroupNetworkRequest,
     CreateGroupNetworkResponse,
     DeleteGroupNetworkRequest,
+    EvictSnapshotRequest,
     StartGroupMemberRequest,
     StartGroupMemberResponse,
     ResourceSpec,
@@ -116,6 +117,31 @@ defmodule Embervm.GroupManager do
   @spec create_group(GenServer.server()) :: {:ok, map()} | {:error, term()}
   def create_group(server) do
     GenServer.call(server, :create_group, :infinity)
+  end
+
+  @doc """
+  Wakes a BANKED group instance in one single-flighted call (R5, Task 7): the
+  relight-or-fresh sequence off `banked`. Re-issues CreateGroupNetwork (the bridge
+  dies with the noded pod), then RESUMES every member in role order (RELIGHT
+  StartGroupMember from its banked `snapshot_ref`). If ANY member relight fails
+  (including the clock-resync FAILED_PRECONDITION noded returns as a member start
+  failure, decision 7), it ABORTS the relight, evicts the whole set (durable
+  `group_set_evicted`), and falls back to a full FRESH boot INSIDE THE SAME CALL
+  (role-ordered fresh member starts on the same subnet), so the parked connection
+  is held across the fallback (the caller blocks on this one `:infinity` call the
+  whole time). Publishes the entry endpoint and moves the group to `running`.
+
+  Returns `{:ok, %{ip, port}, outcome}` where `outcome` is `:relit` (a clean whole-
+  set relight) or `{:fresh, reason}` (the relight aborted and a fresh boot recovered,
+  `reason` one of `:partial_set | :set_unreadable | :relight_failed | ...`), or
+  `{:error, reason}` when even the fresh fallback failed (the group is torn to
+  `failed`). Blocks until the group is running or failed. The instance MUST already
+  exist in the store (the wake brain created/located it); this never creates the
+  singleton row (that is `create_group/1`).
+  """
+  @spec wake_group(GenServer.server()) :: {:ok, map(), atom() | tuple()} | {:error, term()}
+  def wake_group(server) do
+    GenServer.call(server, :wake_group, :infinity)
   end
 
   @doc "The group instance's current entry endpoint (or nil), for tests + straggler resolution."
@@ -152,6 +178,8 @@ defmodule Embervm.GroupManager do
         Keyword.get(opts, :start_group_member_fun, &default_start_group_member/2),
       stop_group_member_fun:
         Keyword.get(opts, :stop_group_member_fun, &default_stop_group_member/2),
+      evict_snapshot_fun:
+        Keyword.get(opts, :evict_snapshot_fun, &default_evict_snapshot/2),
       get_secret_fun: Keyword.get(opts, :get_secret_fun, &Embervm.K8s.get_secret/2),
       secret_fun: Keyword.get(opts, :secret_fun, &mint_secret/0),
       clock: Keyword.get(opts, :clock, &default_clock/0)
@@ -163,6 +191,11 @@ defmodule Embervm.GroupManager do
   @impl true
   def handle_call(:create_group, _from, state) do
     {reply, state} = do_create_group(state)
+    {:reply, reply, state}
+  end
+
+  def handle_call(:wake_group, _from, state) do
+    {reply, state} = do_wake_group(state)
     {:reply, reply, state}
   end
 
@@ -368,6 +401,258 @@ defmodule Embervm.GroupManager do
     _ = delete_network(state)
     Embervm.EndpointPublisher.publish(state.publisher)
     Logger.warning("embervm group create failed, torn down", workload: state.workload, reason: inspect(reason))
+    :ok
+  end
+
+  # -- wake sequence (relight-or-fresh off banked, R5 Task 7) ----------------
+
+  # The single-flighted wake of a BANKED instance: re-issue the group network,
+  # RELIGHT every member in role order, publish. Any member relight failure aborts
+  # the relight, evicts the set, and falls back to a FRESH boot in the SAME call
+  # (the parked caller is held across the fallback). The instance already exists in
+  # the store (the wake brain located/created the banked row); this drives its
+  # banked -> relighting -> creating -> running (or banked -> fresh_booting ->
+  # creating -> running) sequence.
+  defp do_wake_group(state) do
+    with {:ok, instance} <- fetch_instance(state),
+         :banked <- instance.state do
+      entry_cfg = state.entry
+      group = Map.fetch!(entry_cfg, :group)
+      subnet_cidr = instance.subnet_cidr
+      secret = instance_secret(state, entry_cfg, group, instance)
+
+      # The relight plan is anchored to the STORED member rows (their pinned ips +
+      # banked snapshot_refs), enriched with the catalog member config (role,
+      # start_order, health_port, resources, image_ref) so the role ordering + the
+      # fresh-fallback env compose exactly match a create.
+      plan = wake_plan(state, group, subnet_cidr, instance)
+
+      attempt_relight(state, instance, subnet_cidr, secret, group, plan)
+    else
+      {:error, _reason} = error ->
+        {error, state}
+
+      other_state when is_atom(other_state) ->
+        # Not banked (a race: adopted live, destroyed, or already relighting). The
+        # wake brain re-reads the store and resolves the straggler; return the live
+        # endpoint if running, else an error the caller retries.
+        {wake_race_reply(state), state}
+    end
+  end
+
+  defp attempt_relight(state, instance, subnet_cidr, secret, group, plan) do
+    # banked -> relighting (ETS-only mark; a crash mid-relight heals from adoption).
+    case GroupStore.mark(state.store, instance.instance_id, :relight) do
+      {:ok, _} ->
+        with {:ok, _net} <- create_network(state, subnet_cidr),
+             :ok <- resume_members_ordered(state, plan) do
+          # relighting -> creating (durable group_relit), then publish -> running.
+          case GroupStore.transition(state.store, instance.instance_id, :relight_ready, :group_relit, %{}, %{}) do
+            {:ok, _} ->
+              case finish_wake_publish(state, plan, group) do
+                {{:ok, endpoint}, state} -> {{:ok, endpoint, :relit}, state}
+                {{:error, reason}, state} -> {{:error, reason}, state}
+              end
+
+            {:error, reason} ->
+              # The durable relit edge failed: abort back to banked and fall back to
+              # fresh (the set is intact, but we cannot record the relight).
+              _ = GroupStore.mark(state.store, instance.instance_id, :relight_abort)
+              fallback_fresh(state, instance, subnet_cidr, secret, group, {:relit_record_failed, reason})
+          end
+        else
+          {:error, reason} ->
+            # A member relight failed (start error, or the clock-resync
+            # FAILED_PRECONDITION, decision 7): abort back to banked, then evict the
+            # whole set and fresh-boot in the same call. relight_abort is ETS-only.
+            _ = GroupStore.mark(state.store, instance.instance_id, :relight_abort)
+            fallback_fresh(state, instance, subnet_cidr, secret, group, {:relight_failed, reason})
+        end
+
+      {:error, reason} ->
+        {{:error, {:relight_mark, reason}}, state}
+    end
+  end
+
+  # The all-or-nothing fallback: evict the banked set (durable group_set_evicted,
+  # per-ref EvictSnapshot best-effort), transition banked -> fresh_booting ->
+  # creating, then run the SAME role-ordered fresh member starts a create does,
+  # re-issuing the network first (it may already be up from the relight attempt;
+  # CreateGroupNetwork is idempotent daemon-side). The parked caller is still
+  # blocked on the one wake_group call, so this holds the connection across the
+  # fallback. group_fresh_booted{reason} records why the warmth was discarded.
+  defp fallback_fresh(state, instance, subnet_cidr, secret, group, reason) do
+    fresh_reason = fresh_reason_string(reason)
+    _ = evict_set(state, instance)
+
+    with {:ok, _} <- GroupStore.mark(state.store, instance.instance_id, :fresh_boot) |> ok_or(),
+         {:ok, _} <-
+           GroupStore.transition(
+             state.store,
+             instance.instance_id,
+             :fresh_ready,
+             :group_fresh_booted,
+             %{reason: fresh_reason},
+             %{}
+           ),
+         {:ok, _net} <- create_network(state, subnet_cidr),
+         plan = member_plan(group, subnet_cidr),
+         :ok <- start_members_ordered(state, plan, secret, subnet_cidr) do
+      case finish_wake_publish(state, plan, group) do
+        {{:ok, endpoint}, state} ->
+          Logger.info("embervm group fresh-booted (relight fallback)",
+            workload: state.workload,
+            instance_id: instance.instance_id,
+            reason: fresh_reason
+          )
+
+          {{:ok, endpoint, {:fresh, fresh_reason_atom(reason)}}, state}
+
+        {{:error, publish_reason}, state} ->
+          {{:error, publish_reason}, state}
+      end
+    else
+      {:error, fresh_error} ->
+        teardown_failed(state, {:fresh_fallback_failed, fresh_error})
+        {{:error, {:fresh_fallback_failed, fresh_error}}, state}
+    end
+  rescue
+    e ->
+      teardown_failed(state, {:fresh_fallback_crashed, e})
+      {{:error, {:fresh_fallback_crashed, e}}, state}
+  end
+
+  # RELIGHT every member in role order (all of one startOrder in parallel, gated,
+  # then the next), exactly the create ordering but RELIGHT mode from each member's
+  # banked snapshot_ref. Any member start failure short-circuits (aborting the
+  # whole relight). A member with NO banked snapshot_ref is a partial set the wake
+  # brain should already have fresh-booted, but guard it here as a relight failure
+  # so a stale set never resumes half-warm.
+  defp resume_members_ordered(state, plan) do
+    orders =
+      plan
+      |> Enum.group_by(& &1.start_order)
+      |> Enum.sort_by(fn {order, _} -> order end)
+
+    Enum.reduce_while(orders, :ok, fn {_order, members}, :ok ->
+      case resume_order_parallel(state, members) do
+        :ok -> {:cont, :ok}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp resume_order_parallel(state, members) do
+    members
+    |> Enum.map(fn member ->
+      Task.async(fn ->
+        try do
+          resume_one_member(state, member)
+        rescue
+          e -> {:error, {:member_relight_crashed, member.expanded_name, e}}
+        catch
+          kind, reason -> {:error, {:member_relight_crashed, member.expanded_name, {kind, reason}}}
+        end
+      end)
+    end)
+    |> Enum.map(&Task.await(&1, :infinity))
+    |> Enum.find(:ok, &match?({:error, _}, &1))
+  end
+
+  defp resume_one_member(state, member) do
+    case member.snapshot_ref do
+      ref when is_binary(ref) and ref != "" ->
+        req = %StartGroupMemberRequest{
+          trace: %Trace{workload: state.workload},
+          mode: :START_GROUP_MEMBER_MODE_RELIGHT,
+          group_instance_id: state.instance_id,
+          member_name: member.expanded_name,
+          member_index: member.index,
+          ip: member.ip,
+          source: "",
+          snapshot_ref: ref,
+          health_port: member.health_port || 0,
+          resources: %ResourceSpec{vcpus: member.vcpus || 1, mem_mib: member.mem_mib || 512},
+          env: %{}
+        }
+
+        case safe_start_group_member(state, req) do
+          {:ok, %StartGroupMemberResponse{vm_id: vm_id, ip: ip, was_relight: true}}
+          when is_binary(vm_id) and vm_id != "" ->
+            record_member_live(state, member, vm_id, ip)
+
+          # A RELIGHT that the daemon could not verify (clock-resync out of bounds,
+          # decision 7, surfaces as was_relight=false or a FAILED_PRECONDITION): treat
+          # it as a relight failure so the whole set falls back to fresh. We never
+          # accept a half-resumed member.
+          {:ok, %StartGroupMemberResponse{was_relight: false}} ->
+            {:error, {:member_relight_unverified, member.expanded_name}}
+
+          other ->
+            {:error, {:member_relight_failed, member.expanded_name, other}}
+        end
+
+      _ ->
+        {:error, {:member_snapshot_missing, member.expanded_name}}
+    end
+  end
+
+  defp record_member_live(state, member, vm_id, ip) do
+    case GroupStore.member_started(state.store, state.instance_id, %{
+           member_name: member.expanded_name,
+           member_index: member.index,
+           vm_id: vm_id,
+           ip: ip
+         }) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, {:member_record_failed, member.expanded_name, reason}}
+    end
+  end
+
+  # Publish the entry endpoint + move to running (creating -> running), the SAME
+  # finish step create uses, but never tears down on a publish failure inside a wake
+  # (the caller decides). Shared by the relight and fresh-fallback tails.
+  defp finish_wake_publish(state, plan, group) do
+    entry_member = Enum.find(plan, &(&1.expanded_name == group.entry.member))
+
+    case entry_member do
+      nil ->
+        teardown_failed(state, {:entry_member_not_in_plan, group.entry.member})
+        {{:error, {:entry_member_not_in_plan, group.entry.member}}, state}
+
+      %{ip: entry_ip} ->
+        case entry_vm_port(state, entry_ip) do
+          {:ok, vm_port} ->
+            pod_ip = state.pod_ip || entry_ip
+
+            case GroupStore.publish(state.store, state.instance_id, pod_ip, vm_port) do
+              {:ok, _} ->
+                Embervm.EndpointPublisher.publish(state.publisher)
+                Logger.info("embervm group woken", workload: state.workload, instance_id: state.instance_id)
+                {{:ok, %{ip: pod_ip, port: vm_port}}, state}
+
+              {:error, reason} ->
+                {{:error, {:publish_failed, reason}}, state}
+            end
+
+          {:error, reason} ->
+            {{:error, {:entry_port_derivation, reason}}, state}
+        end
+    end
+  end
+
+  # Evict the banked set durably (group_set_evicted clears set_id + each member's
+  # snapshot_ref, no FSM edge; the fresh_booting move is the mark/2 in
+  # fallback_fresh) so a rebuild agrees the warmth is gone, and best-effort
+  # EvictSnapshot each member's bundle on the node (the snapshots must not leak).
+  defp evict_set(state, instance) do
+    members = GroupStore.members(state.store, instance.instance_id)
+    _ = GroupStore.evict_set(state.store, instance.instance_id, "relight_fallback")
+
+    for %{snapshot_ref: ref} <- members, is_binary(ref) and ref != "" do
+      _ = evict_snapshot(state, ref)
+    end
+
     :ok
   end
 
@@ -656,6 +941,93 @@ defmodule Embervm.GroupManager do
   defp default_stop_group_member(channel, req) do
     Embervm.Node.V1.NodeService.Stub.stop_group_member(channel, req)
   end
+
+  defp default_evict_snapshot(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.evict_snapshot(channel, req)
+  end
+
+  # Best-effort EvictSnapshot of one member's banked bundle (group bundles reuse the
+  # R2 EvictSnapshot unchanged). Never raises into the wake: a failed evict leaves a
+  # stale snapshot on disk (the daemon's own bundle GC reclaims it later), which must
+  # not fail the fresh-fallback boot the caller is parked on.
+  defp evict_snapshot(state, snapshot_ref) do
+    req = %EvictSnapshotRequest{trace: %Trace{workload: state.workload}, snapshot_ref: snapshot_ref}
+
+    with {:ok, channel} <- safe_channel(state, state.node_id) do
+      try do
+        state.evict_snapshot_fun.(channel, req)
+      rescue
+        _ -> :error
+      catch
+        _, _ -> :error
+      end
+    end
+
+    :ok
+  end
+
+  # -- wake helpers ----------------------------------------------------------
+
+  defp fetch_instance(state) do
+    case GroupStore.get(state.store, state.instance_id) do
+      {:ok, instance} -> {:ok, instance}
+      :error -> {:error, {:instance_not_found, state.instance_id}}
+    end
+  end
+
+  # The wake plan: the member address plan (deterministic, catalog-derived) merged
+  # with each member's STORED live facts (its banked snapshot_ref, needed for the
+  # RELIGHT source). The pinned ip comes from the deterministic plan (lockstep with
+  # noded), NOT the stored ip, so a relight re-pins the same address a fresh boot
+  # would (the bank cleared the live ip anyway).
+  defp wake_plan(state, group, subnet_cidr, instance) do
+    stored = GroupStore.members(state.store, instance.instance_id)
+    by_name = Map.new(stored, fn m -> {m.member_name, m} end)
+
+    member_plan(group, subnet_cidr)
+    |> Enum.map(fn member ->
+      snapshot_ref =
+        case Map.get(by_name, member.expanded_name) do
+          %{snapshot_ref: ref} -> ref
+          _ -> nil
+        end
+
+      Map.put(member, :snapshot_ref, snapshot_ref)
+    end)
+  end
+
+  # The group secret on a wake: a relight/fresh-boot re-derives the SAME secret the
+  # birth boot recorded (from secretRef, or the minted value on the create op). The
+  # store does not surface the secret on the instance view, so re-resolve it exactly
+  # as create did (a secretRef read is stable; a minted secret is only re-minted on a
+  # fresh boot, which is acceptable: a fresh boot is a NEW first boot of the members,
+  # and the members re-read their birth env fresh anyway).
+  defp instance_secret(state, entry_cfg, group, _instance) do
+    resolve_secret(state, entry_cfg, group)
+  end
+
+  # A wake that found the instance no longer banked (a race with adoption/destroy):
+  # return the live endpoint if it is running, else an error the wake brain surfaces
+  # to the parked caller (which reconnects).
+  defp wake_race_reply(state) do
+    case GroupStore.get(state.store, state.instance_id) do
+      {:ok, %{state: :running, entry_ip: ip, entry_port_published: port}}
+      when is_binary(ip) and is_integer(port) ->
+        {:ok, %{ip: ip, port: port}, :straggler}
+
+      _ ->
+        {:error, :not_banked}
+    end
+  end
+
+  defp fresh_reason_atom({:relight_failed, {:member_relight_unverified, _}}), do: :clock_resync_failed
+  defp fresh_reason_atom({:relight_failed, {:member_snapshot_missing, _}}), do: :partial_set
+  defp fresh_reason_atom({:relight_failed, _}), do: :relight_failed
+  defp fresh_reason_atom({:relit_record_failed, _}), do: :relit_record_failed
+  defp fresh_reason_atom(reason) when is_atom(reason), do: reason
+  defp fresh_reason_atom(_), do: :relight_failed
+
+  defp fresh_reason_string(reason), do: reason |> fresh_reason_atom() |> Atom.to_string()
 
   # -- misc ------------------------------------------------------------------
 

--- a/projects/embervm/control/lib/embervm/group_manager/supervisor.ex
+++ b/projects/embervm/control/lib/embervm/group_manager/supervisor.ex
@@ -78,6 +78,64 @@ defmodule Embervm.GroupManager.Supervisor do
     end
   end
 
+  @doc """
+  Wakes the EXISTING banked instance `instance_id` of `workload` synchronously (R5,
+  Task 7): spawns (or reuses) the GroupManager child bound to that instance and
+  drives its `wake_group/1` (relight, or relight -> fresh fallback in the SAME call).
+  Returns `{:ok, %{ip, port}, outcome}` (`outcome` :relit or `{:fresh, reason}`) or
+  `{:error, reason}`. A second concurrent wake for the same workload finds the
+  registry key taken and reuses the SAME child (single-instance-per-workload at the
+  process level; the wake brain single-flights above this, so only one wake worker
+  ever calls in per burst). On a wake failure the child is retired so a retry spawns
+  fresh; a successful wake keeps the process (a later bank/relight has an owner).
+  """
+  @spec wake_group(String.t(), String.t(), keyword()) :: {:ok, map(), atom() | tuple()} | {:error, term()}
+  def wake_group(workload, instance_id, opts \\ []) do
+    defaults = Application.get_env(:embervm, :group_manager_defaults, [])
+    opts = Keyword.merge(defaults, opts)
+
+    catalog_table = Keyword.get(opts, :catalog_table, WorkloadCatalog.table())
+    capacity_table = Keyword.get(opts, :capacity_table, NodeCapacity.table())
+
+    with {:ok, entry} <- GroupManager.catalog_group(catalog_table, workload),
+         {:ok, node_id} <- anchor_node(capacity_table),
+         {:ok, pid} <- start_or_get_child(workload, instance_id, entry, node_id, opts) do
+      result = GroupManager.wake_group(pid)
+
+      case result do
+        {:ok, _endpoint, _outcome} ->
+          result
+
+        {:error, _reason} ->
+          _ = DynamicSupervisor.terminate_child(@dyn_sup, pid)
+          result
+      end
+    end
+  end
+
+  @doc """
+  Adoption (R5, Task 7): (re)spawn the GroupManager child for a live-adopted instance
+  so a later bank/relight has an owner, WITHOUT driving any lifecycle. Idempotent: a
+  child already registered under the workload is left as-is. Returns `:ok`. Never
+  touches a VM (the reconcile already forced the store state from node truth).
+  """
+  @spec adopt_group(String.t(), String.t(), keyword()) :: :ok
+  def adopt_group(workload, instance_id, opts \\ []) do
+    defaults = Application.get_env(:embervm, :group_manager_defaults, [])
+    opts = Keyword.merge(defaults, opts)
+
+    catalog_table = Keyword.get(opts, :catalog_table, WorkloadCatalog.table())
+    capacity_table = Keyword.get(opts, :capacity_table, NodeCapacity.table())
+
+    with {:ok, entry} <- GroupManager.catalog_group(catalog_table, workload),
+         {:ok, node_id} <- anchor_node(capacity_table) do
+      _ = start_or_get_child(workload, instance_id, entry, node_id, opts)
+      :ok
+    else
+      _ -> :ok
+    end
+  end
+
   @doc "The live GroupManager pid for a workload, or nil."
   @spec whereis(String.t()) :: pid() | nil
   def whereis(workload) do
@@ -91,7 +149,31 @@ defmodule Embervm.GroupManager.Supervisor do
 
   defp start_child(workload, entry, node_id, opts) do
     instance_id = mint_instance_id(opts)
+    do_start_child(workload, instance_id, entry, node_id, opts)
+  end
 
+  # Start a child bound to a SPECIFIC (already-existing) instance_id, or return the
+  # child already registered under the workload (the wake/adopt path: the banked
+  # instance already exists, and a registered owner is reused). A registered pid for
+  # a DIFFERENT instance_id is still returned (one live process per workload; the
+  # registry key is the workload, and the class is a group-level singleton).
+  defp start_or_get_child(workload, instance_id, entry, node_id, opts) do
+    case do_start_child(workload, instance_id, entry, node_id, opts) do
+      {:ok, pid} ->
+        {:ok, pid}
+
+      {:error, :already_live} ->
+        case whereis(workload) do
+          nil -> {:error, :already_live}
+          pid -> {:ok, pid}
+        end
+
+      other ->
+        other
+    end
+  end
+
+  defp do_start_child(workload, instance_id, entry, node_id, opts) do
     child_opts =
       [
         instance_id: instance_id,
@@ -132,6 +214,7 @@ defmodule Embervm.GroupManager.Supervisor do
       :delete_group_network_fun,
       :start_group_member_fun,
       :stop_group_member_fun,
+      :evict_snapshot_fun,
       :get_secret_fun,
       :secret_fun,
       :clock

--- a/projects/embervm/control/lib/embervm/group_manager/supervisor.ex
+++ b/projects/embervm/control/lib/embervm/group_manager/supervisor.ex
@@ -1,0 +1,169 @@
+defmodule Embervm.GroupManager.Supervisor do
+  @moduledoc """
+  Owns the per-group-instance `Embervm.GroupManager` processes: a `DynamicSupervisor`
+  (`Embervm.GroupManager.DynamicSupervisor`) holding one child per LIVE group
+  instance, keyed in a `Registry` (`Embervm.GroupRegistry`, unique keys) by WORKLOAD
+  (a composite workload is a group-level singleton, so one live process per
+  workload). This is the composite counterpart of the SessionManager's
+  SessionRegistry + SessionSupervisor per-instance model; the GroupManager owns the
+  ordered create/start/bank/relight state machine of ONE group.
+
+  `create_group/2` is the entrypoint Task 7's wake-on-connect activator calls: it
+  resolves the composite catalog entry, picks the anchor node, mints the group
+  instance id, spawns a GroupManager child (registered under the workload), and
+  synchronously drives its ordered create sequence, returning the entry endpoint (or
+  an error, with the child having torn the group down to failed). A second concurrent
+  create for the same workload finds the registry key taken and refuses
+  `{:error, :already_live}` (the singleton at the process level; the GroupStore's own
+  singleton gate is the durable backstop).
+  """
+
+  use Supervisor
+
+  alias Embervm.{GroupManager, NodeCapacity, WorkloadCatalog}
+
+  @registry Embervm.GroupRegistry
+  @dyn_sup Embervm.GroupManager.DynamicSupervisor
+
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @impl true
+  def init(opts) do
+    # The default seams are stored in an app-env-backed config the create/2 entrypoint
+    # reads, so the supervisor itself only owns the registry + dynamic supervisor. The
+    # per-group config (store, publisher, capacity/catalog tables, supernet, port_base,
+    # pod_ip, node funs) is passed through create/2's opts (tests inject fakes).
+    Application.put_env(:embervm, :group_manager_defaults, Keyword.get(opts, :defaults, []))
+
+    children = [
+      {Registry, keys: :unique, name: @registry},
+      {DynamicSupervisor, strategy: :one_for_one, name: @dyn_sup}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  @doc """
+  Creates + runs a group for `workload` synchronously. `opts` overrides the app-env
+  defaults (tests inject store/publisher/tables + node funs). Returns
+  `{:ok, %{ip, port}}` (the entry endpoint) or `{:error, reason}`. A second live
+  create for the same workload is `{:error, :already_live}`.
+  """
+  @spec create_group(String.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  def create_group(workload, opts \\ []) do
+    defaults = Application.get_env(:embervm, :group_manager_defaults, [])
+    opts = Keyword.merge(defaults, opts)
+
+    catalog_table = Keyword.get(opts, :catalog_table, WorkloadCatalog.table())
+    capacity_table = Keyword.get(opts, :capacity_table, NodeCapacity.table())
+
+    with {:ok, entry} <- GroupManager.catalog_group(catalog_table, workload),
+         {:ok, node_id} <- anchor_node(capacity_table),
+         {:ok, pid} <- start_child(workload, entry, node_id, opts) do
+      result = GroupManager.create_group(pid)
+      # On a failed create the group is torn down to failed; retire the process so a
+      # later retry spawns a fresh one (a live create keeps the process for Task 7/8's
+      # bank/relight drive).
+      case result do
+        {:ok, _endpoint} ->
+          result
+
+        {:error, _reason} ->
+          _ = DynamicSupervisor.terminate_child(@dyn_sup, pid)
+          result
+      end
+    end
+  end
+
+  @doc "The live GroupManager pid for a workload, or nil."
+  @spec whereis(String.t()) :: pid() | nil
+  def whereis(workload) do
+    case Registry.lookup(@registry, workload) do
+      [{pid, _}] -> pid
+      [] -> nil
+    end
+  end
+
+  # -- internals -------------------------------------------------------------
+
+  defp start_child(workload, entry, node_id, opts) do
+    instance_id = mint_instance_id(opts)
+
+    child_opts =
+      [
+        instance_id: instance_id,
+        workload: workload,
+        principal: group_principal(workload),
+        entry: entry,
+        node_id: node_id,
+        name: {:via, Registry, {@registry, workload}}
+      ] ++ Keyword.take(opts, group_manager_opt_keys())
+
+    spec = %{
+      id: {:group, workload},
+      start: {GroupManager, :start_link, [child_opts]},
+      restart: :temporary,
+      type: :worker
+    }
+
+    case DynamicSupervisor.start_child(@dyn_sup, spec) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, _pid}} -> {:error, :already_live}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # The per-group config keys the GroupManager child accepts (everything the
+  # create/2 caller may inject; production reads the app-env defaults).
+  defp group_manager_opt_keys do
+    [
+      :store,
+      :publisher,
+      :capacity_table,
+      :tenant,
+      :supernet,
+      :port_base,
+      :pod_ip,
+      :channel_fun,
+      :create_group_network_fun,
+      :delete_group_network_fun,
+      :start_group_member_fun,
+      :stop_group_member_fun,
+      :get_secret_fun,
+      :secret_fun,
+      :clock
+    ]
+  end
+
+  # A composite group's synthesized owner principal (mirrors the stateful
+  # system:stateful:<workload> attribution), the op-log owner for its lifecycle ops.
+  defp group_principal(workload), do: "system:group:#{workload}"
+
+  # Pick the anchor node for a fresh group: the first node reporting a
+  # stateful/serving-capable subnet with live-VM budget (rendezvous-hashed with one
+  # node is trivially that node; a real placement is Task 7's concern). No node is
+  # {:error, :no_capacity}.
+  defp anchor_node(capacity_table) do
+    NodeCapacity.all(capacity_table)
+    |> Enum.filter(&group_capable?/1)
+    |> case do
+      [] -> {:error, :no_capacity}
+      [fact | _] -> {:ok, fact.configured_id}
+    end
+  end
+
+  defp group_capable?(fact) do
+    cidr = Map.get(fact, :serving_subnet_cidr)
+    is_binary(cidr) and cidr != ""
+  end
+
+  defp mint_instance_id(opts) do
+    case Keyword.get(opts, :id_fun) do
+      fun when is_function(fun, 0) -> fun.()
+      _ -> "grp-" <> String.trim_leading(Embervm.SessionId.new(System.system_time(:millisecond)), "s-")
+    end
+  end
+end

--- a/projects/embervm/control/lib/embervm/group_state.ex
+++ b/projects/embervm/control/lib/embervm/group_state.ex
@@ -1,0 +1,270 @@
+defmodule Embervm.GroupState do
+  @moduledoc """
+  The composite-group lifecycle FSM (R5), expressed as data, mirroring
+  `Embervm.StatefulState`: a module-attribute map from `{state, event}` to the
+  next state. `Embervm.GroupStore` is the only caller that mutates group state,
+  and every mutation goes through `transition/2` or `transition!/2` first, so an
+  illegal transition fails loudly at the call site instead of corrupting ETS or
+  the op-log with a state the FSM never sanctions.
+
+  ## the class: a scale-to-zero COMPOSITE group of member microVMs
+
+  A composite workload is a group of member VMs that live, bank, relight, and
+  die as ONE unit (ADR embervm/001). Like the stateful class it is a singleton at
+  the GROUP level (decision, mirrored from stateful decision 3): at most one live
+  group INSTANCE per composite CR, backed by a per-group private /24 subnet and a
+  whole-set banked warmth bundle. The lifecycle is the stateful lifecycle
+  generalized to a set, with two structural differences: (1) `banked` is reached
+  from `running` via a transient `banking` (the entry endpoint is pulled the
+  instant a bank begins), and (2) a banked set can wake either WARM (relight,
+  resuming the whole snapshot set) or COLD (`fresh_booting`, when the set is
+  partial/unreadable and warmth must be discarded).
+
+  ## the lifecycle
+
+      creating      -> running                    (every member health-gated, entry published)
+      running       -> banking -> banked          (idle bank / unpublish, Task 7+)
+      banked        -> relighting -> running       (WARM wake, whole set resumed)
+      banked        -> fresh_booting -> running    (COLD wake, set broken, warmth discarded)
+      banked        -> expired                     (banked-TTL GC, terminal)
+      <any live>    -> destroyed | failed          (delete/lifetime | daemon error)
+
+  `degraded` is DELIBERATELY NOT a state: a member falling unhealthy while the
+  group stays up is a FLAG on the `running` instance (`degraded_member` naming the
+  dead member), never a distinct FSM node. Crash-consistency is per-VM (never
+  across members), so a single member loss keeps the group `running`-with-a-flag,
+  and its recovery just clears the flag. This is why the transition table has no
+  `degraded` state and the store carries the flag as an instance field.
+
+  ## naming: the projection strings are authoritative
+
+  Exactly as `StatefulState` aligns to the shipped `stateful_instances`
+  projection, this FSM's persisted states ARE the strings the MERGED PR-1
+  `group_instances` projection (`Embervm.OpLog.SQLite`) writes and no others:
+
+    * `starting`  (group_created, group_relit, group_fresh_booted) <- the
+      pre-running boot/resume state the projection persists (the FSM node is
+      `creating`; a relight/fresh-boot returns to `creating` semantically but the
+      projection writes "starting", so `state_to_string/1` maps `creating ->
+      "starting"`)
+    * `running`   (group_running)          <- the live-and-in-fan-out state
+    * `banked`    (group_banked)
+    * `destroyed` / `failed`               (the terminal kinds; `expired` rides
+      `group_destroyed{reason: expired}`, so there is no distinct `expired`
+      projection string)
+
+  The projection also writes `degraded` (group_degraded), but that is the running
+  instance carrying the degraded FLAG, projected as the `degraded` string for the
+  audit trail; the STORE holds it as `running` + a flag, and `state_from_string/1`
+  maps the `"degraded"` projection string back to `running` (the flag is
+  reconstructed from the unhealthy member rows). The transient states NOT in the
+  projection are `banking`, `relighting`, and `fresh_booting`: all three are
+  ETS-only markers never persisted (see below).
+
+  ## transient (ETS-only) states
+
+  `banking`, `relighting`, and `fresh_booting` are the group counterparts of the
+  stateful FSM's `banking`/`relighting`/`cold_booting`: entered by
+  `Embervm.GroupStore.mark/2` with NO op-log append (the durable log records only
+  COMPLETED lifecycle transitions), and healed from node inventory by adoption
+  (Task 7) if a crash strands them. The paired durable completion op
+  (`group_banked`, `group_relit`, `group_fresh_booted`) is what actually persists
+  the outcome; until it lands these are ETS-only markers a later op or an adoption
+  reconcile resolves. Their `*_abort` edges are the ETS-only recovery when the
+  daemon RPC fails but the VM set / snapshot set is intact, returning the group to
+  the pre-operation state so a later attempt retries.
+
+  ## the two wake paths off `banked`
+
+  `relight` (WARM) resumes the banked set in place; `fresh_boot` (COLD) discards
+  the set and cold-boots every member fresh on the private subnet. The activator
+  (Task 7) chooses between them on the set-completeness check (is every member's
+  bundle present in the set): a complete set relights, a partial/unreadable set
+  fresh-boots (and evicts the stale set via a paired `group_set_evicted`). Both
+  wake edges land back on `creating` (not yet re-running); a paired
+  `group_running` then moves the instance to `running`.
+
+  Terminal states each carry a recorded reason (the op payload's `reason`):
+
+    * `destroyed`: reachable from every non-terminal state (a delete or lifetime
+      expiry can destroy a group at any point). `expired` (banked-TTL /
+      max-lifetime GC) rides `group_destroyed{reason: expired}`.
+    * `failed`: reachable from every LIVE state (a member-start error during
+      create tears the whole group to `failed`, decision 11: create is atomic;
+      a StartGroupMember / StopGroupMember transport error, or an unrestorable
+      set, fails the group from wherever it was). `banked` cannot `fail` (it holds
+      no VMs); a broken banked set `evict`s its warmth (staying live) but the group
+      instance is not failed by it.
+  """
+
+  defmodule IllegalTransition do
+    defexception [:state, :event]
+
+    @impl true
+    def message(%{state: state, event: event}) do
+      "illegal group transition: #{inspect(state)} -/-> on #{inspect(event)}"
+    end
+  end
+
+  @states [
+    :creating,
+    :running,
+    :banking,
+    :banked,
+    :relighting,
+    :fresh_booting,
+    :destroyed,
+    :failed
+  ]
+
+  @terminal_states [:destroyed, :failed]
+
+  # The states that hold a LIVE group (member VMs up or in flight, not a banked
+  # set, not terminal). A live group is the singleton the class allows exactly one
+  # of. `banked` is deliberately NOT live: it holds a snapshot set, no VMs.
+  @live_states [:creating, :running, :banking, :relighting, :fresh_booting]
+
+  @events [
+    :publish,
+    :unpublish,
+    :bank,
+    :bank_ready,
+    :bank_abort,
+    :relight,
+    :relight_ready,
+    :relight_abort,
+    :fresh_boot,
+    :fresh_ready,
+    :fresh_abort,
+    :destroy,
+    :fail
+  ]
+
+  # The transition table. Every legal (state, event) pair; anything not a key here
+  # is illegal by construction. `publish` is the whole-group readiness edge
+  # (creating -> running once every member is health-gated and the entry is
+  # published). There is NO `degrade`/`recover` event: degradation is a FLAG on the
+  # running instance, not an FSM edge (see the moduledoc).
+  @transitions %{
+    # Publish: a created (relit, or fresh-booted) group whose members are all up
+    # and whose entry endpoint is now installed in the fan-out, moving it to
+    # `running`.
+    {:creating, :publish} => :running,
+    # Unpublish / bank: the entry endpoint is pulled from the fan-out and the bank
+    # sequence begins. Transient (ETS-only): a running group being banked leaves the
+    # fan-out and enters `banking` in one ETS-only step. The VMs are not gone yet;
+    # `bank_ready` completes the durable bank. `bank` is the same edge under a
+    # different caller name (an explicit bank vs an unpublish-then-bank).
+    {:running, :unpublish} => :banking,
+    {:running, :bank} => :banking,
+    # Idle-bank completion: banking -> banked (StopGroupMember BANK wrote every
+    # member snapshot). The bank_abort edge (banking -> running) is the ETS-only
+    # recovery when the bank RPC set fails: no complete set was written, so the
+    # group returns to running (a later attempt re-banks, or it is republished).
+    {:banking, :bank_ready} => :banked,
+    {:banking, :bank_abort} => :running,
+    # WARM wake: banked -> relighting (StartGroupMember relight in flight for the
+    # whole set) -> creating (then a paired publish moves it to running). The
+    # relight_abort edge (relighting -> banked) is the ETS-only recovery when a
+    # transient relight failure leaves the set intact: the group returns to banked
+    # and a later miss re-relights (or fresh-boots).
+    {:banked, :relight} => :relighting,
+    {:relighting, :relight_ready} => :creating,
+    {:relighting, :relight_abort} => :banked,
+    # COLD wake: banked -> fresh_booting (the set was broken, warmth discarded, a
+    # fresh cold boot of every member) -> creating. Like relight, its abort edge
+    # (fresh_booting -> banked) is the ETS-only recovery when the fresh boot RPC
+    # fails transiently before the fresh VMs exist (the banked set is still on disk,
+    # so a later attempt retries; the eviction of that set only lands with a
+    # completed fresh_ready + paired group_set_evicted).
+    {:banked, :fresh_boot} => :fresh_booting,
+    {:fresh_booting, :fresh_ready} => :creating,
+    {:fresh_booting, :fresh_abort} => :banked,
+    # Destroy: from every non-terminal state (banked included: a banked group can be
+    # destroyed, evicting its set and retiring the instance).
+    {:creating, :destroy} => :destroyed,
+    {:running, :destroy} => :destroyed,
+    {:banking, :destroy} => :destroyed,
+    {:banked, :destroy} => :destroyed,
+    {:relighting, :destroy} => :destroyed,
+    {:fresh_booting, :destroy} => :destroyed,
+    # Fail (member-start error during create, daemon transport/timeout, unrestorable
+    # set): from every LIVE state that touches the daemon. banked cannot `fail` (it
+    # holds no VMs); a broken banked set `evict`s its warmth, it does not fail the
+    # instance.
+    {:creating, :fail} => :failed,
+    {:running, :fail} => :failed,
+    {:banking, :fail} => :failed,
+    {:relighting, :fail} => :failed,
+    {:fresh_booting, :fail} => :failed
+  }
+
+  @type state ::
+          :creating
+          | :running
+          | :banking
+          | :banked
+          | :relighting
+          | :fresh_booting
+          | :destroyed
+          | :failed
+
+  @type event ::
+          :publish
+          | :unpublish
+          | :bank
+          | :bank_ready
+          | :bank_abort
+          | :relight
+          | :relight_ready
+          | :relight_abort
+          | :fresh_boot
+          | :fresh_ready
+          | :fresh_abort
+          | :destroy
+          | :fail
+
+  @spec states() :: [state()]
+  def states, do: @states
+
+  @spec events() :: [event()]
+  def events, do: @events
+
+  @spec live_states() :: [state()]
+  def live_states, do: @live_states
+
+  @spec terminal_states() :: [state()]
+  def terminal_states, do: @terminal_states
+
+  @spec terminal?(state()) :: boolean()
+  def terminal?(state), do: state in @terminal_states
+
+  @doc """
+  Whether `state` holds a LIVE group (the singleton the class permits one of).
+  True for the five non-terminal, non-banked states; false for `banked` (holds a
+  snapshot set, not VMs) and every terminal state. The store's singleton invariant
+  (`create/2` refuses a second live instance) reads this predicate.
+  """
+  @spec live?(state()) :: boolean()
+  def live?(state), do: state in @live_states
+
+  @spec transition(state(), event()) ::
+          {:ok, state()} | {:error, {:illegal_transition, state(), event()}}
+  def transition(state, event) do
+    case Map.fetch(@transitions, {state, event}) do
+      {:ok, next} -> {:ok, next}
+      :error -> {:error, {:illegal_transition, state, event}}
+    end
+  end
+
+  @spec transition!(state(), event()) :: state()
+  def transition!(state, event) do
+    case transition(state, event) do
+      {:ok, next} ->
+        next
+
+      {:error, {:illegal_transition, state, event}} ->
+        raise IllegalTransition, state: state, event: event
+    end
+  end
+end

--- a/projects/embervm/control/lib/embervm/group_store.ex
+++ b/projects/embervm/control/lib/embervm/group_store.ex
@@ -1,0 +1,1053 @@
+defmodule Embervm.GroupStore do
+  @moduledoc """
+  ETS hot set over the op-log's durable `group_instances` + `group_members`
+  projections (R5), the composite-group generalization of `Embervm.StatefulStore`:
+  every read the publisher, the GroupManager, and the management API need is
+  O(1)-to-bounded against ETS, while every durable write goes through the op-log
+  FIRST and only lands in ETS once the op-log confirms it is durable. That
+  ordering, "op-log append succeeds, then and only then update ETS", is the
+  write-through invariant this module enforces: ETS never shows a group in a state
+  the op-log does not already agree with, and a crash between the two never loses a
+  transition (worst case ETS is briefly stale until the next boot's rebuild replays
+  it).
+
+  ## the two tables
+
+  This is the FIRST multi-row-per-instance store (serving/stateful are one row per
+  instance): a group instance has ONE `@instances_table` row (by `instance_id`) and
+  N `@members_table` rows (by `{instance_id, member_name}`), matching the durable
+  projection shape. On `init/1` this rebuilds both from
+  `OpLog.load_group_instances/1` and `OpLog.load_group_members/1`, the recovery
+  path: a fresh GroupStore against an existing op-log ends up with exactly the state
+  the durable projections recorded, no replay logic beyond "read the projection". A
+  projection rebuild followed by an `Embervm.EndpointPublisher` publish is therefore
+  byte-identical to the pre-restart snapshot (the publisher is a pure function of
+  these facts). Adoption (Task 7) layers the NODE's reported group inventory on top
+  of this durable rebuild to heal residency and limbo states.
+
+  ## the singleton invariant
+
+  A composite workload is a GROUP-LEVEL singleton (mirroring stateful decision 3):
+  at most ONE live group INSTANCE per composite CR. `create/2` enforces this at the
+  write boundary: if a live (non-terminal, non-banked) instance already exists for
+  the workload, it returns `{:error, :already_live}` WITHOUT appending an op, so the
+  durable log never records two concurrent live group boots for one workload. A
+  `banked` instance is NOT live (it holds a snapshot set, not VMs), so a workload
+  with only a banked instance can still `create` a fresh cold boot (the wake path).
+
+  ## degraded is a FLAG, not a state
+
+  A member falling unhealthy while the group stays up is crash-consistency per-VM
+  (never across members): the group stays `running` and the instance carries a
+  `degraded_member` field naming the dead member (nil when whole). `set_member_health/4`
+  flips a member row's `healthy` and recomputes the flag; `degraded?/2` reads it.
+  The FSM has no `degraded` node (see `Embervm.GroupState`); the `"degraded"`
+  projection string rebuilds as `running` and the flag is reconstructed from the
+  member rows' health.
+
+  ## the entry endpoint fact
+
+  A composite group contributes the workload's SINGLE L4 entry endpoint exactly
+  when its FSM state is `running` AND the entry member is healthy AND the entry's
+  published `{ip, port}` is recorded. Because the class is a group-level singleton,
+  `entry_endpoint/2` returns ONE `%{ip, port}` (or nil), NOT a list. The entry
+  endpoint is the entry member's DNAT projection (`{node pod IP, vmPort}`, the
+  D-R3.11.4 lane the noded `EnsureEntryDNAT` installs), recorded by the GroupManager
+  when the group publishes; nil is the signal the publisher swaps in the activator
+  endpoint.
+
+  ## set completeness is a DERIVED fact (eager eviction)
+
+  A banked set is COMPLETE iff the node reports a bundle for EVERY member of the
+  group (each expected member_name present in the reported set). Completeness is
+  recomputed on every NodeStatus sweep, never discovered lazily at wake:
+  `evict_partial_sets/2` takes the node-reported bundle sets, and for each `banked`
+  instance whose reported set is missing any member's bundle, evicts it eagerly
+  through the DURABLE path (`group_set_evicted` reason `partial_set`), clearing its
+  `set_id` so the next wake fresh-boots. This is the primitive; Task 7 owns the
+  sweep cadence that feeds it node facts.
+
+  ## transient states + adoption
+
+  `banking`, `relighting`, and `fresh_booting` are ETS-only markers (`mark/2`, no
+  op-log append): a later durable completion op (`group_banked` / `group_relit` /
+  `group_fresh_booted`) or an adoption reconcile (Task 7) resolves them.
+  `adopt_state/3` forces the ETS view from authoritative node truth, bypassing the
+  FSM (adoption is idempotent and total over limbo states the FSM cannot bridge) and
+  never appending an op.
+  """
+
+  use GenServer
+
+  alias Embervm.OpLog.Op
+  alias Embervm.GroupState
+
+  @instances_table :embervm_group_instances
+  @members_table :embervm_group_members
+
+  # -- Client API ------------------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc """
+  Creates a new group instance (a fresh first boot of the whole group). `attrs` is
+  `%{instance_id, tenant, principal, workload, node_id, subnet_cidr, entry_member,
+  entry_port, listen_port, secret}` (the `secret` is the minted-or-sourced
+  EMBER_GROUP_SECRET recorded in the create op so the log alone reconstructs it).
+  Appends `group_created` (write-through), inserts the ETS instance row in
+  `:creating`, and returns `{:ok, instance}`.
+
+  Enforces the SINGLETON invariant: if a live (non-terminal, non-banked) instance
+  already exists for the workload, returns `{:error, :already_live}` WITHOUT
+  appending an op. A workload with only a banked instance is NOT blocked.
+  """
+  @spec create(GenServer.server(), map()) :: {:ok, map()} | {:error, term()}
+  def create(store \\ __MODULE__, attrs) do
+    GenServer.call(store, {:create, attrs})
+  end
+
+  @doc """
+  Records the group's private subnet is up: appends `group_net_created` (write-
+  through) carrying the `subnet_cidr` and upserts the instance's ETS `subnet_cidr`.
+  Idempotent-ish: a re-record upserts the field. Returns `{:ok, instance}` or an
+  error.
+  """
+  @spec net_created(GenServer.server(), String.t(), String.t()) :: {:ok, map()} | {:error, term()}
+  def net_created(store \\ __MODULE__, instance_id, subnet_cidr) do
+    GenServer.call(store, {:net_created, instance_id, subnet_cidr})
+  end
+
+  @doc """
+  Records one member VM came up (write-through `group_member_started`): upserts the
+  member's ETS row (member_name, member_index, vm_id, ip) in `:starting`, not yet
+  healthy. Returns `{:ok, member}` or an error. A member for an unknown instance is
+  `{:error, {:not_found, instance_id}}`.
+  """
+  @spec member_started(GenServer.server(), String.t(), map()) :: {:ok, map()} | {:error, term()}
+  def member_started(store \\ __MODULE__, instance_id, fields) do
+    GenServer.call(store, {:member_started, instance_id, fields})
+  end
+
+  @doc """
+  Applies an FSM transition to a group instance, appending the matching op write-
+  through. `event` is a `GroupState` event; `op_kind` and `payload` describe the op;
+  `updates` are extra fields merged into the ETS instance row AFTER the durable
+  append succeeds. Terminal transitions record the reason. Returns the updated
+  instance or `{:error, reason}` (including `{:illegal_transition, ...}`). Mirrors
+  `StatefulStore.transition/6`.
+  """
+  @spec transition(GenServer.server(), String.t(), atom(), atom(), map(), map()) ::
+          {:ok, map()} | {:error, term()}
+  def transition(store \\ __MODULE__, instance_id, event, op_kind, payload, updates) do
+    GenServer.call(store, {:transition, instance_id, event, op_kind, payload, updates})
+  end
+
+  @doc """
+  The whole-group readiness edge: transitions `creating` -> `running` with a
+  `group_running` op, marking every member healthy and recording the entry's
+  published `{ip, port}` L4 endpoint on the instance (the entry member is
+  health-gated before the group publishes, so a freshly-published group's entry is
+  healthy by construction; a member falling unhealthy later flips it via
+  `set_member_health/4` + the degraded flag). Clears any degraded flag.
+  """
+  @spec publish(GenServer.server(), String.t(), String.t(), non_neg_integer()) ::
+          {:ok, map()} | {:error, term()}
+  def publish(store \\ __MODULE__, instance_id, entry_ip, entry_port) do
+    GenServer.call(store, {:publish, instance_id, entry_ip, entry_port})
+  end
+
+  @doc """
+  Records the whole set was banked (write-through `group_banked`): transitions
+  `banking` -> `banked`, stamps `set_id` on the instance and each member's
+  `snapshot_ref` from `members` (a list of `%{name, snapshot_ref}`) ATOMICALLY in
+  one append (decision 3), and drops the entry endpoint (the VMs are gone). Returns
+  the updated instance or `{:error, reason}`.
+  """
+  @spec bank_ready(GenServer.server(), String.t(), String.t(), [map()]) ::
+          {:ok, map()} | {:error, term()}
+  def bank_ready(store \\ __MODULE__, instance_id, set_id, members) do
+    GenServer.call(store, {:bank_ready, instance_id, set_id, members})
+  end
+
+  @doc """
+  Applies a TRANSIENT FSM edge WITHOUT an op-log append: the ETS-only move into a
+  mid-operation state (`banking`, `relighting`, `fresh_booting`, or their `*_abort`
+  recoveries) that a crash heals from node inventory rather than from the durable
+  log. `event` must be a legal FSM edge from the instance's current state; an
+  illegal edge is `{:error, {:illegal_transition, ...}}`.
+  """
+  @spec mark(GenServer.server(), String.t(), atom()) :: {:ok, map()} | {:error, term()}
+  def mark(store \\ __MODULE__, instance_id, event) do
+    GenServer.call(store, {:mark, instance_id, event})
+  end
+
+  @doc """
+  Flips one member's `healthy` flag from the node's probe fact (health ejection),
+  WITHOUT an FSM transition or an op-log append (health is a lossy node fact). Also
+  recomputes the instance's `degraded_member` flag: if the flipped member is the
+  only unhealthy one it names it; whole again clears it. A no-op for an unknown
+  member. Returns the updated instance or `:error`.
+  """
+  @spec set_member_health(GenServer.server(), String.t(), String.t(), boolean()) ::
+          {:ok, map()} | :error
+  def set_member_health(store \\ __MODULE__, instance_id, member_name, healthy?) do
+    GenServer.call(store, {:set_member_health, instance_id, member_name, healthy?})
+  end
+
+  @doc "The instance's hot-set row, or `:error` if unknown."
+  @spec get(GenServer.server(), String.t()) :: {:ok, map()} | :error
+  def get(store \\ __MODULE__, instance_id) do
+    GenServer.call(store, {:get, instance_id})
+  end
+
+  @doc "Every member row of a group instance, member-index order."
+  @spec members(GenServer.server(), String.t()) :: [map()]
+  def members(store \\ __MODULE__, instance_id) do
+    GenServer.call(store, {:members, instance_id})
+  end
+
+  @doc """
+  Every instance in the hot set (a full ETS scan), for the adoption reconcile and
+  the management API. Rare (boot + registry sweep + management reads), never on a
+  request path.
+  """
+  @spec all(GenServer.server()) :: [map()]
+  def all(store \\ __MODULE__) do
+    GenServer.call(store, :all)
+  end
+
+  @doc """
+  Every instance for `workload`, newest-created first, for the
+  `GET /v1/groups/{workload}` management API. A bounded ETS scan. Because the class
+  is a group-level singleton there is at most one LIVE instance, but a workload can
+  carry a live instance plus terminal history, so this returns a list.
+  """
+  @spec list(GenServer.server(), String.t()) :: [map()]
+  def list(store \\ __MODULE__, workload) do
+    GenServer.call(store, {:list, workload})
+  end
+
+  @doc """
+  The publisher fact: the workload's SINGLE live entry endpoint as `%{ip, port}`,
+  or nil when the workload has no `running` group with a healthy entry member and a
+  recorded entry endpoint. nil is the signal the publisher swaps in the activator
+  endpoint (or, when no activator is configured, skips the workload entirely).
+  """
+  @spec entry_endpoint(GenServer.server(), String.t()) ::
+          %{ip: String.t(), port: non_neg_integer()} | nil
+  def entry_endpoint(store \\ __MODULE__, workload) do
+    GenServer.call(store, {:entry_endpoint, workload})
+  end
+
+  @doc """
+  Whether the workload's running group is DEGRADED (carrying a dead member flag),
+  and which member. Returns `{true, member_name}` or `false`. Read by the
+  management API and the degraded-group alert path.
+  """
+  @spec degraded?(GenServer.server(), String.t()) :: {true, String.t()} | false
+  def degraded?(store \\ __MODULE__, workload) do
+    GenServer.call(store, {:degraded, workload})
+  end
+
+  @doc """
+  The set of /24 subnet CIDRs currently held by a LIVE-or-BANKED group instance
+  (an instance still owning its subnet). The lowest-free allocator reads this to
+  pick a /24 not in use; a terminal instance's subnet is freed (its
+  `group_net_deleted`/terminal op cleared `subnet_cidr`, and a terminal instance is
+  excluded here regardless).
+  """
+  @spec held_subnets(GenServer.server()) :: MapSet.t(String.t())
+  def held_subnets(store \\ __MODULE__) do
+    GenServer.call(store, :held_subnets)
+  end
+
+  @doc """
+  Adoption: FORCE an instance's ETS state to `new_state` from authoritative node
+  truth, bypassing the FSM (adoption is idempotent and derived from what the node
+  actually holds, so it must be total over limbo states the FSM cannot bridge).
+  Does NOT append an op. A no-op for an unknown or already-terminal instance (never
+  resurrects a terminal row). Returns `:ok`. Task 7 drives this from the reconcile.
+  """
+  @spec adopt_state(GenServer.server(), String.t(), :running | :creating | :banked) :: :ok
+  def adopt_state(store \\ __MODULE__, instance_id, new_state) do
+    GenServer.call(store, {:adopt_state, instance_id, new_state})
+  end
+
+  @doc """
+  Set-completeness sweep PRIMITIVE (eager eviction). `reported_sets` maps
+  `instance_id -> MapSet` of member_names the node reports a bundle for. For every
+  `banked` instance whose reported set is missing ANY of its group's member names
+  (a PARTIAL set), evict it through the DURABLE path (a `group_set_evicted` op with
+  reason `partial_set`), clearing `set_id`. A banked instance with NO reported set
+  at all (absent from `reported_sets`) is also partial (nothing to relight). Returns
+  the list of evicted instance_ids. This is a primitive ONLY: Task 7 owns the sweep
+  cadence + the node-fact plumbing that calls it.
+  """
+  @spec evict_partial_sets(GenServer.server(), %{optional(String.t()) => MapSet.t(String.t())}) ::
+          [String.t()]
+  def evict_partial_sets(store \\ __MODULE__, reported_sets) do
+    GenServer.call(store, {:evict_partial_sets, reported_sets})
+  end
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    op_log = Keyword.get(opts, :op_log, Embervm.OpLog.SQLite)
+    clock = Keyword.get(opts, :clock, &default_clock/0)
+
+    instances = :ets.new(@instances_table, [:set, :private])
+    members = :ets.new(@members_table, [:set, :private])
+
+    state = %{
+      op_log: op_log,
+      clock: clock,
+      instances: instances,
+      members: members
+    }
+
+    case rebuild(state) do
+      {:ok, state} -> {:ok, state}
+      {:error, reason} -> {:stop, {:rebuild_failed, reason}}
+    end
+  end
+
+  # Rebuild: read every durable group-instance + member row and populate the two
+  # hot sets from scratch. No per-op replay: the projections already ARE the current
+  # state. `healthy` is NOT durable on the instance (it is a live node-probe fact);
+  # a rebuilt `running` instance's members keep their projected `healthy` so the
+  # publisher re-derives the exact entry endpoint the projection recorded
+  # (byte-identical rebuild), and the node's next probe corrects a stale flag.
+  defp rebuild(state) do
+    with {:ok, instance_rows} <- Embervm.OpLog.SQLite.load_group_instances(state.op_log),
+         {:ok, member_rows} <- Embervm.OpLog.SQLite.load_group_members(state.op_log) do
+      Enum.each(member_rows, fn row ->
+        member = row_to_member(row)
+        :ets.insert(state.members, {{row.instance_id, row.member_name}, member})
+      end)
+
+      Enum.each(instance_rows, fn row ->
+        instance = row_to_instance(row, member_rows)
+        :ets.insert(state.instances, {instance.instance_id, instance})
+      end)
+
+      {:ok, state}
+    end
+  end
+
+  defp row_to_instance(row, member_rows) do
+    fsm_state = state_from_string(row.state)
+
+    # The degraded flag is reconstructed from the member rows (health is lossy, not
+    # a durable instance column): the projected "degraded" state, or any unhealthy
+    # member on a running instance, names the dead member. On rebuild the entry
+    # endpoint is re-derived from the running-and-published fact + the entry member's
+    # row; a rebuilt running instance keeps its recorded listen_port so the publisher
+    # re-emits identically until the node's next report.
+    degraded_member =
+      if fsm_state == :running do
+        member_rows
+        |> Enum.filter(&(&1.instance_id == row.instance_id and &1.healthy == false))
+        |> Enum.map(& &1.member_name)
+        |> List.first()
+      else
+        nil
+      end
+
+    entry_member_row =
+      Enum.find(member_rows, &(&1.instance_id == row.instance_id and &1.member_name == row.entry_member))
+
+    %{
+      instance_id: row.instance_id,
+      tenant: row.tenant,
+      principal: row.principal,
+      workload: row.workload,
+      state: fsm_state,
+      node_id: row.node_id,
+      subnet_cidr: row.subnet_cidr,
+      entry_member: row.entry_member,
+      entry_port: row.entry_port,
+      listen_port: row.listen_port,
+      set_id: row.set_id,
+      # The published entry endpoint on rebuild is reconstructed from the durable
+      # facts alone: the entry member's tap IP (durable in its member row) and the
+      # group's entry.port. This is the FALLBACK reconstruction (the LIVE publish
+      # records the DNAT {pod IP, vmPort} the node Envoy dials, which the group
+      # projection does not persist a column for); Task 7's adoption reconcile
+      # re-derives + re-publishes the DNAT endpoint on the next sweep, overwriting
+      # these same fields, exactly the stateful adoption posture. A non-running
+      # instance has no live entry endpoint.
+      entry_ip:
+        if(fsm_state == :running and entry_member_row, do: entry_member_row.ip, else: nil),
+      entry_port_published: if(fsm_state == :running, do: row.entry_port, else: nil),
+      degraded_member: degraded_member,
+      created_at: row.created_at,
+      last_active_at: row.last_active_at,
+      updated_at: row.updated_at,
+      terminal_reason: row.terminal_reason
+    }
+  end
+
+  defp row_to_member(row) do
+    %{
+      instance_id: row.instance_id,
+      member_name: row.member_name,
+      member_index: row.member_index,
+      vm_id: row.vm_id,
+      ip: row.ip,
+      state: row.state,
+      snapshot_ref: row.snapshot_ref,
+      # Not durable in intent (a live node-probe fact), but the projection persists
+      # the last-known flag; keep it so a rebuilt group reproduces its degraded flag.
+      healthy: row.healthy,
+      updated_at: row.updated_at
+    }
+  end
+
+  # Explicit map (not String.to_existing_atom): fails loudly on an unknown string
+  # and documents the exact projection strings the merged PR-1 projection writes.
+  # These strings are the complete set `group_instances.state` can hold;
+  # `banking`/`relighting`/`fresh_booting` are transient ETS-only states never
+  # persisted, so they are absent here. `"starting"` is the projection's name for
+  # the FSM's `:creating` node (create/relight/fresh-boot all project "starting");
+  # `"degraded"` is a running instance carrying the degraded flag, so it rebuilds as
+  # `:running` and the flag is reconstructed from the unhealthy member rows.
+  @state_strings %{
+    "starting" => :creating,
+    "running" => :running,
+    "degraded" => :running,
+    "banked" => :banked,
+    "destroyed" => :destroyed,
+    "failed" => :failed
+  }
+
+  defp state_from_string(str), do: Map.fetch!(@state_strings, str)
+
+  @impl true
+  def handle_call({:create, attrs}, _from, state) do
+    do_create(attrs, state)
+  end
+
+  def handle_call({:net_created, instance_id, subnet_cidr}, _from, state) do
+    with {:ok, instance} <- fetch(state, instance_id) do
+      op = %Op{
+        kind: :group_net_created,
+        tenant: instance.tenant,
+        principal: instance.principal,
+        workload: instance.workload,
+        group_instance_id: instance_id,
+        ts: state.clock.(),
+        payload: %{subnet_cidr: subnet_cidr}
+      }
+
+      case Embervm.OpLog.SQLite.append(state.op_log, op) do
+        {:ok, _seq} ->
+          updated = %{instance | subnet_cidr: subnet_cidr, updated_at: op.ts}
+          :ets.insert(state.instances, {instance_id, updated})
+          {:reply, {:ok, updated}, state}
+
+        {:error, _reason} = error ->
+          {:reply, error, state}
+      end
+    else
+      {:error, _reason} = error -> {:reply, error, state}
+    end
+  end
+
+  def handle_call({:member_started, instance_id, fields}, _from, state) do
+    do_member_started(state, instance_id, fields)
+  end
+
+  def handle_call({:transition, instance_id, event, op_kind, payload, updates}, _from, state) do
+    do_transition(state, instance_id, event, op_kind, payload, updates)
+  end
+
+  def handle_call({:publish, instance_id, entry_ip, entry_port}, _from, state) do
+    payload = %{listen_port: entry_port}
+
+    updates = %{
+      entry_ip: entry_ip,
+      entry_port_published: entry_port,
+      listen_port: entry_port,
+      # A (re)published group is running and whole: clear any degraded flag (a member
+      # that came back up on a relight is healthy again).
+      degraded_member: nil
+    }
+
+    case do_transition(state, instance_id, :publish, :group_running, payload, updates) do
+      {:reply, {:ok, instance}, state} ->
+        # Mark every member row healthy (the group_running readiness edge): the
+        # publish is gated on every member being health-checked, mirroring the
+        # projection's mark_all_members_healthy.
+        state = mark_all_members_healthy(state, instance_id, true)
+        {:reply, {:ok, instance}, state}
+
+      other ->
+        other
+    end
+  end
+
+  def handle_call({:bank_ready, instance_id, set_id, members}, _from, state) do
+    payload = %{set_id: set_id, members: members}
+    updates = %{set_id: set_id, entry_ip: nil, entry_port_published: nil, degraded_member: nil}
+
+    case do_transition(state, instance_id, :bank_ready, :group_banked, payload, updates) do
+      {:reply, {:ok, instance}, state} ->
+        # Stamp each member's snapshot_ref and clear its live VM facts (the VMs are
+        # gone), mirroring the projection's bank_group_members.
+        state = bank_members(state, instance_id, members)
+        {:reply, {:ok, instance}, state}
+
+      other ->
+        other
+    end
+  end
+
+  def handle_call({:mark, instance_id, event}, _from, state) do
+    do_mark(state, instance_id, event)
+  end
+
+  def handle_call({:set_member_health, instance_id, member_name, healthy?}, _from, state) do
+    do_set_member_health(state, instance_id, member_name, healthy?)
+  end
+
+  def handle_call({:get, instance_id}, _from, state) do
+    {:reply, get_view(state, instance_id), state}
+  end
+
+  def handle_call({:members, instance_id}, _from, state) do
+    {:reply, member_list(state, instance_id), state}
+  end
+
+  def handle_call(:all, _from, state) do
+    all = :ets.foldl(fn {_id, instance}, acc -> [instance | acc] end, [], state.instances)
+    {:reply, all, state}
+  end
+
+  def handle_call({:list, workload}, _from, state) do
+    items =
+      :ets.foldl(
+        fn {_id, instance}, acc ->
+          if instance.workload == workload, do: [instance | acc], else: acc
+        end,
+        [],
+        state.instances
+      )
+      |> Enum.sort_by(& &1.created_at, :desc)
+
+    {:reply, items, state}
+  end
+
+  def handle_call({:entry_endpoint, workload}, _from, state) do
+    endpoint =
+      :ets.foldl(
+        fn {_id, instance}, acc ->
+          if acc == nil and entry_servable?(instance, workload) do
+            %{ip: instance.entry_ip, port: instance.entry_port_published}
+          else
+            acc
+          end
+        end,
+        nil,
+        state.instances
+      )
+
+    {:reply, endpoint, state}
+  end
+
+  def handle_call({:degraded, workload}, _from, state) do
+    reply =
+      :ets.foldl(
+        fn {_id, instance}, acc ->
+          cond do
+            acc != false ->
+              acc
+
+            instance.workload == workload and instance.state == :running and
+                is_binary(instance.degraded_member) ->
+              {true, instance.degraded_member}
+
+            true ->
+              acc
+          end
+        end,
+        false,
+        state.instances
+      )
+
+    {:reply, reply, state}
+  end
+
+  def handle_call(:held_subnets, _from, state) do
+    held =
+      :ets.foldl(
+        fn {_id, instance}, acc ->
+          if not GroupState.terminal?(instance.state) and is_binary(instance.subnet_cidr) and
+               instance.subnet_cidr != "" do
+            MapSet.put(acc, instance.subnet_cidr)
+          else
+            acc
+          end
+        end,
+        MapSet.new(),
+        state.instances
+      )
+
+    {:reply, held, state}
+  end
+
+  def handle_call({:adopt_state, instance_id, new_state}, _from, state)
+      when new_state in [:running, :creating, :banked] do
+    case fetch(state, instance_id) do
+      {:ok, %{state: cur}} when cur in [:destroyed, :failed] ->
+        # Never resurrect a terminal instance from a stale node fact.
+        {:reply, :ok, state}
+
+      {:ok, instance} ->
+        if instance.state == new_state do
+          {:reply, :ok, state}
+        else
+          ts = state.clock.()
+
+          updated =
+            if new_state == :banked do
+              %{instance | state: :banked, entry_ip: nil, entry_port_published: nil, degraded_member: nil, updated_at: ts}
+            else
+              %{instance | state: new_state, updated_at: ts}
+            end
+
+          :ets.insert(state.instances, {instance_id, updated})
+          {:reply, :ok, state}
+        end
+
+      :error ->
+        {:reply, :ok, state}
+    end
+  end
+
+  def handle_call({:evict_partial_sets, reported_sets}, _from, state) do
+    do_evict_partial_sets(state, reported_sets)
+  end
+
+  # -- create ----------------------------------------------------------------
+
+  defp do_create(attrs, state) do
+    workload = Map.fetch!(attrs, :workload)
+
+    if has_live_instance?(state, workload) do
+      {:reply, {:error, :already_live}, state}
+    else
+      append_create(attrs, workload, state)
+    end
+  end
+
+  defp append_create(attrs, workload, state) do
+    ts = state.clock.()
+    instance_id = Map.fetch!(attrs, :instance_id)
+
+    payload = %{
+      node_id: Map.get(attrs, :node_id),
+      subnet_cidr: Map.get(attrs, :subnet_cidr),
+      entry_member: Map.get(attrs, :entry_member),
+      entry_port: Map.get(attrs, :entry_port),
+      listen_port: Map.get(attrs, :listen_port),
+      # The EMBER_GROUP_SECRET this group boots with (sourced from secretRef, or
+      # minted at create): recorded here so the op-log alone reconstructs it and a
+      # relight/adoption re-derives the same value without re-reading K8s.
+      secret: Map.get(attrs, :secret),
+      state: "starting"
+    }
+
+    op = %Op{
+      kind: :group_created,
+      tenant: Map.fetch!(attrs, :tenant),
+      principal: Map.get(attrs, :principal),
+      workload: workload,
+      group_instance_id: instance_id,
+      ts: ts,
+      payload: payload
+    }
+
+    case Embervm.OpLog.SQLite.append(state.op_log, op) do
+      {:ok, _seq} ->
+        instance = %{
+          instance_id: instance_id,
+          tenant: op.tenant,
+          principal: op.principal,
+          workload: workload,
+          state: :creating,
+          node_id: Map.get(attrs, :node_id),
+          subnet_cidr: Map.get(attrs, :subnet_cidr),
+          entry_member: Map.get(attrs, :entry_member),
+          entry_port: Map.get(attrs, :entry_port),
+          listen_port: Map.get(attrs, :listen_port),
+          set_id: nil,
+          entry_ip: nil,
+          entry_port_published: nil,
+          degraded_member: nil,
+          created_at: ts,
+          last_active_at: nil,
+          updated_at: ts,
+          terminal_reason: nil
+        }
+
+        :ets.insert(state.instances, {instance_id, instance})
+        {:reply, {:ok, instance}, state}
+
+      {:error, _reason} = error ->
+        {:reply, error, state}
+    end
+  end
+
+  # -- member started --------------------------------------------------------
+
+  defp do_member_started(state, instance_id, fields) do
+    with {:ok, instance} <- fetch(state, instance_id) do
+      ts = state.clock.()
+      member_name = Map.fetch!(fields, :member_name)
+
+      op = %Op{
+        kind: :group_member_started,
+        tenant: instance.tenant,
+        principal: instance.principal,
+        workload: instance.workload,
+        group_instance_id: instance_id,
+        ts: ts,
+        payload: %{
+          member_name: member_name,
+          member_index: Map.get(fields, :member_index),
+          vm_id: Map.get(fields, :vm_id),
+          ip: Map.get(fields, :ip)
+        }
+      }
+
+      case Embervm.OpLog.SQLite.append(state.op_log, op) do
+        {:ok, _seq} ->
+          member = %{
+            instance_id: instance_id,
+            member_name: member_name,
+            member_index: Map.get(fields, :member_index),
+            vm_id: Map.get(fields, :vm_id),
+            ip: Map.get(fields, :ip),
+            state: "starting",
+            # A fresh member boot clears any prior banked slice (the warmth is spent).
+            snapshot_ref: nil,
+            healthy: false,
+            updated_at: ts
+          }
+
+          :ets.insert(state.members, {{instance_id, member_name}, member})
+          {:reply, {:ok, member}, state}
+
+        {:error, _reason} = error ->
+          {:reply, error, state}
+      end
+    else
+      {:error, _reason} = error -> {:reply, error, state}
+    end
+  end
+
+  # -- transition ------------------------------------------------------------
+
+  defp do_transition(state, instance_id, event, op_kind, payload, updates) do
+    with {:ok, instance} <- fetch(state, instance_id),
+         {:ok, next} <- GroupState.transition(instance.state, event) do
+      case append_and_update(state, instance, op_kind, next, payload, updates) do
+        {:ok, updated, state} -> {:reply, {:ok, updated}, state}
+        {:error, reason} -> {:reply, {:error, reason}, state}
+      end
+    else
+      {:error, _reason} = error -> {:reply, error, state}
+    end
+  end
+
+  # The write-through core: append to the op-log, and ONLY on {:ok, seq} update ETS.
+  # On append failure ETS is left untouched (as durable as the op-log agrees) and
+  # the error is returned. Terminal transitions record the reason and drop the entry
+  # endpoint; a bank (next == :banked) also drops the entry endpoint.
+  defp append_and_update(state, instance, op_kind, next_state, payload, updates) do
+    ts = state.clock.()
+
+    op = %Op{
+      kind: op_kind,
+      tenant: instance.tenant,
+      principal: instance.principal,
+      workload: instance.workload,
+      group_instance_id: instance.instance_id,
+      ts: ts,
+      payload: payload
+    }
+
+    case Embervm.OpLog.SQLite.append(state.op_log, op) do
+      {:ok, _seq} ->
+        terminal? = GroupState.terminal?(next_state)
+
+        terminal_reason =
+          if terminal? do
+            to_string(Map.get(payload, :reason, next_state))
+          else
+            instance.terminal_reason
+          end
+
+        base =
+          instance
+          |> Map.merge(updates)
+          |> Map.merge(%{state: next_state, updated_at: ts, terminal_reason: terminal_reason})
+
+        updated = post_transition_endpoint(base, next_state, terminal?)
+
+        :ets.insert(state.instances, {instance.instance_id, updated})
+        {:ok, updated, state}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # After a durable transition, reconcile the entry endpoint fact with the new state:
+  #   * terminal -> no live entry endpoint;
+  #   * banked   -> the set is snapshotted and destroyed, so no live entry endpoint;
+  #   * any other -> leave the caller's `updates` as-is (publish set the endpoint).
+  defp post_transition_endpoint(base, next_state, terminal?) do
+    cond do
+      terminal? -> %{base | entry_ip: nil, entry_port_published: nil, degraded_member: nil}
+      next_state == :banked -> %{base | entry_ip: nil, entry_port_published: nil, degraded_member: nil}
+      true -> base
+    end
+  end
+
+  # Transient ETS-only FSM move (no op-log append): banking/relighting/fresh_booting
+  # entry markers and their aborts, which a later completion op or adoption resolves.
+  defp do_mark(state, instance_id, event) do
+    with {:ok, instance} <- fetch(state, instance_id),
+         {:ok, next} <- GroupState.transition(instance.state, event) do
+      ts = state.clock.()
+      updated = %{instance | state: next, updated_at: ts}
+      :ets.insert(state.instances, {instance_id, updated})
+      {:reply, {:ok, updated}, state}
+    else
+      {:error, _reason} = error -> {:reply, error, state}
+    end
+  end
+
+  # -- member health + degraded flag -----------------------------------------
+
+  defp do_set_member_health(state, instance_id, member_name, healthy?) do
+    case fetch_member(state, instance_id, member_name) do
+      {:ok, member} ->
+        ts = state.clock.()
+        updated_member = %{member | healthy: healthy?, updated_at: ts}
+        :ets.insert(state.members, {{instance_id, member_name}, updated_member})
+
+        # Recompute the instance's degraded flag from the full member set. On a
+        # running instance, any unhealthy member names it degraded (first one, stable);
+        # whole again clears it. A non-running instance carries no degraded flag.
+        state = recompute_degraded(state, instance_id)
+        {:reply, get_view(state, instance_id), state}
+
+      :error ->
+        {:reply, :error, state}
+    end
+  end
+
+  defp recompute_degraded(state, instance_id) do
+    case fetch(state, instance_id) do
+      {:ok, %{state: :running} = instance} ->
+        dead =
+          member_list(state, instance_id)
+          |> Enum.filter(&(&1.healthy == false))
+          |> Enum.map(& &1.member_name)
+          |> List.first()
+
+        updated = %{instance | degraded_member: dead, updated_at: state.clock.()}
+        :ets.insert(state.instances, {instance_id, updated})
+        state
+
+      _ ->
+        state
+    end
+  end
+
+  defp mark_all_members_healthy(state, instance_id, healthy?) do
+    ts = state.clock.()
+
+    for {{^instance_id, _name} = key, member} <- member_entries(state, instance_id) do
+      :ets.insert(state.members, {key, %{member | healthy: healthy?, updated_at: ts}})
+    end
+
+    state
+  end
+
+  defp bank_members(state, instance_id, members) do
+    ts = state.clock.()
+    by_name = Map.new(members, fn m -> {member_field(m, :name), member_field(m, :snapshot_ref)} end)
+
+    for {{^instance_id, name} = key, member} <- member_entries(state, instance_id) do
+      case Map.fetch(by_name, name) do
+        {:ok, snapshot_ref} ->
+          updated = %{
+            member
+            | snapshot_ref: snapshot_ref,
+              vm_id: nil,
+              ip: nil,
+              state: "banked",
+              healthy: false,
+              updated_at: ts
+          }
+
+          :ets.insert(state.members, {key, updated})
+
+        :error ->
+          :ok
+      end
+    end
+
+    state
+  end
+
+  # A member payload entry may carry atom or string keys (freshly-appended atom-keyed
+  # op vs a value rebuilt from durable payload_json), so read either.
+  defp member_field(m, key) when is_map(m), do: Map.get(m, key) || Map.get(m, Atom.to_string(key))
+  defp member_field(_m, _key), do: nil
+
+  # -- eager set eviction ----------------------------------------------------
+
+  defp do_evict_partial_sets(state, reported_sets) do
+    banked =
+      :ets.foldl(
+        fn {_id, instance}, acc ->
+          if instance.state == :banked, do: [instance | acc], else: acc
+        end,
+        [],
+        state.instances
+      )
+
+    {evicted_ids, state} =
+      Enum.reduce(banked, {[], state}, fn instance, {ids, acc} ->
+        expected = expected_member_names(acc, instance.instance_id)
+        reported = Map.get(reported_sets, instance.instance_id, MapSet.new())
+
+        if MapSet.subset?(expected, reported) do
+          {ids, acc}
+        else
+          # PARTIAL set: the node is missing at least one member's bundle. Evict
+          # through the durable path (so a rebuild agrees the warmth is gone),
+          # clearing set_id so the next wake fresh-boots. A banked instance stays
+          # `banked` (the FSM has no evict edge off banked in R5: eviction of the
+          # SET is a bundle-audit clear, not a lifecycle transition), so this is an
+          # ETS field update paired with the durable group_set_evicted op.
+          case append_set_evicted(acc, instance) do
+            {:ok, acc} -> {[instance.instance_id | ids], acc}
+            {:error, _reason} -> {ids, acc}
+          end
+        end
+      end)
+
+    {:reply, Enum.reverse(evicted_ids), state}
+  end
+
+  # Append group_set_evicted (durable) and clear the instance's set_id in ETS.
+  # group_set_evicted is a bundle-audit clear, not an FSM transition (the instance
+  # stays banked); a rebuild replays the cleared set_id.
+  defp append_set_evicted(state, instance) do
+    ts = state.clock.()
+
+    op = %Op{
+      kind: :group_set_evicted,
+      tenant: instance.tenant,
+      principal: instance.principal,
+      workload: instance.workload,
+      group_instance_id: instance.instance_id,
+      ts: ts,
+      payload: %{reason: "partial_set"}
+    }
+
+    case Embervm.OpLog.SQLite.append(state.op_log, op) do
+      {:ok, _seq} ->
+        updated = %{instance | set_id: nil, updated_at: ts}
+        :ets.insert(state.instances, {instance.instance_id, updated})
+        {:ok, state}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  # -- helpers ---------------------------------------------------------------
+
+  # A group is the workload's SINGLE servable entry endpoint exactly when it is that
+  # workload's, in the `running` FSM state, and carries a routable entry {ip, port}.
+  # (The entry member's health rides the degraded flag; a degraded group whose entry
+  # member is the dead one has no entry endpoint because publish/bank would have
+  # dropped it, but a running group with a live entry endpoint is servable even if a
+  # NON-entry member is degraded.)
+  defp entry_servable?(instance, workload) do
+    instance.workload == workload and instance.state == :running and
+      is_binary(instance.entry_ip) and instance.entry_ip != "" and
+      is_integer(instance.entry_port_published)
+  end
+
+  defp has_live_instance?(state, workload) do
+    :ets.foldl(
+      fn {_id, instance}, acc ->
+        acc or (instance.workload == workload and GroupState.live?(instance.state))
+      end,
+      false,
+      state.instances
+    )
+  end
+
+  # The expected member names of a group = every member row's name (the members were
+  # recorded at boot; a complete banked set must have a bundle for each). Used by the
+  # set-completeness check.
+  defp expected_member_names(state, instance_id) do
+    member_list(state, instance_id)
+    |> Enum.map(& &1.member_name)
+    |> MapSet.new()
+  end
+
+  defp member_list(state, instance_id) do
+    member_entries(state, instance_id)
+    |> Enum.map(fn {_key, member} -> member end)
+    |> Enum.sort_by(&(&1.member_index || 0))
+  end
+
+  defp member_entries(state, instance_id) do
+    :ets.foldl(
+      fn {{id, _name} = key, member}, acc ->
+        if id == instance_id, do: [{key, member} | acc], else: acc
+      end,
+      [],
+      state.members
+    )
+  end
+
+  defp fetch(state, instance_id) do
+    case :ets.lookup(state.instances, instance_id) do
+      [{^instance_id, instance}] -> {:ok, instance}
+      [] -> {:error, {:not_found, instance_id}}
+    end
+  end
+
+  defp fetch_member(state, instance_id, member_name) do
+    case :ets.lookup(state.members, {instance_id, member_name}) do
+      [{{^instance_id, ^member_name}, member}] -> {:ok, member}
+      [] -> :error
+    end
+  end
+
+  defp get_view(state, instance_id) do
+    case fetch(state, instance_id) do
+      {:ok, instance} -> {:ok, instance}
+      {:error, _} -> :error
+    end
+  end
+
+  defp default_clock, do: System.system_time(:millisecond)
+end

--- a/projects/embervm/control/lib/embervm/group_store.ex
+++ b/projects/embervm/control/lib/embervm/group_store.ex
@@ -280,6 +280,21 @@ defmodule Embervm.GroupStore do
   end
 
   @doc """
+  Adoption: FORCE an instance's published entry endpoint (`entry_ip` /
+  `entry_port_published`) from authoritative node truth, bypassing the FSM and NOT
+  appending an op (the ETS-force sibling of `adopt_state/3`, mirroring
+  `StatefulStore.adopt_endpoint`). The reconcile re-derives the DNAT `{pod_ip,
+  vm_port}` the LIVE publish recorded (which the op-log projection does not persist a
+  column for; a rebuild reconstructs the fallback `{entry tap IP, entry guest port}`
+  instead) and forces it here so a control-plane restart republishes the IDENTICAL
+  endpoint. A no-op for an unknown or terminal instance. Returns `:ok`.
+  """
+  @spec adopt_endpoint(GenServer.server(), String.t(), String.t(), non_neg_integer()) :: :ok
+  def adopt_endpoint(store \\ __MODULE__, instance_id, entry_ip, entry_port) do
+    GenServer.call(store, {:adopt_endpoint, instance_id, entry_ip, entry_port})
+  end
+
+  @doc """
   Set-completeness sweep PRIMITIVE (eager eviction). `reported_sets` maps
   `instance_id -> MapSet` of member_names the node reports a bundle for. For every
   `banked` instance whose reported set is missing ANY of its group's member names
@@ -640,6 +655,19 @@ defmodule Embervm.GroupStore do
         end
 
       :error ->
+        {:reply, :ok, state}
+    end
+  end
+
+  def handle_call({:adopt_endpoint, instance_id, entry_ip, entry_port}, _from, state) do
+    case fetch(state, instance_id) do
+      {:ok, %{state: cur} = instance}
+      when cur not in [:destroyed, :failed] and is_binary(entry_ip) and entry_ip != "" and is_integer(entry_port) ->
+        updated = %{instance | entry_ip: entry_ip, entry_port_published: entry_port, updated_at: state.clock.()}
+        :ets.insert(state.instances, {instance_id, updated})
+        {:reply, :ok, state}
+
+      _ ->
         {:reply, :ok, state}
     end
   end
@@ -1027,10 +1055,14 @@ defmodule Embervm.GroupStore do
 
   # A group is the workload's SINGLE servable entry endpoint exactly when it is that
   # workload's, in the `running` FSM state, and carries a routable entry {ip, port}.
-  # (The entry member's health rides the degraded flag; a degraded group whose entry
-  # member is the dead one has no entry endpoint because publish/bank would have
-  # dropped it, but a running group with a live entry endpoint is servable even if a
-  # NON-entry member is degraded.)
+  # In R5 core a running group publishes a HEALTHY entry by construction (the entry
+  # member is health-gated before publish, and a bank/terminal transition drops the
+  # endpoint), so a running instance with a recorded entry {ip, port} is servable. A
+  # NON-entry member falling unhealthy only sets the degraded FLAG and keeps the entry
+  # endpoint live. Health-DRIVEN withdrawal of a live entry member's endpoint (pulling
+  # the endpoint when the entry member itself later goes unhealthy) is a LATER path,
+  # not this predicate: this check reads only the recorded {ip, port}, it does not
+  # re-probe the entry member's current health.
   defp entry_servable?(instance, workload) do
     instance.workload == workload and instance.state == :running and
       is_binary(instance.entry_ip) and instance.entry_ip != "" and

--- a/projects/embervm/control/lib/embervm/group_store.ex
+++ b/projects/embervm/control/lib/embervm/group_store.ex
@@ -295,6 +295,19 @@ defmodule Embervm.GroupStore do
     GenServer.call(store, {:evict_partial_sets, reported_sets})
   end
 
+  @doc """
+  Evict ONE instance's banked set through the durable path (a `group_set_evicted`
+  op, `reason`), clearing its `set_id` and each member row's `snapshot_ref` (the
+  warmth is gone). NOT an FSM transition (the instance's lifecycle move to
+  `fresh_booting` is a separate `mark/2`); this is the single-instance sibling of
+  `evict_partial_sets/2`, used by the wake path's relight -> fresh fallback so a
+  rebuild agrees the set is spent. A no-op for an unknown instance. Returns `:ok`.
+  """
+  @spec evict_set(GenServer.server(), String.t(), String.t()) :: :ok
+  def evict_set(store \\ __MODULE__, instance_id, reason) do
+    GenServer.call(store, {:evict_set, instance_id, reason})
+  end
+
   # -- GenServer callbacks ---------------------------------------------------
 
   @impl true
@@ -635,6 +648,23 @@ defmodule Embervm.GroupStore do
     do_evict_partial_sets(state, reported_sets)
   end
 
+  def handle_call({:evict_set, instance_id, reason}, _from, state) do
+    case fetch(state, instance_id) do
+      {:ok, instance} ->
+        case append_set_evicted(state, instance, reason) do
+          {:ok, state} ->
+            state = clear_member_snapshots(state, instance_id)
+            {:reply, :ok, state}
+
+          {:error, _reason} ->
+            {:reply, :ok, state}
+        end
+
+      {:error, _} ->
+        {:reply, :ok, state}
+    end
+  end
+
   # -- create ----------------------------------------------------------------
 
   defp do_create(attrs, state) do
@@ -911,6 +941,19 @@ defmodule Embervm.GroupStore do
     state
   end
 
+  # Clear every member row's banked snapshot_ref (a set eviction: the warmth is
+  # gone). Leaves the member rows otherwise intact so the fresh boot re-records live
+  # facts over them via member_started.
+  defp clear_member_snapshots(state, instance_id) do
+    ts = state.clock.()
+
+    for {{^instance_id, _name} = key, member} <- member_entries(state, instance_id) do
+      :ets.insert(state.members, {key, %{member | snapshot_ref: nil, updated_at: ts}})
+    end
+
+    state
+  end
+
   # A member payload entry may carry atom or string keys (freshly-appended atom-keyed
   # op vs a value rebuilt from durable payload_json), so read either.
   defp member_field(m, key) when is_map(m), do: Map.get(m, key) || Map.get(m, Atom.to_string(key))
@@ -942,7 +985,7 @@ defmodule Embervm.GroupStore do
           # `banked` (the FSM has no evict edge off banked in R5: eviction of the
           # SET is a bundle-audit clear, not a lifecycle transition), so this is an
           # ETS field update paired with the durable group_set_evicted op.
-          case append_set_evicted(acc, instance) do
+          case append_set_evicted(acc, instance, "partial_set") do
             {:ok, acc} -> {[instance.instance_id | ids], acc}
             {:error, _reason} -> {ids, acc}
           end
@@ -954,8 +997,9 @@ defmodule Embervm.GroupStore do
 
   # Append group_set_evicted (durable) and clear the instance's set_id in ETS.
   # group_set_evicted is a bundle-audit clear, not an FSM transition (the instance
-  # stays banked); a rebuild replays the cleared set_id.
-  defp append_set_evicted(state, instance) do
+  # stays banked / is separately marked fresh_booting by the wake path); a rebuild
+  # replays the cleared set_id.
+  defp append_set_evicted(state, instance, reason) do
     ts = state.clock.()
 
     op = %Op{
@@ -965,7 +1009,7 @@ defmodule Embervm.GroupStore do
       workload: instance.workload,
       group_instance_id: instance.instance_id,
       ts: ts,
-      payload: %{reason: "partial_set"}
+      payload: %{reason: reason}
     }
 
     case Embervm.OpLog.SQLite.append(state.op_log, op) do

--- a/projects/embervm/control/lib/embervm/group_wake_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_wake_manager.ex
@@ -81,6 +81,7 @@ defmodule Embervm.GroupWakeManager do
 
   use GenServer
   require Logger
+  import Bitwise
 
   alias Embervm.{EndpointPublisher, GroupManager, GroupState, GroupStore, NodeCapacity, WorkloadCatalog}
 
@@ -142,6 +143,16 @@ defmodule Embervm.GroupWakeManager do
       # implementing create_group/2 + wake_group/1 (or a per-workload scripted fake).
       # Production drives Embervm.GroupManager.Supervisor.
       supervisor_mod: Keyword.get(opts, :supervisor_mod, GroupManager.Supervisor),
+      # The composite supernet + DNAT port base + control-plane pod IP, the SAME
+      # shared values that feed the GroupManager (and noded's CompositeSupernet /
+      # ServingPortBase). Adoption re-derives the entry DNAT endpoint `{pod_ip,
+      # port_base + host_offset(entry ip, supernet)}` from these so a CP restart
+      # republishes the IDENTICAL endpoint the live publish recorded (the op-log
+      # rebuild reconstructs only the fallback {tap ip, guest port}). Defaulted to the
+      # group_manager_defaults app-env so production and the GroupManager agree.
+      supernet: Keyword.get(opts, :supernet, group_default(:supernet, "10.101.0.0/16")),
+      port_base: Keyword.get(opts, :port_base, group_default(:port_base, 30_000)),
+      pod_ip: Keyword.get(opts, :pod_ip, group_default(:pod_ip, nil)),
       # workload -> [{from, principal}] parked behind an in-flight wake (single-flight).
       waking: %{},
       # principal -> [wake timestamps within the window] (sliding-window rate limit).
@@ -437,11 +448,13 @@ defmodule Embervm.GroupWakeManager do
   end
 
   # Adopt a node-reported live group WITHOUT touching a VM: force the ETS state to
-  # running, rebind every reported member's live facts + health, respawn the
-  # GroupManager owner in the adopted state, and re-derive the entry endpoint from
-  # the entry member's node-reported ip (the CP-derived DNAT port stays authoritative
-  # for the published endpoint; adoption keeps the SAME entry endpoint the pre-restart
-  # publish recorded, so the republish is identical).
+  # running, rebind every reported member's health, re-derive + force the DNAT entry
+  # endpoint from the entry member's NODE-REPORTED ip (the same `{pod_ip, port_base +
+  # host_offset(entry ip, supernet)}` math the live publish used), and respawn the
+  # GroupManager owner. Forcing the DNAT endpoint is load-bearing: the op-log rebuild
+  # reconstructs only the FALLBACK `{entry tap ip, entry guest port}`, so without this
+  # a CP restart would republish a DIFFERENT endpoint. With it the republish is
+  # byte-identical to the pre-restart snapshot.
   defp adopt_live(state, instance, members) do
     GroupStore.adopt_state(state.store, instance.instance_id, :running)
 
@@ -449,8 +462,34 @@ defmodule Embervm.GroupWakeManager do
       _ = GroupStore.set_member_health(state.store, instance.instance_id, m.member_name, m.healthy)
     end
 
+    _ = adopt_entry_endpoint(state, instance, members)
     _ = adopt_owner(state, instance)
     state
+  end
+
+  # Re-derive the DNAT entry endpoint from the ENTRY member's node-reported ip and
+  # force it into the instance, so the republish equals the pre-restart publish. The
+  # entry member is the instance's `entry_member`; its live ip comes from node truth
+  # (the member VMs the reconcile just indexed). vm_port = port_base + host_offset(ip,
+  # supernet), the exact derivation GroupManager.entry_vm_port uses. A missing entry
+  # member ip, an ip outside the supernet, or no pod_ip configured leaves the endpoint
+  # untouched (the fallback rebuild stands; adoption never publishes a bad endpoint).
+  defp adopt_entry_endpoint(state, instance, members) do
+    with entry_name when is_binary(entry_name) <- instance.entry_member,
+         %{ip: entry_ip} when is_binary(entry_ip) and entry_ip != "" <-
+           Enum.find(members, &(&1.member_name == entry_name)),
+         {:ok, offset} <- host_offset(state.supernet, entry_ip),
+         pod_ip when is_binary(pod_ip) and pod_ip != "" <- state.pod_ip || entry_ip do
+      vm_port = state.port_base + offset
+
+      if vm_port >= 1 and vm_port <= 65_535 do
+        GroupStore.adopt_endpoint(state.store, instance.instance_id, pod_ip, vm_port)
+      else
+        :ok
+      end
+    else
+      _ -> :ok
+    end
   end
 
   defp heal_to_banked(state, %{state: :banked}), do: state
@@ -557,6 +596,45 @@ defmodule Embervm.GroupWakeManager do
   end
 
   defp schedule(_msg, _interval), do: :ok
+
+  # Read a shared group default (supernet / port_base / pod_ip) from the app-env the
+  # GroupManager.Supervisor also reads, so adoption's DNAT re-derivation uses the SAME
+  # values the live publish did. Tests inject these directly via opts.
+  defp group_default(key, fallback) do
+    :embervm
+    |> Application.get_env(:group_manager_defaults, [])
+    |> Keyword.get(key, fallback)
+  end
+
+  # host_offset within the supernet: the ip's host part masked by the supernet prefix,
+  # the EXACT derivation GroupManager.host_offset uses (kept in lockstep with noded's
+  # serving/net.go). v1 supernets are /16, so the offset is (third_octet << 8) |
+  # fourth_octet. Errors when the ip is not inside the supernet.
+  defp host_offset(supernet_cidr, ip) do
+    with [net, prefix_str] <- String.split(supernet_cidr, "/"),
+         {prefix, ""} <- Integer.parse(prefix_str),
+         {:ok, net_int} <- ip_to_int(net),
+         {:ok, ip_int} <- ip_to_int(ip) do
+      mask = mask_for(prefix)
+
+      if band(net_int, mask) == band(ip_int, mask) do
+        {:ok, ip_int |> band(bnot(mask)) |> band(0xFFFFFFFF)}
+      else
+        {:error, {:ip_outside_supernet, ip, supernet_cidr}}
+      end
+    else
+      _ -> {:error, {:bad_supernet, supernet_cidr, ip}}
+    end
+  end
+
+  defp ip_to_int(ip) do
+    case ip |> String.split(".") |> Enum.map(&Integer.parse/1) do
+      [{a, ""}, {b, ""}, {c, ""}, {d, ""}] -> {:ok, bsl(a, 24) + bsl(b, 16) + bsl(c, 8) + d}
+      _ -> :error
+    end
+  end
+
+  defp mask_for(prefix), do: band(bsl(0xFFFFFFFF, 32 - prefix), 0xFFFFFFFF)
 
   defp default_clock, do: System.system_time(:millisecond)
 end

--- a/projects/embervm/control/lib/embervm/group_wake_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_wake_manager.ex
@@ -1,0 +1,562 @@
+defmodule Embervm.GroupWakeManager do
+  @moduledoc """
+  The composite-group wake brain (R5, Task 7): the group counterpart of
+  `Embervm.StatefulManager`, and this rung's headline verb. An inbound TCP
+  connection to a sleeping (banked, or never-yet-booted) composite workload arrives
+  at `Embervm.TcpActivator`, which resolves the workload from the LOCAL accept port
+  (the entry listener port IS the workload identity at L4, decision 5) and calls
+  `wake/3` here. This module SINGLE-FLIGHTS the wake, publishes the fresh entry
+  endpoint via `Embervm.EndpointPublisher`, and hands the woken `{ip, port}` back to
+  every parked connection so the activator splices bytes to the group's entry
+  member. Every SUBSEQUENT connection reaches the entry member node-Envoy-direct
+  with zero control-plane involvement (the same off-hit-path shape as serving +
+  stateful).
+
+  ## why a separate single-flight brain, not the per-instance GroupManager
+
+  `Embervm.GroupManager` is ONE process per LIVE group instance (its ordered
+  create/relight/bank sequence is heavy per-instance work). But the SINGLE-FLIGHT
+  of a wake burst is a per-WORKLOAD concern: N concurrent connections to a banked
+  workload must produce exactly ONE relight sequence and N spliced sessions. So the
+  single-flight lives HERE (one process, a `waking` map keyed by workload, exactly
+  `StatefulManager.waking`), and the heavy per-instance relight/create sequence is
+  delegated to a GroupManager child the wake spawns (via
+  `Embervm.GroupManager.Supervisor`). The first connection kicks one wake worker;
+  every concurrent connection parks; when the wake completes, every parked caller is
+  resolved to the same entry endpoint.
+
+  ## relight vs create vs fresh (decision 3 + decision 8)
+
+  The wake DECISION reads GroupStore facts purely (ETS reads only, mirroring
+  `StatefulManager.plan_wake/2`):
+
+    * a BANKED instance with a COMPLETE set (a bundle for every member) RELIGHTS:
+      the GroupManager child resumes the whole snapshot set in role order. ANY
+      member relight failure (including the clock-resync FAILED_PRECONDITION,
+      decision 7) aborts the relight, evicts the set, and falls back to a full
+      FRESH boot INSIDE THE SAME single-flight (`group_fresh_booted{reason}`), with
+      the parked connection held across the fallback up to `wakeTimeoutSeconds`
+      (the caller blocks on the one wake worker the whole time);
+    * a BANKED instance with a PARTIAL set FRESH-BOOTS straight away (the set can
+      never relight whole); the partial set is evicted eagerly on the NodeStatus
+      sweep (`evict_partial_sets`), so by wake time a partial banked instance has
+      already had its `set_id` cleared and is treated as no-set;
+    * NO instance at all (scale-to-zero from birth, or a destroyed/evicted-then-
+      swept instance) is a full group CREATE (CreateGroupNetwork + role-ordered
+      fresh start), the Task 6 create path unchanged.
+
+  All three recover through the SAME connection path (decision 8: for the life of
+  the CR, the activator is the fallback), single-flighted so N connections yield one
+  wake sequence.
+
+  ## restart adoption (the #3517 lesson, generalized to a set)
+
+  `reconcile/1` (boot + periodic timer) reconciles the `GroupStore` projection
+  against every node's reported `group_networks` + `group_member_vms` +
+  `group_bundle_sets` (mirrors `StatefulManager.reconcile/1`, adapted for the
+  set-shaped, network-anchored composite):
+
+    * an instance whose members are node-reported LIVE (by vm_id) is a live group:
+      `adopt_state(:running)` + rebind each member's endpoint/health from node
+      truth, respawn its GroupManager child so a later bank/relight has an owner,
+      and re-derive the entry endpoint. A control-plane restart with a live group
+      therefore republishes the IDENTICAL endpoint WITHOUT touching any VM;
+    * an instance with NO live members but a node-reported COMPLETE bundle set heals
+      to `:banked` (the set survived the CP restart);
+    * an instance with NO live members and NO (or a PARTIAL) bundle set, whose node
+      is still reporting, is a daemon-restart casualty: resolved to fresh-bootable
+      (its set is evicted, it stays a banked-with-no-set row the next wake fresh-
+      boots) rather than failed;
+    * `banking`/`relighting`/`fresh_booting` LIMBO is healed the same way (from node
+      truth, not the durable log, which never recorded the transient state);
+    * PARTIAL sets are evicted eagerly (`GroupStore.evict_partial_sets/2`) from the
+      same node-reported bundle-set facts every sweep.
+
+  An in-flight wake for a workload is left untouched by a periodic reconcile
+  (mirroring `StatefulManager.adopt_one/4`'s `waking` guard): the wake owns that
+  workload's transition. After every reconcile pass, `EndpointPublisher.publish/1`
+  re-derives the L4 fan-out so a control-plane restart with a live group
+  republishes the identical entry endpoint.
+  """
+
+  use GenServer
+  require Logger
+
+  alias Embervm.{EndpointPublisher, GroupManager, GroupState, GroupStore, NodeCapacity, WorkloadCatalog}
+
+  # Wake-rate + parked-cap defaults mirror the R4 stateful values (a composite group
+  # is a group-level singleton owned by one principal, so per-workload == per-
+  # principal, same reasoning as StatefulManager).
+  @default_wake_max 10
+  @default_wake_window_ms 60_000
+  @default_park_cap 16
+
+  # -- Client API ------------------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc """
+  Handles one activator connect for a composite `workload` on behalf of `principal`
+  (the workload's synthesized owner). Blocks (`:infinity`) until the group is woken
+  and returns `{:ok, %{ip, port}}` for the `Embervm.TcpActivator` to splice the
+  parked connection to, OR a denial (`{:error, {:wake_rate, _}}`,
+  `{:error, {:park_full, _}}`, `{:error, {:wake_failed, r}}`, or
+  `{:error, {:unknown_workload}}`). N concurrent connections for one workload
+  produce exactly ONE wake sequence and N resolved callers (single-flight).
+  """
+  @spec wake(GenServer.server(), String.t(), String.t()) :: {:ok, map()} | {:error, term()}
+  def wake(server \\ __MODULE__, workload, principal) do
+    GenServer.call(server, {:wake, workload, principal}, :infinity)
+  end
+
+  @doc """
+  Runs one adoption reconcile synchronously (boot continue + periodic sweep run the
+  same code) and returns after it completes. Reconciles the GroupStore projection
+  against every node's reported group inventory (live members, bundle sets,
+  networks), evicts partial sets, re-derives + re-pushes the L4 fan-out. Tests drive
+  adoption deterministically through this.
+  """
+  @spec reconcile(GenServer.server()) :: :ok
+  def reconcile(server \\ __MODULE__) do
+    GenServer.call(server, :reconcile, :infinity)
+  end
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    state = %{
+      store: Keyword.get(opts, :store, GroupStore),
+      publisher: Keyword.get(opts, :publisher, EndpointPublisher),
+      capacity_table: Keyword.get(opts, :capacity_table, NodeCapacity.table()),
+      catalog_table: Keyword.get(opts, :catalog_table, WorkloadCatalog.table()),
+      clock: Keyword.get(opts, :clock, &default_clock/0),
+      tenant: Keyword.get(opts, :tenant, "homelab"),
+      # The create + relight-wake entrypoints. Injected in tests as a fake module
+      # implementing create_group/2 + wake_group/1 (or a per-workload scripted fake).
+      # Production drives Embervm.GroupManager.Supervisor.
+      supervisor_mod: Keyword.get(opts, :supervisor_mod, GroupManager.Supervisor),
+      # workload -> [{from, principal}] parked behind an in-flight wake (single-flight).
+      waking: %{},
+      # principal -> [wake timestamps within the window] (sliding-window rate limit).
+      wake_events: %{},
+      wake_max: Keyword.get(opts, :wake_max, @default_wake_max),
+      wake_window_ms: Keyword.get(opts, :wake_window_ms, @default_wake_window_ms),
+      park_cap: Keyword.get(opts, :park_cap, @default_park_cap),
+      reconcile_interval_ms: Keyword.get(opts, :reconcile_interval_ms, 0)
+    }
+
+    if state.reconcile_interval_ms > 0 do
+      {:ok, state, {:continue, :boot}}
+    else
+      {:ok, state}
+    end
+  end
+
+  @impl true
+  def handle_continue(:boot, state) do
+    state = do_reconcile(state)
+    schedule(:reconcile, state.reconcile_interval_ms)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_call({:wake, workload, principal}, from, state) do
+    handle_wake(state, workload, principal, from)
+  end
+
+  def handle_call(:reconcile, _from, state) do
+    {:reply, :ok, do_reconcile(state)}
+  end
+
+  # The async wake worker finished: resolve every parked caller for the workload.
+  @impl true
+  def handle_info({:wake_done, workload, outcome}, state) do
+    {:noreply, finish_wake(state, workload, outcome)}
+  end
+
+  def handle_info(:reconcile, state) do
+    state = do_reconcile(state)
+    schedule(:reconcile, state.reconcile_interval_ms)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # -- wake handling ---------------------------------------------------------
+
+  defp handle_wake(state, workload, principal, from) do
+    # Straggler: the group came up between the node Envoy's miss and this call (a
+    # race with a just-published wake). Resolve to the live entry endpoint directly.
+    case GroupStore.entry_endpoint(state.store, workload) do
+      %{ip: ip, port: port} when is_binary(ip) and ip != "" and is_integer(port) ->
+        {:reply, {:ok, %{ip: ip, port: port}}, state}
+
+      _ ->
+        handle_cold_wake(state, workload, principal, from)
+    end
+  end
+
+  defp handle_cold_wake(state, workload, principal, from) do
+    cond do
+      not composite_workload?(state, workload) ->
+        {:reply, {:error, {:unknown_workload}}, state}
+
+      # Already a wake in flight for this workload: park behind it (single-flight),
+      # subject to the parked-connection cap.
+      Map.has_key?(state.waking, workload) ->
+        park_behind_wake(state, workload, principal, from)
+
+      # First miss: apply the per-workload wake-rate limit, then park + kick ONE
+      # wake worker.
+      wake_allowed?(state, principal) ->
+        state = record_wake(state, principal)
+        state = %{state | waking: Map.put(state.waking, workload, [{from, principal}])}
+        {:noreply, start_wake(state, workload)}
+
+      true ->
+        audit_denial(principal, workload, :wake_rate)
+        {:reply, {:error, {:wake_rate, "per-workload wake-rate limit exceeded"}}, state}
+    end
+  end
+
+  defp park_behind_wake(state, workload, principal, from) do
+    waiters = Map.get(state.waking, workload, [])
+
+    if length(waiters) >= state.park_cap do
+      audit_denial(principal, workload, :park_full)
+      {:reply, {:error, {:park_full, "parked-connection cap exceeded for workload"}}, state}
+    else
+      {:noreply, %{state | waking: Map.put(state.waking, workload, waiters ++ [{from, principal}])}}
+    end
+  end
+
+  # -- wake worker -----------------------------------------------------------
+
+  # Kick ONE async wake for a workload. The relight-vs-create DECISION is read HERE
+  # (a pure GroupStore fact read); the heavy sequence (relight or create) runs in a
+  # spawned worker so a multi-second group boot never head-of-line-blocks another
+  # workload's wake. The worker ALWAYS reports a {:wake_done}, even if it crashes, so
+  # a parked :infinity caller never blocks forever.
+  defp start_wake(state, workload) do
+    owner = self()
+    plan = plan_wake(state, workload)
+
+    spawn_wake(owner, workload, fn -> run_wake(state, workload, plan) end)
+    state
+  end
+
+  defp spawn_wake(owner, workload, fun) do
+    spawn(fn ->
+      outcome =
+        try do
+          fun.()
+        rescue
+          e -> {:error, {:wake_crashed, e}}
+        catch
+          kind, reason -> {:error, {:wake_crashed, {kind, reason}}}
+        end
+
+      send(owner, {:wake_done, workload, outcome})
+    end)
+  end
+
+  # PURE (GroupStore reads only): a banked instance whose set is COMPLETE (its set_id
+  # is still stamped, meaning the eager partial-set sweep did not clear it) relights;
+  # a banked instance with NO set_id (a partial set the sweep evicted, or a fresh-
+  # bootable casualty) fresh-boots; NO instance at all creates.
+  defp plan_wake(state, workload) do
+    case banked_instance(state, workload) do
+      nil -> :create
+      %{instance_id: instance_id, set_id: set_id} when is_binary(set_id) and set_id != "" -> {:relight, instance_id}
+      %{instance_id: instance_id} -> {:fresh, instance_id}
+    end
+  end
+
+  # Drive the actual wake sequence in the worker. For a relight/fresh the wake spawns
+  # a GroupManager child bound to the EXISTING banked instance and calls wake_group/1
+  # (which relights, or on any member failure evicts + fresh-boots in the SAME call,
+  # holding the caller). For a create it drives the Task 6 create path unchanged.
+  defp run_wake(state, workload, plan) do
+    case plan do
+      :create ->
+        case state.supervisor_mod.create_group(workload) do
+          {:ok, endpoint} -> {:ok, endpoint}
+          {:error, reason} -> {:error, {:wake_failed, reason}}
+        end
+
+      {:relight, instance_id} ->
+        run_group_wake(state, workload, instance_id)
+
+      {:fresh, instance_id} ->
+        run_group_wake(state, workload, instance_id)
+    end
+  end
+
+  # Spawn (or reuse) the GroupManager child for the banked instance and drive its
+  # wake_group sequence. wake_group returns {:ok, endpoint, outcome} (relit or fresh-
+  # fallback) or {:error, reason}. The child is bound in the supervisor under the
+  # workload registry key, so a concurrent wake worker cannot spawn a second.
+  defp run_group_wake(state, workload, instance_id) do
+    case state.supervisor_mod.wake_group(workload, instance_id) do
+      {:ok, endpoint, _outcome} -> {:ok, endpoint}
+      {:ok, endpoint} -> {:ok, endpoint}
+      {:error, reason} -> {:error, {:wake_failed, reason}}
+    end
+  end
+
+  # -- finish wake (serialized) ----------------------------------------------
+
+  defp finish_wake(state, workload, outcome) do
+    {waiters, state} = pop_waiters(state, workload)
+
+    reply =
+      case outcome do
+        {:ok, %{ip: _ip, port: _port} = endpoint} -> {:ok, endpoint}
+        {:error, {:wake_failed, _} = reason} -> {:error, reason}
+        {:error, reason} -> {:error, {:wake_failed, reason}}
+      end
+
+    case reply do
+      {:ok, _} ->
+        Logger.info("embervm group woken", workload: workload)
+
+      {:error, reason} ->
+        Logger.warning("embervm group wake failed", workload: workload, reason: inspect(reason))
+    end
+
+    # The publish already happened inside the GroupManager wake sequence; re-derive
+    # once more here so a straggler that connects right after resolves cleanly.
+    EndpointPublisher.publish(state.publisher)
+    reply_all(waiters, reply)
+    state
+  end
+
+  defp pop_waiters(state, workload) do
+    waiters = Map.get(state.waking, workload, [])
+    {waiters, %{state | waking: Map.delete(state.waking, workload)}}
+  end
+
+  defp reply_all(waiters, reply) do
+    for {from, _principal} <- waiters, do: GenServer.reply(from, reply)
+    :ok
+  end
+
+  # -- adoption --------------------------------------------------------------
+
+  # Reconcile the GroupStore projection against every node's reported group
+  # inventory, evict partial sets, then re-derive + re-push. Mirrors
+  # StatefulManager.do_reconcile/1; see the moduledoc's adoption section.
+  defp do_reconcile(state) do
+    facts = NodeCapacity.all(state.capacity_table)
+    live_members = index_group_members(facts)
+    bundle_sets = index_group_bundle_sets(facts)
+
+    state =
+      GroupStore.all(state.store)
+      |> Enum.reject(&GroupState.terminal?(&1.state))
+      |> Enum.reduce(state, fn instance, acc ->
+        adopt_one(acc, instance, live_members, bundle_sets)
+      end)
+
+    # Evict PARTIAL banked sets eagerly from the node-reported bundle-set inventory
+    # (the primitive Task 6 built): for every banked instance the node reports a set
+    # for, is every member's bundle present? A missing member clears the set_id so
+    # the next wake fresh-boots.
+    reported_sets = reported_member_sets(bundle_sets)
+    _ = GroupStore.evict_partial_sets(state.store, reported_sets)
+
+    EndpointPublisher.publish(state.publisher)
+    state
+  end
+
+  # instance_id -> [%{member_name, vm_id, ip, healthy}] of the node-reported LIVE
+  # member VMs for that group.
+  defp index_group_members(facts) do
+    for f <- facts, m <- Map.get(f, :group_member_vms, []) || [], reduce: %{} do
+      acc ->
+        entry = %{
+          node_id: f.configured_id,
+          member_name: m.member_name,
+          vm_id: m.vm_id,
+          ip: m.ip,
+          healthy: Map.get(m, :healthy, true)
+        }
+
+        Map.update(acc, m.group_instance_id, [entry], &[entry | &1])
+    end
+  end
+
+  # instance_id -> %{set_id, members: MapSet of member_names} of the node-reported
+  # bundle set for that group (the daemon reports refs grouped by set dir; it makes
+  # no completeness judgment, the CP does).
+  defp index_group_bundle_sets(facts) do
+    for f <- facts, s <- Map.get(f, :group_bundle_sets, []) || [], into: %{} do
+      names = for member <- Map.get(s, :members, []) || [], into: MapSet.new(), do: member.member_name
+      {s.group_instance_id, %{set_id: s.set_id, members: names, node_id: f.configured_id}}
+    end
+  end
+
+  # The {instance_id -> MapSet of member_names} shape GroupStore.evict_partial_sets/2
+  # consumes (a banked instance ABSENT here reports no set -> partial -> evicted).
+  defp reported_member_sets(bundle_sets) do
+    Map.new(bundle_sets, fn {instance_id, %{members: names}} -> {instance_id, names} end)
+  end
+
+  defp adopt_one(state, instance, live_members, bundle_sets) do
+    cond do
+      # An in-flight wake owns the workload's transition; never touch it.
+      Map.has_key?(state.waking, instance.workload) ->
+        state
+
+      # Live members reported for this instance -> a live group: adopt to running,
+      # rebind member endpoints/health, respawn the GroupManager owner, re-derive
+      # the entry endpoint. Never touches a VM.
+      Map.has_key?(live_members, instance.instance_id) ->
+        adopt_live(state, instance, Map.fetch!(live_members, instance.instance_id))
+
+      # No live members, but a COMPLETE reported bundle set -> heal to banked.
+      complete_set?(state, instance, bundle_sets) ->
+        heal_to_banked(state, instance)
+
+      # No live members and no complete set, but the instance's node is still
+      # reporting -> a daemon-restart casualty: resolve to fresh-bootable (evict any
+      # stale set, leave the banked-with-no-set row the next wake fresh-boots).
+      node_reporting?(state, instance.node_id) ->
+        resolve_casualty(state, instance)
+
+      true ->
+        state
+    end
+  end
+
+  # Adopt a node-reported live group WITHOUT touching a VM: force the ETS state to
+  # running, rebind every reported member's live facts + health, respawn the
+  # GroupManager owner in the adopted state, and re-derive the entry endpoint from
+  # the entry member's node-reported ip (the CP-derived DNAT port stays authoritative
+  # for the published endpoint; adoption keeps the SAME entry endpoint the pre-restart
+  # publish recorded, so the republish is identical).
+  defp adopt_live(state, instance, members) do
+    GroupStore.adopt_state(state.store, instance.instance_id, :running)
+
+    for m <- members do
+      _ = GroupStore.set_member_health(state.store, instance.instance_id, m.member_name, m.healthy)
+    end
+
+    _ = adopt_owner(state, instance)
+    state
+  end
+
+  defp heal_to_banked(state, %{state: :banked}), do: state
+
+  defp heal_to_banked(state, instance) do
+    GroupStore.adopt_state(state.store, instance.instance_id, :banked)
+    Logger.info("embervm group adopted (banked)", instance_id: instance.instance_id)
+    state
+  end
+
+  # A daemon-restart casualty (no live members, no complete set): its warmth is gone.
+  # Evict any stale set so its set_id is cleared, and adopt it to banked-with-no-set
+  # (the next wake fresh-boots). We do NOT fail it: a composite instance with no VMs
+  # and no set is exactly a scale-to-zero group awaiting a fresh wake, not a terminal
+  # failure (banked cannot fail; the group is recoverable through the connection path).
+  defp resolve_casualty(state, %{state: :banked, set_id: nil}), do: state
+
+  defp resolve_casualty(state, instance) do
+    _ = GroupStore.evict_set(state.store, instance.instance_id, "adoption_casualty")
+    GroupStore.adopt_state(state.store, instance.instance_id, :banked)
+    Logger.info("embervm group adopted (fresh-bootable casualty)", instance_id: instance.instance_id)
+    state
+  end
+
+  # Respawn the GroupManager owner for an adopted-live instance so a later
+  # bank/relight has a process. Best-effort: a supervisor without an adopt seam (the
+  # test fakes) is a clean no-op. The child is bound under the workload registry key,
+  # so a second reconcile finds it already-started and leaves it.
+  defp adopt_owner(state, instance) do
+    if function_exported?(state.supervisor_mod, :adopt_group, 2) do
+      state.supervisor_mod.adopt_group(instance.workload, instance.instance_id)
+    else
+      :ok
+    end
+  end
+
+  # A banked set is COMPLETE iff the node reports a bundle for every member the group
+  # expects (each member row's name present in the reported set).
+  defp complete_set?(state, instance, bundle_sets) do
+    case Map.get(bundle_sets, instance.instance_id) do
+      %{members: reported} ->
+        expected = expected_member_names(state, instance)
+        expected != MapSet.new() and MapSet.subset?(expected, reported)
+
+      _ ->
+        false
+    end
+  end
+
+  defp expected_member_names(state, instance) do
+    for m <- GroupStore.members(state.store, instance.instance_id),
+        into: MapSet.new(),
+        do: m.member_name
+  end
+
+  defp node_reporting?(state, node_id) when is_binary(node_id) do
+    match?({:ok, _}, NodeCapacity.fetch(state.capacity_table, node_id))
+  end
+
+  defp node_reporting?(_state, _node_id), do: false
+
+  # -- wake-rate limit -------------------------------------------------------
+
+  defp wake_allowed?(%{wake_max: max}, _principal) when not is_integer(max) or max <= 0, do: true
+
+  defp wake_allowed?(state, principal) do
+    now = state.clock.()
+    length(recent_wakes(state, principal, now)) < state.wake_max
+  end
+
+  defp record_wake(state, principal) do
+    now = state.clock.()
+    recent = recent_wakes(state, principal, now)
+    %{state | wake_events: Map.put(state.wake_events, principal, [now | recent])}
+  end
+
+  defp recent_wakes(state, principal, now) do
+    cutoff = now - state.wake_window_ms
+
+    state.wake_events
+    |> Map.get(principal, [])
+    |> Enum.filter(&(&1 > cutoff))
+  end
+
+  # -- catalog helpers -------------------------------------------------------
+
+  defp composite_workload?(state, workload) do
+    match?({:ok, %{class: "composite"}}, WorkloadCatalog.fetch(state.catalog_table, workload))
+  end
+
+  defp banked_instance(state, workload) do
+    GroupStore.list(state.store, workload)
+    |> Enum.find(&(&1.state == :banked))
+  end
+
+  # -- misc ------------------------------------------------------------------
+
+  defp audit_denial(principal, workload, reason) do
+    Embervm.Metering.record_denial(principal, workload, reason)
+  end
+
+  defp schedule(msg, interval_ms) when interval_ms > 0 do
+    Process.send_after(self(), msg, interval_ms)
+  end
+
+  defp schedule(_msg, _interval), do: :ok
+
+  defp default_clock, do: System.system_time(:millisecond)
+end

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -68,6 +68,9 @@ defmodule Embervm.NodeRegistry do
   alias Embervm.NodeCapacity
 
   alias Embervm.Node.V1.{
+    GroupBundleSet,
+    GroupMemberVm,
+    GroupNetwork,
     NodeService,
     NodeStatus,
     ServingSnapshot,
@@ -441,9 +444,60 @@ defmodule Embervm.NodeRegistry do
       # (wire-compatible), which reads as "no stateful state on this node".
       stateful_vms: stateful_vms_from_status(s),
       stateful_bundles: stateful_bundles_from_status(s),
-      volumes: volumes_from_status(s)
+      volumes: volumes_from_status(s),
+      # Composite-group facts (R5, additive): the node's per-group bridges, LIVE
+      # member VMs (with the daemon's health verdict), and banked bundle-set
+      # inventory. These are the source of truth Embervm.GroupWakeManager's adoption
+      # reconcile heals its ETS residency + set-completeness view against on boot and
+      # every sweep, mirroring the stateful facts above. Empty when a daemon never
+      # sets them (wire-compatible), which reads as "no group state on this node".
+      group_networks: group_networks_from_status(s),
+      group_member_vms: group_member_vms_from_status(s),
+      group_bundle_sets: group_bundle_sets_from_status(s)
     }
   end
+
+  defp group_networks_from_status(%NodeStatus{group_networks: nets}) when is_list(nets) do
+    for %GroupNetwork{} = n <- nets do
+      %{
+        group_instance_id: n.group_instance_id,
+        cidr: n.cidr,
+        bridge: n.bridge,
+        member_count: n.member_count
+      }
+    end
+  end
+
+  defp group_networks_from_status(_s), do: []
+
+  defp group_member_vms_from_status(%NodeStatus{group_member_vms: vms}) when is_list(vms) do
+    for %GroupMemberVm{} = v <- vms do
+      %{
+        vm_id: v.vm_id,
+        group_instance_id: v.group_instance_id,
+        member_name: v.member_name,
+        ip: v.ip,
+        healthy: v.healthy,
+        last_probe_unix_ms: v.last_probe_unix_ms
+      }
+    end
+  end
+
+  defp group_member_vms_from_status(_s), do: []
+
+  defp group_bundle_sets_from_status(%NodeStatus{group_bundle_sets: sets}) when is_list(sets) do
+    for %GroupBundleSet{} = s <- sets do
+      %{
+        set_id: s.set_id,
+        group_instance_id: s.group_instance_id,
+        created_at_unix_ms: s.created_at_unix_ms,
+        members:
+          for(m <- s.members || [], do: %{member_name: m.member_name, snapshot_ref: m.snapshot_ref, size_bytes: m.size_bytes})
+      }
+    end
+  end
+
+  defp group_bundle_sets_from_status(_s), do: []
 
   defp serving_vms_from_status(%NodeStatus{serving_vms: vms}) when is_list(vms) do
     for %ServingVm{} = v <- vms do

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -153,6 +153,12 @@ defmodule Embervm.Router do
     handle_delete_stateful_volume(conn, name)
   end
 
+  # -- composite (group) routes (R5, management introspection) ---------------
+
+  get "/v1/groups/:name" do
+    handle_get_group(conn, name)
+  end
+
   # The activator fallback (R3, Task 8): the catch-all is the front-end the node
   # Envoy routes a MISS to (the fallback endpoint of an empty serve|<workload>
   # cluster). It is identified by the `x-ember-workload` request header the serving
@@ -1008,6 +1014,104 @@ defmodule Embervm.Router do
 
   defp stateful_manager, do: Application.get_env(:embervm, :stateful_manager_mod, Embervm.StatefulManager)
   defp stateful_manager_server, do: Application.get_env(:embervm, :stateful_manager, Embervm.StatefulManager)
+
+  # GET /v1/groups/:name (management auth): the composite group's instance state,
+  # members with health, set id + completeness (the banked set_id, null when nothing
+  # is banked), subnet, and published entry endpoint. Mirrors handle_get_stateful/2's
+  # primary-instance selection.
+  defp handle_get_group(conn, workload) do
+    if group_workload?(workload) do
+      instances = group_store().list(group_store_server(), workload)
+      primary = primary_group_instance(instances)
+      banked = Enum.find(instances, &(&1.state == :banked))
+
+      members =
+        if primary do
+          group_store().members(group_store_server(), primary.instance_id)
+          |> Enum.map(&group_member_view/1)
+        else
+          []
+        end
+
+      send_json(
+        conn,
+        200,
+        json_nullify(%{
+          workload: workload,
+          instance: primary && group_instance_view(primary),
+          state: primary && to_string(primary.state),
+          members: members,
+          # The banked bundle-set handle (the whole-set warmth key), null if nothing
+          # is banked; its presence means a complete set is banked (a partial set is
+          # eagerly evicted, clearing set_id).
+          set_id: (primary && primary.set_id) || (banked && banked.set_id),
+          subnet_cidr: primary && primary.subnet_cidr,
+          degraded_member: primary && primary.degraded_member,
+          published_endpoint: group_store().entry_endpoint(group_store_server(), workload)
+        })
+      )
+    else
+      send_json(conn, 404, %{error: "unknown composite workload", workload: workload, retryable: false})
+    end
+  end
+
+  # The instance the GET's top-level fields describe: the live one (at most one by the
+  # group-level singleton invariant), else the banked one, else the newest row.
+  defp primary_group_instance(instances) do
+    live_states = [:creating, :running, :banking, :relighting, :fresh_booting]
+
+    Enum.find(instances, &(&1.state in live_states)) ||
+      Enum.find(instances, &(&1.state == :banked)) ||
+      List.first(instances)
+  end
+
+  defp group_instance_view(instance) do
+    %{
+      instance_id: instance.instance_id,
+      workload: instance.workload,
+      state: to_string(instance.state),
+      node_id: instance.node_id,
+      subnet_cidr: instance.subnet_cidr,
+      entry_member: instance.entry_member,
+      entry_port: instance.entry_port,
+      listen_port: instance.listen_port,
+      set_id: instance.set_id,
+      degraded_member: instance.degraded_member,
+      entry_ip: instance.entry_ip,
+      entry_port_published: instance.entry_port_published,
+      created_at: instance.created_at,
+      last_active_at: instance.last_active_at,
+      updated_at: instance.updated_at,
+      terminal_reason: instance.terminal_reason
+    }
+  end
+
+  defp group_member_view(member) do
+    %{
+      member_name: member.member_name,
+      member_index: member.member_index,
+      state: member.state,
+      healthy: member.healthy,
+      vm_id: member.vm_id,
+      ip: member.ip,
+      snapshot_ref: member.snapshot_ref
+    }
+  end
+
+  # Whether `workload` is a COMPOSITE-class workload in the catalog. Resolves the
+  # catalog module + table from app-env so a request test can inject a fake.
+  defp group_workload?(workload) do
+    mod = Application.get_env(:embervm, :workload_catalog_mod, Embervm.WorkloadCatalog)
+    table = Application.get_env(:embervm, :workload_catalog_table, Embervm.WorkloadCatalog.table())
+
+    case mod.fetch(table, workload) do
+      {:ok, %{class: "composite"}} -> true
+      _ -> false
+    end
+  end
+
+  defp group_store, do: Application.get_env(:embervm, :group_store_mod, Embervm.GroupStore)
+  defp group_store_server, do: Application.get_env(:embervm, :group_store, Embervm.GroupStore)
 
   defp serving_sweeper, do: Application.get_env(:embervm, :serving_sweeper_mod, Embervm.ServingSweeper)
   defp serving_sweeper_server, do: Application.get_env(:embervm, :serving_sweeper, Embervm.ServingSweeper)

--- a/projects/embervm/control/lib/embervm/tcp_activator.ex
+++ b/projects/embervm/control/lib/embervm/tcp_activator.ex
@@ -119,13 +119,23 @@ defmodule Embervm.TcpActivator do
   def init(opts) do
     state = %{
       port_range: Keyword.get(opts, :port_range, []),
-      # The stateful manager to call on a miss. Injectable for tests (a fake
+      # The stateful manager to call on a stateful miss. Injectable for tests (a fake
       # module/pid implementing wake/3).
       manager: Keyword.get(opts, :manager, Embervm.StatefulManager),
       manager_mod: Keyword.get(opts, :manager_mod, Embervm.StatefulManager),
       catalog_table: Keyword.get(opts, :catalog_table, Embervm.WorkloadCatalog.table()),
       store: Keyword.get(opts, :store, Embervm.StatefulStore),
       store_mod: Keyword.get(opts, :store_mod, Embervm.StatefulStore),
+      # The composite-group wake brain to call on a group miss (R5, Task 7): a
+      # connection accepted on a composite entry.listenPort resolves the workload by
+      # the SAME local-accept-port mechanism as stateful (decision 5), then wakes the
+      # GROUP (relight-or-create single-flighted there) instead of the stateful VM.
+      # Injectable for tests (a fake module implementing wake/3). group_store_mod is
+      # read purely for the straggler check (a group whose entry is already live).
+      group_manager: Keyword.get(opts, :group_manager, Embervm.GroupWakeManager),
+      group_manager_mod: Keyword.get(opts, :group_manager_mod, Embervm.GroupWakeManager),
+      group_store: Keyword.get(opts, :group_store, Embervm.GroupStore),
+      group_store_mod: Keyword.get(opts, :group_store_mod, Embervm.GroupStore),
       # The dial seam for the upstream (woken VM) connection, injectable for
       # tests. Production dials plain gen_tcp. Arity-3: (ip, port,
       # connect_timeout_ms) -> {:ok, socket} | {:error, reason}.
@@ -214,23 +224,28 @@ defmodule Embervm.TcpActivator do
   defp handle_connection(csock, port, ctx) do
     case workload_for_port(ctx, port) do
       nil ->
-        Logger.warning("embervm tcp activator: no stateful workload owns port #{port}; closing")
+        Logger.warning("embervm tcp activator: no stateful/composite workload owns port #{port}; closing")
         :gen_tcp.close(csock)
 
-      workload ->
-        route_connection(csock, workload, ctx)
+      {class, workload} ->
+        route_connection(csock, class, workload, ctx)
     end
   end
 
-  defp route_connection(csock, workload, ctx) do
-    case ctx.store_mod.published_endpoint(ctx.store, workload) do
+  # The straggler check + wake dispatch is CLASS-parameterized: a stateful listener
+  # reads StatefulStore + StatefulManager, a composite listener reads GroupStore +
+  # GroupWakeManager. Both resolve the workload by the LOCAL ACCEPT PORT (decision 5)
+  # and single-flight the wake in their respective manager; the splice below is
+  # identical (opaque L4 bytes either way).
+  defp route_connection(csock, class, workload, ctx) do
+    case live_endpoint(ctx, class, workload) do
       %{ip: ip, port: vm_port} when is_binary(ip) and ip != "" and is_integer(vm_port) ->
-        # Straggler: the VM is already live (a race with the node Envoy's
+        # Straggler: the VM/group is already live (a race with the node Envoy's
         # fallback decision). Splice directly, no wake.
         splice_to(csock, workload, ip, vm_port, ctx)
 
       _ ->
-        wake_and_splice(csock, workload, ctx)
+        wake_and_splice(csock, class, workload, ctx)
     end
   rescue
     e ->
@@ -238,10 +253,18 @@ defmodule Embervm.TcpActivator do
       :gen_tcp.close(csock)
   end
 
-  defp wake_and_splice(csock, workload, ctx) do
-    principal = "system:stateful:#{workload}"
+  defp live_endpoint(ctx, :stateful, workload) do
+    ctx.store_mod.published_endpoint(ctx.store, workload)
+  end
 
-    case ctx.manager_mod.wake(ctx.manager, workload, principal) do
+  defp live_endpoint(ctx, :composite, workload) do
+    ctx.group_store_mod.entry_endpoint(ctx.group_store, workload)
+  end
+
+  defp wake_and_splice(csock, class, workload, ctx) do
+    {manager, manager_mod, principal} = wake_target(ctx, class, workload)
+
+    case manager_mod.wake(manager, workload, principal) do
       {:ok, %{ip: ip, port: vm_port}} ->
         splice_to(csock, workload, ip, vm_port, ctx)
 
@@ -250,6 +273,9 @@ defmodule Embervm.TcpActivator do
         :gen_tcp.close(csock)
     end
   end
+
+  defp wake_target(ctx, :stateful, workload), do: {ctx.manager, ctx.manager_mod, "system:stateful:#{workload}"}
+  defp wake_target(ctx, :composite, workload), do: {ctx.group_manager, ctx.group_manager_mod, "system:group:#{workload}"}
 
   defp splice_to(csock, workload, ip, vm_port, ctx) do
     case ctx.dial_fun.(ip, vm_port, ctx.connect_timeout_ms) do
@@ -359,11 +385,18 @@ defmodule Embervm.TcpActivator do
 
   # -- workload resolution ---------------------------------------------------
 
+  # Resolve the workload (and its CLASS) that owns the local accept `port`: a
+  # stateful workload by its `stateful.listen_port`, or a composite group by its
+  # `group.entry.listen_port` (the R4 stateful range 5400-5409 and the R5 composite
+  # range 5410-5419 are disjoint, and each workload's listen port is unique across
+  # both classes by the WorkloadWatcher's validation, so at most one match). Returns
+  # `{:stateful, name}` | `{:composite, name}` | nil.
   defp workload_for_port(ctx, port) do
     Embervm.WorkloadCatalog.all_names(ctx.catalog_table)
-    |> Enum.find(fn name ->
+    |> Enum.find_value(fn name ->
       case Embervm.WorkloadCatalog.fetch(ctx.catalog_table, name) do
-        {:ok, %{class: "stateful", stateful: %{listen_port: ^port}}} -> true
+        {:ok, %{class: "stateful", stateful: %{listen_port: ^port}}} -> {:stateful, name}
+        {:ok, %{class: "composite", group: %{entry: %{listen_port: ^port}}}} -> {:composite, name}
         _ -> false
       end
     end)

--- a/projects/embervm/control/test/embervm/endpoint_publisher_group_test.exs
+++ b/projects/embervm/control/test/embervm/endpoint_publisher_group_test.exs
@@ -1,0 +1,149 @@
+defmodule Embervm.EndpointPublisherGroupTest do
+  @moduledoc """
+  Pure-function tests for the R5 composite (L4) extension of Embervm.EndpointPublisher:
+  a composite-class workload renders a `group|<workload>` cluster + `group-<listen_port>`
+  listener whose endpoint is the live ENTRY member when running, the activator TCP
+  fallback otherwise (banked OR no instance, for the life of the CR), and NOTHING when
+  cold with no activator configured. The no-composite REGRESSION is asserted: a
+  serving-only render is byte-identical whether or not a GroupStore is wired, and the
+  document carries no `listeners` key.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.{EndpointPublisher, GroupStore, ServingStore, StatefulStore, WorkloadCatalog}
+  alias Embervm.OpLog.SQLite
+
+  defp start_stack(_opts \\ []) do
+    suffix = System.unique_integer([:positive])
+    cat_table = :"gpcat_#{suffix}"
+    WorkloadCatalog.create(cat_table)
+
+    path = Path.join(System.tmp_dir!(), "embervm_pubgroup_test_#{suffix}.db")
+    on_exit(fn -> File.rm_rf!(path) end)
+
+    {:ok, op_log} = SQLite.start_link(name: nil, path: path)
+    {:ok, serving_store} = ServingStore.start_link(name: nil, op_log: op_log, clock: fn -> 1_000 end)
+
+    {:ok, sf_counter} = Agent.start_link(fn -> 2_000 end)
+    {:ok, stateful_store} = StatefulStore.start_link(name: nil, op_log: op_log, clock: fn -> Agent.get_and_update(sf_counter, fn n -> {n, n + 1} end) end)
+
+    {:ok, g_counter} = Agent.start_link(fn -> 5_000 end)
+    {:ok, group_store} = GroupStore.start_link(name: nil, op_log: op_log, clock: fn -> Agent.get_and_update(g_counter, fn n -> {n, n + 1} end) end)
+
+    %{cat_table: cat_table, serving_store: serving_store, stateful_store: stateful_store, group_store: group_store}
+  end
+
+  defp build_ctx(stack, opts) do
+    %{
+      store: stack.serving_store,
+      stateful_store: stack.stateful_store,
+      group_store: stack.group_store,
+      catalog_table: stack.cat_table,
+      activator_endpoint: Keyword.get(opts, :activator_endpoint, %{ip: "10.1.1.1", port: 7000}),
+      activator_ip: Keyword.get(opts, :activator_ip, nil),
+      connect_timeout_ms: 1_000
+    }
+  end
+
+  defp composite_workload(stack, name, listen_port) do
+    WorkloadCatalog.upsert(stack.cat_table, name, %{
+      class: "composite",
+      group: %{entry: %{member: "leader", port: 8080, listen_port: listen_port}}
+    })
+  end
+
+  defp serving_workload(stack, name, host) do
+    WorkloadCatalog.upsert(stack.cat_table, name, %{class: "serving", serving: %{host: host, port: 8080}})
+  end
+
+  defp running_group(stack, instance_id, workload, entry_ip, entry_port) do
+    {:ok, _} =
+      GroupStore.create(stack.group_store, %{
+        instance_id: instance_id,
+        tenant: "homelab",
+        principal: "system:group:#{workload}",
+        workload: workload,
+        node_id: "node-4",
+        subnet_cidr: "10.101.0.0/24",
+        entry_member: "leader",
+        entry_port: 8080,
+        listen_port: entry_port,
+        secret: "s"
+      })
+
+    {:ok, _} = GroupStore.member_started(stack.group_store, instance_id, %{member_name: "leader", member_index: 0, vm_id: "vm-l", ip: "10.101.0.10"})
+    {:ok, _} = GroupStore.publish(stack.group_store, instance_id, entry_ip, entry_port)
+  end
+
+  test "a running composite workload renders group|<workload> cluster + group-<port> listener at the entry endpoint" do
+    stack = start_stack()
+    composite_workload(stack, "grp-a", 5410)
+    running_group(stack, "g-1", "grp-a", "10.0.0.9", 30_010)
+
+    ctx = build_ctx(stack, [])
+    desired = EndpointPublisher.desired_for_node(ctx, "v1")
+
+    cluster = Enum.find(desired.clusters, &(&1.name == "group|grp-a"))
+    assert cluster.endpoints == [%{ip: "10.0.0.9", port: 30_010}]
+
+    listener = Enum.find(desired.listeners, &(&1.name == "group-5410"))
+    assert listener.port == 5410
+    assert listener.cluster == "group|grp-a"
+  end
+
+  test "a cold composite workload with an activator_ip swaps in the activator TCP fallback at its OWN listen_port" do
+    stack = start_stack()
+    composite_workload(stack, "grp-a", 5411)
+    # No group instance at all (cold).
+
+    ctx = build_ctx(stack, activator_ip: "10.2.2.2")
+    desired = EndpointPublisher.desired_for_node(ctx, "v1")
+
+    cluster = Enum.find(desired.clusters, &(&1.name == "group|grp-a"))
+    # The activator fallback at the workload's OWN listen_port (5411), not a shared one.
+    assert cluster.endpoints == [%{ip: "10.2.2.2", port: 5411}]
+  end
+
+  test "a banked composite workload (no live entry) swaps in the activator fallback" do
+    stack = start_stack()
+    composite_workload(stack, "grp-a", 5412)
+    running_group(stack, "g-1", "grp-a", "10.0.0.9", 30_010)
+    {:ok, _} = GroupStore.mark(stack.group_store, "g-1", :bank)
+    {:ok, _} = GroupStore.bank_ready(stack.group_store, "g-1", "set-1", [%{name: "leader", snapshot_ref: "snap-l"}])
+
+    ctx = build_ctx(stack, activator_ip: "10.2.2.2")
+    desired = EndpointPublisher.desired_for_node(ctx, "v1")
+
+    cluster = Enum.find(desired.clusters, &(&1.name == "group|grp-a"))
+    assert cluster.endpoints == [%{ip: "10.2.2.2", port: 5412}]
+  end
+
+  test "a cold composite workload with NO activator_ip emits no cluster, no listener" do
+    stack = start_stack()
+    composite_workload(stack, "grp-a", 5413)
+
+    ctx = build_ctx(stack, activator_ip: nil)
+    desired = EndpointPublisher.desired_for_node(ctx, "v1")
+
+    refute Enum.any?(desired.clusters, &(&1.name == "group|grp-a"))
+    # No composite listener; and with only this cold no-activator workload the
+    # document carries no listeners key at all.
+    refute Map.has_key?(desired, :listeners)
+  end
+
+  test "no-composite regression: a serving-only render is byte-identical and carries no listeners key" do
+    stack = start_stack()
+    serving_workload(stack, "svc-a", "svc-a.example.com")
+
+    ctx = build_ctx(stack, [])
+    desired = EndpointPublisher.desired_for_node(ctx, "v1")
+
+    # The serving cluster is present; no composite (or stateful) clusters/listeners.
+    assert Enum.any?(desired.clusters, &(&1.name == "serve|svc-a"))
+    refute Enum.any?(desired.clusters, &String.starts_with?(&1.name, "group|"))
+    refute Map.has_key?(desired, :listeners)
+
+    # The document shape is exactly {version, clusters, routes} (the pre-R4 wire).
+    assert Map.keys(desired) |> Enum.sort() == [:clusters, :routes, :version]
+  end
+end

--- a/projects/embervm/control/test/embervm/group_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_manager_test.exs
@@ -48,6 +48,11 @@ defmodule Embervm.GroupManagerTest do
     {:ok, rec} = recorder()
 
     fail_member = Keyword.get(opts, :fail_member)
+    # A member whose RELIGHT StartGroupMember fails (Task 7): forces the all-or-
+    # nothing relight -> fresh fallback. relight_unverified_member instead returns a
+    # was_relight=false response (the clock-resync casualty, decision 7).
+    relight_fail_member = Keyword.get(opts, :relight_fail_member)
+    relight_unverified_member = Keyword.get(opts, :relight_unverified_member)
 
     create_group_network_fun = fn _ch, req ->
       record(rec, {:create_network, req.group_instance_id, req.cidr})
@@ -60,13 +65,29 @@ defmodule Embervm.GroupManagerTest do
     end
 
     start_group_member_fun = fn _ch, req ->
-      record(rec, {:start_member, req.member_name, req.member_index, req.ip, req.env})
+      relight? = req.mode == :START_GROUP_MEMBER_MODE_RELIGHT
+      record(rec, {:start_member, req.member_name, req.member_index, req.ip, req.env, req.mode})
 
-      if req.member_name == fail_member do
-        {:error, :boom}
-      else
-        {:ok, %StartGroupMemberResponse{vm_id: "vm-#{req.member_name}", ip: req.ip, was_relight: false}}
+      cond do
+        req.member_name == fail_member ->
+          {:error, :boom}
+
+        relight? and req.member_name == relight_fail_member ->
+          {:error, :relight_boom}
+
+        relight? and req.member_name == relight_unverified_member ->
+          # A resume the daemon could not verify (clock-resync out of bounds):
+          # was_relight=false on a RELIGHT-mode response.
+          {:ok, %StartGroupMemberResponse{vm_id: "vm-#{req.member_name}", ip: req.ip, was_relight: false}}
+
+        true ->
+          {:ok, %StartGroupMemberResponse{vm_id: "vm-#{req.member_name}", ip: req.ip, was_relight: relight?}}
       end
+    end
+
+    evict_snapshot_fun = fn _ch, req ->
+      record(rec, {:evict_snapshot, req.snapshot_ref})
+      {:ok, %Embervm.Node.V1.EvictSnapshotResponse{}}
     end
 
     {:ok, secret_reads} = Agent.start_link(fn -> [] end)
@@ -94,6 +115,7 @@ defmodule Embervm.GroupManagerTest do
       create_group_network_fun: create_group_network_fun,
       delete_group_network_fun: delete_group_network_fun,
       start_group_member_fun: start_group_member_fun,
+      evict_snapshot_fun: evict_snapshot_fun,
       get_secret_fun: get_secret_fun,
       secret_fun: Keyword.get(opts, :secret_fun, fn -> "minted-secret" end),
       clock: fn -> 1_000 end
@@ -148,8 +170,8 @@ defmodule Embervm.GroupManagerTest do
 
     starts =
       events(ctx.rec)
-      |> Enum.filter(&match?({:start_member, _, _, _, _}, &1))
-      |> Enum.map(fn {:start_member, name, _idx, _ip, _env} -> name end)
+      |> Enum.filter(&match?({:start_member, _, _, _, _, _}, &1))
+      |> Enum.map(fn {:start_member, name, _idx, _ip, _env, _mode} -> name end)
 
     # leader (startOrder 0) must come before BOTH worker replicas (startOrder 1).
     leader_pos = Enum.find_index(starts, &(&1 == "leader"))
@@ -180,8 +202,8 @@ defmodule Embervm.GroupManagerTest do
     {:ok, _} = GroupManager.create_group(ctx.mgr)
 
     # The env the WORKER-0 member was started with.
-    {:start_member, "worker-0", _idx, _ip, env} =
-      events(ctx.rec) |> Enum.find(&match?({:start_member, "worker-0", _, _, _}, &1))
+    {:start_member, "worker-0", _idx, _ip, env, _mode} =
+      events(ctx.rec) |> Enum.find(&match?({:start_member, "worker-0", _, _, _, _}, &1))
 
     # Member identity.
     assert env["EMBER_GROUP_MEMBER"] == "worker-0"
@@ -198,8 +220,8 @@ defmodule Embervm.GroupManagerTest do
     assert env["EMBER_GROUP_SECRET"] == "minted-secret"
 
     # The leader carries its declared env untouched too.
-    {:start_member, "leader", _, _, leader_env} =
-      events(ctx.rec) |> Enum.find(&match?({:start_member, "leader", _, _, _}, &1))
+    {:start_member, "leader", _, _, leader_env, _mode} =
+      events(ctx.rec) |> Enum.find(&match?({:start_member, "leader", _, _, _, _}, &1))
 
     assert leader_env["FOO"] == "bar"
     assert leader_env["EMBER_GROUP_IP"] == "10.101.0.10"
@@ -220,8 +242,8 @@ defmodule Embervm.GroupManagerTest do
     ctx = start_group(entry: entry)
     {:ok, _} = GroupManager.create_group(ctx.mgr)
 
-    {:start_member, "leader", _, _, env} =
-      events(ctx.rec) |> Enum.find(&match?({:start_member, "leader", _, _, _}, &1))
+    {:start_member, "leader", _, _, env, _mode} =
+      events(ctx.rec) |> Enum.find(&match?({:start_member, "leader", _, _, _, _}, &1))
 
     # The secret came from the referenced K8s Secret's key, not a mint.
     assert env["EMBER_GROUP_SECRET"] == "from-k8s"
@@ -233,11 +255,99 @@ defmodule Embervm.GroupManagerTest do
     ctx = start_group(secret_fun: fn -> "fixed-mint" end)
     {:ok, _} = GroupManager.create_group(ctx.mgr)
 
-    {:start_member, "leader", _, _, env} =
-      events(ctx.rec) |> Enum.find(&match?({:start_member, "leader", _, _, _}, &1))
+    {:start_member, "leader", _, _, env, _mode} =
+      events(ctx.rec) |> Enum.find(&match?({:start_member, "leader", _, _, _, _}, &1))
 
     assert env["EMBER_GROUP_SECRET"] == "fixed-mint"
     # No K8s read happened.
     assert Agent.get(ctx.secret_reads, & &1) == []
+  end
+
+  # -- wake (relight / fresh fallback), R5 Task 7 ----------------------------
+
+  # Drive the created group to `banked` with a complete set (a snapshot_ref for every
+  # expanded member), so a wake_group relights it.
+  defp bank_complete(ctx) do
+    {:ok, _} = GroupStore.mark(ctx.store, "g-1", :bank)
+
+    members = [
+      %{name: "leader", snapshot_ref: "snap-leader"},
+      %{name: "worker-0", snapshot_ref: "snap-worker-0"},
+      %{name: "worker-1", snapshot_ref: "snap-worker-1"}
+    ]
+
+    {:ok, _} = GroupStore.bank_ready(ctx.store, "g-1", "set-1", members)
+    :ok
+  end
+
+  defp relight_events(ctx) do
+    events(ctx.rec)
+    |> Enum.filter(&match?({:start_member, _, _, _, _, :START_GROUP_MEMBER_MODE_RELIGHT}, &1))
+    |> Enum.map(fn {:start_member, name, _idx, _ip, _env, _mode} -> name end)
+  end
+
+  test "wake_group relights a complete banked set in role order and republishes the entry" do
+    ctx = start_group()
+    {:ok, _} = GroupManager.create_group(ctx.mgr)
+    :ok = bank_complete(ctx)
+
+    assert {:ok, endpoint, :relit} = GroupManager.wake_group(ctx.mgr)
+    assert endpoint == %{ip: "10.0.0.9", port: 30_010}
+
+    {:ok, inst} = GroupStore.get(ctx.store, "g-1")
+    assert inst.state == :running
+    assert inst.entry_port_published == 30_010
+
+    # Every member was RELIGHT-resumed (not fresh), in role order (leader before both
+    # workers), and the network was re-issued before the resumes.
+    relit = relight_events(ctx)
+    assert Enum.sort(relit) == ["leader", "worker-0", "worker-1"]
+    assert Enum.find_index(relit, &(&1 == "leader")) < Enum.find_index(relit, &(&1 == "worker-0"))
+
+    # The network was re-created on the wake (the bridge dies with the noded pod).
+    creates = Enum.count(events(ctx.rec), &match?({:create_network, "g-1", _}, &1))
+    assert creates >= 2
+  end
+
+  test "wake_group falls back to a FRESH boot (same call) when a member relight fails, evicting the set" do
+    ctx = start_group(relight_fail_member: "worker-1")
+    {:ok, _} = GroupManager.create_group(ctx.mgr)
+    :ok = bank_complete(ctx)
+
+    assert {:ok, endpoint, {:fresh, :relight_failed}} = GroupManager.wake_group(ctx.mgr)
+    assert endpoint == %{ip: "10.0.0.9", port: 30_010}
+
+    {:ok, inst} = GroupStore.get(ctx.store, "g-1")
+    assert inst.state == :running
+    # The set was evicted (set_id cleared) and each member's snapshot_ref cleared.
+    assert inst.set_id == nil
+    assert Enum.all?(GroupStore.members(ctx.store, "g-1"), &is_nil(&1.snapshot_ref))
+
+    # The banked snapshots were EvictSnapshot'd on the node.
+    evicted = for {:evict_snapshot, ref} <- events(ctx.rec), do: ref
+    assert Enum.sort(evicted) == ["snap-leader", "snap-worker-0", "snap-worker-1"]
+
+    # After the fallback, every member was FRESH-started (mode FRESH), and the group
+    # is whole again.
+    fresh =
+      events(ctx.rec)
+      |> Enum.filter(&match?({:start_member, _, _, _, _, :START_GROUP_MEMBER_MODE_FRESH}, &1))
+      |> Enum.map(fn {:start_member, name, _, _, _, _} -> name end)
+
+    # Fresh starts happen both at create AND at the fallback: the fallback set is the
+    # last three.
+    assert Enum.take(fresh, -3) |> Enum.sort() == ["leader", "worker-0", "worker-1"]
+  end
+
+  test "wake_group treats an UNVERIFIED relight (clock-resync) as a failure and fresh-boots" do
+    ctx = start_group(relight_unverified_member: "leader")
+    {:ok, _} = GroupManager.create_group(ctx.mgr)
+    :ok = bank_complete(ctx)
+
+    assert {:ok, _endpoint, {:fresh, :clock_resync_failed}} = GroupManager.wake_group(ctx.mgr)
+
+    {:ok, inst} = GroupStore.get(ctx.store, "g-1")
+    assert inst.state == :running
+    assert inst.set_id == nil
   end
 end

--- a/projects/embervm/control/test/embervm/group_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_manager_test.exs
@@ -1,0 +1,243 @@
+defmodule Embervm.GroupManagerTest do
+  @moduledoc """
+  Exercises Embervm.GroupManager (the per-instance composite create brain) against a
+  real GroupStore + op-log, an injected CreateGroupNetwork/StartGroupMember seam
+  (a recording fake), and a FakePublisher. Covers: the ordered create round-trip
+  (network up -> role-ordered health-gated member starts -> entry published ->
+  running), the ordered-start PROPERTY (order N never starts before all order N-1
+  are up, asserted from the recorded call order), create-failure teardown (a member
+  start failure tears the group to failed AND deletes the network), the EMBER_GROUP_*
+  env compose (member/role/ip/peer-map/secret keys, casing + .10+i addressing), and
+  secret sourcing (secretRef read stable vs minted).
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.{GroupManager, GroupStore}
+  alias Embervm.OpLog.SQLite
+
+  alias Embervm.Node.V1.{CreateGroupNetworkResponse, StartGroupMemberResponse}
+
+  defmodule FakePublisher do
+    use GenServer
+    def start_link, do: GenServer.start_link(__MODULE__, 0)
+    def count(pid), do: GenServer.call(pid, :count)
+    @impl true
+    def init(n), do: {:ok, n}
+    @impl true
+    def handle_cast(:publish, n), do: {:noreply, n + 1}
+    @impl true
+    def handle_call(:count, _from, n), do: {:reply, n, n}
+  end
+
+  # A recording seam: every CreateGroupNetwork / StartGroupMember / DeleteGroupNetwork
+  # call is appended (with a monotonic sequence + the request) to an Agent so a test
+  # can assert the ORDER and content. StartGroupMember can be made to fail for a named
+  # member.
+  defp recorder, do: Agent.start_link(fn -> [] end)
+  defp record(agent, event), do: Agent.update(agent, &(&1 ++ [event]))
+  defp events(agent), do: Agent.get(agent, & &1)
+
+  defp start_group(opts \\ []) do
+    suffix = System.unique_integer([:positive])
+    path = Path.join(System.tmp_dir!(), "embervm_groupmgr_test_#{suffix}.db")
+    on_exit(fn -> File.rm_rf!(path) end)
+
+    {:ok, op_log} = SQLite.start_link(name: nil, path: path)
+    {:ok, store} = GroupStore.start_link(name: nil, op_log: op_log, clock: fn -> 1_000 end)
+    {:ok, pub} = FakePublisher.start_link()
+    {:ok, rec} = recorder()
+
+    fail_member = Keyword.get(opts, :fail_member)
+
+    create_group_network_fun = fn _ch, req ->
+      record(rec, {:create_network, req.group_instance_id, req.cidr})
+      {:ok, %CreateGroupNetworkResponse{bridge_name: "emg123", gateway_ip: "10.101.0.1"}}
+    end
+
+    delete_group_network_fun = fn _ch, req ->
+      record(rec, {:delete_network, req.group_instance_id})
+      {:ok, %Embervm.Node.V1.DeleteGroupNetworkResponse{}}
+    end
+
+    start_group_member_fun = fn _ch, req ->
+      record(rec, {:start_member, req.member_name, req.member_index, req.ip, req.env})
+
+      if req.member_name == fail_member do
+        {:error, :boom}
+      else
+        {:ok, %StartGroupMemberResponse{vm_id: "vm-#{req.member_name}", ip: req.ip, was_relight: false}}
+      end
+    end
+
+    {:ok, secret_reads} = Agent.start_link(fn -> [] end)
+
+    get_secret_fun =
+      Keyword.get(opts, :get_secret_fun, fn ns, name ->
+        Agent.update(secret_reads, &[{ns, name} | &1])
+        {:ok, %{"token" => "from-k8s"}}
+      end)
+
+    entry = Keyword.get(opts, :entry, default_entry())
+
+    mgr_opts = [
+      instance_id: "g-1",
+      workload: "grp-a",
+      principal: "system:group:grp-a",
+      entry: entry,
+      node_id: "node-4",
+      store: store,
+      publisher: pub,
+      supernet: "10.101.0.0/16",
+      port_base: 30_000,
+      pod_ip: "10.0.0.9",
+      channel_fun: fn _node -> {:ok, :ch} end,
+      create_group_network_fun: create_group_network_fun,
+      delete_group_network_fun: delete_group_network_fun,
+      start_group_member_fun: start_group_member_fun,
+      get_secret_fun: get_secret_fun,
+      secret_fun: Keyword.get(opts, :secret_fun, fn -> "minted-secret" end),
+      clock: fn -> 1_000 end
+    ]
+
+    {:ok, mgr} = GroupManager.start_link(mgr_opts)
+
+    %{mgr: mgr, store: store, pub: pub, rec: rec, op_log: op_log, secret_reads: secret_reads}
+  end
+
+  defp default_entry do
+    %{
+      name: "grp-a",
+      namespace: "embervm-workloads",
+      class: "composite",
+      group: %{
+        entry: %{member: "leader", port: 8080, listen_port: 5410},
+        secret_ref: nil,
+        members: [
+          %{name: "leader", role: "leader", start_order: 0, replicas: 1, image_ref: "img-l", health_port: 9000, env: %{"FOO" => "bar"}},
+          %{name: "worker", role: "worker", start_order: 1, replicas: 2, image_ref: "img-w", health_port: 9001, env: %{}}
+        ]
+      }
+    }
+  end
+
+  test "the ordered create round-trip: network up -> members -> published -> running" do
+    ctx = start_group()
+
+    assert {:ok, endpoint} = GroupManager.create_group(ctx.mgr)
+    # The published entry endpoint is {pod IP, vmPort}: vmPort = 30000 + hostOffset of
+    # the entry member's IP (.10 in the group /24). For 10.101.0.10 in 10.101.0.0/16
+    # the offset is (0 << 8) | 10 = 10, so vmPort = 30010.
+    assert endpoint == %{ip: "10.0.0.9", port: 30_010}
+
+    {:ok, inst} = GroupStore.get(ctx.store, "g-1")
+    assert inst.state == :running
+    assert inst.entry_ip == "10.0.0.9"
+    assert inst.entry_port_published == 30_010
+
+    # Three expanded members recorded (leader, worker-0, worker-1).
+    members = GroupStore.members(ctx.store, "g-1")
+    assert Enum.map(members, & &1.member_name) |> Enum.sort() == ["leader", "worker-0", "worker-1"]
+    assert Enum.all?(members, & &1.healthy)
+
+    assert FakePublisher.count(ctx.pub) >= 1
+  end
+
+  test "ordered-start property: order N never starts before every order N-1 member" do
+    ctx = start_group()
+    {:ok, _} = GroupManager.create_group(ctx.mgr)
+
+    starts =
+      events(ctx.rec)
+      |> Enum.filter(&match?({:start_member, _, _, _, _}, &1))
+      |> Enum.map(fn {:start_member, name, _idx, _ip, _env} -> name end)
+
+    # leader (startOrder 0) must come before BOTH worker replicas (startOrder 1).
+    leader_pos = Enum.find_index(starts, &(&1 == "leader"))
+    w0_pos = Enum.find_index(starts, &(&1 == "worker-0"))
+    w1_pos = Enum.find_index(starts, &(&1 == "worker-1"))
+
+    assert leader_pos < w0_pos
+    assert leader_pos < w1_pos
+
+    # The network is created before any member starts.
+    assert [{:create_network, "g-1", "10.101.0.0/24"} | _] = events(ctx.rec)
+  end
+
+  test "create-failure teardown: a member start failure tears the group to failed AND deletes the network" do
+    ctx = start_group(fail_member: "worker-0")
+
+    assert {:error, _reason} = GroupManager.create_group(ctx.mgr)
+
+    {:ok, inst} = GroupStore.get(ctx.store, "g-1")
+    assert inst.state == :failed
+
+    # The group network was torn down (no half-group leaks).
+    assert Enum.any?(events(ctx.rec), &match?({:delete_network, "g-1"}, &1))
+  end
+
+  test "EMBER_GROUP_* env: member/role/ip/peer-map/secret keys, casing + .10+i addressing" do
+    ctx = start_group()
+    {:ok, _} = GroupManager.create_group(ctx.mgr)
+
+    # The env the WORKER-0 member was started with.
+    {:start_member, "worker-0", _idx, _ip, env} =
+      events(ctx.rec) |> Enum.find(&match?({:start_member, "worker-0", _, _, _}, &1))
+
+    # Member identity.
+    assert env["EMBER_GROUP_MEMBER"] == "worker-0"
+    assert env["EMBER_GROUP_ROLE"] == "worker"
+    # worker-0 is the 2nd expanded member (index 1) -> .10 + 1 = .11.
+    assert env["EMBER_GROUP_IP"] == "10.101.0.11"
+
+    # The peer map: every member's IP, keyed UPPERCASE with - -> _.
+    assert env["EMBER_PEER_LEADER"] == "10.101.0.10"
+    assert env["EMBER_PEER_WORKER_0"] == "10.101.0.11"
+    assert env["EMBER_PEER_WORKER_1"] == "10.101.0.12"
+
+    # The minted group secret (no secretRef in the default entry).
+    assert env["EMBER_GROUP_SECRET"] == "minted-secret"
+
+    # The leader carries its declared env untouched too.
+    {:start_member, "leader", _, _, leader_env} =
+      events(ctx.rec) |> Enum.find(&match?({:start_member, "leader", _, _, _}, &1))
+
+    assert leader_env["FOO"] == "bar"
+    assert leader_env["EMBER_GROUP_IP"] == "10.101.0.10"
+  end
+
+  test "secret sourcing: with secretRef the K8s key is read (stable), recorded in the create op" do
+    entry = %{
+      name: "grp-a",
+      namespace: "embervm-workloads",
+      class: "composite",
+      group: %{
+        entry: %{member: "leader", port: 8080, listen_port: 5410},
+        secret_ref: %{name: "grp-secret", key: "token"},
+        members: [%{name: "leader", role: "leader", start_order: 0, replicas: 1, image_ref: "img-l", health_port: 9000, env: %{}}]
+      }
+    }
+
+    ctx = start_group(entry: entry)
+    {:ok, _} = GroupManager.create_group(ctx.mgr)
+
+    {:start_member, "leader", _, _, env} =
+      events(ctx.rec) |> Enum.find(&match?({:start_member, "leader", _, _, _}, &1))
+
+    # The secret came from the referenced K8s Secret's key, not a mint.
+    assert env["EMBER_GROUP_SECRET"] == "from-k8s"
+    # The secretRef was read at create.
+    assert Agent.get(ctx.secret_reads, & &1) == [{"embervm-workloads", "grp-secret"}]
+  end
+
+  test "secret sourcing: without secretRef, a secret is MINTED at create" do
+    ctx = start_group(secret_fun: fn -> "fixed-mint" end)
+    {:ok, _} = GroupManager.create_group(ctx.mgr)
+
+    {:start_member, "leader", _, _, env} =
+      events(ctx.rec) |> Enum.find(&match?({:start_member, "leader", _, _, _}, &1))
+
+    assert env["EMBER_GROUP_SECRET"] == "fixed-mint"
+    # No K8s read happened.
+    assert Agent.get(ctx.secret_reads, & &1) == []
+  end
+end

--- a/projects/embervm/control/test/embervm/group_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_manager_test.exs
@@ -64,9 +64,36 @@ defmodule Embervm.GroupManagerTest do
       {:ok, %Embervm.Node.V1.DeleteGroupNetworkResponse{}}
     end
 
+    # Models noded's pinned-IP allocator: reserve a member's IP on start, REJECT a
+    # double-reserve (:ip_in_use), release it on StopGroupMember DESTROY. So a fresh
+    # re-pin over a member whose relight-resumed VM was NOT destroyed first FAILS on
+    # its IP, exactly as the real EnsureMemberTap/alloc.reserve would. `vm_id -> ip`
+    # tracks live members so a DESTROY (by vm_id) frees the right IP.
+    {:ok, alloc} = Agent.start_link(fn -> %{reserved: MapSet.new(), by_vm: %{}} end)
+
+    reserve = fn ip, vm_id ->
+      Agent.get_and_update(alloc, fn s ->
+        if MapSet.member?(s.reserved, ip) do
+          {:error, s}
+        else
+          {:ok, %{reserved: MapSet.put(s.reserved, ip), by_vm: Map.put(s.by_vm, vm_id, ip)}}
+        end
+      end)
+    end
+
+    release = fn vm_id ->
+      Agent.update(alloc, fn s ->
+        case Map.get(s.by_vm, vm_id) do
+          nil -> s
+          ip -> %{reserved: MapSet.delete(s.reserved, ip), by_vm: Map.delete(s.by_vm, vm_id)}
+        end
+      end)
+    end
+
     start_group_member_fun = fn _ch, req ->
       relight? = req.mode == :START_GROUP_MEMBER_MODE_RELIGHT
       record(rec, {:start_member, req.member_name, req.member_index, req.ip, req.env, req.mode})
+      vm_id = "vm-#{req.member_name}"
 
       cond do
         req.member_name == fail_member ->
@@ -77,12 +104,26 @@ defmodule Embervm.GroupManagerTest do
 
         relight? and req.member_name == relight_unverified_member ->
           # A resume the daemon could not verify (clock-resync out of bounds):
-          # was_relight=false on a RELIGHT-mode response.
-          {:ok, %StartGroupMemberResponse{vm_id: "vm-#{req.member_name}", ip: req.ip, was_relight: false}}
+          # was_relight=false on a RELIGHT-mode response. It still RESERVED the IP (the
+          # VM did resume before verification failed), so a later fresh re-pin collides
+          # unless it is destroyed first.
+          case reserve.(req.ip, vm_id) do
+            :ok -> {:ok, %StartGroupMemberResponse{vm_id: vm_id, ip: req.ip, was_relight: false}}
+            :error -> {:error, :ip_in_use}
+          end
 
         true ->
-          {:ok, %StartGroupMemberResponse{vm_id: "vm-#{req.member_name}", ip: req.ip, was_relight: relight?}}
+          case reserve.(req.ip, vm_id) do
+            :ok -> {:ok, %StartGroupMemberResponse{vm_id: vm_id, ip: req.ip, was_relight: relight?}}
+            :error -> {:error, :ip_in_use}
+          end
       end
+    end
+
+    stop_group_member_fun = fn _ch, req ->
+      record(rec, {:stop_member, req.vm_id, req.mode})
+      if req.mode == :STOP_GROUP_MEMBER_MODE_DESTROY, do: release.(req.vm_id)
+      {:ok, %Embervm.Node.V1.StopGroupMemberResponse{}}
     end
 
     evict_snapshot_fun = fn _ch, req ->
@@ -115,6 +156,7 @@ defmodule Embervm.GroupManagerTest do
       create_group_network_fun: create_group_network_fun,
       delete_group_network_fun: delete_group_network_fun,
       start_group_member_fun: start_group_member_fun,
+      stop_group_member_fun: stop_group_member_fun,
       evict_snapshot_fun: evict_snapshot_fun,
       get_secret_fun: get_secret_fun,
       secret_fun: Keyword.get(opts, :secret_fun, fn -> "minted-secret" end),
@@ -123,7 +165,7 @@ defmodule Embervm.GroupManagerTest do
 
     {:ok, mgr} = GroupManager.start_link(mgr_opts)
 
-    %{mgr: mgr, store: store, pub: pub, rec: rec, op_log: op_log, secret_reads: secret_reads}
+    %{mgr: mgr, store: store, pub: pub, rec: rec, op_log: op_log, secret_reads: secret_reads, alloc: alloc}
   end
 
   defp default_entry do
@@ -266,7 +308,10 @@ defmodule Embervm.GroupManagerTest do
   # -- wake (relight / fresh fallback), R5 Task 7 ----------------------------
 
   # Drive the created group to `banked` with a complete set (a snapshot_ref for every
-  # expanded member), so a wake_group relights it.
+  # expanded member), so a wake_group relights it. A real bank (StopGroupMember BANK)
+  # snapshots then tears down every live VM, freeing its pinned tap+IP; the store-level
+  # bank_ready here bypasses the RPC, so free the allocator model to match (otherwise a
+  # relight would spuriously collide on the still-reserved create-time IPs).
   defp bank_complete(ctx) do
     {:ok, _} = GroupStore.mark(ctx.store, "g-1", :bank)
 
@@ -277,6 +322,7 @@ defmodule Embervm.GroupManagerTest do
     ]
 
     {:ok, _} = GroupStore.bank_ready(ctx.store, "g-1", "set-1", members)
+    Agent.update(ctx.alloc, fn _ -> %{reserved: MapSet.new(), by_vm: %{}} end)
     :ok
   end
 
@@ -326,6 +372,20 @@ defmodule Embervm.GroupManagerTest do
     # The banked snapshots were EvictSnapshot'd on the node.
     evicted = for {:evict_snapshot, ref} <- events(ctx.rec), do: ref
     assert Enum.sort(evicted) == ["snap-leader", "snap-worker-0", "snap-worker-1"]
+
+    # CRITICAL (the collision fix): every member that DID resume (leader order 0,
+    # worker-0 order 1) was StopGroupMember DESTROY'd BEFORE the fresh re-pin, so their
+    # taps+IPs were freed. Without this the fresh boot would collide on .10/.11
+    # (:ip_in_use, modeled by the allocator fake) and the whole wake would fail.
+    destroyed =
+      for {:stop_member, vm_id, :STOP_GROUP_MEMBER_MODE_DESTROY} <- events(ctx.rec), do: vm_id
+
+    assert "vm-leader" in destroyed
+    assert "vm-worker-0" in destroyed
+
+    # Each DESTROY preceded the fresh re-pin of that member's IP (the allocator would
+    # have rejected the fresh reserve otherwise, so the run reaching :ok proves order):
+    # the successful {:ok, endpoint, {:fresh, ...}} above is the end-to-end proof.
 
     # After the fallback, every member was FRESH-started (mode FRESH), and the group
     # is whole again.

--- a/projects/embervm/control/test/embervm/group_state_test.exs
+++ b/projects/embervm/control/test/embervm/group_state_test.exs
@@ -1,0 +1,82 @@
+defmodule Embervm.GroupStateTest do
+  @moduledoc """
+  Exhaustive coverage of the composite-group FSM (`Embervm.GroupState`): every
+  legal transition maps to the documented next state, and EVERY illegal (state,
+  event) pair is refused by `transition/2` and RAISES via `transition!/2`. The
+  live/terminal predicates and the deliberate ABSENCE of a `degraded` state are
+  asserted too (degraded is a flag on `running`, not an FSM node).
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.GroupState
+  alias Embervm.GroupState.IllegalTransition
+
+  @legal %{
+    {:creating, :publish} => :running,
+    {:running, :unpublish} => :banking,
+    {:running, :bank} => :banking,
+    {:banking, :bank_ready} => :banked,
+    {:banking, :bank_abort} => :running,
+    {:banked, :relight} => :relighting,
+    {:relighting, :relight_ready} => :creating,
+    {:relighting, :relight_abort} => :banked,
+    {:banked, :fresh_boot} => :fresh_booting,
+    {:fresh_booting, :fresh_ready} => :creating,
+    {:fresh_booting, :fresh_abort} => :banked,
+    {:creating, :destroy} => :destroyed,
+    {:running, :destroy} => :destroyed,
+    {:banking, :destroy} => :destroyed,
+    {:banked, :destroy} => :destroyed,
+    {:relighting, :destroy} => :destroyed,
+    {:fresh_booting, :destroy} => :destroyed,
+    {:creating, :fail} => :failed,
+    {:running, :fail} => :failed,
+    {:banking, :fail} => :failed,
+    {:relighting, :fail} => :failed,
+    {:fresh_booting, :fail} => :failed
+  }
+
+  test "every legal transition maps to the documented next state" do
+    for {{state, event}, next} <- @legal do
+      assert GroupState.transition(state, event) == {:ok, next}
+      assert GroupState.transition!(state, event) == next
+    end
+  end
+
+  test "there is no `degraded` FSM state (degraded is a flag on running)" do
+    refute :degraded in GroupState.states()
+    # No event ever transitions INTO or OUT of a degraded state.
+    refute Enum.any?(@legal, fn {{s, _e}, n} -> s == :degraded or n == :degraded end)
+  end
+
+  test "every (state, event) pair NOT in the legal table is illegal and raises" do
+    states = GroupState.states()
+    events = GroupState.events()
+
+    for state <- states, event <- events, not Map.has_key?(@legal, {state, event}) do
+      assert GroupState.transition(state, event) == {:error, {:illegal_transition, state, event}},
+             "expected #{inspect(state)} -/-> on #{inspect(event)} to be illegal"
+
+      assert_raise IllegalTransition, fn -> GroupState.transition!(state, event) end
+    end
+  end
+
+  test "terminal states never transition on any event" do
+    for state <- GroupState.terminal_states(), event <- GroupState.events() do
+      assert GroupState.transition(state, event) == {:error, {:illegal_transition, state, event}}
+    end
+  end
+
+  test "live? is the five non-terminal, non-banked states" do
+    assert GroupState.live_states() == [:creating, :running, :banking, :relighting, :fresh_booting]
+
+    for s <- [:creating, :running, :banking, :relighting, :fresh_booting], do: assert(GroupState.live?(s))
+    for s <- [:banked, :destroyed, :failed], do: refute(GroupState.live?(s))
+  end
+
+  test "terminal? is exactly destroyed + failed" do
+    assert GroupState.terminal_states() == [:destroyed, :failed]
+    for s <- [:destroyed, :failed], do: assert(GroupState.terminal?(s))
+    for s <- [:creating, :running, :banking, :banked, :relighting, :fresh_booting], do: refute(GroupState.terminal?(s))
+  end
+end

--- a/projects/embervm/control/test/embervm/group_store_test.exs
+++ b/projects/embervm/control/test/embervm/group_store_test.exs
@@ -1,0 +1,233 @@
+defmodule Embervm.GroupStoreTest do
+  @moduledoc """
+  Exercises Embervm.GroupStore against a real op-log: the singleton create gate,
+  write-through transitions (durable op BEFORE ETS visibility), the member lifecycle
+  (start -> running -> bank), the degraded FLAG (a member unhealthy on a running
+  group), illegal-transition raise-through, set-completeness derivation + eager
+  eviction of a partial set, the entry-endpoint fact, and a rebuild-from-projection
+  reproducing exact instance + member state.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.{GroupStore, GroupState}
+  alias Embervm.OpLog.SQLite
+
+  defp start_store(_opts \\ []) do
+    suffix = System.unique_integer([:positive])
+    path = Path.join(System.tmp_dir!(), "embervm_groupstore_test_#{suffix}.db")
+    on_exit(fn -> File.rm_rf!(path) end)
+
+    {:ok, counter} = Agent.start_link(fn -> 1_000 end)
+    clock = fn -> Agent.get_and_update(counter, fn n -> {n, n + 1} end) end
+
+    {:ok, op_log} = SQLite.start_link(name: nil, path: path)
+    {:ok, store} = GroupStore.start_link(name: nil, op_log: op_log, clock: clock)
+    %{store: store, op_log: op_log, path: path}
+  end
+
+  defp create(ctx, instance_id, workload \\ "grp-a", extra \\ %{}) do
+    attrs =
+      Map.merge(
+        %{
+          instance_id: instance_id,
+          tenant: "homelab",
+          principal: "system:group:#{workload}",
+          workload: workload,
+          node_id: "node-4",
+          subnet_cidr: "10.101.0.0/24",
+          entry_member: "leader",
+          entry_port: 8080,
+          listen_port: 5410,
+          secret: "s3cr3t"
+        },
+        extra
+      )
+
+    GroupStore.create(ctx.store, attrs)
+  end
+
+  defp member(ctx, instance_id, name, index, extra \\ %{}) do
+    fields = Map.merge(%{member_name: name, member_index: index, vm_id: "vm-#{name}", ip: "10.101.0.#{10 + index}"}, extra)
+    GroupStore.member_started(ctx.store, instance_id, fields)
+  end
+
+  test "create records a group in :creating and inserts the instance row" do
+    ctx = start_store()
+    assert {:ok, instance} = create(ctx, "g-1")
+    assert instance.state == :creating
+    assert instance.subnet_cidr == "10.101.0.0/24"
+    assert instance.entry_member == "leader"
+    assert {:ok, ^instance} = GroupStore.get(ctx.store, "g-1")
+  end
+
+  test "the singleton gate refuses a second LIVE instance for the workload without appending" do
+    ctx = start_store()
+    assert {:ok, _} = create(ctx, "g-1", "grp-a")
+    assert {:error, :already_live} = create(ctx, "g-2", "grp-a")
+    # A different workload is fine.
+    assert {:ok, _} = create(ctx, "g-3", "grp-b")
+  end
+
+  test "a banked instance does NOT block a fresh create (banked is not live)" do
+    ctx = start_store()
+    assert {:ok, _} = create(ctx, "g-1", "grp-a")
+    # Drive to banked: members up -> running -> bank -> bank_ready.
+    {:ok, _} = member(ctx, "g-1", "leader", 0)
+    {:ok, _} = GroupStore.publish(ctx.store, "g-1", "10.0.0.9", 30012)
+    {:ok, _} = GroupStore.mark(ctx.store, "g-1", :bank)
+    {:ok, _} = GroupStore.bank_ready(ctx.store, "g-1", "set-1", [%{name: "leader", snapshot_ref: "snap-l"}])
+
+    # Now a banked-only workload can create a fresh cold boot.
+    assert {:ok, _} = create(ctx, "g-2", "grp-a")
+  end
+
+  test "member lifecycle: started -> running marks healthy -> bank stamps snapshot + clears VM" do
+    ctx = start_store()
+    {:ok, _} = create(ctx, "g-1")
+    {:ok, m} = member(ctx, "g-1", "leader", 0)
+    assert m.state == "starting"
+    assert m.healthy == false
+
+    {:ok, inst} = GroupStore.publish(ctx.store, "g-1", "10.0.0.9", 30012)
+    assert inst.state == :running
+    assert inst.entry_ip == "10.0.0.9"
+    assert inst.entry_port_published == 30012
+
+    [leader] = GroupStore.members(ctx.store, "g-1")
+    assert leader.healthy == true
+
+    {:ok, _} = GroupStore.mark(ctx.store, "g-1", :bank)
+    {:ok, banked} = GroupStore.bank_ready(ctx.store, "g-1", "set-1", [%{name: "leader", snapshot_ref: "snap-l"}])
+    assert banked.state == :banked
+    assert banked.set_id == "set-1"
+    assert banked.entry_ip == nil
+
+    [leader] = GroupStore.members(ctx.store, "g-1")
+    assert leader.snapshot_ref == "snap-l"
+    assert leader.vm_id == nil
+    assert leader.state == "banked"
+  end
+
+  test "the degraded flag: one member unhealthy on a running group names it; recovery clears it" do
+    ctx = start_store()
+    {:ok, _} = create(ctx, "g-1")
+    {:ok, _} = member(ctx, "g-1", "leader", 0)
+    {:ok, _} = member(ctx, "g-1", "worker", 1)
+    {:ok, _} = GroupStore.publish(ctx.store, "g-1", "10.0.0.9", 30012)
+
+    assert GroupStore.degraded?(ctx.store, "grp-a") == false
+
+    {:ok, inst} = GroupStore.set_member_health(ctx.store, "g-1", "worker", false)
+    assert inst.state == :running
+    assert inst.degraded_member == "worker"
+    assert GroupStore.degraded?(ctx.store, "grp-a") == {true, "worker"}
+
+    {:ok, inst} = GroupStore.set_member_health(ctx.store, "g-1", "worker", true)
+    assert inst.degraded_member == nil
+    assert GroupStore.degraded?(ctx.store, "grp-a") == false
+  end
+
+  test "an illegal transition raises out of transition/6 as an error (never corrupts ETS)" do
+    ctx = start_store()
+    {:ok, _} = create(ctx, "g-1")
+    # :bank_ready is illegal from :creating (only from :banking).
+    assert {:error, {:illegal_transition, :creating, :bank_ready}} =
+             GroupStore.transition(ctx.store, "g-1", :bank_ready, :group_banked, %{}, %{})
+
+    # ETS is untouched: still creating.
+    assert {:ok, %{state: :creating}} = GroupStore.get(ctx.store, "g-1")
+  end
+
+  test "the entry-endpoint fact is the running entry {ip, port}, nil otherwise" do
+    ctx = start_store()
+    {:ok, _} = create(ctx, "g-1")
+    {:ok, _} = member(ctx, "g-1", "leader", 0)
+    assert GroupStore.entry_endpoint(ctx.store, "grp-a") == nil
+
+    {:ok, _} = GroupStore.publish(ctx.store, "g-1", "10.0.0.9", 30012)
+    assert GroupStore.entry_endpoint(ctx.store, "grp-a") == %{ip: "10.0.0.9", port: 30012}
+
+    {:ok, _} = GroupStore.mark(ctx.store, "g-1", :bank)
+    {:ok, _} = GroupStore.bank_ready(ctx.store, "g-1", "set-1", [%{name: "leader", snapshot_ref: "snap-l"}])
+    assert GroupStore.entry_endpoint(ctx.store, "grp-a") == nil
+  end
+
+  test "set-completeness: a banked set missing a member's bundle is eagerly evicted (partial_set)" do
+    ctx = start_store()
+    {:ok, _} = create(ctx, "g-1")
+    {:ok, _} = member(ctx, "g-1", "leader", 0)
+    {:ok, _} = member(ctx, "g-1", "worker", 1)
+    {:ok, _} = GroupStore.publish(ctx.store, "g-1", "10.0.0.9", 30012)
+    {:ok, _} = GroupStore.mark(ctx.store, "g-1", :bank)
+
+    {:ok, _} =
+      GroupStore.bank_ready(ctx.store, "g-1", "set-1", [
+        %{name: "leader", snapshot_ref: "snap-l"},
+        %{name: "worker", snapshot_ref: "snap-w"}
+      ])
+
+    # A COMPLETE reported set (both members) survives.
+    complete = %{"g-1" => MapSet.new(["leader", "worker"])}
+    assert GroupStore.evict_partial_sets(ctx.store, complete) == []
+    assert {:ok, %{set_id: "set-1"}} = GroupStore.get(ctx.store, "g-1")
+
+    # A PARTIAL reported set (worker's bundle gone) is evicted: set_id cleared.
+    partial = %{"g-1" => MapSet.new(["leader"])}
+    assert GroupStore.evict_partial_sets(ctx.store, partial) == ["g-1"]
+    assert {:ok, %{set_id: nil, state: :banked}} = GroupStore.get(ctx.store, "g-1")
+  end
+
+  test "a banked instance ABSENT from the reported sets is treated as partial (evicted)" do
+    ctx = start_store()
+    {:ok, _} = create(ctx, "g-1")
+    {:ok, _} = member(ctx, "g-1", "leader", 0)
+    {:ok, _} = GroupStore.publish(ctx.store, "g-1", "10.0.0.9", 30012)
+    {:ok, _} = GroupStore.mark(ctx.store, "g-1", :bank)
+    {:ok, _} = GroupStore.bank_ready(ctx.store, "g-1", "set-1", [%{name: "leader", snapshot_ref: "snap-l"}])
+
+    assert GroupStore.evict_partial_sets(ctx.store, %{}) == ["g-1"]
+    assert {:ok, %{set_id: nil}} = GroupStore.get(ctx.store, "g-1")
+  end
+
+  test "held_subnets reports every live-or-banked instance's /24, excluding terminal ones" do
+    ctx = start_store()
+    {:ok, _} = create(ctx, "g-1", "grp-a", %{subnet_cidr: "10.101.0.0/24"})
+    {:ok, _} = create(ctx, "g-2", "grp-b", %{subnet_cidr: "10.101.1.0/24"})
+
+    held = GroupStore.held_subnets(ctx.store)
+    assert MapSet.member?(held, "10.101.0.0/24")
+    assert MapSet.member?(held, "10.101.1.0/24")
+
+    # Destroy g-2: its subnet is freed.
+    {:ok, _} = GroupStore.transition(ctx.store, "g-2", :destroy, :group_destroyed, %{reason: "test"}, %{})
+    held = GroupStore.held_subnets(ctx.store)
+    refute MapSet.member?(held, "10.101.1.0/24")
+    assert MapSet.member?(held, "10.101.0.0/24")
+  end
+
+  test "rebuild from the durable projection reproduces exact instance + member state" do
+    ctx = start_store()
+    {:ok, _} = create(ctx, "g-1")
+    {:ok, _} = member(ctx, "g-1", "leader", 0)
+    {:ok, _} = member(ctx, "g-1", "worker", 1)
+    {:ok, _} = GroupStore.publish(ctx.store, "g-1", "10.0.0.9", 30012)
+    {:ok, _} = GroupStore.set_member_health(ctx.store, "g-1", "worker", false)
+
+    # A fresh store over the SAME op-log rebuilds from the projection alone.
+    {:ok, store2} = GroupStore.start_link(name: nil, op_log: ctx.op_log, clock: fn -> 9_000 end)
+
+    assert {:ok, inst} = GroupStore.get(store2, "g-1")
+    assert inst.state == :running
+    assert inst.entry_member == "leader"
+    # The degraded flag is reconstructed from the unhealthy member row.
+    assert inst.degraded_member == "worker"
+    # The entry endpoint is reconstructed from durable facts alone: the entry
+    # member's tap ip + the group's entry.port (Task 7 adoption re-derives the DNAT
+    # {pod IP, vmPort} on the next sweep).
+    assert GroupStore.entry_endpoint(store2, "grp-a") == %{ip: "10.101.0.10", port: 8080}
+
+    members = GroupStore.members(store2, "g-1")
+    assert length(members) == 2
+    assert Enum.find(members, &(&1.member_name == "worker")).healthy == false
+  end
+end

--- a/projects/embervm/control/test/embervm/group_store_test.exs
+++ b/projects/embervm/control/test/embervm/group_store_test.exs
@@ -9,7 +9,7 @@ defmodule Embervm.GroupStoreTest do
   """
   use ExUnit.Case, async: true
 
-  alias Embervm.{GroupStore, GroupState}
+  alias Embervm.GroupStore
   alias Embervm.OpLog.SQLite
 
   defp start_store(_opts \\ []) do
@@ -211,7 +211,6 @@ defmodule Embervm.GroupStoreTest do
     {:ok, _} = member(ctx, "g-1", "leader", 0)
     {:ok, _} = member(ctx, "g-1", "worker", 1)
     {:ok, _} = GroupStore.publish(ctx.store, "g-1", "10.0.0.9", 30012)
-    {:ok, _} = GroupStore.set_member_health(ctx.store, "g-1", "worker", false)
 
     # A fresh store over the SAME op-log rebuilds from the projection alone.
     {:ok, store2} = GroupStore.start_link(name: nil, op_log: ctx.op_log, clock: fn -> 9_000 end)
@@ -219,8 +218,9 @@ defmodule Embervm.GroupStoreTest do
     assert {:ok, inst} = GroupStore.get(store2, "g-1")
     assert inst.state == :running
     assert inst.entry_member == "leader"
-    # The degraded flag is reconstructed from the unhealthy member row.
-    assert inst.degraded_member == "worker"
+    # A durably-running group is whole (group_running marked every member healthy
+    # durably), so no degraded flag on rebuild.
+    assert inst.degraded_member == nil
     # The entry endpoint is reconstructed from durable facts alone: the entry
     # member's tap ip + the group's entry.port (Task 7 adoption re-derives the DNAT
     # {pod IP, vmPort} on the next sweep).
@@ -228,6 +228,25 @@ defmodule Embervm.GroupStoreTest do
 
     members = GroupStore.members(store2, "g-1")
     assert length(members) == 2
-    assert Enum.find(members, &(&1.member_name == "worker")).healthy == false
+    assert Enum.all?(members, & &1.healthy)
+  end
+
+  test "an ETS-only member-health flip is LOSSY: it does not survive a rebuild" do
+    ctx = start_store()
+    {:ok, _} = create(ctx, "g-1")
+    {:ok, _} = member(ctx, "g-1", "leader", 0)
+    {:ok, _} = member(ctx, "g-1", "worker", 1)
+    {:ok, _} = GroupStore.publish(ctx.store, "g-1", "10.0.0.9", 30012)
+
+    # set_member_health is an ETS-only lossy node fact (no op-log append), exactly
+    # like the stateful set_health/2: the degraded flag is live-visible...
+    {:ok, inst} = GroupStore.set_member_health(ctx.store, "g-1", "worker", false)
+    assert inst.degraded_member == "worker"
+
+    # ...but a rebuild from the durable projection (which was never told the member
+    # went unhealthy) sees a whole group. A durable degrade rides a group_degraded op
+    # (Task 7's health/adoption path), not this ETS-only flip.
+    {:ok, store2} = GroupStore.start_link(name: nil, op_log: ctx.op_log, clock: fn -> 9_000 end)
+    assert {:ok, %{degraded_member: nil}} = GroupStore.get(store2, "g-1")
   end
 end

--- a/projects/embervm/control/test/embervm/group_wake_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_wake_manager_test.exs
@@ -139,8 +139,16 @@ defmodule Embervm.GroupWakeManagerTest do
         adopts: 0
       }
 
-    {:ok, _} = Agent.start_link(fn -> sup_state end, name: FakeSupervisor)
-    on_exit(fn -> if Process.whereis(FakeSupervisor), do: Agent.stop(FakeSupervisor) end)
+    # Start the fake's state Agent under the ExUnit test supervisor (start_supervised),
+    # NOT a bare Agent.start_link with a hand-rolled on_exit. Two robustness reasons:
+    # (1) start_supervised tears the child down SYNCHRONOUSLY between tests, so the next
+    # test's Agent under the same module name can never collide with a prior test's not-
+    # yet-reaped one (a bare Agent.start_link linked to the test process dies
+    # asynchronously when the test process exits, and a whereis-then-stop on_exit then
+    # races the name being re-registered -> the "no process" exit we hit); (2) no manual
+    # stop, so there is no double-stop of an already-dead name. The Agent is keyed by a
+    # fixed id (:fake_supervisor) but registered under the module name the fake resolves.
+    _ = start_supervised!(%{id: :fake_supervisor, start: {Agent, :start_link, [fn -> sup_state end, [name: FakeSupervisor]]}})
 
     {:ok, mgr} =
       GroupWakeManager.start_link(

--- a/projects/embervm/control/test/embervm/group_wake_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_wake_manager_test.exs
@@ -1,0 +1,426 @@
+defmodule Embervm.GroupWakeManagerTest do
+  @moduledoc """
+  Exercises Embervm.GroupWakeManager (the composite wake brain) against a real
+  GroupStore + op-log, a FakePublisher, a fake WorkloadCatalog + NodeCapacity, and a
+  FAKE group supervisor (recording create_group/wake_group/adopt_group calls, with
+  injectable latency so N concurrent wakes race). Covers:
+
+    * single-flight: N concurrent wakes -> exactly ONE wake sequence + N replies;
+    * miss round-trip: a banked complete set relights and resolves the parked caller;
+      a subsequent connection is a straggler (no wake, resolved from the live entry);
+    * relight-failure -> fresh fallback is opaque to the brain (the GroupManager owns
+      it); the brain just single-flights and resolves;
+    * the wake DECISION (create vs relight vs fresh) from GroupStore facts;
+    * wake-rate limit + parked-cap denials;
+    * adoption matrix: a restart during each non-terminal state converges +
+      republishes the identical entry endpoint without touching a VM;
+    * degraded-group wake: a group with a dead NON-entry member is live (not banked)
+      and routes normally (straggler, no wake).
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.{GroupStore, GroupWakeManager, NodeCapacity, WorkloadCatalog}
+  alias Embervm.OpLog.SQLite
+
+  defmodule FakePublisher do
+    use GenServer
+    def start_link, do: GenServer.start_link(__MODULE__, 0)
+    def count(pid), do: GenServer.call(pid, :count)
+    @impl true
+    def init(n), do: {:ok, n}
+    @impl true
+    def handle_cast(:publish, n), do: {:noreply, n + 1}
+    @impl true
+    def handle_call(:count, _from, n), do: {:reply, n, n}
+  end
+
+  # A fake group supervisor: records every create_group/wake_group/adopt_group call
+  # (so a test asserts EXACTLY ONE happened per burst), sleeps `latency_ms` to widen
+  # the concurrent-wake race window, and drives the REAL GroupStore so the wake's
+  # publish makes the entry endpoint live (the brain re-reads the store to resolve
+  # stragglers). Configured via the process registered name below.
+  defmodule FakeSupervisor do
+    def create_group(workload) do
+      call({:create, workload})
+    end
+
+    def wake_group(workload, instance_id) do
+      call({:wake, workload, instance_id})
+    end
+
+    def adopt_group(workload, instance_id) do
+      call({:adopt, workload, instance_id})
+    end
+
+    defp call(msg) do
+      Agent.get_and_update(__MODULE__, fn s ->
+        {reply, s} = handle(msg, s)
+        {reply, s}
+      end)
+    end
+
+    defp handle({:create, workload}, s) do
+      maybe_sleep(s)
+      s = %{s | creates: s.creates + 1}
+      resolve(workload, s)
+    end
+
+    defp handle({:wake, workload, _instance_id}, s) do
+      maybe_sleep(s)
+      s = %{s | wakes: s.wakes + 1}
+
+      case resolve(workload, s) do
+        {{:ok, endpoint}, s} -> {{:ok, endpoint, :relit}, s}
+        other -> other
+      end
+    end
+
+    defp handle({:adopt, _workload, _instance_id}, s) do
+      {:ok, %{s | adopts: s.adopts + 1}}
+    end
+
+    # Publish the endpoint into the real store (drive the instance to running) so the
+    # brain's straggler re-read + the FakePublisher both see it. The endpoint is fixed.
+    defp resolve(_workload, %{fail: true} = s), do: {{:error, {:wake_failed, :scripted}}, s}
+
+    defp resolve(_workload, s) do
+      endpoint = %{ip: "10.0.0.9", port: 30_010}
+      publish_running(s)
+      {{:ok, endpoint}, s}
+    end
+
+    defp publish_running(%{store: store, instance_id: instance_id}) when is_binary(instance_id) do
+      _ = GroupStore.publish(store, instance_id, "10.0.0.9", 30_010)
+      :ok
+    end
+
+    defp publish_running(_s), do: :ok
+
+    defp maybe_sleep(%{latency_ms: ms}) when is_integer(ms) and ms > 0, do: Process.sleep(ms)
+    defp maybe_sleep(_s), do: :ok
+  end
+
+  defp start_stack(opts \\ []) do
+    suffix = System.unique_integer([:positive])
+    path = Path.join(System.tmp_dir!(), "embervm_groupwake_test_#{suffix}.db")
+    on_exit(fn -> File.rm_rf!(path) end)
+
+    {:ok, counter} = Agent.start_link(fn -> 1_000 end)
+    clock = fn -> Agent.get_and_update(counter, fn n -> {n, n + 1} end) end
+
+    {:ok, op_log} = SQLite.start_link(name: nil, path: path)
+    {:ok, store} = GroupStore.start_link(name: nil, op_log: op_log, clock: clock)
+    {:ok, pub} = FakePublisher.start_link()
+
+    cap_table = :"gwm_cap_#{suffix}"
+    cat_table = :"gwm_cat_#{suffix}"
+    NodeCapacity.create(cap_table)
+    WorkloadCatalog.create(cat_table)
+
+    WorkloadCatalog.upsert(cat_table, "grp-a", %{
+      class: "composite",
+      group: %{entry: %{member: "leader", port: 8080, listen_port: 5410}}
+    })
+
+    sup_state =
+      %{
+        store: store,
+        instance_id: Keyword.get(opts, :instance_id),
+        latency_ms: Keyword.get(opts, :latency_ms, 0),
+        fail: Keyword.get(opts, :fail, false),
+        creates: 0,
+        wakes: 0,
+        adopts: 0
+      }
+
+    {:ok, _} = Agent.start_link(fn -> sup_state end, name: FakeSupervisor)
+    on_exit(fn -> if Process.whereis(FakeSupervisor), do: Agent.stop(FakeSupervisor) end)
+
+    {:ok, mgr} =
+      GroupWakeManager.start_link(
+        name: nil,
+        store: store,
+        publisher: pub,
+        capacity_table: cap_table,
+        catalog_table: cat_table,
+        supervisor_mod: FakeSupervisor,
+        clock: clock,
+        reconcile_interval_ms: 0
+      )
+
+    %{mgr: mgr, store: store, pub: pub, cap_table: cap_table, cat_table: cat_table, op_log: op_log}
+  end
+
+  defp sup_counts do
+    Agent.get(FakeSupervisor, fn s -> {s.creates, s.wakes, s.adopts} end)
+  end
+
+  # Seed a node fact carrying the given group inventory (live members / bundle sets),
+  # so the adoption reconcile has node truth to reconcile against.
+  defp seed_node(ctx, facts) do
+    base = %{
+      configured_id: "node-4",
+      node_id: "node-4",
+      serving_subnet_cidr: "10.200.0.0/24",
+      max_live_vms: 10,
+      live_vms: 0,
+      group_networks: [],
+      group_member_vms: [],
+      group_bundle_sets: []
+    }
+
+    NodeCapacity.put(ctx.cap_table, "node-4", Map.merge(base, facts))
+  end
+
+  # Create + drive an instance to banked with a complete set (leader-only group for
+  # brevity). Returns the instance_id.
+  defp seed_banked(ctx, instance_id, set_id \\ "set-1") do
+    {:ok, _} =
+      GroupStore.create(ctx.store, %{
+        instance_id: instance_id,
+        tenant: "homelab",
+        principal: "system:group:grp-a",
+        workload: "grp-a",
+        node_id: "node-4",
+        subnet_cidr: "10.101.0.0/24",
+        entry_member: "leader",
+        entry_port: 8080,
+        listen_port: 5410,
+        secret: "s"
+      })
+
+    {:ok, _} = GroupStore.member_started(ctx.store, instance_id, %{member_name: "leader", member_index: 0, vm_id: "vm-l", ip: "10.101.0.10"})
+    {:ok, _} = GroupStore.publish(ctx.store, instance_id, "10.0.0.9", 30_010)
+    {:ok, _} = GroupStore.mark(ctx.store, instance_id, :bank)
+    {:ok, _} = GroupStore.bank_ready(ctx.store, instance_id, set_id, [%{name: "leader", snapshot_ref: "snap-l"}])
+    instance_id
+  end
+
+  # -- single-flight ---------------------------------------------------------
+
+  test "single-flight: N concurrent wakes to a banked group produce ONE wake + N replies" do
+    ctx = start_stack(instance_id: "g-1", latency_ms: 40)
+    _ = seed_banked(ctx, "g-1")
+
+    parent = self()
+
+    tasks =
+      for i <- 1..8 do
+        Task.async(fn ->
+          reply = GroupWakeManager.wake(ctx.mgr, "grp-a", "system:group:grp-a")
+          send(parent, {:done, i})
+          reply
+        end)
+      end
+
+    replies = Enum.map(tasks, &Task.await(&1, 5_000))
+
+    # Every caller got the SAME live endpoint.
+    assert Enum.all?(replies, &(&1 == {:ok, %{ip: "10.0.0.9", port: 30_010}}))
+
+    # Exactly ONE wake sequence ran for the burst (single-flight).
+    {creates, wakes, _adopts} = sup_counts()
+    assert creates == 0
+    assert wakes == 1
+  end
+
+  test "create path: no instance at all -> exactly one create_group, N replies" do
+    ctx = start_stack(instance_id: "g-created", latency_ms: 30)
+    # The create records the instance in the store so the FakeSupervisor's publish
+    # lands on a real row: pre-seed a creating instance the create "fills in".
+    {:ok, _} =
+      GroupStore.create(ctx.store, %{
+        instance_id: "g-created",
+        tenant: "homelab",
+        principal: "system:group:grp-a",
+        workload: "grp-a",
+        node_id: "node-4",
+        subnet_cidr: "10.101.0.0/24",
+        entry_member: "leader",
+        entry_port: 8080,
+        listen_port: 5410,
+        secret: "s"
+      })
+
+    {:ok, _} = GroupStore.member_started(ctx.store, "g-created", %{member_name: "leader", member_index: 0, vm_id: "vm-l", ip: "10.101.0.10"})
+
+    tasks = for _ <- 1..5, do: Task.async(fn -> GroupWakeManager.wake(ctx.mgr, "grp-a", "system:group:grp-a") end)
+    replies = Enum.map(tasks, &Task.await(&1, 5_000))
+
+    assert Enum.all?(replies, &match?({:ok, %{ip: "10.0.0.9"}}, &1))
+    {creates, wakes, _} = sup_counts()
+    assert creates == 1
+    assert wakes == 0
+  end
+
+  # -- straggler -------------------------------------------------------------
+
+  test "straggler: a connection to an already-live group resolves WITHOUT a wake" do
+    ctx = start_stack(instance_id: "g-1")
+    _ = seed_banked(ctx, "g-1")
+    # First wake makes it live.
+    assert {:ok, _} = GroupWakeManager.wake(ctx.mgr, "grp-a", "system:group:grp-a")
+    {_c, wakes_after_first, _} = sup_counts()
+    assert wakes_after_first == 1
+
+    # A subsequent connection is a straggler: resolved from the live entry endpoint,
+    # no additional wake.
+    assert {:ok, %{ip: "10.0.0.9", port: 30_010}} = GroupWakeManager.wake(ctx.mgr, "grp-a", "system:group:grp-a")
+    {_c, wakes, _} = sup_counts()
+    assert wakes == 1
+  end
+
+  test "unknown workload is refused" do
+    ctx = start_stack()
+    assert {:error, {:unknown_workload}} = GroupWakeManager.wake(ctx.mgr, "not-a-group", "p")
+  end
+
+  # -- rate limit + park cap -------------------------------------------------
+
+  test "wake-rate limit denies past the window budget (fail-scripted so the workload never goes live)" do
+    # fail: true => the FakeSupervisor never publishes, so the workload never goes
+    # live and each miss re-enters the wake path (not the straggler path), letting the
+    # per-workload wake-rate limit bite. wake_max: 1 allows one wake per window.
+    ctx = start_stack(instance_id: "g-1", fail: true)
+    _ = seed_banked(ctx, "g-1")
+
+    {:ok, mgr} =
+      GroupWakeManager.start_link(
+        name: nil,
+        store: ctx.store,
+        publisher: ctx.pub,
+        capacity_table: ctx.cap_table,
+        catalog_table: ctx.cat_table,
+        supervisor_mod: FakeSupervisor,
+        wake_max: 1,
+        reconcile_interval_ms: 0
+      )
+
+    # First wake: allowed, but the scripted failure means it errors (not live).
+    assert {:error, {:wake_failed, _}} = GroupWakeManager.wake(mgr, "grp-a", "system:group:grp-a")
+    # Second wake within the window: the per-workload budget (1) is spent -> denied.
+    assert {:error, {:wake_rate, _}} = GroupWakeManager.wake(mgr, "grp-a", "system:group:grp-a")
+  end
+
+  # -- adoption matrix -------------------------------------------------------
+
+  test "adoption: a live group (node reports live members) is adopted to running + republished, no VM touched" do
+    ctx = start_stack()
+    instance_id = "g-live"
+
+    # Seed a running instance, then simulate a CP restart by forcing it to a limbo
+    # state the node truth heals: mark it relighting (a stranded transient).
+    _ = seed_banked(ctx, instance_id)
+    {:ok, _} = GroupStore.mark(ctx.store, instance_id, :relight)
+
+    seed_node(ctx, %{
+      group_member_vms: [%{vm_id: "vm-l", group_instance_id: instance_id, member_name: "leader", ip: "10.101.0.10", healthy: true}]
+    })
+
+    :ok = GroupWakeManager.reconcile(ctx.mgr)
+
+    {:ok, inst} = GroupStore.get(ctx.store, instance_id)
+    assert inst.state == :running
+    # The GroupManager owner was respawned for the adopted-live group.
+    {_c, _w, adopts} = sup_counts()
+    assert adopts >= 1
+    # The entry endpoint republishes (the publisher was pinged).
+    assert FakePublisher.count(ctx.pub) >= 1
+  end
+
+  test "adoption: a banked instance with a COMPLETE reported set heals to banked" do
+    ctx = start_stack()
+    instance_id = "g-banked"
+    _ = seed_banked(ctx, instance_id)
+    # Strand it in a relighting limbo; node reports the complete bundle set.
+    {:ok, _} = GroupStore.mark(ctx.store, instance_id, :relight)
+
+    seed_node(ctx, %{
+      group_bundle_sets: [
+        %{set_id: "set-1", group_instance_id: instance_id, created_at_unix_ms: 0, members: [%{member_name: "leader", snapshot_ref: "snap-l"}]}
+      ]
+    })
+
+    :ok = GroupWakeManager.reconcile(ctx.mgr)
+
+    {:ok, inst} = GroupStore.get(ctx.store, instance_id)
+    assert inst.state == :banked
+  end
+
+  test "adoption: a partial reported set is EVICTED (set_id cleared) so the next wake fresh-boots" do
+    ctx = start_stack()
+    instance_id = "g-partial"
+
+    # A two-member group banked, but the node reports only ONE member's bundle.
+    {:ok, _} =
+      GroupStore.create(ctx.store, %{
+        instance_id: instance_id,
+        tenant: "homelab",
+        principal: "system:group:grp-a",
+        workload: "grp-a",
+        node_id: "node-4",
+        subnet_cidr: "10.101.0.0/24",
+        entry_member: "leader",
+        entry_port: 8080,
+        listen_port: 5410,
+        secret: "s"
+      })
+
+    {:ok, _} = GroupStore.member_started(ctx.store, instance_id, %{member_name: "leader", member_index: 0, vm_id: "vm-l", ip: "10.101.0.10"})
+    {:ok, _} = GroupStore.member_started(ctx.store, instance_id, %{member_name: "worker", member_index: 1, vm_id: "vm-w", ip: "10.101.0.11"})
+    {:ok, _} = GroupStore.publish(ctx.store, instance_id, "10.0.0.9", 30_010)
+    {:ok, _} = GroupStore.mark(ctx.store, instance_id, :bank)
+
+    {:ok, _} =
+      GroupStore.bank_ready(ctx.store, instance_id, "set-1", [
+        %{name: "leader", snapshot_ref: "snap-l"},
+        %{name: "worker", snapshot_ref: "snap-w"}
+      ])
+
+    # Node reports ONLY the leader's bundle (worker's is gone): a partial set.
+    seed_node(ctx, %{
+      group_bundle_sets: [
+        %{set_id: "set-1", group_instance_id: instance_id, created_at_unix_ms: 0, members: [%{member_name: "leader", snapshot_ref: "snap-l"}]}
+      ]
+    })
+
+    :ok = GroupWakeManager.reconcile(ctx.mgr)
+
+    {:ok, inst} = GroupStore.get(ctx.store, instance_id)
+    assert inst.set_id == nil
+  end
+
+  # -- degraded-group wake ---------------------------------------------------
+
+  test "degraded-group wake: a running group with a dead NON-entry member routes normally (straggler, no wake)" do
+    ctx = start_stack()
+    instance_id = "g-degraded"
+
+    {:ok, _} =
+      GroupStore.create(ctx.store, %{
+        instance_id: instance_id,
+        tenant: "homelab",
+        principal: "system:group:grp-a",
+        workload: "grp-a",
+        node_id: "node-4",
+        subnet_cidr: "10.101.0.0/24",
+        entry_member: "leader",
+        entry_port: 8080,
+        listen_port: 5410,
+        secret: "s"
+      })
+
+    {:ok, _} = GroupStore.member_started(ctx.store, instance_id, %{member_name: "leader", member_index: 0, vm_id: "vm-l", ip: "10.101.0.10"})
+    {:ok, _} = GroupStore.member_started(ctx.store, instance_id, %{member_name: "worker", member_index: 1, vm_id: "vm-w", ip: "10.101.0.11"})
+    {:ok, _} = GroupStore.publish(ctx.store, instance_id, "10.0.0.9", 30_010)
+    # A non-entry member falls unhealthy: the group is DEGRADED (a flag), still running.
+    {:ok, _} = GroupStore.set_member_health(ctx.store, instance_id, "worker", false)
+
+    assert {true, "worker"} = GroupStore.degraded?(ctx.store, "grp-a")
+
+    # A connection routes normally: the entry is live, so it is a straggler (no wake).
+    assert {:ok, %{ip: "10.0.0.9", port: 30_010}} = GroupWakeManager.wake(ctx.mgr, "grp-a", "system:group:grp-a")
+    {_c, wakes, _} = sup_counts()
+    assert wakes == 0
+  end
+end

--- a/projects/embervm/control/test/embervm/group_wake_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_wake_manager_test.exs
@@ -89,8 +89,14 @@ defmodule Embervm.GroupWakeManagerTest do
       {{:ok, endpoint}, s}
     end
 
+    # Drive the instance to running with its published entry endpoint, exactly as a
+    # real relight (banked -> relighting -> creating -> running -> publish) leaves it,
+    # so the brain's straggler re-read of GroupStore.entry_endpoint/2 sees the live
+    # endpoint. Uses the ETS-force adopt path (adopt_state + adopt_endpoint) to reach
+    # running from banked without replaying every FSM edge in the fake.
     defp publish_running(%{store: store, instance_id: instance_id}) when is_binary(instance_id) do
-      _ = GroupStore.publish(store, instance_id, "10.0.0.9", 30_010)
+      _ = GroupStore.adopt_state(store, instance_id, :running)
+      _ = GroupStore.adopt_endpoint(store, instance_id, "10.0.0.9", 30_010)
       :ok
     end
 
@@ -144,6 +150,13 @@ defmodule Embervm.GroupWakeManagerTest do
         capacity_table: cap_table,
         catalog_table: cat_table,
         supervisor_mod: FakeSupervisor,
+        # The shared DNAT-derivation values (same as the live publish): a group /24
+        # entry at .10 in the 10.101.0.0/16 supernet derives vm_port = 30000 + 10 =
+        # 30010, published as {pod_ip 10.0.0.9, 30010} -> the endpoint the fake's
+        # publish_running records AND adoption must re-derive identically.
+        supernet: "10.101.0.0/16",
+        port_base: 30_000,
+        pod_ip: "10.0.0.9",
         clock: clock,
         reconcile_interval_ms: 0
       )
@@ -321,6 +334,13 @@ defmodule Embervm.GroupWakeManagerTest do
 
     {:ok, inst} = GroupStore.get(ctx.store, instance_id)
     assert inst.state == :running
+    # The DNAT entry endpoint was RE-DERIVED from the entry member's node-reported ip
+    # (.10 -> 30000 + 10) and forced back, so the republished endpoint is IDENTICAL to
+    # the pre-restart live publish {pod_ip 10.0.0.9, 30010} (NOT the fallback {tap ip,
+    # guest port}). This is the "republish identical snapshot without touching a VM" bar.
+    assert %{ip: "10.0.0.9", port: 30_010} = GroupStore.entry_endpoint(ctx.store, "grp-a")
+    assert inst.entry_ip == "10.0.0.9"
+    assert inst.entry_port_published == 30_010
     # The GroupManager owner was respawned for the adopted-live group.
     {_c, _w, adopts} = sup_counts()
     assert adopts >= 1

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.84
+      targetRevision: 0.1.85
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
EmberVM R5 **Task 6**: the composite control-plane brain. One process per group instance running the ordered start/bank/relight state machine, one store projecting facts, one publisher extension making the entry reachable.

## What's here
- **`Embervm.GroupState`** — the composite FSM (creating -> running -> banking -> banked -> relighting/fresh_booting -> running; terminal destroyed/failed). `degraded` is a flag on `running`, not a state. Illegal transitions raise.
- **`Embervm.GroupStore`** — ETS hot set (instances + members tables) over the `group_instances`/`group_members` projections, rebuilt on boot; write-through (durable op BEFORE ETS visibility); group-level singleton gate; degraded-flag recompute; entry-endpoint fact; lowest-free /24 held-subnet set; set-completeness derivation with eager eviction of a partial set.
- **`Embervm.GroupManager`** (one supervised process per group instance via a new `DynamicSupervisor` + `Registry`) — idempotent CreateGroupNetwork, role-ordered health-gated member starts (parallel within a `startOrder`, gated between orders), `EMBER_GROUP_*` env compose (peer map from the deterministic `.10+i` plan; secret from `secretRef` or minted), create-atomic teardown-to-failed.
- **`EndpointPublisher`** composite extension — `group|<workload>` cluster + `group-<listen_port>` listener, live entry member when running / activator fallback otherwise, byte-identical no-composite regression.
- **Chart** — composite L4 range (5410-5419) as `group-<port>` container ports (Envoy DaemonSet + CP pod), `group-<port>` Service TCP ports, composite activator env; `EMBERVM_COMPOSITE_SUPERNET`/`PORT_BASE` + pod IP wired to the CP from the shared `noded.compositeSupernet` / `noded.servingPortBase` values.
- **`GET /v1/groups/{workload}`** management endpoint.
- **ExUnit** — FSM exhaustive/illegal, ordered-start property, create-failure teardown, set-completeness eviction, publisher composite render + activator swap + no-composite regression, secret stable-vs-minted.

## Lockstep guards (per coordinator direction)
- Group `/24` allocation: **lowest-free** from the composite supernet (pure function of live state; freed /24s reused).
- Entry endpoint: CP **re-derives** `vmPort = portBase + hostOffset(entryIP, supernet)` from the SAME shared chart values that feed noded (`noded/serving/net.go:PortForIP`), rendered into both pods. The derived port lives in the ETS/op-log fact the publisher reads, so Task 7 can later swap to node-reported truth without a migration.

`helm template` verified for the new ports/env. Chart bumped 0.1.84 -> 0.1.85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hRr3Xsj74f6BzB47RUvRE