### PR TITLE
fix(embervm): give composite k3s all writable dirs on the read-only rootfs

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.99
+version: 0.1.100

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.99
+      targetRevision: 0.1.100
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/k3s/guest-init/cmd/mount_linux.go
+++ b/projects/embervm/runtimes/k3s/guest-init/cmd/mount_linux.go
@@ -55,24 +55,37 @@ func mountGuestFilesystems(logger *slog.Logger) {
 	}
 }
 
-// mountCompositeDataDir gives a WARMTH-ONLY composite member (R5, no volume) its
-// writable k3s data dir. The stateful lane mounts a block-device volume at
-// k3sDataDir; a composite member has none, and the rootfs is read-only, so
-// k3s's self-extract + datastore + containerd unpack have nowhere to write (k3s
-// dies "extracting data: no such file or directory"). This mounts a tmpfs there
-// instead and stages the baked airgap tarball into it, exactly as
-// mountStatefulVolume does after its block mount. The k3s datastore + unpacked
-// images therefore live in RAM (counting against the member's mem_mib) and are
-// lost on fresh/destroy, which IS the R5 warmth-only contract. No explicit size
-// is set, so the tmpfs defaults to 50% of guest RAM and auto-scales with the
-// member's mem_mib (server larger than agent). A tmpfs mount failure is FATAL: a
-// member that cannot get a writable data dir must fail the boot loudly rather
-// than crash obscurely inside k3s.
+// mountCompositeDataDir gives a WARMTH-ONLY composite member (R5, no volume) the
+// writable filesystems k3s needs. The stateful lane mounts a block-device volume
+// at k3sDataDir; a composite member has none, and the rootfs is read-only, so
+// EVERY path k3s (and its embedded kubelet + CNI) writes needs a tmpfs. It is not
+// just the data dir: k3s also writes the kubeconfig under /etc/rancher/k3s (and,
+// on an agent, the node password under /etc/rancher/node), kubelet state under
+// /var/lib/kubelet, and CNI IPAM state under /var/lib/cni (the k3s read-only-root
+// writable contract, docs.k3s.io/advanced; /run + /var/log are already tmpfs from
+// mountGuestFilesystems). The first k3s attempt to write any uncovered path fatals
+// on the read-only rootfs. All of it lives in RAM (counting against the member's
+// mem_mib) and is lost on fresh/destroy, which IS the R5 warmth-only contract. No
+// explicit size, so each tmpfs defaults to 50% of guest RAM and auto-scales with
+// mem_mib. A tmpfs mount failure is FATAL: a member that cannot get its writable
+// dirs must fail the boot loudly rather than crash obscurely inside k3s.
 func mountCompositeDataDir(logger *slog.Logger) error {
-	if err := unix.Mount("tmpfs", k3sDataDir, "tmpfs", 0, "mode=0700"); err != nil {
-		return fmt.Errorf("mount tmpfs at %s: %w", k3sDataDir, err)
+	for _, dir := range compositeWritableDirs {
+		if err := unix.Mount("tmpfs", dir, "tmpfs", 0, "mode=0700"); err != nil {
+			return fmt.Errorf("mount tmpfs at %s: %w", dir, err)
+		}
 	}
-	logger.Info("composite member: k3s data dir on tmpfs (warmth-only, no volume)", "mount", k3sDataDir)
+	logger.Info("composite member: writable tmpfs mounts for k3s (warmth-only, no volume)", "dirs", compositeWritableDirs)
+
+	// k3s writes the kubeconfig under /etc/rancher/k3s and (on an agent) the node
+	// password under /etc/rancher/node. Recreate both on the now-fresh /etc/rancher
+	// tmpfs so those writes land (k3s MkdirAll's them itself, but be explicit and
+	// fail-soft so a surprising permission issue surfaces here, not deep in k3s).
+	for _, dir := range []string{"/etc/rancher/k3s", "/etc/rancher/node"} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			logger.Warn("composite member: mkdir on /etc/rancher tmpfs failed", "dir", dir, "err", err)
+		}
+	}
 
 	// Stage the baked airgap tarball from /opt/k3s-airgap (outside the tree, so the
 	// tmpfs did not hide it) into <k3sDataDir>/agent/images so k3s auto-imports it.
@@ -82,6 +95,19 @@ func mountCompositeDataDir(logger *slog.Logger) error {
 		logger.Warn("composite member: staging airgap images failed", "err", err)
 	}
 	return nil
+}
+
+// compositeWritableDirs is the set of paths a warmth-only composite k3s member
+// (no volume, read-only rootfs) must have writable, beyond the /run + /var/log
+// tmpfs mountGuestFilesystems already provides. Each is baked as an empty dir in
+// the k3s images' apko `paths` so a tmpfs has a mountpoint on the RO rootfs.
+// k3sDataDir is first so the airgap staging that follows the mounts writes into
+// the mounted data dir.
+var compositeWritableDirs = []string{
+	k3sDataDir,         // /var/lib/rancher/k3s: server db, containerd, kubelet, self-extract
+	"/etc/rancher",     // k3s.yaml kubeconfig + the agent's /etc/rancher/node/password
+	"/var/lib/kubelet", // kubelet's own state dir (k3s does not relocate it under the data dir)
+	"/var/lib/cni",     // CNI IPAM allocation state (/var/lib/cni/networks/...)
 }
 
 // mount is a thin logged wrapper over unix.Mount so each call site reads as one

--- a/projects/embervm/runtimes/k3s/k3s-agent/apko.lock.json
+++ b/projects/embervm/runtimes/k3s/k3s-agent/apko.lock.json
@@ -2,7 +2,7 @@
   "version": "v1",
   "config": {
     "name": "apko.yaml",
-    "checksum": "sha256-DjAwUKNACOtretBfVB6smxGi6qmRw8GaquHiDRw1WL0="
+    "checksum": "sha256-3fYQUCGkqhdgEkrnQvaeOfUNYpkG7ExGQk8YuRx7EEM="
   },
   "contents": {
     "keyring": [

--- a/projects/embervm/runtimes/k3s/k3s-agent/apko.yaml
+++ b/projects/embervm/runtimes/k3s/k3s-agent/apko.yaml
@@ -68,6 +68,22 @@ paths:
     uid: 0
     gid: 0
     permissions: 0o700
+  # Warmth-only composite members have NO volume and a read-only rootfs, so k3s +
+  # its embedded kubelet/CNI need these as tmpfs mounts too (guest-init
+  # mountCompositeDataDir). A tmpfs mount needs its mountpoint to pre-exist on the
+  # read-only rootfs, so bake them empty here (the stateful/base-build lanes never
+  # mount over them, so they stay harmless empty dirs there). The k3s read-only-root
+  # contract's writable set is data-dir + /etc/rancher + these two + /run + /var/log.
+  - path: /var/lib/kubelet
+    type: directory
+    uid: 0
+    gid: 0
+    permissions: 0o700
+  - path: /var/lib/cni
+    type: directory
+    uid: 0
+    gid: 0
+    permissions: 0o700
   - path: /run
     type: directory
     uid: 0

--- a/projects/embervm/runtimes/k3s/k3s-server/apko.lock.json
+++ b/projects/embervm/runtimes/k3s/k3s-server/apko.lock.json
@@ -2,7 +2,7 @@
   "version": "v1",
   "config": {
     "name": "apko.yaml",
-    "checksum": "sha256-dX1E5CFWEVjnwUm1HQwm0YTXt2DjVddyNyAGQ05845k="
+    "checksum": "sha256-5PvgbEKfOLuUrkoAQdHz7h2NcVi50326tp/T7n4ajrg="
   },
   "contents": {
     "keyring": [

--- a/projects/embervm/runtimes/k3s/k3s-server/apko.yaml
+++ b/projects/embervm/runtimes/k3s/k3s-server/apko.yaml
@@ -68,6 +68,22 @@ paths:
     uid: 0
     gid: 0
     permissions: 0o700
+  # Warmth-only composite members have NO volume and a read-only rootfs, so k3s +
+  # its embedded kubelet/CNI need these as tmpfs mounts too (guest-init
+  # mountCompositeDataDir). A tmpfs mount needs its mountpoint to pre-exist on the
+  # read-only rootfs, so bake them empty here (the stateful/base-build lanes never
+  # mount over them, so they stay harmless empty dirs there). The k3s read-only-root
+  # contract's writable set is data-dir + /etc/rancher + these two + /run + /var/log.
+  - path: /var/lib/kubelet
+    type: directory
+    uid: 0
+    gid: 0
+    permissions: 0o700
+  - path: /var/lib/cni
+    type: directory
+    uid: 0
+    gid: 0
+    permissions: 0o700
   - path: /run
     type: directory
     uid: 0


### PR DESCRIPTION
## Third layer of R5 gate-1 composite-boot (should complete it)

Chain so far: #3638 (guest-init ran k3s) → #3641 (tmpfs data dir let k3s start) → this. Each fix let k3s get one step further and revealed the next read-only-rootfs write it couldn't do. After #3641, the live drill showed k3s reach "Running kube-apiserver" then fatal:

```
FATA open /etc/rancher/k3s/k3s.yaml: read-only file system
```
(writing its admin kubeconfig) → PID 1 exit → kernel panic.

**Root:** a warmth-only composite member has no volume and a read-only rootfs, and k3s writes to **several** dirs, not just the data dir. #3641 only covered `/var/lib/rancher/k3s`.

## The fix

Cover the full k3s read-only-root writable contract ([docs.k3s.io/advanced](https://docs.k3s.io/advanced)). `/run` + `/var/log` are already tmpfs (`mountGuestFilesystems`); this adds tmpfs at:
- `/etc/rancher` — the kubeconfig (`/etc/rancher/k3s/k3s.yaml`) and, on an agent, the node password (`/etc/rancher/node/password`)
- `/var/lib/kubelet` — kubelet state
- `/var/lib/cni` — CNI IPAM state

alongside the existing `/var/lib/rancher/k3s`. A tmpfs needs its mountpoint to pre-exist on the RO rootfs, so `/var/lib/kubelet` + `/var/lib/cni` are baked as empty dirs in **both** k3s images' apko `paths` (`/etc/rancher` already exists via `/etc/rancher/k3s`). On the fresh `/etc/rancher` tmpfs, guest-init recreates `k3s/` and `node/`. All warmth-only (RAM, lost on fresh/destroy).

Fetched the authoritative writable set from the k3s docs rather than drilling one path per ~15-min CI+rollout cycle.

Chart `0.1.99 → 0.1.100`.

## Testing

- `gofmt`/`vet`/linux build green; both apko YAMLs parse and carry the 2 new dirs. `TestClassifyBoot` unchanged.
- Post-merge drill: drive a `scratch-k8s` wake and confirm the k3s server reaches Ready on 6443 and both agents join — gate-1 full boot (3 Ready nodes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)