### PR TITLE
fix(demos): k8s terminal PTY becomes the controlling terminal

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.191
+version: 0.89.193
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.191
+      targetRevision: 0.89.193
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.266
+version: 0.285.267
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/demos/k8s_terminal_api.py
+++ b/projects/monolith/demos/k8s_terminal_api.py
@@ -500,8 +500,19 @@ class _TerminalSession:
             # logs location"). LOGNAME for the same lookup on other paths.
             "USER": "demo",
             "LOGNAME": "demo",
+            # k9s logs land somewhere findable for the next debugging session.
+            "XDG_STATE_HOME": "/tmp/k8s-demo-home/.state",
         }
         _write_k9s_config()
+
+        def _become_tty_session() -> None:
+            # New session + make the PTY slave (stdin) the CONTROLLING terminal.
+            # start_new_session alone leaves the child with NO controlling tty,
+            # and k9s/tcell opens /dev/tty directly - "open /dev/tty: no such
+            # device or address", exit 1, the first live session's failure.
+            os.setsid()
+            fcntl.ioctl(0, termios.TIOCSCTTY, 0)
+
         self.proc = await asyncio.create_subprocess_exec(
             _K9S_BIN,
             "--logoless",
@@ -509,7 +520,7 @@ class _TerminalSession:
             stdout=slave_fd,
             stderr=slave_fd,
             env=env,
-            start_new_session=True,
+            preexec_fn=_become_tty_session,
         )
         os.close(slave_fd)
 

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.266
+      targetRevision: 0.285.267
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

k9s exited 1 immediately after successful API discovery in the first working-PTY session: tcell opens `/dev/tty`, which requires a controlling terminal, and `start_new_session=True` gave the child a session without one. Reproduced exactly in-pod. The child now does `setsid` + `TIOCSCTTY` on the PTY slave via preexec (process-group teardown semantics unchanged), and `XDG_STATE_HOME` is set so k9s's own log is findable next time. Chart: monolith 0.285.267 (+ public coupling).

## Test plan
- In-pod repro showed the exact same error; the fix is the standard PTY controlling-terminal incantation.
- Live after merge: connect on the demos tab; k9s should render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)