### PR TITLE
fix(monolith): always-on comparison stat strip, config-hash badge tooltip

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.206
+version: 0.89.207
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.206
+      targetRevision: 0.89.207
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.280
+version: 0.285.281
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.280
+      targetRevision: 0.285.281
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
@@ -459,6 +459,32 @@
         </span>
       </div>
 
+      <!-- Compact always-on-screen comparison strip: the cold/warm recorded
+           baselines plus this session's live numbers, so the core point (a
+           frozen brain answers in a fraction of a cold analysis) is visible
+           while querying without scrolling to the detailed section below. The
+           two baselines mirror the recorded-panel constants; "this query" is the
+           last run's round trip; "saved" is the all-time counter. -->
+      <div class="stat-strip">
+        <span class="stat-item"
+          ><span class="stat-key">cold</span> <span class="stat-val stat-cold">13.8 s</span></span
+        >
+        <span class="stat-sep">/</span>
+        <span class="stat-item"
+          ><span class="stat-key">warm</span> <span class="stat-val stat-warm">0.31 s</span></span
+        >
+        <span class="stat-sep">/</span>
+        <span class="stat-item"
+          ><span class="stat-key">this query</span>
+          <span class="stat-val stat-live">{running ? ms(stopwatchMs) : ms(result?.wall_ms)}</span></span
+        >
+        <span class="stat-sep">/</span>
+        <span class="stat-item"
+          ><span class="stat-key">saved so far</span>
+          <span class="stat-val stat-saved">{formatSavedTime(savedS)}</span></span
+        >
+      </div>
+
       {#if runError}
         <div class="run-error">
           <span class="run-error-label">bazel says:</span>
@@ -511,7 +537,11 @@
               <li>
                 <span class="label-target">{item.target}</span>
                 {#if item.configHash}
-                  <span class="label-config-badge">{item.configHash}</span>
+                  <span
+                    class="label-config-badge"
+                    title="the target's configuration hash; source files have none"
+                    >{item.configHash}</span
+                  >
                 {/if}
               </li>
             {:else}
@@ -519,12 +549,8 @@
             {/each}
           </ul>
 
-          <div class="result-footer-row">
-            <p class="result-footer">
-              the badge is the target's configuration hash; source files have
-              none
-            </p>
-            {#if labelPageCount > 1}
+          {#if labelPageCount > 1}
+            <div class="result-footer-row">
               <div class="pager">
                 <button
                   class="pager-btn"
@@ -546,8 +572,8 @@
                   &#8250;
                 </button>
               </div>
-            {/if}
-          </div>
+            </div>
+          {/if}
         </div>
       {/if}
     </section>
@@ -830,6 +856,54 @@
     display: inline-block;
   }
 
+  /* No card chrome by design: an inline row of small mono figures that sits with
+     the round-trip readout so the comparison is always on screen. Colours reuse
+     the recorded-panel tokens (frost=cold, amber=warm, ember-deep=live). */
+  .stat-strip {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 6px 10px;
+    font-family: var(--em-mono);
+    font-size: 12px;
+    color: var(--em-faint);
+  }
+
+  .stat-item {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 5px;
+  }
+
+  .stat-key {
+    color: var(--em-faint);
+  }
+
+  .stat-val {
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stat-cold {
+    color: var(--em-frost);
+  }
+
+  .stat-warm {
+    color: var(--em-amber);
+  }
+
+  .stat-live {
+    color: var(--em-ember-deep);
+  }
+
+  .stat-saved {
+    color: var(--em-ember-deep);
+  }
+
+  .stat-sep {
+    color: var(--em-line);
+  }
+
   .run-error {
     background: color-mix(in srgb, var(--em-ember-dim) 25%, var(--em-ground));
     border: 1px solid var(--em-ember-dim);
@@ -1018,16 +1092,10 @@
 
   .result-footer-row {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     gap: 12px;
     flex-wrap: wrap;
-  }
-
-  .result-footer {
-    margin: 0;
-    font-size: 11px;
-    color: var(--em-faint);
   }
 
   .pager {


### PR DESCRIPTION
Two more Joe items for the /ember/bazel console (pure frontend). The original error-relay PR (#3700) already merged, so these land as a follow-up.

## 6. Always-on comparison stat strip

The cold/warm/live timing summary was below the fold and invisible while using the console. Added a compact inline stat strip directly under the round-trip readout: `cold 13.8 s / warm 0.31 s / this query <live> / saved so far <total>`, small mono type, no card chrome, using the existing recorded-panel colour tokens (frost=cold, amber=warm, ember-deep=live/saved). "this query" wires to the last run's round trip (and ticks live while running); "saved so far" wires to the savings total already fetched/SSR-seeded. The detailed "Cold, warm, and live" section below is kept as-is (it carries the notes and the design-doc link); the strip is the always-visible summary.

## 7. Config-hash caption to tooltip

Removed the "the badge is the target's configuration hash; source files have none" caption line under the label list (it did not earn its space), and moved the same text to a `title` tooltip on each config-hash badge. With the caption gone the footer row now renders only when there is more than one page (the pager), right-aligned.

## Verification

fast-format clean, no em-dashes. Svelte/vitest run in CI. Charts bumped: monolith 0.285.281, monolith-public 0.89.207 (both serve /ember). No embervm change this time (frontend only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
