### PR TITLE
feat(embervm): flip warmth-GC gate on (#36)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.195
+version: 0.1.197

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -321,6 +321,14 @@ spec:
             - name: EMBERVM_BASE_RETENTION_SWEEP
               value: {{ .Values.baseRetention.sweepEnabled | quote }}
             {{- end }}
+            {{- if .Values.warmthRetention.sweepEnabled }}
+            # Warmth-retention sweep gate (base-durability PR-3, extended to
+            # stateful and group orphans): "1" arms the reconciled eviction of
+            # orphaned stateful/group warmth; empty-binding orphans are skipped.
+            # Unset keeps the dry-run that only logs. See warmthRetention in values.
+            - name: EMBERVM_WARMTH_RETENTION_SWEEP
+              value: {{ .Values.warmthRetention.sweepEnabled | quote }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -712,6 +712,15 @@ statefulSweeper:
 baseRetention:
   sweepEnabled: ""
 
+# Warmth-retention sweep gate (base-durability PR-3, extended to stateful and group
+# orphans, task #36): "1" arms the reconciled eviction of orphaned stateful/group
+# warmth. Empty-binding orphans (banked pre-sidecar, no workload/group_instance_id
+# recovered on a boot scan) are SKIPPED, so a drained-local-but-stranded-remote leak
+# cannot happen. Unset ("") keeps the dry-run that only logs. Flipping back to "" is
+# the entire rollback lever.
+warmthRetention:
+  sweepEnabled: ""
+
 # The rootfs-builder tool image (crane + e2fsprogs + bash) that bakes each
 # workload's guest OCI image into an ext4 base rootfs at pod init. Reuses the
 # fc-invoke rootfs-builder image; Bazel pins repository:tag from its .info.

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.195
+      targetRevision: 0.1.197
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -200,3 +200,11 @@ statefulSweeper:
 # Rollback: set back to "" and bump the chart; that stops further eviction.
 baseRetention:
   sweepEnabled: "1"
+
+# Arm the warmth-retention sweep (task #36, Joe 2026-07-22): flips the merged-inert
+# WarmthReaper from dry-run to acting. With #38 fix C the reaper SKIPS empty-binding
+# orphans (all pre-sidecar backlog), so this reclaims steady-state forward (new
+# orphans) safely; the existing ~120G backlog is reclaimed separately by the S3-direct
+# GC (task #39). Rollback: set back to "" and bump the chart; that stops eviction.
+warmthRetention:
+  sweepEnabled: "1"


### PR DESCRIPTION
Flips the merged-inert WarmthReaper from dry-run to acting by wiring + setting EMBERVM_WARMTH_RETENTION_SWEEP=1 (mirrors the baseRetention gate).

Safe by construction: #38 fix C makes the reaper SKIP empty-binding orphans (all pre-sidecar backlog), so this reclaims forward-only steady-state hygiene. The existing ~120G backlog is reclaimed separately by the S3-direct GC (#39). Rollback lever: set warmthRetention.sweepEnabled back to "" + bump.

HELD for merge until a clean dry-run sweep is confirmed in the live CP logs (pre-flight). Chart 0.1.197 (leapfrogs op-log 0.1.195 + scratch-prep-drop 0.1.196).

🤖 Generated with [Claude Code](https://claude.com/claude-code)