### PR TITLE
fix(seaweedfs): default replication 000 (001 unsatisfiable, wedged writes)

### DIFF
--- a/projects/platform/seaweedfs/values.yaml
+++ b/projects/platform/seaweedfs/values.yaml
@@ -4,6 +4,26 @@
 seaweedfs:
   global:
     enableSecurity: false
+    # Cluster-wide default replication for NEW volumes/buckets that do not set
+    # their own. Single copy ("000"). The vendored chart defaults this to "001"
+    # (2 copies on different servers), which is unsatisfiable here: adding the
+    # node-4 volume server made the master enforce 001 strictly, but the node-2
+    # server is slot-saturated (130/130, 0 free) so it can never host the second
+    # replica. The master then fails EVERY new write it must grow a volume for
+    # ("failed to find writable volumes ... replication:001: No writable
+    # volumes"), which wedged all embervm base exports (large memfiles that force
+    # a volume grow) and is the same class as the CNPG WAL 500-on-PutObject.
+    # Small writes fit existing volumes; only grows failed, so the break was
+    # silent until a GB-sized write appeared.
+    #
+    # Per Joe's 2026-07-21 decision (base store n=1-on-S3 is fine; normal
+    # Longhorn + offsite backups is the durability path, not app-layer 001),
+    # single-copy is the accepted floor: block-layer durability comes from the
+    # volume servers' Longhorn PVCs (node-2's is 2-replica; node-4's node4-ssd
+    # class is 1-replica by design). Revisit "001" only once BOTH servers have
+    # free writable slots (raise node-2 maxVolumes with disk headroom, or add a
+    # third writable server) and the existing 000 volumes have been re-replicated.
+    replicationPlacment: "000"
     monitoring:
       enabled: false
     # SeaweedFS-layer replication (Phase 0 of the embervm base-durability


### PR DESCRIPTION
## Problem (found verifying base-durability PR-1 live)

EmberVM base exports (PR #3782) fired correctly but every one 500'd on the large `memfile`:

```
failed to find writable volumes for collection:embervm replication:001: No writable volumes
```

Root cause: the vendored SeaweedFS chart defaults `-defaultReplication=001` (2 copies, different servers). node-2's volume server is slot-saturated (`130/130, free 0`), so once Phase 0's node-4 server made the master enforce 001 strictly, it could never allocate a paired volume. Small descriptor files fit existing volumes and succeeded; the GB-sized `memfile` forced a volume *grow*, which the master does at 001 → fails. Silent until a large write appeared. Same class as the CNPG WAL 500-on-PutObject.

## Fix

Set `global.replicationPlacment: "000"` (single copy). Writes land on node-4's 346 free slots. Block-layer durability comes from the volume servers' Longhorn PVCs (node-2 = 2-replica, node-4 node4-ssd = 1-replica by design), per Joe's 2026-07-21 decision that base store n=1-on-S3 is acceptable and normal Longhorn + offsite backups is the durability path (not app-layer 001).

Revisit 001 only once both servers have free writable slots (or a third server) and existing 000 volumes are re-replicated.

## Verification
- Confirmed live: `base/amd/<workload>` descriptor files land; `memfile` 500s on 001 grow.
- After merge + master roll: watch `fs.du /buckets/embervm/base` climb to ~11G and 500s cease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFXpz6XW8Tmb3Yj5t3b1c