### PR TITLE
fix(cloudflare-gateway): decouple cloudflared liveness from edge health, bump to 2026.7.2

### DIFF
--- a/projects/platform/cloudflare-gateway/values.yaml
+++ b/projects/platform/cloudflare-gateway/values.yaml
@@ -45,7 +45,9 @@ tunnel:
 
   image:
     repository: cloudflare/cloudflared
-    tag: "2025.4.0"
+    # Pinned deliberately (noAutoupdate: true). 2026.7.x adds startup
+    # DNS/UDP/TCP connectivity prechecks and clearer connection failures.
+    tag: "2026.7.2"
     pullPolicy: IfNotPresent
 
   # Tunnel identity (set from secret when using OnePassword)
@@ -89,19 +91,21 @@ tunnel:
     seccompProfile:
       type: RuntimeDefault
 
+  # Liveness only checks the local metrics/process is alive (TCP connect to the
+  # metrics listener), NOT edge readiness. An upstream Cloudflare transport
+  # outage must not restart an otherwise-healthy, reconnecting cloudflared:
+  # that just adds synchronized restart churn and extends the outage. Edge
+  # health is a readiness concern (below). Requires metrics bound to 0.0.0.0
+  # so the kubelet can reach it on the pod IP (see metrics.address).
   livenessProbe:
-    exec:
-      command:
-        - cloudflared
-        - tunnel
-        - --metrics
-        - 127.0.0.1:2000
-        - ready
+    tcpSocket:
+      port: 2000
     failureThreshold: 6
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
 
+  # Readiness DOES gate on edge readiness (runs in-container against loopback).
   readinessProbe:
     exec:
       command:
@@ -117,7 +121,10 @@ tunnel:
 
   metrics:
     enabled: true
-    address: "127.0.0.1:2000"
+    # Bound to 0.0.0.0 (was 127.0.0.1) so the kubelet tcpSocket liveness probe
+    # can reach it on the pod IP. Exposure is in-cluster only (ClusterIP service,
+    # never internet-facing); tighten with a CiliumNetworkPolicy if needed.
+    address: "0.0.0.0:2000"
 
   envoy:
     enabled: false


### PR DESCRIPTION
## What

Two independent robustness fixes to the Cloudflare tunnel, both in `projects/platform/cloudflare-gateway/values.yaml`:

1. **Split the liveness/readiness probes.** They previously ran the *identical* `cloudflared tunnel --metrics 127.0.0.1:2000 ready` exec. An upstream Cloudflare transport outage makes `ready` return not-ready, which failed **liveness** and restarted both otherwise-healthy, actively-reconnecting pods in lockstep (`replicaCount: 2`, shared WAN failure domain). That adds synchronized restart churn and *extends* the outage.
   - **Liveness** is now a `tcpSocket` on port 2000: it only checks the cloudflared process/metrics listener is alive, not edge health.
   - **Readiness** is unchanged (still gates on edge readiness via the loopback exec).
   - Required binding metrics to `0.0.0.0:2000` (was loopback-only) so the kubelet `tcpSocket` probe can reach it on the pod IP. Exposure is **in-cluster ClusterIP only**, never internet-facing; the readiness exec against `127.0.0.1` still works since `0.0.0.0` includes loopback. Can be tightened with a `CiliumNetworkPolicy` later.

2. **Bump cloudflared `2025.4.0` → `2026.7.2`** (current stable). The `2026.7.x` line includes the startup DNS/UDP/TCP connectivity prechecks and clearer connection-failure output (landed 2026.5.2). `noAutoupdate: true` retained; the pin is deliberate.

## Protocol decision

Left `protocol: ""` (default `auto`) **unchanged**: QUIC when UDP/7844 works, automatic HTTP/2 fallback when it does not. Not hard-pinning `quic` (removes the fallback we want) nor `http2` (permanently sacrifices QUIC perf / post-quantum). `http2` remains available as a *temporary* mitigation if prechecks later confirm UDP/7844 is broken.

## Not included

- No network-policy change for UDP/7844: there is no egress `CiliumNetworkPolicy` on cloudflared in this repo and Cilium is default-allow, so a dropped UDP path would be upstream of the cluster (router / ISP / NAT / Cloudflare edge), not a manifest we own.

## Deploy mechanics

This app is a git-path ArgoCD Application (`targetRevision: HEAD`), not the OCI-chart pattern, so **no chart-version bump is needed**; it syncs on merge.

## Verification

`helm template` with `values.yaml` + `values-prod.yaml` renders: image `2026.7.2`, `livenessProbe.tcpSocket.port: 2000`, readiness exec unchanged, configmap `metrics: 0.0.0.0:2000`, no `--protocol` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)