### PR TITLE
fix(embervm): key NodeChannel by node-name so dial-home dispatch resolves

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.160
+version: 0.1.161

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -1074,9 +1074,20 @@ defmodule Embervm.NodeRegistry do
   end
 
   # Seed a newly-registered instance's runtime, propagate its address to the
-  # Prime/Assign channel holder and the BaseBuilder (both keyed by INSTANCE id so a
-  # surge pod gets its own channel), and open its streamer. Mirrors the static seed
-  # shape so age-out and streamer plumbing treat a registered instance identically.
+  # Prime/Assign channel holder (keyed by NODE NAME, see below) and the BaseBuilder
+  # (keyed by INSTANCE id), and open its streamer. Mirrors the static seed shape so
+  # age-out and streamer plumbing treat a registered instance identically.
+  #
+  # NodeChannel keying (single-instance bridge): the registry's own tables are keyed
+  # by instance_id ("node/pod_uid") for future multi-brick, but NodeChannel is the
+  # DISPATCH channel and every consumer addresses it by NODE NAME: PoolManager.refill_node/2
+  # keys on facts.configured_id ("node-4"), and stateful/session/serving/group placement
+  # resolve to a node-name anchor and dispatch by node-name. Keying NodeChannel by
+  # instance_id here left NodeChannel.get("node-4") returning :unknown_node, so the CP
+  # could dispatch NO work behind healthy pods. For today's one-instance-per-node fleet
+  # we point NodeChannel at norm.node (the node name) so every consumer's lookup hits.
+  # The brick-capacity placement PR will migrate NodeChannel AND all consumers to
+  # instance_id keying for multi-instance; this is the single-instance-correct bridge.
   defp add_instance(state, norm, now) do
     rt =
       seed_runtime(
@@ -1091,7 +1102,7 @@ defmodule Embervm.NodeRegistry do
       "embervm node registry: registered instance #{rt.instance_id} (node #{norm.node}, pod #{norm.pod_uid}, #{norm.address})"
     )
 
-    safe_channel_update(state.channel_updater_fun, rt.instance_id, norm.address)
+    safe_channel_update(state.channel_updater_fun, norm.node, norm.address)
     safe_base_builder_update(state.base_builder_updater_fun, {:add, rt.instance_id, norm.address})
 
     state
@@ -1178,10 +1189,16 @@ defmodule Embervm.NodeRegistry do
       :ok
   end
 
-  # Default: point the singleton Embervm.NodeChannel at the instance's address
-  # (the Prime/Assign hot path dials per instance_id, so a surge pod is distinct).
-  defp default_channel_update(instance_id, address) do
-    Embervm.NodeChannel.update_address(instance_id, address)
+  # Default: point the singleton Embervm.NodeChannel at the node's address, keyed by
+  # NODE NAME (not instance_id). Every dispatch consumer (PoolManager.refill_node/2 on
+  # facts.configured_id, plus stateful/session/serving/group placement) looks up the
+  # channel by node-name, so the propagation must match. On a re-registration at a new
+  # address, update_address unconditionally erases the channel cached under this same
+  # node-name key and re-points it, so no stale endpoint survives. (Multi-instance
+  # per node is not reachable until the brick-capacity placement PR migrates NodeChannel
+  # and all consumers to instance_id keying; this node-name keying is that bridge.)
+  defp default_channel_update(node_name, address) do
+    Embervm.NodeChannel.update_address(node_name, address)
     :ok
   end
 

--- a/projects/embervm/control/test/embervm/node_registry_test.exs
+++ b/projects/embervm/control/test/embervm/node_registry_test.exs
@@ -443,8 +443,34 @@ defmodule Embervm.NodeRegistryTest do
     # Same instance (node+pod_uid), NEW address.
     :ok = NodeRegistry.register(reg, %{"node" => "node-4", "pod_uid" => "uid-1", "address" => "new-ip:9090"})
     eventually(fn -> "new-ip:9090" in Agent.get(dialed, & &1) end, 200)
-    eventually(fn -> {"node-4/uid-1", "new-ip:9090"} in Agent.get(chan, & &1) end, 200)
+    # NodeChannel is re-pointed under the NODE NAME key (what every dispatch consumer
+    # looks up), not the instance_id, so a node-name lookup after a re-registration
+    # resolves the new address rather than dialing the dead old endpoint.
+    eventually(fn -> {"node-4", "new-ip:9090"} in Agent.get(chan, & &1) end, 200)
     assert NodeRegistry.status(reg)["node-4/uid-1"].address == "new-ip:9090"
+  end
+
+  test "dial-home registration keys NodeChannel by NODE NAME (what dispatch consumers look up), not instance_id" do
+    # The dispatch outage this guards against: NodeChannel keyed by instance_id
+    # ("node-4/<pod_uid>") left every consumer's node-name lookup (PoolManager.refill_node/2
+    # on facts.configured_id "node-4", and stateful/session/serving/group placement)
+    # returning :unknown_node, so the CP could dispatch NO work behind healthy pods.
+    {:ok, chan} = Agent.start_link(fn -> [] end)
+    on_exit(fn -> if Process.alive?(chan), do: Agent.stop(chan) end)
+
+    {reg, _table} =
+      start_registry(
+        register_seams(
+          channel_updater_fun: fn id, addr -> Agent.update(chan, &[{id, addr} | &1]) end
+        )
+      )
+
+    :ok = NodeRegistry.register(reg, %{"node" => "node-4", "pod_uid" => "uid-1", "address" => "10.42.1.24:9090"})
+
+    # Addressable by the bare node name (the key PoolManager/placement use).
+    eventually(fn -> {"node-4", "10.42.1.24:9090"} in Agent.get(chan, & &1) end, 200)
+    # And NEVER keyed by the instance_id "node-4/uid-1" (that key is invisible to consumers).
+    refute {"node-4/uid-1", "10.42.1.24:9090"} in Agent.get(chan, & &1)
   end
 
   test "registration feeds instance add to the BaseBuilder (so BuildBase can place)" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.160
+      targetRevision: 0.1.161
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Fleet-wide dispatch outage from the dial-home cutover (R0 PR-2)

The dial-home register flow in \`node_registry.ex\` propagated the registered daemon's address to the singleton \`Embervm.NodeChannel\` keyed by the **instance_id** (\`\"node-4/<pod_uid>\"\`). But every dispatch consumer looks up NodeChannel by the bare **node-name**:

- \`Embervm.PoolManager.refill_node/2\` keys on \`facts.configured_id\` = \`\"node-4\"\`.
- Stateful / session / serving / group placement resolve to a node-name anchor and dispatch by node-name.

So \`NodeChannel.get(\"node-4\")\` returned \`{:error, :unknown_node}\` and the CP could dispatch **no** work behind healthy pods: every PoolManager prime failed \`{:connect, :unknown_node}\`, every stateful wake failed \`{:wake_failed, {:start_failed, {:error, :unknown_node}}}\`. Confirmed live on prod and hot-patched in-memory via \`NodeChannel.update_address(NodeChannel, \"node-4\", \"10.42.1.24:9090\")\`, which immediately restored priming and wakes. That alias dies on the next CP restart; this is the durable fix.

## Fix (minimal, single-instance-correct bridge)

Point the register -> NodeChannel propagation at \`norm.node\` (the node-name), matching every consumer:

- \`add_instance/3\` now calls \`safe_channel_update(..., norm.node, norm.address)\` instead of \`rt.instance_id\`.
- \`default_channel_update/2\` renamed its param to \`node_name\` and documents the node-name keying.
- Re-registration at a new address re-points the **same** node-name key (\`update_address\` unconditionally erases the stale channel), so no dead endpoint survives.

The registry's own runtime and BaseBuilder tables stay **instance_id**-keyed (correct for future multi-brick). A comment notes the brick-capacity placement PR will migrate NodeChannel and all consumers to instance_id keying for multi-instance; this is the single-instance-correct bridge. No boot-ordering / Finch changes: this is a pure keying change in existing handlers.

## Tests

- New test: a dial-home registration for \`node-4\` (pod \`uid-1\`) makes NodeChannel addressable by \`\"node-4\"\` (the key PoolManager/placement use), and asserts it is **never** keyed by \`\"node-4/uid-1\"\`.
- Updated the existing re-registration test to assert the node-name key (\`{\"node-4\", \"new-ip:9090\"}\`) is re-pointed on a new address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAW1XXqeE7KwrUHUkd1ajM