### PR TITLE
fix(monolith): correct copy defects on the ember demo pages

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.255
+version: 0.89.256
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.255
+      targetRevision: 0.89.256
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.329
+version: 0.285.330
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.329
+      targetRevision: 0.285.330
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -95,7 +95,7 @@
     {
       done: true,
       name: "R0 tasks",
-      desc: "Dispatch, fair round-robin pooling, metering and quotas, tracing. Untrusted code runs and is billed.",
+      desc: "Dispatch, fair round-robin pooling, metering and quotas, tracing. Untrusted code runs and every run counts against a quota.",
     },
     {
       done: true,
@@ -135,7 +135,7 @@
     {
       done: false,
       name: "R8 elasticity",
-      desc: "Capacity becomes fixed-size bricks: each a plain pod owning a slice of VMs, so the Kubernetes scheduler bin-packs them and a Pending brick is the autoscaler's signal to buy a spot node. The fleet grows and shrinks with demand, and preemption is routine rather than an outage, because every workload is a durable snapshot that wakes wherever there is room.",
+      desc: "Capacity becomes fixed-size bricks: each a plain pod owning a slice of VMs, so the Kubernetes scheduler bin-packs them and a Pending brick is the autoscaler's signal to buy a spot node. Every workload is a durable snapshot that wakes wherever there is room; preemption costs a wake, not an outage.",
     },
   ];
 </script>
@@ -206,7 +206,8 @@
       </h2>
       <p class="body">
         Everything Ember runs is declared as a Kubernetes custom resource in
-        one of three classes. The classes differ in exactly one dimension:
+        one of three classes, and a composite workload groups several of them
+        into one unit that wakes together. What separates the classes:
         <b>how much of the machine the guest is allowed to touch</b>.
       </p>
       <dl class="classes">
@@ -491,7 +492,7 @@
         <p>
           Metering rides the operation itself; <b
             >a crash cannot lose usage</b
-          >. Every task is billed on success and on failure.
+          >. Every task counts against its quota on success and on failure.
         </p>
         <p>
           The one public route is scoped at <b>three independent layers</b>:
@@ -506,8 +507,8 @@
         <a class="anchor" href="#live-exhibits">See it run</a>
       </h2>
       <p class="body">
-        Four exhibits run on the live system, through the same wake path
-        production uses.
+        Three of these exhibits run on the live system, through the same wake
+        path production uses; the fourth explains the resume itself.
       </p>
       <div class="doors">
         <a class="door" href="/ember/postgres">

--- a/projects/monolith/frontend/src/routes/public/ember/postgres/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/postgres/+page.svelte
@@ -37,7 +37,7 @@
       ><a class="brand" href="/"><strong>jomcgi.dev</strong></a> /
       <a class="brand" href="/ember">ember</a> / postgres</span
     >
-    <a class="topbar-cross" href="/ember/firecracker">how does firecracker work?</a>
+    <a class="topbar-cross" href="/ember/firecracker">how firecracker resumes a VM</a>
   </header>
 
   <main class="ember-page">


### PR DESCRIPTION
CV probe review (2026-07-22 run, first pass over the linked demo surface) flagged concrete copy defects on the /ember hero pages. All are wording-only; no behavior changes.

## Fixes

- **Class-count contradiction**: /ember said "one of three classes" while listing and roadmapping a composite class (bar-raiser, ten-second catch). The intro now names composite as a grouping of the three classes.
- **"exactly one dimension"**: factually loose, since lifecycle differs across classes too (insider). Now "what separates the classes".
- **"billed" x2**: invoicing vocabulary on a homelab demo; it means quota-recorded (insider). Now "counts against a quota" / "counts against its quota".
- **"Four exhibits run on the live system"**: one is an explainer (insider). Now "three of these... the fourth explains the resume itself".
- **R8 consequence-narration close** (bar-raiser): "preemption is routine rather than an outage, because..." now ends on the concrete claim: "preemption costs a wake, not an outage".
- **Orphaned topbar link** on /ember/postgres: "how does firecracker work?" retitled "how firecracker resumes a VM", matching the bazel page's declarative cross-link register.

Deliberate anthropomorphic voice ("frozen Bazel brain", "make a mess in") left untouched pending a separate taste ruling.

Chart bumps: monolith 0.285.330, monolith-public 0.89.256 (public tier serves these pages, both required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)