### PR TITLE
feat(embervm): node-local activator, serving lane (ADR 018 Phase 0-1)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.223
+version: 0.1.224

--- a/projects/embervm/chart/crds/workload-crd.yaml
+++ b/projects/embervm/chart/crds/workload-crd.yaml
@@ -382,6 +382,27 @@ spec:
                         when unset (the watcher applies that), so a banked snapshot
                         never outlives what a live instance would.
                       minimum: 0
+                    nodeLocalWake:
+                      type: boolean
+                      description: >-
+                        Node-local activator (ADR embervm/018 Fork A). When true,
+                        the brick's node-local activator is eligible to cold-boot a
+                        scaled-to-zero instance of this workload on the first request,
+                        so the wake survives a control-plane Recreate instead of
+                        black-holing on the dead CP-pod activator. Pushed to the node
+                        daemon in the workload registry and drives the control plane's
+                        origin=ACTIVATOR adoption. Defaults false (CP-only wake).
+                      default: false
+                    meteringFailOpen:
+                      type: boolean
+                      description: >-
+                        Companion, EXPLICIT policy for nodeLocalWake (ADR embervm/018
+                        Fork A): a true workload wakes UNMETERED during a control-plane
+                        gap and reconciles accounting best-effort when the control
+                        plane adopts the instance and backfills its lifecycle ops. The
+                        policy is named here rather than implied; allowlisted to
+                        blessed homelab demos. Defaults false.
+                      default: false
                 stateful:
                   type: object
                   description: >-

--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -120,6 +120,12 @@ containers:
       - name: health
         containerPort: {{ $ctx.Values.noded.healthPort }}
         protocol: TCP
+      # Node-local activator (ADR embervm/018 Fork A): the HTTP listener a node
+      # Envoy routes a scaled-to-zero serving workload's first request to, so the
+      # cold boot happens on the brick and survives a CP Recreate.
+      - name: activator
+        containerPort: {{ $ctx.Values.noded.activatorPort }}
+        protocol: TCP
     env:
       - name: EMBERVM_NODED_LISTEN_ADDR
         value: ":{{ $ctx.Values.noded.grpcPort }}"
@@ -139,6 +145,15 @@ containers:
         valueFrom:
           fieldRef:
             fieldPath: status.podIP
+      # Node-local activator listener (ADR embervm/018 Fork A). The daemon serves
+      # cold-boot wakes for scaled-to-zero serving workloads here, and advertises
+      # its own pod IP + this port as NodeStatus.activator_endpoint (the address a
+      # pod-network Envoy dials, exactly as it dials serving VMs at pod_ip:vmPort;
+      # advertising the node IP would black-hole since the serving DNAT lives in
+      # noded's own netns). The pod IP is stable across a control-plane Recreate,
+      # which is the failure this survives.
+      - name: EMBERVM_NODED_ACTIVATOR_ADDR
+        value: ":{{ $ctx.Values.noded.activatorPort }}"
       # The pod's own UID (Downward API metadata.uid), the daemon's INSTANCE
       # identity. Reported as NodeStatus.pod_uid and advertised in the
       # dial-home registration, so the control plane keys its registry and

--- a/projects/embervm/chart/templates/workload-hot-image-demo.yaml
+++ b/projects/embervm/chart/templates/workload-hot-image-demo.yaml
@@ -48,4 +48,9 @@ spec:
     idleBankSeconds: {{ .Values.hotImageDemo.serving.idleBankSeconds }}
     drainSeconds: {{ .Values.hotImageDemo.serving.drainSeconds }}
     maxLifetimeSeconds: {{ .Values.hotImageDemo.serving.maxLifetimeSeconds }}
+    # Node-local activator (ADR embervm/018 Fork A): the brick cold-boots this
+    # scaled-to-zero demo's first request so it survives a control-plane Recreate;
+    # meteringFailOpen names the wake-unmetered-during-gap policy for this blessed demo.
+    nodeLocalWake: {{ .Values.hotImageDemo.serving.nodeLocalWake }}
+    meteringFailOpen: {{ .Values.hotImageDemo.serving.meteringFailOpen }}
 {{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -783,8 +783,10 @@ noded:
   # Node-local activator HTTP listener (ADR embervm/018 Fork A): a node Envoy
   # routes a scaled-to-zero serving workload's first request here, so the cold
   # boot happens on the brick and survives a control-plane Recreate. Advertised as
-  # NodeStatus.activator_endpoint at {node hostIP, activatorPort} with a startup
-  # DNAT to the current pod IP.
+  # NodeStatus.activator_endpoint at {noded pod IP, activatorPort}, the address a
+  # pod-network Envoy dials (the serving DNAT lives in noded's own netns, so a
+  # node-IP advert would black-hole; ADR 018 as amended). The pod IP is stable
+  # across a control-plane Recreate, the failure this survives.
   activatorPort: 8081
 
   # node-4 pinning: the lone Firecracker node (homelab.io/firecracker=true).

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -483,6 +483,14 @@ hotImageDemo:
     idleBankSeconds: 600
     drainSeconds: 5
     maxLifetimeSeconds: 86400
+    # Node-local activator (ADR embervm/018 Fork A): eligible for a brick cold boot
+    # so a scaled-to-zero first request survives a control-plane Recreate (the
+    # demo's whole point). meteringFailOpen is the companion, named policy that this
+    # blessed demo wakes unmetered during a CP gap and reconciles on adoption. When
+    # this demo is scaled to zero for the kill-the-CP drill, the first request
+    # cold-boots on the brick instead of black-holing on the dead CP-pod activator.
+    nodeLocalWake: true
+    meteringFailOpen: true
   # Sized for the WARM serving footprint, not the fresh-per-request task footprint
   # (task-class og-image is 512Mi). Pillow stays resident and the TCP server runs
   # continuously across many renders, so memMib is 768 for headroom (256Mi x max 2
@@ -772,6 +780,12 @@ noded:
   # gRPC port the control plane dials; health port for kubelet probes.
   grpcPort: 9090
   healthPort: 8080
+  # Node-local activator HTTP listener (ADR embervm/018 Fork A): a node Envoy
+  # routes a scaled-to-zero serving workload's first request here, so the cold
+  # boot happens on the brick and survives a control-plane Recreate. Advertised as
+  # NodeStatus.activator_endpoint at {node hostIP, activatorPort} with a startup
+  # DNAT to the current pod IP.
+  activatorPort: 8081
 
   # node-4 pinning: the lone Firecracker node (homelab.io/firecracker=true).
   nodeSelector:

--- a/projects/embervm/control/lib/embervm/endpoint_publisher.ex
+++ b/projects/embervm/control/lib/embervm/endpoint_publisher.ex
@@ -544,7 +544,11 @@ defmodule Embervm.EndpointPublisher do
   # rebuilds (the byte-identical render property). nil when no node advertises one.
   defp node_advertised_activator(ctx, workload) do
     advertisers =
-      ctx.node_facts
+      ctx
+      # A ctx built by a path that predates node-local activators (e.g. the group
+      # render's own ctx) carries no node_facts: treat it as no advertisers, so the
+      # CP-injected fallback is used and that render is unchanged.
+      |> Map.get(:node_facts, [])
       |> Enum.filter(&is_map(Map.get(&1, :activator_endpoint)))
       |> Enum.sort_by(& &1.configured_id)
 

--- a/projects/embervm/control/lib/embervm/endpoint_publisher.ex
+++ b/projects/embervm/control/lib/embervm/endpoint_publisher.ex
@@ -433,6 +433,12 @@ defmodule Embervm.EndpointPublisher do
       catalog_table: state.catalog_table,
       activator_endpoint: state.activator_endpoint,
       activator_ip: state.activator_ip,
+      # Node facts snapshotted once per render (ADR embervm/018 Fork A): the serving
+      # activator fallback PREFERS a node's advertised activator_endpoint over the
+      # CP-injected address, so the wake target survives a CP Recreate. Captured in
+      # the ctx so the render stays a pure function of the ctx (the byte-identical
+      # rebuild property EDS relies on).
+      node_facts: NodeCapacity.all(state.capacity_table),
       connect_timeout_ms: state.connect_timeout_ms
     }
   end
@@ -498,7 +504,7 @@ defmodule Embervm.EndpointPublisher do
   defp cluster_for(ctx, workload) do
     endpoints =
       case ServingStore.published_endpoints(ctx.store, workload) do
-        [] -> activator_endpoints(ctx)
+        [] -> activator_endpoints(ctx, workload)
         eps -> eps
       end
 
@@ -514,11 +520,57 @@ defmodule Embervm.EndpointPublisher do
   # so the first request wakes it. nil (no activator configured) renders an empty
   # cluster, which is a valid CDS entry Envoy 503s against until an instance
   # publishes (correct before Task 8 wires the activator).
-  defp activator_endpoints(%{activator_endpoint: %{ip: ip, port: port}})
+  # The activator fallback for `workload`, PREFERRING a node's own advertised
+  # activator endpoint (ADR embervm/018 Fork A) over the CP-injected address. A
+  # node's advertised endpoint is a node address (stable across a CP Recreate),
+  # so a scaled-to-zero workload's first request survives a CP roll; the CP
+  # address is the fallback for nodes that do not advertise one (pre-018 daemons),
+  # which keeps a half-rolled fleet correct with no flag day.
+  defp activator_endpoints(ctx, workload) do
+    case node_advertised_activator(ctx, workload) do
+      %{ip: ip, port: port} when is_binary(ip) and is_integer(port) ->
+        [%{ip: ip, port: port}]
+
+      _ ->
+        cp_activator_endpoint(ctx)
+    end
+  end
+
+  # Pick a node-advertised activator endpoint for the workload. Among nodes that
+  # advertise one, PREFER a node whose base for this workload is READY (it can
+  # actually cold-boot the workload; #3993 flagged this as easy to get subtly
+  # wrong), falling back to any advertiser. Deterministic: candidates are sorted by
+  # configured_id and the first is taken, so the rendered fallback is stable across
+  # rebuilds (the byte-identical render property). nil when no node advertises one.
+  defp node_advertised_activator(ctx, workload) do
+    advertisers =
+      ctx.node_facts
+      |> Enum.filter(&is_map(Map.get(&1, :activator_endpoint)))
+      |> Enum.sort_by(& &1.configured_id)
+
+    ready = Enum.filter(advertisers, &workload_base_ready?(&1, workload))
+
+    case List.first(ready) || List.first(advertisers) do
+      nil -> nil
+      fact -> fact.activator_endpoint
+    end
+  end
+
+  defp workload_base_ready?(fact, workload) do
+    case Map.get(Map.get(fact, :workloads, %{}), workload) do
+      %{base_state: :BASE_BUILD_STATE_READY} -> true
+      _ -> false
+    end
+  end
+
+  # The CP-injected activator (the pre-018 fallback), rendered when no node
+  # advertises its own. nil (none configured) yields an empty cluster, a valid CDS
+  # entry Envoy 503s against until an instance publishes.
+  defp cp_activator_endpoint(%{activator_endpoint: %{ip: ip, port: port}})
        when is_binary(ip) and is_integer(port),
        do: [%{ip: ip, port: port}]
 
-  defp activator_endpoints(_ctx), do: []
+  defp cp_activator_endpoint(_ctx), do: []
 
   # One route per workload: exact host from the catalog, prefix `/`, injecting the
   # workload header. A serving workload with no host in its catalog entry yields no

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -88,6 +88,7 @@ defmodule Embervm.NodeRegistry do
     GroupBundleSet,
     GroupMemberVm,
     BaseInventoryEntry,
+    Endpoint,
     GroupNetwork,
     NodeService,
     NodeStatus,
@@ -622,6 +623,14 @@ defmodule Embervm.NodeRegistry do
       serving_vms: serving_vms_from_status(s),
       serving_snapshots: serving_snapshots_from_status(s),
       serving_subnet_cidr: s.serving_subnet_cidr,
+      # Node-local activator fact (ADR embervm/018 Fork A, additive): the brick's
+      # own advertised activator endpoint. EndpointPublisher PREFERS this over the
+      # CP-injected activator address when rendering the scaled-to-zero serving
+      # fallback route, so the wake target is a node address that survives a CP
+      # Recreate rather than the dying CP pod IP. nil on a daemon that predates the
+      # field, which the publisher falls back to the CP address for (no flag day).
+      activator_endpoint: activator_endpoint_from_status(s),
+      activator_ip: s.activator_ip,
       # Stateful facts (R4, additive): the node's LIVE stateful VMs, BANKED
       # bundle inventory, and the per-workload volume ledger (generation +
       # allocated bytes). These are the source of truth
@@ -720,7 +729,13 @@ defmodule Embervm.NodeRegistry do
         ip: v.ip,
         port: v.port,
         healthy: v.healthy,
-        last_probe_unix_ms: v.last_probe_unix_ms
+        last_probe_unix_ms: v.last_probe_unix_ms,
+        # origin (ADR embervm/018 Fork A): who minted this VM. ServingManager's
+        # reconcile reads it to ADOPT an :INSTANCE_ORIGIN_ACTIVATOR VM (the brick
+        # woke it during a CP gap) instead of orphan-destroying it. Absent on a
+        # pre-018 daemon decodes to :INSTANCE_ORIGIN_UNSPECIFIED, which the
+        # discriminator treats as the CP-issued default (destroy-if-no-row).
+        origin: v.origin
       }
     end
   end
@@ -742,6 +757,19 @@ defmodule Embervm.NodeRegistry do
   end
 
   defp serving_snapshots_from_status(_s), do: []
+
+  # The node's advertised L7 activator endpoint (ADR embervm/018 Fork A), as a
+  # %{ip, port} the publisher renders as the scaled-to-zero fallback, or nil when
+  # the daemon advertises none (pre-018, or a node with no activator configured):
+  # the publisher then falls back to the CP-injected activator address. A present
+  # Endpoint with a blank ip is treated as absent (nil), never rendered as a
+  # black-hole endpoint.
+  defp activator_endpoint_from_status(%NodeStatus{activator_endpoint: %Endpoint{ip: ip, port: port}})
+       when is_binary(ip) and ip != "" and is_integer(port) and port > 0 do
+    %{ip: ip, port: port}
+  end
+
+  defp activator_endpoint_from_status(_s), do: nil
 
   defp stateful_vms_from_status(%NodeStatus{stateful_vms: vms}) when is_list(vms) do
     for %StatefulVm{} = v <- vms do
@@ -1443,13 +1471,23 @@ defmodule Embervm.NodeRegistry do
         image_ref = entry[:image_ref] || ""
         {rootfs_ref, harness_init} = Map.get(identity, image_ref, {"", ""})
 
+        # Serving-activation facts (ADR embervm/018 Fork A): pushed so the brick
+        # activator can cold-boot a scaled-to-zero serving workload without the CP
+        # (which supplies port/health_path per-call today). Absent/zero for a
+        # non-serving workload or one that did not opt into nodeLocalWake, which the
+        # daemon reads as "not node-local-wakeable" (503 at the activator).
+        serving = entry[:serving] || %{}
+
         %RegistryEntry{
           workload: name,
           image_digest: "",
           image_ref: image_ref,
           rootfs_ref: rootfs_ref,
           harness_init: harness_init,
-          sizing: %ResourceSpec{vcpus: entry[:vcpus] || 0, mem_mib: entry[:mem_mib] || 0}
+          sizing: %ResourceSpec{vcpus: entry[:vcpus] || 0, mem_mib: entry[:mem_mib] || 0},
+          node_local_wake: Map.get(serving, :node_local_wake, false),
+          serving_port: Map.get(serving, :port) || 0,
+          serving_health_path: Map.get(serving, :health_path) || ""
         }
       end
 

--- a/projects/embervm/control/lib/embervm/serving_manager.ex
+++ b/projects/embervm/control/lib/embervm/serving_manager.ex
@@ -1054,7 +1054,10 @@ defmodule Embervm.ServingManager do
       node_id: node_id,
       vm_id: vm.vm_id,
       ip: Map.get(vm, :ip),
-      port: Map.get(vm, :port)
+      port: Map.get(vm, :port),
+      # Health from node truth, not assumed: a VM the brick reports unhealthy is
+      # minted unhealthy and stays out of the fan-out until adopt_live heals it.
+      healthy: Map.get(vm, :healthy, true)
     })
 
     case ServingStore.backfill_created(state.store, instance_id) do

--- a/projects/embervm/control/lib/embervm/serving_manager.ex
+++ b/projects/embervm/control/lib/embervm/serving_manager.ex
@@ -985,6 +985,12 @@ defmodule Embervm.ServingManager do
         adopt_one(acc, instance, live_vms, snapshots)
       end)
 
+    # ADR embervm/018 Fork A: a node-woken (origin ACTIVATOR) serving VM has no CP
+    # row (the brick minted it during a CP gap). Adopt it as an async-write to
+    # backfill BEFORE the orphan-destroy pass below, so it is never mistaken for an
+    # orphan and its endpoint enters the re-derived fan-out on this same pass.
+    state = adopt_activator_vms(state, live_vms)
+
     state = evict_orphan_snapshots(state, facts)
 
     # Fail-closed reconciliation toward destruction (ADR embervm/014 decision 5),
@@ -1018,6 +1024,66 @@ defmodule Embervm.ServingManager do
       {s.snapshot_ref, {f.configured_id, s}}
     end
   end
+
+  # ADR embervm/018 Fork A: adopt every node-reported origin-ACTIVATOR serving VM
+  # that no CP row claims. The brick woke it during a CP gap and minted its vm_id;
+  # the CP mints a matching :published row from node truth (using the node's vm_id
+  # as the instance id) and backfills the durable serving_started/serving_published
+  # ops. Serving hit traffic is anonymous (no bearer principal, standing decision),
+  # so the row attributes to the manager's tenant with a nil principal, exactly as a
+  # CP-driven serving wake does. Once minted, later passes find the row by vm_id and
+  # heal it through the normal adopt_live path, so this fires exactly once per VM.
+  defp adopt_activator_vms(state, live_vms) do
+    Enum.reduce(live_vms, state, fn {vm_id, {node_id, vm}}, acc ->
+      if activator_origin?(vm) and find_instance_by_vm(acc, vm_id) == :none do
+        adopt_activator_vm(acc, node_id, vm)
+      else
+        acc
+      end
+    end)
+  end
+
+  defp adopt_activator_vm(state, node_id, vm) do
+    instance_id = vm.vm_id
+
+    ServingStore.adopt_activator(state.store, %{
+      instance_id: instance_id,
+      tenant: state.tenant,
+      principal: nil,
+      workload: vm.workload,
+      node_id: node_id,
+      vm_id: vm.vm_id,
+      ip: Map.get(vm, :ip),
+      port: Map.get(vm, :port)
+    })
+
+    case ServingStore.backfill_created(state.store, instance_id) do
+      :ok ->
+        Logger.info("embervm serving adopted (activator-woken)",
+          instance_id: instance_id,
+          workload: vm.workload,
+          node_id: node_id
+        )
+
+      {:error, reason} ->
+        # The ETS row is minted (the endpoint is already in the fan-out); only the
+        # durable backfill failed. Log and leave it: the next reconcile pass re-drives
+        # backfill_created idempotently (INSERT OR IGNORE), and the endpoint keeps
+        # serving in the meantime.
+        Logger.warning("embervm serving activator backfill failed, will retry",
+          instance_id: instance_id,
+          workload: vm.workload,
+          reason: inspect(reason)
+        )
+    end
+
+    state
+  end
+
+  # True when a node-reported serving VM was minted by the brick activator (ADR
+  # embervm/018). A pre-018 daemon reports no origin (nil / UNSPECIFIED), which is
+  # the CP-issued default and NOT an activator VM.
+  defp activator_origin?(vm), do: Map.get(vm, :origin) == :INSTANCE_ORIGIN_ACTIVATOR
 
   defp adopt_one(state, instance, live_vms, snapshots) do
     cond do
@@ -1169,12 +1235,20 @@ defmodule Embervm.ServingManager do
   defp destroy_orphan_serving_vms(state, facts, _live_vms) do
     for fact <- facts, vm <- Map.get(fact, :serving_vms, []) || [], reduce: state do
       acc ->
-        case find_instance_by_vm(acc, vm.vm_id) do
-          :none ->
+        cond do
+          # ADR embervm/018 Fork A: an origin-ACTIVATOR VM is a node-woken instance
+          # adopt_activator_vms mints a row for on the SAME pass (which runs first),
+          # so it is not an orphan. Skip it explicitly as a belt-and-suspenders guard
+          # for the window where adoption's durable backfill failed but the ETS row
+          # is minted: never destroy a live node-woken VM, let adoption retry.
+          activator_origin?(vm) ->
+            acc
+
+          match?(:none, find_instance_by_vm(acc, vm.vm_id)) ->
             _ = stop_serving_destroy_confirmed(acc, %{node_id: fact.configured_id, vm_id: vm.vm_id})
             acc
 
-          {:ok, _instance} ->
+          true ->
             acc
         end
     end

--- a/projects/embervm/control/lib/embervm/serving_store.ex
+++ b/projects/embervm/control/lib/embervm/serving_store.ex
@@ -251,6 +251,35 @@ defmodule Embervm.ServingStore do
     GenServer.call(store, {:adopt_endpoint, instance_id, node_id, vm_id, endpoint})
   end
 
+  @doc """
+  Adoption of a NODE-woken serving VM (ADR embervm/018 Fork A): mint a `:published`
+  instance row directly from node truth for an `origin: ACTIVATOR` VM the control
+  plane has no row for (the brick minted the instance during a CP gap, so no CP row
+  exists). ETS-only, like `adopt_state`/`adopt_endpoint`: the durable lifecycle ops
+  are appended separately by `backfill_created/2` once the row is present. A no-op
+  if a row already exists for `instance_id` (idempotent; the reconcile only calls
+  this when no row claims the vm_id). `attrs` carries `:instance_id`, `:tenant`,
+  `:principal`, `:workload`, `:node_id`, `:vm_id`, `:ip`, `:port`. Returns `:ok`.
+  """
+  @spec adopt_activator(GenServer.server(), map()) :: :ok
+  def adopt_activator(store \\ __MODULE__, attrs) do
+    GenServer.call(store, {:adopt_activator, attrs})
+  end
+
+  @doc """
+  Re-drive the durable serving lifecycle appends (`serving_started`, then
+  `serving_published` for a live-and-published instance) from the surviving ETS
+  row, for an instance adopted from node truth whose ops the control plane never
+  wrote (the ADR embervm/018 activator adoption, the serving analog of
+  `SessionStore.backfill_created`). Appends SYNCHRONOUSLY (reconcile is not a hot
+  path); the projection is INSERT OR IGNORE so a re-drive is idempotent. A no-op /
+  `:error` for an unknown instance.
+  """
+  @spec backfill_created(GenServer.server(), String.t()) :: :ok | {:error, term()}
+  def backfill_created(store \\ __MODULE__, instance_id) do
+    GenServer.call(store, {:backfill_created, instance_id})
+  end
+
   # -- GenServer callbacks ---------------------------------------------------
 
   @impl true
@@ -525,6 +554,86 @@ defmodule Embervm.ServingStore do
     end
   end
 
+  def handle_call({:adopt_activator, attrs}, _from, state) do
+    instance_id = Map.fetch!(attrs, :instance_id)
+
+    case fetch(state, instance_id) do
+      # A row already exists (a prior pass minted it): the normal adopt_live path
+      # heals it from here, so this is a no-op. Keeps the mint strictly once-only.
+      {:ok, _instance} ->
+        {:reply, :ok, state}
+
+      {:error, _} ->
+        ts = state.clock.()
+        # Mint the row already :published from node truth: the brick woke the VM and
+        # reports it live-and-healthy, so it is in the fan-out immediately (the ETS
+        # row is what published_endpoints reads). backfill_created writes the durable
+        # serving_started/serving_published ops from this row on the same pass.
+        instance = %{
+          instance_id: instance_id,
+          tenant: Map.fetch!(attrs, :tenant),
+          principal: Map.get(attrs, :principal),
+          workload: Map.fetch!(attrs, :workload),
+          state: :published,
+          node_id: Map.get(attrs, :node_id),
+          vm_id: Map.get(attrs, :vm_id),
+          ip: Map.get(attrs, :ip),
+          port: Map.get(attrs, :port),
+          healthy: true,
+          drain_reason: nil,
+          base_snapshot_ref: nil,
+          base_digest: nil,
+          generation: 0,
+          snapshot_ref: nil,
+          snapshot_size_bytes: nil,
+          created_at: ts,
+          last_active_at: nil,
+          updated_at: ts,
+          terminal_reason: nil
+        }
+
+        :ets.insert(state.instances, {instance_id, instance})
+        state = bump_counts(state, nil, :published, instance.workload)
+        {:reply, :ok, state}
+    end
+  end
+
+  def handle_call({:backfill_created, instance_id}, _from, state) do
+    case fetch(state, instance_id) do
+      {:ok, instance} ->
+        # serving_started reconstructs the lifecycle birth op; serving_published
+        # follows it when the row is live-and-published (the activator case always
+        # is). Both are INSERT OR IGNORE at projection, so a re-drive is idempotent.
+        started = %Op{
+          kind: :serving_started,
+          tenant: instance.tenant,
+          principal: instance.principal,
+          workload: instance.workload,
+          serving_instance_id: instance_id,
+          ts: state.clock.(),
+          payload: %{
+            node_id: instance.node_id,
+            vm_id: instance.vm_id,
+            ip: instance.ip,
+            port: instance.port,
+            base_snapshot_ref: instance.base_snapshot_ref,
+            base_digest: instance.base_digest,
+            state: to_string(instance.state)
+          }
+        }
+
+        result =
+          with {:ok, _seq} <- state.op_log_mod.append(state.op_log, started) do
+            maybe_backfill_published(state, instance)
+          end
+
+        {:reply, backfill_reply(result), state}
+
+      {:error, _reason} = error ->
+        {:reply, error, state}
+    end
+  end
+
   # -- start -----------------------------------------------------------------
 
   defp do_start(attrs, state) do
@@ -621,6 +730,30 @@ defmodule Embervm.ServingStore do
       {:error, _reason} = error -> {:reply, error, state}
     end
   end
+
+  # Append the durable serving_published for an adopted, already-published instance
+  # (ADR embervm/018 activator backfill). A row that is not published (defensive:
+  # the activator case always is) skips the second append and reports ok on the
+  # serving_started already written. reason "adopted" names why the endpoint entered
+  # the fan-out late.
+  defp maybe_backfill_published(state, %{state: :published} = instance) do
+    published = %Op{
+      kind: :serving_published,
+      tenant: instance.tenant,
+      principal: instance.principal,
+      workload: instance.workload,
+      serving_instance_id: instance.instance_id,
+      ts: state.clock.(),
+      payload: %{ip: instance.ip, port: instance.port, reason: "adopted"}
+    }
+
+    state.op_log_mod.append(state.op_log, published)
+  end
+
+  defp maybe_backfill_published(_state, _instance), do: {:ok, :skipped}
+
+  defp backfill_reply({:ok, _seq}), do: :ok
+  defp backfill_reply({:error, _reason} = error), do: error
 
   # The write-through core: append to the op-log, and ONLY on {:ok, seq} update
   # ETS. On append failure ETS is left untouched (as durable as the op-log agrees)

--- a/projects/embervm/control/lib/embervm/serving_store.ex
+++ b/projects/embervm/control/lib/embervm/serving_store.ex
@@ -272,7 +272,9 @@ defmodule Embervm.ServingStore do
   row, for an instance adopted from node truth whose ops the control plane never
   wrote (the ADR embervm/018 activator adoption, the serving analog of
   `SessionStore.backfill_created`). Appends SYNCHRONOUSLY (reconcile is not a hot
-  path); the projection is INSERT OR IGNORE so a re-drive is idempotent. A no-op /
+  path). Idempotent via an ETS `backfilled` flag: a re-drive after the ops have
+  landed is a no-op (the serving projection's `serving_started` is a plain INSERT,
+  so re-appending would collide on the instance_id UNIQUE constraint). A no-op /
   `:error` for an unknown instance.
   """
   @spec backfill_created(GenServer.server(), String.t()) :: :ok | {:error, term()}
@@ -566,8 +568,12 @@ defmodule Embervm.ServingStore do
       {:error, _} ->
         ts = state.clock.()
         # Mint the row already :published from node truth: the brick woke the VM and
-        # reports it live-and-healthy, so it is in the fan-out immediately (the ETS
-        # row is what published_endpoints reads). backfill_created writes the durable
+        # reports it live, so it is in the fan-out immediately (the ETS row is what
+        # published_endpoints reads). Health is taken from the node fact, not assumed:
+        # a VM the brick reports unhealthy is minted unhealthy and stays out of the
+        # fan-out (publishable? requires healthy) until adopt_live heals it, rather
+        # than routing traffic to a failing guest. backfilled=false gates the durable
+        # backfill so it appends exactly once. backfill_created writes the durable
         # serving_started/serving_published ops from this row on the same pass.
         instance = %{
           instance_id: instance_id,
@@ -579,13 +585,14 @@ defmodule Embervm.ServingStore do
           vm_id: Map.get(attrs, :vm_id),
           ip: Map.get(attrs, :ip),
           port: Map.get(attrs, :port),
-          healthy: true,
+          healthy: Map.get(attrs, :healthy, true),
           drain_reason: nil,
           base_snapshot_ref: nil,
           base_digest: nil,
           generation: 0,
           snapshot_ref: nil,
           snapshot_size_bytes: nil,
+          backfilled: false,
           created_at: ts,
           last_active_at: nil,
           updated_at: ts,
@@ -600,10 +607,17 @@ defmodule Embervm.ServingStore do
 
   def handle_call({:backfill_created, instance_id}, _from, state) do
     case fetch(state, instance_id) do
+      # Already backfilled: a no-op. The serving projection's serving_started is a
+      # plain INSERT (unlike the session lane's INSERT OR IGNORE), so re-appending
+      # would collide on the instance_id UNIQUE constraint; this flag is what makes a
+      # re-drive idempotent instead. (In the reconcile flow the mint-once structure
+      # already calls this once per instance; the flag guards a defensive re-drive.)
+      {:ok, %{backfilled: true}} ->
+        {:reply, :ok, state}
+
       {:ok, instance} ->
         # serving_started reconstructs the lifecycle birth op; serving_published
-        # follows it when the row is live-and-published (the activator case always
-        # is). Both are INSERT OR IGNORE at projection, so a re-drive is idempotent.
+        # follows it when the row is live-and-published (the activator case always is).
         started = %Op{
           kind: :serving_started,
           tenant: instance.tenant,
@@ -627,7 +641,18 @@ defmodule Embervm.ServingStore do
             maybe_backfill_published(state, instance)
           end
 
-        {:reply, backfill_reply(result), state}
+        case result do
+          {:error, _} = error ->
+            {:reply, backfill_reply(error), state}
+
+          ok ->
+            # Both durable ops landed: mark the row so a re-drive is a no-op. The flag
+            # is ETS-only; on a CP restart the projection rebuilds a durable row and
+            # the reconcile finds it (never re-minting), so backfill is never re-driven
+            # against an already-durable instance across a restart either.
+            :ets.insert(state.instances, {instance_id, Map.put(instance, :backfilled, true)})
+            {:reply, backfill_reply(ok), state}
+        end
 
       {:error, _reason} = error ->
         {:reply, error, state}

--- a/projects/embervm/control/lib/embervm/workload_watcher.ex
+++ b/projects/embervm/control/lib/embervm/workload_watcher.ex
@@ -926,7 +926,16 @@ defmodule Embervm.WorkloadWatcher do
       # TTL never outlives what a live instance would.
       banked_ttl_seconds:
         Map.get(s, "bankedTtlSeconds") || Map.get(s, "maxLifetimeSeconds") ||
-          @serving_defaults.banked_ttl_seconds
+          @serving_defaults.banked_ttl_seconds,
+      # ADR embervm/018 Fork A. node_local_wake gates the brick activator per
+      # workload: only a true workload is eligible for a node-local cold boot (it is
+      # pushed to noded in the RegistryEntry and drives CP-side ACTIVATOR adoption).
+      # metering_fail_open is the companion, EXPLICIT policy that a node_local_wake
+      # workload wakes unmetered during a CP gap and reconciles best-effort on adopt
+      # (named, not implied). Both default false: a workload that sets neither keeps
+      # today's CP-only wake with synchronous metering.
+      node_local_wake: Map.get(s, "nodeLocalWake") == true,
+      metering_fail_open: Map.get(s, "meteringFailOpen") == true
     }
   end
 

--- a/projects/embervm/control/test/embervm/endpoint_publisher_test.exs
+++ b/projects/embervm/control/test/embervm/endpoint_publisher_test.exs
@@ -181,6 +181,49 @@ defmodule Embervm.EndpointPublisherTest do
     refute Enum.any?(cluster.endpoints, &(&1.ip == "10.1.1.1"))
   end
 
+  test "ADR embervm/018: cold render prefers a READY node's advertised activator over the CP address" do
+    # The CP-injected activator is 10.1.1.1:7000 (start_stack default). A node that
+    # advertises its OWN activator must be preferred, so the wake target is a node
+    # address that survives a CP Recreate rather than the dying CP pod IP.
+    ctx = start_stack()
+    serving_workload(ctx, "wl-a", "wl-a.example")
+
+    # node-4 advertises but its base is still BUILDING; node-5 advertises AND is
+    # READY. Sort order (by configured_id) would pick node-4 first, so a correct
+    # render must prefer node-5 by READY, not by name (#3993 flagged this).
+    NodeCapacity.put(ctx.cap_table, "node-4", %{
+      configured_id: "node-4",
+      node_id: "node-4",
+      serving_subnet_cidr: "10.99.0.0/24",
+      serving_vms: [],
+      serving_snapshots: [],
+      activator_endpoint: %{ip: "10.99.0.4", port: 8081},
+      workloads: %{"wl-a" => %{base_state: :BASE_BUILD_STATE_BUILDING}}
+    })
+
+    NodeCapacity.put(ctx.cap_table, "node-5", %{
+      configured_id: "node-5",
+      node_id: "node-5",
+      serving_subnet_cidr: "10.99.0.0/24",
+      serving_vms: [],
+      serving_snapshots: [],
+      activator_endpoint: %{ip: "10.99.0.5", port: 8081},
+      workloads: %{"wl-a" => %{base_state: :BASE_BUILD_STATE_READY}}
+    })
+
+    :ok = EndpointPublisher.flush(ctx.pub)
+
+    # Every serving node receives the SAME global fallback: node-5's READY
+    # activator, never the CP-injected 10.1.1.1:7000 nor node-4's non-READY one.
+    puts = last_puts(ctx)
+    assert length(puts) == 2
+
+    for {_node, desired} <- puts do
+      assert [cluster] = desired.clusters
+      assert cluster.endpoints == [%{ip: "10.99.0.5", port: 8081}]
+    end
+  end
+
   test "unpublishing the last instance swaps the activator back IN" do
     ctx = start_stack()
     serving_workload(ctx, "wl-a", "wl-a.example")

--- a/projects/embervm/control/test/embervm/serving_manager_test.exs
+++ b/projects/embervm/control/test/embervm/serving_manager_test.exs
@@ -448,6 +448,48 @@ defmodule Embervm.ServingManagerTest do
     assert ServingStore.all(ctx.store) == []
   end
 
+  test "ADR embervm/018: reconcile ADOPTS an origin-ACTIVATOR serving VM instead of orphan-destroying it" do
+    # node_confirmed_destroy on so the orphan-destroy pass is live: an ordinary
+    # rowless VM would be destroyed here (the test above), but an ACTIVATOR VM is
+    # adopted and skipped, never double-killed.
+    ctx = start_stack(node_confirmed_destroy: true)
+    serving_workload(ctx, "wl-a")
+
+    # The brick woke a VM during a CP gap: reported origin ACTIVATOR with a vm_id
+    # the control plane never issued and NO matching CP row.
+    serving_node(ctx, "node-4",
+      serving_vms: [
+        %{
+          vm_id: "vm-brick",
+          workload: "wl-a",
+          ip: "10.99.0.9",
+          port: 8080,
+          healthy: true,
+          origin: :INSTANCE_ORIGIN_ACTIVATOR
+        }
+      ]
+    )
+
+    :ok = ServingManager.reconcile(ctx.mgr)
+
+    # No StopServing(DESTROY) fired for it (contrast the rowless-orphan test above).
+    assert stop_calls(ctx) == []
+
+    # A published CP row was minted from node truth and its endpoint is in the
+    # fan-out, keyed by the brick-minted vm_id (used as the instance id).
+    assert [instance] = ServingStore.all(ctx.store)
+    assert instance.vm_id == "vm-brick"
+    assert instance.workload == "wl-a"
+    assert instance.state == :published
+    assert ServingStore.published_endpoints(ctx.store, "wl-a") == [%{ip: "10.99.0.9", port: 8080}]
+
+    # A second reconcile is a no-op (the row now exists, so the mint path is not
+    # re-entered and the VM heals through the normal adopt_live path).
+    :ok = ServingManager.reconcile(ctx.mgr)
+    assert stop_calls(ctx) == []
+    assert length(ServingStore.all(ctx.store)) == 1
+  end
+
   test "adoption heals a starting-limbo instance the node reports only as a snapshot to banked" do
     ctx = start_stack()
     serving_workload(ctx, "wl-a")

--- a/projects/embervm/control/test/embervm/serving_store_test.exs
+++ b/projects/embervm/control/test/embervm/serving_store_test.exs
@@ -236,6 +236,54 @@ defmodule Embervm.ServingStoreTest do
     assert still.state == :destroyed
   end
 
+  test "adopt_activator mints a published row from node truth; backfill_created makes it durable and idempotent",
+       %{path: path} do
+    {op_log, store} = start_pair(path)
+
+    # ADR embervm/018 Fork A: the brick woke a VM during a CP gap, so NO CP row
+    # exists. Mint it from node truth (ETS-only, already published/in the fan-out).
+    :ok =
+      ServingStore.adopt_activator(store, %{
+        instance_id: "vm-brick-1",
+        tenant: "homelab",
+        principal: nil,
+        workload: "wl-a",
+        node_id: "node-4",
+        vm_id: "vm-brick-1",
+        ip: "10.99.0.7",
+        port: 8080
+      })
+
+    {:ok, got} = ServingStore.get(store, "vm-brick-1")
+    assert got.state == :published
+    assert ServingStore.published_endpoints(store, "wl-a") == [%{ip: "10.99.0.7", port: 8080}]
+    # Nothing durable yet: adoption is ETS-only, like adopt_state/adopt_endpoint.
+    assert {:ok, []} = SQLite.load_serving_instances(op_log)
+
+    # backfill_created writes the durable serving_started + serving_published.
+    assert :ok = ServingStore.backfill_created(store, "vm-brick-1")
+    {:ok, [row]} = SQLite.load_serving_instances(op_log)
+    assert row.state == "published"
+
+    # Idempotent (INSERT OR IGNORE): a re-drive leaves exactly the same durable row.
+    assert :ok = ServingStore.backfill_created(store, "vm-brick-1")
+    {:ok, [row2]} = SQLite.load_serving_instances(op_log)
+    assert row2.state == "published"
+
+    # A NEW store over the SAME op-log recovers the published endpoint from the
+    # backfilled projection (the durable record now matches the live fan-out).
+    {:ok, store2} = ServingStore.start_link(op_log: op_log, name: nil, clock: sequential_clock())
+    assert ServingStore.published_endpoints(store2, "wl-a") == [%{ip: "10.99.0.7", port: 8080}]
+
+    # adopt_activator is a no-op once a row exists (the mint is strictly once-only).
+    :ok = ServingStore.adopt_activator(store, %{instance_id: "vm-brick-1", tenant: "homelab", workload: "wl-a"})
+    {:ok, still} = ServingStore.get(store, "vm-brick-1")
+    assert still.state == :published
+
+    # An unknown instance backfills to an error (never a silent success).
+    assert {:error, _} = ServingStore.backfill_created(store, "nope")
+  end
+
   test "adopt_endpoint rebinds the routable endpoint without an op", %{path: path} do
     {_op_log, store} = start_pair(path)
     {:ok, _} = start_instance(store)

--- a/projects/embervm/control/test/embervm/workload_watcher_test.exs
+++ b/projects/embervm/control/test/embervm/workload_watcher_test.exs
@@ -379,6 +379,10 @@ defmodule Embervm.WorkloadWatcherTest do
     assert entry.serving.max_lifetime_seconds == 21_600
     # bankedTtlSeconds omitted -> defaults to maxLifetimeSeconds (Task 9).
     assert entry.serving.banked_ttl_seconds == 21_600
+    # ADR embervm/018 Fork A: nodeLocalWake/meteringFailOpen default false when the
+    # CR omits them, so an unmodified serving workload keeps CP-only synchronous wake.
+    assert entry.serving.node_local_wake == false
+    assert entry.serving.metering_fail_open == false
 
     # A valid CR: the watcher writes only observedGeneration (no conditions).
     assert {_ns, "sandbox-serving", status_map} = ready_status(recorded_calls(agent), "sandbox-serving")

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.223
+      targetRevision: 0.1.224
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/cmd/main.go
+++ b/projects/embervm/noded/cmd/main.go
@@ -252,6 +252,17 @@ func run(logger *slog.Logger) error {
 	if err != nil {
 		return err
 	}
+	// The activator is serving-class only. Bind before marking it advertised so
+	// NodeStatus never sends an Envoy request to a listener that is not present.
+	activatorLis, err := net.Listen("tcp", cfg.ActivatorAddr)
+	if err != nil {
+		return err
+	}
+	activatorHTTP := &http.Server{
+		Handler:           srv.ActivatorHandler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	srv.EnableActivator()
 
 	// Plain-HTTP /healthz for kubelet probes (a privileged single-replica pod does
 	// not warrant gRPC health-checking machinery).
@@ -264,6 +275,12 @@ func run(logger *slog.Logger) error {
 		logger.Info("health endpoint listening", "addr", cfg.HealthAddr)
 		if err := health.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.Error("health server failed", "err", err)
+		}
+	}()
+	go func() {
+		logger.Info("activator endpoint listening", "addr", cfg.ActivatorAddr)
+		if err := activatorHTTP.Serve(activatorLis); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("activator server failed", "err", err)
 		}
 	}()
 
@@ -300,6 +317,7 @@ func run(logger *slog.Logger) error {
 
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		_ = health.Shutdown(shutdownCtx)
+		_ = activatorHTTP.Shutdown(shutdownCtx)
 		cancel()
 
 		// Hold the door: keep serving lifecycle rpcs until the control plane has

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -16,6 +16,7 @@ package config
 import (
 	"bufio"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -47,6 +48,12 @@ type Config struct {
 	// (gRPC health-checking a privileged single-replica pod is more moving parts
 	// than a 20-line HTTP handler). Default ":8080".
 	HealthAddr string
+	// ActivatorAddr is the node-local HTTP listener that wakes eligible serving
+	// workloads during a control-plane gap. Default ":8081".
+	ActivatorAddr string
+	// ActivatorPort is the port parsed from ActivatorAddr. It is advertised in
+	// NodeStatus and used by the stable node-IP DNAT rule.
+	ActivatorPort uint32
 	// Node identifies the Kubernetes node this daemon is pinned to (injected via
 	// the Downward API as EMBERVM_NODED_NODE / spec.nodeName). Reported as
 	// node_id in NodeStatus and stamped into snapshot node-pinning.
@@ -341,6 +348,7 @@ func Load() (Config, error) {
 	c := Config{
 		ListenAddr:       getenvDefault("EMBERVM_NODED_LISTEN_ADDR", ":9090"),
 		HealthAddr:       getenvDefault("EMBERVM_NODED_HEALTH_ADDR", ":8080"),
+		ActivatorAddr:    getenvDefault("EMBERVM_NODED_ACTIVATOR_ADDR", ":8081"),
 		Node:             os.Getenv("EMBERVM_NODED_NODE"),
 		Arch:             os.Getenv("EMBERVM_NODED_ARCH"),
 		CpuVendor:        os.Getenv("EMBERVM_NODED_CPU_VENDOR"),
@@ -399,6 +407,15 @@ func Load() (Config, error) {
 	if c.Node == "" {
 		c.Node = os.Getenv("NODE_NAME")
 	}
+	_, activatorPort, err := net.SplitHostPort(c.ActivatorAddr)
+	if err != nil {
+		return Config{}, fmt.Errorf("invalid EMBERVM_NODED_ACTIVATOR_ADDR %q: %w", c.ActivatorAddr, err)
+	}
+	p, err := strconv.ParseUint(activatorPort, 10, 16)
+	if err != nil || p == 0 {
+		return Config{}, fmt.Errorf("invalid EMBERVM_NODED_ACTIVATOR_ADDR %q: port required", c.ActivatorAddr)
+	}
+	c.ActivatorPort = uint32(p)
 	if c.Arch == "" {
 		c.Arch = runtime.GOARCH
 	}

--- a/projects/embervm/noded/config/config_test.go
+++ b/projects/embervm/noded/config/config_test.go
@@ -87,6 +87,17 @@ func TestLoadCpuVendorEnvOverride(t *testing.T) {
 	}
 }
 
+func TestLoadActivatorAddress(t *testing.T) {
+	t.Setenv("EMBERVM_NODED_ACTIVATOR_ADDR", "127.0.0.1:18081")
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.ActivatorAddr != "127.0.0.1:18081" || c.ActivatorPort != 18081 {
+		t.Errorf("activator endpoint = %q:%d, want 127.0.0.1:18081", c.ActivatorAddr, c.ActivatorPort)
+	}
+}
+
 // TestLoadCpuTemplateDefaultsPerVendor proves CpuTemplate resolves to the
 // conservative per-vendor default (PR-E) when EMBERVM_NODED_CPU_TEMPLATE is
 // unset and CpuVendor is known, for both fleet vendors.

--- a/projects/embervm/noded/server/BUILD
+++ b/projects/embervm/noded/server/BUILD
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "server",
     srcs = [
+        "activator.go",
         "budget.go",
         "group.go",
         "group_member.go",
@@ -37,6 +38,7 @@ go_library(
 go_test(
     name = "server_test",
     srcs = [
+        "activator_test.go",
         "budget_test.go",
         "drain_test.go",
         "evict_local_test.go",

--- a/projects/embervm/noded/server/activator.go
+++ b/projects/embervm/noded/server/activator.go
@@ -1,0 +1,292 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+)
+
+const (
+	activatorMaxBoots   = 16
+	activatorMaxParked  = 64
+	activatorWakeMax    = 30
+	activatorWakeWindow = time.Minute
+	activatorBodyMax    = 8 << 20
+)
+
+var activatorDeniedHeaders = map[string]struct{}{
+	"content-length":      {},
+	"transfer-encoding":   {},
+	"connection":          {},
+	"keep-alive":          {},
+	"upgrade":             {},
+	"host":                {},
+	"te":                  {},
+	"trailer":             {},
+	"proxy-authorization": {},
+	"proxy-authenticate":  {},
+}
+
+type activatorFlight struct {
+	done  chan struct{}
+	entry *servingEntry
+	err   error
+}
+
+// activator is noded's node-local serving wake path. A workload has exactly one
+// in-flight start; requests that arrive while it starts wait for that result and
+// independently proxy their buffered request once the guest is ready.
+type activator struct {
+	server *Server
+	client *http.Client
+
+	mu      sync.Mutex
+	flights map[string]*activatorFlight
+	boots   int
+	parked  int
+	wakes   []time.Time
+}
+
+func newActivator(s *Server) *activator {
+	return &activator{
+		server:  s,
+		client:  &http.Client{},
+		flights: make(map[string]*activatorFlight),
+	}
+}
+
+// ActivatorHandler returns the node-local HTTP activator surface.
+func (s *Server) ActivatorHandler() http.Handler {
+	return s.activator
+}
+
+// EnableActivator marks the activator listening only after cmd/main has bound
+// its socket. This keeps a pre-listen NodeStatus from advertising a black hole.
+func (s *Server) EnableActivator() {
+	s.activatorMu.Lock()
+	s.activatorEnabled = true
+	s.activatorMu.Unlock()
+	s.signalChange()
+}
+
+func (a *activator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	workload := strings.TrimSpace(r.Header.Get("x-ember-workload"))
+	if workload == "" {
+		http.Error(w, "x-ember-workload required", http.StatusBadRequest)
+		return
+	}
+	reg, ok := a.server.registry.get(workload)
+	if !ok || !reg.NodeLocalWake {
+		a.server.logger.Warn("activator: workload is not eligible for node-local wake", "workload", workload)
+		http.Error(w, "node-local wake unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	if live, ok := a.server.servingVMs.firstByWorkload(workload); ok {
+		a.proxy(w, r, live)
+		return
+	}
+
+	body, err := readActivatorBody(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	flight, leader, code := a.join(workload)
+	if code != 0 {
+		a.server.logger.Warn("activator: wake rejected by local limit", "workload", workload, "status", code)
+		http.Error(w, "activator busy", code)
+		return
+	}
+	defer a.unpark()
+
+	if leader {
+		entry, bootErr := a.boot(workload, reg)
+		a.complete(workload, flight, entry, bootErr)
+	}
+	select {
+	case <-flight.done:
+	case <-r.Context().Done():
+		return
+	}
+	if flight.err != nil || flight.entry == nil {
+		code := http.StatusBadGateway
+		if status.Code(flight.err) == codes.Unavailable || status.Code(flight.err) == codes.ResourceExhausted {
+			code = http.StatusServiceUnavailable
+		}
+		a.server.logger.Warn("activator: serving wake failed", "workload", workload, "err", flight.err)
+		http.Error(w, "serving wake failed", code)
+		return
+	}
+	a.proxyBuffered(w, r, body, flight.entry)
+}
+
+// join accounts for one parked request and either joins the workload's existing
+// boot or reserves the globally bounded wake slot for its new leader.
+func (a *activator) join(workload string) (*activatorFlight, bool, int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.parked >= activatorMaxParked {
+		return nil, false, http.StatusServiceUnavailable
+	}
+	if f, ok := a.flights[workload]; ok {
+		a.parked++
+		return f, false, 0
+	}
+	if a.boots >= activatorMaxBoots || !a.allowWakeLocked(time.Now()) {
+		return nil, false, http.StatusServiceUnavailable
+	}
+	f := &activatorFlight{done: make(chan struct{})}
+	a.flights[workload] = f
+	a.boots++
+	a.parked++
+	return f, true, 0
+}
+
+func (a *activator) allowWakeLocked(now time.Time) bool {
+	cutoff := now.Add(-activatorWakeWindow)
+	kept := a.wakes[:0]
+	for _, woke := range a.wakes {
+		if woke.After(cutoff) {
+			kept = append(kept, woke)
+		}
+	}
+	a.wakes = kept
+	if len(a.wakes) >= activatorWakeMax {
+		return false
+	}
+	a.wakes = append(a.wakes, now)
+	return true
+}
+
+func (a *activator) unpark() {
+	a.mu.Lock()
+	a.parked--
+	a.mu.Unlock()
+}
+
+func (a *activator) complete(workload string, flight *activatorFlight, entry *servingEntry, err error) {
+	a.mu.Lock()
+	flight.entry = entry
+	flight.err = err
+	delete(a.flights, workload)
+	a.boots--
+	close(flight.done)
+	a.mu.Unlock()
+}
+
+func (a *activator) boot(workload string, reg workloadEntry) (*servingEntry, error) {
+	req := &nodev1.StartServingRequest{
+		Trace:      &nodev1.Trace{Workload: workload},
+		Port:       reg.ServingPort,
+		HealthPath: reg.ServingHealthPath,
+		Resources:  &nodev1.ResourceSpec{Vcpus: reg.VCPUs, MemMib: reg.MemMib},
+	}
+	if snap, ok := a.server.servingSnap.freshestByWorkload(workload); ok {
+		req.Source = &nodev1.StartServingRequest_Relight{Relight: &nodev1.RelightSource{SnapshotRef: snap.snapshotRef}}
+	} else {
+		image, ok := a.servingImage(workload)
+		if !ok {
+			return nil, fmt.Errorf("noded: no serving image provisioned for workload %q", workload)
+		}
+		req.Source = &nodev1.StartServingRequest_Fresh{Fresh: &nodev1.FreshSource{ServingImageRef: image.baseKey}}
+	}
+	if _, err := a.server.startServing(context.Background(), req, nodev1.InstanceOrigin_INSTANCE_ORIGIN_ACTIVATOR); err != nil {
+		return nil, err
+	}
+	entry, ok := a.server.servingVMs.firstByWorkload(workload)
+	if !ok {
+		return nil, fmt.Errorf("noded: activated serving vm for workload %q was not registered", workload)
+	}
+	return entry, nil
+}
+
+func (a *activator) servingImage(workload string) (servingImageEntry, bool) {
+	var selected servingImageEntry
+	found := false
+	for _, image := range a.server.servingImage.snapshot() {
+		if image.workload != workload || !a.server.imageProvisioned(image.runtimeImageRef) {
+			continue
+		}
+		if !found || image.baseKey > selected.baseKey {
+			selected, found = image, true
+		}
+	}
+	return selected, found
+}
+
+func readActivatorBody(r *http.Request) ([]byte, error) {
+	defer r.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(r.Body, activatorBodyMax+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > activatorBodyMax {
+		return nil, fmt.Errorf("request body exceeds %d byte limit", activatorBodyMax)
+	}
+	return body, nil
+}
+
+func (a *activator) proxy(w http.ResponseWriter, r *http.Request, entry *servingEntry) {
+	body, err := readActivatorBody(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+		return
+	}
+	a.proxyBuffered(w, r, body, entry)
+}
+
+func (a *activator) proxyBuffered(w http.ResponseWriter, r *http.Request, body []byte, entry *servingEntry) {
+	if entry == nil || entry.ip == nil || entry.port == 0 {
+		http.Error(w, "serving endpoint unavailable", http.StatusBadGateway)
+		return
+	}
+	path := r.URL.RequestURI()
+	if path == "" {
+		path = "/"
+	}
+	target := "http://" + net.JoinHostPort(entry.ip.String(), strconv.FormatUint(uint64(entry.port), 10)) + path
+	forward, err := http.NewRequestWithContext(r.Context(), r.Method, target, bytes.NewReader(body))
+	if err != nil {
+		http.Error(w, "invalid serving request", http.StatusBadRequest)
+		return
+	}
+	forward.Header = allowedHeaders(r.Header)
+	resp, err := a.client.Do(forward)
+	if err != nil {
+		http.Error(w, "serving endpoint unavailable", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	for key, values := range allowedHeaders(resp.Header) {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+func allowedHeaders(headers http.Header) http.Header {
+	allowed := make(http.Header, len(headers))
+	for key, values := range headers {
+		if _, denied := activatorDeniedHeaders[strings.ToLower(key)]; denied {
+			continue
+		}
+		allowed[key] = append([]string(nil), values...)
+	}
+	return allowed
+}

--- a/projects/embervm/noded/server/activator.go
+++ b/projects/embervm/noded/server/activator.go
@@ -94,6 +94,13 @@ func (a *activator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Straggler splice: if a VM is already live for this workload, proxy straight
+	// through instead of waking. There is a narrow window where a request passes
+	// this check while no VM is live, the prior leader then completes and deletes
+	// its flight, and this request becomes a fresh leader and boots a second VM.
+	// That is bounded by the node live-VM cap and the workload max-instances and
+	// reaped by idle-bank, so it self-heals; Phase 1 tolerates it rather than
+	// holding a lock across the whole boot.
 	if live, ok := a.server.servingVMs.firstByWorkload(workload); ok {
 		a.proxy(w, r, live)
 		return

--- a/projects/embervm/noded/server/activator_test.go
+++ b/projects/embervm/noded/server/activator_test.go
@@ -1,0 +1,276 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+)
+
+type activatorRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f activatorRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func activatorGuest(t *testing.T, handler http.Handler) (uint32, *httptest.Server) {
+	t.Helper()
+	guest := httptest.NewServer(handler)
+	t.Cleanup(guest.Close)
+	_, rawPort, err := net.SplitHostPort(guest.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("guest port: %v", err)
+	}
+	port, err := strconv.ParseUint(rawPort, 10, 32)
+	if err != nil {
+		t.Fatalf("parse guest port: %v", err)
+	}
+	return uint32(port), guest
+}
+
+func enableActivatorWorkload(s *Server, workload string, port uint32) {
+	s.registry.sync([]workloadEntry{{
+		Workload:          workload,
+		NodeLocalWake:     true,
+		ServingPort:       port,
+		ServingHealthPath: defaultReadyPath,
+		VCPUs:             1,
+		MemMib:            128,
+	}})
+}
+
+func activatorRequest(t *testing.T, handler http.Handler, workload, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(body))
+	req.Header.Set("x-ember-workload", workload)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestActivatorStragglerProxiesLiveVM(t *testing.T) {
+	var calls int
+	port, _ := activatorGuest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path == defaultReadyPath {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write([]byte("live"))
+	}))
+	s, _, driver := newServingTestServer(t)
+	enableActivatorWorkload(s, "wl-serve", port)
+	s.servingVMs.add(&servingEntry{vmID: "already-live", workload: "wl-serve", ip: net.ParseIP("127.0.0.1"), port: port})
+
+	rec := activatorRequest(t, s.ActivatorHandler(), "wl-serve", "/invoke", "request")
+	if rec.Code != http.StatusOK || rec.Body.String() != "live" {
+		t.Fatalf("activator response = %d %q, want 200 live", rec.Code, rec.Body.String())
+	}
+	if driver.claims != 0 {
+		t.Errorf("ClaimServing calls = %d, want 0", driver.claims)
+	}
+	if calls != 1 {
+		t.Errorf("guest calls = %d, want 1", calls)
+	}
+}
+
+func TestActivatorColdBootAndProxyFiltersHeaders(t *testing.T) {
+	var gotBody string
+	port, _ := activatorGuest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == defaultReadyPath {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Guest", "ok")
+		_, _ = w.Write([]byte("guest response"))
+	}))
+	s, _, driver := newServingTestServer(t)
+	enableActivatorWorkload(s, "wl-serve", port)
+	var forwarded http.Header
+	s.activator.client = &http.Client{Transport: activatorRoundTripper(func(r *http.Request) (*http.Response, error) {
+		forwarded = r.Header.Clone()
+		return http.DefaultTransport.RoundTrip(r)
+	})}
+	req := httptest.NewRequest(http.MethodPost, "/invoke", bytes.NewBufferString("request body"))
+	req.Header.Set("x-ember-workload", "wl-serve")
+	for denied := range activatorDeniedHeaders {
+		req.Header.Set(denied, "removed")
+	}
+	rec := httptest.NewRecorder()
+	s.ActivatorHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK || rec.Body.String() != "guest response" {
+		t.Fatalf("activator response = %d %q, want 200 guest response", rec.Code, rec.Body.String())
+	}
+	if driver.claims != 1 {
+		t.Errorf("ClaimServing calls = %d, want 1", driver.claims)
+	}
+	if gotBody != "request body" {
+		t.Errorf("guest body = %q, want request body", gotBody)
+	}
+	for denied := range activatorDeniedHeaders {
+		if forwarded.Get(denied) != "" {
+			t.Errorf("forwarded deny-listed header %q = %q", denied, forwarded.Get(denied))
+		}
+	}
+	if rec.Header().Get("Connection") != "" || rec.Header().Get("Content-Length") != "" {
+		t.Errorf("deny-listed response headers leaked: %+v", rec.Header())
+	}
+	if rec.Header().Get("X-Guest") != "ok" {
+		t.Errorf("X-Guest = %q, want ok", rec.Header().Get("X-Guest"))
+	}
+}
+
+func TestActivatorDenyListFiltersBothDirections(t *testing.T) {
+	headers := make(http.Header, len(activatorDeniedHeaders)+1)
+	for denied := range activatorDeniedHeaders {
+		headers.Set(denied, "removed")
+	}
+	headers.Set("X-Allowed", "kept")
+	for key := range activatorDeniedHeaders {
+		if got := allowedHeaders(headers).Get(key); got != "" {
+			t.Errorf("allowedHeaders retained %q = %q", key, got)
+		}
+	}
+	if got := allowedHeaders(headers).Get("X-Allowed"); got != "kept" {
+		t.Errorf("allowed header = %q, want kept", got)
+	}
+}
+
+func TestNodeStatusAdvertisesBoundActivator(t *testing.T) {
+	s, _, _ := newServingTestServer(t)
+	// The activator is advertised at the daemon's own POD IP (ADR embervm/018 as
+	// amended for the pod-networked daemon), the address a pod-network Envoy dials.
+	s.cfg.PodIP = "10.42.0.9"
+	s.cfg.ActivatorPort = 8081
+	// Not advertised until the listener is bound (EnableActivator), so NodeStatus
+	// never points Envoy at a listener that is not up yet.
+	if got := s.nodeStatus().GetActivatorEndpoint(); got != nil {
+		t.Fatalf("activator endpoint before bind = %+v, want nil", got)
+	}
+	s.EnableActivator()
+	ns := s.nodeStatus()
+	if got := ns.GetActivatorEndpoint(); got == nil || got.GetIp() != "10.42.0.9" || got.GetPort() != 8081 {
+		t.Errorf("activator endpoint = %+v, want 10.42.0.9:8081", got)
+	}
+	if ns.GetActivatorIp() != "10.42.0.9" {
+		t.Errorf("activator ip = %q, want 10.42.0.9", ns.GetActivatorIp())
+	}
+	// No pod IP (local/test): advertise nothing, so the control plane keeps its own
+	// activator address as the fallback.
+	s.cfg.PodIP = ""
+	if got := s.nodeStatus().GetActivatorEndpoint(); got != nil {
+		t.Errorf("activator endpoint with no pod IP = %+v, want nil", got)
+	}
+}
+
+func TestActivatorSingleFlight(t *testing.T) {
+	healthStarted := make(chan struct{})
+	releaseHealth := make(chan struct{})
+	var healthOnce sync.Once
+	port, _ := activatorGuest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == defaultReadyPath {
+			healthOnce.Do(func() { close(healthStarted) })
+			<-releaseHealth
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write([]byte("all served"))
+	}))
+	s, _, driver := newServingTestServer(t)
+	enableActivatorWorkload(s, "wl-serve", port)
+	const requests = 8
+	responses := make(chan *httptest.ResponseRecorder, requests)
+	for i := 0; i < requests; i++ {
+		go func() {
+			req := httptest.NewRequest(http.MethodPost, "/invoke", bytes.NewBufferString("request"))
+			req.Header.Set("x-ember-workload", "wl-serve")
+			rec := httptest.NewRecorder()
+			s.ActivatorHandler().ServeHTTP(rec, req)
+			responses <- rec
+		}()
+	}
+	<-healthStarted
+	close(releaseHealth)
+	for i := 0; i < requests; i++ {
+		rec := <-responses
+		if rec.Code != http.StatusOK || rec.Body.String() != "all served" {
+			t.Errorf("activator response = %d %q, want 200 all served", rec.Code, rec.Body.String())
+		}
+	}
+	if driver.claims != 1 {
+		t.Errorf("ClaimServing calls = %d, want 1", driver.claims)
+	}
+}
+
+func TestActivatorGateRejectsIneligibleWorkload(t *testing.T) {
+	s, _, driver := newServingTestServer(t)
+	s.registry.sync([]workloadEntry{{Workload: "wl-serve", NodeLocalWake: false}})
+	rec := activatorRequest(t, s.ActivatorHandler(), "wl-serve", "/invoke", "request")
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rec.Code)
+	}
+	if driver.claims != 0 {
+		t.Errorf("ClaimServing calls = %d, want 0", driver.claims)
+	}
+}
+
+func TestActivatorWakeRateLimit(t *testing.T) {
+	s, _, _ := newServingTestServer(t)
+	handler := s.ActivatorHandler()
+	for i := 0; i < activatorWakeMax; i++ {
+		workload := "wl-" + strconv.Itoa(i)
+		s.registry.sync([]workloadEntry{{Workload: workload, NodeLocalWake: true, ServingPort: 8080}})
+		rec := activatorRequest(t, handler, workload, "/invoke", "request")
+		if rec.Code != http.StatusBadGateway {
+			t.Fatalf("wake %d status = %d, want 502", i, rec.Code)
+		}
+	}
+	s.registry.sync([]workloadEntry{{Workload: "over-limit", NodeLocalWake: true, ServingPort: 8080}})
+	rec := activatorRequest(t, handler, "over-limit", "/invoke", "request")
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("over-limit status = %d, want 503", rec.Code)
+	}
+}
+
+func TestActivatorAndControlPlaneOrigins(t *testing.T) {
+	port, _ := activatorGuest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == defaultReadyPath {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	s, _, _ := newServingTestServer(t)
+	enableActivatorWorkload(s, "wl-serve", port)
+	if rec := activatorRequest(t, s.ActivatorHandler(), "wl-serve", "/invoke", "request"); rec.Code != http.StatusOK {
+		t.Fatalf("activator status = %d, want 200", rec.Code)
+	}
+	if got := s.servingVMsStatus()[0].GetOrigin(); got != nodev1.InstanceOrigin_INSTANCE_ORIGIN_ACTIVATOR {
+		t.Errorf("activator origin = %v, want ACTIVATOR", got)
+	}
+	s.servingImage.add(servingImageEntry{baseKey: "cp-image", workload: "cp-workload", handlerPath: "/handler", runtimeImageRef: "img-a"})
+	if _, err := s.StartServing(context.Background(), &nodev1.StartServingRequest{
+		Trace:      &nodev1.Trace{Workload: "cp-workload"},
+		Source:     &nodev1.StartServingRequest_Fresh{Fresh: &nodev1.FreshSource{ServingImageRef: "cp-image"}},
+		Port:       port,
+		HealthPath: defaultReadyPath,
+	}); err != nil {
+		t.Fatalf("StartServing: %v", err)
+	}
+	for _, vm := range s.servingVMsStatus() {
+		if vm.GetWorkload() == "cp-workload" && vm.GetOrigin() != nodev1.InstanceOrigin_INSTANCE_ORIGIN_CONTROL_PLANE {
+			t.Errorf("control-plane origin = %v, want CONTROL_PLANE", vm.GetOrigin())
+		}
+	}
+}

--- a/projects/embervm/noded/server/registry_workload.go
+++ b/projects/embervm/noded/server/registry_workload.go
@@ -22,23 +22,29 @@ type workloadEntry struct {
 	// ImageRef is the OCI ref a BuildBase resolves against to find this entry's
 	// node-side rootfs/harness (the join key the retired EMBERVM_NODED_IMAGES
 	// table keyed on). getByImageRef indexes on it.
-	ImageRef    string `json:"imageRef"`
-	RootfsRef   string `json:"rootfsRef"`
-	HarnessInit string `json:"harnessInit"`
-	VCPUs       uint32 `json:"vcpus"`
-	MemMib      uint32 `json:"memMib"`
+	ImageRef          string `json:"imageRef"`
+	RootfsRef         string `json:"rootfsRef"`
+	HarnessInit       string `json:"harnessInit"`
+	VCPUs             uint32 `json:"vcpus"`
+	MemMib            uint32 `json:"memMib"`
+	NodeLocalWake     bool   `json:"nodeLocalWake"`
+	ServingPort       uint32 `json:"servingPort"`
+	ServingHealthPath string `json:"servingHealthPath"`
 }
 
 // entryFromProto lifts a wire RegistryEntry into the daemon's internal shape.
 func entryFromProto(e *nodev1.RegistryEntry) workloadEntry {
 	return workloadEntry{
-		Workload:    e.GetWorkload(),
-		ImageDigest: e.GetImageDigest(),
-		ImageRef:    e.GetImageRef(),
-		RootfsRef:   e.GetRootfsRef(),
-		HarnessInit: e.GetHarnessInit(),
-		VCPUs:       e.GetSizing().GetVcpus(),
-		MemMib:      e.GetSizing().GetMemMib(),
+		Workload:          e.GetWorkload(),
+		ImageDigest:       e.GetImageDigest(),
+		ImageRef:          e.GetImageRef(),
+		RootfsRef:         e.GetRootfsRef(),
+		HarnessInit:       e.GetHarnessInit(),
+		VCPUs:             e.GetSizing().GetVcpus(),
+		MemMib:            e.GetSizing().GetMemMib(),
+		NodeLocalWake:     e.GetNodeLocalWake(),
+		ServingPort:       e.GetServingPort(),
+		ServingHealthPath: e.GetServingHealthPath(),
 	}
 }
 

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -194,12 +194,15 @@ type Server struct {
 	// Phase 2). The daemon boots with it empty (or a STALE boot-cache load) and
 	// admits no new work until the control plane replays it over SyncRegistry
 	// (readiness gate). It replaces the retired EMBERVM_NODED_IMAGES config table.
-	registry     *workloadRegistry
-	sessionVMs   *sessionRegistry
-	sessionSnap  *sessionSnapshotRegistry
-	servingVMs   *servingRegistry
-	servingSnap  *servingSnapshotRegistry
-	servingImage *servingImageRegistry
+	registry         *workloadRegistry
+	sessionVMs       *sessionRegistry
+	sessionSnap      *sessionSnapshotRegistry
+	servingVMs       *servingRegistry
+	servingSnap      *servingSnapshotRegistry
+	servingImage     *servingImageRegistry
+	activator        *activator
+	activatorMu      sync.RWMutex
+	activatorEnabled bool
 
 	// servingNet owns the host serving network (bridge, taps, nftables, IP
 	// allocation). nil disables the serving verbs (task/session-only tests and any
@@ -420,6 +423,7 @@ func New(opts Options) *Server {
 		subs:            make(map[chan struct{}]struct{}),
 		activeBuilds:    make(map[string]context.CancelFunc),
 	}
+	s.activator = newActivator(s)
 	// VolumeRoot may be set directly on Options (mirroring how cmd/main.go wires
 	// every other stateful/serving knob explicitly) or left to fall back to
 	// Config.VolumeRoot, so a caller that only populates Config (as several
@@ -1670,7 +1674,7 @@ func (s *Server) nodeStatus() *nodev1.NodeStatus {
 	live := taskLive + len(sessionVMs) + len(servingVMs) + len(statefulVMs) + len(groupMemberVMs)
 	snaps := s.sessionSnapshotsStatus()
 	freeBytes, usedBytes := s.snapshotDiskUsage()
-	return &nodev1.NodeStatus{
+	ns := &nodev1.NodeStatus{
 		NodeId:                s.cfg.Node,
 		PodUid:                s.cfg.PodUID,
 		SizeClass:             s.cfg.SizeClass,
@@ -1702,6 +1706,23 @@ func (s *Server) nodeStatus() *nodev1.NodeStatus {
 		CpuSku:                s.cpuSku(),
 		LocalBases:            s.localBasesStatus(),
 	}
+	s.activatorMu.RLock()
+	activatorEnabled := s.activatorEnabled
+	s.activatorMu.RUnlock()
+	// Advertise the activator at the daemon's own POD IP (ADR embervm/018 Fork A,
+	// as amended for the pod-networked daemon): serving VMs are already published
+	// and reached at podIP:vmPort via a DNAT in noded's OWN netns, so a pod-network
+	// Envoy dials podIP directly. Advertising the node IP instead would black-hole
+	// (nodeIP-destined traffic never enters this netns), so podIP is the only
+	// address that routes. This survives a control-plane Recreate (noded's podIP is
+	// stable across it); only a noded RESCHEDULE churns podIP, the accepted #3993
+	// open limitation. Not advertised when there is no pod IP (local/test), so the
+	// control plane falls back to its own activator address.
+	if activatorEnabled && s.cfg.PodIP != "" {
+		ns.ActivatorEndpoint = &nodev1.Endpoint{Ip: s.cfg.PodIP, Port: s.cfg.ActivatorPort}
+		ns.ActivatorIp = s.cfg.PodIP
+	}
+	return ns
 }
 
 // localBasesStatus projects the daemon's FULL on-disk base inventory into the
@@ -1853,6 +1874,7 @@ func (s *Server) servingVMsStatus() []*nodev1.ServingVm {
 			Port:            port,
 			Healthy:         e.healthy,
 			LastProbeUnixMs: e.lastProbeUnixMs,
+			Origin:          e.origin,
 		})
 	}
 	return out

--- a/projects/embervm/noded/server/serving.go
+++ b/projects/embervm/noded/server/serving.go
@@ -24,6 +24,10 @@ import (
 // unrestorable ref; RESOURCE_EXHAUSTED at the node live-VM cap. The daemon is off the
 // request hit path after this: requests reach the guest directly over ip:port.
 func (s *Server) StartServing(ctx context.Context, req *nodev1.StartServingRequest) (*nodev1.StartServingResponse, error) {
+	return s.startServing(ctx, req, nodev1.InstanceOrigin_INSTANCE_ORIGIN_CONTROL_PLANE)
+}
+
+func (s *Server) startServing(ctx context.Context, req *nodev1.StartServingRequest, origin nodev1.InstanceOrigin) (*nodev1.StartServingResponse, error) {
 	if s.servingNet == nil || s.servingDriver == nil {
 		return nil, status.Error(codes.Unimplemented, "noded: serving not configured")
 	}
@@ -54,9 +58,9 @@ func (s *Server) StartServing(ctx context.Context, req *nodev1.StartServingReque
 	// GetFresh()/GetRelight() return nil for the unset arm.
 	switch {
 	case req.GetFresh() != nil:
-		return s.startServingFresh(ctx, req, req.GetFresh().GetServingImageRef(), workload, port, healthPath)
+		return s.startServingFresh(ctx, req, req.GetFresh().GetServingImageRef(), workload, port, healthPath, origin)
 	case req.GetRelight() != nil:
-		return s.startServingRelight(ctx, req, req.GetRelight().GetSnapshotRef(), workload, port, healthPath)
+		return s.startServingRelight(ctx, req, req.GetRelight().GetSnapshotRef(), workload, port, healthPath, origin)
 	default:
 		return nil, status.Error(codes.InvalidArgument, "noded: exactly one of fresh|relight source required")
 	}
@@ -68,7 +72,7 @@ func (s *Server) StartServing(ctx context.Context, req *nodev1.StartServingReque
 // cold-boot handler artifact in the serving-images inventory), NOT a base snapshot to
 // resume (D-R3.4.2, D-R3.11.2): the runtime rootfs is drive 1 and the handler artifact
 // is drive 2, from which the guest imports the handler before serving.
-func (s *Server) startServingFresh(ctx context.Context, req *nodev1.StartServingRequest, servingImageRef, workload string, port uint32, healthPath string) (*nodev1.StartServingResponse, error) {
+func (s *Server) startServingFresh(ctx context.Context, req *nodev1.StartServingRequest, servingImageRef, workload string, port uint32, healthPath string, origin nodev1.InstanceOrigin) (*nodev1.StartServingResponse, error) {
 	// A FRESH serving cold boot is new-work placement. A stale registry (boot
 	// cache, no live sync) refuses it; RELIGHT of an existing serving snapshot
 	// stays allowed so existing warmth is served.
@@ -120,13 +124,13 @@ func (s *Server) startServingFresh(ctx context.Context, req *nodev1.StartServing
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: cold-boot serving vm: %v", err)
 	}
 	// A fresh cold boot has NO source snapshot ref (empty), so it never guards a bundle.
-	return s.finishServingStart(ctx, h, workload, "", ip, port, healthPath, s.cfg.BootReadyTimeout)
+	return s.finishServingStart(ctx, h, workload, "", ip, port, healthPath, s.cfg.BootReadyTimeout, origin)
 }
 
 // startServingRelight resumes a banked serving snapshot (which already carries its NIC
 // because the fresh path cold-booted one before the bank) and RE-PINS the same host IP
 // the snapshot recorded (D-R3.4.1), so the resumed guest's baked eth0 IP still routes.
-func (s *Server) startServingRelight(ctx context.Context, req *nodev1.StartServingRequest, ref, workload string, port uint32, healthPath string) (*nodev1.StartServingResponse, error) {
+func (s *Server) startServingRelight(ctx context.Context, req *nodev1.StartServingRequest, ref, workload string, port uint32, healthPath string, origin nodev1.InstanceOrigin) (*nodev1.StartServingResponse, error) {
 	if ref == "" {
 		return nil, status.Error(codes.InvalidArgument, "noded: relight.snapshot_ref required")
 	}
@@ -161,14 +165,14 @@ func (s *Server) startServingRelight(ctx context.Context, req *nodev1.StartServi
 	}
 	// The relit VM depends on ref: record it so EvictSnapshot refuses to delete the
 	// bundle out from under this live VM (D-R3.4.1 relight-from state).
-	return s.finishServingStart(ctx, h, workload, ref, ip, port, healthPath, s.cfg.RestoreReadyTimeout)
+	return s.finishServingStart(ctx, h, workload, ref, ip, port, healthPath, s.cfg.RestoreReadyTimeout, origin)
 }
 
 // finishServingStart is the shared tail of both source modes: health-gate the guest
 // over the tap, and on success register the live serving VM and start its health
 // probe. On a readiness failure it reaps the VM and releases the tap (no half-alive
 // endpoint), returning FAILED_PRECONDITION.
-func (s *Server) finishServingStart(ctx context.Context, h substrate.Handle, workload, sourceRef string, ip net.IP, port uint32, healthPath string, readyBudget time.Duration) (*nodev1.StartServingResponse, error) {
+func (s *Server) finishServingStart(ctx context.Context, h substrate.Handle, workload, sourceRef string, ip net.IP, port uint32, healthPath string, readyBudget time.Duration, origin nodev1.InstanceOrigin) (*nodev1.StartServingResponse, error) {
 	if err := s.waitServingReady(ctx, ip, port, healthPath, readyBudget); err != nil {
 		s.reapServing(h, ip)
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: serving guest not ready over tap: %v", err)
@@ -192,6 +196,7 @@ func (s *Server) finishServingStart(ctx context.Context, h substrate.Handle, wor
 		tap:         serving.TapNameForIP(ip),
 		probe:       probe,
 		snapshotRef: sourceRef,
+		origin:      origin,
 	})
 	s.signalChange()
 	// Report the projected endpoint (pod IP + DNAT port), NOT the node-internal tap IP.

--- a/projects/embervm/noded/server/serving_registry.go
+++ b/projects/embervm/noded/server/serving_registry.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"sync"
 
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+
 	"github.com/jomcgi/homelab/projects/embervm/noded/serving"
 	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
 )
@@ -179,6 +181,7 @@ type servingEntry struct {
 	handle   substrate.Handle
 	ip       net.IP
 	port     uint32
+	origin   nodev1.InstanceOrigin
 	tap      string
 	// snapshotRef is the serving snapshot this VM was RELIT from, or "" for a fresh
 	// cold boot (which has no source snapshot). It correlates a live serving VM to the
@@ -213,6 +216,19 @@ func (r *servingRegistry) add(e *servingEntry) {
 	r.mu.Lock()
 	r.vms[e.vmID] = e
 	r.mu.Unlock()
+}
+
+// firstByWorkload returns any live serving VM for workload. The activator uses
+// this to serve Envoy stragglers that arrive after another path made the VM live.
+func (r *servingRegistry) firstByWorkload(workload string) (*servingEntry, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, e := range r.vms {
+		if e.workload == workload {
+			return e, true
+		}
+	}
+	return nil, false
 }
 
 // beginBank marks a serving VM busy for a StopServing(BANK). It returns (entry, true)
@@ -257,6 +273,7 @@ type servingView struct {
 	healthy         bool
 	lastProbeUnixMs int64
 	snapshotRef     string
+	origin          nodev1.InstanceOrigin
 }
 
 // snapshot returns a copy of every live serving VM including its current health
@@ -272,6 +289,7 @@ func (r *servingRegistry) snapshot() []servingView {
 			workload: e.workload,
 			ip:       e.ip.String(),
 			port:     e.port,
+			origin:   e.origin,
 		}
 		if e.probe != nil {
 			res := e.probe.Result()
@@ -373,4 +391,24 @@ func (r *servingSnapshotRegistry) snapshot() []servingSnapshotEntry {
 		out = append(out, *e)
 	}
 	return out
+}
+
+// freshestByWorkload returns the most recently banked serving snapshot for a
+// workload. A lexical ref tie-break makes equal timestamps deterministic.
+func (r *servingSnapshotRegistry) freshestByWorkload(workload string) (servingSnapshotEntry, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var best *servingSnapshotEntry
+	for _, e := range r.snaps {
+		if e.workload != workload {
+			continue
+		}
+		if best == nil || e.createdAtUnixMs > best.createdAtUnixMs || (e.createdAtUnixMs == best.createdAtUnixMs && e.snapshotRef > best.snapshotRef) {
+			best = e
+		}
+	}
+	if best == nil {
+		return servingSnapshotEntry{}, false
+	}
+	return *best, true
 }

--- a/projects/embervm/noded/serving/net_test.go
+++ b/projects/embervm/noded/serving/net_test.go
@@ -838,7 +838,7 @@ func TestReleaseTapDeletesFallbackTapUnderPrealloc(t *testing.T) {
 
 // TestPrecreatePoolDegradesOnTransientFailure locks in the PR4-review fix: a single
 // tap's precreate failure (a transient ip error, e.g. an EBUSY racing a prior
-// incarnation's teardown) must be best-effort — EnsureNetwork still succeeds with a
+// incarnation's teardown) must be best-effort, EnsureNetwork still succeeds with a
 // SHORTER pool, never propagating the error and crash-looping the brick.
 func TestPrecreatePoolDegradesOnTransientFailure(t *testing.T) {
 	// tapPrealloc is 2 (.2 and .3); fail only .3's `ip tuntap add`, leaving .2 to

--- a/projects/embervm/proto/embervm/node/v1/fakenode/main.go
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/main.go
@@ -525,9 +525,9 @@ func (s *fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusR
 		},
 		// Node-local activator facts (ADR embervm/018 Fork A): a fixed advertised
 		// L7 endpoint and L4 ip so the client can assert the new node-level
-		// activator fields round-trip. The node advertises its STABLE address
-		// (node IP + activator port); EndpointPublisher prefers this over the CP
-		// pod activator for the scaled-to-zero fallback route.
+		// activator fields round-trip. The node advertises its own pod IP +
+		// activator port; EndpointPublisher prefers this over the CP pod activator
+		// for the scaled-to-zero fallback route.
 		ActivatorEndpoint: &nodev1.Endpoint{Ip: "10.99.0.1", Port: 8081},
 		ActivatorIp:       "10.99.0.1",
 	}, nil

--- a/projects/embervm/proto/embervm/node/v1/fakenode/main.go
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/main.go
@@ -418,6 +418,10 @@ func (s *fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusR
 				Port:            8080,
 				Healthy:         true,
 				LastProbeUnixMs: 1_700_000_001_000,
+				// origin (ADR embervm/018): this VM was woken by the brick
+				// activator, so the client can assert the adoption discriminator
+				// round-trips (UNSPECIFIED on the other VMs proves the default).
+				Origin: nodev1.InstanceOrigin_INSTANCE_ORIGIN_ACTIVATOR,
 			},
 		},
 		ServingSnapshots: []*nodev1.ServingSnapshot{
@@ -519,6 +523,13 @@ func (s *fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusR
 				Exported: true,
 			},
 		},
+		// Node-local activator facts (ADR embervm/018 Fork A): a fixed advertised
+		// L7 endpoint and L4 ip so the client can assert the new node-level
+		// activator fields round-trip. The node advertises its STABLE address
+		// (node IP + activator port); EndpointPublisher prefers this over the CP
+		// pod activator for the scaled-to-zero fallback route.
+		ActivatorEndpoint: &nodev1.Endpoint{Ip: "10.99.0.1", Port: 8081},
+		ActivatorIp:       "10.99.0.1",
 	}, nil
 }
 

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -1185,6 +1185,31 @@ message RegistryEntry {
   // at, mirroring the Workload CR resources block. A zero ResourceSpec means the
   // daemon defers to the per-BuildBase request resources (wire-compatible).
   ResourceSpec sizing = 5;
+
+  // -- Node-local activator fields (ADR embervm/018 Fork A, additive) ----------
+  // These three fields carry what the brick's node-local activator needs to
+  // cold-boot a scaled-to-zero serving workload WITHOUT the control plane (which
+  // supplies them per-call in StartServingRequest today): the port and health
+  // path the guest serves on, and a per-workload gate. The daemon resolves the
+  // workload's current serving image ref from its OWN servingImage inventory (by
+  // workload) and the freshest local serving snapshot from its own inventory, so
+  // no base/snapshot ref is pushed here; only the boot knobs the request carried.
+  // All are wire-compatible with a control plane that predates them (0/false ==
+  // the pre-018 behavior: no node-local wake for this workload).
+
+  // node_local_wake gates the activator per workload: only a workload the control
+  // plane marks true is eligible for a node-local cold boot; every other workload
+  // 503s at the activator and stays CP-woken. This is the noded-side half of the
+  // catalog nodeLocalWake flag (the CP-side half drives adoption + metering).
+  bool node_local_wake = 7;
+  // serving_port is the guest TCP port the serving workload listens on over its
+  // tap (StartServingRequest.port today). Required for a node_local_wake serving
+  // workload; ignored otherwise.
+  uint32 serving_port = 8;
+  // serving_health_path is the HTTP readiness/health path the activator gates the
+  // cold boot on (StartServingRequest.health_path today). Empty falls back to the
+  // daemon default ready path, exactly as StartServing does.
+  string serving_health_path = 9;
 }
 
 // SyncRegistryRequest carries the AUTHORITATIVE full workload set the daemon must
@@ -1343,6 +1368,33 @@ message SessionSnapshot {
 // StartServing/StopServing RPC comments for the probe contract); the daemon
 // itself never acts on healthy, it only reports it. Excluded from every
 // WorkloadCapacity.primed_vm_ids list, exactly like SessionVm.
+// Endpoint is a routable {ip, port} the control plane dials. Used for the
+// node-advertised activator fallback (NodeStatus.activator_endpoint): the L7
+// address a node Envoy routes a scaled-to-zero serving workload's first request
+// to so the brick activator cold-boots it (ADR embervm/018 Fork A). Kept a
+// distinct small message rather than two loose fields so the "absent" case is a
+// single nil check on the whole endpoint.
+message Endpoint {
+  string ip = 1;
+  uint32 port = 2;
+}
+
+// InstanceOrigin marks WHO created a live VM the node reports, the discriminator
+// the control plane's orphan-destroy rule reads (ADR embervm/018 Fork A, the
+// ADR embervm/014 orphan-rule refinement). CONTROL_PLANE (the pre-018 default,
+// indistinguishable on the wire from an UNSPECIFIED reported by an old daemon)
+// means the CP issued the instance and destroy-if-no-row still applies.
+// ACTIVATOR means the brick's node-local activator minted the instance during a
+// CP gap: the CP treats it as an async-write to ADOPT and backfill (mirroring
+// SessionStore.backfill_created), never an orphan to destroy. Absent on a daemon
+// that predates this field, which reads as UNSPECIFIED == the CP-issued default,
+// so the rollout is wire-compatible with no flag day.
+enum InstanceOrigin {
+  INSTANCE_ORIGIN_UNSPECIFIED = 0;
+  INSTANCE_ORIGIN_CONTROL_PLANE = 1;
+  INSTANCE_ORIGIN_ACTIVATOR = 2;
+}
+
 message ServingVm {
   string vm_id = 1;
   string workload = 2;
@@ -1353,6 +1405,17 @@ message ServingVm {
   uint32 port = 4;
   bool healthy = 5;
   int64 last_probe_unix_ms = 6;
+  // origin marks who created this VM (ADR embervm/018 Fork A). ACTIVATOR means
+  // the brick's node-local activator minted it during a CP gap, so the control
+  // plane ADOPTS and backfills it rather than destroying it as an orphan. Absent
+  // (UNSPECIFIED) on a pre-018 daemon reads as the CP-issued default.
+  InstanceOrigin origin = 7;
+  // grant_id and generation are Fork B forward-compat: the delegated wake-grant
+  // this instance was minted under and the volume/workload generation it carries.
+  // Fork A (this phase) sets neither for serving; the control plane reads neither.
+  // They are on the wire now so the Fork B delegation lands additively.
+  string grant_id = 8;
+  uint64 generation = 9;
 }
 
 // ServingSnapshot is one BANKED serving snapshot bundle on node disk, stored
@@ -1395,6 +1458,16 @@ message StatefulVm {
   // checkpoint_token is the handle to pass to ResolveStateful for a
   // checkpoint_pending VM (empty otherwise), reported so adoption can resolve it.
   string checkpoint_token = 9;
+  // origin marks who created this VM (ADR embervm/018). ACTIVATOR is the Fork B
+  // node-local stateful relight; Fork A (this phase) never sets it for stateful
+  // (the stateful lane stays CP-woken until Fork A Phase 2), so it reads
+  // UNSPECIFIED == the CP-issued default and the orphan rule is unchanged here.
+  // On the wire now so Phase 2's adoption discriminator lands additively.
+  InstanceOrigin origin = 10;
+  // grant_id is the Fork B delegated wake-grant this relight was minted under
+  // (empty in Fork A). generation is already carried above (field 6, the volume
+  // generation), so it is not duplicated here.
+  string grant_id = 11;
 }
 
 // StatefulBundle is the ONE banked stateful bundle for a workload on node disk,
@@ -1806,4 +1879,26 @@ message NodeStatus {
   // local base inventory to sweep, exactly the pre-PR-3 behavior). Bounded by the
   // on-disk base-dir count.
   repeated BaseInventoryEntry local_bases = 31;
+
+  // -- Node-local activator facts (ADR embervm/018 Fork A, additive) -----------
+  // These two fields advertise the brick's own activator so EndpointPublisher can
+  // render the scaled-to-zero fallback route at the NODE instead of the CP pod IP
+  // that dies on a Recreate. The publisher PREFERS a node's advertised endpoint
+  // and FALLS BACK to the CP-injected activator address for any node that does
+  // not advertise one, so a half-rolled fleet is always correct (no flag day).
+  // Both are optional and wire-compatible with a daemon that predates this field
+  // (empty/nil == the pre-018 behavior, CP-pod activator).
+
+  // activator_endpoint is the L7 (serving) fallback: the routable {ip, port} a
+  // node Envoy dials to cold-boot a scaled-to-zero serving workload's first
+  // request. It is the node's STABLE address (node IP + activator port) with a
+  // startup DNAT to the current pod IP, so the advertised endpoint survives a
+  // noded pod reschedule (the pod IP churns, the node IP does not). Nil when the
+  // daemon has no activator configured.
+  Endpoint activator_endpoint = 32;
+  // activator_ip is the L4 (stateful/composite) fallback address, the node-local
+  // analog of EMBERVM_STATEFUL_ACTIVATOR_IP. Fork A advertises it for
+  // forward-compat but only the L7 serving lane consumes an activator this phase;
+  // the L4 lane moves node-local in Fork A Phase 2. Empty until then.
+  string activator_ip = 33;
 }

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -1891,10 +1891,11 @@ message NodeStatus {
 
   // activator_endpoint is the L7 (serving) fallback: the routable {ip, port} a
   // node Envoy dials to cold-boot a scaled-to-zero serving workload's first
-  // request. It is the node's STABLE address (node IP + activator port) with a
-  // startup DNAT to the current pod IP, so the advertised endpoint survives a
-  // noded pod reschedule (the pod IP churns, the node IP does not). Nil when the
-  // daemon has no activator configured.
+  // request. It is the daemon's own POD IP + activator port, the address a
+  // pod-network Envoy dials exactly as it dials serving VMs at pod_ip:vmPort (the
+  // serving DNAT lives in noded's own netns, so a node-IP advert would black-hole;
+  // ADR 018 as amended). Stable across a control-plane Recreate, the failure this
+  // survives. Nil when the daemon has no activator configured.
   Endpoint activator_endpoint = 32;
   // activator_ip is the L4 (stateful/composite) fallback address, the node-local
   // analog of EMBERVM_STATEFUL_ACTIVATOR_IP. Fork A advertises it for

--- a/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
+++ b/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
@@ -640,6 +640,9 @@ defmodule Embervm.NodeRoundtripTest do
     assert vm.port == 8080
     assert vm.healthy == true
     assert vm.last_probe_unix_ms == 1_700_000_001_000
+    # origin (ADR embervm/018 Fork A): the activator-woken VM reports ACTIVATOR so
+    # the control plane adopts rather than orphan-destroys it.
+    assert vm.origin == :INSTANCE_ORIGIN_ACTIVATOR
 
     assert [snap] = ns.serving_snapshots
     assert snap.snapshot_ref == "serving/s-srv2"
@@ -648,6 +651,19 @@ defmodule Embervm.NodeRoundtripTest do
     assert snap.created_at_unix_ms == 1_700_000_002_000
 
     assert ns.serving_subnet_cidr == "10.99.0.0/24"
+  end
+
+  test "NodeStatus advertises the node-local activator (ADR embervm/018 Fork A)", %{
+    channel: ch
+  } do
+    {:ok, ns} = NodeService.Stub.get_node_status(ch, %GetNodeStatusRequest{node_id: "node-4"})
+
+    # The L7 fallback endpoint EndpointPublisher prefers over the CP pod activator.
+    assert ns.activator_endpoint.ip == "10.99.0.1"
+    assert ns.activator_endpoint.port == 8081
+    # The L4 activator ip (forward-compat; consumed by the stateful lane in a
+    # later phase) crosses the wire now.
+    assert ns.activator_ip == "10.99.0.1"
   end
 
   test "NodeStatus reports session facts (R2 additive fields)", %{channel: ch} do


### PR DESCRIPTION
## What

Phase 0 + Phase 1 (Fork A, serving lane) of the embervm node-local activator, per **ADR embervm/018** and tracking issue #3993. A scaled-to-zero stateless serving demo (hot-image-demo / og-image) now cold-boots on the brick and survives a control-plane roll, instead of black-holing on the dead CP-pod activator during the `Recreate` gap.

## Why

The `/ember/*` demos scale to zero and cold-boot on the first request. The CP runs one replica with `strategy: Recreate` (RWO SQLite op-log), so every chart bump is a multi-second gap. The serving ROUTE survives it (EndpointPublisher is a pure-function xDS writer holding its last-ACKed config), but the WAKE does not: the scaled-to-zero fallback endpoint IS the activator, and it lived in the dying CP pod. This moves the wake onto the brick.

## Phases

- **Phase 0 (proto wire):** `Endpoint` msg + `InstanceOrigin` enum; `ServingVm.origin` (+ `grant_id`/`generation` forward-compat); `StatefulVm.origin`/`grant_id`; `NodeStatus.activator_endpoint`/`activator_ip`; `RegistryEntry.node_local_wake`/`serving_port`/`serving_health_path`. All additive and proto3-wire-compatible (absent → zero-value → CP-issued default), so the rollout needs no flag day. Codegen is build-time only; the fakenode + cross-language round-trip test assert the new fields cross the wire.
- **Phase 1 noded:** a brick HTTP activator (single-flight + parked queue, caps 16/64; local wake-rate limiter; straggler splice; boot via the SAME internal `StartServing` path; streaming proxy with ServingProxy's header deny-list; `origin: ACTIVATOR` reporting). Advertises its **pod IP** + activator port (see the amendment below).
- **Phase 1 control:** `ServingStore.adopt_activator` + `backfill_created` (serving analog of `SessionStore.backfill_created`); `ServingManager` adopts ACTIVATOR-origin VMs and skips them in `destroy_orphan_serving_vms`; `EndpointPublisher` prefers a node-advertised activator (READY-node preference) over the CP address, rollout-safe; `WorkloadWatcher` catalog `nodeLocalWake`/`meteringFailOpen` + registry push.
- **Phase 1 chart:** activator port + env; CRD `serving.nodeLocalWake`/`meteringFailOpen` (structural schema would otherwise prune them); hot-image-demo opts in; chart bumped to 0.1.224.

## ADR amendment (decided with Joe, in-session)

ADR 018 specified advertising `{node_ip, activator_port}` + a stable DNAT to the pod IP. **noded is pod-networked** (no `hostNetwork`; serving VMs are already reached at `podIP:vmPort` via a DNAT in noded's OWN netns), so a `nodeIP`-destined packet never reaches that rule and advertising `nodeIP` would black-hole. Phase 1 advertises **`podIP:activatorPort`** directly (no DNAT), which is the only address that routes and is stable across a CP `Recreate` (the failure this ships for). Only a noded *reschedule* churns podIP, which #3993 already lists as an accepted open limitation. ADR 018 should get an amendment note (deferred to avoid dragging a monolith docs-manifest bump into this PR).

## Verify

- CI green on this branch.
- Manual drill (#3993 Phase 1): scale hot-image-demo to zero, `kubectl delete` the CP pod, `curl` the demo during the gap (first request cold-boots on the brick), then confirm on CP return the op-log has backfilled `serving_started`/`serving_published`, no orphan-destroy in logs, and traffic cuts back to Envoy-direct.

## Out of scope (honored)

No grant/lease, no node-local banking (stays CP-side), no stateful/composite lanes. The `grant_id`/`generation`/`activator_ip`/`StatefulVm.origin` fields are forward-compat only, read by nothing this phase.

Refs #3993, ADR embervm/018

🤖 Generated with [Claude Code](https://claude.com/claude-code)