### PR TITLE
fix(embervm): skip a base export when a same-vendor sibling already exported it

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.249
+version: 0.1.251

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.249
+      targetRevision: 0.1.251
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/store.go
+++ b/projects/embervm/noded/server/store.go
@@ -928,6 +928,19 @@ func (s *Server) runExportJob(ctx context.Context, job exportJob) {
 		// The artifact vanished (evicted before the export ran); nothing to do.
 		return
 	}
+	// Already off node under this (vendor, ref)? Then a sibling node of the same
+	// vendor exported it and there is nothing to upload. Without this the CP-driven
+	// path fell through to Store.Export's CONTENT-addressed compare, which never
+	// matches across nodes for a base (snapshots are not byte-reproducible), so
+	// every node re-uploaded ~1 GiB over the sibling's object under the same key.
+	// The startup reconcile sweep already gated on presence; this is the same
+	// policy on the path the control plane actually drives.
+	if s.alreadyDurable(ctx, job.ref, job.key) {
+		s.logger.Info("noded: export skipped, artifact already durable in store",
+			"artifact", job.key, "kind", job.ref.GetKind().String())
+		s.signalChange()
+		return
+	}
 	_, skipped, err := s.store.Export(ctx, job.key, localDir, files, generation, time.Now().UnixMilli(), s.cfg.CpuVendor, s.cfg.CpuTemplate)
 	if err != nil {
 		s.logger.Warn("noded: async export failed (will retry on reconcile)", "artifact", job.key, "err", err)
@@ -999,25 +1012,62 @@ func (s *Server) enqueueIfMissing(ctx context.Context, ref *nodev1.ArtifactRef) 
 	// only ever hold node-4 (amd) artifacts, so a node of any other vendor must
 	// never claim a legacy copy as its own durable export (it would silently
 	// skip exporting its own artifact).
+	if s.alreadyDurable(ctx, ref, prefix) {
+		return
+	}
+	s.enqueueExport(ref)
+}
+
+// alreadyDurable reports whether the store already holds this artifact, and marks
+// it exported when so. It is the single place the "is it already off node?"
+// policy lives, shared by the startup reconcile sweep (enqueueIfMissing) and the
+// CP-driven export worker (runExportJob), so the two cannot drift.
+//
+// Presence, NOT content equality, is the test for every kind except VOLUME. The
+// store key is REF-addressed (`base/<vendor>/<workload>/<ref>`) while
+// Store.Export's own short-circuit is CONTENT-addressed (`sameFiles`), and for a
+// base those disagree by construction: a Firecracker memory snapshot is not
+// byte-reproducible, so two nodes that independently build the SAME ref hold
+// different bytes (verified 2026-07-27: bazel-query__00ada79f752f differs between
+// node-1 and node-2). Content equality therefore never holds across nodes, the
+// short-circuit never fires, and each node re-uploads ~1 GiB over the sibling's
+// object. It is also not NEEDED: same vendor and template means either node's
+// copy restores, which is the premise vendor keying already rests on.
+//
+// A VOLUME is data rather than a snapshot, so it keeps the stricter generation
+// test: presence at a STALE generation must still re-export.
+//
+// A store error means "not durable" (fail toward durability): the caller exports,
+// and Store.Export's own Head-compare makes the final call.
+func (s *Server) alreadyDurable(ctx context.Context, ref *nodev1.ArtifactRef, prefix string) bool {
+	if s.store == nil || prefix == "" {
+		return false
+	}
+	// A vendor-bound kind already durable under the legacy un-vendored prefix
+	// (this node's own artifact, exported before vendor keying shipped) is
+	// already exported; treat it as present so the reconcile sweep never
+	// re-exports it under the new layout for content it already has off node.
+	// Gated on the node itself being the alias vendor: the legacy layout can
+	// only ever hold node-4 (amd) artifacts, so a node of any other vendor must
+	// never claim a legacy copy as its own durable export (it would silently
+	// skip exporting its own artifact).
 	if legacy := legacyArtifactPrefix(ref); legacy != "" && s.cfg.CpuVendor == legacyVendorAlias {
 		if legacyPresent, legacyGen, _, _, lerr := s.store.Present(ctx, legacy); lerr == nil && legacyPresent {
 			s.exported.mark(prefix, legacyGen)
-			return
+			return true
 		}
 	}
 	present, gen, _, _, err := s.store.Present(ctx, prefix)
-	if err == nil && present {
-		if ref.GetKind() == nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME {
-			if cur := s.artifactGeneration(ref); cur == gen {
-				s.exported.mark(prefix, gen) // already durable at the current gen
-				return
-			}
-		} else {
-			s.exported.mark(prefix, gen)
-			return
+	if err != nil || !present {
+		return false
+	}
+	if ref.GetKind() == nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME {
+		if cur := s.artifactGeneration(ref); cur != gen {
+			return false
 		}
 	}
-	s.enqueueExport(ref)
+	s.exported.mark(prefix, gen) // already durable
+	return true
 }
 
 // ---- async BASE-restore queue ----------------------------------------------

--- a/projects/embervm/noded/server/store_test.go
+++ b/projects/embervm/noded/server/store_test.go
@@ -519,6 +519,115 @@ func TestExportArtifactBaseMissingLocalFailsEvenAsync(t *testing.T) {
 	}
 }
 
+// TestExportArtifactBaseSkipsWhenSiblingVendorCopyExists proves the (vendor, ref)
+// presence gate (#4079): when another node of the SAME vendor already exported
+// this base, the control-plane-driven export must not re-upload, EVEN THOUGH the
+// local bytes differ from the stored ones.
+//
+// Two nodes that independently build the same base ref hold different bytes (a
+// Firecracker memory snapshot is not byte-reproducible; verified live on
+// 2026-07-27, bazel-query__00ada79f752f differed between node-1 and node-2). So
+// Store.Export's content-addressed compare never matches across nodes, and before
+// this gate the CP-driven path re-uploaded the whole base OVER the sibling's
+// object under the same key. Files are PUT before meta.json, so that overwrite
+// also left a window where a concurrent restore saw files inconsistent with the
+// meta it had already fetched.
+func TestExportArtifactBaseSkipsWhenSiblingVendorCopyExists(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx := context.Background()
+	// Production shape: the async BASE queue is the path the CP drives.
+	s.startExportQueue(ctx)
+
+	ref := "bazel-query__00ada79f752f"
+	workload := "bazel-query"
+	digest := "img@sha256:cafef00d"
+	prefix := "base/amd/bazel-query/bazel-query__00ada79f752f"
+
+	// A sibling node of the same vendor already exported this ref, with ITS OWN
+	// snapshot bytes.
+	sibling := map[string]string{"imageref": "img", "memfile": "SIBLING-mem", "snapfile": "SIBLING-snap"}
+	fs.seedArtifact(prefix, sibling, 0, "amd", "")
+
+	s.registry.sync([]workloadEntry{{Workload: workload, ImageRef: digest, RootfsRef: "/rootfs/bazel-query"}})
+	s.bases.readyBuild(ref, workload, digest, "/shim/ready", 2048)
+
+	dir := filepath.Join(s.cfg.SnapshotRoot, "bases", ref)
+	// Deliberately DIFFERENT bytes from the seeded sibling copy, which is the
+	// real cross-node situation.
+	writeBundleFiles(t, dir, map[string]string{"imageref": "img", "memfile": "LOCAL-mem", "snapfile": "LOCAL-snap"})
+
+	if _, err := s.ExportArtifact(ctx, &nodev1.ExportArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_BASE, Workload: workload, Ref: ref},
+	}); err != nil {
+		t.Fatalf("ExportArtifact: %v", err)
+	}
+
+	// The queue worker settles into "already durable" and flips the exported flag.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !baseExportedInStatus(s, workload, ref) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !baseExportedInStatus(s, workload, ref) {
+		t.Fatal("base should report exported=true once a same-vendor sibling copy is durable")
+	}
+
+	// No upload was even attempted.
+	if got := fs.calls(prefix); got != 0 {
+		t.Fatalf("store.Export called %d times for an already-durable ref, want 0", got)
+	}
+
+	// And the sibling's bytes were NOT clobbered.
+	fs.mu.Lock()
+	stored := fs.arts[prefix].files
+	fs.mu.Unlock()
+	if !sameStringMap(stored, sibling) {
+		t.Fatalf("sibling copy was overwritten: got %v, want %v", stored, sibling)
+	}
+}
+
+// TestExportQueueVolumeStillReExportsAtStaleGeneration proves the presence gate
+// does NOT weaken VOLUME durability. A volume is data rather than a memory
+// snapshot, so presence alone is not enough: a stored copy at a STALE generation
+// must still be re-exported, and only the generation-matched case skips.
+//
+// Driven through the queue (enqueueExport -> runExportJob) because that is the
+// path the gate is on; a VOLUME ExportArtifact RPC is synchronous and does not
+// reach it.
+func TestExportQueueVolumeStillReExportsAtStaleGeneration(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx := context.Background()
+	s.startExportQueue(ctx)
+
+	workload := "scratch-postgres"
+	prefix := "volume/scratch-postgres"
+
+	if err := s.volumes.Create(workload, 1<<20); err != nil {
+		t.Fatalf("create volume: %v", err)
+	}
+	if _, err := s.volumes.BumpGeneration(workload); err != nil {
+		t.Fatalf("bump: %v", err)
+	}
+	cur, err := s.volumes.Generation(workload)
+	if err != nil {
+		t.Fatalf("generation: %v", err)
+	}
+
+	// A stored copy at a STALE generation (one behind the node's current volume).
+	fs.seedArtifact(prefix, map[string]string{"disk.img": "OLD"}, cur-1, "", "")
+
+	s.enqueueExport(&nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: workload})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && fs.calls(prefix) == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := fs.calls(prefix); got == 0 {
+		t.Fatal("a VOLUME present at a STALE generation must still be re-exported, got 0 export calls")
+	}
+}
+
 // evictBase is a small helper: EvictArtifact{remote:false} of a BASE ref.
 func evictBase(s *Server, workload, ref string) error {
 	_, err := s.EvictArtifact(context.Background(), &nodev1.EvictArtifactRequest{


### PR DESCRIPTION
Closes #4079.

## The bug

The control-plane-driven base export re-uploaded a full base **over** an object a sibling node had already stored under the same key.

The store key is **ref**-addressed (`base/<vendor>/<workload>/<ref>`) while `Store.Export`'s idempotency short-circuit is **content**-addressed:

```go
if present, remoteMeta, merr := s.getMeta(ctx, prefix); merr == nil && present && sameFiles(remoteMeta.Files, meta.Files) {
    return 0, true, nil
}
```

For a base those disagree by construction. A Firecracker memory snapshot is not byte-reproducible, so two nodes that independently build the SAME ref hold different bytes. Verified live on 2026-07-27:

| node | vendor | ref | snapfile md5 |
|---|---|---|---|
| node-1 | intel | `bazel-query__00ada79f752f` | `e7fc948294f49f91473f16d6eb7144af` |
| node-2 | intel | `bazel-query__00ada79f752f` | `71b6f75b648cdada01751d82c3fa4436` |

Identical sizes, different content. So `sameFiles` never matched across nodes, the short-circuit never fired, and each node's first export was a full ~1 GiB upload that overwrote the sibling's object.

**The wasted bandwidth is the smaller half.** Files are PUT before `meta.json`, so the overwrite also left a window where a concurrent restore saw files inconsistent with the meta it had already fetched. Restore verifies SHA-256 per file and rejects a mismatch, so this is fail-safe rather than corrupting, but it means a base restore could fail purely because a sibling node re-exported the same ref.

## The fix

noded **already had the right policy**. `enqueueIfMissing` gates on store PRESENCE, with a generation carve-out for VOLUME. It was only reachable from the startup reconcile sweep, so the path the control plane actually drives bypassed it entirely:

```
ExportArtifact -> enqueueExport -> runExportJob -> Store.Export   (content-addressed)
```

This lifts that policy into `alreadyDurable/3` and calls it from **both** paths, so they cannot drift.

Presence rather than content is the correct test because content equality is *unachievable* across nodes and *unnecessary* within a vendor: same vendor and template means either node's copy restores, which is the premise vendor keying already rests on.

## What is deliberately NOT changed

- **VOLUME keeps the stricter generation test.** A volume is data rather than a memory snapshot, so presence alone is not enough and a stale stored generation must still re-export.
- **`Store.Export`'s content-addressed short-circuit is untouched.** The gate lives at the server layer, which knows `ref.GetKind()`; the store only sees an opaque prefix. Putting it in the store would have applied presence-skipping to every kind.
- **Eviction stays per node** (do not regress #4052). The asymmetry is now the point and is commented where it lands: **export is per (vendor, ref), eviction is per node.**

## A correction to the issue

I filed #4079 claiming each node did a redundant full export of an object that already exists. The conclusion was right, the reason was wrong, and the impact is larger. `Store.Export` *does* have an idempotency short-circuit, so the cost should have been a HEAD plus a small GET. It never fires across nodes for the reason above. Also, `exports_in_flight` already dedupes on `{workload, ref}` synchronously, so the redundancy never occurred within a single post-build fan-out, only across fan-outs when a node reported later. [Full correction on the issue.](https://github.com/jomcgi/homelab/issues/4079#issuecomment-5097826062)

## Tests

- `TestExportArtifactBaseSkipsWhenSiblingVendorCopyExists`: seeds the store as a sibling node would, with **different bytes** from local, then drives the CP path. Asserts `store.Export` is called **zero** times, the base still reports `exported=true`, and the sibling's bytes are **not** clobbered.
- `TestExportQueueVolumeStillReExportsAtStaleGeneration`: a VOLUME present at a stale generation still re-exports. Driven through `enqueueExport -> runExportJob` because that is the path the gate is on; a VOLUME `ExportArtifact` RPC is synchronous and does not reach it.

`ci test` green: `754 tests pass`.

## Deploy

noded image changes, so chart bumped to `0.1.251` with `Chart.yaml` and `deploy/application.yaml` moved together.