### PR TITLE
fix(ci): request the Test action's 120GB disk for ci test

### DIFF
--- a/bazel/tools/ci/ci
+++ b/bazel/tools/ci/ci
@@ -273,8 +273,20 @@ cmd_test() {
 	dim "  bb remote --os=linux --arch=amd64 ${bazel_args[*]}"
 	dim "  (include-secrets=true: runner may receive org secrets; treat as CI)"
 
+	# Match the Test action's `resource_requests.disk` in buildbuddy.yaml (120GB).
+	# Parity with CI was previously argv-only: targets, --config, --deleted_packages
+	# and --test_tag_filters all matched, but resource requests live in the YAML
+	# rather than the bazel command line, so they were never mirrored and this path
+	# silently took the much smaller default runner disk. //... pulls an external
+	# tree over 11G (apko layers, the semgrep_pro OCI archive, pip wheels, npm), so
+	# the default fills and the build dies mid-fetch with "No space left on device"
+	# on whichever repository happened to be unpacking. It presents as flakiness:
+	# the failing target moves between runs, and it is never the target you changed.
+	# Confirmed not to be runner-recycling debris; a fresh runner
+	# (recycle-runner=false) ran out of disk the same way.
 	bb remote --os=linux --arch=amd64 \
 		--runner_exec_properties=include-secrets=true \
+		--runner_exec_properties=EstimatedFreeDiskBytes=120GB \
 		"${bazel_args[@]}"
 }
 


### PR DESCRIPTION
## Problem

`ci test` advertises 1:1 parity with the `Test` action in `buildbuddy.yaml`, and it is 1:1 on argv: same targets, `--config=ci`, `--deleted_packages`, `--test_tag_filters`. But `resource_requests` live in the YAML rather than on the bazel command line, so they were never mirrored. The local path took the default runner disk while CI's `Test` action requests **120GB**.

`//...` pulls an external tree over 11G (apko layers, the semgrep_pro OCI archive, pip wheels, npm), so the default fills and the build dies mid-fetch:

```
ERROR: no such package '@@rules_apko++apko+embervm_runtime_postgres_lock_icu78-data-full_aarch64_78.3-r1//':
  concatenate_gzip_segments failed.
  stdout: cat: write error: No space left on device
```

This presents as flakiness. The failing target moved every run and was never the target under change:

| Run | Failing target |
|---|---|
| 1, 2 | `semgrep_experimental_engine_amd64` |
| 3 | `embervm_runtime_postgres_lock_icu78-data-full` |
| 4 | `embervm_runtime_bazel_lock_gcc_aarch64` |

The tell is that the failures land in fetch/unpack rather than in compile or test.

## Not a recycling problem

Worth recording, since stale VM snapshots are the intuitive suspect and the repo has been bitten by snapshot reuse before (the Buck2 action's `buck2 killall`). Run 4 used `--runner_exec_properties=recycle-runner=false` and got a genuinely cold runner. It ran out of disk the same way. Accumulation was never the mechanism, and invalidating snapshots would have cost every future run a cold start while fixing nothing.

## Fix

Mirror the `Test` action's disk request explicitly:

```bash
--runner_exec_properties=EstimatedFreeDiskBytes=120GB
```

## Verification

`ci test` on this branch: **exit 0, 747 tests pass**, no disk error, and the runner's high-disk warning is gone.

```
INFO: Elapsed time: 494.550s, Critical Path: 74.20s
Executed 388 out of 747 tests: 747 tests pass.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)