### PR TITLE
fix(embervm): shorten brick warmth path under SUN_LEN + GC orphan warmth

### DIFF
--- a/projects/embervm/noded/cmd/main.go
+++ b/projects/embervm/noded/cmd/main.go
@@ -62,6 +62,16 @@ func run(logger *slog.Logger) error {
 		"node", cfg.Node, "arch", cfg.Arch,
 		"maxLiveVMs", cfg.MaxLiveVMs, "registryCache", cfg.RegistryCachePath)
 
+	// Startup GC of orphan per-instance (brick) warmth: reap SnapshotRoot/i/<seg>
+	// dirs left by evicted/rolled-out co-located bricks whose pod UID is not ours.
+	// Fail-soft (warmth is regenerable) and narrow: bases/ and the VolumeRoot are
+	// never touched, and this is a no-op on the legacy DaemonSet (flat warmth).
+	if removed := config.PruneStaleInstanceWarmth(cfg, func(segment string, err error) {
+		logger.Warn("startup GC: could not remove stale instance warmth", "segment", segment, "err", err)
+	}); len(removed) > 0 {
+		logger.Info("startup GC: reaped stale instance warmth", "count", len(removed), "segments", removed)
+	}
+
 	self, err := os.Executable()
 	if err != nil {
 		return err

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -108,13 +108,19 @@ type Config struct {
 	// stateful bundles, group sets, per-thread bundles, checkpoints, group
 	// networks). Derived in Load, never read from env. For a BRICK (a sized
 	// instance, SizeClass and PodUID both set) it nests under
-	// SnapshotRoot/instances/<pod_uid> so two bricks co-located on one node never
-	// clobber each other's warmth; for the legacy DaemonSet (empty SizeClass) it
-	// equals SnapshotRoot, keeping the flat pre-brick layout byte-for-byte so the
-	// DS pod repaths nothing. Bases stay on SnapshotRoot; VolumeRoot (durable
-	// data) and RegistryCachePath are instance-agnostic and unchanged. The driver
-	// falls back to SnapshotRoot when this is empty, so a Config built directly
-	// (tests) without deriving it keeps the flat layout.
+	// SnapshotRoot/i/<short-uid> (see instanceSegment) so two bricks co-located
+	// on one node never clobber each other's warmth; for the legacy DaemonSet
+	// (empty SizeClass) it equals SnapshotRoot, keeping the flat pre-brick layout
+	// byte-for-byte so the DS pod repaths nothing. The per-instance segment is
+	// kept DELIBERATELY SHORT (i/<12 hex>, not instances/<36-char uuid>) because
+	// the firecracker unix API/restore/vsock sockets nest a per-op thread-<hex>
+	// dir under it, and the full socket path must stay under the 108-byte
+	// sockaddr_un SUN_LEN limit; the long layout overflowed it and every VM op on
+	// a brick failed with "path must be shorter than SUN_LEN". Bases stay on
+	// SnapshotRoot; VolumeRoot (durable data) and RegistryCachePath are
+	// instance-agnostic and unchanged. The driver falls back to SnapshotRoot when
+	// this is empty, so a Config built directly (tests) without deriving it keeps
+	// the flat layout.
 	WarmthRoot string
 	// BinPath is the firecracker binary (baked into the image at /opt/fc).
 	BinPath string
@@ -384,14 +390,16 @@ func Load() (Config, error) {
 	}
 
 	// Per-instance warmth root (brick-capacity). A brick (SizeClass + PodUID both
-	// set) nests warmth under SnapshotRoot/instances/<pod_uid>; every other case
-	// (the legacy DaemonSet with no SizeClass, or an out-of-cluster run with no
-	// PodUID) keeps warmth flat at SnapshotRoot, byte-for-byte the pre-brick
-	// layout. Only derived when SnapshotRoot is set (an unset root disables the
-	// driver entirely, so WarmthRoot stays empty too).
+	// set) nests warmth under SnapshotRoot/i/<short-uid> (instanceSegment); every
+	// other case (the legacy DaemonSet with no SizeClass, or an out-of-cluster run
+	// with no PodUID) keeps warmth flat at SnapshotRoot, byte-for-byte the
+	// pre-brick layout. The segment is kept short so the firecracker
+	// thread-<hex>/{api,restore,vsock}.sock paths nested under it stay under the
+	// 108-byte sockaddr_un SUN_LEN limit. Only derived when SnapshotRoot is set (an
+	// unset root disables the driver entirely, so WarmthRoot stays empty too).
 	if c.SnapshotRoot != "" {
 		if c.SizeClass != "" && c.PodUID != "" {
-			c.WarmthRoot = filepath.Join(c.SnapshotRoot, "instances", c.PodUID)
+			c.WarmthRoot = filepath.Join(c.SnapshotRoot, InstanceWarmthSubdir, instanceSegment(c.PodUID))
 		} else {
 			c.WarmthRoot = c.SnapshotRoot
 		}
@@ -444,6 +452,87 @@ func Load() (Config, error) {
 	}
 
 	return c, nil
+}
+
+// PruneStaleInstanceWarmth removes per-instance (brick) warmth directories under
+// SnapshotRoot/i/ that do NOT belong to this daemon's own pod UID, reclaiming the
+// regenerable snapshot state left behind by evicted or rolled-out co-located
+// bricks (nothing GCs dead-instance warmth today, so orphan dirs accumulate).
+// It is deliberately narrow and fail-soft:
+//
+//   - It ONLY touches SnapshotRoot/i/<segment> entries. It never removes bases/
+//     (node-shared rootfs snapshots), the VolumeRoot (durable data, a separate
+//     root entirely), or the daemon's OWN live warmth segment.
+//   - It is a no-op unless this instance is itself a brick (SizeClass + PodUID
+//     both set): the legacy DaemonSet's warmth is flat at SnapshotRoot with no
+//     i/ subtree to sweep, so there is nothing (and nothing safe) to prune.
+//   - A missing i/ directory, an unreadable entry, or a failed removal is logged
+//     via removeErr (if non-nil) and skipped, never fatal: warmth is regenerable,
+//     so a boot must not block on a GC hiccup.
+//
+// It returns the list of segments it removed (for logging/tests). removeErr, when
+// non-nil, is called once per entry that could not be removed.
+func PruneStaleInstanceWarmth(c Config, removeErr func(segment string, err error)) []string {
+	if c.SnapshotRoot == "" || c.SizeClass == "" || c.PodUID == "" {
+		return nil
+	}
+	instancesDir := filepath.Join(c.SnapshotRoot, InstanceWarmthSubdir)
+	entries, err := os.ReadDir(instancesDir)
+	if err != nil {
+		// A missing i/ dir (first brick on this node, or nothing warmed yet) is the
+		// common case and not an error worth surfacing; any other read error is
+		// reported through removeErr with an empty segment so a caller can log it.
+		if !os.IsNotExist(err) && removeErr != nil {
+			removeErr("", err)
+		}
+		return nil
+	}
+	ownSegment := instanceSegment(c.PodUID)
+	var removed []string
+	for _, e := range entries {
+		if e.Name() == ownSegment {
+			continue // never reap our own live warmth
+		}
+		if err := os.RemoveAll(filepath.Join(instancesDir, e.Name())); err != nil {
+			if removeErr != nil {
+				removeErr(e.Name(), err)
+			}
+			continue
+		}
+		removed = append(removed, e.Name())
+	}
+	return removed
+}
+
+// InstanceWarmthSubdir is the single-letter parent directory under SnapshotRoot
+// that per-instance (brick) warmth roots nest inside: SnapshotRoot/i/<short-uid>.
+// It is intentionally one byte ("i", not "instances") to keep the firecracker
+// unix socket paths nested under it (thread-<hex>/{api,restore,vsock}.sock) well
+// under the 108-byte sockaddr_un SUN_LEN limit. GC scans this directory to reap
+// dead-instance warmth (see PruneStaleInstanceWarmth).
+const InstanceWarmthSubdir = "i"
+
+// instanceSegmentLen is how many hex characters of the pod UID the per-instance
+// warmth segment keeps. Kubernetes pod UIDs are RFC 4122 v4 UUIDs (36 chars with
+// hyphens, 32 hex nibbles = 128 bits); 10 hex chars is 40 bits, collision-safe
+// for the handful (single digits) of noded instances that ever co-locate on one
+// node, while keeping the worst-case firecracker socket path comfortably under
+// the 108-byte SUN_LEN limit (98 bytes with the longest fleet snapshot root).
+// Deterministic: the same pod UID always maps to the same segment, so a restarted
+// daemon reattaches to its own warmth rather than orphaning it.
+const instanceSegmentLen = 10
+
+// instanceSegment derives the short, deterministic per-instance warmth path
+// segment from a pod UID. It strips the UUID hyphens (so the 12 kept characters
+// are all entropy-bearing hex, not layout punctuation) and lowercases; a UID
+// shorter than instanceSegmentLen is used whole. The result is filesystem-safe
+// and stable across restarts of the same pod.
+func instanceSegment(podUID string) string {
+	s := strings.ToLower(strings.ReplaceAll(podUID, "-", ""))
+	if len(s) > instanceSegmentLen {
+		s = s[:instanceSegmentLen]
+	}
+	return s
 }
 
 // vendorUnsafe strips anything but letters/digits from an unrecognised

--- a/projects/embervm/noded/config/config_test.go
+++ b/projects/embervm/noded/config/config_test.go
@@ -323,12 +323,15 @@ func TestLoadRejectsBadDuration(t *testing.T) {
 	}
 }
 
-// TestLoadWarmthRootDerivation proves the per-instance warmth root (brick-capacity
-// PR-2.5): a brick (SizeClass + PodUID both set) nests warmth under
-// SnapshotRoot/instances/<pod_uid>; every other case keeps warmth flat at
+// TestLoadWarmthRootDerivation proves the per-instance warmth root (brick-capacity):
+// a brick (SizeClass + PodUID both set) nests warmth under SnapshotRoot/i/<short-uid>
+// (the SHORT segment, kept under SUN_LEN); every other case keeps warmth flat at
 // SnapshotRoot so the legacy DaemonSet repaths nothing.
 func TestLoadWarmthRootDerivation(t *testing.T) {
 	root := "/scratch/embervm-noded/snapshots"
+	// A realistic k8s pod UID (RFC 4122 v4); the segment is its first 10 hex chars
+	// with hyphens stripped: "a1b2c3d4e5".
+	const uid = "a1b2c3d4-e5f6-4788-9abc-def012345678"
 	cases := []struct {
 		name      string
 		snapshot  string
@@ -336,10 +339,10 @@ func TestLoadWarmthRootDerivation(t *testing.T) {
 		podUID    string
 		want      string
 	}{
-		{"brick nests per pod_uid", root, "8gi", "pod-123", root + "/instances/pod-123"},
-		{"legacy DS stays flat (no size class)", root, "", "pod-123", root},
+		{"brick nests per short uid", root, "8gi", uid, root + "/i/a1b2c3d4e5"},
+		{"legacy DS stays flat (no size class)", root, "", uid, root},
 		{"size class but no pod_uid stays flat", root, "8gi", "", root},
-		{"no snapshot root yields empty", "", "8gi", "pod-123", ""},
+		{"no snapshot root yields empty", "", "8gi", uid, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -359,4 +362,127 @@ func TestLoadWarmthRootDerivation(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestInstanceSegmentDeterministicAndDistinct proves the per-instance segment is
+// deterministic (same UID -> same segment, so a restarted daemon reattaches to
+// its own warmth) and distinct across co-located UIDs (no clobber).
+func TestInstanceSegmentDeterministicAndDistinct(t *testing.T) {
+	const a = "a1b2c3d4-e5f6-4788-9abc-def012345678"
+	const b = "f9e8d7c6-b5a4-4300-8fed-cba987654321"
+	if instanceSegment(a) != instanceSegment(a) {
+		t.Error("instanceSegment not deterministic")
+	}
+	if instanceSegment(a) == instanceSegment(b) {
+		t.Errorf("distinct UIDs collided: %q", instanceSegment(a))
+	}
+	if got := instanceSegment(a); got != "a1b2c3d4e5" {
+		t.Errorf("instanceSegment(%q) = %q, want a1b2c3d4e5", a, got)
+	}
+	// A UID shorter than the cap is used whole (no panic, no padding).
+	if got := instanceSegment("short"); got != "short" {
+		t.Errorf("instanceSegment(short) = %q, want short", got)
+	}
+}
+
+// TestWorstCaseSocketPathUnderSunLen is the regression guard for the bug this PR
+// fixes: on a brick, the LONGEST firecracker unix socket path (a per-op
+// thread-<16hex> bundle dir under the per-instance warmth root, holding
+// restore.sock) MUST stay under the 108-byte sockaddr_un SUN_LEN limit, or every
+// VM operation fails with "path must be shorter than SUN_LEN". We reconstruct the
+// exact worst-case path the driver builds and assert it is comfortably under the
+// limit.
+func TestWorstCaseSocketPathUnderSunLen(t *testing.T) {
+	// The real production NVMe scratch snapshot root (the longest root in the
+	// fleet), a realistic pod UID, and the longest per-op thread id (thread- +
+	// 16 hex chars = 8 random bytes) with the longest socket basename.
+	const snapshotRoot = "/var/lib/embervm/scratch/embervm-noded/snapshots"
+	const podUID = "a1b2c3d4-e5f6-4788-9abc-def012345678"
+	const threadDir = "thread-0123456789abcdef" // driver: "thread-" + 16 hex
+	const longestSock = "restore.sock"          // > api.sock, vsock.sock
+
+	t.Setenv("EMBERVM_NODED_SNAPSHOT_ROOT", snapshotRoot)
+	t.Setenv("EMBERVM_NODED_SIZE_CLASS", "16gi")
+	t.Setenv("EMBERVM_POD_UID", podUID)
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	worst := filepath.Join(c.WarmthRoot, threadDir, longestSock)
+	// SUN_LEN is 108 on Linux; a NUL terminator eats one byte, so the usable path
+	// is <= 107. We assert a hard margin (< 100) so a future root/threadid tweak
+	// cannot silently creep back over the cliff.
+	if len(worst) >= 108 {
+		t.Fatalf("worst-case socket path OVERFLOWS SUN_LEN: %d bytes: %q", len(worst), worst)
+	}
+	if len(worst) >= 100 {
+		t.Errorf("worst-case socket path %d bytes (want < 100 for margin): %q", len(worst), worst)
+	}
+	t.Logf("worst-case brick socket path is %d bytes: %q", len(worst), worst)
+}
+
+// TestPruneStaleInstanceWarmth proves the startup GC reaps orphan per-instance
+// warmth (other pods' i/<seg> dirs) while never touching our own segment, bases/,
+// or anything outside i/; and that it is a no-op for the legacy DaemonSet.
+func TestPruneStaleInstanceWarmth(t *testing.T) {
+	const ownUID = "a1b2c3d4-e5f6-4788-9abc-def012345678"
+	ownSeg := instanceSegment(ownUID)
+
+	t.Run("brick reaps other segments, keeps own and bases", func(t *testing.T) {
+		root := t.TempDir()
+		instancesDir := filepath.Join(root, InstanceWarmthSubdir)
+		mkdir := func(p string) {
+			if err := os.MkdirAll(p, 0o750); err != nil {
+				t.Fatal(err)
+			}
+		}
+		mkdir(filepath.Join(instancesDir, ownSeg))
+		mkdir(filepath.Join(instancesDir, "deadbeef0000")) // orphan
+		mkdir(filepath.Join(instancesDir, "cafef00d1111")) // orphan
+		basesDir := filepath.Join(root, "bases", "somekey")
+		mkdir(basesDir)
+
+		c := Config{SnapshotRoot: root, SizeClass: "8gi", PodUID: ownUID}
+		removed := PruneStaleInstanceWarmth(c, func(seg string, err error) {
+			t.Errorf("unexpected removeErr(%q, %v)", seg, err)
+		})
+		if len(removed) != 2 {
+			t.Errorf("removed = %v, want 2 orphans", removed)
+		}
+		if _, err := os.Stat(filepath.Join(instancesDir, ownSeg)); err != nil {
+			t.Errorf("own segment must survive GC: %v", err)
+		}
+		if _, err := os.Stat(basesDir); err != nil {
+			t.Errorf("bases/ must NEVER be touched by GC: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(instancesDir, "deadbeef0000")); !os.IsNotExist(err) {
+			t.Errorf("orphan segment should be gone, stat err = %v", err)
+		}
+	})
+
+	t.Run("legacy DS is a no-op", func(t *testing.T) {
+		root := t.TempDir()
+		// Even if an i/ dir somehow exists, a non-brick (empty SizeClass) never sweeps.
+		if err := os.MkdirAll(filepath.Join(root, InstanceWarmthSubdir, "deadbeef0000"), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		c := Config{SnapshotRoot: root, SizeClass: "", PodUID: ownUID}
+		if removed := PruneStaleInstanceWarmth(c, nil); removed != nil {
+			t.Errorf("legacy DS GC removed %v, want nil", removed)
+		}
+		if _, err := os.Stat(filepath.Join(root, InstanceWarmthSubdir, "deadbeef0000")); err != nil {
+			t.Errorf("non-brick must not touch i/: %v", err)
+		}
+	})
+
+	t.Run("missing i/ dir is not an error", func(t *testing.T) {
+		root := t.TempDir()
+		c := Config{SnapshotRoot: root, SizeClass: "8gi", PodUID: ownUID}
+		if removed := PruneStaleInstanceWarmth(c, func(seg string, err error) {
+			t.Errorf("unexpected removeErr(%q, %v) for missing dir", seg, err)
+		}); removed != nil {
+			t.Errorf("removed = %v, want nil for missing i/", removed)
+		}
+	})
 }

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -78,10 +78,11 @@ type Config struct {
 	SnapshotRoot string
 	// WarmthRoot is the root for per-INSTANCE warmth (sessions/serving/stateful
 	// bundles/group sets/per-thread bundles/checkpoints/group networks): a brick
-	// nests it under SnapshotRoot/instances/<pod_uid>; the legacy DaemonSet leaves
-	// it equal to SnapshotRoot (flat, unchanged). Bases stay on SnapshotRoot.
-	// Empty falls back to SnapshotRoot (see warmthRoot), so a driver built from a
-	// Config that never derived it keeps the flat pre-brick layout.
+	// nests it under SnapshotRoot/i/<short-uid> (a SHORT segment so the nested
+	// firecracker thread-<hex>/*.sock paths stay under SUN_LEN); the legacy
+	// DaemonSet leaves it equal to SnapshotRoot (flat, unchanged). Bases stay on
+	// SnapshotRoot. Empty falls back to SnapshotRoot (see warmthRoot), so a driver
+	// built from a Config that never derived it keeps the flat pre-brick layout.
 	WarmthRoot string
 	// Node and Arch pin where snapshots may be restored.
 	Node string
@@ -278,7 +279,7 @@ func templateMismatch(refTemplate, nodeTemplate string) (bool, string) {
 
 // warmthRoot is the root for per-INSTANCE warmth (sessions, serving, stateful
 // bundles, group sets, per-thread bundles, checkpoints, group networks). For a
-// brick it is SnapshotRoot/instances/<pod_uid> (set by config.Load); for the
+// brick it is SnapshotRoot/i/<short-uid> (set by config.Load); for the
 // legacy DaemonSet it equals SnapshotRoot. Falls back to SnapshotRoot when unset
 // so a driver built from a Config that never derived WarmthRoot (tests) keeps the
 // flat pre-brick layout. Bases (baseDir) deliberately do NOT go through here:


### PR DESCRIPTION
## The bug

Every VM operation on every brick fails at the firecracker API-socket bind:

```
Error: RunWithApi(FailedToBindAndRunHttpServer(IOError(... "path must be shorter than SUN_LEN")))
```

The PR-2.5 per-instance warmth root nested brick warmth at `SnapshotRoot/instances/<pod_uid>`. The firecracker unix sockets (`api.sock`, `restore.sock`, `vsock.sock`) live under a per-op `thread-<16hex>` dir inside that root, so the full path overflowed the 108-byte `sockaddr_un` SUN_LEN limit:

```
/var/lib/embervm/scratch/embervm-noded/snapshots (48)
  + /instances/<36-char-uuid> (47)
  + /thread-<16hex> (23)
  + /restore.sock (13)     = ~127 bytes  >> 108
```

The DaemonSet's flat root (~80 bytes) is why the DS never hit this.

## The fix

- Shorten the per-instance segment from `instances/<36-char-uuid>` to `i/<10-hex>` (`InstanceWarmthSubdir` = `"i"`, `instanceSegment(podUID)` strips the UUID hyphens and keeps the first 10 hex chars = 40 bits).
  - **Deterministic**: same pod UID always maps to the same segment, so a restarted daemon reattaches to its own warmth rather than orphaning it.
  - **Collision-safe**: 40 bits across the single-digit number of noded instances that ever co-locate on one node.
  - **New worst-case socket path: 98 bytes** (longest fleet snapshot root + `thread-<16hex>` + `restore.sock`), a 10-byte margin under SUN_LEN. Guarded by a unit test that reconstructs the exact path and asserts `< 108` (and `< 100` for margin).
- `bases/` (node-shared rootfs snapshots) is deliberately left on `SnapshotRoot` and never per-instanced. The durable `VolumeRoot` is untouched.

## Also: startup GC of orphan warmth

`PruneStaleInstanceWarmth` runs on noded boot and reaps `SnapshotRoot/i/<seg>` dirs whose segment is not this daemon's own pod UID (reclaiming warmth left by evicted / rolled-out co-located bricks; nothing GCs dead-instance warmth today). It is:

- **Narrow**: only touches `SnapshotRoot/i/<seg>` entries; never `bases/`, never the `VolumeRoot`, never its own live segment.
- **Fail-soft**: a missing `i/` dir, unreadable entry, or failed removal is logged and skipped, never fatal (warmth is regenerable).
- **A no-op on the legacy DaemonSet** (empty `SizeClass` -> flat warmth, no `i/` subtree).

## Scope

Inert until bricks return at foundation plan Step 6. **No chart bump.**

## Tests

`projects/embervm/noded/config` package tests pass locally, including the new `TestWorstCaseSocketPathUnderSunLen`, `TestInstanceSegmentDeterministicAndDistinct`, `TestPruneStaleInstanceWarmth`, and the updated `TestLoadWarmthRootDerivation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)