### PR TITLE
fix(embervm): noded stateful+group local eviction arms + reaper remote-guard (#38)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.192
+version: 0.1.194

--- a/projects/embervm/control/lib/embervm/warmth_reaper.ex
+++ b/projects/embervm/control/lib/embervm/warmth_reaper.ex
@@ -303,6 +303,31 @@ defmodule Embervm.WarmthReaper do
   # uses); the single remote EvictArtifact{remote: true, kind: GROUP_SET, workload:
   # group_instance_id, ref: set_id} that drops the whole set prefix at once fires
   # ONLY when EVERY member's local eviction succeeded.
+  # Empty-binding SKIP (#38 fix C): a bundle boot-scanned from disk before the
+  # binding sidecar shipped (or after a crash between snapfile-publish and
+  # sidecar-write) seeds with workload/group_instance_id = "" or nil. Its LOCAL
+  # evict would succeed and DRAIN the on-disk copy, but the REMOTE (S3) evict needs
+  # the workload to compose the prefix and fails InvalidArgument, so the set/bundle
+  # would be locally gone yet its S3 copy stranded FOREVER with no handle to find it
+  # again (Fable F2, worse than nothing). So we run NEITHER copy's evict and log ONE
+  # info line. Reclaiming these pre-sidecar orphans is a separate decision (task
+  # #39); until then they are safely left whole.
+  defp evict_entry(_state, %{kind: :stateful, id: ref, workload: workload}) when workload in [nil, ""] do
+    Logger.info(
+      "embervm warmth reaper: SKIP orphaned stateful bundle #{inspect(ref)} (no workload binding on disk; cannot evict remote copy safely, leaving whole)"
+    )
+
+    :ok
+  end
+
+  defp evict_entry(_state, %{kind: :group, id: set_id, workload: gid}) when gid in [nil, ""] do
+    Logger.info(
+      "embervm warmth reaper: SKIP orphaned group set #{inspect(set_id)} (no group_instance_id binding on disk; cannot evict remote copy safely, leaving whole)"
+    )
+
+    :ok
+  end
+
   defp evict_entry(state, %{kind: :stateful, id: ref, workload: workload, node_id: node_id}) do
     dial_key = WakeInstance.dial_for_bundle(state.capacity_table, node_id, ref)
     artifact = %ArtifactRef{kind: :ARTIFACT_KIND_STATEFUL, workload: workload, ref: ref}

--- a/projects/embervm/control/lib/embervm/warmth_reaper.ex
+++ b/projects/embervm/control/lib/embervm/warmth_reaper.ex
@@ -286,26 +286,35 @@ defmodule Embervm.WarmthReaper do
   # is gone (orphan), so both copies go (Joe's "orphaned instances evicted
   # entirely"). Every eviction is idempotent on an already-absent artifact.
   #
-  # STATEFUL: local is EvictArtifact{remote: false, kind: STATEFUL, ref} (which noded
-  # routes to EvictSnapshot(ref) -> os.RemoveAll(stateful/<ref>)); remote is the same
-  # ref with remote: true (deletes the S3 stateful/<vendor>/<workload>/<ref> prefix).
+  # The remote (S3) copy is deleted ONLY when the local eviction succeeded (#38): a
+  # local FAILED_PRECONDITION (a live VM was relit from the ref) or any local error
+  # SKIPS the remote, so the reaper never destroys the off-node recovery copy of a
+  # bundle the node itself refused to remove. See run_evict/2 for the ordering.
+  #
+  # STATEFUL: local is EvictArtifact{remote: false, kind: STATEFUL, ref}, which noded
+  # routes to its stateful arm (evictStatefulSnapshot -> RemoveStatefulBundle(ref) ->
+  # os.RemoveAll(stateful/<ref>)); remote is the same ref with remote: true (deletes
+  # the S3 stateful/<vendor>/<workload>/<ref> prefix), fired only on local success.
   #
   # GROUP: local set eviction is PER-MEMBER (noded refuses a set-level local evict as
   # Unimplemented; a set is evicted locally by EvictSnapshot on each member's
-  # snapshot_ref, the R5 contract the GroupSweeper uses); remote is one
-  # EvictArtifact{remote: true, kind: GROUP_SET, workload: group_instance_id, ref:
-  # set_id} that drops the whole set prefix at once.
+  # snapshot_ref, which noded routes to its group-member arm ->
+  # RemoveGroupMemberBundle(set_id, member_name), the R5 contract the GroupSweeper
+  # uses); the single remote EvictArtifact{remote: true, kind: GROUP_SET, workload:
+  # group_instance_id, ref: set_id} that drops the whole set prefix at once fires
+  # ONLY when EVERY member's local eviction succeeded.
   defp evict_entry(state, %{kind: :stateful, id: ref, workload: workload, node_id: node_id}) do
     dial_key = WakeInstance.dial_for_bundle(state.capacity_table, node_id, ref)
     artifact = %ArtifactRef{kind: :ARTIFACT_KIND_STATEFUL, workload: workload, ref: ref}
 
+    local = {:artifact, %EvictArtifactRequest{artifact: artifact, remote: false, trace: %Trace{workload: workload}}}
+    remote = {:artifact, %EvictArtifactRequest{artifact: artifact, remote: true, trace: %Trace{workload: workload}}}
+
     spawn(fn ->
       with {:ok, channel} <- safe_channel(state, dial_key) do
-        run_evict(state, channel, [
-          {:artifact, %EvictArtifactRequest{artifact: artifact, remote: false, trace: %Trace{workload: workload}}},
-          {:artifact, %EvictArtifactRequest{artifact: artifact, remote: true, trace: %Trace{workload: workload}}}
-        ])
-
+        # Remote (S3) evict fires ONLY if the local disk evict succeeded: never
+        # delete the recovery copy of a bundle the node refused/failed to remove.
+        run_evict(state, channel, [local], remote)
         release_channel(state, channel)
       end
     end)
@@ -328,7 +337,10 @@ defmodule Embervm.WarmthReaper do
 
     spawn(fn ->
       with {:ok, channel} <- safe_channel(state, dial_key) do
-        run_evict(state, channel, per_member ++ [remote])
+        # The single remote GROUP_SET evict (drops the whole S3 set prefix at once)
+        # fires ONLY if EVERY member's local evict succeeded: one refused/failed
+        # member (e.g. a live relit member) leaves the set's recovery copy intact.
+        run_evict(state, channel, per_member, remote)
         release_channel(state, channel)
       end
     end)
@@ -336,25 +348,63 @@ defmodule Embervm.WarmthReaper do
     :ok
   end
 
-  # Fire a batch of evictions on an already-dialled channel, best-effort: a single
-  # failure is logged and never aborts the rest (each artifact/copy is independent
-  # and idempotent). Kept out of the spawn body so both evict_entry clauses share it.
-  defp run_evict(state, channel, requests) do
-    Enum.each(requests, fn
-      {:artifact, req} -> safe_call(fn -> state.evict_artifact_fun.(channel, req) end, req)
-      {:snapshot, req} -> safe_call(fn -> state.evict_snapshot_fun.(channel, req) end, req)
-    end)
+  # Fire an entry's LOCAL evictions then, ONLY if every local succeeded, the single
+  # REMOTE (S3) evict, on an already-dialled channel (#38). Locals are best-effort
+  # among themselves (each is independent and idempotent, so one failure is logged
+  # and does not abort the rest), but a local failure of ANY kind (a warning return
+  # OR a raised/thrown call, including a FAILED_PRECONDITION from noded's in-use
+  # guard) withholds the remote: the reaper must never delete the off-node recovery
+  # copy of a bundle the node itself refused/failed to remove locally. A local
+  # success is a genuine (idempotent) removal, so the remote copy is then safe to
+  # drop. Kept out of the spawn body so both evict_entry clauses share it.
+  defp run_evict(state, channel, locals, remote) do
+    all_local_ok =
+      Enum.reduce(locals, true, fn req, acc ->
+        # Reduce, not all?/2 with side effects: run EVERY local (they are
+        # independent) while tracking whether all succeeded, so a group set still
+        # attempts each member's local evict even when an earlier one failed.
+        case run_one(state, channel, req) do
+          :ok -> acc
+          :error -> false
+        end
+      end)
+
+    if all_local_ok do
+      run_one(state, channel, remote)
+    else
+      Logger.info(
+        "embervm warmth reaper: skipping remote evict #{inspect(remote_req(remote))} (a local eviction was refused or failed; recovery copy kept)"
+      )
+    end
+
+    :ok
   end
 
+  defp run_one(state, channel, {:artifact, req}), do: safe_call(fn -> state.evict_artifact_fun.(channel, req) end, req)
+  defp run_one(state, channel, {:snapshot, req}), do: safe_call(fn -> state.evict_snapshot_fun.(channel, req) end, req)
+
+  defp remote_req({_tag, req}), do: req
+
+  # Returns :ok on a genuine (idempotent) eviction, :error on any refusal, error
+  # return, raise, or throw. The caller uses :error to withhold the paired remote
+  # evict; every path still logs so a best-effort sweep stays observable.
   defp safe_call(fun, req) do
     case fun.() do
-      {:ok, _} -> :ok
-      other -> Logger.warning("embervm warmth reaper: eviction #{inspect(req)} failed: #{inspect(other)}")
+      {:ok, _} ->
+        :ok
+
+      other ->
+        Logger.warning("embervm warmth reaper: eviction #{inspect(req)} failed: #{inspect(other)}")
+        :error
     end
   rescue
-    e -> Logger.warning("embervm warmth reaper: eviction #{inspect(req)} raised: #{inspect(e)}")
+    e ->
+      Logger.warning("embervm warmth reaper: eviction #{inspect(req)} raised: #{inspect(e)}")
+      :error
   catch
-    kind, reason -> Logger.warning("embervm warmth reaper: eviction #{inspect(req)} threw: #{inspect({kind, reason})}")
+    kind, reason ->
+      Logger.warning("embervm warmth reaper: eviction #{inspect(req)} threw: #{inspect({kind, reason})}")
+      :error
   end
 
   defp schedule_sweep(%{sweep_interval_ms: ms}) when ms > 0 do

--- a/projects/embervm/control/test/embervm/warmth_reaper_test.exs
+++ b/projects/embervm/control/test/embervm/warmth_reaper_test.exs
@@ -299,4 +299,125 @@ defmodule Embervm.WarmthReaperTest do
       assert WarmthReaper.sweep_now(reaper) == []
     end
   end
+
+  # #38: the remote (S3) evict is the recovery copy; it must fire ONLY when the
+  # paired local disk evict succeeded, so the reaper never destroys the off-node
+  # copy of a bundle the node itself refused/failed to remove locally.
+  describe "remote evict is gated on local success (#38)" do
+    test "stateful: local failure withholds the remote S3 evict" do
+      test_pid = self()
+      table = new_cap_table()
+      # A local (remote: false) evict that FAILS; the remote would succeed if reached.
+      # Records every call so the test can assert the remote never ran.
+      artifact_fun = fn _channel, req ->
+        send(test_pid, {:evict_artifact, req.artifact.kind, req.artifact.ref, req.remote})
+
+        if req.remote do
+          {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
+        else
+          {:error, :failed_precondition}
+        end
+      end
+
+      {_unused, snapshot_fun} = recording_evict_funs(test_pid)
+
+      put_warmth_fact(table, "node-4", [stateful_bundle("orphan-dead", "pg", 4_096)], [])
+      stateful = start_store([stateful_instance(:destroyed, "orphan-dead")])
+      group = start_store([])
+
+      reaper =
+        start_reaper(
+          capacity_table: table,
+          stateful_store: stateful,
+          group_store: group,
+          evict_artifact_fun: artifact_fun,
+          evict_snapshot_fun: snapshot_fun,
+          channel_fun: fake_channel_fun(),
+          sweep_enabled: true
+        )
+
+      WarmthReaper.sweep_now(reaper)
+
+      # The local evict was attempted...
+      assert_receive {:evict_artifact, :ARTIFACT_KIND_STATEFUL, "orphan-dead", false}, 1_000
+      # ...but because it failed, the remote (recovery copy) evict NEVER fired.
+      refute_receive {:evict_artifact, :ARTIFACT_KIND_STATEFUL, "orphan-dead", true}, 300
+    end
+
+    test "stateful: local success permits the remote S3 evict" do
+      test_pid = self()
+      table = new_cap_table()
+      {artifact_fun, snapshot_fun} = recording_evict_funs(test_pid)
+
+      put_warmth_fact(table, "node-4", [stateful_bundle("orphan-dead", "pg", 4_096)], [])
+      stateful = start_store([stateful_instance(:destroyed, "orphan-dead")])
+      group = start_store([])
+
+      reaper =
+        start_reaper(
+          capacity_table: table,
+          stateful_store: stateful,
+          group_store: group,
+          evict_artifact_fun: artifact_fun,
+          evict_snapshot_fun: snapshot_fun,
+          channel_fun: fake_channel_fun(),
+          sweep_enabled: true
+        )
+
+      WarmthReaper.sweep_now(reaper)
+
+      # Local ok THEN remote: the recovery copy is dropped only after the disk copy.
+      assert_receive {:evict_artifact, :ARTIFACT_KIND_STATEFUL, "orphan-dead", false}, 1_000
+      assert_receive {:evict_artifact, :ARTIFACT_KIND_STATEFUL, "orphan-dead", true}, 1_000
+    end
+
+    test "group: one member's local failure withholds the whole-set remote evict" do
+      test_pid = self()
+      table = new_cap_table()
+
+      # Record every artifact call so we can assert the GROUP_SET remote never ran.
+      artifact_fun = fn _channel, req ->
+        send(test_pid, {:evict_artifact, req.artifact.kind, req.artifact.ref, req.remote})
+        {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
+      end
+
+      # Member "a" evicts fine; member "b"'s local evict fails (e.g. a live relit
+      # member): FAILED_PRECONDITION from noded's in-use guard.
+      snapshot_fun = fn _channel, req ->
+        send(test_pid, {:evict_snapshot, req.snapshot_ref})
+
+        if req.snapshot_ref == "m-orph-b" do
+          {:error, :failed_precondition}
+        else
+          {:ok, %Embervm.Node.V1.EvictSnapshotResponse{}}
+        end
+      end
+
+      put_warmth_fact(table, "node-4", [], [
+        group_set("orphan-set", "grp-orphan-set", [member("a", "m-orph-a", 1_000), member("b", "m-orph-b", 2_000)])
+      ])
+
+      stateful = start_store([])
+      group = start_store([group_instance(:destroyed, "orphan-set")])
+
+      reaper =
+        start_reaper(
+          capacity_table: table,
+          stateful_store: stateful,
+          group_store: group,
+          evict_artifact_fun: artifact_fun,
+          evict_snapshot_fun: snapshot_fun,
+          channel_fun: fake_channel_fun(),
+          sweep_enabled: true
+        )
+
+      WarmthReaper.sweep_now(reaper)
+
+      # BOTH members are still attempted locally (independent, run-every semantics)...
+      assert_receive {:evict_snapshot, "m-orph-a"}, 1_000
+      assert_receive {:evict_snapshot, "m-orph-b"}, 1_000
+      # ...but because one member's local evict failed, the whole-set remote copy is kept.
+      refute_receive {:evict_artifact, :ARTIFACT_KIND_GROUP_SET, "orphan-set", true}, 300
+    end
+  end
 end

--- a/projects/embervm/control/test/embervm/warmth_reaper_test.exs
+++ b/projects/embervm/control/test/embervm/warmth_reaper_test.exs
@@ -420,4 +420,72 @@ defmodule Embervm.WarmthReaperTest do
       refute_receive {:evict_artifact, :ARTIFACT_KIND_GROUP_SET, "orphan-set", true}, 300
     end
   end
+
+  # #38 fix C: an orphan boot-scanned before the binding sidecar shipped has an
+  # empty workload/group_instance_id. Its local evict would drain the disk copy
+  # while its remote evict fails InvalidArgument, stranding the S3 copy forever. So
+  # such an entry is SKIPPED entirely: NEITHER local nor remote runs.
+  describe "empty-binding orphans are skipped entirely (#38 fix C)" do
+    test "a stateful orphan with no workload binding runs no local and no remote evict" do
+      test_pid = self()
+      table = new_cap_table()
+      {artifact_fun, snapshot_fun} = recording_evict_funs(test_pid)
+
+      # The disk-reported bundle has workload "" (pre-sidecar boot scan). Its
+      # instance is destroyed, so it classifies as an orphan.
+      put_warmth_fact(table, "node-4", [stateful_bundle("orphan-nobind", "", 4_096)], [])
+      stateful = start_store([stateful_instance(:destroyed, "orphan-nobind")])
+      group = start_store([])
+
+      reaper =
+        start_reaper(
+          capacity_table: table,
+          stateful_store: stateful,
+          group_store: group,
+          evict_artifact_fun: artifact_fun,
+          evict_snapshot_fun: snapshot_fun,
+          channel_fun: fake_channel_fun(),
+          sweep_enabled: true
+        )
+
+      plan = WarmthReaper.sweep_now(reaper)
+      # It is still PLANNED as an orphan (visibility) ...
+      assert Enum.any?(plan, &(&1.id == "orphan-nobind"))
+      # ... but NOTHING is evicted, local or remote.
+      refute_receive {:evict_artifact, :ARTIFACT_KIND_STATEFUL, "orphan-nobind", _}, 300
+    end
+
+    test "a group orphan with no group_instance_id binding runs no member local and no remote evict" do
+      test_pid = self()
+      table = new_cap_table()
+      {artifact_fun, snapshot_fun} = recording_evict_funs(test_pid)
+
+      # set with group_instance_id "" (pre-sidecar). group_set/3 takes the gid as
+      # arg 2; pass "".
+      put_warmth_fact(table, "node-4", [], [
+        group_set("orphan-nobind-set", "", [member("a", "m-nb-a", 1_000), member("b", "m-nb-b", 2_000)])
+      ])
+
+      stateful = start_store([])
+      group = start_store([group_instance(:destroyed, "orphan-nobind-set")])
+
+      reaper =
+        start_reaper(
+          capacity_table: table,
+          stateful_store: stateful,
+          group_store: group,
+          evict_artifact_fun: artifact_fun,
+          evict_snapshot_fun: snapshot_fun,
+          channel_fun: fake_channel_fun(),
+          sweep_enabled: true
+        )
+
+      plan = WarmthReaper.sweep_now(reaper)
+      assert Enum.any?(plan, &(&1.id == "orphan-nobind-set"))
+      # No per-member local evict, no whole-set remote evict.
+      refute_receive {:evict_snapshot, "m-nb-a"}, 300
+      refute_receive {:evict_snapshot, "m-nb-b"}, 200
+      refute_receive {:evict_artifact, :ARTIFACT_KIND_GROUP_SET, "orphan-nobind-set", true}, 200
+    end
+  end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.192
+      targetRevision: 0.1.194
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/BUILD
+++ b/projects/embervm/noded/server/BUILD
@@ -38,6 +38,7 @@ go_test(
     srcs = [
         "budget_test.go",
         "drain_test.go",
+        "evict_local_test.go",
         "group_member_test.go",
         "group_test.go",
         "register_test.go",

--- a/projects/embervm/noded/server/evict_local_test.go
+++ b/projects/embervm/noded/server/evict_local_test.go
@@ -74,7 +74,10 @@ func newEvictTestServer(t *testing.T) (nodev1.NodeServiceClient, *Server, string
 	// has a session driver wired.
 	drv := &fakeDriver{sessionsDir: filepath.Join(root, "sessions"), sessionBundles: map[string]string{}}
 	s := New(Options{
-		Config:         config.Config{Arch: "amd64", Node: "node-4", SnapshotRoot: root, VolumeRoot: volRoot},
+		// CpuVendor is REQUIRED: artifactPrefix refuses a vendor-bound kind (STATEFUL)
+		// with an empty vendor, so a STATEFUL EvictArtifact would fail InvalidArgument
+		// before reaching the local arm. A real node always has its vendor configured.
+		Config:         config.Config{Arch: "amd64", Node: "node-4", CpuVendor: "amd", SnapshotRoot: root, VolumeRoot: volRoot},
 		Driver:         drv,
 		SessionDriver:  drv,
 		StatefulDriver: newDiskScanStatefulDriver(root),
@@ -254,6 +257,36 @@ func TestEvictGroupMemberInUseRefused(t *testing.T) {
 	}
 	if !groupMemberDirExists(root, set, "entry") {
 		t.Fatalf("group/%s/entry must SURVIVE a refused in-use evict", set)
+	}
+}
+
+// TestEvictGroupMemberInUseRefusedRefFirstNoGid proves a live member relit from a
+// ref is protected (FAILED_PRECONDITION, bundle survives) via the ref-first match
+// EVEN when its banked-bundle entry lost its group_instance_id to a pre-sidecar
+// boot scan (gid=""). This closes the F3 window: without the ref-first match, the
+// (gid, member) fallback would find no gid to match and the live member's bundle
+// would be wrongly evictable.
+func TestEvictGroupMemberInUseRefusedRefFirstNoGid(t *testing.T) {
+	client, s, root := newEvictTestServer(t)
+	ctx := context.Background()
+
+	set := "k3s-cluster__set3"
+	ref := "group/" + set + "/entry"
+	writeBundleFiles(t, filepath.Join(root, "group", set, "entry"), map[string]string{"snapfile": "snap", "memfile": "mem"})
+	// Bundle entry seeded WITHOUT a group_instance_id, as a pre-sidecar boot scan
+	// would (ReconcileGroupBundlesFromDisk reads back "" for a member with no
+	// sidecar).
+	s.groupBundles.add(groupBundleEntry{setID: set, memberName: "entry", groupInstanceID: "", snapshotRef: ref, sizeBytes: 5120})
+	// A live member relit from this ref carries the snapshotRef (set by the relight
+	// plumbing) but its groupInstanceID need not match the empty bundle entry.
+	s.groupMembers.add(&groupMemberEntry{vmID: "live-relit-1", groupInstanceID: "grp-k3s-3", memberName: "entry", snapshotRef: ref, ip: net.ParseIP("10.0.0.9")})
+
+	_, err := client.EvictSnapshot(ctx, &nodev1.EvictSnapshotRequest{SnapshotRef: ref})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("ref-first in-use guard: want FAILED_PRECONDITION, got %v", err)
+	}
+	if !groupMemberDirExists(root, set, "entry") {
+		t.Fatalf("group/%s/entry must SURVIVE: a live member relit from the ref holds it", set)
 	}
 }
 

--- a/projects/embervm/noded/server/evict_local_test.go
+++ b/projects/embervm/noded/server/evict_local_test.go
@@ -1,0 +1,287 @@
+package server
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+
+	"github.com/jomcgi/homelab/projects/embervm/noded/config"
+	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
+)
+
+// These tests exercise the #38 local eviction arms over a REAL in-process gRPC
+// dial (bufconn) AND a REAL on-disk SnapshotRoot: they assert the bundle dir
+// actually leaves disk, which is the ONLY assertion that catches the misroute
+// (a stateful/group-member ref falling through to RemoveSessionBundle, which
+// no-op-removes a nonexistent sessions/<ref> and returns a false success). A
+// faked-RPC test returning :ok would mask exactly this bug.
+
+// diskGroupMemberDriver is a group-member-driver stub whose RemoveGroupMemberBundle
+// does a REAL os.RemoveAll of group/<set>/<member> under the temp root (mirroring
+// the production *driver.Driver), so a group eviction test asserts the member dir
+// actually leaves disk. The other methods are unused by these eviction tests.
+type diskGroupMemberDriver struct {
+	groupRoot string // <SnapshotRoot>/group
+}
+
+func (d *diskGroupMemberDriver) GroupSetsDir() string { return d.groupRoot }
+
+func (d *diskGroupMemberDriver) RemoveGroupMemberBundle(setID, memberName string) error {
+	return os.RemoveAll(filepath.Join(d.groupRoot, setID, memberName))
+}
+
+// The remaining groupMemberDriver methods are never reached by these local
+// eviction tests (they never start or restore a member VM), so they return
+// Unimplemented / zero values to satisfy the interface.
+func (d *diskGroupMemberDriver) ClaimGroupMember(_ context.Context, _, _ string, _, _ int, _ substrate.NICSpec, _ map[string]string) (substrate.Handle, error) {
+	return substrate.Handle{}, status.Error(codes.Unimplemented, "unused")
+}
+
+func (d *diskGroupMemberDriver) SnapshotGroupMember(_ context.Context, _ substrate.Handle, _, _ string) (substrate.SnapshotRef, error) {
+	return substrate.SnapshotRef{}, status.Error(codes.Unimplemented, "unused")
+}
+
+func (d *diskGroupMemberDriver) RestoreGroupMember(_ context.Context, _, _ string) (substrate.Handle, error) {
+	return substrate.Handle{}, status.Error(codes.Unimplemented, "unused")
+}
+
+func (d *diskGroupMemberDriver) ScanGroupBundleSets() []substrate.GroupBundleSetInfo { return nil }
+
+// newEvictTestServer wires a Server behind a REAL bufconn gRPC dial with a
+// disk-scanning stateful driver AND a disk-real group-member driver sharing ONE
+// on-disk SnapshotRoot, so an eviction routed through the gRPC client mutates the
+// real temp dir the test then inspects. Returns the client, the server (for
+// direct registry seeding of live VMs), and the SnapshotRoot.
+func newEvictTestServer(t *testing.T) (nodev1.NodeServiceClient, *Server, string) {
+	t.Helper()
+	root := t.TempDir()
+	volRoot := t.TempDir()
+	// The fakeDriver serves BOTH the task vmDriver seam and the sessionDriver seam
+	// so a ref in NO typed inventory falls through to the idempotent session path
+	// (an unknown ref is a no-op success), matching a production noded which always
+	// has a session driver wired.
+	drv := &fakeDriver{sessionsDir: filepath.Join(root, "sessions"), sessionBundles: map[string]string{}}
+	s := New(Options{
+		Config:         config.Config{Arch: "amd64", Node: "node-4", SnapshotRoot: root, VolumeRoot: volRoot},
+		Driver:         drv,
+		SessionDriver:  drv,
+		StatefulDriver: newDiskScanStatefulDriver(root),
+		GroupDriver:    &diskGroupMemberDriver{groupRoot: filepath.Join(root, "group")},
+		Transport:      &fakeTransport{},
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	s.memHeadroom = func() uint64 { return 0 }
+
+	lis := bufconn.Listen(1 << 20)
+	gs := grpc.NewServer()
+	nodev1.RegisterNodeServiceServer(gs, s)
+	go func() { _ = gs.Serve(lis) }()
+	t.Cleanup(gs.Stop)
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dial bufconn: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return nodev1.NewNodeServiceClient(conn), s, root
+}
+
+func statefulDirExists(root, ref string) bool {
+	_, err := os.Stat(filepath.Join(root, "stateful", ref))
+	return err == nil
+}
+
+func groupMemberDirExists(root, setID, member string) bool {
+	_, err := os.Stat(filepath.Join(root, "group", setID, member))
+	return err == nil
+}
+
+// TestEvictArtifactLocalStatefulRemovesDisk proves a typed STATEFUL local evict
+// over bufconn actually removes stateful/<ref> from disk and drops it from
+// NodeStatus. Against the pre-#38 code this FAILS: the STATEFUL ref fell into the
+// session path, RemoveAll(sessions/<ref>) no-op'd, and stateful/<ref> survived.
+func TestEvictArtifactLocalStatefulRemovesDisk(t *testing.T) {
+	client, s, root := newEvictTestServer(t)
+	ctx := context.Background()
+
+	ref := "scratch-postgres__g5"
+	writeBundleFiles(t, filepath.Join(root, "stateful", ref), map[string]string{"snapfile": "snap", "memfile": "mem", "gen": "5"})
+	s.statefulBundles.add(statefulBundleEntry{snapshotRef: ref, workload: "scratch-postgres", generation: 5})
+
+	if !statefulDirExists(root, ref) {
+		t.Fatalf("precondition: stateful/%s should exist before evict", ref)
+	}
+	if _, err := client.EvictArtifact(ctx, &nodev1.EvictArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL, Workload: "scratch-postgres", Ref: ref},
+		Remote:   false,
+	}); err != nil {
+		t.Fatalf("EvictArtifact(stateful, local): %v", err)
+	}
+	if statefulDirExists(root, ref) {
+		t.Fatalf("stateful/%s should be GONE from disk after local evict (pre-#38 misroute leaves it)", ref)
+	}
+	if _, ok := s.statefulBundles.get(ref); ok {
+		t.Fatalf("stateful bundle %s should be dropped from NodeStatus inventory after evict", ref)
+	}
+}
+
+// TestEvictSnapshotStatefulRemovesDisk proves the same removal via the raw
+// EvictSnapshot verb (the path the reaper's per-bundle stateful evict and the
+// GroupSweeper drive), dispatching on the banked-bundle inventory.
+func TestEvictSnapshotStatefulRemovesDisk(t *testing.T) {
+	client, s, root := newEvictTestServer(t)
+	ctx := context.Background()
+
+	ref := "demo-postgres__g2"
+	writeBundleFiles(t, filepath.Join(root, "stateful", ref), map[string]string{"snapfile": "snap", "memfile": "mem"})
+	s.statefulBundles.add(statefulBundleEntry{snapshotRef: ref, workload: "demo-postgres", generation: 2})
+
+	if _, err := client.EvictSnapshot(ctx, &nodev1.EvictSnapshotRequest{SnapshotRef: ref}); err != nil {
+		t.Fatalf("EvictSnapshot(stateful ref): %v", err)
+	}
+	if statefulDirExists(root, ref) {
+		t.Fatalf("stateful/%s should be GONE from disk after EvictSnapshot", ref)
+	}
+}
+
+// TestEvictStatefulInUseRefused proves a STATEFUL evict is refused
+// FAILED_PRECONDITION while a live stateful VM was relit from the ref, and the
+// dir SURVIVES (the reaper's remote-guard then withholds the S3 delete too).
+func TestEvictStatefulInUseRefused(t *testing.T) {
+	client, s, root := newEvictTestServer(t)
+	ctx := context.Background()
+
+	ref := "scratch-postgres__live"
+	writeBundleFiles(t, filepath.Join(root, "stateful", ref), map[string]string{"snapfile": "snap", "memfile": "mem"})
+	s.statefulBundles.add(statefulBundleEntry{snapshotRef: ref, workload: "scratch-postgres", generation: 3})
+	// A live stateful VM relit from this ref (snapshotRef set == relight).
+	s.statefulVMs.add(&statefulEntry{vmID: "live-vm-1", workload: "scratch-postgres", snapshotRef: ref, generation: 3})
+
+	_, err := client.EvictArtifact(ctx, &nodev1.EvictArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL, Workload: "scratch-postgres", Ref: ref},
+		Remote:   false,
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("in-use stateful evict: want FAILED_PRECONDITION, got %v", err)
+	}
+	if !statefulDirExists(root, ref) {
+		t.Fatalf("stateful/%s must SURVIVE a refused in-use evict", ref)
+	}
+}
+
+// TestEvictStatefulIdempotentAlreadyGone proves a second evict of an
+// already-removed ref returns success (RemoveStatefulBundle is idempotent). The
+// second call goes through the typed STATEFUL path even with no inventory entry.
+func TestEvictStatefulIdempotentAlreadyGone(t *testing.T) {
+	client, _, root := newEvictTestServer(t)
+	ctx := context.Background()
+
+	ref := "gone__g1"
+	// No bundle on disk, no inventory entry: desired end-state already holds.
+	if _, err := client.EvictArtifact(ctx, &nodev1.EvictArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL, Workload: "w", Ref: ref},
+		Remote:   false,
+	}); err != nil {
+		t.Fatalf("idempotent stateful evict of absent ref should succeed: %v", err)
+	}
+	if statefulDirExists(root, ref) {
+		t.Fatalf("stateful/%s should not exist", ref)
+	}
+}
+
+// TestEvictSnapshotGroupMemberRemovesDisk proves per-member EvictSnapshot over
+// bufconn removes each member bundle dir (group/<set>/<member>) from disk, so
+// evicting every member of a two-member set clears the whole set. Against the
+// pre-#38 code this FAILS: a group/<set>/<member> ref fell into the session path.
+func TestEvictSnapshotGroupMemberRemovesDisk(t *testing.T) {
+	client, s, root := newEvictTestServer(t)
+	ctx := context.Background()
+
+	set := "k3s-cluster__set1"
+	seedGroupMember(t, s, root, set, "a", "grp-k3s-1")
+	seedGroupMember(t, s, root, set, "b", "grp-k3s-1")
+
+	for _, m := range []string{"a", "b"} {
+		ref := "group/" + set + "/" + m
+		if _, err := client.EvictSnapshot(ctx, &nodev1.EvictSnapshotRequest{SnapshotRef: ref}); err != nil {
+			t.Fatalf("EvictSnapshot(%s): %v", ref, err)
+		}
+		if groupMemberDirExists(root, set, m) {
+			t.Fatalf("group/%s/%s should be GONE from disk after EvictSnapshot (pre-#38 misroute leaves it)", set, m)
+		}
+	}
+	// The whole set dir is empty of members now.
+	if groupMemberDirExists(root, set, "a") || groupMemberDirExists(root, set, "b") {
+		t.Fatalf("both members of set %s should be gone", set)
+	}
+}
+
+// TestEvictGroupMemberInUseRefused proves a per-member evict is refused
+// FAILED_PRECONDITION while a live member relit from that (set, member) is
+// attached, and the member bundle SURVIVES.
+func TestEvictGroupMemberInUseRefused(t *testing.T) {
+	client, s, root := newEvictTestServer(t)
+	ctx := context.Background()
+
+	set := "k3s-cluster__set2"
+	inst := "grp-k3s-2"
+	seedGroupMember(t, s, root, set, "entry", inst)
+	// A live member VM matching (group_instance_id, member_name): a relit member.
+	s.groupMembers.add(&groupMemberEntry{vmID: "live-member-1", groupInstanceID: inst, memberName: "entry", ip: net.ParseIP("10.0.0.5")})
+
+	ref := "group/" + set + "/entry"
+	_, err := client.EvictSnapshot(ctx, &nodev1.EvictSnapshotRequest{SnapshotRef: ref})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("in-use group member evict: want FAILED_PRECONDITION, got %v", err)
+	}
+	if !groupMemberDirExists(root, set, "entry") {
+		t.Fatalf("group/%s/entry must SURVIVE a refused in-use evict", set)
+	}
+}
+
+// TestEvictSnapshotGroupMemberIdempotentUnknownRef proves an EvictSnapshot for a
+// group-shaped ref that is NOT in the banked inventory returns success without
+// touching disk (nothing to remove, no live member could hold it).
+func TestEvictSnapshotGroupMemberIdempotentUnknownRef(t *testing.T) {
+	client, _, _ := newEvictTestServer(t)
+	ctx := context.Background()
+
+	// This ref is group-shaped but never banked, so it is not in groupBundles; it
+	// falls through to the idempotent session path (no such dir) and succeeds.
+	if _, err := client.EvictSnapshot(ctx, &nodev1.EvictSnapshotRequest{SnapshotRef: "group/unknown-set/x"}); err != nil {
+		t.Fatalf("EvictSnapshot of an unbanked group ref should be idempotent success: %v", err)
+	}
+}
+
+// seedGroupMember writes a real member bundle dir under group/<set>/<member> and
+// registers it in the banked-bundle inventory keyed by its snapshot_ref, with the
+// group_instance_id the in-use guard matches live members against.
+func seedGroupMember(t *testing.T, s *Server, root, setID, member, groupInstanceID string) {
+	t.Helper()
+	writeBundleFiles(t, filepath.Join(root, "group", setID, member), map[string]string{"snapfile": "snap", "memfile": "mem"})
+	s.groupBundles.add(groupBundleEntry{
+		setID:           setID,
+		memberName:      member,
+		groupInstanceID: groupInstanceID,
+		snapshotRef:     "group/" + setID + "/" + member,
+		sizeBytes:       5120,
+	})
+}

--- a/projects/embervm/noded/server/group.go
+++ b/projects/embervm/noded/server/group.go
@@ -183,9 +183,11 @@ func (s *Server) groupNetworksStatus() []*nodev1.GroupNetwork {
 // kills every LIVE member (they died with the pod, the standing single-node
 // availability posture); only the on-disk bundle sets survive, and the control plane
 // resolves each group to relightable (a complete set) or fresh-bootable from these
-// reports (the daemon makes NO completeness judgment). A member bundle carries no
-// group_instance_id on disk (the set dir names only the set_id + member), so the
-// group binding is left empty for the control plane to rebind by adoption.
+// reports (the daemon makes NO completeness judgment). The set dir names only the
+// set_id + member, but a member banked after #38 carries a group_instance_id
+// sidecar beside its bundle, which this rescan reads back so the boot-scanned
+// entry is remotely evictable; a pre-sidecar member reads back "" and the control
+// plane rebinds it by adoption (and the reaper SKIPS an empty-binding set).
 func (s *Server) ReconcileGroupBundlesFromDisk() {
 	if s.groupDriver == nil {
 		return
@@ -203,8 +205,12 @@ func (s *Server) ReconcileGroupBundlesFromDisk() {
 	for _, set := range sets {
 		for _, m := range set.Members {
 			s.groupBundles.add(groupBundleEntry{
-				setID:           set.SetID,
-				memberName:      m.MemberName,
+				setID:      set.SetID,
+				memberName: m.MemberName,
+				// Recover the group_instance_id from the on-disk sidecar (#38 F2), so
+				// this boot-scanned member is remotely evictable across a restart.
+				// "" for a pre-sidecar member: the reaper SKIPS such a set.
+				groupInstanceID: s.readGroupInstanceSidecar(set.SetID, m.MemberName),
 				snapshotRef:     m.SnapshotRef,
 				sizeBytes:       m.SizeBytes,
 				createdAtUnixMs: set.CreatedAtUnixMs,

--- a/projects/embervm/noded/server/group_member.go
+++ b/projects/embervm/noded/server/group_member.go
@@ -126,7 +126,7 @@ func (s *Server) startGroupMemberFresh(ctx context.Context, req *nodev1.StartGro
 		s.groupNet.RemoveMemberTap(ctx, groupInstanceID, tap, ip)
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: cold-boot group member: %v", err)
 	}
-	return s.finishGroupMemberStart(ctx, h, groupInstanceID, memberName, req.GetMemberIndex(), tap, ip, healthPort, req.GetEntryGuestPort(), false, groupMemberReadyBudget(req, s.cfg.BootReadyTimeout))
+	return s.finishGroupMemberStart(ctx, h, groupInstanceID, memberName, req.GetMemberIndex(), tap, ip, healthPort, req.GetEntryGuestPort(), false, "", groupMemberReadyBudget(req, s.cfg.BootReadyTimeout))
 }
 
 // groupMemberReadyBudget resolves the readiness budget for one member start: the
@@ -187,14 +187,14 @@ func (s *Server) startGroupMemberRelight(ctx context.Context, req *nodev1.StartG
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: group member %q clock resync failed: %v", ref, clockErr)
 	}
 
-	return s.finishGroupMemberStart(ctx, h, groupInstanceID, memberName, req.GetMemberIndex(), tap, ip, healthPort, req.GetEntryGuestPort(), true, groupMemberReadyBudget(req, s.cfg.RestoreReadyTimeout))
+	return s.finishGroupMemberStart(ctx, h, groupInstanceID, memberName, req.GetMemberIndex(), tap, ip, healthPort, req.GetEntryGuestPort(), true, ref, groupMemberReadyBudget(req, s.cfg.RestoreReadyTimeout))
 }
 
 // finishGroupMemberStart is the shared tail of both member start paths: TCP-health-
 // gate {ip, health_port}, register the live member, and start its probe. On a
 // readiness failure it reaps the VM and removes the tap, returning
 // FAILED_PRECONDITION (no half-alive member is ever published).
-func (s *Server) finishGroupMemberStart(ctx context.Context, h substrate.Handle, groupInstanceID, memberName string, memberIndex uint32, tap string, ip net.IP, healthPort, entryGuestPort uint32, wasRelight bool, readyBudget time.Duration) (*nodev1.StartGroupMemberResponse, error) {
+func (s *Server) finishGroupMemberStart(ctx context.Context, h substrate.Handle, groupInstanceID, memberName string, memberIndex uint32, tap string, ip net.IP, healthPort, entryGuestPort uint32, wasRelight bool, snapshotRef string, readyBudget time.Duration) (*nodev1.StartGroupMemberResponse, error) {
 	if err := s.waitStatefulReady(ctx, ip, healthPort, readyBudget); err != nil {
 		// Loud on purpose: this reap is the daemon KILLING a member that missed its
 		// readiness budget. Silent, it reads as a mystery VM disappearance (the R6
@@ -227,6 +227,7 @@ func (s *Server) finishGroupMemberStart(ctx context.Context, h substrate.Handle,
 		tap:             tap,
 		port:            healthPort,
 		handle:          h,
+		snapshotRef:     snapshotRef,
 		probe:           probe,
 	})
 	s.signalChange()
@@ -318,6 +319,10 @@ func (s *Server) stopGroupMemberBank(ctx context.Context, req *nodev1.StopGroupM
 		sizeBytes:       ref.SizeBytes,
 		createdAtUnixMs: time.Now().UnixMilli(),
 	})
+	// Persist the group_instance_id binding beside the member bundle so a boot-scan
+	// reconciliation (which reads only set_id + member_name off the dir) can recover
+	// it and compose the remote (S3) GROUP_SET prefix at eviction time (#38 F2).
+	s.writeGroupInstanceSidecar(setID, memberName, e.groupInstanceID)
 	// Async off-node write-back (R6): a group set is the export unit, so enqueue
 	// the SET (keyed by group instance + set_id) fire-and-forget after each member
 	// bank. The dedupe coalesces overlapping member banks of the same set; the

--- a/projects/embervm/noded/server/group_member_test.go
+++ b/projects/embervm/noded/server/group_member_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
@@ -725,5 +727,49 @@ func TestReconcileGroupBundlesFromDisk(t *testing.T) {
 	}
 	if bySet["set-1"] != 2 || bySet["set-2"] != 1 {
 		t.Errorf("bundle set membership wrong: %v", bySet)
+	}
+}
+
+// TestReconcileGroupReadsInstanceSidecar proves a boot-scan reconciliation
+// recovers the group_instance_id from the on-disk sidecar (#38 F2), so a member
+// banked (with its sidecar) before a restart re-seeds with its REAL group binding
+// and is remotely evictable, while a pre-sidecar member seeds with "".
+func TestReconcileGroupReadsInstanceSidecar(t *testing.T) {
+	dir := t.TempDir()
+	gmd := newFakeGroupMemberDriver(dir)
+	gmd.banked["set-1/worker-0"] = true // has a sidecar (below)
+	gmd.banked["set-1/worker-1"] = true // pre-sidecar (no sidecar file)
+
+	// Write the group_instance_id sidecar beside worker-0's bundle on real disk,
+	// where readGroupInstanceSidecar looks (GroupSetsDir/set/member/...).
+	sidecarDir := filepath.Join(gmd.GroupSetsDir(), "set-1", "worker-0")
+	if err := os.MkdirAll(sidecarDir, 0o700); err != nil {
+		t.Fatalf("mkdir sidecar dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sidecarDir, groupInstanceSidecar), []byte("grp-alpha"), 0o600); err != nil {
+		t.Fatalf("write gid sidecar: %v", err)
+	}
+
+	s := New(Options{
+		Config:       config.Config{Arch: "amd64", Node: "node-4", SnapshotRoot: dir},
+		Driver:       groupMemberVMDriverAdapter{gmd},
+		Transport:    &fakeTransport{},
+		GroupNet:     newFakeGroupNet(),
+		GroupRecords: newFakeGroupRecords(t.TempDir()),
+		GroupDriver:  gmd,
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	s.memHeadroom = func() uint64 { return 0 }
+	s.ReconcileGroupBundlesFromDisk()
+
+	byRef := map[string]string{} // snapshotRef -> groupInstanceID
+	for _, e := range s.groupBundles.snapshot() {
+		byRef[e.snapshotRef] = e.groupInstanceID
+	}
+	if got := byRef["group/set-1/worker-0"]; got != "grp-alpha" {
+		t.Fatalf("worker-0 groupInstanceID = %q, want grp-alpha (from sidecar)", got)
+	}
+	if got := byRef["group/set-1/worker-1"]; got != "" {
+		t.Fatalf("worker-1 (pre-sidecar) groupInstanceID = %q, want \"\"", got)
 	}
 }

--- a/projects/embervm/noded/server/group_registry.go
+++ b/projects/embervm/noded/server/group_registry.go
@@ -227,6 +227,24 @@ func (r *groupMemberRegistry) hasMembers(groupInstanceID string) bool {
 	return r.memberCount(groupInstanceID) > 0
 }
 
+// memberInUse reports whether a LIVE member VM matching (groupInstanceID,
+// memberName) is currently attached, i.e. a member relit from this bundle is
+// still running. It is the in-use guard for a per-member local group eviction
+// (#38): removing a member bundle out from under a live relit member would lose
+// the state needed to re-bank it. A live member carries no snapshotRef of its
+// own, so the caller recovers (groupInstanceID, memberName) from the banked
+// bundle inventory and matches on that pair. Returns the live member's vm_id.
+func (r *groupMemberRegistry) memberInUse(groupInstanceID, memberName string) (string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for id, e := range r.members {
+		if e.groupInstanceID == groupInstanceID && e.memberName == memberName {
+			return id, true
+		}
+	}
+	return "", false
+}
+
 // groupMemberView is a lock-free, read-only projection of a groupMemberEntry, for
 // NodeStatus.group_member_vms (Task 5 populates the health verdict).
 type groupMemberView struct {
@@ -302,6 +320,20 @@ func (r *groupBundleRegistry) add(e groupBundleEntry) {
 	defer r.mu.Unlock()
 	cp := e
 	r.snaps[e.snapshotRef] = &cp
+}
+
+// get returns a copy of the banked group bundle entry for a member snapshot_ref
+// (group/<set_id>/<member_name>), recovering the (set_id, member_name,
+// group_instance_id) a per-member local eviction needs. Absent -> (_, false),
+// which the caller treats as an idempotent already-gone success.
+func (r *groupBundleRegistry) get(ref string) (groupBundleEntry, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e, ok := r.snaps[ref]
+	if !ok {
+		return groupBundleEntry{}, false
+	}
+	return *e, true
 }
 
 // remove deletes a snapshot_ref from the inventory (idempotent).

--- a/projects/embervm/noded/server/group_registry.go
+++ b/projects/embervm/noded/server/group_registry.go
@@ -139,6 +139,13 @@ type groupMemberEntry struct {
 	handle substrate.Handle
 	// isEntry marks the group's entry member (the one exposed via the entry DNAT).
 	isEntry bool
+	// snapshotRef is the group member bundle this VM was RELIT from
+	// (group/<set_id>/<member_name>), or "" for a fresh/cold boot (which has no
+	// source snapshot). Mirrors statefulEntry.snapshotRef; it is the primary key
+	// the per-member eviction in-use guard (memberInUse) matches on, so a live
+	// relit member protects its bundle even when the banked-bundle entry lost its
+	// group_instance_id to a pre-sidecar boot scan (#38 F3).
+	snapshotRef string
 	// probe is the running TCP-connect health-probe loop for this member.
 	probe *serving.ProbeHandle
 
@@ -227,18 +234,26 @@ func (r *groupMemberRegistry) hasMembers(groupInstanceID string) bool {
 	return r.memberCount(groupInstanceID) > 0
 }
 
-// memberInUse reports whether a LIVE member VM matching (groupInstanceID,
-// memberName) is currently attached, i.e. a member relit from this bundle is
-// still running. It is the in-use guard for a per-member local group eviction
-// (#38): removing a member bundle out from under a live relit member would lose
-// the state needed to re-bank it. A live member carries no snapshotRef of its
-// own, so the caller recovers (groupInstanceID, memberName) from the banked
-// bundle inventory and matches on that pair. Returns the live member's vm_id.
-func (r *groupMemberRegistry) memberInUse(groupInstanceID, memberName string) (string, bool) {
+// memberInUse reports whether a LIVE member VM is currently attached that was
+// relit from the given bundle, i.e. removing the bundle would lose the state a
+// running member needs to re-bank. It is the in-use guard for a per-member local
+// group eviction (#38). It matches REF-FIRST on the live member's snapshotRef
+// (set at relight, mirroring the stateful guard), which is authoritative and
+// survives a boot scan that lost the bundle's group_instance_id (F3); it falls
+// back to matching (groupInstanceID, memberName) so a member relit before this
+// snapshotRef plumbing shipped, or whose bundle entry still carries a gid, is
+// still protected. An empty snapshotRef (fresh/cold member) never ref-matches.
+// Returns the live member's vm_id.
+func (r *groupMemberRegistry) memberInUse(ref, groupInstanceID, memberName string) (string, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for id, e := range r.members {
-		if e.groupInstanceID == groupInstanceID && e.memberName == memberName {
+		if ref != "" && e.snapshotRef == ref {
+			return id, true
+		}
+	}
+	for id, e := range r.members {
+		if groupInstanceID != "" && e.groupInstanceID == groupInstanceID && e.memberName == memberName {
 			return id, true
 		}
 	}

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1498,7 +1498,9 @@ func (s *Server) evictGroupMemberSnapshot(ref string) (*nodev1.EvictSnapshotResp
 		return &nodev1.EvictSnapshotResponse{}, nil
 	}
 	// In-use guard: refuse while a live member relit from this bundle is attached.
-	if vmID, inUse := s.groupMembers.memberInUse(entry.groupInstanceID, entry.memberName); inUse {
+	// Matched ref-first (authoritative, survives a gid-less boot scan), falling
+	// back to (group_instance_id, member_name) from the bundle entry.
+	if vmID, inUse := s.groupMembers.memberInUse(ref, entry.groupInstanceID, entry.memberName); inUse {
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: group member snapshot %q is in use by live vm %q", ref, vmID)
 	}
 	if err := s.groupDriver.RemoveGroupMemberBundle(entry.setID, entry.memberName); err != nil {
@@ -2536,9 +2538,12 @@ func (s *Server) ReconcileStatefulFromDisk() {
 	for _, b := range bundles {
 		s.statefulBundles.add(statefulBundleEntry{
 			snapshotRef: b.SnapshotRef,
-			// workload is unknown from disk alone (the bundle dir name is the
-			// opaque snapshot_ref); the control plane rebinds by adoption, same
-			// as a disk-only serving/session rescan entry.
+			// Recover the workload from the on-disk sidecar written at bank time
+			// (#38 F1), so a boot-scanned bundle is remotely evictable across a
+			// restart. A pre-sidecar bundle reads back "" and the reaper SKIPS it
+			// (fix C) rather than draining its local copy while its S3 copy strands.
+			// The control plane still rebinds by adoption for live-instance purposes.
+			workload:        s.readStatefulWorkloadSidecar(b.SnapshotRef),
 			generation:      b.Generation,
 			sizeBytes:       b.SizeBytes,
 			createdAtUnixMs: b.CreatedAtUnixMs,

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1382,12 +1382,26 @@ func (s *Server) EvictSnapshot(_ context.Context, req *nodev1.EvictSnapshotReque
 	if ref == "" {
 		return nil, status.Error(codes.InvalidArgument, "noded: snapshot_ref required")
 	}
-	// A serving snapshot ref is evicted exactly like a session ref, just stored under
-	// the serving/ prefix (per the PR-1 proto contract: serving reuses EvictSnapshot).
 	// Dispatch on which inventory holds the ref BEFORE the session-driver guard so a
-	// serving ref evicts even in a build wired only for serving.
+	// serving/stateful/group ref evicts even in a build wired only for that class,
+	// and so a typed ref removes its REAL on-disk bundle instead of falling through
+	// to the session path (which would RemoveAll a nonexistent sessions/<ref> and
+	// return a false success while the real bundle leaks: the exact misroute the
+	// BASE arm fixed for base refs, #38 fixes for stateful and group-member refs).
+	// Order: serving -> stateful -> group-member -> session fallback. A ref in NO
+	// inventory keeps today's idempotent session-path semantics.
 	if _, ok := s.servingSnap.get(ref); ok {
 		return s.evictServingSnapshot(ref)
+	}
+	if s.statefulBundles != nil {
+		if _, ok := s.statefulBundles.get(ref); ok {
+			return s.evictStatefulSnapshot(ref)
+		}
+	}
+	if s.groupBundles != nil {
+		if _, ok := s.groupBundles.get(ref); ok {
+			return s.evictGroupMemberSnapshot(ref)
+		}
 	}
 	if s.sessionDriver == nil {
 		return nil, status.Error(codes.Unimplemented, "noded: session eviction not configured")
@@ -1426,6 +1440,71 @@ func (s *Server) evictServingSnapshot(ref string) (*nodev1.EvictSnapshotResponse
 		return nil, status.Errorf(codes.Internal, "noded: evict serving snapshot %q: %v", ref, err)
 	}
 	s.servingSnap.remove(ref)
+	s.signalChange()
+	return &nodev1.EvictSnapshotResponse{}, nil
+}
+
+// evictStatefulSnapshot deletes a banked stateful bundle (stateful/<ref>) from
+// disk. It mirrors the serving eviction path: idempotent, and refusing
+// FAILED_PRECONDITION when a LIVE stateful VM was relit from this ref (evicting
+// the bundle out from under a live relit VM would lose the state needed to
+// re-bank it if the VM dies or the node restarts before the next bank). This is
+// the arm the warmth reaper's per-bundle stateful eviction drives (#38): before
+// it existed a STATEFUL local evict fell through to the SESSION bundle path
+// (RemoveSessionBundle), which no-op-removed a nonexistent sessions/<ref> and
+// returned success while stateful/<ref> survived, the same misroute class the
+// BASE arm fixed in base-durability PR-3. RemoveStatefulBundle is idempotent, so
+// an already-absent bundle is success.
+func (s *Server) evictStatefulSnapshot(ref string) (*nodev1.EvictSnapshotResponse, error) {
+	if s.statefulDriver == nil {
+		return nil, status.Error(codes.Unimplemented, "noded: stateful eviction not configured")
+	}
+	// In-use guard: refuse while a live stateful VM was relit from this ref.
+	if vmID, inUse := s.statefulVMs.snapshotRefInUse(ref); inUse {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: stateful snapshot %q is in use by live vm %q", ref, vmID)
+	}
+	if err := s.statefulDriver.RemoveStatefulBundle(ref); err != nil {
+		return nil, status.Errorf(codes.Internal, "noded: evict stateful snapshot %q: %v", ref, err)
+	}
+	s.statefulBundles.remove(ref)
+	s.signalChange()
+	return &nodev1.EvictSnapshotResponse{}, nil
+}
+
+// evictGroupMemberSnapshot deletes one banked group member bundle
+// (group/<set_id>/<member_name>) from disk. A group set is evicted locally
+// PER-MEMBER (the R5 contract: there is no set-level local-evict driver op), so
+// this is the arm each per-member EvictSnapshot resolves to; the GroupSweeper and
+// the warmth reaper drive it (#38). Before it existed a group-member ref fell
+// through to the SESSION path and no-op-removed a nonexistent
+// sessions/group/<set>/<member>, leaving the real member bundle on disk. It
+// recovers (set_id, member_name, group_instance_id) from the banked-bundle
+// inventory (the only place the ref -> instance mapping is recorded), refuses
+// FAILED_PRECONDITION while a live member relit from this ref is still attached
+// (matched on group_instance_id + member_name, since a live member carries no
+// snapshotRef of its own), then removes the member bundle dir. Idempotent: a ref
+// absent from the inventory has no on-disk bundle and no live member could have
+// relit from it, so it is a success (the caller reached here only because the ref
+// WAS in the inventory; the RemoveGroupMemberBundle driver op is itself
+// idempotent on an already-absent dir).
+func (s *Server) evictGroupMemberSnapshot(ref string) (*nodev1.EvictSnapshotResponse, error) {
+	if s.groupDriver == nil {
+		return nil, status.Error(codes.Unimplemented, "noded: group member eviction not configured")
+	}
+	entry, ok := s.groupBundles.get(ref)
+	if !ok {
+		// Not in the inventory: nothing on disk to remove and no live member could
+		// have relit from it. Idempotent success (desired end-state already holds).
+		return &nodev1.EvictSnapshotResponse{}, nil
+	}
+	// In-use guard: refuse while a live member relit from this bundle is attached.
+	if vmID, inUse := s.groupMembers.memberInUse(entry.groupInstanceID, entry.memberName); inUse {
+		return nil, status.Errorf(codes.FailedPrecondition, "noded: group member snapshot %q is in use by live vm %q", ref, vmID)
+	}
+	if err := s.groupDriver.RemoveGroupMemberBundle(entry.setID, entry.memberName); err != nil {
+		return nil, status.Errorf(codes.Internal, "noded: evict group member snapshot %q: %v", ref, err)
+	}
+	s.groupBundles.remove(ref)
 	s.signalChange()
 	return &nodev1.EvictSnapshotResponse{}, nil
 }

--- a/projects/embervm/noded/server/stateful.go
+++ b/projects/embervm/noded/server/stateful.go
@@ -531,6 +531,9 @@ func (s *Server) commitCheckpoint(ctx context.Context, e *statefulEntry, token s
 		sizeBytes:       ref.SizeBytes,
 		createdAtUnixMs: time.Now().UnixMilli(),
 	})
+	// Persist the workload binding beside the committed bundle (#38 F1), same as
+	// the direct-bank path.
+	s.writeStatefulWorkloadSidecar(ref.ID, e.workload)
 	// Async off-node write-back (R6): the committed bundle and its paired volume,
 	// fire-and-forget (identical to stopStatefulBank's tail).
 	s.enqueueExport(&nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL, Workload: e.workload, Ref: ref.ID})
@@ -627,6 +630,12 @@ func (s *Server) stopStatefulBank(ctx context.Context, vmID string) (*nodev1.Sto
 		sizeBytes:       ref.SizeBytes,
 		createdAtUnixMs: time.Now().UnixMilli(),
 	})
+	// Persist the workload binding beside the bundle so a boot-scan reconciliation
+	// (which knows only the opaque ref) can recover it and compose the remote (S3)
+	// prefix at eviction time (#38 F1). Written after the driver published the
+	// complete bundle, so a crash before this leaves a usable bundle that seeds
+	// empty and is safely SKIPPED by the reaper.
+	s.writeStatefulWorkloadSidecar(ref.ID, e.workload)
 	// Async off-node write-back (R6): a stateful bank ships BOTH the bundle and its
 	// paired volume (vol.img + gen); the volume export skips when its generation is
 	// unchanged since the last export. Both are fire-and-forget (never blocking).

--- a/projects/embervm/noded/server/stateful_registry.go
+++ b/projects/embervm/noded/server/stateful_registry.go
@@ -268,6 +268,29 @@ func (r *statefulRegistry) byWorkload(workload string) (*statefulEntry, bool) {
 	return nil, false
 }
 
+// snapshotRefInUse reports whether any LIVE stateful VM was relit from the given
+// stateful bundle ref, i.e. the bundle is still needed by a running guest that
+// resumed from it. It is the in-use guard for a local STATEFUL eviction (#38):
+// evicting a bundle out from under a live relit VM would lose the state needed to
+// re-bank it if the VM dies before the next bank. It scans the LIVE registry's
+// snapshotRef (set on relight, "" on a fresh/cold boot, so a fresh VM never
+// matches). The R4 v1 note on statefulEntry.snapshotRef deferred exactly this
+// guard; the reaper's per-bundle evict makes it load-bearing, so it lands now. An
+// empty ref never matches. Returns the vm_id of the first live VM holding the ref.
+func (r *statefulRegistry) snapshotRefInUse(ref string) (string, bool) {
+	if ref == "" {
+		return "", false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for id, e := range r.vms {
+		if e.snapshotRef == ref {
+			return id, true
+		}
+	}
+	return "", false
+}
+
 // statefulView is a lock-free, read-only projection of a statefulEntry, for
 // NodeStatus.stateful_vms.
 type statefulView struct {

--- a/projects/embervm/noded/server/store.go
+++ b/projects/embervm/noded/server/store.go
@@ -147,6 +147,88 @@ func artifactPrefix(ref *nodev1.ArtifactRef, vendor string) string {
 	return kindStr + "/" + ref.GetWorkload()
 }
 
+// The binding sidecars record, on disk beside a banked bundle, the control-plane
+// identity noded needs to compose the bundle's REMOTE (S3) prefix at eviction
+// time (#38 F1/F2). The bundle dir name is only the opaque snapshot_ref, so
+// without these a boot-scanned inventory entry seeds with an empty workload /
+// group_instance_id and its remote evict fails InvalidArgument, stranding the S3
+// copy. Written by the server AFTER the driver publishes the (already complete)
+// bundle, mirroring the driver's gen/pinned-IP sidecars; a bundle banked before
+// this change (or a crash between snapfile-publish and sidecar-write) simply has
+// no sidecar and reads back empty, which the reaper then SKIPS (see #38 fix C).
+const (
+	statefulWorkloadSidecar = "workload"
+	groupInstanceSidecar    = "group_instance_id"
+)
+
+// writeStatefulWorkloadSidecar records the workload beside a banked stateful
+// bundle (stateful/<ref>/workload). Best-effort: a write failure logs and leaves
+// the bundle usable, degrading only to the empty-binding SKIP the reaper handles.
+func (s *Server) writeStatefulWorkloadSidecar(ref, workload string) {
+	if s.statefulDriver == nil || workload == "" || ref == "" {
+		return
+	}
+	root := s.statefulDriver.StatefulDir()
+	if root == "" {
+		return
+	}
+	path := filepath.Join(root, ref, statefulWorkloadSidecar)
+	if err := os.WriteFile(path, []byte(workload), 0o600); err != nil {
+		s.logger.Warn("noded: write stateful workload sidecar (bundle still usable, will seed empty on restart)", "ref", ref, "workload", workload, "err", err)
+	}
+}
+
+// readStatefulWorkloadSidecar reads the workload a stateful bundle was banked for
+// ("" if the sidecar is absent or unreadable: a pre-sidecar bundle).
+func (s *Server) readStatefulWorkloadSidecar(ref string) string {
+	if s.statefulDriver == nil || ref == "" {
+		return ""
+	}
+	root := s.statefulDriver.StatefulDir()
+	if root == "" {
+		return ""
+	}
+	raw, err := os.ReadFile(filepath.Join(root, ref, statefulWorkloadSidecar))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+// writeGroupInstanceSidecar records the group_instance_id beside a banked group
+// member bundle (group/<set>/<member>/group_instance_id). Best-effort, same
+// contract as the stateful sidecar.
+func (s *Server) writeGroupInstanceSidecar(setID, memberName, groupInstanceID string) {
+	if s.groupDriver == nil || groupInstanceID == "" || setID == "" || memberName == "" {
+		return
+	}
+	root := s.groupDriver.GroupSetsDir()
+	if root == "" {
+		return
+	}
+	path := filepath.Join(root, setID, memberName, groupInstanceSidecar)
+	if err := os.WriteFile(path, []byte(groupInstanceID), 0o600); err != nil {
+		s.logger.Warn("noded: write group instance sidecar (bundle still usable, will seed empty on restart)", "set", setID, "member", memberName, "gid", groupInstanceID, "err", err)
+	}
+}
+
+// readGroupInstanceSidecar reads the group_instance_id a member bundle was banked
+// under ("" if absent: a pre-sidecar bundle).
+func (s *Server) readGroupInstanceSidecar(setID, memberName string) string {
+	if s.groupDriver == nil || setID == "" || memberName == "" {
+		return ""
+	}
+	root := s.groupDriver.GroupSetsDir()
+	if root == "" {
+		return ""
+	}
+	raw, err := os.ReadFile(filepath.Join(root, setID, memberName, groupInstanceSidecar))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}
+
 // legacyArtifactPrefix composes the pre-R7 un-vendored prefix for a vendor-bound
 // kind (<kindStr>/<workload>/<ref>), the key layout every BASE/SESSION/SERVING/
 // STATEFUL/GROUP_SET artifact used before vendor keying shipped. It is the alias

--- a/projects/embervm/noded/server/store.go
+++ b/projects/embervm/noded/server/store.go
@@ -482,6 +482,18 @@ func (s *Server) EvictArtifact(ctx context.Context, req *nodev1.EvictArtifactReq
 			return nil, status.Errorf(codes.FailedPrecondition, "noded: volume for %q still pairs with a banked bundle; refusing evict", ref.GetWorkload())
 		}
 	}
+	// Stateful in-use guard (defense-in-depth, #38): refuse to evict a STATEFUL
+	// artifact (local OR remote store copy) while a live VM was relit from this ref.
+	// The reaper only ever targets orphans (no live instance) and gates its remote
+	// evict on the local one, so in normal operation this never fires; it is the
+	// backstop against a mistargeted control-plane request deleting the recovery
+	// copy of a bundle a running guest still depends on, mirroring the volume
+	// pairing guard's intent for the store copy.
+	if ref.GetKind() == nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL && s.statefulVMs != nil {
+		if vmID, inUse := s.statefulVMs.snapshotRefInUse(ref.GetRef()); inUse {
+			return nil, status.Errorf(codes.FailedPrecondition, "noded: stateful snapshot %q is in use by live vm %q; refusing evict", ref.GetRef(), vmID)
+		}
+	}
 	if req.GetRemote() {
 		if s.store == nil {
 			// No store: the remote copy cannot exist, so the desired end-state
@@ -501,15 +513,26 @@ func (s *Server) EvictArtifact(ctx context.Context, req *nodev1.EvictArtifactReq
 }
 
 // evictArtifactLocal deletes the on-disk copy of an artifact over the typed ref,
-// reusing the existing kind-specific eviction path (EvictSnapshot for a session/
-// serving/stateful bundle, RemoveGroupMemberBundle per member for a group set,
-// DeleteVolume for a volume, a direct bases/<ref> removal for a BASE). Idempotent.
+// reusing the kind-specific eviction path (EvictSnapshot for a session/serving
+// bundle, the stateful arm for a stateful bundle, RemoveGroupMemberBundle per
+// member for a group set, DeleteVolume for a volume, a direct bases/<ref> removal
+// for a BASE). Idempotent.
 func (s *Server) evictArtifactLocal(ctx context.Context, ref *nodev1.ArtifactRef) (*nodev1.EvictArtifactResponse, error) {
 	switch ref.GetKind() {
 	case nodev1.ArtifactKind_ARTIFACT_KIND_BASE:
 		return s.evictBaseLocal(ref)
-	case nodev1.ArtifactKind_ARTIFACT_KIND_SESSION, nodev1.ArtifactKind_ARTIFACT_KIND_SERVING, nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL:
+	case nodev1.ArtifactKind_ARTIFACT_KIND_SESSION, nodev1.ArtifactKind_ARTIFACT_KIND_SERVING:
 		if _, err := s.EvictSnapshot(ctx, &nodev1.EvictSnapshotRequest{SnapshotRef: ref.GetRef()}); err != nil {
+			return nil, err
+		}
+	case nodev1.ArtifactKind_ARTIFACT_KIND_STATEFUL:
+		// Dispatch STATEFUL directly to its own arm (NOT via the generic
+		// EvictSnapshot inventory dispatch) so a typed stateful evict removes the
+		// on-disk stateful/<ref> dir even if the banked-bundle inventory entry is
+		// missing (e.g. a bundle that reconcile has not re-registered). The arm's
+		// RemoveStatefulBundle is idempotent, so an already-absent bundle is
+		// success; its in-use guard still refuses a bundle a live relit VM holds.
+		if _, err := s.evictStatefulSnapshot(ref.GetRef()); err != nil {
 			return nil, err
 		}
 	case nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME:

--- a/projects/embervm/noded/server/store_test.go
+++ b/projects/embervm/noded/server/store_test.go
@@ -190,6 +190,18 @@ func newDiskScanStatefulDriver(snapshotRoot string) *diskScanStatefulDriver {
 
 func (d *diskScanStatefulDriver) StatefulDir() string { return d.statefulRoot }
 
+// RemoveStatefulBundle does a REAL os.RemoveAll of stateful/<ref> under the temp
+// root (mirroring the production *driver.Driver), so an eviction test can assert
+// the on-disk dir actually leaves disk rather than a faked in-memory map mutation
+// masking the misroute #38 fixes. It also drops the in-memory banked entry so a
+// subsequent ScanStatefulBundles agrees with disk.
+func (d *diskScanStatefulDriver) RemoveStatefulBundle(snapshotRef string) error {
+	if err := os.RemoveAll(filepath.Join(d.statefulRoot, snapshotRef)); err != nil {
+		return err
+	}
+	return d.fakeStatefulDriver.RemoveStatefulBundle(snapshotRef)
+}
+
 // ScanStatefulBundles reads the on-disk stateful/ dir (mirroring the real
 // driver): a bundle is any subdir holding a snapfile, keyed by the dir name, its
 // generation read from the gen sidecar. This is what makes a restored bundle dir

--- a/projects/embervm/noded/server/store_test.go
+++ b/projects/embervm/noded/server/store_test.go
@@ -308,6 +308,58 @@ func waitForExport(t *testing.T, fs *fakeStore, prefix string) {
 	t.Fatalf("export of %q did not land within the deadline", prefix)
 }
 
+// TestReconcileStatefulReadsWorkloadSidecar proves a boot-scan reconciliation
+// recovers the workload from the on-disk sidecar (#38 F1), so a bundle banked
+// (with its sidecar) before a restart re-seeds with its REAL workload and is
+// therefore remotely evictable, instead of seeding with "".
+func TestReconcileStatefulReadsWorkloadSidecar(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+
+	ref := "scratch-postgres__g9"
+	dir := filepath.Join(s.cfg.SnapshotRoot, "stateful", ref)
+	// A complete bundle (snapfile makes ScanStatefulBundles report it) WITH the
+	// workload sidecar written at bank time.
+	writeBundleFiles(t, dir, map[string]string{
+		"snapfile":              "snap",
+		"memfile":               "mem",
+		"gen":                   "9",
+		statefulWorkloadSidecar: "scratch-postgres",
+	})
+
+	s.ReconcileStatefulFromDisk()
+
+	got, ok := s.statefulBundles.get(ref)
+	if !ok {
+		t.Fatalf("reconcile should have seeded stateful bundle %q", ref)
+	}
+	if got.workload != "scratch-postgres" {
+		t.Fatalf("reconciled workload = %q, want scratch-postgres (from sidecar)", got.workload)
+	}
+}
+
+// TestReconcileStatefulNoSidecarSeedsEmptyWorkload proves a pre-sidecar bundle
+// (no workload file) reconciles with workload "", which the reaper then SKIPS
+// (fix C) rather than draining a bundle whose S3 copy it cannot address.
+func TestReconcileStatefulNoSidecarSeedsEmptyWorkload(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+
+	ref := "legacy__nobind"
+	dir := filepath.Join(s.cfg.SnapshotRoot, "stateful", ref)
+	writeBundleFiles(t, dir, map[string]string{"snapfile": "snap", "memfile": "mem", "gen": "1"})
+
+	s.ReconcileStatefulFromDisk()
+
+	got, ok := s.statefulBundles.get(ref)
+	if !ok {
+		t.Fatalf("reconcile should still seed the bundle %q", ref)
+	}
+	if got.workload != "" {
+		t.Fatalf("pre-sidecar bundle should seed workload \"\", got %q", got.workload)
+	}
+}
+
 // TestExportArtifactStateful proves a direct ExportArtifact of a banked stateful
 // bundle uploads its files and reports it exported in NodeStatus.
 func TestExportArtifactStateful(t *testing.T) {


### PR DESCRIPTION
## Summary

PR-1 of the EmberVM fleet-finish plan. Fixes the noded local-eviction misroute that BLOCKS the #36 warmth-GC flip: without it, flipping the retention sweep would delete each orphan's S3 recovery copy while the disk copy leaks forever. Now folds in Fable's adversarial-review fixes (B/C/D below) so the fix is **sufficient** to gate the mass-delete, not merely safe.

### The bug
`EvictSnapshot` had only a **serving** arm and a **session** arm. Both a `STATEFUL` ref and a group-member ref (`group/<set>/<member>`) fell through to `RemoveSessionBundle(ref)`, which `os.RemoveAll`'d a nonexistent `sessions/<ref>` and returned a **false success** while the real bundle survived on disk. Same misroute class the BASE arm fixed in base-durability PR-3.

## Core fix (arms + guards + reaper gate)

**noded (Go)**
- `evictStatefulSnapshot` / `evictGroupMemberSnapshot` mirroring `evictServingSnapshot`: idempotent removal via `RemoveStatefulBundle` / `RemoveGroupMemberBundle`, each refusing `FAILED_PRECONDITION` while a live VM relit from the ref is still running.
- `EvictSnapshot` dispatches **serving → stateful → group-member → session fallback**; `evictArtifactLocal` routes typed `STATEFUL` straight to its arm; `GROUP_SET` stays per-member.
- Defense-in-depth STATEFUL in-use guard on the `EvictArtifact` local + remote store path.

**reaper (Elixir)**
- `run_evict` fires the remote (S3) evict **only when every paired local evict succeeded**; a refused/failed local withholds the remote so the recovery copy is kept. Group whole-set remote gated on all members' locals.

## Fable review fold-in (B/C/D)

Root cause Fable found: boot-scanned inventory entries lost their control-plane binding (stateful `workload=""`, group `group_instance_id=""`), and this PR's own deploy restarts noded, so every existing bundle re-seeds empty. An empty-binding local evict drains the disk copy while the remote evict fails `InvalidArgument`, stranding the recovery copy forever (worse than nothing).

**A. CI fix** — `newEvictTestServer` now sets `CpuVendor: "amd"`; `artifactPrefix` refuses a vendor-bound STATEFUL kind with an empty vendor, so the STATEFUL evict tests were failing `InvalidArgument` before reaching the arm.

**B. Durable binding sidecars** (mirror the `gen` sidecar): stateful bank (direct + checkpoint commit) writes a `workload` sidecar into `stateful/<ref>/`; group bank writes a `group_instance_id` sidecar into `group/<set>/<member>/`. The two boot rescans read them back so a bundle banked after this change is remotely evictable across a restart. Written by the SERVER after the driver publishes the complete bundle (no driver-signature churn); a crash before the write, or a pre-sidecar bundle, seeds empty and is handled by C.

**C. Reaper skips empty-binding entries** — `evict_entry` has guard clauses that, for a stateful entry with `workload ""` or a group entry with `group_instance_id ""`, run **NEITHER** local nor remote evict and log one info line. Prevents the drain-local-strand-remote failure.

**D. Group in-use guard, ref-first (closes F3)** — `startGroupMemberRelight` threads the `snapshot_ref` onto the live `groupMemberEntry`; `memberInUse` matches `snapshotRef` first (authoritative, survives a gid-less boot scan), falling back to `(group_instance_id, member_name)`. A live relit member is protected even when its bundle entry lost its gid.

## Tests (assert real disk / real RPC)

- `evict_local_test.go` (bufconn + real on-disk SnapshotRoot, disk-real removal stubs): stateful/group-member removed from disk after evict (fail against pre-fix code); in-use refusal keeps the dir; `TestEvictGroupMemberInUseRefusedRefFirstNoGid` (ref-first guard protects a live relit member whose bundle entry has `gid=""`); idempotency.
- `store_test.go`: `TestReconcileStatefulReadsWorkloadSidecar`, `TestReconcileStatefulNoSidecarSeedsEmptyWorkload`.
- `group_member_test.go`: `TestReconcileGroupReadsInstanceSidecar`.
- `warmth_reaper_test.exs`: remote withheld on local failure (stateful + one group member); remote fired on local success; empty-binding stateful and group orphans run no local and no remote evict.

## Chart
Bumped to **0.1.194** (Chart.yaml + application.yaml together; noded + control-plane images deploy through it).

## Known accepted races (documented, not fixed here)
- **F4 (stale-fact predecessor-delete race):** a sweep acting on a slightly stale node fact could delete a predecessor copy; harm is bounded to a predecessor `N=2` copy, no disk-pressure risk. Accepted as a known bounded race.
- **Pre-sidecar orphan backlog (the existing ~143 stateful + ~5 group orphans):** these have no sidecar, so C safely SKIPS them (left whole, local AND remote). Reclaiming them is a separate decision tracked as **task #39**; this PR deliberately adds no backfill / local-only-strand path.

## Notes
- Tests are **not** run locally per repo policy; BuildBuddy CI verifies (the new Go tests fail against the old code).
- Do **not** auto-merge; the dispatching reviewer wants to review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFXpz6XW8Tmb3Yj5t3b1c