### PR TITLE
chore(platform): storage hygiene, SigNoz system-log TTLs + Longhorn stale-snapshot cleanup

### DIFF
--- a/projects/platform/longhorn/kustomization.yaml
+++ b/projects/platform/longhorn/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ./namespace.yaml
   - ./storageclass-gpu.yaml
   - ./configure-node-4-disks.yaml
+  - ./recurringjob-snapshot-cleanup.yaml
   - ./longhorn-httpcheck-alert.yaml

--- a/projects/platform/longhorn/recurringjob-snapshot-cleanup.yaml
+++ b/projects/platform/longhorn/recurringjob-snapshot-cleanup.yaml
@@ -1,0 +1,47 @@
+# Longhorn RecurringJob: purge stale, removable snapshots on a schedule.
+#
+# Why this exists: the storage audit (docs/plans/2026-07-20-cluster-storage-rightsizing.md)
+# found old system snapshots inflating Longhorn actualSize far beyond live data
+# (a 136d-old ClickHouse snapshot holding ~54G of blocks, a 7d SeaweedFS chain, a
+# 36d zookeeper/mcp-pg chain). Nothing was pruning them, so blocks accumulated.
+#
+# Task choice: "snapshot-cleanup" (NOT "snapshot-delete"). snapshot-cleanup only
+# removes REMOVABLE snapshots: Longhorn system snapshots (auto-created during
+# replica rebuilds / volume operations) and snapshots already marked for deletion.
+# It coalesces and purges those blocks. It does NOT delete usable user restore
+# points, and it never creates a new snapshot. This is the conservative choice:
+# it frees the retained-block bloat the audit flagged without ever removing a
+# deliberate restore point.
+#
+# Durable-asset safety (SeaweedFS = S3, CNPG = Pg): because snapshot-cleanup only
+# touches removable/system snapshots, it cannot delete a usable restore point on
+# the SeaweedFS or CNPG volumes even though it applies to the "default" group
+# (see below). The audit's confirm-only item (the SeaweedFS 136d snapshot) is a
+# USER-visible snapshot decision and is deliberately NOT auto-pruned here: if that
+# snapshot is a usable restore point, snapshot-cleanup leaves it in place, and its
+# removal stays a manual, human-confirmed action. If it is merely a removable
+# system snapshot, cleanup reclaiming it is safe by definition.
+#
+# Grouping: group "default". Longhorn adds the "default" group to any volume that
+# has no other recurring-job label, so this covers all current cluster volumes
+# (clickhouse, seaweedfs, monolith-pg, zookeeper, embervm-oplog, etc.) with one
+# job. Safe here precisely because the task is removable-only.
+#
+# retain: 1. For snapshot-cleanup the retain count is not used to prune user
+# snapshots (it only affects snapshot/backup-creating tasks); it is set to a small
+# value for schema clarity. concurrency 1 keeps the cleanup gentle on the cluster.
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: stale-snapshot-cleanup
+  namespace: longhorn
+spec:
+  # Weekly, Sunday 03:15 UTC (off-peak). Cleanup is idempotent and cheap; weekly
+  # is frequent enough to keep removable-snapshot bloat bounded without churn.
+  cron: "15 3 * * 0"
+  task: snapshot-cleanup
+  groups:
+    - default
+  retain: 1
+  concurrency: 1
+  labels: {}

--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -217,27 +217,46 @@ signoz:
         cpu: 4
         memory: 10Gi
     persistence:
+      # LEFT AT 150Gi DELIBERATELY. Kubernetes PVCs cannot shrink in place
+      # (Longhorn allowVolumeExpansion only grows a volume); lowering this value
+      # would be ignored by the running PVC or force a destructive recreate. The
+      # storage audit's suggested 150Gi -> 100Gi ceiling reduction therefore
+      # requires a separate, planned PVC migration and is OUT OF SCOPE here. This
+      # PR frees space WITHIN the existing 150Gi by tightening system-log TTLs
+      # below; the filesystem holds only ~48G of 147G, so headroom is ample.
       size: 150Gi
-    # System table TTL settings (days) - prevents unbounded growth
+    # System table TTL settings (days) - prevents unbounded growth.
+    #
+    # These are ClickHouse's own SYSTEM-table logs, not SigNoz app telemetry.
+    # App-data retention (logs_v2, traces, samples_v4 metrics) is NOT a chart
+    # value: it is set via the SigNoz retention API and stored in the SigNoz DB,
+    # so it is out of GitOps scope and untouched here. Durable observability data
+    # (the ~30G of logs/traces/metrics the owner wants) is unaffected by these
+    # system-log TTLs.
+    #
+    # Reduced per the storage audit (2026-07-20): zookeeper_log alone held ~11.5G
+    # at a 7d TTL, so the high-volume system logs are cut 7d -> 3d. traceLog and
+    # processorsProfileLog were already at 3d. sessionLog kept at 7d (tiny, and
+    # useful for auth debugging).
     clickhouseOperator:
       queryLog:
-        ttl: 7
+        ttl: 3
       partLog:
-        ttl: 7
+        ttl: 3
       traceLog:
         ttl: 3
       metricLog:
-        ttl: 7
+        ttl: 3
       asynchronousMetricLog:
-        ttl: 7
+        ttl: 3
       sessionLog:
         ttl: 7
       zookeeperLog:
-        ttl: 7
+        ttl: 3
       processorsProfileLog:
         ttl: 3
       queryViewsLog:
-        ttl: 7
+        ttl: 3
     # Zookeeper is a subchart of clickhouse
     zookeeper:
       # 7-day working_set ~1.13Gi against a 1Gi request: raised 1 -> 1.25 to


### PR DESCRIPTION
Two conservative, GitOps-only storage reclaim changes from the 2026-07-20 cluster storage audit (`docs/plans/2026-07-20-cluster-storage-rightsizing.md`). Neither touches durable data (SeaweedFS/S3, CNPG/Pg) nor any PVC size. **Please review before merge, auto-merge is intentionally NOT enabled.**

## Item 1: SigNoz/ClickHouse system-log TTLs (`projects/platform/signoz/values-prod.yaml`)

Reduce ClickHouse SYSTEM-log TTLs 7d -> 3d for the high-volume tables. `zookeeper_log` alone held ~11.5G at 7d.

| Table | Before | After |
|-------|--------|-------|
| queryLog | 7 | 3 |
| partLog | 7 | 3 |
| metricLog | 7 | 3 |
| asynchronousMetricLog | 7 | 3 |
| zookeeperLog | 7 | 3 |
| queryViewsLog | 7 | 3 |
| traceLog | 3 | 3 (unchanged) |
| processorsProfileLog | 3 | 3 (unchanged) |
| sessionLog | 7 | 7 (kept: tiny, useful for auth debugging) |

- These are ClickHouse's own operational logs, **not** SigNoz app telemetry. App-data retention (logs/traces/metrics) is set via the SigNoz retention API, not a chart value, so it is out of GitOps scope and untouched. The ~30G of durable observability data the owner wants is unaffected.
- **PVC size left at 150Gi deliberately.** PVCs cannot shrink in place (Longhorn `allowVolumeExpansion` only grows), so the audit's 150Gi -> 100Gi ceiling is a separate destructive migration and is out of scope here. Documented inline in the values file.
- Estimated reclaim: ~12-15G within the existing PVC (audit item 3).

## Item 2: Longhorn stale-snapshot RecurringJob (`projects/platform/longhorn/recurringjob-snapshot-cleanup.yaml`)

New weekly `RecurringJob` (`task: snapshot-cleanup`, cron `15 3 * * 0`, group `default`, concurrency 1).

- `snapshot-cleanup` only removes **removable** snapshots: Longhorn system snapshots (auto-created during replica rebuilds/operations) and snapshots already marked for deletion. It **never** deletes a usable user restore point and never creates a snapshot.
- Because it is removable-only, it is safe across the `default` group even though that group covers the SeaweedFS and CNPG volumes: it cannot delete a needed restore point on them.
- The audit's confirm-only SeaweedFS 136d snapshot: if it is a usable restore point, `snapshot-cleanup` leaves it in place, so it stays a manual, human-confirmed decision (not auto-pruned).
- Frees retained-block bloat (a 136d ClickHouse snapshot held ~54G of blocks), not live data.

## Validation
- `helm template` on SigNoz: TTLs propagate (`interval 3 day`), PVC stays 150Gi.
- `kustomize build` on Longhorn: RecurringJob renders valid.
- Formatter run; unrelated gazelle BUILD drift reverted (only the 3 intended files remain).
- No local tests (repo convention); deferring to CI.

## Note on R7
Per the audit, these GitOps levers free only a few GB on the control-plane masters (node-1/node-3). Those nodes' pressure is host-level containerd/k3s state, not Longhorn, so this PR does **not** unblock R7 on its own (host image GC + backup target, tracked separately).