### PR TITLE
fix(embervm): skip :destroying instances in serving/stateful/group adoption

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.214
+version: 0.1.216

--- a/projects/embervm/control/lib/embervm/group_wake_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_wake_manager.ex
@@ -801,6 +801,14 @@ defmodule Embervm.GroupWakeManager do
 
   defp adopt_one(state, instance, live_members, bundle_sets) do
     cond do
+      # A destroying instance (ADR embervm/014 decision 5) is mid node-confirmed
+      # teardown; adoption must NOT re-adopt it even though the node still reports its
+      # live members (the teardown RPCs are in flight). Keying off the CP state, not
+      # the node report, is the fix for the TLC NoDestroyBeforeConfirm violation
+      # modeled in adoption.tla. redrive_destroying (gated) owns the transition.
+      instance.state == :destroying ->
+        state
+
       # A wake stuck waking past 2 * wakeTimeoutSeconds (Task 10): the worker never
       # reported and the {:wake_timeout} timer is lost (a CP restart drops the timer
       # but the projection is rebuilt, so `waking` is empty on boot; this covers the

--- a/projects/embervm/control/lib/embervm/serving_manager.ex
+++ b/projects/embervm/control/lib/embervm/serving_manager.ex
@@ -1001,6 +1001,14 @@ defmodule Embervm.ServingManager do
 
   defp adopt_one(state, instance, live_vms, snapshots) do
     cond do
+      # A destroying instance (ADR embervm/014 decision 5) is mid node-confirmed
+      # teardown; adoption must NOT re-bind it to published even though the node still
+      # reports its live VM (the teardown RPC is in flight). Keying off the CP state,
+      # not the node report, is the fix for the TLC NoDestroyBeforeConfirm violation
+      # modeled in adoption.tla. redrive_destroying (gated) owns the transition.
+      instance.state == :destroying ->
+        state
+
       # This manager has an in-flight wake for the workload: it owns the transition,
       # so a periodic reconcile must NOT touch its instances. On BOOT `waking` is
       # empty (fresh process), so boot adoption still fully heals every limbo.

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -1862,6 +1862,14 @@ defmodule Embervm.StatefulManager do
 
   defp adopt_one(state, instance, live_vms, bundles) do
     cond do
+      # A destroying instance (ADR embervm/014 decision 5) is mid node-confirmed
+      # teardown; adoption must NOT re-adopt it to live even though the node still
+      # reports its VM (the teardown RPC is in flight). Keying off the CP state, not
+      # the node report, is the fix for the TLC NoDestroyBeforeConfirm violation
+      # modeled in adoption.tla. redrive_destroying (gated) owns the transition.
+      instance.state == :destroying ->
+        state
+
       # A wake stuck waking past 2 * wakeTimeoutSeconds (Task 10): the worker never
       # reported and the {:wake_timeout} timer is lost (the in-process wedge a timer
       # somehow missed). Recover it: drop the stale waking bookkeeping + err the parked

--- a/projects/embervm/control/test/embervm/group_wake_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_wake_manager_test.exs
@@ -447,7 +447,7 @@ defmodule Embervm.GroupWakeManagerTest do
     # Seed an instance, then force it into :destroying: mid node-confirmed teardown
     # (ADR embervm/014 decision 5), the per-member teardown RPCs in flight.
     _ = seed_banked(ctx, instance_id)
-    _ = GroupStore.adopt_state(ctx.store, instance_id, :destroying)
+    {:ok, _} = GroupStore.mark(ctx.store, instance_id, :begin_destroy)
 
     # The node still reports the group's members live: the straggler report that turns
     # on the TLC NoDestroyBeforeConfirm violation if adoption keys off the node.

--- a/projects/embervm/control/test/embervm/group_wake_manager_test.exs
+++ b/projects/embervm/control/test/embervm/group_wake_manager_test.exs
@@ -440,6 +440,28 @@ defmodule Embervm.GroupWakeManagerTest do
     assert FakePublisher.count(ctx.pub) >= 1
   end
 
+  test "adoption SKIPS a :destroying group even though the node still reports live members" do
+    ctx = start_stack()
+    instance_id = "g-destroying"
+
+    # Seed an instance, then force it into :destroying: mid node-confirmed teardown
+    # (ADR embervm/014 decision 5), the per-member teardown RPCs in flight.
+    _ = seed_banked(ctx, instance_id)
+    _ = GroupStore.adopt_state(ctx.store, instance_id, :destroying)
+
+    # The node still reports the group's members live: the straggler report that turns
+    # on the TLC NoDestroyBeforeConfirm violation if adoption keys off the node.
+    seed_node(ctx, %{
+      group_member_vms: [%{vm_id: "vm-l", group_instance_id: instance_id, member_name: "leader", ip: "10.101.0.10", healthy: true}]
+    })
+
+    :ok = GroupWakeManager.reconcile(ctx.mgr)
+
+    # NOT re-adopted to :running; stays destroying for the (gated) redrive to own.
+    {:ok, inst} = GroupStore.get(ctx.store, instance_id)
+    assert inst.state == :destroying
+  end
+
   test "adoption: a banked instance with a COMPLETE reported set heals to banked" do
     ctx = start_stack()
     instance_id = "g-banked"

--- a/projects/embervm/control/test/embervm/serving_manager_test.exs
+++ b/projects/embervm/control/test/embervm/serving_manager_test.exs
@@ -299,6 +299,41 @@ defmodule Embervm.ServingManagerTest do
     assert Agent.get(ctx.starts, & &1) == 0
   end
 
+  test "adoption SKIPS a :destroying instance even though the node still reports its live VM" do
+    ctx = start_stack()
+    serving_workload(ctx, "wl-a")
+
+    {:ok, _} =
+      ServingStore.start(ctx.store, %{
+        instance_id: "srv-destroying",
+        tenant: "homelab",
+        principal: "serving:wl-a",
+        workload: "wl-a",
+        node_id: "node-4",
+        vm_id: "vm-live",
+        ip: "10.99.0.9",
+        port: 8080
+      })
+
+    # Force the instance into :destroying: mid node-confirmed teardown (ADR
+    # embervm/014 decision 5), the teardown RPC in flight.
+    _ = ServingStore.adopt_state(ctx.store, "srv-destroying", :destroying)
+
+    # The node still reports the VM as live+healthy: the exact straggler report that
+    # turns on the TLC NoDestroyBeforeConfirm violation if adoption keys off the node.
+    serving_node(ctx, "node-4",
+      serving_vms: [%{vm_id: "vm-live", workload: "wl-a", ip: "10.99.0.9", port: 8080, healthy: true, last_probe_unix_ms: 1}]
+    )
+
+    :ok = ServingManager.reconcile(ctx.mgr)
+
+    # NOT re-adopted to :published; stays destroying for the (gated) redrive to own.
+    {:ok, inst} = ServingStore.get(ctx.store, "srv-destroying")
+    assert inst.state == :destroying
+    assert ServingStore.published_endpoints(ctx.store, "wl-a") == []
+    assert Agent.get(ctx.starts, & &1) == 0
+  end
+
   test "adoption heals a starting-limbo instance the node reports only as a snapshot to banked" do
     ctx = start_stack()
     serving_workload(ctx, "wl-a")

--- a/projects/embervm/control/test/embervm/serving_manager_test.exs
+++ b/projects/embervm/control/test/embervm/serving_manager_test.exs
@@ -315,9 +315,9 @@ defmodule Embervm.ServingManagerTest do
         port: 8080
       })
 
-    # Force the instance into :destroying: mid node-confirmed teardown (ADR
-    # embervm/014 decision 5), the teardown RPC in flight.
-    _ = ServingStore.adopt_state(ctx.store, "srv-destroying", :destroying)
+    # Drive the instance into :destroying via the begin_destroy FSM edge: mid
+    # node-confirmed teardown (ADR embervm/014 decision 5), the teardown RPC in flight.
+    {:ok, _} = ServingStore.mark(ctx.store, "srv-destroying", :begin_destroy)
 
     # The node still reports the VM as live+healthy: the exact straggler report that
     # turns on the TLC NoDestroyBeforeConfirm violation if adoption keys off the node.

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -830,6 +830,39 @@ defmodule Embervm.StatefulManagerTest do
     assert Agent.get(ctx.starts, & &1) == 0
   end
 
+  test "adoption SKIPS a :destroying instance even though the node still reports its live VM" do
+    ctx = start_stack()
+    stateful_workload(ctx, "wl-a")
+
+    {:ok, _} =
+      StatefulStore.start(ctx.store, %{
+        instance_id: "stf-destroying",
+        tenant: "homelab",
+        principal: "p",
+        workload: "wl-a",
+        node_id: "node-4",
+        vm_id: "vm-live",
+        generation: 1
+      })
+
+    # Force the instance into :destroying: mid node-confirmed teardown (ADR
+    # embervm/014 decision 5), the teardown RPC in flight.
+    _ = StatefulStore.adopt_state(ctx.store, "stf-destroying", :destroying)
+
+    # The node still reports the VM live: the straggler report that turns on the TLC
+    # NoDestroyBeforeConfirm violation if adoption keys off the node, not the CP state.
+    stateful_node(ctx, "node-4",
+      stateful_vms: [%{vm_id: "vm-live", workload: "wl-a", ip: "10.88.0.9", port: 5432, healthy: true, generation: 1, last_probe_unix_ms: 1}]
+    )
+
+    :ok = StatefulManager.reconcile(ctx.mgr)
+
+    # NOT re-adopted to :serving; stays destroying for the (gated) redrive to own.
+    {:ok, inst} = StatefulStore.get(ctx.store, "stf-destroying")
+    assert inst.state == :destroying
+    assert Agent.get(ctx.starts, & &1) == 0
+  end
+
   test "adoption heals a limbo instance the node reports only as a bundle to banked" do
     ctx = start_stack()
     stateful_workload(ctx, "wl-a")

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -845,9 +845,9 @@ defmodule Embervm.StatefulManagerTest do
         generation: 1
       })
 
-    # Force the instance into :destroying: mid node-confirmed teardown (ADR
-    # embervm/014 decision 5), the teardown RPC in flight.
-    _ = StatefulStore.adopt_state(ctx.store, "stf-destroying", :destroying)
+    # Drive the instance into :destroying via the begin_destroy FSM edge: mid
+    # node-confirmed teardown (ADR embervm/014 decision 5), the teardown RPC in flight.
+    {:ok, _} = StatefulStore.mark(ctx.store, "stf-destroying", :begin_destroy)
 
     # The node still reports the VM live: the straggler report that turns on the TLC
     # NoDestroyBeforeConfirm violation if adoption keys off the node, not the CP state.

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.214
+      targetRevision: 0.1.216
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## What

Adds the `:destroying` adopt-skip to `serving_manager`, `stateful_manager`, and `group_wake_manager` adoption — the guard that previously existed only in `session_manager` (L1793).

First of the ADR 014 **destroy-lane PR 1b** follow-ups, split out as the load-bearing, TLA-proven slice (plan: `docs/plans/2026-07-23-embervm-destroy-lane-1b.md`, on branch `feat/embervm-destroy-lane-1b`).

## Why

PR 5's `adoption.tla` work had TLC catch a reachable `NoDestroyBeforeConfirm` violation: `AdoptInventory` keys off the **node report** (`msg.primed`), not the CP destroy state, so a straggler live-VM report arriving during a node-confirmed teardown re-adopts an instance mid-destroy, which then gets re-assigned. The real reconcile guards this **only for sessions** (`session_manager.ex:1793`); serving/stateful/group `adopt_one` had no equivalent skip. See memory `reference_embervm_tla_adopt_destroying_guard`.

## Change

`instance.state == :destroying -> state` as the **first** cond branch of each `adopt_one` (takes precedence over stuck-wake recovery and the live-VM adopt branch), keyed off the CP state rather than the node report.

Each manager gets a test: seed an instance, force it to `:destroying` via `Store.adopt_state`, have the node still report its live VM/members, reconcile, assert it stays `:destroying` and is not re-adopted.

## Safety

**Inert today.** `:destroying` is only reachable for these three classes once the gated node-confirmed destroy path lands (PRs 3-5 of the 1b plan); until then no instance ever enters `:destroying`, so this branch never matches. It is a safe, additive correctness guard staged ahead of `EMBERVM_NODE_CONFIRMED_DESTROY=1`. Gate remains default-OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)