### PR TITLE
fix(embervm): dedup destroying-stuck alarm + de-mislead Placement.Retry log (pre-flip hardening)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.219
+version: 0.1.220

--- a/projects/embervm/control/lib/embervm/group_wake_manager.ex
+++ b/projects/embervm/control/lib/embervm/group_wake_manager.ex
@@ -191,6 +191,8 @@ defmodule Embervm.GroupWakeManager do
       node_confirmed_destroy: Keyword.get(opts, :node_confirmed_destroy, false),
       destroying_alarm_ms: Keyword.get(opts, :destroying_alarm_ms, 300_000),
       orphan_grace_ms: Keyword.get(opts, :orphan_grace_ms, 60_000),
+      # Ids already alarmed for being stuck in destroying (log once per id, not per tick).
+      destroying_alarmed: MapSet.new(),
       # The composite supernet + DNAT port base + control-plane pod IP, the SAME
       # shared values that feed the GroupManager (and noded's CompositeSupernet /
       # ServingPortBase). Adoption re-derives the entry DNAT endpoint `{pod_ip,
@@ -791,27 +793,38 @@ defmodule Embervm.GroupWakeManager do
   defp redrive_destroying(state, live_members) do
     now = state.clock.()
 
-    GroupStore.all(state.store)
-    |> Enum.filter(&(&1.state == :destroying))
-    |> Enum.reduce(state, fn instance, acc ->
-      maybe_alarm_destroying(acc, instance, now)
+    destroying =
+      GroupStore.all(state.store)
+      |> Enum.filter(&(&1.state == :destroying))
+
+    # Prune the alarmed set to instances still destroying (see session_manager).
+    still = MapSet.new(destroying, & &1.instance_id)
+    state = %{state | destroying_alarmed: MapSet.intersection(state.destroying_alarmed, still)}
+
+    Enum.reduce(destroying, state, fn instance, acc ->
+      acc = maybe_alarm_destroying(acc, instance, now)
       redrive_one_destroying(acc, instance, live_members)
     end)
   end
 
+  # Alarm ONCE per stuck group (dedup via destroying_alarmed): every-tick logging
+  # would flood SigNoz for a genuinely stuck destroy. Returns the updated state.
   defp maybe_alarm_destroying(state, instance, now) do
+    id = instance.instance_id
     elapsed = now - instance.updated_at
 
-    if elapsed > state.destroying_alarm_ms do
+    if elapsed > state.destroying_alarm_ms and not MapSet.member?(state.destroying_alarmed, id) do
       Logger.error("embervm group stuck in destroying",
-        instance_id: instance.instance_id,
+        instance_id: id,
         workload: instance.workload,
         elapsed_ms: elapsed,
         alarm_threshold_ms: state.destroying_alarm_ms
       )
-    end
 
-    :ok
+      %{state | destroying_alarmed: MapSet.put(state.destroying_alarmed, id)}
+    else
+      state
+    end
   end
 
   defp redrive_one_destroying(state, instance, live_members) do

--- a/projects/embervm/control/lib/embervm/placement/retry.ex
+++ b/projects/embervm/control/lib/embervm/placement/retry.ex
@@ -148,13 +148,22 @@ defmodule Embervm.Placement.Retry do
         # into `rest`, and `rest` never contains it again: candidates are unique by
         # instance_id). The advisory downward-headroom refresh is the caller's view
         # concern, delegated to on_reject.
+        # Whether a further attempt will actually run: budget left AND a candidate
+        # left. Under the gate-off single-attempt path (max == 1) this is false, so
+        # the log must NOT claim "retrying" when the very next call stops on the
+        # tried >= max guard (the historic mislead).
+        next = tried + 1
+        will_retry? = next < ctx.max and rest != []
+
         Logger.debug(fn ->
+          outcome = if will_retry?, do: "retrying next candidate", else: "no capacity left within budget"
+
           "embervm placement: brick #{inspect(Map.get(brick, :instance_id))} rejected " <>
-            "(#{inspect(reason)}); retrying next candidate (attempt #{tried + 1}/#{ctx.max})"
+            "(#{inspect(reason)}); #{outcome} (attempt #{next}/#{ctx.max})"
         end)
 
         safe_on_reject(ctx.on_reject, brick, reason)
-        attempt(rest, ctx, tried + 1)
+        attempt(rest, ctx, next)
     end
   end
 

--- a/projects/embervm/control/lib/embervm/serving_manager.ex
+++ b/projects/embervm/control/lib/embervm/serving_manager.ex
@@ -199,6 +199,8 @@ defmodule Embervm.ServingManager do
       node_confirmed_destroy: Keyword.get(opts, :node_confirmed_destroy, false),
       destroying_alarm_ms: Keyword.get(opts, :destroying_alarm_ms, 300_000),
       orphan_grace_ms: Keyword.get(opts, :orphan_grace_ms, 60_000),
+      # Ids already alarmed for being stuck in destroying (log once per id, not per tick).
+      destroying_alarmed: MapSet.new(),
       # The adoption reconcile cadence (0 = off, tests drive reconcile/1).
       reconcile_interval_ms: Keyword.get(opts, :reconcile_interval_ms, 0)
     }
@@ -1090,28 +1092,39 @@ defmodule Embervm.ServingManager do
   defp redrive_destroying(state, live_vms) do
     now = state.clock.()
 
-    ServingStore.all(state.store)
-    |> Enum.filter(&(&1.state == :destroying))
-    |> Enum.reduce(state, fn instance, acc ->
-      maybe_alarm_destroying(acc, instance, now)
+    destroying =
+      ServingStore.all(state.store)
+      |> Enum.filter(&(&1.state == :destroying))
+
+    # Prune the alarmed set to instances still destroying (see session_manager).
+    still = MapSet.new(destroying, & &1.instance_id)
+    state = %{state | destroying_alarmed: MapSet.intersection(state.destroying_alarmed, still)}
+
+    Enum.reduce(destroying, state, fn instance, acc ->
+      acc = maybe_alarm_destroying(acc, instance, now)
       redrive_one_destroying(acc, instance, live_vms)
     end)
   end
 
+  # Alarm ONCE per stuck instance (dedup via destroying_alarmed): every-tick logging
+  # would flood SigNoz for a genuinely stuck destroy. Returns the updated state.
   defp maybe_alarm_destroying(state, instance, now) do
+    id = instance.instance_id
     elapsed = now - instance.updated_at
 
-    if elapsed > state.destroying_alarm_ms do
+    if elapsed > state.destroying_alarm_ms and not MapSet.member?(state.destroying_alarmed, id) do
       Logger.error("embervm serving stuck in destroying",
-        instance_id: instance.instance_id,
+        instance_id: id,
         workload: instance.workload,
         vm_id: instance.vm_id,
         elapsed_ms: elapsed,
         alarm_threshold_ms: state.destroying_alarm_ms
       )
-    end
 
-    :ok
+      %{state | destroying_alarmed: MapSet.put(state.destroying_alarmed, id)}
+    else
+      state
+    end
   end
 
   defp redrive_one_destroying(state, instance, live_vms) do

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -263,6 +263,9 @@ defmodule Embervm.SessionManager do
       # only bite under the node_confirmed_destroy gate.
       destroying_alarm_ms: Keyword.get(opts, :destroying_alarm_ms, 300_000),
       orphan_grace_ms: Keyword.get(opts, :orphan_grace_ms, 60_000),
+      # Ids already alarmed for being stuck in destroying, so the error logs once
+      # per stuck id rather than every reconcile tick (pruned as ids terminalize).
+      destroying_alarmed: MapSet.new(),
       # EMBERVM_ASYNC_LIFECYCLE_WRITES (ADR embervm/014 decision 2). When on, the
       # Direction-2 orphan reconcile ADOPTS-and-backfills a reported session VM whose
       # store row is absent BUT a durable write is still in flight for it (a young
@@ -1583,28 +1586,41 @@ defmodule Embervm.SessionManager do
   defp redrive_destroying(state, live_vms) do
     now = state.clock.()
 
-    SessionStore.all(state.session_store)
-    |> Enum.filter(&(&1.state == :destroying))
-    |> Enum.reduce(state, fn session, acc ->
-      maybe_alarm_destroying(acc, session, now)
+    destroying =
+      SessionStore.all(state.session_store)
+      |> Enum.filter(&(&1.state == :destroying))
+
+    # Prune the alarmed set to sessions still destroying: a terminalized id must not
+    # leak (unbounded growth) and a future re-destroy of the same id should re-alarm.
+    still = MapSet.new(destroying, & &1.session_id)
+    state = %{state | destroying_alarmed: MapSet.intersection(state.destroying_alarmed, still)}
+
+    Enum.reduce(destroying, state, fn session, acc ->
+      acc = maybe_alarm_destroying(acc, session, now)
       redrive_one_destroying(acc, session, live_vms)
     end)
   end
 
+  # Alarm ONCE per stuck session (dedup via destroying_alarmed): reconcile runs every
+  # few seconds, so logging every tick would flood SigNoz for a genuinely stuck
+  # destroy. Returns the updated state (the alarmed set is threaded through redrive).
   defp maybe_alarm_destroying(state, session, now) do
+    id = session.session_id
     elapsed = now - session.updated_at
 
-    if elapsed > state.destroying_alarm_ms do
+    if elapsed > state.destroying_alarm_ms and not MapSet.member?(state.destroying_alarmed, id) do
       Logger.error("embervm session stuck in destroying",
-        session_id: session.session_id,
+        session_id: id,
         workload: session.workload,
         vm_id: session.vm_id,
         elapsed_ms: elapsed,
         alarm_threshold_ms: state.destroying_alarm_ms
       )
-    end
 
-    :ok
+      %{state | destroying_alarmed: MapSet.put(state.destroying_alarmed, id)}
+    else
+      state
+    end
   end
 
   defp redrive_one_destroying(state, session, live_vms) do

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -338,6 +338,8 @@ defmodule Embervm.StatefulManager do
       node_confirmed_destroy: Keyword.get(opts, :node_confirmed_destroy, false),
       destroying_alarm_ms: Keyword.get(opts, :destroying_alarm_ms, 300_000),
       orphan_grace_ms: Keyword.get(opts, :orphan_grace_ms, 60_000),
+      # Ids already alarmed for being stuck in destroying (log once per id, not per tick).
+      destroying_alarmed: MapSet.new(),
       # workload -> monotonic ms the in-flight wake started (Task 10). Feeds the
       # adoption self-recovery + the park_full oldest-waiter age: a workload still
       # waking past 2 * wakeTimeoutSeconds is a wedged wake whose worker never
@@ -1867,28 +1869,39 @@ defmodule Embervm.StatefulManager do
   defp redrive_destroying(state, live_vms) do
     now = state.clock.()
 
-    StatefulStore.all(state.store)
-    |> Enum.filter(&(&1.state == :destroying))
-    |> Enum.reduce(state, fn instance, acc ->
-      maybe_alarm_destroying(acc, instance, now)
+    destroying =
+      StatefulStore.all(state.store)
+      |> Enum.filter(&(&1.state == :destroying))
+
+    # Prune the alarmed set to instances still destroying (see session_manager).
+    still = MapSet.new(destroying, & &1.instance_id)
+    state = %{state | destroying_alarmed: MapSet.intersection(state.destroying_alarmed, still)}
+
+    Enum.reduce(destroying, state, fn instance, acc ->
+      acc = maybe_alarm_destroying(acc, instance, now)
       redrive_one_destroying(acc, instance, live_vms)
     end)
   end
 
+  # Alarm ONCE per stuck instance (dedup via destroying_alarmed): every-tick logging
+  # would flood SigNoz for a genuinely stuck destroy. Returns the updated state.
   defp maybe_alarm_destroying(state, instance, now) do
+    id = instance.instance_id
     elapsed = now - instance.updated_at
 
-    if elapsed > state.destroying_alarm_ms do
+    if elapsed > state.destroying_alarm_ms and not MapSet.member?(state.destroying_alarmed, id) do
       Logger.error("embervm stateful instance stuck in destroying",
-        instance_id: instance.instance_id,
+        instance_id: id,
         workload: instance.workload,
         vm_id: instance.vm_id,
         elapsed_ms: elapsed,
         alarm_threshold_ms: state.destroying_alarm_ms
       )
-    end
 
-    :ok
+      %{state | destroying_alarmed: MapSet.put(state.destroying_alarmed, id)}
+    else
+      state
+    end
   end
 
   defp redrive_one_destroying(state, instance, live_vms) do

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -58,8 +58,20 @@ defmodule Embervm.SessionManagerTest do
     async = Keyword.get(opts, :async_lifecycle_writes, false)
     {:ok, writer} = Embervm.AsyncWriter.start_link(name: nil)
 
+    # Optional store clock: the manager clock is fixed at 5_000_000, so a test that
+    # exercises the stuck-in-destroying alarm passes store_clock: fn -> 0 end to make
+    # a row's updated_at precede now and the elapsed compare positive.
+    store_clock_opts =
+      case Keyword.get(opts, :store_clock) do
+        nil -> []
+        c -> [clock: c]
+      end
+
     {:ok, store} =
-      SessionStore.start_link(name: nil, op_log: op_log, async_writer: writer, async_lifecycle_writes: async)
+      SessionStore.start_link(
+        [name: nil, op_log: op_log, async_writer: writer, async_lifecycle_writes: async] ++
+          store_clock_opts
+      )
 
     registry = :"sreg_#{suffix}"
     {:ok, _registry_pid} = Registry.start_link(keys: :unique, name: registry)
@@ -569,6 +581,44 @@ defmodule Embervm.SessionManagerTest do
 
     {:ok, session} = SessionStore.get(ctx.store, created.session_id)
     assert session.state == :destroyed
+  end
+
+  test "gated: a session stuck in destroying alarms ONCE across reconciles, not every tick" do
+    # Unconfirming teardown so the session stays destroying across both reconciles.
+    # store_clock: fn -> 0 end sets updated_at before the manager's fixed 5_000_000
+    # clock, so elapsed exceeds the alarm threshold and the alarm is eligible each tick.
+    ctx =
+      start_stack(
+        node_confirmed_destroy: true,
+        destroying_alarm_ms: 100,
+        store_clock: fn -> 0 end,
+        session_channel_fun: fn _node -> {:ok, :ch} end,
+        destroy_fun: fn _ch, _vm -> {:ok, %{teardown_confirmed: false}} end
+      )
+
+    put_session_workload(ctx, "wl-alarm")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-alarm", "p1")
+
+    {:ok, _} =
+      SessionStore.transition(ctx.store, created.session_id, :begin_destroy, :session_destroying, %{reason: :destroyed}, %{})
+
+    report_session_vm(ctx, created.session_id, "wl-alarm")
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        :ok = SessionManager.reconcile(ctx.mgr)
+        :ok = SessionManager.reconcile(ctx.mgr)
+      end)
+
+    # Teardown never confirmed, so it is still destroying and BOTH reconciles were
+    # alarm-eligible, but the dedup logs the stuck error exactly once.
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :destroying
+
+    hits = (log |> String.split("session stuck in destroying") |> length()) - 1
+    assert hits == 1, "expected exactly one stuck-in-destroying alarm, got #{hits}"
+
+    assert MapSet.member?(:sys.get_state(ctx.mgr).destroying_alarmed, created.session_id)
   end
 
   test "gated: reconcile destroys an orphan reported session VM with no CP row" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.219
+      targetRevision: 0.1.220
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## What

Pre-flip hardening for `EMBERVM_NODE_CONFIRMED_DESTROY` (gate stays default-OFF). Two clear items from the ADR 014 destroy-lane follow-up list, now that 1b (#3938) has landed the node-confirmed destroy across all four classes.

## 1. Alarm dedup (session/serving/stateful/group_wake)

`maybe_alarm_destroying` logged `Logger.error("... stuck in destroying")` on **every reconcile tick** for a genuinely-stuck destroying instance. Reconcile runs every few seconds, so once the gate is flipped a stuck destroy would flood SigNoz with hundreds of identical errors/hour, drowning the signal it's meant to raise.

Fix: thread a `destroying_alarmed` MapSet through `redrive_destroying` so the error logs **once per stuck id**. The set is pruned each pass to ids still `:destroying` (bounded growth; a future re-destroy of the same id re-alarms). `maybe_alarm_destroying` now returns the updated state.

## 2. `Placement.Retry` misleading log

The `{:reject, _}` branch logged `"retrying next candidate"` **before** the `tried >= max` guard runs. Under the gate-off single-attempt path (`max == 1`), the very next `attempt/3` call stops immediately with `:no_capacity` — so the log claimed a retry that never happens. Now it logs `"retrying"` only when a further attempt will actually run (budget left **and** a candidate left), else `"no capacity left within budget"`.

## Test

`session_manager_test` gains a small `store_clock` injection (the manager clock is fixed at `5_000_000`, so a row's `updated_at` must precede it for the elapsed compare to fire) and a dedup test: two reconciles on a stuck destroying session → exactly one alarm, and the id is recorded in `destroying_alarmed`. The refactor's correctness is additionally covered by 1b's existing redrive tests, which exercise the refactored functions.

## Safety

No gate flip. Both gates stay default-OFF; this only changes observability (log volume + accuracy) and is inert on the gate-off path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)