### PR TITLE
feat(monolith): configure CNPG backups for monolith-pg to SeaweedFS

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.244
+version: 0.89.246
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.244
+      targetRevision: 0.89.246
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.318
+version: 0.285.320
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cnpg-backup-s3-secret.yaml
+++ b/projects/monolith/chart/templates/cnpg-backup-s3-secret.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.postgres.backup.enabled }}
+# S3 credentials for the CNPG Barman object-store backup to SeaweedFS.
+#
+# CNPG's spec.backup.barmanObjectStore.s3Credentials only accepts a Secret
+# reference, not literal values. SeaweedFS S3 runs with auth disabled
+# (enableAuth: false) and the whole cluster shares the non-secret "duckdb"
+# dummy keys (see stars.s3AccessKeyId in values.yaml), so these are low-value
+# placeholders, not real credentials. They live in the chart rather than in
+# 1Password because there is no 1Password S3 item to source (SeaweedFS S3 has
+# no real credentials in this cluster). If SeaweedFS ever enables auth, switch
+# this to a 1Password-operator OnePasswordItem instead.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "monolith.fullname" . }}-pg-backup-s3
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  ACCESS_KEY_ID: {{ .Values.postgres.backup.s3AccessKeyId | quote }}
+  ACCESS_SECRET_KEY: {{ .Values.postgres.backup.s3SecretAccessKey | quote }}
+{{- end }}

--- a/projects/monolith/chart/templates/cnpg-cluster.yaml
+++ b/projects/monolith/chart/templates/cnpg-cluster.yaml
@@ -76,3 +76,29 @@ spec:
       owner: app
       postInitSQL:
         - CREATE EXTENSION IF NOT EXISTS vector
+  {{- if .Values.postgres.backup.enabled }}
+  # Barman object-store backup to the in-cluster SeaweedFS S3 gateway. Closes the
+  # zero-backup gap from the ext4-corruption recovery: backups live in SeaweedFS
+  # (a different volume set) so they survive Pg-volume corruption. NOT off-cluster
+  # DR (a cluster loss takes both); that is a separate follow-up. Uses the in-spec
+  # barmanObjectStore mechanism supported by the deployed CNPG 1.28.1 operator
+  # (the Barman Cloud Plugin is not installed). Credentials are the shared
+  # non-secret SeaweedFS dummy keys via the chart-managed Opaque secret
+  # (cnpg-backup-s3-secret.yaml); SeaweedFS S3 runs auth-disabled.
+  backup:
+    retentionPolicy: {{ .Values.postgres.backup.retentionPolicy | quote }}
+    barmanObjectStore:
+      destinationPath: {{ .Values.postgres.backup.destinationPath | quote }}
+      endpointURL: {{ .Values.postgres.backup.endpointURL | quote }}
+      s3Credentials:
+        accessKeyId:
+          name: {{ include "monolith.fullname" . }}-pg-backup-s3
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: {{ include "monolith.fullname" . }}-pg-backup-s3
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
+  {{- end }}

--- a/projects/monolith/chart/templates/cnpg-scheduledbackup.yaml
+++ b/projects/monolith/chart/templates/cnpg-scheduledbackup.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.postgres.backup.enabled }}
+# Daily base backup of monolith-pg to the SeaweedFS Barman object store. WAL
+# archiving (configured on the Cluster's spec.backup) runs continuously; this
+# ScheduledBackup takes the periodic full base backup that WALs replay from and
+# that the retentionPolicy prunes against. method defaults to barmanObjectStore.
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: {{ include "monolith.fullname" . }}-pg-daily
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+spec:
+  # CNPG cron format has a leading seconds field (6 fields).
+  schedule: {{ .Values.postgres.backup.scheduledBackup.cron | quote }}
+  backupOwnerReference: self
+  cluster:
+    name: {{ include "monolith.fullname" . }}-pg
+{{- end }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -741,6 +741,55 @@ postgres:
     storageClass: ""
   pgvector:
     image: ghcr.io/cloudnative-pg/pgvector:0.8.2-202604021427-18-trixie
+  # Barman object-store backups (WAL archiving + scheduled base backups) to the
+  # in-cluster SeaweedFS S3 gateway. This closes the zero-backup gap exposed when
+  # the Pg Longhorn volume suffered ext4 corruption and had to be fsck-recovered
+  # with no backups. Because the backups live in SeaweedFS (a different volume
+  # set) they survive the Pg-volume-corruption failure class. NOTE: this is NOT
+  # off-cluster disaster recovery (a node/cluster loss still takes both); that is
+  # a separate follow-up.
+  #
+  # Uses the in-spec barmanObjectStore mechanism (supported by the deployed CNPG
+  # 1.28.1 operator). The newer Barman Cloud Plugin is not installed, so the
+  # plugin path is not available here.
+  #
+  # Credentials: SeaweedFS S3 runs with enableAuth: false and every workload uses
+  # the shared non-secret "duckdb"/"duckdb" keys (see stars.s3AccessKeyId). CNPG
+  # s3Credentials only accepts a Secret reference (not literals), so the chart
+  # emits a small Opaque Secret (templates/cnpg-backup-s3-secret.yaml) holding
+  # these same low-value dummy keys. There is no 1Password S3 item to reuse
+  # because SeaweedFS S3 has no real credentials in this cluster.
+  # Landed DISABLED on purpose. Enabling continuous WAL archiving to a not-yet-
+  # created bucket, or turning archive_mode on, can trigger a CNPG rolling
+  # switchover of the primary, which must not run unwatched against the freshly
+  # fsck-recovered monolith-pg. The live enable is a deliberate, watched step:
+  # (1) pre-create the s3://monolith-pg-backups bucket via `weed shell`
+  #     s3.bucket.create (NOT the chart bucket hook, which flips SeaweedFS S3 to
+  #     auth-enforced and breaks every S3 workload),
+  # (2) confirm the standby is caught up (instances: 2, streaming),
+  # (3) flip enabled: true and watch the Cluster's ContinuousArchiving condition
+  #     plus the first ScheduledBackup completing.
+  backup:
+    enabled: false
+    # SeaweedFS S3 gateway (path-style, plaintext HTTP), same endpoint the app
+    # workloads use.
+    endpointURL: "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333"
+    # s3://<bucket>/<path>. The bucket must be pre-created out-of-band (see the
+    # note in seaweedfs values.yaml: never let the chart's bucket hook run, it
+    # flips the whole cluster S3 to auth-enforced). CNPG writes base backups and
+    # WALs under this prefix.
+    destinationPath: "s3://monolith-pg-backups/monolith-pg"
+    s3AccessKeyId: "duckdb"
+    s3SecretAccessKey: "duckdb"
+    # Keep 14 days of backups + WALs. Barman prunes on each new base backup.
+    retentionPolicy: "14d"
+    scheduledBackup:
+      # Daily base backup. CNPG cron format has a leading seconds field, so this
+      # is 02:00 UTC daily. Named `cron` rather than `schedule` because the
+      # `schedule:` key under values.yaml triggers the Argo-CronWorkflow
+      # activeDeadlineSeconds lint, which does not apply to a CNPG
+      # ScheduledBackup (no such field in its schema).
+      cron: "0 0 2 * * *"
 
 service:
   port: 3000

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.318
+      targetRevision: 0.285.320
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

Configures **CNPG backups for `monolith-pg`**, closing the zero-backup gap exposed today when the Pg Longhorn volume suffered ext4 corruption and had to be `fsck`-recovered with **no backups configured** (task #20, a zero-backup near-miss).

Adds, gated behind `postgres.backup.enabled`:
- **Continuous WAL archiving + a daily base backup** to the in-cluster SeaweedFS S3 gateway via `spec.backup.barmanObjectStore` on the CNPG `Cluster`.
- A **14-day `retentionPolicy`**.
- A **`ScheduledBackup`** resource (daily, 02:00 UTC).
- A chart-managed **Opaque `Secret`** (`monolith-pg-backup-s3`) supplying the S3 credentials CNPG's `s3Credentials` requires.

Only backup config is added. The existing `Cluster` spec (instances, storage, managed roles, resources, bootstrap) is untouched.

## Backup target: in-cluster SeaweedFS, NOT off-cluster DR

The backup target is **SeaweedFS in-cluster S3 (Barman object store)**, a recorded decision. Because backups live in SeaweedFS (a **different volume set** from the Pg Longhorn volume), they survive the exact **Pg-volume-corruption failure class** we just hit.

**This is explicitly NOT off-cluster disaster recovery.** A node loss or whole-cluster loss still takes both the Pg volume and the SeaweedFS volumes. Off-cluster DR is a separate follow-up; this PR closes the volume-corruption gap only.

## Mechanism: in-spec `barmanObjectStore` (not the plugin)

The deployed **CNPG operator is `1.28.1`** (`ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1`, verified read-only via `kubectl -n cnpg-system`). While 1.26+ introduces the newer **Barman Cloud Plugin**, that plugin requires a separate operator/plugin install which is **NOT present** in this cluster (no `barman` pod, no plugin CRD). The in-spec `spec.backup.barmanObjectStore` mechanism is still fully supported in 1.28.1, so that is what this PR uses. Migrating to the plugin later is a separate, optional change.

## SeaweedFS endpoint + credential source

- **S3 endpoint:** `http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333` (the same gateway every workload uses).
- **Credentials:** SeaweedFS S3 runs with **`enableAuth: false`** and the whole cluster shares the **non-secret `duckdb`/`duckdb` dummy keys** (see `stars.s3AccessKeyId` in `values.yaml`). CNPG's `s3Credentials` only accepts a **Secret reference** (not literals), so the chart emits a small Opaque Secret holding those same low-value dummy keys.
  - **There is no 1Password S3 item to reuse** for this: SeaweedFS S3 has no real credentials in this cluster (auth is disabled). If SeaweedFS ever enables auth, swap this Secret for a `OnePasswordItem`-backed one.

## Required manual step: pre-create the bucket

SeaweedFS requires the bucket to exist first, and the chart's bucket-creation hook **must not** be used (it flips the whole cluster S3 to auth-enforced and breaks every S3 workload, per the incident note in `seaweedfs/values.yaml`). **Before this merges / before the first backup runs, create the bucket out-of-band:**

```
weed shell
> s3.bucket.create -name monolith-pg-backups
```

(destinationPath is `s3://monolith-pg-backups/monolith-pg`.)

## Chart bump required at merge

This deploys via the monolith chart and **requires a monolith chart bump** (`bazel/tools/git/bump-chart.sh projects/monolith`) to actually roll out. Per the working agreement, **the bump is deliberately NOT included here; the lead bumps at merge.**

## Verification

- `helm template monolith projects/monolith/chart/ -f projects/monolith/deploy/values.yaml` renders the `Cluster` `spec.backup`, the `ScheduledBackup`, and the `Secret` cleanly; the existing `Cluster` spec is unchanged.
- No live-cluster mutation performed (kubectl read-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFXpz6XW8Tmb3Yj5t3b1c