### PR TITLE
fix(longhorn): add required spec.name to stale-snapshot-cleanup RecurringJob

### DIFF
--- a/projects/platform/longhorn/recurringjob-snapshot-cleanup.yaml
+++ b/projects/platform/longhorn/recurringjob-snapshot-cleanup.yaml
@@ -36,12 +36,21 @@ metadata:
   name: stale-snapshot-cleanup
   namespace: longhorn
 spec:
+  # spec.name is REQUIRED by the Longhorn RecurringJob validator (it is the job
+  # identifier, distinct from metadata.name). Omitting it made the webhook reject
+  # the object ("invalid job {Name: ...}"), which failed the ENTIRE home-cluster
+  # root-app (canada) sync and silently blocked every new Application from being
+  # created cluster-wide until it was noticed. Must match metadata.name.
+  name: stale-snapshot-cleanup
   # Weekly, Sunday 03:15 UTC (off-peak). Cleanup is idempotent and cheap; weekly
   # is frequent enough to keep removable-snapshot bloat bounded without churn.
   cron: "15 3 * * 0"
   task: snapshot-cleanup
   groups:
     - default
-  retain: 1
+  # retain is coerced to 0 by Longhorn for cleanup/delete tasks (it only applies to
+  # snapshot/backup-CREATING tasks), so set it to 0 explicitly to match what the
+  # validator stores and avoid the misleading git-vs-live mismatch.
+  retain: 0
   concurrency: 1
   labels: {}


### PR DESCRIPTION
The stale-snapshot-cleanup RecurringJob omitted `spec.name` (required by validator.longhorn.io). The webhook rejected it, which failed the ENTIRE home-cluster root-app (canada) sync - so no new ArgoCD Application could be created cluster-wide since #3763 merged. This surfaced when the base-durability Phase 0 app (seaweedfs-node4) never got created. Adds spec.name + sets retain 0 (coerced anyway for cleanup tasks). Unblocks canada, which then creates the pending seaweedfs-node4 app. 🤖 Generated with [Claude Code](https://claude.com/claude-code)