### PR TITLE
fix(embervm): group entry endpoint, member ready budget, expired-wake teardown

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.110
+version: 0.1.111

--- a/projects/embervm/control/lib/embervm/group_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_manager.ex
@@ -423,16 +423,27 @@ defmodule Embervm.GroupManager do
       # member named by the workload's entry carries a non-zero port; every other
       # member gets 0 (no DNAT). Without this the published entry is a dead port
       # (the entry-EOF): noded never wired the DNAT the endpoint assumes.
-      entry_guest_port: entry_guest_port_for(state, member)
+      entry_guest_port: entry_guest_port_for(state, member),
+      # Forward the workload's wake budget as the daemon's per-member readiness
+      # budget, so both ends enforce ONE policy. Without it noded reaps a member at
+      # its own (shorter) default while this create is still inside the wake bound:
+      # the k3s agents died exactly this way, silently, at noded's 60s.
+      ready_budget_seconds: wake_budget_seconds(state)
     }
 
     case safe_start_group_member(state, req) do
-      {:ok, %StartGroupMemberResponse{vm_id: vm_id, ip: ip}} when is_binary(vm_id) and vm_id != "" ->
+      {:ok, %StartGroupMemberResponse{vm_id: vm_id, ip: ip} = resp} when is_binary(vm_id) and vm_id != "" ->
         case GroupStore.member_started(state.store, state.instance_id, %{
                member_name: member.expanded_name,
                member_index: member.index,
                vm_id: vm_id,
-               ip: ip
+               ip: ip,
+               # The daemon's own entry-endpoint projection ({noded pod IP, vmPort}),
+               # non-empty only for the entry member. Recorded so finish_create
+               # publishes the address the DNAT actually lives at (the daemon pod),
+               # not this control plane's own pod IP.
+               endpoint_ip: resp.endpoint_ip || "",
+               endpoint_port: resp.endpoint_port || 0
              }) do
           {:ok, _} -> :ok
           {:error, reason} -> {:error, {:member_record_failed, member.expanded_name, reason}}
@@ -440,6 +451,16 @@ defmodule Embervm.GroupManager do
 
       other ->
         {:error, {:member_start_failed, member.expanded_name, other}}
+    end
+  end
+
+  # The workload's wakeTimeoutSeconds from the catalog entry this manager was
+  # spawned with, forwarded to noded as the per-member readiness budget. 0 (keep
+  # the daemon default) when the entry carries none.
+  defp wake_budget_seconds(state) do
+    case state.entry do
+      %{group: %{wake_timeout_seconds: secs}} when is_integer(secs) and secs > 0 -> secs
+      _ -> 0
     end
   end
 
@@ -461,9 +482,14 @@ defmodule Embervm.GroupManager do
     end
   end
 
-  # Publish the entry endpoint + move to running. The published endpoint is the entry
-  # member's DNAT projection: {pod IP, vmPort}, vmPort re-derived from the entry
-  # member's group-subnet IP (see the moduledoc's lockstep note).
+  # Publish the entry endpoint + move to running. The published endpoint is the
+  # DAEMON's own projection {noded pod IP, vmPort}, reported by noded in the entry
+  # member's StartGroupMemberResponse and recorded on its member row: the entry
+  # DNAT lives in the noded pod's netns, so that pod's IP is the only address the
+  # endpoint is reachable at. The CP-local derivation ({state.pod_ip, re-derived
+  # vmPort}, the pre-R6 lane) remains ONLY as a fallback for a daemon that reports
+  # no endpoint (older noded, or DNAT disabled); publishing the CP's own pod IP was
+  # the F-bug that made every published group entry unroutable.
   defp finish_create(state, plan, group) do
     entry_member = Enum.find(plan, &(&1.expanded_name == group.entry.member))
 
@@ -473,15 +499,13 @@ defmodule Embervm.GroupManager do
         {{:error, {:entry_member_not_in_plan, group.entry.member}}, state}
 
       %{ip: entry_ip} ->
-        case entry_vm_port(state, entry_ip) do
-          {:ok, vm_port} ->
-            pod_ip = state.pod_ip || entry_ip
-
-            case GroupStore.publish(state.store, state.instance_id, pod_ip, vm_port) do
+        case entry_publish_endpoint(state, group, entry_ip) do
+          {:ok, ep_ip, ep_port} ->
+            case GroupStore.publish(state.store, state.instance_id, ep_ip, ep_port) do
               {:ok, _} ->
                 Embervm.EndpointPublisher.publish(state.publisher)
                 Logger.info("embervm group running", workload: state.workload, instance_id: state.instance_id)
-                {{:ok, %{ip: pod_ip, port: vm_port}}, state}
+                {{:ok, %{ip: ep_ip, port: ep_port}}, state}
 
               {:error, reason} ->
                 teardown_failed(state, {:publish_failed, reason})
@@ -491,6 +515,32 @@ defmodule Embervm.GroupManager do
           {:error, reason} ->
             teardown_failed(state, {:entry_port_derivation, reason})
             {{:error, {:entry_port_derivation, reason}}, state}
+        end
+    end
+  end
+
+  # The endpoint to publish for the entry member: the daemon-reported projection
+  # recorded on the entry member's row when present, else the CP-local derivation
+  # (fallback for a daemon that reported none).
+  defp entry_publish_endpoint(state, group, entry_ip) do
+    daemon_reported =
+      GroupStore.members(state.store, state.instance_id)
+      |> Enum.find_value(fn m ->
+        if m.member_name == group.entry.member and
+             is_binary(Map.get(m, :endpoint_ip)) and Map.get(m, :endpoint_ip) != "" and
+             is_integer(Map.get(m, :endpoint_port)) and Map.get(m, :endpoint_port) > 0 do
+          {Map.get(m, :endpoint_ip), Map.get(m, :endpoint_port)}
+        end
+      end)
+
+    case daemon_reported do
+      {ip, port} ->
+        {:ok, ip, port}
+
+      nil ->
+        case entry_vm_port(state, entry_ip) do
+          {:ok, vm_port} -> {:ok, state.pod_ip || entry_ip, vm_port}
+          {:error, reason} -> {:error, reason}
         end
     end
   end
@@ -746,13 +796,16 @@ defmodule Embervm.GroupManager do
           snapshot_ref: ref,
           health_port: member.health_port || 0,
           resources: %ResourceSpec{vcpus: member.vcpus || 1, mem_mib: member.mem_mib || 512},
-          env: %{}
+          env: %{},
+          # Same one-policy budget forwarding as the FRESH path: the daemon's
+          # readiness gate must not undercut the wake bound this relight runs under.
+          ready_budget_seconds: wake_budget_seconds(state)
         }
 
         case safe_start_group_member(state, req) do
-          {:ok, %StartGroupMemberResponse{vm_id: vm_id, ip: ip, was_relight: true}}
+          {:ok, %StartGroupMemberResponse{vm_id: vm_id, was_relight: true} = resp}
           when is_binary(vm_id) and vm_id != "" ->
-            record_member_live(state, member, vm_id, ip)
+            record_member_live(state, member, resp)
 
           # A RELIGHT that the daemon could not verify (clock-resync out of bounds,
           # decision 7, surfaces as was_relight=false): the VM DID resume and is holding
@@ -761,10 +814,10 @@ defmodule Embervm.GroupManager do
           # whole set falls back to fresh. We never accept a half-resumed member as
           # part of a live relit set, but we must not leak its tap either. Stamp the
           # span's was_relight=false so the trace records the clock-resync-failed member.
-          {:ok, %StartGroupMemberResponse{vm_id: vm_id, ip: ip, was_relight: false}}
+          {:ok, %StartGroupMemberResponse{vm_id: vm_id, was_relight: false} = resp}
           when is_binary(vm_id) and vm_id != "" ->
             Tracer.set_attributes(%{"ember.was_relight" => false})
-            _ = record_member_live(state, member, vm_id, ip)
+            _ = record_member_live(state, member, resp)
             {:error, {:member_relight_unverified, member.expanded_name}}
 
           {:ok, %StartGroupMemberResponse{was_relight: false}} ->
@@ -780,12 +833,16 @@ defmodule Embervm.GroupManager do
     end
   end
 
-  defp record_member_live(state, member, vm_id, ip) do
+  defp record_member_live(state, member, %StartGroupMemberResponse{vm_id: vm_id, ip: ip} = resp) do
     case GroupStore.member_started(state.store, state.instance_id, %{
            member_name: member.expanded_name,
            member_index: member.index,
            vm_id: vm_id,
-           ip: ip
+           ip: ip,
+           # Daemon-reported entry-endpoint projection (entry member only), the
+           # address finish_wake_publish/finish_create must publish.
+           endpoint_ip: resp.endpoint_ip || "",
+           endpoint_port: resp.endpoint_port || 0
          }) do
       {:ok, _} -> :ok
       {:error, reason} -> {:error, {:member_record_failed, member.expanded_name, reason}}
@@ -804,15 +861,13 @@ defmodule Embervm.GroupManager do
         {{:error, {:entry_member_not_in_plan, group.entry.member}}, state}
 
       %{ip: entry_ip} ->
-        case entry_vm_port(state, entry_ip) do
-          {:ok, vm_port} ->
-            pod_ip = state.pod_ip || entry_ip
-
-            case GroupStore.publish(state.store, state.instance_id, pod_ip, vm_port) do
+        case entry_publish_endpoint(state, group, entry_ip) do
+          {:ok, ep_ip, ep_port} ->
+            case GroupStore.publish(state.store, state.instance_id, ep_ip, ep_port) do
               {:ok, _} ->
                 Embervm.EndpointPublisher.publish(state.publisher)
                 Logger.info("embervm group woken", workload: state.workload, instance_id: state.instance_id)
-                {{:ok, %{ip: pod_ip, port: vm_port}}, state}
+                {{:ok, %{ip: ep_ip, port: ep_port}}, state}
 
               {:error, reason} ->
                 {{:error, {:publish_failed, reason}}, state}

--- a/projects/embervm/control/lib/embervm/group_store.ex
+++ b/projects/embervm/control/lib/embervm/group_store.ex
@@ -792,7 +792,8 @@ defmodule Embervm.GroupStore do
   # -- member started --------------------------------------------------------
 
   defp do_member_started(state, instance_id, fields) do
-    with {:ok, instance} <- fetch(state, instance_id) do
+    with {:ok, instance} <- fetch(state, instance_id),
+         :ok <- refuse_terminal(instance) do
       ts = state.clock.()
       member_name = Map.fetch!(fields, :member_name)
 
@@ -819,6 +820,12 @@ defmodule Embervm.GroupStore do
             member_index: Map.get(fields, :member_index),
             vm_id: Map.get(fields, :vm_id),
             ip: Map.get(fields, :ip),
+            # The daemon-reported entry-endpoint projection ({noded pod IP, vmPort}),
+            # set only on the ENTRY member's report. Held in ETS only (not projected
+            # to SQLite): it is consumed by the same in-flight wake that recorded it
+            # (the publish that follows), and a rebuilt CP never resumes that wake.
+            endpoint_ip: Map.get(fields, :endpoint_ip, ""),
+            endpoint_port: Map.get(fields, :endpoint_port, 0),
             state: "starting",
             # A fresh member boot clears any prior banked slice (the warmth is spent).
             snapshot_ref: nil,
@@ -835,6 +842,13 @@ defmodule Embervm.GroupStore do
     else
       {:error, _reason} = error -> {:reply, error, state}
     end
+  end
+
+  # A member report against a terminal instance is a zombie worker (its wake
+  # expired at the bound and the instance was rolled while a StartGroupMember hung):
+  # refuse rather than resurrecting rows on a destroyed/failed instance.
+  defp refuse_terminal(%{state: st}) do
+    if GroupState.terminal?(st), do: {:error, {:instance_terminal, st}}, else: :ok
   end
 
   # -- transition ------------------------------------------------------------

--- a/projects/embervm/control/lib/embervm/group_wake_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_wake_manager.ex
@@ -164,6 +164,13 @@ defmodule Embervm.GroupWakeManager do
       # implementing create_group/2 + wake_group/1 (or a per-workload scripted fake).
       # Production drives Embervm.GroupManager.Supervisor.
       supervisor_mod: Keyword.get(opts, :supervisor_mod, GroupManager.Supervisor),
+      # The teardown seam for a wake that expired at the bound (and for a dead
+      # create found by adoption): force-rolls the workload's live instance so the
+      # singleton gate releases and the NEXT wake can create afresh. Without this a
+      # bound-expired create leaves a live-forever instance every later wake
+      # bounces off (:already_live), a permanent wedge only an operator's forced
+      # roll could clear. Injected in tests as a module implementing force_roll/1.
+      sweeper_mod: Keyword.get(opts, :sweeper_mod, Embervm.GroupSweeper),
       # Restore-on-miss seams (R6, Task 8). Unlike serving/stateful this module owns
       # no dispatch channel of its own (the heavy relight is delegated to a
       # GroupManager child), so the restore-before-relight RPC dials its own channel
@@ -245,7 +252,15 @@ defmodule Embervm.GroupWakeManager do
   def handle_info({:wake_timeout, workload}, state) do
     if Map.has_key?(state.waking, workload) do
       Logger.warning("embervm group wake timed out at bound", workload: workload)
-      {:noreply, finish_wake(state, workload, {:error, {:wake_failed, :wake_timeout}})}
+      state = finish_wake(state, workload, {:error, {:wake_failed, :wake_timeout}})
+      # Tear the expired wake's instance down (async: force_roll drives noded RPCs
+      # and must not block this manager). The create/relight worker behind it may
+      # still be hung inside a member start; rolling the instance terminal releases
+      # the singleton so the next wake can create afresh instead of bouncing off
+      # :already_live forever, and the store's publish guard keeps the zombie
+      # worker from publishing onto the rolled instance if it ever returns.
+      teardown_expired_wake(state, workload)
+      {:noreply, state}
     else
       {:noreply, state}
     end
@@ -370,6 +385,29 @@ defmodule Embervm.GroupWakeManager do
   end
 
   defp schedule_wake_timeout(_workload, _bound_ms), do: :ok
+
+  # Force-roll a workload's live instance after its wake expired at the bound (or
+  # adoption found a dead create). Async and best-effort: the sweeper drives noded
+  # StopGroupMember/DeleteGroupNetwork RPCs, so it must not run on this manager's
+  # process; a crash in the spawned task only means the wedge waits for the next
+  # adoption pass (which retries via the same seam).
+  defp teardown_expired_wake(state, workload) do
+    sweeper = state.sweeper_mod
+
+    spawn(fn ->
+      try do
+        result = sweeper.force_roll(workload)
+        Logger.warning("embervm group expired wake torn down", workload: workload, result: inspect(result))
+      rescue
+        e -> Logger.error("embervm group expired-wake teardown failed", workload: workload, error: inspect(e))
+      catch
+        kind, reason ->
+          Logger.error("embervm group expired-wake teardown failed", workload: workload, error: inspect({kind, reason}))
+      end
+    end)
+
+    :ok
+  end
 
   defp spawn_wake(owner, workload, fun) do
     spawn(fn ->
@@ -733,6 +771,21 @@ defmodule Embervm.GroupWakeManager do
       Map.has_key?(state.waking, instance.workload) ->
         state
 
+      # A `creating` instance with NO in-flight wake is a dead create: its owning
+      # worker is gone (a CP restart mid-create, or a bound-expired wake whose
+      # teardown was lost). It can never finish, and adopting whatever members DID
+      # start to `running` would publish a partial group (the 1-of-3-members zombie
+      # from the R6 Gate-1 drill). Roll it terminal (destroys the reported members
+      # + network, releases the singleton) so the next connection creates afresh.
+      instance.state == :creating ->
+        Logger.warning("embervm group adoption: dead create, rolling terminal",
+          workload: instance.workload,
+          instance_id: instance.instance_id
+        )
+
+        teardown_expired_wake(state, instance.workload)
+        state
+
       # Live members reported for this instance -> a live group: adopt to running,
       # rebind member endpoints/health, respawn the GroupManager owner, re-derive
       # the entry endpoint. Never touches a VM.
@@ -774,29 +827,43 @@ defmodule Embervm.GroupWakeManager do
     state
   end
 
-  # Re-derive the DNAT entry endpoint from the ENTRY member's node-reported ip and
-  # force it into the instance, so the republish equals the pre-restart publish. The
-  # entry member is the instance's `entry_member`; its live ip comes from node truth
-  # (the member VMs the reconcile just indexed). vm_port = port_base + host_offset(ip,
-  # supernet), the exact derivation GroupManager.entry_vm_port uses. A missing entry
-  # member ip, an ip outside the supernet, or no pod_ip configured leaves the endpoint
-  # untouched (the fallback rebuild stands; adoption never publishes a bad endpoint).
+  # Re-derive the DNAT entry endpoint's PORT from the ENTRY member's node-reported
+  # ip (vm_port = port_base + host_offset(ip, supernet), the exact derivation
+  # GroupManager.entry_vm_port uses) and force it into the instance, so the
+  # republish equals the pre-restart publish.
+  #
+  # The endpoint HOST prefers the instance's already-recorded entry_ip: the publish
+  # that recorded it carried the DAEMON's endpoint projection (the noded pod IP,
+  # where the DNAT actually lives), and adoption must not clobber it. state.pod_ip
+  # (this control plane's OWN pod IP) remains only as the legacy fallback for an
+  # instance that was never published; for a split noded deployment it is known-
+  # unroutable (the F-bug), but adoption preserves the old shape rather than
+  # publishing nothing. A missing entry member ip, an ip outside the supernet, or
+  # no host at all leaves the endpoint untouched (the fallback rebuild stands;
+  # adoption never publishes a bad endpoint).
   defp adopt_entry_endpoint(state, instance, members) do
+    recorded_host = Map.get(instance, :entry_ip)
+
     with entry_name when is_binary(entry_name) <- instance.entry_member,
          %{ip: entry_ip} when is_binary(entry_ip) and entry_ip != "" <-
            Enum.find(members, &(&1.member_name == entry_name)),
          {:ok, offset} <- host_offset(state.supernet, entry_ip),
-         pod_ip when is_binary(pod_ip) and pod_ip != "" <- state.pod_ip || entry_ip do
+         host when is_binary(host) and host != "" <-
+           first_present([recorded_host, state.pod_ip, entry_ip]) do
       vm_port = state.port_base + offset
 
       if vm_port >= 1 and vm_port <= 65_535 do
-        GroupStore.adopt_endpoint(state.store, instance.instance_id, pod_ip, vm_port)
+        GroupStore.adopt_endpoint(state.store, instance.instance_id, host, vm_port)
       else
         :ok
       end
     else
       _ -> :ok
     end
+  end
+
+  defp first_present(candidates) do
+    Enum.find(candidates, fn v -> is_binary(v) and v != "" end)
   end
 
   defp heal_to_banked(state, %{state: :banked}), do: state

--- a/projects/embervm/control/test/embervm/group_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_manager_test.exs
@@ -56,6 +56,11 @@ defmodule Embervm.GroupManagerTest do
     # was_relight=false response (the clock-resync casualty, decision 7).
     relight_fail_member = Keyword.get(opts, :relight_fail_member)
     relight_unverified_member = Keyword.get(opts, :relight_unverified_member)
+    # A scripted daemon endpoint projection {ip, port} the fake attaches to the
+    # ENTRY member's response (the F-fix lane: the CP must publish the DAEMON's
+    # reported endpoint, not its own pod IP). nil models a pre-R6/DNAT-disabled
+    # daemon that reports none.
+    daemon_endpoint = Keyword.get(opts, :daemon_endpoint)
 
     create_group_network_fun = fn _ch, req ->
       record(rec, {:create_network, req.group_instance_id, req.cidr})
@@ -100,6 +105,9 @@ defmodule Embervm.GroupManagerTest do
       # assertions, which all filter/find by that tag) so a test can assert only the
       # entry member carries a non-zero entry_guest_port.
       record(rec, {:start_member_entry, req.member_name, req.entry_guest_port})
+      # Additive record of the forwarded readiness budget (the G-fix lane: the
+      # daemon gate must share the workload's wake policy).
+      record(rec, {:start_member_budget, req.member_name, req.ready_budget_seconds})
       vm_id = "vm-#{req.member_name}"
 
       cond do
@@ -124,8 +132,22 @@ defmodule Embervm.GroupManagerTest do
 
         true ->
           case reserve.(req.ip, vm_id) do
-            :ok -> {:ok, %StartGroupMemberResponse{vm_id: vm_id, ip: req.ip, was_relight: relight?}}
-            :error -> {:error, :ip_in_use}
+            :ok ->
+              resp = %StartGroupMemberResponse{vm_id: vm_id, ip: req.ip, was_relight: relight?}
+
+              resp =
+                case {daemon_endpoint, req.entry_guest_port} do
+                  {{ep_ip, ep_port}, p} when is_integer(p) and p > 0 ->
+                    %{resp | endpoint_ip: ep_ip, endpoint_port: ep_port}
+
+                  _ ->
+                    resp
+                end
+
+              {:ok, resp}
+
+            :error ->
+              {:error, :ip_in_use}
           end
       end
     end
@@ -245,6 +267,47 @@ defmodule Embervm.GroupManagerTest do
     assert entry_ports["leader"] == 8080
     assert entry_ports["worker-0"] == 0
     assert entry_ports["worker-1"] == 0
+  end
+
+  test "create publishes the DAEMON-reported entry endpoint over the CP-local derivation" do
+    # The daemon reports its own projection ({noded pod IP, vmPort}): that is where
+    # the entry DNAT lives, so THAT is what must be published. The CP-local
+    # {pod_ip: 10.0.0.9, 30010} derivation (asserted by the round-trip test above
+    # when no daemon endpoint is reported) is only the fallback.
+    ctx = start_group(daemon_endpoint: {"10.42.1.95", 36_443})
+
+    assert {:ok, endpoint} = GroupManager.create_group(ctx.mgr)
+    assert endpoint == %{ip: "10.42.1.95", port: 36_443}
+
+    {:ok, inst} = GroupStore.get(ctx.store, "g-1")
+    assert inst.entry_ip == "10.42.1.95"
+    assert inst.entry_port_published == 36_443
+  end
+
+  test "the workload wake budget is forwarded as every member's ready budget" do
+    entry = default_entry()
+    entry = %{entry | group: Map.put(entry.group, :wake_timeout_seconds, 180)}
+    ctx = start_group(entry: entry)
+    {:ok, _} = GroupManager.create_group(ctx.mgr)
+
+    budgets =
+      events(ctx.rec)
+      |> Enum.filter(&match?({:start_member_budget, _, _}, &1))
+      |> Map.new(fn {:start_member_budget, name, secs} -> {name, secs} end)
+
+    assert budgets == %{"leader" => 180, "worker-0" => 180, "worker-1" => 180}
+  end
+
+  test "no wake budget in the catalog forwards 0 (daemon default)" do
+    ctx = start_group()
+    {:ok, _} = GroupManager.create_group(ctx.mgr)
+
+    budgets =
+      events(ctx.rec)
+      |> Enum.filter(&match?({:start_member_budget, _, _}, &1))
+      |> Enum.map(fn {:start_member_budget, _, secs} -> secs end)
+
+    assert budgets == [0, 0, 0]
   end
 
   test "ordered-start property: order N never starts before every order N-1 member" do

--- a/projects/embervm/control/test/embervm/group_store_test.exs
+++ b/projects/embervm/control/test/embervm/group_store_test.exs
@@ -108,6 +108,32 @@ defmodule Embervm.GroupStoreTest do
     assert leader.state == "banked"
   end
 
+  test "member_started records the daemon-reported entry endpoint (ETS-only)" do
+    ctx = start_store()
+    {:ok, _} = create(ctx, "g-1")
+    {:ok, m} = member(ctx, "g-1", "leader", 0, %{endpoint_ip: "10.42.1.95", endpoint_port: 36_443})
+    assert m.endpoint_ip == "10.42.1.95"
+    assert m.endpoint_port == 36_443
+
+    # A member reported without one carries the zero values, not nil.
+    {:ok, w} = member(ctx, "g-1", "worker-0", 1)
+    assert w.endpoint_ip == ""
+    assert w.endpoint_port == 0
+  end
+
+  test "member_started against a terminal instance is refused (zombie worker guard)" do
+    # A StartGroupMember that returns AFTER the wake bound expired and the instance
+    # was force-rolled must not resurrect member rows on the destroyed instance.
+    ctx = start_store()
+    {:ok, _} = create(ctx, "g-1")
+
+    {:ok, _} =
+      GroupStore.transition(ctx.store, "g-1", :destroy, :group_destroyed, %{reason: "forced_roll"}, %{})
+
+    assert {:error, {:instance_terminal, :destroyed}} = member(ctx, "g-1", "leader", 0)
+    assert GroupStore.members(ctx.store, "g-1") == []
+  end
+
   test "the degraded flag: one member unhealthy on a running group names it; recovery clears it" do
     ctx = start_store()
     {:ok, _} = create(ctx, "g-1")

--- a/projects/embervm/control/test/embervm/group_wake_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_wake_manager_test.exs
@@ -106,6 +106,22 @@ defmodule Embervm.GroupWakeManagerTest do
     defp maybe_sleep(_s), do: :ok
   end
 
+  # The bound-expiry teardown seam (H-fix): records force_roll calls to a per-test
+  # probe process when one is registered, so a test can assert an expired wake (or
+  # a dead create found by adoption) rolled the instance. Tests within one module
+  # run serially (async: true parallelizes across modules), so the registered
+  # probe name cannot cross-talk.
+  defmodule FakeSweeper do
+    def force_roll(workload) do
+      case Process.whereis(:gwm_sweeper_probe) do
+        nil -> :ok
+        pid -> send(pid, {:force_rolled, workload})
+      end
+
+      %{destroyed: 1, evicted: 0}
+    end
+  end
+
   defp start_stack(opts \\ []) do
     suffix = System.unique_integer([:positive])
     path = Path.join(System.tmp_dir!(), "embervm_groupwake_test_#{suffix}.db")
@@ -172,6 +188,9 @@ defmodule Embervm.GroupWakeManagerTest do
         clock: clock,
         channel_fun: fn _node -> {:ok, :ch} end,
         op_log: op_log,
+        # Default the teardown seam to the no-op fake: without it an expired-wake
+        # teardown would dial the real (absent) GroupSweeper and log a crash.
+        sweeper_mod: FakeSweeper,
         reconcile_interval_ms: 0
       ] ++ Keyword.take(opts, [:wake_bound_ms, :mono_clock, :restore_artifact_fun])
 
@@ -530,6 +549,62 @@ defmodule Embervm.GroupWakeManagerTest do
     :ok = GroupWakeManager.reconcile(ctx.mgr)
     {:ok, inst} = GroupStore.get(ctx.store, "g-1")
     assert inst.state == :banked
+  end
+
+  test "a bound-expired wake tears its instance down via the sweeper (H-fix)" do
+    # A wake that expires at the bound must force-roll the workload's instance:
+    # without it a bound-expired CREATE leaves a live-forever :creating instance and
+    # every later wake bounces off :already_live (the permanent Gate-1 wedge).
+    Process.register(self(), :gwm_sweeper_probe)
+    on_exit(fn -> if Process.whereis(:gwm_sweeper_probe) == self(), do: Process.unregister(:gwm_sweeper_probe) end)
+
+    ctx = start_stack(instance_id: "g-1", latency_ms: 3_000, fail: true, wake_bound_ms: 40)
+    _ = seed_banked(ctx, "g-1")
+
+    assert {:error, {:wake_failed, :wake_timeout}} =
+             GroupWakeManager.wake(ctx.mgr, "grp-a", "system:group:grp-a")
+
+    assert_receive {:force_rolled, "grp-a"}, 1_000
+  end
+
+  test "adoption rolls a dead create (:creating with no in-flight wake) terminal" do
+    # A :creating instance with no wake in flight is a dead create (a CP restart
+    # mid-create, or a lost bound timer): it can never finish, and adopting its
+    # partial member set to running would publish a partial group. Adoption must
+    # roll it via the sweeper instead of adopt_live-ing it.
+    Process.register(self(), :gwm_sweeper_probe)
+    on_exit(fn -> if Process.whereis(:gwm_sweeper_probe) == self(), do: Process.unregister(:gwm_sweeper_probe) end)
+
+    ctx = start_stack(instance_id: nil)
+
+    {:ok, _} =
+      GroupStore.create(ctx.store, %{
+        instance_id: "g-dead",
+        tenant: "homelab",
+        principal: "system:group:grp-a",
+        workload: "grp-a",
+        node_id: "node-4",
+        subnet_cidr: "10.101.0.0/24",
+        entry_member: "leader",
+        entry_port: 8080,
+        listen_port: 5410,
+        secret: "s"
+      })
+
+    # One live member reported by the node (the 1-of-3 zombie shape): without the
+    # dead-create branch this instance would be adopt_live'd to running.
+    seed_node(ctx, %{
+      group_member_vms: [
+        %{group_instance_id: "g-dead", member_name: "leader", vm_id: "vm-l", ip: "10.101.0.10", healthy: true}
+      ]
+    })
+
+    :ok = GroupWakeManager.reconcile(ctx.mgr)
+
+    assert_receive {:force_rolled, "grp-a"}, 1_000
+    # The instance was NOT adopted to running (the sweeper owns its teardown).
+    {:ok, inst} = GroupStore.get(ctx.store, "g-dead")
+    refute inst.state == :running
   end
 
   test "adoption recovers a workload stuck waking past 2 * wakeTimeoutSeconds" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.110
+      targetRevision: 0.1.111
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/group_member.go
+++ b/projects/embervm/noded/server/group_member.go
@@ -120,7 +120,21 @@ func (s *Server) startGroupMemberFresh(ctx context.Context, req *nodev1.StartGro
 		s.groupNet.RemoveMemberTap(ctx, groupInstanceID, tap, ip)
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: cold-boot group member: %v", err)
 	}
-	return s.finishGroupMemberStart(ctx, h, groupInstanceID, memberName, req.GetMemberIndex(), tap, ip, healthPort, req.GetEntryGuestPort(), false, s.cfg.BootReadyTimeout)
+	return s.finishGroupMemberStart(ctx, h, groupInstanceID, memberName, req.GetMemberIndex(), tap, ip, healthPort, req.GetEntryGuestPort(), false, groupMemberReadyBudget(req, s.cfg.BootReadyTimeout))
+}
+
+// groupMemberReadyBudget resolves the readiness budget for one member start: the
+// request's ready_budget_seconds when set (the control plane forwards the
+// workload's wakeTimeoutSeconds so daemon gate and CP wake bound share one
+// policy), else the daemon default for the start mode. Without the override a
+// member that needs longer than the daemon default (a k3s agent's kubelet opens
+// :10250 only after the full join) is reaped here while the CP is still waiting
+// on its own, longer bound.
+func groupMemberReadyBudget(req *nodev1.StartGroupMemberRequest, fallback time.Duration) time.Duration {
+	if secs := req.GetReadyBudgetSeconds(); secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	return fallback
 }
 
 // startGroupMemberRelight recreates the member's pinned tap world, resumes the banked
@@ -167,7 +181,7 @@ func (s *Server) startGroupMemberRelight(ctx context.Context, req *nodev1.StartG
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: group member %q clock resync failed: %v", ref, clockErr)
 	}
 
-	return s.finishGroupMemberStart(ctx, h, groupInstanceID, memberName, req.GetMemberIndex(), tap, ip, healthPort, req.GetEntryGuestPort(), true, s.cfg.RestoreReadyTimeout)
+	return s.finishGroupMemberStart(ctx, h, groupInstanceID, memberName, req.GetMemberIndex(), tap, ip, healthPort, req.GetEntryGuestPort(), true, groupMemberReadyBudget(req, s.cfg.RestoreReadyTimeout))
 }
 
 // finishGroupMemberStart is the shared tail of both member start paths: TCP-health-
@@ -176,8 +190,14 @@ func (s *Server) startGroupMemberRelight(ctx context.Context, req *nodev1.StartG
 // FAILED_PRECONDITION (no half-alive member is ever published).
 func (s *Server) finishGroupMemberStart(ctx context.Context, h substrate.Handle, groupInstanceID, memberName string, memberIndex uint32, tap string, ip net.IP, healthPort, entryGuestPort uint32, wasRelight bool, readyBudget time.Duration) (*nodev1.StartGroupMemberResponse, error) {
 	if err := s.waitStatefulReady(ctx, ip, healthPort, readyBudget); err != nil {
+		// Loud on purpose: this reap is the daemon KILLING a member that missed its
+		// readiness budget. Silent, it reads as a mystery VM disappearance (the R6
+		// Gate-1 drill lost both k3s agents here with no trace).
+		s.logger.Warn("noded: reaping group member (readiness gate missed)",
+			"group", groupInstanceID, "member", memberName, "vm", h.ID,
+			"ip", ip.String(), "health_port", healthPort, "budget", readyBudget.String(), "err", err.Error())
 		s.reapGroupMember(h, groupInstanceID, tap, ip)
-		return nil, status.Errorf(codes.FailedPrecondition, "noded: group member not ready over tap: %v", err)
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: group member %q not ready over tap within %s: %v", memberName, readyBudget, err)
 	}
 	// Install the entry DNAT for the ENTRY member (entry_guest_port > 0) so the entry
 	// endpoint the control plane publishes, {pod_ip, vmPort}, actually routes to this
@@ -204,11 +224,23 @@ func (s *Server) finishGroupMemberStart(ctx context.Context, h substrate.Handle,
 		probe:           probe,
 	})
 	s.signalChange()
-	return &nodev1.StartGroupMemberResponse{
+	resp := &nodev1.StartGroupMemberResponse{
 		VmId:       h.ID,
 		Ip:         ip.String(),
 		WasRelight: wasRelight,
-	}, nil
+	}
+	// The ENTRY member's response carries the daemon's own projection of the entry
+	// endpoint, {noded pod IP, vmPort}: the DNAT installed above lives in THIS
+	// pod's netns, so this address (not the control plane's own pod IP) is the one
+	// the CP must publish. Empty when DNAT is disabled (no pod IP configured).
+	if entryGuestPort > 0 {
+		epIP, epPort := s.groupNet.EntryEndpoint(ip, entryGuestPort)
+		if epIP != "" && epIP != ip.String() {
+			resp.EndpointIp = epIP
+			resp.EndpointPort = epPort
+		}
+	}
+	return resp, nil
 }
 
 // StopGroupMember tears down one live member VM. BANK pauses it, snapshots it under

--- a/projects/embervm/noded/server/group_member_test.go
+++ b/projects/embervm/noded/server/group_member_test.go
@@ -292,6 +292,82 @@ func TestStartGroupMemberEntryInstallsDNAT(t *testing.T) {
 	}
 }
 
+// TestStartGroupMemberEntryReportsEndpoint proves the ENTRY member's response
+// carries the daemon's endpoint projection ({pod IP, vmPort}) when DNAT is
+// enabled, and that non-entry members (and a DNAT-disabled daemon) report none.
+// Regression for the F-bug: the control plane used to publish its OWN pod IP,
+// an address the entry DNAT does not live at.
+func TestStartGroupMemberEntryReportsEndpoint(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, gn, _, _ := newGroupMemberTestServer(t)
+	gn.podIP = "10.42.1.95"
+
+	// Non-entry member: no endpoint reported.
+	worker := startFreshMember(t, s, port, "worker-1", 1)
+	if worker.GetEndpointIp() != "" || worker.GetEndpointPort() != 0 {
+		t.Errorf("non-entry member reported an endpoint: %q:%d", worker.GetEndpointIp(), worker.GetEndpointPort())
+	}
+
+	// Entry member: the response carries the daemon's projection.
+	resp, err := s.StartGroupMember(context.Background(), &nodev1.StartGroupMemberRequest{
+		Mode:            nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_FRESH,
+		GroupInstanceId: "grp-A",
+		MemberName:      "server",
+		MemberIndex:     0,
+		Ip:              "127.0.0.1",
+		Source:          "src-a",
+		HealthPort:      port,
+		EntryGuestPort:  6443,
+	})
+	if err != nil {
+		t.Fatalf("StartGroupMember(entry): %v", err)
+	}
+	if resp.GetEndpointIp() != "10.42.1.95" || resp.GetEndpointPort() != 30000+6443 {
+		t.Errorf("entry endpoint = %q:%d want 10.42.1.95:%d", resp.GetEndpointIp(), resp.GetEndpointPort(), 30000+6443)
+	}
+}
+
+// TestStartGroupMemberEntryNoDNATReportsNoEndpoint proves a DNAT-disabled daemon
+// (no pod IP; EntryEndpoint falls back to the tap) reports NO endpoint, so the
+// control plane falls back to its own derivation instead of publishing a
+// node-internal tap address.
+func TestStartGroupMemberEntryNoDNATReportsNoEndpoint(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, _, _, _ := newGroupMemberTestServer(t)
+
+	resp, err := s.StartGroupMember(context.Background(), &nodev1.StartGroupMemberRequest{
+		Mode:            nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_FRESH,
+		GroupInstanceId: "grp-A",
+		MemberName:      "server",
+		MemberIndex:     0,
+		Ip:              "127.0.0.1",
+		Source:          "src-a",
+		HealthPort:      port,
+		EntryGuestPort:  6443,
+	})
+	if err != nil {
+		t.Fatalf("StartGroupMember(entry): %v", err)
+	}
+	if resp.GetEndpointIp() != "" || resp.GetEndpointPort() != 0 {
+		t.Errorf("DNAT-disabled daemon reported an endpoint: %q:%d", resp.GetEndpointIp(), resp.GetEndpointPort())
+	}
+}
+
+// TestGroupMemberReadyBudget proves the request's ready_budget_seconds overrides
+// the daemon default and 0 keeps it. Regression for the silent 60s reap: noded's
+// own BootReadyTimeout undercut the workload's wakeTimeoutSeconds, so the k3s
+// agents (kubelet up only after the full join) were reaped mid-join with the
+// control plane still inside its wake bound.
+func TestGroupMemberReadyBudget(t *testing.T) {
+	req := &nodev1.StartGroupMemberRequest{ReadyBudgetSeconds: 180}
+	if got := groupMemberReadyBudget(req, 60*time.Second); got != 180*time.Second {
+		t.Errorf("override budget = %v want 180s", got)
+	}
+	if got := groupMemberReadyBudget(&nodev1.StartGroupMemberRequest{}, 60*time.Second); got != 60*time.Second {
+		t.Errorf("default budget = %v want 60s", got)
+	}
+}
+
 // TestStartGroupMemberEntryDNATFailureReaps proves an entry DNAT install failure
 // reaps the member (no half-published entry whose DNAT never landed).
 func TestStartGroupMemberEntryDNATFailureReaps(t *testing.T) {

--- a/projects/embervm/noded/server/group_test.go
+++ b/projects/embervm/noded/server/group_test.go
@@ -35,6 +35,10 @@ type fakeGroupNet struct {
 	ensureCalls  []ensureTapCall
 	entryDNATs   []entryDNATCall // recorded EnsureEntryDNAT calls
 	entryDNATErr error
+	// podIP, when set, makes EntryEndpoint return the DNAT projection
+	// (podIP, 30000+port) instead of the tap fallback, mirroring the real
+	// GroupManager with a configured pod IP.
+	podIP string
 }
 
 // entryDNATCall records one EnsureEntryDNAT invocation for assertions.
@@ -146,6 +150,11 @@ func (f *fakeGroupNet) GatewayIP(id string) net.IP { return net.IPv4(10, 101, 1,
 func (f *fakeGroupNet) PrefixLen(id string) int    { return 24 }
 
 func (f *fakeGroupNet) EntryEndpoint(ip net.IP, port uint32) (string, uint32) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.podIP != "" {
+		return f.podIP, 30000 + port
+	}
 	return ip.String(), port
 }
 

--- a/projects/embervm/proto/embervm/node/v1/fakenode/main.go
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/main.go
@@ -253,10 +253,21 @@ func (*fakeServer) StartGroupMember(_ context.Context, req *nodev1.StartGroupMem
 			VmId: "vm:" + ref, Ip: req.GetIp(), WasRelight: true,
 		}, nil
 	}
-	// FRESH: cold boot from the source, echo the pinned ip.
-	return &nodev1.StartGroupMemberResponse{
+	// FRESH: cold boot from the source, echo the pinned ip. The R6 request fields
+	// derive response content so the client can assert they crossed the wire:
+	// ready_budget_seconds folds into vm_id ("@<n>s") and a non-zero
+	// entry_guest_port yields the daemon-side endpoint projection fields.
+	resp := &nodev1.StartGroupMemberResponse{
 		VmId: "vm:" + req.GetSource(), Ip: req.GetIp(), WasRelight: false,
-	}, nil
+	}
+	if b := req.GetReadyBudgetSeconds(); b > 0 {
+		resp.VmId = fmt.Sprintf("%s@%ds", resp.VmId, b)
+	}
+	if p := req.GetEntryGuestPort(); p > 0 {
+		resp.EndpointIp = "fakenode-pod"
+		resp.EndpointPort = 30000 + p
+	}
+	return resp, nil
 }
 
 // StopGroupMember returns a per-member bundle ref under the caller-supplied set

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -993,6 +993,15 @@ message StartGroupMemberRequest {
   // workload's entry). It may differ from health_port (the health-gate port), so it
   // is carried explicitly rather than reusing health_port.
   uint32 entry_guest_port = 12;
+  // ready_budget_seconds, when > 0, overrides the daemon's default readiness
+  // budget (BootReadyTimeout for FRESH, RestoreReadyTimeout for RELIGHT) for THIS
+  // member's health gate. The control plane sets it from the workload's
+  // wakeTimeoutSeconds so the daemon's per-member gate and the CP's whole-wake
+  // bound share one policy: without it a member that legitimately needs longer
+  // than the daemon default (a k3s agent's kubelet only opens :10250 after the
+  // full join) is silently reaped at the daemon's own budget while the CP is
+  // still waiting. 0 keeps the daemon default.
+  uint32 ready_budget_seconds = 13;
 }
 
 message StartGroupMemberResponse {
@@ -1005,6 +1014,15 @@ message StartGroupMemberResponse {
   // was_relight is true when the call resumed a banked bundle (a verified RELIGHT,
   // clock-resync within one second); false for a FRESH cold boot.
   bool was_relight = 3;
+  // endpoint_ip/endpoint_port carry the daemon's OWN projection of the entry
+  // endpoint, {noded pod IP, vmPort}, filled only for the ENTRY member
+  // (entry_guest_port > 0) after its DNAT install. This is the address the control
+  // plane must publish: the DNAT lives in the DAEMON pod's network namespace, so
+  // publishing any other pod's IP (the CP's own, as the pre-R6 code did) produces
+  // an endpoint no client can reach. Empty/0 for non-entry members and when DNAT
+  // is disabled (no pod IP configured on the daemon).
+  string endpoint_ip = 4;
+  uint32 endpoint_port = 5;
 }
 
 enum StopGroupMemberMode {

--- a/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
+++ b/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
@@ -357,6 +357,33 @@ defmodule Embervm.NodeRoundtripTest do
     assert fresh.vm_id == "vm:worker-base"
     assert fresh.ip == "10.100.0.10"
     assert fresh.was_relight == false
+    # No entry port and no budget on this request -> the R6 fields stay zero-valued.
+    assert fresh.endpoint_ip == ""
+    assert fresh.endpoint_port == 0
+
+    # StartGroupMember FRESH, ENTRY member with a readiness budget (R6): proves
+    # ready_budget_seconds crosses the wire (the fake folds it into vm_id) and the
+    # daemon-side endpoint projection fields cross back (the F-fix lane: the CP
+    # publishes the DAEMON's reported endpoint, so these must survive the wire).
+    {:ok, entry_fresh} =
+      NodeService.Stub.start_group_member(ch, %StartGroupMemberRequest{
+        trace: %Trace{workload: "composite"},
+        mode: :START_GROUP_MEMBER_MODE_FRESH,
+        group_instance_id: "grp-inst1",
+        member_name: "server",
+        member_index: 0,
+        ip: "10.100.0.10",
+        source: "server-base",
+        health_port: 6443,
+        resources: %ResourceSpec{vcpus: 1, mem_mib: 256},
+        env: %{},
+        entry_guest_port: 6443,
+        ready_budget_seconds: 180
+      })
+
+    assert entry_fresh.vm_id == "vm:server-base@180s"
+    assert entry_fresh.endpoint_ip == "fakenode-pod"
+    assert entry_fresh.endpoint_port == 36_443
 
     # StartGroupMember RELIGHT, verified: resumes warm (was_relight true) once the
     # clock-resync handshake verified within one second. The fake scripts a warm


### PR DESCRIPTION
## Summary

The three composite-group fixes behind the R6 Gate-1 blocker, shipped as one deploy (chart 0.1.111). The drill's kubectl-via-5410 EOF was a cascade of three independent pre-existing bugs, root-caused live on 2026-07-18.

- **G - silent 60s reap**: noded health-gated each group member within its own `BootReadyTimeout` (60s) and reaped the VM on a miss with no log line. The k3s agents (kubelet opens :10250 only after the full join) died this way on every drill while the CP waited out its 180s wake bound. `StartGroupMemberRequest` gains `ready_budget_seconds`, set from the workload's `wakeTimeoutSeconds`, so daemon gate and CP bound enforce one policy; the reap now logs loudly.
- **F - unroutable entry endpoint**: the CP published the group entry as `{its OWN pod IP, vmPort}`, but the entry DNAT lives in the noded pod's netns, so every published group entry was unreachable by construction once noded split into its own deployment. `StartGroupMemberResponse` now carries noded's own endpoint projection (`{noded pod IP, vmPort}`, the same lane stateful uses) and the CP publishes that, keeping the old derivation only as fallback. Adoption prefers the instance's recorded `entry_ip` over re-deriving with the CP pod IP.
- **H - permanent wake wedge**: a wake expiring at the bound left its hung create's `:creating` instance live forever, so every later wake was refused `:already_live` (silently). Bound expiry now force-rolls the instance via the sweeper; adoption rolls a `:creating` instance with no in-flight wake (a dead create) instead of adopting a partial member set to running; the store refuses member reports against terminal instances.

## Test plan

- Go: budget override resolution, endpoint projection on the entry response, DNAT-disabled fallback, existing DNAT/reap tests.
- Elixir: daemon-endpoint preferred over CP-local derivation, budget forwarded to every member, bound-expiry force-roll, dead-create adoption roll, terminal-instance guards.
- Cross-language roundtrip proves the three new proto fields are wire-correct.
- Live confirmation after merge: re-drive the R6 Gate-1 drill (fresh scratch-k8s wake; agents must survive past 60s and join; then kubectl get nodes through 5410), plus a postgres-demo warmth check after the rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)