### PR TITLE
fix(embervm): invalidate the node channel when a daemon call exits :noproc

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.100
+version: 0.1.101

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -1242,7 +1242,14 @@ defmodule Embervm.StatefulManager do
       rescue
         _ -> :error
       catch
-        _, _ -> :error
+        # Dead Mint ConnectionProcess: invalidate so the next verb re-dials
+        # (best-effort verb, but leaving the corpse cached wedges later wakes).
+        :exit, _ ->
+          _ = state.invalidate_fun.(node_id, channel)
+          :error
+
+        _, _ ->
+          :error
       end
     end
 
@@ -1288,7 +1295,13 @@ defmodule Embervm.StatefulManager do
       rescue
         _ -> :error
       catch
-        _, _ -> :error
+        # Same dead-ConnectionProcess invalidation as stop_stateful_destroy.
+        :exit, _ ->
+          _ = state.invalidate_fun.(node_id, channel)
+          :error
+
+        _, _ ->
+          :error
       end
     end
 
@@ -1520,25 +1533,39 @@ defmodule Embervm.StatefulManager do
 
   defp safe_start_stateful(state, node_id, req) do
     with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
-      case state.start_stateful_fun.(channel, req) do
-        {:error, reason} = err ->
-          # A wake that failed because the channel's transport is dead must tear
-          # the cached channel down so the NEXT wake re-dials; see
-          # Embervm.NodeChannel.transport_dead?/1 (the wrapped-RPCError case).
-          if Embervm.NodeChannel.transport_dead?(reason) do
-            _ = state.invalidate_fun.(node_id, channel)
-          end
+      try do
+        case state.start_stateful_fun.(channel, req) do
+          {:error, reason} = err ->
+            # A wake that failed because the channel's transport is dead must
+            # tear the cached channel down so the NEXT wake re-dials; see
+            # Embervm.NodeChannel.transport_dead?/1 (the wrapped-RPCError case).
+            if Embervm.NodeChannel.transport_dead?(reason) do
+              _ = state.invalidate_fun.(node_id, channel)
+            end
 
-          err
+            err
 
-        other ->
-          other
+          other ->
+            other
+        end
+      rescue
+        e -> {:error, {:start_stateful_raised, e}}
+      catch
+        :exit, reason ->
+          # The Mint ConnectionProcess behind the cached channel died (a noded
+          # rollout kills in-flight connections), so GenServer.call exits
+          # :noproc instead of returning a transport error. Without this
+          # invalidation the dead channel stays cached and EVERY subsequent
+          # wake fails until the control plane restarts, wedging the workload
+          # (observed live on demo-postgres, 2026-07-18). Mirrors
+          # Embervm.GroupManager.over_channel/3.
+          _ = state.invalidate_fun.(node_id, channel)
+          {:error, {:start_stateful_raised, {:exit, reason}}}
+
+        kind, reason ->
+          {:error, {:start_stateful_raised, {kind, reason}}}
       end
     end
-  rescue
-    e -> {:error, {:start_stateful_raised, e}}
-  catch
-    kind, reason -> {:error, {:start_stateful_raised, {kind, reason}}}
   end
 
   defp safe_channel(channel_fun, node_id) do

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -407,6 +407,28 @@ defmodule Embervm.StatefulManagerTest do
     assert_receive {:invalidated, "node-4", :ch}, 1_000
   end
 
+  test "a wake whose channel process is dead (:noproc exit) invalidates so the next wake re-dials" do
+    # A noded rollout kills the Mint ConnectionProcess behind the cached
+    # channel; the gRPC stub's GenServer.call then EXITS :noproc instead of
+    # returning a transport error. Observed live on demo-postgres 2026-07-18:
+    # without invalidation every subsequent wake failed until a control-plane
+    # restart.
+    test_pid = self()
+
+    ctx =
+      start_stack(
+        start_stateful_fun: fn _ch, _req -> exit({:noproc, {GenServer, :call, [:dead_pid]}}) end,
+        invalidate_fun: fn node_id, chan -> send(test_pid, {:invalidated, node_id, chan}) end,
+        wake_max: 100
+      )
+
+    stateful_workload(ctx, "wl-a")
+    stateful_node(ctx, "node-4")
+
+    assert {:error, {:wake_failed, _}} = StatefulManager.wake(ctx.mgr, "wl-a", "p")
+    assert_receive {:invalidated, "node-4", :ch}, 1_000
+  end
+
   # -- straggler -----------------------------------------------------------------
 
   test "a connection arriving while a live endpoint exists is resolved, not re-woken" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.100
+      targetRevision: 0.1.101
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
A noded rollout kills the Mint ConnectionProcess behind the control plane's cached channel; the gRPC stub's GenServer.call then EXITS :noproc instead of returning a transport error. StatefulManager's daemon seams caught that exit OUTSIDE the transport_dead? invalidation, so the dead channel stayed cached and every subsequent wake failed until a manual control-plane restart.

Observed live on the public demo tonight: demo-postgres wedged in `evicted`, every visitor interaction failing with 'server closed the connection unexpectedly' in ~9ms, recovered only by `kubectl rollout restart` of the CP. GroupManager.over_channel/3 already handles this exact exit shape; this brings StatefulManager's three daemon seams (safe_start_stateful, stop_stateful_destroy, safe_delete_volume) in line, with a regression test on the wake path.

With this fix the failure mode becomes: one visitor's wake fails, the channel invalidates, the next wake re-dials and succeeds — no operator in the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzSpVf5jQsax3m1e3J6CGR