### PR TITLE
fix(embervm): group create/wake probes every capable node, not just the first

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.228
+version: 0.1.229

--- a/projects/embervm/control/lib/embervm/group_manager/supervisor.ex
+++ b/projects/embervm/control/lib/embervm/group_manager/supervisor.ex
@@ -280,28 +280,51 @@ defmodule Embervm.GroupManager.Supervisor do
   # {:error, :no_capacity} (no group-capable node) / {:error, :no_eligible_instance}
   # (a node exists but no instance on it can host the group).
   defp anchor_instance(capacity_table, entry, workload, group_instance_id) do
+    need_mib = group_mem_mib(entry)
+    select_opts = [table: capacity_table, workload: workload, need_mib: need_mib] ++ warmth_opts(group_instance_id)
+
     NodeCapacity.all(capacity_table)
     |> Enum.filter(&group_capable?/1)
     |> case do
       [] ->
         {:error, :no_capacity}
 
-      [fact | _] ->
-        node_id = fact.configured_id
-
-        select_opts =
-          [
-            table: capacity_table,
-            workload: workload,
-            need_mib: group_mem_mib(entry)
-          ] ++ warmth_opts(group_instance_id)
-
-        case Embervm.WakeInstance.select(node_id, select_opts) do
-          {:ok, dial_id} -> {:ok, node_id, dial_id}
-          {:error, reason} -> {:error, reason}
-        end
+      facts ->
+        # Try EVERY group-capable node, warmth-matching nodes first, and take the
+        # first whose per-node select fits the group's total member memory + base.
+        # The prior code probed only the FIRST group-capable node, so a small brick
+        # sorted ahead of the only node large enough (the fleet's 2Gi co-located
+        # bricks vs a ~10Gi composite) failed the whole create/wake with
+        # :no_eligible_instance without ever trying the big node. Warmth ordering is
+        # preserved so a wake/adopt still relights on the node holding the banked set.
+        facts
+        |> prefer_warm_nodes(group_instance_id)
+        |> Enum.uniq_by(& &1.configured_id)
+        |> Enum.find_value({:error, :no_eligible_instance}, fn fact ->
+          case Embervm.WakeInstance.select(fact.configured_id, select_opts) do
+            {:ok, dial_id} -> {:ok, fact.configured_id, dial_id}
+            {:error, _reason} -> false
+          end
+        end)
     end
   end
+
+  # Order group-capable node facts so any node already reporting the banked group's
+  # SET (its group_bundle_sets carries group_instance_id) is tried before cold nodes,
+  # so a wake/adopt relights on the anchor instead of cold-booting elsewhere. A fresh
+  # CREATE (nil id) has no owning set, so the order is left unchanged.
+  defp prefer_warm_nodes(facts, group_instance_id) when is_binary(group_instance_id) and group_instance_id != "" do
+    {warm, cold} =
+      Enum.split_with(facts, fn fact ->
+        fact
+        |> Map.get(:group_bundle_sets, [])
+        |> Enum.any?(fn set -> Map.get(set, :group_instance_id) == group_instance_id end)
+      end)
+
+    warm ++ cold
+  end
+
+  defp prefer_warm_nodes(facts, _group_instance_id), do: facts
 
   # Warmth selection for a wake/bank/adopt (the banked instance's set): match the
   # node's group_bundle_sets by the group_instance_id the set is keyed on. A fresh

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.228
+      targetRevision: 0.1.229
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Problem (found during the Phase 3 composite-relight drill)

`GroupManager.Supervisor.anchor_instance` selected the node for a composite create/wake/adopt by taking only the **first** group-capable node fact (`[fact | _]`) and running `WakeInstance.select` against it. Once the fleet gained small co-located bricks (2Gi) that sort ahead of the large node in `NodeCapacity.all`, a composite whose member memory sum exceeds the small brick failed the entire create with `:no_eligible_instance` **without ever trying the node that fits**.

scratch-k8s needs `server 4096 + agent 3072 = 7168 MiB`. Live confirmation:
- `WakeInstance.select("node-2" /* 2Gi, sorts first */, need_mib: 7168)` -> `{:error, :no_eligible_instance}`
- `WakeInstance.select("node-4" /* 16Gi */, need_mib: 7168)` -> `{:ok, dial}`
- `anchor_instance` picked node-2 and stopped.

This silently made scratch-k8s (and any group larger than the smallest brick) uncreatable, which blocks the node-local composite relight drill: no banked set can exist without a first create.

## Fix

Iterate **every** group-capable node, warmth-matching nodes first, and take the first whose per-node `select` fits the group's total member memory + base. `prefer_warm_nodes` keeps a wake/adopt relighting on the node holding the banked set (its `group_bundle_sets` carries the `group_instance_id`) rather than cold-booting on an earlier-sorted node. The `no_capacity` (none group-capable) vs `no_eligible_instance` (capable but none fits) distinction is preserved.

## Testing

Verified live on the cluster via CP rpc (the select results above), and the acceptance is the node-local composite relight drill on the rolled-out build: the first scratch-k8s create is the direct exercise of this path. The `GroupManager.Supervisor` has no existing unit harness (its tests drive the per-instance `GroupManager`); building one is out of scope for this one-function fix given the live + drill validation.

Unblocks the ADR 018 Phase 3 drill (PR #4000). Pre-existing bug, orthogonal to Phase 3, exposed by the fleet's 2Gi bricks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)