### PR TITLE
fix(embervm): R6 PR-6 bound wake workers and let adoption recover stuck wakes

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.105
+version: 0.1.106

--- a/projects/embervm/control/lib/embervm/group_wake_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_wake_manager.ex
@@ -92,6 +92,21 @@ defmodule Embervm.GroupWakeManager do
   @default_wake_window_ms 60_000
   @default_park_cap 16
 
+  # Wake-worker bound (R6, Task 10). A wedged member boot (the R5 drill: a member
+  # that never opens its port, chaining `:infinity` waits) must NOT pin `waking`
+  # forever, starving `adopt_one` and overflowing the park. So the WORKER is bounded
+  # by the workload's `wakeTimeoutSeconds` plus this margin: on the bound the wake is
+  # FAILED (single-flight released, parked callers erred/re-parked, the banked set
+  # left re-wakeable), NOT held. The parked caller's own `:infinity` GenServer.call is
+  # untouched: a caller waits as long as it chooses, the bound is on the wake it waits
+  # behind. The margin covers the legitimate relight/fresh sequence beyond the guest's
+  # own readiness budget (network setup, the create fallback). Default group
+  # wakeTimeoutSeconds is 120 (scratch-k8s 180), so the bound defaults to ~135s.
+  @default_wake_timeout_margin_ms 15_000
+  # Fallback wakeTimeoutSeconds when the catalog entry carries none (matches
+  # WorkloadWatcher's @group_defaults.wake_timeout_seconds).
+  @default_wake_timeout_seconds 120
+
   # -- Client API ------------------------------------------------------------
 
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -155,11 +170,24 @@ defmodule Embervm.GroupWakeManager do
       pod_ip: Keyword.get(opts, :pod_ip, group_default(:pod_ip, nil)),
       # workload -> [{from, principal}] parked behind an in-flight wake (single-flight).
       waking: %{},
+      # workload -> monotonic ms the in-flight wake started (Task 10). Feeds the
+      # adoption self-recovery: a workload still `waking` past 2 * wakeTimeoutSeconds
+      # is a wedged wake whose worker never reported, recovered as a casualty rather
+      # than skipped forever.
+      wake_started: %{},
       # principal -> [wake timestamps within the window] (sliding-window rate limit).
       wake_events: %{},
       wake_max: Keyword.get(opts, :wake_max, @default_wake_max),
       wake_window_ms: Keyword.get(opts, :wake_window_ms, @default_wake_window_ms),
       park_cap: Keyword.get(opts, :park_cap, @default_park_cap),
+      # Wake-worker bound (Task 10). Derived per-wake from the workload's
+      # wakeTimeoutSeconds + this margin, unless `wake_bound_ms` overrides it outright
+      # (tests inject a tiny bound so a never-ready wake fails deterministically). The
+      # monotonic clock the bound + the adoption stuck-check read is injectable too
+      # (tests drive it with a fake counter).
+      wake_timeout_margin_ms: Keyword.get(opts, :wake_timeout_margin_ms, @default_wake_timeout_margin_ms),
+      wake_bound_ms: Keyword.get(opts, :wake_bound_ms, nil),
+      mono_clock: Keyword.get(opts, :mono_clock, &default_mono/0),
       reconcile_interval_ms: Keyword.get(opts, :reconcile_interval_ms, 0)
     }
 
@@ -190,6 +218,21 @@ defmodule Embervm.GroupWakeManager do
   @impl true
   def handle_info({:wake_done, workload, outcome}, state) do
     {:noreply, finish_wake(state, workload, outcome)}
+  end
+
+  # The wake-worker bound (Task 10) elapsed. If the wake for THIS workload is still
+  # in flight (the worker never reported a {:wake_done}, the wedged-boot case), fail
+  # it: finish_wake releases single-flight and errs the parked callers, leaving the
+  # banked set re-wakeable. A stale timer for a wake that already finished (or a newer
+  # wake replaced it) is a no-op: `waking` no longer has the workload, so finish_wake
+  # pops an empty waiter list and touches nothing.
+  def handle_info({:wake_timeout, workload}, state) do
+    if Map.has_key?(state.waking, workload) do
+      Logger.warning("embervm group wake timed out at bound", workload: workload)
+      {:noreply, finish_wake(state, workload, {:error, {:wake_failed, :wake_timeout}})}
+    else
+      {:noreply, state}
+    end
   end
 
   def handle_info(:reconcile, state) do
@@ -242,9 +285,31 @@ defmodule Embervm.GroupWakeManager do
 
     if length(waiters) >= state.park_cap do
       audit_denial(principal, workload, :park_full)
+      log_park_full(state, workload, length(waiters))
       {:reply, {:error, {:park_full, "parked-connection cap exceeded for workload"}}, state}
     else
       {:noreply, %{state | waking: Map.put(state.waking, workload, waiters ++ [{from, principal}])}}
+    end
+  end
+
+  # Log a park overflow as STRUCTURED warning (Task 10) so the Task 11 alert can match
+  # `park_full` with the oldest-waiter age: a park filling up means the in-flight wake
+  # is not draining, the exact R5 symptom. The oldest-waiter age is how long the wake
+  # this park sits behind has been in flight (mono now - wake_started); 0 when no start
+  # was recorded. The alert is NOT implemented here (PR-7); this only emits the signal.
+  defp log_park_full(state, workload, depth) do
+    Logger.warning("embervm group park_full",
+      event: :park_full,
+      workload: workload,
+      park_depth: depth,
+      oldest_waiter_age_ms: oldest_waiter_age_ms(state, workload)
+    )
+  end
+
+  defp oldest_waiter_age_ms(state, workload) do
+    case Map.get(state.wake_started, workload) do
+      started when is_integer(started) -> max(state.mono_clock.() - started, 0)
+      _ -> 0
     end
   end
 
@@ -260,8 +325,35 @@ defmodule Embervm.GroupWakeManager do
     plan = plan_wake(state, workload)
 
     spawn_wake(owner, workload, fn -> run_wake(state, workload, plan) end)
-    state
+    # Stamp the wake's start (for the adoption stuck-check) and arm the wake-worker
+    # bound: if the worker has not reported a {:wake_done} by then, {:wake_timeout}
+    # fails the wake so single-flight releases (Task 10).
+    schedule_wake_timeout(workload, wake_bound_ms(state, workload))
+    %{state | wake_started: Map.put(state.wake_started, workload, state.mono_clock.())}
   end
+
+  # The per-wake worker bound in ms: the explicit `wake_bound_ms` override (tests) or
+  # the workload's wakeTimeoutSeconds + margin.
+  defp wake_bound_ms(%{wake_bound_ms: ms}, _workload) when is_integer(ms) and ms > 0, do: ms
+
+  defp wake_bound_ms(state, workload) do
+    wake_timeout_seconds(state, workload) * 1_000 + state.wake_timeout_margin_ms
+  end
+
+  # The workload's wakeTimeoutSeconds from the catalog (group config), defaulting to
+  # @default_wake_timeout_seconds when the entry carries none.
+  defp wake_timeout_seconds(state, workload) do
+    case WorkloadCatalog.fetch(state.catalog_table, workload) do
+      {:ok, %{group: %{wake_timeout_seconds: secs}}} when is_integer(secs) and secs > 0 -> secs
+      _ -> @default_wake_timeout_seconds
+    end
+  end
+
+  defp schedule_wake_timeout(workload, bound_ms) when is_integer(bound_ms) and bound_ms > 0 do
+    Process.send_after(self(), {:wake_timeout, workload}, bound_ms)
+  end
+
+  defp schedule_wake_timeout(_workload, _bound_ms), do: :ok
 
   defp spawn_wake(owner, workload, fun) do
     spawn(fn ->
@@ -351,7 +443,7 @@ defmodule Embervm.GroupWakeManager do
 
   defp pop_waiters(state, workload) do
     waiters = Map.get(state.waking, workload, [])
-    {waiters, %{state | waking: Map.delete(state.waking, workload)}}
+    {waiters, %{state | waking: Map.delete(state.waking, workload), wake_started: Map.delete(state.wake_started, workload)}}
   end
 
   defp reply_all(waiters, reply) do
@@ -422,7 +514,24 @@ defmodule Embervm.GroupWakeManager do
 
   defp adopt_one(state, instance, live_members, bundle_sets) do
     cond do
-      # An in-flight wake owns the workload's transition; never touch it.
+      # A wake stuck waking past 2 * wakeTimeoutSeconds (Task 10): the worker never
+      # reported and the {:wake_timeout} timer is lost (a CP restart drops the timer
+      # but the projection is rebuilt, so `waking` is empty on boot; this covers the
+      # in-process wedge a timer somehow missed). Recover it as a casualty: drop the
+      # stale waking bookkeeping, then fall through to the normal casualty/heal logic
+      # below rather than skipping it forever. A wake within the bound still OWNS its
+      # transition and is skipped (the next case).
+      Map.has_key?(state.waking, instance.workload) and wake_stuck?(state, instance.workload) ->
+        Logger.warning("embervm group wake stuck past bound, recovering as casualty",
+          workload: instance.workload,
+          instance_id: instance.instance_id
+        )
+
+        state = clear_stuck_wake(state, instance.workload)
+        adopt_one(state, instance, live_members, bundle_sets)
+
+      # An in-flight wake (within the bound) owns the workload's transition; never
+      # touch it.
       Map.has_key?(state.waking, instance.workload) ->
         state
 
@@ -551,6 +660,33 @@ defmodule Embervm.GroupWakeManager do
 
   defp node_reporting?(_state, _node_id), do: false
 
+  # -- stuck-wake recovery (Task 10) -----------------------------------------
+
+  # A workload is stuck iff its in-flight wake has been waking past 2 *
+  # wakeTimeoutSeconds. The bound itself (start_wake's {:wake_timeout} timer) is the
+  # primary release; this is the backstop for a wedge the timer missed (or a CP that
+  # somehow rebuilt `waking`). No start timestamp recorded (never happens on the wake
+  # path) reads as NOT stuck, so adoption defers to the timer.
+  defp wake_stuck?(state, workload) do
+    case Map.get(state.wake_started, workload) do
+      started when is_integer(started) ->
+        state.mono_clock.() - started >= 2 * wake_timeout_seconds(state, workload) * 1_000
+
+      _ ->
+        false
+    end
+  end
+
+  # Drop the stale waking bookkeeping for a stuck wake and err its parked callers so
+  # they stop blocking (their own retry re-enters the wake path once the workload is
+  # recovered to a re-wakeable row). Single-flight is released; the reconcile then
+  # heals the workload's state through the normal casualty/heal path.
+  defp clear_stuck_wake(state, workload) do
+    {waiters, state} = pop_waiters(state, workload)
+    reply_all(waiters, {:error, {:wake_failed, :wake_stuck}})
+    state
+  end
+
   # -- wake-rate limit -------------------------------------------------------
 
   defp wake_allowed?(%{wake_max: max}, _principal) when not is_integer(max) or max <= 0, do: true
@@ -637,4 +773,8 @@ defmodule Embervm.GroupWakeManager do
   defp mask_for(prefix), do: band(bsl(0xFFFFFFFF, 32 - prefix), 0xFFFFFFFF)
 
   defp default_clock, do: System.system_time(:millisecond)
+
+  # Monotonic ms for the wake-worker bound + the adoption stuck-check (never wall
+  # time: the bound is a duration, immune to clock steps). Tests inject a fake.
+  defp default_mono, do: System.monotonic_time(:millisecond)
 end

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -164,6 +164,20 @@ defmodule Embervm.StatefulManager do
   # burst is already anomalous rather than ordinary multi-tenant fan-in.
   @default_park_cap 16
 
+  # Wake-worker bound (R6, Task 10). A wedged boot (a guest that never opens its
+  # port, chaining `:infinity` waits) must NOT pin `waking` forever, starving
+  # `adopt_one` and overflowing the park (the R5 drill symptom). So the WORKER is
+  # bounded by the workload's `wakeTimeoutSeconds` plus this margin: on the bound the
+  # wake FAILS (single-flight released, parked callers erred, the banked bundle left
+  # re-wakeable via adoption), NOT held. The parked caller's own `:infinity`
+  # GenServer.call is untouched: a caller waits as long as it chooses, the bound is on
+  # the wake it waits behind. Default stateful wakeTimeoutSeconds is 60, so the bound
+  # defaults to ~75s.
+  @default_wake_timeout_margin_ms 15_000
+  # Fallback wakeTimeoutSeconds when the catalog entry carries none (matches
+  # WorkloadWatcher's @stateful_defaults.wake_timeout_seconds).
+  @default_wake_timeout_seconds 60
+
   # -- Client API ------------------------------------------------------------
 
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -297,6 +311,17 @@ defmodule Embervm.StatefulManager do
       wake_max: Keyword.get(opts, :wake_max, @default_wake_max),
       wake_window_ms: Keyword.get(opts, :wake_window_ms, @default_wake_window_ms),
       park_cap: Keyword.get(opts, :park_cap, @default_park_cap),
+      # workload -> monotonic ms the in-flight wake started (Task 10). Feeds the
+      # adoption self-recovery + the park_full oldest-waiter age: a workload still
+      # waking past 2 * wakeTimeoutSeconds is a wedged wake whose worker never
+      # reported, recovered rather than skipped forever.
+      wake_started: %{},
+      # Wake-worker bound (Task 10): derived per-wake from wakeTimeoutSeconds + this
+      # margin unless `wake_bound_ms` overrides it (tests inject a tiny bound). The
+      # monotonic clock the bound + the stuck-check read is injectable too.
+      wake_timeout_margin_ms: Keyword.get(opts, :wake_timeout_margin_ms, @default_wake_timeout_margin_ms),
+      wake_bound_ms: Keyword.get(opts, :wake_bound_ms, nil),
+      mono_clock: Keyword.get(opts, :mono_clock, &default_mono/0),
       # The adoption reconcile cadence (0 = off, tests drive reconcile/1).
       reconcile_interval_ms: Keyword.get(opts, :reconcile_interval_ms, 0)
     }
@@ -343,6 +368,22 @@ defmodule Embervm.StatefulManager do
   @impl true
   def handle_info({:wake_done, workload, outcome}, state) do
     {:noreply, finish_wake(state, workload, outcome)}
+  end
+
+  # The wake-worker bound (Task 10) elapsed. If the wake for THIS workload is still in
+  # flight (the worker never reported a {:wake_done}, the wedged-boot case), fail it:
+  # finish_wake releases single-flight and errs the parked callers, leaving the banked
+  # bundle re-wakeable (adoption heals a stranded :relighting mark back to :banked on
+  # the next reconcile). A stale timer for a wake that already finished (or a newer
+  # wake replaced it) is a no-op: `waking` no longer has the workload, so finish_wake
+  # pops an empty waiter list and touches nothing.
+  def handle_info({:wake_timeout, workload}, state) do
+    if Map.has_key?(state.waking, workload) do
+      Logger.warning("embervm stateful wake timed out at bound", workload: workload)
+      {:noreply, finish_wake(state, workload, {:error, {:wake_timeout, workload}})}
+    else
+      {:noreply, state}
+    end
   end
 
   def handle_info(:reconcile, state) do
@@ -458,6 +499,7 @@ defmodule Embervm.StatefulManager do
 
     if length(waiters) >= state.park_cap do
       audit_denial(state, principal, workload, :park_full)
+      log_park_full(state, workload, length(waiters))
       {:reply, {:error, {:park_full, "parked-connection cap exceeded for workload"}}, state}
     else
       state =
@@ -495,10 +537,33 @@ defmodule Embervm.StatefulManager do
 
     if length(waiters) >= state.park_cap do
       audit_denial(state, principal, workload, :park_full)
+      log_park_full(state, workload, length(waiters))
       {:reply, {:error, {:park_full, "parked-connection cap exceeded for workload"}}, state}
     else
       state = %{state | waking: Map.put(state.waking, workload, waiters ++ [{from, principal}])}
       {:noreply, state}
+    end
+  end
+
+  # Log a park overflow as STRUCTURED warning (Task 10) so the Task 11 alert can match
+  # `park_full` with the oldest-waiter age: a park filling up means the in-flight wake
+  # is not draining, the exact R5 symptom. The oldest-waiter age is how long the wake
+  # this park sits behind has been in flight (mono now - wake_started); 0 when no start
+  # was recorded (e.g. a park_during_checkpoint before a wake was armed). The alert is
+  # NOT implemented here (PR-7); this only emits the signal.
+  defp log_park_full(state, workload, depth) do
+    Logger.warning("embervm stateful park_full",
+      event: :park_full,
+      workload: workload,
+      park_depth: depth,
+      oldest_waiter_age_ms: oldest_waiter_age_ms(state, workload)
+    )
+  end
+
+  defp oldest_waiter_age_ms(state, workload) do
+    case Map.get(state.wake_started, workload) do
+      started when is_integer(started) -> max(state.mono_clock.() - started, 0)
+      _ -> 0
     end
   end
 
@@ -538,6 +603,12 @@ defmodule Embervm.StatefulManager do
     plan = plan_wake(state, workload)
     cold = match?({:cold, _, _, _, _}, plan)
     state = stamp_wake_trace(state, workload, %{wake_start: wake_start, cold: cold})
+
+    # Stamp the wake's start (for the adoption stuck-check + park_full age) and arm the
+    # wake-worker bound: if the worker has not reported a {:wake_done} by then,
+    # {:wake_timeout} fails the wake so single-flight releases (Task 10).
+    schedule_wake_timeout(workload, wake_bound_ms(state, workload))
+    state = %{state | wake_started: Map.put(state.wake_started, workload, state.mono_clock.())}
 
     case plan do
       {:relight, instance, node_id, snapshot_ref} ->
@@ -585,6 +656,31 @@ defmodule Embervm.StatefulManager do
       send(owner, {:wake_done, workload, outcome})
     end)
   end
+
+  # -- wake-worker bound (Task 10) --------------------------------------------
+
+  # The per-wake worker bound in ms: the explicit `wake_bound_ms` override (tests) or
+  # the workload's wakeTimeoutSeconds + margin.
+  defp wake_bound_ms(%{wake_bound_ms: ms}, _workload) when is_integer(ms) and ms > 0, do: ms
+
+  defp wake_bound_ms(state, workload) do
+    wake_timeout_seconds(state, workload) * 1_000 + state.wake_timeout_margin_ms
+  end
+
+  # The workload's wakeTimeoutSeconds from the catalog (stateful config), defaulting to
+  # @default_wake_timeout_seconds when the entry carries none.
+  defp wake_timeout_seconds(state, workload) do
+    case WorkloadCatalog.fetch(state.catalog_table, workload) do
+      {:ok, %{stateful: %{wake_timeout_seconds: secs}}} when is_integer(secs) and secs > 0 -> secs
+      _ -> @default_wake_timeout_seconds
+    end
+  end
+
+  defp schedule_wake_timeout(workload, bound_ms) when is_integer(bound_ms) and bound_ms > 0 do
+    Process.send_after(self(), {:wake_timeout, workload}, bound_ms)
+  end
+
+  defp schedule_wake_timeout(_workload, _bound_ms), do: :ok
 
   # -- placement (relight vs cold, volume-anchored) ---------------------------
 
@@ -1083,7 +1179,7 @@ defmodule Embervm.StatefulManager do
 
   defp pop_waiters(state, workload) do
     waiters = Map.get(state.waking, workload, [])
-    {waiters, %{state | waking: Map.delete(state.waking, workload)}}
+    {waiters, %{state | waking: Map.delete(state.waking, workload), wake_started: Map.delete(state.wake_started, workload)}}
   end
 
   defp reply_all(waiters, reply) do
@@ -1348,8 +1444,24 @@ defmodule Embervm.StatefulManager do
 
   defp adopt_one(state, instance, live_vms, bundles) do
     cond do
-      # An in-flight wake for the workload owns its transition; a periodic
-      # reconcile must not touch it (the wake's own finish_wake will land, and
+      # A wake stuck waking past 2 * wakeTimeoutSeconds (Task 10): the worker never
+      # reported and the {:wake_timeout} timer is lost (the in-process wedge a timer
+      # somehow missed). Recover it: drop the stale waking bookkeeping + err the parked
+      # callers, then fall through to the normal live/bundle/vanished logic below (a
+      # stranded :relighting mark heals back to :banked when the node still reports the
+      # bundle) rather than skipping it forever. A wake within the bound still OWNS its
+      # transition and is skipped (the next case).
+      Map.has_key?(state.waking, instance.workload) and wake_stuck?(state, instance.workload) ->
+        Logger.warning("embervm stateful wake stuck past bound, recovering",
+          workload: instance.workload,
+          instance_id: instance.instance_id
+        )
+
+        state = clear_stuck_wake(state, instance.workload)
+        adopt_one(state, instance, live_vms, bundles)
+
+      # An in-flight wake (within the bound) for the workload owns its transition; a
+      # periodic reconcile must not touch it (the wake's own finish_wake will land, and
       # the NEXT reconcile adopts the result cleanly). On boot `waking` is
       # empty, so boot adoption still fully heals every limbo.
       Map.has_key?(state.waking, instance.workload) ->
@@ -1446,6 +1558,33 @@ defmodule Embervm.StatefulManager do
   end
 
   defp node_reporting?(_state, _node_id), do: false
+
+  # -- stuck-wake recovery (Task 10) -----------------------------------------
+
+  # A workload is stuck iff its in-flight wake has been waking past 2 *
+  # wakeTimeoutSeconds. The bound itself (start_wake's {:wake_timeout} timer) is the
+  # primary release; this is the backstop for a wedge the timer missed. No start
+  # timestamp (never happens on the wake path) reads as NOT stuck.
+  defp wake_stuck?(state, workload) do
+    case Map.get(state.wake_started, workload) do
+      started when is_integer(started) ->
+        state.mono_clock.() - started >= 2 * wake_timeout_seconds(state, workload) * 1_000
+
+      _ ->
+        false
+    end
+  end
+
+  # Drop the stale waking bookkeeping for a stuck wake and err its parked callers so
+  # they stop blocking (their own retry re-enters the wake path once the workload is
+  # recovered). Single-flight is released; the reconcile then heals the workload's
+  # state through the normal live/bundle/vanished path.
+  defp clear_stuck_wake(state, workload) do
+    {waiters, state} = pop_waiters(state, workload)
+    {_trace, state} = pop_wake_trace(state, workload)
+    reply_all(waiters, {:error, {:wake_failed, :wake_stuck}})
+    state
+  end
 
   # Fold every reporting node's `volumes` facts into the StatefulStore's live
   # volume ledger (generation + allocated_bytes), so pair-validity always
@@ -1604,4 +1743,8 @@ defmodule Embervm.StatefulManager do
   defp schedule(_msg, _interval), do: :ok
 
   defp default_clock, do: System.system_time(:millisecond)
+
+  # Monotonic ms for the wake-worker bound + the adoption stuck-check (never wall
+  # time: the bound is a duration, immune to clock steps). Tests inject a fake.
+  defp default_mono, do: System.monotonic_time(:millisecond)
 end

--- a/projects/embervm/control/test/embervm/group_wake_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_wake_manager_test.exs
@@ -125,7 +125,11 @@ defmodule Embervm.GroupWakeManagerTest do
 
     WorkloadCatalog.upsert(cat_table, "grp-a", %{
       class: "composite",
-      group: %{entry: %{member: "leader", port: 8080, listen_port: 5410}}
+      group:
+        Map.merge(
+          %{entry: %{member: "leader", port: 8080, listen_port: 5410}},
+          Keyword.get(opts, :group_extra, %{})
+        )
     })
 
     sup_state =
@@ -150,8 +154,8 @@ defmodule Embervm.GroupWakeManagerTest do
     # fixed id (:fake_supervisor) but registered under the module name the fake resolves.
     _ = start_supervised!(%{id: :fake_supervisor, start: {Agent, :start_link, [fn -> sup_state end, [name: FakeSupervisor]]}})
 
-    {:ok, mgr} =
-      GroupWakeManager.start_link(
+    mgr_opts =
+      [
         name: nil,
         store: store,
         publisher: pub,
@@ -167,7 +171,9 @@ defmodule Embervm.GroupWakeManagerTest do
         pod_ip: "10.0.0.9",
         clock: clock,
         reconcile_interval_ms: 0
-      )
+      ] ++ Keyword.take(opts, [:wake_bound_ms, :mono_clock])
+
+    {:ok, mgr} = GroupWakeManager.start_link(mgr_opts)
 
     %{mgr: mgr, store: store, pub: pub, cap_table: cap_table, cat_table: cat_table, op_log: op_log}
   end
@@ -450,5 +456,68 @@ defmodule Embervm.GroupWakeManagerTest do
     assert {:ok, %{ip: "10.0.0.9", port: 30_010}} = GroupWakeManager.wake(ctx.mgr, "grp-a", "system:group:grp-a")
     {_c, wakes, _} = sup_counts()
     assert wakes == 0
+  end
+
+  # -- wake-worker bound + adoption self-recovery (Task 10) ------------------
+
+  test "a never-ready member fails the group wake at the bound, releasing single-flight" do
+    # The fake wake_group blocks for 3s (a wedged member boot that never opens its
+    # port, the R5 `:infinity`-chain symptom); the wake WORKER is bounded to 40ms, so
+    # {:wake_timeout} fails the wake before the worker ever reports. The parked caller
+    # gets a wake_failed error (NOT a forever-hang), and single-flight releases so a
+    # later connection can retry.
+    ctx = start_stack(instance_id: "g-1", latency_ms: 3_000, fail: true, wake_bound_ms: 40)
+    _ = seed_banked(ctx, "g-1")
+
+    assert {:error, {:wake_failed, :wake_timeout}} =
+             GroupWakeManager.wake(ctx.mgr, "grp-a", "system:group:grp-a")
+
+    # Single-flight released: the banked instance is still re-wakeable (the fake never
+    # published, so it stayed :banked), and a reconcile leaves it banked (re-wakeable),
+    # not skipped forever.
+    :ok = GroupWakeManager.reconcile(ctx.mgr)
+    {:ok, inst} = GroupStore.get(ctx.store, "g-1")
+    assert inst.state == :banked
+  end
+
+  test "adoption recovers a workload stuck waking past 2 * wakeTimeoutSeconds" do
+    # Directly exercise the adoption self-recovery: an in-flight wake whose worker
+    # never reports and whose {:wake_timeout} timer is (modeled as) lost. wake_bound_ms
+    # is set huge so the timer never fires within the test; the injected mono_clock
+    # jumps past 2 * wakeTimeoutSeconds (1s here) between the wake stamp and the
+    # reconcile, so wake_stuck? trips and adoption recovers the workload instead of
+    # skipping it. The parked caller is erred out of its :infinity wait.
+    {:ok, mono} = Agent.start_link(fn -> 0 end)
+    mono_clock = fn -> Agent.get(mono, & &1) end
+
+    ctx =
+      start_stack(
+        instance_id: "g-1",
+        latency_ms: 3_000,
+        fail: true,
+        wake_bound_ms: 10 * 60_000,
+        mono_clock: mono_clock,
+        group_extra: %{wake_timeout_seconds: 1}
+      )
+
+    _ = seed_banked(ctx, "g-1")
+
+    # Kick a wake that hangs (worker blocked in the fake for 60s). It stamps
+    # wake_started at mono 0 and parks the caller.
+    caller = Task.async(fn -> GroupWakeManager.wake(ctx.mgr, "grp-a", "system:group:grp-a") end)
+    # Let the wake register as in-flight before advancing the clock.
+    Process.sleep(50)
+
+    # Advance mono past 2 * wakeTimeoutSeconds (2 * 1s = 2000ms).
+    Agent.update(mono, fn _ -> 5_000 end)
+
+    # The reconcile now sees the wake as stuck and recovers it (erra the caller,
+    # releases single-flight, leaves the instance re-wakeable).
+    :ok = GroupWakeManager.reconcile(ctx.mgr)
+
+    assert {:error, {:wake_failed, :wake_stuck}} = Task.await(caller, 5_000)
+
+    {:ok, inst} = GroupStore.get(ctx.store, "g-1")
+    assert inst.state == :banked
   end
 end

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -85,7 +85,7 @@ defmodule Embervm.StatefulManagerTest do
         get_secret_fun: get_secret_fun,
         reconcile_interval_ms: 0,
         id_fun: id_seq(suffix)
-      ] ++ Keyword.take(opts, [:wake_max, :wake_window_ms, :park_cap])
+      ] ++ Keyword.take(opts, [:wake_max, :wake_window_ms, :park_cap, :wake_bound_ms, :mono_clock, :wake_timeout_margin_ms])
 
     {:ok, mgr} = StatefulManager.start_link(mgr_opts)
 
@@ -918,5 +918,84 @@ defmodule Embervm.StatefulManagerTest do
     assert %{destroyed: 1, evicted: 0} = StatefulManager.destroy_instance(ctx.mgr, "wl-a")
     assert {:ok, %{deleted: true}} = StatefulManager.delete_volume(ctx.mgr, "wl-a")
     assert StatefulStore.get_volume(ctx.store, "wl-a") == nil
+  end
+
+  # -- wake-worker bound + adoption self-recovery (Task 10) --------------------
+
+  test "a wedged wake worker fails at the bound, releasing single-flight, and adoption heals back to banked" do
+    # A relight whose StartStateful never returns (the guest never opens its port,
+    # the R5 `:infinity`-chain symptom): the fake sleeps 3s, but the wake WORKER is
+    # bounded to 40ms, so {:wake_timeout} fails the wake before the worker reports.
+    # The parked caller gets a wake_failed error (NOT a forever-hang). The instance is
+    # stranded in :relighting; the next reconcile heals it back to :banked (the node
+    # still reports the bundle + matching volume), so it is re-wakeable.
+    hang_fun = fn _ch, _req ->
+      Process.sleep(3_000)
+      {:error, :never_ready}
+    end
+
+    ctx = start_stack(start_stateful_fun: hang_fun, wake_bound_ms: 40)
+    stateful_workload(ctx, "wl-a")
+    stateful_node(ctx, "node-4",
+      stateful_bundles: [%{snapshot_ref: "stateful/stf-banked", workload: "wl-a", generation: 3, size_bytes: 10, created_at_unix_ms: 1}],
+      volumes: [%{workload: "wl-a", node_id: "node-4", generation: 3, size_bytes: 100, allocated_bytes: 10}]
+    )
+
+    seed_banked_with_pair(ctx, "stf-banked", "node-4", 3, 3)
+    assert StatefulStore.pair_valid?(ctx.store, "wl-a")
+
+    assert {:error, {:wake_failed, {:wake_timeout, "wl-a"}}} =
+             StatefulManager.wake(ctx.mgr, "wl-a", "p")
+
+    # Single-flight released + the stranded relight heals back to banked (re-wakeable).
+    :ok = StatefulManager.reconcile(ctx.mgr)
+    {:ok, healed} = StatefulStore.get(ctx.store, "stf-banked")
+    assert healed.state == :banked
+    assert StatefulStore.pair_valid?(ctx.store, "wl-a")
+  end
+
+  test "adoption recovers a workload stuck waking past 2 * wakeTimeoutSeconds" do
+    # Directly exercise the adoption self-recovery: an in-flight wake whose worker
+    # never reports and whose {:wake_timeout} timer is (modeled as) lost. wake_bound_ms
+    # is huge so the timer never fires within the test; the injected mono_clock jumps
+    # past 2 * wakeTimeoutSeconds (60s here, so 120s) between the wake stamp and the
+    # reconcile, so wake_stuck? trips and adoption recovers the workload instead of
+    # skipping it. The parked caller is erred out of its :infinity wait.
+    {:ok, mono} = Agent.start_link(fn -> 0 end)
+    mono_clock = fn -> Agent.get(mono, & &1) end
+
+    hang_fun = fn _ch, _req ->
+      Process.sleep(3_000)
+      {:error, :never_ready}
+    end
+
+    ctx =
+      start_stack(
+        start_stateful_fun: hang_fun,
+        wake_bound_ms: 10 * 60_000,
+        mono_clock: mono_clock
+      )
+
+    stateful_workload(ctx, "wl-a")
+    stateful_node(ctx, "node-4",
+      stateful_bundles: [%{snapshot_ref: "stateful/stf-banked", workload: "wl-a", generation: 3, size_bytes: 10, created_at_unix_ms: 1}],
+      volumes: [%{workload: "wl-a", node_id: "node-4", generation: 3, size_bytes: 100, allocated_bytes: 10}]
+    )
+
+    seed_banked_with_pair(ctx, "stf-banked", "node-4", 3, 3)
+
+    caller = Task.async(fn -> StatefulManager.wake(ctx.mgr, "wl-a", "p") end)
+    # Let the wake register as in-flight (mark :relighting, stamp wake_started at 0).
+    Process.sleep(50)
+
+    # Advance mono past 2 * wakeTimeoutSeconds (2 * 60s = 120_000ms).
+    Agent.update(mono, fn _ -> 200_000 end)
+
+    :ok = StatefulManager.reconcile(ctx.mgr)
+
+    assert {:error, {:wake_failed, :wake_stuck}} = Task.await(caller, 5_000)
+
+    {:ok, healed} = StatefulStore.get(ctx.store, "stf-banked")
+    assert healed.state == :banked
   end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.105
+      targetRevision: 0.1.106
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## R6 Continuity, PR-6 (Task 10)

Closes the R5-drill resilience gaps: a wedged boot no longer holds `waking`
forever (the `:infinity` chains starved `adopt_one` and overflowed the park).

### Changes
- **group_wake_manager / stateful_manager**: when a wake starts, arm a
  `{:wake_timeout, workload}` timer at `wakeTimeoutSeconds * 1000 + margin`
  (margin default 15s). On fire, if the workload is still `waking`, route through
  the existing `finish_wake` failure path: pop waiters (release single-flight), err
  the parked callers. The parked caller's own `:infinity` GenServer.call is
  untouched (the bound is on the WORKER, not the caller).
- **Adoption self-recovery**: `adopt_one` previously skipped any `waking` workload
  forever. Now a workload stuck `waking` past `2 * wakeTimeoutSeconds` drops its
  stale bookkeeping, errs its callers, and re-runs adoption so it heals to a
  re-wakeable state (`:banked`) or resolves as a casualty. The timer is the primary
  release; this is the backstop.
- **park_full**: structured `Logger.warning(event: :park_full, park_depth,
  oldest_waiter_age_ms, workload)` at each cap-overflow site, so the PR-7 alert can
  match it. Shed-newest behavior unchanged.
- Tests: never-ready wake fails at an injected bound and releases single-flight,
  reconcile leaves the workload re-wakeable; adoption stuck-check recovers via an
  injected monotonic clock past the bound. Per class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)