### PR TITLE
fix(embervm): exclude reclaimable page cache from brick memory headroom

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.238
+version: 0.1.239

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.238
+      targetRevision: 0.1.239
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/budget.go
+++ b/projects/embervm/noded/server/budget.go
@@ -135,7 +135,9 @@ func (b *budget) MemBudgetMib() uint64 {
 
 // MemHeadroomMib returns free schedulable guest memory in MiB. Identical
 // semantics to the retired readMemHeadroomMib, folded in here so the daemon
-// has one cgroup reader instead of two.
+// has one cgroup reader instead of two. An unreadable memory.stat falls back
+// to max minus current, which is conservative because it does not subtract
+// any unverified reclaimable cache.
 func (b *budget) MemHeadroomMib() uint64 {
 	dir := cgroupDir()
 	maxRaw, err := os.ReadFile(filepath.Join(dir, "memory.max"))
@@ -146,7 +148,11 @@ func (b *budget) MemHeadroomMib() uint64 {
 	if err != nil {
 		return 0
 	}
-	return parseMemHeadroomMib(string(maxRaw), string(curRaw))
+	statRaw, err := os.ReadFile(filepath.Join(dir, "memory.stat"))
+	if err != nil {
+		statRaw = nil
+	}
+	return parseMemHeadroomMib(string(maxRaw), string(curRaw), string(statRaw))
 }
 
 // CpuBudgetMillicores returns the cgroup v2 cpu.max quota/period pair
@@ -283,26 +289,48 @@ func (s *Server) StartBudgetLoop(ctx context.Context) {
 	}()
 }
 
-// parseMemHeadroomMib computes (max-current) in MiB from cgroup v2
-// memory.max and memory.current contents. "max" (unlimited) or a parse error
-// yields 0. Folded in from the retired free-function readMemHeadroomMib.
-func parseMemHeadroomMib(maxRaw, curRaw string) uint64 {
+// parseMemHeadroomMib computes headroom in MiB from cgroup v2 memory.max,
+// memory.current, and memory.stat contents. "max" (unlimited) or a parse
+// error yields 0. Folded in from the retired free-function readMemHeadroomMib.
+func parseMemHeadroomMib(maxRaw, curRaw, statRaw string) uint64 {
 	maxStr := strings.TrimSpace(maxRaw)
 	if maxStr == "max" || maxStr == "" {
 		return 0
 	}
 	maxB, err := strconv.ParseInt(maxStr, 10, 64)
-	if err != nil {
+	if err != nil || maxB < 0 {
 		return 0
 	}
 	curB, err := strconv.ParseInt(strings.TrimSpace(curRaw), 10, 64)
-	if err != nil {
+	if err != nil || curB < 0 {
 		return 0
 	}
-	if curB >= maxB {
+	workingSetB := curB
+	for _, line := range strings.Split(statRaw, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || fields[0] != "inactive_file" {
+			continue
+		}
+		inactiveFileB, statErr := strconv.ParseUint(fields[1], 10, 64)
+		if statErr != nil {
+			break
+		}
+		// kubelet uses inactive_file for working_set because this cache is
+		// reclaimed first under pressure. Do not subtract all file cache,
+		// or anon plus slab, since those are not equivalent eviction signals.
+		// The cgroup files are read separately, so inactive_file can race
+		// memory.current. Keep the conservative current-based working set when
+		// the sample is racy instead of treating it as fully reclaimable.
+		if inactiveFileB < uint64(curB) {
+			workingSetB = curB - int64(inactiveFileB)
+		}
+		break
+	}
+
+	if uint64(maxB) <= uint64(workingSetB) {
 		return 0
 	}
-	return uint64(maxB-curB) / (1 << 20)
+	return (uint64(maxB) - uint64(workingSetB)) / (1 << 20)
 }
 
 // parseMemBudgetMib computes (max - reserve) in MiB from cgroup v2

--- a/projects/embervm/noded/server/budget_test.go
+++ b/projects/embervm/noded/server/budget_test.go
@@ -31,8 +31,9 @@ func writeBudgetFile(t *testing.T, name, content string) {
 
 func TestBudgetReadsCgroupV2(t *testing.T) {
 	withBudgetFsRoot(t, map[string]string{
-		"memory.max":     "4294967296\n",    // 4 GiB
-		"memory.current": "1073741824\n",    // 1 GiB
+		"memory.max":     "4294967296\n", // 4 GiB
+		"memory.current": "1073741824\n", // 1 GiB
+		"memory.stat":    "inactive_file 0\n",
 		"cpu.max":        "200000 100000\n", // 2 cores
 		"cpu.stat":       "usage_usec 1000000\nnr_periods 5\n",
 	})
@@ -66,6 +67,72 @@ func TestUnlimitedCgroupReportsZero(t *testing.T) {
 	}
 	if got := b.CpuBudgetMillicores(); got != 0 {
 		t.Errorf("CpuBudgetMillicores() on unlimited cgroup = %d, want 0 (unknown)", got)
+	}
+}
+
+func TestMemHeadroomFallsBackWhenMemoryStatUnreadable(t *testing.T) {
+	withBudgetFsRoot(t, map[string]string{
+		"memory.max":     "4294967296\n",
+		"memory.current": "1073741824\n",
+	})
+
+	if got, want := newBudget(0).MemHeadroomMib(), uint64(3072); got != want {
+		t.Errorf("MemHeadroomMib() without memory.stat = %d, want %d", got, want)
+	}
+}
+
+func TestParseMemHeadroomMibWithPageCache(t *testing.T) {
+	cases := []struct {
+		name                    string
+		maxRaw, curRaw, statRaw string
+		want                    uint64
+	}{
+		{
+			name:    "issue 4058 reclaimable cache",
+			maxRaw:  "2147483648",
+			curRaw:  "1482084352",
+			statRaw: "inactive_file 1263054848\n",
+			want:    1839,
+		},
+		{
+			name:    "current equals max with reclaimable",
+			maxRaw:  "2147483648",
+			curRaw:  "2147483648",
+			statRaw: "inactive_file 1073741824\n",
+			want:    1024,
+		},
+		{
+			name:    "stat missing falls back to max minus current",
+			maxRaw:  "2147483648",
+			curRaw:  "1482084352",
+			statRaw: "",
+			want:    634,
+		},
+		{name: "missing stat", maxRaw: "4294967296", curRaw: "1073741824", want: 3072},
+		{
+			name:    "stat without inactive file",
+			maxRaw:  "4294967296",
+			curRaw:  "1073741824",
+			statRaw: "anon 123456\nfile 987654\n",
+			want:    3072,
+		},
+		{
+			name:    "racy inactive file",
+			maxRaw:  "2147483648",
+			curRaw:  "536870912",
+			statRaw: "inactive_file 1073741824\n",
+			want:    1536,
+		},
+		{name: "unlimited", maxRaw: "max", curRaw: "1073741824", statRaw: "inactive_file 1\n", want: 0},
+		{name: "invalid inputs", maxRaw: "garbage", curRaw: "1", statRaw: "inactive_file 1\n", want: 0},
+		{name: "invalid current", maxRaw: "2147483648", curRaw: "garbage", statRaw: "inactive_file 1\n", want: 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := parseMemHeadroomMib(c.maxRaw, c.curRaw, c.statRaw); got != c.want {
+				t.Errorf("parseMemHeadroomMib(%q, %q, %q) = %d, want %d", c.maxRaw, c.curRaw, c.statRaw, got, c.want)
+			}
+		})
 	}
 }
 
@@ -222,6 +289,9 @@ func TestCgroupDirResolvesHostNsPath(t *testing.T) {
 	}
 	if err := os.WriteFile(filepath.Join(leaf, "memory.current"), []byte("536870912\n"), 0o644); err != nil {
 		t.Fatalf("write leaf memory.current: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(leaf, "memory.stat"), []byte("inactive_file 0\n"), 0o644); err != nil {
+		t.Fatalf("write leaf memory.stat: %v", err)
 	}
 	withSelfCgroup(t, "0::/kubepods.slice/cri-containerd-abc.scope\n")
 

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -1160,8 +1160,8 @@ func TestParseMemHeadroomMib(t *testing.T) {
 		{"104857600\n", "4194304\n", 96}, // 100MiB - 4MiB
 	}
 	for _, c := range cases {
-		if got := parseMemHeadroomMib(c.maxRaw, c.curRaw); got != c.want {
-			t.Errorf("parseMemHeadroomMib(%q,%q) = %d, want %d", c.maxRaw, c.curRaw, got, c.want)
+		if got := parseMemHeadroomMib(c.maxRaw, c.curRaw, ""); got != c.want {
+			t.Errorf("parseMemHeadroomMib(%q,%q,%q) = %d, want %d", c.maxRaw, c.curRaw, "", got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
## Why

Brick admission control counted reclaimable page cache as used memory, so a brick that had
just done heavy file I/O refused to admit VMs despite having almost all of its memory free.

This is self-defeating, because the operation that generates the most page cache IS base
build and base export (writing and reading multi-GB memfiles). A brick builds a base, fills
its cgroup with that memfile's page cache, and then rejects the VM the base was built for.

Measured live on node-2's brick while `scratch-postgres` was failing to wake at ~20/min:

```
memory.max        2147483648   = 2048 MiB
memory.current    1482084352   = 1413 MiB
  anon              12521472   =   12 MiB   <- real process memory
  file            1456840704   = 1389 MiB   <- page cache
  inactive_file   1263054848   = 1204 MiB   <- reclaimable
```

`MemHeadroomMib()` returned `max - current` = 635 MiB, and `memPressured` rejects when
`headroom < need + floor` (`635 < 512 + 512`), producing exactly the observed error:

```
noded: pressure:mem (need 512 MiB, floor 512 MiB)
```

The brick's real process memory was 12 MiB. It rejected a 512 MiB guest while ~1.8G of its
2G was reclaimable cache.

## What changed

`MemHeadroomMib()` now reads `memory.stat` from the SAME resolved `cgroupDir()` and computes:

```
working_set = memory.current - inactive_file
headroom    = memory.max - working_set
```

On the numbers above that is `2048 - (1413 - 1204) = 1839 MiB`, which correctly admits.

`inactive_file` is the deliberate choice: it is what the kernel reclaims first under pressure,
and it is the same quantity the kubelet uses for its own `working_set`. Subtracting all of
`file` would ignore that `active_file` may be genuinely hot; using `anon + slab` as "true
usage" would undercount other non-reclaimable allocations.

## Safety properties preserved

Two directions matter here, and both are covered by tests:

- **Fail-open is unchanged.** An unreadable `memory.max` or `memory.current` still returns 0,
  which `memPressured` treats as "unknown ceiling, never a guess" and admits. A missing or
  fieldless `memory.stat` degrades to the OLD `max - current` behaviour rather than returning
  0, so it can never become a licence to admit onto a genuinely full brick.
- **No unsigned underflow.** `inactive_file` can race `memory.current` because the files are
  read separately. When it exceeds `memory.current` the working set stays at `memory.current`
  (the conservative value) rather than wrapping to a huge number and making the brick look
  infinitely free.

Note the read must come from the resolved `cgroupDir()` (which walks `/proc/self/cgroup`), not
from `/sys/fs/cgroup` directly: the bare path yields node-level numbers. Verified live, where
it reported `anon 6066003968 / file 8392298496`, i.e. the whole node.

## Verification

`ci test`: exit 0, 745 tests pass, no build failures.

New table-driven cases cover the measured production numbers (-> 1839, not 635), a cgroup
whose cache has grown to `current == max` (-> real headroom, not 0), a missing `memory.stat`
(-> falls back to `max - current`), a stat file without `inactive_file`, the racy
`inactive_file > current` clamp, and unlimited/unreadable inputs (-> still 0).

## Expected effect

`scratch-postgres` has been failing every placement attempt at roughly 20/min. It should begin
waking once this deploys.

Related: #4054 (the effect scales with base size, so shrinking bazel-query's 3072 MiB helps
twice), #4057, #4056.

Closes #4058
