### PR TITLE
fix(embervm): inner scratch-k8s CIDRs must not shadow the outer cluster

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.112
+version: 0.1.113

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.112
+      targetRevision: 0.1.113
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/k3s/guest-init/cmd/k3s.go
+++ b/projects/embervm/runtimes/k3s/guest-init/cmd/k3s.go
@@ -100,6 +100,16 @@ func k3sArgv(env func(string) string) ([]string, error) {
 		argv := []string{
 			bin, "server",
 			"--flannel-backend=host-gw",
+			// Non-default cluster/service CIDRs: the OUTER homelab cluster is also
+			// k3s with the default 10.42.0.0/16 pods + 10.43.0.0/16 services, so an
+			// inner cluster left on the defaults shadows the entire outer pod
+			// network. Once flannel host-gw installs the inner per-node 10.42.x/24
+			// routes, the guest routes replies to any outer-pod client INTO its own
+			// pod network instead of back out the default gateway - the entry DNAT
+			// blackhole behind the R6 Gate-1 EOF (traffic in, SYN-ACK swallowed).
+			"--cluster-cidr=10.52.0.0/16",
+			"--service-cidr=10.53.0.0/16",
+			"--cluster-dns=10.53.0.10",
 		}
 		if secret != "" {
 			// A supplied secret becomes the cluster token AND the static token-auth

--- a/projects/embervm/runtimes/k3s/guest-init/cmd/k3s_test.go
+++ b/projects/embervm/runtimes/k3s/guest-init/cmd/k3s_test.go
@@ -28,6 +28,9 @@ func TestK3sArgv(t *testing.T) {
 			want: []string{
 				"/usr/local/bin/k3s", "server",
 				"--flannel-backend=host-gw",
+				"--cluster-cidr=10.52.0.0/16",
+				"--service-cidr=10.53.0.0/16",
+				"--cluster-dns=10.53.0.10",
 				"--token", "s3cr3t",
 				"--kube-apiserver-arg=token-auth-file=/run/ember/token-auth.csv",
 				"--node-ip", "10.101.0.10",
@@ -43,6 +46,9 @@ func TestK3sArgv(t *testing.T) {
 			want: []string{
 				"/usr/local/bin/k3s", "server",
 				"--flannel-backend=host-gw",
+				"--cluster-cidr=10.52.0.0/16",
+				"--service-cidr=10.53.0.0/16",
+				"--cluster-dns=10.53.0.10",
 			},
 		},
 		{
@@ -54,6 +60,9 @@ func TestK3sArgv(t *testing.T) {
 			want: []string{
 				"/usr/local/bin/k3s", "server",
 				"--flannel-backend=host-gw",
+				"--cluster-cidr=10.52.0.0/16",
+				"--service-cidr=10.53.0.0/16",
+				"--cluster-dns=10.53.0.10",
 				"--node-ip", "10.101.0.10",
 				"--advertise-address", "10.101.0.10",
 			},


### PR DESCRIPTION
## Summary

The final Gate-1 blocker (chart 0.1.113). The inner scratch-k8s cluster ran on k3s defaults (`cluster-cidr 10.42.0.0/16`, `service-cidr 10.43.0.0/16`) - the same defaults the OUTER homelab k3s uses. Once the inner cluster forms, flannel host-gw installs inner per-node `10.42.x/24` routes in the guest, so replies to any outer-pod client (Envoy, the activator) are routed into the inner pod network instead of back out the default gateway.

Confirmed live with temporary nft counters after the 0.1.112 deadline fix got the group all the way to `running`+published for the first time: the entry DNAT delivered rewritten SYNs to the k3s server tap, and the SYN-ACKs vanished inside the guest; the identical probe from the group gateway IP (outside `10.42.0.0/16`) connects fine.

Inner cluster now uses `10.52.0.0/16` pods, `10.53.0.0/16` services, `10.53.0.10` cluster DNS - unused ranges in the homelab (outer pods 10.42/16, outer services 10.43/16, composite supernet 10.101/16, stateful 172.31/24).

## Test plan

- k3sArgv table tests updated for the three server cases (agents inherit from the server).
- Live after rollout: Gate-1 drill end to end - `kubectl get nodes` through 5410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)