### PR TITLE
fix(embervm): let a visitor wake demo-postgres via the node-local activator

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.248
+version: 0.1.249

--- a/projects/embervm/chart/templates/workload-demo-postgres.yaml
+++ b/projects/embervm/chart/templates/workload-demo-postgres.yaml
@@ -61,4 +61,12 @@ spec:
     autoWake: {{ .Values.demoPostgres.autoWake }}
     # Reuse the scratch-postgres Secret: same superuser password on first boot.
     secretRef: {{ include "embervm.fullname" . }}-scratch-postgres
+    # Node-local activator (ADR embervm/018 Phase 2). REQUIRED for a visitor to be
+    # able to wake this exhibit at all: noded's statefulByListenPort gate is
+    # `NodeLocalWake && StatefulListenPort == port`, so with this false the L4
+    # activator logs "no eligible workload for listener" and closes the connection
+    # (issue #4077). autoWake above only covers the base-READY case, which is the
+    # control plane waking itself, never a connection arriving on 5401.
+    nodeLocalWake: {{ .Values.demoPostgres.nodeLocalWake }}
+    meteringFailOpen: {{ .Values.demoPostgres.meteringFailOpen }}
 {{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -636,6 +636,17 @@ demoPostgres:
   # would otherwise leave the demo wedged until a manual forced wake, so the CP
   # wakes it as soon as the rebuilt base advertises READY.
   autoWake: true
+  # Node-local activator (ADR embervm/018 Phase 2), same rationale as
+  # scratch-postgres above, and NOT optional for this workload: the daemon's
+  # statefulByListenPort gate requires nodeLocalWake, so without it the L4
+  # activator answers a connect on 5401 with "no eligible workload for listener"
+  # and closes the socket. That left the public exhibit unwakeable while
+  # /api/health still read "banked, pair valid" (issue #4077): the control plane
+  # can wake this workload (autoWake does), but nothing converts a VISITOR's
+  # connection into a wake. meteringFailOpen names the wake-unmetered-during-gap
+  # policy, as for the other blessed demo.
+  nodeLocalWake: true
+  meteringFailOpen: true
   # Toy dataset: a handful of demo rows, not a real datastore.
   volumeSizeGiB: 2
 

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.248
+      targetRevision: 0.1.249
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Fixes the public ember demo-postgres exhibit, which no visitor could wake.

## The bug

noded resolves an L4 stateful activator connection purely from the local accept
port, and the gate requires BOTH the port match and the opt-in flag
(`noded/server/registry_workload.go`):

```go
func (r *workloadRegistry) statefulByListenPort(port uint32) (workloadEntry, bool) {
	for _, e := range r.entries {
		if e.NodeLocalWake && e.StatefulListenPort == port {
```

`chart/templates/workload-demo-postgres.yaml` never set `nodeLocalWake`, so the CR
carried `false`, port 5401 matched no entry, and the caller closed the socket
(`noded/server/stateful_activator.go`):

```go
a.server.logger.Warn("stateful activator: no eligible workload for listener", "port", listenPort)
_ = conn.Close()
```

Observed live on 2026-07-27:

```
{"level":"WARN","msg":"stateful activator: no eligible workload for listener","port":5401}
```

which surfaced to every visitor and to the new synthetic probe as:

```
connection failed: connection to server at "10.43.236.150", port 5401 failed:
server closed the connection unexpectedly
```

in ~6ms, because nothing was ever attempted.

## Why it stayed hidden

`autoWake: true` covers the control plane waking itself once a base goes READY, and
that works: the CP cold-booted demo-postgres at 22:40:36 and the workload settled
`banked, pair_valid: true`. So the passive `/api/health` component read healthy:

```json
"demo_postgres": {"ok": true, "detail": "banked, pair valid"}
```

while the exhibit was unusable. CP-wakes-itself and visitor-connection-wakes-it are
two different paths; only the first was wired. The ember synthetic probe (#4065,
merged as #4076) caught this on its first real run, which is exactly the blind spot
it was built for.

`scratch-postgres` has carried `nodeLocalWake: true` since ADR embervm/018 Phase 2
and wakes normally on the same node, which is why only the public demo broke.
#4013 recorded the demos as already opted in; demo-postgres was the one that was not.

## The change

`nodeLocalWake: true` + `meteringFailOpen: true` on demo-postgres, matching
scratch-postgres. `meteringFailOpen` is declarative in Fork A (it names the policy,
no code reads it) and is set for consistency, not as part of the fix.

## Safety of the accepting node

This makes a node's activator start accepting 5401 connections. Envoy currently
points demo-postgres's cluster at node-2's activator while the volume anchor is
node-4, so the accepting node may not hold the volume. Two properties make that safe:

- the activator's wake request sets no `CreateIfMissing`, so a cold boot without the
  local volume fails cleanly rather than fabricating an empty database;
- on a failed wake it calls `forwardToControlPlane` rather than closing, handing off
  to the CP, which demonstrably can wake this workload.

## Verification

- `helm template` renders `nodeLocalWake: true` / `meteringFailOpen: true` on the
  demo-postgres Workload CR; the CRD accepts both under `stateful`.
- `ci test`: 754 tests pass.
- Post-merge: re-run `POST /internal/ember/synthetic-probe` and confirm the postgres
  probe goes green against the real cluster.

That last step is the real proof, and it is deliberately not claimed here. The
anchor-node mismatch above is unexplained; if the CP handoff does not cover it, that
is the next layer (the serving Envoy is 8 days old with continuously thrashing CDS).

Refs #4077, #4013
