### PR TITLE
feat(tooling): add prettier-plugin-svelte for local+CI format parity

### DIFF
--- a/bazel/semgrep/tests/fixtures/no-create-event-dispatcher-runes.svelte
+++ b/bazel/semgrep/tests/fixtures/no-create-event-dispatcher-runes.svelte
@@ -1,30 +1,13 @@
-# Test fixtures for the no-create-event-dispatcher-runes semgrep rule.
-#
-# Annotations:
-#   # ruleid: no-create-event-dispatcher-runes  — the next non-annotation line MUST be flagged
-#   # ok: no-create-event-dispatcher-runes      — the next non-annotation line MUST NOT be flagged
-
-# Positive examples — createEventDispatcher in a runes file (should be flagged)
-
-# Bare named import:
-# ruleid: no-create-event-dispatcher-runes
-import { createEventDispatcher } from 'svelte';
-
-# Combined import alongside other Svelte exports:
-# ruleid: no-create-event-dispatcher-runes
-import { createEventDispatcher, onMount } from 'svelte';
-
-# Double-quoted module specifier:
-# ruleid: no-create-event-dispatcher-runes
-import { createEventDispatcher } from "svelte";
-
-# Negative examples — safe imports that must not be flagged
-
-# ok: no-create-event-dispatcher-runes
-import { onMount } from 'svelte';
-
-# ok: no-create-event-dispatcher-runes
-import { $state } from 'svelte/reactivity';
-
-# ok: no-create-event-dispatcher-runes
-import { createEventDispatcher } from 'svelte/legacy';
+# Test fixtures for the no-create-event-dispatcher-runes semgrep rule. # #
+Annotations: # # ruleid: no-create-event-dispatcher-runes — the next
+non-annotation line MUST be flagged # # ok: no-create-event-dispatcher-runes —
+the next non-annotation line MUST NOT be flagged # Positive examples —
+createEventDispatcher in a runes file (should be flagged) # Bare named import: #
+ruleid: no-create-event-dispatcher-runes import {createEventDispatcher} from 'svelte';
+# Combined import alongside other Svelte exports: # ruleid: no-create-event-dispatcher-runes
+import {(createEventDispatcher, onMount)} from 'svelte'; # Double-quoted module specifier:
+# ruleid: no-create-event-dispatcher-runes import {createEventDispatcher} from "svelte";
+# Negative examples — safe imports that must not be flagged # ok: no-create-event-dispatcher-runes
+import {onMount} from 'svelte'; # ok: no-create-event-dispatcher-runes import {$state}
+from 'svelte/reactivity'; # ok: no-create-event-dispatcher-runes import {createEventDispatcher}
+from 'svelte/legacy';

--- a/bazel/tools/ci/ci
+++ b/bazel/tools/ci/ci
@@ -81,9 +81,10 @@ code_changed() {
 }
 
 # ---------- lint (file-selective format) ----------
-# Extension list is what standalone prettier/ruff/etc. can format without extra
-# plugins. prettier.config.cjs has no svelte plugin, so *.svelte is intentionally
-# omitted (CI format_multirun uses the same prettier binary).
+# Extension list matches what PATH prettier/ruff/etc. can format. *.svelte needs
+# prettier-plugin-svelte (wired in bazel/tools/format/prettier.config.cjs); pass
+# --config so PATH prettier loads the plugin the same way the Bazel binary does.
+PRETTIER_CONFIG="${PRETTIER_CONFIG:-bazel/tools/format/prettier.config.cjs}"
 cmd_lint() {
 	local -a files=()
 	local f
@@ -105,7 +106,7 @@ cmd_lint() {
 		BUILD | BUILD.bazel | *.bzl | WORKSPACE | WORKSPACE.bazel | */BUILD | */BUILD.bazel)
 			star+=("$f")
 			;;
-		*.js | *.jsx | *.ts | *.tsx | *.mjs | *.cjs | *.json | *.yaml | *.yml | *.md | *.css | *.html)
+		*.js | *.jsx | *.ts | *.tsx | *.mjs | *.cjs | *.json | *.yaml | *.yml | *.md | *.css | *.html | *.svelte)
 			pretty+=("$f")
 			;;
 		esac
@@ -135,7 +136,7 @@ cmd_lint() {
 	}
 	[[ ${#pretty[@]} -gt 0 ]] && {
 		dim "  prettier (${#pretty[@]})"
-		prettier --write "${pretty[@]}" >/dev/null
+		prettier --config "$PRETTIER_CONFIG" --write "${pretty[@]}" >/dev/null
 	}
 	if [[ ${#star[@]} -gt 0 ]]; then
 		if command -v buildifier >/dev/null 2>&1; then

--- a/bazel/tools/ci/ci_test.sh
+++ b/bazel/tools/ci/ci_test.sh
@@ -53,10 +53,10 @@ else
 	fail "flags_before_bb" "flag parse (line $flag_ln) must precede bb check (line $bb_ln)"
 fi
 
-if grep -qE '\*\.py\)' "$CI" && grep -qE '\*\.js' "$CI"; then
+if grep -qE '\*\.py\)' "$CI" && grep -qE '\*\.js' "$CI" && grep -qE '\*\.svelte' "$CI"; then
 	pass "lint_extensions"
 else
-	fail "lint_extensions" "missing py/js cases"
+	fail "lint_extensions" "missing py/js/svelte cases"
 fi
 
 if grep -q 'need_generators' "$CI" && grep -q 'need_gazelle' "$CI"; then

--- a/bazel/tools/format/BUILD
+++ b/bazel/tools/format/BUILD
@@ -25,6 +25,12 @@ sh_test(
 js_library(
     name = "prettierrc",
     srcs = ["prettier.config.cjs"],
+    # Plugin + peer must be in runfiles so require("prettier-plugin-svelte")
+    # from the config resolves under the hermetic prettier binary.
+    deps = [
+        "//:node_modules/prettier-plugin-svelte",
+        "//:node_modules/svelte",
+    ],
 )
 
 prettier.prettier_binary(
@@ -54,6 +60,14 @@ format_multirun(
     starlark = "@buildifier_prebuilt//:buildifier",
 )
 
+# aspect_rules_lint has no Svelte dialect; format tracked *.svelte via the same
+# hermetic prettier (plugin loaded from :prettierrc).
+sh_binary(
+    name = "format_svelte",
+    srcs = ["format-svelte.sh"],
+    data = [":prettier"],
+)
+
 # All committed-artifact generators live in ONE list (run-generators.sh), shared
 # with fast-format.sh, so the local and CI format paths cannot drift.
 sh_binary(
@@ -66,6 +80,7 @@ multirun(
     commands = [
         ":run_generators",
         ":format_code",
+        ":format_svelte",
         "//:gazelle",
     ],
     jobs = 10,

--- a/bazel/tools/format/fast-format.sh
+++ b/bazel/tools/format/fast-format.sh
@@ -71,7 +71,7 @@ if $STAGED; then
 			STARLARK_FILES+=("$f")
 			BUILD_FILES+=("$f")
 			;;
-		*.js | *.jsx | *.ts | *.tsx | *.json | *.yaml | *.yml | *.md | *.css | *.html)
+		*.js | *.jsx | *.ts | *.tsx | *.json | *.yaml | *.yml | *.md | *.css | *.html | *.svelte)
 			PRETTIER_FILES+=("$f")
 			;;
 		esac
@@ -79,6 +79,7 @@ if $STAGED; then
 
 	log "Formatting ${#STAGED_FILES[@]} staged files..."
 	PIDS=()
+	PRETTIER_CONFIG="${PRETTIER_CONFIG:-bazel/tools/format/prettier.config.cjs}"
 
 	if [ ${#PY_FILES[@]} -gt 0 ]; then
 		ruff format "${PY_FILES[@]}" 2>/dev/null &
@@ -97,7 +98,7 @@ if $STAGED; then
 		PIDS+=($!)
 	fi
 	if [ ${#PRETTIER_FILES[@]} -gt 0 ]; then
-		(prettier --write "${PRETTIER_FILES[@]}" 2>/dev/null || true) &
+		(prettier --config "$PRETTIER_CONFIG" --write "${PRETTIER_FILES[@]}" 2>/dev/null || true) &
 		PIDS+=($!)
 	fi
 
@@ -168,8 +169,9 @@ fi
 	xargs -0 gofumpt -w 2>/dev/null || true) &
 PIDS+=($!)
 
-# Prettier (JS/TS/JSON/YAML/MD)
-prettier --write . 2>/dev/null &
+# Prettier (JS/TS/JSON/YAML/MD/Svelte); --config loads prettier-plugin-svelte
+PRETTIER_CONFIG="${PRETTIER_CONFIG:-bazel/tools/format/prettier.config.cjs}"
+prettier --config "$PRETTIER_CONFIG" --write . 2>/dev/null &
 PIDS+=($!)
 
 # Doc/config generators — ONE shared list (also run by the CI format multirun via

--- a/bazel/tools/format/format-svelte.sh
+++ b/bazel/tools/format/format-svelte.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Format all tracked *.svelte files with the hermetic prettier binary.
+#
+# aspect_rules_lint format_multirun has no Svelte language dialect (JavaScript
+# includes Vue but not Svelte), so CI Format would otherwise skip these files.
+# This step is wired into //bazel/tools/format:format so local and CI share one
+# path once prettier-plugin-svelte is in the hermetic config.
+set -euo pipefail
+
+ROOT="${BUILD_WORKSPACE_DIRECTORY:-$(git rev-parse --show-toplevel)}"
+cd "$ROOT"
+
+# Locate this binary's runfiles (bazel run / multirun).
+RUNFILES="${RUNFILES_DIR:-}"
+if [[ -z "$RUNFILES" ]]; then
+	if [[ -d "${0}.runfiles" ]]; then
+		RUNFILES="${0}.runfiles"
+	elif [[ -d "$(dirname "$0")/format_svelte.runfiles" ]]; then
+		RUNFILES="$(dirname "$0")/format_svelte.runfiles"
+	fi
+fi
+
+PRETTIER=""
+if [[ -n "$RUNFILES" ]]; then
+	for candidate in \
+		"$RUNFILES/_main/bazel/tools/format/prettier_/prettier" \
+		"$RUNFILES/homelab/bazel/tools/format/prettier_/prettier"; do
+		if [[ -x "$candidate" ]]; then
+			PRETTIER="$candidate"
+			break
+		fi
+	done
+	if [[ -z "$PRETTIER" ]]; then
+		PRETTIER=$(find "$RUNFILES" -path '*/prettier_/prettier' \( -type f -o -type l \) 2>/dev/null | head -1 || true)
+	fi
+fi
+
+if [[ -z "${PRETTIER:-}" || ! -x "$PRETTIER" ]]; then
+	echo "ERROR: hermetic prettier not found in runfiles (RUNFILES=${RUNFILES:-unset})" >&2
+	exit 1
+fi
+
+mapfile -t files < <(git ls-files '*.svelte' | grep -v '^\.claude/' || true)
+if [[ ${#files[@]} -eq 0 ]]; then
+	exit 0
+fi
+
+# Batch to avoid ARG_MAX on large trees; prettier is fine with many args but
+# keep chunks modest for older hosts.
+batch_size=200
+for ((i = 0; i < ${#files[@]}; i += batch_size)); do
+	chunk=("${files[@]:i:batch_size}")
+	"$PRETTIER" --write "${chunk[@]}"
+done

--- a/bazel/tools/format/prettier.config.cjs
+++ b/bazel/tools/format/prettier.config.cjs
@@ -1,12 +1,17 @@
 /**
  * @see https://prettier.io/docs/en/configuration.html
+ *
+ * Plugin require() resolves relative to this file (then walks up to the
+ * workspace root node_modules). Bazel includes the plugin via the prettierrc
+ * js_library deps so the hermetic prettier binary can resolve it from
+ * runfiles. PATH prettier (tools image) relies on NODE_PATH pointing at
+ * /usr/local/lib/node_modules where the plugin is packaged.
  */
 const config = {
   tabWidth: 2,
   plugins: [
-    // Add plugins here using a require() statement.
-    // This is required to ensure the node module resolution algorithm starts walking
-    // up the filesystem from this file, rather than from the location where prettier interprets it.
+    // require() so resolution starts from this file, not prettier's install dir.
+    require("prettier-plugin-svelte"),
   ],
 };
 

--- a/bazel/tools/image/BUILD
+++ b/bazel/tools/image/BUILD
@@ -57,23 +57,58 @@ genrule(
     """,
 )
 
-# Package prettier from the pnpm lockfile-managed npm package.
-# Places the package at /usr/local/lib/node_modules/prettier/
-# with a symlink at /usr/bin/prettier for PATH discovery.
+# Package prettier + prettier-plugin-svelte (+ peer svelte) from the pnpm
+# lockfile-managed npm packages. Plugins live next to prettier under
+# /usr/local/lib/node_modules/; /usr/bin/prettier is a wrapper that sets
+# NODE_PATH so require("prettier-plugin-svelte") from the repo config resolves
+# without a full workspace node_modules tree (bootstrap / ci lint path).
+# nosemgrep: single-npm-package-in-apko-genrule -- intentional multi-package node_modules for PATH prettier plugins
 genrule(
     name = "prettier_tar",
-    srcs = ["//:node_modules/prettier"],
+    srcs = [
+        "//:node_modules/prettier",
+        "//:node_modules/prettier-plugin-svelte",
+        "//:node_modules/svelte",
+    ],
     outs = ["prettier.tar"],
     cmd = """
         set -e
         WORK=$$(mktemp -d)
-        DEST="$$WORK/usr/local/lib/node_modules/prettier"
-        mkdir -p "$$DEST"
-        SRC_DIR=$$(echo '$(locations //:node_modules/prettier)' | tr ' ' '\\n' | grep 'prettier$$' | head -1)
-        cp -rL "$$SRC_DIR/." "$$DEST/"
-        chmod 755 "$$DEST/bin/prettier.cjs"
-        mkdir -p "$$WORK/usr/bin"
-        ln -s "../local/lib/node_modules/prettier/bin/prettier.cjs" "$$WORK/usr/bin/prettier"
+        NM="$$WORK/usr/local/lib/node_modules"
+        mkdir -p "$$NM" "$$WORK/usr/bin"
+
+        copy_pkg() {
+            local name="$$1"
+            local locations="$$2"
+            local dest="$$NM/$$name"
+            mkdir -p "$$dest"
+            local src
+            src=$$(echo "$$locations" | tr ' ' '\\n' | grep "/$${name}$$" | head -1)
+            if [[ -z "$$src" ]]; then
+                src=$$(echo "$$locations" | tr ' ' '\\n' | grep "$${name}$$" | head -1)
+            fi
+            if [[ -z "$$src" || ! -d "$$src" ]]; then
+                echo "ERROR: could not locate package dir for $$name in: $$locations" >&2
+                exit 1
+            fi
+            cp -rL "$$src/." "$$dest/"
+        }
+
+        copy_pkg prettier '$(locations //:node_modules/prettier)'
+        copy_pkg prettier-plugin-svelte '$(locations //:node_modules/prettier-plugin-svelte)'
+        copy_pkg svelte '$(locations //:node_modules/svelte)'
+
+        chmod 755 "$$NM/prettier/bin/prettier.cjs"
+        cat > "$$WORK/usr/bin/prettier" << 'WRAPPER'
+#!/usr/bin/env bash
+# Ensure plugins packaged next to prettier resolve from any config require().
+export NODE_PATH="/usr/local/lib/node_modules$${NODE_PATH:+:$$NODE_PATH}"
+if [[ -x /usr/bin/node ]]; then
+  exec /usr/bin/node /usr/local/lib/node_modules/prettier/bin/prettier.cjs "$$@"
+fi
+exec /usr/local/lib/node_modules/prettier/bin/prettier.cjs "$$@"
+WRAPPER
+        chmod 755 "$$WORK/usr/bin/prettier"
         tar -cf $@ -C "$$WORK" .
         rm -rf "$$WORK"
     """,

--- a/bazel/tools/image/README.md
+++ b/bazel/tools/image/README.md
@@ -17,12 +17,15 @@ Python services, nginx frontends), those live in [`//bazel/tools/oci`](../oci/RE
 | `node`                                 | `@nodejs_{platform}//:node_bin` from rules_nodejs          |
 | Python runtime + stdlib + pip packages | `py_image_layer` from `@aspect_rules_py`, with platform transitions |
 | `pnpm`                                 | `@pnpm//:pkg` (aspect_rules_js)                            |
-| `prettier`                             | `//:node_modules/prettier` (pnpm lockfile)                 |
+| `prettier` (+ `prettier-plugin-svelte`, peer `svelte`) | `//:node_modules/*` (pnpm lockfile); wrapper sets `NODE_PATH` |
 | `homelab` CLI                          | Source from `//tools/cli:*`, wrapped in a bash exec script |
 
 All binaries land under `/usr/bin/`; Python's stdlib is in the runfiles tree
-alongside the interpreter. pnpm and prettier are installed under
-`/usr/local/lib/node_modules/` with symlinks at `/usr/bin/`.
+alongside the interpreter. pnpm and prettier (with the Svelte plugin) are
+installed under `/usr/local/lib/node_modules/`; `/usr/bin/prettier` is a
+wrapper that sets `NODE_PATH` so `require("prettier-plugin-svelte")` from
+`bazel/tools/format/prettier.config.cjs` resolves without a workspace
+`node_modules` tree.
 
 ## Build targets
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "happy-dom": "^20.8.9",
     "postcss": "^8.5.6",
     "prettier": "^3.8.1",
+    "prettier-plugin-svelte": "^4.1.1",
+    "svelte": "^5.56.4",
     "tailwindcss": "^3.4.19",
     "typescript": "5.9.3",
     "typescript-eslint": "^8.53.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,10 +51,10 @@ overrides:
 
 patchedDependencies:
   '@sveltejs/kit':
-    hash: ioxopooydvkqrz5sfysetr3ozi
+    hash: f35513c93bdfe798a534e43824cf9bc7c123bf2464047ccc5d9ed9867c26f4e4
     path: bazel/patches/@sveltejs__kit.patch
   rollup:
-    hash: ucodry5rwsvqoy3uc2v6oocfeq
+    hash: f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248
     path: bazel/patches/rollup.patch
 
 importers:
@@ -134,6 +134,12 @@ importers:
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
+      prettier-plugin-svelte:
+        specifier: ^4.1.1
+        version: 4.1.1(prettier@3.8.1)(svelte@5.56.4(@typescript-eslint/types@8.53.1))
+      svelte:
+        specifier: ^5.56.4
+        version: 5.56.4(@typescript-eslint/types@8.53.1)
       tailwindcss:
         specifier: ^3.4.19
         version: 3.4.19(tsx@4.21.0)
@@ -251,10 +257,10 @@ importers:
         version: 4.59.0
       '@sveltejs/adapter-node':
         specifier: ^5.0.0
-        version: 5.5.4(@sveltejs/kit@2.69.2(patch_hash=ioxopooydvkqrz5sfysetr3ozi)(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.56.4(@typescript-eslint/types@8.53.1))(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
+        version: 5.5.4(@sveltejs/kit@2.69.2(patch_hash=f35513c93bdfe798a534e43824cf9bc7c123bf2464047ccc5d9ed9867c26f4e4)(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.56.4(@typescript-eslint/types@8.53.1))(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
       '@sveltejs/kit':
         specifier: '>=2.60.1 <3'
-        version: 2.69.2(patch_hash=ioxopooydvkqrz5sfysetr3ozi)(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.56.4(@typescript-eslint/types@8.53.1))(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+        version: 2.69.2(patch_hash=f35513c93bdfe798a534e43824cf9bc7c123bf2464047ccc5d9ed9867c26f4e4)(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.56.4(@typescript-eslint/types@8.53.1))(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.0
         version: 4.0.4(svelte@5.56.4(@typescript-eslint/types@8.53.1))(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
@@ -2739,6 +2745,13 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier-plugin-svelte@4.1.1:
+    resolution: {integrity: sha512-wXvbXMjSvb4C9ENWTHXyd+ihakKCsJ6rJhLP6/8HFNj4GkZr48jqL9PoKsl2sk7SyCZRTnJ7O2TTowUpOxP/KA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      prettier: ^3.0.0
+      svelte: '>=5.55.7 <6'
+
   prettier@3.8.1:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
@@ -3832,9 +3845,9 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
-  '@rollup/plugin-commonjs@29.0.2(rollup@4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq))':
+  '@rollup/plugin-commonjs@29.0.2(rollup@4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248))':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq))
+      '@rollup/pluginutils': 5.3.0(rollup@4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248))
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3842,31 +3855,31 @@ snapshots:
       magic-string: 0.30.21
       picomatch: 4.0.4
     optionalDependencies:
-      rollup: 4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq)
+      rollup: 4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248)
 
-  '@rollup/plugin-json@6.1.0(rollup@4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq))':
+  '@rollup/plugin-json@6.1.0(rollup@4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248))':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq))
+      '@rollup/pluginutils': 5.3.0(rollup@4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248))
     optionalDependencies:
-      rollup: 4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq)
+      rollup: 4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248)
 
-  '@rollup/plugin-node-resolve@16.0.3(rollup@4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq))':
+  '@rollup/plugin-node-resolve@16.0.3(rollup@4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248))':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq))
+      '@rollup/pluginutils': 5.3.0(rollup@4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248))
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.11
     optionalDependencies:
-      rollup: 4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq)
+      rollup: 4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248)
 
-  '@rollup/pluginutils@5.3.0(rollup@4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq))':
+  '@rollup/pluginutils@5.3.0(rollup@4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248))':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
-      rollup: 4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq)
+      rollup: 4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248)
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -3948,15 +3961,15 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.69.2(patch_hash=ioxopooydvkqrz5sfysetr3ozi)(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.56.4(@typescript-eslint/types@8.53.1))(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))':
+  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.69.2(patch_hash=f35513c93bdfe798a534e43824cf9bc7c123bf2464047ccc5d9ed9867c26f4e4)(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.56.4(@typescript-eslint/types@8.53.1))(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))':
     dependencies:
-      '@rollup/plugin-commonjs': 29.0.2(rollup@4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq))
-      '@rollup/plugin-json': 6.1.0(rollup@4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq))
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq))
-      '@sveltejs/kit': 2.69.2(patch_hash=ioxopooydvkqrz5sfysetr3ozi)(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.56.4(@typescript-eslint/types@8.53.1))(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
-      rollup: 4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq)
+      '@rollup/plugin-commonjs': 29.0.2(rollup@4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248))
+      '@rollup/plugin-json': 6.1.0(rollup@4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248))
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248))
+      '@sveltejs/kit': 2.69.2(patch_hash=f35513c93bdfe798a534e43824cf9bc7c123bf2464047ccc5d9ed9867c26f4e4)(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.56.4(@typescript-eslint/types@8.53.1))(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      rollup: 4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248)
 
-  '@sveltejs/kit@2.69.2(patch_hash=ioxopooydvkqrz5sfysetr3ozi)(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.56.4(@typescript-eslint/types@8.53.1))(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
+  '@sveltejs/kit@2.69.2(patch_hash=f35513c93bdfe798a534e43824cf9bc7c123bf2464047ccc5d9ed9867c26f4e4)(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.56.4(@typescript-eslint/types@8.53.1))(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.11(acorn@8.16.0)
@@ -5785,6 +5798,11 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prettier-plugin-svelte@4.1.1(prettier@3.8.1)(svelte@5.56.4(@typescript-eslint/types@8.53.1)):
+    dependencies:
+      prettier: 3.8.1
+      svelte: 5.56.4(@typescript-eslint/types@8.53.1)
+
   prettier@3.8.1: {}
 
   pretty-format@27.5.1:
@@ -5906,7 +5924,7 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
-  rollup@4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq):
+  rollup@4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248):
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
@@ -6286,7 +6304,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
       postcss: 8.5.17
-      rollup: 4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq)
+      rollup: 4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248)
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.19.7
@@ -6301,7 +6319,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
       postcss: 8.5.17
-      rollup: 4.59.0(patch_hash=ucodry5rwsvqoy3uc2v6oocfeq)
+      rollup: 4.59.0(patch_hash=f31ed8307e22e66f5490b9eb104740c54dc64c6c68d19857b9917fb809d3b248)
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.5.2

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.231
+version: 0.1.232

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.231
+      targetRevision: 0.1.232
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.92
+version: 0.4.93

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.92
+      targetRevision: 0.4.93
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.281
+version: 0.89.283
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.281
+      targetRevision: 0.89.283
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.355
+version: 0.285.357
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.355
+      targetRevision: 0.285.357
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/components/notes/GraphLegend.svelte
+++ b/projects/monolith/frontend/src/lib/components/notes/GraphLegend.svelte
@@ -10,9 +10,7 @@
       return acc;
     }, {}),
   );
-  let entries = $derived(
-    Object.entries(counts).sort((a, b) => b[1] - a[1]),
-  );
+  let entries = $derived(Object.entries(counts).sort((a, b) => b[1] - a[1]));
 </script>
 
 <div class="legend">

--- a/projects/monolith/frontend/src/lib/components/notes/KnowledgeGraph.svelte
+++ b/projects/monolith/frontend/src/lib/components/notes/KnowledgeGraph.svelte
@@ -858,11 +858,7 @@
 </script>
 
 <div class="stage" bind:this={stage}>
-  <canvas
-    bind:this={canvas}
-    class:panning
-    class:over-node={overNode}
-  ></canvas>
+  <canvas bind:this={canvas} class:panning class:over-node={overNode}></canvas>
 </div>
 
 <style>

--- a/projects/monolith/frontend/src/lib/components/notes/NotePanel.svelte
+++ b/projects/monolith/frontend/src/lib/components/notes/NotePanel.svelte
@@ -12,9 +12,7 @@
   } = $props();
 
   let byId = $derived(new Map(nodes.map((n) => [n.id, n])));
-  let titleMap = $derived(
-    new Map(nodes.map((n) => [n.title, { id: n.id }])),
-  );
+  let titleMap = $derived(new Map(nodes.map((n) => [n.title, { id: n.id }])));
   let selectedNode = $derived(byId.get(selectedId));
 
   // Dedupe per column: a single source/target pair can have multiple
@@ -63,10 +61,7 @@
     // Drop trailing `## links` / `## related` / `## related links`
     // section through end of document. Case-insensitive, optional
     // pluralisation.
-    s = s.replace(
-      /\n##+\s+(?:related\s+)?links?\b[^\n]*\n[\s\S]*$/i,
-      "",
-    );
+    s = s.replace(/\n##+\s+(?:related\s+)?links?\b[^\n]*\n[\s\S]*$/i, "");
     s = s.replace(/\n##+\s+related\b[^\n]*\n[\s\S]*$/i, "");
     return s.trimEnd();
   }
@@ -87,7 +82,9 @@
     fetch(`${apiBase}/${encodeURIComponent(selectedId)}`, {
       signal: controller.signal,
     })
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error("fetch failed"))))
+      .then((r) =>
+        r.ok ? r.json() : Promise.reject(new Error("fetch failed")),
+      )
       .then((data) => {
         // Private endpoint returns `content` (raw markdown incl. frontmatter,
         // trimmed client-side); public endpoint returns `body` (already
@@ -114,14 +111,16 @@
 {#if selectedNode}
   <aside class="panel">
     <div class="panel-head">
-      <span class="panel-dot" style:background={colorFor(selectedNode.type)}></span>
+      <span class="panel-dot" style:background={colorFor(selectedNode.type)}
+      ></span>
       <div class="panel-titlewrap">
         <div class="panel-eyebrow">
           {labelFor(selectedNode.type).toUpperCase()}
         </div>
         <div class="panel-title">{selectedNode.title}</div>
       </div>
-      <button class="panel-close" onclick={onClose} aria-label="close">×</button>
+      <button class="panel-close" onclick={onClose} aria-label="close">×</button
+      >
     </div>
 
     <div
@@ -147,8 +146,13 @@
         <ul class="link-list">
           {#each backlinks.slice(0, 10) as nb}
             <li>
-              <button type="button" class="link-row" onclick={() => onSelect(nb.id)}>
-                <span class="swatch" style:background={colorFor(nb.type)}></span>
+              <button
+                type="button"
+                class="link-row"
+                onclick={() => onSelect(nb.id)}
+              >
+                <span class="swatch" style:background={colorFor(nb.type)}
+                ></span>
                 <span>{nb.title}</span>
               </button>
             </li>
@@ -166,8 +170,13 @@
         <ul class="link-list">
           {#each outgoing.slice(0, 10) as nb}
             <li>
-              <button type="button" class="link-row" onclick={() => onSelect(nb.id)}>
-                <span class="swatch" style:background={colorFor(nb.type)}></span>
+              <button
+                type="button"
+                class="link-row"
+                onclick={() => onSelect(nb.id)}
+              >
+                <span class="swatch" style:background={colorFor(nb.type)}
+                ></span>
                 <span>{nb.title}</span>
               </button>
             </li>

--- a/projects/monolith/frontend/src/lib/components/notes/StatusBar.svelte
+++ b/projects/monolith/frontend/src/lib/components/notes/StatusBar.svelte
@@ -23,8 +23,10 @@
 <div class="statusbar">
   <div class="statusbar-track">
     <span class="stat">~/KG</span>
-    <span class="stat"><strong>{nodeCount.toLocaleString()}</strong> NOTES</span>
-    <span class="stat"><strong>{edgeCount.toLocaleString()}</strong> LINKS</span>
+    <span class="stat"><strong>{nodeCount.toLocaleString()}</strong> NOTES</span
+    >
+    <span class="stat"><strong>{edgeCount.toLocaleString()}</strong> LINKS</span
+    >
     <span class="stat"><strong>{clusterCount}</strong> CLUSTERS</span>
     <span class="stat">ZOOM <strong>{zoom.toFixed(2)}</strong>×</span>
     <span class="stat">HOVER <strong>{hoverTitle}</strong></span>

--- a/projects/monolith/frontend/src/lib/private/components/UndoToast.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/UndoToast.svelte
@@ -8,12 +8,7 @@
   //   onUndo   — () => void, invoked when the user clicks Undo
   //   onDismiss — () => void, invoked on auto-timeout or X click
   //   durationMs — auto-dismiss delay (default 10s)
-  let {
-    label,
-    onUndo,
-    onDismiss,
-    durationMs = 10_000,
-  } = $props();
+  let { label, onUndo, onDismiss, durationMs = 10_000 } = $props();
 
   // Restart the auto-dismiss timer whenever the label changes — useful
   // when the user deletes another item before the previous toast has
@@ -34,8 +29,8 @@
     type="button"
     class="toast-dismiss"
     aria-label="Dismiss"
-    onclick={() => onDismiss?.()}
-  >×</button>
+    onclick={() => onDismiss?.()}>×</button
+  >
 </div>
 
 <style>

--- a/projects/monolith/frontend/src/lib/private/components/demos/K8sTerminalPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/K8sTerminalPanel.svelte
@@ -127,8 +127,14 @@
   function estimateGeometry() {
     if (!cardEl) return { cols: FALLBACK_COLS, rows: FALLBACK_ROWS };
     const rect = cardEl.getBoundingClientRect();
-    const cols = Math.max(20, Math.floor(rect.width / CHAR_W_PX) || FALLBACK_COLS);
-    const rows = Math.max(8, Math.floor(rect.height / CHAR_H_PX) || FALLBACK_ROWS);
+    const cols = Math.max(
+      20,
+      Math.floor(rect.width / CHAR_W_PX) || FALLBACK_COLS,
+    );
+    const rows = Math.max(
+      8,
+      Math.floor(rect.height / CHAR_H_PX) || FALLBACK_ROWS,
+    );
     return { cols, rows };
   }
 
@@ -254,7 +260,9 @@
 
   function sendResize() {
     if (!term || !ws || ws.readyState !== WebSocket.OPEN) return;
-    ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+    ws.send(
+      JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }),
+    );
   }
 
   function teardownSession() {
@@ -272,7 +280,10 @@
     if (ws) {
       const socket = ws;
       ws = null;
-      if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+      if (
+        socket.readyState === WebSocket.OPEN ||
+        socket.readyState === WebSocket.CONNECTING
+      ) {
         socket.close();
       }
     }
@@ -307,7 +318,10 @@
       <span class="chip-label">{chip.label}</span>
     </div>
     {#if status?.warm}
-      <span class="warm-badge" title="A banked snapshot exists; the next wake attempts a relight">
+      <span
+        class="warm-badge"
+        title="A banked snapshot exists; the next wake attempts a relight"
+      >
         warm snapshot ready
       </span>
     {/if}
@@ -383,9 +397,8 @@
   {/if}
 
   <p class="footnote">
-    This is a real 3-node k3s cluster in Firecracker microVMs. It wakes when
-    you connect and banks to memory snapshots about 10 minutes after you
-    disconnect.
+    This is a real 3-node k3s cluster in Firecracker microVMs. It wakes when you
+    connect and banks to memory snapshots about 10 minutes after you disconnect.
   </p>
 </section>
 

--- a/projects/monolith/frontend/src/lib/private/components/demos/LoadTestPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/LoadTestPanel.svelte
@@ -71,7 +71,9 @@
     });
     const data = await res.json().catch(() => ({}));
     if (!res.ok) {
-      const err = new Error(data?.error || data?.detail || `HTTP ${res.status}`);
+      const err = new Error(
+        data?.error || data?.detail || `HTTP ${res.status}`,
+      );
       err.status = res.status;
       throw err;
     }
@@ -131,7 +133,10 @@
     startError = null;
     busyNotice = false;
     try {
-      const data = await postJson(`/api/demos/firecracker/load-test/${workload}`, {});
+      const data = await postJson(
+        `/api/demos/firecracker/load-test/${workload}`,
+        {},
+      );
       runId = data.run_id;
       // already_running is not an error: adopt the existing run and poll it.
       resetReceipts();
@@ -230,7 +235,9 @@
   let scansPage = $derived(
     scansTotal > 0 ? Math.floor(scansOffset / SCANS_PAGE_SIZE) + 1 : 0,
   );
-  let scansPageCount = $derived(Math.max(1, Math.ceil(scansTotal / SCANS_PAGE_SIZE)));
+  let scansPageCount = $derived(
+    Math.max(1, Math.ceil(scansTotal / SCANS_PAGE_SIZE)),
+  );
 
   function fmt(n, digits = 1) {
     return n == null ? "-" : Number(n).toFixed(digits);
@@ -311,7 +318,8 @@
     {#if view === "live"}
       <div class="lt-live">
         <div class="throughput-hero">
-          <span class="throughput-value">{fmt(rollup.throughput_per_s, 2)}</span>
+          <span class="throughput-value">{fmt(rollup.throughput_per_s, 2)}</span
+          >
           <span class="throughput-unit">{nounPlural}/s</span>
         </div>
 
@@ -337,7 +345,9 @@
           </div>
           <div class="stat">
             <span class="stat-label">errors</span>
-            <span class="stat-value" class:stat-value--bad={(rollup.errors ?? 0) > 0}
+            <span
+              class="stat-value"
+              class:stat-value--bad={(rollup.errors ?? 0) > 0}
               >{rollup.errors ?? 0}</span
             >
           </div>
@@ -355,7 +365,9 @@
           </div>
           <div class="stat">
             <span class="stat-label">mean peak rss</span>
-            <span class="stat-value">{fmt(rollup.peak_rss_mib_mean, 0)} MiB</span>
+            <span class="stat-value"
+              >{fmt(rollup.peak_rss_mib_mean, 0)} MiB</span
+            >
           </div>
         </div>
 
@@ -378,11 +390,15 @@
             <span class="extrap-label">extrapolation</span>
             <div class="extrap-figures">
               <div class="extrap-figure">
-                <span class="extrap-value">{fmt(s.extrapolation?.per_node_throughput_per_s, 2)}</span>
+                <span class="extrap-value"
+                  >{fmt(s.extrapolation?.per_node_throughput_per_s, 2)}</span
+                >
                 <span class="extrap-unit">{nounPlural}/s per node</span>
               </div>
               <div class="extrap-figure">
-                <span class="extrap-value">{fmt(s.extrapolation?.scans_per_core_s, 3)}</span>
+                <span class="extrap-value"
+                  >{fmt(s.extrapolation?.scans_per_core_s, 3)}</span
+                >
                 <span class="extrap-unit">{nounPlural}/core/s</span>
               </div>
             </div>
@@ -395,13 +411,19 @@
               <div class="stat">
                 <span class="stat-label">daemon cpu (mean/max)</span>
                 <span class="stat-value"
-                  >{fmt(s.daemon?.pod_cpu_m?.mean, 0)} / {fmt(s.daemon?.pod_cpu_m?.max, 0)}m</span
+                  >{fmt(s.daemon?.pod_cpu_m?.mean, 0)} / {fmt(
+                    s.daemon?.pod_cpu_m?.max,
+                    0,
+                  )}m</span
                 >
               </div>
               <div class="stat">
                 <span class="stat-label">daemon rss (mean/max)</span>
                 <span class="stat-value"
-                  >{fmt(s.daemon?.pod_rss_mib?.mean, 0)} / {fmt(s.daemon?.pod_rss_mib?.max, 0)} MiB</span
+                  >{fmt(s.daemon?.pod_rss_mib?.mean, 0)} / {fmt(
+                    s.daemon?.pod_rss_mib?.max,
+                    0,
+                  )} MiB</span
                 >
               </div>
               <div class="stat">
@@ -412,13 +434,19 @@
                 <div class="stat">
                   <span class="stat-label">node cpu (mean/max)</span>
                   <span class="stat-value"
-                    >{fmt(s.node?.cpu_m?.mean, 0)} / {fmt(s.node?.cpu_m?.max, 0)}m</span
+                    >{fmt(s.node?.cpu_m?.mean, 0)} / {fmt(
+                      s.node?.cpu_m?.max,
+                      0,
+                    )}m</span
                   >
                 </div>
                 <div class="stat">
                   <span class="stat-label">node rss (mean/max)</span>
                   <span class="stat-value"
-                    >{fmt(s.node?.rss_mib?.mean, 0)} / {fmt(s.node?.rss_mib?.max, 0)} MiB</span
+                    >{fmt(s.node?.rss_mib?.mean, 0)} / {fmt(
+                      s.node?.rss_mib?.max,
+                      0,
+                    )} MiB</span
                   >
                 </div>
               {/if}
@@ -426,31 +454,44 @@
           </div>
 
           <div class="summary-section">
-            <span class="section-title">{noun} time + per-{noun} resources</span>
+            <span class="section-title">{noun} time + per-{noun} resources</span
+            >
             <div class="stat-grid">
               <div class="stat">
                 <span class="stat-label">{noun} time p50/p95/max</span>
                 <span class="stat-value"
-                  >{fmt(s.latency_ms?.p50, 0)} / {fmt(s.latency_ms?.p95, 0)} / {fmt(s.latency_ms?.max, 0)}ms</span
+                  >{fmt(s.latency_ms?.p50, 0)} / {fmt(s.latency_ms?.p95, 0)} / {fmt(
+                    s.latency_ms?.max,
+                    0,
+                  )}ms</span
                 >
               </div>
               <div class="stat">
                 <span class="stat-label">per-{noun} cpu p50/p95</span>
                 <span class="stat-value"
-                  >{fmt(s.per_scan_cpu_ms?.p50, 0)} / {fmt(s.per_scan_cpu_ms?.p95, 0)}ms</span
+                  >{fmt(s.per_scan_cpu_ms?.p50, 0)} / {fmt(
+                    s.per_scan_cpu_ms?.p95,
+                    0,
+                  )}ms</span
                 >
               </div>
               <div class="stat">
                 <span class="stat-label">per-{noun} peak rss p50/p95</span>
                 <span class="stat-value"
-                  >{fmt(s.per_scan_peak_rss_mib?.p50, 0)} / {fmt(s.per_scan_peak_rss_mib?.p95, 0)} MiB</span
+                  >{fmt(s.per_scan_peak_rss_mib?.p50, 0)} / {fmt(
+                    s.per_scan_peak_rss_mib?.p95,
+                    0,
+                  )} MiB</span
                 >
               </div>
               {#if s.result_count}
                 <div class="stat">
                   <span class="stat-label">result count p50/p95/max</span>
                   <span class="stat-value"
-                    >{fmt(s.result_count?.p50, 1)} / {fmt(s.result_count?.p95, 1)} / {fmt(s.result_count?.max, 0)}</span
+                    >{fmt(s.result_count?.p50, 1)} / {fmt(
+                      s.result_count?.p95,
+                      1,
+                    )} / {fmt(s.result_count?.max, 0)}</span
                   >
                 </div>
               {/if}
@@ -458,13 +499,16 @@
                 <div class="stat">
                   <span class="stat-label">exit 0 / nonzero</span>
                   <span class="stat-value"
-                    >{s.sandbox_exit.ok_count ?? 0} / {s.sandbox_exit.nonzero_count ?? 0}</span
+                    >{s.sandbox_exit.ok_count ?? 0} / {s.sandbox_exit
+                      .nonzero_count ?? 0}</span
                   >
                 </div>
               {/if}
               <div class="stat">
                 <span class="stat-label">total {nounPlural} / errors</span>
-                <span class="stat-value">{s.total_scans ?? 0} / {s.errors ?? 0}</span>
+                <span class="stat-value"
+                  >{s.total_scans ?? 0} / {s.errors ?? 0}</span
+                >
               </div>
             </div>
           </div>
@@ -478,7 +522,10 @@
                     <span class="lang-name">{name}</span>
                     <span class="lang-count">{stats.count}</span>
                     <span class="lang-extra"
-                      >p50 {fmt(stats.p50_ms, 0)}ms · cpu p50 {fmt(stats.p50_cpu_ms, 0)}ms</span
+                      >p50 {fmt(stats.p50_ms, 0)}ms · cpu p50 {fmt(
+                        stats.p50_cpu_ms,
+                        0,
+                      )}ms</span
                     >
                   </div>
                 {/each}
@@ -492,35 +539,47 @@
     {:else if view === "receipts"}
       <div class="lt-receipts">
         {#if selectedScan}
-          <button type="button" class="back-link" onclick={() => (selectedScan = null)}>
+          <button
+            type="button"
+            class="back-link"
+            onclick={() => (selectedScan = null)}
+          >
             &larr; back to scans
           </button>
           {#if selectedScanLoading}
             <p class="result-empty">Loading...</p>
           {:else if selectedScanError}
-            <div class="notice notice--error" role="alert">{selectedScanError}</div>
+            <div class="notice notice--error" role="alert">
+              {selectedScanError}
+            </div>
           {:else}
             <div class="scan-detail">
               <div class="result-grid">
                 <span class="result-key">{noun}</span>
-                <span class="result-val">#{selectedScan.seq} · {selectedScan.name}</span>
+                <span class="result-val"
+                  >#{selectedScan.seq} · {selectedScan.name}</span
+                >
               </div>
               <div class="result-grid">
                 <span class="result-key">status</span>
-                <span class="result-val" class:result-val--bad={selectedScan.status === "error"}
+                <span
+                  class="result-val"
+                  class:result-val--bad={selectedScan.status === "error"}
                   >{selectedScan.status}</span
                 >
               </div>
               <div class="result-grid">
                 <span class="result-key">{noun} time / cpu / rss</span>
                 <span class="result-val"
-                  >{selectedScan.scan_ms ?? "-"}ms / {selectedScan.cpu_ms ?? "-"}ms
-                  / {selectedScan.peak_rss_mib ?? "-"} MiB</span
+                  >{selectedScan.scan_ms ?? "-"}ms / {selectedScan.cpu_ms ??
+                    "-"}ms / {selectedScan.peak_rss_mib ?? "-"} MiB</span
                 >
               </div>
 
               {#if selectedScan.error}
-                <div class="notice notice--error" role="alert">{selectedScan.error}</div>
+                <div class="notice notice--error" role="alert">
+                  {selectedScan.error}
+                </div>
               {/if}
 
               {#if workload === "semgrep"}
@@ -545,7 +604,8 @@
                 {#if selectedScan.result?.errors?.length}
                   <div class="result-block">
                     <span class="body-label">scan errors</span>
-                    <pre class="body-text body-text--error">{selectedScan.result.errors.join(
+                    <pre
+                      class="body-text body-text--error">{selectedScan.result.errors.join(
                         "\n",
                       )}</pre>
                   </div>
@@ -564,7 +624,9 @@
                 </div>
                 <div class="result-grid">
                   <span class="result-key">duration</span>
-                  <span class="result-val">{selectedScan.result?.duration_ms ?? "-"}ms</span>
+                  <span class="result-val"
+                    >{selectedScan.result?.duration_ms ?? "-"}ms</span
+                  >
                 </div>
                 {#if selectedScan.result?.stdout}
                   <div class="result-block">
@@ -575,7 +637,8 @@
                 {#if selectedScan.result?.stderr}
                   <div class="result-block">
                     <span class="body-label">stderr</span>
-                    <pre class="body-text body-text--error">{selectedScan.result.stderr}</pre>
+                    <pre class="body-text body-text--error">{selectedScan.result
+                        .stderr}</pre>
                   </div>
                 {/if}
               {/if}
@@ -619,10 +682,16 @@
             </table>
 
             <div class="pager">
-              <button type="button" onclick={prevPage} disabled={scansOffset <= 0}>
+              <button
+                type="button"
+                onclick={prevPage}
+                disabled={scansOffset <= 0}
+              >
                 Prev
               </button>
-              <span class="pager-label">page {scansPage} of {scansPageCount}</span>
+              <span class="pager-label"
+                >page {scansPage} of {scansPageCount}</span
+              >
               <button
                 type="button"
                 onclick={nextPage}
@@ -721,8 +790,13 @@
 
   .notice--warn {
     color: var(--ink);
-    background: color-mix(in srgb, var(--loadtest-highlight) 18%, var(--surface));
-    border: 1px solid color-mix(in srgb, var(--loadtest-highlight) 40%, var(--line));
+    background: color-mix(
+      in srgb,
+      var(--loadtest-highlight) 18%,
+      var(--surface)
+    );
+    border: 1px solid
+      color-mix(in srgb, var(--loadtest-highlight) 40%, var(--line));
   }
 
   .lt-tabs {
@@ -904,8 +978,13 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-    border: 1px solid color-mix(in srgb, var(--loadtest-highlight) 40%, var(--line));
-    background: color-mix(in srgb, var(--loadtest-highlight) 10%, var(--surface));
+    border: 1px solid
+      color-mix(in srgb, var(--loadtest-highlight) 40%, var(--line));
+    background: color-mix(
+      in srgb,
+      var(--loadtest-highlight) 10%,
+      var(--surface)
+    );
     border-radius: 8px;
     padding: 16px 18px;
   }

--- a/projects/monolith/frontend/src/lib/private/components/demos/PostgresPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/PostgresPanel.svelte
@@ -217,10 +217,16 @@
     const next = new Date(now);
     next.setMinutes(0, 0, 0);
     next.setHours(next.getHours() + 1);
-    const remainingS = Math.max(0, Math.round((next.getTime() - now.getTime()) / 1000));
+    const remainingS = Math.max(
+      0,
+      Math.round((next.getTime() - now.getTime()) / 1000),
+    );
     const mm = String(Math.floor(remainingS / 60)).padStart(2, "0");
     const ss = String(remainingS % 60).padStart(2, "0");
-    const clockLabel = next.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    const clockLabel = next.toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
     return { mmss: `${mm}:${ss}`, clockLabel };
   });
 
@@ -234,7 +240,12 @@
   let lastOwnActivityAt = 0;
   let othersWoke = $state(false);
 
-  const WAKING_STATES = new Set(["relighting", "cold_booting", "starting", "serving"]);
+  const WAKING_STATES = new Set([
+    "relighting",
+    "cold_booting",
+    "starting",
+    "serving",
+  ]);
 
   async function pollStatus() {
     try {
@@ -283,7 +294,10 @@
       return { ok: false, permanent: true, error: body.detail };
     }
     if (!resp.ok) {
-      return { ok: false, error: body?.detail || `query failed (${resp.status})` };
+      return {
+        ok: false,
+        error: body?.detail || `query failed (${resp.status})`,
+      };
     }
     if (body.error) {
       return { ok: false, error: body.error };
@@ -452,7 +466,9 @@
   }
 
   function mibSeconds(v) {
-    return v < 1024 ? `${Math.round(v)} MiB·s` : `${(v / 1024).toFixed(1)} GiB·s`;
+    return v < 1024
+      ? `${Math.round(v)} MiB·s`
+      : `${(v / 1024).toFixed(1)} GiB·s`;
   }
 
   // Compact number formatting shared by the aggregate headline and the
@@ -519,7 +535,7 @@
   });
 
   let maxRevenue = $derived(
-    Math.max(1, ...((lastRun?.breakdown ?? []).map((b) => b.revenue))),
+    Math.max(1, ...(lastRun?.breakdown ?? []).map((b) => b.revenue)),
   );
 
   // Asleep hero copy: the volume size and best-known relight time, so the
@@ -530,7 +546,9 @@
       : "some",
   );
 
-  let asleepWake = $derived(tiers.relight != null ? ms(tiers.relight) : "under 100 ms");
+  let asleepWake = $derived(
+    tiers.relight != null ? ms(tiers.relight) : "under 100 ms",
+  );
 
   // Dozing narration while serving-but-idle: an approach, not a countdown.
   let dozeHint = $derived(
@@ -570,7 +588,9 @@
           {asleepWake}.
         </p>
       {:else}
-        <p class="state-sentence">{dozeHint ?? othersHint ?? stateView.sentence}</p>
+        <p class="state-sentence">
+          {dozeHint ?? othersHint ?? stateView.sentence}
+        </p>
       {/if}
       <dl class="state-facts">
         <div>
@@ -579,7 +599,13 @@
         </div>
         <div>
           <dt>snapshot pairs</dt>
-          <dd>{status?.pair_valid == null ? "–" : status.pair_valid ? "yes" : "no"}</dd>
+          <dd>
+            {status?.pair_valid == null
+              ? "–"
+              : status.pair_valid
+                ? "yes"
+                : "no"}
+          </dd>
         </div>
         <div>
           <dt>volume</dt>
@@ -632,8 +658,8 @@
         </button>
       </div>
       <p class="destructive-caption">
-        cold boot destroys the VM but keeps the data; the ledger clears
-        itself on the hour
+        cold boot destroys the VM but keeps the data; the ledger clears itself
+        on the hour
       </p>
     </div>
 
@@ -641,7 +667,8 @@
       <p class="run-error">
         {runError}
         <span class="run-error-hint">
-          (a refused connect usually means the wake-rate limiter; wait a beat and retry)
+          (a refused connect usually means the wake-rate limiter; wait a beat
+          and retry)
         </span>
       </p>
     {/if}
@@ -655,15 +682,25 @@
           <span class="last-run-label">wake + connect</span>
         </div>
         <div class="last-run-big">
-          <span class="last-run-value">{running ? "–" : ms(lastRun?.query_ms)}</span>
+          <span class="last-run-value"
+            >{running ? "–" : ms(lastRun?.query_ms)}</span
+          >
           <span class="last-run-label">query</span>
         </div>
       </div>
-      <p class="last-run-narration">{running ? wakeNarration : lastRunSentence}</p>
+      <p class="last-run-narration">
+        {running ? wakeNarration : lastRunSentence}
+      </p>
       <div class="timing-bar" aria-hidden="true">
         {#if lastRun}
-          <span class="bar-connect" style:width="{barPct(lastRun, lastRun.connect_ms)}%"></span>
-          <span class="bar-query" style:width="{barPct(lastRun, lastRun.query_ms)}%"></span>
+          <span
+            class="bar-connect"
+            style:width="{barPct(lastRun, lastRun.connect_ms)}%"
+          ></span>
+          <span
+            class="bar-query"
+            style:width="{barPct(lastRun, lastRun.query_ms)}%"
+          ></span>
         {/if}
       </div>
     </div>
@@ -734,13 +771,25 @@
             <tfoot>
               <tr class="summary-total">
                 <td>Σ total</td>
-                <td class="col-numeric">{lastRun?.total_orders != null ? countHeadline((lastRun.breakdown ?? []).reduce((n, b) => n + b.units, 0)) : "–"} units</td>
-                <td class="col-numeric">{moneyHeadline(lastRun?.total_revenue)}</td>
+                <td class="col-numeric"
+                  >{lastRun?.total_orders != null
+                    ? countHeadline(
+                        (lastRun.breakdown ?? []).reduce(
+                          (n, b) => n + b.units,
+                          0,
+                        ),
+                      )
+                    : "–"} units</td
+                >
+                <td class="col-numeric"
+                  >{moneyHeadline(lastRun?.total_revenue)}</td
+                >
               </tr>
             </tfoot>
           </table>
           <p class="result-footer">
-            ({(lastRun?.breakdown ?? []).length} groups from {lastRun?.total_orders ?? 0} orders)
+            ({(lastRun?.breakdown ?? []).length} groups from {lastRun?.total_orders ??
+              0} orders)
           </p>
         </div>
       {:else}
@@ -749,7 +798,11 @@
             <thead>
               <tr>
                 {#each ORDER_COLUMNS as col (col.key)}
-                  <th class={col.key === "qty" || col.key === "unit_price" ? "col-numeric" : ""}>
+                  <th
+                    class={col.key === "qty" || col.key === "unit_price"
+                      ? "col-numeric"
+                      : ""}
+                  >
                     <span class="col-name">{col.label}</span>
                     <span class="col-type">{col.type}</span>
                   </th>
@@ -786,8 +839,8 @@
           <p class="result-footer">({lastRun?.total_orders ?? 0} rows)</p>
           <p class="result-note">
             Bands group rows written by the same database process. A new band
-            means the VM was rebuilt from scratch; older rows surviving it
-            show the data outlives the VM.
+            means the VM was rebuilt from scratch; older rows surviving it show
+            the data outlives the VM.
           </p>
         </div>
       {/if}

--- a/projects/monolith/frontend/src/lib/private/components/demos/RunPanel.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/RunPanel.svelte
@@ -23,14 +23,20 @@
     subTab = "single";
   });
 
-  let showsLoadTestTab = $derived(project.key === "python" || project.key === "semgrep");
-  let loadTestWorkload = $derived(project.key === "python" ? "sandbox" : "semgrep");
+  let showsLoadTestTab = $derived(
+    project.key === "python" || project.key === "semgrep",
+  );
+  let loadTestWorkload = $derived(
+    project.key === "python" ? "sandbox" : "semgrep",
+  );
 
   // Backend-measured timing label. Only the semgrep demo now bypasses the
   // idempotency dedupe (dedupe=false), so its timing is a genuine fresh scan;
   // the python sandbox tab still reports a plain invocation time, so the label
   // stays honest per project rather than saying "fresh scan" for everything.
-  let latencyLabel = $derived(project.key === "semgrep" ? "fresh scan" : "invocation");
+  let latencyLabel = $derived(
+    project.key === "semgrep" ? "fresh scan" : "invocation",
+  );
 
   // Inputs, seeded from the project's sample so Run works with zero edits,
   // but everything stays editable.
@@ -115,7 +121,9 @@
           const res = await fetch(`/api/demos/firecracker/goose/${threadId}`);
           if (!res.ok) {
             const data = await res.json().catch(() => ({}));
-            throw new Error(data?.error || data?.detail || `HTTP ${res.status}`);
+            throw new Error(
+              data?.error || data?.detail || `HTTP ${res.status}`,
+            );
           }
           const data = await res.json();
           gooseStatus = data.status;
@@ -220,176 +228,179 @@
   {#if showsLoadTestTab && subTab === "load"}
     <LoadTestPanel workload={loadTestWorkload} />
   {:else}
-  <div class="input-area">
-    {#if project.key === "python"}
-      <label class="field-label" for="python-code">code.py</label>
-      <textarea
-        id="python-code"
-        class="code-input"
-        bind:value={pythonCode}
-        spellcheck="false"
-        rows="12"
-      ></textarea>
-    {:else if project.key === "semgrep"}
-      <label class="field-label" for="semgrep-path">file path</label>
-      <input
-        id="semgrep-path"
-        class="text-input"
-        bind:value={semgrepPath}
-        spellcheck="false"
-      />
-      <label class="field-label" for="semgrep-code">file contents</label>
-      <textarea
-        id="semgrep-code"
-        class="code-input"
-        bind:value={semgrepCode}
-        spellcheck="false"
-        rows="12"
-      ></textarea>
-    {:else if project.key === "goose"}
-      <label class="field-label" for="goose-task">task</label>
-      <textarea
-        id="goose-task"
-        class="code-input code-input--prose"
-        bind:value={gooseTask}
-        spellcheck="true"
-        rows="5"
-      ></textarea>
-      <div class="goose-extra">
-        <div>
-          <label class="field-label" for="goose-recipe">recipe (optional)</label>
-          <input
-            id="goose-recipe"
-            class="text-input"
-            bind:value={gooseRecipe}
-            placeholder="default"
-          />
+    <div class="input-area">
+      {#if project.key === "python"}
+        <label class="field-label" for="python-code">code.py</label>
+        <textarea
+          id="python-code"
+          class="code-input"
+          bind:value={pythonCode}
+          spellcheck="false"
+          rows="12"></textarea>
+      {:else if project.key === "semgrep"}
+        <label class="field-label" for="semgrep-path">file path</label>
+        <input
+          id="semgrep-path"
+          class="text-input"
+          bind:value={semgrepPath}
+          spellcheck="false"
+        />
+        <label class="field-label" for="semgrep-code">file contents</label>
+        <textarea
+          id="semgrep-code"
+          class="code-input"
+          bind:value={semgrepCode}
+          spellcheck="false"
+          rows="12"></textarea>
+      {:else if project.key === "goose"}
+        <label class="field-label" for="goose-task">task</label>
+        <textarea
+          id="goose-task"
+          class="code-input code-input--prose"
+          bind:value={gooseTask}
+          spellcheck="true"
+          rows="5"></textarea>
+        <div class="goose-extra">
+          <div>
+            <label class="field-label" for="goose-recipe"
+              >recipe (optional)</label
+            >
+            <input
+              id="goose-recipe"
+              class="text-input"
+              bind:value={gooseRecipe}
+              placeholder="default"
+            />
+          </div>
+          <div>
+            <label class="field-label" for="goose-tier">tier (optional)</label>
+            <input
+              id="goose-tier"
+              class="text-input"
+              bind:value={gooseTier}
+              placeholder="default"
+            />
+          </div>
         </div>
-        <div>
-          <label class="field-label" for="goose-tier">tier (optional)</label>
-          <input
-            id="goose-tier"
-            class="text-input"
-            bind:value={gooseTier}
-            placeholder="default"
-          />
-        </div>
+      {/if}
+    </div>
+
+    <div class="run-bar">
+      <button
+        class="run-button"
+        class:run-button--running={running}
+        onclick={run}
+        disabled={running || !canRun}
+      >
+        {#if running}
+          <span class="spinner" aria-hidden="true"></span> Running
+        {:else}
+          Run
+        {/if}
+      </button>
+
+      <div class="latency" aria-live="polite">
+        <span class="latency-item">
+          <span class="latency-label">wall</span>
+          <span class="latency-value">{displayMs.toFixed(0)}ms</span>
+        </span>
+        {#if result?.duration_ms != null}
+          <span class="latency-item">
+            <span class="latency-label">{latencyLabel}</span>
+            <span class="latency-value">{result.duration_ms}ms</span>
+          </span>
+        {/if}
+      </div>
+    </div>
+
+    {#if errorMsg}
+      <div class="error-banner" role="alert">{errorMsg}</div>
+    {/if}
+
+    {#if project.key === "goose" && running}
+      <div class="goose-status">
+        <span class="pulse-dot" aria-hidden="true"></span>
+        status: {gooseStatus ?? "queued"}
       </div>
     {/if}
-  </div>
 
-  <div class="run-bar">
-    <button
-      class="run-button"
-      class:run-button--running={running}
-      onclick={run}
-      disabled={running || !canRun}
-    >
-      {#if running}
-        <span class="spinner" aria-hidden="true"></span> Running
-      {:else}
-        Run
-      {/if}
-    </button>
-
-    <div class="latency" aria-live="polite">
-      <span class="latency-item">
-        <span class="latency-label">wall</span>
-        <span class="latency-value">{displayMs.toFixed(0)}ms</span>
-      </span>
-      {#if result?.duration_ms != null}
-        <span class="latency-item">
-          <span class="latency-label">{latencyLabel}</span>
-          <span class="latency-value">{result.duration_ms}ms</span>
-        </span>
-      {/if}
-    </div>
-  </div>
-
-  {#if errorMsg}
-    <div class="error-banner" role="alert">{errorMsg}</div>
-  {/if}
-
-  {#if project.key === "goose" && running}
-    <div class="goose-status">
-      <span class="pulse-dot" aria-hidden="true"></span>
-      status: {gooseStatus ?? "queued"}
-    </div>
-  {/if}
-
-  {#if result}
-    <div class="result-pane">
-      {#if project.key === "python"}
-        <div class="result-grid">
-          <span class="result-key">exit code</span>
-          <span
-            class="result-val"
-            class:result-val--bad={result.exit_code !== 0}
-            >{result.exit_code}</span
-          >
-        </div>
-        {#if result.stdout}
-          <div class="result-block">
-            <span class="body-label">stdout</span>
-            <pre class="body-text">{result.stdout}</pre>
+    {#if result}
+      <div class="result-pane">
+        {#if project.key === "python"}
+          <div class="result-grid">
+            <span class="result-key">exit code</span>
+            <span
+              class="result-val"
+              class:result-val--bad={result.exit_code !== 0}
+              >{result.exit_code}</span
+            >
           </div>
-        {/if}
-        {#if result.stderr}
-          <div class="result-block">
-            <span class="body-label">stderr</span>
-            <pre class="body-text body-text--error">{result.stderr}</pre>
+          {#if result.stdout}
+            <div class="result-block">
+              <span class="body-label">stdout</span>
+              <pre class="body-text">{result.stdout}</pre>
+            </div>
+          {/if}
+          {#if result.stderr}
+            <div class="result-block">
+              <span class="body-label">stderr</span>
+              <pre class="body-text body-text--error">{result.stderr}</pre>
+            </div>
+          {/if}
+          {#if result.error}
+            <div class="error-banner" role="alert">{result.error}</div>
+          {/if}
+        {:else if project.key === "semgrep"}
+          {#if result.findings?.length}
+            <ul class="findings">
+              {#each result.findings as f}
+                <li class="finding">
+                  <span class="finding-sev {severityClass(f.severity)}"
+                    >{f.severity}</span
+                  >
+                  <span class="finding-loc"
+                    >{f.path}:{f.line}{f.col ? `:${f.col}` : ""}</span
+                  >
+                  <span class="finding-rule">{f.rule_id}</span>
+                  <span class="finding-msg">{f.message}</span>
+                </li>
+              {/each}
+            </ul>
+          {:else}
+            <p class="result-empty">No findings.</p>
+          {/if}
+          {#if result.errors?.length}
+            <div class="result-block">
+              <span class="body-label">scan errors</span>
+              <pre class="body-text body-text--error">{result.errors.join(
+                  "\n",
+                )}</pre>
+            </div>
+          {/if}
+          {#if result.error}
+            <div class="error-banner" role="alert">{result.error}</div>
+          {/if}
+        {:else if project.key === "goose"}
+          <div class="result-grid">
+            <span class="result-key">status</span>
+            <span class="result-val">{result.status}</span>
           </div>
+          {#if result.result}
+            <div class="result-block">
+              <span class="body-label">result</span>
+              <pre class="body-text">{typeof result.result === "string"
+                  ? result.result
+                  : JSON.stringify(result.result, null, 2)}</pre>
+            </div>
+          {/if}
+          {#if result.result_error}
+            <div class="error-banner" role="alert">{result.result_error}</div>
+          {/if}
         {/if}
-        {#if result.error}
-          <div class="error-banner" role="alert">{result.error}</div>
-        {/if}
-      {:else if project.key === "semgrep"}
-        {#if result.findings?.length}
-          <ul class="findings">
-            {#each result.findings as f}
-              <li class="finding">
-                <span class="finding-sev {severityClass(f.severity)}"
-                  >{f.severity}</span
-                >
-                <span class="finding-loc">{f.path}:{f.line}{f.col ? `:${f.col}` : ""}</span>
-                <span class="finding-rule">{f.rule_id}</span>
-                <span class="finding-msg">{f.message}</span>
-              </li>
-            {/each}
-          </ul>
-        {:else}
-          <p class="result-empty">No findings.</p>
-        {/if}
-        {#if result.errors?.length}
-          <div class="result-block">
-            <span class="body-label">scan errors</span>
-            <pre class="body-text body-text--error">{result.errors.join("\n")}</pre>
-          </div>
-        {/if}
-        {#if result.error}
-          <div class="error-banner" role="alert">{result.error}</div>
-        {/if}
-      {:else if project.key === "goose"}
-        <div class="result-grid">
-          <span class="result-key">status</span>
-          <span class="result-val">{result.status}</span>
-        </div>
-        {#if result.result}
-          <div class="result-block">
-            <span class="body-label">result</span>
-            <pre class="body-text">{typeof result.result === "string"
-                ? result.result
-                : JSON.stringify(result.result, null, 2)}</pre>
-          </div>
-        {/if}
-        {#if result.result_error}
-          <div class="error-banner" role="alert">{result.result_error}</div>
-        {/if}
-      {/if}
-    </div>
-  {/if}
+      </div>
+    {/if}
 
-  <TraceWaterfall {traceId} />
+    <TraceWaterfall {traceId} />
   {/if}
 </div>
 

--- a/projects/monolith/frontend/src/lib/private/components/demos/TraceWaterfall.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/demos/TraceWaterfall.svelte
@@ -50,7 +50,11 @@
   // teardown / bundle cleanup): real work, but off the caller's critical path,
   // so we dim them and tag them rather than let them read as latency the caller
   // waited on.
-  const OFF_PATH_SPANS = new Set(["guest_teardown", "vm_release", "bundle_cleanup"]);
+  const OFF_PATH_SPANS = new Set([
+    "guest_teardown",
+    "vm_release",
+    "bundle_cleanup",
+  ]);
 
   function isOffPath(name) {
     return OFF_PATH_SPANS.has(name);
@@ -97,7 +101,10 @@
       consecutiveErrors = 0;
     } catch (e) {
       consecutiveErrors += 1;
-      if (spans.length === 0 && consecutiveErrors >= MAX_CONSECUTIVE_ERRORS_WHEN_EMPTY) {
+      if (
+        spans.length === 0 &&
+        consecutiveErrors >= MAX_CONSECUTIVE_ERRORS_WHEN_EMPTY
+      ) {
         fetchError = e?.message ?? String(e);
         status = "error";
         stopPolling();
@@ -179,7 +186,10 @@
   }
 
   function timelineEndFor(set) {
-    return Math.max(1, ...set.map((s) => (s.start_ms ?? 0) + (s.duration_ms ?? 0)));
+    return Math.max(
+      1,
+      ...set.map((s) => (s.start_ms ?? 0) + (s.duration_ms ?? 0)),
+    );
   }
 
   // Bar geometry against a set's OWN timelineEnd, so the correlated goose set
@@ -191,7 +201,9 @@
   }
 
   let depthById = $derived(depthMapFor(spans));
-  let sortedSpans = $derived([...spans].sort((a, b) => a.start_ms - b.start_ms));
+  let sortedSpans = $derived(
+    [...spans].sort((a, b) => a.start_ms - b.start_ms),
+  );
   let timelineEnd = $derived(timelineEndFor(spans));
 
   let correlatedDepthById = $derived(depthMapFor(correlated));
@@ -274,7 +286,8 @@
   {:else}
     <div class="axis" aria-hidden="true">
       {#each axisTicks as tick}
-        <span class="axis-tick" style={`left: ${tick.pct}%;`}>{tick.label}</span>
+        <span class="axis-tick" style={`left: ${tick.pct}%;`}>{tick.label}</span
+        >
       {/each}
     </div>
 
@@ -287,7 +300,9 @@
         >
           <span class="row-label" title={`${span.name} · ${span.service}`}>
             {span.name}
-            {#if isOffPath(span.name)}<span class="row-tag">off critical path</span>{/if}
+            {#if isOffPath(span.name)}<span class="row-tag"
+                >off critical path</span
+              >{/if}
             <span class="row-service">{span.service}</span>
           </span>
           <div class="row-track">
@@ -319,8 +334,8 @@
       </div>
       <p class="correlated-note">
         The agent's own spans, correlated to this run by trace id. Goose runs in
-        its own trace (it does not honor an inbound parent context), so these are
-        shown on their own relative timeline rather than nested above.
+        its own trace (it does not honor an inbound parent context), so these
+        are shown on their own relative timeline rather than nested above.
       </p>
       <div class="rows">
         {#each sortedCorrelated as span (span.span_id)}

--- a/projects/monolith/frontend/src/lib/public/components/Footer.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/Footer.svelte
@@ -24,7 +24,9 @@
   </svg>
 
   <div class="wrap footer-content">
-    <Sticker color="var(--coral)" rotate={-4} class="footer-sticker">GET IN TOUCH</Sticker>
+    <Sticker color="var(--coral)" rotate={-4} class="footer-sticker"
+      >GET IN TOUCH</Sticker
+    >
     <h2 class="footer-headline">LET'S<br />BUILD SOMETHING.</h2>
     <div class="footer-links">
       <a href="mailto:joe@jomcgi.dev" class="btn btn-primary">JOE@JOMCGI.DEV</a>
@@ -78,7 +80,6 @@
     flex-wrap: wrap;
     margin-bottom: 48px;
   }
-
 
   /* Off-axis on purpose: the sticker hangs left of the centered headline. */
   :global(.footer-sticker) {

--- a/projects/monolith/frontend/src/lib/public/components/Marquee.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/Marquee.svelte
@@ -15,7 +15,8 @@
   <div class="marquee-track" style="animation-duration: {duration};">
     {#each { length: 3 } as _}
       {#each items as item}
-        <span class="marquee-item"><span class="marquee-dot"></span>{item}</span>
+        <span class="marquee-item"><span class="marquee-dot"></span>{item}</span
+        >
       {/each}
     {/each}
   </div>

--- a/projects/monolith/frontend/src/lib/public/components/Nav.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/Nav.svelte
@@ -21,9 +21,7 @@
   // REVIEW only renders on the private tier — the route exists only at
   // routes/private/review/ and showing the link on public.jomcgi.dev
   // would leak the existence of an internal surface.
-  const privateItems = [
-    { slug: "review", label: "REVIEW", href: "/review" },
-  ];
+  const privateItems = [{ slug: "review", label: "REVIEW", href: "/review" }];
 
   const items = $derived(
     isPrivate ? [...publicItems, ...privateItems] : publicItems,
@@ -180,7 +178,13 @@
                             stroke-linecap="round"
                             stroke-dasharray="0.2 3.4"
                           />
-                          <circle cx="5" cy="20" r="1.9" fill="currentColor" stroke="none" />
+                          <circle
+                            cx="5"
+                            cy="20"
+                            r="1.9"
+                            fill="currentColor"
+                            stroke="none"
+                          />
                           <path
                             d="M17 3 C 14.5 3 13 4.8 13 6.8 C 13 9.6 17 12.5 17 12.5 C 17 12.5 21 9.6 21 6.8 C 21 4.8 19.5 3 17 3 Z"
                             fill="none"
@@ -188,7 +192,13 @@
                             stroke-width="1.8"
                             stroke-linejoin="round"
                           />
-                          <circle cx="17" cy="6.8" r="1.4" fill="currentColor" stroke="none" />
+                          <circle
+                            cx="17"
+                            cy="6.8"
+                            r="1.4"
+                            fill="currentColor"
+                            stroke="none"
+                          />
                         </svg>
                       {:else if app.slug === "hikes"}
                         <svg width="22" height="22" viewBox="0 0 24 24">

--- a/projects/monolith/frontend/src/lib/public/components/ScrollCta.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ScrollCta.svelte
@@ -11,7 +11,11 @@
 </script>
 
 {#if visible}
-  <button class="scroll-bar" onclick={handleClick} transition:fade={{ duration: 300 }}>
+  <button
+    class="scroll-bar"
+    onclick={handleClick}
+    transition:fade={{ duration: 300 }}
+  >
     <span class="scroll-bar-inner">
       <span class="scroll-bar-label">HOMELAB SLOS</span>
       <span class="scroll-bar-arrow">↓</span>
@@ -59,8 +63,13 @@
   }
 
   @keyframes nudge {
-    0%, 100% { transform: translateY(0); }
-    50% { transform: translateY(3px); }
+    0%,
+    100% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(3px);
+    }
   }
 
   .scroll-bar:hover .scroll-bar-arrow {

--- a/projects/monolith/frontend/src/lib/public/components/TurnstileGate.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/TurnstileGate.svelte
@@ -116,9 +116,7 @@
     {#if status === "verifying"}
       <p class="turnstile-gate__note">Verifying…</p>
     {:else if status === "error"}
-      <p class="turnstile-gate__note">
-        Verification failed. Please try again.
-      </p>
+      <p class="turnstile-gate__note">Verification failed. Please try again.</p>
     {/if}
   </div>
 {/if}

--- a/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
@@ -37,14 +37,21 @@
     if (!legendOpen) return;
     function onDocPointerdown(e) {
       if (
-        legendEl && !legendEl.contains(e.target) &&
-        toggleEl && !toggleEl.contains(e.target)
+        legendEl &&
+        !legendEl.contains(e.target) &&
+        toggleEl &&
+        !toggleEl.contains(e.target)
       ) {
         legendOpen = false;
       }
     }
-    document.addEventListener("pointerdown", onDocPointerdown, { capture: true });
-    return () => document.removeEventListener("pointerdown", onDocPointerdown, { capture: true });
+    document.addEventListener("pointerdown", onDocPointerdown, {
+      capture: true,
+    });
+    return () =>
+      document.removeEventListener("pointerdown", onDocPointerdown, {
+        capture: true,
+      });
   });
 
   // Data-viz ramp colors: outside the design-token system (intentionally, same
@@ -341,12 +348,7 @@
                 ["interpolate", ["linear"], ["get", "good_days"], 0, 28, 7, 38],
               ],
             ],
-            "circle-stroke-width": [
-              "case",
-              ["==", ["get", "sel"], 1],
-              3,
-              1.5,
-            ],
+            "circle-stroke-width": ["case", ["==", ["get", "sel"], 1], 3, 1.5],
             "circle-stroke-color": STROKE,
             "circle-opacity": ["case", ["==", ["get", "sel"], 1], 1, 0.85],
           },
@@ -469,8 +471,8 @@
     aria-expanded={legendOpen}
     aria-controls="campsites-legend"
     onclick={() => (legendOpen = !legendOpen)}
-    bind:this={toggleEl}
-  >{legendOpen ? "Close" : "Legend"}</button>
+    bind:this={toggleEl}>{legendOpen ? "Close" : "Legend"}</button
+  >
 </div>
 
 <style>

--- a/projects/monolith/frontend/src/lib/public/components/diagrams/DArrow.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/diagrams/DArrow.svelte
@@ -11,7 +11,13 @@
   {#if label}<span class="darrow-label">{label}</span>{/if}
   <svg viewBox="0 0 34 12" width="34" height="12">
     <line x1="0" y1="6" x2="26" y2="6" stroke="var(--ink)" stroke-width="2.5" />
-    <path d="M24,1 L33,6 L24,11" fill="none" stroke="var(--ink)" stroke-width="2.5" stroke-linejoin="round" />
+    <path
+      d="M24,1 L33,6 L24,11"
+      fill="none"
+      stroke="var(--ink)"
+      stroke-width="2.5"
+      stroke-linejoin="round"
+    />
   </svg>
 </span>
 

--- a/projects/monolith/frontend/src/lib/public/components/hikes/HikesMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/hikes/HikesMap.svelte
@@ -1,7 +1,10 @@
 <script>
   import { onMount } from "svelte";
   import "maplibre-gl/dist/maplibre-gl.css";
-  import { groupWindowsByDay, windowFields } from "$lib/public/hikes/filters.js";
+  import {
+    groupWindowsByDay,
+    windowFields,
+  } from "$lib/public/hikes/filters.js";
 
   // `walks` is the filtered set to plot; clicking a marker opens the card.
   // `selectedDay` is the parent's chosen day chip (YYYY-MM-DD) or null for
@@ -91,7 +94,9 @@
     detailLoading = true;
     const token = ++detailToken;
     try {
-      const res = await fetch(`/app/hikes/walk/${encodeURIComponent(walk.uuid)}`);
+      const res = await fetch(
+        `/app/hikes/walk/${encodeURIComponent(walk.uuid)}`,
+      );
       if (!res.ok) throw new Error(`status ${res.status}`);
       const detail = await res.json();
       if (token !== detailToken) return; // a newer selection superseded this one
@@ -187,7 +192,9 @@
 
   // Window rows for the selected walk's card, grouped by UK-local day. Windows
   // come from the per-walk detail fetch (selectedDetail), not the light list.
-  let cardDays = $derived(selectedDetail ? groupWindowsByDay(selectedDetail) : {});
+  let cardDays = $derived(
+    selectedDetail ? groupWindowsByDay(selectedDetail) : {},
+  );
   let cardDayKeys = $derived(Object.keys(cardDays).sort());
   // The days the server judged DOABLE for this walk's length (duration-aware: a
   // long-enough run of good hours, see router._doable_days). The card honours it
@@ -374,8 +381,10 @@
 
   {#if selected}
     <aside class="card">
-      <button class="card-close" onclick={closeCard} aria-label="Close walk card"
-        >&times;</button
+      <button
+        class="card-close"
+        onclick={closeCard}
+        aria-label="Close walk card">&times;</button
       >
       <h2 class="card-name">
         <a href={selected.url} target="_blank" rel="noopener"
@@ -385,9 +394,18 @@
         >
       </h2>
       <dl class="card-stats">
-        <div><dt>Distance</dt><dd>{selected.distance_km} km</dd></div>
-        <div><dt>Ascent</dt><dd>{selected.ascent_m} m</dd></div>
-        <div><dt>Duration</dt><dd>{fmtDuration(selected.duration_h)}</dd></div>
+        <div>
+          <dt>Distance</dt>
+          <dd>{selected.distance_km} km</dd>
+        </div>
+        <div>
+          <dt>Ascent</dt>
+          <dd>{selected.ascent_m} m</dd>
+        </div>
+        <div>
+          <dt>Duration</dt>
+          <dd>{fmtDuration(selected.duration_h)}</dd>
+        </div>
       </dl>
       {#if selectedDetail?.summary}
         <p class="card-summary">{selectedDetail.summary}</p>

--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -65,12 +65,42 @@
   // Vessel-type filter. Each legend box toggles whether that ITU band shows on
   // the map; toggling sets a MapLibre layer filter on the `icon` property.
   const LEGEND = [
-    { key: "passenger", label: "Passenger", icon: "ship-passenger", color: VESSEL_COLORS.passenger },
-    { key: "cargo", label: "Cargo", icon: "ship-cargo", color: VESSEL_COLORS.cargo },
-    { key: "tanker", label: "Tanker", icon: "ship-tanker", color: VESSEL_COLORS.tanker },
-    { key: "hsc", label: "High-speed", icon: "ship-hsc", color: VESSEL_COLORS.hsc },
-    { key: "special", label: "Special", icon: "ship-special", color: VESSEL_COLORS.special },
-    { key: "unknown", label: "Other", icon: "ship-unknown", color: VESSEL_COLORS.unknown },
+    {
+      key: "passenger",
+      label: "Passenger",
+      icon: "ship-passenger",
+      color: VESSEL_COLORS.passenger,
+    },
+    {
+      key: "cargo",
+      label: "Cargo",
+      icon: "ship-cargo",
+      color: VESSEL_COLORS.cargo,
+    },
+    {
+      key: "tanker",
+      label: "Tanker",
+      icon: "ship-tanker",
+      color: VESSEL_COLORS.tanker,
+    },
+    {
+      key: "hsc",
+      label: "High-speed",
+      icon: "ship-hsc",
+      color: VESSEL_COLORS.hsc,
+    },
+    {
+      key: "special",
+      label: "Special",
+      icon: "ship-special",
+      color: VESSEL_COLORS.special,
+    },
+    {
+      key: "unknown",
+      label: "Other",
+      icon: "ship-unknown",
+      color: VESSEL_COLORS.unknown,
+    },
   ];
   // The full legend order, used as the vessel-type allow-list + "all on" default
   // for URL sync, and to write `types` in a stable order.
@@ -732,7 +762,11 @@
   });
 </script>
 
-<div class="map-wrap" class:heat-mode={mode === "heat"} class:panel-open={selected}>
+<div
+  class="map-wrap"
+  class:heat-mode={mode === "heat"}
+  class:panel-open={selected}
+>
   <div class="map" bind:this={mapContainer}></div>
 
   <nav class="map-chip" aria-label="Breadcrumb">
@@ -747,7 +781,10 @@
   </nav>
 
   <div class="mode-toggle" role="group" aria-label="Map mode">
-    <button class:active={mode === "vessels"} onclick={() => setMode("vessels")}>
+    <button
+      class:active={mode === "vessels"}
+      onclick={() => setMode("vessels")}
+    >
       Vessels
     </button>
     <button class:active={mode === "heat"} onclick={() => setMode("heat")}>
@@ -779,7 +816,8 @@
       <ul class="heat-scale">
         {#each heatBreaks.slice(0, HEAT_COLORS.length) as br, i (br)}
           <li>
-            <span class="heat-sw" style="background: {HEAT_COLORS[i]}"></span>{heatLabel(heatBreaks, i)}
+            <span class="heat-sw" style="background: {HEAT_COLORS[i]}"
+            ></span>{heatLabel(heatBreaks, i)}
           </li>
         {/each}
       </ul>
@@ -788,18 +826,35 @@
 
   {#if selected}
     <aside class="panel">
-      <button class="panel-close" onclick={closePanel} aria-label="Close vessel panel"
-        >&times;</button
+      <button
+        class="panel-close"
+        onclick={closePanel}
+        aria-label="Close vessel panel">&times;</button
       >
       <h2 class="panel-name">
         {selected.name || selected.ship_name || `MMSI ${selected.mmsi}`}
       </h2>
       <dl class="panel-rows">
-        <div><dt>MMSI</dt><dd>{selected.mmsi}</dd></div>
-        <div><dt>Type</dt><dd>{shipTypeLabel(selected.ship_type)}</dd></div>
-        <div><dt>Speed</dt><dd>{fmtSpeed(selected.speed)}</dd></div>
-        <div><dt>Course</dt><dd>{fmtDeg(selected.course)}</dd></div>
-        <div><dt>Heading</dt><dd>{fmtDeg(selected.heading)}</dd></div>
+        <div>
+          <dt>MMSI</dt>
+          <dd>{selected.mmsi}</dd>
+        </div>
+        <div>
+          <dt>Type</dt>
+          <dd>{shipTypeLabel(selected.ship_type)}</dd>
+        </div>
+        <div>
+          <dt>Speed</dt>
+          <dd>{fmtSpeed(selected.speed)}</dd>
+        </div>
+        <div>
+          <dt>Course</dt>
+          <dd>{fmtDeg(selected.course)}</dd>
+        </div>
+        <div>
+          <dt>Heading</dt>
+          <dd>{fmtDeg(selected.heading)}</dd>
+        </div>
         <div>
           <dt>Destination</dt>
           <dd>{selected.destination || "Unknown"}</dd>

--- a/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
@@ -615,8 +615,10 @@
         <p class="card-title">
           {mode === "historical" ? "Clear dark hours by month" : windowsTitle}
         </p>
-        <button class="card-close" onclick={closeCard} aria-label="Close site card"
-          >&times;</button
+        <button
+          class="card-close"
+          onclick={closeCard}
+          aria-label="Close site card">&times;</button
         >
       </header>
 
@@ -675,7 +677,8 @@
                 >{bar.value}</text
               >
             {/if}
-            <text x={x + bw / 2} y={100} class="chart-tick">{bar.short[0]}</text>
+            <text x={x + bw / 2} y={100} class="chart-tick">{bar.short[0]}</text
+            >
           {/each}
         </svg>
         <p class="card-empty">

--- a/projects/monolith/frontend/src/lib/public/components/trips/DayMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/DayMap.svelte
@@ -237,7 +237,11 @@
             type: "line",
             source: "route",
             layout: { "line-join": "round", "line-cap": "round" },
-            paint: { "line-color": "#1a1a1a", "line-width": 6, "line-opacity": 1 },
+            paint: {
+              "line-color": "#1a1a1a",
+              "line-width": 6,
+              "line-opacity": 1,
+            },
           });
           // Thin real-day-colour core down the centre of the ink casing.
           map.addLayer({
@@ -257,7 +261,11 @@
             type: "line",
             source: "route",
             layout: { "line-join": "round", "line-cap": "round" },
-            paint: { "line-color": "transparent", "line-width": 20, "line-opacity": 0 },
+            paint: {
+              "line-color": "transparent",
+              "line-width": 20,
+              "line-opacity": 0,
+            },
           });
 
           if (onLocationClick) {

--- a/projects/monolith/frontend/src/lib/public/components/trips/DayNav.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/DayNav.svelte
@@ -27,15 +27,19 @@
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
-      aria-hidden="true"><polyline points="15 18 9 12 15 6" /></svg>
+      aria-hidden="true"><polyline points="15 18 9 12 15 6" /></svg
+    >
     <span>Summary</span>
   </a>
 
   <div class="title">
     <div class="eyebrow">
-      Day {dayNumber} of {totalDays}{#if date}<span class="date">{date}</span>{/if}
+      Day {dayNumber} of {totalDays}{#if date}<span class="date">{date}</span
+        >{/if}
     </div>
-    <div class="label" style={`border-bottom:3px solid ${dayColor}`}>{label}</div>
+    <div class="label" style={`border-bottom:3px solid ${dayColor}`}>
+      {label}
+    </div>
   </div>
 
   <div class="arrows">
@@ -49,7 +53,8 @@
           stroke-width="2"
           stroke-linecap="round"
           stroke-linejoin="round"
-          aria-hidden="true"><polyline points="15 18 9 12 15 6" /></svg>
+          aria-hidden="true"><polyline points="15 18 9 12 15 6" /></svg
+        >
         <span>Prev</span>
       </a>
     {:else}
@@ -61,7 +66,8 @@
           stroke="currentColor"
           stroke-width="2"
           stroke-linecap="round"
-          stroke-linejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
+          stroke-linejoin="round"><polyline points="15 18 9 12 15 6" /></svg
+        >
         <span>Prev</span>
       </span>
     {/if}
@@ -77,7 +83,8 @@
           stroke-width="2"
           stroke-linecap="round"
           stroke-linejoin="round"
-          aria-hidden="true"><polyline points="9 18 15 12 9 6" /></svg>
+          aria-hidden="true"><polyline points="9 18 15 12 9 6" /></svg
+        >
       </a>
     {:else}
       <span class="navbtn disabled" aria-hidden="true">
@@ -89,7 +96,8 @@
           stroke="currentColor"
           stroke-width="2"
           stroke-linecap="round"
-          stroke-linejoin="round"><polyline points="9 18 15 12 9 6" /></svg>
+          stroke-linejoin="round"><polyline points="9 18 15 12 9 6" /></svg
+        >
       </span>
     {/if}
   </div>
@@ -112,7 +120,10 @@
     align-items: center;
     gap: 4px;
     padding: 8px 14px;
-    font-family: system-ui, -apple-system, sans-serif;
+    font-family:
+      system-ui,
+      -apple-system,
+      sans-serif;
     font-size: 13px;
     font-weight: 600;
     color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
@@ -169,7 +180,10 @@
     margin-left: 8px;
   }
   .label {
-    font-family: system-ui, -apple-system, sans-serif;
+    font-family:
+      system-ui,
+      -apple-system,
+      sans-serif;
     font-size: 18px;
     font-weight: 700;
     color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */

--- a/projects/monolith/frontend/src/lib/public/components/trips/PhotoGrid.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/PhotoGrid.svelte
@@ -9,7 +9,11 @@
 {#if photos.length}
   <div class="grid">
     {#each photos as photo, i (photo.id)}
-      <button class="tile" onclick={() => onOpen(i)} aria-label={`Open photo ${i + 1}`}>
+      <button
+        class="tile"
+        onclick={() => onOpen(i)}
+        aria-label={`Open photo ${i + 1}`}
+      >
         <img
           src={photo.imgGallery}
           alt={`Photo ${i + 1}`}

--- a/projects/monolith/frontend/src/lib/public/components/trips/PhotoViewer.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/PhotoViewer.svelte
@@ -46,29 +46,44 @@
 </script>
 
 {#if photo}
-  <div class="overlay" role="dialog" aria-modal="true" aria-label="Photo viewer">
-    <button class="backdrop" onclick={onClose} aria-label="Close photo viewer"></button>
+  <div
+    class="overlay"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Photo viewer"
+  >
+    <button class="backdrop" onclick={onClose} aria-label="Close photo viewer"
+    ></button>
     <button class="close" onclick={onClose} aria-label="Close">&times;</button>
 
     {#if hasPrev}
-      <button class="nav prev" onclick={prev} aria-label="Previous photo">&larr;</button>
+      <button class="nav prev" onclick={prev} aria-label="Previous photo"
+        >&larr;</button
+      >
     {/if}
 
     <figure class="frame">
-      <img src={photo.imgDisplay} alt={`Photo ${index + 1} of ${photos.length}`} />
+      <img
+        src={photo.imgDisplay}
+        alt={`Photo ${index + 1} of ${photos.length}`}
+      />
       <figcaption>
         <span class="count">{index + 1} / {photos.length}</span>
         {#if photo.taken_at}<span>{fmtTime(photo.taken_at)}</span>{/if}
-        {#if photo.focal_length_35mm}<span>{photo.focal_length_35mm}mm</span>{/if}
+        {#if photo.focal_length_35mm}<span>{photo.focal_length_35mm}mm</span
+          >{/if}
         {#if photo.aperture}<span>&fnof;/{photo.aperture}</span>{/if}
         {#if photo.iso}<span>ISO {photo.iso}</span>{/if}
         {#if photo.shutter_speed}<span>{photo.shutter_speed}</span>{/if}
-        {#if photo.elevation != null}<span>{Math.round(photo.elevation)}m</span>{/if}
+        {#if photo.elevation != null}<span>{Math.round(photo.elevation)}m</span
+          >{/if}
       </figcaption>
     </figure>
 
     {#if hasNext}
-      <button class="nav next" onclick={next} aria-label="Next photo">&rarr;</button>
+      <button class="nav next" onclick={next} aria-label="Next photo"
+        >&rarr;</button
+      >
     {/if}
   </div>
 {/if}

--- a/projects/monolith/frontend/src/lib/public/components/trips/TripMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/TripMap.svelte
@@ -23,7 +23,9 @@
   let ready = false;
 
   function allPoints() {
-    return days.flatMap((d) => d.points).filter((p) => p.lat != null && p.lng != null);
+    return days
+      .flatMap((d) => d.points)
+      .filter((p) => p.lat != null && p.lng != null);
   }
 
   function bounds() {
@@ -65,7 +67,9 @@
       map = new maplibregl.Map({
         container: mapContainer,
         style: BASEMAP_STYLE,
-        ...(b ? { bounds: b, fitBoundsOptions: { padding: 40 } } : { center: [0, 30], zoom: 1.4 }),
+        ...(b
+          ? { bounds: b, fitBoundsOptions: { padding: 40 } }
+          : { center: [0, 30], zoom: 1.4 }),
         attributionControl: { compact: true },
         scrollZoom: false,
         dragPan: false,
@@ -104,7 +108,11 @@
             type: "line",
             source: sourceId,
             layout: { "line-join": "round", "line-cap": "round" },
-            paint: { "line-color": color, "line-width": 3.5, "line-opacity": 1 },
+            paint: {
+              "line-color": color,
+              "line-width": 3.5,
+              "line-opacity": 1,
+            },
           });
 
           map.on("mouseenter", `route-hit-${i}`, () => {

--- a/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberConsole.svelte
@@ -58,7 +58,11 @@
   // savings-only seed (status missing) is merged onto the status shape so
   // total_saved_mib_s still renders while state waits for the first poll.
   status = initialStatus?.configured
-    ? { ...initialStatus, total_saved_mib_s: initialSavings?.total_saved_mib_s ?? initialStatus.total_saved_mib_s }
+    ? {
+        ...initialStatus,
+        total_saved_mib_s:
+          initialSavings?.total_saved_mib_s ?? initialStatus.total_saved_mib_s,
+      }
     : initialSavings
       ? { total_saved_mib_s: initialSavings.total_saved_mib_s }
       : null;
@@ -88,7 +92,9 @@
     const lo = Math.max(1, Math.min(...vals) * 0.8);
     const hi = Math.max(...vals) * 1.1;
     if (hi / lo < 1.05) return 60;
-    const frac = (Math.log10(connectMs) - Math.log10(lo)) / (Math.log10(hi) - Math.log10(lo));
+    const frac =
+      (Math.log10(connectMs) - Math.log10(lo)) /
+      (Math.log10(hi) - Math.log10(lo));
     return Math.max(12, Math.min(100, Math.round(frac * 100)));
   }
 
@@ -136,10 +142,15 @@
   let queued = $state([]);
 
   let queuedInserts = $derived(queued.filter((m) => m === "insert").length);
-  let queuedAggregates = $derived(queued.filter((m) => m === "aggregate").length);
+  let queuedAggregates = $derived(
+    queued.filter((m) => m === "aggregate").length,
+  );
 
   function requestRun(mode) {
-    if (mode === "insert" && ((!!turnstileSiteKey && !sessionReady) || insertUnavailable)) {
+    if (
+      mode === "insert" &&
+      ((!!turnstileSiteKey && !sessionReady) || insertUnavailable)
+    ) {
       return;
     }
     if (running || cooldown) {
@@ -224,10 +235,16 @@
     const next = new Date(now);
     next.setMinutes(0, 0, 0);
     next.setHours(next.getHours() + 1);
-    const remainingS = Math.max(0, Math.round((next.getTime() - now.getTime()) / 1000));
+    const remainingS = Math.max(
+      0,
+      Math.round((next.getTime() - now.getTime()) / 1000),
+    );
     const mm = String(Math.floor(remainingS / 60)).padStart(2, "0");
     const ss = String(remainingS % 60).padStart(2, "0");
-    const clockLabel = next.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    const clockLabel = next.toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
     return { mmss: `${mm}:${ss}`, clockLabel };
   });
 
@@ -350,21 +367,28 @@
       return {
         ok: false,
         permanent: true,
-        error: "the demo is busy right now, give it a few seconds and try again",
+        error:
+          "the demo is busy right now, give it a few seconds and try again",
       };
     }
     const body = await parseJsonSafe(resp);
     if (body == null) {
       // Non-JSON on any other status (a gateway error page, a proxy hiccup):
       // surface it calmly instead of leaking a raw JSON SyntaxError.
-      return { ok: false, error: `unexpected response from the demo (${resp.status})` };
+      return {
+        ok: false,
+        error: `unexpected response from the demo (${resp.status})`,
+      };
     }
     if (resp.status === 503 && /not configured/i.test(body?.detail ?? "")) {
       // Permanent: no DSN configured on this deployment, retrying won't help.
       return { ok: false, permanent: true, error: body.detail };
     }
     if (!resp.ok) {
-      return { ok: false, error: body?.detail || `query failed (${resp.status})` };
+      return {
+        ok: false,
+        error: body?.detail || `query failed (${resp.status})`,
+      };
     }
     if (body.session_required) {
       if (!turnstileSiteKey) insertUnavailable = true;
@@ -534,7 +558,9 @@
     return items;
   });
 
-  let orderPageCount = $derived(Math.max(1, Math.ceil(orderItems.length / PAGE_ITEMS)));
+  let orderPageCount = $derived(
+    Math.max(1, Math.ceil(orderItems.length / PAGE_ITEMS)),
+  );
 
   let pagedOrderItems = $derived.by(() => {
     const page = Math.min(resultPage, orderPageCount - 1);
@@ -544,13 +570,15 @@
   let shownPage = $derived(Math.min(resultPage, orderPageCount - 1));
 
   let maxRevenue = $derived(
-    Math.max(1, ...((lastRun?.breakdown ?? []).map((b) => b.revenue))),
+    Math.max(1, ...(lastRun?.breakdown ?? []).map((b) => b.revenue)),
   );
 
   // The wake promise: best measured relight this session, else the honest
   // ceiling. Published as a bindable so the stage's asleep overlay shows it
   // (the separate state card duplicated the stage and is gone).
-  let wakeHeadline = $derived(tiers.relight != null ? `~${ms(tiers.relight)}` : "<1 s");
+  let wakeHeadline = $derived(
+    tiers.relight != null ? `~${ms(tiers.relight)}` : "<1 s",
+  );
 
   $effect(() => {
     wakePromise = wakeHeadline;
@@ -562,12 +590,14 @@
   // remove-on-unmount pattern rather than importing that component directly,
   // since this gate's admit callback needs to feed mintSession (an
   // ember-specific proxy path) rather than the chat admission module.
-  const TURNSTILE_SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+  const TURNSTILE_SCRIPT_SRC =
+    "https://challenges.cloudflare.com/turnstile/v0/api.js";
   let widgetEl;
   let widgetId = null;
 
   function renderTurnstileWidget() {
-    if (!window.turnstile || !widgetEl || !turnstileSiteKey || sessionReady) return;
+    if (!window.turnstile || !widgetEl || !turnstileSiteKey || sessionReady)
+      return;
     if (widgetId !== null) return;
     widgetId = window.turnstile.render(widgetEl, {
       sitekey: turnstileSiteKey,
@@ -595,7 +625,9 @@
       renderTurnstileWidget();
       return removeTurnstileWidget;
     }
-    let script = document.querySelector(`script[src="${TURNSTILE_SCRIPT_SRC}"]`);
+    let script = document.querySelector(
+      `script[src="${TURNSTILE_SCRIPT_SRC}"]`,
+    );
     if (!script) {
       script = document.createElement("script");
       script.src = TURNSTILE_SCRIPT_SRC;
@@ -631,11 +663,19 @@
         disabled={(!!turnstileSiteKey && !sessionReady) || insertUnavailable}
       >
         {insertUnavailable ? "INSERTs unavailable" : "INSERT an order"}
-        {#if queuedInserts > 0}<span class="queue-chip">+{queuedInserts} queued</span>{/if}
+        {#if queuedInserts > 0}<span class="queue-chip"
+            >+{queuedInserts} queued</span
+          >{/if}
       </button>
-      <button class="aggregate-btn" type="button" onclick={() => requestRun("aggregate")}>
+      <button
+        class="aggregate-btn"
+        type="button"
+        onclick={() => requestRun("aggregate")}
+      >
         Run aggregate
-        {#if queuedAggregates > 0}<span class="queue-chip">+{queuedAggregates} queued</span>{/if}
+        {#if queuedAggregates > 0}<span class="queue-chip"
+            >+{queuedAggregates} queued</span
+          >{/if}
       </button>
     </div>
 
@@ -674,7 +714,9 @@
           <span class="stat-value">
             {#key running || !lastRun ? "none" : lastRun.connect_ms}
               <span class="fade-swap" in:fade={{ duration: 220 }}>
-                {running || !lastRun ? "–" : ms((lastRun.connect_ms ?? 0) + (lastRun.query_ms ?? 0))}
+                {running || !lastRun
+                  ? "–"
+                  : ms((lastRun.connect_ms ?? 0) + (lastRun.query_ms ?? 0))}
               </span>
             {/key}
           </span>
@@ -689,7 +731,9 @@
               ></span>
             {/each}
           </div>
-          <span class="spark-caption">wake + connect, every run this session</span>
+          <span class="spark-caption"
+            >wake + connect, every run this session</span
+          >
         </div>
       </div>
 
@@ -698,25 +742,30 @@
         <div class="stat-row">
           <span class="stat-name">cold start</span>
           <span class="stat-value">
-            {#key tiers.cold}<span class="fade-swap" in:fade={{ duration: 220 }}>{ms(tiers.cold)}</span>{/key}
+            {#key tiers.cold}<span class="fade-swap" in:fade={{ duration: 220 }}
+                >{ms(tiers.cold)}</span
+              >{/key}
           </span>
         </div>
         <div class="stat-row">
           <span class="stat-name">from snapshot</span>
           <span class="stat-value">
-            {#key tiers.relight}<span class="fade-swap" in:fade={{ duration: 220 }}>{ms(tiers.relight)}</span>{/key}
+            {#key tiers.relight}<span
+                class="fade-swap"
+                in:fade={{ duration: 220 }}>{ms(tiers.relight)}</span
+              >{/key}
           </span>
         </div>
         <div class="stat-row">
           <span class="stat-name">already awake</span>
           <span class="stat-value">
-            {#key tiers.warm}<span class="fade-swap" in:fade={{ duration: 220 }}>{ms(tiers.warm)}</span>{/key}
+            {#key tiers.warm}<span class="fade-swap" in:fade={{ duration: 220 }}
+                >{ms(tiers.warm)}</span
+              >{/key}
           </span>
         </div>
       </div>
     </div>
-
-
   </div>
 
   <div class="right-col">
@@ -767,13 +816,25 @@
             <tfoot>
               <tr class="summary-total">
                 <td>Σ total</td>
-                <td class="col-numeric">{lastRun?.total_orders != null ? countHeadline((lastRun.breakdown ?? []).reduce((n, b) => n + b.units, 0)) : "–"} units</td>
-                <td class="col-numeric">{moneyHeadline(lastRun?.total_revenue)}</td>
+                <td class="col-numeric"
+                  >{lastRun?.total_orders != null
+                    ? countHeadline(
+                        (lastRun.breakdown ?? []).reduce(
+                          (n, b) => n + b.units,
+                          0,
+                        ),
+                      )
+                    : "–"} units</td
+                >
+                <td class="col-numeric"
+                  >{moneyHeadline(lastRun?.total_revenue)}</td
+                >
               </tr>
             </tfoot>
           </table>
           <p class="result-footer">
-            ({(lastRun?.breakdown ?? []).length} groups from {lastRun?.total_orders ?? 0} orders)
+            ({(lastRun?.breakdown ?? []).length} groups from {lastRun?.total_orders ??
+              0} orders)
           </p>
         </div>
       {:else}
@@ -782,7 +843,11 @@
             <thead>
               <tr>
                 {#each ORDER_COLUMNS as col (col.key)}
-                  <th class={col.key === "qty" || col.key === "unit_price" ? "col-numeric" : ""}>
+                  <th
+                    class={col.key === "qty" || col.key === "unit_price"
+                      ? "col-numeric"
+                      : ""}
+                  >
                     <span class="col-name">{col.label}</span>
                     <span class="col-type">{col.type}</span>
                   </th>
@@ -830,11 +895,13 @@
                 >
                   &#8249;
                 </button>
-                <span class="pager-count">{shownPage + 1}/{orderPageCount}</span>
+                <span class="pager-count">{shownPage + 1}/{orderPageCount}</span
+                >
                 <button
                   class="pager-btn"
                   type="button"
-                  onclick={() => (resultPage = Math.min(orderPageCount - 1, shownPage + 1))}
+                  onclick={() =>
+                    (resultPage = Math.min(orderPageCount - 1, shownPage + 1))}
                   disabled={shownPage >= orderPageCount - 1}
                   aria-label="older rows"
                 >
@@ -991,7 +1058,6 @@
     color: var(--em-ember-deep);
     font-size: 13px;
   }
-
 
   .stats-card {
     background: var(--em-panel);
@@ -1282,7 +1348,11 @@
   }
 
   .epoch-band.epoch-current td {
-    background: color-mix(in srgb, var(--em-ember-dim) 40%, var(--em-line-soft));
+    background: color-mix(
+      in srgb,
+      var(--em-ember-dim) 40%,
+      var(--em-line-soft)
+    );
   }
 
   .summary-row td:first-child {

--- a/projects/monolith/frontend/src/lib/public/ember/EmberStage.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/EmberStage.svelte
@@ -113,7 +113,10 @@
       const coldSat = 52 + Math.random() * 14;
       const coldLight = 60 + Math.random() * 12;
       d.style.setProperty("--hot", `hsl(${hotHue} ${hotSat}% ${hotLight}%)`);
-      d.style.setProperty("--cold", `hsl(${coldHue} ${coldSat}% ${coldLight}%)`);
+      d.style.setProperty(
+        "--cold",
+        `hsl(${coldHue} ${coldSat}% ${coldLight}%)`,
+      );
       gridEl.appendChild(d);
       cells.push({
         el: d,
@@ -193,12 +196,18 @@
       if (now - flickerTickAt > 900) {
         flickerTickAt = now;
         const hotCells = cells.filter((c) => c.hot && !c.twinkling);
-        const n = Math.min(hotCells.length, Math.max(1, Math.round(cells.length * 0.008)));
+        const n = Math.min(
+          hotCells.length,
+          Math.max(1, Math.round(cells.length * 0.008)),
+        );
         for (let i = 0; i < n; i++) {
           const c = hotCells[Math.floor(Math.random() * hotCells.length)];
           if (!c || c.twinkling) continue;
           c.twinkling = true;
-          c.el.style.setProperty("--tw-dur", `${(1.4 + Math.random() * 1.2).toFixed(2)}s`);
+          c.el.style.setProperty(
+            "--tw-dur",
+            `${(1.4 + Math.random() * 1.2).toFixed(2)}s`,
+          );
           c.el.style.setProperty("--flicker", "1");
           c.el.addEventListener(
             "animationend",
@@ -327,7 +336,11 @@
 <div class="ember-stage">
   <div class="es-grid" bind:this={gridEl} aria-hidden="true"></div>
   {#if reduced}
-    <div class="es-grid es-static" class:es-static-hot={staticHot} aria-hidden="true"></div>
+    <div
+      class="es-grid es-static"
+      class:es-static-hot={staticHot}
+      aria-hidden="true"
+    ></div>
   {/if}
 
   <div class="es-overlay">
@@ -341,7 +354,8 @@
         <span class="es-watchers" in:fade={{ duration: 260 }}>
           <span class="es-watchers-dot" aria-hidden="true"></span>
           {#key watchers}
-            <span class="fade-swap" in:fade={{ duration: 260 }}>{watchers}</span>
+            <span class="fade-swap" in:fade={{ duration: 260 }}>{watchers}</span
+            >
           {/key}
         </span>
       {/if}
@@ -351,9 +365,12 @@
         <div class="es-hero-inner" in:fade={{ duration: 260 }}>
           {#if heroKind === "cold"}
             <span class="es-hero-value">{gbHours(totalSavedMibS)}</span>
-            <span class="es-hero-caption">saved all-time by scaling to zero</span>
+            <span class="es-hero-caption"
+              >saved all-time by scaling to zero</span
+            >
           {:else if heroKind === "waking"}
-            <span class="es-hero-value">{ms(running ? stopwatchMs : null)}</span>
+            <span class="es-hero-value">{ms(running ? stopwatchMs : null)}</span
+            >
             <span class="es-hero-caption">waking up</span>
           {:else}
             <span class="es-hero-value">512 MiB</span>

--- a/projects/monolith/frontend/src/lib/public/ember/ScanView.svelte
+++ b/projects/monolith/frontend/src/lib/public/ember/ScanView.svelte
@@ -393,8 +393,7 @@
         spellcheck="false"
         autocapitalize="off"
         autocorrect="off"
-        aria-label="code snippet to scan"
-      ></textarea>
+        aria-label="code snippet to scan"></textarea>
     </div>
 
     <div class="editor-footer">
@@ -441,14 +440,15 @@
       >
       <div class="track">
         <div class="fill" style:width="{ghostPct}%"></div>
-        <span class="seg" class:show={segShow[0]} style:left="2%"
-          >booting…</span
+        <span class="seg" class:show={segShow[0]} style:left="2%">booting…</span
         >
         <span class="seg" class:show={segShow[1]} style:left="{BOOT_END * 100}%"
           >loading rules…</span
         >
-        <span class="seg" class:show={segShow[2]} style:left="{RULES_END * 100}%"
-          >scanning…</span
+        <span
+          class="seg"
+          class:show={segShow[2]}
+          style:left="{RULES_END * 100}%">scanning…</span
         >
       </div>
       <span class="stat">{ghostStat || " "}</span>
@@ -474,8 +474,7 @@
               class:finding-row-active={f.line === highlightedLine}
               onclick={() => selectFinding(f)}
             >
-              <span
-                class="severity-badge severity-{f.severity?.toLowerCase()}"
+              <span class="severity-badge severity-{f.severity?.toLowerCase()}"
                 >{f.severity}</span
               >
               <span class="finding-main">
@@ -712,7 +711,8 @@
     right: 0;
     height: 2px;
     background: var(--em-ember);
-    box-shadow: 0 0 10px 1px color-mix(in srgb, var(--em-ember) 50%, transparent);
+    box-shadow: 0 0 10px 1px
+      color-mix(in srgb, var(--em-ember) 50%, transparent);
     pointer-events: none;
   }
 

--- a/projects/monolith/frontend/src/lib/public/fcstory/FcScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/fcstory/FcScrollStory.svelte
@@ -349,8 +349,8 @@
     <span
       ><a class="brand" href="/" bind:this={brandEl}
         ><strong>jomcgi.dev</strong></a
-      > / <a class="brand" href="/ember" bind:this={crumbEl}>ember</a> /
-      firecracker</span
+      >
+      / <a class="brand" href="/ember" bind:this={crumbEl}>ember</a> / firecracker</span
     >
   </header>
 
@@ -365,8 +365,8 @@
             <span class="warm-word">forever</span>.
           </h1>
           <p>
-            This site runs untrusted code in Firecracker microVMs. Building
-            the first one took
+            This site runs untrusted code in Firecracker microVMs. Building the
+            first one took
             <span class="num big frost-text"
               >{(cold.total / 1000).toFixed(1)} seconds</span
             >. Every sandbox since has woken from disk in about
@@ -385,11 +385,9 @@
             >.
           </h2>
           <p>
-            The slow part is waiting
-            for a useful guest: kernel up, agent listening, toolchain warm.
-            Measured cold, that wait is
-            <span class="num big">{coldWait.ms.toLocaleString()}&nbsp;ms</span
-            >.
+            The slow part is waiting for a useful guest: kernel up, agent
+            listening, toolchain warm. Measured cold, that wait is
+            <span class="num big">{coldWait.ms.toLocaleString()}&nbsp;ms</span>.
           </p>
         </div>
         <div class="caption" bind:this={capFreezeEl}>
@@ -400,8 +398,8 @@
           <p>
             Every page of guest RAM and every device register is written to
             disk: a memory file and a vmstate file. Saving the snapshot takes
-            <span class="num big">{coldSave.ms.toLocaleString()}&nbsp;ms</span
-            >, paid one time at startup.
+            <span class="num big">{coldSave.ms.toLocaleString()}&nbsp;ms</span>,
+            paid one time at startup.
           </p>
         </div>
         <div class="caption" bind:this={capRestoreEl}>
@@ -409,13 +407,14 @@
           <p>
             The bytes map from disk straight back into memory and the guest
             resumes mid-thought. The readiness wait that cost
-            <span class="num big">{coldWait.ms.toLocaleString()}&nbsp;ms</span
-            > cold takes
+            <span class="num big">{coldWait.ms.toLocaleString()}&nbsp;ms</span>
+            cold takes
             <span class="num big"
               >{firstRestore.phases
                 .find((p) => p.name === "guest_wait_ready")
                 .ms.toFixed(1)}&nbsp;ms</span
-            > warm. The whole wake-up:
+            >
+            warm. The whole wake-up:
             <span class="num ember-text"
               >~{Math.round(meanSnapshotRestoreMs)}&nbsp;ms</span
             >.
@@ -425,8 +424,8 @@
           <h2>And again. And again.</h2>
           <p>
             Each restore is a fresh, isolated VM from the same frozen image,
-            then discarded. {restores.length} real recorded runs, end to end,
-            including auth and code execution.
+            then discarded. {restores.length} real recorded runs, end to end, including
+            auth and code execution.
           </p>
         </div>
 
@@ -575,9 +574,9 @@
   <section class="replay">
     <h2>Feel it. Restore one now.</h2>
     <p>
-      This button replays one of the {restores.length} recorded runs at its true
-      speed. No cluster is touched: the timings below were captured from the live
-      daemon and baked into this page. Blink and you miss it.
+      This button replays one of the {restores.length} recorded runs at its true speed.
+      No cluster is touched: the timings below were captured from the live daemon
+      and baked into this page. Blink and you miss it.
     </p>
     <ReplayWidget {restores} {PHASE_HUMAN} />
   </section>
@@ -588,8 +587,8 @@
       <h1 class="static-hero-title">Boot once. Restore forever.</h1>
       <p class="static-muted">
         This site runs untrusted code in Firecracker microVMs. Building the
-        first one took {(cold.total / 1000).toFixed(1)} seconds. Every sandbox
-        since has woken from disk in about
+        first one took {(cold.total / 1000).toFixed(1)} seconds. Every sandbox since
+        has woken from disk in about
         {Math.round(meanSnapshotRestoreMs)} milliseconds.
       </p>
     </section>
@@ -600,18 +599,15 @@
         >
       </h2>
       <p class="static-muted num">
-        {#each cold.phases as p, i (p.name)}{i > 0
-            ? " · "
-            : ""}{p.name} {p.ms.toFixed(1)} ms{/each}
+        {#each cold.phases as p, i (p.name)}{i > 0 ? " · " : ""}{p.name}
+          {p.ms.toFixed(1)} ms{/each}
       </p>
     </section>
     <section>
       <h2>
         Warm, every request:
         <span class="num ember-text"
-          >{restoreTotalMin.toFixed(0)}&ndash;{restoreTotalMax.toFixed(
-            0,
-          )} ms</span
+          >{restoreTotalMin.toFixed(0)}&ndash;{restoreTotalMax.toFixed(0)} ms</span
         >
       </h2>
       <p class="static-muted">
@@ -1056,7 +1052,11 @@
     background: var(--fc-seg-boot);
   }
   .seg.wait {
-    background: linear-gradient(90deg, var(--fc-seg-wait-a), var(--fc-seg-wait-b));
+    background: linear-gradient(
+      90deg,
+      var(--fc-seg-wait-a),
+      var(--fc-seg-wait-b)
+    );
   }
   .seg.save {
     background: var(--fc-seg-save);

--- a/projects/monolith/frontend/src/lib/public/fcstory/ReplayWidget.svelte
+++ b/projects/monolith/frontend/src/lib/public/fcstory/ReplayWidget.svelte
@@ -129,8 +129,8 @@
     {/each}
   </div>
   <div class="provenance">
-    Every number on this page is a real measurement exported by the daemon's
-    own tracing, recorded and baked in at build time. Warm restores: {restores.length}
+    Every number on this page is a real measurement exported by the daemon's own
+    tracing, recorded and baked in at build time. Warm restores: {restores.length}
     consecutive live runs.
     <br />
     source:

--- a/projects/monolith/frontend/src/lib/public/grimoire/ChaptersNav.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/ChaptersNav.svelte
@@ -138,7 +138,10 @@
             <span class="pub-chapters-row-title">{node.title}</span>
           </button>
           {#if isOpen}
-            <div class="pub-chapters-list--nested" id={"pub-chapter-" + nodePath}>
+            <div
+              class="pub-chapters-list--nested"
+              id={"pub-chapter-" + nodePath}
+            >
               {@render branch(node.children)}
             </div>
           {/if}

--- a/projects/monolith/frontend/src/lib/public/grimoire/ConstellationDock.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/ConstellationDock.svelte
@@ -58,7 +58,11 @@
 {#if state.nodes.length > 0}
   <div class="constel-dock" class:reduced={REDUCED_MOTION}>
     {#if expanded}
-      <div class="dock-panel" role="dialog" aria-label="Entities you've explored">
+      <div
+        class="dock-panel"
+        role="dialog"
+        aria-label="Entities you've explored"
+      >
         <div class="dock-panel-head">
           <span class="dock-panel-title">YOUR TRAIL</span>
           <button

--- a/projects/monolith/frontend/src/lib/public/grimoire/MiniConstellation.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/MiniConstellation.svelte
@@ -365,10 +365,7 @@
 
   function fadeFrame() {
     if (viewAnim) {
-      const p = Math.min(
-        1,
-        (performance.now() - viewAnim.start) / CAMERA_MS,
-      );
+      const p = Math.min(1, (performance.now() - viewAnim.start) / CAMERA_MS);
       const e = 1 - Math.pow(1 - p, 3);
       view = {
         k: viewAnim.from.k + (viewAnim.to.k - viewAnim.from.k) * e,

--- a/projects/monolith/frontend/src/lib/public/grimoire/Reader.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/Reader.svelte
@@ -141,10 +141,15 @@
   function bodyBlocks(item) {
     const blocks = renderChunk(item.content);
     const first = blocks[0];
-    if (!first || (first.type !== "heading" && first.type !== "para")) return blocks;
+    if (!first || (first.type !== "heading" && first.type !== "para"))
+      return blocks;
     const norm = (s) => (s ?? "").trim().toUpperCase();
     const head = norm(first.text);
-    if (head && (head === norm(item.section_path) || head === norm(sectionTitle(item.section_path)))) {
+    if (
+      head &&
+      (head === norm(item.section_path) ||
+        head === norm(sectionTitle(item.section_path)))
+    ) {
       return blocks.slice(1);
     }
     return blocks;
@@ -170,7 +175,12 @@
     for (const e of entities) {
       if (seen.has(e.name)) continue;
       seen.add(e.name);
-      touched.push({ id: e.id, title: e.name, kind: "entity", entity_type: e.entity_type });
+      touched.push({
+        id: e.id,
+        title: e.name,
+        kind: "entity",
+        entity_type: e.entity_type,
+      });
     }
     return touched;
   }
@@ -229,7 +239,8 @@
         const hit = entries
           .filter((e) => e.isIntersecting)
           .sort(
-            (a, b) => Number(b.target.dataset.seq) - Number(a.target.dataset.seq),
+            (a, b) =>
+              Number(b.target.dataset.seq) - Number(a.target.dataset.seq),
           )[0];
         if (hit) {
           activeSeq = Number(hit.target.dataset.seq);
@@ -256,7 +267,10 @@
     const reduceMotion = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
-    el.scrollIntoView({ behavior: reduceMotion ? "auto" : "smooth", block: "start" });
+    el.scrollIntoView({
+      behavior: reduceMotion ? "auto" : "smooth",
+      block: "start",
+    });
   });
 
   // Section-heading deep links. The host route (+page.svelte) only parses
@@ -283,7 +297,10 @@
     const reduceMotion = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
-    el.scrollIntoView({ behavior: reduceMotion ? "auto" : "smooth", block: "start" });
+    el.scrollIntoView({
+      behavior: reduceMotion ? "auto" : "smooth",
+      block: "start",
+    });
   });
 
   // Reading-progress bar. The app root scrolls the window (see the
@@ -399,7 +416,9 @@
                 {sectionParent(row.item.section_path)}
               </p>
             {/if}
-            <h2 class="pub-section-title">{sectionTitle(row.item.section_path)}</h2>
+            <h2 class="pub-section-title">
+              {sectionTitle(row.item.section_path)}
+            </h2>
           </div>
         {/if}
 
@@ -430,7 +449,9 @@
             {#each bodyBlocks(row.item) as block, bi (bi)}
               {#if block.type === "heading"}
                 {#if touched.length}
-                  <h3 class="pub-inline-heading">{@html markText(block.text, touched)}</h3>
+                  <h3 class="pub-inline-heading">
+                    {@html markText(block.text, touched)}
+                  </h3>
                 {:else}
                   <h3 class="pub-inline-heading">{block.text}</h3>
                 {/if}

--- a/projects/monolith/frontend/src/lib/public/grimoire/explore/ExploreCanvas.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/explore/ExploreCanvas.svelte
@@ -584,7 +584,14 @@
       } else if (pointers.size === 2) {
         panStart = null;
         const { dist, midX, midY } = pinchGeometry();
-        pinchStart = { dist, k: view.k, viewX: view.x, viewY: view.y, midX, midY };
+        pinchStart = {
+          dist,
+          k: view.k,
+          viewX: view.x,
+          viewY: view.y,
+          midX,
+          midY,
+        };
         moved = true; // a pinch is never a tap, even if it started as one
       }
     }
@@ -650,7 +657,14 @@
         // Still pinching with whichever two pointers remain: rebase so the
         // gesture continues smoothly instead of jumping.
         const { dist, midX, midY } = pinchGeometry();
-        pinchStart = { dist, k: view.k, viewX: view.x, viewY: view.y, midX, midY };
+        pinchStart = {
+          dist,
+          k: view.k,
+          viewX: view.x,
+          viewY: view.y,
+          midX,
+          midY,
+        };
         panStart = null;
       } else if (pointers.size === 1) {
         // Dropped from a pinch to a single finger: rebase to a pan from
@@ -685,7 +699,10 @@
       const my = e.clientY - rect.top;
       const wx = (mx - view.x) / view.k;
       const wy = (my - view.y) / view.k;
-      const k2 = Math.max(0.4, Math.min(3, view.k * (e.deltaY < 0 ? 1.12 : 0.89)));
+      const k2 = Math.max(
+        0.4,
+        Math.min(3, view.k * (e.deltaY < 0 ? 1.12 : 0.89)),
+      );
       view.k = k2;
       view.x = mx - wx * k2;
       view.y = my - wy * k2;

--- a/projects/monolith/frontend/src/lib/public/grimoire/explore/ExploreCodex.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/explore/ExploreCodex.svelte
@@ -59,7 +59,8 @@
     ]);
     relationships =
       egoRes.status === "fulfilled" ? buildRelationships(id, egoRes.value) : [];
-    mentions = mentionsRes.status === "fulfilled" ? (mentionsRes.value ?? []) : [];
+    mentions =
+      mentionsRes.status === "fulfilled" ? (mentionsRes.value ?? []) : [];
     loading = false;
   }
 
@@ -165,7 +166,11 @@
 
       {#if artUrl}
         <div class="art">
-          <img src={artUrl} alt={`Illustration of ${entity.name}`} loading="lazy" />
+          <img
+            src={artUrl}
+            alt={`Illustration of ${entity.name}`}
+            loading="lazy"
+          />
         </div>
       {:else}
         <div

--- a/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/scrollstory/ScrollStory.svelte
@@ -72,9 +72,7 @@
 
   const segHtml = (segs) =>
     segs
-      .map((s) =>
-        s.c ? `<mark data-c="${s.c}">${esc(s.t)}</mark>` : esc(s.t),
-      )
+      .map((s) => (s.c ? `<mark data-c="${s.c}">${esc(s.t)}</mark>` : esc(s.t)))
       .join("");
 
   // Chunk cards: section breadcrumb + highlighted body. bodyHtml is built once
@@ -109,9 +107,7 @@
         pi,
         html: segmentize(sentence, PHRASES)
           .map((s) =>
-            s.c
-              ? `<mark style="color:${s.c}">${esc(s.t)}</mark>`
-              : esc(s.t),
+            s.c ? `<mark style="color:${s.c}">${esc(s.t)}</mark>` : esc(s.t),
           )
           .join(""),
       });
@@ -623,8 +619,7 @@
         fromX = W * 0.74;
         fromY = H * 0.5;
         opa =
-          Math.min(raw * 3, 1) *
-          lerp(1, 0.4, Math.max(shrink * 0.5, graphDim));
+          Math.min(raw * 3, 1) * lerp(1, 0.4, Math.max(shrink * 0.5, graphDim));
         scl = lerp(0.4, 1, pop) * lerp(1, 0.66, shrink);
       }
       lastNodePos[i] = [gx, gy];
@@ -959,8 +954,8 @@
                 togglePopout(i);
               }}
             >
-              <span class="dot" style="background:{typeVar(n.type)}"></span
-              >{n.name}
+              <span class="dot" style="background:{typeVar(n.type)}"
+              ></span>{n.name}
             </button>
           {/each}
         </div>
@@ -972,7 +967,9 @@
         {#if popData}
           <span
             class="ptype"
-            style="color:{typeVar(popData.type)};background:color-mix(in srgb, {typeVar(
+            style="color:{typeVar(
+              popData.type,
+            )};background:color-mix(in srgb, {typeVar(
               popData.type,
             )} 12%, transparent)">{popData.type}</span
           >
@@ -993,7 +990,9 @@
       </div>
 
       <div class="scale-panel" bind:this={scalePanelEl}>
-        <div class="scale-head grim-title section-head">Unearthed from this page</div>
+        <div class="scale-head grim-title section-head">
+          Unearthed from this page
+        </div>
         <div class="this-page">
           <span>{story.bboxes.length} blocks</span><span class="k">/</span>
           <span>{story.chunks.length} chunks</span><span class="k">/</span>
@@ -1054,8 +1053,8 @@
                 togglePopout(viewIdxById[n.id] ?? -1, [r.left, r.top - 250]);
               }}
             >
-              <span class="dot" style="background:{typeVar(n.type)}"></span
-              >{n.name}
+              <span class="dot" style="background:{typeVar(n.type)}"
+              ></span>{n.name}
             </button>
           {/each}
         </div>
@@ -1106,7 +1105,10 @@
     </section>
 
     <section class="static-scene">
-      <p class="static-cap"><b>1 / Layout detection.</b> Marker reads the scanned page and finds its structure: headers, columns, asides, art.</p>
+      <p class="static-cap">
+        <b>1 / Layout detection.</b> Marker reads the scanned page and finds its structure:
+        headers, columns, asides, art.
+      </p>
       <div class="static-page" style="aspect-ratio:{aspect}">
         <img
           src={story.image}
@@ -1131,7 +1133,10 @@
     </section>
 
     <section class="static-scene">
-      <p class="static-cap"><b>2 / Structural chunking.</b> Blocks become chunks in reading order, keyed to the section they belong to.</p>
+      <p class="static-cap">
+        <b>2 / Structural chunking.</b> Blocks become chunks in reading order, keyed
+        to the section they belong to.
+      </p>
       <div class="static-cards">
         {#each cards as c (c.id)}
           <div class="chunk-card">
@@ -1143,8 +1148,17 @@
     </section>
 
     <section class="static-scene">
-      <p class="static-cap"><b>3 / Entity extraction.</b> An LLM reads each chunk and emits typed entities and how they relate.</p>
-      <svg class="static-graph" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Relationship graph of the entities on this page">
+      <p class="static-cap">
+        <b>3 / Entity extraction.</b> An LLM reads each chunk and emits typed entities
+        and how they relate.
+      </p>
+      <svg
+        class="static-graph"
+        viewBox="0 0 100 100"
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+        aria-label="Relationship graph of the entities on this page"
+      >
         {#each graphEdges as e, i (i)}
           <line
             x1={50 + nById[e.from].x * 40}
@@ -1154,20 +1168,29 @@
           />
         {/each}
         {#each nodes as n (n.id)}
-          <circle cx={50 + n.x * 40} cy={50 + n.y * 32} r="1.4" fill={typeVar(n.type)} />
+          <circle
+            cx={50 + n.x * 40}
+            cy={50 + n.y * 32}
+            r="1.4"
+            fill={typeVar(n.type)}
+          />
         {/each}
       </svg>
       <ul class="static-roster">
         {#each nodes as n (n.id)}
           <li>
-            <span class="dot" style="background:{typeVar(n.type)}"></span>{n.name}
+            <span class="dot" style="background:{typeVar(n.type)}"
+            ></span>{n.name}
           </li>
         {/each}
       </ul>
     </section>
 
     <section class="static-scene">
-      <p class="static-cap"><b>4 / The entire compendium.</b> You just watched a single page unearthed. Every book in the compendium gets the same treatment.</p>
+      <p class="static-cap">
+        <b>4 / The entire compendium.</b> You just watched a single page unearthed.
+        Every book in the compendium gets the same treatment.
+      </p>
       <div class="static-counters">
         {#each COUNTS as [label, value] (label)}
           <div class="counter">
@@ -1187,7 +1210,10 @@
     </section>
 
     <section class="static-scene">
-      <p class="static-cap"><b>5 / Grounded answers.</b> Every claim cites the chunks and entities it came from.</p>
+      <p class="static-cap">
+        <b>5 / Grounded answers.</b> Every claim cites the chunks and entities it
+        came from.
+      </p>
       <div class="chat static-chat">
         {#if isPlaceholder}
           <div class="mock-note">mock transcript</div>
@@ -1206,8 +1232,8 @@
           <span class="lbl">GROUNDED IN</span>
           {#each groundedNodes as n (n.id)}
             <span class="gchip">
-              <span class="dot" style="background:{typeVar(n.type)}"></span
-              >{n.name}
+              <span class="dot" style="background:{typeVar(n.type)}"
+              ></span>{n.name}
             </span>
           {/each}
         </div>
@@ -1525,7 +1551,8 @@
       0 2px 8px rgba(10, 14, 22, 0.2);
   }
   .chip.open {
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--grim-accent) 45%, transparent);
+    box-shadow: 0 0 0 3px
+      color-mix(in srgb, var(--grim-accent) 45%, transparent);
   }
 
   /* entity pop-out */

--- a/projects/monolith/frontend/src/lib/public/grimoire/statblock/Creature.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/statblock/Creature.svelte
@@ -29,20 +29,28 @@
 
   <dl class="topline">
     {#if data.ac != null}
-      <div><dt>Armor Class</dt>
-        <dd>{data.ac}</dd></div>
+      <div>
+        <dt>Armor Class</dt>
+        <dd>{data.ac}</dd>
+      </div>
     {/if}
     {#if data.hp_avg != null}
-      <div><dt>Hit Points</dt>
-        <dd>{data.hp_avg}</dd></div>
+      <div>
+        <dt>Hit Points</dt>
+        <dd>{data.hp_avg}</dd>
+      </div>
     {/if}
     {#if speed}
-      <div><dt>Speed</dt>
-        <dd>{speed}</dd></div>
+      <div>
+        <dt>Speed</dt>
+        <dd>{speed}</dd>
+      </div>
     {/if}
     {#if data.cr != null}
-      <div><dt>Challenge</dt>
-        <dd>{data.cr}</dd></div>
+      <div>
+        <dt>Challenge</dt>
+        <dd>{data.cr}</dd>
+      </div>
     {/if}
   </dl>
 

--- a/projects/monolith/frontend/src/lib/public/grimoire/statblock/Spell.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/statblock/Spell.svelte
@@ -1,12 +1,16 @@
 <script>
-  import { normalizeBlocks, scalarToText } from "$lib/public/grimoire/format.js";
+  import {
+    normalizeBlocks,
+    scalarToText,
+  } from "$lib/public/grimoire/format.js";
 
   let { data } = $props();
 
   const strap = $derived(
     data.level === 0 || data.level === "0"
       ? [data.school, "cantrip"].filter(Boolean).join(" ")
-      : ["Level", data.level, data.school].filter((x) => x != null && x !== "")
+      : ["Level", data.level, data.school]
+          .filter((x) => x != null && x !== "")
           .join(" "),
   );
 

--- a/projects/monolith/frontend/src/lib/public/grimoire/world/EntitySearch.svelte
+++ b/projects/monolith/frontend/src/lib/public/grimoire/world/EntitySearch.svelte
@@ -196,7 +196,9 @@
       role="combobox"
       aria-expanded={open}
       aria-controls="world-search-listbox"
-      aria-activedescendant={open && activeIdx >= 0 ? optionId(activeIdx) : null}
+      aria-activedescendant={open && activeIdx >= 0
+        ? optionId(activeIdx)
+        : null}
       aria-autocomplete="list"
       aria-label="Search entities"
       bind:value={q}
@@ -214,7 +216,9 @@
         aria-label="Search results"
       >
         {#each groups as g (g.entity_type)}
-          <li class="group-head" role="presentation">{typeLabel(g.entity_type)}</li>
+          <li class="group-head" role="presentation">
+            {typeLabel(g.entity_type)}
+          </li>
           {#each g.rows as it (it.id)}
             {@const idx = flat.indexOf(it)}
             <li
@@ -252,7 +256,8 @@
         aria-pressed={type === t.value}
         onclick={() => selectChip(t.value)}
       >
-        <span class="sw" style={`background: var(--grim-type-${t.value})`}></span>
+        <span class="sw" style={`background: var(--grim-type-${t.value})`}
+        ></span>
         {t.label}
       </button>
     {/each}

--- a/projects/monolith/frontend/src/lib/public/llm-leaderboard/Scatter.svelte
+++ b/projects/monolith/frontend/src/lib/public/llm-leaderboard/Scatter.svelte
@@ -12,22 +12,62 @@
   let metric = $state("cost"); // cost | wall | tokens | turns
   let taskSel = $state("all"); // 'all' | task id
 
-  const shortName = (id) => (id.includes("/") ? id.split("/").slice(1).join("/") : id);
+  const shortName = (id) =>
+    id.includes("/") ? id.split("/").slice(1).join("/") : id;
   const provider = (id) => (id.includes("/") ? id.split("/")[0] : id);
   const cellOf = (m, tid) => (m.tasks ?? []).find((t) => t.id === tid);
 
   const money = (v) => `$${v < 0.01 ? v.toFixed(4) : v.toFixed(3)}`;
   const secs = (v) => `${v.toFixed(v < 10 ? 1 : 0)}s`;
-  const kfmt = (v) => (v >= 1000 ? `${(v / 1000).toFixed(v >= 10000 ? 0 : 1)}k` : `${Math.round(v)}`);
+  const kfmt = (v) =>
+    v >= 1000
+      ? `${(v / 1000).toFixed(v >= 10000 ? 0 : 1)}k`
+      : `${Math.round(v)}`;
   const round = (v) => `${v.toFixed(v < 10 ? 1 : 0)}`;
 
   // Each tab: the X metric. `get` reads the model-level mean; `cell` reads one task's
   // raw value; `log` picks a log axis for the wide-range metrics.
   const METRICS = {
-    cost: { label: "Cost", axis: "avg cost per task", lens: "cloud", beat: "cheaper than Claude", log: true, get: (m) => m.cost_usd, cell: (c) => c.cost_usd, fmt: money },
-    wall: { label: "Wall-time", axis: "avg wall-time per task", lens: "cloud", beat: "faster than Claude", log: false, get: (m) => (m.mean_latency_ms ?? 0) / 1000, cell: (c) => c.latency_ms / 1000, fmt: secs },
-    tokens: { label: "Output tokens", axis: "avg tokens per task", lens: "self-host", beat: "leaner than Claude", log: true, get: (m) => m.mean_tokens, cell: (c) => c.tokens, fmt: kfmt },
-    turns: { label: "Agent steps", axis: "avg steps per task", lens: "self-host", beat: "fewer steps than Claude", log: false, get: (m) => m.mean_turns, cell: (c) => c.turns, fmt: round },
+    cost: {
+      label: "Cost",
+      axis: "avg cost per task",
+      lens: "cloud",
+      beat: "cheaper than Claude",
+      log: true,
+      get: (m) => m.cost_usd,
+      cell: (c) => c.cost_usd,
+      fmt: money,
+    },
+    wall: {
+      label: "Wall-time",
+      axis: "avg wall-time per task",
+      lens: "cloud",
+      beat: "faster than Claude",
+      log: false,
+      get: (m) => (m.mean_latency_ms ?? 0) / 1000,
+      cell: (c) => c.latency_ms / 1000,
+      fmt: secs,
+    },
+    tokens: {
+      label: "Output tokens",
+      axis: "avg tokens per task",
+      lens: "self-host",
+      beat: "leaner than Claude",
+      log: true,
+      get: (m) => m.mean_tokens,
+      cell: (c) => c.tokens,
+      fmt: kfmt,
+    },
+    turns: {
+      label: "Agent steps",
+      axis: "avg steps per task",
+      lens: "self-host",
+      beat: "fewer steps than Claude",
+      log: false,
+      get: (m) => m.mean_turns,
+      cell: (c) => c.turns,
+      fmt: round,
+    },
   };
   const MK = ["cost", "wall", "tokens", "turns"];
   const cfg = $derived(METRICS[metric]);
@@ -62,7 +102,13 @@
         x = cfg.cell(c);
       }
       if (!(x > 0)) continue; // metric must be positive (log axis + a real run)
-      pts.push({ id: m.id, name: m.name ?? shortName(m.id), anchor: m.role === "anchor", x, y });
+      pts.push({
+        id: m.id,
+        name: m.name ?? shortName(m.id),
+        anchor: m.role === "anchor",
+        x,
+        y,
+      });
     }
     return pts;
   });
@@ -74,7 +120,9 @@
     const a = points.filter((p) => p.anchor).map((p) => p.x);
     return a.length ? Math.min(...a) : null;
   });
-  const providersShown = $derived([...new Set(points.map((p) => provider(p.id)))]);
+  const providersShown = $derived([
+    ...new Set(points.map((p) => provider(p.id))),
+  ]);
 
   // ---- geometry ----
   const W = 760;
@@ -100,7 +148,10 @@
     const [lo, hi] = xdomain;
     if (cfg.log) {
       const vv = Math.max(v, lo);
-      return M.l + (iw * (Math.log(hi) - Math.log(vv))) / (Math.log(hi) - Math.log(lo));
+      return (
+        M.l +
+        (iw * (Math.log(hi) - Math.log(vv))) / (Math.log(hi) - Math.log(lo))
+      );
     }
     return M.l + (iw * (hi - v)) / (hi - lo);
   };
@@ -111,7 +162,11 @@
   // envelope (screen-left = expensive, screen-right = cheap).
   const frontier = $derived.by(() => {
     const nd = points.filter(
-      (p) => !points.some((q) => q !== p && q.y >= p.y && q.x <= p.x && (q.y > p.y || q.x < p.x)),
+      (p) =>
+        !points.some(
+          (q) =>
+            q !== p && q.y >= p.y && q.x <= p.x && (q.y > p.y || q.x < p.x),
+        ),
     );
     return nd.sort((a, b) => b.x - a.x); // expensive -> cheap == screen left -> right
   });
@@ -133,7 +188,9 @@
       return { ...p, cx, cy, leftSide, ly: cy, show };
     });
     for (const side of [true, false]) {
-      const grp = rows.filter((r) => r.show && r.leftSide === side).sort((a, b) => a.ly - b.ly);
+      const grp = rows
+        .filter((r) => r.show && r.leftSide === side)
+        .sort((a, b) => a.ly - b.ly);
       for (let i = 1; i < grp.length; i++) {
         if (grp[i].ly - grp[i - 1].ly < 13) grp[i].ly = grp[i - 1].ly + 13;
       }
@@ -146,7 +203,11 @@
     const [lo, hi] = xdomain;
     const out = [];
     for (let i = 0; i < 5; i++) {
-      out.push(cfg.log ? Math.exp(Math.log(lo) + ((Math.log(hi) - Math.log(lo)) * i) / 4) : lo + ((hi - lo) * i) / 4);
+      out.push(
+        cfg.log
+          ? Math.exp(Math.log(lo) + ((Math.log(hi) - Math.log(lo)) * i) / 4)
+          : lo + ((hi - lo) * i) / 4,
+      );
     }
     return out;
   });
@@ -156,7 +217,9 @@
   <div class="controls">
     <div class="tabs" role="group" aria-label="Metric">
       {#each MK as k}
-        <button class:on={metric === k} onclick={() => (metric = k)}>{METRICS[k].label}</button>
+        <button class:on={metric === k} onclick={() => (metric = k)}
+          >{METRICS[k].label}</button
+        >
       {/each}
     </div>
     <label class="task">
@@ -174,44 +237,97 @@
   {#if !points.length}
     <p class="empty">No data to plot for this view.</p>
   {:else}
-    <svg viewBox="0 0 {W} {H}" role="img" aria-label="Hard-task pass versus {cfg.axis}">
-      <text class="ylab" x={M.l} y={M.t - 8}>{isAll ? "hard-task pass" : "pass"}</text>
-      <text class="eff" x={M.l + iw} y={M.t - 8} text-anchor="end">most efficient ↗</text>
+    <svg
+      viewBox="0 0 {W} {H}"
+      role="img"
+      aria-label="Hard-task pass versus {cfg.axis}"
+    >
+      <text class="ylab" x={M.l} y={M.t - 8}
+        >{isAll ? "hard-task pass" : "pass"}</text
+      >
+      <text class="eff" x={M.l + iw} y={M.t - 8} text-anchor="end"
+        >most efficient ↗</text
+      >
 
       {#each yticks as tv}
-        <line class="grid" x1={M.l} y1={yScale(tv)} x2={M.l + iw} y2={yScale(tv)} />
-        <text class="tick" x={M.l - 8} y={yScale(tv) + 3} text-anchor="end">{Math.round(tv * 100)}%</text>
+        <line
+          class="grid"
+          x1={M.l}
+          y1={yScale(tv)}
+          x2={M.l + iw}
+          y2={yScale(tv)}
+        />
+        <text class="tick" x={M.l - 8} y={yScale(tv) + 3} text-anchor="end"
+          >{Math.round(tv * 100)}%</text
+        >
       {/each}
       {#each xticks as tv}
-        <text class="tick" x={xScale(tv)} y={M.t + ih + 16} text-anchor="middle">{cfg.fmt(tv)}</text>
+        <text class="tick" x={xScale(tv)} y={M.t + ih + 16} text-anchor="middle"
+          >{cfg.fmt(tv)}</text
+        >
       {/each}
-      <text class="axis-title" x={M.l + iw / 2} y={H - 8} text-anchor="middle">{cfg.axis}{cfg.log ? " (log)" : ""}</text>
+      <text class="axis-title" x={M.l + iw / 2} y={H - 8} text-anchor="middle"
+        >{cfg.axis}{cfg.log ? " (log)" : ""}</text
+      >
 
       <!-- budget zone: right of the most efficient Claude anchor -->
       {#if anchorBound != null && xScale(anchorBound) < M.l + iw - 4}
-        <rect class="zone" x={xScale(anchorBound)} y={M.t} width={M.l + iw - xScale(anchorBound)} height={ih} />
-        <line class="zone-edge" x1={xScale(anchorBound)} y1={M.t} x2={xScale(anchorBound)} y2={M.t + ih} />
-        <text class="zone-lab" x={xScale(anchorBound) + 6} y={M.t + ih - 8}>{cfg.beat}</text>
+        <rect
+          class="zone"
+          x={xScale(anchorBound)}
+          y={M.t}
+          width={M.l + iw - xScale(anchorBound)}
+          height={ih}
+        />
+        <line
+          class="zone-edge"
+          x1={xScale(anchorBound)}
+          y1={M.t}
+          x2={xScale(anchorBound)}
+          y2={M.t + ih}
+        />
+        <text class="zone-lab" x={xScale(anchorBound) + 6} y={M.t + ih - 8}
+          >{cfg.beat}</text
+        >
       {/if}
 
       {#if frontier.length > 1}
-        <polyline class="frontier" points={frontier.map((p) => `${xScale(p.x)},${yScale(p.y)}`).join(" ")} />
+        <polyline
+          class="frontier"
+          points={frontier
+            .map((p) => `${xScale(p.x)},${yScale(p.y)}`)
+            .join(" ")}
+        />
       {/if}
 
       {#each laidOut as p (p.id)}
         <g class="pt" class:on-frontier={frontierIds.has(p.id)}>
           <title>{p.name}: {cfg.fmt(p.x)}, {Math.round(p.y * 100)}% pass</title>
           {#if p.show}
-            <line class="lead" x1={p.cx} y1={p.cy} x2={p.leftSide ? p.cx - 10 : p.cx + 10} y2={p.ly} />
+            <line
+              class="lead"
+              x1={p.cx}
+              y1={p.cy}
+              x2={p.leftSide ? p.cx - 10 : p.cx + 10}
+              y2={p.ly}
+            />
           {/if}
-          <circle class="mark" cx={p.cx} cy={p.cy} r={p.anchor ? 6.5 : 5.5} style="fill:{provColor(p.id)}" class:anchor={p.anchor} />
+          <circle
+            class="mark"
+            cx={p.cx}
+            cy={p.cy}
+            r={p.anchor ? 6.5 : 5.5}
+            style="fill:{provColor(p.id)}"
+            class:anchor={p.anchor}
+          />
           {#if p.show}
             <text
               class="lbl"
               x={p.leftSide ? p.cx - 13 : p.cx + 13}
               y={p.ly + 3}
               text-anchor={p.leftSide ? "end" : "start"}
-              style="fill:{provColor(p.id)}">{p.name}{p.anchor ? " (anchor)" : ""}</text
+              style="fill:{provColor(p.id)}"
+              >{p.name}{p.anchor ? " (anchor)" : ""}</text
             >
           {/if}
         </g>
@@ -219,12 +335,15 @@
     </svg>
 
     <div class="cap">
-      {cfg.label} · {isAll ? "hard-task pass, mean over all tasks" : taskSel} · match the
-      frontier (top), beat its {cfg.label.toLowerCase()} ceiling (right)
+      {cfg.label} · {isAll ? "hard-task pass, mean over all tasks" : taskSel} · match
+      the frontier (top), beat its {cfg.label.toLowerCase()} ceiling (right)
     </div>
     <div class="key">
       {#each providersShown as pv}
-        <span class="k"><i class="sw" style="background:{PROV[pv] ?? '#6b6658'}"></i>{pv}</span>
+        <span class="k"
+          ><i class="sw" style="background:{PROV[pv] ?? '#6b6658'}"
+          ></i>{pv}</span
+        >
       {/each}
       <span class="k frontier-k"><i class="sw-line"></i>frontier</span>
     </div>

--- a/projects/monolith/frontend/src/routes/+error.svelte
+++ b/projects/monolith/frontend/src/routes/+error.svelte
@@ -17,7 +17,9 @@
   let path = $derived($page.url.pathname);
 
   let eyebrow = $derived(
-    isNotFound ? `ERROR 404 // OFF THE MAP` : `ERROR ${status} // SOMETHING BROKE`,
+    isNotFound
+      ? `ERROR 404 // OFF THE MAP`
+      : `ERROR ${status} // SOMETHING BROKE`,
   );
   let headline = $derived(
     isNotFound ? "you wandered off the map." : "the server hit a rough patch.",
@@ -26,7 +28,7 @@
     isNotFound
       ? "this page never existed, or it got refactored into the void. either way, there's nothing docked here."
       : ($page.error?.message ??
-        "an unexpected error knocked this page over. it's not you, it's the cluster."),
+          "an unexpected error knocked this page over. it's not you, it's the cluster."),
   );
 </script>
 
@@ -35,7 +37,11 @@
   <meta name="robots" content="noindex" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+  <link
+    rel="preconnect"
+    href="https://fonts.gstatic.com"
+    crossorigin="anonymous"
+  />
   <link
     href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@300;400;500;600&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
     rel="stylesheet"
@@ -44,7 +50,12 @@
 
 <main class="nf">
   <!-- decorative brutalist shapes, same flat-ink language as the homepage hero -->
-  <svg class="deco deco-star" width="56" height="56" viewBox="0 0 40 40" aria-hidden="true"
+  <svg
+    class="deco deco-star"
+    width="56"
+    height="56"
+    viewBox="0 0 40 40"
+    aria-hidden="true"
     ><path
       d="M20,2 L22.5,14 L34,10 L26,20 L34,30 L22.5,26 L20,38 L17.5,26 L6,30 L14,20 L6,10 L17.5,14 Z"
       fill="var(--blue)"
@@ -53,13 +64,40 @@
       stroke-linejoin="round"
     /></svg
   >
-  <svg class="deco deco-diamond" width="22" height="22" viewBox="0 0 24 24" aria-hidden="true"
-    ><path d="M12,2 L22,12 L12,22 L2,12 Z" fill="none" stroke="var(--ink)" stroke-width="2" /></svg
+  <svg
+    class="deco deco-diamond"
+    width="22"
+    height="22"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    ><path
+      d="M12,2 L22,12 L12,22 L2,12 Z"
+      fill="none"
+      stroke="var(--ink)"
+      stroke-width="2"
+    /></svg
   >
-  <svg class="deco deco-circle" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"
-    ><circle cx="12" cy="12" r="10" fill="var(--coral)" stroke="var(--ink)" stroke-width="2" /></svg
+  <svg
+    class="deco deco-circle"
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    ><circle
+      cx="12"
+      cy="12"
+      r="10"
+      fill="var(--coral)"
+      stroke="var(--ink)"
+      stroke-width="2"
+    /></svg
   >
-  <svg class="deco deco-squiggle" width="80" height="24" viewBox="0 0 80 24" aria-hidden="true"
+  <svg
+    class="deco deco-squiggle"
+    width="80"
+    height="24"
+    viewBox="0 0 80 24"
+    aria-hidden="true"
     ><path
       d="M2,12 Q 10,2 18,12 T 34,12 T 50,12 T 66,12 T 78,12"
       fill="none"
@@ -76,7 +114,12 @@
          and ends at an X, evoking a map track that leads nowhere. -->
     <div class="nf-code-wrap">
       <span class="display nf-code">{status}</span>
-      <svg class="nf-track" viewBox="0 0 400 80" aria-hidden="true" preserveAspectRatio="none">
+      <svg
+        class="nf-track"
+        viewBox="0 0 400 80"
+        aria-hidden="true"
+        preserveAspectRatio="none"
+      >
         <path
           d="M8,64 Q 90,12 170,52 T 330,40"
           fill="none"
@@ -98,7 +141,9 @@
     <p class="nf-blurb">{blurb}</p>
 
     {#if isNotFound}
-      <p class="mono nf-path">you tried: <span class="nf-path-val">{path}</span></p>
+      <p class="mono nf-path">
+        you tried: <span class="nf-path-val">{path}</span>
+      </p>
     {/if}
 
     <div class="nf-cta">

--- a/projects/monolith/frontend/src/routes/private/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/private/+layout.svelte
@@ -23,8 +23,7 @@
   // paths un-prefixed), but strip a literal /private prefix too in case a
   // route is hit directly.
   let showBack = $derived.by(() => {
-    const path =
-      $page.url.pathname.replace(/^\/private(?=\/|$)/, "") || "/";
+    const path = $page.url.pathname.replace(/^\/private(?=\/|$)/, "") || "/";
     if (path === "/") return false;
     if (/^\/(app|demos|review|chat|notes)(\/|$)/.test(path)) return false;
     return true;

--- a/projects/monolith/frontend/src/routes/private/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/+page.svelte
@@ -29,7 +29,9 @@
   let events = $derived(
     dash?.today && !dash.today.error ? (dash.today.events ?? []) : null,
   );
-  let health = $derived(dash?.health && !dash.health.error ? dash.health : null);
+  let health = $derived(
+    dash?.health && !dash.health.error ? dash.health : null,
+  );
   let alerts = $derived(
     dash?.alerts && !dash.alerts.error ? (dash.alerts.firing ?? []) : null,
   );
@@ -198,7 +200,8 @@
     <!-- Cluster pulse ribbon -->
     <section
       class="pulse"
-      class:pulse--bad={health != null && (!health.healthy || (alerts?.length ?? 0) > 0)}
+      class:pulse--bad={health != null &&
+        (!health.healthy || (alerts?.length ?? 0) > 0)}
     >
       {#if health == null && alerts == null}
         <span class="pulse-dot pulse-dot--unknown"></span>
@@ -207,7 +210,9 @@
         <span class="pulse-dot pulse-dot--ok"></span>
         <span class="pulse-text">
           All quiet on the cluster
-          <span class="pulse-sub">{health?.scanned ?? 0} workloads scanned · no alerts firing</span>
+          <span class="pulse-sub"
+            >{health?.scanned ?? 0} workloads scanned · no alerts firing</span
+          >
         </span>
       {:else}
         <div class="pulse-head">
@@ -224,7 +229,9 @@
               workloads healthy
             {/if}
             {#if alerts && alerts.length > 0}
-              <span class="pulse-sub">{alerts.length} alert{alerts.length === 1 ? "" : "s"} firing</span>
+              <span class="pulse-sub"
+                >{alerts.length} alert{alerts.length === 1 ? "" : "s"} firing</span
+              >
             {/if}
           </span>
         </div>
@@ -234,7 +241,9 @@
               {#each rows ?? [] as row}
                 <li class="pulse-item">
                   <span class="pulse-kind">{kind}</span>
-                  <span class="mono">{row.namespace ? `${row.namespace}/` : ""}{row.name}</span>
+                  <span class="mono"
+                    >{row.namespace ? `${row.namespace}/` : ""}{row.name}</span
+                  >
                 </li>
               {/each}
             {/each}
@@ -303,7 +312,13 @@
                   onclick={() => toggleTask(task)}
                 >
                   <svg viewBox="0 0 12 12" aria-hidden="true">
-                    <path d="M2.5 6.5 5 9l4.5-6" fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+                    <path
+                      d="M2.5 6.5 5 9l4.5-6"
+                      fill="none"
+                      stroke-width="1.8"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
                   </svg>
                 </button>
                 <span
@@ -325,7 +340,13 @@
                   onclick={() => toggleTask(task)}
                 >
                   <svg viewBox="0 0 12 12" aria-hidden="true">
-                    <path d="M2.5 6.5 5 9l4.5-6" fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+                    <path
+                      d="M2.5 6.5 5 9l4.5-6"
+                      fill="none"
+                      stroke-width="1.8"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
                   </svg>
                 </button>
                 <span class="task-title" class:task-title--done={isDone(task)}

--- a/projects/monolith/frontend/src/routes/private/chat/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/chat/+page.svelte
@@ -166,11 +166,11 @@
   //   4. Drain again (absorbs anything that arrived during animation)
   const MOVE_MS = 400;
   const PEN_EASE = "cubic-bezier(0.65, 0, 0.15, 1)";
-  const PENCIL_MS = 600;   // pencil sketch total (4 sides)
-  const INK_MS = 500;      // ink retrace total (4 sides)
-  const TEXT_MS = 300;      // text fade-in
+  const PENCIL_MS = 600; // pencil sketch total (4 sides)
+  const INK_MS = 500; // ink retrace total (4 sides)
+  const TEXT_MS = 300; // text fade-in
   const EDGE_PENCIL_MS = 400; // pencil line between nodes
-  const EDGE_INK_MS = 340;    // ink retrace on edge
+  const EDGE_INK_MS = 340; // ink retrace on edge
   let eventQueue = [];
   let draining = false;
   let pendingRevealIds = new Set();
@@ -182,7 +182,10 @@
   }
 
   function drainQueue() {
-    if (eventQueue.length === 0) { draining = false; return; }
+    if (eventQueue.length === 0) {
+      draining = false;
+      return;
+    }
     draining = true;
 
     // Absorb ALL queued events at once into graph state
@@ -194,10 +197,18 @@
         pendingRevealIds.add(evt.data.note_id);
         graphState.addNode(evt.data);
         for (const edge of evt.data.edges || []) {
-          graphState.addEdge(evt.data.note_id, edge.target_id, edge.edge_type || "link");
+          graphState.addEdge(
+            evt.data.note_id,
+            edge.target_id,
+            edge.edge_type || "link",
+          );
         }
       } else if (evt.type === "edge_traversed") {
-        graphState.addEdge(evt.data.from_id, evt.data.to_id, evt.data.edge_type);
+        graphState.addEdge(
+          evt.data.from_id,
+          evt.data.to_id,
+          evt.data.edge_type,
+        );
       } else if (evt.type === "node_discarded") {
         graphState.discardNode(evt.data.note_id);
       }
@@ -225,23 +236,35 @@
     const id = ids[idx];
     pendingRevealIds.delete(id);
     const entry = drawnNodes.get(id);
-    if (!entry) { revealNodes(ids, idx + 1); return; }
+    if (!entry) {
+      revealNodes(ids, idx + 1);
+      return;
+    }
 
     // Animate the node box: pencil → ink → fill → text
     animateNodeEntry(entry);
 
     // Animate any pending edges connected to this node (after node ink starts)
-    setTimeout(() => {
-      for (const [key, edgeEntry] of drawnEdges) {
-        if (pendingEdgeKeys.has(key) && (edgeEntry.from === id || edgeEntry.to === id)) {
-          pendingEdgeKeys.delete(key);
-          animateEdgeEntry(edgeEntry);
+    setTimeout(
+      () => {
+        for (const [key, edgeEntry] of drawnEdges) {
+          if (
+            pendingEdgeKeys.has(key) &&
+            (edgeEntry.from === id || edgeEntry.to === id)
+          ) {
+            pendingEdgeKeys.delete(key);
+            animateEdgeEntry(edgeEntry);
+          }
         }
-      }
-    }, PENCIL_MS + INK_MS * 0.3); // start edge draw as node ink is partway through
+      },
+      PENCIL_MS + INK_MS * 0.3,
+    ); // start edge draw as node ink is partway through
 
     // Total animation time for one node + its edges, then start next
-    const nodeAnimMs = PENCIL_MS + INK_MS + Math.max(TEXT_MS, EDGE_PENCIL_MS + EDGE_INK_MS) * 0.6;
+    const nodeAnimMs =
+      PENCIL_MS +
+      INK_MS +
+      Math.max(TEXT_MS, EDGE_PENCIL_MS + EDGE_INK_MS) * 0.6;
     setTimeout(() => revealNodes(ids, idx + 1), nodeAnimMs);
   }
 
@@ -320,15 +343,16 @@
   const NODE_H = 44;
 
   // Persistent refs — survive across effect runs so we can diff
-  let drawnNodes = new Map();   // id → { g, origX, origY }
-  let drawnEdges = new Map();   // "from|to" → { el, from, to }
+  let drawnNodes = new Map(); // id → { g, origX, origY }
+  let drawnEdges = new Map(); // "from|to" → { el, from, to }
   let nodeElsForDim = new Map();
   let edgeElsForDim = new Map();
 
   /** Deterministic seed from string. */
   function seed(str) {
     let h = 0;
-    for (let i = 0; i < str.length; i++) h = ((h << 5) - h + str.charCodeAt(i)) | 0;
+    for (let i = 0; i < str.length; i++)
+      h = ((h << 5) - h + str.charCodeAt(i)) | 0;
     return Math.abs(h);
   }
 
@@ -359,7 +383,9 @@
           const len = p.getTotalLength();
           p.style.strokeDasharray = String(len);
           p.style.strokeDashoffset = String(len);
-        } catch { /* fallback handled in animation */ }
+        } catch {
+          /* fallback handled in animation */
+        }
       });
     } else {
       ink.style.opacity = "0.5";
@@ -430,8 +456,10 @@
     g.appendChild(fillEl);
 
     // Draw 4 sides as individual lines — enables per-side pencil→ink animation
-    const x1 = -w / 2, y1 = -h / 2;
-    const x2 = w / 2, y2 = h / 2;
+    const x1 = -w / 2,
+      y1 = -h / 2;
+    const x2 = w / 2,
+      y2 = h / 2;
     const sides = [
       { from: [x1, y1], to: [x2, y1], key: "top" },
       { from: [x2, y1], to: [x2, y2], key: "right" },
@@ -443,12 +471,18 @@
       const sideSeed = seed(node.id + side.key);
 
       // Pencil: light gray sketch
-      const pencil = rc.line(side.from[0], side.from[1], side.to[0], side.to[1], {
-        stroke: "#c0b8a8",
-        roughness: 1.2,
-        strokeWidth: 1,
-        seed: sideSeed,
-      });
+      const pencil = rc.line(
+        side.from[0],
+        side.from[1],
+        side.to[0],
+        side.to[1],
+        {
+          stroke: "#c0b8a8",
+          roughness: 1.2,
+          strokeWidth: 1,
+          seed: sideSeed,
+        },
+      );
       pencil.style.opacity = isPending ? "0" : "0.5";
       pencil.dataset.layer = "pencil";
       g.appendChild(pencil);
@@ -468,7 +502,9 @@
             const len = p.getTotalLength();
             p.style.strokeDasharray = String(len);
             p.style.strokeDashoffset = String(len);
-          } catch { /* fill paths — handled by nodeIn */ }
+          } catch {
+            /* fill paths — handled by nodeIn */
+          }
         });
       }
       g.appendChild(ink);
@@ -480,7 +516,10 @@
     text.setAttribute("y", 4);
     text.setAttribute("text-anchor", "middle");
     text.setAttribute("font-size", "10");
-    text.setAttribute("class", `node-label${node.discarded ? " node-label--discarded" : ""}`);
+    text.setAttribute(
+      "class",
+      `node-label${node.discarded ? " node-label--discarded" : ""}`,
+    );
     text.textContent = node.label;
     if (isPending) text.style.opacity = "0";
     g.appendChild(text);
@@ -498,7 +537,10 @@
     const discardG = svgEl.querySelector(".graph-discards");
 
     // Compute viewBox
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity;
     for (const n of layoutResult.nodes) {
       minX = Math.min(minX, n.x - n.hw - 16);
       maxX = Math.max(maxX, n.x + n.hw + 16);
@@ -557,20 +599,55 @@
       const existing = drawnEdges.get(key);
       if (existing) {
         // Only redraw if endpoints actually moved
-        if (existing.fx !== from.x || existing.fy !== from.y || existing.tx !== to.x || existing.ty !== to.y) {
+        if (
+          existing.fx !== from.x ||
+          existing.fy !== from.y ||
+          existing.tx !== to.x ||
+          existing.ty !== to.y
+        ) {
           clearChildren(existing.el);
-          fillEdgeGroup(rc, existing.el, from.x, from.y, to.x, to.y, edgeColor, edgeSeed, false);
+          fillEdgeGroup(
+            rc,
+            existing.el,
+            from.x,
+            from.y,
+            to.x,
+            to.y,
+            edgeColor,
+            edgeSeed,
+            false,
+          );
         }
-        existing.fx = from.x; existing.fy = from.y;
-        existing.tx = to.x; existing.ty = to.y;
+        existing.fx = from.x;
+        existing.fy = from.y;
+        existing.tx = to.x;
+        existing.ty = to.y;
         newEdgeEls.set(key, existing);
       } else {
         // New edge — create group, draw hidden, queue for animation
         const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
         g.style.transition = "opacity 0.15s";
-        fillEdgeGroup(rc, g, from.x, from.y, to.x, to.y, edgeColor, edgeSeed, true);
+        fillEdgeGroup(
+          rc,
+          g,
+          from.x,
+          from.y,
+          to.x,
+          to.y,
+          edgeColor,
+          edgeSeed,
+          true,
+        );
         edgeG.appendChild(g);
-        newEdgeEls.set(key, { el: g, from: edge.from, to: edge.to, fx: from.x, fy: from.y, tx: to.x, ty: to.y });
+        newEdgeEls.set(key, {
+          el: g,
+          from: edge.from,
+          to: edge.to,
+          fx: from.x,
+          fy: from.y,
+          tx: to.x,
+          ty: to.y,
+        });
         newEdgeIds.push(key);
       }
     }
@@ -595,12 +672,20 @@
       const x2 = node.x + w / 2 - 3;
       const y1 = node.y - h / 2 + 3;
       const y2 = node.y + h / 2 - 3;
-      discardG.appendChild(rc.line(x1, y1, x2, y2, {
-        stroke: "#ff3d00", strokeWidth: 2, roughness: 1.5,
-      }));
-      discardG.appendChild(rc.line(x2, y1, x1, y2, {
-        stroke: "#ff3d00", strokeWidth: 2, roughness: 1.5,
-      }));
+      discardG.appendChild(
+        rc.line(x1, y1, x2, y2, {
+          stroke: "#ff3d00",
+          strokeWidth: 2,
+          roughness: 1.5,
+        }),
+      );
+      discardG.appendChild(
+        rc.line(x2, y1, x1, y2, {
+          stroke: "#ff3d00",
+          strokeWidth: 2,
+          roughness: 1.5,
+        }),
+      );
     }
 
     // Update refs for dimming effect
@@ -619,7 +704,8 @@
     }
     for (const [key, edge] of edgeElsForDim) {
       if (pendingEdgeKeys.has(key)) continue; // don't touch edges mid-reveal
-      const dim = connected && !connected.has(edge.from) && !connected.has(edge.to);
+      const dim =
+        connected && !connected.has(edge.from) && !connected.has(edge.to);
       edge.el.style.opacity = dim ? "0.1" : "1";
     }
   });
@@ -640,7 +726,8 @@
       <div class="chat-log" bind:this={chatLog}>
         {#each messages as msg, i}
           <div class="chat-msg chat-msg--{msg.role}">
-            <span class="chat-role">{msg.role === "user" ? "you" : "qwen"}</span>
+            <span class="chat-role">{msg.role === "user" ? "you" : "qwen"}</span
+            >
             {#if msg.role === "assistant"}
               <span class="chat-text">{@html marked(msg.content)}</span>
             {:else}
@@ -652,7 +739,9 @@
           </div>
         {/each}
         {#if messages.length === 0}
-          <p class="chat-empty">Ask a question to explore your knowledge graph</p>
+          <p class="chat-empty">
+            Ask a question to explore your knowledge graph
+          </p>
         {/if}
       </div>
       <div class="chat-input-bar">
@@ -663,7 +752,10 @@
           placeholder="explore your knowledge..."
           disabled={isStreaming}
         />
-        <button onclick={sendMessage} disabled={isStreaming || !inputText.trim()}>
+        <button
+          onclick={sendMessage}
+          disabled={isStreaming || !inputText.trim()}
+        >
           &rarr;
         </button>
       </div>
@@ -673,7 +765,11 @@
       {#if layoutResult.nodes.length === 0}
         <p class="graph-empty">Ask a question to start exploring</p>
       {:else}
-        <svg bind:this={svgEl} class="graph-svg" xmlns="http://www.w3.org/2000/svg">
+        <svg
+          bind:this={svgEl}
+          class="graph-svg"
+          xmlns="http://www.w3.org/2000/svg"
+        >
           <g class="graph-edges"></g>
           <g class="graph-nodes"></g>
           <g class="graph-discards"></g>
@@ -692,7 +788,8 @@
                   aria-label={node.label}
                   onmouseenter={() => (hoveredNode = node.id)}
                   onmouseleave={() => (hoveredNode = null)}
-                  onclick={() => (selectedNode = selectedNode === node.id ? null : node.id)}
+                  onclick={() =>
+                    (selectedNode = selectedNode === node.id ? null : node.id)}
                 />
               {/if}
             {/each}
@@ -703,11 +800,7 @@
   </div>
 
   {#if selectedNode}
-    <div
-      class="note-drawer"
-      role="complementary"
-      aria-label="Note details"
-    >
+    <div class="note-drawer" role="complementary" aria-label="Note details">
       <button class="drawer-close" onclick={() => (selectedNode = null)}>
         &times;
       </button>
@@ -716,7 +809,11 @@
       {:else if drawerNote}
         <h2 class="drawer-title">{drawerNote.title}</h2>
         <div class="drawer-meta">
-          <span class="drawer-type" style="background: {TYPE_COLORS[drawerNote.type]?.border || '#ffd54f'}">{drawerNote.type}</span>
+          <span
+            class="drawer-type"
+            style="background: {TYPE_COLORS[drawerNote.type]?.border ||
+              '#ffd54f'}">{drawerNote.type}</span
+          >
           {#each drawerNote.tags || [] as tag}
             <span class="drawer-tag">{tag}</span>
           {/each}
@@ -729,8 +826,12 @@
             <h3 class="drawer-edges-title">EDGES</h3>
             {#each drawerNote.edges as edge}
               <div class="drawer-edge">
-                <span class="drawer-edge-type">{edge.edge_type || edge.kind || "link"}</span>
-                <span class="drawer-edge-target">{edge.target_title || edge.target_id}</span>
+                <span class="drawer-edge-type"
+                  >{edge.edge_type || edge.kind || "link"}</span
+                >
+                <span class="drawer-edge-target"
+                  >{edge.target_title || edge.target_id}</span
+                >
               </div>
             {/each}
           </div>
@@ -933,16 +1034,30 @@
   }
   /* Pencil→ink draw animation keyframes (global — targets dynamic SVG elements) */
   @keyframes -global-edgeDraw {
-    to { stroke-dashoffset: 0; }
+    to {
+      stroke-dashoffset: 0;
+    }
   }
   @keyframes -global-nodeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
   }
   @keyframes -global-textJot {
-    0% { opacity: 0; transform: translate(-1px, 0.5px); }
-    40% { opacity: 0.85; }
-    100% { opacity: 1; transform: translate(0, 0); }
+    0% {
+      opacity: 0;
+      transform: translate(-1px, 0.5px);
+    }
+    40% {
+      opacity: 0.85;
+    }
+    100% {
+      opacity: 1;
+      transform: translate(0, 0);
+    }
   }
   .note-drawer {
     position: fixed;

--- a/projects/monolith/frontend/src/routes/private/perf/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/perf/+page.svelte
@@ -87,7 +87,10 @@
     const x = (i) => padL + (W - padL - padR) * (i / (n - 1));
     const y = (v) => padT + (H - padT - padB) * (1 - (v - ymin) / yrange);
     const line = pts
-      .map((p, i) => `${i === 0 ? "M" : "L"} ${x(i).toFixed(1)} ${y(p.speedup).toFixed(1)}`)
+      .map(
+        (p, i) =>
+          `${i === 0 ? "M" : "L"} ${x(i).toFixed(1)} ${y(p.speedup).toFixed(1)}`,
+      )
       .join(" ");
     const area = `${line} L ${x(n - 1).toFixed(1)} ${H - padB} L ${x(0).toFixed(1)} ${H - padB} Z`;
     return {
@@ -137,12 +140,15 @@
       <h1 class="greeting">
         Semgrep scan performance<span class="greeting-mark">.</span>
       </h1>
-      <p class="masthead-lead">homelab (self-hosted) vs Semgrep managed scans</p>
+      <p class="masthead-lead">
+        homelab (self-hosted) vs Semgrep managed scans
+      </p>
       {#if data.counts}
         <p class="masthead-sub">
           <span class="mono">{data.counts.homelab ?? 0}</span> homelab
           <span class="sub-sep">&middot;</span>
-          <span class="mono">{data.counts.managed ?? 0}</span> managed{#if data.windowStart}
+          <span class="mono">{data.counts.managed ?? 0}</span>
+          managed{#if data.windowStart}
             <span class="sub-sep">&middot;</span> since {formatDay(
               data.windowStart,
             )}{/if}
@@ -188,7 +194,9 @@
                 </div>
               </div>
               <p class="agg-foot">
-                {agg.pairs} matched pair{agg.pairs === 1 ? "" : "s"}{#if agg.findings_pairs > 0}
+                {agg.pairs} matched pair{agg.pairs === 1
+                  ? ""
+                  : "s"}{#if agg.findings_pairs > 0}
                   <span class="sub-sep">&middot;</span> findings agree on {agg.findings_agree}/{agg.findings_pairs}{/if}
               </p>
             {:else}
@@ -232,7 +240,8 @@
               <span class="trend-meta"
                 >{data.trend.window_days}-day rolling &middot; latest
                 <span class="mono">{chart.latest.speedup.toFixed(1)}x</span>
-                (was <span class="mono">{chart.first.speedup.toFixed(1)}x</span
+                (was
+                <span class="mono">{chart.first.speedup.toFixed(1)}x</span
                 >)</span
               >
             </div>
@@ -247,9 +256,10 @@
               {#each chart.dots as d}
                 <circle class="trend-dot" cx={d.cx} cy={d.cy} r="2.5">
                   <title
-                    >{formatDay(d.date)}: {d.speedup.toFixed(1)}x &middot; homelab {formatDuration(
-                      d.homelab_median,
-                    )} vs managed {formatDuration(d.managed_median)} &middot; {d.pairs}
+                    >{formatDay(d.date)}: {d.speedup.toFixed(1)}x &middot;
+                    homelab {formatDuration(d.homelab_median)} vs managed {formatDuration(
+                      d.managed_median,
+                    )} &middot; {d.pairs}
                     pairs</title
                   >
                 </circle>
@@ -275,8 +285,8 @@
             </svg>
             <p class="trend-note">
               Higher is a wider lead. A drop means our advantage is narrowing
-              &mdash; hover a point to see whether homelab slowed or managed sped
-              up.
+              &mdash; hover a point to see whether homelab slowed or managed
+              sped up.
             </p>
           </section>
         {/if}
@@ -286,8 +296,8 @@
         <section class="card cohorts">
           <h2 class="section-label">Speedup by diff cohort</h2>
           <p class="cohort-note">
-            {data.cohorts.total_pairs} matched PR pair{data.cohorts.total_pairs ===
-            1
+            {data.cohorts.total_pairs} matched PR pair{data.cohorts
+              .total_pairs === 1
               ? ""
               : "s"} segmented by diff shape &mdash; which cohorts are at parity vs
             a major speedup.
@@ -349,7 +359,8 @@
         {#if data.comparisons.length > matchedComparisons.length}
           <label class="onesided-toggle">
             <input type="checkbox" bind:checked={showOneSided} />
-            show one-sided ({data.comparisons.length - matchedComparisons.length}
+            show one-sided ({data.comparisons.length -
+              matchedComparisons.length}
             scans with no counterpart yet)
           </label>
         {/if}

--- a/projects/monolith/frontend/src/routes/private/review/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/review/+page.svelte
@@ -409,8 +409,8 @@
         type="button"
         class="banner-dismiss"
         onclick={() => (pendingError = null)}
-        aria-label="Dismiss error"
-      >×</button>
+        aria-label="Dismiss error">×</button
+      >
     </div>
   {/if}
 

--- a/projects/monolith/frontend/src/routes/public/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/public/+layout.svelte
@@ -10,7 +10,11 @@
   {@html personLdScript}
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+  <link
+    rel="preconnect"
+    href="https://fonts.gstatic.com"
+    crossorigin="anonymous"
+  />
   <link
     href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
     rel="stylesheet"

--- a/projects/monolith/frontend/src/routes/public/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/+page.svelte
@@ -14,7 +14,8 @@
     const k = stats?.knowledge;
     const d = stats?.deploy;
 
-    if (c?.nodes != null && c?.pods != null) items.push(`${c.nodes} nodes · ${c.pods} pods`);
+    if (c?.nodes != null && c?.pods != null)
+      items.push(`${c.nodes} nodes · ${c.pods} pods`);
     if (c?.cpu_used_cores != null && c?.cpu_capacity_cores != null) {
       items.push(`cpu: ${c.cpu_used_cores} / ${c.cpu_capacity_cores} cores`);
     }
@@ -22,9 +23,10 @@
       items.push(`mem: ${c.memory_used_gb} / ${c.memory_capacity_gb} gb`);
     }
     if (g?.utilization_pct != null) {
-      const memPart = g?.memory_used_gb != null && g?.memory_total_gb != null
-        ? ` · ${g.memory_used_gb} / ${g.memory_total_gb} gb`
-        : "";
+      const memPart =
+        g?.memory_used_gb != null && g?.memory_total_gb != null
+          ? ` · ${g.memory_used_gb} / ${g.memory_total_gb} gb`
+          : "";
       items.push(`gpu: ${g.utilization_pct}%${memPart}`);
     }
     if (c?.argocd_apps != null) items.push(`argocd: ${c.argocd_apps} apps`);
@@ -92,85 +94,134 @@
 <Marquee items={MARQUEE_ITEMS} />
 
 <div class="above-fold">
-<!-- ═══ Hero ═══ -->
-<section class="hero">
-  <!-- decorative shapes -->
-  <svg class="deco deco-diamond-1" width="28" height="28" viewBox="0 0 24 24"
-    ><path d="M12,2 L22,12 L12,22 L2,12 Z" fill="none" stroke="var(--ink)" stroke-width="2" /></svg
-  >
-  <svg class="deco deco-circle-1" width="18" height="18" viewBox="0 0 24 24"
-    ><circle cx="12" cy="12" r="10" fill="var(--coral)" stroke="var(--ink)" stroke-width="2" /></svg
-  >
-  <svg class="deco deco-star" width="56" height="56" viewBox="0 0 40 40"
-    ><path
-      d="M20,2 L22.5,14 L34,10 L26,20 L34,30 L22.5,26 L20,38 L17.5,26 L6,30 L14,20 L6,10 L17.5,14 Z"
-      fill="var(--blue)"
-      stroke="var(--ink)"
-      stroke-width="2"
-      stroke-linejoin="round"
-    /></svg
-  >
-  <svg class="deco deco-cloud" width="120" height="60" viewBox="0 0 120 60"
-    ><path
-      d="M10,45 Q 8,30 22,28 Q 26,14 42,18 Q 54,10 66,20 Q 82,16 88,30 Q 104,28 108,44 Q 108,52 98,52 L 20,52 Q 10,52 10,45 Z"
-      fill="none"
-      stroke="var(--ink)"
-      stroke-width="2.5"
-      stroke-linejoin="round"
-    /></svg
-  >
-  <svg class="deco deco-squiggle" width="80" height="24" viewBox="0 0 80 24"
-    ><path
-      d="M2,12 Q 10,2 18,12 T 34,12 T 50,12 T 66,12 T 78,12"
-      fill="none"
-      stroke="var(--ink)"
-      stroke-width="2.5"
-      stroke-linecap="round"
-    /></svg
-  >
-  <svg class="deco deco-diamond-2" width="18" height="18" viewBox="0 0 24 24"
-    ><path d="M12,2 L22,12 L12,22 L2,12 Z" fill="none" stroke="var(--ink)" stroke-width="2" /></svg
-  >
+  <!-- ═══ Hero ═══ -->
+  <section class="hero">
+    <!-- decorative shapes -->
+    <svg class="deco deco-diamond-1" width="28" height="28" viewBox="0 0 24 24"
+      ><path
+        d="M12,2 L22,12 L12,22 L2,12 Z"
+        fill="none"
+        stroke="var(--ink)"
+        stroke-width="2"
+      /></svg
+    >
+    <svg class="deco deco-circle-1" width="18" height="18" viewBox="0 0 24 24"
+      ><circle
+        cx="12"
+        cy="12"
+        r="10"
+        fill="var(--coral)"
+        stroke="var(--ink)"
+        stroke-width="2"
+      /></svg
+    >
+    <svg class="deco deco-star" width="56" height="56" viewBox="0 0 40 40"
+      ><path
+        d="M20,2 L22.5,14 L34,10 L26,20 L34,30 L22.5,26 L20,38 L17.5,26 L6,30 L14,20 L6,10 L17.5,14 Z"
+        fill="var(--blue)"
+        stroke="var(--ink)"
+        stroke-width="2"
+        stroke-linejoin="round"
+      /></svg
+    >
+    <svg class="deco deco-cloud" width="120" height="60" viewBox="0 0 120 60"
+      ><path
+        d="M10,45 Q 8,30 22,28 Q 26,14 42,18 Q 54,10 66,20 Q 82,16 88,30 Q 104,28 108,44 Q 108,52 98,52 L 20,52 Q 10,52 10,45 Z"
+        fill="none"
+        stroke="var(--ink)"
+        stroke-width="2.5"
+        stroke-linejoin="round"
+      /></svg
+    >
+    <svg class="deco deco-squiggle" width="80" height="24" viewBox="0 0 80 24"
+      ><path
+        d="M2,12 Q 10,2 18,12 T 34,12 T 50,12 T 66,12 T 78,12"
+        fill="none"
+        stroke="var(--ink)"
+        stroke-width="2.5"
+        stroke-linecap="round"
+      /></svg
+    >
+    <svg class="deco deco-diamond-2" width="18" height="18" viewBox="0 0 24 24"
+      ><path
+        d="M12,2 L22,12 L12,22 L2,12 Z"
+        fill="none"
+        stroke="var(--ink)"
+        stroke-width="2"
+      /></svg
+    >
 
-  <div class="wrap hero-content">
-    <h1 class="hero-headline">ten years ago i was underwriting policies and winning insurance hackathons. now i'm building <span class="hl hl-yellow">production grade infra</span> for weekend side quests and keeping <a href="https://semgrep.dev" class="hero-mono">semgrep</a> online.</h1>
-    <div class="hero-cta-row">
-      <a href="#homelab" class="btn btn-primary">SEE MY HOMELAB <span class="btn-arr">→</span></a>
-      <a href="/app/notes" class="btn btn-secondary">TALK TO MY NOTES</a>
+    <div class="wrap hero-content">
+      <h1 class="hero-headline">
+        ten years ago i was underwriting policies and winning insurance
+        hackathons. now i'm building <span class="hl hl-yellow"
+          >production grade infra</span
+        >
+        for weekend side quests and keeping
+        <a href="https://semgrep.dev" class="hero-mono">semgrep</a> online.
+      </h1>
+      <div class="hero-cta-row">
+        <a href="#homelab" class="btn btn-primary"
+          >SEE MY HOMELAB <span class="btn-arr">→</span></a
+        >
+        <a href="/app/notes" class="btn btn-secondary">TALK TO MY NOTES</a>
+      </div>
+      <Sticker color="var(--coral)" rotate={-5} class="sticker-hero"
+        >← BUILT THIS SITE TOO</Sticker
+      >
     </div>
-    <Sticker color="var(--coral)" rotate={-5} class="sticker-hero">← BUILT THIS SITE TOO</Sticker>
-  </div>
-</section>
+  </section>
 
-<!-- ═══ Bio panel (yellow) ═══ -->
-<section class="bio-panel reveal">
-  <!-- decorative shapes -->
-  <svg class="deco deco-bio-squiggle" width="80" height="24" viewBox="0 0 80 24"
-    ><path
-      d="M2,12 Q 10,2 18,12 T 34,12 T 50,12 T 66,12 T 78,12"
-      fill="none"
-      stroke="var(--ink)"
-      stroke-width="2.5"
-      stroke-linecap="round"
-    /></svg
-  >
-  <svg class="deco deco-bio-diamond" width="20" height="20" viewBox="0 0 24 24"
-    ><path d="M12,2 L22,12 L12,22 L2,12 Z" fill="none" stroke="var(--ink)" stroke-width="2" /></svg
-  >
-  <svg class="deco deco-bio-circle" width="24" height="24" viewBox="0 0 24 24"
-    ><circle cx="12" cy="12" r="10" fill="none" stroke="var(--ink)" stroke-width="2" /></svg
-  >
-  <div class="wrap bio-content">
-    <div class="bio-left">
-      <Sticker color="var(--paper)" rotate={-3} class="sticker-bio">A LITTLE ABOUT ME</Sticker>
-      <p class="bio-sub">
-        I'm Joe, from Scotland, living in Vancouver.<br />
-        Monorepo enthusiast. Care<em>mad</em> about developer experience.
-      </p>
+  <!-- ═══ Bio panel (yellow) ═══ -->
+  <section class="bio-panel reveal">
+    <!-- decorative shapes -->
+    <svg
+      class="deco deco-bio-squiggle"
+      width="80"
+      height="24"
+      viewBox="0 0 80 24"
+      ><path
+        d="M2,12 Q 10,2 18,12 T 34,12 T 50,12 T 66,12 T 78,12"
+        fill="none"
+        stroke="var(--ink)"
+        stroke-width="2.5"
+        stroke-linecap="round"
+      /></svg
+    >
+    <svg
+      class="deco deco-bio-diamond"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      ><path
+        d="M12,2 L22,12 L12,22 L2,12 Z"
+        fill="none"
+        stroke="var(--ink)"
+        stroke-width="2"
+      /></svg
+    >
+    <svg class="deco deco-bio-circle" width="24" height="24" viewBox="0 0 24 24"
+      ><circle
+        cx="12"
+        cy="12"
+        r="10"
+        fill="none"
+        stroke="var(--ink)"
+        stroke-width="2"
+      /></svg
+    >
+    <div class="wrap bio-content">
+      <div class="bio-left">
+        <Sticker color="var(--paper)" rotate={-3} class="sticker-bio"
+          >A LITTLE ABOUT ME</Sticker
+        >
+        <p class="bio-sub">
+          I'm Joe, from Scotland, living in Vancouver.<br />
+          Monorepo enthusiast. Care<em>mad</em> about developer experience.
+        </p>
+      </div>
     </div>
-  </div>
-</section>
-
+  </section>
 </div>
 
 <!-- ═══ Project stack ═══ -->
@@ -178,7 +229,6 @@
 
 <!-- ═══ Footer ═══ -->
 <Footer />
-
 
 <style>
   /* ── Above-fold wrapper ─────────────────── */

--- a/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
+++ b/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
@@ -19,8 +19,14 @@
   const featuredApps = apps.filter((a) => a.featured);
 </script>
 
-<section class="rack-section" id="homelab" aria-label="Homelab hardware and systems">
-  <p class="rack-eyebrow">4 nodes &middot; 52 CPUs &middot; 112 GB &middot; one RTX 4090</p>
+<section
+  class="rack-section"
+  id="homelab"
+  aria-label="Homelab hardware and systems"
+>
+  <p class="rack-eyebrow">
+    4 nodes &middot; 52 CPUs &middot; 112 GB &middot; one RTX 4090
+  </p>
   <h2>HOMELAB</h2>
 
   <div class="rack-grid">
@@ -39,7 +45,9 @@
       </div>
       <div class="node gpu">
         <span class="nname">NODE-4</span>
-        <div class="nrole">16 cpu &middot; 64 gb &middot; rtx 4090 &middot; microvms</div>
+        <div class="nrole">
+          16 cpu &middot; 64 gb &middot; rtx 4090 &middot; microvms
+        </div>
       </div>
       <div class="maps">
         <span class="lbl">Live maps</span>
@@ -61,9 +69,8 @@
           {#if app.slug === "grimoire"}
             <p>
               A D&amp;D campaign manager built on grants: the same monster
-              renders full stats for the DM, redacted stats for a player who
-              has fought it, and just a name for one who has only heard
-              rumours.
+              renders full stats for the DM, redacted stats for a player who has
+              fought it, and just a name for one who has only heard rumours.
               <a class="more" href="/app/grimoire">play &rarr;</a>
             </p>
           {:else if app.slug === "firecracker"}
@@ -72,9 +79,11 @@
               request. The guest never holds a real secret; an egress proxy
               swaps placeholder tokens for credentials at the network hop.
               <b>EmberVM</b> runs this substrate today: one-shot tasks, stateful
-              sessions, and warm HTTP serving. Watch a microVM restore from
-              disk in <b>{sandboxRestoreMs}ms</b>.
-              <a class="more" href="/ember/firecracker">watch it restore &rarr;</a>
+              sessions, and warm HTTP serving. Watch a microVM restore from disk
+              in <b>{sandboxRestoreMs}ms</b>.
+              <a class="more" href="/ember/firecracker"
+                >watch it restore &rarr;</a
+              >
             </p>
           {/if}
         </div>
@@ -85,10 +94,11 @@
           <span class="where">NODE-4</span>
         </div>
         <p>
-          Tag <b>@Bosun</b> in a Discord thread and a <b>goose</b> agent wakes in its own
-          microVM, runs a recipe, and replies with an artifact or a PR. Ambient chat,
-          scheduled routines, and coding agents all dispatch through fc-invoke
-          (~{agentFirstModelCallMs}ms to first model call). Its successor,
+          Tag <b>@Bosun</b> in a Discord thread and a <b>goose</b> agent wakes
+          in its own microVM, runs a recipe, and replies with an artifact or a
+          PR. Ambient chat, scheduled routines, and coding agents all dispatch
+          through fc-invoke (~{agentFirstModelCallMs}ms to first model call).
+          Its successor,
           <b>EmberVM</b>, already runs the semgrep scans and warm HTTP serving;
           fc-invoke is frozen and the goose agent is its last tenant.
         </p>
@@ -103,9 +113,9 @@
           <span class="where">NODE-4</span>
         </div>
         <p>
-          vLLM serving a <b>35B sparse-MoE</b> (~3B active), int4-mixed weights with an fp8
-          KV-cache, <b>~170 tok/s</b> single-stream decode. Chat, the agents, and the knowledge
-          graph's RAG all share the 4090.
+          vLLM serving a <b>35B sparse-MoE</b> (~3B active), int4-mixed weights
+          with an fp8 KV-cache, <b>~170 tok/s</b> single-stream decode. Chat, the
+          agents, and the knowledge graph's RAG all share the 4090.
         </p>
       </div>
       <div class="callout">
@@ -114,7 +124,8 @@
           <span class="where">NODE-1</span>
         </div>
         <p>
-          One Postgres backs every app; pgvector indexes the embeddings for a fileless knowledge graph.
+          One Postgres backs every app; pgvector indexes the embeddings for a
+          fileless knowledge graph.
           <a class="more" href="/app/notes">notes</a> is a public RAG over it. Declarative
           migrations applied by an operator, volumes replicated across nodes.
         </p>
@@ -125,8 +136,9 @@
           <span class="where">ALL NODES</span>
         </div>
         <p>
-          Five custom Bazel rulesets build every image dual-arch and pin digests into versioned
-          OCI Helm charts; ArgoCD reconciles the cluster from the repo.
+          Five custom Bazel rulesets build every image dual-arch and pin digests
+          into versioned OCI Helm charts; ArgoCD reconciles the cluster from the
+          repo.
         </p>
         <div class="clinks">
           <a class="more" href="/docs/contributing">the pipeline &rarr;</a>

--- a/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
@@ -123,8 +123,18 @@
   // Date formatting.
 
   const MONTHS = [
-    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
   ];
   const SHORT_DAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
 
@@ -275,7 +285,11 @@
   />
 </svelte:head>
 
-<div class="campsites-page" class:has-selection={!!selectedPark} class:list-open={listOpen}>
+<div
+  class="campsites-page"
+  class:has-selection={!!selectedPark}
+  class:list-open={listOpen}
+>
   <!-- The visible heading is the breadcrumb chip; keep a real (hidden) h1 for
        SEO + a11y. -->
   <h1 class="sr-only">BC Parks campsites, open sites and clear-sky weather</h1>
@@ -286,7 +300,8 @@
   <div class="crumb-card">
     <nav class="crumb" aria-label="Breadcrumb">
       <a class="crumb-home" href="https://jomcgi.dev/"
-        >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span></a
+        >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
+        ></a
       >
       <span class="crumb-sep">/</span>
       <span class="crumb-name">campsites</span>
@@ -297,8 +312,8 @@
       >
     </nav>
     <p class="crumb-note">
-      {#if generatedAt}As of {fmtGeneratedAt(generatedAt)}. {/if}Green = open AND
-      clear skies.
+      {#if generatedAt}As of {fmtGeneratedAt(generatedAt)}.
+      {/if}Green = open AND clear skies.
     </p>
   </div>
 
@@ -447,10 +462,7 @@
 
   <!-- Detail panel: bottom sheet for the selected park's 14-day forecast. -->
   {#if selectedPark}
-    <section
-      class="detail"
-      aria-label="{selectedPark.name} 14-day forecast"
-    >
+    <section class="detail" aria-label="{selectedPark.name} 14-day forecast">
       <button
         type="button"
         class="detail-close"
@@ -500,9 +512,7 @@
                   class="day-rain"
                   class:day-rain-wet={day.precip > 0}
                   style={day.precip > 0 ? `color: ${VIZ_RAIN}` : undefined}
-                  >{day.precip > 0
-                    ? `${day.precip.toFixed(1)}mm`
-                    : "·"}</span
+                  >{day.precip > 0 ? `${day.precip.toFixed(1)}mm` : "·"}</span
                 >
               {/if}
             </li>

--- a/projects/monolith/frontend/src/routes/public/app/dr-jobs/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/dr-jobs/+page.svelte
@@ -56,8 +56,18 @@
   });
 
   const MONTHS = [
-    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
   ];
 
   function fmtDate(iso) {
@@ -142,7 +152,8 @@
       <div class="crumb-row">
         <nav class="crumb" aria-label="Breadcrumb">
           <a class="crumb-home" href="https://jomcgi.dev/"
-            >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
+            >jomcgi.dev<span class="crumb-arrow" aria-hidden="true"
+              >&nearr;</span
             ></a
           >
           <span class="crumb-sep">/</span>
@@ -194,8 +205,8 @@
     {#if visible.length === 0}
       <p class="empty">
         {#if view === "live"}
-          No live anaesthetics consultant posts right now. Try History for recent
-          listings.
+          No live anaesthetics consultant posts right now. Try History for
+          recent listings.
         {:else}
           No past listings recorded yet.
         {/if}
@@ -234,7 +245,10 @@
               </span>
               <span class="r-when">
                 <span class="r-date">{fmtDate(j.closing_date)}</span>
-                <span class="r-rel" class:urgent={isClosingSoon(j.closing_date)}>
+                <span
+                  class="r-rel"
+                  class:urgent={isClosingSoon(j.closing_date)}
+                >
                   {closesLabel(j.closing_date)}
                 </span>
               </span>

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+layout.svelte
@@ -127,25 +127,25 @@
   </header>
 
   <main class="grimoire-shell">
-  {#if isUngated || admitted}
-    <PageTurn section={pageTurnSegment}>
-      {@render children()}
-    </PageTurn>
-  {:else}
-    <div class="wrap-narrow gate">
-      <p class="gate-eyebrow">Grimoire Access</p>
-      <h1 class="grim-title gate-title">
-        solve to <span class="gate-accent">explore.</span>
-      </h1>
-      <p class="gate-copy">
-        Bots? <em>Get outta here!</em>
-      </p>
-      <TurnstileGate
-        siteKey={data.turnstileSiteKey}
-        onAdmitted={() => (admitted = true)}
-      />
-    </div>
-  {/if}
+    {#if isUngated || admitted}
+      <PageTurn section={pageTurnSegment}>
+        {@render children()}
+      </PageTurn>
+    {:else}
+      <div class="wrap-narrow gate">
+        <p class="gate-eyebrow">Grimoire Access</p>
+        <h1 class="grim-title gate-title">
+          solve to <span class="gate-accent">explore.</span>
+        </h1>
+        <p class="gate-copy">
+          Bots? <em>Get outta here!</em>
+        </p>
+        <TurnstileGate
+          siteKey={data.turnstileSiteKey}
+          onAdmitted={() => (admitted = true)}
+        />
+      </div>
+    {/if}
   </main>
 
   {#if showDock}

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/+page.svelte
@@ -64,17 +64,18 @@
       <span class="kn">demo</span>
     </div>
     <p class="block-lede">
-      The same entity renders differently
-      for each player character, depending on the scope their DM has granted.
-      The creature below is invented for this demo; the real corpus works the
-      same way.
+      The same entity renders differently for each player character, depending
+      on the scope their DM has granted. The creature below is invented for this
+      demo; the real corpus works the same way.
     </p>
     <div class="grant-row">
       <article class="grant-card">
         <p class="scope scope-full">full</p>
         <h3 class="grim-title card-name">Vellum Lurker</h3>
         <p class="card-type">Medium aberration</p>
-        <p class="card-stats">AC 15 <span class="dot">/</span> HP 66 <span class="dot">/</span> CR 4</p>
+        <p class="card-stats">
+          AC 15 <span class="dot">/</span> HP 66 <span class="dot">/</span> CR 4
+        </p>
         <p class="card-body">
           A predator that folds itself flat between the pages of unattended
           books. Vulnerable to fire; regenerates in libraries.
@@ -349,7 +350,6 @@
   /* ── Responsive ── */
 
   @media (max-width: 960px) {
-
     .grant-row {
       grid-template-columns: 1fr 1fr;
     }
@@ -359,7 +359,6 @@
     .home {
       padding: 36px 20px 60px;
     }
-
 
     .grant-row {
       grid-template-columns: 1fr;

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/chat/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/chat/+page.svelte
@@ -338,124 +338,128 @@
     </div>
 
     <div class="chat-main">
-    <div class="chat-transcript" bind:this={transcriptEl}>
-      {#if !admitted}
-        <div class="chat-gate">
-          <p class="eyebrow chat-gate-eyebrow">START CHATTING</p>
-          <p class="chat-gate-copy">
-            Solve the challenge once to open a session. Every answer is
-            grounded in the loaded sourcebooks, cited, and never invented.
-          </p>
-          <TurnstileGate
-            siteKey={data.turnstileSiteKey}
-            admit={createChatSession}
-            onAdmitted={() => {
-              admitted = true;
-              queueMicrotask(() => inputEl?.focus());
-            }}
-          />
-        </div>
-      {:else if messages.length === 0 && !sending}
-        <div class="chat-empty">
-          <h2 class="grim-title empty-headline">
-            ask the grimoire <span class="empty-hl">anything.</span>
-          </h2>
-          <p class="empty-sub">
-            Rules, spells, monsters, magic items, lore, adventures. A sage
-            reads the loaded sourcebooks and answers, citing what it drew on.
-            No tools, no cloud, no telemetry.
-          </p>
-          <div class="chat-examples">
-            {#each EXAMPLES as ex}
-              <button type="button" class="chat-example" onclick={() => send(ex)}>
-                {ex}
-              </button>
-            {/each}
+      <div class="chat-transcript" bind:this={transcriptEl}>
+        {#if !admitted}
+          <div class="chat-gate">
+            <p class="eyebrow chat-gate-eyebrow">START CHATTING</p>
+            <p class="chat-gate-copy">
+              Solve the challenge once to open a session. Every answer is
+              grounded in the loaded sourcebooks, cited, and never invented.
+            </p>
+            <TurnstileGate
+              siteKey={data.turnstileSiteKey}
+              admit={createChatSession}
+              onAdmitted={() => {
+                admitted = true;
+                queueMicrotask(() => inputEl?.focus());
+              }}
+            />
           </div>
-        </div>
-      {:else}
-        {#each messages as m}
-          {#if m.role === "user"}
-            <article class="turn turn-user">
-              <div class="user-bubble">{m.content}</div>
-            </article>
-          {:else}
+        {:else if messages.length === 0 && !sending}
+          <div class="chat-empty">
+            <h2 class="grim-title empty-headline">
+              ask the grimoire <span class="empty-hl">anything.</span>
+            </h2>
+            <p class="empty-sub">
+              Rules, spells, monsters, magic items, lore, adventures. A sage
+              reads the loaded sourcebooks and answers, citing what it drew on.
+              No tools, no cloud, no telemetry.
+            </p>
+            <div class="chat-examples">
+              {#each EXAMPLES as ex}
+                <button
+                  type="button"
+                  class="chat-example"
+                  onclick={() => send(ex)}
+                >
+                  {ex}
+                </button>
+              {/each}
+            </div>
+          </div>
+        {:else}
+          {#each messages as m}
+            {#if m.role === "user"}
+              <article class="turn turn-user">
+                <div class="user-bubble">{m.content}</div>
+              </article>
+            {:else}
+              <article class="turn turn-bot">
+                <p class="bot-label">{BOT_LABEL}</p>
+                <div class="turn-card">
+                  <div class="turn-md">
+                    {@html renderReply(m.content, m.touched)}
+                  </div>
+                  {#if m.touched && m.touched.length}
+                    <div class="turn-touched">
+                      <span class="turn-touched-label">GROUNDED IN</span>
+                      {#each m.touched as n}
+                        {#if n.kind === "entity"}
+                          <a
+                            href={worldHref(n.id)}
+                            class="touched-chip touched-chip-entity"
+                            style="--chip-color: var(--grim-type-{TYPE_ALLOWLIST.test(
+                              n.entity_type ?? '',
+                            )
+                              ? n.entity_type
+                              : 'class'}, currentColor)"
+                          >
+                            {n.title || "untitled entity"}
+                          </a>
+                        {:else}
+                          <button
+                            type="button"
+                            class="touched-chip"
+                            onclick={() => (activeSource = n)}
+                          >
+                            {n.title || "untitled passage"}
+                          </button>
+                        {/if}
+                      {/each}
+                    </div>
+                  {/if}
+                </div>
+              </article>
+            {/if}
+          {/each}
+
+          {#if sending}
             <article class="turn turn-bot">
               <p class="bot-label">{BOT_LABEL}</p>
-              <div class="turn-card">
-                <div class="turn-md">
-                  {@html renderReply(m.content, m.touched)}
-                </div>
-                {#if m.touched && m.touched.length}
-                  <div class="turn-touched">
-                    <span class="turn-touched-label">GROUNDED IN</span>
-                    {#each m.touched as n}
-                      {#if n.kind === "entity"}
-                        <a
-                          href={worldHref(n.id)}
-                          class="touched-chip touched-chip-entity"
-                          style="--chip-color: var(--grim-type-{TYPE_ALLOWLIST.test(
-                            n.entity_type ?? '',
-                          )
-                            ? n.entity_type
-                            : 'class'}, currentColor)"
-                        >
-                          {n.title || "untitled entity"}
-                        </a>
-                      {:else}
-                        <button
-                          type="button"
-                          class="touched-chip"
-                          onclick={() => (activeSource = n)}
-                        >
-                          {n.title || "untitled passage"}
-                        </button>
-                      {/if}
-                    {/each}
+              {#if turn.assistant}
+                <div class="turn-card">
+                  <div class="turn-md">
+                    {@html renderReply(turn.assistant, turn.touched)}<span
+                      class="caret"
+                    ></span>
                   </div>
-                {/if}
-              </div>
+                </div>
+              {:else}
+                <p class="turn-thinking">
+                  <span class="dot"></span><span class="dot"></span><span
+                    class="dot"
+                  ></span>
+                  {turn.touched.length ? "reading the sourcebooks" : "thinking"}
+                </p>
+              {/if}
             </article>
           {/if}
-        {/each}
-
-        {#if sending}
-          <article class="turn turn-bot">
-            <p class="bot-label">{BOT_LABEL}</p>
-            {#if turn.assistant}
-              <div class="turn-card">
-                <div class="turn-md">
-                  {@html renderReply(turn.assistant, turn.touched)}<span
-                    class="caret"
-                  ></span>
-                </div>
-              </div>
-            {:else}
-              <p class="turn-thinking">
-                <span class="dot"></span><span class="dot"></span><span
-                  class="dot"
-                ></span>
-                {turn.touched.length ? "reading the sourcebooks" : "thinking"}
-              </p>
-            {/if}
-          </article>
         {/if}
-      {/if}
-    </div>
+      </div>
 
-    {#if constellation.nodes.length > 0}
-      <aside
-        class="constellation"
-        aria-label="Entities this conversation has drawn on"
-      >
-        <span class="constellation-cap">SESSION CONSTELLATION</span>
-        <MiniConstellation
-          nodes={constellation.nodes}
-          edges={constellation.edges}
-          revealedIds={new Set(constellation.ids)}
-        />
-      </aside>
-    {/if}
+      {#if constellation.nodes.length > 0}
+        <aside
+          class="constellation"
+          aria-label="Entities this conversation has drawn on"
+        >
+          <span class="constellation-cap">SESSION CONSTELLATION</span>
+          <MiniConstellation
+            nodes={constellation.nodes}
+            edges={constellation.edges}
+            revealedIds={new Set(constellation.ids)}
+          />
+        </aside>
+      {/if}
     </div>
 
     {#if notice}
@@ -481,8 +485,7 @@
           rows="1"
           maxlength={CHARACTER_LIMIT}
           disabled={sending}
-          aria-label="Your message"
-        ></textarea>
+          aria-label="Your message"></textarea>
         <div class="chat-input-side">
           <span
             class="chat-count"
@@ -1071,7 +1074,11 @@
   .touched-chip-entity:focus-visible {
     color: var(--chip-color, var(--grim-ink));
     border-color: var(--chip-color, var(--grim-accent));
-    background: color-mix(in srgb, var(--chip-color, var(--grim-accent)) 12%, transparent);
+    background: color-mix(
+      in srgb,
+      var(--chip-color, var(--grim-accent)) 12%,
+      transparent
+    );
   }
 
   /* ── notice ─────────────────────────────────────────────────── */

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/chat/s/[id]/+page@.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/chat/s/[id]/+page@.svelte
@@ -88,7 +88,8 @@
   <header class="app-header">
     <nav class="crumb" aria-label="Breadcrumb">
       <a class="crumb-home" href="https://jomcgi.dev/"
-        >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span></a
+        >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
+        ></a
       >
       <span class="crumb-sep">/</span>
       <span class="crumb-name">shared grimoire chat</span>
@@ -101,7 +102,11 @@
       <span class="panel-readonly">READ-ONLY</span>
       <span class="panel-spacer"></span>
       {#if canFork && !forking}
-        <button type="button" class="bar-btn bar-btn-primary" onclick={startFork}>
+        <button
+          type="button"
+          class="bar-btn bar-btn-primary"
+          onclick={startFork}
+        >
           CONTINUE THIS CHAT
         </button>
       {/if}
@@ -121,7 +126,9 @@
             <article class="turn turn-bot">
               <p class="bot-label">{BOT_LABEL}</p>
               <div class="turn-card">
-                <div class="turn-md">{@html renderReply(m.content, m.touched)}</div>
+                <div class="turn-md">
+                  {@html renderReply(m.content, m.touched)}
+                </div>
                 {#if m.touched && m.touched.length}
                   <!-- The same GROUNDED IN set the live app shows, persisted on
                        the assistant turn and carried into the snapshot.
@@ -177,8 +184,8 @@
 
     <div class="share-foot">
       <p class="share-foot-copy">
-        This is a read-only snapshot of a conversation with the Grimoire, a
-        sage grounded in the D&D sourcebooks loaded on my homelab cluster.
+        This is a read-only snapshot of a conversation with the Grimoire, a sage
+        grounded in the D&D sourcebooks loaded on my homelab cluster.
       </p>
       <a class="share-cta" href="/app/grimoire/chat">Ask the Grimoire &rarr;</a>
     </div>
@@ -552,7 +559,11 @@
   .touched-chip-entity:focus-visible {
     color: var(--chip-color, var(--grim-ink));
     border-color: var(--chip-color, var(--grim-accent));
-    background: color-mix(in srgb, var(--chip-color, var(--grim-accent)) 12%, transparent);
+    background: color-mix(
+      in srgb,
+      var(--chip-color, var(--grim-accent)) 12%,
+      transparent
+    );
   }
 
   .share-foot {

--- a/projects/monolith/frontend/src/routes/public/app/grimoire/world/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/grimoire/world/+page.svelte
@@ -231,7 +231,8 @@
           edges: [],
         };
         if (requestId !== egoRequestSeq) return;
-        const isNarrowed = currentScope !== "everything" || currentLens !== "world";
+        const isNarrowed =
+          currentScope !== "everything" || currentLens !== "world";
         const isEmpty = (res.nodes ?? []).length <= 1;
         if (isNarrowed && isEmpty && fellBackFor !== comboKey) {
           fellBackFor = comboKey;

--- a/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
@@ -9,7 +9,10 @@
     filterWalksByLocation,
     upcomingUkDays,
   } from "$lib/public/hikes/filters.js";
-  import { readHikeParams, writeHikeParams } from "$lib/public/hikes/urlParams.js";
+  import {
+    readHikeParams,
+    writeHikeParams,
+  } from "$lib/public/hikes/urlParams.js";
 
   let { data } = $props();
 
@@ -61,10 +64,7 @@
   // restores it) and mirrored back as it changes (see the $effect below). The
   // numeric fields stay strings to match the <input bind:value>; "" means "no
   // constraint" (the filters module reads undefined/NaN as unbounded).
-  const initial = readHikeParams(
-    $page.url.searchParams,
-    VALID_NEAR_KEYS,
-  );
+  const initial = readHikeParams($page.url.searchParams, VALID_NEAR_KEYS);
 
   // The five numeric filters.
   let minDuration = $state(initial.minDuration);
@@ -313,7 +313,8 @@
       <div class="crumb-row">
         <nav class="crumb" aria-label="Breadcrumb">
           <a class="crumb-home" href="https://jomcgi.dev/"
-            >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
+            >jomcgi.dev<span class="crumb-arrow" aria-hidden="true"
+              >&nearr;</span
             ></a
           >
           <span class="crumb-sep">/</span>
@@ -397,7 +398,8 @@
           </label>
         </div>
 
-        <button type="button" class="reset" onclick={resetFilters}>Reset</button>
+        <button type="button" class="reset" onclick={resetFilters}>Reset</button
+        >
       </div>
     {/if}
   </div>

--- a/projects/monolith/frontend/src/routes/public/app/llm-leaderboard/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/llm-leaderboard/+page.svelte
@@ -19,7 +19,8 @@
   const money = (x) => `$${(x ?? 0).toFixed(4)}`;
   const secs = (ms) => (ms == null ? "n/a" : `${(ms / 1000).toFixed(1)}s`);
   // Drop the provider prefix for the headline name, keep the full slug beneath.
-  const shortName = (id) => (id.includes("/") ? id.split("/").slice(1).join("/") : id);
+  const shortName = (id) =>
+    id.includes("/") ? id.split("/").slice(1).join("/") : id;
   const isAnchor = (m) => m.role === "anchor";
 
   // Deep-dive: a row expands into its per-task breakdown. Guard on the data so the
@@ -39,8 +40,7 @@
     }
   };
 
-  const toolLabel = (t) =>
-    t >= 0.999 ? "ok" : t > 0 ? "flaky" : "none";
+  const toolLabel = (t) => (t >= 0.999 ? "ok" : t > 0 ? "flaky" : "none");
 </script>
 
 <svelte:head>
@@ -56,12 +56,14 @@
     <div class="hero-mark">MODEL-BENCH</div>
     <h1>LLM Leaderboard</h1>
     <p class="lede">
-      An <strong>agentic</strong> coding benchmark over this homelab's real monolith.
-      Each model is dropped into a snapshot of the repo with file tools and has to
-      make the change itself over multiple turns; it is then graded by the repo's
+      An <strong>agentic</strong> coding benchmark over this homelab's real
+      monolith. Each model is dropped into a snapshot of the repo with file
+      tools and has to make the change itself over multiple turns; it is then
+      graded by the repo's
       <strong>own tests</strong>. Tasks are tiered: a model must clear every
-      <strong>easy + standard</strong> task to <strong>qualify</strong> as viable, and
-      the <strong>hard</strong> tasks plus cost and speed rank the ones that do.
+      <strong>easy + standard</strong> task to <strong>qualify</strong> as
+      viable, and the <strong>hard</strong> tasks plus cost and speed rank the ones
+      that do.
     </p>
     <div class="meta">
       <span>{qualified.length}/{models.length} qualified</span>
@@ -117,23 +119,35 @@
               onkeydown={(e) => onRowKey(e, m)}
             >
               <td class="rk">
-                {#if hasBreakdown(m)}<span class="chev" aria-hidden="true">{openId === m.id ? "▾" : "▸"}</span>{/if}{i + 1}
+                {#if hasBreakdown(m)}<span class="chev" aria-hidden="true"
+                    >{openId === m.id ? "▾" : "▸"}</span
+                  >{/if}{i + 1}
               </td>
               <td class="mdl">
                 <span class="name">{m.name ?? shortName(m.id)}</span>
                 <span class="slug">{m.id}</span>
-                {#if m.role === "anchor"}<span class="tag anchor">anchor</span>{/if}
+                {#if m.role === "anchor"}<span class="tag anchor">anchor</span
+                  >{/if}
               </td>
               <td class="n">
-                <span class="rate {m.hard_pass === m.hard_n ? 'full' : 'partial'}">{m.hard_pass}/{m.hard_n}</span>
+                <span
+                  class="rate {m.hard_pass === m.hard_n ? 'full' : 'partial'}"
+                  >{m.hard_pass}/{m.hard_n}</span
+                >
               </td>
               <td class="n mono">{num(m.mean_tokens)}</td>
               <td class="n mono">{m.mean_turns}</td>
               <td class="n mono">{secs(m.mean_latency_ms)}</td>
               <td class="n mono">{money(m.cost_usd)}</td>
-              <td class="n mono">{m.cost_per_solve_usd == null ? "n/a" : money(m.cost_per_solve_usd)}</td>
+              <td class="n mono"
+                >{m.cost_per_solve_usd == null
+                  ? "n/a"
+                  : money(m.cost_per_solve_usd)}</td
+              >
               <td class="n">
-                <span class="pill {toolLabel(m.tool_use_ok)}">{toolLabel(m.tool_use_ok)}</span>
+                <span class="pill {toolLabel(m.tool_use_ok)}"
+                  >{toolLabel(m.tool_use_ok)}</span
+                >
               </td>
             </tr>
             {#if openId === m.id && hasBreakdown(m)}
@@ -142,13 +156,17 @@
                   <div class="detail">
                     <div class="detail-head">
                       Per-task breakdown
-                      <span class="detail-sub">solved {solvedCount(m)}/{m.tasks.length}</span>
+                      <span class="detail-sub"
+                        >solved {solvedCount(m)}/{m.tasks.length}</span
+                      >
                     </div>
                     <ul class="bd">
                       {#each m.tasks as bt (bt.id)}
                         {@const meta = taskById[bt.id]}
                         <li>
-                          <span class="bd-status {bt.passed ? 'pass' : 'fail'}">{bt.passed ? "PASS" : "FAIL"}</span>
+                          <span class="bd-status {bt.passed ? 'pass' : 'fail'}"
+                            >{bt.passed ? "PASS" : "FAIL"}</span
+                          >
                           <span class="bd-main">
                             <span class="bd-id">{bt.id}</span>
                             {#if meta?.real_test}
@@ -174,13 +192,18 @@
       </table>
     </div>
     <div class="legend">
-      <span><b>Tokens / Turns / Wall-time</b> are the <b>mean per task</b> (not the
-        median): the tasks vary ~5x in size, so the mean keeps a blow-up on one hard
-        task visible instead of hiding it. Open a row for the per-task split.</span>
-      <span><b>Hard / Tokens / Turns / Tools</b> are model-intrinsic (the
+      <span
+        ><b>Tokens / Turns / Wall-time</b> are the <b>mean per task</b> (not the median):
+        the tasks vary ~5x in size, so the mean keeps a blow-up on one hard task visible
+        instead of hiding it. Open a row for the per-task split.</span
+      >
+      <span
+        ><b>Hard / Tokens / Turns / Tools</b> are model-intrinsic (the
         <b>self-host lens</b>); <b>Wall-time / Cost / $-per-solve</b> are the
-        <b>cloud lens</b>: the real time and money to rent this model versus the Claude
-        <b>anchor</b> rows you would be replacing. Wall-time is via OpenRouter.</span>
+        <b>cloud lens</b>: the real time and money to rent this model versus the
+        Claude
+        <b>anchor</b> rows you would be replacing. Wall-time is via OpenRouter.</span
+      >
     </div>
   </section>
 
@@ -204,10 +227,16 @@
                   <span class="name">{m.name ?? shortName(m.id)}</span>
                   <span class="slug">{m.id}</span>
                 </td>
-                <td class="n"><span class="rate zero">{m.floor_pass}/{m.floor_n}</span></td>
-                <td class="fail">{(m.floor_failed ?? []).join(", ") || "(none run)"}</td>
+                <td class="n"
+                  ><span class="rate zero">{m.floor_pass}/{m.floor_n}</span></td
+                >
+                <td class="fail"
+                  >{(m.floor_failed ?? []).join(", ") || "(none run)"}</td
+                >
                 <td class="n">
-                  <span class="pill {toolLabel(m.tool_use_ok)}">{toolLabel(m.tool_use_ok)}</span>
+                  <span class="pill {toolLabel(m.tool_use_ok)}"
+                    >{toolLabel(m.tool_use_ok)}</span
+                  >
                 </td>
               </tr>
             {/each}
@@ -240,15 +269,17 @@
 
   <footer class="note">
     <p>
-      SWE-bench style: each task snapshots the <em>parent</em> of a real fix commit
-      (the buggy state), the model edits the snapshot through file tools, and the
-      fix commit's gold test is run against the result on a vendored venv. A "repo
-      test" task is graded by the monolith's own pytest suite; a "behavioural" one
-      by a hand-written check. Model calls run through OpenRouter at list price.
-      Tasks carry a difficulty <em>tier</em>: easy + standard form the qualification
-      floor (miss one and a model is disqualified as not yet viable), while the hard
-      tasks and the cost and speed columns rank the ones that clear it.
-      Regenerate with <code>python3 -m bench report --json-out</code> in
+      SWE-bench style: each task snapshots the <em>parent</em> of a real fix
+      commit (the buggy state), the model edits the snapshot through file tools,
+      and the fix commit's gold test is run against the result on a vendored
+      venv. A "repo test" task is graded by the monolith's own pytest suite; a
+      "behavioural" one by a hand-written check. Model calls run through
+      OpenRouter at list price. Tasks carry a difficulty <em>tier</em>: easy +
+      standard form the qualification floor (miss one and a model is
+      disqualified as not yet viable), while the hard tasks and the cost and
+      speed columns rank the ones that clear it. Regenerate with
+      <code>python3 -m bench report --json-out</code>
+      in
       <code>projects/model-bench</code>.
     </p>
   </footer>
@@ -295,7 +326,10 @@
     line-height: 1.55;
     color: var(--ink-2);
   }
-  .lede strong { font-weight: 700; color: var(--ink); }
+  .lede strong {
+    font-weight: 700;
+    color: var(--ink);
+  }
   .meta {
     margin-top: 16px;
     font-family: var(--mono);
@@ -306,7 +340,9 @@
     gap: 8px;
     align-items: center;
   }
-  .meta .dot { color: var(--rule-2); }
+  .meta .dot {
+    color: var(--rule-2);
+  }
 
   /* ── Panels ───────────────────────────── */
   .panel {
@@ -335,8 +371,14 @@
   }
 
   /* ── Table ────────────────────────────── */
-  .scroll { overflow-x: auto; }
-  table { width: 100%; border-collapse: collapse; font-size: 14px; }
+  .scroll {
+    overflow-x: auto;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+  }
   thead th {
     font-family: var(--mono);
     font-size: 11px;
@@ -348,14 +390,19 @@
     border-bottom: 2px solid var(--ink);
     white-space: nowrap;
   }
-  thead th.rk, thead th.mdl { text-align: left; }
+  thead th.rk,
+  thead th.mdl {
+    text-align: left;
+  }
   tbody td {
     padding: 12px 14px;
     border-bottom: 1px solid var(--rule);
     text-align: right;
     vertical-align: middle;
   }
-  tbody tr:last-child td { border-bottom: none; }
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
   td.rk {
     font-family: var(--mono);
     font-weight: 700;
@@ -363,7 +410,9 @@
     text-align: left;
     width: 34px;
   }
-  td.mdl { text-align: left; }
+  td.mdl {
+    text-align: left;
+  }
   .name {
     font-weight: 700;
     font-size: 14.5px;
@@ -375,18 +424,30 @@
     font-size: 11px;
     color: var(--ink-3);
   }
-  .mono { font-family: var(--mono); }
+  .mono {
+    font-family: var(--mono);
+  }
 
-  tr.winner td { background: var(--accent); }
-  tr.winner td.rk { color: var(--ink); }
+  tr.winner td {
+    background: var(--accent);
+  }
+  tr.winner td.rk {
+    color: var(--ink);
+  }
   /* Claude anchors: the paid baseline you are deciding whether to replace. */
-  tr.anchor-row:not(.winner) td.rk { box-shadow: inset 3px 0 0 var(--blue); }
+  tr.anchor-row:not(.winner) td.rk {
+    box-shadow: inset 3px 0 0 var(--blue);
+  }
 
   /* Expandable rows: the hover/highlight is now a real affordance (click or Enter
      opens the per-task deep-dive) rather than a dead visual. */
-  tr.expandable { cursor: pointer; }
+  tr.expandable {
+    cursor: pointer;
+  }
   tr.expandable:not(.winner):hover td,
-  tr.expandable.open:not(.winner) td { background: var(--bg-elev); }
+  tr.expandable.open:not(.winner) td {
+    background: var(--bg-elev);
+  }
   tr.expandable:focus-visible {
     outline: 2px solid var(--ink);
     outline-offset: -2px;
@@ -397,7 +458,9 @@
     color: var(--ink-3);
     margin-right: 4px;
   }
-  tr.open .chev { color: var(--ink); }
+  tr.open .chev {
+    color: var(--ink);
+  }
 
   /* Deep-dive detail row */
   .detail-row td {
@@ -406,7 +469,9 @@
     background: var(--cream);
     border-bottom: 1px solid var(--rule);
   }
-  .detail { padding: 14px 16px 16px; }
+  .detail {
+    padding: 14px 16px 16px;
+  }
   .detail-head {
     font-family: var(--mono);
     font-size: 11px;
@@ -415,8 +480,15 @@
     color: var(--ink-3);
     margin-bottom: 10px;
   }
-  .detail-sub { margin-left: 8px; color: var(--ink-2); }
-  .bd { display: flex; flex-direction: column; gap: 6px; }
+  .detail-sub {
+    margin-left: 8px;
+    color: var(--ink-2);
+  }
+  .bd {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
   .bd li {
     display: flex;
     align-items: center;
@@ -436,9 +508,20 @@
     width: 46px;
     text-align: center;
   }
-  .bd-status.pass { background: var(--green); }
-  .bd-status.fail { background: var(--coral); color: var(--paper); }
-  .bd-main { display: flex; align-items: center; gap: 6px; min-width: 0; flex: 1; }
+  .bd-status.pass {
+    background: var(--green);
+  }
+  .bd-status.fail {
+    background: var(--coral);
+    color: var(--paper);
+  }
+  .bd-main {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    flex: 1;
+  }
   .bd-id {
     font-family: var(--mono);
     font-size: 12.5px;
@@ -457,10 +540,20 @@
   }
 
   /* pass-rate cell */
-  .rate { font-family: var(--mono); font-weight: 700; font-size: 15px; }
-  .rate.full { color: var(--teal); }
-  .rate.partial { color: var(--ink-2); }
-  .rate.zero { color: var(--coral); }
+  .rate {
+    font-family: var(--mono);
+    font-weight: 700;
+    font-size: 15px;
+  }
+  .rate.full {
+    color: var(--teal);
+  }
+  .rate.partial {
+    color: var(--ink-2);
+  }
+  .rate.zero {
+    color: var(--coral);
+  }
 
   /* tool-use pill */
   .pill {
@@ -472,9 +565,16 @@
     padding: 2px 7px;
     display: inline-block;
   }
-  .pill.ok { background: var(--green); }
-  .pill.flaky { background: var(--accent); }
-  .pill.none { background: var(--coral); color: var(--paper); }
+  .pill.ok {
+    background: var(--green);
+  }
+  .pill.flaky {
+    background: var(--accent);
+  }
+  .pill.none {
+    background: var(--coral);
+    color: var(--paper);
+  }
 
   /* tags */
   .tag {
@@ -487,22 +587,41 @@
     margin-left: 6px;
     vertical-align: middle;
   }
-  .tag.anchor { background: var(--blue); }
-  .tag.real { background: var(--green); }
-  .tag.synth { background: var(--bg-elev); color: var(--ink-2); }
-  .tag.tier-easy { background: var(--bg-elev); color: var(--ink-3); }
-  .tag.tier-standard { background: var(--blue); }
-  .tag.tier-hard { background: var(--accent); }
+  .tag.anchor {
+    background: var(--blue);
+  }
+  .tag.real {
+    background: var(--green);
+  }
+  .tag.synth {
+    background: var(--bg-elev);
+    color: var(--ink-2);
+  }
+  .tag.tier-easy {
+    background: var(--bg-elev);
+    color: var(--ink-3);
+  }
+  .tag.tier-standard {
+    background: var(--blue);
+  }
+  .tag.tier-hard {
+    background: var(--accent);
+  }
 
   /* Disqualified table: the failed-floor-tasks column + muted rows. */
-  th.fail, td.fail { text-align: left; }
+  th.fail,
+  td.fail {
+    text-align: left;
+  }
   td.fail {
     font-family: var(--mono);
     font-size: 11.5px;
     color: var(--ink-3);
     line-height: 1.4;
   }
-  tr.dq .name { color: var(--ink-2); }
+  tr.dq .name {
+    color: var(--ink-2);
+  }
 
   .legend {
     display: flex;
@@ -514,19 +633,42 @@
     color: var(--ink-3);
     background: var(--bg-elev);
   }
-  .legend b { color: var(--ink-2); }
+  .legend b {
+    color: var(--ink-2);
+  }
 
   /* ── Tasks ────────────────────────────── */
-  .tasks { padding: 6px 0; }
+  .tasks {
+    padding: 6px 0;
+  }
   .tasks li {
     padding: 13px 16px;
     border-bottom: 1px solid var(--rule);
   }
-  .tasks li:last-child { border-bottom: none; }
-  .t-top { display: flex; align-items: center; gap: 8px; }
-  .t-id { font-family: var(--mono); font-weight: 700; font-size: 13.5px; }
-  .t-score { margin-left: auto; color: var(--ink-3); font-size: 13px; }
-  .t-blurb { margin-top: 4px; font-size: 13.5px; color: var(--ink-2); line-height: 1.45; }
+  .tasks li:last-child {
+    border-bottom: none;
+  }
+  .t-top {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .t-id {
+    font-family: var(--mono);
+    font-weight: 700;
+    font-size: 13.5px;
+  }
+  .t-score {
+    margin-left: auto;
+    color: var(--ink-3);
+    font-size: 13px;
+  }
+  .t-blurb {
+    margin-top: 4px;
+    font-size: 13.5px;
+    color: var(--ink-2);
+    line-height: 1.45;
+  }
 
   /* ── Note ─────────────────────────────── */
   .note {
@@ -544,9 +686,18 @@
   }
 
   @media (max-width: 560px) {
-    .slug { display: none; }
-    .hero { padding: 20px 16px; }
-    .bd li { flex-wrap: wrap; }
-    .bd-nums { margin-left: 0; width: 100%; }
+    .slug {
+      display: none;
+    }
+    .hero {
+      padding: 20px 16px;
+    }
+    .bd li {
+      flex-wrap: wrap;
+    }
+    .bd-nums {
+      margin-left: 0;
+      width: 100%;
+    }
   }
 </style>

--- a/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
@@ -311,7 +311,11 @@
         },
       });
     } catch {
-      turn = { ...turn, status: "error", error: "The connection dropped. Please try again." };
+      turn = {
+        ...turn,
+        status: "error",
+        error: "The connection dropped. Please try again.",
+      };
     }
 
     // Commit any streamed reply, then surface a notice for busy / error so the
@@ -448,7 +452,8 @@
   <header class="app-header">
     <nav class="crumb" aria-label="Breadcrumb">
       <a class="crumb-home" href="https://jomcgi.dev/"
-        >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span></a
+        >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
+        ></a
       >
       <span class="crumb-sep">/</span>
       <span class="crumb-name">notes</span>
@@ -507,7 +512,8 @@
     <div class="ticker-track">
       {#each { length: 3 } as _}
         {#each tickerItems as item}
-          <span class="ticker-item"><span class="ticker-dot"></span>{item}</span>
+          <span class="ticker-item"><span class="ticker-dot"></span>{item}</span
+          >
         {/each}
       {/each}
     </div>
@@ -515,255 +521,260 @@
 
   <div class="view-area">
     {#if view === "chat"}
-    <section class="chat-box">
-      <div class="panel-head">
-        <span class="panel-tag">PUBLIC CHAT</span>
-        <span class="session" class:on={admitted}>
-          <span class="led" class:on={admitted}></span>
-          {admitted ? "SESSION OPEN" : "LOCKED"}
-        </span>
-        <span class="panel-spacer"></span>
-        {#if admitted && messages.length > 0}
-          {#if shareFeedback}
-            <span class="share-feedback" role="status">{shareFeedback}</span>
+      <section class="chat-box">
+        <div class="panel-head">
+          <span class="panel-tag">PUBLIC CHAT</span>
+          <span class="session" class:on={admitted}>
+            <span class="led" class:on={admitted}></span>
+            {admitted ? "SESSION OPEN" : "LOCKED"}
+          </span>
+          <span class="panel-spacer"></span>
+          {#if admitted && messages.length > 0}
+            {#if shareFeedback}
+              <span class="share-feedback" role="status">{shareFeedback}</span>
+            {/if}
+            <button
+              type="button"
+              class="bar-btn"
+              onclick={shareChat}
+              disabled={sharing}
+            >
+              {sharing ? "..." : "SHARE"}
+            </button>
           {/if}
-          <button
-            type="button"
-            class="bar-btn"
-            onclick={shareChat}
-            disabled={sharing}
-          >
-            {sharing ? "..." : "SHARE"}
-          </button>
-        {/if}
-        {#if admitted}
-          <button type="button" class="bar-btn" onclick={newChat}>
-            NEW CHAT
-          </button>
-        {/if}
-      </div>
+          {#if admitted}
+            <button type="button" class="bar-btn" onclick={newChat}>
+              NEW CHAT
+            </button>
+          {/if}
+        </div>
 
-      <div class="chat-transcript" bind:this={transcriptEl}>
-        {#if !admitted}
-          <div class="chat-gate">
-            <p class="chat-gate-eyebrow">START CHATTING</p>
-            <p class="chat-gate-copy">
-              Solve the challenge once to open a session. No sign-in, no
-              tracking beyond what keeps the bots out.
-            </p>
-            <TurnstileGate
-              siteKey={data.turnstileSiteKey}
-              onAdmitted={() => {
-                admitted = true;
-                queueMicrotask(() => inputEl?.focus());
-              }}
-            />
-          </div>
-        {:else if messages.length === 0 && !sending}
-          <div class="chat-empty">
-            <!-- Scattered brutalist doodles, decorative only. Hidden under 640px
+        <div class="chat-transcript" bind:this={transcriptEl}>
+          {#if !admitted}
+            <div class="chat-gate">
+              <p class="chat-gate-eyebrow">START CHATTING</p>
+              <p class="chat-gate-copy">
+                Solve the challenge once to open a session. No sign-in, no
+                tracking beyond what keeps the bots out.
+              </p>
+              <TurnstileGate
+                siteKey={data.turnstileSiteKey}
+                onAdmitted={() => {
+                  admitted = true;
+                  queueMicrotask(() => inputEl?.focus());
+                }}
+              />
+            </div>
+          {:else if messages.length === 0 && !sending}
+            <div class="chat-empty">
+              <!-- Scattered brutalist doodles, decorative only. Hidden under 640px
                  and pointer-events:none so they never interfere. -->
+              <svg
+                class="doodle doodle-cloud"
+                viewBox="0 0 64 40"
+                fill="none"
+                aria-hidden="true"
+              >
+                <path
+                  d="M14 32 Q4 32 5 24 Q5 16 14 17 Q15 7 26 9 Q33 2 42 10 Q54 9 53 19 Q62 19 60 27 Q59 32 50 32 Z"
+                  stroke="currentColor"
+                  stroke-width="2.5"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <svg
+                class="doodle doodle-star"
+                viewBox="0 0 40 40"
+                aria-hidden="true"
+              >
+                <path
+                  d="M20 2 L24 16 L38 20 L24 24 L20 38 L16 24 L2 20 L16 16 Z"
+                  fill="var(--blue)"
+                  stroke="var(--ink)"
+                  stroke-width="2"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <svg
+                class="doodle doodle-squiggle"
+                viewBox="0 0 84 20"
+                fill="none"
+                aria-hidden="true"
+              >
+                <path
+                  d="M2 10 Q12 -1 22 10 T42 10 T62 10 T82 10"
+                  stroke="currentColor"
+                  stroke-width="2.5"
+                  stroke-linecap="round"
+                />
+              </svg>
+              <svg
+                class="doodle doodle-diamond"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <rect
+                  x="6"
+                  y="6"
+                  width="12"
+                  height="12"
+                  transform="rotate(45 12 12)"
+                  fill="var(--coral)"
+                  stroke="var(--ink)"
+                  stroke-width="2"
+                />
+              </svg>
+
+              <h2 class="empty-headline">
+                ask my notes <span class="empty-hl">anything.</span>
+              </h2>
+              <p class="empty-sub">
+                There are {fmtCount(PUBLIC_NOTE_COUNT)} of them: coffee logs, ADRs,
+                dark-sky readings, half-finished side quests. An open model reads
+                the graph and answers. No tools, no cloud, no telemetry.
+              </p>
+              <div class="chat-examples">
+                {#each EXAMPLES as ex}
+                  <button
+                    type="button"
+                    class="chat-example"
+                    onclick={() => send(ex)}
+                  >
+                    {ex}
+                  </button>
+                {/each}
+              </div>
+            </div>
+          {:else}
+            {#each messages as m}
+              {#if m.role === "user"}
+                <article class="turn turn-user">
+                  <div class="user-bubble">{m.content}</div>
+                </article>
+              {:else}
+                <article class="turn turn-bot">
+                  <p class="bot-label">{BOT_LABEL}</p>
+                  <div class="turn-md">{@html renderReply(m.content)}</div>
+                  {#if m.touched && m.touched.length}
+                    <div class="turn-touched">
+                      <span class="turn-touched-label">GROUNDED IN</span>
+                      {#each m.touched as n}
+                        <button
+                          type="button"
+                          class="touched-chip"
+                          onclick={() => showGraph(n.id)}
+                        >
+                          {n.title || "untitled note"}
+                        </button>
+                      {/each}
+                    </div>
+                  {/if}
+                </article>
+              {/if}
+            {/each}
+
+            {#if sending}
+              <article class="turn turn-bot">
+                <p class="bot-label">{BOT_LABEL}</p>
+                {#if turn.assistant}
+                  <div class="turn-md">
+                    {@html renderReply(turn.assistant)}<span class="caret"
+                    ></span>
+                  </div>
+                {:else}
+                  <p class="turn-thinking">
+                    <span class="dot"></span><span class="dot"></span><span
+                      class="dot"
+                    ></span>
+                    {touched.length ? "reading the graph" : "thinking"}
+                  </p>
+                {/if}
+              </article>
+            {/if}
+          {/if}
+        </div>
+
+        {#if notice}
+          <div class="chat-notice" class:busy={noticeIsBusy} role="status">
+            <span class="chat-notice-text">{notice.message}</span>
+            <button
+              type="button"
+              class="chat-notice-retry"
+              onclick={() => send(lastUserMessage)}
+            >
+              TRY AGAIN
+            </button>
+          </div>
+        {/if}
+
+        {#if admitted}
+          <form class="chat-input" onsubmit={onSubmit}>
+            <!-- Small blue squiggle doodle anchored bottom-left of the dock. -->
             <svg
-              class="doodle doodle-cloud"
-              viewBox="0 0 64 40"
+              class="dock-doodle"
+              viewBox="0 0 60 14"
               fill="none"
               aria-hidden="true"
             >
               <path
-                d="M14 32 Q4 32 5 24 Q5 16 14 17 Q15 7 26 9 Q33 2 42 10 Q54 9 53 19 Q62 19 60 27 Q59 32 50 32 Z"
-                stroke="currentColor"
-                stroke-width="2.5"
-                stroke-linejoin="round"
-              />
-            </svg>
-            <svg
-              class="doodle doodle-star"
-              viewBox="0 0 40 40"
-              aria-hidden="true"
-            >
-              <path
-                d="M20 2 L24 16 L38 20 L24 24 L20 38 L16 24 L2 20 L16 16 Z"
-                fill="var(--blue)"
-                stroke="var(--ink)"
-                stroke-width="2"
-                stroke-linejoin="round"
-              />
-            </svg>
-            <svg
-              class="doodle doodle-squiggle"
-              viewBox="0 0 84 20"
-              fill="none"
-              aria-hidden="true"
-            >
-              <path
-                d="M2 10 Q12 -1 22 10 T42 10 T62 10 T82 10"
-                stroke="currentColor"
+                d="M2 7 Q9 0 16 7 T30 7 T44 7 T58 7"
+                stroke="var(--blue)"
                 stroke-width="2.5"
                 stroke-linecap="round"
               />
             </svg>
-            <svg
-              class="doodle doodle-diamond"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <rect
-                x="6"
-                y="6"
-                width="12"
-                height="12"
-                transform="rotate(45 12 12)"
-                fill="var(--coral)"
-                stroke="var(--ink)"
-                stroke-width="2"
-              />
-            </svg>
-
-            <h2 class="empty-headline">
-              ask my notes <span class="empty-hl">anything.</span>
-            </h2>
-            <p class="empty-sub">
-              There are {fmtCount(PUBLIC_NOTE_COUNT)} of them: coffee logs, ADRs,
-              dark-sky readings, half-finished side quests. An open model reads
-              the graph and answers. No tools, no cloud, no telemetry.
-            </p>
-            <div class="chat-examples">
-              {#each EXAMPLES as ex}
-                <button
-                  type="button"
-                  class="chat-example"
-                  onclick={() => send(ex)}
-                >
-                  {ex}
-                </button>
-              {/each}
+            <textarea
+              bind:this={inputEl}
+              bind:value={input}
+              onkeydown={onKeydown}
+              placeholder="Ask the graph..."
+              rows="1"
+              maxlength={CHARACTER_LIMIT}
+              disabled={sending}
+              aria-label="Your message"></textarea>
+            <div class="chat-input-side">
+              <span
+                class="chat-count"
+                class:warn={input.length > CHARACTER_LIMIT * 0.9}
+              >
+                {input.length}/{CHARACTER_LIMIT}
+              </span>
+              <button
+                type="submit"
+                class="chat-send"
+                disabled={sending || !input.trim()}
+              >
+                {sending ? "..." : "SEND"}
+              </button>
             </div>
-          </div>
-        {:else}
-          {#each messages as m}
-            {#if m.role === "user"}
-              <article class="turn turn-user">
-                <div class="user-bubble">{m.content}</div>
-              </article>
-            {:else}
-              <article class="turn turn-bot">
-                <p class="bot-label">{BOT_LABEL}</p>
-                <div class="turn-md">{@html renderReply(m.content)}</div>
-                {#if m.touched && m.touched.length}
-                  <div class="turn-touched">
-                    <span class="turn-touched-label">GROUNDED IN</span>
-                    {#each m.touched as n}
-                      <button
-                        type="button"
-                        class="touched-chip"
-                        onclick={() => showGraph(n.id)}
-                      >
-                        {n.title || "untitled note"}
-                      </button>
-                    {/each}
-                  </div>
-                {/if}
-              </article>
-            {/if}
-          {/each}
-
-          {#if sending}
-            <article class="turn turn-bot">
-              <p class="bot-label">{BOT_LABEL}</p>
-              {#if turn.assistant}
-                <div class="turn-md">{@html renderReply(turn.assistant)}<span class="caret"></span></div>
-              {:else}
-                <p class="turn-thinking">
-                  <span class="dot"></span><span class="dot"></span><span
-                    class="dot"
-                  ></span>
-                  {touched.length ? "reading the graph" : "thinking"}
-                </p>
-              {/if}
-            </article>
-          {/if}
+          </form>
         {/if}
-      </div>
-
-      {#if notice}
-        <div class="chat-notice" class:busy={noticeIsBusy} role="status">
-          <span class="chat-notice-text">{notice.message}</span>
-          <button
-            type="button"
-            class="chat-notice-retry"
-            onclick={() => send(lastUserMessage)}
-          >
-            TRY AGAIN
-          </button>
-        </div>
-      {/if}
-
-      {#if admitted}
-        <form class="chat-input" onsubmit={onSubmit}>
-          <!-- Small blue squiggle doodle anchored bottom-left of the dock. -->
-          <svg
-            class="dock-doodle"
-            viewBox="0 0 60 14"
-            fill="none"
-            aria-hidden="true"
-          >
-            <path
-              d="M2 7 Q9 0 16 7 T30 7 T44 7 T58 7"
-              stroke="var(--blue)"
-              stroke-width="2.5"
-              stroke-linecap="round"
-            />
-          </svg>
-          <textarea
-            bind:this={inputEl}
-            bind:value={input}
-            onkeydown={onKeydown}
-            placeholder="Ask the graph..."
-            rows="1"
-            maxlength={CHARACTER_LIMIT}
-            disabled={sending}
-            aria-label="Your message"
-          ></textarea>
-          <div class="chat-input-side">
-            <span class="chat-count" class:warn={input.length > CHARACTER_LIMIT * 0.9}>
-              {input.length}/{CHARACTER_LIMIT}
-            </span>
-            <button
-              type="submit"
-              class="chat-send"
-              disabled={sending || !input.trim()}
-            >
-              {sending ? "..." : "SEND"}
-            </button>
-          </div>
-        </form>
-      {/if}
-    </section>
-  {:else if graphLoadError}
-    <section class="graph-fallback">
-      <p class="graph-fallback-copy">The graph could not be loaded.</p>
-      <button
-        type="button"
-        class="graph-fallback-retry"
-        onclick={() => {
-          graphLoadError = false;
-          ensureGraphView();
-        }}
-      >
-        TRY AGAIN
-      </button>
-    </section>
-  {:else if GraphView}
-    <GraphView {touched} focusId={graphFocusId} />
-  {:else}
-    <section class="graph-fallback">
-      <p class="graph-thinking">
-        <span class="dot"></span><span class="dot"></span><span class="dot"
-        ></span>
-        opening the graph
-      </p>
-    </section>
-  {/if}
+      </section>
+    {:else if graphLoadError}
+      <section class="graph-fallback">
+        <p class="graph-fallback-copy">The graph could not be loaded.</p>
+        <button
+          type="button"
+          class="graph-fallback-retry"
+          onclick={() => {
+            graphLoadError = false;
+            ensureGraphView();
+          }}
+        >
+          TRY AGAIN
+        </button>
+      </section>
+    {:else if GraphView}
+      <GraphView {touched} focusId={graphFocusId} />
+    {:else}
+      <section class="graph-fallback">
+        <p class="graph-thinking">
+          <span class="dot"></span><span class="dot"></span><span class="dot"
+          ></span>
+          opening the graph
+        </p>
+      </section>
+    {/if}
   </div>
 </main>
 
@@ -781,8 +792,10 @@
     display: flex;
     flex-direction: column;
     gap: 14px;
-    padding: calc(20px + env(safe-area-inset-top)) calc(24px + env(safe-area-inset-right))
-      calc(20px + env(safe-area-inset-bottom)) calc(24px + env(safe-area-inset-left));
+    padding: calc(20px + env(safe-area-inset-top))
+      calc(24px + env(safe-area-inset-right))
+      calc(20px + env(safe-area-inset-bottom))
+      calc(24px + env(safe-area-inset-left));
     overflow: hidden;
     font-family: var(--mono);
     color: var(--ink);
@@ -1655,8 +1668,10 @@
   @media (max-width: 640px) {
     .chat-app {
       gap: 10px;
-      padding: calc(14px + env(safe-area-inset-top)) calc(14px + env(safe-area-inset-right))
-        calc(14px + env(safe-area-inset-bottom)) calc(14px + env(safe-area-inset-left));
+      padding: calc(14px + env(safe-area-inset-top))
+        calc(14px + env(safe-area-inset-right))
+        calc(14px + env(safe-area-inset-bottom))
+        calc(14px + env(safe-area-inset-left));
     }
     .explainer-hint {
       display: none;

--- a/projects/monolith/frontend/src/routes/public/app/notes/s/[id]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/s/[id]/+page.svelte
@@ -61,7 +61,8 @@
   <header class="app-header">
     <nav class="crumb" aria-label="Breadcrumb">
       <a class="crumb-home" href="https://jomcgi.dev/"
-        >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span></a
+        >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
+        ></a
       >
       <span class="crumb-sep">/</span>
       <span class="crumb-name">shared chat</span>
@@ -74,7 +75,11 @@
       <span class="panel-readonly">READ-ONLY</span>
       <span class="panel-spacer"></span>
       {#if canFork && !forking}
-        <button type="button" class="bar-btn bar-btn-primary" onclick={startFork}>
+        <button
+          type="button"
+          class="bar-btn bar-btn-primary"
+          onclick={startFork}
+        >
           CONTINUE THIS CHAT
         </button>
       {/if}
@@ -101,7 +106,9 @@
                 <div class="turn-touched">
                   <span class="turn-touched-label">GROUNDED IN</span>
                   {#each m.touched as n}
-                    <span class="touched-chip">{n.title || "untitled note"}</span>
+                    <span class="touched-chip"
+                      >{n.title || "untitled note"}</span
+                    >
                   {/each}
                 </div>
               {/if}
@@ -129,10 +136,12 @@
 
     <div class="share-foot">
       <p class="share-foot-copy">
-        This is a read-only snapshot of a conversation with an open model running
-        on my homelab cluster.
+        This is a read-only snapshot of a conversation with an open model
+        running on my homelab cluster.
       </p>
-      <a class="share-cta" href="/public/app/notes">Start your own chat &rarr;</a>
+      <a class="share-cta" href="/public/app/notes"
+        >Start your own chat &rarr;</a
+      >
     </div>
   </section>
 </main>

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
@@ -264,7 +264,8 @@
       <div class="crumb-row">
         <nav class="crumb" aria-label="Breadcrumb">
           <a class="crumb-home" href="https://jomcgi.dev/"
-            >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
+            >jomcgi.dev<span class="crumb-arrow" aria-hidden="true"
+              >&nearr;</span
             ></a
           >
           <span class="crumb-sep">/</span>
@@ -358,9 +359,9 @@
            twilight windows (down to -10 deg) and says so. -->
       {#if darkness === "none"}
         <div class="panel disclaimer" role="status">
-          No usable stargazing windows in Scotland this week: right now the summer
-          sky never gets dark enough, even for twilight. Astronomical darkness
-          returns by August.
+          No usable stargazing windows in Scotland this week: right now the
+          summer sky never gets dark enough, even for twilight. Astronomical
+          darkness returns by August.
         </div>
       {:else if darkness === "twilight"}
         <div class="panel disclaimer" role="status">
@@ -428,8 +429,8 @@
         </div>
       {:else if histReady && histCount === 0}
         <div class="panel empty-state" role="status">
-          No clear dark hours {historyScope}. The seasonal baseline comes from the
-          ERA5 reanalysis backfill.
+          No clear dark hours {historyScope}. The seasonal baseline comes from
+          the ERA5 reanalysis backfill.
         </div>
       {/if}
     {/if}

--- a/projects/monolith/frontend/src/routes/public/app/trips/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/+page.svelte
@@ -18,7 +18,8 @@
   <header class="head">
     <nav class="crumb" aria-label="Breadcrumb">
       <a class="crumb-home" href="https://jomcgi.dev/"
-        >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span></a
+        >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
+        ></a
       >
       <span class="crumb-sep">/</span>
       <span class="crumb-name">trips</span>

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/+page.svelte
@@ -89,7 +89,11 @@ ${trkpts}
         tags: p.tags?.length ? p.tags : undefined,
       })),
     };
-    download(`${trip.slug}.json`, JSON.stringify(payload, null, 2), "application/json");
+    download(
+      `${trip.slug}.json`,
+      JSON.stringify(payload, null, 2),
+      "application/json",
+    );
   }
 </script>
 
@@ -104,7 +108,8 @@ ${trkpts}
   <header class="head">
     <nav class="crumb" aria-label="Breadcrumb">
       <a class="crumb-home" href="https://jomcgi.dev/"
-        >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span></a
+        >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
+        ></a
       >
       <span class="crumb-sep">/</span>
       <a class="crumb-link" href="/app/trips">trips</a>
@@ -116,13 +121,17 @@ ${trkpts}
       <div>
         {#if stats}
           <p class="dateline">
-            {fmtDate(stats.startIso)} &ndash; {fmtDate(stats.endIso)}, {year(stats.endIso)}
+            {fmtDate(stats.startIso)} &ndash; {fmtDate(stats.endIso)}, {year(
+              stats.endIso,
+            )}
           </p>
         {/if}
         <h1>{trip?.title}</h1>
         {#if trip?.subtitle}<p class="sub">{trip.subtitle}</p>{/if}
       </div>
-      <a class="btn" href={`/app/trips/${trip.slug}/timeline`}>Timeline &rarr;</a>
+      <a class="btn" href={`/app/trips/${trip.slug}/timeline`}
+        >Timeline &rarr;</a
+      >
     </div>
   </header>
 
@@ -186,22 +195,31 @@ ${trkpts}
         <div class="totals">
           <div class="tcell">
             <span class="label">Total distance</span>
-            <span class="big">{stats.totalDistance.toLocaleString()}<span class="unit">km</span></span>
+            <span class="big"
+              >{stats.totalDistance.toLocaleString()}<span class="unit">km</span
+              ></span
+            >
           </div>
           <div class="tcell">
             <span class="label">Duration</span>
-            <span class="big">{stats.totalDays}<span class="unit">days</span></span>
+            <span class="big"
+              >{stats.totalDays}<span class="unit">days</span></span
+            >
           </div>
           {#if stats.maxLat != null}
             <div class="tcell">
               <span class="label">Furthest north</span>
-              <span class="big">{stats.maxLat.toFixed(2)}<span class="unit">&deg;N</span></span>
+              <span class="big"
+                >{stats.maxLat.toFixed(2)}<span class="unit">&deg;N</span></span
+              >
             </div>
           {/if}
           {#if stats.coldestTemp != null}
             <div class="tcell">
               <span class="label">Coldest temp</span>
-              <span class="big cold">{stats.coldestTemp}<span class="unit">&deg;C</span></span>
+              <span class="big cold"
+                >{stats.coldestTemp}<span class="unit">&deg;C</span></span
+              >
             </div>
           {/if}
         </div>
@@ -220,7 +238,9 @@ ${trkpts}
                   onmouseleave={() => (hoveredDay = null)}
                   onclick={() => goToDay(day.dayNumber)}
                 >
-                  <span class="dlabel">{dayLabel(trip.days, day.dayNumber)}</span>
+                  <span class="dlabel"
+                    >{dayLabel(trip.days, day.dayNumber)}</span
+                  >
                   {#if stats.hasElevation}
                     <span class="profile">
                       <ElevationChart
@@ -231,10 +251,14 @@ ${trkpts}
                       />
                     </span>
                   {/if}
-                  <span class="dkm">{day.distance}<span class="unit">km</span></span>
+                  <span class="dkm"
+                    >{day.distance}<span class="unit">km</span></span
+                  >
                   {#if stats.hasElevation}
                     <span class="delev">
-                      <span class="up">+{day.ascent}</span>/<span class="down">-{day.descent}</span>
+                      <span class="up">+{day.ascent}</span>/<span class="down"
+                        >-{day.descent}</span
+                      >
                     </span>
                   {/if}
                   <span class="chev" aria-hidden="true">&rarr;</span>

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
@@ -60,7 +60,8 @@
     showFullscreen = false;
   });
   $effect(() => {
-    if (current > photos.length - 1) current = clampIndex(current, photos.length);
+    if (current > photos.length - 1)
+      current = clampIndex(current, photos.length);
   });
 
   const photo = $derived(photos[current] ?? null);
@@ -111,7 +112,8 @@
   // for the map's terrain hillshade relighting (mirrors the original's
   // SunCalc.getPosition()).
   const sunPosition = $derived.by(() => {
-    if (!telemetry || telemetry.lat == null || telemetry.lng == null) return null;
+    if (!telemetry || telemetry.lat == null || telemetry.lng == null)
+      return null;
     if (!photo?.taken_at) return null;
     const d = new Date(photo.taken_at);
     if (Number.isNaN(d.getTime())) return null;
@@ -203,14 +205,19 @@
 </script>
 
 <svelte:head>
-  <title>{trip ? `${trip.short_title ?? trip.title} - Day ${dayNumber}` : "Day"}</title>
+  <title
+    >{trip
+      ? `${trip.short_title ?? trip.title} - Day ${dayNumber}`
+      : "Day"}</title
+  >
 </svelte:head>
 
 <div class="root">
   <div class="inner">
     {#if !day}
       <p class="missing">
-        Day {dayNumber} not found. <a href={`/app/trips/${trip?.slug}`}>Back to summary</a>.
+        Day {dayNumber} not found.
+        <a href={`/app/trips/${trip?.slug}`}>Back to summary</a>.
       </p>
     {:else}
       <DayNav
@@ -265,7 +272,11 @@
               </div>
               <div class="cell r1 div-thin">
                 <div class="label">SOLAR</div>
-                <div class="val">{t.solarAltDeg != null ? `${t.solarAltDeg.toFixed(0)}°` : "--"}</div>
+                <div class="val">
+                  {t.solarAltDeg != null
+                    ? `${t.solarAltDeg.toFixed(0)}°`
+                    : "--"}
+                </div>
                 <div class="sub">{t.solarLabel}</div>
               </div>
               <div class="cell r1 div-thin">
@@ -279,7 +290,11 @@
               </div>
               <div class="cell r1">
                 <div class="label">ELEV</div>
-                <div class="val">{t.elevation != null ? Math.round(t.elevation) : "--"}<span class="unit">m</span></div>
+                <div class="val">
+                  {t.elevation != null ? Math.round(t.elevation) : "--"}<span
+                    class="unit">m</span
+                  >
+                </div>
               </div>
 
               <!-- ROW 2: OPTICS+NAV+BEARING | ELEVATION PROFILE -->
@@ -287,9 +302,13 @@
                 <div class="optics">
                   <div class="label">OPTICS</div>
                   <div class="optics-line">
-                    {t.focalLength35mm != null ? `${t.focalLength35mm}mm` : "--"} &fnof;/{t.aperture ?? "--"}
+                    {t.focalLength35mm != null
+                      ? `${t.focalLength35mm}mm`
+                      : "--"} &fnof;/{t.aperture ?? "--"}
                   </div>
-                  <div class="optics-sub">ISO {t.iso ?? "--"} · {t.shutterSpeed ?? "--"}</div>
+                  <div class="optics-sub">
+                    ISO {t.iso ?? "--"} · {t.shutterSpeed ?? "--"}
+                  </div>
                 </div>
 
                 <div class="nav">
@@ -300,7 +319,15 @@
                       disabled={!hasPrev}
                       aria-label="Previous photo"
                     >
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        ><polyline points="15 18 9 12 15 6" /></svg
+                      >
                     </button>
                     <button
                       class="navstep"
@@ -308,23 +335,39 @@
                       disabled={!hasNext}
                       aria-label="Next photo"
                     >
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6" /></svg>
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        ><polyline points="9 18 15 12 9 6" /></svg
+                      >
                     </button>
                   </div>
-                  <div class="counter" style={`background:${color}`}>{photos.length ? current + 1 : 0} / {photos.length}</div>
+                  <div class="counter" style={`background:${color}`}>
+                    {photos.length ? current + 1 : 0} / {photos.length}
+                  </div>
                 </div>
 
                 <div class="bearing">
                   <div class="label">BEARING</div>
                   <div class="arrow">{t.bearingArrow}</div>
-                  <div class="bearing-deg">{t.bearing != null ? `${Math.round(t.bearing)}°` : "--"}</div>
+                  <div class="bearing-deg">
+                    {t.bearing != null ? `${Math.round(t.bearing)}°` : "--"}
+                  </div>
                 </div>
               </div>
 
               <div class="elev-profile">
                 <div class="label">ELEVATION PROFILE</div>
                 <div class="elev-inner">
-                  <DayElevationProfile data={profile} progress={profileProgress} accentColor={color} />
+                  <DayElevationProfile
+                    data={profile}
+                    progress={profileProgress}
+                    accentColor={color}
+                  />
                 </div>
               </div>
 
@@ -338,22 +381,31 @@
               </div>
               <div class="cell-stat div-thin">
                 <div class="label">KM</div>
-                <div class="km-val">{t.km ?? 0}<span class="small">/{t.totalKm ?? 0}</span></div>
+                <div class="km-val">
+                  {t.km ?? 0}<span class="small">/{t.totalKm ?? 0}</span>
+                </div>
               </div>
               <div class="cell-stat div-thin">
                 <div class="label">ASCENT</div>
-                <div class="stat-val up">+{(dayStats?.ascent ?? 0).toLocaleString()}m</div>
+                <div class="stat-val up">
+                  +{(dayStats?.ascent ?? 0).toLocaleString()}m
+                </div>
               </div>
               <div class="cell-stat div-thin">
                 <div class="label">DESCENT</div>
-                <div class="stat-val down">-{(dayStats?.descent ?? 0).toLocaleString()}m</div>
+                <div class="stat-val down">
+                  -{(dayStats?.descent ?? 0).toLocaleString()}m
+                </div>
               </div>
               <div class="cell-stat">
                 <div class="label">PHOTOS</div>
                 <div class="stat-val">{dayStats?.photoCount ?? 0}</div>
               </div>
             {:else}
-              <div class="cell r1"><div class="label">TELEMETRY</div><div class="val sm">--</div></div>
+              <div class="cell r1">
+                <div class="label">TELEMETRY</div>
+                <div class="val sm">--</div>
+              </div>
             {/if}
           </div>
         </div>
@@ -372,7 +424,10 @@
     aria-label="Close fullscreen photo"
     onclick={() => (showFullscreen = false)}
   >
-    <img src={photo.imgGallery ?? displayedSrc} alt={`Photo ${current + 1} of ${photos.length}`} />
+    <img
+      src={photo.imgGallery ?? displayedSrc}
+      alt={`Photo ${current + 1} of ${photos.length}`}
+    />
   </button>
 {/if}
 
@@ -380,7 +435,10 @@
   .root {
     min-height: 100vh;
     background: white;
-    font-family: system-ui, -apple-system, sans-serif;
+    font-family:
+      system-ui,
+      -apple-system,
+      sans-serif;
     color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
   }
   .inner {

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/timeline/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/timeline/+page.svelte
@@ -53,7 +53,9 @@
 </script>
 
 <svelte:head>
-  <title>{trip ? `${trip.short_title ?? trip.title} - Timeline` : "Timeline"}</title>
+  <title
+    >{trip ? `${trip.short_title ?? trip.title} - Timeline` : "Timeline"}</title
+  >
 </svelte:head>
 
 <div class="page">
@@ -61,7 +63,9 @@
     <nav class="crumb" aria-label="Breadcrumb">
       <a class="crumb-link" href="/app/trips">trips</a>
       <span class="crumb-sep">/</span>
-      <a class="crumb-link" href={`/app/trips/${trip?.slug}`}>{trip?.short_title ?? trip?.slug}</a>
+      <a class="crumb-link" href={`/app/trips/${trip?.slug}`}
+        >{trip?.short_title ?? trip?.slug}</a
+      >
       <span class="crumb-sep">/</span>
       <span class="crumb-name">timeline</span>
     </nav>
@@ -88,7 +92,8 @@
     <div class="map-box">
       <TripMap
         {days}
-        onDayClick={(n) => (window.location.href = `/app/trips/${trip.slug}/day/${n}`)}
+        onDayClick={(n) =>
+          (window.location.href = `/app/trips/${trip.slug}/day/${n}`)}
       />
     </div>
   {:else}

--- a/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
@@ -123,8 +123,18 @@
   );
 
   const MONTHS = [
-    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
   ];
   const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
@@ -243,7 +253,8 @@
       <div class="crumb-row">
         <nav class="crumb" aria-label="Breadcrumb">
           <a class="crumb-home" href="https://jomcgi.dev/"
-            >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
+            >jomcgi.dev<span class="crumb-arrow" aria-hidden="true"
+              >&nearr;</span
             ></a
           >
           <span class="crumb-sep">/</span>
@@ -302,7 +313,14 @@
                     onclick={() => choose(t.fifa_code)}
                   >
                     {#if t.flag_url}
-                      <img class="flag" src={t.flag_url} alt="" width="20" height="14" loading="lazy" />
+                      <img
+                        class="flag"
+                        src={t.flag_url}
+                        alt=""
+                        width="20"
+                        height="14"
+                        loading="lazy"
+                      />
                     {/if}
                     <span class="picker-opt-name">{t.name}</span>
                     <span class="picker-opt-grp">{t.group_name}</span>
@@ -322,7 +340,10 @@
       <p class="headline-label">
         {countryName}'s chance of reaching the Round of 32
       </p>
-      <p class="headline-figure" class:verdict={q.status === "qualified" || q.status === "eliminated"}>
+      <p
+        class="headline-figure"
+        class:verdict={q.status === "qualified" || q.status === "eliminated"}
+      >
         {headline}
       </p>
 
@@ -363,7 +384,6 @@
           <strong>{elimPct}%</strong>
         </li>
       </ul>
-
     </section>
 
     <!-- HOW IT WORKS (expandable, directly under the headline) -->
@@ -375,39 +395,39 @@
       <div class="explainer-body">
         <p>
           It's a Monte Carlo simulation. Every remaining group game is played
-          out {nSims} times, and Scotland's chance is the share of those runs
-          where they reach the Round of 32.
+          out {nSims} times, and Scotland's chance is the share of those runs where
+          they reach the Round of 32.
         </p>
         <ol class="explainer-steps">
           <li>
-            <strong>Rate each team, with uncertainty.</strong> Every team starts
-            from a pre-tournament Elo rating, then moves up or down with the
-            group results already played, so a side that has over-performed
-            carries that into its remaining games. Because a rating is an
-            estimate and not a fact, each run draws the team's strength from a
-            range around that value (wider for teams who have played fewer
-            games), so a heavy favourite is never treated as a sure thing.
+            <strong>Rate each team, with uncertainty.</strong> Every team starts from
+            a pre-tournament Elo rating, then moves up or down with the group results
+            already played, so a side that has over-performed carries that into its
+            remaining games. Because a rating is an estimate and not a fact, each
+            run draws the team's strength from a range around that value (wider for
+            teams who have played fewer games), so a heavy favourite is never treated
+            as a sure thing.
           </li>
           <li>
-            <strong>Score each match.</strong> For an unplayed match, each
-            team's Poisson scoring rate is built from both sides' drawn strengths
-            and from how freely it has actually scored and conceded so far, so a
-            strong attack and a leaky defence are modelled separately. Scorelines
-            are sampled with a small low-score correction, so the stronger team
-            scores more and evenly matched sides draw about a quarter of the time.
+            <strong>Score each match.</strong> For an unplayed match, each team's
+            Poisson scoring rate is built from both sides' drawn strengths and from
+            how freely it has actually scored and conceded so far, so a strong attack
+            and a leaky defence are modelled separately. Scorelines are sampled with
+            a small low-score correction, so the stronger team scores more and evenly
+            matched sides draw about a quarter of the time.
           </li>
           <li>
-            <strong>Rank by the real rules.</strong> Each simulated tournament
-            applies the actual 2026 rules: top two of every group, plus the
-            eight best third-placed teams. Within a group, a tie on points is
-            settled head-to-head first (the result between the level teams), then
-            overall goal difference and goals scored; the third-placed teams, who
-            never met, are compared on points, goal difference and goals scored.
+            <strong>Rank by the real rules.</strong> Each simulated tournament applies
+            the actual 2026 rules: top two of every group, plus the eight best third-placed
+            teams. Within a group, a tie on points is settled head-to-head first (the
+            result between the level teams), then overall goal difference and goals
+            scored; the third-placed teams, who never met, are compared on points,
+            goal difference and goals scored.
           </li>
           <li>
-            <strong>Aggregate over the runs.</strong> Across all {nSims} runs,
-            the qualify chance, the top-two versus best-third split, and each
-            match's swing are all just counts from the same set of simulations.
+            <strong>Aggregate over the runs.</strong> Across all {nSims} runs, the
+            qualify chance, the top-two versus best-third split, and each match's
+            swing are all just counts from the same set of simulations.
           </li>
         </ol>
         <p class="explainer-fine">
@@ -452,7 +472,14 @@
                 <td class="col-team">
                   <span class="team">
                     {#if t.flag_url}
-                      <img class="flag" src={t.flag_url} alt="" width="22" height="15" loading="lazy" />
+                      <img
+                        class="flag"
+                        src={t.flag_url}
+                        alt=""
+                        width="22"
+                        height="15"
+                        loading="lazy"
+                      />
                     {/if}
                     <span class="team-name">{t.name}</span>
                   </span>
@@ -472,7 +499,9 @@
                     <span class="verdict out">Out</span>
                   {:else}
                     <span class="chance">
-                      <span class="chance-num">{pctClamped(ql.prob_qualify)}</span>
+                      <span class="chance-num"
+                        >{pctClamped(ql.prob_qualify)}</span
+                      >
                       <span class="chance-bar">
                         <span
                           class="chance-fill"
@@ -499,8 +528,8 @@
       <h2 class="block-title">Matches that could change it</h2>
       <p class="block-sub">
         Each remaining match, ranked by how much its result moves {countryName}'s
-        qualify chance. The three figures are {countryName}'s qualify chance after
-        each outcome.
+        qualify chance. The three figures are {countryName}'s qualify chance
+        after each outcome.
       </p>
 
       {#if swings.length === 0}
@@ -518,7 +547,8 @@
               <div class="swing-head">
                 <span class="fixture">
                   <span class="rank">{String(i + 1).padStart(2, "0")}</span>
-                  {m.home_code} <span class="v">v</span> {m.away_code}
+                  {m.home_code} <span class="v">v</span>
+                  {m.away_code}
                   {#if m.is_own_match}
                     <span class="badge own">{countryName}</span>
                   {/if}
@@ -529,9 +559,7 @@
                   title="How much this match moves {countryName}'s chance"
                 >
                   <span class="swing-track">
-                    <span
-                      class="swing-fill"
-                      style="width:{swingBar(m.swing)}%"
+                    <span class="swing-fill" style="width:{swingBar(m.swing)}%"
                     ></span>
                   </span>
                   &plusmn;{points(m.swing)}
@@ -541,9 +569,7 @@
 
               <div class="line">
                 <span class="line-track">
-                  <span
-                    class="line-span"
-                    style="left:{lo}%; right:{100 - hi}%"
+                  <span class="line-span" style="left:{lo}%; right:{100 - hi}%"
                   ></span>
                   <span class="dot dot-lo" style="left:{lo}%"></span>
                   <span class="dot dot-hi" style="left:{hi}%"></span>
@@ -609,8 +635,9 @@
     <!-- FOOTER -->
     <footer class="foot">
       <p>
-        Data from <a href="https://worldcup26.ir" rel="external noopener">worldcup26.ir</a>.
-        Odds from an Elo-weighted Monte Carlo, {nSims} simulations.
+        Data from <a href="https://worldcup26.ir" rel="external noopener"
+          >worldcup26.ir</a
+        >. Odds from an Elo-weighted Monte Carlo, {nSims} simulations.
       </p>
       <p class="caveat">
         The final two FIFA tiebreakers (disciplinary record and FIFA ranking)

--- a/projects/monolith/frontend/src/routes/public/cv/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/cv/+page.svelte
@@ -119,7 +119,12 @@
       /></svg
     >
     <svg class="deco deco-diamond" width="20" height="20" viewBox="0 0 24 24"
-      ><path d="M12,2 L22,12 L12,22 L2,12 Z" fill="none" stroke="var(--ink)" stroke-width="2" /></svg
+      ><path
+        d="M12,2 L22,12 L12,22 L2,12 Z"
+        fill="none"
+        stroke="var(--ink)"
+        stroke-width="2"
+      /></svg
     >
     <svg class="deco deco-squiggle" width="76" height="22" viewBox="0 0 80 24"
       ><path
@@ -136,12 +141,20 @@
       <h1 class="cv-name display">{name}</h1>
       <p class="cv-tagline mono">{tagline}</p>
       <div class="cv-contacts">
-        <a class="btn btn-primary" href={`mailto:${contact.email}`}>{contact.email}</a>
-        <a class="btn btn-secondary" href={contact.linkedin.href} target="_blank" rel="noreferrer"
-          >{contact.linkedin.label}</a
+        <a class="btn btn-primary" href={`mailto:${contact.email}`}
+          >{contact.email}</a
         >
-        <a class="btn btn-secondary" href={contact.github.href} target="_blank" rel="noreferrer"
-          >{contact.github.label}</a
+        <a
+          class="btn btn-secondary"
+          href={contact.linkedin.href}
+          target="_blank"
+          rel="noreferrer">{contact.linkedin.label}</a
+        >
+        <a
+          class="btn btn-secondary"
+          href={contact.github.href}
+          target="_blank"
+          rel="noreferrer">{contact.github.label}</a
         >
         <span class="loc-chip mono">◍ {contact.location}</span>
       </div>
@@ -190,7 +203,9 @@
                     <p class="highlight-kicker">{highlight.kicker}</p>
                   {/if}
                   {#if highlight.intro}
-                    <p class="highlight-intro">{@render inline(highlight.intro)}</p>
+                    <p class="highlight-intro">
+                      {@render inline(highlight.intro)}
+                    </p>
                   {/if}
                   <ul class="bullets">
                     {#each highlight.bullets as bullet}

--- a/projects/monolith/frontend/src/routes/public/docs/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/docs/+page.svelte
@@ -5,7 +5,11 @@
   let { data } = $props();
 </script>
 
-<Seo title="Documentation · jomcgi.dev" description={data.meta.description} path="/docs" />
+<Seo
+  title="Documentation · jomcgi.dev"
+  description={data.meta.description}
+  path="/docs"
+/>
 
 <DocsShell sidebar={data.sidebar} activeSlug="">
   <header class="docs-hero">

--- a/projects/monolith/frontend/src/routes/public/docs/DocsShell.svelte
+++ b/projects/monolith/frontend/src/routes/public/docs/DocsShell.svelte
@@ -25,8 +25,10 @@
     const out = [];
     for (const node of nodes) {
       const top = topName ?? node.name;
-      if (node.slug) out.push({ slug: node.slug, title: node.title, group: top });
-      if (node.children.length) out.push(...flattenProjects(node.children, top));
+      if (node.slug)
+        out.push({ slug: node.slug, title: node.title, group: top });
+      if (node.children.length)
+        out.push(...flattenProjects(node.children, top));
     }
     return out;
   }
@@ -176,90 +178,89 @@
 </header>
 
 <div class="docs-page">
-<div class="docs-layout" class:has-toc={hasToc}>
-  <aside class="docs-side">
-    <nav class="side-nav mono" aria-label="Documentation">
-      <p class="side-head">Projects</p>
-      {@render projectTree(sidebar.projects, "")}
+  <div class="docs-layout" class:has-toc={hasToc}>
+    <aside class="docs-side">
+      <nav class="side-nav mono" aria-label="Documentation">
+        <p class="side-head">Projects</p>
+        {@render projectTree(sidebar.projects, "")}
 
-      <p class="side-head">Decisions</p>
-      <ul class="side-list">
-        {#if sidebar.decisions.index}
-          <li>
-            <a
-              class="side-link"
-              class:active={activeSlug === sidebar.decisions.index.slug}
-              href={`/docs/${sidebar.decisions.index.slug}`}>Index</a
-            >
-          </li>
-        {/if}
-      </ul>
+        <p class="side-head">Decisions</p>
+        <ul class="side-list">
+          {#if sidebar.decisions.index}
+            <li>
+              <a
+                class="side-link"
+                class:active={activeSlug === sidebar.decisions.index.slug}
+                href={`/docs/${sidebar.decisions.index.slug}`}>Index</a
+              >
+            </li>
+          {/if}
+        </ul>
 
-      {#each sidebar.decisions.categories as cat}
-        <button
-          type="button"
-          class="side-cat"
-          aria-expanded={!!openCats[cat.name]}
-          onclick={() => toggleCat(cat.name)}
-        >
-          <svg
-            class="side-cat-chevron"
-            class:open={openCats[cat.name]}
-            width="9"
-            height="9"
-            viewBox="0 0 10 10"
-            aria-hidden="true"
+        {#each sidebar.decisions.categories as cat}
+          <button
+            type="button"
+            class="side-cat"
+            aria-expanded={!!openCats[cat.name]}
+            onclick={() => toggleCat(cat.name)}
           >
-            <path
-              d="M3 1 L7 5 L3 9"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.6"
-              stroke-linecap="square"
-            />
-          </svg>
-          <span class="side-cat-name">{cat.name}</span>
-          <span class="side-cat-count">{cat.items.length}</span>
-        </button>
-        {#if openCats[cat.name]}
-          <ul class="side-list">
-            {#each cat.items as item}
-              <li>
-                <a
-                  class="side-link"
-                  class:active={activeSlug === item.slug}
-                  href={`/docs/${item.slug}`}
-                  title={item.title}>{item.title}</a
-                >
-              </li>
-            {/each}
-          </ul>
-        {/if}
-      {/each}
-    </nav>
-  </aside>
-
-  <main class="docs-main">
-    <div class="docs-card">
-      {@render children()}
-    </div>
-  </main>
-
-  {#if hasToc}
-    <aside class="docs-toc mono" aria-label="On this page">
-      <p class="side-head">On this page</p>
-      <ul class="toc-list">
-        {#each toc as h}
-          <li class:lvl3={h.depth === 3}>
-            <a href={`#${h.id}`}>{h.text}</a>
-          </li>
+            <svg
+              class="side-cat-chevron"
+              class:open={openCats[cat.name]}
+              width="9"
+              height="9"
+              viewBox="0 0 10 10"
+              aria-hidden="true"
+            >
+              <path
+                d="M3 1 L7 5 L3 9"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="square"
+              />
+            </svg>
+            <span class="side-cat-name">{cat.name}</span>
+            <span class="side-cat-count">{cat.items.length}</span>
+          </button>
+          {#if openCats[cat.name]}
+            <ul class="side-list">
+              {#each cat.items as item}
+                <li>
+                  <a
+                    class="side-link"
+                    class:active={activeSlug === item.slug}
+                    href={`/docs/${item.slug}`}
+                    title={item.title}>{item.title}</a
+                  >
+                </li>
+              {/each}
+            </ul>
+          {/if}
         {/each}
-      </ul>
+      </nav>
     </aside>
-  {/if}
-</div>
-</div>
 
+    <main class="docs-main">
+      <div class="docs-card">
+        {@render children()}
+      </div>
+    </main>
+
+    {#if hasToc}
+      <aside class="docs-toc mono" aria-label="On this page">
+        <p class="side-head">On this page</p>
+        <ul class="toc-list">
+          {#each toc as h}
+            <li class:lvl3={h.depth === 3}>
+              <a href={`#${h.id}`}>{h.text}</a>
+            </li>
+          {/each}
+        </ul>
+      </aside>
+    {/if}
+  </div>
+</div>
 
 <style>
   /* ── Top bar: apex back link on the left, docs section nav on the right.

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -210,9 +210,9 @@
         <a class="anchor" href="#classes">Three kinds of workload</a>
       </h2>
       <p class="body">
-        Everything Ember runs is declared as a Kubernetes custom resource in
-        one of three classes, and a composite workload groups several of them
-        into one unit that wakes together. What separates the classes:
+        Everything Ember runs is declared as a Kubernetes custom resource in one
+        of three classes, and a composite workload groups several of them into
+        one unit that wakes together. What separates the classes:
         <b>how much of the machine the guest is allowed to touch</b>.
       </p>
       <dl class="classes">
@@ -220,18 +220,18 @@
           <dt>task<small>run once</small></dt>
           <dd>
             One-shot execution in a fresh or snapshot-restored VM.
-            <b>No network device at all</b>: the guest speaks only vsock to
-            the daemon, then the VM is destroyed.
+            <b>No network device at all</b>: the guest speaks only vsock to the
+            daemon, then the VM is destroyed.
           </dd>
         </div>
         <div class="class">
           <dt>session<small>sleep &amp; wake</small></dt>
           <dd>
-            A stateful sandbox that survives across invocations. Idle
-            sessions are <b>banked</b> (snapshotted to disk) and
-            <b>relit</b> (restored) on the next call, with memory, processes
-            and open files intact. Banked snapshots are offloaded to S3; a
-            session survives the node it slept on.
+            A stateful sandbox that survives across invocations. Idle sessions
+            are <b>banked</b> (snapshotted to disk) and
+            <b>relit</b> (restored) on the next call, with memory, processes and open
+            files intact. Banked snapshots are offloaded to S3; a session survives
+            the node it slept on.
           </dd>
         </div>
         <div class="class">
@@ -239,8 +239,9 @@
           <dd>
             A warm HTTP endpoint. The guest answers TCP over a tap NIC and a
             per-node Envoy routes to it.
-            <b>The control plane programs that Envoy and stays off the
-              request path</b
+            <b
+              >The control plane programs that Envoy and stays off the request
+              path</b
             >.
           </dd>
         </div>
@@ -252,23 +253,24 @@
         <a class="anchor" href="#uses">What that lets you run</a>
       </h2>
       <p class="body">
-        All four run on this cluster today. The design assumption behind each
-        of them: <b>the guest is hostile</b>.
+        All four run on this cluster today. The design assumption behind each of
+        them: <b>the guest is hostile</b>.
       </p>
       <dl class="classes">
         <div class="class">
           <dt>an agent's sandbox<small>session</small></dt>
           <dd>
             Each AI agent gets its own machine to make a mess in: shell,
-            filesystem, packages. Banked between turns, relit
-            mid-conversation, <b>destroyed without ceremony</b>.
+            filesystem, packages. Banked between turns, relit mid-conversation, <b
+              >destroyed without ceremony</b
+            >.
           </dd>
         </div>
         <div class="class">
           <dt>a database nobody queries at 3am<small>session</small></dt>
           <dd>
-            Postgres banked to disk the moment it goes idle, woken by the
-            next connection. <b>Zero compute while asleep.</b>
+            Postgres banked to disk the moment it goes idle, woken by the next
+            connection. <b>Zero compute while asleep.</b>
             <a class="sig" href="/ember/postgres">see it live →</a>
           </dd>
         </div>
@@ -284,8 +286,8 @@
           <dt>a public function, served warm<small>serving</small></dt>
           <dd>
             An image renderer answering real internet traffic from a warm
-            microVM, <b>rate-limited and quota-capped</b> so untrusted
-            traffic cannot spend more than it is allowed to.
+            microVM, <b>rate-limited and quota-capped</b> so untrusted traffic cannot
+            spend more than it is allowed to.
           </dd>
         </div>
       </dl>
@@ -406,7 +408,8 @@
           >
 
           <rect x="436" y="136" width="130" height="40" rx="8" class="box" />
-          <text x="501" y="154" text-anchor="middle" class="node-label">S3</text>
+          <text x="501" y="154" text-anchor="middle" class="node-label">S3</text
+          >
           <text x="501" y="168" text-anchor="middle" class="node-sub"
             >snapshots + images</text
           >
@@ -425,7 +428,8 @@
           >
 
           <rect x="622" y="196" width="72" height="46" rx="8" class="box" />
-          <text x="658" y="216" text-anchor="middle" class="node-label">VM</text>
+          <text x="658" y="216" text-anchor="middle" class="node-label">VM</text
+          >
           <text x="658" y="231" text-anchor="middle" class="node-sub"
             >tap NIC</text
           >
@@ -465,20 +469,18 @@
         </svg>
         <div class="legend">
           <span
-            ><i class="swatch sw-control"></i> control path (tasks &amp;
-            sessions)</span
+            ><i class="swatch sw-control"></i> control path (tasks &amp; sessions)</span
           >
           <span><i class="swatch sw-data"></i> serving data path</span>
-          <span
-            ><i class="swatch sw-xds"></i> configuration, ahead of time</span
+          <span><i class="swatch sw-xds"></i> configuration, ahead of time</span
           >
         </div>
       </div>
       <p class="arch-punch">
-        <b>Serving requests never touch the control plane.</b> The edge routes
-        to a node-local Envoy the control plane has already programmed, and
-        the kernel DNATs the connection into the VM. The control plane can
-        restart mid-request; serving traffic notices nothing.
+        <b>Serving requests never touch the control plane.</b> The edge routes to
+        a node-local Envoy the control plane has already programmed, and the kernel
+        DNATs the connection into the VM. The control plane can restart mid-request;
+        serving traffic notices nothing.
       </p>
     </section>
 
@@ -491,18 +493,16 @@
           reach exactly one thing: the daemon, over vsock.
         </p>
         <p>
-          <b>Quotas fail closed.</b> A principal with quota 0 is hard-stopped
-          at submit.
+          <b>Quotas fail closed.</b> A principal with quota 0 is hard-stopped at submit.
         </p>
         <p>
-          Metering rides the operation itself; <b
-            >a crash cannot lose usage</b
-          >. Every task counts against its quota on success and on failure.
+          Metering rides the operation itself; <b>a crash cannot lose usage</b>.
+          Every task counts against its quota on success and on failure.
         </p>
         <p>
-          The one public route is scoped at <b>three independent layers</b>:
-          the edge pins host and path, Envoy exact-matches the internal
-          authority, and the guest shim reserves its own control prefix.
+          The one public route is scoped at <b>three independent layers</b>: the
+          edge pins host and path, Envoy exact-matches the internal authority,
+          and the guest shim reserves its own control prefix.
         </p>
       </div>
     </section>
@@ -520,9 +520,8 @@
           <span class="k">live demo</span>
           <h3>A Postgres that sleeps</h3>
           <p>
-            A real database banked to disk. Click connect, watch the
-            stopwatch: snapshot restore, disk to answering queries, best wake
-            78&nbsp;ms.
+            A real database banked to disk. Click connect, watch the stopwatch:
+            snapshot restore, disk to answering queries, best wake 78&nbsp;ms.
           </p>
           <span class="go">ember/postgres</span>
         </a>
@@ -530,8 +529,8 @@
           <span class="k">live demo</span>
           <h3>Query a frozen Bazel brain</h3>
           <p>
-            Each query runs in a disposable clone of a snapshotted warm
-            Bazel server.
+            Each query runs in a disposable clone of a snapshotted warm Bazel
+            server.
           </p>
           <span class="go">ember/bazel</span>
         </a>
@@ -548,8 +547,8 @@
           <span class="k">workload demo</span>
           <h3>Semgrep</h3>
           <p>
-            The CI security scanner, warm in a microVM, scanning your snippet
-            in about a second.
+            The CI security scanner, warm in a microVM, scanning your snippet in
+            about a second.
           </p>
           <span class="go">ember/semgrep</span>
         </a>
@@ -563,8 +562,7 @@
       <div class="roadmap">
         {#each MILESTONES as m (m.name)}
           <div class="milestone">
-            <span class="cb" class:todo={!m.done}
-              >{m.done ? "[x]" : "[ ]"}</span
+            <span class="cb" class:todo={!m.done}>{m.done ? "[x]" : "[ ]"}</span
             >
             <span class="rname">{m.name}</span>
             <p class="rdesc">{m.desc}</p>

--- a/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/bazel/+page.svelte
@@ -59,7 +59,8 @@
       const resp = await fetch(`${API}/savings`);
       if (!resp.ok) return;
       const body = await parseJsonSafe(resp);
-      if (body?.total_analysis_s_saved != null) savedS = body.total_analysis_s_saved;
+      if (body?.total_analysis_s_saved != null)
+        savedS = body.total_analysis_s_saved;
     } catch {
       // best-effort: leave the last known value on screen
     }
@@ -193,7 +194,8 @@
         return;
       }
       if (resp.status === 429) {
-        runError = "the demo is busy right now, give it a few seconds and try again";
+        runError =
+          "the demo is busy right now, give it a few seconds and try again";
         return;
       }
       if (!resp.ok) {
@@ -204,7 +206,8 @@
         // or timeout. Pre-submit rejections (bad expression, missing
         // session, rate limit, busy semaphore) are handled below as in-band
         // 200 + {error, ...flag} bodies instead.
-        runError = body?.detail ?? body?.error ?? `query failed (${resp.status})`;
+        runError =
+          body?.detail ?? body?.error ?? `query failed (${resp.status})`;
         return;
       }
       if (body.session_required) {
@@ -266,12 +269,14 @@
 
   // Turnstile widget lifecycle: mirrors EmberConsole's script-load +
   // render-once + remove-on-unmount pattern.
-  const TURNSTILE_SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+  const TURNSTILE_SCRIPT_SRC =
+    "https://challenges.cloudflare.com/turnstile/v0/api.js";
   let widgetEl;
   let widgetId = null;
 
   function renderTurnstileWidget() {
-    if (!window.turnstile || !widgetEl || !turnstileSiteKey || sessionReady) return;
+    if (!window.turnstile || !widgetEl || !turnstileSiteKey || sessionReady)
+      return;
     if (widgetId !== null) return;
     widgetId = window.turnstile.render(widgetEl, {
       sitekey: turnstileSiteKey,
@@ -299,7 +304,9 @@
       renderTurnstileWidget();
       return removeTurnstileWidget;
     }
-    let script = document.querySelector(`script[src="${TURNSTILE_SCRIPT_SRC}"]`);
+    let script = document.querySelector(
+      `script[src="${TURNSTILE_SCRIPT_SRC}"]`,
+    );
     if (!script) {
       script = document.createElement("script");
       script.src = TURNSTILE_SCRIPT_SRC;
@@ -370,10 +377,14 @@
   let filteredLabelItems = $derived.by(() => {
     const needle = filterText.trim().toLowerCase();
     if (!needle) return labelItems;
-    return labelItems.filter((item) => item.target.toLowerCase().includes(needle));
+    return labelItems.filter((item) =>
+      item.target.toLowerCase().includes(needle),
+    );
   });
 
-  let labelPageCount = $derived(Math.max(1, Math.ceil(filteredLabelItems.length / PAGE_SIZE)));
+  let labelPageCount = $derived(
+    Math.max(1, Math.ceil(filteredLabelItems.length / PAGE_SIZE)),
+  );
 
   let shownLabelPage = $derived(Math.min(labelPage, labelPageCount - 1));
 
@@ -421,8 +432,8 @@
         <a class="inline-link" href="https://github.com/abseil/abseil-cpp"
           >Abseil</a
         >
-        (514 targets) was analyzed once and the warm server snapshotted with
-        Firecracker. Every query below restores a throwaway copy.
+        (514 targets) was analyzed once and the warm server snapshotted with Firecracker.
+        Every query below restores a throwaway copy.
       </p>
     </header>
 
@@ -601,11 +612,17 @@
                 >
                   &#8249;
                 </button>
-                <span class="pager-count">page {shownLabelPage + 1} of {labelPageCount}</span>
+                <span class="pager-count"
+                  >page {shownLabelPage + 1} of {labelPageCount}</span
+                >
                 <button
                   class="pager-btn"
                   type="button"
-                  onclick={() => (labelPage = Math.min(labelPageCount - 1, shownLabelPage + 1))}
+                  onclick={() =>
+                    (labelPage = Math.min(
+                      labelPageCount - 1,
+                      shownLabelPage + 1,
+                    ))}
                   disabled={shownLabelPage >= labelPageCount - 1}
                   aria-label="next page"
                 >

--- a/projects/monolith/frontend/src/routes/public/ember/postgres/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/postgres/+page.svelte
@@ -37,15 +37,17 @@
       ><a class="brand" href="/"><strong>jomcgi.dev</strong></a> /
       <a class="brand" href="/ember">ember</a> / postgres</span
     >
-    <a class="topbar-cross" href="/ember/firecracker">how firecracker resumes a VM</a>
+    <a class="topbar-cross" href="/ember/firecracker"
+      >how firecracker resumes a VM</a
+    >
   </header>
 
   <main class="ember-page">
     <header class="masthead">
       <h1><span class="ember-word">Ember</span> Postgres</h1>
       <p class="subtitle">
-        Postgres scaling to zero on Firecracker microVMs with sub-second
-        resume from disk to memory.
+        Postgres scaling to zero on Firecracker microVMs with sub-second resume
+        from disk to memory.
       </p>
     </header>
 

--- a/projects/monolith/frontend/src/routes/public/engineering/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/engineering/+page.svelte
@@ -1,7 +1,12 @@
 <script>
   import { onMount } from "svelte";
   import { Footer, Sticker, Marquee } from "$lib/public/components";
-  import { intro, marqueeItems, categories, projects } from "./engineering-data.js";
+  import {
+    intro,
+    marqueeItems,
+    categories,
+    projects,
+  } from "./engineering-data.js";
   import { diagrams } from "./diagrams/index.js";
 
   // Stable two-digit section numbers derived from roster order. The repo
@@ -68,7 +73,9 @@
     const marquee = document.querySelector(".marquee");
     const updateRail = () => {
       const navBottom = nav ? nav.getBoundingClientRect().bottom : 0;
-      const marqueeBottom = marquee ? marquee.getBoundingClientRect().bottom : 0;
+      const marqueeBottom = marquee
+        ? marquee.getBoundingClientRect().bottom
+        : 0;
       const top = Math.max(0, navBottom, marqueeBottom);
       railY = top + (window.innerHeight - top) / 2;
     };
@@ -100,12 +107,21 @@
       <h1 class="display eng-title">{intro.title}</h1>
       <div class="hero-stickers">
         {#each stickers as s, i}
-          <Sticker color={stickerColors[i % stickerColors.length]} rotate={i % 2 ? 3 : -3}>
+          <Sticker
+            color={stickerColors[i % stickerColors.length]}
+            rotate={i % 2 ? 3 : -3}
+          >
             {s}
           </Sticker>
         {/each}
-        <a class="sticker-link" href={intro.source.href} target="_blank" rel="noreferrer">
-          <Sticker color="var(--paper)" rotate={2}>{intro.source.label}</Sticker>
+        <a
+          class="sticker-link"
+          href={intro.source.href}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <Sticker color="var(--paper)" rotate={2}>{intro.source.label}</Sticker
+          >
         </a>
       </div>
       <p class="lede">{intro.lede}</p>
@@ -125,7 +141,11 @@
   </nav>
 
   <!-- ═══ Scroll-spy rail (desktop) ═══ -->
-  <nav class="rail mono" aria-label="Sections" style:top={railY ? `${railY}px` : null}>
+  <nav
+    class="rail mono"
+    aria-label="Sections"
+    style:top={railY ? `${railY}px` : null}
+  >
     {#each numbered as p}
       <a
         class="rail-link"
@@ -147,7 +167,12 @@
           <span class="dive-num mono">{p.num}</span>
           <h2 class="dive-title" id={`${p.id}-h`}>
             {#if p.repoHref}
-              <a class="title-link" href={p.repoHref} target="_blank" rel="noreferrer">
+              <a
+                class="title-link"
+                href={p.repoHref}
+                target="_blank"
+                rel="noreferrer"
+              >
                 {p.title}<span class="title-arrow" aria-hidden="true">↗</span>
               </a>
             {:else}
@@ -155,7 +180,10 @@
             {/if}
           </h2>
           <span class="tag mono">
-            <span class="tag-dot" style:background={categories[p.category].color}></span>
+            <span
+              class="tag-dot"
+              style:background={categories[p.category].color}
+            ></span>
             {categories[p.category].label}
           </span>
           {#if p.status}
@@ -175,7 +203,10 @@
           {/each}
         </div>
 
-        <div class="motivation" style:border-left-color={categories[p.category].color}>
+        <div
+          class="motivation"
+          style:border-left-color={categories[p.category].color}
+        >
           <span class="motivation-label mono">Motivation</span>
           <p>{p.motivation}</p>
         </div>

--- a/projects/monolith/frontend/src/routes/public/engineering/diagrams/Goosecracker.svelte
+++ b/projects/monolith/frontend/src/routes/public/engineering/diagrams/Goosecracker.svelte
@@ -24,10 +24,13 @@
   >
     <DBox role="process" sub="CoW rootfs {goosecrackerRootfsMs}ms">Boot</DBox>
     <DBox role="process" sub="FC restore {goosecrackerBootMs}ms">microVM</DBox>
-    <DBox role="process" sub="init ~{goosecrackerGuestInitMs}ms">Guest PID 1</DBox>
+    <DBox role="process" sub="init ~{goosecrackerGuestInitMs}ms"
+      >Guest PID 1</DBox
+    >
   </DGroup>
   <DArrow label="goose init {goosecrackerAgentUpMs}ms" />
-  <DBox role="process" sub="~{agentFirstModelCallMs}ms to first RPC">Agent</DBox>
+  <DBox role="process" sub="~{agentFirstModelCallMs}ms to first RPC">Agent</DBox
+  >
   <DArrow label="builds + publishes" />
   <DGroup label="Artifact" stack>
     <DBox role="output" sub="self-contained HTML">Artifact</DBox>

--- a/projects/monolith/frontend/src/routes/public/engineering/diagrams/Loom.svelte
+++ b/projects/monolith/frontend/src/routes/public/engineering/diagrams/Loom.svelte
@@ -15,7 +15,9 @@
   <DBox role="process" sub="Rust">DataFusion</DBox>
   <DArrow />
   <DBox role="store" sub="S3 object storage">DuckLake tables</DBox>
-  <DBox role="store" sub="queue, catalog, ontology, ACL, lineage">Postgres control plane</DBox>
+  <DBox role="store" sub="queue, catalog, ontology, ACL, lineage"
+    >Postgres control plane</DBox
+  >
   <DArrow label="speaks" />
   <DBox role="output" sub="DuckDB-compatible">Quack protocol</DBox>
 </Diagram>

--- a/projects/operators/oci-model-cache/deploy/application.yaml
+++ b/projects/operators/oci-model-cache/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: oci-model-cache-operator
-      targetRevision: 0.2.5
+      targetRevision: 0.2.6
       helm:
         valueFiles:
           - $values/projects/operators/oci-model-cache/deploy/values.yaml

--- a/projects/operators/oci-model-cache/helm/oci-model-cache-operator/Chart.yaml
+++ b/projects/operators/oci-model-cache/helm/oci-model-cache-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: oci-model-cache-operator
 description: A Helm chart for the OCI Model Cache Operator - caches HuggingFace models as OCI artifacts
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: "latest"
 keywords:
   - oci


### PR DESCRIPTION
## Summary

Closes #4021. One prettier path for Svelte across local `ci lint`, Bazel format, and the tools image.

- Add root `prettier-plugin-svelte` + peer `svelte` (pnpm lockfile)
- Wire plugin in `bazel/tools/format/prettier.config.cjs` via `require()`
- Hermetic `//bazel/tools/format:prettier` gets plugin via `prettierrc` js_library deps
- New `//bazel/tools/format:format_svelte` step on the format multirun (aspect_rules_lint has no Svelte dialect; JavaScript includes Vue but not Svelte)
- `ci lint` / `fast-format` include `*.svelte` and pass `--config`
- Tools image ships plugin + svelte next to prettier; wrapper sets `NODE_PATH`
- One-time reformat of tracked `*.svelte` files (~77 needed style fixes)

## Test plan

- [x] `prettier --config bazel/tools/format/prettier.config.cjs --check '**/*.svelte'` clean after reformat
- [x] `bb remote run //bazel/tools/format:format_svelte --config=ci` (exit 0)
- [x] `bb remote build //bazel/tools/image:prettier_tar --config=ci`
- [x] `bb remote test //bazel/tools/ci:ci_test //bazel/tools/format:check_migration_ordering_test --config=ci`
- [x] `ci lint` formats dirty `.svelte` without "No parser could be inferred"
- [ ] PR Workflows Format + Test (full `//...` pre-push hit runner disk-full infra; not a product failure)