### PR TITLE
feat(embervm): arm base-retention sweep (enable base GC, reclaim ~340G superseded)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.185
+version: 0.1.186

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.185
+      targetRevision: 0.1.186
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -183,4 +183,4 @@ statefulSweeper:
 # local eviction, and hydrate-on-miss restores from S3 on a cold start.
 # Rollback: set back to "" and bump the chart; that stops further eviction.
 baseRetention:
-  sweepEnabled: ""
+  sweepEnabled: "1"


### PR DESCRIPTION
Flips the base-retention GC from dry-run to armed by setting baseRetention.sweepEnabled to "1" in deploy values (EMBERVM_BASE_RETENTION_SWEEP=1 on the control-plane; sweep runs every 300s).

Safety properties:
- The durability guard skips any workload whose current base is not exported=true in S3.
- Only SUPERSEDED local base dirs outside each workload's desired set are evicted; currents are never touched.
- Rollback lever: set sweepEnabled back to "" and bump the chart; that stops further eviction.

Includes the chart bump (0.1.185 -> 0.1.186) so the value change deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFXpz6XW8Tmb3Yj5t3b1c