### PR TITLE
fix(embervm): brick Deployments roll with maxSurge=0 (no surge deadlock)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.166
+version: 0.1.167

--- a/projects/embervm/chart/templates/brick-deployment.yaml
+++ b/projects/embervm/chart/templates/brick-deployment.yaml
@@ -31,6 +31,21 @@ metadata:
   labels:
     {{- include "embervm.brick.labels" (dict "ctx" $ctx "class" $class.name) | nindent 4 }}
 spec:
+  # A brick's memory is a HARD reservation (request==limit), so two same-class
+  # bricks never fit where one does on a capacity-tight node. The default
+  # RollingUpdate surges (new pod before old), which needs 2x the class's memory
+  # and DEADLOCKS on a single-node fleet: the surge pod sits Pending "Insufficient
+  # memory" forever while the old pod it would replace stays up (observed
+  # 2026-07-20, the 16Gi brick roll). maxSurge:0 rolls each brick in place (kill
+  # old, then schedule new into the freed reservation); maxUnavailable:1 still
+  # rolls a multi-replica class one pod at a time. A zero-downtime surge-roll needs
+  # a second node with a class-sized memory hole to land on (ADR embervm/011); on
+  # the current single big-memory node the large class cannot surge.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   # replicas is only the value at FIRST create: the BrickController (PR-3) owns it
   # thereafter, and ArgoCD ignores Deployment /spec/replicas fleet-wide (the HPA
   # ignoreDifferences rule) so the controller's scaling never shows as drift. Both

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.166
+      targetRevision: 0.1.167
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Problem

Rolling the noded image (to deploy the tap fix #3745) deadlocked the **16Gi brick**: its Deployment defaulted to RollingUpdate, which surges the new pod before killing the old. A 16Gi brick is a **hard** reservation (request==limit), so 2×16Gi doesn't fit on node-4 (the only FC node) → the surge pod sat `Pending: Insufficient memory` forever while the old kept running.

## Fix

`strategy: maxSurge: 0, maxUnavailable: 1` on the brick Deployment template. Each brick rolls in place (kill old → schedule new into the freed reservation); a multi-replica class still rolls one at a time. Zero-impact here: the 16Gi brick is empty (scratch-k8s banked).

## Why not surge onto another node

Zero-downtime surge needs a second node with a **class-sized** memory hole. The Intel masters are memory-modest (~12Gi allocatable, 4-6Gi free per ADR 012) and **cannot hold a 16Gi brick** — so the large class stays single-node and cannot surge. Bringing up the masters helps the small CPU-heavy classes (which fit and can surge), not the 16Gi.

Bumps chart 0.1.166 → 0.1.167; also completes the tap-fix rollout stranded by the deadlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)