### PR TITLE
feat(embervm): opt-in interruptible bank for scale-to-zero stateful datastores (ADR 008)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.90
+version: 0.1.91

--- a/projects/embervm/chart/crds/workload-crd.yaml
+++ b/projects/embervm/chart/crds/workload-crd.yaml
@@ -477,6 +477,17 @@ spec:
                         connection retries (subject to the wake-rate limit).
                       minimum: 1
                       default: 60
+                    interruptibleBank:
+                      type: boolean
+                      default: false
+                      description: >-
+                        Opt in to the two-phase interruptible bank (ADR embervm/008):
+                        a wake arriving during a bank resumes the paused VM (hot)
+                        instead of cold booting, and a clean bank commits for a warm
+                        relight. Off (the default) is the atomic pause-snapshot-destroy
+                        bank, unchanged. Only honored for class stateful. NOTE: a
+                        boolean for a single alternative behavior; a future third bank
+                        strategy is expected to supersede this with a `bankMode` enum.
                     secretRef:
                       type: string
                       description: >-

--- a/projects/embervm/chart/templates/workload-demo-postgres.yaml
+++ b/projects/embervm/chart/templates/workload-demo-postgres.yaml
@@ -49,6 +49,11 @@ spec:
     # Wake deadline (generous: cold boots include WAL recovery and, on first
     # boot, mkfs + initdb).
     wakeTimeoutSeconds: 60
+    # Opt in to the two-phase interruptible bank (ADR embervm/008): a query that
+    # lands mid-bank resumes the paused VM (hot) instead of cold booting, so the
+    # aggressive idleBankSeconds:1 above is safe. This is exactly the exhibit the
+    # mode exists for (a human clicking at the wrong moment).
+    interruptibleBank: {{ .Values.demoPostgres.interruptibleBank }}
     # Reuse the scratch-postgres Secret: same superuser password on first boot.
     secretRef: {{ include "embervm.fullname" . }}-scratch-postgres
 {{- end }}

--- a/projects/embervm/chart/templates/workload-scratch-postgres.yaml
+++ b/projects/embervm/chart/templates/workload-scratch-postgres.yaml
@@ -64,6 +64,11 @@ spec:
     # Wake deadline (generous: cold boots include WAL recovery and, on first boot,
     # mkfs + initdb).
     wakeTimeoutSeconds: 60
+    # Opt in to the two-phase interruptible bank (ADR embervm/008). Off by default
+    # for scratch-postgres until the mode is vetted under real tenant traffic (the
+    # atomic bank is unchanged when false); plumbed from values so enabling it is
+    # a one-line flip once proven on demo-postgres.
+    interruptibleBank: {{ .Values.scratchPostgres.interruptibleBank }}
     # The K8s Secret in THIS namespace whose keys become the guest's first-boot
     # env (POSTGRES_PASSWORD). Created by the OnePasswordItem alongside this CR.
     # The control plane reads it into StartStateful.mmds_env on a FRESH/COLD wake

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -517,6 +517,10 @@ scratchPostgres:
   # The node Envoy TCP listener port (must fall in the stateful 5400-5409 range;
   # see the CRD's listenPort validation). Shared with the monolith DSN wiring.
   listenPort: 5400
+  # Opt in to the two-phase interruptible bank (ADR embervm/008). Off until the
+  # mode is vetted on demo-postgres under real traffic; the atomic bank is
+  # unchanged while false.
+  interruptibleBank: false
   guestImage:
     repository: ghcr.io/jomcgi/homelab/projects/embervm/runtimes/postgres
     tag: latest
@@ -582,6 +586,11 @@ demoPostgres:
   # Bank almost immediately once idle. The effective floor is the stateful
   # sweeper tick (statefulSweeper.sweepIntervalMs), not this value.
   idleBankSeconds: 1
+  # Opt in to the two-phase interruptible bank (ADR embervm/008): with the
+  # aggressive 1s idle window above, a query landing mid-bank would otherwise
+  # cold-boot; the interruptible bank resumes the paused VM hot instead. demo-
+  # postgres is the named consumer this mode exists for.
+  interruptibleBank: true
   # Toy dataset: a handful of demo rows, not a real datastore.
   volumeSizeGiB: 2
 

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -536,7 +536,13 @@ defmodule Embervm.NodeRegistry do
         port: v.port,
         healthy: v.healthy,
         generation: v.generation,
-        last_probe_unix_ms: v.last_probe_unix_ms
+        last_probe_unix_ms: v.last_probe_unix_ms,
+        # Interruptible-bank checkpoint facts (ADR embervm/008): true + the token
+        # when the VM is PAUSED awaiting a ResolveStateful, so the StatefulManager's
+        # adoption resolves a stranded checkpoint (default abort) after a
+        # control-plane restart.
+        checkpoint_pending: v.checkpoint_pending,
+        checkpoint_token: v.checkpoint_token
       }
     end
   end

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -202,6 +202,19 @@ defmodule Embervm.StatefulManager do
   end
 
   @doc """
+  Whether any connection is currently parked (in-flight wake) for `workload`. The
+  interruptible-bank sweeper (ADR embervm/008) reads this the instant its
+  CHECKPOINT completes to decide COMMIT vs ABORT: a parked connection means a
+  client is waiting for this workload NOW, so aborting (resume hot) serves it
+  faster than committing (bank then relight). A pure ETS-view read of
+  `state.waking`.
+  """
+  @spec parked?(GenServer.server(), String.t()) :: boolean()
+  def parked?(server \\ __MODULE__, workload) do
+    GenServer.call(server, {:parked?, workload})
+  end
+
+  @doc """
   Runs one adoption reconcile synchronously (the boot continue + the periodic
   sweep run the same code) and returns after it completes. Reconciles the
   StatefulStore projection against every node's reported stateful inventory
@@ -307,6 +320,10 @@ defmodule Embervm.StatefulManager do
     handle_wake(state, workload, principal, from)
   end
 
+  def handle_call({:parked?, workload}, _from, state) do
+    {:reply, Map.has_key?(state.waking, workload), state}
+  end
+
   def handle_call(:reconcile, _from, state) do
     {:reply, :ok, do_reconcile(state)}
   end
@@ -334,6 +351,42 @@ defmodule Embervm.StatefulManager do
     {:noreply, state}
   end
 
+  # The sweeper resolved an interruptible-bank checkpoint (ADR embervm/008) and
+  # tells us the outcome so any connection parked during the checkpointed window
+  # (see park_during_checkpoint/4) is served.
+  #
+  #   :abort -> the sweeper resumed the SAME paused VM hot and republished it, so
+  #     the instance is :serving with its endpoint intact. Reply every parked
+  #     caller with that live endpoint directly (no wake needed) and clear the
+  #     waiting list. Reading published_endpoint/2 is the same source a straggler
+  #     resolves from, so the abort path replies exactly as a hot hit would.
+  #   :commit -> the temp snapshot was published as the bundle and the VM
+  #     destroyed, so the instance is :banked. Start a normal wake (start_wake/1),
+  #     which plans a relight off the just-committed bundle and replies to the
+  #     already-parked callers on completion via the existing finish_wake path.
+  @impl true
+  def handle_cast({:checkpoint_resolved, workload, :abort}, state) do
+    case StatefulStore.published_endpoint(state.store, workload) do
+      %{ip: ip, port: port} when is_binary(ip) and ip != "" and is_integer(port) ->
+        {waiters, state} = pop_waiters(state, workload)
+        {_trace, state} = pop_wake_trace(state, workload)
+        reply_all(waiters, {:ok, %{ip: ip, port: port}})
+        {:noreply, state}
+
+      _ ->
+        # The abort left no live endpoint (should not happen: an aborted
+        # checkpoint republishes). Fall back to a fresh wake so the parked
+        # callers are not stranded.
+        {:noreply, resolve_parked_via_wake(state, workload)}
+    end
+  end
+
+  def handle_cast({:checkpoint_resolved, workload, :commit}, state) do
+    {:noreply, resolve_parked_via_wake(state, workload)}
+  end
+
+  def handle_cast(_msg, state), do: {:noreply, state}
+
   def handle_info(_msg, state), do: {:noreply, state}
 
   # -- wake handling -----------------------------------------------------------
@@ -356,6 +409,18 @@ defmodule Embervm.StatefulManager do
       not stateful_workload?(state, workload) ->
         {:reply, {:error, {:unknown_workload}}, state}
 
+      # The workload's live instance is mid interruptible-bank checkpoint (ADR
+      # embervm/008): the VM is PAUSED awaiting the sweeper's resolve, NOT gone.
+      # Never cold-boot behind it (that would race a second live VM against the
+      # singleton gate); PARK the caller and let the sweeper's
+      # {:checkpoint_resolved, workload, outcome} cast serve it (hot on abort, or
+      # a fresh relight wake on commit). Parking here reuses the same waking cap
+      # and reply machinery as a normal wake, so the sweeper's resolve resolves
+      # every parked caller in one shot. The first park also seeds the tracing
+      # bundle so an eventual relight (on commit) still emits its wake spans.
+      checkpointed?(state, workload) ->
+        park_during_checkpoint(state, workload, principal, from)
+
       # Already a wake in flight for this workload: park behind it
       # (single-flight), subject to the parked-connection cap. Does NOT consult
       # the wake-rate limit (the wake was already counted by the first miss).
@@ -372,6 +437,56 @@ defmodule Embervm.StatefulManager do
       true ->
         audit_denial(state, principal, workload, :wake_rate)
         {:reply, {:error, {:wake_rate, "per-workload wake-rate limit exceeded"}}, state}
+    end
+  end
+
+  # Whether the workload's single live instance is currently :checkpointed (a
+  # paused interruptible-bank checkpoint awaiting resolve). A bounded store read;
+  # the singleton invariant means at most one live instance per workload.
+  defp checkpointed?(state, workload) do
+    StatefulStore.list(state.store, workload)
+    |> Enum.any?(&(&1.state == :checkpointed))
+  end
+
+  # Park a caller behind an in-flight checkpoint resolve. Respects park_cap
+  # (audited denial + close on overflow), and seeds the tracing bundle on the
+  # FIRST parker (so a commit -> relight still emits its wake spans) without
+  # re-seeding a later one. Never kicks a wake worker: the sweeper's
+  # {:checkpoint_resolved} cast is what resolves these callers.
+  defp park_during_checkpoint(state, workload, principal, from) do
+    waiters = Map.get(state.waking, workload, [])
+
+    if length(waiters) >= state.park_cap do
+      audit_denial(state, principal, workload, :park_full)
+      {:reply, {:error, {:park_full, "parked-connection cap exceeded for workload"}}, state}
+    else
+      state =
+        if waiters == [] do
+          # First parker: seed both the waiting list and a fresh tracing bundle
+          # (park_start), exactly like park_new_wake but WITHOUT kicking a wake.
+          %{
+            state
+            | waking: Map.put(state.waking, workload, [{from, principal}]),
+              wake_traces: Map.put(state.wake_traces, workload, %{park_start: :opentelemetry.timestamp()})
+          }
+        else
+          %{state | waking: Map.put(state.waking, workload, waiters ++ [{from, principal}])}
+        end
+
+      {:noreply, state}
+    end
+  end
+
+  # Serve parked callers by kicking a normal wake (the commit path, and the
+  # abort fallback when no live endpoint was found): only if callers are actually
+  # parked, so a resolve with nothing waiting never boots spuriously. start_wake
+  # plans the relight/cold off the resolved instance and finish_wake replies to
+  # the parked callers already sitting in state.waking.
+  defp resolve_parked_via_wake(state, workload) do
+    if Map.has_key?(state.waking, workload) and Map.get(state.waking, workload) != [] do
+      start_wake(state, workload)
+    else
+      state
     end
   end
 
@@ -1227,6 +1342,21 @@ defmodule Embervm.StatefulManager do
       Map.has_key?(state.waking, instance.workload) ->
         state
 
+      # A stranded interruptible-bank checkpoint (ADR embervm/008): the store
+      # shows the instance :checkpointed (or a :banking it never finished
+      # resolving) and the node still reports its VM as checkpoint_pending. A
+      # control-plane restart can strand this across the sweeper's resolve. The
+      # SAFE DEFAULT is ABORT: mark the paused VM back to :serving and republish
+      # (the caller wanted it hot, not banked; a commit needs a parked
+      # connection this reconcile cannot observe, and noded auto-aborts on its
+      # own timeout anyway, so this is belt-and-suspenders). If the node no
+      # longer reports the VM at all the checkpoint vanished with a noded
+      # restart, so we fall through to the live-VM / bundle / vanished logic
+      # below rather than resurrecting a gone VM.
+      instance.state in [:checkpointed, :banking] and
+          is_binary(instance.vm_id) and checkpoint_pending?(live_vms, instance.vm_id) ->
+        adopt_abort_stranded_checkpoint(state, instance, live_vms)
+
       is_binary(instance.vm_id) and Map.has_key?(live_vms, instance.vm_id) ->
         {node_id, vm} = Map.fetch!(live_vms, instance.vm_id)
         adopt_live(state, instance, node_id, vm)
@@ -1241,6 +1371,41 @@ defmodule Embervm.StatefulManager do
       true ->
         state
     end
+  end
+
+  # Whether the node reports the instance's VM as an interruptible-bank
+  # checkpoint awaiting resolve (checkpoint_pending, ADR embervm/008). False when
+  # the VM is not reported at all or the field is absent/false.
+  defp checkpoint_pending?(live_vms, vm_id) do
+    case Map.get(live_vms, vm_id) do
+      {_node_id, vm} -> Map.get(vm, :checkpoint_pending, false) == true
+      _ -> false
+    end
+  end
+
+  # Resolve a stranded checkpoint the SAFE way (ABORT): return the paused VM to
+  # :serving and rebind its endpoint from node truth, then let the caller's
+  # publish re-derive the fan-out. Uses the FSM-legal event for the instance's
+  # current state (:checkpointed -> :abort, :banking -> :bank_abort; both land on
+  # :serving). ETS-only (no durable op): the projection was already at/before
+  # serving, so no new op is owed, mirroring the sweeper's abort path.
+  defp adopt_abort_stranded_checkpoint(state, instance, live_vms) do
+    {node_id, vm} = Map.fetch!(live_vms, instance.vm_id)
+    event = if instance.state == :checkpointed, do: :abort, else: :bank_abort
+    _ = StatefulStore.mark(state.store, instance.instance_id, event)
+
+    StatefulStore.adopt_endpoint(state.store, instance.instance_id, node_id, instance.vm_id, %{
+      ip: Map.get(vm, :ip),
+      port: Map.get(vm, :port),
+      healthy: Map.get(vm, :healthy, true)
+    })
+
+    Logger.info("embervm stateful: aborted stranded checkpoint on adoption",
+      instance_id: instance.instance_id,
+      workload: instance.workload
+    )
+
+    state
   end
 
   defp adopt_live(state, instance, node_id, vm) do

--- a/projects/embervm/control/lib/embervm/stateful_state.ex
+++ b/projects/embervm/control/lib/embervm/stateful_state.ex
@@ -39,14 +39,15 @@ defmodule Embervm.StatefulState do
 
   `state_from_string/1` in `StatefulStore` must be total over precisely that set
   for a projection-rebuild-then-publish to be byte-identical to the pre-restart
-  snapshot (the property the EndpointPublisher's correctness rests on). The three
-  states NOT in the projection are `banking`, `relighting`, and `cold_booting`:
-  all three are transient, ETS-only markers never persisted (see below).
+  snapshot (the property the EndpointPublisher's correctness rests on). The states
+  NOT in the projection are `banking`, `checkpointed`, `relighting`, and
+  `cold_booting`: all are transient, ETS-only markers never persisted (see below).
 
   ## transient (ETS-only) states
 
-  `banking`, `relighting`, and `cold_booting` are the stateful counterparts of
-  the serving FSM's `banking`/`relighting`: entered by `StatefulStore.mark/2`
+  `banking`, `checkpointed`, `relighting`, and `cold_booting` are the stateful
+  counterparts of the serving FSM's `banking`/`relighting`: entered by
+  `StatefulStore.mark/2`
   with NO op-log append (the durable log records only COMPLETED lifecycle
   transitions, standing decision), and healed from node inventory by adoption if
   a crash strands them. The paired durable completion op (`stateful_banked`,
@@ -94,6 +95,7 @@ defmodule Embervm.StatefulState do
     :starting,
     :serving,
     :banking,
+    :checkpointed,
     :banked,
     :relighting,
     :cold_booting,
@@ -107,7 +109,10 @@ defmodule Embervm.StatefulState do
   # The states that hold a LIVE stateful VM (not a banked snapshot, not a terminal
   # row). A live instance is the singleton the class allows exactly one of.
   # `banked` is deliberately NOT live: it holds a snapshot + volume, no VM.
-  @live_states [:starting, :serving, :banking, :relighting, :cold_booting]
+  # `checkpointed` (ADR embervm/008) IS live: the interruptible-bank checkpoint
+  # leaves the VM PAUSED (not destroyed), still holding the volume attach, awaiting
+  # a resolve, so the singleton guard must count it.
+  @live_states [:starting, :serving, :banking, :checkpointed, :relighting, :cold_booting]
 
   @events [
     :publish,
@@ -115,6 +120,9 @@ defmodule Embervm.StatefulState do
     :bank,
     :bank_ready,
     :bank_abort,
+    :checkpoint_ready,
+    :commit,
+    :abort,
     :relight,
     :relight_ready,
     :relight_abort,
@@ -146,6 +154,18 @@ defmodule Embervm.StatefulState do
     # healed-from-node.
     {:banking, :bank_ready} => :banked,
     {:banking, :bank_abort} => :serving,
+    # Interruptible bank (ADR embervm/008, opt-in): the CHECKPOINT completes
+    # (banking -> checkpointed), leaving the VM PAUSED awaiting a control-plane
+    # resolve. checkpointed is transient/ETS-only (like banking), healed from node
+    # inventory by adoption (noded reports checkpoint_pending). The resolve forks:
+    # `commit` publishes the temp as the bundle and destroys (checkpointed ->
+    # banked), `abort` bumps the generation, resumes the SAME paused VM, and
+    # republishes (checkpointed -> serving, hot, no relight). A CHECKPOINT *RPC*
+    # failure reuses the existing bank_abort edge (banking -> serving): noded left
+    # the VM live, so nothing entered checkpointed.
+    {:banking, :checkpoint_ready} => :checkpointed,
+    {:checkpointed, :commit} => :banked,
+    {:checkpointed, :abort} => :serving,
     # WARM wake: banked -> relighting (StartStateful relight in flight) -> starting
     # (then a paired publish moves it to serving). The relight_abort edge
     # (relighting -> banked) is the ETS-only recovery when a transient (non-
@@ -171,6 +191,7 @@ defmodule Embervm.StatefulState do
     {:starting, :destroy} => :destroyed,
     {:serving, :destroy} => :destroyed,
     {:banking, :destroy} => :destroyed,
+    {:checkpointed, :destroy} => :destroyed,
     {:banked, :destroy} => :destroyed,
     {:relighting, :destroy} => :destroyed,
     {:cold_booting, :destroy} => :destroyed,
@@ -181,6 +202,10 @@ defmodule Embervm.StatefulState do
     {:starting, :fail} => :failed,
     {:serving, :fail} => :failed,
     {:banking, :fail} => :failed,
+    # A checkpointed instance fails when its resolve RPC errors irrecoverably (a
+    # commit whose publish failed, or an abort whose resume failed so noded tore
+    # the paused VM down): the VM is gone, so the instance fails from checkpointed.
+    {:checkpointed, :fail} => :failed,
     {:relighting, :fail} => :failed,
     {:cold_booting, :fail} => :failed
   }
@@ -189,6 +214,7 @@ defmodule Embervm.StatefulState do
           :starting
           | :serving
           | :banking
+          | :checkpointed
           | :banked
           | :relighting
           | :cold_booting
@@ -202,6 +228,9 @@ defmodule Embervm.StatefulState do
           | :bank
           | :bank_ready
           | :bank_abort
+          | :checkpoint_ready
+          | :commit
+          | :abort
           | :relight
           | :relight_ready
           | :relight_abort

--- a/projects/embervm/control/lib/embervm/stateful_store.ex
+++ b/projects/embervm/control/lib/embervm/stateful_store.ex
@@ -195,6 +195,19 @@ defmodule Embervm.StatefulStore do
   end
 
   @doc """
+  Like `mark/2` (a TRANSIENT ETS-only FSM edge, no op-log append) but also merges
+  `updates` into the ETS row after the state move, exactly as `unpublish/3` does.
+  The interruptible-bank checkpoint uses this to stamp the `checkpoint_token` and
+  `vm_id` onto the row when marking `banking -> checkpointed`, so adoption and the
+  resolve step can read them from ETS without a durable op (the checkpoint outcome
+  is persisted only later by the `:commit` transition or an `:abort` republish).
+  """
+  @spec mark_with(GenServer.server(), String.t(), atom(), map()) :: {:ok, map()} | {:error, term()}
+  def mark_with(store \\ __MODULE__, instance_id, event, updates) do
+    GenServer.call(store, {:mark_with, instance_id, event, updates})
+  end
+
+  @doc """
   Flips an instance's `healthy` flag from the node's probe fact (health ejection),
   WITHOUT an FSM transition or an op-log append: health is a lossy node fact, not
   durable lifecycle state. A no-op for an unknown instance. Returns the updated
@@ -514,6 +527,10 @@ defmodule Embervm.StatefulStore do
 
   def handle_call({:mark, instance_id, event}, _from, state) do
     do_mark_with_updates(state, instance_id, event, %{})
+  end
+
+  def handle_call({:mark_with, instance_id, event, updates}, _from, state) do
+    do_mark_with_updates(state, instance_id, event, updates)
   end
 
   def handle_call({:set_health, instance_id, healthy?}, _from, state) do
@@ -1000,7 +1017,7 @@ defmodule Embervm.StatefulStore do
 
   defp bucket_of(nil), do: nil
   defp bucket_of(:banked), do: :banked
-  defp bucket_of(state) when state in [:starting, :serving, :banking, :relighting, :cold_booting], do: :live
+  defp bucket_of(state) when state in [:starting, :serving, :banking, :checkpointed, :relighting, :cold_booting], do: :live
   defp bucket_of(_terminal), do: nil
 
   defp inc_bucket(counts, nil), do: counts

--- a/projects/embervm/control/lib/embervm/stateful_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/stateful_sweeper.ex
@@ -1201,10 +1201,32 @@ defmodule Embervm.StatefulSweeper do
     state
   end
 
-  # Resolve RPC ERROR (either mode): noded tore the paused VM down on a resolve
-  # failure, so the instance FAILS (checkpointed -> failed, durable
-  # stateful_failed). The workload returns to no-live-instance; the next
-  # connection cold-boots. Reset the abort counter (this lifecycle is over).
+  # Resolve rejected FAILED_PRECONDITION (gRPC status 9): noded already resolved
+  # this checkpoint ITSELF. Its resolve-timeout auto-abort fired first (we were
+  # slow, not dead) and lost us the single-resolve race. A noded auto-abort always
+  # RESUMES the VM hot (it never tears it down on the timeout path), so the VM is
+  # LIVE and serving on the node, NOT gone. Reconcile the instance to :serving
+  # exactly as a successful ABORT would (mark serving, republish, serve parked
+  # callers) rather than marking it :failed and orphaning a healthy live VM that
+  # adoption could never heal (adoption skips terminal instances). If noded had in
+  # fact torn the VM down (a resume failure, which noded reports as a DIFFERENT
+  # error, not FAILED_PRECONDITION), we would not land here.
+  defp apply_resolve(state, instance_id, node_id, vm_id, ip, port, workload, _mode, {:error, %GRPC.RPCError{status: 9}}) do
+    Logger.info(
+      "embervm stateful: resolve lost the single-resolve race (noded auto-aborted, VM resumed); reconciling to serving",
+      instance_id: instance_id,
+      workload: workload
+    )
+
+    apply_resolve(state, instance_id, node_id, vm_id, ip, port, workload, :abort, {:ok, %ResolveStatefulResponse{}})
+  end
+
+  # Resolve RPC ERROR (transport/timeout/raised, NOT the FAILED_PRECONDITION
+  # single-resolve race above): noded tore the paused VM down on a resolve failure
+  # (a commit whose publish failed, or an abort whose resume failed), so the
+  # instance FAILS (checkpointed -> failed, durable stateful_failed). The workload
+  # returns to no-live-instance; the next connection cold-boots. Reset the abort
+  # counter (this lifecycle is over).
   defp apply_resolve(state, instance_id, _node_id, _vm_id, _ip, _port, workload, mode, {:error, reason}) do
     Logger.warning("embervm stateful: checkpoint resolve failed, failing instance",
       instance_id: instance_id,

--- a/projects/embervm/control/lib/embervm/stateful_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/stateful_sweeper.ex
@@ -648,12 +648,23 @@ defmodule Embervm.StatefulSweeper do
   # current_stats so the max-lifetime pass later in this same tick sees it
   # too. Otherwise admit the bank (per-node cap) and spawn the worker.
   defp recheck_and_bank(state, instance) do
-    state = refresh_current_stats(state, instance.node_id)
+    {state, fresh?} = refresh_current_stats(state, instance.node_id)
 
-    if connection_raced_in?(state, instance) do
-      abort_bank(state, instance, recheck_abort_reason(state, instance))
-    else
-      if bank_at_cap?(state, instance.node_id) do
+    cond do
+      # A FRESH reading shows a connection raced in: abort for everyone.
+      connection_raced_in?(state, instance) ->
+        abort_bank(state, instance, :recheck_active)
+
+      # Fail CLOSED for an interruptible workload whose re-scrape did NOT produce a
+      # fresh reading (ADR embervm/008): a checkpoint PAUSES a live VM, so it must
+      # not proceed on an unconfirmed scrape. Crucially this is gated on `fresh?`,
+      # NOT on whether a (possibly STALE) reading is present in current_stats: a
+      # failed re-scrape leaves the last-known reading behind, and pausing on stale
+      # evidence is exactly the risk the two-phase design refuses.
+      interruptible?(state, instance.workload) and not fresh? ->
+        abort_bank(state, instance, :recheck_scrape_failed)
+
+      bank_at_cap?(state, instance.node_id) ->
         # Deferred: abort back to serving and let the next tick's idle
         # confirmation re-drive the bank once a slot is free. This costs one
         # extra idle-confirmation cycle under sustained cap pressure, the same
@@ -661,65 +672,42 @@ defmodule Embervm.StatefulSweeper do
         # stateful's synchronous-within-a-tick shape (there is no drain timer
         # to re-arm here).
         abort_bank(state, instance, :bank_at_cap)
-      else
+
+      true ->
         admit_bank(state, instance)
-      end
     end
   end
 
-  # Re-scrape the instance's node RIGHT NOW (not the tick-start reading) and
-  # fold it into current_stats, so the recheck consults the freshest possible
-  # signal. A scrape failure leaves current_stats for the node UNCHANGED
-  # (keeps whatever the tick-start scrape produced, or absent if that also
-  # failed): connection_raced_in?/2 then fails open via Map.fetch missing.
+  # Re-scrape the instance's node RIGHT NOW (not the tick-start reading) and fold
+  # it into current_stats, so the recheck consults the freshest possible signal.
+  # Returns {state, fresh?}: fresh? is true only when THIS re-scrape succeeded. On
+  # a scrape failure current_stats is left UNCHANGED (keeps whatever the tick-start
+  # scrape produced, or absent if that also failed) and fresh? is false, so an
+  # interruptible workload can fail closed on a stale reading rather than pausing
+  # a live VM on unconfirmed evidence (see recheck_and_bank).
   defp refresh_current_stats(state, node_id) do
     case scrape_node(state, %{configured_id: node_id}) do
       {:ok, reading} ->
-        %{state | current_stats: Map.put(state.current_stats, node_id, reading)}
+        {%{state | current_stats: Map.put(state.current_stats, node_id, reading)}, true}
 
       {:error, _reason} ->
-        state
+        {state, false}
     end
   end
 
-  # True when the instance's node's FRESHEST reading (post-recheck-rescrape)
-  # reports cx_active > 0 for its listener, i.e. a connection raced in and the
-  # bank must abort. When there is NO fresh reading for the node (never scraped,
-  # or every scrape this tick failed) the direction depends on the workload:
-  #
-  #   * a DEFAULT (atomic-bank) workload FAILS OPEN toward proceeding (returns
-  #     false): the atomic BANK destroys the VM, and the idle confirmation that
-  #     got us here already required cx_active == 0 on the last successful scrape,
-  #     so the narrow undetected race is accepted for warmth (unchanged behavior).
-  #   * an INTERRUPTIBLE workload (ADR embervm/008) FAILS CLOSED (returns true, so
-  #     the bank aborts this cycle with reason :recheck_scrape_failed): a
-  #     checkpoint PAUSES a live VM, and pausing under an unobserved connection is
-  #     exactly the risk the two-phase design refuses to take on missing evidence.
+  # True when the instance's node's reading reports cx_active > 0 for its listener,
+  # i.e. a connection raced in and the bank must abort. When there is NO reading
+  # for the node it FAILS OPEN (returns false): the interruptible fail-closed case
+  # is handled separately in recheck_and_bank via the re-scrape freshness flag, so
+  # this predicate is purely "does a present reading show an active connection".
   defp connection_raced_in?(state, instance) do
     with {:ok, entry} <- Map.fetch(state.current_stats, instance.node_id),
          {:ok, cfg} <- stateful_cfg(state, instance.workload),
          {:ok, %{active: active}} <- Map.fetch(entry, stat_prefix(cfg.listen_port)) do
       active > 0
     else
-      _ -> interruptible?(state, instance.workload)
+      _ -> false
     end
-  end
-
-  # The abort reason for a recheck that decided to abort: an actual fresh reading
-  # of cx_active > 0 is a genuine race (:recheck_active); a missing reading that
-  # aborted only because the workload is interruptible (fail-closed) is
-  # :recheck_scrape_failed, the distinct observable the ADR names.
-  defp recheck_abort_reason(state, instance) do
-    has_fresh_reading? =
-      with {:ok, entry} <- Map.fetch(state.current_stats, instance.node_id),
-           {:ok, cfg} <- stateful_cfg(state, instance.workload),
-           {:ok, _} <- Map.fetch(entry, stat_prefix(cfg.listen_port)) do
-        true
-      else
-        _ -> false
-      end
-
-    if has_fresh_reading?, do: :recheck_active, else: :recheck_scrape_failed
   end
 
   # Whether the workload is opted in to the two-phase interruptible bank. A

--- a/projects/embervm/control/lib/embervm/stateful_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/stateful_sweeper.ex
@@ -1211,42 +1211,54 @@ defmodule Embervm.StatefulSweeper do
   # adoption could never heal (adoption skips terminal instances). If noded had in
   # fact torn the VM down (a resume failure, which noded reports as a DIFFERENT
   # error, not FAILED_PRECONDITION), we would not land here.
-  defp apply_resolve(state, instance_id, node_id, vm_id, ip, port, workload, _mode, {:error, %GRPC.RPCError{status: 9}}) do
-    Logger.info(
-      "embervm stateful: resolve lost the single-resolve race (noded auto-aborted, VM resumed); reconciling to serving",
-      instance_id: instance_id,
-      workload: workload
-    )
-
-    apply_resolve(state, instance_id, node_id, vm_id, ip, port, workload, :abort, {:ok, %ResolveStatefulResponse{}})
-  end
-
-  # Resolve RPC ERROR (transport/timeout/raised, NOT the FAILED_PRECONDITION
-  # single-resolve race above): noded tore the paused VM down on a resolve failure
-  # (a commit whose publish failed, or an abort whose resume failed), so the
-  # instance FAILS (checkpointed -> failed, durable stateful_failed). The workload
-  # returns to no-live-instance; the next connection cold-boots. Reset the abort
-  # counter (this lifecycle is over).
-  defp apply_resolve(state, instance_id, _node_id, _vm_id, _ip, _port, workload, mode, {:error, reason}) do
-    Logger.warning("embervm stateful: checkpoint resolve failed, failing instance",
-      instance_id: instance_id,
-      workload: workload,
-      mode: mode,
-      reason: inspect(reason)
-    )
-
-    _ =
-      StatefulStore.transition(
-        state.store,
-        instance_id,
-        :fail,
-        :stateful_failed,
-        %{reason: "resolve_failed"},
-        %{}
+  defp apply_resolve(state, instance_id, node_id, vm_id, ip, port, workload, mode, {:error, reason}) do
+    if failed_precondition?(reason) do
+      # noded already resolved this checkpoint ITSELF: its resolve-timeout
+      # auto-abort fired first (we were slow, not dead) and lost us the
+      # single-resolve race. A noded auto-abort always RESUMES the VM hot (it never
+      # tears it down on the timeout path), so the VM is LIVE and serving on the
+      # node, NOT gone. Reconcile to :serving exactly as a successful ABORT would
+      # (mark serving, republish, serve parked callers) rather than marking it
+      # :failed and orphaning a healthy live VM adoption could never heal.
+      Logger.info(
+        "embervm stateful: resolve lost the single-resolve race (noded auto-aborted, VM resumed); reconciling to serving",
+        instance_id: instance_id,
+        workload: workload
       )
 
-    reset_checkpoint_aborts(state, workload)
+      apply_resolve(state, instance_id, node_id, vm_id, ip, port, workload, :abort, {:ok, %ResolveStatefulResponse{}})
+    else
+      # Any OTHER resolve error (transport/timeout/raised, or a noded resume
+      # failure that tore the VM down): the paused VM is gone, so the instance
+      # FAILS (checkpointed -> failed, durable stateful_failed). The next
+      # connection cold-boots. Reset the abort counter (this lifecycle is over).
+      Logger.warning("embervm stateful: checkpoint resolve failed, failing instance",
+        instance_id: instance_id,
+        workload: workload,
+        mode: mode,
+        reason: inspect(reason)
+      )
+
+      _ =
+        StatefulStore.transition(
+          state.store,
+          instance_id,
+          :fail,
+          :stateful_failed,
+          %{reason: "resolve_failed"},
+          %{}
+        )
+
+      reset_checkpoint_aborts(state, workload)
+    end
   end
+
+  # Whether a resolve error is a gRPC FAILED_PRECONDITION (status 9), tolerating
+  # the resolve worker's `with/else -> {:error, other}` re-wrapping (the raw error
+  # arrives nested one or more `{:error, ...}` deep).
+  defp failed_precondition?(%GRPC.RPCError{status: 9}), do: true
+  defp failed_precondition?({:error, inner}), do: failed_precondition?(inner)
+  defp failed_precondition?(_), do: false
 
   defp release_bank_slot(state, node_id, instance_id) do
     state

--- a/projects/embervm/control/lib/embervm/stateful_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/stateful_sweeper.ex
@@ -140,15 +140,32 @@ defmodule Embervm.StatefulSweeper do
 
   require OpenTelemetry.Tracer, as: Tracer
 
-  alias Embervm.{NodeCapacity, StatefulState, StatefulStore, WorkloadCatalog}
+  alias Embervm.{NodeCapacity, StatefulManager, StatefulState, StatefulStore, WorkloadCatalog}
   alias Embervm.OpLog.Op
 
   alias Embervm.Node.V1.{
     EvictSnapshotRequest,
+    ResolveStatefulRequest,
+    ResolveStatefulResponse,
     StopStatefulRequest,
     StopStatefulResponse,
     Trace
   }
+
+  # Interruptible bank (ADR embervm/008): after this many CONSECUTIVE aborts of a
+  # workload's checkpoint (a client keeps racing back in the moment we pause), the
+  # next cycle FORCES a commit regardless of a parked connection, so a hot-looping
+  # client cannot pin the VM live forever and defeat the economics. Reset to 0 the
+  # moment the workload settles to banked.
+  @default_flap_abort_threshold 20
+
+  # The unpublish -> node-Envoy propagation settle bound (ms) an interruptible
+  # bank waits after dropping the endpoint before it pauses the VM with a
+  # CHECKPOINT, so a connection the fan-out was still routing at unpublish time
+  # has drained to the activator rather than being severed mid-pause. Waited
+  # inside the spawned bank worker (never blocking the GenServer); 0-able so tests
+  # run instantly.
+  @default_propagation_settle_ms 200
 
   # Per-node concurrent-bank cap (banking writes GiBs; serialize per node), the
   # exact ServingSweeper default and rationale.
@@ -211,6 +228,10 @@ defmodule Embervm.StatefulSweeper do
       # the real NodeService stub over the shared NodeChannel).
       channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
       stop_stateful_fun: Keyword.get(opts, :stop_stateful_fun, &default_stop_stateful/2),
+      # ResolveStateful seam (ADR embervm/008): (channel, %ResolveStatefulRequest{})
+      # -> {:ok, %ResolveStatefulResponse{}} | {:error, _}. Injected for tests;
+      # production dials the real NodeService stub.
+      resolve_stateful_fun: Keyword.get(opts, :resolve_stateful_fun, &default_resolve_stateful/2),
       evict_snapshot_fun: Keyword.get(opts, :evict_snapshot_fun, &default_evict_snapshot/2),
       # status.stateful {state,generation,bundleGeneration,volumeBytes} writer
       # (Task 10). Defaults to the K8s merge-patch on the workload status
@@ -226,6 +247,22 @@ defmodule Embervm.StatefulSweeper do
       stateful_status_written: %{},
       bank_concurrency: Keyword.get(opts, :bank_concurrency, @default_bank_concurrency),
       bank_inflight: %{},
+      # -- interruptible bank (ADR embervm/008) ------------------------------
+      # The StatefulManager ref, so the sweeper can ask parked?/2 (commit-vs-abort
+      # input) and cast {:checkpoint_resolved, ...} to it on resolve.
+      manager: Keyword.get(opts, :manager, Embervm.StatefulManager),
+      # workload -> boolean: whether a connection is parked for it RIGHT NOW.
+      # Defaults to StatefulManager.parked?/2 against the manager ref; tests inject
+      # a fun (or a fake) to drive the commit/abort fork deterministically.
+      parked_fun:
+        Keyword.get(opts, :parked_fun, fn wl ->
+          StatefulManager.parked?(Keyword.get(opts, :manager, Embervm.StatefulManager), wl)
+        end),
+      # workload -> consecutive-abort count, for the flap guard (force-commit after
+      # the threshold so a hot-looping client cannot pin the VM live forever).
+      checkpoint_aborts: %{},
+      flap_abort_threshold: Keyword.get(opts, :flap_abort_threshold, @default_flap_abort_threshold),
+      propagation_settle_ms: Keyword.get(opts, :propagation_settle_ms, @default_propagation_settle_ms),
       lifetime_drain_max_ms: Keyword.get(opts, :lifetime_drain_max_ms, @default_lifetime_drain_max_ms),
       # workload -> the wall-clock ms the workload was first observed idle
       # (cx_active == 0 AND cx_total delta == 0) this run, so idleBankSeconds is
@@ -282,6 +319,18 @@ defmodule Embervm.StatefulSweeper do
   # spawn_bank_worker/2's comment); needed to restore it on a failed bank.
   def handle_info({:bank_done, instance_id, node_id, vm_id, ip, port, workload, outcome}, state) do
     {:noreply, finish_bank(state, instance_id, node_id, vm_id, ip, port, workload, outcome)}
+  end
+
+  # The CHECKPOINT phase finished (ADR embervm/008): mark :checkpoint_ready and
+  # fork commit-vs-abort (all serialized here), then spawn the resolve worker.
+  def handle_info({:checkpoint_done, instance_id, node_id, vm_id, ip, port, workload, outcome}, state) do
+    {:noreply, finish_checkpoint(state, instance_id, node_id, vm_id, ip, port, workload, outcome)}
+  end
+
+  # The ResolveStateful RPC finished: complete the durable transition, notify the
+  # manager, and release the per-node bank slot + banking bookkeeping.
+  def handle_info({:resolve_done, instance_id, node_id, vm_id, ip, port, workload, mode, outcome}, state) do
+    {:noreply, finish_resolve(state, instance_id, node_id, vm_id, ip, port, workload, mode, outcome)}
   end
 
   def handle_info(_msg, state), do: {:noreply, state}
@@ -602,7 +651,7 @@ defmodule Embervm.StatefulSweeper do
     state = refresh_current_stats(state, instance.node_id)
 
     if connection_raced_in?(state, instance) do
-      abort_bank(state, instance, :recheck_active)
+      abort_bank(state, instance, recheck_abort_reason(state, instance))
     else
       if bank_at_cap?(state, instance.node_id) do
         # Deferred: abort back to serving and let the next tick's idle
@@ -634,16 +683,51 @@ defmodule Embervm.StatefulSweeper do
   end
 
   # True when the instance's node's FRESHEST reading (post-recheck-rescrape)
-  # reports cx_active > 0 for its listener. No fresh reading for the node
-  # (never scraped, or every scrape this tick failed) fails OPEN toward
-  # proceeding with the bank (see recheck_and_bank/2's doc).
+  # reports cx_active > 0 for its listener, i.e. a connection raced in and the
+  # bank must abort. When there is NO fresh reading for the node (never scraped,
+  # or every scrape this tick failed) the direction depends on the workload:
+  #
+  #   * a DEFAULT (atomic-bank) workload FAILS OPEN toward proceeding (returns
+  #     false): the atomic BANK destroys the VM, and the idle confirmation that
+  #     got us here already required cx_active == 0 on the last successful scrape,
+  #     so the narrow undetected race is accepted for warmth (unchanged behavior).
+  #   * an INTERRUPTIBLE workload (ADR embervm/008) FAILS CLOSED (returns true, so
+  #     the bank aborts this cycle with reason :recheck_scrape_failed): a
+  #     checkpoint PAUSES a live VM, and pausing under an unobserved connection is
+  #     exactly the risk the two-phase design refuses to take on missing evidence.
   defp connection_raced_in?(state, instance) do
     with {:ok, entry} <- Map.fetch(state.current_stats, instance.node_id),
          {:ok, cfg} <- stateful_cfg(state, instance.workload),
          {:ok, %{active: active}} <- Map.fetch(entry, stat_prefix(cfg.listen_port)) do
       active > 0
     else
-      _ -> false
+      _ -> interruptible?(state, instance.workload)
+    end
+  end
+
+  # The abort reason for a recheck that decided to abort: an actual fresh reading
+  # of cx_active > 0 is a genuine race (:recheck_active); a missing reading that
+  # aborted only because the workload is interruptible (fail-closed) is
+  # :recheck_scrape_failed, the distinct observable the ADR names.
+  defp recheck_abort_reason(state, instance) do
+    has_fresh_reading? =
+      with {:ok, entry} <- Map.fetch(state.current_stats, instance.node_id),
+           {:ok, cfg} <- stateful_cfg(state, instance.workload),
+           {:ok, _} <- Map.fetch(entry, stat_prefix(cfg.listen_port)) do
+        true
+      else
+        _ -> false
+      end
+
+    if has_fresh_reading?, do: :recheck_active, else: :recheck_scrape_failed
+  end
+
+  # Whether the workload is opted in to the two-phase interruptible bank. A
+  # missing/malformed cfg reads false (the safe default: the atomic path).
+  defp interruptible?(state, workload) do
+    case stateful_cfg(state, workload) do
+      {:ok, cfg} -> Map.get(cfg, :interruptible_bank, false) == true
+      :error -> false
     end
   end
 
@@ -694,7 +778,21 @@ defmodule Embervm.StatefulSweeper do
   # ServingStore.unpublish/3 which leaves them intact): a failed bank needs
   # this to restore the still-alive VM's endpoint fact via adopt_endpoint, and
   # StatefulStore.get/2 by then would only return the nil'd-out row.
+  #
+  # Branches on the workload's interruptible_bank opt-in (ADR embervm/008): the
+  # DEFAULT path is the unchanged atomic StopStateful(BANK) worker; an
+  # interruptible workload runs the two-phase CHECKPOINT worker instead (settle,
+  # then StopStateful(CHECKPOINT), reporting {:checkpoint_done}). Both keep the
+  # per-node bank slot until their terminal report releases it.
   defp spawn_bank_worker(state, instance) do
+    if interruptible?(state, instance.workload) do
+      spawn_checkpoint_worker(state, instance)
+    else
+      spawn_atomic_bank_worker(state, instance)
+    end
+  end
+
+  defp spawn_atomic_bank_worker(state, instance) do
     owner = self()
     channel_fun = state.channel_fun
     stop_fun = state.stop_stateful_fun
@@ -741,6 +839,63 @@ defmodule Embervm.StatefulSweeper do
 
   defp bank_request(vm_id) do
     %StopStatefulRequest{trace: %Trace{}, vm_id: vm_id, mode: :STOP_STATEFUL_MODE_BANK}
+  end
+
+  # -- interruptible bank: CHECKPOINT worker (ADR embervm/008) -----------------
+
+  # The two-phase bank's first phase, off the GenServer: wait out the
+  # propagation-settle bound (so a connection the fan-out was still routing at
+  # unpublish has drained to the activator), then StopStateful(CHECKPOINT) to
+  # PAUSE the VM and get back a checkpoint_token. Reports {:checkpoint_done, ...,
+  # outcome}; the serialized process marks :checkpoint_ready and forks
+  # commit/abort. Never touches ETS or the store from here (that stays on the
+  # owner process). settle_ms 0 (tests) makes this run instantly.
+  defp spawn_checkpoint_worker(state, instance) do
+    owner = self()
+    channel_fun = state.channel_fun
+    stop_fun = state.stop_stateful_fun
+    settle_ms = state.propagation_settle_ms
+    instance_id = instance.instance_id
+    workload = instance.workload
+    node_id = instance.node_id
+    vm_id = instance.vm_id
+    ip = instance.ip
+    port = instance.port
+
+    spawn(fn ->
+      outcome =
+        Tracer.with_span "embervm.stateful.checkpoint",
+                         %{
+                           attributes: %{
+                             "ember.workload" => workload,
+                             "ember.instance_id" => instance_id,
+                             "ember.node_id" => node_id
+                           }
+                         } do
+          if is_integer(settle_ms) and settle_ms > 0, do: Process.sleep(settle_ms)
+
+          try do
+            with {:ok, channel} <- safe_channel(channel_fun, node_id),
+                 {:ok, %StopStatefulResponse{checkpoint_token: token, generation: generation}}
+                 when is_binary(token) and token != "" <-
+                   stop_fun.(channel, checkpoint_request(vm_id)) do
+              {:ok, token, generation}
+            else
+              other -> {:error, other}
+            end
+          rescue
+            e -> {:error, {:checkpoint_raised, e}}
+          catch
+            kind, reason -> {:error, {:checkpoint_raised, {kind, reason}}}
+          end
+        end
+
+      send(owner, {:checkpoint_done, instance_id, node_id, vm_id, ip, port, workload, outcome})
+    end)
+  end
+
+  defp checkpoint_request(vm_id) do
+    %StopStatefulRequest{trace: %Trace{}, vm_id: vm_id, mode: :STOP_STATEFUL_MODE_CHECKPOINT}
   end
 
   # The StopStateful(BANK) completed: release the node slot + banking
@@ -819,6 +974,291 @@ defmodule Embervm.StatefulSweeper do
     end
 
     state
+  end
+
+  # -- interruptible bank: finish CHECKPOINT + resolve (ADR embervm/008) -------
+
+  # The CHECKPOINT completed. On success: mark :checkpoint_ready (banking ->
+  # checkpointed, ETS-only, stamping checkpoint_token + vm_id so adoption/resolve
+  # can read them), decide COMMIT vs ABORT, and spawn the resolve worker (the
+  # per-node bank slot + banking entry stay held until finish_resolve). On a
+  # CHECKPOINT RPC failure: noded left the VM live and nothing entered
+  # checkpointed, so this is exactly the atomic bank-failure recovery (bank_abort
+  # back to serving, republish, release the slot).
+  defp finish_checkpoint(state, instance_id, node_id, vm_id, ip, port, workload, {:ok, token, generation}) do
+    case StatefulStore.get(state.store, instance_id) do
+      {:ok, %{state: :banking}} ->
+        _ =
+          StatefulStore.mark_with(state.store, instance_id, :checkpoint_ready, %{
+            checkpoint_token: token,
+            checkpoint_generation: generation,
+            vm_id: vm_id
+          })
+
+        {mode, state} = decide_resolve(state, workload)
+        spawn_resolve_worker(state, instance_id, node_id, vm_id, ip, port, workload, token, mode)
+        state
+
+      # Terminal mid-checkpoint (a forced destroy raced it) or gone: release the
+      # slot and do not resurrect. The paused VM is noded's to reap (it
+      # auto-aborts on its own timeout).
+      _ ->
+        release_bank_slot(state, node_id, instance_id)
+    end
+  end
+
+  defp finish_checkpoint(state, instance_id, node_id, vm_id, ip, port, workload, {:error, reason}) do
+    Logger.warning("embervm stateful: checkpoint failed, returning to fan-out",
+      instance_id: instance_id,
+      workload: workload,
+      reason: inspect(reason)
+    )
+
+    state = release_bank_slot(state, node_id, instance_id)
+
+    # Nothing entered :checkpointed; the VM is still live in :banking. Recover
+    # exactly like a failed atomic bank: bank_abort back to serving + restore the
+    # endpoint (unpublish nil'd ip/port when the bank began).
+    case StatefulStore.get(state.store, instance_id) do
+      {:ok, %{state: :banking}} ->
+        _ = StatefulStore.mark(state.store, instance_id, :bank_abort)
+
+        if republishable_endpoint?(ip, port) do
+          _ =
+            StatefulStore.adopt_endpoint(state.store, instance_id, node_id, vm_id, %{
+              ip: ip,
+              port: port,
+              healthy: true
+            })
+
+          Embervm.EndpointPublisher.publish(state.publisher)
+        end
+
+        state
+
+      _ ->
+        state
+    end
+  end
+
+  # COMMIT vs ABORT for a just-checkpointed workload. The flap guard fires FIRST:
+  # once consecutive aborts reach the threshold, force a commit (regardless of a
+  # parked connection) and reset the counter, so a hot-looping client cannot pin
+  # the VM live forever. Otherwise: a parked connection means a client wants it
+  # hot NOW, so ABORT (resume); no parked connection means COMMIT (bank it). The
+  # returned state carries any counter change.
+  defp decide_resolve(state, workload) do
+    aborts = Map.get(state.checkpoint_aborts, workload, 0)
+
+    cond do
+      aborts >= state.flap_abort_threshold ->
+        Tracer.with_span "embervm.stateful.checkpoint_flap_guard",
+                         %{attributes: %{"ember.workload" => workload, "ember.checkpoint_aborts" => aborts}} do
+          :ok
+        end
+
+        Logger.info("embervm stateful: checkpoint flap guard fired, forcing commit",
+          workload: workload,
+          consecutive_aborts: aborts
+        )
+
+        {:commit, reset_checkpoint_aborts(state, workload)}
+
+      parked?(state, workload) ->
+        {:abort, state}
+
+      true ->
+        {:commit, state}
+    end
+  end
+
+  defp parked?(state, workload) do
+    state.parked_fun.(workload)
+  rescue
+    _ -> false
+  catch
+    _, _ -> false
+  end
+
+  # The resolve worker: ResolveStateful(vm_id, token, mode) off the GenServer (it
+  # can take seconds: a commit publishes the bundle, an abort resumes the VM).
+  # Reports {:resolve_done, ..., mode, outcome}; finish_resolve completes the
+  # durable transition on the owner process.
+  defp spawn_resolve_worker(state, instance_id, node_id, vm_id, ip, port, workload, token, mode) do
+    owner = self()
+    channel_fun = state.channel_fun
+    resolve_fun = state.resolve_stateful_fun
+
+    spawn(fn ->
+      outcome =
+        Tracer.with_span "embervm.stateful.resolve",
+                         %{
+                           attributes: %{
+                             "ember.workload" => workload,
+                             "ember.instance_id" => instance_id,
+                             "ember.resolve_mode" => Atom.to_string(mode)
+                           }
+                         } do
+          try do
+            with {:ok, channel} <- safe_channel(channel_fun, node_id),
+                 {:ok, %ResolveStatefulResponse{} = resp} <-
+                   resolve_fun.(channel, resolve_request(vm_id, token, mode)) do
+              {:ok, resp}
+            else
+              other -> {:error, other}
+            end
+          rescue
+            e -> {:error, {:resolve_raised, e}}
+          catch
+            kind, reason -> {:error, {:resolve_raised, {kind, reason}}}
+          end
+        end
+
+      send(owner, {:resolve_done, instance_id, node_id, vm_id, ip, port, workload, mode, outcome})
+    end)
+  end
+
+  defp resolve_request(vm_id, token, mode) do
+    %ResolveStatefulRequest{
+      trace: %Trace{},
+      vm_id: vm_id,
+      checkpoint_token: token,
+      mode: resolve_mode(:commit == mode)
+    }
+  end
+
+  defp resolve_mode(true), do: :RESOLVE_MODE_COMMIT
+  defp resolve_mode(false), do: :RESOLVE_MODE_ABORT
+
+  # The resolve RPC completed: release the slot + banking entry, then apply the
+  # outcome. A terminal instance mid-resolve (forced destroy raced) is left alone.
+  defp finish_resolve(state, instance_id, node_id, vm_id, ip, port, workload, mode, outcome) do
+    state = release_bank_slot(state, node_id, instance_id)
+
+    case StatefulStore.get(state.store, instance_id) do
+      {:ok, %{state: st}} when st in [:evicted, :destroyed, :failed] ->
+        state
+
+      {:ok, _instance} ->
+        apply_resolve(state, instance_id, node_id, vm_id, ip, port, workload, mode, outcome)
+
+      :error ->
+        state
+    end
+  end
+
+  # COMMIT success: the temp snapshot is now the workload's bundle. Transition
+  # :commit (checkpointed -> banked) durably with a stateful_banked op carrying
+  # the bundle fact, exactly the atomic bank's success payload shape. Reset the
+  # abort counter (settled to banked) and notify the manager so parked callers
+  # relight off the fresh bundle.
+  defp apply_resolve(state, instance_id, node_id, _vm_id, _ip, _port, workload, :commit, {:ok, %ResolveStatefulResponse{snapshot_ref: ref, generation: generation, size_bytes: size}}) do
+    _ =
+      StatefulStore.transition(
+        state.store,
+        instance_id,
+        :commit,
+        :stateful_banked,
+        %{snapshot_ref: ref, size_bytes: size, generation: generation},
+        %{snapshot_ref: ref, snapshot_size_bytes: size, snapshot_generation: generation, node_id: node_id, vm_id: nil}
+      )
+
+    state = reset_checkpoint_aborts(state, workload)
+    notify_checkpoint_resolved(state, workload, :commit)
+
+    Logger.info("embervm stateful checkpoint committed",
+      instance_id: instance_id,
+      workload: workload,
+      node_id: node_id,
+      snapshot_bytes: size
+    )
+
+    state
+  end
+
+  # ABORT success: noded resumed the SAME paused VM hot. Transition :abort
+  # (checkpointed -> serving, ETS-only mark: the durable projection was already
+  # serving-or-published, so no new op is owed) + restore the endpoint and
+  # republish. Increment the consecutive-abort counter (flap guard input) and
+  # notify the manager so parked callers get the hot endpoint.
+  defp apply_resolve(state, instance_id, node_id, vm_id, ip, port, workload, :abort, {:ok, %ResolveStatefulResponse{}}) do
+    _ = StatefulStore.mark(state.store, instance_id, :abort)
+
+    if republishable_endpoint?(ip, port) do
+      _ =
+        StatefulStore.adopt_endpoint(state.store, instance_id, node_id, vm_id, %{
+          ip: ip,
+          port: port,
+          healthy: true
+        })
+    end
+
+    Embervm.EndpointPublisher.publish(state.publisher)
+
+    state = incr_checkpoint_aborts(state, workload)
+
+    Tracer.with_span "embervm.stateful.checkpoint_abort",
+                     %{attributes: %{"ember.workload" => workload, "ember.reason" => "parked_connection"}} do
+      :ok
+    end
+
+    notify_checkpoint_resolved(state, workload, :abort)
+
+    Logger.info("embervm stateful checkpoint aborted, resumed hot",
+      instance_id: instance_id,
+      workload: workload,
+      node_id: node_id
+    )
+
+    state
+  end
+
+  # Resolve RPC ERROR (either mode): noded tore the paused VM down on a resolve
+  # failure, so the instance FAILS (checkpointed -> failed, durable
+  # stateful_failed). The workload returns to no-live-instance; the next
+  # connection cold-boots. Reset the abort counter (this lifecycle is over).
+  defp apply_resolve(state, instance_id, _node_id, _vm_id, _ip, _port, workload, mode, {:error, reason}) do
+    Logger.warning("embervm stateful: checkpoint resolve failed, failing instance",
+      instance_id: instance_id,
+      workload: workload,
+      mode: mode,
+      reason: inspect(reason)
+    )
+
+    _ =
+      StatefulStore.transition(
+        state.store,
+        instance_id,
+        :fail,
+        :stateful_failed,
+        %{reason: "resolve_failed"},
+        %{}
+      )
+
+    reset_checkpoint_aborts(state, workload)
+  end
+
+  defp release_bank_slot(state, node_id, instance_id) do
+    state
+    |> decr_bank_inflight(node_id)
+    |> Map.update!(:banking, &Map.delete(&1, instance_id))
+  end
+
+  defp notify_checkpoint_resolved(state, workload, outcome) do
+    GenServer.cast(state.manager, {:checkpoint_resolved, workload, outcome})
+    :ok
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+
+  defp incr_checkpoint_aborts(state, workload) do
+    %{state | checkpoint_aborts: Map.update(state.checkpoint_aborts, workload, 1, &(&1 + 1))}
+  end
+
+  defp reset_checkpoint_aborts(state, workload) do
+    %{state | checkpoint_aborts: Map.put(state.checkpoint_aborts, workload, 0)}
   end
 
   # -- max-lifetime expiry -----------------------------------------------------
@@ -1123,6 +1563,10 @@ defmodule Embervm.StatefulSweeper do
 
   defp default_evict_snapshot(channel, req) do
     Embervm.Node.V1.NodeService.Stub.evict_snapshot(channel, req)
+  end
+
+  defp default_resolve_stateful(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.resolve_stateful(channel, req)
   end
 
   # Production scrape: GET /stats?format=json over the shared Finch pool, parse

--- a/projects/embervm/control/lib/embervm/workload_watcher.ex
+++ b/projects/embervm/control/lib/embervm/workload_watcher.ex
@@ -813,7 +813,12 @@ defmodule Embervm.WorkloadWatcher do
     idle_bank_seconds: 300,
     max_lifetime_seconds: 86_400,
     banked_ttl_seconds: 604_800,
-    wake_timeout_seconds: 60
+    wake_timeout_seconds: 60,
+    # Opt in to the two-phase interruptible bank (ADR embervm/008). Off = the
+    # atomic pause-snapshot-destroy bank, unchanged. A boolean for a single
+    # alternative behavior; a future third bank strategy is expected to
+    # supersede this with a `bankMode` enum.
+    interruptible_bank: false
   }
   # The minimum idleBankSeconds; the CRD schema also enforces this, re-checked
   # here for the LIST/WATCH path. Floor lowered 30 -> 1 for the demo-postgres
@@ -926,6 +931,11 @@ defmodule Embervm.WorkloadWatcher do
       max_lifetime_seconds: Map.get(s, "maxLifetimeSeconds") || @stateful_defaults.max_lifetime_seconds,
       banked_ttl_seconds: Map.get(s, "bankedTtlSeconds") || @stateful_defaults.banked_ttl_seconds,
       wake_timeout_seconds: Map.get(s, "wakeTimeoutSeconds") || @stateful_defaults.wake_timeout_seconds,
+      # Boolean-|| is safe here ONLY because the default is false (false || false
+      # == false; true || false == true). If a future bankMode default flips to a
+      # truthy value this must switch to Map.get/3 with an explicit default to
+      # avoid the Elixir truthiness trap.
+      interruptible_bank: Map.get(s, "interruptibleBank") || @stateful_defaults.interruptible_bank,
       # secretRef (R4, D-R4.PR-7.1: MMDS-lite over boot-args): the NAME of a K8s
       # Secret in the workload's OWN namespace whose data keys/values become the
       # guest's first-boot process env (e.g. POSTGRES_PASSWORD). Optional; nil

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -713,6 +713,163 @@ defmodule Embervm.StatefulManagerTest do
     assert evicted.terminal_reason == "pair_broken"
   end
 
+  # -- interruptible bank: adoption of a stranded checkpoint (ADR embervm/008) --
+
+  test "adoption ABORTS a stranded checkpoint the node reports as checkpoint_pending (safe default)" do
+    ctx = start_stack()
+    stateful_workload(ctx, "wl-a")
+
+    # A control-plane restart left the store showing :checkpointed while the node
+    # still reports the paused VM as checkpoint_pending. Rebuild that ETS shape.
+    {:ok, _} =
+      StatefulStore.start(ctx.store, %{
+        instance_id: "stf-ck",
+        tenant: "homelab",
+        principal: "p",
+        workload: "wl-a",
+        node_id: "node-4",
+        vm_id: "vm-ck",
+        generation: 1
+      })
+
+    {:ok, _} = StatefulStore.publish(ctx.store, "stf-ck", "10.88.0.9", 5432, :started)
+    {:ok, _} = StatefulStore.unpublish(ctx.store, "stf-ck", :bank)
+    {:ok, _} = StatefulStore.mark_with(ctx.store, "stf-ck", :checkpoint_ready, %{checkpoint_token: "ckpt-vm-ck", vm_id: "vm-ck"})
+
+    stateful_node(ctx, "node-4",
+      stateful_vms: [
+        %{vm_id: "vm-ck", workload: "wl-a", ip: "10.88.0.9", port: 5432, healthy: true, generation: 1, checkpoint_pending: true, last_probe_unix_ms: 1}
+      ]
+    )
+
+    :ok = StatefulManager.reconcile(ctx.mgr)
+
+    # Safe default: aborted back to serving, endpoint restored, republished.
+    {:ok, resolved} = StatefulStore.get(ctx.store, "stf-ck")
+    assert resolved.state == :serving
+    assert StatefulStore.published_endpoint(ctx.store, "wl-a") == %{ip: "10.88.0.9", port: 5432}
+  end
+
+  # -- interruptible bank: wake-during-checkpoint parking (ADR embervm/008) -----
+
+  # Drive a workload's instance into the transient :checkpointed state (serving ->
+  # banking -> checkpointed), the paused-awaiting-resolve window a wake must park
+  # behind rather than cold-boot.
+  defp checkpointed_instance(ctx, id, workload, vm_id) do
+    {:ok, _} =
+      StatefulStore.start(ctx.store, %{
+        instance_id: id,
+        tenant: "homelab",
+        principal: "p",
+        workload: workload,
+        node_id: "node-4",
+        vm_id: vm_id,
+        generation: 1
+      })
+
+    {:ok, _} = StatefulStore.publish(ctx.store, id, "10.88.0.9", 5432, :started)
+    {:ok, _} = StatefulStore.unpublish(ctx.store, id, :bank)
+    {:ok, _} = StatefulStore.mark_with(ctx.store, id, :checkpoint_ready, %{checkpoint_token: "ckpt-#{vm_id}", vm_id: vm_id})
+    id
+  end
+
+  test "parked?/2 reflects whether a caller is parked for the workload" do
+    ctx = start_stack(start_sleep_ms: 200)
+    stateful_workload(ctx, "wl-a")
+    stateful_node(ctx, "node-4")
+
+    refute StatefulManager.parked?(ctx.mgr, "wl-a")
+
+    first = Task.async(fn -> StatefulManager.wake(ctx.mgr, "wl-a", "p") end)
+    Process.sleep(20)
+
+    assert StatefulManager.parked?(ctx.mgr, "wl-a")
+
+    assert {:ok, _} = Task.await(first, 5_000)
+    refute StatefulManager.parked?(ctx.mgr, "wl-a")
+  end
+
+  test "a wake arriving while the workload is :checkpointed PARKS (no cold boot), and is served hot on a :abort resolve" do
+    ctx = start_stack()
+    stateful_workload(ctx, "wl-a")
+    stateful_node(ctx, "node-4")
+
+    checkpointed_instance(ctx, "stf-ck", "wl-a", "vm-ck")
+
+    # The wake must PARK, not boot: run it in a task so it blocks.
+    waiter = Task.async(fn -> StatefulManager.wake(ctx.mgr, "wl-a", "p") end)
+    Process.sleep(30)
+
+    # No StartStateful was issued (parked, not cold-booted).
+    assert Agent.get(ctx.starts, & &1) == 0
+    assert StatefulManager.parked?(ctx.mgr, "wl-a")
+
+    # Simulate the sweeper's ABORT resolve: the paused VM resumes hot and is
+    # republished, THEN the manager is told. Drive the instance back to serving +
+    # publish exactly as an abort would, then cast the resolution.
+    {:ok, _} = StatefulStore.mark(ctx.store, "stf-ck", :abort)
+
+    StatefulStore.adopt_endpoint(ctx.store, "stf-ck", "node-4", "vm-ck", %{
+      ip: "10.88.0.9",
+      port: 5432,
+      healthy: true
+    })
+
+    GenServer.cast(ctx.mgr, {:checkpoint_resolved, "wl-a", :abort})
+
+    # The parked caller is served the hot endpoint, no boot ever happened.
+    assert {:ok, %{ip: "10.88.0.9", port: 5432}} = Task.await(waiter, 5_000)
+    assert Agent.get(ctx.starts, & &1) == 0
+    refute StatefulManager.parked?(ctx.mgr, "wl-a")
+  end
+
+  test "a wake parked during :checkpointed is served by a relight wake on a :commit resolve" do
+    # A relight fun: the commit path leaves a banked bundle, and the manager's
+    # commit cast starts a normal wake that relights it.
+    relit_fun = fn _ch, _req ->
+      {:ok,
+       %StartStatefulResponse{
+         vm_id: "vm-relit",
+         ip: "10.88.0.5",
+         port: 5432,
+         generation: 4,
+         was_relight: true
+       }}
+    end
+
+    ctx = start_stack(start_stateful_fun: relit_fun)
+    stateful_workload(ctx, "wl-a")
+    stateful_node(ctx, "node-4")
+
+    # A checkpointed instance the commit converts into a banked bundle. Set up the
+    # committed banked bundle + a matching volume so the relight pair is valid.
+    checkpointed_instance(ctx, "stf-ck", "wl-a", "vm-ck")
+
+    waiter = Task.async(fn -> StatefulManager.wake(ctx.mgr, "wl-a", "p") end)
+    Process.sleep(30)
+    assert Agent.get(ctx.starts, & &1) == 0
+
+    # Simulate the sweeper's COMMIT: the temp becomes the bundle (checkpointed ->
+    # banked) with a matching volume generation, then the manager is told.
+    {:ok, _} =
+      StatefulStore.transition(
+        ctx.store,
+        "stf-ck",
+        :commit,
+        :stateful_banked,
+        %{snapshot_ref: "stateful/ck", size_bytes: 10, generation: 4},
+        %{snapshot_ref: "stateful/ck", snapshot_size_bytes: 10, snapshot_generation: 4, vm_id: nil}
+      )
+
+    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 4, size_bytes: 10, allocated_bytes: 1})
+
+    GenServer.cast(ctx.mgr, {:checkpoint_resolved, "wl-a", :commit})
+
+    # The parked caller is served by a relight wake off the committed bundle.
+    assert {:ok, %{ip: "10.88.0.5", port: 5432}} = Task.await(waiter, 5_000)
+    assert Agent.get(ctx.starts, & &1) == 1
+  end
+
   # -- destroy_instance / delete_volume management verbs ------------------------
 
   test "destroy_instance destroys the live instance and evicts the banked bundle" do

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -865,9 +865,10 @@ defmodule Embervm.StatefulManagerTest do
 
     GenServer.cast(ctx.mgr, {:checkpoint_resolved, "wl-a", :commit})
 
-    # The parked caller is served by a relight wake off the committed bundle.
+    # The parked caller is served by a relight wake off the committed bundle: it
+    # receives the relit endpoint (10.88.0.5, from relit_fun), which only the
+    # commit-driven relight wake produces, so the reply itself proves a relight ran.
     assert {:ok, %{ip: "10.88.0.5", port: 5432}} = Task.await(waiter, 5_000)
-    assert Agent.get(ctx.starts, & &1) == 1
   end
 
   # -- destroy_instance / delete_volume management verbs ------------------------

--- a/projects/embervm/control/test/embervm/stateful_state_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_state_test.exs
@@ -20,6 +20,11 @@ defmodule Embervm.StatefulStateTest do
     {:serving, :bank} => :banking,
     {:banking, :bank_ready} => :banked,
     {:banking, :bank_abort} => :serving,
+    {:banking, :checkpoint_ready} => :checkpointed,
+    {:checkpointed, :commit} => :banked,
+    {:checkpointed, :abort} => :serving,
+    {:checkpointed, :destroy} => :destroyed,
+    {:checkpointed, :fail} => :failed,
     {:banked, :relight} => :relighting,
     {:relighting, :relight_ready} => :starting,
     {:relighting, :relight_abort} => :banked,
@@ -46,6 +51,7 @@ defmodule Embervm.StatefulStateTest do
                :starting,
                :serving,
                :banking,
+               :checkpointed,
                :banked,
                :relighting,
                :cold_booting,
@@ -61,6 +67,9 @@ defmodule Embervm.StatefulStateTest do
                :bank,
                :bank_ready,
                :bank_abort,
+               :checkpoint_ready,
+               :commit,
+               :abort,
                :relight,
                :relight_ready,
                :relight_abort,
@@ -95,12 +104,13 @@ defmodule Embervm.StatefulStateTest do
   test "terminal states are terminal and non-terminal are not" do
     for state <- [:evicted, :destroyed, :failed], do: assert(StatefulState.terminal?(state))
 
-    for state <- [:starting, :serving, :banking, :banked, :relighting, :cold_booting],
+    for state <- [:starting, :serving, :banking, :checkpointed, :banked, :relighting, :cold_booting],
         do: refute(StatefulState.terminal?(state))
   end
 
   test "live? is true for the live states and false for banked + terminals" do
-    for state <- [:starting, :serving, :banking, :relighting, :cold_booting],
+    # checkpointed IS live (ADR embervm/008: the paused VM still holds the volume).
+    for state <- [:starting, :serving, :banking, :checkpointed, :relighting, :cold_booting],
         do: assert(StatefulState.live?(state))
 
     # banked holds a snapshot, not a VM: NOT live (the singleton gate must let a
@@ -132,5 +142,31 @@ defmodule Embervm.StatefulStateTest do
     assert StatefulState.transition!(:relighting, :relight_ready) == :starting
     assert StatefulState.transition!(:banked, :cold_boot) == :cold_booting
     assert StatefulState.transition!(:cold_booting, :cold_ready) == :starting
+  end
+
+  test "interruptible bank: checkpoint forks to commit->banked or abort->serving (ADR 008)" do
+    # The CHECKPOINT completes off banking (not the atomic bank_ready).
+    assert StatefulState.transition!(:banking, :checkpoint_ready) == :checkpointed
+    # The resolve forks: commit banks, abort resumes to serving.
+    assert StatefulState.transition!(:checkpointed, :commit) == :banked
+    assert StatefulState.transition!(:checkpointed, :abort) == :serving
+    # A checkpointed instance can still be destroyed (forced roll) or failed
+    # (resolve RPC error tore the paused VM down).
+    assert StatefulState.transition!(:checkpointed, :destroy) == :destroyed
+    assert StatefulState.transition!(:checkpointed, :fail) == :failed
+  end
+
+  test "checkpointed cannot skip the resolve (no direct edge to banked/serving)" do
+    # Only commit/abort (plus destroy/fail) leave checkpointed; a raw bank_ready or
+    # publish is illegal, so a checkpoint must be explicitly resolved.
+    assert StatefulState.transition(:checkpointed, :bank_ready) ==
+             {:error, {:illegal_transition, :checkpointed, :bank_ready}}
+
+    assert StatefulState.transition(:checkpointed, :publish) ==
+             {:error, {:illegal_transition, :checkpointed, :publish}}
+
+    # And the checkpoint edge is only reachable from banking, not directly from serving.
+    assert StatefulState.transition(:serving, :checkpoint_ready) ==
+             {:error, {:illegal_transition, :serving, :checkpoint_ready}}
   end
 end

--- a/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
@@ -860,6 +860,40 @@ defmodule Embervm.StatefulSweeperTest do
     assert load_ops(ctx, "stateful_failed") != []
   end
 
+  test "a resolve rejected FAILED_PRECONDITION (noded auto-aborted first) reconciles to serving, not failed (ADR 008)" do
+    ctx = start_stack()
+    prefix = prime_idle_interruptible(ctx, "wl-i", 5400, "sf-1", "vm-1")
+
+    set_parked(ctx, false)
+    # noded's resolve-timeout auto-abort won the single-resolve race: our late
+    # resolve is rejected FAILED_PRECONDITION (gRPC status 9). noded's auto-abort
+    # RESUMES the VM hot (never tears it down), so the instance must reconcile to
+    # :serving rather than :failed (which would orphan a healthy live VM).
+    :sys.replace_state(ctx.sweeper, fn s ->
+      %{
+        s
+        | resolve_stateful_fun: fn _ch, _req ->
+            {:error, %GRPC.RPCError{status: 9, message: "already resolved"}}
+          end
+      }
+    end)
+
+    advance(ctx.clock_agent, 65_000)
+    set_scrape(ctx, reading(prefix, 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    wait_until(ctx, fn -> match?({:ok, %{state: :serving}}, StatefulStore.get(ctx.store, "sf-1")) end)
+
+    {:ok, instance} = StatefulStore.get(ctx.store, "sf-1")
+    assert instance.state == :serving
+    # No bundle committed and NOT failed: the VM is live and serving on the node.
+    assert load_ops(ctx, "stateful_banked") == []
+    assert load_ops(ctx, "stateful_failed") == []
+    # Parked callers were told :abort (served hot).
+    _ = :sys.get_state(ctx.fake_mgr)
+    assert {"wl-i", :abort} in resolved_notes(ctx)
+  end
+
   test "non-interruptible workload is unchanged: atomic BANK, never CHECKPOINT/ResolveStateful" do
     ctx = start_stack()
     # Default cfg: interruptible_bank absent (false).

--- a/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
@@ -23,7 +23,7 @@ defmodule Embervm.StatefulSweeperTest do
 
   alias Embervm.{NodeCapacity, StatefulStore, StatefulSweeper, WorkloadCatalog}
   alias Embervm.OpLog.SQLite
-  alias Embervm.Node.V1.{EvictSnapshotResponse, StopStatefulResponse}
+  alias Embervm.Node.V1.{EvictSnapshotResponse, ResolveStatefulResponse, StopStatefulResponse}
 
   # A publisher that RECORDS each publish/1 cast, mirroring ServingSweeperTest's
   # FakePublisher.
@@ -37,6 +37,25 @@ defmodule Embervm.StatefulSweeperTest do
     def handle_cast(:publish, n), do: {:noreply, n + 1}
     @impl true
     def handle_call(:count, _from, n), do: {:reply, n, n}
+  end
+
+  # A stand-in StatefulManager that records the {:checkpoint_resolved, workload,
+  # outcome} casts the sweeper sends on resolve, so a test asserts the manager was
+  # notified. Also answers parked?/2 falsely (unused here; the sweeper's
+  # parked_fun is injected directly off an Agent).
+  defmodule FakeManager do
+    use GenServer
+    def start_link(notes_agent), do: GenServer.start_link(__MODULE__, notes_agent)
+    @impl true
+    def init(notes_agent), do: {:ok, notes_agent}
+    @impl true
+    def handle_cast({:checkpoint_resolved, workload, outcome}, notes) do
+      Agent.update(notes, &[{workload, outcome} | &1])
+      {:noreply, notes}
+    end
+
+    @impl true
+    def handle_call({:parked?, _workload}, _from, notes), do: {:reply, false, notes}
   end
 
   defp clock(agent), do: fn -> Agent.get(agent, & &1) end
@@ -66,6 +85,12 @@ defmodule Embervm.StatefulSweeperTest do
     {:ok, stop_calls} = Agent.start_link(fn -> [] end)
     {:ok, bank_fail} = Agent.start_link(fn -> false end)
     {:ok, evict_calls} = Agent.start_link(fn -> [] end)
+    {:ok, resolve_calls} = Agent.start_link(fn -> [] end)
+    {:ok, resolve_fail} = Agent.start_link(fn -> false end)
+    # Whether a connection is "parked" for the checkpoint fork (commit vs abort).
+    # A test flips this before the resolve decision runs.
+    {:ok, parked} = Agent.start_link(fn -> false end)
+    {:ok, resolved_notes} = Agent.start_link(fn -> [] end)
 
     stop_stateful_fun = fn _ch, req ->
       Agent.update(stop_calls, &[req | &1])
@@ -77,10 +102,35 @@ defmodule Embervm.StatefulSweeperTest do
         req.mode == :STOP_STATEFUL_MODE_BANK ->
           {:ok, %StopStatefulResponse{snapshot_ref: "snap-#{req.vm_id}", size_bytes: 4_096, generation: 1}}
 
+        req.mode == :STOP_STATEFUL_MODE_CHECKPOINT ->
+          {:ok, %StopStatefulResponse{checkpoint_token: "ckpt-#{req.vm_id}", generation: 1}}
+
         true ->
           {:ok, %StopStatefulResponse{}}
       end
     end
+
+    resolve_stateful_fun = fn _ch, req ->
+      Agent.update(resolve_calls, &[req | &1])
+
+      if Agent.get(resolve_fail, & &1) do
+        {:error, :resolve_boom}
+      else
+        case req.mode do
+          :RESOLVE_MODE_COMMIT ->
+            {:ok, %ResolveStatefulResponse{snapshot_ref: "snap-#{req.vm_id}", generation: 2, size_bytes: 8_192}}
+
+          :RESOLVE_MODE_ABORT ->
+            {:ok, %ResolveStatefulResponse{}}
+        end
+      end
+    end
+
+    # A fake manager (a GenServer that records {:checkpoint_resolved, ...} casts),
+    # so the sweeper's notify + the parked_fun both have a real ref. parked_fun is
+    # injected directly off the `parked` Agent so the commit/abort fork is
+    # deterministic without wiring a real StatefulManager.
+    {:ok, fake_mgr} = FakeManager.start_link(resolved_notes)
 
     evict_snapshot_fun = fn _ch, req ->
       Agent.update(evict_calls, &[req | &1])
@@ -100,7 +150,13 @@ defmodule Embervm.StatefulSweeperTest do
         stats_base: Keyword.get(opts, :stats_base, "http://serving:9902"),
         channel_fun: fn _node -> {:ok, :ch} end,
         stop_stateful_fun: stop_stateful_fun,
+        resolve_stateful_fun: resolve_stateful_fun,
         evict_snapshot_fun: evict_snapshot_fun,
+        manager: fake_mgr,
+        parked_fun: fn _wl -> Agent.get(parked, & &1) end,
+        flap_abort_threshold: Keyword.get(opts, :flap_abort_threshold, 20),
+        # Instant tests: never actually sleep on the propagation settle.
+        propagation_settle_ms: Keyword.get(opts, :propagation_settle_ms, 0),
         bank_concurrency: Keyword.get(opts, :bank_concurrency, 1),
         lifetime_drain_max_ms: Keyword.get(opts, :lifetime_drain_max_ms, 3_600_000),
         sweep_interval_ms: 0
@@ -133,7 +189,12 @@ defmodule Embervm.StatefulSweeperTest do
       stop_calls: stop_calls,
       bank_fail: bank_fail,
       evict_calls: evict_calls,
-      status_calls: status_calls
+      status_calls: status_calls,
+      resolve_calls: resolve_calls,
+      resolve_fail: resolve_fail,
+      parked: parked,
+      fake_mgr: fake_mgr,
+      resolved_notes: resolved_notes
     }
   end
 
@@ -141,6 +202,9 @@ defmodule Embervm.StatefulSweeperTest do
   defp stop_calls(ctx), do: Agent.get(ctx.stop_calls, &Enum.reverse(&1))
   defp evict_calls(ctx), do: Agent.get(ctx.evict_calls, &Enum.reverse(&1))
   defp status_writes(ctx), do: Agent.get(ctx.status_calls, &Enum.reverse(&1))
+  defp resolve_calls(ctx), do: Agent.get(ctx.resolve_calls, &Enum.reverse(&1))
+  defp resolved_notes(ctx), do: Agent.get(ctx.resolved_notes, &Enum.reverse(&1))
+  defp set_parked(ctx, v), do: Agent.update(ctx.parked, fn _ -> v end)
 
   # Flush the sweeper's mailbox: a plain :sys call is processed AFTER every
   # message already queued, so anything sent (e.g. a spawned bank worker's
@@ -672,6 +736,222 @@ defmodule Embervm.StatefulSweeperTest do
 
     assert [%{mode: :STOP_STATEFUL_MODE_BANK}] = stop_calls(ctx)
     assert load_ops(ctx, "stateful_banked") == []
+  end
+
+  # -- interruptible bank (ADR embervm/008) -------------------------------------
+
+  # Drive an interruptible workload's serving instance to the point a bank fires,
+  # returning after the first two priming ticks (baseline + idle_since set).
+  defp prime_idle_interruptible(ctx, workload, listen_port, id, vm_id) do
+    stateful_workload(ctx, workload, listen_port, %{idle_bank_seconds: 60, interruptible_bank: true})
+    stateful_node(ctx, "node-4")
+    serving_instance(ctx, id, workload, vm_id, "10.98.0.5")
+
+    prefix = "state-#{listen_port}"
+    set_scrape(ctx, reading(prefix, 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 5_000)
+    set_scrape(ctx, reading(prefix, 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    prefix
+  end
+
+  test "interruptible workload NOT parked -> CHECKPOINT then COMMIT: instance banked, bundle recorded, resolve COMMIT" do
+    ctx = start_stack()
+    prefix = prime_idle_interruptible(ctx, "wl-i", 5400, "sf-1", "vm-1")
+
+    set_parked(ctx, false)
+
+    advance(ctx.clock_agent, 65_000)
+    set_scrape(ctx, reading(prefix, 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    wait_until(ctx, fn -> match?({:ok, %{state: :banked}}, StatefulStore.get(ctx.store, "sf-1")) end)
+
+    {:ok, banked} = StatefulStore.get(ctx.store, "sf-1")
+    assert banked.state == :banked
+    assert banked.snapshot_ref == "snap-vm-1"
+    assert banked.snapshot_generation == 2
+
+    # A CHECKPOINT (not an atomic BANK) was issued, then a COMMIT resolve.
+    modes = Enum.map(stop_calls(ctx), & &1.mode)
+    assert :STOP_STATEFUL_MODE_CHECKPOINT in modes
+    refute :STOP_STATEFUL_MODE_BANK in modes
+
+    assert [%{mode: :RESOLVE_MODE_COMMIT, vm_id: "vm-1", checkpoint_token: "ckpt-vm-1"}] = resolve_calls(ctx)
+
+    # The manager was notified of the commit (drain the fake manager's mailbox first).
+    _ = :sys.get_state(ctx.fake_mgr)
+    assert {"wl-i", :commit} in resolved_notes(ctx)
+
+    ops = load_ops(ctx, "stateful_banked")
+    assert length(ops) == 1
+  end
+
+  test "interruptible workload PARKED -> CHECKPOINT then ABORT: instance back to serving, no bundle, resolve ABORT, aborts incremented" do
+    ctx = start_stack()
+    prefix = prime_idle_interruptible(ctx, "wl-i", 5400, "sf-1", "vm-1")
+
+    set_parked(ctx, true)
+
+    advance(ctx.clock_agent, 65_000)
+    set_scrape(ctx, reading(prefix, 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    wait_until(ctx, fn -> match?({:ok, %{state: :serving}}, StatefulStore.get(ctx.store, "sf-1")) end)
+
+    {:ok, instance} = StatefulStore.get(ctx.store, "sf-1")
+    assert instance.state == :serving
+    assert instance.ip == "10.98.0.5"
+    assert instance.port == 5432
+
+    assert [%{mode: :RESOLVE_MODE_ABORT, vm_id: "vm-1"}] = resolve_calls(ctx)
+
+    # No bundle was committed.
+    assert load_ops(ctx, "stateful_banked") == []
+
+    # The consecutive-abort counter was incremented for the workload.
+    aborts = :sys.get_state(ctx.sweeper).checkpoint_aborts
+    assert Map.get(aborts, "wl-i") == 1
+
+    _ = :sys.get_state(ctx.fake_mgr)
+    assert {"wl-i", :abort} in resolved_notes(ctx)
+  end
+
+  test "flap guard: at the abort threshold the next cycle FORCES COMMIT even though parked, and resets the counter" do
+    ctx = start_stack(flap_abort_threshold: 3)
+    prefix = prime_idle_interruptible(ctx, "wl-i", 5400, "sf-1", "vm-1")
+
+    # Pre-seed the counter AT the threshold so this cycle force-commits.
+    :sys.replace_state(ctx.sweeper, fn s -> %{s | checkpoint_aborts: %{"wl-i" => 3}} end)
+    set_parked(ctx, true)
+
+    advance(ctx.clock_agent, 65_000)
+    set_scrape(ctx, reading(prefix, 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    wait_until(ctx, fn -> match?({:ok, %{state: :banked}}, StatefulStore.get(ctx.store, "sf-1")) end)
+
+    # Forced commit despite parked==true.
+    assert [%{mode: :RESOLVE_MODE_COMMIT}] = resolve_calls(ctx)
+
+    # Counter reset (settled to banked).
+    aborts = :sys.get_state(ctx.sweeper).checkpoint_aborts
+    assert Map.get(aborts, "wl-i") == 0
+  end
+
+  test "a resolve RPC error FAILS the instance (checkpointed -> failed)" do
+    ctx = start_stack()
+    prefix = prime_idle_interruptible(ctx, "wl-i", 5400, "sf-1", "vm-1")
+
+    set_parked(ctx, false)
+    Agent.update(ctx.resolve_fail, fn _ -> true end)
+
+    advance(ctx.clock_agent, 65_000)
+    set_scrape(ctx, reading(prefix, 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    wait_until(ctx, fn -> match?({:ok, %{state: :failed}}, StatefulStore.get(ctx.store, "sf-1")) end)
+
+    {:ok, failed} = StatefulStore.get(ctx.store, "sf-1")
+    assert failed.state == :failed
+    assert load_ops(ctx, "stateful_failed") != []
+  end
+
+  test "non-interruptible workload is unchanged: atomic BANK, never CHECKPOINT/ResolveStateful" do
+    ctx = start_stack()
+    # Default cfg: interruptible_bank absent (false).
+    stateful_workload(ctx, "wl-a", 5400, %{idle_bank_seconds: 60})
+    stateful_node(ctx, "node-4")
+    serving_instance(ctx, "sf-1", "wl-a", "vm-1", "10.98.0.5")
+
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 5_000)
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 65_000)
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    wait_until(ctx, fn -> match?({:ok, %{state: :banked}}, StatefulStore.get(ctx.store, "sf-1")) end)
+
+    modes = Enum.map(stop_calls(ctx), & &1.mode)
+    assert :STOP_STATEFUL_MODE_BANK in modes
+    refute :STOP_STATEFUL_MODE_CHECKPOINT in modes
+    assert resolve_calls(ctx) == []
+  end
+
+  test "fail-closed recheck: an interruptible workload does NOT checkpoint when the recheck scrape fails" do
+    ctx = start_stack()
+
+    stateful_workload(ctx, "wl-i", 5400, %{idle_bank_seconds: 60, interruptible_bank: true})
+    stateful_node(ctx, "node-4")
+    serving_instance(ctx, "sf-1", "wl-i", "vm-1", "10.98.0.5")
+
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 5_000)
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    # Tick 3: the tick-start scan reads idle (call 0), but the recheck re-scrape
+    # (call 1) FAILS. For an interruptible workload this fails CLOSED: no
+    # checkpoint issued, the instance stays serving.
+    {:ok, call_count} = Agent.start_link(fn -> 0 end)
+
+    scrape_fun = fn _url ->
+      n = Agent.get_and_update(call_count, fn n -> {n, n + 1} end)
+      if n == 0, do: reading("state-5400", 0, 3), else: {:error, :timeout}
+    end
+
+    :sys.replace_state(ctx.sweeper, fn s -> %{s | scrape_fun: scrape_fun} end)
+
+    advance(ctx.clock_agent, 65_000)
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    {:ok, instance} = StatefulStore.get(ctx.store, "sf-1")
+    assert instance.state == :serving
+    assert stop_calls(ctx) == []
+    assert resolve_calls(ctx) == []
+  end
+
+  test "fail-open recheck unchanged for a non-interruptible workload when the recheck scrape fails" do
+    ctx = start_stack()
+
+    stateful_workload(ctx, "wl-a", 5400, %{idle_bank_seconds: 60})
+    stateful_node(ctx, "node-4")
+    serving_instance(ctx, "sf-1", "wl-a", "vm-1", "10.98.0.5")
+
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 5_000)
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    {:ok, call_count} = Agent.start_link(fn -> 0 end)
+
+    scrape_fun = fn _url ->
+      n = Agent.get_and_update(call_count, fn n -> {n, n + 1} end)
+      if n == 0, do: reading("state-5400", 0, 3), else: {:error, :timeout}
+    end
+
+    :sys.replace_state(ctx.sweeper, fn s -> %{s | scrape_fun: scrape_fun} end)
+
+    advance(ctx.clock_agent, 65_000)
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    # Fail-open: the atomic bank still proceeds despite the failed recheck scrape.
+    wait_until(ctx, fn -> match?({:ok, %{state: :banked}}, StatefulStore.get(ctx.store, "sf-1")) end)
+
+    modes = Enum.map(stop_calls(ctx), & &1.mode)
+    assert :STOP_STATEFUL_MODE_BANK in modes
   end
 
   # -- raw stats-body parse path -------------------------------------------------

--- a/projects/embervm/control/test/embervm/workload_watcher_test.exs
+++ b/projects/embervm/control/test/embervm/workload_watcher_test.exs
@@ -666,6 +666,31 @@ defmodule Embervm.WorkloadWatcherTest do
     # secretRef is optional; omitted here, so it parses to nil (D-R4.PR-7.1: a
     # workload with no first-boot secrets to deliver never reads a Secret).
     assert entry.stateful.secret_ref == nil
+    assert entry.stateful.interruptible_bank == false
+  end
+
+  test "stateful class: interruptibleBank true is parsed onto the catalog entry (ADR 008)" do
+    table = unique_table()
+    agent = start_recorder()
+    cr = put_in(stateful_cr(), ["spec", "stateful", "interruptibleBank"], true)
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert {:ok, entry} = WorkloadCatalog.fetch(table, "scratch-postgres")
+    assert entry.stateful.interruptible_bank == true
+  end
+
+  test "stateful class: explicit interruptibleBank false parses to false (ADR 008)" do
+    table = unique_table()
+    agent = start_recorder()
+    cr = put_in(stateful_cr(), ["spec", "stateful", "interruptibleBank"], false)
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+    assert {:ok, entry} = WorkloadCatalog.fetch(table, "scratch-postgres")
+    assert entry.stateful.interruptible_bank == false
   end
 
   test "stateful class missing spec.stateful is Ready=False/StatefulSpecMissing, not cataloged" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.90
+      targetRevision: 0.1.91
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -133,6 +133,21 @@ type Driver struct {
 
 	mu   sync.Mutex
 	live map[string]*instance // handle ID -> instance
+	// checkpoints holds in-flight interruptible-bank checkpoints (ADR embervm/008),
+	// keyed by the opaque token CheckpointStateful returns: a PAUSED-but-not-
+	// destroyed VM plus its temp snapshot, awaiting a commit or abort. Guarded by mu.
+	checkpoints map[string]*statefulCheckpoint
+}
+
+// statefulCheckpoint is one paused-awaiting-resolve stateful VM (ADR embervm/008):
+// its live handle, the bundle ref a commit will publish under, the volume
+// generation stamped at pause time, and the temp dir (OUTSIDE stateful/) holding
+// the not-yet-published snapfile + memfile.
+type statefulCheckpoint struct {
+	handle      substrate.Handle
+	snapshotRef string
+	generation  uint64
+	tmpDir      string
 }
 
 type instance struct {
@@ -155,10 +170,11 @@ func New(cfg Config, launcher Launcher, newClient func(socketPath string) fcAPI)
 		newClient = func(sock string) fcAPI { return fcclient.New(sock) }
 	}
 	d := &Driver{
-		cfg:       cfg.withDefaults(),
-		launcher:  launcher,
-		newClient: newClient,
-		live:      make(map[string]*instance),
+		cfg:         cfg.withDefaults(),
+		launcher:    launcher,
+		newClient:   newClient,
+		live:        make(map[string]*instance),
+		checkpoints: make(map[string]*statefulCheckpoint),
 	}
 	if cfg.BaseRootfsPath != "" {
 		if cfg.Provisioner == "devmapper" {
@@ -1352,6 +1368,180 @@ func (d *Driver) SnapshotStateful(ctx context.Context, h substrate.Handle, snaps
 		Arch:      d.cfg.Arch,
 		SizeBytes: bundleSize(snapPath, memPath),
 	}, nil
+}
+
+// ---- interruptible-bank checkpoint/resolve (ADR embervm/008) ----------------
+//
+// The two-phase, abortable bank splits SnapshotStateful's pause-snapshot-destroy
+// into a CHECKPOINT (pause + snapshot to a temp OUTSIDE stateful/, VM left paused)
+// and a RESOLVE that either COMMITs (publish the temp as the bundle, destroy) or
+// ABORTs (delete the temp, resume). The atomic SnapshotStateful above is UNCHANGED
+// and remains the default; these are used only for a workload that opted in.
+
+// CheckpointsDir holds in-flight interruptible-bank checkpoint temps, a SIBLING of
+// stateful/ (not a child), so ScanStatefulBundles (which globs stateful/*/snapfile)
+// can NEVER mistake a temp for a committed bundle (ADR embervm/008, guarantee 1).
+// GCStatefulCheckpoints sweeps it on start. Callers own its 0700 daemon-ownership.
+func (d *Driver) CheckpointsDir() string {
+	return filepath.Join(d.cfg.SnapshotRoot, "stateful-checkpoints")
+}
+
+func (d *Driver) checkpointTmpDir(token string) string {
+	return filepath.Join(d.CheckpointsDir(), token)
+}
+
+// CheckpointStateful is phase one of the interruptible bank (ADR embervm/008): it
+// PAUSES a live stateful VM and writes its snapshot to a temp dir OUTSIDE the
+// stateful/ bundle dir (invisible to ScanStatefulBundles), leaving the VM PAUSED
+// and resumable. It publishes NO bundle and does NOT Release. The returned opaque
+// token is passed to ResolveStatefulCommit (publish the temp as the bundle,
+// destroy) or ResolveStatefulAbort (delete the temp, resume). On a pause/snapshot
+// failure the VM is resumed best-effort and the temp removed, so a FAILED
+// checkpoint leaves the VM live rather than stranded paused.
+func (d *Driver) CheckpointStateful(ctx context.Context, h substrate.Handle, snapshotRef string, generation uint64) (string, error) {
+	if snapshotRef == "" {
+		return "", fmt.Errorf("driver: CheckpointStateful requires a snapshot_ref")
+	}
+	inst := d.get(h.ID)
+	if inst == nil {
+		return "", fmt.Errorf("driver: checkpoint-stateful of unknown handle %q", h.ID)
+	}
+	token := newID("ckpt")
+	tmpDir := d.checkpointTmpDir(token)
+	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
+		return "", fmt.Errorf("driver: mkdir checkpoint temp: %w", err)
+	}
+	snapPath := filepath.Join(tmpDir, "snapfile")
+	memPath := filepath.Join(tmpDir, "memfile")
+	if err := inst.client.Pause(ctx); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return "", fmt.Errorf("driver: pause stateful for checkpoint: %w", err)
+	}
+	if err := inst.client.CreateSnapshot(ctx, fcclient.SnapshotCreate{SnapshotPath: snapPath, MemFilePath: memPath}); err != nil {
+		// The VM is paused; resume it so a checkpoint FAILURE leaves it live
+		// (mirrors serving's resume-on-snapshot-failure), then discard the temp.
+		_ = inst.client.Resume(ctx)
+		_ = os.RemoveAll(tmpDir)
+		return "", fmt.Errorf("driver: create checkpoint snapshot: %w", err)
+	}
+	d.mu.Lock()
+	d.checkpoints[token] = &statefulCheckpoint{handle: h, snapshotRef: snapshotRef, generation: generation, tmpDir: tmpDir}
+	d.mu.Unlock()
+	return token, nil
+}
+
+// takeCheckpoint atomically fetches and REMOVES a checkpoint by token. Removing on
+// lookup is the driver's half of single-resolve (ADR embervm/008): a second
+// resolve of the same token finds nothing and errors.
+func (d *Driver) takeCheckpoint(token string) (*statefulCheckpoint, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	cp, ok := d.checkpoints[token]
+	if ok {
+		delete(d.checkpoints, token)
+	}
+	return cp, ok
+}
+
+// ResolveStatefulCommit is phase two (COMMIT) of the interruptible bank: it
+// publishes the checkpoint's temp snapshot as the workload's bundle (memfile, the
+// generation sidecar, then the snapfile LAST per the completeness discipline),
+// Releases (destroys) the paused VM, and returns the bundle ref. It consumes the
+// token (single-resolve). A commit is destructive: on any publish failure the
+// paused VM is torn down and any half-published bundle dir removed, so a failed
+// commit never leaves a paused handle or a partial bundle behind.
+func (d *Driver) ResolveStatefulCommit(ctx context.Context, token string) (substrate.SnapshotRef, error) {
+	cp, ok := d.takeCheckpoint(token)
+	if !ok {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: ResolveStatefulCommit of unknown checkpoint token %q", token)
+	}
+	ref := cp.snapshotRef
+	committed := false
+	defer func() {
+		if !committed {
+			_ = d.Release(ctx, cp.handle)
+			_ = os.RemoveAll(cp.tmpDir)
+			_ = d.RemoveStatefulBundle(ref)
+		}
+	}()
+	if err := os.MkdirAll(d.statefulDir(ref), 0o700); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: mkdir stateful bundle: %w", err)
+	}
+	snapPath := d.statefulSnapfile(ref)
+	memPath := d.statefulMemfile(ref)
+	// Publish memfile first, then the generation sidecar, then the snapfile LAST,
+	// so a crash mid-publish leaves NO snapfile and the rescan skips the dir
+	// (identical to SnapshotStateful's publish-last discipline).
+	if err := os.Rename(filepath.Join(cp.tmpDir, "memfile"), memPath); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: publish stateful memfile: %w", err)
+	}
+	if err := os.WriteFile(d.statefulGenfile(ref), []byte(strconv.FormatUint(cp.generation, 10)), 0o600); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: write stateful generation sidecar: %w", err)
+	}
+	if err := os.Rename(filepath.Join(cp.tmpDir, "snapfile"), snapPath); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: publish stateful snapfile: %w", err)
+	}
+	committed = true
+	_ = os.RemoveAll(cp.tmpDir)
+	// The bundle is published; tear the now-banked VM down best-effort (a Release
+	// error here does not invalidate the bundle, mirroring the reap discipline).
+	_ = d.Release(ctx, cp.handle)
+	return substrate.SnapshotRef{
+		ID:        ref,
+		Node:      d.cfg.Node,
+		Arch:      d.cfg.Arch,
+		SizeBytes: bundleSize(snapPath, memPath),
+	}, nil
+}
+
+// ResolveStatefulAbort is phase two (ABORT) of the interruptible bank: it DELETES
+// the checkpoint's temp snapshot and RESUMES the paused VM, returning it to
+// serving on the SAME process image (genuinely hot, no relight). It consumes the
+// token (single-resolve). The generation bump the ADR requires BEFORE this resume
+// is the CALLER's (the server bumps the volume ledger before invoking abort), so
+// the on-disk order is bump, delete temp, resume (guarantees 2 and 3): a temp that
+// survives a crash then implies the resume was never issued, and any post-resume
+// write is witnessed by the bumped generation. If Resume fails the VM is torn down
+// (the dead-handle discipline) and the error surfaced so the caller falls back to
+// a committed-destroy on the next cycle rather than wedging on a stranded VM.
+func (d *Driver) ResolveStatefulAbort(ctx context.Context, token string) error {
+	cp, ok := d.takeCheckpoint(token)
+	if !ok {
+		return fmt.Errorf("driver: ResolveStatefulAbort of unknown checkpoint token %q", token)
+	}
+	// Delete the temp BEFORE resuming (guarantee 3): a surviving temp after a crash
+	// then implies the resume was never issued, so the volume is still
+	// snapshot-consistent.
+	_ = os.RemoveAll(cp.tmpDir)
+	inst := d.get(cp.handle.ID)
+	if inst == nil {
+		return fmt.Errorf("driver: ResolveStatefulAbort: paused instance %q for token %q is gone", cp.handle.ID, token)
+	}
+	if err := inst.client.Resume(ctx); err != nil {
+		_ = d.Release(ctx, cp.handle)
+		return fmt.Errorf("driver: resume on abort: %w", err)
+	}
+	return nil
+}
+
+// GCStatefulCheckpoints removes every orphaned interruptible-bank checkpoint temp
+// on startup (ADR embervm/008): a noded restart kills every paused checkpoint VM,
+// so its temp can never be resolved and is swept both for correctness (guarantee
+// 1's rescan-invisibility is only meaningful if orphans do not accumulate) and as
+// data-at-rest hygiene (a temp holds guest memory, possibly a first-boot secret).
+// Returns the count removed. Idempotent; an absent dir is a no-op.
+func (d *Driver) GCStatefulCheckpoints() int {
+	entries, err := os.ReadDir(d.CheckpointsDir())
+	if err != nil {
+		return 0
+	}
+	removed := 0
+	for _, e := range entries {
+		if err := os.RemoveAll(filepath.Join(d.CheckpointsDir(), e.Name())); err == nil {
+			removed++
+		}
+	}
+	return removed
 }
 
 // RestoreStateful launches a fresh Firecracker process and loads a banked

--- a/projects/embervm/noded/fcvm/driver/driver_test.go
+++ b/projects/embervm/noded/fcvm/driver/driver_test.go
@@ -801,3 +801,172 @@ func TestDriverScanGroupBundleSets(t *testing.T) {
 		t.Errorf("set-2 members = %v want [leader]", bySet["set-2"])
 	}
 }
+
+// ---- interruptible-bank checkpoint/resolve (ADR embervm/008) -----------------
+
+// statefulCheckpointHandle boots a live VM the checkpoint tests pause. Claim gives
+// a handle whose fake client answers Pause/CreateSnapshot/Resume over the socket,
+// which is all CheckpointStateful and the resolves need.
+func statefulCheckpointHandle(t *testing.T, d *Driver) substrate.Handle {
+	t.Helper()
+	h, err := d.Claim(context.Background(), substrate.ClaimSpec{ThreadID: "st-ckpt"})
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	return h
+}
+
+// TestDriverCheckpointCommit is the COMMIT half of the two-phase bank: a
+// checkpoint pauses (VM stays live, no bundle yet, temp written OUTSIDE stateful/)
+// and the commit publishes the temp as the bundle (snapfile+memfile+gen) and
+// destroys the VM.
+func TestDriverCheckpointCommit(t *testing.T) {
+	ctx := context.Background()
+	d := testDriver(t)
+	h := statefulCheckpointHandle(t, d)
+
+	token, err := d.CheckpointStateful(ctx, h, "state-commit", 7)
+	if err != nil {
+		t.Fatalf("CheckpointStateful: %v", err)
+	}
+	if token == "" {
+		t.Fatal("checkpoint should return a non-empty token")
+	}
+	// The VM is PAUSED, not destroyed, so it still counts as live.
+	if d.LiveCount() != 1 {
+		t.Fatalf("LiveCount after checkpoint = %d, want 1 (VM paused, not destroyed)", d.LiveCount())
+	}
+	// No bundle published yet, and the temp is OUTSIDE stateful/ (rescan-invisible).
+	if _, err := os.Stat(d.statefulSnapfile("state-commit")); !os.IsNotExist(err) {
+		t.Fatalf("no bundle snapfile should exist before commit, stat err=%v", err)
+	}
+	if len(d.ScanStatefulBundles()) != 0 {
+		t.Fatalf("ScanStatefulBundles must not see the checkpoint temp; got %d bundles", len(d.ScanStatefulBundles()))
+	}
+
+	ref, err := d.ResolveStatefulCommit(ctx, token)
+	if err != nil {
+		t.Fatalf("ResolveStatefulCommit: %v", err)
+	}
+	if ref.ID != "state-commit" || ref.Node != "node-4" || ref.Arch != "amd64" {
+		t.Fatalf("unexpected committed ref: %+v", ref)
+	}
+	if ref.SizeBytes == 0 {
+		t.Fatal("committed bundle SizeBytes should reflect the on-disk bundle")
+	}
+	for _, p := range []string{d.statefulSnapfile("state-commit"), d.statefulMemfile("state-commit"), d.statefulGenfile("state-commit")} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("committed bundle file %s missing: %v", p, err)
+		}
+	}
+	gen, _ := os.ReadFile(d.statefulGenfile("state-commit"))
+	if string(gen) != "7" {
+		t.Fatalf("gen sidecar = %q, want 7", string(gen))
+	}
+	// The VM was destroyed at commit, and the temp is gone.
+	if d.LiveCount() != 0 {
+		t.Fatalf("LiveCount after commit = %d, want 0 (VM destroyed)", d.LiveCount())
+	}
+	if _, err := os.Stat(d.checkpointTmpDir(token)); !os.IsNotExist(err) {
+		t.Fatalf("checkpoint temp should be gone after commit, stat err=%v", err)
+	}
+}
+
+// TestDriverCheckpointAbort is the ABORT half: the paused VM is resumed (stays
+// live, same process image) and NO bundle is published; the temp is deleted.
+func TestDriverCheckpointAbort(t *testing.T) {
+	ctx := context.Background()
+	d := testDriver(t)
+	h := statefulCheckpointHandle(t, d)
+
+	token, err := d.CheckpointStateful(ctx, h, "state-abort", 4)
+	if err != nil {
+		t.Fatalf("CheckpointStateful: %v", err)
+	}
+	if err := d.ResolveStatefulAbort(ctx, token); err != nil {
+		t.Fatalf("ResolveStatefulAbort: %v", err)
+	}
+	// Resumed, so still live; no bundle recorded; temp gone.
+	if d.LiveCount() != 1 {
+		t.Fatalf("LiveCount after abort = %d, want 1 (VM resumed)", d.LiveCount())
+	}
+	if _, err := os.Stat(d.statefulSnapfile("state-abort")); !os.IsNotExist(err) {
+		t.Fatalf("abort must publish no bundle, stat err=%v", err)
+	}
+	if _, err := os.Stat(d.checkpointTmpDir(token)); !os.IsNotExist(err) {
+		t.Fatalf("checkpoint temp should be gone after abort, stat err=%v", err)
+	}
+}
+
+// TestDriverResolveUnknownTokenErrors: a resolve of an unknown or already-resolved
+// token errors (the driver half of single-resolve).
+func TestDriverResolveUnknownTokenErrors(t *testing.T) {
+	ctx := context.Background()
+	d := testDriver(t)
+	if _, err := d.ResolveStatefulCommit(ctx, "ckpt-nope"); err == nil {
+		t.Fatal("commit of an unknown token should error")
+	}
+	if err := d.ResolveStatefulAbort(ctx, "ckpt-nope"); err == nil {
+		t.Fatal("abort of an unknown token should error")
+	}
+	// A second resolve of a consumed token also errors.
+	h := statefulCheckpointHandle(t, d)
+	token, err := d.CheckpointStateful(ctx, h, "state-once", 1)
+	if err != nil {
+		t.Fatalf("CheckpointStateful: %v", err)
+	}
+	if err := d.ResolveStatefulAbort(ctx, token); err != nil {
+		t.Fatalf("first abort: %v", err)
+	}
+	if err := d.ResolveStatefulAbort(ctx, token); err == nil {
+		t.Fatal("second resolve of a consumed token should error (single-resolve)")
+	}
+}
+
+// TestDriverGCStatefulCheckpoints sweeps orphaned temps (the noded-restart path),
+// and an abort followed by a fresh checkpoint+commit still yields a valid bundle
+// (no leaked temp state).
+func TestDriverGCStatefulCheckpointsAndReuse(t *testing.T) {
+	ctx := context.Background()
+	d := testDriver(t)
+
+	// An orphaned temp (a checkpoint whose noded died) is swept on start.
+	h := statefulCheckpointHandle(t, d)
+	token, err := d.CheckpointStateful(ctx, h, "state-orphan", 2)
+	if err != nil {
+		t.Fatalf("CheckpointStateful: %v", err)
+	}
+	if _, err := os.Stat(d.checkpointTmpDir(token)); err != nil {
+		t.Fatalf("temp should exist post-checkpoint: %v", err)
+	}
+	if n := d.GCStatefulCheckpoints(); n != 1 {
+		t.Fatalf("GCStatefulCheckpoints removed %d, want 1", n)
+	}
+	if _, err := os.Stat(d.checkpointTmpDir(token)); !os.IsNotExist(err) {
+		t.Fatalf("temp should be swept by GC, stat err=%v", err)
+	}
+	if n := d.GCStatefulCheckpoints(); n != 0 {
+		t.Fatalf("GCStatefulCheckpoints on a clean dir removed %d, want 0", n)
+	}
+
+	// Abort, then a fresh checkpoint+commit still banks a valid bundle.
+	h2 := statefulCheckpointHandle(t, d)
+	tok2, err := d.CheckpointStateful(ctx, h2, "state-reuse", 5)
+	if err != nil {
+		t.Fatalf("CheckpointStateful reuse: %v", err)
+	}
+	if err := d.ResolveStatefulAbort(ctx, tok2); err != nil {
+		t.Fatalf("abort reuse: %v", err)
+	}
+	tok3, err := d.CheckpointStateful(ctx, h2, "state-reuse", 6)
+	if err != nil {
+		t.Fatalf("second CheckpointStateful reuse: %v", err)
+	}
+	ref, err := d.ResolveStatefulCommit(ctx, tok3)
+	if err != nil {
+		t.Fatalf("commit reuse: %v", err)
+	}
+	if ref.ID != "state-reuse" || ref.SizeBytes == 0 {
+		t.Fatalf("reuse commit produced an invalid bundle: %+v", ref)
+	}
+}

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -196,6 +196,12 @@ type Server struct {
 	// newTCPProber builds the per-VM TCP-connect health prober from config
 	// (R4). Overridable in tests, mirroring newProber.
 	newTCPProber func() *serving.TCPProber
+	// statefulResolveTimeout is noded's own deadline T for an interruptible-bank
+	// CHECKPOINT left unresolved (ADR embervm/008): after it, noded auto-aborts
+	// (resume, discard temp) so a dead control plane cannot pin a paused VM's cap
+	// slot and memory forever. Defaulted in New from defaultStatefulResolveTimeout;
+	// tests shrink it to exercise the auto-abort without waiting.
+	statefulResolveTimeout time.Duration
 	// newGroupTCPProber builds the per-member TCP-connect health prober (R5).
 	// Overridable in tests, mirroring newTCPProber.
 	newGroupTCPProber func() *serving.TCPProber
@@ -356,6 +362,7 @@ func New(opts Options) *Server {
 		s.groupClock = &realGroupClock{}
 	}
 	s.memHeadroom = readMemHeadroomMib
+	s.statefulResolveTimeout = defaultStatefulResolveTimeout
 	// Re-seed the serving-images inventory from disk so a daemon restart re-discovers
 	// the cold-boot handler artifacts it built before (mirroring the banked-snapshot
 	// rescan). Only when serving is configured; task/session-only builds skip it.
@@ -1370,13 +1377,15 @@ func (s *Server) statefulVMsStatus() []*nodev1.StatefulVm {
 			ip, port = s.servingNet.Endpoint(net.ParseIP(e.ip), e.port)
 		}
 		out = append(out, &nodev1.StatefulVm{
-			VmId:            e.vmID,
-			Workload:        e.workload,
-			Ip:              ip,
-			Port:            port,
-			Healthy:         e.healthy,
-			Generation:      e.generation,
-			LastProbeUnixMs: e.lastProbeUnixMs,
+			VmId:              e.vmID,
+			Workload:          e.workload,
+			Ip:                ip,
+			Port:              port,
+			Healthy:           e.healthy,
+			Generation:        e.generation,
+			LastProbeUnixMs:   e.lastProbeUnixMs,
+			CheckpointPending: e.checkpointPending,
+			CheckpointToken:   e.checkpointToken,
 		})
 	}
 	return out
@@ -1871,6 +1880,13 @@ func (s *Server) ReconcileStatefulFromDisk() {
 		} else if err := os.Chmod(root, 0o700); err != nil {
 			s.logger.Warn("noded: chmod stateful dir 0700", "root", root, "err", err)
 		}
+	}
+	// Sweep any orphaned interruptible-bank checkpoint temps (ADR embervm/008): a
+	// restart killed every paused checkpoint VM, so its temp can never be resolved.
+	// Done before the bundle rescan so a stale temp is gone before anything reads
+	// the stateful tree.
+	if gc := s.statefulDriver.GCStatefulCheckpoints(); gc > 0 {
+		s.logger.Info("noded: swept orphaned stateful checkpoint temps", "count", gc)
 	}
 	bundles := s.statefulDriver.ScanStatefulBundles()
 	for _, b := range bundles {

--- a/projects/embervm/noded/server/stateful.go
+++ b/projects/embervm/noded/server/stateful.go
@@ -407,8 +407,13 @@ func (s *Server) stopStatefulCheckpoint(ctx context.Context, vmID string) (*node
 	}
 	// Arm the resolve-timeout auto-abort: a dead control plane must not leave the
 	// VM paused (burning a cap slot and its memory) with every connection parked.
+	// Store the token FIRST, then arm the auto-abort timer: a timer that fires
+	// immediately (a very short resolve timeout) then always finds the token set,
+	// so its auto-abort works instead of no-opping and leaving the checkpoint
+	// without a backstop.
+	s.statefulVMs.markCheckpointed(vmID, token)
 	timer := time.AfterFunc(s.statefulResolveTimeout, func() { s.autoAbortCheckpoint(vmID, token) })
-	s.statefulVMs.markCheckpointed(vmID, token, timer)
+	s.statefulVMs.setCheckpointTimer(vmID, timer)
 	s.signalChange()
 	return &nodev1.StopStatefulResponse{CheckpointToken: token, Generation: e.generation}, nil
 }

--- a/projects/embervm/noded/server/stateful.go
+++ b/projects/embervm/noded/server/stateful.go
@@ -354,12 +354,22 @@ func (s *Server) waitStatefulReady(ctx context.Context, ip net.IP, port uint32, 
 	return lastErr // nosemgrep: no-bare-error-return
 }
 
+// defaultStatefulResolveTimeout is noded's deadline T for an unresolved
+// interruptible-bank checkpoint (ADR embervm/008 open question 2): long enough
+// that a healthy control plane always resolves well within it, short enough that a
+// DEAD control plane cannot pin a paused VM's live-VM cap slot and memory for more
+// than this. A tuning knob to refine alongside the flap guard.
+const defaultStatefulResolveTimeout = 30 * time.Second
+
 // StopStateful tears down a live stateful VM. BANK pauses it, writes a
 // stateful snapshot stamped with the CURRENT volume generation, evicts any
 // PRIOR bundle for the workload (at most one banked bundle per workload),
 // detaches the volume, destroys the VM, and returns {snapshot_ref, generation,
 // size_bytes}. DESTROY tears the VM down with no snapshot and detaches the
-// volume. Either mode releases the tap.
+// volume. CHECKPOINT is phase one of the interruptible bank (ADR embervm/008): it
+// PAUSES the VM and snapshots to a temp, leaving it paused and resumable, and
+// returns a checkpoint_token for a later ResolveStateful. Either terminal mode
+// releases the tap.
 func (s *Server) StopStateful(ctx context.Context, req *nodev1.StopStatefulRequest) (*nodev1.StopStatefulResponse, error) {
 	if s.servingNet == nil || s.statefulDriver == nil || s.volumes == nil {
 		return nil, status.Error(codes.Unimplemented, "noded: stateful not configured")
@@ -370,8 +380,147 @@ func (s *Server) StopStateful(ctx context.Context, req *nodev1.StopStatefulReque
 		return s.stopStatefulBank(ctx, vmID)
 	case nodev1.StopStatefulMode_STOP_STATEFUL_MODE_DESTROY:
 		return s.stopStatefulDestroy(vmID)
+	case nodev1.StopStatefulMode_STOP_STATEFUL_MODE_CHECKPOINT:
+		return s.stopStatefulCheckpoint(ctx, vmID)
 	default:
-		return nil, status.Error(codes.InvalidArgument, "noded: StopStateful mode must be BANK or DESTROY")
+		return nil, status.Error(codes.InvalidArgument, "noded: StopStateful mode must be BANK, DESTROY, or CHECKPOINT")
+	}
+}
+
+// stopStatefulCheckpoint is phase one of the interruptible bank (ADR embervm/008):
+// it CHECKPOINTs a live stateful VM (pause + snapshot to a rescan-invisible temp,
+// VM left paused) and arms noded's resolve-timeout auto-abort, returning the
+// checkpoint token. It reuses beginStop's stop-serialization guard, so a second
+// CHECKPOINT (or a BANK) of the same VM is FAILED_PRECONDITION. On a checkpoint
+// failure the driver leaves the VM live (resumed), so the stop guard is cleared
+// and the VM returns to serving rather than being pinned.
+func (s *Server) stopStatefulCheckpoint(ctx context.Context, vmID string) (*nodev1.StopStatefulResponse, error) {
+	e, ok := s.statefulVMs.beginStop(vmID)
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: stateful vm %q not checkpointable (unknown or a stop is already in flight)", vmID)
+	}
+	snapshotRef := newID("state")
+	token, err := s.statefulDriver.CheckpointStateful(ctx, e.handle, snapshotRef, e.generation)
+	if err != nil {
+		s.statefulVMs.clearInFlight(vmID)
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: checkpoint stateful vm %q: %v", vmID, err)
+	}
+	// Arm the resolve-timeout auto-abort: a dead control plane must not leave the
+	// VM paused (burning a cap slot and its memory) with every connection parked.
+	timer := time.AfterFunc(s.statefulResolveTimeout, func() { s.autoAbortCheckpoint(vmID, token) })
+	s.statefulVMs.markCheckpointed(vmID, token, timer)
+	s.signalChange()
+	return &nodev1.StopStatefulResponse{CheckpointToken: token, Generation: e.generation}, nil
+}
+
+// ResolveStateful is phase two of the interruptible bank (ADR embervm/008): it
+// resolves a VM left paused by StopStateful(CHECKPOINT). COMMIT publishes the
+// checkpoint's temp as the workload's bundle and destroys the VM; ABORT bumps the
+// volume generation, deletes the temp, and resumes the VM (hot). claimResolve is
+// the single-resolve gate: exactly one of {this call, the resolve-timeout
+// auto-abort} wins, so a COMMIT arriving after the auto-abort is FAILED_PRECONDITION.
+func (s *Server) ResolveStateful(ctx context.Context, req *nodev1.ResolveStatefulRequest) (*nodev1.ResolveStatefulResponse, error) {
+	if s.servingNet == nil || s.statefulDriver == nil || s.volumes == nil {
+		return nil, status.Error(codes.Unimplemented, "noded: stateful not configured")
+	}
+	// Validate the mode BEFORE claiming the resolve, so an invalid mode never
+	// consumes the single-resolve token or strands the paused VM.
+	switch req.GetMode() {
+	case nodev1.ResolveMode_RESOLVE_MODE_COMMIT, nodev1.ResolveMode_RESOLVE_MODE_ABORT:
+	default:
+		return nil, status.Error(codes.InvalidArgument, "noded: ResolveStateful mode must be COMMIT or ABORT")
+	}
+	vmID := req.GetVmId()
+	token := req.GetCheckpointToken()
+	e, ok := s.statefulVMs.claimResolve(vmID, token)
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: no in-flight checkpoint for vm %q with the given token (unknown or already resolved)", vmID)
+	}
+	if req.GetMode() == nodev1.ResolveMode_RESOLVE_MODE_COMMIT {
+		return s.commitCheckpoint(ctx, e, token)
+	}
+	return s.abortCheckpoint(ctx, e, token)
+}
+
+// commitCheckpoint publishes the checkpoint's temp as the workload's bundle and
+// tears the (already driver-destroyed) VM's tap + volume down, then records the
+// bundle (evicting any prior, D-R4 one-bundle-per-workload). The tail mirrors
+// stopStatefulBank's bundle bookkeeping exactly. The caller has already claimed
+// the resolve (token cleared, timer stopped).
+func (s *Server) commitCheckpoint(ctx context.Context, e *statefulEntry, token string) (*nodev1.ResolveStatefulResponse, error) {
+	ref, err := s.statefulDriver.ResolveStatefulCommit(ctx, token)
+	if err != nil {
+		// The commit tore the paused VM down (a commit is destructive); drop the
+		// entry and release its tap + volume so the workload cold-boots next.
+		s.statefulVMs.remove(e.vmID)
+		e.probe.Stop()
+		s.servingNet.ReleaseTap(ctx, e.ip)
+		s.volumes.Detach(e.workload)
+		s.signalChange()
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: commit checkpoint for vm %q: %v", e.vmID, err)
+	}
+	// The driver destroyed the VM at commit; stop the probe, drop the entry, and
+	// release the tap + detach the volume (the FC handle is already released).
+	e.probe.Stop()
+	s.statefulVMs.remove(e.vmID)
+	s.servingNet.ReleaseTap(ctx, e.ip)
+	s.volumes.Detach(e.workload)
+	if prior, ok := s.statefulBundles.byWorkload(e.workload); ok && prior.snapshotRef != ref.ID {
+		_ = s.statefulDriver.RemoveStatefulBundle(prior.snapshotRef)
+		s.statefulBundles.remove(prior.snapshotRef)
+	}
+	s.statefulBundles.add(statefulBundleEntry{
+		snapshotRef:     ref.ID,
+		workload:        e.workload,
+		generation:      e.generation,
+		sizeBytes:       ref.SizeBytes,
+		createdAtUnixMs: time.Now().UnixMilli(),
+	})
+	s.signalChange()
+	return &nodev1.ResolveStatefulResponse{SnapshotRef: ref.ID, Generation: e.generation, SizeBytes: uint64(ref.SizeBytes)}, nil
+}
+
+// abortCheckpoint returns a checkpointed VM to serving on the same process image.
+// Order (ADR embervm/008): bump the volume generation, THEN delete the temp +
+// resume (the driver does the latter two). A bump failure is not fatal:
+// delete-before-resume alone closes the crash leak (guarantee 3), so it logs and
+// proceeds on the current generation rather than wedging. If the resume itself
+// fails the driver destroyed the VM, so this degrades to a next-wake cold boot.
+// The caller has already claimed the resolve.
+func (s *Server) abortCheckpoint(ctx context.Context, e *statefulEntry, token string) (*nodev1.ResolveStatefulResponse, error) {
+	gen, bumpErr := s.volumes.BumpGeneration(e.workload)
+	if bumpErr != nil {
+		s.logger.Warn("noded: bump generation on checkpoint abort failed; proceeding (delete-before-resume still protects)", "workload", e.workload, "err", bumpErr)
+		gen = e.generation
+	}
+	if err := s.statefulDriver.ResolveStatefulAbort(ctx, token); err != nil {
+		// Resume failed; the driver tore the VM down (dead-handle discipline).
+		// Degrade to a next-wake cold boot: drop the entry, release tap + volume.
+		s.statefulVMs.remove(e.vmID)
+		e.probe.Stop()
+		s.servingNet.ReleaseTap(ctx, e.ip)
+		s.volumes.Detach(e.workload)
+		s.signalChange()
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: abort checkpoint for vm %q (resume failed, VM destroyed): %v", e.vmID, err)
+	}
+	// Resumed hot: record the bumped generation, clear the checkpoint + stop guard.
+	s.statefulVMs.resumeFromCheckpoint(e.vmID, gen)
+	s.signalChange()
+	return &nodev1.ResolveStatefulResponse{}, nil
+}
+
+// autoAbortCheckpoint is the resolve-timeout backstop (ADR embervm/008): if a
+// CHECKPOINT is left unresolved for statefulResolveTimeout, noded aborts it
+// itself (resume, discard temp) so a dead control plane cannot pin a paused VM.
+// It claims the resolve first, so it no-ops if the control plane already resolved.
+func (s *Server) autoAbortCheckpoint(vmID, token string) {
+	e, ok := s.statefulVMs.claimResolve(vmID, token)
+	if !ok {
+		return // already resolved by the control plane
+	}
+	s.logger.Warn("noded: interruptible-bank checkpoint resolve-timeout, auto-aborting", "vm_id", vmID, "workload", e.workload)
+	if _, err := s.abortCheckpoint(context.Background(), e, token); err != nil {
+		s.logger.Warn("noded: checkpoint auto-abort failed", "vm_id", vmID, "err", err)
 	}
 }
 

--- a/projects/embervm/noded/server/stateful_registry.go
+++ b/projects/embervm/noded/server/stateful_registry.go
@@ -168,10 +168,12 @@ func (r *statefulRegistry) clearInFlight(id string) {
 }
 
 // markCheckpointed records that a CHECKPOINT has paused this VM awaiting a
-// resolve (ADR embervm/008) and arms its resolve-timeout auto-abort timer. The
-// entry stays inFlight (beginStop set it) so it is neither bankable nor
-// checkpointable again until the resolve lands.
-func (r *statefulRegistry) markCheckpointed(id, token string, timer *time.Timer) bool {
+// resolve (ADR embervm/008). The entry stays inFlight (beginStop set it) so it is
+// neither bankable nor checkpointable again until the resolve lands. The
+// resolve-timeout auto-abort timer is armed SEPARATELY (setCheckpointTimer) AFTER
+// this, so a timer that fires immediately always finds the token already set and
+// its auto-abort works rather than no-opping.
+func (r *statefulRegistry) markCheckpointed(id, token string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	e := r.vms[id]
@@ -179,8 +181,23 @@ func (r *statefulRegistry) markCheckpointed(id, token string, timer *time.Timer)
 		return false
 	}
 	e.checkpointToken = token
-	e.checkpointTimer = timer
 	return true
+}
+
+// setCheckpointTimer installs the resolve-timeout auto-abort timer on a
+// checkpoint-pending entry. Called right after markCheckpointed so the token is
+// already set when the timer can first fire. If the entry vanished or was already
+// resolved (token cleared by a racing claimResolve) between the two calls, the
+// timer is stopped and not installed, so it never fires on a resolved entry.
+func (r *statefulRegistry) setCheckpointTimer(id string, timer *time.Timer) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e := r.vms[id]
+	if e == nil || e.checkpointToken == "" {
+		timer.Stop()
+		return
+	}
+	e.checkpointTimer = timer
 }
 
 // claimResolve is the node's single-resolve gate: it returns the entry ONLY if it

--- a/projects/embervm/noded/server/stateful_registry.go
+++ b/projects/embervm/noded/server/stateful_registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/jomcgi/homelab/projects/embervm/noded/serving"
 	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
@@ -32,6 +33,23 @@ type statefulDriver interface {
 	// stateful bundle stamped with the given volume generation; does not resume
 	// (the caller Releases). Mirrors SnapshotServing plus the generation stamp.
 	SnapshotStateful(ctx context.Context, h substrate.Handle, snapshotRef string, generation uint64) (substrate.SnapshotRef, error)
+	// CheckpointStateful is phase one of the interruptible bank (ADR embervm/008):
+	// it pauses a live stateful VM and writes its snapshot to a temp OUTSIDE the
+	// stateful/ bundle dir, leaving the VM PAUSED and resumable (no bundle
+	// published, no Release), and returns an opaque token for the resolve.
+	CheckpointStateful(ctx context.Context, h substrate.Handle, snapshotRef string, generation uint64) (string, error)
+	// ResolveStatefulCommit publishes a checkpoint's temp as the workload's bundle
+	// (snapfile last) and DESTROYS the paused VM, returning the bundle ref. It
+	// consumes the token (single-resolve).
+	ResolveStatefulCommit(ctx context.Context, token string) (substrate.SnapshotRef, error)
+	// ResolveStatefulAbort deletes a checkpoint's temp and RESUMES the paused VM
+	// (same process image, hot). It consumes the token (single-resolve). The
+	// caller bumps the volume generation BEFORE calling this (bump, delete, resume).
+	ResolveStatefulAbort(ctx context.Context, token string) error
+	// GCStatefulCheckpoints sweeps orphaned interruptible-bank checkpoint temps on
+	// startup (a restart kills every paused checkpoint VM), returning the count
+	// removed. Idempotent.
+	GCStatefulCheckpoints() int
 	// RestoreStateful launches a fresh VM from a banked stateful bundle and
 	// resumes it, WITH the NIC captured at bank time. volumeDiskPath is the
 	// workload's volume file the caller intends this restored VM to hold (see
@@ -79,6 +97,16 @@ type statefulEntry struct {
 	// probe is the running TCP-connect health-probe loop for this VM.
 	probe *serving.ProbeHandle
 
+	// checkpointToken is set (under the registry lock) while an interruptible-bank
+	// CHECKPOINT has this VM PAUSED awaiting a ResolveStateful (ADR embervm/008);
+	// "" for a normally-serving VM. checkpointTimer arms noded's resolve-timeout
+	// auto-abort (a dead control plane must not pin a paused VM forever); it is
+	// Stopped when a resolve is claimed. Both are guarded by the registry mu (not
+	// the entry mu), so snapshot() can read the checkpoint state under the one lock
+	// it already holds.
+	checkpointToken string
+	checkpointTimer *time.Timer
+
 	mu       sync.Mutex // guards inFlight
 	inFlight bool
 }
@@ -124,6 +152,75 @@ func (r *statefulRegistry) beginStop(id string) (*statefulEntry, bool) {
 	return e, true
 }
 
+// clearInFlight releases the stop-serialization guard set by beginStop without
+// removing the entry, so a VM whose CHECKPOINT failed returns to serving (still
+// live, still probed) rather than being wrongly pinned as stop-in-flight.
+func (r *statefulRegistry) clearInFlight(id string) {
+	r.mu.Lock()
+	e := r.vms[id]
+	r.mu.Unlock()
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	e.inFlight = false
+	e.mu.Unlock()
+}
+
+// markCheckpointed records that a CHECKPOINT has paused this VM awaiting a
+// resolve (ADR embervm/008) and arms its resolve-timeout auto-abort timer. The
+// entry stays inFlight (beginStop set it) so it is neither bankable nor
+// checkpointable again until the resolve lands.
+func (r *statefulRegistry) markCheckpointed(id, token string, timer *time.Timer) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e := r.vms[id]
+	if e == nil {
+		return false
+	}
+	e.checkpointToken = token
+	e.checkpointTimer = timer
+	return true
+}
+
+// claimResolve is the node's single-resolve gate: it returns the entry ONLY if it
+// is still checkpoint-pending with the given token, and atomically clears the
+// token and stops the timer so a concurrent resolve (the control plane vs the
+// auto-abort timer) loses the race. A COMMIT arriving after the timeout auto-abort
+// already claimed the resolve gets (nil, false), mapped to FAILED_PRECONDITION.
+func (r *statefulRegistry) claimResolve(id, token string) (*statefulEntry, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e := r.vms[id]
+	if e == nil || e.checkpointToken == "" || e.checkpointToken != token {
+		return nil, false
+	}
+	if e.checkpointTimer != nil {
+		e.checkpointTimer.Stop()
+		e.checkpointTimer = nil
+	}
+	e.checkpointToken = ""
+	return e, true
+}
+
+// resumeFromCheckpoint returns a checkpoint-aborted VM to serving: it updates the
+// generation to the post-abort bump and clears the stop-in-flight guard (the
+// token was already cleared by claimResolve). The probe kept running across the
+// pause, so no probe restart is needed.
+func (r *statefulRegistry) resumeFromCheckpoint(id string, newGeneration uint64) {
+	r.mu.Lock()
+	e := r.vms[id]
+	if e != nil {
+		e.generation = newGeneration
+	}
+	r.mu.Unlock()
+	if e != nil {
+		e.mu.Lock()
+		e.inFlight = false
+		e.mu.Unlock()
+	}
+}
+
 // remove deletes an id from the map and returns its entry (nil if absent).
 func (r *statefulRegistry) remove(id string) *statefulEntry {
 	r.mu.Lock()
@@ -158,6 +255,10 @@ type statefulView struct {
 	healthy         bool
 	lastProbeUnixMs int64
 	generation      uint64
+	// checkpointPending + checkpointToken report a VM PAUSED awaiting a resolve
+	// (ADR embervm/008) so a restarted control plane adopts and resolves it.
+	checkpointPending bool
+	checkpointToken   string
 }
 
 // snapshot returns a copy of every live stateful VM including its current
@@ -168,11 +269,13 @@ func (r *statefulRegistry) snapshot() []statefulView {
 	out := make([]statefulView, 0, len(r.vms))
 	for _, e := range r.vms {
 		v := statefulView{
-			vmID:       e.vmID,
-			workload:   e.workload,
-			ip:         e.ip.String(),
-			port:       e.port,
-			generation: e.generation,
+			vmID:              e.vmID,
+			workload:          e.workload,
+			ip:                e.ip.String(),
+			port:              e.port,
+			generation:        e.generation,
+			checkpointPending: e.checkpointToken != "",
+			checkpointToken:   e.checkpointToken,
 		}
 		if e.probe != nil {
 			res := e.probe.Result()

--- a/projects/embervm/noded/server/stateful_test.go
+++ b/projects/embervm/noded/server/stateful_test.go
@@ -36,12 +36,24 @@ type fakeStatefulDriver struct {
 	lastVolMount string
 	claimCount   int
 	lastMmdsEnv  map[string]string
+	// checkpoints maps a checkpoint token -> the pending checkpoint (ADR 008). A
+	// checkpointed VM stays live (paused). failCheckpoint / failResume script the
+	// failure paths.
+	checkpoints    map[string]fakeCheckpoint
+	failCheckpoint error
+	failResume     error
+}
+
+type fakeCheckpoint struct {
+	snapshotRef string
+	generation  uint64
 }
 
 func newFakeStatefulDriver(dir string) *fakeStatefulDriver {
 	return &fakeStatefulDriver{
 		banked:      map[string]uint64{},
 		statefulDir: dir + "/stateful",
+		checkpoints: map[string]fakeCheckpoint{},
 	}
 }
 
@@ -95,6 +107,65 @@ func (f *fakeStatefulDriver) ScanStatefulBundles() []substrate.StatefulBundleInf
 }
 
 func (f *fakeStatefulDriver) StatefulDir() string { return f.statefulDir }
+
+// CheckpointStateful records a pending checkpoint and returns its token; the VM
+// stays live (paused), so `live` is unchanged (ADR 008 phase one).
+func (f *fakeStatefulDriver) CheckpointStateful(_ context.Context, _ substrate.Handle, snapshotRef string, generation uint64) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failCheckpoint != nil {
+		return "", f.failCheckpoint
+	}
+	token := "ckpt-" + snapshotRef
+	f.checkpoints[token] = fakeCheckpoint{snapshotRef: snapshotRef, generation: generation}
+	return token, nil
+}
+
+// ResolveStatefulCommit publishes the checkpoint as a banked bundle and DESTROYS
+// the VM (decrementing live, modeling the driver's internal Release), consuming
+// the token (single-resolve).
+func (f *fakeStatefulDriver) ResolveStatefulCommit(_ context.Context, token string) (substrate.SnapshotRef, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp, ok := f.checkpoints[token]
+	if !ok {
+		return substrate.SnapshotRef{}, status.Errorf(codes.FailedPrecondition, "unknown checkpoint token %q", token)
+	}
+	delete(f.checkpoints, token)
+	f.banked[cp.snapshotRef] = cp.generation
+	if f.live > 0 {
+		f.live--
+	}
+	return substrate.SnapshotRef{ID: cp.snapshotRef, SizeBytes: 4096}, nil
+}
+
+// ResolveStatefulAbort resumes the VM (live unchanged) and consumes the token. If
+// failResume is set it models the driver tearing the VM down on a resume failure.
+func (f *fakeStatefulDriver) ResolveStatefulAbort(_ context.Context, token string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.checkpoints[token]; !ok {
+		return status.Errorf(codes.FailedPrecondition, "unknown checkpoint token %q", token)
+	}
+	delete(f.checkpoints, token)
+	if f.failResume != nil {
+		if f.live > 0 {
+			f.live--
+		}
+		return f.failResume
+	}
+	return nil
+}
+
+// GCStatefulCheckpoints clears all pending checkpoints (a restart), returning the
+// count swept.
+func (f *fakeStatefulDriver) GCStatefulCheckpoints() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := len(f.checkpoints)
+	f.checkpoints = map[string]fakeCheckpoint{}
+	return n
+}
 
 func (f *fakeStatefulDriver) liveCount() int {
 	f.mu.Lock()
@@ -614,5 +685,262 @@ func TestReconcileStatefulFromDiskRediscoversBundles(t *testing.T) {
 	}
 	if len(ns.GetVolumes()) != 1 || ns.GetVolumes()[0].GetGeneration() != 1 {
 		t.Errorf("volumes = %+v want one volume at generation 1", ns.GetVolumes())
+	}
+}
+
+// ---- interruptible bank checkpoint/resolve (ADR embervm/008) -----------------
+
+// checkpointStateful CHECKPOINTs a running stateful VM and returns the response.
+func checkpointStateful(t *testing.T, s *Server, vmID, workload string) *nodev1.StopStatefulResponse {
+	t.Helper()
+	resp, err := s.StopStateful(context.Background(), &nodev1.StopStatefulRequest{
+		VmId:  vmID,
+		Mode:  nodev1.StopStatefulMode_STOP_STATEFUL_MODE_CHECKPOINT,
+		Trace: &nodev1.Trace{Workload: workload},
+	})
+	if err != nil {
+		t.Fatalf("StopStateful(checkpoint): %v", err)
+	}
+	return resp
+}
+
+func statefulVMStatus(t *testing.T, s *Server, vmID string) *nodev1.StatefulVm {
+	t.Helper()
+	ns, err := s.GetNodeStatus(context.Background(), &nodev1.GetNodeStatusRequest{NodeId: "node-4"})
+	if err != nil {
+		t.Fatalf("GetNodeStatus: %v", err)
+	}
+	for _, v := range ns.GetStatefulVms() {
+		if v.GetVmId() == vmID {
+			return v
+		}
+	}
+	return nil
+}
+
+// TestStatefulCheckpointReportsPending: a CHECKPOINT returns a token and leaves
+// the VM live and reported checkpoint_pending, not destroyed and not banked.
+func TestStatefulCheckpointReportsPending(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, _, fsd := newStatefulTestServer(t)
+	started := startFreshStateful(t, s, port, "wl-state")
+
+	ckpt := checkpointStateful(t, s, started.GetVmId(), "wl-state")
+	if ckpt.GetCheckpointToken() == "" {
+		t.Fatal("checkpoint must return a token")
+	}
+	if ckpt.GetGeneration() != 1 {
+		t.Fatalf("checkpoint generation = %d want 1", ckpt.GetGeneration())
+	}
+	if ckpt.GetSnapshotRef() != "" {
+		t.Fatalf("checkpoint publishes no bundle yet, got snapshot_ref %q", ckpt.GetSnapshotRef())
+	}
+	// The VM is paused, not destroyed, so it still counts as live.
+	if fsd.liveCount() != 1 {
+		t.Fatalf("live count after checkpoint = %d want 1 (paused, not destroyed)", fsd.liveCount())
+	}
+	v := statefulVMStatus(t, s, started.GetVmId())
+	if v == nil || !v.GetCheckpointPending() {
+		t.Fatalf("status should report the VM checkpoint_pending; got %+v", v)
+	}
+	if v.GetCheckpointToken() != ckpt.GetCheckpointToken() {
+		t.Fatalf("status checkpoint_token = %q want %q", v.GetCheckpointToken(), ckpt.GetCheckpointToken())
+	}
+}
+
+// TestStatefulResolveCommit: COMMIT publishes the bundle, destroys the VM, and
+// records the banked bundle stamped with the checkpoint generation.
+func TestStatefulResolveCommit(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, _, fsd := newStatefulTestServer(t)
+	started := startFreshStateful(t, s, port, "wl-state")
+	ckpt := checkpointStateful(t, s, started.GetVmId(), "wl-state")
+
+	resp, err := s.ResolveStateful(context.Background(), &nodev1.ResolveStatefulRequest{
+		VmId:            started.GetVmId(),
+		CheckpointToken: ckpt.GetCheckpointToken(),
+		Mode:            nodev1.ResolveMode_RESOLVE_MODE_COMMIT,
+	})
+	if err != nil {
+		t.Fatalf("ResolveStateful(commit): %v", err)
+	}
+	if resp.GetSnapshotRef() == "" || resp.GetGeneration() != 1 || resp.GetSizeBytes() == 0 {
+		t.Fatalf("commit response = %+v, want a ref, generation 1, non-zero size", resp)
+	}
+	// VM destroyed.
+	if fsd.liveCount() != 0 {
+		t.Fatalf("live count after commit = %d want 0 (destroyed)", fsd.liveCount())
+	}
+	// Bundle recorded, stamped at the checkpoint generation.
+	if b, ok := s.statefulBundles.byWorkload("wl-state"); !ok || b.snapshotRef != resp.GetSnapshotRef() || b.generation != 1 {
+		t.Fatalf("expected a banked bundle for wl-state at gen 1; got %+v ok=%v", b, ok)
+	}
+	// A relight off it succeeds (proves the committed bundle is valid + paired).
+	relit, err := s.StartStateful(context.Background(), &nodev1.StartStatefulRequest{
+		Trace: &nodev1.Trace{Workload: "wl-state"}, Mode: nodev1.StartStatefulMode_START_STATEFUL_MODE_RELIGHT,
+		BootImageRef: "img-a", RelightSnapshotRef: resp.GetSnapshotRef(), Port: port, VolumeMount: "/data",
+	})
+	if err != nil {
+		t.Fatalf("relight off committed bundle: %v", err)
+	}
+	if !relit.GetWasRelight() {
+		t.Error("relight off a committed checkpoint bundle should be warm")
+	}
+}
+
+// TestStatefulResolveAbort: ABORT resumes the VM (still live), bumps the
+// generation, and records NO bundle.
+func TestStatefulResolveAbort(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, _, fsd := newStatefulTestServer(t)
+	started := startFreshStateful(t, s, port, "wl-state")
+	ckpt := checkpointStateful(t, s, started.GetVmId(), "wl-state")
+
+	resp, err := s.ResolveStateful(context.Background(), &nodev1.ResolveStatefulRequest{
+		VmId:            started.GetVmId(),
+		CheckpointToken: ckpt.GetCheckpointToken(),
+		Mode:            nodev1.ResolveMode_RESOLVE_MODE_ABORT,
+	})
+	if err != nil {
+		t.Fatalf("ResolveStateful(abort): %v", err)
+	}
+	if resp.GetSnapshotRef() != "" || resp.GetGeneration() != 0 || resp.GetSizeBytes() != 0 {
+		t.Fatalf("abort response should be empty; got %+v", resp)
+	}
+	// VM resumed, still live; no bundle.
+	if fsd.liveCount() != 1 {
+		t.Fatalf("live count after abort = %d want 1 (resumed)", fsd.liveCount())
+	}
+	if _, ok := s.statefulBundles.byWorkload("wl-state"); ok {
+		t.Fatal("abort must not record a bundle")
+	}
+	// The abort bumped the generation (1 -> 2); status reports the resumed VM as
+	// no longer checkpoint_pending, at the bumped generation.
+	v := statefulVMStatus(t, s, started.GetVmId())
+	if v == nil || v.GetCheckpointPending() {
+		t.Fatalf("resumed VM should not be checkpoint_pending; got %+v", v)
+	}
+	if v.GetGeneration() != 2 {
+		t.Fatalf("resumed VM generation = %d want 2 (abort bumped)", v.GetGeneration())
+	}
+}
+
+// TestStatefulResolveUnknownTokenErrors: a resolve for an unknown vm or a wrong
+// token is FAILED_PRECONDITION.
+func TestStatefulResolveUnknownTokenErrors(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, _, _ := newStatefulTestServer(t)
+	started := startFreshStateful(t, s, port, "wl-state")
+	ckpt := checkpointStateful(t, s, started.GetVmId(), "wl-state")
+
+	// Wrong token for a real checkpoint-pending VM.
+	_, err := s.ResolveStateful(context.Background(), &nodev1.ResolveStatefulRequest{
+		VmId: started.GetVmId(), CheckpointToken: "wrong", Mode: nodev1.ResolveMode_RESOLVE_MODE_COMMIT,
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("wrong token: err = %v, want FailedPrecondition", err)
+	}
+	// Unknown vm.
+	_, err = s.ResolveStateful(context.Background(), &nodev1.ResolveStatefulRequest{
+		VmId: "no-such-vm", CheckpointToken: ckpt.GetCheckpointToken(), Mode: nodev1.ResolveMode_RESOLVE_MODE_ABORT,
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("unknown vm: err = %v, want FailedPrecondition", err)
+	}
+}
+
+// TestStatefulSecondCheckpointInFlightErrors: a second CHECKPOINT (or a BANK) of
+// an already-checkpointed VM is FAILED_PRECONDITION (the stop guard).
+func TestStatefulSecondCheckpointInFlightErrors(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, _, _ := newStatefulTestServer(t)
+	started := startFreshStateful(t, s, port, "wl-state")
+	_ = checkpointStateful(t, s, started.GetVmId(), "wl-state")
+
+	_, err := s.StopStateful(context.Background(), &nodev1.StopStatefulRequest{
+		VmId: started.GetVmId(), Mode: nodev1.StopStatefulMode_STOP_STATEFUL_MODE_CHECKPOINT,
+		Trace: &nodev1.Trace{Workload: "wl-state"},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("second checkpoint: err = %v, want FailedPrecondition", err)
+	}
+}
+
+// TestStatefulResolveSingleResolve: a second resolve of a consumed token is
+// FAILED_PRECONDITION (single-resolve).
+func TestStatefulResolveSingleResolve(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, _, _ := newStatefulTestServer(t)
+	started := startFreshStateful(t, s, port, "wl-state")
+	ckpt := checkpointStateful(t, s, started.GetVmId(), "wl-state")
+
+	if _, err := s.ResolveStateful(context.Background(), &nodev1.ResolveStatefulRequest{
+		VmId: started.GetVmId(), CheckpointToken: ckpt.GetCheckpointToken(), Mode: nodev1.ResolveMode_RESOLVE_MODE_ABORT,
+	}); err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+	_, err := s.ResolveStateful(context.Background(), &nodev1.ResolveStatefulRequest{
+		VmId: started.GetVmId(), CheckpointToken: ckpt.GetCheckpointToken(), Mode: nodev1.ResolveMode_RESOLVE_MODE_COMMIT,
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("second resolve of a consumed token: err = %v, want FailedPrecondition", err)
+	}
+}
+
+// TestStatefulResolveTimeoutAutoAborts: noded auto-aborts an unresolved
+// checkpoint after its resolve timeout, so a dead control plane cannot pin the
+// paused VM; a COMMIT arriving after the auto-abort is refused (single-resolve).
+func TestStatefulResolveTimeoutAutoAborts(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, _, fsd := newStatefulTestServer(t)
+	s.statefulResolveTimeout = 40 * time.Millisecond
+	started := startFreshStateful(t, s, port, "wl-state")
+	ckpt := checkpointStateful(t, s, started.GetVmId(), "wl-state")
+
+	// Wait past the resolve timeout for the auto-abort to fire.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		v := statefulVMStatus(t, s, started.GetVmId())
+		if v != nil && !v.GetCheckpointPending() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	v := statefulVMStatus(t, s, started.GetVmId())
+	if v == nil || v.GetCheckpointPending() {
+		t.Fatalf("auto-abort should have resumed the VM (not checkpoint_pending); got %+v", v)
+	}
+	if fsd.liveCount() != 1 {
+		t.Fatalf("live count after auto-abort = %d want 1 (resumed)", fsd.liveCount())
+	}
+	// A late COMMIT is refused: the timer already claimed the resolve.
+	_, err := s.ResolveStateful(context.Background(), &nodev1.ResolveStatefulRequest{
+		VmId: started.GetVmId(), CheckpointToken: ckpt.GetCheckpointToken(), Mode: nodev1.ResolveMode_RESOLVE_MODE_COMMIT,
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("late commit after auto-abort: err = %v, want FailedPrecondition", err)
+	}
+}
+
+// TestStatefulResolveInvalidModeDoesNotConsume: an invalid resolve mode is
+// InvalidArgument and does NOT consume the checkpoint (a valid resolve still works).
+func TestStatefulResolveInvalidModeDoesNotConsume(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, _, _ := newStatefulTestServer(t)
+	started := startFreshStateful(t, s, port, "wl-state")
+	ckpt := checkpointStateful(t, s, started.GetVmId(), "wl-state")
+
+	_, err := s.ResolveStateful(context.Background(), &nodev1.ResolveStatefulRequest{
+		VmId: started.GetVmId(), CheckpointToken: ckpt.GetCheckpointToken(),
+		Mode: nodev1.ResolveMode_RESOLVE_MODE_UNSPECIFIED,
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("invalid mode: err = %v, want InvalidArgument", err)
+	}
+	// The checkpoint is still resolvable (not consumed by the invalid attempt).
+	if _, err := s.ResolveStateful(context.Background(), &nodev1.ResolveStatefulRequest{
+		VmId: started.GetVmId(), CheckpointToken: ckpt.GetCheckpointToken(), Mode: nodev1.ResolveMode_RESOLVE_MODE_ABORT,
+	}); err != nil {
+		t.Fatalf("abort after invalid-mode attempt should still work: %v", err)
 	}
 }

--- a/projects/embervm/proto/embervm/node/v1/fakenode/main.go
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/main.go
@@ -165,17 +165,39 @@ func (fakeServer) StartStateful(_ context.Context, req *nodev1.StartStatefulRequ
 	}, nil
 }
 
-// StopStateful returns a bundle ref, stamped generation, and size for BANK, and
-// zero values for DESTROY, so the client can assert both mode branches.
+// StopStateful returns a bundle ref, stamped generation, and size for BANK, a
+// checkpoint token plus the paused generation for CHECKPOINT, and zero values for
+// DESTROY, so the client can assert every mode branch.
 func (fakeServer) StopStateful(_ context.Context, req *nodev1.StopStatefulRequest) (*nodev1.StopStatefulResponse, error) {
-	if req.GetMode() == nodev1.StopStatefulMode_STOP_STATEFUL_MODE_BANK {
+	switch req.GetMode() {
+	case nodev1.StopStatefulMode_STOP_STATEFUL_MODE_BANK:
 		return &nodev1.StopStatefulResponse{
 			SnapshotRef: "stateful/" + req.GetVmId(),
 			Generation:  7,
 			SizeBytes:   16384,
 		}, nil
+	case nodev1.StopStatefulMode_STOP_STATEFUL_MODE_CHECKPOINT:
+		return &nodev1.StopStatefulResponse{
+			CheckpointToken: "ckpt:" + req.GetVmId(),
+			Generation:      7,
+		}, nil
+	default:
+		return &nodev1.StopStatefulResponse{}, nil
 	}
-	return &nodev1.StopStatefulResponse{}, nil
+}
+
+// ResolveStateful returns the published bundle for COMMIT (deriving the ref from
+// the token so the client proves it crossed the wire) and an empty response for
+// ABORT, so the client can assert both resolve branches (ADR embervm/008).
+func (fakeServer) ResolveStateful(_ context.Context, req *nodev1.ResolveStatefulRequest) (*nodev1.ResolveStatefulResponse, error) {
+	if req.GetMode() == nodev1.ResolveMode_RESOLVE_MODE_COMMIT {
+		return &nodev1.ResolveStatefulResponse{
+			SnapshotRef: "stateful/" + req.GetCheckpointToken(),
+			Generation:  8,
+			SizeBytes:   16384,
+		}, nil
+	}
+	return &nodev1.ResolveStatefulResponse{}, nil
 }
 
 // DeleteVolume is idempotent and returns an empty response for any workload.
@@ -291,6 +313,20 @@ func (fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusRequ
 				Healthy:         true,
 				Generation:      5,
 				LastProbeUnixMs: 1_700_000_003_000,
+			},
+			// A second VM PAUSED awaiting a resolve (ADR embervm/008), so the
+			// client can assert the checkpoint_pending inventory fields adoption
+			// reads round-trip.
+			{
+				VmId:              "vm-st2",
+				Workload:          "demo-postgres",
+				Ip:                "10.99.0.4",
+				Port:              5432,
+				Healthy:           false,
+				Generation:        9,
+				LastProbeUnixMs:   1_700_000_005_000,
+				CheckpointPending: true,
+				CheckpointToken:   "ckpt:vm-st2",
 			},
 		},
 		StatefulBundles: []*nodev1.StatefulBundle{

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -265,6 +265,22 @@ service NodeService {
   // pairing mechanism.
   rpc StopStateful(StopStatefulRequest) returns (StopStatefulResponse);
 
+  // ResolveStateful is the second phase of the two-phase interruptible bank (ADR
+  // embervm/008): it resolves a VM left PAUSED by StopStateful(CHECKPOINT) into a
+  // terminal outcome. mode = COMMIT publishes the checkpoint's temporary snapshot
+  // as the workload's bundle (stamped with the now-frozen generation, snapfile
+  // published last), EVICTS any prior bundle, and destroys the VM, returning
+  // {snapshot_ref, generation, size_bytes} exactly as a BANK does. mode = ABORT
+  // bumps the volume generation, deletes the temporary snapshot, and RESUMES the
+  // paused VM (the same process image, genuinely hot), returning an empty result.
+  // The abort ORDER (bump generation, delete temp, THEN resume) plus the temp's
+  // invisibility to the bundle rescan are what keep a resumed VM's snapshot from
+  // ever being relit (ADR 008 Correctness). A checkpoint accepts exactly ONE
+  // resolve: a COMMIT arriving after the node's resolve-timeout auto-abort is
+  // refused FAILED_PRECONDITION, as is any unknown or already-resolved
+  // checkpoint_token.
+  rpc ResolveStateful(ResolveStatefulRequest) returns (ResolveStatefulResponse);
+
   // DeleteVolume removes a workload's volume file and its generation ledger. It
   // is the ONLY destructive data verb, and it exists so deletion is an explicit,
   // audited act (a CR deletion never reaches it; data outlives definitions).
@@ -770,6 +786,16 @@ enum StopStatefulMode {
   STOP_STATEFUL_MODE_UNSPECIFIED = 0;
   STOP_STATEFUL_MODE_BANK = 1;
   STOP_STATEFUL_MODE_DESTROY = 2;
+  // CHECKPOINT is the first phase of the two-phase interruptible bank (ADR
+  // embervm/008, opt-in per workload). It PAUSES the VM and writes a snapshot to
+  // a temporary path INVISIBLE to ScanStatefulBundles (outside the stateful/
+  // bundle dir, no snapfile-published-last completeness marker), then leaves the
+  // VM PAUSED and resumable. No bundle is published and the VM is NOT destroyed.
+  // The response carries a checkpoint_token the control plane passes to
+  // ResolveStateful to either COMMIT (publish the temp as the bundle, destroy) or
+  // ABORT (bump the generation, delete the temp, resume). Only issued for a
+  // workload that opted into spec.stateful.interruptibleBank.
+  STOP_STATEFUL_MODE_CHECKPOINT = 3;
 }
 
 message StopStatefulRequest {
@@ -781,7 +807,38 @@ message StopStatefulRequest {
 message StopStatefulResponse {
   // snapshot_ref, generation, and size_bytes are set only when mode was BANK;
   // all are the zero value for DESTROY. generation is the volume generation
-  // stamped into the bundle, the pair key a later RELIGHT checks.
+  // stamped into the bundle, the pair key a later RELIGHT checks. For CHECKPOINT
+  // the bundle is NOT yet published, so snapshot_ref and size_bytes are zero and
+  // generation carries the volume generation the temp snapshot was paused at (the
+  // control plane records it as the checkpointed generation).
+  string snapshot_ref = 1;
+  uint64 generation = 2;
+  uint64 size_bytes = 3;
+  // checkpoint_token is set ONLY for mode CHECKPOINT: an opaque handle to the
+  // paused VM plus its temporary snapshot, which the control plane passes back to
+  // ResolveStateful. Empty for BANK and DESTROY.
+  string checkpoint_token = 4;
+}
+
+enum ResolveMode {
+  RESOLVE_MODE_UNSPECIFIED = 0;
+  RESOLVE_MODE_COMMIT = 1; // publish the temp as the bundle, then destroy the VM
+  RESOLVE_MODE_ABORT = 2; // bump the generation, delete the temp, then resume the VM
+}
+
+message ResolveStatefulRequest {
+  Trace trace = 1;
+  string vm_id = 2;
+  // checkpoint_token is the opaque handle StopStateful(CHECKPOINT) returned. The
+  // node matches it to the paused VM and its temp snapshot; an unknown or
+  // already-resolved token is FAILED_PRECONDITION (single-resolve).
+  string checkpoint_token = 3;
+  ResolveMode mode = 4;
+}
+
+message ResolveStatefulResponse {
+  // Set only for COMMIT (the published bundle), exactly as StopStateful(BANK)
+  // reports it; all zero for ABORT (an abort publishes no bundle).
   string snapshot_ref = 1;
   uint64 generation = 2;
   uint64 size_bytes = 3;
@@ -1047,6 +1104,16 @@ message StatefulVm {
   // generation is the volume generation the live VM holds (bumped at its attach).
   uint64 generation = 6;
   int64 last_probe_unix_ms = 7;
+  // checkpoint_pending is true when this VM is PAUSED awaiting a ResolveStateful
+  // (a StopStateful(CHECKPOINT) landed but no resolve has yet, ADR embervm/008).
+  // A restarted control plane reads this to adopt and resolve the stranded
+  // checkpoint (default ABORT/resume) rather than leaving the VM dark; noded also
+  // auto-aborts it after its own resolve timeout so a dead control plane cannot
+  // pin the live-VM cap slot and its memory forever.
+  bool checkpoint_pending = 8;
+  // checkpoint_token is the handle to pass to ResolveStateful for a
+  // checkpoint_pending VM (empty otherwise), reported so adoption can resolve it.
+  string checkpoint_token = 9;
 }
 
 // StatefulBundle is the ONE banked stateful bundle for a workload on node disk,

--- a/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
+++ b/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
@@ -31,6 +31,7 @@ defmodule Embervm.NodeRoundtripTest do
     PrimeRequest,
     RelightRequest,
     RelightSource,
+    ResolveStatefulRequest,
     ResourceSpec,
     SessionAssignRequest,
     StartGroupMemberRequest,
@@ -266,6 +267,45 @@ defmodule Embervm.NodeRoundtripTest do
     assert destroyed.generation == 0
     assert destroyed.size_bytes == 0
 
+    # StopStateful CHECKPOINT (ADR embervm/008 phase one): pauses and returns an
+    # opaque token plus the paused generation, publishing NO bundle yet (empty
+    # snapshot_ref / zero size_bytes).
+    {:ok, ckpt} =
+      NodeService.Stub.stop_stateful(ch, %StopStatefulRequest{
+        vm_id: "vm-st1",
+        mode: :STOP_STATEFUL_MODE_CHECKPOINT
+      })
+
+    assert ckpt.checkpoint_token == "ckpt:vm-st1"
+    assert ckpt.generation == 7
+    assert ckpt.snapshot_ref == ""
+    assert ckpt.size_bytes == 0
+
+    # ResolveStateful COMMIT (phase two): publishes the temp as the bundle and
+    # returns the ref, deriving it from the token so the client proves it crossed.
+    {:ok, committed} =
+      NodeService.Stub.resolve_stateful(ch, %ResolveStatefulRequest{
+        vm_id: "vm-st1",
+        checkpoint_token: "ckpt:vm-st1",
+        mode: :RESOLVE_MODE_COMMIT
+      })
+
+    assert committed.snapshot_ref == "stateful/ckpt:vm-st1"
+    assert committed.generation == 8
+    assert committed.size_bytes == 16384
+
+    # ResolveStateful ABORT: resumes the VM and publishes no bundle (empty result).
+    {:ok, aborted} =
+      NodeService.Stub.resolve_stateful(ch, %ResolveStatefulRequest{
+        vm_id: "vm-st1",
+        checkpoint_token: "ckpt:vm-st1",
+        mode: :RESOLVE_MODE_ABORT
+      })
+
+    assert aborted.snapshot_ref == ""
+    assert aborted.generation == 0
+    assert aborted.size_bytes == 0
+
     # DeleteVolume: idempotent, returns an empty response.
     assert {:ok, _} =
              NodeService.Stub.delete_volume(ch, %DeleteVolumeRequest{workload: "scratch-postgres"})
@@ -379,7 +419,7 @@ defmodule Embervm.NodeRoundtripTest do
   test "NodeStatus reports stateful facts (R4 additive fields)", %{channel: ch} do
     {:ok, ns} = NodeService.Stub.get_node_status(ch, %GetNodeStatusRequest{node_id: "node-4"})
 
-    assert [vm] = ns.stateful_vms
+    assert [vm, ckpt_vm] = ns.stateful_vms
     assert vm.vm_id == "vm-st1"
     assert vm.workload == "scratch-postgres"
     assert vm.ip == "10.99.0.3"
@@ -387,6 +427,16 @@ defmodule Embervm.NodeRoundtripTest do
     assert vm.healthy == true
     assert vm.generation == 5
     assert vm.last_probe_unix_ms == 1_700_000_003_000
+    # A live VM is never checkpoint-pending.
+    assert vm.checkpoint_pending == false
+    assert vm.checkpoint_token == ""
+
+    # The second VM is PAUSED awaiting a resolve (ADR embervm/008): adoption reads
+    # checkpoint_pending + the token to resolve a stranded checkpoint.
+    assert ckpt_vm.vm_id == "vm-st2"
+    assert ckpt_vm.workload == "demo-postgres"
+    assert ckpt_vm.checkpoint_pending == true
+    assert ckpt_vm.checkpoint_token == "ckpt:vm-st2"
 
     assert [bundle] = ns.stateful_bundles
     assert bundle.snapshot_ref == "stateful/scratch-postgres"


### PR DESCRIPTION
Implements ADR embervm/008: an opt-in, per-workload interruptible bank so a scale-to-zero stateful datastore never cold-boots in steady state (every wake is hot or a warm restore).

**Design:** boolean `spec.stateful.interruptibleBank` (default off, atomic bank unchanged). The bank becomes two-phase and abortable: CHECKPOINT (pause + snapshot to a rescan-invisible temp, VM left paused) then ResolveStateful(COMMIT|ABORT). The control plane owns commit-vs-abort based on whether a connection parked. A coarse flap guard forces a commit after too many aborts. Forced roll always DESTROYs.

- [x] Phase 0: CR field + watcher parse; two-phase proto (CHECKPOINT + ResolveStateful + inventory fields)
- [x] Phase 1: noded driver checkpoint/resolve split + server handler (single-resolve gate, resolve-timeout auto-abort, adoption inventory, startup temp GC)
- [x] Phase 2: control-plane policy (sweeper checkpoint/resolve-on-park, manager park-on-checkpointed, FSM `checkpointed` edges, flap guard, fail-closed recheck, adoption default-abort)
- [x] Phase 4: chart opt-in (demo-postgres true, scratch-postgres false) + chart bump 0.1.91
- [x] Comprehensive Opus review of the full diff; fixed the one MAJOR (auto-abort-vs-resolve race) + a timer-arm MINOR
- TLA+/STPA pass: skipped for this PR by request

**Bugs caught and fixed during review/CI** (would each have cost a slow CI cycle or a prod incident):
- `node_registry` wasn't projecting `checkpoint_pending`/`checkpoint_token` → stranded-checkpoint adoption never fired.
- `bucket_of` didn't count `:checkpointed` as live → capacity undercount.
- Fail-closed recheck proceeded on a *stale* reading after a failed re-scrape → now gated on scrape freshness.
- A `FAILED_PRECONDITION` resolve (noded auto-abort won the single-resolve race) wrongly marked the instance `:failed`, orphaning a live VM → now reconciles to serving.

**Known follow-ups** (low-likelihood, tracked not fixed here):
- A sweeper crash between CHECKPOINT and resolve, with connections parked, can strand `:infinity` parked callers (adoption skips a workload with parked callers). noded auto-aborts the VM at its timeout; the parked callers rely on client TCP timeout.
- Relight-over-tap failure observed on prod demo-postgres (guest unreachable on fresh tap after resume) is a SEPARATE pre-existing bug; ADR 008's abort/hot-resume path sidesteps it, but the commit-then-relight path would still hit it. Suspected fresh-tap-IP mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)