### PR TITLE
feat(embervm): instance-aware wakes select+dial a specific brick (Step 4)

### DIFF
--- a/projects/embervm/control/lib/embervm/group_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_manager.ex
@@ -200,6 +200,14 @@ defmodule Embervm.GroupManager do
       principal: Keyword.fetch!(opts, :principal),
       entry: Keyword.fetch!(opts, :entry),
       node_id: Keyword.fetch!(opts, :node_id),
+      # The channel dial KEY (brick co-location foundation, Step 4): the specific
+      # instance on `node_id` this group's member RPCs dial, as an instance_id
+      # ("node/pod_uid") the dual-keyed Embervm.NodeChannel resolves without the
+      # node-name-alias collapse. Distinct from `node_id`, which stays the K8s NODE
+      # NAME recorded durably (GroupStore rows, adoption's node lookups). Defaults to
+      # `node_id` so a caller that does not select an instance (or a single-instance
+      # fleet) dials exactly as before.
+      dial_id: Keyword.get(opts, :dial_id) || Keyword.fetch!(opts, :node_id),
       store: Keyword.get(opts, :store, GroupStore),
       publisher: Keyword.get(opts, :publisher, Embervm.EndpointPublisher),
       capacity_table: Keyword.get(opts, :capacity_table, NodeCapacity.table()),
@@ -1017,7 +1025,7 @@ defmodule Embervm.GroupManager do
       member_name: member.member_name
     }
 
-    case over_channel(state, state.node_id, &state.stop_group_member_fun.(&1, req)) do
+    case over_channel(state, state.dial_id, &state.stop_group_member_fun.(&1, req)) do
       {:ok, %StopGroupMemberResponse{snapshot_ref: ref}} when is_binary(ref) and ref != "" ->
         {:ok, %{name: member.member_name, snapshot_ref: ref}}
 
@@ -1344,7 +1352,7 @@ defmodule Embervm.GroupManager do
       cidr: cidr
     }
 
-    case over_channel(state, state.node_id, &state.create_group_network_fun.(&1, req)) do
+    case over_channel(state, state.dial_id, &state.create_group_network_fun.(&1, req)) do
       {:ok, %CreateGroupNetworkResponse{} = resp} -> {:ok, resp}
       other -> {:error, {:create_network_failed, other}}
     end
@@ -1355,7 +1363,7 @@ defmodule Embervm.GroupManager do
   defp delete_network(state) do
     req = %DeleteGroupNetworkRequest{trace: %Trace{workload: state.workload}, group_instance_id: state.instance_id}
 
-    with {:ok, channel} <- safe_channel(state, state.node_id) do
+    with {:ok, channel} <- safe_channel(state, state.dial_id) do
       try do
         state.delete_group_network_fun.(channel, req)
       rescue
@@ -1369,7 +1377,7 @@ defmodule Embervm.GroupManager do
   end
 
   defp safe_start_group_member(state, req) do
-    over_channel(state, state.node_id, &state.start_group_member_fun.(&1, req))
+    over_channel(state, state.dial_id, &state.start_group_member_fun.(&1, req))
   rescue
     e -> {:error, {:start_group_member_raised, e}}
   catch
@@ -1465,7 +1473,7 @@ defmodule Embervm.GroupManager do
       member_name: member.member_name
     }
 
-    with {:ok, channel} <- safe_channel(state, state.node_id) do
+    with {:ok, channel} <- safe_channel(state, state.dial_id) do
       try do
         state.stop_group_member_fun.(channel, req)
       rescue
@@ -1485,7 +1493,7 @@ defmodule Embervm.GroupManager do
   defp evict_snapshot(state, snapshot_ref) do
     req = %EvictSnapshotRequest{trace: %Trace{workload: state.workload}, snapshot_ref: snapshot_ref}
 
-    with {:ok, channel} <- safe_channel(state, state.node_id) do
+    with {:ok, channel} <- safe_channel(state, state.dial_id) do
       try do
         state.evict_snapshot_fun.(channel, req)
       rescue

--- a/projects/embervm/control/lib/embervm/group_manager/supervisor.ex
+++ b/projects/embervm/control/lib/embervm/group_manager/supervisor.ex
@@ -61,8 +61,8 @@ defmodule Embervm.GroupManager.Supervisor do
     capacity_table = Keyword.get(opts, :capacity_table, NodeCapacity.table())
 
     with {:ok, entry} <- GroupManager.catalog_group(catalog_table, workload),
-         {:ok, node_id} <- anchor_node(capacity_table),
-         {:ok, pid} <- start_child(workload, entry, node_id, opts) do
+         {:ok, node_id, dial_id} <- anchor_instance(capacity_table, entry, workload, nil),
+         {:ok, pid} <- start_child(workload, entry, node_id, dial_id, opts) do
       result = GroupManager.create_group(pid)
       # On a failed create the group is torn down to failed; retire the process so a
       # later retry spawns a fresh one (a live create keeps the process for Task 7/8's
@@ -98,8 +98,8 @@ defmodule Embervm.GroupManager.Supervisor do
     capacity_table = Keyword.get(opts, :capacity_table, NodeCapacity.table())
 
     with {:ok, entry} <- GroupManager.catalog_group(catalog_table, workload),
-         {:ok, node_id} <- anchor_node(capacity_table),
-         {:ok, pid} <- start_or_get_child(workload, instance_id, entry, node_id, opts) do
+         {:ok, node_id, dial_id} <- anchor_instance(capacity_table, entry, workload, instance_id),
+         {:ok, pid} <- start_or_get_child(workload, instance_id, entry, node_id, dial_id, opts) do
       result = GroupManager.wake_group(pid)
 
       case result do
@@ -132,8 +132,8 @@ defmodule Embervm.GroupManager.Supervisor do
     capacity_table = Keyword.get(opts, :capacity_table, NodeCapacity.table())
 
     with {:ok, entry} <- GroupManager.catalog_group(catalog_table, workload),
-         {:ok, node_id} <- anchor_node(capacity_table),
-         {:ok, pid} <- start_or_get_child(workload, instance_id, entry, node_id, opts) do
+         {:ok, node_id, dial_id} <- anchor_instance(capacity_table, entry, workload, instance_id),
+         {:ok, pid} <- start_or_get_child(workload, instance_id, entry, node_id, dial_id, opts) do
       case GroupManager.bank_group(pid) do
         {:ok, _} = ok ->
           ok
@@ -164,8 +164,8 @@ defmodule Embervm.GroupManager.Supervisor do
     capacity_table = Keyword.get(opts, :capacity_table, NodeCapacity.table())
 
     with {:ok, entry} <- GroupManager.catalog_group(catalog_table, workload),
-         {:ok, node_id} <- anchor_node(capacity_table) do
-      _ = start_or_get_child(workload, instance_id, entry, node_id, opts)
+         {:ok, node_id, dial_id} <- anchor_instance(capacity_table, entry, workload, instance_id) do
+      _ = start_or_get_child(workload, instance_id, entry, node_id, dial_id, opts)
       :ok
     else
       _ -> :ok
@@ -183,9 +183,9 @@ defmodule Embervm.GroupManager.Supervisor do
 
   # -- internals -------------------------------------------------------------
 
-  defp start_child(workload, entry, node_id, opts) do
+  defp start_child(workload, entry, node_id, dial_id, opts) do
     instance_id = mint_instance_id(opts)
-    do_start_child(workload, instance_id, entry, node_id, opts)
+    do_start_child(workload, instance_id, entry, node_id, dial_id, opts)
   end
 
   # Start a child bound to a SPECIFIC (already-existing) instance_id, or return the
@@ -193,8 +193,8 @@ defmodule Embervm.GroupManager.Supervisor do
   # instance already exists, and a registered owner is reused). A registered pid for
   # a DIFFERENT instance_id is still returned (one live process per workload; the
   # registry key is the workload, and the class is a group-level singleton).
-  defp start_or_get_child(workload, instance_id, entry, node_id, opts) do
-    case do_start_child(workload, instance_id, entry, node_id, opts) do
+  defp start_or_get_child(workload, instance_id, entry, node_id, dial_id, opts) do
+    case do_start_child(workload, instance_id, entry, node_id, dial_id, opts) do
       {:ok, pid} ->
         {:ok, pid}
 
@@ -209,7 +209,7 @@ defmodule Embervm.GroupManager.Supervisor do
     end
   end
 
-  defp do_start_child(workload, instance_id, entry, node_id, opts) do
+  defp do_start_child(workload, instance_id, entry, node_id, dial_id, opts) do
     child_opts =
       [
         instance_id: instance_id,
@@ -217,6 +217,10 @@ defmodule Embervm.GroupManager.Supervisor do
         principal: group_principal(workload),
         entry: entry,
         node_id: node_id,
+        # The channel dial key (Step 4): the specific instance on node_id the group's
+        # member RPCs dial, distinct from the durable node_id. Defaults to node_id in
+        # the GroupManager when absent, so a test/legacy caller is unaffected.
+        dial_id: dial_id,
         name: {:via, Registry, {@registry, workload}}
       ] ++ Keyword.take(opts, group_manager_opt_keys())
 
@@ -262,16 +266,63 @@ defmodule Embervm.GroupManager.Supervisor do
   # system:stateful:<workload> attribution), the op-log owner for its lifecycle ops.
   defp group_principal(workload), do: "system:group:#{workload}"
 
-  # Pick the anchor node for a fresh group: the first node reporting a
-  # stateful/serving-capable subnet with live-VM budget (rendezvous-hashed with one
-  # node is trivially that node; a real placement is Task 7's concern). No node is
-  # {:error, :no_capacity}.
-  defp anchor_node(capacity_table) do
+  # Pick the anchor node for a group AND the specific instance on it to dial
+  # (brick co-location foundation, Step 4). The node is the first group-capable node
+  # (rendezvous-hashed with one node is trivially that node; a real placement is a
+  # later concern); the dial_id is the instance on that node to send member RPCs to.
+  #
+  # `group_instance_id` (nil for a fresh CREATE, the banked instance id for a
+  # wake/bank/adopt) drives warmth selection: a relight MUST land on the instance
+  # that banked the group's SET on disk (per-instance-on-disk, PR-2.5), matched by
+  # the reported `group_bundle_sets` row whose `group_instance_id` equals it. A cold
+  # CREATE has no owning set, so it falls to a mem-eligible instance sized for the
+  # group's total member memory. Returns {:ok, node_id, dial_id} or
+  # {:error, :no_capacity} (no group-capable node) / {:error, :no_eligible_instance}
+  # (a node exists but no instance on it can host the group).
+  defp anchor_instance(capacity_table, entry, workload, group_instance_id) do
     NodeCapacity.all(capacity_table)
     |> Enum.filter(&group_capable?/1)
     |> case do
-      [] -> {:error, :no_capacity}
-      [fact | _] -> {:ok, fact.configured_id}
+      [] ->
+        {:error, :no_capacity}
+
+      [fact | _] ->
+        node_id = fact.configured_id
+
+        select_opts =
+          [
+            table: capacity_table,
+            workload: workload,
+            need_mib: group_mem_mib(entry)
+          ] ++ warmth_opts(group_instance_id)
+
+        case Embervm.WakeInstance.select(node_id, select_opts) do
+          {:ok, dial_id} -> {:ok, node_id, dial_id}
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  # Warmth selection for a wake/bank/adopt (the banked instance's set): match the
+  # node's group_bundle_sets by the group_instance_id the set is keyed on. A fresh
+  # CREATE (nil id) carries no warmth, so it goes straight to the mem-eligible pick.
+  defp warmth_opts(group_instance_id) when is_binary(group_instance_id) and group_instance_id != "" do
+    [warmth_key: :group_bundle_sets, warmth_match_field: :group_instance_id, warmth_ref: group_instance_id]
+  end
+
+  defp warmth_opts(_group_instance_id), do: []
+
+  # The group's total member memory (MiB): a composite group's members are all
+  # co-located on the anchor instance, so the instance must fit their sum. Reads
+  # each member's mem_mib from the catalog group entry (512 default), summing to the
+  # cold-selection need. 0 members reads as 512 so an entry with no member sizing
+  # still needs the baseline.
+  defp group_mem_mib(entry) do
+    members = get_in(entry, [:group, :members]) || []
+
+    case Enum.reduce(members, 0, fn m, acc -> acc + (Map.get(m, :mem_mib) || 512) end) do
+      0 -> 512
+      total -> total
     end
   end
 

--- a/projects/embervm/control/lib/embervm/group_wake_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_wake_manager.ex
@@ -485,11 +485,48 @@ defmodule Embervm.GroupWakeManager do
          when is_binary(node_id) and is_binary(set_id) and set_id != "" <-
            GroupStore.get(state.store, instance_id),
          false <- set_local?(state, node_id, instance_id),
-         true <- store_reachable?(state, node_id) do
-      restore_set(state, node_id, workload, set_id)
+         true <- store_reachable?(state, node_id),
+         # Instance selection (Step 4): the restore must land the set on the SAME
+         # instance the delegated GroupManager boot dials, since bundle sets are
+         # per-instance on disk (PR-2.5). Resolve the boot's instance with the
+         # IDENTICAL WakeInstance.select the Supervisor's anchor_instance uses (same
+         # table, workload key, and need_mib), so both pick the same dial_id (the set
+         # is not local here, so warmth matches nothing and both take the deterministic
+         # cold pick). A no-eligible-instance result skips the restore (the delegated
+         # wake fails/fresh-boots as it would without a restore).
+         {:ok, dial_id} <- select_restore_instance(state, node_id, workload) do
+      restore_set(state, dial_id, node_id, workload, set_id)
       :ok
     else
       _ -> :ok
+    end
+  end
+
+  # Resolve the instance the delegated boot will dial (see maybe_restore_set), keyed
+  # identically to Embervm.GroupManager.Supervisor.anchor_instance: the workload as
+  # the deterministic choose key and the group's total member memory as need_mib. The
+  # set is absent locally on this path, so there is no warmth owner to prefer.
+  defp select_restore_instance(state, node_id, workload) do
+    Embervm.WakeInstance.select(node_id,
+      table: state.capacity_table,
+      workload: workload,
+      need_mib: group_mem_mib(state, workload)
+    )
+  end
+
+  # The group's total member memory (MiB), mirroring
+  # Embervm.GroupManager.Supervisor.group_mem_mib so the restore-instance pick matches
+  # the boot-instance pick. 512 default per member and as the floor.
+  defp group_mem_mib(state, workload) do
+    members =
+      case WorkloadCatalog.fetch(state.catalog_table, workload) do
+        {:ok, %{group: %{members: members}}} when is_list(members) -> members
+        _ -> []
+      end
+
+    case Enum.reduce(members, 0, fn m, acc -> acc + (Map.get(m, :mem_mib) || 512) end) do
+      0 -> 512
+      total -> total
     end
   end
 
@@ -522,11 +559,15 @@ defmodule Embervm.GroupWakeManager do
     end
   end
 
-  defp restore_set(state, node_id, workload, set_id) do
+  # `dial_id` is the boot's selected instance (Step 4): restore the set onto it, not
+  # the node-name alias. `node_id` is kept for the vendor stamp only (see the
+  # stateful/serving restore notes: RestoreVendor keys on the node name, and the
+  # vendor is identical across a node's instances).
+  defp restore_set(state, dial_id, node_id, workload, set_id) do
     ref = %ArtifactRef{kind: :ARTIFACT_KIND_GROUP_SET, workload: workload, ref: set_id}
     req = %RestoreArtifactRequest{artifact: ref, trace: %Trace{workload: workload}}
 
-    case safe_restore_artifact(state, node_id, req) do
+    case safe_restore_artifact(state, dial_id, node_id, req) do
       {:ok, resp} ->
         record_restore(state, workload, set_id, resp)
         :ok
@@ -542,10 +583,13 @@ defmodule Embervm.GroupWakeManager do
     end
   end
 
-  defp safe_restore_artifact(state, node_id, %RestoreArtifactRequest{artifact: ref} = req) do
+  # Dial the restore on `dial_id` (the boot's instance, Step 4) but stamp the vendor
+  # off `node_id` (the node-name anchor RestoreVendor can resolve). Transport-death
+  # invalidation is keyed on `dial_id` (the channel we actually dialled).
+  defp safe_restore_artifact(state, dial_id, node_id, %RestoreArtifactRequest{artifact: ref} = req) do
     req = Embervm.RestoreVendor.stamp(state.capacity_table, node_id, req)
 
-    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+    with {:ok, channel} <- safe_channel(state.channel_fun, dial_id) do
       # The `artifact_restore` span (Task 11): a child span around the
       # RestoreArtifact RPC (the restore-on-miss read path). A group set is always
       # kind GROUP_SET; bytes-moved/skipped stamped from the response.
@@ -557,7 +601,7 @@ defmodule Embervm.GroupWakeManager do
                            "ember.artifact_ref" => ref.ref
                          }
                        } do
-        result = restore_rpc(state, node_id, channel, req)
+        result = restore_rpc(state, dial_id, channel, req)
         stamp_restore_span(result)
         result
       end
@@ -565,13 +609,14 @@ defmodule Embervm.GroupWakeManager do
   end
 
   # The RestoreArtifact RPC with transport-death channel invalidation. Extracted so
-  # the `artifact_restore` span wraps exactly the call and its result.
-  defp restore_rpc(state, node_id, channel, req) do
+  # the `artifact_restore` span wraps exactly the call and its result. Invalidates by
+  # `dial_id` (the instance the channel was dialled on, Step 4).
+  defp restore_rpc(state, dial_id, channel, req) do
     try do
       case state.restore_artifact_fun.(channel, req) do
         {:error, reason} = err ->
           if Embervm.NodeChannel.transport_dead?(reason) do
-            _ = state.invalidate_fun.(node_id, channel)
+            _ = state.invalidate_fun.(dial_id, channel)
           end
 
           err
@@ -583,7 +628,7 @@ defmodule Embervm.GroupWakeManager do
       e -> {:error, {:restore_artifact_raised, e}}
     catch
       :exit, reason ->
-        _ = state.invalidate_fun.(node_id, channel)
+        _ = state.invalidate_fun.(dial_id, channel)
         {:error, {:restore_artifact_raised, {:exit, reason}}}
 
       kind, reason ->

--- a/projects/embervm/control/lib/embervm/serving_manager.ex
+++ b/projects/embervm/control/lib/embervm/serving_manager.ex
@@ -376,7 +376,11 @@ defmodule Embervm.ServingManager do
                 req = relight_request(entry, instance)
 
                 spawn_wake(owner, workload, fn ->
-                  _ = restore_bundle(state, node_id, workload, instance.snapshot_ref)
+                  # Restore onto the SAME instance the boot dials (dial_id), not the
+                  # node-name alias: serving snapshots are per-instance ON DISK
+                  # (PR-2.5), so restoring onto an arbitrary co-located instance while
+                  # the boot runs on another leaves the boot's local disk empty.
+                  _ = restore_bundle(state, dial_id, node_id, workload, instance.snapshot_ref)
                   run_relight(state, instance, node_id, dial_id, req)
                 end)
 
@@ -1168,10 +1172,16 @@ defmodule Embervm.ServingManager do
   # falls through to the relight, which the daemon degrades to a cold boot on a
   # truly-missing snapshot (fail-open warmth). Idempotent on the daemon side, so a
   # re-run of a partially-restored artifact is safe.
-  defp restore_bundle(state, node_id, workload, snapshot_ref) do
+  # `dial_id` is the SELECTED instance's dial key (Step 4): the restore RPC must land
+  # the bundle on the same instance the subsequent relight dials, since serving
+  # snapshots are per-instance on disk (PR-2.5). `node_id` is the node-name anchor
+  # kept only for the VENDOR stamp (RestoreVendor resolves the node's CPU vendor via
+  # NodeCapacity.fetch, which keys on the node name; an instance_id string would not
+  # resolve, and the vendor is identical across a node's instances anyway).
+  defp restore_bundle(state, dial_id, node_id, workload, snapshot_ref) do
     ref = %ArtifactRef{kind: :ARTIFACT_KIND_SERVING, workload: workload, ref: snapshot_ref}
 
-    case safe_restore_artifact(state, node_id, ref) do
+    case safe_restore_artifact(state, dial_id, node_id, ref) do
       {:ok, resp} ->
         record_restore(state, workload, :ARTIFACT_KIND_SERVING, snapshot_ref, resp)
         :ok
@@ -1187,11 +1197,14 @@ defmodule Embervm.ServingManager do
     end
   end
 
-  defp safe_restore_artifact(state, node_id, %ArtifactRef{} = ref) do
+  # Dial the restore on `dial_id` (the relight's instance, Step 4) but stamp the
+  # vendor off `node_id` (the node-name anchor RestoreVendor can resolve). Transport-
+  # death invalidation is keyed on `dial_id` (the channel we actually dialled).
+  defp safe_restore_artifact(state, dial_id, node_id, %ArtifactRef{} = ref) do
     req = %RestoreArtifactRequest{artifact: ref, trace: %Trace{workload: ref.workload}}
     req = Embervm.RestoreVendor.stamp(state.capacity_table, node_id, req)
 
-    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+    with {:ok, channel} <- safe_channel(state.channel_fun, dial_id) do
       # The `artifact_restore` span (Task 11): a child span around the
       # RestoreArtifact RPC (the restore-on-miss read path). Identity up front,
       # bytes-moved/skipped stamped from the response.
@@ -1203,7 +1216,7 @@ defmodule Embervm.ServingManager do
                            "ember.artifact_ref" => ref.ref
                          }
                        } do
-        result = restore_rpc(state, node_id, channel, req)
+        result = restore_rpc(state, dial_id, channel, req)
         stamp_restore_span(result)
         result
       end
@@ -1211,13 +1224,14 @@ defmodule Embervm.ServingManager do
   end
 
   # The RestoreArtifact RPC with transport-death channel invalidation. Extracted so
-  # the `artifact_restore` span wraps exactly the call and its result.
-  defp restore_rpc(state, node_id, channel, req) do
+  # the `artifact_restore` span wraps exactly the call and its result. Invalidates by
+  # `dial_id` (the instance the channel was dialled on, Step 4).
+  defp restore_rpc(state, dial_id, channel, req) do
     try do
       case state.restore_artifact_fun.(channel, req) do
         {:error, reason} = err ->
           if Embervm.NodeChannel.transport_dead?(reason) do
-            _ = state.invalidate_fun.(node_id, channel)
+            _ = state.invalidate_fun.(dial_id, channel)
           end
 
           err
@@ -1229,7 +1243,7 @@ defmodule Embervm.ServingManager do
       e -> {:error, {:restore_artifact_raised, e}}
     catch
       :exit, reason ->
-        _ = state.invalidate_fun.(node_id, channel)
+        _ = state.invalidate_fun.(dial_id, channel)
         {:error, {:restore_artifact_raised, {:exit, reason}}}
 
       kind, reason ->

--- a/projects/embervm/control/lib/embervm/serving_manager.ex
+++ b/projects/embervm/control/lib/embervm/serving_manager.ex
@@ -337,18 +337,28 @@ defmodule Embervm.ServingManager do
 
     case plan do
       {:relight, instance, node_id} ->
-        # Move the banked instance to relighting (ETS-only, no op) before the RPC, so
-        # a concurrent reconcile does not touch it and the later serving_relit is a
-        # legal relighting -> starting edge.
-        case ServingStore.mark(state.store, instance.instance_id, :relight) do
-          {:ok, _} ->
-            req = relight_request(entry, instance)
-            spawn_wake(owner, workload, fn -> run_relight(state, instance, node_id, req) end)
+        # Instance selection (Step 4): a relight MUST land on the instance that
+        # BANKED this serving snapshot on disk (per-instance-on-disk, PR-2.5), so
+        # dial that instance's instance_id rather than the collapsing node-name
+        # alias. No owning instance -> a mem-eligible one; none at all -> fail clean.
+        case dial_instance(state, workload, entry, node_id, warmth_ref: instance.snapshot_ref) do
+          {:ok, dial_id} ->
+            # Move the banked instance to relighting (ETS-only, no op) before the RPC,
+            # so a concurrent reconcile does not touch it and the later serving_relit
+            # is a legal relighting -> starting edge.
+            case ServingStore.mark(state.store, instance.instance_id, :relight) do
+              {:ok, _} ->
+                req = relight_request(entry, instance)
+                spawn_wake(owner, workload, fn -> run_relight(state, instance, node_id, dial_id, req) end)
+
+              {:error, reason} ->
+                # The instance moved off banked concurrently: report a wake failure so
+                # the parked callers 503 and the next miss retries.
+                send(self(), {:wake_done, workload, {:error, {:relight_mark, reason}}})
+            end
 
           {:error, reason} ->
-            # The instance moved off banked concurrently: report a wake failure so the
-            # parked callers 503 and the next miss retries.
-            send(self(), {:wake_done, workload, {:error, {:relight_mark, reason}}})
+            send(self(), {:wake_done, workload, {:error, reason}})
         end
 
       # Restore-on-miss (R6): the local snapshot is gone but its store copy is
@@ -357,22 +367,39 @@ defmodule Embervm.ServingManager do
       # path. The restore failing (store unreachable mid-wake, or the copy vanished)
       # degrades to the daemon's own cold-boot fallback (fail-open warmth).
       {:restore_then_relight, instance, node_id} ->
-        case ServingStore.mark(state.store, instance.instance_id, :relight) do
-          {:ok, _} ->
-            req = relight_request(entry, instance)
+        # The local snapshot is gone, so no instance reports it: selection falls to a
+        # mem-eligible instance the restore lands the bundle onto.
+        case dial_instance(state, workload, entry, node_id, warmth_ref: instance.snapshot_ref) do
+          {:ok, dial_id} ->
+            case ServingStore.mark(state.store, instance.instance_id, :relight) do
+              {:ok, _} ->
+                req = relight_request(entry, instance)
 
-            spawn_wake(owner, workload, fn ->
-              _ = restore_bundle(state, node_id, workload, instance.snapshot_ref)
-              run_relight(state, instance, node_id, req)
-            end)
+                spawn_wake(owner, workload, fn ->
+                  _ = restore_bundle(state, node_id, workload, instance.snapshot_ref)
+                  run_relight(state, instance, node_id, dial_id, req)
+                end)
+
+              {:error, reason} ->
+                send(self(), {:wake_done, workload, {:error, {:relight_mark, reason}}})
+            end
 
           {:error, reason} ->
-            send(self(), {:wake_done, workload, {:error, {:relight_mark, reason}}})
+            send(self(), {:wake_done, workload, {:error, reason}})
         end
 
       {:cold, node_id, base_ref} ->
-        req = cold_request(entry, workload, base_ref)
-        spawn_wake(owner, workload, fn -> run_cold(state, workload, node_id, base_ref, req) end)
+        # A cold boot has no owning snapshot: select a mem-eligible instance on the
+        # node (a too-small classed brick is skipped, the DS wildcard is always
+        # eligible), failing cleanly if none has room.
+        case dial_instance(state, workload, entry, node_id, []) do
+          {:ok, dial_id} ->
+            req = cold_request(entry, workload, base_ref)
+            spawn_wake(owner, workload, fn -> run_cold(state, workload, node_id, dial_id, base_ref, req) end)
+
+          {:error, select_reason} ->
+            send(self(), {:wake_done, workload, {:error, select_reason}})
+        end
 
       {:error, reason} ->
         # No capacity / snapshot lost: report it so the parked callers 503.
@@ -380,6 +407,24 @@ defmodule Embervm.ServingManager do
     end
 
     state
+  end
+
+  # Select the SPECIFIC instance on the resolved node to dial (Step 4): prefer the
+  # instance that banked this workload's serving snapshot (its serving_snapshots
+  # report `warmth_ref`), else a mem-eligible instance sized for the workload's
+  # mem_mib, else `{:error, :no_eligible_instance}`. Returns the dial key
+  # (instance_id, or the node name for a legacy fact without one). A cold boot passes
+  # no `:warmth_ref` and goes straight to the mem-eligible pick.
+  defp dial_instance(state, workload, entry, node_id, opts) do
+    Embervm.WakeInstance.select(
+      node_id,
+      [
+        table: state.capacity_table,
+        workload: workload,
+        need_mib: Map.get(entry, :mem_mib) || 512,
+        warmth_key: :serving_snapshots
+      ] ++ opts
+    )
   end
 
   # Spawn a wake worker that ALWAYS reports a {:wake_done} outcome, even if the RPC
@@ -548,8 +593,8 @@ defmodule Embervm.ServingManager do
 
   # The relight RPC (in the spawned worker). Returns the outcome finish_wake
   # projects durably.
-  defp run_relight(state, instance, node_id, req) do
-    case safe_start_serving(state, node_id, req) do
+  defp run_relight(state, instance, node_id, dial_id, req) do
+    case safe_start_serving(state, dial_id, req) do
       {:ok, %StartServingResponse{vm_id: vm_id, ip: ip, port: port}}
       when is_binary(vm_id) and vm_id != "" ->
         {:relit, instance.instance_id, node_id, %{vm_id: vm_id, ip: ip, port: port}}
@@ -560,8 +605,8 @@ defmodule Embervm.ServingManager do
   end
 
   # The cold-create RPC (in the spawned worker).
-  defp run_cold(state, workload, node_id, base_ref, req) do
-    case safe_start_serving(state, node_id, req) do
+  defp run_cold(state, workload, node_id, dial_id, base_ref, req) do
+    case safe_start_serving(state, dial_id, req) do
       {:ok, %StartServingResponse{vm_id: vm_id, ip: ip, port: port}}
       when is_binary(vm_id) and vm_id != "" ->
         attrs = %{

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -720,7 +720,11 @@ defmodule Embervm.StatefulManager do
                 req = relight_request(entry, snapshot_ref, fallback_ref, blessed_generation)
 
                 spawn_wake(owner, workload, fn ->
-                  _ = restore_bundle(state, node_id, workload, snapshot_ref)
+                  # Restore onto the SAME instance the boot dials (dial_id), not the
+                  # node-name alias: PR-2.5 made banked bundles per-instance ON DISK,
+                  # so restoring onto an arbitrary co-located instance while the boot
+                  # runs on another leaves the boot's local disk empty (cold-fails).
+                  _ = restore_bundle(state, dial_id, node_id, workload, snapshot_ref)
                   run_relight(state, instance, node_id, dial_id, req)
                 end)
 
@@ -759,7 +763,10 @@ defmodule Embervm.StatefulManager do
             reason = cold_reason(volume)
 
             spawn_wake(owner, workload, fn ->
-              _ = restore_volume(state, node_id, wl, volume)
+              # Restore onto the boot's instance (dial_id), not the node-name alias
+              # (see the relight-with-restore note above): the cold boot reads the
+              # volume from dial_id's local disk.
+              _ = restore_volume(state, dial_id, node_id, wl, volume)
               run_cold(state, wl, node_id, dial_id, boot_ref, :cold, reason, req)
             end)
 
@@ -2019,10 +2026,16 @@ defmodule Embervm.StatefulManager do
   # falls through to the relight, which the daemon degrades to a cold boot via the
   # boot_image_ref that rides the request (fail-open warmth). Idempotent on the
   # daemon side, so a re-run of a partially-restored artifact is safe.
-  defp restore_bundle(state, node_id, workload, snapshot_ref) do
+  # `dial_id` is the SELECTED instance's dial key (Step 4): the restore RPC must land
+  # the bundle on the same instance the subsequent boot dials, since bundles are
+  # per-instance on disk (PR-2.5). `node_id` is the node-name anchor kept only for the
+  # VENDOR stamp: RestoreVendor resolves the node's CPU vendor via NodeCapacity.fetch,
+  # which keys on the node name (an instance_id string would not resolve); the vendor
+  # is identical across a node's instances, so this is correct.
+  defp restore_bundle(state, dial_id, node_id, workload, snapshot_ref) do
     ref = %ArtifactRef{kind: :ARTIFACT_KIND_STATEFUL, workload: workload, ref: snapshot_ref}
 
-    case safe_restore_artifact(state, node_id, ref) do
+    case safe_restore_artifact(state, dial_id, node_id, ref) do
       {:ok, resp} ->
         record_restore(state, workload, :ARTIFACT_KIND_STATEFUL, snapshot_ref, resp)
         :ok
@@ -2043,10 +2056,10 @@ defmodule Embervm.StatefulManager do
   # (vol.img, gen) pair, then record :artifact_restored. Best-effort, same as
   # restore_bundle: a failure degrades to a plain cold boot (which the daemon fails
   # closed on for a truly-absent volume).
-  defp restore_volume(state, node_id, workload, _volume) do
+  defp restore_volume(state, dial_id, node_id, workload, _volume) do
     ref = %ArtifactRef{kind: :ARTIFACT_KIND_VOLUME, workload: workload, ref: workload}
 
-    case safe_restore_artifact(state, node_id, ref) do
+    case safe_restore_artifact(state, dial_id, node_id, ref) do
       {:ok, resp} ->
         record_restore(state, workload, :ARTIFACT_KIND_VOLUME, workload, resp)
         :ok
@@ -2061,11 +2074,14 @@ defmodule Embervm.StatefulManager do
     end
   end
 
-  defp safe_restore_artifact(state, node_id, %ArtifactRef{} = ref) do
+  # Dial the restore on `dial_id` (the boot's instance, Step 4) but stamp the vendor
+  # off `node_id` (the node-name anchor RestoreVendor can resolve). Invalidation on a
+  # dead transport is also keyed on `dial_id` (the channel we actually dialled).
+  defp safe_restore_artifact(state, dial_id, node_id, %ArtifactRef{} = ref) do
     req = %RestoreArtifactRequest{artifact: ref, trace: %Trace{workload: ref.workload}}
     req = Embervm.RestoreVendor.stamp(state.capacity_table, node_id, req)
 
-    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+    with {:ok, channel} <- safe_channel(state.channel_fun, dial_id) do
       # The `artifact_restore` span (Task 11): a child span around the
       # RestoreArtifact RPC (the restore-on-miss read path). Carries the artifact
       # identity up front and stamps bytes-moved/skipped from the response, so the
@@ -2078,7 +2094,7 @@ defmodule Embervm.StatefulManager do
                            "ember.artifact_ref" => ref.ref
                          }
                        } do
-        result = restore_rpc(state, node_id, channel, req)
+        result = restore_rpc(state, dial_id, channel, req)
         stamp_restore_span(result)
         result
       end
@@ -2086,13 +2102,14 @@ defmodule Embervm.StatefulManager do
   end
 
   # The RestoreArtifact RPC with transport-death channel invalidation. Extracted so
-  # the `artifact_restore` span wraps exactly the call and its result.
-  defp restore_rpc(state, node_id, channel, req) do
+  # the `artifact_restore` span wraps exactly the call and its result. Invalidates by
+  # `dial_id` (the instance the channel was dialled on, Step 4).
+  defp restore_rpc(state, dial_id, channel, req) do
     try do
       case state.restore_artifact_fun.(channel, req) do
         {:error, reason} = err ->
           if Embervm.NodeChannel.transport_dead?(reason) do
-            _ = state.invalidate_fun.(node_id, channel)
+            _ = state.invalidate_fun.(dial_id, channel)
           end
 
           err
@@ -2104,7 +2121,7 @@ defmodule Embervm.StatefulManager do
       e -> {:error, {:restore_artifact_raised, e}}
     catch
       :exit, reason ->
-        _ = state.invalidate_fun.(node_id, channel)
+        _ = state.invalidate_fun.(dial_id, channel)
         {:error, {:restore_artifact_raised, {:exit, reason}}}
 
       kind, reason ->

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -675,20 +675,30 @@ defmodule Embervm.StatefulManager do
 
     case plan do
       {:relight, instance, node_id, snapshot_ref} ->
-        case StatefulStore.mark(state.store, instance.instance_id, :relight) do
-          {:ok, _} ->
-            # boot_image_ref rides even a RELIGHT: if the daemon discovers the
-            # generation pair is actually broken (a mismatch we could not see
-            # from here, or an unreadable ledger) it falls back to a cold boot
-            # from THIS ref rather than failing the call outright.
-            fallback_ref = boot_image_ref(state, node_id, workload)
-            req = relight_request(entry, snapshot_ref, fallback_ref, blessed_generation)
-            spawn_wake(owner, workload, fn -> run_relight(state, instance, node_id, req) end)
+        # Instance selection (Step 4): a relight MUST land on the instance that
+        # BANKED this bundle on disk (per-instance-on-disk, PR-2.5), so dial the
+        # bundle-owning instance's instance_id, not the bare node name. No owning
+        # instance on the node -> a mem-eligible one; none at all -> fail cleanly.
+        case dial_instance(state, workload, entry, node_id, warmth_ref: snapshot_ref) do
+          {:ok, dial_id} ->
+            case StatefulStore.mark(state.store, instance.instance_id, :relight) do
+              {:ok, _} ->
+                # boot_image_ref rides even a RELIGHT: if the daemon discovers the
+                # generation pair is actually broken (a mismatch we could not see
+                # from here, or an unreadable ledger) it falls back to a cold boot
+                # from THIS ref rather than failing the call outright.
+                fallback_ref = boot_image_ref(state, node_id, workload)
+                req = relight_request(entry, snapshot_ref, fallback_ref, blessed_generation)
+                spawn_wake(owner, workload, fn -> run_relight(state, instance, node_id, dial_id, req) end)
+
+              {:error, reason} ->
+                # The instance moved off banked concurrently: report a wake failure
+                # so the parked callers error and the next connection retries.
+                send(self(), {:wake_done, workload, {:error, {:relight_mark, reason}}})
+            end
 
           {:error, reason} ->
-            # The instance moved off banked concurrently: report a wake failure
-            # so the parked callers error and the next connection retries.
-            send(self(), {:wake_done, workload, {:error, {:relight_mark, reason}}})
+            send(self(), {:wake_done, workload, {:error, reason}})
         end
 
       # Restore-on-miss (R6): the local bundle is gone but its store copy is
@@ -698,23 +708,43 @@ defmodule Embervm.StatefulManager do
       # vanished) degrades to the daemon's cold-boot fallback via the boot_image_ref
       # that rides the relight request (fail-open warmth).
       {:restore_then_relight, instance, node_id, snapshot_ref} ->
-        case StatefulStore.mark(state.store, instance.instance_id, :relight) do
-          {:ok, _} ->
-            fallback_ref = boot_image_ref(state, node_id, workload)
-            req = relight_request(entry, snapshot_ref, fallback_ref, blessed_generation)
+        # A restore-on-miss relight targets the SAME instance a warm relight would:
+        # the bundle-owning instance when one still reports it, else a mem-eligible
+        # cold candidate the restore lands the bundle onto (warmth_ref matches
+        # nothing when the local bundle is gone, so this falls to the cold pick).
+        case dial_instance(state, workload, entry, node_id, warmth_ref: snapshot_ref) do
+          {:ok, dial_id} ->
+            case StatefulStore.mark(state.store, instance.instance_id, :relight) do
+              {:ok, _} ->
+                fallback_ref = boot_image_ref(state, node_id, workload)
+                req = relight_request(entry, snapshot_ref, fallback_ref, blessed_generation)
 
-            spawn_wake(owner, workload, fn ->
-              _ = restore_bundle(state, node_id, workload, snapshot_ref)
-              run_relight(state, instance, node_id, req)
-            end)
+                spawn_wake(owner, workload, fn ->
+                  _ = restore_bundle(state, node_id, workload, snapshot_ref)
+                  run_relight(state, instance, node_id, dial_id, req)
+                end)
+
+              {:error, reason} ->
+                send(self(), {:wake_done, workload, {:error, {:relight_mark, reason}}})
+            end
 
           {:error, reason} ->
-            send(self(), {:wake_done, workload, {:error, {:relight_mark, reason}}})
+            send(self(), {:wake_done, workload, {:error, reason}})
         end
 
       {:cold, node_id, boot_ref, mode, reason} ->
-        req = cold_request(state, entry, workload, boot_ref, mode, blessed_generation)
-        spawn_wake(owner, workload, fn -> run_cold(state, workload, node_id, boot_ref, mode, reason, req) end)
+        # A cold boot has no owning bundle: select a mem-eligible instance on the
+        # node (a too-small classed brick is skipped; the DS wildcard is always
+        # eligible), and fail cleanly if none has room rather than dialling a
+        # too-small one.
+        case dial_instance(state, workload, entry, node_id, []) do
+          {:ok, dial_id} ->
+            req = cold_request(state, entry, workload, boot_ref, mode, blessed_generation)
+            spawn_wake(owner, workload, fn -> run_cold(state, workload, node_id, dial_id, boot_ref, mode, reason, req) end)
+
+          {:error, select_reason} ->
+            send(self(), {:wake_done, workload, {:error, select_reason}})
+        end
 
       # Restore-on-miss (R6): the volume itself is gone but a (vol.img, gen) pair is
       # exported. Restore the VOLUME inside the wake worker FIRST, then cold-boot at
@@ -722,14 +752,20 @@ defmodule Embervm.StatefulManager do
       # restore, no create). A restore failure degrades to a plain cold boot, which
       # for a truly-absent volume the daemon fails closed on (data fails closed).
       {:restore_volume_then_cold, wl, node_id, volume} ->
-        boot_ref = boot_image_ref(state, node_id, wl)
-        req = cold_request(state, entry, wl, boot_ref, :cold, blessed_generation)
-        reason = cold_reason(volume)
+        case dial_instance(state, wl, entry, node_id, []) do
+          {:ok, dial_id} ->
+            boot_ref = boot_image_ref(state, node_id, wl)
+            req = cold_request(state, entry, wl, boot_ref, :cold, blessed_generation)
+            reason = cold_reason(volume)
 
-        spawn_wake(owner, workload, fn ->
-          _ = restore_volume(state, node_id, wl, volume)
-          run_cold(state, wl, node_id, boot_ref, :cold, reason, req)
-        end)
+            spawn_wake(owner, workload, fn ->
+              _ = restore_volume(state, node_id, wl, volume)
+              run_cold(state, wl, node_id, dial_id, boot_ref, :cold, reason, req)
+            end)
+
+          {:error, select_reason} ->
+            send(self(), {:wake_done, workload, {:error, select_reason}})
+        end
 
       {:error, reason} ->
         send(self(), {:wake_done, workload, {:error, reason}})
@@ -1030,6 +1066,28 @@ defmodule Embervm.StatefulManager do
     |> Enum.find(&(&1.state == :banked))
   end
 
+  # Select the SPECIFIC instance on the resolved anchor node to dial (Step 4):
+  # prefer the instance that banked this workload's bundle (its stateful_bundles
+  # report `warmth_ref`), else a mem-eligible instance sized for the workload's
+  # mem_mib, else `{:error, :no_eligible_instance}`. Returns the dial key
+  # (instance_id, or the node name for a legacy fact without one) so the caller
+  # dials by instance_id instead of the collapsing node-name alias. `opts` may
+  # carry `:warmth_ref` (the snapshot_ref a relight must land on); a cold boot omits
+  # it and goes straight to the mem-eligible pick.
+  defp dial_instance(state, workload, entry, node_id, opts) do
+    %ResourceSpec{mem_mib: need_mib} = resource_spec(entry)
+
+    Embervm.WakeInstance.select(
+      node_id,
+      [
+        table: state.capacity_table,
+        workload: workload,
+        need_mib: need_mib,
+        warmth_key: :stateful_bundles
+      ] ++ opts
+    )
+  end
+
   # -- request builders --------------------------------------------------------
 
   # RELIGHT never carries mmds_env (R4, D-R4.PR-7.1): a relight resumes the
@@ -1141,8 +1199,8 @@ defmodule Embervm.StatefulManager do
 
   # -- wake RPC workers ---------------------------------------------------------
 
-  defp run_relight(state, instance, node_id, req) do
-    case safe_start_stateful(state, node_id, req) do
+  defp run_relight(state, instance, node_id, dial_id, req) do
+    case safe_start_stateful(state, dial_id, req) do
       {:ok, %StartStatefulResponse{vm_id: vm_id, ip: ip, port: port, generation: generation, was_relight: true}}
       when is_binary(vm_id) and vm_id != "" ->
         {:relit, instance.instance_id, node_id, %{vm_id: vm_id, ip: ip, port: port, generation: generation}}
@@ -1161,8 +1219,8 @@ defmodule Embervm.StatefulManager do
     end
   end
 
-  defp run_cold(state, workload, node_id, boot_ref, mode, reason, req) do
-    case safe_start_stateful(state, node_id, req) do
+  defp run_cold(state, workload, node_id, dial_id, boot_ref, mode, reason, req) do
+    case safe_start_stateful(state, dial_id, req) do
       {:ok, %StartStatefulResponse{vm_id: vm_id, ip: ip, port: port, generation: generation}}
       when is_binary(vm_id) and vm_id != "" ->
         attrs = %{

--- a/projects/embervm/control/lib/embervm/wake_instance.ex
+++ b/projects/embervm/control/lib/embervm/wake_instance.ex
@@ -1,0 +1,187 @@
+defmodule Embervm.WakeInstance do
+  @moduledoc """
+  Instance selection for the stateful/serving/group WAKE dial (brick co-location
+  foundation, Step 4).
+
+  A wake resolves its target NODE first (the volume-anchored node for stateful, the
+  snapshot-owning node for serving, the network-anchored node for a group). Before
+  the brick co-location work, the manager then dialled `channel_fun.(node_id)` with
+  that bare NODE NAME. Under one instance per node that was unambiguous. Under
+  CO-LOCATED bricks (several noded instances on one node, ADR embervm/012 / the
+  brick capacity ladder) it is not: the dual-keyed `Embervm.NodeChannel` resolves a
+  node-name alias to ONE arbitrary instance (the last registrant), so a Postgres
+  wake could land on a 2Gi brick too small to boot it.
+
+  This module closes that gap: given the resolved node, it selects the SPECIFIC
+  instance on that node the wake must dial, and returns that instance's
+  `instance_id` (`"node/pod_uid"`) so the caller dials `channel_fun.(instance_id)`
+  (the exact per-instance key the dual-keyed channel resolves without the
+  node-name-alias collapse).
+
+  ## selection priority
+
+    1. The instance that BANKED this workload's warmth on disk. PR-2.5 made banked
+       bundles/snapshots per-instance ON DISK, so a relight MUST land on the instance
+       that banked it or the bundle is not there. `owning_instance/4` scans the node's
+       per-instance capacity facts for the one whose warmth inventory (the
+       `serving_snapshots` / `stateful_bundles` / `group_bundle_sets` list named by
+       `warmth_key`) contains the wake's `ref`, and returns its `instance_id`.
+
+    2. Else (a cold boot, or no owning instance found) a mem-ELIGIBLE instance on the
+       node: the node's bricks (`Embervm.BrickLedger.bricks/1`) filtered by the
+       DS-wildcard rule, then `Embervm.BrickLedger.choose(list, workload)` for a
+       deterministic, sticky pick. `need_mib` is the workload's `mem_mib`. The
+       DS-wildcard rule: a wildcard/zero-budget instance (`size_class == ""`, the big
+       burst-envelope DaemonSet with no cgroup limit, reporting `mem_headroom_mib =
+       0` / `mem_budget_mib = 0`) is ALWAYS eligible on the mem gate; only a CLASSED
+       brick with a real budget is gated on `mem_headroom_mib >= need_mib`. We do NOT
+       reuse `BrickLedger.candidates/3` here: it gates EVERY brick on headroom (right
+       for the dispatcher, where a co-located brick reports a real budget), which
+       would wrongly exclude a zero-headroom wildcard on the still-DS-only fleet.
+
+    3. If NEITHER an owning instance NOR an eligible cold candidate exists on the node,
+       `{:error, :no_eligible_instance}`: the caller fails the wake with a clear reason
+       rather than dialling a too-small instance.
+
+  ## inert on the current single-instance-per-node fleet
+
+  With one instance per node the node's only instance IS the owner (it banked
+  everything) and IS the sole cold candidate, so selection always returns that
+  instance and the caller dials its `instance_id`, which the dual-keyed channel
+  resolves identically to the old node-name dial. Output-equivalent, so this deploys
+  later at the re-canary with no behaviour change today.
+
+  ## legacy / test facts without an instance_id
+
+  A capacity fact that carries no `:instance_id` (a statically-seeded instance or a
+  test fixture that predates the field) falls back to the fact's `node_id`, so the
+  dial still resolves via the node-name alias exactly as before. The selection logic
+  is unchanged; only the dial key degrades gracefully.
+  """
+
+  alias Embervm.{BrickLedger, NodeCapacity}
+
+  @typedoc "A warmth-inventory field on a per-instance capacity fact + the id key its rows carry."
+  @type warmth_key :: :serving_snapshots | :stateful_bundles | :group_bundle_sets
+
+  @doc """
+  Select the instance on `node_id` a wake must dial. Returns `{:ok, instance_id}`
+  (the `"node/pod_uid"` key to pass to `channel_fun`) or
+  `{:error, :no_eligible_instance}`.
+
+  Options:
+
+    * `:workload`  (required) - the workload id, both the `choose/2` sticky key and the
+      warmth match field for serving/stateful (see `:warmth_match_field`).
+    * `:need_mib`  (required) - the workload's `mem_mib`; the cold-candidate mem gate.
+    * `:warmth_key` - which per-instance warmth list to scan for the owning instance
+      (`:serving_snapshots` / `:stateful_bundles` / `:group_bundle_sets`). Omit for a
+      pure cold pick (no owning instance to prefer, e.g. a fresh first boot).
+    * `:warmth_ref` - the ref the owning instance's warmth row must carry (the
+      snapshot_ref for serving/stateful, the set_id for a group). Omit/`nil` with a
+      `:warmth_key` means "no warmth to prefer", so it goes straight to the cold pick.
+    * `:warmth_match_field` - the row field the `:warmth_ref` is matched against
+      (default `:snapshot_ref`; groups pass `:set_id`).
+    * `:table` - the capacity ETS table (default `NodeCapacity.table()`).
+  """
+  @spec select(String.t(), keyword()) :: {:ok, String.t()} | {:error, :no_eligible_instance}
+  def select(node_id, opts) when is_binary(node_id) do
+    table = Keyword.get(opts, :table, NodeCapacity.table())
+    workload = Keyword.fetch!(opts, :workload)
+    need_mib = Keyword.fetch!(opts, :need_mib)
+
+    case owning_instance(table, node_id, opts) do
+      {:ok, instance_id} -> {:ok, instance_id}
+      :none -> cold_instance(table, node_id, workload, need_mib)
+    end
+  end
+
+  def select(_node_id, _opts), do: {:error, :no_eligible_instance}
+
+  # The instance on `node_id` whose warmth inventory reports this wake's ref: a
+  # relight MUST land on the instance that banked the bundle (per-instance-on-disk,
+  # PR-2.5). :none when there is no warmth to prefer (a cold boot, no key/ref given)
+  # or no instance on the node reports it (a true local miss / co-located-but-elsewhere,
+  # which then falls through to the cold pick).
+  defp owning_instance(table, node_id, opts) do
+    warmth_key = Keyword.get(opts, :warmth_key)
+    warmth_ref = Keyword.get(opts, :warmth_ref)
+    match_field = Keyword.get(opts, :warmth_match_field, :snapshot_ref)
+
+    if is_atom(warmth_key) and is_binary(warmth_ref) and warmth_ref != "" do
+      table
+      |> instances_on(node_id)
+      |> Enum.find(fn fact -> fact_reports_warmth?(fact, warmth_key, warmth_ref, match_field) end)
+      |> case do
+        nil -> :none
+        fact -> {:ok, dial_id(fact)}
+      end
+    else
+      :none
+    end
+  end
+
+  # A mem-eligible cold candidate on the node, then a deterministic sticky pick
+  # keyed by the workload. Eligibility folds the DS-wildcard-always-eligible rule
+  # (below) over the node's bricks: a wildcard/zero-budget instance is never mem-
+  # gated (it is the big burst-envelope DS reporting `mem_headroom_mib = 0` under no
+  # cgroup limit), while a CLASSED brick with a real budget must clear
+  # `mem_headroom_mib >= need_mib`. `BrickLedger.candidates/3` gates EVERY brick on
+  # headroom (correct for the dispatcher, where a wildcard reports a real budget),
+  # so the wake path applies the rule itself rather than reusing that filter, which
+  # would wrongly exclude a zero-headroom wildcard.
+  defp cold_instance(table, node_id, workload, need_mib) do
+    table
+    |> BrickLedger.bricks()
+    |> Enum.filter(fn brick -> brick.node_id == node_id and wake_eligible?(brick, need_mib) end)
+    |> BrickLedger.choose(workload)
+    |> case do
+      nil -> {:error, :no_eligible_instance}
+      brick -> {:ok, dial_id_from_brick(brick)}
+    end
+  end
+
+  # A brick can serve a cold wake when it has a free live-VM slot AND either it is
+  # the wildcard/zero-budget DS (always mem-eligible) or it is a classed brick with
+  # the headroom for the workload's need.
+  defp wake_eligible?(brick, need_mib) do
+    brick.free_slots > 0 and (wildcard?(brick) or brick.mem_headroom_mib >= need_mib)
+  end
+
+  # The always-mem-eligible DS: an empty size-class (the legacy wildcard) OR a
+  # zero/absent memory budget (no cgroup limit, the big burst envelope).
+  defp wildcard?(brick) do
+    brick.size_class == "" or brick.mem_budget_mib == 0
+  end
+
+  # Every per-instance capacity fact on `node_id` (co-located bricks + the DS
+  # wildcard), in no particular order.
+  defp instances_on(table, node_id) do
+    table
+    |> NodeCapacity.all()
+    |> Enum.filter(fn fact -> Map.get(fact, :node_id) == node_id end)
+  end
+
+  defp fact_reports_warmth?(fact, warmth_key, ref, match_field) do
+    fact
+    |> Map.get(warmth_key, [])
+    |> Kernel.||([])
+    |> Enum.any?(fn row -> Map.get(row, match_field) == ref end)
+  end
+
+  # The dial key for a capacity fact: its instance_id when present, else the node
+  # name (legacy/static facts without the field still resolve via the node-name
+  # alias, keeping single-instance behaviour identical).
+  defp dial_id(fact) do
+    case Map.get(fact, :instance_id) do
+      id when is_binary(id) and id != "" -> id
+      _ -> Map.get(fact, :node_id)
+    end
+  end
+
+  # Same fallback for a brick map (BrickLedger normalizes instance_id to "" when the
+  # fact lacked it, so treat "" as absent and fall back to node_id).
+  defp dial_id_from_brick(%{instance_id: id, node_id: node_id}) do
+    if is_binary(id) and id != "", do: id, else: node_id
+  end
+end

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -78,7 +78,7 @@ defmodule Embervm.StatefulManagerTest do
         capacity_table: cap_table,
         catalog_table: cat_table,
         clock: Keyword.get(opts, :clock, fn -> 1_000 end),
-        channel_fun: fn _node -> {:ok, :ch} end,
+        channel_fun: Keyword.get(opts, :channel_fun, fn _node -> {:ok, :ch} end),
         invalidate_fun: Keyword.get(opts, :invalidate_fun, fn _node, _chan -> :ok end),
         start_stateful_fun: start_stateful_fun,
         stop_stateful_fun: Keyword.get(opts, :stop_stateful_fun, fn _ch, _req -> {:ok, %Embervm.Node.V1.StopStatefulResponse{}} end),
@@ -118,6 +118,10 @@ defmodule Embervm.StatefulManagerTest do
   end
 
   defp stateful_workload(ctx, name, extra \\ %{}) do
+    # `:resources` promotes to the TOP-LEVEL entry (where resource_spec/1 reads
+    # mem_mib/vcpus); everything else merges into the stateful cfg.
+    {resources, extra} = Map.pop(extra, :resources)
+
     stateful_cfg =
       Map.merge(
         %{
@@ -134,7 +138,10 @@ defmodule Embervm.StatefulManagerTest do
         extra
       )
 
-    WorkloadCatalog.upsert(ctx.cat_table, name, %{class: "stateful", namespace: "embervm-workloads", stateful: stateful_cfg})
+    entry = %{class: "stateful", namespace: "embervm-workloads", stateful: stateful_cfg}
+    entry = if resources, do: Map.put(entry, :resources, resources), else: entry
+
+    WorkloadCatalog.upsert(ctx.cat_table, name, entry)
   end
 
   defp stateful_node(ctx, node_id, opts \\ []) do
@@ -1268,5 +1275,109 @@ defmodule Embervm.StatefulManagerTest do
 
     # No restore was attempted (store unreachable), and no wake was blocked.
     assert Agent.get(restore_calls, & &1) == []
+  end
+
+  # -- instance-aware dial (brick co-location foundation, Step 4) ----------------
+
+  # Put ONE per-instance capacity fact (keyed by {node, pod_uid}) for a co-located
+  # brick, carrying the fields WakeInstance.select reads.
+  defp put_brick(ctx, node_id, pod_uid, opts) do
+    NodeCapacity.put(ctx.cap_table, {node_id, pod_uid}, %{
+      node_id: node_id,
+      configured_id: node_id,
+      pod_uid: pod_uid,
+      instance_id: "#{node_id}/#{pod_uid}",
+      serving_subnet_cidr: "10.88.0.0/24",
+      size_class: Keyword.get(opts, :size_class, "8gi"),
+      mem_headroom_mib: Keyword.get(opts, :mem_headroom_mib, 8_000),
+      mem_budget_mib: Keyword.get(opts, :mem_budget_mib, 8_192),
+      live_vms: 0,
+      max_live_vms: 4,
+      workloads: %{"wl-a" => %{base_state: :BASE_BUILD_STATE_READY, snapshot_ref: "snap-a"}},
+      stateful_vms: [],
+      stateful_bundles: Keyword.get(opts, :stateful_bundles, []),
+      volumes: Keyword.get(opts, :volumes, []),
+      store_reachable: false
+    })
+  end
+
+  test "a relight dials the bundle-OWNING co-located instance's instance_id, not the node name" do
+    {:ok, dialed} = Agent.start_link(fn -> [] end)
+
+    relit_fun = fn _ch, _req ->
+      {:ok, %StartStatefulResponse{vm_id: "vm-relit", ip: "10.88.0.5", port: 5432, generation: 3, was_relight: true}}
+    end
+
+    capture_channel = fn key ->
+      Agent.update(dialed, &[key | &1])
+      {:ok, :ch}
+    end
+
+    ctx = start_stack(start_stateful_fun: relit_fun, channel_fun: capture_channel)
+    stateful_workload(ctx, "wl-a")
+
+    # Two co-located bricks on node-4. pod-b banked the bundle on disk; pod-a is a
+    # too-small 2Gi brick. A node-name dial could hit either; instance selection
+    # must pin the relight to pod-b (the owner).
+    put_brick(ctx, "node-4", "pod-a",
+      size_class: "2gi",
+      mem_headroom_mib: 100,
+      mem_budget_mib: 2_048,
+      volumes: [%{workload: "wl-a", node_id: "node-4", generation: 3, size_bytes: 100, allocated_bytes: 10}]
+    )
+
+    put_brick(ctx, "node-4", "pod-b",
+      stateful_bundles: [%{snapshot_ref: "stateful/stf-banked", workload: "wl-a", generation: 3, size_bytes: 10, created_at_unix_ms: 1}],
+      volumes: [%{workload: "wl-a", node_id: "node-4", generation: 3, size_bytes: 100, allocated_bytes: 10}]
+    )
+
+    seed_banked_with_pair(ctx, "stf-banked", "node-4", 3, 3)
+
+    assert {:ok, %{ip: "10.88.0.5", port: 5432}} = StatefulManager.wake(ctx.mgr, "wl-a", "p")
+    assert Agent.get(dialed, & &1) == ["node-4/pod-b"]
+  end
+
+  test "a cold wake dials a mem-eligible co-located instance and skips a too-small classed brick" do
+    {:ok, dialed} = Agent.start_link(fn -> [] end)
+
+    cold_fun = fn _ch, _req ->
+      {:ok, %StartStatefulResponse{vm_id: "vm-cold", ip: "10.88.0.5", port: 5432, generation: 1, was_relight: false}}
+    end
+
+    capture_channel = fn key ->
+      Agent.update(dialed, &[key | &1])
+      {:ok, :ch}
+    end
+
+    # A large workload (4000 MiB) so the 2Gi brick is ineligible.
+    ctx = start_stack(start_stateful_fun: cold_fun, channel_fun: capture_channel)
+    stateful_workload(ctx, "wl-a", %{resources: %{vcpus: 2, mem_mib: 4_000}})
+
+    put_brick(ctx, "node-4", "pod-small", size_class: "2gi", mem_headroom_mib: 100, mem_budget_mib: 2_048)
+    put_brick(ctx, "node-4", "pod-big", size_class: "8gi", mem_headroom_mib: 8_000, mem_budget_mib: 8_192)
+
+    # Fresh first boot (no volume): a cold wake places on a mem-eligible instance.
+    assert {:ok, %{ip: "10.88.0.5", port: 5432}} = StatefulManager.wake(ctx.mgr, "wl-a", "p")
+    assert Agent.get(dialed, & &1) == ["node-4/pod-big"]
+  end
+
+  test "a cold wake with no eligible instance fails cleanly rather than dialing a too-small brick" do
+    {:ok, dialed} = Agent.start_link(fn -> [] end)
+
+    capture_channel = fn key ->
+      Agent.update(dialed, &[key | &1])
+      {:ok, :ch}
+    end
+
+    ctx = start_stack(channel_fun: capture_channel)
+    stateful_workload(ctx, "wl-a", %{resources: %{vcpus: 2, mem_mib: 4_000}})
+
+    # The node's only instance is a too-small 2Gi classed brick.
+    put_brick(ctx, "node-4", "pod-small", size_class: "2gi", mem_headroom_mib: 100, mem_budget_mib: 2_048)
+
+    assert {:error, {:wake_failed, :no_eligible_instance}} = StatefulManager.wake(ctx.mgr, "wl-a", "p")
+    # No dial happened: the wake failed at selection, never sending a StartStateful.
+    assert Agent.get(dialed, & &1) == []
+    assert Agent.get(ctx.starts, & &1) == 0
   end
 end

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -1282,6 +1282,12 @@ defmodule Embervm.StatefulManagerTest do
   # Put ONE per-instance capacity fact (keyed by {node, pod_uid}) for a co-located
   # brick, carrying the fields WakeInstance.select reads.
   defp put_brick(ctx, node_id, pod_uid, opts) do
+    # free_slots (BrickLedger.to_brick) = max(max_live_vms - live_vms, 0), and a cold
+    # pick requires free_slots > 0 (a full instance cannot take a new VM). Default to a
+    # free slot (max_live_vms 4, live_vms 0) so a brick this fixture expects the cold
+    # path to select is not filtered out on SLOTS - a too-small brick must be excluded
+    # on MEM, not because the fixture forgot to give it a slot. Overridable to model a
+    # genuinely full instance.
     NodeCapacity.put(ctx.cap_table, {node_id, pod_uid}, %{
       node_id: node_id,
       configured_id: node_id,
@@ -1291,13 +1297,13 @@ defmodule Embervm.StatefulManagerTest do
       size_class: Keyword.get(opts, :size_class, "8gi"),
       mem_headroom_mib: Keyword.get(opts, :mem_headroom_mib, 8_000),
       mem_budget_mib: Keyword.get(opts, :mem_budget_mib, 8_192),
-      live_vms: 0,
-      max_live_vms: 4,
+      live_vms: Keyword.get(opts, :live_vms, 0),
+      max_live_vms: Keyword.get(opts, :max_live_vms, 4),
       workloads: %{"wl-a" => %{base_state: :BASE_BUILD_STATE_READY, snapshot_ref: "snap-a"}},
       stateful_vms: [],
       stateful_bundles: Keyword.get(opts, :stateful_bundles, []),
       volumes: Keyword.get(opts, :volumes, []),
-      store_reachable: false
+      store_reachable: Keyword.get(opts, :store_reachable, false)
     })
   end
 

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -1361,6 +1361,63 @@ defmodule Embervm.StatefulManagerTest do
     assert Agent.get(dialed, & &1) == ["node-4/pod-big"]
   end
 
+  test "restore-on-miss dials the RESTORE and the BOOT on the SAME selected instance_id (not the node name)" do
+    # Regression for the co-location restore bug: PR-2.5 makes banked bundles
+    # per-instance ON DISK, so the RestoreArtifact RPC must land the bundle on the
+    # SAME instance the subsequent relight dials. A node-name dial would resolve the
+    # restore to an arbitrary co-located instance (channel alias), stranding the boot
+    # on an instance whose disk never got the bundle.
+    {:ok, restore_channels} = Agent.start_link(fn -> [] end)
+    {:ok, boot_channels} = Agent.start_link(fn -> [] end)
+
+    # A channel tagged with the exact key it was dialled on, so both the restore and
+    # the boot record which instance_id they targeted.
+    capture_channel = fn key -> {:ok, {:ch, key}} end
+
+    restore_fun = fn {:ch, key}, _req ->
+      Agent.update(restore_channels, &[key | &1])
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{bytes_moved: 4096, skipped: false, generation: 3}}
+    end
+
+    relit_fun = fn {:ch, key}, _req ->
+      Agent.update(boot_channels, &[key | &1])
+      {:ok, %StartStatefulResponse{vm_id: "vm-relit", ip: "10.88.0.5", port: 5432, generation: 3, was_relight: true}}
+    end
+
+    ctx = start_stack(start_stateful_fun: relit_fun, channel_fun: capture_channel, restore_artifact_fun: restore_fun)
+    stateful_workload(ctx, "wl-a", %{resources: %{vcpus: 2, mem_mib: 4_000}})
+
+    # Two co-located bricks; NEITHER reports the bundle locally (a true local miss),
+    # the store is reachable, and pod-small is too small for the 4000 MiB workload.
+    # The relight's restore + boot must BOTH land on pod-big.
+    put_brick(ctx, "node-4", "pod-small",
+      size_class: "2gi",
+      mem_headroom_mib: 100,
+      mem_budget_mib: 2_048,
+      stateful_bundles: [],
+      volumes: [%{workload: "wl-a", node_id: "node-4", generation: 3, size_bytes: 100, allocated_bytes: 10, exported_generation: 3}],
+      store_reachable: true
+    )
+
+    put_brick(ctx, "node-4", "pod-big",
+      size_class: "8gi",
+      mem_headroom_mib: 8_000,
+      mem_budget_mib: 8_192,
+      stateful_bundles: [],
+      volumes: [%{workload: "wl-a", node_id: "node-4", generation: 3, size_bytes: 100, allocated_bytes: 10, exported_generation: 3}],
+      store_reachable: true
+    )
+
+    seed_banked_with_pair(ctx, "stf-banked", "node-4", 3, 3)
+
+    assert {:ok, %{ip: "10.88.0.5", port: 5432}} = StatefulManager.wake(ctx.mgr, "wl-a", "p")
+
+    # The restore and the boot both dialled the SAME mem-eligible instance_id, never
+    # the collapsing "node-4" node-name alias and never the too-small "node-4/pod-small".
+    assert Agent.get(restore_channels, & &1) == ["node-4/pod-big"]
+    assert Agent.get(boot_channels, & &1) == ["node-4/pod-big"]
+  end
+
   test "a cold wake with no eligible instance fails cleanly rather than dialing a too-small brick" do
     {:ok, dialed} = Agent.start_link(fn -> [] end)
 

--- a/projects/embervm/control/test/embervm/wake_instance_test.exs
+++ b/projects/embervm/control/test/embervm/wake_instance_test.exs
@@ -1,0 +1,230 @@
+defmodule Embervm.WakeInstanceTest do
+  @moduledoc """
+  Exercises Embervm.WakeInstance (brick co-location foundation, Step 4): selecting
+  the SPECIFIC instance on a resolved anchor node a wake must dial, so a co-located
+  brick set no longer collapses to the last node-name registrant.
+
+  Covers the spec's four cases: a relight prefers the bundle-OWNING instance; a cold
+  wake picks a mem-eligible instance and skips a too-small classed brick; the DS
+  wildcard (empty class / zero budget) is always eligible; no eligible instance ->
+  a clean :no_eligible_instance failure (never a bad dial). Plus the inert
+  single-instance case that keeps the current fleet output-equivalent.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.{NodeCapacity, WakeInstance}
+
+  setup do
+    table = :"wi_cap_#{System.unique_integer([:positive])}"
+    NodeCapacity.create(table)
+    %{table: table}
+  end
+
+  # A per-instance capacity fact. Defaults model a real classed brick with headroom
+  # and a free slot; override per case (size_class "" / mem_budget_mib 0 => wildcard).
+  defp put_instance(table, node_id, pod_uid, opts) do
+    instance_id = "#{node_id}/#{pod_uid}"
+
+    facts =
+      %{
+        node_id: node_id,
+        configured_id: node_id,
+        pod_uid: pod_uid,
+        instance_id: instance_id,
+        size_class: Keyword.get(opts, :size_class, "8gi"),
+        mem_headroom_mib: Keyword.get(opts, :mem_headroom_mib, 8_000),
+        mem_budget_mib: Keyword.get(opts, :mem_budget_mib, 8_192),
+        live_vms: Keyword.get(opts, :live_vms, 0),
+        max_live_vms: Keyword.get(opts, :max_live_vms, 4),
+        stateful_bundles: Keyword.get(opts, :stateful_bundles, []),
+        serving_snapshots: Keyword.get(opts, :serving_snapshots, []),
+        group_bundle_sets: Keyword.get(opts, :group_bundle_sets, []),
+        updated_at: Keyword.get(opts, :updated_at, 0)
+      }
+
+    NodeCapacity.put(table, {node_id, pod_uid}, facts)
+    instance_id
+  end
+
+  describe "warmth ownership (a relight lands on the bundle-owning instance)" do
+    test "prefers the instance whose stateful_bundles report the snapshot_ref", %{table: table} do
+      # Two co-located bricks on node-4; only pod-b banked the bundle on disk.
+      _a = put_instance(table, "node-4", "pod-a", stateful_bundles: [])
+
+      owner =
+        put_instance(table, "node-4", "pod-b",
+          stateful_bundles: [%{snapshot_ref: "stateful/wl-a", workload: "wl-a", generation: 3}]
+        )
+
+      assert {:ok, ^owner} =
+               WakeInstance.select("node-4",
+                 table: table,
+                 workload: "wl-a",
+                 need_mib: 2_000,
+                 warmth_key: :stateful_bundles,
+                 warmth_ref: "stateful/wl-a"
+               )
+    end
+
+    test "a group set owner is matched by group_instance_id", %{table: table} do
+      _a = put_instance(table, "node-4", "pod-a", group_bundle_sets: [])
+
+      owner =
+        put_instance(table, "node-4", "pod-b",
+          group_bundle_sets: [%{group_instance_id: "grp-1", set_id: "set-xyz", members: [%{member_name: "db"}]}]
+        )
+
+      assert {:ok, ^owner} =
+               WakeInstance.select("node-4",
+                 table: table,
+                 workload: "gwl",
+                 need_mib: 1_000,
+                 warmth_key: :group_bundle_sets,
+                 warmth_match_field: :group_instance_id,
+                 warmth_ref: "grp-1"
+               )
+    end
+
+    test "the owner is chosen even if it is mem-too-small (a relight must land on its disk)", %{table: table} do
+      # The owner is a 2Gi brick with only 100 MiB headroom; the need is 4000. Warmth
+      # ownership wins regardless: the bundle is only on this instance's disk.
+      owner =
+        put_instance(table, "node-4", "pod-small",
+          size_class: "2gi",
+          mem_headroom_mib: 100,
+          mem_budget_mib: 2_048,
+          stateful_bundles: [%{snapshot_ref: "stateful/wl-a"}]
+        )
+
+      _big = put_instance(table, "node-4", "pod-big", size_class: "16gi", mem_headroom_mib: 16_000, mem_budget_mib: 16_384)
+
+      assert {:ok, ^owner} =
+               WakeInstance.select("node-4",
+                 table: table,
+                 workload: "wl-a",
+                 need_mib: 4_000,
+                 warmth_key: :stateful_bundles,
+                 warmth_ref: "stateful/wl-a"
+               )
+    end
+  end
+
+  describe "cold pick (mem-eligible, skips too-small classed bricks)" do
+    test "picks a mem-eligible instance and never a too-small classed brick", %{table: table} do
+      # A 2Gi brick (100 MiB headroom) and an 8Gi brick (8000 MiB). The 2Gi is too
+      # small for a 4000 MiB need; selection must land on the 8Gi one, for every
+      # workload key (so it is never the 2Gi brick by hash chance).
+      small = put_instance(table, "node-4", "pod-small", size_class: "2gi", mem_headroom_mib: 100, mem_budget_mib: 2_048)
+      big = put_instance(table, "node-4", "pod-big", size_class: "8gi", mem_headroom_mib: 8_000, mem_budget_mib: 8_192)
+
+      for wl <- ~w(wl-a wl-b wl-c wl-d wl-e) do
+        assert {:ok, picked} =
+                 WakeInstance.select("node-4", table: table, workload: wl, need_mib: 4_000, warmth_key: :stateful_bundles)
+
+        assert picked == big
+        refute picked == small
+      end
+    end
+
+    test "no warmth_ref given falls straight through to the cold pick", %{table: table} do
+      big = put_instance(table, "node-4", "pod-big", size_class: "8gi", mem_headroom_mib: 8_000, mem_budget_mib: 8_192)
+
+      # warmth_key present but no warmth_ref => nothing to prefer => cold pick.
+      assert {:ok, ^big} =
+               WakeInstance.select("node-4", table: table, workload: "wl-a", need_mib: 1_000, warmth_key: :stateful_bundles)
+    end
+  end
+
+  describe "DS wildcard is always mem-eligible" do
+    test "an empty-size-class instance is eligible even with zero headroom", %{table: table} do
+      wildcard =
+        put_instance(table, "node-4", "ds", size_class: "", mem_headroom_mib: 0, mem_budget_mib: 0, max_live_vms: 10)
+
+      assert {:ok, ^wildcard} =
+               WakeInstance.select("node-4", table: table, workload: "wl-a", need_mib: 4_000)
+    end
+
+    test "a zero-budget (no cgroup limit) instance is eligible even with a non-empty class", %{table: table} do
+      # Non-empty class but mem_budget_mib 0 (no cgroup limit): treated as the big
+      # burst envelope, always mem-eligible.
+      wildcard = put_instance(table, "node-4", "burst", size_class: "8gi", mem_headroom_mib: 0, mem_budget_mib: 0)
+
+      assert {:ok, ^wildcard} =
+               WakeInstance.select("node-4", table: table, workload: "wl-a", need_mib: 4_000)
+    end
+  end
+
+  describe "no eligible instance -> clean failure (never a bad dial)" do
+    test "a node whose only instance is a too-small classed brick fails cleanly", %{table: table} do
+      _small = put_instance(table, "node-4", "pod-small", size_class: "2gi", mem_headroom_mib: 100, mem_budget_mib: 2_048)
+
+      assert {:error, :no_eligible_instance} =
+               WakeInstance.select("node-4", table: table, workload: "wl-a", need_mib: 4_000)
+    end
+
+    test "a node with no free slots fails cleanly", %{table: table} do
+      _full = put_instance(table, "node-4", "pod-full", mem_headroom_mib: 8_000, live_vms: 4, max_live_vms: 4)
+
+      assert {:error, :no_eligible_instance} =
+               WakeInstance.select("node-4", table: table, workload: "wl-a", need_mib: 1_000)
+    end
+
+    test "a node not in the table fails cleanly", %{table: table} do
+      assert {:error, :no_eligible_instance} =
+               WakeInstance.select("ghost-node", table: table, workload: "wl-a", need_mib: 1_000)
+    end
+  end
+
+  describe "inert on the single-instance-per-node fleet" do
+    test "the node's sole instance is returned and dialed by its instance_id", %{table: table} do
+      only = put_instance(table, "node-4", "pod-only", size_class: "", mem_headroom_mib: 0, mem_budget_mib: 0, max_live_vms: 4)
+
+      # Cold pick and warmth pick both resolve to the same sole instance.
+      assert {:ok, ^only} = WakeInstance.select("node-4", table: table, workload: "wl-a", need_mib: 512)
+
+      only_with_bundle =
+        put_instance(table, "node-4", "pod-only",
+          size_class: "",
+          mem_headroom_mib: 0,
+          mem_budget_mib: 0,
+          max_live_vms: 4,
+          stateful_bundles: [%{snapshot_ref: "stateful/wl-a"}]
+        )
+
+      assert {:ok, ^only_with_bundle} =
+               WakeInstance.select("node-4",
+                 table: table,
+                 workload: "wl-a",
+                 need_mib: 512,
+                 warmth_key: :stateful_bundles,
+                 warmth_ref: "stateful/wl-a"
+               )
+    end
+
+    test "a fact without an instance_id falls back to the node name (legacy/dual-key)", %{table: table} do
+      # Mirror a statically-seeded / pre-field fact: no :instance_id, keyed by node.
+      NodeCapacity.put(table, "node-4", %{
+        node_id: "node-4",
+        configured_id: "node-4",
+        size_class: "",
+        mem_headroom_mib: 0,
+        mem_budget_mib: 0,
+        live_vms: 0,
+        max_live_vms: 4,
+        stateful_bundles: [%{snapshot_ref: "stateful/wl-a"}]
+      })
+
+      assert {:ok, "node-4"} =
+               WakeInstance.select("node-4", table: table, workload: "wl-a", need_mib: 512)
+
+      assert {:ok, "node-4"} =
+               WakeInstance.select("node-4",
+                 table: table,
+                 workload: "wl-a",
+                 need_mib: 512,
+                 warmth_key: :stateful_bundles,
+                 warmth_ref: "stateful/wl-a"
+               )
+    end
+  end
+end


### PR DESCRIPTION
## What

Step 4 of the EmberVM brick co-location foundation: stateful/serving/group **wakes** now select a specific, eligible **instance** on the anchored node and dial it by `instance_id`, instead of dialing by node name (which collapses co-located instances to one arbitrary registrant).

**No chart bump** — this is inert/output-equivalent on the current single-instance-per-node fleet and deploys later at the re-canary.

## The bug

A wake resolved its target NODE, then dialled `channel_fun.(node_name)`. The dual-keyed `NodeChannel` resolves a node-name alias to ONE arbitrary instance (the last registrant), so under co-located bricks a postgres wake could land on a 2Gi brick too small to boot it.

## Change

New `Embervm.WakeInstance.select/2`: given the resolved node, pick the instance to dial and return its `instance_id`.

1. **Warmth owner** — the instance that BANKED this workload's bundle/snapshot/set on disk (per-instance-on-disk, PR-2.5), matched in the per-instance capacity facts (`stateful_bundles` / `serving_snapshots` / `group_bundle_sets`). A relight MUST land there or the bundle is not present.
2. **Cold pick** — else a mem-eligible instance on the node. **DS wildcard is always eligible**: an empty `size_class` OR zero `mem_budget_mib` (no cgroup limit, the big burst-envelope DS reporting `mem_headroom_mib = 0`) is never mem-gated; only a classed brick with a real budget is gated on `mem_headroom_mib >= need_mib`. `need_mib` is the workload's `mem_mib`; the pick is `BrickLedger.choose(list, workload)` (deterministic + sticky).
3. Else `{:error, :no_eligible_instance}` — fail the wake cleanly, never a bad dial.

Wired into all three wake dial paths (`stateful_manager`, `serving_manager`, `group_wake_manager` via `GroupManager.Supervisor` + a new `dial_id` on `GroupManager` distinct from the durable `node_id`). Dials by `instance_id`; invalidates by that same key on transport death. Durable `node_id` (records, adoption node lookups) unchanged.

## Why we don't reuse `BrickLedger.candidates/3`

`candidates/3` gates EVERY brick on `mem_headroom_mib >= need_mib` (correct for the dispatcher, where a co-located brick reports a real budget). On the still-DS-only fleet the wildcard reports `mem_headroom_mib = 0`, so `candidates/3` would wrongly exclude it. `WakeInstance` applies the wildcard-always-eligible rule itself.

## Fable follow-up (writable-attach lease on failed attach)

Purely noded-side and **already correct**: both the relight and cold-boot paths in `noded/server/stateful.go` install a `defer` that `Detach`es the volume on any failure after `Attach` (ownership then passes to `finishStatefulStart`'s detach-on-failure path). The CP wake never issues `Attach`, so there is no CP lease to leak — no CP change warranted.

## Tests

- `wake_instance_test.exs`: relight prefers the bundle-owning instance; owner wins even if mem-too-small; cold pick skips a too-small classed brick; the DS wildcard (empty class / zero budget) is always eligible; no eligible instance -> clean `:no_eligible_instance`; single-instance inert case (+ legacy fact without `instance_id` falls back to the node name).
- `stateful_manager_test.exs`: a relight dials the bundle-owning co-located `instance_id`; a cold wake dials a mem-eligible co-located instance and skips a too-small brick; no-eligible-instance fails cleanly with no dial and no StartStateful.

## Inert

With one instance per node, selection returns that node's only instance and dials its `instance_id`, which the dual-keyed channel resolves identically to the old node-name dial. Existing stateful/serving/group manager tests exercise the single-instance case and stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)