### PR TITLE
fix(embervm): rebuild group bridge on idempotent CreateGroupNetwork re-issue

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.108
+version: 0.1.109

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.108
+      targetRevision: 0.1.109
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/serving/group.go
+++ b/projects/embervm/noded/serving/group.go
@@ -379,16 +379,41 @@ func (m *GroupManager) validateGroupCIDR(cidr string) (*net.IPNet, error) {
 	return ipnet, nil
 }
 
+// ensureBridgeDeviceLocked (re)creates the group's bridge device idempotently: each
+// setup command tolerates an already-present device ("file exists"), so a healthy
+// bridge is a no-op and a missing one is rebuilt. On a hard (non-exists) failure it
+// tears the partial bridge back down so a failed setup leaks no half-bridge, and
+// returns the error. Shared by the full create path and the idempotent re-issue so
+// both self-heal a bridge that outlived its record. Callers must hold m.mu.
+func (m *GroupManager) ensureBridgeDeviceLocked(ctx context.Context, bridge, gatewayIP string, prefixLen int) error {
+	for _, argv := range groupBridgeSetupArgs(bridge, gatewayIP, prefixLen) {
+		if _, rerr := m.runner.Run(ctx, argv[0], argv[1:]...); rerr != nil {
+			if isAlreadyExists(rerr) {
+				continue
+			}
+			_, _ = m.runner.Run(ctx, "ip", groupBridgeTeardownArgs(bridge)[1:]...)
+			return rerr
+		}
+	}
+	return nil
+}
+
 // CreateGroupNetwork validates cidr (a /24 within the supernet, non-overlapping
 // with an existing group bridge), creates the per-group bridge, and installs the
 // inter-group isolation + entry-DNAT scaffolding by regenerating the whole
 // embervm_group table. It is IDEMPOTENT per group_instance_id: a re-issue for a
 // group that already exists with the SAME cidr returns the existing
-// (bridge, gateway) without touching the bridge (so the control plane can safely
-// re-issue before a relight or an adoption-time rebind). A re-issue with a
-// DIFFERENT cidr, or a cidr that overlaps a DIFFERENT group's /24, is refused
-// (overlapErr, which the caller maps to FAILED_PRECONDITION). It returns the
-// bridge name and the group gateway IP.
+// (bridge, gateway) and ENSURES the kernel bridge device is present, rebuilding it
+// if it is missing. This matters because the in-memory record can outlive the
+// device: the bridge dies with the pod while AdoptGroupNetwork re-seeds the record
+// without it on the next boot, so the control plane's re-issue-before-relight (and
+// adoption-time rebind) is exactly how a missing bridge is rebuilt. Trusting the
+// record instead of the device is the bug that left EnsureMemberTap pinning a tap
+// to a nonexistent bridge ("Device does not exist"). The rebuild is idempotent (a
+// healthy bridge is a no-op) and preserves the existing record's IP allocator. A
+// re-issue with a DIFFERENT cidr, or a cidr that overlaps a DIFFERENT group's /24,
+// is refused (overlapErr, which the caller maps to FAILED_PRECONDITION). It returns
+// the bridge name and the group gateway IP.
 func (m *GroupManager) CreateGroupNetwork(ctx context.Context, groupInstanceID, cidr string) (bridge, gatewayIP string, err error) {
 	if groupInstanceID == "" {
 		return "", "", fmt.Errorf("serving: group_instance_id required")
@@ -401,11 +426,23 @@ func (m *GroupManager) CreateGroupNetwork(ctx context.Context, groupInstanceID, 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Idempotency: an existing group with the SAME /24 is a no-op hit. A different
-	// /24 for the same id is a conflict (the control plane must delete first).
+	// Idempotency: an existing group with the SAME /24 is a hit. A different /24 for
+	// the same id is a conflict (the control plane must delete first).
 	if existing, ok := m.groups[groupInstanceID]; ok {
 		if existing.cidr.String() != ipnet.String() {
 			return "", "", fmt.Errorf("serving: group %q already exists with cidr %v, cannot recreate as %v", groupInstanceID, existing.cidr, ipnet)
+		}
+		// The record can outlive the kernel bridge (it died with the pod and was
+		// re-seeded by AdoptGroupNetwork without the device, or a prior create's
+		// device was removed while the map entry survived). So ENSURE the bridge
+		// exists rather than trust the record; the rebuild is idempotent (a healthy
+		// bridge is a no-op) and keeps the existing record's IP allocator intact.
+		if berr := m.ensureBridgeDeviceLocked(ctx, existing.bridge, existing.gatewayIP.String(), existing.prefixLen); berr != nil {
+			return "", "", berr
+		}
+		// Regenerate the ruleset so the (possibly just-rebuilt) bridge is covered.
+		if aerr := m.applyRulesetLocked(ctx); aerr != nil {
+			return "", "", aerr
 		}
 		return existing.bridge, existing.gatewayIP.String(), nil
 	}
@@ -425,17 +462,8 @@ func (m *GroupManager) CreateGroupNetwork(ctx context.Context, groupInstanceID, 
 	prefixLen, _ := ipnet.Mask.Size()
 	bridgeName := groupBridgeName(groupInstanceID)
 
-	// Create the bridge idempotently (tolerate an already-present device on a
-	// re-entry after a partial prior create).
-	for _, argv := range groupBridgeSetupArgs(bridgeName, gwIP.String(), prefixLen) {
-		if _, rerr := m.runner.Run(ctx, argv[0], argv[1:]...); rerr != nil {
-			if isAlreadyExists(rerr) {
-				continue
-			}
-			// Roll back the bridge fragment so a failed create leaks no half-bridge.
-			_, _ = m.runner.Run(ctx, "ip", groupBridgeTeardownArgs(bridgeName)[1:]...)
-			return "", "", rerr
-		}
+	if berr := m.ensureBridgeDeviceLocked(ctx, bridgeName, gwIP.String(), prefixLen); berr != nil {
+		return "", "", berr
 	}
 
 	g := &groupNet{

--- a/projects/embervm/noded/serving/group_test.go
+++ b/projects/embervm/noded/serving/group_test.go
@@ -251,9 +251,10 @@ func TestGroupManagerCIDRValidation(t *testing.T) {
 	}
 }
 
-// TestGroupManagerCreateIdempotent asserts a re-issue with the same cidr is a
-// no-op hit (same bridge/gateway, no extra bridge-create calls), and a re-issue
-// with a DIFFERENT cidr for the same id is refused.
+// TestGroupManagerCreateIdempotent asserts a re-issue with the same cidr returns
+// the same (bridge, gateway) and re-issues the idempotent bridge setup (so a bridge
+// that outlived its record is rebuilt rather than trusted), and a re-issue with a
+// DIFFERENT cidr for the same id is refused.
 func TestGroupManagerCreateIdempotent(t *testing.T) {
 	fr := &fakeRunner{}
 	m, err := NewGroupManager(fr, "10.101.0.0/16", "", "", 40000)
@@ -273,14 +274,54 @@ func TestGroupManagerCreateIdempotent(t *testing.T) {
 	if br1 != br2 || gw1 != gw2 {
 		t.Errorf("idempotent re-create changed identity: (%s,%s) vs (%s,%s)", br1, gw1, br2, gw2)
 	}
-	// A re-issue must NOT run any new ip/nft commands (no bridge re-create).
-	if len(fr.calls) != callsAfterFirst {
-		t.Errorf("idempotent re-create ran %d extra commands, want 0", len(fr.calls)-callsAfterFirst)
+	// A re-issue must re-run the idempotent bridge setup so a bridge that died with
+	// a prior pod (record survives) is rebuilt, not silently trusted.
+	sawAdd := false
+	for _, c := range fr.calls[callsAfterFirst:] {
+		if strings.Join(c, " ") == fmt.Sprintf("ip link add name %s type bridge", br2) {
+			sawAdd = true
+		}
+	}
+	if !sawAdd {
+		t.Errorf("idempotent re-create did not re-issue the bridge setup; extra calls: %v", fr.calls[callsAfterFirst:])
 	}
 
 	// Same id, different cidr => conflict.
 	if _, _, err := m.CreateGroupNetwork(context.Background(), "grp-A", "10.101.2.0/24"); err == nil {
 		t.Error("re-creating grp-A with a different cidr should conflict")
+	}
+}
+
+// TestGroupManagerCreateRebuildsBridgeAfterAdopt is the regression for the R6
+// drill wedge: AdoptGroupNetwork re-seeds a group record on boot WITHOUT creating
+// the bridge (it died with the prior pod), and a subsequent CreateGroupNetwork
+// re-issue must REBUILD the bridge. Before the fix the idempotency hit short-
+// circuited on the map entry and issued no bridge setup, so EnsureMemberTap later
+// pinned a member tap to a nonexistent bridge ("Device does not exist").
+func TestGroupManagerCreateRebuildsBridgeAfterAdopt(t *testing.T) {
+	fr := &fakeRunner{}
+	m, err := NewGroupManager(fr, "10.101.0.0/16", "", "", 40000)
+	if err != nil {
+		t.Fatalf("NewGroupManager: %v", err)
+	}
+	// Boot rescan seeds the record but not the device.
+	if err := m.AdoptGroupNetwork("grp-A", "10.101.1.0/24", 0); err != nil {
+		t.Fatalf("adopt: %v", err)
+	}
+	callsAfterAdopt := len(fr.calls)
+
+	br, _, err := m.CreateGroupNetwork(context.Background(), "grp-A", "10.101.1.0/24")
+	if err != nil {
+		t.Fatalf("create after adopt: %v", err)
+	}
+	sawAdd := false
+	for _, c := range fr.calls[callsAfterAdopt:] {
+		if strings.Join(c, " ") == fmt.Sprintf("ip link add name %s type bridge", br) {
+			sawAdd = true
+		}
+	}
+	if !sawAdd {
+		t.Fatalf("create after adopt did NOT rebuild the bridge (idempotency short-circuit skipped bridge setup); calls: %v", fr.argvStrings())
 	}
 }
 


### PR DESCRIPTION
## What the R6 continuity drill found

Driving the first live R6 continuity drill (Gate 1: R5 entry path via port 5410), `scratch-k8s` wedged **before** the entry-routing question we came to test. Every wake failed at the first member start:

```
noded: pin group member tap: serving: ip link set emgtb791c7 master emg278367:
  exit status 255: Error: argument "emg278367" is wrong: Device does not exist
```

## Root cause

`serving.CreateGroupNetwork`'s idempotency hit returned the **recorded** bridge name without verifying the kernel device exists. But the in-memory `m.groups` record can outlive the bridge:

- the bridge dies with the noded pod, and `AdoptGroupNetwork` (boot rescan) re-seeds the record **without** recreating the device, or
- a prior create's device was removed while the map entry survived.

So the control plane's re-issue-before-relight (the exact mechanism documented to "rebuild each bridge") short-circuited and never rebuilt it, and `EnsureMemberTap` then pinned a member tap to a nonexistent bridge. Empirically confirmed live: noded netns had **no** `emg*` bridge, the `group_networks` records dir was empty, yet the failure was a *pin* error (not "group not found") — proving a stale record pointing at an absent device. It is a **permanent** wedge: every wake short-circuits identically.

## Fix

Ensure the kernel bridge is actually present on the idempotent path via a shared, idempotent `ensureBridgeDeviceLocked` (a healthy bridge is a no-op; a missing one is rebuilt), then regenerate the ruleset — preserving the existing record's IP allocator. Both the full-create path and the idempotent re-issue now share this helper, so both self-heal a bridge that outlived its record.

## Tests

- `TestGroupManagerCreateRebuildsBridgeAfterAdopt` (new): reproduces the production path — adopt a record (no device), then a create re-issue must rebuild the bridge. Fails on the old code.
- `TestGroupManagerCreateIdempotent` (updated): a re-issue now re-runs the idempotent bridge setup instead of asserting zero extra commands.

## Deploy note

A noded roll to ship this also clears the current in-memory orphan (fresh boot, empty records → next create takes the full path), so the rollout both lands the fix and unwedges `scratch-k8s`. Chart bumped 0.1.108 → 0.1.109.

## Out of scope (separate findings from the same drill)

- The CP's Mint gRPC connection still crashes on noded stream-cancel (`{:server_closed_request, :cancel}`), self-healing via the 0.1.97 `over_channel` invalidation.
- SeaweedFS S3 store returning 500 on export `PUT` (blocks the restore-from-store gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)