### PR TITLE
feat(embervm): enable BEAM distribution on the control plane

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.152
+version: 0.1.154

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -60,6 +60,20 @@ spec:
             {{- end }}
             {{- end }}
           env:
+            # BEAM distribution: name the node after the pod IP so `bin/embervm
+            # rpc`/`remote` work (operational access, generation blessing) and so
+            # a future multi-replica CP (PR-J) can cluster. RELEASE_NODE must be
+            # set AFTER the IP var it interpolates. Cookie is auto-generated per
+            # pod for now (single replica); PR-J adds a shared-secret cookie for
+            # clustering.
+            - name: RELEASE_DISTRIBUTION
+              value: name
+            - name: EMBERVM_RELEASE_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: RELEASE_NODE
+              value: "embervm@$(EMBERVM_RELEASE_POD_IP)"
             - name: EMBERVM_HTTP_PORT
               value: {{ .Values.service.port | quote }}
             - name: EMBERVM_OPLOG_PATH

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.152
+      targetRevision: 0.1.154
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Names the CP node after its pod IP so `bin/embervm rpc`/`remote` work (ops access, generation blessing) and PR-J HA clustering. Today's demo-postgres quarantine recovery needed this (rpc impossible with RELEASE_DISTRIBUTION=none). Single-replica auto-cookie for now; PR-J adds a shared-secret cookie.