### PR TITLE
fix(monolith): truncate ember semgrep inline flag chip to trailing rule-id segments

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.237
+version: 0.89.238
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.237
+      targetRevision: 0.89.238
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.311
+version: 0.285.312
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.311
+      targetRevision: 0.285.312
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/ember/ScanView.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/ScanView.svelte
@@ -259,6 +259,26 @@
     highlightedLine = f.line;
   }
 
+  // Rule ids are dot-separated paths whose specificity increases left to
+  // right (etc.semgrep.rules.pro-javascript....express-child-process), so
+  // the inline flag chip keeps whole trailing segments within its width
+  // budget and drops the registry-boilerplate prefix behind an ellipsis.
+  // The findings list below still shows the full id.
+  const FLAG_ID_BUDGET = 28;
+
+  function shortRuleId(id) {
+    if (!id || id.length <= FLAG_ID_BUDGET) return id;
+    const segs = id.split(".");
+    let out = segs.pop() ?? "";
+    while (
+      segs.length > 0 &&
+      out.length + segs[segs.length - 1].length + 1 <= FLAG_ID_BUDGET
+    ) {
+      out = `${segs.pop()}.${out}`;
+    }
+    return `…${out}`;
+  }
+
   let sortedFindings = $derived.by(() => {
     const order = { ERROR: 0, WARNING: 1, INFO: 2 };
     return [...findings].sort(
@@ -325,7 +345,7 @@
                 class:err={finding.severity === "ERROR"}
                 class:warn={finding.severity !== "ERROR"}
               >
-                {finding.rule_id}
+                {shortRuleId(finding.rule_id)}
               </span>
             {/if}
           </div>
@@ -598,6 +618,9 @@
     border-radius: 4px;
     color: var(--em-on-color);
     white-space: nowrap;
+    max-width: 172px;
+    overflow: hidden;
+    text-overflow: ellipsis;
     opacity: 0;
     translate: 8px 0;
     transition:


### PR DESCRIPTION
The /ember/semgrep inline flag chip rendered the full Pro rule id (~90 chars for e.g. `etc.semgrep.rules.pro-javascript.javascript.express.express-child-process.express-child-process`), blowing past the row's 190px flag reservation and overlapping the code text.

Fix: a small `shortRuleId` helper keeps whole trailing dot-segments within a 28-char budget and prefixes an ellipsis (rule-id specificity increases left to right, so the tail carries all the signal). The findings list below still shows the full id. A CSS `max-width` + `text-overflow: ellipsis` on `.flag` backstops any single segment longer than the budget.

Both charts bumped (public page, shared image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)