### PR TITLE
fix(ember): session cookie path + restyle /ember/* in the explainer's visual language

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.164
+version: 0.89.165
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.164
+      targetRevision: 0.89.165
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.239
+version: 0.285.240
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.239
+      targetRevision: 0.285.240
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
@@ -849,6 +849,10 @@
 </section>
 
 <style>
+  /* Styled in the /ember mini-site language (lib/public/ember/ember.css, the
+     fcstory palette): white panels on the warm ground, 1px hairlines, soft
+     layered shadows, ember/frost accents, mono micro-labels. The page wraps
+     this component in .ember-site, which provides every var(--em-*) below. */
   .pg-panel {
     display: grid;
     grid-template-columns: 380px 1fr;
@@ -881,9 +885,10 @@
   }
 
   .state-block {
-    background: var(--paper);
-    border: 2px solid var(--ink);
-    border-radius: var(--radius);
+    background: var(--em-panel);
+    border: 1px solid var(--em-line);
+    border-radius: 14px;
+    box-shadow: var(--em-shadow-soft);
     padding: 18px 20px;
     min-height: 212px;
     display: flex;
@@ -894,40 +899,45 @@
   .state-chip {
     display: inline-flex;
     align-items: center;
-    gap: 10px;
-    padding: 8px 16px;
+    gap: 9px;
+    padding: 6px 14px;
     border-radius: 999px;
-    border: 2px solid var(--ink);
-    font-weight: 700;
-    font-size: 15px;
+    border: 1px solid var(--em-line);
+    background: var(--em-ground);
+    font-family: var(--em-mono);
+    font-weight: 600;
+    font-size: 12.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--em-ink);
     align-self: flex-start;
   }
 
   .state-dot {
-    width: 10px;
-    height: 10px;
+    width: 9px;
+    height: 9px;
     border-radius: 50%;
-    background: var(--ink-3);
+    background: var(--em-faint);
   }
 
   .tone-awake .state-dot {
-    background: var(--teal);
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--teal) 20%, transparent);
+    background: var(--em-ember);
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--em-ember) 18%, transparent);
   }
 
   .tone-drowsy .state-dot,
   .tone-waking .state-dot {
-    background: var(--accent);
+    background: var(--em-amber);
     animation: pulse 0.9s ease-in-out infinite;
   }
 
   .tone-asleep .state-dot {
-    background: var(--blue);
-    opacity: 0.45;
+    background: var(--em-frost);
+    opacity: 0.55;
   }
 
   .tone-asleep .state-label {
-    color: var(--ink-3);
+    color: var(--em-muted);
   }
 
   @keyframes pulse {
@@ -944,51 +954,53 @@
 
   .state-sentence {
     margin: 0;
-    color: var(--ink);
+    color: var(--em-ink);
     font-size: 15px;
-    line-height: 1.45;
+    line-height: 1.5;
     min-height: 2.9em;
   }
 
   .state-sentence strong {
-    font-weight: 700;
+    font-weight: 650;
   }
 
   .state-facts {
     display: flex;
     gap: 18px;
     margin: 0;
-    opacity: 0.7;
   }
 
   .state-facts dt {
-    font-size: 11px;
+    font-family: var(--em-mono);
+    font-size: 10.5px;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: var(--ink-3);
+    color: var(--em-faint);
   }
 
   .state-facts dd {
     margin: 2px 0 0;
+    font-family: var(--em-mono);
+    font-size: 13px;
     font-variant-numeric: tabular-nums;
     font-weight: 600;
+    color: var(--em-muted);
   }
 
   .savings-line {
     margin: 0;
     font-size: 13px;
-    color: var(--ink-3);
-    opacity: 0.6;
+    color: var(--em-faint);
   }
 
   .savings-line.savings-active {
-    color: var(--ink);
-    opacity: 1;
+    color: var(--em-ink);
   }
 
   .savings-value {
     display: inline-block;
     min-width: 8ch;
+    font-family: var(--em-mono);
     font-variant-numeric: tabular-nums;
     font-weight: 700;
   }
@@ -996,33 +1008,35 @@
   .savings-caption {
     margin: -8px 0 0;
     font-size: 11px;
-    color: var(--ink-3);
+    color: var(--em-faint);
   }
 
   .alltime-savings {
     margin: 0;
     font-size: 11px;
-    color: var(--ink-3);
+    color: var(--em-faint);
   }
 
   .alltime-savings-value {
     display: inline-block;
     min-width: 6ch;
+    font-family: var(--em-mono);
     font-variant-numeric: tabular-nums;
     font-weight: 600;
-    color: var(--ink-2);
+    color: var(--em-muted);
   }
 
   .soft-error {
     margin: 0;
-    color: var(--coral);
+    color: var(--em-ember-deep);
     font-size: 12px;
   }
 
   .turnstile-slot {
-    background: var(--paper);
-    border: 2px solid var(--ink);
-    border-radius: var(--radius);
+    background: var(--em-panel);
+    border: 1px solid var(--em-line);
+    border-radius: 14px;
+    box-shadow: var(--em-shadow-soft);
     padding: 14px 18px;
     display: flex;
     flex-direction: column;
@@ -1031,8 +1045,8 @@
 
   .turnstile-hint {
     margin: 0;
-    font-size: 12px;
-    color: var(--ink-3);
+    font-size: 12.5px;
+    color: var(--em-muted);
   }
 
   .controls {
@@ -1043,46 +1057,62 @@
 
   .run-btn,
   .aggregate-btn {
-    padding: 10px 18px;
-    border-radius: var(--radius);
-    border: 2px solid var(--ink);
+    padding: 11px 18px;
+    border-radius: 10px;
+    font-family: inherit;
     font-weight: 600;
     font-size: 14px;
     cursor: pointer;
     min-width: 100%;
     box-sizing: border-box;
+    transition:
+      background-color 0.15s ease,
+      border-color 0.15s ease,
+      box-shadow 0.15s ease;
   }
 
   .run-btn {
-    background: var(--accent);
-    color: var(--ink);
+    background: var(--em-ember);
+    border: 1px solid var(--em-ember-deep);
+    color: var(--em-on-color);
+    box-shadow: var(--em-shadow-soft);
+  }
+
+  .run-btn:hover:not(:disabled) {
+    background: var(--em-ember-deep);
   }
 
   .aggregate-btn {
-    background: var(--paper);
-    color: var(--ink);
+    background: var(--em-panel);
+    border: 1px solid var(--em-line);
+    color: var(--em-ink);
+  }
+
+  .aggregate-btn:hover:not(:disabled) {
+    border-color: var(--em-faint);
   }
 
   .run-btn:disabled,
   .aggregate-btn:disabled {
-    opacity: 0.6;
+    opacity: 0.55;
     cursor: default;
   }
 
   .run-error {
     margin: 0;
-    color: var(--coral);
+    color: var(--em-ember-deep);
     font-size: 13px;
   }
 
   .run-error-hint {
-    color: var(--ink-2);
+    color: var(--em-muted);
   }
 
   .last-run {
-    background: var(--paper);
-    border: 2px solid var(--ink);
-    border-radius: var(--radius);
+    background: var(--em-panel);
+    border: 1px solid var(--em-line);
+    border-radius: 14px;
+    box-shadow: var(--em-shadow-soft);
     padding: 18px 20px;
   }
 
@@ -1097,24 +1127,28 @@
   }
 
   .last-run-value {
+    font-family: var(--em-mono);
     font-size: 30px;
     font-weight: 700;
     font-variant-numeric: tabular-nums;
+    letter-spacing: -0.02em;
     line-height: 1.1;
+    color: var(--em-ink);
   }
 
   .last-run-label {
-    font-size: 12px;
+    font-family: var(--em-mono);
+    font-size: 10.5px;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: var(--ink-3);
-    margin-top: 4px;
+    color: var(--em-faint);
+    margin-top: 5px;
   }
 
   .last-run-narration {
     margin: 10px 0 0;
     font-size: 13px;
-    color: var(--ink-2);
+    color: var(--em-muted);
     min-height: 1.4em;
   }
 
@@ -1124,21 +1158,22 @@
     border-radius: 4px;
     overflow: hidden;
     margin-top: 12px;
-    background: var(--bg-elev);
+    background: var(--em-track);
   }
 
   .bar-connect {
-    background: var(--accent);
+    background: var(--em-ember);
   }
 
   .bar-query {
-    background: var(--teal);
+    background: var(--em-frost);
   }
 
   .tiers {
-    background: var(--paper);
-    border: 2px solid var(--ink);
-    border-radius: var(--radius);
+    background: var(--em-panel);
+    border: 1px solid var(--em-line);
+    border-radius: 14px;
+    box-shadow: var(--em-shadow-soft);
     padding: 14px 18px;
     display: flex;
     align-items: center;
@@ -1152,60 +1187,65 @@
   }
 
   .tier-value {
-    font-size: 20px;
+    font-family: var(--em-mono);
+    font-size: 19px;
     font-weight: 700;
     font-variant-numeric: tabular-nums;
+    color: var(--em-ink);
   }
 
   .tier-label {
-    font-size: 11px;
+    font-family: var(--em-mono);
+    font-size: 10.5px;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: var(--ink-3);
+    color: var(--em-faint);
   }
 
   .tier-arrow {
-    color: var(--ink-3);
+    color: var(--em-line);
     font-size: 18px;
   }
 
   .tiers-caption {
     margin: 0 0 0 auto;
     font-size: 12px;
-    color: var(--ink-3);
+    color: var(--em-faint);
   }
 
   .formula-bar {
     margin: 0;
     padding: 6px 4px;
-    font-family: var(--mono);
+    font-family: var(--em-mono);
     font-size: 12px;
-    color: var(--ink-3);
+    color: var(--em-muted);
   }
 
   .reset-countdown {
     margin: 0;
     padding: 0 4px;
     font-size: 12px;
-    color: var(--ink-3);
+    color: var(--em-faint);
   }
 
   .reset-countdown-value {
     display: inline-block;
     min-width: 5ch;
+    font-family: var(--em-mono);
     font-variant-numeric: tabular-nums;
     font-weight: 600;
-    color: var(--ink-2);
+    color: var(--em-muted);
   }
 
   .reset-countdown-clock {
-    color: var(--ink-3);
+    color: var(--em-faint);
   }
 
   .result-card {
-    background: var(--paper);
-    border: 2px solid var(--ink);
-    border-radius: var(--radius);
+    background: var(--em-panel);
+    border: 1px solid var(--em-line);
+    border-radius: 14px;
+    box-shadow: var(--em-shadow);
     padding: 18px 20px;
     min-height: 420px;
   }
@@ -1235,13 +1275,13 @@
     width: 100%;
     border-collapse: collapse;
     font-size: 13px;
-    font-family: var(--mono);
+    font-family: var(--em-mono);
   }
 
   .result-table th {
     text-align: left;
     padding: 4px 10px 8px 0;
-    border-bottom: 1px solid var(--rule);
+    border-bottom: 1px solid var(--em-line);
     vertical-align: bottom;
   }
 
@@ -1253,7 +1293,7 @@
     display: block;
     font-size: 12px;
     text-transform: lowercase;
-    color: var(--ink);
+    color: var(--em-ink);
     font-weight: 700;
   }
 
@@ -1262,14 +1302,15 @@
     font-size: 10px;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--ink-3);
+    color: var(--em-faint);
     font-weight: 400;
   }
 
   .result-table td {
     padding: 6px 10px 6px 0;
-    border-bottom: 1px solid var(--rule);
+    border-bottom: 1px solid var(--em-line-soft);
     font-variant-numeric: tabular-nums;
+    color: var(--em-ink);
   }
 
   .result-table td.col-numeric {
@@ -1284,8 +1325,8 @@
     display: inline-block;
     padding: 1px 8px;
     border-radius: 999px;
-    background: color-mix(in srgb, var(--accent) 40%, transparent);
-    color: var(--ink);
+    background: color-mix(in srgb, var(--em-ember-dim) 55%, transparent);
+    color: var(--em-ember-deep);
     font-size: 11px;
     font-weight: 700;
     text-transform: lowercase;
@@ -1293,23 +1334,23 @@
 
   .visitor-label {
     font-size: 11px;
-    color: var(--ink-3);
+    color: var(--em-faint);
     text-transform: lowercase;
   }
 
   .epoch-band td {
     padding: 6px 10px;
-    font-family: var(--sans);
+    font-family: var(--em-sans);
     font-size: 11px;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--ink-2);
-    background: var(--bg-elev);
-    border-bottom: 1px solid var(--rule);
+    color: var(--em-muted);
+    background: var(--em-line-soft);
+    border-bottom: 1px solid var(--em-line);
   }
 
   .epoch-band.epoch-current td {
-    background: color-mix(in srgb, var(--accent) 25%, var(--bg-elev));
+    background: color-mix(in srgb, var(--em-ember-dim) 40%, var(--em-line-soft));
   }
 
   .summary-row td:first-child {
@@ -1319,7 +1360,7 @@
   .summary-bar {
     position: absolute;
     inset: 2px 0;
-    background: color-mix(in srgb, var(--accent) 30%, transparent);
+    background: color-mix(in srgb, var(--em-ember-dim) 45%, transparent);
     border-radius: 3px;
     z-index: 0;
   }
@@ -1333,7 +1374,7 @@
 
   .summary-total td {
     border-bottom: none;
-    border-top: 2px solid var(--rule-2);
+    border-top: 2px solid var(--em-line);
     font-weight: 700;
     padding-top: 10px;
   }
@@ -1341,14 +1382,14 @@
   .result-footer {
     margin: 10px 0 0;
     font-size: 12px;
-    font-family: var(--mono);
-    color: var(--ink-3);
+    font-family: var(--em-mono);
+    color: var(--em-faint);
   }
 
   .result-note {
     margin: 12px 0 0;
     font-size: 12px;
-    color: var(--ink-2);
+    color: var(--em-muted);
   }
 
   @media (prefers-reduced-motion: no-preference) {
@@ -1360,11 +1401,11 @@
     @keyframes connect-pulse {
       0% {
         transform: scale(1.25);
-        color: var(--teal);
+        color: var(--em-ember);
       }
       100% {
         transform: scale(1);
-        color: var(--ink);
+        color: var(--em-ink);
       }
     }
 
@@ -1374,7 +1415,7 @@
 
     @keyframes row-new-fade {
       0% {
-        background: color-mix(in srgb, var(--accent) 45%, transparent);
+        background: color-mix(in srgb, var(--em-ember-dim) 60%, transparent);
       }
       100% {
         background: transparent;

--- a/projects/monolith/frontend/src/lib/public/ember/EmberStage.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberStage.svelte
@@ -248,9 +248,10 @@
     position: relative;
     width: 100%;
     height: 280px;
-    border-radius: var(--radius, 8px);
-    border: 2px solid var(--es-border);
+    border-radius: 14px;
+    border: 1px solid var(--es-border);
     background: var(--es-panel);
+    box-shadow: var(--em-shadow-soft);
     overflow: hidden;
   }
 
@@ -329,8 +330,9 @@
   }
 
   .es-state-word {
-    font-size: 13px;
-    font-weight: 700;
+    font-family: var(--em-mono, ui-monospace, monospace);
+    font-size: 12.5px;
+    font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.1em;
     color: var(--es-muted);
@@ -349,7 +351,9 @@
   }
 
   .es-hero-value {
+    font-family: var(--em-mono, ui-monospace, monospace);
     font-size: clamp(28px, 4vw, 44px);
+    letter-spacing: -0.02em;
     font-weight: 700;
     font-variant-numeric: tabular-nums;
     color: var(--es-ink);

--- a/projects/monolith/frontend/src/lib/public/ember/ember-stage.css
+++ b/projects/monolith/frontend/src/lib/public/ember/ember-stage.css
@@ -7,12 +7,12 @@
  */
 
 .ember-stage {
-  --es-panel: var(--paper, #ffffff);
-  --es-border: var(--ink, #1a1a1a);
+  --es-panel: var(--em-panel, #ffffff);
+  --es-border: var(--em-line, #e3dfd5);
   --es-grid-bg: #eeebe3;
   --es-cell-idle-bg: #e6e2d7;
-  --es-ink: var(--ink, #1a1a1a);
-  --es-muted: var(--ink-3, #6b6658);
+  --es-ink: var(--em-ink, #20222a);
+  --es-muted: var(--em-muted, #525965);
 
   /* Cold (banked) cell hue range: same blue family fcstory uses for its
    * frost tones. */

--- a/projects/monolith/frontend/src/lib/public/ember/ember.css
+++ b/projects/monolith/frontend/src/lib/public/ember/ember.css
@@ -1,0 +1,39 @@
+/* Design tokens for the public /ember/* mini-site, scoped under .ember-site.
+ * Same palette, type stack, and shadow language as fcstory.css (the
+ * /ember/firecracker scroll story's approved reference mockup), so the demo
+ * pages and the explainer read as one small site distinct from the
+ * neobrutalist jomcgi.dev baseline. All literal hex values live here: the
+ * semgrep rule svelte-hardcoded-color-in-style flags bare hex inside a
+ * .svelte <style> block, so components reference var(--em-*) exclusively.
+ */
+
+.ember-site {
+  --em-ground: #f7f5f0;
+  --em-panel: #ffffff;
+  --em-line: #e3dfd5;
+  --em-line-soft: #ece8df;
+  --em-ink: #20222a;
+  --em-muted: #525965;
+  --em-faint: #7d838e;
+  --em-ember: #e05c26;
+  --em-ember-deep: #b7461a;
+  --em-ember-dim: #f0c4ae;
+  --em-frost: #3d7ec2;
+  --em-frost-dim: #b9d2ea;
+  --em-amber: #f2b04e;
+  --em-on-color: #ffffff;
+  --em-track: #eceade;
+  --em-mono:
+    ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+  --em-sans:
+    -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+  --em-shadow:
+    0 2px 6px rgba(32, 34, 42, 0.04), 0 18px 44px rgba(32, 34, 42, 0.09);
+  --em-shadow-soft:
+    0 1px 3px rgba(32, 34, 42, 0.05), 0 10px 24px rgba(32, 34, 42, 0.06);
+
+  background: var(--em-ground);
+  color: var(--em-ink);
+  font-family: var(--em-sans);
+  -webkit-font-smoothing: antialiased;
+}

--- a/projects/monolith/frontend/src/lib/public/fcstory/FcScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/fcstory/FcScrollStory.svelte
@@ -347,7 +347,7 @@
     <span
       ><a class="brand" href="/" bind:this={brandEl}
         ><strong>jomcgi.dev</strong></a
-      > / firecracker</span
+      > / ember / firecracker</span
     >
   </header>
 

--- a/projects/monolith/frontend/src/routes/public/ember/postgres/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/postgres/+page.svelte
@@ -4,8 +4,13 @@
   // demo VM through the same wake-on-connect path the private panel uses,
   // Turnstile-gated and rate-limited for public traffic (see the design doc,
   // docs/plans/2026-07-18-ember-public-pages-design.md).
+  //
+  // Visual language: the /ember/* pages are their own small site in the
+  // fcstory palette (lib/public/ember/ember.css), not the neobrutalist
+  // jomcgi.dev baseline. The topbar wordmark is the only nav: it links home.
   import EmberConsole from "$lib/public/ember/EmberConsole.svelte";
   import EmberStage from "$lib/public/ember/EmberStage.svelte";
+  import "$lib/public/ember/ember.css";
 
   let { data } = $props();
 
@@ -25,64 +30,133 @@
   />
 </svelte:head>
 
-<main class="ember-page">
-  <header class="ember-hero">
-    <h1>A database that sleeps when nobody's asking.</h1>
-    <p class="lede">
-      This Postgres microVM banks itself to disk about a second after its
-      last connection closes, so it costs nothing while idle. The next query
-      wakes it, usually in well under a second, against the exact data it
-      left behind.
-    </p>
+<div class="ember-site">
+  <header class="topbar">
+    <span
+      ><a class="brand" href="/"><strong>jomcgi.dev</strong></a> / ember /
+      postgres</span
+    >
+    <a class="topbar-cross" href="/ember/firecracker">how the freeze works</a>
   </header>
 
-  <EmberStage
-    vmState={consoleStatus?.state}
-    totalSavedMibS={consoleStatus?.total_saved_mib_s}
-    stopwatchMs={consoleStopwatchMs}
-    running={consoleRunning}
-  />
+  <main class="ember-page">
+    <header class="ember-hero">
+      <h1>
+        A database that <span class="frost-word">sleeps</span> when nobody's
+        asking.
+      </h1>
+      <p class="lede">
+        This Postgres microVM banks itself to disk about a second after its
+        last connection closes, so it costs nothing while idle. The next query
+        <span class="ember-word">wakes it</span>, usually in well under a
+        second, against the exact data it left behind.
+      </p>
+    </header>
 
-  <EmberConsole
-    turnstileSiteKey={data.turnstileSiteKey}
-    initialStatus={data.initialStatus}
-    initialSavings={data.initialSavings}
-    bind:status={consoleStatus}
-    bind:running={consoleRunning}
-    bind:stopwatchMs={consoleStopwatchMs}
-  />
+    <EmberStage
+      vmState={consoleStatus?.state}
+      totalSavedMibS={consoleStatus?.total_saved_mib_s}
+      stopwatchMs={consoleStopwatchMs}
+      running={consoleRunning}
+    />
 
-  <section class="explainer">
-    <h2>What "banking" means</h2>
-    <p>
-      Banking is a pause-to-disk, not a shutdown: the VM's live memory and CPU
-      state are snapshotted and the process is torn down, leaving nothing
-      running and nothing billed while it waits. A snapshot is a much faster
-      thing to resume than a fresh boot is to perform, which is why most wakes
-      land under a second instead of paying a full cold start.
-    </p>
-  </section>
+    <EmberConsole
+      turnstileSiteKey={data.turnstileSiteKey}
+      initialStatus={data.initialStatus}
+      initialSavings={data.initialSavings}
+      bind:status={consoleStatus}
+      bind:running={consoleRunning}
+      bind:stopwatchMs={consoleStopwatchMs}
+    />
 
-  <section class="explainer">
-    <h2>Why the data survives, and what the wake number means</h2>
-    <p>
-      The orders table lives on a separate data volume from the snapshot, so
-      destroying the VM (or losing the snapshot entirely) never touches the
-      rows already written. A fresh cold boot against that same volume is
-      slower than resuming from a snapshot, but it recovers every row, which
-      is the actual point of the exhibit: the compute is disposable, the data
-      is not. The "wake + connect" number on the console is the wall-clock
-      time from the first TCP packet to a usable connection, whichever path
-      the VM had to take to get there.
-    </p>
-  </section>
-</main>
+    <section class="explainer">
+      <h2>What "banking" means</h2>
+      <p>
+        Banking is a pause-to-disk, not a shutdown: the VM's live memory and CPU
+        state are snapshotted and the process is torn down, leaving nothing
+        running and nothing billed while it waits. A snapshot is a much faster
+        thing to resume than a fresh boot is to perform, which is why most wakes
+        land under a second instead of paying a full cold start.
+      </p>
+    </section>
+
+    <section class="explainer">
+      <h2>Why the data survives, and what the wake number means</h2>
+      <p>
+        The orders table lives on a separate data volume from the snapshot, so
+        destroying the VM (or losing the snapshot entirely) never touches the
+        rows already written. A fresh cold boot against that same volume is
+        slower than resuming from a snapshot, but it recovers every row, which
+        is the actual point of the exhibit: the compute is disposable, the data
+        is not. The "wake + connect" number on the console is the wall-clock
+        time from the first TCP packet to a usable connection, whichever path
+        the VM had to take to get there.
+      </p>
+    </section>
+
+    <footer class="ember-foot">
+      <p>
+        The freeze-and-restore trick underneath this demo has its own story:
+        <a href="/ember/firecracker">boot once, restore forever</a>.
+      </p>
+    </footer>
+  </main>
+</div>
 
 <style>
+  .ember-site {
+    min-height: 100dvh;
+  }
+
+  .topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    padding: 16px 28px;
+    font-family: var(--em-mono);
+    font-size: 12.5px;
+    color: var(--em-muted);
+  }
+
+  .topbar strong {
+    color: var(--em-ink);
+    font-weight: 600;
+  }
+
+  .topbar .brand {
+    color: inherit;
+    text-decoration: none;
+    border-radius: 4px;
+  }
+
+  .topbar .brand:hover {
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  .topbar .brand:focus-visible,
+  .topbar-cross:focus-visible {
+    outline: 2px solid var(--em-ember-deep);
+    outline-offset: 3px;
+  }
+
+  .topbar-cross {
+    color: var(--em-muted);
+    text-decoration: none;
+    border-radius: 4px;
+  }
+
+  .topbar-cross:hover {
+    color: var(--em-ember-deep);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
   .ember-page {
     max-width: 1100px;
     margin: 0 auto;
-    padding: 48px 24px 96px;
+    padding: 40px 24px 96px;
     display: flex;
     flex-direction: column;
     gap: 40px;
@@ -91,22 +165,35 @@
   .ember-hero {
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    max-width: 760px;
+    gap: 14px;
+    max-width: 780px;
   }
 
   .ember-hero h1 {
-    font-family: var(--serif);
-    font-size: clamp(32px, 4.5vw, 48px);
-    font-weight: 400;
-    line-height: 1.1;
-    color: var(--ink);
+    margin: 0;
+    font-size: clamp(34px, 4.8vw, 56px);
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    line-height: 1.05;
+    color: var(--em-ink);
+    text-wrap: balance;
+  }
+
+  .frost-word {
+    color: var(--em-frost);
+  }
+
+  .ember-word {
+    color: var(--em-ember);
+    font-weight: 600;
   }
 
   .lede {
-    font-size: 17px;
-    line-height: 1.55;
-    color: var(--ink-2);
+    margin: 0;
+    font-size: clamp(16px, 1.4vw, 19px);
+    line-height: 1.6;
+    color: var(--em-muted);
+    max-width: 58ch;
   }
 
   .explainer {
@@ -117,15 +204,36 @@
   }
 
   .explainer h2 {
-    font-family: var(--serif);
-    font-size: 24px;
-    font-weight: 400;
-    color: var(--ink);
+    margin: 0;
+    font-size: clamp(21px, 2vw, 26px);
+    font-weight: 750;
+    letter-spacing: -0.02em;
+    color: var(--em-ink);
+    text-wrap: balance;
   }
 
   .explainer p {
-    font-size: 15px;
-    line-height: 1.6;
-    color: var(--ink-2);
+    margin: 0;
+    font-size: 15.5px;
+    line-height: 1.65;
+    color: var(--em-muted);
+  }
+
+  .ember-foot {
+    border-top: 1px solid var(--em-line);
+    padding-top: 24px;
+    max-width: 720px;
+  }
+
+  .ember-foot p {
+    margin: 0;
+    font-size: 14px;
+    color: var(--em-faint);
+  }
+
+  .ember-foot a {
+    color: var(--em-ember-deep);
+    text-decoration: underline;
+    text-underline-offset: 3px;
   }
 </style>

--- a/projects/monolith/frontend/src/routes/public/ember/postgres/api/session/+server.js
+++ b/projects/monolith/frontend/src/routes/public/ember/postgres/api/session/+server.js
@@ -11,9 +11,12 @@ const API_BASE = process.env.API_BASE || "http://localhost:8000";
 // Cookie handling is bidirectional: the inbound request's cookie header is
 // forwarded so the backend can no-op on an existing demo_pg_session cookie, and
 // the upstream response's set-cookie header (the httpOnly cookie the backend
-// mints) is relayed back verbatim. This is the one proxy in this family that
-// needs raw set-cookie pass-through, since the cookie value is opaque and
-// backend-chosen; there is nothing for this route to reissue itself.
+// mints) is relayed back with ONE rewrite. The backend scopes the cookie to its
+// own mount path (Path=/api/ember/postgres), but the visitor's browser talks to
+// this proxy family at /ember/postgres/api/*, so a verbatim relay stores a
+// cookie the browser never sends back: inserts then fail session_required even
+// after a solved Turnstile check. Rescope the Path to the public page's own
+// prefix; the cookie value itself stays opaque and backend-chosen.
 export async function POST({ request, fetch }) {
   const headers = { "content-type": "application/json" };
   const cookie = request.headers.get("cookie");
@@ -31,7 +34,12 @@ export async function POST({ request, fetch }) {
     "cache-control": "no-store",
   });
   const setCookie = res.headers.get("set-cookie");
-  if (setCookie) outHeaders.set("set-cookie", setCookie);
+  if (setCookie) {
+    outHeaders.set(
+      "set-cookie",
+      setCookie.replace(/Path=\/api\/ember\/postgres/i, "Path=/ember/postgres"),
+    );
+  }
 
   return new Response(await res.text(), {
     status: res.status,

--- a/projects/monolith/frontend/src/routes/public/ember/postgres/api/session/server.test.js
+++ b/projects/monolith/frontend/src/routes/public/ember/postgres/api/session/server.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { POST } from "./+server.js";
+
+function makeHeaders(map = {}) {
+  const lower = Object.fromEntries(
+    Object.entries(map).map(([k, v]) => [k.toLowerCase(), v]),
+  );
+  return { get: (name) => lower[name.toLowerCase()] ?? null };
+}
+
+function makeRequest({ cookie } = {}) {
+  return {
+    headers: makeHeaders(cookie ? { cookie } : {}),
+    text: async () => JSON.stringify({ turnstile_token: "tok" }),
+  };
+}
+
+function upstream({ setCookie } = {}) {
+  return vi.fn().mockResolvedValue({
+    status: 200,
+    headers: makeHeaders(setCookie ? { "set-cookie": setCookie } : {}),
+    text: async () => JSON.stringify({ ok: true }),
+  });
+}
+
+describe("/ember/postgres/api/session POST", () => {
+  it("rescopes the upstream cookie Path to the public proxy prefix", async () => {
+    // The backend scopes demo_pg_session to its own mount
+    // (Path=/api/ember/postgres), but the browser only ever requests
+    // /ember/postgres/api/*: relayed verbatim, the cookie is never sent back
+    // and every insert fails session_required despite a solved check.
+    const fetch = upstream({
+      setCookie:
+        "demo_pg_session=abc123; HttpOnly; Max-Age=3600; " +
+        "Path=/api/ember/postgres; SameSite=lax; Secure",
+    });
+
+    const resp = await POST({ request: makeRequest(), fetch });
+
+    const relayed = resp.headers.get("set-cookie");
+    expect(relayed).toContain("Path=/ember/postgres");
+    expect(relayed).not.toContain("Path=/api/ember/postgres");
+    // Everything else passes through untouched.
+    expect(relayed).toContain("demo_pg_session=abc123");
+    expect(relayed).toContain("HttpOnly");
+    expect(relayed).toContain("Secure");
+  });
+
+  it("omits set-cookie when upstream minted nothing (existing session)", async () => {
+    const fetch = upstream();
+    const resp = await POST({
+      request: makeRequest({ cookie: "demo_pg_session=abc" }),
+      fetch,
+    });
+    expect(resp.headers.get("set-cookie")).toBeNull();
+    expect(await resp.json()).toEqual({ ok: true });
+  });
+
+  it("forwards the inbound cookie header upstream so mint can no-op", async () => {
+    const fetch = upstream();
+    await POST({
+      request: makeRequest({ cookie: "demo_pg_session=abc" }),
+      fetch,
+    });
+    const [, init] = fetch.mock.calls[0];
+    expect(init.headers.cookie).toBe("demo_pg_session=abc");
+  });
+});


### PR DESCRIPTION
## What

Two changes to the public /ember pages:

1. **Bug fix: INSERT always failed with "solve the check above to add orders".** The backend mints the `demo_pg_session` cookie scoped to its own mount path (`Path=/api/ember/postgres`), but the browser talks to the public proxies at `/ember/postgres/api/*`. The session proxy relayed `Set-Cookie` verbatim, so the browser stored a cookie it never sent back: the mint looked successful (widget disappeared, often after an invisible managed-mode solve, so no challenge was ever visible), then every INSERT hit the backend cookieless and got `session_required`. The proxy now rescopes the cookie Path to `/ember/postgres`; a new vitest covers the rewrite, the no-mint passthrough, and the inbound cookie forward.

2. **Restyle: /ember/* is now its own small site in the fcstory visual language.** New scoped token sheet `lib/public/ember/ember.css` mirrors the firecracker explainer's palette (warm paper ground, white panels, 1px hairlines, soft layered shadows, ember/frost accents, system sans, mono micro-labels), replacing the neobrutalist jomcgi.dev baseline on the postgres demo. The page gains an fcstory-style topbar whose wordmark backlinks to jomcgi.dev (the only nav), a heavier hero, and a footer crosslink to the explainer; the explainer's topbar now reads `jomcgi.dev / ember / firecracker`.

## Verification

- Svelte components compile (server target) and the new/changed proxies pass `node --check`.
- Local `vite dev` SSR is broken repo-wide by the kit inline-styles patch (`css is not a function` on every route, pre-existing), so visual verification rides on the CI visual-regression action: /ember/postgres and /ember/firecracker are registered targets, and the PR comment will carry before/after renders.
- CI runs the new session-proxy vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzSpVf5jQsax3m1e3J6CGR