### PR TITLE
feat(demos): hourly ledger window, sessions, and multi-visitor narration

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.159
+version: 0.89.160
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.159
+      targetRevision: 0.89.160
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.234
+version: 0.285.235
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/demos/firecracker_api.py
+++ b/projects/monolith/demos/firecracker_api.py
@@ -12,6 +12,7 @@ waterfall:
 - ``GET  /postgres/status``  the demo-postgres stateful lifecycle (sleep indicator).
 - ``POST /postgres/query``   timed connect (the wake) + insert or aggregate against demo-postgres.
 - ``POST /postgres/reset``   destroy the live VM + evict its snapshot (force cold boot).
+- ``POST /postgres/session`` mint a session cookie for ledger attribution (Turnstile-gated when public).
 
 Each POST wraps its invocation in a fresh ROOT span, detached from any inbound
 trace context, via ``context=Context()``. Browser-initiated requests arrive
@@ -28,17 +29,19 @@ owns no fc-invoke or ClickHouse client of its own.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
 import random
+import secrets
 from time import perf_counter
 from typing import Literal
 from uuid import uuid4
 
 import httpx
 import psycopg
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request, Response
 from opentelemetry import trace
 from opentelemetry.context import Context
 from pydantic import BaseModel
@@ -580,6 +583,31 @@ def _demo_pg_dsn() -> str:
     return os.environ.get("DEMO_POSTGRES_DSN", "")
 
 
+def _demo_pg_turnstile_secret() -> str:
+    """Read at call time so tests can patch the environment."""
+    return os.environ.get("TURNSTILE_SECRET_KEY", "")
+
+
+_DEMO_PG_SESSION_COOKIE = "demo_pg_session"
+
+
+def _demo_pg_session_salt() -> str:
+    """Derived from the DSN so the salt is stable across replicas and restarts
+    without a new secret. Never returned to clients."""
+    return hashlib.sha256(
+        ("demo-pg-session-salt:" + _demo_pg_dsn()).encode()
+    ).hexdigest()
+
+
+def _demo_pg_session_tag(cookie_value: str) -> str | None:
+    """Hash the session cookie into an opaque per-visitor tag for attribution.
+    Returns None when there is no cookie to tag."""
+    if not cookie_value:
+        return None
+    salt = _demo_pg_session_salt()
+    return hashlib.sha256((salt + ":" + cookie_value).encode()).hexdigest()[:16]
+
+
 async def _fetch_demo_pg_status() -> dict:
     """GET the control plane's stateful introspection for the demo workload."""
     async with httpx.AsyncClient(timeout=10) as client:
@@ -646,16 +674,29 @@ _DEMO_PG_DDL = (
     "  qty int NOT NULL,"
     "  unit_price numeric(8,2) NOT NULL,"
     "  written_at timestamptz NOT NULL DEFAULT now(),"
-    "  postmaster_start timestamptz NOT NULL)"
+    "  postmaster_start timestamptz NOT NULL,"
+    "  session_tag text)"
 )
 
+# The prod table predates session_tag; this idempotent ALTER backfills it on
+# every roundtrip so existing deployments pick up the column without a
+# separate migration step.
+_DEMO_PG_ADD_SESSION_TAG = (
+    "ALTER TABLE demo_orders ADD COLUMN IF NOT EXISTS session_tag text"
+)
+
+# The ledger is a rolling one-hour window: this sweep runs lazily on the
+# first query past the hour (the VM may be asleep at the stroke of the hour,
+# and nothing can observe the data until a query wakes it anyway).
+_DEMO_PG_SWEEP = "DELETE FROM demo_orders WHERE written_at < date_trunc('hour', now())"
+
 _DEMO_PG_INSERT = (
-    "INSERT INTO demo_orders (item, qty, unit_price, postmaster_start) "
-    "VALUES (%s, %s, %s, pg_postmaster_start_time()) RETURNING id"
+    "INSERT INTO demo_orders (item, qty, unit_price, postmaster_start, session_tag) "
+    "VALUES (%s, %s, %s, pg_postmaster_start_time(), %s) RETURNING id"
 )
 
 _DEMO_PG_RECENT = (
-    "SELECT id, item, qty, unit_price, written_at, postmaster_start "
+    "SELECT id, item, qty, unit_price, written_at, postmaster_start, session_tag "
     "FROM demo_orders ORDER BY id DESC LIMIT %s"
 )
 
@@ -670,7 +711,7 @@ _DEMO_PG_TOTALS = (
 )
 
 
-def _demo_pg_orders_roundtrip(dsn: str, mode: str) -> dict:
+def _demo_pg_orders_roundtrip(dsn: str, mode: str, session_tag: str | None) -> dict:
     """Connect, run the mode's statements, and time each one. Sync; to_thread.
 
     connect_ms is the wake (the activator parks the TCP connect while the VM
@@ -678,7 +719,8 @@ def _demo_pg_orders_roundtrip(dsn: str, mode: str) -> dict:
     its own wall time so the UI can show the SQL that just ran. The connection
     is short-lived by design: an open connection pins the VM awake.
 
-    insert    - DDL-if-missing, append a random menu line item, then read the
+    insert    - DDL-if-missing, sweep the ledger to its rolling one-hour
+                window, append a random menu line item, then read the
                 recent rows, the aggregate breakdown, and the totals.
     aggregate - read-only: the same reads without writing anything, proving a
                 wake needs no write.
@@ -699,10 +741,12 @@ def _demo_pg_orders_roundtrip(dsn: str, mode: str) -> dict:
     # psycopg3: the connection context commits on clean exit AND closes.
     with conn, conn.cursor() as cur:
         run(cur, _DEMO_PG_DDL)
+        run(cur, _DEMO_PG_ADD_SESSION_TAG)
+        run(cur, _DEMO_PG_SWEEP)
         if mode == "insert":
             item, unit_price = random.choice(_DEMO_PG_MENU)
             qty = random.randint(1, 5)
-            run(cur, _DEMO_PG_INSERT, (item, qty, unit_price))
+            run(cur, _DEMO_PG_INSERT, (item, qty, unit_price, session_tag))
             inserted = {
                 "id": cur.fetchone()[0],
                 "item": item,
@@ -718,6 +762,7 @@ def _demo_pg_orders_roundtrip(dsn: str, mode: str) -> dict:
                 "unit_price": float(r[3]),
                 "written_at": r[4].isoformat(),
                 "postmaster_start": r[5].isoformat(),
+                "yours": bool(session_tag and r[6] == session_tag),
             }
             for r in cur.fetchall()
         ]
@@ -748,6 +793,10 @@ class PostgresQueryRequest(BaseModel):
     mode: Literal["insert", "aggregate"] = "insert"
 
 
+class PostgresSessionRequest(BaseModel):
+    turnstile_token: str = ""
+
+
 @router.get("/postgres/status")
 async def postgres_status() -> dict:
     """The demo-postgres lifecycle snapshot driving the sleep indicator.
@@ -768,7 +817,7 @@ async def postgres_status() -> dict:
 
 
 @router.post("/postgres/query")
-async def postgres_query(body: PostgresQueryRequest) -> dict:
+async def postgres_query(body: PostgresQueryRequest, request: Request) -> dict:
     """Timed roundtrip against demo-postgres: the wake IS the connect time.
 
     Captures the lifecycle state just before connecting to classify what this
@@ -784,6 +833,8 @@ async def postgres_query(body: PostgresQueryRequest) -> dict:
             status_code=503, detail="DEMO_POSTGRES_DSN is not configured"
         )
 
+    session_tag = _demo_pg_session_tag(request.cookies.get(_DEMO_PG_SESSION_COOKIE, ""))
+
     before = None
     if EMBERVM_URL:
         try:
@@ -794,7 +845,9 @@ async def postgres_query(body: PostgresQueryRequest) -> dict:
 
     started = perf_counter()
     try:
-        result = await asyncio.to_thread(_demo_pg_orders_roundtrip, dsn, body.mode)
+        result = await asyncio.to_thread(
+            _demo_pg_orders_roundtrip, dsn, body.mode, session_tag
+        )
     except Exception as exc:  # noqa: BLE001 - surface connect/query failures in-band
         logger.warning("demo-postgres query roundtrip failed: %s", exc)
         return {
@@ -839,30 +892,49 @@ async def postgres_reset() -> dict:
     }
 
 
-def _demo_pg_truncate(dsn: str) -> dict:
-    """TRUNCATE demo_orders. Sync; via to_thread. Wakes the VM like any connect."""
-    started = perf_counter()
-    conn = psycopg.connect(dsn, connect_timeout=_DEMO_PG_CONNECT_TIMEOUT_S)
-    connect_ms = (perf_counter() - started) * 1000
-    with conn, conn.cursor() as cur:
-        cur.execute(_DEMO_PG_DDL)
-        cur.execute("TRUNCATE demo_orders")
-    return {"truncated": True, "connect_ms": connect_ms}
-
-
-@router.post("/postgres/truncate")
-async def postgres_truncate() -> dict:
-    """Clear the ledger. The data dies, the VM lives: the mirror image of reset
-    (which destroys the VM and keeps the data). Private tier only, like the
-    rest of this router. Errors come back in-band, mirroring the query shape.
-    """
-    dsn = _demo_pg_dsn()
-    if not dsn:
-        raise HTTPException(
-            status_code=503, detail="DEMO_POSTGRES_DSN is not configured"
+async def _verify_turnstile(token: str) -> bool:
+    """Server-side verification against Cloudflare's siteverify endpoint."""
+    if not token:
+        return False
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.post(
+            "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+            data={"secret": _demo_pg_turnstile_secret(), "response": token},
         )
-    try:
-        return await asyncio.to_thread(_demo_pg_truncate, dsn)
-    except Exception as exc:  # noqa: BLE001 - surface connect failures in-band
-        logger.warning("demo-postgres truncate failed: %s", exc)
-        return {"truncated": False, "error": str(exc)}
+        resp.raise_for_status()
+        return bool(resp.json().get("success"))
+
+
+@router.post("/postgres/session")
+async def postgres_session(
+    body: PostgresSessionRequest, request: Request, response: Response
+) -> dict:
+    """Mint a session cookie for ledger attribution, gated by Turnstile when
+    the demo is public.
+
+    Private tier (behind Cloudflare Access) leaves TURNSTILE_SECRET_KEY unset,
+    so it mints without verification. Once a public page sits in front of
+    this endpoint, setting the env turns on server-side Turnstile
+    verification so anonymous visitors can't mint sessions without solving
+    the challenge.
+    """
+    existing = request.cookies.get(_DEMO_PG_SESSION_COOKIE, "")
+    if existing:
+        return {"ok": True, "existing": True}
+
+    secret = _demo_pg_turnstile_secret()
+    if secret:
+        verified = await _verify_turnstile(body.turnstile_token)
+        if not verified:
+            raise HTTPException(status_code=403, detail="turnstile verification failed")
+
+    response.set_cookie(
+        _DEMO_PG_SESSION_COOKIE,
+        secrets.token_hex(16),
+        httponly=True,
+        samesite="lax",
+        secure=True,
+        max_age=3600,
+        path="/api/demos/firecracker/postgres",
+    )
+    return {"ok": True, "existing": False}

--- a/projects/monolith/demos/firecracker_api_test.py
+++ b/projects/monolith/demos/firecracker_api_test.py
@@ -293,9 +293,10 @@ def test_postgres_query_returns_timings_and_classification(monkeypatch):
     async def fake_status():
         return _pg_status_payload(state="banked", pair_valid=True)
 
-    def fake_roundtrip(dsn, mode):
+    def fake_roundtrip(dsn, mode, session_tag):
         assert dsn == "postgresql://x"
         assert mode == "insert"
+        assert session_tag is None
         return {
             "connect_ms": 850.0,
             "query_ms": 12.0,
@@ -359,7 +360,7 @@ def test_postgres_query_aggregate_mode(monkeypatch):
     async def fake_status():
         return _pg_status_payload(state="serving")
 
-    def fake_roundtrip(dsn, mode):
+    def fake_roundtrip(dsn, mode, session_tag):
         assert mode == "aggregate"
         return {
             "connect_ms": 1.5,
@@ -393,7 +394,7 @@ def test_postgres_query_default_mode_is_insert(monkeypatch):
     async def fake_status():
         return _pg_status_payload(state="serving")
 
-    def fake_roundtrip(dsn, mode):
+    def fake_roundtrip(dsn, mode, session_tag):
         assert mode == "insert"
         return {
             "connect_ms": 1.5,
@@ -425,7 +426,7 @@ def test_postgres_query_connect_failure_is_in_band(monkeypatch):
     async def fake_status():
         return _pg_status_payload(state="serving")
 
-    def fake_roundtrip(dsn, mode):
+    def fake_roundtrip(dsn, mode, session_tag):
         raise OSError("connection refused")
 
     monkeypatch.setattr(fc, "_fetch_demo_pg_status", fake_status)
@@ -481,36 +482,123 @@ def test_postgres_reset_proxies_destroy(monkeypatch):
     assert resp.json() == {"destroyed": 1, "evicted": 1}
 
 
-def test_postgres_truncate_unconfigured_is_503(monkeypatch):
-    monkeypatch.delenv("DEMO_POSTGRES_DSN", raising=False)
+def test_postgres_session_mint_without_turnstile_secret(monkeypatch):
+    monkeypatch.delenv("TURNSTILE_SECRET_KEY", raising=False)
 
-    resp = _client().post("/api/demos/firecracker/postgres/truncate")
-    assert resp.status_code == 503
-
-
-def test_postgres_truncate_ok(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-
-    def fake_truncate(dsn):
-        return {"truncated": True, "connect_ms": 5.0}
-
-    monkeypatch.setattr(fc, "_demo_pg_truncate", fake_truncate)
-
-    resp = _client().post("/api/demos/firecracker/postgres/truncate")
-    assert resp.status_code == 200
-    assert resp.json() == {"truncated": True, "connect_ms": 5.0}
-
-
-def test_postgres_truncate_error_in_band(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-
-    def fake_truncate(dsn):
-        raise OSError("connection refused")
-
-    monkeypatch.setattr(fc, "_demo_pg_truncate", fake_truncate)
-
-    resp = _client().post("/api/demos/firecracker/postgres/truncate")
+    resp = _client().post("/api/demos/firecracker/postgres/session", json={})
     assert resp.status_code == 200
     body = resp.json()
-    assert body["truncated"] is False
-    assert "connection refused" in body["error"]
+    assert body == {"ok": True, "existing": False}
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "demo_pg_session" in set_cookie
+    assert "HttpOnly" in set_cookie
+
+
+def test_postgres_session_requires_token_when_turnstile_configured(monkeypatch):
+    monkeypatch.setenv("TURNSTILE_SECRET_KEY", "sekret")
+
+    resp = _client().post("/api/demos/firecracker/postgres/session", json={})
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "turnstile verification failed"
+
+
+def test_postgres_session_verifies_token_with_turnstile(monkeypatch):
+    monkeypatch.setenv("TURNSTILE_SECRET_KEY", "sekret")
+
+    captured = {}
+
+    class FakeResponse:
+        def __init__(self, success):
+            self._success = success
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"success": self._success}
+
+    class FakeAsyncClient:
+        def __init__(self, timeout=None):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, data=None):
+            assert url == "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+            assert data["secret"] == "sekret"
+            captured["response"] = data["response"]
+            return FakeResponse(captured.get("success", False))
+
+    monkeypatch.setattr(fc.httpx, "AsyncClient", FakeAsyncClient)
+
+    captured["success"] = False
+    resp = _client().post(
+        "/api/demos/firecracker/postgres/session",
+        json={"turnstile_token": "bad-token"},
+    )
+    assert resp.status_code == 403
+    assert captured["response"] == "bad-token"
+
+    captured["success"] = True
+    resp = _client().post(
+        "/api/demos/firecracker/postgres/session",
+        json={"turnstile_token": "good-token"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"ok": True, "existing": False}
+    assert "demo_pg_session" in resp.headers.get("set-cookie", "")
+
+
+def test_postgres_session_existing_cookie_short_circuits(monkeypatch):
+    monkeypatch.delenv("TURNSTILE_SECRET_KEY", raising=False)
+
+    client = _client()
+    client.cookies.set("demo_pg_session", "already-here")
+
+    resp = client.post("/api/demos/firecracker/postgres/session", json={})
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "existing": True}
+    assert "set-cookie" not in resp.headers
+
+
+def test_postgres_query_passes_session_tag_from_cookie(monkeypatch):
+    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
+    monkeypatch.setattr(fc, "EMBERVM_URL", "http://embervm")
+
+    async def fake_status():
+        return _pg_status_payload(state="serving")
+
+    captured = {}
+
+    def fake_roundtrip(dsn, mode, session_tag):
+        captured["session_tag"] = session_tag
+        return {
+            "connect_ms": 1.5,
+            "query_ms": 3.0,
+            "mode": mode,
+            "statements": [],
+            "inserted": None,
+            "rows": [],
+            "breakdown": [],
+            "total_orders": 0,
+            "total_revenue": 0.0,
+            "postmaster_start": "2026-07-17T08:00:00+00:00",
+        }
+
+    monkeypatch.setattr(fc, "_fetch_demo_pg_status", fake_status)
+    monkeypatch.setattr(fc, "_demo_pg_orders_roundtrip", fake_roundtrip)
+
+    client = _client()
+    client.cookies.set("demo_pg_session", "visitor-cookie-value")
+
+    resp = client.post("/api/demos/firecracker/postgres/query", json={})
+    assert resp.status_code == 200
+    tag = captured["session_tag"]
+    assert isinstance(tag, str)
+    assert len(tag) == 16
+    assert re.fullmatch(r"[0-9a-f]{16}", tag)

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.234
+      targetRevision: 0.285.235
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/PostgresPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/PostgresPanel.svelte
@@ -15,13 +15,15 @@
   //                  statements against an orders ledger, and returns two
   //                  separately-bracketed wall times: connect (which IS the
   //                  wake when asleep) and query, plus the verbatim SQL run.
-  //   truncate    -> POST /api/demos/firecracker/postgres/truncate. Clears
-  //                  the ledger; the VM lives, the data dies (the mirror of
-  //                  reset, which destroys the VM and keeps the data).
   //   reset       -> POST /api/demos/firecracker/postgres/reset. Destroys the
   //                  live VM AND evicts its snapshot; the data volume
   //                  survives, so the next query pays a full cold boot against
   //                  retained rows: the durability proof on demand.
+  //
+  // The ledger is a rolling one-hour window: the backend lazily deletes rows
+  // older than the current hour on each query, so there's no manual clear.
+  // A session cookie (minted fire-and-forget on mount) attributes inserted
+  // rows to the caller, surfaced in the grid as the "yours" column.
   import { onMount } from "svelte";
 
   const API = "/api/demos/firecracker/postgres";
@@ -44,6 +46,7 @@
     { key: "qty", label: "qty", type: "int" },
     { key: "unit_price", label: "unit_price", type: "numeric(8,2)" },
     { key: "written_at", label: "written_at", type: "timestamptz" },
+    { key: "yours", label: "session", type: "who" },
   ];
 
   const ORDERS_SQL = "SELECT * FROM demo_orders ORDER BY id DESC";
@@ -54,13 +57,11 @@
   let statusError = $state("");
   let running = $state(false);
   let resetting = $state(false);
-  let truncating = $state(false);
-  let truncateConfirming = $state(false);
   let lastRun = $state(null);
   let runError = $state("");
 
-  // Which result shape the right column shows. INSERT and TRUNCATE land on
-  // the orders grid; the aggregate query switches to the summary table.
+  // Which result shape the right column shows. INSERT lands on the orders
+  // grid; the aggregate query switches to the summary table.
   let view = $state("orders");
 
   // Best-seen wall time per boot path: the demo's headline comparison.
@@ -137,8 +138,8 @@
   // times, waiting the next backoff delay between attempts. doAttempt should
   // return {ok: true, ...} on success or {ok: false, permanent, error} on a
   // failure worth surfacing; a thrown error is treated as transient. The
-  // caller's own running/truncating flag is expected to already be set, so
-  // this never overlaps with a fresh click.
+  // caller's own running flag is expected to already be set, so this never
+  // overlaps with a fresh click.
   async function fetchWithBackoff(doAttempt) {
     let lastResult = null;
     for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
@@ -182,6 +183,38 @@
       savingsTimer = null;
     }
   }
+
+  // Hourly reset countdown: the backend lazily deletes rows older than the
+  // current hour on each query, so there's no event to listen for, just a
+  // clock. A plain 1 s setInterval keeps a $state(Date.now()) fresh; the
+  // remaining time to the next top of the hour is derived from it.
+  let nowMs = $state(Date.now());
+  let clockTimer = null;
+
+  function startClockTimer() {
+    clockTimer = setInterval(() => {
+      nowMs = Date.now();
+    }, 1000);
+  }
+
+  function stopClockTimer() {
+    if (clockTimer != null) {
+      clearInterval(clockTimer);
+      clockTimer = null;
+    }
+  }
+
+  let resetCountdown = $derived.by(() => {
+    const now = new Date(nowMs);
+    const next = new Date(now);
+    next.setMinutes(0, 0, 0);
+    next.setHours(next.getHours() + 1);
+    const remainingS = Math.max(0, Math.round((next.getTime() - now.getTime()) / 1000));
+    const mm = String(Math.floor(remainingS / 60)).padStart(2, "0");
+    const ss = String(remainingS % 60).padStart(2, "0");
+    const clockLabel = next.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    return { mmss: `${mm}:${ss}`, clockLabel };
+  });
 
   async function pollStatus() {
     try {
@@ -234,7 +267,6 @@
 
   async function runQuery(mode) {
     if (running) return;
-    truncateConfirming = false;
     running = true;
     runError = "";
     startStopwatch();
@@ -262,51 +294,8 @@
     }
   }
 
-  function onTruncateClick() {
-    if (running || truncating) return;
-    if (!truncateConfirming) {
-      truncateConfirming = true;
-      return;
-    }
-    truncateConfirming = false;
-    truncateLedger();
-  }
-
-  async function attemptTruncate() {
-    const resp = await fetch(`${API}/truncate`, { method: "POST" });
-    const body = await resp.json();
-    if (resp.status === 503 && /not configured/i.test(body?.detail ?? "")) {
-      return { ok: false, permanent: true, error: body.detail };
-    }
-    if (!resp.ok) {
-      return { ok: false, error: body?.detail || `truncate failed (${resp.status})` };
-    }
-    if (!body.truncated) {
-      return { ok: false, error: body.error || "truncate failed" };
-    }
-    return { ok: true };
-  }
-
-  async function truncateLedger() {
-    truncating = true;
-    runError = "";
-    try {
-      const result = await fetchWithBackoff(attemptTruncate);
-      if (!result.ok) {
-        runError = result.error;
-        return;
-      }
-      lastRun = null;
-      view = "orders";
-    } finally {
-      truncating = false;
-      cancelPendingRetry();
-    }
-  }
-
   async function resetInstance() {
     if (resetting) return;
-    truncateConfirming = false;
     resetting = true;
     runError = "";
     try {
@@ -323,16 +312,27 @@
   }
 
   onMount(() => {
+    // Fire-and-forget: mints the session cookie that attributes inserted
+    // rows to this visitor. Kicked off first (not awaited) so it usually
+    // wins the race with the first insert click, without blocking paint.
+    fetch(`${API}/session`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ turnstile_token: "" }),
+    }).catch(() => {});
+
     // Opening the tab IS the wake-on-connect demo: fire a read-only aggregate
     // unprompted so the visitor watches the VM wake for them without writing,
     // then start the lifecycle poll.
     runQuery("aggregate");
     pollStatus();
     pollTimer = setInterval(pollStatus, POLL_MS);
+    startClockTimer();
     return () => {
       clearInterval(pollTimer);
       stopStopwatch();
       stopSavingsTimer();
+      stopClockTimer();
       cancelPendingRetry();
       if (pulseTimer) clearTimeout(pulseTimer);
     };
@@ -533,20 +533,6 @@
       </button>
       <div class="destructive-group">
         <button
-          class="truncate-btn"
-          class:confirming={truncateConfirming}
-          type="button"
-          onclick={onTruncateClick}
-          disabled={running || truncating}
-          title="TRUNCATE demo_orders. The VM lives, the data dies."
-        >
-          {truncating
-            ? "Truncating…"
-            : truncateConfirming
-              ? "really truncate?"
-              : "Clear ledger (TRUNCATE)"}
-        </button>
-        <button
           class="reset-btn"
           type="button"
           onclick={resetInstance}
@@ -557,8 +543,8 @@
         </button>
       </div>
       <p class="destructive-caption">
-        truncate keeps the VM and kills the data; cold boot keeps the data and
-        kills the VM
+        cold boot destroys the VM but keeps the data; the ledger clears
+        itself on the hour
       </p>
     </div>
 
@@ -614,6 +600,12 @@
 
   <div class="right-col">
     <p class="formula-bar">{view === "summary" ? SUMMARY_SQL : ORDERS_SQL}</p>
+    <p class="reset-countdown">
+      ledger resets on the hour · <span class="reset-countdown-value"
+        >{resetCountdown.mmss}</span
+      >
+      <span class="reset-countdown-clock">({resetCountdown.clockLabel})</span>
+    </p>
     <div class="result-card">
       {#if view === "summary"}
         <div class="result-view swap-in">
@@ -690,6 +682,13 @@
                     <td class="col-numeric">{row.qty}</td>
                     <td class="col-numeric">{money(row.unit_price)}</td>
                     <td>{clock(row.written_at)}</td>
+                    <td class="col-session">
+                      {#if row.yours}
+                        <span class="yours-chip">you</span>
+                      {:else}
+                        <span class="visitor-label">visitor</span>
+                      {/if}
+                    </td>
                   </tr>
                 {/each}
               {/each}
@@ -872,7 +871,6 @@
 
   .run-btn,
   .aggregate-btn,
-  .truncate-btn,
   .reset-btn {
     padding: 10px 18px;
     border-radius: 8px;
@@ -898,7 +896,6 @@
 
   .run-btn:disabled,
   .aggregate-btn:disabled,
-  .truncate-btn:disabled,
   .reset-btn:disabled {
     opacity: 0.6;
     cursor: default;
@@ -909,22 +906,9 @@
     gap: 10px;
   }
 
-  .destructive-group .truncate-btn,
-  .destructive-group .reset-btn {
-    flex: 1 1 50%;
-    min-width: 0;
-  }
-
-  .truncate-btn,
   .reset-btn {
     background: var(--surface);
     color: var(--danger);
-  }
-
-  .truncate-btn.confirming {
-    background: var(--danger);
-    border-color: var(--danger);
-    color: var(--surface);
   }
 
   .destructive-caption {
@@ -1047,6 +1031,25 @@
     color: var(--text-faint);
   }
 
+  .reset-countdown {
+    margin: 0;
+    padding: 0 4px;
+    font-size: 12px;
+    color: var(--text-faint);
+  }
+
+  .reset-countdown-value {
+    display: inline-block;
+    min-width: 5ch;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    color: var(--text-dim);
+  }
+
+  .reset-countdown-clock {
+    color: var(--text-faint);
+  }
+
   .result-card {
     background: var(--surface);
     border: 1px solid var(--line);
@@ -1119,6 +1122,27 @@
 
   .result-table td.col-numeric {
     text-align: right;
+  }
+
+  .col-session {
+    white-space: nowrap;
+  }
+
+  .yours-chip {
+    display: inline-block;
+    padding: 1px 8px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--accent) 18%, transparent);
+    color: var(--accent);
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: lowercase;
+  }
+
+  .visitor-label {
+    font-size: 11px;
+    color: var(--text-faint);
+    text-transform: lowercase;
   }
 
   .epoch-band td {

--- a/projects/monolith/frontend/src/lib/private/components/demos/PostgresPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/PostgresPanel.svelte
@@ -216,6 +216,18 @@
     return { mmss: `${mm}:${ss}`, clockLabel };
   });
 
+  // Who-woke-it inference: client-side only, no backend signal for this.
+  // prevState is the state seen on the previous poll (plain let, mutated
+  // inside pollStatus, never read reactively so it can't trigger an effect
+  // loop). lastOwnActivityAt is the wall-clock time our own last runQuery
+  // finished; likewise a plain let. othersWoke is the one piece that needs
+  // to be $state, since it must persist across polls and render.
+  let prevState = null;
+  let lastOwnActivityAt = 0;
+  let othersWoke = $state(false);
+
+  const WAKING_STATES = new Set(["relighting", "cold_booting", "starting", "serving"]);
+
   async function pollStatus() {
     try {
       const resp = await fetch(`${API}/status`);
@@ -237,9 +249,15 @@
           : 0;
       if (body.state === "banked") {
         startSavingsTimer();
+        othersWoke = false;
       } else {
         stopSavingsTimer();
       }
+      const wasAsleep = prevState == null || prevState === "banked";
+      if (wasAsleep && WAKING_STATES.has(body.state) && !running) {
+        othersWoke = true;
+      }
+      prevState = body.state;
     } catch (err) {
       statusError = String(err);
     }
@@ -269,6 +287,7 @@
     if (running) return;
     running = true;
     runError = "";
+    othersWoke = false;
     startStopwatch();
     try {
       const result = await fetchWithBackoff(() => attemptQuery(mode));
@@ -289,6 +308,7 @@
       flashConnectPulse();
     } finally {
       running = false;
+      lastOwnActivityAt = Date.now();
       cancelPendingRetry();
       stopStopwatch();
     }
@@ -470,6 +490,22 @@
       ? "Dozing off any moment."
       : null,
   );
+
+  // Who-woke-it narration: with multiple visitors on the same demo, the
+  // panel otherwise can't say whether the VM is awake because of you or
+  // someone else. othersWoke covers the transition (set in pollStatus);
+  // the second branch covers the ongoing case, an in-flight visit that
+  // keeps last_active_at fresh without any activity of our own.
+  let othersHint = $derived(
+    othersWoke
+      ? "Another visitor just woke it."
+      : status?.state === "serving" &&
+          !running &&
+          Date.now() - lastOwnActivityAt > 5000 &&
+          idleSeconds < 1.5
+        ? "Another visitor is using it right now."
+        : null,
+  );
 </script>
 
 <section class="pg-panel">
@@ -486,7 +522,7 @@
           {asleepWake}.
         </p>
       {:else}
-        <p class="state-sentence">{dozeHint ?? stateView.sentence}</p>
+        <p class="state-sentence">{dozeHint ?? othersHint ?? stateView.sentence}</p>
       {/if}
       <dl class="state-facts">
         <div>


### PR DESCRIPTION
Prepares the Postgres demo for a future public page and removes the manual truncate.

## Backend
- The ledger is now a rolling one-hour window: a lazy DELETE sweep (rows older than date_trunc('hour', now())) runs before every read; the truncate endpoint is removed. The sweep is lazy by design: the VM may be asleep at the stroke of the hour, and nothing can observe the data until a query wakes it.
- New POST /postgres/session mints an HttpOnly path-scoped session cookie (1 h TTL). When TURNSTILE_SECRET_KEY is set the mint requires server-side Turnstile verification; unset (private tier behind CF Access) mints freely.
- Session attribution: inserts store a salted-hash session tag; each returned row carries yours: true/false. Raw tags and cookie values never appear in responses.

## Frontend
- Truncate UI removed; caption now explains the self-clearing ledger.
- Always-mounted countdown: "ledger resets on the hour · MM:SS".
- Session bootstrap on mount (fire-and-forget); orders grid gains a subtle session column (you / visitor).
- Multi-visitor narration inferred client-side: "Another visitor just woke it." / "Another visitor is using it right now." in the reserved state line.

## Charts
- monolith 0.285.235, monolith-public 0.89.160 (coupled image).

Tests updated/added for the new roundtrip signature, session mint paths (no-secret, missing token 403, siteverify success/failure, existing-cookie idempotence), and cookie-to-tag plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)