### PR TITLE
fix(monolith): run the ember probes in the API pod, trigger them from Argo

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.306
+version: 0.89.307
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.306
+      targetRevision: 0.89.307
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -482,12 +482,13 @@ _PUBLIC_PRUNE_EXCLUDE = [
     "app/main_domain.py",
     # Batch-jobs entrypoint: runs as :jobs_image, never in the public binary.
     "app/jobs_main.py",
-    # Ember synthetic prober: runs only as the ember-synthetic CronWorkflows in
-    # the jobs image. The public tier ships the READ side (synthetic.py +
+    # Ember synthetic prober and private trigger: run only in the private API
+    # and jobs images. The public tier ships the READ side (synthetic.py +
     # synthetic_models.py, which health.py needs to answer /api/health) but must
-    # not carry the prober that drives the workloads, same split as
+    # not carry the prober or internal endpoint that drives the workloads, same split as
     # worldcup/jobs.py and campsites/jobs.py.
     "ember_public/synthetic_probe.py",
+    "ember_public/synthetic_router.py",
     # Private knowledge routers / write paths / heavy maintenance internals.
     "knowledge/router.py",
     "knowledge/tasks_router.py",
@@ -5112,6 +5113,18 @@ py_test(
         "@pip//pytest",
         "@pip//pytest_asyncio",
         "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "ember_public_synthetic_router_test",
+    srcs = ["ember_public/synthetic_router_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
     ],
 )
 

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -37,41 +37,27 @@ app = typer.Typer(
 )
 
 
-def _run_ember_synthetic() -> None:
-    from ember_public.synthetic_probe import (
-        probe_bazel,
-        probe_pages,
-        probe_postgres,
-        probe_semgrep,
-        record,
-    )
+@app.command("ember-synthetic-trigger")
+def ember_synthetic_trigger() -> None:
+    """Trigger the synthetic probes in the monolith API pod.
+
+    Deliberately lightweight: it POSTs the running API pod's internal endpoint,
+    which fires all four probes IN THAT process (where the embervm token,
+    FC_INVOKE_URL, DEMO_POSTGRES_DSN, and a DB session already live). The
+    probes run in the API pod, not this ephemeral job pod, so the job needs
+    only HTTP access, not tokens or DB.
+    """
+    import httpx
 
     configure_logging()
-    logger.info("ember-synthetic: starting")
-
-    async def run() -> None:
-        probes = {
-            "bazel": probe_bazel(),
-            "semgrep": probe_semgrep(),
-            "pages": probe_pages(),
-            "postgres": probe_postgres(),
-        }
-        results = await asyncio.gather(*probes.values())
-        for demo, result in zip(probes, results):
-            if not result["ok"]:
-                logger.warning("ember synthetic %s failed: %s", demo, result["detail"])
-            await record(demo, result)
-
-    asyncio.run(run())
-    logger.info("ember-synthetic: done")
-
-
-@app.command("ember-synthetic")
-def ember_synthetic() -> None:
-    """Probe Bazel, Semgrep, pages, and Postgres, recording detector state."""
-    # Probe failures intentionally exit 0: health is the failure signal, while
-    # Argo retries and failed-job alerts are reserved for DB recording errors.
-    _run_ember_synthetic()
+    url = os.environ.get("MONOLITH_INTERNAL_URL", "")
+    if not url:
+        raise RuntimeError("MONOLITH_INTERNAL_URL is not set")
+    logger.info("ember-synthetic-trigger: POST %s/internal/ember/synthetic-probe", url)
+    resp = httpx.post(f"{url}/internal/ember/synthetic-probe", timeout=180)
+    resp.raise_for_status()
+    body = resp.json()
+    logger.info("ember-synthetic-trigger: %s", body)
 
 
 @app.callback()

--- a/projects/monolith/app/main_public_imports_test.py
+++ b/projects/monolith/app/main_public_imports_test.py
@@ -82,12 +82,13 @@ FORBIDDEN_MODULES = [
     "worldcup.jobs",
     "worldcup.client",
     "worldcup.sim",
-    # Ember synthetic prober: the public tier reads the probe latch
-    # (ember_public.synthetic) to answer /api/health, but the prober that
-    # drives the demos runs only in the jobs image. Pruned from the public
+    # Ember synthetic prober and private trigger: the public tier reads the probe
+    # latch (ember_public.synthetic) to answer /api/health, but the prober and
+    # internal endpoint that drive the demos run only in private images. Pruned from the public
     # file set in BUILD; this locks the split so a future health.py edit
     # cannot quietly pull the prober into the public closure.
     "ember_public.synthetic_probe",
+    "ember_public.synthetic_router",
 ]
 
 # Snippet run in the child: import the public app, then dump every loaded module

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.380
+version: 0.285.381
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -117,26 +117,6 @@ spec:
                   name: monolith-chat-secrets
                   key: GITHUB_TOKEN
             {{- end }}
-            {{- if .emberSynthetic }}
-            # The ember synthetic probes back the ember_* components of the
-            # public tier's /api/health (jomcgi.dev/health), so a broken demo
-            # 503s the uptime check before a visitor finds it.
-            #
-            # EMBERVM_URL is read from semgrep.embervmUrl, the SAME value the
-            # backend Deployment uses, rather than repeated as a literal in the
-            # entry's env map: a control-plane move must not leave the prober
-            # probing the old address while the backend follows the new one.
-            #
-            # EMBER_SYNTHETIC_BASE_URL is the PUBLIC site, not an in-cluster
-            # Service. The page and demo-postgres probes deliberately egress
-            # through Cloudflare so they exercise the visitor's real path
-            # (CDN + HTTPRoute + SSR); an in-cluster shortcut would also be
-            # dropped by the monolith-public frontend's Cilium ingress policy.
-            - name: EMBERVM_URL
-              value: {{ $.Values.semgrep.embervmUrl | quote }}
-            - name: EMBER_SYNTHETIC_BASE_URL
-              value: {{ $.Values.emberSynthetic.baseUrl | quote }}
-            {{- end }}
             {{- if .whatsapp }}
             # The morning-digest job reads WHATSAPP_TZ for the household-local send
             # time and quiet hours. Derive it from the same single source the

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
             - name: EMBERVM_URL
               value: {{ .Values.semgrep.embervmUrl | quote }}
             {{- end }}
+            {{- if .Values.emberSynthetic.baseUrl }}
+            - name: EMBER_SYNTHETIC_BASE_URL
+              value: {{ .Values.emberSynthetic.baseUrl | quote }}
+            {{- end }}
             {{- if .Values.faas }}
             # FaaS zip-lane function registry (ADR 045 / embervm R1). The read
             # base is the in-cluster SeaweedFS S3 host noded GETs archives from;

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -718,14 +718,10 @@ jobs:
           memory: 128Mi
         limits:
           memory: 256Mi
-    # Ember synthetic probes. These exercise the public demos and write a
-    # pass/fail latch row that the public tier's /api/health reads, so a broken
-    # exhibit 503s jomcgi.dev/health (and the uptime monitor) before a visitor
-    # finds it. Before this, ember_public/health.py could only read a cached
-    # control-plane status plus the last real visitor's query outcome, so with
-    # no visitors a broken demo reported healthy: an unprovisioned base image
-    # failed every cold boot for hours on 2026-07-19 while /api/health stayed
-    # green.
+    # Ember synthetic probes run in the API pod and write a pass/fail latch row
+    # that the public tier's /api/health reads. The cron only triggers the API
+    # endpoint, so its 180s request timeout plus margin covers a cold Postgres
+    # boot; it no longer runs five sequential page fetches in the job pod.
     #
     # All four probes run in this one job, concurrently, so wall time is the
     # slowest probe rather than their sum. 5m suits all four, including the
@@ -736,31 +732,23 @@ jobs:
     # leave the demo warm for a visitor, and costs ~1% of the sleep-savings
     # accrual. Slowing this down would only trade detection latency for nothing.
     - name: ember-synthetic
-      args: ["ember-synthetic"]
+      args: ["ember-synthetic-trigger"]
       schedule: "*/5 * * * *"
       concurrencyPolicy: Forbid
-      # Worst case is 5 sequential page fetches (30s client timeout each), which
-      # dominates the three concurrent workload probes (the postgres one allows
-      # 90s for a cold boot). 300s clears that inside the 5m window, so Forbid
-      # never stacks a backlog.
+      # The trigger allows 180s for a demo-postgres cold boot, plus margin.
       activeDeadlineSeconds: 300
-      # SUSPENDED until the jobs pod can actually reach all four targets. Three
-      # of the four probes failed on environment, not on broken demos, and
-      # latched jomcgi.dev/health to 503 (a false uptime alert):
-      #   bazel    - embervm auth.allowedServiceAccounts admits
-      #              monolith:monolith and monolith-public:monolith-public, but
-      #              this job runs as monolith-workflows:argo-workflow, so the
-      #              control plane 403s "service account not permitted".
-      #   semgrep  - semgrep_scan.client needs FC_INVOKE_URL (set on the backend
-      #              Deployment, never added to this entry's env).
-      #   postgres - POST https://jomcgi.dev/api/ember/postgres/query returns the
-      #              SvelteKit HTML shell, not JSON: /api/ember/* is not on the
-      #              public HTTPRoute for direct external calls.
-      # `pages` was the only one that worked (200 + SSR title on all five).
-      # Re-enable ONLY after a real run proves all four green; a probe that
-      # cannot reach its target is worse than no probe, because it pages you.
+      # SUSPENDED until a live API-pod run proves all four targets green. The
+      # previous job-pod implementation failed three probes on environment,
+      # not on broken demos: bazel lacked the admitted ServiceAccount, semgrep
+      # lacked FC_INVOKE_URL, and postgres used a public HTTP path that is not
+      # routed for direct calls. The API pod now supplies all of those values.
+      # Re-enable ONLY after a real run proves all four green, because a probe
+      # that cannot reach its target is worse than no probe.
       suspend: true
-      emberSynthetic: true
+      env:
+        # The in-cluster API service the trigger POSTs; injected here (not baked
+        # in code) so a release rename cannot silently break the DNS name.
+        MONOLITH_INTERNAL_URL: "http://monolith.monolith.svc.cluster.local:8000"
       resources:
         requests:
           cpu: 100m
@@ -768,8 +756,8 @@ jobs:
         limits:
           memory: 256Mi
 
-# Ember synthetic probes (the ember-synthetic CronWorkflow above). Only the
-# base URL lives here; the probes' control-plane address is read from
+# Ember synthetic probes (the ember-synthetic CronWorkflow above). This now
+# feeds the Deployment, not the cron; the probes' control-plane address is read from
 # semgrep.embervmUrl so it cannot drift from the backend's.
 #
 # This is the PUBLIC origin on purpose, not an in-cluster Service: the page and

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.380
+      targetRevision: 0.285.381
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/ember_public/__init__.py
+++ b/projects/monolith/ember_public/__init__.py
@@ -45,7 +45,9 @@ def register(app: FastAPI) -> None:
     from ember_public.bazel_router import router as bazel_router
     from ember_public.router import router
     from ember_public.semgrep_router import router as semgrep_router
+    from ember_public.synthetic_router import internal_router
 
     app.include_router(router)
     app.include_router(bazel_router)
     app.include_router(semgrep_router)
+    app.include_router(internal_router)

--- a/projects/monolith/ember_public/synthetic_probe.py
+++ b/projects/monolith/ember_public/synthetic_probe.py
@@ -1,4 +1,12 @@
-"""Private jobs-pod synthetic probes for the public Ember demos."""
+"""Synthetic probes for the public Ember demos.
+
+These run in the PRIVATE API pod, driven by synthetic_router's internal
+endpoint, which the ember-synthetic CronWorkflow only triggers. The API pod is
+where the admitted ServiceAccount, FC_INVOKE_URL and DEMO_POSTGRES_DSN live;
+running them in the ephemeral job pod instead is what broke the #4065 rollout.
+Each probe returns its failure in-band as {ok, detail, latency_ms} and never
+raises, because a crashing probe IS the finding.
+"""
 
 from __future__ import annotations
 
@@ -12,7 +20,7 @@ import httpx
 from sqlmodel import Session
 
 from app.db import get_engine
-from ember_public import bazel_core, semgrep_core
+from ember_public import bazel_core, core, semgrep_core
 from ember_public.synthetic_models import EmberSyntheticProbe
 
 logger = logging.getLogger(__name__)
@@ -125,13 +133,13 @@ async def probe_pages() -> dict:
     if not base:
         return {"ok": True, "detail": "not configured", "latency_ms": None}
     started = perf_counter()
-    # This deliberately goes over the public internet, rather than in-cluster:
-    # it covers Cloudflare, the HTTPRoute, and SSR as a visitor experiences
-    # them. monolith-public has Cilium ingress policies
-    # (monolith-public-frontend-ingress) that would drop a cross-namespace
-    # fetch from monolith-workflows into monolith-public anyway. The single
-    # retry with 0.2s backoff prevents one Cloudflare blip from latching the
-    # demo down for a full five-minute probe cadence.
+    # This deliberately goes out over the public internet rather than to the
+    # monolith-public Service in-cluster: it covers Cloudflare, the HTTPRoute
+    # and SSR the way a visitor experiences them, and monolith-public's Cilium
+    # ingress policies would drop a cross-namespace fetch anyway. It is the one
+    # probe that still exercises the public edge now that the others call their
+    # cores in-process. The single retry with 0.2s backoff keeps one Cloudflare
+    # blip from latching the demo down for a whole five-minute cadence.
     try:
         async with httpx.AsyncClient(timeout=30) as client:
             for path, sentinel in PAGE_SENTINELS.items():
@@ -177,48 +185,48 @@ async def probe_pages() -> dict:
 
 
 async def probe_postgres() -> dict:
-    """Probe aggregate through the real public HTTP path.
+    """Probe via a direct core call, not HTTP.
 
-    The router nests the Turnstile/session gate entirely inside the insert
-    branch, so aggregate needs no session cookie, Turnstile token, bypass, or
-    secret. A busy response means visitors own the global semaphore, so it is
-    skipped and the previous latch row remains untouched.
+    Aggregate is read-only (same reads without writing, proving wake needs no
+    write), so the probe never appends to the visitor ledger. It respects the
+    query slot semaphore so it never starves real visitors.
     """
-    base = os.environ.get("EMBER_SYNTHETIC_BASE_URL", "").rstrip("/")
-    if not base:
+    dsn = core.demo_pg_dsn()
+    if not dsn:
         return {"ok": True, "detail": "not configured", "latency_ms": None}
-    try:
-        async with httpx.AsyncClient(timeout=90) as client:
-            response = await client.post(
-                f"{base}/api/ember/postgres/query", json={"mode": "aggregate"}
-            )
-        body = response.json()
-        if body.get("busy") or body.get("error") == "busy":
-            return {
-                "ok": True,
-                "detail": "busy, skipped",
-                "latency_ms": None,
-                "skip": True,
-            }
-        if response.status_code != 200:
-            return {
-                "ok": False,
-                "detail": f"status {response.status_code}: {body.get('error', response.text)}",
-                "latency_ms": body.get("connect_ms"),
-            }
-        if body.get("error") is not None:
-            return {
-                "ok": False,
-                "detail": str(body["error"]),
-                "latency_ms": body.get("connect_ms"),
-            }
+
+    before = None
+    if core.EMBERVM_URL:
+        try:
+            before = await core.cached_demo_pg_status()
+        except Exception as exc:  # noqa: BLE001 - classification is best-effort
+            logger.warning("demo-postgres synthetic pre-query status failed: %s", exc)
+            before = None
+
+    if not core.try_acquire_query_slot():
         return {
             "ok": True,
-            "detail": f"{body.get('classification', 'unknown')}, {body.get('connect_ms')}ms",
-            "latency_ms": body.get("connect_ms"),
+            "detail": "busy, skipped",
+            "latency_ms": None,
+            "skip": True,
+        }
+
+    try:
+        result = await asyncio.to_thread(
+            core.demo_pg_orders_roundtrip, dsn, "aggregate", None
+        )
+        core.record_query_outcome(ok=True, connect_ms=result["connect_ms"])
+        return {
+            "ok": True,
+            "detail": f"{core.classify_wake(before)}, {result.get('connect_ms')}ms",
+            "latency_ms": result.get("connect_ms"),
         }
     except Exception as exc:  # noqa: BLE001 - probes report failures in-band
+        logger.warning("demo-postgres synthetic roundtrip failed: %s", exc)
+        core.record_query_outcome(ok=False, connect_ms=None)
         return _failure(exc)
+    finally:
+        core.release_query_slot()
 
 
 def _record_sync(demo: str, result: dict) -> None:

--- a/projects/monolith/ember_public/synthetic_probe_test.py
+++ b/projects/monolith/ember_public/synthetic_probe_test.py
@@ -30,28 +30,36 @@ async def test_semgrep_empty_findings_is_not_ok(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_postgres_busy_is_skipped(monkeypatch):
-    class Client:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            return None
-
-        async def post(self, *args, **kwargs):
-            return type(
-                "Response",
-                (),
-                {
-                    "status_code": 200,
-                    "text": "",
-                    "json": lambda self: {"busy": True, "error": "busy"},
-                },
-            )()
-
-    monkeypatch.setenv("EMBER_SYNTHETIC_BASE_URL", "https://example.test")
-    monkeypatch.setattr(probe.httpx, "AsyncClient", lambda **_: Client())
+    monkeypatch.setattr(probe.core, "demo_pg_dsn", lambda: "postgres://test")
+    monkeypatch.setattr(probe.core, "try_acquire_query_slot", lambda: False)
     result = await probe.probe_postgres()
     assert result["skip"] is True
+
+
+@pytest.mark.asyncio
+async def test_postgres_aggregate_roundtrip_success(monkeypatch):
+    """Successful aggregate roundtrip records ok with connect_ms as latency."""
+    monkeypatch.setattr(probe.core, "demo_pg_dsn", lambda: "postgres://test")
+    monkeypatch.setattr(probe.core, "EMBERVM_URL", "http://test")
+    monkeypatch.setattr(
+        probe.core,
+        "cached_demo_pg_status",
+        lambda: {"state": "asleep", "generation": 1},
+    )
+    monkeypatch.setattr(probe.core, "try_acquire_query_slot", lambda: True)
+    monkeypatch.setattr(
+        probe.core,
+        "demo_pg_orders_roundtrip",
+        lambda *_: {"connect_ms": 42, "total_ms": 100},
+    )
+    monkeypatch.setattr(probe.core, "record_query_outcome", lambda **_: None)
+    monkeypatch.setattr(probe.core, "classify_wake", lambda _: "cold")
+    monkeypatch.setattr(probe.core, "release_query_slot", lambda: None)
+
+    result = await probe.probe_postgres()
+    assert result["ok"] is True
+    assert result["latency_ms"] == 42
+    assert "cold" in result["detail"]
 
 
 @pytest.mark.asyncio

--- a/projects/monolith/ember_public/synthetic_router.py
+++ b/projects/monolith/ember_public/synthetic_router.py
@@ -1,0 +1,79 @@
+"""Private-tier internal endpoint that runs the ember synthetic probes.
+
+The cron job only TRIGGERS this; the probing happens in the API pod, mirroring
+semgrep_scan.router's /internal/semgrep/harvest-scans ("the harvest runs in the
+API pod, not this ephemeral job pod, so the job needs no tokens or DB access,
+just HTTP").
+
+That split is not stylistic here, it is the fix for the #4065 rollout. Probing
+from the job pod failed on three counts, none of which CI could catch:
+
+- bazel: embervm's auth.allowedServiceAccounts admits
+  system:serviceaccount:monolith:monolith, but an Argo job runs as
+  monolith-workflows:argo-workflow, so the control plane 403s.
+- semgrep: semgrep_scan.client needs FC_INVOKE_URL, which the backend
+  Deployment sets and the job pod never had.
+- postgres: reaching the demo over the public origin returns the SvelteKit HTML
+  shell, because /api/ember/* is not on the public HTTPRoute.
+
+This pod holds the admitted ServiceAccount and all three env vars, so each of
+those disappears rather than being worked around.
+
+A failing probe still returns 200: the failure travels through the recorded
+latch row into /api/health, which is the alerting surface. Only an unreachable
+endpoint or a failed DB write should fail the triggering job.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from fastapi import APIRouter
+
+logger = logging.getLogger(__name__)
+
+internal_router = APIRouter(prefix="/internal/ember", tags=["ember-internal"])
+
+# Guards against overlapping runs: a second trigger while one is in flight is a
+# no-op rather than a second concurrent sweep competing for the same demo VMs
+# (mirrors semgrep_scan.router's _harvest_in_flight).
+_probe_in_flight = False
+
+
+@internal_router.post("/synthetic-probe")
+async def synthetic_probe_endpoint() -> dict:
+    """Run all four ember probes concurrently and record their latch rows."""
+    global _probe_in_flight
+
+    if _probe_in_flight:
+        logger.info("synthetic probe already in flight, skipping this trigger")
+        return {"skipped": True, "detail": "already running"}
+
+    _probe_in_flight = True
+    try:
+        from ember_public import synthetic_probe
+
+        probes = {
+            "bazel": synthetic_probe.probe_bazel,
+            "semgrep": synthetic_probe.probe_semgrep,
+            "pages": synthetic_probe.probe_pages,
+            "postgres": synthetic_probe.probe_postgres,
+        }
+        # Concurrent, so wall time is the slowest probe rather than their sum.
+        # Every probe returns its failure in-band, so gather never raises here.
+        outcomes = await asyncio.gather(*(probe() for probe in probes.values()))
+        results = dict(zip(probes, outcomes))
+
+        for demo, result in results.items():
+            if not result["ok"]:
+                logger.warning("ember synthetic %s failed: %s", demo, result["detail"])
+
+        # Recording IS allowed to raise: a failed write means the detector is
+        # blind, which the triggering job should surface as a job failure.
+        await asyncio.gather(
+            *(synthetic_probe.record(demo, result) for demo, result in results.items())
+        )
+        return results
+    finally:
+        _probe_in_flight = False

--- a/projects/monolith/ember_public/synthetic_router_test.py
+++ b/projects/monolith/ember_public/synthetic_router_test.py
@@ -1,0 +1,115 @@
+"""Tests for the internal ember synthetic-probe endpoint.
+
+Every probe is mocked: the point of these tests is the endpoint's orchestration
+(running all four, recording each, the in-flight guard), not the probes
+themselves, which are covered in synthetic_probe_test.py.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ember_public import synthetic_router
+from ember_public.synthetic_router import internal_router
+
+DEMOS = ("bazel", "semgrep", "pages", "postgres")
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.include_router(internal_router)
+    return app
+
+
+@pytest.fixture
+def recorded(monkeypatch):
+    """Mock all four probes plus record(); return the recorded {demo: result}."""
+    rows: dict[str, dict] = {}
+
+    def install(ok: bool = True, detail: str = "test"):
+        for demo in DEMOS:
+
+            async def probe(_demo=demo):
+                return {"ok": ok, "detail": f"{detail}:{_demo}", "latency_ms": 10.0}
+
+            monkeypatch.setattr(f"ember_public.synthetic_probe.probe_{demo}", probe)
+
+        async def record(demo, result):
+            rows[demo] = result
+
+        monkeypatch.setattr("ember_public.synthetic_probe.record", record)
+        return rows
+
+    return install
+
+
+def test_runs_every_probe_and_records_each(app, recorded):
+    rows = recorded()
+
+    resp = TestClient(app).post("/internal/ember/synthetic-probe")
+
+    assert resp.status_code == 200
+    assert set(resp.json()) == set(DEMOS)
+    # Recorded, not merely returned: the latch row is what /api/health reads.
+    assert set(rows) == set(DEMOS)
+    assert rows["bazel"]["detail"] == "test:bazel"
+
+
+def test_probe_failure_still_returns_200_and_records(app, recorded):
+    """A failing probe is not an endpoint error: the latch row carries it.
+
+    The triggering job must exit 0 so Argo retries and failed-job alerts stay
+    reserved for a genuinely unreachable endpoint or a failed DB write.
+    """
+    rows = recorded(ok=False, detail="boom")
+
+    resp = TestClient(app).post("/internal/ember/synthetic-probe")
+
+    assert resp.status_code == 200
+    assert resp.json()["bazel"]["ok"] is False
+    assert rows["bazel"]["ok"] is False
+
+
+def test_trigger_while_in_flight_is_a_noop(app, recorded, monkeypatch):
+    """The guard short-circuits without running or recording anything."""
+    rows = recorded()
+    monkeypatch.setattr(synthetic_router, "_probe_in_flight", True)
+
+    resp = TestClient(app).post("/internal/ember/synthetic-probe")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"skipped": True, "detail": "already running"}
+    assert rows == {}
+
+
+def test_in_flight_flag_is_cleared_after_a_run(app, recorded):
+    """A run must not wedge the guard, or every later trigger no-ops forever."""
+    recorded()
+    client = TestClient(app)
+
+    client.post("/internal/ember/synthetic-probe")
+
+    assert synthetic_router._probe_in_flight is False
+    assert set(client.post("/internal/ember/synthetic-probe").json()) == set(DEMOS)
+
+
+def test_record_failure_propagates(app, monkeypatch):
+    """A failed write must surface, so the job fails rather than going blind."""
+    for demo in DEMOS:
+
+        async def probe(_demo=demo):
+            return {"ok": True, "detail": "ok", "latency_ms": 1.0}
+
+        monkeypatch.setattr(f"ember_public.synthetic_probe.probe_{demo}", probe)
+
+    async def record(demo, result):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr("ember_public.synthetic_probe.record", record)
+
+    with pytest.raises(RuntimeError, match="db down"):
+        TestClient(app).post("/internal/ember/synthetic-probe")
+
+    # The guard must still be released when recording blew up mid-run.
+    assert synthetic_router._probe_in_flight is False


### PR DESCRIPTION
## Why

The #4065 rollout probed from the ephemeral Argo job pod and failed on three counts, none of which CI could catch, then latched `jomcgi.dev/health` to 503 (fixed by suspending in #4074):

| Probe | Cause |
|---|---|
| bazel | embervm's `auth.allowedServiceAccounts` admits `system:serviceaccount:monolith:monolith`; an Argo job runs as `monolith-workflows:argo-workflow`, so the control plane 403s. |
| semgrep | `semgrep_scan.client` needs `FC_INVOKE_URL`, which only the backend Deployment sets. |
| postgres | Reaching the demo over the public origin returns the SvelteKit HTML shell, because `/api/ember/*` is not on the public HTTPRoute. |

## The fix

Rather than widening embervm's allowlist to the **shared** Argo executor SA (which would grant control-plane access to every job in that namespace), move the work to the pod that already has what it needs. The cron now only POSTs `/internal/ember/synthetic-probe`; the API pod runs all four probes in-process.

This mirrors the existing `semgrep-harvest-trigger` precedent exactly, whose docstring already states the reasoning: *"the harvest runs in the API pod, not this ephemeral job pod, so the job needs no tokens or DB access, just HTTP"*.

All three failures disappear rather than being worked around, and no cross-service grant is needed.

## Verified live before writing any of it

- API pod SA is `monolith`, which is in embervm's allowlist.
- API pod has `FC_INVOKE_URL`, `EMBERVM_URL` and `DEMO_POSTGRES_DSN`.
- `semgrep-scan-harvest`, using the identical trigger path, succeeded 14 minutes before this was written.

## Notable changes

- `ember_public/synthetic_router.py`: private-tier-only `internal_router`, in-flight guard mirroring `_harvest_in_flight`. A failing probe still returns 200, because the failure travels through the latch row into `/api/health`; only an unreachable endpoint or a failed DB write fails the job.
- `probe_postgres` calls the core directly for a read-only `aggregate` roundtrip, holding the same query-slot semaphore the visitor path uses so it never starves a real visitor, and feeding `record_query_outcome` so the passive `demo_postgres` component sees it too. No HTTP, so no routing problem.
- `probe_pages` unchanged, still over the public origin. It is the one probe covering Cloudflare, the HTTPRoute and SSR, and the only one that worked before.
- `EMBER_SYNTHETIC_BASE_URL` moves from the cron entry to the Deployment; the `{{- if .emberSynthetic }}` cron block is deleted entirely.
- `synthetic_router.py` joins `synthetic_probe.py` in `_PUBLIC_PRUNE_EXCLUDE` and `FORBIDDEN_MODULES`. The public tier still ships only the read side.

## Still suspended, deliberately

`suspend: true` stays. This detector pages Joe when it is wrong, and the last rollout proved green CI says nothing about auth, routing or env. Sequence: merge this, hand-trigger the endpoint in-cluster, confirm all four probes green, then flip `suspend` in a separate PR.

`ci test`: 751 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WQAne8Y28jP2NNzgsnrKf