### PR TITLE
feat(embervm): instrument bazel warm memory measurement (phase 1, #4054)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.239
+version: 0.1.240

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.239
+      targetRevision: 0.1.240
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/bazel/guest-init/cmd/BUILD
+++ b/projects/embervm/runtimes/bazel/guest-init/cmd/BUILD
@@ -22,15 +22,8 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//projects/firecracker/substrate/vsockproto",
-    ] + select({
-        "@rules_go//go/platform:android": [
-            "@org_golang_x_sys//unix",
-        ],
-        "@rules_go//go/platform:linux": [
-            "@org_golang_x_sys//unix",
-        ],
-        "//conditions:default": [],
-    }),
+        "@org_golang_x_sys//unix",
+    ],
 )
 
 go_binary(

--- a/projects/embervm/runtimes/bazel/guest-init/cmd/main.go
+++ b/projects/embervm/runtimes/bazel/guest-init/cmd/main.go
@@ -35,6 +35,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -49,6 +50,7 @@ import (
 	"time"
 
 	"github.com/jomcgi/homelab/projects/firecracker/substrate/vsockproto"
+	"golang.org/x/sys/unix"
 )
 
 // validateExpr rejection reasons, kept as sentinel errors so the tests assert on
@@ -158,6 +160,7 @@ func run(logger *slog.Logger) error {
 			return waitForShutdown(ctx, serveErr, logger)
 		}
 	}
+	logWarmMemoryMetrics(logger)
 	// Log the flip on BOTH sides of ready.Store, so a snapshot pause landing
 	// between the store and a single log line cannot hide the transition.
 	logger.Info("ember-bazel-init: ready flipping")
@@ -167,6 +170,90 @@ func run(logger *slog.Logger) error {
 	// Hold PID 1. Exiting PID 1 panics the guest kernel before noded can snapshot
 	// the base or before a restored clone can answer its one query.
 	return waitForShutdown(ctx, serveErr, logger)
+}
+
+// logWarmMemoryMetrics is temporary instrumentation for GitHub issue #4054.
+// This runs after warming and settling, immediately before ready is flipped:
+// Firecracker captures the guest RAM at that instant when it cuts the warm
+// base snapshot. In particular, tmpfs pages are unevictable, so /tmp usage is
+// a hard floor for memMib. Measurements are best-effort and must never fail
+// the base build.
+func logWarmMemoryMetrics(logger *slog.Logger) {
+	attrs := []any{"phase", "measurement for #4054"}
+
+	var st unix.Statfs_t
+	if err := unix.Statfs("/tmp", &st); err != nil {
+		logger.Warn("ember-bazel-init: tmpfs memory measurement failed", "err", err)
+		errValue := fmt.Sprintf("error: %v", err)
+		attrs = append(attrs,
+			"tmpfs_mib_total", errValue,
+			"tmpfs_mib_used", errValue,
+			"tmpfs_mib_free", errValue,
+		)
+	} else {
+		blockSize := uint64(st.Bsize)
+		total := st.Blocks * blockSize / (1024 * 1024)
+		free := st.Bfree * blockSize / (1024 * 1024)
+		used := total - free
+		attrs = append(attrs,
+			"tmpfs_mib_total", total,
+			"tmpfs_mib_used", used,
+			"tmpfs_mib_free", free,
+		)
+	}
+
+	data, err := os.ReadFile("/proc/meminfo")
+	if err == nil {
+		var fields map[string]uint64
+		fields, err = parseMeminfoFields(string(data))
+		if err == nil {
+			attrs = append(attrs,
+				"mem_total_mib", fields["MemTotal"],
+				"mem_free_mib", fields["MemFree"],
+				"mem_available_mib", fields["MemAvailable"],
+				"mem_cached_mib", fields["Cached"],
+			)
+		}
+	}
+	if err != nil {
+		logger.Warn("ember-bazel-init: /proc/meminfo measurement failed", "err", err)
+		errValue := fmt.Sprintf("error: %v", err)
+		attrs = append(attrs,
+			"mem_total_mib", errValue,
+			"mem_free_mib", errValue,
+			"mem_available_mib", errValue,
+			"mem_cached_mib", errValue,
+		)
+	}
+	logger.Log(context.Background(), slog.LevelInfo, "ember-bazel-init: warm memory metrics", attrs...)
+}
+
+// parseMeminfoFields extracts the requested /proc/meminfo values and converts
+// its kB values to MiB. Requiring all fields keeps a partial measurement from
+// looking complete in the structured snapshot instrumentation.
+func parseMeminfoFields(input string) (map[string]uint64, error) {
+	want := map[string]bool{
+		"MemTotal": true, "MemFree": true, "MemAvailable": true, "Cached": true,
+	}
+	fields := make(map[string]uint64, len(want))
+	for _, line := range strings.Split(input, "\n") {
+		parts := strings.Fields(line)
+		if len(parts) < 2 || !want[strings.TrimSuffix(parts[0], ":")] {
+			continue
+		}
+		name := strings.TrimSuffix(parts[0], ":")
+		value, err := strconv.ParseUint(parts[1], 10, 64)
+		if err != nil || len(parts) != 3 || parts[2] != "kB" {
+			return nil, fmt.Errorf("invalid %s line %q", name, line)
+		}
+		fields[name] = value / 1024
+	}
+	for name := range want {
+		if _, ok := fields[name]; !ok {
+			return nil, fmt.Errorf("missing %s", name)
+		}
+	}
+	return fields, nil
 }
 
 // buildArgv is the SINGLE source of truth for every bazel invocation, warming and

--- a/projects/embervm/runtimes/bazel/guest-init/cmd/main_test.go
+++ b/projects/embervm/runtimes/bazel/guest-init/cmd/main_test.go
@@ -6,6 +6,41 @@ import (
 	"testing"
 )
 
+func TestParseMeminfoFields(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		input   string
+		want    map[string]uint64
+		wantErr bool
+	}{
+		{
+			"success",
+			"MemTotal:       3072000 kB\nMemFree:         245760 kB\nMemAvailable:     319488 kB\nCached:            68608 kB\n",
+			map[string]uint64{"MemTotal": 3000, "MemFree": 240, "MemAvailable": 312, "Cached": 67},
+			false,
+		},
+		{"missing field", "MemTotal: 1024 kB\nMemFree: 512 kB\nCached: 256 kB\n", nil, true},
+		{"malformed value", "MemTotal: nope kB\nMemFree: 512 kB\nMemAvailable: 512 kB\nCached: 256 kB\n", nil, true},
+		{"malformed unit", "MemTotal: 1024 MB\nMemFree: 512 kB\nMemAvailable: 512 kB\nCached: 256 kB\n", nil, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseMeminfoFields(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseMeminfoFields() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseMeminfoFields() error = %v, want nil", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("parseMeminfoFields() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestValidateExpr is the defense-in-depth gate on the visitor-supplied cquery
 // expression (ADR embervm/010 Security; the ember_public edge validates first,
 // this is the guest's independent second gate). It must accept the ordinary


### PR DESCRIPTION
## Why

Phase 1 of #4054, measurement only. No sizing values change here.

`bazel-query` is the fleet's largest base snapshot at `memMib: 3072`. A base bundle is exactly
`memMib` written dense (verified: the exported memfile is 3221225472 bytes = 3072 MiB), so that
cost is paid per version, per node, and again as a RAM reservation when placed at `cap: 2`.

We measured that a RESTORED clone touches only 245-300 MiB. But `memMib` is set by the
WARM-time peak, not serve time, because Firecracker restores a snapshot at the size it was
captured. The documented budget (`runtimes/bazel/README.md` "Sizing") is tmpfs 1536m + `-Xmx1g`
+ ~512 OS = 3072, but nobody has measured what warming ACTUALLY uses.

Guessing is not free: too small a tmpfs fails warming with `ENOSPC`, which fails the base build
and takes the live `/ember/bazel` page down. This PR gets the numbers so phase 2 can set tmpfs,
`-Xmx`, and `memMib` from data in one change.

## What it measures, and when

`logWarmMemoryMetrics` runs after warming completes and immediately BEFORE `ready.Store(true)`.
That instant is the one that matters: Firecracker captures guest RAM there when it cuts the base
snapshot, so that state is what `memMib` must cover.

- **tmpfs occupancy at `/tmp`** via `statfs`: total, used, free. This is the hard floor. `/tmp`
  is mounted `size=1536m` and holds bazel's install base plus the extracted `external/` tree, and
  tmpfs pages are unevictable, so the kernel can never reclaim them under a smaller `memMib`.
- **`/proc/meminfo`**: `MemTotal`, `MemFree`, `MemAvailable`, `Cached`. The gap between
  `MemAvailable` and `MemFree` shows how much of the footprint is reclaimable.

## Deliberately NOT measured: the Skyframe heap

The original plan also ran `bazel info used-heap-size-after-gc` to size `-Xmx`. It was dropped.

That call attaches to the warm server AFTER warming, inside the exact window whose state gets
frozen into the snapshot. `info` is nominally read-only, but we could not establish with
confidence that it never re-analyzes or invalidates, and every future clone restores from that
frozen state. A wrong call there is silent and permanent; the number it buys only refines `-Xmx`,
which is the last 2x toward 512 MiB rather than the first 3x toward 1024.

If that number is wanted later, the safe route is to run `info` during a THROWAWAY warm rather
than the one being snapshotted.

## Safety

Every measurement is best-effort. A failed `statfs` or unreadable `/proc/meminfo` logs a warning
and continues to the ready flip; instrumentation must never prevent a snapshot. The code is
sequential by design (no goroutines or channels) because it sits in the one path that must never
hang: a block here means warming never completes, the base build never finishes, and
`/ember/bazel` breaks.

The comment marks it as temporary instrumentation for #4054 so a later reader knows it can be
removed once the sizing is settled. `buildArgv` is untouched, so its golden test is unaffected.

## Verification

`ci test`: exit 0, 959 tests, 0 failures. Includes a unit test for the `/proc/meminfo` parser.

## Next

Deploy, read `tmpfs_mib_used` and the meminfo figures off the boot log after the base rebuilds,
then phase 2 sets tmpfs and `memMib` together (3072 -> ~1024 expected).

Refs #4054
