### PR TITLE
fix(embervm): reap base snapshots left behind by deleted workloads

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.241
+version: 0.1.242

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -270,6 +270,18 @@ defmodule Embervm.BaseBuilder do
     GenServer.call(server, :retention_sweep_now)
   end
 
+  @doc """
+  Mark the WorkloadWatcher initial LIST as complete, unlocking the unknown-workload
+  retention pass. Until the watcher has finished its first LIST, the builder holds
+  `workload_sync_done: false` so the retention sweep cannot evict bases: an unsynced CP
+  sees every base as an orphan and would delete the entire fleet. This gate fires only
+  once per boot after the watcher's successful LIST completes.
+  """
+  @spec mark_watcher_synced(GenServer.server()) :: :ok
+  def mark_watcher_synced(server \\ __MODULE__) do
+    cast_if_alive(server, {:mark_watcher_synced})
+  end
+
   defp cast_if_alive(server, msg) do
     case GenServer.whereis(server) do
       nil -> :ok
@@ -384,6 +396,7 @@ defmodule Embervm.BaseBuilder do
       node_addr: node_addr,
       nodes: node_runtime,
       workloads: %{},
+      workload_sync_done: false,
       # pid -> %{node_id, name, signature} for the CURRENT build worker, so a
       # result from a superseded worker (or for a since-changed spec) is dropped.
       workers: %{},
@@ -437,6 +450,10 @@ defmodule Embervm.BaseBuilder do
 
   def handle_cast({:forget, name}, state) do
     {:noreply, forget_workload(state, name)}
+  end
+
+  def handle_cast({:mark_watcher_synced}, state) do
+    {:noreply, %{state | workload_sync_done: true}}
   end
 
   def handle_cast({:add_node, node_id, address}, state) do
@@ -1574,9 +1591,9 @@ defmodule Embervm.BaseBuilder do
   # EvictArtifact{remote: false} for each superseded local base outside the desired
   # set. Returns the (possibly updated) state. This is the reconciled backstop the
   # event-driven refcount path lacks: it enumerates from the node's REPORTED local
-  # inventory (NodeStatus.local_bases), so it prunes even the pre-R2 orphans the CP
-  # never tracked in base_refs and the superseded refs whose refcount event fired
-  # and no-op'd before this fix, which the event path alone can never re-fire.
+  # inventory (NodeStatus.local_bases). It prunes orphan REFS of known workloads
+  # in the first pass, and orphan WORKLOADS entirely in a second pass once the
+  # WorkloadWatcher has completed its initial LIST.
   defp retention_sweep(state) do
     {_plan, state} = retention_sweep_plan(state)
     state
@@ -1594,7 +1611,7 @@ defmodule Embervm.BaseBuilder do
   # eviction on that same node. noded's in-use/current/BUILDING guard is the final
   # backstop beneath this.
   defp retention_sweep_plan(state) do
-    Enum.reduce(state.workloads, {[], state}, fn {name, w}, {plan, acc} ->
+    {plan, state} = Enum.reduce(state.workloads, {[], state}, fn {name, w}, {plan, acc} ->
       per_node_outcomes = workload_retention(acc, w)
 
       Enum.reduce(per_node_outcomes, {plan, acc}, fn outcome, {p, a} ->
@@ -1612,7 +1629,18 @@ defmodule Embervm.BaseBuilder do
         end
       end)
     end)
-    |> then(fn {plan, acc} -> {Enum.reverse(plan), acc} end)
+
+    {plan, state} =
+      if state.workload_sync_done do
+        Enum.reduce(unknown_workload_retention(state), {plan, state}, fn {workload, node_id, refs, bytes}, {p, a} ->
+          entry = %{workload: workload, evict_refs: refs, evict_bytes: bytes, skipped_unexported: false, node_id: node_id}
+          {[entry | p], apply_retention(a, workload, node_id, refs, bytes)}
+        end)
+      else
+        {plan, state}
+      end
+
+    {Enum.reverse(plan), state}
   end
 
   # Decide one retention outcome per node from the representative reported facts:
@@ -1886,6 +1914,34 @@ defmodule Embervm.BaseBuilder do
       if not Map.get(w.base_refs[ref] || %{}, :evicted, true) and Map.has_key?(w.base_refs, ref),
         do: name,
         else: nil
+    end)
+  end
+
+  defp unknown_workload_retention(state) do
+    protected_refs =
+      for {_name, w} <- state.workloads,
+          {ref, entry} <- w.base_refs,
+          not Map.get(entry, :evicted, false),
+          into: MapSet.new(),
+          do: ref
+
+    state
+    |> representative_facts_by_node(nil)
+    |> Enum.flat_map(fn fact ->
+      fact
+      |> Map.get(:local_bases, [])
+      |> Enum.filter(fn b ->
+        is_binary(b.workload) and
+          not Map.has_key?(state.workloads, b.workload) and
+          b.base_state != :BASE_BUILD_STATE_BUILDING and
+          not MapSet.member?(protected_refs, b.ref)
+      end)
+      |> Enum.group_by(& &1.workload)
+      |> Enum.map(fn {workload, bases} ->
+        refs = Enum.map(bases, & &1.ref)
+        bytes = Enum.map(bases, &(&1.size_bytes || 0)) |> Enum.sum()
+        {workload, fact[:instance_id], refs, bytes}
+      end)
     end)
   end
 

--- a/projects/embervm/control/lib/embervm/workload_watcher.ex
+++ b/projects/embervm/control/lib/embervm/workload_watcher.ex
@@ -249,7 +249,8 @@ defmodule Embervm.WorkloadWatcher do
       # watch end must resync via LIST rather than blindly re-watching a
       # resourceVersion the apiserver no longer knows.
       needs_relist: false,
-      resync_interval_ms: resync_interval_ms
+      resync_interval_ms: resync_interval_ms,
+      initial_sync_done: false
     }
 
     # watch_startup drives the informer from init; tests set it false and drive
@@ -366,7 +367,12 @@ defmodule Embervm.WorkloadWatcher do
   # backoff. This is the single entry point for both boot and every resync.
   defp relist_then_watch(state) do
     case do_list_reconcile(state) do
-      {:ok, state} -> start_streamer(%{state | backoff_ms: state.base_backoff})
+      {:ok, state} ->
+        unless state.initial_sync_done do
+          Embervm.BaseBuilder.mark_watcher_synced()
+        end
+
+        start_streamer(%{state | backoff_ms: state.base_backoff, initial_sync_done: true})
       {:error, state} -> schedule(:resync, state)
     end
   end

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -722,6 +722,17 @@ defmodule Embervm.BaseBuilderTest do
     )
   end
 
+  defp put_unknown_local_bases_fact(table, node_id, pod_uid, local_bases) do
+    NodeCapacity.put(table, {node_id, pod_uid}, %{
+      node_id: node_id,
+      configured_id: node_id,
+      instance_id: "#{node_id}/#{pod_uid}",
+      workloads: %{},
+      local_bases: local_bases,
+      updated_at: 0
+    })
+  end
+
   defp ready_base(ref, workload, bytes) do
     %{ref: ref, workload: workload, size_bytes: bytes, base_state: :BASE_BUILD_STATE_READY}
   end
@@ -784,6 +795,87 @@ defmodule Embervm.BaseBuilderTest do
     assert_receive {:evicted, "w", "w__superseded"}, 1_000
     assert_receive {:evicted, "w", "w__tmporphan"}, 1_000
     refute_receive {:evicted, "w", "w__current"}, 100
+  end
+
+  test "retention sweep evicts an unknown workload once the watcher is synced and coalesces bricks" do
+    test_pid = self()
+    table = new_cap_table()
+    orphan = ready_base("deleted__old", "deleted", 2_048)
+
+    put_node_local_bases_fact(table, "node-4", "large", "deleted", "deleted__current", true, [orphan])
+    put_node_local_bases_fact(table, "node-4", "small", "deleted", "deleted__current", true, [orphan])
+
+    builder = start_builder(
+      capacity_table: table,
+      evict_fun: fn :fake_channel, workload, ref ->
+        send(test_pid, {:evicted, workload, ref})
+        {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
+      end,
+      retention_sweep_enabled: true
+    )
+
+    :sys.replace_state(builder, fn state -> %{state | workload_sync_done: true} end)
+    [entry] = BaseBuilder.retention_sweep_now(builder)
+    assert entry.workload == "deleted"
+    assert entry.evict_refs == ["deleted__old"]
+    assert entry.evict_bytes == 2_048
+    assert_receive {:evicted, "deleted", "deleted__old"}, 1_000
+    refute_receive {:evicted, "deleted", "deleted__old"}, 100
+  end
+
+  test "retention sweep does not evict unknown workloads before the watcher sync" do
+    table = new_cap_table()
+    put_node_local_bases_fact(table, "node-4", "ds", "deleted", "deleted__current", true, [ready_base("deleted__old", "deleted", 2_048)])
+    builder = start_builder(capacity_table: table, retention_sweep_enabled: true)
+
+    plan = BaseBuilder.retention_sweep_now(builder)
+    assert plan == []
+  end
+
+  test "retention sweep evicts a deleted workload without requiring an exported current base" do
+    test_pid = self()
+    table = new_cap_table()
+    put_node_local_bases_fact(table, "node-4", "ds", "deleted", "deleted__current", false, [ready_base("deleted__old", "deleted", 512)])
+
+    builder = start_builder(
+      capacity_table: table,
+      evict_fun: fn :fake_channel, workload, ref ->
+        send(test_pid, {:evicted, workload, ref})
+        {:ok, %Embervm.Node.V1.EvictArtifactResponse{}}
+      end,
+      retention_sweep_enabled: true
+    )
+
+    :sys.replace_state(builder, fn state -> %{state | workload_sync_done: true} end)
+    plan = BaseBuilder.retention_sweep_now(builder)
+    assert [%{evict_refs: ["deleted__old"]}] = plan
+    assert_receive {:evicted, "deleted", "deleted__old"}, 1_000
+  end
+
+  test "retention sweep does not evict a BUILDING base for an unknown workload" do
+    table = new_cap_table()
+    base = Map.put(ready_base("deleted__building", "deleted", 512), :base_state, :BASE_BUILD_STATE_BUILDING)
+    put_unknown_local_bases_fact(table, "node-4", "ds", [base])
+    builder = start_builder(capacity_table: table, retention_sweep_enabled: true)
+
+    :sys.replace_state(builder, fn state -> %{state | workload_sync_done: true} end)
+    assert BaseBuilder.retention_sweep_now(builder) == []
+  end
+
+  test "retention sweep protects an unknown base still present in base_refs" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_unknown_local_bases_fact(table, "node-4", "ds", [ready_base("deleted__held", "deleted", 512)])
+    builder = start_builder(capacity_table: table, status_writer: recording_status_writer(agent))
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+    :sys.replace_state(builder, fn state ->
+      w = state.workloads["w"]
+      w = %{w | base_refs: %{"deleted__held" => %{primed: 1, sessions: 0, evicted: false}}}
+      %{state | workload_sync_done: true, workloads: %{"w" => w}}
+    end)
+
+    assert BaseBuilder.retention_sweep_now(builder) == []
   end
 
   test "retention sweep is a dry-run no-op with the gate OFF (default): plans but evicts nothing" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.241
+      targetRevision: 0.1.242
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Why

Deleting a Workload did not reclaim its base snapshots. They stayed on every node forever.

Observed live today after retiring both image demos and `scratch-k8s`: the Workload CRs were
gone from the fleet, yet their bases remained on every node.

```
node-1:  cold-image-demo__a20465c75982 513M   hot-image-demo__a20465c75982 769M
node-2:  cold-image-demo__a20465c75982 513M   hot-image-demo__a20465c75982 769M
node-3:  cold-image-demo__a20465c75982 513M   hot-image-demo__a20465c75982 769M
```

~1.28G leaked per node for the demos, plus 2049M per node for `scratch-k8s`. All of it needed a
manual reclaim, which rather defeats retiring workloads to reclaim disk in the first place.

## Cause

`retention_sweep_plan/1` iterated `state.workloads`, then filtered each node's reported inventory
by `b.workload == w.name`. A deleted workload is removed from `state.workloads` (`forget/2`), so
its bases were never reached and never became candidates.

The comment above `retention_sweep/1` also overstated the behaviour, claiming it enumerates from
the node's reported inventory and so prunes orphans the CP never tracked. It pruned orphan REFS
of KNOWN workloads; it did not prune orphan WORKLOADS. That comment is corrected here, since it
is what made the gap invisible on a read.

## What changed

A second pass over each node's reported `local_bases` whose workload is not in `state.workloads`,
evicting them wholesale. It reuses the existing per-node grouping from #4052 (one representative
brick per node, because bases live on the node's shared hostPath scratch) and routes through the
same `apply_retention/5`, so the dry-run gate and logging are unchanged.

## The dangerous part, and how it is guarded

The naive version of this fix is far worse than the bug. On CP cold start `state.workloads` is
empty while the WorkloadWatcher does its first LIST. An unknown-workload pass running in that
window would classify EVERY base on EVERY node as an orphan and wipe the fleet's entire snapshot
inventory.

So the pass is gated on a real initial-sync signal:

- `workload_sync_done` defaults to **false** in `init/1`.
- `WorkloadWatcher` calls `BaseBuilder.mark_watcher_synced/1` only after a SUCCESSFUL LIST, once
  per boot.
- That call is whereis-guarded (`cast_if_alive`), so it cannot crash the watcher when BaseBuilder
  is not running.
- `retention_sweep_plan/1` runs the orphan pass only when the flag is set.

Note the gate is deliberately NOT "state.workloads is non-empty", which is itself wrong on a
fleet whose only workload was just deleted.

The export/durability gate is also deliberately NOT applied to this pass. `workload_retention/2`
refuses to evict until the node's CURRENT base is `exported: true`, but a deleted workload has no
current base and never will, so applying it would make these unreapable forever, which is the
bug. The BUILDING exclusion and the `base_refs` refcount protection are both kept.

## Out of scope

The S3 copies under `base/<vendor>/<workload>/` are untouched. Whether a deleted workload should
also reap its store copies is a separate decision tracked on #3947, and it has a real cost
either way (an orphaned object store entry versus deleting the only durable copy).

## Verification

`ci test`: exit 0, 964 tests, 0 failures (up from 959, the five new cases).

New tests:
- unknown workload with the sync signal SET -> evicted, and two bricks on one node coalesce to a
  single plan entry with bytes counted once (does not regress #4052)
- unknown workload with the sync signal NOT set -> nothing evicted (the fleet-wipe guard, the most
  important test here)
- a deleted workload's base is evicted without requiring an exported current base
- a BUILDING base for an unknown workload is NOT evicted
- an unknown base still present in `base_refs` is protected

Closes #4057
