### PR TITLE
fix(monolith): build-systems framing for the /ember/bazel intro

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.136
+version: 0.1.138

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.136
+      targetRevision: 0.1.138
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.209
+version: 0.89.210
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.209
+      targetRevision: 0.89.210
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.283
+version: 0.285.284
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.283
+      targetRevision: 0.285.284
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
@@ -375,7 +375,7 @@
   <title>Ember Bazel Skyframe Query</title>
   <meta
     name="description"
-    content="Bazel spends seconds to minutes analyzing a build graph before it can answer a query. This page skips that step: Abseil (514 targets) was analyzed once, the warm Bazel server was snapshotted with Firecracker, and each query runs in its own throwaway copy of that snapshot."
+    content="Remote execution speeds up a Bazel build's action phase, not loading and analysis. This page removes that cost: Abseil (514 targets) was analyzed once, the warm Bazel server was snapshotted with Firecracker, and each query runs in its own throwaway copy: 13.8 s of cold analysis replaced by a roughly 450 ms round trip."
   />
 </svelte:head>
 
@@ -392,15 +392,17 @@
     <header class="masthead">
       <h1><span class="ember-word">Ember</span> Bazel Skyframe Query</h1>
       <p class="subtitle">
-        Bazel spends seconds to minutes analyzing a build graph before it can
-        answer anything. This page skips that step:
+        Remote execution and remote caching speed up the third phase of a Bazel
+        build: executing actions. They do nothing for the first two, loading and
+        analysis, which run on one machine, in one JVM heap, and are re-paid
+        every time a server starts cold. This page removes that cost.
         <a class="inline-link" href="https://github.com/abseil/abseil-cpp"
           >Abseil</a
         >
         (release 20240116.2, 514 targets) was analyzed once, the warm Bazel
         server was snapshotted with Firecracker, and each query below runs in
-        its own throwaway copy of that snapshot. One query per copy, then it is
-        destroyed.
+        its own throwaway copy of that snapshot: 13.8 seconds of cold analysis
+        replaced by a roughly 450 ms round trip.
       </p>
     </header>
 


### PR DESCRIPTION
Item 9 revision: reframe the /ember/bazel intro around build systems, in the same plain, checkable register as the rest of the page.

## Why

The old intro said "Bazel spends seconds to minutes analyzing before it can answer" but did not name what the demo actually removes or why remote execution/caching does not already solve it. The revised framing makes the point precisely: RE/RBE speed up the action phase; loading and analysis run in one JVM heap and are re-paid on every cold start; this page removes that cost.

## Final intro

> Remote execution and remote caching speed up the third phase of a Bazel build: executing actions. They do nothing for the first two, loading and analysis, which run on one machine, in one JVM heap, and are re-paid every time a server starts cold. This page removes that cost. Abseil (release 20240116.2, 514 targets) was analyzed once, the warm Bazel server was snapshotted with Firecracker, and each query below runs in its own throwaway copy of that snapshot: 13.8 seconds of cold analysis replaced by a roughly 450 ms round trip.

The meta description is updated to match. The rest of the item-9 copy (proof caption, "Cold, warm, and live" intro, savings label, card notes) already merged in the plain register and is unchanged here; it was reviewed to still fit.

## Verification

fast-format clean, no em-dashes, svelte/vitest run in CI. Charts bumped: monolith 0.285.284, monolith-public 0.89.210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
