### PR TITLE
fix(monolith): drop CNPG WAL archiving to SeaweedFS

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.248
+version: 0.89.250
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.248
+      targetRevision: 0.89.250
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.322
+version: 0.285.324
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -759,16 +759,16 @@ postgres:
   # emits a small Opaque Secret (templates/cnpg-backup-s3-secret.yaml) holding
   # these same low-value dummy keys. There is no 1Password S3 item to reuse
   # because SeaweedFS S3 has no real credentials in this cluster.
-  # ENABLED 2026-07-21 after the watched preconditions were met: the
-  # s3://monolith-pg-backups bucket was pre-created via `weed shell` s3.bucket.create
-  # (NOT the chart bucket hook, which flips SeaweedFS S3 to auth-enforced), and the
-  # monolith-pg standby was confirmed caught up (2/2, streaming, primary monolith-pg-3).
-  # Continuous WAL archiving + a daily base backup now write to the in-cluster
-  # SeaweedFS S3 (a different volume set, so backups survive the Pg-volume-corruption
-  # class that bit us on 2026-07-21). NOT off-cluster DR: a node/cluster loss takes
-  # both the Pg volume and the backups; off-cluster replication is a separate follow-up.
+  # DISABLED 2026-07-21. WAL archiving to SeaweedFS was enabled briefly, but
+  # SeaweedFS's intermittent 500-on-PutObject (benign-retryable for embervm async
+  # exports) makes it a poor WAL-archive target: ContinuousArchiving flapped Failing
+  # and the archiver burned retries. For now the Pg durability floor is Longhorn block
+  # replication (the monolith-pg data volume is already multi-replica). Proper OFFSITE
+  # backups (a real object store / DR target, not the in-cluster SeaweedFS) are a
+  # deliberate future task, not this in-cluster WAL path. Re-enabling here requires
+  # both a reliable object store and the backup-secret RBAC fix.
   backup:
-    enabled: true
+    enabled: false
     # SeaweedFS S3 gateway (path-style, plaintext HTTP), same endpoint the app
     # workloads use.
     endpointURL: "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333"

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.322
+      targetRevision: 0.285.324
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
SeaweedFS intermittent 500-on-PutObject made it a poor WAL-archive target (ContinuousArchiving flapped Failing). Reverts the enable from #3776. Pg durability floor is Longhorn block replication (data volume already multi-replica); proper offsite backups are a future task. Renders to a no-op (backup resources gone). 🤖 Generated with [Claude Code](https://claude.com/claude-code)