### PR TITLE
feat(embervm): instance-key unification for stateful dials (PR-B0a)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.170
+version: 0.1.171

--- a/projects/embervm/chart/crds/workload-crd.yaml
+++ b/projects/embervm/chart/crds/workload-crd.yaml
@@ -488,6 +488,18 @@ spec:
                         bank, unchanged. Only honored for class stateful. NOTE: a
                         boolean for a single alternative behavior; a future third bank
                         strategy is expected to supersede this with a `bankMode` enum.
+                    autoWake:
+                      type: boolean
+                      default: false
+                      description: >-
+                        Opt in to post-base-READY auto-wake (instance-key unification
+                        PR-B0a, A2): when the control plane observes this workload's
+                        base transition to READY and it has no live or banked instance,
+                        the StatefulManager reconcile triggers a wake instead of waiting
+                        for the first connection. Set for demo-postgres so a chart bump's
+                        noded roll (which rebuilds the base) does not leave the public
+                        /health demo wedged until a manual forced wake. Off (the default)
+                        is lazy first-connection wake, unchanged.
                     secretRef:
                       type: string
                       description: >-

--- a/projects/embervm/chart/templates/workload-demo-postgres.yaml
+++ b/projects/embervm/chart/templates/workload-demo-postgres.yaml
@@ -54,6 +54,11 @@ spec:
     # aggressive idleBankSeconds:1 above is safe. This is exactly the exhibit the
     # mode exists for (a human clicking at the wrong moment).
     interruptibleBank: {{ .Values.demoPostgres.interruptibleBank }}
+    # Auto-wake after base READY (instance-key unification PR-B0a, A2): this is the
+    # public /health exhibit, so a chart bump's noded roll (which rebuilds the base)
+    # must not leave it wedged until a manual forced wake. The CP wakes it the moment
+    # the rebuilt base is READY.
+    autoWake: {{ .Values.demoPostgres.autoWake }}
     # Reuse the scratch-postgres Secret: same superuser password on first boot.
     secretRef: {{ include "embervm.fullname" . }}-scratch-postgres
 {{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -653,6 +653,11 @@ demoPostgres:
   # cold-boot; the interruptible bank resumes the paused VM hot instead. demo-
   # postgres is the named consumer this mode exists for.
   interruptibleBank: true
+  # Auto-wake once the base is READY (instance-key unification PR-B0a, A2). This
+  # is the public /health exhibit; a chart bump's noded roll rebuilds the base and
+  # would otherwise leave the demo wedged until a manual forced wake, so the CP
+  # wakes it as soon as the rebuilt base advertises READY.
+  autoWake: true
   # Toy dataset: a handful of demo rows, not a real datastore.
   volumeSizeGiB: 2
 

--- a/projects/embervm/control/lib/embervm/pool_manager.ex
+++ b/projects/embervm/control/lib/embervm/pool_manager.ex
@@ -208,7 +208,15 @@ defmodule Embervm.PoolManager do
   end
 
   defp refill_node(state, facts) do
-    node_id = facts.configured_id
+    # Dial the SPECIFIC instance this capacity fact belongs to (its instance_id,
+    # `"node/pod_uid"`), not the bare node name (instance-key unification PR-B0a):
+    # under brick co-location the node-name channel alias resolves to an arbitrary
+    # sibling that never adopted this instance's base, so a Prime against the alias
+    # fails "unknown snapshot_ref" and loops at the refill cadence. Fall back to the
+    # node name for a legacy/single-instance fact (no instance_id), unchanged. This
+    # key is also the per-instance bookkeeping key (inflight primes, floor status)
+    # so two co-located instances track independently.
+    node_id = dial_id(facts)
     workloads = ready_workloads(state, facts)
 
     # Node live-VM budget minus what this loop already has in flight for the node.
@@ -224,7 +232,7 @@ defmodule Embervm.PoolManager do
     if budget <= 0 or workloads == [] do
       state
     else
-      allocation = plan_primes(state, facts, workloads, budget)
+      allocation = plan_primes(state, node_id, workloads, budget)
       spawn_primes(state, node_id, allocation)
     end
   end
@@ -247,9 +255,7 @@ defmodule Embervm.PoolManager do
 
   # Decide how many VMs to prime per workload within `budget`: floors first
   # (round-robin fair under scarcity), then surplus proportional to queue depth.
-  defp plan_primes(state, facts, workloads, budget) do
-    node_id = facts.configured_id
-
+  defp plan_primes(state, node_id, workloads, budget) do
     floor_deficits =
       for w <- workloads, into: %{} do
         have = w.free + inflight_for(state, node_id, w.workload)
@@ -442,6 +448,16 @@ defmodule Embervm.PoolManager do
 
   defp stale?(f, now, stale_after), do: now - Map.get(f, :updated_at, 0) > stale_after
   defp draining?(f), do: Map.get(f, :draining, false) == true
+
+  # The dial/bookkeeping key for a capacity fact: its instance_id (`"node/pod_uid"`)
+  # when present, else the bare node name (a legacy/single-instance fact without the
+  # field still resolves via the node-name alias, unchanged behaviour).
+  defp dial_id(facts) do
+    case Map.get(facts, :instance_id) do
+      id when is_binary(id) and id != "" -> id
+      _ -> facts.configured_id
+    end
+  end
 
   defp queue_depth(state, wl) do
     if :ets.whereis(state.depth_table) == :undefined do

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -686,8 +686,10 @@ defmodule Embervm.StatefulManager do
                 # boot_image_ref rides even a RELIGHT: if the daemon discovers the
                 # generation pair is actually broken (a mismatch we could not see
                 # from here, or an unreadable ledger) it falls back to a cold boot
-                # from THIS ref rather than failing the call outright.
-                fallback_ref = boot_image_ref(state, node_id, workload)
+                # from THIS ref rather than failing the call outright. Resolved off
+                # dial_id (the instance the relight dials), not the node-name alias,
+                # so the fallback ref belongs to the SAME instance.
+                fallback_ref = boot_image_ref(state, dial_id, workload)
                 req = relight_request(entry, snapshot_ref, fallback_ref, blessed_generation)
                 spawn_wake(owner, workload, fn -> run_relight(state, instance, node_id, dial_id, req) end)
 
@@ -716,7 +718,8 @@ defmodule Embervm.StatefulManager do
           {:ok, dial_id} ->
             case StatefulStore.mark(state.store, instance.instance_id, :relight) do
               {:ok, _} ->
-                fallback_ref = boot_image_ref(state, node_id, workload)
+                # Fallback ref off the chosen instance (dial_id), not the node alias.
+                fallback_ref = boot_image_ref(state, dial_id, workload)
                 req = relight_request(entry, snapshot_ref, fallback_ref, blessed_generation)
 
                 spawn_wake(owner, workload, fn ->
@@ -736,13 +739,20 @@ defmodule Embervm.StatefulManager do
             send(self(), {:wake_done, workload, {:error, reason}})
         end
 
-      {:cold, node_id, boot_ref, mode, reason} ->
+      {:cold, node_id, _plan_boot_ref, mode, reason} ->
         # A cold boot has no owning bundle: select a mem-eligible instance on the
         # node (a too-small classed brick is skipped; the DS wildcard is always
         # eligible), and fail cleanly if none has room rather than dialling a
         # too-small one.
         case dial_instance(state, workload, entry, node_id, []) do
           {:ok, dial_id} ->
+            # Resolve the base snapshot_ref from the CHOSEN instance's fact (dial_id),
+            # not the node-name alias the plan phase used: under co-location the
+            # node-name fetch races across the three co-located facts and can read a
+            # sibling brick's ABSENT workload entry (nil -> boot_image_ref "" ->
+            # noded rejects). Reading it here off dial_id guarantees the ref and the
+            # RPC target are the same instance.
+            boot_ref = boot_image_ref(state, dial_id, workload)
             req = cold_request(state, entry, workload, boot_ref, mode, blessed_generation)
             spawn_wake(owner, workload, fn -> run_cold(state, workload, node_id, dial_id, boot_ref, mode, reason, req) end)
 
@@ -758,7 +768,10 @@ defmodule Embervm.StatefulManager do
       {:restore_volume_then_cold, wl, node_id, volume} ->
         case dial_instance(state, wl, entry, node_id, []) do
           {:ok, dial_id} ->
-            boot_ref = boot_image_ref(state, node_id, wl)
+            # Resolve the base ref from the chosen instance (dial_id), not the node
+            # alias (see the {:cold, ...} arm note): the restored volume cold-boots
+            # from the ref THIS instance advertises.
+            boot_ref = boot_image_ref(state, dial_id, wl)
             req = cold_request(state, entry, wl, boot_ref, :cold, blessed_generation)
             reason = cold_reason(volume)
 
@@ -941,19 +954,22 @@ defmodule Embervm.StatefulManager do
     end
   end
 
-  # Whether the anchor node still reports the instance's bundle on LOCAL disk (its
-  # snapshot_ref is in the node's stateful_bundles). A relight needs no restore when
-  # true; a true local miss (false) may consult the store.
+  # Whether ANY instance on the node still reports the bundle on LOCAL disk (its
+  # snapshot_ref is in some co-located instance's stateful_bundles). A relight needs
+  # no restore when true; a true local miss (false) may consult the store. Scans
+  # every per-instance fact on the node (not the freshest single fact): under
+  # co-location the bundle lives on the ONE instance that banked it (per-instance-
+  # on-disk, PR-2.5), which the node-name-keyed fetch could race past, wrongly
+  # deciding a present bundle is missing and triggering a needless restore.
   defp bundle_local?(state, node_id, snapshot_ref) when is_binary(snapshot_ref) and snapshot_ref != "" do
-    case NodeCapacity.fetch(state.capacity_table, node_id) do
-      {:ok, fact} ->
-        fact
-        |> Map.get(:stateful_bundles, [])
-        |> Enum.any?(&(&1.snapshot_ref == snapshot_ref))
-
-      :error ->
-        false
-    end
+    state.capacity_table
+    |> NodeCapacity.all()
+    |> Enum.filter(fn fact -> Map.get(fact, :node_id) == node_id end)
+    |> Enum.any?(fn fact ->
+      fact
+      |> Map.get(:stateful_bundles, [])
+      |> Enum.any?(&(&1.snapshot_ref == snapshot_ref))
+    end)
   end
 
   defp bundle_local?(_state, _node_id, _ref), do: false
@@ -1055,8 +1071,8 @@ defmodule Embervm.StatefulManager do
   # key instead (resolving it via its base registry, not the serving-image
   # inventory). Empty when the node has not built the base yet; the daemon then
   # fails the RPC loudly rather than booting an empty rootfs.
-  defp boot_image_ref(state, node_id, workload) do
-    case NodeCapacity.fetch(state.capacity_table, node_id) do
+  defp boot_image_ref(state, dial_key, workload) do
+    case fact_for_dial(state, dial_key) do
       {:ok, fact} ->
         fact
         |> Map.get(:workloads, %{})
@@ -1067,6 +1083,30 @@ defmodule Embervm.StatefulManager do
         nil
     end
   end
+
+  # Resolve the capacity fact for a dial key that is EITHER an instance_id string
+  # (`"node/pod_uid"`, the exact instance WakeInstance.select chose) OR a bare node
+  # name (a legacy/single-instance dial, or a plan-phase node-scoped resolve). An
+  # instance_id string is matched EXACTLY against the per-instance facts (no
+  # node-name-alias race across co-located siblings, the pathology this PR fixes);
+  # a bare node name uses NodeCapacity's node-scoped clause unchanged. This keeps
+  # boot_image_ref reading the SAME instance the RPC will dial, so the base
+  # snapshot_ref pick and the ref resolution can never disagree.
+  defp fact_for_dial(state, dial_key) when is_binary(dial_key) do
+    if String.contains?(dial_key, "/") do
+      state.capacity_table
+      |> NodeCapacity.all()
+      |> Enum.find(fn fact -> Map.get(fact, :instance_id) == dial_key end)
+      |> case do
+        nil -> :error
+        fact -> {:ok, fact}
+      end
+    else
+      NodeCapacity.fetch(state.capacity_table, dial_key)
+    end
+  end
+
+  defp fact_for_dial(_state, _dial_key), do: :error
 
   defp banked_instance(state, workload) do
     StatefulStore.list(state.store, workload)
@@ -1712,7 +1752,56 @@ defmodule Embervm.StatefulManager do
     _ = StatefulStore.eager_evict_broken_pairs(state.store)
 
     EndpointPublisher.publish(state.publisher)
-    state
+
+    auto_wake_ready_workloads(state, facts)
+  end
+
+  # A2 auto-wake (instance-key unification PR-B0a): kick a wake for every catalog-
+  # flagged autoWake stateful workload whose base is READY on some instance AND that
+  # has no live or banked instance AND no wake already in flight. This retires the
+  # recurring "every chart bump wedges the public demo until a manual forced wake"
+  # ops step: THIS PR's chart bump rolls the noded and rebuilds demo-postgres' base,
+  # and without this the demo stays dark until a connection (or an operator) wakes
+  # it. A workload with a live/banked instance is left alone (nothing to wake); one
+  # mid-wake is owned by that wake. start_wake parks no caller, so a successful wake
+  # simply publishes the endpoint for the next connection (reply_all([]) is a no-op).
+  defp auto_wake_ready_workloads(state, facts) do
+    WorkloadCatalog.all_names(state.catalog_table)
+    |> Enum.reduce(state, fn workload, acc ->
+      if auto_wake_eligible?(acc, workload, facts) do
+        Logger.info("embervm stateful: auto-waking workload after base READY", workload: workload)
+        start_wake(acc, workload)
+      else
+        acc
+      end
+    end)
+  end
+
+  defp auto_wake_eligible?(state, workload, facts) do
+    auto_wake_workload?(state, workload) and
+      not Map.has_key?(state.waking, workload) and
+      not has_nonterminal_instance?(state, workload) and
+      base_ready_somewhere?(facts, workload)
+  end
+
+  defp auto_wake_workload?(state, workload) do
+    match?({:ok, %{class: "stateful", stateful: %{auto_wake: true}}}, WorkloadCatalog.fetch(state.catalog_table, workload))
+  end
+
+  # Whether the workload has ANY non-terminal instance (live OR banked): if so there
+  # is nothing to auto-wake (a banked instance relights on the next connection, and
+  # a live one is already serving).
+  defp has_nonterminal_instance?(state, workload) do
+    StatefulStore.list(state.store, workload)
+    |> Enum.any?(&(not StatefulState.terminal?(&1.state)))
+  end
+
+  # Whether some reporting instance advertises this workload's base as READY (the
+  # signal that a wake can resolve a boot_image_ref and cold-boot). Reuses the
+  # shared Placement.base_ready?/2 predicate so the READY representation (proto atom
+  # or the integer form) can never drift from the cold-placement paths.
+  defp base_ready_somewhere?(facts, workload) do
+    Enum.any?(facts, fn fact -> Embervm.Placement.base_ready?(fact, workload) end)
   end
 
   defp index_stateful_vms(facts) do

--- a/projects/embervm/control/lib/embervm/stateful_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/stateful_sweeper.ex
@@ -180,6 +180,16 @@ defmodule Embervm.StatefulSweeper do
   # forever.
   @default_lifetime_drain_max_ms 3_600_000
 
+  # Bank-retry backoff (instance-key unification PR-B0a). A NON-terminal bank
+  # failure (a transient transport/daemon error, not an unknown-vm
+  # FAILED_PRECONDITION) aborts+republishes and defers the next bank attempt for
+  # this workload, doubling from @bank_backoff_base_ms up to @bank_backoff_cap_ms.
+  # Without it a persistent failure re-drives the bank at the 1 s sweep frequency;
+  # with it a stuck workload backs off to ~0.03 Hz. A successful bank (or a bank
+  # abort for a raced-in connection, which is not a failure) clears the entry.
+  @bank_backoff_base_ms 1_000
+  @bank_backoff_cap_ms 30_000
+
   # -- Client API ------------------------------------------------------------
 
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -291,6 +301,13 @@ defmodule Embervm.StatefulSweeper do
       # the threshold so a hot-looping client cannot pin the VM live forever).
       checkpoint_aborts: %{},
       flap_abort_threshold: Keyword.get(opts, :flap_abort_threshold, @default_flap_abort_threshold),
+      # workload -> {next_attempt_at_ms, current_backoff_ms}: a non-terminal bank
+      # failure defers this workload's next bank attempt (exponential, capped), so
+      # a persistent daemon-side wedge loops at ~0.03 Hz not the 1 s sweep. Cleared
+      # on a successful bank. Overridable for tests.
+      bank_backoff: %{},
+      bank_backoff_base_ms: Keyword.get(opts, :bank_backoff_base_ms, @bank_backoff_base_ms),
+      bank_backoff_cap_ms: Keyword.get(opts, :bank_backoff_cap_ms, @bank_backoff_cap_ms),
       propagation_settle_ms: Keyword.get(opts, :propagation_settle_ms, @default_propagation_settle_ms),
       lifetime_drain_max_ms: Keyword.get(opts, :lifetime_drain_max_ms, @default_lifetime_drain_max_ms),
       # workload -> the wall-clock ms the workload was first observed idle
@@ -659,14 +676,45 @@ defmodule Embervm.StatefulSweeper do
          since when is_integer(since) <- Map.get(state.idle_since, instance.workload) do
       idle_ms = cfg.idle_bank_seconds * 1000
 
-      if now - since >= idle_ms do
-        begin_bank(state, instance, now)
-      else
-        state
+      cond do
+        # A workload backing off from a recent non-terminal bank failure is not
+        # re-driven until its next-attempt time, so a persistent daemon-side wedge
+        # loops at ~0.03 Hz instead of the sweep frequency.
+        bank_backed_off?(state, instance.workload, now) ->
+          state
+
+        now - since >= idle_ms ->
+          begin_bank(state, instance, now)
+
+        true ->
+          state
       end
     else
       _ -> state
     end
+  end
+
+  defp bank_backed_off?(state, workload, now) do
+    case Map.get(state.bank_backoff, workload) do
+      {until, _cur} when is_integer(until) -> now < until
+      _ -> false
+    end
+  end
+
+  # Arm/advance the workload's bank backoff after a non-terminal failure: next
+  # attempt at now + backoff, backoff doubling from the base to the cap.
+  defp arm_bank_backoff(state, workload, now) do
+    cur =
+      case Map.get(state.bank_backoff, workload) do
+        {_until, prev} when is_integer(prev) -> min(prev * 2, state.bank_backoff_cap_ms)
+        _ -> state.bank_backoff_base_ms
+      end
+
+    %{state | bank_backoff: Map.put(state.bank_backoff, workload, {now + cur, cur})}
+  end
+
+  defp clear_bank_backoff(state, workload) do
+    %{state | bank_backoff: Map.delete(state.bank_backoff, workload)}
   end
 
   # -- drain force-bank (R6, ADR embervm/009) ---------------------------------
@@ -885,6 +933,12 @@ defmodule Embervm.StatefulSweeper do
     workload = instance.workload
     node_id = instance.node_id
     vm_id = instance.vm_id
+    # Dial the OWNING noded instance (the one whose capacity fact reports this
+    # live vm_id), not the node-name alias (which co-location made point at an
+    # arbitrary sibling brick). Falls back to node_id for a legacy/single-instance
+    # fact, preserving single-instance behaviour exactly. Resolved here on the
+    # owner process so the worker reads a settled key.
+    dial_key = dial_for_vm(state, node_id, vm_id)
     ip = instance.ip
     port = instance.port
 
@@ -899,7 +953,7 @@ defmodule Embervm.StatefulSweeper do
                            }
                          } do
           try do
-            case over_channel(channel_fun, invalidate_fun, node_id, &stop_fun.(&1, bank_request(vm_id))) do
+            case over_channel(channel_fun, invalidate_fun, dial_key, &stop_fun.(&1, bank_request(vm_id))) do
               {:ok, %StopStatefulResponse{snapshot_ref: ref, size_bytes: size, generation: generation}}
               when is_binary(ref) and ref != "" ->
                 # generation only becomes known once the daemon replies (the pair-key
@@ -945,6 +999,8 @@ defmodule Embervm.StatefulSweeper do
     workload = instance.workload
     node_id = instance.node_id
     vm_id = instance.vm_id
+    # Same owning-instance dial resolution as the atomic bank worker.
+    dial_key = dial_for_vm(state, node_id, vm_id)
     ip = instance.ip
     port = instance.port
 
@@ -961,7 +1017,7 @@ defmodule Embervm.StatefulSweeper do
           if is_integer(settle_ms) and settle_ms > 0, do: Process.sleep(settle_ms)
 
           try do
-            case over_channel(channel_fun, invalidate_fun, node_id, &stop_fun.(&1, checkpoint_request(vm_id))) do
+            case over_channel(channel_fun, invalidate_fun, dial_key, &stop_fun.(&1, checkpoint_request(vm_id))) do
               {:ok, %StopStatefulResponse{checkpoint_token: token, generation: generation}}
               when is_binary(token) and token != "" ->
                 {:ok, token, generation}
@@ -1029,23 +1085,59 @@ defmodule Embervm.StatefulSweeper do
       snapshot_bytes: size
     )
 
-    state
+    # A clean bank clears any backoff armed by a prior failure for this workload.
+    clear_bank_backoff(state, workload)
   end
 
+  # UNKNOWN-VM FAILED_PRECONDITION (gRPC status 9): the daemon we dialled does not
+  # own this VM ("not bankable / unknown vm"). Do NOT resurrect the endpoint into
+  # the fan-out (blind republish looped this at the 1 s sweep frequency before the
+  # dial-key fix, and even with it a genuinely-gone VM must not linger dark): fail
+  # the instance (banking -> failed, durable stateful_failed) so the wake path
+  # cold-boots a fresh one on the next connection. No backoff needed: the instance
+  # is terminal, so idle_bank_pass never re-selects it.
   defp finish_bank_active(state, instance, node_id, vm_id, ip, port, workload, {:error, reason}) do
-    Logger.warning("embervm stateful: bank failed, returning to fan-out",
+    if failed_precondition?(reason) do
+      Logger.warning("embervm stateful: bank rejected unknown vm, failing instance",
+        instance_id: instance.instance_id,
+        workload: workload,
+        reason: inspect(reason)
+      )
+
+      _ =
+        StatefulStore.transition(
+          state.store,
+          instance.instance_id,
+          :fail,
+          :stateful_failed,
+          %{reason: "bank_unknown_vm"},
+          %{}
+        )
+
+      state
+    else
+      other_error_bank_recovery(state, instance, node_id, vm_id, ip, port, workload, reason)
+    end
+  end
+
+  # Any OTHER bank error (transient transport/daemon failure, the VM still live):
+  # abort back to the fan-out and republish the still-alive VM, but ARM the
+  # per-workload backoff so a persistent failure re-drives at ~0.03 Hz, not the
+  # sweep frequency.
+  #
+  # bank_abort (banking -> serving) lands directly in the live state; no further
+  # FSM transition applies (see abort_bank/3's comment on why a `publish` call here
+  # would be the illegal {:serving, :publish} edge). Restore the endpoint fact via
+  # adopt_endpoint (ETS-only, no transition) using the endpoint captured BEFORE
+  # unpublish cleared the ETS row (the freshly-refetched `instance` here has nil
+  # ip/port, per StatefulStore.unpublish/3's clearing).
+  defp other_error_bank_recovery(state, instance, node_id, vm_id, ip, port, workload, reason) do
+    Logger.warning("embervm stateful: bank failed, returning to fan-out (backing off)",
       instance_id: instance.instance_id,
       workload: workload,
       reason: inspect(reason)
     )
 
-    # bank_abort (banking -> serving) lands directly in the live state; no
-    # further FSM transition applies (see abort_bank/3's comment on why a
-    # `publish` call here would be the illegal {:serving, :publish} edge).
-    # Restore the endpoint fact via adopt_endpoint (ETS-only, no transition)
-    # so the still-alive VM re-enters the fan-out, using the endpoint captured
-    # BEFORE unpublish cleared the ETS row (the freshly re-fetched `instance`
-    # here has nil ip/port, per StatefulStore.unpublish/3's clearing).
     _ = StatefulStore.mark(state.store, instance.instance_id, :bank_abort)
 
     if republishable_endpoint?(ip, port) do
@@ -1059,7 +1151,7 @@ defmodule Embervm.StatefulSweeper do
       Embervm.EndpointPublisher.publish(state.publisher)
     end
 
-    state
+    arm_bank_backoff(state, workload, state.clock.())
   end
 
   # -- interruptible bank: finish CHECKPOINT + resolve (ADR embervm/008) -------
@@ -1181,6 +1273,8 @@ defmodule Embervm.StatefulSweeper do
     channel_fun = state.channel_fun
     invalidate_fun = state.invalidate_fun
     resolve_fun = state.resolve_stateful_fun
+    # The paused VM is still on its owning instance: dial that, not the alias.
+    dial_key = dial_for_vm(state, node_id, vm_id)
 
     spawn(fn ->
       outcome =
@@ -1193,7 +1287,7 @@ defmodule Embervm.StatefulSweeper do
                            }
                          } do
           try do
-            case over_channel(channel_fun, invalidate_fun, node_id, &resolve_fun.(&1, resolve_request(vm_id, token, mode))) do
+            case over_channel(channel_fun, invalidate_fun, dial_key, &resolve_fun.(&1, resolve_request(vm_id, token, mode))) do
               {:ok, %ResolveStatefulResponse{} = resp} ->
                 {:ok, resp}
 
@@ -1575,8 +1669,9 @@ defmodule Embervm.StatefulSweeper do
 
   defp stop_stateful_destroy(state, %{node_id: node_id, vm_id: vm_id}) when is_binary(node_id) and is_binary(vm_id) do
     req = %StopStatefulRequest{trace: %Trace{}, vm_id: vm_id, mode: :STOP_STATEFUL_MODE_DESTROY}
+    dial_key = dial_for_vm(state, node_id, vm_id)
 
-    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+    with {:ok, channel} <- safe_channel(state.channel_fun, dial_key) do
       try do
         state.stop_stateful_fun.(channel, req)
       rescue
@@ -1593,8 +1688,9 @@ defmodule Embervm.StatefulSweeper do
 
   defp evict_snapshot(state, %{node_id: node_id, snapshot_ref: ref}) when is_binary(node_id) and is_binary(ref) do
     req = %EvictSnapshotRequest{trace: %Trace{}, snapshot_ref: ref}
+    dial_key = dial_for_bundle(state, node_id, ref)
 
-    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+    with {:ok, channel} <- safe_channel(state.channel_fun, dial_key) do
       try do
         state.evict_snapshot_fun.(channel, req)
       rescue
@@ -1618,8 +1714,9 @@ defmodule Embervm.StatefulSweeper do
        when is_binary(node_id) and is_binary(ref) and ref != "" do
     artifact = %ArtifactRef{kind: :ARTIFACT_KIND_STATEFUL, workload: workload, ref: ref}
     req = %EvictArtifactRequest{artifact: artifact, remote: true, trace: %Trace{workload: workload}}
+    dial_key = dial_for_bundle(state, node_id, ref)
 
-    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+    with {:ok, channel} <- safe_channel(state.channel_fun, dial_key) do
       try do
         state.evict_artifact_fun.(channel, req)
       rescue
@@ -1728,6 +1825,21 @@ defmodule Embervm.StatefulSweeper do
     e -> {:error, {:channel_raised, e}}
   catch
     kind, reason -> {:error, {:channel_raised, {kind, reason}}}
+  end
+
+  # The channel key for a live-VM dial (bank/checkpoint/resolve/destroy): the
+  # OWNING noded instance reporting `vm_id`, else the node name (single-instance /
+  # legacy fallback, unchanged behaviour). Instance-key unification (PR-B0a): a
+  # co-located node's node-name alias resolves to an arbitrary sibling brick, so a
+  # bank against the alias misroutes to a brick that never owned the VM and loops.
+  defp dial_for_vm(state, node_id, vm_id) do
+    Embervm.WakeInstance.dial_for_vm(state.capacity_table, node_id, vm_id)
+  end
+
+  # The channel key for a bundle dial (EvictSnapshot/EvictArtifact): the instance
+  # holding the bundle on disk (per-instance-on-disk, PR-2.5), else the node name.
+  defp dial_for_bundle(state, node_id, snapshot_ref) do
+    Embervm.WakeInstance.dial_for_bundle(state.capacity_table, node_id, snapshot_ref)
   end
 
   # Acquire the node's shared channel and run a stateful verb over it, invalidating

--- a/projects/embervm/control/lib/embervm/wake_instance.ex
+++ b/projects/embervm/control/lib/embervm/wake_instance.ex
@@ -98,6 +98,58 @@ defmodule Embervm.WakeInstance do
 
   def select(_node_id, _opts), do: {:error, :no_eligible_instance}
 
+  @doc """
+  The channel key of the instance on `node_id` currently RUNNING `vm_id` (its
+  per-instance capacity fact reports the `vm_id` in `stateful_vms`), or the bare
+  `node_id` when no reporting instance is found (a legacy/single-instance fact, or
+  the VM not yet re-reported after a roll: the node-name alias still resolves it).
+
+  This is the post-wake dial resolution the sweeper's bank/checkpoint/resolve
+  workers use so a StopStateful/ResolveStateful lands on the instance that actually
+  holds the live VM, not the collapsing node-name alias (which co-location made
+  point at an arbitrary sibling brick). Same fail-open-to-node_id contract as the
+  wake dial's `select/2`.
+  """
+  @spec dial_for_vm(atom(), String.t(), String.t()) :: String.t()
+  def dial_for_vm(table \\ NodeCapacity.table(), node_id, vm_id)
+
+  def dial_for_vm(table, node_id, vm_id)
+      when is_binary(node_id) and is_binary(vm_id) and vm_id != "" do
+    table
+    |> instances_on(node_id)
+    |> Enum.find(fn fact -> fact_reports_vm?(fact, vm_id) end)
+    |> case do
+      nil -> node_id
+      fact -> dial_id(fact)
+    end
+  end
+
+  def dial_for_vm(_table, node_id, _vm_id), do: node_id
+
+  @doc """
+  The channel key of the instance on `node_id` currently HOLDING the banked bundle
+  `snapshot_ref` on disk (its `stateful_bundles` report it), or the bare `node_id`
+  when none is found. The evict/GC dial resolution: an EvictSnapshot/EvictArtifact
+  must land on the instance that owns the bundle on disk (per-instance-on-disk,
+  PR-2.5), not the node-name alias. Fail-open to `node_id` (legacy/single-instance
+  facts, or a bundle not re-reported yet) exactly like `dial_for_vm/3`.
+  """
+  @spec dial_for_bundle(atom(), String.t(), String.t()) :: String.t()
+  def dial_for_bundle(table \\ NodeCapacity.table(), node_id, snapshot_ref)
+
+  def dial_for_bundle(table, node_id, snapshot_ref)
+      when is_binary(node_id) and is_binary(snapshot_ref) and snapshot_ref != "" do
+    table
+    |> instances_on(node_id)
+    |> Enum.find(fn fact -> fact_reports_warmth?(fact, :stateful_bundles, snapshot_ref, :snapshot_ref) end)
+    |> case do
+      nil -> node_id
+      fact -> dial_id(fact)
+    end
+  end
+
+  def dial_for_bundle(_table, node_id, _ref), do: node_id
+
   # The instance on `node_id` whose warmth inventory reports this wake's ref: a
   # relight MUST land on the instance that banked the bundle (per-instance-on-disk,
   # PR-2.5). :none when there is no warmth to prefer (a cold boot, no key/ref given)
@@ -173,6 +225,15 @@ defmodule Embervm.WakeInstance do
     |> Map.get(warmth_key, [])
     |> Kernel.||([])
     |> Enum.any?(fn row -> Map.get(row, match_field) == ref end)
+  end
+
+  # Whether this instance's per-instance capacity fact reports `vm_id` as a live
+  # stateful VM it is running (the sweeper's live-VM dial resolution).
+  defp fact_reports_vm?(fact, vm_id) do
+    fact
+    |> Map.get(:stateful_vms, [])
+    |> Kernel.||([])
+    |> Enum.any?(fn row -> Map.get(row, :vm_id) == vm_id end)
   end
 
   # The dial key for a capacity fact: its instance_id when present, else the node

--- a/projects/embervm/control/lib/embervm/workload_watcher.ex
+++ b/projects/embervm/control/lib/embervm/workload_watcher.ex
@@ -948,7 +948,14 @@ defmodule Embervm.WorkloadWatcher do
     # atomic pause-snapshot-destroy bank, unchanged. A boolean for a single
     # alternative behavior; a future third bank strategy is expected to
     # supersede this with a `bankMode` enum.
-    interruptible_bank: false
+    interruptible_bank: false,
+    # Opt in to POST-BASE-READY auto-wake: when the CP observes this workload's
+    # base transition to READY and it has no live or banked instance, the
+    # StatefulManager reconcile triggers a wake (instance-key unification PR-B0a,
+    # A2). Off = the workload wakes lazily on the first connection. Set for
+    # demo-postgres so a chart bump's noded roll (which rebuilds the base) does
+    # not leave the public /health demo wedged until a manual forced wake.
+    auto_wake: false
   }
   # The minimum idleBankSeconds; the CRD schema also enforces this, re-checked
   # here for the LIST/WATCH path. Floor lowered 30 -> 1 for the demo-postgres
@@ -1066,6 +1073,9 @@ defmodule Embervm.WorkloadWatcher do
       # truthy value this must switch to Map.get/3 with an explicit default to
       # avoid the Elixir truthiness trap.
       interruptible_bank: Map.get(s, "interruptibleBank") || @stateful_defaults.interruptible_bank,
+      # Boolean-|| safe only because the default is false (same trap note as
+      # interruptible_bank above): auto-wake this workload once its base is READY.
+      auto_wake: Map.get(s, "autoWake") || @stateful_defaults.auto_wake,
       # secretRef (R4, D-R4.PR-7.1: MMDS-lite over boot-args): the NAME of a K8s
       # Secret in the workload's OWN namespace whose data keys/values become the
       # guest's first-boot process env (e.g. POSTGRES_PASSWORD). Optional; nil

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -1443,9 +1443,16 @@ defmodule Embervm.StatefulManagerTest do
     # reconcile must auto-wake the workload (retires the post-roll manual wake).
     :ok = StatefulManager.reconcile(ctx.mgr)
 
-    poll_mgr(ctx, fn -> Agent.get(wakes, & &1) == 1 end)
+    # The StartStateful RPC records `wakes` inside the spawned wake worker, BEFORE
+    # it posts {:wake_done}; the publish only lands when finish_wake handles that
+    # message. So poll on the PUBLISHED ENDPOINT (the terminal effect), not `wakes`,
+    # to avoid asserting between the RPC return and the async publish.
+    poll_mgr(ctx, fn ->
+      match?(%{ip: "10.88.0.5", port: 5432}, StatefulStore.published_endpoint(ctx.store, "wl-a"))
+    end)
+
     assert Agent.get(wakes, & &1) == 1
-    assert match?(%{ip: "10.88.0.5", port: 5432}, StatefulStore.published_endpoint(ctx.store, "wl-a"))
+    assert StatefulStore.published_endpoint(ctx.store, "wl-a") == %{ip: "10.88.0.5", port: 5432}
   end
 
   test "reconcile does NOT auto-wake when autoWake is unset, or an instance already exists" do

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -117,6 +117,22 @@ defmodule Embervm.StatefulManagerTest do
     fn -> "stf-#{suffix}-#{Agent.get_and_update(counter, fn n -> {n + 1, n + 1} end)}" end
   end
 
+  # Flush the manager mailbox (a :sys call is processed after every already-queued
+  # message). An auto-wake dispatched by reconcile reports {:wake_done} from a
+  # spawned worker asynchronously, so a test asserting its outcome polls: flush,
+  # check, retry.
+  defp flush_mgr(ctx), do: :sys.get_state(ctx.mgr)
+
+  defp poll_mgr(ctx, fun, tries \\ 50) do
+    flush_mgr(ctx)
+
+    cond do
+      fun.() -> :ok
+      tries <= 0 -> flunk("poll_mgr: condition never held")
+      true -> poll_mgr(ctx, fun, tries - 1)
+    end
+  end
+
   defp stateful_workload(ctx, name, extra \\ %{}) do
     # `:resources` promotes to the TOP-LEVEL entry (where resource_spec/1 reads
     # mem_mib/vcpus); everything else merges into the stateful cfg.
@@ -1299,8 +1315,8 @@ defmodule Embervm.StatefulManagerTest do
       mem_budget_mib: Keyword.get(opts, :mem_budget_mib, 8_192),
       live_vms: Keyword.get(opts, :live_vms, 0),
       max_live_vms: Keyword.get(opts, :max_live_vms, 4),
-      workloads: %{"wl-a" => %{base_state: :BASE_BUILD_STATE_READY, snapshot_ref: "snap-a"}},
-      stateful_vms: [],
+      workloads: Keyword.get(opts, :workloads, %{"wl-a" => %{base_state: :BASE_BUILD_STATE_READY, snapshot_ref: "snap-a"}}),
+      stateful_vms: Keyword.get(opts, :stateful_vms, []),
       stateful_bundles: Keyword.get(opts, :stateful_bundles, []),
       volumes: Keyword.get(opts, :volumes, []),
       store_reachable: Keyword.get(opts, :store_reachable, false)
@@ -1365,6 +1381,110 @@ defmodule Embervm.StatefulManagerTest do
     # Fresh first boot (no volume): a cold wake places on a mem-eligible instance.
     assert {:ok, %{ip: "10.88.0.5", port: 5432}} = StatefulManager.wake(ctx.mgr, "wl-a", "p")
     assert Agent.get(dialed, & &1) == ["node-4/pod-big"]
+  end
+
+  test "boot_image_ref resolves from the CHOSEN instance's fact, not a co-located sibling that lacks the workload" do
+    # Instance-key unification (PR-B0a): the cold pick is instance-aware, but
+    # boot_image_ref used to re-resolve the base snapshot_ref by BARE node name,
+    # racing across the co-located facts. A sibling brick that never built this
+    # workload's base advertises NO wl-a entry, so the node-name fetch could read
+    # its ABSENT workload (nil -> boot_image_ref "" -> noded rejects). The ref must
+    # be read from the SAME instance the cold RPC dials.
+    {:ok, captured} = Agent.start_link(fn -> nil end)
+
+    cold_fun = fn _ch, req ->
+      Agent.update(captured, fn _ -> req end)
+      {:ok, %StartStatefulResponse{vm_id: "vm-cold", ip: "10.88.0.5", port: 5432, generation: 1, was_relight: false}}
+    end
+
+    # A large workload (4000 MiB) so the 2Gi sibling is mem-ineligible and the cold
+    # pick lands on pod-big deterministically.
+    ctx = start_stack(start_stateful_fun: cold_fun)
+    stateful_workload(ctx, "wl-a", %{resources: %{vcpus: 2, mem_mib: 4_000}})
+
+    # pod-small: mem-ineligible AND advertises NO wl-a base (empty workloads), the
+    # exact ABSENT-fact a node-name fetch could race onto.
+    put_brick(ctx, "node-4", "pod-small",
+      size_class: "2gi",
+      mem_headroom_mib: 100,
+      mem_budget_mib: 2_048,
+      workloads: %{}
+    )
+
+    # pod-big: the chosen instance, advertising the wl-a base READY with its ref.
+    put_brick(ctx, "node-4", "pod-big",
+      size_class: "8gi",
+      mem_headroom_mib: 8_000,
+      mem_budget_mib: 8_192,
+      workloads: %{"wl-a" => %{base_state: :BASE_BUILD_STATE_READY, snapshot_ref: "snap-a"}}
+    )
+
+    assert {:ok, %{ip: "10.88.0.5", port: 5432}} = StatefulManager.wake(ctx.mgr, "wl-a", "p")
+
+    req = Agent.get(captured, & &1)
+    assert req.boot_image_ref == "snap-a"
+  end
+
+  # -- A2 auto-wake after base READY (instance-key unification PR-B0a) ----------
+
+  test "reconcile auto-wakes an autoWake workload whose base is READY and has no instance" do
+    {:ok, wakes} = Agent.start_link(fn -> 0 end)
+
+    start_fun = fn _ch, _req ->
+      Agent.update(wakes, &(&1 + 1))
+      {:ok, %StartStatefulResponse{vm_id: "vm-auto", ip: "10.88.0.5", port: 5432, generation: 1, was_relight: false}}
+    end
+
+    ctx = start_stack(start_stateful_fun: start_fun)
+    stateful_workload(ctx, "wl-a", %{auto_wake: true})
+    stateful_node(ctx, "node-4")
+
+    # No instance exists yet; the base is READY (stateful_node advertises it). A
+    # reconcile must auto-wake the workload (retires the post-roll manual wake).
+    :ok = StatefulManager.reconcile(ctx.mgr)
+
+    poll_mgr(ctx, fn -> Agent.get(wakes, & &1) == 1 end)
+    assert Agent.get(wakes, & &1) == 1
+    assert match?(%{ip: "10.88.0.5", port: 5432}, StatefulStore.published_endpoint(ctx.store, "wl-a"))
+  end
+
+  test "reconcile does NOT auto-wake when autoWake is unset, or an instance already exists" do
+    {:ok, wakes} = Agent.start_link(fn -> 0 end)
+
+    start_fun = fn _ch, _req ->
+      Agent.update(wakes, &(&1 + 1))
+      {:ok, %StartStatefulResponse{vm_id: "vm-auto", ip: "10.88.0.5", port: 5432, generation: 1, was_relight: false}}
+    end
+
+    ctx = start_stack(start_stateful_fun: start_fun)
+    # autoWake unset (default false): a base-READY workload is NOT auto-woken.
+    stateful_workload(ctx, "wl-a", %{})
+    stateful_node(ctx, "node-4")
+
+    :ok = StatefulManager.reconcile(ctx.mgr)
+    flush_mgr(ctx)
+    assert Agent.get(wakes, & &1) == 0
+  end
+
+  test "reconcile does NOT auto-wake an autoWake workload that already has a banked instance" do
+    {:ok, wakes} = Agent.start_link(fn -> 0 end)
+
+    start_fun = fn _ch, _req ->
+      Agent.update(wakes, &(&1 + 1))
+      {:ok, %StartStatefulResponse{vm_id: "vm-auto", ip: "10.88.0.5", port: 5432, generation: 1, was_relight: false}}
+    end
+
+    ctx = start_stack(start_stateful_fun: start_fun)
+    stateful_workload(ctx, "wl-a", %{auto_wake: true})
+    stateful_node(ctx, "node-4",
+      stateful_bundles: [%{snapshot_ref: "stateful/stf-banked", workload: "wl-a", generation: 3, size_bytes: 10, created_at_unix_ms: 1}]
+    )
+    seed_banked_with_pair(ctx, "stf-banked", "node-4", 3, 3)
+
+    :ok = StatefulManager.reconcile(ctx.mgr)
+    flush_mgr(ctx)
+    # A banked instance relights on the next connection; nothing to auto-wake.
+    assert Agent.get(wakes, & &1) == 0
   end
 
   test "restore-on-miss dials the RESTORE and the BOOT on the SAME selected instance_id (not the node name)" do

--- a/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
@@ -155,7 +155,7 @@ defmodule Embervm.StatefulSweeperTest do
         clock: clock(clock_agent),
         scrape_fun: fn _url -> Agent.get(scrape_agent, & &1) end,
         stats_base: Keyword.get(opts, :stats_base, "http://serving:9902"),
-        channel_fun: fn _node -> {:ok, :ch} end,
+        channel_fun: Keyword.get(opts, :channel_fun, fn _node -> {:ok, :ch} end),
         invalidate_fun: Keyword.get(opts, :invalidate_fun, fn _n, _c -> :ok end),
         stop_stateful_fun: stop_stateful_fun,
         resolve_stateful_fun: resolve_stateful_fun,
@@ -1225,6 +1225,151 @@ defmodule Embervm.StatefulSweeperTest do
     atom = String.to_existing_atom(kind)
     {:ok, ops} = SQLite.read_from(ctx.op_log, 0)
     Enum.filter(ops, &(&1.kind == atom))
+  end
+
+  # -- instance-key unification (PR-B0a) ---------------------------------------
+
+  # Put one per-instance capacity fact (keyed by {node, pod_uid}) carrying the
+  # per-instance live-VM / bundle inventory the sweeper's dial resolution reads.
+  defp put_brick(ctx, node_id, pod_uid, opts) do
+    NodeCapacity.put(ctx.cap_table, {node_id, pod_uid}, %{
+      node_id: node_id,
+      configured_id: node_id,
+      pod_uid: pod_uid,
+      instance_id: "#{node_id}/#{pod_uid}",
+      serving_subnet_cidr: "10.98.0.0/24",
+      max_live_vms: 8,
+      live_vms: 0,
+      workloads: %{},
+      stateful_vms: Keyword.get(opts, :stateful_vms, []),
+      stateful_bundles: Keyword.get(opts, :stateful_bundles, []),
+      volumes: []
+    })
+  end
+
+  test "the bank dials the OWNER instance_id even when the node-name alias points at a sibling" do
+    {:ok, dialed} = Agent.start_link(fn -> [] end)
+
+    capture_channel = fn key ->
+      Agent.update(dialed, &[key | &1])
+      {:ok, :ch}
+    end
+
+    ctx = start_stack(channel_fun: capture_channel)
+    stateful_workload(ctx, "wl-a", 5400, %{idle_bank_seconds: 60})
+
+    # Two co-located instances on node-4. pod-owner RUNS vm-1; pod-sibling does not
+    # (it is the last registrant the node-name alias would collapse to). The bank
+    # must dial pod-owner, never the alias.
+    put_brick(ctx, "node-4", "pod-sibling", stateful_vms: [])
+    put_brick(ctx, "node-4", "pod-owner",
+      stateful_vms: [%{vm_id: "vm-1", workload: "wl-a", ip: "10.98.0.5", port: 5432, healthy: true, generation: 0}]
+    )
+
+    serving_instance(ctx, "sf-1", "wl-a", "vm-1", "10.98.0.5")
+
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 5_000)
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 65_000)
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    wait_until(ctx, fn -> match?({:ok, %{state: :banked}}, StatefulStore.get(ctx.store, "sf-1")) end)
+
+    # The StopStateful(BANK) dialled the owning instance, not the node-name alias.
+    assert "node-4/pod-owner" in Agent.get(dialed, & &1)
+    refute "node-4" in Agent.get(dialed, & &1)
+  end
+
+  test "an unknown-vm FAILED_PRECONDITION terminalizes the instance (-> :failed), not loop/republish" do
+    ctx = start_stack()
+    stateful_workload(ctx, "wl-a", 5400, %{idle_bank_seconds: 60})
+    stateful_node(ctx, "node-4")
+    serving_instance(ctx, "sf-1", "wl-a", "vm-1", "10.98.0.5")
+
+    # The daemon rejects the bank FAILED_PRECONDITION (status 9): it does not own
+    # this VM ("not bankable / unknown vm"). The instance must FAIL, not abort back
+    # to serving and re-drive next tick.
+    :sys.replace_state(ctx.sweeper, fn s ->
+      %{
+        s
+        | stop_stateful_fun: fn _ch, req ->
+            if req.mode == :STOP_STATEFUL_MODE_BANK do
+              {:error, %GRPC.RPCError{status: 9, message: "not bankable (unknown vm)"}}
+            else
+              {:ok, %StopStatefulResponse{}}
+            end
+          end
+      }
+    end)
+
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 5_000)
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 65_000)
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    wait_until(ctx, fn -> match?({:ok, %{state: :failed}}, StatefulStore.get(ctx.store, "sf-1")) end)
+
+    {:ok, instance} = StatefulStore.get(ctx.store, "sf-1")
+    assert instance.state == :failed
+    assert load_ops(ctx, "stateful_banked") == []
+    # A durable stateful_failed was recorded (the wake path cold-boots next).
+    assert length(load_ops(ctx, "stateful_failed")) == 1
+  end
+
+  test "a NON-terminal bank error backs off (does not re-drive at sweep frequency)" do
+    ctx = start_stack(bank_backoff_base_ms: 10_000, bank_backoff_cap_ms: 30_000)
+    stateful_workload(ctx, "wl-a", 5400, %{idle_bank_seconds: 60})
+    stateful_node(ctx, "node-4")
+    serving_instance(ctx, "sf-1", "wl-a", "vm-1", "10.98.0.5")
+
+    # A transient (non-FAILED_PRECONDITION) bank failure: abort back to serving,
+    # arm the backoff.
+    Agent.update(ctx.bank_fail, fn _ -> true end)
+
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 5_000)
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    # This tick crosses idle: the first bank fires and fails, arming the backoff.
+    advance(ctx.clock_agent, 65_000)
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    wait_until(ctx, fn -> match?({:ok, %{state: :serving}}, StatefulStore.get(ctx.store, "sf-1")) end)
+
+    bank_calls = fn -> Enum.count(stop_calls(ctx), &(&1.mode == :STOP_STATEFUL_MODE_BANK)) end
+    assert bank_calls.() == 1
+
+    # A sweep only 1 s later (well inside the 10 s backoff) must NOT re-drive the
+    # bank: this is the loop the backoff kills.
+    advance(ctx.clock_agent, 1_000)
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+    flush(ctx)
+    assert bank_calls.() == 1
+
+    # Past the backoff window, the bank is re-driven (still failing, still one more
+    # attempt: the point is it backed OFF, not that it gave up).
+    advance(ctx.clock_agent, 11_000)
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+    wait_until(ctx, fn -> bank_calls.() == 2 end)
+    assert bank_calls.() == 2
   end
 
   describe "drain_node/2 (R6 force-bank)" do

--- a/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
@@ -168,6 +168,8 @@ defmodule Embervm.StatefulSweeperTest do
         propagation_settle_ms: Keyword.get(opts, :propagation_settle_ms, 0),
         bank_concurrency: Keyword.get(opts, :bank_concurrency, 1),
         lifetime_drain_max_ms: Keyword.get(opts, :lifetime_drain_max_ms, 3_600_000),
+        bank_backoff_base_ms: Keyword.get(opts, :bank_backoff_base_ms, 1_000),
+        bank_backoff_cap_ms: Keyword.get(opts, :bank_backoff_cap_ms, 30_000),
         sweep_interval_ms: 0
       ]
 

--- a/projects/embervm/control/test/embervm/workload_watcher_test.exs
+++ b/projects/embervm/control/test/embervm/workload_watcher_test.exs
@@ -667,6 +667,20 @@ defmodule Embervm.WorkloadWatcherTest do
     # workload with no first-boot secrets to deliver never reads a Secret).
     assert entry.stateful.secret_ref == nil
     assert entry.stateful.interruptible_bank == false
+    assert entry.stateful.auto_wake == false
+  end
+
+  test "stateful class: autoWake true is parsed onto the catalog entry (PR-B0a A2)" do
+    table = unique_table()
+    agent = start_recorder()
+    cr = put_in(stateful_cr(), ["spec", "stateful", "autoWake"], true)
+    lister = fn -> {:ok, [cr]} end
+    watcher = start_watcher(lister, recording_status_writer(agent), table)
+
+    :ok = WorkloadWatcher.reconcile_now(watcher)
+
+    assert {:ok, entry} = WorkloadCatalog.fetch(table, "scratch-postgres")
+    assert entry.stateful.auto_wake == true
   end
 
   test "stateful class: interruptibleBank true is parsed onto the catalog entry (ADR 008)" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.170
+      targetRevision: 0.1.171
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Why

Since brick co-location (2+ noded on one node), the NodeChannel node-name alias (\`"node-4"\`) is last-writer-wins and currently resolves to the 2gi brick, not the DS noded that owns every live VM and base. Several CP consumers still dial / fetch capacity facts by the bare node name, so their RPCs misroute to a sibling that owns nothing. Result: three 1 Hz retry loops with no backoff and a 503 on jomcgi.dev/health.

1. scratch-postgres bank loop: the sweeper dialed the alias -> a brick that does not own the VM -> FAILED_PRECONDITION -> republish forever.
2. demo-postgres wake \`boot_image_ref required\`: \`boot_image_ref\` fetched the fact by bare node name and raced across the three co-located facts, reading a brick's ABSENT workload entry (nil -> "").
3. cold-image-demo pool prime loop: \`PoolManager.refill_node\` keyed on the bare node name.

Root: the instance-key migration was deferred at brick-capacity PR-2 (dispatcher + wake dial migrated; sweeper / boot_image_ref / PoolManager did not). This PR finishes it for those consumers.

## What

- **Dial the owning instance, not the node.** New \`WakeInstance.dial_for_vm/3\` (owner running the live vm_id) and \`dial_for_bundle/3\` (instance holding the bundle on disk), resolved from live NodeCapacity facts, both **fail open to the node name** so single-instance / legacy behaviour is identical. The sweeper's bank / checkpoint / resolve / destroy / evict workers dial through these.
- **boot_image_ref resolves the fact for the CHOSEN instance.** \`fact_for_dial\` exact-matches an instance_id (\`node/pod_uid\`) against per-instance facts, so the base snapshot_ref pick and the RPC target are always the same instance. \`bundle_local?\` now scans every co-located fact (the bundle lives on the one instance that banked it).
- **Terminalize + back off the bank retry.** An unknown-vm FAILED_PRECONDITION fails the instance (banking -> failed) so the wake path cold-boots fresh, instead of looping; any other error keeps the abort+republish path but arms a per-workload exponential backoff (1s -> 30s cap), so a persistent failure runs at ~0.03 Hz not the sweep frequency.
- **PoolManager.refill_node keys on the fact's instance_id** (fallback node name).
- **A2 auto-wake** (new catalog flag \`autoWake\`, set for demo-postgres): after a base goes READY with no live/banked instance and no wake in flight, the CP wakes the workload. This self-heals the public demo after a noded roll (including this PR's own chart-bump roll), retiring the recurring manual-wake ops step. Reuses \`Placement.base_ready?/2\` so the READY predicate cannot drift.

The node-name alias is intentionally kept as a fallback; deleting it (plus the serving/session/group caller audit, task #4) is the deliberate PR-B0b fast-follow, once live rows carry the instance stamp.

## Known follow-up (tracked)

The terminalize fires on unknown-vm even when the dial fell open to the node name; in a narrow stale-fact race that could fail a still-live instance. Realistically only demo-postgres (1s idle, throwaway data) is exposed; hardening (terminalize only when owner-resolved) is a follow-up, with R7 fence + CP-lease as the volume-safety backstop.

## Tests

Sweeper: owner-instance bank dial with the alias on a sibling; unknown-vm terminalize; non-terminal backoff. StatefulManager: boot_image_ref from the chosen instance past a sibling lacking the workload; three auto-wake cases. Workload watcher: autoWake parse.

Chart bumped to 0.1.171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)