### PR TITLE
fix(ember): ship semgrep_scan.client in the public image

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.230
+version: 0.89.231
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.230
+      targetRevision: 0.89.231
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -424,6 +424,16 @@ py3_image(
 _PUBLIC_PRUNE_EXCLUDE = [
     # Standard excludes (mirror :monolith_backend / :main).
     "**/*_test.py",
+    # Semgrep: the public tier ships only semgrep_scan/client.py (+ __init__)
+    # for the ember demo; the MCP tool, App reporting, PR router, full-scan
+    # and perf surfaces are private-only.
+    "semgrep_scan/mcp.py",
+    "semgrep_scan/module.py",
+    "semgrep_scan/report.py",
+    "semgrep_scan/full_scan.py",
+    "semgrep_scan/router.py",
+    "semgrep_scan/cohorts.py",
+    "semgrep_scan/perf_*.py",
     "**/test_*.py",
     "*/tests/**/*.py",
     "shared/testing/**/*.py",
@@ -610,6 +620,10 @@ py_venv_binary(
             # below; main_public_imports_test enforces they stay out of the closure.
             "faas/**/*.py",
             "ember_public/**/*.py",
+            # Semgrep demo (ember_public.semgrep_router): only client.py + the
+            # package __init__ ship; mcp/report/full_scan/router/perf stay
+            # pruned below (private-tier surfaces).
+            "semgrep_scan/**/*.py",
         ],
         exclude = _PUBLIC_PRUNE_EXCLUDE,
     ),  # keep

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -552,6 +552,9 @@ py_library(
             # the demo-postgres core, public-safe by construction (never imports
             # demos/sandbox.client; EMBERVM_URL read directly from the environment).
             "ember_public/**/*.py",
+            # Semgrep demo (ember_public.semgrep_router): only client.py + the
+            # package __init__ ship; the rest is pruned below (private-only).
+            "semgrep_scan/**/*.py",
         ],
         exclude = _PUBLIC_PRUNE_EXCLUDE,
     ),  # keep

--- a/projects/monolith/app/main_public_imports_test.py
+++ b/projects/monolith/app/main_public_imports_test.py
@@ -29,6 +29,12 @@ import pytest  # noqa: F401  (keeps the gazelle pytest dep; see module docstring
 # is matched as a module name OR a dotted prefix (so "chat" also forbids
 # "chat.anything").
 FORBIDDEN_MODULES = [
+    # semgrep_scan: only .client (the fc-invoke HTTP client) is public-safe,
+    # for the ember semgrep demo; the rest of the package is private-only.
+    "semgrep_scan.mcp",
+    "semgrep_scan.report",
+    "semgrep_scan.full_scan",
+    "semgrep_scan.router",
     # Private domains.
     "chat",
     "agent",

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.304
+version: 0.285.305
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.304
+      targetRevision: 0.285.305
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/ember_public/semgrep_router.py
+++ b/projects/monolith/ember_public/semgrep_router.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel
 
 from chat_public.turnstile import siteverify
 from ember_public import semgrep_core
+
 # Module-level so the public binary's srcs must include semgrep_scan and
 # main_public_imports_test verifies the closure stays public-safe in CI.
 from semgrep_scan.client import scan_files

--- a/projects/monolith/ember_public/semgrep_router.py
+++ b/projects/monolith/ember_public/semgrep_router.py
@@ -24,6 +24,9 @@ from pydantic import BaseModel
 
 from chat_public.turnstile import siteverify
 from ember_public import semgrep_core
+# Module-level so the public binary's srcs must include semgrep_scan and
+# main_public_imports_test verifies the closure stays public-safe in CI.
+from semgrep_scan.client import scan_files
 
 logger = logging.getLogger(__name__)
 
@@ -92,12 +95,6 @@ async def semgrep_scan_endpoint(body: SemgrepScanRequest, request: Request) -> d
             status_code=429,
             content={"error": "one scan per few seconds", "retry_after_s": 3},
         )
-
-    # semgrep_scan.client is imported lazily so the fc-invoke HTTP client
-    # (httpx + shared.k8s_auth) is only pulled in on an actual scan request,
-    # keeping module import time light; see app/main_public_imports_test.py
-    # for the public import-closure guard this package must stay clean of.
-    from semgrep_scan.client import scan_files
 
     before_slot = time.monotonic()
     try:


### PR DESCRIPTION
The ember semgrep demo's /scan endpoint imported semgrep_scan.client
lazily, so the public binary's explicit srcs glob never included the
package and every public scan 500d with ModuleNotFoundError (found by
live post-deploy verification; CI passed because the lazy import kept
app.main_public importable).

Fix: glob semgrep_scan into main_public srcs with prune excludes so only
client.py (+ __init__) ships, import it at module level so
main_public_imports_test now guards the closure in CI, and forbid the
private-only semgrep_scan surfaces (mcp, report, full_scan, router)
explicitly in that test.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
