### PR TITLE
fix(embervm): invalidate shared noded channel on transport death (sweeper + group manager)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.96
+version: 0.1.97

--- a/projects/embervm/control/lib/embervm/group_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_manager.ex
@@ -210,6 +210,11 @@ defmodule Embervm.GroupManager do
       # Daemon group-verb seams (injected for tests; production dials the real
       # NodeService stub over the shared NodeChannel).
       channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
+      # Drop the shared node channel when a group verb reveals its transport is dead
+      # (a noded rollout), so the next safe_channel/2 re-dials instead of every member
+      # start failing on a dead ConnectionProcess until the control plane restarts
+      # (D-R2.7.2). Injected for tests.
+      invalidate_fun: Keyword.get(opts, :invalidate_fun, &Embervm.NodeChannel.invalidate/2),
       create_group_network_fun:
         Keyword.get(opts, :create_group_network_fun, &default_create_group_network/2),
       delete_group_network_fun:
@@ -923,12 +928,12 @@ defmodule Embervm.GroupManager do
       member_name: member.member_name
     }
 
-    with {:ok, channel} <- safe_channel(state, state.node_id),
-         {:ok, %StopGroupMemberResponse{snapshot_ref: ref}} when is_binary(ref) and ref != "" <-
-           state.stop_group_member_fun.(channel, req) do
-      {:ok, %{name: member.member_name, snapshot_ref: ref}}
-    else
-      other -> {:error, {:member_bank_failed, member.member_name, other}}
+    case over_channel(state, state.node_id, &state.stop_group_member_fun.(&1, req)) do
+      {:ok, %StopGroupMemberResponse{snapshot_ref: ref}} when is_binary(ref) and ref != "" ->
+        {:ok, %{name: member.member_name, snapshot_ref: ref}}
+
+      other ->
+        {:error, {:member_bank_failed, member.member_name, other}}
     end
   rescue
     e -> {:error, {:member_bank_raised, member.member_name, e}}
@@ -1250,11 +1255,9 @@ defmodule Embervm.GroupManager do
       cidr: cidr
     }
 
-    with {:ok, channel} <- safe_channel(state, state.node_id) do
-      case state.create_group_network_fun.(channel, req) do
-        {:ok, %CreateGroupNetworkResponse{} = resp} -> {:ok, resp}
-        other -> {:error, {:create_network_failed, other}}
-      end
+    case over_channel(state, state.node_id, &state.create_group_network_fun.(&1, req)) do
+      {:ok, %CreateGroupNetworkResponse{} = resp} -> {:ok, resp}
+      other -> {:error, {:create_network_failed, other}}
     end
   rescue
     e -> {:error, {:create_network_raised, e}}
@@ -1277,9 +1280,7 @@ defmodule Embervm.GroupManager do
   end
 
   defp safe_start_group_member(state, req) do
-    with {:ok, channel} <- safe_channel(state, state.node_id) do
-      state.start_group_member_fun.(channel, req)
-    end
+    over_channel(state, state.node_id, &state.start_group_member_fun.(&1, req))
   rescue
     e -> {:error, {:start_group_member_raised, e}}
   catch
@@ -1292,6 +1293,27 @@ defmodule Embervm.GroupManager do
     e -> {:error, {:channel_raised, e}}
   catch
     kind, reason -> {:error, {:channel_raised, {kind, reason}}}
+  end
+
+  # Acquire the node's shared channel and run a group verb over it, invalidating that
+  # channel (so the next safe_channel/2 re-dials) when the call reveals the transport
+  # is dead: a transport_dead? error return, or an :exit from the Mint ConnectionProcess
+  # dying (its crash on an in-flight stream RST during a noded rollout surfaces here as
+  # an exit). A server-returned gRPC status rode a HEALTHY channel and never invalidates
+  # it (Embervm.NodeChannel.transport_dead?/1, D-R2.7.2). Returns the verb's raw result,
+  # {:error, {:exit, reason}} on an exit, or the safe_channel error if no channel.
+  defp over_channel(state, node_id, call_fun) do
+    with {:ok, channel} <- safe_channel(state, node_id) do
+      try do
+        result = call_fun.(channel)
+        if Embervm.NodeChannel.transport_dead?(result), do: state.invalidate_fun.(node_id, channel)
+        result
+      catch
+        :exit, reason ->
+          state.invalidate_fun.(node_id, channel)
+          {:error, {:exit, reason}}
+      end
+    end
   end
 
   defp default_create_group_network(channel, req) do

--- a/projects/embervm/control/lib/embervm/stateful_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/stateful_sweeper.ex
@@ -227,6 +227,10 @@ defmodule Embervm.StatefulSweeper do
       # The daemon stateful-verb seams (injected for tests; production dials
       # the real NodeService stub over the shared NodeChannel).
       channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
+      # Drop the shared node channel when a verb reveals its transport is dead (a
+      # noded rollout), so the next safe_channel/2 re-dials instead of hammering a
+      # dead ConnectionProcess forever (D-R2.7.2). Injected for tests.
+      invalidate_fun: Keyword.get(opts, :invalidate_fun, &Embervm.NodeChannel.invalidate/2),
       stop_stateful_fun: Keyword.get(opts, :stop_stateful_fun, &default_stop_stateful/2),
       # ResolveStateful seam (ADR embervm/008): (channel, %ResolveStatefulRequest{})
       # -> {:ok, %ResolveStatefulResponse{}} | {:error, _}. Injected for tests;
@@ -783,6 +787,7 @@ defmodule Embervm.StatefulSweeper do
   defp spawn_atomic_bank_worker(state, instance) do
     owner = self()
     channel_fun = state.channel_fun
+    invalidate_fun = state.invalidate_fun
     stop_fun = state.stop_stateful_fun
     instance_id = instance.instance_id
     workload = instance.workload
@@ -802,17 +807,17 @@ defmodule Embervm.StatefulSweeper do
                            }
                          } do
           try do
-            with {:ok, channel} <- safe_channel(channel_fun, node_id),
-                 {:ok, %StopStatefulResponse{snapshot_ref: ref, size_bytes: size, generation: generation}}
-                 when is_binary(ref) and ref != "" <-
-                   stop_fun.(channel, bank_request(vm_id)) do
-              # generation only becomes known once the daemon replies (the pair-key
-              # baseline the bundle is stamped with), so it is set here rather than
-              # in the span's opening attributes, exactly like ember.snapshot_bytes.
-              Tracer.set_attributes(%{"ember.snapshot_bytes" => size, "ember.generation" => generation || 0})
-              {:ok, ref, size, generation}
-            else
-              other -> {:error, other}
+            case over_channel(channel_fun, invalidate_fun, node_id, &stop_fun.(&1, bank_request(vm_id))) do
+              {:ok, %StopStatefulResponse{snapshot_ref: ref, size_bytes: size, generation: generation}}
+              when is_binary(ref) and ref != "" ->
+                # generation only becomes known once the daemon replies (the pair-key
+                # baseline the bundle is stamped with), so it is set here rather than
+                # in the span's opening attributes, exactly like ember.snapshot_bytes.
+                Tracer.set_attributes(%{"ember.snapshot_bytes" => size, "ember.generation" => generation || 0})
+                {:ok, ref, size, generation}
+
+              other ->
+                {:error, other}
             end
           rescue
             e -> {:error, {:bank_raised, e}}
@@ -841,6 +846,7 @@ defmodule Embervm.StatefulSweeper do
   defp spawn_checkpoint_worker(state, instance) do
     owner = self()
     channel_fun = state.channel_fun
+    invalidate_fun = state.invalidate_fun
     stop_fun = state.stop_stateful_fun
     settle_ms = state.propagation_settle_ms
     instance_id = instance.instance_id
@@ -863,13 +869,13 @@ defmodule Embervm.StatefulSweeper do
           if is_integer(settle_ms) and settle_ms > 0, do: Process.sleep(settle_ms)
 
           try do
-            with {:ok, channel} <- safe_channel(channel_fun, node_id),
-                 {:ok, %StopStatefulResponse{checkpoint_token: token, generation: generation}}
-                 when is_binary(token) and token != "" <-
-                   stop_fun.(channel, checkpoint_request(vm_id)) do
-              {:ok, token, generation}
-            else
-              other -> {:error, other}
+            case over_channel(channel_fun, invalidate_fun, node_id, &stop_fun.(&1, checkpoint_request(vm_id))) do
+              {:ok, %StopStatefulResponse{checkpoint_token: token, generation: generation}}
+              when is_binary(token) and token != "" ->
+                {:ok, token, generation}
+
+              other ->
+                {:error, other}
             end
           rescue
             e -> {:error, {:checkpoint_raised, e}}
@@ -1075,6 +1081,7 @@ defmodule Embervm.StatefulSweeper do
   defp spawn_resolve_worker(state, instance_id, node_id, vm_id, ip, port, workload, token, mode) do
     owner = self()
     channel_fun = state.channel_fun
+    invalidate_fun = state.invalidate_fun
     resolve_fun = state.resolve_stateful_fun
 
     spawn(fn ->
@@ -1088,12 +1095,12 @@ defmodule Embervm.StatefulSweeper do
                            }
                          } do
           try do
-            with {:ok, channel} <- safe_channel(channel_fun, node_id),
-                 {:ok, %ResolveStatefulResponse{} = resp} <-
-                   resolve_fun.(channel, resolve_request(vm_id, token, mode)) do
-              {:ok, resp}
-            else
-              other -> {:error, other}
+            case over_channel(channel_fun, invalidate_fun, node_id, &resolve_fun.(&1, resolve_request(vm_id, token, mode))) do
+              {:ok, %ResolveStatefulResponse{} = resp} ->
+                {:ok, resp}
+
+              other ->
+                {:error, other}
             end
           rescue
             e -> {:error, {:resolve_raised, e}}
@@ -1577,6 +1584,28 @@ defmodule Embervm.StatefulSweeper do
     e -> {:error, {:channel_raised, e}}
   catch
     kind, reason -> {:error, {:channel_raised, {kind, reason}}}
+  end
+
+  # Acquire the node's shared channel and run a stateful verb over it, invalidating
+  # that channel (so the next safe_channel/2 re-dials) when the call reveals the
+  # transport is dead: a transport_dead? error return, or an :exit from the Mint
+  # ConnectionProcess dying (its crash on an in-flight stream RST during a noded
+  # rollout surfaces here as an exit). A server-returned gRPC status rode a HEALTHY
+  # channel and never invalidates it (Embervm.NodeChannel.transport_dead?/1, D-R2.7.2).
+  # Returns the verb's raw result ({:ok, _} | {:error, _}), {:error, {:exit, reason}}
+  # on an exit, or the safe_channel error if no channel could be obtained.
+  defp over_channel(channel_fun, invalidate_fun, node_id, call_fun) do
+    with {:ok, channel} <- safe_channel(channel_fun, node_id) do
+      try do
+        result = call_fun.(channel)
+        if Embervm.NodeChannel.transport_dead?(result), do: invalidate_fun.(node_id, channel)
+        result
+      catch
+        :exit, reason ->
+          invalidate_fun.(node_id, channel)
+          {:error, {:exit, reason}}
+      end
+    end
   end
 
   defp default_stop_stateful(channel, req) do

--- a/projects/embervm/control/test/embervm/group_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_manager_test.exs
@@ -48,6 +48,9 @@ defmodule Embervm.GroupManagerTest do
     {:ok, rec} = recorder()
 
     fail_member = Keyword.get(opts, :fail_member)
+    # A member whose start returns a transport-dead error (a wrapped "connection is
+    # closed", the shape a noded rollout surfaces), for the channel-invalidation test.
+    transport_dead_member = Keyword.get(opts, :transport_dead_member)
     # A member whose RELIGHT StartGroupMember fails (Task 7): forces the all-or-
     # nothing relight -> fresh fallback. relight_unverified_member instead returns a
     # was_relight=false response (the clock-resync casualty, decision 7).
@@ -96,6 +99,9 @@ defmodule Embervm.GroupManagerTest do
       vm_id = "vm-#{req.member_name}"
 
       cond do
+        req.member_name == transport_dead_member ->
+          {:error, %GRPC.RPCError{status: 2, message: "the connection is closed"}}
+
         req.member_name == fail_member ->
           {:error, :boom}
 
@@ -168,6 +174,7 @@ defmodule Embervm.GroupManagerTest do
       port_base: 30_000,
       pod_ip: "10.0.0.9",
       channel_fun: fn _node -> {:ok, :ch} end,
+      invalidate_fun: Keyword.get(opts, :invalidate_fun, fn _n, _c -> :ok end),
       create_group_network_fun: create_group_network_fun,
       delete_group_network_fun: delete_group_network_fun,
       start_group_member_fun: start_group_member_fun,
@@ -252,6 +259,40 @@ defmodule Embervm.GroupManagerTest do
 
     # The group network was torn down (no half-group leaks).
     assert Enum.any?(events(ctx.rec), &match?({:delete_network, "g-1"}, &1))
+  end
+
+  test "a transport-dead member start invalidates the shared channel so the next wake re-dials" do
+    test_pid = self()
+
+    ctx =
+      start_group(
+        transport_dead_member: "worker-0",
+        invalidate_fun: fn node_id, chan -> send(test_pid, {:invalidated, node_id, chan}) end
+      )
+
+    assert {:error, _reason} = GroupManager.create_group(ctx.mgr)
+
+    # The dead shared channel was dropped (node "node-4", channel :ch), so the next
+    # safe_channel/2 re-dials instead of every member start wedging on a dead
+    # ConnectionProcess until the control plane restarts (D-R2.7.2).
+    assert_receive {:invalidated, "node-4", :ch}, 1_000
+  end
+
+  test "a server-status member start failure leaves the shared channel up (no needless invalidate)" do
+    test_pid = self()
+
+    ctx =
+      start_group(
+        fail_member: "worker-0",
+        invalidate_fun: fn node_id, chan -> send(test_pid, {:invalidated, node_id, chan}) end
+      )
+
+    assert {:error, _reason} = GroupManager.create_group(ctx.mgr)
+
+    # :boom is a plain application error that rode a HEALTHY channel; it must NOT tear
+    # the shared channel down (D-R2.7.2), else a legit member rejection would needlessly
+    # redial for every other consumer of the node.
+    refute_receive {:invalidated, _, _}, 300
   end
 
   test "EMBER_GROUP_* env: member/role/ip/peer-map/secret keys, casing + .10+i addressing" do

--- a/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
@@ -149,6 +149,7 @@ defmodule Embervm.StatefulSweeperTest do
         scrape_fun: fn _url -> Agent.get(scrape_agent, & &1) end,
         stats_base: Keyword.get(opts, :stats_base, "http://serving:9902"),
         channel_fun: fn _node -> {:ok, :ch} end,
+        invalidate_fun: Keyword.get(opts, :invalidate_fun, fn _n, _c -> :ok end),
         stop_stateful_fun: stop_stateful_fun,
         resolve_stateful_fun: resolve_stateful_fun,
         evict_snapshot_fun: evict_snapshot_fun,

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.96
+      targetRevision: 0.1.97
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## What the R5 gate drills found (bug 2 of 2)

After PR #3633 fixed the composite base resolution, re-running gate 1 showed the `scratch-k8s` `server` member FRESH-boots correctly, but the k3s bring-up was cut short mid-wake. Root cause: a **control-plane -> noded gRPC channel wedge** that also breaks stateful banking, and only recovers via a manual control-plane restart.

## Root cause

The control plane shares ONE long-lived Mint gRPC channel per node (`NodeChannel`, cached in `:persistent_term`). When noded rolls out, an in-flight stream is RST'd (`{:server_closed_request, :cancel}`), which grpc-elixir 1.0.2's `process_response/2` has **no clause for**, so the shared `ConnectionProcess` crashes. Every later call then reuses the dead handle:

- `StatefulSweeper.spawn_atomic_bank_worker` -> `StopStateful` (banking VMs that died in the rollout) spins forever, logging `no process` / `econnrefused`.
- `GroupManager` member starts fail the same way, so a composite cluster never finishes waking.

`NodeChannel` already documents this exact class (D-R2.7.2) and provides the remedy — `transport_dead?/1` + `invalidate/3` — which `PoolManager`/`Dispatcher` use. But **`StatefulSweeper` and `GroupManager` use the shared channel without ever invalidating it**, so the dead channel is never dropped and `get/1` never re-dials.

## Fix

Both modules gain an `over_channel/N` helper that acquires the shared channel, runs the verb, and invalidates it (so the next `safe_channel` re-dials) when the call reveals the transport is dead:
- a `transport_dead?` error return (the clean pod-replaced shape), **or**
- an `:exit` from the `ConnectionProcess` dying (the crash shape).

A server-returned gRPC status rode a *healthy* channel and never invalidates it (so a legit member rejection doesn't needlessly redial for every other consumer). `NodeChannel` is unchanged. Routed through it: the three `StatefulSweeper` workers (bank/checkpoint/resolve) and the `GroupManager` member-start/bank/create-network paths. Best-effort teardown (destroy/evict/delete-network) is left as-is.

### Not in scope (follow-up)
The *trigger* is grpc-elixir 1.0.2 crashing on `{:server_closed_request, :cancel}` instead of returning an error. Patching the vendored dep would stop the scary crash log entirely; this PR makes the system **self-heal** after it (the documented + approved approach). Recorded for later.

## Tests
- `group_manager_test`: a transport-dead member start **invalidates** the shared channel (next wake re-dials); a plain server-status failure does **not** (no needless redial). Mirrors `pool_manager_test`'s contract.
- Both harnesses gain an injectable `invalidate_fun` (no-op default), which also stops existing tests from touching the real `NodeChannel`.

## After merge
Deploy (chart bumped), then complete R5 gates 1-9 against the live cluster and record the numbers into the drill runbook + plan Closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)