### PR TITLE
feat(embervm): finish co-location instance-key migration (PR-B0b)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.171
+version: 0.1.172

--- a/projects/embervm/control/lib/embervm/group_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/group_sweeper.ex
@@ -1037,7 +1037,7 @@ defmodule Embervm.GroupSweeper do
       member_name: member.member_name
     }
 
-    with {:ok, channel} <- safe_channel(state, instance.node_id) do
+    with {:ok, channel} <- safe_channel(state, dial_for_group(state, instance)) do
       try do
         state.stop_group_member_fun.(channel, req)
       rescue
@@ -1067,7 +1067,7 @@ defmodule Embervm.GroupSweeper do
   defp delete_network(state, instance) do
     req = %DeleteGroupNetworkRequest{trace: %Trace{workload: nil}, group_instance_id: instance.instance_id}
 
-    with {:ok, channel} <- safe_channel(state, instance.node_id) do
+    with {:ok, channel} <- safe_channel(state, dial_for_group(state, instance)) do
       try do
         state.delete_group_network_fun.(channel, req)
       rescue
@@ -1083,7 +1083,7 @@ defmodule Embervm.GroupSweeper do
   defp evict_snapshot(state, instance, ref) do
     req = %EvictSnapshotRequest{trace: %Trace{workload: nil}, snapshot_ref: ref}
 
-    with {:ok, channel} <- safe_channel(state, instance.node_id) do
+    with {:ok, channel} <- safe_channel(state, dial_for_group(state, instance)) do
       try do
         state.evict_snapshot_fun.(channel, req)
       rescue
@@ -1100,12 +1100,12 @@ defmodule Embervm.GroupSweeper do
   # remote=true) alongside the local per-member eviction. ref is the set_id (the set
   # is the export/evict unit). Best-effort; a set with no set_id (a partial set
   # already cleared) or no node is a clean no-op.
-  defp evict_remote_set(state, %{node_id: node_id, set_id: set_id, workload: workload})
+  defp evict_remote_set(state, %{node_id: node_id, set_id: set_id, workload: workload} = instance)
        when is_binary(node_id) and is_binary(set_id) and set_id != "" do
     artifact = %ArtifactRef{kind: :ARTIFACT_KIND_GROUP_SET, workload: workload, ref: set_id}
     req = %EvictArtifactRequest{artifact: artifact, remote: true, trace: %Trace{workload: workload}}
 
-    with {:ok, channel} <- safe_channel(state, node_id) do
+    with {:ok, channel} <- safe_channel(state, dial_for_group(state, instance)) do
       try do
         state.evict_artifact_fun.(channel, req)
       rescue
@@ -1192,6 +1192,17 @@ defmodule Embervm.GroupSweeper do
     e -> {:error, {:channel_raised, e}}
   catch
     kind, reason -> {:error, {:channel_raised, {kind, reason}}}
+  end
+
+  # The channel key for a group teardown dial (StopGroupMember / DeleteGroupNetwork /
+  # EvictSnapshot / EvictArtifact): the OWNING instance on the group's node reporting
+  # this group_instance_id (live group_member_vms or banked group_bundle_sets), else
+  # the node name. Instance-key unification (PR-B0b): a group's members are all
+  # co-located on ONE instance, so a teardown against the co-located node-name alias
+  # misroutes to an arbitrary sibling brick. Fail-open to the instance's node_id
+  # preserves single-instance behaviour exactly.
+  defp dial_for_group(state, %{instance_id: instance_id, node_id: node_id}) do
+    Embervm.WakeInstance.dial_for_group(state.capacity_table, node_id, instance_id)
   end
 
   defp default_bank(workload, instance_id) do

--- a/projects/embervm/control/lib/embervm/serving_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/serving_sweeper.ex
@@ -642,6 +642,12 @@ defmodule Embervm.ServingSweeper do
     instance_id = instance.instance_id
     workload = instance.workload
     generation = (instance.generation || 0) + 1
+    # Dial the OWNING instance (the one whose capacity fact reports this live serving
+    # vm_id), not the node-name alias (co-location made it point at an arbitrary
+    # sibling brick). Falls back to node_id for a legacy/single-instance fact,
+    # preserving single-instance behaviour. Resolved on the owner so the worker reads
+    # a settled key.
+    dial_key = dial_for_serving_vm(state, node_id, vm_id)
 
     spawn(fn ->
       # The `bank` lifecycle span (Task 10): a ROOT span in the spawned worker (the
@@ -659,7 +665,7 @@ defmodule Embervm.ServingSweeper do
                            }
                          } do
           try do
-            with {:ok, channel} <- safe_channel(channel_fun, node_id),
+            with {:ok, channel} <- safe_channel(channel_fun, dial_key),
                  {:ok, %StopServingResponse{snapshot_ref: ref, size_bytes: size}}
                  when is_binary(ref) and ref != "" <-
                    stop_fun.(channel, bank_request(vm_id)) do
@@ -967,8 +973,10 @@ defmodule Embervm.ServingSweeper do
        when is_binary(node_id) and is_binary(ref) and ref != "" do
     artifact = %ArtifactRef{kind: :ARTIFACT_KIND_SERVING, workload: workload, ref: ref}
     req = %EvictArtifactRequest{artifact: artifact, remote: true, trace: %Trace{workload: workload}}
+    # Dial the instance holding the banked serving bundle on disk, not the alias.
+    dial_key = dial_for_serving_bundle(state, node_id, ref)
 
-    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+    with {:ok, channel} <- safe_channel(state.channel_fun, dial_key) do
       try do
         state.evict_artifact_fun.(channel, req)
       rescue
@@ -986,8 +994,10 @@ defmodule Embervm.ServingSweeper do
   defp stop_serving_destroy(state, %{node_id: node_id, vm_id: vm_id})
        when is_binary(node_id) and is_binary(vm_id) do
     req = %StopServingRequest{trace: %Trace{}, vm_id: vm_id, mode: :STOP_SERVING_MODE_DESTROY}
+    # Dial the OWNING instance running this serving vm_id, not the node-name alias.
+    dial_key = dial_for_serving_vm(state, node_id, vm_id)
 
-    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+    with {:ok, channel} <- safe_channel(state.channel_fun, dial_key) do
       try do
         state.stop_serving_fun.(channel, req)
       rescue
@@ -1093,6 +1103,21 @@ defmodule Embervm.ServingSweeper do
     e -> {:error, {:channel_raised, e}}
   catch
     kind, reason -> {:error, {:channel_raised, {kind, reason}}}
+  end
+
+  # The channel key for a live serving-VM dial (bank/destroy): the OWNING instance
+  # reporting `vm_id` in serving_vms, else the node name (single-instance / legacy
+  # fallback). Instance-key unification (PR-B0b): a co-located node's node-name alias
+  # resolves to an arbitrary sibling brick, so a bank/destroy against the alias
+  # misroutes to a brick that never ran the VM.
+  defp dial_for_serving_vm(state, node_id, vm_id) do
+    Embervm.WakeInstance.dial_for_serving_vm(state.capacity_table, node_id, vm_id)
+  end
+
+  # The channel key for a serving-bundle dial (EvictArtifact SERVING): the instance
+  # holding the bundle on disk (serving_snapshots), else the node name.
+  defp dial_for_serving_bundle(state, node_id, snapshot_ref) do
+    Embervm.WakeInstance.dial_for_serving_bundle(state.capacity_table, node_id, snapshot_ref)
   end
 
   defp default_stop_serving(channel, req) do

--- a/projects/embervm/control/lib/embervm/session.ex
+++ b/projects/embervm/control/lib/embervm/session.ex
@@ -110,6 +110,12 @@ defmodule Embervm.Session do
       workload: Keyword.fetch!(opts, :workload),
       principal: Keyword.get(opts, :principal),
       node_id: Keyword.fetch!(opts, :node_id),
+      # The channel key this session's per-invoke SessionAssign / destroy dial. Under
+      # brick co-location several noded instances share node_id, and the node-name
+      # alias collapses to an arbitrary sibling; dial_id is the SPECIFIC instance
+      # running this session's VM (instance-key unification PR-B0b). Defaults to
+      # node_id so a legacy/single-instance caller (and older tests) is unaffected.
+      dial_id: Keyword.get(opts, :dial_id) || Keyword.fetch!(opts, :node_id),
       vm_id: Keyword.fetch!(opts, :vm_id),
       # Session config from the catalog entry: the invoke queue cap, the guest
       # round-trip timeout, and (PR-4) the idle-bank delay.
@@ -284,6 +290,7 @@ defmodule Embervm.Session do
   defp spawn_invoke_worker(state, req, enqueued_at) do
     owner = self()
     node_id = state.node_id
+    dial_id = state.dial_id
     vm_id = state.vm_id
     session_id = state.session_id
     workload = state.workload
@@ -325,6 +332,7 @@ defmodule Embervm.Session do
                          } do
           run_invoke(%{
             node_id: node_id,
+            dial_id: dial_id,
             vm_id: vm_id,
             session_id: session_id,
             workload: workload,
@@ -347,7 +355,7 @@ defmodule Embervm.Session do
   # failure, so it does NOT fail the session (the caller decides). Only a transport
   # error, a DEADLINE_EXCEEDED, or a daemon-flagged `suspect` VM fails the session.
   defp run_invoke(ctx) do
-    case ctx.channel_fun.(ctx.node_id) do
+    case ctx.channel_fun.(ctx.dial_id) do
       {:ok, channel} ->
         guest_req = %GuestRequest{
           method: Map.get(ctx.req, :method, "POST"),
@@ -369,7 +377,7 @@ defmodule Embervm.Session do
 
         case ctx.assign_fun.(channel, assign_req) do
           {:ok, %SessionAssignResponse{suspect: true}} ->
-            _ = ctx.invalidate_fun.(ctx.node_id, channel)
+            _ = ctx.invalidate_fun.(ctx.dial_id, channel)
             {:error, :suspect}
 
           {:ok, %SessionAssignResponse{response: %GuestResponse{} = resp, usage: usage}} ->
@@ -401,14 +409,14 @@ defmodule Embervm.Session do
   # invalidate-always, unchanged.
   defp maybe_invalidate(ctx, channel, %GRPC.RPCError{} = reason) do
     if Embervm.NodeChannel.transport_dead?(reason) do
-      _ = ctx.invalidate_fun.(ctx.node_id, channel)
+      _ = ctx.invalidate_fun.(ctx.dial_id, channel)
     end
 
     :ok
   end
 
   defp maybe_invalidate(ctx, channel, _reason) do
-    _ = ctx.invalidate_fun.(ctx.node_id, channel)
+    _ = ctx.invalidate_fun.(ctx.dial_id, channel)
     :ok
   end
 
@@ -455,7 +463,7 @@ defmodule Embervm.Session do
   end
 
   defp destroy_vm(state) do
-    case state.channel_fun.(state.node_id) do
+    case state.channel_fun.(state.dial_id) do
       {:ok, channel} ->
         try do
           state.destroy_fun.(channel, state.vm_id)

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -390,7 +390,7 @@ defmodule Embervm.SessionManager do
           # node regardless of which co-located instance banked it. On the single-
           # instance fleet dial_id resolves to the node's sole instance, so claim/prime
           # is output-equivalent to the old node-name dial: inert today.
-          register_and_start(state, workload, principal, entry, node_id, vm_id)
+          register_and_start(state, workload, principal, entry, node_id, vm_id, dial_id)
         else
           {:error, reason} ->
             audit_denial(state, principal, workload, reason)
@@ -523,7 +523,7 @@ defmodule Embervm.SessionManager do
   # PR-4 rebinds). If the process fails to start, the durable session is orphaned as
   # a live-but-unrouted row; PR-4 adoption rebinds it from NodeStatus, so we surface
   # the create as failed rather than leave the caller a token to a dead process.
-  defp register_and_start(state, workload, principal, entry, node_id, vm_id) do
+  defp register_and_start(state, workload, principal, entry, node_id, vm_id, dial_id) do
     attrs = %{
       tenant: state.tenant,
       principal: principal,
@@ -537,7 +537,7 @@ defmodule Embervm.SessionManager do
 
     case SessionStore.create(state.session_store, attrs) do
       {:ok, %{session_id: session_id} = created} ->
-        case start_session_process(state, session_id, workload, principal, entry, node_id, vm_id) do
+        case start_session_process(state, session_id, workload, principal, entry, node_id, vm_id, dial_id) do
           {:ok, _pid} ->
             {:ok, created}
 
@@ -551,13 +551,17 @@ defmodule Embervm.SessionManager do
     end
   end
 
-  defp start_session_process(state, session_id, workload, principal, entry, node_id, vm_id) do
+  defp start_session_process(state, session_id, workload, principal, entry, node_id, vm_id, dial_id) do
     child_opts =
       [
         session_id: session_id,
         workload: workload,
         principal: principal,
         node_id: node_id,
+        # The per-invoke dial key: the SPECIFIC co-located instance running this
+        # session's VM (instance-key unification PR-B0b), not the node-name alias.
+        # Falls back to node_id when the caller had no owning instance to resolve.
+        dial_id: dial_id || node_id,
         vm_id: vm_id,
         queue_cap: entry.session.invoke_queue_cap,
         timeout_ms: entry.timeout_ms,
@@ -587,10 +591,19 @@ defmodule Embervm.SessionManager do
   # entry, used by relight and adoption (which have the row, not the create args).
   # A catalog miss (workload deleted) is surfaced so the caller can fail the session
   # rather than start a process with no config.
-  defp start_session_from_row(state, session, node_id, vm_id) do
+  defp start_session_from_row(state, session, node_id, vm_id, dial_id) do
     case fetch_session_workload(state, session.workload) do
       {:ok, entry} ->
-        start_session_process(state, session.session_id, session.workload, session.principal, entry, node_id, vm_id)
+        start_session_process(
+          state,
+          session.session_id,
+          session.workload,
+          session.principal,
+          entry,
+          node_id,
+          vm_id,
+          dial_id
+        )
 
       {:error, reason} ->
         {:error, {:no_catalog_entry, reason}}
@@ -796,6 +809,10 @@ defmodule Embervm.SessionManager do
     workload = session.workload
     parent_base_ref = session.base_snapshot_ref
     generation = (session.generation || 0) + 1
+    # Dial the OWNING instance running this live vm_id, not the node-name alias
+    # (co-location made it point at an arbitrary sibling brick). Resolved on the owner
+    # so the worker reads a settled key; fail-open to node_id.
+    dial_key = Embervm.WakeInstance.dial_for_session_vm(state.capacity_table, node_id, vm_id)
 
     spawn(fn ->
       # A lifecycle span (Task 9). Idle-bank has no caller trace, so it is a root
@@ -810,7 +827,7 @@ defmodule Embervm.SessionManager do
                              "ember.generation" => generation
                            }
                          } do
-          with {:ok, channel} <- safe_channel(channel_fun, node_id),
+          with {:ok, channel} <- safe_channel(channel_fun, dial_key),
                {:ok, %BankResponse{snapshot_ref: ref, size_bytes: size}} when is_binary(ref) and ref != "" <-
                  safe_bank(bank_fun, channel, workload, session_id, vm_id) do
             Tracer.set_attributes(%{"ember.snapshot_bytes" => size})
@@ -933,7 +950,10 @@ defmodule Embervm.SessionManager do
             state
 
           [] ->
-            _ = start_session_from_row(state, session, node_id, vm_id)
+            # Resolve the co-located instance still running this live vm_id so the
+            # restarted process's per-invoke dial targets the owner, not the alias.
+            dial_id = Embervm.WakeInstance.dial_for_session_vm(state.capacity_table, node_id, vm_id)
+            _ = start_session_from_row(state, session, node_id, vm_id, dial_id)
             state
         end
 
@@ -1095,9 +1115,15 @@ defmodule Embervm.SessionManager do
         # restore FAILURE falls back to the normal node_for_relight path (fail-open).
         restore_target =
           case restore do
-            {:restore, restore_node_id, restore_ref} ->
-              case restore_bundle(state, restore_node_id, session.workload, restore_ref) do
-                :ok -> {:ok, restore_node_id}
+            {:restore, restore_node_id, restore_dial_id, restore_ref} ->
+              # Restore onto, and later relight from, the SAME co-located instance
+              # (restore_dial_id): a session snapshot is per-instance ON DISK
+              # (PR-2.5), so restoring onto one brick while the relight dials another
+              # leaves the relight's local disk empty. On a true local miss no
+              # instance reports the snapshot, so this is a mem-eligible pick that both
+              # the restore and the relight agree on.
+              case restore_bundle(state, session.node_id, restore_dial_id, session.workload, restore_ref) do
+                :ok -> {:ok, restore_dial_id}
                 _ -> :none
               end
 
@@ -1107,15 +1133,19 @@ defmodule Embervm.SessionManager do
 
         outcome =
           case relight_node(restore_target, session, capacity_table) do
-            {:ok, node_id} ->
+            {:ok, dial_id} ->
               t0 = clock.()
 
-              with {:ok, channel} <- safe_channel(channel_fun, node_id),
+              # dial_id is the OWNING instance the relight lands on (instance-key
+              # unification PR-B0b); the durable row keeps the NODE name (session.
+              # node_id), which adoption/drain read node-scoped. On the single-instance
+              # fleet dial_id == node_id, so this is inert there.
+              with {:ok, channel} <- safe_channel(channel_fun, dial_id),
                    {:ok, %RelightResponse{vm_id: vm_id}} when is_binary(vm_id) and vm_id != "" <-
                      safe_relight(relight_fun, channel, session) do
                 relight_ms = clock.() - t0
                 Tracer.set_attributes(%{"ember.relight_ms" => relight_ms})
-                {:ok, node_id, vm_id, relight_ms}
+                {:ok, session.node_id, vm_id, relight_ms, dial_id}
               else
                 {:error, reason} -> classify_relight_error(reason)
                 other -> classify_relight_error({:relight_failed, other})
@@ -1152,9 +1182,36 @@ defmodule Embervm.SessionManager do
 
     if is_binary(node_id) and node_id != "" and is_binary(snapshot_ref) and snapshot_ref != "" and
          not bundle_local?(state, node_id, snapshot_ref) and store_reachable?(state, node_id) do
-      {:restore, node_id, snapshot_ref}
+      # The co-located instance to restore onto AND then relight from. On a true
+      # local miss no instance reports the snapshot, so WakeInstance.select falls to a
+      # mem-eligible pick sized for the session's mem_mib (the owning-instance branch
+      # would apply only if an instance still reported it). Fail-open: no eligible
+      # instance leaves the bare node_id, byte-identical to pre-co-location behaviour.
+      {:restore, node_id, restore_dial_id(state, session, node_id, snapshot_ref), snapshot_ref}
     else
       :skip
+    end
+  end
+
+  # The instance key to restore the session bundle onto (and relight from). Prefers
+  # the instance still reporting the snapshot; else a mem-eligible pick (the true
+  # local-miss case), sized by the catalog mem_mib; else the bare node_id.
+  defp restore_dial_id(state, session, node_id, snapshot_ref) do
+    need_mib =
+      case WorkloadCatalog.fetch(state.catalog_table, Map.get(session, :workload)) do
+        {:ok, entry} -> Map.get(entry, :mem_mib) || 512
+        _ -> 512
+      end
+
+    case Embervm.WakeInstance.select(node_id,
+           table: state.capacity_table,
+           workload: Map.get(session, :workload),
+           need_mib: need_mib,
+           warmth_key: :session_snapshots,
+           warmth_ref: snapshot_ref
+         ) do
+      {:ok, dial_id} -> dial_id
+      {:error, _} -> node_id
     end
   end
 
@@ -1191,10 +1248,10 @@ defmodule Embervm.SessionManager do
   # caller falls through to node_for_relight's existing check, which the daemon (or
   # the placement layer) degrades to snapshot_lost exactly as it would without this
   # feature (fail-open warmth). Idempotent on the daemon side.
-  defp restore_bundle(state, node_id, workload, snapshot_ref) do
+  defp restore_bundle(state, node_id, dial_id, workload, snapshot_ref) do
     ref = %ArtifactRef{kind: :ARTIFACT_KIND_SESSION, workload: workload, ref: snapshot_ref}
 
-    case safe_restore_artifact(state, node_id, ref) do
+    case safe_restore_artifact(state, node_id, dial_id, ref) do
       {:ok, resp} ->
         record_restore(state, workload, :ARTIFACT_KIND_SESSION, snapshot_ref, resp)
         :ok
@@ -1210,11 +1267,15 @@ defmodule Embervm.SessionManager do
     end
   end
 
-  defp safe_restore_artifact(state, node_id, %ArtifactRef{} = ref) do
+  defp safe_restore_artifact(state, node_id, dial_id, %ArtifactRef{} = ref) do
     req = %RestoreArtifactRequest{artifact: ref, trace: %Trace{workload: ref.workload}}
+    # Stamp the vendor from the NODE (a node-scoped fact shared across its instances),
+    # but DIAL the specific owning/target instance (dial_id): the restore must land on
+    # the same co-located instance the relight then dials (PR-B0b), mirroring
+    # ServingManager.safe_restore_artifact.
     req = Embervm.RestoreVendor.stamp(state.capacity_table, node_id, req)
 
-    with {:ok, channel} <- safe_channel(state.channel_fun, node_id) do
+    with {:ok, channel} <- safe_channel(state.channel_fun, dial_id) do
       # The `artifact_restore` span (Task 11): a child span around the
       # RestoreArtifact RPC (the restore-on-miss read path). Identity up front,
       # bytes-moved/skipped stamped from the response.
@@ -1342,7 +1403,7 @@ defmodule Embervm.SessionManager do
 
   defp finish_relight_active(state, session_id, outcome) do
     case outcome do
-      {:ok, node_id, vm_id, relight_ms} ->
+      {:ok, node_id, vm_id, relight_ms, dial_id} ->
         session = get_session!(state, session_id)
 
         _ =
@@ -1357,7 +1418,7 @@ defmodule Embervm.SessionManager do
 
         state = clear_bank_failures(state, session_id)
 
-        case start_session_from_row(state, %{session | node_id: node_id, vm_id: vm_id}, node_id, vm_id) do
+        case start_session_from_row(state, %{session | node_id: node_id, vm_id: vm_id}, node_id, vm_id, dial_id) do
           {:ok, pid} ->
             Logger.info("embervm session relit",
               session_id: session_id,
@@ -1472,10 +1533,22 @@ defmodule Embervm.SessionManager do
     evict_orphan_snapshots(state, facts)
   end
 
-  # vm session_id -> {node_id, vm_id}; snapshot session_id -> {node_id, snapshot_ref}.
+  # vm session_id -> {node_id, vm_id, dial_id}; snapshot session_id ->
+  # {node_id, snapshot_ref}. dial_id is the REPORTING instance's channel key (its
+  # instance_id, else the node name) so an adopted live session dials the co-located
+  # instance actually running the VM, not the node-name alias (PR-B0b).
   defp index_session_vms(facts) do
     for f <- facts, v <- Map.get(f, :session_vms, []) || [], into: %{} do
-      {v.session_id, {f.configured_id, v.vm_id}}
+      {v.session_id, {f.configured_id, v.vm_id, fact_dial_id(f)}}
+    end
+  end
+
+  # The channel key for a capacity fact: its instance_id when present, else the node
+  # name (legacy/single-instance facts resolve via the node-name alias, unchanged).
+  defp fact_dial_id(fact) do
+    case Map.get(fact, :instance_id) do
+      id when is_binary(id) and id != "" -> id
+      _ -> Map.get(fact, :configured_id)
     end
   end
 
@@ -1501,8 +1574,8 @@ defmodule Embervm.SessionManager do
       # The node reports a LIVE VM for this session: rebind it (residency + process),
       # regardless of whether ETS thinks it is running/banking/relighting.
       Map.has_key?(live_vms, sid) ->
-        {node_id, vm_id} = Map.fetch!(live_vms, sid)
-        adopt_live(state, session, node_id, vm_id)
+        {node_id, vm_id, dial_id} = Map.fetch!(live_vms, sid)
+        adopt_live(state, session, node_id, vm_id, dial_id)
 
       # No live VM, but the node reports its SNAPSHOT: it is banked (or a bank/relight
       # that did not finish leaving only the snapshot). Heal ETS to banked.
@@ -1525,7 +1598,7 @@ defmodule Embervm.SessionManager do
   # Rebind a live session VM to a fresh process (idempotent). Forces ETS to running
   # from node truth (a banking/relighting/creating limbo whose node actually holds a
   # live VM), writes the residency fact + vm_id, and starts a process if none runs.
-  defp adopt_live(state, session, node_id, vm_id) do
+  defp adopt_live(state, session, node_id, vm_id, dial_id) do
     SessionStore.adopt_state(state.session_store, session.session_id, :running)
     SessionStore.adopt_residency(state.session_store, session.session_id, node_id, vm_id)
 
@@ -1536,7 +1609,7 @@ defmodule Embervm.SessionManager do
         state
 
       [] ->
-        case start_session_from_row(state, %{session | node_id: node_id, vm_id: vm_id}, node_id, vm_id) do
+        case start_session_from_row(state, %{session | node_id: node_id, vm_id: vm_id}, node_id, vm_id, dial_id) do
           {:ok, _pid} ->
             Logger.info("embervm session adopted (live)", session_id: session.session_id, node_id: node_id)
             state
@@ -1799,11 +1872,15 @@ defmodule Embervm.SessionManager do
 
   defp evict_snapshot_on_node(state, node_id, snapshot_ref, _reported_id, workload)
        when is_binary(node_id) and is_binary(snapshot_ref) do
+    # Dial the instance holding this banked session bundle on disk (session_snapshots),
+    # not the node-name alias (co-location safe, PR-B0b). Fail-open to node_id.
+    dial_key = Embervm.WakeInstance.dial_for_session_bundle(state.capacity_table, node_id, snapshot_ref)
+
     # A lifecycle span (Task 9): reclaiming a snapshot bundle from node disk. Root
     # span (eviction is sweep/adoption-driven, no caller trace).
     Tracer.with_span "embervm.session.evict",
                      %{attributes: %{"ember.node_id" => node_id}} do
-      with {:ok, channel} <- state.channel_fun.(node_id) do
+      with {:ok, channel} <- state.channel_fun.(dial_key) do
         req = %EvictSnapshotRequest{trace: %Trace{}, snapshot_ref: snapshot_ref}
 
         try do
@@ -1819,8 +1896,8 @@ defmodule Embervm.SessionManager do
       # EvictSnapshot, on every eviction trigger (banked TTL, disk pressure,
       # destroy, expiry, orphan sweep) since they all funnel through here. Sessions
       # carry no volume/generation, so no pairing guard applies (unlike the
-      # stateful class's volume-generation guard).
-      _ = evict_remote_bundle(state, node_id, workload, snapshot_ref)
+      # stateful class's volume-generation guard). Dial the SAME owning instance.
+      _ = evict_remote_bundle(state, dial_key, workload, snapshot_ref)
 
       :ok
     end
@@ -1967,7 +2044,10 @@ defmodule Embervm.SessionManager do
   end
 
   defp destroy_vm(state, %{node_id: node_id, vm_id: vm_id}) when is_binary(node_id) and is_binary(vm_id) do
-    with {:ok, channel} <- state.channel_fun.(node_id) do
+    # Dial the OWNING instance running this live vm_id, not the node-name alias.
+    dial_key = Embervm.WakeInstance.dial_for_session_vm(state.capacity_table, node_id, vm_id)
+
+    with {:ok, channel} <- state.channel_fun.(dial_key) do
       opts = state.session_opts
 
       destroy_fun =

--- a/projects/embervm/control/lib/embervm/session_placement.ex
+++ b/projects/embervm/control/lib/embervm/session_placement.ex
@@ -66,20 +66,36 @@ defmodule Embervm.SessionPlacement do
   end
 
   @doc """
-  Resolves the node a BANKED `session` relights on: the session's recorded
-  `node_id`, CONFIRMED to be a ready node currently reporting the session's
-  `snapshot_ref` in its `session_snapshots` inventory. Returns `{:ok, node_id}` or
-  `{:error, :snapshot_lost}` when no ready node holds the snapshot (node death,
-  out-of-band eviction). Placement never picks a DIFFERENT node for a relight: a
-  node-local snapshot is restorable on exactly its owning node (standing decision 3).
+  Resolves the dial key a BANKED `session` relights on: the specific INSTANCE on the
+  session's recorded `node_id` currently reporting the session's `snapshot_ref` in
+  its `session_snapshots` inventory. Returns `{:ok, dial_key}` (the owning instance's
+  `instance_id`, or its node name for a legacy/single-instance fact) or
+  `{:error, :snapshot_lost}` when no instance on the node holds the snapshot (node
+  death, out-of-band eviction).
+
+  Instance-key unification (PR-B0b): a session's snapshot is per-instance ON DISK
+  (PR-2.5), so an established session's next invoke must relight against the INSTANCE
+  that banked it, not the collapsing node-name alias (co-location made the alias
+  point at an arbitrary sibling brick that never held the snapshot). Placement still
+  never picks a DIFFERENT node (a node-local snapshot is restorable on exactly its
+  owning node, standing decision 3); this only pins the specific co-located instance.
   """
   @spec node_for_relight(map(), atom()) :: {:ok, String.t()} | {:error, :snapshot_lost}
   def node_for_relight(session, capacity_table \\ NodeCapacity.table()) do
     snapshot_ref = Map.get(session, :snapshot_ref)
     node_id = Map.get(session, :node_id)
 
-    if is_binary(snapshot_ref) and snapshot_ref != "" and node_reports_snapshot?(capacity_table, node_id, snapshot_ref) do
-      {:ok, node_id}
+    if is_binary(snapshot_ref) and snapshot_ref != "" do
+      case Embervm.WakeInstance.owning_instance_for(
+             capacity_table,
+             node_id,
+             :session_snapshots,
+             :snapshot_ref,
+             snapshot_ref
+           ) do
+        {:ok, dial_key} -> {:ok, dial_key}
+        :none -> {:error, :snapshot_lost}
+      end
     else
       {:error, :snapshot_lost}
     end
@@ -133,20 +149,4 @@ defmodule Embervm.SessionPlacement do
     :erlang.phash2({key, node_id}, 4_294_967_296)
   end
 
-  # Whether a READY node with the given id currently reports `snapshot_ref` among
-  # its banked-snapshot inventory. A node absent from the (fail-closed) capacity
-  # table is not ready, so a session on a down node reads as snapshot_lost.
-  defp node_reports_snapshot?(_capacity_table, node_id, _snapshot_ref) when not is_binary(node_id), do: false
-
-  defp node_reports_snapshot?(capacity_table, node_id, snapshot_ref) do
-    case NodeCapacity.fetch(capacity_table, node_id) do
-      {:ok, fact} ->
-        fact
-        |> Map.get(:session_snapshots, [])
-        |> Enum.any?(fn snap -> Map.get(snap, :snapshot_ref) == snapshot_ref end)
-
-      :error ->
-        false
-    end
-  end
 end

--- a/projects/embervm/control/lib/embervm/stateful_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/stateful_sweeper.ex
@@ -387,11 +387,11 @@ defmodule Embervm.StatefulSweeper do
   # transition + inflight release on this serialized process. ip/port are the
   # endpoint captured BEFORE unpublish cleared the ETS row (see
   # spawn_bank_worker/2's comment); needed to restore it on a failed bank.
-  def handle_info({:bank_done, instance_id, node_id, vm_id, ip, port, workload, outcome}, state) do
+  def handle_info({:bank_done, instance_id, node_id, vm_id, ip, port, workload, owner_resolved, outcome}, state) do
     # Atomic bank finished: clear any drain mark (interruptible workloads clear at
     # resolve_done instead, after decide_resolve has read it).
     state = clear_draining(state, workload)
-    {:noreply, finish_bank(state, instance_id, node_id, vm_id, ip, port, workload, outcome)}
+    {:noreply, finish_bank(state, instance_id, node_id, vm_id, ip, port, workload, owner_resolved, outcome)}
   end
 
   # The CHECKPOINT phase finished (ADR embervm/008): mark :checkpoint_ready and
@@ -939,6 +939,13 @@ defmodule Embervm.StatefulSweeper do
     # fact, preserving single-instance behaviour exactly. Resolved here on the
     # owner process so the worker reads a settled key.
     dial_key = dial_for_vm(state, node_id, vm_id)
+    # Whether the dial resolved to a SPECIFIC owning instance (a live owner fact
+    # reported the vm_id) versus falling open to the bare node name. Task #12: an
+    # unknown-vm FAILED_PRECONDITION only terminalizes the instance when we dialled
+    # the owner; a fail-open dial to the node alias could be hitting the WRONG sibling
+    # (a stale-fact race), so terminalizing there could fail a still-live instance and
+    # split-brain a second VM on the same volume. See finish_bank_active.
+    owner_resolved = dial_key != node_id
     ip = instance.ip
     port = instance.port
 
@@ -972,7 +979,7 @@ defmodule Embervm.StatefulSweeper do
           end
         end
 
-      send(owner, {:bank_done, instance_id, node_id, vm_id, ip, port, workload, outcome})
+      send(owner, {:bank_done, instance_id, node_id, vm_id, ip, port, workload, owner_resolved, outcome})
     end)
   end
 
@@ -1046,7 +1053,7 @@ defmodule Embervm.StatefulSweeper do
   #     (snapshot fact + generation, the pair-key baseline);
   #   * on failure: `banking -[bank_abort]-> serving` (ETS-only, VM intact) and
   #     republish (a failed bank must not leave a warm VM dark).
-  defp finish_bank(state, instance_id, node_id, vm_id, ip, port, workload, outcome) do
+  defp finish_bank(state, instance_id, node_id, vm_id, ip, port, workload, owner_resolved, outcome) do
     state =
       state
       |> decr_bank_inflight(node_id)
@@ -1058,14 +1065,14 @@ defmodule Embervm.StatefulSweeper do
         state
 
       {:ok, instance} ->
-        finish_bank_active(state, instance, node_id, vm_id, ip, port, workload, outcome)
+        finish_bank_active(state, instance, node_id, vm_id, ip, port, workload, owner_resolved, outcome)
 
       :error ->
         state
     end
   end
 
-  defp finish_bank_active(state, instance, node_id, _vm_id, _ip, _port, workload, {:ok, ref, size, generation}) do
+  defp finish_bank_active(state, instance, node_id, _vm_id, _ip, _port, workload, _owner_resolved, {:ok, ref, size, generation}) do
     _ =
       StatefulStore.transition(
         state.store,
@@ -1090,15 +1097,24 @@ defmodule Embervm.StatefulSweeper do
   end
 
   # UNKNOWN-VM FAILED_PRECONDITION (gRPC status 9): the daemon we dialled does not
-  # own this VM ("not bankable / unknown vm"). Do NOT resurrect the endpoint into
-  # the fan-out (blind republish looped this at the 1 s sweep frequency before the
-  # dial-key fix, and even with it a genuinely-gone VM must not linger dark): fail
-  # the instance (banking -> failed, durable stateful_failed) so the wake path
-  # cold-boots a fresh one on the next connection. No backoff needed: the instance
-  # is terminal, so idle_bank_pass never re-selects it.
-  defp finish_bank_active(state, instance, node_id, vm_id, ip, port, workload, {:error, reason}) do
-    if failed_precondition?(reason) do
-      Logger.warning("embervm stateful: bank rejected unknown vm, failing instance",
+  # own this VM ("not bankable / unknown vm").
+  #
+  # Terminalize (banking -> failed, durable stateful_failed, so the wake path
+  # cold-boots a fresh one) ONLY when the dial was OWNER-RESOLVED: we reached the
+  # exact instance whose capacity fact reported this vm_id, so its "unknown vm" reply
+  # is authoritative that the VM is genuinely gone. No backoff needed: the instance is
+  # terminal, so idle_bank_pass never re-selects it.
+  #
+  # When the dial FELL OPEN to the bare node name (no owner fact reported the vm_id,
+  # owner_resolved false), an unknown-vm reply is NOT authoritative: under co-location
+  # the node-name alias can resolve to the wrong sibling brick (a stale-fact race
+  # where the owner's fact has not landed yet), so terminalizing here could fail a
+  # still-live instance and cold-boot a SECOND VM on the same volume (split-brain).
+  # Treat it as a NON-terminal error instead: abort back to the fan-out and arm the
+  # backoff, so the next sweep re-resolves the dial once the owner fact settles.
+  defp finish_bank_active(state, instance, node_id, vm_id, ip, port, workload, owner_resolved, {:error, reason}) do
+    if failed_precondition?(reason) and owner_resolved do
+      Logger.warning("embervm stateful: bank rejected unknown vm on owner-resolved dial, failing instance",
         instance_id: instance.instance_id,
         workload: workload,
         reason: inspect(reason)

--- a/projects/embervm/control/lib/embervm/wake_instance.ex
+++ b/projects/embervm/control/lib/embervm/wake_instance.ex
@@ -62,7 +62,7 @@ defmodule Embervm.WakeInstance do
   alias Embervm.{BrickLedger, NodeCapacity}
 
   @typedoc "A warmth-inventory field on a per-instance capacity fact + the id key its rows carry."
-  @type warmth_key :: :serving_snapshots | :stateful_bundles | :group_bundle_sets
+  @type warmth_key :: :serving_snapshots | :stateful_bundles | :group_bundle_sets | :session_snapshots
 
   @doc """
   Select the instance on `node_id` a wake must dial. Returns `{:ok, instance_id}`
@@ -113,18 +113,8 @@ defmodule Embervm.WakeInstance do
   @spec dial_for_vm(atom(), String.t(), String.t()) :: String.t()
   def dial_for_vm(table \\ NodeCapacity.table(), node_id, vm_id)
 
-  def dial_for_vm(table, node_id, vm_id)
-      when is_binary(node_id) and is_binary(vm_id) and vm_id != "" do
-    table
-    |> instances_on(node_id)
-    |> Enum.find(fn fact -> fact_reports_vm?(fact, vm_id) end)
-    |> case do
-      nil -> node_id
-      fact -> dial_id(fact)
-    end
-  end
-
-  def dial_for_vm(_table, node_id, _vm_id), do: node_id
+  def dial_for_vm(table, node_id, vm_id),
+    do: dial_owning(table, node_id, :stateful_vms, :vm_id, vm_id)
 
   @doc """
   The channel key of the instance on `node_id` currently HOLDING the banked bundle
@@ -135,20 +125,121 @@ defmodule Embervm.WakeInstance do
   facts, or a bundle not re-reported yet) exactly like `dial_for_vm/3`.
   """
   @spec dial_for_bundle(atom(), String.t(), String.t()) :: String.t()
-  def dial_for_bundle(table \\ NodeCapacity.table(), node_id, snapshot_ref)
+  def dial_for_bundle(table \\ NodeCapacity.table(), node_id, snapshot_ref),
+    do: dial_owning(table, node_id, :stateful_bundles, :snapshot_ref, snapshot_ref)
 
-  def dial_for_bundle(table, node_id, snapshot_ref)
-      when is_binary(node_id) and is_binary(snapshot_ref) and snapshot_ref != "" do
+  @doc """
+  The channel key of the instance on `node_id` currently RUNNING the SERVING VM
+  `vm_id` (its `serving_vms` report it), or the bare `node_id` when none is found.
+  The serving-sweeper's live-VM dial resolution (StopServing BANK/DESTROY): a serving
+  VM lives on ONE instance, so co-location's node-name alias misroutes to a sibling.
+  Same fail-open-to-node_id contract as `dial_for_vm/3`.
+  """
+  @spec dial_for_serving_vm(atom(), String.t(), String.t()) :: String.t()
+  def dial_for_serving_vm(table \\ NodeCapacity.table(), node_id, vm_id),
+    do: dial_owning(table, node_id, :serving_vms, :vm_id, vm_id)
+
+  @doc """
+  The channel key of the instance on `node_id` currently RUNNING the SESSION VM
+  `vm_id` (its `session_vms` report it), or the bare `node_id` when none is found.
+  The session restart/adoption dial resolution: a session's live VM is on ONE
+  instance, so co-location's node-name alias misroutes to a sibling. Same fail-open-
+  to-node_id contract as `dial_for_vm/3`.
+  """
+  @spec dial_for_session_vm(atom(), String.t(), String.t()) :: String.t()
+  def dial_for_session_vm(table \\ NodeCapacity.table(), node_id, vm_id),
+    do: dial_owning(table, node_id, :session_vms, :vm_id, vm_id)
+
+  @doc """
+  The channel key of the instance on `node_id` HOLDING the banked SERVING snapshot
+  `snapshot_ref` on disk (its `serving_snapshots` report it), or the bare `node_id`
+  when none is found. The serving evict dial resolution (EvictArtifact SERVING). Same
+  fail-open-to-node_id contract as `dial_for_bundle/3`.
+  """
+  @spec dial_for_serving_bundle(atom(), String.t(), String.t()) :: String.t()
+  def dial_for_serving_bundle(table \\ NodeCapacity.table(), node_id, snapshot_ref),
+    do: dial_owning(table, node_id, :serving_snapshots, :snapshot_ref, snapshot_ref)
+
+  @doc """
+  The channel key of the instance on `node_id` HOLDING the banked SESSION snapshot
+  `snapshot_ref` on disk (its `session_snapshots` report it), or the bare `node_id`
+  when none is found. The session evict dial resolution (EvictSnapshot / EvictArtifact
+  SESSION). Same fail-open-to-node_id contract as `dial_for_bundle/3`.
+  """
+  @spec dial_for_session_bundle(atom(), String.t(), String.t()) :: String.t()
+  def dial_for_session_bundle(table \\ NodeCapacity.table(), node_id, snapshot_ref),
+    do: dial_owning(table, node_id, :session_snapshots, :snapshot_ref, snapshot_ref)
+
+  @doc """
+  The channel key of the instance on `node_id` OWNING the composite group instance
+  `group_instance_id` (it reports the id in either `group_member_vms`, a live group,
+  or `group_bundle_sets`, a banked group), or the bare `node_id` when none is found.
+  The group-sweeper's dial resolution (StopGroupMember/DeleteGroupNetwork/Evict): a
+  group's members are all co-located on ONE instance, keyed by the durable
+  group_instance_id, so the node-name alias misroutes to a sibling under co-location.
+  Same fail-open-to-node_id contract as `dial_for_vm/3`.
+  """
+  @spec dial_for_group(atom(), String.t(), String.t()) :: String.t()
+  def dial_for_group(table \\ NodeCapacity.table(), node_id, group_instance_id)
+
+  def dial_for_group(table, node_id, group_instance_id)
+      when is_binary(node_id) and is_binary(group_instance_id) and group_instance_id != "" do
     table
     |> instances_on(node_id)
-    |> Enum.find(fn fact -> fact_reports_warmth?(fact, :stateful_bundles, snapshot_ref, :snapshot_ref) end)
+    |> Enum.find(fn fact ->
+      fact_reports_warmth?(fact, :group_member_vms, group_instance_id, :group_instance_id) or
+        fact_reports_warmth?(fact, :group_bundle_sets, group_instance_id, :group_instance_id)
+    end)
     |> case do
       nil -> node_id
       fact -> dial_id(fact)
     end
   end
 
-  def dial_for_bundle(_table, node_id, _ref), do: node_id
+  def dial_for_group(_table, node_id, _group_instance_id), do: node_id
+
+  @doc """
+  The channel key of the instance on `node_id` HOLDING `ref` in the inventory list
+  `key` under `match_field`, as `{:ok, dial_key}`, or `:none` when no instance on the
+  node reports it. Unlike the `dial_for_*` helpers this fails CLOSED (`:none`, not the
+  node name), for a caller whose absence must be a distinct outcome (the session
+  relight's `snapshot_lost`, where a missing snapshot must 410, not silently dial the
+  node alias). The dial key is still the owning instance_id (co-location safe).
+  """
+  @spec owning_instance_for(atom(), String.t(), atom(), atom(), String.t()) ::
+          {:ok, String.t()} | :none
+  def owning_instance_for(table \\ NodeCapacity.table(), node_id, key, match_field, ref)
+
+  def owning_instance_for(table, node_id, key, match_field, ref)
+      when is_binary(node_id) and is_binary(ref) and ref != "" do
+    table
+    |> instances_on(node_id)
+    |> Enum.find(fn fact -> fact_reports_warmth?(fact, key, ref, match_field) end)
+    |> case do
+      nil -> :none
+      fact -> {:ok, dial_id(fact)}
+    end
+  end
+
+  def owning_instance_for(_table, _node_id, _key, _match_field, _ref), do: :none
+
+  # The owning instance on `node_id` whose capacity fact reports `ref` in the
+  # inventory list `key` under `field`, else the bare `node_id` (legacy/single-
+  # instance fact, or the row not re-reported yet). The shared core of the
+  # instance-key dial resolution: every stateful/serving live-VM and bundle dial
+  # routes through here so they cannot drift on the fail-open contract.
+  defp dial_owning(table, node_id, key, field, ref)
+       when is_binary(node_id) and is_binary(ref) and ref != "" do
+    table
+    |> instances_on(node_id)
+    |> Enum.find(fn fact -> fact_reports_warmth?(fact, key, ref, field) end)
+    |> case do
+      nil -> node_id
+      fact -> dial_id(fact)
+    end
+  end
+
+  defp dial_owning(_table, node_id, _key, _field, _ref), do: node_id
 
   # The instance on `node_id` whose warmth inventory reports this wake's ref: a
   # relight MUST land on the instance that banked the bundle (per-instance-on-disk,
@@ -225,15 +316,6 @@ defmodule Embervm.WakeInstance do
     |> Map.get(warmth_key, [])
     |> Kernel.||([])
     |> Enum.any?(fn row -> Map.get(row, match_field) == ref end)
-  end
-
-  # Whether this instance's per-instance capacity fact reports `vm_id` as a live
-  # stateful VM it is running (the sweeper's live-VM dial resolution).
-  defp fact_reports_vm?(fact, vm_id) do
-    fact
-    |> Map.get(:stateful_vms, [])
-    |> Kernel.||([])
-    |> Enum.any?(fn row -> Map.get(row, :vm_id) == vm_id end)
   end
 
   # The dial key for a capacity fact: its instance_id when present, else the node

--- a/projects/embervm/control/test/embervm/group_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/group_sweeper_test.exs
@@ -128,7 +128,7 @@ defmodule Embervm.GroupSweeperTest do
       stats_base: Keyword.get(opts, :stats_base, "http://serving:9902"),
       splices_table: splices,
       bank_fun: bank_fun,
-      channel_fun: fn _node -> {:ok, :ch} end,
+      channel_fun: Keyword.get(opts, :channel_fun, fn _node -> {:ok, :ch} end),
       stop_group_member_fun: stop_group_member_fun,
       delete_group_network_fun: delete_group_network_fun,
       evict_snapshot_fun: evict_snapshot_fun,
@@ -717,5 +717,61 @@ defmodule Embervm.GroupSweeperTest do
     set_scrape(ctx, reading("group-5410", 1, 3))
     assert :ok = GroupSweeper.sweep(ctx.sweeper)
     assert {:ok, %{state: :running}} = GroupStore.get(ctx.store, "gi-1")
+  end
+
+  # -- instance-key unification (PR-B0b) ---------------------------------------
+
+  # A per-instance capacity fact carrying the per-instance group inventory the
+  # sweeper's dial resolution reads (keyed on group_instance_id).
+  defp group_brick(ctx, node_id, pod_uid, opts) do
+    NodeCapacity.put(ctx.cap_table, {node_id, pod_uid}, %{
+      configured_id: node_id,
+      node_id: node_id,
+      pod_uid: pod_uid,
+      instance_id: "#{node_id}/#{pod_uid}",
+      serving_subnet_cidr: "10.98.0.0/24",
+      max_live_vms: 8,
+      live_vms: 0,
+      workloads: %{},
+      group_member_vms: Keyword.get(opts, :group_member_vms, []),
+      group_bundle_sets: Keyword.get(opts, :group_bundle_sets, [])
+    })
+  end
+
+  test "group teardown dials the OWNER instance_id even when the node-name alias points at a sibling" do
+    {:ok, dialed} = Agent.start_link(fn -> [] end)
+
+    capture_channel = fn key ->
+      Agent.update(dialed, &[key | &1])
+      {:ok, :ch}
+    end
+
+    ctx = start_stack(channel_fun: capture_channel)
+    group_workload(ctx, "grp-a", 5410, %{max_lifetime_seconds: 100})
+
+    # Two co-located instances on node-4. pod-owner reports the live group gi-1;
+    # pod-sibling does not (the last registrant the node alias would collapse to). The
+    # destroy (StopGroupMember + DeleteGroupNetwork) must dial pod-owner.
+    group_brick(ctx, "node-4", "pod-sibling", group_member_vms: [])
+
+    group_brick(ctx, "node-4", "pod-owner",
+      group_member_vms: [
+        %{vm_id: "vm-gi-1-a", group_instance_id: "gi-1", member_name: "a", ip: "10.101.0.10", healthy: true},
+        %{vm_id: "vm-gi-1-b", group_instance_id: "gi-1", member_name: "b", ip: "10.101.0.11", healthy: true}
+      ]
+    )
+
+    running_group(ctx, "gi-1", "grp-a")
+
+    advance(ctx.clock_agent, 200_000)
+    set_scrape(ctx, reading("group-5410", 0, 0))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    assert {:ok, %{state: :destroyed}} = GroupStore.get(ctx.store, "gi-1")
+
+    keys = Agent.get(dialed, & &1)
+    assert "node-4/pod-owner" in keys
+    refute "node-4" in keys
+    refute "node-4/pod-sibling" in keys
   end
 end

--- a/projects/embervm/control/test/embervm/serving_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/serving_sweeper_test.exs
@@ -106,7 +106,7 @@ defmodule Embervm.ServingSweeperTest do
         clock: clock(clock_agent),
         scrape_fun: fn _url -> Agent.get(scrape_agent, & &1) end,
         stats_base: Keyword.get(opts, :stats_base, "http://serving:9902"),
-        channel_fun: fn _node -> {:ok, :ch} end,
+        channel_fun: Keyword.get(opts, :channel_fun, fn _node -> {:ok, :ch} end),
         stop_serving_fun: stop_serving_fun,
         timer_fun: timer_fun,
         bank_concurrency: Keyword.get(opts, :bank_concurrency, 1),
@@ -770,5 +770,60 @@ defmodule Embervm.ServingSweeperTest do
     :sys.replace_state(ctx.sweeper, fn s -> %{s | status_writer: fn _ns, _n, _m -> raise "boom" end} end)
 
     assert :ok = ServingSweeper.sweep(ctx.sweeper)
+  end
+
+  # -- instance-key unification (PR-B0b) ---------------------------------------
+
+  # A per-instance capacity fact (keyed by {node, pod_uid}) carrying the per-instance
+  # live serving-VM inventory the sweeper's dial resolution reads.
+  defp put_serving_brick(ctx, node_id, pod_uid, opts) do
+    NodeCapacity.put(ctx.cap_table, {node_id, pod_uid}, %{
+      configured_id: node_id,
+      node_id: node_id,
+      pod_uid: pod_uid,
+      instance_id: "#{node_id}/#{pod_uid}",
+      serving_subnet_cidr: "10.99.0.0/24",
+      max_live_vms: 8,
+      live_vms: 0,
+      workloads: %{},
+      serving_vms: Keyword.get(opts, :serving_vms, []),
+      serving_snapshots: Keyword.get(opts, :serving_snapshots, [])
+    })
+  end
+
+  test "the serving bank dials the OWNER instance_id even when the node-name alias points at a sibling" do
+    {:ok, dialed} = Agent.start_link(fn -> [] end)
+
+    capture_channel = fn key ->
+      Agent.update(dialed, &[key | &1])
+      {:ok, :ch}
+    end
+
+    ctx = start_stack(channel_fun: capture_channel)
+    serving_workload(ctx, "wl-a", %{min_instances: 0, idle_bank_seconds: 60, drain_seconds: 5})
+
+    # Two co-located instances on node-4. pod-owner RUNS vm-1; pod-sibling does not (it
+    # is the last registrant the node-name alias would collapse to). The bank must dial
+    # pod-owner, never the alias.
+    put_serving_brick(ctx, "node-4", "pod-sibling", serving_vms: [])
+
+    put_serving_brick(ctx, "node-4", "pod-owner",
+      serving_vms: [%{vm_id: "vm-1", workload: "wl-a", ip: "10.99.0.5", port: 8080, healthy: true}]
+    )
+
+    published_instance(ctx, "srv-1", "wl-a", "vm-1", "10.99.0.5")
+
+    set_scrape(ctx, {:ok, %{"serve|wl-a" => 0}})
+    ServingSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 70_000)
+    set_scrape(ctx, {:ok, %{"serve|wl-a" => 0}})
+    ServingSweeper.sweep(ctx.sweeper)
+
+    fire_drain(ctx, "srv-1")
+    wait_until(ctx, fn -> match?({:ok, %{state: :banked}}, ServingStore.get(ctx.store, "srv-1")) end)
+
+    assert "node-4/pod-owner" in Agent.get(dialed, & &1)
+    refute "node-4" in Agent.get(dialed, & &1)
   end
 end

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -42,7 +42,7 @@ defmodule Embervm.SessionManagerTest do
     assign_fun = Keyword.get(opts, :assign_fun, &default_assign/2)
 
     session_opts = [
-      channel_fun: fn _node -> {:ok, :ch} end,
+      channel_fun: Keyword.get(opts, :session_channel_fun, fn _node -> {:ok, :ch} end),
       assign_fun: assign_fun,
       destroy_fun: Keyword.get(opts, :destroy_fun, fn _ch, _vm -> {:ok, %{}} end),
       invalidate_fun: fn _node, _ch -> :ok end
@@ -200,6 +200,58 @@ defmodule Embervm.SessionManagerTest do
     # node-scoped, not the dial instance_id.
     {:ok, session} = SessionStore.get(ctx.store, created.session_id)
     assert session.node_id == "node-4"
+  end
+
+  test "the per-invoke dial targets the OWNER instance_id, not the node-name alias (task #4)" do
+    {:ok, dialed} = Agent.start_link(fn -> [] end)
+
+    capture_channel = fn key ->
+      Agent.update(dialed, &[key | &1])
+      {:ok, :ch}
+    end
+
+    ctx =
+      start_stack(
+        # The claim lands the VM on the big brick.
+        claim_fun: fn _d, _dial_id, _w -> {:ok, "vm-owner"} end,
+        session_channel_fun: capture_channel
+      )
+
+    WorkloadCatalog.upsert(ctx.cat_table, "wl-a", %{
+      name: "wl-a",
+      namespace: "embervm",
+      class: "session",
+      image_ref: "img@sha256:abc",
+      invoke_path: "/",
+      timeout_ms: 90_000,
+      cap: 8,
+      floor: 1,
+      mem_mib: 4_000,
+      session: %{
+        idle_bank_seconds: 300,
+        max_lifetime_seconds: 3600,
+        banked_ttl_seconds: 3600,
+        max_sessions: 16,
+        invoke_queue_cap: 4
+      }
+    })
+
+    # Two co-located bricks: the 2Gi cannot boot the 4Gi-need session, so dial_instance
+    # picks node-4/big. The node-name alias would collapse to whichever brick
+    # registered last; the per-invoke dial must target node-4/big regardless.
+    put_brick(ctx, "wl-a", "small", size_class: "2gi", mem_headroom: 100, mem_budget: 2_048)
+    put_brick(ctx, "wl-a", "big", size_class: "8gi", mem_headroom: 8_000, mem_budget: 8_192)
+
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-a", "p1")
+
+    {:ok, _resp} =
+      SessionManager.invoke(ctx.mgr, created.session_id, %{method: "POST", path: "/", headers: %{}, body: "hi"})
+
+    # The invoke's SessionAssign dialled the owning instance, never the node alias.
+    keys = Agent.get(dialed, & &1)
+    assert "node-4/big" in keys
+    refute "node-4" in keys
+    refute "node-4/small" in keys
   end
 
   test "create happy path: claims a primed VM, mints a token, starts a live session" do

--- a/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
@@ -1288,10 +1288,16 @@ defmodule Embervm.StatefulSweeperTest do
     refute "node-4" in Agent.get(dialed, & &1)
   end
 
-  test "an unknown-vm FAILED_PRECONDITION terminalizes the instance (-> :failed), not loop/republish" do
+  test "an owner-resolved unknown-vm FAILED_PRECONDITION terminalizes the instance (-> :failed), not loop/republish" do
     ctx = start_stack()
     stateful_workload(ctx, "wl-a", 5400, %{idle_bank_seconds: 60})
-    stateful_node(ctx, "node-4")
+    # An OWNER-RESOLVED dial: a per-instance fact reports the live vm_id, so the
+    # unknown-vm reply is authoritative (we reached the exact owner). Only then does
+    # the terminalize fire (task #12).
+    put_brick(ctx, "node-4", "pod-owner",
+      stateful_vms: [%{vm_id: "vm-1", workload: "wl-a", ip: "10.98.0.5", port: 5432, healthy: true, generation: 0}]
+    )
+
     serving_instance(ctx, "sf-1", "wl-a", "vm-1", "10.98.0.5")
 
     # The daemon rejects the bank FAILED_PRECONDITION (status 9): it does not own
@@ -1328,6 +1334,59 @@ defmodule Embervm.StatefulSweeperTest do
     assert load_ops(ctx, "stateful_banked") == []
     # A durable stateful_failed was recorded (the wake path cold-boots next).
     assert length(load_ops(ctx, "stateful_failed")) == 1
+  end
+
+  test "a FAIL-OPEN unknown-vm FAILED_PRECONDITION does NOT terminalize (backs off instead)" do
+    # No per-instance fact reports vm-1, so the dial FALLS OPEN to the bare node name
+    # (owner_resolved false). Under co-location the alias could be the wrong sibling
+    # (a stale-fact race), so an unknown-vm reply here is NOT authoritative: task #12
+    # requires we back off (abort + arm backoff), NOT fail the instance (which would
+    # risk cold-booting a second VM on the same volume). The instance stays serving.
+    ctx = start_stack(bank_backoff_base_ms: 10_000, bank_backoff_cap_ms: 30_000)
+    stateful_workload(ctx, "wl-a", 5400, %{idle_bank_seconds: 60})
+    stateful_node(ctx, "node-4")
+    serving_instance(ctx, "sf-1", "wl-a", "vm-1", "10.98.0.5")
+
+    :sys.replace_state(ctx.sweeper, fn s ->
+      %{
+        s
+        | stop_stateful_fun: fn _ch, req ->
+            if req.mode == :STOP_STATEFUL_MODE_BANK do
+              {:error, %GRPC.RPCError{status: 9, message: "not bankable (unknown vm)"}}
+            else
+              {:ok, %StopStatefulResponse{}}
+            end
+          end
+      }
+    end)
+
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 5_000)
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    advance(ctx.clock_agent, 65_000)
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+
+    # It aborted back to serving (NOT failed), and recorded no durable stateful_failed.
+    wait_until(ctx, fn -> match?({:ok, %{state: :serving}}, StatefulStore.get(ctx.store, "sf-1")) end)
+    {:ok, instance} = StatefulStore.get(ctx.store, "sf-1")
+    assert instance.state == :serving
+    assert load_ops(ctx, "stateful_failed") == []
+
+    # And it armed the backoff: a sweep 1 s later (inside the 10 s window) does not
+    # re-drive the bank.
+    bank_calls = fn -> Enum.count(stop_calls(ctx), &(&1.mode == :STOP_STATEFUL_MODE_BANK)) end
+    n = bank_calls.()
+
+    advance(ctx.clock_agent, 1_000)
+    set_scrape(ctx, reading("state-5400", 0, 3))
+    StatefulSweeper.sweep(ctx.sweeper)
+    flush(ctx)
+    assert bank_calls.() == n
   end
 
   test "a NON-terminal bank error backs off (does not re-drive at sweep frequency)" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.171
+      targetRevision: 0.1.172
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Why

PR-B0a (#3762) migrated the stateful sweeper, boot_image_ref, and pool manager to dial the OWNING noded instance instead of the node-name alias (which co-location makes point at an arbitrary sibling brick). This finishes the migration for the remaining stateful-affinity consumers, which were still node-name-keyed and so still misroute under co-location.

## What

- **Shared resolvers** (`wake_instance.ex`): factored a `dial_owning/5` core (find the instance on the node whose capacity fact reports the ref, fail open to the node name) with named wrappers per subsystem, plus `owning_instance_for/5`, a fail-CLOSED variant for the session relight (`snapshot_lost` must 410, not silently dial the alias). Existing `dial_for_vm`/`dial_for_bundle` now delegate to the same core, behaviour unchanged.
- **Serving** (`serving_sweeper.ex`): the StopServing BANK/DESTROY and evict dials resolve the owning instance (`dial_for_serving_vm`/`dial_for_serving_bundle`). ServingManager's wake was already instance-keyed.
- **Session** (`session.ex`, `session_manager.ex`, `session_placement.ex`): the live Session process carries a `dial_id` (defaulting to `node_id`) and dials it for every per-invoke SessionAssign / invalidate / destroy. This is the session per-invoke fix (task #4): an established session's next invoke dials the instance its VM was claimed/relit on, not the node anchor. The relight re-resolution now targets the specific instance reporting the session snapshot.
- **Group** (`group_sweeper.ex`): teardown / network-delete / evict dials + orphan-network GC resolve via `dial_for_group` on the durable `group_instance_id`. GroupManager already carried a supervisor-resolved dial key.
- **Terminalize hardening** (task #12, `stateful_sweeper.ex`): the unknown-vm FAILED_PRECONDITION terminalize now fires only when the dial was OWNER-RESOLVED (`dial_key != node_id`), threaded through the `{:bank_done}` message. A fail-open dial treats unknown-vm as non-terminal (abort + backoff), avoiding a stale-fact race that could fail a live instance and split-brain a second VM on the same volume.

**Dispatcher left node-keyed** (assessed): its prime/claim inventory already keys on the instance_id (`f.instance_id || configured_id`), so it reaches the specific instance for both stateless function pools and stateful dispatch. No misroute; no change.

The node-name alias is intentionally KEPT as a fallback; deleting it is the deferred PR-B0c once soaked. Every change fails open to the alias.

## Tests

Per-subsystem two-instances-on-one-node fixtures (alias on the non-owner) asserting the dial targets the owner; session per-invoke and relight instance targeting; task #12 both branches (owner-resolved terminalizes, fail-open backs off).

Chart bumped to 0.1.172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)