### PR TITLE
fix(seaweedfs): remove duplicate replicationPlacment (001 overriding 000)

### DIFF
--- a/projects/platform/seaweedfs/values.yaml
+++ b/projects/platform/seaweedfs/values.yaml
@@ -26,22 +26,6 @@ seaweedfs:
     replicationPlacment: "000"
     monitoring:
       enabled: false
-    # SeaweedFS-layer replication (Phase 0 of the embervm base-durability
-    # plan): every NEW S3 volume is paired across two DIFFERENT volume servers
-    # ("001" = same rack, different server), i.e. this release's server plus
-    # the node-4 server (../seaweedfs-node4). Notes:
-    #   - Only volumes created AFTER this flip get 2 copies. Existing volumes
-    #     keep their creation-time 000 and need a manual, operator-run
-    #     `volume.configure.replication` + `volume.fix.replication` pass in
-    #     weed shell to gain a second copy (see the plan doc; do not run
-    #     without a go-ahead, it copies tens of GB).
-    #   - With 001, allocating a new volume and writing to a 001 volume
-    #     require BOTH servers up; reads survive either one. Two volume
-    #     servers is the minimum for this placement, so this must not be
-    #     enabled unless the seaweedfs-node4 release is deployed.
-    # (replicationPlacment is the upstream chart's key spelling.)
-    enableReplication: true
-    replicationPlacment: "001"
 
   master:
     enabled: true


### PR DESCRIPTION
Follow-up to #3783. The `global:` map had two `replicationPlacment` keys (my `000` from #3783 plus the pre-existing Phase 0 `001` flip that landed concurrently). YAML uses the last key, so `001` kept winning: the master never changed off `defaultReplication=001`, and embervm base-export memfiles kept 500ing on the unsatisfiable 001 volume grow (node-2 saturated, no pair).

Removes the duplicate Phase 0 `enableReplication` + `replicationPlacment: "001"` block, leaving a single `replicationPlacment: "000"`. See [reference] the base-durability program; single-copy is the accepted floor (Longhorn block-layer durability), per Joe's n=1-on-S3 decision.

After merge + master roll: `-defaultReplication=000`, and `fs.du /buckets/embervm/base` climbs to ~11G as memfiles land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFXpz6XW8Tmb3Yj5t3b1c