### PR TITLE
feat(embervm): noded reports real cgroup memory facts (brick step 3)

### DIFF
--- a/projects/embervm/noded/server/budget.go
+++ b/projects/embervm/noded/server/budget.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -14,6 +15,69 @@ import (
 // without threading a new knob through every other Config consumer; mirrors
 // how parseMemHeadroomMib already isolates the parsing logic for injection.
 var budgetFsRoot = "/sys/fs/cgroup"
+
+// selfCgroupPath is the path the reader parses to discover the daemon's OWN
+// cgroup v2 directory (the "0::<path>" line of /proc/self/cgroup). A package
+// var so tests can point it at a fixture file, mirroring budgetFsRoot.
+//
+// Why this exists: the noded container runs privileged (chart _noded-pod.tpl),
+// so on containerd it inherits the HOST cgroup namespace. There, plain
+// budgetFsRoot ("/sys/fs/cgroup") is the host ROOT cgroup, which has no
+// memory.max at all, so every capacity read returned 0 ("unknown"). The pod's
+// real leaf cgroup (e.g. .../cri-containerd-<id>.scope) does carry memory.max,
+// and /proc/self/cgroup names it. Under a PRIVATE cgroup namespace the line is
+// "0::/" and budgetFsRoot already IS the pod's cgroup, so resolution falls
+// back to budgetFsRoot and behaves exactly as before.
+var selfCgroupPath = "/proc/self/cgroup"
+
+// cgroupDir resolves the directory whose cgroup v2 controller files (memory.max,
+// cpu.max, ...) describe THIS daemon's cgroup. It parses selfCgroupPath for the
+// "0::<path>" entry and joins <path> under budgetFsRoot. It degrades gracefully:
+//   - a "0::/" self-path (private cgroupns) or an unreadable/absent
+//     /proc/self/cgroup falls back to budgetFsRoot;
+//   - a joined dir that lacks memory.max (e.g. the host-root join does not
+//     exist, or a fixture wrote files at budgetFsRoot itself) also falls back
+//     to budgetFsRoot.
+//
+// The result is correct under BOTH host and private cgroup namespaces without a
+// namespace probe: the join is only preferred when it actually carries the
+// controller files.
+func cgroupDir() string {
+	rel := parseSelfCgroupV2Path(readSelfCgroup())
+	if rel == "" || rel == "/" {
+		return budgetFsRoot
+	}
+	joined := filepath.Join(budgetFsRoot, rel)
+	if _, err := os.Stat(filepath.Join(joined, "memory.max")); err != nil {
+		// The self-path does not resolve to a cgroup dir with controller files
+		// under this root; fall back rather than read nothing.
+		return budgetFsRoot
+	}
+	return joined
+}
+
+// readSelfCgroup returns the contents of selfCgroupPath, or "" on error (which
+// cgroupDir treats as the budgetFsRoot fallback).
+func readSelfCgroup() string {
+	raw, err := os.ReadFile(selfCgroupPath)
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}
+
+// parseSelfCgroupV2Path extracts the <path> from the cgroup v2 "0::<path>" line
+// of /proc/self/cgroup contents. Returns "" when no such line exists (a pure
+// cgroup v1 host, which this daemon does not target). The leading "0::" marks
+// the unified (v2) hierarchy; its path is relative to the cgroup v2 mount.
+func parseSelfCgroupV2Path(raw string) string {
+	for _, line := range strings.Split(raw, "\n") {
+		if rest, ok := strings.CutPrefix(line, "0::"); ok {
+			return strings.TrimSpace(rest)
+		}
+	}
+	return ""
+}
 
 // budget is the daemon's self-reported resource ceiling and real headroom,
 // read from its own cgroup v2 controller files rather than static config
@@ -45,6 +109,12 @@ type budget struct {
 	// can pin the sample instant and assert an exact usage-rate delta instead
 	// of racing sub-microsecond wall-clock jitter between two time.Now calls.
 	now func() time.Time
+
+	// memBudgetOverride, when set, replaces MemBudgetMib as the source
+	// SlotCeiling divides. Test-only seam so the ceiling arithmetic can be
+	// asserted against fixed budgets without a fixture cgroup filesystem; nil
+	// in production, where SlotCeiling reads the real budget.
+	memBudgetOverride func() uint64
 }
 
 // newBudget constructs a reader with the given daemon-RSS reserve.
@@ -55,7 +125,8 @@ func newBudget(reserveMib uint64) *budget {
 // MemBudgetMib returns memory.max minus the reserve, in MiB. Unlimited or
 // unreadable cgroups report 0 (unknown).
 func (b *budget) MemBudgetMib() uint64 {
-	maxRaw, err := os.ReadFile(budgetFsRoot + "/memory.max")
+	dir := cgroupDir()
+	maxRaw, err := os.ReadFile(filepath.Join(dir, "memory.max"))
 	if err != nil {
 		return 0
 	}
@@ -66,11 +137,12 @@ func (b *budget) MemBudgetMib() uint64 {
 // semantics to the retired readMemHeadroomMib, folded in here so the daemon
 // has one cgroup reader instead of two.
 func (b *budget) MemHeadroomMib() uint64 {
-	maxRaw, err := os.ReadFile(budgetFsRoot + "/memory.max")
+	dir := cgroupDir()
+	maxRaw, err := os.ReadFile(filepath.Join(dir, "memory.max"))
 	if err != nil {
 		return 0
 	}
-	curRaw, err := os.ReadFile(budgetFsRoot + "/memory.current")
+	curRaw, err := os.ReadFile(filepath.Join(dir, "memory.current"))
 	if err != nil {
 		return 0
 	}
@@ -81,11 +153,51 @@ func (b *budget) MemHeadroomMib() uint64 {
 // expressed as millicores. Unlimited ("max" quota) or unreadable cgroups
 // report 0 (unknown).
 func (b *budget) CpuBudgetMillicores() uint64 {
-	raw, err := os.ReadFile(budgetFsRoot + "/cpu.max")
+	raw, err := os.ReadFile(filepath.Join(cgroupDir(), "cpu.max"))
 	if err != nil {
 		return 0
 	}
 	return parseCpuBudgetMillicores(string(raw))
+}
+
+// minSlotWorkloadMib is the smallest guest footprint a live-VM slot is assumed
+// to hold, used only to turn the memory budget into a slot ceiling. It is a
+// floor for the divisor, not a real per-workload size (workloads are sized from
+// the registry): dividing the budget by it yields the MOST slots a brick could
+// ever host, which is the honest ceiling maxLiveVMs must not exceed. Set to a
+// conservative small-guest size so the ceiling errs high (the configured
+// MaxLiveVMs backstop and real per-VM Claim accounting are the tighter caps);
+// 512 MiB keeps a 2gi/512-reserve brick at 3 slots rather than the configured
+// default of 8/16.
+const minSlotWorkloadMib = 512
+
+// SlotCeiling returns the brick's cgroup-derived live-VM slot ceiling per ADR
+// embervm/013 section 7 ("maxLiveVMs is the brick's cgroup-derived slot
+// ceiling, never a control-plane knob"): floor(MemBudgetMib /
+// minSlotWorkloadMib), clamped so it never EXCEEDS the configured backstop
+// (configured stays an upper bound). When the budget is unknown (0, an
+// unlimited or unreadable cgroup) the ceiling is unknown too, so the configured
+// backstop is used unchanged: an environment that cannot observe its cgroup
+// keeps exactly the pre-budget behavior rather than collapsing to zero slots.
+func (b *budget) SlotCeiling(configured uint64) uint64 {
+	budgetMib := b.MemBudgetMib()
+	if b.memBudgetOverride != nil {
+		budgetMib = b.memBudgetOverride()
+	}
+	if budgetMib == 0 {
+		return configured
+	}
+	derived := budgetMib / minSlotWorkloadMib
+	if derived == 0 {
+		// A budget smaller than one slot still hosts at least one VM (the
+		// backstop and Claim accounting gate the real limit); never advertise
+		// a zero ceiling that would wedge a small brick out of all placement.
+		derived = 1
+	}
+	if configured > 0 && derived > configured {
+		return configured
+	}
+	return derived
 }
 
 // CpuHeadroomMillicores returns the last computed CPU headroom: budget minus
@@ -103,13 +215,14 @@ func (b *budget) CpuHeadroomMillicores() uint64 {
 // observed without a daemon restart. Mem fields are cheap best-effort reads
 // and are NOT cached; only the CPU side needs a two-sample delta.
 func (b *budget) Refresh() {
-	cpuMaxRaw, err := os.ReadFile(budgetFsRoot + "/cpu.max")
+	dir := cgroupDir()
+	cpuMaxRaw, err := os.ReadFile(filepath.Join(dir, "cpu.max"))
 	if err != nil {
 		return
 	}
 	budgetMilli := parseCpuBudgetMillicores(string(cpuMaxRaw))
 
-	statRaw, err := os.ReadFile(budgetFsRoot + "/cpu.stat")
+	statRaw, err := os.ReadFile(filepath.Join(dir, "cpu.stat"))
 	if err != nil {
 		return
 	}

--- a/projects/embervm/noded/server/budget_test.go
+++ b/projects/embervm/noded/server/budget_test.go
@@ -167,6 +167,154 @@ func TestParseCpuUsageUsec(t *testing.T) {
 	}
 }
 
+// withSelfCgroup points selfCgroupPath at a fixture /proc/self/cgroup file for
+// the duration of the test.
+func withSelfCgroup(t *testing.T, content string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "self-cgroup")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write self-cgroup fixture: %v", err)
+	}
+	orig := selfCgroupPath
+	selfCgroupPath = path
+	t.Cleanup(func() { selfCgroupPath = orig })
+}
+
+func TestParseSelfCgroupV2Path(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		// Host cgroup namespace: the pod's leaf scope under kubepods.
+		{"0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podabc.slice/cri-containerd-def.scope\n", "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podabc.slice/cri-containerd-def.scope"},
+		// Private cgroup namespace: root path, resolution falls back to budgetFsRoot.
+		{"0::/\n", "/"},
+		// Legacy v1 lines present but no v2 unified line.
+		{"12:memory:/kubepods\n11:cpu:/kubepods\n", ""},
+		// v2 line among v1 lines.
+		{"1:name=systemd:/foo\n0::/leaf.scope\n", "/leaf.scope"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := parseSelfCgroupV2Path(c.raw); got != c.want {
+			t.Errorf("parseSelfCgroupV2Path(%q) = %q, want %q", c.raw, got, c.want)
+		}
+	}
+}
+
+// TestCgroupDirResolvesHostNsPath proves the host-cgroupns case: /proc/self/cgroup
+// names a leaf scope under budgetFsRoot, and cgroupDir resolves the reader to
+// that leaf (where memory.max actually lives), NOT the controller-file-less
+// root the privileged container's plain /sys/fs/cgroup points at.
+func TestCgroupDirResolvesHostNsPath(t *testing.T) {
+	root := t.TempDir()
+	orig := budgetFsRoot
+	budgetFsRoot = root
+	t.Cleanup(func() { budgetFsRoot = orig })
+
+	// The host root has NO memory.max (the real bug), the pod leaf does.
+	leaf := filepath.Join(root, "kubepods.slice", "cri-containerd-abc.scope")
+	if err := os.MkdirAll(leaf, 0o755); err != nil {
+		t.Fatalf("mkdir leaf: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(leaf, "memory.max"), []byte("2147483648\n"), 0o644); err != nil {
+		t.Fatalf("write leaf memory.max: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(leaf, "memory.current"), []byte("536870912\n"), 0o644); err != nil {
+		t.Fatalf("write leaf memory.current: %v", err)
+	}
+	withSelfCgroup(t, "0::/kubepods.slice/cri-containerd-abc.scope\n")
+
+	if got, want := cgroupDir(), leaf; got != want {
+		t.Fatalf("cgroupDir() = %q, want leaf %q", got, want)
+	}
+
+	b := newBudget(512)
+	// 2 GiB - 512 MiB reserve = 1536, the exact 2gi-brick expectation.
+	if got, want := b.MemBudgetMib(), uint64(2048-512); got != want {
+		t.Errorf("MemBudgetMib() host-ns = %d, want %d", got, want)
+	}
+	if got, want := b.MemHeadroomMib(), uint64(2048-512); got != want {
+		t.Errorf("MemHeadroomMib() host-ns = %d, want %d", got, want)
+	}
+}
+
+// TestCgroupDirFallsBackOnRootSelfPath proves the private-cgroupns case: a
+// "0::/" self-path means budgetFsRoot IS already the pod's cgroup, so cgroupDir
+// returns budgetFsRoot unchanged and the reader behaves exactly as before the
+// resolution was added.
+func TestCgroupDirFallsBackOnRootSelfPath(t *testing.T) {
+	root := t.TempDir()
+	orig := budgetFsRoot
+	budgetFsRoot = root
+	t.Cleanup(func() { budgetFsRoot = orig })
+	if err := os.WriteFile(filepath.Join(root, "memory.max"), []byte("4294967296\n"), 0o644); err != nil {
+		t.Fatalf("write root memory.max: %v", err)
+	}
+	withSelfCgroup(t, "0::/\n")
+
+	if got, want := cgroupDir(), root; got != want {
+		t.Fatalf("cgroupDir() on 0::/ = %q, want budgetFsRoot %q", got, want)
+	}
+	b := newBudget(512)
+	if got, want := b.MemBudgetMib(), uint64(4096-512); got != want {
+		t.Errorf("MemBudgetMib() private-ns fallback = %d, want %d", got, want)
+	}
+}
+
+// TestCgroupDirFallsBackWhenJoinedDirLacksControllers proves the graceful-
+// degradation path: a host-ns self-path whose joined dir does NOT exist (or has
+// no memory.max) under this root falls back to budgetFsRoot rather than reading
+// nothing. This is also why the pre-existing budget_test fixtures (files written
+// at budgetFsRoot itself) keep working with an unset selfCgroupPath.
+func TestCgroupDirFallsBackWhenJoinedDirLacksControllers(t *testing.T) {
+	root := t.TempDir()
+	orig := budgetFsRoot
+	budgetFsRoot = root
+	t.Cleanup(func() { budgetFsRoot = orig })
+	if err := os.WriteFile(filepath.Join(root, "memory.max"), []byte("4294967296\n"), 0o644); err != nil {
+		t.Fatalf("write root memory.max: %v", err)
+	}
+	// Self-path names a leaf that does not exist under root.
+	withSelfCgroup(t, "0::/kubepods.slice/nonexistent.scope\n")
+
+	if got, want := cgroupDir(), root; got != want {
+		t.Fatalf("cgroupDir() with missing leaf = %q, want fallback %q", got, want)
+	}
+}
+
+func TestSlotCeiling(t *testing.T) {
+	cases := []struct {
+		name       string
+		budgetMib  uint64
+		configured uint64
+		want       uint64
+	}{
+		// 2gi brick, 512 reserve -> 1536 budget -> floor(1536/512)=3 slots,
+		// clamped under the configured default of 8 (the whole point: not 8/16).
+		{"2gi-brick", 1536, 8, 3},
+		// 4gi brick -> 3584 budget -> 7 slots, still under configured 8.
+		{"4gi-brick", 3584, 8, 7},
+		// 16gi brick -> derived exceeds configured 8, so configured clamps it.
+		{"large-brick-clamped", 15872, 8, 8},
+		// Unknown budget (unlimited/unreadable cgroup) -> configured unchanged.
+		{"unknown-budget", 0, 8, 8},
+		// Budget smaller than one slot still reports at least 1.
+		{"sub-slot-budget", 256, 8, 1},
+		// Configured 0 (unbounded backstop) -> report the derived ceiling.
+		{"unbounded-config", 1536, 0, 3},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			b := newBudget(0)
+			b.memBudgetOverride = func() uint64 { return c.budgetMib }
+			if got := b.SlotCeiling(c.configured); got != c.want {
+				t.Errorf("SlotCeiling(%d) with budget %d = %d, want %d", c.configured, c.budgetMib, got, c.want)
+			}
+		})
+	}
+}
+
 func TestParseMemBudgetMib(t *testing.T) {
 	cases := []struct {
 		maxRaw     string

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -177,6 +177,12 @@ type Server struct {
 	// minus the observed usage rate across the two most recent Refresh
 	// calls). 0 until a second sample exists. Overridable in tests.
 	cpuHeadroom func() uint64
+	// slotCeiling maps the configured MaxLiveVMs backstop to the brick's
+	// cgroup-derived live-VM slot ceiling (floor(MemBudgetMib/minWorkload),
+	// clamped to the configured value). The reported MaxLiveVms is this
+	// ceiling, so a 2gi brick advertises a handful of slots rather than the
+	// configured default. Overridable in tests.
+	slotCeiling func(configured uint64) uint64
 
 	// httpClient fetches zip-lane archives from the in-cluster SeaweedFS read path
 	// over the pod network. Overridable in tests (a fake archive server).
@@ -435,6 +441,7 @@ func New(opts Options) *Server {
 	s.memBudget = s.budget.MemBudgetMib
 	s.cpuBudget = s.budget.CpuBudgetMillicores
 	s.cpuHeadroom = s.budget.CpuHeadroomMillicores
+	s.slotCeiling = s.budget.SlotCeiling
 	s.statefulResolveTimeout = defaultStatefulResolveTimeout
 	// Re-seed the serving-images inventory from disk so a daemon restart re-discovers
 	// the cold-boot handler artifacts it built before (mirroring the banked-snapshot
@@ -1515,6 +1522,12 @@ func (s *Server) nodeStatus() *nodev1.NodeStatus {
 	if maxLive < 0 {
 		maxLive = 0
 	}
+	// The reported MaxLiveVms is the brick's cgroup-derived slot ceiling (ADR
+	// embervm/013 section 7), with the configured backstop as an upper clamp:
+	// a size-class brick advertises a budget-honest slot count, never the raw
+	// configured default. When the cgroup budget is unknown the ceiling equals
+	// the configured backstop, preserving pre-budget behavior.
+	maxLive = int(s.slotCeiling(uint64(maxLive)))
 	// Session and serving VMs both count against the node live-VM total alongside
 	// task-pool VMs (all three classes Claim through the same driver, but this sum
 	// names the invariant at the call site).

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -327,7 +327,8 @@ func newTestServer(t *testing.T, drv *fakeDriver, tr *fakeTransport, maxLive int
 		Transport: tr,
 		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
-	s.memHeadroom = func() uint64 { return 0 } // deterministic, no cgroup read
+	s.memHeadroom = func() uint64 { return 0 }                           // deterministic, no cgroup read
+	s.slotCeiling = func(configured uint64) uint64 { return configured } // report configured max, no host cgroup read
 
 	lis := bufconn.Listen(1 << 20)
 	gs := grpc.NewServer()
@@ -372,6 +373,7 @@ func newSessionTestServer(t *testing.T, drv *fakeDriver, tr *fakeTransport, maxL
 		Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
 	s.memHeadroom = func() uint64 { return 0 }
+	s.slotCeiling = func(configured uint64) uint64 { return configured }
 
 	lis := bufconn.Listen(1 << 20)
 	gs := grpc.NewServer()


### PR DESCRIPTION
## What

Step 3 of the EmberVM brick co-location foundation. Fixes the noded (Go) daemon so it reports real cgroup-derived memory facts. Before this, every instance reported `mem_budget_mib=0` and `mem_headroom_mib=0`.

## Root cause

`noded/server/budget.go` read `/sys/fs/cgroup/memory.max`. The noded container is `privileged: true` (chart `_noded-pod.tpl`), so on containerd it inherits the HOST cgroup namespace: inside the pod, `/sys/fs/cgroup` is the host ROOT cgroup, which has no `memory.max` file. The `ReadFile` errored, and the code correctly reported 0 ("unknown, never a guess"). Verified live in the 2gi brick.

## Fix

- Resolve the daemon's OWN cgroup dir from `/proc/self/cgroup` (the cgroup v2 `0::<path>` line) and join it under `budgetFsRoot` before reading `memory.max` / `memory.current` / `cpu.max` / `cpu.stat`.
- Graceful degradation, correct under BOTH namespaces without a namespace probe:
  - `0::/` self-path (private cgroupns, where `/sys/fs/cgroup` already IS the pod cgroup) -> fall back to `budgetFsRoot`.
  - unreadable/absent `/proc/self/cgroup` -> fall back.
  - joined dir that lacks `memory.max` (host-root join does not exist under this root, or a fixture wrote at the root itself) -> fall back.
- `max_live_vms` is now budget-derived per ADR embervm/013 section 7 (slot ceiling is cgroup-derived, never a control-plane knob): `floor(mem_budget_mib / 512)` clamped to the configured `MaxLiveVMs` backstop as an upper bound. A 2gi brick advertises 3 slots instead of the configured default of 8. Unknown budget keeps the configured value unchanged.

`mem_budget_mib`, `mem_headroom_mib` semantics unchanged (reserve-adjusted budget; max-minus-current headroom). Proto/CP untouched (fields 3/26/30 already exist).

## Tests

Go unit tests in `budget_test.go`:
- `parseSelfCgroupV2Path` table (host-ns leaf path, `0::/`, v1-only lines, mixed).
- `cgroupDir` resolves a host-ns leaf under a fake fs root to that leaf; `0::/` and a missing-leaf self-path both fall back to `budgetFsRoot`. Host-ns case asserts `MemBudgetMib()`/`MemHeadroomMib()` read from the leaf.
- `SlotCeiling` table (2gi->3, 4gi->7, large clamped to configured, unknown budget passthrough, sub-slot->1, unbounded config).

Existing `newTestServer`/`newSessionTestServer` override `slotCeiling` to identity for deterministic `MaxLiveVms` assertions (no host cgroup read).

## No chart bump

Inert until size-aware placement reads these facts at plan steps 4/5 and the re-canary at step 6.

## After deploy

A 2gi brick should report `mem_budget_mib ~= 1536` (2048 - 512 reserve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)