### PR TITLE
feat(embervm): base export to S3 (base-durability PR-1)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.178
+version: 0.1.179

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -105,9 +105,11 @@ defmodule Embervm.BaseBuilder do
   require Logger
 
   alias Embervm.Node.V1.{
+    ArtifactRef,
     BuildBaseRequest,
     BuildBaseResponse,
     EvictSnapshotRequest,
+    ExportArtifactRequest,
     NodeService,
     ResourceSpec,
     Trace,
@@ -117,6 +119,14 @@ defmodule Embervm.BaseBuilder do
   # Backoff for a failed build: exponential from 1s, capped at the spec's 10m.
   @base_backoff_ms 1_000
   @max_backoff_ms 600_000
+
+  # Base-durability PR-1: how often the export reconcile sweeps for a current base
+  # that is present-but-unexported and re-issues ExportArtifact. The immediate
+  # post-build export is the fast path; this sweep is the self-healing backstop
+  # (a lost export result, a CP restart between build and export, or a store that
+  # was down at build time). 60s is well below any base's lifetime and the sweep
+  # is bounded to current-base-present-but-unexported, so it never hammers.
+  @export_reconcile_interval_ms 60_000
 
   # -- Client API ------------------------------------------------------------
 
@@ -256,6 +266,22 @@ defmodule Embervm.BaseBuilder do
     # NodeService.Stub.evict_snapshot/2 over a per-call channel; tests inject a
     # fake to assert eviction fires exactly when both refcounts hit zero.
     evict_fun = Keyword.get(opts, :evict_fun, &default_evict/2)
+    # Base-durability PR-1: the ExportArtifact seam that writes a freshly-built
+    # (or present-but-unexported) base back to the object store. Defaults to the
+    # real NodeService.Stub.export_artifact/2 over a per-call channel; tests
+    # inject a fake to assert export fires after a build and on the reconcile.
+    export_fun = Keyword.get(opts, :export_fun, &default_export/2)
+    # Op-log seam for the audit-only :artifact_exported record (no projection
+    # table; the log itself is the record). Mirrors the sweeper managers.
+    op_log = Keyword.get(opts, :op_log, Embervm.OpLog.SQLite)
+    op_log_mod = Keyword.get(opts, :op_log_mod, Embervm.OpLog.SQLite)
+    tenant = Keyword.get(opts, :tenant, "homelab")
+    # Sweep cadence for the export reconcile. 0 disables the timer entirely (the
+    # unit-test default, so a test drives :export_reconcile explicitly and asserts
+    # deterministically); production uses the module default.
+    export_reconcile_interval_ms =
+      Keyword.get(opts, :export_reconcile_interval_ms, @export_reconcile_interval_ms)
+
     status_writer = Keyword.get(opts, :status_writer, &Embervm.K8s.patch_workload_status/3)
     clock = Keyword.get(opts, :clock, fn -> System.system_time(:millisecond) end)
     base_backoff = Keyword.get(opts, :base_backoff_ms, @base_backoff_ms)
@@ -298,6 +324,11 @@ defmodule Embervm.BaseBuilder do
       connect_fun: connect_fun,
       disconnect_fun: disconnect_fun,
       evict_fun: evict_fun,
+      export_fun: export_fun,
+      op_log: op_log,
+      op_log_mod: op_log_mod,
+      tenant: tenant,
+      export_reconcile_interval_ms: export_reconcile_interval_ms,
       runtime_images: runtime_images,
       capacity_table: capacity_table,
       status_writer: status_writer,
@@ -305,6 +336,8 @@ defmodule Embervm.BaseBuilder do
       base_backoff_ms: base_backoff,
       max_backoff_ms: max_backoff
     }
+
+    schedule_export_reconcile(state)
 
     {:ok, state}
   end
@@ -377,6 +410,14 @@ defmodule Embervm.BaseBuilder do
   # A backoff retry timer fired for a failed build.
   def handle_info({:retry, name}, state) do
     {:noreply, retry_workload(state, name)}
+  end
+
+  # Base-durability PR-1: the periodic export reconcile fired. Re-issue export for
+  # any current base present-but-unexported, then re-arm the timer.
+  def handle_info(:export_reconcile, state) do
+    state = export_reconcile(state)
+    schedule_export_reconcile(state)
+    {:noreply, state}
   end
 
   def handle_info(_msg, state), do: {:noreply, state}
@@ -972,8 +1013,166 @@ defmodule Embervm.BaseBuilder do
     }
 
     state = put_in(state.workloads[w.name], w)
+
+    # Base-durability PR-1: drive the durability floor. Export the freshly-built
+    # current base to the object store on the node that built it. Fire-and-forget
+    # in a spawned worker (the RPC blocks on the store write and must never freeze
+    # this GenServer); the periodic export reconcile is the backstop if this
+    # result is lost or the store was down. Idempotent per checksum, so a redundant
+    # export (e.g. an already_built no-op build that reports the same ref) is a
+    # cheap skipped no-op on the node.
+    spawn_export(state, w.node_id, w.name, w.snapshot_ref)
+
     write_base_status(state, w, :built)
   end
+
+  # -- base export + durability (base-durability PR-1) ------------------------
+
+  # Periodic reconcile: for every workload whose CURRENT base (snapshot_ref) is
+  # present on its node but reported not-yet-exported, re-issue ExportArtifact.
+  # This is the self-healing backstop to the immediate post-build export: it
+  # recovers a lost export result, a CP restart between build and export, or a
+  # store that was down at build time. Deliberately bounded to
+  # current-base-present-but-unexported (never the superseded refs, which PR-1
+  # must not ship into the store), so it cannot hammer.
+  defp export_reconcile(state) do
+    Enum.each(state.workloads, fn {_name, w} ->
+      if current_base_present_but_unexported?(state, w) do
+        spawn_export(state, w.node_id, w.name, w.snapshot_ref)
+      end
+    end)
+
+    state
+  end
+
+  # A workload's current base needs (re-)export when it has a built ref placed on
+  # a known node AND the node's reported fact for that same ref is a READY base
+  # that is not yet exported. Matching the ref guards against exporting during a
+  # turnover (the node may still report the old ref); requiring READY guards
+  # against exporting a BUILDING/FAILED entry; requiring the node fact at all
+  # means a base whose node has not yet reported is left for the next sweep
+  # (never blindly re-exported without evidence it is present).
+  defp current_base_present_but_unexported?(state, w) do
+    is_binary(w.node_id) and is_binary(w.snapshot_ref) and
+      case node_base_fact(state, w.node_id, w.name) do
+        {:ok, %{snapshot_ref: ref, base_state: base_state, exported: exported}} ->
+          ref == w.snapshot_ref and
+            base_state == :BASE_BUILD_STATE_READY and exported != true
+
+        _ ->
+          false
+      end
+  end
+
+  # Look up one node's reported per-workload base fact (snapshot_ref, base_state,
+  # exported) from the shared capacity table. Returns :error when the node has no
+  # fact for the workload (unreported, or the base is not present there).
+  defp node_base_fact(state, node_id, workload) do
+    case find_capacity_fact(state.capacity_table, node_id) do
+      {:ok, fact} ->
+        case get_in(fact, [:workloads, workload]) do
+          nil -> :error
+          wl -> {:ok, wl}
+        end
+
+      :error ->
+        :error
+    end
+  end
+
+  # Spawn a fire-and-forget ExportArtifact worker for one base ref on its node.
+  # ExportArtifact is idempotent per checksum (an already-exported base is a
+  # skipped no-op), so a lost result or a retry is harmless; failures are logged,
+  # not retried here (the periodic reconcile is the backstop). Not monitored: an
+  # export result never mutates BaseBuilder state (durability lives on the node's
+  # exported flag, read back on the next status). The op-log audit entry is
+  # written from the worker only on success so the log records a real durability
+  # landing, never a mere attempt.
+  defp spawn_export(state, node_id, workload, ref) do
+    address = state.node_addr[node_id]
+    connect_fun = state.connect_fun
+    disconnect_fun = state.disconnect_fun
+    export_fun = state.export_fun
+    op_log = state.op_log
+    op_log_mod = state.op_log_mod
+    tenant = state.tenant
+    clock = state.clock
+
+    spawn(fn ->
+      result =
+        case connect_fun.(address) do
+          {:ok, channel} ->
+            try do
+              export_fun.(channel, %ExportArtifactRequest{
+                artifact: %ArtifactRef{
+                  kind: :ARTIFACT_KIND_BASE,
+                  workload: workload,
+                  ref: ref
+                },
+                trace: %Trace{workload: workload}
+              })
+            catch
+              kind, reason -> {:error, {kind, reason}}
+            after
+              disconnect_fun.(channel)
+            end
+
+          {:error, reason} ->
+            {:error, {:connect, reason}}
+        end
+
+      case result do
+        {:ok, resp} ->
+          record_base_exported(op_log_mod, op_log, tenant, clock, workload, ref, resp)
+
+        other ->
+          Logger.warning(
+            "embervm base builder: ExportArtifact #{workload}/#{ref} failed: #{inspect(other)}"
+          )
+      end
+    end)
+
+    :ok
+  end
+
+  # Append the audit-only :artifact_exported op (no projection table; the log
+  # itself is the record), mirroring the restore-audit recorders in the session/
+  # serving/stateful managers. Best-effort: an append failure must never crash
+  # the export worker (the durable fact is the exported bytes, not this row).
+  defp record_base_exported(op_log_mod, op_log, tenant, clock, workload, ref, resp) do
+    op = %Embervm.OpLog.Op{
+      kind: :artifact_exported,
+      tenant: tenant,
+      principal: "system:base:#{workload}",
+      workload: workload,
+      ts: clock.(),
+      payload: %{
+        kind: "base",
+        ref: ref,
+        bytes_moved: Map.get(resp, :bytes_moved, 0),
+        generation: Map.get(resp, :generation, 0),
+        skipped: Map.get(resp, :skipped, false)
+      }
+    }
+
+    _ = op_log_mod.append(op_log, op)
+    :ok
+  rescue
+    e ->
+      Logger.warning("embervm base builder: artifact_exported append raised",
+        workload: workload,
+        error: inspect(e)
+      )
+
+      :ok
+  end
+
+  defp schedule_export_reconcile(%{export_reconcile_interval_ms: ms}) when ms > 0 do
+    Process.send_after(self(), :export_reconcile, ms)
+    :ok
+  end
+
+  defp schedule_export_reconcile(_state), do: :ok
 
   # -- base refcounting + eviction (R2) ---------------------------------------
 
@@ -1267,6 +1466,15 @@ defmodule Embervm.BaseBuilder do
       trace: %Trace{},
       snapshot_ref: ref
     })
+  end
+
+  # ExportArtifact one base ref to the object store (base-durability PR-1). The
+  # node stamps its own cpu vendor into the store key and meta.json, so the
+  # request carries only the ref (unlike restore, which the CP vendor-stamps).
+  # A generous timeout: a first-time export moves the whole base (up to a few GB)
+  # to SeaweedFS; a re-export is a checksum-compare skip and returns fast.
+  defp default_export(channel, %ExportArtifactRequest{} = request) do
+    NodeService.Stub.export_artifact(channel, request, timeout: 600_000)
   end
 
   # A gRPC-level failure (e.g. FAILED_PRECONDITION for an image the daemon does

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -533,6 +533,13 @@ defmodule Embervm.NodeRegistry do
            # with no serving base built on this node.
            serving_image_ref: wc.serving_image_ref,
            base_state: wc.base_state,
+           # exported (base-durability PR-1, additive): true when this workload's
+           # current base has a complete store copy. BaseBuilder's periodic
+           # export reconcile reads it to re-issue ExportArtifact only for a
+           # current base that is present-but-unexported. false on a daemon that
+           # predates the field, which BaseBuilder safely re-exports (the export
+           # verb is idempotent per checksum).
+           exported: wc.exported,
            # The vm_ids of this node's primed VMs for the workload, so the
            # dispatcher can adopt an existing warm pool into its inventory after
            # a control-plane restart instead of orphaning it (see Dispatcher

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -26,6 +26,12 @@ defmodule Embervm.BaseBuilderTest do
 
   @node %{id: "node-4", address: "node-4:9090"}
 
+  # A no-op op-log: swallows every append so a build's export audit never touches
+  # the real SQLite in tests that do not assert on the op-log.
+  defmodule DiscardOpLog do
+    def append(_op_log, _op), do: :ok
+  end
+
   # -- helpers ----------------------------------------------------------------
 
   defp start_recorder do
@@ -85,8 +91,19 @@ defmodule Embervm.BaseBuilderTest do
           name: nil,
           nodes: Keyword.get(opts, :nodes, [@node]),
           connect_fun: fn _addr -> {:ok, :fake_channel} end,
-          disconnect_fun: fn :fake_channel -> :ok end
-        ] ++ opts
+          disconnect_fun: fn :fake_channel -> :ok end,
+          # Base-durability PR-1 defaults for tests that do not exercise export:
+          # a no-op export seam (so a build's immediate export never dials the real
+          # stub against the fake channel) and a disabled reconcile timer (so no
+          # background sweep perturbs timing). Export-specific tests override both.
+          export_fun: Keyword.get(opts, :export_fun, fn :fake_channel, _req -> {:ok, %{}} end),
+          export_reconcile_interval_ms: Keyword.get(opts, :export_reconcile_interval_ms, 0),
+          # Default the op-log to a discarding fake so a build's export audit never
+          # touches the real SQLite in tests that do not assert on it. The
+          # op-log-specific test overrides both to observe the append.
+          op_log: Keyword.get(opts, :op_log, :discard),
+          op_log_mod: Keyword.get(opts, :op_log_mod, DiscardOpLog)
+        ] ++ Keyword.drop(opts, [:export_fun, :export_reconcile_interval_ms, :op_log, :op_log_mod])
       )
 
     pid
@@ -848,5 +865,169 @@ defmodule Embervm.BaseBuilderTest do
     :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
 
     assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].node_id == "node-4/mid" end)
+  end
+
+  # -- base export durability (base-durability PR-1) --------------------------
+
+  # A fake op-log module: append/2 forwards the op to the test pid so a test can
+  # assert the :artifact_exported audit entry was written. Matches the
+  # {op_log, op} arg order the real Embervm.OpLog.SQLite.append/2 takes.
+  defmodule FakeOpLog do
+    def append(pid, op) when is_pid(pid) do
+      send(pid, {:op_appended, op})
+      :ok
+    end
+  end
+
+  test "a successful build exports the current base to the store on its node" do
+    agent = start_recorder()
+    test_pid = self()
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("snap1")} end
+
+    export_fun = fn :fake_channel, %Embervm.Node.V1.ExportArtifactRequest{artifact: ref} = req ->
+      send(test_pid, {:exported, ref.kind, ref.workload, ref.ref, req.trace.workload})
+      {:ok, %Embervm.Node.V1.ExportArtifactResponse{bytes_moved: 123, skipped: false, generation: 0}}
+    end
+
+    builder =
+      start_builder(
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        export_fun: export_fun
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{}))
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap1"}, latest(agent, "w")) end)
+
+    # Export fires for the freshly-built current base, kind BASE, on its node.
+    assert_receive {:exported, :ARTIFACT_KIND_BASE, "w", "snap1", "w"}, 1_000
+  end
+
+  test "a successful export appends the :artifact_exported op-log audit entry" do
+    agent = start_recorder()
+    test_pid = self()
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("snap1")} end
+
+    export_fun = fn :fake_channel, _req ->
+      {:ok, %Embervm.Node.V1.ExportArtifactResponse{bytes_moved: 42, skipped: false, generation: 0}}
+    end
+
+    builder =
+      start_builder(
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        export_fun: export_fun,
+        op_log: test_pid,
+        op_log_mod: FakeOpLog
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{}))
+
+    assert_receive {:op_appended, op}, 1_000
+    assert op.kind == :artifact_exported
+    assert op.workload == "w"
+    assert op.principal == "system:base:w"
+    assert op.payload.kind == "base"
+    assert op.payload.ref == "snap1"
+    assert op.payload.bytes_moved == 42
+  end
+
+  test "the export reconcile re-exports a current base reported present-but-unexported" do
+    agent = start_recorder()
+    test_pid = self()
+    table = new_cap_table()
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("snap1")} end
+
+    export_fun = fn :fake_channel, %Embervm.Node.V1.ExportArtifactRequest{artifact: ref} ->
+      send(test_pid, {:exported, ref.ref})
+      {:ok, %Embervm.Node.V1.ExportArtifactResponse{bytes_moved: 0, skipped: true, generation: 0}}
+    end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/big", address: "a"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        export_fun: export_fun,
+        # A tight reconcile cadence so the sweep fires within the test window.
+        export_reconcile_interval_ms: 20
+      )
+
+    put_brick(table, "node-4", "big", size_class: "16gi", mem_budget: 16_384, mem_headroom: 16_000)
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "snap1" end)
+
+    # Drain the immediate post-build export so the reconcile-driven one is the
+    # signal under test.
+    assert_receive {:exported, "snap1"}, 1_000
+
+    # The node now reports the current base READY but NOT exported: the periodic
+    # reconcile must re-issue ExportArtifact for it.
+    put_base_fact(table, "node-4", "big", "w", "snap1", :BASE_BUILD_STATE_READY, false)
+    assert_receive {:exported, "snap1"}, 1_000
+  end
+
+  test "the export reconcile does not re-export a base already reported exported" do
+    agent = start_recorder()
+    test_pid = self()
+    table = new_cap_table()
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("snap1")} end
+
+    export_fun = fn :fake_channel, %Embervm.Node.V1.ExportArtifactRequest{artifact: ref} ->
+      send(test_pid, {:exported, ref.ref})
+      {:ok, %Embervm.Node.V1.ExportArtifactResponse{bytes_moved: 0, skipped: true, generation: 0}}
+    end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/big", address: "a"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        export_fun: export_fun,
+        export_reconcile_interval_ms: 20
+      )
+
+    put_brick(table, "node-4", "big", size_class: "16gi", mem_budget: 16_384, mem_headroom: 16_000)
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "snap1" end)
+
+    # Drain the immediate post-build export.
+    assert_receive {:exported, "snap1"}, 1_000
+
+    # The node reports the current base as ALREADY exported: the reconcile must
+    # NOT fire another export for it.
+    put_base_fact(table, "node-4", "big", "w", "snap1", :BASE_BUILD_STATE_READY, true)
+    refute_receive {:exported, "snap1"}, 200
+  end
+
+  # Seed one node's per-workload base fact (snapshot_ref, base_state, exported)
+  # into an existing brick capacity row so the export reconcile can read it.
+  # Merges into the row put_brick/4 already wrote, keyed the same way.
+  defp put_base_fact(table, node_id, pod_uid, workload, ref, base_state, exported) do
+    existing =
+      case :ets.lookup(table, {node_id, pod_uid}) do
+        [{_key, facts}] -> facts
+        [] -> %{node_id: node_id, configured_id: node_id, instance_id: "#{node_id}/#{pod_uid}"}
+      end
+
+    workloads =
+      Map.put(Map.get(existing, :workloads, %{}), workload, %{
+        free_primed_slots: 0,
+        snapshot_ref: ref,
+        serving_image_ref: "",
+        base_state: base_state,
+        exported: exported,
+        primed_vm_ids: []
+      })
+
+    NodeCapacity.put(table, {node_id, pod_uid}, Map.put(existing, :workloads, workloads))
   end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.178
+      targetRevision: 0.1.179
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1804,6 +1804,15 @@ func (s *Server) workloadCapacities(primed map[string][]string) []*nodev1.Worklo
 		c := get(b.workload)
 		c.SnapshotRef = b.snapshotRef
 		c.BaseState = b.state
+		// Base durability (base-durability PR-1, additive): report whether this
+		// base's store copy is present and current, read from the same
+		// exportedCache the session/serving/stateful projections read via
+		// artifactExported. The control plane's BaseBuilder uses this to know the
+		// durability floor has landed before it treats the local disk as a cache.
+		// artifactExported is false for a base whose prefix cannot be composed
+		// (no vendor detected), which the control plane safely reads as
+		// not-yet-exported and re-exports (the export verb is idempotent).
+		c.Exported = s.artifactExported(nodev1.ArtifactKind_ARTIFACT_KIND_BASE, b.workload, b.snapshotRef)
 	}
 	// Serving images (cold-boot handler artifacts) are reported in a DISTINCT field
 	// from the base memory snapshot (D-R3.11.2): serving placement cold-boots this ref,

--- a/projects/embervm/noded/server/store_test.go
+++ b/projects/embervm/noded/server/store_test.go
@@ -332,6 +332,77 @@ func TestExportArtifactStateful(t *testing.T) {
 	}
 }
 
+// TestExportArtifactBaseReportsExported proves a direct ExportArtifact of a base
+// snapshot uploads its files under base/<vendor>/<workload>/<ref> and, crucially
+// for base-durability PR-1, that the workload's NodeStatus capacity then reports
+// exported=true, projected from the same exportedCache the other artifact kinds
+// read. The base must be a provisioned READY base to be advertised at all, so the
+// test syncs the runtime image and marks the base READY.
+func TestExportArtifactBaseReportsExported(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx := context.Background()
+
+	ref := "semgrep__0148fb2f0ac5"
+	workload := "semgrep"
+	digest := "img@sha256:deadbeef"
+
+	// Provision the runtime image so imageProvisioned(digest) is true (else the
+	// READY base is filtered out of NodeStatus and never reports exported).
+	s.registry.sync([]workloadEntry{{Workload: workload, ImageRef: digest, RootfsRef: "/rootfs/semgrep"}})
+	s.bases.readyBuild(ref, workload, digest, "/shim/ready", 2048)
+
+	dir := filepath.Join(s.cfg.SnapshotRoot, "bases", ref)
+	writeBundleFiles(t, dir, map[string]string{"imageref": "img", "memfile": "mem", "snapfile": "snap"})
+
+	// Before export, the base is present but NOT exported.
+	if exported := baseExportedInStatus(s, workload, ref); exported {
+		t.Fatal("base should report exported=false before export")
+	}
+
+	resp, err := s.ExportArtifact(ctx, &nodev1.ExportArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_BASE, Workload: workload, Ref: ref},
+	})
+	if err != nil {
+		t.Fatalf("ExportArtifact: %v", err)
+	}
+	if resp.GetSkipped() {
+		t.Fatal("first export should not be skipped")
+	}
+	prefix := "base/amd/semgrep/semgrep__0148fb2f0ac5"
+	if !fs.has(prefix) {
+		t.Fatalf("store missing %q after export", prefix)
+	}
+
+	// After export, the workload capacity reports exported=true.
+	if exported := baseExportedInStatus(s, workload, ref); !exported {
+		t.Fatal("base should report exported=true after export")
+	}
+
+	// A second export is an idempotent skipped no-op (store already holds the
+	// same checksum), so a re-issue from the control plane is harmless.
+	resp2, err := s.ExportArtifact(ctx, &nodev1.ExportArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_BASE, Workload: workload, Ref: ref},
+	})
+	if err != nil {
+		t.Fatalf("second ExportArtifact: %v", err)
+	}
+	if !resp2.GetSkipped() {
+		t.Fatal("re-export of an unchanged base should be skipped")
+	}
+}
+
+// baseExportedInStatus finds the workload's capacity entry in NodeStatus whose
+// snapshot_ref matches and returns its exported flag; false if not reported.
+func baseExportedInStatus(s *Server, workload, ref string) bool {
+	for _, wc := range s.nodeStatus().GetWorkloads() {
+		if wc.GetWorkload() == workload && wc.GetSnapshotRef() == ref {
+			return wc.GetExported()
+		}
+	}
+	return false
+}
+
 // TestExportArtifactMissingLocalFails proves ExportArtifact refuses
 // FAILED_PRECONDITION when the local artifact is absent.
 func TestExportArtifactMissingLocalFails(t *testing.T) {

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -1217,6 +1217,19 @@ message WorkloadCapacity {
   // neither assign to them nor prime past them: dispatch deadlocks. The node is
   // the source of truth for the pool; the control plane reconciles from this.
   repeated string primed_vm_ids = 5;
+  // exported is true when this workload's CURRENT base (snapshot_ref) has a
+  // complete store copy (its meta.json completeness marker matches the local
+  // checksum), mirroring SessionSnapshot.exported for the other artifact kinds.
+  // The base durability lives on the WorkloadCapacity entry rather than a
+  // dedicated snapshot message because a base is reported per workload as node
+  // capacity, not as a repeated bundle inventory. The control plane reads it to
+  // know a base's durability floor has landed: BaseBuilder issues ExportArtifact
+  // after a build and its periodic reconcile re-issues export whenever the
+  // current base shows present-but-unexported here (base-durability PR-1,
+  // additive; false on a daemon that predates the field, which the control plane
+  // reads as "not yet exported" and safely re-exports, the export verb being
+  // idempotent per checksum).
+  bool exported = 7;
 }
 
 enum BaseBuildState {


### PR DESCRIPTION
## What

PR-1 of the EmberVM base-durability program (plan: `docs/plans/2026-07-21-embervm-base-durability-and-cross-vendor.md`). Makes each **current** Firecracker base durable in S3 (SeaweedFS `embervm` bucket), so node-4's scratch disk is no longer the only copy of every base. **Export only** - eviction, hydrate, and S3 retention GC are PR-2/3/4.

## Changes

- **proto** (`node.proto`): additive `exported` bool (field 7) on `WorkloadCapacity`, the per-workload base status noded reports. Mirrors the `exported` flag every other artifact kind (session/serving/stateful/group/volume) already carries. Additive and wire-safe: an old daemon leaves it `false`, which the CP reads as not-yet-exported and safely re-exports.
- **noded** (`server.go`): project `exported` for a base from the existing `exportedCache` via `artifactExported` (the same cache + helper the other kinds read), set alongside `snapshot_ref`/`base_state` in `workloadCapacities`. The export verb already handled `ARTIFACT_KIND_BASE` end to end; this is only the status projection. `enqueueReconcileExports` is deliberately untouched (it must not blanket-sweep the 245 leaked versions into a 41G store).
- **CP** (`base_builder.ex`): after a successful build records an advanced `snapshotRef`, issue `ExportArtifact` (kind BASE) to the building node in a fire-and-forget worker (**the first `ExportArtifact` call site in the CP**). A periodic reconcile (60s) re-issues export for any current base a node reports present-but-unexported, bounded to current-base-present (never superseded refs). One audit-only `:artifact_exported` op-log entry per successful export.
- **node_registry** (`node_registry.ex`): carry `wc.exported` into the per-workload capacity facts so BaseBuilder's reconcile can read it.
- Chart bumped to **0.1.179** (CP + noded change deploys).

## Proto codegen

Codegen is build-time via Bazel (`proto_library` globs the `.proto`; no checked-in `.pb.go`/`.pb.ex`). Adding a field to an existing message is purely additive - no BUILD change. Verified no `WorkloadCapacity` field 7 collision (existing fields are 1-6).

## Tests

- Go (`store_test.go`): `TestExportArtifactBaseReportsExported` - a real BASE export lands under `base/amd/semgrep/<ref>`, NodeStatus then reports `exported=true`, and a re-export is a skipped idempotent no-op.
- Elixir (`base_builder_test.exs`): a successful build exports the current base on its node; the export appends the `:artifact_exported` op-log entry; the periodic reconcile re-exports a present-but-unexported base and does NOT re-export one already exported.

## Verify live (post-deploy, not runnable here)

`base/amd/<workload>/<ref>` appears in S3 for all 9 current bases; meta.json stamped `amd/amd-default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFXpz6XW8Tmb3Yj5t3b1c