### PR TITLE
feat(monolith): fast SSRF python example + language-grouped chips on ember semgrep

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.239
+version: 0.89.240
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.239
+      targetRevision: 0.89.240
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.313
+version: 0.285.314
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.313
+      targetRevision: 0.285.314
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/ember/ScanView.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/ScanView.svelte
@@ -297,21 +297,44 @@
   });
 
   let scanErrors = $derived(result?.errors ?? []);
+
+  // Example chips grouped by consecutive language runs so each language
+  // gets a small caption and a divider; indices stay global because
+  // onpickexample addresses the flat examples array.
+  let exampleGroups = $derived.by(() => {
+    const groups = [];
+    examples.forEach((ex, i) => {
+      const last = groups[groups.length - 1];
+      if (last && last.language === ex.language) {
+        last.items.push({ ex, i });
+      } else {
+        groups.push({ language: ex.language, items: [{ ex, i }] });
+      }
+    });
+    return groups;
+  });
 </script>
 
 <div class="sv">
   <div class="editor">
     <div class="editor-head">
       <div class="examples">
-        {#each examples as ex, i (i)}
-          <button
-            type="button"
-            class="ex-chip"
-            class:on={activeExampleIndex === i}
-            onclick={() => onpickexample(i)}
-          >
-            {ex.label}
-          </button>
+        {#each exampleGroups as group (group.language)}
+          <div class="ex-group">
+            <span class="ex-lang">{group.language}</span>
+            <div class="ex-chips">
+              {#each group.items as { ex, i } (i)}
+                <button
+                  type="button"
+                  class="ex-chip"
+                  class:on={activeExampleIndex === i}
+                  onclick={() => onpickexample(i)}
+                >
+                  {ex.label}
+                </button>
+              {/each}
+            </div>
+          </div>
         {/each}
       </div>
       <button
@@ -507,6 +530,31 @@
   }
 
   .examples {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 14px;
+  }
+
+  .ex-group {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .ex-group + .ex-group {
+    border-left: 1px solid var(--em-line);
+    padding-left: 14px;
+  }
+
+  .ex-lang {
+    font-size: 10px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--em-faint);
+    user-select: none;
+  }
+
+  .ex-chips {
     display: flex;
     flex-wrap: wrap;
     gap: 6px;

--- a/projects/monolith/frontend/src/routes/public/ember/semgrep/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/semgrep/+page.svelte
@@ -85,20 +85,22 @@ def run():
     },
     {
       language: "python",
-      label: "SQL injection",
-      code: `import sqlite3
+      label: "SSRF",
+      code: `import urllib.request
 
 from flask import Flask, request
 
 app = Flask(__name__)
 
 
-@app.route("/user")
-def user():
-    name = request.args.get("name")
-    db = sqlite3.connect("app.db")
-    row = db.execute(f"SELECT * FROM users WHERE name = '{name}'").fetchone()
-    return str(row)
+def build_url():
+    host = request.args.get("host")
+    return f"http://{host}/status"
+
+
+@app.route("/probe")
+def probe():
+    return urllib.request.urlopen(build_url()).read()
 `,
     },
   ];


### PR DESCRIPTION
Two /ember/semgrep polish items:

**SQL injection example replaced with SSRF.** The SQL snippet scanned in ~2s while every other example is well under 1s. Measured live in the public pod: the latency is content-driven (the snippet's SQL surface activates the large SQL-injection taint-rule family; removing the `import sqlite3` line changed nothing at ~1.97s either way). Candidates were timed live too: path traversal, pickle deserialization, and SSRF all scan in ~0.7s, and SSRF wins on demo value, 2 findings including `tainted-url-host` via cross-function taint through a `build_url()` helper. Verified: 0.70-0.74s, 2 findings across 3 reps.

**Example chips grouped by language.** Consecutive same-language examples render under a small uppercase caption (JAVASCRIPT / PYTHON) with a vertical divider between groups, so the duplicate "command injection" labels read as the js/python pair they are. Indices stay global, so `onpickexample` wiring is unchanged.

Both charts bumped (public page, shared image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)