### PR TITLE
fix(embervm): unblock bazel warming guest (loopback, hosts, entropy, console visibility)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.116
+version: 0.1.117

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.116
+      targetRevision: 0.1.117
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/bazel/BUILD
+++ b/projects/embervm/runtimes/bazel/BUILD
@@ -27,8 +27,8 @@ platform_transition_filegroup(
 tar(
     name = "guest_init_tar_amd64",
     srcs = [
-        ":guest_init_amd64_bin",
         "etc/hosts",
+        ":guest_init_amd64_bin",
     ],
     mtree = [
         "./usr/local/bin/ember-bazel-init type=file content=$(execpath :guest_init_amd64_bin) mode=0755 uid=0 gid=0",
@@ -51,8 +51,8 @@ platform_transition_filegroup(
 tar(
     name = "guest_init_tar_arm64",
     srcs = [
-        ":guest_init_arm64_bin",
         "etc/hosts",
+        ":guest_init_arm64_bin",
     ],
     mtree = [
         "./usr/local/bin/ember-bazel-init type=file content=$(execpath :guest_init_arm64_bin) mode=0755 uid=0 gid=0",

--- a/projects/embervm/runtimes/bazel/BUILD
+++ b/projects/embervm/runtimes/bazel/BUILD
@@ -26,9 +26,19 @@ platform_transition_filegroup(
 
 tar(
     name = "guest_init_tar_amd64",
-    srcs = [":guest_init_amd64_bin"],
+    srcs = [
+        ":guest_init_amd64_bin",
+        "etc/hosts",
+    ],
     mtree = [
         "./usr/local/bin/ember-bazel-init type=file content=$(execpath :guest_init_amd64_bin) mode=0755 uid=0 gid=0",
+        # Bake /etc/hosts (127.0.0.1 localhost + the guest hostname) into the
+        # read-only rootfs. /etc is read-only at boot so guest-init cannot write
+        # it; the JVM's InetAddress.getLocalHost() resolves against this instead
+        # of stalling on a lookup. Layered here (not via apko's base baselayout)
+        # so the localhost + hostname mapping is explicit and versioned with the
+        # runtime.
+        "./etc/hosts type=file content=$(execpath etc/hosts) mode=0644 uid=0 gid=0",
     ],
 )
 
@@ -40,9 +50,14 @@ platform_transition_filegroup(
 
 tar(
     name = "guest_init_tar_arm64",
-    srcs = [":guest_init_arm64_bin"],
+    srcs = [
+        ":guest_init_arm64_bin",
+        "etc/hosts",
+    ],
     mtree = [
         "./usr/local/bin/ember-bazel-init type=file content=$(execpath :guest_init_arm64_bin) mode=0755 uid=0 gid=0",
+        # See guest_init_tar_amd64: /etc/hosts baked into the read-only rootfs.
+        "./etc/hosts type=file content=$(execpath etc/hosts) mode=0644 uid=0 gid=0",
     ],
 )
 

--- a/projects/embervm/runtimes/bazel/etc/hosts
+++ b/projects/embervm/runtimes/bazel/etc/hosts
@@ -1,0 +1,2 @@
+127.0.0.1 localhost ember-bazel
+::1 localhost ip6-localhost ip6-loopback

--- a/projects/embervm/runtimes/bazel/guest-init/cmd/BUILD
+++ b/projects/embervm/runtimes/bazel/guest-init/cmd/BUILD
@@ -13,6 +13,8 @@ go_library(
         "main.go",
         "mount_linux.go",
         "mount_other.go",
+        "net_linux.go",
+        "net_other.go",
         "vsock_linux.go",
         "vsock_other.go",
     ],

--- a/projects/embervm/runtimes/bazel/guest-init/cmd/main.go
+++ b/projects/embervm/runtimes/bazel/guest-init/cmd/main.go
@@ -35,6 +35,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -66,6 +67,15 @@ const (
 	distDir      = "/opt/distdir" // vendored dep archives (read-only rootfs); offline --distdir
 	warmExpr     = "//absl/..."   // the warming query: analyze the whole Abseil graph
 	heapArg      = "--host_jvm_args=-Xmx1g"
+	// egdArg points the JVM's SecureRandom seed source at /dev/urandom. In a
+	// NIC-less Firecracker microVM the kernel CRNG can take a long time to reach
+	// "initialized" (little entropy is gathered without disks/network/interrupts),
+	// and the bazel server JVM blocks on getrandom() during SecureRandom init,
+	// which presents as a warming VM stuck at ZERO CPU with no bazel output. Seeding
+	// from /dev/urandom (non-blocking) removes that stall. Passed as a SECOND
+	// --host_jvm_args startup option (bazel accepts the flag repeatedly, each adding
+	// one JVM arg), kept inside buildArgv so warming and serving stay identical.
+	egdArg       = "--host_jvm_args=-Djava.security.egd=file:/dev/urandom"
 	queryTimeout = 15 * time.Second // per-serving-query wall budget (guest side)
 	settleDelay  = 10 * time.Second // post-warming idle before ready, lets the JVM GC settle
 	maxOutput    = 256 << 10        // bytes; cap the labels payload over vsock
@@ -99,6 +109,18 @@ func run(logger *slog.Logger) error {
 	}
 	setDefaultEnv(logger)
 
+	// Bring up the loopback interface and set the hostname BEFORE warming. The
+	// bazel client talks to the bazel SERVER over a gRPC socket on 127.0.0.1; a
+	// raw Firecracker boot leaves `lo` DOWN, so that connect blocks forever and
+	// the warming VM sits at zero CPU. Setting the hostname (with 127.0.0.1
+	// localhost + the hostname baked into /etc/hosts) also stops the JVM stalling
+	// on an InetAddress.getLocalHost() reverse lookup. Both are best-effort: a
+	// failure is logged loudly to the console but does not abort the boot (so the
+	// failure is diagnosable rather than a silent exit), and if warming then still
+	// hangs the console output pinpoints which hedge did not take.
+	bringUpLoopback(logger)
+	setHostname(logger)
+
 	// ready gates GET /shim/ready. It stays false until the warming client has
 	// exited cleanly and the settle delay has passed, so a base build never
 	// snapshots a cold-or-broken server (a warming failure leaves ready false and
@@ -121,13 +143,14 @@ func run(logger *slog.Logger) error {
 
 	// The warming client has exited. Let the JVM settle (idle GC, any lazily
 	// spawned worker threads quiesce) before the snapshot is cut.
+	logger.Info("ember-bazel-init: settling before ready", "settle", settleDelay.String())
 	select {
 	case <-time.After(settleDelay):
 	case <-ctx.Done():
 		return waitForShutdown(ctx, serveErr, logger)
 	}
 	ready.Store(true)
-	logger.Info("ember-bazel-init: warm base ready", "settle", settleDelay.String())
+	logger.Info("ember-bazel-init: settle done, warm base ready")
 
 	// Hold PID 1. Exiting PID 1 panics the guest kernel before noded can snapshot
 	// the base or before a restored clone can answer its one query.
@@ -145,6 +168,7 @@ func buildArgv(expr string) []string {
 		"/usr/local/bin/bazel",
 		"--output_user_root=" + outputRoot,
 		heapArg,
+		egdArg,
 		// --max_idle_secs=0 disables the bazel server's idle-shutdown timer. The
 		// warm server IS the base snapshot; a restored clone resumes it possibly
 		// long after the snapshot was cut, and if the guest clock is corrected
@@ -160,23 +184,42 @@ func buildArgv(expr string) []string {
 	}
 }
 
-// warm runs the warming cquery and returns an error if it does not exit 0. Its
-// stderr is logged (the "Analyzed ... (N packages loaded ...)" line is the
-// baseline; a restored clone re-emitting "0 packages loaded" is the proof the
-// snapshot reused this analysis). No timeout here: warming an image on a cold CI
-// runner is legitimately minutes; BuildBase's own BootReadyTimeout is the outer
-// bound.
+// warm runs the warming cquery and returns an error if it does not exit 0. It
+// PIPES the bazel subprocess stdout and stderr straight through to PID 1's own
+// stdout/stderr (the guest console, which noded captures), so the warming phase
+// is visible in noded logs in real time; without this a stall (e.g. the JVM
+// blocking on entropy, or the client blocking connecting to the server over
+// loopback) is a blind zero-CPU hang with no output. Stderr is ALSO teed into an
+// in-memory capture so the "Analyzed ... (N packages loaded ...)" line can still
+// be grepped afterwards (the baseline; a restored clone re-emitting "0 packages
+// loaded" is the proof the snapshot reused this analysis). Wall-time checkpoints
+// (client started / exited) bracket the run so a hang's phase is obvious. No
+// timeout here: warming an image on a cold CI runner is legitimately minutes;
+// BuildBase's own BootReadyTimeout is the outer bound.
 func warm(ctx context.Context, logger *slog.Logger) error {
 	argv := buildArgv(warmExpr)
-	logger.Info("ember-bazel-init: warming", "expr", warmExpr, "argv", argv)
+	logger.Info("ember-bazel-init: warming client starting", "expr", warmExpr, "argv", argv)
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...) // nosemgrep: no-shell-command-injection
 	cmd.Dir = workspaceDir
 	cmd.Env = append(os.Environ(), "HOME="+homeDir)
-	out, err := cmd.CombinedOutput()
+
+	// Stdout streams to the console only (bazel writes the label list there; it is
+	// large and not needed for the Analyzed grep). Stderr streams to the console
+	// AND a capture builder for the Analyzed line. Capturing stderr in memory is
+	// fine: bazel's stderr is progress lines, kilobytes, not the big label list.
+	var stderrCap strings.Builder
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrCap)
+
+	t0 := time.Now()
+	err := cmd.Run()
+	elapsed := time.Since(t0)
 	if err != nil {
-		logger.Error("ember-bazel-init: warming exited non-zero", "err", err, "tail", tail(out, stderrTail))
+		logger.Error("ember-bazel-init: warming client exited non-zero", "err", err, "elapsed", elapsed.String(), "tail", tail([]byte(stderrCap.String()), stderrTail))
 		return err
 	}
+	logger.Info("ember-bazel-init: warming client exited 0", "elapsed", elapsed.String())
+
 	// Warming succeeded (exit 0), but a flag typo can make cquery a silent no-op
 	// (e.g. an unrecognized target pattern that matches nothing, or a flag that
 	// changes --output so the "Analyzed" progress line never appears). If bazel
@@ -186,9 +229,9 @@ func warm(ctx context.Context, logger *slog.Logger) error {
 	// the line legitimately reports NON-zero packages loaded (this IS the cold
 	// analysis); the "0 packages loaded" invariant applies to restored CLONES,
 	// checked in handleQuery, not here.
-	analyzed := analyzedLineFromStderr(string(out))
+	analyzed := analyzedLineFromStderr(stderrCap.String())
 	if analyzed == "" {
-		logger.Warn("ember-bazel-init: warming exit 0 but no 'Analyzed' line found; the snapshot may capture an EMPTY analysis graph (check for a flag typo)", "tail", tail(out, stderrTail))
+		logger.Warn("ember-bazel-init: warming exit 0 but no 'Analyzed' line found; the snapshot may capture an EMPTY analysis graph (check for a flag typo)", "tail", tail([]byte(stderrCap.String()), stderrTail))
 	} else {
 		logger.Info("ember-bazel-init: warming output", "analyzed", analyzed)
 	}

--- a/projects/embervm/runtimes/bazel/guest-init/cmd/main_test.go
+++ b/projects/embervm/runtimes/bazel/guest-init/cmd/main_test.go
@@ -89,6 +89,7 @@ func TestBuildArgvGolden(t *testing.T) {
 		"/usr/local/bin/bazel",
 		"--output_user_root=/tmp/bazel",
 		"--host_jvm_args=-Xmx1g",
+		"--host_jvm_args=-Djava.security.egd=file:/dev/urandom",
 		"--max_idle_secs=0",
 		"cquery",
 		"deps(//absl/strings)",

--- a/projects/embervm/runtimes/bazel/guest-init/cmd/net_linux.go
+++ b/projects/embervm/runtimes/bazel/guest-init/cmd/net_linux.go
@@ -1,0 +1,62 @@
+//go:build linux
+
+package main
+
+import (
+	"log/slog"
+	"os"
+	"os/exec"
+
+	"golang.org/x/sys/unix"
+)
+
+// guestHostname is the name set on the guest and matched in the baked /etc/hosts
+// (see the BUILD's guest_init_tar). Any stable, resolvable name works; it exists
+// only so InetAddress.getLocalHost() resolves without a DNS round trip.
+const guestHostname = "ember-bazel"
+
+// bringUpLoopback brings the loopback interface UP. A raw Firecracker boot leaves
+// `lo` DOWN, and the bazel client connects to the bazel SERVER over a gRPC socket
+// on 127.0.0.1; with lo down that connect blocks forever and the warming VM sits
+// at ZERO CPU with no output. This is best-effort by design: on failure it logs
+// LOUDLY to the console (so a still-hung warming is diagnosable) but does not
+// abort the boot.
+//
+// It shells out to busybox rather than issuing the SIOCSIFFLAGS ioctl directly:
+// the vendored x/sys/unix has no generic Ifreq helper, so a raw ioctl would mean
+// hand-laying the ifreq union struct, which is fragile across arches; busybox
+// (already in the image) provides `ip` and `ifconfig` applets that do exactly
+// this. `ip link set lo up` is tried first, `ifconfig lo up` as a fallback.
+func bringUpLoopback(logger *slog.Logger) {
+	attempts := [][]string{
+		{"ip", "link", "set", "lo", "up"},
+		{"ifconfig", "lo", "up"},
+	}
+	for _, args := range attempts {
+		cmd := exec.Command(args[0], args[1:]...) // nosemgrep: no-shell-command-injection
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			logger.Info("ember-bazel-init: loopback up", "via", args[0])
+			return
+		}
+		logger.Warn("ember-bazel-init: loopback up attempt failed", "cmd", args, "err", err, "out", string(out))
+	}
+	logger.Error("ember-bazel-init: could NOT bring up loopback; bazel client may block connecting to the server on 127.0.0.1 (warming will hang)")
+}
+
+// setHostname sets the guest hostname when it is unset or the default. It pairs
+// with the baked /etc/hosts (127.0.0.1 localhost + guestHostname), so a JVM
+// InetAddress.getLocalHost() resolves locally instead of stalling on a lookup.
+// Best-effort: a failure is logged, not fatal.
+func setHostname(logger *slog.Logger) {
+	if cur, err := os.Hostname(); err == nil && cur != "" && cur != "(none)" && cur != "localhost" {
+		// A meaningful hostname is already set (e.g. noded injected one); leave it.
+		logger.Info("ember-bazel-init: hostname already set", "hostname", cur)
+		return
+	}
+	if err := unix.Sethostname([]byte(guestHostname)); err != nil {
+		logger.Warn("ember-bazel-init: sethostname failed", "hostname", guestHostname, "err", err)
+		return
+	}
+	logger.Info("ember-bazel-init: hostname set", "hostname", guestHostname)
+}

--- a/projects/embervm/runtimes/bazel/guest-init/cmd/net_other.go
+++ b/projects/embervm/runtimes/bazel/guest-init/cmd/net_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package main
+
+import "log/slog"
+
+// bringUpLoopback / setHostname are no-ops off Linux (the interface ioctl and
+// sethostname syscall are Linux-only). The guest runs inside a Linux microVM;
+// these stubs keep the package building under the host toolchain for unit tests
+// and local builds.
+func bringUpLoopback(_ *slog.Logger) {}
+func setHostname(_ *slog.Logger)     {}


### PR DESCRIPTION
## The block

PR 1 merged and the live base build is blocked: the warming VM sits at ZERO CPU indefinitely (two attempts, ~24 min and ~8 min, no completion, no bazel output on the console). Diagnosis was blind because guest-init captured the bazel subprocess output with `CombinedOutput()` and only logged it after the process returned, so a hang produced nothing.

## The fix (deliberate shotgun, four changes in one roundtrip)

One control-plane base-build cycle is minutes of wall time, so serial single-hypothesis guessing is expensive. This PR fires all four high-probability fixes at once, and crucially makes the NEXT failure diagnosable so a second roundtrip is not another blind one.

1. **Diagnosability (the non-negotiable):** `warm()` now pipes the bazel subprocess stdout/stderr straight through to PID 1's own stdout/stderr (the guest console, which noded captures), so the warming phase streams into noded logs in real time. Stderr is teed into an in-memory capture so the `Analyzed ...` proof line is still grepped. Wall-time checkpoints bracket the run (client starting / client exited + elapsed / settling / settle done), so a future hang's phase is obvious from the logs alone.

2. **Loopback up (prime suspect a):** a raw Firecracker boot leaves `lo` DOWN. The bazel client connects to the bazel server over a gRPC socket on 127.0.0.1; with lo down that connect blocks forever at zero CPU. guest-init now brings `lo` up before warming (busybox `ip link set lo up`, `ifconfig lo up` fallback; the vendored x/sys/unix has no generic Ifreq helper so a raw SIOCSIFFLAGS ioctl would mean hand-laying the union struct). Best-effort: logged loudly on failure, does not abort.

3. **/etc/hosts + hostname:** `/etc/hosts` (127.0.0.1 localhost + the guest hostname) is baked into the read-only rootfs via the guest_init tar layer (/etc is read-only at boot so guest-init cannot write it), and guest-init sets the hostname at runtime when unset. This stops a JVM `InetAddress.getLocalHost()` lookup from stalling.

4. **Entropy hedge (prime suspect b):** added `--host_jvm_args=-Djava.security.egd=file:/dev/urandom` as a second startup option in `buildArgv`. A NIC-less microVM gathers little entropy, so the server JVM can block on `getrandom()` during SecureRandom init, another zero-CPU stall; seeding from non-blocking /dev/urandom removes it.

`buildArgv` remains the single source of truth (warming == serving), so the entropy flag is applied identically to restored clones; the golden test is updated. Loopback/hostname are Linux-only with `_other.go` stubs mirroring the mount split.

## Verification

Local (allowed, no bazel against the repo): `go test`, `go vet`, and `GOOS=linux` cross-compiles for amd64 + arm64 all pass. Chart bumped to 0.1.117 so the rebuilt guest image rolls out. The real test is the live base build after merge: the console should now show the warming phase (loopback up, hostname set, warming client starting, the bazel `Analyzed ...` line) instead of silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
