### PR TITLE
fix(ember): EmberStage prop named state shadowed the $state rune, 500ing SSR

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.163
+version: 0.89.164
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.163
+      targetRevision: 0.89.164
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.238
+version: 0.285.239
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.238
+      targetRevision: 0.285.239
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/ember/EmberStage.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberStage.svelte
@@ -10,8 +10,8 @@
   import { onMount } from "svelte";
   import "./ember-stage.css";
 
-  /** @type {{ state?: string|null, totalSavedMibS?: number|null, stopwatchMs?: number, running?: boolean }} */
-  let { state = null, totalSavedMibS = null, stopwatchMs = 0, running = false } = $props();
+  /** @type {{ vmState?: string|null, totalSavedMibS?: number|null, stopwatchMs?: number, running?: boolean }} */
+  let { vmState = null, totalSavedMibS = null, stopwatchMs = 0, running = false } = $props();
 
   const WAKING = new Set(["relighting", "cold_booting", "starting"]);
 
@@ -88,13 +88,13 @@
   let flickerTickAt = 0;
 
   function targetFor(now) {
-    if (state === "banked" || state == null) return 0;
-    if (state === "serving") return 1;
-    if (WAKING.has(state)) {
+    if (vmState === "banked" || vmState == null) return 0;
+    if (vmState === "serving") return 1;
+    if (WAKING.has(vmState)) {
       const frac = Math.min(1, (now - sweepStartAt) / WAKE_SWEEP_MS);
       return sweepFromW + (1 - sweepFromW) * frac;
     }
-    if (state === "banking") {
+    if (vmState === "banking") {
       const frac = Math.min(1, (now - sweepStartAt) / BANK_SWEEP_MS);
       return sweepFromW * (1 - frac);
     }
@@ -105,11 +105,11 @@
     const dt = lastFrameAt ? now - lastFrameAt : 16;
     lastFrameAt = now;
 
-    if (state !== prevFrameState) {
+    if (vmState !== prevFrameState) {
       // Entered a new state this frame: (re)start the sweep clock from the
       // current eased warmth, so a mid-sweep state flip (e.g. banking
       // interrupted by a new request) never snaps.
-      prevFrameState = state;
+      prevFrameState = vmState;
       sweepStartAt = now;
       sweepFromW = w;
     }
@@ -125,7 +125,7 @@
       }
     }
 
-    if (state === "serving") {
+    if (vmState === "serving") {
       // Subtle per-cell flicker: a handful of hot cells get a brief opacity
       // wobble, staggered by picking a new random subset roughly every
       // 250ms rather than every frame.
@@ -181,7 +181,7 @@
   });
 
   // ── Reduced-motion static fallback: two-state cell fill, no rAF loop ──
-  let staticHot = $derived(state === "serving" || WAKING.has(state ?? ""));
+  let staticHot = $derived(vmState === "serving" || WAKING.has(vmState ?? ""));
 
   function ms(v) {
     if (v == null) return "–";
@@ -213,10 +213,10 @@
     return `${humanize(gbh)} GB·h`;
   }
 
-  let stateWord = $derived(STATE_WORD[state ?? ""] ?? "Asleep");
+  let stateWord = $derived(STATE_WORD[vmState ?? ""] ?? "Asleep");
 
   let heroKind = $derived(
-    state === "serving" ? "serving" : state != null && WAKING.has(state) ? "waking" : "cold",
+    vmState === "serving" ? "serving" : vmState != null && WAKING.has(vmState) ? "waking" : "cold",
   );
 </script>
 
@@ -294,7 +294,7 @@
   }
 
   /* Reduced-motion fallback: a second, static grid painted with a plain
-     two-state (cold/hot) fill using the same cell tokens, no per-cell
+     two-vmState (cold/hot) fill using the same cell tokens, no per-cell
      randomness and no rAF loop. Only one of the two .es-grid elements is
      visible at a time (see the media query below). */
   .es-static :global(.es-cell) {

--- a/projects/monolith/frontend/src/routes/public/ember/postgres/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/postgres/+page.svelte
@@ -37,7 +37,7 @@
   </header>
 
   <EmberStage
-    state={consoleStatus?.state}
+    vmState={consoleStatus?.state}
     totalSavedMibS={consoleStatus?.total_saved_mib_s}
     stopwatchMs={consoleStopwatchMs}
     running={consoleRunning}


### PR DESCRIPTION
https://jomcgi.dev/ember/postgres SSR-crashed with `TypeError: store_get(...) is not a function`: a prop named `state` makes the Svelte 5 compiler resolve `$state(false)` as a store subscription on that prop instead of the rune. Renamed the prop to `vmState` (component + page callsite). Verified by compiling both files with generate: server and confirming no store_get emission.

Escaped CI because a brand-new visual-regression target has no baseline to diff against, so the error render passed as "added". Charts: monolith 0.285.239, monolith-public 0.89.164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)