### PR TITLE
feat(embervm): R6 PR-1 proto contract for drain + artifact export/restore/evict

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.101
+version: 0.1.102

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.101
+      targetRevision: 0.1.102
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/proto/embervm/node/v1/fakenode/main.go
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/main.go
@@ -45,7 +45,7 @@ func storeKey(a *nodev1.ArtifactRef) string {
 	return fmt.Sprintf("%d/%s/%s", a.GetKind(), a.GetWorkload(), a.GetRef())
 }
 
-func (fakeServer) BuildBase(_ context.Context, req *nodev1.BuildBaseRequest) (*nodev1.BuildBaseResponse, error) {
+func (*fakeServer) BuildBase(_ context.Context, req *nodev1.BuildBaseRequest) (*nodev1.BuildBaseResponse, error) {
 	// Echo image_ref into snapshot_ref so the client can prove the request field
 	// arrived, and reflect the requested memory shape back.
 	return &nodev1.BuildBaseResponse{
@@ -57,11 +57,11 @@ func (fakeServer) BuildBase(_ context.Context, req *nodev1.BuildBaseRequest) (*n
 	}, nil
 }
 
-func (fakeServer) Prime(_ context.Context, req *nodev1.PrimeRequest) (*nodev1.PrimeResponse, error) {
+func (*fakeServer) Prime(_ context.Context, req *nodev1.PrimeRequest) (*nodev1.PrimeResponse, error) {
 	return &nodev1.PrimeResponse{VmId: "vm:" + req.GetSnapshotRef()}, nil
 }
 
-func (fakeServer) Assign(_ context.Context, req *nodev1.AssignRequest) (*nodev1.AssignResponse, error) {
+func (*fakeServer) Assign(_ context.Context, req *nodev1.AssignRequest) (*nodev1.AssignResponse, error) {
 	// Echo the guest request body and path back so the client can assert the full
 	// HTTP-semantics payload survived the round trip.
 	return &nodev1.AssignResponse{
@@ -74,7 +74,7 @@ func (fakeServer) Assign(_ context.Context, req *nodev1.AssignRequest) (*nodev1.
 	}, nil
 }
 
-func (fakeServer) Destroy(_ context.Context, _ *nodev1.DestroyRequest) (*nodev1.DestroyResponse, error) {
+func (*fakeServer) Destroy(_ context.Context, _ *nodev1.DestroyRequest) (*nodev1.DestroyResponse, error) {
 	return &nodev1.DestroyResponse{}, nil
 }
 
@@ -82,7 +82,7 @@ func (fakeServer) Destroy(_ context.Context, _ *nodev1.DestroyRequest) (*nodev1.
 // deliver-without-destroy by echoing the session_id it was handed into a
 // response header the client asserts on (the VM "survives", so the session id
 // is still meaningful). suspect is left false (a clean round trip).
-func (fakeServer) SessionAssign(_ context.Context, req *nodev1.SessionAssignRequest) (*nodev1.SessionAssignResponse, error) {
+func (*fakeServer) SessionAssign(_ context.Context, req *nodev1.SessionAssignRequest) (*nodev1.SessionAssignResponse, error) {
 	return &nodev1.SessionAssignResponse{
 		Response: &nodev1.GuestResponse{
 			StatusCode: 200,
@@ -99,7 +99,7 @@ func (fakeServer) SessionAssign(_ context.Context, req *nodev1.SessionAssignRequ
 
 // Bank derives a snapshot_ref from the session_id so the client can prove the
 // request field crossed the wire, and returns a fixed size.
-func (fakeServer) Bank(_ context.Context, req *nodev1.BankRequest) (*nodev1.BankResponse, error) {
+func (*fakeServer) Bank(_ context.Context, req *nodev1.BankRequest) (*nodev1.BankResponse, error) {
 	return &nodev1.BankResponse{
 		SnapshotRef: "sessions/" + req.GetSessionId(),
 		SizeBytes:   2048,
@@ -108,19 +108,19 @@ func (fakeServer) Bank(_ context.Context, req *nodev1.BankRequest) (*nodev1.Bank
 
 // Relight derives a vm_id from the snapshot_ref so the client can prove the
 // restore request crossed the wire intact.
-func (fakeServer) Relight(_ context.Context, req *nodev1.RelightRequest) (*nodev1.RelightResponse, error) {
+func (*fakeServer) Relight(_ context.Context, req *nodev1.RelightRequest) (*nodev1.RelightResponse, error) {
 	return &nodev1.RelightResponse{VmId: "vm:" + req.GetSnapshotRef()}, nil
 }
 
 // EvictSnapshot is idempotent and returns an empty response for any ref.
-func (fakeServer) EvictSnapshot(_ context.Context, _ *nodev1.EvictSnapshotRequest) (*nodev1.EvictSnapshotResponse, error) {
+func (*fakeServer) EvictSnapshot(_ context.Context, _ *nodev1.EvictSnapshotRequest) (*nodev1.EvictSnapshotResponse, error) {
 	return &nodev1.EvictSnapshotResponse{}, nil
 }
 
 // StartServing derives vm_id and ip from whichever source ref was set (fresh or
 // relight) so the client can prove both oneof branches cross the wire, and
 // echoes the requested port back.
-func (fakeServer) StartServing(_ context.Context, req *nodev1.StartServingRequest) (*nodev1.StartServingResponse, error) {
+func (*fakeServer) StartServing(_ context.Context, req *nodev1.StartServingRequest) (*nodev1.StartServingResponse, error) {
 	ref := req.GetFresh().GetServingImageRef()
 	if ref == "" {
 		ref = req.GetRelight().GetSnapshotRef()
@@ -134,7 +134,7 @@ func (fakeServer) StartServing(_ context.Context, req *nodev1.StartServingReques
 
 // StopServing returns a snapshot_ref/size_bytes for BANK, and zero values for
 // DESTROY, so the client can assert both mode branches.
-func (fakeServer) StopServing(_ context.Context, req *nodev1.StopServingRequest) (*nodev1.StopServingResponse, error) {
+func (*fakeServer) StopServing(_ context.Context, req *nodev1.StopServingRequest) (*nodev1.StopServingResponse, error) {
 	if req.GetMode() == nodev1.StopServingMode_STOP_SERVING_MODE_BANK {
 		return &nodev1.StopServingResponse{
 			SnapshotRef: "serving/" + req.GetVmId(),
@@ -150,7 +150,7 @@ func (fakeServer) StopServing(_ context.Context, req *nodev1.StopServingRequest)
 // fallback, "noledger" -> ledger_unreadable, otherwise a warm relight), which is
 // how the round-trip test exercises each pairing branch against a stateless fake.
 // FRESH/COLD cold-boot from boot_image_ref and report a bumped generation.
-func (fakeServer) StartStateful(_ context.Context, req *nodev1.StartStatefulRequest) (*nodev1.StartStatefulResponse, error) {
+func (*fakeServer) StartStateful(_ context.Context, req *nodev1.StartStatefulRequest) (*nodev1.StartStatefulResponse, error) {
 	if req.GetMode() == nodev1.StartStatefulMode_START_STATEFUL_MODE_RELIGHT {
 		ref := req.GetRelightSnapshotRef()
 		switch {
@@ -181,7 +181,7 @@ func (fakeServer) StartStateful(_ context.Context, req *nodev1.StartStatefulRequ
 // StopStateful returns a bundle ref, stamped generation, and size for BANK, a
 // checkpoint token plus the paused generation for CHECKPOINT, and zero values for
 // DESTROY, so the client can assert every mode branch.
-func (fakeServer) StopStateful(_ context.Context, req *nodev1.StopStatefulRequest) (*nodev1.StopStatefulResponse, error) {
+func (*fakeServer) StopStateful(_ context.Context, req *nodev1.StopStatefulRequest) (*nodev1.StopStatefulResponse, error) {
 	switch req.GetMode() {
 	case nodev1.StopStatefulMode_STOP_STATEFUL_MODE_BANK:
 		return &nodev1.StopStatefulResponse{
@@ -202,7 +202,7 @@ func (fakeServer) StopStateful(_ context.Context, req *nodev1.StopStatefulReques
 // ResolveStateful returns the published bundle for COMMIT (deriving the ref from
 // the token so the client proves it crossed the wire) and an empty response for
 // ABORT, so the client can assert both resolve branches (ADR embervm/008).
-func (fakeServer) ResolveStateful(_ context.Context, req *nodev1.ResolveStatefulRequest) (*nodev1.ResolveStatefulResponse, error) {
+func (*fakeServer) ResolveStateful(_ context.Context, req *nodev1.ResolveStatefulRequest) (*nodev1.ResolveStatefulResponse, error) {
 	if req.GetMode() == nodev1.ResolveMode_RESOLVE_MODE_COMMIT {
 		return &nodev1.ResolveStatefulResponse{
 			SnapshotRef: "stateful/" + req.GetCheckpointToken(),
@@ -214,7 +214,7 @@ func (fakeServer) ResolveStateful(_ context.Context, req *nodev1.ResolveStateful
 }
 
 // DeleteVolume is idempotent and returns an empty response for any workload.
-func (fakeServer) DeleteVolume(_ context.Context, _ *nodev1.DeleteVolumeRequest) (*nodev1.DeleteVolumeResponse, error) {
+func (*fakeServer) DeleteVolume(_ context.Context, _ *nodev1.DeleteVolumeRequest) (*nodev1.DeleteVolumeResponse, error) {
 	return &nodev1.DeleteVolumeResponse{}, nil
 }
 
@@ -222,7 +222,7 @@ func (fakeServer) DeleteVolume(_ context.Context, _ *nodev1.DeleteVolumeRequest)
 // the client can prove the fields crossed the wire, and scripts the CIDR-overlap
 // refusal off the cidr content ("overlap" -> FAILED_PRECONDITION), which is how
 // the round-trip test exercises the create-refusal branch against a stateless fake.
-func (fakeServer) CreateGroupNetwork(_ context.Context, req *nodev1.CreateGroupNetworkRequest) (*nodev1.CreateGroupNetworkResponse, error) {
+func (*fakeServer) CreateGroupNetwork(_ context.Context, req *nodev1.CreateGroupNetworkRequest) (*nodev1.CreateGroupNetworkResponse, error) {
 	if strings.Contains(req.GetCidr(), "overlap") {
 		return nil, status.Errorf(codes.FailedPrecondition, "cidr %q overlaps an existing group bridge", req.GetCidr())
 	}
@@ -233,7 +233,7 @@ func (fakeServer) CreateGroupNetwork(_ context.Context, req *nodev1.CreateGroupN
 }
 
 // DeleteGroupNetwork is idempotent and returns an empty response for any group.
-func (fakeServer) DeleteGroupNetwork(_ context.Context, _ *nodev1.DeleteGroupNetworkRequest) (*nodev1.DeleteGroupNetworkResponse, error) {
+func (*fakeServer) DeleteGroupNetwork(_ context.Context, _ *nodev1.DeleteGroupNetworkRequest) (*nodev1.DeleteGroupNetworkResponse, error) {
 	return &nodev1.DeleteGroupNetworkResponse{}, nil
 }
 
@@ -243,7 +243,7 @@ func (fakeServer) DeleteGroupNetwork(_ context.Context, _ *nodev1.DeleteGroupNet
 // detail, otherwise a verified warm relight), which is how the round-trip test
 // exercises the resync-failure branch against a stateless fake. FRESH cold-boots
 // from source and echoes the pinned ip.
-func (fakeServer) StartGroupMember(_ context.Context, req *nodev1.StartGroupMemberRequest) (*nodev1.StartGroupMemberResponse, error) {
+func (*fakeServer) StartGroupMember(_ context.Context, req *nodev1.StartGroupMemberRequest) (*nodev1.StartGroupMemberResponse, error) {
 	if req.GetMode() == nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_RELIGHT {
 		ref := req.GetSnapshotRef()
 		if strings.Contains(ref, "clockfail") {
@@ -262,7 +262,7 @@ func (fakeServer) StartGroupMember(_ context.Context, req *nodev1.StartGroupMemb
 // StopGroupMember returns a per-member bundle ref under the caller-supplied set
 // dir and a size for BANK, and zero values for DESTROY, so the client can assert
 // both mode branches and that set_id/member_name crossed the wire.
-func (fakeServer) StopGroupMember(_ context.Context, req *nodev1.StopGroupMemberRequest) (*nodev1.StopGroupMemberResponse, error) {
+func (*fakeServer) StopGroupMember(_ context.Context, req *nodev1.StopGroupMemberRequest) (*nodev1.StopGroupMemberResponse, error) {
 	if req.GetMode() == nodev1.StopGroupMemberMode_STOP_GROUP_MEMBER_MODE_BANK {
 		return &nodev1.StopGroupMemberResponse{
 			SnapshotRef: "group/" + req.GetSetId() + "/" + req.GetMemberName(),
@@ -476,7 +476,7 @@ func (s *fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusR
 	}, nil
 }
 
-func (fakeServer) WatchNode(req *nodev1.WatchNodeRequest, stream grpc.ServerStreamingServer[nodev1.NodeStatus]) error {
+func (*fakeServer) WatchNode(req *nodev1.WatchNodeRequest, stream grpc.ServerStreamingServer[nodev1.NodeStatus]) error {
 	// Stream a fixed number of heartbeats with an incrementing live_vms counter so
 	// the client can assert both the count and the ordering, then complete.
 	for i := uint32(0); i < watchNodeHeartbeats; i++ {

--- a/projects/embervm/proto/embervm/node/v1/fakenode/main.go
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/main.go
@@ -17,6 +17,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 
 	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
 	"google.golang.org/grpc"
@@ -30,6 +31,18 @@ const watchNodeHeartbeats = 3
 
 type fakeServer struct {
 	nodev1.UnimplementedNodeServiceServer
+	// store is the in-memory object-store stand-in for the continuity verbs (R6):
+	// ExportArtifact records a key, a repeat export short-circuits skipped, and
+	// EvictArtifact removes it, so the round-trip test proves the verbs cross the
+	// wire and observe each other's effect within one test's fresh server.
+	mu    sync.Mutex
+	store map[string]bool
+}
+
+// storeKey mirrors the Fork-3 layout <kind>/<workload>/<ref> so the fake's
+// idempotency keying matches the real store's.
+func storeKey(a *nodev1.ArtifactRef) string {
+	return fmt.Sprintf("%d/%s/%s", a.GetKind(), a.GetWorkload(), a.GetRef())
 }
 
 func (fakeServer) BuildBase(_ context.Context, req *nodev1.BuildBaseRequest) (*nodev1.BuildBaseResponse, error) {
@@ -259,11 +272,84 @@ func (fakeServer) StopGroupMember(_ context.Context, req *nodev1.StopGroupMember
 	return &nodev1.StopGroupMemberResponse{}, nil
 }
 
-func (fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusRequest) (*nodev1.NodeStatus, error) {
+// ExportArtifact records the artifact key in the in-memory store and reports the
+// bytes moved (derived from the ref length so the client proves the ref crossed),
+// short-circuiting skipped=true on a repeat export of the same key. It echoes the
+// volume generation for a VOLUME artifact so the pairing fact crosses the wire.
+func (s *fakeServer) ExportArtifact(_ context.Context, req *nodev1.ExportArtifactRequest) (*nodev1.ExportArtifactResponse, error) {
+	art := req.GetArtifact()
+	if art.GetRef() == "" && art.GetKind() != nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME {
+		return nil, status.Errorf(codes.FailedPrecondition, "artifact ref required for kind %v", art.GetKind())
+	}
+	key := storeKey(art)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.store[key] {
+		return &nodev1.ExportArtifactResponse{BytesMoved: 0, Skipped: true, Generation: volGen(art)}, nil
+	}
+	s.store[key] = true
+	return &nodev1.ExportArtifactResponse{
+		BytesMoved: uint64(len(art.GetWorkload()) + len(art.GetRef())),
+		Skipped:    false,
+		Generation: volGen(art),
+	}, nil
+}
+
+// RestoreArtifact reports a successful restore for a key present in the store,
+// echoing the volume generation for a VOLUME. FAILED_PRECONDITION when the store
+// has no copy (a corrupt or absent restore surfaces loudly, never silently).
+func (s *fakeServer) RestoreArtifact(_ context.Context, req *nodev1.RestoreArtifactRequest) (*nodev1.RestoreArtifactResponse, error) {
+	art := req.GetArtifact()
+	key := storeKey(art)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.store[key] {
+		return nil, status.Errorf(codes.FailedPrecondition, "artifact %q absent from store", key)
+	}
+	return &nodev1.RestoreArtifactResponse{
+		BytesMoved: uint64(len(art.GetWorkload()) + len(art.GetRef())),
+		Skipped:    false,
+		Generation: volGen(art),
+	}, nil
+}
+
+// EvictArtifact deletes the key from the store (remote=true) and is idempotent on
+// an already-absent artifact. remote=false is accepted as the typed local-evict
+// alias and returns OK without touching the store map.
+func (s *fakeServer) EvictArtifact(_ context.Context, req *nodev1.EvictArtifactRequest) (*nodev1.EvictArtifactResponse, error) {
+	art := req.GetArtifact()
+	key := storeKey(art)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	present := s.store[key]
+	if req.GetRemote() {
+		delete(s.store, key)
+	}
+	if !present {
+		return &nodev1.EvictArtifactResponse{BytesFreed: 0}, nil
+	}
+	return &nodev1.EvictArtifactResponse{BytesFreed: uint64(len(art.GetWorkload()) + len(art.GetRef()))}, nil
+}
+
+// volGen scripts a fixed volume generation for a VOLUME artifact so the client
+// can assert the generation echo crosses the wire; 0 for every other kind.
+func volGen(a *nodev1.ArtifactRef) uint64 {
+	if a.GetKind() == nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME {
+		return 5
+	}
+	return 0
+}
+
+func (s *fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusRequest) (*nodev1.NodeStatus, error) {
 	return &nodev1.NodeStatus{
 		NodeId:     req.GetNodeId(),
 		LiveVms:    1,
 		MaxLiveVms: 10,
+		// Continuity facts (R6): a fixed drain deadline and store reachability so
+		// the client can assert the new node-level fields round-trip. The bundle,
+		// volume, and set exported flags below prove the per-artifact fields cross.
+		DrainDeadlineUnixMs: 1_700_000_009_000,
+		StoreReachable:      true,
 		// Session facts (R2): deterministic, so the client can assert the new
 		// repeated/scalar status fields round-trip.
 		SessionVms: []*nodev1.SessionVm{
@@ -336,6 +422,8 @@ func (fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusRequ
 				Generation:      5,
 				SizeBytes:       16384,
 				CreatedAtUnixMs: 1_700_000_004_000,
+				// exported (R6): this bundle's store copy is present and current.
+				Exported: true,
 			},
 		},
 		Volumes: []*nodev1.Volume{
@@ -345,6 +433,9 @@ func (fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusRequ
 				SizeBytes:      10_737_418_240,
 				AllocatedBytes: 536_870_912,
 				Attached:       true,
+				// exported_generation (R6): the store holds the gen-5 (vol.img, gen)
+				// pair, so a disk-loss restore recovers to generation 5.
+				ExportedGeneration: 5,
 			},
 		},
 		// Group facts (R5): deterministic, so the client can assert the new
@@ -378,6 +469,8 @@ func (fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusRequ
 					{MemberName: "worker-0", SnapshotRef: "group/set-abc/worker-0", SizeBytes: 5120},
 				},
 				CreatedAtUnixMs: 1_700_000_006_000,
+				// exported (R6): the whole set's store copy is present and current.
+				Exported: true,
 			},
 		},
 	}, nil
@@ -401,7 +494,7 @@ func main() {
 		os.Exit(1)
 	}
 	srv := grpc.NewServer()
-	nodev1.RegisterNodeServiceServer(srv, fakeServer{})
+	nodev1.RegisterNodeServiceServer(srv, &fakeServer{store: map[string]bool{}})
 
 	// Announce the chosen port on stdout (unbuffered) so the harness can connect.
 	fmt.Printf("PORT=%d\n", lis.Addr().(*net.TCPAddr).Port)

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -382,6 +382,50 @@ service NodeService {
   // set membership. BANK refuses FAILED_PRECONDITION if a stop of the same vm_id
   // is already in flight (the daemon backstop; the control plane serializes too).
   rpc StopGroupMember(StopGroupMemberRequest) returns (StopGroupMemberResponse);
+
+  // -- Continuity verbs (R6) --------------------------------------------------
+  //
+  // These three verbs are the off-node durability vocabulary, ADDITIVE to every
+  // contract above (all task, session, serving, stateful, and group RPCs are
+  // byte-for-byte unchanged). They move a banked artifact between node disk and a
+  // configurable S3-API object store so a node (or its NVMe) can be lost without
+  // losing data. An artifact is named by a typed ArtifactRef {kind, workload,
+  // ref}: bases, session/serving/stateful bundles, group bundle SETS, and raw
+  // volumes are the kinds. Every verb is idempotent per ref and CP-driven; the
+  // daemon is a dumb executor that copies bytes and never decides WHEN to move
+  // them. Export happens only against a crash-consistent banked artifact (never a
+  // live VM) as async write-back after a bank commit; restore is the wake-path
+  // fallback when local disk misses; evict refuses while the artifact is still
+  // referenced, mirroring the local eviction rules (ADR embervm/003 generalized
+  // from ExportBase/RestoreBase/EvictBase to every artifact kind).
+
+  // ExportArtifact copies one banked artifact's files, then its meta.json
+  // completeness marker LAST, to the object store under the Fork-3 key scheme
+  // (<kind>/<workload>/<ref>/<file>). Idempotent: a Head that finds the same
+  // checksum short-circuits without re-uploading. Runs only against a down,
+  // crash-consistent artifact (post-bank-commit); NEVER against a live VM.
+  // FAILED_PRECONDITION if the local artifact is absent; the response reports
+  // bytes moved and whether the upload was skipped as already-present.
+  rpc ExportArtifact(ExportArtifactRequest) returns (ExportArtifactResponse);
+
+  // RestoreArtifact is the inverse: fetch meta.json first, verify every listed
+  // file is present with a matching SHA-256, then stream the files into the
+  // correct on-disk directory for the kind and re-register via the same reconcile
+  // helpers a rescan uses. Idempotent: a restore of an artifact already present
+  // locally with a matching checksum is a no-op. FAILED_PRECONDITION if the store
+  // copy is absent, incomplete (no meta.json), or checksum-mismatched (a corrupt
+  // restore surfaces loudly; the local state is never overwritten with bad bytes).
+  rpc RestoreArtifact(RestoreArtifactRequest) returns (RestoreArtifactResponse);
+
+  // EvictArtifact(remote=true) deletes an artifact's store keys, meta.json FIRST
+  // so a partially-deleted artifact is invisible (mirrors the write ordering).
+  // EvictArtifact(remote=false) is an alias for the existing local EvictSnapshot
+  // path over the typed ref, kept so the CP has one eviction verb across kinds.
+  // Refuses FAILED_PRECONDITION for a VOLUME whose generation still pairs with any
+  // bundle (local or remote): the store is never the only copy of a volume
+  // generation a banked bundle needs (standing decision 8). Idempotent on an
+  // already-absent artifact (the desired end-state already holds).
+  rpc EvictArtifact(EvictArtifactRequest) returns (EvictArtifactResponse);
 }
 
 // Trace carries the cross-cutting identifiers every RPC threads for tracing and
@@ -1055,6 +1099,11 @@ message SessionSnapshot {
   string workload = 3;
   uint64 size_bytes = 4;
   int64 created_at_unix_ms = 5;
+  // exported is true when this bundle's store copy is present and current (its
+  // meta.json completeness marker matches the local checksum). The control plane
+  // reads it to know a wake could restore-on-miss and that a roll that exits now
+  // loses nothing (R6, additive; false on a pre-R6 daemon).
+  bool exported = 6;
 }
 
 // ServingVm is one LIVE serving VM the node currently holds, reported so a
@@ -1086,6 +1135,8 @@ message ServingSnapshot {
   string workload = 2;
   uint64 size_bytes = 3;
   int64 created_at_unix_ms = 4;
+  // exported: see SessionSnapshot.exported (R6, additive).
+  bool exported = 5;
 }
 
 // StatefulVm is one LIVE stateful VM the node currently holds, reported so a
@@ -1127,6 +1178,8 @@ message StatefulBundle {
   uint64 generation = 3;
   uint64 size_bytes = 4;
   int64 created_at_unix_ms = 5;
+  // exported: see SessionSnapshot.exported (R6, additive).
+  bool exported = 6;
 }
 
 // Volume is one workload's raw volume file on node NVMe, the durable data that
@@ -1141,6 +1194,12 @@ message Volume {
   uint64 size_bytes = 3;
   uint64 allocated_bytes = 4;
   bool attached = 5;
+  // exported_generation is the volume generation whose (vol.img, gen) pair the
+  // store currently holds, 0 if no store copy exists. The control plane skips a
+  // re-export when it equals generation and knows a disk-loss restore recovers to
+  // this generation (R6, additive). A separate field from a bool because the
+  // exported generation can lag the live generation.
+  uint64 exported_generation = 6;
 }
 
 // GroupNetwork is one per-group bridge the node currently holds, reported so a
@@ -1188,6 +1247,89 @@ message GroupBundleSet {
   string group_instance_id = 2;
   repeated GroupBundleMember members = 3;
   int64 created_at_unix_ms = 4;
+  // exported is true when the WHOLE set's store copy is present and current
+  // (every member's meta.json matches). A set is the export unit: a partially
+  // exported set is not exported (R6, additive; the completeness judgment for
+  // relight stays in the control plane, but export atomicity is per set).
+  bool exported = 5;
+}
+
+// ---- Continuity artifacts (R6) ---------------------------------------------
+
+// ArtifactKind is the closed set of banked-artifact kinds the continuity verbs
+// move off node. Every kind is exported/restored/evicted through the same
+// ArtifactRef vocabulary; the daemon dispatches on kind to the right on-disk
+// directory and enumeration helper. BASE generalizes ADR 003's ExportBase.
+enum ArtifactKind {
+  ARTIFACT_KIND_UNSPECIFIED = 0;
+  ARTIFACT_KIND_BASE = 1;
+  ARTIFACT_KIND_SESSION = 2;
+  ARTIFACT_KIND_SERVING = 3;
+  ARTIFACT_KIND_STATEFUL = 4;
+  ARTIFACT_KIND_GROUP_SET = 5;
+  ARTIFACT_KIND_VOLUME = 6;
+}
+
+// ArtifactRef names exactly one banked artifact for the continuity verbs. kind
+// selects the on-disk layout and store key prefix; workload namespaces the store
+// keys (no artifact is ever restored into another workload's lineage); ref is the
+// opaque per-artifact identifier (snapshot_ref for bundles, set_id for a group
+// set, and the workload itself for a singleton VOLUME, whose ref MAY be empty).
+// The store key scheme is <kind>/<workload>/<ref>/<file> (Fork 3), mirroring the
+// on-disk layout so restore is a pure copy and store GC audits against a local
+// scan.
+message ArtifactRef {
+  ArtifactKind kind = 1;
+  string workload = 2;
+  string ref = 3;
+}
+
+// ExportArtifactRequest asks the daemon to write-back one banked artifact to the
+// object store. trace threads correlation as every RPC does.
+message ExportArtifactRequest {
+  ArtifactRef artifact = 1;
+  Trace trace = 2;
+}
+
+// ExportArtifactResponse reports the outcome. bytes_moved is 0 when skipped=true
+// (the store already held the same checksum). generation echoes the exported
+// volume generation for a VOLUME artifact (0 for non-volume kinds), the pairing
+// fact the control plane records against the remote copy.
+message ExportArtifactResponse {
+  uint64 bytes_moved = 1;
+  bool skipped = 2;
+  uint64 generation = 3;
+}
+
+// RestoreArtifactRequest asks the daemon to fetch one artifact from the store
+// back onto local disk and re-register it.
+message RestoreArtifactRequest {
+  ArtifactRef artifact = 1;
+  Trace trace = 2;
+}
+
+// RestoreArtifactResponse reports the outcome. bytes_moved is 0 when the artifact
+// was already present locally with a matching checksum (idempotent no-op).
+// generation echoes the restored volume generation for a VOLUME (0 otherwise).
+message RestoreArtifactResponse {
+  uint64 bytes_moved = 1;
+  bool skipped = 2;
+  uint64 generation = 3;
+}
+
+// EvictArtifactRequest asks the daemon to delete one artifact. remote=true
+// evicts the store copy; remote=false evicts the local copy over the typed ref
+// (the EvictSnapshot path). Both are idempotent on an already-absent artifact.
+message EvictArtifactRequest {
+  ArtifactRef artifact = 1;
+  bool remote = 2;
+  Trace trace = 3;
+}
+
+// EvictArtifactResponse reports the outcome. bytes_freed is best-effort (0 when
+// the artifact was already absent).
+message EvictArtifactResponse {
+  uint64 bytes_freed = 1;
 }
 
 // NodeStatus is the whole capacity fact set: per-workload primed slots and base
@@ -1283,4 +1425,20 @@ message NodeStatus {
   // group_bundle_sets is the banked-group-bundle inventory scanned from the
   // group/ prefix of the bundle dir, refs grouped by set directory.
   repeated GroupBundleSet group_bundle_sets = 21;
+
+  // -- Continuity facts (R6, additive) ----------------------------------------
+  // These two node-level fields drive the bounded-preemption drain and the
+  // restore-on-miss wake planner. Both are optional and wire-compatible with a
+  // daemon that never sets them (0 / false = the pre-R6 behavior).
+
+  // drain_deadline_unix_ms is the wall-clock instant the daemon will stop holding
+  // shutdown and reap whatever remains. 0 when not draining. On the draining edge
+  // the control plane reads this to bound its force-bank pass (bank everything
+  // before deadline - safety_margin). Set together with draining=true on SIGTERM.
+  int64 drain_deadline_unix_ms = 22;
+  // store_reachable is the daemon's latest object-store reachability verdict from
+  // its probe loop. false never blocks a local-state wake (fail-open warmth); the
+  // control plane only consults it to decide whether a restore-on-miss can be
+  // planned at all. Unset (false) on a daemon with no store configured.
+  bool store_reachable = 23;
 }

--- a/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
+++ b/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
@@ -15,6 +15,7 @@ defmodule Embervm.NodeRoundtripTest do
   use ExUnit.Case, async: false
 
   alias Embervm.Node.V1.{
+    ArtifactRef,
     AssignRequest,
     BankRequest,
     BuildBaseRequest,
@@ -22,7 +23,9 @@ defmodule Embervm.NodeRoundtripTest do
     DeleteGroupNetworkRequest,
     DeleteVolumeRequest,
     DestroyRequest,
+    EvictArtifactRequest,
     EvictSnapshotRequest,
+    ExportArtifactRequest,
     FreshSource,
     GetNodeStatusRequest,
     GuestRequest,
@@ -33,6 +36,7 @@ defmodule Embervm.NodeRoundtripTest do
     RelightSource,
     ResolveStatefulRequest,
     ResourceSpec,
+    RestoreArtifactRequest,
     SessionAssignRequest,
     StartGroupMemberRequest,
     StartServingRequest,
@@ -519,6 +523,86 @@ defmodule Embervm.NodeRoundtripTest do
 
     assert ns.snapshot_disk_free_bytes == 9_000_000_000
     assert ns.snapshot_disk_used_bytes == 1_000_000_000
+  end
+
+  test "continuity verbs round-trip across the wire (R6 additive contract)", %{channel: ch} do
+    # ExportArtifact: first export of a stateful bundle records the store key and
+    # reports bytes moved (derived from workload+ref length), not skipped.
+    stateful = %ArtifactRef{
+      kind: :ARTIFACT_KIND_STATEFUL,
+      workload: "scratch-postgres",
+      ref: "stateful/scratch-postgres"
+    }
+
+    {:ok, exp} =
+      NodeService.Stub.export_artifact(ch, %ExportArtifactRequest{
+        artifact: stateful,
+        trace: %Trace{workload: "scratch-postgres"}
+      })
+
+    assert exp.skipped == false
+    assert exp.bytes_moved > 0
+    assert exp.generation == 0
+
+    # A repeat export of the same key short-circuits skipped=true, no bytes moved.
+    {:ok, again} =
+      NodeService.Stub.export_artifact(ch, %ExportArtifactRequest{artifact: stateful})
+
+    assert again.skipped == true
+    assert again.bytes_moved == 0
+
+    # A VOLUME export echoes the volume generation so the pairing fact crosses.
+    volume = %ArtifactRef{kind: :ARTIFACT_KIND_VOLUME, workload: "scratch-postgres", ref: ""}
+    {:ok, vol_exp} = NodeService.Stub.export_artifact(ch, %ExportArtifactRequest{artifact: volume})
+    assert vol_exp.generation == 5
+
+    # RestoreArtifact: the bundle is present in the store, so restore succeeds.
+    {:ok, res} =
+      NodeService.Stub.restore_artifact(ch, %RestoreArtifactRequest{artifact: stateful})
+
+    assert res.bytes_moved > 0
+
+    # RestoreArtifact of an absent key surfaces FAILED_PRECONDITION (never silent).
+    absent = %ArtifactRef{kind: :ARTIFACT_KIND_SESSION, workload: "nope", ref: "sessions/none"}
+
+    {:error, missing} =
+      NodeService.Stub.restore_artifact(ch, %RestoreArtifactRequest{artifact: absent})
+
+    assert missing.status == GRPC.Status.failed_precondition()
+
+    # EvictArtifact(remote=true): removes the store copy, reports bytes freed.
+    {:ok, ev} =
+      NodeService.Stub.evict_artifact(ch, %EvictArtifactRequest{artifact: stateful, remote: true})
+
+    assert ev.bytes_freed > 0
+
+    # After eviction, a restore of the same key fails (the copy is gone).
+    {:error, gone} =
+      NodeService.Stub.restore_artifact(ch, %RestoreArtifactRequest{artifact: stateful})
+
+    assert gone.status == GRPC.Status.failed_precondition()
+
+    # EvictArtifact is idempotent on an already-absent artifact.
+    {:ok, noop} =
+      NodeService.Stub.evict_artifact(ch, %EvictArtifactRequest{artifact: stateful, remote: true})
+
+    assert noop.bytes_freed == 0
+  end
+
+  test "NodeStatus reports continuity facts (R6 additive fields)", %{channel: ch} do
+    {:ok, ns} = NodeService.Stub.get_node_status(ch, %GetNodeStatusRequest{node_id: "node-4"})
+
+    assert ns.drain_deadline_unix_ms == 1_700_000_009_000
+    assert ns.store_reachable == true
+
+    assert [bundle] = ns.stateful_bundles
+    assert bundle.exported == true
+
+    assert [vol] = ns.volumes
+    assert vol.exported_generation == 5
+
+    assert [set] = ns.group_bundle_sets
+    assert set.exported == true
   end
 
   test "WatchNode server-streams heartbeats in order", %{channel: ch} do


### PR DESCRIPTION
## R6 Continuity, PR-1 (Task 2)

The additive proto contract every later R6 PR builds against. Design + plan:
`docs/plans/2026-07-18-embervm-r6-continuity-spec-and-plan.md`.

### Changes (all additive, no field renumbered)
- `ArtifactKind` enum + `ArtifactRef {kind, workload, ref}` typed handle over
  BASE/SESSION/SERVING/STATEFUL/GROUP_SET/VOLUME.
- `ExportArtifact` / `RestoreArtifact` / `EvictArtifact` RPCs (+ req/resp).
  `EvictArtifact.remote` distinguishes store eviction from the local
  `EvictSnapshot` path. All idempotent per ref.
- `NodeStatus.drain_deadline_unix_ms` (0 when not draining) + `store_reachable`;
  per-artifact `exported` flags on the bundle/set status messages and
  `exported_generation` on `Volume`.
- fakenode implements the three verbs (in-memory store map) and reports the new
  fields; the cross-language round-trip test covers them.

No behavior change: codegen is build-time only; nothing generated is checked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)