### PR TITLE
fix(embervm): resolve tag-skewed rootfs to the real base path, never empty

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.155
+version: 0.1.157

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.155
+      targetRevision: 0.1.157
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/registry_workload.go
+++ b/projects/embervm/noded/server/registry_workload.go
@@ -149,6 +149,16 @@ func (r *workloadRegistry) get(workload string) (workloadEntry, bool) {
 // getByImageRef returns the entry whose ImageRef matches imageRef (the BuildBase
 // join). An empty imageRef never matches, so a caller that has no image_ref
 // (e.g. the zip lane's runtime is resolved separately) falls through cleanly.
+//
+// An entry whose RootfsRef is EMPTY is not a valid resolution: it names no
+// node-side rootfs, so returning it hands Firecracker an empty PUT /drives/rootfs
+// path ("No such file or directory") at cold boot. This happens under tag skew:
+// when a workload's base was cut under a guest-image tag that has since churned,
+// the control plane pushes a per-CR entry that matches by image_ref but whose
+// rootfs_ref the identity map could not resolve (empty). We therefore skip
+// empty-RootfsRef matches and prefer the first entry that carries a real path
+// (e.g. the synthetic "image:"-keyed identity entry for the same ref), so a
+// churned tag still resolves to the base present on disk instead of failing.
 func (r *workloadRegistry) getByImageRef(imageRef string) (workloadEntry, bool) {
 	if imageRef == "" {
 		return workloadEntry{}, false
@@ -156,7 +166,7 @@ func (r *workloadRegistry) getByImageRef(imageRef string) (workloadEntry, bool) 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, e := range r.entries {
-		if e.ImageRef == imageRef {
+		if e.ImageRef == imageRef && e.RootfsRef != "" {
 			return e, true
 		}
 	}

--- a/projects/embervm/noded/server/registry_workload_test.go
+++ b/projects/embervm/noded/server/registry_workload_test.go
@@ -190,3 +190,49 @@ func TestPersistAtomicRoundTrip(t *testing.T) {
 		t.Errorf("round-trip mismatch: got %+v (ok=%v), want %+v", got, ok, want)
 	}
 }
+
+// TestGetByImageRefSkipsEmptyRootfsUnderTagSkew is the demo-postgres cold-boot
+// regression: under guest-image tag churn the control plane pushes a per-CR entry
+// that matches by image_ref but whose rootfs_ref the identity map could not
+// resolve (empty), alongside the synthetic "image:"-keyed identity entry that
+// carries the base's real on-disk path. getByImageRef must NOT return the
+// empty-rootfs entry (which would hand Firecracker an empty PUT /drives/rootfs
+// path, "No such file or directory"); it must fall through to the entry with a
+// real path so the churned tag still resolves to the base present on disk.
+func TestGetByImageRefSkipsEmptyRootfsUnderTagSkew(t *testing.T) {
+	r := newWorkloadRegistry("")
+	// Order-independent: register the empty per-CR entry first so a naive
+	// first-match would return it. Both entries carry the SAME image_ref (the
+	// churned tag the daemon resolves a stateful cold boot against).
+	r.sync([]workloadEntry{
+		{Workload: "demo-postgres", ImageRef: "img-pg", RootfsRef: ""},
+		{Workload: "image:img-pg", ImageRef: "img-pg", RootfsRef: "/rootfs/pg", HarnessInit: "/init"},
+	})
+
+	got, ok := r.getByImageRef("img-pg")
+	if !ok {
+		t.Fatal("getByImageRef found no entry for img-pg; want the real-path identity entry")
+	}
+	if got.RootfsRef == "" {
+		t.Fatalf("getByImageRef returned an empty-rootfs entry (%+v); want the entry with a real path", got)
+	}
+	if got.RootfsRef != "/rootfs/pg" {
+		t.Errorf("RootfsRef = %q, want /rootfs/pg", got.RootfsRef)
+	}
+}
+
+// TestGetByImageRefEmptyOnlyDoesNotResolve proves that when the ONLY entry for a
+// ref carries an empty rootfs (no provisioned base anywhere), getByImageRef
+// resolves nothing rather than yielding an empty path. This keeps the cold-boot
+// caller's "not provisioned" FailedPrecondition correct instead of failing later
+// inside Firecracker.
+func TestGetByImageRefEmptyOnlyDoesNotResolve(t *testing.T) {
+	r := newWorkloadRegistry("")
+	r.sync([]workloadEntry{
+		{Workload: "demo-postgres", ImageRef: "img-pg", RootfsRef: ""},
+	})
+
+	if got, ok := r.getByImageRef("img-pg"); ok {
+		t.Fatalf("getByImageRef resolved an empty-rootfs-only ref to %+v; want no resolution", got)
+	}
+}

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -507,7 +507,10 @@ func (s *Server) resolveImage(workload, imageRef string) (config.Image, bool) {
 // through the pushed registry's image_ref index, falling back to the legacy
 // cfg.Images table (empty after Phase 2, kept for tests that seed it).
 func (s *Server) resolveImageByRef(imageRef string) (config.Image, bool) {
-	if e, ok := s.registry.getByImageRef(imageRef); ok {
+	// getByImageRef already skips empty-RootfsRef entries (tag-skew guard), but
+	// assert the invariant here too so this resolution boundary never yields an
+	// empty rootfs path to a cold boot, mirroring the by-workload guard above.
+	if e, ok := s.registry.getByImageRef(imageRef); ok && e.RootfsRef != "" {
 		return config.Image{RootfsPath: e.RootfsRef, HarnessInit: e.HarnessInit}, true
 	}
 	img, ok := s.cfg.Images[imageRef]

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -2001,3 +2001,37 @@ func writeReconcileBase(t *testing.T, basesDir, baseKey, ref string) {
 		}
 	}
 }
+
+// TestResolveImageByRefTagSkewReturnsRealPath is the demo-postgres cold-boot
+// regression at the resolution boundary: with cfg.Images empty (the Phase 2 prod
+// condition) and a tag-skewed registry (an empty-rootfs per-CR entry plus the
+// synthetic identity entry carrying the base's real path, both under the same
+// image_ref), resolveImageByRef must return the REAL rootfs path, never the empty
+// one that Firecracker rejects with "No such file or directory". resolveImage's
+// by-ref fallback and imageProvisioned resolve through the same path.
+func TestResolveImageByRefTagSkewReturnsRealPath(t *testing.T) {
+	_, s := newTestServer(t, &fakeDriver{}, &fakeTransport{}, 8)
+	s.cfg.Images = map[string]config.Image{}
+	s.registry.sync([]workloadEntry{
+		{Workload: "demo-postgres", ImageRef: "img-pg", RootfsRef: ""},
+		{Workload: "image:img-pg", ImageRef: "img-pg", RootfsRef: "/rootfs/pg", HarnessInit: "/init"},
+	})
+
+	img, ok := s.resolveImageByRef("img-pg")
+	if !ok {
+		t.Fatal("resolveImageByRef did not resolve img-pg under tag skew")
+	}
+	if img.RootfsPath != "/rootfs/pg" {
+		t.Fatalf("resolveImageByRef RootfsPath = %q, want /rootfs/pg (never empty)", img.RootfsPath)
+	}
+	if !s.imageProvisioned("img-pg") {
+		t.Error("imageProvisioned(img-pg) = false; want true (base is present under the skewed tag)")
+	}
+
+	// resolveImage's by-ref fallback (workload not keyed, resolves by ref) must
+	// also land on the real path, not the empty per-CR entry.
+	got, ok := s.resolveImage("unknown-workload", "img-pg")
+	if !ok || got.RootfsPath != "/rootfs/pg" {
+		t.Fatalf("resolveImage by-ref fallback = %+v (ok=%v), want RootfsPath=/rootfs/pg", got, ok)
+	}
+}


### PR DESCRIPTION
## Symptom (confirmed on prod)
demo-postgres cold-boot fails at `PUT /drives/rootfs: status 400: Drive config error: ... Error manipulating the backing file: No such file or directory`, while scratch-postgres (same base image) cold-boots fine. The base rootfs files exist on the node's disk. So the base is present; demo-postgres's *resolution* pointed at an empty path.

## Root cause
Under guest-image tag churn (today's repeated image rebuilds), the control plane (`node_registry.ex`) pushes each workload a per-CR `RegistryEntry` whose `rootfs_ref` is looked up from the identity map by `image_ref`: `Map.get(identity, image_ref, {"", ""})`. When the workload's base was cut under a tag that has since churned, that lookup misses and the pushed per-CR entry carries an **empty** `rootfs_ref` (matching by `image_ref` but naming no rootfs). The CP also emits a synthetic `"image:"`-keyed identity entry for every ref the identity map knows, which **does** carry the base's real on-disk path.

On the daemon, `getByImageRef` returned the **first** entry matching by `image_ref`, which could be the empty-rootfs per-CR entry, and `resolveImageByRef` (stateful cold-boot resolves `base.imageDigest` through it) handed that empty path straight to Firecracker. scratch-postgres's identity lookup hit, so its entry carried a real path and it booted.

## Fix (noded-only, minimal)
- `getByImageRef` now skips empty-`RootfsRef` matches and falls through to the entry with a real path (the synthetic identity entry for the same ref), so a churned tag still resolves to the base present on disk.
- `resolveImageByRef` asserts the same `RootfsRef != ""` invariant at the resolution boundary, mirroring the by-workload guard `resolveImage` already applies.
- `resolveImage`'s by-ref fallback and `imageProvisioned` resolve through the same path, so advertised and cold-bootable stay in lockstep.

**CP side left unchanged on purpose.** The empty value originates in `node_registry.ex`, but for any ref the base was actually built from, the identity map holds a non-empty synthetic entry, so the noded non-empty preference fully resolves the live symptom; a CP populate would be redundant. Two in-flight PRs (PR-E cpu_sku #3728 and an R0 dial-home PR) touch that file, so the diff is kept localized to the daemon resolution logic for a clean rebase.

## Tests
- `TestGetByImageRefSkipsEmptyRootfsUnderTagSkew` — empty per-CR entry + real identity entry under the same `image_ref`; asserts the real path is returned, never empty.
- `TestGetByImageRefEmptyOnlyDoesNotResolve` — an empty-rootfs-only ref resolves nothing (keeps the caller's "not provisioned" `FailedPrecondition` correct instead of failing inside Firecracker).
- `TestResolveImageByRefTagSkewReturnsRealPath` — server-level: with `cfg.Images` empty (Phase 2 prod condition) and a skewed registry, `resolveImageByRef`, `resolveImage`'s by-ref fallback, and `imageProvisioned` all land on the real path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAW1XXqeE7KwrUHUkd1ajM