### PR TITLE
feat(ember): align insert rate limit to one per second so the queue drains

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.171
+version: 0.89.172
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.171
+      targetRevision: 0.89.172
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.246
+version: 0.285.247
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.246
+      targetRevision: 0.285.247
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/ember_public/core.py
+++ b/projects/monolith/ember_public/core.py
@@ -172,12 +172,15 @@ def release_query_slot() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Per-session insert bucket: one insert per session_tag per 5 seconds. Keyed
+# Per-session insert bucket: one insert per session_tag per second. Keyed
 # on the opaque session tag (not IP), bounded by pruning stale entries on
 # every access so long-running processes never grow this dict unbounded.
+# The window sits just below the frontend queue's 1000ms cooldown so the
+# honest one-per-second queue never trips it; this stays a backstop against
+# scripted clients that bypass the UI or tabs racing a shared session cookie.
 # ---------------------------------------------------------------------------
 
-_INSERT_BUCKET_WINDOW_S = 5.0
+_INSERT_BUCKET_WINDOW_S = 0.9
 _INSERT_BUCKET_PRUNE_AGE_S = 3600.0
 _insert_bucket: dict[str, float] = {}
 

--- a/projects/monolith/ember_public/router.py
+++ b/projects/monolith/ember_public/router.py
@@ -89,7 +89,7 @@ async def postgres_query(body: PostgresQueryRequest, request: Request) -> dict:
     - a session is required for inserts once Turnstile is configured (public
       tier); the private tier, which leaves TURNSTILE_SECRET_KEY unset, still
       allows sessionless inserts.
-    - one insert per session per 5 seconds (core.check_and_record_insert).
+    - one insert per session per second (core.check_and_record_insert).
     - a global semaphore around the roundtrip (core.try_acquire_query_slot),
       exhausted under a concurrent burst.
     """
@@ -113,7 +113,7 @@ async def postgres_query(body: PostgresQueryRequest, request: Request) -> dict:
                 }
         elif not core.check_and_record_insert(session_tag):
             return {
-                "error": "one order per five seconds",
+                "error": "one order per second",
                 "rate_limited": True,
                 "mode": body.mode,
             }

--- a/projects/monolith/ember_public/router_test.py
+++ b/projects/monolith/ember_public/router_test.py
@@ -708,7 +708,7 @@ def test_semaphore_slot_released_after_roundtrip_allows_next_request(monkeypatch
     assert core._query_semaphore._value == core._QUERY_SEMAPHORE_SIZE
 
 
-def test_insert_bucket_rejects_second_insert_within_five_seconds(monkeypatch):
+def test_insert_bucket_rejects_second_insert_within_window(monkeypatch):
     monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
     monkeypatch.setattr(core, "EMBERVM_URL", "")
 
@@ -742,10 +742,10 @@ def test_insert_bucket_rejects_second_insert_within_five_seconds(monkeypatch):
     assert second.status_code == 200
     body = second.json()
     assert body["rate_limited"] is True
-    assert "five seconds" in body["error"]
+    assert "per second" in body["error"]
 
 
-def test_insert_bucket_allows_after_five_seconds_elapse(monkeypatch):
+def test_insert_bucket_allows_after_window_elapses(monkeypatch):
     monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
     monkeypatch.setattr(core, "EMBERVM_URL", "")
 

--- a/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
@@ -331,7 +331,7 @@
       return {
         ok: false,
         permanent: true,
-        error: "rate limited to one order per 5s, wait a bit and retry",
+        error: "rate limited to one order per second, wait a moment and retry",
       };
     }
     if (body.error) {


### PR DESCRIPTION
## What

The Ember Postgres exhibit (`jomcgi.dev/ember`) has two independent limiters on the insert path that currently disagree:

- **Frontend** (`EmberConsole.svelte`) already queues insert clicks (cap 3) and drains them at one per second (`COOLDOWN_MS = 1000`).
- **Backend** (`ember_public/core.py`) rejected any insert within **5s** of the last accepted one, so queued inserts bounced with `rate_limited` and the visitor saw "one order per five seconds". The queue never flushed at its own pace.

This drops the backend per-session window from `5.0s` to `0.9s`, aligning it with the frontend queue.

## Why 0.9s and not 1.0s

The frontend cooldown timer starts *after* a run settles, so the real gap between two queued insert request-starts is `previous_query_duration + 1000ms`, always `> 1000ms`. Setting the backend window just under that (0.9s) guarantees the honest one-per-second queue never trips it, absorbing timing jitter, while the bucket remains a backstop against:

- scripted clients hitting the API directly, bypassing the Svelte queue;
- two tabs sharing one session cookie, each with its own independent 1/sec queue, interleaving on the same `session_tag`.

Enforcement stays server-side; the frontend limit is a UX pacer, the backend limit is the security control.

## Changes

- `ember_public/core.py`: `_INSERT_BUCKET_WINDOW_S = 5.0 → 0.9`, updated the comment.
- `ember_public/router.py` + `EmberConsole.svelte`: rate-limit copy now reads "one per second".
- `ember_public/router_test.py`: updated the literal error-string assertion and two test names; the window value is asserted symbolically (`core._INSERT_BUCKET_WINDOW_S`), so timing tests needed no change.
- Bumped `monolith` + `monolith-public` charts (shared image) so both tiers deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)