### PR TITLE
feat(ember): clarify the savings stat is an all-time counter

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.173
+version: 0.89.175
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.173
+      targetRevision: 0.89.175
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.248
+version: 0.285.250
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.248
+      targetRevision: 0.285.250
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/ember/EmberStage.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberStage.svelte
@@ -326,7 +326,7 @@
         <div class="es-hero-inner" in:fade={{ duration: 260 }}>
           {#if heroKind === "cold"}
             <span class="es-hero-value">{gbHours(totalSavedMibS)}</span>
-            <span class="es-hero-caption">saved by scaling to zero</span>
+            <span class="es-hero-caption">saved all-time by scaling to zero</span>
           {:else if heroKind === "waking"}
             <span class="es-hero-value">{ms(running ? stopwatchMs : null)}</span>
             <span class="es-hero-caption">waking up</span>


### PR DESCRIPTION
## What

Changes the Ember Postgres hero caption from "saved by scaling to zero" to **"saved all-time by scaling to zero"** (`EmberStage.svelte:329`).

## Why

The `X GB·h` hero number is a single-row, all-time counter in Postgres (`demo_pg_savings`, id=1), shared across every visitor and never auto-reset. It accrues conservatively, only between two consecutive `banked` status polls of the same VM generation (512 MiB/s), so it undercounts rather than over-claims.

Rendered right beside the "ASLEEP" badge, the unqualified caption read as this-sleep or per-visitor savings. "all-time" disambiguates it as the cumulative aggregate.

Copy-only change; bumps `monolith` + `monolith-public` (shared image) so both tiers deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)