### PR TITLE
fix(embervm): bank-lane hardening - adoption race, owner cleanup, network GC

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.115
+version: 0.1.116

--- a/projects/embervm/control/lib/embervm/group_manager/supervisor.ex
+++ b/projects/embervm/control/lib/embervm/group_manager/supervisor.ex
@@ -134,7 +134,18 @@ defmodule Embervm.GroupManager.Supervisor do
     with {:ok, entry} <- GroupManager.catalog_group(catalog_table, workload),
          {:ok, node_id} <- anchor_node(capacity_table),
          {:ok, pid} <- start_or_get_child(workload, instance_id, entry, node_id, opts) do
-      GroupManager.bank_group(pid)
+      case GroupManager.bank_group(pid) do
+        {:ok, _} = ok ->
+          ok
+
+        {:error, _reason} = error ->
+          # Terminate the owner on a failed bank, mirroring create_group: a
+          # registered child left behind refuses every later wake as
+          # :already_live at the DynamicSupervisor layer (the invisible-wedge
+          # class), while a fresh wake respawns an owner cleanly.
+          _ = DynamicSupervisor.terminate_child(@dyn_sup, pid)
+          error
+      end
     end
   end
 

--- a/projects/embervm/control/lib/embervm/group_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/group_sweeper.ex
@@ -289,8 +289,43 @@ defmodule Embervm.GroupSweeper do
       |> idle_bank_pass(now)
       |> sweep_lifetime(now)
       |> sweep_banked_ttl(now)
+      |> gc_orphan_networks()
       |> write_group_status()
     end
+  end
+
+  # -- orphan group-network GC -------------------------------------------------
+
+  # Delete node-held group networks whose instance is terminal or absent. A
+  # teardown that dies before DeleteGroupNetwork (a failed bank, a dead channel
+  # mid-forced-roll, a noded that restarted and re-adopted its on-disk record)
+  # leaves the bridge record squatting the composite CIDR, and every later
+  # create fails with "cidr overlaps existing group" until an operator deletes
+  # the record by hand - three times on 2026-07-18/19 alone. Best-effort: an
+  # RPC failure just leaves the orphan for the next sweep.
+  defp gc_orphan_networks(state) do
+    for fact <- NodeCapacity.all(state.capacity_table),
+        net <- Map.get(fact, :group_networks, []) || [] do
+      instance_id = Map.get(net, :group_instance_id)
+
+      orphaned? =
+        case GroupStore.get(state.store, instance_id) do
+          {:ok, instance} -> GroupState.terminal?(instance.state)
+          {:error, _} -> true
+        end
+
+      if orphaned? and is_binary(instance_id) and instance_id != "" do
+        Logger.warning("embervm group: GC deleting orphan group network",
+          instance_id: instance_id,
+          node_id: fact.configured_id,
+          cidr: Map.get(net, :cidr)
+        )
+
+        _ = delete_network(state, %{instance_id: instance_id, node_id: fact.configured_id})
+      end
+    end
+
+    state
   end
 
   # -- status.group (Task 9) --------------------------------------------------

--- a/projects/embervm/control/lib/embervm/group_wake_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_wake_manager.ex
@@ -771,6 +771,18 @@ defmodule Embervm.GroupWakeManager do
       Map.has_key?(state.waking, instance.workload) ->
         state
 
+      # A `banking` instance is MID-BANK: the sweeper owns its transition. The
+      # members are still node-reported live for most of the bank (they are
+      # paused+snapshotted one by one), so without this skip the adopt_live
+      # branch below force-flips banking -> running mid-bank and the sweeper's
+      # bank_ready record then dies on {:illegal_transition, :running,
+      # :bank_ready}, failing the instance AFTER noded already destroyed the
+      # VMs (the 2026-07-19 bank_record_failed wedge). A bank that truly died
+      # mid-flight resolves on a LATER pass: once the node stops reporting the
+      # members, the complete-set/casualty branches below handle it.
+      instance.state == :banking ->
+        state
+
       # A `creating` instance with NO in-flight wake is a dead create: its owning
       # worker is gone (a CP restart mid-create, or a bound-expired wake whose
       # teardown was lost). It can never finish, and adopting whatever members DID

--- a/projects/embervm/control/test/embervm/group_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/group_sweeper_test.exs
@@ -653,6 +653,59 @@ defmodule Embervm.GroupSweeperTest do
     assert status_map["group"]["members"] == %{"live" => 0, "degraded" => 0}
   end
 
+  test "orphan network GC: a node-reported network for a TERMINAL instance is deleted" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410, %{idle_bank_seconds: 600})
+    group_node(ctx, "node-4")
+    id = running_group(ctx, "gi-orphan", "grp-a")
+
+    # The instance goes terminal WITHOUT a network teardown (the failed-bank /
+    # dead-channel shapes), while the node still reports its group network.
+    {:ok, _} = GroupStore.transition(ctx.store, id, :destroy, :group_destroyed, %{reason: "test"}, %{})
+
+    NodeCapacity.put(ctx.cap_table, "node-4", %{
+      configured_id: "node-4",
+      node_id: "node-4",
+      serving_subnet_cidr: "10.98.0.0/24",
+      max_live_vms: 8,
+      live_vms: 0,
+      workloads: %{},
+      group_member_vms: [],
+      group_bundle_sets: [],
+      group_networks: [%{group_instance_id: id, cidr: "10.101.0.0/24", bridge: "emg1", member_count: 0}]
+    })
+
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    assert [req] = delete_net_calls(ctx)
+    assert req.group_instance_id == id
+  end
+
+  test "orphan network GC: a LIVE instance's network is never touched" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410, %{idle_bank_seconds: 600})
+    group_node(ctx, "node-4")
+    id = running_group(ctx, "gi-live", "grp-a")
+
+    NodeCapacity.put(ctx.cap_table, "node-4", %{
+      configured_id: "node-4",
+      node_id: "node-4",
+      serving_subnet_cidr: "10.98.0.0/24",
+      max_live_vms: 8,
+      live_vms: 0,
+      workloads: %{},
+      group_member_vms: [],
+      group_bundle_sets: [],
+      group_networks: [%{group_instance_id: id, cidr: "10.101.0.0/24", bridge: "emg1", member_count: 2}]
+    })
+
+    set_scrape(ctx, reading("group-5410", 1, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    assert delete_net_calls(ctx) == []
+  end
+
   test "a status-write failure never crashes the sweep" do
     ctx = start_stack()
     group_workload(ctx, "grp-a", 5410, %{idle_bank_seconds: 600})

--- a/projects/embervm/control/test/embervm/group_wake_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_wake_manager_test.exs
@@ -567,6 +567,31 @@ defmodule Embervm.GroupWakeManagerTest do
     assert_receive {:force_rolled, "grp-a"}, 1_000
   end
 
+  test "adoption leaves a :banking instance alone (the sweeper owns the bank)" do
+    # Mid-bank the node still reports live members; without the banking skip the
+    # adopt_live branch force-flips banking -> running and the sweeper's
+    # bank_ready record dies on {:illegal_transition, :running, :bank_ready}
+    # (the 2026-07-19 bank_record_failed wedge).
+    ctx = start_stack()
+    instance_id = "g-banking"
+    _ = seed_banked(ctx, instance_id)
+    # Back to running, then into :banking (running -> banking), the mid-bank state.
+    {:ok, _} = GroupStore.mark(ctx.store, instance_id, :relight)
+    {:ok, _} = GroupStore.transition(ctx.store, instance_id, :relight_ready, :group_relit, %{}, %{})
+    {:ok, _} = GroupStore.publish(ctx.store, instance_id, "10.0.0.9", 30_010)
+    {:ok, _} = GroupStore.mark(ctx.store, instance_id, :bank)
+    assert {:ok, %{state: :banking}} = GroupStore.get(ctx.store, instance_id)
+
+    seed_node(ctx, %{
+      group_member_vms: [%{vm_id: "vm-l", group_instance_id: instance_id, member_name: "leader", ip: "10.101.0.10", healthy: true}]
+    })
+
+    :ok = GroupWakeManager.reconcile(ctx.mgr)
+
+    {:ok, inst} = GroupStore.get(ctx.store, instance_id)
+    assert inst.state == :banking
+  end
+
   test "adoption rolls a dead create (:creating with no in-flight wake) terminal" do
     # A :creating instance with no wake in flight is a dead create (a CP restart
     # mid-create, or a lost bound timer): it can never finish, and adopting its

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.115
+      targetRevision: 0.1.116
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Summary

Three fixes from the first live idle-bank failure (chart 0.1.115), observed via the k8s-terminal demo:

- **Adoption vs bank race**: `adopt_live` force-flipped a `:banking` instance to `:running` mid-bank (members are still node-reported live while being banked one by one), so `bank_ready` died on `{:illegal_transition, :running, :bank_ready}` and the instance was failed AFTER noded destroyed the VMs (`terminal_reason: bank_record_failed`, 00:05:51Z). Adoption now skips `:banking` instances - the sweeper owns that transition.
- **Failed bank leaves no owner**: `Supervisor.bank_group` terminates its GroupManager child on error, mirroring `create_group`. The registered leftover child was the silent `:already_live` refusal that blocked every wake after the failed bank.
- **Orphan group-network GC** (third manual cleanup tonight): the sweeper now deletes node-reported group networks whose instance is terminal/absent, ending the `cidr overlaps existing group` wedge class (failed banks, dead-channel forced rolls, noded record re-adoption).

## Test plan

- New tests: adoption leaves `:banking` untouched; GC deletes a terminal instance's network and never touches a live one's; existing suites cover the surrounding paths.
- Live after merge: let the demo cluster idle-bank with the reconcile ticking (the exact race window), verify `group banked` lands and a later wake relights/creates cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)