### PR TITLE
feat(embervm): R6 PR-2 noded drain hold + deadline publish

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.102
+version: 0.1.103

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -689,11 +689,15 @@ noded:
   # CR automatically. Entries here merge on top.
   images: {}
 
-  # Graceful-drain budget: on SIGTERM the daemon waits up to this long for in-
-  # flight Assigns before exiting. terminationGracePeriodSeconds is set above it
-  # (grace = drain + 30s), so a rollout never drops a running task.
+  # Graceful-drain budget (R6 bounded preemption, ADR embervm/009): on SIGTERM the
+  # daemon publishes a drain deadline (now + this) via NodeStatus and HOLDS the
+  # gRPC surface up so the control plane can force-bank every managed session/
+  # serving/stateful/group VM before the deadline; only then does it drain
+  # in-flight task Assigns and exit. terminationGracePeriodSeconds is set above it
+  # (grace = drain + 30s), so a rollout never SIGKILLs mid-bank and never drops a
+  # running task. 120s is the v1 spot-instance preemption window.
   drain:
-    timeoutSeconds: 60
+    timeoutSeconds: 120
 
   # R1 zip lane: a BuildBase zip source is a runtime image plus a zip archive noded
   # fetches, sha256-verifies into memory, and hydrates into the build VM over vsock

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.102
+      targetRevision: 0.1.103
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/cmd/main.go
+++ b/projects/embervm/noded/cmd/main.go
@@ -230,23 +230,41 @@ func run(logger *slog.Logger) error {
 	case err := <-errCh:
 		return err
 	case <-ctx.Done():
-		// Drain: stop advertising capacity, stop accepting new RPCs, and let
-		// in-flight Assigns finish. Each Assign holds its microVM until it returns,
-		// so GracefulStop draining handlers == draining running tasks (the fc-invoke
-		// HTTP-Shutdown lesson). The pod's terminationGracePeriodSeconds is set
-		// above DrainTimeout so Kubernetes never SIGKILLs mid-drain.
-		logger.Info("shutdown signal received; draining", "budget", cfg.DrainTimeout)
-		srv.SetDraining()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = health.Shutdown(shutdownCtx)
+		// Drain (R6 bounded preemption): publish a deadline and HOLD the door.
+		// noded has no lifecycle authority, so it does not bank anything itself; it
+		// sets draining + a deadline on NodeStatus, and the control plane, watching
+		// that stream, force-banks every managed session/serving/stateful/group VM
+		// before the deadline (ADR embervm/009). The gRPC surface stays UP the whole
+		// time so those Bank/Stop/Resolve rpcs are served; only new BuildBase/Prime/
+		// Assign are refused (the draining flag). We hold until the managed live-VM
+		// registry empties or the deadline passes, then drain in-flight task Assigns
+		// via GracefulStop. The pod's terminationGracePeriodSeconds is drain + 30s so
+		// Kubernetes never SIGKILLs mid-bank.
+		deadline := time.Now().Add(cfg.DrainTimeout)
+		logger.Info("shutdown signal received; draining", "budget", cfg.DrainTimeout, "deadline", deadline.UTC())
+		srv.SetDraining(deadline)
 
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = health.Shutdown(shutdownCtx)
+		cancel()
+
+		// Hold the door: keep serving lifecycle rpcs until the control plane has
+		// banked every managed VM, or the deadline elapses. remaining>0 means the
+		// bank pass could not finish in the window; those VMs die with the pod (spot
+		// semantics: their durable state is the volume or a prior bundle).
+		if remaining := srv.WaitForManagedDrain(context.Background(), deadline); remaining > 0 {
+			logger.Warn("drain deadline reached with managed VMs still live; they will be reaped with the pod", "remaining", remaining)
+		} else {
+			logger.Info("all managed VMs drained; stopping")
+		}
+
+		// Now stop the server: in-flight task Assigns get a short grace, then hard stop.
 		done := make(chan struct{})
 		go func() { gs.GracefulStop(); close(done) }()
 		select {
 		case <-done:
-		case <-time.After(cfg.DrainTimeout):
-			logger.Warn("drain budget exceeded; forcing stop", "budget", cfg.DrainTimeout)
+		case <-time.After(10 * time.Second):
+			logger.Warn("graceful stop budget exceeded; forcing stop")
 			gs.Stop()
 		}
 		return nil

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -86,9 +86,13 @@ type Config struct {
 	// A restored guest is already warm; this short budget only covers WaitReady
 	// retrying past the Firecracker post-restore vsock RX-queue race. Default 2s.
 	RestoreReadyTimeout time.Duration
-	// DrainTimeout bounds graceful shutdown: on SIGTERM the daemon stops
-	// accepting new RPCs and waits up to this long for in-flight Assigns to
-	// finish. The pod's terminationGracePeriodSeconds must exceed it. Default 60s.
+	// DrainTimeout bounds graceful shutdown: on SIGTERM the daemon publishes a
+	// drain deadline (now + DrainTimeout) via NodeStatus and HOLDS the gRPC
+	// surface up, serving lifecycle RPCs, until every managed (session/serving/
+	// stateful/group) VM has left the registry (the control plane force-banks
+	// them, R6) or this budget elapses; only then does it drain in-flight Assigns
+	// and stop. The pod's terminationGracePeriodSeconds must exceed it (chart sets
+	// drain + 30s). Default 120s (the R6 bounded-preemption window).
 	DrainTimeout time.Duration
 
 	// EgressSidecarAddr is the pod-local egress-proxy sidecar TCP address. The
@@ -190,7 +194,7 @@ func Load() (Config, error) {
 		GuestOomScoreAdj:    atoiDefault("EMBERVM_NODED_GUEST_OOM_SCORE_ADJ", 1000),
 		BootReadyTimeout:    60 * time.Second,
 		RestoreReadyTimeout: 2 * time.Second,
-		DrainTimeout:        60 * time.Second,
+		DrainTimeout:        120 * time.Second,
 		EgressSidecarAddr:   getenvDefault("EMBERVM_NODED_EGRESS_SIDECAR_ADDR", "127.0.0.1:8888"),
 		ArchiveFetchTimeout: 60 * time.Second,
 		ArchiveMaxBytes:     512 << 20,

--- a/projects/embervm/noded/server/BUILD
+++ b/projects/embervm/noded/server/BUILD
@@ -32,6 +32,7 @@ go_library(
 go_test(
     name = "server_test",
     srcs = [
+        "drain_test.go",
         "group_member_test.go",
         "group_test.go",
         "server_test.go",

--- a/projects/embervm/noded/server/drain_test.go
+++ b/projects/embervm/noded/server/drain_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestSetDrainingPublishesDeadline proves SetDraining flips the draining flag,
+// records the deadline, and surfaces both on NodeStatus (the fact the control
+// plane reads off WatchNode to bound its force-bank pass).
+func TestSetDrainingPublishesDeadline(t *testing.T) {
+	drv := &fakeDriver{}
+	_, s := newTestServer(t, drv, &fakeTransport{}, 10)
+
+	if s.isDraining() {
+		t.Fatal("server should not start draining")
+	}
+	if got := s.nodeStatus().GetDrainDeadlineUnixMs(); got != 0 {
+		t.Fatalf("drain deadline should be 0 before drain, got %d", got)
+	}
+
+	deadline := time.Now().Add(120 * time.Second)
+	s.SetDraining(deadline)
+
+	if !s.isDraining() {
+		t.Fatal("server should be draining after SetDraining")
+	}
+	ns := s.nodeStatus()
+	if !ns.GetDraining() {
+		t.Fatal("NodeStatus.draining should be true")
+	}
+	if got, want := ns.GetDrainDeadlineUnixMs(), deadline.UnixMilli(); got != want {
+		t.Fatalf("NodeStatus.drain_deadline_unix_ms = %d, want %d", got, want)
+	}
+}
+
+// TestWaitForManagedDrainEmpty proves the wait returns immediately with zero
+// remaining when there are no managed VMs to bank.
+func TestWaitForManagedDrainEmpty(t *testing.T) {
+	drv := &fakeDriver{}
+	_, s := newTestServer(t, drv, &fakeTransport{}, 10)
+
+	// A generous deadline: an empty registry must return well before it.
+	remaining := s.WaitForManagedDrain(context.Background(), time.Now().Add(10*time.Second))
+	if remaining != 0 {
+		t.Fatalf("empty drain should return 0, got %d", remaining)
+	}
+}
+
+// TestWaitForManagedDrainEarlyExit proves the wait ends as soon as the control
+// plane has banked (removed) the last managed VM, long before the deadline. The
+// removal signals a NodeStatus change exactly as a real Bank/Stop does.
+func TestWaitForManagedDrainEarlyExit(t *testing.T) {
+	drv := &fakeDriver{}
+	_, s := newTestServer(t, drv, &fakeTransport{}, 10)
+
+	s.statefulVMs.add(&statefulEntry{vmID: "vm-st1", workload: "scratch-postgres"})
+	if got := s.managedLiveVMCount(); got != 1 {
+		t.Fatalf("managedLiveVMCount = %d, want 1", got)
+	}
+
+	// Simulate the control plane force-banking the VM shortly after drain begins.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		s.statefulVMs.remove("vm-st1")
+		s.signalChange()
+	}()
+
+	start := time.Now()
+	// A far deadline: the early exit must be driven by the empty registry, not it.
+	remaining := s.WaitForManagedDrain(context.Background(), start.Add(30*time.Second))
+	if remaining != 0 {
+		t.Fatalf("early-exit drain should return 0, got %d", remaining)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("early exit took %s; should have returned promptly on the bank signal", elapsed)
+	}
+}
+
+// TestWaitForManagedDrainDeadline proves a VM that cannot bank in the window is
+// left live at the deadline (its count is returned so the caller can log it; the
+// pod then reaps it under spot semantics).
+func TestWaitForManagedDrainDeadline(t *testing.T) {
+	drv := &fakeDriver{}
+	_, s := newTestServer(t, drv, &fakeTransport{}, 10)
+
+	s.statefulVMs.add(&statefulEntry{vmID: "vm-st1", workload: "scratch-postgres"})
+
+	// A short deadline with the VM never removed: the wait must return it as still
+	// live once the deadline passes.
+	remaining := s.WaitForManagedDrain(context.Background(), time.Now().Add(80*time.Millisecond))
+	if remaining != 1 {
+		t.Fatalf("deadline drain should return 1 straggler, got %d", remaining)
+	}
+}

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -234,8 +234,9 @@ type Server struct {
 	// groupclock.Resync; overridable in tests.
 	groupClock groupClock
 
-	drainingMu sync.RWMutex
-	draining   bool
+	drainingMu          sync.RWMutex
+	draining            bool
+	drainDeadlineUnixMs int64
 
 	subMu sync.Mutex
 	subs  map[chan struct{}]struct{}
@@ -1293,6 +1294,7 @@ func (s *Server) nodeStatus() *nodev1.NodeStatus {
 		LiveVms:               uint32(live),
 		MaxLiveVms:            uint32(maxLive),
 		Draining:              s.isDraining(),
+		DrainDeadlineUnixMs:   s.drainDeadline(),
 		BuildError:            s.bases.firstBuildError(),
 		SessionVms:            sessionVMs,
 		SessionSnapshots:      snaps,
@@ -1540,11 +1542,17 @@ func (s *Server) workloadCapacities(primed map[string][]string) []*nodev1.Worklo
 
 // ---- drain + change notification -------------------------------------------
 
-// SetDraining marks the daemon draining so WatchNode reports draining=true and
-// new BuildBase/Prime calls are rejected. Called on SIGTERM before GracefulStop.
-func (s *Server) SetDraining() {
+// SetDraining marks the daemon draining and publishes the drain deadline so
+// WatchNode reports draining=true plus drain_deadline_unix_ms, and new
+// BuildBase/Prime/Assign calls are rejected. The control plane reads the deadline
+// off the WatchNode stream and force-banks every managed VM before it (R6). All
+// LIFECYCLE rpcs (Bank/Stop/Resolve/StopGroupMember) keep being served while
+// draining so that force-bank can run; only new-work verbs are refused. Called on
+// SIGTERM before the daemon holds shutdown for the bank pass.
+func (s *Server) SetDraining(deadline time.Time) {
 	s.drainingMu.Lock()
 	s.draining = true
+	s.drainDeadlineUnixMs = deadline.UnixMilli()
 	s.drainingMu.Unlock()
 	s.signalChange()
 }
@@ -1553,6 +1561,53 @@ func (s *Server) isDraining() bool {
 	s.drainingMu.RLock()
 	defer s.drainingMu.RUnlock()
 	return s.draining
+}
+
+// drainDeadline returns the published drain deadline in unix-ms, 0 when not
+// draining. Surfaced in NodeStatus so the control plane bounds its force-bank
+// pass to deadline - safety_margin.
+func (s *Server) drainDeadline() int64 {
+	s.drainingMu.RLock()
+	defer s.drainingMu.RUnlock()
+	return s.drainDeadlineUnixMs
+}
+
+// managedLiveVMCount is the number of live NON-task VMs the control plane must
+// force-bank during a drain: session, serving, stateful, and group member VMs.
+// Task-class VMs (in-flight Assigns) are excluded; they drain via GracefulStop.
+// The shutdown path holds the gRPC surface up until this reaches zero (every
+// managed VM banked or destroyed by the control plane) or the deadline passes.
+func (s *Server) managedLiveVMCount() int {
+	return len(s.sessionVMs.snapshot()) + s.servingVMs.count() + s.statefulVMs.count() + s.groupMembers.count()
+}
+
+// WaitForManagedDrain holds until every managed VM has left the registry (the
+// control plane force-banked or destroyed them) or the deadline passes,
+// whichever comes first, and returns the count still live at return (0 on a
+// clean drain). It wakes on every NodeStatus change (each Bank/Stop signals) so a
+// clean drain returns promptly, with a periodic re-check as a backstop against a
+// missed signal. It does NOT stop the gRPC server: the caller does that after
+// this returns, so lifecycle rpcs stay served for the whole window.
+func (s *Server) WaitForManagedDrain(ctx context.Context, deadline time.Time) int {
+	ch := s.subscribe()
+	defer s.unsubscribe(ch)
+	timer := time.NewTimer(time.Until(deadline))
+	defer timer.Stop()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if n := s.managedLiveVMCount(); n == 0 {
+			return 0
+		}
+		select {
+		case <-ch:
+		case <-ticker.C:
+		case <-timer.C:
+			return s.managedLiveVMCount()
+		case <-ctx.Done():
+			return s.managedLiveVMCount()
+		}
+	}
 }
 
 func (s *Server) subscribe() chan struct{} {


### PR DESCRIPTION
## R6 Continuity, PR-2 (Task 3)

On SIGTERM noded now publishes a drain deadline and HOLDS the gRPC surface up,
serving all lifecycle rpcs, so the control plane can force-bank every managed VM
before the pod exits (ADR embervm/009 bounded preemption, 2-minute window).

### Why
Today the shutdown path calls `GracefulStop()` immediately, which rejects new
RPCs, so the control plane can never issue the `Bank`/`Stop` calls: live session/
serving/stateful/group VMs die with the pod. This closes that gap.

### Changes
- `config`: `DrainTimeout` default 60s to 120s (v1 spot preemption window).
- `server`: `SetDraining(deadline)` publishes `drain_deadline_unix_ms` on
  NodeStatus and signals WatchNode; `managedLiveVMCount` + `WaitForManagedDrain`
  hold until every session/serving/stateful/group VM has left the registry or the
  deadline passes.
- `cmd/main`: shutdown sets the deadline, holds the door, then drains in-flight
  task Assigns via `GracefulStop`.
- `chart`: `noded.drain.timeoutSeconds` 60 to 120 (grace = drain + 30 = 150s,
  already derived in the deployment template); embervm chart bumped.
- `drain_test`: deadline publish, empty / early-exit / deadline drain paths.

The control-plane side that actually force-banks on the observed deadline lands in
PR-3 (DrainCoordinator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)