### PR TITLE
feat(embervm): re-canary 2gi brick + deploy co-location foundation (Step 6)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.168
+version: 0.1.169

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.168
+      targetRevision: 0.1.169
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -104,8 +104,18 @@ noded:
 # un-pins and re-places every workload on the DS (flat warmth root, no SUN_LEN),
 # and bases rebuild. Re-canary at plan Step 6 once Steps 1-5 land. No chart bump
 # ($values git ref).
+# Size-class BRICK re-canary, step 1 (foundation plan Step 6, small-first). The
+# co-location foundation is now in place: SUN_LEN-safe short warmth root, real
+# cgroup memory facts, dual-key instance addressing, instance-aware wakes, and
+# size-aware placement + class-eligible base builds. This flip re-enables the
+# FIRST co-located brick (2gi beside the DS) on node-4, exercising all of the
+# above together. Deep-merged over the chart classes ladder. desiredReplicas
+# lists ONLY 2gi (others render at 0). The 16gi large brick follows in a second
+# flip after this small brick verifies against the decision-log checklist.
 bricks:
-  enabled: false
+  enabled: true
+  desiredReplicas:
+    2gi: 1
 
 # EmberVM R4 scale-to-zero scratch-postgres (ADR embervm/001, D-R4.PR-11.1):
 # enabled with the k8s-homelab 1Password item whose POSTGRES_PASSWORD field syncs


### PR DESCRIPTION
Foundation plan Step 6 (small-first re-canary). One chart bump (0.1.168->0.1.169) deploys the inert foundation code (SUN_LEN, cgroup mem facts, dual-key addressing, instance-aware wakes, size-aware placement) AND enables the first co-located 2gi brick beside the DS on node-4.

Renders: 2gi=1, 4/8/16gi=0; `EMBERVM_NODED_SIZE_CLASS=2gi` (1 CPU / 2Gi); CP `EMBERVM_BRICK_CLASSES` carries the class.

Post-merge checklist (decision-log 3b): brick dial-homes with size_class=2gi, reports nonzero mem_budget/headroom, base builds land only on eligible instances, dispatch spreads via BrickLedger, per-instance warmth uses the short SUN_LEN-safe form with no cross-clobber, a deliberate demo-postgres wake hits the right instance, no spurious :fleet_full. Then the 16gi large brick follows. 3c (DS prune) stays gated.

Reverts by bricks.enabled=false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)