### PR TITLE
fix(monolith): sync ember semgrep sweep ignition to row pixel positions

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.238
+version: 0.89.239
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.238
+      targetRevision: 0.89.239
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.312
+version: 0.285.313
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.312
+      targetRevision: 0.285.313
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/ember/ScanView.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/ScanView.svelte
@@ -148,7 +148,13 @@
     const sweepMs = Math.max(scanMs, 700);
     const lineOrder = codeLines.map((_, i) => i);
     const total = Math.max(lineOrder.length, 1);
-    const boxH = mirrorEl ? mirrorEl.scrollHeight : 0;
+    // The sweep must travel the rows' actual pixel height, and lines must
+    // ignite by pixel comparison against it. scrollHeight clamps to the
+    // 320px viewport when the snippet is shorter, so using it (or line
+    // fractions of the duration) makes findings light up after the sweep
+    // has already passed their row.
+    const rowH = mirrorEl?.querySelector(".row")?.offsetHeight ?? 0;
+    const boxH = rowH > 0 ? rowH * total : (mirrorEl?.scrollHeight ?? 0);
 
     if (reduced) {
       sweepOpacity = 0;
@@ -168,7 +174,11 @@
       let changed = false;
       lineOrder.forEach((i) => {
         const line = i + 1;
-        if (findingByLine.has(line) && !next.has(i) && (i + 0.5) / total <= p) {
+        if (
+          findingByLine.has(line) &&
+          !next.has(i) &&
+          sweepTop >= (i + 0.5) * (boxH / total)
+        ) {
           next.add(i);
           changed = true;
         }


### PR DESCRIPTION
Findings on /ember/semgrep lit up after the sweep line had visibly passed their row. Cause: the sweep travelled `scrollHeight` (clamped to the 320px viewport for short snippets) while ignition compared line-count fractions of the animation duration, two different coordinate systems. Now the sweep travels the rows' measured pixel height (`rowH * total`, falling back to `scrollHeight` if no row is measurable) and lines ignite when the sweep reaches their pixel center, so the flag chip appears exactly as the line is crossed.

Both charts bumped (public page, shared image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)