### PR TITLE
feat(embervm): proto contract for vendor keying, generation blessing, and device volumes

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.119
+version: 0.1.120

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.119
+      targetRevision: 0.1.120
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/proto/embervm/node/v1/fakenode/main.go
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/main.go
@@ -150,31 +150,52 @@ func (*fakeServer) StopServing(_ context.Context, req *nodev1.StopServingRequest
 // fallback, "noledger" -> ledger_unreadable, otherwise a warm relight), which is
 // how the round-trip test exercises each pairing branch against a stateless fake.
 // FRESH/COLD cold-boot from boot_image_ref and report a bumped generation.
+//
+// blessed_generation and volume_device (R7) are recorded on the fake's response
+// so the client can assert both crossed the wire: the returned generation
+// mirrors blessed_generation when the caller set one (0 falls back to the
+// scripted legacy self-bump values below), and volume_device is echoed back
+// verbatim in vm_id's suffix so an empty value (legacy vol.img lane) and a set
+// one (Longhorn device path) are both observable.
 func (*fakeServer) StartStateful(_ context.Context, req *nodev1.StartStatefulRequest) (*nodev1.StartStatefulResponse, error) {
+	vmIDSuffix := ""
+	if dev := req.GetVolumeDevice(); dev != "" {
+		vmIDSuffix = "@" + dev
+	}
 	if req.GetMode() == nodev1.StartStatefulMode_START_STATEFUL_MODE_RELIGHT {
 		ref := req.GetRelightSnapshotRef()
 		switch {
 		case strings.Contains(ref, "mismatch"):
 			return &nodev1.StartStatefulResponse{
-				VmId: "vm:" + ref, Ip: "10.99.0.3", Port: req.GetPort(),
+				VmId: "vm:" + ref + vmIDSuffix, Ip: "10.99.0.3", Port: req.GetPort(),
 				Generation: 8, WasRelight: false, ColdBootReason: "generation_mismatch",
 			}, nil
 		case strings.Contains(ref, "noledger"):
 			return &nodev1.StartStatefulResponse{
-				VmId: "vm:" + ref, Ip: "10.99.0.3", Port: req.GetPort(),
+				VmId: "vm:" + ref + vmIDSuffix, Ip: "10.99.0.3", Port: req.GetPort(),
 				Generation: 8, WasRelight: false, ColdBootReason: "ledger_unreadable",
 			}, nil
 		default:
+			gen := uint64(7)
+			if bg := req.GetBlessedGeneration(); bg != 0 {
+				gen = bg
+			}
 			return &nodev1.StartStatefulResponse{
-				VmId: "vm:" + ref, Ip: "10.99.0.3", Port: req.GetPort(),
-				Generation: 7, WasRelight: true, ColdBootReason: "",
+				VmId: "vm:" + ref + vmIDSuffix, Ip: "10.99.0.3", Port: req.GetPort(),
+				Generation: gen, WasRelight: true, ColdBootReason: "",
 			}, nil
 		}
 	}
-	// FRESH or COLD: cold boot from the boot image ref, generation bumped.
+	// FRESH or COLD: cold boot from the boot image ref. The blessed generation
+	// wins when the caller supplied one (R7); 0 falls back to the legacy
+	// self-bump value of 1, matching pre-blessing daemon behavior.
+	gen := uint64(1)
+	if bg := req.GetBlessedGeneration(); bg != 0 {
+		gen = bg
+	}
 	return &nodev1.StartStatefulResponse{
-		VmId: "vm:" + req.GetBootImageRef(), Ip: "10.99.0.3", Port: req.GetPort(),
-		Generation: 1, WasRelight: false, ColdBootReason: "",
+		VmId: "vm:" + req.GetBootImageRef() + vmIDSuffix, Ip: "10.99.0.3", Port: req.GetPort(),
+		Generation: gen, WasRelight: false, ColdBootReason: "",
 	}, nil
 }
 
@@ -308,7 +329,10 @@ func (s *fakeServer) ExportArtifact(_ context.Context, req *nodev1.ExportArtifac
 
 // RestoreArtifact reports a successful restore for a key present in the store,
 // echoing the volume generation for a VOLUME. FAILED_PRECONDITION when the store
-// has no copy (a corrupt or absent restore surfaces loudly, never silently).
+// has no copy (a corrupt or absent restore surfaces loudly, never silently), and
+// also when vendor is set but does not match the vendor the artifact was
+// exported under (R7, standing decision 1: restore fails closed on a vendor
+// mismatch, the fake mirrors the arch-mismatch behavior noded already has).
 func (s *fakeServer) RestoreArtifact(_ context.Context, req *nodev1.RestoreArtifactRequest) (*nodev1.RestoreArtifactResponse, error) {
 	art := req.GetArtifact()
 	key := storeKey(art)
@@ -316,6 +340,9 @@ func (s *fakeServer) RestoreArtifact(_ context.Context, req *nodev1.RestoreArtif
 	defer s.mu.Unlock()
 	if !s.store[key] {
 		return nil, status.Errorf(codes.FailedPrecondition, "artifact %q absent from store", key)
+	}
+	if v := req.GetVendor(); v != "" && strings.Contains(art.GetRef(), "vendor-mismatch") {
+		return nil, status.Errorf(codes.FailedPrecondition, "artifact %q vendor mismatch for %q", key, v)
 	}
 	return &nodev1.RestoreArtifactResponse{
 		BytesMoved: uint64(len(art.GetWorkload()) + len(art.GetRef())),
@@ -361,6 +388,10 @@ func (s *fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusR
 		// volume, and set exported flags below prove the per-artifact fields cross.
 		DrainDeadlineUnixMs: 1_700_000_009_000,
 		StoreReachable:      true,
+		// Distribution facts (R7): fixed vendor and template hash so the client can
+		// assert the new node-level fields round-trip.
+		CpuVendor:        "amd",
+		NodeTemplateHash: "tmpl-abc123",
 		// Session facts (R2): deterministic, so the client can assert the new
 		// repeated/scalar status fields round-trip.
 		SessionVms: []*nodev1.SessionVm{
@@ -447,6 +478,10 @@ func (s *fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusR
 				// exported_generation (R6): the store holds the gen-5 (vol.img, gen)
 				// pair, so a disk-loss restore recovers to generation 5.
 				ExportedGeneration: 5,
+				// generation_blessed (R7): this volume's generation was issued by the
+				// control plane's blessing ledger, so the client can assert the new
+				// field round-trips true for the blessed case.
+				GenerationBlessed: true,
 			},
 		},
 		// Group facts (R5): deterministic, so the client can assert the new

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -801,6 +801,17 @@ message StartStatefulRequest {
   // MMDS seam (the secrets seam for first-boot DB credentials), exactly as
   // existing verbs deliver init env. The daemon never persists or interprets them.
   map<string, string> mmds_env = 10;
+  // blessed_generation is the volume generation the control plane issued for
+  // THIS writable attach (R7, ADR embervm/011, standing decision 4). The daemon
+  // records it and reports it back, it never invents one. 0 means legacy
+  // self-bump, accepted only until noded's EMBERVM_NODED_REQUIRE_BLESSING flag
+  // is set, after which 0 is rejected.
+  uint64 blessed_generation = 11;
+  // volume_device is the host block-device path (e.g. /dev/longhorn/<name>) the
+  // control plane resolved for this workload's Longhorn-native volume (R7,
+  // standing decision 2). Empty means the legacy vol.img lane during the
+  // transition: the daemon falls back to volume_size_bytes/volume_mount.
+  string volume_device = 12;
 }
 
 message StartStatefulResponse {
@@ -1229,6 +1240,12 @@ message Volume {
   // this generation (R6, additive). A separate field from a bool because the
   // exported generation can lag the live generation.
   uint64 exported_generation = 6;
+  // generation_blessed is true when this volume's current generation was issued
+  // by the control plane's blessing ledger (R7, standing decision 4), false when
+  // it is an unblessed self-bumped generation the control plane has not yet
+  // reconciled. The control plane quarantines a volume reporting false here: no
+  // wake is planned for it until a runbook decision resolves the mismatch.
+  bool generation_blessed = 7;
 }
 
 // GroupNetwork is one per-group bridge the node currently holds, reported so a
@@ -1335,6 +1352,13 @@ message ExportArtifactResponse {
 message RestoreArtifactRequest {
   ArtifactRef artifact = 1;
   Trace trace = 2;
+  // vendor is the CPUID vendor ("amd", "intel") the control plane resolves the
+  // restore against (R7, standing decision 1 and 11). Vendor-bound kinds
+  // (BASE, SESSION, SERVING, STATEFUL, GROUP_SET) key in the store as
+  // <kind>/<vendor>/<workload>/<ref>/<file>; the daemon restores only the
+  // vendor-matching copy and fails closed on a mismatch, never a silent cold
+  // boot at this layer. Empty for VOLUME, which is vendor-portable.
+  string vendor = 3;
 }
 
 // RestoreArtifactResponse reports the outcome. bytes_moved is 0 when the artifact
@@ -1470,4 +1494,21 @@ message NodeStatus {
   // control plane only consults it to decide whether a restore-on-miss can be
   // planned at all. Unset (false) on a daemon with no store configured.
   bool store_reachable = 23;
+
+  // -- Distribution facts (R7, additive) --------------------------------------
+  // These two fields drive vendor-keyed warmth and the CP-sequenced rollout
+  // controller. Both are optional and wire-compatible with a daemon that never
+  // sets them (empty = the pre-R7 behavior, treated as node-4's vendor by the
+  // one-time reconcile-side alias, standing decision 11).
+
+  // cpu_vendor is the CPUID vendor this node reports ("amd", "intel"), detected
+  // from /proc/cpuinfo vendor_id. The control plane keys warmth artifacts and
+  // placement decisions on this (standing decision 1): memory snapshots never
+  // cross the vendor boundary.
+  string cpu_vendor = 24;
+  // node_template_hash is the pod-template hash the running noded was deployed
+  // from (the DaemonSet controller-revision the pod's owner reference names).
+  // The CP rollout controller (standing decision 6) compares this against the
+  // current DaemonSet template hash to decide which node still needs a roll.
+  string node_template_hash = 25;
 }

--- a/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
+++ b/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
@@ -315,6 +315,80 @@ defmodule Embervm.NodeRoundtripTest do
              NodeService.Stub.delete_volume(ch, %DeleteVolumeRequest{workload: "scratch-postgres"})
   end
 
+  test "StartStateful honors blessed_generation and volume_device (R7 additive fields)", %{
+    channel: ch
+  } do
+    # FRESH with blessed_generation set: the control-plane-issued generation wins
+    # over the fake's legacy self-bump value of 1.
+    {:ok, fresh_blessed} =
+      NodeService.Stub.start_stateful(ch, %StartStatefulRequest{
+        mode: :START_STATEFUL_MODE_FRESH,
+        boot_image_ref: "pg-base",
+        port: 5432,
+        blessed_generation: 42
+      })
+
+    assert fresh_blessed.generation == 42
+
+    # FRESH with blessed_generation unset (0): falls back to the legacy scripted
+    # value, proving a pre-blessing daemon/CP pair still round-trips.
+    {:ok, fresh_legacy} =
+      NodeService.Stub.start_stateful(ch, %StartStatefulRequest{
+        mode: :START_STATEFUL_MODE_FRESH,
+        boot_image_ref: "pg-base",
+        port: 5432
+      })
+
+    assert fresh_legacy.generation == 1
+
+    # RELIGHT with blessed_generation set: same override on the warm-relight path.
+    {:ok, relight_blessed} =
+      NodeService.Stub.start_stateful(ch, %StartStatefulRequest{
+        mode: :START_STATEFUL_MODE_RELIGHT,
+        relight_snapshot_ref: "stateful/scratch-postgres",
+        boot_image_ref: "pg-base",
+        port: 5432,
+        blessed_generation: 43
+      })
+
+    assert relight_blessed.generation == 43
+    assert relight_blessed.was_relight == true
+
+    # RELIGHT with blessed_generation unset (0): falls back to the legacy scripted
+    # value of 7 for the warm-relight branch.
+    {:ok, relight_legacy} =
+      NodeService.Stub.start_stateful(ch, %StartStatefulRequest{
+        mode: :START_STATEFUL_MODE_RELIGHT,
+        relight_snapshot_ref: "stateful/scratch-postgres",
+        boot_image_ref: "pg-base",
+        port: 5432
+      })
+
+    assert relight_legacy.generation == 7
+
+    # volume_device set (R7, Longhorn-native lane): the fake echoes it into vm_id
+    # so the client can assert the device path crossed the wire.
+    {:ok, device_set} =
+      NodeService.Stub.start_stateful(ch, %StartStatefulRequest{
+        mode: :START_STATEFUL_MODE_FRESH,
+        boot_image_ref: "pg-base",
+        port: 5432,
+        volume_device: "/dev/longhorn/scratch-postgres"
+      })
+
+    assert device_set.vm_id == "vm:pg-base@/dev/longhorn/scratch-postgres"
+
+    # volume_device empty (legacy vol.img lane): no suffix on vm_id.
+    {:ok, device_unset} =
+      NodeService.Stub.start_stateful(ch, %StartStatefulRequest{
+        mode: :START_STATEFUL_MODE_FRESH,
+        boot_image_ref: "pg-base",
+        port: 5432
+      })
+
+    assert device_unset.vm_id == "vm:pg-base"
+  end
+
   test "group verbs round-trip across the wire (R5 additive contract)", %{channel: ch} do
     # CreateGroupNetwork: derives bridge_name/gateway_ip from the request, proving
     # the group_instance_id and cidr fields crossed the wire.
@@ -597,6 +671,35 @@ defmodule Embervm.NodeRoundtripTest do
 
     assert missing.status == GRPC.Status.failed_precondition()
 
+    # RestoreArtifact with vendor set (R7): a normal ref restores fine, proving
+    # vendor crosses the wire without being misread as a mismatch.
+    {:ok, vendor_ok} =
+      NodeService.Stub.restore_artifact(ch, %RestoreArtifactRequest{
+        artifact: stateful,
+        vendor: "amd"
+      })
+
+    assert vendor_ok.bytes_moved > 0
+
+    # RestoreArtifact vendor mismatch (R7, standing decision 1): the fake scripts
+    # a FAILED_PRECONDITION off a "vendor-mismatch" ref when vendor is set, proving
+    # a cross-vendor restore fails closed rather than silently cold-booting.
+    mismatched = %ArtifactRef{
+      kind: :ARTIFACT_KIND_STATEFUL,
+      workload: "scratch-postgres",
+      ref: "stateful/scratch-postgres-vendor-mismatch"
+    }
+
+    {:ok, _} = NodeService.Stub.export_artifact(ch, %ExportArtifactRequest{artifact: mismatched})
+
+    {:error, vendor_mismatch} =
+      NodeService.Stub.restore_artifact(ch, %RestoreArtifactRequest{
+        artifact: mismatched,
+        vendor: "intel"
+      })
+
+    assert vendor_mismatch.status == GRPC.Status.failed_precondition()
+
     # EvictArtifact(remote=true): removes the store copy, reports bytes freed.
     {:ok, ev} =
       NodeService.Stub.evict_artifact(ch, %EvictArtifactRequest{artifact: stateful, remote: true})
@@ -630,6 +733,16 @@ defmodule Embervm.NodeRoundtripTest do
 
     assert [set] = ns.group_bundle_sets
     assert set.exported == true
+  end
+
+  test "NodeStatus reports distribution facts (R7 additive fields)", %{channel: ch} do
+    {:ok, ns} = NodeService.Stub.get_node_status(ch, %GetNodeStatusRequest{node_id: "node-4"})
+
+    assert ns.cpu_vendor == "amd"
+    assert ns.node_template_hash == "tmpl-abc123"
+
+    assert [vol] = ns.volumes
+    assert vol.generation_blessed == true
   end
 
   test "WatchNode server-streams heartbeats in order", %{channel: ch} do


### PR DESCRIPTION
PR-2 of the EmberVM R7 Distribution plan (Task 4, docs/plans/2026-07-18-embervm-r7-distribution-spec-and-plan.md). Additive-only node.proto changes so PR-3 (noded vendor detection) and PR-4 (control-plane generation blessing) can build against a stable contract.

## Changes

- `NodeStatus` gains `cpu_vendor` (CPUID vendor, amd/intel) and `node_template_hash` (the pod-template hash the running noded was deployed from), the facts vendor-keyed placement and the CP-sequenced rollout controller need from node truth.
- `StartStatefulRequest` gains `blessed_generation` (the volume generation the control plane issued for this writable attach; 0 means legacy self-bump, rejected once blessing ships) and `volume_device` (the resolved Longhorn block-device path; empty means the legacy vol.img lane during the transition).
- `Volume` gains `generation_blessed` so the control plane can distinguish a CP-blessed generation from an unblessed self-bumped one and quarantine the latter.
- `RestoreArtifactRequest` gains `vendor` so restores only pull vendor-matching warmth for vendor-bound artifact kinds.
- fakenode honors every new field: `StartStateful` echoes `blessed_generation` and `volume_device`, `RestoreArtifact` fails closed on a scripted vendor mismatch, and `GetNodeStatus` reports a fixed `cpu_vendor`/`node_template_hash` plus a blessed volume.

No behavior change. Codegen is build-time only (protoc genrules, per node.proto's BUILD comment), so nothing generated is checked in; every existing field number is unchanged. Chart bumped to 0.1.117 since the embervm image rebuilds from this proto edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)