### PR TITLE
feat(ember): one-motion wake sweep and full-contrast secondary text

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.168
+version: 0.89.169
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.168
+      targetRevision: 0.89.169
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.243
+version: 0.285.244
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.243
+      targetRevision: 0.285.244
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
@@ -345,6 +345,15 @@
       }
       const body = result.body;
       lastRun = body;
+      // A completed roundtrip MEANS the VM is serving right now; reflect it
+      // immediately instead of letting the stage fall back to "banked" for
+      // the up-to-1.2s gap (500ms status cache + 700ms poll) between running
+      // flipping false and the poll confirming. Without this the warm sweep
+      // visibly dips mid-wake; the next poll still owns the true state.
+      if (status?.state !== "serving") {
+        status = { ...(status ?? {}), state: "serving" };
+        prevState = "serving";
+      }
       view = mode === "aggregate" ? "summary" : "orders";
       const tier =
         body.classification === "relight" || body.classification === "warm"
@@ -946,7 +955,6 @@
 
   .tone-asleep .state-dot {
     background: var(--em-frost);
-    opacity: 0.55;
   }
 
   .tone-asleep .state-label {

--- a/projects/monolith/frontend/src/lib/public/ember/ember.css
+++ b/projects/monolith/frontend/src/lib/public/ember/ember.css
@@ -13,8 +13,12 @@
   --em-line: #e3dfd5;
   --em-line-soft: #ece8df;
   --em-ink: #20222a;
-  --em-muted: #525965;
-  --em-faint: #7d838e;
+  /* One tier darker than fcstory's #525965/#7d838e: on the warm ground the
+   * originals read grey-on-beige (the muted look Joe also vetoed on the
+   * homepage); secondary text stays secondary through size and weight, not
+   * washout. */
+  --em-muted: #3d434e;
+  --em-faint: #646b76;
   --em-ember: #e05c26;
   --em-ember-deep: #b7461a;
   --em-ember-dim: #f0c4ae;


### PR DESCRIPTION
- A completed roundtrip now sets state serving immediately instead of
  letting the stage fall back to banked for the up-to-1.2s status-cache +
  poll gap: the warm sweep no longer starts, dips, and restarts; it rolls
  across in one motion. Setting prevState alongside also stops the poll's
  own banked->serving confirmation from reading as another visitor's wake.
- Secondary text tokens darken one tier (muted #3d434e, faint #646b76):
  the fcstory greys read grey-on-beige on the warm ground. The asleep
  chip dot drops its 0.55 opacity for the same reason.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TzSpVf5jQsax3m1e3J6CGR
