### PR TITLE
fix(ember): default the semgrep demo to javascript

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.231
+version: 0.89.232
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.231
+      targetRevision: 0.89.232
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.305
+version: 0.285.306
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.305
+      targetRevision: 0.285.306
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/ember/semgrep/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/semgrep/+page.svelte
@@ -25,6 +25,36 @@
   // ---------------------------------------------------------------------
   const EXAMPLES = [
     {
+      language: "javascript",
+      label: "command injection across functions",
+      code: `const express = require("express");
+const { exec } = require("child_process");
+
+const app = express();
+
+function buildCommand(req) {
+  return "convert " + req.query.file + " out.png";
+}
+
+app.get("/convert", (req, res) => {
+  exec(buildCommand(req), () => res.send("ok"));
+});
+`,
+    },
+    {
+      language: "javascript",
+      label: "code injection via eval",
+      code: `const express = require("express");
+
+const app = express();
+
+app.get("/calc", (req, res) => {
+  const result = eval(req.query.expr);
+  res.send(String(result));
+});
+`,
+    },
+    {
       language: "python",
       label: "command injection across functions",
       code: `import os
@@ -61,36 +91,6 @@ def user():
     db = sqlite3.connect("app.db")
     row = db.execute(f"SELECT * FROM users WHERE name = '{name}'").fetchone()
     return str(row)
-`,
-    },
-    {
-      language: "javascript",
-      label: "command injection across functions",
-      code: `const express = require("express");
-const { exec } = require("child_process");
-
-const app = express();
-
-function buildCommand(req) {
-  return "convert " + req.query.file + " out.png";
-}
-
-app.get("/convert", (req, res) => {
-  exec(buildCommand(req), () => res.send("ok"));
-});
-`,
-    },
-    {
-      language: "javascript",
-      label: "code injection via eval",
-      code: `const express = require("express");
-
-const app = express();
-
-app.get("/calc", (req, res) => {
-  const result = eval(req.query.expr);
-  res.send(String(result));
-});
 `,
     },
   ];
@@ -391,15 +391,15 @@ app.get("/calc", (req, res) => {
               <button
                 type="button"
                 class="lang-btn"
-                class:active={language === "python"}
-                onclick={() => setLanguage("python")}>python</button
+                class:active={language === "javascript"}
+                onclick={() => setLanguage("javascript")}
+                >javascript</button
               >
               <button
                 type="button"
                 class="lang-btn"
-                class:active={language === "javascript"}
-                onclick={() => setLanguage("javascript")}
-                >javascript</button
+                class:active={language === "python"}
+                onclick={() => setLanguage("python")}>python</button
               >
             </div>
             <div class="example-picker">


### PR DESCRIPTION
The per-scan cost is the language rule pack (pro-javascript 1.9MB vs
pro-python 15MB), so javascript scans in ~200ms vs ~2s for python. Lead
with the instant one; python stays one toggle away.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
