### PR TITLE
fix(embervm): attempt-aliasing epoch guard for async lifecycle writes

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.221
+version: 0.1.222

--- a/projects/embervm/control/lib/embervm/op_log/postgres.ex
+++ b/projects/embervm/control/lib/embervm/op_log/postgres.ex
@@ -590,11 +590,11 @@ defmodule Embervm.OpLog.Postgres do
   # while a legitimate forward jump still applies. Inert under the gate off. See the
   # SQLite backend for the full rationale.
   defp project(conn, %Op{kind: :assigned} = op, _seq) do
-    advance_task_state(conn, op.task_id, :assigned, op.ts)
+    advance_task_state(conn, op.task_id, :assigned, op.ts, epoch_of(op))
   end
 
   defp project(conn, %Op{kind: :started} = op, _seq) do
-    advance_task_state(conn, op.task_id, :running, op.ts)
+    advance_task_state(conn, op.task_id, :running, op.ts, epoch_of(op))
   end
 
   defp project(conn, %Op{kind: :succeeded} = op, _seq) do
@@ -1334,19 +1334,38 @@ defmodule Embervm.OpLog.Postgres do
   end
 
   # Monotonic advance for a deferred async lifecycle append: SET `to_state` only
-  # when the row ranks strictly below it in the lifecycle partial order
-  # (see Embervm.OpLog.SQLite.advance_task_state/4 and Embervm.TaskState.states_below/1).
-  defp advance_task_state(conn, task_id, to_state, ts) do
+  # when the row ranks strictly below it in the lifecycle partial order AND the
+  # row's retry count is still below the op's issue-time attempt (see
+  # Embervm.OpLog.SQLite.advance_task_state/5 for the full attempt-aliasing
+  # rationale and Embervm.TaskState.states_below/1 for the rank order). `epoch` nil
+  # (sync write-through, or a pre-epoch op) runs only the rank guard, unchanged.
+  defp advance_task_state(conn, task_id, to_state, ts, epoch \\ nil) do
     below = Embervm.TaskState.states_below(to_state)
     # $1 to_state, $2 ts, $3 task_id, then $4.. for the state-in list.
     placeholders = below |> Enum.with_index(4) |> Enum.map_join(",", fn {_, i} -> "$#{i}" end)
 
+    {epoch_clause, epoch_args} =
+      case epoch do
+        e when is_integer(e) -> {" AND attempt < $#{4 + length(below)}", [e]}
+        _ -> {"", []}
+      end
+
     exec(
       conn,
-      "UPDATE tasks SET state=$1, updated_at=$2 WHERE task_id=$3 AND state IN (#{placeholders})",
-      [Atom.to_string(to_state), ts, task_id | below]
+      "UPDATE tasks SET state=$1, updated_at=$2 WHERE task_id=$3 AND state IN (#{placeholders})" <>
+        epoch_clause,
+      [Atom.to_string(to_state), ts, task_id | below] ++ epoch_args
     )
   end
+
+  # The dispatch attempt (1-based) a deferred async :assigned/:started op was issued
+  # under, from the op payload (atom key on a fresh append, string key if ever
+  # re-projected from durable JSON). nil when absent. Mirrors Embervm.OpLog.SQLite.
+  defp epoch_of(%Op{payload: payload}) when is_map(payload) do
+    Map.get(payload, :epoch) || Map.get(payload, "epoch")
+  end
+
+  defp epoch_of(_op), do: nil
 
   # -- usage accrual, mirrors Embervm.OpLog.SQLite exactly -------------------
 

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -730,11 +730,11 @@ defmodule Embervm.OpLog.SQLite do
   # live write-through path and a full oplog rebuild-replay, regardless of async
   # append order. Inert under the gate off (appends always arrive in rank order).
   defp project(conn, %Op{kind: :assigned} = op, _seq) do
-    advance_task_state(conn, op.task_id, :assigned, op.ts)
+    advance_task_state(conn, op.task_id, :assigned, op.ts, epoch_of(op))
   end
 
   defp project(conn, %Op{kind: :started} = op, _seq) do
-    advance_task_state(conn, op.task_id, :running, op.ts)
+    advance_task_state(conn, op.task_id, :running, op.ts, epoch_of(op))
   end
 
   defp project(conn, %Op{kind: :succeeded} = op, _seq) do
@@ -1932,18 +1932,53 @@ defmodule Embervm.OpLog.SQLite do
   # so an out-of-order async append can never regress the durable state; a
   # legitimate forward jump (queued -> running when :assigned was lost) still
   # applies. Same guard, same outcome on the live path and on rebuild-replay.
-  defp advance_task_state(conn, task_id, to_state, ts) do
+  #
+  # `epoch` is the SECOND, ORTHOGONAL half of the guard: the state-rank test alone
+  # cannot catch an ATTEMPT-ALIASED stale append, because queued -> assigned is
+  # FORWARD in the rank order regardless of which dispatch attempt issued it. A task
+  # that was assigned under attempt N (deferred :assigned enqueued), then failed and
+  # `:retried` (back to queued, attempt N+1) awaiting a fresh dispatch, would have
+  # that stale attempt-N :assigned land against the now-queued row and re-assign it
+  # to a worker that no longer exists. So the deferred op carries the 1-based attempt
+  # it was issued under, and we additionally require the row's retry count (the
+  # 0-based `attempt` column) to still be BELOW that epoch: `attempt < epoch`. A
+  # stale attempt-N append (epoch N) against a row already retried to attempt N (SQL
+  # attempt column N, i.e. not < N) matches no row and is dropped; the current
+  # attempt's append (epoch N+1 against SQL attempt N) still applies. `epoch` is nil
+  # for the write-through (gate-off) path and every pre-epoch op, in which case only
+  # the rank guard runs and behaviour is exactly as before.
+  defp advance_task_state(conn, task_id, to_state, ts, epoch \\ nil) do
     below = Embervm.TaskState.states_below(to_state)
     placeholders = Enum.map_join(below, ",", fn _ -> "?" end)
-    sql = "UPDATE tasks SET state=?, updated_at=? WHERE task_id=? AND state IN (#{placeholders})"
+
+    {epoch_clause, epoch_args} =
+      case epoch do
+        e when is_integer(e) -> {" AND attempt < ?", [e]}
+        _ -> {"", []}
+      end
+
+    sql =
+      "UPDATE tasks SET state=?, updated_at=? WHERE task_id=? AND state IN (#{placeholders})" <>
+        epoch_clause
 
     with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
-         :ok <- Sqlite3.bind(stmt, [Atom.to_string(to_state), ts, task_id | below]),
+         :ok <- Sqlite3.bind(stmt, [Atom.to_string(to_state), ts, task_id | below] ++ epoch_args),
          :done <- Sqlite3.step(conn, stmt),
          :ok <- Sqlite3.release(conn, stmt) do
       :ok
     end
   end
+
+  # The dispatch attempt (1-based) a deferred async :assigned/:started op was issued
+  # under, read from the op payload (atom key on a fresh append, string key if ever
+  # re-projected from durable JSON). nil when absent (sync write-through path, or an
+  # op appended before the epoch tag existed): the caller then applies only the
+  # state-rank guard, unchanged.
+  defp epoch_of(%Op{payload: payload}) when is_map(payload) do
+    Map.get(payload, :epoch) || Map.get(payload, "epoch")
+  end
+
+  defp epoch_of(_op), do: nil
 
   # Accumulating usage upsert, run INSIDE the same transaction as the
   # :succeeded/:failed op (see project/2), so a task's usage commits with its

--- a/projects/embervm/control/lib/embervm/task_store.ex
+++ b/projects/embervm/control/lib/embervm/task_store.ex
@@ -740,7 +740,13 @@ defmodule Embervm.TaskStore do
         workload: task.workload,
         task_id: task_id,
         ts: ts,
-        payload: %{}
+        # The dispatch attempt (1-based ETS `attempt`, unchanged by :assign/:start)
+        # this deferred op belongs to. The op-log projection's monotonic guard
+        # (advance_task_state/5) applies it only while the durable row has not yet
+        # `:retried` past this attempt, so a stale attempt-N :assigned/:started that
+        # lands after a retry re-queued the task (attempt N+1) is dropped instead of
+        # re-assigning a worker that no longer exists.
+        payload: %{epoch: task.attempt}
       }
 
       Embervm.AsyncWriter.enqueue(state.async_writer, %{

--- a/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/sqlite_test.exs
@@ -920,4 +920,61 @@ defmodule Embervm.OpLog.SQLiteTest do
     assert task_state(server2, "task-z") == "succeeded"
     :ok = GenServer.stop(server2)
   end
+
+  # -- attempt-aliasing epoch guard (ADR embervm/014 decision 2, async gate) --
+
+  test "attempt-aliasing: a stale :assigned from a prior attempt does NOT re-assign a task retried back to queued",
+       %{path: path} do
+    server = start_server(path)
+
+    append_task_op(server, :submitted, "task-a", 100, %{idempotency_key: nil, expires_at: nil})
+    # Attempt 1 (epoch 1) is dispatched: its deferred :assigned/:started land and
+    # advance the row to running (attempt column still 0).
+    append_task_op(server, :assigned, "task-a", 101, %{epoch: 1})
+    append_task_op(server, :started, "task-a", 102, %{epoch: 1})
+    assert task_state(server, "task-a") == "running"
+
+    # Attempt 1 fails and is retried: back to queued, attempt column now 1.
+    append_task_op(server, :failed, "task-a", 103, %{state: :failed_retryable, reason: :transport})
+    append_task_op(server, :retried, "task-a", 104)
+    assert task_state(server, "task-a") == "queued"
+
+    # The DEFERRED attempt-1 :assigned finally lands (epoch 1). queued -> assigned is
+    # FORWARD in the state-rank order, so the rank guard alone would let it through;
+    # the EPOCH guard drops it because the row has already retried to attempt 1
+    # (1 is not < 1). Without this guard the task would be re-assigned to attempt 1's
+    # worker, which no longer exists.
+    append_task_op(server, :assigned, "task-a", 105, %{epoch: 1})
+    assert task_state(server, "task-a") == "queued"
+
+    # The CURRENT attempt (epoch 2) assigns normally: the row's attempt (1) is still
+    # below the op's epoch (2), so the same guard admits it.
+    append_task_op(server, :assigned, "task-a", 106, %{epoch: 2})
+    assert task_state(server, "task-a") == "assigned"
+
+    # And the stale epoch-1 append is STILL in the durable log (audit trail), so the
+    # guard suppressed the projection effect, not the record: three :assigned ops.
+    {:ok, ops} = SQLite.read_from(server, 0)
+    assert Enum.count(ops, &(&1.task_id == "task-a" and &1.kind == :assigned)) == 3
+
+    :ok = GenServer.stop(server)
+    server2 = start_server(path)
+    assert task_state(server2, "task-a") == "assigned"
+    :ok = GenServer.stop(server2)
+  end
+
+  test "an epoch-tagged :assigned still applies on the normal forward path (no retry, attempt 0 < epoch 1)",
+       %{path: path} do
+    server = start_server(path)
+
+    append_task_op(server, :submitted, "task-b", 100, %{idempotency_key: nil, expires_at: nil})
+    # No retry has happened: attempt column is 0, below epoch 1, so the epoch guard
+    # is a no-op and the row advances exactly as the un-tagged path would.
+    append_task_op(server, :assigned, "task-b", 101, %{epoch: 1})
+    assert task_state(server, "task-b") == "assigned"
+    append_task_op(server, :started, "task-b", 102, %{epoch: 1})
+    assert task_state(server, "task-b") == "running"
+
+    :ok = GenServer.stop(server)
+  end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.221
+      targetRevision: 0.1.222
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## What

Closes the last subtle correctness gap before `EMBERVM_ASYNC_LIFECYCLE_WRITES` can flip (ADR embervm/014 decision 2).

Under the async gate, the `:assigned`/`:started` durable oplog append is deferred through `AsyncWriter`. The op-log projection's monotonic guard (`advance_task_state`) prevented a late append from **regressing** a row backward in the state-rank order (`states_below`). But `queued -> assigned` is **forward** in that order regardless of which dispatch attempt issued the op, so the rank guard cannot see an **attempt-aliased** stale write:

1. Attempt N is dispatched: deferred `:assigned` enqueued.
2. It fails and `:retried` back to `queued` (attempt N+1), awaiting a fresh dispatch.
3. The stale attempt-N `:assigned` finally lands, matches the now-`queued` row (forward jump), and re-assigns the task to a worker that no longer exists.

## Fix

Tag each deferred `:assigned`/`:started` op with the 1-based `attempt` it was issued under (an `epoch`), and require the durable row's 0-based retry count to still be below it (`attempt < epoch`) in the **same** `UPDATE`. A stale-epoch append matches no row and is dropped; the current attempt's append still applies. The existing forward-jump (lost-`:assigned` → `:started` still advances) and terminal-regression guarantees are untouched.

`epoch` is `nil` for the sync write-through path and every op appended before this change, in which case only the state-rank guard runs, so the **gate-off path is byte-identical to before**. Mirrored in the Postgres backend (compile-verified; no live PG in CI).

## Test

`sqlite_test.exs`: a stale attempt-1 `:assigned` landing after a retry-to-queued is dropped (row stays `queued`), the current attempt (epoch 2) assigns normally, and the stale op is still recorded in the durable log (audit). Plus a forward-path test proving an epoch-tagged append with no retry (attempt 0 < epoch 1) advances exactly as the untagged path did.

Chart bumped to 0.1.222 (control-plane code change; gate stays default-OFF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)