### PR TITLE
fix(embervm): run k3s for warmth-only composite members in guest-init

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.97
+version: 0.1.98

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.97
+      targetRevision: 0.1.98
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/k3s/guest-init/cmd/cmdline.go
+++ b/projects/embervm/runtimes/k3s/guest-init/cmd/cmdline.go
@@ -65,9 +65,49 @@ func statefulVolumeFromCmdline(logger *slog.Logger) (dev, mountPath string) {
 }
 
 // k3sDataDir is k3s's writable state root (server sqlite db, kubelet, containerd
-// state). The stateful lane's volume mounts here so the datastore is durable. It
-// is also the CR's volumeMountPath in the drill.
+// state). The stateful lane's volume mounts here so the datastore is durable; a
+// composite member (warmth-only, no volume) runs k3s here on the ephemeral
+// writable rootfs subtree (mountGuestFilesystems makes it writable), losing state
+// on fresh/destroy by design. It is also the CR's volumeMountPath in the drill.
 const k3sDataDir = "/var/lib/rancher/k3s"
+
+// bootClass is the guest boot lane this VM was started in. ONE k3s rootfs serves
+// three: a base build (snapshot bake, no k3s), a stateful cold boot (postgres
+// precedent, volume-backed k3s), and an R5 composite member (warmth-only,
+// volume-less k3s). Deciding it purely from the volume boot-arg was correct until
+// R5: a composite member is a real k3s boot that carries NO volume (a standing R5
+// warmth-only decision), so volume-presence alone misclassifies every member as a
+// base build and k3s never runs. classifyBoot adds the composite lane.
+type bootClass int
+
+const (
+	// bootBaseBuild: no volume and no composite facts. Answer the vsock ready
+	// contract only; run no k3s. noded's BuildBase snapshots then reaps the VM.
+	bootBaseBuild bootClass = iota
+	// bootStateful: a writable volume boot-arg is present (the scratch-postgres
+	// lane). Mount the volume at k3s's data dir, then run k3s.
+	bootStateful
+	// bootComposite: an R5 composite group member (EMBER_GROUP_MEMBER injected),
+	// warmth-only with no volume. Run k3s directly on the ephemeral writable rootfs
+	// subtree; there is no volume to mount.
+	bootComposite
+)
+
+// classifyBoot decides the boot lane from the resolved volume device (dev, "" when
+// absent) and an env lookup (env, os.Getenv in production, after setMmdsEnv has
+// decoded the boot-args). A volume is unambiguously the stateful lane. Absent a
+// volume, an injected EMBER_GROUP_MEMBER fact marks a composite member that MUST
+// still run k3s; only a boot with neither signal is a base build. Pure over its
+// inputs so it is table-testable without a microVM.
+func classifyBoot(dev string, env func(string) string) bootClass {
+	if dev != "" {
+		return bootStateful
+	}
+	if env(memberEnv) != "" {
+		return bootComposite
+	}
+	return bootBaseBuild
+}
 
 // setMmdsEnv decodes every `ember.env.<KEY>=<base64url>` boot-arg into a process
 // env var named exactly <KEY>. A missing /proc/cmdline, no matching tokens, an

--- a/projects/embervm/runtimes/k3s/guest-init/cmd/cmdline_test.go
+++ b/projects/embervm/runtimes/k3s/guest-init/cmd/cmdline_test.go
@@ -103,6 +103,76 @@ func TestStatefulVolumeFromCmdline(t *testing.T) {
 	}
 }
 
+func TestClassifyBoot(t *testing.T) {
+	cases := []struct {
+		name string
+		dev  string
+		env  map[string]string
+		want bootClass
+	}{
+		{
+			name: "no volume and no facts is a base build",
+			dev:  "",
+			env:  map[string]string{},
+			want: bootBaseBuild,
+		},
+		{
+			name: "a volume boot-arg is the stateful lane",
+			dev:  "/dev/vdc",
+			env:  map[string]string{},
+			want: bootStateful,
+		},
+		{
+			// The regression this fix exists for: an R5 composite member carries
+			// EMBER_GROUP_* facts but NO volume (warmth-only), and MUST run k3s. The
+			// old volume-only discriminator classified it as a base build, so k3s
+			// never started and the member's health-gate never passed.
+			name: "composite member (facts, no volume) runs k3s, not a base build",
+			dev:  "",
+			env: map[string]string{
+				"EMBER_GROUP_MEMBER": "server",
+				"EMBER_GROUP_ROLE":   "server",
+				"EMBER_GROUP_IP":     "10.101.0.10",
+				"EMBER_GROUP_SECRET": "s3cr3t",
+			},
+			want: bootComposite,
+		},
+		{
+			name: "an agent member is also composite",
+			dev:  "",
+			env: map[string]string{
+				"EMBER_GROUP_MEMBER": "agent-0",
+				"EMBER_GROUP_ROLE":   "agent",
+			},
+			want: bootComposite,
+		},
+		{
+			// A volume takes precedence: the stateful lane is volume-backed even if
+			// group facts were somehow also present (they are not, in practice).
+			name: "a volume wins over facts (stateful, not composite)",
+			dev:  "/dev/vdc",
+			env:  map[string]string{"EMBER_GROUP_MEMBER": "server"},
+			want: bootStateful,
+		},
+		{
+			// A composite member with an empty role still classifies composite: the
+			// member-name marker (not the role) is the discriminator, because the CR
+			// role can be empty and k3sArgv then defaults to server.
+			name: "member name present but role empty is still composite",
+			dev:  "",
+			env:  map[string]string{"EMBER_GROUP_MEMBER": "server", "EMBER_GROUP_ROLE": ""},
+			want: bootComposite,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyBoot(tc.dev, envFunc(tc.env)); got != tc.want {
+				t.Fatalf("classifyBoot(%q, %v) = %d, want %d", tc.dev, tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsValidEnvKeyName(t *testing.T) {
 	cases := map[string]bool{
 		"EMBER_GROUP_ROLE":   true,

--- a/projects/embervm/runtimes/k3s/guest-init/cmd/k3s.go
+++ b/projects/embervm/runtimes/k3s/guest-init/cmd/k3s.go
@@ -9,6 +9,13 @@ import (
 // Role env facts (standing decision 13). The platform injects only generic
 // facts; this image owns the k3s knowledge. The k3s images' init maps them here.
 const (
+	// memberEnv names this member's expanded name (e.g. "server", "agent-0"). The
+	// platform sets it for EVERY composite member (server and agent) and never for
+	// a base build or the stateful-postgres lane, so its presence is the reliable
+	// marker of an R5 composite member runtime boot. It is preferred over roleEnv
+	// as the discriminator because the CR's role field can be empty (roleEnv then
+	// defaults to server in k3sArgv), whereas the expanded name is always set.
+	memberEnv = "EMBER_GROUP_MEMBER"
 	// roleEnv names the member's role: "server" or "agent".
 	roleEnv = "EMBER_GROUP_ROLE"
 	// secretEnv is the per-group shared secret. It becomes K3S_TOKEN (server and

--- a/projects/embervm/runtimes/k3s/guest-init/cmd/main.go
+++ b/projects/embervm/runtimes/k3s/guest-init/cmd/main.go
@@ -6,7 +6,8 @@
 // A raw Firecracker boot ignores the OCI image config entirely and boots
 // init=<HarnessInit> (see the noded driver's bootArgs), so the apko entrypoint
 // is never honoured. This init is that missing PID 1. Like the scratch-postgres
-// guest-init it has to satisfy TWO distinct boot classes off ONE rootfs:
+// guest-init it has to satisfy THREE distinct boot classes off ONE rootfs
+// (classified by classifyBoot from the volume boot-arg + the injected facts):
 //
 //   - BASE BUILD (a plain cold boot with NO volume boot-arg): noded's BuildBase
 //     cold-boots the guest, health-gates it over vsock at the frozen readiness
@@ -26,6 +27,16 @@
 //     `k3s server`/`k3s agent`. Runtime health is a TCP connect to the k3s port
 //     over the tap NIC (noded's finishStatefulStart), NOT the vsock ready path;
 //     the vsock server stays up harmlessly.
+//
+//   - COMPOSITE MEMBER (R5, a cold boot carrying the EMBER_GROUP_* facts but NO
+//     volume boot-arg): a group member is WARMTH-ONLY (a standing R5 decision: no
+//     member volume, state lost on fresh/destroy), yet it is a real k3s boot. It
+//     runs exactly like the stateful lane MINUS the volume mount: k3s's datastore
+//     lives on the ephemeral writable rootfs subtree. EMBER_GROUP_MEMBER (set for
+//     every member, never for a base build) is the marker that separates it from a
+//     base build, which also carries no volume. Without this lane the volume-only
+//     discriminator sends every composite member down the base-build path and k3s
+//     never starts (the bug this init originally shipped with).
 //
 // The airgap image tarball baked at /var/lib/rancher/k3s/agent/images is imported
 // by k3s itself at startup (standing decision 12: zero-egress). This init never
@@ -93,29 +104,43 @@ func run(logger *slog.Logger) error {
 	var ready readyFlag
 	serveErr := startVsockReadyServer(ctx, logger, ready.Load)
 
-	// Detect the boot class from the presence of the volume boot-arg (exactly as
-	// scratch-postgres distinguishes a base build from a stateful cold boot). A
-	// base build has none and only needs the vsock ready answer; a stateful cold
-	// boot mounts the volume and runs k3s.
+	// Detect the boot class from the volume boot-arg AND the injected composite
+	// facts. Three lanes off one rootfs (see classifyBoot): a base build (no volume,
+	// no facts -> vsock ready only, no k3s), a stateful cold boot (volume-backed
+	// k3s), and an R5 composite member (warmth-only, volume-less k3s). Deciding on
+	// the volume alone predates R5 and misclassifies every composite member (which
+	// carries NO volume) as a base build, so k3s never runs; classifyBoot fixes that.
 	dev, mountPath := statefulVolumeFromCmdline(logger)
 
-	if dev == "" {
+	switch classifyBoot(dev, getenv) {
+	case bootBaseBuild:
 		// Base build: no volume, no k3s. Answer ready and hold PID 1 until the
 		// host snapshots and reaps the VM. Do NOT exit: exiting PID 1 panics the
 		// guest kernel before noded can snapshot.
 		ready.Store(true)
 		logger.Info("ember-k3s-init: base build boot, ready (no volume, no k3s)")
 		return waitForShutdown(ctx, serveErr, logger)
+
+	case bootStateful:
+		// Stateful cold boot: mount the writable volume at k3s's data dir BEFORE
+		// k3s starts, so the sqlite datastore + kubelet state land on durable
+		// storage.
+		if err := mountStatefulVolume(logger, dev, mountPath); err != nil {
+			return err
+		}
+
+	case bootComposite:
+		// R5 composite member (warmth-only, no volume): k3s runs on the ephemeral
+		// writable rootfs subtree (mountGuestFilesystems made /var/lib/rancher/k3s
+		// writable). State is lost on fresh/destroy by design (the R5 warmth-only
+		// decision); there is no volume to mount.
+		logger.Info("ember-k3s-init: composite member boot, running k3s (warmth-only, no volume)",
+			"member", getenv(memberEnv), "role", getenv(roleEnv))
 	}
 
-	// Stateful cold boot: mount the writable volume at k3s's data dir BEFORE k3s
-	// starts, so the sqlite datastore + kubelet state land on durable storage.
-	if err := mountStatefulVolume(logger, dev, mountPath); err != nil {
-		return err
-	}
-
-	// Start the vsock guest control agent (guestagent) sidecar on the frozen port
-	// 1024, so a post-resume clock resync works (standing decision 7). Non-fatal
+	// Both k3s lanes (stateful + composite) start the guest control agent
+	// (guestagent) sidecar on the frozen vsock port 1024, so a post-resume clock
+	// resync works (standing decision 7; R5 relight has the same contract). Non-fatal
 	// off Linux / no vsock. It is a SUPERVISED sidecar alongside k3s.
 	startGuestAgent(ctx, logger)
 


### PR DESCRIPTION
## Root cause of R5 gate-1 bug 3 (found live, corrects the prior CP-state-machine hypothesis)

The last session's memory hypothesized bug 3 lived in the control-plane wake/adoption state machine. Live evidence proves that wrong: the CP **does** drive the boot. The real root is one branch in the **guest** init.

**Evidence chain:**
- CP logs: `scratch-k8s` emits only an endless `park_full` storm, zero group wake/relight/adopt logs (the wake never errors or completes), while `scratch-postgres` (stateful) cycles perfectly.
- noded logs: the `server` member **does** fresh-boot (full `EMBER_GROUP_*` env, k3s rootfs, k3s init) and re-boots every ~5 min (a retry cycle).
- Guest console (smoking gun): `ember-k3s-init: base build boot, ready (no volume, no k3s)` — the guest booted in **base-build mode** and never started k3s.

**The bug:** `ember-k3s-init` decided *base-build vs run-k3s* purely on the presence of a volume boot-arg (`statefulVolumeFromCmdline`), a heuristic inherited from the stateful/postgres lane where every runtime boot carries a volume. R5 composite members are **warmth-only, no volume** (a standing R5 decision), so every member boot fell into the base-build branch → k3s never started → the k3s server's 6443 health-gate never passed → the role-ordered group wake blocked forever on it (holding the single-flight, starving the 10s adoption reconcile, overflowing park). Every downstream symptom flows from that one misclassification.

## The fix

Add a third boot lane via a pure, table-tested `classifyBoot`:
- **base build** (no volume, no facts): vsock ready only, no k3s (unchanged).
- **stateful** (volume present): mount volume, run k3s (unchanged).
- **composite member** (`EMBER_GROUP_MEMBER` injected, no volume): run k3s exactly like the stateful lane **minus** the volume mount. The datastore lives on the ephemeral writable rootfs subtree (state lost on fresh/destroy, per the R5 warmth-only decision).

`EMBER_GROUP_MEMBER` is the marker: the CP sets it for every member (server and agent) via `member_env`, and it is never present for a base build or the stateful lane. `k3sArgv` already supported the volume-less case; only `run()` never wired it.

## Deploy

Chart `0.1.97 -> 0.1.98` so the rebuilt `k3s-server`/`k3s-agent` images (which bake `ember-k3s-init`, auto-pinned into the chart via `helm_images_values`) deploy.

## Scope

Root fix only (per direction). The CP structural amplifiers (a stuck member boot holds `waking` and starves the adoption reconcile; park overflows on a wedged member) are real but were amplifiers, not the cause; tracked as a separate follow-up.

## Testing

- `TestClassifyBoot` covers all three lanes plus the regression: a composite member (facts, no volume) must classify `bootComposite`, not `bootBaseBuild`.
- `gofmt`, `go vet`, and linux cross-build green locally. Full test run defers to CI (no local darwin runners).
- Live validation after merge: drive a `scratch-k8s` wake and confirm the server member reaches k3s Ready on 6443 (gate-1 full boot: 3 Ready nodes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)