### PR TITLE
fix(embervm): roll the op-log back to SQLite, the CP crash-loops on Postgres

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.234
+version: 0.1.235

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.234
+      targetRevision: 0.1.235
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -17,7 +17,16 @@ opLog:
   # Still one replica with strategy: Recreate. Multi-replica needs ADR 007's
   # single-writer-per-cell op-log appender, which this does not deliver.
   postgres:
-    enabled: true
+    # ROLLED BACK 2026-07-27. The Postgres adapter connected fine ("op-log opened
+    # against Postgres"), then the CP crash-looped: Embervm.TaskStore called
+    # GenServer.call(Embervm.OpLog.SQLite, :load_tasks) against a process that was
+    # never started. 15 modules take BOTH :op_log (the server to call) and
+    # :op_log_mod (the module), and application.ex threads op_log_mod() to nearly
+    # all of them while passing :op_log at only two sites, so :op_log falls back to
+    # its hardcoded Embervm.OpLog.SQLite default. Re-enable only once that is
+    # fixed and verified by booting the supervision tree against a real Postgres,
+    # which the adapter-level conformance suite does not cover.
+    enabled: false
     secretName: embervm-oplog-password
     onepassword:
       itemPath: vaults/k8s-homelab/items/embervm-oplog-db


### PR DESCRIPTION
## Incident

#4047 flipped the op-log to Postgres. The connection worked, then the control
plane failed to boot:

```
{"message":"embervm op-log opened against Postgres"}   <- adapter started fine
failed to start child: Embervm.TaskStore
  (EXIT) exited in: GenServer.call(Embervm.OpLog.SQLite, :load_tasks, 5000)
  (EXIT) no process
```

Impact: `CrashLoopBackOff` on the CP. Warm workloads keep serving and noded keeps
its cached registry (this is the ADR 018 / ADR 020 design working), but no new
lifecycle actions land. The Postgres side is fine: role reconciled, database
`embervm_oplog` created and owned by `embervm`.

## Root cause: a latent wiring bug, not the adapter and not the chart

Fifteen modules take **two** options:

```elixir
op_log     = Keyword.get(opts, :op_log,     Embervm.OpLog.SQLite)  # GenServer to call
op_log_mod = Keyword.get(opts, :op_log_mod, Embervm.OpLog.SQLite)  # module for functions
```

`application.ex` threads `op_log_mod: op_log_mod()` into nearly all of them but
passes `op_log:` at only **two** sites (`BaseBuilder` and the sweeper). Everywhere
else `:op_log` silently keeps its hardcoded `Embervm.OpLog.SQLite` default and
addresses a process that is never started once the Postgres adapter is selected.

Invisible while the adapter was dormant, and **the conformance suite added in
#4047 cannot catch it**: it exercises `Embervm.OpLog.Postgres` directly, not the
supervision tree that wires it up. That is the gap to close.

## The real fix, deliberately not in this PR

Thread `:op_log` alongside `:op_log_mod` at every site (both adapters register
under their own module name, so the server reference *is* the module). Better
still, collapse the two options into one, since nothing ever legitimately wants
them to differ, which removes the whole failure mode rather than patching 15
instances of it.

Acceptance bar for that PR is booting the **application** against a real
Postgres, not calling the adapter.

## Why roll back rather than fix forward

The CP is degraded now, a one-line values flip is provably correct, and a
fifteen-site change deserves verification rather than haste. Both paths have the
same deploy latency (bump, publish, sync), so fixing forward buys nothing.

The monolith side stays enabled: the role and database are harmless while idle
and `databaseReclaimPolicy: retain`, so re-enabling is a values flip once the
wiring is fixed. The 1Password item and the CNPG basic-auth secret both stay.

Rollback comes up with an **empty** SQLite op-log, which is the accepted trade
from #4047 (running state rebuilds from node adoption on dial-home).

## Verification

`helm template` renders `EMBERVM_OPLOG_PATH`, no `EMBERVM_OPLOG_DSN`, and the PVC
back. embervm chart bumped 0.1.234 to 0.1.235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)