### PR TITLE
feat(embervm): base eviction fix + reconciled retention sweep (PR-3)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.181
+version: 0.1.182

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -93,7 +93,10 @@ defmodule Embervm.Application do
       # dials the daemon over its own Mint gRPC connection (per build), so it
       # depends on Finch but not on the watcher or node registry. Empty node
       # config (no daemon wired) means it holds descriptors and builds nothing.
-      {Embervm.BaseBuilder, nodes: configured_nodes(), runtime_images: configured_runtime_images()},
+      {Embervm.BaseBuilder,
+       nodes: configured_nodes(),
+       runtime_images: configured_runtime_images(),
+       retention_sweep_enabled: base_retention_sweep_enabled()},
       # The Workload informer (Task 5): LISTs then WATCHes Workload CRs over the
       # Finch pool above and writes Embervm.WorkloadCatalog, which
       # TaskStore.cfg_for/1 reads. Placed after Finch (its watch streams over
@@ -445,6 +448,20 @@ defmodule Embervm.Application do
               acc
           end
         end)
+    end
+  end
+
+  # Base-durability PR-3: the destructive gate for the BaseBuilder base-retention
+  # sweep, from EMBERVM_BASE_RETENTION_SWEEP. UNSET or "0"/"false"/"" (the default,
+  # and what this PR ships) => the sweep runs but only LOGS what it would evict,
+  # deleting nothing. "1"/"true" => the sweep issues EvictArtifact{remote: false}
+  # for each superseded local base outside the desired set (the one-shot ~290G
+  # backlog reclaim an operator supervises). Wired here so it flips via a deploy
+  # values env change, no code change. Nothing sets it on in this PR.
+  defp base_retention_sweep_enabled do
+    case trimmed_env("EMBERVM_BASE_RETENTION_SWEEP") do
+      v when v in ["1", "true", "TRUE", "True"] -> true
+      _ -> false
     end
   end
 

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -108,7 +108,7 @@ defmodule Embervm.BaseBuilder do
     ArtifactRef,
     BuildBaseRequest,
     BuildBaseResponse,
-    EvictSnapshotRequest,
+    EvictArtifactRequest,
     ExportArtifactRequest,
     NodeService,
     ResourceSpec,
@@ -128,6 +128,16 @@ defmodule Embervm.BaseBuilder do
   # was down at build time). 60s is well below any base's lifetime and the sweep
   # is bounded to current-base-present-but-unexported, so it never hammers.
   @export_reconcile_interval_ms 60_000
+
+  # Base-durability PR-3: how often the reconciled base-retention sweep runs. It
+  # reconciles each node's reported local base inventory (NodeStatus.local_bases,
+  # the full per-ref disk truth) against the desired set (current ref + still-
+  # refcounted superseded refs) and, when the destructive gate is on, evicts the
+  # difference. 300s: retention is a slow-moving reconcile (a superseded base is
+  # only born on a build turnover), never a hot path, and the sweep is bounded to
+  # workloads whose current base is already exported. Well below any base's
+  # lifetime; the guarded, idempotent EvictArtifact makes a re-sweep harmless.
+  @retention_sweep_interval_ms 300_000
 
   # -- Client API ------------------------------------------------------------
 
@@ -246,6 +256,20 @@ defmodule Embervm.BaseBuilder do
     GenServer.call(server, :status)
   end
 
+  @doc """
+  Run one reconciled base-retention sweep synchronously and return the dry-run
+  plan (a list of `%{workload, evict_refs, evict_bytes, skipped_unexported}`
+  descriptors), for tests and operational visibility. A synchronous call so a
+  test can drive the sweep deterministically and assert what it evicted (or, with
+  the destructive gate off, what it WOULD evict) without waiting on the timer.
+  The actual evictions (gate on) are spawned fire-and-forget exactly as the timer
+  path does; the returned plan is the sweep's decision, independent of the gate.
+  """
+  @spec retention_sweep_now(GenServer.server()) :: [map()]
+  def retention_sweep_now(server \\ __MODULE__) do
+    GenServer.call(server, :retention_sweep_now)
+  end
+
   defp cast_if_alive(server, msg) do
     case GenServer.whereis(server) do
       nil -> :ok
@@ -262,11 +286,18 @@ defmodule Embervm.BaseBuilder do
     build_fun = Keyword.get(opts, :build_fun, &default_build/2)
     connect_fun = Keyword.get(opts, :connect_fun, &default_connect/1)
     disconnect_fun = Keyword.get(opts, :disconnect_fun, &default_disconnect/1)
-    # R2: the EvictSnapshot seam for destroying a fully-drained superseded base
-    # (the ADR embervm/003 eviction verb, landed early). Defaults to the real
-    # NodeService.Stub.evict_snapshot/2 over a per-call channel; tests inject a
-    # fake to assert eviction fires exactly when both refcounts hit zero.
-    evict_fun = Keyword.get(opts, :evict_fun, &default_evict/2)
+    # R2 + PR-3: the eviction seam for destroying a fully-drained superseded base.
+    # It now uses EvictArtifact{remote: false} (kind BASE) rather than the R2-era
+    # EvictSnapshot: EvictSnapshot dispatched a base ref into the SESSION bundle
+    # path on the node (RemoveSessionBundle), which no-op-removed a nonexistent
+    # sessions/<ref> dir and returned success while bases/<ref> survived, so every
+    # superseded base leaked. EvictArtifact routes to the new noded BASE arm that
+    # removes bases/<ref> behind an in-use/BUILDING/not-last guard. Defaults to the
+    # real NodeService.Stub.evict_artifact/2 over a per-call channel; tests inject a
+    # fake to assert eviction fires exactly when both refcounts hit zero. The seam
+    # takes (channel, workload, ref) so it can compose the vendor-keyed store prefix
+    # (the BASE key is base/<vendor>/<workload>/<ref>).
+    evict_fun = Keyword.get(opts, :evict_fun, &default_evict/3)
     # Base-durability PR-1: the ExportArtifact seam that writes a freshly-built
     # (or present-but-unexported) base back to the object store. Defaults to the
     # real NodeService.Stub.export_artifact/2 over a per-call channel; tests
@@ -301,6 +332,22 @@ defmodule Embervm.BaseBuilder do
     # shrink both so a fallback path asserts deterministically without real sleep.
     hydrate_poll_interval_ms = Keyword.get(opts, :hydrate_poll_interval_ms, 5_000)
     hydrate_poll_max = Keyword.get(opts, :hydrate_poll_max, 90)
+
+    # Base-durability PR-3: the reconciled base-retention sweep cadence. 0 disables
+    # the timer entirely (the unit-test default, so a test drives :retention_sweep
+    # explicitly and asserts deterministically); production uses the module default.
+    retention_sweep_interval_ms =
+      Keyword.get(opts, :retention_sweep_interval_ms, @retention_sweep_interval_ms)
+
+    # Base-durability PR-3: the destructive gate. When FALSE (the default, and the
+    # production default until an operator opts in) the retention sweep computes and
+    # LOGS what it would evict (a dry-run line per workload: candidate count + total
+    # bytes) but deletes NOTHING. When TRUE it issues EvictArtifact{remote: false}
+    # for each superseded local base outside the desired set. application.ex reads it
+    # from EMBERVM_BASE_RETENTION_SWEEP ("1"/"true" => on, unset/"0" => off) so it can
+    # be enabled later via deploy values without a code change; nothing in this PR
+    # sets it on. Merging this PR is inert: the sweep runs but only logs.
+    retention_sweep_enabled = Keyword.get(opts, :retention_sweep_enabled, false)
 
     status_writer = Keyword.get(opts, :status_writer, &Embervm.K8s.patch_workload_status/3)
     clock = Keyword.get(opts, :clock, fn -> System.system_time(:millisecond) end)
@@ -372,10 +419,13 @@ defmodule Embervm.BaseBuilder do
       status_writer: status_writer,
       clock: clock,
       base_backoff_ms: base_backoff,
-      max_backoff_ms: max_backoff
+      max_backoff_ms: max_backoff,
+      retention_sweep_interval_ms: retention_sweep_interval_ms,
+      retention_sweep_enabled: retention_sweep_enabled
     }
 
     schedule_export_reconcile(state)
+    schedule_retention_sweep(state)
 
     {:ok, state}
   end
@@ -400,6 +450,11 @@ defmodule Embervm.BaseBuilder do
   @impl true
   def handle_call({:report_base_refs, ref, counts}, _from, state) do
     {:reply, :ok, apply_base_refs(state, ref, counts)}
+  end
+
+  def handle_call(:retention_sweep_now, _from, state) do
+    {plan, state} = retention_sweep_plan(state)
+    {:reply, plan, state}
   end
 
   def handle_call(:status, _from, state) do
@@ -462,6 +517,15 @@ defmodule Embervm.BaseBuilder do
   def handle_info(:export_reconcile, state) do
     state = export_reconcile(state)
     schedule_export_reconcile(state)
+    {:noreply, state}
+  end
+
+  # Base-durability PR-3: the periodic reconciled base-retention sweep fired.
+  # Reconcile each node's reported local base inventory against the desired set and
+  # (when the destructive gate is on) evict the difference, then re-arm the timer.
+  def handle_info(:retention_sweep, state) do
+    state = retention_sweep(state)
+    schedule_retention_sweep(state)
     {:noreply, state}
   end
 
@@ -1429,6 +1493,142 @@ defmodule Embervm.BaseBuilder do
     end
   end
 
+  # -- reconciled base-retention sweep (base-durability PR-3) ------------------
+
+  # Run one reconciled base-retention sweep and apply it: with the destructive gate
+  # OFF, log the dry-run plan and change nothing; with the gate ON, spawn an
+  # EvictArtifact{remote: false} for each superseded local base outside the desired
+  # set. Returns the (possibly updated) state. This is the reconciled backstop the
+  # event-driven refcount path lacks: it enumerates from the node's REPORTED local
+  # inventory (NodeStatus.local_bases), so it prunes even the pre-R2 orphans the CP
+  # never tracked in base_refs and the superseded refs whose refcount event fired
+  # and no-op'd before this fix, which the event path alone can never re-fire.
+  defp retention_sweep(state) do
+    {_plan, state} = retention_sweep_plan(state)
+    state
+  end
+
+  # Compute the sweep plan (a per-workload list of what to evict) AND apply the
+  # gated action. The plan is returned for tests/visibility; the action is the
+  # spawned evictions (gate on) or the dry-run log (gate off).
+  #
+  # For each workload with a placed, exported current base:
+  #   candidates = local READY bases the node reports (local_bases, READY only)
+  #                MINUS the desired set (current ref + still-refcounted superseded
+  #                refs). BUILDING/FAILED local bases are never candidates (a
+  #                BUILDING base is being written; noded also refuses it).
+  # Durability-before-eviction: a workload whose CURRENT base is not yet exported
+  # is SKIPPED WHOLE (never empty the local cache before the S3 floor lands). noded's
+  # in-use/current/BUILDING guard is the final backstop beneath this.
+  defp retention_sweep_plan(state) do
+    Enum.reduce(state.workloads, {[], state}, fn {name, w}, {plan, acc} ->
+      case workload_retention(acc, w) do
+        :skip ->
+          {plan, acc}
+
+        {:skip_unexported, node_id} ->
+          entry = %{workload: name, evict_refs: [], evict_bytes: 0, skipped_unexported: true, node_id: node_id}
+          {[entry | plan], acc}
+
+        {:evict, node_id, refs, bytes} ->
+          entry = %{workload: name, evict_refs: refs, evict_bytes: bytes, skipped_unexported: false, node_id: node_id}
+          acc = apply_retention(acc, name, node_id, refs, bytes)
+          {[entry | plan], acc}
+      end
+    end)
+    |> then(fn {plan, acc} -> {Enum.reverse(plan), acc} end)
+  end
+
+  # Decide one workload's retention outcome from the node's reported facts:
+  #   :skip                          - not placed, no node fact, or nothing to evict
+  #   {:skip_unexported, node_id}    - current base present but not yet exported
+  #   {:evict, node_id, refs, bytes} - superseded local bases to evict + their bytes
+  defp workload_retention(state, w) do
+    with true <- is_binary(w.node_id) and is_binary(w.snapshot_ref),
+         {:ok, fact} <- find_capacity_fact(state.capacity_table, w.node_id),
+         locals when is_list(locals) <- Map.get(fact, :local_bases, []) do
+      current_exported? =
+        case get_in(fact, [:workloads, w.name]) do
+          %{snapshot_ref: ref, exported: exported} -> ref == w.snapshot_ref and exported == true
+          _ -> false
+        end
+
+      cond do
+        not current_exported? ->
+          # Durability floor not yet confirmed for this workload: skip it whole.
+          {:skip_unexported, w.node_id}
+
+        true ->
+          desired = desired_refs(w)
+
+          # A candidate is any local base for this workload that is NOT desired and
+          # NOT currently BUILDING. READY superseded versions AND unregistered/.tmp
+          # orphan dirs (base_state UNSPECIFIED) are both candidates, so the reclaim
+          # drains the orphans too; a BUILDING ref is never a candidate (it is being
+          # written, and noded refuses it as the final backstop). The current ref is
+          # excluded via `desired`, and durability-before-eviction gated this whole
+          # workload above.
+          candidates =
+            for b <- locals,
+                b.workload == w.name,
+                b.base_state != :BASE_BUILD_STATE_BUILDING,
+                b.ref not in desired,
+                do: b
+
+          if candidates == [] do
+            :skip
+          else
+            refs = Enum.map(candidates, & &1.ref)
+            bytes = candidates |> Enum.map(&(&1.size_bytes || 0)) |> Enum.sum()
+            {:evict, w.node_id, refs, bytes}
+          end
+      end
+    else
+      _ -> :skip
+    end
+  end
+
+  # The desired base refs for a workload: its CURRENT ref, PLUS every superseded
+  # ref the CP still refcounts (a base_refs entry that is not yet evicted, so a
+  # primed VM or pinned session may still ride it). A ref whose refcounts drained
+  # and fired an eviction (evicted: true) is NOT desired: it is a candidate. This
+  # keeps the sweep from ever removing a base a live VM or banked session still
+  # needs, independent of noded's own in-use guard.
+  defp desired_refs(w) do
+    superseded_desired =
+      for {ref, entry} <- w.base_refs, not Map.get(entry, :evicted, false), do: ref
+
+    [w.snapshot_ref | superseded_desired]
+  end
+
+  # Apply the gated retention action for one workload. Gate OFF: log the dry-run
+  # (count + total bytes) and change nothing. Gate ON: spawn an idempotent
+  # EvictArtifact{remote: false} per candidate ref (noded's guard is the final
+  # backstop) and log the reclaim.
+  defp apply_retention(state, workload, node_id, refs, bytes) do
+    if state.retention_sweep_enabled do
+      Logger.info(
+        "embervm base builder: base-retention sweep evicting #{length(refs)} superseded local base(s) for #{workload} (~#{bytes} bytes) on #{node_id}"
+      )
+
+      Enum.each(refs, fn ref -> spawn_evict(state, node_id, workload, ref) end)
+      state
+    else
+      Logger.info(
+        "embervm base builder: base-retention sweep (DRY RUN, gate off) WOULD evict #{length(refs)} superseded local base(s) for #{workload} (~#{bytes} bytes) on #{node_id}"
+      )
+
+      state
+    end
+  end
+
+  defp schedule_retention_sweep(%{retention_sweep_interval_ms: ms}) when ms > 0 do
+    Process.send_after(self(), :retention_sweep, ms)
+    :ok
+  end
+
+  defp schedule_retention_sweep(_state), do: :ok
+
   # Spawn a fire-and-forget ExportArtifact worker for one base ref on its node,
   # unless an export for the same {workload, ref} is already in flight. Returns the
   # (possibly updated) state with the in-flight key marked.
@@ -1650,18 +1850,19 @@ defmodule Embervm.BaseBuilder do
       }
 
       state = put_in(state.workloads[name], w)
-      spawn_evict(state, entry.node_id, ref)
+      spawn_evict(state, entry.node_id, name, ref)
       state
     else
       state
     end
   end
 
-  # Spawn a fire-and-forget eviction worker. EvictSnapshot is idempotent (an
-  # unknown ref is OK), so a lost result or a retry is harmless; failures are
-  # logged, not retried here (the next report, or the banked-TTL GC, is the
-  # backstop). Not monitored: a crash cannot un-evict the already-marked ref.
-  defp spawn_evict(state, node_id, ref) do
+  # Spawn a fire-and-forget eviction worker. EvictArtifact{remote: false} is
+  # idempotent (an already-gone base is success), so a lost result or a retry is
+  # harmless; failures are logged, not retried here (the next report, or the
+  # reconciled retention sweep, is the backstop). Not monitored: a crash cannot
+  # un-evict the already-marked ref.
+  defp spawn_evict(state, node_id, workload, ref) do
     address = state.node_addr[node_id]
     connect_fun = state.connect_fun
     disconnect_fun = state.disconnect_fun
@@ -1672,7 +1873,7 @@ defmodule Embervm.BaseBuilder do
         case connect_fun.(address) do
           {:ok, channel} ->
             try do
-              evict_fun.(channel, ref)
+              evict_fun.(channel, workload, ref)
             catch
               kind, reason -> {:error, {kind, reason}}
             after
@@ -1684,8 +1885,13 @@ defmodule Embervm.BaseBuilder do
         end
 
       case result do
-        {:ok, _} -> :ok
-        other -> Logger.warning("embervm base builder: EvictSnapshot #{ref} failed: #{inspect(other)}")
+        {:ok, _} ->
+          :ok
+
+        other ->
+          Logger.warning(
+            "embervm base builder: EvictArtifact #{workload}/#{ref} failed: #{inspect(other)}"
+          )
       end
     end)
 
@@ -1853,12 +2059,20 @@ defmodule Embervm.BaseBuilder do
     NodeService.Stub.build_base(channel, request, timeout: 600_000)
   end
 
-  # EvictSnapshot the superseded base ref. Trace carries no workload (a base
-  # eviction is not a per-workload task op); the ref is the whole payload.
-  defp default_evict(channel, ref) do
-    NodeService.Stub.evict_snapshot(channel, %EvictSnapshotRequest{
-      trace: %Trace{},
-      snapshot_ref: ref
+  # EvictArtifact{remote: false} the superseded base ref (kind BASE): remove the
+  # LOCAL bases/<ref> dir on the node, leaving any store copy untouched. The
+  # ArtifactRef carries the workload so the node composes the vendor-keyed base
+  # store prefix; the node stamps its own cpu vendor. Idempotent on an
+  # already-gone base.
+  defp default_evict(channel, workload, ref) do
+    NodeService.Stub.evict_artifact(channel, %EvictArtifactRequest{
+      artifact: %ArtifactRef{
+        kind: :ARTIFACT_KIND_BASE,
+        workload: workload,
+        ref: ref
+      },
+      remote: false,
+      trace: %Trace{workload: workload}
     })
   end
 

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -87,6 +87,7 @@ defmodule Embervm.NodeRegistry do
   alias Embervm.Node.V1.{
     GroupBundleSet,
     GroupMemberVm,
+    BaseInventoryEntry,
     GroupNetwork,
     NodeService,
     NodeStatus,
@@ -639,9 +640,31 @@ defmodule Embervm.NodeRegistry do
       # sets them (wire-compatible), which reads as "no group state on this node".
       group_networks: group_networks_from_status(s),
       group_member_vms: group_member_vms_from_status(s),
-      group_bundle_sets: group_bundle_sets_from_status(s)
+      group_bundle_sets: group_bundle_sets_from_status(s),
+      # Local base inventory (base-durability PR-3, additive): the node's FULL
+      # per-ref base disk inventory (every dir under bases/, including superseded
+      # versions), which the WorkloadCapacity projection cannot convey (it reports
+      # only the ONE current base per workload). Embervm.BaseBuilder's reconciled
+      # base-retention sweep reconciles this observed local set against its desired
+      # set (current + still-refcounted refs) and evicts the difference. Empty when
+      # a daemon predates the field (wire-compatible), which the sweep reads as "no
+      # local base inventory to reconcile", exactly the pre-PR-3 behavior.
+      local_bases: local_bases_from_status(s)
     }
   end
+
+  defp local_bases_from_status(%NodeStatus{local_bases: bases}) when is_list(bases) do
+    for %BaseInventoryEntry{} = b <- bases do
+      %{
+        ref: b.ref,
+        workload: b.workload,
+        size_bytes: b.size_bytes,
+        base_state: b.base_state
+      }
+    end
+  end
+
+  defp local_bases_from_status(_), do: []
 
   defp group_networks_from_status(%NodeStatus{group_networks: nets}) when is_list(nets) do
     for %GroupNetwork{} = n <- nets do

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -98,12 +98,23 @@ defmodule Embervm.BaseBuilderTest do
           # background sweep perturbs timing). Export-specific tests override both.
           export_fun: Keyword.get(opts, :export_fun, fn :fake_channel, _req -> {:ok, %{}} end),
           export_reconcile_interval_ms: Keyword.get(opts, :export_reconcile_interval_ms, 0),
+          # Base-durability PR-3: disable the retention-sweep timer by default so no
+          # background sweep perturbs the other tests' timing; the sweep-specific
+          # tests drive :retention_sweep_now synchronously and opt the gate on/off.
+          retention_sweep_interval_ms: Keyword.get(opts, :retention_sweep_interval_ms, 0),
           # Default the op-log to a discarding fake so a build's export audit never
           # touches the real SQLite in tests that do not assert on it. The
           # op-log-specific test overrides both to observe the append.
           op_log: Keyword.get(opts, :op_log, :discard),
           op_log_mod: Keyword.get(opts, :op_log_mod, DiscardOpLog)
-        ] ++ Keyword.drop(opts, [:export_fun, :export_reconcile_interval_ms, :op_log, :op_log_mod])
+        ] ++
+          Keyword.drop(opts, [
+            :export_fun,
+            :export_reconcile_interval_ms,
+            :retention_sweep_interval_ms,
+            :op_log,
+            :op_log_mod
+          ])
       )
 
     pid
@@ -525,7 +536,7 @@ defmodule Embervm.BaseBuilderTest do
   # -- base refcounting + eviction (R2) ---------------------------------------
 
   # Drives a base turnover (snap1 -> snap2) and then feeds refcounts against the
-  # superseded snap1 via report_base_refs/3, asserting that EvictSnapshot fires
+  # superseded snap1 via report_base_refs/3, asserting that EvictArtifact fires
   # exactly once, and only when BOTH primed and session refcounts are zero.
   defp turnover_to_snap2(builder, agent) do
     # gen1 -> snap1.
@@ -547,9 +558,9 @@ defmodule Embervm.BaseBuilderTest do
       {:ok, resp(ref)}
     end
 
-    evict_fun = fn :fake_channel, ref ->
+    evict_fun = fn :fake_channel, _workload, ref ->
       send(test_pid, {:evicted, ref})
-      {:ok, %Embervm.Node.V1.EvictSnapshotResponse{}}
+      {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
     end
 
     builder =
@@ -592,9 +603,9 @@ defmodule Embervm.BaseBuilderTest do
       {:ok, resp(ref)}
     end
 
-    evict_fun = fn :fake_channel, ref ->
+    evict_fun = fn :fake_channel, _workload, ref ->
       send(test_pid, {:evicted, ref})
-      {:ok, %Embervm.Node.V1.EvictSnapshotResponse{}}
+      {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
     end
 
     builder =
@@ -638,9 +649,9 @@ defmodule Embervm.BaseBuilderTest do
       {:ok, resp(ref)}
     end
 
-    evict_fun = fn :fake_channel, ref ->
+    evict_fun = fn :fake_channel, _workload, ref ->
       send(test_pid, {:evicted, ref})
-      {:ok, %Embervm.Node.V1.EvictSnapshotResponse{}}
+      {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
     end
 
     builder =
@@ -664,6 +675,216 @@ defmodule Embervm.BaseBuilderTest do
     # either.
     :ok = BaseBuilder.report_base_refs(builder, "snap1", sessions: 0)
     assert_receive {:evicted, "snap1"}, 1_000
+  end
+
+  # -- reconciled base-retention sweep (base-durability PR-3) ------------------
+
+  # Put a node-4 capacity fact carrying a current-base WorkloadCapacity fact (with
+  # its exported flag) and a full local_bases inventory, so the retention sweep can
+  # reconcile the reported local set against its desired set. instance_id is "node-4"
+  # so find_capacity_fact(table, w.node_id) matches (the workload places on @node).
+  defp put_local_bases_fact(table, workload, current_ref, exported?, local_bases) do
+    NodeCapacity.put(table, {"node-4", "ds"}, %{
+      node_id: "node-4",
+      configured_id: "node-4",
+      instance_id: "node-4",
+      workloads: %{
+        workload => %{
+          snapshot_ref: current_ref,
+          base_state: :BASE_BUILD_STATE_READY,
+          exported: exported?
+        }
+      },
+      local_bases: local_bases,
+      updated_at: 0
+    })
+  end
+
+  defp ready_base(ref, workload, bytes) do
+    %{ref: ref, workload: workload, size_bytes: bytes, base_state: :BASE_BUILD_STATE_READY}
+  end
+
+  # An unregistered / .tmp-orphan on-disk base dir: noded reports it with
+  # base_state UNSPECIFIED. The sweep must treat it as a candidate (it is neither
+  # current nor BUILDING), so the reclaim drains orphans too.
+  defp orphan_base(ref, workload, bytes) do
+    %{ref: ref, workload: workload, size_bytes: bytes, base_state: :BASE_BUILD_STATE_UNSPECIFIED}
+  end
+
+  # Drive one build so the CP has a placed, current snapshot_ref for "w" on node-4.
+  # The builder's own build_fun (set by the caller) returns `ref`.
+  defp build_current(builder, agent, ref) do
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 1, image_ref: "imgA"}))
+    assert_eventually(fn -> match?(%{"snapshotRef" => ^ref}, latest(agent, "w")) end)
+  end
+
+  test "retention sweep evicts superseded local bases outside the desired set (gate on)" do
+    agent = start_recorder()
+    test_pid = self()
+    table = new_cap_table()
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__current")} end
+
+    evict_fun = fn :fake_channel, workload, ref ->
+      send(test_pid, {:evicted, workload, ref})
+      {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
+    end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        evict_fun: evict_fun,
+        retention_sweep_enabled: true
+      )
+
+    build_current(builder, agent, "w__current")
+
+    # The node reports its full on-disk inventory: the current base, a READY
+    # superseded version the CP never tracked, AND an unregistered .tmp orphan
+    # (base_state UNSPECIFIED). Both non-current dirs must evict.
+    put_local_bases_fact(table, "w", "w__current", true, [
+      ready_base("w__current", "w", 512),
+      ready_base("w__superseded", "w", 2_048),
+      orphan_base("w__tmporphan", "w", 1_024)
+    ])
+
+    plan = BaseBuilder.retention_sweep_now(builder)
+
+    entry = Enum.find(plan, &(&1.workload == "w"))
+    assert entry.skipped_unexported == false
+    assert Enum.sort(entry.evict_refs) == ["w__superseded", "w__tmporphan"]
+    assert entry.evict_bytes == 3_072
+
+    # Gate on: both the superseded READY base and the .tmp orphan are evicted;
+    # the current base is never touched.
+    assert_receive {:evicted, "w", "w__superseded"}, 1_000
+    assert_receive {:evicted, "w", "w__tmporphan"}, 1_000
+    refute_receive {:evicted, "w", "w__current"}, 100
+  end
+
+  test "retention sweep is a dry-run no-op with the gate OFF (default): plans but evicts nothing" do
+    agent = start_recorder()
+    test_pid = self()
+    table = new_cap_table()
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__current")} end
+
+    evict_fun = fn :fake_channel, workload, ref ->
+      send(test_pid, {:evicted, workload, ref})
+      {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
+    end
+
+    # No retention_sweep_enabled opt => default false (what this PR ships).
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        evict_fun: evict_fun
+      )
+
+    build_current(builder, agent, "w__current")
+
+    put_local_bases_fact(table, "w", "w__current", true, [
+      ready_base("w__current", "w", 512),
+      ready_base("w__orphan1", "w", 2_048)
+    ])
+
+    plan = BaseBuilder.retention_sweep_now(builder)
+
+    # The plan still identifies the candidate (observability), but nothing is evicted.
+    entry = Enum.find(plan, &(&1.workload == "w"))
+    assert entry.evict_refs == ["w__orphan1"]
+    assert entry.evict_bytes == 2_048
+    refute_receive {:evicted, "w", "w__orphan1"}, 200
+  end
+
+  test "retention sweep skips a workload whose current base is not yet exported (durability floor)" do
+    agent = start_recorder()
+    test_pid = self()
+    table = new_cap_table()
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__current")} end
+
+    evict_fun = fn :fake_channel, workload, ref ->
+      send(test_pid, {:evicted, workload, ref})
+      {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
+    end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        evict_fun: evict_fun,
+        retention_sweep_enabled: true
+      )
+
+    build_current(builder, agent, "w__current")
+
+    # Current base is present but NOT yet exported: the whole workload is skipped,
+    # so the local cache is never emptied before the S3 durability floor lands.
+    put_local_bases_fact(table, "w", "w__current", false, [
+      ready_base("w__current", "w", 512),
+      ready_base("w__orphan1", "w", 2_048)
+    ])
+
+    plan = BaseBuilder.retention_sweep_now(builder)
+
+    entry = Enum.find(plan, &(&1.workload == "w"))
+    assert entry.skipped_unexported == true
+    assert entry.evict_refs == []
+    refute_receive {:evicted, "w", "w__orphan1"}, 200
+  end
+
+  test "retention sweep never evicts a still-refcounted superseded ref" do
+    agent = start_recorder()
+    test_pid = self()
+    table = new_cap_table()
+
+    # Turnover so the CP tracks snap-old as a superseded ref, then hold it
+    # refcounted (a primed VM still rides it: primed reported, sessions unknown).
+    build_fun = fn :fake_channel, req ->
+      ref = if req.image_ref == "imgA", do: "snap-old", else: "snap-new"
+      {:ok, resp(ref)}
+    end
+
+    evict_fun = fn :fake_channel, workload, ref ->
+      send(test_pid, {:evicted, workload, ref})
+      {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
+    end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        evict_fun: evict_fun,
+        retention_sweep_enabled: true
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 1, image_ref: "imgA"}))
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap-old"}, latest(agent, "w")) end)
+    :ok = BaseBuilder.reconcile(builder, desc(%{generation: 2, image_ref: "imgB"}))
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap-new"}, latest(agent, "w")) end)
+
+    # snap-old is still refcounted (a primed VM rides it): sessions unknown (nil)
+    # keeps it un-evictable in the R2 path AND desired in the sweep.
+    :ok = BaseBuilder.report_base_refs(builder, "snap-old", primed: 1)
+
+    put_local_bases_fact(table, "w", "snap-new", true, [
+      ready_base("snap-new", "w", 512),
+      ready_base("snap-old", "w", 2_048)
+    ])
+
+    plan = BaseBuilder.retention_sweep_now(builder)
+
+    entry = Enum.find(plan, &(&1.workload == "w"))
+    # snap-old is refcounted, so it is in the desired set: nothing to evict.
+    assert entry == nil or entry.evict_refs == []
+    refute_receive {:evicted, "w", "snap-old"}, 200
   end
 
   # -- discovery-fed node set (artifact-decoupling PR-C, C4) -------------------

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.181
+      targetRevision: 0.1.182
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/registry.go
+++ b/projects/embervm/noded/server/registry.go
@@ -145,6 +145,29 @@ func (r *vmRegistry) liveCount() int {
 	return len(r.vms)
 }
 
+// snapshotRefInUse reports whether any live task VM (primed or assigned) was
+// restored from the given base ref, i.e. its birth base is still needed by a
+// running guest. It is the in-use guard for a local BASE eviction (PR-3): a base
+// dir must never be removed out from under a VM that restored from it. A primed
+// session VM before its first SessionAssign also lives here (claimForSession
+// promotes it out only on adoption), so this covers the pre-adoption session
+// lane too; post-adoption session/serving VMs ride their own session/serving
+// bundle refs, never a base ref, so they are correctly not consulted here. An
+// empty ref never matches a real VM.
+func (r *vmRegistry) snapshotRefInUse(ref string) (string, bool) {
+	if ref == "" {
+		return "", false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for id, e := range r.vms {
+		if e.snapshotRef == ref {
+			return id, true
+		}
+	}
+	return "", false
+}
+
 // ---- session VM registry ---------------------------------------------------
 
 // sessionEntry is one LIVE session microVM the daemon supervises. Unlike a task
@@ -437,6 +460,14 @@ func (b *baseRegistry) register(e baseEntry) {
 		readyPath:   e.readyPath,
 		state:       e.state,
 	}
+}
+
+// remove forgets a base entry by snapshot_ref (after its on-disk dir is deleted),
+// so NodeStatus stops advertising it. Idempotent on an absent ref.
+func (b *baseRegistry) remove(ref string) {
+	b.mu.Lock()
+	delete(b.bases, ref)
+	b.mu.Unlock()
 }
 
 // snapshot returns a copy of all base entries, for building NodeStatus.

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1586,7 +1586,124 @@ func (s *Server) nodeStatus() *nodev1.NodeStatus {
 		MemBudgetMib:          s.memBudget(),
 		CpuBudgetMillicores:   s.cpuBudget(),
 		CpuSku:                s.cpuSku(),
+		LocalBases:            s.localBasesStatus(),
 	}
+}
+
+// localBasesStatus projects the daemon's FULL on-disk base inventory into the
+// repeated NodeStatus.local_bases (base-durability PR-3). Unlike the
+// WorkloadCapacity projection (ONE current base per workload) AND unlike the base
+// registry alone, this SCANS the bases/ directory so it reports EVERY dir present:
+//   - registered bases (READY/BUILDING/FAILED), carrying the registry's state +
+//     size,
+//   - superseded versions left by turnovers,
+//   - and UNREGISTERED on-disk-only dirs (a build that died mid-write leaves a
+//     memfile.tmp/snapfile.tmp orphan with no snapfile, so ReconcileBasesFromDisk
+//     never registered it), reported with base_state UNSPECIFIED.
+//
+// Scanning disk (not just the registry) is what lets the control plane's retention
+// sweep target the .tmp orphans too: a registry-only projection would hide them,
+// stranding the exact bytes PR-3 exists to reclaim. A dir also present in the
+// registry takes the registry's state/size (authoritative for a live BUILDING
+// ref); a dir absent from the registry is sized from its files on disk. Bounded by
+// the on-disk base-dir count.
+func (s *Server) localBasesStatus() []*nodev1.BaseInventoryEntry {
+	root := filepath.Join(s.cfg.SnapshotRoot, "bases")
+	dirents, err := os.ReadDir(root)
+	if err != nil {
+		// Missing dir (fresh node) or unreadable: fall back to the registry view so
+		// a scan error never blanks an inventory the registry could still report.
+		return s.localBasesFromRegistry()
+	}
+	// Index the registry by ref so a scanned dir can adopt its authoritative state.
+	reg := make(map[string]baseEntry)
+	for _, b := range s.bases.snapshot() {
+		reg[b.snapshotRef] = b
+	}
+	out := make([]*nodev1.BaseInventoryEntry, 0, len(dirents))
+	seen := make(map[string]struct{}, len(dirents))
+	for _, ent := range dirents {
+		if !ent.IsDir() {
+			continue
+		}
+		ref := ent.Name()
+		seen[ref] = struct{}{}
+		if b, ok := reg[ref]; ok {
+			out = append(out, &nodev1.BaseInventoryEntry{
+				Ref:       ref,
+				Workload:  b.workload,
+				SizeBytes: uint64(b.sizeBytes),
+				BaseState: b.state,
+			})
+			continue
+		}
+		// Unregistered on-disk dir (a superseded dir not re-registered, or a .tmp
+		// orphan): report it so the sweep can reclaim it. base_state UNSPECIFIED
+		// marks "on disk, not a registry-known build".
+		out = append(out, &nodev1.BaseInventoryEntry{
+			Ref:       ref,
+			Workload:  workloadFromBaseKey(ref),
+			SizeBytes: dirSizeBytes(filepath.Join(root, ref)),
+			BaseState: nodev1.BaseBuildState_BASE_BUILD_STATE_UNSPECIFIED,
+		})
+	}
+	// A BUILDING ref whose dir has not yet materialized on disk (the build just
+	// started) lives only in the registry; include it so the sweep sees it BUILDING
+	// and never targets it.
+	for ref, b := range reg {
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		out = append(out, &nodev1.BaseInventoryEntry{
+			Ref:       ref,
+			Workload:  b.workload,
+			SizeBytes: uint64(b.sizeBytes),
+			BaseState: b.state,
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// localBasesFromRegistry is the registry-only fallback for localBasesStatus when
+// the bases/ dir cannot be scanned (missing on a fresh node, or a read error).
+func (s *Server) localBasesFromRegistry() []*nodev1.BaseInventoryEntry {
+	entries := s.bases.snapshot()
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]*nodev1.BaseInventoryEntry, 0, len(entries))
+	for _, b := range entries {
+		out = append(out, &nodev1.BaseInventoryEntry{
+			Ref:       b.snapshotRef,
+			Workload:  b.workload,
+			SizeBytes: uint64(b.sizeBytes),
+			BaseState: b.state,
+		})
+	}
+	return out
+}
+
+// dirSizeBytes sums the regular-file sizes directly under a base dir (snapfile +
+// memfile + any .tmp partials + sidecars), best-effort: an unreadable dir or entry
+// contributes 0 rather than failing the whole NodeStatus projection.
+func dirSizeBytes(dir string) uint64 {
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	var total uint64
+	for _, e := range ents {
+		if e.IsDir() {
+			continue
+		}
+		if fi, err := e.Info(); err == nil && fi.Size() > 0 {
+			total += uint64(fi.Size())
+		}
+	}
+	return total
 }
 
 // cpuSku builds this node's full CPU-restore identity (PR-E): vendor plus the

--- a/projects/embervm/noded/server/store.go
+++ b/projects/embervm/noded/server/store.go
@@ -503,9 +503,11 @@ func (s *Server) EvictArtifact(ctx context.Context, req *nodev1.EvictArtifactReq
 // evictArtifactLocal deletes the on-disk copy of an artifact over the typed ref,
 // reusing the existing kind-specific eviction path (EvictSnapshot for a session/
 // serving/stateful bundle, RemoveGroupMemberBundle per member for a group set,
-// DeleteVolume for a volume). Idempotent.
+// DeleteVolume for a volume, a direct bases/<ref> removal for a BASE). Idempotent.
 func (s *Server) evictArtifactLocal(ctx context.Context, ref *nodev1.ArtifactRef) (*nodev1.EvictArtifactResponse, error) {
 	switch ref.GetKind() {
+	case nodev1.ArtifactKind_ARTIFACT_KIND_BASE:
+		return s.evictBaseLocal(ref)
 	case nodev1.ArtifactKind_ARTIFACT_KIND_SESSION, nodev1.ArtifactKind_ARTIFACT_KIND_SERVING, nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL:
 		if _, err := s.EvictSnapshot(ctx, &nodev1.EvictSnapshotRequest{SnapshotRef: ref.GetRef()}); err != nil {
 			return nil, err
@@ -525,6 +527,74 @@ func (s *Server) evictArtifactLocal(ctx context.Context, ref *nodev1.ArtifactRef
 	default:
 		return nil, status.Errorf(codes.InvalidArgument, "noded: artifact kind %s not locally evictable", ref.GetKind())
 	}
+	return &nodev1.EvictArtifactResponse{}, nil
+}
+
+// evictBaseLocal removes a base snapshot dir (SnapshotRoot/bases/<ref>) behind
+// two safety guards, then forgets any registry entry so NodeStatus stops
+// advertising it. It is the local arm the control plane's superseded-ref eviction
+// and its reconciled retention sweep drive (PR-3): before this arm existed, a BASE
+// local evict fell through to InvalidArgument, so the control plane's EvictSnapshot
+// dispatched a base ref into the SESSION bundle path (RemoveSessionBundle), which
+// no-op-removed a nonexistent sessions/<ref> dir and returned success while
+// bases/<ref> survived. Every superseded base leaked that way.
+//
+// Guards (both refuse FAILED_PRECONDITION; these are the REAL safety, and they are
+// the only two facts noded can judge authoritatively about a ref):
+//   - (a) IN-USE: no live task VM (or pre-adoption session VM) was restored from
+//     this ref (vmRegistry.snapshotRefInUse). Evicting a base out from under a
+//     running guest that restored from it would strand the birth lineage.
+//   - (b) BUILDING: the ref is not currently BUILDING (a build writes into
+//     bases/<ref>; removing it mid-build corrupts the in-progress snapshot).
+//
+// Deliberately NO registry-membership, not-last, or "current base" guard here.
+// noded does not know the control plane's authoritative CURRENT ref (its own
+// per-workload capacity projection is last-wins-nondeterministic among multiple
+// provisioned READY bases, so it cannot be trusted to identify current), and a
+// registry/completeness guard would REFUSE exactly the artifacts PR-3 must delete:
+// the pre-R2 superseded versions AND the incomplete/.tmp orphan dirs (a build that
+// died mid-write leaves memfile.tmp/snapfile.tmp with no snapfile, so
+// ReconcileBasesFromDisk never registers it, so a registry-gated guard would strand
+// it forever). CURRENT-base protection is the CONTROL PLANE's job and is enforced
+// there: the retention sweep's desired set always includes the workload's current
+// ref (never a candidate) and the ongoing superseded-eviction path only ever names
+// a drained superseded ref, so noded is never asked to evict a current base. The
+// in-use and BUILDING guards below are the defense-in-depth backstop against a
+// mistargeted request. Result: every non-current, non-in-use, non-BUILDING dir
+// (registered, unregistered, or a .tmp orphan) is evictable, which is what drains
+// the backlog to exactly the current set.
+//
+// Idempotent: an already-absent dir is success (the desired end-state holds), so a
+// retry or a re-sweep is harmless.
+func (s *Server) evictBaseLocal(ref *nodev1.ArtifactRef) (*nodev1.EvictArtifactResponse, error) {
+	baseRef := ref.GetRef()
+	if baseRef == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: base ref required for local eviction")
+	}
+	if s.cfg.SnapshotRoot == "" {
+		return nil, status.Error(codes.FailedPrecondition, "noded: snapshot root not configured; base not locally evictable")
+	}
+	dir := filepath.Join(s.cfg.SnapshotRoot, "bases", baseRef)
+
+	// (a) In-use guard: refuse while a live VM was restored from this base ref.
+	if vmID, inUse := s.vms.snapshotRefInUse(baseRef); inUse {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: base %q is in use by live vm %q; refusing evict", baseRef, vmID)
+	}
+
+	// (b) BUILDING guard: never remove a base dir a BuildBase is writing into. An
+	// unknown ref (no registry entry, e.g. a superseded or .tmp-orphan dir) is by
+	// definition not BUILDING, so this only ever fires for a live in-progress build.
+	if entry, known := s.bases.get(baseRef); known && entry.state == nodev1.BaseBuildState_BASE_BUILD_STATE_BUILDING {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: base %q is BUILDING; refusing evict", baseRef)
+	}
+
+	// Remove the on-disk dir (idempotent: RemoveAll on an absent path is nil) and
+	// forget any registry entry so NodeStatus stops advertising it.
+	if err := os.RemoveAll(dir); err != nil {
+		return nil, status.Errorf(codes.Internal, "noded: evict base %q: %v", baseRef, err)
+	}
+	s.bases.remove(baseRef)
+	s.signalChange()
 	return &nodev1.EvictArtifactResponse{}, nil
 }
 

--- a/projects/embervm/noded/server/store_test.go
+++ b/projects/embervm/noded/server/store_test.go
@@ -455,6 +455,195 @@ func TestExportArtifactBaseMissingLocalFailsEvenAsync(t *testing.T) {
 	}
 }
 
+// evictBase is a small helper: EvictArtifact{remote:false} of a BASE ref.
+func evictBase(s *Server, workload, ref string) error {
+	_, err := s.EvictArtifact(context.Background(), &nodev1.EvictArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_BASE, Workload: workload, Ref: ref},
+		Remote:   false,
+	})
+	return err
+}
+
+// seedLocalBase writes a base dir on disk and registers it READY. Returns the dir path.
+func seedLocalBase(t *testing.T, s *Server, workload, ref string) string {
+	t.Helper()
+	dir := filepath.Join(s.cfg.SnapshotRoot, "bases", ref)
+	writeBundleFiles(t, dir, map[string]string{"imageref": "img", "memfile": "mem", "snapfile": "snap"})
+	s.bases.readyBuild(ref, workload, "img@sha256:seed", "/shim/ready", 2048)
+	return dir
+}
+
+// dirExists reports whether path is an existing directory (test-only helper).
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// TestEvictBaseLocalRemovesSupersededDir proves the PR-3 BASE arm: an
+// EvictArtifact{remote:false} of a superseded base ref removes bases/<ref> from
+// disk and forgets its registry entry, while the workload's CURRENT base survives.
+// This is the arm that fixes the leak: before it existed the control plane's
+// EvictSnapshot misrouted a base ref into the session path and no-op'd.
+func TestEvictBaseLocalRemovesSupersededDir(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+
+	current := "semgrep__current00"
+	superseded := "semgrep__old0000000"
+	seedLocalBase(t, s, "semgrep", current)
+	oldDir := seedLocalBase(t, s, "semgrep", superseded)
+
+	if err := evictBase(s, "semgrep", superseded); err != nil {
+		t.Fatalf("evict superseded base: %v", err)
+	}
+	if dirExists(oldDir) {
+		t.Fatalf("superseded base dir %q survived eviction", oldDir)
+	}
+	if _, ok := s.bases.get(superseded); ok {
+		t.Fatal("superseded base still registered after eviction")
+	}
+	// The current base is untouched.
+	if _, ok := s.bases.get(current); !ok {
+		t.Fatal("current base was wrongly forgotten")
+	}
+	if !dirExists(filepath.Join(s.cfg.SnapshotRoot, "bases", current)) {
+		t.Fatal("current base dir was wrongly removed")
+	}
+}
+
+// TestEvictBaseLocalIdempotentAlreadyGone proves an evict of an already-absent
+// base ref (never on disk, never registered) is success, so a retry or a
+// duplicate reconcile sweep is harmless.
+func TestEvictBaseLocalIdempotentAlreadyGone(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+	if err := evictBase(s, "semgrep", "semgrep__neverexisted"); err != nil {
+		t.Fatalf("evict of absent base should be idempotent success, got %v", err)
+	}
+}
+
+// TestEvictBaseLocalRefusesInUse proves the in-use guard: a base a live VM was
+// restored from is NOT evicted (its dir survives), so a running guest never loses
+// its birth lineage.
+func TestEvictBaseLocalRefusesInUse(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+
+	inUse := "sandbox__inuse00000"
+	dir := seedLocalBase(t, s, "sandbox", inUse)
+	s.vms.add(&vmEntry{id: "vm-live-1", workload: "sandbox", snapshotRef: inUse, state: vmPrimed})
+
+	err := evictBase(s, "sandbox", inUse)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("in-use base evict: want FailedPrecondition, got %v", err)
+	}
+	if !dirExists(dir) {
+		t.Fatal("in-use base dir was removed despite the guard")
+	}
+}
+
+// TestEvictBaseLocalRefusesBuilding proves the BUILDING guard: a base a BuildBase
+// is currently writing is NOT evicted (removing it mid-build would corrupt the
+// in-progress snapshot).
+func TestEvictBaseLocalRefusesBuilding(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+
+	// A current READY base plus a BUILDING one for the same workload.
+	seedLocalBase(t, s, "bazel-query", "bazel-query__ready000")
+	building := "bazel-query__building"
+	dir := filepath.Join(s.cfg.SnapshotRoot, "bases", building)
+	writeBundleFiles(t, dir, map[string]string{"imageref": "img", "memfile": "mem", "snapfile": "snap"})
+	s.bases.beginBuild(building, "bazel-query", "/shim/ready")
+
+	err := evictBase(s, "bazel-query", building)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("BUILDING base evict: want FailedPrecondition, got %v", err)
+	}
+	if !dirExists(dir) {
+		t.Fatal("BUILDING base dir was removed despite the guard")
+	}
+}
+
+// TestEvictBaseLocalEvictsUnregisteredOrphan proves the reclaim requirement: a
+// base dir with NO registry entry (a superseded dir not re-registered, or a build
+// that died leaving memfile.tmp/snapfile.tmp with no snapfile so
+// ReconcileBasesFromDisk never registered it) IS evicted, not refused. A
+// registry-gated guard would strand exactly these bytes, which is the leak PR-3
+// exists to drain. Current-base protection is the control plane's job (its sweep
+// never targets a current ref), not a noded registry guard.
+func TestEvictBaseLocalEvictsUnregisteredOrphan(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+
+	// A .tmp orphan: no snapfile, never registered.
+	orphan := "scratch-k8s__fc281c2c3e10"
+	dir := filepath.Join(s.cfg.SnapshotRoot, "bases", orphan)
+	writeBundleFiles(t, dir, map[string]string{"memfile.tmp": "partial", "snapfile.tmp": "partial"})
+	if _, ok := s.bases.get(orphan); ok {
+		t.Fatal("precondition: orphan should not be registered")
+	}
+
+	if err := evictBase(s, "scratch-k8s", orphan); err != nil {
+		t.Fatalf("evict unregistered orphan: %v (want success)", err)
+	}
+	if dirExists(dir) {
+		t.Fatal("unregistered .tmp orphan dir survived eviction")
+	}
+}
+
+// TestEvictBaseLocalEvictsOnlyBaseWhenTargeted proves noded has NO not-last guard:
+// when the control plane targets a base for local eviction (its desired-set
+// computation and durability gate having already run), noded removes it even if it
+// is the workload's last local READY base. The current-base floor lives in the CP
+// (which never targets a current ref), not in noded; a not-last guard here would
+// refuse a legitimately-superseded ref that happened to be the last on-disk copy.
+func TestEvictBaseLocalEvictsOnlyBaseWhenTargeted(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+
+	only := "scratch-k8s__only0000"
+	dir := seedLocalBase(t, s, "scratch-k8s", only)
+
+	if err := evictBase(s, "scratch-k8s", only); err != nil {
+		t.Fatalf("evict targeted base: %v (want success)", err)
+	}
+	if dirExists(dir) {
+		t.Fatal("targeted base dir survived eviction")
+	}
+	if _, ok := s.bases.get(only); ok {
+		t.Fatal("evicted base still registered")
+	}
+}
+
+// TestLocalBasesStatusReportsOrphans proves the Option-B inventory SCANS the
+// bases/ dir (not just the registry), so unregistered/.tmp orphan dirs appear in
+// NodeStatus.local_bases and the control plane's sweep can target them. A
+// registry-only projection would hide the orphans and strand them.
+func TestLocalBasesStatusReportsOrphans(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+
+	// A registered READY base and an unregistered .tmp orphan for the same workload.
+	seedLocalBase(t, s, "scratch-k8s", "scratch-k8s__current0")
+	orphanDir := filepath.Join(s.cfg.SnapshotRoot, "bases", "scratch-k8s__orphan00")
+	writeBundleFiles(t, orphanDir, map[string]string{"memfile.tmp": "partial"})
+
+	inv := s.localBasesStatus()
+	byRef := make(map[string]*nodev1.BaseInventoryEntry)
+	for _, e := range inv {
+		byRef[e.GetRef()] = e
+	}
+
+	reg, ok := byRef["scratch-k8s__current0"]
+	if !ok || reg.GetBaseState() != nodev1.BaseBuildState_BASE_BUILD_STATE_READY {
+		t.Fatalf("registered base missing/not READY in inventory: %+v", reg)
+	}
+	orphan, ok := byRef["scratch-k8s__orphan00"]
+	if !ok {
+		t.Fatal("unregistered .tmp orphan not reported in local_bases (would be stranded)")
+	}
+	if orphan.GetBaseState() != nodev1.BaseBuildState_BASE_BUILD_STATE_UNSPECIFIED {
+		t.Fatalf("orphan base_state = %v, want UNSPECIFIED", orphan.GetBaseState())
+	}
+	if orphan.GetWorkload() != "scratch-k8s" {
+		t.Fatalf("orphan workload = %q, want scratch-k8s (from base-key prefix)", orphan.GetWorkload())
+	}
+}
+
 // baseExportedInStatus finds the workload's capacity entry in NodeStatus whose
 // snapshot_ref matches and returns its exported flag; false if not reported.
 func baseExportedInStatus(s *Server, workload, ref string) bool {

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -1240,6 +1240,34 @@ enum BaseBuildState {
   BASE_BUILD_STATE_FAILED = 4;    // last BuildBase failed (see build_error)
 }
 
+// BaseInventoryEntry is ONE base snapshot dir the daemon holds on local disk
+// (base-durability PR-3, additive). WorkloadCapacity reports only the ONE current
+// base per workload (last-wins over the daemon's base registry), so it cannot
+// convey the SUPERSEDED versions that accumulate under bases/ across turnovers.
+// This repeated inventory is the daemon's full per-ref base disk truth, which the
+// control plane's reconciled base-retention sweep needs to compute (reported local
+// set MINUS desired set) and evict the difference. It is DELIBERATELY LOCAL-only:
+// {ref, workload, size_bytes, base_state}, NOT the S3 object listing (that is
+// PR-4's ListArtifacts, which is remote and carries vendor + created-at for
+// retention-by-count). Bounded by the on-disk base-dir count (~245 during the
+// backlog, shrinking toward ~9 per workload set post-reclaim), well within gRPC
+// message limits.
+message BaseInventoryEntry {
+  // ref is the base snapshot_ref (== the base dir name under bases/, the
+  // "<workload>__<sig>" base key).
+  string ref = 1;
+  // workload is the base's owning workload (recovered from the ref's
+  // "<workload>__" prefix on a disk-only entry).
+  string workload = 2;
+  // size_bytes is the base dir's on-disk size (snapfile + memfile), for the
+  // sweep's reclaim-bytes accounting and the dry-run log.
+  uint64 size_bytes = 3;
+  // base_state is the daemon's build state for this ref (READY/BUILDING/FAILED),
+  // so the sweep and its guards can reason about a BUILDING ref without a second
+  // lookup.
+  BaseBuildState base_state = 4;
+}
+
 // SessionVm is one LIVE session VM the node currently holds: the daemon reports
 // it (with the opaque session_id it was given at SessionAssign/Relight) so a
 // restarted control plane ADOPTS the running session instead of orphaning it,
@@ -1729,4 +1757,16 @@ message NodeStatus {
   // placement is unchanged) and on any daemon that predates this field; the
   // control plane treats empty as the wildcard class, never a guess.
   string size_class = 30;
+
+  // -- Local base inventory (base-durability PR-3, additive) -------------------
+  // local_bases is the daemon's FULL per-ref base disk inventory, one entry per
+  // dir under bases/. WorkloadCapacity carries only the ONE current base per
+  // workload, so the superseded versions that accumulate across turnovers are
+  // invisible to the control plane there; this field is the observed-truth input
+  // the CP base-retention sweep reconciles against its desired set (current +
+  // still-refcounted refs), evicting the difference via EvictArtifact{remote:
+  // false}. Empty on a daemon that predates this field (the CP then simply has no
+  // local base inventory to sweep, exactly the pre-PR-3 behavior). Bounded by the
+  // on-disk base-dir count.
+  repeated BaseInventoryEntry local_bases = 31;
 }


### PR DESCRIPTION
## Base-durability PR-3: fix the superseded-base leak + reconciled, gated reclaim

Fixes the leak that accumulated **245 superseded base dirs (~290G)** on node-4, and adds the reconciled retention sweep that drains it (including the incomplete/.tmp orphans), GATED OFF by default (merging deletes nothing).

### Root cause (confirmed in code)
The CP's `BaseBuilder` evicted a drained superseded base via `EvictSnapshot`. noded's handler (`server.go:1369`) checks the serving inventory, then falls to `sessionDriver.RemoveSessionBundle(ref)` = `os.RemoveAll(d.sessionDir(ref))` (`driver.go:1266`). `os.RemoveAll` returns `nil` for a nonexistent path, so a base ref no-op-removed the never-existent `sessions/<baseRef>` and returned success while `bases/<baseRef>` survived. That silent success is why the CP never saw an error.

### Parts
**Part 1 (noded).** A BASE arm in `evictArtifactLocal` (`evictBaseLocal`, `store.go`) removes `bases/<ref>` behind **two** guards only: **in-use** (a live task / pre-adoption-session VM restored from the ref) and **BUILDING**. Idempotent on already-gone. Deliberately NO not-last / registry-membership guard: those would refuse the exact dirs PR-3 must delete (unregistered superseded versions and `.tmp` orphans a dead build left with no snapfile). Current-base protection is the CONTROL PLANE's job (its sweep never targets a current ref); in-use+BUILDING is the defense-in-depth backstop.

**Part 2 (CP).** Superseded-ref eviction switches from `EvictSnapshot` to `EvictArtifact{remote: false}` (kind BASE), routing to the new arm. `evict_fun` seam widened to arity-3 to carry the workload for the vendor-keyed key.

**Part 3 (CP + additive proto).** A reconciled base-retention sweep:
- noded reports its **full on-disk base inventory** (additive `repeated BaseInventoryEntry local_bases` on `NodeStatus`: `{ref, workload, size_bytes, base_state}`), which `WorkloadCapacity` (one current base per workload) can't convey. It **scans the `bases/` dir**, not just the registry, so unregistered/`.tmp` orphans appear (base_state `UNSPECIFIED`) and the sweep can target them. LOCAL inventory only, distinct from PR-4's S3 `ListArtifacts`.
- The sweep reconciles the reported local set against the **desired set** (current ref UNION any superseded ref the CP still refcounts) and evicts the difference. A candidate is any local base NOT desired and NOT BUILDING (READY superseded AND `UNSPECIFIED` orphans both qualify). Reconcile-from-observed-truth, so it drains the pre-R2 orphans the CP never tracked.
- **Durability-before-eviction:** a workload whose current base is not yet `exported` in S3 is skipped whole (protects orphans and superseded alike behind the S3 floor).
- **Gated OFF by default:** `EMBERVM_BASE_RETENTION_SWEEP` (unset/`0` => sweep only LOGS a per-workload dry-run line: count + bytes; `1` => it evicts), read at runtime in `application.ex` and passed to `BaseBuilder`. An operator flips it via a deploy-values env change, no code change. Nothing sets it on here: merging is inert.

### Confirmed hypothesis
`RemoveSessionBundle` -> `os.RemoveAll(sessionDir)` returns idempotent success for an unknown (base) ref (`os.RemoveAll` is nil on a nonexistent path). That is the silent misroute.

### Tests
- Go (`store_test.go`): removes superseded, idempotent already-gone, refuses in-use, refuses BUILDING, **evicts an unregistered `.tmp` orphan**, **evicts a targeted last base**, and `localBasesStatus` **reports orphans** (scans disk).
- Elixir (`base_builder_test.exs`): sweep evicts local-minus-desired incl. a `.tmp` orphan (gate on), dry-run no-op (gate off, default), skips a workload whose current base is unexported, never evicts a still-refcounted superseded ref. Existing R2 evict fakes widened to arity-3 + `EvictArtifactResponse`.

### Chart
embervm `0.1.180 -> 0.1.182`.

### Review focus
- Gate defaults OFF; merging deletes nothing (dry-run only).
- noded guards are in-use + BUILDING; current protection is CP-side (desired set + durability gate). Confirm nothing can target a current, in-use, BUILDING, or unexported-workload base.
- `local_bases` scans disk so orphans are reclaimable; bounded by on-disk dir count (~245 backlog -> ~9 post-reclaim).
- Net effect: every non-current, non-in-use, non-BUILDING dir on node-4 (245 superseded + `.tmp` orphan) is reclaimable, leaving exactly the 9 current bases.

Do NOT auto-merge: after review, verify the flag-OFF deploy is inert, THEN a separate operator run flips the flag to reclaim the ~290G.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFXpz6XW8Tmb3Yj5t3b1c