### PR TITLE
feat(embervm): size/instance-aware NEW-placement (brick co-location Step 5)

### DIFF
--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -267,6 +267,16 @@ defmodule Embervm.BaseBuilder do
     # every zip build is held with a clear "runtime not configured" condition.
     runtime_images = Keyword.get(opts, :runtime_images, %{})
 
+    # Per-instance capacity facts (Step 5): placement reads each registered
+    # instance's mem_budget_mib / size_class / node_id from here so a base is built
+    # on an instance big enough to boot the guest, and the biggest-budget instance is
+    # preferred (the DS wildcard first, else the largest classed brick), instead of
+    # blindly pinning the first-registered instance. Defaults to the shared registry
+    # table; tests that assert pure placement leave it empty, and placement fails OPEN
+    # (treats a budget-unknown instance as eligible) so a builder with no capacity view
+    # still places, keeping its behaviour identical to the pre-Step-5 List.first pick.
+    capacity_table = Keyword.get(opts, :capacity_table, Embervm.NodeCapacity.table())
+
     node_ids = Enum.map(nodes, & &1.id)
 
     node_addr = for %{id: id, address: address} <- nodes, into: %{}, do: {id, address}
@@ -289,6 +299,7 @@ defmodule Embervm.BaseBuilder do
       disconnect_fun: disconnect_fun,
       evict_fun: evict_fun,
       runtime_images: runtime_images,
+      capacity_table: capacity_table,
       status_writer: status_writer,
       clock: clock,
       base_backoff_ms: base_backoff,
@@ -386,7 +397,7 @@ defmodule Embervm.BaseBuilder do
   # configured yet means we cannot build: record the intent and report it.
   defp reconcile_desc(state, %{name: name} = desc) do
     prev = Map.get(state.workloads, name)
-    node_id = placement(state, prev)
+    node_id = placement(state, prev, Map.get(desc, :mem_mib) || 0)
 
     w = merge_desc(prev, desc, node_id)
     state = put_in(state.workloads[name], w)
@@ -457,7 +468,7 @@ defmodule Embervm.BaseBuilder do
   # uses. A workload already placed or already built is left untouched.
   defp redrive_pending_workload(state, name) do
     w = Map.get(state.workloads, name)
-    node_id = placement(state, %{node_id: nil})
+    node_id = placement(state, %{node_id: nil}, (w && w.mem_mib) || 0)
 
     cond do
       w == nil or node_id == nil ->
@@ -538,11 +549,122 @@ defmodule Embervm.BaseBuilder do
     end
   end
 
-  # Placement: in R0 every Workload's base is built on the single configured
-  # node; a Workload keeps whichever node it was first placed on. Returns nil
-  # when no node is configured. Multi-node placement is Task 11's job.
-  defp placement(_state, %{node_id: node_id}) when is_binary(node_id), do: node_id
-  defp placement(state, _prev), do: List.first(state.node_ids)
+  # Placement (Step 5, brick co-location): pick the registered INSTANCE a workload's
+  # base builds on. `state.node_ids` are instance_ids (NodeRegistry registers each
+  # noded pod by its instance_id, node_registry.ex default_base_builder_update), so
+  # under co-located bricks a node holds several. The old `List.first(state.node_ids)`
+  # blindly pinned the first-registered instance, which Fable found live pinned ALL
+  # workloads to the one 2Gi brick, starving the DS/16Gi bricks of bases and wedging
+  # the fleet at :no_capacity.
+  #
+  # Instead: among the instances that can actually BUILD this workload (mem_budget_mib
+  # big enough to boot a `need_mib` guest, OR a wildcard/zero-budget instance that is
+  # always eligible), pick the one with the LARGEST budget (the DS wildcard ranks
+  # first as the full-node envelope, else the biggest classed brick) so a small brick
+  # never captures a base it cannot build. Bases are NODE-SHARED (baseDir =
+  # SnapshotRoot/bases, served by any co-located instance), so we only need ONE build
+  # per node; picking a single best instance yields exactly one (node, workload) build.
+  #
+  # STICKY (no thrash): a workload keeps its current pin as long as that instance is
+  # still registered AND still eligible AND no STRICTLY-larger eligible instance has
+  # since registered. It re-places only when its instance expired/deregistered, became
+  # ineligible, or a bigger eligible instance appeared. Determinism: ties (equal rank)
+  # break on instance_id, so the choice is stable run to run.
+  #
+  # Fail-OPEN when capacity is unknown: an instance with no capacity fact (a builder
+  # seeded before WatchNode populated facts, or a test with no table) is treated as an
+  # eligible wildcard, so placement still returns a node and is behaviour-identical to
+  # the pre-Step-5 pick on a fleet with no per-instance budgets reported.
+  defp placement(state, prev, need_mib) do
+    case eligible_build_instances(state, need_mib) do
+      [] ->
+        nil
+
+      instances ->
+        best = Enum.max_by(instances, &build_rank/1)
+        keep_or_replace(prev, instances, best)
+    end
+  end
+
+  # Keep the workload's current pin when it is still an eligible candidate and no
+  # strictly-larger one exists; otherwise move to the best. Comparing on build_rank
+  # (not identity) means an equal-rank newcomer never steals a healthy pin.
+  defp keep_or_replace(%{node_id: node_id}, instances, best) when is_binary(node_id) do
+    case Enum.find(instances, fn i -> i.instance_id == node_id end) do
+      nil -> best.instance_id
+      current -> if build_rank(best) > build_rank(current), do: best.instance_id, else: node_id
+    end
+  end
+
+  defp keep_or_replace(_prev, _instances, best), do: best.instance_id
+
+  # The registered instances that can BUILD `need_mib`, each as a compact map
+  # (instance_id + the fields the rank/eligibility read). An instance with no capacity
+  # fact is a fail-open wildcard (budget/class unknown => always eligible). Node-shared
+  # bases mean we keep at most one instance per node_id (the highest-ranked), so the
+  # best pick is naturally one build per node.
+  defp eligible_build_instances(state, need_mib) do
+    state.node_ids
+    |> Enum.map(fn iid -> instance_build_facts(state, iid) end)
+    |> Enum.filter(fn i -> build_eligible?(i, need_mib) end)
+    |> dedupe_per_node()
+  end
+
+  # Compact build-facts for a registered instance_id: its reported size_class /
+  # mem_budget_mib / node_id, or wildcard defaults (size_class "", budget 0) when no
+  # capacity fact is found (fail-open). node_id falls back to the instance_id itself so
+  # dedupe_per_node still groups sanely for a fact-less id.
+  defp instance_build_facts(state, instance_id) do
+    case find_capacity_fact(state.capacity_table, instance_id) do
+      {:ok, f} ->
+        %{
+          instance_id: instance_id,
+          node_id: Map.get(f, :node_id) || instance_id,
+          size_class: Map.get(f, :size_class, ""),
+          mem_budget_mib: Map.get(f, :mem_budget_mib, 0)
+        }
+
+      :error ->
+        %{instance_id: instance_id, node_id: instance_id, size_class: "", mem_budget_mib: 0}
+    end
+  end
+
+  # Look up the capacity fact whose derived instance_id matches (the registry stamps
+  # :instance_id = "node/pod_uid" into each fact). Returns :error when the table is
+  # absent/empty or no fact carries that instance_id, which makes placement fail-open.
+  defp find_capacity_fact(table, instance_id) do
+    table
+    |> Embervm.NodeCapacity.all()
+    |> Enum.find(fn f -> Map.get(f, :instance_id) == instance_id end)
+    |> case do
+      nil -> :error
+      f -> {:ok, f}
+    end
+  end
+
+  # An instance can build the workload when it is a wildcard (empty class or zero
+  # budget: the full-node envelope, always able to boot) or its budget covers need.
+  defp build_eligible?(i, need_mib) do
+    Embervm.Placement.wildcard?(i) or i.mem_budget_mib >= need_mib
+  end
+
+  # Rank for "largest-budget eligible": the DS wildcard ranks above every classed
+  # brick (rank tuple {1, budget}); classed bricks rank by budget ({0, budget}). Higher
+  # is better; max_by picks the biggest. (A zero-budget wildcard still beats a classed
+  # brick because its first tuple element is 1.)
+  defp build_rank(i) do
+    if Embervm.Placement.wildcard?(i), do: {1, i.mem_budget_mib}, else: {0, i.mem_budget_mib}
+  end
+
+  # Bases are node-shared, so at most one instance per node_id needs to build: keep the
+  # highest-ranked instance per node (ties break on instance_id for determinism).
+  defp dedupe_per_node(instances) do
+    instances
+    |> Enum.group_by(& &1.node_id)
+    |> Enum.map(fn {_node, group} ->
+      Enum.max_by(group, fn i -> {build_rank(i), i.instance_id} end)
+    end)
+  end
 
   # Fold a fresh desc into the workload's build state, preserving the built base
   # (built_signature/snapshot_ref/digest/superseded) across spec edits so a

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -410,7 +410,7 @@ defmodule Embervm.Dispatcher do
         bump_denial(state, :cap)
 
       true ->
-        case pick_node(state, wl) do
+        case pick_node(state, wl, entry) do
           {:error, kind} ->
             bump_denial(state, kind)
 
@@ -518,9 +518,10 @@ defmodule Embervm.Dispatcher do
   #     wedged, and we must not trust an old fact);
   #   * otherwise -> :no_capacity (no base for wl anywhere, or every candidate is
   #     at its node live-VM cap so a miss cannot prime).
-  defp pick_node(state, wl) do
+  defp pick_node(state, wl, entry) do
     now = state.clock.()
     facts = NodeCapacity.all(state.capacity_table)
+    need_mib = Map.get(entry, :mem_mib) || 0
 
     # Nodes that carry a base for this workload at all (fresh or not), used to
     # distinguish "stale" from "no base anywhere".
@@ -554,13 +555,30 @@ defmodule Embervm.Dispatcher do
         # pod flips to draining, so we accept a rare, self-healing chance of picking
         # a pod about to drain rather than keep node-keyed grouping (wrong under
         # bricks).
+        #
+        # SIZE-AWARE MISS TIER (Step 5): the WARM tier is left unchanged (a brick
+        # that already holds a primed VM for wl is by construction big enough to run
+        # it, and we must not refuse a warm hit). The MISS tier, which places a BRAND-
+        # NEW VM, is additionally gated on `Embervm.Placement.mem_eligible?/2` so a
+        # miss never primes onto a brick too small to boot the workload: a wildcard/
+        # zero-budget DS is always eligible (inert on the DS-only fleet), a classed
+        # brick needs `mem_headroom_mib >= mem_mib`. No eligible brick -> the existing
+        # :no_capacity path (never a too-small placement).
         warm_candidates =
           Enum.filter(candidates, fn f -> inventory_ready?(state, instance_id_of(f), wl) end)
 
         case BrickLedger.choose(warm_candidates, wl) do
           nil ->
-            # No warm VM anywhere: a miss needs node budget to prime one.
-            case BrickLedger.choose(Enum.filter(candidates, &has_budget?/1), wl) do
+            # No warm VM anywhere: a miss needs a brick that both has node budget to
+            # prime (has_budget?, the free-slot check) AND is mem-eligible for the
+            # workload's mem_mib (the size gate). We filter the raw facts (not brick
+            # maps) so the chosen fact still carries its `workloads` for snapshot_ref_of.
+            miss_candidates =
+              Enum.filter(candidates, fn f ->
+                has_budget?(f) and Embervm.Placement.mem_eligible?(f, need_mib)
+              end)
+
+            case BrickLedger.choose(miss_candidates, wl) do
               nil -> {:error, :no_capacity}
               f -> {:ok, instance_id_of(f), :miss, snapshot_ref_of(f, wl)}
             end

--- a/projects/embervm/control/lib/embervm/placement.ex
+++ b/projects/embervm/control/lib/embervm/placement.ex
@@ -1,0 +1,101 @@
+defmodule Embervm.Placement do
+  @moduledoc """
+  The one shared brick-eligibility predicate every NEW-placement path reasons
+  about (brick co-location foundation, Step 5). Before this module the memory
+  gate lived in three shapes that could drift: `Embervm.WakeInstance` had the
+  correct DS-wildcard-always-eligible rule (Step 4), `Embervm.BrickLedger.candidates/3`
+  had a subtly WRONG one (it gates EVERY brick on headroom, so a zero-budget
+  wildcard is excluded), and the task dispatcher had NO memory gate at all (it
+  used `choose/2` only as a tie-break, so a miss could land on a brick too small
+  to boot the workload). This module is the single source of truth those NEW-
+  placement paths now share.
+
+  ## the eligibility rule
+
+  A brick is eligible to take a NEW placement of a workload needing `need_mib`
+  MiB iff it has a free live-VM slot AND it is mem-eligible:
+
+    * a WILDCARD brick (`size_class == ""`, the legacy DaemonSet, OR
+      `mem_budget_mib == 0`, a brick under no cgroup limit reporting a zero
+      budget: the big burst envelope) is ALWAYS mem-eligible, regardless of the
+      headroom it reports (a zero-budget wildcard reports `mem_headroom_mib = 0`
+      but can still boot the guest);
+    * a CLASSED brick with a real budget is mem-eligible only when its
+      `mem_headroom_mib >= need_mib`.
+
+  This is exactly the rule `Embervm.WakeInstance` encoded for the WAKE dial;
+  extracting it here lets the dispatcher miss tier and the session/serving CREATE
+  paths reuse the identical predicate instead of each re-deriving it (and
+  drifting, as `candidates/3` did).
+
+  ## why NOT `BrickLedger.candidates/3`
+
+  `candidates/3` gates every brick on `mem_headroom_mib >= need_mib` (correct for
+  a fleet of only classed bricks, where a wildcard reports a real budget), which
+  wrongly excludes a zero-headroom wildcard. On the still-DS-only fleet the single
+  DS instance IS a zero-budget wildcard, so gating it on headroom would deny every
+  placement. Keeping the wildcard always-eligible is what makes this change INERT
+  today: the sole DS brick per node is a wildcard, so it is always the (only)
+  eligible candidate and every path is output-equivalent to its pre-Step-5 form.
+
+  ## pure functions over brick maps
+
+  Every function here is pure over the normalized brick maps
+  `Embervm.BrickLedger.bricks/1` produces (or a raw capacity fact, which carries
+  the same `size_class` / `mem_headroom_mib` / `mem_budget_mib` fields). No
+  process, no ETS handle of its own: callers pass the already-read brick list, so
+  this module never drifts from the capacity view its caller dispatched against.
+  """
+
+  alias Embervm.BrickLedger
+
+  @typedoc "A brick or capacity-fact map carrying at least the fields the rule reads."
+  @type brick :: map()
+
+  @doc """
+  Whether `brick` can take a NEW placement of a workload needing `need_mib` MiB:
+  it has a free live-VM slot AND is `mem_eligible?/2`. This is the gate the
+  dispatcher miss tier, the session/serving create pick, and the wake cold pick
+  all apply so nothing lands on a brick too small to boot the guest.
+  """
+  @spec eligible?(brick(), non_neg_integer()) :: boolean()
+  def eligible?(brick, need_mib) do
+    Map.get(brick, :free_slots, 0) > 0 and mem_eligible?(brick, need_mib)
+  end
+
+  @doc """
+  The MEMORY half of eligibility (no slot check): a wildcard brick is always
+  mem-eligible; a classed brick with a real budget needs `mem_headroom_mib >=
+  need_mib`. Split out so a caller that has already applied its own slot check
+  (the dispatcher's `has_budget?`) can reuse just the memory rule.
+  """
+  @spec mem_eligible?(brick(), non_neg_integer()) :: boolean()
+  def mem_eligible?(brick, need_mib) do
+    wildcard?(brick) or Map.get(brick, :mem_headroom_mib, 0) >= need_mib
+  end
+
+  @doc """
+  Whether `brick` is the always-mem-eligible WILDCARD: an empty size-class (the
+  legacy DaemonSet) OR a zero/absent memory budget (no cgroup limit, the big
+  burst envelope). A wildcard satisfies any `need_mib`.
+  """
+  @spec wildcard?(brick()) :: boolean()
+  def wildcard?(brick) do
+    Map.get(brick, :size_class, "") == "" or Map.get(brick, :mem_budget_mib, 0) == 0
+  end
+
+  @doc """
+  Filter `bricks` to those `eligible?/2` for `need_mib`, then deterministically
+  pick one keyed by `key` (`BrickLedger.choose/2`: sorted by `instance_id`,
+  hashed on the key, so the same key sticks and distinct keys spread across the
+  eligible bricks). Returns the chosen brick map or `nil` when none is eligible.
+  The NEW-placement primitive the wake cold pick and the session create pick
+  share.
+  """
+  @spec pick([brick()], term(), non_neg_integer()) :: brick() | nil
+  def pick(bricks, key, need_mib) do
+    bricks
+    |> Enum.filter(&eligible?(&1, need_mib))
+    |> BrickLedger.choose(key)
+  end
+end

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -378,7 +378,18 @@ defmodule Embervm.SessionManager do
              :ok <- check_workload_cap(state, workload, entry),
              :ok <- check_quota(state, principal),
              {:ok, node_id, snapshot_ref} <- pick_node(state, workload),
-             {:ok, vm_id} <- claim_or_prime(state, node_id, workload, snapshot_ref) do
+             {:ok, dial_id} <- dial_instance(state, workload, entry, node_id),
+             {:ok, vm_id} <- claim_or_prime(state, dial_id, workload, snapshot_ref) do
+          # SIZE-AWARE CREATE (Step 5): pick_node resolves the NODE (rendezvous over
+          # ready nodes with budget); dial_instance then selects the mem-eligible
+          # INSTANCE on it (a too-small classed brick is skipped, the DS wildcard is
+          # always eligible) so claim/prime lands the VM on a brick big enough to boot
+          # the workload. The session ROW still records the NODE name (node_id), not
+          # dial_id: relight/drain read it node-scoped via NodeCapacity.fetch (which
+          # matches on :node_id), and a node-local snapshot is restorable on its owning
+          # node regardless of which co-located instance banked it. On the single-
+          # instance fleet dial_id resolves to the node's sole instance, so claim/prime
+          # is output-equivalent to the old node-name dial: inert today.
           register_and_start(state, workload, principal, entry, node_id, vm_id)
         else
           {:error, reason} ->
@@ -451,6 +462,23 @@ defmodule Embervm.SessionManager do
   # node + its base snapshot_ref (for Prime on a claim miss).
   defp pick_node(state, workload) do
     SessionPlacement.node_for_create(workload, state.capacity_table)
+  end
+
+  # Select the SPECIFIC instance on the resolved node to dial for claim/prime
+  # (Step 5, mirroring ServingManager.dial_instance): a mem-eligible instance sized
+  # for the workload's mem_mib, so a NEW session VM never primes onto a brick too
+  # small to boot it (a too-small classed brick is skipped; the DS wildcard is
+  # always eligible). No `:warmth_key` is passed because a fresh session has nothing
+  # banked to prefer, so WakeInstance.select goes straight to the mem-eligible cold
+  # pick and returns the dial key (instance_id, or the node name for a legacy fact).
+  # No eligible instance -> {:error, :no_eligible_instance}, which the create `with`
+  # turns into a denial rather than a too-small placement.
+  defp dial_instance(state, workload, entry, node_id) do
+    Embervm.WakeInstance.select(node_id,
+      table: state.capacity_table,
+      workload: workload,
+      need_mib: Map.get(entry, :mem_mib) || 512
+    )
   end
 
   # Claim a primed VM from the dispatcher's inventory, or Prime one on a miss (the

--- a/projects/embervm/control/lib/embervm/wake_instance.ex
+++ b/projects/embervm/control/lib/embervm/wake_instance.ex
@@ -122,36 +122,24 @@ defmodule Embervm.WakeInstance do
   end
 
   # A mem-eligible cold candidate on the node, then a deterministic sticky pick
-  # keyed by the workload. Eligibility folds the DS-wildcard-always-eligible rule
-  # (below) over the node's bricks: a wildcard/zero-budget instance is never mem-
-  # gated (it is the big burst-envelope DS reporting `mem_headroom_mib = 0` under no
-  # cgroup limit), while a CLASSED brick with a real budget must clear
-  # `mem_headroom_mib >= need_mib`. `BrickLedger.candidates/3` gates EVERY brick on
-  # headroom (correct for the dispatcher, where a wildcard reports a real budget),
-  # so the wake path applies the rule itself rather than reusing that filter, which
-  # would wrongly exclude a zero-headroom wildcard.
+  # keyed by the workload. Eligibility is the SHARED `Embervm.Placement.eligible?/2`
+  # predicate (the one source of truth every NEW-placement path uses, Step 5): a
+  # free slot AND either the DS wildcard/zero-budget brick (always mem-eligible, the
+  # big burst envelope reporting `mem_headroom_mib = 0` under no cgroup limit) or a
+  # CLASSED brick with `mem_headroom_mib >= need_mib`. We scope the node's bricks
+  # first, then delegate the filter+`choose` to `Placement.pick/3` so the wake and
+  # dispatcher/session miss tiers can never drift on the memory gate.
+  # `BrickLedger.candidates/3` is deliberately NOT used: it gates EVERY brick on
+  # headroom, wrongly excluding a zero-headroom wildcard on the still-DS-only fleet.
   defp cold_instance(table, node_id, workload, need_mib) do
     table
     |> BrickLedger.bricks()
-    |> Enum.filter(fn brick -> brick.node_id == node_id and wake_eligible?(brick, need_mib) end)
-    |> BrickLedger.choose(workload)
+    |> Enum.filter(fn brick -> brick.node_id == node_id end)
+    |> Embervm.Placement.pick(workload, need_mib)
     |> case do
       nil -> {:error, :no_eligible_instance}
       brick -> {:ok, dial_id_from_brick(brick)}
     end
-  end
-
-  # A brick can serve a cold wake when it has a free live-VM slot AND either it is
-  # the wildcard/zero-budget DS (always mem-eligible) or it is a classed brick with
-  # the headroom for the workload's need.
-  defp wake_eligible?(brick, need_mib) do
-    brick.free_slots > 0 and (wildcard?(brick) or brick.mem_headroom_mib >= need_mib)
-  end
-
-  # The always-mem-eligible DS: an empty size-class (the legacy wildcard) OR a
-  # zero/absent memory budget (no cgroup limit, the big burst envelope).
-  defp wildcard?(brick) do
-    brick.size_class == "" or brick.mem_budget_mib == 0
   end
 
   # Every per-instance capacity fact on `node_id` (co-located bricks + the DS

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -21,6 +21,7 @@ defmodule Embervm.BaseBuilderTest do
   use ExUnit.Case, async: false
 
   alias Embervm.BaseBuilder
+  alias Embervm.NodeCapacity
   alias Embervm.Node.V1.BuildBaseResponse
 
   @node %{id: "node-4", address: "node-4:9090"}
@@ -710,5 +711,142 @@ defmodule Embervm.BaseBuilderTest do
       st = BaseBuilder.status(builder)
       st.workloads["w"].node_id == nil and not Map.has_key?(st.nodes, "node-4")
     end)
+  end
+
+  # -- size-aware placement (Step 5, brick co-location) -----------------------
+
+  # An isolated capacity table with per-instance brick facts.
+  defp new_cap_table do
+    table = :"bb_cap_#{System.unique_integer([:positive])}"
+    NodeCapacity.create(table)
+    table
+  end
+
+  defp put_brick(table, node_id, pod_uid, opts) do
+    NodeCapacity.put(table, {node_id, pod_uid}, %{
+      node_id: node_id,
+      configured_id: node_id,
+      instance_id: "#{node_id}/#{pod_uid}",
+      size_class: Keyword.get(opts, :size_class, "8gi"),
+      mem_budget_mib: Keyword.get(opts, :mem_budget, 8_192),
+      mem_headroom_mib: Keyword.get(opts, :mem_headroom, 8_000),
+      live_vms: 0,
+      max_live_vms: 8,
+      updated_at: 0
+    })
+  end
+
+  test "placement picks the LARGEST-budget eligible instance, never List.first" do
+    # Three co-located bricks on node-4; the first-registered is the 2Gi one (the
+    # old List.first bug pinned everything to it). The base must land on the 16Gi
+    # brick (largest budget) for a 4Gi-need workload.
+    table = new_cap_table()
+    put_brick(table, "node-4", "small", size_class: "2gi", mem_budget: 2_048, mem_headroom: 100)
+    put_brick(table, "node-4", "mid", size_class: "8gi", mem_budget: 8_192, mem_headroom: 8_000)
+    put_brick(table, "node-4", "big", size_class: "16gi", mem_budget: 16_384, mem_headroom: 16_000)
+
+    agent = start_recorder()
+    build_fun = fn :fake_channel, _req -> {:ok, resp("snap-big")} end
+
+    builder =
+      start_builder(
+        # node_ids ARE instance_ids in production; registration order puts small first.
+        nodes: [
+          %{id: "node-4/small", address: "a"},
+          %{id: "node-4/mid", address: "a"},
+          %{id: "node-4/big", address: "a"}
+        ],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+
+    assert_eventually(fn ->
+      match?(%{"snapshotRef" => "snap-big"}, latest(agent, "w"))
+    end)
+
+    st = BaseBuilder.status(builder)
+    assert st.workloads["w"].node_id == "node-4/big"
+  end
+
+  test "placement never captures a base on a too-small instance" do
+    # A 2Gi brick and an 8Gi brick; a 4Gi-need workload must NOT land on the 2Gi one.
+    table = new_cap_table()
+    put_brick(table, "node-4", "small", size_class: "2gi", mem_budget: 2_048, mem_headroom: 100)
+    put_brick(table, "node-4", "ok", size_class: "8gi", mem_budget: 8_192, mem_headroom: 8_000)
+
+    agent = start_recorder()
+    build_fun = fn :fake_channel, _req -> {:ok, resp("snap-ok")} end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/small", address: "a"}, %{id: "node-4/ok", address: "a"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap-ok"}, latest(agent, "w")) end)
+    assert BaseBuilder.status(builder).workloads["w"].node_id == "node-4/ok"
+  end
+
+  test "placement re-places a workload when a LARGER eligible instance registers" do
+    # Start with only an 8Gi brick; the base pins there. A 16Gi brick then registers,
+    # and a reconcile re-places the workload onto it (a bigger eligible instance).
+    table = new_cap_table()
+    put_brick(table, "node-4", "mid", size_class: "8gi", mem_budget: 8_192, mem_headroom: 8_000)
+
+    agent = start_recorder()
+    build_fun = fn :fake_channel, _req -> {:ok, resp("snap1")} end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/mid", address: "a"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].node_id == "node-4/mid" end)
+
+    # A larger brick appears on the node and registers.
+    put_brick(table, "node-4", "big", size_class: "16gi", mem_budget: 16_384, mem_headroom: 16_000)
+    :ok = BaseBuilder.add_node(builder, "node-4/big", "a")
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].node_id == "node-4/big" end)
+  end
+
+  test "placement re-places when its chosen instance deregisters" do
+    table = new_cap_table()
+    put_brick(table, "node-4", "big", size_class: "16gi", mem_budget: 16_384, mem_headroom: 16_000)
+    put_brick(table, "node-4", "mid", size_class: "8gi", mem_budget: 8_192, mem_headroom: 8_000)
+
+    agent = start_recorder()
+    build_fun = fn :fake_channel, _req -> {:ok, resp("snap1")} end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/big", address: "a"}, %{id: "node-4/mid", address: "a"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].node_id == "node-4/big" end)
+
+    # The chosen instance vanishes: remove_node unpins it (node_id -> nil), and a
+    # re-add/reconcile re-places onto the remaining eligible 8Gi brick.
+    :ok = BaseBuilder.remove_node(builder, "node-4/big")
+    NodeCapacity.drop(table, {"node-4", "big"})
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].node_id == "node-4/mid" end)
   end
 end

--- a/projects/embervm/control/test/embervm/dispatcher_test.exs
+++ b/projects/embervm/control/test/embervm/dispatcher_test.exs
@@ -41,7 +41,7 @@ defmodule Embervm.DispatcherTest do
         catalog_table: cat_table,
         depth_table: depth_table,
         clock: fn -> 1_000_000 end,
-        channel_fun: fn _node -> {:ok, :ch} end,
+        channel_fun: Keyword.get(opts, :channel_fun, fn _node -> {:ok, :ch} end),
         assign_fun: Keyword.get(opts, :assign_fun, fn _ch, _req -> {:ok, success_resp()} end),
         prime_fun: Keyword.get(opts, :prime_fun, fn _ch, _req -> {:ok, %PrimeResponse{vm_id: "vm-#{System.unique_integer([:positive])}"}} end),
         start_sweep: false
@@ -80,7 +80,12 @@ defmodule Embervm.DispatcherTest do
           primed_vm_ids: Keyword.get(opts, :primed_ids, [])
         }
       },
-      mem_headroom_mib: 4096,
+      # Default: no size_class / zero mem_budget => a WILDCARD brick (always
+      # mem-eligible), which keeps every pre-Step-5 test inert. A size-aware test
+      # overrides size_class + mem_budget + mem_headroom to model a classed brick.
+      size_class: Keyword.get(opts, :size_class, ""),
+      mem_headroom_mib: Keyword.get(opts, :mem_headroom, 4096),
+      mem_budget_mib: Keyword.get(opts, :mem_budget, 0),
       cpu_headroom_millicores: 4000,
       live_vms: Keyword.get(opts, :live, 0),
       max_live_vms: Keyword.get(opts, :max, 8),
@@ -95,6 +100,7 @@ defmodule Embervm.DispatcherTest do
       namespace: "embervm",
       cap: Keyword.get(opts, :cap, 10),
       floor: Keyword.get(opts, :floor, 0),
+      mem_mib: Keyword.get(opts, :mem_mib, 0),
       invoke_path: "/",
       timeout_ms: 5_000,
       result_ttl_ms: 60_000,
@@ -289,6 +295,76 @@ defmodule Embervm.DispatcherTest do
     stats = Dispatcher.stats(ctx.name)
     assert stats.misses >= 1
     assert stats.warm_hits == 0
+  end
+
+  # -- size-aware miss placement (Step 5) ------------------------------------
+
+  test "a miss with a too-small co-located brick + a big brick primes on the big one" do
+    parent = self()
+
+    # The channel_fun records which INSTANCE the miss worker dialed, so we can assert
+    # the miss never landed on the too-small 2Gi brick (pick_node passes the chosen
+    # instance_id as ctx.node_id, which the worker dials via channel_fun).
+    ctx =
+      start_stack(
+        stale_after_ms: 60_000,
+        prime_fun: fn _ch, _req -> {:ok, %PrimeResponse{vm_id: "vm-big"}} end,
+        channel_fun: fn node ->
+          send(parent, {:dialed, node})
+          {:ok, :ch}
+        end
+      )
+
+    # A 4Gi-need workload; a 2Gi brick (100 MiB headroom) cannot boot it, an 8Gi brick can.
+    put_catalog(ctx, "wl-a", cap: 10, mem_mib: 4_000)
+
+    put_facts(ctx, "wl-a",
+      key: {"node-4", "small"},
+      instance_id: "node-4/small",
+      size_class: "2gi",
+      mem_budget: 2_048,
+      mem_headroom: 100,
+      free: 0,
+      live: 0,
+      max: 8
+    )
+
+    put_facts(ctx, "wl-a",
+      key: {"node-4", "big"},
+      instance_id: "node-4/big",
+      size_class: "8gi",
+      mem_budget: 8_192,
+      mem_headroom: 8_000,
+      free: 0,
+      live: 0,
+      max: 8
+    )
+
+    tid = submit(ctx, "wl-a", "p1")
+    assert eventually(fn -> state_of(ctx, tid) == :succeeded end)
+    assert_receive {:dialed, "node-4/big"}, 2_000
+    refute_received {:dialed, "node-4/small"}
+  end
+
+  test "a miss where the ONLY brick is too small denies :no_capacity (never a bad placement)" do
+    ctx = start_stack(stale_after_ms: 60_000)
+    put_catalog(ctx, "wl-a", cap: 10, mem_mib: 4_000)
+
+    put_facts(ctx, "wl-a",
+      key: {"node-4", "small"},
+      instance_id: "node-4/small",
+      size_class: "2gi",
+      mem_budget: 2_048,
+      mem_headroom: 100,
+      free: 0,
+      live: 0,
+      max: 8
+    )
+
+    tid = submit(ctx, "wl-a", "p1")
+    # Never dispatched: stays queued, denial is :no_capacity (not a too-small prime).
+    assert eventually(fn -> Dispatcher.stats(ctx.name).denials.no_capacity >= 1 end)
+    assert state_of(ctx, tid) == :queued
   end
 
   # -- fail-closed -----------------------------------------------------------

--- a/projects/embervm/control/test/embervm/placement_test.exs
+++ b/projects/embervm/control/test/embervm/placement_test.exs
@@ -1,0 +1,96 @@
+defmodule Embervm.PlacementTest do
+  @moduledoc """
+  Exercises Embervm.Placement (brick co-location foundation, Step 5): the ONE shared
+  eligibility predicate + deterministic pick every NEW-placement path (dispatcher
+  miss tier, session/serving create, the wake cold pick) reuses so the memory gate
+  can never drift.
+
+  Covers the DS-wildcard-always-eligible rule (empty class OR zero budget), the
+  headroom gate for a classed brick, the free-slot gate, and that `pick/3` skips a
+  too-small brick and spreads deterministically over the eligible ones.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.Placement
+
+  defp brick(opts) do
+    %{
+      instance_id: Keyword.get(opts, :instance_id, "node/pod"),
+      node_id: Keyword.get(opts, :node_id, "node"),
+      size_class: Keyword.get(opts, :size_class, "8gi"),
+      mem_headroom_mib: Keyword.get(opts, :mem_headroom_mib, 8_000),
+      mem_budget_mib: Keyword.get(opts, :mem_budget_mib, 8_192),
+      free_slots: Keyword.get(opts, :free_slots, 4)
+    }
+  end
+
+  describe "wildcard?/1" do
+    test "empty size_class is a wildcard" do
+      assert Placement.wildcard?(brick(size_class: "", mem_budget_mib: 8_192))
+    end
+
+    test "zero mem_budget_mib is a wildcard even with a non-empty class" do
+      assert Placement.wildcard?(brick(size_class: "8gi", mem_budget_mib: 0))
+    end
+
+    test "a classed brick with a real budget is not a wildcard" do
+      refute Placement.wildcard?(brick(size_class: "8gi", mem_budget_mib: 8_192))
+    end
+  end
+
+  describe "mem_eligible?/2" do
+    test "a wildcard is eligible for any need, even at zero headroom" do
+      assert Placement.mem_eligible?(brick(size_class: "", mem_headroom_mib: 0, mem_budget_mib: 0), 4_000)
+    end
+
+    test "a classed brick needs headroom >= need" do
+      assert Placement.mem_eligible?(brick(mem_headroom_mib: 8_000), 4_000)
+      refute Placement.mem_eligible?(brick(mem_headroom_mib: 100), 4_000)
+    end
+  end
+
+  describe "eligible?/2 (folds in the free-slot gate)" do
+    test "a mem-eligible brick with a free slot is eligible" do
+      assert Placement.eligible?(brick(mem_headroom_mib: 8_000, free_slots: 1), 4_000)
+    end
+
+    test "a mem-eligible brick with no free slot is NOT eligible" do
+      refute Placement.eligible?(brick(mem_headroom_mib: 8_000, free_slots: 0), 4_000)
+    end
+
+    test "a wildcard with no free slot is NOT eligible (slots still gate)" do
+      refute Placement.eligible?(brick(size_class: "", mem_budget_mib: 0, free_slots: 0), 4_000)
+    end
+  end
+
+  describe "pick/3" do
+    test "skips a too-small classed brick and lands on the big one for every key" do
+      small = brick(instance_id: "n/small", size_class: "2gi", mem_headroom_mib: 100, mem_budget_mib: 2_048)
+      big = brick(instance_id: "n/big", size_class: "8gi", mem_headroom_mib: 8_000, mem_budget_mib: 8_192)
+
+      for key <- ~w(a b c d e f) do
+        picked = Placement.pick([small, big], key, 4_000)
+        assert picked.instance_id == "n/big"
+      end
+    end
+
+    test "the wildcard DS is always a candidate" do
+      ds = brick(instance_id: "n/ds", size_class: "", mem_headroom_mib: 0, mem_budget_mib: 0)
+      assert Placement.pick([ds], "k", 16_000).instance_id == "n/ds"
+    end
+
+    test "no eligible brick yields nil" do
+      small = brick(size_class: "2gi", mem_headroom_mib: 100, mem_budget_mib: 2_048)
+      assert Placement.pick([small], "k", 4_000) == nil
+    end
+
+    test "distinct keys spread across two eligible bricks" do
+      a = brick(instance_id: "n/a", mem_headroom_mib: 8_000, mem_budget_mib: 8_192)
+      b = brick(instance_id: "n/b", mem_headroom_mib: 8_000, mem_budget_mib: 8_192)
+
+      picked = for k <- ~w(k1 k2 k3 k4 k5 k6 k7 k8), do: Placement.pick([a, b], k, 1_000).instance_id
+      # Both bricks are hit at least once across the key space (deterministic spread).
+      assert "n/a" in picked and "n/b" in picked
+    end
+  end
+end

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -128,7 +128,79 @@ defmodule Embervm.SessionManagerTest do
     })
   end
 
+  # A per-INSTANCE capacity fact on a node (Step 5 size-aware create). Two co-located
+  # bricks share configured_id "node-4" so node_for_create resolves the node, then
+  # dial_instance selects the mem-eligible one among them.
+  defp put_brick(ctx, wl, pod_uid, opts) do
+    NodeCapacity.put(ctx.cap_table, {"node-4", pod_uid}, %{
+      node_id: "node-4",
+      configured_id: "node-4",
+      instance_id: "node-4/#{pod_uid}",
+      size_class: Keyword.get(opts, :size_class, "8gi"),
+      mem_headroom_mib: Keyword.get(opts, :mem_headroom, 8_000),
+      mem_budget_mib: Keyword.get(opts, :mem_budget, 8_192),
+      workloads: %{
+        wl => %{
+          free_primed_slots: 1,
+          snapshot_ref: "snap-#{wl}",
+          base_state: :BASE_BUILD_STATE_READY,
+          primed_vm_ids: []
+        }
+      },
+      live_vms: 0,
+      max_live_vms: 8,
+      draining: false,
+      updated_at: 5_000_000
+    })
+  end
+
   # -- create ----------------------------------------------------------------
+
+  test "size-aware create: a too-small co-located brick + a big brick claims on the big one" do
+    parent = self()
+
+    ctx =
+      start_stack(
+        claim_fun: fn _d, dial_id, _w ->
+          send(parent, {:claimed, dial_id})
+          {:ok, "vm-big"}
+        end
+      )
+
+    # A 4Gi-need session workload; the 2Gi brick cannot boot it, the 8Gi can.
+    WorkloadCatalog.upsert(ctx.cat_table, "wl-a", %{
+      name: "wl-a",
+      namespace: "embervm",
+      class: "session",
+      image_ref: "img@sha256:abc",
+      invoke_path: "/",
+      timeout_ms: 90_000,
+      cap: 8,
+      floor: 1,
+      mem_mib: 4_000,
+      session: %{
+        idle_bank_seconds: 300,
+        max_lifetime_seconds: 3600,
+        banked_ttl_seconds: 3600,
+        max_sessions: 16,
+        invoke_queue_cap: 4
+      }
+    })
+
+    put_brick(ctx, "wl-a", "small", size_class: "2gi", mem_headroom: 100, mem_budget: 2_048)
+    put_brick(ctx, "wl-a", "big", size_class: "8gi", mem_headroom: 8_000, mem_budget: 8_192)
+
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-a", "p1")
+    assert String.starts_with?(created.session_id, "s-")
+    # The claim (and hence the VM) dialed the big instance, never the too-small one.
+    assert_receive {:claimed, "node-4/big"}
+    refute_received {:claimed, "node-4/small"}
+
+    # The session ROW records the NODE name (node-4) so relight/drain read it
+    # node-scoped, not the dial instance_id.
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.node_id == "node-4"
+  end
 
   test "create happy path: claims a primed VM, mints a token, starts a live session" do
     ctx = start_stack()


### PR DESCRIPTION
Step 5 (final foundation code step) of the EmberVM brick co-location plan: make every NEW-placement path size/instance-aware so nothing lands on an instance too small to boot the workload, and one instance cannot capture the whole fleet's base builds.

**No chart bump: inert / output-equivalent on the current single-instance-per-node fleet** (the sole DS brick per node is a wildcard, so it is always the only eligible candidate and every path is byte-identical to today). Deploys later at the re-canary.

## What changed

- **`Embervm.Placement` (new)**: the ONE shared eligibility predicate (`eligible?/2` = free slot AND `mem_eligible?/2`; wildcard-or-headroom>=need) plus `pick/3` (filter + deterministic `BrickLedger.choose`). Extracted from Step 4's `WakeInstance` rule so the dispatcher miss tier, session create, and the wake cold pick share one gate and cannot drift. Deliberately not `BrickLedger.candidates/3`, which gates every brick on headroom and so wrongly excludes a zero-budget wildcard (the still-DS-only fleet's single instance).
- **`WakeInstance`**: cold pick delegates its filter+choose to `Placement.pick/3`; behaviour identical.
- **`Dispatcher.pick_node`**: the **MISS** tier now gates candidates on `Placement.mem_eligible?` for the workload's `mem_mib` (threaded from the catalog `entry`). The **WARM** tier is left unchanged (a brick already holding a primed VM fits by construction). No eligible brick -> the existing `:no_capacity` path, never a too-small placement.
- **`SessionManager` create**: a new `dial_instance` selects the mem-eligible instance on the resolved node for claim/prime (mirroring `ServingManager`, whose cold create path Step 4 already made size-aware). The session ROW still records the NODE name so relight/drain reads stay node-scoped.
- **`BaseBuilder.placement`**: replaces `List.first(node_ids)` with a class-eligible, largest-budget, per-node pick over per-instance capacity facts (DS wildcard ranks first, else biggest brick), sticky with re-placement when its chosen instance deregisters or a larger eligible one registers. Fixes the live bug where all workloads pinned to the one 2Gi brick, starving DS/16Gi bricks of bases and wedging the fleet at `:no_capacity`. Fails open when capacity is unknown, so a fact-less builder places exactly as before.

## Tests
- `placement_test`: predicate (wildcard / headroom / free-slot) + `pick/3` (skips too-small, wildcard always eligible, spread, empty -> nil).
- `dispatcher_test`: a miss with a too-small + a big co-located brick primes on the big one; only-too-small denies `:no_capacity`.
- `session_manager_test`: size-aware create claims on the big brick, never the too-small one; the row stores the node name.
- `base_builder_test`: largest-budget pick (not `List.first`), never too-small, re-place on larger-registers and on chosen-deregisters.

No local Elixir toolchain; ExUnit runs in CI. Reverted unrelated gazelle BUILD drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)