### PR TITLE
fix(embervm): group bank/wake targets the instance's node (#4006)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.230
+version: 0.1.231

--- a/projects/embervm/control/lib/embervm/group_manager/supervisor.ex
+++ b/projects/embervm/control/lib/embervm/group_manager/supervisor.ex
@@ -316,9 +316,8 @@ defmodule Embervm.GroupManager.Supervisor do
   defp prefer_warm_nodes(facts, group_instance_id) when is_binary(group_instance_id) and group_instance_id != "" do
     {warm, cold} =
       Enum.split_with(facts, fn fact ->
-        fact
-        |> Map.get(:group_bundle_sets, [])
-        |> Enum.any?(fn set -> Map.get(set, :group_instance_id) == group_instance_id end)
+        hosts_instance?(fact, :group_bundle_sets, group_instance_id) or
+          hosts_instance?(fact, :group_member_vms, group_instance_id)
       end)
 
     warm ++ cold
@@ -326,11 +325,34 @@ defmodule Embervm.GroupManager.Supervisor do
 
   defp prefer_warm_nodes(facts, _group_instance_id), do: facts
 
+  # True when a node fact reports the instance under `key` (a list of rows keyed by
+  # group_instance_id: group_bundle_sets for a banked instance, group_member_vms for
+  # a running one).
+  defp hosts_instance?(fact, key, group_instance_id) do
+    fact
+    |> Map.get(key, [])
+    |> Kernel.||([])
+    |> Enum.any?(fn row -> Map.get(row, :group_instance_id) == group_instance_id end)
+  end
+
   # Warmth selection for a wake/bank/adopt (the banked instance's set): match the
   # node's group_bundle_sets by the group_instance_id the set is keyed on. A fresh
   # CREATE (nil id) carries no warmth, so it goes straight to the mem-eligible pick.
   defp warmth_opts(group_instance_id) when is_binary(group_instance_id) and group_instance_id != "" do
-    [warmth_key: :group_bundle_sets, warmth_match_field: :group_instance_id, warmth_ref: group_instance_id]
+    # A bank/wake/adopt of an ALREADY-PLACED instance must target the node it is on,
+    # not re-pick by free capacity. A banked instance is found by its group_bundle_sets;
+    # a RUNNING instance being banked has no set yet, so it is found by its LIVE
+    # group_member_vms (warmth_also_keys). Both match on group_instance_id. Without the
+    # live-member key, banking a group that occupies most of a node fails
+    # :no_eligible_instance (its own memory counts against the free-capacity check) and
+    # wedges in :banking (#4006). A fresh CREATE (nil id) carries no warmth and still
+    # cold-picks a node with room, which is correct.
+    [
+      warmth_key: :group_bundle_sets,
+      warmth_also_keys: [:group_member_vms],
+      warmth_match_field: :group_instance_id,
+      warmth_ref: group_instance_id
+    ]
   end
 
   defp warmth_opts(_group_instance_id), do: []

--- a/projects/embervm/control/lib/embervm/wake_instance.ex
+++ b/projects/embervm/control/lib/embervm/wake_instance.ex
@@ -296,11 +296,19 @@ defmodule Embervm.WakeInstance do
     warmth_key = Keyword.get(opts, :warmth_key)
     warmth_ref = Keyword.get(opts, :warmth_ref)
     match_field = Keyword.get(opts, :warmth_match_field, :snapshot_ref)
+    # Additional fact keys that also count as "this node owns the instance", tried
+    # after warmth_key. The group lane passes group_member_vms here so a bank of a
+    # RUNNING instance (which has no banked set yet) still resolves to the node it is
+    # on rather than cold-picking by free capacity (#4006). Other lanes pass none.
+    also_keys = Keyword.get(opts, :warmth_also_keys, [])
 
     if is_atom(warmth_key) and is_binary(warmth_ref) and warmth_ref != "" do
       table
       |> instances_on(node_id)
-      |> Enum.find(fn fact -> fact_reports_warmth?(fact, warmth_key, warmth_ref, match_field) end)
+      |> Enum.find(fn fact ->
+        fact_reports_warmth?(fact, warmth_key, warmth_ref, match_field) or
+          Enum.any?(also_keys, fn k -> fact_reports_warmth?(fact, k, warmth_ref, match_field) end)
+      end)
       |> case do
         nil -> :none
         fact -> {:ok, dial_id(fact)}

--- a/projects/embervm/control/test/embervm/wake_instance_test.exs
+++ b/projects/embervm/control/test/embervm/wake_instance_test.exs
@@ -53,11 +53,56 @@ defmodule Embervm.WakeInstanceTest do
         stateful_bundles: Keyword.get(opts, :stateful_bundles, []),
         serving_snapshots: Keyword.get(opts, :serving_snapshots, []),
         group_bundle_sets: Keyword.get(opts, :group_bundle_sets, []),
+        group_member_vms: Keyword.get(opts, :group_member_vms, []),
         updated_at: Keyword.get(opts, :updated_at, 0)
       }
 
     NodeCapacity.put(table, {node_id, pod_uid}, facts)
     instance_id
+  end
+
+  describe "warmth_also_keys (a bank of a RUNNING group resolves to its node, #4006)" do
+    test "matches a LIVE group member even when the node has no free capacity", %{table: table} do
+      # The running group occupies node-4, so it has NO room for a second copy. A bank
+      # must still resolve to this node via its live group_member_vms, not fail the
+      # free-capacity cold-pick (which would wedge the bank in :banking).
+      owner =
+        put_instance(table, "node-4", "pod-a",
+          mem_headroom_mib: 100,
+          group_member_vms: [%{group_instance_id: "grp-1", member_name: "server"}]
+        )
+
+      assert {:ok, ^owner} =
+               WakeInstance.select("node-4",
+                 table: table,
+                 workload: "gwl",
+                 need_mib: 7_168,
+                 warmth_key: :group_bundle_sets,
+                 warmth_also_keys: [:group_member_vms],
+                 warmth_match_field: :group_instance_id,
+                 warmth_ref: "grp-1"
+               )
+    end
+
+    test "without warmth_also_keys a running-only instance still fails the capacity pick", %{table: table} do
+      # Same node, same lack of capacity, but no live-member fallback key: the bank
+      # would fail (the pre-#4006 behaviour), confirming the fix is what rescues it.
+      _owner =
+        put_instance(table, "node-4", "pod-a",
+          mem_headroom_mib: 100,
+          group_member_vms: [%{group_instance_id: "grp-1", member_name: "server"}]
+        )
+
+      assert {:error, :no_eligible_instance} =
+               WakeInstance.select("node-4",
+                 table: table,
+                 workload: "gwl",
+                 need_mib: 7_168,
+                 warmth_key: :group_bundle_sets,
+                 warmth_match_field: :group_instance_id,
+                 warmth_ref: "grp-1"
+               )
+    end
   end
 
   describe "warmth ownership (a relight lands on the bundle-owning instance)" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.230
+      targetRevision: 0.1.231
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Fixes #4006: banking a running composite that occupies most of a node wedges in `:banking` because `anchor_instance` re-picks a node by **free** capacity for the group's full member-memory, double-counting the memory the running group already uses.

## Fix

Warmth ownership now matches a **live** instance, not only a banked set. `WakeInstance.owning_instance` honors a new `warmth_also_keys` option; the group lane passes `group_member_vms`, so a running instance being banked resolves to the node it is already on (bypassing the free-capacity gate it already satisfies). `prefer_warm_nodes` sorts that node first. A fresh CREATE (nil instance id) still cold-picks a node with real room. Other lanes (serving/stateful/session) pass no extra key, so their selection is unchanged.

Confirmed live: node-4 headroom 5734/5352 MiB vs a 7168 MiB need -> `no_eligible_instance` before the fix. Two `wake_instance_test` cases cover it (live-member match despite no capacity; and the pre-fix failure without the key).

Unblocks the ADR 018 Phase 3 relight drill. Sub-issue of #3993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)