### PR TITLE
fix(embervm): instrument bazel guest settle window and ready flip

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.126
+version: 0.1.127

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.126
+      targetRevision: 0.1.127
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/bazel/guest-init/cmd/main.go
+++ b/projects/embervm/runtimes/bazel/guest-init/cmd/main.go
@@ -43,6 +43,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -142,15 +143,26 @@ func run(logger *slog.Logger) error {
 	}
 
 	// The warming client has exited. Let the JVM settle (idle GC, any lazily
-	// spawned worker threads quiesce) before the snapshot is cut.
+	// spawned worker threads quiesce) before the snapshot is cut. A per-second tick
+	// loop (instead of one time.After(settleDelay)) is instrumentation: if the
+	// ticks never print, in-guest timers are broken; if they print and later lines
+	// vanish, the pause/console theory revives. Every branch logs so the settle
+	// window can never be a silent gap.
 	logger.Info("ember-bazel-init: settling before ready", "settle", settleDelay.String())
-	select {
-	case <-time.After(settleDelay):
-	case <-ctx.Done():
-		return waitForShutdown(ctx, serveErr, logger)
+	for i := 1; i <= int(settleDelay.Seconds()); i++ {
+		select {
+		case <-time.After(time.Second):
+			logger.Info("ember-bazel-init: settle tick", "i", i)
+		case <-ctx.Done():
+			logger.Warn("ember-bazel-init: settle interrupted by signal")
+			return waitForShutdown(ctx, serveErr, logger)
+		}
 	}
+	// Log the flip on BOTH sides of ready.Store, so a snapshot pause landing
+	// between the store and a single log line cannot hide the transition.
+	logger.Info("ember-bazel-init: ready flipping")
 	ready.Store(true)
-	logger.Info("ember-bazel-init: settle done, warm base ready")
+	logger.Info("ember-bazel-init: ready flipped, warm base ready")
 
 	// Hold PID 1. Exiting PID 1 panics the guest kernel before noded can snapshot
 	// the base or before a restored clone can answer its one query.
@@ -212,7 +224,14 @@ func warm(ctx context.Context, logger *slog.Logger) error {
 	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrCap)
 
 	t0 := time.Now()
-	err := cmd.Run()
+	// Start (not Run) so the client PID is logged the moment it launches: if the
+	// process never even starts, that is a different failure than a mid-run stall.
+	if err := cmd.Start(); err != nil {
+		logger.Error("ember-bazel-init: warming client failed to start", "err", err)
+		return err
+	}
+	logger.Info("ember-bazel-init: bazel client started", "pid", cmd.Process.Pid)
+	err := cmd.Wait()
 	elapsed := time.Since(t0)
 	if err != nil {
 		logger.Error("ember-bazel-init: warming client exited non-zero", "err", err, "elapsed", elapsed.String(), "tail", tail([]byte(stderrCap.String()), stderrTail))
@@ -263,8 +282,19 @@ func newMux(ready func() bool, logger *slog.Logger) *http.ServeMux {
 	mux.HandleFunc("GET /shim/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
+	// Log the FIRST /shim/ready poll received and the FIRST answered 200 (once
+	// each, never per-poll: noded's WaitReady polls continuously and that would
+	// spam). This shows whether WaitReady is reaching the guest at all, and the
+	// moment it first observes readiness (which is when BuildBase cuts the snapshot).
+	var firstPoll, firstReady sync.Once
 	mux.HandleFunc("GET /shim/ready", func(w http.ResponseWriter, _ *http.Request) {
+		firstPoll.Do(func() {
+			logger.Info("ember-bazel-init: first /shim/ready poll received")
+		})
 		if ready() {
+			firstReady.Do(func() {
+				logger.Info("ember-bazel-init: first /shim/ready answered 200")
+			})
 			w.WriteHeader(http.StatusOK)
 		} else {
 			w.WriteHeader(http.StatusServiceUnavailable)


### PR DESCRIPTION
## The puzzle

With loopback fixed (#3690), warming now completes: `Analyzed 514 targets (77 packages loaded, 2292 targets configured)`, client exits 0 in ~6s, and `settling before ready` logs. But `settle done, warm base ready` has NEVER printed across two attempts: ready never flips, no snapshot is cut, no kernel panic or error. The noded pod hosting attempt 2 stayed alive through the whole window, so console capture was healthy; the guest genuinely never gets past the 10s `time.After` select (or its post-select logs vanish).

This PR does not fix that; it INSTRUMENTS the settle window so the next attempt says exactly where it dies.

## Changes (all logging, behavior otherwise identical)

1. **Per-second settle loop** replaces the single `select { <-time.After(settleDelay) }` with a 10x one-second tick loop that logs `settle tick i=N` each second, `settle interrupted by signal` on ctx cancel. If the ticks never print, in-guest timers are broken; if they print and later lines vanish, the pause/console theory revives. Every branch logs, so the window can never be a silent gap.
2. **Ready flip bracketed:** `ready flipping` before `ready.Store(true)` and `ready flipped, warm base ready` after, so a snapshot pause landing between the store and a single log line cannot hide the transition.
3. **First /shim/ready poll + first 200** logged via `sync.Once` each (never per-poll, which would spam), so we can see whether noded's WaitReady is polling the guest at all and the moment it first sees ready (which is when BuildBase cuts the snapshot).
4. **warm() logs the client PID:** switched `cmd.Run()` to `cmd.Start()` + `Wait()` so `bazel client started pid=N` prints the instant it launches (a never-started process is a different failure than a mid-run stall).

## Verification

Local: `go test`, `go vet`, both `GOOS=linux` cross-compiles pass. No test changes needed (buildArgv unchanged). Chart bumped to 0.1.127. The next base build's console will show the tick sequence and pinpoint the phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
