### PR TITLE
fix(embervm): pin the tap IP on stateful relight

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.91
+version: 0.1.92

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.91
+      targetRevision: 0.1.92
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -148,6 +148,9 @@ type statefulCheckpoint struct {
 	snapshotRef string
 	generation  uint64
 	tmpDir      string
+	// pinnedIP is the tap IP the paused VM held, recorded so a COMMIT publishes it
+	// as the bundle's pinned-IP sidecar and a later relight re-acquires the same IP.
+	pinnedIP string
 }
 
 type instance struct {
@@ -1311,16 +1314,51 @@ func (d *Driver) statefulGenfile(ref string) string {
 	return filepath.Join(d.statefulDir(ref), "gen")
 }
 
+// statefulMetafile is the sidecar recording the tap IP a stateful bundle was
+// banked with, the exact analogue of the serving pinned-IP sidecar. A relight
+// resumes the guest from its memory snapshot, which has this IP baked into eth0,
+// so the relight MUST re-acquire the SAME tap IP or the resumed guest answers on
+// an address the fresh tap does not have and is unreachable ("guest not ready over
+// tap"). Published alongside the gen sidecar before the completeness snapfile, so
+// StatefulPinnedIP reads it back after a restart.
+func (d *Driver) statefulMetafile(ref string) string {
+	return filepath.Join(d.statefulDir(ref), "pinned-ip")
+}
+
+// StatefulPinnedIP reads the tap IP a stateful bundle was banked with, for a
+// relight to re-acquire before restoring. "" when the sidecar is absent (a bundle
+// banked before pinning, or an unreadable sidecar), in which case the caller falls
+// back to a fresh tap.
+func (d *Driver) StatefulPinnedIP(snapshotRef string) string {
+	b, err := os.ReadFile(d.statefulMetafile(snapshotRef))
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// writeStatefulPinnedIP publishes the pinned-IP sidecar, a no-op for an empty IP
+// (which leaves the relight to fall back to a fresh tap, so an older bundle with no
+// sidecar still relights, just without the IP-match guarantee).
+func (d *Driver) writeStatefulPinnedIP(snapshotRef, pinnedIP string) error {
+	if pinnedIP == "" {
+		return nil
+	}
+	if err := os.WriteFile(d.statefulMetafile(snapshotRef), []byte(pinnedIP), 0o600); err != nil {
+		return fmt.Errorf("driver: write stateful pinned-ip sidecar: %w", err)
+	}
+	return nil
+}
+
 // SnapshotStateful pauses a live stateful VM and writes a self-contained
-// stateful bundle (memfile + snapfile) under stateful/<ref>, plus the
-// generation sidecar. It does NOT resume: the caller Releases the VM
+// stateful bundle (memfile + snapfile) under stateful/<ref>, plus the generation
+// and pinned-IP sidecars. It does NOT resume: the caller Releases the VM
 // immediately after (StopStateful BANK destroys). It mirrors SnapshotServing
-// exactly except the sidecar is a generation, not a pinned IP, and it stamps
-// NOTHING about the volume itself: the volume file is not opened, copied, or
-// hashed here. On any failure after the handle is confirmed the VM is torn
-// down (a bank is destructive), so a failed bank never leaves a live/paused
-// handle behind.
-func (d *Driver) SnapshotStateful(ctx context.Context, h substrate.Handle, snapshotRef string, generation uint64) (substrate.SnapshotRef, error) {
+// (which also pins the tap IP) and stamps NOTHING about the volume itself: the
+// volume file is not opened, copied, or hashed here. On any failure after the
+// handle is confirmed the VM is torn down (a bank is destructive), so a failed
+// bank never leaves a live/paused handle behind.
+func (d *Driver) SnapshotStateful(ctx context.Context, h substrate.Handle, snapshotRef string, generation uint64, pinnedIP string) (substrate.SnapshotRef, error) {
 	if snapshotRef == "" {
 		return substrate.SnapshotRef{}, fmt.Errorf("driver: SnapshotStateful requires a snapshot_ref")
 	}
@@ -1357,6 +1395,9 @@ func (d *Driver) SnapshotStateful(ctx context.Context, h substrate.Handle, snaps
 	}
 	if err := os.WriteFile(d.statefulGenfile(snapshotRef), []byte(strconv.FormatUint(generation, 10)), 0o600); err != nil {
 		return substrate.SnapshotRef{}, fmt.Errorf("driver: write stateful generation sidecar: %w", err)
+	}
+	if err := d.writeStatefulPinnedIP(snapshotRef, pinnedIP); err != nil {
+		return substrate.SnapshotRef{}, err
 	}
 	if err := os.Rename(snapTmp, snapPath); err != nil {
 		return substrate.SnapshotRef{}, fmt.Errorf("driver: publish stateful snapfile: %w", err)
@@ -1398,7 +1439,7 @@ func (d *Driver) checkpointTmpDir(token string) string {
 // destroy) or ResolveStatefulAbort (delete the temp, resume). On a pause/snapshot
 // failure the VM is resumed best-effort and the temp removed, so a FAILED
 // checkpoint leaves the VM live rather than stranded paused.
-func (d *Driver) CheckpointStateful(ctx context.Context, h substrate.Handle, snapshotRef string, generation uint64) (string, error) {
+func (d *Driver) CheckpointStateful(ctx context.Context, h substrate.Handle, snapshotRef string, generation uint64, pinnedIP string) (string, error) {
 	if snapshotRef == "" {
 		return "", fmt.Errorf("driver: CheckpointStateful requires a snapshot_ref")
 	}
@@ -1425,7 +1466,7 @@ func (d *Driver) CheckpointStateful(ctx context.Context, h substrate.Handle, sna
 		return "", fmt.Errorf("driver: create checkpoint snapshot: %w", err)
 	}
 	d.mu.Lock()
-	d.checkpoints[token] = &statefulCheckpoint{handle: h, snapshotRef: snapshotRef, generation: generation, tmpDir: tmpDir}
+	d.checkpoints[token] = &statefulCheckpoint{handle: h, snapshotRef: snapshotRef, generation: generation, tmpDir: tmpDir, pinnedIP: pinnedIP}
 	d.mu.Unlock()
 	return token, nil
 }
@@ -1477,6 +1518,9 @@ func (d *Driver) ResolveStatefulCommit(ctx context.Context, token string) (subst
 	}
 	if err := os.WriteFile(d.statefulGenfile(ref), []byte(strconv.FormatUint(cp.generation, 10)), 0o600); err != nil {
 		return substrate.SnapshotRef{}, fmt.Errorf("driver: write stateful generation sidecar: %w", err)
+	}
+	if err := d.writeStatefulPinnedIP(ref, cp.pinnedIP); err != nil {
+		return substrate.SnapshotRef{}, err
 	}
 	if err := os.Rename(filepath.Join(cp.tmpDir, "snapfile"), snapPath); err != nil {
 		return substrate.SnapshotRef{}, fmt.Errorf("driver: publish stateful snapfile: %w", err)

--- a/projects/embervm/noded/fcvm/driver/driver_test.go
+++ b/projects/embervm/noded/fcvm/driver/driver_test.go
@@ -825,7 +825,7 @@ func TestDriverCheckpointCommit(t *testing.T) {
 	d := testDriver(t)
 	h := statefulCheckpointHandle(t, d)
 
-	token, err := d.CheckpointStateful(ctx, h, "state-commit", 7)
+	token, err := d.CheckpointStateful(ctx, h, "state-commit", 7, "10.0.0.5")
 	if err != nil {
 		t.Fatalf("CheckpointStateful: %v", err)
 	}
@@ -863,6 +863,11 @@ func TestDriverCheckpointCommit(t *testing.T) {
 	if string(gen) != "7" {
 		t.Fatalf("gen sidecar = %q, want 7", string(gen))
 	}
+	// The pinned tap IP is published so a relight re-acquires the SAME IP (the
+	// resumed guest's baked-in eth0 matches the fresh tap).
+	if got := d.StatefulPinnedIP("state-commit"); got != "10.0.0.5" {
+		t.Fatalf("StatefulPinnedIP after commit = %q, want 10.0.0.5", got)
+	}
 	// The VM was destroyed at commit, and the temp is gone.
 	if d.LiveCount() != 0 {
 		t.Fatalf("LiveCount after commit = %d, want 0 (VM destroyed)", d.LiveCount())
@@ -879,7 +884,7 @@ func TestDriverCheckpointAbort(t *testing.T) {
 	d := testDriver(t)
 	h := statefulCheckpointHandle(t, d)
 
-	token, err := d.CheckpointStateful(ctx, h, "state-abort", 4)
+	token, err := d.CheckpointStateful(ctx, h, "state-abort", 4, "10.0.0.5")
 	if err != nil {
 		t.Fatalf("CheckpointStateful: %v", err)
 	}
@@ -911,7 +916,7 @@ func TestDriverResolveUnknownTokenErrors(t *testing.T) {
 	}
 	// A second resolve of a consumed token also errors.
 	h := statefulCheckpointHandle(t, d)
-	token, err := d.CheckpointStateful(ctx, h, "state-once", 1)
+	token, err := d.CheckpointStateful(ctx, h, "state-once", 1, "10.0.0.5")
 	if err != nil {
 		t.Fatalf("CheckpointStateful: %v", err)
 	}
@@ -932,7 +937,7 @@ func TestDriverGCStatefulCheckpointsAndReuse(t *testing.T) {
 
 	// An orphaned temp (a checkpoint whose noded died) is swept on start.
 	h := statefulCheckpointHandle(t, d)
-	token, err := d.CheckpointStateful(ctx, h, "state-orphan", 2)
+	token, err := d.CheckpointStateful(ctx, h, "state-orphan", 2, "10.0.0.5")
 	if err != nil {
 		t.Fatalf("CheckpointStateful: %v", err)
 	}
@@ -951,14 +956,14 @@ func TestDriverGCStatefulCheckpointsAndReuse(t *testing.T) {
 
 	// Abort, then a fresh checkpoint+commit still banks a valid bundle.
 	h2 := statefulCheckpointHandle(t, d)
-	tok2, err := d.CheckpointStateful(ctx, h2, "state-reuse", 5)
+	tok2, err := d.CheckpointStateful(ctx, h2, "state-reuse", 5, "10.0.0.5")
 	if err != nil {
 		t.Fatalf("CheckpointStateful reuse: %v", err)
 	}
 	if err := d.ResolveStatefulAbort(ctx, tok2); err != nil {
 		t.Fatalf("abort reuse: %v", err)
 	}
-	tok3, err := d.CheckpointStateful(ctx, h2, "state-reuse", 6)
+	tok3, err := d.CheckpointStateful(ctx, h2, "state-reuse", 6, "10.0.0.5")
 	if err != nil {
 		t.Fatalf("second CheckpointStateful reuse: %v", err)
 	}

--- a/projects/embervm/noded/server/stateful.go
+++ b/projects/embervm/noded/server/stateful.go
@@ -184,13 +184,29 @@ func (s *Server) startStatefulRelight(ctx context.Context, req *nodev1.StartStat
 		return nil, status.Errorf(codes.Internal, "noded: bump generation for %q: %v", workload, err)
 	}
 
-	// A stateful relight does not pin a specific IP the way a serving relight
-	// does (D-R3.4.1): the stateful endpoint is control-plane-addressed (the
-	// control plane reads {ip, port} fresh off every StartStateful response),
-	// not guest-baked-critical, so a fresh tap allocation is sufficient.
-	_, ip, err := s.servingNet.AllocateTap(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.ResourceExhausted, "noded: allocate stateful tap: %v", err)
+	// Re-acquire the SAME tap IP the bundle was banked with, exactly as serving
+	// relight does. A relight resumes the guest from its memory snapshot, which has
+	// this IP configured on eth0; a fresh tap with a DIFFERENT IP leaves the resumed
+	// guest answering on an address the host tap does not have, so the readiness
+	// probe times out ("guest not ready over tap") and the relight fails, which then
+	// burns two generations (relight bump + cold fallback bump) and strands the
+	// bundle. An absent pin (a bundle banked before this fix) falls back to a fresh
+	// tap, so older bundles still relight, just without the IP-match guarantee.
+	pinned := s.statefulDriver.StatefulPinnedIP(ref)
+	var ip net.IP
+	if pinned != "" {
+		ip = net.ParseIP(pinned)
+		if ip == nil {
+			return nil, status.Errorf(codes.Internal, "noded: stateful snapshot %q has a malformed pinned ip %q", ref, pinned)
+		}
+		if _, aerr := s.servingNet.AllocateTapForIP(ctx, ip); aerr != nil {
+			return nil, status.Errorf(codes.FailedPrecondition, "noded: re-acquire pinned stateful ip %s: %v", pinned, aerr)
+		}
+	} else {
+		var aerr error
+		if _, ip, aerr = s.servingNet.AllocateTap(ctx); aerr != nil {
+			return nil, status.Errorf(codes.ResourceExhausted, "noded: allocate stateful tap: %v", aerr)
+		}
 	}
 	h, err := s.statefulDriver.RestoreStateful(ctx, ref, s.volumes.VolumePath(workload))
 	if err != nil {
@@ -400,7 +416,7 @@ func (s *Server) stopStatefulCheckpoint(ctx context.Context, vmID string) (*node
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: stateful vm %q not checkpointable (unknown or a stop is already in flight)", vmID)
 	}
 	snapshotRef := newID("state")
-	token, err := s.statefulDriver.CheckpointStateful(ctx, e.handle, snapshotRef, e.generation)
+	token, err := s.statefulDriver.CheckpointStateful(ctx, e.handle, snapshotRef, e.generation, e.ip.String())
 	if err != nil {
 		s.statefulVMs.clearInFlight(vmID)
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: checkpoint stateful vm %q: %v", vmID, err)
@@ -540,7 +556,7 @@ func (s *Server) stopStatefulBank(ctx context.Context, vmID string) (*nodev1.Sto
 	}
 	e.probe.Stop()
 	snapshotRef := newID("state")
-	ref, err := s.statefulDriver.SnapshotStateful(ctx, e.handle, snapshotRef, e.generation)
+	ref, err := s.statefulDriver.SnapshotStateful(ctx, e.handle, snapshotRef, e.generation, e.ip.String())
 	if err != nil {
 		// A bank is destructive: SnapshotStateful tore the VM down on failure, so
 		// drop the now-dead registry entry, release its tap, and detach the

--- a/projects/embervm/noded/server/stateful_registry.go
+++ b/projects/embervm/noded/server/stateful_registry.go
@@ -30,14 +30,20 @@ type statefulDriver interface {
 	// snapshot via RestoreStateful instead).
 	ClaimStateful(ctx context.Context, rootfsPath, harnessInit string, vcpus, memMib int, nic substrate.NICSpec, handlerDiskPath string, handlerZipBytes int64, volumeDiskPath, volumeMount string, mmdsEnv map[string]string) (substrate.Handle, error)
 	// SnapshotStateful pauses a live stateful VM and writes a self-contained
-	// stateful bundle stamped with the given volume generation; does not resume
-	// (the caller Releases). Mirrors SnapshotServing plus the generation stamp.
-	SnapshotStateful(ctx context.Context, h substrate.Handle, snapshotRef string, generation uint64) (substrate.SnapshotRef, error)
+	// stateful bundle stamped with the given volume generation and the pinnedIP the
+	// VM held; does not resume (the caller Releases). Mirrors SnapshotServing plus
+	// the generation stamp. pinnedIP is re-acquired on relight so the resumed
+	// guest's baked-in eth0 IP matches the fresh tap.
+	SnapshotStateful(ctx context.Context, h substrate.Handle, snapshotRef string, generation uint64, pinnedIP string) (substrate.SnapshotRef, error)
 	// CheckpointStateful is phase one of the interruptible bank (ADR embervm/008):
 	// it pauses a live stateful VM and writes its snapshot to a temp OUTSIDE the
 	// stateful/ bundle dir, leaving the VM PAUSED and resumable (no bundle
-	// published, no Release), and returns an opaque token for the resolve.
-	CheckpointStateful(ctx context.Context, h substrate.Handle, snapshotRef string, generation uint64) (string, error)
+	// published, no Release), and returns an opaque token for the resolve. pinnedIP
+	// is carried so the COMMIT publishes it as the bundle's pinned-IP sidecar.
+	CheckpointStateful(ctx context.Context, h substrate.Handle, snapshotRef string, generation uint64, pinnedIP string) (string, error)
+	// StatefulPinnedIP reads the tap IP a bundle was banked with (empty if absent),
+	// so a relight re-acquires the SAME IP before restoring.
+	StatefulPinnedIP(snapshotRef string) string
 	// ResolveStatefulCommit publishes a checkpoint's temp as the workload's bundle
 	// (snapfile last) and DESTROYS the paused VM, returning the bundle ref. It
 	// consumes the token (single-resolve).

--- a/projects/embervm/noded/server/stateful_test.go
+++ b/projects/embervm/noded/server/stateful_test.go
@@ -42,11 +42,15 @@ type fakeStatefulDriver struct {
 	checkpoints    map[string]fakeCheckpoint
 	failCheckpoint error
 	failResume     error
+	// pinnedIPs maps a banked snapshotRef -> the tap IP it was banked with, so a
+	// test can assert relight re-pins it (ADR embervm/008 relight IP fix).
+	pinnedIPs map[string]string
 }
 
 type fakeCheckpoint struct {
 	snapshotRef string
 	generation  uint64
+	pinnedIP    string
 }
 
 func newFakeStatefulDriver(dir string) *fakeStatefulDriver {
@@ -54,6 +58,7 @@ func newFakeStatefulDriver(dir string) *fakeStatefulDriver {
 		banked:      map[string]uint64{},
 		statefulDir: dir + "/stateful",
 		checkpoints: map[string]fakeCheckpoint{},
+		pinnedIPs:   map[string]string{},
 	}
 }
 
@@ -72,11 +77,18 @@ func (f *fakeStatefulDriver) ClaimStateful(_ context.Context, _ string, _ string
 	return substrate.Handle{ID: "state-vm-" + strconv.Itoa(f.claims), ThreadID: "t-" + strconv.Itoa(f.claims), Node: "node-4"}, nil
 }
 
-func (f *fakeStatefulDriver) SnapshotStateful(_ context.Context, _ substrate.Handle, snapshotRef string, generation uint64) (substrate.SnapshotRef, error) {
+func (f *fakeStatefulDriver) SnapshotStateful(_ context.Context, _ substrate.Handle, snapshotRef string, generation uint64, pinnedIP string) (substrate.SnapshotRef, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.banked[snapshotRef] = generation
+	f.pinnedIPs[snapshotRef] = pinnedIP
 	return substrate.SnapshotRef{ID: snapshotRef, SizeBytes: 4096}, nil
+}
+
+func (f *fakeStatefulDriver) StatefulPinnedIP(snapshotRef string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.pinnedIPs[snapshotRef]
 }
 
 func (f *fakeStatefulDriver) RestoreStateful(_ context.Context, snapshotRef, _ string) (substrate.Handle, error) {
@@ -110,14 +122,14 @@ func (f *fakeStatefulDriver) StatefulDir() string { return f.statefulDir }
 
 // CheckpointStateful records a pending checkpoint and returns its token; the VM
 // stays live (paused), so `live` is unchanged (ADR 008 phase one).
-func (f *fakeStatefulDriver) CheckpointStateful(_ context.Context, _ substrate.Handle, snapshotRef string, generation uint64) (string, error) {
+func (f *fakeStatefulDriver) CheckpointStateful(_ context.Context, _ substrate.Handle, snapshotRef string, generation uint64, pinnedIP string) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.failCheckpoint != nil {
 		return "", f.failCheckpoint
 	}
 	token := "ckpt-" + snapshotRef
-	f.checkpoints[token] = fakeCheckpoint{snapshotRef: snapshotRef, generation: generation}
+	f.checkpoints[token] = fakeCheckpoint{snapshotRef: snapshotRef, generation: generation, pinnedIP: pinnedIP}
 	return token, nil
 }
 
@@ -133,6 +145,7 @@ func (f *fakeStatefulDriver) ResolveStatefulCommit(_ context.Context, token stri
 	}
 	delete(f.checkpoints, token)
 	f.banked[cp.snapshotRef] = cp.generation
+	f.pinnedIPs[cp.snapshotRef] = cp.pinnedIP
 	if f.live > 0 {
 		f.live--
 	}
@@ -942,5 +955,46 @@ func TestStatefulResolveInvalidModeDoesNotConsume(t *testing.T) {
 		VmId: started.GetVmId(), CheckpointToken: ckpt.GetCheckpointToken(), Mode: nodev1.ResolveMode_RESOLVE_MODE_ABORT,
 	}); err != nil {
 		t.Fatalf("abort after invalid-mode attempt should still work: %v", err)
+	}
+}
+
+// TestStartStatefulRelightRepinsTapIP proves the relight IP-pin fix: a bank
+// records the VM's tap IP, and the relight re-acquires that SAME IP via
+// AllocateTapForIP (not a fresh AllocateTap), so the resumed guest's baked-in
+// eth0 matches the host tap and is reachable.
+func TestStartStatefulRelightRepinsTapIP(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, fsn, _ := newStatefulTestServer(t)
+	started := startFreshStateful(t, s, port, "wl-state")
+
+	bankResp, err := s.StopStateful(context.Background(), &nodev1.StopStatefulRequest{
+		VmId: started.GetVmId(), Mode: nodev1.StopStatefulMode_STOP_STATEFUL_MODE_BANK,
+		Trace: &nodev1.Trace{Workload: "wl-state"},
+	})
+	if err != nil {
+		t.Fatalf("StopStateful(bank): %v", err)
+	}
+
+	relit, err := s.StartStateful(context.Background(), &nodev1.StartStatefulRequest{
+		Trace: &nodev1.Trace{Workload: "wl-state"}, Mode: nodev1.StartStatefulMode_START_STATEFUL_MODE_RELIGHT,
+		BootImageRef: "img-a", RelightSnapshotRef: bankResp.GetSnapshotRef(), Port: port, VolumeMount: "/data",
+	})
+	if err != nil {
+		t.Fatalf("StartStateful(relight): %v", err)
+	}
+	if !relit.GetWasRelight() {
+		t.Fatal("a matched-generation relight should report was_relight")
+	}
+	// The relight re-acquired the SAME tap IP the bank recorded (127.0.0.1, the
+	// fake AllocateTap IP), via AllocateTapForIP.
+	pins := fsn.pinReacquires()
+	found := false
+	for _, ip := range pins {
+		if ip == "127.0.0.1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("relight should re-pin the banked tap IP 127.0.0.1 via AllocateTapForIP; got pins %v", pins)
 	}
 }


### PR DESCRIPTION
Fixes the demo-postgres "always cold-boots, never warm relights" behavior found while verifying ADR 008 in prod.

**Root cause (from prod op-log):** demo-postgres generations jumped +2 per cycle (relight bump + cold-boot fallback bump), and every bundle was evicted `pair_broken`. Stateful relight allocated a **fresh tap IP** that didn't match the IP baked into the guest's eth0 in the memory snapshot, so the resumed Postgres was unreachable on the new tap → "guest not ready over tap" → relight fails → double-bump → bundle stranded → every wake cold-boots. demo (idleBankSeconds:1) hit it every cycle; scratch survived by luck (rare relights got the same IP back).

**Fix:** record the tap IP in a `pinned-ip` sidecar at bank/checkpoint time (mirroring the serving class, which already pins), and re-acquire the SAME IP via `AllocateTapForIP` on relight. Applies to both the atomic bank and the interruptible commit. An absent sidecar (older bundle) falls back to a fresh tap. Entirely noded-internal: no proto or control-plane change.

Tests: driver commit test asserts the pinned-ip sidecar round-trips; server test asserts a bank→relight cycle re-pins the banked IP via AllocateTapForIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)