### PR TITLE
fix(monolith): relay bazel query errors verbatim, proof styling, example chips

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.133
+version: 0.1.134

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.133
+      targetRevision: 0.1.134
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/bazel/guest-init/cmd/main.go
+++ b/projects/embervm/runtimes/bazel/guest-init/cmd/main.go
@@ -267,6 +267,29 @@ type queryResult struct {
 	WallMs       int64  `json:"wall_ms"`
 }
 
+// queryError is the JSON body returned for a FAILED query (bad expression,
+// bazel non-zero exit, or in-guest timeout). It is returned with HTTP 200, not a
+// non-2xx: EmberVM's task pipeline relays only a SUCCESSFUL-task guest response
+// verbatim to the caller; a guest non-2xx is treated as a failed task and
+// replaced with the pipeline's own dead-letter envelope, so bazel's real error
+// text would never reach the backend or the visitor. A visitor's typo'd query is
+// a successful DEMO run whose payload happens to carry the failure, hence 200.
+// It carries NO labels/analyzed_line, so the edge discriminates success from
+// failure on the presence of the "error" key.
+type queryError struct {
+	Error    string `json:"error"`
+	ExitCode int    `json:"exit_code"`
+	WallMs   int64  `json:"wall_ms"`
+}
+
+// queryErrorBody marshals a queryError. Split out so the failure-payload shape is
+// unit-tested and every failure path (validation, non-zero exit, timeout) emits
+// an identical envelope.
+func queryErrorBody(errText string, exitCode int, wallMs int64) []byte {
+	body, _ := json.Marshal(queryError{Error: errText, ExitCode: exitCode, WallMs: wallMs})
+	return body
+}
+
 // queryRequest is the POST /query body.
 type queryRequest struct {
 	Expression string `json:"expression"`
@@ -307,18 +330,24 @@ func newMux(ready func() bool, logger *slog.Logger) *http.ServeMux {
 }
 
 // handleQuery serves one visitor cquery. A restored clone serves exactly one of
-// these and is then destroyed by Assign. A bad expression (validation failure or
-// a bazel non-zero exit, which a visitor's typo'd query is the normal cause of)
-// returns 422 carrying bazel's real error text, so the demo surfaces the actual
-// query error rather than a generic 5xx.
+// these and is then destroyed by Assign.
+//
+// EVERY visitor-facing failure (a malformed body, a validation rejection, a bazel
+// non-zero exit from a typo'd query, or the in-guest timeout) is returned as HTTP
+// 200 with a queryError payload, NOT a non-2xx. The reason is the EmberVM task
+// pipeline: it relays a successful-task guest response verbatim, but replaces a
+// guest non-2xx with its own dead-letter envelope, so bazel's real error text
+// would never reach the backend. A bad visitor query is a SUCCESSFUL demo run
+// whose payload carries the failure. The edge (bazel_core.run_query) turns an
+// error-key payload back into a 422 for the browser.
 func handleQuery(w http.ResponseWriter, r *http.Request, logger *slog.Logger) {
 	var req queryRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeErr(w, http.StatusBadRequest, "malformed request body: "+err.Error())
+		writeJSON(w, http.StatusOK, queryErrorBody("malformed request body: "+err.Error(), -1, 0))
 		return
 	}
 	if err := validateExpr(req.Expression); err != nil {
-		writeErr(w, http.StatusUnprocessableEntity, "invalid expression: "+err.Error())
+		writeJSON(w, http.StatusOK, queryErrorBody("invalid expression: "+err.Error(), -1, 0))
 		return
 	}
 
@@ -337,14 +366,19 @@ func handleQuery(w http.ResponseWriter, r *http.Request, logger *slog.Logger) {
 	wallMs := time.Since(t0).Milliseconds()
 
 	if ctx.Err() == context.DeadlineExceeded {
-		writeErr(w, http.StatusUnprocessableEntity, "query exceeded "+queryTimeout.String()+" time budget")
+		writeJSON(w, http.StatusOK, queryErrorBody("query exceeded "+queryTimeout.String()+" time budget", -1, wallMs))
 		return
 	}
 	if err != nil {
 		// A visitor's bad query (unknown target, syntax error) exits non-zero;
-		// surface bazel's stderr tail so they see the real error, as a 422 (the
-		// input was the problem, not the server).
-		writeErr(w, http.StatusUnprocessableEntity, tail([]byte(stderr.String()), stderrTail))
+		// surface bazel's stderr tail so they see the real error. Still HTTP 200
+		// (a successful demo run) so the pipeline relays it instead of dead-lettering.
+		exitCode := -1
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		}
+		writeJSON(w, http.StatusOK, queryErrorBody(tail([]byte(stderr.String()), stderrTail), exitCode, wallMs))
 		return
 	}
 
@@ -361,23 +395,18 @@ func handleQuery(w http.ResponseWriter, r *http.Request, logger *slog.Logger) {
 		AnalyzedLine: analyzed,
 		WallMs:       wallMs,
 	})
-	// Explicit Content-Length so the response is fixed-length framed, not chunked:
-	// the vsock transport surfaced chunked bodies as malformed-encoding resets on
-	// the daemon side (see shim.Server.invokeHandler for the same defence).
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(body)
+	writeJSON(w, http.StatusOK, body)
 }
 
-// writeErr writes a plain-text error body with an explicit Content-Length (same
-// fixed-length-framing reason as handleQuery's success path).
-func writeErr(w http.ResponseWriter, status int, msg string) {
-	b := []byte(msg)
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	w.Header().Set("Content-Length", strconv.Itoa(len(b)))
+// writeJSON writes a JSON body with an explicit Content-Length so the response is
+// fixed-length framed, not chunked: the vsock transport surfaced chunked bodies
+// as malformed-encoding resets on the daemon side (see shim.Server.invokeHandler
+// for the same defence).
+func writeJSON(w http.ResponseWriter, status int, body []byte) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(status)
-	_, _ = w.Write(b)
+	_, _ = w.Write(body)
 }
 
 // validateExpr is the guest's independent gate on the visitor expression (ADR

--- a/projects/embervm/runtimes/bazel/guest-init/cmd/main_test.go
+++ b/projects/embervm/runtimes/bazel/guest-init/cmd/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -178,5 +179,63 @@ func TestTruncate(t *testing.T) {
 	}
 	if len(s) != maxOutput {
 		t.Fatalf("truncate(big) len = %d, want %d", len(s), maxOutput)
+	}
+}
+
+// TestQueryErrorBody covers the failure-payload shape. A bad visitor query (a
+// bazel non-zero exit, an in-guest timeout, or a validation rejection) is a
+// SUCCESSFUL demo run whose payload carries the failure, so handleQuery returns
+// HTTP 200 with this body and NO labels/analyzed_line. EmberVM's task pipeline
+// only relays a successful-task guest response verbatim; a guest non-2xx would be
+// dead-lettered and the visitor would never see bazel's error. So the body must
+// carry the error text, the exit code, and wall_ms, and must NOT carry a labels
+// or analyzed_line key (their presence is the success discriminator on the edge).
+func TestQueryErrorBody(t *testing.T) {
+	raw := queryErrorBody("ERROR: no such target '//absl/stringsm'", 1, 240)
+
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("queryErrorBody produced invalid JSON: %v", err)
+	}
+	if got["error"] != "ERROR: no such target '//absl/stringsm'" {
+		t.Fatalf("error = %v, want the stderr text", got["error"])
+	}
+	// JSON numbers decode to float64 through any.
+	if got["exit_code"].(float64) != 1 {
+		t.Fatalf("exit_code = %v, want 1", got["exit_code"])
+	}
+	if got["wall_ms"].(float64) != 240 {
+		t.Fatalf("wall_ms = %v, want 240", got["wall_ms"])
+	}
+	if _, ok := got["labels"]; ok {
+		t.Fatalf("error body must NOT carry a labels key: %v", got)
+	}
+	if _, ok := got["analyzed_line"]; ok {
+		t.Fatalf("error body must NOT carry an analyzed_line key: %v", got)
+	}
+}
+
+// TestQuerySuccessBodyHasNoError guards the success discriminator from the other
+// side: a successful query's body carries labels + analyzed_line and NO error
+// key, so the edge (bazel_core.run_query) can branch on error-presence alone.
+func TestQuerySuccessBodyHasNoError(t *testing.T) {
+	raw, err := json.Marshal(queryResult{
+		Labels:       "//absl/strings:strings\n",
+		Truncated:    false,
+		AnalyzedLine: "Analyzed 3 targets (0 packages loaded, 0 targets configured).",
+		WallMs:       120,
+	})
+	if err != nil {
+		t.Fatalf("marshal queryResult: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if _, ok := got["error"]; ok {
+		t.Fatalf("success body must NOT carry an error key: %v", got)
+	}
+	if got["labels"] == "" || got["analyzed_line"] == "" {
+		t.Fatalf("success body must carry labels + analyzed_line: %v", got)
 	}
 }

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.205
+version: 0.89.206
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.205
+      targetRevision: 0.89.206
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.279
+version: 0.285.280
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.279
+      targetRevision: 0.285.280
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/ember_public/bazel_core.py
+++ b/projects/monolith/ember_public/bazel_core.py
@@ -178,8 +178,16 @@ async def run_query(expr: str) -> tuple[int, dict]:
 
     - transport failure -> 502
     - timeout -> 504
-    - guest 422 (bad query) -> passed through, error text from the guest body
-    - guest 200 -> forwarded verbatim, with a drift check on analyzed_line
+    - guest 200 with an `error` key (a failed query: bad expression, bazel
+      non-zero exit, or in-guest timeout) -> remapped to 422 with that error
+      text. The guest returns 200 for these because EmberVM's task pipeline
+      relays only a successful-task guest response verbatim and dead-letters a
+      guest non-2xx, so a bad visitor query must ride back as a successful task
+      whose payload carries the failure. The router turns this 422 into an
+      HTTPException so the browser shows bazel's real error.
+    - guest 200 (success) -> forwarded verbatim, with a drift check on analyzed_line
+    - legacy guest 422 -> passed through (kept during the deploy overlap, before
+      the new guest image with the 200+error contract is rolled out everywhere)
     """
     body = json.dumps({"expression": expr}).encode()
     try:
@@ -198,10 +206,16 @@ async def run_query(expr: str) -> tuple[int, dict]:
 
     if resp.status_code == 200:
         payload = resp.json()
+        # A failed query rides back as a successful task carrying an `error` key
+        # (the new guest contract). Remap to 422 so the router surfaces bazel's
+        # text to the browser instead of a stale "success" panel.
+        if payload.get("error"):
+            return 422, {"error": payload["error"]}
         _check_drift(payload.get("analyzed_line"))
         return 200, payload
 
     if resp.status_code == 422:
+        # Legacy guest that still returns 422 directly (pre-rollout overlap).
         return 422, {"error": resp.text}
 
     logger.warning(

--- a/projects/monolith/ember_public/bazel_core_test.py
+++ b/projects/monolith/ember_public/bazel_core_test.py
@@ -223,6 +223,31 @@ async def test_run_query_forwards_guest_422_with_error_text(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_query_maps_guest_200_error_payload_to_422(monkeypatch):
+    # New guest contract: a failed query (bad expression, bazel non-zero exit,
+    # in-guest timeout) is a SUCCESSFUL task returning HTTP 200 with an `error`
+    # key and no labels/analyzed_line, because EmberVM only relays successful-task
+    # responses verbatim. run_query must turn that into a 422 so the router raises
+    # HTTPException(422) and the browser shows bazel's real error text.
+    async def fake_submit(name, *, body, guest_path, read_timeout, **kwargs):
+        return _guest_response(
+            200,
+            {
+                "error": "ERROR: no such target '//absl/stringsm'",
+                "exit_code": 1,
+                "wall_ms": 210,
+            },
+        )
+
+    monkeypatch.setattr(bazel_core.embervm_client, "submit", fake_submit)
+
+    status, payload = await bazel_core.run_query("deps(//absl/stringsm)")
+
+    assert status == 422
+    assert "no such target" in payload["error"]
+
+
+@pytest.mark.asyncio
 async def test_run_query_maps_timeout_to_504(monkeypatch):
     async def fake_submit(name, *, body, guest_path, read_timeout, **kwargs):
         raise EmberVMTimeout("read timed out")

--- a/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
@@ -24,9 +24,16 @@
   const API = "/ember/bazel/api";
 
   const DEFAULT_EXPR = "deps(//absl/strings)";
+  // Known-good cquery expressions offered as one-click chips. Each is verified
+  // against the backend charset validator (bazel_core.validate_expr) and is a
+  // real Abseil target/pattern, so a click always returns a result, never an
+  // error. Clicking populates the input AND runs (respecting the cooldown).
   const EXAMPLES = [
+    { label: "deps", expr: "deps(//absl/strings)" },
     { label: "cc_library kinds", expr: 'kind("cc_library", //absl/...)' },
     { label: "somepath", expr: "somepath(//absl/base, //absl/time)" },
+    { label: "reverse deps", expr: "rdeps(//absl/..., //absl/base:config)" },
+    { label: "package labels", expr: "//absl/hash/..." },
   ];
 
   const PROOF_MARKER = "0 packages loaded, 0 targets configured";
@@ -163,6 +170,11 @@
     if (running) return;
     running = true;
     runError = "";
+    // Clear the previous result/proof/labels up front so a new run that errors
+    // does not leave a stale success panel (and its green proof badge) rendered
+    // underneath the error box. Filter text resets with it.
+    result = null;
+    filterText = "";
     startStopwatch();
     try {
       const resp = await fetch(`${API}/query`, {
@@ -457,7 +469,10 @@
       {#if result}
         {#if analyzedParts.before || analyzedParts.marker}
           <div class="proof-badge">
-            <span class="proof-kicker">proof of reuse, bazel's own words</span>
+            <span class="proof-kicker"
+              ><span class="proof-check" aria-hidden="true">✓</span> proof of reuse,
+              bazel's own words</span
+            >
             <p class="proof-line">
               {analyzedParts.before}{#if analyzedParts.marker}<b class="proof-marker">{analyzedParts.marker}</b>{/if}{analyzedParts.after}
             </p>
@@ -843,9 +858,18 @@
     word-break: break-word;
   }
 
+  /* Positive/success accent, scoped to this page: the shared ember palette has
+     only ember (red), frost (blue), and amber, and the proof badge previously
+     reused the ember-dim salmon, which reads as an ERROR next to the run-error
+     box (they shared a hue). A muted, warm-consistent green marks the proof as
+     clearly good. Kept local rather than added to ember.css so the token change
+     stays contained to the one place that needs it. */
   .proof-badge {
-    background: color-mix(in srgb, var(--em-ember-dim) 35%, var(--em-panel));
-    border: 1px solid var(--em-ember-dim);
+    --em-good: #2f7d55;
+    --em-good-deep: #1f6042;
+    --em-good-dim: #bfe0cd;
+    background: color-mix(in srgb, var(--em-good-dim) 34%, var(--em-panel));
+    border: 1px solid var(--em-good-dim);
     border-radius: 12px;
     padding: 16px 18px;
     display: flex;
@@ -858,8 +882,25 @@
     font-size: 11px;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: var(--em-ember-deep);
+    color: var(--em-good-deep);
     font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .proof-check {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 15px;
+    height: 15px;
+    border-radius: 999px;
+    background: var(--em-good);
+    color: var(--em-on-color);
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
   }
 
   .proof-line {
@@ -872,7 +913,7 @@
   }
 
   .proof-marker {
-    background: var(--em-ember);
+    background: var(--em-good);
     color: var(--em-on-color);
     border-radius: 4px;
     padding: 1px 6px;


### PR DESCRIPTION
Joe's live feedback, spanning guest + backend + frontend.

## Problem 1 (root fix, guest): typo'd query showed "unexpected response (502)"

A typo'd query (e.g. `deps(//absl/stringsm)`) showed a generic 502 instead of bazel's error. Cause: the guest returned HTTP 422 for a failed query, and EmberVM's task pipeline treats a guest non-2xx as a FAILED task and replaces it with its own `{"error":"task did not succeed","state":"dead_lettered"}` envelope, so bazel's stderr never reached the backend.

Fix in `projects/embervm/runtimes/bazel/guest-init/cmd/main.go` `handleQuery`: a bazel non-zero exit, the in-guest timeout, AND validation rejections now return HTTP 200 with `{"error": "<stderr tail>", "exit_code": N, "wall_ms": ...}` and no labels/analyzed_line. EmberVM relays a successful-task response verbatim, so a bad visitor query rides back as a successful demo run whose payload carries the failure. Success shape unchanged. TDD: `queryErrorBody` extracted and unit-tested (carries error/exit_code/wall_ms, never labels/analyzed_line).

## Problem 1b (backend): map the new shape to 422

`ember_public/bazel_core.run_query`: a guest 200 with an `error` key is remapped to 422, so `bazel_router`'s existing `status != 200` branch raises HTTPException(422, detail=error) and the existing frontend non-ok path shows bazel's text verbatim. The legacy guest-422 passthrough is kept during the deploy overlap. `bazel_core_test.py` extended for the new shape.

## Problem 2 (frontend): proof panel read as an error; stale panel under errors

- The proof badge used the same ember-dim salmon as the error box, so a success read as an error. Restyled with a scoped positive-green accent (the shared palette has only ember/frost/amber, no success token) and a small check glyph before "proof of reuse"; the highlighted marker is now green, not alarm-red. Kept local to the page's `<style>` so no shared token churn.
- A new run now clears the previous `result`/proof/labels (and filter text) up front, so an errored run no longer leaves a stale success panel rendered under the error box (Joe's screenshot).

## Problem 3 (frontend): more example chips

Expanded to five one-click chips: `deps(//absl/strings)`, `kind("cc_library", //absl/...)`, `somepath(//absl/base, //absl/time)`, `rdeps(//absl/..., //absl/base:config)`, and `//absl/hash/...`. Each is verified against the backend charset validator and is a real Abseil target/pattern (`//absl/base:config` is a real target). Clicking a chip populates the input AND runs it, respecting the cooldown.

## Verification

Guest: `go test`, `go vet`, both `GOOS=linux` cross-compiles pass. Backend + frontend: syntax-checked; Elixir/pytest/vitest run in CI. Charts bumped: embervm 0.1.134, monolith 0.285.280, monolith-public 0.89.206 (guest image + base rebuild, backend, and page all change). Commit uses a single `fix(monolith)` scope (the compound scope is not allowed by the hook); the embervm guest change is described above and in the commit body.

After merge the embervm base rebuilds automatically (~1 min warm now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
