### PR TITLE
fix(embervm): tmpfs-back the k3s data dir for warmth-only composite members

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.98
+version: 0.1.99

--- a/projects/embervm/chart/templates/workload-scratch-k8s.yaml
+++ b/projects/embervm/chart/templates/workload-scratch-k8s.yaml
@@ -62,8 +62,11 @@ spec:
       # The server member: one VM, boots first (startOrder 0). k3s server with the
       # sqlite datastore, flannel host-gw, EMBER_GROUP_SECRET as the cluster token
       # AND the static token-auth API entry. Health gates on a TCP connect to 6443.
-      # 2 vCPU / 2048 MiB per the Task 3 spike memory floor (airgap import high-
-      # water mark) with headroom.
+      # 2 vCPU / 4096 MiB: warmth-only members have NO volume, so k3s's data dir is
+      # a tmpfs (guest-init mountCompositeDataDir), meaning the unpacked airgap +
+      # containerd content + sqlite live in RAM alongside the apiserver/etcd. The
+      # old 2048 floor was sized for the base build (k3s NOT running); a running
+      # server needs ~2x. node-4 has ample RAM (ADR 002 rule 4 arithmetic holds).
       - name: server
         role: server
         startOrder: 0
@@ -73,12 +76,15 @@ spec:
             ref: "{{ .Values.scratchK8sServer.guestImage.repository }}:{{ .Values.scratchK8sServer.guestImage.tag }}"
         resources:
           vcpus: 2
-          memMib: 2048
+          memMib: 4096
         healthPort: 6443
       # The agent members: two VMs (agent-0, agent-1), boot after the server
       # (startOrder 1). k3s agent joining https://$EMBER_PEER_SERVER:6443 with the
       # shared token. Health gates on a TCP connect to the kubelet on 10250. 1 vCPU
-      # / 1024 MiB each (a worker node's steady footprint is well under the server).
+      # / 3072 MiB each: like the server, an agent is warmth-only (no volume), so
+      # its containerd unpacks the airgap images into a tmpfs data dir (RAM). Its
+      # steady footprint is under the server's (no apiserver/etcd), but the airgap
+      # unpack is the same, so the old 1024 base-build floor is far too small.
       - name: agent
         role: agent
         startOrder: 1
@@ -88,7 +94,7 @@ spec:
             ref: "{{ .Values.scratchK8sAgent.guestImage.repository }}:{{ .Values.scratchK8sAgent.guestImage.tag }}"
         resources:
           vcpus: 1
-          memMib: 1024
+          memMib: 3072
         healthPort: 10250
     # The group's single ingress: traffic reaches the server member's API on 6443,
     # exposed cluster-internally on the node Envoy at listenPort 5410 (the first

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.98
+      targetRevision: 0.1.99
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/k3s/guest-init/cmd/main.go
+++ b/projects/embervm/runtimes/k3s/guest-init/cmd/main.go
@@ -31,12 +31,15 @@
 //   - COMPOSITE MEMBER (R5, a cold boot carrying the EMBER_GROUP_* facts but NO
 //     volume boot-arg): a group member is WARMTH-ONLY (a standing R5 decision: no
 //     member volume, state lost on fresh/destroy), yet it is a real k3s boot. It
-//     runs exactly like the stateful lane MINUS the volume mount: k3s's datastore
-//     lives on the ephemeral writable rootfs subtree. EMBER_GROUP_MEMBER (set for
-//     every member, never for a base build) is the marker that separates it from a
-//     base build, which also carries no volume. Without this lane the volume-only
-//     discriminator sends every composite member down the base-build path and k3s
-//     never starts (the bug this init originally shipped with).
+//     runs like the stateful lane but, having no volume, backs k3s's data dir with
+//     a tmpfs (mountCompositeDataDir) instead of a block-device mount: the rootfs
+//     is read-only, so without a writable data dir k3s dies extracting its assets.
+//     The datastore + unpacked airgap therefore live in RAM (counting against the
+//     member's mem_mib). EMBER_GROUP_MEMBER (set for every member, never for a base
+//     build) is the marker that separates it from a base build, which also carries
+//     no volume. Without this lane the volume-only discriminator sends every
+//     composite member down the base-build path and k3s never starts (the bug this
+//     init originally shipped with).
 //
 // The airgap image tarball baked at /var/lib/rancher/k3s/agent/images is imported
 // by k3s itself at startup (standing decision 12: zero-egress). This init never
@@ -130,12 +133,16 @@ func run(logger *slog.Logger) error {
 		}
 
 	case bootComposite:
-		// R5 composite member (warmth-only, no volume): k3s runs on the ephemeral
-		// writable rootfs subtree (mountGuestFilesystems made /var/lib/rancher/k3s
-		// writable). State is lost on fresh/destroy by design (the R5 warmth-only
-		// decision); there is no volume to mount.
+		// R5 composite member (warmth-only, no volume): the rootfs is read-only and
+		// there is no volume, so k3s's data dir needs a writable tmpfs backing (else
+		// k3s dies extracting its assets). Mount it + stage the airgap here. State
+		// lives in RAM and is lost on fresh/destroy by design (the R5 warmth-only
+		// decision).
 		logger.Info("ember-k3s-init: composite member boot, running k3s (warmth-only, no volume)",
 			"member", getenv(memberEnv), "role", getenv(roleEnv))
+		if err := mountCompositeDataDir(logger); err != nil {
+			return err
+		}
 	}
 
 	// Both k3s lanes (stateful + composite) start the guest control agent

--- a/projects/embervm/runtimes/k3s/guest-init/cmd/mount_linux.go
+++ b/projects/embervm/runtimes/k3s/guest-init/cmd/mount_linux.go
@@ -55,6 +55,35 @@ func mountGuestFilesystems(logger *slog.Logger) {
 	}
 }
 
+// mountCompositeDataDir gives a WARMTH-ONLY composite member (R5, no volume) its
+// writable k3s data dir. The stateful lane mounts a block-device volume at
+// k3sDataDir; a composite member has none, and the rootfs is read-only, so
+// k3s's self-extract + datastore + containerd unpack have nowhere to write (k3s
+// dies "extracting data: no such file or directory"). This mounts a tmpfs there
+// instead and stages the baked airgap tarball into it, exactly as
+// mountStatefulVolume does after its block mount. The k3s datastore + unpacked
+// images therefore live in RAM (counting against the member's mem_mib) and are
+// lost on fresh/destroy, which IS the R5 warmth-only contract. No explicit size
+// is set, so the tmpfs defaults to 50% of guest RAM and auto-scales with the
+// member's mem_mib (server larger than agent). A tmpfs mount failure is FATAL: a
+// member that cannot get a writable data dir must fail the boot loudly rather
+// than crash obscurely inside k3s.
+func mountCompositeDataDir(logger *slog.Logger) error {
+	if err := unix.Mount("tmpfs", k3sDataDir, "tmpfs", 0, "mode=0700"); err != nil {
+		return fmt.Errorf("mount tmpfs at %s: %w", k3sDataDir, err)
+	}
+	logger.Info("composite member: k3s data dir on tmpfs (warmth-only, no volume)", "mount", k3sDataDir)
+
+	// Stage the baked airgap tarball from /opt/k3s-airgap (outside the tree, so the
+	// tmpfs did not hide it) into <k3sDataDir>/agent/images so k3s auto-imports it.
+	// Non-fatal, same posture as the stateful lane: a k3s that cannot find the
+	// airgap set fails its own readiness loudly downstream (the honest place).
+	if err := stageAirgapImages(logger, k3sDataDir); err != nil {
+		logger.Warn("composite member: staging airgap images failed", "err", err)
+	}
+	return nil
+}
+
 // mount is a thin logged wrapper over unix.Mount so each call site reads as one
 // line and a failure is logged with its target rather than crashing PID 1 (which
 // would panic the guest kernel).

--- a/projects/embervm/runtimes/k3s/guest-init/cmd/mount_other.go
+++ b/projects/embervm/runtimes/k3s/guest-init/cmd/mount_other.go
@@ -20,3 +20,10 @@ func mountGuestFilesystems(_ *slog.Logger) {}
 func mountStatefulVolume(_ *slog.Logger, dev, _ string) error {
 	return fmt.Errorf("ember-k3s-init: stateful volume mount unsupported on %s (dev=%s)", runtime.GOOS, dev)
 }
+
+// mountCompositeDataDir always fails off Linux: the tmpfs mount is Linux-only.
+// The composite path only runs inside the microVM; this stub keeps the package
+// building under the host toolchain for unit tests, which never reach it.
+func mountCompositeDataDir(_ *slog.Logger) error {
+	return fmt.Errorf("ember-k3s-init: composite data dir mount unsupported on %s", runtime.GOOS)
+}


### PR DESCRIPTION
## Second-layer fix for R5 gate-1 bug 3

Follow-up to #3638 (chart 0.1.98), which fixed the guest-init base-build misclassification and let a composite member actually run k3s. That fix is **merged and validated live** (guest console: `composite member boot, running k3s`), and it uncovered a second, latent blocker on the same critical path.

**The bug:** a warmth-only composite member has **no volume**, and the rootfs is mounted **read-only**. The stateful lane gives k3s a writable data dir via a mounted block-device volume; a composite member had neither, so k3s died the instant it started:

```
INFO Acquiring lock file /var/lib/rancher/k3s/data/.lock
FATA extracting data: no such file or directory
```
(then PID 1 exits → guest kernel panic). This path had never executed before #3638, because a volume-less k3s had never run.

## The fix

- `mountCompositeDataDir` (guest-init): for a composite member, mount a **tmpfs** at `/var/lib/rancher/k3s` and stage the baked airgap tarball into it (`/opt/k3s-airgap` → `<data>/agent/images`), exactly as `mountStatefulVolume` does after its block mount. k3s's datastore + unpacked containerd images live in RAM, lost on fresh/destroy (the R5 warmth-only contract). No explicit tmpfs size → defaults to 50% of guest RAM, auto-scaling per member.
- **Sizing bump:** the unpacked airgap now lives in RAM, so the old member floors (sized for the base build, where k3s does *not* run) are too small. Server `2048 → 4096`, agent `1024 → 3072` MiB. node-4 has ~48G free (25% used), well within the ADR 002 rule-4 arithmetic.

Chart `0.1.98 → 0.1.99`.

## Testing

- `gofmt`, `go vet`, linux cross-build green; `helm template` renders the new member `memMib`. `TestClassifyBoot` (from #3638) still covers lane selection.
- The mount itself is a syscall path (not unit-testable off-guest); validated by the post-merge drill: drive a `scratch-k8s` wake and confirm the k3s server reaches Ready on 6443 and the agents join (gate-1 full boot: 3 Ready nodes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)