### PR TITLE
feat(embervm): demand-driven brick autoscaling (Axis C)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.177
+version: 0.1.178

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -232,20 +232,28 @@ spec:
             {{- if .Values.bricks.enabled }}
             # Brick capacity (PR-3): the per-size-class DESIRED replica counts the
             # Embervm.BrickController reconciles the brick Deployments to, as a JSON
-            # array of {name,desired} (desired from the bricks.desiredReplicas map,
-            # default 0 for an unlisted class), plus the brick Deployment name prefix
-            # the controller appends the class to. Rendered ONLY when bricks are
-            # enabled, so a disabled fleet leaves the class list empty and the
-            # controller inert (it scales nothing, flags nothing).
+            # array of {name,desired,min,max} (desired from the bricks.desiredReplicas
+            # map, default 0 for an unlisted class; min/max are the Axis C autoscale
+            # clamp from bricks.autoscale.minReplicas/maxReplicas, unlisted min reads
+            # 0 and unlisted max falls back to the class's desired: no headroom), plus
+            # the brick Deployment name prefix the controller appends the class to and
+            # the autoscale mode gate. Rendered ONLY when bricks are enabled, so a
+            # disabled fleet leaves the class list empty and the controller inert (it
+            # scales nothing, flags nothing).
             {{- $desired := .Values.bricks.desiredReplicas }}
+            {{- $auto := .Values.bricks.autoscale | default dict }}
+            {{- $mins := $auto.minReplicas | default dict }}
+            {{- $maxs := $auto.maxReplicas | default dict }}
             {{- $classes := list }}
             {{- range .Values.bricks.classes }}
-            {{- $classes = append $classes (dict "name" .name "desired" (index $desired .name | default 0)) }}
+            {{- $classes = append $classes (dict "name" .name "desired" (index $desired .name | default 0) "min" (index $mins .name | default 0) "max" (index $maxs .name | default (index $desired .name | default 0))) }}
             {{- end }}
             - name: EMBERVM_BRICK_CLASSES
               value: {{ $classes | toJson | quote }}
             - name: EMBERVM_BRICK_DEPLOYMENT_PREFIX
               value: {{ printf "%s-brick-" (include "embervm.noded.fullname" .) | quote }}
+            - name: EMBERVM_BRICK_AUTOSCALE_MODE
+              value: {{ $auto.mode | default "off" | quote }}
             {{- end }}
             # The R5 composite (group) TCP activator port range: the values-declared
             # range the activator physically binds on the pod (Task 7), so the node

--- a/projects/embervm/chart/templates/rbac.yaml
+++ b/projects/embervm/chart/templates/rbac.yaml
@@ -93,3 +93,46 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "embervm.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- if .Values.bricks.enabled }}
+---
+# Drain-aware brick scale-down (Axis C, bricks.autoscale.mode=full): before
+# shrinking a brick Deployment the BrickController picks its own idle,
+# fully-exported victim and DIRECTS the ReplicaSet's choice by annotating that
+# pod with a negative controller.kubernetes.io/pod-deletion-cost; `pods list`
+# resolves the victim's name from the capacity fact's uid, `pods patch` writes
+# the annotation. A namespaced Role (not more rules on the ClusterRole above):
+# the controller only ever touches brick pods in its own release namespace, and
+# pods patch is too broad a grant to hold cluster-wide. Rendered only when
+# bricks are enabled, matching the brick Deployments themselves.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "embervm.fullname" . }}-brick-pods
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "embervm.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "embervm.fullname" . }}-brick-pods
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "embervm.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "embervm.fullname" . }}-brick-pods
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "embervm.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -907,6 +907,33 @@ bricks:
   # Deployment /spec/replicas fleet-wide, so the controller (not this value) is the
   # ongoing authority after first create.
   desiredReplicas: {}
+  # Demand-driven autoscale (fleet plan Axis C). The BrickController computes a
+  # per-class target from placement-denial pressure (up) and sustained brick
+  # idleness (down), clamped to [minReplicas, maxReplicas], with asymmetric
+  # cooldowns so it cannot flap. mode gates how much of the loop ACTS:
+  #   off     - legacy static reconcile to desiredReplicas only.
+  #   observe - DEFAULT: acts statically, logs every would-be decision
+  #             ("brick autoscale: would scale class ..."), so the loop soaks
+  #             against real traffic before it may act. Merging is safe.
+  #   up      - scale-up acts; scale-down stays observe-only.
+  #   full    - both act; scale-down is drain-aware (the controller picks an
+  #             idle, fully-exported victim and directs the Deployment's choice
+  #             via pod-deletion-cost before shrinking).
+  # Rollout is a values change (observe -> up -> full), never a code revert.
+  autoscale:
+    mode: observe
+    # Recorded policy (2026-07-20): keep one 16Gi brick warm so the scratch-k8s
+    # composite (a ~10 GiB single-brick group) wakes without a scale-up round
+    # trip; every other class may drain to zero. An unlisted class reads min 0.
+    minReplicas:
+      16gi: 1
+    # Recorded policy ceilings (no prior chart ceiling existed): the scale-up
+    # clamp per class. An unlisted class reads max(desired, min): no headroom.
+    maxReplicas:
+      2gi: 4
+      4gi: 3
+      8gi: 2
+      16gi: 2
   classes:
     - name: 2gi
       resources:

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -864,16 +864,37 @@ defmodule Embervm.Application do
       "" -> :ok
       prefix -> Application.put_env(:embervm, :brick_deployment_prefix, prefix)
     end
+
+    case brick_autoscale_mode_env() do
+      nil -> :ok
+      mode -> Application.put_env(:embervm, :brick_autoscale_mode, mode)
+    end
+  end
+
+  # Parse EMBERVM_BRICK_AUTOSCALE_MODE (Axis C). Only the four known modes are
+  # accepted; unset or unrecognized leaves the key absent so the controller's
+  # :off default fires (fail-safe: a typo in values must never ENABLE acting).
+  defp brick_autoscale_mode_env do
+    case trimmed_env("EMBERVM_BRICK_AUTOSCALE_MODE") do
+      "off" -> :off
+      "observe" -> :observe
+      "up" -> :up
+      "full" -> :full
+      _ -> nil
+    end
   end
 
   # BrickController reads all of its inputs from Application env at init, so no
   # start options are threaded here (the test suite injects its own).
   defp brick_controller_opts, do: []
 
-  # Parse EMBERVM_BRICK_CLASSES (a JSON array of {"name","desired"} objects) into a
-  # list of %{name, desired}. nil when unset, malformed, or empty, so the
+  # Parse EMBERVM_BRICK_CLASSES (a JSON array of {"name","desired"} objects, plus
+  # optional autoscale clamp fields "min"/"max") into a list of
+  # %{name, desired, min, max}. nil when unset, malformed, or empty, so the
   # controller's empty-list default fires (it reconciles nothing). A class missing
-  # a binary name or a non-negative integer desired is dropped, never crashing boot.
+  # a binary name or a non-negative integer desired is dropped, never crashing
+  # boot; an invalid/absent min reads 0 and an invalid/absent max reads nil (the
+  # controller then clamps to max(desired, min): no autoscale headroom).
   defp brick_classes_env do
     case trimmed_env("EMBERVM_BRICK_CLASSES") do
       "" ->
@@ -883,11 +904,16 @@ defmodule Embervm.Application do
         case safe_json_decode(raw) do
           list when is_list(list) ->
             parsed =
-              for %{"name" => name, "desired" => desired} <- list,
+              for %{"name" => name, "desired" => desired} = class <- list,
                   is_binary(name),
                   is_integer(desired),
                   desired >= 0 do
-                %{name: name, desired: desired}
+                %{
+                  name: name,
+                  desired: desired,
+                  min: non_neg_int_or(Map.get(class, "min"), 0),
+                  max: non_neg_int_or(Map.get(class, "max"), nil)
+                }
               end
 
             if parsed == [], do: nil, else: parsed
@@ -897,6 +923,9 @@ defmodule Embervm.Application do
         end
     end
   end
+
+  defp non_neg_int_or(value, _default) when is_integer(value) and value >= 0, do: value
+  defp non_neg_int_or(_value, default), do: default
 
   # :json.decode raises on malformed input; a bad EMBERVM_BRICK_CLASSES must leave
   # the controller inert, not crash the whole control plane at boot.

--- a/projects/embervm/control/lib/embervm/brick_controller.ex
+++ b/projects/embervm/control/lib/embervm/brick_controller.ex
@@ -143,6 +143,12 @@ defmodule Embervm.BrickController do
     * `:scale_get_fun`        - `(ns, name) -> {:ok, replicas} | {:error, term}`,
       the live replica read the autoscale loop bases decisions on; default
       `&Embervm.K8s.get_deployment_scale/2` (injected in tests).
+    * `:pods_fun`             - `(ns, label_selector) -> {:ok, [%{name, uid}]}`,
+      resolves the scale-down victim's pod name; default
+      `&Embervm.K8s.list_pods/2` (injected in tests).
+    * `:annotate_fun`         - `(ns, pod, annotations) -> :ok | {:error, term}`,
+      sets the victim's pod-deletion-cost; default
+      `&Embervm.K8s.annotate_pod/3` (injected in tests).
     * `:registered_fun`       - `() -> %{class => count}` of registered bricks,
       default derived from `Embervm.BrickLedger.by_class/0` (injected in tests).
     * `:facts_fun`            - `() -> [facts]` raw capacity facts (idle/victim
@@ -196,6 +202,8 @@ defmodule Embervm.BrickController do
       fleet_full_after_ms: Keyword.get(opts, :fleet_full_after_ms, @default_fleet_full_after_ms),
       scale_fun: Keyword.get(opts, :scale_fun, &K8s.scale_deployment/3),
       scale_get_fun: Keyword.get(opts, :scale_get_fun, &K8s.get_deployment_scale/2),
+      pods_fun: Keyword.get(opts, :pods_fun, &K8s.list_pods/2),
+      annotate_fun: Keyword.get(opts, :annotate_fun, &K8s.annotate_pod/3),
       registered_fun: Keyword.get(opts, :registered_fun, &registered_by_class/0),
       facts_fun: Keyword.get(opts, :facts_fun, fn -> NodeCapacity.all(NodeCapacity.table()) end),
       up_threshold: Keyword.get(opts, :up_threshold, @default_up_threshold),
@@ -357,24 +365,49 @@ defmodule Embervm.BrickController do
 
     with true <- state.mode != :off,
          {:ok, current} <- read_current(state, name) do
-      {target, reason} = desired(current, signals(state, class, now))
-      acting = acting_replicas(state, static, current, target)
-      state = note_decision(state, name, current, target, reason, now, acting == target)
-      {acting, state}
+      execute(state, class, current, now)
     else
       _ -> {static, state}
     end
   end
 
-  # What the tick WRITES. :observe always asserts the static desired (legacy
-  # behavior, decisions log-only). The acting modes assert the LIVE current as
-  # their baseline (the controller keeps re-asserting every tick, staying the
-  # single writer) and move it only in the direction(s) the mode enables:
-  # :up acts on increases (min-floor jumps included) and leaves decreases as
-  # would-scale logs; :full (phase 3) acts on decreases too.
-  defp acting_replicas(%{mode: :observe}, static, _current, _target), do: static
-  defp acting_replicas(_state, _static, current, target) when target > current, do: target
-  defp acting_replicas(_state, _static, current, _target), do: current
+  # Decide and (mode permitting) act for one class. What the tick WRITES:
+  # :observe always asserts the static desired (legacy behavior, decisions
+  # log-only). The acting modes assert the LIVE current as their baseline (the
+  # controller keeps re-asserting every tick, staying the single writer) and
+  # move it only in the direction(s) the mode enables: :up acts on increases
+  # (min-floor jumps included) and leaves decreases as would-scale logs; :full
+  # acts on decreases too, but only through the drain-aware victim gate (a
+  # skipped victim leaves the count as-is this tick, no cooldown stamped, so
+  # the decision retries as soon as a replica is safely removable).
+  defp execute(state, class, current, now) do
+    name = class_name(class)
+    {target, reason} = desired(current, signals(state, class, now))
+
+    cond do
+      state.mode == :observe ->
+        {class_desired(class), note_decision(state, name, current, target, reason, now, false)}
+
+      target > current ->
+        {target, note_decision(state, name, current, target, reason, now, true)}
+
+      target < current and state.mode == :full ->
+        case prepare_scale_down(state, name) do
+          :ok ->
+            {target, note_decision(state, name, current, target, reason, now, true)}
+
+          {:skip, why} ->
+            Logger.info("brick autoscale: skipping scale-down of class #{name} (reason=#{why})")
+            {current, state}
+        end
+
+      target < current ->
+        {current, note_decision(state, name, current, target, reason, now, false)}
+
+      true ->
+        {current, state}
+    end
+  end
 
   defp read_current(state, name) do
     deployment = state.deployment_prefix <> name
@@ -497,6 +530,81 @@ defmodule Embervm.BrickController do
     case Map.get(stamps, name) do
       nil -> true
       at -> now - at >= cooldown_ms
+    end
+  end
+
+  # -- drain-aware scale-down (mode :full) -------------------------------------
+
+  @deletion_cost_annotation "controller.kubernetes.io/pod-deletion-cost"
+  # Any negative cost beats the default (an unannotated sibling reads 0), so the
+  # ReplicaSet deletes the chosen victim first when /scale shrinks.
+  @victim_deletion_cost "-1000"
+
+  # The warmth inventories a brick advertises in its capacity fact; a victim may
+  # only be removed when EVERY entry across them has a current store copy
+  # (exported: true), else banked state would be stranded on the dying pod's
+  # per-instance warmth root (PR-2.5: a successor pod cannot see it on disk,
+  # only the store restore-on-miss path can, and that needs the export).
+  @warmth_keys [:stateful_bundles, :session_snapshots, :serving_snapshots, :group_bundle_sets]
+
+  # Select a safe victim and direct the Deployment's scale-down choice at it.
+  # :ok means the victim is annotated and the /scale shrink may proceed;
+  # {:skip, why} means no replica can be removed safely this tick (the
+  # refuse-to-strand rail) or the directing write failed, and the scale-down is
+  # deferred, never forced. Between the annotate and the ReplicaSet's kill a
+  # placement can still race a VM onto the victim; the existing bounded
+  # preemption drain (noded SIGTERM -> registry drain edge -> DrainCoordinator
+  # force-bank) is the backstop for exactly that window.
+  defp prepare_scale_down(state, class) do
+    case pick_victim(state.facts_fun.(), class) do
+      nil -> {:skip, :no_safe_victim}
+      victim -> direct_victim(state, class, victim)
+    end
+  end
+
+  # The refuse-to-strand rail: a victim must be a registered, non-draining brick
+  # of the class with ZERO live VMs and a fully-exported warmth inventory.
+  # Among the safe candidates, remove the one with the least warmth to lose
+  # (fewest banked bundles/snapshots; ties fall to the first sorted).
+  defp pick_victim(facts, class) do
+    facts
+    |> Enum.filter(fn f ->
+      Map.get(f, :size_class, "") == class and not Map.get(f, :draining, false) and
+        Map.get(f, :live_vms, 0) == 0 and warmth_all_exported?(f)
+    end)
+    |> case do
+      [] -> nil
+      safe -> Enum.min_by(safe, &length(warmth_inventory(&1)))
+    end
+  end
+
+  defp warmth_inventory(fact), do: Enum.flat_map(@warmth_keys, &(Map.get(fact, &1) || []))
+
+  # An entry without the flag reads NOT exported (fail-closed: unknown warmth is
+  # never assumed store-recoverable).
+  defp warmth_all_exported?(fact) do
+    Enum.all?(warmth_inventory(fact), fn entry -> Map.get(entry, :exported, false) == true end)
+  end
+
+  # Resolve the victim's pod NAME (facts carry only the uid) via the brick
+  # selector labels, then set the negative deletion cost on it. Any miss along
+  # the way (pods list failure, the victim's pod already gone, the PATCH
+  # refused) skips the scale-down rather than shrinking with an undirected
+  # victim choice.
+  defp direct_victim(state, class, victim) do
+    selector = "app.kubernetes.io/component=noded-brick,embervm.jomcgi.dev/size-class=#{class}"
+
+    with {:ok, pods} <- state.pods_fun.(state.namespace, selector),
+         %{name: pod_name} <-
+           Enum.find(pods, :no_pod, fn pod -> pod.uid == Map.get(victim, :pod_uid) end),
+         :ok <-
+           state.annotate_fun.(state.namespace, pod_name, %{
+             @deletion_cost_annotation => @victim_deletion_cost
+           }) do
+      :ok
+    else
+      :no_pod -> {:skip, :victim_pod_not_found}
+      {:error, reason} -> {:skip, inspect(reason)}
     end
   end
 

--- a/projects/embervm/control/lib/embervm/brick_controller.ex
+++ b/projects/embervm/control/lib/embervm/brick_controller.ex
@@ -347,9 +347,10 @@ defmodule Embervm.BrickController do
   # The per-class plan: what replica count to ACT with this tick, plus the
   # autoscale decision log. Mode :off is the legacy static reconcile untouched.
   # Every other mode computes the autoscale target off the LIVE /scale read;
-  # in this phase (observe-only) ALL modes still act statically and the target
-  # is logged, never written. A failed /scale read degrades that class to the
-  # static path for the tick (the decision needs a trustworthy current).
+  # :observe still acts statically and only logs the target, the acting modes
+  # assert the live current and move it in the enabled direction(s). A failed
+  # /scale read degrades that class to the static path for the tick (the
+  # decision needs a trustworthy current).
   defp plan_class(state, class, now) do
     name = class_name(class)
     static = class_desired(class)
@@ -357,12 +358,23 @@ defmodule Embervm.BrickController do
     with true <- state.mode != :off,
          {:ok, current} <- read_current(state, name) do
       {target, reason} = desired(current, signals(state, class, now))
-      state = note_decision(state, name, current, target, reason, now)
-      {static, state}
+      acting = acting_replicas(state, static, current, target)
+      state = note_decision(state, name, current, target, reason, now, acting == target)
+      {acting, state}
     else
       _ -> {static, state}
     end
   end
+
+  # What the tick WRITES. :observe always asserts the static desired (legacy
+  # behavior, decisions log-only). The acting modes assert the LIVE current as
+  # their baseline (the controller keeps re-asserting every tick, staying the
+  # single writer) and move it only in the direction(s) the mode enables:
+  # :up acts on increases (min-floor jumps included) and leaves decreases as
+  # would-scale logs; :full (phase 3) acts on decreases too.
+  defp acting_replicas(%{mode: :observe}, static, _current, _target), do: static
+  defp acting_replicas(_state, _static, current, target) when target > current, do: target
+  defp acting_replicas(_state, _static, current, _target), do: current
 
   defp read_current(state, name) do
     deployment = state.deployment_prefix <> name
@@ -402,24 +414,27 @@ defmodule Embervm.BrickController do
     }
   end
 
-  # Log the decision and stamp the direction cooldown. Stamped in observe mode
-  # too, so the observed log stream paces exactly as the acting modes would
-  # (one would-scale line per cooldown, not one per tick).
-  defp note_decision(state, name, current, target, reason, now) do
+  # Log the decision and stamp the direction cooldown. Stamped on would-scale
+  # decisions (observe, or a direction the mode has not enabled) too, so the
+  # observed log stream paces exactly as the acting modes would (one line per
+  # cooldown, not one per tick) and a mode flip inherits sane cooldown state.
+  defp note_decision(state, name, current, target, reason, now, acted?) do
+    verb = if acted?, do: "scaling", else: "would scale"
+
     cond do
       target == current ->
         state
 
       target > current ->
         Logger.info(
-          "brick autoscale: would scale class #{name} from #{current} to #{target} (reason=#{reason})"
+          "brick autoscale: #{verb} class #{name} from #{current} to #{target} (reason=#{reason})"
         )
 
         %{state | last_up_at: Map.put(state.last_up_at, name, now)}
 
       target < current ->
         Logger.info(
-          "brick autoscale: would scale class #{name} from #{current} to #{target} (reason=#{reason})"
+          "brick autoscale: #{verb} class #{name} from #{current} to #{target} (reason=#{reason})"
         )
 
         %{state | last_down_at: Map.put(state.last_down_at, name, now)}

--- a/projects/embervm/control/lib/embervm/brick_controller.ex
+++ b/projects/embervm/control/lib/embervm/brick_controller.ex
@@ -16,6 +16,64 @@ defmodule Embervm.BrickController do
   on Deployment `/spec/replicas` (the HPA rule) keeps these writes invisible to
   selfHeal.
 
+  ## demand-driven autoscale (fleet plan Axis C)
+
+  Beyond the static per-class desired count, the controller runs a DEMAND loop
+  gated by `bricks.autoscale.mode` (values -> `EMBERVM_BRICK_AUTOSCALE_MODE`):
+
+    * `off`     - legacy behavior: reconcile to the static `desired` only.
+    * `observe` - DEFAULT. Still ACTS statically (identical live behavior to
+      `off`), but computes and LOGS the autoscale decision each tick
+      ("brick autoscale: would scale class X from N to M (reason=...)"), so the
+      loop soaks against real traffic before it is allowed to act.
+    * `up`      - scale-UP decisions act; scale-down stays observe-only.
+    * `full`    - both directions act; scale-down is drain-aware (victim rail).
+
+  The loop is level-based per class, evaluated on the reconcile tick against the
+  LIVE replica count read from the Deployment's `/scale` subresource (so a CP
+  restart never forgets a prior scale-up): `desired/2` is the pure decision
+  function, `{target, reason} = desired(current, signals)`.
+
+  Scale-UP signal: placement CAPACITY denials. The two choke points every
+  new-placement path funnels through call `note_denial/2` (an async cast, never
+  blocking placement) when demand hits a capacity wall: the cold wake pick
+  (`Embervm.WakeInstance`) when NO brick on the node is slot/mem-eligible, and
+  the dispatcher miss tier when ready candidates exist but none has budget/mem
+  headroom. A denial is attributed to the SMALLEST configured class whose
+  capacity fits the workload's `need_mib` (class capacity parsed from the ladder
+  label, `"2gi"` -> 2048 MiB). `up_threshold` denials (default 3) inside
+  `up_window_ms` (default 60s) step the class +1, clamped to `max`.
+
+  Scale-down signal: the class has at least one IDLE brick (a registered,
+  non-draining instance with zero live VMs) continuously for `down_idle_ms`
+  (default 15m) AND zero denials in the window AND no fleet-full episode inside
+  the same window. Steps -1, never below `min`.
+
+  Hysteresis: separate cooldowns per direction (`up_cooldown_ms` default 60s,
+  `down_cooldown_ms` default 10m; a scale-up also blocks scale-down for the
+  down cooldown), plus the asymmetric windows above, so the loop cannot flap.
+  Cooldowns are stamped in `observe` mode too, so the observed log stream is a
+  faithful simulation of what `full` would have done.
+
+  Recorded policy (2026-07-20, values-declared, not hardcoded): per-class
+  min-floor `{2gi: 0, 4gi: 0, 8gi: 0, 16gi: 1}` (one 16Gi stays warm for the
+  scratch-k8s composite, which must fit a single brick) and per-class max
+  `{2gi: 4, 4gi: 3, 8gi: 2, 16gi: 2}` (`bricks.autoscale.minReplicas` /
+  `maxReplicas` in the chart values, deep-merged like `desiredReplicas`).
+
+  Drain-aware scale-down (mode `full`): a Deployment picks its own scale-down
+  victim, which is unacceptable when a sibling replica holds live VMs or
+  un-exported warmth. Before writing `current - 1` the controller selects a SAFE
+  victim itself: a brick of the class with ZERO live VMs whose entire warmth
+  inventory (stateful bundles, session/serving snapshots, group bundle sets) is
+  `exported: true` (refuse-to-strand rail: no safe victim means the scale-down
+  is SKIPPED this tick and logged, never forced). It then directs the
+  Deployment's choice by annotating the victim pod with a negative
+  `controller.kubernetes.io/pod-deletion-cost` and only then PATCHes `/scale`.
+  If a placement races a VM onto the victim between the check and the kill, the
+  existing bounded-preemption drain (noded SIGTERM -> registry drain edge ->
+  `Embervm.DrainCoordinator` force-bank) is the backstop.
+
   ## fleet-full
 
   A class is FLEET-FULL when its desired count exceeds the number of dial-home
@@ -26,7 +84,9 @@ defmodule Embervm.BrickController do
   reads `fleet_full?/2` to turn a would-be denial into a terminal `:fleet_full`
   (503) rather than a retryable park, and the flag transition is logged + traced
   for a SigNoz alert. A class recovers (unflagged) the first tick its registered
-  count catches up to desired.
+  count catches up to desired. A flagged class also refuses further autoscale
+  UP steps (scaling desired past a scheduler that cannot place is runaway) and
+  blocks DOWN steps for the idle window after the episode clears.
 
   ## inert until bricks exist
 
@@ -48,20 +108,31 @@ defmodule Embervm.BrickController do
   require Logger
   require OpenTelemetry.Tracer, as: Tracer
 
-  alias Embervm.{BrickLedger, K8s}
+  alias Embervm.{BrickLedger, K8s, NodeCapacity}
 
   @default_interval_ms 30_000
   @default_fleet_full_after_ms 300_000
+  @default_up_threshold 3
+  @default_up_window_ms 60_000
+  @default_up_cooldown_ms 60_000
+  @default_down_idle_ms 900_000
+  @default_down_cooldown_ms 600_000
 
-  @typedoc "One size-class the controller reconciles: its label and desired replica count."
+  @typedoc """
+  One size-class the controller reconciles: its label, static desired replica
+  count, and the autoscale clamp (`min`/`max`, optional: absent min reads 0,
+  absent max reads `max(desired, min)`, i.e. no autoscale headroom).
+  """
   @type class :: %{name: String.t(), desired: non_neg_integer()}
 
   @doc """
   Start options (all optional; production reads from Application env / K8s):
 
     * `:name`                 - registered name (default `#{inspect(__MODULE__)}`).
-    * `:classes`              - `[%{name, desired}]`; default from
+    * `:classes`              - `[%{name, desired, min, max}]`; default from
       `Application.get_env(:embervm, :brick_classes, [])` (empty = inert).
+    * `:mode`                 - autoscale mode `:off | :observe | :up | :full`;
+      default `Application.get_env(:embervm, :brick_autoscale_mode, :off)`.
     * `:deployment_prefix`    - the brick Deployment name prefix; a class scales
       `<prefix><class>`. Default from `EMBERVM_BRICK_DEPLOYMENT_PREFIX` app env.
     * `:namespace`            - default `Embervm.K8s.namespace/0`.
@@ -69,8 +140,16 @@ defmodule Embervm.BrickController do
     * `:fleet_full_after_ms`  - desired>registered dwell before flagging (default 5m).
     * `:scale_fun`            - `(ns, name, replicas) -> :ok | {:error, term}`,
       default `&Embervm.K8s.scale_deployment/3` (injected in tests).
+    * `:scale_get_fun`        - `(ns, name) -> {:ok, replicas} | {:error, term}`,
+      the live replica read the autoscale loop bases decisions on; default
+      `&Embervm.K8s.get_deployment_scale/2` (injected in tests).
     * `:registered_fun`       - `() -> %{class => count}` of registered bricks,
       default derived from `Embervm.BrickLedger.by_class/0` (injected in tests).
+    * `:facts_fun`            - `() -> [facts]` raw capacity facts (idle/victim
+      inputs), default `NodeCapacity.all/1` (injected in tests).
+    * `:up_threshold` / `:up_window_ms` / `:up_cooldown_ms` /
+      `:down_idle_ms` / `:down_cooldown_ms` - hysteresis knobs (defaults
+      3 / 60s / 60s / 15m / 10m).
     * `:clock`                - `() -> integer()` ms clock (injected in tests).
     * `:reconcile_on_start`   - reconcile once immediately (default true).
   """
@@ -91,10 +170,24 @@ defmodule Embervm.BrickController do
     GenServer.call(server, :flagged)
   end
 
+  @doc """
+  Record one placement CAPACITY denial for a workload needing `need_mib` MiB
+  (the scale-up demand signal). Fire-and-forget cast so the placement hot path
+  never blocks on (or crashes with) the controller; when the controller is not
+  running (tests, DS-only fleets) the cast is a silent no-op. The denial is
+  attributed to the smallest configured class whose capacity fits `need_mib`;
+  a need no class can hold is dropped (scaling any class would not help).
+  """
+  @spec note_denial(GenServer.server(), non_neg_integer()) :: :ok
+  def note_denial(server \\ __MODULE__, need_mib) do
+    GenServer.cast(server, {:denial, need_mib})
+  end
+
   @impl true
   def init(opts) do
     state = %{
       classes: Keyword.get(opts, :classes) || Application.get_env(:embervm, :brick_classes, []),
+      mode: Keyword.get(opts, :mode) || Application.get_env(:embervm, :brick_autoscale_mode, :off),
       deployment_prefix:
         Keyword.get(opts, :deployment_prefix) ||
           Application.get_env(:embervm, :brick_deployment_prefix, ""),
@@ -102,11 +195,28 @@ defmodule Embervm.BrickController do
       interval_ms: Keyword.get(opts, :interval_ms, @default_interval_ms),
       fleet_full_after_ms: Keyword.get(opts, :fleet_full_after_ms, @default_fleet_full_after_ms),
       scale_fun: Keyword.get(opts, :scale_fun, &K8s.scale_deployment/3),
+      scale_get_fun: Keyword.get(opts, :scale_get_fun, &K8s.get_deployment_scale/2),
       registered_fun: Keyword.get(opts, :registered_fun, &registered_by_class/0),
+      facts_fun: Keyword.get(opts, :facts_fun, fn -> NodeCapacity.all(NodeCapacity.table()) end),
+      up_threshold: Keyword.get(opts, :up_threshold, @default_up_threshold),
+      up_window_ms: Keyword.get(opts, :up_window_ms, @default_up_window_ms),
+      up_cooldown_ms: Keyword.get(opts, :up_cooldown_ms, @default_up_cooldown_ms),
+      down_idle_ms: Keyword.get(opts, :down_idle_ms, @default_down_idle_ms),
+      down_cooldown_ms: Keyword.get(opts, :down_cooldown_ms, @default_down_cooldown_ms),
       clock: Keyword.get(opts, :clock, &now_ms/0),
       # class => the ms timestamp desired first exceeded registered (cleared when it recovers).
       over_since: %{},
-      flagged: MapSet.new()
+      flagged: MapSet.new(),
+      # Autoscale bookkeeping, all per class-name:
+      # recent denial timestamps (pruned to up_window_ms each tick),
+      denials: %{},
+      # since when the class has continuously had >=1 idle brick,
+      idle_since: %{},
+      # last up/down decision stamps (hysteresis cooldowns),
+      last_up_at: %{},
+      last_down_at: %{},
+      # last tick the class was flagged fleet-full (blocks down for the idle window).
+      last_full_at: %{}
     }
 
     if Keyword.get(opts, :reconcile_on_start, true), do: send(self(), :reconcile)
@@ -119,6 +229,18 @@ defmodule Embervm.BrickController do
     state = reconcile(state)
     schedule(state)
     {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast({:denial, need_mib}, state) do
+    case class_for_need(state.classes, need_mib) do
+      nil ->
+        {:noreply, state}
+
+      class ->
+        now = state.clock.()
+        {:noreply, %{state | denials: Map.update(state.denials, class, [now], &[now | &1])}}
+    end
   end
 
   @impl true
@@ -141,40 +263,253 @@ defmodule Embervm.BrickController do
     {:reply, :ok, reconcile(state)}
   end
 
+  # -- the pure decision function ---------------------------------------------
+
+  @doc """
+  The pure autoscale decision for one class: given the LIVE replica count and
+  the signal snapshot, return `{target, reason}`. `signals` carries:
+
+    * `:min` / `:max`          - the clamp (max is normalized to `>= min`).
+    * `:denials`               - capacity denials attributed to the class inside
+      the up window.
+    * `:up_threshold`          - denials needed to step up.
+    * `:fleet_full_now`        - the class is currently flagged fleet-full
+      (refuses UP: desired already outruns what the scheduler can place).
+    * `:fleet_full_recent`     - a fleet-full episode inside the down window
+      (refuses DOWN: capacity was just proven scarce).
+    * `:idle_dwell_ok`         - the class has had an idle brick continuously
+      for the down idle window.
+    * `:up_cooldown_ok` / `:down_cooldown_ok` - per-direction hysteresis gates.
+
+  One step per decision (`+1`/`-1`); the min-floor jump is the only multi-step
+  move (a class below its floor goes straight to `min`). Reasons are the
+  machine-readable tail of the decision log line.
+  """
+  @spec desired(non_neg_integer(), map()) :: {non_neg_integer(), atom()}
+  def desired(current, signals) do
+    min = Map.get(signals, :min, 0)
+    max = max(Map.get(signals, :max, min), min)
+    pressure? = signals.denials >= signals.up_threshold
+
+    cond do
+      current < min -> {min, :min_floor}
+      pressure? and current >= max -> {current, :at_max}
+      pressure? and signals.fleet_full_now -> {current, :fleet_full_wait}
+      pressure? and not signals.up_cooldown_ok -> {current, :up_cooldown}
+      pressure? -> {current + 1, :denial_pressure}
+      current > max -> {current - 1, :over_max}
+      down_ok?(current, min, signals) -> {current - 1, :idle_drain}
+      true -> {current, :steady}
+    end
+  end
+
+  defp down_ok?(current, min, signals) do
+    current > min and signals.denials == 0 and signals.idle_dwell_ok and
+      signals.down_cooldown_ok and not signals.fleet_full_recent
+  end
+
   # -- reconcile ---------------------------------------------------------------
 
   defp reconcile(state) do
     registered = state.registered_fun.()
     now = state.clock.()
+    state = if state.mode == :off, do: state, else: state |> prune_denials(now) |> track_idle(now)
 
-    {over_since, flagged} =
-      Enum.reduce(state.classes, {%{}, MapSet.new()}, fn class, {os, fl} ->
+    {over_since, flagged, state} =
+      Enum.reduce(state.classes, {%{}, MapSet.new(), state}, fn class, {os, fl, st} ->
         name = class_name(class)
-        desired = class_desired(class)
+        {acting, st} = plan_class(st, class, now)
 
-        scale(state, name, desired)
+        scale(st, name, acting)
 
         reg = Map.get(registered, name, 0)
 
-        if desired > reg do
-          since = Map.get(state.over_since, name, now)
+        if acting > reg do
+          since = Map.get(st.over_since, name, now)
           os = Map.put(os, name, since)
 
-          if now - since >= state.fleet_full_after_ms do
-            maybe_flag(state, name, desired, reg)
-            {os, MapSet.put(fl, name)}
+          if now - since >= st.fleet_full_after_ms do
+            maybe_flag(st, name, acting, reg)
+            {os, MapSet.put(fl, name), %{st | last_full_at: Map.put(st.last_full_at, name, now)}}
           else
-            {os, fl}
+            {os, fl, st}
           end
         else
           # Caught up (or over-provisioned): clear any prior over-window and flag.
-          maybe_unflag(state, name)
-          {os, fl}
+          maybe_unflag(st, name)
+          {os, fl, st}
         end
       end)
 
     %{state | over_since: over_since, flagged: flagged}
   end
+
+  # The per-class plan: what replica count to ACT with this tick, plus the
+  # autoscale decision log. Mode :off is the legacy static reconcile untouched.
+  # Every other mode computes the autoscale target off the LIVE /scale read;
+  # in this phase (observe-only) ALL modes still act statically and the target
+  # is logged, never written. A failed /scale read degrades that class to the
+  # static path for the tick (the decision needs a trustworthy current).
+  defp plan_class(state, class, now) do
+    name = class_name(class)
+    static = class_desired(class)
+
+    with true <- state.mode != :off,
+         {:ok, current} <- read_current(state, name) do
+      {target, reason} = desired(current, signals(state, class, now))
+      state = note_decision(state, name, current, target, reason, now)
+      {static, state}
+    else
+      _ -> {static, state}
+    end
+  end
+
+  defp read_current(state, name) do
+    deployment = state.deployment_prefix <> name
+
+    case state.scale_get_fun.(state.namespace, deployment) do
+      {:ok, current} ->
+        {:ok, current}
+
+      {:error, reason} ->
+        # Same tolerance as scale/3: a 404 (not-yet-rendered class) or transient
+        # apiserver error skips the autoscale decision for the tick, never crashes.
+        Logger.warning("embervm brick autoscale current read failed",
+          size_class: name,
+          deployment: deployment,
+          reason: inspect(reason)
+        )
+
+        :error
+    end
+  end
+
+  defp signals(state, class, now) do
+    name = class_name(class)
+
+    %{
+      min: class_min(class),
+      max: class_max(class),
+      denials: length(Map.get(state.denials, name, [])),
+      up_threshold: state.up_threshold,
+      fleet_full_now: MapSet.member?(state.flagged, name),
+      fleet_full_recent: fleet_full_recent?(state, name, now),
+      idle_dwell_ok: idle_dwell_ok?(state, name, now),
+      up_cooldown_ok: cooldown_ok?(state.last_up_at, name, now, state.up_cooldown_ms),
+      down_cooldown_ok:
+        cooldown_ok?(state.last_down_at, name, now, state.down_cooldown_ms) and
+          cooldown_ok?(state.last_up_at, name, now, state.down_cooldown_ms)
+    }
+  end
+
+  # Log the decision and stamp the direction cooldown. Stamped in observe mode
+  # too, so the observed log stream paces exactly as the acting modes would
+  # (one would-scale line per cooldown, not one per tick).
+  defp note_decision(state, name, current, target, reason, now) do
+    cond do
+      target == current ->
+        state
+
+      target > current ->
+        Logger.info(
+          "brick autoscale: would scale class #{name} from #{current} to #{target} (reason=#{reason})"
+        )
+
+        %{state | last_up_at: Map.put(state.last_up_at, name, now)}
+
+      target < current ->
+        Logger.info(
+          "brick autoscale: would scale class #{name} from #{current} to #{target} (reason=#{reason})"
+        )
+
+        %{state | last_down_at: Map.put(state.last_down_at, name, now)}
+    end
+  end
+
+  defp prune_denials(state, now) do
+    horizon = now - state.up_window_ms
+
+    denials =
+      state.denials
+      |> Enum.map(fn {class, stamps} -> {class, Enum.filter(stamps, &(&1 > horizon))} end)
+      |> Enum.reject(fn {_class, stamps} -> stamps == [] end)
+      |> Map.new()
+
+    %{state | denials: denials}
+  end
+
+  # A class's idle dwell: idle_since[class] holds from the first tick the class
+  # had >=1 idle brick (a registered, non-draining instance with zero live VMs)
+  # and clears the tick it has none, so the dwell requires CONTINUOUS idleness.
+  defp track_idle(state, now) do
+    facts = state.facts_fun.()
+
+    idle_since =
+      Enum.reduce(state.classes, %{}, fn class, acc ->
+        name = class_name(class)
+
+        if Enum.any?(facts, &idle_brick?(&1, name)) do
+          Map.put(acc, name, Map.get(state.idle_since, name, now))
+        else
+          acc
+        end
+      end)
+
+    %{state | idle_since: idle_since}
+  end
+
+  defp idle_brick?(fact, class) do
+    Map.get(fact, :size_class, "") == class and not Map.get(fact, :draining, false) and
+      Map.get(fact, :live_vms, 0) == 0
+  end
+
+  defp idle_dwell_ok?(state, name, now) do
+    case Map.get(state.idle_since, name) do
+      nil -> false
+      since -> now - since >= state.down_idle_ms
+    end
+  end
+
+  defp fleet_full_recent?(state, name, now) do
+    MapSet.member?(state.flagged, name) or
+      case Map.get(state.last_full_at, name) do
+        nil -> false
+        at -> now - at < state.down_idle_ms
+      end
+  end
+
+  defp cooldown_ok?(stamps, name, now, cooldown_ms) do
+    case Map.get(stamps, name) do
+      nil -> true
+      at -> now - at >= cooldown_ms
+    end
+  end
+
+  # -- denial attribution ------------------------------------------------------
+
+  # The smallest configured class whose capacity holds need_mib. Class capacity
+  # is parsed from the ladder label ("2gi" -> 2048 MiB): the label IS the size by
+  # chart construction (each class's memory request==limit is its name), so the
+  # name is the one source the CP already has. A label that does not parse (or a
+  # need bigger than every class) attributes nowhere: scaling cannot serve it.
+  defp class_for_need(classes, need_mib) do
+    classes
+    |> Enum.map(fn c -> {class_name(c), class_capacity_mib(class_name(c))} end)
+    |> Enum.filter(fn {_name, cap} -> is_integer(cap) and cap >= need_mib end)
+    |> case do
+      [] -> nil
+      fits -> fits |> Enum.min_by(fn {_name, cap} -> cap end) |> elem(0)
+    end
+  end
+
+  defp class_capacity_mib(name) do
+    case Regex.run(~r/^(\d+)gi$/, name) do
+      [_, n] -> String.to_integer(n) * 1024
+      _ -> nil
+    end
+  end
+
+  # -- scale write -------------------------------------------------------------
 
   defp scale(state, name, desired) do
     deployment = state.deployment_prefix <> name
@@ -236,6 +571,17 @@ defmodule Embervm.BrickController do
   defp class_desired(%{desired: d}), do: d
   defp class_desired(%{"desired" => d}), do: d
   defp class_desired(_), do: 0
+
+  defp class_min(class), do: class_field(class, [:min, "min"]) || 0
+
+  # Absent max reads max(desired, min): a class the values never granted headroom
+  # cannot be scaled past its static count (fail-safe for an env that predates
+  # the autoscale fields).
+  defp class_max(class) do
+    class_field(class, [:max, "max"]) || max(class_desired(class), class_min(class))
+  end
+
+  defp class_field(class, keys), do: Enum.find_value(keys, &Map.get(class, &1))
 
   defp schedule(state), do: Process.send_after(self(), :reconcile, state.interval_ms)
 

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -579,8 +579,18 @@ defmodule Embervm.Dispatcher do
               end)
 
             case BrickLedger.choose(miss_candidates, wl) do
-              nil -> {:error, :no_capacity}
-              f -> {:ok, instance_id_of(f), :miss, snapshot_ref_of(f, wl)}
+              nil ->
+                # A true CAPACITY wall (Axis C demand signal): ready, base-holding
+                # candidates exist but every one is out of slots or too small for
+                # the workload's mem_mib. The no-base / stale branches above are
+                # deliberately NOT noted: they wait on provisioning or fact
+                # freshness, which a scale-up cannot serve. Async cast; a missing
+                # controller (tests) makes it a silent no-op.
+                Embervm.BrickController.note_denial(need_mib)
+                {:error, :no_capacity}
+
+              f ->
+                {:ok, instance_id_of(f), :miss, snapshot_ref_of(f, wl)}
             end
 
           warm ->

--- a/projects/embervm/control/lib/embervm/k8s.ex
+++ b/projects/embervm/control/lib/embervm/k8s.ex
@@ -379,6 +379,64 @@ defmodule Embervm.K8s do
     end
   end
 
+  @doc """
+  Lists pods in `namespace` matching `label_selector`, projected to just the
+  identity fields the BrickController's victim-directing needs (`name` to PATCH
+  the annotation, `uid` to match the capacity fact's `pod_uid`). Namespaced
+  `pods list` RBAC, granted by the brick-pods Role only when bricks are enabled.
+  """
+  @spec list_pods(String.t(), String.t()) ::
+          {:ok, [%{name: String.t(), uid: String.t()}]} | {:error, term()}
+  def list_pods(namespace, label_selector) do
+    path =
+      "/api/v1/namespaces/#{URI.encode(namespace)}/pods?labelSelector=#{URI.encode_www_form(label_selector)}"
+
+    case do_request(:get, path, nil, nil) do
+      {:ok, 200, body} ->
+        pods =
+          body
+          |> :json.decode()
+          |> Map.get("items", [])
+          |> Enum.map(fn item ->
+            %{
+              name: get_in(item, ["metadata", "name"]),
+              uid: get_in(item, ["metadata", "uid"])
+            }
+          end)
+
+        {:ok, pods}
+
+      {:ok, status, _resp_body} ->
+        {:error, {:apiserver_status, status}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Merge-patches `annotations` onto one pod's metadata (only the given keys are
+  touched). The BrickController's single use is setting a negative
+  `controller.kubernetes.io/pod-deletion-cost` on its chosen scale-down victim
+  so the ReplicaSet deletes THAT replica when `/scale` shrinks, instead of its
+  own (age-based) pick landing on a busy sibling brick.
+  """
+  @spec annotate_pod(String.t(), String.t(), %{String.t() => String.t()}) ::
+          :ok | {:error, term()}
+  def annotate_pod(namespace, name, annotations) do
+    path = "/api/v1/namespaces/#{URI.encode(namespace)}/pods/#{URI.encode(name)}"
+
+    body =
+      :json.encode(%{"metadata" => %{"annotations" => annotations}})
+      |> :erlang.iolist_to_binary()
+
+    case do_request(:patch, path, body, "application/merge-patch+json") do
+      {:ok, 200, _resp_body} -> :ok
+      {:ok, status, _resp_body} -> {:error, {:apiserver_status, status}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   # TokenReview create returns 201 (some clusters 200); anything else is an
   # API-server error we surface without trusting the token.
   defp parse_review(status, body) when status in [200, 201] do

--- a/projects/embervm/control/lib/embervm/k8s.ex
+++ b/projects/embervm/control/lib/embervm/k8s.ex
@@ -343,6 +343,42 @@ defmodule Embervm.K8s do
     end
   end
 
+  @doc """
+  Reads a Deployment's LIVE replica count from its `/scale` subresource (the
+  `deployments/scale` `get` verb the BrickController RBAC already grants). This
+  is the current the autoscale loop bases decisions on: reading the subresource
+  (not the full Deployment) keeps the controller scale-only, and reading LIVE
+  state (not remembering its own writes) means a control-plane restart never
+  forgets a prior scale-up. A `spec.replicas` the apiserver omits (a scale of 0
+  can serialize without the field) reads as 0.
+  """
+  @spec get_deployment_scale(String.t(), String.t()) ::
+          {:ok, non_neg_integer()} | {:error, term()}
+  def get_deployment_scale(namespace, name) do
+    path =
+      "/apis/apps/v1/namespaces/#{URI.encode(namespace)}/deployments/#{URI.encode(name)}/scale"
+
+    case do_request(:get, path, nil, nil) do
+      {:ok, 200, body} ->
+        case :json.decode(body) do
+          %{"spec" => %{"replicas" => replicas}} when is_integer(replicas) and replicas >= 0 ->
+            {:ok, replicas}
+
+          %{"spec" => _} ->
+            {:ok, 0}
+
+          _ ->
+            {:error, :bad_scale_body}
+        end
+
+      {:ok, status, _resp_body} ->
+        {:error, {:apiserver_status, status}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
   # TokenReview create returns 201 (some clusters 200); anything else is an
   # API-server error we surface without trusting the token.
   defp parse_review(status, body) when status in [200, 201] do

--- a/projects/embervm/control/lib/embervm/wake_instance.ex
+++ b/projects/embervm/control/lib/embervm/wake_instance.ex
@@ -298,13 +298,28 @@ defmodule Embervm.WakeInstance do
   # on the still-DS-only fleet. This is the COLD path only; the warmth/relight-owner
   # branch of `select/2` is unchanged (the banked instance already holds the base).
   defp cold_instance(table, node_id, workload, need_mib) do
-    table
-    |> BrickLedger.bricks()
-    |> Enum.filter(fn brick -> brick.node_id == node_id end)
-    |> Embervm.Placement.pick_ready(workload, need_mib)
-    |> case do
-      nil -> {:error, :no_eligible_instance}
-      brick -> {:ok, dial_id_from_brick(brick)}
+    node_bricks =
+      table
+      |> BrickLedger.bricks()
+      |> Enum.filter(fn brick -> brick.node_id == node_id end)
+
+    case Embervm.Placement.pick_ready(node_bricks, workload, need_mib) do
+      nil ->
+        # Distinguish WHY the pick failed before feeding the autoscaler (Axis C):
+        # if some brick was slot/mem-eligible but merely not base-READY yet, the
+        # wake is waiting on provisioning, not on capacity, and a scale-up would
+        # not help (a fresh brick is equally un-ready). Only when NO brick is
+        # eligible at all is this a CAPACITY denial worth a demand signal. The
+        # note is an async cast: a missing controller (tests, DS-only fleet)
+        # makes it a silent no-op, and the wake outcome is unchanged either way.
+        unless Enum.any?(node_bricks, &Embervm.Placement.eligible?(&1, need_mib)) do
+          Embervm.BrickController.note_denial(need_mib)
+        end
+
+        {:error, :no_eligible_instance}
+
+      brick ->
+        {:ok, dial_id_from_brick(brick)}
     end
   end
 

--- a/projects/embervm/control/test/embervm/brick_controller_test.exs
+++ b/projects/embervm/control/test/embervm/brick_controller_test.exs
@@ -136,4 +136,119 @@ defmodule Embervm.BrickControllerTest do
     BrickController.reconcile_now(pid)
     refute BrickController.fleet_full?(pid, "2gi")
   end
+
+  # -- desired/2 (the pure autoscale decision, Axis C) ------------------------
+
+  defp base_signals(overrides \\ %{}) do
+    Map.merge(
+      %{
+        min: 0,
+        max: 4,
+        denials: 0,
+        up_threshold: 3,
+        fleet_full_now: false,
+        fleet_full_recent: false,
+        idle_dwell_ok: false,
+        up_cooldown_ok: true,
+        down_cooldown_ok: true
+      },
+      overrides
+    )
+  end
+
+  test "desired/2 steps up one under denial pressure, clamped to max" do
+    assert BrickController.desired(1, base_signals(%{denials: 3})) == {2, :denial_pressure}
+    assert BrickController.desired(4, base_signals(%{denials: 3})) == {4, :at_max}
+  end
+
+  test "desired/2 refuses up while fleet-full or inside the up cooldown" do
+    assert BrickController.desired(1, base_signals(%{denials: 3, fleet_full_now: true})) ==
+             {1, :fleet_full_wait}
+
+    assert BrickController.desired(1, base_signals(%{denials: 3, up_cooldown_ok: false})) ==
+             {1, :up_cooldown}
+  end
+
+  test "desired/2 jumps to the min floor and steps down from over max" do
+    assert BrickController.desired(0, base_signals(%{min: 1})) == {1, :min_floor}
+    assert BrickController.desired(6, base_signals(%{max: 4})) == {5, :over_max}
+  end
+
+  test "desired/2 steps down only on a clean idle dwell" do
+    assert BrickController.desired(2, base_signals(%{idle_dwell_ok: true})) == {1, :idle_drain}
+
+    # Any of: denials in the window, a recent fleet-full episode, the down
+    # cooldown, or sitting at min already, holds the count steady.
+    assert BrickController.desired(2, base_signals(%{idle_dwell_ok: true, denials: 1})) ==
+             {2, :steady}
+
+    assert BrickController.desired(2, base_signals(%{idle_dwell_ok: true, fleet_full_recent: true})) ==
+             {2, :steady}
+
+    assert BrickController.desired(2, base_signals(%{idle_dwell_ok: true, down_cooldown_ok: false})) ==
+             {2, :steady}
+
+    assert BrickController.desired(1, base_signals(%{min: 1, idle_dwell_ok: true})) ==
+             {1, :steady}
+  end
+
+  # -- observe mode (phase 1: decisions logged, never acted) -------------------
+
+  test "observe mode still scales statically and only LOGS the autoscale target" do
+    {record, calls} = new_recorder()
+    {clock, advance} = new_clock()
+
+    pid =
+      start(
+        mode: :observe,
+        classes: [%{name: "2gi", desired: 1, min: 0, max: 4}],
+        scale_fun: record,
+        scale_get_fun: fn _ns, _name -> {:ok, 1} end,
+        facts_fun: fn -> [] end,
+        registered_fun: fn -> %{"2gi" => 1} end,
+        up_threshold: 1,
+        clock: clock
+      )
+
+    # A denial for a 2gi-sized need crosses the (test) threshold of 1.
+    BrickController.note_denial(pid, 512)
+    advance.(1)
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        BrickController.reconcile_now(pid)
+      end)
+
+    assert log =~ "brick autoscale: would scale class 2gi from 1 to 2 (reason=denial_pressure)"
+    # The ACTING write stayed the static desired (1), not the target (2).
+    assert calls.() == [{"embervm", "embervm-embervm-noded-brick-2gi", 1}]
+  end
+
+  test "a denial is attributed to the smallest class that fits the need" do
+    {clock, advance} = new_clock()
+
+    pid =
+      start(
+        mode: :observe,
+        classes: [
+          %{name: "2gi", desired: 0, min: 0, max: 2},
+          %{name: "16gi", desired: 0, min: 0, max: 2}
+        ],
+        scale_fun: fn _ns, _name, _r -> :ok end,
+        scale_get_fun: fn _ns, _name -> {:ok, 0} end,
+        facts_fun: fn -> [] end,
+        registered_fun: fn -> %{} end,
+        up_threshold: 1,
+        clock: clock
+      )
+
+    # 4096 MiB does not fit the 2gi class: the denial lands on 16gi.
+    BrickController.note_denial(pid, 4096)
+    advance.(1)
+
+    log = ExUnit.CaptureLog.capture_log(fn -> BrickController.reconcile_now(pid) end)
+
+    assert log =~ "would scale class 16gi from 0 to 1"
+    refute log =~ "would scale class 2gi"
+  end
 end

--- a/projects/embervm/control/test/embervm/brick_controller_test.exs
+++ b/projects/embervm/control/test/embervm/brick_controller_test.exs
@@ -224,6 +224,67 @@ defmodule Embervm.BrickControllerTest do
     assert calls.() == [{"embervm", "embervm-embervm-noded-brick-2gi", 1}]
   end
 
+  # -- up mode (phase 2: scale-up acts, scale-down stays observe-only) ---------
+
+  test "up mode acts on denial pressure and writes the target" do
+    {record, calls} = new_recorder()
+    {clock, advance} = new_clock()
+
+    pid =
+      start(
+        mode: :up,
+        classes: [%{name: "2gi", desired: 1, min: 0, max: 4}],
+        scale_fun: record,
+        scale_get_fun: fn _ns, _name -> {:ok, 1} end,
+        facts_fun: fn -> [] end,
+        registered_fun: fn -> %{"2gi" => 1} end,
+        up_threshold: 1,
+        clock: clock
+      )
+
+    BrickController.note_denial(pid, 512)
+    advance.(1)
+
+    log = ExUnit.CaptureLog.capture_log(fn -> BrickController.reconcile_now(pid) end)
+
+    assert log =~ "brick autoscale: scaling class 2gi from 1 to 2 (reason=denial_pressure)"
+    assert calls.() == [{"embervm", "embervm-embervm-noded-brick-2gi", 2}]
+  end
+
+  test "up mode asserts the live current and leaves a down decision as a log" do
+    {record, calls} = new_recorder()
+    {clock, advance} = new_clock()
+
+    pid =
+      start(
+        mode: :up,
+        # Static desired is 1 but the live Deployment sits at 3 (a prior
+        # scale-up): the acting baseline is the LIVE count, and the idle-drain
+        # decision must NOT act in :up mode.
+        classes: [%{name: "2gi", desired: 1, min: 0, max: 4}],
+        scale_fun: record,
+        scale_get_fun: fn _ns, _name -> {:ok, 3} end,
+        facts_fun: fn ->
+          [%{size_class: "2gi", live_vms: 0, draining: false}]
+        end,
+        registered_fun: fn -> %{"2gi" => 3} end,
+        down_idle_ms: 100,
+        clock: clock
+      )
+
+    # First reconcile starts the idle dwell; past it, the down decision fires.
+    BrickController.reconcile_now(pid)
+    advance.(200)
+    log = ExUnit.CaptureLog.capture_log(fn -> BrickController.reconcile_now(pid) end)
+
+    assert log =~ "brick autoscale: would scale class 2gi from 3 to 2 (reason=idle_drain)"
+    # Both ticks wrote the LIVE current (3), never the static desired (1).
+    assert calls.() == [
+             {"embervm", "embervm-embervm-noded-brick-2gi", 3},
+             {"embervm", "embervm-embervm-noded-brick-2gi", 3}
+           ]
+  end
+
   test "a denial is attributed to the smallest class that fits the need" do
     {clock, advance} = new_clock()
 

--- a/projects/embervm/control/test/embervm/brick_controller_test.exs
+++ b/projects/embervm/control/test/embervm/brick_controller_test.exs
@@ -285,6 +285,100 @@ defmodule Embervm.BrickControllerTest do
            ]
   end
 
+  # -- full mode (phase 3: drain-aware scale-down acts) ------------------------
+
+  defp new_annotator do
+    {:ok, pid} = Agent.start_link(fn -> [] end)
+    on_exit(fn -> if Process.alive?(pid), do: Agent.stop(pid) end)
+
+    annotate = fn ns, pod, annotations ->
+      Agent.update(pid, &[{ns, pod, annotations} | &1])
+      :ok
+    end
+
+    calls = fn -> pid |> Agent.get(& &1) |> Enum.reverse() end
+    {annotate, calls}
+  end
+
+  defp full_mode_opts(facts, scale_recorder, annotate) do
+    [
+      mode: :full,
+      classes: [%{name: "2gi", desired: 2, min: 0, max: 4}],
+      scale_fun: scale_recorder,
+      scale_get_fun: fn _ns, _name -> {:ok, 2} end,
+      facts_fun: fn -> facts end,
+      pods_fun: fn _ns, _selector ->
+        {:ok, [%{name: "brick-a", uid: "uid-a"}, %{name: "brick-b", uid: "uid-b"}]}
+      end,
+      annotate_fun: annotate,
+      registered_fun: fn -> %{"2gi" => 2} end,
+      down_idle_ms: 100
+    ]
+  end
+
+  test "full mode scale-down annotates the idle victim then shrinks" do
+    {record, calls} = new_recorder()
+    {annotate, annotated} = new_annotator()
+    {clock, advance} = new_clock()
+
+    facts = [
+      %{size_class: "2gi", pod_uid: "uid-a", live_vms: 1, draining: false},
+      %{
+        size_class: "2gi",
+        pod_uid: "uid-b",
+        live_vms: 0,
+        draining: false,
+        stateful_bundles: [%{exported: true}]
+      }
+    ]
+
+    pid = start(full_mode_opts(facts, record, annotate) ++ [clock: clock])
+
+    BrickController.reconcile_now(pid)
+    advance.(200)
+    log = ExUnit.CaptureLog.capture_log(fn -> BrickController.reconcile_now(pid) end)
+
+    assert log =~ "brick autoscale: scaling class 2gi from 2 to 1 (reason=idle_drain)"
+    # The idle brick (uid-b), not the busy one, got the negative deletion cost.
+    assert annotated.() == [
+             {"embervm", "brick-b", %{"controller.kubernetes.io/pod-deletion-cost" => "-1000"}}
+           ]
+
+    assert List.last(calls.()) == {"embervm", "embervm-embervm-noded-brick-2gi", 1}
+  end
+
+  test "full mode refuses to strand un-exported warmth and skips the shrink" do
+    {record, calls} = new_recorder()
+    {annotate, annotated} = new_annotator()
+    {clock, advance} = new_clock()
+
+    facts = [
+      %{size_class: "2gi", pod_uid: "uid-a", live_vms: 1, draining: false},
+      # Idle, but its banked bundle has no current store copy: not a safe victim.
+      %{
+        size_class: "2gi",
+        pod_uid: "uid-b",
+        live_vms: 0,
+        draining: false,
+        stateful_bundles: [%{exported: false}]
+      }
+    ]
+
+    pid = start(full_mode_opts(facts, record, annotate) ++ [clock: clock])
+
+    BrickController.reconcile_now(pid)
+    advance.(200)
+    log = ExUnit.CaptureLog.capture_log(fn -> BrickController.reconcile_now(pid) end)
+
+    assert log =~ "brick autoscale: skipping scale-down of class 2gi (reason=no_safe_victim)"
+    assert annotated.() == []
+    # Both ticks re-asserted the live current (2); the shrink never happened.
+    assert calls.() == [
+             {"embervm", "embervm-embervm-noded-brick-2gi", 2},
+             {"embervm", "embervm-embervm-noded-brick-2gi", 2}
+           ]
+  end
+
   test "a denial is attributed to the smallest class that fits the need" do
     {clock, advance} = new_clock()
 

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.177
+      targetRevision: 0.1.178
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -122,6 +122,20 @@ bricks:
     # workloads (the ~10Gi scratch-k8s composite group) need the 16gi class.
     # Values-only flip: foundation images already deployed at 0.1.169.
     16gi: 1
+  # Demand-driven brick autoscale (fleet plan Axis C), pinned explicitly so the
+  # cluster's rollout rung is visible here, not implied by a chart default. The
+  # ladder is observe -> up -> full, each a values-only flip:
+  #   observe: acts statically (identical to before), logs every would-be
+  #            decision ("brick autoscale: would scale class ...") for a soak.
+  #   up:      denial-driven scale-up acts (clamped to chart maxReplicas);
+  #            scale-down stays observe-only.
+  #   full:    drain-aware scale-down acts too (idle 15m + fully-exported
+  #            victim rail, never below chart minReplicas; 16gi keeps min 1
+  #            for the scratch-k8s composite).
+  # min/max clamps live in the chart values (recorded policy 2026-07-20:
+  # min {16gi: 1}, max {2gi: 4, 4gi: 3, 8gi: 2, 16gi: 2}).
+  autoscale:
+    mode: observe
 
 # EmberVM R4 scale-to-zero scratch-postgres (ADR embervm/001, D-R4.PR-11.1):
 # enabled with the k8s-homelab 1Password item whose POSTGRES_PASSWORD field syncs


### PR DESCRIPTION
Implements fleet-plan Axis C: the BrickController's replica counts become demand-driven, gated behind `bricks.autoscale.mode = off|observe|up|full` (default **observe**, so merging only adds logs; rollout is a values change, never a code revert).

## Control loop (Option A from the plan: grow BrickController, no new process)

Per class, on the existing 30s reconcile tick, level-based against the LIVE replica count read from the Deployment `/scale` subresource (a CP restart never forgets a prior scale-up):

- **Up signal**: placement CAPACITY denials fed via `note_denial/2` (async cast) from the two choke points: the cold wake pick (only when no brick is slot/mem-eligible; base-unready waits are not capacity) and the dispatcher miss tier (ready candidates exist, none has budget/mem). Denials attribute to the smallest class whose ladder-label capacity fits `need_mib`. 3 denials in 60s step +1, clamped to max; a fleet-full-flagged class refuses further up (runaway rail).
- **Down signal**: continuously >=1 idle brick (zero live VMs, not draining) for 15m, zero denials in window, no recent fleet-full. Steps -1, never below min.
- **Hysteresis**: up cooldown 60s, down cooldown 10m (an up also blocks down), stamped in observe mode too so the soak log paces faithfully.
- **Drain-aware down (mode full)**: the controller picks its own victim (zero live VMs AND all warmth `exported: true` across stateful bundles / session + serving snapshots / group bundle sets), refuses-to-strand (skip + log when no safe victim), and directs the ReplicaSet by annotating the victim with negative `controller.kubernetes.io/pod-deletion-cost` before patching `/scale`. A raced placement onto the victim is backstopped by the existing SIGTERM -> DrainCoordinator force-bank.

## Recorded policy (values-declared)

- min-floor `{2gi: 0, 4gi: 0, 8gi: 0, 16gi: 1}` (one 16Gi warm for the scratch-k8s composite)
- max `{2gi: 4, 4gi: 3, 8gi: 2, 16gi: 2}` (no prior chart ceiling existed; added to chart values)

## Commits (one per phase, all mode-gated)

1. observe-only: signals + pure `desired/2` + config plumbing, decisions logged, static behavior unchanged
2. up-scale acts in modes `up`/`full`
3. drain-aware scale-down acts in `full` (+ namespaced `brick-pods` Role: pods list/patch, rendered only with `bricks.enabled`)

## Notes for review

- **No chart bump included** (bumped sequentially at merge).
- New RBAC is namespaced, not on the ClusterRole.
- `EMBERVM_BRICK_CLASSES` gains optional `min`/`max` fields; the parser defaults absent max to `max(desired, min)` (no headroom) for env-skew safety.
- Elixir unit tests cover `desired/2`, denial attribution, observe/up/full acting behavior, and the refuse-to-strand rail (not executed locally; CI validates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFXpz6XW8Tmb3Yj5t3b1c