### PR TITLE
fix(embervm): periodic registry re-push + scale-to-zero activator demo

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.224
+version: 0.1.225

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -472,13 +472,13 @@ hotImageDemo:
     # value, so the workload spec carries none of the cluster's ingress DNS. Keep in
     # sync with each route's rewriteHost.
     host: hot-image-demo.serving.internal
-    # Floor of one warm instance: the sweeper never idle-banks the last instance, so
-    # once the workload has served its first request it STAYS live and no subsequent
-    # request waits on (or 503s from) an idle-wake. (There is no proactive primer, so
-    # the very first request after a cold start still cold-boots; steady-state is warm.)
-    # This is the cold-vs-hot contrast the demo shows: cold-image-demo boots per
-    # request, hot-image-demo stays live. Costs one resident microVM.
-    minInstances: 1
+    # Scale-to-zero (ADR embervm/018): the demo idle-banks to zero and cold-boots on
+    # the first request, which is the whole point of the node-local activator (the
+    # first request during a control-plane gap cold-boots on the brick instead of
+    # black-holing on the dead CP-pod activator). This is what makes hot-image-demo
+    # the activator showcase; the warm-vs-cold contrast now lives entirely in
+    # cold-image-demo (task-class, vsock) vs this serving-class tap boot.
+    minInstances: 0
     maxInstances: 2
     idleBankSeconds: 600
     drainSeconds: 5

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -118,6 +118,16 @@ defmodule Embervm.NodeRegistry do
   # its last_registered_at stays nil and expiry is skipped for it.
   @expire_after_ms 90_000
 
+  # How often the control plane re-pushes the authoritative workload registry to
+  # every CONNECTED daemon (SyncRegistry). The per-connection push in
+  # start_streamer fires ONCE per (re)connect, so a CATALOG CHANGE to an
+  # already-connected daemon (e.g. nodeLocalWake toggled on a workload, ADR
+  # embervm/018) never reaches it until the daemon reconnects. This periodic,
+  # idempotent re-push converges that drift within one interval, mirroring the
+  # WorkloadWatcher's periodic BaseBuilder resync. 0 disables the timer (tests that
+  # drive the informer manually).
+  @registry_resync_ms 60_000
+
   # Closed enum of node health states, the age-out machine's whole codomain
   # (evaluate_node_age computes exactly these). Exposed for the spec vocabulary
   # sync test (ADR embervm/006 layer 1); nothing here reads it, so behavior is
@@ -234,6 +244,13 @@ defmodule Embervm.NodeRegistry do
     # watch_startup drives the informer from init; tests set it false and drive
     # inject_status/1 + tick/1 explicitly so no background stream or timer fires.
     watch_startup = Keyword.get(opts, :watch_startup, true)
+
+    registry_resync_ms =
+      Keyword.get(
+        opts,
+        :registry_resync_ms,
+        env_ms("EMBERVM_NODE_REGISTRY_RESYNC_INTERVAL_MS", @registry_resync_ms)
+      )
     # How long an instance may go without re-registering (dial-home) before its
     # registration is LAPSED; expiry additionally requires a dead stream.
     expire_after = Keyword.get(opts, :expire_after_ms, @expire_after_ms)
@@ -289,6 +306,7 @@ defmodule Embervm.NodeRegistry do
       channel_updater_fun: channel_updater_fun,
       channel_remover_fun: channel_remover_fun,
       base_builder_updater_fun: base_builder_updater_fun,
+      registry_resync_ms: registry_resync_ms,
       node_runtime: node_runtime,
       # The process notified once per drain rising edge with {:node_draining,
       # node_id, pod_uid, deadline_ms} so it can force-bank the instance's live VMs
@@ -323,6 +341,7 @@ defmodule Embervm.NodeRegistry do
       end)
 
     schedule_age_check(state)
+    schedule_registry_resync(state)
     {:noreply, state}
   end
 
@@ -382,6 +401,41 @@ defmodule Embervm.NodeRegistry do
   def handle_info(:age_check, state) do
     state = evaluate_ages(state)
     schedule_age_check(state)
+    {:noreply, state}
+  end
+
+  # Periodic idempotent registry re-push to every CONNECTED daemon (a node with a
+  # live streamer). The per-connection push is once-per-connect, so this is what
+  # propagates a CATALOG CHANGE (e.g. nodeLocalWake toggled on a workload, ADR
+  # embervm/018) to an already-connected daemon. Each re-push runs in a spawned
+  # process over a FRESH short-lived channel so a slow dial never blocks this
+  # GenServer (or its age-out timer) and the streamer's own watch channel is
+  # untouched; SyncRegistry is idempotent, so a re-push is safe to repeat.
+  def handle_info(:resync_registry, state) do
+    connect_fun = state.connect_fun
+    disconnect_fun = state.disconnect_fun
+    sync_registry_fun = state.sync_registry_fun
+
+    for {_id, rt} <- state.node_runtime, not is_nil(rt.streamer) do
+      address = rt.address
+      node_id = rt.configured_id
+
+      spawn(fn ->
+        case connect_fun.(address) do
+          {:ok, channel} ->
+            try do
+              sync_registry_fun.(channel, node_id)
+            after
+              disconnect_fun.(channel)
+            end
+
+          _ ->
+            :ok
+        end
+      end)
+    end
+
+    schedule_registry_resync(state)
     {:noreply, state}
   end
 
@@ -1097,6 +1151,30 @@ defmodule Embervm.NodeRegistry do
 
   defp schedule_age_check(state) do
     Process.send_after(self(), :age_check, state.age_check_ms)
+  end
+
+  # Arm the periodic registry re-push. Disabled (no timer) when the interval is 0
+  # (tests drive the informer manually), so no background re-sync fires there.
+  defp schedule_registry_resync(%{registry_resync_ms: ms}) when is_integer(ms) and ms > 0 do
+    Process.send_after(self(), :resync_registry, ms)
+  end
+
+  defp schedule_registry_resync(_state), do: :ok
+
+  # Parse a non-negative-integer millisecond env var, falling back to `default` on
+  # an unset or unparseable value (a positive default is never silently disabled by
+  # a typo; only an explicit 0 disables the timer).
+  defp env_ms(var, default) do
+    case System.get_env(var) do
+      nil ->
+        default
+
+      raw ->
+        case Integer.parse(raw) do
+          {ms, _} when ms >= 0 -> ms
+          _ -> default
+        end
+    end
   end
 
   # -- dial-home registration -------------------------------------------------

--- a/projects/embervm/control/test/embervm/node_registry_test.exs
+++ b/projects/embervm/control/test/embervm/node_registry_test.exs
@@ -37,7 +37,10 @@ defmodule Embervm.NodeRegistryTest do
       name: nil,
       table: table,
       nodes: [%{id: "node-4", address: "node-4.test:9090"}],
-      watch_startup: false
+      watch_startup: false,
+      # No background registry re-push unless a test opts in (mirrors the manual
+      # informer control the harness relies on).
+      registry_resync_ms: 0
     ]
 
     {:ok, pid} = NodeRegistry.start_link(Keyword.merge(defaults, opts))
@@ -352,6 +355,47 @@ defmodule Embervm.NodeRegistryTest do
     # The clean-close reconnect replayed it AGAIN (re-converge on every connect).
     assert_receive {:replayed, "node-4"}, 1_000
     eventually(fn -> length(Agent.get(syncs, & &1)) >= 2 end, 200)
+  end
+
+  test "periodically re-pushes the registry to a still-connected daemon (ADR embervm/018 catalog-change convergence)" do
+    {:ok, syncs} = Agent.start_link(fn -> 0 end)
+    on_exit(fn -> if Process.alive?(syncs), do: Agent.stop(syncs) end)
+    test_pid = self()
+
+    sync_registry_fun = fn :fake_channel, node_id ->
+      n = Agent.get_and_update(syncs, fn c -> {c + 1, c + 1} end)
+      send(test_pid, {:synced, node_id, n})
+      :ok
+    end
+
+    # A watch that STAYS open (blocks), so the streamer never reconnects: any
+    # re-push beyond the first connect-time one is the PERIODIC re-sync, which is
+    # what propagates a catalog change (e.g. nodeLocalWake) to a connected daemon.
+    watch_fun = fn :fake_channel, node_id, emit ->
+      emit.(node_status(node_id: node_id))
+      receive do: (:never -> {:ok, :closed})
+    end
+
+    {_reg, _table} =
+      start_registry(
+        watch_startup: true,
+        connect_fun: fn _address -> {:ok, :fake_channel} end,
+        watch_fun: watch_fun,
+        sync_registry_fun: sync_registry_fun,
+        disconnect_fun: fn :fake_channel -> :ok end,
+        registry_resync_ms: 30,
+        base_backoff_ms: 60_000,
+        max_backoff_ms: 60_000,
+        age_check_ms: 60_000,
+        unknown_after_ms: 60_000,
+        down_after_ms: 60_000
+      )
+
+    # The connect-time push fired once, then the periodic re-sync fires AGAIN and
+    # AGAIN with no reconnect (the streamer is still blocked in watch_fun).
+    assert_receive {:synced, "node-4", 1}, 1_000
+    assert_receive {:synced, "node-4", 2}, 1_000
+    assert_receive {:synced, "node-4", 3}, 1_000
   end
 
   # -- dial-home registration (R0 PR-2) --------------------------------------

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.224
+      targetRevision: 0.1.225
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## What

Follow-up to the node-local activator (#3995, ADR embervm/018), driven by findings from the live kill-the-CP drill.

## Why (the drill found a real gap)

After #3995 deployed, node-4's brick rejected hot-image-demo as "not eligible for node-local wake" — despite the control plane being fully correct (catalog, `registry_entries`, and the `RegistryEntry` wire encode/decode all carried `node_local_wake=true`, verified by remote-eval on the live CP). 

**Root cause:** `SyncRegistry` is pushed **once per daemon channel (re)connect** (`node_registry.ex` `start_streamer`), with no re-push on catalog change. The `nodeLocalWake` flag was toggled on during the 0.1.224 rollout, after node-4's brick had already connected, so it never reached the daemon. This is a pre-existing latent limitation the activator is the first feature to depend on.

## Changes

- **Periodic registry re-push.** `NodeRegistry` re-pushes the authoritative registry to every connected daemon on a timer (default 60s, `EMBERVM_NODE_REGISTRY_RESYNC_INTERVAL_MS`, 0 disables). Each re-push runs in a spawned process over a fresh short-lived channel, so a slow dial never blocks the GenServer and the streamer's own watch channel is untouched. `SyncRegistry` is idempotent, so re-pushing is safe. Converges `nodeLocalWake` (and any catalog change) to connected daemons within one interval, mirroring the WorkloadWatcher's periodic BaseBuilder resync. Test: a still-connected daemon (blocking watch, no reconnect) receives repeated re-pushes.
- **hot-image-demo → `minInstances: 0`.** It now idle-banks to zero and cold-boots on the first request, which is the activator showcase ADR 018 calls for. The warm/cold contrast now lives in cold-image-demo (task-class) vs this serving boot.
- Chart bumped 0.1.225.

## Verify

- CI green.
- Post-deploy: re-run the kill-the-CP drill (scale-to-zero is now automatic via idle-bank; delete the CP pod; curl the demo during the gap → cold-boots on the brick; confirm backfilled adoption + Envoy-direct after the CP returns).

Refs #3993, ADR embervm/018

🤖 Generated with [Claude Code](https://claude.com/claude-code)