### PR TITLE
debug(embervm): inline pair-check diagnostic values

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.93
+version: 0.1.94

--- a/projects/embervm/control/lib/embervm/stateful_store.ex
+++ b/projects/embervm/control/lib/embervm/stateful_store.ex
@@ -972,11 +972,14 @@ defmodule Embervm.StatefulStore do
     # attributed to a missing volume row vs a generation mismatch. Only when a
     # banked instance exists, so a scaled-to-zero-no-bundle workload stays quiet.
     if is_map(banked) do
-      Logger.info("embervm stateful pair check",
-        workload: workload,
-        banked_snapshot_generation: Map.get(banked, :snapshot_generation),
-        volume: (if is_map(volume), do: Map.get(volume, :generation), else: :no_volume_row),
-        pair_valid: result
+      vol_gen = if is_map(volume), do: Map.get(volume, :generation), else: :no_volume_row
+      vol_node = if is_map(volume), do: Map.get(volume, :node_id), else: nil
+
+      Logger.info(
+        "embervm stateful pair check " <>
+          "workload=#{workload} banked_snap_gen=#{inspect(Map.get(banked, :snapshot_generation))} " <>
+          "volume_gen=#{inspect(vol_gen)} volume_node=#{inspect(vol_node)} " <>
+          "banked_node=#{inspect(Map.get(banked, :node_id))} pair_valid=#{result}"
       )
     end
 

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.93
+      targetRevision: 0.1.94
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Follow-up to #3626: the structured metadata was dropped by the JSON logger allow-list; inline the values in the message. Revert with #3626 once root cause found.