### PR TITLE
fix(monolith): ember/postgres pill contrast + stats gap shift

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.186
+version: 0.89.187
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.186
+      targetRevision: 0.89.187
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.261
+version: 0.285.262
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.261
+      targetRevision: 0.285.262
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
@@ -1002,7 +1002,6 @@
     display: flex;
     flex-direction: column;
     gap: 16px;
-    flex: 1;
   }
 
   .stats-section {
@@ -1012,7 +1011,6 @@
   }
 
   .stats-best {
-    margin-top: auto;
     border-top: 1px solid var(--em-line-soft);
     padding-top: 14px;
     gap: 8px;

--- a/projects/monolith/frontend/src/lib/public/ember/EmberStage.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberStage.svelte
@@ -467,6 +467,7 @@
     letter-spacing: 0.1em;
     color: var(--es-ink);
     background: var(--es-panel);
+    border: 1px solid var(--es-border);
     box-shadow: var(--em-shadow-soft);
     padding: 4px 12px;
     border-radius: 999px;
@@ -484,7 +485,8 @@
     font-weight: 600;
     letter-spacing: 0.04em;
     color: var(--es-ink);
-    background: color-mix(in srgb, var(--es-panel) 88%, transparent);
+    background: var(--es-panel);
+    border: 1px solid var(--es-border);
     box-shadow: var(--em-shadow-soft);
     padding: 4px 11px;
     border-radius: 999px;


### PR DESCRIPTION
Two visual fixes on the `/ember/postgres` demo page, both flagged from screenshots.

## 1. Presence pill contrast
The `ASLEEP` and `just you here now` pills washed out against the blue mosaic grid. The watchers pill used a translucent panel (`88%`) so the multicolor grid bled through and dulled the text, and both pills were borderless white that blended into pale mosaic tiles. Now both use an opaque panel background plus a `--es-border` hairline so they read cleanly and their edges separate from the backdrop.

## 2. Stats card gap shift
Switching **Run aggregate -> INSERT an order** opened a growing gap between the "Last run" and "Best times this session" sections. Root cause: `.pg-panel` is a grid with `align-items: stretch`, so the left column is forced to match the taller orders table. `.stats-card { flex: 1 }` absorbed that height and `.stats-best { margin-top: auto }` pushed "Best times" to the bottom, so the *variable* height opened as a gap between the two sections. Dropping the `flex: 1` + `margin-top: auto` pair keeps the card at its natural height and the section spacing fixed across views.

Includes the coupled monolith + monolith-public chart bumps (the page is baked into the monolith image).

The Visual regression action renders before/after for the changed page inline.