### PR TITLE
feat(monolith): /ember/bazel bazel skyframe query demo (ADR 010, PR 2 of 2)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.130
+version: 0.1.132

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.130
+      targetRevision: 0.1.132
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.200
+version: 0.89.201
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.200
+      targetRevision: 0.89.201
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -5093,6 +5093,20 @@ py_test(
     ],
 )
 
+# Hand-registered (ember_public is gazelle-excluded): the bazel skyframe
+# query demo core (validation, session rate limit, semaphore, error mapping).
+py_test(
+    name = "ember_public_bazel_core_test",
+    srcs = ["ember_public/bazel_core_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
 py_test(
     name = "demos_loadtest_corpus_test",
     srcs = ["demos/loadtest_corpus_test.py"],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.274
+version: 0.285.275
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.274
+      targetRevision: 0.285.275
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/ember_public/__init__.py
+++ b/projects/monolith/ember_public/__init__.py
@@ -28,14 +28,19 @@ __all__ = ["register", "register_public"]
 
 
 def register_public(app: FastAPI) -> None:
-    """Register the demo-postgres router on the public app."""
+    """Register the demo-postgres and bazel-query routers on the public app."""
+    from ember_public.bazel_router import router as bazel_router
     from ember_public.router import router
 
     app.include_router(router)
+    app.include_router(bazel_router)
 
 
 def register(app: FastAPI) -> None:
-    """Register the demo-postgres router on the private app (same router)."""
+    """Register the demo-postgres and bazel-query routers on the private app
+    (same routers as the public app)."""
+    from ember_public.bazel_router import router as bazel_router
     from ember_public.router import router
 
     app.include_router(router)
+    app.include_router(bazel_router)

--- a/projects/monolith/ember_public/bazel_core.py
+++ b/projects/monolith/ember_public/bazel_core.py
@@ -17,7 +17,8 @@ Gating mirrors core.py's demo-postgres helpers:
     bazel flag (e.g. --output=starlark, which is code execution) through the
     single `expression` argv element.
   - check_and_record_query: a per-session token bucket, one query per
-    _RATE_LIMIT_WINDOW_S seconds.
+    _RATE_LIMIT_WINDOW_S seconds, keyed on a salted hash of the session
+    cookie rather than the cookie itself.
   - try_acquire_query_slot / release_query_slot: a module-level semaphore
     sized to the workload's `cap` (2), so a burst of visitors cannot pile
     more concurrent tasks onto the workload than it has clones for.
@@ -26,8 +27,10 @@ Gating mirrors core.py's demo-postgres helpers:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
+import os
 import re
 from time import monotonic
 
@@ -69,13 +72,28 @@ def validate_expr(expr: str) -> str | None:
 
 # ---------------------------------------------------------------------------
 # Per-session rate limit: one query per _RATE_LIMIT_WINDOW_S seconds. Keyed on
-# the opaque session tag, bounded by pruning stale entries on access (mirrors
-# core.py's _insert_bucket pattern).
+# a salted hash of the session cookie, not the raw cookie value, so a visitor
+# who rotates or grows an oversized cookie cannot grow this dict unboundedly
+# (mirrors core.py's demo_pg_session_tag). Bounded further by pruning stale
+# entries on access.
 # ---------------------------------------------------------------------------
 
 _RATE_LIMIT_WINDOW_S = 3.0
 _RATE_LIMIT_PRUNE_AGE_S = 3600.0
 _rate_bucket: dict[str, float] = {}
+
+
+# Optional salt mixed into the rate-limit key so it is not a bare sha256 of
+# the cookie value (mirrors chat_public.sessions.IP_HASH_SALT). No default:
+# an empty salt is acceptable for dev/test; production injects one via
+# BAZEL_QUERY_SESSION_SALT.
+_SESSION_SALT = os.environ.get("BAZEL_QUERY_SESSION_SALT", "")
+
+
+def _session_tag(session_cookie: str) -> str:
+    """Hash the session cookie into a short, bounded, opaque rate-limit key
+    so a rotated or oversized cookie cannot grow _rate_bucket unboundedly."""
+    return hashlib.sha256((_SESSION_SALT + session_cookie).encode()).hexdigest()[:16]
 
 
 def _prune_rate_bucket(now: float) -> None:
@@ -88,17 +106,17 @@ def _prune_rate_bucket(now: float) -> None:
         del _rate_bucket[tag]
 
 
-def check_and_record_query(session_tag: str) -> bool:
-    """True if this query is allowed; records the attempt either way.
-
-    A rejected attempt does not reset the visitor's own window (mirrors
+def check_and_record_query(session_cookie: str) -> bool:
+    """True if this query is allowed; records ONLY an allowed attempt (a
+    rejected attempt does not reset the visitor's own window, mirroring
     core.check_and_record_insert)."""
+    tag = _session_tag(session_cookie)
     now = monotonic()
     _prune_rate_bucket(now)
-    last = _rate_bucket.get(session_tag)
+    last = _rate_bucket.get(tag)
     if last is not None and (now - last) < _RATE_LIMIT_WINDOW_S:
         return False
-    _rate_bucket[session_tag] = now
+    _rate_bucket[tag] = now
     return True
 
 

--- a/projects/monolith/ember_public/bazel_core.py
+++ b/projects/monolith/ember_public/bazel_core.py
@@ -1,0 +1,184 @@
+"""Bazel skyframe query demo core (ADR embervm/010).
+
+Each visitor query runs against the `bazel-query` EmberVM workload: a
+disposable CoW clone restored from a snapshot of a warm Bazel server (the
+Abseil analysis graph already resident in the JVM heap). Task-class `Assign`
+destroys the clone after the single response, so there is no idle-TTL logic
+here, only the submit and its error mapping.
+
+This module must stay importable in the public closure (see
+ember_public/__init__.py's docstring): it imports faas.embervm_client, which
+is already part of the public-safe surface (no sandbox.client, no demos).
+
+Gating mirrors core.py's demo-postgres helpers:
+  - validate_expr: the primary defense-in-depth gate (the guest validates
+    again; see runtimes/bazel/guest-init). A whitespace-delimited token
+    starting with "-" is rejected outright so a visitor cannot smuggle a
+    bazel flag (e.g. --output=starlark, which is code execution) through the
+    single `expression` argv element.
+  - check_and_record_query: a per-session token bucket, one query per
+    _RATE_LIMIT_WINDOW_S seconds.
+  - try_acquire_query_slot / release_query_slot: a module-level semaphore
+    sized to the workload's `cap` (2), so a burst of visitors cannot pile
+    more concurrent tasks onto the workload than it has clones for.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from time import monotonic
+
+from faas import embervm_client
+from faas.embervm_client import EmberVMTimeout, EmberVMTransportError
+
+logger = logging.getLogger(__name__)
+
+_WORKLOAD_NAME = "bazel-query"
+_GUEST_PATH = "/query"
+_READ_TIMEOUT_S = 25.0
+
+_MAX_EXPR_LEN = 512
+# Letters, digits, and the punctuation a cquery expression legitimately needs:
+# path separators, package/target markers, wildcards, parens for function
+# calls, quotes for string args, comma for multi-arg functions, "=" for
+# kind()-style attribute matches, space between tokens.
+_EXPR_CHARSET_RE = re.compile(r'^[A-Za-z0-9_/:.@~+*\-(),"\'= ]+$')
+_TOKEN_RE = re.compile(r"\S+")
+
+
+def validate_expr(expr: str) -> str | None:
+    """Returns an error string if `expr` is not a safe cquery expression,
+    else None. This is the primary gate; the guest validates again
+    (defense in depth), but nothing unsafe should reach the guest at all."""
+    if not expr or not expr.strip():
+        return "expression must not be empty"
+    if "\n" in expr or "\r" in expr:
+        return "expression must be a single line"
+    if len(expr) > _MAX_EXPR_LEN:
+        return f"expression exceeds {_MAX_EXPR_LEN} characters"
+    if not _EXPR_CHARSET_RE.match(expr):
+        return "expression contains disallowed characters"
+    for token in _TOKEN_RE.findall(expr):
+        if token.startswith("-"):
+            return "expression must not contain flag-like tokens"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Per-session rate limit: one query per _RATE_LIMIT_WINDOW_S seconds. Keyed on
+# the opaque session tag, bounded by pruning stale entries on access (mirrors
+# core.py's _insert_bucket pattern).
+# ---------------------------------------------------------------------------
+
+_RATE_LIMIT_WINDOW_S = 3.0
+_RATE_LIMIT_PRUNE_AGE_S = 3600.0
+_rate_bucket: dict[str, float] = {}
+
+
+def _prune_rate_bucket(now: float) -> None:
+    stale = [
+        tag
+        for tag, last in _rate_bucket.items()
+        if (now - last) > _RATE_LIMIT_PRUNE_AGE_S
+    ]
+    for tag in stale:
+        del _rate_bucket[tag]
+
+
+def check_and_record_query(session_tag: str) -> bool:
+    """True if this query is allowed; records the attempt either way.
+
+    A rejected attempt does not reset the visitor's own window (mirrors
+    core.check_and_record_insert)."""
+    now = monotonic()
+    _prune_rate_bucket(now)
+    last = _rate_bucket.get(session_tag)
+    if last is not None and (now - last) < _RATE_LIMIT_WINDOW_S:
+        return False
+    _rate_bucket[session_tag] = now
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Global query semaphore, sized to the workload's `cap` (2 primed/live clones;
+# see projects/embervm/chart/values.yaml bazelQueryWorkload.cap). Non-blocking
+# acquire: an exhausted semaphore returns an in-band busy response rather than
+# queuing (mirrors core.py's demo-postgres semaphore).
+# ---------------------------------------------------------------------------
+
+_QUERY_SEMAPHORE_SIZE = 2
+_query_semaphore = asyncio.Semaphore(_QUERY_SEMAPHORE_SIZE)
+
+
+def try_acquire_query_slot() -> bool:
+    """Non-blocking acquire. Caller MUST release_query_slot() iff this is True."""
+    if _query_semaphore.locked():
+        return False
+    _query_semaphore._value -= 1
+    return True
+
+
+def release_query_slot() -> None:
+    _query_semaphore.release()
+
+
+# ---------------------------------------------------------------------------
+# The submit + response mapping.
+# ---------------------------------------------------------------------------
+
+_ANALYZED_LINE_OK_MARKER = "0 packages loaded"
+
+
+def _check_drift(analyzed_line: str | None) -> None:
+    """Log a WARNING when a served response re-analyzed packages: the base
+    snapshot's whole point is that Skyframe is already warm, so nonzero
+    packages loaded means either the flags drifted from the warming run or
+    the snapshot was served cold (ADR condition 2)."""
+    if analyzed_line and _ANALYZED_LINE_OK_MARKER not in analyzed_line:
+        logger.warning(
+            "bazel-query drift: analyzed_line lacks '%s': %r",
+            _ANALYZED_LINE_OK_MARKER,
+            analyzed_line,
+        )
+
+
+async def run_query(expr: str) -> tuple[int, dict]:
+    """Submit `expr` to the bazel-query workload and return (status, payload).
+
+    - transport failure -> 502
+    - timeout -> 504
+    - guest 422 (bad query) -> passed through, error text from the guest body
+    - guest 200 -> forwarded verbatim, with a drift check on analyzed_line
+    """
+    body = json.dumps({"expression": expr}).encode()
+    try:
+        resp = await embervm_client.submit(
+            _WORKLOAD_NAME,
+            body=body,
+            guest_path=_GUEST_PATH,
+            read_timeout=_READ_TIMEOUT_S,
+        )
+    except EmberVMTimeout as exc:
+        logger.warning("bazel-query submit timed out: %s", exc)
+        return 504, {"error": f"query timed out: {exc}"}
+    except EmberVMTransportError as exc:
+        logger.warning("bazel-query submit transport error: %s", exc)
+        return 502, {"error": f"could not reach the query workload: {exc}"}
+
+    if resp.status_code == 200:
+        payload = resp.json()
+        _check_drift(payload.get("analyzed_line"))
+        return 200, payload
+
+    if resp.status_code == 422:
+        return 422, {"error": resp.text}
+
+    logger.warning(
+        "bazel-query guest returned unexpected status %s: %s",
+        resp.status_code,
+        resp.text[:500],
+    )
+    return resp.status_code, {"error": resp.text}

--- a/projects/monolith/ember_public/bazel_core_test.py
+++ b/projects/monolith/ember_public/bazel_core_test.py
@@ -1,0 +1,280 @@
+"""Tests for the bazel skyframe query demo core (validation, gate, error mapping).
+
+Mirrors router_test.py's style: no real EmberVM, no real bazel; every
+faas.embervm_client.submit call is stubbed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import httpx
+import pytest
+
+import ember_public.bazel_core as bazel_core
+from faas.embervm_client import EmberVMTimeout, EmberVMTransportError
+
+
+@pytest.fixture(autouse=True)
+def _reset_bazel_core_module_state():
+    """The semaphore and rate-limit bucket are process-global; reset around
+    every test so back-to-back tests do not leak acquired slots or bucket
+    entries into each other."""
+
+    def _reset():
+        bazel_core._rate_bucket.clear()
+        while bazel_core._query_semaphore._value < bazel_core._QUERY_SEMAPHORE_SIZE:
+            bazel_core._query_semaphore.release()
+
+    _reset()
+    yield
+    _reset()
+
+
+# ---------------------------------------------------------------------------
+# validate_expr
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "deps(//absl/strings)",
+        'kind("cc_library", //absl/...)',
+        "somepath(//absl/base, //absl/time)",
+    ],
+)
+def test_validate_expr_accepts_well_formed_queries(expr):
+    assert bazel_core.validate_expr(expr) is None
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "--output=starlark",
+        "foo --flag",
+        "x" * 600,
+        "deps(//absl/strings)\ndeps(//absl/time)",
+        "",
+        "   ",
+    ],
+)
+def test_validate_expr_rejects_bad_queries(expr):
+    assert bazel_core.validate_expr(expr) is not None
+
+
+def test_validate_expr_rejects_disallowed_characters():
+    assert bazel_core.validate_expr("deps(//absl/strings); rm -rf /") is not None
+
+
+def test_validate_expr_rejects_flag_smuggling_mid_expression():
+    # A whitespace-delimited token starting with "-" anywhere must be rejected,
+    # not just when the expression starts with one.
+    assert bazel_core.validate_expr("deps(//absl/strings) -k") is not None
+
+
+def test_validate_expr_accepts_exactly_max_length():
+    expr = "deps(//absl/" + ("a" * (512 - len("deps(//absl/") - 1)) + ")"
+    assert len(expr) == 512
+    assert bazel_core.validate_expr(expr) is None
+
+
+def test_validate_expr_rejects_over_max_length():
+    expr = "deps(//absl/" + ("a" * (513 - len("deps(//absl/") - 1)) + ")"
+    assert len(expr) == 513
+    assert bazel_core.validate_expr(expr) is not None
+
+
+# ---------------------------------------------------------------------------
+# rate limit (token bucket: 1 query per 3s per session)
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limit_allows_first_query_then_blocks_within_window(monkeypatch):
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(bazel_core, "monotonic", lambda: clock["t"])
+
+    assert bazel_core.check_and_record_query("session-a") is True
+    assert bazel_core.check_and_record_query("session-a") is False
+
+
+def test_rate_limit_allows_again_after_window_elapses(monkeypatch):
+    clock = {"t": 2000.0}
+    monkeypatch.setattr(bazel_core, "monotonic", lambda: clock["t"])
+
+    assert bazel_core.check_and_record_query("session-b") is True
+    clock["t"] += bazel_core._RATE_LIMIT_WINDOW_S + 0.01
+    assert bazel_core.check_and_record_query("session-b") is True
+
+
+def test_rate_limit_is_per_session(monkeypatch):
+    clock = {"t": 3000.0}
+    monkeypatch.setattr(bazel_core, "monotonic", lambda: clock["t"])
+
+    assert bazel_core.check_and_record_query("session-a") is True
+    assert bazel_core.check_and_record_query("session-b") is True
+
+
+def test_rate_limit_prunes_stale_entries(monkeypatch):
+    clock = {"t": 4000.0}
+    monkeypatch.setattr(bazel_core, "monotonic", lambda: clock["t"])
+
+    assert bazel_core.check_and_record_query("stale-session") is True
+    clock["t"] += bazel_core._RATE_LIMIT_PRUNE_AGE_S + 1
+    assert bazel_core.check_and_record_query("other-session") is True
+    assert "stale-session" not in bazel_core._rate_bucket
+
+
+# ---------------------------------------------------------------------------
+# semaphore
+# ---------------------------------------------------------------------------
+
+
+def test_semaphore_size_matches_workload_cap():
+    assert bazel_core._QUERY_SEMAPHORE_SIZE == 2
+
+
+def test_try_acquire_and_release_query_slot():
+    acquired = [bazel_core.try_acquire_query_slot() for _ in range(2)]
+    assert all(acquired)
+    assert bazel_core.try_acquire_query_slot() is False
+
+    bazel_core.release_query_slot()
+    assert bazel_core.try_acquire_query_slot() is True
+
+
+# ---------------------------------------------------------------------------
+# run_query: submit call shape + response mapping
+# ---------------------------------------------------------------------------
+
+
+def _guest_response(status_code: int, payload) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        content=json.dumps(payload).encode(),
+        request=httpx.Request(
+            "POST", "http://embervm.test/v1/workloads/bazel-query/tasks"
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_query_submits_expected_shape(monkeypatch):
+    captured = {}
+
+    async def fake_submit(name, *, body, guest_path, read_timeout, **kwargs):
+        captured["name"] = name
+        captured["body"] = body
+        captured["guest_path"] = guest_path
+        captured["read_timeout"] = read_timeout
+        return _guest_response(
+            200,
+            {
+                "labels": "//absl/strings:strings",
+                "truncated": False,
+                "analyzed_line": "Analyzed 13 targets (0 packages loaded, 0 targets configured).",
+                "wall_ms": 240,
+            },
+        )
+
+    monkeypatch.setattr(bazel_core.embervm_client, "submit", fake_submit)
+
+    status, payload = await bazel_core.run_query("deps(//absl/strings)")
+
+    assert status == 200
+    assert captured["name"] == "bazel-query"
+    assert json.loads(captured["body"]) == {"expression": "deps(//absl/strings)"}
+    assert captured["guest_path"] == "/query"
+    assert captured["read_timeout"] == 25.0
+    assert payload["labels"] == "//absl/strings:strings"
+    assert payload["wall_ms"] == 240
+
+
+@pytest.mark.asyncio
+async def test_run_query_forwards_guest_422_with_error_text(monkeypatch):
+    async def fake_submit(name, *, body, guest_path, read_timeout, **kwargs):
+        return httpx.Response(
+            422,
+            content=b"ERROR: no such package '@absl//nope'",
+            request=httpx.Request("POST", "http://embervm.test"),
+        )
+
+    monkeypatch.setattr(bazel_core.embervm_client, "submit", fake_submit)
+
+    status, payload = await bazel_core.run_query("deps(//nope)")
+
+    assert status == 422
+    assert "no such package" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_run_query_maps_timeout_to_504(monkeypatch):
+    async def fake_submit(name, *, body, guest_path, read_timeout, **kwargs):
+        raise EmberVMTimeout("read timed out")
+
+    monkeypatch.setattr(bazel_core.embervm_client, "submit", fake_submit)
+
+    status, payload = await bazel_core.run_query("deps(//absl/strings)")
+
+    assert status == 504
+    assert "timed out" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_run_query_maps_transport_error_to_502(monkeypatch):
+    async def fake_submit(name, *, body, guest_path, read_timeout, **kwargs):
+        raise EmberVMTransportError("connection refused")
+
+    monkeypatch.setattr(bazel_core.embervm_client, "submit", fake_submit)
+
+    status, payload = await bazel_core.run_query("deps(//absl/strings)")
+
+    assert status == 502
+    assert "connection refused" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_run_query_warns_on_drift_when_packages_loaded_nonzero(
+    monkeypatch, caplog
+):
+    async def fake_submit(name, *, body, guest_path, read_timeout, **kwargs):
+        return _guest_response(
+            200,
+            {
+                "labels": "//absl/strings:strings",
+                "truncated": False,
+                "analyzed_line": "Analyzed 13 targets (4 packages loaded, 4 targets configured).",
+                "wall_ms": 9000,
+            },
+        )
+
+    monkeypatch.setattr(bazel_core.embervm_client, "submit", fake_submit)
+
+    with caplog.at_level(logging.WARNING):
+        status, payload = await bazel_core.run_query("deps(//absl/strings)")
+
+    assert status == 200
+    assert any("0 packages loaded" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_run_query_no_warning_when_packages_loaded_is_zero(monkeypatch, caplog):
+    async def fake_submit(name, *, body, guest_path, read_timeout, **kwargs):
+        return _guest_response(
+            200,
+            {
+                "labels": "//absl/strings:strings",
+                "truncated": False,
+                "analyzed_line": "Analyzed 13 targets (0 packages loaded, 0 targets configured).",
+                "wall_ms": 240,
+            },
+        )
+
+    monkeypatch.setattr(bazel_core.embervm_client, "submit", fake_submit)
+
+    with caplog.at_level(logging.WARNING):
+        status, payload = await bazel_core.run_query("deps(//absl/strings)")
+
+    assert status == 200
+    assert not any("0 packages loaded" in rec.message for rec in caplog.records)

--- a/projects/monolith/ember_public/bazel_core_test.py
+++ b/projects/monolith/ember_public/bazel_core_test.py
@@ -126,6 +126,17 @@ def test_rate_limit_prunes_stale_entries(monkeypatch):
     assert "stale-session" not in bazel_core._rate_bucket
 
 
+def test_rate_limit_bucket_keys_are_hashed_not_raw_cookies(monkeypatch):
+    clock = {"t": 5000.0}
+    monkeypatch.setattr(bazel_core, "monotonic", lambda: clock["t"])
+
+    cookie = "a-real-session-cookie-value"
+    bazel_core.check_and_record_query(cookie)
+
+    assert cookie not in bazel_core._rate_bucket
+    assert bazel_core._session_tag(cookie) in bazel_core._rate_bucket
+
+
 # ---------------------------------------------------------------------------
 # semaphore
 # ---------------------------------------------------------------------------

--- a/projects/monolith/ember_public/bazel_router.py
+++ b/projects/monolith/ember_public/bazel_router.py
@@ -47,6 +47,11 @@ async def bazel_query(body: BazelQueryRequest, request: Request) -> dict:
     if error is not None:
         return {"error": error}
 
+    # Existence-checked only: the cookie value itself is opaque and never
+    # verified against a store (no session table). This deliberately matches
+    # the postgres demo's accepted trade; the real abuse bound is downstream,
+    # the semaphore(2) slot cap and the one-clone-per-query reap, not this
+    # cookie check.
     session_cookie = request.cookies.get(_BAZEL_SESSION_COOKIE, "")
     if not session_cookie:
         if turnstile.SECRET_KEY:

--- a/projects/monolith/ember_public/bazel_router.py
+++ b/projects/monolith/ember_public/bazel_router.py
@@ -1,0 +1,96 @@
+"""Public-safe HTTP API for the bazel skyframe query demo (ADR embervm/010).
+
+Mounted at ``/api/ember/bazel`` on the public app, Turnstile-gated the same
+way the demo-postgres session is: ``POST /session`` mints a cookie once a
+Turnstile token is verified, and ``POST /query`` requires that cookie before
+submitting to the ``bazel-query`` EmberVM workload.
+
+Session admission uses ``chat_public.turnstile.siteverify`` (see
+bazel_core.py's neighbour, ember_public/router.py, for the same pattern):
+when ``TURNSTILE_SECRET_KEY`` is unset (private tier) it stub-accepts.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+
+from fastapi import APIRouter, HTTPException, Request, Response
+from pydantic import BaseModel
+
+from chat_public import turnstile
+from chat_public.turnstile import siteverify
+from ember_public import bazel_core
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/ember/bazel", tags=["ember"])
+
+_BAZEL_SESSION_COOKIE = "bazel_query_session"
+
+
+class BazelQueryRequest(BaseModel):
+    expression: str = ""
+
+
+class BazelSessionRequest(BaseModel):
+    turnstile_token: str = ""
+
+
+@router.post("/query")
+async def bazel_query(body: BazelQueryRequest, request: Request) -> dict:
+    """Validate, session-gate, rate-limit, then submit to the bazel-query
+    workload. Every rejection is returned in-band (never a 5xx for a visitor
+    mistake), matching the demo-postgres query endpoint's shape.
+    """
+    error = bazel_core.validate_expr(body.expression)
+    if error is not None:
+        return {"error": error}
+
+    session_cookie = request.cookies.get(_BAZEL_SESSION_COOKIE, "")
+    if not session_cookie:
+        if turnstile.SECRET_KEY:
+            return {"error": "solve the challenge first", "session_required": True}
+        session_cookie = "sessionless"
+
+    if not bazel_core.check_and_record_query(session_cookie):
+        return {"error": "one query per few seconds", "rate_limited": True}
+
+    if not bazel_core.try_acquire_query_slot():
+        return {"error": "busy, one moment", "busy": True}
+
+    try:
+        status, payload = await bazel_core.run_query(body.expression)
+    finally:
+        bazel_core.release_query_slot()
+
+    if status != 200:
+        raise HTTPException(status_code=status, detail=payload.get("error"))
+    return payload
+
+
+@router.post("/session")
+async def bazel_session(
+    body: BazelSessionRequest, request: Request, response: Response
+) -> dict:
+    """Mint a session cookie for the query rate limit, gated by Turnstile when
+    the demo is public. Mirrors ember_public/router.py's postgres_session.
+    """
+    existing = request.cookies.get(_BAZEL_SESSION_COOKIE, "")
+    if existing:
+        return {"ok": True, "existing": True}
+
+    result = await siteverify(body.turnstile_token)
+    if not result.success:
+        raise HTTPException(status_code=403, detail="turnstile verification failed")
+
+    response.set_cookie(
+        _BAZEL_SESSION_COOKIE,
+        secrets.token_hex(16),
+        httponly=True,
+        samesite="lax",
+        secure=True,
+        max_age=3600,
+        path="/api/ember/bazel",
+    )
+    return {"ok": True, "existing": False}

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -508,7 +508,7 @@
         <a class="anchor" href="#live-exhibits">See it run</a>
       </h2>
       <p class="body">
-        Two exhibits run on the live system, through the same wake path
+        Three exhibits run on the live system, through the same wake path
         production uses.
       </p>
       <div class="doors">
@@ -521,6 +521,15 @@
             78&nbsp;ms.
           </p>
           <span class="go">ember/postgres</span>
+        </a>
+        <a class="door" href="/ember/bazel">
+          <span class="k">live demo</span>
+          <h3>Query a frozen Bazel brain</h3>
+          <p>
+            Each query runs in a disposable clone of a snapshotted warm
+            Bazel server.
+          </p>
+          <span class="go">ember/bazel</span>
         </a>
         <a class="door" href="/ember/firecracker">
           <span class="k">explainer</span>
@@ -1076,7 +1085,7 @@
   /* ---------- doors ---------- */
   .doors {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 16px;
   }
 

--- a/projects/monolith/frontend/src/routes/public/ember/bazel/+page.server.js
+++ b/projects/monolith/frontend/src/routes/public/ember/bazel/+page.server.js
@@ -1,0 +1,14 @@
+// The public Turnstile site key gates the query session on this demo (see
+// ADR embervm/010 and ember_public/bazel_router.py). It is PUBLIC by design
+// (it identifies the widget, not a credential); the Turnstile *secret* never
+// enters the frontend, only the FastAPI backend. Same convention as
+// routes/public/ember/postgres/+page.server.js.
+const TURNSTILE_SITE_KEY = process.env.TURNSTILE_SITE_KEY || "";
+
+export async function load() {
+  // No status endpoint for this demo (see plan Task 7): each query is a
+  // one-shot task-class Assign, there is no VM lifecycle to poll.
+  return {
+    turnstileSiteKey: TURNSTILE_SITE_KEY,
+  };
+}

--- a/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
@@ -1,0 +1,880 @@
+<script>
+  // /ember/bazel: the frozen-Skyframe query exhibit (ADR embervm/010).
+  // A real Bazel server was warmed once, its Skyframe graph resident in the
+  // JVM heap after loading and analyzing Abseil (514 targets), then frozen
+  // as a Firecracker memory snapshot. Every query below runs in a disposable
+  // copy-on-write clone of that frozen brain: relight, one query, destroy.
+  //
+  // Console flow mirrors /ember/postgres's EmberConsole: Turnstile-gated
+  // session mint (sessionless when no site key, i.e. dev), a stopwatch that
+  // ticks live via requestAnimationFrame, and an in-band error shape split
+  // between pre-submit rejections (200 + {error, ...flag}) and post-submit
+  // failures (a real non-2xx status; see ember_public/bazel_router.py).
+  // Unlike postgres, there is no lifecycle to poll: each query is one
+  // task-class Assign, so there is no status endpoint and no wake stage.
+  //
+  // Same-origin proxies only (public-tier rule 2): every call below goes
+  // through /ember/bazel/api/*, never /api/... directly.
+  import { onMount } from "svelte";
+  import { fade } from "svelte/transition";
+  import "$lib/public/ember/ember.css";
+
+  let { data } = $props();
+
+  const API = "/ember/bazel/api";
+
+  const DEFAULT_EXPR = "deps(//absl/strings)";
+  const EXAMPLES = [
+    { label: "cc_library kinds", expr: 'kind("cc_library", //absl/...)' },
+    { label: "somepath", expr: "somepath(//absl/base, //absl/time)" },
+  ];
+
+  const PROOF_MARKER = "0 packages loaded, 0 targets configured";
+
+  let expr = $state(DEFAULT_EXPR);
+  let running = $state(false);
+  let stopwatchMs = $state(0);
+  let result = $state(null);
+  let runError = $state("");
+
+  let stopwatchRaf = null;
+  let stopwatchStart = 0;
+
+  function startStopwatch() {
+    stopwatchStart = performance.now();
+    stopwatchMs = 0;
+    const tick = () => {
+      stopwatchMs = performance.now() - stopwatchStart;
+      stopwatchRaf = requestAnimationFrame(tick);
+    };
+    stopwatchRaf = requestAnimationFrame(tick);
+  }
+
+  function stopStopwatch() {
+    if (stopwatchRaf != null) {
+      cancelAnimationFrame(stopwatchRaf);
+      stopwatchRaf = null;
+    }
+  }
+
+  function ms(v) {
+    if (v == null) return "–";
+    return v >= 1000 ? `${(v / 1000).toFixed(2)} s` : `${Math.round(v)} ms`;
+  }
+
+  // Session gate: sessionReady flips true once /session mints (or confirms)
+  // a cookie. Sessionless-mint mode (no site key) starts true only after the
+  // fire-and-forget mint on mount resolves ok, matching the postgres console.
+  let turnstileSiteKey = data.turnstileSiteKey ?? "";
+  let sessionReady = $state(false);
+  let sessionError = $state("");
+  let queryUnavailable = $state(false);
+
+  async function parseJsonSafe(resp) {
+    const text = await resp.text();
+    try {
+      return JSON.parse(text);
+    } catch {
+      return null;
+    }
+  }
+
+  async function mintSession(turnstileToken = "") {
+    try {
+      const resp = await fetch(`${API}/session`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ turnstile_token: turnstileToken }),
+      });
+      if (resp.status === 429) return;
+      const body = (await parseJsonSafe(resp)) ?? {};
+      if (resp.ok && body.ok) {
+        sessionReady = true;
+        sessionError = "";
+        queryUnavailable = false;
+      } else if (!resp.ok) {
+        if (turnstileSiteKey) {
+          sessionError = "verification failed, try again";
+        } else {
+          queryUnavailable = true;
+        }
+      }
+    } catch {
+      // fire-and-forget: a network hiccup just leaves querying gated
+    }
+  }
+
+  // Client-side cooldown so repeat clicks cannot outrun the backend's own
+  // one-query-per-3s session bucket; a click during the gap queues (capped).
+  const COOLDOWN_MS = 3200;
+  let cooldown = $state(false);
+  let cooldownTimer = null;
+  let queuedExpr = $state(null);
+
+  function startCooldown() {
+    cooldown = true;
+    if (cooldownTimer) clearTimeout(cooldownTimer);
+    cooldownTimer = setTimeout(() => {
+      cooldown = false;
+      cooldownTimer = null;
+      if (queuedExpr != null) {
+        const next = queuedExpr;
+        queuedExpr = null;
+        runQuery(next);
+      }
+    }, COOLDOWN_MS);
+  }
+
+  function requestRun(runExpr) {
+    if (!!turnstileSiteKey && !sessionReady) return;
+    if (queryUnavailable) return;
+    if (running || cooldown) {
+      queuedExpr = runExpr;
+      return;
+    }
+    runQuery(runExpr);
+  }
+
+  async function runQuery(runExpr) {
+    if (running) return;
+    running = true;
+    runError = "";
+    startStopwatch();
+    try {
+      const resp = await fetch(`${API}/query`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ expression: runExpr }),
+      });
+      const body = await parseJsonSafe(resp);
+      if (body == null) {
+        runError = `unexpected response from the demo (${resp.status})`;
+        return;
+      }
+      if (resp.status === 429) {
+        runError = "the demo is busy right now, give it a few seconds and try again";
+        return;
+      }
+      if (body.session_required) {
+        if (!turnstileSiteKey) queryUnavailable = true;
+        runError = turnstileSiteKey
+          ? "solve the check above to query"
+          : "querying needs the human check, which is not configured here";
+        return;
+      }
+      if (body.rate_limited) {
+        runError = "one query per few seconds, wait a moment and retry";
+        return;
+      }
+      if (body.busy) {
+        runError = "both clones are busy right now, try again in a moment";
+        return;
+      }
+      if (body.error) {
+        // A real bazel error (from the guest's own 422, or a validation
+        // rejection) shown verbatim: a typo'd query is a feature here, not
+        // a bug, visitors see bazel's actual error text.
+        runError = body.error;
+        return;
+      }
+      result = body;
+    } catch (err) {
+      runError = String(err);
+    } finally {
+      running = false;
+      stopStopwatch();
+      startCooldown();
+    }
+  }
+
+  onMount(() => {
+    if (!turnstileSiteKey) {
+      mintSession("");
+    }
+  });
+
+  // Turnstile widget lifecycle: mirrors EmberConsole's script-load +
+  // render-once + remove-on-unmount pattern.
+  const TURNSTILE_SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+  let widgetEl;
+  let widgetId = null;
+
+  function renderTurnstileWidget() {
+    if (!window.turnstile || !widgetEl || !turnstileSiteKey || sessionReady) return;
+    if (widgetId !== null) return;
+    widgetId = window.turnstile.render(widgetEl, {
+      sitekey: turnstileSiteKey,
+      callback: (token) => mintSession(token),
+      "error-callback": () => {
+        sessionError = "verification failed, try again";
+      },
+    });
+  }
+
+  function removeTurnstileWidget() {
+    if (widgetId !== null && window.turnstile) {
+      try {
+        window.turnstile.remove(widgetId);
+      } catch {
+        // widget already gone; nothing to clean up
+      }
+    }
+    widgetId = null;
+  }
+
+  onMount(() => {
+    if (!turnstileSiteKey) return undefined;
+    if (window.turnstile) {
+      renderTurnstileWidget();
+      return removeTurnstileWidget;
+    }
+    let script = document.querySelector(`script[src="${TURNSTILE_SCRIPT_SRC}"]`);
+    if (!script) {
+      script = document.createElement("script");
+      script.src = TURNSTILE_SCRIPT_SRC;
+      script.async = true;
+      script.defer = true;
+      document.head.appendChild(script);
+    }
+    script.addEventListener("load", renderTurnstileWidget);
+    return () => {
+      script.removeEventListener("load", renderTurnstileWidget);
+      removeTurnstileWidget();
+    };
+  });
+
+  // Highlight the proof marker inside analyzed_line for the badge. Falls
+  // back to the raw line (no highlight span) if the marker is missing,
+  // which would itself be the drift condition the backend logs a warning
+  // for (ember_public/bazel_core.py _check_drift).
+  let analyzedParts = $derived.by(() => {
+    const line = result?.analyzed_line ?? "";
+    const idx = line.indexOf(PROOF_MARKER);
+    if (idx === -1) return { before: line, marker: "", after: "" };
+    return {
+      before: line.slice(0, idx),
+      marker: line.slice(idx, idx + PROOF_MARKER.length),
+      after: line.slice(idx + PROOF_MARKER.length),
+    };
+  });
+
+  let labelLines = $derived((result?.labels ?? "").split("\n").filter((l) => l.length > 0));
+</script>
+
+<svelte:head>
+  <title>Ember Bazel Skyframe Query</title>
+  <meta
+    name="description"
+    content="Query a warm Bazel analysis graph frozen as a Firecracker memory snapshot. Each query runs in a disposable clone: relight, cquery, destroy. Bazel's own output proves zero re-analysis happened."
+  />
+</svelte:head>
+
+<div class="ember-site">
+  <header class="topbar">
+    <span
+      ><a class="brand" href="/"><strong>jomcgi.dev</strong></a> /
+      <a class="brand" href="/ember">ember</a> / bazel</span
+    >
+    <a class="topbar-cross" href="/ember/postgres">see the postgres exhibit</a>
+  </header>
+
+  <main class="ember-page">
+    <header class="masthead">
+      <h1><span class="ember-word">Ember</span> Bazel Skyframe Query</h1>
+      <p class="subtitle">
+        A real Bazel server was warmed once: loading and analysis of Abseil,
+        514 targets. That warm server was frozen as a Firecracker memory
+        snapshot. Every query below runs in a disposable copy-on-write clone
+        of that frozen brain: relight, one query, destroy.
+      </p>
+    </header>
+
+    <section class="console-section">
+      {#if turnstileSiteKey && !sessionReady}
+        <div class="turnstile-slot">
+          <p class="turnstile-hint">solve the check to query</p>
+          <div bind:this={widgetEl} class="turnstile-widget"></div>
+          {#if sessionError}
+            <p class="soft-error">{sessionError}</p>
+          {/if}
+        </div>
+      {/if}
+
+      <div class="query-bar">
+        <input
+          class="query-input"
+          type="text"
+          bind:value={expr}
+          spellcheck="false"
+          autocomplete="off"
+          placeholder={DEFAULT_EXPR}
+        />
+        <button
+          class="run-btn"
+          type="button"
+          onclick={() => requestRun(expr)}
+          disabled={(!!turnstileSiteKey && !sessionReady) || queryUnavailable}
+        >
+          {queryUnavailable ? "unavailable" : running ? "querying…" : "run cquery"}
+        </button>
+      </div>
+
+      <div class="chips">
+        {#each EXAMPLES as ex (ex.expr)}
+          <button
+            class="chip"
+            type="button"
+            onclick={() => {
+              expr = ex.expr;
+              requestRun(ex.expr);
+            }}
+          >
+            {ex.label}
+          </button>
+        {/each}
+      </div>
+
+      <div class="stopwatch-row">
+        <span class="stopwatch-label">round trip</span>
+        <span class="stopwatch-value" class:stopwatch-live={running}>
+          {#key running ? "live" : (result?.wall_ms ?? "none")}
+            <span class="fade-swap" in:fade={{ duration: 220 }}>
+              {running ? ms(stopwatchMs) : ms(result?.wall_ms)}
+            </span>
+          {/key}
+        </span>
+      </div>
+
+      {#if runError}
+        <div class="run-error">
+          <span class="run-error-label">bazel says:</span>
+          <pre class="run-error-text">{runError}</pre>
+        </div>
+      {/if}
+
+      {#if result}
+        {#if analyzedParts.before || analyzedParts.marker}
+          <div class="proof-badge">
+            <span class="proof-kicker">proof of reuse, bazel's own words</span>
+            <p class="proof-line">
+              {analyzedParts.before}{#if analyzedParts.marker}<b class="proof-marker">{analyzedParts.marker}</b>{/if}{analyzedParts.after}
+            </p>
+            <p class="proof-caption">
+              Zero packages loaded, zero targets configured: bazel's own
+              admission that no re-analysis happened. This clone answered
+              the query by reusing the Skyframe graph restored straight from
+              the frozen heap.
+            </p>
+          </div>
+        {/if}
+
+        <div class="result-card">
+          <div class="result-header">
+            <span class="result-count">{labelLines.length} label{labelLines.length === 1 ? "" : "s"}</span>
+            {#if result.truncated}
+              <span class="result-truncated">output truncated</span>
+            {/if}
+          </div>
+          <ul class="label-list">
+            {#each labelLines as label, i (i)}
+              <li>{label}</li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+    </section>
+
+    <section class="recorded-section">
+      <h2 class="h2">Cold, warm, and live</h2>
+      <p class="body">
+        Three numbers, three different things measured. The first two are a
+        recorded comparison from before the snapshot existed; the third is
+        what actually happens on your query above.
+      </p>
+      <div class="recorded-panel">
+        <div class="recorded-stat">
+          <span class="recorded-value recorded-cold">13.8 s</span>
+          <span class="recorded-name">cold: loading + analysis</span>
+          <span class="recorded-note">warm dev server, macOS, 10 cores, pre-snapshot</span>
+        </div>
+        <div class="recorded-stat">
+          <span class="recorded-value recorded-warm">0.31 s</span>
+          <span class="recorded-name">warm: cquery on an already-loaded server</span>
+          <span class="recorded-note">same machine, same run, cache hot</span>
+        </div>
+        <div class="recorded-stat">
+          <span class="recorded-value recorded-live">~450 ms</span>
+          <span class="recorded-name">live: one visitor query, end to end</span>
+          <span class="recorded-note"
+            >measured on the production node tonight, includes clone
+            relight and reap, ~300&nbsp;ms of it inside bazel</span
+          >
+        </div>
+      </div>
+      <p class="recorded-footer">
+        Design doc: <a
+          href="https://github.com/jomcgi/homelab/blob/main/docs/decisions/embervm/010-bazel-skyframe-snapshot-query-demo.md"
+          >ADR embervm/010</a
+        >.
+      </p>
+    </section>
+  </main>
+</div>
+
+<style>
+  .ember-site {
+    min-height: 100dvh;
+  }
+
+  .topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    padding: 14px 28px;
+    font-family: var(--em-mono);
+    font-size: 12.5px;
+    color: var(--em-muted);
+  }
+
+  .topbar strong {
+    color: var(--em-ink);
+    font-weight: 600;
+  }
+
+  .topbar .brand {
+    color: inherit;
+    text-decoration: none;
+    border-radius: 4px;
+  }
+
+  .topbar .brand:hover {
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  .topbar .brand:focus-visible,
+  .topbar-cross:focus-visible {
+    outline: 2px solid var(--em-ember-deep);
+    outline-offset: 3px;
+  }
+
+  .topbar-cross {
+    color: var(--em-muted);
+    text-decoration: none;
+    border-radius: 4px;
+  }
+
+  .topbar-cross:hover {
+    color: var(--em-ember-deep);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  .ember-page {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 4px 24px 64px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .masthead {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-bottom: 4px;
+  }
+
+  .masthead h1 {
+    margin: 0;
+    font-size: clamp(24px, 2.4vw, 30px);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
+    color: var(--em-ink);
+  }
+
+  .ember-word {
+    color: var(--em-ember);
+  }
+
+  .subtitle {
+    margin: 0;
+    font-size: 14.5px;
+    line-height: 1.5;
+    color: var(--em-muted);
+    max-width: 68ch;
+  }
+
+  .console-section {
+    background: var(--em-panel);
+    border: 1px solid var(--em-line);
+    border-radius: 14px;
+    box-shadow: var(--em-shadow);
+    padding: 18px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 8px;
+  }
+
+  .turnstile-slot {
+    background: var(--em-ground);
+    border: 1px solid var(--em-line);
+    border-radius: 12px;
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .turnstile-hint {
+    margin: 0;
+    font-size: 12.5px;
+    color: var(--em-muted);
+  }
+
+  .soft-error {
+    margin: 0;
+    color: var(--em-ember-deep);
+    font-size: 12px;
+  }
+
+  .query-bar {
+    display: flex;
+    gap: 10px;
+  }
+
+  .query-input {
+    flex: 1;
+    min-width: 0;
+    padding: 11px 14px;
+    border-radius: 10px;
+    border: 1px solid var(--em-line);
+    background: var(--em-ground);
+    color: var(--em-ink);
+    font-family: var(--em-mono);
+    font-size: 13.5px;
+  }
+
+  .query-input:focus-visible {
+    outline: 2px solid var(--em-ember-deep);
+    outline-offset: 1px;
+  }
+
+  .run-btn {
+    flex: none;
+    padding: 11px 20px;
+    border-radius: 10px;
+    font-family: inherit;
+    font-weight: 600;
+    font-size: 14px;
+    cursor: pointer;
+    background: var(--em-ember);
+    border: 1px solid var(--em-ember-deep);
+    color: var(--em-on-color);
+    box-shadow: var(--em-shadow-soft);
+    transition:
+      background-color 0.15s ease,
+      box-shadow 0.15s ease;
+  }
+
+  .run-btn:hover:not(:disabled) {
+    background: var(--em-ember-deep);
+  }
+
+  .run-btn:disabled {
+    opacity: 0.55;
+    cursor: default;
+  }
+
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .chip {
+    padding: 6px 12px;
+    border-radius: 999px;
+    border: 1px solid var(--em-line);
+    background: var(--em-ground);
+    color: var(--em-muted);
+    font-family: var(--em-mono);
+    font-size: 12px;
+    cursor: pointer;
+    transition:
+      border-color 0.15s ease,
+      color 0.15s ease;
+  }
+
+  .chip:hover {
+    border-color: var(--em-ember-dim);
+    color: var(--em-ember-deep);
+  }
+
+  .stopwatch-row {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding-top: 2px;
+  }
+
+  .stopwatch-label {
+    font-size: 13px;
+    color: var(--em-muted);
+  }
+
+  .stopwatch-value {
+    font-family: var(--em-mono);
+    font-size: 16px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--em-ink);
+  }
+
+  .stopwatch-value.stopwatch-live {
+    color: var(--em-ember);
+  }
+
+  .fade-swap {
+    display: inline-block;
+  }
+
+  .run-error {
+    background: color-mix(in srgb, var(--em-ember-dim) 25%, var(--em-ground));
+    border: 1px solid var(--em-ember-dim);
+    border-radius: 10px;
+    padding: 10px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .run-error-label {
+    font-family: var(--em-mono);
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--em-ember-deep);
+  }
+
+  .run-error-text {
+    margin: 0;
+    font-family: var(--em-mono);
+    font-size: 12.5px;
+    line-height: 1.5;
+    color: var(--em-ink);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .proof-badge {
+    background: color-mix(in srgb, var(--em-ember-dim) 35%, var(--em-panel));
+    border: 1px solid var(--em-ember-dim);
+    border-radius: 12px;
+    padding: 16px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .proof-kicker {
+    font-family: var(--em-mono);
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--em-ember-deep);
+    font-weight: 600;
+  }
+
+  .proof-line {
+    margin: 0;
+    font-family: var(--em-mono);
+    font-size: 13.5px;
+    line-height: 1.5;
+    color: var(--em-ink);
+    word-break: break-word;
+  }
+
+  .proof-marker {
+    background: var(--em-ember);
+    color: var(--em-on-color);
+    border-radius: 4px;
+    padding: 1px 6px;
+    font-weight: 700;
+  }
+
+  .proof-caption {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--em-muted);
+  }
+
+  .result-card {
+    border: 1px solid var(--em-line);
+    border-radius: 12px;
+    background: var(--em-ground);
+    padding: 12px 16px;
+    max-height: 360px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .result-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-family: var(--em-mono);
+    font-size: 12px;
+    color: var(--em-faint);
+  }
+
+  .result-truncated {
+    color: var(--em-ember-deep);
+  }
+
+  .label-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-family: var(--em-mono);
+    font-size: 12.5px;
+    color: var(--em-ink);
+  }
+
+  .label-list li {
+    padding: 2px 0;
+    border-bottom: 1px solid var(--em-line-soft);
+    word-break: break-all;
+  }
+
+  .label-list li:last-child {
+    border-bottom: none;
+  }
+
+  .recorded-section {
+    margin-top: 12px;
+  }
+
+  .h2 {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin: 0 0 10px;
+    font-size: 20px;
+    font-weight: 750;
+    letter-spacing: -0.015em;
+    color: var(--em-ink);
+  }
+
+  .h2::before {
+    content: "##";
+    font-family: var(--em-mono);
+    font-size: 14px;
+    font-weight: 400;
+    color: var(--em-ember);
+  }
+
+  .body {
+    margin: 0 0 14px;
+    font-size: 14.5px;
+    line-height: 1.55;
+    color: var(--em-muted);
+    max-width: 68ch;
+  }
+
+  .recorded-panel {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 14px;
+    background: var(--eml-panel-warm, var(--em-panel));
+    border: 1px solid var(--em-line);
+    border-radius: 12px;
+    box-shadow: var(--em-shadow-soft);
+    padding: 18px;
+  }
+
+  .recorded-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .recorded-value {
+    font-family: var(--em-mono);
+    font-size: 26px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .recorded-cold {
+    color: var(--em-frost);
+  }
+
+  .recorded-warm {
+    color: var(--em-amber);
+  }
+
+  .recorded-live {
+    color: var(--em-ember-deep);
+  }
+
+  .recorded-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--em-ink);
+  }
+
+  .recorded-note {
+    font-size: 11.5px;
+    line-height: 1.4;
+    color: var(--em-faint);
+  }
+
+  .recorded-footer {
+    margin: 12px 2px 0;
+    font-family: var(--em-mono);
+    font-size: 12px;
+    color: var(--em-faint);
+  }
+
+  .recorded-footer a {
+    color: var(--em-ember-deep);
+    text-decoration: none;
+    border-bottom: 1px solid var(--em-ember-dim);
+  }
+
+  .recorded-footer a:hover {
+    border-bottom-color: var(--em-ember-deep);
+  }
+
+  @media (max-width: 900px) {
+    .topbar {
+      padding: 12px 16px;
+    }
+
+    .ember-page {
+      padding: 4px 16px 48px;
+      gap: 14px;
+    }
+
+    .recorded-panel {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media (max-width: 560px) {
+    .query-bar {
+      flex-direction: column;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
@@ -155,6 +155,17 @@
         runError = "the demo is busy right now, give it a few seconds and try again";
         return;
       }
+      if (!resp.ok) {
+        // Post-submit failures come back as a real HTTP status with a
+        // FastAPI {"detail": ...} body (see ember_public/bazel_router.py's
+        // HTTPException on non-200 from run_query): the guest's own 422 with
+        // bazel's verbatim error text, or a 502/504 from a transport error
+        // or timeout. Pre-submit rejections (bad expression, missing
+        // session, rate limit, busy semaphore) are handled below as in-band
+        // 200 + {error, ...flag} bodies instead.
+        runError = body?.detail ?? body?.error ?? `query failed (${resp.status})`;
+        return;
+      }
       if (body.session_required) {
         if (!turnstileSiteKey) queryUnavailable = true;
         runError = turnstileSiteKey
@@ -191,6 +202,10 @@
     if (!turnstileSiteKey) {
       mintSession("");
     }
+    return () => {
+      stopStopwatch();
+      if (cooldownTimer) clearTimeout(cooldownTimer);
+    };
   });
 
   // Turnstile widget lifecycle: mirrors EmberConsole's script-load +

--- a/projects/monolith/frontend/src/routes/public/ember/bazel/api/query/+server.js
+++ b/projects/monolith/frontend/src/routes/public/ember/bazel/api/query/+server.js
@@ -1,0 +1,31 @@
+// nosemgrep: sveltekit-server-hardcoded-api-base-fallback
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// Same-origin proxy for the bazel skyframe query roundtrip (see
+// ember_public/bazel_router.py POST /query). The backend's own read timeout
+// on the workload submit is 25s; give the proxy a slightly wider ceiling so
+// the backend's own 504 is what a visitor sees on a slow clone, not a proxy
+// timeout racing it. The request cookie header is forwarded upstream
+// unmodified so the backend can read the bazel_query_session cookie (session
+// attribution, rate limiting); there is no set-cookie to relay back since
+// this endpoint never mints a session itself.
+export async function POST({ request, fetch }) {
+  const headers = { "content-type": "application/json" };
+  const cookie = request.headers.get("cookie");
+  if (cookie) headers.cookie = cookie;
+
+  const res = await fetch(`${API_BASE}/api/ember/bazel/query`, {
+    method: "POST",
+    headers,
+    body: await request.text(),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  return new Response(await res.text(), {
+    status: res.status,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/projects/monolith/frontend/src/routes/public/ember/bazel/api/session/+server.js
+++ b/projects/monolith/frontend/src/routes/public/ember/bazel/api/session/+server.js
@@ -1,0 +1,45 @@
+// nosemgrep: sveltekit-server-hardcoded-api-base-fallback
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// Same-origin proxy for minting the bazel-query demo session cookie (see
+// ember_public/bazel_router.py POST /session). 30s timeout, matching /query.
+//
+// Cookie handling is bidirectional: the inbound request's cookie header is
+// forwarded so the backend can no-op on an existing bazel_query_session
+// cookie, and the upstream response's set-cookie header (the httpOnly cookie
+// the backend mints) is relayed back with ONE rewrite. The backend scopes
+// the cookie to its own mount path (Path=/api/ember/bazel), but the
+// visitor's browser talks to this proxy family at /ember/bazel/api/*, so a
+// verbatim relay stores a cookie the browser never sends back: queries then
+// fail session_required even after a solved Turnstile check. Rescope the
+// Path to the public page's own prefix; the cookie value itself stays opaque
+// and backend-chosen.
+export async function POST({ request, fetch }) {
+  const headers = { "content-type": "application/json" };
+  const cookie = request.headers.get("cookie");
+  if (cookie) headers.cookie = cookie;
+
+  const res = await fetch(`${API_BASE}/api/ember/bazel/session`, {
+    method: "POST",
+    headers,
+    body: await request.text(),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  const outHeaders = new Headers({
+    "content-type": "application/json",
+    "cache-control": "no-store",
+  });
+  const setCookie = res.headers.get("set-cookie");
+  if (setCookie) {
+    outHeaders.set(
+      "set-cookie",
+      setCookie.replace(/Path=\/api\/ember\/bazel/i, "Path=/ember/bazel"),
+    );
+  }
+
+  return new Response(await res.text(), {
+    status: res.status,
+    headers: outHeaders,
+  });
+}

--- a/projects/monolith/frontend/visual/fixtures/api/ember_bazel_query.json
+++ b/projects/monolith/frontend/visual/fixtures/api/ember_bazel_query.json
@@ -1,0 +1,6 @@
+{
+  "labels": "//absl/strings:strings\n//absl/strings:string_view\n//absl/base:core_headers\n//absl/base:config",
+  "truncated": false,
+  "analyzed_line": "Analyzed target //absl/strings:strings (0 packages loaded, 0 targets configured).",
+  "wall_ms": 312
+}

--- a/projects/monolith/frontend/visual/fixtures/api/ember_bazel_session.json
+++ b/projects/monolith/frontend/visual/fixtures/api/ember_bazel_session.json
@@ -1,0 +1,4 @@
+{
+  "ok": true,
+  "existing": false
+}

--- a/projects/monolith/frontend/visual/mock-server.mjs
+++ b/projects/monolith/frontend/visual/mock-server.mjs
@@ -29,6 +29,11 @@ const ROUTES = [
   ["/api/ember/postgres/savings", "fixtures/api/ember_postgres_savings.json"],
   ["/api/ember/postgres/session", "fixtures/api/ember_postgres_session.json"],
   ["/api/ember/postgres/query", "fixtures/api/ember_postgres_query.json"],
+  // /ember/bazel fires a fire-and-forget session mint on mount (no
+  // unprompted query, unlike postgres); the session fixture is what capture
+  // actually exercises, the query fixture is here for parity/coverage.
+  ["/api/ember/bazel/session", "fixtures/api/ember_bazel_session.json"],
+  ["/api/ember/bazel/query", "fixtures/api/ember_bazel_query.json"],
 ];
 const PREFIX = [["/api/trips/trip/", "fixtures/api/trips_trip.json"]];
 

--- a/projects/monolith/frontend/visual/targets.json
+++ b/projects/monolith/frontend/visual/targets.json
@@ -40,6 +40,7 @@
       "path": "/ember/postgres",
       "static_initial": true
     },
+    { "id": "ember-bazel", "path": "/ember/bazel" },
     { "id": "docs", "path": "/docs" },
     { "id": "docs-slug", "path": "/docs/agents" },
     { "id": "cv", "path": "/cv" },


### PR DESCRIPTION
## Summary

PR 2 of 2 for ADR embervm/010: the public consumer surface for the frozen-Bazel-brain exhibit. PR 1 (merged) shipped the guest runtime, the workload registration, and live-verified base-build proof (0 packages loaded on a served query). This PR adds:

- **Backend** (`ember_public/bazel_router.py`, `bazel_core.py`): `POST /api/ember/bazel/query` and `POST /api/ember/bazel/session`, mirroring the demo-postgres endpoint shape. Security gates: an allow-list expression validator that rejects flag-smuggling tokens (defense in depth ahead of the guest's own validation), a Turnstile session gate identical to the postgres demo, a per-session rate limit (one query per 3s, keyed on a salted hash of the session cookie so a rotated cookie cannot grow the limiter's dict unboundedly), and a `asyncio.Semaphore(2)` matching the workload's clone cap so a burst of visitors cannot pile more concurrent tasks onto the workload than it has clones for.
- **Frontend** (`/ember/bazel`): a query console (input, example chips, live stopwatch, results list), same-origin proxies only (never direct `/api/...` fetches), and the proof badge: bazel's own `analyzed_line` rendered verbatim with the `0 packages loaded, 0 targets configured` fragment highlighted, the visible evidence that a served query is pure Skyframe reuse from the restored heap, not re-analysis. A static recorded panel cites the cold (13.8s) vs warm (0.31s) comparison and tonight's live-verified end-to-end figure (~450ms per visitor query including clone relight and reap, ~300ms of it inside bazel, measured on the production node). Landing door card added to `/ember`.
- **Isolation**: the guest has no network device at all (task class), one query destroys the clone (task-class `Assign` reaps unconditionally), and the flag-smuggling defense means a visitor's expression can only ever be one argv element to a fixed `cquery` invocation.

## Test plan

- [x] `ember_public/bazel_core_test.py`: validation allow-list, rate limit (including the new hashed-bucket-key assertion), semaphore, and the full status-code mapping (200/422/502/504) with drift-warning coverage
- [x] Frontend: non-2xx `/query` responses (guest 422 with bazel's verbatim error text, 502/504) now surface correctly instead of rendering an empty result card
- [x] Visual regression: `/ember/bazel` added to `targets.json` with committed session/query fixtures
- [ ] CI: format, gazelle, `bazel test //...`, chart-version-collision guard
- [ ] Live: confirm `/ember/bazel` serves after ArgoCD sync and a real query round-trips end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>