### PR TITLE
feat(embervm): retire wildcard noded DaemonSet, go bricks-only (autoscale up)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.190
+version: 0.1.192

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -100,11 +100,16 @@ spec:
             - name: EMBERVM_NODE_ADDRESS
               value: {{ .Values.node.address | quote }}
             {{- end }}
-            {{- if .Values.noded.enabled }}
+            {{- if or .Values.noded.enabled .Values.bricks.enabled }}
             # The noded ServiceAccount username the control plane authenticates the
             # dial-home POST against (a valid TokenReview whose username equals this,
             # NOT the task-submit allow-list). Rendered from the release namespace +
             # noded SA name so it survives a rename.
+            #
+            # SHARED (not DS-specific): brick pods dial home as this same SA, so the
+            # CP must accept it whenever the DS OR any brick exists. Gated on
+            # (noded OR bricks) so retiring the DS (bricks-only) does not strip the
+            # CP's dial-home auth allow-list out from under the bricks.
             - name: EMBERVM_NODED_SERVICE_ACCOUNT
               value: {{ printf "system:serviceaccount:%s:%s" .Release.Namespace (include "embervm.noded.serviceAccountName" .) | quote }}
             {{- end }}

--- a/projects/embervm/chart/templates/noded-serviceaccount.yaml
+++ b/projects/embervm/chart/templates/noded-serviceaccount.yaml
@@ -1,8 +1,14 @@
-{{- if .Values.noded.enabled }}
+{{- if or .Values.noded.enabled .Values.bricks.enabled }}
 # The node daemon needs no Kubernetes API access (no TokenReview, no CR watch):
 # its gRPC surface is gated by a static bearer token, not the apiserver. So this
 # ServiceAccount carries no RBAC - it exists only to give the privileged pod a
 # non-default identity and to attach the GHCR image-pull secret.
+#
+# SHARED IDENTITY (not DS-specific): brick pods run as this same SA (the shared
+# _noded-pod.tpl sets serviceAccountName to it), so it must render whenever the
+# DS OR any brick exists. Gating it on noded.enabled alone would delete the SA
+# out from under the bricks when the DS is retired (bricks-only), so their
+# dial-home would fail auth. Rendered for (noded OR bricks).
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.190
+      targetRevision: 0.1.192
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -74,6 +74,17 @@ tracing:
 # ~1.5Gi/VM that is ~24Gi worst case, well within budget. This only raises the
 # runaway backstop, not any pool floor.
 noded:
+  # WILDCARD DAEMONSET DEPRECATED (bricks-only migration). The per-node wildcard
+  # noded DaemonSet is retired: node capacity is now provided entirely by the
+  # size-class brick Deployments the BrickController autoscales (bricks.autoscale
+  # = up below), so the CP picks the optimal brick mix from placement demand
+  # rather than one fixed daemon per node. Discovery is dial-home (not the noded
+  # Service), and the shared noded ServiceAccount + the CP dial-home auth env are
+  # decoupled from this flag (rendered for noded OR bricks), so bricks keep their
+  # identity with the DS off. Rollback: set back to true (the DS re-renders and
+  # backstops beside the bricks). node scratch is provisioned out of band now
+  # (docs/runbooks/embervm-node-scratch-setup.md).
+  enabled: false
   maxLiveVMs: 16
 
 # Node-provisioning contract (ADR embervm/012 storage-tiers amendment; warmth
@@ -135,7 +146,12 @@ bricks:
   # min/max clamps live in the chart values (recorded policy 2026-07-20:
   # min {16gi: 1}, max {2gi: 4, 4gi: 3, 8gi: 2, 16gi: 2}).
   autoscale:
-    mode: observe
+    # up: with the wildcard DaemonSet retired (noded.enabled=false above), bricks
+    # are the ONLY capacity, so the BrickController must act on placement-denial
+    # pressure and scale classes up (clamped to chart maxReplicas: 2gi 4, 16gi 2)
+    # to absorb the migrated workloads. Scale-down stays observe-only until we
+    # promote to full. This is what lets the CP choose the optimal brick mix.
+    mode: up
 
 # EmberVM R4 scale-to-zero scratch-postgres (ADR embervm/001, D-R4.PR-11.1):
 # enabled with the k8s-homelab 1Password item whose POSTGRES_PASSWORD field syncs


### PR DESCRIPTION
Retire the per-node wildcard noded DaemonSet; node capacity is now entirely size-class brick Deployments the BrickController autoscales. The CP picks the optimal brick mix from placement demand instead of one fixed daemon per node.

## The trap this defuses
`noded.enabled` was overloaded: it gated not just the DaemonSet but the SHARED noded ServiceAccount and the CP's dial-home auth env (`EMBERVM_NODED_SERVICE_ACCOUNT`) - both of which the brick pods depend on (bricks run as the noded SA). A naive flip would delete the SA + CP auth out from under the bricks -> every dial-home fails auth -> fleet dark. This PR decouples both (render for `noded OR bricks`).

## Changes
- `noded.enabled=false`: drops the DaemonSet + its (dial-home-obsolete) headless Service.
- SA template + CP `EMBERVM_NODED_SERVICE_ACCOUNT` env: gated on `(noded OR bricks)`.
- `bricks.autoscale.mode=up`: BrickController scales classes on placement-denial pressure (clamped to chart maxReplicas 2gi 4 / 16gi 2).

## Verified (helm template with deploy values)
DS **not** rendered; noded SA **rendered**; `EMBERVM_NODED_SERVICE_ACCOUNT` **rendered**; brick Deployments (2/4/8/16gi) rendered.

## Rollback
`noded.enabled=true` re-renders the DS beside the bricks. Discovery is dial-home so nothing else depends on the DS.