### PR TITLE
fix(ember): stop the postgres demo crashing on gateway rate limits

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.183
+version: 0.89.185
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/templates/httproute-public.yaml
+++ b/projects/monolith-public/chart/templates/httproute-public.yaml
@@ -119,6 +119,46 @@ spec:
       timeouts:
         request: 60s
 ---
+# /ember/postgres/api/status + /savings -> the frontend, on their OWN HTTPRoute
+# so the demo's sub-second lifecycle polling does NOT share the page's coarse
+# rate-limit budget. That page limit is a single gateway-wide bucket shared
+# across ALL clients (Local rate limit, no clientSelectors), and the status poll
+# alone runs ~85 req/min per viewer, so one lingering visitor could starve the
+# whole apex site (429 local_rate_limited for everyone). Both endpoints are
+# cheap, wake-safe control-plane reads served from a short server-side cache
+# (status 500ms single-flight, savings 30s), so a high poll rate costs the
+# backend almost nothing and a generous dedicated limit is safe. The write paths
+# (/query, /session) deliberately stay on the page budget, backstopped by the
+# backend's per-session insert bucket, the query semaphore, and Turnstile.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "monolith-public.fullname" . }}-ember-reads
+  labels:
+    ingress-tier: {{ .Values.cfIngress.public.tier }}
+    {{- include "monolith-public.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ .Values.cfIngress.public.gateway.name }}
+      namespace: {{ .Values.cfIngress.public.gateway.namespace }}
+  hostnames:
+    - {{ .Values.cfIngress.public.hostname | quote }}
+  rules:
+    # Exact matches (higher precedence than the catch-all "/" page rule) so ONLY
+    # these two poll endpoints move to the dedicated budget, not /query|/session.
+    - matches:
+        - path:
+            type: Exact
+            value: /ember/postgres/api/status
+        - path:
+            type: Exact
+            value: /ember/postgres/api/savings
+      backendRefs:
+        - name: {{ include "monolith-public.fullname" . }}-frontend
+          port: {{ .Values.frontend.service.port | int }}
+      timeouts:
+        request: 60s
+---
 {{- $rlParams := dict
   "name" (printf "%s-public" (include "monolith-public.fullname" .))
   "rateLimit" .Values.cfIngress.public.rateLimit
@@ -130,4 +170,10 @@ spec:
   "rateLimit" .Values.cfIngress.public.functionsRateLimit
 }}
 {{- include "cf-ingress.rate-limit" $fnRlParams }}
+---
+{{- $emberRlParams := dict
+  "name" (printf "%s-ember-reads" (include "monolith-public.fullname" .))
+  "rateLimit" .Values.cfIngress.public.emberReadsRateLimit
+}}
+{{- include "cf-ingress.rate-limit" $emberRlParams }}
 {{- end }}

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -656,6 +656,16 @@ cfIngress:
     functionsRateLimit:
       requests: 120
       unit: Minute
+    # Dedicated budget for the ember demo's cheap, wake-safe, server-cached
+    # lifecycle reads (/ember/postgres/api/status + /savings), carved onto their
+    # own HTTPRoute so their sub-second polling never shares (and exhausts) the
+    # page's 100/min gateway-wide bucket. status is 500ms single-flight cached
+    # and savings 30s cached, so a high poll rate is nearly free upstream; 600/min
+    # gives comfortable headroom for concurrent viewers. Writes (/query, /session)
+    # stay on the page limit above, backstopped by the backend gates + Turnstile.
+    emberReadsRateLimit:
+      requests: 600
+      unit: Minute
 
 # CiliumNetworkPolicy gates (ADR platform/012). templates/cilium-policy.yaml is
 # the Cilium translation of the Linkerd policy chain; both gates default off so

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.183
+      targetRevision: 0.89.185
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.258
+version: 0.285.260
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.258
+      targetRevision: 0.285.260
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
@@ -242,13 +242,32 @@
   // insert session cookie.
   let clientId = "";
 
+  // Parse a response body as JSON, returning null instead of throwing when the
+  // body is not JSON. The public gateway enforces a coarse rate limit and
+  // answers 429 with a PLAIN-TEXT body ("local_rate_limited"), and other edge
+  // errors can be non-JSON too; calling resp.json() on those blows up with a
+  // "Unexpected token" SyntaxError that used to leak straight into the panel.
+  async function parseJsonSafe(resp) {
+    const text = await resp.text();
+    try {
+      return JSON.parse(text);
+    } catch {
+      return null;
+    }
+  }
+
   async function pollStatus() {
     try {
       const url = clientId
         ? `${API}/status?p=${encodeURIComponent(clientId)}`
         : `${API}/status`;
       const resp = await fetch(url);
-      const body = await resp.json();
+      // A rate-limited or non-JSON poll is not worth alarming about: keep the
+      // last good status and let the next poll (or a click) recover. Never
+      // surface a raw parse error for a background poll.
+      if (resp.status === 429) return;
+      const body = await parseJsonSafe(resp);
+      if (body == null) return;
       if (body.configured === false) {
         statusError = "demo-postgres is not configured on this deployment";
         return;
@@ -296,7 +315,11 @@
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ turnstile_token: turnstileToken }),
       });
-      const body = await resp.json().catch(() => ({}));
+      // A 429 here is the gateway rate limit, not a verification failure: leave
+      // inserts gated as-is and let a later mint retry, rather than latching
+      // insertUnavailable off a transient limit.
+      if (resp.status === 429) return;
+      const body = (await parseJsonSafe(resp)) ?? {};
       if (resp.ok && body.ok) {
         sessionReady = true;
         sessionError = "";
@@ -319,7 +342,23 @@
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ mode }),
     });
-    const body = await resp.json();
+    // The public gateway answers a tripped rate limit with 429 and a plain-text
+    // "local_rate_limited" body. Handle it before any JSON parse, and mark it
+    // permanent for this run so fetchWithBackoff does NOT retry, hammering a
+    // limiter that is already saying slow down only deepens the wait.
+    if (resp.status === 429) {
+      return {
+        ok: false,
+        permanent: true,
+        error: "the demo is busy right now, give it a few seconds and try again",
+      };
+    }
+    const body = await parseJsonSafe(resp);
+    if (body == null) {
+      // Non-JSON on any other status (a gateway error page, a proxy hiccup):
+      // surface it calmly instead of leaking a raw JSON SyntaxError.
+      return { ok: false, error: `unexpected response from the demo (${resp.status})` };
+    }
     if (resp.status === 503 && /not configured/i.test(body?.detail ?? "")) {
       // Permanent: no DSN configured on this deployment, retrying won't help.
       return { ok: false, permanent: true, error: body.detail };


### PR DESCRIPTION
## Symptom

The `/ember/postgres` panel showed `SyntaxError: Unexpected token 'l', "local_rate_limited" is not valid JSON` after a few seconds of waiting, even though the VM was **warm** (13ms wake). Not a cold boot, a rate limit.

## Root cause

The public Envoy Gateway enforces a coarse **100 req/min** page limit that is a **single bucket shared across all clients** (Local rate limit, no `clientSelectors`). The demo polls `/status` every 700ms ≈ **85 req/min per viewer**, so one lingering visitor nearly exhausts the whole apex budget and trips `429 local_rate_limited`. Two frontend bugs then compounded it:

1. `resp.json()` was called on the plain-text `local_rate_limited` body → `SyntaxError` leaked into the panel.
2. `fetchWithBackoff` retried the 429 (500+1000+2000+3000ms) → the "seconds of wait", while hammering a limiter already saying slow down.

Note: the newly-merged presence pill makes this *more* likely (it encourages lingering = sustained polling), so this is a load fix, not cosmetic.

## Fix

**Frontend (`EmberConsole.svelte`)** — the crash Joe asked to stop:
- `parseJsonSafe()` helper: never throw on a non-JSON body.
- Explicit `429` handling on all three paths (query / status poll / session mint): treat as **back-off-not-retry** with a calm "the demo is busy right now, give it a few seconds" instead of a raw parse error. The status poll silently keeps the last good state.

**Ingress (`monolith-public` chart)** — increase the limit for the cheap cached ops:
- New `-ember-reads` HTTPRoute carving `/ember/postgres/api/status` + `/savings` (exact matches, higher precedence than the catch-all page rule) onto their **own 600/min budget**. These are wake-safe, server-cached reads (status 500ms single-flight, savings 30s), so a high poll rate is nearly free upstream.
- Writes (`/query`, `/session`) deliberately stay on the page budget, backstopped by the backend's per-session insert bucket, the query semaphore, and Turnstile.

## Rollout / verification

Bumps **monolith + monolith-public** (public-tier checklist). Post-deploy I'll curl:
```
curl -sS -o /dev/null -w '%{http_code}\n' https://jomcgi.dev/ember/postgres/api/status
```

Helm render confirmed: the route + `BackendTrafficPolicy` (600/min) generate with both exact path matches → frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)