### PR TITLE
fix(ember): suppress the global site nav on /ember/* pages

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.165
+version: 0.89.166
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.165
+      targetRevision: 0.89.166
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.240
+version: 0.285.241
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.240
+      targetRevision: 0.285.241
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/+layout.svelte
@@ -34,12 +34,18 @@
   // Firecracker demos under /demos/* render their own Grimoire-style topbar
   // (wordmark + tabs) and are a full-page tool, not a page of the portfolio
   // site, so the global nav is suppressed here too.
+  //
+  // The /ember/* pages are their own small site in the fcstory visual
+  // language, each with its own wordmark topbar linking home; they had this
+  // suppression under the old /app/firecracker path and lost it in the move
+  // to /ember.
   let hideNav = $derived(
     isPrivate ||
       /^\/(public\/|private\/)?app\//.test($page.url.pathname) ||
       /^\/(public\/|private\/)?docs(\/|$)/.test($page.url.pathname) ||
       /^\/(public\/|private\/)?artifact(\/|$)/.test($page.url.pathname) ||
       /^\/(public\/|private\/)?demos(\/|$)/.test($page.url.pathname) ||
+      /^\/(public\/|private\/)?ember(\/|$)/.test($page.url.pathname) ||
       $page.error != null,
   );
 


### PR DESCRIPTION
One-line layout fix: /ember/* joins the nav-suppression list in the root layout. The explainer had this suppression at its old /app/firecracker path and lost it in the move to /ember; /ember/postgres never had it, so both pages stacked the portfolio nav on top of their own wordmark topbars. Charts bumped (monolith + monolith-public).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzSpVf5jQsax3m1e3J6CGR