### PR TITLE
fix(embervm): composite FRESH members resolve source as a provisioned image

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.95
+version: 0.1.96

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.95
+      targetRevision: 0.1.96
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/group_member.go
+++ b/projects/embervm/noded/server/group_member.go
@@ -328,17 +328,22 @@ func (s *Server) groupMemberMAC(groupInstanceID, memberName string, memberIndex 
 }
 
 // resolveGroupMemberBoot resolves a FRESH member source to its bootable rootfs +
-// harness init, exactly like the stateful cold-boot source resolution: the source
-// names a built base (a NIC cold boot cannot resume a vsock-only base memory
-// snapshot, D-R3.4.2), whose imageDigest resolves to a provisioned runtime image.
+// harness init. Unlike the stateful cold-boot path (which resumes a built base
+// snapshot and so keys the base registry), a composite member FRESH is a plain
+// rootfs cold boot (plan Task 6: "FRESH cold-boots the image rootfs"; a NIC cold
+// boot never resumes a vsock-only base memory snapshot, D-R3.4.2). So the source
+// names a provisioned runtime image directly, not a built base: the control plane
+// sends member.image_ref as the source, the per-member rootfs is staged on the
+// node by the noded init-container base builder, and s.cfg.Images is the node-side
+// image identity table (image_ref -> {rootfsPath, harnessInit}). Resolving through
+// s.bases here (keyed by baseKeyFor(workload, image_ref, revision), never the raw
+// image_ref) could never match the source the control plane sends, so every
+// composite member start failed with "not a ready base"; a composite cluster could
+// not boot at all until this resolved the image directly.
 func (s *Server) resolveGroupMemberBoot(source string) (rootfsPath, harnessInit string, err error) {
-	base, ok := s.bases.get(source)
-	if !ok || base.state != nodev1.BaseBuildState_BASE_BUILD_STATE_READY {
-		return "", "", status.Errorf(codes.FailedPrecondition, "noded: group member source %q is not a ready base on this node", source)
-	}
-	img, ok := s.cfg.Images[base.imageDigest]
+	img, ok := s.cfg.Images[source]
 	if !ok {
-		return "", "", status.Errorf(codes.FailedPrecondition, "noded: runtime image %q for source %q not provisioned on this node", base.imageDigest, source)
+		return "", "", status.Errorf(codes.FailedPrecondition, "noded: group member source %q is not a provisioned image on this node", source)
 	}
 	harnessInit = img.HarnessInit
 	if harnessInit == "" {

--- a/projects/embervm/noded/server/group_member_test.go
+++ b/projects/embervm/noded/server/group_member_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"strconv"
@@ -147,12 +148,15 @@ func (c *fakeGroupClock) Resync(_ context.Context, uds string) error {
 	defer c.mu.Unlock()
 	c.calls++
 	c.lastUDS = uds
-	return c.err
+	if c.err != nil {
+		return fmt.Errorf("fake group clock resync: %w", c.err)
+	}
+	return nil
 }
 
 // newGroupMemberTestServer wires a Server with the full group member lifecycle
-// (network + member driver + clock), a ready base "src-a" the FRESH source resolves
-// against, and short ready timeouts.
+// (network + member driver + clock), a provisioned image "src-a" the FRESH source
+// resolves against, and short ready timeouts.
 func newGroupMemberTestServer(t *testing.T) (*Server, *fakeGroupNet, *fakeGroupMemberDriver, *fakeGroupClock) {
 	t.Helper()
 	dir := t.TempDir()
@@ -165,7 +169,7 @@ func newGroupMemberTestServer(t *testing.T) (*Server, *fakeGroupNet, *fakeGroupM
 			Arch: "amd64", Node: "node-4", MaxLiveVMs: 8, SnapshotRoot: dir,
 			BootReadyTimeout:    2 * time.Second,
 			RestoreReadyTimeout: 2 * time.Second,
-			Images:              map[string]config.Image{"img-a": {RootfsPath: "/rootfs/a"}},
+			Images:              map[string]config.Image{"src-a": {RootfsPath: "/rootfs/a"}},
 		},
 		Driver:       groupMemberVMDriverAdapter{gmd},
 		Transport:    &fakeTransport{},
@@ -176,9 +180,9 @@ func newGroupMemberTestServer(t *testing.T) (*Server, *fakeGroupNet, *fakeGroupM
 		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
 	s.memHeadroom = func() uint64 { return 0 }
-	// A ready base "src-a" the FRESH source resolves to (image-lane: source names a
-	// base whose imageDigest is a provisioned runtime image, exactly like stateful).
-	s.bases.readyBuild("src-a", "wl-grp", "img-a", "/shim/ready", 2048)
+	// A composite member FRESH is a plain rootfs cold boot: the source names a
+	// PROVISIONED IMAGE directly (the control plane sends member.image_ref), not a
+	// built base snapshot. "src-a" is provisioned above in Config.Images.
 	// Stand up the group network so StartGroupMember's existence check passes.
 	if _, err := s.CreateGroupNetwork(context.Background(), &nodev1.CreateGroupNetworkRequest{
 		GroupInstanceId: "grp-A", Cidr: "10.101.1.0/24",
@@ -269,6 +273,30 @@ func TestStartGroupMemberFreshHealthGateFailure(t *testing.T) {
 	}
 	if len(s.nodeStatus().GetGroupMemberVms()) != 0 {
 		t.Error("no member should be published on a health-gate failure")
+	}
+}
+
+// TestStartGroupMemberFreshUnprovisionedImageFails proves a FRESH source that is not
+// a provisioned image on this node is rejected with FailedPrecondition (no VM start,
+// no tap). This is the regression guard for the composite-boot outage: the control
+// plane sends member.image_ref as the source and it must resolve directly against
+// Config.Images. An image absent from that table (a provisioning gap, or a source
+// that is a base key rather than an image_ref) fails here rather than silently.
+func TestStartGroupMemberFreshUnprovisionedImageFails(t *testing.T) {
+	s, gn, gmd, _ := newGroupMemberTestServer(t)
+	_, err := s.StartGroupMember(context.Background(), &nodev1.StartGroupMemberRequest{
+		Mode:            nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_FRESH,
+		GroupInstanceId: "grp-A", MemberName: "worker-0", MemberIndex: 0,
+		Ip: "127.0.0.1", Source: "not-provisioned", HealthPort: 1,
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("unprovisioned FRESH source: got %v want FailedPrecondition", err)
+	}
+	if gmd.claims != 0 {
+		t.Errorf("no VM should be claimed for an unresolvable source (claims=%d)", gmd.claims)
+	}
+	if len(gn.taps) != 0 {
+		t.Error("no tap should be pinned for an unresolvable source")
 	}
 }
 


### PR DESCRIPTION
## What the R5 gate-1 drill found

Running the deferred **R5 gate 1** (cold wake to three Ready `scratch-k8s` nodes) surfaced a headline-blocking bug: the composite group can never boot. Every cold wake failed with:

```
noded: group member source ".../k3s-server:2026.07.17.23.13.21-4f517c4" is not a ready base on this node
```

Envoy accepted the connect, the control plane tried to start the `server` member, and noded rejected it. The kubectl retry storm then tripped the per-workload wake-rate limiter (fail-closed metering working correctly).

## Root cause

Composite FRESH was written to the **stateful** mental model, where the source names a built base *snapshot* keyed in `s.bases`. But bases are keyed `baseKeyFor(workload, image_ref, revision)` (e.g. `scratch-k8s__523d71cc61bb` — this is literally the CR's `snapshotRef`), while the control plane sends `member.image_ref` as the source (`group_manager.ex:411`). Those keys can never match, so `resolveGroupMemberBoot` (`group_member.go`) always returned "not a ready base."

It passed all CI because noded is stubbed in unit tests and the group path was never live-drilled — the sibling stateful/serving lanes resolve through the base key correctly, which is why demo-postgres etc. are `Ready`. Classic "code shipped ≠ behavior proven," which is exactly why the R5 closure marked these gates live-pending.

## Fix

A composite member FRESH is a plain **rootfs cold boot** (plan Task 6: "FRESH cold-boots the image rootfs"), never a snapshot resume, so it needs a *provisioned image*, not a *built base*. Both member rootfs images (`k3s-server` + `k3s-agent`) are already staged on-node by the noded init-container base builder and present in `Config.Images` under the exact `image_ref` the control plane sends (verified against the running noded's `EMBERVM_NODED_IMAGES`).

So `resolveGroupMemberBoot` now resolves `source` directly against `s.cfg.Images`. **No control-plane change and no per-member base build needed.** The stateful cold-boot path (which genuinely resumes a base) is untouched.

### Alternative considered (and why not)
The "stateful-consistent" fix — build a base per distinct composite member image and pass each member's base key as the source — is much larger (touches the base builder's one-base-per-workload state model) and would build an agent base *snapshot that FRESH never uses*. Aligning the resolver with the boot model the plan specified is both simpler and more correct. Happy to switch if you'd rather preserve the "source names a built base" invariant across all classes.

## Tests
- Updated the FRESH fixture, which **masked the bug** by registering a base whose key equalled the source; it now models the real path (source names a provisioned image).
- Added `TestStartGroupMemberFreshUnprovisionedImageFails`: an unprovisioned source fails `FailedPrecondition` before any VM start or tap pin (the guard that would have caught this).
- Wrapped a pre-existing bare error return in the fake clock brought into semgrep scope.

## After merge
Deploy (chart bumped so noded redeploys), then re-run gates 1–9 against the live cluster and record the numbers into the drill runbook + plan Closure. Gate 10 is a 48h soak (separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)