### PR TITLE
feat(embervm): report base refs per CPU vendor in Workload status

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.247
+version: 0.1.248

--- a/projects/embervm/chart/crds/workload-crd.yaml
+++ b/projects/embervm/chart/crds/workload-crd.yaml
@@ -872,6 +872,22 @@ spec:
                 snapshotDigest:
                   type: string
                   description: Resolved OCI image digest the base was built from.
+                snapshotRefs:
+                  type: object
+                  description: >-
+                    Base refs the fleet currently reports for this workload,
+                    grouped by CPU vendor. Observability only: additive to
+                    snapshotRef, which stays the single builder-advanced handle.
+                    A base ref is vendor-specific by construction (Firecracker
+                    snapshots cannot cross CPU vendors), so a mixed fleet holds
+                    one ref per vendor. Each value is a LIST because a vendor
+                    legitimately holds two refs mid-rollout, while some nodes
+                    still run the previous runtime image. Absent until at least
+                    one node reports a base.
+                  additionalProperties:
+                    type: array
+                    items:
+                      type: string
                 primedFloorSatisfied:
                   type: boolean
                 sessions:

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -2108,7 +2108,7 @@ defmodule Embervm.BaseBuilder do
 
     status_map =
       %{"conditions" => [ready, base_built]}
-      |> maybe_put_snapshot(w, phase)
+      |> maybe_put_snapshot(state, w, phase)
 
     case state.status_writer.(w.namespace, w.name, status_map) do
       :ok ->
@@ -2125,13 +2125,59 @@ defmodule Embervm.BaseBuilder do
     state
   end
 
-  defp maybe_put_snapshot(status_map, w, :built) do
+  defp maybe_put_snapshot(status_map, state, w, :built) do
     status_map
     |> Map.put("snapshotRef", w.snapshot_ref || "")
     |> Map.put("snapshotDigest", w.snapshot_digest || "")
+    |> put_snapshot_refs(state, w)
   end
 
-  defp maybe_put_snapshot(status_map, _w, _phase), do: status_map
+  defp maybe_put_snapshot(status_map, state, w, _phase), do: put_snapshot_refs(status_map, state, w)
+
+  # Additive per-vendor fleet view (#4061). Written on EVERY phase, not just
+  # :built, because it is derived from live capacity facts rather than from build
+  # state: gating it on a build would leave it stale after an unrelated node
+  # rebuilt its own base or after retention evicted one. An EMPTY map is never
+  # written, so a CP that has not yet heard from any node cannot clobber a good
+  # value with {} (the same fail-open posture as find_capacity_fact/2).
+  defp put_snapshot_refs(status_map, state, w) do
+    case snapshot_refs_by_vendor(state, w) do
+      empty when map_size(empty) == 0 -> status_map
+      refs -> Map.put(status_map, "snapshotRefs", refs)
+    end
+  end
+
+  # The base refs the FLEET reports for this workload, grouped by CPU vendor:
+  #
+  #     %{"amd" => ["bazel-query__426e..."], "intel" => ["bazel-query__00ad..."]}
+  #
+  # A LIST per vendor, not a single ref. A vendor legitimately holds two refs
+  # mid-rollout (observed 2026-07-27: node-1/2 on one Intel ref, node-3 still on
+  # the previous runtime image with another), and the per-node capacity fact
+  # carries no base digest, so the CP cannot tell "current" from "superseded"
+  # here. Collapsing to one ref would make the written value depend on fact
+  # iteration order and could report a superseded ref as current during exactly
+  # the window a reader consults status to decide whether a rollout has landed.
+  #
+  # status.snapshotRef stays the single builder-advanced ref and is unchanged;
+  # this field is observability, not a resolution input. Placement and the pool
+  # already resolve each node's ref from that node's own reported facts, so no
+  # consumer reads this to decide what to restore.
+  defp snapshot_refs_by_vendor(state, w) do
+    state
+    |> representative_facts_by_node(w.name)
+    |> Enum.reduce(%{}, fn fact, acc ->
+      vendor = fact |> Map.get(:cpu_vendor, "") |> to_string() |> String.trim()
+      ref = get_in(fact, [:workloads, w.name, :snapshot_ref])
+
+      if vendor != "" and is_binary(ref) and ref != "" do
+        Map.update(acc, vendor, [ref], &[ref | &1])
+      else
+        acc
+      end
+    end)
+    |> Map.new(fn {vendor, refs} -> {vendor, refs |> Enum.uniq() |> Enum.sort()} end)
+  end
 
   defp ready_condition(state, w) do
     if w.snapshot_ref do

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -1814,4 +1814,125 @@ defmodule Embervm.BaseBuilderTest do
 
     NodeCapacity.put(table, {node_id, pod_uid}, Map.put(existing, :workloads, workloads))
   end
+
+  # -- per-vendor base refs in status (#4061) ---------------------------------
+
+  # A capacity fact carrying the node's CPU vendor alongside its OWN reported base
+  # ref for `workload`. pod_uid nil keeps instance_id the bare node name, which is
+  # what find_capacity_fact/2 matches for the builder's placement node ("node-4").
+  defp put_vendor_fact(table, node_id, pod_uid, workload, ref, vendor) do
+    instance_id = if pod_uid in [nil, ""], do: node_id, else: "#{node_id}/#{pod_uid}"
+
+    NodeCapacity.put(table, {node_id, pod_uid || "ds"}, %{
+      node_id: node_id,
+      configured_id: node_id,
+      instance_id: instance_id,
+      cpu_vendor: vendor,
+      workloads: %{
+        workload => %{
+          snapshot_ref: ref,
+          base_state: :BASE_BUILD_STATE_READY,
+          exported: true
+        }
+      },
+      local_bases: [],
+      updated_at: 0
+    })
+  end
+
+  test "status carries one entry per CPU vendor the fleet reports a base on" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_vendor_fact(table, "node-4", nil, "w", "w__amd", "amd")
+    put_vendor_fact(table, "node-1", "ds", "w", "w__intel", "intel")
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__amd")} end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun
+      )
+
+    build_current(builder, agent, "w__amd")
+
+    status = latest(agent, "w")
+
+    # The single builder-advanced handle is unchanged (additive field).
+    assert status["snapshotRef"] == "w__amd"
+    assert status["snapshotRefs"] == %{"amd" => ["w__amd"], "intel" => ["w__intel"]}
+  end
+
+  test "a vendor mid-rollout carries BOTH of its refs, sorted, not an arbitrary winner" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_vendor_fact(table, "node-4", nil, "w", "w__amd", "amd")
+    # node-1 rebuilt; node-2 still runs the previous runtime image. Same vendor,
+    # two live refs. Collapsing to one would be order-dependent and could report
+    # the superseded ref as current.
+    put_vendor_fact(table, "node-1", "ds", "w", "w__intel_new", "intel")
+    put_vendor_fact(table, "node-2", "ds", "w", "w__intel_old", "intel")
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__amd")} end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun
+      )
+
+    build_current(builder, agent, "w__amd")
+
+    assert latest(agent, "w")["snapshotRefs"] == %{
+             "amd" => ["w__amd"],
+             "intel" => ["w__intel_new", "w__intel_old"]
+           }
+  end
+
+  test "a node reporting no CPU vendor is left out rather than keyed under an empty vendor" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_vendor_fact(table, "node-4", nil, "w", "w__amd", "amd")
+    # A daemon that predates vendor reporting: no key, not a wrong key.
+    put_vendor_fact(table, "node-1", "ds", "w", "w__unknown", "")
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__amd")} end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun
+      )
+
+    build_current(builder, agent, "w__amd")
+
+    assert latest(agent, "w")["snapshotRefs"] == %{"amd" => ["w__amd"]}
+  end
+
+  test "no vendor known anywhere omits the key rather than writing an empty map" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_vendor_fact(table, "node-4", nil, "w", "w__amd", "")
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__amd")} end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun
+      )
+
+    build_current(builder, agent, "w__amd")
+
+    status = latest(agent, "w")
+
+    # Absent, NOT %{}: a CP that has heard no vendors must not clobber a good
+    # value already on the CR with an empty map.
+    refute Map.has_key?(status, "snapshotRefs")
+    assert status["snapshotRef"] == "w__amd"
+  end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.247
+      targetRevision: 0.1.248
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Closes #4061. Splits the export-gate design point out to #4079.

## What

Adds `status.snapshotRefs`, an additive map of CPU vendor to the base refs the fleet reports for a workload:

```yaml
status:
  snapshotRef: bazel-query__426e3036636c      # unchanged, single builder-advanced handle
  snapshotDigest: ...@sha256:70f7d13e
  snapshotRefs:
    amd:   [bazel-query__426e3036636c]
    intel: [bazel-query__00ada79f752f, bazel-query__c227418a9b7f]
```

`snapshotRef` keeps its current meaning, so nothing that reads it changes and the `.status.snapshotRef` print column still works. No CR migration is needed.

## Scope: smaller than the issue proposed, and why

The issue proposed widening `snapshot_ref` to a `vendor -> ref` map across 12 CP modules plus a status-shape migration. Investigation found **the functional half is already done**:

- `SessionPlacement.node_for_create` reads the ref from `fact.workloads[wl]`, the **node's own reported inventory**, not from the CR. `eligible_for_workload?` skips any node whose own `base_state` is not READY with a non-empty ref.
- `PoolManager.ready_workloads/2` does the same, per node, inside a `refill_node` loop over `NodeCapacity.all()`.
- #4052 already made export and retention per node.

Against the issue's acceptance criteria: placement resolves per vendor **already holds**; a node whose vendor has no base is skipped cleanly **already holds**; retention still evicts per node **already holds**. Only "a workload with bases built on both vendors carries both refs in CR status" was unmet. Confirmed live: `bazel-query` status showed only `426e3036636c` (node-4, AMD) while both Intel refs existed on disk and were invisible.

The issue's supporting citation does not say what it claims. `base_builder.ex` "today's single-vendor fleet" is about `stamp_key/2` falling back to a raw node_id when no capacity fact is found, a CPU template stamping fallback, not `snapshot_ref` modelling. It even ends "correct once vendors are reported", and vendors are now reported.

The larger grep counts in the issue come from the name being overloaded: the op-log carries `base_snapshot_ref` **and** `snapshot_ref` as separate columns, and most hits are per-instance bank refs, a different concept. Genuine `w.snapshot_ref` reads are 18 in `base_builder.ex` and 1 in `pool_manager.ex`, and the latter is the node's own ref, not the CR's.

## Why a list per vendor, not a single ref

A vendor legitimately holds two refs mid-rollout. Observed live on 2026-07-27:

| Node | Vendor | ref | base built | runtime imageref |
|---|---|---|---|---|
| node-4 | amd | `426e3036636c` | | |
| node-1 | intel | `00ada79f752f` | 07:52 | `@sha256:70f7d13e` |
| node-2 | intel | `00ada79f752f` | | |
| node-3 | intel | `c227418a9b7f` | 02:43 | `@sha256:88d7a80c` |

node-3 is not a same-vendor divergence, it is staleness: it still holds a base built from an older bazel runtime image. So `vendor -> ref` is well-defined **in steady state** and ill-defined precisely during a rollout.

The per-node capacity fact carries `snapshot_ref`, `base_state` and `exported` but **no base digest**, so the CP cannot tell current from superseded here. Collapsing to one ref would make the written value depend on fact iteration order, and could report a superseded ref as current during exactly the window a reader consults status to decide whether a rollout has landed. A status field correct only in steady state is a trap, because status is read during rollouts. Refs are sorted so an unchanged fleet writes a stable value.

Filtering by digest at source is the structurally cleaner model, but it needs a proto field on `WorkloadCapacity` plus noded changes and a wire-compat story for older daemons. That is a cross-component change, deliberately not bundled here.

## Write timing

Written on every phase rather than only on `:built`, because the map derives from live capacity facts rather than build state, and gating it on a build would leave it stale after an unrelated node rebuild or a retention eviction. An **empty map is never written**, so a CP that has not yet heard from any node cannot clobber a good value with `{}`. Same fail-open posture as `find_capacity_fact/2`.

## Tests

Four new cases in `base_builder_test.exs`:

- two vendors each carry their own ref, and `snapshotRef` is unchanged
- a vendor mid-rollout carries **both** refs, sorted, rather than an arbitrary winner
- a node reporting no CPU vendor is left out rather than keyed under `""`
- no vendor known anywhere omits the key rather than writing `{}`

`ci test` green: `968 tests, 0 failures, 6 skipped` (was 964).

## Deploy

CRD change, so chart bumped to `0.1.248` with `Chart.yaml` and `deploy/application.yaml` moved together.