### PR TITLE
feat(embervm): enable node-2/node-3 brick floors, complete fleet distribution (#35)

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -163,10 +163,10 @@ bricks:
   nodeFloors:
     - node: node-1
       class: 2gi
-    # - node: node-2
-    #   class: 2gi
-    # - node: node-3
-    #   class: 2gi
+    - node: node-2
+      class: 2gi
+    - node: node-3
+      class: 2gi
 
 # EmberVM R4 scale-to-zero scratch-postgres (ADR embervm/001, D-R4.PR-11.1):
 # enabled with the k8s-homelab 1Password item whose POSTGRES_PASSWORD field syncs


### PR DESCRIPTION
Values-only follow-up to #35. Enables the node-2 + node-3 floor entries (node-1 canary validated: floor brick dial-home registered with the CP). node-3 scratch verified (/dev/loop0, 35G, 29G free); node-2 runs a live brick already.

No chart bump: the nodeFloors template range shipped in 0.1.198, so this deploys via the $values git ref, rendering two new floor Deployments (node-2, node-3) with no CP restart. Result: a guaranteed brick on all four FC nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)