### PR TITLE
feat(ember): optimistic wake sweep, fold-fitting layout, tighter copy

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.166
+version: 0.89.167
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.166
+      targetRevision: 0.89.167
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.241
+version: 0.285.242
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.241
+      targetRevision: 0.285.242
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
@@ -395,7 +395,7 @@
       label: "Awake",
       tone: "awake",
       sentence:
-        "Awake. Queries answer instantly; it falls back asleep about a second after the last one.",
+        "Answering in single-digit milliseconds. Asleep again about a second after the last query.",
     },
     banking: {
       label: "Falling asleep",
@@ -403,6 +403,7 @@
       sentence: "Saving itself to disk...",
     },
     banked: { label: "Asleep", tone: "asleep", sentence: "" },
+    checkpointed: { label: "Asleep", tone: "asleep", sentence: "" },
     relighting: {
       label: "Waking (from snapshot)",
       tone: "waking",
@@ -538,7 +539,11 @@
       : "some",
   );
 
-  let asleepWake = $derived(tiers.relight != null ? ms(tiers.relight) : "under 100 ms");
+  // Full phrase, not a bare value: composing "in about" with the "under
+  // 100 ms" fallback used to render "in about under 100 ms".
+  let asleepWakePhrase = $derived(
+    tiers.relight != null ? `in about ${ms(tiers.relight)}` : "in under a second",
+  );
 
   // Dozing narration while serving-but-idle: an approach, not a countdown.
   let dozeHint = $derived(
@@ -621,11 +626,10 @@
         <span class="state-dot" aria-hidden="true"></span>
         <span class="state-label">{stateView.label}</span>
       </div>
-      {#if stateView.tone === "asleep" && status?.state === "banked"}
+      {#if stateView.tone === "asleep" && (status?.state === "banked" || status?.state === "checkpointed")}
         <p class="state-sentence">
-          <strong>Asleep, costing nothing.</strong> 0 CPU, 0 memory. Your {asleepMib}
-          of data is safe on disk. The next query wakes the database in about
-          {asleepWake}.
+          <strong>Asleep, costing nothing.</strong> 0 CPU, 0 memory, {asleepMib}
+          safe on disk. The next query wakes it {asleepWakePhrase}.
         </p>
       {:else}
         <p class="state-sentence">{dozeHint ?? othersHint ?? stateView.sentence}</p>
@@ -855,9 +859,9 @@
      this component in .ember-site, which provides every var(--em-*) below. */
   .pg-panel {
     display: grid;
-    grid-template-columns: 380px 1fr;
+    grid-template-columns: 340px 1fr;
     align-items: start;
-    gap: 20px;
+    gap: 16px;
     max-width: 1100px;
   }
 
@@ -866,15 +870,19 @@
       grid-template-columns: 1fr;
     }
 
-    .right-col {
-      order: -1;
+    .state-block {
+      min-height: 0;
+    }
+
+    .result-card {
+      min-height: 200px;
     }
   }
 
   .left-col {
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: 12px;
   }
 
   .right-col {
@@ -889,8 +897,8 @@
     border: 1px solid var(--em-line);
     border-radius: 14px;
     box-shadow: var(--em-shadow-soft);
-    padding: 18px 20px;
-    min-height: 212px;
+    padding: 14px 16px;
+    min-height: 168px;
     display: flex;
     flex-direction: column;
     gap: 12px;
@@ -1037,7 +1045,7 @@
     border: 1px solid var(--em-line);
     border-radius: 14px;
     box-shadow: var(--em-shadow-soft);
-    padding: 14px 18px;
+    padding: 12px 16px;
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -1113,7 +1121,7 @@
     border: 1px solid var(--em-line);
     border-radius: 14px;
     box-shadow: var(--em-shadow-soft);
-    padding: 18px 20px;
+    padding: 14px 16px;
   }
 
   .last-run-numbers {
@@ -1128,7 +1136,7 @@
 
   .last-run-value {
     font-family: var(--em-mono);
-    font-size: 30px;
+    font-size: 26px;
     font-weight: 700;
     font-variant-numeric: tabular-nums;
     letter-spacing: -0.02em;
@@ -1174,7 +1182,7 @@
     border: 1px solid var(--em-line);
     border-radius: 14px;
     box-shadow: var(--em-shadow-soft);
-    padding: 14px 18px;
+    padding: 12px 16px;
     display: flex;
     align-items: center;
     gap: 14px;
@@ -1246,8 +1254,8 @@
     border: 1px solid var(--em-line);
     border-radius: 14px;
     box-shadow: var(--em-shadow);
-    padding: 18px 20px;
-    min-height: 420px;
+    padding: 14px 16px;
+    min-height: 300px;
   }
 
   .result-view {

--- a/projects/monolith/frontend/src/lib/public/ember/EmberStage.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberStage.svelte
@@ -27,6 +27,7 @@
 
   const STATE_WORD = {
     banked: "Asleep",
+    checkpointed: "Asleep",
     banking: "Falling asleep",
     relighting: "Waking",
     cold_booting: "Waking",
@@ -87,14 +88,29 @@
 
   let flickerTickAt = 0;
 
-  function targetFor(now) {
-    if (vmState === "banked" || vmState == null) return 0;
-    if (vmState === "serving") return 1;
-    if (WAKING.has(vmState)) {
+  // Optimistic wake: the moment a query is in flight against a cold VM, treat
+  // the state as waking instead of waiting for the control plane -> status
+  // cache -> poll chain to report it (~1-2s of dead air after the click). The
+  // click IS the wake signal; if the run is refused (rate limiter, busy), the
+  // console flips running off, the effective state falls back to banked, and
+  // the eased warmth drifts back down without a snap.
+  const COLD_STATES = new Set(["banked", "checkpointed"]);
+
+  function effectiveState() {
+    if (running && (vmState == null || COLD_STATES.has(vmState))) {
+      return "relighting";
+    }
+    return vmState;
+  }
+
+  function targetFor(now, state) {
+    if (state === "banked" || state === "checkpointed" || state == null) return 0;
+    if (state === "serving") return 1;
+    if (WAKING.has(state)) {
       const frac = Math.min(1, (now - sweepStartAt) / WAKE_SWEEP_MS);
       return sweepFromW + (1 - sweepFromW) * frac;
     }
-    if (vmState === "banking") {
+    if (state === "banking") {
       const frac = Math.min(1, (now - sweepStartAt) / BANK_SWEEP_MS);
       return sweepFromW * (1 - frac);
     }
@@ -105,15 +121,17 @@
     const dt = lastFrameAt ? now - lastFrameAt : 16;
     lastFrameAt = now;
 
-    if (vmState !== prevFrameState) {
-      // Entered a new state this frame: (re)start the sweep clock from the
-      // current eased warmth, so a mid-sweep state flip (e.g. banking
-      // interrupted by a new request) never snaps.
-      prevFrameState = vmState;
+    const state = effectiveState();
+    if (state !== prevFrameState) {
+      // Entered a new (effective) state this frame: (re)start the sweep clock
+      // from the current eased warmth, so a mid-sweep state flip (e.g. banking
+      // interrupted by a new request, or an optimistic wake refused) never
+      // snaps.
+      prevFrameState = state;
       sweepStartAt = now;
       sweepFromW = w;
     }
-    const target = targetFor(now);
+    const target = targetFor(now, state);
     const k = 1 - Math.exp(-EASE_PER_MS * dt);
     w = w + (target - w) * k;
 
@@ -180,8 +198,16 @@
     };
   });
 
+  // Reactive mirror of effectiveState() for the derived display bits below
+  // (the rAF loop reads effectiveState() directly each frame instead).
+  let optimisticWaking = $derived(
+    running && (vmState == null || COLD_STATES.has(vmState)),
+  );
+
   // ── Reduced-motion static fallback: two-state cell fill, no rAF loop ──
-  let staticHot = $derived(vmState === "serving" || WAKING.has(vmState ?? ""));
+  let staticHot = $derived(
+    vmState === "serving" || WAKING.has(vmState ?? "") || optimisticWaking,
+  );
 
   function ms(v) {
     if (v == null) return "–";
@@ -213,10 +239,16 @@
     return `${humanize(gbh)} GB·h`;
   }
 
-  let stateWord = $derived(STATE_WORD[vmState ?? ""] ?? "Asleep");
+  let stateWord = $derived(
+    optimisticWaking ? "Waking" : (STATE_WORD[vmState ?? ""] ?? "Asleep"),
+  );
 
   let heroKind = $derived(
-    vmState === "serving" ? "serving" : vmState != null && WAKING.has(vmState) ? "waking" : "cold",
+    vmState === "serving"
+      ? "serving"
+      : optimisticWaking || (vmState != null && WAKING.has(vmState))
+        ? "waking"
+        : "cold",
   );
 </script>
 
@@ -236,8 +268,8 @@
         <span class="es-hero-value">{ms(running ? stopwatchMs : null)}</span>
         <span class="es-hero-caption">waking up</span>
       {:else}
-        <span class="es-hero-value">answering</span>
-        <span class="es-hero-caption">answering in single-digit milliseconds</span>
+        <span class="es-hero-value">awake</span>
+        <span class="es-hero-caption">single-digit millisecond answers</span>
       {/if}
     </div>
   </div>
@@ -247,7 +279,7 @@
   .ember-stage {
     position: relative;
     width: 100%;
-    height: 280px;
+    height: clamp(150px, 24vh, 230px);
     border-radius: 14px;
     border: 1px solid var(--es-border);
     background: var(--es-panel);
@@ -352,7 +384,7 @@
 
   .es-hero-value {
     font-family: var(--em-mono, ui-monospace, monospace);
-    font-size: clamp(28px, 4vw, 44px);
+    font-size: clamp(24px, 3.4vw, 38px);
     letter-spacing: -0.02em;
     font-weight: 700;
     font-variant-numeric: tabular-nums;

--- a/projects/monolith/frontend/src/routes/public/ember/postgres/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/postgres/+page.svelte
@@ -40,25 +40,31 @@
   </header>
 
   <main class="ember-page">
-    <header class="ember-hero">
-      <h1>
-        A database that <span class="frost-word">sleeps</span> when nobody's
-        asking.
-      </h1>
-      <p class="lede">
-        This Postgres microVM banks itself to disk about a second after its
-        last connection closes, so it costs nothing while idle. The next query
-        <span class="ember-word">wakes it</span>, usually in well under a
-        second, against the exact data it left behind.
-      </p>
-    </header>
+    <!-- The fold: claim on the left, live proof on the right, console
+         controls directly below. A visitor on a ~900px window sees the state,
+         the headline number, and both buttons without scrolling; the prose
+         explainers live below the fold. -->
+    <div class="fold">
+      <header class="ember-hero">
+        <h1>
+          A database that <span class="frost-word">sleeps</span> when nobody's
+          asking.
+        </h1>
+        <p class="lede">
+          Banks itself to disk a second after the last connection closes, then
+          costs nothing. The next query
+          <span class="ember-word">wakes it</span> in under a second, on the
+          exact data it left behind.
+        </p>
+      </header>
 
-    <EmberStage
-      vmState={consoleStatus?.state}
-      totalSavedMibS={consoleStatus?.total_saved_mib_s}
-      stopwatchMs={consoleStopwatchMs}
-      running={consoleRunning}
-    />
+      <EmberStage
+        vmState={consoleStatus?.state}
+        totalSavedMibS={consoleStatus?.total_saved_mib_s}
+        stopwatchMs={consoleStopwatchMs}
+        running={consoleRunning}
+      />
+    </div>
 
     <EmberConsole
       turnstileSiteKey={data.turnstileSiteKey}
@@ -72,31 +78,29 @@
     <section class="explainer">
       <h2>What "banking" means</h2>
       <p>
-        Banking is a pause-to-disk, not a shutdown: the VM's live memory and CPU
-        state are snapshotted and the process is torn down, leaving nothing
-        running and nothing billed while it waits. A snapshot is a much faster
-        thing to resume than a fresh boot is to perform, which is why most wakes
-        land under a second instead of paying a full cold start.
+        A pause-to-disk, not a shutdown: live memory and CPU state are
+        snapshotted and the process is torn down. Nothing runs and nothing is
+        billed while it waits. Resuming a snapshot is far faster than a fresh
+        boot, which is why most wakes land under a second instead of paying a
+        full cold start.
       </p>
     </section>
 
     <section class="explainer">
-      <h2>Why the data survives, and what the wake number means</h2>
+      <h2>Why the data survives</h2>
       <p>
-        The orders table lives on a separate data volume from the snapshot, so
-        destroying the VM (or losing the snapshot entirely) never touches the
-        rows already written. A fresh cold boot against that same volume is
-        slower than resuming from a snapshot, but it recovers every row, which
-        is the actual point of the exhibit: the compute is disposable, the data
-        is not. The "wake + connect" number on the console is the wall-clock
-        time from the first TCP packet to a usable connection, whichever path
-        the VM had to take to get there.
+        The orders table lives on a separate volume from the snapshot, so
+        destroying the VM never touches rows already written. A cold boot
+        against that volume is slower than a snapshot resume but recovers
+        every row: the compute is disposable, the data is not. "Wake +
+        connect" on the console is wall-clock time from the first TCP packet
+        to a usable connection, whichever path the wake took.
       </p>
     </section>
 
     <footer class="ember-foot">
       <p>
-        The freeze-and-restore trick underneath this demo has its own story:
+        The freeze and restore underneath this demo:
         <a href="/ember/firecracker">boot once, restore forever</a>.
       </p>
     </footer>
@@ -113,7 +117,7 @@
     justify-content: space-between;
     align-items: center;
     gap: 16px;
-    padding: 16px 28px;
+    padding: 14px 28px;
     font-family: var(--em-mono);
     font-size: 12.5px;
     color: var(--em-muted);
@@ -156,25 +160,31 @@
   .ember-page {
     max-width: 1100px;
     margin: 0 auto;
-    padding: 40px 24px 96px;
+    padding: 12px 24px 80px;
     display: flex;
     flex-direction: column;
-    gap: 40px;
+    gap: 24px;
+  }
+
+  .fold {
+    display: grid;
+    grid-template-columns: minmax(300px, 380px) 1fr;
+    gap: 24px;
+    align-items: center;
   }
 
   .ember-hero {
     display: flex;
     flex-direction: column;
-    gap: 14px;
-    max-width: 780px;
+    gap: 10px;
   }
 
   .ember-hero h1 {
     margin: 0;
-    font-size: clamp(34px, 4.8vw, 56px);
+    font-size: clamp(26px, 2.8vw, 36px);
     font-weight: 800;
-    letter-spacing: -0.03em;
-    line-height: 1.05;
+    letter-spacing: -0.025em;
+    line-height: 1.08;
     color: var(--em-ink);
     text-wrap: balance;
   }
@@ -190,22 +200,22 @@
 
   .lede {
     margin: 0;
-    font-size: clamp(16px, 1.4vw, 19px);
-    line-height: 1.6;
+    font-size: 15px;
+    line-height: 1.55;
     color: var(--em-muted);
-    max-width: 58ch;
+    max-width: 44ch;
   }
 
   .explainer {
     max-width: 720px;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
   }
 
   .explainer h2 {
     margin: 0;
-    font-size: clamp(21px, 2vw, 26px);
+    font-size: clamp(19px, 1.8vw, 23px);
     font-weight: 750;
     letter-spacing: -0.02em;
     color: var(--em-ink);
@@ -214,14 +224,14 @@
 
   .explainer p {
     margin: 0;
-    font-size: 15.5px;
-    line-height: 1.65;
+    font-size: 15px;
+    line-height: 1.6;
     color: var(--em-muted);
   }
 
   .ember-foot {
     border-top: 1px solid var(--em-line);
-    padding-top: 24px;
+    padding-top: 20px;
     max-width: 720px;
   }
 
@@ -235,5 +245,30 @@
     color: var(--em-ember-deep);
     text-decoration: underline;
     text-underline-offset: 3px;
+  }
+
+  @media (max-width: 900px) {
+    .topbar {
+      padding: 12px 16px;
+    }
+
+    .ember-page {
+      padding: 8px 16px 64px;
+      gap: 18px;
+    }
+
+    .fold {
+      grid-template-columns: 1fr;
+      gap: 14px;
+    }
+
+    .ember-hero h1 {
+      font-size: clamp(24px, 6.4vw, 30px);
+    }
+
+    .lede {
+      font-size: 14px;
+      max-width: none;
+    }
   }
 </style>


### PR DESCRIPTION
Visitor-experience pass on /ember/postgres, per Joe's three asks:

1. **Kill the wake-animation lag.** The stage's warm sweep used to wait for click -> control plane -> status cache -> 700ms poll before starting (~1-2s of dead air). It now starts optimistically the moment a query is in flight against a cold VM; if the run is refused (wake-rate limiter / busy semaphore), `running` drops and the warmth eases back down without a snap. The state word, stopwatch hero, and reduced-motion fallback all follow the same optimistic state.

2. **Fit the fold.** Hero claim sits beside the live stage on desktop (grid, 340px rail matching the console below), so a ~900px window shows the claim, the live state, the headline number, and both buttons without scrolling. Stage height is now viewport-relative (clamp 150-230px). Mobile: controls come before the result grid (previously a screen of table buried the buttons), panels compress, paddings tighten.

3. **Copy trim.** Checkable numbers, no filler: serving caption is now 'single-digit millisecond answers' (was 'answering' / 'answering in single-digit milliseconds' twice), the asleep sentence no longer renders 'in about under 100 ms' (grammar bug from composing a fallback), explainers cut roughly in half, footer link tightened. The raw `checkpointed` lifecycle state now displays as Asleep in both the console chip and the stage instead of leaking the enum.

Charts: monolith 0.285.242 + monolith-public 0.89.167 (frontend ships in both images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzSpVf5jQsax3m1e3J6CGR