### PR TITLE
feat(monolith): queued button state, examples fill without running

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.140
+version: 0.1.141

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.140
+      targetRevision: 0.1.141
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.215
+version: 0.89.217
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.215
+      targetRevision: 0.89.217
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.289
+version: 0.285.291
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.289
+      targetRevision: 0.285.291
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
@@ -25,8 +25,9 @@
   const DEFAULT_EXPR = "deps(//absl/strings)";
   // Known-good cquery expressions offered as one-click chips. Each is verified
   // against the backend charset validator (bazel_core.validate_expr) and is a
-  // real Abseil target/pattern, so a click always returns a result, never an
-  // error. Clicking populates the input AND runs (respecting the cooldown).
+  // real Abseil target/pattern, so running one always returns a result, never
+  // an error. Clicking a chip only fills the input; the visitor runs it with
+  // the button (so they can eyeball or tweak the expression first).
   const EXAMPLES = [
     { label: "deps", expr: "deps(//absl/strings)" },
     { label: "cc_library kinds", expr: 'kind("cc_library", //absl/...)' },
@@ -495,11 +496,18 @@
         />
         <button
           class="run-btn"
+          class:is-pending={running || queuedExpr != null}
           type="button"
           onclick={() => requestRun(expr)}
           disabled={(!!turnstileSiteKey && !sessionReady) || queryUnavailable}
         >
-          {queryUnavailable ? "unavailable" : running ? "querying…" : "run cquery"}
+          {queryUnavailable
+            ? "unavailable"
+            : running
+              ? "querying…"
+              : queuedExpr != null
+                ? "queued…"
+                : "run cquery"}
         </button>
       </div>
 
@@ -510,7 +518,6 @@
             type="button"
             onclick={() => {
               expr = ex.expr;
-              requestRun(ex.expr);
             }}
           >
             {ex.label}
@@ -519,7 +526,7 @@
       </div>
 
       {#if !running && !result && !runError}
-        <p class="idle-hint">run a query or tap an example</p>
+        <p class="idle-hint">pick an example or type your own, then run</p>
       {/if}
 
       {#if runError}
@@ -886,6 +893,29 @@
   .run-btn:disabled {
     opacity: 0.55;
     cursor: default;
+  }
+
+  /* Same "working" cue for both states that block a query: a query in flight
+     (running) and a click parked during the cooldown (queued). A steady pulse
+     reads as pending without the hard-dimmed look of :disabled. */
+  .run-btn.is-pending {
+    cursor: default;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .run-btn.is-pending {
+      animation: run-btn-pulse 1s ease-in-out infinite;
+    }
+  }
+
+  @keyframes run-btn-pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.6;
+    }
   }
 
   /* Drop the generic blue UA focus ring left after a mouse click, but keep an


### PR DESCRIPTION
Two UX tweaks to the `/ember/bazel` demo query bar, following #3709.

## Queued visual when a query is blocked

Queries are blocked in two states: `running` (one in flight) and `queuedExpr != null` (a click parked during the client cooldown). Only `running` had a visual before, so a queued click silently parked while the button still read "run cquery". The button now reads **"queued…"** and shares a steady pulse with the running state (guarded by `prefers-reduced-motion`), so both blocking states look the same.

## Examples fill the input, they don't run

Clicking an example chip now only populates the input; the visitor runs it with the button, so they can read or tweak the expression first. The idle-hint copy moves in lockstep ("pick an example or type your own, then run").

## Rollout

Bumps both `monolith` (0.285.291) and `monolith-public` (0.89.217) per the public-tier checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pyb8Nv483e9vay1rboAEtb