### PR TITLE
perf(embervm): fast-retry noded dial-home until first registration

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.173
+version: 0.1.174

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.173
+      targetRevision: 0.1.174
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/register.go
+++ b/projects/embervm/noded/server/register.go
@@ -73,10 +73,26 @@ func (s *Server) RunRegisterLoop(ctx context.Context) {
 	s.runRegisterLoop(ctx, client, newID("boot"), s.cfg.RegisterInterval)
 }
 
+// registerFastRetryBase is the delay before the FIRST re-attempt while the
+// instance has never successfully registered (its base is on disk but not yet
+// advertised as READY, because the control plane has not dialed WatchNode and
+// pushed SyncRegistry yet). A fresh pod whose first POST races pod-network /
+// control-plane readiness (DNS not resolvable, a 5s HTTP timeout) must NOT wait a
+// full RegisterInterval (30s) to re-advertise: that idle gap IS the co-location
+// base-advertisement window (~36s = 5s timeout + ~30s interval). We fast-retry
+// from here, doubling to the steady interval, so a fresh instance is adopted in
+// seconds. Once the first POST succeeds we switch to the steady interval, so this
+// never raises the healthy-fleet report frequency (no thundering herd).
+const registerFastRetryBase = 1 * time.Second
+
 // runRegisterLoop is the testable core: an injected doer, a fixed boot id, and
-// an explicit interval. It registers once immediately (so the control plane
-// adopts a fresh pod without waiting a full interval), then re-registers on a
-// jittered tick until ctx is cancelled or the daemon starts draining.
+// an explicit steady interval. It registers once immediately (so the control
+// plane adopts a fresh pod without waiting a full interval); until that first
+// POST succeeds it fast-retries on an exponential backoff (registerFastRetryBase,
+// doubling, capped at the steady interval) so a fresh instance whose first POST
+// races control-plane reachability re-advertises in seconds instead of idling a
+// full interval; after the first success it re-registers on the jittered steady
+// tick. Loops until ctx is cancelled or the daemon starts draining.
 func (s *Server) runRegisterLoop(ctx context.Context, doer httpDoer, bootID string, interval time.Duration) {
 	if interval <= 0 {
 		interval = 30 * time.Second
@@ -86,6 +102,9 @@ func (s *Server) runRegisterLoop(ctx context.Context, doer httpDoer, bootID stri
 	// CHANGE (ok<->fail), never once per successful tick.
 	var lastOK bool
 	firstAttempt := true
+	// registered flips true after the first successful POST; until then the loop
+	// waits on the fast-retry backoff rather than the steady interval.
+	registered := false
 
 	attempt := func() {
 		// A draining instance stops re-advertising: the control plane ages it out
@@ -98,6 +117,9 @@ func (s *Server) runRegisterLoop(ctx context.Context, doer httpDoer, bootID stri
 
 		err := s.register(ctx, doer, bootID)
 		ok := err == nil
+		if ok {
+			registered = true
+		}
 
 		if firstAttempt || ok != lastOK {
 			if ok {
@@ -115,12 +137,28 @@ func (s *Server) runRegisterLoop(ctx context.Context, doer httpDoer, bootID stri
 
 	go func() {
 		attempt()
+		// Fast-retry backoff, armed while the instance has never registered. Once
+		// registered it is irrelevant (the steady interval takes over).
+		fastRetry := registerFastRetryBase
 		for {
+			// While never-yet-registered, wait the (capped) fast-retry backoff; once
+			// registered, wait the jittered steady interval. This keeps a fresh pod's
+			// re-advertisement in the single-digit-seconds range without changing the
+			// healthy-fleet cadence.
+			wait := jitter(interval)
+			if !registered {
+				wait = fastRetry
+			}
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(jitter(interval)):
+			case <-time.After(wait):
 				attempt()
+				if !registered {
+					if fastRetry *= 2; fastRetry > interval {
+						fastRetry = interval
+					}
+				}
 			}
 		}
 	}()

--- a/projects/embervm/noded/server/register_test.go
+++ b/projects/embervm/noded/server/register_test.go
@@ -205,6 +205,63 @@ func (d *countingDoer) Do(req *http.Request) (*http.Response, error) {
 
 func (d *countingDoer) count() int { return int(atomic.LoadInt64(&d.n)) }
 
+// failThenOKDoer returns a transport error for the first `failFor` calls, then
+// 2xx. It models a fresh pod whose first dial-home POST races control-plane
+// reachability (DNS/route not ready) before the control plane becomes dialable.
+type failThenOKDoer struct {
+	mu      sync.Mutex
+	n       int
+	failFor int
+}
+
+func (d *failThenOKDoer) Do(_ *http.Request) (*http.Response, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.n++
+	if d.n <= d.failFor {
+		return nil, io.ErrUnexpectedEOF
+	}
+	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+}
+
+func (d *failThenOKDoer) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.n
+}
+
+// register-fast-retries-until-first-success: when the first POST(s) fail, the
+// loop must re-attempt on the SHORT fast-retry backoff, never idle the full
+// steady interval. With a steady interval far larger than the fast-retry base, a
+// fresh instance that fails its first two POSTs still registers within a couple
+// of fast-retry ticks (the co-location base-advertisement window fix). This test
+// pins the behaviour with registerFastRetryBase kept small by the production
+// constant and a deliberately large steady interval: if the loop waited the
+// steady interval on failure, no re-attempt would land inside the window.
+func TestRegisterFastRetriesUntilFirstSuccess(t *testing.T) {
+	s := registerTestServer(config.Config{
+		Node:            "node-4",
+		PodUID:          "uid-abc",
+		ControlPlaneURL: "http://cp:8080",
+	})
+	// Fail the first two POSTs (immediate + one fast-retry), succeed on the third.
+	doer := &failThenOKDoer{failFor: 2}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// A steady interval far larger than registerFastRetryBase (1s): were the loop
+	// to wait the steady interval on a failed first POST, the third attempt would
+	// not land for minutes. The fast-retry (1s, then 2s) must land it in seconds.
+	s.runRegisterLoop(ctx, doer, "boot", time.Hour)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for doer.count() < 3 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := doer.count(); got < 3 {
+		t.Fatalf("expected the loop to fast-retry to a successful registration (>=3 POSTs) within the window, got %d", got)
+	}
+}
+
 // grpc-port-parse: the advertised port is extracted from various ListenAddr
 // shapes, defaulting to 9090.
 func TestGrpcPortOf(t *testing.T) {


### PR DESCRIPTION
## Problem

Task #7: shrink the ~36s window before the control plane sees a fresh noded instance's base advertised `BASE_BUILD_STATE_READY` after a co-located brick roll (or a DaemonSet noded restart). During that window the base-readiness gate (de48b05f6) correctly makes cold wakes WAIT, but the advertisement itself arrives slowly.

## Root cause

The base facts flow noded -> CP over the WatchNode stream, and that stream (plus its `SyncRegistry` replay) is opened by the CP only in response to the instance's dial-home registration. So the advertisement window is bounded by how fast the FIRST dial-home POST lands.

A fresh instance:
1. adopts its node-shared bases from disk synchronously at boot (`ReconcileBasesFromDisk`, marked READY), then
2. dials home; the CP `register/2` -> `add_instance` -> `start_streamer` -> `SyncRegistry` -> first `WatchNode` snapshot, at which point `imageProvisioned` returns true and `workloadCapacities` finally advertises the base.

The register loop (`noded/server/register.go`) fired one immediate POST, then **unconditionally** slept `jitter(RegisterInterval)` before retrying, **regardless of whether that first POST succeeded**. The dominant constant is `RegisterInterval = 30s` (`config.go:350`). A fresh pod whose first POST races control-plane reachability (DNS/route not yet ready, up to a 5s HTTP client timeout) then did not re-advertise for a full ~30s, so the CP did not adopt it and the base stayed unadvertised for **~36s = 5s timeout + ~30s interval**.

## Fix

Fast-retry the register loop **while the instance has never successfully registered**: back off exponentially from `1s` (doubling, capped at the steady interval) instead of idling the full interval; after the first `2xx`, switch to the jittered steady interval. Mirrors the CP-side reconnect backoff shape (`@base_backoff_ms 1_000`).

- Fresh instance is adopted (base advertised) in single-digit seconds.
- **Inert on a healthy fleet**: once registered, cadence is unchanged, so no thundering herd and no extra steady-state report frequency.
- Draining still short-circuits every attempt.

## Test

`TestRegisterFastRetriesUntilFirstSuccess`: with a steady interval of 1h, an instance that fails its first two POSTs still reaches a successful registration within the fast-retry window (would be impossible if the loop waited the steady interval on failure).

No chart bump (bumped at merge).