### PR TITLE
feat(embervm): drop node-name alias from NodeChannel keying (PR-B0c)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.172
+version: 0.1.173

--- a/projects/embervm/control/lib/embervm/node_channel.ex
+++ b/projects/embervm/control/lib/embervm/node_channel.ex
@@ -97,12 +97,11 @@ defmodule Embervm.NodeChannel do
   @doc """
   Drop `node_id` from the address map entirely and erase any cached channel, so a
   subsequent `get/1` returns `{:error, :unknown_node}` rather than re-dialing a
-  dead endpoint. Used by `Embervm.NodeRegistry` when an instance expires: under the
-  dual-key registration (brick co-location foundation, Step 1) an instance is
-  registered under BOTH its instance_id (`"node/pod_uid"`) and its node-name alias,
-  and both must be removed on expiry so no stale alias points at a torn-down pod's
-  address. Idempotent: removing an unknown key is a no-op. Synchronous so the caller
-  knows the map no longer resolves the key before it drops its own runtime entry.
+  dead endpoint. Used by `Embervm.NodeRegistry` when an instance expires: post-B0c an
+  instance is registered under its instance_id (`"node/pod_uid"`) alone, so expiry
+  removes that single key and no stale endpoint points at a torn-down pod's address.
+  Idempotent: removing an unknown key is a no-op. Synchronous so the caller knows the
+  map no longer resolves the key before it drops its own runtime entry.
   """
   @spec remove_address(GenServer.server(), String.t()) :: :ok
   def remove_address(server \\ __MODULE__, node_id) do

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -243,12 +243,11 @@ defmodule Embervm.NodeRegistry do
     channel_updater_fun =
       Keyword.get(opts, :channel_updater_fun, &default_channel_update/2)
 
-    # How an expired instance's keys are REMOVED from the Prime/Assign channel
-    # holder. Under the dual-key registration an instance is added to NodeChannel
-    # under both its instance_id and its node-name alias; on expiry both must be
-    # dropped so no stale alias keeps pointing at a torn-down pod's address. Keyed
-    # like channel_updater_fun (one call per key). Default calls the singleton
-    # NodeChannel; tests inject a fake to assert both removals fire.
+    # How an expired instance's key is REMOVED from the Prime/Assign channel holder.
+    # Post-B0c an instance is added to NodeChannel under its instance_id alone, so
+    # expiry drops that one key and no stale endpoint keeps pointing at a torn-down
+    # pod's address. Keyed like channel_updater_fun (one call per key). Default calls
+    # the singleton NodeChannel; tests inject a fake to assert the removal fires.
     channel_remover_fun =
       Keyword.get(opts, :channel_remover_fun, &default_channel_remove/1)
 
@@ -1085,14 +1084,17 @@ defmodule Embervm.NodeRegistry do
   defp instance_id_of(node, ""), do: node
   defp instance_id_of(node, pod_uid), do: node <> "/" <> pod_uid
 
-  # The NodeChannel keys this instance is registered under: its instance_id
-  # ("node/pod_uid", what the dispatcher's pick_node resolves to) and, when it
-  # differs, the node-name alias ("node", what the legacy stateful/serving/session/
-  # group wakes still resolve to). For a node-scoped instance (empty pod_uid) the
-  # instance_id IS the node name, so the two collapse to a single key. Add and
-  # remove drive off this same list so registration stays consistent on both edges.
+  # The NodeChannel key this instance is registered under: its instance_id
+  # ("node/pod_uid", what the dispatcher's pick_node resolves to and, post the
+  # instance-key migration, what every stateful/serving/session/group wake resolves
+  # to as well). PR-B0c removed the node-name alias: with all consumers dialing the
+  # owning instance_id, a shared last-writer-wins node-name key could only misroute a
+  # wake across a node's co-located bricks, so dropping it makes that misroute
+  # structurally impossible. For a node-scoped instance (empty pod_uid) the instance_id
+  # IS the node name, so a static/pinned single-daemon override still keys under its
+  # node name unchanged. Returned as a list so add and remove drive off the same shape.
   defp channel_keys(rt) do
-    Enum.uniq([rt.instance_id, rt.configured_id])
+    [rt.instance_id]
   end
 
   # Apply one registration: upsert the instance keyed by {node, pod_uid}. Three
@@ -1129,23 +1131,16 @@ defmodule Embervm.NodeRegistry do
   # (keyed by INSTANCE id), and open its streamer. Mirrors the static seed shape so
   # age-out and streamer plumbing treat a registered instance identically.
   #
-  # NodeChannel keying (DUAL-KEY, brick co-location foundation Step 1): the
-  # registry's own tables are keyed by instance_id ("node/pod_uid"). NodeChannel is
-  # the DISPATCH channel and has two classes of consumer, keyed differently:
-  #   * the dispatcher (PR-2) resolves pick_node to an INSTANCE_ID ("node-4/<uid>")
-  #     and calls NodeChannel.get("node-4/<uid>");
-  #   * the legacy wakes (PoolManager.refill_node/2 on facts.configured_id, plus
-  #     stateful/session/serving/group placement) still resolve to a NODE-NAME anchor
-  #     and call NodeChannel.get("node-4").
-  # A single-key registration therefore starved one class or the other (keying only
-  # by node-name left the dispatcher's get(instance_id) at :unknown_node, so EVERY
-  # assign died {:no_channel, :unknown_node}; keying only by instance_id would break
-  # the legacy wakes). So we register the SAME address under BOTH keys: the
-  # instance_id and, when it differs, the node-name alias. Both resolve to this
-  # instance's address; expire_instance removes both so no stale alias survives. The
-  # node-name alias is deliberately kept until the wakes migrate to instance_id
-  # keying (a later step) and stays #3732-safe: it maps a constructed node name to a
-  # real instance's address rather than into an instance-keyed map with no entry.
+  # NodeChannel keying (single-key, post instance-key migration): the registry's own
+  # tables are keyed by instance_id ("node/pod_uid"), and so now is NodeChannel. Every
+  # consumer resolves the owning instance_id before dialing: the dispatcher (PR-2)
+  # resolves pick_node to an instance_id, and the stateful/session/serving/group wakes
+  # and PoolManager were migrated (B0a/B0b) to dial the owning instance_id too. The
+  # node-name alias that briefly bridged the legacy wakes was removed in PR-B0c: a
+  # shared, last-writer-wins node-name key across a node's co-located bricks could only
+  # misroute a wake to the wrong sibling, so dropping it makes that misroute
+  # structurally impossible. A node-scoped instance (empty pod_uid) has instance_id ==
+  # node name, so a static/pinned single-daemon override still keys under its node name.
   defp add_instance(state, norm, now) do
     rt =
       seed_runtime(
@@ -1203,25 +1198,18 @@ defmodule Embervm.NodeRegistry do
     }
   end
 
-  # Remove an instance from the registry: retract its capacity row, drop its OWN
-  # NodeChannel key (the instance_id, NOT the shared node-name alias, see below),
+  # Remove an instance from the registry: retract its capacity row, drop its
+  # NodeChannel key (its instance_id, the only key it is registered under post-B0c),
   # tell the BaseBuilder to drop it, kill its streamer if any (forgetting the pid
   # first so the ensuing DOWN is ignored), and drop its runtime so no reconnect
   # resurrects it. Used both by two-signal expiry and by a re-registration re-point.
   #
-  # NodeChannel removal (dual-key, brick co-location foundation Step 1): add_instance
-  # registered this instance's address under BOTH its instance_id and its node-name
-  # alias, but expiry removes ONLY the instance_id. The instance_id is unique to this
-  # instance, so removing it is always correct. The node-name alias ("node-4") is a
-  # SHARED, last-writer-wins key across a node's co-located instances (add_instance's
-  # unconditional update_address overwrites it): removing it here on ONE instance's
-  # expiry would CLOBBER a still-live sibling that currently owns the alias, so a
-  # legacy stateful/serving/session/group wake for that node would get :unknown_node
-  # until the sibling re-registered. So the alias is managed solely by registration
-  # (last-writer), exactly as pre-PR where expire_instance never touched NodeChannel.
-  # The only residual is that the alias may transiently point at a just-expired owner
-  # until the next registration re-points it (acceptable; the pre-PR behaviour). Step
-  # 4 removes the node-name alias entirely once the wakes migrate to instance_id.
+  # NodeChannel removal (single-key, post instance-key migration): add_instance
+  # registered this instance's address under its instance_id alone, and expiry removes
+  # that same key. The instance_id is unique to this instance, so removing it is always
+  # correct and, crucially, cannot affect a co-located sibling: siblings on the same
+  # node now hold independent instance_id keys, so there is no shared node-name alias
+  # left for one instance's expiry to clobber (the misroute PR-B0c eliminated).
   defp expire_instance(state, instance_id) do
     Logger.info("embervm node registry: instance #{instance_id} expired; tearing down")
 
@@ -1267,20 +1255,19 @@ defmodule Embervm.NodeRegistry do
   end
 
   # Default: point the singleton Embervm.NodeChannel at the instance's address under
-  # one key (add_instance calls this once per key in channel_keys/1: the instance_id
-  # for the dispatcher, the node-name alias for the legacy wakes). On a
-  # re-registration at a new address, update_address unconditionally erases the
-  # channel cached under this key and re-points it, so no stale endpoint survives.
+  # its instance_id (add_instance calls this once per key in channel_keys/1, which is
+  # now just the instance_id). On a re-registration at a new address, update_address
+  # unconditionally erases the channel cached under this key and re-points it, so no
+  # stale endpoint survives.
   defp default_channel_update(key, address) do
     Embervm.NodeChannel.update_address(key, address)
     :ok
   end
 
   # Propagate an instance expiry to the Prime/Assign channel holder by dropping the
-  # expiring instance's OWN key (its instance_id; expire_instance deliberately leaves
-  # the shared node-name alias to registration's last-writer). Swallowing any error
-  # mirrors safe_channel_update: a NodeChannel that is not running, or a slow call,
-  # must never crash expiry.
+  # expiring instance's instance_id key (its only NodeChannel key post-B0c). Swallowing
+  # any error mirrors safe_channel_update: a NodeChannel that is not running, or a slow
+  # call, must never crash expiry.
   defp safe_channel_remove(nil, _key), do: :ok
 
   defp safe_channel_remove(remover, key) do

--- a/projects/embervm/control/lib/embervm/pool_manager.ex
+++ b/projects/embervm/control/lib/embervm/pool_manager.ex
@@ -450,8 +450,10 @@ defmodule Embervm.PoolManager do
   defp draining?(f), do: Map.get(f, :draining, false) == true
 
   # The dial/bookkeeping key for a capacity fact: its instance_id (`"node/pod_uid"`)
-  # when present, else the bare node name (a legacy/single-instance fact without the
-  # field still resolves via the node-name alias, unchanged behaviour).
+  # when present, else the bare node name. Post-B0c there is no node-name alias, so the
+  # fallback resolves only for a node-scoped instance (empty pod_uid, whose instance_id
+  # IS the node name it registers under); a dial-home brick fact always carries
+  # instance_id, so the fallback is never hit for co-located bricks.
   defp dial_id(facts) do
     case Map.get(facts, :instance_id) do
       id when is_binary(id) and id != "" -> id

--- a/projects/embervm/control/lib/embervm/wake_instance.ex
+++ b/projects/embervm/control/lib/embervm/wake_instance.ex
@@ -47,16 +47,19 @@ defmodule Embervm.WakeInstance do
 
   With one instance per node the node's only instance IS the owner (it banked
   everything) and IS the sole cold candidate, so selection always returns that
-  instance and the caller dials its `instance_id`, which the dual-keyed channel
-  resolves identically to the old node-name dial. Output-equivalent, so this deploys
-  later at the re-canary with no behaviour change today.
+  instance and the caller dials its `instance_id`, which is the single key
+  NodeChannel is registered under (post-B0c the node-name alias is gone). The dial
+  key is the instance_id in every case.
 
   ## legacy / test facts without an instance_id
 
   A capacity fact that carries no `:instance_id` (a statically-seeded instance or a
-  test fixture that predates the field) falls back to the fact's `node_id`, so the
-  dial still resolves via the node-name alias exactly as before. The selection logic
-  is unchanged; only the dial key degrades gracefully.
+  test fixture that predates the field) falls back to the fact's `node_id`. For a
+  node-scoped instance that node_id IS the key it registers under, so the dial still
+  resolves; a dial-home fact always carries `:instance_id`, so this fallback is not
+  hit for co-located bricks (and post-B0c a bare node name no longer misroutes: it
+  fails closed to `:unknown_node`). The selection logic is unchanged; only the dial
+  key degrades gracefully.
   """
 
   alias Embervm.{BrickLedger, NodeCapacity}
@@ -102,7 +105,9 @@ defmodule Embervm.WakeInstance do
   The channel key of the instance on `node_id` currently RUNNING `vm_id` (its
   per-instance capacity fact reports the `vm_id` in `stateful_vms`), or the bare
   `node_id` when no reporting instance is found (a legacy/single-instance fact, or
-  the VM not yet re-reported after a roll: the node-name alias still resolves it).
+  the VM not yet re-reported after a roll). Post-B0c the bare `node_id` resolves only
+  for a node-scoped instance; a co-located VM not yet re-reported fails closed to
+  `:unknown_node` (a retryable miss) rather than misrouting to a sibling brick.
 
   This is the post-wake dial resolution the sweeper's bank/checkpoint/resolve
   workers use so a StopStateful/ResolveStateful lands on the instance that actually

--- a/projects/embervm/control/test/embervm/node_channel_test.exs
+++ b/projects/embervm/control/test/embervm/node_channel_test.exs
@@ -95,10 +95,11 @@ defmodule Embervm.NodeChannelTest do
     assert {:error, :unknown_node} = NodeChannel.get(pid, "not-configured-#{System.unique_integer([:positive])}")
   end
 
-  test "update_address adds a previously-unknown key so get/1 resolves it (dual-key add)" do
-    # The registry (Bug A fix) registers an instance under BOTH its instance_id and
-    # its node-name alias via update_address; a key unknown at init must become
-    # dialable rather than staying :unknown_node.
+  test "update_address adds a previously-unknown key so get/1 resolves it" do
+    # The registry registers an instance under its instance_id via update_address; a
+    # key unknown at init must become dialable rather than staying :unknown_node. (This
+    # exercises NodeChannel's key-add API, which is unchanged by B0c; only the set of
+    # keys the registry adds narrowed to the instance_id alone.)
     nid = node_id()
     {_dials, connect} = counting_connect()
     pid = start(nid, connect)
@@ -111,8 +112,8 @@ defmodule Embervm.NodeChannelTest do
   end
 
   test "remove_address drops the key and its cached channel so get/1 falls back to :unknown_node" do
-    # Instance expiry (Bug A fix) removes both keys; a removed key must no longer
-    # resolve, so no stale alias keeps dialing a torn-down pod's address.
+    # Instance expiry removes the instance's key; a removed key must no longer resolve,
+    # so no stale endpoint keeps dialing a torn-down pod's address.
     nid = node_id()
     {_dials, connect} = counting_connect()
     pid = start(nid, connect)

--- a/projects/embervm/control/test/embervm/node_registry_test.exs
+++ b/projects/embervm/control/test/embervm/node_registry_test.exs
@@ -454,10 +454,10 @@ defmodule Embervm.NodeRegistryTest do
     # Same instance (node+pod_uid), NEW address.
     :ok = NodeRegistry.register(reg, %{"node" => "node-4", "pod_uid" => "uid-1", "address" => "new-ip:9090"})
     eventually(fn -> "new-ip:9090" in Agent.get(dialed, & &1) end, 200)
-    # NodeChannel is re-pointed under the NODE NAME key (what every dispatch consumer
-    # looks up), not the instance_id, so a node-name lookup after a re-registration
-    # resolves the new address rather than dialing the dead old endpoint.
-    eventually(fn -> {"node-4", "new-ip:9090"} in Agent.get(chan, & &1) end, 200)
+    # NodeChannel is re-pointed under the instance_id key (post-B0c the only key it is
+    # registered under, and what every consumer resolves before dialing), so a lookup
+    # after a re-registration resolves the new address rather than the dead old endpoint.
+    eventually(fn -> {"node-4/uid-1", "new-ip:9090"} in Agent.get(chan, & &1) end, 200)
     assert NodeRegistry.status(reg)["node-4/uid-1"].address == "new-ip:9090"
   end
 

--- a/projects/embervm/control/test/embervm/node_registry_test.exs
+++ b/projects/embervm/control/test/embervm/node_registry_test.exs
@@ -461,14 +461,13 @@ defmodule Embervm.NodeRegistryTest do
     assert NodeRegistry.status(reg)["node-4/uid-1"].address == "new-ip:9090"
   end
 
-  test "dial-home registration DUAL-KEYS NodeChannel: instance_id (dispatcher) AND node-name alias (legacy wakes)" do
-    # Bug A fix (brick co-location foundation Step 1). Two consumer classes address
-    # NodeChannel differently: the dispatcher (PR-2) resolves pick_node to an
-    # instance_id ("node-4/uid-1") and calls get("node-4/uid-1"); the legacy wakes
-    # (PoolManager.refill_node/2 on facts.configured_id "node-4", plus
-    # stateful/session/serving/group placement) call get("node-4"). A single-key
-    # registration starved one class or the other. So registration points BOTH keys
-    # at the instance's address; both lookups resolve.
+  test "dial-home registration keys NodeChannel ONLY by instance_id (node-name alias removed, PR-B0c)" do
+    # Post the instance-key migration (B0a/B0b) every NodeChannel consumer resolves the
+    # owning instance_id before dialing: the dispatcher (PR-2) via pick_node, and the
+    # stateful/session/serving/group wakes plus PoolManager via their dial resolvers.
+    # PR-B0c dropped the node-name alias: a shared last-writer-wins node-name key across
+    # a node's co-located bricks could only misroute a wake to the wrong sibling. So
+    # registration now points a SINGLE key, the instance_id, at the instance's address.
     {:ok, chan} = Agent.start_link(fn -> [] end)
     on_exit(fn -> if Process.alive?(chan), do: Agent.stop(chan) end)
 
@@ -481,16 +480,15 @@ defmodule Embervm.NodeRegistryTest do
 
     :ok = NodeRegistry.register(reg, %{"node" => "node-4", "pod_uid" => "uid-1", "address" => "10.42.1.24:9090"})
 
-    # Both keys resolve to the instance's address: the node-name alias (legacy wakes)
-    # AND the instance_id (dispatcher). Neither class is starved.
-    eventually(fn -> {"node-4", "10.42.1.24:9090"} in Agent.get(chan, & &1) end, 200)
+    # The instance_id key resolves; the bare node-name alias is NOT registered.
     eventually(fn -> {"node-4/uid-1", "10.42.1.24:9090"} in Agent.get(chan, & &1) end, 200)
+    refute {"node-4", "10.42.1.24:9090"} in Agent.get(chan, & &1)
   end
 
-  test "a node-scoped instance (empty pod_uid) keys NodeChannel exactly once (keys collapse)" do
-    # When pod_uid is empty the instance_id IS the node name, so channel_keys/1
-    # de-dups to a single key: the static/pinned single-daemon override registers
-    # NodeChannel once, not twice under the same key.
+  test "a node-scoped instance (empty pod_uid) keys NodeChannel exactly once under its node name" do
+    # When pod_uid is empty the instance_id IS the node name, so channel_keys/1 (just
+    # [instance_id] post-B0c) registers the static/pinned single-daemon override once,
+    # under its node name, which is where a node-scoped fact's dial resolves anyway.
     {:ok, chan} = Agent.start_link(fn -> [] end)
     on_exit(fn -> if Process.alive?(chan), do: Agent.stop(chan) end)
 
@@ -508,13 +506,11 @@ defmodule Embervm.NodeRegistryTest do
     assert length(updates) == 1
   end
 
-  test "instance expiry removes ONLY its own instance_id from NodeChannel, never the shared node-name alias" do
-    # Expiry drops the expiring instance's UNIQUE instance_id key, but must NOT touch
-    # the shared node-name alias: the alias is last-writer-wins across a node's
-    # co-located instances, so removing it on one instance's expiry would clobber a
-    # still-live sibling (regression covered end-to-end in the next test). The alias
-    # is managed solely by registration, exactly as pre-PR where expire never touched
-    # NodeChannel.
+  test "instance expiry removes its instance_id from NodeChannel (its only key, no node-name alias post-B0c)" do
+    # Expiry drops the expiring instance's UNIQUE instance_id key, which post-B0c is the
+    # only key it was registered under. There is no shared node-name alias to touch, so
+    # removing the instance_id can never affect a co-located sibling (covered end-to-end
+    # in the next test).
     {clock, advance} = new_clock()
     {:ok, removed} = Agent.start_link(fn -> [] end)
     on_exit(fn -> if Process.alive?(removed), do: Agent.stop(removed) end)
@@ -540,19 +536,20 @@ defmodule Embervm.NodeRegistryTest do
     NodeRegistry.tick(reg)
     eventually(fn -> not Map.has_key?(NodeRegistry.status(reg), "node-4/uid-1") end, 50)
 
-    # ONLY the instance_id was removed from NodeChannel; the node-name alias was left
-    # for registration to manage.
+    # The instance_id was removed from NodeChannel; the bare node name was never a key,
+    # so it never appears in the removal list.
     keys = Agent.get(removed, & &1)
     assert "node-4/uid-1" in keys
     refute "node-4" in keys
   end
 
-  test "expiring one co-located instance does NOT clobber a live sibling's node-name alias (Step 6 regression)" do
+  test "expiring one co-located instance leaves its sibling's instance_id intact (PR-B0c: no shared alias)" do
     # The real NodeChannel is the source of truth: register two co-located instances A
-    # and B on node-4 (B last, so B owns the shared "node-4" alias). Expire A. The
-    # legacy wakes' get("node-4") must still resolve to B's address, and A's own
-    # instance_id must be gone. Removing the alias on A's expiry (the reviewed bug)
-    # would leave node-4's wakes at :unknown_node until B re-registered.
+    # and B on the same node. Post-B0c there is no shared node-name alias: A and B are
+    # keyed purely by their unique instance_ids, so expiring A cannot affect B. This is
+    # the structural fix for the co-location misroute: with no shared, last-writer-wins
+    # node-name key, one sibling's expiry has nothing to clobber, and the bare node name
+    # resolves to nothing (every consumer dials the owning instance_id).
     nid_suffix = System.unique_integer([:positive])
     a_id = "node-#{nid_suffix}/uid-A"
     b_id = "node-#{nid_suffix}/uid-B"
@@ -589,15 +586,14 @@ defmodule Embervm.NodeRegistryTest do
 
     :ok = NodeRegistry.register(reg, %{"node" => node, "pod_uid" => "uid-A", "address" => a_addr})
     eventually(fn -> Map.has_key?(NodeRegistry.status(reg), a_id) end, 200)
-    # B registers LAST, so it owns the shared node-name alias.
     :ok = NodeRegistry.register(reg, %{"node" => node, "pod_uid" => "uid-B", "address" => b_addr})
     eventually(fn -> Map.has_key?(NodeRegistry.status(reg), b_id) end, 200)
 
-    # Sanity: before expiry, both instance keys and the alias resolve, and the alias
-    # points at B (the last writer).
+    # Sanity: before expiry, both instance_id keys resolve to their own address, and
+    # the bare node name resolves to nothing (no alias post-B0c).
     assert {:ok, {:chan, ^a_addr}} = Embervm.NodeChannel.get(nc, a_id)
     assert {:ok, {:chan, ^b_addr}} = Embervm.NodeChannel.get(nc, b_id)
-    assert {:ok, {:chan, ^b_addr}} = Embervm.NodeChannel.get(nc, node)
+    assert {:error, :unknown_node} = Embervm.NodeChannel.get(nc, node)
 
     # Expire A only: lapse its registration + kill its stream while B keeps re-registering.
     # (Advancing the clock lapses BOTH; we refresh B's liveness by re-registering it so
@@ -607,11 +603,11 @@ defmodule Embervm.NodeRegistryTest do
     NodeRegistry.tick(reg)
     eventually(fn -> not Map.has_key?(NodeRegistry.status(reg), a_id) end, 50)
 
-    # A's own key is gone.
+    # A's own key is gone; B's instance_id is untouched; the bare node name still
+    # resolves to nothing. A's expiry could not affect B because they never shared a key.
     assert {:error, :unknown_node} = Embervm.NodeChannel.get(nc, a_id)
-    # The shared node-name alias STILL resolves to the live sibling B (not clobbered).
-    assert {:ok, {:chan, ^b_addr}} = Embervm.NodeChannel.get(nc, node)
     assert {:ok, {:chan, ^b_addr}} = Embervm.NodeChannel.get(nc, b_id)
+    assert {:error, :unknown_node} = Embervm.NodeChannel.get(nc, node)
   end
 
   test "registration feeds instance add to the BaseBuilder (so BuildBase can place)" do

--- a/projects/embervm/control/test/embervm/wake_instance_test.exs
+++ b/projects/embervm/control/test/embervm/wake_instance_test.exs
@@ -279,8 +279,11 @@ defmodule Embervm.WakeInstanceTest do
                )
     end
 
-    test "a fact without an instance_id falls back to the node name (legacy/dual-key)", %{table: table} do
+    test "a fact without an instance_id falls back to the node name (legacy/node-scoped)", %{table: table} do
       # Mirror a statically-seeded / pre-field fact: no :instance_id, keyed by node.
+      # Post-B0c this bare node name is still a valid key for a node-scoped instance
+      # (its instance_id IS the node name), so the fallback resolves; only a co-located
+      # dial-home fact (which always carries :instance_id) would bypass it.
       NodeCapacity.put(table, "node-4", %{
         node_id: "node-4",
         configured_id: "node-4",

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.172
+      targetRevision: 0.1.173
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## What

Final step of the co-location instance-key migration (B0a #3762, B0b #3765, **B0c** here). `NodeRegistry.channel_keys/1` now returns `[instance_id]` alone, deleting the node-name alias that was kept as a fallback while the wakes were migrated.

## Why

After B0a/B0b, every NodeChannel consumer resolves the owning `instance_id` before dialing:
- dispatcher: `pick_node` -> instance_id (PR-2)
- stateful / serving / session / group wakes: `WakeInstance.dial_owning/5` and friends
- PoolManager: `dial_id/1` prefers `instance_id`

So the node-name alias is dead weight that can only **misroute**: it is a shared, last-writer-wins key across a node's co-located bricks, so `get("node-4")` resolves to whichever sibling registered last, not the VM owner. This was the root cause of the 2026-07-21 co-location incident (three 1 Hz retry loops + `/health` 503). Dropping it makes the misroute structurally impossible.

## Behavior change

A dial that cannot resolve an instance previously **failed open** to the bare node name (silently reaching an arbitrary sibling brick, a data-integrity hazard: you could bank/checkpoint the wrong VM). It now **fails closed** to `:unknown_node` (a loud, retryable miss). This is strictly safer, and only reachable now that every consumer resolves `instance_id` first. For a node-scoped instance the `instance_id` IS the node name, so static/pinned single-daemon overrides are unaffected.

## Tests

The three dual-key `node_registry_test` cases are rewritten to assert the single-key invariant: only the `instance_id` is registered; co-located siblings hold independent keys through one's expiry; the bare node name resolves to nothing. Stale present-tense "dual-key" comments in `node_channel`, `wake_instance`, and `pool_manager` are corrected. The historical "dial the owner, not the alias" rationale comments are left as accurate history.

## Rollout

Chart bumped to 0.1.173. This is the one irreversible keying step; verified safe by confirming no runtime consumer dials the bare node name (all `channel_fun` call sites pass an instance-resolved key). 🤖 Generated with [Claude Code](https://claude.com/claude-code)