### PR TITLE
feat(embervm): brick capacity PR-3b canary (enable 2gi brick on node-4)

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -92,6 +92,24 @@ noded:
     nodeMap:
       node-4: /disks/nvme-02
 
+# Size-class BRICK cutover, canary step 1 (brick-capacity PR-3b, decisions.md
+# 2026-07-19). Flips bricks on for the FIRST real co-location beside the legacy
+# noded DaemonSet on node-4. Deep-merged over the chart's bricks block, so this
+# overlay only adds the two keys and the chart's classes ladder (2/4/8/16Gi)
+# stands. desiredReplicas lists ONLY 2gi, so the small brick renders at 1 replica
+# and the other three classes render at 0 (an unlisted class defaults to 0): one
+# live 2gi brick pod plus three empty Deployments. Small-first is deliberate: it
+# adds only +1 core to node-4 during the DS overlap and exercises the whole path
+# (PR-2 dispatcher spread, PR-2.5 per-instance warmth, PR-3a BrickController
+# reconcile + dial-home size_class) before the large 16gi brick lands in a
+# follow-up. No chart bump: this is the $values git ref, read straight from git;
+# ArgoCD ignores Deployment /spec/replicas fleet-wide so the controller (not this
+# value) owns the count after first create.
+bricks:
+  enabled: true
+  desiredReplicas:
+    2gi: 1
+
 # EmberVM R4 scale-to-zero scratch-postgres (ADR embervm/001, D-R4.PR-11.1):
 # enabled with the k8s-homelab 1Password item whose POSTGRES_PASSWORD field syncs
 # into this namespace's Secret. listenPort (5400) + embervmNamespace default from


### PR DESCRIPTION
## What

Canary step 1 of the DaemonSet→brick cutover. Flips `bricks.enabled=true` with `desiredReplicas: {2gi: 1}` on the embervm `$values` deploy ref (no chart bump).

## Render diff vs main (verified locally)

Purely additive, zero removals:
- **Four** brick Deployments render: `noded-brick-2gi` at **replicas 1**, `4gi`/`8gi`/`16gi` at **0** (unlisted → default 0).
- The live 2gi brick's main noded container carries `EMBERVM_NODED_SIZE_CLASS: "2gi"`, `requests.cpu: "1"`, `requests/limits.memory: 2Gi` (Joe's ladder; mem request==limit, no cpu limit).
- CP pod gains `EMBERVM_BRICK_CLASSES` + `EMBERVM_BRICK_DEPLOYMENT_PREFIX`, arming the already-live `Embervm.BrickController`.

## Why small-first

Adds only +1 core to node-4 during the DS overlap and exercises the whole new path (PR-2 dispatcher spread, PR-2.5 per-instance warmth, PR-3a controller reconcile + dial-home `size_class`) before the 16gi brick lands in a follow-up. Per `docs/decisions/embervm/brick-program-decisions.md` (2026-07-19).

## Rollback

`bricks.enabled=false` (cheaply reversible). PR-3c (DS prune) is separate and gated on explicit go-ahead.

## Post-merge soak plan

Verify: both classes... 2gi brick dial-homes registered with `size_class=2gi`; dispatch lands on the brick via `BrickLedger.choose`; per-instance warmth dir created with no cross-clobber; no spurious `:fleet_full`; CP stable; one deliberate demo-postgres exercise. Soak a few hours past the 5m fleet-full window before the 16gi step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)