### PR TITLE
fix(embervm): stateful activator resolves boot_image_ref locally (COLD path)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.226
+version: 0.1.227

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.226
+      targetRevision: 0.1.227
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/registry.go
+++ b/projects/embervm/noded/server/registry.go
@@ -397,6 +397,28 @@ func (b *baseRegistry) get(ref string) (baseEntry, bool) {
 	return *e, true
 }
 
+// readyByWorkload returns the snapshot_ref of a READY base for the workload, so
+// the node-local stateful activator can resolve boot_image_ref itself (the
+// control plane supplies it per-call in StartStatefulRequest, but the activator
+// has no control plane during a gap). The base key is node-local, so it cannot
+// ride the global workload registry; the daemon owns it here, exactly as the
+// serving activator resolves its serving image from its own inventory. On more
+// than one READY base for a workload (a mid-turnover overlap) the lexically
+// greatest ref wins, deterministically.
+func (b *baseRegistry) readyByWorkload(workload string) (string, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	best := ""
+	for ref, e := range b.bases {
+		if e.workload == workload && e.state == nodev1.BaseBuildState_BASE_BUILD_STATE_READY {
+			if best == "" || ref > best {
+				best = ref
+			}
+		}
+	}
+	return best, best != ""
+}
+
 // beginBuild marks a base BUILDING. It returns false if a build for this key is
 // already in progress (BUILDING), so BuildBase serializes per key without
 // blocking. A READY or FAILED entry is re-driven (a rebuild after failure, or a

--- a/projects/embervm/noded/server/stateful_activator.go
+++ b/projects/embervm/noded/server/stateful_activator.go
@@ -215,10 +215,19 @@ func (a *statefulActivator) wake(ctx context.Context, reg workloadEntry) (*state
 		return resumed, nil
 	}
 
+	// Resolve boot_image_ref from the daemon's OWN base registry by workload (the
+	// control plane supplies it per-call today, but the activator has no control
+	// plane during a gap; the base key is node-local so it cannot ride the global
+	// workload registry). Threaded into BOTH modes so a RELIGHT that falls back to
+	// a cold boot (generation mismatch or an unreadable ledger) still has a base.
+	// A COLD wake with no ready base fails cleanly (the workload stays dark until
+	// the control plane returns), the accepted node-local degradation.
+	bootImageRef, _ := a.server.bases.readyByWorkload(reg.Workload)
+
 	req := &nodev1.StartStatefulRequest{
 		Trace:             &nodev1.Trace{Workload: reg.Workload},
 		Port:              reg.StatefulPort,
-		BootImageRef:      reg.StatefulBootImageRef,
+		BootImageRef:      bootImageRef,
 		VolumeMount:       reg.StatefulVolumeMount,
 		VolumeDevice:      reg.StatefulVolumeDevice,
 		BlessedGeneration: 0,

--- a/projects/embervm/noded/server/stateful_activator_test.go
+++ b/projects/embervm/noded/server/stateful_activator_test.go
@@ -103,6 +103,35 @@ func addStatefulActivatorBundle(t *testing.T, s *Server, driver *fakeStatefulDri
 	s.statefulBundles.add(statefulBundleEntry{snapshotRef: ref, workload: workload, generation: 0})
 }
 
+func TestStatefulActivatorColdBootResolvesBaseLocally(t *testing.T) {
+	port := statefulActivatorEchoServer(t)
+	s, _, driver := newStatefulTestServer(t)
+	listenPort := startStatefulActivator(t, s)
+	enableStatefulActivatorWorkload(s, "wl-state", listenPort, port)
+	// A volume exists but there is NO banked bundle, so the activator must COLD-boot.
+	// The COLD path needs boot_image_ref, which the control plane does not push (it
+	// is node-local); the activator resolves it from the daemon's own base registry
+	// (readyByWorkload). The harness seeds a READY base "img-a" for "wl-state".
+	if err := s.volumes.Create("wl-state", 1<<20); err != nil {
+		t.Fatalf("create stateful volume: %v", err)
+	}
+
+	conn := statefulActivatorConn(t, listenPort)
+	defer conn.Close()
+	statefulActivatorRoundTrip(t, conn, "cold-hello")
+
+	driver.mu.Lock()
+	claims := driver.claims
+	driver.mu.Unlock()
+	if claims != 1 {
+		t.Errorf("ClaimStateful calls = %d, want 1 (one cold boot)", claims)
+	}
+	status := s.statefulVMsStatus()
+	if len(status) != 1 || status[0].GetOrigin() != nodev1.InstanceOrigin_INSTANCE_ORIGIN_ACTIVATOR {
+		t.Errorf("expected one ACTIVATOR-origin stateful VM, got %+v", status)
+	}
+}
+
 func TestStatefulActivatorStragglerSplicesLiveVM(t *testing.T) {
 	port := statefulActivatorEchoServer(t)
 	s, _, driver := newStatefulTestServer(t)


### PR DESCRIPTION
## What

Phase 2 (#3997) drill follow-up: the node-local stateful activator's COLD path could not wake a fully-cold (destroyed, no banked bundle) workload.

## Why (drill finding)

`coldBootStateful` **requires** a non-empty `boot_image_ref` (`"boot_image_ref required"`). The activator left it empty (the CP supplies it per-call, and the base key is node-local so it can't ride the global workload registry). Because the Phase 2 publisher now routes a cold stateful workload's L4 fallback to the **node** activator, this regressed the cold-from-destroyed wake vs the pre-Phase-2 CP-activator path (which resolves `boot_image_ref` CP-side). Found by inspecting the live 0.1.226 rollout: scratch-postgres was fully cold (no bundle, only its volume on node-4), so the drill's relight would have hit the broken COLD path.

## Fix

`baseRegistry.readyByWorkload(workload)` resolves the workload's READY base key from noded's own inventory; the activator threads it into the `StartStateful` request for **both** modes (so a RELIGHT that falls back to COLD also has a base). A COLD wake with no ready base still fails cleanly (workload stays dark until the CP returns, the accepted node-local degradation). The RELIGHT path (bundle present) is unchanged. Mirrors how the serving activator resolves its serving image locally. Chart bumped 0.1.227.

Test: `TestStatefulActivatorColdBootResolvesBaseLocally` — no bundle, volume present → the activator cold-boots once via the locally-resolved base and reports an ACTIVATOR-origin VM.

Refs #3993, ADR embervm/018

🤖 Generated with [Claude Code](https://claude.com/claude-code)