### PR TITLE
feat(cilium): enable kubeProxyReplacement with loopback k8sServiceHost

### DIFF
--- a/projects/platform/cilium/bootstrap/cilium-helmchart.yaml
+++ b/projects/platform/cilium/bootstrap/cilium-helmchart.yaml
@@ -30,10 +30,13 @@ spec:
   bootstrap: true
   failurePolicy: abort
   valuesContent: |-
-    kubeProxyReplacement: false
-
-    # k8sServiceHost/Port omitted on purpose (see ../values.yaml): kube-proxy
-    # routes the kubernetes Service, and 127.0.0.1 would be wrong on the agent.
+    kubeProxyReplacement: true
+    # 127.0.0.1:6444 is valid on every node (see ../values.yaml for the full
+    # reasoning and the evidence): on servers it is the apiserver's own
+    # --secure-port, and on the node-4 agent it is the k3s-agent client-side
+    # load balancer that proxies to all three servers with failover.
+    k8sServiceHost: "127.0.0.1"
+    k8sServicePort: 6444
     # cni.exclusive: false lets Cilium coexist with k3s CNI config management.
     # confPath/binPath point at k3s's real CNI dirs (from `k3s crictl info`):
     # Cilium's defaults (/etc/cni/net.d, /opt/cni/bin) are dirs k3s never reads,

--- a/projects/platform/cilium/values.yaml
+++ b/projects/platform/cilium/values.yaml
@@ -4,13 +4,36 @@
 # upstream oci://quay.io/cilium/charts cilium chart), so these values are nested
 # under the `cilium:` subchart key to reach the upstream chart's values.
 cilium:
-  kubeProxyReplacement: false # keep k3s kube-proxy (deferred item)
+  kubeProxyReplacement: true # ADR networking/003 capability #3
 
-  # k8sServiceHost/Port intentionally NOT set. With kubeProxyReplacement=false,
-  # kube-proxy already routes the in-cluster kubernetes Service, so cilium-agent
-  # (hostNetwork) reaches the apiserver through it on every node. A literal
-  # 127.0.0.1 would be correct on servers but WRONG on the node-4 agent, which
-  # has no local apiserver.
+  # cilium-agent can no longer reach the apiserver through the kube-proxy-routed
+  # in-cluster kubernetes Service once kube-proxy is gone, so it must be given
+  # the address directly. 127.0.0.1:6444 is correct on EVERY node, because the
+  # address resolves to a different (but equally valid) thing per role:
+  #
+  #   node-1/2/3 (servers): the apiserver's own secure port. It binds
+  #     --bind-address=127.0.0.1 --secure-port=6444 (see the kube-apiserver argv
+  #     in `journalctl -u k3s`); :6443 is the public listener in front of it.
+  #   node-4 (agent): the k3s-agent client-side load balancer, which listens on
+  #     127.0.0.1:6444 and proxies to ALL three servers with failover. Its server
+  #     list lives in <data-dir>/agent/etc/k3s-agent-load-balancer.json and holds
+  #     all of 192.168.1.119/.161/.123, not just the node's join address.
+  #
+  # This supersedes an earlier comment here which said 127.0.0.1 "would be WRONG
+  # on the node-4 agent, which has no local apiserver". node-4 indeed runs no
+  # apiserver process, but it does expose a local loopback API endpoint, which is
+  # what k8sServiceHost actually needs. Verified on all four nodes: a listener on
+  # 127.0.0.1:6444 answering /healthz with 401 (TLS up, anonymous auth refused,
+  # which is the expected response given --anonymous-auth=false).
+  #
+  # Using the loopback endpoint rather than a server IP also avoids making one
+  # node a single point of failure for service routing, and needs no VIP (this
+  # cluster runs no kube-vip/keepalived/metallb).
+  #
+  # cilium-agent runs hostNetwork, so 127.0.0.1 in its namespace is the host's
+  # loopback and reaches the local endpoint directly.
+  k8sServiceHost: "127.0.0.1"
+  k8sServicePort: 6444
 
   # Coexist with k3s's own CNI config management rather than taking the CNI conf
   # directory exclusively (k3s writes and owns it). Recommended for k3s+Cilium.


### PR DESCRIPTION
Track 1 of #3823 (capability #3 of ADR networking/003). **Merging this alone does not remove kube-proxy** — k3s keeps running its embedded kube-proxy until `disable-kube-proxy` lands in Track 2, so Cilium runs in compatible mode and the value is already reconciled when the nodes restart.

## The highest-risk decision, resolved

The plan called picking `k8sServiceHost` for node-4 "the single highest-risk step" and framed it as a binary:

- a **VIP** — this cluster has none (no kube-vip, keepalived, or metallb), or
- a **single server IP** — which makes one node a single point of failure for all service routing once kube-proxy is gone.

There is a third option the plan didn't consider: **`127.0.0.1:6444` is valid on every node**, because the address resolves to a different but equally correct thing per role.

| Role | What `127.0.0.1:6444` is |
|---|---|
| node-1/2/3 (servers) | the apiserver's own secure port (`--bind-address=127.0.0.1 --secure-port=6444`; `:6443` is the public listener in front of it) |
| node-4 (agent) | the `k3s-agent` client-side load balancer, proxying to **all three** servers with failover |

This needs no VIP and introduces no SPOF.

## Supersedes a documented assumption

`values.yaml` previously asserted that `127.0.0.1` "would be WRONG on the node-4 agent, which has no local apiserver". That conflates two things: node-4 runs no apiserver *process*, but it does expose a local loopback API *endpoint*, which is what `k8sServiceHost` actually needs.

Evidence gathered before changing it:

- All four nodes have a listener on `127.0.0.1:6444` answering `/healthz` with **401** (TLS established, anonymous auth refused, exactly as expected under `--anonymous-auth=false`).
- node-4's `<data-dir>/agent/etc/k3s-agent-load-balancer.json` lists all three servers, not just its join address:
  ```json
  {"ServerURL": "https://192.168.1.119:6443",
   "ServerAddresses": ["192.168.1.119:6443","192.168.1.161:6443","192.168.1.123:6443"]}
  ```
- node-4 stayed `Ready` throughout a restart of node-1 (its join address) during the #689 rollout earlier today, so the failover works in practice, not just on paper.

## Render verified

- `cilium-config`: `kube-proxy-replacement: "true"`
- `KUBERNETES_SERVICE_HOST=127.0.0.1` / `PORT=6444` on `cilium` + `cilium-envoy` DaemonSets and the `cilium-operator` Deployment. All three run `hostNetwork`, so loopback reaches the local endpoint directly.

## Track 2 (not this PR)

Node ops: `disable-kube-proxy: true` per node + k3s restart, with an etcd snapshot first. Proposed deviation from the plan's servers-first order: do **node-4 first**, since it is the node whose API path is the genuinely novel piece and the only one that is not an etcd member, and the plan's own Step 3 calls the node-4 reachability check "the critical check". Will also verify `iptables -t nat -S | grep -c '^-N CNI-DN-'` is 0 per node, given the stale flannel-era portmap chains found during #689.

Note: committed with `--no-verify` because the vendored prettier wrapper (`~/.cache/homelab-tools/usr/bin/prettier`) execs a container path that does not exist on darwin. Files were formatted with the repo-local prettier instead (no changes needed). That wrapper is broken for any darwin session, independent of this change.

Refs #3823

🤖 Generated with [Claude Code](https://claude.com/claude-code)