### PR TITLE
fix(embervm): complete node-local group relight (deadline + ready budget + CP fallback)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.229
+version: 0.1.230

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -131,7 +131,7 @@ defmodule Embervm.Application do
       # it) and after WorkloadWatcher; it dials the daemon directly over its own
       # Mint gRPC connection, so it does not depend on the Finch pool. With no node
       # wired (empty address), it supervises an empty node list and does nothing.
-      {Embervm.NodeRegistry, nodes: configured_nodes()},
+      {Embervm.NodeRegistry, node_registry_opts()},
       # The shared per-node gRPC channel holder (Task 11): one long-lived, reused
       # Mint channel per node for the Prime/Assign hot path (unlike NodeRegistry/
       # BaseBuilder, which each own their own channel and can afford a per-op
@@ -753,6 +753,13 @@ defmodule Embervm.Application do
       activator_endpoint: activator_endpoint(),
       activator_ip: stateful_activator_ip()
     ] ++ repush_opt()
+  end
+
+  defp node_registry_opts do
+    [
+      nodes: configured_nodes(),
+      control_plane_activator_ip: stateful_activator_ip()
+    ]
   end
 
   # The activator endpoint the node Envoy routes to when a serving workload has no

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -229,11 +229,14 @@ defmodule Embervm.NodeRegistry do
     watch_fun = Keyword.get(opts, :watch_fun, &default_watch/3)
     disconnect_fun = Keyword.get(opts, :disconnect_fun, &default_disconnect/1)
     # Artifact-decoupling Phase 2: the on-(re)connect registry replay seam. The
-    # default reads the control plane's workload view (WorkloadCatalog + the
-    # chart-delivered node-side image identity) and pushes SyncRegistry over the
-    # just-connected channel. Tests inject a fake to assert the replay fires (and
-    # with what entries) without a real daemon or catalog.
-    sync_registry_fun = Keyword.get(opts, :sync_registry_fun, &default_sync_registry/2)
+    # default pushes the constructed SyncRegistry envelope over the just-connected
+    # channel. Tests inject a fake to assert the replay fires (and with what
+    # entries) without a real daemon or catalog.
+    sync_registry_fun = Keyword.get(opts, :sync_registry_fun, &default_sync_registry/3)
+    # ADR embervm/018 Phase 3: when a brick cannot complete a node-local group
+    # relight, it forwards the held connection to the control plane's own L4
+    # activator. This is the CP address, never a daemon-advertised activator_ip.
+    control_plane_activator_ip = Keyword.get(opts, :control_plane_activator_ip, "") || ""
     clock = Keyword.get(opts, :clock, &default_clock/0)
     reassign_fun = Keyword.get(opts, :reassign_fun, &default_reassign/1)
     unknown_after = Keyword.get(opts, :unknown_after_ms, @unknown_after_ms)
@@ -296,6 +299,7 @@ defmodule Embervm.NodeRegistry do
       watch_fun: watch_fun,
       disconnect_fun: disconnect_fun,
       sync_registry_fun: sync_registry_fun,
+      control_plane_activator_ip: control_plane_activator_ip,
       reassign_fun: reassign_fun,
       unknown_after_ms: unknown_after,
       down_after_ms: down_after,
@@ -425,7 +429,7 @@ defmodule Embervm.NodeRegistry do
         case connect_fun.(address) do
           {:ok, channel} ->
             try do
-              sync_registry_fun.(channel, node_id)
+              sync_registry(sync_registry_fun, channel, node_id, state.control_plane_activator_ip)
             after
               disconnect_fun.(channel)
             end
@@ -1085,7 +1089,7 @@ defmodule Embervm.NodeRegistry do
                 # reconnect. A push failure is logged and non-fatal (the daemon
                 # simply stays not-ready and the next reconnect retries); we still
                 # enter the watch so capacity facts flow either way.
-                sync_registry_fun.(channel, configured_id)
+                sync_registry(sync_registry_fun, channel, configured_id, state.control_plane_activator_ip)
 
                 watch_fun.(channel, configured_id, fn status ->
                   send(owner, {:node_status, streamer, status})
@@ -1509,10 +1513,8 @@ defmodule Embervm.NodeRegistry do
   # or an EXIT is caught and logged too. The daemon simply stays not-ready and the
   # next reconnect retries; crashing the streamer here would take down capacity
   # reporting for the node, which is strictly worse than a missed replay.
-  defp default_sync_registry(channel, node_id) do
-    entries = registry_entries()
-
-    case NodeService.Stub.sync_registry(channel, %SyncRegistryRequest{entries: entries}) do
+  defp default_sync_registry(channel, node_id, request) do
+    case NodeService.Stub.sync_registry(channel, request) do
       {:ok, %{entry_count: n}} ->
         Logger.info("embervm node registry: replayed #{n} workload registry entries to #{node_id}")
         :ok
@@ -1529,6 +1531,25 @@ defmodule Embervm.NodeRegistry do
     kind, reason ->
       Logger.warning("embervm node registry: SyncRegistry to #{node_id} exited: #{inspect({kind, reason})}")
       :ok
+  end
+
+  defp sync_registry(sync_registry_fun, channel, node_id, control_plane_activator_ip) do
+    sync_registry_fun.(channel, node_id, sync_registry_request(control_plane_activator_ip))
+  rescue
+    e ->
+      Logger.warning("embervm node registry: SyncRegistry to #{node_id} raised: #{inspect(e)}")
+      :ok
+  catch
+    kind, reason ->
+      Logger.warning("embervm node registry: SyncRegistry to #{node_id} exited: #{inspect({kind, reason})}")
+      :ok
+  end
+
+  defp sync_registry_request(control_plane_activator_ip) do
+    %SyncRegistryRequest{
+      entries: registry_entries(),
+      control_plane_activator_ip: control_plane_activator_ip
+    }
   end
 
   # Build the authoritative RegistryEntry set from the control plane's workload
@@ -1636,6 +1657,7 @@ defmodule Embervm.NodeRegistry do
     entry = Map.get(group, :entry, %{})
     entry_member = Map.get(entry, :member)
     entry_port = Map.get(entry, :port) || 0
+    ready_budget_seconds = Map.get(group, :wake_timeout_seconds) || 0
 
     group
     |> Map.get(:members, [])
@@ -1648,7 +1670,8 @@ defmodule Embervm.NodeRegistry do
         start_order: member.start_order,
         health_port: member.health_port,
         entry_guest_port: if(member.name == entry_member, do: entry_port, else: 0),
-        sizing: %ResourceSpec{vcpus: member.vcpus, mem_mib: member.mem_mib}
+        sizing: %ResourceSpec{vcpus: member.vcpus, mem_mib: member.mem_mib},
+        ready_budget_seconds: ready_budget_seconds
       }
     end)
   end

--- a/projects/embervm/control/test/embervm/node_registry_test.exs
+++ b/projects/embervm/control/test/embervm/node_registry_test.exs
@@ -12,7 +12,7 @@ defmodule Embervm.NodeRegistryTest do
   # test), proving connect -> emit -> ETS publish -> reconnect-on-drop.
   use ExUnit.Case, async: true
 
-  alias Embervm.NodeRegistry
+  alias Embervm.{NodeRegistry, WorkloadCatalog}
   alias Embervm.Node.V1.{GroupMemberVm, NodeStatus, WorkloadCapacity}
 
   # -- helpers ---------------------------------------------------------------
@@ -263,7 +263,7 @@ defmodule Embervm.NodeRegistryTest do
         # Stub the registry replay: the real default dials NodeService.Stub over
         # the fake channel, which is not a real gRPC channel. The replay is not
         # under test here (see the dedicated reconnect-replays-registry test).
-        sync_registry_fun: fn :fake_channel, _id -> :ok end,
+        sync_registry_fun: fn :fake_channel, _id, _request -> :ok end,
         disconnect_fun: fn :fake_channel -> :ok end,
         # Small backoff so the reconnect fires quickly; large age-out so the
         # real-time ticks do not race the assertions.
@@ -311,7 +311,7 @@ defmodule Embervm.NodeRegistryTest do
         watch_fun: watch_fun,
         # Stub the registry replay: the real default dials NodeService.Stub over
         # the fake channel (not a real gRPC channel); the replay is not under test.
-        sync_registry_fun: fn :fake_channel, _id -> :ok end,
+        sync_registry_fun: fn :fake_channel, _id, _request -> :ok end,
         disconnect_fun: fn :fake_channel -> :ok end,
         reassign_fun: fn id -> send(test_pid, {:reassigned, id}) end,
         # Small age-out windows and backoff so the wedge is detected and the kill
@@ -344,7 +344,7 @@ defmodule Embervm.NodeRegistryTest do
     # Record each replay (channel, node_id) and let the streamer proceed. The
     # sync_registry_fun is the seam the production default reads the catalog and
     # calls SyncRegistry through; here we just assert it fires on each connect.
-    sync_registry_fun = fn :fake_channel, node_id ->
+    sync_registry_fun = fn :fake_channel, node_id, _request ->
       Agent.update(syncs, &[node_id | &1])
       send(test_pid, {:replayed, node_id})
       :ok
@@ -385,7 +385,7 @@ defmodule Embervm.NodeRegistryTest do
     on_exit(fn -> if Process.alive?(syncs), do: Agent.stop(syncs) end)
     test_pid = self()
 
-    sync_registry_fun = fn :fake_channel, node_id ->
+    sync_registry_fun = fn :fake_channel, node_id, _request ->
       n = Agent.get_and_update(syncs, fn c -> {c + 1, c + 1} end)
       send(test_pid, {:synced, node_id, n})
       :ok
@@ -421,6 +421,75 @@ defmodule Embervm.NodeRegistryTest do
     assert_receive {:synced, "node-4", 3}, 1_000
   end
 
+  test "a node-local-wake composite registry plan carries the group's ready budget" do
+    workload = "registry-group-#{System.unique_integer([:positive])}"
+
+    WorkloadCatalog.upsert(WorkloadCatalog.table(), workload, %{
+      image_ref: "registry-group-image",
+      vcpus: 2,
+      mem_mib: 1024,
+      group: %{
+        node_local_wake: true,
+        wake_timeout_seconds: 47,
+        entry: %{member: "api", port: 8080, listen_port: 5410},
+        members: [
+          %{name: "api", start_order: 10, health_port: 8080, vcpus: 2, mem_mib: 1024},
+          %{name: "worker", replicas: 2, start_order: 20, health_port: 9090, vcpus: 1, mem_mib: 512}
+        ]
+      }
+    })
+
+    on_exit(fn -> WorkloadCatalog.drop(WorkloadCatalog.table(), workload) end)
+    test_pid = self()
+
+    {_reg, _table} =
+      start_registry(
+        watch_startup: true,
+        connect_fun: fn _address -> {:ok, :fake_channel} end,
+        watch_fun: blocking_watch(),
+        sync_registry_fun: fn :fake_channel, "node-4", request ->
+          send(test_pid, {:registry_sync, request})
+          :ok
+        end,
+        disconnect_fun: fn :fake_channel -> :ok end,
+        age_check_ms: 60_000,
+        unknown_after_ms: 60_000,
+        down_after_ms: 60_000
+      )
+
+    assert_receive {:registry_sync, request}, 1_000
+    entry = Enum.find(request.entries, &(&1.workload == workload))
+
+    assert Enum.map(entry.group_member_plan, & &1.member_name) == ["api", "worker-0", "worker-1"]
+    assert Enum.all?(entry.group_member_plan, &(&1.ready_budget_seconds == 47))
+  end
+
+  test "SyncRegistry carries the configured control-plane activator IP, or empty when unset" do
+    test_pid = self()
+
+    sync_registry_fun = fn :fake_channel, node_id, request ->
+      send(test_pid, {:registry_sync, node_id, request})
+      :ok
+    end
+
+    registry_opts = [
+      watch_startup: true,
+      connect_fun: fn _address -> {:ok, :fake_channel} end,
+      watch_fun: blocking_watch(),
+      sync_registry_fun: sync_registry_fun,
+      disconnect_fun: fn :fake_channel -> :ok end,
+      age_check_ms: 60_000,
+      unknown_after_ms: 60_000,
+      down_after_ms: 60_000
+    ]
+
+    {_configured, _table} = start_registry(Keyword.put(registry_opts, :control_plane_activator_ip, "10.0.0.12"))
+    assert_receive {:registry_sync, "node-4", %{control_plane_activator_ip: "10.0.0.12"}}, 1_000
+
+    {_unset, _table} = start_registry(registry_opts)
+    assert_receive {:registry_sync, "node-4", %{control_plane_activator_ip: ""}}, 1_000
+  end
+
   # -- dial-home registration (R0 PR-2) --------------------------------------
 
   # A watch that stays open (blocks) so a per-instance streamer persists and the
@@ -439,7 +508,7 @@ defmodule Embervm.NodeRegistryTest do
         nodes: [],
         connect_fun: fn _addr -> {:ok, :fake_channel} end,
         watch_fun: blocking_watch(),
-        sync_registry_fun: fn _ch, _id -> :ok end,
+        sync_registry_fun: fn _ch, _id, _request -> :ok end,
         disconnect_fun: fn :fake_channel -> :ok end,
         channel_updater_fun: fn _id, _addr -> :ok end,
         age_check_ms: 60_000,

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.229
+      targetRevision: 0.1.230
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/activator.go
+++ b/projects/embervm/noded/server/activator.go
@@ -297,3 +297,34 @@ func allowedHeaders(headers http.Header) http.Header {
 	}
 	return allowed
 }
+
+func spliceTCP(ctx context.Context, client net.Conn, address string) error {
+	guest, err := (&net.Dialer{}).DialContext(ctx, "tcp", address)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	defer guest.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		pumpTCP(guest, client)
+	}()
+	go func() {
+		defer wg.Done()
+		pumpTCP(client, guest)
+	}()
+	wg.Wait()
+	return nil
+}
+
+func pumpTCP(dst, src net.Conn) {
+	_, _ = io.Copy(dst, src)
+	if conn, ok := dst.(*net.TCPConn); ok {
+		_ = conn.CloseWrite()
+		return
+	}
+	_ = dst.Close()
+}

--- a/projects/embervm/noded/server/group_activator.go
+++ b/projects/embervm/noded/server/group_activator.go
@@ -124,8 +124,13 @@ func (a *groupActivator) handle(ctx context.Context, conn net.Conn, listenPort u
 		_ = conn.Close()
 		return
 	}
-	if flight.err != nil || flight.entry == nil {
+	if flight.err != nil {
 		a.server.logger.Warn("group activator: wake failed", "workload", reg.Workload, "err", flight.err)
+		a.forwardToControlPlane(ctx, conn, listenPort)
+		return
+	}
+	if flight.entry == nil {
+		a.server.logger.Warn("group activator: wake returned no entry", "workload", reg.Workload)
 		_ = conn.Close()
 		return
 	}
@@ -237,21 +242,7 @@ func (a *groupActivator) wake(ctx context.Context, reg workloadEntry) (*groupMem
 		for _, member := range members[first:last] {
 			member := member
 			go func() {
-				resp, startErr := a.server.startGroupMember(ctx, &nodev1.StartGroupMemberRequest{
-					Trace:           &nodev1.Trace{Workload: reg.Workload},
-					Mode:            nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_RELIGHT,
-					GroupInstanceId: groupInstanceID,
-					MemberName:      member.plan.MemberName,
-					MemberIndex:     member.plan.MemberIndex,
-					Ip:              member.bundle.pinnedIP,
-					SnapshotRef:     member.bundle.snapshotRef,
-					HealthPort:      member.plan.HealthPort,
-					Resources: &nodev1.ResourceSpec{
-						Vcpus:  member.plan.VCPUs,
-						MemMib: member.plan.MemMib,
-					},
-					EntryGuestPort: member.plan.EntryGuestPort,
-				}, nodev1.InstanceOrigin_INSTANCE_ORIGIN_ACTIVATOR)
+				resp, startErr := a.server.startGroupMember(ctx, groupActivatorRelightRequest(reg.Workload, groupInstanceID, member), nodev1.InstanceOrigin_INSTANCE_ORIGIN_ACTIVATOR)
 				results <- result{member: member, resp: resp, err: startErr}
 			}()
 		}
@@ -281,6 +272,25 @@ func (a *groupActivator) wake(ctx context.Context, reg workloadEntry) (*groupMem
 		return nil, fmt.Errorf("noded: relit group %q has no live entry member", groupInstanceID)
 	}
 	return entry, nil
+}
+
+func groupActivatorRelightRequest(workload, groupInstanceID string, member groupRelightMember) *nodev1.StartGroupMemberRequest {
+	return &nodev1.StartGroupMemberRequest{
+		Trace:              &nodev1.Trace{Workload: workload},
+		Mode:               nodev1.StartGroupMemberMode_START_GROUP_MEMBER_MODE_RELIGHT,
+		GroupInstanceId:    groupInstanceID,
+		MemberName:         member.plan.MemberName,
+		MemberIndex:        member.plan.MemberIndex,
+		Ip:                 member.bundle.pinnedIP,
+		SnapshotRef:        member.bundle.snapshotRef,
+		HealthPort:         member.plan.HealthPort,
+		ReadyBudgetSeconds: member.plan.ReadyBudgetSeconds,
+		Resources: &nodev1.ResourceSpec{
+			Vcpus:  member.plan.VCPUs,
+			MemMib: member.plan.MemMib,
+		},
+		EntryGuestPort: member.plan.EntryGuestPort,
+	}
 }
 
 func groupEntryPlan(plan []groupMemberPlanEntry) (groupMemberPlanEntry, error) {
@@ -409,24 +419,22 @@ func (a *groupActivator) splice(ctx context.Context, client net.Conn, entry *gro
 		_ = client.Close()
 		return
 	}
-	guest, err := (&net.Dialer{}).DialContext(ctx, "tcp", net.JoinHostPort(entry.ip.String(), strconv.FormatUint(uint64(entry.entryGuestPort), 10)))
-	if err != nil {
+	address := net.JoinHostPort(entry.ip.String(), strconv.FormatUint(uint64(entry.entryGuestPort), 10))
+	if err := spliceTCP(ctx, client, address); err != nil {
 		a.server.logger.Warn("group activator: entry dial failed", "workload", entry.workload, "err", err)
+		_ = client.Close()
+	}
+}
+
+func (a *groupActivator) forwardToControlPlane(ctx context.Context, client net.Conn, listenPort uint32) {
+	ip := a.server.registry.controlPlaneActivator()
+	if ip == "" {
 		_ = client.Close()
 		return
 	}
-	defer client.Close()
-	defer guest.Close()
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		pumpTCP(guest, client)
-	}()
-	go func() {
-		defer wg.Done()
-		pumpTCP(client, guest)
-	}()
-	wg.Wait()
+	address := net.JoinHostPort(ip, strconv.FormatUint(uint64(listenPort), 10))
+	if err := spliceTCP(ctx, client, address); err != nil {
+		a.server.logger.Warn("group activator: control-plane forward dial failed", "address", address, "err", err)
+		_ = client.Close()
+	}
 }

--- a/projects/embervm/noded/server/group_activator_test.go
+++ b/projects/embervm/noded/server/group_activator_test.go
@@ -81,9 +81,9 @@ func groupActivatorRoundTrip(t *testing.T, conn net.Conn, body string) {
 
 func groupActivatorPlan(port uint32) []groupMemberPlanEntry {
 	return []groupMemberPlanEntry{
-		{MemberName: "server", MemberIndex: 0, StartOrder: 0, HealthPort: port, EntryGuestPort: port, VCPUs: 1, MemMib: 128},
-		{MemberName: "agent-0", MemberIndex: 1, StartOrder: 1, HealthPort: port, VCPUs: 1, MemMib: 128},
-		{MemberName: "agent-1", MemberIndex: 2, StartOrder: 1, HealthPort: port, VCPUs: 1, MemMib: 128},
+		{MemberName: "server", MemberIndex: 0, StartOrder: 0, HealthPort: port, EntryGuestPort: port, ReadyBudgetSeconds: 30, VCPUs: 1, MemMib: 128},
+		{MemberName: "agent-0", MemberIndex: 1, StartOrder: 1, HealthPort: port, ReadyBudgetSeconds: 30, VCPUs: 1, MemMib: 128},
+		{MemberName: "agent-1", MemberIndex: 2, StartOrder: 1, HealthPort: port, ReadyBudgetSeconds: 30, VCPUs: 1, MemMib: 128},
 	}
 }
 
@@ -125,10 +125,65 @@ func assertGroupActivatorClosed(t *testing.T, conn net.Conn) {
 	}
 }
 
+func controlPlaneActivatorEchoServer(t *testing.T, listenPort uint32) (string, <-chan struct{}) {
+	t.Helper()
+	const ip = "127.0.0.2"
+	lis, err := net.Listen("tcp", net.JoinHostPort(ip, strconv.FormatUint(uint64(listenPort), 10)))
+	if err != nil {
+		t.Fatalf("control-plane activator listen: %v", err)
+	}
+	t.Cleanup(func() { _ = lis.Close() })
+	accepted := make(chan struct{}, 1)
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			select {
+			case accepted <- struct{}{}:
+			default:
+			}
+			go func() {
+				defer conn.Close()
+				_, _ = io.Copy(conn, conn)
+			}()
+		}
+	}()
+	return ip, accepted
+}
+
+func assertNoControlPlaneForward(t *testing.T, accepted <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-accepted:
+		t.Fatal("connection was forwarded to the control-plane activator")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestGroupActivatorRelightRequestCarriesReadyBudget(t *testing.T) {
+	req := groupActivatorRelightRequest("scratch-k8s", "grp-A", groupRelightMember{
+		plan: groupMemberPlanEntry{
+			MemberName:         "server",
+			ReadyBudgetSeconds: 47,
+		},
+		bundle: groupBundleEntry{
+			pinnedIP:    "127.0.0.1",
+			snapshotRef: "group/set-1/server",
+		},
+	})
+	if got := req.GetReadyBudgetSeconds(); got != 47 {
+		t.Errorf("relight ready budget = %d, want 47", got)
+	}
+}
+
 func TestGroupActivatorStragglerSplicesLiveEntry(t *testing.T) {
 	port := groupActivatorEchoServer(t)
 	s, _, driver, _ := newGroupMemberTestServer(t)
 	listenPort := startGroupActivator(t, s)
+	controlPlaneIP, cpAccepted := controlPlaneActivatorEchoServer(t, listenPort)
+	s.registry.setControlPlaneActivator(controlPlaneIP)
 	enableGroupActivatorWorkload(s, "scratch-k8s", listenPort, port)
 	s.groupMembers.add(&groupMemberEntry{
 		vmID:            "already-live",
@@ -144,15 +199,16 @@ func TestGroupActivatorStragglerSplicesLiveEntry(t *testing.T) {
 	defer conn.Close()
 	groupActivatorRoundTrip(t, conn, "live group bytes")
 	driver.mu.Lock()
-	defer driver.mu.Unlock()
 	if driver.restores != 0 || driver.claims != 0 {
 		t.Errorf("group wake calls = claims:%d restores:%d, want 0:0", driver.claims, driver.restores)
 	}
+	driver.mu.Unlock()
+	assertNoControlPlaneForward(t, cpAccepted)
 }
 
 func TestGroupActivatorRelightsCompleteSetInRoleOrder(t *testing.T) {
 	port := groupActivatorEchoServer(t)
-	s, _, driver, _ := newGroupMemberTestServer(t)
+	s, _, driver, clock := newGroupMemberTestServer(t)
 	listenPort := startGroupActivator(t, s)
 	enableGroupActivatorWorkload(s, "scratch-k8s", listenPort, port)
 	addCompleteGroupActivatorSet(s, driver, port)
@@ -178,6 +234,17 @@ func TestGroupActivatorRelightsCompleteSetInRoleOrder(t *testing.T) {
 	for _, member := range status {
 		if member.GetOrigin() != nodev1.InstanceOrigin_INSTANCE_ORIGIN_ACTIVATOR {
 			t.Errorf("member %q origin = %v, want ACTIVATOR", member.GetMemberName(), member.GetOrigin())
+		}
+	}
+	clock.mu.Lock()
+	deadlines := append([]time.Time(nil), clock.deadlines...)
+	clock.mu.Unlock()
+	if len(deadlines) != 3 {
+		t.Fatalf("clock resync deadlines = %d, want 3", len(deadlines))
+	}
+	for _, deadline := range deadlines {
+		if remaining := time.Until(deadline); remaining < 20*time.Second {
+			t.Errorf("clock resync deadline remaining = %v, want plan budget near 30s", remaining)
 		}
 	}
 }
@@ -295,4 +362,69 @@ func TestGroupActivatorRelightFailureReapsStartedMembers(t *testing.T) {
 	if got := len(s.groupBundles.snapshot()); got != 3 {
 		t.Errorf("banked bundles after failed relight = %d, want 3", got)
 	}
+}
+
+func TestGroupActivatorWakeFailureForwardsToControlPlane(t *testing.T) {
+	port := groupActivatorEchoServer(t)
+	s, _, driver, _ := newGroupMemberTestServer(t)
+	listenPort := startGroupActivator(t, s)
+	controlPlaneIP, cpAccepted := controlPlaneActivatorEchoServer(t, listenPort)
+	s.registry.setControlPlaneActivator(controlPlaneIP)
+	enableGroupActivatorWorkload(s, "scratch-k8s", listenPort, port)
+
+	conn := groupActivatorConn(t, listenPort)
+	defer conn.Close()
+	groupActivatorRoundTrip(t, conn, "forwarded group bytes")
+	select {
+	case <-cpAccepted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("control-plane activator did not receive the failed group wake")
+	}
+	driver.mu.Lock()
+	defer driver.mu.Unlock()
+	if driver.restores != 0 {
+		t.Errorf("RestoreGroupMember calls = %d, want 0 for incomplete set", driver.restores)
+	}
+}
+
+func TestGroupActivatorWakeFailureWithoutControlPlaneAddressCloses(t *testing.T) {
+	port := groupActivatorEchoServer(t)
+	s, _, _, _ := newGroupMemberTestServer(t)
+	listenPort := startGroupActivator(t, s)
+	enableGroupActivatorWorkload(s, "scratch-k8s", listenPort, port)
+
+	assertGroupActivatorClosed(t, groupActivatorConn(t, listenPort))
+}
+
+func TestGroupActivatorWakeFailureControlPlaneDialFailureCloses(t *testing.T) {
+	port := groupActivatorEchoServer(t)
+	s, _, _, _ := newGroupMemberTestServer(t)
+	listenPort := startGroupActivator(t, s)
+	const controlPlaneIP = "127.0.0.2"
+	probe, err := net.Listen("tcp", net.JoinHostPort(controlPlaneIP, strconv.FormatUint(uint64(listenPort), 10)))
+	if err != nil {
+		t.Fatalf("reserve control-plane activator address: %v", err)
+	}
+	_ = probe.Close()
+	s.registry.setControlPlaneActivator(controlPlaneIP)
+	enableGroupActivatorWorkload(s, "scratch-k8s", listenPort, port)
+
+	assertGroupActivatorClosed(t, groupActivatorConn(t, listenPort))
+}
+
+func TestGroupActivatorRateLimitDoesNotForward(t *testing.T) {
+	port := groupActivatorEchoServer(t)
+	s, _, _, _ := newGroupMemberTestServer(t)
+	listenPort := startGroupActivator(t, s)
+	controlPlaneIP, cpAccepted := controlPlaneActivatorEchoServer(t, listenPort)
+	s.registry.setControlPlaneActivator(controlPlaneIP)
+	enableGroupActivatorWorkload(s, "scratch-k8s", listenPort, port)
+	s.groupActivator.mu.Lock()
+	for i := 0; i < activatorWakeMax; i++ {
+		s.groupActivator.wakes = append(s.groupActivator.wakes, time.Now())
+	}
+	s.groupActivator.mu.Unlock()
+
+	assertGroupActivatorClosed(t, groupActivatorConn(t, listenPort))
+	assertNoControlPlaneForward(t, cpAccepted)
 }

--- a/projects/embervm/noded/server/group_member.go
+++ b/projects/embervm/noded/server/group_member.go
@@ -194,7 +194,7 @@ func (s *Server) startGroupMemberRelight(ctx context.Context, req *nodev1.StartG
 	// over the port-1024 length-prefixed JSON agent channel (NOT the old HTTP
 	// /shim/clock path). A read-back more than one second off fails the call.
 	uds := s.driver.VsockUDSPath(h.ThreadID)
-	clockCtx, cancelClock := context.WithTimeout(ctx, s.cfg.RestoreReadyTimeout)
+	clockCtx, cancelClock := context.WithTimeout(ctx, groupMemberReadyBudget(req, s.cfg.RestoreReadyTimeout))
 	clockErr := s.groupClock.Resync(clockCtx, uds)
 	cancelClock()
 	if clockErr != nil {

--- a/projects/embervm/noded/server/group_member_test.go
+++ b/projects/embervm/noded/server/group_member_test.go
@@ -166,17 +166,21 @@ func (a groupMemberVMDriverAdapter) LiveCount() int {
 // that Resync was called so a test can assert the resync ran on RELIGHT (and never
 // on FRESH).
 type fakeGroupClock struct {
-	mu      sync.Mutex
-	calls   int
-	err     error
-	lastUDS string
+	mu        sync.Mutex
+	calls     int
+	err       error
+	lastUDS   string
+	deadlines []time.Time
 }
 
-func (c *fakeGroupClock) Resync(_ context.Context, uds string) error {
+func (c *fakeGroupClock) Resync(ctx context.Context, uds string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.calls++
 	c.lastUDS = uds
+	if deadline, ok := ctx.Deadline(); ok {
+		c.deadlines = append(c.deadlines, deadline)
+	}
 	if c.err != nil {
 		return fmt.Errorf("fake group clock resync: %w", c.err)
 	}

--- a/projects/embervm/noded/server/registry_workload.go
+++ b/projects/embervm/noded/server/registry_workload.go
@@ -40,13 +40,14 @@ type workloadEntry struct {
 }
 
 type groupMemberPlanEntry struct {
-	MemberName     string `json:"memberName"`
-	MemberIndex    uint32 `json:"memberIndex"`
-	StartOrder     uint32 `json:"startOrder"`
-	HealthPort     uint32 `json:"healthPort"`
-	EntryGuestPort uint32 `json:"entryGuestPort"`
-	VCPUs          uint32 `json:"vcpus"`
-	MemMib         uint32 `json:"memMib"`
+	MemberName         string `json:"memberName"`
+	MemberIndex        uint32 `json:"memberIndex"`
+	StartOrder         uint32 `json:"startOrder"`
+	HealthPort         uint32 `json:"healthPort"`
+	EntryGuestPort     uint32 `json:"entryGuestPort"`
+	ReadyBudgetSeconds uint32 `json:"readyBudgetSeconds"`
+	VCPUs              uint32 `json:"vcpus"`
+	MemMib             uint32 `json:"memMib"`
 }
 
 // entryFromProto lifts a wire RegistryEntry into the daemon's internal shape.
@@ -54,13 +55,14 @@ func entryFromProto(e *nodev1.RegistryEntry) workloadEntry {
 	groupPlan := make([]groupMemberPlanEntry, 0, len(e.GetGroupMemberPlan()))
 	for _, member := range e.GetGroupMemberPlan() {
 		groupPlan = append(groupPlan, groupMemberPlanEntry{
-			MemberName:     member.GetMemberName(),
-			MemberIndex:    member.GetMemberIndex(),
-			StartOrder:     member.GetStartOrder(),
-			HealthPort:     member.GetHealthPort(),
-			EntryGuestPort: member.GetEntryGuestPort(),
-			VCPUs:          member.GetSizing().GetVcpus(),
-			MemMib:         member.GetSizing().GetMemMib(),
+			MemberName:         member.GetMemberName(),
+			MemberIndex:        member.GetMemberIndex(),
+			StartOrder:         member.GetStartOrder(),
+			HealthPort:         member.GetHealthPort(),
+			EntryGuestPort:     member.GetEntryGuestPort(),
+			ReadyBudgetSeconds: member.GetReadyBudgetSeconds(),
+			VCPUs:              member.GetSizing().GetVcpus(),
+			MemMib:             member.GetSizing().GetMemMib(),
 		})
 	}
 	return workloadEntry{
@@ -102,6 +104,9 @@ func entryFromProto(e *nodev1.RegistryEntry) workloadEntry {
 type workloadRegistry struct {
 	mu      sync.Mutex
 	entries map[string]workloadEntry
+	// controlPlaneActivatorIP is supplied only by a live SyncRegistry. It is
+	// intentionally absent from the persisted workload-entry cache.
+	controlPlaneActivatorIP string
 	// synced is true once the daemon has applied at least one live SyncRegistry
 	// this process lifetime (readiness gate). A cache load does NOT set it.
 	synced bool
@@ -128,6 +133,14 @@ func newWorkloadRegistry(cachePath string) *workloadRegistry {
 // applying the same set twice yields the same table and the same on-disk cache.
 // Returns the resulting entry count.
 func (r *workloadRegistry) sync(entries []workloadEntry) int {
+	return r.syncEntries(entries, "", false)
+}
+
+func (r *workloadRegistry) syncFromControlPlane(entries []workloadEntry, controlPlaneActivatorIP string) int {
+	return r.syncEntries(entries, controlPlaneActivatorIP, true)
+}
+
+func (r *workloadRegistry) syncEntries(entries []workloadEntry, controlPlaneActivatorIP string, updateControlPlaneActivator bool) int {
 	r.mu.Lock()
 	next := make(map[string]workloadEntry, len(entries))
 	for _, e := range entries {
@@ -137,6 +150,9 @@ func (r *workloadRegistry) sync(entries []workloadEntry) int {
 		next[e.Workload] = e
 	}
 	r.entries = next
+	if updateControlPlaneActivator {
+		r.controlPlaneActivatorIP = controlPlaneActivatorIP
+	}
 	r.synced = true
 	r.stale = false
 	snapshot := r.snapshotLocked()
@@ -214,6 +230,18 @@ func (r *workloadRegistry) groupByListenPort(port uint32) (workloadEntry, bool) 
 		}
 	}
 	return workloadEntry{}, false
+}
+
+func (r *workloadRegistry) setControlPlaneActivator(ip string) {
+	r.mu.Lock()
+	r.controlPlaneActivatorIP = ip
+	r.mu.Unlock()
+}
+
+func (r *workloadRegistry) controlPlaneActivator() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.controlPlaneActivatorIP
 }
 
 // getByImageRef returns the entry whose ImageRef matches imageRef (the BuildBase

--- a/projects/embervm/noded/server/registry_workload_test.go
+++ b/projects/embervm/noded/server/registry_workload_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -20,11 +21,12 @@ func TestGroupByListenPortRequiresNodeLocalWakeAndPlan(t *testing.T) {
 		NodeLocalWake:   true,
 		GroupListenPort: 5410,
 		GroupMemberPlan: []*nodev1.GroupMemberPlanEntry{{
-			MemberName:     "server",
-			StartOrder:     0,
-			HealthPort:     6443,
-			EntryGuestPort: 6443,
-			Sizing:         &nodev1.ResourceSpec{Vcpus: 2, MemMib: 1024},
+			MemberName:         "server",
+			StartOrder:         0,
+			HealthPort:         6443,
+			EntryGuestPort:     6443,
+			ReadyBudgetSeconds: 180,
+			Sizing:             &nodev1.ResourceSpec{Vcpus: 2, MemMib: 1024},
 		}},
 	})
 	r.sync([]workloadEntry{group})
@@ -35,11 +37,32 @@ func TestGroupByListenPortRequiresNodeLocalWakeAndPlan(t *testing.T) {
 	if got.GroupMemberPlan[0].MemMib != 1024 || got.GroupMemberPlan[0].EntryGuestPort != 6443 {
 		t.Errorf("group plan = %+v", got.GroupMemberPlan[0])
 	}
+	if got.GroupMemberPlan[0].ReadyBudgetSeconds != 180 {
+		t.Errorf("group ready budget = %d, want 180", got.GroupMemberPlan[0].ReadyBudgetSeconds)
+	}
 
 	group.NodeLocalWake = false
 	r.sync([]workloadEntry{group})
 	if _, ok := r.groupByListenPort(5410); ok {
 		t.Error("groupByListenPort accepted a workload without node_local_wake")
+	}
+}
+
+func TestSyncRegistryStoresControlPlaneActivator(t *testing.T) {
+	_, s := newTestServer(t, &fakeDriver{}, &fakeTransport{}, 8)
+	if _, err := s.SyncRegistry(context.Background(), &nodev1.SyncRegistryRequest{
+		ControlPlaneActivatorIp: "10.42.0.19",
+	}); err != nil {
+		t.Fatalf("SyncRegistry: %v", err)
+	}
+	if got := s.registry.controlPlaneActivator(); got != "10.42.0.19" {
+		t.Errorf("control-plane activator = %q, want %q", got, "10.42.0.19")
+	}
+	if _, err := s.SyncRegistry(context.Background(), &nodev1.SyncRegistryRequest{}); err != nil {
+		t.Fatalf("SyncRegistry(empty activator): %v", err)
+	}
+	if got := s.registry.controlPlaneActivator(); got != "" {
+		t.Errorf("control-plane activator after empty sync = %q, want empty", got)
 	}
 }
 

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1552,7 +1552,7 @@ func (s *Server) SyncRegistry(_ context.Context, req *nodev1.SyncRegistryRequest
 	for _, e := range req.GetEntries() {
 		entries = append(entries, entryFromProto(e))
 	}
-	n := s.registry.sync(entries)
+	n := s.registry.syncFromControlPlane(entries, req.GetControlPlaneActivatorIp())
 	s.logger.Info("workload registry synced", "entries", n)
 	// A sync can flip the daemon ready; wake any WatchNode observers so the
 	// control plane sees the new registry-derived facts promptly.

--- a/projects/embervm/noded/server/stateful_activator.go
+++ b/projects/embervm/noded/server/stateful_activator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"strconv"
 	"sync"
@@ -126,8 +125,13 @@ func (a *statefulActivator) handle(ctx context.Context, conn net.Conn, listenPor
 		_ = conn.Close()
 		return
 	}
-	if flight.err != nil || flight.entry == nil {
+	if flight.err != nil {
 		a.server.logger.Warn("stateful activator: wake failed", "workload", reg.Workload, "err", flight.err)
+		a.forwardToControlPlane(ctx, conn, listenPort)
+		return
+	}
+	if flight.entry == nil {
+		a.server.logger.Warn("stateful activator: wake returned no entry", "workload", reg.Workload)
 		_ = conn.Close()
 		return
 	}
@@ -254,33 +258,22 @@ func (a *statefulActivator) splice(ctx context.Context, client net.Conn, entry *
 		_ = client.Close()
 		return
 	}
-	guest, err := (&net.Dialer{}).DialContext(ctx, "tcp", net.JoinHostPort(entry.ip.String(), strconv.FormatUint(uint64(entry.port), 10)))
-	if err != nil {
+	address := net.JoinHostPort(entry.ip.String(), strconv.FormatUint(uint64(entry.port), 10))
+	if err := spliceTCP(ctx, client, address); err != nil {
 		a.server.logger.Warn("stateful activator: guest dial failed", "workload", entry.workload, "err", err)
+		_ = client.Close()
+	}
+}
+
+func (a *statefulActivator) forwardToControlPlane(ctx context.Context, client net.Conn, listenPort uint32) {
+	ip := a.server.registry.controlPlaneActivator()
+	if ip == "" {
 		_ = client.Close()
 		return
 	}
-	defer client.Close()
-	defer guest.Close()
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		pumpTCP(guest, client)
-	}()
-	go func() {
-		defer wg.Done()
-		pumpTCP(client, guest)
-	}()
-	wg.Wait()
-}
-
-func pumpTCP(dst, src net.Conn) {
-	_, _ = io.Copy(dst, src)
-	if conn, ok := dst.(*net.TCPConn); ok {
-		_ = conn.CloseWrite()
-		return
+	address := net.JoinHostPort(ip, strconv.FormatUint(uint64(listenPort), 10))
+	if err := spliceTCP(ctx, client, address); err != nil {
+		a.server.logger.Warn("stateful activator: control-plane forward dial failed", "address", address, "err", err)
+		_ = client.Close()
 	}
-	_ = dst.Close()
 }

--- a/projects/embervm/noded/server/stateful_activator_test.go
+++ b/projects/embervm/noded/server/stateful_activator_test.go
@@ -262,3 +262,24 @@ func TestStatefulActivatorAndControlPlaneOrigins(t *testing.T) {
 		}
 	}
 }
+
+func TestStatefulActivatorWakeFailureForwardsToControlPlane(t *testing.T) {
+	port := statefulActivatorEchoServer(t)
+	s, _, driver := newStatefulTestServer(t)
+	listenPort := startStatefulActivator(t, s)
+	controlPlaneIP, cpAccepted := controlPlaneActivatorEchoServer(t, listenPort)
+	s.registry.setControlPlaneActivator(controlPlaneIP)
+	enableStatefulActivatorWorkload(s, "wl-state", listenPort, port)
+
+	conn := statefulActivatorConn(t, listenPort)
+	defer conn.Close()
+	statefulActivatorRoundTrip(t, conn, "forwarded stateful bytes")
+	select {
+	case <-cpAccepted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("control-plane activator did not receive the failed stateful wake")
+	}
+	if driver.claims != 0 || driver.restores != 0 {
+		t.Errorf("stateful wake calls = claims:%d restores:%d, want 0:0", driver.claims, driver.restores)
+	}
+}

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -1168,6 +1168,13 @@ message GroupMemberPlanEntry {
   uint32 entry_guest_port = 5;
   // sizing is the member VM resource shape.
   ResourceSpec sizing = 6;
+  // ready_budget_seconds is the workload's wake/ready budget (its
+  // wakeTimeoutSeconds), forwarded so the brick's node-local relight uses the SAME
+  // deadline the control plane grants for both the clock-resync and the health
+  // gate. Without it the brick falls back to the 2s RestoreReadyTimeout default,
+  // which a resumed k3s member cannot meet (it reaps the member mid-relight). 0
+  // keeps the daemon default.
+  uint32 ready_budget_seconds = 7;
 }
 
 // RegistryEntry is the node-side identity of ONE workload the daemon can build a
@@ -1285,6 +1292,16 @@ message RegistryEntry {
 message SyncRegistryRequest {
   repeated RegistryEntry entries = 1;
   Trace trace = 2;
+  // control_plane_activator_ip is the control plane's OWN L4 activator address
+  // (the same activator_ip it advertises for the pre-018 CP-side fallback). The
+  // node-local activator dials {control_plane_activator_ip, listen_port} and
+  // splices the parked connection through when its own relight fails or the local
+  // set is incomplete, instead of closing: a fallback-of-the-fallback that keeps a
+  // banked workload from black-holing while the control plane is reachable
+  // (pre-018 recovery), and that simply fails-and-closes during a CP gap (bounded
+  // by CP recreate). Empty disables the forward. Pushed on the SyncRegistry
+  // envelope so it tracks CP pod recreation for free.
+  string control_plane_activator_ip = 3;
 }
 
 // SyncRegistryResponse echoes the resulting registry size after convergence, for


### PR DESCRIPTION
Makes a node-local composite (group) relight actually **complete** and never black-hole, closing the three gaps the ADR 018 Phase 3 live drill exposed. Fixes #4002, #4003, #4004.

## Context

The Phase 3 drill proved the node-local relight *fires* during a CP gap (resolves, gates, finds the complete set, role-orders, resumes) but it could not complete: the resume then failed at clock-resync, and a failure black-holed the workload. SigNoz confirmed the root cause: scratch-k8s relight is marginal on the 2s deadline (historical CP relights succeeded when calm, the drill failed under CP-recreate load), and the agents' readiness gate is the dominant historical `relight_failed` cause.

## The three fixes

- **#4002 clock-resync deadline** (`group_member.go`): was `RestoreReadyTimeout` (2s), now `groupMemberReadyBudget(req, ...)` so the resync gets the workload's wake budget. The 1s clock **skew** tolerance is unchanged.
- **#4003 ready budget** (proto + `node_registry.ex` + `group_activator.go`): the CP stamps `ready_budget_seconds` (from `wakeTimeoutSeconds`) on every pushed `GroupMemberPlanEntry`, and the activator forwards it onto the relight request, so the health gate gets the full window instead of 2s (the R6 Gate-1 agent-loss failure).
- **#4004 forward-to-CP fallback** (proto + `node_registry.ex` + `group_activator.go` + `stateful_activator.go`): on a wake failure the brick activator forwards the held connection to the CP's own L4 activator (`control_plane_activator_ip`, pushed on the SyncRegistry envelope from `EMBERVM_STATEFUL_ACTIVATOR_IP`) and splices it through, instead of closing. An empty CP address or a failed dial (a real CP gap) falls back to closing, so the CP-gap demo behavior is unchanged and a reachable-CP relight failure recovers exactly as pre-018. Applied to the stateful activator too for symmetry.

## Testing

CI on this branch (proto codegen + the new Go/Elixir unit tests). Acceptance is the composite gap drill re-run on the rolled-out build: the node-local relight should now **complete** (server + agents resume, kubectl served during the gap), and a forced relight failure should forward to the CP instead of black-holing.

Sub-issues of #3993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)