### PR TITLE
feat(ember): live watcher count on the postgres demo

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.182
+version: 0.89.183
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.182
+      targetRevision: 0.89.183
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.257
+version: 0.285.258
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.257
+      targetRevision: 0.285.258
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/ember_public/core.py
+++ b/projects/monolith/ember_public/core.py
@@ -212,6 +212,56 @@ def check_and_record_insert(session_tag: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Presence: a rough live count of visitors watching the exhibit right now, so
+# the shared-VM warmth reads as "N people are here poking it" instead of a
+# ghost wake nobody in the room triggered. Each client mints an ephemeral id
+# on page load and carries it on every status poll (the poll the page already
+# fires sub-second); we stamp last-seen per id and count ids seen within the
+# TTL window. Keyed on the opaque client id, never an IP, and NOT the insert
+# session_tag: the session cookie is minted only on first insert and is not
+# forwarded on the status poll, so tagging presence to it would count only
+# people who have written, not people watching.
+#
+# Bounded two ways: a TTL prune on every access (a client that closes the tab
+# ages out within _PRESENCE_TTL_S), plus a hard id cap so a scripted client
+# churning a fresh id every poll cannot grow the map without limit.
+# ---------------------------------------------------------------------------
+
+_PRESENCE_TTL_S = 6.0
+_PRESENCE_MAX_IDS = 5000
+_PRESENCE_ID_MAXLEN = 64
+_presence: dict[str, float] = {}
+
+
+def _prune_presence(now: float) -> None:
+    cutoff = now - _PRESENCE_TTL_S
+    stale = [cid for cid, seen in _presence.items() if seen < cutoff]
+    for cid in stale:
+        del _presence[cid]
+
+
+def record_presence(client_id: str) -> None:
+    """Stamp this client id as seen now. Ignores an empty or oversized id, and
+    refuses a brand-new id once the map is at its cap (so an id-churning client
+    cannot grow it past _PRESENCE_MAX_IDS); an id already present is always
+    refreshed so genuine visitors never age out under the cap."""
+    if not client_id or len(client_id) > _PRESENCE_ID_MAXLEN:
+        return
+    now = monotonic()
+    _prune_presence(now)
+    if client_id not in _presence and len(_presence) >= _PRESENCE_MAX_IDS:
+        return
+    _presence[client_id] = now
+
+
+def present_count() -> int:
+    """Distinct client ids seen within the TTL window (prunes as it reads)."""
+    now = monotonic()
+    _prune_presence(now)
+    return len(_presence)
+
+
+# ---------------------------------------------------------------------------
 # Most recent query outcome, module-level. Task 4's health check consumes
 # this to detect a failed or slow wake with no newer success; no health logic
 # lives here, this module only records the observation.

--- a/projects/monolith/ember_public/router.py
+++ b/projects/monolith/ember_public/router.py
@@ -48,7 +48,7 @@ class PostgresSessionRequest(BaseModel):
 
 
 @router.get("/status")
-async def postgres_status() -> dict:
+async def postgres_status(request: Request) -> dict:
     """The demo-postgres lifecycle snapshot driving the sleep indicator.
 
     A management-API read only: the frontend polls this sub-second while the
@@ -58,19 +58,35 @@ async def postgres_status() -> dict:
 
     Reads through the 500ms single-flight cache (core.cached_demo_pg_status)
     so a burst of concurrent pollers shares one control-plane read.
+
+    The optional ``p`` query param is the caller's ephemeral per-page client id
+    (not the insert session cookie, which the status proxy never forwards). We
+    stamp it into the presence tracker and return ``present``, the live count
+    of visitors watching, so the shared VM's warmth reads as a crowd rather
+    than a ghost wake. Presence is computed per-request (outside the status
+    cache), so concurrent pollers each record their own id.
     """
     if not core.EMBERVM_URL or not core.demo_pg_dsn():
         return {"configured": False}
+    client_id = request.query_params.get("p", "")
+    if client_id:
+        core.record_presence(client_id)
+    present = core.present_count()
     try:
         status = await core.cached_demo_pg_status()
     except Exception as exc:  # noqa: BLE001 - poll errors are data, not faults
         logger.warning("demo-postgres status poll failed: %s", exc)
-        return {"configured": True, "error": str(exc)}
+        return {"configured": True, "present": present, "error": str(exc)}
     shaped = core.shape_pg_status(status)
     total = await core.record_demo_pg_savings(shaped["state"], shaped["generation"])
     if total is not None:
-        return {"configured": True, **shaped, "total_saved_mib_s": total}
-    return {"configured": True, **shaped}
+        return {
+            "configured": True,
+            "present": present,
+            **shaped,
+            "total_saved_mib_s": total,
+        }
+    return {"configured": True, "present": present, **shaped}
 
 
 @router.post("/query")

--- a/projects/monolith/ember_public/router_test.py
+++ b/projects/monolith/ember_public/router_test.py
@@ -45,6 +45,7 @@ def _reset_ember_public_module_state():
             {"at": None, "payload": None, "state": None, "state_changed_at": None}
         )
         core._insert_bucket.clear()
+        core._presence.clear()
         core._last_query_outcome.update(
             {"at_monotonic": None, "ok": None, "connect_ms": None}
         )
@@ -104,6 +105,46 @@ def test_postgres_status_shapes_control_plane_payload(monkeypatch):
     assert body["pair_valid"] is True
     assert body["healthy"] is True
     assert body["last_active_at"] == "2026-07-17T10:00:00Z"
+
+
+def test_postgres_status_reports_live_presence(monkeypatch):
+    """The ?p= client id is counted and returned as `present` so the UI can
+    show how many visitors are watching the shared VM."""
+    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
+    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
+
+    async def fake_status():
+        return _pg_status_payload()
+
+    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
+    client = _client()
+
+    def present_for(query: str) -> int:
+        body = client.get(f"/api/ember/postgres/status{query}").json()
+        return body["present"]
+
+    # Two distinct client ids -> two watchers; a sessionless poll still returns
+    # a count (it just does not add one of its own).
+    assert present_for("?p=alice") == 1
+    assert present_for("?p=bob") == 2
+    # Same id again does not double-count.
+    assert present_for("?p=alice") == 2
+    assert present_for("") == 2
+
+
+def test_postgres_status_error_path_still_reports_presence(monkeypatch):
+    """A flaky control-plane poll returns present alongside the in-band error."""
+    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
+    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
+
+    async def fake_status():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
+
+    body = _client().get("/api/ember/postgres/status?p=alice").json()
+    assert body["present"] == 1
+    assert "boom" in body["error"]
 
 
 def test_postgres_status_error_is_in_band(monkeypatch):
@@ -278,6 +319,43 @@ def test_postgres_query_connect_failure_is_in_band(monkeypatch):
     assert "connection refused" in body["error"]
     assert body["mode"] == "insert"
     assert body["classification"] == "warm"
+
+
+def test_presence_ttl_prunes_and_counts(monkeypatch):
+    core._presence.clear()
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(core, "monotonic", lambda: clock["t"])
+
+    core.record_presence("a")
+    core.record_presence("b")
+    assert core.present_count() == 2
+
+    # Refreshing "a" keeps it alive across the TTL boundary; "b" ages out.
+    clock["t"] = 1000.0 + core._PRESENCE_TTL_S - 0.1
+    core.record_presence("a")
+    clock["t"] = 1000.0 + core._PRESENCE_TTL_S + 0.1
+    assert core.present_count() == 1  # only "a" survived
+
+
+def test_presence_ignores_empty_and_oversized_ids():
+    core._presence.clear()
+    core.record_presence("")
+    core.record_presence("x" * (core._PRESENCE_ID_MAXLEN + 1))
+    assert core.present_count() == 0
+
+
+def test_presence_cap_refuses_new_ids_but_refreshes_known(monkeypatch):
+    core._presence.clear()
+    monkeypatch.setattr(core, "_PRESENCE_MAX_IDS", 2)
+
+    core.record_presence("a")
+    core.record_presence("b")
+    core.record_presence("c")  # over cap: refused
+    assert core.present_count() == 2
+    assert "c" not in core._presence
+    # A known id is still refreshed even at the cap.
+    core.record_presence("a")
+    assert core.present_count() == 2
 
 
 def test_classify_wake_paths():

--- a/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
@@ -235,9 +235,19 @@
   // below keys off it.
   let lastOwnActivityAt = 0;
 
+  // Ephemeral per-page client id for the live-watchers count. Minted once in
+  // onMount (never at SSR/module eval, hence the empty default), carried on
+  // every status poll as ?p=. Opaque and not persisted: it identifies this
+  // open tab for the ~6s presence TTL, nothing more, and is unrelated to the
+  // insert session cookie.
+  let clientId = "";
+
   async function pollStatus() {
     try {
-      const resp = await fetch(`${API}/status`);
+      const url = clientId
+        ? `${API}/status?p=${encodeURIComponent(clientId)}`
+        : `${API}/status`;
+      const resp = await fetch(url);
       const body = await resp.json();
       if (body.configured === false) {
         statusError = "demo-postgres is not configured on this deployment";
@@ -384,6 +394,14 @@
   }
 
   onMount(() => {
+    // Mint the ephemeral watcher id before the first poll so this tab is
+    // counted from its opening request. crypto.randomUUID is available on the
+    // https public site and on localhost; the Math.random fallback covers any
+    // context without it (the id only needs to be unique-ish per tab).
+    clientId =
+      globalThis.crypto?.randomUUID?.() ??
+      `c-${Math.random().toString(36).slice(2)}${Math.random().toString(36).slice(2)}`;
+
     if (!turnstileSiteKey) {
       // No widget configured (dev): mint sessionlessly, matching the private
       // panel and the backend's private-tier allowance.

--- a/projects/monolith/frontend/src/lib/public/ember/EmberStage.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberStage.svelte
@@ -11,13 +11,14 @@
   import { fade } from "svelte/transition";
   import "./ember-stage.css";
 
-  /** @type {{ vmState?: string|null, totalSavedMibS?: number|null, stopwatchMs?: number, running?: boolean, wakePromise?: string }} */
+  /** @type {{ vmState?: string|null, totalSavedMibS?: number|null, stopwatchMs?: number, running?: boolean, wakePromise?: string, present?: number|null }} */
   let {
     vmState = null,
     totalSavedMibS = null,
     stopwatchMs = 0,
     running = false,
     wakePromise = "",
+    present = null,
   } = $props();
 
   const WAKING = new Set(["relighting", "cold_booting", "starting"]);
@@ -307,6 +308,20 @@
         ? "waking"
         : "cold",
   );
+
+  // Live watchers pill: names the OTHER cause of warmth on this shared VM.
+  // Without it a wake someone else triggered reads as a ghost ("why is it
+  // glowing, I did nothing"); with it the crowd is the explanation. Solo is
+  // its own message on purpose: "just you" is exactly when you WILL see the VM
+  // sleep, so it reinforces the exhibit instead of looking lonely. Hidden
+  // entirely until the first poll returns a count (present == null).
+  let watchers = $derived(
+    present == null
+      ? null
+      : present <= 1
+        ? "just you here now"
+        : `${present} here now`,
+  );
 </script>
 
 <div class="ember-stage">
@@ -316,11 +331,21 @@
   {/if}
 
   <div class="es-overlay">
-    <span class="es-state-word">
-      {#key stateWord}
-        <span class="fade-swap" in:fade={{ duration: 260 }}>{stateWord}</span>
-      {/key}
-    </span>
+    <div class="es-status-row">
+      <span class="es-state-word">
+        {#key stateWord}
+          <span class="fade-swap" in:fade={{ duration: 260 }}>{stateWord}</span>
+        {/key}
+      </span>
+      {#if watchers}
+        <span class="es-watchers" in:fade={{ duration: 260 }}>
+          <span class="es-watchers-dot" aria-hidden="true"></span>
+          {#key watchers}
+            <span class="fade-swap" in:fade={{ duration: 260 }}>{watchers}</span>
+          {/key}
+        </span>
+      {/if}
+    </div>
     <div class="es-hero">
       {#key heroKind}
         <div class="es-hero-inner" in:fade={{ duration: 260 }}>
@@ -426,6 +451,14 @@
     text-align: center;
   }
 
+  .es-status-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
   .es-state-word {
     font-family: var(--em-mono, ui-monospace, monospace);
     font-size: 12.5px;
@@ -437,6 +470,47 @@
     box-shadow: var(--em-shadow-soft);
     padding: 4px 12px;
     border-radius: 999px;
+  }
+
+  /* Watchers pill: quieter than the state word (it is context, not the
+     headline), same panel chip language. The dot is the only warm accent, a
+     "live" tell borrowed from presence indicators everywhere. */
+  .es-watchers {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--em-mono, ui-monospace, monospace);
+    font-size: 11.5px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--es-ink);
+    background: color-mix(in srgb, var(--es-panel) 88%, transparent);
+    box-shadow: var(--em-shadow-soft);
+    padding: 4px 11px;
+    border-radius: 999px;
+  }
+
+  .es-watchers-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 999px;
+    background: var(--em-ember, currentColor);
+    flex: none;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .es-watchers-dot {
+      animation: es-watchers-pulse 2.2s ease-in-out infinite;
+    }
+    @keyframes es-watchers-pulse {
+      0%,
+      100% {
+        opacity: 1;
+      }
+      50% {
+        opacity: 0.35;
+      }
+    }
   }
 
   .es-hero {

--- a/projects/monolith/frontend/src/routes/public/ember/postgres/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/postgres/+page.svelte
@@ -55,6 +55,7 @@
       stopwatchMs={consoleStopwatchMs}
       running={consoleRunning}
       wakePromise={consoleWakePromise}
+      present={consoleStatus?.present}
     />
 
     <EmberConsole

--- a/projects/monolith/frontend/src/routes/public/ember/postgres/api/status/+server.js
+++ b/projects/monolith/frontend/src/routes/public/ember/postgres/api/status/+server.js
@@ -10,8 +10,16 @@ const API_BASE = process.env.API_BASE || "http://localhost:8000";
 // demo workload itself, so the frontend can poll it sub-second without waking the
 // VM. No cookie forwarding: status is session-optional. No caching: the whole point
 // is watching state change in near real time.
-export async function GET({ fetch }) {
-  const res = await fetch(`${API_BASE}/api/ember/postgres/status`, {
+//
+// The `p` query param is the console's ephemeral per-page client id, forwarded
+// so the backend can count live watchers (the "N here now" pill). It is not the
+// insert session cookie (which this proxy deliberately never forwards); it only
+// exists to make the shared VM's warmth legible.
+export async function GET({ fetch, url }) {
+  const target = new URL(`${API_BASE}/api/ember/postgres/status`);
+  const clientId = url.searchParams.get("p");
+  if (clientId) target.searchParams.set("p", clientId);
+  const res = await fetch(target, {
     signal: AbortSignal.timeout(5_000),
   });
   const body = await res.json();

--- a/projects/monolith/frontend/visual/fixtures/api/ember_postgres_status.json
+++ b/projects/monolith/frontend/visual/fixtures/api/ember_postgres_status.json
@@ -1,5 +1,6 @@
 {
   "configured": true,
+  "present": 3,
   "state": "banked",
   "generation": 60,
   "pair_valid": true,


### PR DESCRIPTION
## Why

The `/ember/postgres` exhibit runs **one shared Firecracker VM**. With any concurrent traffic the warmth signal was ambiguous: another visitor's query kept the VM awake and the heat grid animated `Waking` / `Awake` with no input from you, reading as a ghost wake (or a bug). The most impressive part, the visible cold relight, also silently disappears exactly when the most people are watching.

This surfaces the *other* cause of warmth so concurrency becomes the headline ("one sleepy VM serving a crowd") instead of a confusing artifact. Joe's suggestion.

## What

A live **"N here now"** pill beside the `Awake` / `Asleep` word in the stage overlay.

- Each tab mints an **ephemeral client id** in `onMount` (never SSR), carried on the status poll the page already fires every 700ms as `?p=`. No new poller, no websocket, no new endpoint.
- Backend stamps last-seen per id (`ember_public/core.py`), 6s TTL with prune-on-access, plus a hard id cap so an id-churning client can't grow the map. Keyed on the opaque client id, never an IP, and deliberately **not** the insert session cookie (the status proxy never forwards it, so it would only count people who've written).
- `/status` returns `present`; it rides the existing status body that already flows `EmberConsole` → `EmberStage` → page, so the frontend needed one prop, not a new data path.
- Solo renders **"just you here now"**, which is exactly when the VM *does* sleep, so it reinforces the exhibit instead of looking lonely.

## Deploy

Bumps **monolith** and **monolith-public**: the router is mounted on both tiers and `/ember/postgres` is a public-tier page, so both images must ship the new `/status` shape.

## Tests

- Router: `present` counts distinct `?p=` ids, doesn't double-count, and is returned on the in-band error path too.
- Core: TTL prune (refreshed id survives the boundary, stale ages out), empty/oversized ids ignored, cap refuses new ids but still refreshes known ones.
- Visual regression: status fixture seeded with `present: 3` so the pill renders deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)