### PR TITLE
feat(embervm): wire the claude runtime workload and its egress lane

### DIFF
--- a/projects/embervm/chart/BUILD
+++ b/projects/embervm/chart/BUILD
@@ -29,6 +29,10 @@ helm_chart(
         # R1 zip lane (ADR embervm/002): the runtime-python base image the zip
         # lane layers an adopter's archive onto. Distinct top-level key (D14a.6).
         "runtimePython.guestImage": "//projects/embervm/runtimes/python:image.info",
+        # The egress-proxy sidecar (ADR 023). Shared with fc-invoke rather than
+        # forked: same binary, same posture, one place to fix. Pinned from its
+        # .info so the sidecar the daemon tunnels to is the digest CI built.
+        "egress.image": "//projects/firecracker/substrate/egress-proxy:image.info",
         # Issue #4055: the runtime-claude base image, a session-class guest that
         # runs the Claude Code CLI headlessly under a vsock shim so monolith can
         # expose agent sessions as MCP tools. Distinct FLAT top-level key (D14a.6),

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.246
+version: 0.1.247

--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -218,6 +218,15 @@ containers:
       {{- end }}
       - name: EMBERVM_NODED_DRAIN_TIMEOUT
         value: "{{ $ctx.Values.noded.drain.timeoutSeconds }}s"
+      {{- if $ctx.Values.egress.enabled }}
+      # Guest egress lane (ADR 023 phase 6a). Serve the vsock egress port per
+      # guest and tunnel to the sidecar above; the addr must match its
+      # EGRESS_LISTEN. Absent when disabled, so the daemon's default stays off.
+      - name: EMBERVM_NODED_EGRESS_ENABLED
+        value: "true"
+      - name: EMBERVM_NODED_EGRESS_SIDECAR_ADDR
+        value: "127.0.0.1:8888"
+      {{- end }}
       # R1 zip lane: bounds a single archive HTTP GET and caps the fetched
       # bytes. The archive_url is minted by the control plane (fully-qualified
       # SeaweedFS S3 read URL); noded fetches it on the pod network. See
@@ -285,7 +294,85 @@ containers:
         mountPath: /dev/kvm
       - name: nvme
         mountPath: {{ $ctx.Values.noded.firecracker.nvmeRoot }}
+{{- if $ctx.Values.egress.enabled }}
+  # Egress-proxy sidecar (ADR 023). noded tunnels each guest's vsock egress to
+  # this process over localhost; it is the only thing in the pod that reaches the
+  # network on a guest's behalf. Keeping it a separate container is the point: the
+  # daemon parses guest control frames but never egress bytes and holds no
+  # credential, so a daemon compromise does not hand over the secrets.
+  # nosemgrep: require-readiness-probe
+  - name: egress-proxy
+    image: "{{ $ctx.Values.egress.image.repository }}@{{ $ctx.Values.egress.image.digest }}"
+    imagePullPolicy: {{ $ctx.Values.noded.image.pullPolicy | default "IfNotPresent" }}
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 65532
+      runAsGroup: 65532
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+    env:
+      # Must match EMBERVM_NODED_EGRESS_SIDECAR_ADDR on the noded container: the
+      # daemon dials what this binds.
+      - name: EGRESS_LISTEN
+        value: ":8888"
+      # Split-horizon guardrail. Secret egressTo hosts are external and are
+      # reached by external:allow, so they never belong in the internal allowlist.
+      - name: EGRESS_EXTERNAL
+        value: {{ $ctx.Values.egress.external | default "allow" | quote }}
+      - name: EGRESS_INTERNAL_DEFAULT
+        value: {{ $ctx.Values.egress.internal.default | default "deny" | quote }}
+      {{- with $ctx.Values.egress.internal.allowlist }}
+      - name: EGRESS_INTERNAL_ALLOWLIST
+        value: {{ join "," . | quote }}
+      {{- end }}
+      {{- with $ctx.Values.egress.internal.cidrs }}
+      - name: EGRESS_INTERNAL_CIDRS
+        value: {{ join "," . | quote }}
+      {{- end }}
+      {{- if $ctx.Values.egress.secrets }}
+      # Phase 6b. EGRESS_SECRETS is the NON-secret catalog (placeholder -> env ->
+      # egressTo); each real value arrives separately from its own Secret below,
+      # so the catalog itself is safe to render into the pod spec.
+      {{- $catalog := list }}
+      {{- range $s := $ctx.Values.egress.secrets }}
+      {{- $catalog = append $catalog (dict "placeholder" $s.placeholder "env" $s.env "egressTo" $s.egressTo) }}
+      {{- end }}
+      - name: EGRESS_SECRETS
+        value: {{ $catalog | toJson | quote }}
+      - name: EGRESS_CA_CERT_FILE
+        value: /etc/egress-ca/tls.crt
+      - name: EGRESS_CA_KEY_FILE
+        value: /etc/egress-ca/tls.key
+      {{- range $s := $ctx.Values.egress.secrets }}
+      - name: {{ $s.env }}
+        {{- if $s.secretRef }}
+        valueFrom:
+          secretKeyRef:
+            name: {{ $s.secretRef.name }}
+            key: {{ $s.secretRef.key }}
+        {{- else }}
+        value: {{ $s.value | quote }}
+        {{- end }}
+      {{- end }}
+      {{- end }}
+    {{- if $ctx.Values.egress.secrets }}
+    volumeMounts:
+      - name: egress-ca
+        mountPath: /etc/egress-ca
+        readOnly: true
+    {{- end }}
+    resources:
+      {{- toYaml $ctx.Values.egress.resources | nindent 6 }}
+{{- end }}
 volumes:
+{{- if and $ctx.Values.egress.enabled $ctx.Values.egress.secrets }}
+  - name: egress-ca
+    secret:
+      secretName: {{ include "embervm.fullname" $ctx }}-egress-ca
+{{- end }}
   - name: dev-kvm
     hostPath:
       path: /dev/kvm

--- a/projects/embervm/chart/templates/workload-claude-runtime.yaml
+++ b/projects/embervm/chart/templates/workload-claude-runtime.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.claudeRuntimeWorkload.enabled }}
+# The claude-runtime workload (issue #4055): voice-drivable Claude Code agent
+# sessions, and the first consumer of the guest egress lane (ADR 023).
+#
+# This is the object the monolith addresses. agent_sessions/transport.py POSTs to
+# /v1/workloads/{name}/sessions and then /v1/sessions/{id}/invoke with
+# X-Ember-Guest-Path: /shim/turn, so the name here is a cross-service contract
+# with that module, not a local label.
+#
+# Session class, not stateful: a session VM survives an invoke (SessionAssign,
+# not Assign), banks to a node snapshot when idle, and relights on the next
+# invoke, so the CLI process and its conversation accrete across turns. It has no
+# writable volume by design; the workspace is tmpfs, which is why memMib carries
+# the checkout as well as the process (see the disk arithmetic in values.yaml).
+#
+# Egress is NOT a field here. The lane is a daemon-level switch
+# (EMBERVM_NODED_EGRESS_ENABLED) and the policy lives in the egress-proxy
+# sidecar, so a workload does not opt in; it simply configures a client to use
+# the port, which only this guest does.
+apiVersion: embervm.dev/v1alpha1
+kind: Workload
+metadata:
+  name: {{ .Values.claudeRuntimeWorkload.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # Apply after the CRD (wave 0) establishes, like every other workload.
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    {{- include "embervm.labels" . | nindent 4 }}
+spec:
+  class: session
+  source:
+    image:
+      # Bazel-pinned from the runtime-claude guest image's .info provider, the
+      # same digest the rootfs-builder initContainer bakes onto node scratch, so
+      # the Workload and the rootfs on disk can never disagree.
+      ref: "{{ .Values.runtimeClaude.guestImage.repository }}@{{ .Values.runtimeClaude.guestImage.digest }}"
+      port: {{ .Values.claudeRuntimeWorkload.port }}
+      readyPath: {{ .Values.claudeRuntimeWorkload.readyPath | quote }}
+      invokePath: {{ .Values.claudeRuntimeWorkload.invokePath | quote }}
+  resources:
+    vcpus: {{ .Values.claudeRuntimeWorkload.vcpus }}
+    memMib: {{ .Values.claudeRuntimeWorkload.memMib }}
+  concurrency:
+    # floor is the pristine pool kept warm for fast create (0 here: see values),
+    # cap is the max number of LIVE session VMs. Banked sessions hold only disk
+    # and are bounded separately by session.maxSessions.
+    floor: {{ .Values.claudeRuntimeWorkload.floor }}
+    cap: {{ .Values.claudeRuntimeWorkload.cap }}
+  session:
+    idleBankSeconds: {{ .Values.claudeRuntimeWorkload.session.idleBankSeconds }}
+    maxLifetimeSeconds: {{ .Values.claudeRuntimeWorkload.session.maxLifetimeSeconds }}
+    bankedTtlSeconds: {{ .Values.claudeRuntimeWorkload.session.bankedTtlSeconds }}
+    maxSessions: {{ .Values.claudeRuntimeWorkload.session.maxSessions }}
+    invokeQueueCap: {{ .Values.claudeRuntimeWorkload.session.invokeQueueCap }}
+{{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -989,3 +989,100 @@ bricks:
   # onto whichever node the scheduler fills first. Empty by default (no
   # floors); deploy/values.yaml sets the fleet's actual floor entries.
   nodeFloors: []
+
+# Guest egress lane (ADR 023). When enabled, noded serves each guest's vsock
+# egress port and tunnels every connection to a pod-local egress-proxy sidecar,
+# the only process that reaches the network on a guest's behalf. The daemon never
+# parses the bytes, so the secret-holding proxy stays a separate blast radius.
+#
+# Off by default: a node without the sidecar must not open the lane. The claude
+# runtime is the first and only consumer, because it is the only guest that
+# points a client at the egress port (via HTTPS_PROXY); every other guest ignores
+# the listener entirely, which is why this is one daemon-level switch rather than
+# a per-workload field threaded through the CRD and control plane.
+egress:
+  enabled: false
+  # Split-horizon posture (ADR 023). external "allow" lets the agent read the open
+  # internet; internal is deny-by-default and confined to internal.allowlist.
+  # Classification is on the IP the sidecar actually resolves and dials, not the
+  # host the guest claims, so a public name pointed at an internal address is
+  # still denied and a hostile guest cannot race DNS.
+  external: allow
+  internal:
+    default: deny
+    # Internal (cluster/private) destinations permitted under deny-by-default, as
+    # host[:port]. Empty: the claude runtime needs the public internet, not this
+    # cluster, and an agent that could reach in-cluster services is exactly the
+    # pivot this setting exists to prevent.
+    allowlist: []
+    # Extra CIDRs treated as internal beyond the baked private/loopback/link-local
+    # ranges. This cluster's pod/service/node nets are already RFC1918.
+    cidrs: []
+  # Bazel-pinned at chart-build from the egress-proxy image .info provider
+  # (chart/BUILD `images`), so the digest cannot drift from the built image.
+  image: {}
+  # Phase 6b CA: cert-manager mints the self-signed CA the sidecar uses to forge
+  # leaf certs when it TLS-terminates a secret-bearing destination. Only created
+  # when `secrets` below is non-empty.
+  ca:
+    duration: 87600h # 10y; rotation churns guest trust, keep it rare
+    renewBefore: 2160h # 90d
+  # Phase 6b secret catalog. Each entry gives the guest an inert `placeholder` as
+  # env `env`; the sidecar swaps it for the real value only on a connection to a
+  # host in `egressTo`, so the real credential is unreachable everywhere else and
+  # never enters the guest. Empty here: phase 6a (plain allowlist-forward) is what
+  # this chart turns on, and populating this list is what enables 6b.
+  secrets: []
+  # Repo convention: memory requests == limits (no bursting); CPU is a request
+  # only (no limit, to avoid throttling).
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      memory: 64Mi
+
+# The claude-runtime session workload (issue #4055): voice-drivable Claude Code
+# agent sessions. Same frozen guest contract as every other guest (vsock 1027,
+# /shim/ready), but the invoke path is /shim/turn, and the monolith addresses it
+# by the name below (agent_sessions/transport.py defaults to `claude-runtime`), so
+# renaming this without renaming there breaks session creation with a 404.
+#
+# Node disk arithmetic, documented so it is bounded rather than discovered (ADR
+# embervm/002 rule 4). memMib is 4096, so a banked session's memory snapshot is
+# worst-case ~4 GiB. maxSessions 2 (live + banked combined) caps the snapshot dir
+# at 2 x 4 GiB = 8 GiB, and cap 1 caps live RAM at 4 GiB. Deliberately small: this
+# is a single-operator feature sharing node-4 scratch with the task pools and the
+# 8-session sandbox tier, and it is the values knob to raise once the lane has
+# earned its keep.
+#
+# floor is 0, unlike the sandbox tier: a pristine 4 GiB VM held warm is expensive,
+# and the runtime does not need warmth. A cold spawn to first request is ~250ms
+# against an API leg of 1-5s, so warmth would buy roughly 5% of a turn for a
+# permanently resident 4 GiB.
+claudeRuntimeWorkload:
+  enabled: false
+  name: claude-runtime
+  port: 1027
+  readyPath: /shim/ready
+  invokePath: /shim/turn
+  vcpus: 2
+  # 4 GiB: the CLI is a 262 MB Node ELF with a V8 heap on top, and guest-init
+  # mounts tmpfs on both /tmp and /workspace. Those are caps, not reservations, so
+  # they cost only what a turn actually writes, but a session that checks out a
+  # repository and builds it is spending this budget on RAM with no disk to fall
+  # back to (a session-class guest has no writable volume).
+  memMib: 4096
+  floor: 0
+  cap: 1
+  session:
+    # Bank an idle session after 5 minutes. Longer than the sandbox tier's 2: a
+    # voice-driven conversation has human-length gaps between turns, and a bank
+    # plus relight inside one conversation is wasted work.
+    idleBankSeconds: 300
+    # A session rides its birth base until this expires, then the next invoke
+    # 410s onto the current base.
+    maxLifetimeSeconds: 21600
+    bankedTtlSeconds: 21600
+    maxSessions: 2
+    invokeQueueCap: 4

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.246
+      targetRevision: 0.1.247
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -240,3 +240,22 @@ warmthS3Gc:
     - node-2
     - node-3
     - node-4
+
+# Guest egress lane (ADR 023 phase 6a, issue #4071). Turns on the egress-proxy
+# sidecar and tells noded to serve the vsock egress port for each guest. The
+# claude runtime is the only guest that dials it; every other guest ignores the
+# listener, so this is a lane opening rather than a posture change for the fleet.
+#
+# Phase 6a only: plain allowlist-forward with the split-horizon guardrail. No
+# `secrets` catalog, so no CA is minted and the sidecar never terminates TLS. The
+# public internet is reachable (external: allow) and the cluster is not
+# (internal.default: deny), which is what stops an agent in a guest from reaching
+# in-cluster services.
+egress:
+  enabled: true
+
+# Voice-drivable Claude Code agent sessions (issue #4055). The monolith addresses
+# this workload by name, so it must exist before agent_sessions can create a
+# session at all. Sizing and the node disk arithmetic are in chart/values.yaml.
+claudeRuntimeWorkload:
+  enabled: true

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -183,11 +183,26 @@ type Config struct {
 	// notification latency (ADR embervm/009 resolved-question 5).
 	DrainTimeout time.Duration
 
-	// EgressSidecarAddr is the pod-local egress-proxy sidecar TCP address. The
-	// task class gets no NIC and egress is disabled, so this is unused today but
-	// carried so a future egress-enabled workload needs no config reshape.
+	// EgressSidecarAddr is the pod-local egress-proxy sidecar TCP address that
+	// EgressEnabled forwards guest vsock egress to.
 	// Default "127.0.0.1:8888".
 	EgressSidecarAddr string
+
+	// EgressEnabled turns on the guest egress lane (ADR 023 phase 6a): the daemon
+	// serves vsockproto.EgressPort for each live guest and tunnels every
+	// connection to the egress-proxy sidecar at EgressSidecarAddr, which is the
+	// only process that reaches the network on a guest's behalf.
+	//
+	// Daemon-level rather than per-workload on purpose. A guest reaches the lane
+	// only by dialling the egress port, which nothing but a guest configured to
+	// proxy (today: runtime-claude) ever does, so serving it for every guest costs
+	// one idle listener and changes no existing guest's behaviour. Egress POLICY
+	// belongs to the sidecar, which classifies the resolved IP and denies internal
+	// destinations by default; putting an allow/deny bit here as well would split
+	// that decision across two processes.
+	//
+	// Defaults false, so a node without the sidecar deployed never opens the lane.
+	EgressEnabled bool
 
 	// ArchiveFetchTimeout bounds a single zip-lane archive HTTP GET (the R1 zip
 	// lane fetches the archive from the in-cluster SeaweedFS read path on the pod
@@ -379,6 +394,7 @@ func Load() (Config, error) {
 		RestoreReadyTimeout: 2 * time.Second,
 		DrainTimeout:        110 * time.Second,
 		EgressSidecarAddr:   getenvDefault("EMBERVM_NODED_EGRESS_SIDECAR_ADDR", "127.0.0.1:8888"),
+		EgressEnabled:       boolDefault("EMBERVM_NODED_EGRESS_ENABLED", false),
 		ArchiveFetchTimeout: 60 * time.Second,
 		ArchiveMaxBytes:     512 << 20,
 

--- a/projects/embervm/noded/server/BUILD
+++ b/projects/embervm/noded/server/BUILD
@@ -25,6 +25,7 @@ go_library(
     visibility = ["//projects/embervm/noded:__subpackages__"],
     deps = [
         "//projects/embervm/noded/config",
+        "//projects/embervm/noded/egress",
         "//projects/embervm/noded/groupclock",
         "//projects/embervm/noded/serving",
         "//projects/embervm/noded/substrate",

--- a/projects/embervm/noded/server/registry.go
+++ b/projects/embervm/noded/server/registry.go
@@ -182,6 +182,12 @@ type sessionEntry struct {
 	workload    string
 	snapshotRef string // the base ref it was relit/primed from (for correlation)
 	handle      substrate.Handle
+	// egressCancel stops this VM's egress forwarder (ADR 023 phase 6a). Never
+	// nil: a VM with egress disabled carries a no-op, so every teardown path can
+	// call it unconditionally. A session adopted from a primed task VM INHERITS
+	// the forwarder Prime started rather than opening a second one, so the cancel
+	// travels with the VM across that registry move.
+	egressCancel func()
 
 	mu       sync.Mutex // guards inFlight
 	inFlight bool

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -45,6 +45,7 @@ import (
 	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
 
 	"github.com/jomcgi/homelab/projects/embervm/noded/config"
+	"github.com/jomcgi/homelab/projects/embervm/noded/egress"
 	"github.com/jomcgi/homelab/projects/embervm/noded/serving"
 	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
 	"github.com/jomcgi/homelab/projects/embervm/noded/volume"
@@ -991,7 +992,7 @@ func (s *Server) Prime(ctx context.Context, req *nodev1.PrimeRequest) (*nodev1.P
 		workload:     base.workload,
 		snapshotRef:  ref,
 		handle:       h,
-		egressCancel: func() {},
+		egressCancel: s.startEgress(uds, h.ID),
 		state:        vmPrimed,
 	})
 	s.signalChange()
@@ -1104,7 +1105,7 @@ func (s *Server) Destroy(_ context.Context, req *nodev1.DestroyRequest) (*nodev1
 	// A session VM destroyed out of band (e.g. the control plane tearing down a
 	// suspect or terminal session) lives in the distinct session registry.
 	if e := s.sessionVMs.remove(req.GetVmId()); e != nil {
-		if err := s.reap(e.handle, func() {}); err != nil {
+		if err := s.reap(e.handle, e.egressCancel); err != nil {
 			return nil, status.Errorf(codes.Internal, "noded: reap session vm %q: %v", req.GetVmId(), err)
 		}
 		s.signalChange()
@@ -1157,7 +1158,12 @@ func (s *Server) adoptPrimedSession(vmID, sessionID, workload string) (*sessionE
 		workload:    workload,
 		snapshotRef: ve.snapshotRef,
 		handle:      ve.handle,
-		inFlight:    true, // held for the SessionAssign that triggered this adoption
+		// Inherit the forwarder Prime opened for this physical VM. Only the
+		// registry bookkeeping changes here, so opening a second forwarder would
+		// collide on the same unix socket, and dropping the cancel would leak the
+		// goroutine past the session's teardown.
+		egressCancel: ve.egressCancel,
+		inFlight:     true, // held for the SessionAssign that triggered this adoption
 	}
 	s.sessionVMs.add(se)
 	s.signalChange() // the VM moved primed -> session-live; refresh NodeStatus
@@ -1282,12 +1288,17 @@ func (s *Server) Bank(ctx context.Context, req *nodev1.BankRequest) (*nodev1.Ban
 	snapshotRef := newID("sess")
 	ref, err := s.sessionDriver.SnapshotSession(ctx, e.handle, snapshotRef)
 	if err != nil {
-		s.sessionVMs.remove(vmID)
+		// SnapshotSession already tore the VM down, so there is nothing to reap,
+		// but the forwarder is still bound to a socket for a VM that no longer
+		// exists. Stop it here or it outlives every failed bank.
+		if removed := s.sessionVMs.remove(vmID); removed != nil && removed.egressCancel != nil {
+			removed.egressCancel()
+		}
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: bank session vm %q: %v", vmID, err)
 	}
 	// Destroy the VM: the session releases its live capacity and holds only disk.
 	if removed := s.sessionVMs.remove(vmID); removed != nil {
-		s.reap(removed.handle, func() {})
+		s.reap(removed.handle, removed.egressCancel)
 	}
 	s.sessionSnap.add(sessionSnapshotEntry{
 		snapshotRef:     ref.ID,
@@ -1343,13 +1354,18 @@ func (s *Server) Relight(ctx context.Context, req *nodev1.RelightRequest) (*node
 	}
 	cancelPrime()
 
+	// Open this guest's egress lane before the health gate, so a guest whose
+	// readiness depends on reaching the network is not deadlocked by a forwarder
+	// that only starts once it is already ready.
+	relitEgressCancel := s.startEgress(uds, h.ID)
+
 	readyCtx, cancelReady := context.WithTimeout(ctx, s.cfg.RestoreReadyTimeout)
 	readyErr := s.transport.WaitReady(readyCtx, uds, defaultReadyPath)
 	cancelReady()
 	if readyErr != nil {
 		// A restore that never health-gates is discarded; the snapshot stays on disk
 		// for the control plane to decide (never a silent blank VM).
-		s.reap(h, func() {})
+		s.reap(h, relitEgressCancel)
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: relit guest not ready: %v", readyErr)
 	}
 
@@ -1359,11 +1375,12 @@ func (s *Server) Relight(ctx context.Context, req *nodev1.RelightRequest) (*node
 	s.resyncGuestClock(ctx, uds, h.ID)
 
 	s.sessionVMs.add(&sessionEntry{
-		vmID:        h.ID,
-		sessionID:   req.GetSessionId(),
-		workload:    req.GetTrace().GetWorkload(),
-		snapshotRef: ref,
-		handle:      h,
+		vmID:         h.ID,
+		sessionID:    req.GetSessionId(),
+		workload:     req.GetTrace().GetWorkload(),
+		snapshotRef:  ref,
+		handle:       h,
+		egressCancel: relitEgressCancel,
 	})
 	s.signalChange()
 	return &nodev1.RelightResponse{VmId: h.ID}, nil
@@ -2297,6 +2314,29 @@ func (s *Server) WaitForBuildsOrAbort(deadline time.Time) int {
 	s.buildsMu.Unlock()
 	<-done
 	return aborted
+}
+
+// startEgress serves this guest's vsock egress port and tunnels every connection
+// to the pod-local egress-proxy sidecar (ADR 023 phase 6a), returning the cancel
+// that stops it. The returned func is ALWAYS safe to call and always non-nil, so
+// teardown paths never branch: when egress is disabled it is a no-op and no
+// listener is opened at all.
+//
+// The forwarder is bound to context.Background(), not to the request context that
+// created the VM: it must outlive the Prime/Relight RPC and live exactly as long
+// as the guest. Every path that reaps a VM calls the cancel, so the goroutine and
+// its unix socket never outlive the guest they belong to.
+func (s *Server) startEgress(uds, vmID string) func() {
+	if !s.cfg.EgressEnabled {
+		return func() {}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		if err := egress.ServeEgress(ctx, s.logger, uds, s.cfg.EgressSidecarAddr); err != nil {
+			s.logger.Warn("noded: egress forwarder stopped", "vm", vmID, "err", err)
+		}
+	}()
+	return cancel
 }
 
 func (s *Server) subscribe() chan struct{} {

--- a/projects/embervm/runtimes/claude/guest-init/cmd/main.go
+++ b/projects/embervm/runtimes/claude/guest-init/cmd/main.go
@@ -109,6 +109,18 @@ func setDefaultEnv(logger *slog.Logger) {
 		"PYTHONUNBUFFERED":       "1",
 		"TERM":                   "dumb",
 		"EMBER_CLAUDE_WORKSPACE": "/workspace",
+		// The shim treats a committer identity as mandatory and fails a spawn
+		// without one, so every turn would 503 on a guest that has none. A
+		// session-class guest is restored from a SHARED pristine snapshot, so
+		// there is no per-session boot to carry a per-session identity: boot-args
+		// are consumed once, at base-build time, for every session alike.
+		//
+		// So default to a service identity here and let setMmdsEnv override it,
+		// which keeps the guest bootable today without pretending the value is
+		// per-principal. Attributing a commit to the human who asked for it is
+		// per-commit --author, tracked with the rest of git integration in #4070.
+		"EMBER_GIT_USER_NAME":  "EmberVM Agent",
+		"EMBER_GIT_USER_EMAIL": "agent@jomcgi.dev",
 	}
 	for key, value := range defaults {
 		if _, set := os.LookupEnv(key); set {

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -29,6 +29,10 @@ CLOCK_PATH = "/shim/clock"
 DEFAULT_WORKSPACE = "/workspace"
 MAX_REQUEST_BODY_BYTES = 1 << 20
 MAX_TOOL_INPUT_BYTES = 4096
+# Cap on the proxy request head the egress forwarder reads before it knows the
+# destination. Generous for real headers, bounded so a client that never sends
+# the terminating blank line cannot grow this buffer without limit.
+MAX_PROXY_HEAD_BYTES = 64 << 10
 INIT_READ_TIMEOUT = 15.0
 # Per-event inactivity timeout for the read loop in turn(). Resets on every
 # stream event, so a turn emitting steady output can run far longer than this.
@@ -225,11 +229,74 @@ class VsockEgressForwarder:
             except OSError:
                 pass
 
+    @staticmethod
+    def _read_proxy_request(client):
+        """Read the proxy request head and return (host_port, leftover, is_connect).
+
+        The CLI treats this listener as an ordinary HTTP proxy because that is
+        what HTTPS_PROXY means, so it opens with either a CONNECT for a TLS
+        origin or an absolute-URI request for a plain one. The host-side lane
+        speaks neither: it wants a single "host:port\\n" preamble and raw bytes
+        after it. This reads just far enough to learn the destination.
+
+        Returns (None, b"", False) when the head is malformed or oversized, which
+        the caller answers with an error rather than guessing a destination.
+        """
+        head = b""
+        while b"\r\n\r\n" not in head:
+            if len(head) > MAX_PROXY_HEAD_BYTES:
+                return None, b"", False
+            chunk = client.recv(4096)
+            if not chunk:
+                return None, b"", False
+            head += chunk
+        raw_head, _, leftover = head.partition(b"\r\n\r\n")
+        lines = raw_head.split(b"\r\n")
+        parts = lines[0].split()
+        if len(parts) < 2:
+            return None, b"", False
+        method, target = parts[0].upper(), parts[1].decode("latin-1")
+        if method == b"CONNECT":
+            # "CONNECT host:443 HTTP/1.1": the target IS the destination, and the
+            # head is consumed here because the client expects a proxy response
+            # before it starts its TLS handshake.
+            return target, leftover, True
+        # An absolute-URI request ("GET http://host/path HTTP/1.1"). Take the
+        # destination from the Host header, then replay the WHOLE head upstream:
+        # an origin server must accept an absolute-URI request line, so no
+        # rewriting is needed and none is attempted.
+        host_port = None
+        for line in lines[1:]:
+            name, sep, value = line.partition(b":")
+            if sep and name.strip().lower() == b"host":
+                host_port = value.strip().decode("latin-1")
+                break
+        if not host_port:
+            return None, b"", False
+        if ":" not in host_port:
+            host_port += ":80"
+        return host_port, raw_head + b"\r\n\r\n" + leftover, False
+
     def _forward(self, client):
         upstream = None
         try:
+            host_port, pending, is_connect = self._read_proxy_request(client)
+            if host_port is None:
+                client.sendall(b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n")
+                return
             upstream = socket.socket(VSOCK_ADDRESS_FAMILY, socket.SOCK_STREAM)
             upstream.connect((VSOCK_EGRESS_CID, VSOCK_EGRESS_PORT))
+            # The one-line preamble the host lane parses before it dials, and the
+            # only thing this forwarder ever writes on the guest's behalf.
+            upstream.sendall(("%s\n" % host_port).encode("latin-1"))
+            if is_connect:
+                # The tunnel is established as far as the client is concerned; the
+                # sidecar reports a dial failure by closing, which surfaces to the
+                # CLI as a dropped connection rather than a proxy error, matching
+                # how any CONNECT proxy behaves once it has answered.
+                client.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            if pending:
+                upstream.sendall(pending)
             copies = [
                 threading.Thread(target=self._copy, args=(client, upstream)),
                 threading.Thread(target=self._copy, args=(upstream, client)),

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -330,6 +330,14 @@ def test_egress_forwarder_opens_one_vsock_connection_per_accept(monkeypatch):
     forwarder.listen()
     client = socket.create_connection((shim.EGRESS_LOCALHOST, forwarder.port))
     try:
+        # The CLI opens an HTTPS_PROXY connection with CONNECT; the host lane is
+        # told the destination as a bare "host:port" line, and only then do raw
+        # bytes flow.
+        client.sendall(b"CONNECT api.anthropic.com:443 HTTP/1.1\r\n\r\n")
+        preamble = b"api.anthropic.com:443\n"
+        assert vsock_peer.recv(len(preamble)) == preamble
+        established = b"HTTP/1.1 200 Connection Established\r\n\r\n"
+        assert client.recv(len(established)) == established
         client.sendall(b"request")
         assert vsock_peer.recv(7) == b"request"
         vsock_peer.sendall(b"response")
@@ -339,6 +347,79 @@ def test_egress_forwarder_opens_one_vsock_connection_per_accept(monkeypatch):
         client.close()
         vsock_peer.close()
         forwarder.close()
+
+
+def _forwarder_exchange(monkeypatch, request_bytes):
+    """Drive one connection through the forwarder, returning what the lane saw."""
+    forwarder = shim.VsockEgressForwarder(port=0)
+    original_socket = socket.socket
+    vsock_peer, vsock_forwarder = socket.socketpair()
+
+    class FakeVsock:
+        def connect(self, address):
+            pass
+
+        def recv(self, size):
+            return vsock_forwarder.recv(size)
+
+        def sendall(self, data):
+            return vsock_forwarder.sendall(data)
+
+        def shutdown(self, how):
+            return vsock_forwarder.shutdown(how)
+
+        def close(self):
+            return vsock_forwarder.close()
+
+    def socket_factory(family, *args, **kwargs):
+        if family == shim.VSOCK_ADDRESS_FAMILY:
+            return FakeVsock()
+        return original_socket(family, *args, **kwargs)
+
+    monkeypatch.setattr(shim.socket, "socket", socket_factory)
+    forwarder.listen()
+    client = socket.create_connection((shim.EGRESS_LOCALHOST, forwarder.port))
+    try:
+        client.sendall(request_bytes)
+        vsock_peer.settimeout(2)
+        client.settimeout(2)
+        try:
+            upstream_saw = vsock_peer.recv(4096)
+        except (TimeoutError, OSError):
+            upstream_saw = b""
+        try:
+            client_saw = client.recv(4096)
+        except (TimeoutError, OSError):
+            client_saw = b""
+        return upstream_saw, client_saw
+    finally:
+        client.close()
+        vsock_peer.close()
+        forwarder.close()
+
+
+def test_egress_forwarder_takes_absolute_uri_host_and_replays_the_request(monkeypatch):
+    # HTTP_PROXY is set alongside HTTPS_PROXY, so a plain-HTTP request arrives as
+    # an absolute-URI line rather than a CONNECT. The destination comes from Host,
+    # and the whole head is replayed: an origin server must accept an absolute-URI
+    # request line, so the forwarder never rewrites it.
+    upstream_saw, _ = _forwarder_exchange(
+        monkeypatch,
+        b"GET http://example.com/x HTTP/1.1\r\nHost: example.com\r\n\r\n",
+    )
+    assert upstream_saw.startswith(b"example.com:80\n")
+    assert b"GET http://example.com/x HTTP/1.1" in upstream_saw
+
+
+def test_egress_forwarder_rejects_a_head_it_cannot_route(monkeypatch):
+    # No Host header and no CONNECT target: there is no destination to put in the
+    # preamble, so the forwarder answers the client rather than opening a tunnel
+    # to a guessed host.
+    upstream_saw, client_saw = _forwarder_exchange(
+        monkeypatch, b"GET /relative HTTP/1.1\r\n\r\n"
+    )
+    assert upstream_saw == b""
+    assert client_saw.startswith(b"HTTP/1.1 400")
 
 
 def test_session_id_mismatch_is_rejected_and_missing_id_resumes(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes the three integration gaps from #4071, so an MCP tool call can reach a
turn in the guest. Each of the three broke the path on its own.

## What was broken

**No `claude-runtime` Workload.** `agent_sessions/transport.py` POSTs to
`/v1/workloads/claude-runtime/sessions`; nothing by that name existed, so session
creation 404d before a guest was ever involved. The `workloads.runtimeClaude`
entry already in the chart is not this: it only drives the rootfs-builder
initContainer.

**No egress host half.** `egress.ServeEgress` had zero callers in noded, and
`server.go` recorded the lane as "present but unused". There was no egress-proxy
sidecar in this chart either, so `EMBERVM_NODED_EGRESS_SIDECAR_ADDR` pointed at
an unbound port. The guest's `HTTPS_PROXY` dead-ended.

**No committer identity.** `_configure_git` raises on every spawn without one, so
every turn would have returned 503.

## What this does

- **noded serves the lane**, one forwarder per guest tunnelling to the sidecar,
  mirroring the fc-invoke invoker. Gated by `EMBERVM_NODED_EGRESS_ENABLED`,
  daemon-level rather than per-workload: a guest reaches the lane only by
  dialling the port, which only a guest configured to proxy ever does, so
  existing guests are byte-unchanged and egress *policy* stays in the sidecar
  instead of being split across two processes.
- **The egress-proxy sidecar**, ported from the fc-invoke substrate chart and
  sharing the same image rather than forking it. Split-horizon guardrail: the
  public internet is reachable, the cluster is not, classified on the IP the
  sidecar resolves and dials rather than the host the guest claims.
- **The `claude-runtime` session Workload**, pinned to the same digest the
  rootfs-builder bakes, with node disk arithmetic written down (ADR embervm/002
  rule 4): `memMib` 4096, `maxSessions` 2, `cap` 1, so banked snapshots are
  capped at 8 GiB and live RAM at 4 GiB. `floor` is 0 because a cold spawn is
  ~250ms against a 1-5s API leg.
- **A CONNECT-to-preamble bridge in the shim.** `HTTPS_PROXY` makes the CLI send
  `CONNECT`; the host lane reads a single `host:port` line. Without translation
  the proxy would have parsed a CONNECT request line as a hostname.
- **A default service git identity** in guest-init.

## The lifetime bug this was easy to introduce

The forwarder is bound to `context.Background()` so it outlives the RPC that
created the VM, which means its cancel has to be threaded through *every*
teardown path or the goroutine and its socket outlive the guest. Covered: Prime,
relight, both destroy paths, and the failed-bank path where `SnapshotSession` has
already killed the VM so there is nothing left to reap. Session adoption
**inherits** the primed VM's forwarder rather than opening a second one, which
would collide on the same unix socket.

## What still does not work

**A live turn**, because the CLI has no credential. Joe picked the subscription
OAuth token; delivering it is ADR 023 phase 6b, which needs the CA minted and the
guest trusting the forged leaf. The 6b branch of the sidecar template is carried
here but inert (`secrets: []`), so enabling it is a values change plus a
1Password item, not a template change. Tracked in #4071.

## Verification

`ci test`: 753 tests pass. `helm template` renders the sidecar into both the
noded and brick deployments, the env onto noded, and the Workload CR. The shim
suite covers CONNECT, the absolute-URI form (`HTTP_PROXY` is set too), and an
unroutable head, which is answered rather than tunnelled to a guessed host.

Refs #4055