### PR TITLE
fix(cloudflare-gateway): pin tunnel transport to http2

### DIFF
--- a/projects/platform/cloudflare-gateway/values-prod.yaml
+++ b/projects/platform/cloudflare-gateway/values-prod.yaml
@@ -25,6 +25,18 @@ tunnel:
     onepassword:
       itemPath: "vaults/k8s-homelab/items/cluster-cloudflare-tunnel"
 
+  # Pinned to http2 (TCP) instead of the cloudflared default of quic (UDP).
+  # The shared WAN egress path drops UDP flows periodically, which stranded the
+  # tunnel and made Cloudflare serve 530 on the public tier while the cluster
+  # itself was healthy. Over one 96h sample: 241 QUIC teardowns across 69
+  # episodes, 70% of them simultaneous (within 5s) on both replicas despite
+  # running on different nodes and different edge PoPs, so the fault is on the
+  # shared path rather than in the cluster. TCP egress over the same window and
+  # the same path had zero failures.
+  #
+  # Revert to "" (quic) only once the egress path is confirmed to hold UDP.
+  protocol: http2
+
   ingress:
     routes:
       # argocd, longhorn, and signoz retired: they now serve under


### PR DESCRIPTION
## Problem

The public tier intermittently serves Cloudflare **530** while the cluster itself is perfectly healthy. A 530 is generated at the Cloudflare edge and means "no origin reachable", so it points at the tunnel rather than at Kubernetes.

## Root cause

The shared WAN egress path drops UDP flows periodically. `cloudflared` defaults to the QUIC transport (UDP), so when the path drops UDP the tunnel deregisters and Cloudflare has nothing to route to.

Evidence over an 83h sample:

| Signal | Value |
|---|---|
| QUIC teardown events | 241 |
| Distinct outage episodes | 69 (~1 per 72 min) |
| Teardowns simultaneous on **both** replicas (within 5s) | **70%** |
| TCP egress failures over the same window and path | **0** |

The two replicas run on different nodes and hold connections to different Cloudflare PoPs (`yvr01`, `yvr02`, `sea06-09`). A per-node fault or a Cloudflare-side fault cannot synchronise to within 5 seconds across both, so the fault lies on the path they share. Neither pod ever restarted (`RESTARTS: 0`), which is why this never surfaced as a Kubernetes-level alert.

## Change

Set `tunnel.protocol: http2` so the tunnel rides TCP, the transport with a zero-failure record on this path.

The chart already wired this value through to the cloudflared `--protocol` flag at `tunnel-deployment.yaml:119-121`. It had simply never been set, so `protocol: ""` fell through to the QUIC default. Rendered result:

```
args:
- tunnel
- --config
- /etc/cloudflared/config/config.yaml
- --protocol
- http2
- run
- $(TUNNEL_ID)
```

Tradeoff: HTTP/2 gives up QUIC's better loss recovery and a slightly higher throughput ceiling. At homelab link scale that is negligible against an outage every ~72 minutes.

## No chart bump

This Application uses `targetRevision: HEAD` on a git path (`projects/platform/cloudflare-gateway`), so ArgoCD syncs it straight from main. The missed-bump guard compares pinned **image digests**, which are unchanged here since no image is rebuilt.

## Verification

- `helm template` confirms the flag renders into the container args.
- `ci lint` passes.
- `ci test` currently fails on **unrelated infrastructure**: the BuildBuddy remote executor is out of disk (`No space left on device`, `high VM disk usage (99.27%)`, `output-base` at 12G). It fails while fetching k3s/kata/npm artifacts, before running any test. This chart has no `BUILD` file and is not a Bazel target, so this diff cannot affect it. Flagged separately.

## Rollback

Set `protocol` back to `""` to return to QUIC.