### PR TITLE
feat(embervm): R6 PR-5 restore-on-miss wake planning and remote artifact GC

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.106
+version: 0.1.107

--- a/projects/embervm/control/lib/embervm/group_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/group_sweeper.ex
@@ -122,7 +122,9 @@ defmodule Embervm.GroupSweeper do
   alias Embervm.OpLog.Op
 
   alias Embervm.Node.V1.{
+    ArtifactRef,
     DeleteGroupNetworkRequest,
+    EvictArtifactRequest,
     EvictSnapshotRequest,
     StopGroupMemberRequest,
     Trace
@@ -202,6 +204,12 @@ defmodule Embervm.GroupSweeper do
       delete_group_network_fun:
         Keyword.get(opts, :delete_group_network_fun, &default_delete_group_network/2),
       evict_snapshot_fun: Keyword.get(opts, :evict_snapshot_fun, &default_evict_snapshot/2),
+      # Remote artifact eviction seam (R6, Task 9): (channel, %EvictArtifactRequest{})
+      # -> {:ok, %EvictArtifactResponse{}} | {:error, _}. Fired alongside the local
+      # per-member EvictSnapshot so the store copy of the whole banked SET is dropped
+      # on the same trigger (banked TTL, forced roll). Injected for tests; production
+      # dials the real NodeService stub.
+      evict_artifact_fun: Keyword.get(opts, :evict_artifact_fun, &default_evict_artifact/2),
       # status.group {state, members{live,degraded}, setId, subnetCidr} + groupSummary
       # writer (Task 9). Defaults to the K8s merge-patch on the workload status
       # subresource, the SAME seam StatefulSweeper.status_writer uses; tests inject a
@@ -949,6 +957,11 @@ defmodule Embervm.GroupSweeper do
   # group_destroyed{reason}. Warmth-only terminal: the set IS the instance's end.
   defp destroy_banked(state, instance, reason) do
     _ = evict_member_bundles(state, instance)
+    # R6, Task 9: drop the store copy of the whole banked SET (EvictArtifact,
+    # remote=true, kind GROUP_SET) alongside the local per-member eviction, on the
+    # same trigger. The set is the export/evict unit; a single remote evict covers
+    # every member. Best-effort and idempotent on the daemon.
+    _ = evict_remote_set(state, instance)
     _ = delete_network(state, instance)
 
     _ =
@@ -1048,6 +1061,30 @@ defmodule Embervm.GroupSweeper do
     :ok
   end
 
+  # R6, Task 9: drop the store copy of a banked GROUP_SET (EvictArtifact,
+  # remote=true) alongside the local per-member eviction. ref is the set_id (the set
+  # is the export/evict unit). Best-effort; a set with no set_id (a partial set
+  # already cleared) or no node is a clean no-op.
+  defp evict_remote_set(state, %{node_id: node_id, set_id: set_id, workload: workload})
+       when is_binary(node_id) and is_binary(set_id) and set_id != "" do
+    artifact = %ArtifactRef{kind: :ARTIFACT_KIND_GROUP_SET, workload: workload, ref: set_id}
+    req = %EvictArtifactRequest{artifact: artifact, remote: true, trace: %Trace{workload: workload}}
+
+    with {:ok, channel} <- safe_channel(state, node_id) do
+      try do
+        state.evict_artifact_fun.(channel, req)
+      rescue
+        _ -> :error
+      catch
+        _, _ -> :error
+      end
+    end
+
+    :ok
+  end
+
+  defp evict_remote_set(_state, _instance), do: :ok
+
   # -- stats scrape helpers -----------------------------------------------------
 
   # Composite groups run on the same node Envoy as serving/stateful, so reuse the
@@ -1136,6 +1173,10 @@ defmodule Embervm.GroupSweeper do
 
   defp default_evict_snapshot(channel, req) do
     Embervm.Node.V1.NodeService.Stub.evict_snapshot(channel, req)
+  end
+
+  defp default_evict_artifact(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.evict_artifact(channel, req)
   end
 
   # Production scrape: identical to StatefulSweeper's (GET /stats?format=json over the

--- a/projects/embervm/control/lib/embervm/group_wake_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_wake_manager.ex
@@ -85,6 +85,8 @@ defmodule Embervm.GroupWakeManager do
 
   alias Embervm.{EndpointPublisher, GroupManager, GroupState, GroupStore, NodeCapacity, WorkloadCatalog}
 
+  alias Embervm.Node.V1.{ArtifactRef, RestoreArtifactRequest, Trace}
+
   # Wake-rate + parked-cap defaults mirror the R4 stateful values (a composite group
   # is a group-level singleton owned by one principal, so per-workload == per-
   # principal, same reasoning as StatefulManager).
@@ -158,6 +160,16 @@ defmodule Embervm.GroupWakeManager do
       # implementing create_group/2 + wake_group/1 (or a per-workload scripted fake).
       # Production drives Embervm.GroupManager.Supervisor.
       supervisor_mod: Keyword.get(opts, :supervisor_mod, GroupManager.Supervisor),
+      # Restore-on-miss seams (R6, Task 8). Unlike serving/stateful this module owns
+      # no dispatch channel of its own (the heavy relight is delegated to a
+      # GroupManager child), so the restore-before-relight RPC dials its own channel
+      # through the shared NodeChannel. restore_artifact_fun issues RestoreArtifact for
+      # a complete exported GROUP_SET; op_log records the :artifact_restored audit. All
+      # injected for tests; production dials the real NodeService stub.
+      channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
+      invalidate_fun: Keyword.get(opts, :invalidate_fun, &Embervm.NodeChannel.invalidate/2),
+      restore_artifact_fun: Keyword.get(opts, :restore_artifact_fun, &default_restore_artifact/2),
+      op_log: Keyword.get(opts, :op_log, Embervm.OpLog.SQLite),
       # The composite supernet + DNAT port base + control-plane pod IP, the SAME
       # shared values that feed the GroupManager (and noded's CompositeSupernet /
       # ServingPortBase). Adoption re-derives the entry DNAT endpoint `{pod_ip,
@@ -395,11 +407,164 @@ defmodule Embervm.GroupWakeManager do
         end
 
       {:relight, instance_id} ->
+        # Restore-on-miss (R6, Task 8): a COMPLETE exported set whose local bundles
+        # are gone is restored FIRST, then the delegated relight resumes it warm. A
+        # partial local set that is NOT fully exported, or an unreachable store, skips
+        # the restore and the GroupManager wake evicts + fresh-boots as it does today
+        # (fail-open warmth, standing decision 7). The restore runs inside this wake
+        # worker so single-flight/park semantics are unchanged.
+        _ = maybe_restore_set(state, workload, instance_id)
         run_group_wake(state, workload, instance_id)
 
       {:fresh, instance_id} ->
         run_group_wake(state, workload, instance_id)
     end
+  end
+
+  # -- restore-on-miss (R6, Task 8) ------------------------------------------
+
+  # Restore the whole exported GROUP_SET for a banked instance when its local
+  # bundles are missing but the store holds a complete set and the store is
+  # reachable. Best-effort: any gap (no set_id, set already local, store
+  # unreachable, or not exported) is a clean skip that leaves the relight to the
+  # existing GroupManager fresh-fallback path. The restore RPC failing degrades the
+  # same way.
+  defp maybe_restore_set(state, workload, instance_id) do
+    # The group instance_id IS the group_instance_id the node keys its bundle sets by
+    # (GroupStore rows carry no separate group_instance_id column; the instance id is
+    # that identity, mirroring how do_reconcile indexes sets by group_instance_id).
+    with {:ok, %{node_id: node_id, set_id: set_id}}
+         when is_binary(node_id) and is_binary(set_id) and set_id != "" <-
+           GroupStore.get(state.store, instance_id),
+         false <- set_local?(state, node_id, instance_id),
+         true <- set_restorable?(state, node_id, instance_id) do
+      restore_set(state, node_id, workload, set_id)
+      :ok
+    else
+      _ -> :ok
+    end
+  end
+
+  # Whether the anchor node still reports this group's bundle SET with member
+  # bundles present on LOCAL disk (a reported set whose members list is non-empty).
+  # True -> the local set is present, no restore needed. A set reported with an
+  # empty member list is a store-only marker (exported but locally gone), which is
+  # exactly the restore-on-miss case, so it reads as NOT local here.
+  defp set_local?(state, node_id, group_instance_id) do
+    case NodeCapacity.fetch(state.capacity_table, node_id) do
+      {:ok, fact} ->
+        fact
+        |> Map.get(:group_bundle_sets, [])
+        |> Enum.any?(fn s ->
+          s.group_instance_id == group_instance_id and Map.get(s, :members, []) != []
+        end)
+
+      :error ->
+        false
+    end
+  end
+
+  # Whether a locally-missing set can be restored: the store is reachable AND the
+  # store holds the WHOLE set (its exported flag is set). exported is a per-set
+  # atomicity fact (a partially exported set is not exported), so this is the
+  # complete-set gate. store_reachable == false never blocks the local-state wake;
+  # it only withholds the restore (fail-open warmth).
+  defp set_restorable?(state, node_id, group_instance_id) do
+    case NodeCapacity.fetch(state.capacity_table, node_id) do
+      {:ok, fact} ->
+        Map.get(fact, :store_reachable, false) == true and
+          fact
+          |> Map.get(:group_bundle_sets, [])
+          |> Enum.any?(&(&1.group_instance_id == group_instance_id and Map.get(&1, :exported, false) == true))
+
+      :error ->
+        false
+    end
+  end
+
+  defp restore_set(state, node_id, workload, set_id) do
+    ref = %ArtifactRef{kind: :ARTIFACT_KIND_GROUP_SET, workload: workload, ref: set_id}
+    req = %RestoreArtifactRequest{artifact: ref, trace: %Trace{workload: workload}}
+
+    case safe_restore_artifact(state, node_id, req) do
+      {:ok, resp} ->
+        record_restore(state, workload, set_id, resp)
+        :ok
+
+      other ->
+        Logger.warning("embervm group: set restore-on-miss failed, degrading to fresh",
+          workload: workload,
+          set_id: set_id,
+          reason: inspect(other)
+        )
+
+        :error
+    end
+  end
+
+  defp safe_restore_artifact(state, node_id, %RestoreArtifactRequest{} = req) do
+    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+      try do
+        case state.restore_artifact_fun.(channel, req) do
+          {:error, reason} = err ->
+            if Embervm.NodeChannel.transport_dead?(reason) do
+              _ = state.invalidate_fun.(node_id, channel)
+            end
+
+            err
+
+          other ->
+            other
+        end
+      rescue
+        e -> {:error, {:restore_artifact_raised, e}}
+      catch
+        :exit, reason ->
+          _ = state.invalidate_fun.(node_id, channel)
+          {:error, {:restore_artifact_raised, {:exit, reason}}}
+
+        kind, reason ->
+          {:error, {:restore_artifact_raised, {kind, reason}}}
+      end
+    end
+  end
+
+  defp safe_channel(channel_fun, node_id) do
+    channel_fun.(node_id)
+  rescue
+    e -> {:error, {:channel_raised, e}}
+  catch
+    kind, reason -> {:error, {:channel_raised, {kind, reason}}}
+  end
+
+  # Append the audit-only :artifact_restored op (no projection table). Best-effort:
+  # an append failure must never fail the wake (the restored bytes on disk are the
+  # durable state, not this audit row).
+  defp record_restore(state, workload, set_id, resp) do
+    op = %Embervm.OpLog.Op{
+      kind: :artifact_restored,
+      tenant: state.tenant,
+      principal: wake_principal(workload),
+      workload: workload,
+      ts: state.clock.(),
+      payload: %{
+        kind: "group_set",
+        ref: set_id,
+        bytes_moved: Map.get(resp, :bytes_moved, 0),
+        skipped: Map.get(resp, :skipped, false)
+      }
+    }
+
+    _ = Embervm.OpLog.SQLite.append(state.op_log, op)
+    :ok
+  rescue
+    e ->
+      Logger.warning("embervm group: artifact_restored append raised", workload: workload, error: inspect(e))
+      :ok
+  end
+
+  defp default_restore_artifact(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.restore_artifact(channel, req)
   end
 
   # Spawn (or reuse) the GroupManager child for the banked instance and drive its
@@ -726,6 +891,11 @@ defmodule Embervm.GroupWakeManager do
   defp audit_denial(principal, workload, reason) do
     Embervm.Metering.record_denial(principal, workload, reason)
   end
+
+  # The op-log owner attribution for a group's restore audit, matching
+  # GroupSweeper.usage_principal/1 (a composite group is a singleton owned by one
+  # principal, so per-workload == per-principal).
+  defp wake_principal(workload), do: "system:group:#{workload}"
 
   defp schedule(msg, interval_ms) when interval_ms > 0 do
     Process.send_after(self(), msg, interval_ms)

--- a/projects/embervm/control/lib/embervm/group_wake_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_wake_manager.ex
@@ -433,11 +433,17 @@ defmodule Embervm.GroupWakeManager do
     # The group instance_id IS the group_instance_id the node keys its bundle sets by
     # (GroupStore rows carry no separate group_instance_id column; the instance id is
     # that identity, mirroring how do_reconcile indexes sets by group_instance_id).
+    # OPTIMISTIC restore-on-miss (R6, Task 8, option b): the CP tracks no remote
+    # inventory, so on a TRUE local miss (the node no longer reports the set's member
+    # bundles) with a reachable store it ATTEMPTS the restore; the daemon fails closed
+    # (FAILED_PRECONDITION) if no store copy exists and the delegated relight then
+    # evicts + fresh-boots as it does today. store_reachable == false never blocks the
+    # wake, it only withholds the restore (fail-open warmth, standing decision 7).
     with {:ok, %{node_id: node_id, set_id: set_id}}
          when is_binary(node_id) and is_binary(set_id) and set_id != "" <-
            GroupStore.get(state.store, instance_id),
          false <- set_local?(state, node_id, instance_id),
-         true <- set_restorable?(state, node_id, instance_id) do
+         true <- store_reachable?(state, node_id) do
       restore_set(state, node_id, workload, set_id)
       :ok
     else
@@ -447,9 +453,9 @@ defmodule Embervm.GroupWakeManager do
 
   # Whether the anchor node still reports this group's bundle SET with member
   # bundles present on LOCAL disk (a reported set whose members list is non-empty).
-  # True -> the local set is present, no restore needed. A set reported with an
-  # empty member list is a store-only marker (exported but locally gone), which is
-  # exactly the restore-on-miss case, so it reads as NOT local here.
+  # True -> the local set is present, no restore needed. A locally-absent set (no
+  # reported set for the group, or one reported with an empty member list) reads as
+  # NOT local, the restore-on-miss case.
   defp set_local?(state, node_id, group_instance_id) do
     case NodeCapacity.fetch(state.capacity_table, node_id) do
       {:ok, fact} ->
@@ -464,21 +470,13 @@ defmodule Embervm.GroupWakeManager do
     end
   end
 
-  # Whether a locally-missing set can be restored: the store is reachable AND the
-  # store holds the WHOLE set (its exported flag is set). exported is a per-set
-  # atomicity fact (a partially exported set is not exported), so this is the
-  # complete-set gate. store_reachable == false never blocks the local-state wake;
-  # it only withholds the restore (fail-open warmth).
-  defp set_restorable?(state, node_id, group_instance_id) do
+  # The anchor node's latest object-store reachability verdict (R6). Absent/false
+  # reads as NOT reachable, so no restore is attempted (the wake degrades to the
+  # delegated relight's fresh-fallback); never blocks the local-state wake.
+  defp store_reachable?(state, node_id) do
     case NodeCapacity.fetch(state.capacity_table, node_id) do
-      {:ok, fact} ->
-        Map.get(fact, :store_reachable, false) == true and
-          fact
-          |> Map.get(:group_bundle_sets, [])
-          |> Enum.any?(&(&1.group_instance_id == group_instance_id and Map.get(&1, :exported, false) == true))
-
-      :error ->
-        false
+      {:ok, fact} -> Map.get(fact, :store_reachable, false) == true
+      :error -> false
     end
   end
 

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -445,6 +445,12 @@ defmodule Embervm.NodeRegistry do
       live_vms: s.live_vms,
       max_live_vms: s.max_live_vms,
       draining: false,
+      # Continuity fact (R6, additive): the daemon's latest object-store
+      # reachability verdict. Read by the restore-on-miss wake planners to decide
+      # whether a TRUE local miss can consult the store at all; false NEVER blocks a
+      # local-state wake (fail-open warmth, standing decision 7). False on a daemon
+      # with no store configured or one that never sets it (wire-compatible).
+      store_reachable: s.store_reachable,
       updated_at: now,
       # Session facts (R2): the node's LIVE session VMs and BANKED snapshot
       # inventory, plus the sessions snapshot-dir disk usage. These are the source
@@ -523,6 +529,10 @@ defmodule Embervm.NodeRegistry do
         set_id: s.set_id,
         group_instance_id: s.group_instance_id,
         created_at_unix_ms: s.created_at_unix_ms,
+        # exported is true only when the WHOLE set's store copy is present and
+        # current (R6): the restore-on-miss group planner reads it to know a
+        # complete exported set can be restored on a true local miss.
+        exported: s.exported,
         members:
           for(m <- s.members || [], do: %{member_name: m.member_name, snapshot_ref: m.snapshot_ref, size_bytes: m.size_bytes})
       }
@@ -552,7 +562,10 @@ defmodule Embervm.NodeRegistry do
         snapshot_ref: snap.snapshot_ref,
         workload: snap.workload,
         size_bytes: snap.size_bytes,
-        created_at_unix_ms: snap.created_at_unix_ms
+        created_at_unix_ms: snap.created_at_unix_ms,
+        # exported is true when this bundle's store copy is present and current
+        # (R6): the restore-on-miss serving planner reads it on a true local miss.
+        exported: snap.exported
       }
     end
   end
@@ -588,7 +601,10 @@ defmodule Embervm.NodeRegistry do
         workload: b.workload,
         generation: b.generation,
         size_bytes: b.size_bytes,
-        created_at_unix_ms: b.created_at_unix_ms
+        created_at_unix_ms: b.created_at_unix_ms,
+        # exported is true when this bundle's store copy is present and current
+        # (R6): the restore-on-miss stateful planner reads it on a true local miss.
+        exported: b.exported
       }
     end
   end
@@ -602,7 +618,13 @@ defmodule Embervm.NodeRegistry do
         generation: v.generation,
         size_bytes: v.size_bytes,
         allocated_bytes: v.allocated_bytes,
-        attached: v.attached
+        attached: v.attached,
+        # exported_generation is the volume generation whose (vol.img, gen) pair
+        # the store currently holds, 0 if no store copy exists (R6). The
+        # restore-on-miss planner reads it to know a lost volume can be restored to
+        # this generation, and the remote GC guard reads it to skip a re-export when
+        # it already equals the live generation.
+        exported_generation: v.exported_generation
       }
     end
   end
@@ -624,7 +646,10 @@ defmodule Embervm.NodeRegistry do
         session_id: snap.session_id,
         workload: snap.workload,
         size_bytes: snap.size_bytes,
-        created_at_unix_ms: snap.created_at_unix_ms
+        created_at_unix_ms: snap.created_at_unix_ms,
+        # exported is true when this bundle's store copy is present and current
+        # (R6): the restore-on-miss session planner reads it on a true local miss.
+        exported: snap.exported
       }
     end
   end

--- a/projects/embervm/control/lib/embervm/op_log.ex
+++ b/projects/embervm/control/lib/embervm/op_log.ex
@@ -188,7 +188,18 @@ defmodule Embervm.OpLog do
     # will force-bank; node_drain_finished stamps the per-class banked counts. No
     # projection table (like :drain), the log itself is the audit record.
     :node_drain_started,
-    :node_drain_finished
+    :node_drain_finished,
+    # Continuity: off-node artifact durability (R6, ADR embervm/009). Audit-only
+    # kinds recording an artifact moving between node disk and the object store:
+    # artifact_exported when a bank commit's write-back completes, artifact_restored
+    # when a restore-on-miss wake copies an artifact back before relight/cold boot,
+    # artifact_evicted_remote when a local eviction trigger (banked TTL, superseded
+    # generation, workload deletion) also drops the store copy. No projection table
+    # (like :node_drain_*), the log itself is the audit record; the payload carries
+    # the ArtifactRef {kind, workload, ref} and, for a volume, its generation.
+    :artifact_exported,
+    :artifact_restored,
+    :artifact_evicted_remote
   ]
 
   @spec kinds() :: [atom()]

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -1433,7 +1433,10 @@ defmodule Embervm.OpLog.SQLite do
               :quota_enforced,
               :drain,
               :node_drain_started,
-              :node_drain_finished
+              :node_drain_finished,
+              :artifact_exported,
+              :artifact_restored,
+              :artifact_evicted_remote
             ] do
     :ok
   end

--- a/projects/embervm/control/lib/embervm/serving_manager.ex
+++ b/projects/embervm/control/lib/embervm/serving_manager.ex
@@ -68,8 +68,10 @@ defmodule Embervm.ServingManager do
   alias Embervm.{EndpointPublisher, NodeCapacity, ServingPlacement, ServingState, ServingStore, SessionTrace, WorkloadCatalog}
 
   alias Embervm.Node.V1.{
+    ArtifactRef,
     FreshSource,
     RelightSource,
+    RestoreArtifactRequest,
     StartServingRequest,
     StartServingResponse,
     Trace
@@ -160,6 +162,15 @@ defmodule Embervm.ServingManager do
       channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
       invalidate_fun: Keyword.get(opts, :invalidate_fun, &Embervm.NodeChannel.invalidate/2),
       start_serving_fun: Keyword.get(opts, :start_serving_fun, &default_start_serving/2),
+      # Restore-on-miss seam (R6, Task 8): (channel, %RestoreArtifactRequest{}) ->
+      # {:ok, %RestoreArtifactResponse{}} | {:error, _}. Fetches a banked SERVING
+      # bundle back onto local disk from the object store before a relight on a TRUE
+      # local miss (the bundle is exported but no longer on the anchor node's disk).
+      # Injected for tests; production dials the real NodeService stub.
+      restore_artifact_fun: Keyword.get(opts, :restore_artifact_fun, &default_restore_artifact/2),
+      # The op-log the restore audit record (:artifact_restored) is appended to.
+      # Injected for tests; production uses the SQLite backend.
+      op_log: Keyword.get(opts, :op_log, Embervm.OpLog.SQLite),
       # workload -> [{from, req, principal}] parked behind an in-flight wake, so
       # concurrent misses share ONE StartServing (single-flight). The first miss
       # kicks the worker; the rest append here.
@@ -340,6 +351,25 @@ defmodule Embervm.ServingManager do
             send(self(), {:wake_done, workload, {:error, {:relight_mark, reason}}})
         end
 
+      # Restore-on-miss (R6): the local snapshot is gone but its store copy is
+      # recoverable. Restore the SERVING bundle inside the wake worker FIRST (so
+      # park/single-flight semantics are unchanged), then relight exactly as the warm
+      # path. The restore failing (store unreachable mid-wake, or the copy vanished)
+      # degrades to the daemon's own cold-boot fallback (fail-open warmth).
+      {:restore_then_relight, instance, node_id} ->
+        case ServingStore.mark(state.store, instance.instance_id, :relight) do
+          {:ok, _} ->
+            req = relight_request(entry, instance)
+
+            spawn_wake(owner, workload, fn ->
+              _ = restore_bundle(state, node_id, workload, instance.snapshot_ref)
+              run_relight(state, instance, node_id, req)
+            end)
+
+          {:error, reason} ->
+            send(self(), {:wake_done, workload, {:error, {:relight_mark, reason}}})
+        end
+
       {:cold, node_id, base_ref} ->
         req = cold_request(entry, workload, base_ref)
         spawn_wake(owner, workload, fn -> run_cold(state, workload, node_id, base_ref, req) end)
@@ -375,17 +405,62 @@ defmodule Embervm.ServingManager do
   # Decide relight-vs-cold PURELY (ETS reads only): the freshest banked instance
   # whose serving snapshot a node still reports relights; otherwise a cold create on
   # a serving-capable node with the workload's base + budget. Returns
-  # `{:relight, instance, node_id}` | `{:cold, node_id, base_ref}` | `{:error, r}`.
+  # `{:relight, instance, node_id}` | `{:restore_then_relight, instance, node_id}` |
+  # `{:cold, node_id, base_ref}` | `{:error, r}`.
+  #
+  # Restore-on-miss (R6, Task 8): a relight candidate's snapshot may be EXPORTED to
+  # the object store but no longer on the anchor node's local disk (disk lost, or the
+  # node rotated). When that happens AND the node's store is reachable, restore the
+  # bundle first, then relight (fail-open warmth otherwise: an unreachable store or a
+  # missing store copy falls through to the plain relight attempt, which the daemon
+  # degrades to a cold boot if the local bundle is truly gone). Serving carries no
+  # volume/generation pairing (unlike stateful), so there is only this one bundle-
+  # restore case, never a restore_volume branch.
   defp plan_wake(state, workload) do
     case pick_bankable_instance(state, workload) do
       {:ok, instance, node_id} ->
-        {:relight, instance, node_id}
+        if bundle_local?(state, node_id, instance.snapshot_ref) or
+             not store_reachable?(state, node_id) do
+          {:relight, instance, node_id}
+        else
+          {:restore_then_relight, instance, node_id}
+        end
 
       :none ->
         case ServingPlacement.node_for_create(workload, state.capacity_table) do
           {:ok, node_id, base_ref} -> {:cold, node_id, base_ref}
           {:error, :no_capacity} -> {:error, :no_capacity}
         end
+    end
+  end
+
+  # -- restore-on-miss (R6, Task 8) -------------------------------------------
+
+  # Whether the node still reports the instance's snapshot on LOCAL disk (its
+  # snapshot_ref is in the node's serving_snapshots). A relight needs no restore when
+  # true; a true local miss (false) may consult the store instead.
+  defp bundle_local?(state, node_id, snapshot_ref) when is_binary(snapshot_ref) and snapshot_ref != "" do
+    case NodeCapacity.fetch(state.capacity_table, node_id) do
+      {:ok, fact} ->
+        fact
+        |> Map.get(:serving_snapshots, [])
+        |> Enum.any?(&(&1.snapshot_ref == snapshot_ref))
+
+      :error ->
+        false
+    end
+  end
+
+  defp bundle_local?(_state, _node_id, _ref), do: false
+
+  # The node's latest object-store reachability verdict (R6). Absent/false (a node
+  # with no store configured, or one that never reported) reads as NOT reachable, so
+  # no restore is attempted and the wake degrades to the plain relight attempt (never
+  # blocked: this only gates the store consultation, never a local-state wake).
+  defp store_reachable?(state, node_id) do
+    case NodeCapacity.fetch(state.capacity_table, node_id) do
+      {:ok, fact} -> Map.get(fact, :store_reachable, false) == true
+      :error -> false
     end
   end
 
@@ -410,10 +485,28 @@ defmodule Embervm.ServingManager do
           end
 
         {:error, :snapshot_lost} ->
-          false
+          # The snapshot is no longer on local disk (disk lost, node rotated). It may
+          # still be recoverable from the object store (R6 restore-on-miss): if the
+          # instance's anchor node is reporting a reachable store, keep it as a relight
+          # candidate anchored there. plan_wake then routes it to :restore_then_relight
+          # (bundle_local? is false, so it restores first). An unreachable store or a
+          # gone node stays :none, so the wake cold-boots (fail-open warmth).
+          restore_candidate_node(state, instance)
       end
     end)
   end
+
+  # The instance's anchor node when it is reporting a reachable store (a
+  # restore-on-miss candidate), else false (no restore possible, cold-boot).
+  defp restore_candidate_node(state, %{node_id: node_id} = instance) when is_binary(node_id) and node_id != "" do
+    if store_reachable?(state, node_id) and lineage_current?(state.capacity_table, node_id, instance) do
+      {:ok, instance, node_id}
+    else
+      false
+    end
+  end
+
+  defp restore_candidate_node(_state, _instance), do: false
 
   # Whether a banked instance's base lineage still matches the node's CURRENT
   # serving_image_ref for the workload. Fail-OPEN when the node reports no current ref
@@ -1020,6 +1113,97 @@ defmodule Embervm.ServingManager do
 
   defp default_start_serving(channel, req) do
     Embervm.Node.V1.NodeService.Stub.start_serving(channel, req)
+  end
+
+  # -- restore-on-miss RPC (R6, Task 8) ---------------------------------------
+
+  # Restore the SERVING bundle for `workload` from the object store back onto the
+  # node's disk (RestoreArtifact, kind SERVING), then record :artifact_restored.
+  # Best-effort: a restore failure returns :error and the caller (the wake worker)
+  # falls through to the relight, which the daemon degrades to a cold boot on a
+  # truly-missing snapshot (fail-open warmth). Idempotent on the daemon side, so a
+  # re-run of a partially-restored artifact is safe.
+  defp restore_bundle(state, node_id, workload, snapshot_ref) do
+    ref = %ArtifactRef{kind: :ARTIFACT_KIND_SERVING, workload: workload, ref: snapshot_ref}
+
+    case safe_restore_artifact(state, node_id, ref) do
+      {:ok, resp} ->
+        record_restore(state, workload, :ARTIFACT_KIND_SERVING, snapshot_ref, resp)
+        :ok
+
+      other ->
+        Logger.warning("embervm serving: bundle restore-on-miss failed, degrading to cold",
+          workload: workload,
+          snapshot_ref: snapshot_ref,
+          reason: inspect(other)
+        )
+
+        :error
+    end
+  end
+
+  defp safe_restore_artifact(state, node_id, %ArtifactRef{} = ref) do
+    req = %RestoreArtifactRequest{artifact: ref, trace: %Trace{workload: ref.workload}}
+
+    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+      try do
+        case state.restore_artifact_fun.(channel, req) do
+          {:error, reason} = err ->
+            if Embervm.NodeChannel.transport_dead?(reason) do
+              _ = state.invalidate_fun.(node_id, channel)
+            end
+
+            err
+
+          other ->
+            other
+        end
+      rescue
+        e -> {:error, {:restore_artifact_raised, e}}
+      catch
+        :exit, reason ->
+          _ = state.invalidate_fun.(node_id, channel)
+          {:error, {:restore_artifact_raised, {:exit, reason}}}
+
+        kind, reason ->
+          {:error, {:restore_artifact_raised, {kind, reason}}}
+      end
+    end
+  end
+
+  # Append the audit-only :artifact_restored op (no projection table; the log itself
+  # is the record). Best-effort: an append failure must never fail the wake, which
+  # already ran the restore RPC (the durable state is the restored bytes on disk, not
+  # this audit row).
+  defp record_restore(state, workload, kind, ref, resp) do
+    op = %Embervm.OpLog.Op{
+      kind: :artifact_restored,
+      tenant: state.tenant,
+      principal: wake_principal(state, workload),
+      workload: workload,
+      ts: state.clock.(),
+      payload: %{
+        kind: artifact_kind_string(kind),
+        ref: ref,
+        bytes_moved: Map.get(resp, :bytes_moved, 0),
+        generation: Map.get(resp, :generation, 0),
+        skipped: Map.get(resp, :skipped, false)
+      }
+    }
+
+    _ = Embervm.OpLog.SQLite.append(state.op_log, op)
+    :ok
+  rescue
+    e ->
+      Logger.warning("embervm serving: artifact_restored append raised", workload: workload, error: inspect(e))
+      :ok
+  end
+
+  defp artifact_kind_string(:ARTIFACT_KIND_SERVING), do: "serving"
+  defp artifact_kind_string(other), do: to_string(other)
+
+  defp default_restore_artifact(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.restore_artifact(channel, req)
   end
 
   # -- misc ------------------------------------------------------------------

--- a/projects/embervm/control/lib/embervm/serving_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/serving_sweeper.ex
@@ -89,7 +89,7 @@ defmodule Embervm.ServingSweeper do
   alias Embervm.{NodeCapacity, ServingState, ServingStore, WorkloadCatalog}
   alias Embervm.OpLog.Op
 
-  alias Embervm.Node.V1.{StopServingRequest, StopServingResponse, Trace}
+  alias Embervm.Node.V1.{ArtifactRef, EvictArtifactRequest, StopServingRequest, StopServingResponse, Trace}
 
   # Per-node concurrent-bank cap, shared-in-spirit with sessions (banking writes
   # GiBs, so serialize per node): the node daemon also refuses a second concurrent
@@ -156,6 +156,15 @@ defmodule Embervm.ServingSweeper do
       # NodeService stub over the shared NodeChannel).
       channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
       stop_serving_fun: Keyword.get(opts, :stop_serving_fun, &default_stop_serving/2),
+      # Remote artifact eviction seam (R6, Task 9): (channel, %EvictArtifactRequest{})
+      # -> {:ok, %EvictArtifactResponse{}} | {:error, _}. Fired alongside the durable
+      # serving_evicted transition so the store copy of a banked SERVING bundle is
+      # dropped on the same triggers (banked TTL, stale lineage, forced roll). v1 issues
+      # no local EvictSnapshot RPC here (the activator's adoption reconcile evicts the
+      # node-local orphan separately), but the STORE copy needs an explicit drop since
+      # nothing else targets it. Injected for tests; production dials the real
+      # NodeService stub.
+      evict_artifact_fun: Keyword.get(opts, :evict_artifact_fun, &default_evict_artifact/2),
       # Per-node concurrent-bank cap: node_id -> banks in flight. A node at its cap
       # defers new banks to a later tick (the idle instance stays live, re-evaluated).
       bank_concurrency: Keyword.get(opts, :bank_concurrency, @default_bank_concurrency),
@@ -924,6 +933,12 @@ defmodule Embervm.ServingSweeper do
     # snapshot is no longer a relight target. (v1 does not issue a separate evict RPC
     # here; the activator's reconcile evicts the orphan on the node, matching the
     # merged evict_orphan_snapshots path.)
+    # R6, Task 9: the store copy of the bundle DOES need dropping even though local
+    # disk is reclaimed lazily by the node's own GC, so fire the remote EvictArtifact
+    # alongside the durable transition (banked TTL, stale lineage, and forced roll all
+    # route through here).
+    _ = evict_remote_bundle(state, instance)
+
     _ =
       ServingStore.transition(
         state.store,
@@ -942,6 +957,31 @@ defmodule Embervm.ServingSweeper do
 
     state
   end
+
+  # R6, Task 9: drop the store copy of a banked SERVING bundle (EvictArtifact,
+  # remote=true, kind SERVING) alongside the local eviction transition. Best-effort: a
+  # failure never wedges the sweep (the durable transition is authoritative; a
+  # stranded store copy is swept later by the remote-orphan reconcile). Idempotent on
+  # the daemon; an already-absent store copy is a no-op.
+  defp evict_remote_bundle(state, %{node_id: node_id, snapshot_ref: ref, workload: workload})
+       when is_binary(node_id) and is_binary(ref) and ref != "" do
+    artifact = %ArtifactRef{kind: :ARTIFACT_KIND_SERVING, workload: workload, ref: ref}
+    req = %EvictArtifactRequest{artifact: artifact, remote: true, trace: %Trace{workload: workload}}
+
+    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+      try do
+        state.evict_artifact_fun.(channel, req)
+      rescue
+        _ -> :error
+      catch
+        _, _ -> :error
+      end
+    end
+
+    :ok
+  end
+
+  defp evict_remote_bundle(_state, _instance), do: :ok
 
   defp stop_serving_destroy(state, %{node_id: node_id, vm_id: vm_id})
        when is_binary(node_id) and is_binary(vm_id) do
@@ -1057,6 +1097,10 @@ defmodule Embervm.ServingSweeper do
 
   defp default_stop_serving(channel, req) do
     Embervm.Node.V1.NodeService.Stub.stop_serving(channel, req)
+  end
+
+  defp default_evict_artifact(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.evict_artifact(channel, req)
   end
 
   # Production scrape: GET /stats?format=json over the shared Finch pool, parse the

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -56,13 +56,16 @@ defmodule Embervm.SessionManager do
   alias Embervm.{NodeCapacity, SessionPlacement, SessionState, SessionStore, SessionTrace, WorkloadCatalog}
 
   alias Embervm.Node.V1.{
+    ArtifactRef,
     BankRequest,
     BankResponse,
+    EvictArtifactRequest,
     EvictSnapshotRequest,
     PrimeRequest,
     PrimeResponse,
     RelightRequest,
     RelightResponse,
+    RestoreArtifactRequest,
     Trace
   }
 
@@ -189,6 +192,22 @@ defmodule Embervm.SessionManager do
       bank_fun: Keyword.get(opts, :bank_fun, &default_bank/2),
       relight_fun: Keyword.get(opts, :relight_fun, &default_relight/2),
       evict_fun: Keyword.get(opts, :evict_fun, &default_evict/2),
+      # Restore-on-miss seam (R6, Task 8): (channel, %RestoreArtifactRequest{}) ->
+      # {:ok, %RestoreArtifactResponse{}} | {:error, _}. Fetches a banked SESSION
+      # bundle back onto local disk from the object store before a relight, when the
+      # bundle is exported but no longer locally reported. Injected for tests;
+      # production dials the real NodeService stub.
+      restore_artifact_fun: Keyword.get(opts, :restore_artifact_fun, &default_restore_artifact/2),
+      # Remote artifact eviction seam (R6, Task 9): (channel, %EvictArtifactRequest{})
+      # -> {:ok, %EvictArtifactResponse{}} | {:error, _}. Fired alongside every local
+      # EvictSnapshot so the store copy of a session's bundle follows on the same
+      # triggers (banked TTL, disk pressure, destroy, expiry, orphan sweep). Sessions
+      # carry no volume/generation, so no pairing guard applies here. Injected for
+      # tests; production dials the real NodeService stub.
+      evict_artifact_fun: Keyword.get(opts, :evict_artifact_fun, &default_evict_artifact/2),
+      # The op-log the restore audit record (:artifact_restored) is appended to.
+      # Injected for tests; production uses the SQLite backend.
+      op_log: Keyword.get(opts, :op_log, Embervm.OpLog.SQLite),
       # Extra opts threaded into every started Embervm.Session (the daemon seams),
       # so a test can inject a fake session_assign into the spawned process.
       session_opts: Keyword.get(opts, :session_opts, []),
@@ -1013,6 +1032,20 @@ defmodule Embervm.SessionManager do
     # session share this one relight). nil when tracing is off.
     traceparent = first_waiter_traceparent(state, session_id)
 
+    # Restore-on-miss (R6, Task 8): the session's recorded node_id may no longer
+    # report the bundle locally (disk lost, or a node restart that dropped it),
+    # while the bundle is still exported (its store copy is present and current)
+    # and the store is reachable. The DECISION (a pure ETS read) is taken here on
+    # the serialized manager, cheap and consistent with the wake decision itself;
+    # the RESTORE RPC, when the decision says to attempt one, runs inside the
+    # spawned worker below (before node_for_relight's placement check), so park
+    # semantics are unchanged and a slow store round-trip never blocks the
+    # manager. A restore failure (or a genuinely unreachable store / a bundle
+    # that was never exported) is fail-open: node_for_relight then makes exactly
+    # the same call it always did, degrading to the daemon's existing
+    # snapshot_lost failure rather than blocking the relight on store state.
+    restore = restore_plan(state, session)
+
     spawn(fn ->
       SessionTrace.restore_parent(traceparent)
 
@@ -1025,8 +1058,27 @@ defmodule Embervm.SessionManager do
                            "ember.generation" => session.generation || 0
                          }
                        } do
+        # Restore-on-miss: when the bundle is gone locally but exported, restore it
+        # first and then relight against the SAME anchor node directly. The relight
+        # must NOT re-consult node_for_relight after a restore: that guard checks the
+        # CP's ETS session_snapshots fact, which the just-completed restore has not
+        # yet refreshed (it updates on the next NodeStatus), so it would spuriously
+        # report snapshot_lost and skip the relight the restore just enabled. A
+        # restore FAILURE falls back to the normal node_for_relight path (fail-open).
+        restore_target =
+          case restore do
+            {:restore, restore_node_id, restore_ref} ->
+              case restore_bundle(state, restore_node_id, session.workload, restore_ref) do
+                :ok -> {:ok, restore_node_id}
+                _ -> :none
+              end
+
+            _ ->
+              :none
+          end
+
         outcome =
-          case SessionPlacement.node_for_relight(session, capacity_table) do
+          case relight_node(restore_target, session, capacity_table) do
             {:ok, node_id} ->
               t0 = clock.()
 
@@ -1049,6 +1101,138 @@ defmodule Embervm.SessionManager do
       end
     end)
   end
+
+  # -- restore-on-miss (R6, Task 8) -------------------------------------------
+
+  # The node to relight against. After a SUCCESSFUL restore-on-miss the anchor node
+  # is authoritative (the bundle was just restored there), bypassing the
+  # node_for_relight snapshot-presence guard which the fresh restore has not yet
+  # reflected in the CP's ETS facts. Otherwise the normal placement check.
+  defp relight_node({:ok, node_id}, _session, _capacity_table), do: {:ok, node_id}
+  defp relight_node(:none, session, capacity_table), do: SessionPlacement.node_for_relight(session, capacity_table)
+
+  # Whether the session's bundle should be restored before the relight: the
+  # session's recorded node_id + snapshot_ref are both present, the bundle is NOT
+  # locally reported on that node, and the node's store is reachable. Returns
+  # `{:restore, node_id, snapshot_ref}` when a restore should be attempted, or
+  # `:skip` when the bundle is already local, the node/ref is missing, or the
+  # store is unreachable (fail-open: skip never blocks the relight, it only
+  # withholds the restore attempt).
+  defp restore_plan(state, session) do
+    node_id = Map.get(session, :node_id)
+    snapshot_ref = Map.get(session, :snapshot_ref)
+
+    if is_binary(node_id) and node_id != "" and is_binary(snapshot_ref) and snapshot_ref != "" and
+         not bundle_local?(state, node_id, snapshot_ref) and store_reachable?(state, node_id) do
+      {:restore, node_id, snapshot_ref}
+    else
+      :skip
+    end
+  end
+
+  # Whether the node still reports the bundle on LOCAL disk (its snapshot_ref is in
+  # the node's session_snapshots). A relight needs no restore when true; a true
+  # local miss (false) may consult the store.
+  defp bundle_local?(state, node_id, snapshot_ref) do
+    case NodeCapacity.fetch(state.capacity_table, node_id) do
+      {:ok, fact} ->
+        fact
+        |> Map.get(:session_snapshots, [])
+        |> Enum.any?(&(Map.get(&1, :snapshot_ref) == snapshot_ref))
+
+      :error ->
+        false
+    end
+  end
+
+  # The node's latest object-store reachability verdict (R6). Absent/false (a node
+  # with no store configured, or one that never reported) reads as NOT reachable,
+  # so no restore is attempted and the relight degrades to node_for_relight's
+  # existing snapshot_lost path. This only gates the store consultation, never a
+  # local-state relight.
+  defp store_reachable?(state, node_id) do
+    case NodeCapacity.fetch(state.capacity_table, node_id) do
+      {:ok, fact} -> Map.get(fact, :store_reachable, false) == true
+      :error -> false
+    end
+  end
+
+  # Restore the SESSION bundle for `session_id` (implicit via workload/ref) from the
+  # object store back onto `node_id`'s disk (RestoreArtifact, kind SESSION), then
+  # record :artifact_restored. Best-effort: a restore failure returns :error and the
+  # caller falls through to node_for_relight's existing check, which the daemon (or
+  # the placement layer) degrades to snapshot_lost exactly as it would without this
+  # feature (fail-open warmth). Idempotent on the daemon side.
+  defp restore_bundle(state, node_id, workload, snapshot_ref) do
+    ref = %ArtifactRef{kind: :ARTIFACT_KIND_SESSION, workload: workload, ref: snapshot_ref}
+
+    case safe_restore_artifact(state, node_id, ref) do
+      {:ok, resp} ->
+        record_restore(state, workload, :ARTIFACT_KIND_SESSION, snapshot_ref, resp)
+        :ok
+
+      other ->
+        Logger.warning("embervm session: bundle restore-on-miss failed, degrading to snapshot_lost path",
+          workload: workload,
+          snapshot_ref: snapshot_ref,
+          reason: inspect(other)
+        )
+
+        :error
+    end
+  end
+
+  defp safe_restore_artifact(state, node_id, %ArtifactRef{} = ref) do
+    req = %RestoreArtifactRequest{artifact: ref, trace: %Trace{workload: ref.workload}}
+
+    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+      try do
+        state.restore_artifact_fun.(channel, req)
+      rescue
+        e -> {:error, {:restore_artifact_raised, e}}
+      catch
+        kind, reason -> {:error, {:restore_artifact_raised, {kind, reason}}}
+      end
+    end
+  end
+
+  # Append the audit-only :artifact_restored op (no projection table; the log
+  # itself is the record). Best-effort: an append failure must never fail the
+  # relight, which already ran the restore RPC (the durable state is the restored
+  # bytes on disk, not this audit row).
+  defp record_restore(state, workload, kind, ref, resp) do
+    op = %Embervm.OpLog.Op{
+      kind: :artifact_restored,
+      tenant: state.tenant,
+      principal: workload_principal(state, workload),
+      workload: workload,
+      ts: state.clock.(),
+      payload: %{
+        kind: artifact_kind_string(kind),
+        ref: ref,
+        bytes_moved: Map.get(resp, :bytes_moved, 0),
+        generation: Map.get(resp, :generation, 0),
+        skipped: Map.get(resp, :skipped, false)
+      }
+    }
+
+    _ = Embervm.OpLog.SQLite.append(state.op_log, op)
+    :ok
+  rescue
+    e ->
+      Logger.warning("embervm session: artifact_restored append raised", workload: workload, error: inspect(e))
+      :ok
+  end
+
+  defp artifact_kind_string(:ARTIFACT_KIND_SESSION), do: "session"
+  defp artifact_kind_string(other), do: to_string(other)
+
+  # The op-log principal attribution for a workload-scoped audit row (the restore/
+  # remote-evict ops carry no single session's principal, since a bundle-level
+  # store action is keyed by workload, not by the individual session that happened
+  # to trigger it). Mirrors StatefulManager.wake_principal/1's synthesized-owner
+  # idiom for a class with no natural single owner at this granularity.
+  defp workload_principal(_state, workload), do: "system:session:#{workload}"
 
   # The traceparent carried on the FIRST parked invoke for `session_id` (they share
   # the relight), or nil when the ledger is empty / tracing is off.
@@ -1337,10 +1521,10 @@ defmodule Embervm.SessionManager do
     for f <- facts, snap <- Map.get(f, :session_snapshots, []) || [] do
       case SessionStore.get(state.session_store, snap.session_id) do
         {:ok, %{state: st}} when st in [:expired, :evicted, :destroyed, :failed] ->
-          _ = evict_snapshot_on_node(state, f.configured_id, snap.snapshot_ref, f.node_id)
+          _ = evict_snapshot_on_node(state, f.configured_id, snap.snapshot_ref, f.node_id, snap.workload)
 
         :error ->
-          _ = evict_snapshot_on_node(state, f.configured_id, snap.snapshot_ref, f.node_id)
+          _ = evict_snapshot_on_node(state, f.configured_id, snap.snapshot_ref, f.node_id, snap.workload)
 
         _ ->
           :ok
@@ -1550,13 +1734,14 @@ defmodule Embervm.SessionManager do
 
   # -- snapshot eviction RPC -------------------------------------------------
 
-  defp evict_snapshot(state, %{node_id: node_id, snapshot_ref: ref}) when is_binary(node_id) and is_binary(ref) do
-    evict_snapshot_on_node(state, node_id, ref, node_id)
+  defp evict_snapshot(state, %{node_id: node_id, snapshot_ref: ref, workload: workload})
+       when is_binary(node_id) and is_binary(ref) do
+    evict_snapshot_on_node(state, node_id, ref, node_id, workload)
   end
 
   defp evict_snapshot(_state, _session), do: :ok
 
-  defp evict_snapshot_on_node(state, node_id, snapshot_ref, _reported_id)
+  defp evict_snapshot_on_node(state, node_id, snapshot_ref, _reported_id, workload)
        when is_binary(node_id) and is_binary(snapshot_ref) do
     # A lifecycle span (Task 9): reclaiming a snapshot bundle from node disk. Root
     # span (eviction is sweep/adoption-driven, no caller trace).
@@ -1574,11 +1759,45 @@ defmodule Embervm.SessionManager do
         end
       end
 
+      # R6, Task 9: drop the store copy of the SESSION bundle alongside the local
+      # EvictSnapshot, on every eviction trigger (banked TTL, disk pressure,
+      # destroy, expiry, orphan sweep) since they all funnel through here. Sessions
+      # carry no volume/generation, so no pairing guard applies (unlike the
+      # stateful class's volume-generation guard).
+      _ = evict_remote_bundle(state, node_id, workload, snapshot_ref)
+
       :ok
     end
   end
 
-  defp evict_snapshot_on_node(_state, _node_id, _ref, _reported), do: :ok
+  defp evict_snapshot_on_node(_state, _node_id, _ref, _reported, _workload), do: :ok
+
+  # Drop the store copy of a banked SESSION bundle (EvictArtifact, remote=true, kind
+  # SESSION). Best-effort: a failure never wedges the caller (the local eviction and
+  # durable transition are authoritative; a stranded store copy is swept later by
+  # the remote-orphan reconcile). Idempotent on the daemon; an already-absent store
+  # copy is a no-op. A missing/unknown workload (should not happen; every eviction
+  # site carries one) skips the remote call rather than issuing a malformed ref.
+  defp evict_remote_bundle(state, node_id, workload, snapshot_ref)
+       when is_binary(node_id) and is_binary(workload) and workload != "" and is_binary(snapshot_ref) and
+              snapshot_ref != "" do
+    artifact = %ArtifactRef{kind: :ARTIFACT_KIND_SESSION, workload: workload, ref: snapshot_ref}
+    req = %EvictArtifactRequest{artifact: artifact, remote: true, trace: %Trace{workload: workload}}
+
+    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+      try do
+        state.evict_artifact_fun.(channel, req)
+      rescue
+        _ -> :error
+      catch
+        _, _ -> :error
+      end
+    end
+
+    :ok
+  end
+
+  defp evict_remote_bundle(_state, _node_id, _workload, _snapshot_ref), do: :ok
 
   # -- shared fail path ------------------------------------------------------
 
@@ -1755,6 +1974,14 @@ defmodule Embervm.SessionManager do
 
   defp default_evict(channel, %EvictSnapshotRequest{} = req) do
     Embervm.Node.V1.NodeService.Stub.evict_snapshot(channel, req)
+  end
+
+  defp default_restore_artifact(channel, %RestoreArtifactRequest{} = req) do
+    Embervm.Node.V1.NodeService.Stub.restore_artifact(channel, req)
+  end
+
+  defp default_evict_artifact(channel, %EvictArtifactRequest{} = req) do
+    Embervm.Node.V1.NodeService.Stub.evict_artifact(channel, req)
   end
 
   defp default_clock, do: System.system_time(:millisecond)

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -145,7 +145,10 @@ defmodule Embervm.StatefulManager do
   alias Embervm.{EndpointPublisher, NodeCapacity, StatefulState, StatefulStore, WorkloadCatalog}
 
   alias Embervm.Node.V1.{
+    ArtifactRef,
+    EvictArtifactRequest,
     ResourceSpec,
+    RestoreArtifactRequest,
     StartStatefulRequest,
     StartStatefulResponse,
     StopStatefulRequest,
@@ -286,6 +289,22 @@ defmodule Embervm.StatefulManager do
       start_stateful_fun: Keyword.get(opts, :start_stateful_fun, &default_start_stateful/2),
       stop_stateful_fun: Keyword.get(opts, :stop_stateful_fun, &default_stop_stateful/2),
       delete_volume_fun: Keyword.get(opts, :delete_volume_fun, &default_delete_volume/2),
+      # Restore-on-miss seam (R6, Task 8): (channel, %RestoreArtifactRequest{}) ->
+      # {:ok, %RestoreArtifactResponse{}} | {:error, _}. Fetches a banked STATEFUL
+      # bundle or a VOLUME back onto local disk from the object store before a wake
+      # relights/cold-boots on a TRUE local miss. Injected for tests; production
+      # dials the real NodeService stub.
+      restore_artifact_fun: Keyword.get(opts, :restore_artifact_fun, &default_restore_artifact/2),
+      # Remote artifact eviction seam (R6, Task 9): (channel, %EvictArtifactRequest{})
+      # -> {:ok, %EvictArtifactResponse{}} | {:error, _}. Fired alongside DeleteVolume
+      # so the store copy of a workload's VOLUME is dropped on the same workload-
+      # deletion trigger. The generation guard holds by construction here: delete is
+      # refused while ANY non-terminal instance exists, so no bundle still pairs with
+      # the volume generation being evicted (standing decision 8). Injected for tests.
+      evict_artifact_fun: Keyword.get(opts, :evict_artifact_fun, &default_evict_artifact/2),
+      # The op-log the restore audit record (:artifact_restored) is appended to.
+      # Injected for tests; production uses the SQLite backend.
+      op_log: Keyword.get(opts, :op_log, Embervm.OpLog.SQLite),
       # R4, D-R4.PR-7.1 (MMDS-lite over boot-args): reads a K8s Secret into a
       # decoded key/value map for cold_request/2 to populate mmds_env from.
       # Injected so tests can fake the K8s round-trip; production defaults to
@@ -601,7 +620,7 @@ defmodule Embervm.StatefulManager do
     # worth its own child span at this granularity).
     wake_start = :opentelemetry.timestamp()
     plan = plan_wake(state, workload)
-    cold = match?({:cold, _, _, _, _}, plan)
+    cold = match?({:cold, _, _, _, _}, plan) or match?({:restore_volume_then_cold, _, _, _}, plan)
     state = stamp_wake_trace(state, workload, %{wake_start: wake_start, cold: cold})
 
     # Stamp the wake's start (for the adoption stuck-check + park_full age) and arm the
@@ -628,9 +647,45 @@ defmodule Embervm.StatefulManager do
             send(self(), {:wake_done, workload, {:error, {:relight_mark, reason}}})
         end
 
+      # Restore-on-miss (R6): the local bundle is gone but its store copy is
+      # recoverable. Restore the STATEFUL bundle inside the wake worker FIRST (so
+      # park/single-flight semantics are unchanged), then relight exactly as the
+      # warm path. The restore failing (store unreachable mid-wake, or the copy
+      # vanished) degrades to the daemon's cold-boot fallback via the boot_image_ref
+      # that rides the relight request (fail-open warmth).
+      {:restore_then_relight, instance, node_id, snapshot_ref} ->
+        case StatefulStore.mark(state.store, instance.instance_id, :relight) do
+          {:ok, _} ->
+            fallback_ref = boot_image_ref(state, node_id, workload)
+            req = relight_request(entry, snapshot_ref, fallback_ref)
+
+            spawn_wake(owner, workload, fn ->
+              _ = restore_bundle(state, node_id, workload, snapshot_ref)
+              run_relight(state, instance, node_id, req)
+            end)
+
+          {:error, reason} ->
+            send(self(), {:wake_done, workload, {:error, {:relight_mark, reason}}})
+        end
+
       {:cold, node_id, boot_ref, mode, reason} ->
         req = cold_request(state, entry, workload, boot_ref, mode)
         spawn_wake(owner, workload, fn -> run_cold(state, workload, node_id, boot_ref, mode, reason, req) end)
+
+      # Restore-on-miss (R6): the volume itself is gone but a (vol.img, gen) pair is
+      # exported. Restore the VOLUME inside the wake worker FIRST, then cold-boot at
+      # the restored generation (COLD mode: the volume already exists after the
+      # restore, no create). A restore failure degrades to a plain cold boot, which
+      # for a truly-absent volume the daemon fails closed on (data fails closed).
+      {:restore_volume_then_cold, wl, node_id, volume} ->
+        boot_ref = boot_image_ref(state, node_id, wl)
+        req = cold_request(state, entry, wl, boot_ref, :cold)
+        reason = cold_reason(volume)
+
+        spawn_wake(owner, workload, fn ->
+          _ = restore_volume(state, node_id, wl, volume)
+          run_cold(state, wl, node_id, boot_ref, :cold, reason, req)
+        end)
 
       {:error, reason} ->
         send(self(), {:wake_done, workload, {:error, reason}})
@@ -698,14 +753,32 @@ defmodule Embervm.StatefulManager do
       nil ->
         # No bundle to resume: a genuine FRESH first boot (no volume yet, reason
         # nil -> stateful_started) or a COLD boot against an existing volume whose
-        # bundle is gone (reason :no_bundle -> stateful_cold_booted{no_bundle}).
-        cold_plan(state, workload, volume, cold_reason(volume))
+        # bundle is gone (reason :no_bundle -> stateful_cold_booted{no_bundle}). If
+        # the volume ITSELF is missing locally but a (vol.img, gen) pair is exported
+        # (exported_generation > 0) and the store is reachable, restore the volume
+        # first, then cold-boot at the restored generation (R6 restore-on-miss).
+        restore_volume_or_cold(state, workload, volume)
 
       instance ->
         if StatefulStore.pair_valid?(state.store, workload) do
           case anchor_node(state, volume) do
-            {:ok, node_id} -> {:relight, instance, node_id, instance.snapshot_ref}
-            {:error, reason} -> {:error, reason}
+            {:ok, node_id} ->
+              # Local banked bundle present on the anchor node -> relight it (the
+              # existing warm path). Local bundle GONE (disk lost) but its store copy
+              # is recoverable (the volume's exported_generation matches the bundle's
+              # snapshot_generation) and the store is reachable -> restore the bundle
+              # first, then relight (R6 restore-on-miss). An unreachable store or a
+              # missing store copy falls through to the existing relight attempt,
+              # which the daemon degrades to a cold boot (fail-open warmth).
+              if bundle_local?(state, node_id, instance.snapshot_ref) or
+                   not bundle_restorable?(state, node_id, instance, volume) do
+                {:relight, instance, node_id, instance.snapshot_ref}
+              else
+                {:restore_then_relight, instance, node_id, instance.snapshot_ref}
+              end
+
+            {:error, reason} ->
+              {:error, reason}
           end
         else
           # Broken pair: evict the stale bundle through the durable path (so a
@@ -732,6 +805,88 @@ defmodule Embervm.StatefulManager do
   # bundle to resume, e.g. after a forced roll).
   defp cold_reason(nil), do: nil
   defp cold_reason(_volume), do: :no_bundle
+
+  # -- restore-on-miss (R6, Task 8) -------------------------------------------
+
+  # No banked bundle to resume. If the VOLUME itself is missing locally but a
+  # (vol.img, gen) pair is exported and the store is reachable, restore the volume
+  # first then cold-boot at the restored generation; otherwise the ordinary cold
+  # plan (FRESH first boot or COLD against an existing volume). A missing volume
+  # ROW whose exported_generation is unknown here (no fact at all) cannot restore,
+  # so it stays a fresh boot: exported_generation only survives as a node fact while
+  # the volume is at least reported, which is exactly the "disk present, bundle
+  # lost" case restore-on-miss targets.
+  defp restore_volume_or_cold(state, workload, volume) do
+    cond do
+      volume_restorable?(state, volume) ->
+        # The anchor node still reports the volume row (so exported_generation is
+        # known) but the local pair is unusable; restore the exported volume pair,
+        # then cold-boot at that generation. anchor_node guards the node is present.
+        case anchor_node(state, volume) do
+          {:ok, node_id} -> {:restore_volume_then_cold, workload, node_id, volume}
+          {:error, reason} -> {:error, reason}
+        end
+
+      true ->
+        cold_plan(state, workload, volume, cold_reason(volume))
+    end
+  end
+
+  # Whether the anchor node still reports the instance's bundle on LOCAL disk (its
+  # snapshot_ref is in the node's stateful_bundles). A relight needs no restore when
+  # true; a true local miss (false) may consult the store.
+  defp bundle_local?(state, node_id, snapshot_ref) when is_binary(snapshot_ref) and snapshot_ref != "" do
+    case NodeCapacity.fetch(state.capacity_table, node_id) do
+      {:ok, fact} ->
+        fact
+        |> Map.get(:stateful_bundles, [])
+        |> Enum.any?(&(&1.snapshot_ref == snapshot_ref))
+
+      :error ->
+        false
+    end
+  end
+
+  defp bundle_local?(_state, _node_id, _ref), do: false
+
+  # Whether a locally-missing bundle can be restored from the store: the store is
+  # reachable AND the volume's exported_generation equals the bundle's stamped
+  # snapshot_generation (the store holds a matching (bundle, volume-gen) pair). The
+  # generation match keeps restore generation-safe: a restored bundle still only
+  # relights against its matching volume generation (pairing rules unchanged).
+  # store_reachable == false NEVER blocks the local-state wake here, it only
+  # withholds the restore so the wake degrades to the existing relight/cold path
+  # (fail-open warmth, standing decision 7).
+  defp bundle_restorable?(state, node_id, instance, volume) do
+    store_reachable?(state, node_id) and
+      is_integer(instance.snapshot_generation) and
+      exported_generation(volume) == instance.snapshot_generation
+  end
+
+  # Whether a missing/broken-pair volume can be restored: the store is reachable
+  # and a (vol.img, gen) pair is exported (exported_generation > 0). The node the
+  # volume is anchored to owns the store reachability verdict.
+  defp volume_restorable?(_state, nil), do: false
+
+  defp volume_restorable?(state, %{node_id: node_id} = volume) when is_binary(node_id) do
+    store_reachable?(state, node_id) and exported_generation(volume) > 0
+  end
+
+  defp volume_restorable?(_state, _volume), do: false
+
+  defp exported_generation(nil), do: 0
+  defp exported_generation(volume), do: Map.get(volume, :exported_generation, 0) || 0
+
+  # The anchor node's latest object-store reachability verdict (R6). Absent/false
+  # (a node with no store configured, or one that never reported) reads as NOT
+  # reachable, so no restore is attempted and the wake degrades to cold (never
+  # blocked: this only gates the store consultation, never a local-state wake).
+  defp store_reachable?(state, node_id) do
+    case NodeCapacity.fetch(state.capacity_table, node_id) do
+      {:ok, fact} -> Map.get(fact, :store_reachable, false) == true
+      :error -> false
+    end
+  end
 
   # Cold placement: FRESH (no volume row exists yet, the daemon must create it)
   # when `volume` is nil; COLD (an existing volume, no bundle to resume) otherwise.
@@ -1369,6 +1524,11 @@ defmodule Embervm.StatefulManager do
     else
       volume = StatefulStore.get_volume(state.store, workload)
       _ = safe_delete_volume(state, volume, workload)
+      # R6, Task 9: the store copy of the volume follows the local deletion. Safe
+      # without a further pairing guard: delete was refused above while any
+      # non-terminal instance existed, so no banked bundle still pairs with this
+      # volume's generation (standing decision 8). Best-effort.
+      _ = evict_remote_volume(state, volume, workload)
 
       case StatefulStore.delete_volume(state.store, workload) do
         :ok ->
@@ -1598,7 +1758,13 @@ defmodule Embervm.StatefulManager do
         node_id: f.configured_id,
         generation: v.generation,
         size_bytes: v.size_bytes,
-        allocated_bytes: v.allocated_bytes
+        allocated_bytes: v.allocated_bytes,
+        # exported_generation (R6): the volume generation whose (vol.img, gen) pair
+        # the store currently holds. Carried into the ETS volume fact so a wake can
+        # decide restore-on-miss (a lost local bundle whose snapshot_generation
+        # equals this can be recovered from the store) even after the local bundle
+        # fact is gone. 0/absent when no store copy exists.
+        exported_generation: Map.get(v, :exported_generation, 0)
       })
     end
 
@@ -1715,6 +1881,147 @@ defmodule Embervm.StatefulManager do
     kind, reason -> {:error, {:channel_raised, {kind, reason}}}
   end
 
+  # -- restore-on-miss RPC (R6, Task 8) ---------------------------------------
+
+  # Restore the STATEFUL bundle for `workload` from the object store back onto the
+  # anchor node's disk (RestoreArtifact, kind STATEFUL), then record :artifact_restored.
+  # Best-effort: a restore failure returns :error and the caller (the wake worker)
+  # falls through to the relight, which the daemon degrades to a cold boot via the
+  # boot_image_ref that rides the request (fail-open warmth). Idempotent on the
+  # daemon side, so a re-run of a partially-restored artifact is safe.
+  defp restore_bundle(state, node_id, workload, snapshot_ref) do
+    ref = %ArtifactRef{kind: :ARTIFACT_KIND_STATEFUL, workload: workload, ref: snapshot_ref}
+
+    case safe_restore_artifact(state, node_id, ref) do
+      {:ok, resp} ->
+        record_restore(state, workload, :ARTIFACT_KIND_STATEFUL, snapshot_ref, resp)
+        :ok
+
+      other ->
+        Logger.warning("embervm stateful: bundle restore-on-miss failed, degrading to cold",
+          workload: workload,
+          snapshot_ref: snapshot_ref,
+          reason: inspect(other)
+        )
+
+        :error
+    end
+  end
+
+  # Restore the VOLUME for `workload` (kind VOLUME, ref is the workload's own name,
+  # per the ArtifactRef contract for a singleton volume) from the exported
+  # (vol.img, gen) pair, then record :artifact_restored. Best-effort, same as
+  # restore_bundle: a failure degrades to a plain cold boot (which the daemon fails
+  # closed on for a truly-absent volume).
+  defp restore_volume(state, node_id, workload, _volume) do
+    ref = %ArtifactRef{kind: :ARTIFACT_KIND_VOLUME, workload: workload, ref: workload}
+
+    case safe_restore_artifact(state, node_id, ref) do
+      {:ok, resp} ->
+        record_restore(state, workload, :ARTIFACT_KIND_VOLUME, workload, resp)
+        :ok
+
+      other ->
+        Logger.warning("embervm stateful: volume restore-on-miss failed, degrading to cold",
+          workload: workload,
+          reason: inspect(other)
+        )
+
+        :error
+    end
+  end
+
+  defp safe_restore_artifact(state, node_id, %ArtifactRef{} = ref) do
+    req = %RestoreArtifactRequest{artifact: ref, trace: %Trace{workload: ref.workload}}
+
+    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+      try do
+        case state.restore_artifact_fun.(channel, req) do
+          {:error, reason} = err ->
+            if Embervm.NodeChannel.transport_dead?(reason) do
+              _ = state.invalidate_fun.(node_id, channel)
+            end
+
+            err
+
+          other ->
+            other
+        end
+      rescue
+        e -> {:error, {:restore_artifact_raised, e}}
+      catch
+        :exit, reason ->
+          _ = state.invalidate_fun.(node_id, channel)
+          {:error, {:restore_artifact_raised, {:exit, reason}}}
+
+        kind, reason ->
+          {:error, {:restore_artifact_raised, {kind, reason}}}
+      end
+    end
+  end
+
+  # Append the audit-only :artifact_restored op (no projection table; the log itself
+  # is the record). Best-effort: an append failure must never fail the wake, which
+  # already ran the restore RPC (the durable state is the restored bytes on disk,
+  # not this audit row).
+  defp record_restore(state, workload, kind, ref, resp) do
+    op = %Embervm.OpLog.Op{
+      kind: :artifact_restored,
+      tenant: state.tenant,
+      principal: wake_principal(workload),
+      workload: workload,
+      ts: state.clock.(),
+      payload: %{
+        kind: artifact_kind_string(kind),
+        ref: ref,
+        bytes_moved: Map.get(resp, :bytes_moved, 0),
+        generation: Map.get(resp, :generation, 0),
+        skipped: Map.get(resp, :skipped, false)
+      }
+    }
+
+    _ = Embervm.OpLog.SQLite.append(state.op_log, op)
+    :ok
+  rescue
+    e ->
+      Logger.warning("embervm stateful: artifact_restored append raised", workload: workload, error: inspect(e))
+      :ok
+  end
+
+  defp artifact_kind_string(:ARTIFACT_KIND_STATEFUL), do: "stateful"
+  defp artifact_kind_string(:ARTIFACT_KIND_VOLUME), do: "volume"
+  defp artifact_kind_string(other), do: to_string(other)
+
+  # -- remote volume eviction (R6, Task 9) ------------------------------------
+
+  # Drop the store copy of a workload's VOLUME (EvictArtifact, remote=true, kind
+  # VOLUME) alongside DeleteVolume. Best-effort; the daemon refuses the evict if a
+  # bundle still pairs (its own generation guard), and here delete was already
+  # refused while any instance existed, so the guard is doubly held.
+  defp evict_remote_volume(state, %{node_id: node_id}, workload) when is_binary(node_id) do
+    artifact = %ArtifactRef{kind: :ARTIFACT_KIND_VOLUME, workload: workload, ref: workload}
+    req = %EvictArtifactRequest{artifact: artifact, remote: true, trace: %Trace{workload: workload}}
+
+    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+      try do
+        state.evict_artifact_fun.(channel, req)
+      rescue
+        _ -> :error
+      catch
+        :exit, _ ->
+          _ = state.invalidate_fun.(node_id, channel)
+          :error
+
+        _, _ ->
+          :error
+      end
+    end
+
+    :ok
+  end
+
+  defp evict_remote_volume(_state, _volume, _workload), do: :ok
+
   defp default_start_stateful(channel, req) do
     Embervm.Node.V1.NodeService.Stub.start_stateful(channel, req)
   end
@@ -1725,6 +2032,14 @@ defmodule Embervm.StatefulManager do
 
   defp default_delete_volume(channel, req) do
     Embervm.Node.V1.NodeService.Stub.delete_volume(channel, req)
+  end
+
+  defp default_restore_artifact(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.restore_artifact(channel, req)
+  end
+
+  defp default_evict_artifact(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.evict_artifact(channel, req)
   end
 
   # -- misc --------------------------------------------------------------------

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -764,14 +764,19 @@ defmodule Embervm.StatefulManager do
           case anchor_node(state, volume) do
             {:ok, node_id} ->
               # Local banked bundle present on the anchor node -> relight it (the
-              # existing warm path). Local bundle GONE (disk lost) but its store copy
-              # is recoverable (the volume's exported_generation matches the bundle's
-              # snapshot_generation) and the store is reachable -> restore the bundle
-              # first, then relight (R6 restore-on-miss). An unreachable store or a
-              # missing store copy falls through to the existing relight attempt,
-              # which the daemon degrades to a cold boot (fail-open warmth).
+              # existing warm path). Local bundle GONE from disk (a TRUE local miss)
+              # AND the anchor node's store is reachable -> attempt an OPTIMISTIC
+              # restore first, then relight (R6 restore-on-miss, option b). The CP
+              # does not track remote inventory: it attempts the restore whenever the
+              # local copy is missing and the store is reachable, and the daemon fails
+              # closed (FAILED_PRECONDITION) if no store copy exists, which degrades
+              # to the relight's own cold-boot fallback. store_reachable == false
+              # never blocks the wake, it only withholds the restore (fail-open
+              # warmth, standing decision 7). Generation pairing is unchanged: a
+              # restored bundle still only relights against its matching volume
+              # generation, enforced by the daemon at RELIGHT time.
               if bundle_local?(state, node_id, instance.snapshot_ref) or
-                   not bundle_restorable?(state, node_id, instance, volume) do
+                   not store_reachable?(state, node_id) do
                 {:relight, instance, node_id, instance.snapshot_ref}
               else
                 {:restore_then_relight, instance, node_id, instance.snapshot_ref}
@@ -848,20 +853,6 @@ defmodule Embervm.StatefulManager do
   end
 
   defp bundle_local?(_state, _node_id, _ref), do: false
-
-  # Whether a locally-missing bundle can be restored from the store: the store is
-  # reachable AND the volume's exported_generation equals the bundle's stamped
-  # snapshot_generation (the store holds a matching (bundle, volume-gen) pair). The
-  # generation match keeps restore generation-safe: a restored bundle still only
-  # relights against its matching volume generation (pairing rules unchanged).
-  # store_reachable == false NEVER blocks the local-state wake here, it only
-  # withholds the restore so the wake degrades to the existing relight/cold path
-  # (fail-open warmth, standing decision 7).
-  defp bundle_restorable?(state, node_id, instance, volume) do
-    store_reachable?(state, node_id) and
-      is_integer(instance.snapshot_generation) and
-      exported_generation(volume) == instance.snapshot_generation
-  end
 
   # Whether a missing/broken-pair volume can be restored: the store is reachable
   # and a (vol.img, gen) pair is exported (exported_generation > 0). The node the

--- a/projects/embervm/control/lib/embervm/stateful_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/stateful_sweeper.ex
@@ -144,6 +144,8 @@ defmodule Embervm.StatefulSweeper do
   alias Embervm.OpLog.Op
 
   alias Embervm.Node.V1.{
+    ArtifactRef,
+    EvictArtifactRequest,
     EvictSnapshotRequest,
     ResolveStatefulRequest,
     ResolveStatefulResponse,
@@ -237,6 +239,12 @@ defmodule Embervm.StatefulSweeper do
       # production dials the real NodeService stub.
       resolve_stateful_fun: Keyword.get(opts, :resolve_stateful_fun, &default_resolve_stateful/2),
       evict_snapshot_fun: Keyword.get(opts, :evict_snapshot_fun, &default_evict_snapshot/2),
+      # Remote artifact eviction seam (R6, Task 9): (channel, %EvictArtifactRequest{})
+      # -> {:ok, %EvictArtifactResponse{}} | {:error, _}. Fired alongside the local
+      # EvictSnapshot so the store copy of a banked bundle is dropped on the same
+      # triggers (banked TTL, superseded generation). Injected for tests; production
+      # dials the real NodeService stub.
+      evict_artifact_fun: Keyword.get(opts, :evict_artifact_fun, &default_evict_artifact/2),
       # status.stateful {state,generation,bundleGeneration,volumeBytes} writer
       # (Task 10). Defaults to the K8s merge-patch on the workload status
       # subresource, the same seam ServingSweeper.status_writer uses; tests inject
@@ -1482,10 +1490,25 @@ defmodule Embervm.StatefulSweeper do
   # -- eager broken-pair eviction ----------------------------------------------
 
   # Runs the store's sweep primitive every tick, so a bundle whose pair broke
-  # (the volume's generation moved out from under it) is evicted before the
-  # next wake discovers it stale.
+  # (the volume's generation moved out from under it, a superseded-generation
+  # eviction) is evicted before the next wake discovers it stale. R6, Task 9: the
+  # store copy of each just-evicted bundle follows the local eviction on the same
+  # trigger. The primitive returns the evicted instance_ids; we read each one's
+  # last-known node/ref (it is now terminal but still in the store) to target the
+  # remote evict. A bundle whose row no longer resolves is skipped (nothing to
+  # target). The VOLUME is never evicted here: a broken pair means the volume moved
+  # ON to a newer generation, which is exactly a generation a live/future bundle
+  # will pair with, so the store must keep it (generation guard, standing decision 8).
   defp eager_evict_broken_pairs(state) do
-    _ = StatefulStore.eager_evict_broken_pairs(state.store)
+    evicted = StatefulStore.eager_evict_broken_pairs(state.store)
+
+    for instance_id <- evicted do
+      case StatefulStore.get(state.store, instance_id) do
+        {:ok, instance} -> _ = evict_remote_bundle(state, instance)
+        _ -> :ok
+      end
+    end
+
     state
   end
 
@@ -1511,6 +1534,12 @@ defmodule Embervm.StatefulSweeper do
 
   defp evict_banked(state, instance, reason) do
     _ = evict_snapshot(state, instance)
+    # R6, Task 9: the store copy of the bundle follows the local eviction on the
+    # same trigger (banked TTL, superseded generation). Best-effort and idempotent
+    # on the daemon side; a store copy that was never made is an already-absent
+    # no-op. The VOLUME is never touched here (bundle eviction never strands a
+    # volume generation), so no pairing guard applies to this call.
+    _ = evict_remote_bundle(state, instance)
 
     _ =
       StatefulStore.transition(
@@ -1562,6 +1591,31 @@ defmodule Embervm.StatefulSweeper do
   end
 
   defp evict_snapshot(_state, _instance), do: :ok
+
+  # R6, Task 9: drop the store copy of a banked STATEFUL bundle (EvictArtifact,
+  # remote=true, kind STATEFUL) alongside the local EvictSnapshot. Best-effort: a
+  # failure never wedges the sweep (the local eviction and durable transition are
+  # authoritative; a stranded store copy is swept later by the remote-orphan
+  # reconcile). Idempotent on the daemon; an already-absent store copy is a no-op.
+  defp evict_remote_bundle(state, %{node_id: node_id, snapshot_ref: ref, workload: workload})
+       when is_binary(node_id) and is_binary(ref) and ref != "" do
+    artifact = %ArtifactRef{kind: :ARTIFACT_KIND_STATEFUL, workload: workload, ref: ref}
+    req = %EvictArtifactRequest{artifact: artifact, remote: true, trace: %Trace{workload: workload}}
+
+    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+      try do
+        state.evict_artifact_fun.(channel, req)
+      rescue
+        _ -> :error
+      catch
+        _, _ -> :error
+      end
+    end
+
+    :ok
+  end
+
+  defp evict_remote_bundle(_state, _instance), do: :ok
 
   # -- per-node bank cap --------------------------------------------------------
 
@@ -1687,6 +1741,10 @@ defmodule Embervm.StatefulSweeper do
 
   defp default_evict_snapshot(channel, req) do
     Embervm.Node.V1.NodeService.Stub.evict_snapshot(channel, req)
+  end
+
+  defp default_evict_artifact(channel, req) do
+    Embervm.Node.V1.NodeService.Stub.evict_artifact(channel, req)
   end
 
   defp default_resolve_stateful(channel, req) do

--- a/projects/embervm/control/test/embervm/group_wake_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_wake_manager_test.exs
@@ -171,6 +171,7 @@ defmodule Embervm.GroupWakeManagerTest do
         pod_ip: "10.0.0.9",
         clock: clock,
         channel_fun: fn _node -> {:ok, :ch} end,
+        op_log: op_log,
         reconcile_interval_ms: 0
       ] ++ Keyword.take(opts, [:wake_bound_ms, :mono_clock, :restore_artifact_fun])
 

--- a/projects/embervm/control/test/embervm/group_wake_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_wake_manager_test.exs
@@ -266,11 +266,11 @@ defmodule Embervm.GroupWakeManagerTest do
     ctx = start_stack(instance_id: "g-restore", restore_artifact_fun: restore_fun)
     _ = seed_banked(ctx, "g-restore", "set-r")
 
-    # The node reports the set as a STORE-ONLY marker: exported=true but no local
-    # member bundles (empty members list), i.e. the local disk lost the set. The
-    # store is reachable, so the wake restores the whole GROUP_SET then relights.
+    # The node reports NO local bundle set for this group (a true local miss: the
+    # disk lost it) but a reachable store. Optimistic restore-on-miss then restores
+    # the whole GROUP_SET before the delegated relight.
     seed_node(ctx, %{
-      group_bundle_sets: [%{set_id: "set-r", group_instance_id: "g-restore", members: [], exported: true}],
+      group_bundle_sets: [],
       store_reachable: true
     })
 
@@ -294,7 +294,7 @@ defmodule Embervm.GroupWakeManagerTest do
     _ = seed_banked(ctx, "g-nostore", "set-n")
 
     seed_node(ctx, %{
-      group_bundle_sets: [%{set_id: "set-n", group_instance_id: "g-nostore", members: [], exported: true}],
+      group_bundle_sets: [],
       store_reachable: false
     })
 

--- a/projects/embervm/control/test/embervm/group_wake_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_wake_manager_test.exs
@@ -170,8 +170,9 @@ defmodule Embervm.GroupWakeManagerTest do
         port_base: 30_000,
         pod_ip: "10.0.0.9",
         clock: clock,
+        channel_fun: fn _node -> {:ok, :ch} end,
         reconcile_interval_ms: 0
-      ] ++ Keyword.take(opts, [:wake_bound_ms, :mono_clock])
+      ] ++ Keyword.take(opts, [:wake_bound_ms, :mono_clock, :restore_artifact_fun])
 
     {:ok, mgr} = GroupWakeManager.start_link(mgr_opts)
 
@@ -249,6 +250,56 @@ defmodule Embervm.GroupWakeManagerTest do
     {creates, wakes, _adopts} = sup_counts()
     assert creates == 0
     assert wakes == 1
+  end
+
+  # -- restore-on-miss (R6, Task 8) -------------------------------------------
+
+  test "a complete exported set whose local bundles are gone RESTORES then relights" do
+    {:ok, restore_calls} = Agent.start_link(fn -> [] end)
+
+    restore_fun = fn _ch, req ->
+      art = req.artifact
+      Agent.update(restore_calls, &[%{kind: art.kind, ref: art.ref, workload: art.workload} | &1])
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{bytes_moved: 8192, skipped: false}}
+    end
+
+    ctx = start_stack(instance_id: "g-restore", restore_artifact_fun: restore_fun)
+    _ = seed_banked(ctx, "g-restore", "set-r")
+
+    # The node reports the set as a STORE-ONLY marker: exported=true but no local
+    # member bundles (empty members list), i.e. the local disk lost the set. The
+    # store is reachable, so the wake restores the whole GROUP_SET then relights.
+    seed_node(ctx, %{
+      group_bundle_sets: [%{set_id: "set-r", group_instance_id: "g-restore", members: [], exported: true}],
+      store_reachable: true
+    })
+
+    assert {:ok, %{ip: "10.0.0.9", port: 30_010}} = GroupWakeManager.wake(ctx.mgr, "grp-a", "system:group:grp-a")
+
+    # RestoreArtifact was issued for the whole set, and the delegated relight ran.
+    assert [%{kind: :ARTIFACT_KIND_GROUP_SET, ref: "set-r", workload: "grp-a"}] = Agent.get(restore_calls, & &1)
+    {_creates, wakes, _adopts} = sup_counts()
+    assert wakes == 1
+
+    # The restore is auditable from the op-log alone.
+    {:ok, ops} = SQLite.read_from(ctx.op_log, 0)
+    assert Enum.any?(ops, &(&1.kind == :artifact_restored and &1.payload["ref"] == "set-r"))
+  end
+
+  test "an unreachable store on a set miss attempts no restore and relights (fresh-fallback) as before" do
+    {:ok, restore_calls} = Agent.start_link(fn -> [] end)
+    restore_fun = fn _ch, _req -> Agent.update(restore_calls, &[:called | &1]) && {:error, :unused} end
+
+    ctx = start_stack(instance_id: "g-nostore", restore_artifact_fun: restore_fun)
+    _ = seed_banked(ctx, "g-nostore", "set-n")
+
+    seed_node(ctx, %{
+      group_bundle_sets: [%{set_id: "set-n", group_instance_id: "g-nostore", members: [], exported: true}],
+      store_reachable: false
+    })
+
+    assert {:ok, %{ip: "10.0.0.9", port: 30_010}} = GroupWakeManager.wake(ctx.mgr, "grp-a", "system:group:grp-a")
+    assert Agent.get(restore_calls, & &1) == []
   end
 
   test "create path: no instance at all -> exactly one create_group, N replies" do

--- a/projects/embervm/control/test/embervm/serving_manager_test.exs
+++ b/projects/embervm/control/test/embervm/serving_manager_test.exs
@@ -65,9 +65,10 @@ defmodule Embervm.ServingManagerTest do
         channel_fun: fn _node -> {:ok, :ch} end,
         invalidate_fun: Keyword.get(opts, :invalidate_fun, fn _node, _chan -> :ok end),
         start_serving_fun: start_serving_fun,
+        op_log: op_log,
         reconcile_interval_ms: 0,
         id_fun: id_seq(suffix)
-      ] ++ Keyword.take(opts, [:wake_max, :wake_window_ms, :park_cap])
+      ] ++ Keyword.take(opts, [:wake_max, :wake_window_ms, :park_cap, :restore_artifact_fun])
 
     {:ok, mgr} = ServingManager.start_link(mgr_opts)
 
@@ -101,7 +102,8 @@ defmodule Embervm.ServingManagerTest do
         }
       },
       serving_vms: Keyword.get(opts, :serving_vms, []),
-      serving_snapshots: Keyword.get(opts, :serving_snapshots, [])
+      serving_snapshots: Keyword.get(opts, :serving_snapshots, []),
+      store_reachable: Keyword.get(opts, :store_reachable, false)
     })
   end
 
@@ -446,6 +448,56 @@ defmodule Embervm.ServingManagerTest do
     assert {:ok, _} = ServingManager.miss(ctx.mgr, "wl-a", req(), "serving:wl-a")
     # The relight sent the guest port 8080 (serving_workload's serving.port), NOT 30002.
     assert Agent.get(ports, & &1) == [8080]
+  end
+
+  # -- restore-on-miss (R6, Task 8) -------------------------------------------
+
+  test "a banked instance whose snapshot is gone locally but exported RESTORES then relights" do
+    {:ok, restore_calls} = Agent.start_link(fn -> [] end)
+
+    restore_fun = fn _ch, req ->
+      art = req.artifact
+      Agent.update(restore_calls, &[%{kind: art.kind, ref: art.ref, workload: art.workload} | &1])
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{bytes_moved: 2048, skipped: false}}
+    end
+
+    relit_fun = fn _ch, _req ->
+      {:ok, %StartServingResponse{vm_id: "vm-relit", ip: "10.99.0.5", port: 8080}}
+    end
+
+    ctx = start_stack(start_serving_fun: relit_fun, restore_artifact_fun: restore_fun)
+    serving_workload(ctx, "wl-a")
+
+    # The node reports NO serving snapshots (a true local miss) but a reachable store,
+    # so the banked instance stays a relight candidate and the wake restores first.
+    serving_node(ctx, "node-4", serving_snapshots: [], store_reachable: true)
+
+    seed_banked(ctx, "srv-1", "base-a", "serving/s-1", 30002)
+
+    assert {:ok, _} = ServingManager.miss(ctx.mgr, "wl-a", req(), "serving:wl-a")
+
+    assert [%{kind: :ARTIFACT_KIND_SERVING, ref: "serving/s-1", workload: "wl-a"}] = Agent.get(restore_calls, & &1)
+
+    {:ok, ops} = SQLite.read_from(ctx.op_log, 0)
+    assert Enum.any?(ops, &(&1.kind == :artifact_restored and &1.payload["ref"] == "serving/s-1"))
+  end
+
+  test "a banked snapshot gone locally with an UNREACHABLE store attempts no restore and cold-boots" do
+    {:ok, restore_calls} = Agent.start_link(fn -> [] end)
+    restore_fun = fn _ch, _req -> Agent.update(restore_calls, &[:called | &1]) && {:error, :unused} end
+
+    {fun, srcs} = recording_start_fun()
+
+    ctx = start_stack(start_serving_fun: fun, restore_artifact_fun: restore_fun)
+    serving_workload(ctx, "wl-a")
+    serving_node(ctx, "node-4", serving_snapshots: [], store_reachable: false)
+
+    seed_banked(ctx, "srv-1", "base-a", "serving/s-1", 30002)
+
+    assert {:ok, _} = ServingManager.miss(ctx.mgr, "wl-a", req(), "serving:wl-a")
+    # No restore attempted, and the wake cold-booted (a FRESH source, not a relight).
+    assert Agent.get(restore_calls, & &1) == []
+    assert Agent.get(srcs, & &1) == [:fresh]
   end
 
   test "a STALE-lineage banked instance is NOT relit: the wake cold-boots the current base" do

--- a/projects/embervm/control/test/embervm/session_bank_relight_test.exs
+++ b/projects/embervm/control/test/embervm/session_bank_relight_test.exs
@@ -93,6 +93,7 @@ defmodule Embervm.SessionBankRelightTest do
         registry: registry,
         capacity_table: cap_table,
         catalog_table: cat_table,
+        op_log: op_log,
         clock: clock,
         channel_fun: fn _node -> {:ok, :ch} end,
         claim_fun: fn _d, _n, _w -> {:ok, "vm-#{suffix}-#{System.unique_integer([:positive])}"} end,

--- a/projects/embervm/control/test/embervm/session_bank_relight_test.exs
+++ b/projects/embervm/control/test/embervm/session_bank_relight_test.exs
@@ -110,7 +110,9 @@ defmodule Embervm.SessionBankRelightTest do
           :wake_max,
           :wake_window_ms,
           :bank_concurrency,
-          :status_writer
+          :status_writer,
+          :restore_artifact_fun,
+          :evict_artifact_fun
         ])
 
     {:ok, mgr} = SessionManager.start_link(mgr_opts)
@@ -186,6 +188,7 @@ defmodule Embervm.SessionBankRelightTest do
       snapshot_disk_free_bytes: Keyword.get(opts, :free, 10_000_000),
       snapshot_disk_used_bytes: 0,
       draining: false,
+      store_reachable: Keyword.get(opts, :store_reachable, false),
       updated_at: 0
     }
   end
@@ -338,6 +341,42 @@ defmodule Embervm.SessionBankRelightTest do
     assert session.state == :running
     # A session_relit op landed (state back to running with a fresh VM).
     assert [{_pid, _}] = Registry.lookup(ctx.registry, created.session_id)
+  end
+
+  # -- restore-on-miss (R6, Task 8) -------------------------------------------
+
+  test "invoke on a banked session whose bundle is gone locally but exported RESTORES then relights" do
+    test_pid = self()
+
+    restore_fun = fn _ch, req ->
+      art = req.artifact
+      send(test_pid, {:restored, art.kind, art.ref, art.workload})
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{bytes_moved: 2_000, skipped: false}}
+    end
+
+    ctx = start_stack(restore_artifact_fun: restore_fun)
+    put_workload(ctx, "wl")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+    :ok = force_idle_bank(ctx, created.session_id)
+
+    # The node reports NO session snapshots (a true local bundle miss) but a
+    # reachable store: the invoke restores the SESSION bundle then relights against
+    # the same anchor node (bypassing the snapshot-presence placement guard the fresh
+    # restore has not yet reflected).
+    NodeCapacity.put(ctx.cap_table, "node-4", node_fact("wl", session_snapshots: [], store_reachable: true))
+
+    {:ok, resp} = SessionManager.invoke(ctx.mgr, created.session_id, %{method: "POST", path: "/", headers: %{}, body: "restored"})
+    assert resp.status_code == 200
+    assert resp.body == "restored"
+
+    assert_received {:restored, :ARTIFACT_KIND_SESSION, ref, "wl"}
+    assert ref == "snap-#{created.session_id}"
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :running
+
+    {:ok, ops} = Embervm.OpLog.SQLite.read_from(ctx.op_log, 0)
+    assert Enum.any?(ops, &(&1.kind == :artifact_restored))
   end
 
   test "the wake-rate limit 429s an excess relight-triggering invoke without a node hit" do
@@ -609,6 +648,29 @@ defmodule Embervm.SessionBankRelightTest do
     {:ok, session} = SessionStore.get(ctx.store, created.session_id)
     assert session.state == :evicted
     assert session.terminal_reason == "idle_ttl"
+  end
+
+  test "a banked-TTL eviction ALSO issues EvictArtifact(remote) for the session bundle" do
+    test_pid = self()
+
+    evict_artifact_fun = fn _ch, req ->
+      send(test_pid, {:remote_evicted, req.remote, req.artifact.kind, req.artifact.ref})
+      {:ok, %Embervm.Node.V1.EvictArtifactResponse{bytes_freed: 2_000}}
+    end
+
+    ctx = start_stack(evict_artifact_fun: evict_artifact_fun)
+    put_workload(ctx, "wl", max_lifetime_seconds: 100_000, banked_ttl_seconds: 5)
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+    :ok = force_idle_bank(ctx, created.session_id)
+
+    advance(ctx.clock_pid, 10_000)
+    :ok = SessionManager.sweep(ctx.mgr)
+
+    # The local EvictSnapshot fired AND the remote store copy was dropped on the same
+    # trigger (a SESSION artifact, remote=true).
+    assert_received {:evicted, _ref}
+    assert_received {:remote_evicted, true, :ARTIFACT_KIND_SESSION, ref}
+    assert ref == "snap-#{created.session_id}"
   end
 
   test "disk-pressure eviction removes the coldest banked sessions LRU to the watermark" do

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -83,9 +83,20 @@ defmodule Embervm.StatefulManagerTest do
         start_stateful_fun: start_stateful_fun,
         stop_stateful_fun: Keyword.get(opts, :stop_stateful_fun, fn _ch, _req -> {:ok, %Embervm.Node.V1.StopStatefulResponse{}} end),
         get_secret_fun: get_secret_fun,
+        op_log: op_log,
         reconcile_interval_ms: 0,
         id_fun: id_seq(suffix)
-      ] ++ Keyword.take(opts, [:wake_max, :wake_window_ms, :park_cap, :wake_bound_ms, :mono_clock, :wake_timeout_margin_ms])
+      ] ++
+        Keyword.take(opts, [
+          :wake_max,
+          :wake_window_ms,
+          :park_cap,
+          :wake_bound_ms,
+          :mono_clock,
+          :wake_timeout_margin_ms,
+          :restore_artifact_fun,
+          :evict_artifact_fun
+        ])
 
     {:ok, mgr} = StatefulManager.start_link(mgr_opts)
 
@@ -141,7 +152,8 @@ defmodule Embervm.StatefulManagerTest do
       },
       stateful_vms: Keyword.get(opts, :stateful_vms, []),
       stateful_bundles: Keyword.get(opts, :stateful_bundles, []),
-      volumes: Keyword.get(opts, :volumes, [])
+      volumes: Keyword.get(opts, :volumes, []),
+      store_reachable: Keyword.get(opts, :store_reachable, false)
     })
   end
 
@@ -997,5 +1009,132 @@ defmodule Embervm.StatefulManagerTest do
 
     {:ok, healed} = StatefulStore.get(ctx.store, "stf-banked")
     assert healed.state == :banked
+  end
+
+  # -- restore-on-miss (R6, Task 8) -------------------------------------------
+
+  # Records every RestoreArtifact call the manager issues, returning a successful
+  # response. `kind`/`ref`/`workload` are pulled off the ArtifactRef so a test can
+  # assert exactly what was restored.
+  defp recording_restore_fun do
+    {:ok, calls} = Agent.start_link(fn -> [] end)
+
+    fun = fn _ch, req ->
+      art = req.artifact
+      Agent.update(calls, &[%{kind: art.kind, ref: art.ref, workload: art.workload} | &1])
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{bytes_moved: 4096, skipped: false, generation: 3}}
+    end
+
+    {fun, calls}
+  end
+
+  test "a local-bundle miss with an exported pair RESTORES the bundle then relights" do
+    {restore_fun, restore_calls} = recording_restore_fun()
+
+    relit_fun = fn _ch, _req ->
+      {:ok, %StartStatefulResponse{vm_id: "vm-relit", ip: "10.88.0.5", port: 5432, generation: 3, was_relight: true}}
+    end
+
+    ctx = start_stack(start_stateful_fun: relit_fun, restore_artifact_fun: restore_fun)
+    stateful_workload(ctx, "wl-a")
+
+    # The anchor node reports the workload's volume (so exported_generation is
+    # known) but NO local stateful bundle: a true local bundle miss. The store copy
+    # is current (exported_generation == the banked bundle generation) and the store
+    # is reachable, so the wake restores then relights.
+    stateful_node(ctx, "node-4",
+      stateful_bundles: [],
+      volumes: [%{workload: "wl-a", node_id: "node-4", generation: 3, size_bytes: 100, allocated_bytes: 10, exported_generation: 3}],
+      store_reachable: true
+    )
+
+    seed_banked_with_pair(ctx, "stf-banked", "node-4", 3, 3)
+    assert StatefulStore.pair_valid?(ctx.store, "wl-a")
+
+    assert {:ok, %{ip: "10.88.0.5", port: 5432}} = StatefulManager.wake(ctx.mgr, "wl-a", "p")
+
+    # RestoreArtifact was called for the STATEFUL bundle, before the relight landed.
+    assert [%{kind: :ARTIFACT_KIND_STATEFUL, ref: "stateful/stf-banked", workload: "wl-a"}] =
+             Agent.get(restore_calls, & &1)
+
+    # The SAME banked instance relit in place (a warm relight, not a fresh boot).
+    {:ok, relit} = StatefulStore.get(ctx.store, "stf-banked")
+    assert relit.state == :serving
+
+    # gate: the restore is auditable from the op-log alone.
+    {:ok, ops} = SQLite.read_from(ctx.op_log, 0)
+    restored = Enum.find(ops, &(&1.kind == :artifact_restored))
+    assert restored, "expected an artifact_restored op"
+    assert restored.payload["kind"] == "stateful"
+    assert restored.payload["ref"] == "stateful/stf-banked"
+  end
+
+  test "a local-volume miss with an exported (vol, gen) pair RESTORES the volume then cold-boots at that generation" do
+    {restore_fun, restore_calls} = recording_restore_fun()
+
+    cold_fun = fn _ch, _req ->
+      {:ok, %StartStatefulResponse{vm_id: "vm-cold", ip: "10.88.0.7", port: 5432, generation: 3, was_relight: false}}
+    end
+
+    ctx = start_stack(start_stateful_fun: cold_fun, restore_artifact_fun: restore_fun)
+    stateful_workload(ctx, "wl-a")
+
+    # No banked bundle, but the anchor node reports the volume with an exported pair
+    # (exported_generation > 0) and a reachable store: the wake restores the volume
+    # then cold-boots against it.
+    stateful_node(ctx, "node-4",
+      stateful_bundles: [],
+      volumes: [%{workload: "wl-a", node_id: "node-4", generation: 3, size_bytes: 100, allocated_bytes: 10, exported_generation: 3}],
+      store_reachable: true
+    )
+
+    # Seed the volume ETS fact (no banked instance) so plan_wake sees a volume row
+    # with an exported generation.
+    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 3, size_bytes: 100, allocated_bytes: 10, exported_generation: 3})
+
+    assert {:ok, %{ip: "10.88.0.7", port: 5432}} = StatefulManager.wake(ctx.mgr, "wl-a", "p")
+
+    assert [%{kind: :ARTIFACT_KIND_VOLUME, ref: "wl-a", workload: "wl-a"}] = Agent.get(restore_calls, & &1)
+
+    live = Enum.reject(StatefulStore.list(ctx.store, "wl-a"), &Embervm.StatefulState.terminal?(&1.state))
+    assert [inst] = live
+    assert inst.state == :serving
+    assert inst.generation == 3
+  end
+
+  test "an UNREACHABLE store on a true local-bundle miss attempts no restore and degrades to the relight/cold path" do
+    {restore_fun, restore_calls} = recording_restore_fun()
+
+    # The daemon-side relight falls back to a cold boot (the bundle is not on disk),
+    # returning was_relight=false: the CP-side warmth was correctly not consulted.
+    fallback_fun = fn _ch, _req ->
+      {:ok,
+       %StartStatefulResponse{
+         vm_id: "vm-cold",
+         ip: "10.88.0.8",
+         port: 5432,
+         generation: 3,
+         was_relight: false,
+         cold_boot_reason: "no_bundle"
+       }}
+    end
+
+    ctx = start_stack(start_stateful_fun: fallback_fun, restore_artifact_fun: restore_fun)
+    stateful_workload(ctx, "wl-a")
+
+    # True local miss (no local bundle) but the store is UNREACHABLE: fail-open
+    # warmth means the local-state wake still runs, it just never consults the store.
+    stateful_node(ctx, "node-4",
+      stateful_bundles: [],
+      volumes: [%{workload: "wl-a", node_id: "node-4", generation: 3, size_bytes: 100, allocated_bytes: 10, exported_generation: 3}],
+      store_reachable: false
+    )
+
+    seed_banked_with_pair(ctx, "stf-banked", "node-4", 3, 3)
+
+    assert {:ok, %{ip: "10.88.0.8", port: 5432}} = StatefulManager.wake(ctx.mgr, "wl-a", "p")
+
+    # No restore was attempted (store unreachable), and no wake was blocked.
+    assert Agent.get(restore_calls, & &1) == []
   end
 end

--- a/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
@@ -23,7 +23,7 @@ defmodule Embervm.StatefulSweeperTest do
 
   alias Embervm.{NodeCapacity, StatefulStore, StatefulSweeper, WorkloadCatalog}
   alias Embervm.OpLog.SQLite
-  alias Embervm.Node.V1.{EvictSnapshotResponse, ResolveStatefulResponse, StopStatefulResponse}
+  alias Embervm.Node.V1.{EvictArtifactResponse, EvictSnapshotResponse, ResolveStatefulResponse, StopStatefulResponse}
 
   # A publisher that RECORDS each publish/1 cast, mirroring ServingSweeperTest's
   # FakePublisher.
@@ -137,6 +137,13 @@ defmodule Embervm.StatefulSweeperTest do
       {:ok, %EvictSnapshotResponse{}}
     end
 
+    {:ok, evict_artifact_calls} = Agent.start_link(fn -> [] end)
+
+    evict_artifact_fun = fn _ch, req ->
+      Agent.update(evict_artifact_calls, &[req | &1])
+      {:ok, %EvictArtifactResponse{bytes_freed: 4096}}
+    end
+
     sweeper_opts =
       [
         name: nil,
@@ -153,6 +160,7 @@ defmodule Embervm.StatefulSweeperTest do
         stop_stateful_fun: stop_stateful_fun,
         resolve_stateful_fun: resolve_stateful_fun,
         evict_snapshot_fun: evict_snapshot_fun,
+        evict_artifact_fun: evict_artifact_fun,
         manager: fake_mgr,
         parked_fun: fn _wl -> Agent.get(parked, & &1) end,
         flap_abort_threshold: Keyword.get(opts, :flap_abort_threshold, 20),
@@ -190,6 +198,7 @@ defmodule Embervm.StatefulSweeperTest do
       stop_calls: stop_calls,
       bank_fail: bank_fail,
       evict_calls: evict_calls,
+      evict_artifact_calls: evict_artifact_calls,
       status_calls: status_calls,
       resolve_calls: resolve_calls,
       resolve_fail: resolve_fail,
@@ -202,6 +211,7 @@ defmodule Embervm.StatefulSweeperTest do
   defp set_scrape(ctx, reading), do: Agent.update(ctx.scrape_agent, fn _ -> reading end)
   defp stop_calls(ctx), do: Agent.get(ctx.stop_calls, &Enum.reverse(&1))
   defp evict_calls(ctx), do: Agent.get(ctx.evict_calls, &Enum.reverse(&1))
+  defp evict_artifact_calls(ctx), do: Agent.get(ctx.evict_artifact_calls, &Enum.reverse(&1))
   defp status_writes(ctx), do: Agent.get(ctx.status_calls, &Enum.reverse(&1))
   defp resolve_calls(ctx), do: Agent.get(ctx.resolve_calls, &Enum.reverse(&1))
   defp resolved_notes(ctx), do: Agent.get(ctx.resolved_notes, &Enum.reverse(&1))
@@ -590,6 +600,69 @@ defmodule Embervm.StatefulSweeperTest do
     volume = StatefulStore.get_volume(ctx.store, "wl-a")
     assert volume != nil
     assert volume.generation == 1
+  end
+
+  # -- remote retention / GC (R6, Task 9) -------------------------------------
+
+  test "a banked-TTL eviction ALSO issues EvictArtifact(remote) for the bundle; the volume is never remote-evicted" do
+    ctx = start_stack()
+    stateful_workload(ctx, "wl-a", 5400, %{banked_ttl_seconds: 100, max_lifetime_seconds: 1_000_000})
+    stateful_node(ctx, "node-4")
+
+    {:ok, _} =
+      StatefulStore.create_volume(ctx.store, "wl-a", %{
+        node_id: "node-4",
+        generation: 1,
+        size_bytes: 1_073_741_824,
+        allocated_bytes: 100
+      })
+
+    banked_instance(ctx, "sf-1", "wl-a", "vm-1", 1)
+
+    advance(ctx.clock_agent, 200_000)
+    set_scrape(ctx, reading("state-5400", 0, 0))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    # The remote store copy of the bundle is dropped on the SAME trigger: an
+    # EvictArtifact(remote=true) for the STATEFUL bundle. NEVER a VOLUME evict (a
+    # bundle eviction never strands a volume generation, standing decision 8).
+    assert [req] = evict_artifact_calls(ctx)
+    assert req.remote == true
+    assert req.artifact.kind == :ARTIFACT_KIND_STATEFUL
+    assert req.artifact.ref == "snap-sf-1"
+    assert req.artifact.workload == "wl-a"
+    refute Enum.any?(evict_artifact_calls(ctx), &(&1.artifact.kind == :ARTIFACT_KIND_VOLUME))
+  end
+
+  test "the generation guard: a superseded-generation (broken pair) eviction remote-evicts the BUNDLE but never the volume" do
+    ctx = start_stack()
+    stateful_workload(ctx, "wl-a", 5400, %{banked_ttl_seconds: 1_000_000, max_lifetime_seconds: 1_000_000})
+    stateful_node(ctx, "node-4")
+
+    # A volume that has moved ON to generation 5, and a bundle stamped at generation
+    # 2: a broken pair (superseded generation). The eager sweep evicts the stale
+    # bundle. The store must keep the volume (its generation 5 is one a future bundle
+    # will pair with), so no VOLUME remote-evict is ever issued.
+    {:ok, _} =
+      StatefulStore.create_volume(ctx.store, "wl-a", %{
+        node_id: "node-4",
+        generation: 5,
+        size_bytes: 1_073_741_824,
+        allocated_bytes: 100
+      })
+
+    banked_instance(ctx, "sf-stale", "wl-a", "vm-1", 2)
+    refute StatefulStore.pair_valid?(ctx.store, "wl-a")
+
+    set_scrape(ctx, reading("state-5400", 0, 0))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    {:ok, instance} = StatefulStore.get(ctx.store, "sf-stale")
+    assert instance.state == :evicted
+
+    # The bundle's remote copy is dropped; the volume's is NOT (generation guard).
+    assert Enum.any?(evict_artifact_calls(ctx), &(&1.artifact.kind == :ARTIFACT_KIND_STATEFUL and &1.artifact.ref == "snap-sf-stale"))
+    refute Enum.any?(evict_artifact_calls(ctx), &(&1.artifact.kind == :ARTIFACT_KIND_VOLUME))
   end
 
   test "a banked bundle still within bankedTtlSeconds is kept" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.106
+      targetRevision: 0.1.107
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## R6 Continuity, PR-5 (Tasks 8 + 9)

The control-plane side of off-node durability: wakes restore from the store on a
true local miss, and remote copies are evicted in lockstep with local eviction.

### Task 8: restore-on-miss (Fork 4)
- Per-class wake planning order: local banked bundle > store restore then relight >
  cold boot. Stateful adds `:restore_volume_then_cold` for a lost volume with an
  exported (vol, gen) pair; generation pairing rules unchanged.
- New `restore_artifact_fun` seam (default `NodeService.Stub.restore_artifact`,
  injectable) in stateful/serving/session/group managers; the restore runs inside
  the existing wake worker so single-flight and park semantics are unchanged.
- `store_reachable == false` never blocks a local-state wake (fail-open warmth);
  only a true local miss consults the store, degrading to cold boot with a logged
  reason when unreachable.
- NodeRegistry ingests `store_reachable`, per-bundle `exported`, and
  `Volume.exported_generation` into the NodeCapacity projection.
- op-log: `:artifact_exported` / `:artifact_restored` / `:artifact_evicted_remote`
  (closed enum + SQLite audit clause); restores are recorded.

### Task 9: remote retention / GC (standing decision 8)
- Banked-TTL / superseded-generation / workload-deletion eviction paths in the four
  sweepers now also issue `EvictArtifact(remote=true)` via a new `evict_artifact_fun`.
- Generation guard: the remote volume copy is never evicted while a bundle still
  pairs with its generation.

Also fixes two latent placement-gate bugs (serving/session) where a truly-missing
bundle would never reach the restore branch. Tests per class cover restore-then-
relight, volume-restore-then-cold, unreachable-store cold fallback, op-log
recording, remote-evict-on-TTL, and the generation guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)