### PR TITLE
fix(embervm): bring up loopback via ioctl, busybox lacks ip/ifconfig applets

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.124
+version: 0.1.125

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.124
+      targetRevision: 0.1.125
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/bazel/guest-init/cmd/BUILD
+++ b/projects/embervm/runtimes/bazel/guest-init/cmd/BUILD
@@ -41,6 +41,18 @@ go_binary(
 
 go_test(
     name = "cmd_test",
-    srcs = ["main_test.go"],
+    srcs = [
+        "main_test.go",
+        "net_linux_test.go",
+    ],
     embed = [":cmd_lib"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@org_golang_x_sys//unix",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/projects/embervm/runtimes/bazel/guest-init/cmd/net_linux.go
+++ b/projects/embervm/runtimes/bazel/guest-init/cmd/net_linux.go
@@ -3,9 +3,9 @@
 package main
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 
 	"golang.org/x/sys/unix"
 )
@@ -15,33 +15,59 @@ import (
 // only so InetAddress.getLocalHost() resolves without a DNS round trip.
 const guestHostname = "ember-bazel"
 
-// bringUpLoopback brings the loopback interface UP. A raw Firecracker boot leaves
-// `lo` DOWN, and the bazel client connects to the bazel SERVER over a gRPC socket
-// on 127.0.0.1; with lo down that connect blocks forever and the warming VM sits
-// at ZERO CPU with no output. This is best-effort by design: on failure it logs
-// LOUDLY to the console (so a still-hung warming is diagnosable) but does not
-// abort the boot.
+// loopbackUpFlags returns the interface flags with the up + running bits set. It
+// is the pure flag-math half of bringUpLoopback, split out so the OR is unit
+// tested without a socket (bringing an interface up is read-modify-write:
+// SIOCGIFFLAGS gives the current flags, we set IFF_UP|IFF_RUNNING, SIOCSIFFLAGS
+// writes them back, preserving any other bits the kernel already had).
+func loopbackUpFlags(cur uint16) uint16 {
+	return cur | unix.IFF_UP | unix.IFF_RUNNING
+}
+
+// bringUpLoopback brings the loopback interface UP via the SIOCSIFFLAGS ioctl. A
+// raw Firecracker boot leaves `lo` DOWN, and the bazel client connects to the
+// bazel SERVER over a gRPC socket on 127.0.0.1; with lo down that connect blocks
+// forever and the warming VM sits at ZERO CPU with no output. This is best-effort
+// by design: on failure it logs LOUDLY to the console (so a still-hung warming is
+// diagnosable) but does not abort the boot.
 //
-// It shells out to busybox rather than issuing the SIOCSIFFLAGS ioctl directly:
-// the vendored x/sys/unix has no generic Ifreq helper, so a raw ioctl would mean
-// hand-laying the ifreq union struct, which is fragile across arches; busybox
-// (already in the image) provides `ip` and `ifconfig` applets that do exactly
-// this. `ip link set lo up` is tried first, `ifconfig lo up` as a fallback.
+// It issues the ioctl directly rather than shelling out: Wolfi's busybox ships
+// NEITHER an `ip` nor an `ifconfig` applet (confirmed on the live guest:
+// `exec: "ip": executable file not found in $PATH`), so the exec path could never
+// work in this image. The vendored x/sys/unix DOES expose a type-safe Ifreq
+// wrapper (NewIfreq + IoctlIfreq, present since 2021), so no hand-laid ifreq union
+// struct is needed and the code is arch-portable.
 func bringUpLoopback(logger *slog.Logger) {
-	attempts := [][]string{
-		{"ip", "link", "set", "lo", "up"},
-		{"ifconfig", "lo", "up"},
+	if err := bringUpLoopbackIoctl(); err != nil {
+		logger.Error("ember-bazel-init: could NOT bring up loopback; bazel client may block connecting to the server on 127.0.0.1 (warming will hang)", "err", err)
+		return
 	}
-	for _, args := range attempts {
-		cmd := exec.Command(args[0], args[1:]...) // nosemgrep: no-shell-command-injection
-		out, err := cmd.CombinedOutput()
-		if err == nil {
-			logger.Info("ember-bazel-init: loopback up", "via", args[0])
-			return
-		}
-		logger.Warn("ember-bazel-init: loopback up attempt failed", "cmd", args, "err", err, "out", string(out))
+	logger.Info("ember-bazel-init: loopback up (ioctl)")
+}
+
+// bringUpLoopbackIoctl performs the read-modify-write on `lo`'s flags. A DGRAM
+// socket on AF_INET is the conventional handle for interface-flag ioctls (the
+// socket family is irrelevant; it is only a file descriptor to carry the ioctl).
+// CLOEXEC so the transient fd never leaks into the bazel subprocess.
+func bringUpLoopbackIoctl() error {
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("open ioctl socket: %w", err)
 	}
-	logger.Error("ember-bazel-init: could NOT bring up loopback; bazel client may block connecting to the server on 127.0.0.1 (warming will hang)")
+	defer unix.Close(fd)
+
+	ifr, err := unix.NewIfreq("lo")
+	if err != nil {
+		return fmt.Errorf("new ifreq lo: %w", err)
+	}
+	if err := unix.IoctlIfreq(fd, unix.SIOCGIFFLAGS, ifr); err != nil {
+		return fmt.Errorf("get lo flags: %w", err)
+	}
+	ifr.SetUint16(loopbackUpFlags(ifr.Uint16()))
+	if err := unix.IoctlIfreq(fd, unix.SIOCSIFFLAGS, ifr); err != nil {
+		return fmt.Errorf("set lo flags up: %w", err)
+	}
+	return nil
 }
 
 // setHostname sets the guest hostname when it is unset or the default. It pairs

--- a/projects/embervm/runtimes/bazel/guest-init/cmd/net_linux_test.go
+++ b/projects/embervm/runtimes/bazel/guest-init/cmd/net_linux_test.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package main
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestLoopbackUpFlags covers the read-modify-write flag math bringUpLoopback uses:
+// the up + running bits must be set, and any pre-existing bits (whatever
+// SIOCGIFFLAGS returned) must be PRESERVED, not clobbered. Linux-only because the
+// IFF_* constants and the whole loopback path are Linux-only.
+func TestLoopbackUpFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cur  uint16
+		want uint16
+	}{
+		{"from down (zero flags)", 0, unix.IFF_UP | unix.IFF_RUNNING},
+		{"already up stays up", unix.IFF_UP | unix.IFF_RUNNING, unix.IFF_UP | unix.IFF_RUNNING},
+		{
+			"preserves other bits (e.g. LOOPBACK)",
+			unix.IFF_LOOPBACK,
+			unix.IFF_LOOPBACK | unix.IFF_UP | unix.IFF_RUNNING,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := loopbackUpFlags(tc.cur); got != tc.want {
+				t.Fatalf("loopbackUpFlags(%#x) = %#x, want %#x", tc.cur, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The block, now confirmed

PR #3683 added console streaming of the warming subprocess. That immediately located the hang: warming reaches

```
Starting local Bazel server and connecting to it...
```

then blocks at ZERO CPU indefinitely. The loopback-up hedge from #3683 could not have worked, because both exec attempts failed:

```
exec: "ip": executable file not found in $PATH
exec: "ifconfig": executable file not found in $PATH
```

Wolfi's busybox ships neither the `ip` nor the `ifconfig` applet, so the exec approach was a dead end. Loopback-down is the confirmed blocker: the bazel client dials the bazel server's gRPC port on 127.0.0.1, and with `lo` DOWN that connect never completes.

## The fix

Replace the exec-based `bringUpLoopback` with a direct `SIOCSIFFLAGS` ioctl using the vendored `golang.org/x/sys/unix` (v0.46), which exposes a type-safe `Ifreq` wrapper (`NewIfreq` + `IoctlIfreq`, present upstream since 2021), so no hand-laid ifreq union struct is needed and the code is arch-portable:

- open an `AF_INET` `SOCK_DGRAM|SOCK_CLOEXEC` socket (just an fd to carry the ioctl),
- `SIOCGIFFLAGS` to read `lo`'s current flags,
- OR in `IFF_UP | IFF_RUNNING` (preserving any other bits: read-modify-write),
- `SIOCSIFFLAGS` to write them back.

Logs `loopback up (ioctl)` on success, the error loudly on failure (best-effort, does not abort the boot). The pure flag-math (`loopbackUpFlags`) is split out and unit-tested (up+running set, existing bits preserved) in a Linux-tagged test.

No apko change was needed: the ioctl route means we do NOT have to add the wolfi `iproute2` package. Loopback stays Linux-only behind the existing build-tag split, `net_other.go` unchanged.

## Verification

Local (allowed, no bazel against the repo): host `go test` passes, `GOOS=linux go vet` clean, the linux test binary compiles (so CI runs the new flag-math test), both linux arches build. Chart bumped to 0.1.123 so the rebuilt guest image rolls out. The real test is the next live base build: the console should now show `loopback up (ioctl)` and the warming should proceed past `connecting to it...` into the `Analyzed ...` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
