### PR TITLE
feat(ember): link the landing page to the project README and repo

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.180
+version: 0.89.181
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.180
+      targetRevision: 0.89.181
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.255
+version: 0.285.256
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.255
+      targetRevision: 0.285.256
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -193,6 +193,12 @@
         <span><b>~{vmRestore} ms</b> VM restore</span>
         <span class="sep">·</span>
         <span>numbers are live</span>
+        <span class="sep">·</span>
+        <a
+          class="src"
+          href="https://github.com/jomcgi/homelab/blob/main/projects/embervm/README.md"
+          >read the README</a
+        >
       </p>
     </header>
 
@@ -550,7 +556,12 @@
         >Elixir/OTP control plane · Go node daemon · Firecracker microVMs ·
         running on this cluster</span
       >
-      <a href="/">jomcgi.dev</a>
+      <span class="foot-links">
+        <a href="https://github.com/jomcgi/homelab/tree/main/projects/embervm"
+          >github.com/jomcgi/homelab</a
+        >
+        <a href="/">jomcgi.dev</a>
+      </span>
     </footer>
   </main>
 </div>
@@ -750,6 +761,21 @@
 
   .stats .sep {
     color: var(--eml-line-strong);
+  }
+
+  .stats .src {
+    color: var(--em-ember-deep);
+    text-decoration: none;
+    border-bottom: 1px solid var(--em-ember-dim);
+  }
+
+  .stats .src:hover {
+    border-bottom-color: var(--em-ember-deep);
+  }
+
+  .stats .src:focus-visible {
+    outline: 2px solid var(--em-ember-deep);
+    outline-offset: 3px;
   }
 
   /* ---------- section headings, README style ---------- */
@@ -1177,6 +1203,11 @@
     font-family: var(--em-mono);
     font-size: 12.5px;
     color: var(--em-faint);
+  }
+
+  .foot-links {
+    display: flex;
+    gap: 18px;
   }
 
   .foot a {


### PR DESCRIPTION
The /ember landing page never linked to the source. Adds two links: "read the README" in the masthead stat row (points at projects/embervm/README.md) and github.com/jomcgi/homelab in the footer (points at the embervm tree). Chart bumps included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)