### PR TITLE
fix(ember): roadmap tail reflects distribution and spot elasticity

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.240
+version: 0.89.241
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.240
+      targetRevision: 0.89.241
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.314
+version: 0.285.315
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.314
+      targetRevision: 0.285.315
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -128,14 +128,14 @@
       desc: "Snapshots and built boot images are recorded to S3: sessions restore after preemption, and a new node pulls ready images instead of rebuilding them. Workloads outlive the machine they ran on.",
     },
     {
-      done: true,
-      name: "R7 agents",
-      desc: "AI agents as first-class consumers: each agent session gets its own microVM sandbox, banked between turns.",
+      done: false,
+      name: "R7 distribution",
+      desc: "Workloads stop belonging to one machine: a wake restores the snapshot onto whichever node has room, and capacity is pre-provisioned across the fleet ahead of demand. In progress.",
     },
     {
       done: false,
-      name: "R8 packaging",
-      desc: "Extract the orchestrator from this cluster and open-source it.",
+      name: "R8 elasticity",
+      desc: "Horizontal scale on cheap spot instances: the fleet grows and shrinks with demand, and preemption is routine rather than an outage, because every workload is a durable snapshot that wakes wherever there is room. Declare a workload in one resource; the orchestrator finds it a machine.",
     },
   ];
 </script>

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -186,8 +186,6 @@
         </span>
       </p>
       <p class="stats">
-        <span>four cluster nodes</span>
-        <span class="sep">·</span>
         <span><b>{bestWake} ms</b> best wake</span>
         <span class="sep">·</span>
         <span><b>~{vmRestore} ms</b> VM restore</span>
@@ -345,7 +343,7 @@
             >CONTROL PLANE · ELIXIR/OTP</text
           >
           <rect class="lane" x="420" y="18" width="286" height="264" rx="10" />
-          <text x="432" y="38" class="lane-label">EACH NODE (×4)</text>
+          <text x="432" y="38" class="lane-label">EACH FIRECRACKER NODE</text>
 
           <rect x="14" y="74" width="100" height="44" rx="8" class="box" />
           <text x="64" y="93" text-anchor="middle" class="node-label"


### PR DESCRIPTION
The public /ember roadmap's last two rungs were stale: it marked an "R7 agents" rung shipped and listed packaging as the end state. Per the current direction, agents become just another durable workload once distribution lands, and OSS packaging is already true (the chart helm-installs anywhere), so neither deserves a rung.

New tail, written as project capabilities:

- `[ ]` **R7 distribution** (in progress): wakes restore onto whichever node has room, capacity pre-provisioned across the fleet.
- `[ ]` **R8 elasticity**: horizontal scale on cheap spot instances; preemption routine because every workload is a durable snapshot.

Both monolith and monolith-public charts bumped (public tier checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)