### PR TITLE
feat(embervm): node-local activator, stateful lane (ADR 018 Phase 2)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.225
+version: 0.1.226

--- a/projects/embervm/chart/crds/workload-crd.yaml
+++ b/projects/embervm/chart/crds/workload-crd.yaml
@@ -536,6 +536,29 @@ spec:
                         scratch tier only: the decoded value rides the guest
                         kernel command line for that one boot. Omit for a
                         workload with no first-boot secrets to deliver.
+                    nodeLocalWake:
+                      type: boolean
+                      default: false
+                      description: >-
+                        Node-local activator (ADR embervm/018 Phase 2). When true,
+                        the brick's node-local L4 activator is eligible to relight a
+                        scaled-to-zero instance of this stateful workload on the first
+                        inbound TCP connection, so the wake survives a control-plane
+                        Recreate instead of black-holing on the dead CP-pod activator.
+                        The activator self-bumps the volume generation; the returning
+                        control plane trusts it via the fenced-writer anchor-adoption
+                        rule (ADR embervm/014), so no delegated grant is issued.
+                        Pushed to the node daemon in the workload registry. Defaults
+                        false (CP-only wake via the CP tcp_activator).
+                    meteringFailOpen:
+                      type: boolean
+                      default: false
+                      description: >-
+                        Companion, EXPLICIT policy for nodeLocalWake (ADR embervm/018):
+                        a true workload wakes UNMETERED during a control-plane gap and
+                        reconciles accounting best-effort on adoption. Named here rather
+                        than implied; allowlisted to blessed homelab demos. Defaults
+                        false.
                 group:
                   type: object
                   description: >-

--- a/projects/embervm/chart/templates/workload-scratch-postgres.yaml
+++ b/projects/embervm/chart/templates/workload-scratch-postgres.yaml
@@ -74,4 +74,10 @@ spec:
     # The control plane reads it into StartStateful.mmds_env on a FRESH/COLD wake
     # only, never on RELIGHT.
     secretRef: {{ include "embervm.fullname" . }}-scratch-postgres
+    # Node-local activator (ADR embervm/018 Phase 2): the brick relights this
+    # scaled-to-zero demo on the first connection so it survives a control-plane
+    # Recreate. meteringFailOpen names the wake-unmetered-during-gap policy for this
+    # blessed demo.
+    nodeLocalWake: {{ .Values.scratchPostgres.nodeLocalWake }}
+    meteringFailOpen: {{ .Values.scratchPostgres.meteringFailOpen }}
 {{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -609,6 +609,13 @@ scratchPostgres:
   # mode is vetted on demo-postgres under real traffic; the atomic bank is
   # unchanged while false.
   interruptibleBank: false
+  # Node-local activator (ADR embervm/018 Phase 2): the brick relights this
+  # scaled-to-zero demo on the first connection during a control-plane gap, so a
+  # psql that arrives while the CP is rolling cold-boots on the brick instead of
+  # black-holing on the dead CP-pod activator. meteringFailOpen names the
+  # wake-unmetered-during-gap policy for this blessed demo.
+  nodeLocalWake: true
+  meteringFailOpen: true
   guestImage:
     repository: ghcr.io/jomcgi/homelab/projects/embervm/runtimes/postgres
     tag: latest

--- a/projects/embervm/control/lib/embervm/endpoint_publisher.ex
+++ b/projects/embervm/control/lib/embervm/endpoint_publisher.ex
@@ -678,15 +678,43 @@ defmodule Embervm.EndpointPublisher do
         %{ip: ip, port: port}
 
       _ ->
-        activator_tcp_endpoint(ctx, listen_port)
+        activator_tcp_endpoint(ctx, workload, listen_port)
     end
   end
 
-  defp activator_tcp_endpoint(%{activator_ip: ip}, listen_port)
-       when is_binary(ip) and ip != "" and is_integer(listen_port),
-       do: %{ip: ip, port: listen_port}
+  # The L4 activator fallback for a cold stateful workload (ADR embervm/018 Phase
+  # 2): PREFER the workload's ANCHOR node's advertised activator_ip, falling back
+  # to the CP-injected activator_ip. Unlike serving (any READY node can cold-boot),
+  # only the brick that physically holds the volume can relight a stateful workload,
+  # so the fallback must point at the volume's anchor node. Rendered at the
+  # workload's OWN listen_port (the activator resolves the workload from the local
+  # accept port). nil (no anchor advert and no CP address) => skipped upstream.
+  defp activator_tcp_endpoint(ctx, workload, listen_port) when is_integer(listen_port) do
+    ip = anchor_activator_ip(ctx, workload) || Map.get(ctx, :activator_ip)
 
-  defp activator_tcp_endpoint(_ctx, _listen_port), do: nil
+    if is_binary(ip) and ip != "" do
+      %{ip: ip, port: listen_port}
+    else
+      nil
+    end
+  end
+
+  defp activator_tcp_endpoint(_ctx, _workload, _listen_port), do: nil
+
+  # The advertised activator_ip of the volume's anchor node, or nil when the
+  # workload has no volume yet (never woken, so no anchor) or the anchor node
+  # advertises no activator (pre-018 daemon => the CP address is used instead).
+  defp anchor_activator_ip(ctx, workload) do
+    with %{node_id: anchor} when is_binary(anchor) <-
+           StatefulStore.get_volume(ctx.stateful_store, workload),
+         fact when is_map(fact) <-
+           Enum.find(Map.get(ctx, :node_facts, []), &(Map.get(&1, :configured_id) == anchor)),
+         ip when is_binary(ip) and ip != "" <- Map.get(fact, :activator_ip) do
+      ip
+    else
+      _ -> nil
+    end
+  end
 
   # -- composite (L4) projection (R5) ----------------------------------------
 

--- a/projects/embervm/control/lib/embervm/endpoint_publisher.ex
+++ b/projects/embervm/control/lib/embervm/endpoint_publisher.ex
@@ -701,6 +701,16 @@ defmodule Embervm.EndpointPublisher do
 
   defp activator_tcp_endpoint(_ctx, _workload, _listen_port), do: nil
 
+  # Arity-2 form for the COMPOSITE lane (group_endpoint): a composite has no single
+  # volume anchor, so it keeps the pre-018 CP-injected activator_ip fallback
+  # unchanged (node-local composite relight is Phase 3, out of scope here). The
+  # stateful lane uses the arity-3 form above with its anchor-node preference.
+  defp activator_tcp_endpoint(%{activator_ip: ip}, listen_port)
+       when is_binary(ip) and ip != "" and is_integer(listen_port),
+       do: %{ip: ip, port: listen_port}
+
+  defp activator_tcp_endpoint(_ctx, _listen_port), do: nil
+
   # The advertised activator_ip of the volume's anchor node, or nil when the
   # workload has no volume yet (never woken, so no anchor) or the anchor node
   # advertises no activator (pre-018 daemon => the CP address is used instead).

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -840,7 +840,12 @@ defmodule Embervm.NodeRegistry do
         # adoption resolves a stranded checkpoint (default abort) after a
         # control-plane restart.
         checkpoint_pending: v.checkpoint_pending,
-        checkpoint_token: v.checkpoint_token
+        checkpoint_token: v.checkpoint_token,
+        # origin (ADR embervm/018 Phase 2): a node-woken (brick-relit) stateful VM.
+        # StatefulManager adopts it (the fenced-writer rule already trusts its
+        # forward generation) instead of orphan-destroying it. Absent on a pre-018
+        # daemon reads :INSTANCE_ORIGIN_UNSPECIFIED == the CP-issued default.
+        origin: v.origin
       }
     end
   end
@@ -1555,6 +1560,16 @@ defmodule Embervm.NodeRegistry do
         # non-serving workload or one that did not opt into nodeLocalWake, which the
         # daemon reads as "not node-local-wakeable" (503 at the activator).
         serving = entry[:serving] || %{}
+        # Stateful boot params (ADR embervm/018 Phase 2): the L4 activator binds and
+        # resolves by listen_port, health-gates the guest port, and threads the mount.
+        # boot_image_ref and volume_device stay noded-local (the daemon resolves the
+        # base from its own inventory and the volume from local disk, exactly as the
+        # serving activator resolves its image), so they are NOT pushed here.
+        stateful = entry[:stateful] || %{}
+        # node_local_wake is class-agnostic (a workload is exactly one class), so read
+        # it from whichever class block carries it.
+        node_local_wake =
+          Map.get(serving, :node_local_wake, false) or Map.get(stateful, :node_local_wake, false)
 
         %RegistryEntry{
           workload: name,
@@ -1563,9 +1578,12 @@ defmodule Embervm.NodeRegistry do
           rootfs_ref: rootfs_ref,
           harness_init: harness_init,
           sizing: %ResourceSpec{vcpus: entry[:vcpus] || 0, mem_mib: entry[:mem_mib] || 0},
-          node_local_wake: Map.get(serving, :node_local_wake, false),
+          node_local_wake: node_local_wake,
           serving_port: Map.get(serving, :port) || 0,
-          serving_health_path: Map.get(serving, :health_path) || ""
+          serving_health_path: Map.get(serving, :health_path) || "",
+          stateful_listen_port: Map.get(stateful, :listen_port) || 0,
+          stateful_port: Map.get(stateful, :port) || 0,
+          stateful_volume_mount: Map.get(stateful, :volume_mount_path) || ""
         }
       end
 

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -1840,6 +1840,15 @@ defmodule Embervm.StatefulManager do
     live_vms = index_stateful_vms(facts)
     bundles = index_stateful_bundles(facts)
 
+    # ADR embervm/018 Phase 2: adopt node-woken (origin ACTIVATOR) stateful VMs
+    # BEFORE the adopt_one reduce. The brick relit a scaled-to-zero workload during
+    # a CP gap and minted a vm_id the CP never issued; this relights the workload's
+    # banked CP instance onto that vm_id (or mints a fresh lifecycle if none), so
+    # the reduce below then heals it through the normal live-VM path. The forward
+    # generation it carries is trusted by refresh_volume_facts's fenced-writer rule
+    # (ADR embervm/014), so no delegated grant is needed.
+    state = adopt_activator_stateful_vms(state, live_vms)
+
     state =
       StatefulStore.all(state.store)
       |> Enum.reject(&StatefulState.terminal?(&1.state))
@@ -1946,8 +1955,17 @@ defmodule Embervm.StatefulManager do
   defp destroy_orphan_stateful_vms(state, facts, _live_vms) do
     for fact <- facts, vm <- Map.get(fact, :stateful_vms, []) || [], reduce: state do
       acc ->
-        case Enum.find(StatefulStore.all(acc.store), &(&1.vm_id == vm.vm_id)) do
-          nil ->
+        cond do
+          # ADR embervm/018 Phase 2: an origin-ACTIVATOR stateful VM is a node-woken
+          # (brick-relit) instance adopt_activator_stateful_vms adopts on the SAME
+          # pass (which runs first). Skip it here so a live node-woken VM is never
+          # orphan-destroyed while adoption is landing (belt-and-suspenders for the
+          # window where a durable adoption write failed but the VM is live). Its
+          # forward generation is trusted by the fenced-writer rule, not the grant.
+          activator_origin?(vm) ->
+            acc
+
+          Enum.find(StatefulStore.all(acc.store), &(&1.vm_id == vm.vm_id)) == nil ->
             confirmed =
               stop_stateful_destroy(acc, %{
                 node_id: fact.configured_id,
@@ -1962,9 +1980,109 @@ defmodule Embervm.StatefulManager do
 
             acc
 
-          _instance ->
+          true ->
             acc
         end
+    end
+  end
+
+  # True when a node-reported stateful VM was minted by the brick's L4 activator
+  # (ADR embervm/018 Phase 2). A pre-018 daemon reports no origin (nil /
+  # UNSPECIFIED), the CP-issued default, which is NOT an activator VM.
+  defp activator_origin?(vm), do: Map.get(vm, :origin) == :INSTANCE_ORIGIN_ACTIVATOR
+
+  # ADR embervm/018 Phase 2: adopt every node-reported origin-ACTIVATOR stateful VM
+  # that no CP row claims (by vm_id). The brick relit a scaled-to-zero workload
+  # during a CP gap and minted a vm_id the CP never issued. Singleton, so the adopt
+  # is keyed by workload: relight the workload's BANKED CP instance onto the node's
+  # vm_id (reusing its instance_id, mirroring a CP-driven wake's finish_relit), or
+  # mint a fresh cold-booted lifecycle if the CP has no banked instance. Fires once:
+  # after the relight the instance carries the node vm_id, so the next pass matches
+  # it in adopt_one and heals it through the normal live path.
+  defp adopt_activator_stateful_vms(state, live_vms) do
+    Enum.reduce(live_vms, state, fn {vm_id, {node_id, vm}}, acc ->
+      if activator_origin?(vm) and stateful_vm_unclaimed?(acc, vm_id) do
+        adopt_activator_stateful_vm(acc, node_id, vm)
+      else
+        acc
+      end
+    end)
+  end
+
+  defp stateful_vm_unclaimed?(state, vm_id) do
+    Enum.all?(StatefulStore.all(state.store), &(&1.vm_id != vm_id))
+  end
+
+  defp adopt_activator_stateful_vm(state, node_id, vm) do
+    workload = vm.workload
+
+    endpoint = %{
+      vm_id: vm.vm_id,
+      ip: Map.get(vm, :ip),
+      port: Map.get(vm, :port),
+      generation: Map.get(vm, :generation, 0)
+    }
+
+    case banked_instance_for(state, workload) do
+      {:ok, %{instance_id: instance_id}} ->
+        # Relight the banked instance onto the node's vm_id (reuse instance_id). mark
+        # :relight moves it banked -> relighting (ETS-only), then finish_relit lands
+        # the durable stateful_relit + stateful_published (waiters [] => no callers).
+        _ = StatefulStore.mark(state.store, instance_id, :relight)
+
+        Logger.info("embervm stateful adopted (activator-woken, relit)",
+          instance_id: instance_id,
+          workload: workload,
+          node_id: node_id
+        )
+
+        finish_relit(state, workload, instance_id, node_id, endpoint, [])
+
+      :none ->
+        # No banked CP instance: record a fresh cold-booted lifecycle for the node VM.
+        instance_id = mint_id(state)
+
+        attrs = %{
+          instance_id: instance_id,
+          tenant: state.tenant,
+          principal: wake_principal(workload),
+          workload: workload,
+          node_id: node_id,
+          vm_id: vm.vm_id,
+          generation: Map.get(vm, :generation, 0),
+          reason: "activator_adopted"
+        }
+
+        case StatefulStore.cold_boot(state.store, attrs) do
+          {:ok, _instance} ->
+            Logger.info("embervm stateful adopted (activator-woken, cold)",
+              instance_id: instance_id,
+              workload: workload,
+              node_id: node_id
+            )
+
+            publish_and_resolve(state, instance_id, workload, endpoint, :cold_booted, [])
+
+          {:error, reason} ->
+            Logger.warning("embervm stateful activator adoption cold_boot failed",
+              workload: workload,
+              reason: inspect(reason)
+            )
+
+            state
+        end
+    end
+  end
+
+  # The workload's current BANKED CP instance (the one a node-local relight
+  # resumed), or :none. Singleton, so at most one non-terminal instance exists;
+  # this returns it only when :banked (a live one would already match by vm_id).
+  defp banked_instance_for(state, workload) do
+    StatefulStore.all(state.store)
+    |> Enum.find(&(&1.workload == workload and &1.state == :banked))
+    |> case do
+      nil -> :none
+      instance -> {:ok, instance}
     end
   end
 

--- a/projects/embervm/control/lib/embervm/workload_watcher.ex
+++ b/projects/embervm/control/lib/embervm/workload_watcher.ex
@@ -1091,7 +1091,14 @@ defmodule Embervm.WorkloadWatcher do
       # when absent, matching every other optional stateful field's shape.
       # Embervm.StatefulManager reads it (via Embervm.K8s.get_secret) ONLY on a
       # FRESH/COLD wake, never on RELIGHT.
-      secret_ref: Map.get(s, "secretRef")
+      secret_ref: Map.get(s, "secretRef"),
+      # ADR embervm/018 Fork A Phase 2: node_local_wake gates the brick's L4
+      # activator per stateful workload (pushed to noded in the RegistryEntry and
+      # drives CP-side ACTIVATOR adoption). metering_fail_open is the companion
+      # named policy. Both default false: a stateful workload that sets neither keeps
+      # CP-only wake via the CP tcp_activator.
+      node_local_wake: Map.get(s, "nodeLocalWake") == true,
+      metering_fail_open: Map.get(s, "meteringFailOpen") == true
     }
   end
 

--- a/projects/embervm/control/lib/embervm/workload_watcher.ex
+++ b/projects/embervm/control/lib/embervm/workload_watcher.ex
@@ -1094,10 +1094,15 @@ defmodule Embervm.WorkloadWatcher do
       secret_ref: Map.get(s, "secretRef"),
       # ADR embervm/018 Fork A Phase 2: node_local_wake gates the brick's L4
       # activator per stateful workload (pushed to noded in the RegistryEntry and
-      # drives CP-side ACTIVATOR adoption). metering_fail_open is the companion
-      # named policy. Both default false: a stateful workload that sets neither keeps
-      # CP-only wake via the CP tcp_activator.
+      # drives CP-side ACTIVATOR adoption). Both default false: a stateful workload
+      # that sets neither keeps CP-only wake via the CP tcp_activator.
       node_local_wake: Map.get(s, "nodeLocalWake") == true,
+      # metering_fail_open is DECLARATIVE in Fork A: it NAMES the policy but no code
+      # reads it to suppress metering. During a CP gap the wake is unmetered by
+      # construction (the CP, which meters, is gone) and adoption backfills the
+      # lifecycle ops so accounting reconciles best-effort. It becomes an actual
+      # enforcement point in Fork B, when metering moves fully reconcile-time. Parsed
+      # now so the flag is on the CR from the start (named, not implied).
       metering_fail_open: Map.get(s, "meteringFailOpen") == true
     }
   end

--- a/projects/embervm/control/test/embervm/endpoint_publisher_test.exs
+++ b/projects/embervm/control/test/embervm/endpoint_publisher_test.exs
@@ -449,6 +449,30 @@ defmodule Embervm.EndpointPublisherTest do
     assert cluster.endpoints == [%{ip: "10.2.2.2", port: 9100}]
   end
 
+  test "ADR embervm/018 Phase 2: a cold stateful workload's L4 fallback prefers the anchor node's advertised activator" do
+    # CP activator_ip is 10.2.2.2; the volume's anchor node advertises its own
+    # 10.88.0.7. Only the brick holding the volume can relight it, so the render must
+    # prefer the anchor's activator over the CP address, at the workload's listen_port.
+    ctx = start_stack(activator_ip: "10.2.2.2")
+    stateful_workload(ctx, "wl-s", 9100)
+
+    StatefulStore.upsert_volume(ctx.stateful_store, "wl-s", %{node_id: "node-4", generation: 3})
+
+    NodeCapacity.put(ctx.cap_table, "node-4", %{
+      configured_id: "node-4",
+      node_id: "node-4",
+      serving_subnet_cidr: "10.88.0.0/24",
+      stateful_vms: [],
+      activator_ip: "10.88.0.7"
+    })
+
+    :ok = EndpointPublisher.flush(ctx.pub)
+
+    assert [{"node-4", desired}] = last_puts(ctx)
+    cluster = Enum.find(desired.clusters, &(&1.name == "state|wl-s"))
+    assert cluster.endpoints == [%{ip: "10.88.0.7", port: 9100}]
+  end
+
   test "a second stateful workload falls back to the SAME activator_ip but its OWN listen_port" do
     ctx = start_stack(activator_ip: "10.2.2.2")
     stateful_workload(ctx, "wl-s", 9100)

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -951,6 +951,55 @@ defmodule Embervm.StatefulManagerTest do
     assert still.state == :starting
   end
 
+  test "ADR embervm/018 Phase 2: adopts an origin-ACTIVATOR stateful VM by relighting the banked instance, no orphan-destroy" do
+    parent = self()
+
+    # node_confirmed_destroy on so the orphan-destroy pass is live: an ordinary
+    # rowless node VM would be destroyed, but a node-woken (ACTIVATOR) VM is adopted.
+    ctx =
+      start_stack(
+        node_confirmed_destroy: true,
+        stop_stateful_fun: fn _ch, _req ->
+          send(parent, :stop_stateful_called)
+          {:ok, %Embervm.Node.V1.StopStatefulResponse{teardown_confirmed: true}}
+        end
+      )
+
+    stateful_workload(ctx, "wl-a")
+
+    # A banked CP instance at generation 5 (the workload was banked before the gap).
+    seed_banked_with_pair(ctx, "stf-banked", "node-4", 5, 5)
+
+    # The brick relit it during the CP gap: origin ACTIVATOR, a NEW vm_id the CP
+    # never issued, and a forward generation 6 (the node's self-bump).
+    stateful_node(ctx, "node-4",
+      stateful_vms: [
+        %{
+          vm_id: "vm-brick",
+          workload: "wl-a",
+          ip: "10.88.0.9",
+          port: 5432,
+          healthy: true,
+          generation: 6,
+          origin: :INSTANCE_ORIGIN_ACTIVATOR
+        }
+      ]
+    )
+
+    :ok = StatefulManager.reconcile(ctx.mgr)
+
+    # No orphan-destroy fired for the node-woken VM (it was adopted, not destroyed).
+    refute_received :stop_stateful_called
+
+    # The banked instance was relit onto the node's vm_id (reused instance_id) and
+    # published, and now serves the node-reported endpoint at the forward generation.
+    {:ok, inst} = StatefulStore.get(ctx.store, "stf-banked")
+    assert inst.state == :serving
+    assert inst.vm_id == "vm-brick"
+    assert inst.generation == 6
+    assert StatefulStore.published_endpoint(ctx.store, "wl-a") == %{ip: "10.88.0.9", port: 5432}
+  end
+
   test "adoption refreshes volume facts and eager-evicts a pair broken while the control plane was down" do
     ctx = start_stack()
     stateful_workload(ctx, "wl-a")

--- a/projects/embervm/control/test/embervm/workload_watcher_test.exs
+++ b/projects/embervm/control/test/embervm/workload_watcher_test.exs
@@ -639,6 +639,10 @@ defmodule Embervm.WorkloadWatcherTest do
     assert entry.stateful.banked_ttl_seconds == 2_592_000
     assert entry.stateful.wake_timeout_seconds == 60
     assert entry.stateful.secret_ref == "scratch-postgres-creds"
+    # ADR embervm/018 Phase 2: nodeLocalWake/meteringFailOpen default false when the
+    # CR omits them, so an unmodified stateful workload keeps CP-only wake.
+    assert entry.stateful.node_local_wake == false
+    assert entry.stateful.metering_fail_open == false
 
     assert {_ns, "scratch-postgres", status_map} = ready_status(recorded_calls(agent), "scratch-postgres")
     assert status_map["observedGeneration"] == 1

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.225
+      targetRevision: 0.1.226
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/cmd/main.go
+++ b/projects/embervm/noded/cmd/main.go
@@ -252,7 +252,7 @@ func run(logger *slog.Logger) error {
 	if err != nil {
 		return err
 	}
-	// The activator is serving-class only. Bind before marking it advertised so
+	// The HTTP activator is serving-class only. Bind before marking it advertised so
 	// NodeStatus never sends an Envoy request to a listener that is not present.
 	activatorLis, err := net.Listen("tcp", cfg.ActivatorAddr)
 	if err != nil {
@@ -263,6 +263,20 @@ func run(logger *slog.Logger) error {
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	srv.EnableActivator()
+	var statefulActivatorListeners []net.Listener
+	if lo, hi := cfg.StatefulActivatorPortRange[0], cfg.StatefulActivatorPortRange[1]; lo != 0 && hi >= lo && cfg.VolumeRoot != "" {
+		for port := lo; port <= hi; port++ {
+			statefulLis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+			if err != nil {
+				for _, bound := range statefulActivatorListeners {
+					_ = bound.Close()
+				}
+				return fmt.Errorf("stateful activator listen on port %d: %w", port, err)
+			}
+			statefulActivatorListeners = append(statefulActivatorListeners, statefulLis)
+		}
+		srv.StartStatefulActivator(ctx, statefulActivatorListeners)
+	}
 
 	// Plain-HTTP /healthz for kubelet probes (a privileged single-replica pod does
 	// not warrant gRPC health-checking machinery).

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -54,6 +54,10 @@ type Config struct {
 	// ActivatorPort is the port parsed from ActivatorAddr. It is advertised in
 	// NodeStatus and used by the stable node-IP DNAT rule.
 	ActivatorPort uint32
+	// StatefulActivatorPortRange is the inclusive L4 listener range for
+	// node-local stateful wake. A zero range disables the listeners. Env
+	// EMBERVM_NODED_STATEFUL_ACTIVATOR_PORT_RANGE.
+	StatefulActivatorPortRange [2]uint32
 	// Node identifies the Kubernetes node this daemon is pinned to (injected via
 	// the Downward API as EMBERVM_NODED_NODE / spec.nodeName). Reported as
 	// node_id in NodeStatus and stamped into snapshot node-pinning.
@@ -403,6 +407,15 @@ func Load() (Config, error) {
 
 		RequireBlessing: boolDefault("EMBERVM_NODED_REQUIRE_BLESSING", false),
 	}
+	statefulActivatorRangeRaw := "5400-5409"
+	if raw, ok := os.LookupEnv("EMBERVM_NODED_STATEFUL_ACTIVATOR_PORT_RANGE"); ok {
+		statefulActivatorRangeRaw = raw
+	}
+	statefulActivatorRange, err := parsePortRange(statefulActivatorRangeRaw)
+	if err != nil {
+		return Config{}, fmt.Errorf("invalid EMBERVM_NODED_STATEFUL_ACTIVATOR_PORT_RANGE: %w", err)
+	}
+	c.StatefulActivatorPortRange = statefulActivatorRange
 
 	if c.Node == "" {
 		c.Node = os.Getenv("NODE_NAME")
@@ -496,6 +509,25 @@ func Load() (Config, error) {
 	}
 
 	return c, nil
+}
+
+func parsePortRange(raw string) ([2]uint32, error) {
+	if raw == "" || raw == "0" {
+		return [2]uint32{}, nil
+	}
+	parts := strings.Split(raw, "-")
+	if len(parts) != 2 {
+		return [2]uint32{}, fmt.Errorf("%q must be LO-HI, empty, or 0", raw)
+	}
+	lo, err := strconv.ParseUint(parts[0], 10, 16)
+	if err != nil || lo == 0 {
+		return [2]uint32{}, fmt.Errorf("%q has an invalid lower port", raw)
+	}
+	hi, err := strconv.ParseUint(parts[1], 10, 16)
+	if err != nil || hi == 0 || hi < lo {
+		return [2]uint32{}, fmt.Errorf("%q has an invalid upper port", raw)
+	}
+	return [2]uint32{uint32(lo), uint32(hi)}, nil
 }
 
 // PruneStaleInstanceWarmth removes per-instance (brick) warmth directories under

--- a/projects/embervm/noded/config/config_test.go
+++ b/projects/embervm/noded/config/config_test.go
@@ -98,6 +98,39 @@ func TestLoadActivatorAddress(t *testing.T) {
 	}
 }
 
+func TestLoadStatefulActivatorPortRange(t *testing.T) {
+	t.Setenv("EMBERVM_NODED_STATEFUL_ACTIVATOR_PORT_RANGE", "15400-15409")
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.StatefulActivatorPortRange != [2]uint32{15400, 15409} {
+		t.Errorf("StatefulActivatorPortRange = %v, want [15400 15409]", c.StatefulActivatorPortRange)
+	}
+}
+
+func TestLoadStatefulActivatorPortRangeDisabled(t *testing.T) {
+	t.Setenv("EMBERVM_NODED_STATEFUL_ACTIVATOR_PORT_RANGE", "0")
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.StatefulActivatorPortRange != [2]uint32{} {
+		t.Errorf("StatefulActivatorPortRange = %v, want disabled", c.StatefulActivatorPortRange)
+	}
+}
+
+func TestLoadStatefulActivatorPortRangeEmptyDisables(t *testing.T) {
+	t.Setenv("EMBERVM_NODED_STATEFUL_ACTIVATOR_PORT_RANGE", "")
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.StatefulActivatorPortRange != [2]uint32{} {
+		t.Errorf("StatefulActivatorPortRange = %v, want disabled", c.StatefulActivatorPortRange)
+	}
+}
+
 // TestLoadCpuTemplateDefaultsPerVendor proves CpuTemplate resolves to the
 // conservative per-vendor default (PR-E) when EMBERVM_NODED_CPU_TEMPLATE is
 // unset and CpuVendor is known, for both fleet vendors.

--- a/projects/embervm/noded/server/BUILD
+++ b/projects/embervm/noded/server/BUILD
@@ -4,7 +4,6 @@ go_library(
     name = "server",
     srcs = [
         "activator.go",
-        "stateful_activator.go",
         "budget.go",
         "group.go",
         "group_member.go",
@@ -17,6 +16,7 @@ go_library(
         "serving.go",
         "serving_registry.go",
         "stateful.go",
+        "stateful_activator.go",
         "stateful_registry.go",
         "store.go",
     ],
@@ -40,7 +40,6 @@ go_test(
     name = "server_test",
     srcs = [
         "activator_test.go",
-        "stateful_activator_test.go",
         "budget_test.go",
         "drain_test.go",
         "evict_local_test.go",
@@ -51,6 +50,7 @@ go_test(
         "registry_workload_test.go",
         "server_test.go",
         "serving_test.go",
+        "stateful_activator_test.go",
         "stateful_test.go",
         "store_test.go",
     ],

--- a/projects/embervm/noded/server/BUILD
+++ b/projects/embervm/noded/server/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "server",
     srcs = [
         "activator.go",
+        "stateful_activator.go",
         "budget.go",
         "group.go",
         "group_member.go",
@@ -39,6 +40,7 @@ go_test(
     name = "server_test",
     srcs = [
         "activator_test.go",
+        "stateful_activator_test.go",
         "budget_test.go",
         "drain_test.go",
         "evict_local_test.go",

--- a/projects/embervm/noded/server/registry_workload.go
+++ b/projects/embervm/noded/server/registry_workload.go
@@ -22,29 +22,39 @@ type workloadEntry struct {
 	// ImageRef is the OCI ref a BuildBase resolves against to find this entry's
 	// node-side rootfs/harness (the join key the retired EMBERVM_NODED_IMAGES
 	// table keyed on). getByImageRef indexes on it.
-	ImageRef          string `json:"imageRef"`
-	RootfsRef         string `json:"rootfsRef"`
-	HarnessInit       string `json:"harnessInit"`
-	VCPUs             uint32 `json:"vcpus"`
-	MemMib            uint32 `json:"memMib"`
-	NodeLocalWake     bool   `json:"nodeLocalWake"`
-	ServingPort       uint32 `json:"servingPort"`
-	ServingHealthPath string `json:"servingHealthPath"`
+	ImageRef             string `json:"imageRef"`
+	RootfsRef            string `json:"rootfsRef"`
+	HarnessInit          string `json:"harnessInit"`
+	VCPUs                uint32 `json:"vcpus"`
+	MemMib               uint32 `json:"memMib"`
+	NodeLocalWake        bool   `json:"nodeLocalWake"`
+	ServingPort          uint32 `json:"servingPort"`
+	ServingHealthPath    string `json:"servingHealthPath"`
+	StatefulListenPort   uint32 `json:"statefulListenPort"`
+	StatefulPort         uint32 `json:"statefulPort"`
+	StatefulVolumeMount  string `json:"statefulVolumeMount"`
+	StatefulBootImageRef string `json:"statefulBootImageRef"`
+	StatefulVolumeDevice string `json:"statefulVolumeDevice"`
 }
 
 // entryFromProto lifts a wire RegistryEntry into the daemon's internal shape.
 func entryFromProto(e *nodev1.RegistryEntry) workloadEntry {
 	return workloadEntry{
-		Workload:          e.GetWorkload(),
-		ImageDigest:       e.GetImageDigest(),
-		ImageRef:          e.GetImageRef(),
-		RootfsRef:         e.GetRootfsRef(),
-		HarnessInit:       e.GetHarnessInit(),
-		VCPUs:             e.GetSizing().GetVcpus(),
-		MemMib:            e.GetSizing().GetMemMib(),
-		NodeLocalWake:     e.GetNodeLocalWake(),
-		ServingPort:       e.GetServingPort(),
-		ServingHealthPath: e.GetServingHealthPath(),
+		Workload:             e.GetWorkload(),
+		ImageDigest:          e.GetImageDigest(),
+		ImageRef:             e.GetImageRef(),
+		RootfsRef:            e.GetRootfsRef(),
+		HarnessInit:          e.GetHarnessInit(),
+		VCPUs:                e.GetSizing().GetVcpus(),
+		MemMib:               e.GetSizing().GetMemMib(),
+		NodeLocalWake:        e.GetNodeLocalWake(),
+		ServingPort:          e.GetServingPort(),
+		ServingHealthPath:    e.GetServingHealthPath(),
+		StatefulListenPort:   e.GetStatefulListenPort(),
+		StatefulPort:         e.GetStatefulPort(),
+		StatefulVolumeMount:  e.GetStatefulVolumeMount(),
+		StatefulBootImageRef: e.GetStatefulBootImageRef(),
+		StatefulVolumeDevice: e.GetStatefulVolumeDevice(),
 	}
 }
 
@@ -150,6 +160,20 @@ func (r *workloadRegistry) get(workload string) (workloadEntry, bool) {
 	defer r.mu.Unlock()
 	e, ok := r.entries[workload]
 	return e, ok
+}
+
+// statefulByListenPort resolves the opaque-L4 activator identity. The local
+// accept port is the only workload discriminator, so node_local_wake and a
+// nonzero stateful listen port are both required.
+func (r *workloadRegistry) statefulByListenPort(port uint32) (workloadEntry, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, e := range r.entries {
+		if e.NodeLocalWake && e.StatefulListenPort == port {
+			return e, true
+		}
+	}
+	return workloadEntry{}, false
 }
 
 // getByImageRef returns the entry whose ImageRef matches imageRef (the BuildBase

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -194,15 +194,16 @@ type Server struct {
 	// Phase 2). The daemon boots with it empty (or a STALE boot-cache load) and
 	// admits no new work until the control plane replays it over SyncRegistry
 	// (readiness gate). It replaces the retired EMBERVM_NODED_IMAGES config table.
-	registry         *workloadRegistry
-	sessionVMs       *sessionRegistry
-	sessionSnap      *sessionSnapshotRegistry
-	servingVMs       *servingRegistry
-	servingSnap      *servingSnapshotRegistry
-	servingImage     *servingImageRegistry
-	activator        *activator
-	activatorMu      sync.RWMutex
-	activatorEnabled bool
+	registry          *workloadRegistry
+	sessionVMs        *sessionRegistry
+	sessionSnap       *sessionSnapshotRegistry
+	servingVMs        *servingRegistry
+	servingSnap       *servingSnapshotRegistry
+	servingImage      *servingImageRegistry
+	activator         *activator
+	statefulActivator *statefulActivator
+	activatorMu       sync.RWMutex
+	activatorEnabled  bool
 
 	// servingNet owns the host serving network (bridge, taps, nftables, IP
 	// allocation). nil disables the serving verbs (task/session-only tests and any
@@ -424,6 +425,7 @@ func New(opts Options) *Server {
 		activeBuilds:    make(map[string]context.CancelFunc),
 	}
 	s.activator = newActivator(s)
+	s.statefulActivator = newStatefulActivator(s)
 	// VolumeRoot may be set directly on Options (mirroring how cmd/main.go wires
 	// every other stateful/serving knob explicitly) or left to fall back to
 	// Config.VolumeRoot, so a caller that only populates Config (as several
@@ -1944,6 +1946,7 @@ func (s *Server) statefulVMsStatus() []*nodev1.StatefulVm {
 			LastProbeUnixMs:   e.lastProbeUnixMs,
 			CheckpointPending: e.checkpointPending,
 			CheckpointToken:   e.checkpointToken,
+			Origin:            e.origin,
 		})
 	}
 	return out

--- a/projects/embervm/noded/server/stateful.go
+++ b/projects/embervm/noded/server/stateful.go
@@ -47,13 +47,17 @@ const (
 // stateful contract is opaque L4 (decision 4). Every mode advances the volume's
 // generation ledger BEFORE the VM boots (via attachGeneration: RecordBlessed
 // when the request carries a nonzero blessed_generation, R7 ADR embervm/011,
-// or the legacy self-bump otherwise), so any writable attach the daemon
+// or the trusted node-local self-bump otherwise), so any writable attach the daemon
 // witnesses is unconditionally reflected in the pair key even if the boot that
 // follows fails; there is no un-bump. A readiness failure DESTROYS the VM,
 // releases the tap, and DETACHES the volume (but never rolls the generation
 // back) and returns FAILED_PRECONDITION: there is no half-alive endpoint a
 // caller could observe or publish.
 func (s *Server) StartStateful(ctx context.Context, req *nodev1.StartStatefulRequest) (*nodev1.StartStatefulResponse, error) {
+	return s.startStateful(ctx, req, nodev1.InstanceOrigin_INSTANCE_ORIGIN_CONTROL_PLANE)
+}
+
+func (s *Server) startStateful(ctx context.Context, req *nodev1.StartStatefulRequest, origin nodev1.InstanceOrigin) (*nodev1.StartStatefulResponse, error) {
 	if s.servingNet == nil || s.servingDriver == nil || s.statefulDriver == nil || s.volumes == nil {
 		return nil, status.Error(codes.Unimplemented, "noded: stateful not configured")
 	}
@@ -80,25 +84,24 @@ func (s *Server) StartStateful(ctx context.Context, req *nodev1.StartStatefulReq
 
 	switch req.GetMode() {
 	case nodev1.StartStatefulMode_START_STATEFUL_MODE_FRESH:
-		return s.startStatefulFresh(ctx, req, workload, port)
+		return s.startStatefulFresh(ctx, req, workload, port, origin)
 	case nodev1.StartStatefulMode_START_STATEFUL_MODE_RELIGHT:
-		return s.startStatefulRelight(ctx, req, workload, port)
+		return s.startStatefulRelight(ctx, req, workload, port, origin)
 	case nodev1.StartStatefulMode_START_STATEFUL_MODE_COLD:
-		return s.startStatefulCold(ctx, req, workload, port)
+		return s.startStatefulCold(ctx, req, workload, port, origin)
 	default:
 		return nil, status.Error(codes.InvalidArgument, "noded: StartStateful mode must be FRESH, RELIGHT, or COLD")
 	}
 }
 
-// attachGeneration resolves the generation a writable attach records, per R7
-// standing decision 4 (the control plane becomes the sole issuer). A nonzero
+// attachGeneration resolves the generation a writable attach records. A nonzero
 // blessedGeneration on the request is recorded via volume.Manager.RecordBlessed
-// (the CP-issued value, never invented here). Zero means the legacy self-bump
-// lane: allowed only while s.cfg.RequireBlessing is false, and rejected
-// FAILED_PRECONDITION once it is true (the chart flips RequireBlessing in the
-// same version the control plane starts blessing, so a mixed state cannot
-// outlive the roll).
-func (s *Server) attachGeneration(workload string, blessedGeneration uint64) (uint64, error) {
+// (the control-plane-issued value, never invented here). Zero means the legacy self-bump
+// lane: allowed for the trusted node-local activator and, while
+// s.cfg.RequireBlessing is false, the legacy RPC path. The activator follows
+// the same self-bump discipline as checkpoint auto-abort and relies on the
+// physical volume attach fence rather than a delegated control-plane grant.
+func (s *Server) attachGeneration(workload string, blessedGeneration uint64, activatorOrigin bool) (uint64, error) {
 	if blessedGeneration > 0 {
 		gen, err := s.volumes.RecordBlessed(workload, blessedGeneration)
 		if err != nil {
@@ -106,7 +109,7 @@ func (s *Server) attachGeneration(workload string, blessedGeneration uint64) (ui
 		}
 		return gen, nil
 	}
-	if s.cfg.RequireBlessing {
+	if s.cfg.RequireBlessing && !activatorOrigin {
 		return 0, status.Errorf(codes.FailedPrecondition, "noded: writable attach for %q requires a blessed_generation (EMBERVM_NODED_REQUIRE_BLESSING is set)", workload)
 	}
 	gen, err := s.volumes.BumpGeneration(workload)
@@ -120,7 +123,7 @@ func (s *Server) attachGeneration(workload string, blessedGeneration uint64) (ui
 // FAILED_PRECONDITION when absent and create_if_missing is false), then cold
 // boots exactly like startStatefulCold. It is the only mode that may create the
 // volume; RELIGHT's fallback and COLD both require it to already exist.
-func (s *Server) startStatefulFresh(ctx context.Context, req *nodev1.StartStatefulRequest, workload string, port uint32) (*nodev1.StartStatefulResponse, error) {
+func (s *Server) startStatefulFresh(ctx context.Context, req *nodev1.StartStatefulRequest, workload string, port uint32, origin nodev1.InstanceOrigin) (*nodev1.StartStatefulResponse, error) {
 	// A FRESH stateful boot is new-work placement (it may create the volume). A
 	// stale registry (boot cache, no live sync) must refuse it; RELIGHT and COLD
 	// operate on EXISTING state and stay allowed so existing warmth is served.
@@ -138,7 +141,7 @@ func (s *Server) startStatefulFresh(ctx context.Context, req *nodev1.StartStatef
 			return nil, status.Errorf(codes.Internal, "noded: create stateful volume for %q: %v", workload, err)
 		}
 	}
-	return s.coldBootStateful(ctx, req, workload, port, "")
+	return s.coldBootStateful(ctx, req, workload, port, "", origin)
 }
 
 // startStatefulCold is an EXPLICIT cold boot from the existing volume (no
@@ -146,11 +149,11 @@ func (s *Server) startStatefulFresh(ctx context.Context, req *nodev1.StartStatef
 // FRESH it never creates one, matching the proto doc's "explicit cold boot from
 // the existing volume". cold_boot_reason is left empty: an explicit COLD boot
 // is not a discarded relight, so it carries no reason.
-func (s *Server) startStatefulCold(ctx context.Context, req *nodev1.StartStatefulRequest, workload string, port uint32) (*nodev1.StartStatefulResponse, error) {
+func (s *Server) startStatefulCold(ctx context.Context, req *nodev1.StartStatefulRequest, workload string, port uint32, origin nodev1.InstanceOrigin) (*nodev1.StartStatefulResponse, error) {
 	if !s.volumes.Exists(workload) {
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: stateful volume for workload %q does not exist (COLD requires an existing volume)", workload)
 	}
-	return s.coldBootStateful(ctx, req, workload, port, "")
+	return s.coldBootStateful(ctx, req, workload, port, "", origin)
 }
 
 // startStatefulRelight resumes the banked bundle (relight_snapshot_ref) iff its
@@ -165,7 +168,7 @@ func (s *Server) startStatefulCold(ctx context.Context, req *nodev1.StartStatefu
 // cannot trust (which could later false-match a stale bundle). The stale bundle
 // is still evicted first, and the volume bytes are never touched, so this is
 // fail-closed-but-data-safe, surfaced for an operator to repair.
-func (s *Server) startStatefulRelight(ctx context.Context, req *nodev1.StartStatefulRequest, workload string, port uint32) (*nodev1.StartStatefulResponse, error) {
+func (s *Server) startStatefulRelight(ctx context.Context, req *nodev1.StartStatefulRequest, workload string, port uint32, origin nodev1.InstanceOrigin) (*nodev1.StartStatefulResponse, error) {
 	ref := req.GetRelightSnapshotRef()
 	if ref == "" {
 		return nil, status.Error(codes.InvalidArgument, "noded: relight_snapshot_ref required for RELIGHT")
@@ -199,7 +202,7 @@ func (s *Server) startStatefulRelight(ctx context.Context, req *nodev1.StartStat
 			_ = s.statefulDriver.RemoveStatefulBundle(ref)
 			s.statefulBundles.remove(ref)
 		}
-		return s.coldBootStateful(ctx, req, workload, port, reason)
+		return s.coldBootStateful(ctx, req, workload, port, reason, origin)
 	}
 
 	// Matched pair: resume the bundle. Attach lock first, then bump (the same
@@ -219,7 +222,7 @@ func (s *Server) startStatefulRelight(ctx context.Context, req *nodev1.StartStat
 			s.volumes.Detach(workload)
 		}
 	}()
-	gen, err := s.attachGeneration(workload, req.GetBlessedGeneration())
+	gen, err := s.attachGeneration(workload, req.GetBlessedGeneration(), origin == nodev1.InstanceOrigin_INSTANCE_ORIGIN_ACTIVATOR)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +257,7 @@ func (s *Server) startStatefulRelight(ctx context.Context, req *nodev1.StartStat
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: relight stateful snapshot %q: %v", ref, err)
 	}
 	attached = false // ownership passes to finishStatefulStart's detach-on-failure path
-	return s.finishStatefulStart(ctx, h, workload, ref, ip, port, gen, true, "", s.cfg.RestoreReadyTimeout)
+	return s.finishStatefulStart(ctx, h, workload, ref, ip, port, gen, true, "", s.cfg.RestoreReadyTimeout, origin)
 }
 
 // coldBootStateful resolves boot_image_ref against the serving-images
@@ -263,7 +266,7 @@ func (s *Server) startStatefulRelight(ctx context.Context, req *nodev1.StartStat
 // volume's generation, attaches the volume, allocates a tap, and cold-boots
 // with the volume as a third writable drive. Shared by FRESH, COLD, and the
 // RELIGHT fallback so all three paths boot identically once the volume exists.
-func (s *Server) coldBootStateful(ctx context.Context, req *nodev1.StartStatefulRequest, workload string, port uint32, coldBootReason string) (*nodev1.StartStatefulResponse, error) {
+func (s *Server) coldBootStateful(ctx context.Context, req *nodev1.StartStatefulRequest, workload string, port uint32, coldBootReason string, origin nodev1.InstanceOrigin) (*nodev1.StartStatefulResponse, error) {
 	bootImageRef := req.GetBootImageRef()
 	if bootImageRef == "" {
 		return nil, status.Error(codes.InvalidArgument, "noded: boot_image_ref required")
@@ -302,7 +305,7 @@ func (s *Server) coldBootStateful(ctx context.Context, req *nodev1.StartStateful
 			s.volumes.Detach(workload)
 		}
 	}()
-	gen, err := s.attachGeneration(workload, req.GetBlessedGeneration())
+	gen, err := s.attachGeneration(workload, req.GetBlessedGeneration(), origin == nodev1.InstanceOrigin_INSTANCE_ORIGIN_ACTIVATOR)
 	if err != nil {
 		return nil, err
 	}
@@ -338,7 +341,7 @@ func (s *Server) coldBootStateful(ctx context.Context, req *nodev1.StartStateful
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: cold-boot stateful vm: %v", err)
 	}
 	attached = false // ownership passes to finishStatefulStart's detach-on-failure path
-	return s.finishStatefulStart(ctx, h, workload, "", ip, port, gen, false, coldBootReason, s.cfg.BootReadyTimeout)
+	return s.finishStatefulStart(ctx, h, workload, "", ip, port, gen, false, coldBootReason, s.cfg.BootReadyTimeout, origin)
 }
 
 // finishStatefulStart is the shared tail of every StartStateful path: health-
@@ -346,7 +349,7 @@ func (s *Server) coldBootStateful(ctx context.Context, req *nodev1.StartStateful
 // stateful VM and start its TCP probe. On a readiness failure it reaps the VM,
 // releases the tap, and DETACHES the volume (never rolling the generation
 // back), returning FAILED_PRECONDITION.
-func (s *Server) finishStatefulStart(ctx context.Context, h substrate.Handle, workload, sourceRef string, ip net.IP, port uint32, generation uint64, wasRelight bool, coldBootReason string, readyBudget time.Duration) (*nodev1.StartStatefulResponse, error) {
+func (s *Server) finishStatefulStart(ctx context.Context, h substrate.Handle, workload, sourceRef string, ip net.IP, port uint32, generation uint64, wasRelight bool, coldBootReason string, readyBudget time.Duration, origin nodev1.InstanceOrigin) (*nodev1.StartStatefulResponse, error) {
 	if err := s.waitStatefulReady(ctx, ip, port, readyBudget); err != nil {
 		s.reapStateful(h, ip, workload)
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: stateful guest not ready over tap: %v", err)
@@ -364,6 +367,7 @@ func (s *Server) finishStatefulStart(ctx context.Context, h substrate.Handle, wo
 		port:        port,
 		tap:         serving.TapNameForIP(ip),
 		generation:  generation,
+		origin:      origin,
 		snapshotRef: sourceRef,
 		probe:       probe,
 	})

--- a/projects/embervm/noded/server/stateful_activator.go
+++ b/projects/embervm/noded/server/stateful_activator.go
@@ -1,0 +1,277 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+)
+
+type statefulActivatorFlight struct {
+	done  chan struct{}
+	entry *statefulEntry
+	err   error
+}
+
+// statefulActivator is noded's node-local opaque-L4 wake path. The accepted
+// port identifies the workload, so each eligible workload has exactly one
+// in-flight relight and its parked connections independently splice once the
+// guest is ready.
+type statefulActivator struct {
+	server *Server
+
+	mu      sync.Mutex
+	flights map[string]*statefulActivatorFlight
+	boots   int
+	parked  map[string]int
+	wakes   []time.Time
+}
+
+func newStatefulActivator(s *Server) *statefulActivator {
+	return &statefulActivator{
+		server:  s,
+		flights: make(map[string]*statefulActivatorFlight),
+		parked:  make(map[string]int),
+	}
+}
+
+// StartStatefulActivator starts one accept loop for every already-bound
+// stateful L4 listener. Listeners are closed when ctx is cancelled so blocked
+// Accept calls exit with the daemon shutdown.
+func (s *Server) StartStatefulActivator(ctx context.Context, listeners []net.Listener) {
+	if s.statefulActivator == nil || len(listeners) == 0 {
+		return
+	}
+	go func() {
+		<-ctx.Done()
+		for _, lis := range listeners {
+			_ = lis.Close()
+		}
+	}()
+	for _, lis := range listeners {
+		port := listenerPort(lis)
+		if port == 0 {
+			s.logger.Warn("stateful activator: listener has no TCP port", "addr", lis.Addr().String())
+			_ = lis.Close()
+			continue
+		}
+		go s.statefulActivator.serve(ctx, lis, port)
+	}
+}
+
+func listenerPort(lis net.Listener) uint32 {
+	if addr, ok := lis.Addr().(*net.TCPAddr); ok && addr.Port > 0 {
+		return uint32(addr.Port)
+	}
+	_, rawPort, err := net.SplitHostPort(lis.Addr().String())
+	if err != nil {
+		return 0
+	}
+	port, err := strconv.ParseUint(rawPort, 10, 16)
+	if err != nil || port == 0 {
+		return 0
+	}
+	return uint32(port)
+}
+
+func (a *statefulActivator) serve(ctx context.Context, lis net.Listener, port uint32) {
+	a.server.logger.Info("stateful activator listener listening", "addr", lis.Addr().String(), "port", port)
+	for {
+		conn, err := lis.Accept()
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, net.ErrClosed) {
+				return
+			}
+			a.server.logger.Warn("stateful activator: accept failed", "port", port, "err", err)
+			continue
+		}
+		go a.handle(ctx, conn, port)
+	}
+}
+
+func (a *statefulActivator) handle(ctx context.Context, conn net.Conn, listenPort uint32) {
+	reg, ok := a.server.registry.statefulByListenPort(listenPort)
+	if !ok {
+		a.server.logger.Warn("stateful activator: no eligible workload for listener", "port", listenPort)
+		_ = conn.Close()
+		return
+	}
+
+	if live, token, ok := a.server.statefulVMs.byWorkloadCheckpoint(reg.Workload); ok && token == "" {
+		a.splice(ctx, conn, live)
+		return
+	}
+
+	flight, leader, ok := a.join(reg.Workload)
+	if !ok {
+		a.server.logger.Warn("stateful activator: wake rejected by local limit", "workload", reg.Workload)
+		_ = conn.Close()
+		return
+	}
+	defer a.unpark(reg.Workload)
+
+	if leader {
+		entry, err := a.wake(ctx, reg)
+		a.complete(reg.Workload, flight, entry, err)
+	}
+	select {
+	case <-flight.done:
+	case <-ctx.Done():
+		_ = conn.Close()
+		return
+	}
+	if flight.err != nil || flight.entry == nil {
+		a.server.logger.Warn("stateful activator: wake failed", "workload", reg.Workload, "err", flight.err)
+		_ = conn.Close()
+		return
+	}
+	a.splice(ctx, conn, flight.entry)
+}
+
+// join accounts for one parked connection. A follower joins an existing
+// workload flight; a leader reserves a globally bounded boot slot and a local
+// wake-rate slot.
+func (a *statefulActivator) join(workload string) (*statefulActivatorFlight, bool, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.parked[workload] >= activatorMaxParked {
+		return nil, false, false
+	}
+	if f, ok := a.flights[workload]; ok {
+		a.parked[workload]++
+		return f, false, true
+	}
+	if a.boots >= activatorMaxBoots || !a.allowWakeLocked(time.Now()) {
+		return nil, false, false
+	}
+	f := &statefulActivatorFlight{done: make(chan struct{})}
+	a.flights[workload] = f
+	a.boots++
+	a.parked[workload]++
+	return f, true, true
+}
+
+func (a *statefulActivator) allowWakeLocked(now time.Time) bool {
+	cutoff := now.Add(-activatorWakeWindow)
+	kept := a.wakes[:0]
+	for _, woke := range a.wakes {
+		if woke.After(cutoff) {
+			kept = append(kept, woke)
+		}
+	}
+	a.wakes = kept
+	if len(a.wakes) >= activatorWakeMax {
+		return false
+	}
+	a.wakes = append(a.wakes, now)
+	return true
+}
+
+func (a *statefulActivator) unpark(workload string) {
+	a.mu.Lock()
+	if a.parked[workload] <= 1 {
+		delete(a.parked, workload)
+	} else {
+		a.parked[workload]--
+	}
+	a.mu.Unlock()
+}
+
+func (a *statefulActivator) complete(workload string, flight *statefulActivatorFlight, entry *statefulEntry, err error) {
+	a.mu.Lock()
+	flight.entry = entry
+	flight.err = err
+	delete(a.flights, workload)
+	a.boots--
+	close(flight.done)
+	a.mu.Unlock()
+}
+
+func (a *statefulActivator) wake(ctx context.Context, reg workloadEntry) (*statefulEntry, error) {
+	if live, token, ok := a.server.statefulVMs.byWorkloadCheckpoint(reg.Workload); ok {
+		if token == "" {
+			return live, nil
+		}
+		e, claimed := a.server.statefulVMs.claimResolve(live.vmID, token)
+		if !claimed {
+			if resumed, resumedToken, found := a.server.statefulVMs.byWorkloadCheckpoint(reg.Workload); found && resumedToken == "" {
+				return resumed, nil
+			}
+			return nil, fmt.Errorf("noded: checkpoint resolve raced for stateful workload %q", reg.Workload)
+		}
+		if _, err := a.server.abortCheckpoint(ctx, e, token, 0); err != nil {
+			return nil, err
+		}
+		resumed, resumedToken, ok := a.server.statefulVMs.byWorkloadCheckpoint(reg.Workload)
+		if !ok || resumedToken != "" {
+			return nil, fmt.Errorf("noded: checkpoint abort for stateful workload %q did not restore a live VM", reg.Workload)
+		}
+		return resumed, nil
+	}
+
+	req := &nodev1.StartStatefulRequest{
+		Trace:             &nodev1.Trace{Workload: reg.Workload},
+		Port:              reg.StatefulPort,
+		BootImageRef:      reg.StatefulBootImageRef,
+		VolumeMount:       reg.StatefulVolumeMount,
+		VolumeDevice:      reg.StatefulVolumeDevice,
+		BlessedGeneration: 0,
+		Resources:         &nodev1.ResourceSpec{Vcpus: reg.VCPUs, MemMib: reg.MemMib},
+	}
+	if bundle, ok := a.server.statefulBundles.byWorkload(reg.Workload); ok {
+		req.Mode = nodev1.StartStatefulMode_START_STATEFUL_MODE_RELIGHT
+		req.RelightSnapshotRef = bundle.snapshotRef
+	} else {
+		req.Mode = nodev1.StartStatefulMode_START_STATEFUL_MODE_COLD
+	}
+	if _, err := a.server.startStateful(ctx, req, nodev1.InstanceOrigin_INSTANCE_ORIGIN_ACTIVATOR); err != nil {
+		return nil, err
+	}
+	entry, ok := a.server.statefulVMs.byWorkload(reg.Workload)
+	if !ok {
+		return nil, fmt.Errorf("noded: activated stateful VM for workload %q was not registered", reg.Workload)
+	}
+	return entry, nil
+}
+
+func (a *statefulActivator) splice(ctx context.Context, client net.Conn, entry *statefulEntry) {
+	if entry == nil || entry.ip == nil || entry.port == 0 {
+		_ = client.Close()
+		return
+	}
+	guest, err := (&net.Dialer{}).DialContext(ctx, "tcp", net.JoinHostPort(entry.ip.String(), strconv.FormatUint(uint64(entry.port), 10)))
+	if err != nil {
+		a.server.logger.Warn("stateful activator: guest dial failed", "workload", entry.workload, "err", err)
+		_ = client.Close()
+		return
+	}
+	defer client.Close()
+	defer guest.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		pumpTCP(guest, client)
+	}()
+	go func() {
+		defer wg.Done()
+		pumpTCP(client, guest)
+	}()
+	wg.Wait()
+}
+
+func pumpTCP(dst, src net.Conn) {
+	_, _ = io.Copy(dst, src)
+	if conn, ok := dst.(*net.TCPConn); ok {
+		_ = conn.CloseWrite()
+		return
+	}
+	_ = dst.Close()
+}

--- a/projects/embervm/noded/server/stateful_activator_test.go
+++ b/projects/embervm/noded/server/stateful_activator_test.go
@@ -1,0 +1,235 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+)
+
+func statefulActivatorEchoServer(t *testing.T) uint32 {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("stateful echo listen: %v", err)
+	}
+	t.Cleanup(func() { _ = lis.Close() })
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				_, _ = io.Copy(conn, conn)
+			}()
+		}
+	}()
+	_, rawPort, err := net.SplitHostPort(lis.Addr().String())
+	if err != nil {
+		t.Fatalf("stateful echo split port: %v", err)
+	}
+	port, err := strconv.ParseUint(rawPort, 10, 32)
+	if err != nil {
+		t.Fatalf("stateful echo parse port: %v", err)
+	}
+	return uint32(port)
+}
+
+func enableStatefulActivatorWorkload(s *Server, workload string, listenPort, guestPort uint32) {
+	s.registry.sync([]workloadEntry{{
+		Workload:             workload,
+		NodeLocalWake:        true,
+		StatefulListenPort:   listenPort,
+		StatefulPort:         guestPort,
+		StatefulVolumeMount:  "/var/lib/postgresql/data",
+		StatefulBootImageRef: "img-a",
+		VCPUs:                1,
+		MemMib:               128,
+	}})
+}
+
+func startStatefulActivator(t *testing.T, s *Server) uint32 {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("stateful activator listen: %v", err)
+	}
+	s.StartStatefulActivator(ctx, []net.Listener{lis})
+	return listenerPort(lis)
+}
+
+func statefulActivatorConn(t *testing.T, listenPort uint32) net.Conn {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.FormatUint(uint64(listenPort), 10)), 2*time.Second)
+	if err != nil {
+		t.Fatalf("stateful activator dial: %v", err)
+	}
+	return conn
+}
+
+func statefulActivatorRoundTrip(t *testing.T, conn net.Conn, body string) {
+	t.Helper()
+	if err := conn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	if _, err := conn.Write([]byte(body)); err != nil {
+		t.Fatalf("activator write: %v", err)
+	}
+	got := make([]byte, len(body))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("activator read: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("activator bytes = %q, want %q", got, body)
+	}
+}
+
+func addStatefulActivatorBundle(t *testing.T, s *Server, driver *fakeStatefulDriver, workload, ref string) {
+	t.Helper()
+	if err := s.volumes.Create(workload, 1<<20); err != nil {
+		t.Fatalf("create stateful volume: %v", err)
+	}
+	driver.mu.Lock()
+	driver.banked[ref] = 0
+	driver.mu.Unlock()
+	s.statefulBundles.add(statefulBundleEntry{snapshotRef: ref, workload: workload, generation: 0})
+}
+
+func TestStatefulActivatorStragglerSplicesLiveVM(t *testing.T) {
+	port := statefulActivatorEchoServer(t)
+	s, _, driver := newStatefulTestServer(t)
+	listenPort := startStatefulActivator(t, s)
+	enableStatefulActivatorWorkload(s, "wl-state", listenPort, port)
+	s.statefulVMs.add(&statefulEntry{vmID: "already-live", workload: "wl-state", ip: net.ParseIP("127.0.0.1"), port: port})
+
+	conn := statefulActivatorConn(t, listenPort)
+	defer conn.Close()
+	statefulActivatorRoundTrip(t, conn, "live bytes")
+	if driver.claims != 0 || driver.restores != 0 {
+		t.Errorf("stateful wake calls = claims:%d restores:%d, want 0:0", driver.claims, driver.restores)
+	}
+}
+
+func TestStatefulActivatorRelightsLocalBundle(t *testing.T) {
+	port := statefulActivatorEchoServer(t)
+	s, _, driver := newStatefulTestServer(t)
+	listenPort := startStatefulActivator(t, s)
+	enableStatefulActivatorWorkload(s, "wl-state", listenPort, port)
+	addStatefulActivatorBundle(t, s, driver, "wl-state", "bundle-state")
+
+	conn := statefulActivatorConn(t, listenPort)
+	defer conn.Close()
+	statefulActivatorRoundTrip(t, conn, "relit bytes")
+	if driver.restores != 1 {
+		t.Errorf("RestoreStateful calls = %d, want 1", driver.restores)
+	}
+	if got := s.statefulVMsStatus()[0].GetOrigin(); got != nodev1.InstanceOrigin_INSTANCE_ORIGIN_ACTIVATOR {
+		t.Errorf("stateful origin = %v, want ACTIVATOR", got)
+	}
+}
+
+func TestStatefulActivatorSingleFlight(t *testing.T) {
+	port := statefulActivatorEchoServer(t)
+	s, _, driver := newStatefulTestServer(t)
+	listenPort := startStatefulActivator(t, s)
+	enableStatefulActivatorWorkload(s, "wl-state", listenPort, port)
+	addStatefulActivatorBundle(t, s, driver, "wl-state", "bundle-state")
+	driver.restoreStarted = make(chan struct{}, 1)
+	driver.releaseRestore = make(chan struct{})
+
+	const clients = 8
+	conns := make(chan net.Conn, clients)
+	for i := 0; i < clients; i++ {
+		conns <- statefulActivatorConn(t, listenPort)
+	}
+	<-driver.restoreStarted
+	close(driver.releaseRestore)
+	for i := 0; i < clients; i++ {
+		conn := <-conns
+		statefulActivatorRoundTrip(t, conn, "all clients")
+		_ = conn.Close()
+	}
+	if driver.restores != 1 {
+		t.Errorf("RestoreStateful calls = %d, want 1", driver.restores)
+	}
+}
+
+func TestStatefulActivatorGateClosesIneligiblePort(t *testing.T) {
+	s, _, driver := newStatefulTestServer(t)
+	listenPort := startStatefulActivator(t, s)
+	s.registry.sync([]workloadEntry{{Workload: "wl-state", NodeLocalWake: false, StatefulListenPort: listenPort}})
+	conn := statefulActivatorConn(t, listenPort)
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+	if _, err := conn.Read(make([]byte, 1)); err == nil {
+		t.Fatal("ineligible stateful activator connection stayed open")
+	}
+	if driver.claims != 0 || driver.restores != 0 {
+		t.Errorf("stateful wake calls = claims:%d restores:%d, want 0:0", driver.claims, driver.restores)
+	}
+}
+
+func TestStatefulActivatorAbortsCheckpointAndSplices(t *testing.T) {
+	port := statefulActivatorEchoServer(t)
+	s, _, driver := newStatefulTestServer(t)
+	listenPort := startStatefulActivator(t, s)
+	enableStatefulActivatorWorkload(s, "wl-state", listenPort, port)
+	started := startFreshStateful(t, s, port, "wl-state")
+	before, err := s.volumes.Generation("wl-state")
+	if err != nil {
+		t.Fatalf("generation before checkpoint: %v", err)
+	}
+	if _, err := s.StopStateful(context.Background(), &nodev1.StopStatefulRequest{
+		VmId: started.GetVmId(), Mode: nodev1.StopStatefulMode_STOP_STATEFUL_MODE_CHECKPOINT,
+	}); err != nil {
+		t.Fatalf("StopStateful(checkpoint): %v", err)
+	}
+
+	conn := statefulActivatorConn(t, listenPort)
+	defer conn.Close()
+	statefulActivatorRoundTrip(t, conn, "resumed bytes")
+	after, err := s.volumes.Generation("wl-state")
+	if err != nil {
+		t.Fatalf("generation after checkpoint abort: %v", err)
+	}
+	if after != before+1 {
+		t.Errorf("generation after checkpoint abort = %d, want %d", after, before+1)
+	}
+	if driver.resumes != 1 {
+		t.Errorf("ResolveStatefulAbort calls = %d, want 1", driver.resumes)
+	}
+}
+
+func TestStatefulActivatorAndControlPlaneOrigins(t *testing.T) {
+	port := statefulActivatorEchoServer(t)
+	s, _, driver := newStatefulTestServer(t)
+	listenPort := startStatefulActivator(t, s)
+	enableStatefulActivatorWorkload(s, "activator-workload", listenPort, port)
+	addStatefulActivatorBundle(t, s, driver, "activator-workload", "bundle-activator")
+
+	conn := statefulActivatorConn(t, listenPort)
+	statefulActivatorRoundTrip(t, conn, "activator origin")
+	_ = conn.Close()
+	if got := s.statefulVMsStatus()[0].GetOrigin(); got != nodev1.InstanceOrigin_INSTANCE_ORIGIN_ACTIVATOR {
+		t.Errorf("activator origin = %v, want ACTIVATOR", got)
+	}
+	if _, err := s.StopStateful(context.Background(), &nodev1.StopStatefulRequest{
+		VmId: s.statefulVMsStatus()[0].GetVmId(), Mode: nodev1.StopStatefulMode_STOP_STATEFUL_MODE_DESTROY,
+	}); err != nil {
+		t.Fatalf("StopStateful(destroy): %v", err)
+	}
+	startFreshStateful(t, s, port, "cp-workload")
+	for _, vm := range s.statefulVMsStatus() {
+		if vm.GetWorkload() == "cp-workload" && vm.GetOrigin() != nodev1.InstanceOrigin_INSTANCE_ORIGIN_CONTROL_PLANE {
+			t.Errorf("control-plane origin = %v, want CONTROL_PLANE", vm.GetOrigin())
+		}
+	}
+}

--- a/projects/embervm/noded/server/stateful_registry.go
+++ b/projects/embervm/noded/server/stateful_registry.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
+
 	"github.com/jomcgi/homelab/projects/embervm/noded/serving"
 	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
 )
@@ -93,6 +95,7 @@ type statefulEntry struct {
 	port       uint32
 	tap        string
 	generation uint64
+	origin     nodev1.InstanceOrigin
 	// snapshotRef is the stateful bundle this VM was RELIT from, or "" for a
 	// cold/fresh boot (which has no source snapshot). Mirrors servingEntry's
 	// snapshotRef, though R4 v1 does not add an in-use eviction guard on it
@@ -268,6 +271,20 @@ func (r *statefulRegistry) byWorkload(workload string) (*statefulEntry, bool) {
 	return nil, false
 }
 
+// byWorkloadCheckpoint returns the workload's live entry and its checkpoint
+// token under the registry lock, so the activator can decide whether it must
+// claim and abort a paused checkpoint before splicing.
+func (r *statefulRegistry) byWorkloadCheckpoint(workload string) (*statefulEntry, string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, e := range r.vms {
+		if e.workload == workload {
+			return e, e.checkpointToken, true
+		}
+	}
+	return nil, "", false
+}
+
 // snapshotRefInUse reports whether any LIVE stateful VM was relit from the given
 // stateful bundle ref, i.e. the bundle is still needed by a running guest that
 // resumed from it. It is the in-use guard for a local STATEFUL eviction (#38):
@@ -301,6 +318,7 @@ type statefulView struct {
 	healthy         bool
 	lastProbeUnixMs int64
 	generation      uint64
+	origin          nodev1.InstanceOrigin
 	// checkpointPending + checkpointToken report a VM PAUSED awaiting a resolve
 	// (ADR embervm/008) so a restarted control plane adopts and resolves it.
 	checkpointPending bool
@@ -320,6 +338,7 @@ func (r *statefulRegistry) snapshot() []statefulView {
 			ip:                e.ip.String(),
 			port:              e.port,
 			generation:        e.generation,
+			origin:            e.origin,
 			checkpointPending: e.checkpointToken != "",
 			checkpointToken:   e.checkpointToken,
 		}

--- a/projects/embervm/noded/server/stateful_test.go
+++ b/projects/embervm/noded/server/stateful_test.go
@@ -25,9 +25,11 @@ import (
 // banks/relights stateful VMs in memory, recording the volume path and the
 // generation each bank was stamped with, mirroring fakeServingDriver's shape.
 type fakeStatefulDriver struct {
-	mu     sync.Mutex
-	live   int
-	claims int
+	mu       sync.Mutex
+	live     int
+	claims   int
+	restores int
+	resumes  int
 	// banked maps snapshotRef -> the generation it was stamped with.
 	banked       map[string]uint64
 	statefulDir  string
@@ -44,7 +46,9 @@ type fakeStatefulDriver struct {
 	failResume     error
 	// pinnedIPs maps a banked snapshotRef -> the tap IP it was banked with, so a
 	// test can assert relight re-pins it (ADR embervm/008 relight IP fix).
-	pinnedIPs map[string]string
+	pinnedIPs      map[string]string
+	restoreStarted chan struct{}
+	releaseRestore chan struct{}
 }
 
 type fakeCheckpoint struct {
@@ -93,11 +97,25 @@ func (f *fakeStatefulDriver) StatefulPinnedIP(snapshotRef string) string {
 
 func (f *fakeStatefulDriver) RestoreStateful(_ context.Context, snapshotRef, _ string) (substrate.Handle, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	if _, ok := f.banked[snapshotRef]; !ok {
+		f.mu.Unlock()
 		return substrate.Handle{}, status.Errorf(codes.FailedPrecondition, "no such banked stateful snapshot %q", snapshotRef)
 	}
+	started, release := f.restoreStarted, f.releaseRestore
+	f.mu.Unlock()
+	if started != nil {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+	}
+	if release != nil {
+		<-release
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.live++
+	f.restores++
 	return substrate.Handle{ID: "relit-" + snapshotRef, ThreadID: "t-relit", Node: "node-4"}, nil
 }
 
@@ -167,6 +185,7 @@ func (f *fakeStatefulDriver) ResolveStatefulAbort(_ context.Context, token strin
 		}
 		return f.failResume
 	}
+	f.resumes++
 	return nil
 }
 

--- a/projects/embervm/proto/embervm/node/v1/fakenode/main.go
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/main.go
@@ -445,6 +445,9 @@ func (s *fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusR
 				Healthy:         true,
 				Generation:      5,
 				LastProbeUnixMs: 1_700_000_003_000,
+				// origin (ADR embervm/018 Phase 2): a node-woken stateful VM the
+				// control plane adopts (fenced-writer adoption trusts its generation).
+				Origin: nodev1.InstanceOrigin_INSTANCE_ORIGIN_ACTIVATOR,
 			},
 			// A second VM PAUSED awaiting a resolve (ADR embervm/008), so the
 			// client can assert the checkpoint_pending inventory fields adoption

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -1210,6 +1210,37 @@ message RegistryEntry {
   // cold boot on (StartServingRequest.health_path today). Empty falls back to the
   // daemon default ready path, exactly as StartServing does.
   string serving_health_path = 9;
+
+  // -- Node-local stateful activator fields (ADR embervm/018 Fork A Phase 2) ----
+  // What the brick's node-local L4 activator needs to RELIGHT (or COLD-boot) a
+  // scaled-to-zero stateful workload without the control plane (which supplies
+  // these per-call in StartStatefulRequest today). The activator resolves the
+  // banked bundle from its OWN local inventory (by workload) and self-bumps the
+  // generation; the fenced-writer anchor-adoption rule (ADR embervm/014) trusts
+  // that generation on CP return, so no delegated grant is carried (Fork A). All
+  // wire-compatible with a control plane that predates them (0/empty == not
+  // node-local-wakeable for stateful; node_local_wake (field 7) is the shared,
+  // class-agnostic gate).
+
+  // stateful_listen_port is the L4 port the brick activator binds AND resolves the
+  // workload by (the workload's stateful.listenPort; opaque L4 has no header, so
+  // the accept port IS the identity, mirroring the CP tcp_activator). Required for
+  // a node_local_wake stateful workload.
+  uint32 stateful_listen_port = 10;
+  // stateful_port is the guest TCP port the relit VM serves on over its tap
+  // (StartStatefulRequest.port today), health-gated by TCP CONNECT.
+  uint32 stateful_port = 11;
+  // stateful_volume_mount is the guest mount path (StartStatefulRequest.volume_mount).
+  string stateful_volume_mount = 12;
+  // stateful_boot_image_ref is the cold-boot source for the COLD fallback when the
+  // banked bundle is absent (StartStatefulRequest.boot_image_ref). The RELIGHT path
+  // resolves the bundle from local inventory and never needs this.
+  string stateful_boot_image_ref = 13;
+  // stateful_volume_device is the resolved host block-device path (e.g.
+  // /dev/longhorn/<name>) for the workload's Longhorn-native volume
+  // (StartStatefulRequest.volume_device). Empty means the legacy vol.img lane
+  // (VolumeRoot/<workload>/vol.img), exactly as StartStateful falls back.
+  string stateful_volume_device = 14;
 }
 
 // SyncRegistryRequest carries the AUTHORITATIVE full workload set the daemon must

--- a/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
+++ b/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
@@ -577,6 +577,9 @@ defmodule Embervm.NodeRoundtripTest do
     # A live VM is never checkpoint-pending.
     assert vm.checkpoint_pending == false
     assert vm.checkpoint_token == ""
+    # origin (ADR embervm/018 Phase 2): a node-woken stateful VM reports ACTIVATOR
+    # so the control plane adopts it (fenced-writer adoption trusts its generation).
+    assert vm.origin == :INSTANCE_ORIGIN_ACTIVATOR
 
     # The second VM is PAUSED awaiting a resolve (ADR embervm/008): adoption reads
     # checkpoint_pending + the token to resolve a stranded checkpoint.


### PR DESCRIPTION
## What

Phase 2 (Fork A, stateful lane) of the embervm node-local activator, per ADR embervm/018 and #3993. A scaled-to-zero **stateful** demo (scratch-postgres) now relights on the brick and survives a control-plane roll: a `psql` that arrives while the CP is rolling cold-boots on the anchor brick instead of black-holing on the dead CP-pod L4 activator.

## The scoping result: no grant (Option A, approved)

ADR 018 prescribes a delegated blessing grant so the CP trusts a brick-advanced generation. **Scoping found it redundant in Fork A:** the CP's existing fenced-writer adoption (ADR 014, `update_quarantine`) already trusts a forward generation from the volume's *anchor* node, and a brick-relit VM is on the anchor by construction (the volume lives there). CP-side idle-banking also caps advancement at ~1/gap. The grant becomes load-bearing only in Fork B (node-local banking → per-request advancement). So Phase 2 reuses the fenced-writer + ADR-017 checkpoint-auto-heal logic for generation trust and carries **no grant, no `wake_grant` op, no delegation protocol** — the safety-critical machinery is avoided entirely, per ADR 018's own claim that grant width is anomaly-detection, never exclusion. Exclusion stays the physical single-writable-attach fence.

## Changes

- **Proto:** `RegistryEntry` stateful boot params; `StatefulVm.origin` round-trip coverage (field added in Phase 0).
- **noded:** opaque-L4 stateful activator (per-port listeners over 5400-5409, workload-by-accept-port, straggler splice, single-flight relight via the internal `startStateful` path, checkpoint abort-and-splice, bidirectional TCP splice, `origin: ACTIVATOR`). Self-bump allowed under `RequireBlessing` for an activator attach.
- **control:** `StatefulManager` adopts `origin: ACTIVATOR` VMs by relighting the banked instance (reusing `finish_relit`, keyed by workload) and skips them in orphan-destroy; generation trust unchanged (fenced-writer). `EndpointPublisher` L4 fallback prefers the volume's **anchor** node's advertised activator. Catalog `nodeLocalWake`/`meteringFailOpen` + registry push.
- **chart:** CRD `stateful.nodeLocalWake`/`meteringFailOpen`; scratch-postgres opts in; bump 0.1.226.

## Verify

- CI green.
- Drill: let scratch-postgres idle-bank to zero, delete the CP pod, `psql` during the gap → relights on the brick; confirm the returning CP re-adopts (fenced-writer trusts the forward gen, no orphan-destroy). Pair-broken drill confirms a *non-anchor* ungranted gen still quarantines (fail-closed unchanged).

## Out of scope

Composite lane (Phase 3) and all of Fork B (node-local banking + the grant, which lands there when it is load-bearing).

Refs #3993, ADR embervm/018

🤖 Generated with [Claude Code](https://claude.com/claude-code)