### PR TITLE
feat(embervm): pre-provision serving taps at brick boot (ADR 014 PR 4)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.205
+version: 0.1.206

--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -168,6 +168,11 @@ containers:
         value: {{ printf "http://%s.%s.svc:%v" (include "embervm.fullname" $ctx) $ctx.Release.Namespace $ctx.Values.service.port | quote }}
       - name: EMBERVM_NODED_MAX_LIVE_VMS
         value: {{ $ctx.Values.noded.maxLiveVMs | quote }}
+      # Serving tap pre-provisioning (ADR embervm/014 decision 4). Zero (default)
+      # disables it; the daemon clamps a positive value to its own cgroup-derived
+      # slot ceiling regardless of what is configured here (server.go SlotCeiling).
+      - name: EMBERVM_NODED_TAP_PREALLOC
+        value: {{ $ctx.Values.noded.tapPrealloc | quote }}
       # R5 composite-group supernet: noded carves a /24 per group out of this
       # supernet and VALIDATES each control-plane-assigned group cidr is a /24
       # wholly within it. Distinct from the serving 172.31/12 tap space so the

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -794,6 +794,16 @@ noded:
   # real concurrency; this only stops a runaway from exhausting the node.
   maxLiveVMs: 8
 
+  # Serving tap pre-provisioning (ADR embervm/014 decision 4): the number of serving
+  # taps EnsureNetwork pre-creates at brick boot, left down until AllocateTap draws
+  # one, so instance boot skips netlink create/attach work. Zero (the default)
+  # disables pre-provisioning: taps are created/deleted on demand exactly as before
+  # this feature existed. A positive value is clamped at the daemon to the brick's
+  # cgroup-derived slot ceiling (server.Server.SlotCeiling), so pre-creating more
+  # taps than the brick could ever host is not possible even if this is set too
+  # high. Not yet flipped fleet-wide; canary one brick class first (Task 4.2).
+  tapPrealloc: 0
+
   # R5 composite-group supernet: noded carves a per-group /24 out of this supernet
   # for each composite-workload group and VALIDATES the control-plane-assigned group
   # cidr is a /24 wholly within it (and non-overlapping with an existing group

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.205
+      targetRevision: 0.1.206
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/cmd/main.go
+++ b/projects/embervm/noded/cmd/main.go
@@ -102,7 +102,9 @@ func run(logger *slog.Logger) error {
 	// loudly. The same restore driver serves the serving driver mechanics: it gains a
 	// cold-boot-with-NIC ClaimServing plus SnapshotServing/RestoreServing under the
 	// serving/ prefix, and its live map counts serving VMs against the node cap.
-	servingNet, err := serving.NewManager(serving.ExecRunner{}, cfg.ServingBridge, cfg.ServingSubnetCIDR, cfg.PodIP, cfg.ServingPortBase)
+	// cfg.TapPrealloc (ADR embervm/014 decision 4) is clamped to the brick's slot
+	// ceiling below, once server.New has built the budget reader that ceiling reads.
+	servingNet, err := serving.NewManager(serving.ExecRunner{}, cfg.ServingBridge, cfg.ServingSubnetCIDR, cfg.PodIP, cfg.ServingPortBase, cfg.TapPrealloc)
 	if err != nil {
 		return err
 	}
@@ -180,6 +182,10 @@ func run(logger *slog.Logger) error {
 		opts.Store = artStore
 	}
 	srv := server.New(opts)
+	// Cap the tap-prealloc pool (ADR embervm/014 decision 4) at the brick's
+	// cgroup-derived slot ceiling: pre-creating more taps than the brick could ever
+	// host wastes boot-time netlink work. Must run before EnsureNetwork below.
+	servingNet.ClampTapPrealloc(srv.SlotCeiling())
 	// Report node-local base snapshots left by a prior incarnation so the control
 	// plane reconciles rather than rebuilding.
 	srv.ReconcileBasesFromDisk()

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -238,6 +238,16 @@ type Config struct {
 	// re-pointed pod IP propagates. Default 30s. Env EMBERVM_NODED_REGISTER_INTERVAL.
 	RegisterInterval time.Duration
 
+	// TapPrealloc is the number of serving taps EnsureNetwork pre-creates at brick
+	// boot (ADR embervm/014 decision 4), left down until AllocateTap draws one:
+	// pre-provisioning removes netlink create/attach work from the instance boot
+	// path. Zero (the default) disables pre-provisioning; AllocateTap/ReleaseTap
+	// fall back to today's create-on-demand/delete-on-release behaviour. The
+	// daemon entrypoint clamps a positive value to the brick's slot ceiling
+	// (server.Server.SlotCeiling): pre-creating more taps than a brick could ever
+	// host wastes boot-time setup. Env EMBERVM_NODED_TAP_PREALLOC.
+	TapPrealloc int
+
 	// ServingPortBase is the base of the deterministic per-VM DNAT port space:
 	// vmPort = ServingPortBase + hostOffset(tapIP). A /24 yields ports base+2..base+254,
 	// clear of noded's own 8080/9090. Default 30000. NewManager rejects a base that
@@ -349,6 +359,7 @@ func Load() (Config, error) {
 		ControlPlaneTokenPath: getenvDefault("EMBERVM_NODED_CONTROL_PLANE_TOKEN_PATH", "/var/run/secrets/kubernetes.io/serviceaccount/token"),
 		RegisterInterval:      30 * time.Second,
 
+		TapPrealloc:               atoiDefault("EMBERVM_NODED_TAP_PREALLOC", 0),
 		ServingPortBase:           atoiDefault("EMBERVM_NODED_SERVING_PORT_BASE", 30000),
 		ServingBridge:             getenvDefault("EMBERVM_NODED_SERVING_BRIDGE", "embervm-serv0"),
 		ServingSubnetCIDR:         getenvDefault("EMBERVM_NODED_SERVING_SUBNET_CIDR", "172.31.0.0/24"),

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1572,6 +1572,19 @@ func (s *Server) RegistrySynced() bool {
 	return s.registry.isSynced()
 }
 
+// SlotCeiling returns the brick's cgroup-derived live-VM slot ceiling (ADR
+// embervm/013 section 7), the same value nodeStatus reports as MaxLiveVms. The
+// daemon entrypoint uses it to size the ADR embervm/014 decision-4 tap prealloc
+// pool by default: pre-creating more taps than a brick could ever host is wasted
+// setup work, so the pool is capped at this ceiling.
+func (s *Server) SlotCeiling() int {
+	maxLive := s.cfg.MaxLiveVMs
+	if maxLive < 0 {
+		maxLive = 0
+	}
+	return int(s.slotCeiling(uint64(maxLive)))
+}
+
 // ---- Node status -----------------------------------------------------------
 
 // GetNodeStatus is the unary snapshot of the capacity facts WatchNode streams.

--- a/projects/embervm/noded/serving/net.go
+++ b/projects/embervm/noded/serving/net.go
@@ -96,6 +96,22 @@ func tapSetupArgs(tap, bridge string) [][]string {
 	}
 }
 
+// tapPrecreateArgs is tapSetupArgs' pre-provisioning sibling: it creates a tap and
+// attaches it to the bridge but leaves it DOWN, since a pre-created pool tap sits
+// idle until AllocateTap draws it and brings it up. Pure for table testing.
+func tapPrecreateArgs(tap, bridge string) [][]string {
+	return [][]string{
+		{"ip", "tuntap", "add", "dev", tap, "mode", "tap"},
+		{"ip", "link", "set", tap, "master", bridge},
+	}
+}
+
+// tapUpArgs and tapDownArgs bring a pre-created pool tap up (on AllocateTap draw)
+// or down (on ReleaseTap return), without creating or deleting the device. Pure for
+// table testing.
+func tapUpArgs(tap string) []string   { return []string{"ip", "link", "set", tap, "up"} }
+func tapDownArgs(tap string) []string { return []string{"ip", "link", "set", tap, "down"} }
+
 // tapTeardownArgs returns the argv to delete a tap device. Deleting the tap detaches
 // it from the bridge implicitly. Pure for table testing.
 func tapTeardownArgs(tap string) []string {
@@ -234,16 +250,30 @@ type Manager struct {
 	// calls cannot interleave ruleset writes.
 	dnatMu sync.Mutex
 	dnat   map[string]dnatEntry
+
+	// tapPrealloc is the number of taps EnsureNetwork pre-creates at brick boot
+	// (ADR embervm/014 decision 4). Zero disables pre-provisioning: AllocateTap/
+	// ReleaseTap fall back to today's create-on-demand/delete-on-release behaviour.
+	tapPrealloc int
+	// poolMu guards pool, which is idle pre-created IPs available for AllocateTap
+	// to draw. An IP leaves pool while its tap is checked out (link up, DNAT wired)
+	// and returns to it on ReleaseTap (link down, DNAT removed); it is never
+	// released back to the allocator, since the tap device persists for the IP's
+	// whole pre-provisioned lifetime, up or down.
+	poolMu sync.Mutex
+	pool   []net.IP
 }
 
 // NewManager builds a serving network Manager for a bridge name and a CIDR. The
 // gateway (bridge) IP is the first usable address (.1) of the CIDR; VM IPs are
 // allocated from .2 upward. podIP is noded's routable pod IP for the DNAT projection
-// (empty disables DNAT and reports tap IPs); portBase is the DNAT port-space base. A
-// malformed CIDR, or (when podIP is set) a portBase whose top offset would overflow
-// 65535, is an error so a misconfiguration fails loudly at startup rather than at the
-// first StartServing.
-func NewManager(runner Runner, bridge, cidr, podIP string, portBase int) (*Manager, error) {
+// (empty disables DNAT and reports tap IPs); portBase is the DNAT port-space base.
+// tapPrealloc is the ADR embervm/014 decision-4 pool size EnsureNetwork pre-creates
+// at boot (0 disables pre-provisioning; see AllocateTap/ReleaseTap). A malformed
+// CIDR, or (when podIP is set) a portBase whose top offset would overflow 65535, is
+// an error so a misconfiguration fails loudly at startup rather than at the first
+// StartServing.
+func NewManager(runner Runner, bridge, cidr, podIP string, portBase, tapPrealloc int) (*Manager, error) {
 	if runner == nil {
 		runner = ExecRunner{}
 	}
@@ -262,16 +292,20 @@ func NewManager(runner Runner, bridge, cidr, podIP string, portBase int) (*Manag
 			return nil, fmt.Errorf("serving: port base %d + subnet %s top offset overflows 65535 (max derived port %d)", portBase, cidr, maxPort)
 		}
 	}
+	if tapPrealloc < 0 {
+		return nil, fmt.Errorf("serving: tap prealloc %d must be >= 0", tapPrealloc)
+	}
 	return &Manager{
-		runner:    runner,
-		bridge:    bridge,
-		cidr:      ipnet,
-		gatewayIP: gatewayIP,
-		prefixLen: prefixLen,
-		alloc:     newIPAllocator(ipnet, gatewayIP),
-		podIP:     podIP,
-		portBase:  portBase,
-		dnat:      make(map[string]dnatEntry),
+		runner:      runner,
+		bridge:      bridge,
+		cidr:        ipnet,
+		gatewayIP:   gatewayIP,
+		prefixLen:   prefixLen,
+		alloc:       newIPAllocator(ipnet, gatewayIP),
+		podIP:       podIP,
+		portBase:    portBase,
+		dnat:        make(map[string]dnatEntry),
+		tapPrealloc: tapPrealloc,
 	}, nil
 }
 
@@ -283,10 +317,25 @@ func (m *Manager) CIDR() string {
 	return m.cidr.String()
 }
 
-// EnsureNetwork creates the bridge (idempotently) and installs the serving forward
-// nftables posture (drop VM-originated NEW forwarding; see nftRuleset). It is called
-// once on daemon start before any serving VM is brought up. Bridge-create batches that
-// fail because the device already exists are
+// ClampTapPrealloc lowers the configured tap-prealloc count to ceiling when it
+// exceeds it, a no-op otherwise. It must be called before EnsureNetwork. The
+// daemon entrypoint uses it to cap the pool at the brick's cgroup-derived slot
+// ceiling (server.Server.SlotCeiling, ADR embervm/013 section 7): that ceiling is
+// only known once server.New has built the budget reader, which happens after this
+// Manager is constructed, so the clamp is applied as a separate step rather than a
+// NewManager argument.
+func (m *Manager) ClampTapPrealloc(ceiling int) {
+	if ceiling >= 0 && m.tapPrealloc > ceiling {
+		m.tapPrealloc = ceiling
+	}
+}
+
+// EnsureNetwork creates the bridge (idempotently), installs the serving forward
+// nftables posture (drop VM-originated NEW forwarding; see nftRuleset), and, when
+// tapPrealloc > 0, pre-creates that many taps left DOWN in the pool (ADR
+// embervm/014 decision 4: pre-provisioning removes netlink work from the instance
+// boot path). It is called once on daemon start before any serving VM is brought
+// up. Bridge-create batches that fail because the device already exists are
 // tolerated (a daemon restart re-enters here with the bridge already present); the
 // nftables apply is inherently idempotent (flush-then-define of our own table).
 func (m *Manager) EnsureNetwork(ctx context.Context) error {
@@ -304,11 +353,45 @@ func (m *Manager) EnsureNetwork(ctx context.Context) error {
 	if _, err := m.runner.Run(ctx, "sysctl", "-w", "net.ipv4.ip_forward=1"); err != nil {
 		return err
 	}
+	if err := m.precreatePool(ctx); err != nil {
+		return err
+	}
 	// Apply the ruleset from the CURRENT (boot: empty) DNAT map. Post-boot, EnsureDNAT/
 	// RemoveDNAT regenerate the same table including the forward posture.
 	m.dnatMu.Lock()
 	defer m.dnatMu.Unlock()
 	return m.applyRulesetLocked(ctx)
+}
+
+// precreatePool pre-creates m.tapPrealloc taps (a no-op when it is 0) using the
+// same deterministic TapNameForIP naming AllocateTap uses on-demand, over IPs drawn
+// from the allocator's usable range. Each tap is created and attached to the bridge
+// but left DOWN (see tapPrecreateArgs); del-before-add is retained per tap, exactly
+// the #3745 stale-tap repair AllocateTap already relies on, since a daemon restart
+// re-enters here with the prior incarnation's pool taps still attached. A failure
+// mid-precreate rolls back only the failed tap's reservation; taps already pooled
+// stay pooled (a partially pre-provisioned pool degrades to more on-demand
+// allocation, not a boot failure).
+func (m *Manager) precreatePool(ctx context.Context) error {
+	for i := 0; i < m.tapPrealloc; i++ {
+		ip, err := m.alloc.allocate()
+		if err != nil {
+			return fmt.Errorf("serving: pre-provisioning tap %d/%d: %w", i+1, m.tapPrealloc, err)
+		}
+		tap := TapNameForIP(ip)
+		_, _ = m.runner.Run(ctx, "ip", tapTeardownArgs(tap)[1:]...)
+		for _, argv := range tapPrecreateArgs(tap, m.bridge) {
+			if _, rerr := m.runner.Run(ctx, argv[0], argv[1:]...); rerr != nil {
+				_, _ = m.runner.Run(ctx, "ip", tapTeardownArgs(tap)[1:]...)
+				m.alloc.release(ip)
+				return fmt.Errorf("serving: pre-provisioning tap %s: %w", tap, rerr)
+			}
+		}
+		m.poolMu.Lock()
+		m.pool = append(m.pool, ip)
+		m.poolMu.Unlock()
+	}
+	return nil
 }
 
 // applyRulesetLocked regenerates the whole serving ruleset from the current DNAT map
@@ -378,11 +461,25 @@ func (m *Manager) Endpoint(ip net.IP, guestPort uint32) (string, uint32) {
 	return m.podIP, vmPort
 }
 
-// AllocateTap allocates the next free IP, creates and attaches a tap named for that
-// IP, and returns (tapName, ip). On any ip failure the partially-created tap and the
+// AllocateTap draws a pre-created pool tap when one is idle (ADR embervm/014
+// decision 4: bring the link up, no netlink create/attach on the instance boot
+// path), falling back to allocating the next free IP and creating a fresh tap when
+// the pool is empty or disabled (tapPrealloc == 0), exactly today's behaviour. It
+// returns (tapName, ip); on any ip failure the partially-created tap and the
 // reserved IP are rolled back so a failed StartServing leaks neither. The returned
 // tap name is deterministic from the IP so teardown needs only the IP.
 func (m *Manager) AllocateTap(ctx context.Context) (tap string, ip net.IP, err error) {
+	if pooled, ok := m.popPool(); ok {
+		tap = TapNameForIP(pooled)
+		if _, rerr := m.runner.Run(ctx, "ip", tapUpArgs(tap)...); rerr != nil {
+			// Bringing an already-attached tap up failed: put it back rather than leak
+			// it out of the pool, then fall through to on-demand creation below so the
+			// caller still gets a usable tap.
+			m.pushPool(pooled)
+		} else {
+			return tap, pooled, nil
+		}
+	}
 	ip, err = m.alloc.allocate()
 	if err != nil {
 		return "", nil, err
@@ -414,9 +511,21 @@ func (m *Manager) AllocateTap(ctx context.Context) (tap string, ip net.IP, err e
 // the guest's eth0 keeps the IP baked at fresh boot (a snapshot resume never re-runs
 // kernel init), so a different IP would black-hole traffic. The IP must be free in the
 // allocator (it will be after a bank released it, or after a restart rescan re-reserved
-// nothing); a conflict is an error the caller maps to FAILED_PRECONDITION.
+// nothing); a conflict is an error the caller maps to FAILED_PRECONDITION. When ip is
+// currently idle in the prealloc pool (already reserved in the allocator by
+// precreatePool, ADR embervm/014 decision 4), it is drawn out of the pool instead of
+// re-reserved, since the allocator already holds it for that tap's whole
+// pre-provisioned lifetime; if bringing the pool tap up fails, the on-demand path
+// below still runs against the freshly-reserved IP.
 func (m *Manager) AllocateTapForIP(ctx context.Context, ip net.IP) (tap string, err error) {
-	if err = m.alloc.reserve(ip); err != nil {
+	if m.popPoolIP(ip) {
+		tap = TapNameForIP(ip)
+		if _, rerr := m.runner.Run(ctx, "ip", tapUpArgs(tap)...); rerr == nil {
+			return tap, nil
+		}
+		// Bringing the pool tap up failed: fall through to the on-demand path, which
+		// re-does the full create+attach+up over an IP the allocator already reserved.
+	} else if err = m.alloc.reserve(ip); err != nil {
 		return "", err
 	}
 	tap = TapNameForIP(ip)
@@ -436,20 +545,71 @@ func (m *Manager) AllocateTapForIP(ctx context.Context, ip net.IP) (tap string, 
 	return tap, nil
 }
 
-// ReleaseTap deletes the tap for an IP and releases the IP back to the allocator. It
-// is idempotent at the ip layer (deleting an absent tap is tolerated) so a teardown
-// after a partial start still frees the IP.
+// ReleaseTap returns a VM's tap. When tapPrealloc is enabled AND the IP was drawn
+// from the pool (a pre-created tap, ADR embervm/014 decision 4), the tap is brought
+// down and returned to the pool instead of deleted, so a later AllocateTap can reuse
+// it without netlink create/attach work; the IP stays reserved in the allocator the
+// whole time (the tap device persists for it, up or down). Otherwise (prealloc
+// disabled, or the tap was created on-demand because the pool was exhausted) it is
+// today's behaviour: delete the tap and free the IP back to the allocator. Either
+// way this is idempotent at the ip layer (deleting/downing an absent tap is
+// tolerated) so a teardown after a partial start still frees the IP.
 func (m *Manager) ReleaseTap(ctx context.Context, ip net.IP) {
 	// Drop the VM's DNAT rule first so the kernel stops advertising the endpoint before
-	// the tap disappears (no-op when DNAT is disabled).
+	// the tap goes down or disappears (no-op when DNAT is disabled).
 	m.RemoveDNAT(ctx, ip)
 	tap := TapNameForIP(ip)
+	if m.tapPrealloc > 0 {
+		if _, err := m.runner.Run(ctx, "ip", tapDownArgs(tap)...); err != nil {
+			_ = err // best-effort: the tap stays attached (possibly still up) rather than wedging release
+		}
+		m.pushPool(ip)
+		return
+	}
 	if _, err := m.runner.Run(ctx, "ip", tapTeardownArgs(tap)[1:]...); err != nil {
 		// A missing tap is fine (already gone); other errors are logged by the caller
 		// via the returned nothing, so swallow here to keep teardown best-effort.
 		_ = err
 	}
 	m.alloc.release(ip)
+}
+
+// popPool removes and returns the lowest-IP idle pool entry, or (nil, false) when
+// the pool is empty or disabled. FIFO (pool is built in ascending IP order by
+// precreatePool and refilled at the tail by pushPool), matching the allocator's own
+// lowest-free convention so pool draws are deterministic and easy to reason about.
+func (m *Manager) popPool() (net.IP, bool) {
+	m.poolMu.Lock()
+	defer m.poolMu.Unlock()
+	if len(m.pool) == 0 {
+		return nil, false
+	}
+	ip := m.pool[0]
+	m.pool = m.pool[1:]
+	return ip, true
+}
+
+// pushPool returns an IP to the idle pool.
+func (m *Manager) pushPool(ip net.IP) {
+	m.poolMu.Lock()
+	m.pool = append(m.pool, ip)
+	m.poolMu.Unlock()
+}
+
+// popPoolIP removes a SPECIFIC IP from the idle pool if present, reporting whether
+// it was found. Used by AllocateTapForIP: a relight pin may name an IP that happens
+// to be sitting idle in the prealloc pool, in which case it must be drawn out (not
+// re-reserved; precreatePool already holds it in the allocator).
+func (m *Manager) popPoolIP(ip net.IP) bool {
+	m.poolMu.Lock()
+	defer m.poolMu.Unlock()
+	for i, pooled := range m.pool {
+		if pooled.Equal(ip) {
+			m.pool = append(m.pool[:i], m.pool[i+1:]...)
+			return true
+		}
+	}
+	return false
 }
 
 // GatewayIP is the bridge IP a guest uses as its default route.

--- a/projects/embervm/noded/serving/net.go
+++ b/projects/embervm/noded/serving/net.go
@@ -255,13 +255,20 @@ type Manager struct {
 	// (ADR embervm/014 decision 4). Zero disables pre-provisioning: AllocateTap/
 	// ReleaseTap fall back to today's create-on-demand/delete-on-release behaviour.
 	tapPrealloc int
-	// poolMu guards pool, which is idle pre-created IPs available for AllocateTap
-	// to draw. An IP leaves pool while its tap is checked out (link up, DNAT wired)
-	// and returns to it on ReleaseTap (link down, DNAT removed); it is never
-	// released back to the allocator, since the tap device persists for the IP's
-	// whole pre-provisioned lifetime, up or down.
-	poolMu sync.Mutex
-	pool   []net.IP
+	// poolMu guards pool (idle pre-created IPs available for AllocateTap to draw)
+	// and poolOrigin (every IP precreatePool ever gave a pool identity, whether
+	// currently idle in pool or checked out). An IP leaves pool while its tap is
+	// checked out (link up, DNAT wired) and returns to it on ReleaseTap (link down,
+	// DNAT removed) WHEN that IP is a pool-origin IP; it is never released back to
+	// the allocator, since the tap device persists for the IP's whole
+	// pre-provisioned lifetime. A fallback IP that AllocateTap created on demand
+	// (pool empty or disabled) is NOT pool-origin: ReleaseTap deletes it and frees
+	// the allocator reservation exactly as it always has, so the idle pool never
+	// grows past tapPrealloc entries and the allocator never accumulates
+	// reservations above the slot ceiling.
+	poolMu     sync.Mutex
+	pool       []net.IP
+	poolOrigin map[string]struct{}
 }
 
 // NewManager builds a serving network Manager for a bridge name and a CIDR. The
@@ -306,6 +313,7 @@ func NewManager(runner Runner, bridge, cidr, podIP string, portBase, tapPrealloc
 		portBase:    portBase,
 		dnat:        make(map[string]dnatEntry),
 		tapPrealloc: tapPrealloc,
+		poolOrigin:  make(map[string]struct{}),
 	}, nil
 }
 
@@ -323,7 +331,11 @@ func (m *Manager) CIDR() string {
 // ceiling (server.Server.SlotCeiling, ADR embervm/013 section 7): that ceiling is
 // only known once server.New has built the budget reader, which happens after this
 // Manager is constructed, so the clamp is applied as a separate step rather than a
-// NewManager argument.
+// NewManager argument. A ceiling of 0 (MaxLiveVMs configured to 0 AND the cgroup
+// memory budget unreadable/unlimited, the one combination server.Server.SlotCeiling
+// can return 0 for, see budget.SlotCeiling) disables pre-provisioning entirely
+// rather than erroring: fails safe to today's create-on-demand behaviour instead of
+// wedging a brick whose capacity cannot be observed.
 func (m *Manager) ClampTapPrealloc(ceiling int) {
 	if ceiling >= 0 && m.tapPrealloc > ceiling {
 		m.tapPrealloc = ceiling
@@ -363,32 +375,45 @@ func (m *Manager) EnsureNetwork(ctx context.Context) error {
 	return m.applyRulesetLocked(ctx)
 }
 
-// precreatePool pre-creates m.tapPrealloc taps (a no-op when it is 0) using the
-// same deterministic TapNameForIP naming AllocateTap uses on-demand, over IPs drawn
-// from the allocator's usable range. Each tap is created and attached to the bridge
-// but left DOWN (see tapPrecreateArgs); del-before-add is retained per tap, exactly
-// the #3745 stale-tap repair AllocateTap already relies on, since a daemon restart
-// re-enters here with the prior incarnation's pool taps still attached. A failure
-// mid-precreate rolls back only the failed tap's reservation; taps already pooled
-// stay pooled (a partially pre-provisioned pool degrades to more on-demand
-// allocation, not a boot failure).
+// precreatePool pre-creates up to m.tapPrealloc taps (a no-op when it is 0) using
+// the same deterministic TapNameForIP naming AllocateTap uses on-demand, over IPs
+// drawn from the allocator's usable range. Each tap is created and attached to the
+// bridge but left DOWN (see tapPrecreateArgs); del-before-add is retained per tap,
+// exactly the #3745 stale-tap repair AllocateTap already relies on, since a daemon
+// restart re-enters here with the prior incarnation's pool taps still attached.
+//
+// A single tap's precreate is best-effort: a transient ip failure (e.g. an EBUSY
+// racing a prior incarnation's teardown) rolls back that one IP's reservation and
+// CONTINUES to the next slot rather than returning an error. AllocateTap's
+// on-demand fallback covers a pool that ends up short, so a brief netlink hiccup at
+// boot degrading to a smaller (or empty) pool is the intended behaviour, never a
+// reason to fail EnsureNetwork and crash-loop the brick.
 func (m *Manager) precreatePool(ctx context.Context) error {
 	for i := 0; i < m.tapPrealloc; i++ {
 		ip, err := m.alloc.allocate()
 		if err != nil {
+			// Subnet exhausted (tapPrealloc configured larger than the CIDR can hold):
+			// nothing further to try, same as an EnsureNetwork-fatal misconfiguration
+			// elsewhere in this function (bad CIDR, sysctl failure).
 			return fmt.Errorf("serving: pre-provisioning tap %d/%d: %w", i+1, m.tapPrealloc, err)
 		}
 		tap := TapNameForIP(ip)
 		_, _ = m.runner.Run(ctx, "ip", tapTeardownArgs(tap)[1:]...)
+		failed := false
 		for _, argv := range tapPrecreateArgs(tap, m.bridge) {
 			if _, rerr := m.runner.Run(ctx, argv[0], argv[1:]...); rerr != nil {
 				_, _ = m.runner.Run(ctx, "ip", tapTeardownArgs(tap)[1:]...)
 				m.alloc.release(ip)
-				return fmt.Errorf("serving: pre-provisioning tap %s: %w", tap, rerr)
+				failed = true
+				break
 			}
+		}
+		if failed {
+			continue
 		}
 		m.poolMu.Lock()
 		m.pool = append(m.pool, ip)
+		m.poolOrigin[ip.String()] = struct{}{}
 		m.poolMu.Unlock()
 	}
 	return nil
@@ -471,7 +496,7 @@ func (m *Manager) Endpoint(ip net.IP, guestPort uint32) (string, uint32) {
 func (m *Manager) AllocateTap(ctx context.Context) (tap string, ip net.IP, err error) {
 	if pooled, ok := m.popPool(); ok {
 		tap = TapNameForIP(pooled)
-		if _, rerr := m.runner.Run(ctx, "ip", tapUpArgs(tap)...); rerr != nil {
+		if _, rerr := m.runner.Run(ctx, "ip", tapUpArgs(tap)[1:]...); rerr != nil {
 			// Bringing an already-attached tap up failed: put it back rather than leak
 			// it out of the pool, then fall through to on-demand creation below so the
 			// caller still gets a usable tap.
@@ -520,7 +545,7 @@ func (m *Manager) AllocateTap(ctx context.Context) (tap string, ip net.IP, err e
 func (m *Manager) AllocateTapForIP(ctx context.Context, ip net.IP) (tap string, err error) {
 	if m.popPoolIP(ip) {
 		tap = TapNameForIP(ip)
-		if _, rerr := m.runner.Run(ctx, "ip", tapUpArgs(tap)...); rerr == nil {
+		if _, rerr := m.runner.Run(ctx, "ip", tapUpArgs(tap)[1:]...); rerr == nil {
 			return tap, nil
 		}
 		// Bringing the pool tap up failed: fall through to the on-demand path, which
@@ -545,22 +570,27 @@ func (m *Manager) AllocateTapForIP(ctx context.Context, ip net.IP) (tap string, 
 	return tap, nil
 }
 
-// ReleaseTap returns a VM's tap. When tapPrealloc is enabled AND the IP was drawn
-// from the pool (a pre-created tap, ADR embervm/014 decision 4), the tap is brought
-// down and returned to the pool instead of deleted, so a later AllocateTap can reuse
-// it without netlink create/attach work; the IP stays reserved in the allocator the
-// whole time (the tap device persists for it, up or down). Otherwise (prealloc
-// disabled, or the tap was created on-demand because the pool was exhausted) it is
-// today's behaviour: delete the tap and free the IP back to the allocator. Either
-// way this is idempotent at the ip layer (deleting/downing an absent tap is
-// tolerated) so a teardown after a partial start still frees the IP.
+// ReleaseTap returns a VM's tap. When ip is POOL-ORIGIN (a tap precreatePool
+// pre-created, ADR embervm/014 decision 4, tracked in poolOrigin regardless of
+// whether tapPrealloc is still positive), the tap is brought down and returned to
+// the pool instead of deleted, so a later AllocateTap can reuse it without netlink
+// create/attach work; the IP stays reserved in the allocator the whole time (the
+// tap device persists for it, up or down). Otherwise (prealloc disabled, or this IP
+// was created ON DEMAND by AllocateTap's fallback because the pool was exhausted)
+// it is today's behaviour: delete the tap and free the IP back to the allocator.
+// This distinction (pool-origin, not "is prealloc currently on") matters: gating on
+// tapPrealloc > 0 alone would return every fallback-created IP to the pool too,
+// letting the idle pool ratchet up past tapPrealloc entries and the allocator
+// accumulate reservations above the brick's slot ceiling. Either way this is
+// idempotent at the ip layer (deleting/downing an absent tap is tolerated) so a
+// teardown after a partial start still frees the IP.
 func (m *Manager) ReleaseTap(ctx context.Context, ip net.IP) {
 	// Drop the VM's DNAT rule first so the kernel stops advertising the endpoint before
 	// the tap goes down or disappears (no-op when DNAT is disabled).
 	m.RemoveDNAT(ctx, ip)
 	tap := TapNameForIP(ip)
-	if m.tapPrealloc > 0 {
-		if _, err := m.runner.Run(ctx, "ip", tapDownArgs(tap)...); err != nil {
+	if m.isPoolOrigin(ip) {
+		if _, err := m.runner.Run(ctx, "ip", tapDownArgs(tap)[1:]...); err != nil {
 			_ = err // best-effort: the tap stays attached (possibly still up) rather than wedging release
 		}
 		m.pushPool(ip)
@@ -589,11 +619,31 @@ func (m *Manager) popPool() (net.IP, bool) {
 	return ip, true
 }
 
-// pushPool returns an IP to the idle pool.
+// pushPool returns an IP to the idle pool. It is a no-op if ip is already present
+// in pool, so a double ReleaseTap on the same IP (a caller bug, or a retried
+// teardown racing itself) cannot duplicate the entry and later hand the same tap to
+// two different VMs out of two AllocateTap calls. Mirrors the idempotence
+// alloc.release already has for the on-demand path this replaces.
 func (m *Manager) pushPool(ip net.IP) {
 	m.poolMu.Lock()
+	defer m.poolMu.Unlock()
+	for _, pooled := range m.pool {
+		if pooled.Equal(ip) {
+			return
+		}
+	}
 	m.pool = append(m.pool, ip)
-	m.poolMu.Unlock()
+}
+
+// isPoolOrigin reports whether ip was ever given a pool identity by precreatePool
+// (ADR embervm/014 decision 4), regardless of whether it is currently idle in pool
+// or checked out. ReleaseTap uses this (not "is tapPrealloc currently positive") to
+// decide whether an IP returns to the pool or is deleted/freed on release.
+func (m *Manager) isPoolOrigin(ip net.IP) bool {
+	m.poolMu.Lock()
+	defer m.poolMu.Unlock()
+	_, ok := m.poolOrigin[ip.String()]
+	return ok
 }
 
 // popPoolIP removes a SPECIFIC IP from the idle pool if present, reporting whether

--- a/projects/embervm/noded/serving/net_test.go
+++ b/projects/embervm/noded/serving/net_test.go
@@ -399,11 +399,21 @@ func TestAllocateTapDeletesStaleTapBeforeCreate(t *testing.T) {
 	})
 }
 
+// TestAllocateTapForIPPinsAndConflicts runs with tapPrealloc > 0 (a 1-tap pool
+// covering only .2) so the pin .7 is NOT pool-origin: AllocateTapForIP must take the
+// on-demand alloc.reserve() branch for it (exactly as with prealloc disabled), while
+// the separately pooled .2 stays untouched and available to a plain AllocateTap.
+// This asserts the pooled-pin-vs-allocator-conflict interaction: a relight pin
+// outside the pool must still conflict correctly against the allocator, and must
+// not accidentally consult or disturb the pool.
 func TestAllocateTapForIPPinsAndConflicts(t *testing.T) {
 	fr := &fakeRunner{}
-	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 0)
+	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 1)
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
+	}
+	if err := m.EnsureNetwork(context.Background()); err != nil {
+		t.Fatalf("EnsureNetwork: %v", err)
 	}
 	pin := net.ParseIP("172.31.0.7")
 	tap, err := m.AllocateTapForIP(context.Background(), pin)
@@ -413,18 +423,19 @@ func TestAllocateTapForIPPinsAndConflicts(t *testing.T) {
 	if tap != TapNameForIP(pin) {
 		t.Errorf("pinned tap name %q != %q", tap, TapNameForIP(pin))
 	}
-	// Re-pinning the same live IP conflicts (two live VMs cannot hold one IP).
+	// Re-pinning the same live IP conflicts (two live VMs cannot hold one IP), same
+	// as with prealloc disabled: the pin path outside the pool is untouched.
 	if _, err := m.AllocateTapForIP(context.Background(), pin); err == nil {
 		t.Error("AllocateTapForIP on an already-held IP should conflict")
 	}
-	// A fresh allocation must skip the pinned .7 (it is taken) but still return the
-	// lowest OTHER free address (.2).
+	// A plain AllocateTap must still draw the pooled .2 (untouched by the .7 pin),
+	// not skip to some fresh on-demand address.
 	_, ip, err := m.AllocateTap(context.Background())
 	if err != nil {
 		t.Fatalf("AllocateTap: %v", err)
 	}
 	if ip.String() != "172.31.0.2" {
-		t.Errorf("fresh alloc after pin = %s, want 172.31.0.2", ip)
+		t.Errorf("pool draw after unrelated pin = %s, want the pooled 172.31.0.2", ip)
 	}
 }
 
@@ -726,5 +737,188 @@ func TestAllocateTapForIPDrawsPooledPin(t *testing.T) {
 	}
 	if drawn.String() == pin.String() {
 		t.Errorf("pool still offered the pinned IP %s after AllocateTapForIP drew it", pin)
+	}
+}
+
+// argvFailer wraps a Runner and fails the FIRST call whose argv exactly matches
+// want, passing every other call straight through to inner. It exists because
+// fakeRunner.failOn only keys on the first two argv tokens ("name arg0"), too
+// coarse to fail one specific `ip link set <tap> up` or `ip tuntap add ...
+// <tap>` call among several without also breaking every other call that shares
+// those tokens (precreate's `ip link set <tap> master <bridge>` is also "ip
+// link", for instance).
+type argvFailer struct {
+	inner  *fakeRunner
+	want   []string
+	err    error
+	failed bool // fires only once, so a retry after the failure succeeds
+	fired  bool
+}
+
+func (f *argvFailer) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	call := append([]string{name}, args...)
+	if !f.failed && argvEqual(call, f.want) {
+		f.failed = true
+		f.fired = true
+		f.inner.calls = append(f.inner.calls, call)
+		return nil, f.err
+	}
+	return f.inner.Run(ctx, name, args...)
+}
+
+func argvEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestReleaseTapDeletesFallbackTapUnderPrealloc locks in the PR4-review fix: a tap
+// AllocateTap created ON DEMAND because the pool was exhausted is NOT pool-origin,
+// so releasing it (even with tapPrealloc > 0) must delete the tap and free the
+// allocator reservation exactly like the prealloc-disabled path, not return it to
+// the pool. Gating release on "tapPrealloc > 0" alone (the pre-fix behaviour) would
+// let the idle pool grow past tapPrealloc entries and the allocator accumulate
+// reservations above the brick's slot ceiling.
+func TestReleaseTapDeletesFallbackTapUnderPrealloc(t *testing.T) {
+	fr := &fakeRunner{}
+	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 1)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := m.EnsureNetwork(context.Background()); err != nil {
+		t.Fatalf("EnsureNetwork: %v", err)
+	}
+	// Drain the 1-tap pool, then force a second AllocateTap through the on-demand
+	// fallback path.
+	_, poolIP, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap (pool draw): %v", err)
+	}
+	_, fallbackIP, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap (fallback): %v", err)
+	}
+	if fallbackIP.String() == poolIP.String() {
+		t.Fatalf("fallback allocation reused the checked-out pool IP %s", poolIP)
+	}
+
+	m.ReleaseTap(context.Background(), fallbackIP)
+	fallbackTap := TapNameForIP(fallbackIP)
+	sawDelete := false
+	for _, c := range fr.calls {
+		if len(c) >= 4 && c[0] == "ip" && c[1] == "link" && c[2] == "del" && c[3] == fallbackTap {
+			sawDelete = true
+		}
+	}
+	if !sawDelete {
+		t.Errorf("ReleaseTap on a fallback-created tap must delete it even with prealloc on; calls: %v", fr.argvStrings())
+	}
+	// The allocator reservation must be freed too: a fresh AllocateTap (poolIP is
+	// still checked out, so this must come from the allocator, not the pool) reuses
+	// fallbackIP rather than advancing past it or erroring.
+	_, reused, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap after release: %v", err)
+	}
+	if reused.String() != fallbackIP.String() {
+		t.Errorf("released fallback IP not freed to the allocator: got %s want %s", reused, fallbackIP)
+	}
+}
+
+// TestPrecreatePoolDegradesOnTransientFailure locks in the PR4-review fix: a single
+// tap's precreate failure (a transient ip error, e.g. an EBUSY racing a prior
+// incarnation's teardown) must be best-effort — EnsureNetwork still succeeds with a
+// SHORTER pool, never propagating the error and crash-looping the brick.
+func TestPrecreatePoolDegradesOnTransientFailure(t *testing.T) {
+	// tapPrealloc is 2 (.2 and .3); fail only .3's `ip tuntap add`, leaving .2 to
+	// precreate successfully.
+	failTap := TapNameForIP(net.ParseIP("172.31.0.3"))
+	inner := &fakeRunner{}
+	failer := &argvFailer{
+		inner: inner,
+		want:  []string{"ip", "tuntap", "add", "dev", failTap, "mode", "tap"},
+		err:   errors.New("simulated transient EBUSY"),
+	}
+	m, err := NewManager(failer, "br0", "172.31.0.0/24", "", 30000, 2)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := m.EnsureNetwork(context.Background()); err != nil {
+		t.Fatalf("EnsureNetwork must degrade to a shorter pool on a transient precreate failure, not error: %v", err)
+	}
+	if !failer.fired {
+		t.Fatal("test did not actually exercise the targeted precreate failure")
+	}
+	// Exactly the one successful precreate (.2) is in the pool; draw it.
+	tap, ip, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap: %v", err)
+	}
+	if ip.String() != "172.31.0.2" {
+		t.Errorf("surviving pool member = %s, want 172.31.0.2 (the one precreate that succeeded)", ip)
+	}
+	if tap != TapNameForIP(ip) {
+		t.Errorf("tap name %q != deterministic %q", tap, TapNameForIP(ip))
+	}
+	// A further draw falls back to on-demand creation (the pool is exhausted at 1
+	// member, not the configured 2), proving the short pool degrades cleanly.
+	createsBefore := countCreateCalls(inner)
+	_, ip2, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap (fallback after short pool): %v", err)
+	}
+	if ip2.String() == ip.String() {
+		t.Fatalf("fallback reused the checked-out pool IP %s", ip)
+	}
+	if got := countCreateCalls(inner); got != createsBefore+1 {
+		t.Errorf("expected fallback to create a fresh tap: creates before=%d after=%d", createsBefore, got)
+	}
+}
+
+// TestAllocateTapPushesBackPoolTapOnLinkUpFailure locks in AllocateTap's pool-draw
+// failure path: when bringing a popped pool tap's link up fails, the IP must be
+// pushed back into the pool (not lost) before AllocateTap falls through to
+// on-demand creation, so a transient failure degrades gracefully instead of leaking
+// a pool slot.
+func TestAllocateTapPushesBackPoolTapOnLinkUpFailure(t *testing.T) {
+	poolTap := TapNameForIP(net.ParseIP("172.31.0.2"))
+	inner := &fakeRunner{}
+	m, err := NewManager(inner, "br0", "172.31.0.0/24", "", 30000, 1)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := m.EnsureNetwork(context.Background()); err != nil {
+		t.Fatalf("EnsureNetwork: %v", err)
+	}
+	// Fail only the pool draw's `ip link set <poolTap> up`; precreate already ran
+	// (above) with a clean runner, so this cannot touch precreate's own calls.
+	failer := &argvFailer{inner: inner, want: tapUpArgs(poolTap), err: errors.New("simulated link-up failure")}
+	m.runner = failer
+
+	_, ip, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap should fall back to on-demand creation, not error: %v", err)
+	}
+	if !failer.fired {
+		t.Fatal("test did not actually exercise the pool tap's link-up path")
+	}
+	if ip.String() == "172.31.0.2" {
+		t.Errorf("AllocateTap returned the pool IP %s despite its link-up failing; fallback should allocate a different IP", ip)
+	}
+	// The pool IP must have been pushed back (not lost): switching back to a clean
+	// runner, a further AllocateTap draws it again from the pool.
+	m.runner = inner
+	_, ip2, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap after push-back: %v", err)
+	}
+	if ip2.String() != "172.31.0.2" {
+		t.Errorf("pool IP not pushed back after link-up failure: got %s want 172.31.0.2", ip2)
 	}
 }

--- a/projects/embervm/noded/serving/net_test.go
+++ b/projects/embervm/noded/serving/net_test.go
@@ -606,16 +606,21 @@ func TestPoolDrainedThenRefilledOnRelease(t *testing.T) {
 	createsAfterDrain := countCreateCalls(fr)
 
 	// Release ip1: prealloc is on, so it must go DOWN and back to the pool, not be
-	// deleted.
+	// deleted. Only inspect calls issued FROM HERE: fr.calls already carries
+	// precreatePool's own del-before-add repair for ip1's tap (EnsureNetwork ran
+	// above), and scanning the whole history would misidentify that boot-time
+	// idempotent delete as a release-time one.
+	callsBeforeRelease := len(fr.calls)
 	m.ReleaseTap(context.Background(), ip1)
+	releaseCalls := fr.calls[callsBeforeRelease:]
 	tap1 := TapNameForIP(ip1)
-	for _, c := range fr.calls {
+	for _, c := range releaseCalls {
 		if len(c) >= 4 && c[0] == "ip" && c[1] == "link" && c[2] == "del" && c[3] == tap1 {
 			t.Errorf("ReleaseTap deleted a pooled tap %s; prealloc mode must return it, not delete it", tap1)
 		}
 	}
 	sawDown := false
-	for _, c := range fr.calls {
+	for _, c := range releaseCalls {
 		if fmt.Sprint(c) == fmt.Sprint(tapDownArgs(tap1)) {
 			sawDown = true
 		}

--- a/projects/embervm/noded/serving/net_test.go
+++ b/projects/embervm/noded/serving/net_test.go
@@ -204,11 +204,11 @@ func TestPortForIP(t *testing.T) {
 // TestNewManagerRejectsPortOverflow proves the range guard fires when a pod IP is set
 // and the base would push the top offset past 65535, but is skipped when DNAT is off.
 func TestNewManagerRejectsPortOverflow(t *testing.T) {
-	if _, err := NewManager(&fakeRunner{}, "br0", "172.31.0.0/24", "10.42.0.9", 65500); err == nil {
+	if _, err := NewManager(&fakeRunner{}, "br0", "172.31.0.0/24", "10.42.0.9", 65500, 0); err == nil {
 		t.Error("NewManager should reject a port base that overflows with a pod IP set")
 	}
 	// The same base is fine when DNAT is disabled (empty pod IP): no derivation happens.
-	if _, err := NewManager(&fakeRunner{}, "br0", "172.31.0.0/24", "", 65500); err != nil {
+	if _, err := NewManager(&fakeRunner{}, "br0", "172.31.0.0/24", "", 65500, 0); err != nil {
 		t.Errorf("NewManager with no pod IP should not validate port base, got %v", err)
 	}
 }
@@ -217,7 +217,7 @@ func TestNewManagerRejectsPortOverflow(t *testing.T) {
 // `nft -f` apply carrying the expected DNAT rule, and that ReleaseTap drops the entry.
 func TestEnsureDNATAndRelease(t *testing.T) {
 	fr := &fakeRunner{}
-	m, err := NewManager(fr, "br0", "172.31.0.0/24", "10.42.0.9", 30000)
+	m, err := NewManager(fr, "br0", "172.31.0.0/24", "10.42.0.9", 30000, 0)
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestEnsureDNATAndRelease(t *testing.T) {
 // TestEnsureDNATDisabledIsNoop asserts that with no pod IP, EnsureDNAT installs nothing.
 func TestEnsureDNATDisabledIsNoop(t *testing.T) {
 	fr := &fakeRunner{}
-	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000)
+	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 0)
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
@@ -257,12 +257,12 @@ func TestEnsureDNATDisabledIsNoop(t *testing.T) {
 // and the tap IP unchanged when it is off.
 func TestEndpointProjection(t *testing.T) {
 	fr := &fakeRunner{}
-	on, _ := NewManager(fr, "br0", "172.31.0.0/24", "10.42.0.9", 30000)
+	on, _ := NewManager(fr, "br0", "172.31.0.0/24", "10.42.0.9", 30000, 0)
 	gotIP, gotPort := on.Endpoint(net.ParseIP("172.31.0.2"), 8080)
 	if gotIP != "10.42.0.9" || gotPort != 30002 {
 		t.Errorf("Endpoint(on) = %s:%d want 10.42.0.9:30002", gotIP, gotPort)
 	}
-	off, _ := NewManager(fr, "br0", "172.31.0.0/24", "", 30000)
+	off, _ := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 0)
 	gotIP, gotPort = off.Endpoint(net.ParseIP("172.31.0.2"), 8080)
 	if gotIP != "172.31.0.2" || gotPort != 8080 {
 		t.Errorf("Endpoint(off) = %s:%d want the tap 172.31.0.2:8080", gotIP, gotPort)
@@ -283,7 +283,7 @@ func TestEnsureNetworkTolLeratesExistingBridge(t *testing.T) {
 	fr := &fakeRunner{failOn: map[string]error{
 		"ip link": errors.New("RTNETLINK answers: File exists"),
 	}}
-	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000)
+	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 0)
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
@@ -315,7 +315,7 @@ func TestEnsureNetworkTolLeratesExistingBridge(t *testing.T) {
 
 func TestAllocateAndReleaseTap(t *testing.T) {
 	fr := &fakeRunner{}
-	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000)
+	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 0)
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
@@ -373,7 +373,7 @@ func TestAllocateTapDeletesStaleTapBeforeCreate(t *testing.T) {
 
 	t.Run("AllocateTap", func(t *testing.T) {
 		fr := &fakeRunner{}
-		m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000)
+		m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 0)
 		if err != nil {
 			t.Fatalf("NewManager: %v", err)
 		}
@@ -386,7 +386,7 @@ func TestAllocateTapDeletesStaleTapBeforeCreate(t *testing.T) {
 
 	t.Run("AllocateTapForIP", func(t *testing.T) {
 		fr := &fakeRunner{}
-		m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000)
+		m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 0)
 		if err != nil {
 			t.Fatalf("NewManager: %v", err)
 		}
@@ -401,7 +401,7 @@ func TestAllocateTapDeletesStaleTapBeforeCreate(t *testing.T) {
 
 func TestAllocateTapForIPPinsAndConflicts(t *testing.T) {
 	fr := &fakeRunner{}
-	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000)
+	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 0)
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
@@ -434,7 +434,7 @@ func TestAllocateTapRollsBackOnIPFailure(t *testing.T) {
 	fr := &fakeRunner{failOn: map[string]error{
 		"ip link": errors.New("boom"), // the `ip link set ... master` step fails
 	}}
-	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000)
+	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 0)
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
@@ -454,7 +454,7 @@ func TestAllocateTapRollsBackOnIPFailure(t *testing.T) {
 
 func TestNewManagerRejectsBadCIDR(t *testing.T) {
 	for _, cidr := range []string{"not-a-cidr", "::1/128", "10.0.0.0/31"} {
-		if _, err := NewManager(&fakeRunner{}, "br0", cidr, "", 30000); err == nil {
+		if _, err := NewManager(&fakeRunner{}, "br0", cidr, "", 30000, 0); err == nil {
 			t.Errorf("NewManager(%q) should error", cidr)
 		}
 	}
@@ -468,5 +468,263 @@ func TestTapNameDeterministicAndBounded(t *testing.T) {
 	}
 	if len(got) > 15 {
 		t.Errorf("tap name %q exceeds the 15-char ifname limit", got)
+	}
+}
+
+// ---- ADR embervm/014 decision 4: tap pre-provisioning ----------------------
+
+// countCreateCalls counts `ip tuntap add` invocations, the on-demand tap-create step
+// that a pool draw must NOT issue.
+func countCreateCalls(f *fakeRunner) int {
+	n := 0
+	for _, c := range f.calls {
+		if len(c) >= 3 && c[0] == "ip" && c[1] == "tuntap" && c[2] == "add" {
+			n++
+		}
+	}
+	return n
+}
+
+// TestEnsureNetworkPrecreatesPool asserts EnsureNetwork with tapPrealloc > 0 creates
+// exactly that many taps, attached to the bridge but left DOWN (no `ip link set ...
+// up` for a pool tap), and del-before-add is exercised for each (the #3745 repair).
+func TestEnsureNetworkPrecreatesPool(t *testing.T) {
+	fr := &fakeRunner{}
+	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 3)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := m.EnsureNetwork(context.Background()); err != nil {
+		t.Fatalf("EnsureNetwork: %v", err)
+	}
+	if n := countCreateCalls(fr); n != 3 {
+		t.Errorf("precreate calls = %d, want 3", n)
+	}
+	wantTaps := []string{TapNameForIP(net.ParseIP("172.31.0.2")), TapNameForIP(net.ParseIP("172.31.0.3")), TapNameForIP(net.ParseIP("172.31.0.4"))}
+	for _, tap := range wantTaps {
+		delIdx, addIdx, masterIdx, upIdx := -1, -1, -1, -1
+		for i, c := range fr.calls {
+			if len(c) >= 4 && c[0] == "ip" && c[1] == "link" && c[2] == "del" && c[3] == tap {
+				delIdx = i
+			}
+			if len(c) >= 5 && c[0] == "ip" && c[1] == "tuntap" && c[2] == "add" && c[4] == tap {
+				addIdx = i
+			}
+			if len(c) >= 4 && c[0] == "ip" && c[1] == "link" && c[2] == "set" && c[3] == tap && len(c) >= 5 && c[4] == "master" {
+				masterIdx = i
+			}
+			if len(c) == 5 && c[0] == "ip" && c[1] == "link" && c[2] == "set" && c[3] == tap && c[4] == "up" {
+				upIdx = i
+			}
+		}
+		if delIdx == -1 || addIdx == -1 {
+			t.Fatalf("tap %s: missing del (%d) or add (%d); calls: %v", tap, delIdx, addIdx, fr.argvStrings())
+		}
+		if delIdx > addIdx {
+			t.Errorf("tap %s: del-before-add violated (del=%d add=%d)", tap, delIdx, addIdx)
+		}
+		if masterIdx == -1 {
+			t.Errorf("tap %s: not attached to bridge (no `ip link set %s master br0`)", tap, tap)
+		}
+		if upIdx != -1 {
+			t.Errorf("tap %s: pre-created tap must be left DOWN, but `ip link set %s up` was issued", tap, tap)
+		}
+	}
+}
+
+// TestAllocateTapDrawsFromPoolWithoutCreate asserts a pool draw brings the link up
+// with no `ip tuntap add`/`master` create-attach work, unlike on-demand allocation.
+func TestAllocateTapDrawsFromPoolWithoutCreate(t *testing.T) {
+	fr := &fakeRunner{}
+	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 2)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := m.EnsureNetwork(context.Background()); err != nil {
+		t.Fatalf("EnsureNetwork: %v", err)
+	}
+	createsBefore := countCreateCalls(fr)
+	tap, ip, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap: %v", err)
+	}
+	if ip.String() != "172.31.0.2" {
+		t.Errorf("pool draw = %s, want the first pre-created IP 172.31.0.2", ip)
+	}
+	if tap != TapNameForIP(ip) {
+		t.Errorf("tap name %q != deterministic %q", tap, TapNameForIP(ip))
+	}
+	if got := countCreateCalls(fr); got != createsBefore {
+		t.Errorf("AllocateTap from a non-empty pool issued a create call: before=%d after=%d", createsBefore, got)
+	}
+	// The draw brought the tap up.
+	sawUp := false
+	for _, c := range fr.calls {
+		if fmt.Sprint(c) == fmt.Sprint(tapUpArgs(tap)) {
+			sawUp = true
+		}
+	}
+	if !sawUp {
+		t.Errorf("AllocateTap pool draw did not bring the tap up; calls: %v", fr.argvStrings())
+	}
+}
+
+// TestPoolDrainedThenRefilledOnRelease drains a 2-tap pool with two AllocateTap
+// calls, then asserts ReleaseTap returns a tap to the pool (down, no delete) so a
+// third AllocateTap reuses it without any create call.
+func TestPoolDrainedThenRefilledOnRelease(t *testing.T) {
+	fr := &fakeRunner{}
+	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 2)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := m.EnsureNetwork(context.Background()); err != nil {
+		t.Fatalf("EnsureNetwork: %v", err)
+	}
+	_, ip1, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap 1: %v", err)
+	}
+	_, ip2, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap 2: %v", err)
+	}
+	if ip1.String() == ip2.String() {
+		t.Fatalf("pool draws returned the same IP twice: %s", ip1)
+	}
+	createsAfterDrain := countCreateCalls(fr)
+
+	// Release ip1: prealloc is on, so it must go DOWN and back to the pool, not be
+	// deleted.
+	m.ReleaseTap(context.Background(), ip1)
+	tap1 := TapNameForIP(ip1)
+	for _, c := range fr.calls {
+		if len(c) >= 4 && c[0] == "ip" && c[1] == "link" && c[2] == "del" && c[3] == tap1 {
+			t.Errorf("ReleaseTap deleted a pooled tap %s; prealloc mode must return it, not delete it", tap1)
+		}
+	}
+	sawDown := false
+	for _, c := range fr.calls {
+		if fmt.Sprint(c) == fmt.Sprint(tapDownArgs(tap1)) {
+			sawDown = true
+		}
+	}
+	if !sawDown {
+		t.Errorf("ReleaseTap did not bring the pooled tap down; calls: %v", fr.argvStrings())
+	}
+
+	// A third AllocateTap must reuse ip1 from the pool with no new create call.
+	_, ip3, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap 3: %v", err)
+	}
+	if ip3.String() != ip1.String() {
+		t.Errorf("refilled draw = %s, want the just-released %s", ip3, ip1)
+	}
+	if got := countCreateCalls(fr); got != createsAfterDrain {
+		t.Errorf("reused pool tap issued a create call: before=%d after=%d", createsAfterDrain, got)
+	}
+}
+
+// TestAllocateTapFallsBackWhenPoolExhausted asserts a drained pool falls through to
+// on-demand creation (today's AllocateTap path) rather than erroring, and that the
+// fallback IP is a fresh one, not a pool member.
+func TestAllocateTapFallsBackWhenPoolExhausted(t *testing.T) {
+	fr := &fakeRunner{}
+	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 1)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := m.EnsureNetwork(context.Background()); err != nil {
+		t.Fatalf("EnsureNetwork: %v", err)
+	}
+	_, poolIP, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap (pool draw): %v", err)
+	}
+	createsBeforeFallback := countCreateCalls(fr)
+	tap, fallbackIP, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap (fallback): %v", err)
+	}
+	if fallbackIP.String() == poolIP.String() {
+		t.Fatalf("fallback allocation reused the checked-out pool IP %s", poolIP)
+	}
+	if got := countCreateCalls(fr); got != createsBeforeFallback+1 {
+		t.Errorf("fallback allocation did not create a fresh tap: creates before=%d after=%d", createsBeforeFallback, got)
+	}
+	if tap != TapNameForIP(fallbackIP) {
+		t.Errorf("fallback tap name %q != deterministic %q", tap, TapNameForIP(fallbackIP))
+	}
+}
+
+// TestReleaseTapDeletesWhenPreallocDisabled locks in that ReleaseTap's pool-return
+// behaviour is gated strictly on tapPrealloc > 0: with it unset (0, the default),
+// release still deletes the tap and frees the IP to the allocator exactly as before
+// this feature existed.
+func TestReleaseTapDeletesWhenPreallocDisabled(t *testing.T) {
+	fr := &fakeRunner{}
+	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 0)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	_, ip, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap: %v", err)
+	}
+	m.ReleaseTap(context.Background(), ip)
+	tap := TapNameForIP(ip)
+	sawDelete := false
+	for _, c := range fr.calls {
+		if len(c) >= 4 && c[0] == "ip" && c[1] == "link" && c[2] == "del" && c[3] == tap {
+			sawDelete = true
+		}
+	}
+	if !sawDelete {
+		t.Errorf("ReleaseTap with prealloc disabled must delete the tap; calls: %v", fr.argvStrings())
+	}
+	// The IP is free again in the allocator (not held for a pool that does not exist).
+	_, ip2, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap after release: %v", err)
+	}
+	if ip2.String() != ip.String() {
+		t.Errorf("released IP not reused: got %s want %s", ip2, ip)
+	}
+}
+
+// TestAllocateTapForIPDrawsPooledPin asserts a relight pin (D-R3.4.1) whose recorded
+// IP happens to be idle in the prealloc pool is drawn out of the pool (bring up,
+// no create/attach), rather than failing "already allocated" against the
+// allocator's permanent pool reservation.
+func TestAllocateTapForIPDrawsPooledPin(t *testing.T) {
+	fr := &fakeRunner{}
+	m, err := NewManager(fr, "br0", "172.31.0.0/24", "", 30000, 2)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := m.EnsureNetwork(context.Background()); err != nil {
+		t.Fatalf("EnsureNetwork: %v", err)
+	}
+	pin := net.ParseIP("172.31.0.2") // the first IP precreatePool reserved.
+	createsBefore := countCreateCalls(fr)
+	tap, err := m.AllocateTapForIP(context.Background(), pin)
+	if err != nil {
+		t.Fatalf("AllocateTapForIP: %v", err)
+	}
+	if tap != TapNameForIP(pin) {
+		t.Errorf("tap name %q != deterministic %q", tap, TapNameForIP(pin))
+	}
+	if got := countCreateCalls(fr); got != createsBefore {
+		t.Errorf("AllocateTapForIP on a pooled IP issued a create call: before=%d after=%d", createsBefore, got)
+	}
+	// The pool must no longer offer this IP: a subsequent AllocateTap draw gets the
+	// OTHER pooled IP, not this one.
+	_, drawn, err := m.AllocateTap(context.Background())
+	if err != nil {
+		t.Fatalf("AllocateTap: %v", err)
+	}
+	if drawn.String() == pin.String() {
+		t.Errorf("pool still offered the pinned IP %s after AllocateTapForIP drew it", pin)
 	}
 }


### PR DESCRIPTION
Implements **PR 4** of the ADR 014 worker-authoritative consistency plan (`docs/plans/2026-07-22-embervm-adr014-worker-authoritative-consistency.md`): pre-provision serving taps at brick boot so netlink work is off the instance boot path.

## What
- Node-agent-only. New env var `EMBERVM_NODED_TAP_PREALLOC` (default `0` = off, matching the `EMBERVM_NODED_*` config convention; noded has no CLI flag parser).
- When > 0, `precreatePool` pre-creates N serving taps at `EnsureNetwork` (attached to the bridge, left down, del-before-add retained per the #3745 repair). N is clamped down to the brick's slot ceiling (`Server.SlotCeiling()` / `Manager.ClampTapPrealloc`); `0` stays a hard off-switch.
- `AllocateTap` draws a pooled tap (link up, DNAT wired), falling back to on-demand creation when the pool is empty or a pooled tap's link-up fails (pushed back first). `ReleaseTap` returns pool-origin taps to the pool (link down, DNAT removed) and deletes+frees fallback-created taps.
- Threaded through `config.go` → `serving.NewManager` → chart `values.yaml` `noded.tapPrealloc` → shared `_noded-pod.tpl` (covers both the DaemonSet and the brick Deployment).

## Gate
Off by default everywhere. No behavioural change until `EMBERVM_NODED_TAP_PREALLOC` is set on a brick class (Task 4.2 canary, a follow-up values-only commit).

## Deviations from the plan (approved)
- Env var instead of a `--tap-prealloc` CLI flag (noded has no flag parser; every knob is `EMBERVM_NODED_*`).
- Clamp-down semantics: a configured value is clamped down to the slot ceiling rather than an unset value defaulting up to it, so `0` is a hard off-switch (honours the off-by-default gate philosophy; Task 4.1 "defaults to slot ceiling" vs Task 4.2 "default 0" tension resolved in favour of gating).

## Review
One comprehensive Opus review + a focused re-review of the fix commit. Findings fixed:
1. `ReleaseTap` branched on `tapPrealloc>0` instead of pool-origin, so fallback taps ratcheted the idle pool above the slot ceiling and never freed their reservation.
2. `precreatePool` made a single transient netlink failure fatal (crash-loop) instead of degrading to on-demand.
3. `pushPool` lacked a dup guard (latent double-release could hand one tap to two VMs).
4. Bonus: pool tap up/down passed full argv without the `[1:]` slice every other call site uses, which would have issued a doubled `ip ip link set ...` and broken every pool up/down at flip time.

Tests assert each fix (fallback-release delete+free, precreate-degrade, link-up push-back, pooled-pin-vs-allocator conflict). Group bridges/taps untouched (out of scope). Defers to CI for the Go compile/test signal per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)