### PR TITLE
fix(semgrep): split guest rule pins from CI digests

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -448,6 +448,18 @@ use_repo(
 semgrep_experimental = use_extension("//bazel/semgrep/third_party/semgrep_experimental:extensions.bzl", "semgrep_experimental")
 use_repo(semgrep_experimental, "semgrep_experimental_engine_amd64")
 
+# Semgrep Pro rule packs for the Firecracker/EmberVM guest image.
+# Manual digests in semgrep_guest/digests.bzl, not the update-semgrep-pro workflow.
+semgrep_guest = use_extension("//bazel/semgrep/third_party/semgrep_guest:extensions.bzl", "semgrep_guest")
+use_repo(
+    semgrep_guest,
+    "semgrep_guest_rules_golang",
+    "semgrep_guest_rules_javascript",
+    "semgrep_guest_rules_kubernetes",
+    "semgrep_guest_rules_python",
+    "semgrep_guest_rules_rust",
+)
+
 # Semgrep OSS — semgrep-core binary from GHCR (extracted from PyPI wheels)
 # Digests auto-updated by .github/workflows/update-semgrep-pro.yaml
 semgrep = use_extension("//bazel/semgrep/third_party/semgrep:extensions.bzl", "semgrep")

--- a/bazel/semgrep/README.md
+++ b/bazel/semgrep/README.md
@@ -129,6 +129,11 @@ The Pro engine also ships per-language rule packs (`@semgrep_pro_rules_golang`,
 archive with its own digest pin in
 `third_party/semgrep_pro/digests.bzl`.
 
+CI tests use the auto-updated `semgrep_pro` rule-pack digests. The Firecracker
+and EmberVM guest image uses the same rule-pack artifacts through
+`semgrep_guest`, which has manual pins in `third_party/semgrep_guest/digests.bzl`
+so CI digest updates do not rebuild the deployable guest.
+
 The test runner stages both binaries in the same temp directory (Pro requires
 `semgrep-core` as a co-located runtime dependency) and passes
 `-pro_inter_file` for cross-file taint analysis. `SEMGREP_APP_TOKEN` is

--- a/bazel/semgrep/guest/BUILD
+++ b/bazel/semgrep/guest/BUILD
@@ -78,11 +78,13 @@ pkg_files(
 )
 
 # Each Pro pack is one or more large YAML/JSON files at its external repo root.
-# Namespace each under its own pro-<lang>/ subdir so the packs cannot collide with
-# each other or with the local rules.
+# These guest rule packs use the frozen, manually managed semgrep_guest pins,
+# rather than the auto-updated CI semgrep_pro digests. Namespace each under its
+# own pro-<lang>/ subdir so the packs cannot collide with each other or with the
+# local rules.
 pkg_files(
     name = "pro_golang_files",
-    srcs = ["@semgrep_pro_rules_golang//:rules"],
+    srcs = ["@semgrep_guest_rules_golang//:rules"],
     attributes = pkg_attributes(mode = "0644"),
     prefix = "etc/semgrep/rules/pro-golang",
     strip_prefix = strip_prefix.from_pkg(""),
@@ -90,7 +92,7 @@ pkg_files(
 
 pkg_files(
     name = "pro_python_files",
-    srcs = ["@semgrep_pro_rules_python//:rules"],
+    srcs = ["@semgrep_guest_rules_python//:rules"],
     attributes = pkg_attributes(mode = "0644"),
     prefix = "etc/semgrep/rules/pro-python",
     strip_prefix = strip_prefix.from_pkg(""),
@@ -98,7 +100,7 @@ pkg_files(
 
 pkg_files(
     name = "pro_javascript_files",
-    srcs = ["@semgrep_pro_rules_javascript//:rules"],
+    srcs = ["@semgrep_guest_rules_javascript//:rules"],
     attributes = pkg_attributes(mode = "0644"),
     prefix = "etc/semgrep/rules/pro-javascript",
     strip_prefix = strip_prefix.from_pkg(""),
@@ -106,7 +108,7 @@ pkg_files(
 
 pkg_files(
     name = "pro_kubernetes_files",
-    srcs = ["@semgrep_pro_rules_kubernetes//:rules"],
+    srcs = ["@semgrep_guest_rules_kubernetes//:rules"],
     attributes = pkg_attributes(mode = "0644"),
     prefix = "etc/semgrep/rules/pro-kubernetes",
     strip_prefix = strip_prefix.from_pkg(""),
@@ -114,7 +116,7 @@ pkg_files(
 
 pkg_files(
     name = "pro_rust_files",
-    srcs = ["@semgrep_pro_rules_rust//:rules"],
+    srcs = ["@semgrep_guest_rules_rust//:rules"],
     attributes = pkg_attributes(mode = "0644"),
     prefix = "etc/semgrep/rules/pro-rust",
     strip_prefix = strip_prefix.from_pkg(""),

--- a/bazel/semgrep/third_party/semgrep_guest/BUILD
+++ b/bazel/semgrep/third_party/semgrep_guest/BUILD
@@ -1,0 +1,17 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "extensions",
+    srcs = ["extensions.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":digests",
+        "//bazel/semgrep/third_party/semgrep_pro:oci_archive",
+    ],
+)
+
+bzl_library(
+    name = "digests",
+    srcs = ["digests.bzl"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/semgrep/third_party/semgrep_guest/digests.bzl
+++ b/bazel/semgrep/third_party/semgrep_guest/digests.bzl
@@ -1,0 +1,15 @@
+"""Semgrep Pro rule-pack digests baked into the Firecracker/EmberVM guest image.
+
+Manual pin (like semgrep_experimental). Intentionally NOT updated by
+.github/workflows/update-semgrep-pro.yaml so CI digest churn does not rebuild the
+deployable guest. Bump deliberately when shipping new guest rule packs; that
+change rebuilds the guest and requires chart bumps for fc-invoke + embervm.
+"""
+
+SEMGREP_GUEST_DIGESTS = {
+    "rules_golang": "sha256:3b4962725eeba008159cff4140cab426439277a8f4cc80187690ba5154d0d11b",
+    "rules_python": "sha256:3d86725726d4cd26607cf752d524980cc4778da0c1a67f9e0157cb0b30e5ae66",
+    "rules_javascript": "sha256:d9789e2eba75c0cb1317a4a1b1838bae6a571e6bf83c87992f762221b95ba69c",
+    "rules_kubernetes": "sha256:eaeeeff194bad2f8ab7433a172e6968b853a2cf3be358563b1134f0b4a447602",
+    "rules_rust": "sha256:14f66ffe8d3250b8855a0fced76de01942bb30b52d7be40d123e874ab337a7d7",
+}

--- a/bazel/semgrep/third_party/semgrep_guest/extensions.bzl
+++ b/bazel/semgrep/third_party/semgrep_guest/extensions.bzl
@@ -1,0 +1,25 @@
+"""Module extension for Semgrep Pro rule packs baked into the guest image."""
+
+load("//bazel/semgrep/third_party/semgrep_pro:oci_archive.bzl", "oci_archive")
+load(":digests.bzl", "SEMGREP_GUEST_DIGESTS")
+
+_GHCR_PREFIX = "jomcgi/homelab/tools/semgrep-pro"
+
+_RULES_BUILD = """\
+filegroup(
+    name = "rules",
+    srcs = glob(["*.yaml", "*.json"], allow_empty = True),
+    visibility = ["//visibility:public"],
+)
+"""
+
+def _semgrep_guest_impl(_module_ctx):
+    for lang in ["golang", "python", "javascript", "kubernetes", "rust"]:
+        oci_archive(
+            name = "semgrep_guest_rules_" + lang,
+            image = _GHCR_PREFIX + "/rules-" + lang,
+            digest = SEMGREP_GUEST_DIGESTS.get("rules_" + lang, ""),
+            build_file_content = _RULES_BUILD,
+        )
+
+semgrep_guest = module_extension(implementation = _semgrep_guest_impl)


### PR DESCRIPTION
## Summary

Weekly (was daily) Semgrep digest updates were rebuilding the Firecracker/EmberVM **guest** image because guest rule packs shared `@semgrep_pro_rules_*` with CI tests. That tripped missed-bump on `fc-invoke` and `embervm` even though engines already use a separate manual pin (`semgrep_experimental`).

This splits guest rule packs onto manual digests (`semgrep_guest`), matching the experimental engine pattern:

- **CI tests**: still `@semgrep_pro_rules_*` (auto-updated by the workflow)
- **Guest image**: `@semgrep_guest_rules_*` (manual; bump only when intentionally shipping new guest rules + chart bumps)

Not removing the guest / fc-invoke path: embervm still pins the same frozen guest image. Full retirement is a separate cutover.

## Test plan

- [x] Guest BUILD references only `@semgrep_guest_rules_*` for pro packs
- [x] `bazel/semgrep/rules/BUILD` still uses `@semgrep_pro_rules_*`
- [x] Local `bazelisk query '@semgrep_guest_rules_python//:rules'` resolves
- [ ] PR CI Test / Push images green (local `ci test` hit BB runner disk-full flakes)
- [ ] Next digests-only PR should not require fc-invoke/embervm chart bumps