### PR TITLE
feat(monolith): enable CNPG backups to SeaweedFS S3

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.247
+version: 0.89.248
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.247
+      targetRevision: 0.89.248
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.321
+version: 0.285.322
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -759,18 +759,16 @@ postgres:
   # emits a small Opaque Secret (templates/cnpg-backup-s3-secret.yaml) holding
   # these same low-value dummy keys. There is no 1Password S3 item to reuse
   # because SeaweedFS S3 has no real credentials in this cluster.
-  # Landed DISABLED on purpose. Enabling continuous WAL archiving to a not-yet-
-  # created bucket, or turning archive_mode on, can trigger a CNPG rolling
-  # switchover of the primary, which must not run unwatched against the freshly
-  # fsck-recovered monolith-pg. The live enable is a deliberate, watched step:
-  # (1) pre-create the s3://monolith-pg-backups bucket via `weed shell`
-  #     s3.bucket.create (NOT the chart bucket hook, which flips SeaweedFS S3 to
-  #     auth-enforced and breaks every S3 workload),
-  # (2) confirm the standby is caught up (instances: 2, streaming),
-  # (3) flip enabled: true and watch the Cluster's ContinuousArchiving condition
-  #     plus the first ScheduledBackup completing.
+  # ENABLED 2026-07-21 after the watched preconditions were met: the
+  # s3://monolith-pg-backups bucket was pre-created via `weed shell` s3.bucket.create
+  # (NOT the chart bucket hook, which flips SeaweedFS S3 to auth-enforced), and the
+  # monolith-pg standby was confirmed caught up (2/2, streaming, primary monolith-pg-3).
+  # Continuous WAL archiving + a daily base backup now write to the in-cluster
+  # SeaweedFS S3 (a different volume set, so backups survive the Pg-volume-corruption
+  # class that bit us on 2026-07-21). NOT off-cluster DR: a node/cluster loss takes
+  # both the Pg volume and the backups; off-cluster replication is a separate follow-up.
   backup:
-    enabled: false
+    enabled: true
     # SeaweedFS S3 gateway (path-style, plaintext HTTP), same endpoint the app
     # workloads use.
     endpointURL: "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333"

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.321
+      targetRevision: 0.285.322
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Enables the CNPG backup config landed disabled in #3768. Preconditions met and verified live:
- Bucket `s3://monolith-pg-backups` pre-created via `weed shell` s3.bucket.create (empty, not the chart hook).
- monolith-pg confirmed healthy 2/2, standby streaming, primary monolith-pg-3.

Flips `postgres.backup.enabled=true`: continuous WAL archiving + daily base backup to in-cluster SeaweedFS S3. Survives the Pg-volume-corruption class from 2026-07-21. NOT off-cluster DR (follow-up). Will watch ContinuousArchiving + first ScheduledBackup post-rollout. 🤖 Generated with [Claude Code](https://claude.com/claude-code)