### PR TITLE
chore(firecracker): rightsize fc-invoke CPU 6000m->1000m (free node-4 for bricks)

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.89
+version: 0.4.90

--- a/projects/firecracker/substrate/chart/values.yaml
+++ b/projects/firecracker/substrate/chart/values.yaml
@@ -284,17 +284,19 @@ workloads:
 # this limit; oom_score_adj makes a guest die first if it is ever breached, never
 # the daemon or a node-critical tenant (ADR platform/010).
 #
-# The CPU REQUEST is load-bearing, not a floor. The guest VMs are 1 vcpu each and
-# CPU-bound. cpu.weight is proportional to the request, so a tiny request (the
-# old 50m) let co-tenants (clickhouse/signoz) out-compete the VMs for cores
-# under contention. 6000m holds ~6 cores of weight under contention and stays
-# schedulable on node-4 (~91% requested already); it is deliberately BELOW the
-# concurrency 16: there is no CPU limit, so load tests burst to all idle
-# cores regardless, and the request only decides who wins when co-tenants are
-# busy. Raising it further would overcommit node-4's requests past 100%.
+# The CPU REQUEST is cpu.weight, not a floor (no CPU limit, so a turn bursts to
+# any idle core). It was 6000m when fc-invoke was the ACTIVE Firecracker
+# substrate serving sandbox/semgrep/og-image; those are all cut over to EmberVM
+# now (live + verified 2026-07-14), so fc-invoke's only remaining live workload
+# is goosecracker's intermittent agent turns (POST /invoke/agent/{session}).
+# EmberVM/noded is the active FC substrate on node-4 and needs that CPU weight
+# for its size-class brick fleet, so the reservation is transferred: 1000m
+# guarantees a goose turn one core and still bursts higher under no contention.
+# Full removal of fc-invoke waits on the goosecracker -> EmberVM session-class
+# migration (roadmap); until then this stays deployed at the rightsized weight.
 resources:
   requests:
-    cpu: 6000m
+    cpu: 1000m
     memory: 2Gi
   limits:
     memory: 40Gi

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.89
+      targetRevision: 0.4.90
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
fc-invoke's active functions are all on EmberVM; only goosecracker's intermittent turns remain. Transfer the 6-core CPU-weight reservation to EmberVM's brick fleet: 6000m->1000m frees ~5 cores of node-4's 93% CPU-request saturation. fc-invoke stays deployed (burstable) for goosecracker until the session-class migration retires it.