### PR TITLE
fix(seaweedfs): raise volume slot ceiling so the embervm collection can write

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.120
+version: 0.1.121

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.120
+      targetRevision: 0.1.121
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/platform/seaweedfs/values.yaml
+++ b/projects/platform/seaweedfs/values.yaml
@@ -48,7 +48,11 @@ seaweedfs:
         type: "persistentVolumeClaim"
         size: "100Gi"
         storageClass: "longhorn"
-        maxVolumes: 0
+        # Explicit slot count. Auto (0) derives max from disk capacity divided by
+        # the master's volumeSizeLimitMB (1000), which saturated at 106 slots with
+        # the disk only a third full; the embervm collection (newest) then had no
+        # writable volumes and every export failed. 130 leaves ~24 free slots.
+        maxVolumes: 130
     idx:
       type: "emptyDir"
     # Regenerate missing .idx files from .dat files on startup.


### PR DESCRIPTION
Task 2 (PR-1a) of the R7 Distribution plan (#3682).

Diagnosis from the live master (/dir/status): topology reports Free: 0 with all 106 slots allocated; the embervm collection layout exists with writables: []. The master runs volumeSizeLimitMB=1000 and the volume server -max 0 (auto = capacity/limit = ~106), so the slot pool saturated while the disk is only 34% used. embervm, the newest collection, never got a writable volume, which is why no R6 export has ever succeeded.

Fix: explicit maxVolumes: 130 (~24 spare slots). The chart is git-sourced (targetRevision HEAD), so no chart bump applies. Follow-up after rollout: first end-to-end export drill, evidence recorded in projects/embervm/docs/drills/store-export-drill.md (PR-1b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)