### PR TITLE
feat(embervm): content-address guest image refs to stop base-rebuild churn

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.184
+version: 0.1.185

--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -47,7 +47,7 @@ securityContext:
 # Build each workload's base rootfs in-cluster from its pinned guest image
 # (crane export + mkfs.ext4 onto the nvme scratch), so node-4 never needs a
 # manual sudo rootfs placement. One builder per workload that declares a
-# top-level `<name>.guestImage` block (Bazel pins its repository:tag from the
+# top-level `<name>.guestImage` block (Bazel pins its repository@digest from the
 # guest image's .info provider); the builder bakes that guest's filesystem
 # into the workload's rootfsPath. Idempotent (a marker skips the multi-GB
 # rebuild when the guest ref is unchanged). Mirrors the fc-invoke pattern.
@@ -63,7 +63,7 @@ initContainers:
     command: ["/bin/bash", "/scripts/build-base-rootfs.sh"]
     env:
       - name: GUEST_IMAGE
-        value: "{{ $top.guestImage.repository }}:{{ $top.guestImage.tag }}"
+        value: "{{ $top.guestImage.repository }}@{{ $top.guestImage.digest }}"
       - name: BASE_ROOTFS_PATH
         value: {{ include "embervm.noded.rootfsPath" (dict "wl" $wl "top" $top) | quote }}
       - name: ROOTFS_SIZE

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -116,7 +116,7 @@ spec:
             # bakes and EMBERVM_NODED_IMAGES keys on (both derive from
             # runtimePython.guestImage), so BuildBase resolves it on the node.
             - name: EMBERVM_RUNTIME_IMAGES
-              value: {{ printf "%s=%s:%s" .Values.runtimePython.runtime .Values.runtimePython.guestImage.repository .Values.runtimePython.guestImage.tag | quote }}
+              value: {{ printf "%s=%s@%s" .Values.runtimePython.runtime .Values.runtimePython.guestImage.repository .Values.runtimePython.guestImage.digest | quote }}
             {{- end }}
             {{- if .Values.workloads }}
             # Artifact-decoupling Phase 2: node-side image identity (rootfs ref +
@@ -129,14 +129,18 @@ spec:
             # harness + sizing into each RegistryEntry). Keying by image_ref (not the
             # workloads values key) is deliberate: the values key is the
             # rootfs-builder key, while image_ref is the CR's stable join key
-            # (source.image.ref == guestImage.repository:tag). Format:
-            # comma-separated `imageRef=rootfsRef|harnessInit`.
+            # (source.image.ref == guestImage.repository@digest). Content-addressed
+            # so a chart republish with an unchanged guest rootfs renders the SAME
+            # ref, leaving the base-build signature stable (no rebuild churn). This
+            # ref MUST render byte-identical to the Workload CR source.image.ref and
+            # the noded rootfs-builder GUEST_IMAGE, since all three join on it.
+            # Format: comma-separated `imageRef=rootfsRef|harnessInit`.
             - name: EMBERVM_NODE_IMAGE_IDENTITY
               {{- $ids := list }}
               {{- range $name, $wl := .Values.workloads }}
               {{- $top := index $.Values $name }}
               {{- if and $top $top.guestImage $top.guestImage.repository }}
-              {{- $ref := printf "%s:%s" $top.guestImage.repository $top.guestImage.tag }}
+              {{- $ref := printf "%s@%s" $top.guestImage.repository $top.guestImage.digest }}
               {{- $rootfs := include "embervm.noded.rootfsPath" (dict "wl" $wl "top" $top) }}
               {{- $ids = append $ids (printf "%s=%s|%s" $ref $rootfs ($wl.harnessInit | default "")) }}
               {{- end }}

--- a/projects/embervm/chart/templates/workload-bazel-query.yaml
+++ b/projects/embervm/chart/templates/workload-bazel-query.yaml
@@ -20,7 +20,7 @@ spec:
     image:
       # Must match the top-level bazelQuery.guestImage exactly (the derived
       # EMBERVM_NODED_IMAGES + rootfs-builder GUEST_IMAGE use the same value).
-      ref: "{{ .Values.bazelQuery.guestImage.repository }}:{{ .Values.bazelQuery.guestImage.tag }}"
+      ref: "{{ .Values.bazelQuery.guestImage.repository }}@{{ .Values.bazelQuery.guestImage.digest }}"
       port: {{ .Values.bazelQueryWorkload.port }}
       readyPath: {{ .Values.bazelQueryWorkload.readyPath | quote }}
       invokePath: {{ .Values.bazelQueryWorkload.invokePath | quote }}

--- a/projects/embervm/chart/templates/workload-demo-postgres.yaml
+++ b/projects/embervm/chart/templates/workload-demo-postgres.yaml
@@ -24,7 +24,7 @@ spec:
       # and the noded image table are keyed on this ref via the scratchPostgres
       # workloads entry, so an identical string is what makes this workload
       # bootable without its own base bake.
-      ref: "{{ .Values.scratchPostgres.guestImage.repository }}:{{ .Values.scratchPostgres.guestImage.tag }}"
+      ref: "{{ .Values.scratchPostgres.guestImage.repository }}@{{ .Values.scratchPostgres.guestImage.digest }}"
       port: 1027
       readyPath: /shim/ready
   resources:

--- a/projects/embervm/chart/templates/workload-sandbox-session.yaml
+++ b/projects/embervm/chart/templates/workload-sandbox-session.yaml
@@ -34,7 +34,7 @@ spec:
       # SAME pin as the one-shot sandbox workload: one guest image serves both
       # the task class and the session class (the kernel mode is opt-in per
       # request via {"mode":"session"}, so the image is byte-identical).
-      ref: "{{ .Values.sandbox.guestImage.repository }}:{{ .Values.sandbox.guestImage.tag }}"
+      ref: "{{ .Values.sandbox.guestImage.repository }}@{{ .Values.sandbox.guestImage.digest }}"
       port: {{ .Values.sandboxSessionWorkload.port }}
       readyPath: {{ .Values.sandboxSessionWorkload.readyPath | quote }}
       invokePath: {{ .Values.sandboxSessionWorkload.invokePath | quote }}

--- a/projects/embervm/chart/templates/workload-sandbox.yaml
+++ b/projects/embervm/chart/templates/workload-sandbox.yaml
@@ -19,7 +19,7 @@ spec:
     image:
       # Must match the top-level sandbox.guestImage exactly (the derived
       # EMBERVM_NODED_IMAGES + rootfs-builder GUEST_IMAGE use the same value).
-      ref: "{{ .Values.sandbox.guestImage.repository }}:{{ .Values.sandbox.guestImage.tag }}"
+      ref: "{{ .Values.sandbox.guestImage.repository }}@{{ .Values.sandbox.guestImage.digest }}"
       port: {{ .Values.sandboxWorkload.port }}
       readyPath: {{ .Values.sandboxWorkload.readyPath | quote }}
       invokePath: {{ .Values.sandboxWorkload.invokePath | quote }}

--- a/projects/embervm/chart/templates/workload-scratch-k8s.yaml
+++ b/projects/embervm/chart/templates/workload-scratch-k8s.yaml
@@ -43,7 +43,7 @@ spec:
   # build is a valid k3s image.
   source:
     image:
-      ref: "{{ .Values.scratchK8sServer.guestImage.repository }}:{{ .Values.scratchK8sServer.guestImage.tag }}"
+      ref: "{{ .Values.scratchK8sServer.guestImage.repository }}@{{ .Values.scratchK8sServer.guestImage.digest }}"
       # The vsock health/ready contract used at BASE BUILD time (the warm-base
       # cold boot health-gates over vsock at readyPath; the k3s guest-init answers
       # /shim/ready there, mirroring scratch-postgres). The RUNTIME health is a TCP
@@ -73,7 +73,8 @@ spec:
         replicas: 1
         source:
           image:
-            ref: "{{ .Values.scratchK8sServer.guestImage.repository }}:{{ .Values.scratchK8sServer.guestImage.tag }}"
+            ref: "{{ .Values.scratchK8sServer.guestImage.repository }}@{{ .Values.scratchK8sServer.guestImage.digest }}"
+            # (server member, same digest as the group source ref above)
         resources:
           vcpus: 2
           memMib: 4096
@@ -91,7 +92,7 @@ spec:
         replicas: 2
         source:
           image:
-            ref: "{{ .Values.scratchK8sAgent.guestImage.repository }}:{{ .Values.scratchK8sAgent.guestImage.tag }}"
+            ref: "{{ .Values.scratchK8sAgent.guestImage.repository }}@{{ .Values.scratchK8sAgent.guestImage.digest }}"
         resources:
           vcpus: 1
           memMib: 3072

--- a/projects/embervm/chart/templates/workload-scratch-postgres.yaml
+++ b/projects/embervm/chart/templates/workload-scratch-postgres.yaml
@@ -21,7 +21,7 @@ spec:
     image:
       # Must match the top-level scratchPostgres.guestImage exactly (the derived
       # EMBERVM_NODED_IMAGES + rootfs-builder GUEST_IMAGE use the same value).
-      ref: "{{ .Values.scratchPostgres.guestImage.repository }}:{{ .Values.scratchPostgres.guestImage.tag }}"
+      ref: "{{ .Values.scratchPostgres.guestImage.repository }}@{{ .Values.scratchPostgres.guestImage.digest }}"
       # The vsock health/ready contract used at BASE BUILD time (the warm-base
       # cold boot health-gates over vsock at readyPath; the guest-init answers
       # /shim/ready there). The RUNTIME health is a TCP connect to stateful.port

--- a/projects/embervm/chart/templates/workload-semgrep.yaml
+++ b/projects/embervm/chart/templates/workload-semgrep.yaml
@@ -17,7 +17,7 @@ spec:
     image:
       # Must match the top-level semgrep.guestImage exactly (the derived
       # EMBERVM_NODED_IMAGES + rootfs-builder GUEST_IMAGE use the same value).
-      ref: "{{ .Values.semgrep.guestImage.repository }}:{{ .Values.semgrep.guestImage.tag }}"
+      ref: "{{ .Values.semgrep.guestImage.repository }}@{{ .Values.semgrep.guestImage.digest }}"
       port: {{ .Values.semgrepWorkload.port }}
       readyPath: {{ .Values.semgrepWorkload.readyPath | quote }}
       invokePath: {{ .Values.semgrepWorkload.invokePath | quote }}

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.184
+      targetRevision: 0.1.185
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## The churn this fixes

EmberVM's base build **signature** includes the guest image **reference string**, which the chart rendered as `<repository>:<tag>` where `<tag>` is commit-SHA-based (e.g. `2026.07.22.00.14.27-dc934d5`). So **every** embervm deploy re-tagged all guest images and changed the base signature, triggering a full rebuild of all 9 workload bases even when the guest **rootfs content** was identical. Tonight 5 embervm merges each caused a rebuild storm. This is churn plus a provisioning-window hazard.

## The fix (chart-template only)

Flip every guest image **reference site** from `<repository>:<tag>` to `<repository>@<digest>` (content-addressed):

- `helm_images_values` already emits a per-image `digest` key alongside `repository`/`tag` (`bazel/helm/images.bzl`), so the digest is available at render time.
- Guest builds are reproducible, so the digest is **stable** across CP/noded-only deploys. That stability is exactly what stops the churn.
- The ref is an **opaque join key** end to end: CP puts it in the Workload CR `source.image.ref`, `EMBERVM_NODE_IMAGE_IDENTITY`, and `EMBERVM_RUNTIME_IMAGES`; noded matches on it via `GUEST_IMAGE`. Changing `:tag` to `@digest` changes only the string's shape; nothing parses it, so **no Go/Elixir/proto change**.

Sites flipped (all guest/runtime rootfs refs):

- `workload-sandbox.yaml`, `workload-sandbox-session.yaml`, `workload-semgrep.yaml`, `workload-bazel-query.yaml`, `workload-scratch-postgres.yaml`, `workload-demo-postgres.yaml`, `workload-scratch-k8s.yaml` (group + server + agent members) — the Workload CR `ref:` fields
- `deployment.yaml` — `EMBERVM_NODE_IMAGE_IDENTITY` and `EMBERVM_RUNTIME_IMAGES`
- `_noded-pod.tpl` — the rootfs-builder `GUEST_IMAGE`

**Untouched:** the container (control-plane / noded / xds / serving-envoy / rootfs-builder / scratch-prep) image refs, and the on-disk `rootfsPath` suffix (`_helpers.tpl`) — that suffix is a local artifact filename, not the base-build signature, and renaming it on rollout would orphan banked session snapshots.

## Verification

`helm template embervm projects/embervm/chart/ -f projects/embervm/deploy/values.yaml` (with a digest overlay, since the real digest is Bazel-injected at build time) confirms: every guest ref renders `<repo>@sha256:...`, none remain on `:tag`, and the **same digest string** appears byte-identical at all join sites for each workload (Workload CR `ref:` == identity env `imageRef` == noded `GUEST_IMAGE`).

## Rollout expectation

One expected **final rebuild storm** on rollout: the ref shape changes once, so all 9 bases rebuild and export once. After that, CP/noded-only deploys mint **zero** bases and the churn goes quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFXpz6XW8Tmb3Yj5t3b1c