### PR TITLE
feat(embervm): hydrate-on-miss base restore PR-2 (async restore + CP restore-first)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.180
+version: 0.1.181

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -112,6 +112,7 @@ defmodule Embervm.BaseBuilder do
     ExportArtifactRequest,
     NodeService,
     ResourceSpec,
+    RestoreArtifactRequest,
     Trace,
     ZipSource
   }
@@ -271,6 +272,14 @@ defmodule Embervm.BaseBuilder do
     # real NodeService.Stub.export_artifact/2 over a per-call channel; tests
     # inject a fake to assert export fires after a build and on the reconcile.
     export_fun = Keyword.get(opts, :export_fun, &default_export/2)
+    # Base-durability PR-2: the RestoreArtifact seam that HYDRATES a recorded base
+    # back onto a node that lacks it locally (cold-start / node-replacement),
+    # turning a rebuild into an S3 download. Defaults to the real
+    # NodeService.Stub.restore_artifact/2 over a per-call channel; tests inject a
+    # fake to assert the restore-first/fallback decision. noded fast-ACKs a BASE
+    # restore (accepted=true) and downloads async, so the CP polls NodeStatus for
+    # the base to appear READY (see spawn_hydrate).
+    restore_fun = Keyword.get(opts, :restore_fun, &default_restore/2)
     # Op-log seam for the audit-only :artifact_exported record (no projection
     # table; the log itself is the record). Mirrors the sweeper managers.
     op_log = Keyword.get(opts, :op_log, Embervm.OpLog.SQLite)
@@ -281,6 +290,17 @@ defmodule Embervm.BaseBuilder do
     # deterministically); production uses the module default.
     export_reconcile_interval_ms =
       Keyword.get(opts, :export_reconcile_interval_ms, @export_reconcile_interval_ms)
+
+    # Base-durability PR-2: how long a hydrate worker polls NodeStatus for the
+    # base to appear READY before giving up and falling back to BuildBase. noded
+    # downloads the base async (a multi-GB, multi-minute S3 read), so the CP polls
+    # rather than blocks. hydrate_poll_interval_ms is the poll cadence,
+    # hydrate_poll_max the attempt ceiling; interval * max bounds the wait before
+    # a stuck/failed hydrate (node died mid-download, S3 flaked) rebuilds instead.
+    # Defaults cover a ~3G base download comfortably (5s * 90 = 7.5 min); tests
+    # shrink both so a fallback path asserts deterministically without real sleep.
+    hydrate_poll_interval_ms = Keyword.get(opts, :hydrate_poll_interval_ms, 5_000)
+    hydrate_poll_max = Keyword.get(opts, :hydrate_poll_max, 90)
 
     status_writer = Keyword.get(opts, :status_writer, &Embervm.K8s.patch_workload_status/3)
     clock = Keyword.get(opts, :clock, fn -> System.system_time(:millisecond) end)
@@ -335,10 +355,18 @@ defmodule Embervm.BaseBuilder do
       disconnect_fun: disconnect_fun,
       evict_fun: evict_fun,
       export_fun: export_fun,
+      restore_fun: restore_fun,
       op_log: op_log,
       op_log_mod: op_log_mod,
       tenant: tenant,
       export_reconcile_interval_ms: export_reconcile_interval_ms,
+      hydrate_poll_interval_ms: hydrate_poll_interval_ms,
+      hydrate_poll_max: hydrate_poll_max,
+      # In-flight hydrate guard: workloads with a hydrate worker running, so a
+      # re-reconcile during the async download does not spawn a second hydrate for
+      # the same base (mirrors the node queue's role for exports/evicts). A worker
+      # clears its own entry on completion via the {:hydrate_done, name} message.
+      hydrating: MapSet.new(),
       runtime_images: runtime_images,
       capacity_table: capacity_table,
       status_writer: status_writer,
@@ -422,6 +450,13 @@ defmodule Embervm.BaseBuilder do
     {:noreply, retry_workload(state, name)}
   end
 
+  # Base-durability PR-2: a hydrate worker finished (hydrated, fell back, or
+  # crashed in `after`). Clear the in-flight guard so a later reconcile can hydrate
+  # (or build) again; the fallback path already re-drove a build via :reconcile.
+  def handle_info({:hydrate_done, name}, state) do
+    {:noreply, update_in(state.hydrating, &MapSet.delete(&1, name))}
+  end
+
   # Base-durability PR-1: the periodic export reconcile fired. Re-issue export for
   # any current base present-but-unexported, then re-arm the timer.
   def handle_info(:export_reconcile, state) do
@@ -472,6 +507,28 @@ defmodule Embervm.BaseBuilder do
         # that broke only the runtime resolution.
         write_base_status(state, w, {:failed, zip_runtime_error(state, w)})
 
+      should_hydrate?(state, w, node_id) ->
+        # Base-durability PR-2: restore-first (hydrate-on-miss). The CP recorded a
+        # base (snapshot_ref set, signature unchanged) but the node AFFIRMATIVELY
+        # reports it absent (base_state NONE, not merely unreported): a cold-start,
+        # a node replacement, or scratch loss. Instead of rebuilding, download the
+        # SAME content-addressed ref back from S3. noded fast-ACKs and downloads
+        # async, so this spawns a worker that triggers RestoreArtifact then polls
+        # NodeStatus for the base to appear READY; it falls back to BuildBase on an
+        # S3 miss (FAILED_PRECONDITION) or a poll timeout.
+        #
+        # SCOPE (deliberate): restore-first covers ONLY the recorded-but-absent
+        # case. A NEW build and a spec-change REBUILD both target a ref the CP
+        # cannot know before building (noded derives <workload>__hash(digest +
+        # revision + vendor) node-side), so they correctly stay BuildBase.
+        # Rollback-to-a-predecessor is intentionally a rebuild, NOT a hydrate:
+        # under N=1 S3 retention (Joe, 2026-07-21) no predecessor ref persists in
+        # the store to hydrate from, so a signature->ref history would be dead
+        # weight. See docs/plans/2026-07-21-embervm-base-durability-and-cross-vendor.md.
+        state
+        |> mark_hydrating(name)
+        |> spawn_hydrate(w)
+
       w.built_signature == signature(w) and w.snapshot_ref != nil ->
         # Desired base already built and recorded: idempotent no-op. (The watcher
         # separately writes observedGeneration for a generation-only change.)
@@ -488,6 +545,282 @@ defmodule Embervm.BaseBuilder do
         |> write_base_status(w, :building)
         |> maybe_start_build(node_id)
     end
+  end
+
+  # -- restore-first (hydrate-on-miss, base-durability PR-2) --------------------
+
+  # Should this workload's recorded base be HYDRATED (S3 restore) rather than
+  # rebuilt? True only when ALL four guards hold (fail-safe: any unmet guard falls
+  # through to the ordinary build/no-op branches):
+  #
+  #   1. a base is recorded (snapshot_ref set) AND the spec is unchanged
+  #      (built_signature == signature): we are restoring the SAME ref we would
+  #      otherwise rebuild, never papering over a spec change (whose target ref is
+  #      unknowable pre-build anyway);
+  #   2. the node AFFIRMATIVELY reports that base absent (base_state NONE for the
+  #      workload). This is the KEY guard: a workload the node has not yet reported
+  #      (no fact) is NOT hydrated, so the race window right after a build (base
+  #      built, node has not re-reported READY) never triggers a spurious restore;
+  #   3. no build is already queued or in flight for the workload (do not race a
+  #      hydrate against a build);
+  #   4. no hydrate is already in flight for the workload (the in-flight guard, so
+  #      a re-reconcile during the async download does not spawn a second worker).
+  defp should_hydrate?(state, w, node_id) do
+    is_binary(w.snapshot_ref) and w.built_signature == signature(w) and
+      node_reports_base_absent?(state, node_id, w.name) and
+      not already_targeting?(state, node_id, w.name, signature(w)) and
+      not MapSet.member?(state.hydrating, w.name)
+  end
+
+  # The node AFFIRMATIVELY reports the workload's base absent: a fact exists for
+  # the workload on the node AND its base_state is NONE. A missing fact (node not
+  # reported yet, or the base present-but-unprojected) is NOT "absent": returning
+  # false there is what keeps the post-build race from hydrating (guard 2 above).
+  defp node_reports_base_absent?(state, node_id, workload) do
+    case node_base_fact(state, node_id, workload) do
+      {:ok, %{base_state: :BASE_BUILD_STATE_NONE}} -> true
+      _ -> false
+    end
+  end
+
+  defp mark_hydrating(state, name) do
+    update_in(state.hydrating, &MapSet.put(&1, name))
+  end
+
+  # Spawn a monitored-free (fire-and-forget) hydrate worker for one recorded base.
+  # The worker triggers RestoreArtifact (vendor-stamped) then polls NodeStatus for
+  # the base to appear READY, since noded downloads a BASE async (fast-ACK
+  # accepted=true, multi-GB download off the RPC). It falls back to a BuildBase by
+  # casting :reconcile for the workload on an S3 miss (FAILED_PRECONDITION) or a
+  # poll timeout; on hydrate success it records :artifact_restored{kind:"base"} so
+  # the hydrate-vs-build ratio is auditable from the op-log. It always sends
+  # {:hydrate_done, name} so the GenServer clears the in-flight guard.
+  #
+  # Not spawn_monitor (unlike a build worker): a hydrate result never mutates
+  # BaseBuilder's build state (the base's presence lives on the node's own fact,
+  # read back on the next status), so a crashed worker only needs the in-flight
+  # guard cleared, which the {:hydrate_done, ...} in `after` guarantees.
+  defp spawn_hydrate(state, w) do
+    owner = self()
+    name = w.name
+    node_id = w.node_id
+    ref = w.snapshot_ref
+    address = state.node_addr[node_id]
+    connect_fun = state.connect_fun
+    disconnect_fun = state.disconnect_fun
+    restore_fun = state.restore_fun
+    capacity_table = state.capacity_table
+    poll_interval = state.hydrate_poll_interval_ms
+    poll_max = state.hydrate_poll_max
+    op_log = state.op_log
+    op_log_mod = state.op_log_mod
+    tenant = state.tenant
+    clock = state.clock
+
+    spawn(fn ->
+      try do
+        outcome =
+          run_hydrate(%{
+            owner: owner,
+            name: name,
+            node_id: node_id,
+            ref: ref,
+            address: address,
+            connect_fun: connect_fun,
+            disconnect_fun: disconnect_fun,
+            restore_fun: restore_fun,
+            capacity_table: capacity_table,
+            poll_interval: poll_interval,
+            poll_max: poll_max
+          })
+
+        case outcome do
+          :hydrated ->
+            record_base_restored(op_log_mod, op_log, tenant, clock, name, ref)
+
+          {:fallback, reason} ->
+            Logger.info(
+              "embervm base builder: hydrate #{name}/#{ref} fell back to build (#{inspect(reason)})"
+            )
+
+            # Re-drive a build for the workload. The reconcile is idempotent and
+            # re-reads current desc/placement, so a spec that changed under the
+            # hydrate is handled correctly.
+            reconcile(owner, hydrate_fallback_desc(w))
+        end
+      after
+        send(owner, {:hydrate_done, name})
+      end
+    end)
+
+    state
+  end
+
+  # Drive one hydrate attempt: RestoreArtifact, then (on accepted) poll NodeStatus
+  # for the base to become READY. Returns :hydrated on success, {:fallback, reason}
+  # on an S3 miss / restore failure / poll timeout (the caller then rebuilds).
+  defp run_hydrate(ctx) do
+    case dial_restore(ctx) do
+      {:ok, %{skipped: true}} ->
+        # The base was already present locally when the RPC ran (a race with
+        # another restore, or the node reported stale): treat as hydrated, the
+        # node's next status advertises it READY.
+        :hydrated
+
+      {:ok, %{accepted: true}} ->
+        poll_base_ready(ctx, ctx.poll_max)
+
+      {:ok, other} ->
+        # An unexpected non-accepted, non-skipped response (e.g. an inline restore
+        # that reported bytes_moved without accepted, from a daemon that predates
+        # the async change). The base is present; treat as hydrated.
+        _ = other
+        :hydrated
+
+      {:error, {:grpc, :failed_precondition, _msg}} ->
+        # S3 does not hold the ref (or the store is disabled): rebuild AT ONCE, no
+        # wait. This is the fast, distinguishable miss the async ack guarantees.
+        {:fallback, :not_present_in_store}
+
+      {:error, reason} ->
+        {:fallback, {:restore_failed, reason}}
+    end
+  end
+
+  # Poll the node fact until the workload's base shows READY (hydrate landed), or
+  # the attempt budget is exhausted (fall back to build). Reads the SHARED capacity
+  # table the node registry keeps fresh, so the poll sees the async download's
+  # ReconcileBasesFromDisk re-registration as soon as it lands. Resolves the fact
+  # by instance_id (find_capacity_fact), matching how node_base_fact reads it (the
+  # builder's node_id is an instance_id "node/pod_uid", not the daemon's node_id).
+  defp poll_base_ready(_ctx, 0), do: {:fallback, :poll_timeout}
+
+  defp poll_base_ready(ctx, attempts_left) do
+    case find_capacity_fact(ctx.capacity_table, ctx.node_id) do
+      {:ok, fact} ->
+        case get_in(fact, [:workloads, ctx.name]) do
+          %{base_state: :BASE_BUILD_STATE_READY, snapshot_ref: ref} when ref == ctx.ref ->
+            :hydrated
+
+          _ ->
+            sleep_then_poll(ctx, attempts_left)
+        end
+
+      :error ->
+        sleep_then_poll(ctx, attempts_left)
+    end
+  end
+
+  defp sleep_then_poll(ctx, attempts_left) do
+    Process.sleep(ctx.poll_interval)
+    poll_base_ready(ctx, attempts_left - 1)
+  end
+
+  # Issue the vendor-stamped RestoreArtifact over a per-call channel, normalising a
+  # GRPC.RPCError into a {:grpc, status_atom, message} tuple so run_hydrate can
+  # distinguish an S3 miss (FAILED_PRECONDITION, fast fallback) from other errors.
+  defp dial_restore(ctx) do
+    case ctx.connect_fun.(ctx.address) do
+      {:ok, channel} ->
+        req =
+          Embervm.RestoreVendor.stamp(
+            ctx.capacity_table,
+            stamp_key(ctx.capacity_table, ctx.node_id),
+            %RestoreArtifactRequest{
+              artifact: %ArtifactRef{
+                kind: :ARTIFACT_KIND_BASE,
+                workload: ctx.name,
+                ref: ctx.ref
+              },
+              trace: %Trace{workload: ctx.name}
+            }
+          )
+
+        try do
+          case ctx.restore_fun.(channel, req) do
+            {:ok, resp} -> {:ok, resp}
+            {:error, err} -> {:error, normalize_grpc_error(err)}
+          end
+        catch
+          kind, reason -> {:error, {kind, reason}}
+        after
+          ctx.disconnect_fun.(channel)
+        end
+
+      {:error, reason} ->
+        {:error, {:connect, reason}}
+    end
+  end
+
+  # Resolve the anchor key RestoreVendor.stamp reads the CPU vendor off. The
+  # builder's node_id is an instance_id ("node/pod_uid"), which NodeCapacity.fetch
+  # does NOT resolve (its binary form matches the daemon's node_id field, its tuple
+  # form matches the {configured_id, pod_uid} ETS key). So resolve the instance's
+  # own capacity fact by instance_id and hand stamp the {configured_id, pod_uid}
+  # tuple, the exact per-instance key. Falls back to the raw node_id string when no
+  # fact is found (stamp then resolves "" and noded maps it to the legacy alias, so
+  # today's single-vendor fleet still restores; correct once vendors are reported).
+  defp stamp_key(table, node_id) do
+    case find_capacity_fact(table, node_id) do
+      {:ok, %{configured_id: cfg, pod_uid: pod}} when is_binary(cfg) -> {cfg, pod || ""}
+      _ -> node_id
+    end
+  end
+
+  # Map a GRPC.RPCError to {:grpc, status_atom, message}; pass other errors through.
+  # FAILED_PRECONDITION (status 9) is noded's S3-not-present / store-disabled /
+  # sku-mismatch signal, which run_hydrate treats as an immediate rebuild fallback.
+  defp normalize_grpc_error(%GRPC.RPCError{status: 9, message: msg}),
+    do: {:grpc, :failed_precondition, msg}
+
+  defp normalize_grpc_error(%GRPC.RPCError{status: status, message: msg}),
+    do: {:grpc, status, msg}
+
+  defp normalize_grpc_error(other), do: other
+
+  # The desc a hydrate fallback re-drives: reconstruct the minimal build descriptor
+  # from the workload's own recorded fields, so the reconcile rebuilds the SAME
+  # base the hydrate failed to restore. class/zip are optional map keys.
+  defp hydrate_fallback_desc(w) do
+    %{
+      name: w.name,
+      namespace: w.namespace,
+      generation: w.generation,
+      class: Map.get(w, :class),
+      image_ref: w.image_ref,
+      zip: Map.get(w, :zip),
+      guest_port: w.guest_port,
+      ready_path: w.ready_path,
+      vcpus: w.vcpus,
+      mem_mib: w.mem_mib,
+      init_env: w.init_env
+    }
+  end
+
+  # Append the audit-only :artifact_restored op recording a base HYDRATE (kind
+  # "base"), the partner signal to :base_built, so the hydrate-vs-build ratio is
+  # auditable from the log alone. Best-effort: an append failure never crashes the
+  # hydrate worker (the durable fact is the restored bytes on the node).
+  defp record_base_restored(op_log_mod, op_log, tenant, clock, workload, ref) do
+    op = %Embervm.OpLog.Op{
+      kind: :artifact_restored,
+      tenant: tenant,
+      principal: "system:base:#{workload}",
+      workload: workload,
+      ts: clock.(),
+      payload: %{kind: "base", ref: ref}
+    }
+
+    _ = op_log_mod.append(op_log, op)
+    :ok
+  rescue
+    e ->
+      Logger.warning("embervm base builder: artifact_restored append raised",
+        workload: workload,
+        error: inspect(e)
+      )
+
+      :ok
   end
 
   # -- node set updates (discovery) --------------------------------------------
@@ -1536,6 +1869,18 @@ defmodule Embervm.BaseBuilder do
   # to SeaweedFS; a re-export is a checksum-compare skip and returns fast.
   defp default_export(channel, %ExportArtifactRequest{} = request) do
     NodeService.Stub.export_artifact(channel, request, timeout: 600_000)
+  end
+
+  # RestoreArtifact one base ref from the object store (base-durability PR-2). noded
+  # FAST-ACKs a BASE restore (accepted=true) and downloads async, so this is NOT a
+  # long-held call: it returns in milliseconds with the ack (or a fast
+  # FAILED_PRECONDITION on an S3 miss). The short default per-call timeout is
+  # therefore correct here (unlike the slow BuildBase path); the multi-minute
+  # download runs on the node's own restore queue, and the CP polls NodeStatus for
+  # READY rather than holding this RPC open (the whole reason the download went
+  # async, mirroring the export idle-close lesson).
+  defp default_restore(channel, %RestoreArtifactRequest{} = request) do
+    NodeService.Stub.restore_artifact(channel, request)
   end
 
   # A gRPC-level failure (e.g. FAILED_PRECONDITION for an image the daemon does

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -1086,6 +1086,173 @@ defmodule Embervm.BaseBuilderTest do
   # Seed one node's per-workload base fact (snapshot_ref, base_state, exported)
   # into an existing brick capacity row so the export reconcile can read it.
   # Merges into the row put_brick/4 already wrote, keyed the same way.
+  # -- restore-first (hydrate-on-miss, base-durability PR-2) -------------------
+
+  # Bring a workload to a recorded-and-built state (snapshot_ref set,
+  # built_signature == signature), then flip the node fact so the base reads
+  # AFFIRMATIVELY absent (BASE_BUILD_STATE_NONE): the recorded-but-absent trigger.
+  # Returns {builder, agent, table}. The initial export is drained so it never
+  # perturbs later assertions.
+  defp build_then_report_base_absent(opts) do
+    agent = start_recorder()
+    test_pid = self()
+    table = new_cap_table()
+    build_fun = Keyword.get(opts, :build_fun, fn :fake_channel, _req -> {:ok, resp("snap1")} end)
+
+    builder =
+      start_builder(
+        [
+          nodes: [%{id: "node-4/big", address: "a"}],
+          capacity_table: table,
+          status_writer: recording_status_writer(agent),
+          build_fun: build_fun,
+          # Signal each export so the immediate post-build one can be drained.
+          export_fun: fn :fake_channel, %Embervm.Node.V1.ExportArtifactRequest{artifact: ref} ->
+            send(test_pid, {:exported, ref.ref})
+            {:ok, %Embervm.Node.V1.ExportArtifactResponse{bytes_moved: 0, skipped: true, generation: 0}}
+          end
+        ] ++ Keyword.take(opts, [:restore_fun, :op_log, :op_log_mod, :hydrate_poll_interval_ms, :hydrate_poll_max])
+      )
+
+    put_brick(table, "node-4", "big", size_class: "16gi", mem_budget: 16_384, mem_headroom: 16_000)
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "snap1" end)
+    assert_receive {:exported, "snap1"}, 1_000
+
+    # The node now AFFIRMATIVELY reports the recorded base absent (a cold-start /
+    # node replacement / scratch loss), the sole restore-first trigger.
+    put_base_fact(table, "node-4", "big", "w", "", :BASE_BUILD_STATE_NONE, false)
+
+    {builder, agent, table}
+  end
+
+  test "restore-first: a recorded-but-absent base is HYDRATED, not rebuilt" do
+    test_pid = self()
+
+    # A restore that fast-ACKs accepted=true (noded's async download path).
+    restore_fun = fn :fake_channel, %Embervm.Node.V1.RestoreArtifactRequest{artifact: ref} ->
+      send(test_pid, {:restore_called, ref.ref})
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{accepted: true}}
+    end
+
+    build_calls = start_recorder()
+
+    {builder, _agent, table} =
+      build_then_report_base_absent(
+        restore_fun: restore_fun,
+        hydrate_poll_interval_ms: 5,
+        hydrate_poll_max: 50,
+        # Count any SECOND build: a hydrate must not rebuild.
+        build_fun: fn :fake_channel, _req ->
+          Agent.update(build_calls, &[:build | &1])
+          {:ok, resp("snap1")}
+        end
+      )
+
+    # Re-reconcile with the SAME (unchanged) spec: restore-first must trigger.
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    assert_receive {:restore_called, "snap1"}, 1_000
+
+    # The async download "lands": flip the node fact back to READY so the poll
+    # sees the base present and the hydrate completes.
+    put_base_fact(table, "node-4", "big", "w", "snap1", :BASE_BUILD_STATE_READY, true)
+
+    # Give the poll a moment; exactly ONE build (the initial one) ever ran.
+    Process.sleep(80)
+    assert Agent.get(build_calls, &length(&1)) == 1
+  end
+
+  test "restore-first falls back to BuildBase on an S3 miss (FAILED_PRECONDITION)" do
+    test_pid = self()
+
+    # noded reports the ref is not in the store: a fast, distinguishable miss.
+    restore_fun = fn :fake_channel, _req ->
+      {:error, %GRPC.RPCError{status: 9, message: "not present in store"}}
+    end
+
+    {builder, _agent, _table} =
+      build_then_report_base_absent(
+        restore_fun: restore_fun,
+        hydrate_poll_interval_ms: 5,
+        hydrate_poll_max: 50,
+        build_fun: fn :fake_channel, _req ->
+          send(test_pid, :rebuilt)
+          {:ok, resp("snap1")}
+        end
+      )
+
+    # Re-reconcile: restore-first tries, gets FAILED_PRECONDITION, falls back to a
+    # rebuild AT ONCE (no poll wait).
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    assert_receive :rebuilt, 1_000
+  end
+
+  test "restore-first falls back to BuildBase when the hydrate never lands (poll timeout)" do
+    test_pid = self()
+
+    # The restore is accepted but the base NEVER becomes READY (node died
+    # mid-download, S3 flaked): the poll must time out and rebuild.
+    restore_fun = fn :fake_channel, _req ->
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{accepted: true}}
+    end
+
+    {builder, _agent, _table} =
+      build_then_report_base_absent(
+        restore_fun: restore_fun,
+        # A tiny poll budget so the timeout fallback is fast and deterministic.
+        hydrate_poll_interval_ms: 2,
+        hydrate_poll_max: 3,
+        build_fun: fn :fake_channel, _req ->
+          send(test_pid, :rebuilt)
+          {:ok, resp("snap1")}
+        end
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    assert_receive :rebuilt, 1_000
+  end
+
+  test "restore-first does NOT fire on a not-yet-reported base (post-build race guard)" do
+    # After a build, before the node re-reports the base READY, there is a window
+    # where the workload has a recorded ref but NO node fact. A reconcile in that
+    # window must NOT hydrate (it would be a spurious restore of a base that is
+    # actually present); it must idempotent-no-op instead.
+    test_pid = self()
+    agent = start_recorder()
+    table = new_cap_table()
+
+    restore_fun = fn :fake_channel, _req ->
+      send(test_pid, :restore_called)
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{accepted: true}}
+    end
+
+    builder =
+      start_builder(
+        nodes: [%{id: "node-4/big", address: "a"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: fn :fake_channel, _req -> {:ok, resp("snap1")} end,
+        restore_fun: restore_fun,
+        hydrate_poll_interval_ms: 5,
+        hydrate_poll_max: 50
+      )
+
+    put_brick(table, "node-4", "big", size_class: "16gi", mem_budget: 16_384, mem_headroom: 16_000)
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "snap1" end)
+
+    # No base fact is ever written for "w" (the node has not re-reported). A
+    # reconcile here must NOT hydrate.
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    refute_receive :restore_called, 200
+  end
+
+  # Seed one node's per-workload base fact (snapshot_ref, base_state, exported)
+  # into an existing brick capacity row so the export reconcile can read it.
+  # Merges into the row put_brick/4 already wrote, keyed the same way.
+
   defp put_base_fact(table, node_id, pod_uid, workload, ref, base_state, exported) do
     existing =
       case :ets.lookup(table, {node_id, pod_uid}) do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.180
+      targetRevision: 0.1.181
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -296,6 +296,16 @@ type Server struct {
 	exportOnce     sync.Once
 	exportDedupeMu sync.Mutex
 	exportDedupe   map[string]struct{}
+	// restoreCh is the bounded async BASE-restore queue; restoreDedupe drops a
+	// re-enqueue of an already-in-flight prefix (held enqueue-through-completion,
+	// so a re-triggered restore of a base still downloading is a no-op). Both
+	// nil/empty until startExportQueue runs (the restore queue shares that
+	// lifecycle). A BASE restore's multi-GB download runs here so the RPC never
+	// holds an idle flow open long enough for the Cilium/eBPF datapath to reap its
+	// conntrack entry, mirroring the export queue (base-durability PR-2).
+	restoreCh       chan restoreJob
+	restoreDedupeMu sync.Mutex
+	restoreDedupe   map[string]struct{}
 	// storeReachable is the latest object-store reachability verdict from the
 	// probe loop, surfaced in NodeStatus.store_reachable.
 	storeMu        sync.RWMutex
@@ -406,6 +416,7 @@ func New(opts Options) *Server {
 		store:           opts.Store,
 		exported:        newExportedCache(),
 		exportDedupe:    make(map[string]struct{}),
+		restoreDedupe:   make(map[string]struct{}),
 		subs:            make(map[chan struct{}]struct{}),
 		activeBuilds:    make(map[string]context.CancelFunc),
 	}

--- a/projects/embervm/noded/server/store.go
+++ b/projects/embervm/noded/server/store.go
@@ -345,6 +345,17 @@ func (s *Server) ExportArtifact(ctx context.Context, req *nodev1.ExportArtifactR
 // Idempotent: an artifact already present locally with a matching checksum is a
 // skipped no-op. FAILED_PRECONDITION when the store is disabled, or the store
 // copy is absent/incomplete/mismatched.
+//
+// BASE restores are ASYNC (base-durability PR-2): a base is a multi-GB S3
+// download, and holding this RPC open for the minutes it takes lets the
+// Cilium/eBPF datapath reap the idle flow's conntrack entry mid-transfer ("the
+// connection is closed"), the same failure that forced base EXPORT async. So a
+// BASE restore that genuinely needs a download runs the cheap presence + sku +
+// already-local checks SYNCHRONOUSLY (so a store-miss is a fast, distinguishable
+// FAILED_PRECONDITION the caller falls back to rebuild on, and an already-local
+// base is an inline skipped no-op), then ENQUEUES the download onto a bounded,
+// deduped queue and fast-ACKs accepted=true. The caller polls NodeStatus for the
+// base to appear READY. Every other (small) kind still restores inline.
 func (s *Server) RestoreArtifact(ctx context.Context, req *nodev1.RestoreArtifactRequest) (*nodev1.RestoreArtifactResponse, error) {
 	if s.store == nil {
 		return nil, status.Error(codes.FailedPrecondition, "noded: object store not configured; restore unavailable")
@@ -383,6 +394,29 @@ func (s *Server) RestoreArtifact(ctx context.Context, req *nodev1.RestoreArtifac
 			return &nodev1.RestoreArtifactResponse{Skipped: true, Generation: gen}, nil
 		}
 	}
+	// A genuine download is needed. The store copy must be present to attempt it:
+	// a not-present copy is FAILED_PRECONDITION (fast, distinguishable), so the
+	// caller falls back to rebuild AT ONCE rather than waiting a timeout for a
+	// base that is not in S3. A transport error probing presence is also
+	// FAILED_PRECONDITION (we cannot prove the copy exists; do not enqueue a
+	// doomed download). This gate is shared by both the async BASE path and the
+	// inline small-kind path.
+	if perr != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: restore artifact %q: store presence probe failed: %v", prefix, perr)
+	}
+	if !present {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: restore artifact %q: not present in store", prefix)
+	}
+
+	// BASE: fast-ACK and download asynchronously (multi-GB; must not hold the RPC).
+	if ref.GetKind() == nodev1.ArtifactKind_ARTIFACT_KIND_BASE {
+		s.enqueueRestore(ref, prefix, localDir)
+		return &nodev1.RestoreArtifactResponse{Accepted: true}, nil
+	}
+
+	// Every other (small) kind restores inline: the download is quick enough that
+	// the idle-flow-reap risk does not apply, and the caller's existing inline
+	// restore-on-miss semantics are unchanged.
 	moved, generation, err := s.store.Restore(ctx, prefix, localDir)
 	if err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: restore artifact %q: %v", prefix, err)
@@ -580,10 +614,12 @@ type exportJob struct {
 	key string // the store prefix, the dedupe key
 }
 
-// startExportQueue launches the bounded export-worker pool. It is idempotent and
-// a no-op when the store is disabled (nil): with no store there is nothing to
-// export. Called once from the daemon entrypoint after the server is built. The
-// workers run until ctx is cancelled (daemon shutdown), draining fire-and-forget.
+// startExportQueue launches the bounded export- AND restore-worker pools. It is
+// idempotent and a no-op when the store is disabled (nil): with no store there is
+// nothing to export or restore. Called once from the daemon entrypoint after the
+// server is built. The workers run until ctx is cancelled (daemon shutdown),
+// draining fire-and-forget. The restore queue shares this lifecycle (one
+// sync.Once) so both pools start and stop together.
 func (s *Server) startExportQueue(ctx context.Context) {
 	if s.store == nil {
 		return
@@ -592,6 +628,10 @@ func (s *Server) startExportQueue(ctx context.Context) {
 		s.exportCh = make(chan exportJob, exportQueueDepth)
 		for i := 0; i < exportQueueWorkers; i++ {
 			go s.exportWorker(ctx)
+		}
+		s.restoreCh = make(chan restoreJob, restoreQueueDepth)
+		for i := 0; i < restoreQueueWorkers; i++ {
+			go s.restoreWorker(ctx)
 		}
 	})
 }
@@ -772,6 +812,110 @@ func (s *Server) enqueueIfMissing(ctx context.Context, ref *nodev1.ArtifactRef) 
 		}
 	}
 	s.enqueueExport(ref)
+}
+
+// ---- async BASE-restore queue ----------------------------------------------
+
+// restoreQueueWorkers is the bounded worker pool draining the restore queue. Two
+// overlaps a large base download with a second without letting downloads pile
+// unbounded. A base restore is demand-driven (the CP triggers one when a base is
+// needed and missing), so contention is naturally low; two is a comfortable
+// ceiling that still overlaps a fresh-node multi-base hydrate.
+const restoreQueueWorkers = 2
+
+// restoreQueueDepth bounds the buffered restore-enqueue channel. An enqueue that
+// would block (queue full) is DROPPED, not awaited: the RPC has already fast-ACKed
+// accepted=true, so a dropped enqueue simply means the base does not appear READY
+// and the CP re-triggers (or falls back to rebuild) on its poll timeout. It is
+// generous because the dedupe set (held enqueue-through-completion) already caps
+// distinct in-flight restores to one per prefix.
+const restoreQueueDepth = 64
+
+// restoreJob names one BASE artifact to download, carrying its resolved store
+// prefix (already vendor/legacy-resolved by resolveRestorePrefix) and local dir
+// so the worker needs no further resolution. Keyed (in the dedupe set) by prefix
+// so a re-triggered restore of an in-flight base is dropped.
+type restoreJob struct {
+	ref      *nodev1.ArtifactRef
+	prefix   string // resolved store prefix, the dedupe key
+	localDir string
+}
+
+// enqueueRestore schedules a BASE download for async write-back. It is
+// non-blocking: a full queue drops the enqueue (the CP's poll re-triggers or
+// falls back to rebuild), and an already-in-flight prefix is a no-op. The dedupe
+// key is held enqueue-THROUGH-COMPLETION (cleared in runRestoreJob's defer, not on
+// dequeue), so a re-triggered restore of a base still downloading never starts a
+// second concurrent download of the same prefix (the node's queue is the real
+// dedupe guard for the CP's retriggers). It no-ops when the store is disabled or
+// the queue is not started.
+func (s *Server) enqueueRestore(ref *nodev1.ArtifactRef, prefix, localDir string) {
+	if s.store == nil || s.restoreCh == nil || prefix == "" {
+		return
+	}
+	s.restoreDedupeMu.Lock()
+	if _, queued := s.restoreDedupe[prefix]; queued {
+		s.restoreDedupeMu.Unlock()
+		return // already downloading (or queued); a re-trigger is a no-op
+	}
+	s.restoreDedupe[prefix] = struct{}{}
+	s.restoreDedupeMu.Unlock()
+
+	select {
+	case s.restoreCh <- restoreJob{ref: ref, prefix: prefix, localDir: localDir}:
+	default:
+		// Queue full: drop and un-mark so a later CP re-trigger can re-enqueue. The
+		// base simply does not appear READY; the CP re-triggers or rebuilds.
+		s.restoreDedupeMu.Lock()
+		delete(s.restoreDedupe, prefix)
+		s.restoreDedupeMu.Unlock()
+		s.logger.Warn("noded: restore queue full; dropping enqueue (CP will re-trigger or rebuild)", "artifact", prefix)
+	}
+}
+
+// restoreWorker drains the restore queue, running each download fire-and-forget.
+// A failure is logged, never retried inline (the base simply does not appear
+// READY and the CP re-triggers or rebuilds); a success re-registers the base so
+// NodeStatus advertises it READY. It exits when ctx is done or the channel closes.
+func (s *Server) restoreWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case job, ok := <-s.restoreCh:
+			if !ok {
+				return
+			}
+			s.runRestoreJob(ctx, job)
+		}
+	}
+}
+
+// runRestoreJob performs one queued BASE download: the multi-GB store.Restore
+// (checksum-verified per file), then re-registers the base via
+// ReconcileBasesFromDisk so a NodeStatus projection advertises it
+// BASE_BUILD_STATE_READY and a later wake sees it. It always clears the dedupe key
+// (guaranteed cleanup via defer, mirroring the export worker's crash-safety
+// discipline) so a subsequent CP re-trigger can re-enqueue. A download failure is
+// logged and dropped: the base stays absent, the CP's poll times out and it
+// rebuilds. It uses ctx (daemon lifetime), NOT the original RPC's context, which
+// returned at the fast-ACK; that is the whole point of going async.
+func (s *Server) runRestoreJob(ctx context.Context, job restoreJob) {
+	defer func() {
+		s.restoreDedupeMu.Lock()
+		delete(s.restoreDedupe, job.prefix)
+		s.restoreDedupeMu.Unlock()
+	}()
+
+	moved, generation, err := s.store.Restore(ctx, job.prefix, job.localDir)
+	if err != nil {
+		s.logger.Warn("noded: async base restore failed (CP will re-trigger or rebuild)", "artifact", job.prefix, "err", err)
+		return
+	}
+	s.reregisterRestored(job.ref)
+	s.exported.mark(job.prefix, generation)
+	s.logger.Info("noded: restored base off store", "artifact", job.prefix, "bytesMoved", moved, "generation", generation)
+	s.signalChange()
 }
 
 // ---- store reachability probe ----------------------------------------------

--- a/projects/embervm/noded/server/store_test.go
+++ b/projects/embervm/noded/server/store_test.go
@@ -468,6 +468,123 @@ func baseExportedInStatus(s *Server, workload, ref string) bool {
 
 // TestExportArtifactMissingLocalFails proves ExportArtifact refuses
 // FAILED_PRECONDITION when the local artifact is absent.
+func waitForBaseOnDisk(t *testing.T, s *Server, ref string) {
+	t.Helper()
+	snapfile := filepath.Join(s.cfg.SnapshotRoot, "bases", ref, "snapfile")
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(snapfile); err == nil {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("base %q did not land on disk within the deadline", ref)
+}
+
+func TestRestoreArtifactBaseIsAsync(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Start the async queues (export + restore share the lifecycle).
+	s.StartStoreLoops(ctx)
+
+	workload := "bazel-query"
+	ref := "bazel-query__abcdef012345"
+	// The runtime must be provisioned so the re-registered base is not GC'd by the
+	// reconcile's imageref gate; seed the store artifact with the imageref file the
+	// disk scan reads back.
+	digest := "sha256:runtime-bazel"
+	s.registry.sync([]workloadEntry{{Workload: workload, ImageRef: digest, RootfsRef: "/rootfs/bazel"}})
+	prefix := "base/amd/" + workload + "/" + ref
+	fs.seedArtifact(prefix, map[string]string{"imageref": digest, "memfile": "mem", "snapfile": "snap"}, 0, "amd", "")
+
+	resp, err := s.RestoreArtifact(ctx, &nodev1.RestoreArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_BASE, Workload: workload, Ref: ref},
+		Vendor:   "amd",
+	})
+	if err != nil {
+		t.Fatalf("RestoreArtifact(base): %v", err)
+	}
+	if !resp.GetAccepted() {
+		t.Fatal("a BASE restore that needs a download must fast-ACK accepted=true")
+	}
+	if resp.GetBytesMoved() != 0 {
+		t.Fatal("the fast-ACK must not report bytes moved (the download runs async)")
+	}
+
+	// The async worker downloads the base onto disk and re-registers it READY.
+	waitForBaseOnDisk(t, s, ref)
+	if got, _ := os.ReadFile(filepath.Join(s.cfg.SnapshotRoot, "bases", ref, "snapfile")); string(got) != "snap" {
+		t.Fatalf("restored base snapfile = %q, want snap", got)
+	}
+	if b, ok := s.bases.get(ref); !ok || b.state != nodev1.BaseBuildState_BASE_BUILD_STATE_READY {
+		t.Fatal("restored base not re-registered READY")
+	}
+}
+
+// TestRestoreArtifactBaseNotPresentFailsFast proves a BASE restore whose store
+// copy is absent returns FAILED_PRECONDITION SYNCHRONOUSLY (never an accepted
+// ack that would make the caller wait a poll timeout), so the control plane
+// falls back to BuildBase at once.
+func TestRestoreArtifactBaseNotPresentFailsFast(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.StartStoreLoops(ctx)
+
+	_, err := s.RestoreArtifact(ctx, &nodev1.RestoreArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_BASE, Workload: "bazel-query", Ref: "missing__000000000000"},
+		Vendor:   "amd",
+	})
+	if err == nil {
+		t.Fatal("a BASE restore of an absent store copy must fail, not ACK")
+	}
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("absent-base restore error code = %v, want FailedPrecondition", status.Code(err))
+	}
+}
+
+// TestRestoreArtifactBaseAlreadyLocalSkips proves a BASE restore is an inline
+// skipped no-op (NOT accepted/async) when the base is already present locally,
+// so a redundant hydrate trigger costs no download.
+func TestRestoreArtifactBaseAlreadyLocalSkips(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.StartStoreLoops(ctx)
+
+	workload := "bazel-query"
+	ref := "bazel-query__abcdef012345"
+	digest := "sha256:runtime-bazel"
+	s.registry.sync([]workloadEntry{{Workload: workload, ImageRef: digest, RootfsRef: "/rootfs/bazel"}})
+	prefix := "base/amd/" + workload + "/" + ref
+	fs.seedArtifact(prefix, map[string]string{"imageref": digest, "memfile": "mem", "snapfile": "snap"}, 0, "amd", "")
+	// The base is ALSO already on local disk.
+	writeBundleFiles(t, filepath.Join(s.cfg.SnapshotRoot, "bases", ref), map[string]string{"imageref": digest, "memfile": "mem", "snapfile": "snap"})
+
+	resp, err := s.RestoreArtifact(ctx, &nodev1.RestoreArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_BASE, Workload: workload, Ref: ref},
+		Vendor:   "amd",
+	})
+	if err != nil {
+		t.Fatalf("RestoreArtifact(already-local base): %v", err)
+	}
+	if !resp.GetSkipped() {
+		t.Fatal("an already-local base restore must be a skipped no-op")
+	}
+	if resp.GetAccepted() {
+		t.Fatal("an already-local base restore must NOT enqueue an async download")
+	}
+}
+
+// baseExportedInStatus finds the workload's capacity entry in NodeStatus whose
+// snapshot_ref matches and returns its exported flag; false if not reported.
+
+// TestExportArtifactMissingLocalFails proves ExportArtifact refuses
+// FAILED_PRECONDITION when the local artifact is absent.
 func TestExportArtifactMissingLocalFails(t *testing.T) {
 	fs := newFakeStore()
 	s := newStoreTestServer(t, fs)

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -1493,6 +1493,21 @@ message RestoreArtifactResponse {
   uint64 bytes_moved = 1;
   bool skipped = 2;
   uint64 generation = 3;
+  // accepted is true when the daemon fast-ACKed a BASE restore whose multi-GB
+  // download it enqueued to run ASYNCHRONOUSLY, rather than completing it inline
+  // (base-durability PR-2, additive). A base restore is a multi-minute S3
+  // download: holding the RPC open for it lets the Cilium/eBPF datapath reap the
+  // idle flow's conntrack entry mid-transfer ("the connection is closed"), the
+  // same failure that forced base EXPORT async. So the daemon runs the download
+  // on a bounded, deduped queue (mirroring the export queue) and returns
+  // accepted=true immediately; the caller then POLLS NodeStatus for the base to
+  // appear BASE_BUILD_STATE_READY (present-and-restorable) instead of blocking.
+  // accepted=false with skipped=true means the artifact was already present
+  // locally (an inline no-op, no poll needed); a not-present store copy is
+  // FAILED_PRECONDITION (not this response), so the caller falls back to rebuild
+  // at once. Only the BASE kind ever sets accepted; the small warmth/volume
+  // kinds still restore inline and return accepted=false.
+  bool accepted = 4;
 }
 
 // EvictArtifactRequest asks the daemon to delete one artifact. remote=true


### PR DESCRIPTION
## What

PR-2 of the EmberVM base-durability program: **hydrate-on-miss**. When a base the control plane recorded is absent locally on its node (cold-start, node replacement, scratch loss), the CP now **restores it from S3 instead of rebuilding it**. Depends on PR-1 (base export, merged).

## The critical finding: BASE restore was synchronous

noded's BASE `RestoreArtifact` drove the multi-GB S3 download **inline**, holding the RPC open for minutes. That is the exact idle-flow risk that forced base **export** async: with no traffic on the flow, the Cilium/eBPF datapath reaps its conntrack entry mid-transfer ("the connection is closed"). So this PR takes the **preferred pattern** and makes the BASE restore async, mirroring the export queue.

## noded

- **`RestoreArtifactResponse.accepted`** (additive proto field): the fast-ACK a BASE restore returns when it enqueued an async download.
- `RestoreArtifact` runs the sku-gate + already-local + S3-presence checks **synchronously** (cheap HEADs). An S3 miss / probe error is an immediate **`FAILED_PRECONDITION`** (fast, distinguishable fallback signal); an already-local base is an inline **skipped** no-op. A genuine BASE download **enqueues** onto a new bounded, deduped restore queue and **fast-ACKs `accepted=true`**. Small (session/serving/stateful/group/volume) kinds still restore inline, unchanged.
- New restore queue (2 workers, depth 64) shares the export queue's lifecycle. Dedupe key held **enqueue-through-completion** (the node queue is the CP-re-trigger dedupe guard), guaranteed cleanup via `defer`. The worker uses the **daemon ctx** (not the returned RPC ctx) and re-registers the base via `ReconcileBasesFromDisk` so NodeStatus advertises it READY.

## Control plane (BaseBuilder)

- **restore-first branch**, before the idempotent no-op, gated on four AND-ed guards:
  1. a recorded `snapshot_ref` with an **unchanged signature** (restoring the same ref we would rebuild);
  2. the node **affirmatively** reports that base absent (`BASE_BUILD_STATE_NONE`, never merely unreported: this is the key guard, it stops a spurious restore in the race window right after a build before the node re-reports READY);
  3. no build in flight;
  4. no hydrate in flight.
- It triggers the **vendor-stamped** `RestoreArtifact` (via `RestoreVendor.stamp`), then **polls NodeStatus** for the base to become READY, falling back to `BuildBase` on an S3 miss (`FAILED_PRECONDITION`) or a poll timeout.
- **op-log**: `:artifact_restored{kind:"base"}` on a hydrate, `:base_built` on a build, so the hydrate-vs-build ratio is auditable (no new op-log kind).

## Scope (deliberate)

restore-first covers **only** the recorded-but-absent case. New builds and spec-change rebuilds target a ref the CP cannot know pre-build (noded derives `<workload>__hash(digest+revision+vendor)` node-side), so they stay `BuildBase`. Rollback-to-a-predecessor is intentionally a **rebuild**, not a hydrate: under **N=1 S3 retention** (Joe, 2026-07-21) no predecessor ref persists in the store to hydrate from, so a signature->ref history would be dead weight. A code comment at the branch states this so it does not read as a missing feature.

## Tests

- **Go**: async BASE restore round-trip (fast-ACK `accepted`, then download lands on disk + re-registers READY), fast `FAILED_PRECONDITION` on an S3 miss, already-local skip.
- **Elixir**: hydrate on recorded-but-absent, fallback on S3 miss, fallback on poll timeout, and **no hydrate on a not-yet-reported base** (the post-build race guard).

Chart bumped to **0.1.181**. No local test loop (per repo convention); CI runs remotely.

## Review focus

- The async-download handling: fast-ACK vs inline, the daemon-ctx worker, and the dedupe held through completion.
- The vendor gate: the hydrate stamps via `RestoreVendor.stamp`; noded's fail-closed sku gate is untouched. `stamp_key/2` resolves the builder's instance_id to the `{configured_id, pod_uid}` tuple the capacity table keys on (the builder's node_id is an instance_id, which `NodeCapacity.fetch` does not resolve as a bare string).
- Guard 3 (affirmatively-absent) as the correctness lynchpin against the post-build race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFXpz6XW8Tmb3Yj5t3b1c