### PR TITLE
fix(embervm): BuildBase client deadline 10m, elixir-grpc default 10s killed long warmings

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.127
+version: 0.1.128

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -986,8 +986,21 @@ defmodule Embervm.BaseBuilder do
     :ok
   end
 
+  # BuildBase legitimately runs for MINUTES (bazel warming + settle, the k3s
+  # airgap image import, cold-boot + WaitReady + snapshot), but elixir-grpc's Mint
+  # adapter defaults to a 10s per-call timeout (config :grpc, GRPC.Client.Adapters.Mint,
+  # timeout: 10_000). With no :timeout option the stub sent grpc-timeout "10S" on
+  # the HTTP/2 stream, so noded's gRPC server enforced the deadline at exactly
+  # boot+10s and SIGKILLed the warming VM (the bazel-query base is 6s warming + 10s
+  # settle, the first base to cross 10s; python/postgres/semgrep all went ready
+  # under 10s and never hit it). Worse, the Mint adapter then crashed on the cancel
+  # frame, swallowing the error so BaseBuilder never logged a failure and the
+  # Workload wedged in BaseBuilding. An explicit generous per-call timeout (10 min
+  # in ms) covers any realistic base build; BuildBase's own BootReadyTimeout is the
+  # real inner bound. This is the SLOW-path build only; the hot-path Prime/Assign
+  # calls keep the short default deliberately.
   defp default_build(channel, %BuildBaseRequest{} = request) do
-    NodeService.Stub.build_base(channel, request)
+    NodeService.Stub.build_base(channel, request, timeout: 600_000)
   end
 
   # EvictSnapshot the superseded base ref. Trace carries no workload (a base

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.127
+      targetRevision: 0.1.128
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Root cause (proven)

The settle-window instrumentation (#3692) nailed it. Evidence chain:

- Settle ticks stop at `i=3`, and the VM is killed at exactly boot+10s.
- The control-plane crash dump shows the BuildBase HTTP/2 stream carried `{"grpc-timeout","10S"}`, the elixir-grpc Mint adapter's DEFAULT deadline (`config :grpc, GRPC.Client.Adapters.Mint, timeout: 10_000`).
- `default_build/2` in `base_builder.ex` called `NodeService.Stub.build_base(channel, request)` with NO `:timeout` option, so the 10s default applied.
- At 10s noded's gRPC server enforces the deadline, aborts `runBuild`, and SIGKILLs the VM. The Mint adapter then crashes on the cancel frame (`FunctionClauseError` in `GRPC.Client.Adapters.Mint.ConnectionProcess.process_response`, `{:server_closed_request, :cancel}`), which SWALLOWS the error, so BaseBuilder never logs a failure and the Workload wedges in `BaseBuilding`.
- Every prior base build (python, semgrep, postgres) went ready in under 10s. The bazel-query base is ~6s warming + 10s settle, the FIRST to cross 10s.

## The fix

`default_build/2` now passes an explicit generous per-call timeout:

```elixir
NodeService.Stub.build_base(channel, request, timeout: 600_000)  # 10 min, ms
```

10 minutes covers any realistic base build (bazel warming + settle, k3s airgap import, cold-boot + WaitReady + snapshot); BuildBase's own BootReadyTimeout remains the real inner bound. A comment records the grpc-timeout 10S evidence.

Scope: this is the SLOW-path BuildBase only. The hot-path Prime/Assign stub calls are deliberately untouched and keep the short default.

## Tests

The base_builder tests inject a `build_fun` seam that stands in for `NodeService.Stub.build_base` entirely, so they never exercise the real stub call or its timeout option; there is no seam to assert the `:timeout` keyword without mocking the vendored stub. The change preserves `default_build/2`'s arity and signature, so existing tests compile and pass unchanged. Elixir tests run in CI.

Verified the option name against elixir-grpc: unary stub calls take an opts keyword list (`Stub.call(channel, request, opts)`), and the Mint adapter's `timeout:` is milliseconds (its documented default is exactly `10_000`, matching the observed 10S).

Chart bumped to 0.1.128 so the CP image rebuild deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
