### PR TITLE
feat(embervm): brick capacity PR-2.5 (per-instance warmth root)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.163
+version: 0.1.164

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.163
+      targetRevision: 0.1.164
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/cmd/main.go
+++ b/projects/embervm/noded/cmd/main.go
@@ -341,6 +341,7 @@ func newDriver(cfg config.Config, self string, x driverExtras) *driver.Driver {
 		VCPUs:             x.vcpus,
 		MemMib:            x.memMib,
 		SnapshotRoot:      cfg.SnapshotRoot,
+		WarmthRoot:        cfg.WarmthRoot,
 		Node:              cfg.Node,
 		Arch:              cfg.Arch,
 		Vendor:            cfg.CpuVendor,

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -99,8 +99,23 @@ type Config struct {
 	DaemonReserveMib int
 
 	// SnapshotRoot is the directory holding FC bundle + base snapshots on the
-	// NVMe scratch disk. Maps to the driver's SnapshotRoot.
+	// NVMe scratch disk. Maps to the driver's SnapshotRoot. Bases (the
+	// node-SHARED rootfs snapshots under SnapshotRoot/bases) always live here,
+	// even for a brick: the same base rootfs is never rebuilt per instance.
 	SnapshotRoot string
+	// WarmthRoot is the root for per-INSTANCE warmth: the regenerable snapshot
+	// state a fresh instance rebuilds rather than shares (sessions, serving,
+	// stateful bundles, group sets, per-thread bundles, checkpoints, group
+	// networks). Derived in Load, never read from env. For a BRICK (a sized
+	// instance, SizeClass and PodUID both set) it nests under
+	// SnapshotRoot/instances/<pod_uid> so two bricks co-located on one node never
+	// clobber each other's warmth; for the legacy DaemonSet (empty SizeClass) it
+	// equals SnapshotRoot, keeping the flat pre-brick layout byte-for-byte so the
+	// DS pod repaths nothing. Bases stay on SnapshotRoot; VolumeRoot (durable
+	// data) and RegistryCachePath are instance-agnostic and unchanged. The driver
+	// falls back to SnapshotRoot when this is empty, so a Config built directly
+	// (tests) without deriving it keeps the flat layout.
+	WarmthRoot string
 	// BinPath is the firecracker binary (baked into the image at /opt/fc).
 	BinPath string
 	// KernelImagePath is the guest kernel (baked at /opt/fc), shared by every VM.
@@ -366,6 +381,20 @@ func Load() (Config, error) {
 		// and must stay outside any bundle-GC policy scoped to SnapshotRoot's
 		// bases/sessions/serving/stateful subtree.
 		c.VolumeRoot = filepath.Join(filepath.Dir(c.SnapshotRoot), filepath.Base(c.SnapshotRoot)+"-volumes")
+	}
+
+	// Per-instance warmth root (brick-capacity). A brick (SizeClass + PodUID both
+	// set) nests warmth under SnapshotRoot/instances/<pod_uid>; every other case
+	// (the legacy DaemonSet with no SizeClass, or an out-of-cluster run with no
+	// PodUID) keeps warmth flat at SnapshotRoot, byte-for-byte the pre-brick
+	// layout. Only derived when SnapshotRoot is set (an unset root disables the
+	// driver entirely, so WarmthRoot stays empty too).
+	if c.SnapshotRoot != "" {
+		if c.SizeClass != "" && c.PodUID != "" {
+			c.WarmthRoot = filepath.Join(c.SnapshotRoot, "instances", c.PodUID)
+		} else {
+			c.WarmthRoot = c.SnapshotRoot
+		}
 	}
 
 	if err := parseDuration("EMBERVM_NODED_BOOT_READY_TIMEOUT", &c.BootReadyTimeout); err != nil {

--- a/projects/embervm/noded/config/config_test.go
+++ b/projects/embervm/noded/config/config_test.go
@@ -322,3 +322,41 @@ func TestLoadRejectsBadDuration(t *testing.T) {
 		t.Error("Load should reject a malformed duration")
 	}
 }
+
+// TestLoadWarmthRootDerivation proves the per-instance warmth root (brick-capacity
+// PR-2.5): a brick (SizeClass + PodUID both set) nests warmth under
+// SnapshotRoot/instances/<pod_uid>; every other case keeps warmth flat at
+// SnapshotRoot so the legacy DaemonSet repaths nothing.
+func TestLoadWarmthRootDerivation(t *testing.T) {
+	root := "/scratch/embervm-noded/snapshots"
+	cases := []struct {
+		name      string
+		snapshot  string
+		sizeClass string
+		podUID    string
+		want      string
+	}{
+		{"brick nests per pod_uid", root, "8gi", "pod-123", root + "/instances/pod-123"},
+		{"legacy DS stays flat (no size class)", root, "", "pod-123", root},
+		{"size class but no pod_uid stays flat", root, "8gi", "", root},
+		{"no snapshot root yields empty", "", "8gi", "pod-123", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("EMBERVM_NODED_SNAPSHOT_ROOT", tc.snapshot)
+			t.Setenv("EMBERVM_NODED_SIZE_CLASS", tc.sizeClass)
+			t.Setenv("EMBERVM_POD_UID", tc.podUID)
+			c, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if c.WarmthRoot != tc.want {
+				t.Errorf("WarmthRoot = %q, want %q", c.WarmthRoot, tc.want)
+			}
+			// Bases stay node-shared on SnapshotRoot regardless.
+			if c.SnapshotRoot != tc.snapshot {
+				t.Errorf("SnapshotRoot = %q, want %q (bases must not move)", c.SnapshotRoot, tc.snapshot)
+			}
+		})
+	}
+}

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -74,7 +74,15 @@ type Config struct {
 	VCPUs  int
 	MemMib int
 	// SnapshotRoot is the directory holding per-thread bundles (/disks/nvme-02).
+	// Node-SHARED base rootfs snapshots (SnapshotRoot/bases) always live here.
 	SnapshotRoot string
+	// WarmthRoot is the root for per-INSTANCE warmth (sessions/serving/stateful
+	// bundles/group sets/per-thread bundles/checkpoints/group networks): a brick
+	// nests it under SnapshotRoot/instances/<pod_uid>; the legacy DaemonSet leaves
+	// it equal to SnapshotRoot (flat, unchanged). Bases stay on SnapshotRoot.
+	// Empty falls back to SnapshotRoot (see warmthRoot), so a driver built from a
+	// Config that never derived it keeps the flat pre-brick layout.
+	WarmthRoot string
 	// Node and Arch pin where snapshots may be restored.
 	Node string
 	Arch string
@@ -268,9 +276,23 @@ func templateMismatch(refTemplate, nodeTemplate string) (bool, string) {
 	return refTemplate != nodeTemplate, refTemplate
 }
 
-// threadDir is the bundle directory for a thread.
+// warmthRoot is the root for per-INSTANCE warmth (sessions, serving, stateful
+// bundles, group sets, per-thread bundles, checkpoints, group networks). For a
+// brick it is SnapshotRoot/instances/<pod_uid> (set by config.Load); for the
+// legacy DaemonSet it equals SnapshotRoot. Falls back to SnapshotRoot when unset
+// so a driver built from a Config that never derived WarmthRoot (tests) keeps the
+// flat pre-brick layout. Bases (baseDir) deliberately do NOT go through here:
+// they stay node-shared on SnapshotRoot.
+func (d *Driver) warmthRoot() string {
+	if d.cfg.WarmthRoot != "" {
+		return d.cfg.WarmthRoot
+	}
+	return d.cfg.SnapshotRoot
+}
+
+// threadDir is the bundle directory for a thread (per-instance warmth).
 func (d *Driver) threadDir(threadID string) string {
-	return filepath.Join(d.cfg.SnapshotRoot, threadID)
+	return filepath.Join(d.warmthRoot(), threadID)
 }
 
 func (d *Driver) snapfilePath(threadID string) string {
@@ -660,7 +682,7 @@ func (d *Driver) ScanServingHandlerArtifacts() []substrate.ServingHandlerArtifac
 // snapshot root so a session bundle is never confused with a base or a per-thread
 // bundle, and so the daemon can rescan exactly this dir on start to report its
 // banked-session inventory. Callers own its 0700 permission and daemon-ownership.
-func (d *Driver) SessionsDir() string { return filepath.Join(d.cfg.SnapshotRoot, "sessions") }
+func (d *Driver) SessionsDir() string { return filepath.Join(d.warmthRoot(), "sessions") }
 
 // sessionDir is the bundle directory for one banked session snapshot, keyed by an
 // opaque session snapshot_ref. It sits under sessions/ so it is never confused
@@ -679,7 +701,7 @@ func (d *Driver) sessionMemfile(ref string) string {
 // under the serving/ prefix of the snapshot root (a sibling of bases/ and sessions/).
 // The daemon rescans exactly this dir on start to report its banked-serving
 // inventory. Callers own its 0700 permission and daemon-ownership.
-func (d *Driver) ServingDir() string { return filepath.Join(d.cfg.SnapshotRoot, "serving") }
+func (d *Driver) ServingDir() string { return filepath.Join(d.warmthRoot(), "serving") }
 
 // servingDir is the bundle directory for one banked serving snapshot, keyed by an
 // opaque serving snapshot_ref. It sits under serving/ so it is never confused with a
@@ -1378,7 +1400,7 @@ func (d *Driver) RemoveServingBundle(snapshotRef string) error {
 // bases/, sessions/, and serving/). The daemon rescans exactly this dir on
 // start via ScanStatefulBundles. Callers own its 0700 permission and
 // daemon-ownership.
-func (d *Driver) StatefulDir() string { return filepath.Join(d.cfg.SnapshotRoot, "stateful") }
+func (d *Driver) StatefulDir() string { return filepath.Join(d.warmthRoot(), "stateful") }
 
 // statefulDir is the bundle directory for one banked stateful snapshot, keyed
 // by an opaque snapshot_ref.
@@ -1512,7 +1534,7 @@ func (d *Driver) SnapshotStateful(ctx context.Context, h substrate.Handle, snaps
 // can NEVER mistake a temp for a committed bundle (ADR embervm/008, guarantee 1).
 // GCStatefulCheckpoints sweeps it on start. Callers own its 0700 daemon-ownership.
 func (d *Driver) CheckpointsDir() string {
-	return filepath.Join(d.cfg.SnapshotRoot, "stateful-checkpoints")
+	return filepath.Join(d.warmthRoot(), "stateful-checkpoints")
 }
 
 func (d *Driver) checkpointTmpDir(token string) string {
@@ -1783,7 +1805,7 @@ func (d *Driver) ScanStatefulBundles() []substrate.StatefulBundleInfo {
 // records, under the group_networks/ prefix of the snapshot root. The daemon
 // rescans exactly this dir on start via ScanGroupNetworks.
 func (d *Driver) GroupNetworksDir() string {
-	return filepath.Join(d.cfg.SnapshotRoot, "group_networks")
+	return filepath.Join(d.warmthRoot(), "group_networks")
 }
 
 // groupNetworkRecordPath is the config.json path for one group-network record,
@@ -1889,7 +1911,7 @@ func (d *Driver) ScanGroupNetworks() []substrate.GroupNetworkRecord {
 // under the group/ prefix of the snapshot root (a sibling of bases/, sessions/,
 // serving/, and stateful/). The daemon rescans exactly this dir on start via
 // ScanGroupBundleSets. Callers own its 0700 permission and daemon-ownership.
-func (d *Driver) GroupSetsDir() string { return filepath.Join(d.cfg.SnapshotRoot, "group") }
+func (d *Driver) GroupSetsDir() string { return filepath.Join(d.warmthRoot(), "group") }
 
 // groupMemberDir is the bundle directory for one banked member snapshot, keyed by
 // the opaque set_id and the member_name: group/<set_id>/<member_name>/.

--- a/projects/embervm/noded/fcvm/driver/driver_test.go
+++ b/projects/embervm/noded/fcvm/driver/driver_test.go
@@ -1184,3 +1184,54 @@ func TestDriverGCStatefulCheckpointsAndReuse(t *testing.T) {
 		t.Fatalf("reuse commit produced an invalid bundle: %+v", ref)
 	}
 }
+
+// TestWarmthRootLayout proves the per-instance warmth split (brick-capacity
+// PR-2.5): a brick (WarmthRoot derived to SnapshotRoot/instances/<pod_uid>) nests
+// every WARMTH dir under WarmthRoot while bases stay node-shared on SnapshotRoot;
+// a Config with no WarmthRoot (the legacy DaemonSet, and every existing test)
+// falls back to SnapshotRoot so the flat pre-brick layout is byte-for-byte
+// unchanged.
+func TestWarmthRootLayout(t *testing.T) {
+	const root = "/scratch/embervm-noded/snapshots"
+
+	brick := New(Config{SnapshotRoot: root, WarmthRoot: root + "/instances/pod-x"}, &fakeLauncher{}, nil)
+	warmth := root + "/instances/pod-x"
+	brickWant := map[string]string{
+		"sessions":             warmth + "/sessions",
+		"serving":              warmth + "/serving",
+		"stateful":             warmth + "/stateful",
+		"group":                warmth + "/group",
+		"stateful-checkpoints": warmth + "/stateful-checkpoints",
+		"group_networks":       warmth + "/group_networks",
+	}
+	got := map[string]string{
+		"sessions":             brick.SessionsDir(),
+		"serving":              brick.ServingDir(),
+		"stateful":             brick.StatefulDir(),
+		"group":                brick.GroupSetsDir(),
+		"stateful-checkpoints": brick.CheckpointsDir(),
+		"group_networks":       brick.GroupNetworksDir(),
+	}
+	for k, want := range brickWant {
+		if got[k] != want {
+			t.Errorf("brick %s dir = %q, want %q", k, got[k], want)
+		}
+	}
+	// A per-thread bundle also nests under the warmth root.
+	if d := brick.threadDir("thread-1"); d != warmth+"/thread-1" {
+		t.Errorf("brick threadDir = %q, want %q", d, warmth+"/thread-1")
+	}
+	// Bases stay NODE-SHARED on SnapshotRoot, never under the instance warmth root.
+	if b := brick.baseDir("base-key"); b != root+"/bases/base-key" {
+		t.Errorf("brick baseDir = %q, want %q (bases must not move per-instance)", b, root+"/bases/base-key")
+	}
+
+	// No WarmthRoot: warmthRoot() falls back to SnapshotRoot (flat, pre-brick).
+	ds := New(Config{SnapshotRoot: root}, &fakeLauncher{}, nil)
+	if d := ds.SessionsDir(); d != root+"/sessions" {
+		t.Errorf("DS SessionsDir = %q, want flat %q", d, root+"/sessions")
+	}
+	if d := ds.StatefulDir(); d != root+"/stateful" {
+		t.Errorf("DS StatefulDir = %q, want flat %q", d, root+"/stateful")
+	}
+}

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -2037,17 +2037,23 @@ func (s *Server) snapshotDiskUsage() (freeBytes, usedBytes uint64) {
 }
 
 // snapshotSessionsDir is the directory holding banked session bundles. It prefers
-// the session driver's own SessionsDir (the single source of truth for the path);
-// when no session driver is wired (task-only tests) it derives it from the config
-// snapshot root, and returns "" if neither is available.
+// the session driver's own SessionsDir (the single source of truth for the path,
+// which resolves under the per-instance warmth root); when no session driver is
+// wired (task-only tests) it derives it from the config warmth root (WarmthRoot
+// when set, else SnapshotRoot, mirroring driver.warmthRoot), and returns "" if
+// neither is available.
 func (s *Server) snapshotSessionsDir() string {
 	if s.sessionDriver != nil {
 		return s.sessionDriver.SessionsDir()
 	}
-	if s.cfg.SnapshotRoot == "" {
+	warmth := s.cfg.WarmthRoot
+	if warmth == "" {
+		warmth = s.cfg.SnapshotRoot
+	}
+	if warmth == "" {
 		return ""
 	}
-	return filepath.Join(s.cfg.SnapshotRoot, "sessions")
+	return filepath.Join(warmth, "sessions")
 }
 
 // ---- startup base reconciliation -------------------------------------------

--- a/projects/embervm/noded/server/store.go
+++ b/projects/embervm/noded/server/store.go
@@ -168,12 +168,22 @@ func legacyArtifactPrefix(ref *nodev1.ArtifactRef) string {
 }
 
 // artifactLocalDir resolves the on-disk directory holding a ref's files. It
-// mirrors the driver's per-kind bundle layout under SnapshotRoot (bases/,
-// sessions/, serving/, stateful/, group/<set_id>/) and the volume manager's
-// VolumeRoot/<workload>. Returns "" when the kind is unknown or the relevant
-// substrate is not configured, which the caller maps to FAILED_PRECONDITION.
+// mirrors the driver's per-kind bundle layout: BASES are node-shared under
+// SnapshotRoot/bases, while the WARMTH kinds (sessions/, serving/, stateful/,
+// group/<set_id>/) live under WarmthRoot, which for a brick nests at
+// SnapshotRoot/instances/<pod_uid> and for the legacy DaemonSet equals
+// SnapshotRoot (the driver's warmthRoot fallback is mirrored here). Volumes live
+// under the volume manager's VolumeRoot/<workload>. Returns "" when the kind is
+// unknown or the relevant substrate is not configured, which the caller maps to
+// FAILED_PRECONDITION.
 func (s *Server) artifactLocalDir(ref *nodev1.ArtifactRef) string {
 	root := s.cfg.SnapshotRoot
+	// Warmth root, mirroring driver.warmthRoot: WarmthRoot when set, else
+	// SnapshotRoot (a Config that never derived WarmthRoot keeps the flat layout).
+	warmth := s.cfg.WarmthRoot
+	if warmth == "" {
+		warmth = s.cfg.SnapshotRoot
+	}
 	switch ref.GetKind() {
 	case nodev1.ArtifactKind_ARTIFACT_KIND_BASE:
 		if root == "" {
@@ -181,25 +191,25 @@ func (s *Server) artifactLocalDir(ref *nodev1.ArtifactRef) string {
 		}
 		return filepath.Join(root, "bases", ref.GetRef())
 	case nodev1.ArtifactKind_ARTIFACT_KIND_SESSION:
-		if root == "" {
+		if warmth == "" {
 			return ""
 		}
-		return filepath.Join(root, "sessions", ref.GetRef())
+		return filepath.Join(warmth, "sessions", ref.GetRef())
 	case nodev1.ArtifactKind_ARTIFACT_KIND_SERVING:
-		if root == "" {
+		if warmth == "" {
 			return ""
 		}
-		return filepath.Join(root, "serving", ref.GetRef())
+		return filepath.Join(warmth, "serving", ref.GetRef())
 	case nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL:
-		if root == "" {
+		if warmth == "" {
 			return ""
 		}
-		return filepath.Join(root, "stateful", ref.GetRef())
+		return filepath.Join(warmth, "stateful", ref.GetRef())
 	case nodev1.ArtifactKind_ARTIFACT_KIND_GROUP_SET:
-		if root == "" {
+		if warmth == "" {
 			return ""
 		}
-		return filepath.Join(root, "group", ref.GetRef())
+		return filepath.Join(warmth, "group", ref.GetRef())
 	case nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME:
 		if s.volumes == nil {
 			return ""


### PR DESCRIPTION
Mechanical driver-side split, landing right before PR-3's canary exercises it (the Fable escape hatch from the PR-1 per-instance-dirs deferral). **Inert on the live DaemonSet**: the DS keeps the flat pre-brick snapshot layout byte-for-byte; only a brick (a sized instance) gets per-instance warmth dirs.

## What changes
- **config**: new `WarmthRoot`, derived in `Load`. A brick (`SizeClass` + `PodUID` both set) nests it at `SnapshotRoot/instances/<pod_uid>`; the legacy DaemonSet (empty `SizeClass`) or an out-of-cluster run (no `PodUID`) leaves it equal to `SnapshotRoot`. **Bases stay node-shared on `SnapshotRoot`**; `VolumeRoot` + `RegistryCachePath` are instance-agnostic and unchanged.
- **driver**: `warmthRoot()` helper — **falls back to `SnapshotRoot` when `WarmthRoot` is unset**, so a `Config` built directly in tests keeps the flat layout untouched. The six warmth accessors (`SessionsDir`/`ServingDir`/`StatefulDir`/`CheckpointsDir`/`GroupNetworksDir`/`GroupSetsDir`) and `threadDir` now resolve under `warmthRoot()`; `baseDir` stays on `SnapshotRoot`. The `stateful-checkpoints`↔`stateful` sibling invariant holds (both move together).
- **store.go** `artifactLocalDir` mirrors it: BASE on `SnapshotRoot`, warmth kinds on the same `WarmthRoot`-with-fallback; `server.snapshotSessionsDir`'s test-only fallback mirrors it too.

## Why
Two bricks co-located on one node (PR-3) must not clobber each other's warmth in a shared dir; bases stay shared so identical rootfs is never rebuilt per instance. Durable data (`VolumeRoot`) is already a separate node-shared root, so the split is bounded to **regenerable warmth** — never data.

## Safety
- The DS render/behavior is unchanged (empty `SizeClass` → `WarmthRoot == SnapshotRoot`).
- Existing driver/server tests are unchanged **by construction**: they set `SnapshotRoot` only, so the `warmthRoot()` fallback keeps them flat.
- New tests: config `WarmthRoot` derivation (brick / DS / no-pod-uid / no-root) and driver layout (brick nests warmth, bases stay on `SnapshotRoot`, empty `WarmthRoot` falls back flat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)