### PR TITLE
test(embervm): yield a scheduler slot in ServingSweeperTest wait_until

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.243
+version: 0.1.245

--- a/projects/embervm/control/test/embervm/serving_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/serving_sweeper_test.exs
@@ -215,15 +215,22 @@ defmodule Embervm.ServingSweeperTest do
 
   # Poll the store until `fun` returns a truthy value or a bounded number of flushes
   # elapse. The bank worker reports {:bank_done} asynchronously, so a test that fired
-  # a drain waits here for the durable transition to land. No real sleep: each
-  # iteration just flushes the mailbox (processing any pending {:bank_done}).
+  # a drain waits here for the durable transition to land.
   defp wait_until(ctx, fun, tries \\ 50) do
     flush(ctx)
 
     cond do
       fun.() -> :ok
       tries <= 0 -> flunk("wait_until: condition never held")
-      true -> wait_until(ctx, fun, tries - 1)
+      true ->
+        # Yield a scheduler slot between tries. flush only drains the sweeper's
+        # own mailbox; a spawned bank worker (posts {:bank_done}) is a separate
+        # process that must be scheduled before the store reaches :banked.
+        # Without this backoff the loop spins through all tries in a couple of ms
+        # and starves the worker under the 8-way parallel CI runner (the historic
+        # "condition never held" bank flake). Mirrors StatefulSweeperTest.
+        Process.sleep(10)
+        wait_until(ctx, fun, tries - 1)
     end
   end
 

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.243
+      targetRevision: 0.1.245
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## What

Adds `Process.sleep(10)` between polls in `ServingSweeperTest`'s `wait_until`, so a spawned bank worker gets a scheduler slot before the poll gives up.

## Why

`ServingSweeperTest` intermittently failed CI with `wait_until: condition never held`, most recently on #4066 where the diff was pure Go and touched no Elixir at all.

The helper polled only via `flush/1` (`:sys.get_state`) with no sleep. That is real synchronization, but not the kind needed here: it forces the sweeper to drain its **already-queued** mailbox, while the bank worker is a **separate process** that must first be scheduled before it can send `{:bank_done}`. Draining a mailbox cannot deliver a message that was never sent, so all 50 tries burned in well under a millisecond and the poll flunked without ever yielding.

Under the 8-way parallel runner with ~960 tests contending, a scheduling slot is exactly the scarce resource, which is why this presented as load sensitivity rather than a plain bug.

## Not a new idea

`StatefulSweeperTest` hit the identical failure on 2026-07-17 and was fixed the same way. That fix has held since, but was never propagated to the serving copy. This PR closes that gap so the two sweeper suites share one idiom.

For the record, four test files hand-roll their own `wait_until`, and the correlation was exact before this change:

| File | Tries | Yields | Had flaked |
|---|---|---|---|
| `sync_wait_test.exs` | 1000 | `Process.sleep(5)` | no |
| `session_bank_relight_test.exs` | 1000 | `Process.sleep(5)` | no |
| `stateful_sweeper_test.exs` | 50 | `Process.sleep(10)` (fixed 07-17) | yes, before fix |
| `serving_sweeper_test.exs` | 50 | **none** | **yes, this PR** |

## Also

Drops the old comment asserting `No real sleep: each iteration just flushes the mailbox`, which described the defect as though it were a deliberate design choice.

## Chart bump to 0.1.245

I first opened this PR claiming a test-only change needs no chart bump. That was wrong, and the `Push images` guard caught it:

```
ERROR: embervm 0.1.243 is already published, but its pinned image digests differ
from the published chart (an image was rebuilt).
```

The reasoning error was arguing from semantics (test files do not ship in an image) when the guard reasons about digests. The embervm image rebuilt on this branch with a digest differing from the one pinned inside the already-published, immutable `0.1.243`. Merging without a bump would leave main carrying image digests that no published chart references, with ArgoCD still serving the old ones.

`0.1.244` was already claimed by another open PR, so `bump-chart.sh` took `0.1.245`. `Chart.yaml` and `deploy/application.yaml` moved together.

## Verification

`ci lint` clean, `ci test` green: `964 tests, 0 failures, 6 skipped`.

Worth stating plainly: a green run is weak evidence for a flake fix, since this test passed most of the time before too. The actual argument is structural (the loop now yields, so the worker is guaranteed an opportunity instead of needing to win a race), backed by the 10-day precedent on the stateful copy.

## Follow-up, not done here

The root problem is that `wait_until` is hand-duplicated in four files, which is how a fix landed in one copy and sat unpropagated for 10 days. Extracting it into a shared test-support module would prevent the next recurrence, but that is a wider refactor than this fix and is left out deliberately.