### PR TITLE
docs(ember): correct the /ember page against the architecture doc

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.292
+version: 0.89.294
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.292
+      targetRevision: 0.89.294
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.366
+version: 0.285.368
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.366
+      targetRevision: 0.285.368
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/ember/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/ember/+page.svelte
@@ -115,7 +115,7 @@
     {
       done: true,
       name: "R4 stateful",
-      desc: "Postgres as a session: a database that sleeps as a snapshot and wakes on connect. The live demo above.",
+      desc: "A database that sleeps as a snapshot and wakes on connect, with its disk as the authoritative copy. The live demo above.",
     },
     {
       done: true,
@@ -130,17 +130,17 @@
     {
       done: false,
       name: "R7 distribution",
-      desc: "Workloads stop belonging to one machine: a wake restores the snapshot onto whichever node has room, and capacity is pre-provisioned across the fleet ahead of demand. In progress.",
+      desc: "Workloads stop belonging to one machine: a wake restores the snapshot onto whichever node has room, and capacity is pre-provisioned across the fleet ahead of demand. Needs a second warm-capable node to matter.",
     },
     {
       done: false,
-      name: "R8 elasticity",
-      desc: "Capacity becomes fixed-size bricks: each a plain pod owning a slice of VMs, so the Kubernetes scheduler bin-packs them and a Pending brick is the autoscaler's signal to buy a spot node. Every workload is a durable snapshot that wakes wherever there is room; preemption costs a wake, not an outage.",
+      name: "R8 consumers",
+      desc: "The agent platform moves onto sessions as a first-class consumer, retiring the older per-agent daemon it grew out of. Dogfooding is the acceptance test: the thing that runs this site's agents runs on the sandbox primitive.",
     },
     {
       done: false,
-      name: "R9 isolation",
-      desc: "A lane for high-throughput isolated requests: Envoy routes straight to the nodes, each request gets a fresh microVM from a node-local pool and the VM is destroyed after the response, confirmed by the node that held it. No control-plane hop per request; it only keeps pools filled and quota leases granted. Planned.",
+      name: "R9 packaging",
+      desc: "Ember becomes a standalone artifact somebody else could run: no dependency on the rest of this cluster, an open-sourceable boundary rather than a folder in a homelab monorepo.",
     },
   ];
 </script>
@@ -199,7 +199,7 @@
         <span class="sep">·</span>
         <a
           class="src"
-          href="https://github.com/jomcgi/homelab/blob/main/projects/embervm/README.md"
+          href="https://github.com/jomcgi/homelab/blob/main/projects/embervm/ARCHITECTURE.md"
           >source</a
         >
       </p>
@@ -210,10 +210,12 @@
         <a class="anchor" href="#classes">Three kinds of workload</a>
       </h2>
       <p class="body">
-        Everything Ember runs is declared as a Kubernetes custom resource in one
-        of three classes, and a composite workload groups several of them into
-        one unit that wakes together. What separates the classes:
-        <b>how much of the machine the guest is allowed to touch</b>.
+        Everything Ember runs is declared as a Kubernetes custom resource. Three
+        classes are the core, and what separates them is
+        <b>how much of the machine the guest is allowed to touch</b>. Two more
+        are advanced options rather than pillars: <b>stateful</b> adds a disk
+        that outlives the VM (the database below), and <b>composite</b> groups several
+        VMs into one unit that wakes together.
       </p>
       <dl class="classes">
         <div class="class">
@@ -267,7 +269,7 @@
           </dd>
         </div>
         <div class="class">
-          <dt>a database nobody queries at 3am<small>session</small></dt>
+          <dt>a database nobody queries at 3am<small>stateful</small></dt>
           <dd>
             Postgres banked to disk the moment it goes idle, woken by the next
             connection. <b>Zero compute while asleep.</b>
@@ -496,8 +498,10 @@
           <b>Quotas fail closed.</b> A principal with quota 0 is hard-stopped at submit.
         </p>
         <p>
-          Metering rides the operation itself; <b>a crash cannot lose usage</b>.
-          Every task counts against its quota on success and on failure.
+          <b>Enforcement fails closed; counting fails open.</b> A node cut off from
+          the control plane keeps running and keeps counting, and unreconciled spend
+          is written off. Refusing to run a workload to protect an internal cost number
+          is the wrong trade.
         </p>
         <p>
           The one public route is scoped at <b>three independent layers</b>: the


### PR DESCRIPTION
## What

Four claims on the public `/ember` page had drifted from what EmberVM actually
does. Found while reviewing `ARCHITECTURE.md` (#4043). Copy only, no layout or
design change.

## 1. The flagship demo was mislabelled

`chart/templates/workload-demo-postgres.yaml` is **`class: stateful`**. The page
called it a session twice, including an R4 milestone reading literally "Postgres
**as a session**".

The page's "three kinds of workload" framing is actually *right* and matches the
product story in ADR 001 (task, serving and session are the core; stateful and
composite are optional advanced classes), so this keeps three core classes and
names stateful and composite as the advanced pair rather than promoting them to
pillars.

## 2. The metering claim was reversed by ADR 020

The page said metering "rides the operation itself" and **"a crash cannot lose
usage"**, which is the strongest form of the old fail-closed posture.

ADR embervm/020 decision 6 makes metering **fail open by design**, writes off
unreconciled spend, and promotes `meteringFailOpen` from an allowlisted exception
to the default. It already ships `true` on `hot-image-demo` and
`scratch-postgres`, which are two of the workloads this page showcases.

The replacement states the real split, which is a better story anyway:
enforcement fails closed, counting fails open, and the reason is that this is
internal cost allocation with no adversary trying to steal compute from itself.
The adjacent quota sentence is untouched, because admission genuinely did stay
fail-closed.

## 3. The roadmap tail was stale by a renumbering

The page had R8 elasticity and R9 isolation. ADR 009 defines **R8 Consumers** and
**R9 Packaging**; the brick work is now in-flight engineering rather than a rung,
and the isolated lane lives under serving as ADR 015. R7 also stopped claiming
"in progress", since it needs a second warm-capable node to matter.

## 4. The source link pointed at the wrong file

`README.md` is no longer where current state lives. Now points at
`ARCHITECTURE.md`.

## Deliberately not changed

The architecture SVG's op-log box reads "Postgres". That is wrong today (the
op-log is SQLite at `/var/lib/embervm/oplog.db`) and becomes **correct** when
#4045 lands the Postgres cutover, so changing it here would only have to be
changed back.

## Verification

- `ci lint` clean, no em-dashes.
- `ci test` green: 748 tests pass.
- Chart bumps for monolith and monolith-public.
- Visual regression will diff the copy changes; expect text-only deltas in the
  classes list, isolation list, and roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)