### PR TITLE
fix(monolith): suspend the ember synthetic cron, it pages on its own gaps

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.304
+version: 0.89.305
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.304
+      targetRevision: 0.89.305
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.378
+version: 0.285.379
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -744,7 +744,22 @@ jobs:
       # 90s for a cold boot). 300s clears that inside the 5m window, so Forbid
       # never stacks a backlog.
       activeDeadlineSeconds: 300
-      suspend: false
+      # SUSPENDED until the jobs pod can actually reach all four targets. Three
+      # of the four probes failed on environment, not on broken demos, and
+      # latched jomcgi.dev/health to 503 (a false uptime alert):
+      #   bazel    - embervm auth.allowedServiceAccounts admits
+      #              monolith:monolith and monolith-public:monolith-public, but
+      #              this job runs as monolith-workflows:argo-workflow, so the
+      #              control plane 403s "service account not permitted".
+      #   semgrep  - semgrep_scan.client needs FC_INVOKE_URL (set on the backend
+      #              Deployment, never added to this entry's env).
+      #   postgres - POST https://jomcgi.dev/api/ember/postgres/query returns the
+      #              SvelteKit HTML shell, not JSON: /api/ember/* is not on the
+      #              public HTTPRoute for direct external calls.
+      # `pages` was the only one that worked (200 + SSR title on all five).
+      # Re-enable ONLY after a real run proves all four green; a probe that
+      # cannot reach its target is worse than no probe, because it pages you.
+      suspend: true
       emberSynthetic: true
       resources:
         requests:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.378
+      targetRevision: 0.285.379
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Stops a false uptime alert

The ember synthetic probes from #4065 went live and three of the four failed on **jobs-pod environment**, not on broken demos. Because a failed row latches, `jomcgi.dev/health` went 503 and stayed there, which is a false page on the uptime channel.

Observed latch rows after the first successful run:

```
bazel    | f | status 403: {"error":"service account not permitted"...
pages    | t | all pages, 224ms
postgres | f | Expecting value: line 1 column 1 (char 0)
semgrep  | f | FC_INVOKE_URL is not configured
```

## Root causes, all in the wiring rather than the demos

| Probe | Cause |
|---|---|
| bazel | embervm `auth.allowedServiceAccounts` admits `monolith:monolith` and `monolith-public:monolith-public`. This job runs as `monolith-workflows:argo-workflow`, so the control plane 403s. |
| semgrep | `semgrep_scan.client` needs `FC_INVOKE_URL` (set on the backend Deployment, never added to the cron entry's `env`). |
| postgres | `POST https://jomcgi.dev/api/ember/postgres/query` returns the SvelteKit HTML shell, not JSON. `/api/ember/*` is not on the public HTTPRoute for direct external calls, so the probe's premise was wrong even though the endpoint genuinely needs no Turnstile. |

`pages` worked correctly: 200 plus the SSR title on all five pages.

## Why suspend rather than revert

The schema, the four health components, the latch and staleness semantics, the public-closure prune and the `public_reader` grants test are all correct and worth keeping. What was missing is wiring that only a live run could expose, which is precisely the gap between `ci test` passing and the feature working. Suspending leaves everything in place and stops the paging.

After this syncs I will clear the three failed latch rows so the components return to `"no probe recorded yet"` and `/health` goes back to 200.

## Follow-up

One PR to fix all three (embervm SA allowlist, `FC_INVOKE_URL` on the cron, and an in-cluster route for the postgres probe), then re-enable only after a live run shows all four green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WQAne8Y28jP2NNzgsnrKf