### PR TITLE
perf(ci): stop stamping every ci command, keep it on the push

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -80,8 +80,26 @@ test --sandbox_default_allow_network=false
 # =============================================================================
 # Run with --config=ci in GitHub Actions
 
-# Stamping: applies to all commands (build, test, run)
-common:ci --stamp
+# Stamping is deliberately NOT enabled here. It belongs only on the one command
+# that needs it: the push job passes --stamp explicitly (buildbuddy.yaml). Do not
+# add `common:ci --stamp` back.
+#
+# Stamping any command makes stable-status.txt and volatile-status.txt inputs of
+# every stamp-aware action. rules_oci gives each image three .digest targets
+# (index plus each platform) and each is a bazel-lib jq rule whose stamp attr
+# follows the flag, with no per-target opt-out. That was 92 ConvertStatusToJson
+# plus 92 Jq actions in `bazel test //...`, whose jq filter (.manifests[0].digest)
+# never even reads $STAMP.
+#
+# They can never hit the remote cache: Bazel rewrites BUILD_TIMESTAMP into
+# volatile-status.txt every invocation, and while Bazel fakes that file's
+# metadata for the LOCAL action cache, the remote action key is the Merkle root
+# over real input contents, so the key changes every build. Making the STABLE_
+# values deterministic does not help (measured: 524 -> 496 misses).
+#
+# Measured on the CI Test action: 262 remote executions per run, 64.6s aggregate
+# queue-to-done for 7.0s of real work. Without stamping the same graph executes
+# 0 actions and fully caches, with all 747 tests still passing.
 common:ci --workspace_status_command=./bazel/tools/workspace_status.sh
 common:ci --define=CI=true
 common:ci --repo_env=GHCR_TOKEN


### PR DESCRIPTION
## What

`.bazelrc` set `common:ci --stamp`, applying stamping to every `--config=ci`
command: build, test and run alike. Only the push needs it, and
`buildbuddy.yaml:219` already passes `--stamp` explicitly to
`//bazel/images:push_all`, so this removes the blanket flag and leaves push
behaviour byte-identical.

## Why

Stamping makes `stable-status.txt` and `volatile-status.txt` inputs of every
stamp-aware action. rules_oci defines three `.digest` targets per image (index
plus each platform) as bazel-lib `jq` rules whose `stamp` attr follows the flag,
with no per-target opt-out. `aquery` counts exactly 92 of them:

```
$ bazel aquery 'mnemonic("ConvertStatusToJson", //...)' --config=ci
92 actions, owned by e.g.
  //projects/monolith/whatsapp:image.digest
  //projects/monolith/whatsapp:image_arm64.digest
  //projects/monolith/whatsapp:image_amd64.digest
```

Their jq filter is `.manifests[0].digest`, which never reads `$STAMP`. The stamp
plumbing on these actions is dead weight.

They can never hit the remote cache. Bazel rewrites `BUILD_TIMESTAMP` into
`volatile-status.txt` on every invocation. Its constant-metadata handling for
that file applies only to the **local** action cache; the remote action key is
the Merkle root over real input contents, so the key changes every build.

## Measured

CI Test action before, per run, on an unchanged tree:

| mnemonic | n | queue to done | actual execution |
|---|---|---|---|
| Jq | 92 | 25.6s | 2.3s |
| ConvertStatusToJson | 92 | 19.8s | 2.3s |
| Action | 62 | 14.3s | 1.5s |
| HelmPackage / HelmImagesValues / Rustc | 16 | 5.0s | 1.0s |
| **total** | **262** | **64.6s** | **7.0s** |

Steady state, two consecutive `ci test` runs each:

```
stamped:   304 processes, 248 remote executions, every run
unstamped: 344 processes,   3 remote executions
```

747 tests pass either way.

## Caveats, stated plainly

- **Wall clock is not yet demonstrated to improve.** Local `ci test` measured
  81-91s unstamped versus 6.4s stamped, but the arms ran in different worktrees
  against `bb remote` runners whose cache warmth I cannot control or observe, and
  the cache-lookup counts differ wildly (30111 versus 749). The action-execution
  reduction is solid; the timing needs this PR's Test action to settle it.
  **Please compare this PR's Test duration against recent main runs before
  merging.**
- An earlier attempt derived the image tag from the commit date instead of the
  wall clock, to make `stable-status.txt` deterministic. It moved misses only
  524 -> 496, because `volatile-status.txt` is the binding constraint. That work
  is parked separately and is not needed for this change.

## Risk

Push is unaffected (`--stamp` passed explicitly at `buildbuddy.yaml:219`), and
`common:release --stamp` is untouched. Audited every other stamp consumer: the
three `bazel/tools/oci/*_image.bzl` macros and `bazel/tools/image/BUILD` feed
push only; `buck2/image_tags.sh` is not Bazel; the embervm chart reference is a
comment. No helm rule reads stamp values, and chart version comes from source
`Chart.yaml`. No chart bump needed since no deployed artifact changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
