### PR TITLE
chore(embervm): bump chart to 0.1.166 (deploy noded tap idempotency fix)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.165
+version: 0.1.166

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.165
+      targetRevision: 0.1.166
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Deploys #3745. The running noded is digest-pinned to the pre-fix image (the bump guard fail-opened on a noded-only code change, so #3745 merged without rolling out). This bump re-pins the fixed noded digest and rolls the noded pods.

- CP image unchanged → no control-plane roll.
- Rolling the DS noded re-evicts banked demo-postgres → `/health` blips 503 until re-woken (now self-healing with the tap fix live). I'll re-wake it immediately post-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)