### PR TITLE
feat(demos): two-column console layout for the postgres demo

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.158
+version: 0.89.159
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.158
+      targetRevision: 0.89.159
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.233
+version: 0.285.234
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.233
+      targetRevision: 0.285.234
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/PostgresPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/PostgresPanel.svelte
@@ -26,15 +26,29 @@
 
   const API = "/api/demos/firecracker/postgres";
   const POLL_MS = 700;
-  const HISTORY_MAX = 8;
 
-  const COLUMN_TYPES = [
+  // Resource-savings counter assumption: the demo VM is sized at 512 MiB, so
+  // every second it spends banked is 512 MiB-seconds of RAM not spent. Not
+  // measured, a stated assumption shown alongside the number.
+  const MIB_SAVED_PER_S = 512;
+  const SAVINGS_TICK_MS = 200;
+
+  // Clicks during a lifecycle transition (mid-bank, wake-rate limiter) fail
+  // transiently; retry the same request under the still-ticking stopwatch so
+  // it reads as one longer wake, not repeated failures. Capped at 3 s.
+  const RETRY_DELAYS_MS = [500, 1000, 2000, 3000];
+
+  const ORDER_COLUMNS = [
     { key: "id", label: "id", type: "bigserial" },
     { key: "item", label: "item", type: "text" },
     { key: "qty", label: "qty", type: "int" },
     { key: "unit_price", label: "unit_price", type: "numeric(8,2)" },
     { key: "written_at", label: "written_at", type: "timestamptz" },
   ];
+
+  const ORDERS_SQL = "SELECT * FROM demo_orders ORDER BY id DESC";
+  const SUMMARY_SQL =
+    "SELECT item, SUM(qty * unit_price) FROM demo_orders GROUP BY item";
 
   let status = $state(null);
   let statusError = $state("");
@@ -43,8 +57,11 @@
   let truncating = $state(false);
   let truncateConfirming = $state(false);
   let lastRun = $state(null);
-  let runs = $state([]);
   let runError = $state("");
+
+  // Which result shape the right column shows. INSERT and TRUNCATE land on
+  // the orders grid; the aggregate query switches to the summary table.
+  let view = $state("orders");
 
   // Best-seen wall time per boot path: the demo's headline comparison.
   let tiers = $state({ cold: null, relight: null, warm: null });
@@ -93,6 +110,79 @@
   // by the status poll (not a fabricated countdown, just a rough approach).
   let idleSeconds = $state(0);
 
+  // True while a retry delay is in flight, so the narration line can say
+  // "still waking, retrying" instead of the poll-driven wake narration or a
+  // mid-sequence error.
+  let retrying = $state(false);
+  let retryTimeoutId = null;
+
+  function sleep(delayMs) {
+    return new Promise((resolve) => {
+      retryTimeoutId = setTimeout(() => {
+        retryTimeoutId = null;
+        resolve();
+      }, delayMs);
+    });
+  }
+
+  function cancelPendingRetry() {
+    if (retryTimeoutId != null) {
+      clearTimeout(retryTimeoutId);
+      retryTimeoutId = null;
+    }
+    retrying = false;
+  }
+
+  // Shared retry wrapper: runs doAttempt() up to 1 + RETRY_DELAYS_MS.length
+  // times, waiting the next backoff delay between attempts. doAttempt should
+  // return {ok: true, ...} on success or {ok: false, permanent, error} on a
+  // failure worth surfacing; a thrown error is treated as transient. The
+  // caller's own running/truncating flag is expected to already be set, so
+  // this never overlaps with a fresh click.
+  async function fetchWithBackoff(doAttempt) {
+    let lastResult = null;
+    for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+      try {
+        const result = await doAttempt();
+        if (result.ok || result.permanent) return result;
+        lastResult = result;
+      } catch (err) {
+        lastResult = { ok: false, error: String(err) };
+      }
+      if (attempt < RETRY_DELAYS_MS.length) {
+        retrying = true;
+        await sleep(RETRY_DELAYS_MS[attempt]);
+        retrying = false;
+      }
+    }
+    return lastResult;
+  }
+
+  // Session-scoped RAM-savings counter: accumulates MiB-seconds while banked.
+  // A coarse setInterval (not raf) is plenty for a number that only needs to
+  // visibly tick, not animate smoothly.
+  let savedMibSeconds = $state(0);
+  let savingsTimer = null;
+  let savingsLastTick = 0;
+
+  function startSavingsTimer() {
+    if (savingsTimer != null) return;
+    savingsLastTick = performance.now();
+    savingsTimer = setInterval(() => {
+      const now = performance.now();
+      const elapsedS = (now - savingsLastTick) / 1000;
+      savingsLastTick = now;
+      savedMibSeconds += elapsedS * MIB_SAVED_PER_S;
+    }, SAVINGS_TICK_MS);
+  }
+
+  function stopSavingsTimer() {
+    if (savingsTimer != null) {
+      clearInterval(savingsTimer);
+      savingsTimer = null;
+    }
+  }
+
   async function pollStatus() {
     try {
       const resp = await fetch(`${API}/status`);
@@ -112,9 +202,34 @@
         body.state === "serving" && body.last_active_at
           ? (Date.now() - new Date(body.last_active_at).getTime()) / 1000
           : 0;
+      if (body.state === "banked") {
+        startSavingsTimer();
+      } else {
+        stopSavingsTimer();
+      }
     } catch (err) {
       statusError = String(err);
     }
+  }
+
+  async function attemptQuery(mode) {
+    const resp = await fetch(`${API}/query`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ mode }),
+    });
+    const body = await resp.json();
+    if (resp.status === 503 && /not configured/i.test(body?.detail ?? "")) {
+      // Permanent: no DSN configured on this deployment, retrying won't help.
+      return { ok: false, permanent: true, error: body.detail };
+    }
+    if (!resp.ok) {
+      return { ok: false, error: body?.detail || `query failed (${resp.status})` };
+    }
+    if (body.error) {
+      return { ok: false, error: body.error };
+    }
+    return { ok: true, body };
   }
 
   async function runQuery(mode) {
@@ -124,22 +239,14 @@
     runError = "";
     startStopwatch();
     try {
-      const resp = await fetch(`${API}/query`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ mode }),
-      });
-      const body = await resp.json();
-      if (!resp.ok) {
-        runError = body?.detail || `query failed (${resp.status})`;
+      const result = await fetchWithBackoff(() => attemptQuery(mode));
+      if (!result.ok) {
+        runError = result.error;
         return;
       }
-      if (body.error) {
-        runError = body.error;
-        return;
-      }
+      const body = result.body;
       lastRun = body;
-      runs = [body, ...runs].slice(0, HISTORY_MAX);
+      view = mode === "aggregate" ? "summary" : "orders";
       const tier =
         body.classification === "relight" || body.classification === "warm"
           ? body.classification
@@ -148,10 +255,9 @@
         tiers = { ...tiers, [tier]: body.connect_ms };
       }
       flashConnectPulse();
-    } catch (err) {
-      runError = String(err);
     } finally {
       running = false;
+      cancelPendingRetry();
       stopStopwatch();
     }
   }
@@ -166,26 +272,35 @@
     truncateLedger();
   }
 
+  async function attemptTruncate() {
+    const resp = await fetch(`${API}/truncate`, { method: "POST" });
+    const body = await resp.json();
+    if (resp.status === 503 && /not configured/i.test(body?.detail ?? "")) {
+      return { ok: false, permanent: true, error: body.detail };
+    }
+    if (!resp.ok) {
+      return { ok: false, error: body?.detail || `truncate failed (${resp.status})` };
+    }
+    if (!body.truncated) {
+      return { ok: false, error: body.error || "truncate failed" };
+    }
+    return { ok: true };
+  }
+
   async function truncateLedger() {
     truncating = true;
     runError = "";
     try {
-      const resp = await fetch(`${API}/truncate`, { method: "POST" });
-      const body = await resp.json();
-      if (!resp.ok) {
-        runError = body?.detail || `truncate failed (${resp.status})`;
-        return;
-      }
-      if (!body.truncated) {
-        runError = body.error || "truncate failed";
+      const result = await fetchWithBackoff(attemptTruncate);
+      if (!result.ok) {
+        runError = result.error;
         return;
       }
       lastRun = null;
-      runs = [];
-    } catch (err) {
-      runError = String(err);
+      view = "orders";
     } finally {
       truncating = false;
+      cancelPendingRetry();
     }
   }
 
@@ -217,6 +332,8 @@
     return () => {
       clearInterval(pollTimer);
       stopStopwatch();
+      stopSavingsTimer();
+      cancelPendingRetry();
       if (pulseTimer) clearTimeout(pulseTimer);
     };
   });
@@ -229,33 +346,67 @@
   };
 
   let wakeNarration = $derived(
-    WAKE_NARRATION[status?.state] ?? "connection parked, waking the VM",
+    retrying
+      ? "still waking, retrying"
+      : (WAKE_NARRATION[status?.state] ?? "connection parked, waking the VM"),
   );
 
   const STATE_VIEW = {
-    serving: { label: "Awake", tone: "awake", hint: "VM live, next query is warm" },
-    banking: { label: "Falling asleep", tone: "drowsy", hint: "pausing to a snapshot bundle" },
-    banked: { label: "Asleep", tone: "asleep", hint: "no VM running; a connection wakes it" },
-    relighting: { label: "Waking (relight)", tone: "waking", hint: "resuming the paused snapshot" },
-    cold_booting: { label: "Waking (cold boot)", tone: "waking", hint: "fresh boot against the volume" },
-    starting: { label: "Starting", tone: "waking", hint: "first boot" },
+    serving: {
+      label: "Awake",
+      tone: "awake",
+      sentence:
+        "Awake. Queries answer instantly; it falls back asleep about a second after the last one.",
+    },
+    banking: {
+      label: "Falling asleep",
+      tone: "drowsy",
+      sentence: "Saving itself to disk...",
+    },
+    banked: { label: "Asleep", tone: "asleep", sentence: "" },
+    relighting: {
+      label: "Waking (from snapshot)",
+      tone: "waking",
+      sentence: "Waking up...",
+    },
+    cold_booting: {
+      label: "Waking (cold start)",
+      tone: "waking",
+      sentence: "Waking up...",
+    },
+    starting: {
+      label: "Starting",
+      tone: "waking",
+      sentence: "Waking up...",
+    },
   };
 
   let stateView = $derived(
     STATE_VIEW[status?.state] ?? {
       label: status?.state || "No instance yet",
       tone: "asleep",
-      hint: "cold-boots on the first connection",
+      sentence: "Cold-boots on the first connection.",
     },
   );
 
-  const CLASS_LABEL = {
-    warm: "warm (VM already awake)",
-    relight: "relight (resumed from snapshot)",
-    cold: "cold boot (fresh VM on the volume)",
-    transitional: "caught mid-transition",
-    unknown: "unclassified",
+  // Classification of the last completed run, in plain words, so the
+  // narration line under the wake number is always occupied: while a query
+  // is in flight it's replaced by the live poll narration instead.
+  const CLASS_SENTENCE = {
+    warm: "was already awake",
+    relight: "woke from a snapshot",
+    cold: "cold start: fresh boot against the saved data",
   };
+
+  let lastRunSentence = $derived.by(() => {
+    if (!lastRun) return "";
+    if (lastRun.classification === "warm") return CLASS_SENTENCE.warm;
+    if (lastRun.classification === "relight") {
+      return `woke from a snapshot in ${ms(lastRun.connect_ms)}`;
+    }
+    if (lastRun.classification === "cold") return CLASS_SENTENCE.cold;
+    return "";
+  });
 
   function ms(v) {
     if (v == null) return "–";
@@ -272,17 +423,15 @@
     return `£${(v ?? 0).toFixed(2)}`;
   }
 
+  function mibSeconds(v) {
+    return v < 1024 ? `${Math.round(v)} MiB·s` : `${(v / 1024).toFixed(1)} GiB·s`;
+  }
+
   function barPct(run, part) {
     const total = (run.connect_ms ?? 0) + (run.query_ms ?? 0);
     if (!total) return 0;
     return (part / total) * 100;
   }
-
-  // Statements shown in the strip: everything the backend ran minus the
-  // DDL-if-missing (real work, but not part of the story we're telling).
-  let strippedStatements = $derived(
-    (lastRun?.statements ?? []).filter((s) => !s.sql.startsWith("CREATE TABLE")),
-  );
 
   // Group rows into epoch bands by postmaster_start, newest group first, so
   // the grid visually shows which rows share a resumed process and which
@@ -305,289 +454,300 @@
     Math.max(1, ...((lastRun?.breakdown ?? []).map((b) => b.revenue))),
   );
 
-  // Asleep hero strip: the "0 vCPU" lead line replaces the muted hint when
-  // the VM is fully banked, so the panel's rest state reads as a claim
-  // rather than an absence.
-  let asleepHero = $derived.by(() => {
-    if (status?.state !== "banked") return null;
-    const mib =
-      status?.volume_bytes != null ? `${(status.volume_bytes / 1024 / 1024).toFixed(1)} MiB` : "some";
-    const wake = tiers.relight != null ? ms(tiers.relight) : "under 100 ms";
-    return `${mib} of orders on disk, waiting. The next connection brings Postgres back in ~${wake}.`;
-  });
+  // Asleep hero copy: the volume size and best-known relight time, so the
+  // panel's rest state reads as a claim rather than an absence.
+  let asleepMib = $derived(
+    status?.volume_bytes != null
+      ? `${(status.volume_bytes / 1024 / 1024).toFixed(1)} MiB`
+      : "some",
+  );
+
+  let asleepWake = $derived(tiers.relight != null ? ms(tiers.relight) : "under 100 ms");
 
   // Dozing narration while serving-but-idle: an approach, not a countdown.
   let dozeHint = $derived(
-    status?.state === "serving" && !running
-      ? idleSeconds < 1
-        ? "idle, falls asleep about a second after the last connection closes"
-        : "dozing off any moment"
+    status?.state === "serving" && !running && idleSeconds >= 1
+      ? "Dozing off any moment."
       : null,
   );
 </script>
 
 <section class="pg-panel">
-  <div class="lifecycle-card">
-    <div class="state-chip tone-{stateView.tone}">
-      <span class="state-dot" aria-hidden="true"></span>
-      <span class="state-label">{stateView.label}</span>
-    </div>
-    {#if asleepHero}
-      <p class="state-hero">
-        <strong>0 vCPU · 0 MiB RAM right now.</strong> {asleepHero}
+  <div class="left-col">
+    <div class="state-block">
+      <div class="state-chip tone-{stateView.tone}">
+        <span class="state-dot" aria-hidden="true"></span>
+        <span class="state-label">{stateView.label}</span>
+      </div>
+      {#if stateView.tone === "asleep" && status?.state === "banked"}
+        <p class="state-sentence">
+          <strong>Asleep, costing nothing.</strong> 0 CPU, 0 memory. Your {asleepMib}
+          of data is safe on disk. The next query wakes the database in about
+          {asleepWake}.
+        </p>
+      {:else}
+        <p class="state-sentence">{dozeHint ?? stateView.sentence}</p>
+      {/if}
+      <dl class="state-facts">
+        <div>
+          <dt>generation</dt>
+          <dd>{status?.generation ?? "–"}</dd>
+        </div>
+        <div>
+          <dt>snapshot pairs</dt>
+          <dd>{status?.pair_valid == null ? "–" : status.pair_valid ? "yes" : "no"}</dd>
+        </div>
+        <div>
+          <dt>volume</dt>
+          <dd>{asleepMib === "some" ? "–" : asleepMib}</dd>
+        </div>
+      </dl>
+      <p class="savings-line" class:savings-active={status?.state === "banked"}>
+        memory saved while asleep this visit:
+        <span class="savings-value">{mibSeconds(savedMibSeconds)}</span>
       </p>
-    {:else}
-      <p class="state-hint">{dozeHint ?? stateView.hint}</p>
-    {/if}
-    <dl class="state-facts">
-      <div>
-        <dt>generation</dt>
-        <dd>{status?.generation ?? "–"}</dd>
-      </div>
-      <div>
-        <dt>snapshot pairs</dt>
-        <dd>{status?.pair_valid == null ? "–" : status.pair_valid ? "yes" : "no"}</dd>
-      </div>
-      <div>
-        <dt>volume</dt>
-        <dd>
-          {status?.volume_bytes != null
-            ? `${(status.volume_bytes / 1024 / 1024).toFixed(1)} MiB`
-            : "–"}
-        </dd>
-      </div>
-    </dl>
-    {#if statusError}
-      <p class="soft-error">status: {statusError}</p>
-    {/if}
-  </div>
+      <p class="savings-caption">assuming the 512 MiB VM stayed running</p>
+      {#if statusError}
+        <p class="soft-error">status: {statusError}</p>
+      {/if}
+    </div>
 
-  <div class="controls">
-    <button
-      class="run-btn"
-      type="button"
-      onclick={() => runQuery("insert")}
-      disabled={running}
-      title="appends a random line item from the menu"
-    >
-      {running ? "Connecting…" : "INSERT an order"}
-    </button>
-    <button
-      class="aggregate-btn"
-      type="button"
-      onclick={() => runQuery("aggregate")}
-      disabled={running}
-      title="SELECT only: wakes the VM without writing"
-    >
-      {running ? "Connecting…" : "Run aggregate"}
-    </button>
-    <div class="destructive-group">
+    <div class="controls">
       <button
-        class="truncate-btn"
-        class:confirming={truncateConfirming}
+        class="run-btn"
         type="button"
-        onclick={onTruncateClick}
-        disabled={running || truncating}
-        title="TRUNCATE demo_orders. The VM lives, the data dies."
+        onclick={() => runQuery("insert")}
+        disabled={running}
+        title="appends a random line item from the menu"
       >
-        {truncating
-          ? "Truncating…"
-          : truncateConfirming
-            ? "really truncate?"
-            : "Clear ledger (TRUNCATE)"}
+        {running ? "Connecting…" : "INSERT an order"}
       </button>
       <button
-        class="reset-btn"
+        class="aggregate-btn"
         type="button"
-        onclick={resetInstance}
-        disabled={resetting || running}
-        title="Destroy the VM and evict its snapshot. The data volume survives, so the next query pays a full cold boot against retained rows."
+        onclick={() => runQuery("aggregate")}
+        disabled={running}
+        title="SELECT only: wakes the VM without writing"
       >
-        {resetting ? "Resetting…" : "Force cold boot"}
+        {running ? "Connecting…" : "Run aggregate"}
       </button>
-    </div>
-    <p class="destructive-caption">
-      truncate keeps the VM and kills the data; cold boot keeps the data and
-      kills the VM
-    </p>
-  </div>
-
-  {#if runError}
-    <p class="run-error">
-      {runError}
-      <span class="run-error-hint">
-        (a refused connect usually means the wake-rate limiter; wait a beat and retry)
-      </span>
-    </p>
-  {/if}
-
-  {#if running}
-    <div class="stopwatch-card">
-      <span class="stopwatch-value">{ms(stopwatchMs)}</span>
-      <span class="stopwatch-narration">{wakeNarration}</span>
-    </div>
-  {/if}
-
-  {#if lastRun}
-    <div class="timing-card">
-      <div class="timing-headline">
-        <div class="timing-big">
-          <span class="timing-value" class:connect-pulse={connectPulse}>{ms(lastRun.connect_ms)}</span>
-          <span class="timing-label">connect (the wake)</span>
-        </div>
-        <div class="timing-big">
-          <span class="timing-value">{ms(lastRun.query_ms)}</span>
-          <span class="timing-label">SQL roundtrip</span>
-        </div>
-        <div class="timing-class">{CLASS_LABEL[lastRun.classification] ?? lastRun.classification}</div>
+      <div class="destructive-group">
+        <button
+          class="truncate-btn"
+          class:confirming={truncateConfirming}
+          type="button"
+          onclick={onTruncateClick}
+          disabled={running || truncating}
+          title="TRUNCATE demo_orders. The VM lives, the data dies."
+        >
+          {truncating
+            ? "Truncating…"
+            : truncateConfirming
+              ? "really truncate?"
+              : "Clear ledger (TRUNCATE)"}
+        </button>
+        <button
+          class="reset-btn"
+          type="button"
+          onclick={resetInstance}
+          disabled={resetting || running}
+          title="Destroy the VM and evict its snapshot. The data volume survives, so the next query pays a full cold boot against retained rows."
+        >
+          {resetting ? "Resetting…" : "Force cold boot"}
+        </button>
       </div>
+      <p class="destructive-caption">
+        truncate keeps the VM and kills the data; cold boot keeps the data and
+        kills the VM
+      </p>
+    </div>
+
+    {#if runError}
+      <p class="run-error">
+        {runError}
+        <span class="run-error-hint">
+          (a refused connect usually means the wake-rate limiter; wait a beat and retry)
+        </span>
+      </p>
+    {/if}
+
+    <div class="last-run">
+      <div class="last-run-numbers">
+        <div class="last-run-big">
+          <span class="last-run-value" class:connect-pulse={connectPulse}>
+            {running ? ms(stopwatchMs) : ms(lastRun?.connect_ms)}
+          </span>
+          <span class="last-run-label">wake + connect</span>
+        </div>
+        <div class="last-run-big">
+          <span class="last-run-value">{running ? "–" : ms(lastRun?.query_ms)}</span>
+          <span class="last-run-label">query</span>
+        </div>
+      </div>
+      <p class="last-run-narration">{running ? wakeNarration : lastRunSentence}</p>
       <div class="timing-bar" aria-hidden="true">
-        <span class="bar-connect" style:width="{barPct(lastRun, lastRun.connect_ms)}%"></span>
-        <span class="bar-query" style:width="{barPct(lastRun, lastRun.query_ms)}%"></span>
+        {#if lastRun}
+          <span class="bar-connect" style:width="{barPct(lastRun, lastRun.connect_ms)}%"></span>
+          <span class="bar-query" style:width="{barPct(lastRun, lastRun.query_ms)}%"></span>
+        {/if}
       </div>
-      <p class="timing-note">
-        The connect bracket includes the whole wake: the activator parks your
-        TCP connection while the microVM {lastRun.classification === "cold"
-          ? "cold-boots"
-          : "relights"}, then splices it through. Once awake, Postgres is just
-        Postgres.
-      </p>
     </div>
 
     <div class="tiers">
       <div class="tier">
         <span class="tier-value">{ms(tiers.cold)}</span>
-        <span class="tier-label">cold boot</span>
+        <span class="tier-label">cold start</span>
       </div>
       <span class="tier-arrow" aria-hidden="true">›</span>
       <div class="tier">
         <span class="tier-value">{ms(tiers.relight)}</span>
-        <span class="tier-label">relight</span>
+        <span class="tier-label">from snapshot</span>
       </div>
       <span class="tier-arrow" aria-hidden="true">›</span>
       <div class="tier">
         <span class="tier-value">{ms(tiers.warm)}</span>
-        <span class="tier-label">warm</span>
+        <span class="tier-label">already awake</span>
       </div>
-      <p class="tiers-caption">best connect time seen this session, per boot path</p>
+      <p class="tiers-caption">best this session</p>
     </div>
-  {/if}
+  </div>
 
-  {#if strippedStatements.length}
-    <div class="statement-card">
-      <h3 class="statement-title">statements run</h3>
-      <ul class="statement-list">
-        {#each strippedStatements as stmt, i (i)}
-          <li class="statement-row">
-            <code class="statement-sql">{stmt.sql}</code>
-            <span class="statement-ms">-&gt; {ms(stmt.ms)}</span>
-          </li>
-        {/each}
-      </ul>
-    </div>
-  {/if}
-
-  {#if lastRun?.breakdown?.length}
-    <div class="aggregate-card">
-      <p class="aggregate-headline">
-        <span class="aggregate-revenue">{money(lastRun.total_revenue)} total revenue</span>
-        · <span class="aggregate-orders">{lastRun.total_orders} orders</span>
-      </p>
-      <ul class="aggregate-list">
-        {#each lastRun.breakdown as item (item.item)}
-          <li class="aggregate-row">
-            <span class="aggregate-item">{item.item}</span>
-            <span class="aggregate-units">{item.units} units</span>
-            <span class="aggregate-item-revenue">{money(item.revenue)}</span>
-            <span class="aggregate-bar-track" aria-hidden="true">
-              <span
-                class="aggregate-bar-fill"
-                style:width="{(item.revenue / maxRevenue) * 100}%"
-              ></span>
-            </span>
-          </li>
-        {/each}
-      </ul>
-    </div>
-  {/if}
-
-  {#if lastRun?.rows?.length}
-    <div class="rows-card">
-      <h3 class="rows-title">orders ledger</h3>
-      <table class="rows-table">
-        <thead>
-          <tr>
-            {#each COLUMN_TYPES as col (col.key)}
-              <th class={col.key === "qty" || col.key === "unit_price" ? "col-numeric" : ""}>
-                <span class="col-name">{col.label}</span>
-                <span class="col-type">{col.type}</span>
-              </th>
-            {/each}
-          </tr>
-        </thead>
-        <tbody>
-          {#each epochBands as band, i (band.postmaster_start)}
-            <tr class="epoch-band" class:epoch-current={i === 0}>
-              <td colspan={COLUMN_TYPES.length}>
-                process born {clock(band.postmaster_start)}
-                · {i === 0 ? "current" : "survived a later boot"}
-              </td>
-            </tr>
-            {#each band.rows as row (row.id)}
-              <tr class:row-new={row.id === lastRun?.inserted?.id}>
-                <td class="col-numeric">{row.id}</td>
-                <td>{row.item}</td>
-                <td class="col-numeric">{row.qty}</td>
-                <td class="col-numeric">{money(row.unit_price)}</td>
-                <td>{clock(row.written_at)}</td>
+  <div class="right-col">
+    <p class="formula-bar">{view === "summary" ? SUMMARY_SQL : ORDERS_SQL}</p>
+    <div class="result-card">
+      {#if view === "summary"}
+        <div class="result-view swap-in">
+          <table class="result-table">
+            <thead>
+              <tr>
+                <th>
+                  <span class="col-name">item</span>
+                  <span class="col-type">text</span>
+                </th>
+                <th class="col-numeric">
+                  <span class="col-name">units</span>
+                  <span class="col-type">bigint</span>
+                </th>
+                <th class="col-numeric">
+                  <span class="col-name">revenue</span>
+                  <span class="col-type">numeric</span>
+                </th>
               </tr>
-            {/each}
-          {/each}
-        </tbody>
-      </table>
-      <p class="rows-footer">({lastRun.total_orders} rows)</p>
-      <p class="rows-note">
-        "Process born" is pg_postmaster_start_time(): rows sharing it were
-        served by the same resumed process (a relight never restarts Postgres);
-        a new value marks a cold boot, and older rows surviving it is the
-        volume outliving the VM.
-      </p>
+            </thead>
+            <tbody>
+              {#each lastRun?.breakdown ?? [] as item (item.item)}
+                <tr class="summary-row">
+                  <td>
+                    <span
+                      class="summary-bar"
+                      style:width="{(item.revenue / maxRevenue) * 100}%"
+                      aria-hidden="true"
+                    ></span>
+                    <span class="summary-item">{item.item}</span>
+                  </td>
+                  <td class="col-numeric">{item.units}</td>
+                  <td class="col-numeric">{money(item.revenue)}</td>
+                </tr>
+              {/each}
+            </tbody>
+            <tfoot>
+              <tr class="summary-total">
+                <td>Σ total</td>
+                <td class="col-numeric">{lastRun?.total_orders != null ? (lastRun.breakdown ?? []).reduce((n, b) => n + b.units, 0) : "–"} units</td>
+                <td class="col-numeric">{money(lastRun?.total_revenue)}</td>
+              </tr>
+            </tfoot>
+          </table>
+          <p class="result-footer">
+            ({(lastRun?.breakdown ?? []).length} groups from {lastRun?.total_orders ?? 0} orders)
+          </p>
+        </div>
+      {:else}
+        <div class="result-view swap-in">
+          <table class="result-table">
+            <thead>
+              <tr>
+                {#each ORDER_COLUMNS as col (col.key)}
+                  <th class={col.key === "qty" || col.key === "unit_price" ? "col-numeric" : ""}>
+                    <span class="col-name">{col.label}</span>
+                    <span class="col-type">{col.type}</span>
+                  </th>
+                {/each}
+              </tr>
+            </thead>
+            <tbody>
+              {#each epochBands as band, i (band.postmaster_start)}
+                <tr class="epoch-band" class:epoch-current={i === 0}>
+                  <td colspan={ORDER_COLUMNS.length}>
+                    process born {clock(band.postmaster_start)}
+                    · {i === 0 ? "current" : "survived a later boot"}
+                  </td>
+                </tr>
+                {#each band.rows as row (row.id)}
+                  <tr class:row-new={row.id === lastRun?.inserted?.id}>
+                    <td class="col-numeric">{row.id}</td>
+                    <td>{row.item}</td>
+                    <td class="col-numeric">{row.qty}</td>
+                    <td class="col-numeric">{money(row.unit_price)}</td>
+                    <td>{clock(row.written_at)}</td>
+                  </tr>
+                {/each}
+              {/each}
+            </tbody>
+          </table>
+          <p class="result-footer">({lastRun?.total_orders ?? 0} rows)</p>
+          <p class="result-note">
+            Bands group rows written by the same database process. A new band
+            means the VM was rebuilt from scratch; older rows surviving it
+            show the data outlives the VM.
+          </p>
+        </div>
+      {/if}
     </div>
-  {/if}
-
-  {#if runs.length > 1}
-    <div class="history">
-      <h3 class="history-title">this session</h3>
-      <ul class="history-list">
-        {#each runs as run, i (runs.length - i)}
-          <li class="history-row">
-            <span class="history-class">{run.classification}</span>
-            <span class="history-connect">{ms(run.connect_ms)} connect</span>
-            <span class="history-query">{ms(run.query_ms)} query</span>
-          </li>
-        {/each}
-      </ul>
-    </div>
-  {/if}
+  </div>
 </section>
 
 <style>
   .pg-panel {
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-    max-width: 860px;
+    display: grid;
+    grid-template-columns: 380px 1fr;
+    align-items: start;
+    gap: 20px;
+    max-width: 1100px;
   }
 
-  .lifecycle-card {
+  @media (max-width: 900px) {
+    .pg-panel {
+      grid-template-columns: 1fr;
+    }
+
+    .right-col {
+      order: -1;
+    }
+  }
+
+  .left-col {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .right-col {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .state-block {
     background: var(--surface);
     border: 1px solid var(--line);
     border-radius: 10px;
     padding: 18px 20px;
+    min-height: 212px;
     display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 14px 22px;
+    flex-direction: column;
+    gap: 12px;
   }
 
   .state-chip {
@@ -599,6 +759,7 @@
     border: 1px solid var(--line);
     font-weight: 700;
     font-size: 15px;
+    align-self: flex-start;
   }
 
   .state-dot {
@@ -640,22 +801,15 @@
     }
   }
 
-  .state-hint {
-    margin: 0;
-    color: var(--text-dim);
-    font-size: 13px;
-    flex: 1 1 200px;
-  }
-
-  .state-hero {
+  .state-sentence {
     margin: 0;
     color: var(--ink);
-    font-size: 19px;
-    line-height: 1.4;
-    flex: 1 1 100%;
+    font-size: 15px;
+    line-height: 1.45;
+    min-height: 2.9em;
   }
 
-  .state-hero strong {
+  .state-sentence strong {
     font-weight: 700;
   }
 
@@ -663,6 +817,7 @@
     display: flex;
     gap: 18px;
     margin: 0;
+    opacity: 0.7;
   }
 
   .state-facts dt {
@@ -678,8 +833,32 @@
     font-weight: 600;
   }
 
+  .savings-line {
+    margin: 0;
+    font-size: 13px;
+    color: var(--text-faint);
+    opacity: 0.6;
+  }
+
+  .savings-line.savings-active {
+    color: var(--ink);
+    opacity: 1;
+  }
+
+  .savings-value {
+    display: inline-block;
+    min-width: 8ch;
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+  }
+
+  .savings-caption {
+    margin: -8px 0 0;
+    font-size: 11px;
+    color: var(--text-faint);
+  }
+
   .soft-error {
-    flex-basis: 100%;
     margin: 0;
     color: var(--danger);
     font-size: 12px;
@@ -687,9 +866,8 @@
 
   .controls {
     display: flex;
-    align-items: center;
+    flex-direction: column;
     gap: 10px;
-    flex-wrap: wrap;
   }
 
   .run-btn,
@@ -702,6 +880,8 @@
     font-weight: 600;
     font-size: 14px;
     cursor: pointer;
+    min-width: 100%;
+    box-sizing: border-box;
   }
 
   .run-btn {
@@ -729,6 +909,12 @@
     gap: 10px;
   }
 
+  .destructive-group .truncate-btn,
+  .destructive-group .reset-btn {
+    flex: 1 1 50%;
+    min-width: 0;
+  }
+
   .truncate-btn,
   .reset-btn {
     background: var(--surface);
@@ -742,7 +928,6 @@
   }
 
   .destructive-caption {
-    flex-basis: 100%;
     margin: 0;
     font-size: 12px;
     color: var(--text-faint);
@@ -758,55 +943,31 @@
     color: var(--text-dim);
   }
 
-  .stopwatch-card {
-    display: flex;
-    align-items: baseline;
-    gap: 14px;
+  .last-run {
     background: var(--surface);
     border: 1px solid var(--line);
     border-radius: 10px;
-    padding: 14px 20px;
+    padding: 18px 20px;
   }
 
-  .stopwatch-value {
-    font-size: 26px;
-    font-weight: 700;
-    font-variant-numeric: tabular-nums;
-    color: var(--accent);
-  }
-
-  .stopwatch-narration {
-    font-size: 13px;
-    color: var(--text-dim);
-  }
-
-  .timing-card {
-    background: var(--surface);
-    border: 1px solid var(--line);
-    border-radius: 10px;
-    padding: 20px;
-  }
-
-  .timing-headline {
+  .last-run-numbers {
     display: flex;
-    align-items: baseline;
-    gap: 32px;
-    flex-wrap: wrap;
+    gap: 28px;
   }
 
-  .timing-big {
+  .last-run-big {
     display: flex;
     flex-direction: column;
   }
 
-  .timing-value {
-    font-size: 34px;
+  .last-run-value {
+    font-size: 30px;
     font-weight: 700;
     font-variant-numeric: tabular-nums;
     line-height: 1.1;
   }
 
-  .timing-label {
+  .last-run-label {
     font-size: 12px;
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -814,19 +975,19 @@
     margin-top: 4px;
   }
 
-  .timing-class {
-    margin-left: auto;
+  .last-run-narration {
+    margin: 10px 0 0;
     font-size: 13px;
-    font-weight: 600;
-    color: var(--accent);
+    color: var(--text-dim);
+    min-height: 1.4em;
   }
 
   .timing-bar {
     display: flex;
-    height: 10px;
-    border-radius: 5px;
+    height: 8px;
+    border-radius: 4px;
     overflow: hidden;
-    margin-top: 16px;
+    margin-top: 12px;
     background: var(--paper);
   }
 
@@ -838,18 +999,15 @@
     background: var(--svc-fc);
   }
 
-  .timing-note {
-    margin: 12px 0 0;
-    font-size: 13px;
-    color: var(--text-dim);
-  }
-
   .tiers {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 14px 18px;
     display: flex;
     align-items: center;
-    gap: 16px;
+    gap: 14px;
     flex-wrap: wrap;
-    padding: 4px 6px;
   }
 
   .tier {
@@ -858,7 +1016,7 @@
   }
 
   .tier-value {
-    font-size: 22px;
+    font-size: 20px;
     font-weight: 700;
     font-variant-numeric: tabular-nums;
   }
@@ -872,7 +1030,7 @@
 
   .tier-arrow {
     color: var(--text-faint);
-    font-size: 20px;
+    font-size: 18px;
   }
 
   .tiers-caption {
@@ -881,152 +1039,58 @@
     color: var(--text-faint);
   }
 
-  .statement-card {
+  .formula-bar {
+    margin: 0;
+    padding: 6px 4px;
+    font-family: var(--font-mono, monospace);
+    font-size: 12px;
+    color: var(--text-faint);
+  }
+
+  .result-card {
     background: var(--surface);
     border: 1px solid var(--line);
     border-radius: 10px;
-    padding: 16px 20px;
+    padding: 18px 20px;
+    min-height: 420px;
   }
 
-  .statement-title {
-    margin: 0 0 10px;
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--text-dim);
-  }
-
-  .statement-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+  .result-view {
     display: flex;
     flex-direction: column;
     gap: 4px;
   }
 
-  .statement-row {
-    display: flex;
-    align-items: baseline;
-    gap: 16px;
-    font-size: 13px;
+  @media (prefers-reduced-motion: no-preference) {
+    .result-view.swap-in {
+      animation: result-crossfade 150ms ease-out;
+    }
+
+    @keyframes result-crossfade {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    }
   }
 
-  .statement-sql {
-    flex: 1 1 auto;
-    font-family: var(--font-mono, monospace);
-    color: var(--ink);
-    white-space: pre-wrap;
-    word-break: break-word;
-  }
-
-  .statement-ms {
-    flex: 0 0 auto;
-    font-family: var(--font-mono, monospace);
-    text-align: right;
-    color: var(--text-faint);
-    font-variant-numeric: tabular-nums;
-  }
-
-  .aggregate-card {
-    background: var(--surface);
-    border: 1px solid var(--line);
-    border-radius: 10px;
-    padding: 20px;
-  }
-
-  .aggregate-headline {
-    margin: 0 0 14px;
-    font-size: 22px;
-    font-weight: 700;
-    font-variant-numeric: tabular-nums;
-  }
-
-  .aggregate-revenue {
-    color: var(--accent);
-  }
-
-  .aggregate-orders {
-    color: var(--ink);
-  }
-
-  .aggregate-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-
-  .aggregate-row {
-    display: grid;
-    grid-template-columns: 1fr auto auto;
-    align-items: center;
-    column-gap: 14px;
-    row-gap: 4px;
-    font-size: 13px;
-  }
-
-  .aggregate-item {
-    font-weight: 600;
-  }
-
-  .aggregate-units {
-    color: var(--text-dim);
-    font-variant-numeric: tabular-nums;
-  }
-
-  .aggregate-item-revenue {
-    font-variant-numeric: tabular-nums;
-    font-weight: 600;
-    text-align: right;
-  }
-
-  .aggregate-bar-track {
-    grid-column: 1 / -1;
-    height: 6px;
-    border-radius: 3px;
-    background: var(--paper);
-    overflow: hidden;
-  }
-
-  .aggregate-bar-fill {
-    display: block;
-    height: 100%;
-    background: var(--accent);
-  }
-
-  .rows-card,
-  .history {
-    background: var(--surface);
-    border: 1px solid var(--line);
-    border-radius: 10px;
-    padding: 18px 20px;
-  }
-
-  .rows-title,
-  .history-title {
-    margin: 0 0 12px;
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--text-dim);
-  }
-
-  .rows-table {
+  .result-table {
     width: 100%;
     border-collapse: collapse;
     font-size: 13px;
     font-family: var(--font-mono, monospace);
   }
 
-  .rows-table th {
+  .result-table th {
     text-align: left;
     padding: 4px 10px 8px 0;
     border-bottom: 1px solid var(--line);
     vertical-align: bottom;
   }
 
-  .rows-table th.col-numeric {
+  .result-table th.col-numeric {
     text-align: right;
   }
 
@@ -1047,13 +1111,13 @@
     font-weight: 400;
   }
 
-  .rows-table td {
+  .result-table td {
     padding: 6px 10px 6px 0;
     border-bottom: 1px solid var(--line);
     font-variant-numeric: tabular-nums;
   }
 
-  .rows-table td.col-numeric {
+  .result-table td.col-numeric {
     text-align: right;
   }
 
@@ -1072,43 +1136,42 @@
     background: color-mix(in srgb, var(--accent) 14%, transparent);
   }
 
-  .rows-footer {
+  .summary-row td:first-child {
+    position: relative;
+  }
+
+  .summary-bar {
+    position: absolute;
+    inset: 2px 0;
+    background: color-mix(in srgb, var(--accent) 14%, transparent);
+    border-radius: 3px;
+    z-index: 0;
+  }
+
+  .summary-item {
+    position: relative;
+    z-index: 1;
+    padding-left: 6px;
+    font-weight: 600;
+  }
+
+  .summary-total td {
+    border-bottom: none;
+    border-top: 2px solid var(--line);
+    font-weight: 700;
+    padding-top: 10px;
+  }
+
+  .result-footer {
     margin: 10px 0 0;
     font-size: 12px;
     font-family: var(--font-mono, monospace);
     color: var(--text-faint);
   }
 
-  .rows-note {
+  .result-note {
     margin: 12px 0 0;
     font-size: 12px;
-    color: var(--text-dim);
-  }
-
-  .history-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-  }
-
-  .history-row {
-    display: flex;
-    gap: 18px;
-    font-size: 13px;
-    font-variant-numeric: tabular-nums;
-  }
-
-  .history-class {
-    width: 90px;
-    font-weight: 600;
-    color: var(--accent);
-  }
-
-  .history-connect,
-  .history-query {
     color: var(--text-dim);
   }
 


### PR DESCRIPTION
Restructures the Firecracker demos Postgres tab into a calm two-column console, addressing layout chaos and jank in the card-stack version.

## What changed (frontend only, PostgresPanel.svelte)

- Two-column grid: lifecycle, controls, and timing on the left (fixed 380px); the result view on the right. Stacks below 900px.
- Anti-jank contract: every region always mounted, buttons fixed-size, the live wake stopwatch ticks inside the wake number slot, the narration line is always reserved. Nothing above the fold changes height at runtime.
- The aggregate button now visibly changes the result: the right pane swaps between the orders grid and a GROUP BY summary table (item/units/revenue with a bold total row), each with a one-line formula-bar caption showing the query. The per-statement SQL card and session history list are removed.
- Plain-language copy throughout for non-technical readers (Asleep, costing nothing / wake + connect / cold start / from snapshot / already awake).
- Live resource-savings counter: while the VM is banked, a session-scoped ticker accumulates 512 MiB-seconds of RAM not spent per second, with the assumption stated in a caption.
- Click smoothing: transient failures (wake-rate limiter, mid-transition connects) auto-retry with exponential backoff (500 ms to 3 s cap, 5 attempts) under the still-ticking stopwatch; unconfigured-DSN 503 surfaces immediately.
- Chart bumps: monolith 0.285.234, monolith-public 0.89.159 (coupled image).

No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)