### PR TITLE
feat(embervm): group idle-to-bank, ttl, forced roll, and degraded handling

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.85
+version: 0.1.86

--- a/projects/embervm/control/lib/embervm/activator_splices.ex
+++ b/projects/embervm/control/lib/embervm/activator_splices.ex
@@ -1,0 +1,144 @@
+defmodule Embervm.ActivatorSplices do
+  @moduledoc """
+  A per-workload live-splice counter for composite groups (R5, Task 8): the ONE
+  activity signal Envoy cannot see. `Embervm.TcpActivator` splices a client
+  connection to a group's entry member in an ephemeral, unsupervised handler
+  process; a long-lived session that BEGAN during a wake (the activator dialed the
+  entry member directly, the byte pump runs for the life of the session) never
+  re-enters the node Envoy's `downstream_cx_active` counter for the entry listener,
+  so a group with a live activator splice can read `cx_active == 0` on the entry
+  listener and LOOK idle when it is not.
+
+  `Embervm.GroupSweeper`'s idle predicate must NOT bank a group with a live
+  activator splice (severing it would drop the session mid-stream, the exact case
+  standing decision 7 forbids), so this module tracks the control plane's OWN count
+  of in-flight splices per workload. It is a plain `:ets.update_counter` table (a
+  monotone increment on splice start, a decrement on splice end): the sweeper reads
+  `live?/2`, the activator brackets each composite splice with `incr/2` .. `decr/2`.
+
+  ## why an explicit counter, not a process registry
+
+  A `Registry` keyed by workload would also count live splices, but every splice
+  handler would have to register + hold a monitored entry, and the sweeper would
+  scan the registry per tick. A single ETS counter cell per workload is cheaper on
+  both the hot splice path (one `update_counter`) and the sweep read (one lookup),
+  and it never leaks a stale entry the way a crashed-before-unregister process could
+  (see the crash note below).
+
+  ## crash safety: the decrement is bracketed, a crash is a NET OVER-count
+
+  The activator brackets a composite splice with `incr` before the byte pump and
+  `decr` in an `after`, so a normal splice teardown decrements exactly once. A
+  handler CRASH between `incr` and the `after` would leak one count (the cell reads
+  one-too-high forever). That error is SAFE for warmth: an over-count only ever
+  keeps a group from banking (it reads busier than it is), never banks a busy group.
+  The counter is clamped at zero on decrement so an over-decrement (double-`decr`, or
+  a `decr` racing a fresh cell) can never drive it negative and thus never FAKE
+  idleness. The fail-direction is deliberately toward warmth, exactly the sweeper's
+  scrape-fails-open posture: when in doubt, do not bank.
+
+  ## test seam
+
+  `start_link/1` names the table (default `Embervm.ActivatorSplices`), so a test can
+  run an isolated counter (`name: :"splices_\#{n}"`) and inject it into both the
+  activator and the sweeper. `live?/2` on an unstarted or unknown table reads
+  `false` (no splice known), the safe default for a sweeper wired without an
+  activator (production always starts the table; a unit test of the sweeper alone
+  can omit it and every group simply reads no-splice).
+  """
+
+  use GenServer
+
+  @table __MODULE__
+
+  # -- Client API ------------------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    # The process is named after its TABLE (the counter's identity), not a fixed
+    # module name: a test starts an isolated counter under `table: :splices_<n>`
+    # alongside the app's own `Embervm.ActivatorSplices` counter without a name
+    # collision (the reads go by table name, so the process name only needs to be
+    # unique-per-table). An explicit `name: nil` starts an unnamed process.
+    name = Keyword.get(opts, :name, Keyword.get(opts, :table, @table))
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  The ETS table name a splice counter uses. `start_link` with `table: :foo` (or the
+  default) creates a public named table `:foo`; `incr/2`, `decr/2`, and `live?/2`
+  take that same table name so a test can point the activator and the sweeper at one
+  isolated counter.
+  """
+  @spec table(GenServer.server()) :: atom()
+  def table(server \\ __MODULE__), do: GenServer.call(server, :table)
+
+  @doc """
+  Increment the live-splice count for `workload` on `table`. Called by the activator
+  the instant a composite splice's byte pump begins. A first splice for a workload
+  creates the cell at 1. A nil/absent table is a no-op (a control plane wired
+  without a splice counter never blocks banking on a signal it does not track).
+  """
+  @spec incr(atom(), String.t()) :: :ok
+  def incr(table, workload) when is_atom(table) and is_binary(workload) do
+    if table_exists?(table) do
+      _ = :ets.update_counter(table, workload, {2, 1}, {workload, 0})
+      :ok
+    else
+      :ok
+    end
+  end
+
+  @doc """
+  Decrement the live-splice count for `workload`, clamped at zero (an
+  over-decrement can never fake idleness). Called by the activator in the `after`
+  that brackets a composite splice, so a normal teardown returns the cell to its
+  pre-splice value. A nil/absent table is a no-op.
+  """
+  @spec decr(atom(), String.t()) :: :ok
+  def decr(table, workload) when is_atom(table) and is_binary(workload) do
+    if table_exists?(table) do
+      # {2, -1, 0, 0}: decrement position 2 by 1, but a threshold of 0 with a
+      # set-value of 0 clamps at zero (update_counter's threshold semantics), so the
+      # count never goes negative and never fakes idleness.
+      _ = :ets.update_counter(table, workload, {2, -1, 0, 0}, {workload, 0})
+      :ok
+    else
+      :ok
+    end
+  end
+
+  @doc """
+  Whether `workload` currently has ANY live activator splice on `table` (count > 0).
+  The sweeper's idle predicate ANDs `not live?/2` with Envoy's `cx_active == 0` +
+  flat `cx_total` before banking. An unstarted/unknown table reads `false` (no
+  splice known), the safe default for a unit test of the sweeper alone.
+  """
+  @spec live?(atom(), String.t()) :: boolean()
+  def live?(table, workload) when is_atom(table) and is_binary(workload) do
+    if table_exists?(table) do
+      case :ets.lookup(table, workload) do
+        [{^workload, n}] -> n > 0
+        [] -> false
+      end
+    else
+      false
+    end
+  end
+
+  defp table_exists?(table), do: :ets.whereis(table) != :undefined
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    table = Keyword.get(opts, :table, @table)
+    # Public named table so the hot splice path (activator handler processes) and the
+    # sweeper's read both reach it directly, no GenServer call on the byte-pump path.
+    ^table = :ets.new(table, [:set, :public, :named_table, {:write_concurrency, true}])
+    {:ok, %{table: table}}
+  end
+
+  @impl true
+  def handle_call(:table, _from, state), do: {:reply, state.table, state}
+end

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -232,6 +232,14 @@ defmodule Embervm.Application do
       # a control-plane restart republishes exactly the same entry endpoint without
       # touching any VM. With no composite node wired, a wake denies :no_capacity.
       {Embervm.GroupWakeManager, group_wake_manager_opts()},
+      # The composite activator live-splice counter (R5, Task 8): a per-workload ETS
+      # count of the byte-pump splices the TcpActivator holds open for a group's entry
+      # member. A splice that began during a wake never re-enters the entry listener's
+      # Envoy cx_active counter, so the GroupSweeper's idle predicate reads this to
+      # avoid banking a group with a live session (standing decision 7). Placed BEFORE
+      # TcpActivator (which increments it per composite splice) and GroupSweeper (which
+      # reads it); it owns only a public named ETS table, so a restart is cheap.
+      {Embervm.ActivatorSplices, []},
       # The L4 TCP activator (R4, Task 8; R5 composite): binds the values-declared
       # stateful (5400-5409) AND composite (5410-5419) port ranges and dispatches an
       # accepted connection to StatefulManager.wake/3 or GroupWakeManager.wake/3
@@ -253,6 +261,18 @@ defmodule Embervm.Application do
       # wake path). With no stats_base wired (reuses EMBERVM_SERVING_STATS_BASE) every
       # tick fails open and banks nothing, mirroring ServingSweeper's no-op default.
       {Embervm.StatefulSweeper, stateful_sweeper_opts()},
+      # The composite-group lifecycle-economics sweeper (R5, Task 8): the group
+      # idle-to-bank / max-lifetime / banked-TTL loop, plus the forced-roll verb the
+      # Router's DELETE /v1/groups/:name/instance calls. It scrapes the SAME node Envoy
+      # stats port for the group's entry listener L4 connection counters (keyed by the
+      # group-<entry.listenPort> stat_prefix), ANDs in the ActivatorSplices count (the
+      # session-splice signal Envoy cannot see), excludes degraded groups from banking
+      # (decision 11), and drives GroupManager.Supervisor.bank_group/2. Placed AFTER
+      # GroupStore/EndpointPublisher (it mutates + re-pushes) and AFTER the
+      # GroupManager.Supervisor + GroupWakeManager + ActivatorSplices it drives/reads.
+      # With no stats_base wired (reuses EMBERVM_SERVING_STATS_BASE) every tick fails
+      # open and banks nothing, mirroring StatefulSweeper's no-op default.
+      {Embervm.GroupSweeper, group_sweeper_opts()},
       # The op-log sweeper (ADR embervm/002): scheduled bounded-batch compaction of
       # the durable projection tables + ops-journal prefix. Placed LATE, right before
       # Bandit: it depends ONLY on the op-log (which starts early), so under
@@ -602,6 +622,29 @@ defmodule Embervm.Application do
     end
   end
 
+  # GroupSweeper (R5, Task 8) config: the sweep cadence, the node Envoy stats base URL
+  # (reuses sweeper_stats_base/0, EMBERVM_SERVING_STATS_BASE: composite entry listeners
+  # live on the SAME node Envoy admin the serving/stateful scrape reaches), the
+  # activator live-splice table (the idle predicate's third clause), and the
+  # max-lifetime drain patience window. Unset stats_base disables the scrape, so every
+  # tick fails open and banks nothing, exactly the StatefulSweeper default.
+  defp group_sweeper_opts do
+    [
+      sweep_interval_ms: group_sweep_interval_ms(),
+      stats_base: sweeper_stats_base(),
+      splices_table: Embervm.ActivatorSplices,
+      lifetime_drain_max_ms: int_env_or_nil("EMBERVM_GROUP_LIFETIME_DRAIN_MAX_MS")
+    ]
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+  end
+
+  defp group_sweep_interval_ms do
+    case trimmed_env("EMBERVM_GROUP_SWEEP_INTERVAL_MS") do
+      "" -> 30_000
+      raw -> String.to_integer(raw)
+    end
+  end
+
   # StatefulManager (R4, Task 8) config: the adoption reconcile cadence + the
   # wake-rate/parked-cap knobs. Defaults keep the reconcile timer ON in
   # production; the module defaults the caps (10/min wake, 16 parked), an order
@@ -653,7 +696,10 @@ defmodule Embervm.Application do
   defp tcp_activator_opts do
     [
       port_range: stateful_activator_port_range() ++ composite_activator_port_range(),
-      activator_ip: stateful_activator_ip()
+      activator_ip: stateful_activator_ip(),
+      # The composite live-splice counter table the activator increments per group
+      # splice and the GroupSweeper reads for its idle predicate (Task 8).
+      splices_table: Embervm.ActivatorSplices
     ]
   end
 

--- a/projects/embervm/control/lib/embervm/group_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_manager.ex
@@ -90,6 +90,7 @@ defmodule Embervm.GroupManager do
     StartGroupMemberRequest,
     StartGroupMemberResponse,
     StopGroupMemberRequest,
+    StopGroupMemberResponse,
     ResourceSpec,
     Trace
   }
@@ -145,6 +146,42 @@ defmodule Embervm.GroupManager do
     GenServer.call(server, :wake_group, :infinity)
   end
 
+  @doc """
+  Banks the whole group as ONE set (R5, Task 8), the bank half of the economics
+  loop the `Embervm.GroupSweeper` drives once a group is confirmed idle. The
+  instance MUST already be in the transient `banking` state: the SWEEPER moves it
+  `running -> banking` (which drops the entry endpoint from the fan-out) and installs
+  the activator BEFORE calling, so a racing connection parks on the activator, not a
+  VM about to be paused (standing decision 7, mirroring StatefulSweeper's
+  unpublish-then-bank). The sequence, decision 3 (all-or-nothing) + decision 10 (an
+  honest pause-spread number):
+
+    1. mint ONE `set_id` shared across the members, and `StopGroupMember(BANK)` every
+       LIVE member under `group/<set_id>/<member>/` (each BANK pauses, snapshots, AND
+       destroys that member's VM per the proto), collecting `{member, snapshot_ref}`;
+    2. if EVERY member banked, record the whole set ATOMICALLY
+       (`GroupStore.bank_ready/4` -> one `group_banked` append, `banking -> banked`,
+       stamping `set_id` + each member's `snapshot_ref`, and dropping the entry
+       endpoint), then re-publish so the activator install is current;
+    3. if ANY member's BANK failed, ABORT (`banking -> running` via `bank_abort`,
+       ETS-only): the partial snapshots are orphans the daemon's own bundle GC
+       reclaims, and the group returns to `running`. The sweeper re-publishes so the
+       still-live group re-enters the fan-out (a failed bank must not leave a warm
+       group dark).
+
+  A crash mid-bank strands the instance in `banking`; adoption heals it (it finds no
+  live members and no complete set and resolves the instance fresh-bootable).
+
+  Returns `{:ok, %{set_id, banked: n, pause_spread_ms: ms}}` on a clean whole-set
+  bank (the closure gate reads `pause_spread_ms`, decision 10), or
+  `{:error, reason}` on an abort (the group is back `running`). Blocks until the
+  bank completes or aborts.
+  """
+  @spec bank_group(GenServer.server()) :: {:ok, map()} | {:error, term()}
+  def bank_group(server) do
+    GenServer.call(server, :bank_group, :infinity)
+  end
+
   @doc "The group instance's current entry endpoint (or nil), for tests + straggler resolution."
   @spec entry_endpoint(GenServer.server()) :: map() | nil
   def entry_endpoint(server) do
@@ -183,6 +220,9 @@ defmodule Embervm.GroupManager do
         Keyword.get(opts, :evict_snapshot_fun, &default_evict_snapshot/2),
       get_secret_fun: Keyword.get(opts, :get_secret_fun, &Embervm.K8s.get_secret/2),
       secret_fun: Keyword.get(opts, :secret_fun, &mint_secret/0),
+      # The bank set_id minter (injected in tests to pin the opaque set directory);
+      # production mints instance_id + bank-start clock (see mint_set_id/2).
+      set_id_fun: Keyword.get(opts, :set_id_fun),
       clock: Keyword.get(opts, :clock, &default_clock/0)
     }
 
@@ -197,6 +237,11 @@ defmodule Embervm.GroupManager do
 
   def handle_call(:wake_group, _from, state) do
     {reply, state} = do_wake_group(state)
+    {:reply, reply, state}
+  end
+
+  def handle_call(:bank_group, _from, state) do
+    {reply, state} = do_bank_group(state)
     {:reply, reply, state}
   end
 
@@ -679,6 +724,186 @@ defmodule Embervm.GroupManager do
     end
 
     :ok
+  end
+
+  # -- bank sequence (whole-set BANK off running, R5 Task 8) ------------------
+
+  # The whole-set bank: StopGroupMember(BANK) every live member under ONE shared
+  # set_id, and either record the set atomically (all banked, banking -> banked) or
+  # abort back to running (any member failed, banking -> running). The instance is
+  # already `banking` (the sweeper moved it there and installed the activator before
+  # calling), so a racing connection already parks on the activator; this sequence
+  # never re-publishes a live endpoint (a clean bank drops it via group_banked; an
+  # abort returns to running and the sweeper re-publishes).
+  defp do_bank_group(state) do
+    with {:ok, instance} <- fetch_instance(state),
+         :banking <- instance.state do
+      members = live_members(state)
+
+      if members == [] do
+        # A banking group with no live member rows: nothing to bank. Abort back to
+        # running so the sweeper can re-publish (an empty group is a degraded/adoption
+        # edge the reconcile heals, not the bank's concern).
+        _ = GroupStore.mark(state.store, instance.instance_id, :bank_abort)
+        {{:error, :no_live_members}, state}
+      else
+        attempt_bank(state, instance, members)
+      end
+    else
+      {:error, _reason} = error ->
+        {error, state}
+
+      other_state when is_atom(other_state) ->
+        # Not banking (a race: already banked, destroyed, or a sweeper that did not
+        # pre-mark). The sweeper re-reads the store next tick; return an error it ignores.
+        {{:error, {:not_banking, other_state}}, state}
+    end
+  end
+
+  defp attempt_bank(state, instance, members) do
+    set_id = mint_set_id(state, instance)
+    {results, pause_spread_ms} = bank_members_parallel(state, members, set_id)
+
+    failed = Enum.filter(results, &match?({:error, _}, &1))
+
+    if failed == [] do
+      finish_bank(state, instance, set_id, results, pause_spread_ms)
+    else
+      abort_bank(state, instance, failed)
+    end
+  end
+
+  # StopGroupMember(BANK) every live member in PARALLEL under the shared set_id (bank
+  # order is irrelevant: each BANK pauses+snapshots+destroys its own VM independently,
+  # and crash-consistency is per-VM, never cross-member, per the GroupState moduledoc).
+  # Returns the per-member results and the pause-spread (decision 10): the wall-clock
+  # span between the first and last member's BANK completing, the honesty number the
+  # closure gate reads. Each task body is wrapped so a raised/exited BANK becomes an
+  # {:error, _} result rather than taking the GroupManager down mid-bank.
+  defp bank_members_parallel(state, members, set_id) do
+    started = state.clock.()
+
+    results =
+      members
+      |> Enum.map(fn member ->
+        Task.async(fn ->
+          try do
+            bank_one_member(state, member, set_id)
+          rescue
+            e -> {:error, {:member_bank_crashed, member.member_name, e}}
+          catch
+            kind, reason -> {:error, {:member_bank_crashed, member.member_name, {kind, reason}}}
+          end
+        end)
+      end)
+      |> Enum.map(&Task.await(&1, :infinity))
+
+    pause_spread_ms = max(state.clock.() - started, 0)
+    {results, pause_spread_ms}
+  end
+
+  defp bank_one_member(state, member, set_id) do
+    req = %StopGroupMemberRequest{
+      trace: %Trace{workload: state.workload},
+      vm_id: member.vm_id,
+      mode: :STOP_GROUP_MEMBER_MODE_BANK,
+      set_id: set_id,
+      member_name: member.member_name
+    }
+
+    with {:ok, channel} <- safe_channel(state, state.node_id),
+         {:ok, %StopGroupMemberResponse{snapshot_ref: ref}} when is_binary(ref) and ref != "" <-
+           state.stop_group_member_fun.(channel, req) do
+      {:ok, %{name: member.member_name, snapshot_ref: ref}}
+    else
+      other -> {:error, {:member_bank_failed, member.member_name, other}}
+    end
+  rescue
+    e -> {:error, {:member_bank_raised, member.member_name, e}}
+  catch
+    kind, reason -> {:error, {:member_bank_raised, member.member_name, {kind, reason}}}
+  end
+
+  # Every member banked: record the whole set ATOMICALLY (one group_banked append
+  # stamping set_id + each member's snapshot_ref, dropping the entry endpoint) and
+  # re-publish so the activator install is current (bank_ready dropped the endpoint,
+  # so this publish swaps in the activator for the now-empty group cluster).
+  defp finish_bank(state, instance, set_id, results, pause_spread_ms) do
+    members = for {:ok, m} <- results, do: m
+
+    case GroupStore.bank_ready(state.store, instance.instance_id, set_id, members) do
+      {:ok, _} ->
+        Embervm.EndpointPublisher.publish(state.publisher)
+
+        Logger.info("embervm group banked",
+          workload: state.workload,
+          instance_id: instance.instance_id,
+          set_id: set_id,
+          members: length(members),
+          pause_spread_ms: pause_spread_ms
+        )
+
+        {{:ok, %{set_id: set_id, banked: length(members), pause_spread_ms: pause_spread_ms}}, state}
+
+      {:error, reason} ->
+        # The durable group_banked append failed AFTER every member's VM was already
+        # snapshotted+destroyed: the set exists on disk but the log never recorded it.
+        # We cannot return to a live group (the VMs are gone). Fail the instance so the
+        # next connection fresh-boots (the orphan snapshots are the daemon's GC and the
+        # adoption casualty path's concern), the honest terminal for an unrecordable
+        # bank.
+        _ =
+          GroupStore.transition(
+            state.store,
+            instance.instance_id,
+            :fail,
+            :group_failed,
+            %{reason: "bank_record_failed"},
+            %{}
+          )
+
+        Embervm.EndpointPublisher.publish(state.publisher)
+        {{:error, {:bank_record_failed, reason}}, state}
+    end
+  end
+
+  # A member BANK failed: abort back to running (banking -> running, ETS-only). The
+  # members that DID bank left orphan snapshots (the daemon's bundle GC reclaims them)
+  # and their VMs are gone; the members that did NOT are still live. The group returns
+  # to running with a partial member set, which the health/adoption path reconciles;
+  # the sweeper re-publishes so the still-live group re-enters the fan-out. A failed
+  # bank must never leave a warm group dark.
+  defp abort_bank(state, instance, failed) do
+    _ = GroupStore.mark(state.store, instance.instance_id, :bank_abort)
+
+    Logger.warning("embervm group: bank aborted (member failure), returning to running",
+      workload: state.workload,
+      instance_id: instance.instance_id,
+      failures: length(failed)
+    )
+
+    {{:error, {:bank_partial, failed}}, state}
+  end
+
+  # The live member rows (a live vm_id): the members a bank pauses+snapshots. A banked
+  # instance's member rows carry nil vm_id (the bank cleared them), so this is empty
+  # for a non-running instance, the guard do_bank_group already enforces.
+  defp live_members(state) do
+    state.store
+    |> GroupStore.members(state.instance_id)
+    |> Enum.filter(fn m -> is_binary(m.vm_id) and m.vm_id != "" end)
+  end
+
+  # A shared set_id across the members of ONE bank (the opaque set directory
+  # group/<set_id>/<member>/ each member's snapshot is written under). The instance_id
+  # plus the bank's start clock keeps it unique across successive banks of the same
+  # instance (a re-bank after a wake gets a fresh set dir, never colliding with the
+  # evicted prior set's dir). The id_fun seam lets a test pin it.
+  defp mint_set_id(state, instance) do
+    case Map.get(state, :set_id_fun) do
+      fun when is_function(fun, 0) -> fun.()
+      _ -> "set-#{instance.instance_id}-#{state.clock.()}"
+    end
   end
 
   # -- member address plan (deterministic, lockstep with the watcher + noded) -

--- a/projects/embervm/control/lib/embervm/group_manager/supervisor.ex
+++ b/projects/embervm/control/lib/embervm/group_manager/supervisor.ex
@@ -114,6 +114,31 @@ defmodule Embervm.GroupManager.Supervisor do
   end
 
   @doc """
+  Banks the live group `instance_id` of `workload` as ONE set (R5, Task 8): locate
+  (or spawn) the GroupManager child bound to the instance and drive its
+  `bank_group/1`. The sweeper calls this once a group is confirmed idle (it already
+  unpublished the entry endpoint). Returns `{:ok, %{set_id, banked, pause_spread_ms}}`
+  on a clean whole-set bank or `{:error, reason}` on an abort (the group is back
+  `running` and the sweeper re-publishes). A group with no live owner process (e.g.
+  a CP restart that has not re-adopted it yet) spawns one bound to the instance so
+  the bank has a driver. A missing catalog entry / anchor node is `{:error, reason}`.
+  """
+  @spec bank_group(String.t(), String.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  def bank_group(workload, instance_id, opts \\ []) do
+    defaults = Application.get_env(:embervm, :group_manager_defaults, [])
+    opts = Keyword.merge(defaults, opts)
+
+    catalog_table = Keyword.get(opts, :catalog_table, WorkloadCatalog.table())
+    capacity_table = Keyword.get(opts, :capacity_table, NodeCapacity.table())
+
+    with {:ok, entry} <- GroupManager.catalog_group(catalog_table, workload),
+         {:ok, node_id} <- anchor_node(capacity_table),
+         {:ok, pid} <- start_or_get_child(workload, instance_id, entry, node_id, opts) do
+      GroupManager.bank_group(pid)
+    end
+  end
+
+  @doc """
   Adoption (R5, Task 7): (re)spawn the GroupManager child for a live-adopted instance
   so a later bank/relight has an owner, WITHOUT driving any lifecycle. Idempotent: a
   child already registered under the workload is left as-is. Returns `:ok`. Never
@@ -217,6 +242,7 @@ defmodule Embervm.GroupManager.Supervisor do
       :evict_snapshot_fun,
       :get_secret_fun,
       :secret_fun,
+      :set_id_fun,
       :clock
     ]
   end

--- a/projects/embervm/control/lib/embervm/group_store.ex
+++ b/projects/embervm/control/lib/embervm/group_store.ex
@@ -200,6 +200,20 @@ defmodule Embervm.GroupStore do
     GenServer.call(store, {:set_member_health, instance_id, member_name, healthy?})
   end
 
+  @doc """
+  Touch a group instance's `last_active_at` (and `updated_at`) to `ts`, WITHOUT an
+  FSM transition or an op-log append (activity is a live node-Envoy stats fact, not a
+  durable lifecycle event). `Embervm.GroupSweeper` calls this on every tick a
+  workload's entry listener showed connection activity, so the banked-TTL and
+  idle-age baselines measure from the last real traffic. A no-op for an unknown
+  instance. Returns the updated instance or `:error`. Mirrors
+  `StatefulStore.touch_active/3`.
+  """
+  @spec touch_active(GenServer.server(), String.t(), integer()) :: {:ok, map()} | :error
+  def touch_active(store \\ __MODULE__, instance_id, ts) do
+    GenServer.call(store, {:touch_active, instance_id, ts})
+  end
+
   @doc "The instance's hot-set row, or `:error` if unknown."
   @spec get(GenServer.server(), String.t()) :: {:ok, map()} | :error
   def get(store \\ __MODULE__, instance_id) do
@@ -543,6 +557,18 @@ defmodule Embervm.GroupStore do
 
   def handle_call({:set_member_health, instance_id, member_name, healthy?}, _from, state) do
     do_set_member_health(state, instance_id, member_name, healthy?)
+  end
+
+  def handle_call({:touch_active, instance_id, ts}, _from, state) do
+    case fetch(state, instance_id) do
+      {:ok, instance} ->
+        updated = %{instance | last_active_at: ts, updated_at: ts}
+        :ets.insert(state.instances, {instance_id, updated})
+        {:reply, {:ok, updated}, state}
+
+      {:error, _} ->
+        {:reply, :error, state}
+    end
   end
 
   def handle_call({:get, instance_id}, _from, state) do

--- a/projects/embervm/control/lib/embervm/group_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/group_sweeper.ex
@@ -1,0 +1,1054 @@
+defmodule Embervm.GroupSweeper do
+  @moduledoc """
+  The composite-group lifecycle-economics loop (R5, Task 8): the group
+  generalization of `Embervm.StatefulSweeper`, and the piece that makes an idle
+  composite cluster actually cost ONE bundle set on disk rather than N running
+  member VMs forever. Like stateful/serving a group instance has NO per-instance
+  supervised economic process (it is a set of ETS rows in `Embervm.GroupStore`; the
+  `Embervm.GroupManager` owns the create/wake/bank sequence but not the timer), so
+  this ONE process drives every economic decision on a timer: it scrapes each node
+  Envoy's L4 connection counters for the group's ENTRY listener to detect idleness,
+  banks idle groups (unpublish then drive `GroupManager.bank_group`), expires
+  over-lifetime ones (destroy the group + its network), GCs stale banked sets
+  (warmth-only: an expired set IS the instance's end), and answers the forced-roll
+  management verb.
+
+  ## the idle signal: the entry listener's L4 cx counts PLUS live activator splices
+
+  A composite group contributes exactly ONE L4 entry endpoint (the entry member's
+  DNAT projection), fronted by a node Envoy `tcp_proxy` listener named
+  `group-<entry.listenPort>` (Task 4's `stat_prefix`). So the Envoy idle signal is
+  that ONE listener's per-connection stats, exactly as stateful reads `state-<port>`:
+
+    * `downstream_cx_active`: currently-open connections to the entry. MUST be zero
+      before a bank is considered (never sever a live connection to bank).
+    * `downstream_cx_total`: the cumulative connection count; a zero delta across
+      `idleBankSeconds` means no NEW connection arrived either.
+
+  Intra-group traffic (member-to-member chatter on the private /24 bridge) is
+  invisible to Envoy BY CONSTRUCTION (it never crosses the entry listener), and
+  correctly does NOT count as activity: the entry-listener cx counts are the right
+  (and only) Envoy signal.
+
+  BUT the entry listener's cx counts miss one thing the control plane itself owns: a
+  long-lived session SPLICED by `Embervm.TcpActivator` during a wake. The activator
+  dials the entry member directly and byte-pumps for the life of the session; that
+  connection never re-enters the node Envoy's entry-listener `cx_active` counter, so
+  a group with a live splice can read `cx_active == 0` and LOOK idle. So the GROUP
+  idle predicate ADDs a third clause the stateful one lacks: zero live activator
+  splices (`Embervm.ActivatorSplices.live?/2`, the control plane's own count of
+  in-flight splices for this workload). A group is idle-bankable iff
+  `cx_active == 0` AND the `cx_total` delta is `0` AND there are zero live activator
+  splices.
+
+  ## degraded groups are EXCLUDED from banking (decision 11), visibly
+
+  A group carrying a `degraded_member` flag (a member fell unhealthy while the group
+  stayed up) is NEVER banked: a bank snapshots the WHOLE set, but a degraded group is
+  missing a live member, so a bank would either write a PARTIAL set (violating the
+  all-or-nothing set invariant, decision 3) or capture a broken group. The exclusion
+  is a LOGGED, VISIBLE fact (a `bank_excluded_degraded` log line per idle-but-degraded
+  group), and the group stays live until it is HEALED (a forced roll, or a member
+  recovering) or EXPIRED (max-lifetime). It is exactly the convergence lever the
+  forced roll below exists to pull.
+
+  ## fail-open for warmth (ADR embervm/001), exactly as stateful/serving
+
+  A scrape failure yields no reading for that node this tick: idle detection is
+  suppressed for every composite workload on that node, never banking on missing or
+  stale stats. Lifetime/TTL GC still run (they read the durable store). A fresh
+  sweeper's first tick only baselines (no prior reading to delta against).
+
+  ## the bank sequence (no drain window, standing decision 7)
+
+  Like stateful, an L4 group connection has no natural completion boundary, so the
+  precondition IS the wait: banking only begins once `cx_active` has read zero for
+  the whole idle window AND no activator splice is live. The sequence:
+
+    1. mark the instance `running -> banking` via the GroupManager's bank drive is
+       preceded by an UNPUBLISH here: the sweeper drops the entry endpoint
+       (`GroupStore` bank_ready drops it, but the entry must leave the fan-out BEFORE
+       the members are paused so a racing connection parks on the activator, not a
+       dead socket). Concretely the sweeper re-publishes with the group still
+       `running` but flagged banking so `EndpointPublisher` swaps in the activator;
+       the actual member pause/snapshot/destroy + the atomic `group_banked` run in
+       `GroupManager.bank_group`;
+    2. RECHECK the freshest `cx_active` + the splice count: if a connection or splice
+       raced in, ABORT (never begin the bank) and leave the group live;
+    3. drive `GroupManager.bank_group` (pause all, snapshot all to a shared set_id,
+       atomic `group_banked`, destroy all), off this process's own call (it blocks
+       until the whole set banks or aborts, which is acceptable at the sweep cadence
+       and keeps the durable append serialized). On a clean bank the group is
+       `banked` with the set on disk; on an abort the group is back `running` and we
+       re-publish so the still-live group re-enters the fan-out.
+
+  ## max-lifetime: destroy the group AND its network (decision 8)
+
+  A group older than `maxLifetimeSeconds` must go so a stale image lineage cannot
+  squat. A live one waits for `cx_active == 0` up to a capped patience window
+  (`EMBERVM_GROUP_LIFETIME_DRAIN_MAX_MS`, default 1 hour) then destroys anyway
+  (unlike stateful there is no durable volume to recover against, so the honest thing
+  is a hard cap then a fresh boot on the next connection). Destroying a group tears
+  down every member VM AND deletes the private /24 network (the bridge leaks
+  otherwise). A banked over-lifetime instance is destroyed immediately (it holds no
+  VMs; its set is evicted as part of the terminal).
+
+  ## banked-TTL GC: warmth-only, the set IS the instance's end
+
+  A banked set untouched (`last_active_at`, else `updated_at`) longer than
+  `bankedTtlSeconds` is GC'd. Unlike R4 stateful (where an evicted bundle leaves the
+  durable VOLUME as a floor, so the instance survives the eviction), a composite
+  group has NO volume floor: an expired set IS the instance's end. So banked-TTL here
+  DESTROYS the instance (`group_destroyed{reason: expired}`) and best-effort evicts
+  each member's bundle, rather than leaving a banked-with-no-set row. The next
+  connection is a full fresh CREATE.
+
+  ## forced roll: the convergence + degraded-recovery lever
+
+  `DELETE /v1/groups/{workload}/instance` (management auth) drives `force_roll/2`:
+  destroy every live member + delete the network + EVICT the banked set, but KEEP the
+  workload DEFINITION (the CR / catalog entry). The next connection fresh-boots a new
+  environment on the CURRENT images. This is both how an operator rolls a group onto
+  new images AND how a stuck degraded group is recovered (a degraded group is never
+  banked, so the roll is the only way to shed it short of lifetime expiry).
+  """
+
+  use GenServer
+  require Logger
+
+  require OpenTelemetry.Tracer, as: Tracer
+
+  alias Embervm.{ActivatorSplices, GroupState, GroupStore, NodeCapacity, WorkloadCatalog}
+  alias Embervm.OpLog.Op
+
+  alias Embervm.Node.V1.{
+    DeleteGroupNetworkRequest,
+    EvictSnapshotRequest,
+    StopGroupMemberRequest,
+    Trace
+  }
+
+  # The capped patience window for a live over-lifetime group to drain (entry
+  # cx_active reach zero) before it is destroyed anyway (decision 8). One hour
+  # default, mirroring StatefulSweeper's lifetime_drain_max_ms.
+  @default_lifetime_drain_max_ms 3_600_000
+
+  # -- Client API ------------------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc """
+  Runs one full sweep synchronously (scrape + group_stats + idle-bank + recheck +
+  lifetime GC + banked-TTL GC) and returns after it completes. Tests drive the
+  economics deterministically through this (with an injected clock + stats seam)
+  instead of waiting on the timer.
+  """
+  @spec sweep(GenServer.server()) :: :ok
+  def sweep(server \\ __MODULE__) do
+    GenServer.call(server, :sweep, :infinity)
+  end
+
+  @doc """
+  Forced roll (management verb behind `DELETE /v1/groups/{workload}/instance`):
+  destroy every live member VM of the workload's group, delete its private network,
+  and evict its banked set, KEEPING the workload definition so the next connection
+  fresh-boots a new environment on the current images. Synchronous; returns
+  `%{destroyed: n, evicted: m}` (n = live instances torn down, m = banked sets
+  evicted; each 0 or 1, the class is a group-level singleton). The convergence +
+  degraded-recovery lever.
+  """
+  @spec force_roll(GenServer.server(), String.t()) :: %{destroyed: non_neg_integer(), evicted: non_neg_integer()}
+  def force_roll(server \\ __MODULE__, workload) do
+    GenServer.call(server, {:force_roll, workload}, :infinity)
+  end
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    state = %{
+      store: Keyword.get(opts, :store, GroupStore),
+      publisher: Keyword.get(opts, :publisher, Embervm.EndpointPublisher),
+      capacity_table: Keyword.get(opts, :capacity_table, NodeCapacity.table()),
+      catalog_table: Keyword.get(opts, :catalog_table, WorkloadCatalog.table()),
+      op_log: Keyword.get(opts, :op_log, Embervm.OpLog.SQLite),
+      clock: Keyword.get(opts, :clock, &default_clock/0),
+      tenant: Keyword.get(opts, :tenant, "homelab"),
+      # The node Envoy stats scrape seam (same shape + endpoint as stateful): (url) ->
+      # {:ok, %{stat_prefix => %{active, total}}} | {:error, reason}. Composite entry
+      # listeners live on the SAME node Envoy admin the serving/stateful scrape reaches.
+      scrape_fun: Keyword.get(opts, :scrape_fun, &default_scrape/1),
+      stats_base: Keyword.get(opts, :stats_base, nil),
+      # The activator live-splice table name: ActivatorSplices.live?(table, workload)
+      # is the third idle clause (zero live splices). nil reads no-splice (a sweeper
+      # wired without an activator never blocks banking on a signal it does not track).
+      splices_table: Keyword.get(opts, :splices_table, ActivatorSplices),
+      # The whole-set bank drive seam: (workload, instance_id) -> {:ok, %{set_id,
+      # banked, pause_spread_ms}} | {:error, reason}. Production drives
+      # GroupManager.Supervisor.bank_group/2 (the per-instance manager pauses/snapshots/
+      # destroys the members and records the set atomically); tests inject a recorder.
+      bank_fun: Keyword.get(opts, :bank_fun, &default_bank/2),
+      # The daemon group-verb seams for lifetime/forced-roll destroys (a banked group
+      # has no live GroupManager process, so the sweeper destroys directly, mirroring
+      # StatefulSweeper). Injected for tests; production dials the real NodeService stub.
+      channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
+      stop_group_member_fun: Keyword.get(opts, :stop_group_member_fun, &default_stop_group_member/2),
+      delete_group_network_fun:
+        Keyword.get(opts, :delete_group_network_fun, &default_delete_group_network/2),
+      evict_snapshot_fun: Keyword.get(opts, :evict_snapshot_fun, &default_evict_snapshot/2),
+      lifetime_drain_max_ms: Keyword.get(opts, :lifetime_drain_max_ms, @default_lifetime_drain_max_ms),
+      # workload -> the ms it was first observed idle this run (cx_active == 0 AND flat
+      # cx_total delta AND no live splice), so idleBankSeconds measures from the first
+      # idle tick. Any activity resets it.
+      idle_since: %{},
+      # workload -> the ms live-seconds were last charged, so each tick bills exactly
+      # the elapsed window (now - last) x per-member compute (no double-count, no gap).
+      # A workload first seen live baselines here and bills from the NEXT tick.
+      last_charged_at: %{},
+      # workload -> the ms an over-lifetime LIVE group was first seen both
+      # over-lifetime and with an active entry connection (the drain patience baseline).
+      lifetime_drain_since: %{},
+      # The prior tick's per-node reading: node_id -> %{stat_prefix => %{active, total}}.
+      last_stats: %{},
+      # This tick's per-node reading (freshest), consulted by the recheck + lifetime pass.
+      current_stats: %{},
+      sweep_interval_ms: Keyword.get(opts, :sweep_interval_ms, 0)
+    }
+
+    if state.sweep_interval_ms > 0 do
+      schedule(:sweep, state.sweep_interval_ms)
+    end
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:sweep, _from, state) do
+    {:reply, :ok, do_sweep(state)}
+  end
+
+  def handle_call({:force_roll, workload}, _from, state) do
+    {reply, state} = do_force_roll(state, workload)
+    {:reply, reply, state}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    state = do_sweep(state)
+    schedule(:sweep, state.sweep_interval_ms)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # -- the sweep -------------------------------------------------------------
+
+  # One tick: (1) scrape every composite-capable node's entry-listener stats, append
+  # group_stats + touch activity; (2) idle-bank: unpublish + recheck + bank drive for
+  # groups confirmed idle past idleBankSeconds (degraded groups EXCLUDED); (3)
+  # max-lifetime expiry (drain-then-destroy, capped patience; destroy group + network);
+  # (4) banked-TTL GC (warmth-only terminal).
+  defp do_sweep(state) do
+    now = state.clock.()
+
+    Tracer.with_span "embervm.group.stats_sweep", %{attributes: %{"ember.tenant" => state.tenant}} do
+      state
+      |> scrape_and_record(now)
+      |> charge_live_seconds(now)
+      |> idle_bank_pass(now)
+      |> sweep_lifetime(now)
+      |> sweep_banked_ttl(now)
+    end
+  end
+
+  # -- usage: per-member live-seconds (decision 9) ---------------------------
+
+  # Charge every LIVE (non-terminal, non-banked) composite group its compute usage for
+  # the elapsed window: a composite bills PER-MEMBER live-seconds (a 3-member group
+  # bills 3 VMs' worth), unlike serving/stateful which count connection/request units.
+  # The group_stats projection expects `%{usage: %{vcpu_seconds, gb_seconds},
+  # member_count}` and multiplies, so the op carries ONE member's live-seconds for the
+  # window plus the member count. A workload first seen live baselines its clock this
+  # tick (bills from the NEXT tick, never a lump-sum from creation). A workload with no
+  # live instance drops its clock so a later boot re-baselines.
+  defp charge_live_seconds(state, now) do
+    live_workloads =
+      GroupStore.all(state.store)
+      |> Enum.filter(&GroupState.live?(&1.state))
+      |> Enum.map(& &1.workload)
+      |> Enum.uniq()
+
+    live_set = MapSet.new(live_workloads)
+
+    state =
+      Enum.reduce(live_workloads, state, fn workload, acc ->
+        charge_one_workload(acc, workload, now)
+      end)
+
+    # Prune the charge clock for workloads no longer live (a re-boot re-baselines).
+    %{state | last_charged_at: Map.take(state.last_charged_at, MapSet.to_list(live_set))}
+  end
+
+  defp charge_one_workload(state, workload, now) do
+    case Map.get(state.last_charged_at, workload) do
+      nil ->
+        # First tick a live workload is seen: baseline only (bill from next tick).
+        %{state | last_charged_at: Map.put(state.last_charged_at, workload, now)}
+
+      last ->
+        window_ms = max(now - last, 0)
+
+        if window_ms > 0 do
+          _ = append_group_stats(state, workload, window_ms, now)
+        end
+
+        %{state | last_charged_at: Map.put(state.last_charged_at, workload, now)}
+    end
+  end
+
+  # -- stats scrape + activity -----------------------------------------------
+
+  # Scrape each composite-capable node's Envoy stats keyed by listener stat_prefix
+  # (group-<listen_port>), map each prefix back to its workload via the catalog, and:
+  # touch last_active_at + reset the idle clock on cx activity (a new connection, an
+  # open connection, or a live activator splice), else mark the idle baseline. Usage
+  # billing is a SEPARATE per-tick live-seconds charge (charge_live_seconds/2), not tied
+  # to the cx delta. A failed node scrape drops its prior reading (fail-open).
+  defp scrape_and_record(state, now) do
+    nodes = group_nodes(state)
+
+    {state, last_stats, current_stats} =
+      Enum.reduce(nodes, {state, state.last_stats, %{}}, fn node, {state_acc, last_acc, current_acc} ->
+        case scrape_node(state_acc, node) do
+          {:ok, reading} ->
+            prior = Map.get(state_acc.last_stats, node.configured_id)
+            state_acc = record_reading(state_acc, node, prior, reading, now)
+            {state_acc, Map.put(last_acc, node.configured_id, reading), Map.put(current_acc, node.configured_id, reading)}
+
+          {:error, reason} ->
+            Logger.debug("embervm group: stats scrape failed",
+              node_id: node.configured_id,
+              reason: inspect(reason)
+            )
+
+            {state_acc, Map.delete(last_acc, node.configured_id), current_acc}
+        end
+      end)
+
+    scraped_ids = MapSet.new(nodes, & &1.configured_id)
+    last_stats = Map.take(last_stats, MapSet.to_list(scraped_ids))
+
+    %{state | last_stats: last_stats, current_stats: current_stats}
+  end
+
+  defp record_reading(state, _node, nil, _reading, _now), do: state
+
+  defp record_reading(state, node, prior, reading, now) do
+    Enum.reduce(reading, state, fn {stat_prefix, %{active: active, total: total}}, acc ->
+      workload = workload_of_stat_prefix(acc, stat_prefix)
+      prior_entry = Map.get(prior, stat_prefix)
+      record_one_reading(acc, node, workload, prior_entry, active, total, now)
+    end)
+  end
+
+  defp record_one_reading(state, _node, nil, _prior, _active, _total, _now), do: state
+  defp record_one_reading(state, _node, _workload, nil, _active, _total, _now), do: state
+
+  defp record_one_reading(state, _node, workload, %{total: prior_total}, active, total, now) do
+    delta = total - prior_total
+    splice_live? = ActivatorSplices.live?(state.splices_table, workload)
+
+    cond do
+      delta < 0 ->
+        # Counter reset (Envoy restarted): re-baseline, reset the idle clock.
+        clear_idle_since(state, workload)
+
+      delta > 0 or active > 0 or splice_live? ->
+        # Activity: a new connection (delta > 0), an open Envoy connection (active > 0),
+        # OR a live activator splice (invisible to Envoy but still activity). Touch
+        # active + clear the idle clock either way. (Usage billing is a SEPARATE
+        # per-tick live-seconds charge, see charge_live_seconds/2: a composite bills
+        # compute-time per member, not connection count, so the cx delta here is ONLY
+        # the activity/idle signal.)
+        touch_workload_active(state, workload, now)
+        clear_idle_since(state, workload)
+
+      true ->
+        # active == 0, delta == 0, AND no live splice: confirmed idle this tick.
+        mark_idle_since(state, workload, now)
+    end
+  end
+
+  defp mark_idle_since(state, workload, now) do
+    if Map.has_key?(state.idle_since, workload) do
+      state
+    else
+      %{state | idle_since: Map.put(state.idle_since, workload, now)}
+    end
+  end
+
+  defp clear_idle_since(state, workload) do
+    %{state | idle_since: Map.delete(state.idle_since, workload)}
+  end
+
+  # Append a group_stats op billing the WHOLE group's compute for `window_ms`: the sum
+  # over every member of {vcpus, mem_gib} x window_seconds, carried as the op's `usage`
+  # with `member_count: 1` (the projection multiplies usage x member_count, so passing
+  # the already-summed group total with count 1 accrues exactly the group's true
+  # per-window compute, heterogeneous member sizes included). group_instance_id is nil
+  # (workload-scoped, like stateful_stats). Best-effort: a usage-op failure must never
+  # wedge the sweep. A workload whose catalog group has no members bills nothing.
+  defp append_group_stats(state, workload, window_ms, now) do
+    case group_cfg(state, workload) do
+      {:ok, cfg} ->
+        window_s = window_ms / 1000
+        {vcpu_seconds, gb_seconds} = group_compute_seconds(cfg, window_s)
+
+        if vcpu_seconds > 0 or gb_seconds > 0 do
+          op = %Op{
+            kind: :group_stats,
+            tenant: state.tenant,
+            principal: usage_principal(workload),
+            workload: workload,
+            group_instance_id: nil,
+            ts: now,
+            payload: %{usage: %{vcpu_seconds: vcpu_seconds, gb_seconds: gb_seconds}, member_count: 1}
+          }
+
+          _ = Embervm.OpLog.SQLite.append(state.op_log, op)
+        end
+
+        :ok
+
+      :error ->
+        :ok
+    end
+  rescue
+    e ->
+      Logger.warning("embervm group: group_stats append raised", workload: workload, error: inspect(e))
+      :ok
+  end
+
+  # The group's summed compute for a window: over every EXPANDED member (replicas
+  # counted), window_seconds x {vcpus, mem_gib}. Mirrors the member_plan expansion
+  # (replicas > 1 -> N copies), so a 2-replica member bills 2 VMs' worth. Defaults a
+  # missing vcpus to 1 and mem to 512 MiB (the GroupManager StartGroupMember defaults),
+  # so an under-specified member still bills a sane floor.
+  defp group_compute_seconds(cfg, window_s) do
+    members = Map.get(cfg, :members, []) || []
+
+    Enum.reduce(members, {0.0, 0.0}, fn member, {vcpu_acc, gb_acc} ->
+      replicas = member_replicas(member)
+      vcpus = (Map.get(member, :vcpus) || 1) * replicas
+      mem_gib = (Map.get(member, :mem_mib) || 512) / 1024 * replicas
+      {vcpu_acc + vcpus * window_s, gb_acc + mem_gib * window_s}
+    end)
+  end
+
+  defp member_replicas(member) do
+    case Map.get(member, :replicas) do
+      n when is_integer(n) and n > 0 -> n
+      _ -> 1
+    end
+  end
+
+  defp touch_workload_active(state, workload, now) do
+    GroupStore.list(state.store, workload)
+    |> Enum.filter(&GroupState.live?(&1.state))
+    |> Enum.each(fn instance ->
+      _ = GroupStore.touch_active(state.store, instance.instance_id, now)
+    end)
+  end
+
+  # -- idle-bank pass ---------------------------------------------------------
+
+  # For every RUNNING group whose workload has been confirmed idle for at least
+  # idleBankSeconds AND is NOT degraded: begin the bank. A degraded group is EXCLUDED
+  # (decision 11) with a visible log line. A workload with no confirmed-idle reading
+  # this tick (a scrape failed, first reading, activity, or a live splice) is
+  # untouched: fail-open for warmth.
+  defp idle_bank_pass(state, now) do
+    GroupStore.all(state.store)
+    |> Enum.filter(&(&1.state == :running))
+    |> Enum.reduce(state, fn instance, acc -> maybe_begin_bank(acc, instance, now) end)
+  end
+
+  defp maybe_begin_bank(state, instance, now) do
+    with {:ok, cfg} <- group_cfg(state, instance.workload),
+         since when is_integer(since) <- Map.get(state.idle_since, instance.workload) do
+      idle_ms = cfg.idle_bank_seconds * 1000
+
+      cond do
+        now - since < idle_ms ->
+          state
+
+        degraded?(instance) ->
+          # A degraded group is EXCLUDED from banking (decision 11): a partial set
+          # would violate all-or-nothing. Make the exclusion a visible, logged fact;
+          # the group stays live until healed (forced roll / member recovery) or
+          # expired (max-lifetime).
+          Logger.info("embervm group: bank excluded, group degraded",
+            workload: instance.workload,
+            instance_id: instance.instance_id,
+            degraded_member: instance.degraded_member
+          )
+
+          state
+
+        true ->
+          begin_bank(state, instance)
+      end
+    else
+      _ -> state
+    end
+  end
+
+  # Begin the bank (mirrors StatefulSweeper's unpublish-then-recheck-then-bank):
+  # move running -> banking (which drops the entry endpoint from the fan-out, since
+  # entry_endpoint/2 only serves a `running` group) and install the activator in the
+  # SAME publish, so a racing connection parks on the activator, not a VM about to be
+  # paused (decision 7). Then RECHECK the freshest cx_active + splice count: a race
+  # ABORTS (banking -> running) and republishes; otherwise drive the whole-set bank.
+  defp begin_bank(state, instance) do
+    Tracer.with_span "embervm.group.drain",
+                     %{attributes: %{"ember.workload" => instance.workload, "ember.instance_id" => instance.instance_id}} do
+      begin_bank_body(state, instance)
+    end
+  end
+
+  defp begin_bank_body(state, instance) do
+    case GroupStore.mark(state.store, instance.instance_id, :bank) do
+      {:ok, _} ->
+        # The endpoint left the fan-out (banking != running); install the activator.
+        Embervm.EndpointPublisher.publish(state.publisher)
+        recheck_and_bank(state, instance)
+
+      {:error, reason} ->
+        Logger.warning("embervm group: bank-drain mark failed",
+          workload: instance.workload,
+          instance_id: instance.instance_id,
+          reason: inspect(reason)
+        )
+
+        state
+    end
+  end
+
+  # The decision-7 recheck: re-scrape the node NOW and re-read the splice count to
+  # catch a connection/splice that opened since the tick-start idle scan. A race
+  # ABORTS (banking -> running) and republishes so the still-live group re-enters the
+  # fan-out; otherwise drive the whole-set bank via the GroupManager.
+  defp recheck_and_bank(state, instance) do
+    state = refresh_current_stats(state, instance.node_id)
+
+    if connection_raced_in?(state, instance) or ActivatorSplices.live?(state.splices_table, instance.workload) do
+      abort_bank(state, instance, :recheck_active)
+    else
+      drive_bank(state, instance)
+    end
+  end
+
+  # A racing connection/splice: abort the bank (banking -> running) and republish so
+  # the still-live group re-enters the fan-out, never severing a live connection.
+  defp abort_bank(state, instance, reason) do
+    _ = GroupStore.mark(state.store, instance.instance_id, :bank_abort)
+    Embervm.EndpointPublisher.publish(state.publisher)
+
+    Logger.info("embervm group: bank aborted, republished",
+      workload: instance.workload,
+      instance_id: instance.instance_id,
+      reason: reason
+    )
+
+    state
+  end
+
+  # Drive the whole-set bank via the GroupManager (StopGroupMember BANK every member
+  # under a shared set_id, atomic group_banked). The instance is already `banking`
+  # (begin_bank_body moved it there). A clean bank leaves it `banked` with the entry
+  # endpoint dropped (the manager re-published the activator swap); an abort/failure
+  # returns it to `running` (the manager's bank_abort), so re-derive the fan-out so
+  # the live group is reachable again.
+  defp drive_bank(state, instance) do
+    case state.bank_fun.(instance.workload, instance.instance_id) do
+      {:ok, %{set_id: set_id, pause_spread_ms: spread}} ->
+        Logger.info("embervm group banked",
+          workload: instance.workload,
+          instance_id: instance.instance_id,
+          set_id: set_id,
+          pause_spread_ms: spread
+        )
+
+        state
+
+      {:error, reason} ->
+        Logger.warning("embervm group: bank drive failed, group left live",
+          workload: instance.workload,
+          instance_id: instance.instance_id,
+          reason: inspect(reason)
+        )
+
+        Embervm.EndpointPublisher.publish(state.publisher)
+        state
+    end
+  end
+
+  defp refresh_current_stats(state, node_id) do
+    case scrape_node(state, %{configured_id: node_id}) do
+      {:ok, reading} -> %{state | current_stats: Map.put(state.current_stats, node_id, reading)}
+      {:error, _reason} -> state
+    end
+  end
+
+  # True when the instance's node's freshest reading reports cx_active > 0 for its
+  # entry listener. No fresh reading fails OPEN toward proceeding (the idle
+  # confirmation that got here already required cx_active == 0 on the last successful
+  # scrape, and the splice-count recheck is a separate independent guard).
+  defp connection_raced_in?(state, instance) do
+    with {:ok, entry} <- Map.fetch(state.current_stats, instance.node_id),
+         {:ok, cfg} <- group_cfg(state, instance.workload),
+         {:ok, %{active: active}} <- Map.fetch(entry, stat_prefix(cfg.entry.listen_port)) do
+      active > 0
+    else
+      _ -> false
+    end
+  end
+
+  # -- max-lifetime expiry -----------------------------------------------------
+
+  # A group older than maxLifetimeSeconds is destroyed. A banked one is destroyed
+  # immediately (it holds no VMs; its set is evicted as part of the terminal). A live
+  # one waits for entry cx_active == 0 up to the capped patience window (decision 8),
+  # tracked from the first tick it was BOTH over-lifetime and active; once the window
+  # elapses, destroy anyway (a fresh boot on the next connection covers it, there is
+  # no volume floor to recover against).
+  defp sweep_lifetime(state, now) do
+    GroupStore.all(state.store)
+    |> Enum.reject(&GroupState.terminal?(&1.state))
+    |> Enum.filter(&over_lifetime?(state, &1, now))
+    |> Enum.reduce(state, fn instance, acc -> expire_instance(acc, instance, now) end)
+  end
+
+  defp over_lifetime?(state, instance, now) do
+    case group_cfg(state, instance.workload) do
+      {:ok, cfg} ->
+        max_ms = cfg.max_lifetime_seconds * 1000
+        is_integer(instance.created_at) and now - instance.created_at >= max_ms
+
+      :error ->
+        false
+    end
+  end
+
+  defp expire_instance(state, %{state: :banked} = instance, _now) do
+    state = clear_lifetime_drain_since(state, instance.workload)
+    destroy_banked(state, instance, "expired")
+  end
+
+  defp expire_instance(state, instance, now) do
+    if instance_active?(state, instance) do
+      lifetime_drain_wait(state, instance, now)
+    else
+      state = clear_lifetime_drain_since(state, instance.workload)
+      destroy_live_group(state, instance, "lifetime")
+    end
+  end
+
+  defp lifetime_drain_wait(state, instance, now) do
+    since = Map.get(state.lifetime_drain_since, instance.workload, now)
+    state = %{state | lifetime_drain_since: Map.put(state.lifetime_drain_since, instance.workload, since)}
+
+    if now - since >= state.lifetime_drain_max_ms do
+      destroy_live_group(clear_lifetime_drain_since(state, instance.workload), instance, "lifetime")
+    else
+      state
+    end
+  end
+
+  defp clear_lifetime_drain_since(state, workload) do
+    %{state | lifetime_drain_since: Map.delete(state.lifetime_drain_since, workload)}
+  end
+
+  # Whether the instance's entry listener currently reports an open connection, from
+  # THIS tick's freshest reading, OR a live activator splice (a spliced session is an
+  # open connection Envoy cannot see). Falls back to "not active" when there is no
+  # fresh reading (which only delays a destroy the patience window still forces).
+  defp instance_active?(state, instance) do
+    envoy_active =
+      with {:ok, entry} <- Map.fetch(state.current_stats, instance.node_id),
+           {:ok, cfg} <- group_cfg(state, instance.workload),
+           {:ok, %{active: active}} <- Map.fetch(entry, stat_prefix(cfg.entry.listen_port)) do
+        active > 0
+      else
+        _ -> false
+      end
+
+    envoy_active or ActivatorSplices.live?(state.splices_table, instance.workload)
+  end
+
+  # -- banked-TTL GC -----------------------------------------------------------
+
+  # A banked set untouched (last_active_at, else updated_at) longer than
+  # bankedTtlSeconds is GC'd. Warmth-only terminal: an expired set IS the instance's
+  # end (no volume floor), so this DESTROYS the instance (group_destroyed{reason:
+  # expired}) and best-effort evicts each member's bundle.
+  defp sweep_banked_ttl(state, now) do
+    GroupStore.all(state.store)
+    |> Enum.filter(&(&1.state == :banked))
+    |> Enum.reduce(state, fn instance, acc ->
+      case group_cfg(acc, instance.workload) do
+        {:ok, cfg} ->
+          ttl_ms = cfg.banked_ttl_seconds * 1000
+          last = instance.last_active_at || instance.updated_at || 0
+
+          if now - last >= ttl_ms do
+            destroy_banked(acc, instance, "expired")
+          else
+            acc
+          end
+
+        :error ->
+          acc
+      end
+    end)
+  end
+
+  # -- forced roll -----------------------------------------------------------
+
+  # Destroy every live member + delete the network + evict the banked set, KEEPING the
+  # workload definition so the next connection fresh-boots on the current images. A
+  # live group is torn down (StopGroupMember DESTROY per member, DeleteGroupNetwork,
+  # group_destroyed); a banked one has its set evicted + the instance destroyed. The
+  # publisher re-derives once at the end (the activator swap for the now-gone group).
+  defp do_force_roll(state, workload) do
+    instances = GroupStore.list(state.store, workload)
+
+    {state, destroyed, evicted} =
+      Enum.reduce(instances, {state, 0, 0}, fn instance, {acc, d, e} ->
+        cond do
+          GroupState.terminal?(instance.state) ->
+            {acc, d, e}
+
+          instance.state == :banked ->
+            {destroy_banked(acc, instance, "forced_roll"), d, e + 1}
+
+          true ->
+            {destroy_live_group(acc, instance, "forced_roll"), d + 1, e}
+        end
+      end)
+
+    Embervm.EndpointPublisher.publish(state.publisher)
+    Logger.info("embervm group: forced roll", workload: workload, destroyed: destroyed, evicted: evicted)
+    {%{destroyed: destroyed, evicted: evicted}, state}
+  end
+
+  # -- destroy / evict RPCs + durable ops --------------------------------------
+
+  # Destroy a LIVE group: unpublish the entry endpoint (if running), StopGroupMember
+  # DESTROY every live member, DeleteGroupNetwork, then the durable
+  # group_destroyed{reason}. The publisher re-derive is batched by the caller for the
+  # forced-roll path; a lifetime destroy re-derives here (a single instance) so the
+  # activator swap lands.
+  defp destroy_live_group(state, instance, reason) do
+    # The terminal group_destroyed clears the entry endpoint (the store's
+    # post_transition_endpoint nils it on a terminal), and the re-publish below swaps
+    # in the activator, so a racing connection parks rather than hitting a dead socket.
+    _ = destroy_all_members(state, instance)
+    _ = delete_network(state, instance)
+
+    _ =
+      GroupStore.transition(
+        state.store,
+        instance.instance_id,
+        :destroy,
+        :group_destroyed,
+        %{reason: reason},
+        %{}
+      )
+
+    Embervm.EndpointPublisher.publish(state.publisher)
+
+    Logger.info("embervm group destroyed",
+      workload: instance.workload,
+      instance_id: instance.instance_id,
+      reason: reason
+    )
+
+    state
+  end
+
+  # Destroy a BANKED instance: best-effort EvictSnapshot each member's bundle (the set
+  # on disk), delete the network (the on-disk network record persists while the
+  # instance does, so a terminal destroy reclaims it), then the durable
+  # group_destroyed{reason}. Warmth-only terminal: the set IS the instance's end.
+  defp destroy_banked(state, instance, reason) do
+    _ = evict_member_bundles(state, instance)
+    _ = delete_network(state, instance)
+
+    _ =
+      GroupStore.transition(
+        state.store,
+        instance.instance_id,
+        :destroy,
+        :group_destroyed,
+        %{reason: reason},
+        %{}
+      )
+
+    Logger.info("embervm group banked set evicted (destroyed)",
+      workload: instance.workload,
+      instance_id: instance.instance_id,
+      reason: reason
+    )
+
+    state
+  end
+
+  defp destroy_all_members(state, instance) do
+    GroupStore.members(state.store, instance.instance_id)
+    |> Enum.filter(fn m -> is_binary(m.vm_id) and m.vm_id != "" end)
+    |> Enum.each(fn m -> _ = stop_group_member_destroy(state, instance, m) end)
+
+    :ok
+  end
+
+  # StopGroupMember DESTROY dials the INSTANCE's node (a composite group is anchored to
+  # one node; members carry no per-member node_id).
+  defp stop_group_member_destroy(state, instance, member) do
+    req = %StopGroupMemberRequest{
+      trace: %Trace{workload: nil},
+      vm_id: member.vm_id,
+      mode: :STOP_GROUP_MEMBER_MODE_DESTROY,
+      set_id: "",
+      member_name: member.member_name
+    }
+
+    with {:ok, channel} <- safe_channel(state, instance.node_id) do
+      try do
+        state.stop_group_member_fun.(channel, req)
+      rescue
+        _ -> :error
+      catch
+        _, _ -> :error
+      end
+    end
+
+    :ok
+  end
+
+  # Evict every member's banked bundle (best-effort; the daemon's own bundle GC
+  # reclaims a missed one). Reads each member row's snapshot_ref (the banked set).
+  defp evict_member_bundles(state, instance) do
+    GroupStore.members(state.store, instance.instance_id)
+    |> Enum.each(fn m ->
+      case m.snapshot_ref do
+        ref when is_binary(ref) and ref != "" -> _ = evict_snapshot(state, instance, ref)
+        _ -> :ok
+      end
+    end)
+
+    :ok
+  end
+
+  defp delete_network(state, instance) do
+    req = %DeleteGroupNetworkRequest{trace: %Trace{workload: nil}, group_instance_id: instance.instance_id}
+
+    with {:ok, channel} <- safe_channel(state, instance.node_id) do
+      try do
+        state.delete_group_network_fun.(channel, req)
+      rescue
+        _ -> :error
+      catch
+        _, _ -> :error
+      end
+    end
+
+    :ok
+  end
+
+  defp evict_snapshot(state, instance, ref) do
+    req = %EvictSnapshotRequest{trace: %Trace{workload: nil}, snapshot_ref: ref}
+
+    with {:ok, channel} <- safe_channel(state, instance.node_id) do
+      try do
+        state.evict_snapshot_fun.(channel, req)
+      rescue
+        _ -> :error
+      catch
+        _, _ -> :error
+      end
+    end
+
+    :ok
+  end
+
+  # -- stats scrape helpers -----------------------------------------------------
+
+  # Composite groups run on the same node Envoy as serving/stateful, so reuse the
+  # serving-capable predicate: any node reporting a serving_subnet_cidr is scraped.
+  defp group_nodes(state) do
+    NodeCapacity.all(state.capacity_table)
+    |> Enum.filter(&group_capable?/1)
+  end
+
+  defp group_capable?(fact) do
+    cidr = Map.get(fact, :serving_subnet_cidr)
+    is_binary(cidr) and cidr != ""
+  end
+
+  defp scrape_node(%{stats_base: nil}, _node), do: {:error, :no_stats_base}
+
+  defp scrape_node(state, _node) do
+    state.scrape_fun.(stats_url(state.stats_base))
+  end
+
+  defp stats_url(base), do: String.trim_trailing(base, "/") <> "/stats?format=json"
+
+  # -- catalog + instance helpers -----------------------------------------------
+
+  defp group_cfg(state, workload) do
+    case WorkloadCatalog.fetch(state.catalog_table, workload) do
+      {:ok, %{class: "composite", group: cfg}} when is_map(cfg) -> {:ok, cfg}
+      _ -> :error
+    end
+  end
+
+  # The entry listener stat_prefix for a workload's entry.listen_port
+  # (group-<listenPort>, Task 4's stat_prefix wiring), the key the scrape reading is
+  # keyed by (mirrors stateful's state-<port>).
+  @stat_prefix "group-"
+  defp stat_prefix(listen_port) when is_integer(listen_port), do: @stat_prefix <> Integer.to_string(listen_port)
+
+  # Map a scraped stat_prefix back to its owning workload via the catalog: the inverse
+  # of stat_prefix/1, found by matching every composite catalog entry's
+  # entry.listen_port.
+  defp workload_of_stat_prefix(state, @stat_prefix <> port_str) do
+    case Integer.parse(port_str) do
+      {port, ""} -> find_workload_by_listen_port(state, port)
+      _ -> nil
+    end
+  end
+
+  defp workload_of_stat_prefix(_state, _other), do: nil
+
+  defp find_workload_by_listen_port(state, port) do
+    WorkloadCatalog.all_names(state.catalog_table)
+    |> Enum.find_value(fn name ->
+      case WorkloadCatalog.fetch(state.catalog_table, name) do
+        {:ok, %{class: "composite", group: %{entry: %{listen_port: ^port}}}} -> name
+        _ -> nil
+      end
+    end)
+  end
+
+  # A group is degraded when it carries a dead-member flag (decision 11 exclusion).
+  defp degraded?(instance), do: is_binary(instance.degraded_member)
+
+  defp usage_principal(workload), do: "system:group:#{workload}"
+
+  # -- daemon + bank seams -------------------------------------------------
+
+  defp safe_channel(state, node_id) do
+    state.channel_fun.(node_id)
+  rescue
+    e -> {:error, {:channel_raised, e}}
+  catch
+    kind, reason -> {:error, {:channel_raised, {kind, reason}}}
+  end
+
+  defp default_bank(workload, instance_id) do
+    Embervm.GroupManager.Supervisor.bank_group(workload, instance_id)
+  end
+
+  defp default_stop_group_member(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.stop_group_member(channel, req)
+  end
+
+  defp default_delete_group_network(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.delete_group_network(channel, req)
+  end
+
+  defp default_evict_snapshot(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.evict_snapshot(channel, req)
+  end
+
+  # Production scrape: identical to StatefulSweeper's (GET /stats?format=json over the
+  # shared Finch pool, parse tcp.<prefix>.downstream_cx_{active,total}). Composite
+  # entry listeners are named group-<port> but share the tcp.* stat namespace, so the
+  # SAME parser keeps both stateful (state-<port>) and group (group-<port>) prefixes.
+  defp default_scrape(url) do
+    req = Finch.build(:get, url)
+
+    case Finch.request(req, Embervm.Finch, receive_timeout: 3_000) do
+      {:ok, %Finch.Response{status: status, body: body}} when status in 200..299 ->
+        parse_stats(body)
+
+      {:ok, %Finch.Response{status: status}} ->
+        {:error, {:stats_status, status}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @tcp_stat_prefix "tcp."
+  @cx_active_suffix ".downstream_cx_active"
+  @cx_total_suffix ".downstream_cx_total"
+
+  @doc """
+  Parse an Envoy `/stats?format=json` body into `%{stat_prefix => %{active: n, total:
+  n}}`, keeping only `tcp.<prefix>.downstream_cx_{active,total}` counters (identical
+  to `StatefulSweeper.parse_stats/1`; the group entry listener shares the tcp.* stat
+  namespace). `@doc false` so the parse path is exercised directly in tests.
+  """
+  @doc false
+  @spec parse_stats(binary()) :: {:ok, %{optional(String.t()) => %{active: integer(), total: integer()}}} | {:error, term()}
+  def parse_stats(body) do
+    case Jason.decode(body) do
+      {:ok, %{"stats" => stats}} when is_list(stats) ->
+        reading = Enum.reduce(stats, %{}, fn stat, acc -> fold_tcp_stat(stat, acc) end)
+        {:ok, reading}
+
+      _ ->
+        {:error, :unparseable_stats}
+    end
+  rescue
+    e -> {:error, {:stats_parse_raised, e}}
+  end
+
+  defp fold_tcp_stat(%{"name" => @tcp_stat_prefix <> rest, "value" => value}, acc) when is_integer(value) do
+    cond do
+      String.ends_with?(rest, @cx_active_suffix) ->
+        prefix = String.replace_suffix(rest, @cx_active_suffix, "")
+        put_field(acc, prefix, :active, value)
+
+      String.ends_with?(rest, @cx_total_suffix) ->
+        prefix = String.replace_suffix(rest, @cx_total_suffix, "")
+        put_field(acc, prefix, :total, value)
+
+      true ->
+        acc
+    end
+  end
+
+  defp fold_tcp_stat(_stat, acc), do: acc
+
+  defp put_field(acc, prefix, field, value) do
+    entry = Map.get(acc, prefix, %{active: 0, total: 0})
+    Map.put(acc, prefix, Map.put(entry, field, value))
+  end
+
+  defp schedule(msg, interval_ms) when interval_ms > 0 do
+    Process.send_after(self(), msg, interval_ms)
+  end
+
+  defp schedule(_msg, _interval), do: :ok
+
+  defp default_clock, do: System.system_time(:millisecond)
+end

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -159,6 +159,15 @@ defmodule Embervm.Router do
     handle_get_group(conn, name)
   end
 
+  # DELETE /v1/groups/:name/instance (management auth): the forced roll. Destroys
+  # every live member + deletes the network + evicts the banked set, KEEPING the
+  # workload definition so the next connection fresh-boots a new environment on the
+  # current images. The convergence + degraded-recovery lever. Returns the counts
+  # destroyed + evicted (each 0 or 1, the class is a group-level singleton).
+  delete "/v1/groups/:name/instance" do
+    handle_force_roll_group(conn, name)
+  end
+
   # The activator fallback (R3, Task 8): the catch-all is the front-end the node
   # Envoy routes a MISS to (the fallback endpoint of an empty serve|<workload>
   # cluster). It is identified by the `x-ember-workload` request header the serving
@@ -1110,8 +1119,23 @@ defmodule Embervm.Router do
     end
   end
 
+  # DELETE /v1/groups/:name/instance handler: forced roll (management auth). Drives
+  # GroupSweeper.force_roll (destroy live members + delete network + evict banked set,
+  # keep the definition) so the next connection fresh-boots on the current images.
+  # Returns the counts; a workload with no instances rolls zero (200), never a 404
+  # (mirrors the serving/stateful forced-roll "rolling nothing is still success").
+  defp handle_force_roll_group(conn, workload) do
+    %{destroyed: destroyed, evicted: evicted} =
+      group_sweeper().force_roll(group_sweeper_server(), workload)
+
+    send_json(conn, 200, %{workload: workload, destroyed: destroyed, evicted: evicted})
+  end
+
   defp group_store, do: Application.get_env(:embervm, :group_store_mod, Embervm.GroupStore)
   defp group_store_server, do: Application.get_env(:embervm, :group_store, Embervm.GroupStore)
+
+  defp group_sweeper, do: Application.get_env(:embervm, :group_sweeper_mod, Embervm.GroupSweeper)
+  defp group_sweeper_server, do: Application.get_env(:embervm, :group_sweeper, Embervm.GroupSweeper)
 
   defp serving_sweeper, do: Application.get_env(:embervm, :serving_sweeper_mod, Embervm.ServingSweeper)
   defp serving_sweeper_server, do: Application.get_env(:embervm, :serving_sweeper, Embervm.ServingSweeper)

--- a/projects/embervm/control/lib/embervm/tcp_activator.ex
+++ b/projects/embervm/control/lib/embervm/tcp_activator.ex
@@ -141,6 +141,12 @@ defmodule Embervm.TcpActivator do
       # connect_timeout_ms) -> {:ok, socket} | {:error, reason}.
       dial_fun: Keyword.get(opts, :dial_fun, &default_dial/3),
       connect_timeout_ms: Keyword.get(opts, :connect_timeout_ms, 5_000),
+      # The composite live-splice counter table (R5, Task 8): a composite splice is
+      # bracketed incr..decr on it so the GroupSweeper's idle predicate can see a
+      # session that began during a wake (invisible to the entry listener's Envoy
+      # cx_active counter). nil disables the bracket (a stateful-only or test run),
+      # a clean no-op via ActivatorSplices' own absent-table guard.
+      splices_table: Keyword.get(opts, :splices_table, Embervm.ActivatorSplices),
       listeners: %{}
     }
 
@@ -242,7 +248,7 @@ defmodule Embervm.TcpActivator do
       %{ip: ip, port: vm_port} when is_binary(ip) and ip != "" and is_integer(vm_port) ->
         # Straggler: the VM/group is already live (a race with the node Envoy's
         # fallback decision). Splice directly, no wake.
-        splice_to(csock, workload, ip, vm_port, ctx)
+        splice_to(csock, class, workload, ip, vm_port, ctx)
 
       _ ->
         wake_and_splice(csock, class, workload, ctx)
@@ -266,7 +272,7 @@ defmodule Embervm.TcpActivator do
 
     case manager_mod.wake(manager, workload, principal) do
       {:ok, %{ip: ip, port: vm_port}} ->
-        splice_to(csock, workload, ip, vm_port, ctx)
+        splice_to(csock, class, workload, ip, vm_port, ctx)
 
       {:error, reason} ->
         Logger.info("embervm tcp activator: wake denied/failed, closing", workload: workload, reason: inspect(reason))
@@ -277,7 +283,7 @@ defmodule Embervm.TcpActivator do
   defp wake_target(ctx, :stateful, workload), do: {ctx.manager, ctx.manager_mod, "system:stateful:#{workload}"}
   defp wake_target(ctx, :composite, workload), do: {ctx.group_manager, ctx.group_manager_mod, "system:group:#{workload}"}
 
-  defp splice_to(csock, workload, ip, vm_port, ctx) do
+  defp splice_to(csock, class, workload, ip, vm_port, ctx) do
     case ctx.dial_fun.(ip, vm_port, ctx.connect_timeout_ms) do
       {:ok, usock} ->
         # The `splice` span (Task 10): bounds the whole spliced connection's
@@ -288,16 +294,41 @@ defmodule Embervm.TcpActivator do
         # lightweight counters pump_both/2 already threads through its
         # accumulator (no extra syscalls: :gen_tcp.recv already returns the byte
         # count via byte_size/1 on data it already read).
-        Tracer.with_span "embervm.stateful.splice", %{attributes: %{"ember.workload" => workload}} do
-          {bytes_in, bytes_out} = pump_both(csock, usock)
-          Tracer.set_attributes(%{"ember.bytes_in" => bytes_in, "ember.bytes_out" => bytes_out})
-        end
+        #
+        # A COMPOSITE splice is bracketed incr..decr on the live-splice counter (R5,
+        # Task 8): a session spliced here never re-enters the entry listener's Envoy
+        # cx_active counter, so the GroupSweeper reads this count as its third idle
+        # clause. The `after` fires on a normal teardown AND a pump crash within this
+        # process (a linked-peer crash cascades here too), so a live splice decrements
+        # exactly once; a NET leak only ever reads busier-than-real (never fakes idle).
+        with_splice_bracket(class, workload, ctx, fn ->
+          Tracer.with_span "embervm.stateful.splice", %{attributes: %{"ember.workload" => workload}} do
+            {bytes_in, bytes_out} = pump_both(csock, usock)
+            Tracer.set_attributes(%{"ember.bytes_in" => bytes_in, "ember.bytes_out" => bytes_out})
+          end
+        end)
 
       {:error, reason} ->
         Logger.warning("embervm tcp activator: dial to woken VM failed", ip: ip, port: vm_port, reason: inspect(reason))
         :gen_tcp.close(csock)
     end
   end
+
+  # Bracket a COMPOSITE splice with incr..decr on the live-splice counter; a stateful
+  # splice runs the body unbracketed (Envoy's state-<port> cx_active already sees a
+  # stateful session, so there is nothing extra to track). The decrement is in an
+  # `after` so it fires on both a clean teardown and a crash in this handler process.
+  defp with_splice_bracket(:composite, workload, ctx, body) do
+    Embervm.ActivatorSplices.incr(ctx.splices_table, workload)
+
+    try do
+      body.()
+    after
+      Embervm.ActivatorSplices.decr(ctx.splices_table, workload)
+    end
+  end
+
+  defp with_splice_bracket(_class, _workload, _ctx, body), do: body.()
 
   defp default_dial(ip, port, connect_timeout_ms) do
     ip_charlist = String.to_charlist(ip)

--- a/projects/embervm/control/test/embervm/activator_splices_test.exs
+++ b/projects/embervm/control/test/embervm/activator_splices_test.exs
@@ -1,0 +1,72 @@
+defmodule Embervm.ActivatorSplicesTest do
+  @moduledoc """
+  Exercises Embervm.ActivatorSplices (the R5 Task 8 per-workload live-splice
+  counter): incr/decr bracket, the zero-clamp (an over-decrement never fakes
+  idleness), live?/2, and the absent-table no-op (a sweeper wired without an
+  activator reads no-splice).
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.ActivatorSplices
+
+  defp start_counter do
+    table = :"splices_#{System.unique_integer([:positive])}"
+    _ = start_supervised!({ActivatorSplices, [table: table]})
+    table
+  end
+
+  test "incr then decr brackets a splice back to not-live" do
+    t = start_counter()
+
+    refute ActivatorSplices.live?(t, "grp-a")
+
+    ActivatorSplices.incr(t, "grp-a")
+    assert ActivatorSplices.live?(t, "grp-a")
+
+    ActivatorSplices.decr(t, "grp-a")
+    refute ActivatorSplices.live?(t, "grp-a")
+  end
+
+  test "concurrent splices: still live until the LAST decrements" do
+    t = start_counter()
+
+    ActivatorSplices.incr(t, "grp-a")
+    ActivatorSplices.incr(t, "grp-a")
+    assert ActivatorSplices.live?(t, "grp-a")
+
+    ActivatorSplices.decr(t, "grp-a")
+    assert ActivatorSplices.live?(t, "grp-a"), "one splice still open"
+
+    ActivatorSplices.decr(t, "grp-a")
+    refute ActivatorSplices.live?(t, "grp-a")
+  end
+
+  test "an over-decrement clamps at zero (never fakes idleness by going negative)" do
+    t = start_counter()
+
+    # Decrement with no prior incr: clamps at 0, still not live.
+    ActivatorSplices.decr(t, "grp-a")
+    refute ActivatorSplices.live?(t, "grp-a")
+
+    # A single incr after the spurious decr reads live (not cancelled by a negative).
+    ActivatorSplices.incr(t, "grp-a")
+    assert ActivatorSplices.live?(t, "grp-a")
+  end
+
+  test "distinct workloads count independently" do
+    t = start_counter()
+
+    ActivatorSplices.incr(t, "grp-a")
+    assert ActivatorSplices.live?(t, "grp-a")
+    refute ActivatorSplices.live?(t, "grp-b")
+  end
+
+  test "an absent table reads not-live and no-ops incr/decr (sweeper without an activator)" do
+    absent = :"never_started_#{System.unique_integer([:positive])}"
+
+    refute ActivatorSplices.live?(absent, "grp-a")
+    assert :ok = ActivatorSplices.incr(absent, "grp-a")
+    assert :ok = ActivatorSplices.decr(absent, "grp-a")
+    refute ActivatorSplices.live?(absent, "grp-a")
+  end
+end

--- a/projects/embervm/control/test/embervm/group_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_manager_test.exs
@@ -120,10 +120,25 @@ defmodule Embervm.GroupManagerTest do
       end
     end
 
+    bank_fail_member = Keyword.get(opts, :bank_fail_member)
+
     stop_group_member_fun = fn _ch, req ->
-      record(rec, {:stop_member, req.vm_id, req.mode})
+      record(rec, {:stop_member, req.vm_id, req.mode, req.set_id, req.member_name})
       if req.mode == :STOP_GROUP_MEMBER_MODE_DESTROY, do: release.(req.vm_id)
-      {:ok, %Embervm.Node.V1.StopGroupMemberResponse{}}
+
+      cond do
+        req.mode == :STOP_GROUP_MEMBER_MODE_BANK and req.member_name == bank_fail_member ->
+          {:error, :bank_boom}
+
+        req.mode == :STOP_GROUP_MEMBER_MODE_BANK ->
+          # BANK pauses+snapshots+destroys, returning the per-member bundle ref written
+          # under group/<set_id>/<member>/.
+          release.(req.vm_id)
+          {:ok, %Embervm.Node.V1.StopGroupMemberResponse{snapshot_ref: "snap-#{req.set_id}-#{req.member_name}", size_bytes: 4_096}}
+
+        true ->
+          {:ok, %Embervm.Node.V1.StopGroupMemberResponse{}}
+      end
     end
 
     evict_snapshot_fun = fn _ch, req ->
@@ -378,7 +393,7 @@ defmodule Embervm.GroupManagerTest do
     # taps+IPs were freed. Without this the fresh boot would collide on .10/.11
     # (:ip_in_use, modeled by the allocator fake) and the whole wake would fail.
     destroyed =
-      for {:stop_member, vm_id, :STOP_GROUP_MEMBER_MODE_DESTROY} <- events(ctx.rec), do: vm_id
+      for {:stop_member, vm_id, :STOP_GROUP_MEMBER_MODE_DESTROY, _set, _name} <- events(ctx.rec), do: vm_id
 
     assert "vm-leader" in destroyed
     assert "vm-worker-0" in destroyed
@@ -409,5 +424,60 @@ defmodule Embervm.GroupManagerTest do
     {:ok, inst} = GroupStore.get(ctx.store, "g-1")
     assert inst.state == :running
     assert inst.set_id == nil
+  end
+
+  # -- bank_group (R5 Task 8) -------------------------------------------------
+
+  test "bank_group banks the whole set under one set_id and records it atomically" do
+    ctx = start_group()
+    {:ok, _} = GroupManager.create_group(ctx.mgr)
+
+    # The sweeper moves running -> banking (unpublish + activator) BEFORE driving the
+    # bank; bank_group operates from :banking.
+    {:ok, _} = GroupStore.mark(ctx.store, "g-1", :bank)
+
+    assert {:ok, %{set_id: set_id, banked: 3, pause_spread_ms: spread}} = GroupManager.bank_group(ctx.mgr)
+    assert is_binary(set_id) and set_id != ""
+    assert spread >= 0
+
+    {:ok, inst} = GroupStore.get(ctx.store, "g-1")
+    assert inst.state == :banked
+    assert inst.set_id == set_id
+
+    # Every member banked under the SAME set_id (BANK mode), each stamped with its ref.
+    banks =
+      for {:stop_member, _vm, :STOP_GROUP_MEMBER_MODE_BANK, sid, name} <- events(ctx.rec), do: {sid, name}
+
+    assert Enum.map(banks, &elem(&1, 0)) |> Enum.uniq() == [set_id], "one shared set_id"
+    assert Enum.map(banks, &elem(&1, 1)) |> Enum.sort() == ["leader", "worker-0", "worker-1"]
+
+    members = GroupStore.members(ctx.store, "g-1")
+    assert Enum.all?(members, &(is_binary(&1.snapshot_ref) and &1.snapshot_ref != ""))
+    assert Enum.all?(members, &(&1.vm_id == nil)), "the VMs are gone after bank"
+
+    # ONE atomic group_banked op recorded the whole set.
+    ops = load_ops(ctx, "group_banked")
+    assert length(ops) == 1
+  end
+
+  test "bank_group ABORTS back to running when a member BANK fails (all-or-nothing)" do
+    ctx = start_group(bank_fail_member: "worker-1")
+    {:ok, _} = GroupManager.create_group(ctx.mgr)
+
+    {:ok, _} = GroupStore.mark(ctx.store, "g-1", :bank)
+
+    assert {:error, {:bank_partial, _}} = GroupManager.bank_group(ctx.mgr)
+
+    {:ok, inst} = GroupStore.get(ctx.store, "g-1")
+    assert inst.state == :running, "a failed member bank returns the group to running"
+    assert inst.set_id == nil
+
+    assert load_ops(ctx, "group_banked") == []
+  end
+
+  defp load_ops(ctx, kind) do
+    atom = String.to_existing_atom(kind)
+    {:ok, ops} = SQLite.read_from(ctx.op_log, 0)
+    Enum.filter(ops, &(&1.kind == atom))
   end
 end

--- a/projects/embervm/control/test/embervm/group_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/group_sweeper_test.exs
@@ -1,0 +1,571 @@
+defmodule Embervm.GroupSweeperTest do
+  @moduledoc """
+  Exercises Embervm.GroupSweeper (the R5 Task 8 lifecycle-economics loop) against a
+  real GroupStore + op-log, an injected stats-scrape seam (scripted
+  downstream_cx_active/total for the group entry listener), an injected bank drive +
+  daemon seams, an isolated ActivatorSplices counter, and an injected clock so no
+  test sleeps. Covers:
+
+    * idle detection with the DEGRADED exclusion (a degraded group is NEVER banked),
+      the zero-activator-splices clause (a live splice blocks banking even at
+      cx_active==0), abort-on-recheck (a connection racing in aborts the bank);
+    * max-lifetime TTL patience (an active group waits the drain window then
+      destroys, tearing down members + the network);
+    * banked-TTL terminal (an expired set DESTROYS the instance, warmth-only);
+    * forced roll (destroys members + evicts the set + keeps the definition, so the
+      next connection fresh-boots);
+    * scrape-fails-open (never banks on stale stats).
+
+  Fake processes use start_supervised! for order-independent teardown; synchronous
+  assertions where possible (the bank drive is an injected synchronous fun, so no
+  wait_until flake).
+  """
+  use ExUnit.Case, async: false
+
+  alias Embervm.{ActivatorSplices, GroupState, GroupStore, NodeCapacity, WorkloadCatalog}
+  alias Embervm.GroupSweeper
+  alias Embervm.OpLog.SQLite
+
+  defmodule FakePublisher do
+    use GenServer
+    def start_link(_ \\ []), do: GenServer.start_link(__MODULE__, 0)
+    def count(pid), do: GenServer.call(pid, :count)
+    @impl true
+    def init(n), do: {:ok, n}
+    @impl true
+    def handle_cast(:publish, n), do: {:noreply, n + 1}
+    @impl true
+    def handle_call(:count, _from, n), do: {:reply, n, n}
+  end
+
+  defp clock(agent), do: fn -> Agent.get(agent, & &1) end
+  defp advance(agent, ms), do: Agent.update(agent, &(&1 + ms))
+
+  defp start_stack(opts \\ []) do
+    suffix = System.unique_integer([:positive])
+    cap_table = :"grswcap_#{suffix}"
+    cat_table = :"grswcat_#{suffix}"
+    splices = :"grswsplices_#{suffix}"
+
+    NodeCapacity.create(cap_table)
+    WorkloadCatalog.create(cat_table)
+
+    path = Path.join(System.tmp_dir!(), "embervm_groupsweeper_test_#{suffix}.db")
+    on_exit(fn -> File.rm_rf!(path) end)
+
+    {:ok, clock_agent} = Agent.start_link(fn -> 10_000 end)
+    {:ok, op_log} = SQLite.start_link(name: nil, path: path)
+    {:ok, store} = GroupStore.start_link(name: nil, op_log: op_log, clock: clock(clock_agent))
+    pub = start_supervised!({FakePublisher, []})
+    _ = start_supervised!({ActivatorSplices, [table: splices]})
+
+    {:ok, scrape_agent} = Agent.start_link(fn -> {:ok, %{}} end)
+    {:ok, bank_calls} = Agent.start_link(fn -> [] end)
+    {:ok, bank_result} = Agent.start_link(fn -> :ok end)
+    {:ok, stop_calls} = Agent.start_link(fn -> [] end)
+    {:ok, delete_net_calls} = Agent.start_link(fn -> [] end)
+    {:ok, evict_calls} = Agent.start_link(fn -> [] end)
+
+    # The bank drive seam: records each (workload, instance_id) and, on :ok, actually
+    # banks the instance in the store (mirroring what GroupManager.bank_group does) so
+    # the sweeper's post-bank state matches production. The sweeper has ALREADY moved
+    # the instance running -> banking before calling (the unpublish-then-bank order),
+    # so this drives from :banking (bank_ready is the banking -> banked edge). On a
+    # scripted {:error, _} it leaves the instance in :banking (an aborting bank returns
+    # it to running via the sweeper's own bank_abort path, not here).
+    bank_fun = fn workload, instance_id ->
+      Agent.update(bank_calls, &[{workload, instance_id} | &1])
+
+      case Agent.get(bank_result, & &1) do
+        :ok ->
+          members = GroupStore.members(store, instance_id)
+          set_members = for m <- members, do: %{name: m.member_name, snapshot_ref: "snap-#{m.member_name}"}
+          {:ok, _} = GroupStore.bank_ready(store, instance_id, "set-#{instance_id}", set_members)
+          {:ok, %{set_id: "set-#{instance_id}", banked: length(set_members), pause_spread_ms: 5}}
+
+        {:error, _} = err ->
+          # A failed member bank: the manager would have marked banking -> running
+          # (bank_abort). Mirror that so the sweeper's re-publish sees a running group.
+          {:ok, _} = GroupStore.mark(store, instance_id, :bank_abort)
+          err
+      end
+    end
+
+    stop_group_member_fun = fn _ch, req ->
+      Agent.update(stop_calls, &[req | &1])
+      {:ok, %Embervm.Node.V1.StopGroupMemberResponse{}}
+    end
+
+    delete_group_network_fun = fn _ch, req ->
+      Agent.update(delete_net_calls, &[req | &1])
+      {:ok, %Embervm.Node.V1.DeleteGroupNetworkResponse{}}
+    end
+
+    evict_snapshot_fun = fn _ch, req ->
+      Agent.update(evict_calls, &[req | &1])
+      {:ok, %Embervm.Node.V1.EvictSnapshotResponse{}}
+    end
+
+    sweeper_opts = [
+      name: nil,
+      store: store,
+      publisher: pub,
+      capacity_table: cap_table,
+      catalog_table: cat_table,
+      op_log: op_log,
+      clock: clock(clock_agent),
+      scrape_fun: fn _url -> Agent.get(scrape_agent, & &1) end,
+      stats_base: Keyword.get(opts, :stats_base, "http://serving:9902"),
+      splices_table: splices,
+      bank_fun: bank_fun,
+      channel_fun: fn _node -> {:ok, :ch} end,
+      stop_group_member_fun: stop_group_member_fun,
+      delete_group_network_fun: delete_group_network_fun,
+      evict_snapshot_fun: evict_snapshot_fun,
+      lifetime_drain_max_ms: Keyword.get(opts, :lifetime_drain_max_ms, 3_600_000),
+      sweep_interval_ms: 0
+    ]
+
+    {:ok, sweeper} = GroupSweeper.start_link(sweeper_opts)
+
+    %{
+      sweeper: sweeper,
+      store: store,
+      op_log: op_log,
+      pub: pub,
+      cap_table: cap_table,
+      cat_table: cat_table,
+      splices: splices,
+      clock_agent: clock_agent,
+      scrape_agent: scrape_agent,
+      bank_calls: bank_calls,
+      bank_result: bank_result,
+      stop_calls: stop_calls,
+      delete_net_calls: delete_net_calls,
+      evict_calls: evict_calls
+    }
+  end
+
+  defp set_scrape(ctx, reading), do: Agent.update(ctx.scrape_agent, fn _ -> reading end)
+  defp bank_calls(ctx), do: Agent.get(ctx.bank_calls, &Enum.reverse(&1))
+  defp stop_calls(ctx), do: Agent.get(ctx.stop_calls, &Enum.reverse(&1))
+  defp delete_net_calls(ctx), do: Agent.get(ctx.delete_net_calls, &Enum.reverse(&1))
+  defp evict_calls(ctx), do: Agent.get(ctx.evict_calls, &Enum.reverse(&1))
+
+  defp reading(prefix, active, total), do: {:ok, %{prefix => %{active: active, total: total}}}
+
+  defp group_workload(ctx, name, listen_port, cfg \\ %{}) do
+    group = %{
+      members: [%{name: "a", start_order: 0}, %{name: "b", start_order: 1}],
+      entry: %{member: "a", port: 8080, listen_port: listen_port},
+      secret_ref: nil,
+      idle_bank_seconds: Map.get(cfg, :idle_bank_seconds, 60),
+      max_lifetime_seconds: Map.get(cfg, :max_lifetime_seconds, 86_400),
+      banked_ttl_seconds: Map.get(cfg, :banked_ttl_seconds, 3_600),
+      wake_timeout_seconds: 120
+    }
+
+    WorkloadCatalog.upsert(ctx.cat_table, name, %{class: "composite", namespace: "embervm", group: group})
+  end
+
+  defp group_node(ctx, node_id) do
+    NodeCapacity.put(ctx.cap_table, node_id, %{
+      configured_id: node_id,
+      node_id: node_id,
+      serving_subnet_cidr: "10.98.0.0/24",
+      max_live_vms: 8,
+      live_vms: 0,
+      workloads: %{},
+      group_member_vms: [],
+      group_bundle_sets: []
+    })
+  end
+
+  # A running group instance with two live members, entry published.
+  defp running_group(ctx, id, workload, opts \\ []) do
+    {:ok, _} =
+      GroupStore.create(ctx.store, %{
+        instance_id: id,
+        tenant: "homelab",
+        principal: "system:group:#{workload}",
+        workload: workload,
+        node_id: Keyword.get(opts, :node_id, "node-4"),
+        subnet_cidr: "10.101.0.0/24",
+        entry_member: "a",
+        entry_port: 8080,
+        listen_port: Keyword.get(opts, :listen_port, 5410),
+        secret: "sekret"
+      })
+
+    {:ok, _} = GroupStore.member_started(ctx.store, id, %{member_name: "a", member_index: 0, vm_id: "vm-#{id}-a", ip: "10.101.0.10"})
+    {:ok, _} = GroupStore.member_started(ctx.store, id, %{member_name: "b", member_index: 1, vm_id: "vm-#{id}-b", ip: "10.101.0.11"})
+    {:ok, _} = GroupStore.publish(ctx.store, id, "10.244.0.5", 30_010)
+    id
+  end
+
+  # Drive a running group to banked directly (bypassing the sweeper), for banked-TTL /
+  # lifetime tests that need a pre-existing banked set.
+  defp banked_group(ctx, id, workload) do
+    _ = running_group(ctx, id, workload)
+    {:ok, _} = GroupStore.mark(ctx.store, id, :bank)
+
+    members = [%{name: "a", snapshot_ref: "snap-a"}, %{name: "b", snapshot_ref: "snap-b"}]
+    {:ok, _} = GroupStore.bank_ready(ctx.store, id, "set-#{id}", members)
+    id
+  end
+
+  defp load_ops(ctx, kind) do
+    atom = String.to_existing_atom(kind)
+    {:ok, ops} = SQLite.read_from(ctx.op_log, 0)
+    Enum.filter(ops, &(&1.kind == atom))
+  end
+
+  # -- idle detection ---------------------------------------------------------
+
+  test "cx_active==0, flat cx_total delta, no live splice banks the group past idleBankSeconds" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410, %{idle_bank_seconds: 60})
+    group_node(ctx, "node-4")
+    running_group(ctx, "gi-1", "grp-a")
+
+    # Tick 1: baseline (no prior reading).
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+    assert {:ok, %{state: :running}} = GroupStore.get(ctx.store, "gi-1")
+
+    # Tick 2: idle confirmed (idle_since set this tick); cannot bank on the same tick.
+    advance(ctx.clock_agent, 5_000)
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+    assert {:ok, %{state: :running}} = GroupStore.get(ctx.store, "gi-1")
+
+    # Tick 3 (65s after idle_since, past idleBankSeconds=60): banks.
+    advance(ctx.clock_agent, 65_000)
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    assert {:ok, %{state: :banked, set_id: set_id}} = GroupStore.get(ctx.store, "gi-1")
+    assert set_id == "set-gi-1"
+    assert [{"grp-a", "gi-1"}] = bank_calls(ctx)
+    assert length(load_ops(ctx, "group_banked")) == 1
+  end
+
+  test "a DEGRADED group is NEVER banked (decision 11), the exclusion is left running" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410, %{idle_bank_seconds: 60})
+    group_node(ctx, "node-4")
+    running_group(ctx, "gi-1", "grp-a")
+
+    # Member b falls unhealthy: the group stays running but carries the degraded flag.
+    {:ok, _} = GroupStore.set_member_health(ctx.store, "gi-1", "b", false)
+    assert {true, "b"} = GroupStore.degraded?(ctx.store, "grp-a")
+
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 5_000)
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    # Well past idleBankSeconds: a NON-degraded group would bank here, but this one
+    # stays running and no bank was driven.
+    advance(ctx.clock_agent, 200_000)
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    assert {:ok, %{state: :running, degraded_member: "b"}} = GroupStore.get(ctx.store, "gi-1")
+    assert bank_calls(ctx) == []
+  end
+
+  test "a live activator splice blocks banking even at cx_active==0 (zero-splice clause)" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410, %{idle_bank_seconds: 60})
+    group_node(ctx, "node-4")
+    running_group(ctx, "gi-1", "grp-a")
+
+    # A session spliced during a wake: invisible to Envoy's entry cx_active, but a
+    # live splice the sweeper counts as activity.
+    ActivatorSplices.incr(ctx.splices, "grp-a")
+
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 200_000)
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    # Never banks while the splice is live (the idle clock never even arms).
+    assert {:ok, %{state: :running}} = GroupStore.get(ctx.store, "gi-1")
+    assert bank_calls(ctx) == []
+
+    # The splice ends: now the group can idle-bank.
+    ActivatorSplices.decr(ctx.splices, "grp-a")
+
+    advance(ctx.clock_agent, 5_000)
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 65_000)
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    assert {:ok, %{state: :banked}} = GroupStore.get(ctx.store, "gi-1")
+  end
+
+  test "a scrape failure fails open: no idle-bank against stale stats" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410, %{idle_bank_seconds: 60})
+    group_node(ctx, "node-4")
+    running_group(ctx, "gi-1", "grp-a")
+
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 300_000)
+    set_scrape(ctx, {:error, :timeout})
+    GroupSweeper.sweep(ctx.sweeper)
+
+    assert {:ok, %{state: :running}} = GroupStore.get(ctx.store, "gi-1")
+    assert bank_calls(ctx) == []
+  end
+
+  # -- abort-on-recheck -------------------------------------------------------
+
+  test "a connection racing in at the recheck ABORTS the bank (never driven, group stays running)" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410, %{idle_bank_seconds: 60})
+    group_node(ctx, "node-4")
+    running_group(ctx, "gi-1", "grp-a")
+
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 5_000)
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    # Tick 3: the tick-start scan reads cx_active==0 (bank begins), but the recheck's
+    # fresh re-scrape reads cx_active==1 (a connection raced in). An Agent-backed call
+    # counter distinguishes the two scrape calls deterministically.
+    {:ok, call_count} = Agent.start_link(fn -> 0 end)
+
+    scrape_fun = fn _url ->
+      n = Agent.get_and_update(call_count, fn n -> {n, n + 1} end)
+      if n == 0, do: reading("group-5410", 0, 3), else: reading("group-5410", 1, 3)
+    end
+
+    :sys.replace_state(ctx.sweeper, fn s -> %{s | scrape_fun: scrape_fun} end)
+
+    advance(ctx.clock_agent, 65_000)
+    GroupSweeper.sweep(ctx.sweeper)
+
+    assert {:ok, %{state: :running}} = GroupStore.get(ctx.store, "gi-1")
+    assert bank_calls(ctx) == []
+    assert load_ops(ctx, "group_banked") == []
+  end
+
+  # -- max-lifetime TTL patience ----------------------------------------------
+
+  test "an idle over-lifetime group destroys immediately (members + network torn down)" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410, %{max_lifetime_seconds: 100})
+    group_node(ctx, "node-4")
+    running_group(ctx, "gi-1", "grp-a")
+
+    advance(ctx.clock_agent, 200_000)
+    set_scrape(ctx, reading("group-5410", 0, 0))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    assert {:ok, %{state: :destroyed, terminal_reason: "lifetime"}} = GroupStore.get(ctx.store, "gi-1")
+
+    destroys = Enum.filter(stop_calls(ctx), &(&1.mode == :STOP_GROUP_MEMBER_MODE_DESTROY))
+    assert length(destroys) == 2, "both member VMs destroyed"
+    assert [%{group_instance_id: "gi-1"}] = delete_net_calls(ctx)
+  end
+
+  test "an active over-lifetime group waits the drain patience window, then destroys anyway" do
+    ctx = start_stack(lifetime_drain_max_ms: 100_000)
+    group_workload(ctx, "grp-a", 5410, %{max_lifetime_seconds: 100})
+    group_node(ctx, "node-4")
+    running_group(ctx, "gi-1", "grp-a")
+
+    # Over lifetime AND actively connected: must NOT destroy yet.
+    advance(ctx.clock_agent, 200_000)
+    set_scrape(ctx, reading("group-5410", 1, 0))
+    GroupSweeper.sweep(ctx.sweeper)
+    assert {:ok, %{state: :running}} = GroupStore.get(ctx.store, "gi-1")
+
+    # Still active, short of the patience window: still alive.
+    advance(ctx.clock_agent, 50_000)
+    set_scrape(ctx, reading("group-5410", 1, 0))
+    GroupSweeper.sweep(ctx.sweeper)
+    assert {:ok, %{state: :running}} = GroupStore.get(ctx.store, "gi-1")
+
+    # Past the patience window: destroyed anyway, even though still active.
+    advance(ctx.clock_agent, 60_000)
+    set_scrape(ctx, reading("group-5410", 1, 0))
+    GroupSweeper.sweep(ctx.sweeper)
+    assert {:ok, %{state: :destroyed, terminal_reason: "lifetime"}} = GroupStore.get(ctx.store, "gi-1")
+  end
+
+  # -- banked-TTL terminal (warmth-only) --------------------------------------
+
+  test "a banked set untouched past bankedTtlSeconds DESTROYS the instance (warmth-only terminal)" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410, %{banked_ttl_seconds: 100, max_lifetime_seconds: 1_000_000})
+    group_node(ctx, "node-4")
+    banked_group(ctx, "gi-1", "grp-a")
+
+    advance(ctx.clock_agent, 200_000)
+    set_scrape(ctx, reading("group-5410", 0, 0))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    # An expired set IS the instance's end (no volume floor): the instance is destroyed
+    # (reason expired), and each member's bundle is evicted.
+    assert {:ok, %{state: :destroyed, terminal_reason: "expired"}} = GroupStore.get(ctx.store, "gi-1")
+    evicted_refs = Enum.map(evict_calls(ctx), & &1.snapshot_ref) |> Enum.sort()
+    assert evicted_refs == ["snap-a", "snap-b"]
+  end
+
+  test "a banked over-lifetime set is destroyed immediately (reason expired)" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410, %{max_lifetime_seconds: 100})
+    group_node(ctx, "node-4")
+    banked_group(ctx, "gi-1", "grp-a")
+
+    advance(ctx.clock_agent, 200_000)
+    set_scrape(ctx, reading("group-5410", 0, 0))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    assert {:ok, %{state: :destroyed, terminal_reason: "expired"}} = GroupStore.get(ctx.store, "gi-1")
+  end
+
+  test "a banked set within bankedTtlSeconds is kept" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410, %{banked_ttl_seconds: 1_000_000, max_lifetime_seconds: 1_000_000})
+    group_node(ctx, "node-4")
+    banked_group(ctx, "gi-1", "grp-a")
+
+    advance(ctx.clock_agent, 200_000)
+    set_scrape(ctx, reading("group-5410", 0, 0))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    assert {:ok, %{state: :banked}} = GroupStore.get(ctx.store, "gi-1")
+  end
+
+  # -- forced roll ------------------------------------------------------------
+
+  test "forced roll destroys the live group + deletes the network, keeps the definition" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410)
+    group_node(ctx, "node-4")
+    running_group(ctx, "gi-1", "grp-a")
+
+    result = GroupSweeper.force_roll(ctx.sweeper, "grp-a")
+    assert result == %{destroyed: 1, evicted: 0}
+
+    assert {:ok, %{state: :destroyed, terminal_reason: "forced_roll"}} = GroupStore.get(ctx.store, "gi-1")
+
+    destroys = Enum.filter(stop_calls(ctx), &(&1.mode == :STOP_GROUP_MEMBER_MODE_DESTROY))
+    assert length(destroys) == 2
+    assert [%{group_instance_id: "gi-1"}] = delete_net_calls(ctx)
+
+    # The DEFINITION is kept: the catalog entry survives, so the next connection
+    # fresh-boots.
+    assert {:ok, %{class: "composite"}} = WorkloadCatalog.fetch(ctx.cat_table, "grp-a")
+  end
+
+  test "forced roll evicts a banked set (keeps the definition, next connect fresh-boots)" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410)
+    group_node(ctx, "node-4")
+    banked_group(ctx, "gi-1", "grp-a")
+
+    result = GroupSweeper.force_roll(ctx.sweeper, "grp-a")
+    assert result == %{destroyed: 0, evicted: 1}
+
+    assert {:ok, %{state: :destroyed, terminal_reason: "forced_roll"}} = GroupStore.get(ctx.store, "gi-1")
+    evicted_refs = Enum.map(evict_calls(ctx), & &1.snapshot_ref) |> Enum.sort()
+    assert evicted_refs == ["snap-a", "snap-b"]
+    assert {:ok, %{class: "composite"}} = WorkloadCatalog.fetch(ctx.cat_table, "grp-a")
+  end
+
+  test "forced roll on a workload with no instances is a clean 0/0 (never a 404)" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410)
+    group_node(ctx, "node-4")
+
+    assert %{destroyed: 0, evicted: 0} = GroupSweeper.force_roll(ctx.sweeper, "grp-a")
+  end
+
+  # -- bank abort returns the group to the fan-out ----------------------------
+
+  test "a bank drive failure leaves the group live and re-publishes" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410, %{idle_bank_seconds: 60})
+    group_node(ctx, "node-4")
+    running_group(ctx, "gi-1", "grp-a")
+
+    Agent.update(ctx.bank_result, fn _ -> {:error, :bank_partial} end)
+
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 5_000)
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 65_000)
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    # The bank was driven but failed: the group is still running (the fake bank_fun
+    # did not transition it), and the sweeper re-published.
+    assert {:ok, %{state: :running}} = GroupStore.get(ctx.store, "gi-1")
+    assert [{"grp-a", "gi-1"}] = bank_calls(ctx)
+  end
+
+  # -- usage: per-member live-seconds (decision 9) ----------------------------
+
+  test "a live group bills per-member live-seconds each tick (group_stats), last_active_at touched" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410, %{idle_bank_seconds: 1_000_000})
+    group_node(ctx, "node-4")
+    running_group(ctx, "gi-1", "grp-a")
+
+    # Tick 1 baselines the charge clock (bills nothing yet).
+    set_scrape(ctx, reading("group-5410", 1, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+    assert load_ops(ctx, "group_stats") == []
+
+    # Tick 2, 30s later: bills the 30s window x 2 members' compute, and touches
+    # last_active_at (the entry listener showed an open connection).
+    advance(ctx.clock_agent, 30_000)
+    set_scrape(ctx, reading("group-5410", 1, 5))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    stats = load_ops(ctx, "group_stats")
+    assert length(stats) == 1
+    [op] = stats
+    # 2 members, default 1 vcpu each, 30s window -> 60 vcpu-seconds.
+    assert op.payload["usage"]["vcpu_seconds"] == 60.0
+
+    {:ok, inst} = GroupStore.get(ctx.store, "gi-1")
+    assert inst.last_active_at != nil
+  end
+
+  # -- raw stats parse --------------------------------------------------------
+
+  test "parse_stats keeps both group- and state- prefixed tcp cx counters" do
+    body =
+      Jason.encode!(%{
+        "stats" => [
+          %{"name" => "tcp.group-5410.downstream_cx_active", "value" => 1},
+          %{"name" => "tcp.group-5410.downstream_cx_total", "value" => 9},
+          %{"name" => "cluster.serve|x.upstream_rq_total", "value" => 5}
+        ]
+      })
+
+    assert {:ok, %{"group-5410" => %{active: 1, total: 9}}} = GroupSweeper.parse_stats(body)
+  end
+end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.85
+      targetRevision: 0.1.86
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
R5 Task 8 (PR-5): generalizes the R4 `StatefulSweeper` to composite groups, the economics half of the composite lifecycle.

## What

- **`Embervm.GroupSweeper`** (mirror of StatefulSweeper): scrapes the group's entry listener (`group-<entry.listenPort>`) L4 `downstream_cx_{active,total}`, ANDs in a **zero-activator-splices** clause, clock-injected idle detection (`idle_since`), the bank sequence (`running -> banking` + activator install -> recheck -> whole-set bank via GroupManager -> abort + republish on a racing connection/splice), max-lifetime destroy (values-capped patience, tears down members **and** the private network), banked-TTL **warmth-only terminal** (an expired set IS the instance's end, unlike R4's volume floor), and per-tick per-member **live-seconds** usage (`group_stats`). Scrape **fails open**. A **degraded** group is **excluded from banking** (decision 11) as a logged, visible fact.
- **`GroupManager.bank_group/1` + `Supervisor.bank_group/2`**: the whole-set bank loop (StopGroupMember BANK every member under one shared `set_id`, **atomic** `group_banked` via `bank_ready`, all-or-nothing abort back to running), logging the **pause-spread** (decision 10). PR-4 had no bank entrypoint on the GroupManager, so this adds it.
- **`Embervm.ActivatorSplices`**: a per-workload ETS live-splice counter the `TcpActivator` brackets `incr..decr` around each **composite** splice; the sweeper reads it as the third idle clause (a session spliced during a wake never re-enters the entry listener's Envoy cx_active). Over-count fails toward warmth; the decrement clamps at zero so it can never fake idleness.
- **`GroupStore.touch_active/3`** for `last_active_at`.
- **`DELETE /v1/groups/{workload}/instance`** forced roll: destroy members + delete network + evict set, **keep the definition** so the next connection fresh-boots. The convergence + degraded-recovery lever.
- Max-lifetime patience knob `EMBERVM_GROUP_LIFETIME_DRAIN_MAX_MS` + full app-supervisor wiring (ActivatorSplices + GroupSweeper children, ordering documented).

## Activator splice signal

New minimal plumbing: the activator had no live-splice tracking (ephemeral unsupervised handler processes). `ActivatorSplices` is a public named ETS counter, bracketed only around **composite** splices (stateful splices are already visible to Envoy).

## Tests

ExUnit (clock-injected, `start_supervised!` fakes, synchronous assertions): idle detection with the **degraded exclusion**, the **zero-splice** clause, **abort-on-recheck**, **TTL patience**, **banked-TTL terminal**, **forced roll** (live + banked, definition kept), live-seconds billing, plus GroupManager whole-set bank + all-or-nothing abort, and the ActivatorSplices counter semantics.

Chart bumped 0.1.85 -> 0.1.86.

Acceptance: CI green; the live scale-to-zero drill is a documented post-merge step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hRr3Xsj74f6BzB47RUvRE