### PR TITLE
fix(embervm): scratch-prep loop mount uses host path (fixes master cap)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.189
+version: 0.1.190

--- a/projects/embervm/chart/templates/scratch-prep-daemonset.yaml
+++ b/projects/embervm/chart/templates/scratch-prep-daemonset.yaml
@@ -78,7 +78,14 @@ spec:
               SCRATCH=/var/lib/embervm/scratch
               # Backing file for the loop-mounted cap. Lives on the host disk via
               # the /host hostPath bind (see volumes), NOT inside scratch itself.
+              # IMG is the CONTAINER view (used by in-container fallocate/mkfs);
+              # HOST_IMG is the SAME physical file as the HOST sees it, used by the
+              # nsenter-into-host `mount -o loop` and the fstab entry. They must
+              # differ: the /host bind path does not exist in the host mount
+              # namespace, so mounting IMG via nsenter fails to open the backing
+              # file ("failed to setup loop device").
               IMG=/host/scratch.img
+              HOST_IMG=/var/lib/embervm/scratch.img
               SIZE_GI="${SCRATCH_SIZE_GI:?scratchSizeGi unset}"
 
               # THE GUARD. A bind mount (node-4's dedicated-NVMe fstab bind) and a
@@ -113,13 +120,13 @@ spec:
               #    check; the earlier guard already proved it is unmounted, this only
               #    guards a mid-script re-entry.
               if ! nsenter -t 1 -m -- mountpoint -q "$SCRATCH"; then
-                nsenter -t 1 -m -- mount -o loop "$IMG" "$SCRATCH"
+                nsenter -t 1 -m -- mount -o loop "$HOST_IMG" "$SCRATCH"
               fi
 
               # 3) Persist across reboots. The fstab entry is keyed on the backing
               #    FILE with the loop option, so the host re-derives the loop device
               #    on boot. Idempotent: appended only if absent.
-              FSTAB_LINE="$IMG $SCRATCH ext4 loop,defaults 0 0"
+              FSTAB_LINE="$HOST_IMG $SCRATCH ext4 loop,defaults 0 0"
               if ! nsenter -t 1 -m -- grep -qF "$FSTAB_LINE" /etc/fstab 2>/dev/null; then
                 nsenter -t 1 -m -- sh -c "echo '$FSTAB_LINE' >> /etc/fstab"
               fi

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.189
+      targetRevision: 0.1.190
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
On the first master onboard, scratch-prep (0.1.189) crashlooped with 'failed to setup loop device for /host/scratch.img'. The host has loop devices (loop built into the 6.8 kernel); the failure is a PATH bug: mount -o loop runs via nsenter into the host mount namespace but was passed the CONTAINER path /host/scratch.img (the /var/lib/embervm hostPath bind), which does not exist there.

Fix: IMG=/host/scratch.img for in-container fallocate+mkfs; HOST_IMG=/var/lib/embervm/scratch.img for the nsenter mount -o loop and fstab. node-4 unaffected (mountpoint guard exits first).