### PR TITLE
chore(embervm): re-bump to clear image-digest drift

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.117
+version: 0.1.119

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.117
+      targetRevision: 0.1.119
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
embervm 0.1.116's chart pins image digests that differ from the rebuilt image (nondeterministic push-images drift), failing main's Push images guard and blocking all PRs. Fresh bump re-pins. See memory pushimages-nondeterministic-drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)