### PR TITLE
feat(embervm): R6 PR-4 object store client and export/restore/evict verbs

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.104
+version: 0.1.105

--- a/projects/embervm/chart/templates/noded-deployment.yaml
+++ b/projects/embervm/chart/templates/noded-deployment.yaml
@@ -165,6 +165,15 @@ spec:
               value: {{ .Values.noded.zipLane.fetchTimeout | quote }}
             - name: EMBERVM_NODED_ARCHIVE_MAX_BYTES
               value: {{ .Values.noded.zipLane.maxBytes | quote }}
+            # R6 off-node durability: the S3-API object store the continuity verbs
+            # (ExportArtifact/RestoreArtifact/EvictArtifact) move banked artifacts to
+            # and from. Default the in-cluster SeaweedFS S3 gateway (anonymous, no
+            # SigV4 in v1). An EMPTY endpoint disables the store: exports are skipped
+            # and restore-on-miss is impossible, so state stays local-only.
+            - name: EMBERVM_NODED_STORE_ENDPOINT
+              value: {{ .Values.noded.store.endpoint | quote }}
+            - name: EMBERVM_NODED_STORE_BUCKET
+              value: {{ .Values.noded.store.bucket | quote }}
             # Node-side image identity table (image_ref -> {rootfsPath, harnessInit}),
             # rendered as JSON. Derived from noded.workloads + each workload's pinned
             # guestImage so the ref here MATCHES the rootfs-builder GUEST_IMAGE and the

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -723,6 +723,16 @@ noded:
     # renders in scientific notation, which strconv.ParseInt would reject).
     maxBytes: "536870912" # 512 MiB
 
+  # R6 off-node durability (ADR embervm/009): the S3-API object store the
+  # continuity verbs move banked artifacts to and from, so a node (or its NVMe)
+  # can be lost without losing data. The first backend is the in-cluster SeaweedFS
+  # S3 gateway (anonymous in-cluster; no SigV4 in v1, a static-credential seam is
+  # left for later). An EMPTY endpoint DISABLES the store: exports are skipped and
+  # restore-on-miss is impossible, so state stays local-only (a safe degrade).
+  store:
+    endpoint: http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333
+    bucket: embervm
+
   # 256Mi req / 36Gi limit (Task 14b full side-by-side). The limit is a cgroup
   # OOM CEILING, not a scheduling reservation (the request stays 256Mi), so it
   # does not overcommit node scheduling, exactly like fc-invoke's 50Gi cap.

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.104
+      targetRevision: 0.1.105
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/cmd/BUILD
+++ b/projects/embervm/noded/cmd/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//projects/embervm/noded/fcvm/driver",
         "//projects/embervm/noded/server",
         "//projects/embervm/noded/serving",
+        "//projects/embervm/noded/store",
         "//projects/embervm/noded/vsockhttp",
         "//projects/embervm/proto/embervm/node/v1:nodev1",
         "@org_golang_google_grpc//:grpc",

--- a/projects/embervm/noded/cmd/main.go
+++ b/projects/embervm/noded/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/jomcgi/homelab/projects/embervm/noded/fcvm/driver"
 	"github.com/jomcgi/homelab/projects/embervm/noded/server"
 	"github.com/jomcgi/homelab/projects/embervm/noded/serving"
+	"github.com/jomcgi/homelab/projects/embervm/noded/store"
 	"github.com/jomcgi/homelab/projects/embervm/noded/vsockhttp"
 )
 
@@ -114,7 +115,19 @@ func run(logger *slog.Logger) error {
 		return err
 	}
 
-	srv := server.New(server.Options{
+	// The off-node object store (R6): the continuity verbs and the async export
+	// queue move banked artifacts to and from this S3-API endpoint. store.New
+	// returns nil for an empty endpoint (the store is disabled), so the Options
+	// field is left unset in that case to keep the server's typed-nil guards clean
+	// (a nil interface, not an interface holding a nil pointer).
+	artStore := store.New(cfg.StoreEndpoint, cfg.StoreBucket)
+	if cfg.StoreEndpoint == "" {
+		logger.Warn("object store DISABLED: EMBERVM_NODED_STORE_ENDPOINT unset; banked state stays local-only (no off-node durability, no restore-on-miss)")
+	} else {
+		logger.Info("object store configured", "endpoint", cfg.StoreEndpoint, "bucket", cfg.StoreBucket)
+	}
+
+	opts := server.Options{
 		Config: cfg,
 		Driver: restoreDriver,
 		// The same restore driver serves the R2 session verbs: SnapshotSession /
@@ -152,7 +165,11 @@ func run(logger *slog.Logger) error {
 		GroupDriver:             restoreDriver,
 		GroupProbeInterval:      cfg.StatefulProbeInterval,
 		GroupUnhealthyThreshold: cfg.StatefulUnhealthyThreshold,
-	})
+	}
+	if artStore != nil {
+		opts.Store = artStore
+	}
+	srv := server.New(opts)
 	// Report node-local base snapshots left by a prior incarnation so the control
 	// plane reconciles rather than rebuilding.
 	srv.ReconcileBasesFromDisk()
@@ -177,6 +194,14 @@ func run(logger *slog.Logger) error {
 	// node truth (live members died with the prior pod; the on-disk bundle sets
 	// survive and the control plane resolves each group to relightable-or-fresh).
 	srv.ReconcileGroupBundlesFromDisk()
+	// R6 off-node durability: start the bounded async export-worker pool, the
+	// store-reachability probe (feeds NodeStatus.store_reachable), and a reconcile
+	// sweep that enqueues an export for any local artifact whose store copy is
+	// missing or stale (covers "a roll exited before exports finished"). All three
+	// no-op when the store is disabled. They run for the daemon's lifetime; ctx
+	// cancels them on shutdown, and the export queue is fire-and-forget so it never
+	// holds the drain deadline.
+	srv.StartStoreLoops(ctx)
 	// Create the serving bridge and install the ingress-only nftables posture before
 	// serving any StartServing. Idempotent across restarts (existing bridge tolerated).
 	if err := servingNet.EnsureNetwork(ctx); err != nil {

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -173,6 +173,18 @@ type Config struct {
 	// unused in Task 4. Default 5s / 3.
 	GroupProbeInterval      time.Duration
 	GroupUnhealthyThreshold int
+
+	// StoreEndpoint is the base URL of the S3-API object store the continuity
+	// verbs (R6) move banked artifacts to and from. Default the in-cluster
+	// SeaweedFS S3 gateway (anonymous, standing decision 5). An EMPTY endpoint
+	// DISABLES the store entirely: exports are skipped, restore-on-miss is
+	// impossible, and ExportArtifact/RestoreArtifact refuse FAILED_PRECONDITION,
+	// so a build without a store (tests, a cluster without SeaweedFS) still runs
+	// with only local durability. Env EMBERVM_NODED_STORE_ENDPOINT.
+	StoreEndpoint string
+	// StoreBucket is the single bucket every artifact key lives under (Fork 3).
+	// Default "embervm". Env EMBERVM_NODED_STORE_BUCKET.
+	StoreBucket string
 }
 
 // Load resolves configuration from the environment, applying defaults for all
@@ -213,6 +225,9 @@ func Load() (Config, error) {
 		CompositeSupernet:       getenvDefault("EMBERVM_NODED_COMPOSITE_SUPERNET", "10.101.0.0/16"),
 		GroupProbeInterval:      5 * time.Second,
 		GroupUnhealthyThreshold: atoiDefault("EMBERVM_NODED_GROUP_UNHEALTHY_THRESHOLD", 3),
+
+		StoreEndpoint: getenvDefault("EMBERVM_NODED_STORE_ENDPOINT", "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333"),
+		StoreBucket:   getenvDefault("EMBERVM_NODED_STORE_BUCKET", "embervm"),
 	}
 
 	if c.Node == "" {

--- a/projects/embervm/noded/server/BUILD
+++ b/projects/embervm/noded/server/BUILD
@@ -12,6 +12,7 @@ go_library(
         "serving_registry.go",
         "stateful.go",
         "stateful_registry.go",
+        "store.go",
     ],
     importpath = "github.com/jomcgi/homelab/projects/embervm/noded/server",
     visibility = ["//projects/embervm/noded:__subpackages__"],
@@ -38,6 +39,7 @@ go_test(
         "server_test.go",
         "serving_test.go",
         "stateful_test.go",
+        "store_test.go",
     ],
     embed = [":server"],
     deps = [

--- a/projects/embervm/noded/server/group.go
+++ b/projects/embervm/noded/server/group.go
@@ -261,6 +261,10 @@ func (s *Server) groupBundleSetsStatus() []*nodev1.GroupBundleSet {
 			GroupInstanceId: agg.groupInstanceID,
 			Members:         agg.members,
 			CreatedAtUnixMs: agg.createdAtUnixMs,
+			// A set is the export unit: `exported` is true only when the WHOLE set's
+			// store copy is present (the export queue marks the set prefix on a
+			// completed set export). Keyed by the group instance + set_id (Fork 3).
+			Exported: s.artifactExported(nodev1.ArtifactKind_ARTIFACT_KIND_GROUP_SET, agg.groupInstanceID, setID),
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].GetSetId() < out[j].GetSetId() })

--- a/projects/embervm/noded/server/group_member.go
+++ b/projects/embervm/noded/server/group_member.go
@@ -268,6 +268,12 @@ func (s *Server) stopGroupMemberBank(ctx context.Context, req *nodev1.StopGroupM
 		sizeBytes:       ref.SizeBytes,
 		createdAtUnixMs: time.Now().UnixMilli(),
 	})
+	// Async off-node write-back (R6): a group set is the export unit, so enqueue
+	// the SET (keyed by group instance + set_id) fire-and-forget after each member
+	// bank. The dedupe coalesces overlapping member banks of the same set; the
+	// export walks whatever is on disk at run time and the checksum-compare re-uploads
+	// on the next member bank until the set converges complete. Never blocks the bank.
+	s.enqueueExport(&nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_GROUP_SET, Workload: e.groupInstanceID, Ref: setID})
 	s.signalChange()
 	return &nodev1.StopGroupMemberResponse{SnapshotRef: ref.ID, SizeBytes: uint64(ref.SizeBytes)}, nil
 }

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -238,6 +238,28 @@ type Server struct {
 	draining            bool
 	drainDeadlineUnixMs int64
 
+	// store is the off-node object-store client the R6 continuity verbs and the
+	// async export queue use. nil disables the store (no endpoint configured):
+	// ExportArtifact/RestoreArtifact refuse FAILED_PRECONDITION, exports are
+	// no-ops, and NodeStatus.store_reachable stays false. In production a
+	// *store.Store satisfies it; tests inject an in-memory fake.
+	store artifactStore
+	// exported caches which artifacts (by store prefix) have a current store copy
+	// and at which generation, updated by the export queue and read by the
+	// NodeStatus projection for the per-artifact `exported` bool and
+	// Volume.exported_generation.
+	exported *exportedCache
+	// exportCh is the bounded async export queue; exportDedupe drops a re-enqueue
+	// of an already-queued prefix. Both nil/empty until startExportQueue runs.
+	exportCh       chan exportJob
+	exportOnce     sync.Once
+	exportDedupeMu sync.Mutex
+	exportDedupe   map[string]struct{}
+	// storeReachable is the latest object-store reachability verdict from the
+	// probe loop, surfaced in NodeStatus.store_reachable.
+	storeMu        sync.RWMutex
+	storeReachable bool
+
 	subMu sync.Mutex
 	subs  map[chan struct{}]struct{}
 }
@@ -300,6 +322,12 @@ type Options struct {
 	// health probe loop (defaults applied when zero), mirroring the stateful knobs.
 	GroupProbeInterval      time.Duration
 	GroupUnhealthyThreshold int
+	// Store is the off-node object-store client the R6 continuity verbs and the
+	// async export queue use. nil (the default) disables the store: the continuity
+	// verbs refuse FAILED_PRECONDITION and exports are no-ops, so a Server built
+	// without a store still compiles and every other class is untouched. In
+	// production a *store.Store satisfies it; tests inject an in-memory fake.
+	Store artifactStore
 }
 
 // New builds a Server. Driver and Transport must not be nil.
@@ -333,6 +361,9 @@ func New(opts Options) *Server {
 		groupDriver:     opts.GroupDriver,
 		groupBundles:    newGroupBundleRegistry(),
 		groupClock:      opts.GroupClock,
+		store:           opts.Store,
+		exported:        newExportedCache(),
+		exportDedupe:    make(map[string]struct{}),
 		subs:            make(map[chan struct{}]struct{}),
 	}
 	// VolumeRoot may be set directly on Options (mirroring how cmd/main.go wires
@@ -1056,6 +1087,9 @@ func (s *Server) Bank(ctx context.Context, req *nodev1.BankRequest) (*nodev1.Ban
 		sizeBytes:       ref.SizeBytes,
 		createdAtUnixMs: time.Now().UnixMilli(),
 	})
+	// Async off-node write-back (R6): the banked bundle is now crash-consistent on
+	// disk, so enqueue its export fire-and-forget (never blocking this bank path).
+	s.enqueueExport(&nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_SESSION, Workload: req.GetTrace().GetWorkload(), Ref: ref.ID})
 	s.signalChange()
 	return &nodev1.BankResponse{SnapshotRef: ref.ID, SizeBytes: uint64(ref.SizeBytes)}, nil
 }
@@ -1309,6 +1343,7 @@ func (s *Server) nodeStatus() *nodev1.NodeStatus {
 		GroupNetworks:         s.groupNetworksStatus(),
 		GroupMemberVms:        groupMemberVMs,
 		GroupBundleSets:       s.groupBundleSetsStatus(),
+		StoreReachable:        s.storeReachableNow(),
 	}
 }
 
@@ -1349,9 +1384,23 @@ func (s *Server) servingSnapshotsStatus() []*nodev1.ServingSnapshot {
 			Workload:        e.workload,
 			SizeBytes:       uint64(e.sizeBytes),
 			CreatedAtUnixMs: e.createdAtUnixMs,
+			Exported:        s.artifactExported(nodev1.ArtifactKind_ARTIFACT_KIND_SERVING, e.workload, e.snapshotRef),
 		})
 	}
 	return out
+}
+
+// artifactExported reports whether an artifact's store copy is currently present
+// (from the exported cache the export queue maintains). A workload-less entry (a
+// disk-only reconcile whose control-plane binding is not yet known) has no
+// composable prefix and reports false until the control plane rebinds it, which
+// is safe: the CP treats false as "a roll would lose this off-node copy".
+func (s *Server) artifactExported(kind nodev1.ArtifactKind, workload, ref string) bool {
+	prefix := artifactPrefix(&nodev1.ArtifactRef{Kind: kind, Workload: workload, Ref: ref})
+	if prefix == "" {
+		return false
+	}
+	return s.exported.present(prefix)
 }
 
 // servingSubnetCIDR reports the serving subnet CIDR for NodeStatus, or "" when no
@@ -1408,6 +1457,7 @@ func (s *Server) statefulBundlesStatus() []*nodev1.StatefulBundle {
 			Generation:      e.generation,
 			SizeBytes:       uint64(e.sizeBytes),
 			CreatedAtUnixMs: e.createdAtUnixMs,
+			Exported:        s.artifactExported(nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL, e.workload, e.snapshotRef),
 		})
 	}
 	return out
@@ -1426,12 +1476,20 @@ func (s *Server) volumesStatus() []*nodev1.Volume {
 	}
 	out := make([]*nodev1.Volume, 0, len(inv))
 	for _, v := range inv {
+		var exportedGen uint64
+		prefix := artifactPrefix(&nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: v.Workload})
+		if prefix != "" {
+			if g, ok := s.exported.generation(prefix); ok {
+				exportedGen = g
+			}
+		}
 		out = append(out, &nodev1.Volume{
-			Workload:       v.Workload,
-			Generation:     v.Generation,
-			SizeBytes:      v.SizeBytes,
-			AllocatedBytes: v.AllocatedBytes,
-			Attached:       v.Attached,
+			Workload:           v.Workload,
+			Generation:         v.Generation,
+			SizeBytes:          v.SizeBytes,
+			AllocatedBytes:     v.AllocatedBytes,
+			Attached:           v.Attached,
+			ExportedGeneration: exportedGen,
 		})
 	}
 	return out
@@ -1465,6 +1523,7 @@ func (s *Server) sessionSnapshotsStatus() []*nodev1.SessionSnapshot {
 			Workload:        e.workload,
 			SizeBytes:       uint64(e.sizeBytes),
 			CreatedAtUnixMs: e.createdAtUnixMs,
+			Exported:        s.artifactExported(nodev1.ArtifactKind_ARTIFACT_KIND_SESSION, e.workload, e.snapshotRef),
 		})
 	}
 	return out

--- a/projects/embervm/noded/server/serving.go
+++ b/projects/embervm/noded/server/serving.go
@@ -275,6 +275,9 @@ func (s *Server) stopServingBank(ctx context.Context, req *nodev1.StopServingReq
 		sizeBytes:       ref.SizeBytes,
 		createdAtUnixMs: time.Now().UnixMilli(),
 	})
+	// Async off-node write-back (R6): enqueue the banked serving bundle's export
+	// fire-and-forget (never blocking this bank path).
+	s.enqueueExport(&nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_SERVING, Workload: req.GetTrace().GetWorkload(), Ref: ref.ID})
 	s.signalChange()
 	return &nodev1.StopServingResponse{SnapshotRef: ref.ID, SizeBytes: uint64(ref.SizeBytes)}, nil
 }

--- a/projects/embervm/noded/server/stateful.go
+++ b/projects/embervm/noded/server/stateful.go
@@ -497,6 +497,10 @@ func (s *Server) commitCheckpoint(ctx context.Context, e *statefulEntry, token s
 		sizeBytes:       ref.SizeBytes,
 		createdAtUnixMs: time.Now().UnixMilli(),
 	})
+	// Async off-node write-back (R6): the committed bundle and its paired volume,
+	// fire-and-forget (identical to stopStatefulBank's tail).
+	s.enqueueExport(&nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL, Workload: e.workload, Ref: ref.ID})
+	s.enqueueExport(&nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: e.workload})
 	s.signalChange()
 	return &nodev1.ResolveStatefulResponse{SnapshotRef: ref.ID, Generation: e.generation, SizeBytes: uint64(ref.SizeBytes)}, nil
 }
@@ -589,6 +593,11 @@ func (s *Server) stopStatefulBank(ctx context.Context, vmID string) (*nodev1.Sto
 		sizeBytes:       ref.SizeBytes,
 		createdAtUnixMs: time.Now().UnixMilli(),
 	})
+	// Async off-node write-back (R6): a stateful bank ships BOTH the bundle and its
+	// paired volume (vol.img + gen); the volume export skips when its generation is
+	// unchanged since the last export. Both are fire-and-forget (never blocking).
+	s.enqueueExport(&nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL, Workload: e.workload, Ref: ref.ID})
+	s.enqueueExport(&nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: e.workload})
 	s.signalChange()
 	return &nodev1.StopStatefulResponse{SnapshotRef: ref.ID, Generation: e.generation, SizeBytes: uint64(ref.SizeBytes)}, nil
 }

--- a/projects/embervm/noded/server/store.go
+++ b/projects/embervm/noded/server/store.go
@@ -1,0 +1,669 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+)
+
+// artifactStore is the seam the R6 continuity verbs and the async export queue
+// depend on: the off-node object-store operations over a Fork-3 key prefix. The
+// real *store.Store satisfies it; tests inject an in-memory fake so no test
+// touches the network. It is a SEPARATE seam (like sessionDriver/servingDriver)
+// so a Server built without a store still compiles: a nil artifactStore leaves
+// ExportArtifact/RestoreArtifact refusing FAILED_PRECONDITION and every export a
+// no-op, and NodeStatus.store_reachable false.
+//
+// Method shapes mirror *store.Store exactly. errNotPresent is the sentinel a
+// Restore/Present returns for an absent store copy; the handlers map it to
+// FAILED_PRECONDITION. A store package cannot be imported for its sentinel here
+// (the fake would then need it too), so the seam declares the sentinel it cares
+// about via a small predicate the store satisfies.
+type artifactStore interface {
+	Export(ctx context.Context, prefix, localDir string, files []string, generation uint64, nowMs int64) (bytesMoved int64, skipped bool, err error)
+	Restore(ctx context.Context, prefix, localDir string) (bytesMoved int64, generation uint64, err error)
+	DeleteArtifact(ctx context.Context, prefix string) error
+	Present(ctx context.Context, prefix string) (bool, uint64, error)
+	Reachable(ctx context.Context) bool
+}
+
+// artifactKindStr maps an ArtifactKind to its lowercase store-key segment (Fork
+// 3: <kindStr>/<workload>/<ref>). Returns "" for the unspecified kind so a
+// caller refuses an unknown ref rather than composing a bogus prefix.
+func artifactKindStr(kind nodev1.ArtifactKind) string {
+	switch kind {
+	case nodev1.ArtifactKind_ARTIFACT_KIND_BASE:
+		return "base"
+	case nodev1.ArtifactKind_ARTIFACT_KIND_SESSION:
+		return "session"
+	case nodev1.ArtifactKind_ARTIFACT_KIND_SERVING:
+		return "serving"
+	case nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL:
+		return "stateful"
+	case nodev1.ArtifactKind_ARTIFACT_KIND_GROUP_SET:
+		return "group_set"
+	case nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME:
+		return "volume"
+	default:
+		return ""
+	}
+}
+
+// artifactPrefix composes the Fork-3 store key prefix for a ref:
+// <kindStr>/<workload>/<ref>. For a VOLUME the ref MAY be empty (the volume is a
+// singleton per workload), so the prefix collapses to volume/<workload>. Returns
+// "" when the kind is unknown or the workload is empty (isolation: keys are
+// always namespaced by workload).
+func artifactPrefix(ref *nodev1.ArtifactRef) string {
+	kindStr := artifactKindStr(ref.GetKind())
+	if kindStr == "" || ref.GetWorkload() == "" {
+		return ""
+	}
+	if r := ref.GetRef(); r != "" {
+		return kindStr + "/" + ref.GetWorkload() + "/" + r
+	}
+	return kindStr + "/" + ref.GetWorkload()
+}
+
+// artifactLocalDir resolves the on-disk directory holding a ref's files. It
+// mirrors the driver's per-kind bundle layout under SnapshotRoot (bases/,
+// sessions/, serving/, stateful/, group/<set_id>/) and the volume manager's
+// VolumeRoot/<workload>. Returns "" when the kind is unknown or the relevant
+// substrate is not configured, which the caller maps to FAILED_PRECONDITION.
+func (s *Server) artifactLocalDir(ref *nodev1.ArtifactRef) string {
+	root := s.cfg.SnapshotRoot
+	switch ref.GetKind() {
+	case nodev1.ArtifactKind_ARTIFACT_KIND_BASE:
+		if root == "" {
+			return ""
+		}
+		return filepath.Join(root, "bases", ref.GetRef())
+	case nodev1.ArtifactKind_ARTIFACT_KIND_SESSION:
+		if root == "" {
+			return ""
+		}
+		return filepath.Join(root, "sessions", ref.GetRef())
+	case nodev1.ArtifactKind_ARTIFACT_KIND_SERVING:
+		if root == "" {
+			return ""
+		}
+		return filepath.Join(root, "serving", ref.GetRef())
+	case nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL:
+		if root == "" {
+			return ""
+		}
+		return filepath.Join(root, "stateful", ref.GetRef())
+	case nodev1.ArtifactKind_ARTIFACT_KIND_GROUP_SET:
+		if root == "" {
+			return ""
+		}
+		return filepath.Join(root, "group", ref.GetRef())
+	case nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME:
+		if s.volumes == nil {
+			return ""
+		}
+		// The volume manager owns VolumeRoot/<workload> (vol.img + gen). VolumePath
+		// names the vol.img inside it; its parent is the artifact dir.
+		return filepath.Dir(s.volumes.VolumePath(ref.GetWorkload()))
+	default:
+		return ""
+	}
+}
+
+// enumerateArtifactFiles lists the files (relative to localDir) that make up an
+// artifact: every regular file under the dir except in-progress *.tmp temps and
+// the meta.json marker the store itself writes. A bundle dir holds exactly one
+// bundle's files (snapfile + memfile + any sidecars), and a group SET dir holds
+// its members' files under per-member subdirs, so a recursive walk yields the
+// complete file list with slash-relative names the store maps 1:1 to keys. An
+// empty result (missing dir, or no files) means the artifact is absent locally.
+func enumerateArtifactFiles(localDir string) ([]string, error) {
+	info, err := os.Stat(localDir)
+	if err != nil || !info.IsDir() {
+		return nil, err
+	}
+	var files []string
+	walkErr := filepath.WalkDir(localDir, func(path string, d os.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if strings.HasSuffix(name, ".tmp") || name == "meta.json" {
+			return nil
+		}
+		rel, rerr := filepath.Rel(localDir, path)
+		if rerr != nil {
+			return rerr
+		}
+		// Store keys use forward slashes on every platform; filepath.Rel returns
+		// OS-native separators, so normalise (a no-op on linux).
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return files, nil
+}
+
+// StartStoreLoops starts the R6 background machinery: the bounded async
+// export-worker pool, the periodic store-reachability probe, and a one-shot
+// reconcile sweep that enqueues an export for any local artifact whose store
+// copy is missing or stale. All three no-op when the store is disabled (nil).
+// The export queue is fire-and-forget, so none of this ever holds the bank path
+// or the drain deadline. Called once from the daemon entrypoint after the
+// startup reconcile sequence; ctx cancels every loop on shutdown.
+func (s *Server) StartStoreLoops(ctx context.Context) {
+	s.startExportQueue(ctx)
+	s.startStoreProbe(ctx)
+	s.enqueueReconcileExports(ctx)
+}
+
+// ---- Continuity verbs (R6) -------------------------------------------------
+
+// ExportArtifact copies one banked, crash-consistent artifact off node to the
+// object store under its Fork-3 prefix (files first, meta.json LAST). It is
+// idempotent per checksum: an unchanged artifact returns skipped=true with
+// bytes_moved=0. FAILED_PRECONDITION when the store is disabled (nil) or the
+// local artifact is absent. It NEVER touches a live VM: the ref names a down,
+// banked artifact (post-bank-commit), so enumeration reads only its on-disk
+// files.
+func (s *Server) ExportArtifact(ctx context.Context, req *nodev1.ExportArtifactRequest) (*nodev1.ExportArtifactResponse, error) {
+	if s.store == nil {
+		return nil, status.Error(codes.FailedPrecondition, "noded: object store not configured; export unavailable")
+	}
+	ref := req.GetArtifact()
+	prefix := artifactPrefix(ref)
+	if prefix == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: artifact kind and workload required")
+	}
+	localDir := s.artifactLocalDir(ref)
+	if localDir == "" {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: artifact kind %s not exportable on this node", ref.GetKind())
+	}
+	files, err := enumerateArtifactFiles(localDir)
+	if err != nil || len(files) == 0 {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: local artifact %q absent or empty (nothing to export)", prefix)
+	}
+	generation := s.artifactGeneration(ref)
+	moved, skipped, err := s.store.Export(ctx, prefix, localDir, files, generation, time.Now().UnixMilli())
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "noded: export artifact %q: %v", prefix, err)
+	}
+	s.exported.mark(prefix, generation)
+	s.signalChange()
+	return &nodev1.ExportArtifactResponse{BytesMoved: moved, Skipped: skipped, Generation: generation}, nil
+}
+
+// RestoreArtifact fetches an artifact from the store back onto local disk into
+// the correct per-kind dir, verifying every file's checksum, then re-registers
+// it via the same reconcile helpers a rescan uses so a later wake sees it.
+// Idempotent: an artifact already present locally with a matching checksum is a
+// skipped no-op. FAILED_PRECONDITION when the store is disabled, or the store
+// copy is absent/incomplete/mismatched.
+func (s *Server) RestoreArtifact(ctx context.Context, req *nodev1.RestoreArtifactRequest) (*nodev1.RestoreArtifactResponse, error) {
+	if s.store == nil {
+		return nil, status.Error(codes.FailedPrecondition, "noded: object store not configured; restore unavailable")
+	}
+	ref := req.GetArtifact()
+	prefix := artifactPrefix(ref)
+	if prefix == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: artifact kind and workload required")
+	}
+	localDir := s.artifactLocalDir(ref)
+	if localDir == "" {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: artifact kind %s not restorable on this node", ref.GetKind())
+	}
+	// Idempotency: if the artifact is already present locally with a checksum
+	// matching the store's marker, the restore is a no-op (the store Export's own
+	// same-checksum compare is the authority; re-check presence cheaply first).
+	if local, err := enumerateArtifactFiles(localDir); err == nil && len(local) > 0 {
+		present, gen, perr := s.store.Present(ctx, prefix)
+		if perr == nil && present {
+			// A local copy exists; treat as already-restored (skipped). The
+			// content-level equality lives in Export's checksum compare on the next
+			// export; a restore's job is to make local non-empty, which it is.
+			s.reregisterRestored(ref)
+			return &nodev1.RestoreArtifactResponse{Skipped: true, Generation: gen}, nil
+		}
+	}
+	moved, generation, err := s.store.Restore(ctx, prefix, localDir)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: restore artifact %q: %v", prefix, err)
+	}
+	s.reregisterRestored(ref)
+	s.exported.mark(prefix, generation)
+	s.signalChange()
+	return &nodev1.RestoreArtifactResponse{BytesMoved: moved, Generation: generation}, nil
+}
+
+// EvictArtifact deletes an artifact. remote=true evicts the store copy
+// (meta.json first, so a partial delete is invisible); remote=false evicts the
+// LOCAL copy over the typed ref via the existing EvictSnapshot/RemoveBundle
+// path. A VOLUME (remote OR local) is refused FAILED_PRECONDITION while its
+// generation still pairs with a local bundle (standing decision 8: the store is
+// never the only copy of a generation a banked bundle needs). Idempotent on an
+// already-absent artifact.
+func (s *Server) EvictArtifact(ctx context.Context, req *nodev1.EvictArtifactRequest) (*nodev1.EvictArtifactResponse, error) {
+	ref := req.GetArtifact()
+	prefix := artifactPrefix(ref)
+	if prefix == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: artifact kind and workload required")
+	}
+	// Volume pairing guard: refuse to evict a volume whose generation still pairs
+	// with a banked local bundle (mirrors the DeleteVolume attach guard's intent
+	// for the store copy). Applied to both remote and local volume evictions.
+	if ref.GetKind() == nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME {
+		if s.volumeGenerationStillPaired(ref.GetWorkload()) {
+			return nil, status.Errorf(codes.FailedPrecondition, "noded: volume for %q still pairs with a banked bundle; refusing evict", ref.GetWorkload())
+		}
+	}
+	if req.GetRemote() {
+		if s.store == nil {
+			// No store: the remote copy cannot exist, so the desired end-state
+			// (gone) already holds. Idempotent success.
+			return &nodev1.EvictArtifactResponse{}, nil
+		}
+		if err := s.store.DeleteArtifact(ctx, prefix); err != nil {
+			return nil, status.Errorf(codes.Unavailable, "noded: evict remote artifact %q: %v", prefix, err)
+		}
+		s.exported.clear(prefix)
+		s.signalChange()
+		return &nodev1.EvictArtifactResponse{}, nil
+	}
+	// Local eviction over the typed ref: reuse the existing EvictSnapshot path for
+	// bundle kinds, DeleteVolume for a VOLUME.
+	return s.evictArtifactLocal(ctx, ref)
+}
+
+// evictArtifactLocal deletes the on-disk copy of an artifact over the typed ref,
+// reusing the existing kind-specific eviction path (EvictSnapshot for a session/
+// serving/stateful bundle, RemoveGroupMemberBundle per member for a group set,
+// DeleteVolume for a volume). Idempotent.
+func (s *Server) evictArtifactLocal(ctx context.Context, ref *nodev1.ArtifactRef) (*nodev1.EvictArtifactResponse, error) {
+	switch ref.GetKind() {
+	case nodev1.ArtifactKind_ARTIFACT_KIND_SESSION, nodev1.ArtifactKind_ARTIFACT_KIND_SERVING, nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL:
+		if _, err := s.EvictSnapshot(ctx, &nodev1.EvictSnapshotRequest{SnapshotRef: ref.GetRef()}); err != nil {
+			return nil, err
+		}
+	case nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME:
+		if _, err := s.DeleteVolume(ctx, &nodev1.DeleteVolumeRequest{Workload: ref.GetWorkload()}); err != nil {
+			return nil, err
+		}
+	case nodev1.ArtifactKind_ARTIFACT_KIND_GROUP_SET:
+		// A group set's LOCAL eviction is per-member (the control plane evicts a
+		// set by evicting each member ref via EvictSnapshot, as R5 established);
+		// there is no single set-level local-evict driver op, so the typed local
+		// evict for a set is Unimplemented and the CP uses the per-member path.
+		// The REMOTE evict (handled above, before this call) does delete the whole
+		// set prefix at once, which is why a set is still one ArtifactRef.
+		return nil, status.Error(codes.Unimplemented, "noded: group set local eviction is per-member (evict each member ref)")
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "noded: artifact kind %s not locally evictable", ref.GetKind())
+	}
+	return &nodev1.EvictArtifactResponse{}, nil
+}
+
+// artifactGeneration reports the generation to stamp into an artifact's export
+// marker: the volume's current generation for a VOLUME (the pairing fact), the
+// stamped bundle generation for a STATEFUL bundle, 0 for kinds without one.
+func (s *Server) artifactGeneration(ref *nodev1.ArtifactRef) uint64 {
+	switch ref.GetKind() {
+	case nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME:
+		if s.volumes == nil {
+			return 0
+		}
+		gen, err := s.volumes.Generation(ref.GetWorkload())
+		if err != nil {
+			return 0
+		}
+		return gen
+	case nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL:
+		if b, ok := s.statefulBundles.get(ref.GetRef()); ok {
+			return b.generation
+		}
+		return 0
+	default:
+		return 0
+	}
+}
+
+// volumeGenerationStillPaired reports whether a workload's CURRENT volume
+// generation still equals a banked local stateful bundle's stamped generation.
+// While it does, evicting the volume (locally or remotely) would strand a bundle
+// that can only relight against that generation, so EvictArtifact refuses it
+// (standing decision 8).
+func (s *Server) volumeGenerationStillPaired(workload string) bool {
+	if s.volumes == nil || s.statefulBundles == nil {
+		return false
+	}
+	volGen, err := s.volumes.Generation(workload)
+	if err != nil {
+		return false
+	}
+	if b, ok := s.statefulBundles.byWorkload(workload); ok && b.generation == volGen {
+		return true
+	}
+	return false
+}
+
+// reregisterRestored re-seeds the in-memory inventory for a just-restored
+// artifact by re-running the kind's disk reconcile helper, so a rescan/adoption
+// (and the NodeStatus projection) sees it immediately, exactly as if the daemon
+// had found it on a startup scan. A VOLUME needs no re-registration (volume.Scan
+// reads VolumeRoot fresh on every NodeStatus).
+func (s *Server) reregisterRestored(ref *nodev1.ArtifactRef) {
+	switch ref.GetKind() {
+	case nodev1.ArtifactKind_ARTIFACT_KIND_BASE:
+		s.ReconcileBasesFromDisk()
+	case nodev1.ArtifactKind_ARTIFACT_KIND_SESSION:
+		s.ReconcileSessionsFromDisk()
+	case nodev1.ArtifactKind_ARTIFACT_KIND_SERVING:
+		s.ReconcileServingFromDisk()
+	case nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL:
+		s.ReconcileStatefulFromDisk()
+	case nodev1.ArtifactKind_ARTIFACT_KIND_GROUP_SET:
+		s.ReconcileGroupBundlesFromDisk()
+	case nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME:
+		// No in-memory seeding: volume.Scan reads disk truth on every NodeStatus.
+	}
+}
+
+// ---- async export-after-commit queue ---------------------------------------
+
+// exportQueueWorkers is the bounded worker pool draining the export queue. Two
+// is enough to overlap a large volume export with a bundle export without
+// letting exports contend with the bank path (they are fire-and-forget).
+const exportQueueWorkers = 2
+
+// exportQueueDepth bounds the buffered enqueue channel. An enqueue that would
+// block (queue full) is DROPPED, not awaited: the export queue must never stall
+// the bank path or the drain deadline (standing decision 7), and the next
+// reconcile re-enqueues any artifact whose store copy is still missing.
+const exportQueueDepth = 256
+
+// exportJob names one artifact to export, carrying enough to compose its prefix
+// and local dir. It is keyed (in the dedupe set) by its store prefix so a
+// re-enqueue of an already-queued artifact is dropped.
+type exportJob struct {
+	ref *nodev1.ArtifactRef
+	key string // the store prefix, the dedupe key
+}
+
+// startExportQueue launches the bounded export-worker pool. It is idempotent and
+// a no-op when the store is disabled (nil): with no store there is nothing to
+// export. Called once from the daemon entrypoint after the server is built. The
+// workers run until ctx is cancelled (daemon shutdown), draining fire-and-forget.
+func (s *Server) startExportQueue(ctx context.Context) {
+	if s.store == nil {
+		return
+	}
+	s.exportOnce.Do(func() {
+		s.exportCh = make(chan exportJob, exportQueueDepth)
+		for i := 0; i < exportQueueWorkers; i++ {
+			go s.exportWorker(ctx)
+		}
+	})
+}
+
+// enqueueExport schedules an artifact for async write-back. It is non-blocking:
+// a full queue or an already-queued key (same prefix) drops the enqueue silently
+// (the next reconcile re-enqueues a still-missing copy). It no-ops when the store
+// is disabled or the queue is not started. It NEVER blocks the caller (the bank
+// path / drain deadline), by design.
+func (s *Server) enqueueExport(ref *nodev1.ArtifactRef) {
+	if s.store == nil || s.exportCh == nil {
+		return
+	}
+	key := artifactPrefix(ref)
+	if key == "" {
+		return
+	}
+	s.exportDedupeMu.Lock()
+	if _, queued := s.exportDedupe[key]; queued {
+		s.exportDedupeMu.Unlock()
+		return // already queued; a re-enqueue is a no-op
+	}
+	s.exportDedupe[key] = struct{}{}
+	s.exportDedupeMu.Unlock()
+
+	select {
+	case s.exportCh <- exportJob{ref: ref, key: key}:
+	default:
+		// Queue full: drop and un-mark so a later reconcile can re-enqueue. The
+		// artifact stays durable on local disk; this only delays the off-node copy.
+		s.exportDedupeMu.Lock()
+		delete(s.exportDedupe, key)
+		s.exportDedupeMu.Unlock()
+		s.logger.Warn("noded: export queue full; dropping enqueue (will retry on reconcile)", "artifact", key)
+	}
+}
+
+// exportWorker drains the export queue, running each export fire-and-forget. An
+// export failure is logged, never retried inline (the next reconcile re-enqueues
+// a still-missing copy); a success marks the artifact exported so NodeStatus
+// reflects it. It exits when ctx is done or the channel is closed.
+func (s *Server) exportWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case job, ok := <-s.exportCh:
+			if !ok {
+				return
+			}
+			s.runExportJob(ctx, job)
+		}
+	}
+}
+
+// runExportJob performs one queued export. For a VOLUME it short-circuits when
+// the current generation is already exported (the store's own Head-compare would
+// also skip, but this avoids the round-trip). It always clears the dedupe key so
+// a subsequent change can re-enqueue.
+func (s *Server) runExportJob(ctx context.Context, job exportJob) {
+	defer func() {
+		s.exportDedupeMu.Lock()
+		delete(s.exportDedupe, job.key)
+		s.exportDedupeMu.Unlock()
+	}()
+
+	generation := s.artifactGeneration(job.ref)
+	// Local short-circuit for a VOLUME whose current generation is already the
+	// exported one (standing decision 6: skip a re-export when gen is unchanged).
+	if job.ref.GetKind() == nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME {
+		if lastGen, ok := s.exported.generation(job.key); ok && lastGen == generation {
+			return
+		}
+	}
+	localDir := s.artifactLocalDir(job.ref)
+	if localDir == "" {
+		return
+	}
+	files, err := enumerateArtifactFiles(localDir)
+	if err != nil || len(files) == 0 {
+		// The artifact vanished (evicted before the export ran); nothing to do.
+		return
+	}
+	_, skipped, err := s.store.Export(ctx, job.key, localDir, files, generation, time.Now().UnixMilli())
+	if err != nil {
+		s.logger.Warn("noded: async export failed (will retry on reconcile)", "artifact", job.key, "err", err)
+		return
+	}
+	s.exported.mark(job.key, generation)
+	if !skipped {
+		s.logger.Info("noded: exported artifact off node", "artifact", job.key, "generation", generation)
+	}
+	s.signalChange()
+}
+
+// enqueueReconcileExports sweeps the local banked inventory on startup and
+// enqueues an export for any artifact whose store copy is missing or stale
+// (covers "a roll exited before exports finished", standing decision 7). It runs
+// off the request path (a goroutine) so a slow store never delays startup, and
+// checks presence per artifact so an already-durable one is not re-uploaded. It
+// no-ops when the store is disabled.
+func (s *Server) enqueueReconcileExports(ctx context.Context) {
+	if s.store == nil {
+		return
+	}
+	go func() {
+		// Session bundles.
+		for _, e := range s.sessionSnap.snapshot() {
+			s.enqueueIfMissing(ctx, &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_SESSION, Workload: e.workload, Ref: e.snapshotRef})
+		}
+		// Serving bundles.
+		for _, e := range s.servingSnap.snapshot() {
+			s.enqueueIfMissing(ctx, &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_SERVING, Workload: e.workload, Ref: e.snapshotRef})
+		}
+		// Stateful bundles + their paired volumes.
+		for _, e := range s.statefulBundles.snapshot() {
+			s.enqueueIfMissing(ctx, &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL, Workload: e.workload, Ref: e.snapshotRef})
+		}
+		if s.volumes != nil {
+			if inv, err := s.volumes.Scan(); err == nil {
+				for _, v := range inv {
+					s.enqueueIfMissing(ctx, &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: v.Workload})
+				}
+			}
+		}
+		// Group bundle sets: enqueue the SET (keyed by set_id) once.
+		seenSets := make(map[string]struct{})
+		for _, e := range s.groupBundles.snapshot() {
+			if _, ok := seenSets[e.setID]; ok {
+				continue
+			}
+			seenSets[e.setID] = struct{}{}
+			s.enqueueIfMissing(ctx, &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_GROUP_SET, Workload: e.groupInstanceID, Ref: e.setID})
+		}
+	}()
+}
+
+// enqueueIfMissing enqueues an export only when the store copy is absent or,
+// for a VOLUME, its generation lags the current one. A store error is treated as
+// "enqueue anyway" (fail toward durability): the export's own Head-compare then
+// makes the final skip decision.
+func (s *Server) enqueueIfMissing(ctx context.Context, ref *nodev1.ArtifactRef) {
+	prefix := artifactPrefix(ref)
+	if prefix == "" {
+		return
+	}
+	present, gen, err := s.store.Present(ctx, prefix)
+	if err == nil && present {
+		if ref.GetKind() == nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME {
+			if cur := s.artifactGeneration(ref); cur == gen {
+				s.exported.mark(prefix, gen) // already durable at the current gen
+				return
+			}
+		} else {
+			s.exported.mark(prefix, gen)
+			return
+		}
+	}
+	s.enqueueExport(ref)
+}
+
+// ---- store reachability probe ----------------------------------------------
+
+// storeProbeInterval is how often the reachability probe refreshes
+// store_reachable, mirroring the serving/stateful probe cadence.
+const storeProbeInterval = 5 * time.Second
+
+// startStoreProbe launches the periodic object-store reachability probe feeding
+// NodeStatus.store_reachable (a warmth hint, never a gate). It no-ops when the
+// store is disabled (store_reachable stays false). Runs until ctx is cancelled.
+func (s *Server) startStoreProbe(ctx context.Context) {
+	if s.store == nil {
+		return
+	}
+	go func() {
+		// Probe once immediately so store_reachable is not falsely false for the
+		// first interval after startup.
+		s.setStoreReachable(s.store.Reachable(ctx))
+		ticker := time.NewTicker(storeProbeInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				prev := s.storeReachableNow()
+				now := s.store.Reachable(ctx)
+				s.setStoreReachable(now)
+				if now != prev {
+					s.signalChange() // reachability edge is a material change
+				}
+			}
+		}
+	}()
+}
+
+func (s *Server) setStoreReachable(r bool) {
+	s.storeMu.Lock()
+	s.storeReachable = r
+	s.storeMu.Unlock()
+}
+
+func (s *Server) storeReachableNow() bool {
+	s.storeMu.RLock()
+	defer s.storeMu.RUnlock()
+	return s.storeReachable
+}
+
+// ---- exported-artifact cache -----------------------------------------------
+
+// exportedCache tracks which artifacts (by store prefix) have a current store
+// copy and, for a volume, at which generation. The export queue updates it and
+// the NodeStatus projection reads it to set the per-artifact `exported` bool and
+// Volume.exported_generation. Safe for concurrent use.
+type exportedCache struct {
+	mu   sync.RWMutex
+	gens map[string]uint64 // prefix -> exported generation (0 for non-volume kinds)
+}
+
+func newExportedCache() *exportedCache {
+	return &exportedCache{gens: make(map[string]uint64)}
+}
+
+// mark records that an artifact's store copy is current at the given generation.
+func (c *exportedCache) mark(prefix string, generation uint64) {
+	c.mu.Lock()
+	c.gens[prefix] = generation
+	c.mu.Unlock()
+}
+
+// clear forgets an artifact (on remote eviction), so NodeStatus stops reporting
+// it exported.
+func (c *exportedCache) clear(prefix string) {
+	c.mu.Lock()
+	delete(c.gens, prefix)
+	c.mu.Unlock()
+}
+
+// present reports whether an artifact prefix has a current store copy.
+func (c *exportedCache) present(prefix string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	_, ok := c.gens[prefix]
+	return ok
+}
+
+// generation returns the exported generation for a prefix and whether it is
+// tracked at all.
+func (c *exportedCache) generation(prefix string) (uint64, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	g, ok := c.gens[prefix]
+	return g, ok
+}

--- a/projects/embervm/noded/server/store.go
+++ b/projects/embervm/noded/server/store.go
@@ -203,7 +203,7 @@ func (s *Server) ExportArtifact(ctx context.Context, req *nodev1.ExportArtifactR
 	}
 	s.exported.mark(prefix, generation)
 	s.signalChange()
-	return &nodev1.ExportArtifactResponse{BytesMoved: moved, Skipped: skipped, Generation: generation}, nil
+	return &nodev1.ExportArtifactResponse{BytesMoved: uint64(moved), Skipped: skipped, Generation: generation}, nil
 }
 
 // RestoreArtifact fetches an artifact from the store back onto local disk into
@@ -245,7 +245,7 @@ func (s *Server) RestoreArtifact(ctx context.Context, req *nodev1.RestoreArtifac
 	s.reregisterRestored(ref)
 	s.exported.mark(prefix, generation)
 	s.signalChange()
-	return &nodev1.RestoreArtifactResponse{BytesMoved: moved, Generation: generation}, nil
+	return &nodev1.RestoreArtifactResponse{BytesMoved: uint64(moved), Generation: generation}, nil
 }
 
 // EvictArtifact deletes an artifact. remote=true evicts the store copy

--- a/projects/embervm/noded/server/store_test.go
+++ b/projects/embervm/noded/server/store_test.go
@@ -1,0 +1,511 @@
+package server
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/config"
+)
+
+// fakeStore is an in-memory artifactStore for the R6 server tests: it records
+// every artifact export (prefix -> the exported meta) so tests assert an export
+// fired, and models restore/evict/present without touching the network. It
+// satisfies the server package's artifactStore seam, so the Server holds it
+// exactly as it would a real *store.Store.
+type fakeStore struct {
+	mu sync.Mutex
+	// arts maps a store prefix to its exported files (name -> content) and gen.
+	arts map[string]fakeArtifact
+	// exportCalls counts Export invocations per prefix (skipped or not).
+	exportCalls map[string]int
+	// reachable is what Reachable reports.
+	reachable bool
+	// order records prefixes in export order (for asserting meta-last is N/A here;
+	// we assert on the fact of export, not object ordering, since the fake stores
+	// whole artifacts atomically).
+	order []string
+}
+
+type fakeArtifact struct {
+	files map[string]string
+	gen   uint64
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		arts:        make(map[string]fakeArtifact),
+		exportCalls: make(map[string]int),
+		reachable:   true,
+	}
+}
+
+func (f *fakeStore) Export(_ context.Context, prefix, localDir string, files []string, generation uint64, _ int64) (int64, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.exportCalls[prefix]++
+	// Read the local files into memory, mirroring the real client's read-then-put.
+	got := make(map[string]string, len(files))
+	var total int64
+	for _, name := range files {
+		b, err := os.ReadFile(filepath.Join(localDir, name))
+		if err != nil {
+			return 0, false, err
+		}
+		got[name] = string(b)
+		total += int64(len(b))
+	}
+	// Idempotency: if the stored content is identical, skip.
+	if existing, ok := f.arts[prefix]; ok && sameStringMap(existing.files, got) {
+		return 0, true, nil
+	}
+	f.arts[prefix] = fakeArtifact{files: got, gen: generation}
+	f.order = append(f.order, prefix)
+	return total, false, nil
+}
+
+func (f *fakeStore) Restore(_ context.Context, prefix, localDir string) (int64, uint64, error) {
+	f.mu.Lock()
+	art, ok := f.arts[prefix]
+	f.mu.Unlock()
+	if !ok {
+		return 0, 0, errFakeNotPresent
+	}
+	if err := os.MkdirAll(localDir, 0o700); err != nil {
+		return 0, 0, err
+	}
+	var total int64
+	for name, content := range art.files {
+		dst := filepath.Join(localDir, name)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+			return 0, 0, err
+		}
+		if err := os.WriteFile(dst, []byte(content), 0o600); err != nil {
+			return 0, 0, err
+		}
+		total += int64(len(content))
+	}
+	return total, art.gen, nil
+}
+
+func (f *fakeStore) DeleteArtifact(_ context.Context, prefix string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.arts, prefix)
+	return nil
+}
+
+func (f *fakeStore) Present(_ context.Context, prefix string) (bool, uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	art, ok := f.arts[prefix]
+	if !ok {
+		return false, 0, nil
+	}
+	return true, art.gen, nil
+}
+
+func (f *fakeStore) Reachable(_ context.Context) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reachable
+}
+
+func (f *fakeStore) calls(prefix string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.exportCalls[prefix]
+}
+
+func (f *fakeStore) has(prefix string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.arts[prefix]
+	return ok
+}
+
+// errFakeNotPresent stands in for store.ErrNotPresent in these in-package tests
+// (the server maps any Restore error to FAILED_PRECONDITION regardless of which
+// sentinel it is).
+var errFakeNotPresent = errFake("not present")
+
+type errFake string
+
+func (e errFake) Error() string { return string(e) }
+
+func sameStringMap(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// newStoreTestServer builds a Server with the fake store wired and a real
+// on-disk SnapshotRoot/VolumeRoot temp layout, so artifact enumeration reads
+// genuine files. No driver networking is needed: the R6 handlers and export
+// queue read the disk directly.
+func newStoreTestServer(t *testing.T, fs *fakeStore) *Server {
+	t.Helper()
+	root := t.TempDir()
+	volRoot := t.TempDir()
+	s := New(Options{
+		Config:    config.Config{Arch: "amd64", Node: "node-4", SnapshotRoot: root, VolumeRoot: volRoot},
+		Driver:    &fakeDriver{},
+		Transport: &fakeTransport{},
+		Store:     fs,
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	s.memHeadroom = func() uint64 { return 0 }
+	return s
+}
+
+// writeBundle writes a fake bundle dir (snapfile + memfile + optional sidecars)
+// under the given kind's local dir, so enumeration finds a complete artifact.
+func writeBundleFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+}
+
+// waitForExport polls until the fake store holds the prefix or the deadline
+// passes (the export queue is async).
+func waitForExport(t *testing.T, fs *fakeStore, prefix string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if fs.has(prefix) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("export of %q did not land within the deadline", prefix)
+}
+
+// TestExportArtifactStateful proves a direct ExportArtifact of a banked stateful
+// bundle uploads its files and reports it exported in NodeStatus.
+func TestExportArtifactStateful(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx := context.Background()
+
+	ref := "state-abc"
+	dir := filepath.Join(s.cfg.SnapshotRoot, "stateful", ref)
+	writeBundleFiles(t, dir, map[string]string{"snapfile": "snap", "memfile": "mem", "gen": "3"})
+	s.statefulBundles.add(statefulBundleEntry{snapshotRef: ref, workload: "scratch-postgres", generation: 3})
+
+	resp, err := s.ExportArtifact(ctx, &nodev1.ExportArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL, Workload: "scratch-postgres", Ref: ref},
+	})
+	if err != nil {
+		t.Fatalf("ExportArtifact: %v", err)
+	}
+	if resp.GetSkipped() {
+		t.Fatal("first export should not be skipped")
+	}
+	if resp.GetBytesMoved() == 0 {
+		t.Fatal("export moved 0 bytes")
+	}
+	prefix := "stateful/scratch-postgres/state-abc"
+	if !fs.has(prefix) {
+		t.Fatalf("store missing %q after export", prefix)
+	}
+	// NodeStatus reports the bundle exported.
+	for _, b := range s.nodeStatus().GetStatefulBundles() {
+		if b.GetSnapshotRef() == ref && !b.GetExported() {
+			t.Fatal("stateful bundle should report exported=true")
+		}
+	}
+}
+
+// TestExportArtifactMissingLocalFails proves ExportArtifact refuses
+// FAILED_PRECONDITION when the local artifact is absent.
+func TestExportArtifactMissingLocalFails(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	_, err := s.ExportArtifact(context.Background(), &nodev1.ExportArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL, Workload: "nope", Ref: "gone"},
+	})
+	if err == nil {
+		t.Fatal("export of an absent artifact should fail")
+	}
+}
+
+// TestExportArtifactStoreDisabled proves the verb refuses when no store is
+// configured (nil).
+func TestExportArtifactStoreDisabled(t *testing.T) {
+	root := t.TempDir()
+	s := New(Options{
+		Config:    config.Config{Arch: "amd64", Node: "node-4", SnapshotRoot: root},
+		Driver:    &fakeDriver{},
+		Transport: &fakeTransport{},
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	_, err := s.ExportArtifact(context.Background(), &nodev1.ExportArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL, Workload: "w", Ref: "r"},
+	})
+	if err == nil {
+		t.Fatal("export with no store should fail FAILED_PRECONDITION")
+	}
+}
+
+// TestBankCommitTriggersExport proves a session Bank enqueues an async export
+// that lands in the store (the export-after-commit path), via the internal
+// enqueue plus the worker pool.
+func TestBankCommitTriggersExport(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx := context.Background()
+	s.startExportQueue(ctx)
+
+	ref := "sess-1"
+	dir := filepath.Join(s.cfg.SnapshotRoot, "sessions", ref)
+	writeBundleFiles(t, dir, map[string]string{"snapfile": "s", "memfile": "m"})
+
+	// Simulate the tail of Bank: enqueue the export for the banked bundle.
+	s.enqueueExport(&nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_SESSION, Workload: "sandbox-session", Ref: ref})
+	waitForExport(t, fs, "session/sandbox-session/sess-1")
+}
+
+// TestVolumeExportSkipsUnchangedGeneration proves a second volume export at the
+// same generation is skipped (the gen-unchanged short-circuit).
+func TestVolumeExportSkipsUnchangedGeneration(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx := context.Background()
+
+	// Create a volume at generation 5.
+	if err := s.volumes.Create("scratch-postgres", 1<<20); err != nil {
+		t.Fatalf("create volume: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		if _, err := s.volumes.BumpGeneration("scratch-postgres"); err != nil {
+			t.Fatalf("bump: %v", err)
+		}
+	}
+	volRef := &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: "scratch-postgres"}
+
+	// First export lands.
+	if _, err := s.ExportArtifact(ctx, &nodev1.ExportArtifactRequest{Artifact: volRef}); err != nil {
+		t.Fatalf("first volume export: %v", err)
+	}
+	prefix := "volume/scratch-postgres"
+	firstCalls := fs.calls(prefix)
+	if firstCalls != 1 {
+		t.Fatalf("first export call count = %d, want 1", firstCalls)
+	}
+
+	// Enqueue an async re-export at the SAME generation: the local short-circuit
+	// (exported cache generation == current) drops it without an Export call.
+	s.startExportQueue(ctx)
+	s.enqueueExport(volRef)
+	// Give the worker a moment; the call count must NOT increase.
+	time.Sleep(100 * time.Millisecond)
+	if got := fs.calls(prefix); got != firstCalls {
+		t.Fatalf("gen-unchanged re-export issued %d extra Export calls, want 0", got-firstCalls)
+	}
+}
+
+// TestRestoreArtifactRoundTrip proves RestoreArtifact fetches a stateful bundle
+// AND a volume pair back onto disk and re-registers the bundle.
+func TestRestoreArtifactRoundTrip(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx := context.Background()
+
+	// Seed the store with a stateful bundle and a volume by exporting them from a
+	// throwaway source layout.
+	bundleRef := "state-xyz"
+	srcBundle := filepath.Join(s.cfg.SnapshotRoot, "stateful", bundleRef)
+	writeBundleFiles(t, srcBundle, map[string]string{"snapfile": "snapdata", "memfile": "memdata", "gen": "4"})
+	s.statefulBundles.add(statefulBundleEntry{snapshotRef: bundleRef, workload: "scratch-postgres", generation: 4})
+	if _, err := s.ExportArtifact(ctx, &nodev1.ExportArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL, Workload: "scratch-postgres", Ref: bundleRef},
+	}); err != nil {
+		t.Fatalf("seed bundle export: %v", err)
+	}
+	if err := s.volumes.Create("scratch-postgres", 1<<20); err != nil {
+		t.Fatalf("create volume: %v", err)
+	}
+	if _, err := s.volumes.BumpGeneration("scratch-postgres"); err != nil {
+		t.Fatalf("bump: %v", err)
+	}
+	if _, err := s.ExportArtifact(ctx, &nodev1.ExportArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: "scratch-postgres"},
+	}); err != nil {
+		t.Fatalf("seed volume export: %v", err)
+	}
+
+	// Wipe local disk copies to force a real restore.
+	if err := os.RemoveAll(srcBundle); err != nil {
+		t.Fatalf("rm bundle: %v", err)
+	}
+	s.statefulBundles.remove(bundleRef)
+	if err := os.RemoveAll(filepath.Dir(s.volumes.VolumePath("scratch-postgres"))); err != nil {
+		t.Fatalf("rm volume: %v", err)
+	}
+
+	// Restore the bundle.
+	resp, err := s.RestoreArtifact(ctx, &nodev1.RestoreArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL, Workload: "scratch-postgres", Ref: bundleRef},
+	})
+	if err != nil {
+		t.Fatalf("restore bundle: %v", err)
+	}
+	if resp.GetGeneration() != 4 {
+		t.Fatalf("restored bundle gen = %d, want 4", resp.GetGeneration())
+	}
+	if got, _ := os.ReadFile(filepath.Join(srcBundle, "snapfile")); string(got) != "snapdata" {
+		t.Fatalf("restored snapfile = %q, want snapdata", got)
+	}
+	// The reconcile re-registered the bundle so a rescan sees it.
+	if _, ok := s.statefulBundles.get(bundleRef); !ok {
+		t.Fatal("restored stateful bundle not re-registered")
+	}
+
+	// Restore the volume pair.
+	if _, err := s.RestoreArtifact(ctx, &nodev1.RestoreArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: "scratch-postgres"},
+	}); err != nil {
+		t.Fatalf("restore volume: %v", err)
+	}
+	if !s.volumes.Exists("scratch-postgres") {
+		t.Fatal("restored volume file missing")
+	}
+	gen, err := s.volumes.Generation("scratch-postgres")
+	if err != nil || gen != 1 {
+		t.Fatalf("restored volume generation = (%d, %v), want (1, nil)", gen, err)
+	}
+}
+
+// TestRestoreArtifactAbsentFails proves RestoreArtifact refuses
+// FAILED_PRECONDITION when the store copy is absent.
+func TestRestoreArtifactAbsentFails(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	_, err := s.RestoreArtifact(context.Background(), &nodev1.RestoreArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL, Workload: "w", Ref: "missing"},
+	})
+	if err == nil {
+		t.Fatal("restore of an absent store copy should fail")
+	}
+}
+
+// TestEvictArtifactRemote proves EvictArtifact(remote=true) removes the store
+// copy and is idempotent.
+func TestEvictArtifactRemote(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx := context.Background()
+
+	ref := "serv-1"
+	dir := filepath.Join(s.cfg.SnapshotRoot, "serving", ref)
+	writeBundleFiles(t, dir, map[string]string{"snapfile": "s", "memfile": "m"})
+	s.servingSnap.add(servingSnapshotEntry{snapshotRef: ref, workload: "hot-image-demo"})
+	if _, err := s.ExportArtifact(ctx, &nodev1.ExportArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_SERVING, Workload: "hot-image-demo", Ref: ref},
+	}); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	prefix := "serving/hot-image-demo/serv-1"
+	if !fs.has(prefix) {
+		t.Fatal("store missing artifact before evict")
+	}
+	if _, err := s.EvictArtifact(ctx, &nodev1.EvictArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_SERVING, Workload: "hot-image-demo", Ref: ref},
+		Remote:   true,
+	}); err != nil {
+		t.Fatalf("evict remote: %v", err)
+	}
+	if fs.has(prefix) {
+		t.Fatal("store still holds artifact after remote evict")
+	}
+	// Idempotent.
+	if _, err := s.EvictArtifact(ctx, &nodev1.EvictArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_SERVING, Workload: "hot-image-demo", Ref: ref},
+		Remote:   true,
+	}); err != nil {
+		t.Fatalf("second evict should be idempotent: %v", err)
+	}
+}
+
+// TestEvictArtifactVolumePairingGuard proves a volume evict is refused while its
+// current generation still pairs with a banked local bundle (standing decision 8).
+func TestEvictArtifactVolumePairingGuard(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx := context.Background()
+
+	if err := s.volumes.Create("scratch-postgres", 1<<20); err != nil {
+		t.Fatalf("create volume: %v", err)
+	}
+	gen, err := s.volumes.BumpGeneration("scratch-postgres")
+	if err != nil {
+		t.Fatalf("bump: %v", err)
+	}
+	// A banked bundle stamped with the CURRENT generation: the pair is live.
+	s.statefulBundles.add(statefulBundleEntry{snapshotRef: "b1", workload: "scratch-postgres", generation: gen})
+
+	_, err = s.EvictArtifact(ctx, &nodev1.EvictArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: "scratch-postgres"},
+		Remote:   true,
+	})
+	if err == nil {
+		t.Fatal("evicting a volume still paired with a banked bundle should be refused")
+	}
+
+	// After the bundle is gone, the evict is allowed.
+	s.statefulBundles.remove("b1")
+	if _, err := s.EvictArtifact(ctx, &nodev1.EvictArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: "scratch-postgres"},
+		Remote:   true,
+	}); err != nil {
+		t.Fatalf("evict after unpairing should succeed: %v", err)
+	}
+}
+
+// TestDrainingDoesNotBlockOnExportQueue proves a full export queue never blocks
+// the enqueue path (fire-and-forget): even with no workers draining it, many
+// enqueues return promptly rather than deadlocking a drain.
+func TestDrainingDoesNotBlockOnExportQueue(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	// Start the queue with workers, then flood far past its depth. The enqueue
+	// must never block even when the queue is saturated (it drops instead).
+	s.startExportQueue(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < exportQueueDepth*4; i++ {
+			s.enqueueExport(&nodev1.ArtifactRef{
+				Kind:     nodev1.ArtifactKind_ARTIFACT_KIND_SESSION,
+				Workload: "w",
+				Ref:      "flood-" + strconv.Itoa(i),
+			})
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("enqueue flood blocked; the export queue must never stall the caller")
+	}
+}

--- a/projects/embervm/noded/server/store_test.go
+++ b/projects/embervm/noded/server/store_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
 
 	"github.com/jomcgi/homelab/projects/embervm/noded/config"
+	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
 )
 
 // fakeStore is an in-memory artifactStore for the R6 server tests: it records
@@ -153,20 +155,71 @@ func sameStringMap(a, b map[string]string) bool {
 	return true
 }
 
+// diskScanStatefulDriver is a stateful-driver stub whose ScanStatefulBundles
+// globs the REAL on-disk stateful/ dir exactly as the production *driver.Driver
+// does (keyed by dir name == snapshot_ref, gen read from the sidecar). It embeds
+// fakeStatefulDriver for the rest of the interface so a store test can exercise
+// the faithful restore -> ReconcileStatefulFromDisk -> re-register path a real
+// daemon takes, rather than the in-memory banked-map scan the base fake does.
+type diskScanStatefulDriver struct {
+	*fakeStatefulDriver
+	statefulRoot string
+}
+
+func newDiskScanStatefulDriver(snapshotRoot string) *diskScanStatefulDriver {
+	root := filepath.Join(snapshotRoot, "stateful")
+	f := newFakeStatefulDriver(snapshotRoot)
+	f.statefulDir = root
+	return &diskScanStatefulDriver{fakeStatefulDriver: f, statefulRoot: root}
+}
+
+func (d *diskScanStatefulDriver) StatefulDir() string { return d.statefulRoot }
+
+// ScanStatefulBundles reads the on-disk stateful/ dir (mirroring the real
+// driver): a bundle is any subdir holding a snapfile, keyed by the dir name, its
+// generation read from the gen sidecar. This is what makes a restored bundle dir
+// visible to ReconcileStatefulFromDisk exactly as a startup rescan would.
+func (d *diskScanStatefulDriver) ScanStatefulBundles() []substrate.StatefulBundleInfo {
+	entries, err := os.ReadDir(d.statefulRoot)
+	if err != nil {
+		return nil
+	}
+	var out []substrate.StatefulBundleInfo
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		ref := e.Name()
+		if _, serr := os.Stat(filepath.Join(d.statefulRoot, ref, "snapfile")); serr != nil {
+			continue
+		}
+		var gen uint64
+		if raw, rerr := os.ReadFile(filepath.Join(d.statefulRoot, ref, "gen")); rerr == nil {
+			if n, perr := strconv.ParseUint(strings.TrimSpace(string(raw)), 10, 64); perr == nil {
+				gen = n
+			}
+		}
+		out = append(out, substrate.StatefulBundleInfo{SnapshotRef: ref, Generation: gen, SizeBytes: 4096})
+	}
+	return out
+}
+
 // newStoreTestServer builds a Server with the fake store wired and a real
 // on-disk SnapshotRoot/VolumeRoot temp layout, so artifact enumeration reads
-// genuine files. No driver networking is needed: the R6 handlers and export
-// queue read the disk directly.
+// genuine files. A disk-scanning stateful driver is wired so the RestoreArtifact
+// re-registration path (ReconcileStatefulFromDisk -> ScanStatefulBundles) sees a
+// restored bundle dir exactly as a startup disk rescan would, matching prod.
 func newStoreTestServer(t *testing.T, fs *fakeStore) *Server {
 	t.Helper()
 	root := t.TempDir()
 	volRoot := t.TempDir()
 	s := New(Options{
-		Config:    config.Config{Arch: "amd64", Node: "node-4", SnapshotRoot: root, VolumeRoot: volRoot},
-		Driver:    &fakeDriver{},
-		Transport: &fakeTransport{},
-		Store:     fs,
-		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Config:         config.Config{Arch: "amd64", Node: "node-4", SnapshotRoot: root, VolumeRoot: volRoot},
+		Driver:         &fakeDriver{},
+		StatefulDriver: newDiskScanStatefulDriver(root),
+		Transport:      &fakeTransport{},
+		Store:          fs,
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
 	s.memHeadroom = func() uint64 { return 0 }
 	return s

--- a/projects/embervm/noded/store/BUILD
+++ b/projects/embervm/noded/store/BUILD
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "store",
+    srcs = ["store.go"],
+    importpath = "github.com/jomcgi/homelab/projects/embervm/noded/store",
+    visibility = ["//projects/embervm/noded:__subpackages__"],
+)
+
+go_test(
+    name = "store_test",
+    srcs = ["store_test.go"],
+    embed = [":store"],
+)

--- a/projects/embervm/noded/store/store.go
+++ b/projects/embervm/noded/store/store.go
@@ -1,0 +1,478 @@
+// Package store is embervm-noded's off-node durability client (R6): a stdlib
+// net/http client against an S3-API object store (SeaweedFS in-cluster is the
+// first backend) that moves banked artifacts between node disk and the store.
+// It is the mechanism behind the continuity verbs (ExportArtifact /
+// RestoreArtifact / EvictArtifact) so a node (or its NVMe) can be lost without
+// losing data.
+//
+// Standing decision 5: this is a RAW S3-API client (PUT/GET/HEAD/DELETE against
+// <endpoint>/<bucket>/<key>), NOT the aws-sdk-go, and there is NO SigV4 signing
+// in v1 (SeaweedFS in-cluster is anonymous; a static-credential header seam is
+// left for later). The style mirrors the zip-lane fetch pattern already in the
+// server (plain net/http, bounded reads, sha256 verification).
+//
+// Artifact layout (Fork 3): every artifact is a set of files under a key prefix
+// <kind>/<workload>/<ref> (kind lowercase; ref MAY be empty for a singleton
+// VOLUME, so the prefix collapses to volume/<workload>). A meta.json
+// completeness marker (per-file sizes + SHA-256, plus a generation and a
+// created-at) is the LAST object written on export and the FIRST read on
+// restore or a presence check, so a partially-written or partially-deleted
+// artifact is invisible: no meta.json means "not present".
+package store
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// metaObject is the object key (within an artifact prefix) of the completeness
+// marker. It is written LAST on export and read FIRST on restore/presence: a
+// prefix without it is an incomplete (or absent) artifact.
+const metaObject = "meta.json"
+
+// reachableTimeout bounds the cheap bucket-root HEAD the reachability probe
+// issues, so an unreachable store fails the probe fast rather than hanging the
+// caller (the probe feeds NodeStatus.store_reachable, a warmth hint, never a
+// gate).
+const reachableTimeout = 3 * time.Second
+
+// ErrNotPresent is the sentinel a Restore (or a meta fetch) returns when the
+// store holds no meta.json for the prefix (the artifact is absent or was only
+// partially written). The verb handler maps it to codes.FailedPrecondition so a
+// restore of an incomplete store copy surfaces loudly instead of overwriting
+// local state with bad bytes.
+var ErrNotPresent = errors.New("store: artifact not present (no meta.json)")
+
+// FileMeta is one file's completeness record within an artifact's meta.json:
+// its exact byte size and hex SHA-256, verified on restore so a corrupt or
+// truncated object never overwrites good local bytes.
+type FileMeta struct {
+	Size   int64  `json:"size"`
+	Sha256 string `json:"sha256"`
+}
+
+// Meta is the artifact completeness marker, JSON-serialized as meta.json and
+// written LAST on export. Files maps each artifact file's base name to its size
+// and checksum; Generation carries the volume generation for a VOLUME artifact
+// (0 for kinds with no generation); CreatedAtUnixMs records when the export ran.
+type Meta struct {
+	Files           map[string]FileMeta `json:"files"`
+	Generation      uint64              `json:"generation"`
+	CreatedAtUnixMs int64               `json:"createdAtUnixMs"`
+}
+
+// Store is the S3-API object-store client. It is safe for concurrent use (the
+// *http.Client is). A nil *Store means the store is disabled (New returns nil on
+// an empty endpoint); every method is nil-safe so callers can hold a nil Store
+// and let the verb handlers refuse with FAILED_PRECONDITION rather than panic.
+type Store struct {
+	endpoint string // base URL, no trailing slash (e.g. http://seaweedfs-s3...:8333)
+	bucket   string
+	client   *http.Client
+}
+
+// New builds a Store for endpoint + bucket. It returns nil when endpoint is
+// empty, which every caller reads as "the store is disabled" (export is skipped,
+// restore-on-miss is impossible, and the continuity verbs refuse). The endpoint
+// is normalised to have no trailing slash so key joins are unambiguous.
+func New(endpoint, bucket string) *Store {
+	if endpoint == "" {
+		return nil
+	}
+	return &Store{
+		endpoint: strings.TrimRight(endpoint, "/"),
+		bucket:   bucket,
+		client:   &http.Client{},
+	}
+}
+
+// url composes the object URL for a key under the bucket. The key is used
+// verbatim (callers build it from a Fork-3 prefix plus a file base name, both
+// filesystem-safe), so no escaping is applied beyond joining with slashes.
+func (s *Store) url(key string) string {
+	return s.endpoint + "/" + s.bucket + "/" + strings.TrimLeft(key, "/")
+}
+
+// ---- raw object operations -------------------------------------------------
+
+// Put uploads size bytes read from r to the object key (HTTP PUT). size is sent
+// as Content-Length so the store can size the object without buffering; a
+// negative size lets net/http chunk it. Any non-2xx status is an error.
+func (s *Store) Put(ctx context.Context, key string, r io.Reader, size int64) error {
+	if s == nil {
+		return ErrNotPresent
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, s.url(key), r)
+	if err != nil {
+		return fmt.Errorf("store: build PUT %q: %w", key, err)
+	}
+	if size >= 0 {
+		req.ContentLength = size
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("store: PUT %q: %w", key, err)
+	}
+	defer drainClose(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("store: PUT %q: unexpected status %d", key, resp.StatusCode)
+	}
+	return nil
+}
+
+// Get fetches the object key (HTTP GET) and returns its body plus the reported
+// size (Content-Length, -1 when unknown). The caller MUST close the returned
+// reader. A 404 is reported as ErrNotPresent so callers can distinguish a
+// missing object from a transport failure.
+func (s *Store) Get(ctx context.Context, key string) (io.ReadCloser, int64, error) {
+	if s == nil {
+		return nil, 0, ErrNotPresent
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.url(key), nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("store: build GET %q: %w", key, err)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("store: GET %q: %w", key, err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		drainClose(resp.Body)
+		return nil, 0, ErrNotPresent
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		drainClose(resp.Body)
+		return nil, 0, fmt.Errorf("store: GET %q: unexpected status %d", key, resp.StatusCode)
+	}
+	return resp.Body, resp.ContentLength, nil
+}
+
+// Head reports whether the object key exists (HTTP HEAD, true iff 200). A 404 is
+// (false, nil); any other non-2xx status is an error so a transport fault is not
+// silently read as absence.
+func (s *Store) Head(ctx context.Context, key string) (bool, error) {
+	if s == nil {
+		return false, nil
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, s.url(key), nil)
+	if err != nil {
+		return false, fmt.Errorf("store: build HEAD %q: %w", key, err)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("store: HEAD %q: %w", key, err)
+	}
+	defer drainClose(resp.Body)
+	if resp.StatusCode == http.StatusOK {
+		return true, nil
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	return false, fmt.Errorf("store: HEAD %q: unexpected status %d", key, resp.StatusCode)
+}
+
+// Delete removes the object key (HTTP DELETE). It is idempotent: a 404 (the
+// object is already gone) is success, matching the desired-end-state contract.
+func (s *Store) Delete(ctx context.Context, key string) error {
+	if s == nil {
+		return nil
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, s.url(key), nil)
+	if err != nil {
+		return fmt.Errorf("store: build DELETE %q: %w", key, err)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("store: DELETE %q: %w", key, err)
+	}
+	defer drainClose(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return nil // already gone: the desired end-state holds
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("store: DELETE %q: unexpected status %d", key, resp.StatusCode)
+	}
+	return nil
+}
+
+// ---- artifact-level helpers ------------------------------------------------
+
+// Export writes each of localDir's named files to the store under prefix, then
+// meta.json LAST as the completeness marker. It first computes every file's
+// SHA-256 and HEAD-compares against any existing meta.json: if the store already
+// holds this exact artifact (identical file checksums), it returns skipped=true
+// and bytesMoved=0 without re-uploading (idempotent per checksum). Otherwise it
+// PUTs each file, then PUTs meta.json, and returns the sum of the uploaded file
+// sizes. files are base names resolved against localDir; a missing local file is
+// an error (an incomplete artifact must not be exported as complete).
+func (s *Store) Export(ctx context.Context, prefix, localDir string, files []string, generation uint64, nowMs int64) (bytesMoved int64, skipped bool, err error) {
+	if s == nil {
+		return 0, false, ErrNotPresent
+	}
+	meta := Meta{
+		Files:           make(map[string]FileMeta, len(files)),
+		Generation:      generation,
+		CreatedAtUnixMs: nowMs,
+	}
+	var totalSize int64
+	for _, name := range files {
+		path := filepath.Join(localDir, name)
+		fm, ferr := fileMeta(path)
+		if ferr != nil {
+			return 0, false, fmt.Errorf("store: stat artifact file %q: %w", name, ferr)
+		}
+		meta.Files[name] = fm
+		totalSize += fm.Size
+	}
+
+	// Idempotency short-circuit: if the store already holds a meta.json whose
+	// per-file checksums match ours, the artifact is already durable at this
+	// content. HEAD-then-GET the marker; a Head miss (or a mismatch) falls
+	// through to a full re-upload.
+	if present, remoteMeta, merr := s.getMeta(ctx, prefix); merr == nil && present && sameFiles(remoteMeta.Files, meta.Files) {
+		return 0, true, nil
+	}
+
+	for name, fm := range meta.Files {
+		f, oerr := os.Open(filepath.Join(localDir, name))
+		if oerr != nil {
+			return bytesMoved, false, fmt.Errorf("store: open artifact file %q: %w", name, oerr)
+		}
+		perr := s.Put(ctx, prefix+"/"+name, f, fm.Size)
+		_ = f.Close()
+		if perr != nil {
+			return bytesMoved, false, perr
+		}
+		bytesMoved += fm.Size
+	}
+
+	// meta.json LAST: only now is the artifact visible as complete.
+	metaBytes, merr := json.Marshal(meta)
+	if merr != nil {
+		return bytesMoved, false, fmt.Errorf("store: marshal meta: %w", merr)
+	}
+	if perr := s.Put(ctx, prefix+"/"+metaObject, bytes.NewReader(metaBytes), int64(len(metaBytes))); perr != nil {
+		return bytesMoved, false, perr
+	}
+	return bytesMoved, false, nil
+}
+
+// Restore fetches meta.json first (ErrNotPresent when absent, which the caller
+// maps to FAILED_PRECONDITION), then GETs each listed file into localDir,
+// verifying its SHA-256 against the marker. Each file is written to a temp path
+// and renamed into place only after its checksum matches, so a mismatch (or a
+// short read) never leaves a corrupt file on disk. It returns the bytes written
+// and the marker's generation.
+func (s *Store) Restore(ctx context.Context, prefix, localDir string) (bytesMoved int64, generation uint64, err error) {
+	if s == nil {
+		return 0, 0, ErrNotPresent
+	}
+	present, meta, merr := s.getMeta(ctx, prefix)
+	if merr != nil {
+		return 0, 0, merr
+	}
+	if !present {
+		return 0, 0, ErrNotPresent
+	}
+	if err := os.MkdirAll(localDir, 0o700); err != nil {
+		return 0, 0, fmt.Errorf("store: mkdir restore dir %q: %w", localDir, err)
+	}
+	for name, fm := range meta.Files {
+		n, ferr := s.restoreFile(ctx, prefix+"/"+name, filepath.Join(localDir, name), fm)
+		if ferr != nil {
+			return bytesMoved, 0, ferr
+		}
+		bytesMoved += n
+	}
+	return bytesMoved, meta.Generation, nil
+}
+
+// restoreFile GETs one object into a temp file alongside dst, verifies its size
+// and SHA-256 against the marker, and only then renames it into place. On any
+// mismatch or read error it removes the temp file and returns an error, so a
+// corrupt restore never leaves a bad file where a good one (or none) belongs.
+func (s *Store) restoreFile(ctx context.Context, key, dst string, want FileMeta) (int64, error) {
+	body, _, err := s.Get(ctx, key)
+	if err != nil {
+		return 0, err
+	}
+	defer drainClose(body)
+
+	tmp := dst + ".restore.tmp"
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return 0, fmt.Errorf("store: create temp restore file %q: %w", tmp, err)
+	}
+	h := sha256.New()
+	n, err := io.Copy(io.MultiWriter(f, h), body)
+	closeErr := f.Close()
+	if err != nil {
+		_ = os.Remove(tmp)
+		return 0, fmt.Errorf("store: read object %q: %w", key, err)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmp)
+		return 0, fmt.Errorf("store: close temp restore file %q: %w", tmp, closeErr)
+	}
+	if want.Size >= 0 && n != want.Size {
+		_ = os.Remove(tmp)
+		return 0, fmt.Errorf("store: object %q size %d != meta %d", key, n, want.Size)
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if want.Sha256 != "" && got != want.Sha256 {
+		_ = os.Remove(tmp)
+		return 0, fmt.Errorf("store: object %q sha256 %s != meta %s", key, got, want.Sha256)
+	}
+	if err := os.Rename(tmp, dst); err != nil {
+		_ = os.Remove(tmp)
+		return 0, fmt.Errorf("store: publish restored file %q: %w", dst, err)
+	}
+	return n, nil
+}
+
+// DeleteArtifact removes an artifact from the store. It deletes meta.json FIRST
+// so the artifact is immediately invisible (a presence check reads meta.json
+// first), then best-effort deletes each file the marker named. If meta.json is
+// already gone, the artifact is treated as absent and the call is a no-op
+// success (idempotent, matching the desired-end-state contract).
+func (s *Store) DeleteArtifact(ctx context.Context, prefix string) error {
+	if s == nil {
+		return nil
+	}
+	present, meta, err := s.getMeta(ctx, prefix)
+	if err != nil {
+		return err
+	}
+	if !present {
+		return nil // already invisible: nothing to delete
+	}
+	// Delete the marker FIRST: from here the artifact is invisible to any
+	// presence check even if the file deletes below partially fail.
+	if err := s.Delete(ctx, prefix+"/"+metaObject); err != nil {
+		return err
+	}
+	// Best-effort delete of each known file (each Delete is idempotent on 404),
+	// so an orphaned file cannot survive a completed marker deletion silently.
+	var firstErr error
+	for name := range meta.Files {
+		if derr := s.Delete(ctx, prefix+"/"+name); derr != nil && firstErr == nil {
+			firstErr = derr
+		}
+	}
+	return firstErr
+}
+
+// Present reports whether the store holds a complete artifact at prefix (a
+// readable meta.json) and its generation. A missing marker is (false, 0, nil):
+// absence is not an error, it is the answer.
+func (s *Store) Present(ctx context.Context, prefix string) (bool, uint64, error) {
+	if s == nil {
+		return false, 0, nil
+	}
+	present, meta, err := s.getMeta(ctx, prefix)
+	if err != nil {
+		return false, 0, err
+	}
+	if !present {
+		return false, 0, nil
+	}
+	return true, meta.Generation, nil
+}
+
+// Reachable is a cheap liveness probe against the bucket root with a short
+// timeout, feeding NodeStatus.store_reachable (a warmth hint, never a gate). A
+// HEAD on the bucket root that returns any HTTP status (2xx, 403, even 404)
+// proves the endpoint answered; only a transport failure or timeout is
+// unreachable. A nil store is never reachable.
+func (s *Store) Reachable(ctx context.Context) bool {
+	if s == nil {
+		return false
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, reachableTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodHead, s.endpoint+"/"+s.bucket, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return false
+	}
+	drainClose(resp.Body)
+	// Any answered status means the endpoint is up; the reachability probe does
+	// not judge the bucket's contents, only that the store responds.
+	return true
+}
+
+// getMeta fetches and decodes meta.json for a prefix. It returns (false, _, nil)
+// when the marker is absent (ErrNotPresent from Get), so callers distinguish an
+// absent artifact from a transport or decode error.
+func (s *Store) getMeta(ctx context.Context, prefix string) (bool, Meta, error) {
+	body, _, err := s.Get(ctx, prefix+"/"+metaObject)
+	if errors.Is(err, ErrNotPresent) {
+		return false, Meta{}, nil
+	}
+	if err != nil {
+		return false, Meta{}, err
+	}
+	defer drainClose(body)
+	var meta Meta
+	if derr := json.NewDecoder(body).Decode(&meta); derr != nil {
+		return false, Meta{}, fmt.Errorf("store: decode meta for %q: %w", prefix, derr)
+	}
+	return true, meta, nil
+}
+
+// fileMeta computes one local file's size and hex SHA-256 for the export marker.
+func fileMeta(path string) (FileMeta, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return FileMeta{}, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	n, err := io.Copy(h, f)
+	if err != nil {
+		return FileMeta{}, err
+	}
+	return FileMeta{Size: n, Sha256: hex.EncodeToString(h.Sum(nil))}, nil
+}
+
+// sameFiles reports whether two file-meta maps carry identical names and
+// checksums (the idempotency test: the store already holds this exact content).
+// Sizes are implied by the checksum but compared too for a cheap early-out.
+func sameFiles(a, b map[string]FileMeta) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for name, fa := range a {
+		fb, ok := b[name]
+		if !ok || fa.Sha256 != fb.Sha256 || fa.Size != fb.Size {
+			return false
+		}
+	}
+	return true
+}
+
+// drainClose drains and closes a response body so the underlying connection can
+// be reused (the net/http keep-alive discipline the zip-lane fetch also follows).
+func drainClose(rc io.ReadCloser) {
+	if rc == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(rc, 4<<10))
+	_ = rc.Close()
+}

--- a/projects/embervm/noded/store/store_test.go
+++ b/projects/embervm/noded/store/store_test.go
@@ -1,0 +1,404 @@
+package store
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeObjectStore is an in-memory S3-API stand-in: a map from object path
+// (/<bucket>/<key>) to bytes, served over an httptest.Server. It honours PUT /
+// GET / HEAD / DELETE exactly as the Store client expects, so the tests exercise
+// the real net/http round-trip without a network dependency.
+type fakeObjectStore struct {
+	mu      sync.Mutex
+	objects map[string][]byte
+	// putOrder records the path of every PUT in order, so a test can assert
+	// meta.json is written LAST.
+	putOrder []string
+}
+
+func newFakeObjectStore() *fakeObjectStore {
+	return &fakeObjectStore{objects: make(map[string][]byte)}
+}
+
+func (f *fakeObjectStore) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.URL.Path
+		switch r.Method {
+		case http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			f.mu.Lock()
+			f.objects[key] = body
+			f.putOrder = append(f.putOrder, key)
+			f.mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			f.mu.Lock()
+			b, ok := f.objects[key]
+			f.mu.Unlock()
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Length", strconv.Itoa(len(b)))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(b)
+		case http.MethodHead:
+			f.mu.Lock()
+			_, ok := f.objects[key]
+			f.mu.Unlock()
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case http.MethodDelete:
+			f.mu.Lock()
+			_, ok := f.objects[key]
+			delete(f.objects, key)
+			f.mu.Unlock()
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+func (f *fakeObjectStore) has(key string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.objects[key]
+	return ok
+}
+
+func (f *fakeObjectStore) putOrderCopy() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.putOrder))
+	copy(out, f.putOrder)
+	return out
+}
+
+// newTestStore stands up a fake object store and returns a Store pointed at it.
+func newTestStore(t *testing.T) (*Store, *fakeObjectStore) {
+	t.Helper()
+	fake := newFakeObjectStore()
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "embervm"), fake
+}
+
+// writeLocalArtifact writes a set of named files with the given contents into a
+// fresh temp dir and returns the dir and the file names.
+func writeLocalArtifact(t *testing.T, files map[string]string) (string, []string) {
+	t.Helper()
+	dir := t.TempDir()
+	names := make([]string, 0, len(files))
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return dir, names
+}
+
+func TestNewDisabledOnEmptyEndpoint(t *testing.T) {
+	if New("", "embervm") != nil {
+		t.Fatal("New(\"\", ...) should return nil (store disabled)")
+	}
+}
+
+// TestRawRoundTrip proves Put/Get/Head/Delete against a raw key work and that
+// Delete is idempotent (a 404 is success).
+func TestRawRoundTrip(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	key := "stateful/scratch-postgres/state-abc/snapfile"
+	payload := []byte("hello snapshot bytes")
+
+	if err := s.Put(ctx, key, strings.NewReader(string(payload)), int64(len(payload))); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	ok, err := s.Head(ctx, key)
+	if err != nil || !ok {
+		t.Fatalf("Head after Put = (%v, %v), want (true, nil)", ok, err)
+	}
+	rc, size, err := s.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	got, _ := io.ReadAll(rc)
+	_ = rc.Close()
+	if string(got) != string(payload) {
+		t.Fatalf("Get body = %q, want %q", got, payload)
+	}
+	if size != int64(len(payload)) {
+		t.Fatalf("Get size = %d, want %d", size, len(payload))
+	}
+	if err := s.Delete(ctx, key); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	ok, err = s.Head(ctx, key)
+	if err != nil || ok {
+		t.Fatalf("Head after Delete = (%v, %v), want (false, nil)", ok, err)
+	}
+	// Idempotent: a second Delete of an absent key succeeds.
+	if err := s.Delete(ctx, key); err != nil {
+		t.Fatalf("second Delete (absent) should be nil, got %v", err)
+	}
+	// Get of an absent key is ErrNotPresent.
+	if _, _, err := s.Get(ctx, key); err != ErrNotPresent {
+		t.Fatalf("Get absent = %v, want ErrNotPresent", err)
+	}
+}
+
+// TestExportWritesMetaLast proves every artifact file is present in the store
+// BEFORE meta.json, so a reader that sees meta.json always finds a complete
+// artifact (the completeness-marker discipline).
+func TestExportWritesMetaLast(t *testing.T) {
+	s, fake := newTestStore(t)
+	ctx := context.Background()
+	dir, names := writeLocalArtifact(t, map[string]string{
+		"snapfile": "snap-content",
+		"memfile":  "mem-content",
+		"gen":      "7",
+	})
+	prefix := "stateful/scratch-postgres/state-abc"
+
+	moved, skipped, err := s.Export(ctx, prefix, dir, names, 7, 111)
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if skipped {
+		t.Fatal("first Export should not be skipped")
+	}
+	wantBytes := int64(len("snap-content") + len("mem-content") + len("7"))
+	if moved != wantBytes {
+		t.Fatalf("Export bytesMoved = %d, want %d", moved, wantBytes)
+	}
+
+	order := fake.putOrderCopy()
+	if len(order) == 0 {
+		t.Fatal("no PUTs recorded")
+	}
+	last := order[len(order)-1]
+	if !strings.HasSuffix(last, "/"+metaObject) {
+		t.Fatalf("last PUT = %q, want the meta.json marker written LAST", last)
+	}
+	// Every file object landed before the marker.
+	for _, name := range names {
+		if !fake.has("/embervm/" + prefix + "/" + name) {
+			t.Fatalf("file object %q missing after Export", name)
+		}
+	}
+	if !fake.has("/embervm/" + prefix + "/" + metaObject) {
+		t.Fatal("meta.json missing after Export")
+	}
+}
+
+// TestExportSkipsUnchanged proves a second Export of identical content HEAD/GET-
+// compares the marker and returns skipped=true without re-uploading.
+func TestExportSkipsUnchanged(t *testing.T) {
+	s, fake := newTestStore(t)
+	ctx := context.Background()
+	dir, names := writeLocalArtifact(t, map[string]string{
+		"snapfile": "snap-content",
+		"memfile":  "mem-content",
+	})
+	prefix := "session/sandbox-session/sess-1"
+
+	if _, skipped, err := s.Export(ctx, prefix, dir, names, 0, 1); err != nil || skipped {
+		t.Fatalf("first Export = (skipped=%v, %v), want (false, nil)", skipped, err)
+	}
+	putsAfterFirst := len(fake.putOrderCopy())
+
+	moved, skipped, err := s.Export(ctx, prefix, dir, names, 0, 2)
+	if err != nil {
+		t.Fatalf("second Export: %v", err)
+	}
+	if !skipped {
+		t.Fatal("second Export of unchanged content should be skipped")
+	}
+	if moved != 0 {
+		t.Fatalf("skipped Export bytesMoved = %d, want 0", moved)
+	}
+	if got := len(fake.putOrderCopy()); got != putsAfterFirst {
+		t.Fatalf("skipped Export issued %d new PUTs, want 0", got-putsAfterFirst)
+	}
+}
+
+// TestRestoreRoundTrip proves Restore fetches the bytes back identically and
+// reports the marker's generation.
+func TestRestoreRoundTrip(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	contents := map[string]string{"snapfile": "snap-bytes", "memfile": "mem-bytes"}
+	srcDir, names := writeLocalArtifact(t, contents)
+	prefix := "stateful/scratch-postgres/state-xyz"
+
+	if _, _, err := s.Export(ctx, prefix, srcDir, names, 9, 42); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	dstDir := t.TempDir()
+	moved, gen, err := s.Restore(ctx, prefix, dstDir)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if gen != 9 {
+		t.Fatalf("Restore generation = %d, want 9", gen)
+	}
+	if moved != int64(len("snap-bytes")+len("mem-bytes")) {
+		t.Fatalf("Restore bytesMoved = %d", moved)
+	}
+	for name, want := range contents {
+		got, rerr := os.ReadFile(filepath.Join(dstDir, name))
+		if rerr != nil {
+			t.Fatalf("read restored %s: %v", name, rerr)
+		}
+		if string(got) != want {
+			t.Fatalf("restored %s = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestRestoreAbsentIsNotPresent proves a restore with no meta.json returns the
+// ErrNotPresent sentinel (which the verb handler maps to FAILED_PRECONDITION).
+func TestRestoreAbsentIsNotPresent(t *testing.T) {
+	s, _ := newTestStore(t)
+	if _, _, err := s.Restore(context.Background(), "stateful/nope/none", t.TempDir()); err != ErrNotPresent {
+		t.Fatalf("Restore of absent artifact = %v, want ErrNotPresent", err)
+	}
+}
+
+// TestRestoreChecksumMismatchLeavesNoCorruptFile proves a corrupted object fails
+// the restore and does NOT leave the corrupt file on local disk.
+func TestRestoreChecksumMismatchLeavesNoCorruptFile(t *testing.T) {
+	s, fake := newTestStore(t)
+	ctx := context.Background()
+	srcDir, names := writeLocalArtifact(t, map[string]string{"snapfile": "good-bytes"})
+	prefix := "session/sandbox-session/sess-corrupt"
+	if _, _, err := s.Export(ctx, prefix, srcDir, names, 0, 1); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	// Corrupt the stored object WITHOUT updating meta.json, so the restore's
+	// checksum verification fails.
+	fake.mu.Lock()
+	fake.objects["/embervm/"+prefix+"/snapfile"] = []byte("tampered!!")
+	fake.mu.Unlock()
+
+	dstDir := t.TempDir()
+	if _, _, err := s.Restore(ctx, prefix, dstDir); err == nil {
+		t.Fatal("Restore of a checksum-mismatched object should fail")
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "snapfile")); !os.IsNotExist(err) {
+		t.Fatalf("corrupt restore left a file on disk (stat err = %v), want it absent", err)
+	}
+	// No temp file left behind either.
+	if _, err := os.Stat(filepath.Join(dstDir, "snapfile.restore.tmp")); !os.IsNotExist(err) {
+		t.Fatalf("corrupt restore left a temp file (stat err = %v)", err)
+	}
+}
+
+// TestDeleteArtifactRemovesMetaFirst proves DeleteArtifact removes meta.json
+// first (making the artifact invisible) and then its files.
+func TestDeleteArtifactRemovesMetaFirst(t *testing.T) {
+	s, fake := newTestStore(t)
+	ctx := context.Background()
+	srcDir, names := writeLocalArtifact(t, map[string]string{"snapfile": "a", "memfile": "b"})
+	prefix := "serving/hot-image-demo/serv-1"
+	if _, _, err := s.Export(ctx, prefix, srcDir, names, 0, 1); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	if err := s.DeleteArtifact(ctx, prefix); err != nil {
+		t.Fatalf("DeleteArtifact: %v", err)
+	}
+	// Everything is gone.
+	if fake.has("/embervm/" + prefix + "/" + metaObject) {
+		t.Fatal("meta.json still present after DeleteArtifact")
+	}
+	for _, name := range names {
+		if fake.has("/embervm/" + prefix + "/" + name) {
+			t.Fatalf("file %q still present after DeleteArtifact", name)
+		}
+	}
+	// Idempotent: deleting an already-absent artifact is a no-op success.
+	if err := s.DeleteArtifact(ctx, prefix); err != nil {
+		t.Fatalf("second DeleteArtifact should be nil, got %v", err)
+	}
+}
+
+// TestPresentPartialWriteInvisible proves that files present WITHOUT a meta.json
+// read as not-present (partial-write invisibility).
+func TestPresentPartialWriteInvisible(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	prefix := "stateful/scratch-postgres/state-partial"
+	// Write a file object but NOT the marker (a partial/interrupted export).
+	body := []byte("orphan-bytes")
+	if err := s.Put(ctx, prefix+"/snapfile", strings.NewReader(string(body)), int64(len(body))); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	present, gen, err := s.Present(ctx, prefix)
+	if err != nil {
+		t.Fatalf("Present: %v", err)
+	}
+	if present {
+		t.Fatal("a prefix with files but no meta.json must read as NOT present")
+	}
+	if gen != 0 {
+		t.Fatalf("Present generation = %d, want 0 for absent", gen)
+	}
+}
+
+// TestPresentReportsGeneration proves Present returns the marker's generation
+// for a complete volume artifact.
+func TestPresentReportsGeneration(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	srcDir, names := writeLocalArtifact(t, map[string]string{"vol.img": "volbytes", "gen": "12"})
+	prefix := "volume/scratch-postgres"
+	if _, _, err := s.Export(ctx, prefix, srcDir, names, 12, 1); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	present, gen, err := s.Present(ctx, prefix)
+	if err != nil {
+		t.Fatalf("Present: %v", err)
+	}
+	if !present || gen != 12 {
+		t.Fatalf("Present = (%v, %d), want (true, 12)", present, gen)
+	}
+}
+
+// TestReachable proves the reachability probe answers true against a live
+// endpoint and false against a dead one.
+func TestReachable(t *testing.T) {
+	s, _ := newTestStore(t)
+	if !s.Reachable(context.Background()) {
+		t.Fatal("Reachable should be true against a live fake store")
+	}
+	dead := New("http://127.0.0.1:1", "embervm") // nothing listens on port 1
+	if dead.Reachable(context.Background()) {
+		t.Fatal("Reachable should be false against a dead endpoint")
+	}
+	var nilStore *Store
+	if nilStore.Reachable(context.Background()) {
+		t.Fatal("a nil (disabled) store is never reachable")
+	}
+}


### PR DESCRIPTION
## R6 Continuity, PR-4 (Tasks 6 + 7)

Off-node durability: banked artifacts now move to a configurable S3-API object
store (SeaweedFS first backend) as async write-back after bank commit, with
restore-on-miss available to the wake path (the CP driver lands in PR-5).

### Task 6: object-store client (`noded/store/`)
- Stdlib `net/http` S3-API client (no aws-sdk, no SigV4): Put/Get/Head/Delete plus
  artifact-level Export/Restore/DeleteArtifact/Present/Reachable over the Fork-3
  key prefix `<kind>/<workload>/<ref>`. `meta.json` is the completeness marker,
  written LAST and read FIRST; SHA-256 recorded in meta and verified on restore.
- Config: `EMBERVM_NODED_STORE_ENDPOINT` (default the SeaweedFS URL) /
  `EMBERVM_NODED_STORE_BUCKET` (default `embervm`); empty endpoint disables.
- Chart: `noded.store.endpoint` / `noded.store.bucket`.

### Task 7: verbs + async export (`noded/server/store.go`)
- ExportArtifact / RestoreArtifact / EvictArtifact handlers over a typed
  `artifactStore` seam (tests inject a fake, no network). A nil store leaves the
  verbs refusing FAILED_PRECONDITION and every export a no-op.
- Async export-after-commit: a bounded worker pool (fire-and-forget, drops on a
  full queue) enqueues an export after each session/serving/stateful/group-set bank
  and volume generation change; a startup reconcile sweep re-enqueues any artifact
  whose store copy is missing or stale.
- NodeStatus `store_reachable` (periodic probe) and the per-artifact `exported`
  flags / `Volume.exported_generation` populated from the exported cache.
- Volume eviction refuses while its generation still pairs with a banked bundle
  (standing decision 8).

Store + config packages build/test clean locally; server/cmd verified by reading
(proto codegen is Bazel-only). All existing verbs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)