### PR TITLE
feat(embervm): per-node brick min-concurrency floor, node-1 canary (#35)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.197
+version: 0.1.198

--- a/projects/embervm/chart/templates/_helpers.tpl
+++ b/projects/embervm/chart/templates/_helpers.tpl
@@ -73,6 +73,27 @@ app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
 {{- end -}}
 
 {{/*
+Per-node brick FLOOR labels (brick-capacity PR-3). A floor Deployment is still
+"a brick of this class" (same component + size-class labels as the class-wide
+Deployment, on purpose: it is the same kind of pod), but it MUST NOT share the
+class Deployment's selector - two Deployments' ReplicaSet controllers fighting
+over the same pods is a live bug, not a style choice. The extra
+embervm.jomcgi.dev/brick-floor=<node> label makes the floor's selector disjoint
+from its class's (and from every other floor's) while still being reachable by
+the shared size-class label for anything that wants "all 2gi bricks, floor or
+not". Input dict: (dict "ctx" $ "class" $class "node" $floor.node).
+*/}}
+{{- define "embervm.brickFloor.selectorLabels" -}}
+{{ include "embervm.brick.selectorLabels" (dict "ctx" .ctx "class" .class) }}
+embervm.jomcgi.dev/brick-floor: {{ .node | quote }}
+{{- end -}}
+
+{{- define "embervm.brickFloor.labels" -}}
+{{ include "embervm.brickFloor.selectorLabels" (dict "ctx" .ctx "class" .class "node" .node) }}
+app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
+{{- end -}}
+
+{{/*
 The per-node serving Envoy tier (R3, PR-3) is a DaemonSet in this one chart. Like
 noded it uses a DISTINCT app.kubernetes.io/name ("<name>-serving-envoy") so its
 selector is disjoint from the control plane and noded, and carries a component

--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -7,19 +7,26 @@ templates; everything a noded pod actually IS (securityContext, KVM + nvme host
 mounts, rootfs-builder initContainers, the full daemon env, probes) lives here.
 
 Input dict:
-  * ctx        - the chart root context (`.` / `$`), for `.Values` / `.Release`.
-  * sizeClass  - the brick T-shirt class label ("2gi".."16gi"); "" for the legacy
-                 DaemonSet, which renders NO EMBERVM_NODED_SIZE_CLASS env (the
-                 wildcard class the control plane treats as matching every
-                 request), so the DS pod is byte-identical to its pre-brick form.
-  * resources  - the noded container's resources map. The DaemonSet passes
-                 .Values.noded.resources unchanged; a brick passes its class's
-                 own request/limit block (memory req==limit, cpu request only).
+  * ctx          - the chart root context (`.` / `$`), for `.Values` / `.Release`.
+  * sizeClass    - the brick T-shirt class label ("2gi".."16gi"); "" for the legacy
+                   DaemonSet, which renders NO EMBERVM_NODED_SIZE_CLASS env (the
+                   wildcard class the control plane treats as matching every
+                   request), so the DS pod is byte-identical to its pre-brick form.
+  * resources    - the noded container's resources map. The DaemonSet passes
+                   .Values.noded.resources unchanged; a brick passes its class's
+                   own request/limit block (memory req==limit, cpu request only).
+  * nodeSelector - OPTIONAL override for the pod's nodeSelector map. Absent (or
+                   nil) falls back to $ctx.Values.noded.nodeSelector (the
+                   fleet-wide FC-node label every bin-packed brick uses). A
+                   per-node floor Deployment (brick-capacity PR-3) passes
+                   {kubernetes.io/hostname: <node>} here to pin onto one host,
+                   which is why this is a dict field and not just $ctx.Values.
 
 Call with `{{- include "embervm.noded.podSpec" (dict "ctx" . "sizeClass" "" "resources" .Values.noded.resources) | nindent 6 }}`.
 */}}
 {{- define "embervm.noded.podSpec" -}}
 {{- $ctx := .ctx -}}
+{{- $nodeSelector := .nodeSelector | default $ctx.Values.noded.nodeSelector -}}
 # Safe-rollout drain: give the daemon time to finish in-flight Assigns on
 # SIGTERM before Kubernetes SIGKILLs it. Set above the daemon's own drain
 # budget (EMBERVM_NODED_DRAIN_TIMEOUT below) so grace always outlasts drain,
@@ -32,7 +39,7 @@ imagePullSecrets:
 {{- end }}
 priorityClassName: {{ $ctx.Values.noded.priorityClassName }}
 nodeSelector:
-  {{- toYaml $ctx.Values.noded.nodeSelector | nindent 2 }}
+  {{- toYaml $nodeSelector | nindent 2 }}
 {{- with $ctx.Values.noded.tolerations }}
 tolerations:
   {{- toYaml . | nindent 2 }}

--- a/projects/embervm/chart/templates/brick-deployment.yaml
+++ b/projects/embervm/chart/templates/brick-deployment.yaml
@@ -67,4 +67,68 @@ spec:
     spec:
       {{- include "embervm.noded.podSpec" (dict "ctx" $ctx "sizeClass" $class.name "resources" $class.resources) | nindent 6 }}
 {{- end }}
+
+# Per-node brick FLOOR Deployments (brick-capacity PR-3, ADR embervm/013 sibling
+# decision): one pinned, fixed-replicas-1 Deployment per `bricks.nodeFloors`
+# entry, guaranteeing that specific node joins active duty instead of every
+# class bin-packing onto whichever node the scheduler happens to fill first
+# (observed: everything landing on node-4 and spilling under load). Each floor
+# renders the SAME shared pod (identical labels, resources, strategy) as its
+# class's demand-driven Deployment, but under a DISTINCT name
+# (`-brick-<class>-<node>` vs `-brick-<class>`) and with nodeSelector pinned to
+# kubernetes.io/hostname instead of the fleet-wide FC-node label.
+#
+# The distinct name is what keeps the BrickController out: it PATCHes /scale by
+# exact Deployment name (deployment_prefix <> class name), never enumerating by
+# label, so a floor Deployment is simply never addressed by the controller and
+# replicas stays a static 1 forever (verified against brick_controller.ex). A
+# floor brick still dial-home registers as a normal instance of its class
+# (registration is name-agnostic), so it counts toward that class's registered
+# total for fleet-full/autoscale accounting - which only ever makes fleet-full
+# LESS likely and idle scale-down MORE likely (the accounting is registered <
+# desired shaped, not equality-shaped), both acceptable per the plan's analysis.
+#
+# Selector: embervm.brickFloor.selectorLabels adds a brick-floor=<node> label on
+# top of the shared class selector, so this Deployment's selector is DISJOINT
+# from its class Deployment's. Reusing the class selector here would be a real
+# bug (two ReplicaSet controllers fighting over the same pods), not just style.
+{{- range $floor := .Values.bricks.nodeFloors }}
+{{- $class := $floor.class }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "embervm.noded.fullname" $ctx }}-brick-{{ $class }}-{{ $floor.node }}
+  labels:
+    {{- include "embervm.brickFloor.labels" (dict "ctx" $ctx "class" $class "node" $floor.node) | nindent 4 }}
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  # Fixed at 1: a floor is a static per-node guarantee, not a scaled quantity.
+  # ArgoCD's fleet-wide replicas ignoreDifferences rule applies here too, but
+  # nothing ever writes a different value, so it is inert for floor Deployments.
+  replicas: 1
+  selector:
+    # nosemgrep: require-component-label-in-selector
+    matchLabels:
+      {{- include "embervm.brickFloor.selectorLabels" (dict "ctx" $ctx "class" $class "node" $floor.node) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "embervm.brickFloor.labels" (dict "ctx" $ctx "class" $class "node" $floor.node) | nindent 8 }}
+    spec:
+      {{- $classSpec := "" }}
+      {{- range $c := $ctx.Values.bricks.classes }}
+      {{- if eq $c.name $class }}
+      {{- $classSpec = $c }}
+      {{- end }}
+      {{- end }}
+      {{- if not $classSpec }}
+      {{- fail (printf "bricks.nodeFloors entry for node %s references unknown class %q (not in bricks.classes)" $floor.node $class) }}
+      {{- end }}
+      {{- include "embervm.noded.podSpec" (dict "ctx" $ctx "sizeClass" $class "resources" $classSpec.resources "nodeSelector" (dict "kubernetes.io/hostname" $floor.node)) | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -992,3 +992,12 @@ bricks:
           memory: 16Gi
         limits:
           memory: 16Gi
+  # Per-node brick FLOOR guarantees (brick-capacity PR-3): a list of
+  # {node, class} pairs, each rendering one ADDITIONAL fixed-replicas-1
+  # Deployment pinned via nodeSelector to that node (kubernetes.io/hostname),
+  # distinct from and never touched by the demand-driven class Deployment or
+  # the BrickController (which scales by exact Deployment name). This is what
+  # pulls a specific node into active duty instead of every class bin-packing
+  # onto whichever node the scheduler fills first. Empty by default (no
+  # floors); deploy/values.yaml sets the fleet's actual floor entries.
+  nodeFloors: []

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.197
+      targetRevision: 0.1.198
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -152,6 +152,21 @@ bricks:
     # to absorb the migrated workloads. Scale-down stays observe-only until we
     # promote to full. This is what lets the CP choose the optimal brick mix.
     mode: up
+  # Per-node brick floor guarantees (PR-3, #35): pins one small brick onto a
+  # specific node so it joins active duty instead of the fleet bin-packing
+  # everything onto node-4 and spilling under load. CANARY: node-1 only for
+  # now, to validate one floor brick before fanning out. node-2/node-3 are
+  # commented and ready; each needs its own scratch pre-flight (mountpoint +
+  # ~35Gi ext4 loop file) verified on the host BEFORE uncommenting - this is a
+  # values-only follow-up PR once the node-1 canary is confirmed healthy
+  # (registered in the CP, canary invoke lands a VM, no fleet_full flag).
+  nodeFloors:
+    - node: node-1
+      class: 2gi
+    # - node: node-2
+    #   class: 2gi
+    # - node: node-3
+    #   class: 2gi
 
 # EmberVM R4 scale-to-zero scratch-postgres (ADR embervm/001, D-R4.PR-11.1):
 # enabled with the k8s-homelab 1Password item whose POSTGRES_PASSWORD field syncs


### PR DESCRIPTION
## Summary

Adds `bricks.nodeFloors`, a values-declared list of `{node, class}` pairs. Each
entry renders one additional, pinned brick Deployment (`nodeSelector:
kubernetes.io/hostname: <node>`, fixed `replicas: 1`), distinct in name from
the demand-driven class Deployment (`-brick-<class>-<node>` vs
`-brick-<class>`) so it is never touched by the `BrickController` (which
`PATCH`es `/scale` by exact Deployment name, no label enumeration).

This is the fix for bricks bin-packing everything onto node-4 and spilling
under load (`bricks-only-migration` memory): node-1/2/3 get a guaranteed
resident brick instead of relying on the scheduler to spread them.

**Design (per the plan, `docs/plans/2026-07-21-embervm-fleet-finish.md` PR-3
section):** NOT topology spread (would reverse the deliberate bin-packing on
the demand-driven bricks), NOT `bricks.autoscale.minReplicas` (per-class
floors can all still land on node-4). A separate static floor Deployment is
the simplest mechanism that pins a *node*, not just a replica count.

## Selector safety (found during implementation, not in the original plan)

The floor Deployment cannot reuse the class Deployment's selector
(`component=noded-brick` + `size-class`) as-is: two Deployments with an
identical selector fight over the same pods via their ReplicaSet
controllers. Added `embervm.brickFloor.selectorLabels` (new helper in
`_helpers.tpl`), which layers an `embervm.jomcgi.dev/brick-floor=<node>`
label on top of the shared class selector so the floor's selector is
provably disjoint from its class's.

## BrickController accounting (verified against `brick_controller.ex`)

- Fleet-full comparison is `if acting > reg` (strictly greater-than,
  `brick_controller.ex:335`) - a floor's extra registered instance can only
  make `acting > reg` *less* likely, never trip a false fleet-full.
- Scale-down idle checks are presence-based (`idle_dwell_ok?`), not count
  comparisons - no equality-shaped logic anywhere that a floor's extra
  registration could violate.
- No code path enumerates brick Deployments by label for scaling; the scale
  write is `deployment_prefix <> name` string concat.
- No controller code changes were needed.

## Pre-flight verification (Step 0 of the plan, done before this PR)

`/var/lib/embervm/scratch` on node-1 confirmed via `kubectl debug node/node-1`:
mountpoint, `/dev/loop7` ext4, 35G total / 30G free. **node-2/node-3 have NOT
been checked** - do not uncomment their entries in `deploy/values.yaml` until
their own scratch mount is verified the same way (the scratch-prep DaemonSet
was retired in #3798; nothing auto-provisions this anymore).

## Chart

`bump-chart.sh`: 0.1.195 -> 0.1.198 (0.1.196/0.1.197 were already claimed by
#3798 and the in-flight #36 warmth-flip PR).

## Rendering proof

`helm template embervm projects/embervm/chart -f projects/embervm/deploy/values.yaml
--show-only templates/brick-deployment.yaml` renders exactly 5 Deployments:
the 4 existing class Deployments (byte-identical to pre-change, diffed and
confirmed) plus `embervm-embervm-noded-brick-2gi-node-1` with
`nodeSelector: {kubernetes.io/hostname: node-1}`, `replicas: 1`, and a
selector disjoint from the `2gi` class Deployment's.

## Test plan

- [ ] CI: format check, Go/Elixir tests, template render, guardrails
- [ ] **HOLD for review before merge** (fleet-capacity deploy, per instructions - do not auto-merge)
- [ ] After merge: supervise the node-1 canary rollout - floor pod Running on
      node-1, registers in the CP as a 2gi brick on node-1, a canary invoke
      lands a VM on it, no fleet_full flag flips, BaseBuilder hydrates bases
      from S3 on first use
- [ ] Only then: values-only follow-up PR adding node-2/node-3 (each gated on
      its own host scratch pre-flight)

https://claude.ai/code/session_01RyFXpz6XW8Tmb3Yj5t3b1c