### PR TITLE
fix(bazel): derive image tag from commit date for reproducibility

### DIFF
--- a/bazel/tools/workspace_status.sh
+++ b/bazel/tools/workspace_status.sh
@@ -14,7 +14,24 @@ auto_version=$(
 )
 
 # Generate timestamp-based image tag: YYYY.MM.DD.HH.MM.SS-shortsha
-base_image_tag=$(date -u +"%Y.%m.%d.%H.%M.%S")-${git_short_sha}
+#
+# The timestamp is the COMMIT date, not the wall clock, so the tag is a function
+# of the commit alone. Rebuilding the same commit republishes the same ghcr tag
+# instead of minting a new one per push run, which matches how the rest of the
+# image pipeline already works (SOURCE_DATE_EPOCH=0 in .bazelrc makes apko
+# digests reproducible; a wall-clock tag undid that property one layer up).
+#
+# Same sortable YYYY.MM.DD.HH.MM.SS-shortsha format, and it still changes on
+# every new commit, so each merge to main still publishes a distinct tag.
+#
+# Note the semantic: the tag now encodes when the commit was authored, not when
+# the image was built. Those differ for a rebuild or a rebase.
+#
+# This is a reproducibility change, not a performance one. Stamp-related remote
+# cache churn was a separate problem, fixed by dropping `common:ci --stamp`
+# (PR #4038); making this value deterministic moved cache misses only 524 -> 496,
+# because volatile-status.txt is the binding constraint there, not this key.
+base_image_tag=$(TZ=UTC git show -s --format=%cd --date=format-local:%Y.%m.%d.%H.%M.%S HEAD)-${git_short_sha}
 
 # Get branch name (sanitized for Docker tags)
 # Check multiple CI environment variables for branch name


### PR DESCRIPTION
## What

`workspace_status.sh` built `STABLE_IMAGE_TAG` from `$(date -u)`, so rebuilding
an unchanged commit minted a brand new ghcr tag on every push run. This derives
the timestamp from the **commit date**, making the tag a function of the commit
alone.

```diff
-base_image_tag=$(date -u +"%Y.%m.%d.%H.%M.%S")-${git_short_sha}
+base_image_tag=$(TZ=UTC git show -s --format=%cd --date=format-local:%Y.%m.%d.%H.%M.%S HEAD)-${git_short_sha}
```

## Why

This extends reproducibility work already done one layer down. `.bazelrc` sets
`SOURCE_DATE_EPOCH=0` so apko image digests are reproducible for identical
source, but a wall-clock tag undid that property at the tag level: same source,
same digest, different tag every time.

## Behaviour

- Format unchanged: `YYYY.MM.DD.HH.MM.SS-shortsha`, still chronologically
  sortable.
- Still distinct per commit, so every merge to main still publishes a new tag.
- Verified stable across invocations:
  ```
  $ bash bazel/tools/workspace_status.sh | grep STABLE_IMAGE_TAG   # twice
  STABLE_IMAGE_TAG dev-2026.07.26.21.09.38-7830835bc
  STABLE_IMAGE_TAG dev-2026.07.26.21.09.38-7830835bc
  ```

## Semantic change worth reviewing

The tag now encodes **when the commit was authored**, not when the image was
built. These differ for a rebuild or a rebase. If you rebase a branch, the tag
moves with the new committer date; if you rebuild an old commit, you get that
commit's original timestamp rather than today's.

Deploys are unaffected: they key on chart version, not image tag, and there is
no ArgoCD Image Updater.

## This is not a performance change

Stamp-related remote cache churn was a separate problem, fixed by dropping
`common:ci --stamp` in #4038. Making this value deterministic was tried first as
a fix for that and moved cache misses only 524 -> 496, because
`volatile-status.txt` is the binding constraint there rather than this key. It is
being landed on reproducibility grounds alone.

## Verification

`ci test`: 747 tests pass, 3 remote executions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
