### PR TITLE
fix(embervm): composite entry DNAT + group bridge addr idempotency

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.109
+version: 0.1.110

--- a/projects/embervm/control/lib/embervm/group_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_manager.ex
@@ -417,7 +417,13 @@ defmodule Embervm.GroupManager do
       snapshot_ref: "",
       health_port: member.health_port || 0,
       resources: %ResourceSpec{vcpus: member.vcpus || 1, mem_mib: member.mem_mib || 512},
-      env: member_env(member, plan, secret, state.workload, subnet_cidr)
+      env: member_env(member, plan, secret, state.workload, subnet_cidr),
+      # Mark the ENTRY member so noded installs the entry DNAT that makes the
+      # {pod IP, vmPort} endpoint we publish actually reach tap:entry_port. Only the
+      # member named by the workload's entry carries a non-zero port; every other
+      # member gets 0 (no DNAT). Without this the published entry is a dead port
+      # (the entry-EOF): noded never wired the DNAT the endpoint assumes.
+      entry_guest_port: entry_guest_port_for(state, member)
     }
 
     case safe_start_group_member(state, req) do
@@ -434,6 +440,24 @@ defmodule Embervm.GroupManager do
 
       other ->
         {:error, {:member_start_failed, member.expanded_name, other}}
+    end
+  end
+
+  # entry_guest_port_for returns the workload entry's guest port when THIS member is
+  # the entry member (matched by expanded_name, exactly as finish_create resolves the
+  # entry from the plan), else 0. A non-zero value tells noded to install the entry
+  # DNAT for this member so the {pod IP, vmPort} endpoint we publish reaches its tap;
+  # 0 means a non-entry member (no DNAT). Kept in lockstep with finish_create's entry
+  # resolution so the member noded DNATs is the same member whose IP we derive vmPort
+  # from.
+  defp entry_guest_port_for(state, member) do
+    entry = with %{group: group} <- state.entry, do: Map.get(group, :entry)
+    name = member.expanded_name
+
+    if is_map(entry) and name == Map.get(entry, :member) do
+      Map.get(entry, :port) || 0
+    else
+      0
     end
   end
 

--- a/projects/embervm/control/test/embervm/group_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_manager_test.exs
@@ -96,6 +96,10 @@ defmodule Embervm.GroupManagerTest do
     start_group_member_fun = fn _ch, req ->
       relight? = req.mode == :START_GROUP_MEMBER_MODE_RELIGHT
       record(rec, {:start_member, req.member_name, req.member_index, req.ip, req.env, req.mode})
+      # Additive record of the entry-DNAT marker (invisible to the :start_member
+      # assertions, which all filter/find by that tag) so a test can assert only the
+      # entry member carries a non-zero entry_guest_port.
+      record(rec, {:start_member_entry, req.member_name, req.entry_guest_port})
       vm_id = "vm-#{req.member_name}"
 
       cond do
@@ -226,6 +230,21 @@ defmodule Embervm.GroupManagerTest do
     assert Enum.all?(members, & &1.healthy)
 
     assert FakePublisher.count(ctx.pub) >= 1
+  end
+
+  test "only the entry member carries a non-zero entry_guest_port (installs the entry DNAT)" do
+    ctx = start_group()
+    {:ok, _} = GroupManager.create_group(ctx.mgr)
+
+    entry_ports =
+      events(ctx.rec)
+      |> Enum.filter(&match?({:start_member_entry, _, _}, &1))
+      |> Map.new(fn {:start_member_entry, name, port} -> {name, port} end)
+
+    # The entry member ("leader") gets the workload entry port; every other member 0.
+    assert entry_ports["leader"] == 8080
+    assert entry_ports["worker-0"] == 0
+    assert entry_ports["worker-1"] == 0
   end
 
   test "ordered-start property: order N never starts before every order N-1 member" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.109
+      targetRevision: 0.1.110
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/group_member.go
+++ b/projects/embervm/noded/server/group_member.go
@@ -120,7 +120,7 @@ func (s *Server) startGroupMemberFresh(ctx context.Context, req *nodev1.StartGro
 		s.groupNet.RemoveMemberTap(ctx, groupInstanceID, tap, ip)
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: cold-boot group member: %v", err)
 	}
-	return s.finishGroupMemberStart(ctx, h, groupInstanceID, memberName, req.GetMemberIndex(), tap, ip, healthPort, false, s.cfg.BootReadyTimeout)
+	return s.finishGroupMemberStart(ctx, h, groupInstanceID, memberName, req.GetMemberIndex(), tap, ip, healthPort, req.GetEntryGuestPort(), false, s.cfg.BootReadyTimeout)
 }
 
 // startGroupMemberRelight recreates the member's pinned tap world, resumes the banked
@@ -167,17 +167,29 @@ func (s *Server) startGroupMemberRelight(ctx context.Context, req *nodev1.StartG
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: group member %q clock resync failed: %v", ref, clockErr)
 	}
 
-	return s.finishGroupMemberStart(ctx, h, groupInstanceID, memberName, req.GetMemberIndex(), tap, ip, healthPort, true, s.cfg.RestoreReadyTimeout)
+	return s.finishGroupMemberStart(ctx, h, groupInstanceID, memberName, req.GetMemberIndex(), tap, ip, healthPort, req.GetEntryGuestPort(), true, s.cfg.RestoreReadyTimeout)
 }
 
 // finishGroupMemberStart is the shared tail of both member start paths: TCP-health-
 // gate {ip, health_port}, register the live member, and start its probe. On a
 // readiness failure it reaps the VM and removes the tap, returning
 // FAILED_PRECONDITION (no half-alive member is ever published).
-func (s *Server) finishGroupMemberStart(ctx context.Context, h substrate.Handle, groupInstanceID, memberName string, memberIndex uint32, tap string, ip net.IP, healthPort uint32, wasRelight bool, readyBudget time.Duration) (*nodev1.StartGroupMemberResponse, error) {
+func (s *Server) finishGroupMemberStart(ctx context.Context, h substrate.Handle, groupInstanceID, memberName string, memberIndex uint32, tap string, ip net.IP, healthPort, entryGuestPort uint32, wasRelight bool, readyBudget time.Duration) (*nodev1.StartGroupMemberResponse, error) {
 	if err := s.waitStatefulReady(ctx, ip, healthPort, readyBudget); err != nil {
 		s.reapGroupMember(h, groupInstanceID, tap, ip)
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: group member not ready over tap: %v", err)
+	}
+	// Install the entry DNAT for the ENTRY member (entry_guest_port > 0) so the entry
+	// endpoint the control plane publishes, {pod_ip, vmPort}, actually routes to this
+	// member's tap:entry_guest_port. Mirrors serving/stateful, which call EnsureDNAT
+	// inline in their start handlers. Refreshed on every entry-member start (fresh or
+	// relight), so it always points at the live entry tap; DeleteGroupNetwork drops it
+	// with the group record on teardown. A non-entry member (0) installs nothing.
+	if entryGuestPort > 0 {
+		if err := s.groupNet.EnsureEntryDNAT(ctx, groupInstanceID, ip, entryGuestPort); err != nil {
+			s.reapGroupMember(h, groupInstanceID, tap, ip)
+			return nil, status.Errorf(codes.Internal, "noded: install group entry DNAT for member %q: %v", memberName, err)
+		}
 	}
 	probe := serving.StartTCPProbe(s.newGroupTCPProber(), ip, healthPort)
 	s.groupMembers.add(&groupMemberEntry{

--- a/projects/embervm/noded/server/group_member_test.go
+++ b/projects/embervm/noded/server/group_member_test.go
@@ -255,6 +255,71 @@ func TestStartGroupMemberFreshBootsOnGroupBridge(t *testing.T) {
 	}
 }
 
+// TestStartGroupMemberEntryInstallsDNAT proves the entry member (entry_guest_port >
+// 0) installs the entry DNAT exposing {pod IP, vmPort} -> {tap, entry_guest_port},
+// and a non-entry member (0) installs none. Regression for the entry-EOF: the entry
+// endpoint the control plane publishes was unreachable because StartGroupMember never
+// called EnsureEntryDNAT.
+func TestStartGroupMemberEntryInstallsDNAT(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, gn, _, _ := newGroupMemberTestServer(t)
+
+	// A non-entry member installs no DNAT.
+	startFreshMember(t, s, port, "worker-1", 1)
+	if len(gn.entryDNATs) != 0 {
+		t.Fatalf("non-entry member installed an entry DNAT: %+v", gn.entryDNATs)
+	}
+
+	// The entry member (entry_guest_port > 0) installs the DNAT at that guest port.
+	if _, err := s.StartGroupMember(context.Background(), &nodev1.StartGroupMemberRequest{
+		Mode:            nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_FRESH,
+		GroupInstanceId: "grp-A",
+		MemberName:      "server",
+		MemberIndex:     0,
+		Ip:              "127.0.0.1",
+		Source:          "src-a",
+		HealthPort:      port,
+		EntryGuestPort:  6443,
+	}); err != nil {
+		t.Fatalf("StartGroupMember(entry): %v", err)
+	}
+	if len(gn.entryDNATs) != 1 {
+		t.Fatalf("entry member entry DNAT calls = %d want 1 (%+v)", len(gn.entryDNATs), gn.entryDNATs)
+	}
+	got := gn.entryDNATs[0]
+	if got.groupInstanceID != "grp-A" || got.entryIP != "127.0.0.1" || got.guestPort != 6443 {
+		t.Errorf("entry DNAT = %+v want {grp-A 127.0.0.1 6443}", got)
+	}
+}
+
+// TestStartGroupMemberEntryDNATFailureReaps proves an entry DNAT install failure
+// reaps the member (no half-published entry whose DNAT never landed).
+func TestStartGroupMemberEntryDNATFailureReaps(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, gn, _, _ := newGroupMemberTestServer(t)
+	gn.entryDNATErr = errors.New("nft apply failed")
+
+	_, err := s.StartGroupMember(context.Background(), &nodev1.StartGroupMemberRequest{
+		Mode:            nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_FRESH,
+		GroupInstanceId: "grp-A",
+		MemberName:      "server",
+		MemberIndex:     0,
+		Ip:              "127.0.0.1",
+		Source:          "src-a",
+		HealthPort:      port,
+		EntryGuestPort:  6443,
+	})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("entry DNAT failure code = %v want Internal", status.Code(err))
+	}
+	if len(gn.removedTaps) != 1 {
+		t.Errorf("entry DNAT failure did not remove the member tap: %v", gn.removedTaps)
+	}
+	if len(s.nodeStatus().GetGroupMemberVms()) != 0 {
+		t.Error("a member whose entry DNAT failed must not be published")
+	}
+}
+
 // TestStartGroupMemberFreshHealthGateFailureReaps proves a member that never health-
 // gates is reaped and its tap removed, and no member is published.
 func TestStartGroupMemberFreshHealthGateFailure(t *testing.T) {

--- a/projects/embervm/noded/server/group_registry.go
+++ b/projects/embervm/noded/server/group_registry.go
@@ -54,6 +54,11 @@ type groupNetwork interface {
 	// EntryEndpoint projects a group entry member's (tap IP, guest port) into the
 	// reported endpoint (pod IP + DNAT port when enabled, else the tap unchanged).
 	EntryEndpoint(entryIP net.IP, guestPort uint32) (string, uint32)
+	// EnsureEntryDNAT installs (or refreshes) the entry-member DNAT exposing the entry
+	// member's tap as {pod IP, vmPort}. Called on a ready entry member so the endpoint
+	// the control plane publishes actually routes to tap:guestPort. No-op when DNAT is
+	// disabled (no pod IP); dropped with the group by DeleteGroupNetwork.
+	EnsureEntryDNAT(ctx context.Context, groupInstanceID string, entryIP net.IP, guestPort uint32) error
 }
 
 // groupMemberDriver is the subset of the fcvm driver the R5 member lifecycle needs

--- a/projects/embervm/noded/server/group_test.go
+++ b/projects/embervm/noded/server/group_test.go
@@ -33,6 +33,15 @@ type fakeGroupNet struct {
 	removedTaps  []string
 	ensureTapErr error
 	ensureCalls  []ensureTapCall
+	entryDNATs   []entryDNATCall // recorded EnsureEntryDNAT calls
+	entryDNATErr error
+}
+
+// entryDNATCall records one EnsureEntryDNAT invocation for assertions.
+type entryDNATCall struct {
+	groupInstanceID string
+	entryIP         string
+	guestPort       uint32
 }
 
 // ensureTapCall records one EnsureMemberTap invocation for pinned-world assertions.
@@ -138,6 +147,16 @@ func (f *fakeGroupNet) PrefixLen(id string) int    { return 24 }
 
 func (f *fakeGroupNet) EntryEndpoint(ip net.IP, port uint32) (string, uint32) {
 	return ip.String(), port
+}
+
+func (f *fakeGroupNet) EnsureEntryDNAT(_ context.Context, id string, entryIP net.IP, guestPort uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.entryDNATErr != nil {
+		return f.entryDNATErr
+	}
+	f.entryDNATs = append(f.entryDNATs, entryDNATCall{groupInstanceID: id, entryIP: entryIP.String(), guestPort: guestPort})
+	return nil
 }
 
 // fakeGroupRecords is an in-memory groupRecordStore.

--- a/projects/embervm/noded/serving/group_test.go
+++ b/projects/embervm/noded/serving/group_test.go
@@ -325,6 +325,37 @@ func TestGroupManagerCreateRebuildsBridgeAfterAdopt(t *testing.T) {
 	}
 }
 
+// TestGroupManagerCreateToleratesExistingBridgeAddress is the regression for the
+// bug the bridge-rebuild fix exposed: an idempotent re-issue re-runs the bridge
+// setup, and on an already-addressed bridge `ip addr add` returns "Address already
+// assigned". That must be tolerated as the desired end-state (not treated as a hard
+// failure that tears the bridge back down). Mirrors the casualty-adoption path: a
+// record is re-seeded on boot, then a wake re-issues CreateGroupNetwork.
+func TestGroupManagerCreateToleratesExistingBridgeAddress(t *testing.T) {
+	fr := &fakeRunner{failOn: map[string]error{
+		"ip addr": errors.New("exit status 2: Error: ipv4: Address already assigned."),
+	}}
+	m, err := NewGroupManager(fr, "10.101.0.0/16", "", "", 40000)
+	if err != nil {
+		t.Fatalf("NewGroupManager: %v", err)
+	}
+	// Boot rescan seeds the record without the device.
+	if err := m.AdoptGroupNetwork("grp-A", "10.101.1.0/24", 0); err != nil {
+		t.Fatalf("adopt: %v", err)
+	}
+	// The re-issue ensures the bridge; the addr add reports already-assigned, which
+	// must be tolerated so the create succeeds.
+	if _, _, err := m.CreateGroupNetwork(context.Background(), "grp-A", "10.101.1.0/24"); err != nil {
+		t.Fatalf("re-issue must tolerate an already-assigned gateway addr, got: %v", err)
+	}
+	// It must NOT have torn the bridge down on the tolerated addr error.
+	for _, c := range fr.calls {
+		if strings.HasPrefix(strings.Join(c, " "), "ip link del ") {
+			t.Errorf("re-issue tore the bridge down on an already-assigned addr: %v", c)
+		}
+	}
+}
+
 // TestGroupManagerDeleteAndBridgeCommands asserts a create issues the bridge
 // setup and a delete issues the bridge teardown, and that delete is idempotent.
 func TestGroupManagerDeleteAndBridgeCommands(t *testing.T) {

--- a/projects/embervm/noded/serving/net.go
+++ b/projects/embervm/noded/serving/net.go
@@ -450,7 +450,15 @@ func isAlreadyExists(err error) bool {
 		return false
 	}
 	s := strings.ToLower(err.Error())
-	return strings.Contains(s, "file exists") || strings.Contains(s, "already exists")
+	// "file exists" / "already exists": a duplicate `ip link add` (bridge or tap).
+	// "already assigned": a duplicate `ip addr add` on a device that already holds
+	// the address (iproute2 prints "Error: ipv4: Address already assigned."), which
+	// is the desired end-state when an idempotent bridge re-issue re-runs the setup
+	// against an already-addressed bridge. Tolerating it keeps ensureBridgeDevice
+	// idempotent instead of tearing a healthy bridge back down.
+	return strings.Contains(s, "file exists") ||
+		strings.Contains(s, "already exists") ||
+		strings.Contains(s, "already assigned")
 }
 
 // TapNameForIP derives the deterministic tap device name from a VM IP: "emtap" plus

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -982,6 +982,17 @@ message StartGroupMemberRequest {
   // not the daemon; the daemon delivers whatever map it is handed and interprets
   // none of it.
   map<string, string> env = 11;
+  // entry_guest_port, when > 0, marks THIS member as the group's entry member and
+  // is its entry guest port (e.g. k3s apiserver 6443). On a ready entry member the
+  // daemon installs the entry DNAT exposing {pod_ip, vmPort} -> {tap_ip,
+  // entry_guest_port} (vmPort = ServingPortBase + hostOffset(ip), the same
+  // derivation the control plane re-publishes), exactly as serving/stateful install
+  // their DNAT inline in StartServing/StartStateful. 0 (the default) means a
+  // non-entry member: no entry DNAT is installed. Only ONE member per group carries
+  // a non-zero value (the control plane sets it for the member named by the
+  // workload's entry). It may differ from health_port (the health-gate port), so it
+  // is carried explicitly rather than reusing health_port.
+  uint32 entry_guest_port = 12;
 }
 
 message StartGroupMemberResponse {


### PR DESCRIPTION
## Summary

Two stacked fixes from the R6 gate-drill investigation, shipped together with one chart bump (0.1.110):

- **A2 (dup-addr idempotency):** tolerate "Address already assigned" when re-issuing the group bridge gateway address on an idempotent CreateGroupNetwork re-issue. This is a regression surface exposed by the bridge-rebuild fix (0.1.109): the rebuild path can now re-add an address that survived on the kernel bridge.
- **E (composite entry DNAT):** install the entry DNAT for composite groups so the published {pod_ip, vmPort} actually reaches the entry member (e.g. k3s server :6443). EnsureEntryDNAT existed but was dead code: no caller, no proto field marking the entry member. This mirrors how serving and stateful install their DNAT inline in the start handler: an additive proto field (entry_guest_port) marks the entry member, noded installs the DNAT once the member is ready, and the control plane sets the field from the spec-declared entry member. This is the root cause of the Gate-1 entry EOF (client through vmPort EOFs while the tap-level health gate passes).

## Test plan

- Unit tests on both the noded (Elixir) and control-plane sides in this PR.
- Proto regen and the actual routing path are CI-verified; the end-to-end confirmation is the R6 Gate-1 live drill (kubectl get nodes via port 5410) after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)