### PR TITLE
fix(embervm): CP crashloop - move noded discovery off the boot path

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.143
+version: 0.1.144

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -353,38 +353,47 @@ defmodule Embervm.Application do
   # supervises nothing rather than crash-looping on a bad dial. The id falls back
   # to the address when unset, purely for correlation labels.
   #
-  # The node list source (artifact-decoupling PR-C, C4). noded is now a DaemonSet
-  # behind a HEADLESS Service, so the control plane discovers every daemon's
-  # INDIVIDUAL pod endpoint via EndpointSlice discovery and dials each one (one
-  # WatchNode stream + one SyncRegistry push per pod), rather than a single
-  # ClusterIP load-balancing one stream to an arbitrary pod. This function
-  # produces the same [%{id, address}] list Embervm.NodeRegistry/NodeChannel
-  # consume, so their ETS projection, age-out, and reassignment are unchanged.
+  # The node list the three node consumers (BaseBuilder, NodeRegistry, NodeChannel)
+  # are SEEDED with at children-construction time (artifact-decoupling PR-C, C4).
   #
-  # An explicit EMBERVM_NODE_ADDRESS override still wins (tests and out-of-cluster
-  # daemons: a single pinned address, no discovery). Otherwise, when the headless
-  # Service name is configured (EMBERVM_NODED_SERVICE), a one-shot EndpointSlice
-  # LIST at boot enumerates the current noded pods. (Interim: a boot-time list, not
-  # a live watch. A daemon whose pod IP changes after a roll is re-discovered on
-  # the next control-plane restart; PR-H replaces this whole seam with CP-managed
-  # per-node Deployments and per-node dialing.) An empty override and no service
-  # name yields [] (the control plane supervises an empty node list and idles).
-  defp configured_nodes do
+  # CRITICAL: this runs while the supervisor children list is being BUILT, which is
+  # BEFORE any child (including Finch, Embervm.K8s.finch_child_spec/0) is started.
+  # So it MUST NOT touch Finch / the K8s API: EndpointSlice discovery cannot run
+  # here (Finch.request would raise "unknown registry: Embervm.Finch" and crash
+  # Application.start into a CrashLoopBackOff). Discovery therefore runs POST-start,
+  # driven by NodeRegistry's periodic discover_fun (which fires promptly after boot,
+  # once Finch is up) and reconciled out to NodeChannel and BaseBuilder as nodes
+  # appear. Here we return only the STATIC source:
+  #
+  #   * an explicit EMBERVM_NODE_ADDRESS override: a single pinned daemon (tests,
+  #     out-of-cluster), which needs no discovery and is safe to seed at boot; or
+  #   * otherwise the EMPTY list. The three consumers start empty and are populated
+  #     by post-Finch discovery. The empty seed is what makes boot Finch-free.
+  # Public (@doc false) so the boot-ordering regression test can assert it is
+  # Finch-free at construction; not part of the module's real API.
+  @doc false
+  def configured_nodes do
     address = trimmed_env("EMBERVM_NODE_ADDRESS")
     id = trimmed_env("EMBERVM_NODE_ID")
 
     cond do
       address != "" and id != "" -> [%{id: id, address: address}]
       address != "" -> [%{id: address, address: address}]
-      true -> discovered_nodes()
+      # Discovery source: seed EMPTY. NodeRegistry's discover_fun populates all
+      # three consumers post-Finch (never at construction, never via Finch here).
+      true -> []
     end
   end
 
   # EndpointSlice-discovered noded endpoints, or [] when discovery is not
   # configured or finds nothing. EMBERVM_NODED_SERVICE names the headless Service;
-  # EMBERVM_NODED_GRPC_PORT is the daemon gRPC port (default 9090). A discovery
-  # error is logged and treated as "no nodes yet" rather than crashing boot: the
-  # control plane still starts (idle) and a later restart re-lists.
+  # EMBERVM_NODED_GRPC_PORT is the daemon gRPC port (default 9090). This is ONLY
+  # ever called POST-start (from NodeRegistry's discover_fun), when Finch is up.
+  #
+  # Defense in depth: the ENTIRE body is wrapped so a transient Finch/API error, or
+  # any raise (e.g. Finch not yet registered on a race, or an apiserver blip), can
+  # NEVER crash the caller: it yields [] (log + idle) and the next discover tick
+  # retries. A raise here previously crashed Application.start; it must not recur.
   defp discovered_nodes do
     service = trimmed_env("EMBERVM_NODED_SERVICE")
 
@@ -403,6 +412,14 @@ defmodule Embervm.Application do
           []
       end
     end
+  rescue
+    e ->
+      Logger.warning("embervm: noded endpoint discovery raised (#{inspect(e)}); starting with no nodes")
+      []
+  catch
+    kind, reason ->
+      Logger.warning("embervm: noded endpoint discovery exited (#{inspect({kind, reason})}); starting with no nodes")
+      []
   end
 
   defp configured_noded_grpc_port do

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -178,6 +178,31 @@ defmodule Embervm.BaseBuilder do
   end
 
   @doc """
+  Add (or update the address of) a node to the builder's placement set
+  (artifact-decoupling PR-C, C4). Under EndpointSlice discovery the builder is
+  SEEDED EMPTY at boot (discovery cannot run at construction time, before Finch),
+  so `Embervm.NodeRegistry`'s post-Finch discovery calls this as each noded pod
+  appears. Adding the FIRST node re-drives every workload that was held
+  `{:pending, :no_node}` so its base finally builds. Idempotent: re-adding a known
+  node only refreshes its address. `whereis`-guarded like `reconcile/2`.
+  """
+  @spec add_node(GenServer.server(), String.t(), String.t()) :: :ok
+  def add_node(server \\ __MODULE__, node_id, address) do
+    cast_if_alive(server, {:add_node, node_id, address})
+  end
+
+  @doc """
+  Remove a node from the builder's placement set (its noded pod vanished from
+  discovery). A workload placed on it is unpinned so a later add re-places it; a
+  build already in flight for that node is left to finish and its result is applied
+  or dropped as usual. `whereis`-guarded like `reconcile/2`.
+  """
+  @spec remove_node(GenServer.server(), String.t()) :: :ok
+  def remove_node(server \\ __MODULE__, node_id) do
+    cast_if_alive(server, {:remove_node, node_id})
+  end
+
+  @doc """
   Report current refcounts against a superseded base snapshot ref for a
   workload, so the BaseBuilder can decide when it is safe to evict (R2 base
   refcounting, ADR embervm/001 standing decision 5). Callers report the counts
@@ -280,6 +305,14 @@ defmodule Embervm.BaseBuilder do
 
   def handle_cast({:forget, name}, state) do
     {:noreply, forget_workload(state, name)}
+  end
+
+  def handle_cast({:add_node, node_id, address}, state) do
+    {:noreply, add_node_to_state(state, node_id, address)}
+  end
+
+  def handle_cast({:remove_node, node_id}, state) do
+    {:noreply, remove_node_from_state(state, node_id)}
   end
 
   @impl true
@@ -387,6 +420,108 @@ defmodule Embervm.BaseBuilder do
         |> write_base_status(w, :building)
         |> maybe_start_build(node_id)
     end
+  end
+
+  # -- node set updates (discovery) --------------------------------------------
+
+  # Add or refresh a node in the placement set, then re-drive every workload that
+  # was held with no node so its base finally builds. Idempotent: a known node id
+  # keeps its queue/worker and only its address is refreshed.
+  defp add_node_to_state(state, node_id, address) do
+    known? = Map.has_key?(state.nodes, node_id)
+
+    state =
+      state
+      |> put_in([:node_addr, node_id], address)
+      |> update_in([:node_ids], fn ids -> if node_id in ids, do: ids, else: ids ++ [node_id] end)
+      |> update_in([:nodes], fn nodes ->
+        Map.put_new(nodes, node_id, %{building: nil, queue: [], worker: nil})
+      end)
+
+    if known? do
+      # A pure address refresh (a rolled pod at a new IP): nothing to re-drive, the
+      # workloads already placed on this id keep their placement and its next build
+      # dials the refreshed address.
+      state
+    else
+      # A newly-added node: re-drive every workload that was held {:pending,
+      # :no_node} (node_id nil, unbuilt) so it places onto the fleet now.
+      state.workloads
+      |> Map.keys()
+      |> Enum.reduce(state, fn name, acc -> redrive_pending_workload(acc, name) end)
+    end
+  end
+
+  # Re-place a held workload (no node, no built base) now that a node exists,
+  # reusing the same enqueue + status + build path reconcile_desc's build branch
+  # uses. A workload already placed or already built is left untouched.
+  defp redrive_pending_workload(state, name) do
+    w = Map.get(state.workloads, name)
+    node_id = placement(state, %{node_id: nil})
+
+    cond do
+      w == nil or node_id == nil ->
+        state
+
+      w.node_id != nil ->
+        # Already placed on some node (or built); do not steal it to a new node.
+        state
+
+      w.snapshot_ref != nil and w.built_signature == signature(w) ->
+        state
+
+      zip_runtime_unresolved?(state, w) ->
+        write_base_status(state, w, {:failed, zip_runtime_error(state, w)})
+
+      true ->
+        w = %{w | node_id: node_id}
+        state = put_in(state.workloads[name], w)
+
+        state
+        |> cancel_pending_retry(name)
+        |> enqueue(node_id, name)
+        |> write_base_status(w, :building)
+        |> maybe_start_build(node_id)
+    end
+  end
+
+  # Remove a node from the placement set: drop it from node_ids/node_addr (so no
+  # NEW build targets it) and UNPIN every workload placed on it (node_id -> nil) so
+  # a later add re-drives it.
+  #
+  # The runtime entry (state.nodes[node_id]) is dropped ONLY when it has no build in
+  # flight. If a worker is still running for this node, we KEEP the entry (with its
+  # queue cleared) so finish_build's put_in([:nodes, node_id, :building], nil) does
+  # not crash on a missing key when that worker reports; the entry is harmless once
+  # node_id is gone from node_ids (nothing places onto it) and finish_build's
+  # trailing maybe_start_build drains the empty queue to a no-op. A pure orphan
+  # entry with no queue and no worker is fine to leave until the next add refreshes
+  # it, but we drop it when idle to keep the map tidy.
+  defp remove_node_from_state(state, node_id) do
+    state =
+      state
+      |> update_in([:node_ids], &List.delete(&1, node_id))
+      |> update_in([:node_addr], &Map.delete(&1, node_id))
+
+    state =
+      case Map.get(state.nodes, node_id) do
+        %{building: nil, worker: nil} ->
+          update_in(state.nodes, &Map.delete(&1, node_id))
+
+        %{} = n ->
+          # Build in flight: keep the entry (clear its queue) so the in-flight
+          # worker's finish_build lands cleanly; it self-cleans on completion.
+          put_in(state.nodes[node_id], %{n | queue: []})
+
+        nil ->
+          state
+      end
+
+    update_in(state.workloads, fn workloads ->
+      for {name, w} <- workloads, into: %{} do
+        if w.node_id == node_id, do: {name, %{w | node_id: nil}}, else: {name, w}
+      end
+    end)
   end
 
   # Cancel a workload's pending backoff-retry timer (if any) when a build is

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -224,6 +224,15 @@ defmodule Embervm.NodeRegistry do
     channel_updater_fun =
       Keyword.get(opts, :channel_updater_fun, &default_channel_update/2)
 
+    # How a discovered node add/remove is propagated to Embervm.BaseBuilder, which
+    # (like NodeChannel) is seeded with an EMPTY node list at boot under discovery
+    # and must learn the fleet so BuildBase can PLACE builds. Without this, a
+    # discovery-configured control plane would never build any base (every workload
+    # holds {:pending, :no_node}). Default calls the singleton BaseBuilder; tests
+    # inject a fake to assert the propagation without a running BaseBuilder.
+    base_builder_updater_fun =
+      Keyword.get(opts, :base_builder_updater_fun, &default_base_builder_update/1)
+
     NodeCapacity.create(table)
 
     now = clock.()
@@ -267,6 +276,7 @@ defmodule Embervm.NodeRegistry do
       discover_fun: discover_fun,
       discover_interval_ms: discover_interval,
       channel_updater_fun: channel_updater_fun,
+      base_builder_updater_fun: base_builder_updater_fun,
       node_runtime: node_runtime,
       # The process notified once per drain rising edge with {:node_draining,
       # node_id, deadline_ms} so it can force-bank the node's live instances before
@@ -296,6 +306,13 @@ defmodule Embervm.NodeRegistry do
       end)
 
     schedule_age_check(state)
+    # Run the FIRST discovery immediately (not after the 30s interval): the app
+    # seeds an EMPTY node list at construction (discovery cannot touch Finch there,
+    # ADR embervm/012 boot ordering), so the fleet only populates once this fires.
+    # By handle_continue time the supervisor has started Finch (NodeRegistry sits
+    # after Finch in the rest_for_one chain), so the K8s list is safe here. A
+    # discover_fun that is nil (pinned override / tests) makes this a no-op.
+    state = reconcile_discovered(state)
     schedule_discover(state)
     {:noreply, state}
   end
@@ -1026,6 +1043,37 @@ defmodule Embervm.NodeRegistry do
     :ok
   end
 
+  # Propagate a discovered node add/remove to the BaseBuilder, swallowing any error
+  # (a BaseBuilder that is not running, a slow call): the fleet still gets WatchNode
+  # capacity via our own streamers, and the next discover tick re-notifies. Never
+  # crash the reconcile on a BaseBuilder hiccup.
+  defp safe_base_builder_update(nil, _msg), do: :ok
+
+  defp safe_base_builder_update(updater, msg) do
+    updater.(msg)
+    :ok
+  rescue
+    e ->
+      Logger.warning("embervm node registry: base builder update #{inspect(msg)} failed: #{inspect(e)}")
+      :ok
+  catch
+    kind, reason ->
+      Logger.warning("embervm node registry: base builder update #{inspect(msg)} exited: #{inspect({kind, reason})}")
+      :ok
+  end
+
+  # Default: add/remove the node on the singleton Embervm.BaseBuilder so BuildBase
+  # placement learns the discovered fleet.
+  defp default_base_builder_update({:add, node_id, address}) do
+    Embervm.BaseBuilder.add_node(node_id, address)
+    :ok
+  end
+
+  defp default_base_builder_update({:remove, node_id}) do
+    Embervm.BaseBuilder.remove_node(node_id)
+    :ok
+  end
+
   # Add a freshly-discovered node (or re-add one at a NEW address after a roll):
   # seed its runtime (mirroring init's shape), propagate the address to the
   # Prime/Assign channel holder so the hot path dials the current endpoint, and
@@ -1048,17 +1096,21 @@ defmodule Embervm.NodeRegistry do
 
     Logger.info("embervm node registry: discovered node #{node_id} (#{address})")
     safe_channel_update(state.channel_updater_fun, node_id, address)
+    safe_base_builder_update(state.base_builder_updater_fun, {:add, node_id, address})
 
     state
     |> put_in([:node_runtime, node_id], rt)
     |> start_streamer(node_id)
   end
 
-  # Remove a node that vanished from discovery: retract its capacity row, kill its
-  # streamer if any (forgetting the pid first so the ensuing DOWN is ignored), and
-  # drop its runtime so no reconnect timer resurrects it.
+  # Remove a node that vanished from discovery: retract its capacity row, tell the
+  # BaseBuilder to drop it, kill its streamer if any (forgetting the pid first so
+  # the ensuing DOWN is ignored), and drop its runtime so no reconnect resurrects
+  # it. (NodeChannel needs no explicit removal: it lazy-dials and invalidates a
+  # dead channel on the next transport error, so a stale map entry is harmless.)
   defp remove_discovered_node(state, node_id) do
     Logger.info("embervm node registry: node #{node_id} vanished from discovery; tearing down")
+    safe_base_builder_update(state.base_builder_updater_fun, {:remove, node_id})
     state = retract_capacity(state, node_id)
 
     state =

--- a/projects/embervm/control/test/embervm/application_test.exs
+++ b/projects/embervm/control/test/embervm/application_test.exs
@@ -1,0 +1,58 @@
+defmodule Embervm.ApplicationTest do
+  @moduledoc """
+  Boot-ordering regression for the noded node-list seed (artifact-decoupling
+  PR-C, C4). `Embervm.Application.configured_nodes/0` seeds BaseBuilder /
+  NodeRegistry / NodeChannel at children-CONSTRUCTION time, which runs BEFORE any
+  supervised child (including Finch) is started. It therefore MUST NOT touch Finch
+  / the K8s API: doing so raised `(ArgumentError) unknown registry: Embervm.Finch`
+  and crash-looped the whole control plane in prod. These tests pin the contract:
+  under discovery config, the seed is EMPTY and Finch-free (post-Finch discovery
+  populates the fleet); the explicit-address override still seeds statically.
+
+  Finch is NOT started in ExUnit, so if configured_nodes/0 called it these tests
+  would RAISE rather than return, which is exactly the regression they guard.
+  """
+  use ExUnit.Case, async: false
+
+  alias Embervm.Application, as: App
+
+  setup do
+    # Snapshot and restore the env vars these tests toggle, so they never leak.
+    saved =
+      for k <- ~w(EMBERVM_NODED_SERVICE EMBERVM_NODE_ADDRESS EMBERVM_NODE_ID EMBERVM_NODED_GRPC_PORT) do
+        {k, System.get_env(k)}
+      end
+
+    on_exit(fn ->
+      for {k, v} <- saved do
+        if v, do: System.put_env(k, v), else: System.delete_env(k)
+      end
+    end)
+
+    for {k, _} <- saved, do: System.delete_env(k)
+    :ok
+  end
+
+  test "configured_nodes/0 seeds EMPTY (and does not touch Finch) under discovery config" do
+    # Discovery is the active source: a headless Service name, no pinned override.
+    System.put_env("EMBERVM_NODED_SERVICE", "embervm-embervm-noded")
+    System.delete_env("EMBERVM_NODE_ADDRESS")
+
+    # Must NOT raise (a Finch call here would raise "unknown registry:
+    # Embervm.Finch" because Finch is not started in ExUnit and, in prod, not yet
+    # started at construction time). Must return the empty seed.
+    assert App.configured_nodes() == []
+  end
+
+  test "configured_nodes/0 seeds the static pinned node when EMBERVM_NODE_ADDRESS is set" do
+    System.put_env("EMBERVM_NODE_ADDRESS", "node-4.test:9090")
+    System.put_env("EMBERVM_NODE_ID", "node-4")
+    # An address override wins over discovery and needs no Finch.
+    assert App.configured_nodes() == [%{id: "node-4", address: "node-4.test:9090"}]
+  end
+
+  test "configured_nodes/0 seeds EMPTY when neither override nor service is configured" do
+    # No discovery, no override: an idle control plane, empty node set, no Finch.
+    assert App.configured_nodes() == []
+  end
+end

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -647,4 +647,68 @@ defmodule Embervm.BaseBuilderTest do
     :ok = BaseBuilder.report_base_refs(builder, "snap1", sessions: 0)
     assert_receive {:evicted, "snap1"}, 1_000
   end
+
+  # -- discovery-fed node set (artifact-decoupling PR-C, C4) -------------------
+
+  test "add_node/3 re-drives a workload held with no node so its base finally builds" do
+    # Under EndpointSlice discovery the builder is SEEDED EMPTY at boot (it cannot
+    # touch Finch at construction), so a workload admitted before any node is
+    # discovered is held {:pending, :no_node}. When NodeRegistry's discovery later
+    # calls add_node, the held workload must re-drive and build.
+    agent = start_recorder()
+    build_fun = fn :fake_channel, _req -> {:ok, resp("snap-late", "sha256:late")} end
+
+    builder =
+      start_builder(nodes: [], status_writer: recording_status_writer(agent), build_fun: build_fun)
+
+    # Admitted with NO node: held pending, no build, Ready=False no_node.
+    :ok = BaseBuilder.reconcile(builder, desc())
+
+    assert_eventually(fn ->
+      case latest(agent, "w") do
+        nil -> false
+        s -> match?(%{"status" => "False"}, condition(s, "Ready")) and s["snapshotRef"] == nil
+      end
+    end)
+
+    # A node is discovered: the held workload re-drives and its base builds.
+    :ok = BaseBuilder.add_node(builder, "node-4", "node-4:9090")
+
+    assert_eventually(fn ->
+      case latest(agent, "w") do
+        nil -> false
+        s -> s["snapshotRef"] == "snap-late"
+      end
+    end)
+
+    st = BaseBuilder.status(builder)
+    assert st.workloads["w"].node_id == "node-4"
+    assert st.workloads["w"].built
+  end
+
+  test "remove_node/2 unpins a workload placed on the vanished node" do
+    agent = start_recorder()
+    build_fun = fn :fake_channel, _req -> {:ok, resp("snap1")} end
+
+    builder =
+      start_builder(nodes: [@node], status_writer: recording_status_writer(agent), build_fun: build_fun)
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+
+    assert_eventually(fn ->
+      case latest(agent, "w") do
+        nil -> false
+        s -> s["snapshotRef"] == "snap1"
+      end
+    end)
+
+    # The node vanishes from discovery: the workload is unpinned (node_id -> nil)
+    # so a later add re-places it, and the node is dropped from the placement set.
+    :ok = BaseBuilder.remove_node(builder, "node-4")
+
+    assert_eventually(fn ->
+      st = BaseBuilder.status(builder)
+      st.workloads["w"].node_id == nil and not Map.has_key?(st.nodes, "node-4")
+    end)
+  end
 end

--- a/projects/embervm/control/test/embervm/node_registry_test.exs
+++ b/projects/embervm/control/test/embervm/node_registry_test.exs
@@ -461,4 +461,45 @@ defmodule Embervm.NodeRegistryTest do
     assert Map.has_key?(NodeRegistry.status(reg), "node-a")
     assert NodeRegistry.status(reg)["node-a"].address == "new-ip:9090"
   end
+
+  test "discovery feeds node add/remove to the BaseBuilder (so BuildBase can place)" do
+    # Under discovery the app seeds BaseBuilder EMPTY at boot (it cannot touch Finch
+    # at construction), so discovery MUST push each node to the BaseBuilder or
+    # BuildBase never places a build. This mirrors the NodeChannel propagation.
+    {:ok, disc} = Agent.start_link(fn -> [] end)
+    on_exit(fn -> if Process.alive?(disc), do: Agent.stop(disc) end)
+
+    {:ok, bb} = Agent.start_link(fn -> [] end)
+    on_exit(fn -> if Process.alive?(bb), do: Agent.stop(bb) end)
+
+    {reg, _table} =
+      start_registry(
+        watch_startup: true,
+        # Seed EMPTY, exactly as the app does under discovery.
+        nodes: [],
+        connect_fun: fn _addr -> {:ok, :fake_channel} end,
+        watch_fun: fn _ch, node_id, emit ->
+          emit.(node_status(node_id: node_id))
+          receive do: (:never -> {:ok, :closed})
+        end,
+        sync_registry_fun: fn _ch, _id -> :ok end,
+        disconnect_fun: fn :fake_channel -> :ok end,
+        discover_fun: fn -> Agent.get(disc, & &1) end,
+        channel_updater_fun: fn _id, _addr -> :ok end,
+        base_builder_updater_fun: fn msg -> Agent.update(bb, &[msg | &1]) end,
+        age_check_ms: 60_000,
+        unknown_after_ms: 60_000,
+        down_after_ms: 60_000
+      )
+
+    # A node appears: the BaseBuilder is told to ADD it (with its address).
+    Agent.update(disc, fn _ -> [%{id: "node-a", address: "a.test:9090"}] end)
+    NodeRegistry.discover(reg)
+    eventually(fn -> {:add, "node-a", "a.test:9090"} in Agent.get(bb, & &1) end, 200)
+
+    # The node vanishes: the BaseBuilder is told to REMOVE it.
+    Agent.update(disc, fn _ -> [] end)
+    NodeRegistry.discover(reg)
+    eventually(fn -> {:remove, "node-a"} in Agent.get(bb, & &1) end, 200)
+  end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.143
+      targetRevision: 0.1.144
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
**Prod-down hotfix.** PR-C shipped a control-plane crashloop: `configured_nodes()` did a Finch-backed EndpointSlice discovery call while the supervision *child list was being constructed*, i.e. before `Supervisor.start_link` starts Finch (child) — so `Finch.request(_, Embervm.Finch, _)` raised `unknown registry: Embervm.Finch` out of `Application.start` → CrashLoopBackOff → fleet down. CI missed it because the Elixir tests stub the discovery seam, so the real Finch path never ran at boot.

## Fix
1. `configured_nodes/0` is Finch-free at construction — seeds an empty list into BaseBuilder/NodeRegistry/NodeChannel under discovery config; the `EMBERVM_NODE_ADDRESS` override stays static. Discovery moved entirely post-Finch.
2. NodeRegistry runs its **first discover immediately** (`handle_continue`, Finch is up by then), so the fleet populates right after boot instead of after the 30s interval.
3. **BaseBuilder learns the discovered fleet** via the same reconcile that already feeds NodeChannel, and adding the first node re-drives every workload held `{:pending, :no_node}` (without this, builds would silently never dispatch).
4. Defense in depth: `discovered_nodes/0` wrapped in `rescue`+`catch` → any error yields `[]` (log + idle), so a raise can never crash boot again.

## Tests
- `application_test.exs` (new): `configured_nodes/0` is Finch-free / returns `[]` under discovery (would raise if it touched Finch, since Finch isn't started in ExUnit — the exact regression), seeds statically under the override.
- discovery-feeds-BaseBuilder (node_registry) + `add_node` re-drives held workload / `remove_node` unpins (base_builder).

Chart 0.1.144. Verify on deploy: CP pod Ready, noded pod Ready after the registry handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)