### PR TITLE
fix(embervm): resolve base export/retention by node, not stale placement instance_id

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.220
+version: 0.1.221

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -1096,6 +1096,40 @@ defmodule Embervm.BaseBuilder do
     end
   end
 
+  # The node-name portion of a placement instance_id ("node/pod_uid" -> "node"; a
+  # bare id with no "/" is already a node name).
+  defp node_name(id) when is_binary(id), do: id |> String.split("/", parts: 2) |> hd()
+  defp node_name(_), do: nil
+
+  # Map a (possibly stale) placement instance_id to the CURRENT registered instance
+  # on the SAME node, preferring one whose reported facts already include `workload`'s
+  # base (node-mates share the hostPath scratch, so any current instance can
+  # export/evict it). Falls back to the original id when no current node-mate is
+  # registered, so the path behaves exactly as before rather than acting on a guess.
+  #
+  # Base ownership is a NODE property: a built base lives on the node's hostPath
+  # scratch and survives a noded pod restart, but the build-time placement instance_id
+  # churns with the pod. Without this remap `find_capacity_fact`/`node_addr` miss after
+  # any pod restart (the churned pod_uid no longer matches w.node_id), which silently
+  # parks the durability export AND the local retention drain: the current base is
+  # never seen as exportable, so the sweep skips every workload as unexported.
+  defp current_instance_on_node(state, stale_id, workload) do
+    target = node_name(stale_id)
+
+    mates =
+      state.capacity_table
+      |> Embervm.NodeCapacity.all()
+      |> Enum.filter(fn f -> node_name(Map.get(f, :instance_id)) == target end)
+
+    reporter = Enum.find(mates, fn f -> get_in(f, [:workloads, workload]) != nil end)
+
+    cond do
+      reporter != nil -> Map.get(reporter, :instance_id)
+      mates != [] -> mates |> hd() |> Map.get(:instance_id)
+      true -> stale_id
+    end
+  end
+
   # An instance can build the workload when it is a wildcard (empty class or zero
   # budget: the full-node envelope, always able to boot) or its budget covers need.
   defp build_eligible?(i, need_mib) do
@@ -1450,8 +1484,10 @@ defmodule Embervm.BaseBuilder do
   # must not ship into the store), so it cannot hammer.
   defp export_reconcile(state) do
     Enum.reduce(state.workloads, state, fn {_name, w}, acc ->
-      if current_base_present_but_unexported?(acc, w) do
-        spawn_export(acc, w.node_id, w.name, w.snapshot_ref)
+      cur = current_instance_on_node(acc, w.node_id, w.name)
+
+      if current_base_present_but_unexported?(acc, cur, w) do
+        spawn_export(acc, cur, w.name, w.snapshot_ref)
       else
         acc
       end
@@ -1465,9 +1501,9 @@ defmodule Embervm.BaseBuilder do
   # against exporting a BUILDING/FAILED entry; requiring the node fact at all
   # means a base whose node has not yet reported is left for the next sweep
   # (never blindly re-exported without evidence it is present).
-  defp current_base_present_but_unexported?(state, w) do
+  defp current_base_present_but_unexported?(state, node_ref, w) do
     is_binary(w.node_id) and is_binary(w.snapshot_ref) and
-      case node_base_fact(state, w.node_id, w.name) do
+      case node_base_fact(state, node_ref, w.name) do
         {:ok, %{snapshot_ref: ref, base_state: base_state, exported: exported}} ->
           ref == w.snapshot_ref and
             base_state == :BASE_BUILD_STATE_READY and exported != true
@@ -1544,8 +1580,10 @@ defmodule Embervm.BaseBuilder do
   #   {:skip_unexported, node_id}    - current base present but not yet exported
   #   {:evict, node_id, refs, bytes} - superseded local bases to evict + their bytes
   defp workload_retention(state, w) do
+    cur = current_instance_on_node(state, w.node_id, w.name)
+
     with true <- is_binary(w.node_id) and is_binary(w.snapshot_ref),
-         {:ok, fact} <- find_capacity_fact(state.capacity_table, w.node_id),
+         {:ok, fact} <- find_capacity_fact(state.capacity_table, cur),
          locals when is_list(locals) <- Map.get(fact, :local_bases, []) do
       current_exported? =
         case get_in(fact, [:workloads, w.name]) do
@@ -1556,7 +1594,7 @@ defmodule Embervm.BaseBuilder do
       cond do
         not current_exported? ->
           # Durability floor not yet confirmed for this workload: skip it whole.
-          {:skip_unexported, w.node_id}
+          {:skip_unexported, cur}
 
         true ->
           desired = desired_refs(w)
@@ -1580,7 +1618,7 @@ defmodule Embervm.BaseBuilder do
           else
             refs = Enum.map(candidates, & &1.ref)
             bytes = candidates |> Enum.map(&(&1.size_bytes || 0)) |> Enum.sum()
-            {:evict, w.node_id, refs, bytes}
+            {:evict, cur, refs, bytes}
           end
       end
     else

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -1229,6 +1229,45 @@ defmodule Embervm.BaseBuilderTest do
     refute_receive {:exported, "snap1"}, 200
   end
 
+  test "export reconcile resolves a stale placement instance_id to the current node-mate (pod-restart churn)" do
+    agent = start_recorder()
+    test_pid = self()
+    table = new_cap_table()
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("snap1")} end
+
+    export_fun = fn :fake_channel, %Embervm.Node.V1.ExportArtifactRequest{artifact: ref} ->
+      send(test_pid, {:exported, ref.ref})
+      {:ok, %Embervm.Node.V1.ExportArtifactResponse{bytes_moved: 0, skipped: true, generation: 0}}
+    end
+
+    builder =
+      start_builder(
+        # Both the build-time pod (big) and the post-restart pod (big2) are
+        # registered with addresses; only big is a brick, so the build places there.
+        nodes: [%{id: "node-4/big", address: "a"}, %{id: "node-4/big2", address: "a"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        export_fun: export_fun,
+        export_reconcile_interval_ms: 20
+      )
+
+    put_brick(table, "node-4", "big", size_class: "16gi", mem_budget: 16_384, mem_headroom: 16_000)
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "snap1" end)
+    assert_receive {:exported, "snap1"}, 1_000
+
+    # The placed pod (big) restarts as a new pod (big2) on the SAME node. Only big2
+    # now reports the base READY-but-unexported; the build-time instance_id (big) is
+    # stale and no longer in the capacity table's workload facts. The reconcile must
+    # resolve big -> big2 (same node) and re-export via big2's address. Before the
+    # node-name remap this missed on the churned instance_id and the export parked.
+    put_base_fact(table, "node-4", "big2", "w", "snap1", :BASE_BUILD_STATE_READY, false)
+    assert_receive {:exported, "snap1"}, 1_000
+  end
+
   test "the reconcile does not fire a second export RPC for a ref already in flight, and re-issues once it settles" do
     # fast-durability-export fix: the CP-side in-flight set trims reconcile RPC churn
     # (noded's exportDedupe is what serializes the actual multi-minute upload). While

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.220
+      targetRevision: 0.1.221
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Problem

The base-retention drain (\`EMBERVM_BASE_RETENTION_SWEEP\`) is armed on main and live, but silently parks: node-4 holds **893 superseded base rootfs files (~470G)** with the gate on and **zero sweep/eviction activity in 48h**.

## Root cause (code-confirmed)

\`base_builder\` keys a workload's placement by **\`instance_id\` = \"node/pod_uid\"** (comments at lines 759, 820, 1007, 1087), and both \`find_capacity_fact\` and \`node_addr\` match on that exact id. The **pod_uid churns on every noded restart**. After a restart:

- \`w.node_id\` still holds the build-time (now stale) instance_id.
- \`node_base_fact\` -> \`find_capacity_fact(w.node_id)\` returns \`:error\` (the current fact is under the new pod_uid).
- \`current_base_present_but_unexported?\` is false -> the reconcile never re-exports.
- \`retention_sweep_plan\` -> \`workload_retention\` hits \`:skip_unexported\` for every workload (durability floor never confirmed) -> **nothing drains**.

Base export crashed identically (\`GRPC.Stub.connect(nil, ...)\` at \`spawn_export\`) on the startup race where the CP tried to export before node-4 re-registered (\`node_addr[stale_id]\` was nil). Verified live: export errors clustered at CP boot (13:39:39), node-4 registered 2 min later (13:41:34).

This is the recurring instance-key-churn class (alias-route / dialhome): a node-name-keyed consumer reading an instance-keyed table.

## Fix

Base ownership is a **NODE** property: the base lives on the node's hostPath scratch and survives a pod restart. So the export + retention lookups now resolve the stale placement instance_id to the **current registered instance on the same node** (\`current_instance_on_node/3\`), preferring one whose reported facts include the workload's base (node-mates share the hostPath, so any current instance can export/evict). Falls back to the original id when no node-mate is registered, so behavior is unchanged when the id is already current.

Applied at the three seams: \`node_base_fact\` (via \`current_base_present_but_unexported?\`), \`spawn_export\` target, and \`workload_retention\` (fact lookup + the evict RPC target). No proto/Go change; the join key stays opaque.

## Test

Adds a regression test: build on \`node-4/big\`, then have only \`node-4/big2\` (same node, new pod) report the base READY-but-unexported. Before the fix the reconcile misses on the churned instance_id; after, it resolves \`big -> big2\` and re-exports. Existing export-reconcile and retention tests are unaffected (the resolver returns the same id when it is already current).

## After merge

Once currents export, the durability floor lands and the retention sweep should drain the ~470G backlog on node-4 (supervised). Confirms finish-the-program Goal 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)