### PR TITLE
feat(monolith): show timing and credit savings on failed bazel query

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.214
+version: 0.89.215
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.214
+      targetRevision: 0.89.215
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.288
+version: 0.285.289
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.288
+      targetRevision: 0.285.289
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/ember_public/bazel_core.py
+++ b/projects/monolith/ember_public/bazel_core.py
@@ -208,9 +208,13 @@ async def run_query(expr: str) -> tuple[int, dict]:
         payload = resp.json()
         # A failed query rides back as a successful task carrying an `error` key
         # (the new guest contract). Remap to 422 so the router surfaces bazel's
-        # text to the browser instead of a stale "success" panel.
+        # text to the browser instead of a stale "success" panel. Preserve the
+        # guest's measured wall_ms: a wrong cquery still ran against the warm
+        # snapshot, so the router shows its timing and credits the skipped cold
+        # analysis. wall_ms is 0 for a pre-flight validation reject (no bazel
+        # run), which the router treats as no-credit.
         if payload.get("error"):
-            return 422, {"error": payload["error"]}
+            return 422, {"error": payload["error"], "wall_ms": payload.get("wall_ms")}
         _check_drift(payload.get("analyzed_line"))
         return 200, payload
 

--- a/projects/monolith/ember_public/bazel_core_test.py
+++ b/projects/monolith/ember_public/bazel_core_test.py
@@ -227,8 +227,9 @@ async def test_run_query_maps_guest_200_error_payload_to_422(monkeypatch):
     # New guest contract: a failed query (bad expression, bazel non-zero exit,
     # in-guest timeout) is a SUCCESSFUL task returning HTTP 200 with an `error`
     # key and no labels/analyzed_line, because EmberVM only relays successful-task
-    # responses verbatim. run_query must turn that into a 422 so the router raises
-    # HTTPException(422) and the browser shows bazel's real error text.
+    # responses verbatim. run_query must turn that into a 422 carrying bazel's
+    # error text AND the measured wall_ms, so the router can show the failed
+    # run's timing and credit the skipped cold analysis.
     async def fake_submit(name, *, body, guest_path, read_timeout, **kwargs):
         return _guest_response(
             200,
@@ -245,6 +246,7 @@ async def test_run_query_maps_guest_200_error_payload_to_422(monkeypatch):
 
     assert status == 422
     assert "no such target" in payload["error"]
+    assert payload["wall_ms"] == 210
 
 
 @pytest.mark.asyncio

--- a/projects/monolith/ember_public/bazel_router.py
+++ b/projects/monolith/ember_public/bazel_router.py
@@ -72,12 +72,25 @@ async def bazel_query(body: BazelQueryRequest, request: Request) -> dict:
     finally:
         bazel_core.release_query_slot()
 
-    if status != 200:
+    # A bazel query rejection (status 422: a wrong cquery the guest evaluated
+    # and refused) is a visitor mistake, so it rides back in-band as a 200 with
+    # {error, wall_ms}, matching the pre-submit rejections above. The browser
+    # shows bazel's error text verbatim AND the failed run's timing in the
+    # scoreboard. A transport error (502) or timeout (504) is a real infra
+    # failure, not a visitor mistake, so it stays a 5xx HTTPException.
+    if status not in (200, 422):
         raise HTTPException(status_code=status, detail=payload.get("error"))
 
+    # bazel ran against the warm snapshot for both a success and a query
+    # rejection, so both skipped the cold load+analyze: credit the savings when
+    # a real run happened. wall_ms is 0 for a pre-flight validation reject (no
+    # bazel run), so it credits nothing.
     wall_ms = payload.get("wall_ms")
-    if isinstance(wall_ms, (int, float)):
+    if isinstance(wall_ms, (int, float)) and wall_ms > 0:
         await bazel_core.record_bazel_query_savings(wall_ms)
+
+    if status == 422:
+        return {"error": payload.get("error"), "wall_ms": wall_ms}
     return payload
 
 

--- a/projects/monolith/ember_public/bazel_router_test.py
+++ b/projects/monolith/ember_public/bazel_router_test.py
@@ -92,9 +92,38 @@ def test_query_with_non_numeric_wall_ms_does_not_call_accrual(monkeypatch):
     assert called["n"] == 0
 
 
-def test_failed_query_does_not_accrue_savings(monkeypatch):
+def test_query_rejection_with_wall_ms_returns_200_and_accrues(monkeypatch):
+    # A wrong cquery bazel evaluated and rejected carries a real wall_ms: it
+    # rides back in-band as a 200 with {error, wall_ms}, and because bazel still
+    # ran against the warm snapshot, it credits the skipped cold analysis.
     async def fake_run_query(expr):
-        return 422, {"error": "ERROR: no such package"}
+        return 422, {"error": "ERROR: no such package", "wall_ms": 236}
+
+    monkeypatch.setattr(bazel_core, "run_query", fake_run_query)
+
+    recorded = {}
+
+    async def fake_record(wall_ms):
+        recorded["wall_ms"] = wall_ms
+        return 13.49
+
+    monkeypatch.setattr(bazel_core, "record_bazel_query_savings", fake_record)
+
+    client = _client()
+    resp = client.post("/api/ember/bazel/query", json={"expression": "deps(//nope)"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "no such package" in body["error"]
+    assert body["wall_ms"] == 236
+    assert recorded["wall_ms"] == 236
+
+
+def test_query_rejection_without_wall_ms_does_not_accrue(monkeypatch):
+    # A pre-flight validation reject (no bazel run) carries wall_ms 0: still
+    # returned in-band as a 200 error, but it credits nothing.
+    async def fake_run_query(expr):
+        return 422, {"error": "invalid expression", "wall_ms": 0}
 
     monkeypatch.setattr(bazel_core, "run_query", fake_run_query)
 
@@ -109,7 +138,32 @@ def test_failed_query_does_not_accrue_savings(monkeypatch):
     client = _client()
     resp = client.post("/api/ember/bazel/query", json={"expression": "deps(//nope)"})
 
-    assert resp.status_code == 422
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["error"] == "invalid expression"
+    assert called["n"] == 0
+
+
+def test_transport_error_stays_5xx_and_does_not_accrue(monkeypatch):
+    # A transport error (502) / timeout (504) is a real infra failure, not a
+    # visitor mistake, so it stays a 5xx and credits nothing.
+    async def fake_run_query(expr):
+        return 502, {"error": "could not reach the query workload"}
+
+    monkeypatch.setattr(bazel_core, "run_query", fake_run_query)
+
+    called = {"n": 0}
+
+    async def fake_record(wall_ms):
+        called["n"] += 1
+        return None
+
+    monkeypatch.setattr(bazel_core, "record_bazel_query_savings", fake_record)
+
+    client = _client()
+    resp = client.post("/api/ember/bazel/query", json={"expression": "deps(//nope)"})
+
+    assert resp.status_code == 502
     assert called["n"] == 0
 
 
@@ -130,7 +184,7 @@ def test_savings_endpoint_returns_cached_value(monkeypatch):
     assert body["as_of"]
 
     second = client.get("/api/ember/bazel/savings")
-    assert second.json()["total_analysis_s_saved"] == 128.0
+    assert second.json().get("total_analysis_s_saved") == 128.0
 
     # Second call within the 30s TTL must not re-read the DB.
     assert calls["n"] == 1

--- a/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
@@ -42,6 +42,10 @@
   let stopwatchMs = $state(0);
   let result = $state(null);
   let runError = $state("");
+  // A rejected query (wrong cquery) still ran against the warm snapshot, so the
+  // backend hands back the failed run's wall_ms. Hold it here so the scoreboard
+  // shows the timing even though `result` stays null on an error.
+  let errorWallMs = $state(null);
 
   // All-time "estimated cold analysis time skipped" counter (see
   // ember_public/bazel_router.py GET /savings). SSR-seeded so the counter
@@ -173,6 +177,7 @@
     // does not leave a stale success panel (and its green proof badge) rendered
     // underneath the error box. Filter text resets with it.
     result = null;
+    errorWallMs = null;
     filterText = "";
     startStopwatch();
     try {
@@ -221,6 +226,15 @@
         // rejection) shown verbatim: a typo'd query is a feature here, not
         // a bug, visitors see bazel's actual error text.
         runError = body.error;
+        // A query bazel actually evaluated and rejected still ran against the
+        // warm snapshot, so the backend returns its real wall_ms and credits
+        // the skipped cold analysis. Surface both: the failed run's timing
+        // lands in the "your query" cell and the shared counter ticks up. A
+        // pre-flight validation reject carries no wall_ms (nothing ran).
+        if (typeof body.wall_ms === "number" && body.wall_ms > 0) {
+          errorWallMs = body.wall_ms;
+          refetchSavings();
+        }
         return;
       }
       result = body;
@@ -446,6 +460,8 @@
               {ms(stopwatchMs)}
             {:else if result?.wall_ms != null}
               {ms(result.wall_ms)}
+            {:else if errorWallMs != null}
+              {ms(errorWallMs)}
             {:else}
               &mdash;
             {/if}
@@ -870,6 +886,19 @@
   .run-btn:disabled {
     opacity: 0.55;
     cursor: default;
+  }
+
+  /* Drop the generic blue UA focus ring left after a mouse click, but keep an
+     ember-colored ring for keyboard focus so tab navigation stays visible. */
+  .run-btn:focus,
+  .chip:focus {
+    outline: none;
+  }
+
+  .run-btn:focus-visible,
+  .chip:focus-visible {
+    outline: 2px solid var(--em-ember-deep);
+    outline-offset: 2px;
   }
 
   .chips {


### PR DESCRIPTION
## What

On the `/ember/bazel` Skyframe demo, a failed query (a wrong cquery bazel evaluated and rejected) dropped the **"your query"** timing back to an em-dash and never moved the **"skipped, all visitors"** counter, even though bazel really did run against the warm snapshot and measured a wall time (visible as `INFO: Elapsed time: 0.236s` in the error output).

This surfaces that timing and credits the savings, exactly as a successful query does. The error box (bazel's verbatim text) is unchanged, so a failed query still reads as an error.

## How

- **`bazel_core.run_query`**: preserves the guest's `wall_ms` when mapping a guest error payload to the 422 tuple (it was dropped before).
- **`bazel_router`**: a bazel query rejection (422) now rides back **in-band as a `200 {error, wall_ms}`**, matching the other pre-submit rejections (a wrong query is a visitor mistake, not a 5xx). It credits the skipped cold analysis when a real run happened (`wall_ms > 0`; a pre-flight validation reject carries `wall_ms 0` and credits nothing). Transport errors (502) and timeouts (504) stay 5xx.
- **`+page.svelte`**: holds the failed run's `wall_ms` in `errorWallMs`, shows it in the "your query" cell, and refetches the shared counter so it ticks up on a rejection too.
- **Focus ring**: dropped the generic blue UA focus ring the run/example buttons kept after a mouse click; added an ember-colored `:focus-visible` ring so keyboard focus stays visible.

## Rollout

Bumps **both** `monolith` (0.285.289) and `monolith-public` (0.89.215) per the public-tier checklist, since the ember page is served by `monolith-public` and the router runs in `monolith`.

## Tests

- Rewrote the router's failed-query test into three: rejection-with-`wall_ms` returns 200 and accrues; rejection-without-`wall_ms` returns 200 and does not accrue; transport error stays 5xx and does not accrue.
- Core mapping test now asserts `wall_ms` is forwarded on the guest-200-error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pyb8Nv483e9vay1rboAEtb