### PR TITLE
feat(embervm): base-readiness gate on cold wake placement

### DIFF
--- a/projects/embervm/control/lib/embervm/brick_ledger.ex
+++ b/projects/embervm/control/lib/embervm/brick_ledger.ex
@@ -59,7 +59,8 @@ defmodule Embervm.BrickLedger do
           mem_budget_mib: non_neg_integer(),
           live_vms: non_neg_integer(),
           max_live_vms: non_neg_integer(),
-          free_slots: non_neg_integer()
+          free_slots: non_neg_integer(),
+          workloads: %{optional(term()) => map()}
         }
 
   @doc """
@@ -169,7 +170,13 @@ defmodule Embervm.BrickLedger do
       mem_budget_mib: Map.get(facts, :mem_budget_mib, 0),
       live_vms: live,
       max_live_vms: max_live,
-      free_slots: max(max_live - live, 0)
+      free_slots: max(max_live - live, 0),
+      # The per-workload capacity submap (`%{workload => %{base_state:, snapshot_ref:,
+      # ...}}`), carried through unchanged so `Embervm.Placement.base_ready?/2` can read
+      # `workloads[workload].base_state` off a normalized brick. Absent on a fact that
+      # predates the field -> `%{}`, which reads as base-not-ready (fail-closed: a brick
+      # that never advertised a base is not a cold-placement target).
+      workloads: Map.get(facts, :workloads) || %{}
     }
   end
 end

--- a/projects/embervm/control/lib/embervm/placement.ex
+++ b/projects/embervm/control/lib/embervm/placement.ex
@@ -85,6 +85,45 @@ defmodule Embervm.Placement do
   end
 
   @doc """
+  Whether `brick` has ADVERTISED `workload`'s base as READY: its
+  `workloads[workload].base_state` is the daemon's `BASE_BUILD_STATE_READY`. This
+  is the co-location READINESS half of a NEW COLD placement, distinct from the
+  memory/slot gate: a freshly-rolled or scaled-up instance is dispatchable and
+  mem-eligible the instant it registers, but until its noded re-provisions the
+  runtime image and advertises the base it CANNOT resolve `boot_image_ref` (the
+  live `noded: boot_image_ref required` failure a fresh 16Gi brick hit on a
+  demo-postgres cold boot). An instance adopts its node-shared bases from disk
+  READY internally but only projects `base_state = READY` after `imageProvisioned`
+  syncs, so this predicate is false in exactly the post-roll/post-scale-up window
+  and true once the instance can actually boot the guest.
+
+  Absent workload entry, or any non-READY `base_state`, is false. The daemon
+  reports `base_state` as the proto enum, projected by the registry as the
+  protobuf-elixir atom `:BASE_BUILD_STATE_READY`; the integer form `3` is accepted
+  defensively, matching the tolerant check the dispatcher and session/serving
+  placement already use so the four NEW-placement paths cannot drift on the
+  readiness representation.
+
+  This gates only the COLD / fresh-placement pick, NEVER the warmth/relight-owner
+  path: a relight targets the specific instance that BANKED the bundle on disk,
+  which by construction already holds (and advertises) that workload's base.
+  """
+  @spec base_ready?(brick(), term()) :: boolean()
+  def base_ready?(brick, workload) do
+    case Map.get(Map.get(brick, :workloads) || %{}, workload) do
+      %{base_state: base_state} -> base_state_ready?(base_state)
+      _ -> false
+    end
+  end
+
+  # The daemon reports base_state as the proto enum. Accept the protobuf-elixir
+  # atom form and the integer form (3) defensively, identical to the tolerant
+  # checks in Dispatcher/SessionPlacement/ServingPlacement.
+  defp base_state_ready?(:BASE_BUILD_STATE_READY), do: true
+  defp base_state_ready?(3), do: true
+  defp base_state_ready?(_), do: false
+
+  @doc """
   Filter `bricks` to those `eligible?/2` for `need_mib`, then deterministically
   pick one keyed by `key` (`BrickLedger.choose/2`: sorted by `instance_id`,
   hashed on the key, so the same key sticks and distinct keys spread across the
@@ -97,5 +136,31 @@ defmodule Embervm.Placement do
     bricks
     |> Enum.filter(&eligible?(&1, need_mib))
     |> BrickLedger.choose(key)
+  end
+
+  @doc """
+  The COLD NEW-placement primitive: filter `bricks` to those `eligible?/2` for
+  `need_mib` AND `base_ready?/2` for `workload` (`workload` is also the sticky
+  `key`), then deterministically pick one via `BrickLedger.choose/2`. Returns the
+  chosen brick or `nil` when no brick is BOTH eligible and base-ready.
+
+  This is the wake cold pick's primitive. It adds the co-location READINESS gate on
+  top of `pick/3`'s slot+memory gate so a fresh stateful/serving/task/group wake
+  never dials a dispatchable, mem-eligible instance that has not yet advertised the
+  workload's base and so would hard-fail `noded: boot_image_ref required`. When no
+  brick qualifies, the caller returns its existing retryable no-eligible outcome
+  (the activators keep retrying), so the wake WAITS for a fresh instance to finish
+  provisioning and advertise the base instead of hard-failing on the first miss.
+
+  Kept distinct from `pick/3` (which stays a pure slot+memory gate) so a caller that
+  legitimately needs only the memory gate is unaffected; the warmth/relight-owner
+  path in `Embervm.WakeInstance` also stays on the owner scan (the banked instance
+  already holds the base) and never routes through here.
+  """
+  @spec pick_ready([brick()], term(), non_neg_integer()) :: brick() | nil
+  def pick_ready(bricks, workload, need_mib) do
+    bricks
+    |> Enum.filter(fn brick -> eligible?(brick, need_mib) and base_ready?(brick, workload) end)
+    |> BrickLedger.choose(workload)
   end
 end

--- a/projects/embervm/control/lib/embervm/wake_instance.ex
+++ b/projects/embervm/control/lib/embervm/wake_instance.ex
@@ -121,21 +121,39 @@ defmodule Embervm.WakeInstance do
     end
   end
 
-  # A mem-eligible cold candidate on the node, then a deterministic sticky pick
-  # keyed by the workload. Eligibility is the SHARED `Embervm.Placement.eligible?/2`
-  # predicate (the one source of truth every NEW-placement path uses, Step 5): a
-  # free slot AND either the DS wildcard/zero-budget brick (always mem-eligible, the
-  # big burst envelope reporting `mem_headroom_mib = 0` under no cgroup limit) or a
-  # CLASSED brick with `mem_headroom_mib >= need_mib`. We scope the node's bricks
-  # first, then delegate the filter+`choose` to `Placement.pick/3` so the wake and
-  # dispatcher/session miss tiers can never drift on the memory gate.
-  # `BrickLedger.candidates/3` is deliberately NOT used: it gates EVERY brick on
-  # headroom, wrongly excluding a zero-headroom wildcard on the still-DS-only fleet.
+  # A mem-eligible AND base-READY cold candidate on the node, then a deterministic
+  # sticky pick keyed by the workload. The gate is the SHARED
+  # `Embervm.Placement.pick_ready/3` predicate (the one source of truth every NEW-
+  # COLD-placement path uses): a free slot, mem-eligibility (the DS wildcard/zero-
+  # budget brick is always mem-eligible, the big burst envelope reporting
+  # `mem_headroom_mib = 0` under no cgroup limit; a CLASSED brick needs
+  # `mem_headroom_mib >= need_mib`), AND `workloads[workload].base_state ==
+  # BASE_BUILD_STATE_READY` so the instance has ADVERTISED the workload's base.
+  #
+  # The base-readiness gate closes the live co-location gap: a freshly-rolled or
+  # scaled-up instance is dispatchable and mem-eligible the instant it registers, but
+  # until its noded re-provisions the runtime image and advertises the base it cannot
+  # resolve `boot_image_ref` and a cold boot hard-fails `noded: boot_image_ref
+  # required` (a fresh 16Gi brick picked for a demo-postgres cold boot did exactly
+  # this). Requiring `base_ready?` here means the cold pick skips the not-yet-ready
+  # instance; if no instance is BOTH eligible and base-ready the `nil` becomes the
+  # existing RETRYABLE `{:error, :no_eligible_instance}` (the activator keeps the
+  # workload published and the client's reconnect re-enters the wake), so the wake
+  # WAITS for a fresh instance to finish provisioning instead of dialling one that
+  # cannot boot. On a STABLE fleet every instance long ago advertised its bases, so
+  # this only changes behaviour in the post-roll/post-scale-up window (the gap).
+  #
+  # We scope the node's bricks first, then delegate the filter+`choose` to
+  # `Placement.pick_ready/3` so the wake and dispatcher/session/serving paths can
+  # never drift on the readiness gate. `BrickLedger.candidates/3` is deliberately NOT
+  # used: it gates EVERY brick on headroom, wrongly excluding a zero-headroom wildcard
+  # on the still-DS-only fleet. This is the COLD path only; the warmth/relight-owner
+  # branch of `select/2` is unchanged (the banked instance already holds the base).
   defp cold_instance(table, node_id, workload, need_mib) do
     table
     |> BrickLedger.bricks()
     |> Enum.filter(fn brick -> brick.node_id == node_id end)
-    |> Embervm.Placement.pick(workload, need_mib)
+    |> Embervm.Placement.pick_ready(workload, need_mib)
     |> case do
       nil -> {:error, :no_eligible_instance}
       brick -> {:ok, dial_id_from_brick(brick)}

--- a/projects/embervm/control/test/embervm/group_wake_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_wake_manager_test.exs
@@ -214,7 +214,14 @@ defmodule Embervm.GroupWakeManagerTest do
       live_vms: 0,
       group_networks: [],
       group_member_vms: [],
-      group_bundle_sets: []
+      group_bundle_sets: [],
+      # The node advertises the group workload's base as READY (the node-shared
+      # base is persistent; a restore-on-miss loses only the per-instance banked
+      # bundle SET, not the base), so the cold-pick base-readiness gate
+      # (Embervm.Placement.base_ready?/2) is satisfied and instance selection can
+      # proceed to the restore/boot. A test wanting a not-yet-advertised instance
+      # would override :workloads with an empty/absent grp-a entry.
+      workloads: %{"grp-a" => %{base_state: :BASE_BUILD_STATE_READY, snapshot_ref: "snap/grp-a"}}
     }
 
     NodeCapacity.put(ctx.cap_table, "node-4", Map.merge(base, facts))

--- a/projects/embervm/control/test/embervm/placement_test.exs
+++ b/projects/embervm/control/test/embervm/placement_test.exs
@@ -133,7 +133,7 @@ defmodule Embervm.PlacementTest do
       ready =
         brick(instance_id: "n/ready", mem_headroom_mib: 16_000, mem_budget_mib: 16_384, workloads: advertising("wl"))
 
-      for key <- ~w(a b c d e f) do
+      for _key <- ~w(a b c d e f) do
         assert Placement.pick_ready([not_ready, ready], "wl", 4_000).instance_id == "n/ready"
       end
     end

--- a/projects/embervm/control/test/embervm/placement_test.exs
+++ b/projects/embervm/control/test/embervm/placement_test.exs
@@ -20,9 +20,16 @@ defmodule Embervm.PlacementTest do
       size_class: Keyword.get(opts, :size_class, "8gi"),
       mem_headroom_mib: Keyword.get(opts, :mem_headroom_mib, 8_000),
       mem_budget_mib: Keyword.get(opts, :mem_budget_mib, 8_192),
-      free_slots: Keyword.get(opts, :free_slots, 4)
+      free_slots: Keyword.get(opts, :free_slots, 4),
+      workloads: Keyword.get(opts, :workloads, %{})
     }
   end
+
+  # A workloads submap advertising `wl` at the given base_state (default the READY
+  # atom the registry projects). `:absent` omits the workload entry entirely.
+  defp advertising(wl, base_state \\ :BASE_BUILD_STATE_READY)
+  defp advertising(_wl, :absent), do: %{}
+  defp advertising(wl, base_state), do: %{wl => %{base_state: base_state, snapshot_ref: "snap"}}
 
   describe "wildcard?/1" do
     test "empty size_class is a wildcard" do
@@ -91,6 +98,75 @@ defmodule Embervm.PlacementTest do
       picked = for k <- ~w(k1 k2 k3 k4 k5 k6 k7 k8), do: Placement.pick([a, b], k, 1_000).instance_id
       # Both bricks are hit at least once across the key space (deterministic spread).
       assert "n/a" in picked and "n/b" in picked
+    end
+  end
+
+  describe "base_ready?/2" do
+    test "true when the workload's base_state is the READY atom" do
+      assert Placement.base_ready?(brick(workloads: advertising("wl")), "wl")
+    end
+
+    test "true for the defensive integer READY form (3)" do
+      assert Placement.base_ready?(brick(workloads: advertising("wl", 3)), "wl")
+    end
+
+    test "false when the workload entry is absent (fresh, not yet advertised)" do
+      refute Placement.base_ready?(brick(workloads: advertising("wl", :absent)), "wl")
+    end
+
+    test "false when base_state is a non-READY state (still building)" do
+      refute Placement.base_ready?(brick(workloads: advertising("wl", :BASE_BUILD_STATE_BUILDING)), "wl")
+    end
+
+    test "false when the workloads map is missing entirely" do
+      refute Placement.base_ready?(%{instance_id: "n/x"}, "wl")
+    end
+  end
+
+  describe "pick_ready/3 (adds the base-readiness gate to pick/3)" do
+    test "skips a mem-eligible brick that has NOT advertised the base, picks the ready one" do
+      # not_ready: mem-eligible + free slot, but base_state absent (fresh/rolled).
+      not_ready =
+        brick(instance_id: "n/fresh", mem_headroom_mib: 16_000, mem_budget_mib: 16_384, workloads: advertising("wl", :absent))
+
+      # ready: mem-eligible AND advertises the base READY.
+      ready =
+        brick(instance_id: "n/ready", mem_headroom_mib: 16_000, mem_budget_mib: 16_384, workloads: advertising("wl"))
+
+      for key <- ~w(a b c d e f) do
+        assert Placement.pick_ready([not_ready, ready], "wl", 4_000).instance_id == "n/ready"
+      end
+    end
+
+    test "only base-ready instance is too small AND only mem-eligible ones are not ready -> nil (retryable no-eligible)" do
+      # base-ready but too small for the need (classed 2gi, 100 MiB headroom).
+      ready_small =
+        brick(instance_id: "n/small", size_class: "2gi", mem_headroom_mib: 100, mem_budget_mib: 2_048, workloads: advertising("wl"))
+
+      # mem-eligible (big) but has NOT advertised the base yet.
+      big_not_ready =
+        brick(instance_id: "n/big", mem_headroom_mib: 16_000, mem_budget_mib: 16_384, workloads: advertising("wl", :absent))
+
+      assert Placement.pick_ready([ready_small, big_not_ready], "wl", 4_000) == nil
+    end
+
+    test "single-instance fleet: the sole advertised instance is picked (output-equivalent)" do
+      sole = brick(instance_id: "n/only", workloads: advertising("wl"))
+      assert Placement.pick_ready([sole], "wl", 4_000).instance_id == "n/only"
+    end
+
+    test "wildcard DS that advertises the base is always the (only) candidate" do
+      ds =
+        brick(instance_id: "n/ds", size_class: "", mem_headroom_mib: 0, mem_budget_mib: 0, workloads: advertising("wl"))
+
+      assert Placement.pick_ready([ds], "wl", 16_000).instance_id == "n/ds"
+    end
+
+    test "a wildcard DS that has NOT advertised the base is skipped -> nil" do
+      ds =
+        brick(instance_id: "n/ds", size_class: "", mem_headroom_mib: 0, mem_budget_mib: 0, workloads: advertising("wl", :absent))
+
+      assert Placement.pick_ready([ds], "wl", 16_000) == nil
     end
   end
 end

--- a/projects/embervm/control/test/embervm/wake_instance_test.exs
+++ b/projects/embervm/control/test/embervm/wake_instance_test.exs
@@ -20,10 +20,23 @@ defmodule Embervm.WakeInstanceTest do
     %{table: table}
   end
 
+  # The workloads every cold-pick test queries; the fixture advertises each as
+  # base READY by default so the base-readiness gate is satisfied and these tests
+  # exercise the mem/slot behaviour. A test that wants a NOT-yet-advertised
+  # instance (the fresh/rolled window) passes `advertise: []`.
+  @default_advertised ~w(wl-a wl-b wl-c wl-d wl-e gwl)
+
   # A per-instance capacity fact. Defaults model a real classed brick with headroom
-  # and a free slot; override per case (size_class "" / mem_budget_mib 0 => wildcard).
+  # and a free slot that has ADVERTISED the default workloads' bases as READY;
+  # override per case (size_class "" / mem_budget_mib 0 => wildcard; advertise: []
+  # => a fresh instance that has not advertised any base yet).
   defp put_instance(table, node_id, pod_uid, opts) do
     instance_id = "#{node_id}/#{pod_uid}"
+
+    workloads =
+      for wl <- Keyword.get(opts, :advertise, @default_advertised), into: %{} do
+        {wl, %{base_state: :BASE_BUILD_STATE_READY, snapshot_ref: "snap/#{wl}"}}
+      end
 
     facts =
       %{
@@ -36,6 +49,7 @@ defmodule Embervm.WakeInstanceTest do
         mem_budget_mib: Keyword.get(opts, :mem_budget_mib, 8_192),
         live_vms: Keyword.get(opts, :live_vms, 0),
         max_live_vms: Keyword.get(opts, :max_live_vms, 4),
+        workloads: workloads,
         stateful_bundles: Keyword.get(opts, :stateful_bundles, []),
         serving_snapshots: Keyword.get(opts, :serving_snapshots, []),
         group_bundle_sets: Keyword.get(opts, :group_bundle_sets, []),
@@ -85,14 +99,17 @@ defmodule Embervm.WakeInstanceTest do
                )
     end
 
-    test "the owner is chosen even if it is mem-too-small (a relight must land on its disk)", %{table: table} do
-      # The owner is a 2Gi brick with only 100 MiB headroom; the need is 4000. Warmth
-      # ownership wins regardless: the bundle is only on this instance's disk.
+    test "the owner is chosen even if it is mem-too-small AND has not advertised the base (a relight must land on its disk)", %{table: table} do
+      # The owner is a 2Gi brick with only 100 MiB headroom (need 4000) that has
+      # advertised NO base (advertise: []). Warmth ownership wins regardless of BOTH
+      # the mem gate and the base-readiness gate: the bundle is only on this instance's
+      # disk, so the readiness gate (which is a COLD-pick-only concern) must not touch it.
       owner =
         put_instance(table, "node-4", "pod-small",
           size_class: "2gi",
           mem_headroom_mib: 100,
           mem_budget_mib: 2_048,
+          advertise: [],
           stateful_bundles: [%{snapshot_ref: "stateful/wl-a"}]
         )
 
@@ -132,6 +149,67 @@ defmodule Embervm.WakeInstanceTest do
       # warmth_key present but no warmth_ref => nothing to prefer => cold pick.
       assert {:ok, ^big} =
                WakeInstance.select("node-4", table: table, workload: "wl-a", need_mib: 1_000, warmth_key: :stateful_bundles)
+    end
+  end
+
+  describe "cold pick gates on base readiness (co-location gap)" do
+    test "skips a mem-eligible instance that has NOT advertised the base, picks the advertised one", %{table: table} do
+      # fresh: mem-eligible + free slot, but advertises no base yet (the post-roll /
+      # post-scale-up window: adopted bases from disk internally but noded has not
+      # re-provisioned the runtime image, so base_state is absent and it cannot resolve
+      # boot_image_ref). ready: same size, advertises the base READY.
+      _fresh =
+        put_instance(table, "node-4", "pod-fresh",
+          size_class: "16gi",
+          mem_headroom_mib: 16_000,
+          mem_budget_mib: 16_384,
+          advertise: []
+        )
+
+      ready =
+        put_instance(table, "node-4", "pod-ready",
+          size_class: "16gi",
+          mem_headroom_mib: 16_000,
+          mem_budget_mib: 16_384
+        )
+
+      for wl <- ~w(wl-a wl-b wl-c wl-d wl-e) do
+        assert {:ok, picked} =
+                 WakeInstance.select("node-4", table: table, workload: wl, need_mib: 4_000, warmth_key: :stateful_bundles)
+
+        assert picked == ready
+      end
+    end
+
+    test "the only base-ready instance is too small AND the mem-eligible one is not ready -> clean no-eligible (retryable, NOT a bad pick)", %{table: table} do
+      # ready_small: advertises the base READY but is a 2Gi brick, too small for 4000.
+      # big_fresh: mem-eligible (16Gi) but has NOT advertised the base. Neither is BOTH
+      # eligible and ready, so selection returns :no_eligible_instance (the wake retries
+      # once big_fresh finishes provisioning) rather than dialling either bad choice.
+      _ready_small =
+        put_instance(table, "node-4", "pod-small",
+          size_class: "2gi",
+          mem_headroom_mib: 100,
+          mem_budget_mib: 2_048
+        )
+
+      _big_fresh =
+        put_instance(table, "node-4", "pod-big",
+          size_class: "16gi",
+          mem_headroom_mib: 16_000,
+          mem_budget_mib: 16_384,
+          advertise: []
+        )
+
+      assert {:error, :no_eligible_instance} =
+               WakeInstance.select("node-4", table: table, workload: "wl-a", need_mib: 4_000, warmth_key: :stateful_bundles)
+    end
+
+    test "a node whose sole instance has not advertised the base fails cleanly (retryable wait)", %{table: table} do
+      _fresh = put_instance(table, "node-4", "pod-fresh", advertise: [])
+
+      assert {:error, :no_eligible_instance} =
+               WakeInstance.select("node-4", table: table, workload: "wl-a", need_mib: 512)
     end
   end
 
@@ -211,6 +289,7 @@ defmodule Embervm.WakeInstanceTest do
         mem_budget_mib: 0,
         live_vms: 0,
         max_live_vms: 4,
+        workloads: %{"wl-a" => %{base_state: :BASE_BUILD_STATE_READY, snapshot_ref: "snap/wl-a"}},
         stateful_bundles: [%{snapshot_ref: "stateful/wl-a"}]
       })
 


### PR DESCRIPTION
## Problem

A stateful/serving/task/group **cold** wake could land on an instance that was dispatchable and mem-eligible but had **not yet advertised the workload's base as READY**. A freshly-rolled or scaled-up instance adopts its node-shared bases from disk internally, but only projects `workloads[wl].base_state = BASE_BUILD_STATE_READY` after its noded re-provisions the runtime image and syncs `imageProvisioned`. Dialling that instance for a cold boot hard-fails `noded: boot_image_ref required`.

This is a real co-location gap found live: a fresh 16Gi/DS instance was picked for a demo-postgres cold boot and failed `noded: boot_image_ref required`.

## Fix

- **`placement.ex`**: new shared `base_ready?/2` predicate (`workloads[workload].base_state == :BASE_BUILD_STATE_READY`, integer `3` accepted defensively) + `pick_ready/3`, the COLD-placement primitive that gates on eligibility **and** base readiness.
- **`wake_instance.ex`**: `cold_instance` now uses `Placement.pick_ready/3`. The warmth/relight-owner branch is unchanged (the banked instance already holds the base).
- **`brick_ledger.ex`**: `to_brick/1` now carries the `workloads` submap through so the predicate reads it off a normalized brick (absent -> `%{}`, fail-closed not-ready).

The task/session/serving **create** paths (Dispatcher `pick_node`, SessionPlacement/ServingPlacement `node_for_create`) already gated on base readiness via their own tolerant checks; this closes the remaining gap in the per-instance wake dial, using the same representation so the four paths cannot drift.

## Retryable, not a hard fail

When no instance is both eligible and base-ready, the cold pick returns the existing **retryable** `:no_eligible_instance`. The activators keep the workload published and the client's reconnect re-enters the wake, so the wake WAITS for a fresh instance to finish provisioning instead of dead-lettering on the first miss (confirmed: no create/wake path terminally dead-letters on first no-eligible).

## Inert on a stable fleet

Every instance on a stable fleet long ago advertised its bases, so this only changes behaviour in the post-roll / post-scale-up window (exactly the gap). Single-instance and stable-fleet tests stay green.

## Tests

New ExUnit coverage: cold wake skips a not-ready mem-eligible instance and picks the advertised one; only-ready-is-too-small + only-eligible-is-not-ready -> retryable no-eligible (not a bad pick); warmth-owner path unaffected even when the owner has advertised no base; single-instance fleet output-equivalent. Plus `Placement.base_ready?/2` and `pick_ready/3` unit tests.

**No chart bump** (deploys with the next embervm bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)