### PR TITLE
test(embervm): deflake stateful manager/sweeper suite

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.212
+version: 0.1.214

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -123,13 +123,26 @@ defmodule Embervm.StatefulManagerTest do
   # check, retry.
   defp flush_mgr(ctx), do: :sys.get_state(ctx.mgr)
 
+  # Number of callers currently parked (owner + parkers) for a workload. Reads the
+  # manager's `waking` map directly so a test can poll for a wake to register as
+  # in-flight instead of guessing with a fixed Process.sleep.
+  defp waiter_count(ctx, workload),
+    do: length(Map.get(:sys.get_state(ctx.mgr).waking, workload, []))
+
   defp poll_mgr(ctx, fun, tries \\ 50) do
     flush_mgr(ctx)
 
     cond do
       fun.() -> :ok
       tries <= 0 -> flunk("poll_mgr: condition never held")
-      true -> poll_mgr(ctx, fun, tries - 1)
+      true ->
+        # Yield a scheduler slot between tries. flush_mgr only drains the
+        # manager's own mailbox; a spawned {:wake_done} worker is a separate
+        # process that must actually be scheduled before the condition can hold.
+        # Without this backoff the loop spins through all tries in a couple of ms
+        # and starves the worker under the 8-way parallel CI runner.
+        Process.sleep(10)
+        poll_mgr(ctx, fun, tries - 1)
     end
   end
 
@@ -540,11 +553,12 @@ defmodule Embervm.StatefulManagerTest do
     # First caller kicks the wake; two more park (filling the cap of 3 with the
     # owner); a fourth is denied.
     first = Task.async(fn -> StatefulManager.wake(ctx.mgr, "wl-a", "p") end)
-    # Give the first call time to register and become the in-flight wake owner.
-    Process.sleep(20)
+    # Wait for the first call to register as the in-flight wake owner (waiter #1).
+    poll_mgr(ctx, fn -> waiter_count(ctx, "wl-a") >= 1 end)
 
     parked = for _ <- 1..2, do: Task.async(fn -> StatefulManager.wake(ctx.mgr, "wl-a", "p") end)
-    Process.sleep(20)
+    # Wait for both parkers to register so the park (cap 3) is exactly full.
+    poll_mgr(ctx, fn -> waiter_count(ctx, "wl-a") == 3 end)
 
     assert {:error, {:park_full, _}} = StatefulManager.wake(ctx.mgr, "wl-a", "p")
 
@@ -998,7 +1012,7 @@ defmodule Embervm.StatefulManagerTest do
     refute StatefulManager.parked?(ctx.mgr, "wl-a")
 
     first = Task.async(fn -> StatefulManager.wake(ctx.mgr, "wl-a", "p") end)
-    Process.sleep(20)
+    poll_mgr(ctx, fn -> StatefulManager.parked?(ctx.mgr, "wl-a") end)
 
     assert StatefulManager.parked?(ctx.mgr, "wl-a")
 
@@ -1015,7 +1029,7 @@ defmodule Embervm.StatefulManagerTest do
 
     # The wake must PARK, not boot: run it in a task so it blocks.
     waiter = Task.async(fn -> StatefulManager.wake(ctx.mgr, "wl-a", "p") end)
-    Process.sleep(30)
+    poll_mgr(ctx, fn -> StatefulManager.parked?(ctx.mgr, "wl-a") end)
 
     # No StartStateful was issued (parked, not cold-booted).
     assert Agent.get(ctx.starts, & &1) == 0
@@ -1063,7 +1077,7 @@ defmodule Embervm.StatefulManagerTest do
     checkpointed_instance(ctx, "stf-ck", "wl-a", "vm-ck")
 
     waiter = Task.async(fn -> StatefulManager.wake(ctx.mgr, "wl-a", "p") end)
-    Process.sleep(30)
+    poll_mgr(ctx, fn -> StatefulManager.parked?(ctx.mgr, "wl-a") end)
     assert Agent.get(ctx.starts, & &1) == 0
 
     # Simulate the sweeper's COMMIT: the temp becomes the bundle (checkpointed ->
@@ -1180,8 +1194,9 @@ defmodule Embervm.StatefulManagerTest do
     seed_banked_with_pair(ctx, "stf-banked", "node-4", 3, 3)
 
     caller = Task.async(fn -> StatefulManager.wake(ctx.mgr, "wl-a", "p") end)
-    # Let the wake register as in-flight (mark :relighting, stamp wake_started at 0).
-    Process.sleep(50)
+    # Wait for the wake to register as in-flight (mark :relighting, stamp
+    # wake_started at 0) before advancing the clock past the stuck threshold.
+    poll_mgr(ctx, fn -> StatefulManager.parked?(ctx.mgr, "wl-a") end)
 
     # Advance mono past 2 * wakeTimeoutSeconds (2 * 60s = 120_000ms).
     Agent.update(mono, fn _ -> 200_000 end)

--- a/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
@@ -303,7 +303,15 @@ defmodule Embervm.StatefulSweeperTest do
     cond do
       fun.() -> :ok
       tries <= 0 -> flunk("wait_until: condition never held")
-      true -> wait_until(ctx, fun, tries - 1)
+      true ->
+        # Yield a scheduler slot between tries. flush only drains the sweeper's
+        # own mailbox; a spawned bank worker (posts {:bank_done}) is a separate
+        # process that must be scheduled before the store reaches :banked.
+        # Without this backoff the loop spins through all tries in a couple of ms
+        # and starves the worker under the 8-way parallel CI runner (the historic
+        # "condition never held" idle-bank flake).
+        Process.sleep(10)
+        wait_until(ctx, fun, tries - 1)
     end
   end
 

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.212
+      targetRevision: 0.1.214
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## What

De-flakes the two EmberVM control-suite tests that intermittently fail in BuildBuddy CI under load (`StatefulSweeperTest` idle-bank "condition never held", `StatefulManagerTest` auto-wake/park races). First of the three tracked ADR 014 follow-ups: it de-flakes CI so the destroy-lane PRs (1b + pre-flip hardening) land without re-run noise misattributed to real failures.

## Root cause

Both suites poll for a **spawned worker** to finish (`{:wake_done}` / `{:bank_done}`) via a helper that busy-loops `:sys.get_state(target) + re-check`, 50 tries, **with no yield between tries**. `:sys.get_state` only drains the target GenServer's own mailbox, not the separate worker process, so the loop can drain in a couple of ms before the worker is ever scheduled under the 8-way parallel runner (~520 tests) → `flunk("condition never held")`. The fake-clock idle logic was never the problem.

## Fix (test-only, no production code touched)

- Add a `Process.sleep(10)` backoff per try to `poll_mgr/3` and `wait_until/3` so each iteration yields a scheduler slot to the spawned worker (~500ms budget vs the old few-ms spin).
- Replace five fixed `Process.sleep(20/30/50)` synchronization points in the manager suite (bets that a `Task.async(wake)` registers within N ms) with `poll_mgr` on an observable predicate — `parked?/2`, or a new `waiter_count/2` reading the manager's `waking` map.
- Fixture `start_sleep_ms` and the intentional `hang_fun` RPC-hang sleeps (which model a hanging StartStateful the wake-bound is meant to beat) are deliberately left untouched.

`RetryTest` was checked and is **not** a current flake source (already `async: false`, pure functions, no env mutation despite a stale module comment), so it is not changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)