### PR TITLE
fix(seaweedfs): raise s3 gateway memory to 2Gi (OOM on large base uploads)

### DIFF
--- a/projects/platform/seaweedfs/values.yaml
+++ b/projects/platform/seaweedfs/values.yaml
@@ -172,7 +172,14 @@ seaweedfs:
     resources:
       requests:
         cpu: 50m
-        memory: 64Mi
+        memory: 128Mi
       limits:
-        cpu: 200m
-        memory: 256Mi
+        cpu: 500m
+        # The S3 gateway streams object PUTs through to the filer. At 256Mi it
+        # OOM-crash-looped (exit 137) once large embervm base memfiles (up to a
+        # few GB) started flowing after the replication-000 fix let their volume
+        # assigns succeed: every large upload killed the gateway, so exports (and
+        # any other large S3 write) failed with connection-refused. 2Gi gives the
+        # streaming/multipart buffers headroom, mirroring the filer's 2Gi bump
+        # after its own cold-load OOM. (2026-07-21.)
+        memory: 2Gi


### PR DESCRIPTION
Third and final blocker in the base-durability live-verify chain (after #3783/#3784 fixed replication).

Once `defaultReplication=000` let the volume assign succeed, the S3 gateway actually streamed the GB-sized base `memfile`s and **OOM-crash-looped** at its 256Mi limit (exit 137, 7 restarts, every ~6 min). All exports then failed with `connection refused` to `seaweedfs-s3:8333`.

Raises the s3 gateway to `limits.memory: 2Gi` (req 128Mi, cpu 500m), mirroring the filer's earlier 2Gi bump after its own cold-load OOM.

After merge + s3 pod roll: base memfiles land, `fs.du /buckets/embervm/base` climbs to ~11G, exports complete with meta.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFXpz6XW8Tmb3Yj5t3b1c