### PR TITLE
fix(embervm): idempotent serving tap create (delete stale tap first)

### DIFF
--- a/projects/embervm/noded/serving/net.go
+++ b/projects/embervm/noded/serving/net.go
@@ -388,6 +388,15 @@ func (m *Manager) AllocateTap(ctx context.Context) (tap string, ip net.IP, err e
 		return "", nil, err
 	}
 	tap = TapNameForIP(ip)
+	// Idempotent create: best-effort delete any stale tap of this name first.
+	// The allocator just handed us this IP exclusively (allocate() marks it used),
+	// so a device already bearing its deterministic name is orphaned, not live: a
+	// prior VM whose setup failed AFTER tap creation (e.g. a downstream volume
+	// attach) and left the device behind. Without this, the leaked tap makes
+	// `ip tuntap add` fail EBUSY and wedges every retry (observed 2026-07-20: a
+	// leaked emtap left demo-postgres unable to relight and 503'd jomcgi.dev/health).
+	// Deleting an absent tap is a tolerated error.
+	_, _ = m.runner.Run(ctx, "ip", tapTeardownArgs(tap)[1:]...)
 	for _, argv := range tapSetupArgs(tap, m.bridge) {
 		if _, rerr := m.runner.Run(ctx, argv[0], argv[1:]...); rerr != nil {
 			// Roll back: delete whatever tap fragment exists, release the IP.
@@ -411,6 +420,12 @@ func (m *Manager) AllocateTapForIP(ctx context.Context, ip net.IP) (tap string, 
 		return "", err
 	}
 	tap = TapNameForIP(ip)
+	// Idempotent create: best-effort delete any stale tap of this name first. The
+	// relight just reserve()'d this exact IP (D-R3.4.1 pin) and reserve errors on a
+	// live conflict, so a device already bearing its name is orphaned, not live, and
+	// recreating over it would fail EBUSY and wedge every retry (see AllocateTap).
+	// Deleting an absent tap is a tolerated error.
+	_, _ = m.runner.Run(ctx, "ip", tapTeardownArgs(tap)[1:]...)
 	for _, argv := range tapSetupArgs(tap, m.bridge) {
 		if _, rerr := m.runner.Run(ctx, argv[0], argv[1:]...); rerr != nil {
 			_, _ = m.runner.Run(ctx, "ip", tapTeardownArgs(tap)[1:]...)

--- a/projects/embervm/noded/serving/net_test.go
+++ b/projects/embervm/noded/serving/net_test.go
@@ -341,6 +341,64 @@ func TestAllocateAndReleaseTap(t *testing.T) {
 	}
 }
 
+// TestAllocateTapDeletesStaleTapBeforeCreate locks in the idempotent-create fix:
+// both allocation paths must issue `ip link del <tap>` BEFORE `ip tuntap add <tap>`,
+// so a tap orphaned by a prior VM whose setup failed after tap creation (e.g. a
+// downstream volume attach) is cleared instead of wedging the recreate with EBUSY
+// (the 2026-07-20 demo-postgres relight wedge that 503'd jomcgi.dev/health).
+func TestAllocateTapDeletesStaleTapBeforeCreate(t *testing.T) {
+	assertDelBeforeAdd := func(t *testing.T, calls [][]string, tap string) {
+		t.Helper()
+		delIdx, addIdx := -1, -1
+		for i, c := range calls {
+			if len(c) >= 4 && c[0] == "ip" && c[1] == "link" && c[2] == "del" && c[3] == tap {
+				if delIdx == -1 {
+					delIdx = i
+				}
+			}
+			if len(c) >= 5 && c[0] == "ip" && c[1] == "tuntap" && c[2] == "add" && c[4] == tap {
+				addIdx = i
+			}
+		}
+		if delIdx == -1 {
+			t.Fatalf("no `ip link del %s` recorded; calls: %v", tap, calls)
+		}
+		if addIdx == -1 {
+			t.Fatalf("no `ip tuntap add ... %s` recorded; calls: %v", tap, calls)
+		}
+		if delIdx > addIdx {
+			t.Errorf("`ip link del %s` (call %d) must precede `ip tuntap add` (call %d)", tap, delIdx, addIdx)
+		}
+	}
+
+	t.Run("AllocateTap", func(t *testing.T) {
+		fr := &fakeRunner{}
+		m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000)
+		if err != nil {
+			t.Fatalf("NewManager: %v", err)
+		}
+		tap, _, err := m.AllocateTap(context.Background())
+		if err != nil {
+			t.Fatalf("AllocateTap: %v", err)
+		}
+		assertDelBeforeAdd(t, fr.calls, tap)
+	})
+
+	t.Run("AllocateTapForIP", func(t *testing.T) {
+		fr := &fakeRunner{}
+		m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000)
+		if err != nil {
+			t.Fatalf("NewManager: %v", err)
+		}
+		pin := net.ParseIP("172.31.0.2")
+		tap, err := m.AllocateTapForIP(context.Background(), pin)
+		if err != nil {
+			t.Fatalf("AllocateTapForIP: %v", err)
+		}
+		assertDelBeforeAdd(t, fr.calls, tap)
+	})
+}
+
 func TestAllocateTapForIPPinsAndConflicts(t *testing.T) {
 	fr := &fakeRunner{}
 	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000)


### PR DESCRIPTION
## Root cause (found via the brick co-location canary)

`AllocateTap`/`AllocateTapForIP` in `noded/serving/net.go` run `ip tuntap add` and only roll back if **that** call fails. When a **downstream** step fails after the tap is created — e.g. a stateful **volume attach** — the tap is left orphaned in noded's netns. The next relight calls `ip tuntap add` over that stale name and fails:

```
noded: allocate stateful tap: ip tuntap add dev emtap0002 mode tap:
exit status 1: ioctl(TUNSETIFF): Device or resource busy
```

...which wedges **every** retry forever.

**Live impact (2026-07-20):** a leaked `emtap0002` left `demo-postgres` unable to relight, so `jomcgi.dev/health` returned 503 until the noded pod was manually restarted. The brick co-location cutover's CP roll was the *trigger* (it forced a stateful re-wake); the bug is pre-existing and independent of bricks — any CP roll or concurrent wake hits it.

## Fix

Best-effort `ip link del <tap>` before create in both allocation paths. Safe because the allocator has already claimed the IP **exclusively** (`allocate()` marks it used; `reserve()` errors on a live conflict), so a device already bearing its deterministic name is **orphaned, not live**. Mirrors the existing bridge idempotency in `EnsureNetwork` (which tolerates "already exists"). Deleting an absent tap is a tolerated error.

Test asserts `ip link del <tap>` precedes `ip tuntap add <tap>` in both `AllocateTap` and `AllocateTapForIP`.

## Not in this PR (filed as follow-ups)

The same incident exposed two other bugs, in different subsystems, each worth its own PR:
1. **Volume writable-attach lease** isn't released on a failed attach → `scratch-postgres` retry-stormed (175 failed wakes/2min) on `already has a writable attach in progress`.
2. **CP gRPC `:noproc`** — the control plane dials a dead Mint connection process (the `grpc 1.0.2` cancel-handling crash); co-location amplifies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)