### PR TITLE
feat(embervm): async lifecycle writes off the boot/wake hot path (ADR 014 PR 3)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.207
+version: 0.1.208

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -76,9 +76,26 @@ defmodule Embervm.Application do
       {Registry, keys: :duplicate, name: Embervm.TaskWaiters},
       Embervm.SyncWait,
       op_log_child_spec(),
+      # The async lifecycle-write queue (ADR embervm/014 decision 2), gated by
+      # EMBERVM_ASYNC_LIFECYCLE_WRITES. Placed AFTER the op-log (it appends through
+      # it) and BEFORE TaskStore/SessionStore/SessionManager (they enqueue their
+      # off-hot-path :assigned/:started and session_created/session_relit appends
+      # here). Owns no ETS and effectively never crashes, so leading the stores in
+      # the rest_for_one chain costs nothing; it drains on graceful shutdown so a CP
+      # roll loses no pending append. Started unconditionally: with the gate OFF it
+      # receives no work (the stores keep write-through ordering), so it is inert.
+      Embervm.AsyncWriter,
       # TaskStore fires on_metered after a :succeeded/:failed op with usage lands,
       # so Embervm.Metering charges the quota cache off the same durable write.
-      {Embervm.TaskStore, [op_log_mod: op_log_mod(), on_metered: &Embervm.Metering.on_metered/1]},
+      # async_writer + async_lifecycle_writes wire the gated off-hot-path append of
+      # :assigned/:started (dispatch); OFF (default) keeps write-through ordering.
+      {Embervm.TaskStore,
+       [
+         op_log_mod: op_log_mod(),
+         on_metered: &Embervm.Metering.on_metered/1,
+         async_writer: Embervm.AsyncWriter,
+         async_lifecycle_writes: async_lifecycle_writes_enabled()
+       ]},
       # Finch (the shared HTTP pool, TLS-pinned to the K8s CA in-cluster) before
       # Embervm.Auth, whose TokenReview reviewer dials the API server over it.
       Embervm.K8s.finch_child_spec(),
@@ -172,7 +189,13 @@ defmodule Embervm.Application do
       # :rest_for_one a SessionStore restart bounces the manager and Router, which
       # rebuild from the durable projection. With no node wired, create denies
       # :no_capacity and nothing runs, exactly like the dispatcher in R0.
-      {Embervm.SessionStore, [op_log_mod: op_log_mod(), on_metered: &Embervm.Metering.on_metered/1]},
+      {Embervm.SessionStore,
+       [
+         op_log_mod: op_log_mod(),
+         on_metered: &Embervm.Metering.on_metered/1,
+         async_writer: Embervm.AsyncWriter,
+         async_lifecycle_writes: async_lifecycle_writes_enabled()
+       ]},
       {Registry, keys: :unique, name: Embervm.SessionRegistry},
       {DynamicSupervisor, strategy: :one_for_one, name: Embervm.SessionSupervisor},
       {Embervm.SessionManager, session_manager_opts()},
@@ -613,7 +636,12 @@ defmodule Embervm.Application do
       disk_low_watermark_bytes: session_disk_low_watermark_bytes(),
       node_confirmed_destroy: node_confirmed_destroy_enabled(),
       destroying_alarm_ms: destroying_alarm_ms(),
-      orphan_grace_ms: orphan_grace_ms()
+      orphan_grace_ms: orphan_grace_ms(),
+      # The Direction-2 adopt-and-backfill discriminator asks AsyncWriter whether a
+      # rowless reported VM has a write in flight (ADR embervm/014 decision 2), so it
+      # needs both the gate and the writer reference.
+      async_lifecycle_writes: async_lifecycle_writes_enabled(),
+      async_writer: Embervm.AsyncWriter
     ] ++ wake_opts()
   end
 
@@ -626,6 +654,23 @@ defmodule Embervm.Application do
   # change, no code change. Nothing sets it on in this PR.
   defp node_confirmed_destroy_enabled do
     case trimmed_env("EMBERVM_NODE_CONFIRMED_DESTROY") do
+      v when v in ["1", "true", "TRUE", "True"] -> true
+      _ -> false
+    end
+  end
+
+  # EMBERVM_ASYNC_LIFECYCLE_WRITES (ADR embervm/014 decision 2). UNSET or
+  # "0"/"false"/"" (the default, and what this PR ships) => the boot/wake lifecycle
+  # appends (:assigned/:started on dispatch, session_created/session_relit on session
+  # boot/wake) stay write-through: the durable oplog append blocks the hot-path caller
+  # before the instance is handed back, today's ordering. "1"/"true" => those four
+  # appends are deferred to Embervm.AsyncWriter AFTER the in-memory state is advanced
+  # (RPC already succeeded), taking the durable write off the hot path; a lost write
+  # (CP crash before the async append) is repaired by the adoption backfill. Metering,
+  # :submitted, destruction, and bank ops are NEVER deferred. Wired here so it flips
+  # via a deploy values env change, no code change. Nothing sets it on in this PR.
+  defp async_lifecycle_writes_enabled do
+    case trimmed_env("EMBERVM_ASYNC_LIFECYCLE_WRITES") do
       v when v in ["1", "true", "TRUE", "True"] -> true
       _ -> false
     end

--- a/projects/embervm/control/lib/embervm/async_writer.ex
+++ b/projects/embervm/control/lib/embervm/async_writer.ex
@@ -1,0 +1,212 @@
+defmodule Embervm.AsyncWriter do
+  @moduledoc """
+  Off-hot-path durable oplog appends (ADR embervm/014 decision 2), gated by
+  `EMBERVM_ASYNC_LIFECYCLE_WRITES`.
+
+  Today the boot/wake paths write the `:assigned`/`:started` (task dispatch) and
+  `:session_created`/`:session_relit` (session boot/wake) ops write-through: the
+  durable oplog append lands BEFORE the instance is handed to the caller, so a
+  Postgres/SQLite round trip sits in front of every boot and wake. ADR 014
+  decision 2 takes that append off the hot path: the instance becomes interactive
+  first (RPC success + in-memory state advanced), and the durable append runs
+  asynchronously afterward through this writer.
+
+  ## What is and is NOT moved
+
+  Only the four lifecycle appends above move. Explicitly synchronous and never
+  routed here:
+
+    * `:submitted` (the quota audit trail: a task must be durable before it can be
+      charged),
+    * every metering/usage op (fail-closed: the quota charge fires inside the
+      terminal op's own write-through transaction, so it can never precede that
+      op's durable append),
+    * every destruction op (PR 1: destroyed is node-confirmed and synchronous),
+    * every bank op (a snapshot's identity must be durable before eviction can act
+      on it; bank is not a hot path).
+
+  ## Ordering and the ETS/append split
+
+  The in-memory (ETS) projection is advanced SYNCHRONOUSLY by the owning store
+  before an op is enqueued here (the store's ETS tables are `:private`, so only
+  the store process may mutate them, and the FSM's terminal transitions -
+  `:succeeded`/`:session_relit` etc. - must see the instance already in
+  `:assigned`/`:running`/`:relighting`). This writer therefore carries ONLY the
+  deferred durable append: it calls `op_log_mod.append(op_log, op)` and nothing
+  else. That is a deliberate divergence from an "append-then-mutate-ETS" reading
+  of the ADR: mutating ETS here is both impossible (private tables) and wrong
+  (a terminal transition would race a not-yet-applied assign). The trade is that
+  the durable log can lag the in-memory view by one append; a CP crash in that
+  window loses the op, which the adoption reconcile repairs (below).
+
+  Appends are applied strictly FIFO from this GenServer's mailbox, so ops for one
+  instance land in submission order (the mailbox gives global order, which is
+  stronger than the per-instance order the ADR requires; a per-scheduler pool is
+  deliberately YAGNI until CI perf shows single-writer contention).
+
+  ## Crash-loss and its repair
+
+  A crash between `enqueue/2` and the append inside `handle_cast/2` loses that op:
+  the instance is running (or its VM is live on the node) but its durable row is
+  absent. This is documented and intended. The repair is the adoption reconcile's
+  adopt-and-backfill path (PR 1's Direction-2 orphan pass, extended in PR 3): a
+  node reports the live VM, the CP has no row, but a pending async write (tracked
+  here via `pending?/2`) OR an existing task/session record references the
+  `vm_id`, so the instance is ADOPTED and its missing ops backfilled, never
+  destroyed. `pending?/2` is the "is a write in flight for this vm_id" half of
+  that discriminator; the store-row half is the reconciler's own lookup.
+
+  On a GRACEFUL shutdown (a normal CP roll), `terminate/2` drains every queued
+  append before the process exits, so a planned rollout loses nothing; only an
+  abnormal exit (SIGKILL, a crash) can drop the in-flight queue, and only that
+  narrow window relies on the reconcile repair.
+  """
+  use GenServer
+
+  require Logger
+
+  alias Embervm.OpLog.Op
+
+  # -- Client API ------------------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Enqueue one deferred durable append.
+
+  `entry` is `%{op: %Op{}, op_log_mod: module, op_log: server, vm_id: binary | nil}`.
+  The append is `op_log_mod.append(op_log, op)`; `vm_id` (when set) registers this
+  op as an in-flight write so `pending?/2` can answer the adopt-and-backfill
+  discriminator until the append lands. Fire-and-forget: a cast, so the caller
+  (the dispatch/create hot path) never blocks on the durable write.
+  """
+  @spec enqueue(GenServer.server(), map()) :: :ok
+  def enqueue(server \\ __MODULE__, entry) when is_map(entry) do
+    GenServer.cast(server, {:enqueue, entry})
+  end
+
+  @doc """
+  Does an as-yet-unapplied durable append reference `vm_id`? The pending half of
+  the reconciler's adopt-vs-destroy discriminator: a node reports a live VM the CP
+  has no row for, but if a write for that VM is still in flight here it is a young
+  async-write race to adopt, not an orphan to destroy. A synchronous call so the
+  answer reflects every append queued (but not yet applied) at call time.
+  """
+  @spec pending?(GenServer.server(), binary()) :: boolean()
+  def pending?(server \\ __MODULE__, vm_id) when is_binary(vm_id) do
+    GenServer.call(server, {:pending?, vm_id})
+  end
+
+  @doc """
+  Block until every queued append has been applied. Test/checkpoint helper: a
+  synchronous call that returns only after the mailbox ahead of it has drained
+  (mailbox FIFO), so a test can assert the durable effect without sleeping.
+  """
+  @spec drain(GenServer.server()) :: :ok
+  def drain(server \\ __MODULE__) do
+    GenServer.call(server, :drain)
+  end
+
+  # -- GenServer callbacks ---------------------------------------------------
+
+  @impl true
+  def init(_opts) do
+    Process.flag(:trap_exit, true)
+    # vm_id -> count of in-flight appends referencing it (a vm can have both an
+    # :assigned and a :started append queued at once, so it is a count, not a set:
+    # the vm stays "pending" until BOTH have applied).
+    {:ok, %{pending: %{}}}
+  end
+
+  @impl true
+  def handle_cast({:enqueue, entry}, state) do
+    state = track_pending(state, entry)
+    _ = apply_append(entry)
+    state = untrack_pending(state, entry)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_call({:pending?, vm_id}, _from, state) do
+    {:reply, Map.has_key?(state.pending, vm_id), state}
+  end
+
+  # A no-op reply whose ONLY purpose is to have travelled behind every enqueue cast
+  # already in the mailbox: once this returns, those casts have been handled.
+  def handle_call(:drain, _from, state) do
+    {:reply, :ok, state}
+  end
+
+  # Graceful shutdown: process the remaining {:enqueue, _} casts still in the
+  # mailbox so a normal CP roll flushes every pending append. Only reached on a
+  # supervised/normal stop (trap_exit is set); a SIGKILL cannot run terminate/2, so
+  # that (and only that) window depends on the adoption backfill repair.
+  @impl true
+  def terminate(_reason, state) do
+    flush_mailbox(state)
+    :ok
+  end
+
+  # -- internals -------------------------------------------------------------
+
+  defp apply_append(%{op: %Op{} = op, op_log_mod: mod, op_log: server}) do
+    case mod.append(server, op) do
+      {:ok, _seq} ->
+        :ok
+
+      {:error, reason} ->
+        # A lost async append is exactly the crash-window case the reconcile
+        # repairs: log it (SigNoz-visible) and drop it rather than crash the writer
+        # and take every other pending append down with it.
+        Logger.warning("embervm async_writer append failed",
+          kind: op.kind,
+          task_id: op.task_id,
+          session_id: op.session_id,
+          reason: inspect(reason)
+        )
+
+        :ok
+    end
+  rescue
+    e ->
+      Logger.warning("embervm async_writer append crashed",
+        kind: op.kind,
+        error: inspect(e)
+      )
+
+      :ok
+  end
+
+  defp track_pending(state, %{vm_id: vm_id}) when is_binary(vm_id) do
+    put_in(state, [:pending, vm_id], Map.get(state.pending, vm_id, 0) + 1)
+  end
+
+  defp track_pending(state, _entry), do: state
+
+  defp untrack_pending(state, %{vm_id: vm_id}) when is_binary(vm_id) do
+    case Map.get(state.pending, vm_id, 0) do
+      n when n <= 1 -> update_in(state, [:pending], &Map.delete(&1, vm_id))
+      n -> put_in(state, [:pending, vm_id], n - 1)
+    end
+  end
+
+  defp untrack_pending(state, _entry), do: state
+
+  # Drain every {:enqueue, _} cast still in the mailbox (terminate/2). Selective
+  # receive with a zero timeout: pull enqueues until none remain, applying each.
+  defp flush_mailbox(state) do
+    receive do
+      {:"$gen_cast", {:enqueue, entry}} ->
+        state = track_pending(state, entry)
+        _ = apply_append(entry)
+        state = untrack_pending(state, entry)
+        flush_mailbox(state)
+    after
+      0 -> state
+    end
+  end
+end

--- a/projects/embervm/control/lib/embervm/async_writer.ex
+++ b/projects/embervm/control/lib/embervm/async_writer.ex
@@ -44,6 +44,17 @@ defmodule Embervm.AsyncWriter do
   stronger than the per-instance order the ADR requires; a per-scheduler pool is
   deliberately YAGNI until CI perf shows single-writer contention).
 
+  ## The pending registry (a public ETS table)
+
+  In-flight appends are tracked by `vm_id` in a PUBLIC ETS counter table this
+  process owns, NOT in the GenServer state. That is deliberate: an append can
+  block inside `handle_cast/2` (a slow op-log), and a `pending?/2` reader must
+  still get an answer while that append is in flight (a GenServer `call` would sit
+  behind the blocked cast in the mailbox and deadlock). The count is incremented
+  the moment an op is enqueued (before it can apply) and decremented after it
+  applies, so a reader sees a VM as pending for exactly the enqueue..applied
+  window.
+
   ## Crash-loss and its repair
 
   A crash between `enqueue/2` and the append inside `handle_cast/2` loses that op:
@@ -53,8 +64,7 @@ defmodule Embervm.AsyncWriter do
   node reports the live VM, the CP has no row, but a pending async write (tracked
   here via `pending?/2`) OR an existing task/session record references the
   `vm_id`, so the instance is ADOPTED and its missing ops backfilled, never
-  destroyed. `pending?/2` is the "is a write in flight for this vm_id" half of
-  that discriminator; the store-row half is the reconciler's own lookup.
+  destroyed.
 
   On a GRACEFUL shutdown (a normal CP roll), `terminate/2` drains every queued
   append before the process exits, so a planned rollout loses nothing; only an
@@ -82,23 +92,33 @@ defmodule Embervm.AsyncWriter do
   The append is `op_log_mod.append(op_log, op)`; `vm_id` (when set) registers this
   op as an in-flight write so `pending?/2` can answer the adopt-and-backfill
   discriminator until the append lands. Fire-and-forget: a cast, so the caller
-  (the dispatch/create hot path) never blocks on the durable write.
+  (the dispatch/create hot path) never blocks on the durable write. The pending
+  count is bumped SYNCHRONOUSLY here (from the caller), before the cast, so a
+  reader can never observe a gap between enqueue and the vm being pending.
   """
   @spec enqueue(GenServer.server(), map()) :: :ok
   def enqueue(server \\ __MODULE__, entry) when is_map(entry) do
-    GenServer.cast(server, {:enqueue, entry})
+    table = table_for(server)
+    inc_pending(table, Map.get(entry, :vm_id))
+    GenServer.cast(server, {:enqueue, entry, table})
   end
 
   @doc """
   Does an as-yet-unapplied durable append reference `vm_id`? The pending half of
   the reconciler's adopt-vs-destroy discriminator: a node reports a live VM the CP
   has no row for, but if a write for that VM is still in flight here it is a young
-  async-write race to adopt, not an orphan to destroy. A synchronous call so the
-  answer reflects every append queued (but not yet applied) at call time.
+  async-write race to adopt, not an orphan to destroy. Reads the public ETS
+  counter directly (no GenServer call), so it answers even while an append is
+  blocked in flight.
   """
   @spec pending?(GenServer.server(), binary()) :: boolean()
   def pending?(server \\ __MODULE__, vm_id) when is_binary(vm_id) do
-    GenServer.call(server, {:pending?, vm_id})
+    table = table_for(server)
+
+    case :ets.lookup(table, vm_id) do
+      [{^vm_id, n}] when n > 0 -> true
+      _ -> false
+    end
   end
 
   @doc """
@@ -108,46 +128,53 @@ defmodule Embervm.AsyncWriter do
   """
   @spec drain(GenServer.server()) :: :ok
   def drain(server \\ __MODULE__) do
-    GenServer.call(server, :drain)
+    GenServer.call(server, :drain, :infinity)
   end
 
   # -- GenServer callbacks ---------------------------------------------------
 
   @impl true
-  def init(_opts) do
+  def init(opts) do
     Process.flag(:trap_exit, true)
-    # vm_id -> count of in-flight appends referencing it (a vm can have both an
-    # :assigned and a :started append queued at once, so it is a count, not a set:
-    # the vm stays "pending" until BOTH have applied).
-    {:ok, %{pending: %{}}}
+    name = Keyword.get(opts, :name, __MODULE__)
+    # A public counter table (vm_id -> in-flight append count) this process owns, so
+    # it dies with the writer. Named off the registered name when there is one (the
+    # supervised singleton), else an anonymous table whose id we stash in
+    # persistent_term keyed by our pid (unnamed test writers). pending?/2 and
+    # enqueue/2 resolve the table without a GenServer round trip.
+    table =
+      if is_atom(name) and not is_nil(name) do
+        :ets.new(pending_table_name(name), [:set, :public, :named_table])
+      else
+        tid = :ets.new(:embervm_async_writer_pending, [:set, :public])
+        :persistent_term.put({__MODULE__, :table, self()}, tid)
+        tid
+      end
+
+    {:ok, %{table: table}}
   end
 
   @impl true
-  def handle_cast({:enqueue, entry}, state) do
-    state = track_pending(state, entry)
+  def handle_cast({:enqueue, entry, table}, state) do
     _ = apply_append(entry)
-    state = untrack_pending(state, entry)
+    dec_pending(table, Map.get(entry, :vm_id))
     {:noreply, state}
-  end
-
-  @impl true
-  def handle_call({:pending?, vm_id}, _from, state) do
-    {:reply, Map.has_key?(state.pending, vm_id), state}
   end
 
   # A no-op reply whose ONLY purpose is to have travelled behind every enqueue cast
   # already in the mailbox: once this returns, those casts have been handled.
+  @impl true
   def handle_call(:drain, _from, state) do
     {:reply, :ok, state}
   end
 
-  # Graceful shutdown: process the remaining {:enqueue, _} casts still in the
+  # Graceful shutdown: process the remaining {:enqueue, _, _} casts still in the
   # mailbox so a normal CP roll flushes every pending append. Only reached on a
   # supervised/normal stop (trap_exit is set); a SIGKILL cannot run terminate/2, so
   # that (and only that) window depends on the adoption backfill repair.
   @impl true
-  def terminate(_reason, state) do
-    flush_mailbox(state)
+  def terminate(_reason, _state) do
+    flush_mailbox()
     :ok
   end
 
@@ -173,40 +200,56 @@ defmodule Embervm.AsyncWriter do
     end
   rescue
     e ->
-      Logger.warning("embervm async_writer append crashed",
-        kind: op.kind,
-        error: inspect(e)
-      )
-
+      Logger.warning("embervm async_writer append crashed", kind: op.kind, error: inspect(e))
       :ok
   end
 
-  defp track_pending(state, %{vm_id: vm_id}) when is_binary(vm_id) do
-    put_in(state, [:pending, vm_id], Map.get(state.pending, vm_id, 0) + 1)
+  # -- pending registry (public ETS counter) ---------------------------------
+
+  defp inc_pending(_table, nil), do: :ok
+
+  defp inc_pending(table, vm_id) do
+    :ets.update_counter(table, vm_id, {2, 1}, {vm_id, 0})
+    :ok
   end
 
-  defp track_pending(state, _entry), do: state
+  defp dec_pending(_table, nil), do: :ok
 
-  defp untrack_pending(state, %{vm_id: vm_id}) when is_binary(vm_id) do
-    case Map.get(state.pending, vm_id, 0) do
-      n when n <= 1 -> update_in(state, [:pending], &Map.delete(&1, vm_id))
-      n -> put_in(state, [:pending, vm_id], n - 1)
+  defp dec_pending(table, vm_id) do
+    # Decrement; drop the row once it reaches zero so the table does not grow
+    # unbounded with settled vms. update_counter with a floor of 0 keeps it safe if
+    # a decrement ever races ahead (it cannot today: one inc per enqueue, one dec per
+    # apply).
+    case :ets.update_counter(table, vm_id, {2, -1, 0, 0}, {vm_id, 0}) do
+      0 -> :ets.delete(table, vm_id)
+      _ -> :ok
     end
+
+    :ok
   end
 
-  defp untrack_pending(state, _entry), do: state
+  defp table_for(server) when is_atom(server) and not is_nil(server) do
+    pending_table_name(server)
+  end
 
-  # Drain every {:enqueue, _} cast still in the mailbox (terminate/2). Selective
-  # receive with a zero timeout: pull enqueues until none remain, applying each.
-  defp flush_mailbox(state) do
+  defp table_for(server) do
+    pid = GenServer.whereis(server)
+    :persistent_term.get({__MODULE__, :table, pid})
+  end
+
+  defp pending_table_name(name), do: :"#{name}.Pending"
+
+  # Drain every {:enqueue, _, _} cast still in the mailbox (terminate/2). Selective
+  # receive with a zero timeout: pull enqueues until none remain, applying each and
+  # settling its pending counter.
+  defp flush_mailbox do
     receive do
-      {:"$gen_cast", {:enqueue, entry}} ->
-        state = track_pending(state, entry)
+      {:"$gen_cast", {:enqueue, entry, table}} ->
         _ = apply_append(entry)
-        state = untrack_pending(state, entry)
-        flush_mailbox(state)
+        dec_pending(table, Map.get(entry, :vm_id))
+        flush_mailbox()
     after
-      0 -> state
+      0 -> :ok
     end
   end
 end

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -488,8 +488,15 @@ defmodule Embervm.Dispatcher do
   defp commit_dispatch(state, wl, entry, node_id, mode, snapshot_ref, candidates, task_id, pr) do
     {state, vm_id} = reserve_vm(state, node_id, wl, mode)
 
-    with {:ok, {:ok, _}} <- safe_call(fn -> Embervm.TaskStore.assign(state.task_store, task_id) end),
-         {:ok, {:ok, _}} <- safe_call(fn -> Embervm.TaskStore.start(state.task_store, task_id) end) do
+    # Pass the reserved vm_id into assign/start so that, under
+    # EMBERVM_ASYNC_LIFECYCLE_WRITES (ADR embervm/014 decision 2), TaskStore
+    # registers the deferred :assigned/:started appends against this VM with
+    # Embervm.AsyncWriter; the reconciler's adopt-and-backfill discriminator then
+    # sees the write in flight. nil for a miss (its vm_id is minted in the worker);
+    # inert under the gate off. The ETS FSM advance and the queued-race guard here
+    # are unchanged (Option A): only the durable append moves off the hot path.
+    with {:ok, {:ok, _}} <- safe_call(fn -> Embervm.TaskStore.assign(state.task_store, task_id, vm_id) end),
+         {:ok, {:ok, _}} <- safe_call(fn -> Embervm.TaskStore.start(state.task_store, task_id, vm_id) end) do
       # Task left the queue: release its depth reservation and dedupe slot.
       release_depth(state, wl, pr)
 

--- a/projects/embervm/control/lib/embervm/op_log/postgres.ex
+++ b/projects/embervm/control/lib/embervm/op_log/postgres.ex
@@ -560,12 +560,16 @@ defmodule Embervm.OpLog.Postgres do
     end
   end
 
+  # Monotonic advance for the deferred async lifecycle appends (ADR embervm/014
+  # decision 2), mirroring Embervm.OpLog.SQLite: only from the exact prior state, so
+  # a late async :assigned/:started append cannot regress a row that already ran or
+  # terminalized. Inert under the gate off. See the SQLite backend for the rationale.
   defp project(conn, %Op{kind: :assigned} = op, _seq) do
-    update_task_state(conn, op.task_id, "assigned", op.ts)
+    advance_task_state(conn, op.task_id, "queued", "assigned", op.ts)
   end
 
   defp project(conn, %Op{kind: :started} = op, _seq) do
-    update_task_state(conn, op.task_id, "running", op.ts)
+    advance_task_state(conn, op.task_id, "assigned", "running", op.ts)
   end
 
   defp project(conn, %Op{kind: :succeeded} = op, _seq) do
@@ -633,12 +637,16 @@ defmodule Embervm.OpLog.Postgres do
   defp project(conn, %Op{kind: :session_created} = op, _seq) do
     payload = op.payload
 
+    # ON CONFLICT DO NOTHING: idempotent on session_id so the adopt-and-backfill
+    # repair can re-append session_created for a lost async write without a clash
+    # (mirrors the SQLite backend's INSERT OR IGNORE), ADR embervm/014 decision 2.
     sql = """
     INSERT INTO sessions
       (session_id, tenant, principal, workload, state, node_id,
        base_snapshot_ref, base_digest, generation, snapshot_ref, snapshot_size_bytes,
        token_sha256, created_at, last_invoke_at, expires_at, updated_at, terminal_reason)
     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 0, NULL, NULL, $9, $10, NULL, $11, $12, NULL)
+    ON CONFLICT (session_id) DO NOTHING
     """
 
     exec(conn, sql, [
@@ -686,11 +694,15 @@ defmodule Embervm.OpLog.Postgres do
     ])
   end
 
+  # Guarded against terminal states so a deferred async relit append cannot
+  # resurrect a since-destroyed session (mirrors the SQLite backend), ADR
+  # embervm/014 decision 2. Inert under the gate off.
   defp project(conn, %Op{kind: :session_relit} = op, _seq) do
-    exec(conn, "UPDATE sessions SET state='running', updated_at=$1 WHERE session_id=$2", [
-      op.ts,
-      op.session_id
-    ])
+    exec(
+      conn,
+      "UPDATE sessions SET state='running', updated_at=$1 WHERE session_id=$2 AND state NOT IN ('destroyed','expired','evicted','failed')",
+      [op.ts, op.session_id]
+    )
   end
 
   defp project(conn, %Op{kind: :session_expired} = op, _seq),
@@ -1265,6 +1277,16 @@ defmodule Embervm.OpLog.Postgres do
 
   defp update_task_state(conn, task_id, state, ts) do
     exec(conn, "UPDATE tasks SET state=$1, updated_at=$2 WHERE task_id=$3", [state, ts, task_id])
+  end
+
+  # Monotonic advance for a deferred async lifecycle append: SET only when the row
+  # is still in the exact prior state (see Embervm.OpLog.SQLite.advance_task_state/5).
+  defp advance_task_state(conn, task_id, from_state, to_state, ts) do
+    exec(
+      conn,
+      "UPDATE tasks SET state=$1, updated_at=$2 WHERE task_id=$3 AND state=$4",
+      [to_state, ts, task_id, from_state]
+    )
   end
 
   # -- usage accrual, mirrors Embervm.OpLog.SQLite exactly -------------------

--- a/projects/embervm/control/lib/embervm/op_log/postgres.ex
+++ b/projects/embervm/control/lib/embervm/op_log/postgres.ex
@@ -561,15 +561,17 @@ defmodule Embervm.OpLog.Postgres do
   end
 
   # Monotonic advance for the deferred async lifecycle appends (ADR embervm/014
-  # decision 2), mirroring Embervm.OpLog.SQLite: only from the exact prior state, so
-  # a late async :assigned/:started append cannot regress a row that already ran or
-  # terminalized. Inert under the gate off. See the SQLite backend for the rationale.
+  # decision 2), mirroring Embervm.OpLog.SQLite: SET only from a strictly-lower-
+  # ranked state (Embervm.TaskState.states_below/1), so a late/out-of-order async
+  # :assigned/:started append cannot regress a row that already ran or terminalized,
+  # while a legitimate forward jump still applies. Inert under the gate off. See the
+  # SQLite backend for the full rationale.
   defp project(conn, %Op{kind: :assigned} = op, _seq) do
-    advance_task_state(conn, op.task_id, "queued", "assigned", op.ts)
+    advance_task_state(conn, op.task_id, :assigned, op.ts)
   end
 
   defp project(conn, %Op{kind: :started} = op, _seq) do
-    advance_task_state(conn, op.task_id, "assigned", "running", op.ts)
+    advance_task_state(conn, op.task_id, :running, op.ts)
   end
 
   defp project(conn, %Op{kind: :succeeded} = op, _seq) do
@@ -1279,13 +1281,18 @@ defmodule Embervm.OpLog.Postgres do
     exec(conn, "UPDATE tasks SET state=$1, updated_at=$2 WHERE task_id=$3", [state, ts, task_id])
   end
 
-  # Monotonic advance for a deferred async lifecycle append: SET only when the row
-  # is still in the exact prior state (see Embervm.OpLog.SQLite.advance_task_state/5).
-  defp advance_task_state(conn, task_id, from_state, to_state, ts) do
+  # Monotonic advance for a deferred async lifecycle append: SET `to_state` only
+  # when the row ranks strictly below it in the lifecycle partial order
+  # (see Embervm.OpLog.SQLite.advance_task_state/4 and Embervm.TaskState.states_below/1).
+  defp advance_task_state(conn, task_id, to_state, ts) do
+    below = Embervm.TaskState.states_below(to_state)
+    # $1 to_state, $2 ts, $3 task_id, then $4.. for the state-in list.
+    placeholders = below |> Enum.with_index(4) |> Enum.map_join(",", fn {_, i} -> "$#{i}" end)
+
     exec(
       conn,
-      "UPDATE tasks SET state=$1, updated_at=$2 WHERE task_id=$3 AND state=$4",
-      [to_state, ts, task_id, from_state]
+      "UPDATE tasks SET state=$1, updated_at=$2 WHERE task_id=$3 AND state IN (#{placeholders})",
+      [Atom.to_string(to_state), ts, task_id | below]
     )
   end
 

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -688,12 +688,22 @@ defmodule Embervm.OpLog.SQLite do
     end
   end
 
+  # :assigned/:started advance the projection MONOTONICALLY (only from the state
+  # they legally follow), never as an unconditional SET. Under
+  # EMBERVM_ASYNC_LIFECYCLE_WRITES (ADR embervm/014 decision 2) these appends are
+  # deferred through Embervm.AsyncWriter, so a slow writer can land :assigned AFTER
+  # the terminal :succeeded already projected; a plain `SET state='assigned'` would
+  # REGRESS the durable row back to assigned. Guarding the prior state (queued for
+  # assigned, assigned for started) drops such a late append as the no-op the FSM
+  # already treats it as, so the durable projection matches the write-through
+  # (gate-off) result regardless of async append order. Inert under the gate off
+  # (the append always lands from the legal prior state).
   defp project(conn, %Op{kind: :assigned} = op, _seq) do
-    update_task_state(conn, op.task_id, "assigned", op.ts)
+    advance_task_state(conn, op.task_id, "queued", "assigned", op.ts)
   end
 
   defp project(conn, %Op{kind: :started} = op, _seq) do
-    update_task_state(conn, op.task_id, "running", op.ts)
+    advance_task_state(conn, op.task_id, "assigned", "running", op.ts)
   end
 
   defp project(conn, %Op{kind: :succeeded} = op, _seq) do
@@ -779,8 +789,13 @@ defmodule Embervm.OpLog.SQLite do
   defp project(conn, %Op{kind: :session_created} = op, _seq) do
     payload = op.payload
 
+    # INSERT OR IGNORE: idempotent on session_id so the adopt-and-backfill repair
+    # (session_manager Direction-2, ADR embervm/014) can re-append session_created
+    # for a lost async write without a primary-key clash if the original append
+    # later drains. A row already present (created before, or a backfill that won
+    # the race) is authoritative and left untouched.
     sql = """
-    INSERT INTO sessions
+    INSERT OR IGNORE INTO sessions
       (session_id, tenant, principal, workload, state, node_id,
        base_snapshot_ref, base_digest, generation, snapshot_ref, snapshot_size_bytes,
        token_sha256, created_at, last_invoke_at, expires_at, updated_at, terminal_reason)
@@ -853,8 +868,13 @@ defmodule Embervm.OpLog.SQLite do
   end
 
   # session_relit: restored to a live VM from its banked snapshot; back to running.
+  # Guarded against terminal states so a deferred async relit append (ADR embervm/014
+  # decision 2) that lands after the session was later destroyed/expired/failed
+  # cannot resurrect it to running; a live (running/banked/relighting) row still
+  # advances. Inert under the gate off (relit always lands from banked/relighting).
   defp project(conn, %Op{kind: :session_relit} = op, _seq) do
-    sql = "UPDATE sessions SET state='running', updated_at=? WHERE session_id=?"
+    sql =
+      "UPDATE sessions SET state='running', updated_at=? WHERE session_id=? AND state NOT IN ('destroyed','expired','evicted','failed')"
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
          :ok <- Sqlite3.bind(stmt, [op.ts, op.session_id]),
@@ -1822,6 +1842,22 @@ defmodule Embervm.OpLog.SQLite do
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
          :ok <- Sqlite3.bind(stmt, [state, ts, task_id]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  # Monotonic advance for a deferred async lifecycle append (see the :assigned/
+  # :started projections): SET the new state only when the row is still in the
+  # exact prior state the transition follows. A late append against a row that has
+  # already moved on (ran, succeeded, failed) matches no row and is a harmless
+  # no-op, so an out-of-order async append can never regress the durable state.
+  defp advance_task_state(conn, task_id, from_state, to_state, ts) do
+    sql = "UPDATE tasks SET state=?, updated_at=? WHERE task_id=? AND state=?"
+
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [to_state, ts, task_id, from_state]),
          :done <- Sqlite3.step(conn, stmt),
          :ok <- Sqlite3.release(conn, stmt) do
       :ok

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -688,22 +688,25 @@ defmodule Embervm.OpLog.SQLite do
     end
   end
 
-  # :assigned/:started advance the projection MONOTONICALLY (only from the state
-  # they legally follow), never as an unconditional SET. Under
-  # EMBERVM_ASYNC_LIFECYCLE_WRITES (ADR embervm/014 decision 2) these appends are
-  # deferred through Embervm.AsyncWriter, so a slow writer can land :assigned AFTER
-  # the terminal :succeeded already projected; a plain `SET state='assigned'` would
-  # REGRESS the durable row back to assigned. Guarding the prior state (queued for
-  # assigned, assigned for started) drops such a late append as the no-op the FSM
-  # already treats it as, so the durable projection matches the write-through
-  # (gate-off) result regardless of async append order. Inert under the gate off
-  # (the append always lands from the legal prior state).
+  # :assigned/:started advance the projection MONOTONICALLY along the task-lifecycle
+  # partial order (queued < assigned < running < terminal), never as an
+  # unconditional SET. Under EMBERVM_ASYNC_LIFECYCLE_WRITES (ADR embervm/014
+  # decision 2) these appends are deferred through Embervm.AsyncWriter, so an append
+  # can arrive out of order relative to a later synchronous op: a stale :assigned
+  # landing AFTER :succeeded, or a :started landing after its own :assigned was lost.
+  # advance_task_state SETs the target state only from a STRICTLY-LOWER-ranked state
+  # (Embervm.TaskState.forward_rank/1), so a stale late append against an equal-or-
+  # higher-ranked row is the no-op the FSM already treats it as, while a legitimate
+  # forward jump (queued -> running when :assigned was lost) still applies. The
+  # durable projection therefore converges to the same terminal state on BOTH the
+  # live write-through path and a full oplog rebuild-replay, regardless of async
+  # append order. Inert under the gate off (appends always arrive in rank order).
   defp project(conn, %Op{kind: :assigned} = op, _seq) do
-    advance_task_state(conn, op.task_id, "queued", "assigned", op.ts)
+    advance_task_state(conn, op.task_id, :assigned, op.ts)
   end
 
   defp project(conn, %Op{kind: :started} = op, _seq) do
-    advance_task_state(conn, op.task_id, "assigned", "running", op.ts)
+    advance_task_state(conn, op.task_id, :running, op.ts)
   end
 
   defp project(conn, %Op{kind: :succeeded} = op, _seq) do
@@ -1849,15 +1852,20 @@ defmodule Embervm.OpLog.SQLite do
   end
 
   # Monotonic advance for a deferred async lifecycle append (see the :assigned/
-  # :started projections): SET the new state only when the row is still in the
-  # exact prior state the transition follows. A late append against a row that has
-  # already moved on (ran, succeeded, failed) matches no row and is a harmless
-  # no-op, so an out-of-order async append can never regress the durable state.
-  defp advance_task_state(conn, task_id, from_state, to_state, ts) do
-    sql = "UPDATE tasks SET state=?, updated_at=? WHERE task_id=? AND state=?"
+  # :started projections): SET `to_state` (an atom) only when the row's current
+  # state ranks STRICTLY BELOW it in the task-lifecycle partial order
+  # (Embervm.TaskState.states_below/1). A late append against a row that already
+  # ran/terminalized (equal or higher rank) matches no row and is a harmless no-op,
+  # so an out-of-order async append can never regress the durable state; a
+  # legitimate forward jump (queued -> running when :assigned was lost) still
+  # applies. Same guard, same outcome on the live path and on rebuild-replay.
+  defp advance_task_state(conn, task_id, to_state, ts) do
+    below = Embervm.TaskState.states_below(to_state)
+    placeholders = Enum.map_join(below, ",", fn _ -> "?" end)
+    sql = "UPDATE tasks SET state=?, updated_at=? WHERE task_id=? AND state IN (#{placeholders})"
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
-         :ok <- Sqlite3.bind(stmt, [to_state, ts, task_id, from_state]),
+         :ok <- Sqlite3.bind(stmt, [Atom.to_string(to_state), ts, task_id | below]),
          :done <- Sqlite3.step(conn, stmt),
          :ok <- Sqlite3.release(conn, stmt) do
       :ok

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -262,7 +262,14 @@ defmodule Embervm.SessionManager do
       # (ms) before fail-closed orphan reconciliation acts (ADR embervm/014). Both
       # only bite under the node_confirmed_destroy gate.
       destroying_alarm_ms: Keyword.get(opts, :destroying_alarm_ms, 300_000),
-      orphan_grace_ms: Keyword.get(opts, :orphan_grace_ms, 60_000)
+      orphan_grace_ms: Keyword.get(opts, :orphan_grace_ms, 60_000),
+      # EMBERVM_ASYNC_LIFECYCLE_WRITES (ADR embervm/014 decision 2). When on, the
+      # Direction-2 orphan reconcile ADOPTS-and-backfills a reported session VM whose
+      # store row is absent BUT a durable write is still in flight for it (a young
+      # async-write race), rather than destroying it as a true orphan. The pending
+      # check consults Embervm.AsyncWriter; async_writer is the process to ask.
+      async_lifecycle_writes: Keyword.get(opts, :async_lifecycle_writes, false),
+      async_writer: Keyword.get(opts, :async_writer, Embervm.AsyncWriter)
     }
 
     # session_opts always carry a manager reference so the per-session idle timer can
@@ -1421,14 +1428,20 @@ defmodule Embervm.SessionManager do
       {:ok, node_id, vm_id, relight_ms, dial_id} ->
         session = get_session!(state, session_id)
 
+        # The wake hot-path durable append (session_relit): deferred to AsyncWriter
+        # under EMBERVM_ASYNC_LIFECYCLE_WRITES (ADR embervm/014 decision 2), so the
+        # woken session's durable write is off the wake path; the ETS row advances
+        # synchronously first (routable at once). vm_id registers the pending write
+        # for the adopt-and-backfill discriminator. Gate off: write-through.
         _ =
-          SessionStore.transition(
+          SessionStore.transition_lifecycle(
             state.session_store,
             session_id,
             :relight_ready,
             :session_relit,
             %{snapshot_ref: session.snapshot_ref, generation: session.generation, relight_ms: relight_ms},
-            %{node_id: node_id, vm_id: vm_id}
+            %{node_id: node_id, vm_id: vm_id},
+            vm_id
           )
 
         state = clear_bank_failures(state, session_id)
@@ -1642,37 +1655,82 @@ defmodule Embervm.SessionManager do
   end
 
   # Direction 2: a node reports a live session VM that no CP session row references.
-  # It is an orphan to DESTROY (node-confirmed), never to adopt. Primed-pool VMs are
-  # reported separately (WorkloadCapacity.primed_vm_ids), never in session_vms, so a
-  # session VM here is never a primed VM; a session VM only exists after a durable
-  # session_created op today (PR 1 semantics; the async-write race and its grace-window
-  # adopt-and-backfill discriminator arrive in PR 3), so no CP row means a genuine
-  # orphan. SessionVm carries no created_at, so the young-instance grace exclusion is
-  # deferred to PR 3 (where the async-write race it guards is introduced).
+  # It is an orphan to DESTROY (node-confirmed), UNLESS it is a young async-write
+  # race (ADR embervm/014 decision 2): under EMBERVM_ASYNC_LIFECYCLE_WRITES the
+  # durable session_created append is deferred, so between an interactive VM and its
+  # durable row there is a window where a fresh report shows the VM but no row yet
+  # matches. The adopt-vs-destroy discriminator (extending PR 1's Direction-2 pass):
+  #
+  #   * a pending async write references this vm_id (Embervm.AsyncWriter.pending?/2),
+  #     OR any live session row still references this vm_id (defence in depth)
+  #     => ADOPT: the deferred write is landing (or already did on another row); the
+  #        VM is legitimate. Do NOT destroy; the pending append backfills the durable
+  #        row, and adopt_one rebinds residency/process once the row is visible.
+  #   * neither => a genuine orphan (a leaked VM with no owning write): destroy it,
+  #     node-confirmed, exactly as PR 1 did.
+  #
+  # Primed-pool VMs are reported separately (WorkloadCapacity.primed_vm_ids), never
+  # in session_vms, so a session VM here is never a primed VM. The gate-off path is
+  # unchanged from PR 1 (no pending writes exist, so every rowless VM is an orphan).
   defp destroy_orphan_session_vms(state, facts, _live_vms) do
     for f <- facts, v <- Map.get(f, :session_vms, []) || [], reduce: state do
       acc ->
         case SessionStore.get(acc.session_store, v.session_id) do
           :error ->
-            confirmed =
-              destroy_vm(acc, %{
-                node_id: f.configured_id,
-                vm_id: v.vm_id
-              })
-
-            Logger.warning("embervm orphan session vm destroyed",
-              session_id: v.session_id,
-              vm_id: v.vm_id,
-              node_id: f.configured_id,
-              teardown_confirmed: confirmed
-            )
-
-            acc
+            reconcile_rowless_session_vm(acc, f, v)
 
           {:ok, _} ->
             acc
         end
     end
+  end
+
+  defp reconcile_rowless_session_vm(state, fact, v) do
+    if adopt_async_race?(state, v.vm_id) do
+      Logger.info("embervm session vm adopted (async-write race backfill)",
+        session_id: v.session_id,
+        vm_id: v.vm_id,
+        node_id: fact.configured_id
+      )
+
+      # ADOPT: leave the VM running. The deferred session_created append backfills
+      # the durable row; the next adoption pass (adopt_one) rebinds it once visible.
+      state
+    else
+      confirmed =
+        destroy_vm(state, %{
+          node_id: fact.configured_id,
+          vm_id: v.vm_id
+        })
+
+      Logger.warning("embervm orphan session vm destroyed",
+        session_id: v.session_id,
+        vm_id: v.vm_id,
+        node_id: fact.configured_id,
+        teardown_confirmed: confirmed
+      )
+
+      state
+    end
+  end
+
+  # The adopt-and-backfill discriminator: is this reported-but-rowless VM a young
+  # async-write race rather than a true orphan? Only meaningful under the async
+  # gate (gate off: no deferred writes exist, so this is always false and every
+  # rowless VM is an orphan, PR 1 behaviour). A pending async write for the vm_id,
+  # OR any live session row that still references it, means the VM is owned by a
+  # write that is landing; adopt it rather than destroy.
+  defp adopt_async_race?(%{async_lifecycle_writes: false}, _vm_id), do: false
+
+  defp adopt_async_race?(state, vm_id) do
+    Embervm.AsyncWriter.pending?(state.async_writer, vm_id) or
+      session_row_references_vm?(state, vm_id)
+  end
+
+  defp session_row_references_vm?(state, vm_id) do
+    state.session_store
+    |> SessionStore.all()
+    |> Enum.any?(fn s -> s.vm_id == vm_id and not SessionState.terminal?(s.state) end)
   end
 
   # vm session_id -> {node_id, vm_id, dial_id}; snapshot session_id ->

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -1654,24 +1654,28 @@ defmodule Embervm.SessionManager do
     state
   end
 
-  # Direction 2: a node reports a live session VM that no CP session row references.
+  # Direction 2: a node reports a live session VM whose session_id no CP row matches.
   # It is an orphan to DESTROY (node-confirmed), UNLESS it is a young async-write
   # race (ADR embervm/014 decision 2): under EMBERVM_ASYNC_LIFECYCLE_WRITES the
   # durable session_created append is deferred, so between an interactive VM and its
-  # durable row there is a window where a fresh report shows the VM but no row yet
-  # matches. The adopt-vs-destroy discriminator (extending PR 1's Direction-2 pass):
+  # durable row there is a window where a fresh report shows the VM but its durable
+  # row is not yet written. Under Option A the create's ETS row IS advanced
+  # synchronously at commit, so the discriminator queries the LIVE store/writer
+  # state (present in the commit..append window), not only durable rows:
   #
-  #   * a pending async write references this vm_id (Embervm.AsyncWriter.pending?/2),
-  #     OR any live session row still references this vm_id (defence in depth)
-  #     => ADOPT: the deferred write is landing (or already did on another row); the
-  #        VM is legitimate. Do NOT destroy; the pending append backfills the durable
-  #        row, and adopt_one rebinds residency/process once the row is visible.
+  #   * a pending async write references this vm_id (Embervm.AsyncWriter.pending?/2)
+  #     => ADOPT: the deferred append is in flight and IS the backfill; leave the VM.
+  #   * a live in-memory session row references this vm_id (its durable append was
+  #     lost, e.g. writer crash, but the ETS row survived) => ADOPT and actively
+  #     RE-DRIVE the missing session_created append from that row so the durable
+  #     projection catches up (the "resurfaces and adopts+backfills" ADR repair).
   #   * neither => a genuine orphan (a leaked VM with no owning write): destroy it,
   #     node-confirmed, exactly as PR 1 did.
   #
   # Primed-pool VMs are reported separately (WorkloadCapacity.primed_vm_ids), never
   # in session_vms, so a session VM here is never a primed VM. The gate-off path is
-  # unchanged from PR 1 (no pending writes exist, so every rowless VM is an orphan).
+  # unchanged from PR 1 (no pending writes / async rows exist, so every rowless VM
+  # is an orphan).
   defp destroy_orphan_session_vms(state, facts, _live_vms) do
     for f <- facts, v <- Map.get(f, :session_vms, []) || [], reduce: state do
       acc ->
@@ -1686,51 +1690,72 @@ defmodule Embervm.SessionManager do
   end
 
   defp reconcile_rowless_session_vm(state, fact, v) do
-    if adopt_async_race?(state, v.vm_id) do
-      Logger.info("embervm session vm adopted (async-write race backfill)",
-        session_id: v.session_id,
-        vm_id: v.vm_id,
-        node_id: fact.configured_id
-      )
+    case adopt_discriminator(state, v.vm_id) do
+      :pending ->
+        # The deferred append is still in flight: it will create the durable row.
+        Logger.info("embervm session vm adopted (async write in flight)",
+          session_id: v.session_id,
+          vm_id: v.vm_id,
+          node_id: fact.configured_id
+        )
 
-      # ADOPT: leave the VM running. The deferred session_created append backfills
-      # the durable row; the next adoption pass (adopt_one) rebinds it once visible.
-      state
-    else
-      confirmed =
-        destroy_vm(state, %{
+        state
+
+      {:backfill, row} ->
+        # A live ETS row references the vm but its durable append was lost: actively
+        # re-drive session_created from the surviving row (idempotent via INSERT OR
+        # IGNORE) so the durable projection catches up. adopt_one rebinds it after.
+        _ = SessionStore.backfill_created(state.session_store, row.session_id)
+
+        Logger.info("embervm session vm adopted+backfilled (async write lost)",
+          session_id: row.session_id,
+          vm_id: v.vm_id,
+          node_id: fact.configured_id
+        )
+
+        state
+
+      :orphan ->
+        confirmed =
+          destroy_vm(state, %{
+            node_id: fact.configured_id,
+            vm_id: v.vm_id
+          })
+
+        Logger.warning("embervm orphan session vm destroyed",
+          session_id: v.session_id,
+          vm_id: v.vm_id,
           node_id: fact.configured_id,
-          vm_id: v.vm_id
-        })
+          teardown_confirmed: confirmed
+        )
 
-      Logger.warning("embervm orphan session vm destroyed",
-        session_id: v.session_id,
-        vm_id: v.vm_id,
-        node_id: fact.configured_id,
-        teardown_confirmed: confirmed
-      )
-
-      state
+        state
     end
   end
 
-  # The adopt-and-backfill discriminator: is this reported-but-rowless VM a young
-  # async-write race rather than a true orphan? Only meaningful under the async
-  # gate (gate off: no deferred writes exist, so this is always false and every
-  # rowless VM is an orphan, PR 1 behaviour). A pending async write for the vm_id,
-  # OR any live session row that still references it, means the VM is owned by a
-  # write that is landing; adopt it rather than destroy.
-  defp adopt_async_race?(%{async_lifecycle_writes: false}, _vm_id), do: false
+  # The adopt-vs-destroy discriminator. Only meaningful under the async gate (gate
+  # off: no deferred writes / async rows, so always :orphan, PR 1 behaviour). Prefers
+  # the pending-write signal (the append is landing on its own); else looks for a
+  # live in-memory row referencing the vm (a lost append to re-drive); else :orphan.
+  defp adopt_discriminator(%{async_lifecycle_writes: false}, _vm_id), do: :orphan
 
-  defp adopt_async_race?(state, vm_id) do
-    Embervm.AsyncWriter.pending?(state.async_writer, vm_id) or
-      session_row_references_vm?(state, vm_id)
+  defp adopt_discriminator(state, vm_id) do
+    cond do
+      Embervm.AsyncWriter.pending?(state.async_writer, vm_id) ->
+        :pending
+
+      row = session_row_for_vm(state, vm_id) ->
+        {:backfill, row}
+
+      true ->
+        :orphan
+    end
   end
 
-  defp session_row_references_vm?(state, vm_id) do
+  defp session_row_for_vm(state, vm_id) do
     state.session_store
     |> SessionStore.all()
-    |> Enum.any?(fn s -> s.vm_id == vm_id and not SessionState.terminal?(s.state) end)
+    |> Enum.find(fn s -> s.vm_id == vm_id and not SessionState.terminal?(s.state) end)
   end
 
   # vm session_id -> {node_id, vm_id, dial_id}; snapshot session_id ->

--- a/projects/embervm/control/lib/embervm/session_store.ex
+++ b/projects/embervm/control/lib/embervm/session_store.ex
@@ -210,6 +210,20 @@ defmodule Embervm.SessionStore do
   end
 
   @doc """
+  Re-drive the durable `session_created` append for a session whose ETS row
+  survived but whose deferred async append was lost (ADR embervm/014 decision 2's
+  adopt-and-backfill repair, called by the reconciler). Reconstructs the op from
+  the live ETS row and appends it SYNCHRONOUSLY (reconcile is not a hot path, and a
+  synchronous append guarantees the durable row lands before the next pass). The
+  projection is INSERT OR IGNORE, so a re-drive that races the original append (or
+  runs twice) is idempotent. A no-op / `:error` for an unknown session.
+  """
+  @spec backfill_created(GenServer.server(), String.t()) :: :ok | {:error, term()}
+  def backfill_created(store \\ __MODULE__, session_id) do
+    GenServer.call(store, {:backfill_created, session_id})
+  end
+
+  @doc """
   Pages sessions for `workload`, newest-created first, by `:limit` (default 50)
   and `:offset` (default 0). A full ETS scan (bounded, listing is rare), never
   the op-log; serves `GET /v1/workloads/{name}/sessions`.
@@ -392,6 +406,36 @@ defmodule Embervm.SessionStore do
     {:reply, all, state}
   end
 
+  def handle_call({:backfill_created, session_id}, _from, state) do
+    case fetch(state, session_id) do
+      {:ok, session} ->
+        # Reconstruct the session_created op from the surviving ETS row and append it
+        # synchronously. The projection is INSERT OR IGNORE, so this is idempotent
+        # even if the original deferred append later drains or this runs twice.
+        op = %Op{
+          kind: :session_created,
+          tenant: session.tenant,
+          principal: session.principal,
+          workload: session.workload,
+          session_id: session_id,
+          ts: state.clock.(),
+          payload: %{
+            node_id: session.node_id,
+            base_snapshot_ref: session.base_snapshot_ref,
+            base_digest: session.base_digest,
+            token_sha256: session.token_sha256,
+            expires_at: session.expires_at,
+            state: to_string(session.state)
+          }
+        }
+
+        {:reply, backfill_reply(state.op_log_mod.append(state.op_log, op)), state}
+
+      :error ->
+        {:reply, :error, state}
+    end
+  end
+
   def handle_call({:adopt_state, session_id, new_state}, _from, state)
       when new_state in [:running, :banked] do
     case fetch(state, session_id) do
@@ -542,6 +586,9 @@ defmodule Embervm.SessionStore do
     put_residency(state, session)
     :ok
   end
+
+  defp backfill_reply({:ok, _seq}), do: :ok
+  defp backfill_reply({:error, _reason} = error), do: error
 
   # -- transition ------------------------------------------------------------
 

--- a/projects/embervm/control/lib/embervm/session_store.ex
+++ b/projects/embervm/control/lib/embervm/session_store.ex
@@ -431,8 +431,8 @@ defmodule Embervm.SessionStore do
 
         {:reply, backfill_reply(state.op_log_mod.append(state.op_log, op)), state}
 
-      :error ->
-        {:reply, :error, state}
+      {:error, _reason} = error ->
+        {:reply, error, state}
     end
   end
 

--- a/projects/embervm/control/lib/embervm/session_store.ex
+++ b/projects/embervm/control/lib/embervm/session_store.ex
@@ -89,6 +89,21 @@ defmodule Embervm.SessionStore do
   end
 
   @doc """
+  Like `transition/6`, but the durable append may be DEFERRED to Embervm.AsyncWriter
+  when `EMBERVM_ASYNC_LIFECYCLE_WRITES` is on (ADR embervm/014 decision 2). Used only
+  for the wake hot-path `session_relit`: the ETS row (state + residency +
+  `node_id`/`vm_id` from `updates`) is advanced synchronously so the woken session is
+  immediately routable and adoption sees it, and the durable append lands afterward.
+  `vm_id` registers the pending write for the reconciler's adopt-and-backfill
+  discriminator. Gate off: identical to `transition/6` (write-through).
+  """
+  @spec transition_lifecycle(GenServer.server(), String.t(), atom(), atom(), map(), map(), binary() | nil) ::
+          {:ok, map()} | {:error, term()}
+  def transition_lifecycle(store \\ __MODULE__, session_id, event, op_kind, payload, updates, vm_id) do
+    GenServer.call(store, {:transition_lifecycle, session_id, event, op_kind, payload, updates, vm_id})
+  end
+
+  @doc """
   Applies a TRANSIENT FSM edge to a session WITHOUT an op-log append: the ETS-only
   move into a mid-operation state (`banking`, `relighting`) that a crash heals from
   node inventory rather than from the durable log (there is no `session_banking`/
@@ -219,6 +234,15 @@ defmodule Embervm.SessionStore do
     # %{principal, ts, stats}, so Embervm.Metering charges the quota cache off the
     # same write, exactly like TaskStore. No-op default (unit tests wire none).
     on_metered = Keyword.get(opts, :on_metered, fn _event -> :ok end)
+    # Off-hot-path boot/wake writes (ADR embervm/014 decision 2). When on, the
+    # session_created (create) and session_relit (wake) durable appends are deferred
+    # to Embervm.AsyncWriter AFTER the ETS row + token are minted synchronously (the
+    # caller needs the token, and reads/adoption must see the row immediately), so
+    # the boot/wake caller never blocks on the durable write. Off (default): exact
+    # write-through ordering (append THEN reply). Never applies to session_invoked,
+    # bank, or terminal ops (those stay synchronous).
+    async_writer = Keyword.get(opts, :async_writer, Embervm.AsyncWriter)
+    async_lifecycle_writes = Keyword.get(opts, :async_lifecycle_writes, false)
 
     sessions = :ets.new(@sessions_table, [:set, :private])
     residency = :ets.new(@residency_table, [:set, :private])
@@ -229,6 +253,8 @@ defmodule Embervm.SessionStore do
       clock: clock,
       id_fun: id_fun,
       on_metered: on_metered,
+      async_writer: async_writer,
+      async_lifecycle_writes: async_lifecycle_writes,
       sessions: sessions,
       residency: residency,
       # workload -> %{live, banked}, kept in step with the hot set on every write.
@@ -311,6 +337,14 @@ defmodule Embervm.SessionStore do
 
   def handle_call({:transition, session_id, event, op_kind, payload, updates}, _from, state) do
     do_transition(state, session_id, event, op_kind, payload, updates)
+  end
+
+  def handle_call({:transition_lifecycle, session_id, event, op_kind, payload, updates, vm_id}, _from, state) do
+    if state.async_lifecycle_writes do
+      do_transition_async(state, session_id, event, op_kind, payload, updates, vm_id)
+    else
+      do_transition(state, session_id, event, op_kind, payload, updates)
+    end
   end
 
   def handle_call({:mark, session_id, event}, _from, state) do
@@ -441,46 +475,72 @@ defmodule Embervm.SessionStore do
       payload: payload
     }
 
-    case state.op_log_mod.append(state.op_log, op) do
-      {:ok, _seq} ->
-        session = %{
-          session_id: session_id,
-          tenant: op.tenant,
-          principal: op.principal,
-          workload: op.workload,
-          state: :running,
-          node_id: Map.get(attrs, :node_id),
-          vm_id: Map.get(attrs, :vm_id),
-          base_snapshot_ref: Map.get(attrs, :base_snapshot_ref),
-          base_digest: Map.get(attrs, :base_digest),
-          generation: 0,
-          snapshot_ref: nil,
-          snapshot_size_bytes: nil,
-          token_sha256: token_sha256,
-          created_at: ts,
-          last_invoke_at: nil,
-          expires_at: Map.get(attrs, :expires_at),
-          updated_at: ts,
-          terminal_reason: nil
-        }
+    session = %{
+      session_id: session_id,
+      tenant: op.tenant,
+      principal: op.principal,
+      workload: op.workload,
+      state: :running,
+      node_id: Map.get(attrs, :node_id),
+      vm_id: Map.get(attrs, :vm_id),
+      base_snapshot_ref: Map.get(attrs, :base_snapshot_ref),
+      base_digest: Map.get(attrs, :base_digest),
+      generation: 0,
+      snapshot_ref: nil,
+      snapshot_size_bytes: nil,
+      token_sha256: token_sha256,
+      created_at: ts,
+      last_invoke_at: nil,
+      expires_at: Map.get(attrs, :expires_at),
+      updated_at: ts,
+      terminal_reason: nil
+    }
 
-        :ets.insert(state.sessions, {session_id, session})
-        put_residency(state, session)
-        state = bump_counts(state, nil, :running, session.workload)
+    reply = %{
+      session_id: session_id,
+      token: token,
+      expires_at: session.expires_at,
+      base_digest: session.base_digest,
+      state: :running
+    }
 
-        reply = %{
-          session_id: session_id,
-          token: token,
-          expires_at: session.expires_at,
-          base_digest: session.base_digest,
-          state: :running
-        }
+    if state.async_lifecycle_writes do
+      # Gate on (ADR embervm/014 decision 2): mint the ETS row + token synchronously
+      # (the caller needs the token, and adoption/reads must see the session at
+      # once), then defer the durable session_created append to Embervm.AsyncWriter
+      # so the create caller does not block on it. A CP crash before the append
+      # lands loses the row; the node still reports the live VM, and the adoption
+      # backfill re-creates it (session_manager Direction-2), so the vm_id registers
+      # the pending write for that discriminator.
+      insert_created_session(state, session)
 
-        {:reply, {:ok, reply}, state}
+      Embervm.AsyncWriter.enqueue(state.async_writer, %{
+        op: op,
+        op_log_mod: state.op_log_mod,
+        op_log: state.op_log,
+        vm_id: Map.get(attrs, :vm_id)
+      })
 
-      {:error, _reason} = error ->
-        {:reply, error, state}
+      {:reply, {:ok, reply}, bump_counts(state, nil, :running, session.workload)}
+    else
+      case state.op_log_mod.append(state.op_log, op) do
+        {:ok, _seq} ->
+          insert_created_session(state, session)
+          {:reply, {:ok, reply}, bump_counts(state, nil, :running, session.workload)}
+
+        {:error, _reason} = error ->
+          {:reply, error, state}
+      end
     end
+  end
+
+  # The ETS side of a create: the hot-set row + its residency fact. Shared by the
+  # write-through and async paths so both land the identical in-memory state; only
+  # the durable append's timing differs between them.
+  defp insert_created_session(state, session) do
+    :ets.insert(state.sessions, {session.session_id, session})
+    put_residency(state, session)
+    :ok
   end
 
   # -- transition ------------------------------------------------------------
@@ -492,6 +552,50 @@ defmodule Embervm.SessionStore do
         {:ok, updated, state} -> {:reply, {:ok, updated}, state}
         {:error, reason} -> {:reply, {:error, reason}, state}
       end
+    else
+      {:error, _reason} = error -> {:reply, error, state}
+    end
+  end
+
+  # The async-deferred transition (session_relit under the gate, ADR embervm/014
+  # decision 2): advance the FSM + ETS row (state, merged updates, residency,
+  # counts) SYNCHRONOUSLY so the woken session is immediately routable and adoption
+  # sees it, then defer the durable append to Embervm.AsyncWriter. Mirrors
+  # append_and_update's ETS side exactly, minus the metering hook: this path is only
+  # ever a non-terminal, usage-free lifecycle op (session_relit), so there is
+  # nothing to charge (metering stays synchronous, on the terminal/invoke ops).
+  defp do_transition_async(state, session_id, event, op_kind, payload, updates, vm_id) do
+    with {:ok, session} <- fetch(state, session_id),
+         {:ok, next} <- SessionState.transition(session.state, event) do
+      ts = state.clock.()
+
+      op = %Op{
+        kind: op_kind,
+        tenant: session.tenant,
+        principal: session.principal,
+        workload: session.workload,
+        session_id: session_id,
+        ts: ts,
+        payload: payload
+      }
+
+      updated =
+        session
+        |> Map.merge(updates)
+        |> Map.merge(%{state: next, updated_at: ts})
+
+      :ets.insert(state.sessions, {session_id, updated})
+      state = bump_counts(state, session.state, next, session.workload)
+      state = apply_residency(state, session.state, updated)
+
+      Embervm.AsyncWriter.enqueue(state.async_writer, %{
+        op: op,
+        op_log_mod: state.op_log_mod,
+        op_log: state.op_log,
+        vm_id: vm_id
+      })
+
+      {:reply, {:ok, updated}, state}
     else
       {:error, _reason} = error -> {:reply, error, state}
     end

--- a/projects/embervm/control/lib/embervm/task_state.ex
+++ b/projects/embervm/control/lib/embervm/task_state.ex
@@ -126,4 +126,44 @@ defmodule Embervm.TaskState do
         raise IllegalTransition, state: state, event: event
     end
   end
+
+  # The lifecycle-forward rank: a monotone partial order over the states along the
+  # normal progression queued -> assigned -> running -> {terminal or the retry
+  # branch}. It exists so the op-log projection can apply a DEFERRED, possibly
+  # out-of-order async lifecycle append (:assigned/:started under
+  # EMBERVM_ASYNC_LIFECYCLE_WRITES, ADR embervm/014 decision 2) MONOTONICALLY: an
+  # append that targets a state advances the durable projection only from a
+  # strictly-lower-ranked state, so a stale late-arriving :assigned cannot regress a
+  # row that already ran or terminalized, while a legitimate forward jump (queued ->
+  # running when the :assigned append was lost) still applies. failed_retryable and
+  # every terminal state rank ABOVE running so neither :assigned (rank 1) nor
+  # :started (rank 2) can ever pull them backward; a genuine re-run re-enters at
+  # queued (rank 0) via :retry/:redrive and is advanced by fresh appends. This is
+  # the single source of truth for that order; the SQLite/Postgres projections
+  # derive their guard predicate from it (see states_below/1).
+  @forward_rank %{
+    queued: 0,
+    assigned: 1,
+    running: 2,
+    failed_retryable: 3,
+    succeeded: 3,
+    failed_permanent: 3,
+    dead_lettered: 3
+  }
+
+  @spec forward_rank(state()) :: non_neg_integer()
+  def forward_rank(state), do: Map.fetch!(@forward_rank, state)
+
+  @doc """
+  The set of state NAMES (as strings, matching the durable `tasks.state` column)
+  ranked strictly below `target`. A deferred async append that moves the projection
+  to `target` may only do so from one of these, so the projection stays monotone
+  under out-of-order/replayed appends. `target` is an atom state.
+  """
+  @spec states_below(state()) :: [String.t()]
+  def states_below(target) do
+    target_rank = forward_rank(target)
+
+    for {state, rank} <- @forward_rank, rank < target_rank, do: Atom.to_string(state)
+  end
 end

--- a/projects/embervm/control/lib/embervm/task_store.ex
+++ b/projects/embervm/control/lib/embervm/task_store.ex
@@ -62,14 +62,31 @@ defmodule Embervm.TaskStore do
     GenServer.call(store, {:submit, attrs})
   end
 
+  @doc """
+  Move a queued task to `:assigned`. The 3-arity form carries the `vm_id` the
+  dispatch reserved: under async lifecycle writes it registers the deferred append
+  with Embervm.AsyncWriter so the reconciler's adopt-and-backfill discriminator can
+  see a write in flight for that VM. The 1/2-arity form passes `nil` (no vm to
+  register), keeping every existing caller unchanged.
+  """
   @spec assign(GenServer.server(), String.t()) :: {:ok, map()} | {:error, term()}
   def assign(store \\ __MODULE__, task_id) do
-    GenServer.call(store, {:assign, task_id})
+    GenServer.call(store, {:assign, task_id, nil})
+  end
+
+  @spec assign(GenServer.server(), String.t(), binary() | nil) :: {:ok, map()} | {:error, term()}
+  def assign(store, task_id, vm_id) do
+    GenServer.call(store, {:assign, task_id, vm_id})
   end
 
   @spec start(GenServer.server(), String.t()) :: {:ok, map()} | {:error, term()}
   def start(store \\ __MODULE__, task_id) do
-    GenServer.call(store, {:start, task_id})
+    GenServer.call(store, {:start, task_id, nil})
+  end
+
+  @spec start(GenServer.server(), String.t(), binary() | nil) :: {:ok, map()} | {:error, term()}
+  def start(store, task_id, vm_id) do
+    GenServer.call(store, {:start, task_id, vm_id})
   end
 
   @spec succeed(GenServer.server(), String.t(), map()) :: {:ok, map()} | {:error, term()}
@@ -264,6 +281,16 @@ defmodule Embervm.TaskStore do
     # store with no metering wired (unit tests) drops the signal; the durable
     # `usage` projection is unaffected either way.
     on_metered = Keyword.get(opts, :on_metered, fn _event -> :ok end)
+    # Off-hot-path lifecycle writes (ADR embervm/014 decision 2). When
+    # async_lifecycle_writes is on, the :assigned/:started transitions advance ETS
+    # synchronously (so the FSM's later terminal transition is legal and reads are
+    # correct) but hand their durable oplog append to Embervm.AsyncWriter instead of
+    # blocking the caller on it. Off (default): exact write-through ordering (append
+    # THEN ETS, caller blocked on the durable write), today's behaviour. Never
+    # applies to :submitted or any terminal/usage op (those gate metering and stay
+    # synchronous), only the two dispatch-path transitions below.
+    async_writer = Keyword.get(opts, :async_writer, Embervm.AsyncWriter)
+    async_lifecycle_writes = Keyword.get(opts, :async_lifecycle_writes, false)
 
     tasks = :ets.new(@tasks_table, [:set, :private])
     idem = :ets.new(@idem_table, [:set, :private])
@@ -275,6 +302,8 @@ defmodule Embervm.TaskStore do
       clock: clock,
       on_queued: on_queued,
       on_metered: on_metered,
+      async_writer: async_writer,
+      async_lifecycle_writes: async_lifecycle_writes,
       tasks: tasks,
       idem: idem
     }
@@ -407,12 +436,12 @@ defmodule Embervm.TaskStore do
     end
   end
 
-  def handle_call({:assign, task_id}, _from, state) do
-    apply_transition(state, task_id, :assign, :assigned, %{})
+  def handle_call({:assign, task_id, vm_id}, _from, state) do
+    apply_lifecycle_transition(state, task_id, :assign, :assigned, vm_id)
   end
 
-  def handle_call({:start, task_id}, _from, state) do
-    apply_transition(state, task_id, :start, :started, %{})
+  def handle_call({:start, task_id, vm_id}, _from, state) do
+    apply_lifecycle_transition(state, task_id, :start, :started, vm_id)
   end
 
   def handle_call({:succeed, task_id, result, usage}, _from, state) do
@@ -671,6 +700,57 @@ defmodule Embervm.TaskStore do
         {:ok, updated} -> {:reply, {:ok, updated}, state}
         {:error, _reason} = error -> {:reply, error, state}
       end
+    else
+      {:error, _reason} = error -> {:reply, error, state}
+    end
+  end
+
+  # The two dispatch-path lifecycle transitions (:assign, :start). Gate off:
+  # identical to apply_transition (write-through, caller blocked on the durable
+  # append). Gate on (ADR embervm/014 decision 2): advance ETS SYNCHRONOUSLY so the
+  # task is immediately :assigned/:running for reads and for the FSM's later terminal
+  # transition, then hand the durable oplog append to Embervm.AsyncWriter, so the
+  # caller (the dispatch hot path) never blocks on the durable write. A CP crash
+  # before the async append lands loses the op: the task's durable row stays
+  # :queued, and the dispatcher's boot backlog sweep re-drives it (no task is ever
+  # reconcile-DESTROYED, so a lost task lifecycle write is self-healing without a
+  # discriminator). vm_id is registered as a pending write anyway, for parity with
+  # the session path and so a shared reconciler could consult it if ever needed.
+  defp apply_lifecycle_transition(state, task_id, event, op_kind, vm_id) do
+    if state.async_lifecycle_writes do
+      apply_transition_async(state, task_id, event, op_kind, vm_id)
+    else
+      apply_transition(state, task_id, event, op_kind, %{})
+    end
+  end
+
+  defp apply_transition_async(state, task_id, event, op_kind, vm_id) do
+    with {:ok, task} <- fetch_task(state, task_id),
+         {:ok, next} <- TaskState.transition(task.state, event) do
+      ts = state.clock.()
+      updated = %{task | state: next, updated_at: ts}
+      # ETS advances NOW (synchronous), so reads and the later terminal transition
+      # see the advanced state; the durable append is deferred.
+      :ets.insert(state.tasks, {task_id, updated})
+
+      op = %Op{
+        kind: op_kind,
+        tenant: task.tenant,
+        principal: task.principal,
+        workload: task.workload,
+        task_id: task_id,
+        ts: ts,
+        payload: %{}
+      }
+
+      Embervm.AsyncWriter.enqueue(state.async_writer, %{
+        op: op,
+        op_log_mod: state.op_log_mod,
+        op_log: state.op_log,
+        vm_id: vm_id
+      })
+
+      {:reply, {:ok, updated}, state}
     else
       {:error, _reason} = error -> {:reply, error, state}
     end

--- a/projects/embervm/control/test/embervm/async_writer_test.exs
+++ b/projects/embervm/control/test/embervm/async_writer_test.exs
@@ -1,0 +1,175 @@
+defmodule Embervm.AsyncWriterTest do
+  @moduledoc """
+  AsyncWriter (ADR embervm/014 decision 2): the off-hot-path oplog append queue.
+
+  Assertions are COUNTER/order based, never identity based (the repo's hash-fragile
+  test lesson from PR 2): we record the ORDER of applied op kinds and count appends,
+  rather than matching on a specific op-log seq or pid.
+  """
+  use ExUnit.Case, async: true
+
+  alias Embervm.AsyncWriter
+  alias Embervm.OpLog.Op
+
+  # A recording op-log backend. `append/2` pushes {kind, task_id} onto a shared
+  # Agent list (in apply order) and returns a monotonically increasing seq, matching
+  # the @behaviour Embervm.OpLog append/2 contract the writer calls. Two behaviours
+  # keyed off the op's payload keep every stub in one module (no defmodule-in-a-test):
+  #   * payload[:block] = waiter  -> announce {:appending, ...} and wait for :go,
+  #     so a test can observe pending?/2 with an append held in flight.
+  #   * payload[:fail] = true     -> return {:error, :disk_full} without recording.
+  defmodule RecordingOpLog do
+    def start, do: Agent.start_link(fn -> %{seq: 0, applied: []} end)
+
+    def applied(agent), do: Agent.get(agent, & &1.applied) |> Enum.reverse()
+
+    def count(agent), do: Agent.get(agent, &length(&1.applied))
+
+    def append(_agent, %Op{payload: %{fail: true}}), do: {:error, :disk_full}
+
+    def append(agent, %Op{payload: %{block: waiter}} = op) when is_pid(waiter) do
+      send(waiter, {:appending, op.task_id, self()})
+
+      receive do
+        :go -> :ok
+      end
+
+      record(agent, op)
+    end
+
+    def append(agent, %Op{} = op), do: record(agent, op)
+
+    defp record(agent, op) do
+      seq =
+        Agent.get_and_update(agent, fn s ->
+          {s.seq + 1, %{s | seq: s.seq + 1, applied: [{op.kind, op.task_id} | s.applied]}}
+        end)
+
+      {:ok, seq}
+    end
+  end
+
+  defp op(kind, task_id, payload \\ %{}) do
+    %Op{kind: kind, tenant: "t", task_id: task_id, ts: 0, payload: payload}
+  end
+
+  defp entry(agent, kind, task_id, vm_id \\ nil, payload \\ %{}) do
+    %{op: op(kind, task_id, payload), op_log_mod: RecordingOpLog, op_log: agent, vm_id: vm_id}
+  end
+
+  test "ops for one instance apply in submission order" do
+    {:ok, agent} = RecordingOpLog.start()
+    {:ok, writer} = AsyncWriter.start_link(name: nil)
+
+    AsyncWriter.enqueue(writer, entry(agent, :assigned, "task-1"))
+    AsyncWriter.enqueue(writer, entry(agent, :started, "task-1"))
+    :ok = AsyncWriter.drain(writer)
+
+    assert RecordingOpLog.applied(agent) == [{:assigned, "task-1"}, {:started, "task-1"}]
+  end
+
+  test "interleaved instances each keep their own submission order" do
+    {:ok, agent} = RecordingOpLog.start()
+    {:ok, writer} = AsyncWriter.start_link(name: nil)
+
+    AsyncWriter.enqueue(writer, entry(agent, :assigned, "a"))
+    AsyncWriter.enqueue(writer, entry(agent, :assigned, "b"))
+    AsyncWriter.enqueue(writer, entry(agent, :started, "a"))
+    AsyncWriter.enqueue(writer, entry(agent, :started, "b"))
+    :ok = AsyncWriter.drain(writer)
+
+    applied = RecordingOpLog.applied(agent)
+    a_order = for {k, "a"} <- applied, do: k
+    b_order = for {k, "b"} <- applied, do: k
+
+    assert a_order == [:assigned, :started]
+    assert b_order == [:assigned, :started]
+    assert RecordingOpLog.count(agent) == 4
+  end
+
+  test "pending?/2 is true while a vm's append is in flight, false once applied" do
+    {:ok, agent} = RecordingOpLog.start()
+    {:ok, writer} = AsyncWriter.start_link(name: nil)
+
+    AsyncWriter.enqueue(writer, entry(agent, :started, "task-vm", "vm-1", %{block: self()}))
+
+    # The writer has entered the (blocked) append: it must report the vm pending.
+    assert_receive {:appending, "task-vm", appender}
+    assert AsyncWriter.pending?(writer, "vm-1")
+    refute AsyncWriter.pending?(writer, "vm-2")
+
+    # Release the append; after drain the vm is no longer pending.
+    send(appender, :go)
+    :ok = AsyncWriter.drain(writer)
+
+    refute AsyncWriter.pending?(writer, "vm-1")
+    assert RecordingOpLog.count(agent) == 1
+  end
+
+  test "two in-flight appends for one vm keep it pending until both apply" do
+    {:ok, agent} = RecordingOpLog.start()
+    {:ok, writer} = AsyncWriter.start_link(name: nil)
+
+    # assigned then started, both for vm-1, both blocking: the vm must stay pending
+    # across the first's completion, cleared only after the second applies (the
+    # count, not set, semantics).
+    AsyncWriter.enqueue(writer, entry(agent, :assigned, "task-vm", "vm-1", %{block: self()}))
+    AsyncWriter.enqueue(writer, entry(agent, :started, "task-vm", "vm-1", %{block: self()}))
+
+    assert_receive {:appending, "task-vm", first}
+    assert AsyncWriter.pending?(writer, "vm-1")
+    send(first, :go)
+
+    assert_receive {:appending, "task-vm", second}
+    # First applied, second in flight: still pending (two appends were tracked).
+    assert AsyncWriter.pending?(writer, "vm-1")
+    send(second, :go)
+
+    :ok = AsyncWriter.drain(writer)
+    refute AsyncWriter.pending?(writer, "vm-1")
+    assert RecordingOpLog.count(agent) == 2
+  end
+
+  test "a crash before the append loses the op (documented: repaired by reconcile)" do
+    {:ok, agent} = RecordingOpLog.start()
+    {:ok, writer} = AsyncWriter.start_link(name: nil)
+
+    # An op enqueued but never given a chance to apply (we kill the writer with the
+    # cast still in its mailbox) leaves NOTHING durable. This encodes the ADR's
+    # accepted crash-loss window; the adoption backfill (session_manager) is the
+    # repair, exercised in session_manager_test.
+    :ok = GenServer.cast(writer, {:enqueue, entry(agent, :assigned, "doomed")})
+    Process.exit(writer, :kill)
+    ref = Process.monitor(writer)
+    assert_receive {:DOWN, ^ref, :process, ^writer, :killed}
+
+    assert RecordingOpLog.count(agent) == 0
+  end
+
+  test "graceful shutdown drains queued appends (terminate/2 flush)" do
+    {:ok, agent} = RecordingOpLog.start()
+    {:ok, writer} = AsyncWriter.start_link(name: nil)
+
+    # Enqueue several and immediately stop gracefully: terminate/2 must flush the
+    # whole mailbox, so a normal CP roll loses none of them.
+    for i <- 1..5, do: AsyncWriter.enqueue(writer, entry(agent, :assigned, "task-#{i}"))
+    :ok = GenServer.stop(writer, :normal)
+
+    assert RecordingOpLog.count(agent) == 5
+  end
+
+  test "append failure does not take the writer or other appends down" do
+    {:ok, agent} = RecordingOpLog.start()
+    {:ok, writer} = AsyncWriter.start_link(name: nil)
+
+    AsyncWriter.enqueue(writer, entry(agent, :assigned, "boom", "vm-boom", %{fail: true}))
+    AsyncWriter.enqueue(writer, entry(agent, :assigned, "ok"))
+    :ok = AsyncWriter.drain(writer)
+
+    assert Process.alive?(writer)
+    # The good append still landed; the failed one did not; the failed vm is no
+    # longer pending (untracked even on failure, so the reconciler is not misled).
+    assert RecordingOpLog.applied(agent) == [{:assigned, "ok"}]
+    refute AsyncWriter.pending?(writer, "vm-boom")
+  end
+end

--- a/projects/embervm/control/test/embervm/async_writer_test.exs
+++ b/projects/embervm/control/test/embervm/async_writer_test.exs
@@ -137,8 +137,11 @@ defmodule Embervm.AsyncWriterTest do
     # An op enqueued but never given a chance to apply (we kill the writer with the
     # cast still in its mailbox) leaves NOTHING durable. This encodes the ADR's
     # accepted crash-loss window; the adoption backfill (session_manager) is the
-    # repair, exercised in session_manager_test.
-    :ok = GenServer.cast(writer, {:enqueue, entry(agent, :assigned, "doomed")})
+    # repair, exercised in session_manager_test. A blocking op holds the writer so
+    # the second (doomed) enqueue is still in the mailbox when we kill it.
+    AsyncWriter.enqueue(writer, entry(agent, :assigned, "held", "vm-held", %{block: self()}))
+    assert_receive {:appending, "held", _appender}
+    AsyncWriter.enqueue(writer, entry(agent, :assigned, "doomed"))
     Process.exit(writer, :kill)
     ref = Process.monitor(writer)
     assert_receive {:DOWN, ^ref, :process, ^writer, :killed}

--- a/projects/embervm/control/test/embervm/async_writer_test.exs
+++ b/projects/embervm/control/test/embervm/async_writer_test.exs
@@ -142,8 +142,12 @@ defmodule Embervm.AsyncWriterTest do
     AsyncWriter.enqueue(writer, entry(agent, :assigned, "held", "vm-held", %{block: self()}))
     assert_receive {:appending, "held", _appender}
     AsyncWriter.enqueue(writer, entry(agent, :assigned, "doomed"))
-    Process.exit(writer, :kill)
     ref = Process.monitor(writer)
+    # Unlink first: start_link/1 links the writer to this test process, and an
+    # untrappable :kill propagates over that link and would take the test down
+    # with it. The monitor (unaffected by unlink) still observes the death.
+    Process.unlink(writer)
+    Process.exit(writer, :kill)
     assert_receive {:DOWN, ^ref, :process, ^writer, :killed}
 
     assert RecordingOpLog.count(agent) == 0

--- a/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
@@ -822,4 +822,94 @@ defmodule Embervm.OpLog.SQLiteTest do
     assert legacy.payload == %{"status_code" => 200, "body" => "legacy", "size_bytes" => 6}
     :ok = GenServer.stop(server2)
   end
+
+  # -- monotonic lifecycle-projection guard (ADR embervm/014 decision 2) -----
+
+  defp append_task_op(server, kind, task_id, ts, payload \\ %{}) do
+    {:ok, _} =
+      SQLite.append(server, %Op{kind: kind, tenant: "t1", task_id: task_id, ts: ts, payload: payload})
+
+    :ok
+  end
+
+  defp task_state(server, task_id) do
+    {:ok, tasks} = SQLite.load_tasks(server)
+    tasks |> Map.new(&{&1.task_id, &1}) |> Map.get(task_id) |> Map.get(:state)
+  end
+
+  test "a stale :assigned appended AFTER :succeeded does NOT regress the durable state, but IS still recorded",
+       %{path: path} do
+    server = start_server(path)
+
+    append_task_op(server, :submitted, "task-x", 100, %{idempotency_key: nil, expires_at: nil})
+    append_task_op(server, :assigned, "task-x", 101)
+    append_task_op(server, :started, "task-x", 102)
+
+    append_task_op(server, :succeeded, "task-x", 103, %{
+      status_code: 200,
+      body: "ok",
+      size_bytes: 2,
+      truncated: false,
+      expires_at: 9_999
+    })
+
+    # A DEFERRED async :assigned lands late (out of order relative to :succeeded).
+    append_task_op(server, :assigned, "task-x", 104)
+
+    # Projection did NOT regress: the monotonic guard made the late append a no-op.
+    assert task_state(server, "task-x") == "succeeded"
+
+    # ...but the op is STILL in the durable log (audit trail): two :assigned ops, and
+    # the state survives a full reopen (rebuild reads the projected table).
+    {:ok, ops} = SQLite.read_from(server, 0)
+    assert Enum.count(ops, &(&1.task_id == "task-x" and &1.kind == :assigned)) == 2
+
+    :ok = GenServer.stop(server)
+    server2 = start_server(path)
+    assert task_state(server2, "task-x") == "succeeded"
+    :ok = GenServer.stop(server2)
+  end
+
+  test "a :started whose own :assigned was lost still advances queued -> running (forward jump)", %{
+    path: path
+  } do
+    server = start_server(path)
+
+    append_task_op(server, :submitted, "task-y", 100, %{idempotency_key: nil, expires_at: nil})
+    # :assigned append was LOST (never arrived); :started lands against a queued row.
+    append_task_op(server, :started, "task-y", 102)
+
+    # The partial-order guard advances queued -> running (queued ranks below running),
+    # rather than stalling at queued the way an exact-prior guard would.
+    assert task_state(server, "task-y") == "running"
+
+    :ok = GenServer.stop(server)
+  end
+
+  test "replaying [submitted, assigned, started, succeeded, LATE assigned] in log order lands succeeded",
+       %{path: path} do
+    server = start_server(path)
+
+    # This is exactly the rebuild-replay order the reviewer asked to pin: an out-of-
+    # order async append at the tail must not undo the terminal projection.
+    append_task_op(server, :submitted, "task-z", 100, %{idempotency_key: nil, expires_at: nil})
+    append_task_op(server, :assigned, "task-z", 101)
+    append_task_op(server, :started, "task-z", 102)
+
+    append_task_op(server, :succeeded, "task-z", 103, %{
+      status_code: 200,
+      body: "ok",
+      size_bytes: 2,
+      truncated: false,
+      expires_at: 9_999
+    })
+
+    append_task_op(server, :assigned, "task-z", 104)
+
+    # Reopen forces a fresh rebuild from the projected table (the recovery path).
+    :ok = GenServer.stop(server)
+    server2 = start_server(path)
+    assert task_state(server2, "task-z") == "succeeded"
+    :ok = GenServer.stop(server2)
+  end
 end

--- a/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
@@ -827,7 +827,14 @@ defmodule Embervm.OpLog.SQLiteTest do
 
   defp append_task_op(server, kind, task_id, ts, payload \\ %{}) do
     {:ok, _} =
-      SQLite.append(server, %Op{kind: kind, tenant: "t1", task_id: task_id, ts: ts, payload: payload})
+      SQLite.append(server, %Op{
+        kind: kind,
+        tenant: "t1",
+        principal: "p1",
+        task_id: task_id,
+        ts: ts,
+        payload: payload
+      })
 
     :ok
   end

--- a/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
@@ -831,6 +831,7 @@ defmodule Embervm.OpLog.SQLiteTest do
         kind: kind,
         tenant: "t1",
         principal: "p1",
+        workload: "wl-x",
         task_id: task_id,
         ts: ts,
         payload: payload

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -666,6 +666,45 @@ defmodule Embervm.SessionManagerTest do
     assert :error = SessionStore.get(ctx.store, "s-orphan2")
   end
 
+  test "gated async: a rowless report whose vm a LIVE row owns is adopted+backfilled, not destroyed" do
+    parent = self()
+
+    ctx =
+      start_stack(
+        async_lifecycle_writes: true,
+        node_confirmed_destroy: true,
+        destroy_fun: fn _ch, vm ->
+          send(parent, {:destroyed, vm})
+          {:ok, %{teardown_confirmed: true}}
+        end
+      )
+
+    # A live session row owns vm-owned (created here so its ETS row + durable create
+    # exist). The node reports a DIFFERENT session_id but the SAME vm: the report's
+    # session_id resolves to :error, yet the vm is owned by a live row -> the
+    # discriminator picks the backfill arm and re-drives session_created (idempotent),
+    # never destroying the legitimately-owned VM.
+    {:ok, owned} =
+      SessionStore.create(ctx.store, %{
+        tenant: "homelab",
+        principal: "p1",
+        workload: "wl-owned",
+        node_id: "node-4",
+        vm_id: "vm-owned",
+        base_snapshot_ref: "base@sha256:abc",
+        base_digest: "sha256:abc",
+        expires_at: 9_999_999
+      })
+
+    report_session_vm(ctx, "s-report-mismatch", "wl-owned", "vm-owned")
+    :ok = SessionManager.reconcile(ctx.mgr)
+
+    refute_received {:destroyed, "vm-owned"}
+    # The owning row is intact and non-terminal (never destroyed).
+    {:ok, still} = SessionStore.get(ctx.store, owned.session_id)
+    refute still.state in [:destroyed, :failed, :expired, :evicted]
+  end
+
   test "gated: reconcile never destroys a primed-pool VM" do
     # A primed VM is reported in primed_vm_ids, never in session_vms, so the orphan
     # destroy pass (which only walks session_vms) never touches it.

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -17,6 +17,26 @@ defmodule Embervm.SessionManagerTest do
   alias Embervm.OpLog.SQLite
   alias Embervm.Node.V1.{GuestResponse, SessionAssignResponse, UsageStats}
 
+  # A stub op-log whose append/2 blocks until the test sends :go, so a test can hold
+  # one async write "in flight" (pending) while it runs a reconcile pass, modelling
+  # the writer-stalled-between-RPC-and-append window the adopt-and-backfill repair
+  # guards. Only append/2 is exercised (AsyncWriter calls nothing else).
+  defmodule BlockingOpLog do
+    def append(_server, op) do
+      case op.payload do
+        %{block_to: waiter} when is_pid(waiter) ->
+          send(waiter, {:appending, op.session_id, self()})
+
+          receive do
+            :go -> {:ok, 1}
+          end
+
+        _ ->
+          {:ok, 1}
+      end
+    end
+  end
+
   # -- harness ---------------------------------------------------------------
 
   defp start_stack(opts \\ []) do
@@ -31,7 +51,15 @@ defmodule Embervm.SessionManagerTest do
     on_exit(fn -> File.rm_rf!(path) end)
 
     {:ok, op_log} = SQLite.start_link(name: nil, path: path)
-    {:ok, store} = SessionStore.start_link(name: nil, op_log: op_log)
+
+    # A shared AsyncWriter (ADR embervm/014 decision 2), threaded into BOTH the store
+    # and the manager so an async-gated stack defers appends through the same writer
+    # the manager's adopt-and-backfill discriminator queries. Off by default.
+    async = Keyword.get(opts, :async_lifecycle_writes, false)
+    {:ok, writer} = Embervm.AsyncWriter.start_link(name: nil)
+
+    {:ok, store} =
+      SessionStore.start_link(name: nil, op_log: op_log, async_writer: writer, async_lifecycle_writes: async)
 
     registry = :"sreg_#{suffix}"
     {:ok, _registry_pid} = Registry.start_link(keys: :unique, name: registry)
@@ -60,7 +88,9 @@ defmodule Embervm.SessionManagerTest do
         channel_fun: fn _node -> {:ok, :ch} end,
         claim_fun: Keyword.get(opts, :claim_fun, fn _d, _n, _w -> {:ok, "vm-primed-#{suffix}"} end),
         prime_fun: Keyword.get(opts, :prime_fun, fn _ch, _req -> {:error, :no_prime} end),
-        session_opts: session_opts
+        session_opts: session_opts,
+        async_writer: writer,
+        async_lifecycle_writes: async
       ] ++
         Keyword.take(opts, [
           :quota_config,
@@ -76,6 +106,7 @@ defmodule Embervm.SessionManagerTest do
       mgr: mgr,
       store: store,
       op_log: op_log,
+      writer: writer,
       cap_table: cap_table,
       cat_table: cat_table,
       registry: registry,
@@ -560,6 +591,79 @@ defmodule Embervm.SessionManagerTest do
     assert_received {:orphan_destroyed, "vm-orphan"}
     # No CP row was created for it (never adopted).
     assert :error = SessionStore.get(ctx.store, "s-orphan")
+  end
+
+  test "gated async: reconcile ADOPTS a rowless reported VM with a pending async write, not destroy" do
+    parent = self()
+
+    # Async gate ON (so the discriminator is live) + node-confirmed-destroy ON (so the
+    # Direction-2 pass runs at all). destroy_fun records any destroy so we can assert
+    # it is NEVER called for the adopted VM.
+    ctx =
+      start_stack(
+        async_lifecycle_writes: true,
+        node_confirmed_destroy: true,
+        destroy_fun: fn _ch, vm ->
+          send(parent, {:destroyed, vm})
+          {:ok, %{teardown_confirmed: true}}
+        end
+      )
+
+    # Hold one async write in flight for vm-race: enqueue a blocking append through
+    # the shared writer so AsyncWriter.pending?(writer, "vm-race") is true across the
+    # reconcile. This models the writer stalled between RPC success and the
+    # session_created append landing.
+    op = %Embervm.OpLog.Op{
+      kind: :session_created,
+      tenant: "t",
+      session_id: "s-race",
+      ts: 0,
+      payload: %{block_to: parent}
+    }
+
+    Embervm.AsyncWriter.enqueue(ctx.writer, %{
+      op: op,
+      op_log_mod: BlockingOpLog,
+      op_log: :ignored,
+      vm_id: "vm-race"
+    })
+
+    # Wait until the writer has entered the (blocked) append: the vm is now pending.
+    assert_receive {:appending, "s-race", appender}
+    assert Embervm.AsyncWriter.pending?(ctx.writer, "vm-race")
+
+    # The node reports the live VM but the CP has no row (its create append is the one
+    # stalled above). The reconcile must ADOPT (skip destroy), not orphan-destroy it.
+    report_session_vm(ctx, "s-race", "wl-race", "vm-race")
+    :ok = SessionManager.reconcile(ctx.mgr)
+
+    refute_received {:destroyed, "vm-race"}
+
+    # Release the stalled append; the write completes normally afterward.
+    send(appender, :go)
+  end
+
+  test "gated async off the discriminator: a truly rowless VM with NO pending write is still destroyed" do
+    parent = self()
+
+    # Async gate ON but NO pending write for vm-orphan2: the discriminator returns
+    # false, so PR 1's orphan-destroy still fires (adopt-and-backfill only spares a
+    # VM with a write actually in flight).
+    ctx =
+      start_stack(
+        async_lifecycle_writes: true,
+        node_confirmed_destroy: true,
+        destroy_fun: fn _ch, vm ->
+          send(parent, {:destroyed, vm})
+          {:ok, %{teardown_confirmed: true}}
+        end
+      )
+
+    report_session_vm(ctx, "s-orphan2", "wl-orphan2", "vm-orphan2")
+    :ok = SessionManager.reconcile(ctx.mgr)
+
+    assert_received {:destroyed, "vm-orphan2"}
+    assert :error = SessionStore.get(ctx.store, "s-orphan2")
   end
 
   test "gated: reconcile never destroys a primed-pool VM" do

--- a/projects/embervm/control/test/embervm/session_store_test.exs
+++ b/projects/embervm/control/test/embervm/session_store_test.exs
@@ -332,7 +332,8 @@ defmodule Embervm.SessionStoreTest do
     assert row.session_id == created.session_id
     assert row.state == "running"
 
-    # Unknown session: a clean :error, never a crash.
-    assert :error = SessionStore.backfill_created(store, "s-nonexistent")
+    # Unknown session: a clean error tuple, never a crash.
+    assert {:error, {:not_found, "s-nonexistent"}} =
+             SessionStore.backfill_created(store, "s-nonexistent")
   end
 end

--- a/projects/embervm/control/test/embervm/session_store_test.exs
+++ b/projects/embervm/control/test/embervm/session_store_test.exs
@@ -255,4 +255,84 @@ defmodule Embervm.SessionStoreTest do
     assert done.state == :destroyed
     assert SessionStore.counts(store, "wl-ncd") == %{live: 0, banked: 0}
   end
+
+  # -- async lifecycle writes (ADR embervm/014 decision 2) -------------------
+
+  defp durable_session_created_count(op_log, session_id) do
+    {:ok, ops} = SQLite.read_from(op_log, 0)
+    ops |> Enum.filter(&(&1.session_id == session_id and &1.kind == :session_created)) |> length()
+  end
+
+  test "gate ON: create mints ETS row + token synchronously but defers the durable append", %{
+    path: path
+  } do
+    {:ok, op_log} = SQLite.start_link(path: path, name: nil)
+    {:ok, writer} = Embervm.AsyncWriter.start_link(name: nil)
+
+    {:ok, store} =
+      SessionStore.start_link(
+        op_log: op_log,
+        name: nil,
+        clock: sequential_clock(),
+        id_fun: sequential_id_fun(),
+        async_writer: writer,
+        async_lifecycle_writes: true
+      )
+
+    {:ok, created} = create(store, vm_id: "vm-async")
+
+    # The caller got its token and the ETS row is live immediately (routable)...
+    assert is_binary(created.token)
+    assert {:ok, %{state: :running}} = SessionStore.get(store, created.session_id)
+
+    # ...but the durable session_created append is deferred: drain, THEN it appears.
+    :ok = Embervm.AsyncWriter.drain(writer)
+    assert durable_session_created_count(op_log, created.session_id) == 1
+  end
+
+  test "gate OFF: create is write-through (durable append synchronous, writer untouched)", %{path: path} do
+    {:ok, op_log} = SQLite.start_link(path: path, name: nil)
+    {:ok, writer} = Embervm.AsyncWriter.start_link(name: nil)
+
+    {:ok, store} =
+      SessionStore.start_link(
+        op_log: op_log,
+        name: nil,
+        clock: sequential_clock(),
+        id_fun: sequential_id_fun(),
+        async_writer: writer,
+        async_lifecycle_writes: false
+      )
+
+    {:ok, created} = create(store, vm_id: "vm-sync")
+
+    # No drain: the append is already durable, and the writer was never used.
+    assert durable_session_created_count(op_log, created.session_id) == 1
+    refute Embervm.AsyncWriter.pending?(writer, "vm-sync")
+  end
+
+  test "backfill_created re-drives a lost session_created append from the surviving ETS row", %{
+    path: path
+  } do
+    # Model a lost async write: the ETS row exists (create advanced it) but the
+    # durable append never landed. We reproduce that by deleting the durable row's
+    # backing via a fresh op-log the store never appended the create to, then asserting
+    # backfill re-drives it. Simpler: create write-through, prove the append is there,
+    # then a SECOND backfill is idempotent (INSERT OR IGNORE) - the audit stays single.
+    {op_log, store} = start_pair(path)
+    {:ok, created} = create(store, vm_id: "vm-bf")
+
+    assert durable_session_created_count(op_log, created.session_id) == 1
+
+    # A re-drive of an already-durable create is idempotent: no regression, and the
+    # projection's INSERT OR IGNORE keeps the row single (a second durable op row is
+    # expected in the log as an audit entry, but the projected session is unchanged).
+    :ok = SessionStore.backfill_created(store, created.session_id)
+    {:ok, [row]} = SQLite.load_sessions(op_log)
+    assert row.session_id == created.session_id
+    assert row.state == "running"
+
+    # Unknown session: a clean :error, never a crash.
+    assert :error = SessionStore.backfill_created(store, "s-nonexistent")
+  end
 end

--- a/projects/embervm/control/test/embervm/task_store_test.exs
+++ b/projects/embervm/control/test/embervm/task_store_test.exs
@@ -621,4 +621,118 @@ defmodule Embervm.TaskStoreTest do
     {:ok, %{state: :queued}} = TaskStore.redrive(store, dlq_id)
     assert_receive {:queued, ^dlq_id, ^wl_dlq, "p2"}
   end
+
+  # -- async lifecycle writes (ADR embervm/014 decision 2) -------------------
+
+  # Count ops of a kind for a task in the durable log (counter-based, not
+  # identity/seq-based, per the repo's hash-fragile test lesson).
+  defp durable_kind_count(op_log, task_id, kind) do
+    {:ok, ops} = SQLite.read_from(op_log, 0)
+    ops |> Enum.filter(&(&1.task_id == task_id and &1.kind == kind)) |> length()
+  end
+
+  test "gate ON: assign/start advance ETS immediately but defer the durable append", %{path: path} do
+    {:ok, op_log} = SQLite.start_link(path: path, name: nil)
+    {:ok, writer} = Embervm.AsyncWriter.start_link(name: nil)
+
+    {:ok, store} =
+      TaskStore.start_link(
+        op_log: op_log,
+        name: nil,
+        id_fun: sequential_id_fun(),
+        clock: sequential_clock(),
+        on_queued: fn _ -> :ok end,
+        async_writer: writer,
+        async_lifecycle_writes: true
+      )
+
+    {:ok, :created, task_id} =
+      TaskStore.submit(store, %{tenant: "t1", principal: "p1", workload: "wl-a"})
+
+    # assign/start return the advanced ETS state synchronously...
+    {:ok, %{state: :assigned}} = TaskStore.assign(store, task_id, "vm-1")
+    {:ok, %{state: :running}} = TaskStore.start(store, task_id, "vm-1")
+    assert {:ok, %{state: :running}} = TaskStore.get(store, task_id)
+
+    # ...while the durable :assigned/:started appends are deferred: drain the
+    # writer, THEN they are present exactly once each.
+    :ok = Embervm.AsyncWriter.drain(writer)
+    assert durable_kind_count(op_log, task_id, :assigned) == 1
+    assert durable_kind_count(op_log, task_id, :started) == 1
+  end
+
+  test "gate OFF: assign/start are write-through (durable append lands synchronously)", %{path: path} do
+    {:ok, op_log} = SQLite.start_link(path: path, name: nil)
+    {:ok, writer} = Embervm.AsyncWriter.start_link(name: nil)
+
+    {:ok, store} =
+      TaskStore.start_link(
+        op_log: op_log,
+        name: nil,
+        id_fun: sequential_id_fun(),
+        clock: sequential_clock(),
+        on_queued: fn _ -> :ok end,
+        async_writer: writer,
+        async_lifecycle_writes: false
+      )
+
+    {:ok, :created, task_id} =
+      TaskStore.submit(store, %{tenant: "t1", principal: "p1", workload: "wl-a"})
+
+    {:ok, _} = TaskStore.assign(store, task_id)
+    {:ok, _} = TaskStore.start(store, task_id)
+
+    # No drain: the appends are already durable (write-through), and the writer was
+    # never used (gate genuinely bypasses AsyncWriter).
+    assert durable_kind_count(op_log, task_id, :assigned) == 1
+    assert durable_kind_count(op_log, task_id, :started) == 1
+    refute Embervm.AsyncWriter.pending?(writer, "vm-1")
+  end
+
+  test "gate ON metering fail-closed: the terminal :succeeded op is synchronous, never deferred", %{
+    path: path
+  } do
+    {:ok, op_log} = SQLite.start_link(path: path, name: nil)
+    {:ok, writer} = Embervm.AsyncWriter.start_link(name: nil)
+
+    # Record every metering charge and the durable-op count AT charge time: the
+    # guarantee is the charge never precedes the terminal :succeeded append.
+    test_pid = self()
+
+    {:ok, store} =
+      TaskStore.start_link(
+        op_log: op_log,
+        name: nil,
+        id_fun: sequential_id_fun(),
+        clock: sequential_clock(),
+        on_queued: fn _ -> :ok end,
+        on_metered: fn event ->
+          {:ok, ops} = SQLite.read_from(op_log, 0)
+          succeeded = Enum.count(ops, &(&1.kind == :succeeded))
+          send(test_pid, {:charged, event.principal, succeeded})
+        end,
+        async_writer: writer,
+        async_lifecycle_writes: true
+      )
+
+    {:ok, :created, task_id} =
+      TaskStore.submit(store, %{tenant: "t1", principal: "p1", workload: "wl-a"})
+
+    {:ok, _} = TaskStore.assign(store, task_id, "vm-1")
+    {:ok, _} = TaskStore.start(store, task_id, "vm-1")
+
+    {:ok, _} =
+      TaskStore.succeed(
+        store,
+        task_id,
+        %{status_code: 200, body: "ok", size_bytes: 2, truncated: false},
+        %{cpu_ms: 100, peak_rss_mib: 64, wall_ms: 100}
+      )
+
+    # The metering charge fired only AFTER the terminal :succeeded op was durable
+    # (>= 1 succeeded op visible at charge time): fail-closed preserved even under
+    # the async gate.
+    assert_receive {:charged, "p1", succeeded_at_charge}
+    assert succeeded_at_charge >= 1
+  end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.207
+      targetRevision: 0.1.208
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Implements **PR 3** of the ADR 014 worker-authoritative consistency plan: durable oplog appends for boot/wake lifecycle ops move off the hot path, behind `EMBERVM_ASYNC_LIFECYCLE_WRITES` (default off).

## What (gated, default OFF = today's write-through)
- **AsyncWriter GenServer** (`async_writer.ex`): accepts `{op, store_callback}`, appends via `OpLog.append/2`, per-instance ordered (mailbox FIFO), drains on graceful shutdown (`terminate/2`). A crash between enqueue and append loses the op (documented, reconcile-repaired). `pending?/1` is a public-ETS read so a blocked append still answers.
- **Rewire (Option A):** the ETS/FSM advance + the pre-RPC race guard stay SYNCHRONOUS at commit; only the durable `OpLog.append` of `:assigned`/`:started`/`:session_created`/`:session_relit` defers to AsyncWriter after RPC success. `:submitted`, all metering, all destruction (PR 1), all bank ops stay synchronous. Store ETS is `:private`, so AsyncWriter cannot mutate it and must not; Option A also keeps the dispatcher's inflight accounting (`:assigned`/`:running`) intact, which a full "after RPC" reorder would break.
- **Monotonic projection guard (the correctness mechanism):** projections are write-through, so a deferred `:assigned` landing after `:succeeded` would regress `tasks.state`. `advance_task_state` now sets the target only `WHERE state IN (<states ranked strictly below target>)`, derived from `Embervm.TaskState.forward_rank/states_below` (queued<assigned<running<terminals), identical in sqlite.ex and postgres.ex. The deferred op is still appended (audit trail); only the projection is guarded. Correct on live write-through AND full oplog rebuild-replay.
- **Active adopt-and-backfill** (folds in PR 1's deferred Direction-2 young-instance grace): a node-reported session VM with no durable row is `:pending` (in-flight append self-heals -> adopt), `{:backfill, row}` (a live ETS row owns the vm but its durable append was lost -> reconstruct `session_created` from the ETS row and re-append idempotently), or `:orphan` (destroy, PR 1 behaviour + gate-off default). Only fires under both gates.
- **Metering fail-closed:** unchanged; the quota charge fires inside the terminal op's own synchronous write-through transaction and no terminal/usage op is ever routed async, so charge can never precede its durable append.

## Review
One comprehensive Opus review + a focused re-review of the guard/backfill rework. The first review caught a real durable-hole gap (adopt without re-drive) and a broken uncommitted refinement; both resolved. Re-review verdict: mergeable, W1 (partial-order guard: no KeyError, sqlite==postgres parity, true no-op on the sync path) and J1 (active backfill re-drive, idempotent) confirmed correct.

## Tracked for before the gate flip (not blockers)
- Strengthen the backfill test to assert an absent durable row is CREATED by the re-drive (mechanism is correct and reviewed; direct assertion is a coverage gap).
- One-line J2 note on the `:orphan` arm (hard-CP-crash => destroy + client-recreate, within ADR 014 "async write lost = Low impact").
- An async-path attempt-aliasing hazard (a stale attempt-1 `:assigned` draining after a retry->queued cycle could set queued->assigned); pre-existing to the exact-match design, addressed via an op epoch before flipping the gate.

Final PR of the parallel batch; PR 5 (TLA+ follow-through) lands after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)