### PR TITLE
feat(embervm): brick capacity PR-3b step 2 (16gi large brick on node-4)

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -109,6 +109,15 @@ bricks:
   enabled: true
   desiredReplicas:
     2gi: 1
+    # Canary step 2 (large): the 16gi brick node-4's serving/session workloads
+    # actually need (a ~10Gi composite group's bridge fits only the 16gi class).
+    # Added after the 2gi brick verified healthy (co-located beside the DS,
+    # dial-home + registry connected/healthy/dispatchable, per-instance warmth
+    # bases built with no clobber, no :fleet_full past the 5m window). Staged
+    # second so node-4 absorbed +1 core then +2 cores rather than +3 at once
+    # during the DS overlap. Projected node-4 load with both bricks: ~83% CPU /
+    # ~81% memory requests, no Pending. Reverts by removing this line.
+    16gi: 1
 
 # EmberVM R4 scale-to-zero scratch-postgres (ADR embervm/001, D-R4.PR-11.1):
 # enabled with the k8s-homelab 1Password item whose POSTGRES_PASSWORD field syncs


### PR DESCRIPTION
## What

Second half of the small-first canary (step 1 was #3742, the 2gi brick). Adds `desiredReplicas: {16gi: 1}` on the embervm `$values` ref (no chart bump), co-locating the large brick beside the 2gi brick and the legacy DaemonSet on node-4.

## Why now / why staged

The 2gi brick verified healthy on the live fleet: registry `connected/healthy/dispatchable`, per-instance warmth bases built with no cross-clobber (DS independently healthy), no `:fleet_full` past the 5m window, CP 0 restarts. Small-first was deliberate so node-4 absorbed +1 then +2 cores rather than +3 at once during the DS overlap.

The 16gi is the class node-4's serving/session workloads actually need (the ~10Gi composite group bridge fits only 16gi), and it's where real dispatch placement will land (2gi is too small for the memory-heavy semgrep/sandbox guests).

## Capacity check (live, before merge)

node-4 with the 2gi brick present: CPU 70%, memory 55%. Adding 16gi (+2 cores, +16Gi): **~83% CPU / ~81% memory** requests. Fits, no Pending.

## Render (verified)

`2gi=1, 16gi=1`, `4gi/8gi=0`; CP `EMBERVM_BRICK_CLASSES` carries both desired counts.

## Rollback

Remove the `16gi: 1` line. PR-3c (DS prune) remains separate and gated on explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)