### PR TITLE
fix(embervm): GroupSweeper crash-loop on absent-instance orphan network

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.176
+version: 0.1.177

--- a/projects/embervm/control/lib/embervm/group_sweeper.ex
+++ b/projects/embervm/control/lib/embervm/group_sweeper.ex
@@ -315,7 +315,15 @@ defmodule Embervm.GroupSweeper do
       orphaned? =
         case GroupStore.get(state.store, instance_id) do
           {:ok, instance} -> GroupState.terminal?(instance.state)
-          {:error, _} -> true
+          # GroupStore.get returns a BARE :error (not {:error, _}) when the instance
+          # is absent from the store (see get_view/2, and group_manager.ex which
+          # matches :error the same way). An absent instance IS orphaned: its network
+          # record outlived its group, which is exactly what this GC collects. The old
+          # {:error, _} clause matched neither {:ok,_} nor a bare :error, so the sweep
+          # crashed with a CaseClauseError PRECISELY when there was an orphan to clean,
+          # crash-looping the sweeper every tick and letting bridge records pile up
+          # ("cidr overlaps existing group").
+          :error -> true
         end
 
       if orphaned? and is_binary(instance_id) and instance_id != "" do

--- a/projects/embervm/control/test/embervm/group_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/group_sweeper_test.exs
@@ -706,6 +706,36 @@ defmodule Embervm.GroupSweeperTest do
     assert delete_net_calls(ctx) == []
   end
 
+  test "orphan network GC: a node-reported network for an ABSENT instance is deleted, no crash" do
+    ctx = start_stack()
+    group_workload(ctx, "grp-a", 5410, %{idle_bank_seconds: 600})
+    group_node(ctx, "node-4")
+
+    # An instance_id the store has NEVER seen: GroupStore.get returns a BARE :error.
+    # Before the fix this crashed the whole sweep with a CaseClauseError (the case only
+    # matched {:ok,_} and {:error,_}); now the absent instance is treated as orphaned
+    # and its squatting network is collected on the same sweep.
+    absent_id = "gi-absent"
+
+    NodeCapacity.put(ctx.cap_table, "node-4", %{
+      configured_id: "node-4",
+      node_id: "node-4",
+      serving_subnet_cidr: "10.98.0.0/24",
+      max_live_vms: 8,
+      live_vms: 0,
+      workloads: %{},
+      group_member_vms: [],
+      group_bundle_sets: [],
+      group_networks: [%{group_instance_id: absent_id, cidr: "10.101.0.0/24", bridge: "emg1", member_count: 0}]
+    })
+
+    set_scrape(ctx, reading("group-5410", 0, 3))
+    GroupSweeper.sweep(ctx.sweeper)
+
+    assert [req] = delete_net_calls(ctx)
+    assert req.group_instance_id == absent_id
+  end
+
   test "a status-write failure never crashes the sweep" do
     ctx = start_stack()
     group_workload(ctx, "grp-a", 5410, %{idle_bank_seconds: 600})

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.176
+      targetRevision: 0.1.177
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## What
`gc_orphan_networks/1` matched `{:error, _}` from `GroupStore.get`, but `get_view/2` returns a **bare `:error`** atom when the instance is absent (and `group_manager.ex:1512` matches it that way too). So an orphan network whose owning instance is gone, the exact case this GC exists to collect, hit no case clause and crashed the whole GroupSweeper sweep with a CaseClauseError.

## Impact
The sweeper crash-looped ~every 30s whenever an orphan group-network record existed, so orphan-network GC never ran and bridge records piled up ("cidr overlaps existing group", the failure this GC was written to prevent). Surfaced live by a teammate reading CP logs during the co-location work.

## Fix
Match the bare `:error` (absent instance = orphaned). One-line production change + an absent-instance regression test (the existing orphan-GC tests only covered TERMINAL and LIVE instances, never the absent/`:error` path that crashed).

Chart bump added at merge. 🤖 Generated with [Claude Code](https://claude.com/claude-code)