### PR TITLE
fix(embervm): make base export and retention per node so mixed-vendor fleets can evict

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.235
+version: 0.1.236

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -1461,14 +1461,39 @@ defmodule Embervm.BaseBuilder do
 
     state = put_in(state.workloads[w.name], w)
 
-    # Base-durability PR-1: drive the durability floor. Export the freshly-built
-    # current base to the object store on the node that built it. Fire-and-forget
-    # in a spawned worker (the RPC returns a fast ack and the node uploads
-    # asynchronously); the periodic export reconcile is the backstop if this
-    # result is lost or the store was down. Idempotent per checksum, so a redundant
-    # export (e.g. an already_built no-op build that reports the same ref) is a
-    # cheap skipped no-op on the node.
-    state = spawn_export(state, w.node_id, w.name, w.snapshot_ref)
+    # Base-durability PR-1: drive the durability floor using each node's own
+    # vendor-specific current ref. The periodic export reconcile remains the
+    # backstop if a result is lost or the store was down.
+    facts = Embervm.NodeCapacity.all(state.capacity_table)
+
+    export_targets =
+      Enum.flat_map(facts, fn fact ->
+        case get_in(fact, [:workloads, w.name]) do
+          nil -> []
+          workload_fact -> [{fact[:instance_id], workload_fact}]
+        end
+      end)
+
+    state =
+      case export_targets do
+        [] ->
+          # A base can finish before its node advertises the workload. Keep the
+          # anchor-node export during that dial-home window; later facts replace it
+          # with the per-node fan-out.
+          spawn_export(state, w.node_id, w.name, w.snapshot_ref)
+
+        _ ->
+          Enum.reduce(export_targets, state, fn {instance_id, workload_fact}, acc ->
+            case workload_fact do
+              %{snapshot_ref: node_ref, exported: exported?}
+              when is_binary(node_ref) and node_ref != "" and exported? != true ->
+                spawn_export(acc, instance_id, w.name, node_ref)
+
+              _ ->
+                acc
+            end
+          end)
+      end
 
     write_base_status(state, w, :built)
   end
@@ -1544,70 +1569,64 @@ defmodule Embervm.BaseBuilder do
     state
   end
 
-  # Compute the sweep plan (a per-workload list of what to evict) AND apply the
+  # Compute the sweep plan (a per-node list of what to evict) AND apply the
   # gated action. The plan is returned for tests/visibility; the action is the
   # spawned evictions (gate on) or the dry-run log (gate off).
   #
-  # For each workload with a placed, exported current base:
-  #   candidates = local READY bases the node reports (local_bases, READY only)
-  #                MINUS the desired set (current ref + still-refcounted superseded
-  #                refs). BUILDING/FAILED local bases are never candidates (a
-  #                BUILDING base is being written; noded also refuses it).
-  # Durability-before-eviction: a workload whose CURRENT base is not yet exported
-  # is SKIPPED WHOLE (never empty the local cache before the S3 floor lands). noded's
-  # in-use/current/BUILDING guard is the final backstop beneath this.
+  # For each capacity fact with a current, exported local base, candidates are
+  # local bases minus the node's current ref and still-refcounted superseded refs.
+  # BUILDING local bases are never candidates, and an unexported current base only
+  # blocks eviction on that same node. noded's in-use/current/BUILDING guard is the
+  # final backstop beneath this.
   defp retention_sweep_plan(state) do
     Enum.reduce(state.workloads, {[], state}, fn {name, w}, {plan, acc} ->
-      case workload_retention(acc, w) do
-        :skip ->
-          {plan, acc}
+      per_node_outcomes = workload_retention(acc, w)
 
-        {:skip_unexported, node_id} ->
-          entry = %{workload: name, evict_refs: [], evict_bytes: 0, skipped_unexported: true, node_id: node_id}
-          {[entry | plan], acc}
+      Enum.reduce(per_node_outcomes, {plan, acc}, fn outcome, {p, a} ->
+        case outcome do
+          :skip ->
+            {p, a}
 
-        {:evict, node_id, refs, bytes} ->
-          entry = %{workload: name, evict_refs: refs, evict_bytes: bytes, skipped_unexported: false, node_id: node_id}
-          acc = apply_retention(acc, name, node_id, refs, bytes)
-          {[entry | plan], acc}
-      end
+          {:skip_unexported, node_id} ->
+            entry = %{workload: name, evict_refs: [], evict_bytes: 0, skipped_unexported: true, node_id: node_id}
+            {[entry | p], a}
+
+          {:evict, node_id, refs, bytes} ->
+            entry = %{workload: name, evict_refs: refs, evict_bytes: bytes, skipped_unexported: false, node_id: node_id}
+            {[entry | p], apply_retention(a, name, node_id, refs, bytes)}
+        end
+      end)
     end)
     |> then(fn {plan, acc} -> {Enum.reverse(plan), acc} end)
   end
 
-  # Decide one workload's retention outcome from the node's reported facts:
-  #   :skip                          - not placed, no node fact, or nothing to evict
-  #   {:skip_unexported, node_id}    - current base present but not yet exported
-  #   {:evict, node_id, refs, bytes} - superseded local bases to evict + their bytes
+  # Decide one retention outcome per capacity fact from the node's reported facts:
+  #   :skip                          - no local base or nothing to evict
+  #   {:skip_unexported, node_id}    - this node's current base is not exported
+  #   {:evict, node_id, refs, bytes} - this node's local bases to evict + bytes
   defp workload_retention(state, w) do
-    cur = current_instance_on_node(state, w.node_id, w.name)
-
-    with true <- is_binary(w.node_id) and is_binary(w.snapshot_ref),
-         {:ok, fact} <- find_capacity_fact(state.capacity_table, cur),
-         locals when is_list(locals) <- Map.get(fact, :local_bases, []) do
-      current_exported? =
-        case get_in(fact, [:workloads, w.name]) do
-          %{snapshot_ref: ref, exported: exported} -> ref == w.snapshot_ref and exported == true
-          _ -> false
-        end
+    for fact <- Embervm.NodeCapacity.all(state.capacity_table),
+        is_list(Map.get(fact, :local_bases, [])),
+        # Deliberate: skip nodes that have local bases but do not report this
+        # workload in :workloads (unknown current ref). Without the node's own
+        # current ref we cannot safely pick eviction candidates; such bases stay
+        # resident. This is the conservative choice, though it may leave orphans
+        # from pre-noded implementations that never tracked bases per-workload.
+        Map.has_key?(Map.get(fact, :workloads, %{}), w.name) do
+      node_ref = get_in(fact, [:workloads, w.name, :snapshot_ref])
 
       cond do
-        not current_exported? ->
-          # Durability floor not yet confirmed for this workload: skip it whole.
-          {:skip_unexported, cur}
+        not is_binary(node_ref) or node_ref == "" ->
+          :skip
+
+        get_in(fact, [:workloads, w.name, :exported]) != true ->
+          {:skip_unexported, fact[:instance_id]}
 
         true ->
-          desired = desired_refs(w)
+          desired = desired_refs_for_node(node_ref, w)
 
-          # A candidate is any local base for this workload that is NOT desired and
-          # NOT currently BUILDING. READY superseded versions AND unregistered/.tmp
-          # orphan dirs (base_state UNSPECIFIED) are both candidates, so the reclaim
-          # drains the orphans too; a BUILDING ref is never a candidate (it is being
-          # written, and noded refuses it as the final backstop). The current ref is
-          # excluded via `desired`, and durability-before-eviction gated this whole
-          # workload above.
           candidates =
-            for b <- locals,
+            for b <- Map.get(fact, :local_bases, []),
                 b.workload == w.name,
                 b.base_state != :BASE_BUILD_STATE_BUILDING,
                 b.ref not in desired,
@@ -1618,26 +1637,35 @@ defmodule Embervm.BaseBuilder do
           else
             refs = Enum.map(candidates, & &1.ref)
             bytes = candidates |> Enum.map(&(&1.size_bytes || 0)) |> Enum.sum()
-            {:evict, cur, refs, bytes}
+            {:evict, fact[:instance_id], refs, bytes}
           end
       end
-    else
-      _ -> :skip
     end
   end
 
-  # The desired base refs for a workload: its CURRENT ref, PLUS every superseded
-  # ref the CP still refcounts (a base_refs entry that is not yet evicted, so a
-  # primed VM or pinned session may still ride it). A ref whose refcounts drained
-  # and fired an eviction (evicted: true) is NOT desired: it is a candidate. This
-  # keeps the sweep from ever removing a base a live VM or banked session still
-  # needs, independent of noded's own in-use guard.
-  defp desired_refs(w) do
+  # The desired base refs for a workload: its CURRENT ref on the node being
+  # swept, PLUS the CP's recorded snapshot_ref (in case the node's ref has moved
+  # ahead and the CP's ref is still on disk but not yet in S3), PLUS every
+  # superseded ref the CP still refcounts (a base_refs entry that is not yet
+  # evicted, so a primed VM or pinned session may still ride it). A ref whose
+  # refcounts drained and fired an eviction (evicted: true) is NOT desired: it is
+  # a candidate. This keeps the sweep from ever removing a base a live VM or
+  # banked session still needs, independent of noded's own in-use guard.
+  #
+  # Protecting the CP's ref: if a node has moved ahead to a newer current ref
+  # (vendor-specific turnover), the sweep MUST NOT evict the old CP ref that is
+  # still on disk but has not yet reached S3 (export has not completed). Including
+  # both refs at most retains one extra base until export finishes and the CP
+  # advances its snapshot_ref; the alternative is a window where eviction deletes
+  # the exact ref the CP considers current.
+  defp desired_refs_for_node(node_ref, w) do
     superseded_desired =
       for {ref, entry} <- w.base_refs, not Map.get(entry, :evicted, false), do: ref
 
-    [w.snapshot_ref | superseded_desired]
+    [node_ref, w.snapshot_ref | superseded_desired]
+    |> Enum.uniq()
   end
+
 
   # Apply the gated retention action for one workload. Gate OFF: log the dry-run
   # (count + total bytes) and change nothing. Gate ON: spawn an idempotent
@@ -1706,58 +1734,68 @@ defmodule Embervm.BaseBuilder do
       # An export RPC for this exact ref is already in flight; skip a redundant one.
       state
     else
-      owner = self()
       address = state.node_addr[node_id]
-      connect_fun = state.connect_fun
-      disconnect_fun = state.disconnect_fun
-      export_fun = state.export_fun
-      op_log = state.op_log
-      op_log_mod = state.op_log_mod
-      tenant = state.tenant
-      clock = state.clock
 
-      spawn(fn ->
-        try do
-          result =
-            case connect_fun.(address) do
-              {:ok, channel} ->
-                try do
-                  export_fun.(channel, %ExportArtifactRequest{
-                    artifact: %ArtifactRef{
-                      kind: :ARTIFACT_KIND_BASE,
-                      workload: workload,
-                      ref: ref
-                    },
-                    trace: %Trace{workload: workload}
-                  })
-                catch
-                  kind, reason -> {:error, {kind, reason}}
-                after
-                  disconnect_fun.(channel)
-                end
+      if is_nil(address) do
+        Logger.warning(
+          "embervm base builder: ExportArtifact skipped because node address is unavailable",
+          instance_id: node_id
+        )
 
-              {:error, reason} ->
-                {:error, {:connect, reason}}
+        state
+      else
+        owner = self()
+        connect_fun = state.connect_fun
+        disconnect_fun = state.disconnect_fun
+        export_fun = state.export_fun
+        op_log = state.op_log
+        op_log_mod = state.op_log_mod
+        tenant = state.tenant
+        clock = state.clock
+
+        spawn(fn ->
+          try do
+            result =
+              case connect_fun.(address) do
+                {:ok, channel} ->
+                  try do
+                    export_fun.(channel, %ExportArtifactRequest{
+                      artifact: %ArtifactRef{
+                        kind: :ARTIFACT_KIND_BASE,
+                        workload: workload,
+                        ref: ref
+                      },
+                      trace: %Trace{workload: workload}
+                    })
+                  catch
+                    kind, reason -> {:error, {kind, reason}}
+                  after
+                    disconnect_fun.(channel)
+                  end
+
+                {:error, reason} ->
+                  {:error, {:connect, reason}}
+              end
+
+            case result do
+              {:ok, resp} ->
+                record_base_exported(op_log_mod, op_log, tenant, clock, workload, ref, resp)
+
+              other ->
+                Logger.warning(
+                  "embervm base builder: ExportArtifact #{workload}/#{ref} failed: #{inspect(other)}"
+                )
             end
-
-          case result do
-            {:ok, resp} ->
-              record_base_exported(op_log_mod, op_log, tenant, clock, workload, ref, resp)
-
-            other ->
-              Logger.warning(
-                "embervm base builder: ExportArtifact #{workload}/#{ref} failed: #{inspect(other)}"
-              )
+          after
+            # Always clear the in-flight key: on success, on a logged failure, and on any
+            # raise from connect_fun/disconnect_fun that skips the case above. A stuck key
+            # would permanently skip this ref's re-export.
+            send(owner, {:export_done, key})
           end
-        after
-          # Always clear the in-flight key: on success, on a logged failure, and on any
-          # raise from connect_fun/disconnect_fun that skips the case above. A stuck key
-          # would permanently skip this ref's re-export.
-          send(owner, {:export_done, key})
-        end
-      end)
+        end)
 
-      %{state | exports_in_flight: MapSet.put(state.exports_in_flight, key)}
+        %{state | exports_in_flight: MapSet.put(state.exports_in_flight, key)}
+      end
     end
   end
 

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -1101,11 +1101,32 @@ defmodule Embervm.BaseBuilder do
   defp node_name(id) when is_binary(id), do: id |> String.split("/", parts: 2) |> hd()
   defp node_name(_), do: nil
 
+  # Group capacity facts by their physical node. Base ownership is a NODE property:
+  # bases live on the node's shared hostPath scratch, so retention and export are
+  # computed once per node even when several bricks run there.
+  defp capacity_facts_by_node(state) do
+    state.capacity_table
+    |> Embervm.NodeCapacity.all()
+    |> Enum.group_by(&node_name(Map.get(&1, :instance_id)))
+  end
+
+  # Pick one node representative, preferring a brick that reports the workload's
+  # base. Any brick on the node can export or evict the shared local base inventory.
+  defp representative_fact(facts, workload) do
+    Enum.find(facts, fn f -> get_in(f, [:workloads, workload]) != nil end) || List.first(facts)
+  end
+
+  defp representative_facts_by_node(state, workload) do
+    for {_node, facts} <- capacity_facts_by_node(state),
+        fact = representative_fact(facts, workload),
+        fact != nil,
+        do: fact
+  end
+
   # Map a (possibly stale) placement instance_id to the CURRENT registered instance
   # on the SAME node, preferring one whose reported facts already include `workload`'s
-  # base (node-mates share the hostPath scratch, so any current instance can
-  # export/evict it). Falls back to the original id when no current node-mate is
-  # registered, so the path behaves exactly as before rather than acting on a guess.
+  # base. Falls back to the original id when no current node-mate is registered, so
+  # the path behaves exactly as before rather than acting on a guess.
   #
   # Base ownership is a NODE property: a built base lives on the node's hostPath
   # scratch and survives a noded pod restart, but the build-time placement instance_id
@@ -1116,17 +1137,9 @@ defmodule Embervm.BaseBuilder do
   defp current_instance_on_node(state, stale_id, workload) do
     target = node_name(stale_id)
 
-    mates =
-      state.capacity_table
-      |> Embervm.NodeCapacity.all()
-      |> Enum.filter(fn f -> node_name(Map.get(f, :instance_id)) == target end)
-
-    reporter = Enum.find(mates, fn f -> get_in(f, [:workloads, workload]) != nil end)
-
-    cond do
-      reporter != nil -> Map.get(reporter, :instance_id)
-      mates != [] -> mates |> hd() |> Map.get(:instance_id)
-      true -> stale_id
+    case state |> capacity_facts_by_node() |> Map.get(target, []) |> representative_fact(workload) do
+      nil -> stale_id
+      fact -> Map.get(fact, :instance_id)
     end
   end
 
@@ -1462,12 +1475,12 @@ defmodule Embervm.BaseBuilder do
     state = put_in(state.workloads[w.name], w)
 
     # Base-durability PR-1: drive the durability floor using each node's own
-    # vendor-specific current ref. The periodic export reconcile remains the
-    # backstop if a result is lost or the store was down.
-    facts = Embervm.NodeCapacity.all(state.capacity_table)
-
+    # vendor-specific current ref. Base ownership is a NODE property, so shared
+    # hostPath scratch is exported once per node even when several bricks report it.
+    # The periodic export reconcile remains the backstop if a result is lost or the
+    # store was down.
     export_targets =
-      Enum.flat_map(facts, fn fact ->
+      Enum.flat_map(representative_facts_by_node(state, w.name), fn fact ->
         case get_in(fact, [:workloads, w.name]) do
           nil -> []
           workload_fact -> [{fact[:instance_id], workload_fact}]
@@ -1573,11 +1586,13 @@ defmodule Embervm.BaseBuilder do
   # gated action. The plan is returned for tests/visibility; the action is the
   # spawned evictions (gate on) or the dry-run log (gate off).
   #
-  # For each capacity fact with a current, exported local base, candidates are
-  # local bases minus the node's current ref and still-refcounted superseded refs.
-  # BUILDING local bases are never candidates, and an unexported current base only
-  # blocks eviction on that same node. noded's in-use/current/BUILDING guard is the
-  # final backstop beneath this.
+  # For each node with a current, exported local base, candidates are local bases
+  # minus the node's current ref and still-refcounted superseded refs. Base ownership
+  # is a NODE property because bases live on shared hostPath scratch, so each node is
+  # considered once even when several bricks report the same local inventory. BUILDING
+  # local bases are never candidates, and an unexported current base only blocks
+  # eviction on that same node. noded's in-use/current/BUILDING guard is the final
+  # backstop beneath this.
   defp retention_sweep_plan(state) do
     Enum.reduce(state.workloads, {[], state}, fn {name, w}, {plan, acc} ->
       per_node_outcomes = workload_retention(acc, w)
@@ -1600,12 +1615,12 @@ defmodule Embervm.BaseBuilder do
     |> then(fn {plan, acc} -> {Enum.reverse(plan), acc} end)
   end
 
-  # Decide one retention outcome per capacity fact from the node's reported facts:
+  # Decide one retention outcome per node from the representative reported facts:
   #   :skip                          - no local base or nothing to evict
   #   {:skip_unexported, node_id}    - this node's current base is not exported
   #   {:evict, node_id, refs, bytes} - this node's local bases to evict + bytes
   defp workload_retention(state, w) do
-    for fact <- Embervm.NodeCapacity.all(state.capacity_table),
+    for fact <- representative_facts_by_node(state, w.name),
         is_list(Map.get(fact, :local_bases, [])),
         # Deliberate: skip nodes that have local bases but do not report this
         # workload in :workloads (unknown current ref). Without the node's own

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -925,6 +925,68 @@ defmodule Embervm.BaseBuilderTest do
     refute_receive {:evicted, "w", "w__old_amd"}, 200
   end
 
+  test "retention and export run once for two bricks sharing a node's base inventory" do
+    agent = start_recorder()
+    test_pid = self()
+    table = new_cap_table()
+
+    put_brick(table, "node-4", "large", size_class: "16gi", mem_budget: 16_384, mem_headroom: 16_000)
+    put_brick(table, "node-4", "small", size_class: "2gi", mem_budget: 2_048, mem_headroom: 2_000)
+
+    local_bases = [
+      ready_base("w__current", "w", 512),
+      ready_base("w__old", "w", 2_048)
+    ]
+
+    put_node_local_bases_fact(table, "node-4", "large", "w", "w__current", false, local_bases)
+    put_node_local_bases_fact(table, "node-4", "small", "w", "w__current", false, local_bases)
+
+    export_fun = fn :fake_channel, %Embervm.Node.V1.ExportArtifactRequest{artifact: ref} ->
+      send(test_pid, {:exported, ref.ref})
+      {:ok, %Embervm.Node.V1.ExportArtifactResponse{bytes_moved: 0, skipped: true, generation: 0}}
+    end
+
+    evict_fun = fn :fake_channel, workload, ref ->
+      send(test_pid, {:evicted, workload, ref})
+      {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
+    end
+
+    builder =
+      start_builder(
+        nodes: [
+          %{id: "node-4/large", address: "large"},
+          %{id: "node-4/small", address: "small"}
+        ],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: fn :fake_channel, _req -> {:ok, resp("w__current")} end,
+        export_fun: export_fun,
+        evict_fun: evict_fun,
+        retention_sweep_enabled: true
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "w__current" end)
+
+    assert_receive {:exported, "w__current"}, 1_000
+    refute_receive {:exported, "w__current"}, 100
+
+    # Export coalescing needs the unexported facts above. Retention, however, is
+    # gated on durability, so update both node-mate facts before asserting that the
+    # shared inventory is planned and evicted once.
+    put_node_local_bases_fact(table, "node-4", "large", "w", "w__current", true, local_bases)
+    put_node_local_bases_fact(table, "node-4", "small", "w", "w__current", true, local_bases)
+
+    plan = BaseBuilder.retention_sweep_now(builder)
+    entries = Enum.filter(plan, &(&1.workload == "w"))
+    assert length(entries) == 1
+    assert hd(entries).evict_refs == ["w__old"]
+    assert hd(entries).evict_bytes == 2_048
+
+    assert_receive {:evicted, "w", "w__old"}, 1_000
+    refute_receive {:evicted, "w", "w__old"}, 100
+  end
+
 
   test "export skips targets without node_addr entries and logs warning" do
     agent = start_recorder()

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -90,7 +90,7 @@ defmodule Embervm.BaseBuilderTest do
         [
           name: nil,
           nodes: Keyword.get(opts, :nodes, [@node]),
-          connect_fun: fn _addr -> {:ok, :fake_channel} end,
+          connect_fun: Keyword.get(opts, :connect_fun, fn _addr -> {:ok, :fake_channel} end),
           disconnect_fun: fn :fake_channel -> :ok end,
           # Base-durability PR-1 defaults for tests that do not exercise export:
           # a no-op export seam (so a build's immediate export never dials the real
@@ -110,6 +110,7 @@ defmodule Embervm.BaseBuilderTest do
         ] ++
           Keyword.drop(opts, [
             :export_fun,
+            :connect_fun,
             :export_reconcile_interval_ms,
             :retention_sweep_interval_ms,
             :op_log,
@@ -700,6 +701,27 @@ defmodule Embervm.BaseBuilderTest do
     })
   end
 
+  defp put_node_local_bases_fact(table, node_id, pod_uid, workload, current_ref, exported?, local_bases) do
+    existing =
+      case :ets.lookup(table, {node_id, pod_uid}) do
+        [{_key, facts}] -> facts
+        [] -> %{node_id: node_id, configured_id: node_id, instance_id: "#{node_id}/#{pod_uid}"}
+      end
+
+    workloads =
+      Map.put(Map.get(existing, :workloads, %{}), workload, %{
+        snapshot_ref: current_ref,
+        base_state: :BASE_BUILD_STATE_READY,
+        exported: exported?
+      })
+
+    NodeCapacity.put(
+      table,
+      {node_id, pod_uid},
+      Map.merge(existing, %{workloads: workloads, local_bases: local_bases, updated_at: 0})
+    )
+  end
+
   defp ready_base(ref, workload, bytes) do
     %{ref: ref, workload: workload, size_bytes: bytes, base_state: :BASE_BUILD_STATE_READY}
   end
@@ -838,6 +860,112 @@ defmodule Embervm.BaseBuilderTest do
     assert entry.evict_refs == []
     refute_receive {:evicted, "w", "w__orphan1"}, 200
   end
+
+  test "retention sweep and export per node when fleet has mixed vendors" do
+    agent = start_recorder()
+    test_pid = self()
+    table = new_cap_table()
+
+    put_brick(table, "node-1", "intel", size_class: "16gi", mem_budget: 16_384, mem_headroom: 16_000)
+    put_brick(table, "node-4", "amd", size_class: "16gi", mem_budget: 16_384, mem_headroom: 16_000)
+
+    put_node_local_bases_fact(table, "node-1", "intel", "w", "w__intel", true, [
+      ready_base("w__intel", "w", 512),
+      ready_base("w__old_intel", "w", 2_048)
+    ])
+
+    put_node_local_bases_fact(table, "node-4", "amd", "w", "w__amd", false, [
+      ready_base("w__amd", "w", 512),
+      ready_base("w__old_amd", "w", 4_096)
+    ])
+
+    export_fun = fn :fake_channel, %Embervm.Node.V1.ExportArtifactRequest{artifact: ref} ->
+      send(test_pid, {:exported, ref.ref})
+      {:ok, %Embervm.Node.V1.ExportArtifactResponse{bytes_moved: 0, skipped: true, generation: 0}}
+    end
+
+    connect_fun = fn address ->
+      send(test_pid, {:connected, address})
+      {:ok, :fake_channel}
+    end
+
+    builder =
+      start_builder(
+        nodes: [
+          %{id: "node-1/intel", address: "node-1/intel"},
+          %{id: "node-4/amd", address: "node-4/amd"}
+        ],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: fn :fake_channel, _req -> {:ok, resp("w__intel")} end,
+        connect_fun: connect_fun,
+        export_fun: export_fun,
+        retention_sweep_enabled: true
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "w__intel" end)
+
+    assert_receive {:connected, "node-4/amd"}, 1_000
+    assert_receive {:exported, "w__amd"}, 1_000
+    refute_receive {:exported, "w__intel"}, 100
+    refute_receive {:connected, "node-4/amd"}, 100
+
+    plan = BaseBuilder.retention_sweep_now(builder)
+    assert Enum.count(plan, &(&1.workload == "w")) == 2
+
+    intel = Enum.find(plan, &(&1.node_id == "node-1/intel"))
+    assert intel.skipped_unexported == false
+    assert intel.evict_refs == ["w__old_intel"]
+    assert intel.evict_bytes == 2_048
+
+    amd = Enum.find(plan, &(&1.node_id == "node-4/amd"))
+    assert amd.skipped_unexported == true
+    assert amd.evict_refs == []
+    refute_receive {:evicted, "w", "w__old_amd"}, 200
+  end
+
+
+  test "export skips targets without node_addr entries and logs warning" do
+    agent = start_recorder()
+    test_pid = self()
+    table = new_cap_table()
+
+    # Set up a capacity fact for a node that has NO entry in state.node_addr
+    put_node_local_bases_fact(table, "node-99", "unknown", "w", "w__unknown", false, [
+      ready_base("w__unknown", "w", 512)
+    ])
+
+    export_fun = fn :fake_channel, %Embervm.Node.V1.ExportArtifactRequest{artifact: ref} ->
+      send(test_pid, {:exported, ref.ref})
+      {:ok, %Embervm.Node.V1.ExportArtifactResponse{bytes_moved: 0, skipped: true, generation: 0}}
+    end
+
+    connect_fun = fn address ->
+      send(test_pid, {:connected, address})
+      {:ok, :fake_channel}
+    end
+
+    # Builder has no entry for "node-99/unknown" in nodes list, so it has no address
+    builder =
+      start_builder(
+        nodes: [%{id: "node-1/intel", address: "node-1/intel"}],
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: fn :fake_channel, _req -> {:ok, resp("w__intel")} end,
+        connect_fun: connect_fun,
+        export_fun: export_fun
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "w__intel" end)
+
+    # Export should target node-99/unknown, but the nil-address guard skips it
+    # (it logs a warning instead of trying to dial nil)
+    refute_receive {:connected, "node-99/unknown"}, 500
+    refute_receive {:exported, "w__unknown"}, 500
+  end
+
 
   test "retention sweep never evicts a still-refcounted superseded ref" do
     agent = start_recorder()

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.235
+      targetRevision: 0.1.236
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Why

The base-retention drain has never evicted anything, fleet-wide, and it filled two
of the three Intel bricks to 0 bytes free tonight. Once a brick is full, the current
base cannot be written (`no space left on device`), so wakes degrade to cold and then
fail `:no_capacity`.

Root cause, verified live and different from what #3992 records:

noded derives base refs as `<workload>__hash(digest + revision + VENDOR)` node-side
(`base_builder.ex:586`), so a ref is vendor-specific by design. Firecracker snapshots
cannot cross CPU vendors, and ADR embervm/011 already decided per-vendor bases keyed
`(workload, vendor)`. noded implements that: vendor detection, `(CpuVendor, CpuTemplate)`
stamping, vendor-segmented store keys `base/<vendor>/<workload>/<ref>`, fail-closed sku
gates.

The control plane never did. It keeps ONE `w.snapshot_ref` per workload and drove export
against ONE anchor node, and `base_builder.ex:826` says why out loud: "today's
single-vendor fleet". That stopped being true when the Intel masters joined. node-1/2/3
are Intel, node-4 is AMD, so the CP was handing node-4 an Intel-keyed ref:

```
ExportArtifact scratch-postgres/scratch-postgres__bbcde555ed07 failed:
  noded: local artifact "base/amd/scratch-postgres/scratch-postgres__bbcde555ed07"
  absent or empty (nothing to export)
```

Export never confirmed, so no base was ever `exported: true`, so `workload_retention/2`
returned `:skip_unexported` and evicted nothing, for every workload, on every node.

For the record, #3992's suspicion of timestamp-tag rootfs churn was wrong: those
`rootfs-2026.07.*.ext4` files all share one inode (hardlinks), so they cost a single
copy. The disk hog is `snapshots/bases/*/memfile`, 2 to 3 GB per bundle.

## What

Make export and retention operate PER NODE, using each node's own reported ref.

- Export fans out over capacity facts, sending each node the ref that node actually
  reports. When no fact reports the workload yet (the base-advert dial-home window),
  it falls back to the previous anchor-node export, so a freshly built base is never
  left unexported.
- `workload_retention/2` returns one outcome per node. Each node gates on its OWN
  `exported` flag and evicts only its OWN superseded refs, so an unexported current on
  one node no longer suppresses eviction everywhere.
- The desired (never-evict) set is `[node_ref, w.snapshot_ref | still-refcounted]`, so
  the sweep can never delete the ref the CP considers current even if a node's ref has
  moved ahead and the CP's has not reached S3 yet.
- `spawn_export/4` skips a target with no `node_addr` entry and logs it, instead of
  dialling `nil`. That is the #3986 crash class; the per-node fan-out can reach
  instances the old anchor path could not.

Deliberately NOT in scope: `snapshot_ref` stays a single string. Widening it to a
`vendor -> ref` map touches 12 CP modules and the CR status, and is Stage 2. That stage
also fixes placement steering, which currently sends `scratch-postgres` to node-4 for an
Intel-keyed base and fails on `pressure:mem`.

## Verification

`ci test` green: 957 tests, 0 failures.

New coverage: a mixed-vendor fleet exports each node's own ref and splits the retention
plan per node; a node whose current is unexported does not suppress eviction on another
node (the exact regression behind the outage); and a target with no `node_addr` entry is
skipped without dialling.

Note one flake seen mid-review, unrelated and untouched: `DrainCoordinatorTest "an
instance-scoped drain (4-tuple) records the pod_uid on the ops"` uses the default 100ms
`assert_receive` window and failed once under load on a diff confined to `base_builder.ex`.

## Ops note

This change cannot recover a brick already at 100%: eviction needs a successful export,
export needs the base present, and building it needs free disk. I reclaimed 15.3G per
brick by hand tonight (12 superseded bundles each; node-1 0 -> 15.1G free, node-2 2.4 ->
17.7G, node-3 0 -> 13.5G). This PR is what stops it recurring.

Refs #3992.
