### PR TITLE
fix(embervm): stage base builds and treat incomplete bundles as absent

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.242
+version: 0.1.243

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.242
+      targetRevision: 0.1.243
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/cmd/main.go
+++ b/projects/embervm/noded/cmd/main.go
@@ -189,6 +189,8 @@ func run(logger *slog.Logger) error {
 	// Report node-local base snapshots left by a prior incarnation so the control
 	// plane reconciles rather than rebuilding.
 	srv.ReconcileBasesFromDisk()
+	// Called only at daemon startup, before any work begins.
+	srv.CleanupStagingDirs()
 	// Report node-local BANKED session snapshots left by a prior incarnation so the
 	// control plane adopts surviving banked sessions (live session VMs died with the
 	// prior daemon; their last banked snapshot, if any, stays restorable).

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -1109,16 +1109,19 @@ func (d *Driver) SnapshotBase(ctx context.Context, h substrate.Handle, baseKey s
 	if inst == nil {
 		return substrate.SnapshotRef{}, fmt.Errorf("driver: snapshot-base of unknown handle %q", h.ID)
 	}
-	if err := os.MkdirAll(d.baseDir(baseKey), 0o750); err != nil {
-		return substrate.SnapshotRef{}, fmt.Errorf("driver: mkdir base bundle: %w", err)
+	finalDir := d.baseDir(baseKey)
+	buildingDir := finalDir + ".building"
+	if err := os.MkdirAll(filepath.Dir(buildingDir), 0o750); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: mkdir base root: %w", err)
 	}
-	snapPath := d.baseSnapfile(baseKey)
-	memPath := d.baseMemfile(baseKey)
-	// Write to temp paths and rename into place. A rebuild must NOT overwrite the
-	// live snapfile/memfile in place: another thread may be restoring from them
-	// (the File mem-backend mmaps the memfile), and overwriting a mapped file is a
-	// SIGBUS foot-gun. rename(2) swaps the directory entry to a new inode while any
-	// in-flight restore keeps the old (now-unlinked) one.
+	if err := os.Mkdir(buildingDir, 0o750); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: mkdir base staging bundle: %w", err)
+	}
+	snapPath := filepath.Join(buildingDir, "snapfile")
+	memPath := filepath.Join(buildingDir, "memfile")
+	// Write to temp paths and rename into place within staging. The final
+	// directory is swapped into place only after both files are complete, so a
+	// failed build never presents a partially published base.
 	snapTmp := snapPath + ".tmp"
 	memTmp := memPath + ".tmp"
 
@@ -1141,6 +1144,9 @@ func (d *Driver) SnapshotBase(ctx context.Context, h substrate.Handle, baseKey s
 	if err := os.Rename(snapTmp, snapPath); err != nil {
 		return substrate.SnapshotRef{}, fmt.Errorf("driver: publish base snapfile: %w", err)
 	}
+	if err := os.Rename(buildingDir, finalDir); err != nil {
+		return substrate.SnapshotRef{}, fmt.Errorf("driver: publish base bundle: %w", err)
+	}
 	return substrate.SnapshotRef{
 		ID:        baseKey,
 		Node:      d.cfg.Node,
@@ -1148,7 +1154,7 @@ func (d *Driver) SnapshotBase(ctx context.Context, h substrate.Handle, baseKey s
 		Vendor:    d.cfg.Vendor,
 		Template:  d.cfg.Template,
 		Base:      true,
-		SizeBytes: bundleSize(snapPath, memPath),
+		SizeBytes: bundleSize(filepath.Join(finalDir, "snapfile"), filepath.Join(finalDir, "memfile")),
 	}, nil
 }
 

--- a/projects/embervm/noded/fcvm/driver/driver_test.go
+++ b/projects/embervm/noded/fcvm/driver/driver_test.go
@@ -442,6 +442,15 @@ func TestDriverWarmBaseStartReusesBaseBundle(t *testing.T) {
 	if !baseRef.Base || baseRef.ID != "base-homelab-amd64" || baseRef.SizeBytes == 0 {
 		t.Fatalf("unexpected base ref: %+v", baseRef)
 	}
+	baseDir := d.baseDir("base-homelab-amd64")
+	for _, name := range []string{"snapfile", "memfile"} {
+		if _, err := os.Stat(filepath.Join(baseDir, name)); err != nil {
+			t.Fatalf("final base %s missing: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(baseDir + ".building"); !os.IsNotExist(err) {
+		t.Fatalf("base staging dir still exists, stat err=%v", err)
+	}
 	if err := d.Release(ctx, warm); err != nil {
 		t.Fatalf("Release warm: %v", err)
 	}

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1740,6 +1740,9 @@ func (s *Server) nodeStatus() *nodev1.NodeStatus {
 //     memfile.tmp/snapfile.tmp orphan with no snapfile, so ReconcileBasesFromDisk
 //     never registered it), reported with base_state UNSPECIFIED.
 //
+// Staging dirs ending in .building are intentionally excluded: the registry's
+// BUILDING entry is authoritative while a build is in flight.
+//
 // Scanning disk (not just the registry) is what lets the control plane's retention
 // sweep target the .tmp orphans too: a registry-only projection would hide them,
 // stranding the exact bytes PR-3 exists to reclaim. A dir also present in the
@@ -1766,24 +1769,40 @@ func (s *Server) localBasesStatus() []*nodev1.BaseInventoryEntry {
 			continue
 		}
 		ref := ent.Name()
+		// Skip staging directories; they are protected by the registry's BUILDING
+		// state and must not be enumerated as independent candidates.
+		if strings.HasSuffix(ref, ".building") {
+			continue
+		}
 		seen[ref] = struct{}{}
 		if b, ok := reg[ref]; ok {
+			state := b.state
+			sizeBytes := uint64(b.sizeBytes)
+			if !isCompleteBase(filepath.Join(root, ref), state) {
+				state = nodev1.BaseBuildState_BASE_BUILD_STATE_UNSPECIFIED
+				sizeBytes = 0
+			}
 			out = append(out, &nodev1.BaseInventoryEntry{
 				Ref:       ref,
 				Workload:  b.workload,
-				SizeBytes: uint64(b.sizeBytes),
-				BaseState: b.state,
+				SizeBytes: sizeBytes,
+				BaseState: state,
 			})
 			continue
 		}
 		// Unregistered on-disk dir (a superseded dir not re-registered, or a .tmp
 		// orphan): report it so the sweep can reclaim it. base_state UNSPECIFIED
 		// marks "on disk, not a registry-known build".
+		state := nodev1.BaseBuildState_BASE_BUILD_STATE_UNSPECIFIED
+		sizeBytes := dirSizeBytes(filepath.Join(root, ref))
+		if !isCompleteBase(filepath.Join(root, ref), state) {
+			sizeBytes = 0
+		}
 		out = append(out, &nodev1.BaseInventoryEntry{
 			Ref:       ref,
 			Workload:  workloadFromBaseKey(ref),
-			SizeBytes: dirSizeBytes(filepath.Join(root, ref)),
-			BaseState: nodev1.BaseBuildState_BASE_BUILD_STATE_UNSPECIFIED,
+			SizeBytes: sizeBytes,
+			BaseState: state,
 		})
 	}
 	// A BUILDING ref whose dir has not yet materialized on disk (the build just
@@ -1806,6 +1825,31 @@ func (s *Server) localBasesStatus() []*nodev1.BaseInventoryEntry {
 	return out
 }
 
+func isCompleteBase(baseDir string, state nodev1.BaseBuildState) bool {
+	if state == nodev1.BaseBuildState_BASE_BUILD_STATE_BUILDING {
+		return true
+	}
+	ents, err := os.ReadDir(baseDir)
+	if err != nil {
+		return false
+	}
+	seen := make(map[string]bool, 3)
+	for _, ent := range ents {
+		if ent.IsDir() {
+			continue
+		}
+		name := ent.Name()
+		if strings.HasSuffix(name, ".tmp") {
+			return false
+		}
+		switch name {
+		case "imageref", "memfile", "snapfile":
+			seen[name] = true
+		}
+	}
+	return seen["imageref"] && seen["memfile"] && seen["snapfile"]
+}
+
 // localBasesFromRegistry is the registry-only fallback for localBasesStatus when
 // the bases/ dir cannot be scanned (missing on a fresh node, or a read error).
 func (s *Server) localBasesFromRegistry() []*nodev1.BaseInventoryEntry {
@@ -1815,11 +1859,17 @@ func (s *Server) localBasesFromRegistry() []*nodev1.BaseInventoryEntry {
 	}
 	out := make([]*nodev1.BaseInventoryEntry, 0, len(entries))
 	for _, b := range entries {
+		state := b.state
+		sizeBytes := uint64(b.sizeBytes)
+		if !isCompleteBase(filepath.Join(s.cfg.SnapshotRoot, "bases", b.snapshotRef), state) {
+			state = nodev1.BaseBuildState_BASE_BUILD_STATE_UNSPECIFIED
+			sizeBytes = 0
+		}
 		out = append(out, &nodev1.BaseInventoryEntry{
 			Ref:       b.snapshotRef,
 			Workload:  b.workload,
-			SizeBytes: uint64(b.sizeBytes),
-			BaseState: b.state,
+			SizeBytes: sizeBytes,
+			BaseState: state,
 		})
 	}
 	return out
@@ -2422,6 +2472,27 @@ func (s *Server) ReconcileBasesFromDisk() {
 	if n > 0 || gc > 0 {
 		s.logger.Info("noded: reconciled base snapshots", "adopted", n, "gc_superseded", gc)
 		s.signalChange()
+	}
+}
+
+// CleanupStagingDirs removes abandoned .building/ staging directories.
+// Called only from daemon startup because ReconcileBasesFromDisk also runs at
+// runtime via reregisterRestored after a base hydrate, where a build may be in
+// flight. Startup-only placement ensures no build can be harmed.
+func (s *Server) CleanupStagingDirs() {
+	root := filepath.Join(s.cfg.SnapshotRoot, "bases")
+	ents, err := os.ReadDir(root)
+	if err != nil {
+		return
+	}
+	for _, ent := range ents {
+		if !ent.IsDir() || !strings.HasSuffix(ent.Name(), ".building") {
+			continue
+		}
+		stagingPath := filepath.Join(root, ent.Name())
+		if err := os.RemoveAll(stagingPath); err != nil {
+			s.logger.Warn("noded: cleanup stale staging dir", "path", stagingPath, "err", err)
+		}
 	}
 }
 

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -2064,6 +2064,9 @@ func writeReconcileBase(t *testing.T, basesDir, baseKey, ref string) {
 	if err := os.WriteFile(filepath.Join(d, "snapfile"), []byte("snap"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(d, "memfile"), []byte("mem"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if ref != "" {
 		if err := os.WriteFile(filepath.Join(d, "imageref"), []byte(ref), 0o644); err != nil {
 			t.Fatal(err)

--- a/projects/embervm/noded/server/store_test.go
+++ b/projects/embervm/noded/server/store_test.go
@@ -708,6 +708,99 @@ func TestLocalBasesStatusReportsOrphans(t *testing.T) {
 	}
 }
 
+func TestLocalBasesStatusSkipsStagingDirectories(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+	stagingDir := filepath.Join(s.cfg.SnapshotRoot, "bases", "scratch-k8s__stale.building")
+	if err := os.MkdirAll(stagingDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	inv := s.localBasesStatus()
+	if len(inv) != 0 {
+		t.Fatalf("localBasesStatus() returned %d entries, want no staging directory", len(inv))
+	}
+}
+
+func TestLocalBasesStatusBuildingReportsOnceNotTwice(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+	ref := "scratch-k8s__building0"
+	s.bases.beginBuild(ref, "scratch-k8s", "/shim/ready")
+	stagingDir := filepath.Join(s.cfg.SnapshotRoot, "bases", ref+".building")
+	if err := os.MkdirAll(stagingDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	inv := s.localBasesStatus()
+	if len(inv) != 1 {
+		t.Fatalf("localBasesStatus() returned %d entries, want exactly one", len(inv))
+	}
+	if inv[0].GetRef() != ref || inv[0].GetBaseState() != nodev1.BaseBuildState_BASE_BUILD_STATE_BUILDING {
+		t.Fatalf("inventory = %+v, want registry BUILDING entry for %q", inv[0], ref)
+	}
+}
+
+func TestCleanupStagingDirsRemovesStaleDirectories(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+	root := filepath.Join(s.cfg.SnapshotRoot, "bases")
+	stale := filepath.Join(root, "scratch-k8s__stale.building")
+	regular := filepath.Join(root, "scratch-k8s__ready")
+	if err := os.MkdirAll(stale, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(regular, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	s.CleanupStagingDirs()
+	if dirExists(stale) {
+		t.Fatal("stale staging directory survived cleanup")
+	}
+	if !dirExists(regular) {
+		t.Fatal("non-staging directory was removed by cleanup")
+	}
+}
+
+func TestIsCompleteBase(t *testing.T) {
+	tests := []struct {
+		name  string
+		files map[string]string
+		state nodev1.BaseBuildState
+		want  bool
+	}{
+		{name: "complete", files: map[string]string{"imageref": "img", "memfile": "mem", "snapfile": "snap"}, want: true},
+		{name: "missing imageref", files: map[string]string{"memfile": "mem", "snapfile": "snap"}},
+		{name: "missing memfile", files: map[string]string{"imageref": "img", "snapfile": "snap"}},
+		{name: "missing snapfile", files: map[string]string{"imageref": "img", "memfile": "mem"}},
+		{name: "temporary file", files: map[string]string{"imageref": "img", "memfile": "mem", "snapfile": "snap", "snapfile.tmp": "partial"}},
+		{name: "building", state: nodev1.BaseBuildState_BASE_BUILD_STATE_BUILDING, files: map[string]string{"memfile.tmp": "partial"}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeBundleFiles(t, dir, tt.files)
+			if got := isCompleteBase(dir, tt.state); got != tt.want {
+				t.Fatalf("isCompleteBase() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLocalBasesStatusReportsIncompleteRegisteredBaseAsAbsent(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+	ref := "scratch-k8s__incomplete0"
+	dir := filepath.Join(s.cfg.SnapshotRoot, "bases", ref)
+	writeBundleFiles(t, dir, map[string]string{"memfile.tmp": "partial"})
+	s.bases.register(baseEntry{snapshotRef: ref, workload: "scratch-k8s", sizeBytes: 123, state: nodev1.BaseBuildState_BASE_BUILD_STATE_READY})
+
+	inv := s.localBasesStatus()
+	if len(inv) != 1 {
+		t.Fatalf("localBasesStatus() returned %d entries, want 1", len(inv))
+	}
+	if inv[0].GetSizeBytes() != 0 || inv[0].GetBaseState() != nodev1.BaseBuildState_BASE_BUILD_STATE_UNSPECIFIED {
+		t.Fatalf("incomplete base inventory = %+v, want zero-sized unspecified", inv[0])
+	}
+}
+
 // baseExportedInStatus finds the workload's capacity entry in NodeStatus whose
 // snapshot_ref matches and returns its exported flag; false if not reported.
 func baseExportedInStatus(s *Server, workload, ref string) bool {
@@ -830,6 +923,38 @@ func TestRestoreArtifactBaseAlreadyLocalSkips(t *testing.T) {
 	}
 	if resp.GetAccepted() {
 		t.Fatal("an already-local base restore must NOT enqueue an async download")
+	}
+}
+
+func TestCleanupStagingDirsNotReachedDuringRestore(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+
+	workload := "bazel-query"
+	ref := "bazel-query__abcdef012345"
+	digest := "sha256:runtime-bazel"
+	s.registry.sync([]workloadEntry{{Workload: workload, ImageRef: digest, RootfsRef: "/rootfs/bazel"}})
+	prefix := "base/amd/" + workload + "/" + ref
+	fs.seedArtifact(prefix, map[string]string{"imageref": digest, "memfile": "mem", "snapfile": "snap"}, 0, "amd", "")
+
+	stale := filepath.Join(s.cfg.SnapshotRoot, "bases", "scratch-k8s__stale.building")
+	if err := os.MkdirAll(stale, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeBundleFiles(t, filepath.Join(s.cfg.SnapshotRoot, "bases", ref), map[string]string{"imageref": digest, "memfile": "mem", "snapfile": "snap"})
+
+	resp, err := s.RestoreArtifact(context.Background(), &nodev1.RestoreArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_BASE, Workload: workload, Ref: ref},
+		Vendor:   "amd",
+	})
+	if err != nil {
+		t.Fatalf("RestoreArtifact(already-local base): %v", err)
+	}
+	if !resp.GetSkipped() {
+		t.Fatal("an already-local base restore must be skipped")
+	}
+	if !dirExists(stale) {
+		t.Fatal("staging directory was removed during restore")
 	}
 }
 


### PR DESCRIPTION
## Why

A base build interrupted mid-write left `.tmp` files in a directory named after the CURRENT
ref. Because the current ref is always in the retention sweep's desired set, that orphan could
NEVER be evicted, and the node was stuck with an unusable base while a complete verified copy
sat in S3.

Found live on node-3 after today's disk-full incident:

```
snapshots/bases/sandbox__02293fcf9708/
  memfile.tmp    536870912   (sparse, ~335M actually written)
  snapfile.tmp       15963
  (no imageref)
```

`base_builder.ex` intends to drain these: its candidate comment says "unregistered/.tmp orphan
dirs (base_state UNSPECIFIED) are both candidates". But candidacy is `b.ref not in desired`, and
the desired set always contains the current ref, so the orphan-draining logic only ever worked
for orphans of SUPERSEDED refs.

Worse than wasted disk: the directory EXISTS, so the CP could believe the base is present and
never trigger hydrate-on-miss, leaving the node permanently unable to serve that workload.

## What changed

**1. Builds stage, then rename atomically.** The driver writes the bundle into
`<ref>.building/` and `os.Rename`s it to `<ref>/` only once every file is complete. A rename
within one filesystem is atomic, so a crash, ENOSPC, or eviction mid-build leaves a directory
that is unambiguously NOT the base, rather than a half-written one wearing the real name. This
makes the original failure structurally impossible.

**2. Incomplete bundles report as ABSENT.** `isCompleteBase` requires the full file set
(`imageref` + `memfile` + `snapfile`) and no `.tmp` siblings. An incomplete directory reports
`BASE_BUILD_STATE_UNSPECIFIED` with size 0, so hydrate-on-miss can restore the real base from
S3 and the sweep can treat it as a candidate. This heals bundles left by older builds, which
part 1 alone cannot.

## Protecting in-flight builds (the risk in this change)

An in-progress build is legitimately incomplete, so "incomplete means absent" must not let the
sweep reap a bundle out from under the process writing it. Guarded at BOTH layers:

- `isCompleteBase` short-circuits to true on `BASE_BUILD_STATE_BUILDING` before touching the
  filesystem, so a registry-known build is never reported absent.
- The bases-dir scan excludes `.building` directories entirely, so a staging dir is never
  enumerated as an orphan. Without this the rename in part 1 would have REMOVED the protection
  part 2 relies on: the registry holds `<ref>` while the staging dir is `<ref>.building`, so the
  scan would have emitted it as an unregistered UNSPECIFIED entry, i.e. an eviction candidate,
  and the sweep could have deleted a live build.

## Cleaning up abandoned staging dirs

Excluding `.building` from the inventory means the sweep can no longer reap them either, so
cleanup is explicit: `CleanupStagingDirs` is called ONLY from daemon startup
(`noded/cmd/main.go`), never from `ReconcileBasesFromDisk`.

That placement is load-bearing and the comment says so. `ReconcileBasesFromDisk` also runs at
RUNTIME via `reregisterRestored` after a base hydrate, where a build may be in flight; cleaning
up from there would delete a live build's staging directory on any hydrate-on-miss. Startup is
the only point where no build can be in flight, so the reasoning needs no liveness check.

## Out of scope

Nothing is deleted by part 2: it changes REPORTING, not eviction. The sweep decides what to
evict; noded's job here is to stop claiming an incomplete bundle is a usable base.

## Verification

`ci test`: exit 0, 959 tests 0 failures, 745 targets pass. The pre-push hook re-ran it after
rebasing onto #4064, which touches the same retention machinery from the CP side.

Closes #4056
