### PR TITLE
revert(embervm): hold base-retention sweep (gate back to dry-run)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.183
+version: 0.1.184

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.183
+      targetRevision: 0.1.184
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -183,4 +183,4 @@ statefulSweeper:
 # local eviction, and hydrate-on-miss restores from S3 on a cold start.
 # Rollback: set back to "" and bump the chart; that stops further eviction.
 baseRetention:
-  sweepEnabled: "1"
+  sweepEnabled: ""


### PR DESCRIPTION
Holds the reclaim enabled in #3789: flips baseRetention.sweepEnabled back to "" (dry-run) while the current-ref rebuild churn on the CP is diagnosed (snapshotRefs changing, several currents transiently unexported to S3, base dir count growing). No evictions had fired yet; the durability gate was correctly skipping the churning workloads. Chart 0.1.184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFXpz6XW8Tmb3Yj5t3b1c