### PR TITLE
style(monolith): ember bazel header lede split, 58ch measure

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.213
+version: 0.89.214
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.213
+      targetRevision: 0.89.214
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.287
+version: 0.285.288
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.287
+      targetRevision: 0.285.288
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
@@ -398,15 +398,16 @@
   <main class="ember-page">
     <header class="masthead">
       <h1><span class="ember-word">Ember</span> Bazel Skyframe Query</h1>
+      <p class="lede">
+        Bazel recomputes its analysis graph (Skyframe) on every cold start:
+        minutes on a large monorepo, and remote execution can't help.
+      </p>
       <p class="subtitle">
-        Bazel's analysis graph (Skyframe) lives only in server memory, so
-        every cold start recomputes it: minutes on a large monorepo, and
-        remote execution can't help. Here it was computed once for
         <a class="inline-link" href="https://github.com/abseil/abseil-cpp"
           >Abseil</a
         >
-        (514 targets), snapshotted with Firecracker, and every query below
-        restores a throwaway copy.
+        (514 targets) was analyzed once and the warm server snapshotted with
+        Firecracker. Every query below restores a throwaway copy.
       </p>
     </header>
 
@@ -674,8 +675,8 @@
   .masthead {
     display: flex;
     flex-direction: column;
-    gap: 4px;
-    padding-bottom: 4px;
+    gap: 8px;
+    padding-bottom: 8px;
   }
 
   .masthead h1 {
@@ -691,12 +692,24 @@
     color: var(--em-ember);
   }
 
+  /* Lede: the one-sentence hook, a touch bolder and darker than the body
+     paragraph beneath it, on a tighter 58ch measure so it reads as a lede
+     rather than a wide body line. */
+  .lede {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 500;
+    line-height: 1.5;
+    color: var(--em-ink);
+    max-width: 58ch;
+  }
+
   .subtitle {
     margin: 0;
     font-size: 14.5px;
     line-height: 1.5;
     color: var(--em-muted);
-    max-width: 68ch;
+    max-width: 58ch;
   }
 
   .inline-link {


### PR DESCRIPTION
Splits the `/ember/bazel` intro into the two-paragraph lede treatment from the approved mock. Copy + layout only; no behavior change.

## Change
- **Paragraph 1 (lede):** "Bazel recomputes its analysis graph (Skyframe) on every cold start: minutes on a large monorepo, and remote execution can't help." Rendered slightly bolder (weight 500) and darker (`--em-ink`) than the body, on a 58ch measure.
- **Paragraph 2 (body):** "Abseil (514 targets) was analyzed once and the warm server snapshotted with Firecracker. Every query below restores a throwaway copy." Regular subtitle styling, Abseil link preserved, 58ch measure.
- Masthead gap widened (4px to 8px) plus a small padding bump for a comfortable rhythm before the console card.

The old single intro paragraph is deleted. Uses existing `--em-*` tokens only (no new hex, semgrep-clean). No em-dashes.

Charts bumped: monolith + monolith-public (shared image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZBPnXRc4GtkpGhiKEfHh5