### PR TITLE
fix(embervm): idempotent scratch-postgres pg_hba config (self-heals poisoned volumes)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.89
+version: 0.1.90

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.89
+      targetRevision: 0.1.90
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/postgres/guest-init/cmd/BUILD
+++ b/projects/embervm/runtimes/postgres/guest-init/cmd/BUILD
@@ -45,6 +45,9 @@ go_binary(
 
 go_test(
     name = "cmd_test",
-    srcs = ["main_test.go"],
+    srcs = [
+        "main_test.go",
+        "postgres_linux_test.go",
+    ],
     embed = [":cmd_lib"],
 )

--- a/projects/embervm/runtimes/postgres/guest-init/cmd/postgres_linux.go
+++ b/projects/embervm/runtimes/postgres/guest-init/cmd/postgres_linux.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -69,11 +70,24 @@ func bootstrapAndLaunchPostgres(ctx context.Context, logger *slog.Logger, mountP
 		if err := runInitdb(logger, pgdata, password); err != nil {
 			return fmt.Errorf("initdb: %w", err)
 		}
-		if err := configurePostgres(pgdata); err != nil {
-			return fmt.Errorf("configure postgres: %w", err)
-		}
 	} else {
 		logger.Info("stateful postgres: PGDATA already initialized, skipping initdb (WAL recovery runs on start)", "pgdata", pgdata)
+	}
+
+	// Ensure the cluster-internal pg_hba rule on EVERY boot, not just first boot.
+	// pgDataInitialized keys on PG_VERSION, which initdb writes BEFORE this policy
+	// is appended; a first boot interrupted in that window (an aggressive idle-bank
+	// or a destroy during boot) leaves PG_VERSION present but pg_hba.conf without
+	// the pod-network rule, and a first-boot-only config would then skip it forever,
+	// leaving the volume permanently rejecting every cluster connection ("no
+	// pg_hba.conf entry for host ..."). Running it unconditionally and idempotently
+	// self-heals such a volume on its next cold boot and closes the race for good.
+	// It runs before postgres launches, so the server reads the corrected file at
+	// startup with no reload needed. (Relights resume a snapshot taken from an
+	// already-serving VM, whose pg_hba was necessarily complete, so they are
+	// unaffected; only cold boots re-read the on-disk file.)
+	if err := ensureHostAuth(logger, pgdata); err != nil {
+		return fmt.Errorf("configure pg_hba: %w", err)
 	}
 
 	// Launch the server as a child so PID 1 (this init) keeps the vsock ready
@@ -168,17 +182,33 @@ func runInitdb(logger *slog.Logger, pgdata, password string) error {
 	return nil
 }
 
-// configurePostgres appends the network policy initdb does not set: listen on
-// the tap NIC and require scram auth for TCP connections from the cluster-
-// internal pod network. The CR is cluster-internal, low-stakes scratch tier
-// (D-R4.PR-11.1), so a single scram rule for all sources is the policy.
-func configurePostgres(pgdata string) error {
+// hbaRuleMarker is the comment that heads the cluster-internal pg_hba block.
+// ensureHostAuth uses it as an idempotency key: its presence means the policy is
+// already installed, so the block is not appended twice.
+const hbaRuleMarker = "# EmberVM scratch-postgres (R4): scram for cluster-internal TCP."
+
+// ensureHostAuth appends the network policy initdb does not set: require scram
+// auth for TCP connections from the cluster-internal pod network. The CR is
+// cluster-internal, low-stakes scratch tier (D-R4.PR-11.1), so a single scram
+// rule for all sources is the policy. IDEMPOTENT: it reads pg_hba.conf first and
+// appends the block only when hbaRuleMarker is absent, so it can run on every
+// boot (see the call site's rationale) without duplicating the rule on a volume
+// that already has it.
+func ensureHostAuth(logger *slog.Logger, pgdata string) error {
 	hba := filepath.Join(pgdata, "pg_hba.conf")
+	existing, err := os.ReadFile(hba)
+	if err != nil {
+		return fmt.Errorf("read pg_hba.conf: %w", err)
+	}
+	if strings.Contains(string(existing), hbaRuleMarker) {
+		return nil
+	}
+
 	// Append: scram over TCP from anywhere (the tap NIC is only reachable from
 	// the node Envoy). initdb already wrote a trust local line plus host scram
 	// lines for 127.0.0.1/::1; this widens host to all IPv4/IPv6 so the
 	// Envoy-forwarded connection (from the pod network) authenticates with scram.
-	rule := "\n# EmberVM scratch-postgres (R4): scram for cluster-internal TCP.\nhost all all 0.0.0.0/0 scram-sha-256\nhost all all ::/0 scram-sha-256\n"
+	rule := "\n" + hbaRuleMarker + "\nhost all all 0.0.0.0/0 scram-sha-256\nhost all all ::/0 scram-sha-256\n"
 	f, err := os.OpenFile(hba, os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return fmt.Errorf("open pg_hba.conf: %w", err)
@@ -187,6 +217,7 @@ func configurePostgres(pgdata string) error {
 	if _, err := f.WriteString(rule); err != nil {
 		return fmt.Errorf("append pg_hba.conf: %w", err)
 	}
+	logger.Info("stateful postgres: installed cluster-internal pg_hba rule", "pgdata", pgdata)
 	return nil
 }
 

--- a/projects/embervm/runtimes/postgres/guest-init/cmd/postgres_linux_test.go
+++ b/projects/embervm/runtimes/postgres/guest-init/cmd/postgres_linux_test.go
@@ -1,0 +1,102 @@
+//go:build linux
+
+package main
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writePgHba writes a minimal pg_hba.conf (the lines initdb produces) into a
+// fresh PGDATA dir and returns the file path.
+func writePgHba(t *testing.T, dir string) string {
+	t.Helper()
+	hba := filepath.Join(dir, "pg_hba.conf")
+	initdbDefault := "" +
+		"local   all             all                                     trust\n" +
+		"host    all             all             127.0.0.1/32            scram-sha-256\n" +
+		"host    all             all             ::1/128                 scram-sha-256\n"
+	if err := os.WriteFile(hba, []byte(initdbDefault), 0o600); err != nil {
+		t.Fatalf("seed pg_hba.conf: %v", err)
+	}
+	return hba
+}
+
+// TestEnsureHostAuthAppendsRule: a freshly-initdb'd pg_hba (no cluster rule) gets
+// the cluster-internal scram block appended.
+func TestEnsureHostAuthAppendsRule(t *testing.T) {
+	dir := t.TempDir()
+	hba := writePgHba(t, dir)
+
+	if err := ensureHostAuth(slog.Default(), dir); err != nil {
+		t.Fatalf("ensureHostAuth: %v", err)
+	}
+
+	got, err := os.ReadFile(hba)
+	if err != nil {
+		t.Fatalf("read pg_hba.conf: %v", err)
+	}
+	if !strings.Contains(string(got), hbaRuleMarker) {
+		t.Errorf("marker not appended; pg_hba.conf:\n%s", got)
+	}
+	if !strings.Contains(string(got), "host all all 0.0.0.0/0 scram-sha-256") {
+		t.Errorf("IPv4 rule not appended; pg_hba.conf:\n%s", got)
+	}
+}
+
+// TestEnsureHostAuthIdempotent: running it twice (the every-boot call path) does
+// NOT duplicate the block, so a healthy volume that already has the rule is left
+// with exactly one copy across repeated cold boots.
+func TestEnsureHostAuthIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	hba := writePgHba(t, dir)
+
+	for i := 0; i < 3; i++ {
+		if err := ensureHostAuth(slog.Default(), dir); err != nil {
+			t.Fatalf("ensureHostAuth pass %d: %v", i, err)
+		}
+	}
+
+	got, err := os.ReadFile(hba)
+	if err != nil {
+		t.Fatalf("read pg_hba.conf: %v", err)
+	}
+	if n := strings.Count(string(got), hbaRuleMarker); n != 1 {
+		t.Errorf("marker appears %d times, want exactly 1; pg_hba.conf:\n%s", n, got)
+	}
+}
+
+// TestEnsureHostAuthSelfHealsPoisonedVolume is the regression this fix exists
+// for: a volume whose first boot was interrupted after initdb wrote PG_VERSION
+// but before the cluster rule was appended (so pg_hba has only the initdb
+// defaults and no marker). The next cold boot's unconditional call must add the
+// rule so the cluster can connect again, rather than skipping config forever
+// because PG_VERSION already exists.
+func TestEnsureHostAuthSelfHealsPoisonedVolume(t *testing.T) {
+	dir := t.TempDir()
+	hba := writePgHba(t, dir) // initdb defaults only: the poisoned-volume state
+
+	if strings.Contains(mustRead(t, hba), hbaRuleMarker) {
+		t.Fatalf("precondition failed: seed should not contain the marker")
+	}
+
+	if err := ensureHostAuth(slog.Default(), dir); err != nil {
+		t.Fatalf("ensureHostAuth: %v", err)
+	}
+
+	if !strings.Contains(mustRead(t, hba), "host all all 0.0.0.0/0 scram-sha-256") {
+		t.Errorf("poisoned volume was not healed; pg_hba.conf:\n%s", mustRead(t, hba))
+	}
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
## Root cause

The scratch-postgres / demo-postgres guest-init poisons its own volume under an interrupted first boot.

- `pgDataInitialized()` decides "already initialized" purely by the presence of `PG_VERSION`.
- `initdb` writes `PG_VERSION` **and then** the guest appends the cluster-internal rule `host all all 0.0.0.0/0 scram-sha-256` to `pg_hba.conf`, as a **first-boot-only** step (inside `if !initialized`).
- If a first boot is interrupted between those two (an aggressive idle-bank, a destroy-during-boot, or racing wakes), the volume is left with `PG_VERSION` present but `pg_hba.conf` missing the rule.
- Every subsequent cold boot sees `already initialized`, **skips config**, and serves a Postgres that rejects every pod-network connection: `FATAL: no pg_hba.conf entry for host "10.42.x.x", user "postgres", database "scratch"`. Permanent poison.

The `demo-postgres` exhibit (1s `idleBankSeconds`) makes the window easy to hit, but scratch-postgres could be poisoned by any interrupted first boot.

## Fix

Run the pg_hba network policy on **every** boot, **idempotently**: `ensureHostAuth()` reads `pg_hba.conf` and appends the block only when its marker comment is absent.

- A poisoned volume **self-heals** on its next cold boot (the config no longer hides behind the first-boot check).
- A healthy volume is never double-appended (marker idempotency).
- It runs before `postgres` launches, so the server reads the corrected file at startup, no reload needed.
- Relights are unaffected: they resume a memory snapshot taken from an already-serving VM whose pg_hba was necessarily complete; only cold boots re-read the on-disk file.

## Tests

`postgres_linux_test.go` covers the three properties the fix rests on: appends the rule to a fresh initdb pg_hba, is idempotent across repeated boots, and self-heals a poisoned volume (PG_VERSION-present-but-rule-absent state).

Chart bump: embervm 0.1.90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)