### PR TITLE
fix(demos): k8s terminal - set USER for k9s, light theme

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.190
+version: 0.89.191
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.190
+      targetRevision: 0.89.191
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.265
+version: 0.285.266
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/demos/k8s_terminal_api.py
+++ b/projects/monolith/demos/k8s_terminal_api.py
@@ -191,6 +191,7 @@ def _write_k9s_config() -> None:
     with open(cfg_path, "w", encoding="utf-8") as f:
         f.write(_K9S_CONFIG)
 
+
 # The single live session (newest connection wins). Guarded by _session_lock.
 _session_lock = asyncio.Lock()
 _current_session: "_TerminalSession | None" = None

--- a/projects/monolith/demos/k8s_terminal_api.py
+++ b/projects/monolith/demos/k8s_terminal_api.py
@@ -83,6 +83,114 @@ _TERM_GRACE_S = 3.0
 _K9S_BIN = "/usr/local/bin/k9s"
 _KUBECTL_BIN = "/usr/local/bin/kubectl"
 
+# Light k9s skin matched to the private demos palette (paper background, ink
+# text, slate accent). Written into K9S_CONFIG_DIR before each spawn so the
+# terminal reads as part of the page rather than a dark hole in it.
+_K9S_SKIN_LIGHT = """k9s:
+  body:
+    fgColor: "#1a1f28"
+    bgColor: "#f7f8fa"
+    logoColor: "#33507a"
+  prompt:
+    fgColor: "#1a1f28"
+    bgColor: "#f7f8fa"
+    suggestColor: "#656e7c"
+  info:
+    fgColor: "#656e7c"
+    sectionColor: "#1a1f28"
+  dialog:
+    fgColor: "#1a1f28"
+    bgColor: "#f7f8fa"
+    buttonFgColor: "#f7f8fa"
+    buttonBgColor: "#33507a"
+    buttonFocusFgColor: "#ffffff"
+    buttonFocusBgColor: "#a4372e"
+    labelFgColor: "#8a5a00"
+    fieldFgColor: "#1a1f28"
+  frame:
+    border:
+      fgColor: "#c9d0d9"
+      focusColor: "#33507a"
+    menu:
+      fgColor: "#1a1f28"
+      keyColor: "#33507a"
+      numKeyColor: "#a4372e"
+    crumbs:
+      fgColor: "#f7f8fa"
+      bgColor: "#33507a"
+      activeColor: "#8a5a00"
+    status:
+      newColor: "#33507a"
+      modifyColor: "#8a5a00"
+      addColor: "#1e6a3c"
+      pendingColor: "#8a5a00"
+      errorColor: "#a4372e"
+      highlightColor: "#33507a"
+      killColor: "#656e7c"
+      completedColor: "#656e7c"
+    title:
+      fgColor: "#1a1f28"
+      bgColor: "#f7f8fa"
+      highlightColor: "#33507a"
+      counterColor: "#8a5a00"
+      filterColor: "#1e6a3c"
+  views:
+    charts:
+      bgColor: "#f7f8fa"
+      defaultDialColors:
+        - "#33507a"
+        - "#a4372e"
+      defaultChartColors:
+        - "#33507a"
+        - "#a4372e"
+    table:
+      fgColor: "#1a1f28"
+      bgColor: "#f7f8fa"
+      cursorFgColor: "#f7f8fa"
+      cursorBgColor: "#33507a"
+      markColor: "#8a5a00"
+      header:
+        fgColor: "#1a1f28"
+        bgColor: "#f7f8fa"
+        sorterColor: "#a4372e"
+    xray:
+      fgColor: "#1a1f28"
+      bgColor: "#f7f8fa"
+      cursorColor: "#33507a"
+      graphicColor: "#33507a"
+      showIcons: false
+    yaml:
+      keyColor: "#33507a"
+      colonColor: "#656e7c"
+      valueColor: "#1a1f28"
+    logs:
+      fgColor: "#1a1f28"
+      bgColor: "#f7f8fa"
+      indicator:
+        fgColor: "#f7f8fa"
+        bgColor: "#33507a"
+"""
+
+# Minimal k9s config selecting the skin; k9s fills in the rest of its schema
+# with defaults and rewrites the file freely (the dir is per-session tmpfs-ish).
+_K9S_CONFIG = """k9s:
+  ui:
+    skin: light
+    logoless: true
+  logger:
+    tail: 200
+"""
+
+
+def _write_k9s_config() -> None:
+    cfg_dir = "/tmp/k8s-demo-home/k9s"
+    os.makedirs(os.path.join(cfg_dir, "skins"), exist_ok=True)
+    with open(os.path.join(cfg_dir, "skins", "light.yaml"), "w", encoding="utf-8") as f:
+        f.write(_K9S_SKIN_LIGHT)
+    cfg_path = os.path.join(cfg_dir, "config.yaml")
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        f.write(_K9S_CONFIG)
+
 # The single live session (newest connection wins). Guarded by _session_lock.
 _session_lock = asyncio.Lock()
 _current_session: "_TerminalSession | None" = None
@@ -386,8 +494,13 @@ class _TerminalSession:
             "K9S_CONFIG_DIR": "/tmp/k8s-demo-home/k9s",
             "PATH": "/usr/local/bin:/usr/bin:/bin",
             "COLORTERM": "truecolor",
+            # k9s is a static (cgo-free) binary: user.Current() fails without
+            # $USER and k9s exits before drawing anything ("Fail to init k9s
+            # logs location"). LOGNAME for the same lookup on other paths.
+            "USER": "demo",
+            "LOGNAME": "demo",
         }
-        os.makedirs("/tmp/k8s-demo-home/k9s", exist_ok=True)
+        _write_k9s_config()
         self.proc = await asyncio.create_subprocess_exec(
             _K9S_BIN,
             "--logoless",

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.265
+      targetRevision: 0.285.266
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/private/components/demos/K8sTerminalPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/K8sTerminalPanel.svelte
@@ -204,8 +204,27 @@
       fontFamily: "var(--font-mono, monospace)",
       fontSize: 13,
       theme: {
-        background: "#101418",
-        foreground: "#d8dee6",
+        background: "#f7f8fa",
+        foreground: "#1a1f28",
+        cursor: "#33507a",
+        cursorAccent: "#f7f8fa",
+        selectionBackground: "#c9d8ee",
+        black: "#1a1f28",
+        red: "#a4372e",
+        green: "#1e6a3c",
+        yellow: "#8a5a00",
+        blue: "#33507a",
+        magenta: "#6b4a7a",
+        cyan: "#1a6a72",
+        white: "#e8ebef",
+        brightBlack: "#656e7c",
+        brightRed: "#c04a3f",
+        brightGreen: "#2a8a50",
+        brightYellow: "#a87200",
+        brightBlue: "#4a6a9a",
+        brightMagenta: "#8a62a0",
+        brightCyan: "#2a8a94",
+        brightWhite: "#ffffff",
       },
     });
     fitAddon = new FitAddon();
@@ -514,7 +533,7 @@
 
   .terminal-card {
     position: relative;
-    background: #101418;
+    background: #f7f8fa;
     border: 1px solid var(--line);
     border-radius: 10px;
     min-height: 420px;
@@ -538,7 +557,7 @@
     max-width: 32em;
     font-size: 14px;
     line-height: 1.5;
-    color: #aab3bf;
+    color: var(--text-faint, #656e7c);
   }
 
   .connect-btn,
@@ -561,7 +580,7 @@
 
   .session-error {
     margin: 0;
-    color: #e0776b;
+    color: var(--danger, #a4372e);
     font-size: 13px;
     max-width: 32em;
   }
@@ -570,7 +589,7 @@
     padding: 16px 20px;
     font-family: var(--font-mono, monospace);
     font-size: 13px;
-    color: #9fe3b0;
+    color: #1e6a3c;
     overflow-y: auto;
     max-height: 420px;
   }


### PR DESCRIPTION
## Summary

Two fixes from the first live session of the k8s terminal (chart 0.285.266 / monolith-public 0.89.191):

- **Blank terminal root cause**: k9s is a static cgo-free binary; `user.Current()` fails without `$USER` and it exits before drawing anything. The wake worked (the band recorded `cold-boot in 19.3s`), then k9s died instantly and silently. Spawn env now sets `USER`/`LOGNAME`. Verified in-pod: secret read via the new RBAC works, `kubectl get nodes` answers through the entry (3 nodes Ready), and k9s starts once USER is set.
- **Light mode** (requested): k9s skin matched to the demos palette (written per session into `K9S_CONFIG_DIR`, `config.yaml` selects it), light xterm theme + full ANSI palette, terminal card + boot log + overlays on page tokens instead of dark constants.

## Test plan

- `pnpm build` passes; in-pod manual repro of the k9s launch path.
- Live after merge: open the tab; k9s should render in light mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)