### PR TITLE
fix(embervm): StartGroupMember deadline covers the member ready budget

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.111
+version: 0.1.112

--- a/projects/embervm/control/lib/embervm/group_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_manager.ex
@@ -1403,8 +1403,23 @@ defmodule Embervm.GroupManager do
     Embervm.Node.V1.NodeService.Stub.delete_group_network(channel, req)
   end
 
+  # StartGroupMember blocks server-side for the member's whole readiness gate (up
+  # to ready_budget_seconds, e.g. 180s for scratch-k8s), so the call deadline must
+  # cover the budget plus RPC margin. Without an explicit timeout the grpc-elixir
+  # default 10s deadline fires mid-gate: the daemon cancels the stream (the member
+  # is reaped "context canceled" while healthy and mid-join) and the RST_STREAM
+  # cancel trips the Mint adapter's connection-crash bug, killing every sibling
+  # member stream on the same channel. This deadline was the true k3s-agent killer
+  # behind the R6 Gate-1 drill; the daemon-side budget fix alone cannot help while
+  # the client hangs up at 10s.
   defp default_start_group_member(channel, req) do
-    Embervm.Node.V1.NodeService.Stub.start_group_member(channel, req)
+    budget_ms =
+      case req.ready_budget_seconds do
+        secs when is_integer(secs) and secs > 0 -> secs * 1_000
+        _ -> 60_000
+      end
+
+    Embervm.Node.V1.NodeService.Stub.start_group_member(channel, req, timeout: budget_ms + 30_000)
   end
 
   defp default_stop_group_member(channel, req) do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.111
+      targetRevision: 0.1.112
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Summary

One-function fix (chart 0.1.112), the final layer under the R6 Gate-1 EOF. `default_start_group_member` rode grpc-elixir's default **10s call deadline** while noded blocks server-side for the member's whole readiness gate (up to `ready_budget_seconds`, 180s for scratch-k8s). At 10s the daemon canceled the stream, so a healthy mid-join k3s agent was reaped as `context canceled`, and the RST_STREAM cancel trips the Mint adapter's connection-crash bug (the known grpc-elixir regression), killing every sibling member stream on the same channel.

Confirmed live twice on 2026-07-18 (22:11 and 22:23 drills): both agents reaped at exactly t+10s with `budget: 3m0s, err: context canceled` in the new reap log, and the crash dump's HPACK table shows `grpc-timeout: 10S`. This client deadline, not the daemon budget, was the k3s agent killer all along; PR #3672's budget forwarding is necessary but not sufficient while the client hangs up at 10s.

Deadline = ready budget (fallback 60s) + 30s RPC margin. Also cures the hung-GroupManager-child wedge: the supervisor terminates the child when the wake call returns an error, which it now always does.

## Test plan

- Compile + existing suites in CI (test fakes inject their own start funs, so behavior under test is unchanged; this touches only the production default).
- Live: re-drive the Gate-1 drill after rollout - agents must survive past 10s and 60s, join, group publishes the daemon endpoint, kubectl through 5410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)