### PR TITLE
feat(embervm): enable base-retention sweep (one-shot ~290G reclaim)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.182
+version: 0.1.183

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -305,6 +305,13 @@ spec:
             - name: EMBERVM_STATEFUL_WAKE_MAX
               value: {{ .Values.statefulSweeper.wakeMax | quote }}
             {{- end }}
+            {{- if .Values.baseRetention.sweepEnabled }}
+            # Base-retention sweep gate (base-durability PR-3): "1" arms the
+            # reconciled eviction of superseded local bases; unset keeps the
+            # dry-run that only logs. See baseRetention.sweepEnabled in values.
+            - name: EMBERVM_BASE_RETENTION_SWEEP
+              value: {{ .Values.baseRetention.sweepEnabled | quote }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -672,6 +672,17 @@ statefulSweeper:
   sweepIntervalMs: ""
   wakeMax: ""
 
+# Base-retention sweep gate (base-durability PR-3, control-plane env). Empty
+# (the default) leaves the reconciled sweep in dry-run: it logs what it would
+# evict and deletes nothing. "1" arms it: superseded local bases outside each
+# workload's desired set (current ref plus still-refcounted refs) are evicted,
+# first as the supervised one-shot backlog reclaim, then as the ongoing
+# retention backstop. Durability is checked before any eviction: a workload is
+# skipped whole unless its current base shows exported=true in S3. Flipping
+# this value back to "" is the entire rollback lever.
+baseRetention:
+  sweepEnabled: ""
+
 # The rootfs-builder tool image (crane + e2fsprogs + bash) that bakes each
 # workload's guest OCI image into an ext4 base rootfs at pod init. Reuses the
 # fc-invoke rootfs-builder image; Bazel pins repository:tag from its .info.

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.182
+      targetRevision: 0.1.183
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -176,3 +176,11 @@ demoPostgres:
 statefulSweeper:
   sweepIntervalMs: "1000"
   wakeMax: "30"
+
+# Arm the base-retention sweep (base-durability PR-3): one-shot supervised
+# reclaim of ~290G of superseded base versions on node-4, then the ongoing
+# retention backstop. Every current base is confirmed durable in S3 before any
+# local eviction, and hydrate-on-miss restores from S3 on a cold start.
+# Rollback: set back to "" and bump the chart; that stops further eviction.
+baseRetention:
+  sweepEnabled: "1"


### PR DESCRIPTION
Arms the reconciled base-retention sweep shipped gated-off in PR #3788 (chart 0.1.182, currently in dry-run logging only).

## What
- New `baseRetention.sweepEnabled` chart value, rendered as `EMBERVM_BASE_RETENTION_SWEEP` on the control-plane container (same conditional values-to-env pattern as `statefulSweeper`). Empty default keeps the dry-run.
- Deploy values set it to `"1"`: the sweep starts evicting superseded local base versions on node-4 (~290G across ~272 leaked version dirs plus one incomplete `.tmp` orphan).
- Chart 0.1.183.

## Safety
- Per workload, the desired set is the current snapshotRef plus still-refcounted superseded refs; only refs outside that set are ever named for eviction.
- A workload is skipped whole unless its current base shows exported=true in S3 (all 9 verified durable before this PR).
- noded refuses eviction of in-use or BUILDING refs; already-gone is success.
- Hydrate-on-miss (PR-2) restores any current base from S3 on a cold start.
- Rollback: set the value back to `""` and bump; that stops further eviction immediately.

This drain is being supervised live: baseline dir count and du are recorded, current refs verified on disk and in S3 after the drain, CP and fleet health watched throughout. The flag stays on afterwards as the ongoing retention backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFXpz6XW8Tmb3Yj5t3b1c