### PR TITLE
chore(embervm): bump chart to ship readiness gate + clear demo-postgres base

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.169
+version: 0.1.170

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.169
+      targetRevision: 0.1.170
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Ships the merged co-location readiness gate and re-pins images; the postgres retag forces a demo-postgres base rebuild against the current digest (task #21), landing it on the DS via the size-aware BaseBuilder. Forced wake + /health verify follow post-deploy.