### PR TITLE
feat(demos): interactive scale-to-zero Postgres exhibit (sleep/wake theater)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.88
+version: 0.1.89

--- a/projects/embervm/chart/crds/workload-crd.yaml
+++ b/projects/embervm/chart/crds/workload-crd.yaml
@@ -442,8 +442,11 @@ spec:
                         delta across the window, per the Task 9 TCP idle scrape)
                         after which the instance is banked and its VM released. A
                         live connection is never severed regardless of this timer
-                        (decision 7).
-                      minimum: 30
+                        (decision 7). Sub-30 values are an informed opt-in for
+                        exhibits like demo-postgres (each bank writes a snapshot
+                        bundle, so a short window under active traffic is
+                        deliberate wake/bank churn).
+                      minimum: 1
                       default: 300
                     maxLifetimeSeconds:
                       type: integer

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -218,6 +218,20 @@ spec:
               value: "http://{{ include "embervm.serving.fullname" . }}:{{ .Values.servingEnvoy.statsPort }}"
             {{- end }}
             {{- end }}
+            {{- if .Values.statefulSweeper.sweepIntervalMs }}
+            # StatefulSweeper tick override (default 30000ms). The demo-postgres
+            # exhibit needs a ~1s tick so idle banking is visibly prompt; banking
+            # per workload stays gated by each CR's own idleBankSeconds.
+            - name: EMBERVM_STATEFUL_SWEEP_INTERVAL_MS
+              value: {{ .Values.statefulSweeper.sweepIntervalMs | quote }}
+            {{- end }}
+            {{- if .Values.statefulSweeper.wakeMax }}
+            # Per-workload wake-rate cap override (default 10/min): with a ~1s
+            # idle bank every demo query is a wake, so the default cap would turn
+            # an eager visitor's clicks into refusals inside a minute.
+            - name: EMBERVM_STATEFUL_WAKE_MAX
+              value: {{ .Values.statefulSweeper.wakeMax | quote }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/projects/embervm/chart/templates/workload-demo-postgres.yaml
+++ b/projects/embervm/chart/templates/workload-demo-postgres.yaml
@@ -1,0 +1,54 @@
+{{- if and .Values.demoPostgres.enabled .Values.scratchPostgres.enabled }}
+# Demo-postgres: the private demos page's sleep/wake exhibit. A second stateful
+# Postgres alongside scratch-postgres, tuned so the lifecycle is watchable: it
+# banks ~a tick after the demo's connection closes and pays a visible relight on
+# the next query. It reuses scratchPostgres' guest image pin (the SAME image ref
+# string, so the noded rootfs base and EMBERVM_NODED_IMAGES entry resolve with
+# zero extra provisioning) and the same first-boot POSTGRES_PASSWORD Secret; only
+# the workload identity, port, and lifecycle economics differ. The volume is its
+# own (volumes are keyed by workload name), so demo rows never land in a real
+# tenant's database.
+apiVersion: embervm.dev/v1alpha1
+kind: Workload
+metadata:
+  name: demo-postgres
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # Apply after the CRD (wave 0) establishes, like the other workloads.
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  class: stateful
+  source:
+    image:
+      # Must match scratchPostgres.guestImage exactly: the rootfs-builder base
+      # and the noded image table are keyed on this ref via the scratchPostgres
+      # workloads entry, so an identical string is what makes this workload
+      # bootable without its own base bake.
+      ref: "{{ .Values.scratchPostgres.guestImage.repository }}:{{ .Values.scratchPostgres.guestImage.tag }}"
+      port: 1027
+      readyPath: /shim/ready
+  resources:
+    # Same warm-peak sizing as scratch-postgres (the fc-base sizing coupling
+    # keys memMib to the shared base image, D-R3.11.1).
+    vcpus: 1
+    memMib: 512
+  stateful:
+    # The port Postgres listens on inside the VM. Health is a TCP connect here.
+    port: 5432
+    listenPort: {{ .Values.demoPostgres.listenPort }}
+    volumeSizeGiB: {{ .Values.demoPostgres.volumeSizeGiB }}
+    volumeMountPath: /data
+    # The demo knob: bank as soon as one sweeper tick sees the workload idle.
+    # A live connection is still never severed (decision 7); the demo backend
+    # uses short-lived connections precisely so this window is reachable.
+    idleBankSeconds: {{ .Values.demoPostgres.idleBankSeconds }}
+    # Version-convergence bound (1 week), as scratch-postgres.
+    maxLifetimeSeconds: 604800
+    # A banked bundle untouched 30 days is GC'd; the volume is never GC'd.
+    bankedTtlSeconds: 2592000
+    # Wake deadline (generous: cold boots include WAL recovery and, on first
+    # boot, mkfs + initdb).
+    wakeTimeoutSeconds: 60
+    # Reuse the scratch-postgres Secret: same superuser password on first boot.
+    secretRef: {{ include "embervm.fullname" . }}-scratch-postgres
+{{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -565,6 +565,37 @@ scratchK8s:
     # OnePasswordItem unrendered (set it to enable the secret sync + Workload CR).
     itemPath: ""
 
+# Demo-postgres: a SECOND stateful Postgres workload backing the private
+# firecracker demos page (sleep/wake theater). Same guest image, Secret, and
+# machinery as scratchPostgres, but with an aggressively short idle window so a
+# visitor can watch the VM bank itself seconds after their query and pay a
+# visible relight on the next one. Deliberately its own workload: scratch-
+# postgres serves real consumers (Loom, sandbox sessions) whose write cadence
+# the 120s idle window was tuned around; pointing the demo knobs at it would
+# thrash those tenants with a bank/wake cycle per background commit. Requires
+# scratchPostgres.enabled (it reuses that guest image pin and Secret).
+demoPostgres:
+  enabled: false
+  # Node Envoy TCP listener port (stateful 5400-5409 range, unique across
+  # stateful workloads; scratch-postgres holds 5400).
+  listenPort: 5401
+  # Bank almost immediately once idle. The effective floor is the stateful
+  # sweeper tick (statefulSweeper.sweepIntervalMs), not this value.
+  idleBankSeconds: 1
+  # Toy dataset: a handful of demo rows, not a real datastore.
+  volumeSizeGiB: 2
+
+# StatefulSweeper cadence + wake-rate overrides (control-plane env). Empty uses
+# the app defaults (30s tick, 10 wakes/min/workload). The demo page wants a ~1s
+# tick so idle banking is visibly prompt, and a higher wake cap so a click-happy
+# visitor gets wakes instead of refusals. Both knobs are control-plane-wide
+# across stateful workloads, but banking itself stays gated by each workload's
+# own idleBankSeconds, so a faster tick only sharpens the granularity for
+# everyone (scratch-postgres still waits its full 120s idle window).
+statefulSweeper:
+  sweepIntervalMs: ""
+  wakeMax: ""
+
 # The rootfs-builder tool image (crane + e2fsprogs + bash) that bakes each
 # workload's guest OCI image into an ext4 base rootfs at pod init. Reuses the
 # fc-invoke rootfs-builder image; Bazel pins repository:tag from its .info.

--- a/projects/embervm/control/lib/embervm/workload_watcher.ex
+++ b/projects/embervm/control/lib/embervm/workload_watcher.ex
@@ -815,9 +815,14 @@ defmodule Embervm.WorkloadWatcher do
     banked_ttl_seconds: 604_800,
     wake_timeout_seconds: 60
   }
-  # The minimum idleBankSeconds (decision: a too-eager bank thrashes wake/bank);
-  # the CRD schema also enforces this, re-checked here for the LIST/WATCH path.
-  @stateful_min_idle_bank_seconds 30
+  # The minimum idleBankSeconds; the CRD schema also enforces this, re-checked
+  # here for the LIST/WATCH path. Floor lowered 30 -> 1 for the demo-postgres
+  # exhibit (the demos page deliberately banks ~a tick after each query so the
+  # sleep/wake cycle is watchable). The original 30s guard kept a tenant from
+  # ACCIDENTALLY configuring wake/bank thrash; a sub-30 value is now an informed
+  # opt-in, the default (300s) still protects the unconfigured path, and zero
+  # stays invalid (a 0 window would bank with no idle observation at all).
+  @stateful_min_idle_bank_seconds 1
 
   defp validate_stateful(_state, _name, spec, class)
        when class in ["task", "session", "serving", "composite"] do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.88
+      targetRevision: 0.1.89
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -97,3 +97,21 @@ scratchK8s:
   enabled: true
   onepassword:
     itemPath: "vaults/k8s-homelab/items/scratch-k8s"
+
+# Demo-postgres (private demos page sleep/wake exhibit): a second stateful
+# Postgres on 5401 with a 1s idle window, so the demo can show the VM banking
+# itself moments after a query and relighting on the next connection. Reuses the
+# scratch-postgres guest image pin + Secret; its own volume keeps demo rows out
+# of real tenants' data.
+demoPostgres:
+  enabled: true
+
+# ~1s sweeper tick makes the idle bank visibly prompt (default is 30s, which
+# would leave the demo VM "awake" for up to half a minute after its 1s idle
+# window elapses). Wake cap raised 10 -> 30/min: with a 1s idle bank every demo
+# query is a wake, and the default cap would turn quick successive clicks into
+# refusals. Both are control-plane-wide; scratch-postgres banking is still
+# gated by its own 120s idleBankSeconds.
+statefulSweeper:
+  sweepIntervalMs: "1000"
+  wakeMax: "30"

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.155
+version: 0.89.156
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.155
+      targetRevision: 0.89.156
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.230
+version: 0.285.231
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -146,6 +146,15 @@ spec:
                   key: POSTGRES_PASSWORD
             - name: SCRATCH_POSTGRES_DSN
               value: "postgresql://postgres:$(SCRATCH_PG_PASSWORD)@{{ .Values.scratchPostgres.servingService }}.{{ .Values.scratchPostgres.embervmNamespace }}.svc:{{ .Values.scratchPostgres.listenPort }}/scratch"
+            {{- if .Values.scratchPostgres.demoListenPort }}
+            # Demo-postgres DSN (the demos page's sleep/wake exhibit): the SAME
+            # serving Service and password (the demo workload reuses the scratch-
+            # postgres Secret on the embervm side), a different stateful listen
+            # port. The demos API connects here so a page visit wakes the demo
+            # VM, never the real scratch-postgres tenant.
+            - name: DEMO_POSTGRES_DSN
+              value: "postgresql://postgres:$(SCRATCH_PG_PASSWORD)@{{ .Values.scratchPostgres.servingService }}.{{ .Values.scratchPostgres.embervmNamespace }}.svc:{{ .Values.scratchPostgres.demoListenPort }}/scratch"
+            {{- end }}
             {{- end }}
             {{- if and .Values.scratchK8s.enabled .Values.scratchK8s.onepassword.itemPath }}
             # EmberVM R5 scratch-k8s kubeconfig (plan Task 10). Agent run_python

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -815,6 +815,11 @@ scratchPostgres:
   # The embervm serving Service listenPort the scratch-postgres workload is
   # exposed on (must match the embervm chart's scratchPostgres.listenPort).
   listenPort: 5400
+  # The demo-postgres workload's listenPort (must match the embervm chart's
+  # demoPostgres.listenPort). Non-empty renders DEMO_POSTGRES_DSN for the
+  # firecracker demos page's sleep/wake exhibit; empty leaves it unrendered.
+  # Same serving Service and password as scratch-postgres, different workload.
+  demoListenPort: ""
   # The embervm namespace the serving Service lives in (the DSN host is
   # <servingService>.<embervmNamespace>.svc).
   embervmNamespace: embervm

--- a/projects/monolith/demos/firecracker_api.py
+++ b/projects/monolith/demos/firecracker_api.py
@@ -9,6 +9,9 @@ waterfall:
 - ``POST /goose``   submits a goosecracker agent run (async, returns immediately).
 - ``GET  /goose/{thread_id}`` polls the agent run ledger for that run's state.
 - ``GET  /trace/{trace_id}``  returns the SigNoz spans for a captured trace.
+- ``GET  /postgres/status``  the demo-postgres stateful lifecycle (sleep indicator).
+- ``POST /postgres/query``   timed connect (the wake) + row append against demo-postgres.
+- ``POST /postgres/reset``   destroy the live VM + evict its snapshot (force cold boot).
 
 Each POST wraps its invocation in a fresh ROOT span, detached from any inbound
 trace context, via ``context=Context()``. Browser-initiated requests arrive
@@ -27,9 +30,12 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from time import perf_counter
 from uuid import uuid4
 
+import httpx
+import psycopg
 from fastapi import APIRouter, HTTPException
 from opentelemetry import trace
 from opentelemetry.context import Context
@@ -42,8 +48,9 @@ import goosecracker.api as goosecracker
 from app.db import get_engine
 from demos.loadtest_corpus import load_corpus
 from home.observability.traces import fetch_correlated_spans, fetch_trace_spans
-from sandbox.client import run_python_in_sandbox
+from sandbox.client import EMBERVM_URL, run_python_in_sandbox
 from semgrep_scan.client import scan_files
+from shared.k8s_auth import auth_headers
 
 logger = logging.getLogger(__name__)
 
@@ -541,3 +548,239 @@ async def get_load_test_scan(run_id: str, scan_id: int) -> dict:
     if detail is None:
         raise HTTPException(status_code=404, detail="scan not found")
     return detail
+
+
+# ---------------------------------------------------------------------------
+# Demo-postgres (embervm R4 stateful sleep/wake exhibit).
+#
+# A dedicated stateful Postgres workload (NOT the scratch-postgres real tenants
+# use) tuned to bank ~a sweeper tick after its last connection closes. The
+# demo's three verbs map straight onto the embervm surfaces:
+#   status -> GET  {EMBERVM_URL}/v1/stateful/demo-postgres (management introspection;
+#             an HTTP read of the control plane, so POLLING NEVER WAKES THE VM)
+#   query  -> a short-lived psycopg connect to DEMO_POSTGRES_DSN; the TCP
+#             activator wakes the VM on a miss, so connect wall time IS the wake
+#   reset  -> DELETE {EMBERVM_URL}/v1/stateful/demo-postgres/instance (destroys
+#             the live VM AND evicts the banked bundle; the volume survives, so
+#             the next connect cold-boots against retained data)
+# ---------------------------------------------------------------------------
+
+_DEMO_PG_WORKLOAD = "demo-postgres"
+# The workload's wakeTimeoutSeconds is 60 (cold boots include WAL recovery and,
+# on first boot, mkfs + initdb); the client timeout must outlast it so a cold
+# wake surfaces as a slow-but-successful connect, not a client-side timeout.
+_DEMO_PG_CONNECT_TIMEOUT_S = 75
+_DEMO_PG_HISTORY_ROWS = 15
+
+
+def _demo_pg_dsn() -> str:
+    """Read at call time (not import) so tests can patch the environment."""
+    return os.environ.get("DEMO_POSTGRES_DSN", "")
+
+
+async def _fetch_demo_pg_status() -> dict:
+    """GET the control plane's stateful introspection for the demo workload."""
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(
+            f"{EMBERVM_URL}/v1/stateful/{_DEMO_PG_WORKLOAD}",
+            headers=auth_headers(),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+def _shape_pg_status(status: dict) -> dict:
+    """Reduce the control-plane payload to what the sleep indicator renders."""
+    instance = status.get("instance") or {}
+    return {
+        "state": status.get("state"),
+        "generation": status.get("generation"),
+        "bundle_generation": status.get("bundle_generation"),
+        "pair_valid": status.get("pair_valid"),
+        "volume_bytes": status.get("volume_bytes"),
+        "healthy": instance.get("healthy"),
+        "last_active_at": instance.get("last_active_at"),
+        "created_at": instance.get("created_at"),
+    }
+
+
+def _classify_wake(before: dict | None) -> str:
+    """Predict this query's boot path from the PRE-query lifecycle state.
+
+    The StartStateful response's was_relight never reaches the management API,
+    so the demo classifies from what the workload looked like the instant
+    before the connect: a serving instance answers warm, a banked bundle whose
+    stamped generation still pairs with the volume relights, a broken pair or
+    no instance at all cold-boots. A mid-transition snapshot (banking,
+    relighting, ...) is reported as such rather than guessed at.
+    """
+    if before is None:
+        return "unknown"
+    state = before.get("state")
+    if state == "serving":
+        return "warm"
+    if state == "banked":
+        return "relight" if before.get("pair_valid") else "cold"
+    if not state:
+        return "cold"
+    return "transitional"
+
+
+def _demo_pg_roundtrip(dsn: str, note: str) -> dict:
+    """Connect, append a visit row, and read history. Sync; via to_thread.
+
+    Two separately-bracketed wall times are the whole point:
+      connect_ms - the TCP connect + auth handshake. When the VM is banked the
+                   activator parks this connect while it relights (or cold-
+                   boots) the VM, so this number IS the wake cost.
+      query_ms   - DDL-if-missing + insert + reads on the open connection: the
+                   "Postgres is just Postgres once awake" baseline.
+
+    Each row records pg_postmaster_start_time() as its proof-of-lifecycle: a
+    relight RESUMES the paused postmaster (older start time than the row), a
+    cold boot starts a fresh one, and either way earlier rows surviving shows
+    the volume outliving the VM. The connection is short-lived by design: an
+    open connection pins the VM awake (the sweeper never severs a live
+    connection), which would keep the exhibit from ever falling asleep.
+    """
+    started = perf_counter()
+    conn = psycopg.connect(dsn, connect_timeout=_DEMO_PG_CONNECT_TIMEOUT_S)
+    connect_ms = (perf_counter() - started) * 1000
+
+    query_started = perf_counter()
+    # psycopg3: the connection context commits on clean exit AND closes.
+    with conn, conn.cursor() as cur:
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS demo_visits ("
+            "  id bigserial PRIMARY KEY,"
+            "  note text NOT NULL,"
+            "  written_at timestamptz NOT NULL DEFAULT now(),"
+            "  postmaster_start timestamptz NOT NULL)"
+        )
+        cur.execute(
+            "INSERT INTO demo_visits (note, postmaster_start) "
+            "VALUES (%s, pg_postmaster_start_time()) RETURNING id",
+            (note,),
+        )
+        inserted_id = cur.fetchone()[0]
+        cur.execute(
+            "SELECT id, note, written_at, postmaster_start FROM demo_visits "
+            "ORDER BY id DESC LIMIT %s",
+            (_DEMO_PG_HISTORY_ROWS,),
+        )
+        rows = [
+            {
+                "id": r[0],
+                "note": r[1],
+                "written_at": r[2].isoformat(),
+                "postmaster_start": r[3].isoformat(),
+            }
+            for r in cur.fetchall()
+        ]
+        cur.execute("SELECT pg_postmaster_start_time(), count(*) FROM demo_visits")
+        postmaster_start, total_rows = cur.fetchone()
+    query_ms = (perf_counter() - query_started) * 1000
+
+    return {
+        "connect_ms": connect_ms,
+        "query_ms": query_ms,
+        "inserted_id": inserted_id,
+        "rows": rows,
+        "total_rows": total_rows,
+        "postmaster_start": postmaster_start.isoformat(),
+    }
+
+
+class PostgresQueryRequest(BaseModel):
+    note: str = ""
+
+
+@router.get("/postgres/status")
+async def postgres_status() -> dict:
+    """The demo-postgres lifecycle snapshot driving the sleep indicator.
+
+    A management-API read only: the frontend polls this sub-second while the
+    exhibit is on screen, and because no TCP connection ever reaches the
+    workload's listener the poll cannot keep the VM awake or wake it. Errors
+    come back in-band (not as 5xx) so one flaky poll doesn't redline the UI.
+    """
+    if not EMBERVM_URL or not _demo_pg_dsn():
+        return {"configured": False}
+    try:
+        status = await _fetch_demo_pg_status()
+    except Exception as exc:  # noqa: BLE001 - poll errors are data, not faults
+        logger.warning("demo-postgres status poll failed: %s", exc)
+        return {"configured": True, "error": str(exc)}
+    return {"configured": True, **_shape_pg_status(status)}
+
+
+@router.post("/postgres/query")
+async def postgres_query(body: PostgresQueryRequest) -> dict:
+    """Timed roundtrip against demo-postgres: the wake IS the connect time.
+
+    Captures the lifecycle state just before connecting to classify what this
+    connect is about to pay for (warm / relight / cold), then measures the
+    connect and the SQL work separately. A failed connect is returned in-band
+    (mirroring the python demo's error shape): the likeliest causes are the
+    wake-rate limiter refusing a burst and a wake genuinely failing, both of
+    which the visitor recovers from by waiting a beat and retrying.
+    """
+    dsn = _demo_pg_dsn()
+    if not dsn:
+        raise HTTPException(
+            status_code=503, detail="DEMO_POSTGRES_DSN is not configured"
+        )
+
+    before = None
+    if EMBERVM_URL:
+        try:
+            before = await _fetch_demo_pg_status()
+        except Exception as exc:  # noqa: BLE001 - classification is best-effort
+            logger.warning("demo-postgres pre-query status failed: %s", exc)
+            before = None
+
+    note = (body.note or "").strip()[:200] or "hello from the demos page"
+    started = perf_counter()
+    try:
+        result = await asyncio.to_thread(_demo_pg_roundtrip, dsn, note)
+    except Exception as exc:  # noqa: BLE001 - surface connect/query failures in-band
+        logger.warning("demo-postgres query roundtrip failed: %s", exc)
+        return {
+            "error": str(exc),
+            "classification": _classify_wake(before),
+            "phase_before": (before or {}).get("state"),
+            "total_ms": (perf_counter() - started) * 1000,
+        }
+
+    return {
+        **result,
+        "total_ms": (perf_counter() - started) * 1000,
+        "classification": _classify_wake(before),
+        "phase_before": (before or {}).get("state"),
+        "generation": (before or {}).get("generation"),
+        "error": None,
+    }
+
+
+@router.post("/postgres/reset")
+async def postgres_reset() -> dict:
+    """Force the next wake down the cold-boot path.
+
+    DELETE .../instance destroys the live VM (if any) AND evicts the banked
+    bundle; the volume is untouched. The next connect therefore cold-boots
+    Postgres against the retained data: the demo's way of producing the
+    cold-start number (and proving durability) on demand.
+    """
+    if not EMBERVM_URL:
+        raise HTTPException(status_code=503, detail="EMBERVM_URL is not configured")
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.delete(
+            f"{EMBERVM_URL}/v1/stateful/{_DEMO_PG_WORKLOAD}/instance",
+            headers=auth_headers(),
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    return {
+        "destroyed": data.get("destroyed", 0),
+        "evicted": data.get("evicted", 0),
+    }

--- a/projects/monolith/demos/firecracker_api_test.py
+++ b/projects/monolith/demos/firecracker_api_test.py
@@ -208,3 +208,179 @@ def test_trace_includes_correlated_goose_spans(monkeypatch):
     assert body["complete"] is False
     assert body["spans"] == []
     assert body["correlated"][0]["span_id"] == "g1"
+
+
+# ---------------------------------------------------------------------------
+# Demo-postgres (stateful sleep/wake exhibit)
+# ---------------------------------------------------------------------------
+
+
+def _pg_status_payload(**overrides):
+    base = {
+        "workload": "demo-postgres",
+        "state": "banked",
+        "generation": 7,
+        "bundle_generation": 7,
+        "pair_valid": True,
+        "volume_bytes": 123456,
+        "instance": {
+            "healthy": True,
+            "last_active_at": "2026-07-17T10:00:00Z",
+            "created_at": "2026-07-17T09:00:00Z",
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def test_postgres_status_unconfigured(monkeypatch):
+    monkeypatch.delenv("DEMO_POSTGRES_DSN", raising=False)
+
+    resp = _client().get("/api/demos/firecracker/postgres/status")
+    assert resp.status_code == 200
+    assert resp.json() == {"configured": False}
+
+
+def test_postgres_status_shapes_control_plane_payload(monkeypatch):
+    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
+    monkeypatch.setattr(fc, "EMBERVM_URL", "http://embervm")
+
+    async def fake_status():
+        return _pg_status_payload()
+
+    monkeypatch.setattr(fc, "_fetch_demo_pg_status", fake_status)
+
+    resp = _client().get("/api/demos/firecracker/postgres/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["configured"] is True
+    assert body["state"] == "banked"
+    assert body["generation"] == 7
+    assert body["bundle_generation"] == 7
+    assert body["pair_valid"] is True
+    assert body["healthy"] is True
+    assert body["last_active_at"] == "2026-07-17T10:00:00Z"
+
+
+def test_postgres_status_error_is_in_band(monkeypatch):
+    """A flaky control-plane poll must not 5xx: the frontend polls sub-second."""
+    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
+    monkeypatch.setattr(fc, "EMBERVM_URL", "http://embervm")
+
+    async def fake_status():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(fc, "_fetch_demo_pg_status", fake_status)
+
+    resp = _client().get("/api/demos/firecracker/postgres/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["configured"] is True
+    assert "boom" in body["error"]
+
+
+def test_postgres_query_unconfigured_is_503(monkeypatch):
+    monkeypatch.delenv("DEMO_POSTGRES_DSN", raising=False)
+
+    resp = _client().post("/api/demos/firecracker/postgres/query", json={})
+    assert resp.status_code == 503
+
+
+def test_postgres_query_returns_timings_and_classification(monkeypatch):
+    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
+    monkeypatch.setattr(fc, "EMBERVM_URL", "http://embervm")
+
+    async def fake_status():
+        return _pg_status_payload(state="banked", pair_valid=True)
+
+    def fake_roundtrip(dsn, note):
+        assert dsn == "postgresql://x"
+        assert note == "my note"
+        return {
+            "connect_ms": 850.0,
+            "query_ms": 12.0,
+            "inserted_id": 42,
+            "rows": [{"id": 42, "note": "my note"}],
+            "total_rows": 42,
+            "postmaster_start": "2026-07-17T08:00:00+00:00",
+        }
+
+    monkeypatch.setattr(fc, "_fetch_demo_pg_status", fake_status)
+    monkeypatch.setattr(fc, "_demo_pg_roundtrip", fake_roundtrip)
+
+    resp = _client().post(
+        "/api/demos/firecracker/postgres/query", json={"note": "my note"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["error"] is None
+    assert body["connect_ms"] == 850.0
+    assert body["query_ms"] == 12.0
+    assert body["classification"] == "relight"
+    assert body["phase_before"] == "banked"
+    assert body["generation"] == 7
+    assert body["rows"][0]["id"] == 42
+    assert body["total_ms"] >= 0
+
+
+def test_postgres_query_connect_failure_is_in_band(monkeypatch):
+    """A refused connect (wake-rate limit / failed wake) reports, not 5xxs."""
+    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
+    monkeypatch.setattr(fc, "EMBERVM_URL", "http://embervm")
+
+    async def fake_status():
+        return _pg_status_payload(state="serving")
+
+    def fake_roundtrip(dsn, note):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(fc, "_fetch_demo_pg_status", fake_status)
+    monkeypatch.setattr(fc, "_demo_pg_roundtrip", fake_roundtrip)
+
+    resp = _client().post("/api/demos/firecracker/postgres/query", json={})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "connection refused" in body["error"]
+    assert body["classification"] == "warm"
+
+
+def test_classify_wake_paths():
+    assert fc._classify_wake(None) == "unknown"
+    assert fc._classify_wake({"state": "serving"}) == "warm"
+    assert fc._classify_wake({"state": "banked", "pair_valid": True}) == "relight"
+    assert fc._classify_wake({"state": "banked", "pair_valid": False}) == "cold"
+    assert fc._classify_wake({"state": None}) == "cold"
+    assert fc._classify_wake({"state": "relighting"}) == "transitional"
+
+
+def test_postgres_reset_proxies_destroy(monkeypatch):
+    monkeypatch.setattr(fc, "EMBERVM_URL", "http://embervm")
+    monkeypatch.setattr(fc, "auth_headers", lambda: {"Authorization": "Bearer t"})
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"workload": "demo-postgres", "destroyed": 1, "evicted": 1}
+
+    class FakeAsyncClient:
+        def __init__(self, timeout=None):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def delete(self, url, headers=None):
+            assert url == "http://embervm/v1/stateful/demo-postgres/instance"
+            assert headers == {"Authorization": "Bearer t"}
+            return FakeResponse()
+
+    monkeypatch.setattr(fc.httpx, "AsyncClient", FakeAsyncClient)
+
+    resp = _client().post("/api/demos/firecracker/postgres/reset")
+    assert resp.status_code == 200
+    assert resp.json() == {"destroyed": 1, "evicted": 1}

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.230
+      targetRevision: 0.285.231
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -438,6 +438,9 @@ agent:
 # (monolith) the SCRATCH_POSTGRES_DSN env for run_python sessions.
 scratchPostgres:
   enabled: true
+  # Renders DEMO_POSTGRES_DSN for the firecracker demos page's sleep/wake
+  # exhibit (matches the embervm chart's demoPostgres.listenPort).
+  demoListenPort: 5401
   onepassword:
     itemPath: "vaults/k8s-homelab/items/scratch-postgres"
 

--- a/projects/monolith/frontend/src/lib/private/components/demos/PostgresPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/PostgresPanel.svelte
@@ -1,0 +1,657 @@
+<script>
+  // Demo-postgres: the embervm R4 stateful sleep/wake exhibit. A dedicated
+  // scale-to-zero Postgres microVM tuned to bank (pause-to-disk) ~a second
+  // after its last connection closes, and wake on the next TCP connect.
+  //
+  // Three moving parts, all backend-proxied:
+  //   status poll -> GET  /api/demos/firecracker/postgres/status. A control-
+  //                  plane management read: it never opens a connection to the
+  //                  workload itself, so polling CANNOT keep the VM awake.
+  //                  This is what lets the sleep indicator watch the VM doze
+  //                  off in real time without heisenberging the demo.
+  //   query       -> POST /api/demos/firecracker/postgres/query. The backend
+  //                  psycopg-connects (short-lived by design: an open
+  //                  connection pins the VM awake), appends a visit row, and
+  //                  returns two separately-bracketed wall times: connect
+  //                  (which IS the wake when asleep) and query.
+  //   reset       -> POST /api/demos/firecracker/postgres/reset. Destroys the
+  //                  live VM AND evicts its snapshot; the data volume
+  //                  survives, so the next query pays a full cold boot against
+  //                  retained rows: the durability proof on demand.
+  import { onMount } from "svelte";
+
+  const API = "/api/demos/firecracker/postgres";
+  const POLL_MS = 700;
+  const HISTORY_MAX = 8;
+
+  let status = $state(null);
+  let statusError = $state("");
+  let running = $state(false);
+  let resetting = $state(false);
+  let note = $state("");
+  let lastRun = $state(null);
+  let runs = $state([]);
+  let runError = $state("");
+
+  // Best-seen wall time per boot path: the demo's headline comparison.
+  let tiers = $state({ cold: null, relight: null, warm: null });
+
+  let pollTimer = null;
+
+  async function pollStatus() {
+    try {
+      const resp = await fetch(`${API}/status`);
+      const body = await resp.json();
+      if (body.configured === false) {
+        statusError = "demo-postgres is not configured on this deployment";
+        return;
+      }
+      if (body.error) {
+        // One flaky poll is data, not an outage: keep the last good status.
+        statusError = body.error;
+        return;
+      }
+      statusError = "";
+      status = body;
+    } catch (err) {
+      statusError = String(err);
+    }
+  }
+
+  async function runQuery() {
+    if (running) return;
+    running = true;
+    runError = "";
+    try {
+      const resp = await fetch(`${API}/query`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ note }),
+      });
+      const body = await resp.json();
+      if (!resp.ok) {
+        runError = body?.detail || `query failed (${resp.status})`;
+        return;
+      }
+      if (body.error) {
+        runError = body.error;
+        return;
+      }
+      lastRun = body;
+      runs = [body, ...runs].slice(0, HISTORY_MAX);
+      const tier =
+        body.classification === "relight" || body.classification === "warm"
+          ? body.classification
+          : "cold";
+      if (tiers[tier] == null || body.connect_ms < tiers[tier]) {
+        tiers = { ...tiers, [tier]: body.connect_ms };
+      }
+      note = "";
+    } catch (err) {
+      runError = String(err);
+    } finally {
+      running = false;
+    }
+  }
+
+  async function resetInstance() {
+    if (resetting) return;
+    resetting = true;
+    runError = "";
+    try {
+      const resp = await fetch(`${API}/reset`, { method: "POST" });
+      if (!resp.ok) {
+        const body = await resp.json().catch(() => null);
+        runError = body?.detail || `reset failed (${resp.status})`;
+      }
+    } catch (err) {
+      runError = String(err);
+    } finally {
+      resetting = false;
+    }
+  }
+
+  onMount(() => {
+    // Opening the tab IS the wake-on-connect demo: fire a query unprompted so
+    // the visitor watches the VM wake for them, then start the lifecycle poll.
+    runQuery();
+    pollStatus();
+    pollTimer = setInterval(pollStatus, POLL_MS);
+    return () => clearInterval(pollTimer);
+  });
+
+  const STATE_VIEW = {
+    serving: { label: "Awake", tone: "awake", hint: "VM live, next query is warm" },
+    banking: { label: "Falling asleep", tone: "drowsy", hint: "pausing to a snapshot bundle" },
+    banked: { label: "Asleep", tone: "asleep", hint: "no VM running; a connection wakes it" },
+    relighting: { label: "Waking (relight)", tone: "waking", hint: "resuming the paused snapshot" },
+    cold_booting: { label: "Waking (cold boot)", tone: "waking", hint: "fresh boot against the volume" },
+    starting: { label: "Starting", tone: "waking", hint: "first boot" },
+  };
+
+  let stateView = $derived(
+    STATE_VIEW[status?.state] ?? {
+      label: status?.state || "No instance yet",
+      tone: "asleep",
+      hint: "cold-boots on the first connection",
+    },
+  );
+
+  const CLASS_LABEL = {
+    warm: "warm (VM already awake)",
+    relight: "relight (resumed from snapshot)",
+    cold: "cold boot (fresh VM on the volume)",
+    transitional: "caught mid-transition",
+    unknown: "unclassified",
+  };
+
+  function ms(v) {
+    if (v == null) return "–";
+    return v >= 1000 ? `${(v / 1000).toFixed(2)} s` : `${Math.round(v)} ms`;
+  }
+
+  function clock(iso) {
+    if (!iso) return "–";
+    const d = new Date(iso);
+    return isNaN(d) ? iso : d.toLocaleTimeString();
+  }
+
+  function barPct(run, part) {
+    const total = (run.connect_ms ?? 0) + (run.query_ms ?? 0);
+    if (!total) return 0;
+    return (part / total) * 100;
+  }
+</script>
+
+<section class="pg-panel">
+  <div class="lifecycle-card">
+    <div class="state-chip tone-{stateView.tone}">
+      <span class="state-dot" aria-hidden="true"></span>
+      <span class="state-label">{stateView.label}</span>
+    </div>
+    <p class="state-hint">{stateView.hint}</p>
+    <dl class="state-facts">
+      <div>
+        <dt>generation</dt>
+        <dd>{status?.generation ?? "–"}</dd>
+      </div>
+      <div>
+        <dt>snapshot pairs</dt>
+        <dd>{status?.pair_valid == null ? "–" : status.pair_valid ? "yes" : "no"}</dd>
+      </div>
+      <div>
+        <dt>volume</dt>
+        <dd>
+          {status?.volume_bytes != null
+            ? `${(status.volume_bytes / 1024 / 1024).toFixed(1)} MiB`
+            : "–"}
+        </dd>
+      </div>
+    </dl>
+    {#if statusError}
+      <p class="soft-error">status: {statusError}</p>
+    {/if}
+  </div>
+
+  <div class="controls">
+    <input
+      class="note-input"
+      type="text"
+      maxlength="200"
+      placeholder="leave a note for the next visitor (optional)"
+      bind:value={note}
+      onkeydown={(e) => e.key === "Enter" && runQuery()}
+    />
+    <button class="run-btn" type="button" onclick={runQuery} disabled={running}>
+      {running ? "Connecting…" : "Query (wakes the VM)"}
+    </button>
+    <button
+      class="reset-btn"
+      type="button"
+      onclick={resetInstance}
+      disabled={resetting || running}
+      title="Destroy the VM and evict its snapshot. The data volume survives, so the next query pays a full cold boot against retained rows."
+    >
+      {resetting ? "Resetting…" : "Force cold boot"}
+    </button>
+  </div>
+
+  {#if runError}
+    <p class="run-error">
+      {runError}
+      <span class="run-error-hint">
+        (a refused connect usually means the wake-rate limiter; wait a beat and retry)
+      </span>
+    </p>
+  {/if}
+
+  {#if lastRun}
+    <div class="timing-card">
+      <div class="timing-headline">
+        <div class="timing-big">
+          <span class="timing-value">{ms(lastRun.connect_ms)}</span>
+          <span class="timing-label">connect (the wake)</span>
+        </div>
+        <div class="timing-big">
+          <span class="timing-value">{ms(lastRun.query_ms)}</span>
+          <span class="timing-label">SQL roundtrip</span>
+        </div>
+        <div class="timing-class">{CLASS_LABEL[lastRun.classification] ?? lastRun.classification}</div>
+      </div>
+      <div class="timing-bar" aria-hidden="true">
+        <span class="bar-connect" style:width="{barPct(lastRun, lastRun.connect_ms)}%"></span>
+        <span class="bar-query" style:width="{barPct(lastRun, lastRun.query_ms)}%"></span>
+      </div>
+      <p class="timing-note">
+        The connect bracket includes the whole wake: the activator parks your
+        TCP connection while the microVM {lastRun.classification === "cold"
+          ? "cold-boots"
+          : "relights"}, then splices it through. Once awake, Postgres is just
+        Postgres.
+      </p>
+    </div>
+
+    <div class="tiers">
+      <div class="tier">
+        <span class="tier-value">{ms(tiers.cold)}</span>
+        <span class="tier-label">cold boot</span>
+      </div>
+      <span class="tier-arrow" aria-hidden="true">›</span>
+      <div class="tier">
+        <span class="tier-value">{ms(tiers.relight)}</span>
+        <span class="tier-label">relight</span>
+      </div>
+      <span class="tier-arrow" aria-hidden="true">›</span>
+      <div class="tier">
+        <span class="tier-value">{ms(tiers.warm)}</span>
+        <span class="tier-label">warm</span>
+      </div>
+      <p class="tiers-caption">best connect time seen this session, per boot path</p>
+    </div>
+  {/if}
+
+  {#if lastRun?.rows?.length}
+    <div class="rows-card">
+      <h3 class="rows-title">
+        visit log · {lastRun.total_rows} rows retained across every sleep, wake,
+        and cold boot
+      </h3>
+      <table class="rows-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>note</th>
+            <th>written</th>
+            <th>postgres process born</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each lastRun.rows as row (row.id)}
+            <tr>
+              <td>{row.id}</td>
+              <td class="row-note">{row.note}</td>
+              <td>{clock(row.written_at)}</td>
+              <td>{clock(row.postmaster_start)}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+      <p class="rows-note">
+        "Process born" is pg_postmaster_start_time(): rows sharing it were
+        served by the same resumed process (a relight never restarts Postgres);
+        a new value marks a cold boot, and older rows surviving it is the
+        volume outliving the VM.
+      </p>
+    </div>
+  {/if}
+
+  {#if runs.length > 1}
+    <div class="history">
+      <h3 class="history-title">this session</h3>
+      <ul class="history-list">
+        {#each runs as run, i (runs.length - i)}
+          <li class="history-row">
+            <span class="history-class">{run.classification}</span>
+            <span class="history-connect">{ms(run.connect_ms)} connect</span>
+            <span class="history-query">{ms(run.query_ms)} query</span>
+          </li>
+        {/each}
+      </ul>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .pg-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    max-width: 860px;
+  }
+
+  .lifecycle-card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 18px 20px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 14px 22px;
+  }
+
+  .state-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 16px;
+    border-radius: 999px;
+    border: 1px solid var(--line);
+    font-weight: 700;
+    font-size: 15px;
+  }
+
+  .state-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--text-faint);
+  }
+
+  .tone-awake .state-dot {
+    background: var(--svc-fc);
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--svc-fc) 20%, transparent);
+  }
+
+  .tone-drowsy .state-dot,
+  .tone-waking .state-dot {
+    background: var(--loadtest-highlight);
+    animation: pulse 0.9s ease-in-out infinite;
+  }
+
+  .tone-asleep .state-dot {
+    background: var(--accent);
+    opacity: 0.45;
+  }
+
+  .tone-asleep .state-label {
+    color: var(--text-dim);
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      transform: scale(1);
+      opacity: 1;
+    }
+    50% {
+      transform: scale(1.35);
+      opacity: 0.55;
+    }
+  }
+
+  .state-hint {
+    margin: 0;
+    color: var(--text-dim);
+    font-size: 13px;
+    flex: 1 1 200px;
+  }
+
+  .state-facts {
+    display: flex;
+    gap: 18px;
+    margin: 0;
+  }
+
+  .state-facts dt {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-faint);
+  }
+
+  .state-facts dd {
+    margin: 2px 0 0;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+  }
+
+  .soft-error {
+    flex-basis: 100%;
+    margin: 0;
+    color: var(--danger);
+    font-size: 12px;
+  }
+
+  .controls {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .note-input {
+    flex: 1 1 260px;
+    padding: 10px 14px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--surface);
+    color: var(--ink);
+    font-size: 14px;
+  }
+
+  .run-btn,
+  .reset-btn {
+    padding: 10px 18px;
+    border-radius: 8px;
+    border: 1px solid var(--line);
+    font-weight: 600;
+    font-size: 14px;
+    cursor: pointer;
+  }
+
+  .run-btn {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--surface);
+  }
+
+  .run-btn:disabled,
+  .reset-btn:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+
+  .reset-btn {
+    background: var(--surface);
+    color: var(--danger);
+  }
+
+  .run-error {
+    margin: 0;
+    color: var(--danger);
+    font-size: 13px;
+  }
+
+  .run-error-hint {
+    color: var(--text-dim);
+  }
+
+  .timing-card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 20px;
+  }
+
+  .timing-headline {
+    display: flex;
+    align-items: baseline;
+    gap: 32px;
+    flex-wrap: wrap;
+  }
+
+  .timing-big {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .timing-value {
+    font-size: 34px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.1;
+  }
+
+  .timing-label {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-faint);
+    margin-top: 4px;
+  }
+
+  .timing-class {
+    margin-left: auto;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--accent);
+  }
+
+  .timing-bar {
+    display: flex;
+    height: 10px;
+    border-radius: 5px;
+    overflow: hidden;
+    margin-top: 16px;
+    background: var(--paper);
+  }
+
+  .bar-connect {
+    background: var(--accent);
+  }
+
+  .bar-query {
+    background: var(--svc-fc);
+  }
+
+  .timing-note {
+    margin: 12px 0 0;
+    font-size: 13px;
+    color: var(--text-dim);
+  }
+
+  .tiers {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+    padding: 4px 6px;
+  }
+
+  .tier {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .tier-value {
+    font-size: 22px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .tier-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-faint);
+  }
+
+  .tier-arrow {
+    color: var(--text-faint);
+    font-size: 20px;
+  }
+
+  .tiers-caption {
+    margin: 0 0 0 auto;
+    font-size: 12px;
+    color: var(--text-faint);
+  }
+
+  .rows-card,
+  .history {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 18px 20px;
+  }
+
+  .rows-title,
+  .history-title {
+    margin: 0 0 12px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-dim);
+  }
+
+  .rows-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+  }
+
+  .rows-table th {
+    text-align: left;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-faint);
+    padding: 4px 10px 6px 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .rows-table td {
+    padding: 6px 10px 6px 0;
+    border-bottom: 1px solid var(--line);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .row-note {
+    max-width: 320px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .rows-note {
+    margin: 12px 0 0;
+    font-size: 12px;
+    color: var(--text-dim);
+  }
+
+  .history-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .history-row {
+    display: flex;
+    gap: 18px;
+    font-size: 13px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .history-class {
+    width: 90px;
+    font-weight: 600;
+    color: var(--accent);
+  }
+
+  .history-connect,
+  .history-query {
+    color: var(--text-dim);
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/private/demos/firecracker/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/demos/firecracker/+page.svelte
@@ -1,12 +1,14 @@
 <script>
   // /demos/firecracker (private tier): a full-page, Grimoire-style tabbed
-  // tool for the three firecracker-backed projects (Python sandbox, Semgrep
-  // diff scan, Goose agent). Each tab renders its own RunPanel full-page,
+  // tool for the firecracker-backed projects (Python sandbox, Semgrep diff
+  // scan, Goose agent, and the demo-postgres sleep/wake exhibit, which
+  // renders its own PostgresPanel). Each other tab renders RunPanel full-page,
   // no modal: a modal close used to break mid-run because the dialog kept
   // its own escape/backdrop-click lifecycle independent of an in-flight
   // request, so we dropped the modal entirely in favor of a plain tabbed
   // page (mirrors the Grimoire app topbar in
   // src/routes/public/app/grimoire/+layout.svelte).
+  import PostgresPanel from "$lib/private/components/demos/PostgresPanel.svelte";
   import RunPanel from "$lib/private/components/demos/RunPanel.svelte";
   import "$lib/private/demos/theme.css";
 
@@ -70,6 +72,15 @@ def handle():
       tagline: "Kicks off an async agent task and polls it to completion.",
       sample: { task: GOOSE_TASK_SAMPLE },
     },
+    {
+      key: "postgres",
+      label: "Postgres",
+      tagline:
+        "A scale-to-zero Postgres microVM: it falls asleep about a second after your last query and wakes on the next connection, data intact.",
+      // No sample: this tab renders its own panel (status poll + timed
+      // queries), not the shared RunPanel run/trace flow.
+      sample: null,
+    },
   ];
 
   let activeKey = $state("python");
@@ -104,7 +115,11 @@ def handle():
       <p class="demos-tagline">{activeProject.tagline}</p>
     </div>
     {#key activeProject.key}
-      <RunPanel project={activeProject} />
+      {#if activeProject.key === "postgres"}
+        <PostgresPanel />
+      {:else}
+        <RunPanel project={activeProject} />
+      {/if}
     {/key}
   </main>
 </div>


### PR DESCRIPTION
## What

A new **Postgres** tab on the private firecracker demos page: an interactive exhibit of the embervm R4 stateful lifecycle (cold start -> sleep -> wake-on-connection) with the wall-time measurements front and center.

- **Live sleep indicator**: the panel polls `GET /postgres/status` (a control-plane management read, so polling can never wake or pin the VM) and shows the lifecycle live: awake -> falling asleep -> asleep -> waking (relight/cold boot). With the 1s idle window + 1s sweeper tick the VM visibly dozes off a beat after each query.
- **Timed queries**: `POST /postgres/query` psycopg-connects (short-lived by design), appends a visitor note, and returns two separately bracketed wall times: **connect** (which IS the wake when asleep, since the TCP activator parks the connect while the VM boots) and **SQL roundtrip**. Each run is classified warm / relight / cold from the pre-query state, and a best-of strip accumulates the three tiers side by side.
- **Retention proof**: the visit log survives every sleep, wake, and cold boot; each row is stamped with `pg_postmaster_start_time()`, so relights (same resumed process) and cold boots (new process, old rows intact) are visibly different.
- **Force cold boot**: `POST /postgres/reset` uses the existing destroy+evict management verb so a visitor can produce the cold-start number on demand.
- Opening the tab fires a query automatically: page load IS the wake-on-connect demo.

## How

- **Dedicated `demo-postgres` workload** (port 5401), NOT the shared scratch-postgres: Loom and sandbox sessions are real tenants of scratch-postgres, and its 120s idle window was tuned around their write cadence. The demo workload reuses the same guest image pin and Secret, with its own volume.
- `idleBankSeconds` floor lowered 30 -> 1 (CRD + watcher): sub-30 becomes an informed opt-in for exhibits; the 300 default still protects the unconfigured path, and zero stays invalid. No test pinned the old floor.
- New control-plane env plumbing: `EMBERVM_STATEFUL_SWEEP_INTERVAL_MS` (1s tick in deploy values) and `EMBERVM_STATEFUL_WAKE_MAX` (30/min, since with a 1s idle bank every query is a wake and the default 10/min cap would turn quick clicks into refusals).
- Monolith gets `DEMO_POSTGRES_DSN` (same secret expansion pattern as `SCRATCH_POSTGRES_DSN`, demo listen port).

## Verification

- `helm template` renders verified for both charts (Workload CR, sweeper envs, DSN).
- Backend tests added for all three routes + wake classification (fakes only; no fc-invoke/psycopg reached).
- Chart bumps: embervm 0.1.89, monolith 0.285.230, monolith-public 0.89.155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)