### PR TITLE
fix(embervm): adopt an anchor node's unblessed forward generation instead of quarantining

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.201
+version: 0.1.203

--- a/projects/embervm/control/lib/embervm/stateful_store.ex
+++ b/projects/embervm/control/lib/embervm/stateful_store.ex
@@ -83,11 +83,18 @@ defmodule Embervm.StatefulStore do
   split-brain write). `upsert_volume/3` re-derives `quarantined` in the
   blessing table on every node refresh that carries a `generation_blessed`
   fact: true when the reported generation exceeds `blessed_generation` AND the
-  node's own `generation_blessed` fact is false; a node reporting
-  `generation_blessed: true` at or below the blessed watermark clears it. Once
-  quarantined, `Embervm.StatefulManager.plan_wake/2` parks the wake rather than
-  placing it (fail closed, no auto-heal in v1: resolution is a runbook
-  decision). A workload that has NEVER been blessed (no CP generation-blessing
+  node's own `generation_blessed` fact is false AND the forward jump comes from
+  a DIFFERENT node than the volume's current anchor. When the volume's OWN anchor
+  node (the single writer Longhorn RWO fencing, ADR embervm/011, guarantees) is
+  the one running ahead of the watermark, that is watermark lag after a CP roll,
+  not split-brain, so `update_quarantine` ADOPTS the reported generation (advances
+  the watermark, clears quarantine) rather than deadlocking the workload; only a
+  forward jump from a non-anchor node stays fail-closed. This is ADR embervm/014's
+  node-authoritative reconciliation applied to the R7 blessing watermark. A node
+  reporting `generation_blessed: true` at or below the blessed watermark clears it.
+  Once quarantined, `Embervm.StatefulManager.plan_wake/2` parks the wake rather than
+  placing it (fail closed: resolution is either the anchor-node adoption above or a
+  runbook decision). A workload that has NEVER been blessed (no CP generation-blessing
   op ever landed, e.g. every pre-R7 volume) has an absent `blessed_generation`
   and is NEVER quarantined by this alone: `quarantined?/2` treats absent as
   "not yet under CP governance" rather than "behind it", so an existing volume
@@ -845,7 +852,13 @@ defmodule Embervm.StatefulStore do
           # pair-key: an unblessed forward jump must be caught, and a settle-back
           # to the blessed watermark must clear it (see the floor comment above).
           quarantine_gen = if is_integer(reported_gen), do: reported_gen, else: Map.get(merged, :generation, 0)
-          update_quarantine(state, workload, quarantine_gen, blessed_on_wire)
+          # reporting_node is who sent THIS report (always carried, see
+          # refresh_volume_facts); anchor_node is the volume's prior holder (the
+          # pre-merge row's node_id). update_quarantine compares them to decide
+          # adopt-vs-quarantine on an unblessed forward jump (see its doc).
+          reporting_node = Map.get(fields, :node_id)
+          anchor_node = Map.get(base, :node_id)
+          update_quarantine(state, workload, quarantine_gen, blessed_on_wire, reporting_node, anchor_node)
       end
 
     {:reply, merged, state}
@@ -1435,24 +1448,79 @@ defmodule Embervm.StatefulStore do
   # it"). Logs a structured warning on a false -> true transition only (Task
   # 16's alert wiring reads the event name), never on an already-quarantined or
   # a never-quarantined report, so a stuck-quarantined workload does not spam.
-  defp update_quarantine(state, workload, reported_gen, blessed_on_wire) do
+  # Derives the blessing ledger's quarantine flag from a fresh node report, and
+  # SELF-HEALS a lagging watermark by adopting a forward generation reported by the
+  # volume's own fenced writer (ADR embervm/014's node-authoritative reconciliation,
+  # applied to the R7 blessing watermark).
+  #
+  # An unblessed forward jump (node reports generation > our blessed watermark with
+  # generation_blessed:false) has two causes that look identical on the wire but are
+  # opposite in danger:
+  #
+  #   * The volume's OWN anchor node (the single writer that Longhorn RWO fencing,
+  #     ADR embervm/011, guarantees is the only one able to attach it RW) running
+  #     ahead of a watermark that REWOUND on a control-plane roll. The op-log replay
+  #     lands the last durably-blessed generation, but the node bumps its on-disk
+  #     generation locally on every attach, so a roll can leave blessed < reported
+  #     for a volume that has exactly one writer. This is watermark lag, not
+  #     split-brain. Quarantining it deadlocks the workload forever: a quarantined
+  #     volume can never wake, so it can never re-bless to catch the watermark up
+  #     (the recurring demo-postgres quarantine after a CP roll). ADOPT it: advance
+  #     the watermark to the reported generation and clear quarantine. The adoption
+  #     is ETS-only (like `quarantined` itself, it is re-derived from node reports,
+  #     never durable); the next real wake blesses next_blessed_generation past it
+  #     durably, and any later roll simply re-adopts from the node's report.
+  #
+  #   * A DIFFERENT node than the fenced anchor reporting a forward jump. That is the
+  #     only shape that is genuine split-brain evidence, so it stays FAIL-CLOSED
+  #     (quarantine). A legitimate RWO handoff whose new anchor reports an unblessed
+  #     generation is the remaining fail-closed case, rare and manually recoverable.
+  defp update_quarantine(state, workload, reported_gen, blessed_on_wire, reporting_node, anchor_node) do
     fact = fetch_blessing(state, workload)
     blessed_gen = Map.get(fact, :blessed_generation)
 
-    quarantined? =
+    forward_unblessed? =
       not blessed_on_wire and is_integer(blessed_gen) and reported_gen > blessed_gen
 
-    if quarantined? and not Map.get(fact, :quarantined, false) do
-      Logger.warning("embervm stateful volume quarantined: unblessed generation reported past the last blessed one",
-        event: :generation_quarantined,
-        workload: workload,
-        generation: reported_gen,
-        blessed_generation: blessed_gen
-      )
-    end
+    fenced_writer? =
+      is_binary(reporting_node) and is_binary(anchor_node) and reporting_node == anchor_node
 
-    :ets.insert(state.blessing, {workload, Map.put(fact, :quarantined, quarantined?)})
-    state
+    cond do
+      forward_unblessed? and fenced_writer? ->
+        Logger.info(
+          "embervm stateful volume generation adopted: fenced writer ran ahead of the blessed watermark",
+          event: :generation_adopted,
+          workload: workload,
+          generation: reported_gen,
+          blessed_generation: blessed_gen,
+          node_id: reporting_node
+        )
+
+        :ets.insert(
+          state.blessing,
+          {workload, Map.merge(fact, %{blessed_generation: reported_gen, quarantined: false})}
+        )
+
+        state
+
+      true ->
+        quarantined? = forward_unblessed?
+
+        if quarantined? and not Map.get(fact, :quarantined, false) do
+          Logger.warning(
+            "embervm stateful volume quarantined: unblessed generation reported past the last blessed one",
+            event: :generation_quarantined,
+            workload: workload,
+            generation: reported_gen,
+            blessed_generation: blessed_gen,
+            node_id: reporting_node,
+            anchor_node: anchor_node
+          )
+        end
+
+        :ets.insert(state.blessing, {workload, Map.put(fact, :quarantined, quarantined?)})
+        state
+    end
   end
 
   # Bump the ETS volume row's pair-key generation to the value an attach (a

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -262,16 +262,41 @@ defmodule Embervm.StatefulManagerTest do
     assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") - 1 == 1
     refute StatefulStore.quarantined?(ctx.store, "wl-a")
 
-    # Simulate a node report of a self-bumped generation the control plane never
-    # blessed (generation 2, blessed_generation still 1): the daemon self-bumped
-    # outside the ledger.
-    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 2, generation_blessed: false})
+    # A forward-unblessed generation reported by a node that is NOT the volume's
+    # anchor (the wake above anchored it to node-4) is the only genuine split-brain
+    # shape and quarantines: a second writer would have to hold the RWO attach that
+    # ADR embervm/011 fencing forbids. (A forward report from the ANCHOR node is
+    # instead adopted, see the adopt test below.)
+    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-9", generation: 2, generation_blessed: false})
     assert StatefulStore.quarantined?(ctx.store, "wl-a")
 
     # A quarantined volume's next wake must park (never place): destroy the live
-    # instance and rewake, which anchors to the volume's node and must refuse.
+    # instance and rewake, which must refuse.
     StatefulManager.destroy_instance(ctx.mgr, "wl-a")
     assert {:error, {:wake_failed, :volume_quarantined}} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
+  end
+
+  test "a forward-unblessed report from the volume's OWN anchor node is adopted, not quarantined, and does not park the next wake" do
+    ctx = start_stack()
+    stateful_workload(ctx, "wl-a")
+    stateful_node(ctx, "node-4")
+
+    assert {:ok, _} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
+    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") - 1 == 1
+
+    # node-4 holds the fenced attach. A generation it reports past the watermark is
+    # the single writer running ahead of a watermark that rewound (e.g. a CP roll),
+    # not split-brain: adopt it (advance the watermark, no quarantine) rather than
+    # deadlock the workload. This is ADR embervm/014's node-authoritative
+    # reconciliation applied to the R7 blessing watermark.
+    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 3, generation_blessed: false})
+    refute StatefulStore.quarantined?(ctx.store, "wl-a")
+    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") == 4
+
+    # The next wake proceeds (the deadlock is gone): destroy the live instance and
+    # rewake, which must NOT refuse with :volume_quarantined.
+    StatefulManager.destroy_instance(ctx.mgr, "wl-a")
+    assert {:ok, _} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
   end
 
   test "a node report that agrees with the last blessed generation (or reports generation_blessed=true) never quarantines" do
@@ -289,10 +314,11 @@ defmodule Embervm.StatefulManagerTest do
     refute StatefulStore.quarantined?(ctx.store, "wl-a")
 
     # A report claiming the reported generation IS blessed clears any prior
-    # quarantine.
-    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 2, generation_blessed: false})
+    # quarantine. Quarantine here is induced from a NON-anchor node (node-9); a
+    # forward jump from the node-4 anchor would be adopted, not quarantined.
+    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-9", generation: 2, generation_blessed: false})
     assert StatefulStore.quarantined?(ctx.store, "wl-a")
-    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 2, generation_blessed: true})
+    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-9", generation: 2, generation_blessed: true})
     refute StatefulStore.quarantined?(ctx.store, "wl-a")
   end
 
@@ -319,7 +345,8 @@ defmodule Embervm.StatefulManagerTest do
     stateful_node(ctx, "node-4")
 
     assert {:ok, _} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
-    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 2, generation_blessed: false})
+    # Quarantine from a NON-anchor node (a node-4-anchor forward report is adopted).
+    StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-9", generation: 2, generation_blessed: false})
     assert StatefulStore.quarantined?(ctx.store, "wl-a")
 
     refute Embervm.StatefulSweeper.export_allowed?(ctx.store, "wl-a")

--- a/projects/embervm/control/test/embervm/stateful_store_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_store_test.exs
@@ -570,6 +570,54 @@ defmodule Embervm.StatefulStoreTest do
     refute StatefulStore.quarantined?(store, "wl-a")
   end
 
+  test "upsert_volume ADOPTS an unblessed forward jump from the volume's own anchor node instead of quarantining",
+       %{path: path} do
+    {_op_log, store} = start_pair(path)
+    {:ok, _} = StatefulStore.create_volume(store, "wl-a", %{node_id: "node-4", generation: 3})
+    {:ok, _} = StatefulStore.bless_generation(store, "wl-a", 3)
+
+    # node-4 is the volume's anchor (it holds the RWO attach). A forward jump it
+    # reports is the fenced single writer running ahead of the watermark, not a
+    # split-brain: adopt it rather than quarantine (which would deadlock the wake).
+    StatefulStore.upsert_volume(store, "wl-a", %{node_id: "node-4", generation: 5, generation_blessed: false})
+    refute StatefulStore.quarantined?(store, "wl-a")
+    # The watermark advanced to the adopted generation, so the next wake blesses past it.
+    assert StatefulStore.next_blessed_generation(store, "wl-a") == 6
+  end
+
+  test "upsert_volume STAYS fail-closed on an unblessed forward jump reported by a node that is NOT the anchor",
+       %{path: path} do
+    {_op_log, store} = start_pair(path)
+    {:ok, _} = StatefulStore.create_volume(store, "wl-a", %{node_id: "node-4", generation: 3})
+    {:ok, _} = StatefulStore.bless_generation(store, "wl-a", 3)
+
+    # A DIFFERENT node than the anchor claiming a forward generation is the only
+    # genuine split-brain shape: quarantine (the watermark must not adopt it).
+    StatefulStore.upsert_volume(store, "wl-a", %{node_id: "node-9", generation: 5, generation_blessed: false})
+    assert StatefulStore.quarantined?(store, "wl-a")
+    assert StatefulStore.next_blessed_generation(store, "wl-a") == 4
+  end
+
+  test "a CP roll that rewinds the watermark below the anchor's on-disk generation self-heals via adoption, not a permanent quarantine",
+       %{path: path} do
+    {op_log, store} = start_pair(path)
+    # The volume exists on node-4 and was durably blessed up to generation 3.
+    {:ok, _} = StatefulStore.create_volume(store, "wl-a", %{node_id: "node-4", generation: 3})
+    {:ok, _} = StatefulStore.bless_generation(store, "wl-a", 3)
+
+    # A control-plane roll: rebuild the store from the same op-log. The blessing
+    # watermark replays to the last DURABLE value (3), but node-4's on-disk volume
+    # generation has since advanced to 5 (bumped locally on attach, never blessed).
+    {:ok, store2} = StatefulStore.start_link(op_log: op_log, name: nil, clock: sequential_clock())
+    assert StatefulStore.next_blessed_generation(store2, "wl-a") == 4
+
+    # The first post-roll node report used to quarantine forever (the workload can
+    # never wake to re-bless). It now adopts and recovers on its own.
+    StatefulStore.upsert_volume(store2, "wl-a", %{node_id: "node-4", generation: 5, generation_blessed: false})
+    refute StatefulStore.quarantined?(store2, "wl-a")
+    assert StatefulStore.next_blessed_generation(store2, "wl-a") == 6
+  end
+
   test "a never-blessed volume (blessed_generation nil) never quarantines from a report alone", %{path: path} do
     {_op_log, store} = start_pair(path)
     {:ok, _} = StatefulStore.create_volume(store, "wl-a", %{node_id: "node-4", generation: 5})

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.201
+      targetRevision: 0.1.203
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## What

A stateful volume (`demo-postgres`) was stuck in a permanent quarantine loop after a control-plane roll, returning **503** on every wake attempt (~1/10s). Root cause: the blessing watermark and the node's on-disk volume generation drift.

- The op-log replay on a CP roll lands `blessed_generation` at the last *durably-blessed* value.
- The node bumps its on-disk volume generation locally on **every** writable attach, so a roll can leave `blessed < reported` for a volume that has exactly **one** writer.
- The quarantine guard reads `reported_gen > blessed AND generation_blessed:false` as a possible split-brain and fails closed. But a quarantined volume can never wake to re-bless, so it **never recovers** on its own.

Confirmed live: node-4 reported `demo-postgres` at generation `546`, CP watermark `544`, `0 live / 0 banked` instances (provably no second writer). Cleared in prod by blessing to 546; this PR stops it recurring.

## Fix

Under ADR embervm/011 Longhorn RWO fencing there is exactly one writer per volume: its anchor node. When that **same** node reports a generation past the watermark, it's watermark lag, not split-brain, so **adopt** it (advance the watermark, clear quarantine) per ADR embervm/014's node-authoritative reconciliation. Only a forward jump reported by a **different** node than the anchor stays fail-closed.

Adoption is ETS-only, symmetric with the existing non-durable `quarantined` flag; the next wake blesses past it durably, and any later roll simply re-adopts from the node report.

## Tests

- adopt on same-anchor forward-unblessed report (watermark advances, quarantine clears)
- stay fail-closed on a different-node forward-unblessed report
- full CP-roll repro: rebuild store from op-log (watermark rewinds to 3), node reports 5 from the anchor, self-heals instead of deadlocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)