### PR TITLE
feat(embervm): control plane becomes the sole issuer of volume generations

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.125
+version: 0.1.126

--- a/projects/embervm/chart/templates/noded-deployment.yaml
+++ b/projects/embervm/chart/templates/noded-deployment.yaml
@@ -174,6 +174,15 @@ spec:
               value: {{ .Values.noded.store.endpoint | quote }}
             - name: EMBERVM_NODED_STORE_BUCKET
               value: {{ .Values.noded.store.bucket | quote }}
+            # R7 (ADR embervm/011, standing decision 4): the control plane becomes
+            # the sole issuer of volume generations. false accepts a legacy
+            # blessed_generation == 0 self-bump (the default, so this PR can land
+            # both sides in one chart version without a wedge); true rejects an
+            # unblessed writable attach FAILED_PRECONDITION. The CP and noded ship
+            # from this ONE chart, so flipping this true here lands in the same
+            # version the control plane starts blessing (never a mixed state).
+            - name: EMBERVM_NODED_REQUIRE_BLESSING
+              value: {{ .Values.noded.requireBlessing | quote }}
             # Node-side image identity table (image_ref -> {rootfsPath, harnessInit}),
             # rendered as JSON. Derived from noded.workloads + each workload's pinned
             # guestImage so the ref here MATCHES the rootfs-builder GUEST_IMAGE and the

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -786,6 +786,14 @@ noded:
     endpoint: http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333
     bucket: embervm
 
+  # R7 (ADR embervm/011, standing decision 4): the control plane becomes the
+  # sole issuer of volume generations. true rejects a writable attach carrying
+  # blessed_generation == 0 (a legacy self-bump) FAILED_PRECONDITION; this chart
+  # deploys BOTH the control plane and noded, so setting this true here lands
+  # in the exact version the control plane starts blessing, never a mixed
+  # CP/noded state.
+  requireBlessing: true
+
   # 256Mi req / 36Gi limit (Task 14b full side-by-side). The limit is a cgroup
   # OOM CEILING, not a scheduling reservation (the request stays 256Mi), so it
   # does not overcommit node scheduling, exactly like fc-invoke's 50Gi cap.

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -624,7 +624,12 @@ defmodule Embervm.NodeRegistry do
         # restore-on-miss planner reads it to know a lost volume can be restored to
         # this generation, and the remote GC guard reads it to skip a re-export when
         # it already equals the live generation.
-        exported_generation: v.exported_generation
+        exported_generation: v.exported_generation,
+        # generation_blessed (R7, ADR embervm/011): true when the node's CURRENT
+        # generation for this volume was recorded via a control-plane-issued
+        # blessing, false for a self-bumped (unblessed) generation. Feeds
+        # Embervm.StatefulManager.refresh_volume_facts/2's quarantine derivation.
+        generation_blessed: v.generation_blessed
       }
     end
   end

--- a/projects/embervm/control/lib/embervm/op_log.ex
+++ b/projects/embervm/control/lib/embervm/op_log.ex
@@ -248,6 +248,14 @@ defmodule Embervm.OpLog do
   # its pair-validity view from on boot. A volume row lives until volume_deleted,
   # outliving every instance by design. A projection read, never the raw ops log.
   @callback load_volumes(server()) :: {:ok, [map()]} | {:error, term()}
+  # Loads every generation-blessing row from the durable `volume_blessing`
+  # projection (R7, ADR embervm/011): the per-workload `blessed_generation`
+  # watermark this control plane's blessing ledger issued. A SEPARATE
+  # projection from load_volumes/1 (see the `volume_blessing` table's comment
+  # in Embervm.OpLog.SQLite for why a shared table would corrupt
+  # StatefulStore.get_volume/2's nil-means-no-volume-yet contract). A
+  # projection read, never the raw ops log.
+  @callback load_volume_blessing(server()) :: {:ok, [map()]} | {:error, term()}
   # Loads every group-instance row from the durable `group_instances` projection
   # (R5), for the future GroupStore's boot/adoption rebuild, exactly mirroring
   # load_stateful_instances/1. One row per composite group. A projection read,

--- a/projects/embervm/control/lib/embervm/op_log.ex
+++ b/projects/embervm/control/lib/embervm/op_log.ex
@@ -145,6 +145,15 @@ defmodule Embervm.OpLog do
     :stateful_destroyed,
     :stateful_failed,
     :stateful_stats,
+    # generation_blessed (R7, ADR embervm/011, standing decision 4): the control
+    # plane durably records the volume generation it is ABOUT to issue for a
+    # workload's next writable attach, appended BEFORE the boot request carrying
+    # that value is dispatched (the fence: a crash between the two leaves a
+    # harmlessly-unused blessed number, the reverse order would leave a hole).
+    # Projects into the `volumes.blessed_generation` column. Carries
+    # `{generation}`; stateful_instance_id is nil (it is workload-scoped, like
+    # volume_created/volume_deleted, not instance-scoped).
+    :generation_blessed,
     # Composite-group lifecycle (R5). Additive to the closed enum, mirroring the R4
     # stateful kinds: a composite group is a set of member microVMs that live, bank,
     # relight, and die as ONE unit (ADR embervm/001) and project into the

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -291,7 +291,8 @@ defmodule Embervm.OpLog.SQLite do
       size_bytes INTEGER,
       allocated_bytes INTEGER,
       created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
+      updated_at INTEGER NOT NULL,
+      blessed_generation INTEGER
     )
     """,
     # Composite-group instance projection (R5): the durable lifecycle + entry-
@@ -1066,6 +1067,41 @@ defmodule Embervm.OpLog.SQLite do
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
          :ok <- Sqlite3.bind(stmt, [op.workload]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # generation_blessed (R7, ADR embervm/011): the control plane durably records
+  # the generation it is about to issue for a workload's next writable attach,
+  # BEFORE dispatching the boot request carrying it. Upserted (not a plain
+  # UPDATE): a workload's FIRST wake is a FRESH boot whose volume_created has
+  # not landed yet (the daemon creates the volume only once the boot succeeds),
+  # so the very first blessing for a never-before-seen workload must create the
+  # volumes row rather than silently no-op against a WHERE clause matching
+  # nothing. A subsequent volume_created upsert (see that projection) merges
+  # over this row without disturbing blessed_generation, since it does not
+  # list that column in its own INSERT/UPDATE.
+  defp project(conn, %Op{kind: :generation_blessed} = op, _seq) do
+    payload = op.payload
+
+    sql = """
+    INSERT INTO volumes (workload, generation, blessed_generation, created_at, updated_at)
+    VALUES (?, 0, ?, ?, ?)
+    ON CONFLICT(workload) DO UPDATE SET
+      blessed_generation = excluded.blessed_generation,
+      updated_at = excluded.updated_at
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <-
+           Sqlite3.bind(stmt, [
+             op.workload,
+             Map.get(payload, :generation),
+             op.ts,
+             op.ts
+           ]),
          :done <- Sqlite3.step(conn, stmt),
          :ok <- Sqlite3.release(conn, stmt) do
       :ok
@@ -2177,7 +2213,7 @@ defmodule Embervm.OpLog.SQLite do
 
   defp do_load_volumes(conn) do
     sql = """
-    SELECT workload, node_id, generation, size_bytes, allocated_bytes, created_at, updated_at
+    SELECT workload, node_id, generation, size_bytes, allocated_bytes, created_at, updated_at, blessed_generation
     FROM volumes
     """
 
@@ -2191,7 +2227,7 @@ defmodule Embervm.OpLog.SQLite do
   defp collect_volumes(conn, stmt, acc) do
     case Sqlite3.step(conn, stmt) do
       {:row,
-       [workload, node_id, generation, size_bytes, allocated_bytes, created_at, updated_at]} ->
+       [workload, node_id, generation, size_bytes, allocated_bytes, created_at, updated_at, blessed_generation]} ->
         volume = %{
           workload: workload,
           node_id: node_id,
@@ -2199,7 +2235,8 @@ defmodule Embervm.OpLog.SQLite do
           size_bytes: size_bytes,
           allocated_bytes: allocated_bytes,
           created_at: created_at,
-          updated_at: updated_at
+          updated_at: updated_at,
+          blessed_generation: blessed_generation
         }
 
         collect_volumes(conn, stmt, [volume | acc])
@@ -2853,7 +2890,8 @@ defmodule Embervm.OpLog.SQLite do
          :ok <- migrate_ops_serving_instance_id(conn),
          :ok <- migrate_usage_request_count(conn),
          :ok <- migrate_ops_stateful_instance_id(conn),
-         :ok <- migrate_ops_group_instance_id(conn) do
+         :ok <- migrate_ops_group_instance_id(conn),
+         :ok <- migrate_volumes_blessed_generation(conn) do
       :ok
     end
   end
@@ -2962,6 +3000,23 @@ defmodule Embervm.OpLog.SQLite do
         conn,
         "CREATE INDEX IF NOT EXISTS ops_group_instance_id_idx ON ops(group_instance_id)"
       )
+    end
+  end
+
+  # R7 (ADR embervm/011): the additive nullable `volumes.blessed_generation`
+  # column, guarded the same way migrate_usage_request_count/1 guards
+  # `usage.request_count`. A fresh DB already built the column from the CREATE
+  # TABLE and skips the ALTER; an upgraded DB gets it added as NULL for every
+  # existing row, which reads back as "never blessed" (the moduledoc's
+  # grandfather rule in Embervm.StatefulStore), correctly reflecting that no
+  # generation_blessed op exists yet for a pre-R7 volume.
+  defp migrate_volumes_blessed_generation(conn) do
+    with {:ok, cols} <- table_columns(conn, "volumes") do
+      if "blessed_generation" in cols do
+        :ok
+      else
+        Sqlite3.execute(conn, "ALTER TABLE volumes ADD COLUMN blessed_generation INTEGER")
+      end
     end
   end
 

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -291,8 +291,26 @@ defmodule Embervm.OpLog.SQLite do
       size_bytes INTEGER,
       allocated_bytes INTEGER,
       created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL,
-      blessed_generation INTEGER
+      updated_at INTEGER NOT NULL
+    )
+    """,
+    # Generation-blessing ledger (R7, ADR embervm/011, standing decision 4): a
+    # SEPARATE table from `volumes`, keyed by workload the same way, because a
+    # workload can be blessed BEFORE it has a real volume row at all (the very
+    # first wake blesses generation 1 before the daemon's FRESH boot creates the
+    # volume). Folding this into `volumes` would make the very first blessing
+    # fabricate a phantom volume row with no node_id, which both defeats
+    # Embervm.StatefulStore.get_volume/2's nil-means-no-volume-yet contract and
+    # crashes the anchor_node placement logic that reads it. blessed_generation is
+    # the last generation THIS control plane's blessing ledger issued; quarantined
+    # is NOT persisted here (it is a live node-report-derived fact, re-derived on
+    # every NodeStatus refresh, exactly like a stateful instance's `healthy`).
+    """
+    CREATE TABLE IF NOT EXISTS volume_blessing (
+      workload TEXT PRIMARY KEY,
+      blessed_generation INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
     )
     """,
     # Composite-group instance projection (R5): the durable lifecycle + entry-
@@ -419,6 +437,11 @@ defmodule Embervm.OpLog.SQLite do
   end
 
   @impl Embervm.OpLog
+  def load_volume_blessing(server \\ __MODULE__) do
+    GenServer.call(server, :load_volume_blessing)
+  end
+
+  @impl Embervm.OpLog
   def load_group_instances(server \\ __MODULE__) do
     GenServer.call(server, :load_group_instances)
   end
@@ -531,6 +554,10 @@ defmodule Embervm.OpLog.SQLite do
 
   def handle_call(:load_volumes, _from, state) do
     {:reply, do_load_volumes(state.conn), state}
+  end
+
+  def handle_call(:load_volume_blessing, _from, state) do
+    {:reply, do_load_volume_blessing(state.conn), state}
   end
 
   def handle_call(:load_group_instances, _from, state) do
@@ -1075,20 +1102,19 @@ defmodule Embervm.OpLog.SQLite do
 
   # generation_blessed (R7, ADR embervm/011): the control plane durably records
   # the generation it is about to issue for a workload's next writable attach,
-  # BEFORE dispatching the boot request carrying it. Upserted (not a plain
-  # UPDATE): a workload's FIRST wake is a FRESH boot whose volume_created has
-  # not landed yet (the daemon creates the volume only once the boot succeeds),
-  # so the very first blessing for a never-before-seen workload must create the
-  # volumes row rather than silently no-op against a WHERE clause matching
-  # nothing. A subsequent volume_created upsert (see that projection) merges
-  # over this row without disturbing blessed_generation, since it does not
-  # list that column in its own INSERT/UPDATE.
+  # BEFORE dispatching the boot request carrying it. Projects into the SEPARATE
+  # `volume_blessing` table, never `volumes` (see that table's comment): a
+  # workload's FIRST wake blesses before its FRESH boot's volume_created has
+  # landed, so writing into `volumes` here would fabricate a phantom,
+  # node_id-less volume row that breaks StatefulStore.get_volume/2's
+  # nil-means-no-volume-yet contract. Upserted (not a plain UPDATE) so a later
+  # blessing for the same workload updates rather than duplicates the row.
   defp project(conn, %Op{kind: :generation_blessed} = op, _seq) do
     payload = op.payload
 
     sql = """
-    INSERT INTO volumes (workload, generation, blessed_generation, created_at, updated_at)
-    VALUES (?, 0, ?, ?, ?)
+    INSERT INTO volume_blessing (workload, blessed_generation, created_at, updated_at)
+    VALUES (?, ?, ?, ?)
     ON CONFLICT(workload) DO UPDATE SET
       blessed_generation = excluded.blessed_generation,
       updated_at = excluded.updated_at
@@ -2213,7 +2239,7 @@ defmodule Embervm.OpLog.SQLite do
 
   defp do_load_volumes(conn) do
     sql = """
-    SELECT workload, node_id, generation, size_bytes, allocated_bytes, created_at, updated_at, blessed_generation
+    SELECT workload, node_id, generation, size_bytes, allocated_bytes, created_at, updated_at
     FROM volumes
     """
 
@@ -2227,7 +2253,7 @@ defmodule Embervm.OpLog.SQLite do
   defp collect_volumes(conn, stmt, acc) do
     case Sqlite3.step(conn, stmt) do
       {:row,
-       [workload, node_id, generation, size_bytes, allocated_bytes, created_at, updated_at, blessed_generation]} ->
+       [workload, node_id, generation, size_bytes, allocated_bytes, created_at, updated_at]} ->
         volume = %{
           workload: workload,
           node_id: node_id,
@@ -2235,11 +2261,40 @@ defmodule Embervm.OpLog.SQLite do
           size_bytes: size_bytes,
           allocated_bytes: allocated_bytes,
           created_at: created_at,
-          updated_at: updated_at,
-          blessed_generation: blessed_generation
+          updated_at: updated_at
         }
 
         collect_volumes(conn, stmt, [volume | acc])
+
+      :done ->
+        Enum.reverse(acc)
+    end
+  end
+
+  defp do_load_volume_blessing(conn) do
+    sql = """
+    SELECT workload, blessed_generation, created_at, updated_at
+    FROM volume_blessing
+    """
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql) do
+      rows = collect_volume_blessing(conn, stmt, [])
+      :ok = Sqlite3.release(conn, stmt)
+      {:ok, rows}
+    end
+  end
+
+  defp collect_volume_blessing(conn, stmt, acc) do
+    case Sqlite3.step(conn, stmt) do
+      {:row, [workload, blessed_generation, created_at, updated_at]} ->
+        row = %{
+          workload: workload,
+          blessed_generation: blessed_generation,
+          created_at: created_at,
+          updated_at: updated_at
+        }
+
+        collect_volume_blessing(conn, stmt, [row | acc])
 
       :done ->
         Enum.reverse(acc)
@@ -2890,8 +2945,7 @@ defmodule Embervm.OpLog.SQLite do
          :ok <- migrate_ops_serving_instance_id(conn),
          :ok <- migrate_usage_request_count(conn),
          :ok <- migrate_ops_stateful_instance_id(conn),
-         :ok <- migrate_ops_group_instance_id(conn),
-         :ok <- migrate_volumes_blessed_generation(conn) do
+         :ok <- migrate_ops_group_instance_id(conn) do
       :ok
     end
   end
@@ -3000,23 +3054,6 @@ defmodule Embervm.OpLog.SQLite do
         conn,
         "CREATE INDEX IF NOT EXISTS ops_group_instance_id_idx ON ops(group_instance_id)"
       )
-    end
-  end
-
-  # R7 (ADR embervm/011): the additive nullable `volumes.blessed_generation`
-  # column, guarded the same way migrate_usage_request_count/1 guards
-  # `usage.request_count`. A fresh DB already built the column from the CREATE
-  # TABLE and skips the ALTER; an upgraded DB gets it added as NULL for every
-  # existing row, which reads back as "never blessed" (the moduledoc's
-  # grandfather rule in Embervm.StatefulStore), correctly reflecting that no
-  # generation_blessed op exists yet for a pre-R7 volume.
-  defp migrate_volumes_blessed_generation(conn) do
-    with {:ok, cols} <- table_columns(conn, "volumes") do
-      if "blessed_generation" in cols do
-        :ok
-      else
-        Sqlite3.execute(conn, "ALTER TABLE volumes ADD COLUMN blessed_generation INTEGER")
-      end
     end
   end
 

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -610,7 +610,6 @@ defmodule Embervm.StatefulManager do
   # another workload's wake; the worker reports the RPC result and finish_wake
   # completes the durable transition + publish on this process.
   defp start_wake(state, workload) do
-    owner = self()
     entry = catalog_entry(state, workload)
 
     # Stamp the wake phase's start + the cold bool into the tracing bundle now
@@ -622,6 +621,51 @@ defmodule Embervm.StatefulManager do
     plan = plan_wake(state, workload)
     cold = match?({:cold, _, _, _, _}, plan) or match?({:restore_volume_then_cold, _, _, _}, plan)
     state = stamp_wake_trace(state, workload, %{wake_start: wake_start, cold: cold})
+
+    # Generation blessing (R7, ADR embervm/011, standing decision 4): every plan
+    # that will dispatch a WRITABLE attach (every arm except a bare {:error, _})
+    # gets the next blessed generation issued and durably recorded HERE, on this
+    # serialized process, BEFORE the boot request is built or dispatched. This is
+    # the fence: bless_generation/3 appends the op-log entry first and only then
+    # returns, so a crash between the append and the RPC leaves an unused (never
+    # dispatched) blessed number, which is harmless; blessing AFTER dispatch would
+    # instead risk a boot the op-log never witnessed, a real fence hole. A
+    # bless_generation failure (an op-log append error) fails the wake outright
+    # rather than dispatching an unblessed attach.
+    case bless_wake_generation(state, workload, plan) do
+      {:ok, blessed_generation} ->
+        start_wake_dispatch(state, workload, entry, plan, blessed_generation)
+
+      :none ->
+        start_wake_dispatch(state, workload, entry, plan, 0)
+
+      {:error, reason} ->
+        send(self(), {:wake_done, workload, {:error, {:bless_generation, reason}}})
+        state
+    end
+  end
+
+  # Whether `plan` will dispatch a writable attach at all (every arm except
+  # {:error, _}), and if so, issue + durably record the next blessed generation
+  # for the workload via StatefulStore.bless_generation/3. Returns `:none` for a
+  # plan that dispatches nothing (the {:error, _} arm: the wake already failed in
+  # plan_wake/2, e.g. :volume_node_gone, so there is no attach to bless).
+  defp bless_wake_generation(_state, _workload, {:error, _reason}), do: :none
+
+  defp bless_wake_generation(state, workload, _plan) do
+    next = StatefulStore.next_blessed_generation(state.store, workload)
+
+    case StatefulStore.bless_generation(state.store, workload, next) do
+      {:ok, _volume} -> {:ok, next}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # Dispatches the wake worker for `plan`, threading `blessed_generation` (0 for
+  # the {:error, _} arm, which never reaches a request builder) into every
+  # StartStatefulRequest this wake sends.
+  defp start_wake_dispatch(state, workload, entry, plan, blessed_generation) do
+    owner = self()
 
     # Stamp the wake's start (for the adoption stuck-check + park_full age) and arm the
     # wake-worker bound: if the worker has not reported a {:wake_done} by then,
@@ -638,7 +682,7 @@ defmodule Embervm.StatefulManager do
             # from here, or an unreadable ledger) it falls back to a cold boot
             # from THIS ref rather than failing the call outright.
             fallback_ref = boot_image_ref(state, node_id, workload)
-            req = relight_request(entry, snapshot_ref, fallback_ref)
+            req = relight_request(entry, snapshot_ref, fallback_ref, blessed_generation)
             spawn_wake(owner, workload, fn -> run_relight(state, instance, node_id, req) end)
 
           {:error, reason} ->
@@ -657,7 +701,7 @@ defmodule Embervm.StatefulManager do
         case StatefulStore.mark(state.store, instance.instance_id, :relight) do
           {:ok, _} ->
             fallback_ref = boot_image_ref(state, node_id, workload)
-            req = relight_request(entry, snapshot_ref, fallback_ref)
+            req = relight_request(entry, snapshot_ref, fallback_ref, blessed_generation)
 
             spawn_wake(owner, workload, fn ->
               _ = restore_bundle(state, node_id, workload, snapshot_ref)
@@ -669,7 +713,7 @@ defmodule Embervm.StatefulManager do
         end
 
       {:cold, node_id, boot_ref, mode, reason} ->
-        req = cold_request(state, entry, workload, boot_ref, mode)
+        req = cold_request(state, entry, workload, boot_ref, mode, blessed_generation)
         spawn_wake(owner, workload, fn -> run_cold(state, workload, node_id, boot_ref, mode, reason, req) end)
 
       # Restore-on-miss (R6): the volume itself is gone but a (vol.img, gen) pair is
@@ -679,7 +723,7 @@ defmodule Embervm.StatefulManager do
       # for a truly-absent volume the daemon fails closed on (data fails closed).
       {:restore_volume_then_cold, wl, node_id, volume} ->
         boot_ref = boot_image_ref(state, node_id, wl)
-        req = cold_request(state, entry, wl, boot_ref, :cold)
+        req = cold_request(state, entry, wl, boot_ref, :cold, blessed_generation)
         reason = cold_reason(volume)
 
         spawn_wake(owner, workload, fn ->
@@ -749,6 +793,23 @@ defmodule Embervm.StatefulManager do
   defp plan_wake(state, workload) do
     volume = StatefulStore.get_volume(state.store, workload)
 
+    cond do
+      StatefulStore.quarantined?(state.store, workload) ->
+        # R7, ADR embervm/011, standing decision 4: a node has reported a
+        # generation past the last one this control plane blessed, with
+        # generation_blessed: false. Fail closed -- park, never place a wake
+        # (relight OR cold) against a volume whose current generation this
+        # control plane cannot vouch for. No auto-heal: resolution (bless-and-
+        # adopt, or discard) is a manual runbook decision.
+        Logger.warning("embervm stateful wake refused: volume quarantined (unblessed generation)", workload: workload)
+        {:error, :volume_quarantined}
+
+      true ->
+        plan_wake_unquarantined(state, workload, volume)
+    end
+  end
+
+  defp plan_wake_unquarantined(state, workload, volume) do
     case banked_instance(state, workload) do
       nil ->
         # No bundle to resume: a genuine FRESH first boot (no volume yet, reason
@@ -979,7 +1040,7 @@ defmodule Embervm.StatefulManager do
   # therefore unconditionally %{} here, with no secret read at all -- not even
   # a wasted one -- keeping a relight's K8s footprint identical to before this
   # feature.
-  defp relight_request(entry, snapshot_ref, fallback_ref) do
+  defp relight_request(entry, snapshot_ref, fallback_ref, blessed_generation) do
     cfg = stateful_cfg(entry)
 
     %StartStatefulRequest{
@@ -992,7 +1053,12 @@ defmodule Embervm.StatefulManager do
       volume_mount: cfg.volume_mount_path,
       create_if_missing: false,
       resources: resource_spec(entry),
-      mmds_env: %{}
+      mmds_env: %{},
+      # blessed_generation (R7, ADR embervm/011): the generation this control
+      # plane already durably blessed for this attach in bless_wake_generation/3,
+      # BEFORE this request was built. The daemon records it verbatim rather than
+      # self-bumping.
+      blessed_generation: blessed_generation
     }
   end
 
@@ -1001,7 +1067,7 @@ defmodule Embervm.StatefulManager do
   # its decoded key/values (R4, D-R4.PR-7.1: MMDS-lite over boot-args). Absent
   # secretRef leaves mmds_env at %{} (no K8s call at all, matching the
   # zero-new-runtime-RBAC baseline for a workload that declares none).
-  defp cold_request(state, entry, workload, boot_ref, mode) do
+  defp cold_request(state, entry, workload, boot_ref, mode, blessed_generation) do
     cfg = stateful_cfg(entry)
 
     %StartStatefulRequest{
@@ -1017,7 +1083,10 @@ defmodule Embervm.StatefulManager do
       # branch selection).
       create_if_missing: mode == :fresh,
       resources: resource_spec(entry),
-      mmds_env: cold_boot_mmds_env(state, entry, workload)
+      mmds_env: cold_boot_mmds_env(state, entry, workload),
+      # blessed_generation (R7, ADR embervm/011): see relight_request/4's note;
+      # identical contract for a FRESH/COLD writable attach.
+      blessed_generation: blessed_generation
     }
   end
 
@@ -1745,6 +1814,15 @@ defmodule Embervm.StatefulManager do
   # workload's volume).
   defp refresh_volume_facts(state, facts) do
     for f <- facts, v <- Map.get(f, :volumes, []) || [] do
+      # R7 grandfather seed (ADR embervm/011): a volume this control plane has
+      # NEVER blessed (blessed_generation nil, e.g. every pre-R7 volume, or a
+      # brand-new one adopted before its first bless_generation call landed)
+      # gets its ledger seeded from THIS eager first report before quarantine is
+      # derived below, so it is never punished for predating blessing. A no-op
+      # once the volume has ever been blessed (seed_blessed_generation_if_unset
+      # only acts on an unset watermark).
+      _ = StatefulStore.seed_blessed_generation_if_unset(state.store, v.workload, v.generation)
+
       StatefulStore.upsert_volume(state.store, v.workload, %{
         node_id: f.configured_id,
         generation: v.generation,
@@ -1755,7 +1833,10 @@ defmodule Embervm.StatefulManager do
         # decide restore-on-miss (a lost local bundle whose snapshot_generation
         # equals this can be recovered from the store) even after the local bundle
         # fact is gone. 0/absent when no store copy exists.
-        exported_generation: Map.get(v, :exported_generation, 0)
+        exported_generation: Map.get(v, :exported_generation, 0),
+        # generation_blessed (R7): the node's per-report wire fact, feeding
+        # StatefulStore's quarantine derivation (see its moduledoc).
+        generation_blessed: Map.get(v, :generation_blessed, false)
       })
     end
 

--- a/projects/embervm/control/lib/embervm/stateful_store.ex
+++ b/projects/embervm/control/lib/embervm/stateful_store.ex
@@ -56,11 +56,23 @@ defmodule Embervm.StatefulStore do
 
   Standing decision 4 inverts who issues a volume's generation: the control
   plane is now the SOLE issuer (`bless_generation/3`), and the daemon records
-  what it is told rather than inventing a value. `next_blessed_generation/2`
-  reads the volume row's `blessed_generation` (the last value THIS control
-  plane blessed, durable via the `generation_blessed` op) and returns one past
-  it; `bless_generation/3` appends that op BEFORE the caller dispatches the
-  boot request (see `Embervm.StatefulManager.plan_wake/2`'s ordering comment:
+  what it is told rather than inventing a value. The blessing ledger
+  (`blessed_generation` + `quarantined`) lives in a table SEPARATE from the
+  volume facts `get_volume/2`/`upsert_volume/3` expose (`@blessing_table`, not
+  `@volumes_table`): a workload can be blessed BEFORE it has a real volume row
+  at all (the very first wake blesses generation 1 before the daemon's FRESH
+  boot creates the volume), and `get_volume/2` returning nil for "no volume
+  yet" vs a map for "an existing volume" is load-bearing for
+  `Embervm.StatefulManager.plan_wake/2`'s FRESH-vs-anchored placement decision.
+  Folding blessing into the volume row would make the very first blessing
+  fabricate a phantom, node_id-less volume that both defeats that nil check
+  and crashes the anchor-to-node placement logic that pattern-matches on it.
+
+  `next_blessed_generation/2` reads the ledger's `blessed_generation` (the last
+  value THIS control plane blessed, durable via the `generation_blessed` op,
+  absent for a never-blessed workload) and returns one past it;
+  `bless_generation/3` appends that op BEFORE the caller dispatches the boot
+  request (see `Embervm.StatefulManager.plan_wake/2`'s ordering comment:
   op-log-before-dispatch is the fence, a crash between the two leaves a
   harmlessly-unused blessed number, never a hole).
 
@@ -68,20 +80,24 @@ defmodule Embervm.StatefulStore do
   the last value this control plane blessed, with `generation_blessed: false`
   on the wire (a self-bump the daemon made outside the blessing ledger, e.g. a
   legacy noded that has not yet enabled `EMBERVM_NODED_REQUIRE_BLESSING`, or a
-  split-brain write). `upsert_volume/3` derives `quarantined` on every node
-  refresh: true when the reported generation exceeds `blessed_generation` AND
-  the node's own `generation_blessed` fact is false; a node reporting
+  split-brain write). `upsert_volume/3` re-derives `quarantined` in the
+  blessing table on every node refresh that carries a `generation_blessed`
+  fact: true when the reported generation exceeds `blessed_generation` AND the
+  node's own `generation_blessed` fact is false; a node reporting
   `generation_blessed: true` at or below the blessed watermark clears it. Once
   quarantined, `Embervm.StatefulManager.plan_wake/2` parks the wake rather than
   placing it (fail closed, no auto-heal in v1: resolution is a runbook
-  decision). A volume that has NEVER been blessed (no CP generation-blessing op
-  ever landed, e.g. every pre-R7 volume) has `blessed_generation` nil and is
-  NEVER quarantined by this alone: `quarantined?/2` treats nil as "not yet
-  under CP governance" rather than "behind it", so an existing volume is
-  grandfathered the first time it is reported (adoption seeds the ledger from
-  that eager first NodeStatus in `Embervm.StatefulManager.plan_wake/2` before
-  any quarantine check runs), never punished retroactively for predating
-  blessing.
+  decision). A workload that has NEVER been blessed (no CP generation-blessing
+  op ever landed, e.g. every pre-R7 volume) has an absent `blessed_generation`
+  and is NEVER quarantined by this alone: `quarantined?/2` treats absent as
+  "not yet under CP governance" rather than "behind it", so an existing volume
+  is grandfathered the first time it is reported (adoption seeds the ledger
+  from that eager first NodeStatus via `seed_blessed_generation_if_unset/3`
+  before any quarantine check runs), never punished retroactively for
+  predating blessing. `quarantined` itself is NOT durable (a live
+  node-report-derived fact, exactly like a stateful instance's `healthy`): a
+  rebuild always starts un-quarantined and the next NodeStatus refresh
+  re-derives it.
 
   ## unpublish is ETS-only (a decision)
 
@@ -116,6 +132,16 @@ defmodule Embervm.StatefulStore do
 
   @instances_table :embervm_stateful_instances
   @volumes_table :embervm_stateful_volumes
+  # The blessing ledger (R7) is DELIBERATELY a separate table from @volumes_table,
+  # keyed by workload exactly like it. A workload can be blessed before it has a
+  # real volume row at all (the very first wake blesses generation 1 BEFORE the
+  # daemon's FRESH boot creates the volume), and get_volume/2's nil/non-nil result
+  # is load-bearing: plan_wake reads nil as "no volume yet, free FRESH placement"
+  # and non-nil as "an existing volume, anchor to its node_id". Folding the
+  # blessing ledger into @volumes_table would make bless_generation/3 fabricate a
+  # non-nil, node_id-less volume row for a workload with no real volume, which
+  # both defeats that nil check AND crashes anchor_node/2 (no node_id to match).
+  @blessing_table :embervm_stateful_blessing
 
   # -- Client API ------------------------------------------------------------
 
@@ -342,11 +368,13 @@ defmodule Embervm.StatefulStore do
   written by the op-log's `volume_created` projection; this is the live-fact
   primitive Task 8 drives from NodeStatus scrapes, the way `set_health/2` /
   `touch_active/3` update lossy node facts). Merges the given fields over any
-  existing row (or inserts a fresh one). When `fields` carries
-  `generation_blessed` (R7, the node's per-volume wire fact), also derives and
-  merges `quarantined` per the moduledoc's rule (a reported generation past the
-  last CP-blessed one, with `generation_blessed: false`, quarantines; anything
-  else clears it). Returns the merged volume row.
+  existing row (or inserts a fresh one) and returns the merged volume row.
+  `generation_blessed` (R7, the node's per-volume wire fact) is NOT stored on
+  this row (see the moduledoc's "generation blessing and quarantine" section
+  for why): when present it instead re-derives `quarantined` in the SEPARATE
+  blessing ledger (a reported generation past the last CP-blessed one, with
+  `generation_blessed: false`, quarantines; anything else clears it), readable
+  via `quarantined?/2`.
   """
   @spec upsert_volume(GenServer.server(), String.t(), map()) :: map()
   def upsert_volume(store \\ __MODULE__, workload, fields) do
@@ -355,9 +383,10 @@ defmodule Embervm.StatefulStore do
 
   @doc """
   The next generation this control plane should bless for `workload`'s volume:
-  one past the volume row's durable `blessed_generation` (nil/absent reads as 0,
-  so the very first blessing for a never-blessed volume is 1). A PURE ETS read;
-  it does not append anything (see `bless_generation/3`).
+  one past the blessing ledger's durable `blessed_generation` (absent reads as
+  0, so the very first blessing for a never-blessed workload is 1). A PURE ETS
+  read against the SEPARATE blessing table (never `@volumes_table`; see the
+  moduledoc); it does not append anything (see `bless_generation/3`).
   """
   @spec next_blessed_generation(GenServer.server(), String.t()) :: pos_integer()
   def next_blessed_generation(store \\ __MODULE__, workload) do
@@ -368,13 +397,15 @@ defmodule Embervm.StatefulStore do
   Durably records that this control plane is about to issue `generation` as
   `workload`'s next writable-attach generation (R7, ADR embervm/011): appends
   the `generation_blessed` op (write-through) and, only on success, bumps the
-  ETS volume row's `blessed_generation` to `generation` and clears
+  SEPARATE blessing ledger's `blessed_generation` to `generation` and clears
   `quarantined` (a fresh CP-issued blessing is by definition not behind
-  itself). MUST be called BEFORE the caller dispatches the boot request
-  carrying this value as `blessed_generation` (the op-log-before-dispatch
-  fence; see `Embervm.StatefulManager.plan_wake/2`). Returns `{:ok, volume}` or
-  `{:error, reason}` on an append failure (the caller must not dispatch a boot
-  whose blessing never durably landed).
+  itself). Never touches `@volumes_table` (see the moduledoc: a workload may
+  not have a real volume row yet). MUST be called BEFORE the caller dispatches
+  the boot request carrying this value as `blessed_generation` (the
+  op-log-before-dispatch fence; see `Embervm.StatefulManager.plan_wake/2`).
+  Returns `{:ok, fact}` (the ledger fact, `%{blessed_generation, quarantined}`)
+  or `{:error, reason}` on an append failure (the caller must not dispatch a
+  boot whose blessing never durably landed).
   """
   @spec bless_generation(GenServer.server(), String.t(), pos_integer()) :: {:ok, map()} | {:error, term()}
   def bless_generation(store \\ __MODULE__, workload, generation) do
@@ -482,12 +513,14 @@ defmodule Embervm.StatefulStore do
 
     instances = :ets.new(@instances_table, [:set, :private])
     volumes = :ets.new(@volumes_table, [:set, :private])
+    blessing = :ets.new(@blessing_table, [:set, :private])
 
     state = %{
       op_log: op_log,
       clock: clock,
       instances: instances,
       volumes: volumes,
+      blessing: blessing,
       # workload -> %{live, banked}, kept in step with the hot set on every write.
       counts: %{}
     }
@@ -507,7 +540,8 @@ defmodule Embervm.StatefulStore do
   # instance is healthy=false (it is not in the fan-out anyway).
   defp rebuild(state) do
     with {:ok, rows} <- Embervm.OpLog.SQLite.load_stateful_instances(state.op_log),
-         {:ok, volumes} <- Embervm.OpLog.SQLite.load_volumes(state.op_log) do
+         {:ok, volumes} <- Embervm.OpLog.SQLite.load_volumes(state.op_log),
+         {:ok, blessing_rows} <- Embervm.OpLog.SQLite.load_volume_blessing(state.op_log) do
       state =
         Enum.reduce(rows, state, fn row, acc ->
           instance = row_to_instance(row)
@@ -517,6 +551,13 @@ defmodule Embervm.StatefulStore do
 
       Enum.each(volumes, fn vol ->
         :ets.insert(state.volumes, {vol.workload, volume_row(vol)})
+      end)
+
+      # quarantined is NOT durable (a live node-report-derived fact, exactly like
+      # a stateful instance's `healthy`): a rebuild always starts un-quarantined
+      # and the next NodeStatus refresh re-derives it.
+      Enum.each(blessing_rows, fn row ->
+        :ets.insert(state.blessing, {row.workload, %{blessed_generation: row.blessed_generation, quarantined: false}})
       end)
 
       {:ok, state}
@@ -562,13 +603,6 @@ defmodule Embervm.StatefulStore do
       generation: vol.generation || 0,
       size_bytes: vol.size_bytes,
       allocated_bytes: vol.allocated_bytes,
-      # blessed_generation is durable (the generation_blessed op projection);
-      # quarantined is NOT (it is derived from a node's live report, see
-      # derive_quarantine/2), so a rebuild always starts un-quarantined and lets
-      # the next NodeStatus refresh re-derive it, exactly like `healthy` for a
-      # stateful instance.
-      blessed_generation: Map.get(vol, :blessed_generation),
-      quarantined: false,
       updated_at: vol.updated_at
     }
   end
@@ -730,26 +764,32 @@ defmodule Embervm.StatefulStore do
           generation: 0,
           size_bytes: nil,
           allocated_bytes: nil,
-          blessed_generation: nil,
-          quarantined: false,
           updated_at: ts
         }
 
     merged =
       base
-      |> Map.merge(fields)
+      |> Map.merge(Map.delete(fields, :generation_blessed))
       |> Map.put(:workload, workload)
       |> Map.put(:updated_at, ts)
-      |> derive_quarantine(fields)
-
-    log_quarantine_transition(base, merged, workload)
 
     :ets.insert(state.volumes, {workload, merged})
+
+    # generation_blessed (R7) is a node-report wire fact feeding the SEPARATE
+    # blessing ledger's quarantine derivation (never stored on the volume row
+    # itself; see @blessing_table's comment). Only touch the blessing table
+    # when this upsert actually carries a fresh report of it.
+    state =
+      case Map.get(fields, :generation_blessed) do
+        nil -> state
+        blessed_on_wire -> update_quarantine(state, workload, Map.get(merged, :generation, 0), blessed_on_wire)
+      end
+
     {:reply, merged, state}
   end
 
   def handle_call({:next_blessed_generation, workload}, _from, state) do
-    current = (fetch_volume(state, workload) || %{}) |> Map.get(:blessed_generation, 0) || 0
+    current = fetch_blessing(state, workload) |> Map.get(:blessed_generation, 0) || 0
     {:reply, current + 1, state}
   end
 
@@ -770,17 +810,13 @@ defmodule Embervm.StatefulStore do
 
     case Embervm.OpLog.SQLite.append(state.op_log, op) do
       {:ok, _seq} ->
-        base = fetch_volume(state, workload) || %{workload: workload, generation: 0}
-
-        merged =
-          base
-          |> Map.put(:blessed_generation, generation)
-          |> Map.put(:quarantined, false)
-          |> Map.put(:workload, workload)
-          |> Map.put(:updated_at, ts)
-
-        :ets.insert(state.volumes, {workload, merged})
-        {:reply, {:ok, merged}, state}
+        # A fresh CP-issued blessing is by definition not behind itself: clear
+        # any prior quarantine. This writes ONLY the separate blessing table,
+        # never @volumes_table (see that table's comment): a volume row for
+        # this workload may not exist yet (the very first wake blesses before
+        # a FRESH boot's volume_created lands).
+        :ets.insert(state.blessing, {workload, %{blessed_generation: generation, quarantined: false}})
+        {:reply, {:ok, fetch_blessing(state, workload)}, state}
 
       {:error, _reason} = error ->
         {:reply, error, state}
@@ -788,25 +824,18 @@ defmodule Embervm.StatefulStore do
   end
 
   def handle_call({:quarantined?, workload}, _from, state) do
-    quarantined? = (fetch_volume(state, workload) || %{}) |> Map.get(:quarantined, false) || false
-    {:reply, quarantined?, state}
+    {:reply, Map.get(fetch_blessing(state, workload), :quarantined, false) || false, state}
   end
 
   def handle_call({:seed_blessed_generation_if_unset, workload, generation}, _from, state) do
-    case fetch_volume(state, workload) do
-      %{blessed_generation: bg} = volume when is_integer(bg) ->
-        {:reply, volume, state}
+    case fetch_blessing(state, workload) do
+      %{blessed_generation: bg} = fact when is_integer(bg) ->
+        {:reply, fact, state}
 
-      volume ->
-        merged =
-          (volume || %{workload: workload, generation: generation})
-          |> Map.put(:blessed_generation, generation)
-          |> Map.put(:quarantined, false)
-          |> Map.put(:workload, workload)
-          |> Map.put(:updated_at, state.clock.())
-
-        :ets.insert(state.volumes, {workload, merged})
-        {:reply, merged, state}
+      _never_blessed ->
+        fact = %{blessed_generation: generation, quarantined: false}
+        :ets.insert(state.blessing, {workload, fact})
+        {:reply, fact, state}
     end
   end
 
@@ -1258,47 +1287,47 @@ defmodule Embervm.StatefulStore do
     end
   end
 
-  # Derive the merged volume row's `quarantined` flag from the node fact carried
-  # in THIS upsert's `fields` (not the merged row: `generation_blessed` is a
-  # per-report wire fact, never a durable ETS field of its own, so it must be
-  # read off the incoming report). Quarantined iff the report says the volume is
-  # NOT blessed (`generation_blessed == false` on the wire) AND its generation is
-  # STRICTLY PAST the last generation this control plane blessed. A volume never
-  # blessed at all (`blessed_generation` nil) never quarantines here (the
-  # moduledoc's grandfather rule: nil means "not yet under CP governance", not
-  # "behind it"). Absent `generation_blessed` in `fields` (an upsert that carries
-  # no fresh node report, e.g. bump_volume_ets's real-time mirror) leaves the
-  # existing `quarantined` value untouched.
-  defp derive_quarantine(merged, fields) do
-    case Map.get(fields, :generation_blessed) do
-      nil ->
-        merged
-
-      blessed_on_wire ->
-        blessed_gen = Map.get(merged, :blessed_generation)
-        reported_gen = Map.get(merged, :generation, 0)
-
-        quarantined? =
-          not blessed_on_wire and is_integer(blessed_gen) and reported_gen > blessed_gen
-
-        Map.put(merged, :quarantined, quarantined?)
+  # The blessing ledger fact for `workload`: `%{blessed_generation, quarantined}`,
+  # defaulting to `%{quarantined: false}` (no `blessed_generation` key) for a
+  # workload never blessed at all. Never nil, so callers Map.get straight off
+  # the result without a fetch_volume-style `|| %{}` guard.
+  defp fetch_blessing(state, workload) do
+    case :ets.lookup(state.blessing, workload) do
+      [{^workload, fact}] -> fact
+      [] -> %{quarantined: false}
     end
   end
 
-  # Structured warning on a false -> true quarantine transition ONLY (Task 16's
-  # alert wiring reads this event name; a simple Logger.warning is all this
-  # task owns, per the plan). Never logs on an already-quarantined or a
-  # never-quarantined report, so a workload stuck quarantined does not spam.
-  defp log_quarantine_transition(%{quarantined: was}, %{quarantined: true} = merged, workload) when was != true do
-    Logger.warning("embervm stateful volume quarantined: unblessed generation reported past the last blessed one",
-      event: :generation_quarantined,
-      workload: workload,
-      generation: Map.get(merged, :generation),
-      blessed_generation: Map.get(merged, :blessed_generation)
-    )
-  end
+  # Re-derive and persist `workload`'s quarantine flag in the SEPARATE blessing
+  # table (never @volumes_table) from a fresh node report: `reported_gen` is the
+  # volume's CURRENT generation this upsert just recorded, `blessed_on_wire` is
+  # the node's own generation_blessed fact for that generation. Quarantined iff
+  # the wire says NOT blessed AND `reported_gen` is STRICTLY PAST the last
+  # generation this control plane blessed. A workload never blessed at all
+  # (`blessed_generation` absent) never quarantines here (the moduledoc's
+  # grandfather rule: absent means "not yet under CP governance", not "behind
+  # it"). Logs a structured warning on a false -> true transition only (Task
+  # 16's alert wiring reads the event name), never on an already-quarantined or
+  # a never-quarantined report, so a stuck-quarantined workload does not spam.
+  defp update_quarantine(state, workload, reported_gen, blessed_on_wire) do
+    fact = fetch_blessing(state, workload)
+    blessed_gen = Map.get(fact, :blessed_generation)
 
-  defp log_quarantine_transition(_base, _merged, _workload), do: :ok
+    quarantined? =
+      not blessed_on_wire and is_integer(blessed_gen) and reported_gen > blessed_gen
+
+    if quarantined? and not Map.get(fact, :quarantined, false) do
+      Logger.warning("embervm stateful volume quarantined: unblessed generation reported past the last blessed one",
+        event: :generation_quarantined,
+        workload: workload,
+        generation: reported_gen,
+        blessed_generation: blessed_gen
+      )
+    end
+
+    :ets.insert(state.blessing, {workload, Map.put(fact, :quarantined, quarantined?)})
+    state
+  end
 
   # Bump the ETS volume row's pair-key generation to the value an attach (a
   # cold/fresh boot or a relight) just booted the volume at, in REAL TIME. Every

--- a/projects/embervm/control/lib/embervm/stateful_store.ex
+++ b/projects/embervm/control/lib/embervm/stateful_store.ex
@@ -52,6 +52,37 @@ defmodule Embervm.StatefulStore do
   instance whose pair is broken (reason `pair_broken`). This module owns the
   primitive only; a later task owns the sweep cadence that calls it.
 
+  ## generation blessing and quarantine (R7, ADR embervm/011)
+
+  Standing decision 4 inverts who issues a volume's generation: the control
+  plane is now the SOLE issuer (`bless_generation/3`), and the daemon records
+  what it is told rather than inventing a value. `next_blessed_generation/2`
+  reads the volume row's `blessed_generation` (the last value THIS control
+  plane blessed, durable via the `generation_blessed` op) and returns one past
+  it; `bless_generation/3` appends that op BEFORE the caller dispatches the
+  boot request (see `Embervm.StatefulManager.plan_wake/2`'s ordering comment:
+  op-log-before-dispatch is the fence, a crash between the two leaves a
+  harmlessly-unused blessed number, never a hole).
+
+  A volume is QUARANTINED when a node reports its generation has moved PAST
+  the last value this control plane blessed, with `generation_blessed: false`
+  on the wire (a self-bump the daemon made outside the blessing ledger, e.g. a
+  legacy noded that has not yet enabled `EMBERVM_NODED_REQUIRE_BLESSING`, or a
+  split-brain write). `upsert_volume/3` derives `quarantined` on every node
+  refresh: true when the reported generation exceeds `blessed_generation` AND
+  the node's own `generation_blessed` fact is false; a node reporting
+  `generation_blessed: true` at or below the blessed watermark clears it. Once
+  quarantined, `Embervm.StatefulManager.plan_wake/2` parks the wake rather than
+  placing it (fail closed, no auto-heal in v1: resolution is a runbook
+  decision). A volume that has NEVER been blessed (no CP generation-blessing op
+  ever landed, e.g. every pre-R7 volume) has `blessed_generation` nil and is
+  NEVER quarantined by this alone: `quarantined?/2` treats nil as "not yet
+  under CP governance" rather than "behind it", so an existing volume is
+  grandfathered the first time it is reported (adoption seeds the ledger from
+  that eager first NodeStatus in `Embervm.StatefulManager.plan_wake/2` before
+  any quarantine check runs), never punished retroactively for predating
+  blessing.
+
   ## unpublish is ETS-only (a decision)
 
   Unlike `ServingStore.unpublish/3`, which is durable (`serving_unpublished` ->
@@ -78,6 +109,7 @@ defmodule Embervm.StatefulStore do
   """
 
   use GenServer
+  require Logger
 
   alias Embervm.OpLog.Op
   alias Embervm.StatefulState
@@ -310,11 +342,71 @@ defmodule Embervm.StatefulStore do
   written by the op-log's `volume_created` projection; this is the live-fact
   primitive Task 8 drives from NodeStatus scrapes, the way `set_health/2` /
   `touch_active/3` update lossy node facts). Merges the given fields over any
-  existing row (or inserts a fresh one). Returns the merged volume row.
+  existing row (or inserts a fresh one). When `fields` carries
+  `generation_blessed` (R7, the node's per-volume wire fact), also derives and
+  merges `quarantined` per the moduledoc's rule (a reported generation past the
+  last CP-blessed one, with `generation_blessed: false`, quarantines; anything
+  else clears it). Returns the merged volume row.
   """
   @spec upsert_volume(GenServer.server(), String.t(), map()) :: map()
   def upsert_volume(store \\ __MODULE__, workload, fields) do
     GenServer.call(store, {:upsert_volume, workload, fields})
+  end
+
+  @doc """
+  The next generation this control plane should bless for `workload`'s volume:
+  one past the volume row's durable `blessed_generation` (nil/absent reads as 0,
+  so the very first blessing for a never-blessed volume is 1). A PURE ETS read;
+  it does not append anything (see `bless_generation/3`).
+  """
+  @spec next_blessed_generation(GenServer.server(), String.t()) :: pos_integer()
+  def next_blessed_generation(store \\ __MODULE__, workload) do
+    GenServer.call(store, {:next_blessed_generation, workload})
+  end
+
+  @doc """
+  Durably records that this control plane is about to issue `generation` as
+  `workload`'s next writable-attach generation (R7, ADR embervm/011): appends
+  the `generation_blessed` op (write-through) and, only on success, bumps the
+  ETS volume row's `blessed_generation` to `generation` and clears
+  `quarantined` (a fresh CP-issued blessing is by definition not behind
+  itself). MUST be called BEFORE the caller dispatches the boot request
+  carrying this value as `blessed_generation` (the op-log-before-dispatch
+  fence; see `Embervm.StatefulManager.plan_wake/2`). Returns `{:ok, volume}` or
+  `{:error, reason}` on an append failure (the caller must not dispatch a boot
+  whose blessing never durably landed).
+  """
+  @spec bless_generation(GenServer.server(), String.t(), pos_integer()) :: {:ok, map()} | {:error, term()}
+  def bless_generation(store \\ __MODULE__, workload, generation) do
+    GenServer.call(store, {:bless_generation, workload, generation})
+  end
+
+  @doc """
+  Whether `workload`'s volume is currently quarantined (R7): a node reported a
+  generation past this control plane's last blessed one with
+  `generation_blessed: false` on the wire. False for an unknown volume (nothing
+  to quarantine) and false for a volume that has never been blessed (see the
+  moduledoc's grandfather note). A PURE ETS read of the flag `upsert_volume/3`
+  derives; this never recomputes it.
+  """
+  @spec quarantined?(GenServer.server(), String.t()) :: boolean()
+  def quarantined?(store \\ __MODULE__, workload) do
+    GenServer.call(store, {:quarantined?, workload})
+  end
+
+  @doc """
+  Seeds `workload`'s blessed-generation watermark to `generation` WITHOUT
+  appending an op-log entry, iff the volume has never been blessed
+  (`blessed_generation` nil/absent). This is the adoption grandfather path (R7):
+  the FIRST NodeStatus report for a pre-R7 (or otherwise never-blessed) volume
+  seeds the ledger from the node's own eager report rather than quarantining a
+  volume that predates blessing entirely. A no-op (returns the existing row
+  unchanged) once a volume has ever been blessed, so it can never roll a real
+  watermark backward or paper over a genuine post-blessing divergence.
+  """
+  @spec seed_blessed_generation_if_unset(GenServer.server(), String.t(), non_neg_integer()) :: map() | nil
+  def seed_blessed_generation_if_unset(store \\ __MODULE__, workload, generation) do
+    GenServer.call(store, {:seed_blessed_generation_if_unset, workload, generation})
   end
 
   @doc """
@@ -470,6 +562,13 @@ defmodule Embervm.StatefulStore do
       generation: vol.generation || 0,
       size_bytes: vol.size_bytes,
       allocated_bytes: vol.allocated_bytes,
+      # blessed_generation is durable (the generation_blessed op projection);
+      # quarantined is NOT (it is derived from a node's live report, see
+      # derive_quarantine/2), so a rebuild always starts un-quarantined and lets
+      # the next NodeStatus refresh re-derive it, exactly like `healthy` for a
+      # stateful instance.
+      blessed_generation: Map.get(vol, :blessed_generation),
+      quarantined: false,
       updated_at: vol.updated_at
     }
   end
@@ -631,12 +730,84 @@ defmodule Embervm.StatefulStore do
           generation: 0,
           size_bytes: nil,
           allocated_bytes: nil,
+          blessed_generation: nil,
+          quarantined: false,
           updated_at: ts
         }
 
-    merged = base |> Map.merge(fields) |> Map.put(:workload, workload) |> Map.put(:updated_at, ts)
+    merged =
+      base
+      |> Map.merge(fields)
+      |> Map.put(:workload, workload)
+      |> Map.put(:updated_at, ts)
+      |> derive_quarantine(fields)
+
+    log_quarantine_transition(base, merged, workload)
+
     :ets.insert(state.volumes, {workload, merged})
     {:reply, merged, state}
+  end
+
+  def handle_call({:next_blessed_generation, workload}, _from, state) do
+    current = (fetch_volume(state, workload) || %{}) |> Map.get(:blessed_generation, 0) || 0
+    {:reply, current + 1, state}
+  end
+
+  def handle_call({:bless_generation, workload, generation}, _from, state) do
+    ts = state.clock.()
+
+    op = %Op{
+      kind: :generation_blessed,
+      tenant: "homelab",
+      # No per-request caller crosses this boundary (the wake plan issues the
+      # blessing internally); the op's principal records the workload's
+      # synthesized system owner, matching every other stateful lifecycle op.
+      principal: "system:stateful:#{workload}",
+      workload: workload,
+      ts: ts,
+      payload: %{generation: generation}
+    }
+
+    case Embervm.OpLog.SQLite.append(state.op_log, op) do
+      {:ok, _seq} ->
+        base = fetch_volume(state, workload) || %{workload: workload, generation: 0}
+
+        merged =
+          base
+          |> Map.put(:blessed_generation, generation)
+          |> Map.put(:quarantined, false)
+          |> Map.put(:workload, workload)
+          |> Map.put(:updated_at, ts)
+
+        :ets.insert(state.volumes, {workload, merged})
+        {:reply, {:ok, merged}, state}
+
+      {:error, _reason} = error ->
+        {:reply, error, state}
+    end
+  end
+
+  def handle_call({:quarantined?, workload}, _from, state) do
+    quarantined? = (fetch_volume(state, workload) || %{}) |> Map.get(:quarantined, false) || false
+    {:reply, quarantined?, state}
+  end
+
+  def handle_call({:seed_blessed_generation_if_unset, workload, generation}, _from, state) do
+    case fetch_volume(state, workload) do
+      %{blessed_generation: bg} = volume when is_integer(bg) ->
+        {:reply, volume, state}
+
+      volume ->
+        merged =
+          (volume || %{workload: workload, generation: generation})
+          |> Map.put(:blessed_generation, generation)
+          |> Map.put(:quarantined, false)
+          |> Map.put(:workload, workload)
+          |> Map.put(:updated_at, state.clock.())
+
+        :ets.insert(state.volumes, {workload, merged})
+        {:reply, merged, state}
+    end
   end
 
   def handle_call({:create_volume, workload, fields}, _from, state) do
@@ -1086,6 +1257,48 @@ defmodule Embervm.StatefulStore do
       [] -> nil
     end
   end
+
+  # Derive the merged volume row's `quarantined` flag from the node fact carried
+  # in THIS upsert's `fields` (not the merged row: `generation_blessed` is a
+  # per-report wire fact, never a durable ETS field of its own, so it must be
+  # read off the incoming report). Quarantined iff the report says the volume is
+  # NOT blessed (`generation_blessed == false` on the wire) AND its generation is
+  # STRICTLY PAST the last generation this control plane blessed. A volume never
+  # blessed at all (`blessed_generation` nil) never quarantines here (the
+  # moduledoc's grandfather rule: nil means "not yet under CP governance", not
+  # "behind it"). Absent `generation_blessed` in `fields` (an upsert that carries
+  # no fresh node report, e.g. bump_volume_ets's real-time mirror) leaves the
+  # existing `quarantined` value untouched.
+  defp derive_quarantine(merged, fields) do
+    case Map.get(fields, :generation_blessed) do
+      nil ->
+        merged
+
+      blessed_on_wire ->
+        blessed_gen = Map.get(merged, :blessed_generation)
+        reported_gen = Map.get(merged, :generation, 0)
+
+        quarantined? =
+          not blessed_on_wire and is_integer(blessed_gen) and reported_gen > blessed_gen
+
+        Map.put(merged, :quarantined, quarantined?)
+    end
+  end
+
+  # Structured warning on a false -> true quarantine transition ONLY (Task 16's
+  # alert wiring reads this event name; a simple Logger.warning is all this
+  # task owns, per the plan). Never logs on an already-quarantined or a
+  # never-quarantined report, so a workload stuck quarantined does not spam.
+  defp log_quarantine_transition(%{quarantined: was}, %{quarantined: true} = merged, workload) when was != true do
+    Logger.warning("embervm stateful volume quarantined: unblessed generation reported past the last blessed one",
+      event: :generation_quarantined,
+      workload: workload,
+      generation: Map.get(merged, :generation),
+      blessed_generation: Map.get(merged, :blessed_generation)
+    )
+  end
+
+  defp log_quarantine_transition(_base, _merged, _workload), do: :ok
 
   # Bump the ETS volume row's pair-key generation to the value an attach (a
   # cold/fresh boot or a relight) just booted the volume at, in REAL TIME. Every

--- a/projects/embervm/control/lib/embervm/stateful_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/stateful_sweeper.ex
@@ -202,6 +202,23 @@ defmodule Embervm.StatefulSweeper do
     GenServer.call(server, :sweep, :infinity)
   end
 
+  @doc """
+  Whether `workload`'s volume is eligible to have any of its artifacts (its
+  banked STATEFUL bundle, or in a later rung its VOLUME snapshot/backup)
+  planned for export (R7, ADR embervm/011, standing decision 4): false while
+  the volume is quarantined (`StatefulStore.quarantined?/2`), true otherwise
+  (including an unknown workload, which has no volume to quarantine). No
+  ExportArtifact planning exists in this control plane yet (Task 10 lands the
+  Longhorn-backed snapshot/backup planning); this predicate is the guard
+  future export-planning call sites (and `eager_evict_broken_pairs`'s bundle
+  eviction, see `do_sweep/1`) must consult FIRST, so quarantine enforcement
+  lands before there is anything to enforce it against.
+  """
+  @spec export_allowed?(GenServer.server(), String.t()) :: boolean()
+  def export_allowed?(store \\ StatefulStore, workload) do
+    not StatefulStore.quarantined?(store, workload)
+  end
+
   # -- GenServer callbacks ---------------------------------------------------
 
   @impl true

--- a/projects/embervm/control/test/embervm/op_log/stateful_projection_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/stateful_projection_test.exs
@@ -454,6 +454,13 @@ defmodule Embervm.OpLog.StatefulProjectionTest do
   end
 
   # -- generation blessing (R7, ADR embervm/011) ------------------------------
+  #
+  # generation_blessed projects into the volume_blessing table, a SEPARATE
+  # table from volumes (see Embervm.OpLog.SQLite's comment on volume_blessing
+  # for why): a workload can be blessed BEFORE its FRESH boot's volume_created
+  # ever lands, and folding blessing into `volumes` would fabricate a phantom,
+  # node_id-less row that breaks the control plane's nil-means-no-volume-yet
+  # placement contract.
 
   defp blessed_op(ts, generation) do
     %Op{
@@ -466,26 +473,36 @@ defmodule Embervm.OpLog.StatefulProjectionTest do
     }
   end
 
-  test "generation_blessed upserts volumes.blessed_generation, workload-scoped (stateful_instance_id nil)", %{path: path} do
+  defp blessing_by_workload(server) do
+    {:ok, rows} = SQLite.load_volume_blessing(server)
+    Map.new(rows, &{&1.workload, &1})
+  end
+
+  test "generation_blessed upserts volume_blessing, workload-scoped (stateful_instance_id nil), never touching volumes",
+       %{path: path} do
     server = start_server(path)
 
     {:ok, _} = SQLite.append(server, blessed_op(90, 1))
+    blessing = blessing_by_workload(server)
+    assert blessing["scratch-postgres"].blessed_generation == 1
+
+    # A blessing landing before any volume_created never creates a volumes row
+    # (a workload's FIRST wake blesses before the daemon's FRESH boot has
+    # created the volume; volumes stays empty until volume_created lands).
     volumes = volume_by_workload(server)
-    assert volumes["scratch-postgres"].blessed_generation == 1
-    # A blessing landing before any volume_created creates the row (a workload's
-    # FIRST wake blesses before the daemon's FRESH boot has created the volume).
-    assert volumes["scratch-postgres"].generation == 0
+    assert volumes == %{}
 
     {:ok, ops} = SQLite.read_from(server, 0)
     blessed = Enum.find(ops, &(&1.kind == :generation_blessed))
     assert blessed.stateful_instance_id == nil
     assert blessed.workload == "scratch-postgres"
-    assert blessed.payload.generation == 1
+    assert blessed.payload["generation"] == 1
 
     :ok = GenServer.stop(server)
   end
 
-  test "generation_blessed after volume_created updates blessed_generation without disturbing the live generation", %{path: path} do
+  test "generation_blessed after volume_created updates the blessing ledger without disturbing the live generation",
+       %{path: path} do
     server = start_server(path)
 
     {:ok, _} = SQLite.append(server, volume_created_op(90, 3))
@@ -493,33 +510,50 @@ defmodule Embervm.OpLog.StatefulProjectionTest do
 
     volumes = volume_by_workload(server)
     assert volumes["scratch-postgres"].generation == 3
-    assert volumes["scratch-postgres"].blessed_generation == 4
+    assert blessing_by_workload(server)["scratch-postgres"].blessed_generation == 4
 
     :ok = GenServer.stop(server)
   end
 
-  test "a volume_created upsert after a blessing never clobbers blessed_generation", %{path: path} do
+  test "a volume_created upsert after a blessing never disturbs the separate blessing ledger", %{path: path} do
     server = start_server(path)
 
     {:ok, _} = SQLite.append(server, blessed_op(90, 1))
     {:ok, _} = SQLite.append(server, volume_created_op(91, 1))
 
-    volumes = volume_by_workload(server)
-    assert volumes["scratch-postgres"].blessed_generation == 1
-    assert volumes["scratch-postgres"].generation == 1
+    assert blessing_by_workload(server)["scratch-postgres"].blessed_generation == 1
+    assert volume_by_workload(server)["scratch-postgres"].generation == 1
 
     :ok = GenServer.stop(server)
   end
 
-  test "kill/restart rebuilds blessed_generation from the durable projection", %{path: path} do
+  test "kill/restart rebuilds the blessing ledger from the durable projection", %{path: path} do
     server = start_server(path)
     {:ok, _} = SQLite.append(server, volume_created_op(90, 1))
     {:ok, _} = SQLite.append(server, blessed_op(91, 2))
     :ok = GenServer.stop(server)
 
     server2 = start_server(path)
-    volumes = volume_by_workload(server2)
-    assert volumes["scratch-postgres"].blessed_generation == 2
+    assert blessing_by_workload(server2)["scratch-postgres"].blessed_generation == 2
+    :ok = GenServer.stop(server2)
+  end
+
+  test "a reopened op-log's read_from still round-trips the generation_blessed payload (string keys, value intact)",
+       %{path: path} do
+    server = start_server(path)
+    {:ok, _} = SQLite.append(server, blessed_op(90, 3))
+    :ok = GenServer.stop(server)
+
+    # Reopening simulates a control-plane restart reading the ops table fresh
+    # (the future replica-catch-up path, per Embervm.OpLog's moduledoc). The
+    # payload comes back through decode_payload/1, which ALWAYS yields
+    # string-keyed maps (even for an ETF-encoded payload written with atom
+    # keys), so a reader must use string keys here, matching every other op
+    # kind's read_from assertions in this suite (never `payload.generation`).
+    server2 = start_server(path)
+    {:ok, ops} = SQLite.read_from(server2, 0)
+    blessed = Enum.find(ops, &(&1.kind == :generation_blessed))
+    assert blessed.payload["generation"] == 3
     :ok = GenServer.stop(server2)
   end
 end

--- a/projects/embervm/control/test/embervm/op_log/stateful_projection_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/stateful_projection_test.exs
@@ -452,4 +452,74 @@ defmodule Embervm.OpLog.StatefulProjectionTest do
 
     :ok = GenServer.stop(server)
   end
+
+  # -- generation blessing (R7, ADR embervm/011) ------------------------------
+
+  defp blessed_op(ts, generation) do
+    %Op{
+      kind: :generation_blessed,
+      tenant: "t1",
+      principal: "p1",
+      workload: "scratch-postgres",
+      ts: ts,
+      payload: %{generation: generation}
+    }
+  end
+
+  test "generation_blessed upserts volumes.blessed_generation, workload-scoped (stateful_instance_id nil)", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, blessed_op(90, 1))
+    volumes = volume_by_workload(server)
+    assert volumes["scratch-postgres"].blessed_generation == 1
+    # A blessing landing before any volume_created creates the row (a workload's
+    # FIRST wake blesses before the daemon's FRESH boot has created the volume).
+    assert volumes["scratch-postgres"].generation == 0
+
+    {:ok, ops} = SQLite.read_from(server, 0)
+    blessed = Enum.find(ops, &(&1.kind == :generation_blessed))
+    assert blessed.stateful_instance_id == nil
+    assert blessed.workload == "scratch-postgres"
+    assert blessed.payload.generation == 1
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "generation_blessed after volume_created updates blessed_generation without disturbing the live generation", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, volume_created_op(90, 3))
+    {:ok, _} = SQLite.append(server, blessed_op(91, 4))
+
+    volumes = volume_by_workload(server)
+    assert volumes["scratch-postgres"].generation == 3
+    assert volumes["scratch-postgres"].blessed_generation == 4
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "a volume_created upsert after a blessing never clobbers blessed_generation", %{path: path} do
+    server = start_server(path)
+
+    {:ok, _} = SQLite.append(server, blessed_op(90, 1))
+    {:ok, _} = SQLite.append(server, volume_created_op(91, 1))
+
+    volumes = volume_by_workload(server)
+    assert volumes["scratch-postgres"].blessed_generation == 1
+    assert volumes["scratch-postgres"].generation == 1
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "kill/restart rebuilds blessed_generation from the durable projection", %{path: path} do
+    server = start_server(path)
+    {:ok, _} = SQLite.append(server, volume_created_op(90, 1))
+    {:ok, _} = SQLite.append(server, blessed_op(91, 2))
+    :ok = GenServer.stop(server)
+
+    server2 = start_server(path)
+    volumes = volume_by_workload(server2)
+    assert volumes["scratch-postgres"].blessed_generation == 2
+    :ok = GenServer.stop(server2)
+  end
 end

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -213,8 +213,11 @@ defmodule Embervm.StatefulManagerTest do
 
     {req, blessed_ops} = Agent.get(captured, & &1)
     assert req.blessed_generation == 1
-    assert Enum.any?(blessed_ops, &(&1.payload.generation == 1))
-    assert StatefulStore.get_volume(ctx.store, "wl-a").blessed_generation == 1
+    assert Enum.any?(blessed_ops, &(&1.payload["generation"] == 1))
+    # The blessing ledger lives separately from the volume row (see
+    # StatefulStore's moduledoc); next_blessed_generation/2 - 1 reads the last
+    # blessed value without a dedicated accessor.
+    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") - 1 == 1
 
     # A second wake (destroy + rewake) issues the NEXT blessed generation, strictly
     # monotonic, never repeating or resetting.
@@ -230,7 +233,7 @@ defmodule Embervm.StatefulManagerTest do
     stateful_node(ctx, "node-4")
 
     assert {:ok, _} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
-    assert StatefulStore.get_volume(ctx.store, "wl-a").blessed_generation == 1
+    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") - 1 == 1
     refute StatefulStore.quarantined?(ctx.store, "wl-a")
 
     # Simulate a node report of a self-bumped generation the control plane never

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -176,6 +176,126 @@ defmodule Embervm.StatefulManagerTest do
     assert row.state == "serving"
   end
 
+  # -- generation blessing (R7, ADR embervm/011, standing decision 4) ---------
+
+  test "plan_wake issues a monotonic blessed generation, durably op-logged BEFORE the boot request carries it" do
+    {:ok, captured} = Agent.start_link(fn -> nil end)
+    {:ok, op_log_ref} = Agent.start_link(fn -> nil end)
+
+    ctx =
+      start_stack(
+        start_stateful_fun: fn _ch, req ->
+          # The op-log-before-dispatch fence, asserted from inside the dispatched
+          # RPC itself: by the time this seam runs, the generation_blessed op for
+          # req.blessed_generation must ALREADY be durable
+          # (bless_wake_generation/3 appends and awaits the op-log BEFORE
+          # start_wake_dispatch/5 builds this request), never the reverse.
+          {:ok, ops} = SQLite.read_from(Agent.get(op_log_ref, & &1), 0)
+          blessed_ops = Enum.filter(ops, &(&1.kind == :generation_blessed))
+          Agent.update(captured, fn _ -> {req, blessed_ops} end)
+
+          {:ok,
+           %StartStatefulResponse{
+             vm_id: "vm-woken",
+             ip: "10.88.0.5",
+             port: 5432,
+             generation: req.blessed_generation,
+             was_relight: false
+           }}
+        end
+      )
+
+    Agent.update(op_log_ref, fn _ -> ctx.op_log end)
+    stateful_workload(ctx, "wl-a")
+    stateful_node(ctx, "node-4")
+
+    assert {:ok, %{ip: "10.88.0.5", port: 5432}} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
+
+    {req, blessed_ops} = Agent.get(captured, & &1)
+    assert req.blessed_generation == 1
+    assert Enum.any?(blessed_ops, &(&1.payload.generation == 1))
+    assert StatefulStore.get_volume(ctx.store, "wl-a").blessed_generation == 1
+
+    # A second wake (destroy + rewake) issues the NEXT blessed generation, strictly
+    # monotonic, never repeating or resetting.
+    StatefulManager.destroy_instance(ctx.mgr, "wl-a")
+    assert {:ok, _} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
+    {req2, _blessed_ops2} = Agent.get(captured, & &1)
+    assert req2.blessed_generation == 2
+  end
+
+  test "an unblessed report (generation past the last blessed one, generation_blessed=false) quarantines the volume and parks the next wake" do
+    ctx = start_stack()
+    stateful_workload(ctx, "wl-a")
+    stateful_node(ctx, "node-4")
+
+    assert {:ok, _} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
+    assert StatefulStore.get_volume(ctx.store, "wl-a").blessed_generation == 1
+    refute StatefulStore.quarantined?(ctx.store, "wl-a")
+
+    # Simulate a node report of a self-bumped generation the control plane never
+    # blessed (generation 2, blessed_generation still 1): the daemon self-bumped
+    # outside the ledger.
+    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 2, generation_blessed: false})
+    assert StatefulStore.quarantined?(ctx.store, "wl-a")
+
+    # A quarantined volume's next wake must park (never place): destroy the live
+    # instance and rewake, which anchors to the volume's node and must refuse.
+    StatefulManager.destroy_instance(ctx.mgr, "wl-a")
+    assert {:error, {:wake_failed, :volume_quarantined}} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
+  end
+
+  test "a node report that agrees with the last blessed generation (or reports generation_blessed=true) never quarantines" do
+    ctx = start_stack()
+    stateful_workload(ctx, "wl-a")
+    stateful_node(ctx, "node-4")
+
+    assert {:ok, _} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
+
+    # Same generation the CP blessed, reported unblessed on the wire: not PAST the
+    # watermark, so no quarantine (an exact-match report is the normal case right
+    # after a blessed attach, before the daemon's own blessed marker write lands
+    # in a subsequent scrape).
+    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 1, generation_blessed: false})
+    refute StatefulStore.quarantined?(ctx.store, "wl-a")
+
+    # A report claiming the reported generation IS blessed clears any prior
+    # quarantine.
+    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 2, generation_blessed: false})
+    assert StatefulStore.quarantined?(ctx.store, "wl-a")
+    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 2, generation_blessed: true})
+    refute StatefulStore.quarantined?(ctx.store, "wl-a")
+  end
+
+  test "a never-blessed volume (pre-R7, blessed_generation nil) is grandfathered on its first report, not quarantined" do
+    ctx = start_stack()
+    stateful_workload(ctx, "wl-a")
+    stateful_node(ctx, "node-4")
+
+    # A pre-R7 volume: created via the durable volume_created op with no blessing
+    # ledger entry at all (blessed_generation stays nil/absent).
+    {:ok, _} = StatefulStore.create_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 5})
+    refute StatefulStore.quarantined?(ctx.store, "wl-a")
+
+    # A node reporting generation 5 unblessed must NOT quarantine: nil means "not
+    # yet under CP governance", never "behind it" (the moduledoc's grandfather
+    # rule) -- distinct from a volume the CP has already blessed at least once.
+    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 5, generation_blessed: false})
+    refute StatefulStore.quarantined?(ctx.store, "wl-a")
+  end
+
+  test "export is never planned for a quarantined volume's artifacts" do
+    ctx = start_stack()
+    stateful_workload(ctx, "wl-a")
+    stateful_node(ctx, "node-4")
+
+    assert {:ok, _} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
+    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 2, generation_blessed: false})
+    assert StatefulStore.quarantined?(ctx.store, "wl-a")
+
+    refute Embervm.StatefulSweeper.export_allowed?(ctx.store, "wl-a")
+  end
+
   # -- mmds_env (R4, D-R4.PR-7.1: MMDS-lite over boot-args) --------------------
 
   test "a FRESH/COLD wake with a secretRef reads the secret and populates mmds_env" do

--- a/projects/embervm/control/test/embervm/stateful_store_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_store_test.exs
@@ -426,21 +426,28 @@ defmodule Embervm.StatefulStoreTest do
     assert StatefulStore.next_blessed_generation(store, "wl-a") == 3
   end
 
-  test "bless_generation durably appends generation_blessed and updates the volume row", %{path: path} do
+  test "bless_generation durably appends generation_blessed and updates the blessing ledger, separate from the volume row",
+       %{path: path} do
     {op_log, store} = start_pair(path)
 
-    assert {:ok, volume} = StatefulStore.bless_generation(store, "wl-a", 1)
-    assert volume.blessed_generation == 1
-    refute volume.quarantined
+    assert {:ok, fact} = StatefulStore.bless_generation(store, "wl-a", 1)
+    assert fact.blessed_generation == 1
+    refute fact.quarantined
+
+    # No real volume row was created by blessing alone (the whole point: a
+    # workload's first wake blesses before its FRESH boot's volume_created
+    # lands), so get_volume/2 still reads nil.
+    assert StatefulStore.get_volume(store, "wl-a") == nil
 
     {:ok, [op]} = SQLite.read_from(op_log, 0)
     assert op.kind == :generation_blessed
     assert op.workload == "wl-a"
-    assert op.payload.generation == 1
+    assert op.payload["generation"] == 1
 
-    # A rebuild sees the durable blessed_generation.
+    # A rebuild sees the durable blessed_generation via next_blessed_generation.
     {:ok, store2} = StatefulStore.start_link(op_log: op_log, name: nil, clock: sequential_clock())
-    assert StatefulStore.get_volume(store2, "wl-a").blessed_generation == 1
+    assert StatefulStore.next_blessed_generation(store2, "wl-a") - 1 == 1
+    assert StatefulStore.get_volume(store2, "wl-a") == nil
   end
 
   test "upsert_volume quarantines a report past the last blessed generation with generation_blessed: false", %{path: path} do
@@ -449,7 +456,6 @@ defmodule Embervm.StatefulStoreTest do
 
     StatefulStore.upsert_volume(store, "wl-a", %{node_id: "node-4", generation: 4, generation_blessed: false})
     assert StatefulStore.quarantined?(store, "wl-a")
-    assert StatefulStore.get_volume(store, "wl-a").quarantined
 
     # A report agreeing with the blessed watermark (or claiming the CURRENT
     # generation IS blessed) clears it.

--- a/projects/embervm/control/test/embervm/stateful_store_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_store_test.exs
@@ -412,4 +412,86 @@ defmodule Embervm.StatefulStoreTest do
     assert sf_b.state == :banked
     assert sf_b.snapshot_generation == 2
   end
+
+  # -- generation blessing (R7, ADR embervm/011, standing decision 4) ---------
+
+  test "next_blessed_generation is 1 for a never-blessed workload and increments monotonically", %{path: path} do
+    {_op_log, store} = start_pair(path)
+    assert StatefulStore.next_blessed_generation(store, "wl-a") == 1
+
+    {:ok, _} = StatefulStore.bless_generation(store, "wl-a", 1)
+    assert StatefulStore.next_blessed_generation(store, "wl-a") == 2
+
+    {:ok, _} = StatefulStore.bless_generation(store, "wl-a", 2)
+    assert StatefulStore.next_blessed_generation(store, "wl-a") == 3
+  end
+
+  test "bless_generation durably appends generation_blessed and updates the volume row", %{path: path} do
+    {op_log, store} = start_pair(path)
+
+    assert {:ok, volume} = StatefulStore.bless_generation(store, "wl-a", 1)
+    assert volume.blessed_generation == 1
+    refute volume.quarantined
+
+    {:ok, [op]} = SQLite.read_from(op_log, 0)
+    assert op.kind == :generation_blessed
+    assert op.workload == "wl-a"
+    assert op.payload.generation == 1
+
+    # A rebuild sees the durable blessed_generation.
+    {:ok, store2} = StatefulStore.start_link(op_log: op_log, name: nil, clock: sequential_clock())
+    assert StatefulStore.get_volume(store2, "wl-a").blessed_generation == 1
+  end
+
+  test "upsert_volume quarantines a report past the last blessed generation with generation_blessed: false", %{path: path} do
+    {_op_log, store} = start_pair(path)
+    {:ok, _} = StatefulStore.bless_generation(store, "wl-a", 3)
+
+    StatefulStore.upsert_volume(store, "wl-a", %{node_id: "node-4", generation: 4, generation_blessed: false})
+    assert StatefulStore.quarantined?(store, "wl-a")
+    assert StatefulStore.get_volume(store, "wl-a").quarantined
+
+    # A report agreeing with the blessed watermark (or claiming the CURRENT
+    # generation IS blessed) clears it.
+    StatefulStore.upsert_volume(store, "wl-a", %{node_id: "node-4", generation: 3, generation_blessed: false})
+    refute StatefulStore.quarantined?(store, "wl-a")
+
+    {:ok, _} = StatefulStore.bless_generation(store, "wl-a", 4)
+    StatefulStore.upsert_volume(store, "wl-a", %{node_id: "node-4", generation: 4, generation_blessed: true})
+    refute StatefulStore.quarantined?(store, "wl-a")
+  end
+
+  test "a never-blessed volume (blessed_generation nil) never quarantines from a report alone", %{path: path} do
+    {_op_log, store} = start_pair(path)
+    {:ok, _} = StatefulStore.create_volume(store, "wl-a", %{node_id: "node-4", generation: 5})
+
+    StatefulStore.upsert_volume(store, "wl-a", %{node_id: "node-4", generation: 5, generation_blessed: false})
+    refute StatefulStore.quarantined?(store, "wl-a")
+
+    StatefulStore.upsert_volume(store, "wl-a", %{node_id: "node-4", generation: 9, generation_blessed: false})
+    refute StatefulStore.quarantined?(store, "wl-a")
+  end
+
+  test "quarantined? is false for an unknown workload", %{path: path} do
+    {_op_log, store} = start_pair(path)
+    refute StatefulStore.quarantined?(store, "no-such-workload")
+  end
+
+  test "seed_blessed_generation_if_unset seeds a never-blessed volume from its first eager report and never rolls a real watermark backward", %{path: path} do
+    {_op_log, store} = start_pair(path)
+    {:ok, _} = StatefulStore.create_volume(store, "wl-a", %{node_id: "node-4", generation: 7})
+
+    seeded = StatefulStore.seed_blessed_generation_if_unset(store, "wl-a", 7)
+    assert seeded.blessed_generation == 7
+    refute seeded.quarantined
+
+    # A once-blessed volume is never touched by the seed path again, even if a
+    # caller passes a different value.
+    unchanged = StatefulStore.seed_blessed_generation_if_unset(store, "wl-a", 99)
+    assert unchanged.blessed_generation == 7
+
+    {:ok, _} = StatefulStore.bless_generation(store, "wl-b", 2)
+    still_blessed = StatefulStore.seed_blessed_generation_if_unset(store, "wl-b", 1)
+    assert still_blessed.blessed_generation == 2
+  end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.125
+      targetRevision: 0.1.126
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -196,6 +196,15 @@ type Config struct {
 	// StoreBucket is the single bucket every artifact key lives under (Fork 3).
 	// Default "embervm". Env EMBERVM_NODED_STORE_BUCKET.
 	StoreBucket string
+
+	// RequireBlessing rejects any writable stateful attach (FRESH/RELIGHT/COLD)
+	// carrying blessed_generation == 0 with FAILED_PRECONDITION, once the
+	// control plane has started issuing blessed generations (R7, ADR
+	// embervm/011, standing decision 4). Defaults false so a rollout can land
+	// the control-plane side first; the chart flips this true in the SAME
+	// version so a mixed CP/noded state cannot outlive the roll. Env
+	// EMBERVM_NODED_REQUIRE_BLESSING.
+	RequireBlessing bool
 }
 
 // Load resolves configuration from the environment, applying defaults for all
@@ -240,6 +249,8 @@ func Load() (Config, error) {
 
 		StoreEndpoint: getenvDefault("EMBERVM_NODED_STORE_ENDPOINT", "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333"),
 		StoreBucket:   getenvDefault("EMBERVM_NODED_STORE_BUCKET", "embervm"),
+
+		RequireBlessing: boolDefault("EMBERVM_NODED_REQUIRE_BLESSING", false),
 	}
 
 	if c.Node == "" {
@@ -399,6 +410,17 @@ func atoiDefault(key string, def int) int {
 	if v := os.Getenv(key); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			return n
+		}
+	}
+	return def
+}
+
+// boolDefault returns the named env var parsed as a bool, or def when unset or
+// unparseable.
+func boolDefault(key string, def bool) bool {
+	if v := os.Getenv(key); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			return b
 		}
 	}
 	return def

--- a/projects/embervm/noded/config/config_test.go
+++ b/projects/embervm/noded/config/config_test.go
@@ -136,6 +136,23 @@ func TestLoadDefaults(t *testing.T) {
 	if c.GroupUnhealthyThreshold != 3 {
 		t.Errorf("GroupUnhealthyThreshold = %d, want 3", c.GroupUnhealthyThreshold)
 	}
+	if c.RequireBlessing {
+		t.Error("RequireBlessing should default false so a rollout can land the control-plane side first")
+	}
+}
+
+// TestLoadRequireBlessingOverride proves EMBERVM_NODED_REQUIRE_BLESSING is
+// parsed as a bool (R7, ADR embervm/011): the chart flips this true in the
+// same version the control plane starts blessing.
+func TestLoadRequireBlessingOverride(t *testing.T) {
+	t.Setenv("EMBERVM_NODED_REQUIRE_BLESSING", "true")
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !c.RequireBlessing {
+		t.Error("RequireBlessing should be true when EMBERVM_NODED_REQUIRE_BLESSING=true")
+	}
 }
 
 func TestLoadCompositeSupernetOverride(t *testing.T) {

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1492,6 +1492,7 @@ func (s *Server) volumesStatus() []*nodev1.Volume {
 			AllocatedBytes:     v.AllocatedBytes,
 			Attached:           v.Attached,
 			ExportedGeneration: exportedGen,
+			GenerationBlessed:  v.GenerationBlessed,
 		})
 	}
 	return out

--- a/projects/embervm/noded/server/stateful.go
+++ b/projects/embervm/noded/server/stateful.go
@@ -44,13 +44,15 @@ const (
 // StartStateful brings up the stateful VM with the workload's volume attached
 // writable, attaching a tap NIC exactly as StartServing does, and health-gates
 // by TCP CONNECT to {ip, port} (serving/probe_tcp.go's TCPProber), not HTTP: the
-// stateful contract is opaque L4 (decision 4). Every mode bumps the volume's
-// generation ledger BEFORE the VM boots (volume.Manager.BumpGeneration), so any
-// writable attach the daemon witnesses is unconditionally reflected in the pair
-// key even if the boot that follows fails; there is no un-bump. A readiness
-// failure DESTROYS the VM, releases the tap, and DETACHES the volume (but never
-// rolls the generation back) and returns FAILED_PRECONDITION: there is no
-// half-alive endpoint a caller could observe or publish.
+// stateful contract is opaque L4 (decision 4). Every mode advances the volume's
+// generation ledger BEFORE the VM boots (via attachGeneration: RecordBlessed
+// when the request carries a nonzero blessed_generation, R7 ADR embervm/011,
+// or the legacy self-bump otherwise), so any writable attach the daemon
+// witnesses is unconditionally reflected in the pair key even if the boot that
+// follows fails; there is no un-bump. A readiness failure DESTROYS the VM,
+// releases the tap, and DETACHES the volume (but never rolls the generation
+// back) and returns FAILED_PRECONDITION: there is no half-alive endpoint a
+// caller could observe or publish.
 func (s *Server) StartStateful(ctx context.Context, req *nodev1.StartStatefulRequest) (*nodev1.StartStatefulResponse, error) {
 	if s.servingNet == nil || s.servingDriver == nil || s.statefulDriver == nil || s.volumes == nil {
 		return nil, status.Error(codes.Unimplemented, "noded: stateful not configured")
@@ -80,6 +82,32 @@ func (s *Server) StartStateful(ctx context.Context, req *nodev1.StartStatefulReq
 	default:
 		return nil, status.Error(codes.InvalidArgument, "noded: StartStateful mode must be FRESH, RELIGHT, or COLD")
 	}
+}
+
+// attachGeneration resolves the generation a writable attach records, per R7
+// standing decision 4 (the control plane becomes the sole issuer). A nonzero
+// blessedGeneration on the request is recorded via volume.Manager.RecordBlessed
+// (the CP-issued value, never invented here). Zero means the legacy self-bump
+// lane: allowed only while s.cfg.RequireBlessing is false, and rejected
+// FAILED_PRECONDITION once it is true (the chart flips RequireBlessing in the
+// same version the control plane starts blessing, so a mixed state cannot
+// outlive the roll).
+func (s *Server) attachGeneration(workload string, blessedGeneration uint64) (uint64, error) {
+	if blessedGeneration > 0 {
+		gen, err := s.volumes.RecordBlessed(workload, blessedGeneration)
+		if err != nil {
+			return 0, status.Errorf(codes.Internal, "noded: record blessed generation for %q: %v", workload, err)
+		}
+		return gen, nil
+	}
+	if s.cfg.RequireBlessing {
+		return 0, status.Errorf(codes.FailedPrecondition, "noded: writable attach for %q requires a blessed_generation (EMBERVM_NODED_REQUIRE_BLESSING is set)", workload)
+	}
+	gen, err := s.volumes.BumpGeneration(workload)
+	if err != nil {
+		return 0, status.Errorf(codes.Internal, "noded: bump generation for %q: %v", workload, err)
+	}
+	return gen, nil
 }
 
 // startStatefulFresh creates the workload's volume if absent (refusing
@@ -179,9 +207,9 @@ func (s *Server) startStatefulRelight(ctx context.Context, req *nodev1.StartStat
 			s.volumes.Detach(workload)
 		}
 	}()
-	gen, err := s.volumes.BumpGeneration(workload)
+	gen, err := s.attachGeneration(workload, req.GetBlessedGeneration())
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "noded: bump generation for %q: %v", workload, err)
+		return nil, err
 	}
 
 	// Re-acquire the SAME tap IP the bundle was banked with, exactly as serving
@@ -262,9 +290,9 @@ func (s *Server) coldBootStateful(ctx context.Context, req *nodev1.StartStateful
 			s.volumes.Detach(workload)
 		}
 	}()
-	gen, err := s.volumes.BumpGeneration(workload)
+	gen, err := s.attachGeneration(workload, req.GetBlessedGeneration())
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "noded: bump generation for %q: %v", workload, err)
+		return nil, err
 	}
 
 	tap, ip, err := s.servingNet.AllocateTap(ctx)

--- a/projects/embervm/noded/server/stateful_test.go
+++ b/projects/embervm/noded/server/stateful_test.go
@@ -404,6 +404,78 @@ func TestStartStatefulGenerationBumpedBeforeBootAndNotRolledBackOnFailure(t *tes
 	}
 }
 
+// TestStartStatefulBlessedGenerationRecordedVerbatim proves a nonzero
+// blessed_generation on the request (R7, ADR embervm/011) is recorded onto
+// the ledger EXACTLY as issued, not self-bumped, and the volume reads blessed
+// afterward.
+func TestStartStatefulBlessedGenerationRecordedVerbatim(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, _, _ := newStatefulTestServer(t)
+
+	resp, err := s.StartStateful(context.Background(), &nodev1.StartStatefulRequest{
+		Trace:             &nodev1.Trace{Workload: "wl-state"},
+		Mode:              nodev1.StartStatefulMode_START_STATEFUL_MODE_FRESH,
+		BootImageRef:      "img-a",
+		Port:              port,
+		VolumeSizeBytes:   1 << 20,
+		VolumeMount:       "/data",
+		CreateIfMissing:   true,
+		BlessedGeneration: 7,
+	})
+	if err != nil {
+		t.Fatalf("StartStateful(fresh, blessed): %v", err)
+	}
+	if resp.GetGeneration() != 7 {
+		t.Errorf("generation = %d want 7 (the control-plane-issued blessed_generation, recorded verbatim)", resp.GetGeneration())
+	}
+	if !s.volumes.GenerationBlessed("wl-state") {
+		t.Error("volume should read as blessed after a blessed FRESH attach")
+	}
+	ns := s.nodeStatus()
+	if len(ns.GetVolumes()) != 1 || !ns.GetVolumes()[0].GetGenerationBlessed() {
+		t.Errorf("NodeStatus volumes = %+v want one volume with generation_blessed=true", ns.GetVolumes())
+	}
+}
+
+// TestStartStatefulUnblessedRejectedWhenRequireBlessingSet proves that once
+// the daemon's EMBERVM_NODED_REQUIRE_BLESSING flag is on, a writable attach
+// carrying blessed_generation == 0 is refused FAILED_PRECONDITION rather than
+// falling back to a legacy self-bump.
+func TestStartStatefulUnblessedRejectedWhenRequireBlessingSet(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, _, _ := newStatefulTestServer(t)
+	s.cfg.RequireBlessing = true
+
+	_, err := s.StartStateful(context.Background(), &nodev1.StartStatefulRequest{
+		Trace:           &nodev1.Trace{Workload: "wl-state"},
+		Mode:            nodev1.StartStatefulMode_START_STATEFUL_MODE_FRESH,
+		BootImageRef:    "img-a",
+		Port:            port,
+		VolumeSizeBytes: 1 << 20,
+		VolumeMount:     "/data",
+		CreateIfMissing: true,
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("unblessed attach with RequireBlessing set: got %v want FailedPrecondition", err)
+	}
+}
+
+// TestStartStatefulUnblessedAllowedWhenRequireBlessingUnset proves the legacy
+// self-bump lane still works while RequireBlessing is false (the default
+// during a rollout where the control plane has not yet started blessing).
+func TestStartStatefulUnblessedAllowedWhenRequireBlessingUnset(t *testing.T) {
+	port := tcpHealthServer(t)
+	s, _, _ := newStatefulTestServer(t)
+
+	resp := startFreshStateful(t, s, port, "wl-state")
+	if resp.GetGeneration() != 1 {
+		t.Errorf("generation = %d want 1 (legacy self-bump)", resp.GetGeneration())
+	}
+	if s.volumes.GenerationBlessed("wl-state") {
+		t.Error("a legacy self-bumped attach must not read as blessed")
+	}
+}
+
 // TestStartStatefulRelightMatchedGeneration proves RELIGHT with a matching
 // stamped generation resumes the bundle (was_relight=true, no cold_boot_reason).
 func TestStartStatefulRelightMatchedGeneration(t *testing.T) {

--- a/projects/embervm/noded/volume/volume.go
+++ b/projects/embervm/noded/volume/volume.go
@@ -26,11 +26,17 @@ import (
 	"sync"
 )
 
-// volFile / genFile are the two files under a workload's volume directory: the
-// raw sparse block device backing file, and the generation ledger.
+// volFile / genFile / blessedFile are the files under a workload's volume
+// directory: the raw sparse block device backing file, the generation ledger,
+// and the blessed-generation marker (R7, ADR embervm/011). blessedFile holds
+// the last generation the control plane's blessing ledger issued for this
+// volume; it lags genFile whenever a self-bump happens without a matching
+// CP-issued blessed_generation (the unblessed case a fresh control plane
+// quarantines on adoption).
 const (
-	volFile = "vol.img"
-	genFile = "gen"
+	volFile     = "vol.img"
+	genFile     = "gen"
+	blessedFile = "genblessed"
 )
 
 // Manager owns the on-disk volume layout under root and the in-process
@@ -59,6 +65,10 @@ func (m *Manager) volPath(workload string) string {
 
 func (m *Manager) genPath(workload string) string {
 	return filepath.Join(m.dir(workload), genFile)
+}
+
+func (m *Manager) blessedPath(workload string) string {
+	return filepath.Join(m.dir(workload), blessedFile)
 }
 
 // Exists reports whether a workload's volume file is already on disk.
@@ -192,6 +202,82 @@ func (m *Manager) Generation(workload string) (uint64, error) {
 	return n, nil
 }
 
+// RecordBlessed records a writable attach whose generation the control plane
+// issued (R7, ADR embervm/011, standing decision 4): it writes gen to BOTH the
+// generation ledger and the blessed marker, so GenerationBlessed reports true
+// for this attach. Unlike BumpGeneration, the caller supplies the value (the
+// control plane's blessing ledger is the sole issuer); the daemon never
+// invents or increments it here. gen MUST be strictly greater than the
+// ledger's current value or this errors: a blessed generation that did not
+// advance the ledger would let a stale bundle falsely re-match, which the
+// pairing mechanism must never allow. Same durability discipline as
+// writeGeneration (temp + rename, no un-bump on a later boot failure).
+func (m *Manager) RecordBlessed(workload string, gen uint64) (uint64, error) {
+	cur, err := m.Generation(workload)
+	if err != nil {
+		return 0, err
+	}
+	if gen <= cur {
+		return 0, fmt.Errorf("volume: blessed generation %d for %q must exceed current ledger generation %d", gen, workload, cur)
+	}
+	if err := m.writeGeneration(workload, gen); err != nil {
+		return 0, fmt.Errorf("volume: record blessed generation for %q: %w", workload, err)
+	}
+	if err := m.writeBlessed(workload, gen); err != nil {
+		return 0, fmt.Errorf("volume: record blessed marker for %q: %w", workload, err)
+	}
+	return gen, nil
+}
+
+// GenerationBlessed reports whether a workload's CURRENT generation (per
+// genFile) matches the last generation the control plane's blessing ledger
+// recorded (per blessedFile). False whenever the two diverge: a legacy
+// self-bump (BumpGeneration, never touching the blessed marker) advances
+// genFile past blessedFile, so a volume that has EVER self-bumped since its
+// last blessing reads unblessed until the control plane blesses again. An
+// absent blessed marker (a volume that has never been blessed, including
+// every volume created before R7) also reads false: fail closed, never
+// fabricate a blessing the control plane never issued.
+func (m *Manager) GenerationBlessed(workload string) bool {
+	cur, err := m.Generation(workload)
+	if err != nil {
+		return false
+	}
+	blessed, err := m.readBlessed(workload)
+	if err != nil {
+		return false
+	}
+	return blessed == cur
+}
+
+func (m *Manager) readBlessed(workload string) (uint64, error) {
+	b, err := os.ReadFile(m.blessedPath(workload))
+	if err != nil {
+		return 0, fmt.Errorf("volume: read blessed marker for %q: %w", workload, err)
+	}
+	n, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("volume: malformed blessed marker for %q: %w", workload, err)
+	}
+	return n, nil
+}
+
+func (m *Manager) writeBlessed(workload string, gen uint64) error {
+	dir := m.dir(workload)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("volume: mkdir %q: %w", dir, err)
+	}
+	path := m.blessedPath(workload)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(strconv.FormatUint(gen, 10)), 0o600); err != nil {
+		return fmt.Errorf("volume: write blessed marker temp file %q: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("volume: publish blessed marker %q: %w", path, err)
+	}
+	return nil
+}
+
 // writeGeneration durably persists a generation value: write to a temp file in
 // the same directory, then os.Rename into place. rename(2) is atomic within a
 // filesystem, so a crash mid-write never leaves a torn ledger (the reader sees
@@ -270,11 +356,12 @@ func (m *Manager) Delete(workload string) error {
 // projection shape (mirrors nodev1.Volume without importing the proto here, so
 // this package stays independent of the gRPC contract; the server maps it).
 type Inventory struct {
-	Workload       string
-	Generation     uint64
-	SizeBytes      uint64
-	AllocatedBytes uint64
-	Attached       bool
+	Workload          string
+	Generation        uint64
+	SizeBytes         uint64
+	AllocatedBytes    uint64
+	Attached          bool
+	GenerationBlessed bool
 }
 
 // Scan walks VolumeRoot for every workload's volume directory and returns its
@@ -318,11 +405,12 @@ func (m *Manager) Scan() ([]Inventory, error) {
 			continue
 		}
 		out = append(out, Inventory{
-			Workload:       workload,
-			Generation:     gen,
-			SizeBytes:      size,
-			AllocatedBytes: alloc,
-			Attached:       m.IsAttached(workload),
+			Workload:          workload,
+			Generation:        gen,
+			SizeBytes:         size,
+			AllocatedBytes:    alloc,
+			Attached:          m.IsAttached(workload),
+			GenerationBlessed: m.GenerationBlessed(workload),
 		})
 	}
 	return out, nil

--- a/projects/embervm/noded/volume/volume_test.go
+++ b/projects/embervm/noded/volume/volume_test.go
@@ -133,6 +133,84 @@ func TestGenerationUnreadableMalformedLedger(t *testing.T) {
 	}
 }
 
+// TestRecordBlessedAdvancesLedgerAndMarksBlessed proves a CP-issued blessed
+// generation (R7, ADR embervm/011) both advances the generation ledger to the
+// exact value the control plane issued and marks the volume blessed, unlike a
+// legacy BumpGeneration which never touches the blessed marker.
+func TestRecordBlessedAdvancesLedgerAndMarksBlessed(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManager(dir)
+	if err := m.Create("wl-a", 1<<20); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if m.GenerationBlessed("wl-a") {
+		t.Error("a freshly created volume must not read as blessed (no blessing ever issued)")
+	}
+
+	gen, err := m.RecordBlessed("wl-a", 3)
+	if err != nil {
+		t.Fatalf("RecordBlessed: %v", err)
+	}
+	if gen != 3 {
+		t.Errorf("RecordBlessed = %d want 3", gen)
+	}
+	got, err := m.Generation("wl-a")
+	if err != nil {
+		t.Fatalf("Generation: %v", err)
+	}
+	if got != 3 {
+		t.Errorf("generation ledger = %d want 3 after RecordBlessed", got)
+	}
+	if !m.GenerationBlessed("wl-a") {
+		t.Error("GenerationBlessed should be true immediately after RecordBlessed")
+	}
+}
+
+// TestRecordBlessedRejectsNonAdvancingGeneration proves RecordBlessed refuses
+// a blessed generation that does not strictly exceed the ledger's current
+// value: a stale or repeated blessing must never let a bundle falsely re-match.
+func TestRecordBlessedRejectsNonAdvancingGeneration(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManager(dir)
+	if err := m.Create("wl-a", 1<<20); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := m.RecordBlessed("wl-a", 5); err != nil {
+		t.Fatalf("RecordBlessed: %v", err)
+	}
+	if _, err := m.RecordBlessed("wl-a", 5); err == nil {
+		t.Error("RecordBlessed with a generation equal to the current ledger value should error")
+	}
+	if _, err := m.RecordBlessed("wl-a", 4); err == nil {
+		t.Error("RecordBlessed with a generation below the current ledger value should error")
+	}
+}
+
+// TestBumpGenerationLeavesBlessedMarkerBehind proves the legacy self-bump path
+// (BumpGeneration) advances the generation ledger WITHOUT touching the
+// blessed marker, so a volume that was blessed and then self-bumps reads
+// unblessed again (the exact "unblessed report" the control plane quarantines
+// on adoption).
+func TestBumpGenerationLeavesBlessedMarkerBehind(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManager(dir)
+	if err := m.Create("wl-a", 1<<20); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := m.RecordBlessed("wl-a", 3); err != nil {
+		t.Fatalf("RecordBlessed: %v", err)
+	}
+	if !m.GenerationBlessed("wl-a") {
+		t.Fatal("expected blessed immediately after RecordBlessed")
+	}
+	if _, err := m.BumpGeneration("wl-a"); err != nil {
+		t.Fatalf("BumpGeneration: %v", err)
+	}
+	if m.GenerationBlessed("wl-a") {
+		t.Error("a self-bump past the last blessed generation must read as unblessed")
+	}
+}
+
 // TestAttachSingletonLockRefusal proves the singleton writable-attach
 // invariant: a second Attach for the same workload while the first is still
 // held is refused.


### PR DESCRIPTION
## Summary

PR-4 of the [R7 Distribution plan](../blob/main/docs/plans/2026-07-18-embervm-r7-distribution-spec-and-plan.md#task-6-control-plane-generation-blessing) (Task 6). Depends on #3684 (proto contract) and #3688 (vendor keying), both already on main.

- **Control plane (Elixir):** `StatefulManager.plan_wake` becomes the sole issuer of a workload's volume generation. `bless_wake_generation/3` issues the next value and durably appends the `generation_blessed` op **before** the boot request that carries it is built or dispatched (the fence: a crash between append and dispatch leaves a harmless unused blessed number; the reverse order would leave a real hole). `StatefulStore` tracks a durable `blessed_generation` watermark per volume and derives a `quarantined` flag whenever a node reports a generation past that watermark with `generation_blessed: false` on the wire; `plan_wake` refuses (parks) a wake against a quarantined volume, no auto-heal.
- **Grandfathering:** a volume this control plane has never blessed (`blessed_generation` nil, i.e. every pre-R7 volume) is seeded from its first `NodeStatus` report (`StatefulStore.seed_blessed_generation_if_unset/3`, called from adoption's `refresh_volume_facts` before quarantine is derived) rather than quarantined, so existing volumes are never punished for predating blessing.
- **noded (Go):** `StartStateful`'s `attachGeneration` helper records a nonzero `blessed_generation` verbatim (a new `genblessed` ledger marker file) instead of self-bumping, and reports `generation_blessed` in `NodeStatus`. `EMBERVM_NODED_REQUIRE_BLESSING` rejects an unblessed (`blessed_generation == 0`) writable attach FAILED_PRECONDITION once set; the legacy self-bump lane stays available while it is unset.
- **Chart:** `noded.requireBlessing` (default `true`) wires the env var. Both the CP and noded deploy from this one chart version, so enabling enforcement lands in the same version the CP starts blessing; a mixed CP/noded state cannot outlive the roll.

## Test plan

- [ ] CI green (Elixir + Go unit tests, no local test loop per repo convention)
- [ ] `helm template` renders (verified locally, `EMBERVM_NODED_REQUIRE_BLESSING=true` present)
- Elixir: monotonic blessing + op-log-before-dispatch ordering; unblessed report quarantines and parks; grandfather seeding never quarantines a never-blessed volume; a blessed report clears quarantine.
- Go: `RecordBlessed` advances the ledger to the CP-issued value and marks blessed; `BumpGeneration` (legacy) leaves the blessed marker behind; `EMBERVM_NODED_REQUIRE_BLESSING` rejects an unblessed attach; the legacy lane still works while unset.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

https://claude.ai/code/session_01QCEyjjV471j6pKce7oBTq6