### PR TITLE
test(embervm): close the two ExUnit races that redden unrelated PRs

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.254
+version: 0.1.255

--- a/projects/embervm/control/test/embervm/brick_controller_test.exs
+++ b/projects/embervm/control/test/embervm/brick_controller_test.exs
@@ -11,13 +11,13 @@ defmodule Embervm.BrickControllerTest do
   # A controllable clock + a scale-call recorder, both backed by Agents.
   defp new_clock do
     {:ok, pid} = Agent.start_link(fn -> 0 end)
-    on_exit(fn -> if Process.alive?(pid), do: Agent.stop(pid) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(pid) end)
     {fn -> Agent.get(pid, & &1) end, fn ms -> Agent.update(pid, &(&1 + ms)) end}
   end
 
   defp new_recorder do
     {:ok, pid} = Agent.start_link(fn -> [] end)
-    on_exit(fn -> if Process.alive?(pid), do: Agent.stop(pid) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(pid) end)
 
     record = fn ns, name, replicas ->
       Agent.update(pid, &[{ns, name, replicas} | &1])
@@ -40,7 +40,7 @@ defmodule Embervm.BrickControllerTest do
     ]
 
     {:ok, pid} = BrickController.start_link(Keyword.merge(defaults, opts))
-    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(pid) end)
     pid
   end
 
@@ -115,7 +115,7 @@ defmodule Embervm.BrickControllerTest do
   test "a flagged class clears once registered catches up to desired" do
     {clock, advance} = new_clock()
     {:ok, reg} = Agent.start_link(fn -> %{"2gi" => 1} end)
-    on_exit(fn -> if Process.alive?(reg), do: Agent.stop(reg) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(reg) end)
 
     pid =
       start(
@@ -289,7 +289,7 @@ defmodule Embervm.BrickControllerTest do
 
   defp new_annotator do
     {:ok, pid} = Agent.start_link(fn -> [] end)
-    on_exit(fn -> if Process.alive?(pid), do: Agent.stop(pid) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(pid) end)
 
     annotate = fn ns, pod, annotations ->
       Agent.update(pid, &[{ns, pod, annotations} | &1])

--- a/projects/embervm/control/test/embervm/node_registry_test.exs
+++ b/projects/embervm/control/test/embervm/node_registry_test.exs
@@ -21,7 +21,7 @@ defmodule Embervm.NodeRegistryTest do
   # every timestamp, and the test advances it to drive age-out deterministically.
   defp new_clock do
     {:ok, pid} = Agent.start_link(fn -> 0 end)
-    on_exit(fn -> if Process.alive?(pid), do: Agent.stop(pid) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(pid) end)
     clock = fn -> Agent.get(pid, & &1) end
     advance = fn ms -> Agent.update(pid, &(&1 + ms)) end
     {clock, advance}
@@ -44,7 +44,7 @@ defmodule Embervm.NodeRegistryTest do
     ]
 
     {:ok, pid} = NodeRegistry.start_link(Keyword.merge(defaults, opts))
-    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(pid) end)
     {pid, table}
   end
 
@@ -241,7 +241,7 @@ defmodule Embervm.NodeRegistryTest do
 
   test "a real spawn_monitor streamer connects, publishes facts, and reconnects on clean drop" do
     {:ok, connects} = Agent.start_link(fn -> 0 end)
-    on_exit(fn -> if Process.alive?(connects), do: Agent.stop(connects) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(connects) end)
 
     connect_fun = fn _address ->
       Agent.update(connects, &(&1 + 1))
@@ -285,7 +285,7 @@ defmodule Embervm.NodeRegistryTest do
 
   test "a wedged real streamer (emit then silent) ages to down, reassigns, kills, and reconnects" do
     {:ok, connects} = Agent.start_link(fn -> 0 end)
-    on_exit(fn -> if Process.alive?(connects), do: Agent.stop(connects) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(connects) end)
     test_pid = self()
 
     connect_fun = fn _address ->
@@ -338,7 +338,7 @@ defmodule Embervm.NodeRegistryTest do
 
   test "pushes SyncRegistry on every (re)connect, before consuming the watch stream" do
     {:ok, syncs} = Agent.start_link(fn -> [] end)
-    on_exit(fn -> if Process.alive?(syncs), do: Agent.stop(syncs) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(syncs) end)
     test_pid = self()
 
     # Record each replay (channel, node_id) and let the streamer proceed. The
@@ -382,7 +382,7 @@ defmodule Embervm.NodeRegistryTest do
 
   test "periodically re-pushes the registry to a still-connected daemon (ADR embervm/018 catalog-change convergence)" do
     {:ok, syncs} = Agent.start_link(fn -> 0 end)
-    on_exit(fn -> if Process.alive?(syncs), do: Agent.stop(syncs) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(syncs) end)
     test_pid = self()
 
     sync_registry_fun = fn :fake_channel, node_id, _request ->
@@ -567,9 +567,9 @@ defmodule Embervm.NodeRegistryTest do
 
   test "re-registration at a NEW address re-points the streamer and channel" do
     {:ok, dialed} = Agent.start_link(fn -> [] end)
-    on_exit(fn -> if Process.alive?(dialed), do: Agent.stop(dialed) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(dialed) end)
     {:ok, chan} = Agent.start_link(fn -> [] end)
-    on_exit(fn -> if Process.alive?(chan), do: Agent.stop(chan) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(chan) end)
 
     connect_fun = fn address ->
       Agent.update(dialed, &[address | &1])
@@ -605,7 +605,7 @@ defmodule Embervm.NodeRegistryTest do
     # a node's co-located bricks could only misroute a wake to the wrong sibling. So
     # registration now points a SINGLE key, the instance_id, at the instance's address.
     {:ok, chan} = Agent.start_link(fn -> [] end)
-    on_exit(fn -> if Process.alive?(chan), do: Agent.stop(chan) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(chan) end)
 
     {reg, _table} =
       start_registry(
@@ -626,7 +626,7 @@ defmodule Embervm.NodeRegistryTest do
     # [instance_id] post-B0c) registers the static/pinned single-daemon override once,
     # under its node name, which is where a node-scoped fact's dial resolves anyway.
     {:ok, chan} = Agent.start_link(fn -> [] end)
-    on_exit(fn -> if Process.alive?(chan), do: Agent.stop(chan) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(chan) end)
 
     {reg, _table} =
       start_registry(
@@ -649,7 +649,7 @@ defmodule Embervm.NodeRegistryTest do
     # in the next test).
     {clock, advance} = new_clock()
     {:ok, removed} = Agent.start_link(fn -> [] end)
-    on_exit(fn -> if Process.alive?(removed), do: Agent.stop(removed) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(removed) end)
 
     {reg, _table} =
       start_registry(
@@ -703,7 +703,7 @@ defmodule Embervm.NodeRegistryTest do
         disconnect_fun: fn _ -> :ok end
       )
 
-    on_exit(fn -> if Process.alive?(nc), do: GenServer.stop(nc) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(nc) end)
 
     {clock, advance} = new_clock()
 
@@ -748,7 +748,7 @@ defmodule Embervm.NodeRegistryTest do
 
   test "registration feeds instance add to the BaseBuilder (so BuildBase can place)" do
     {:ok, bb} = Agent.start_link(fn -> [] end)
-    on_exit(fn -> if Process.alive?(bb), do: Agent.stop(bb) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(bb) end)
 
     {reg, _table} =
       start_registry(register_seams(base_builder_updater_fun: fn msg -> Agent.update(bb, &[msg | &1]) end))

--- a/projects/embervm/control/test/embervm/op_log/postgres_live_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/postgres_live_test.exs
@@ -41,7 +41,7 @@ defmodule Embervm.OpLog.PostgresLiveTest do
     {:ok, server} = Postgres.start_link(dsn: adapter_opts, name: nil, journal_horizon_ms: 0)
 
     on_exit(fn ->
-      if Process.alive?(server), do: GenServer.stop(server)
+      Embervm.TestProcess.stop_safely(server)
       {:ok, cleanup_conn} = Postgrex.start_link(Keyword.put(opts, :name, nil))
       {:ok, _} = Postgrex.query(cleanup_conn, ~s(DROP SCHEMA "#{schema}" CASCADE), [])
       GenServer.stop(cleanup_conn)

--- a/projects/embervm/control/test/embervm/placement/retry_test.exs
+++ b/projects/embervm/control/test/embervm/placement/retry_test.exs
@@ -34,7 +34,7 @@ defmodule Embervm.Placement.RetryTest do
 
   setup do
     {:ok, rec} = Agent.start_link(fn -> [] end)
-    on_exit(fn -> if Process.alive?(rec), do: Agent.stop(rec) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(rec) end)
     %{rec: rec}
   end
 

--- a/projects/embervm/control/test/embervm/tcp_activator_test.exs
+++ b/projects/embervm/control/test/embervm/tcp_activator_test.exs
@@ -229,7 +229,7 @@ defmodule Embervm.TcpActivatorTest do
         store_mod: NoEndpointStore
       )
 
-    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+    on_exit(fn -> Embervm.TestProcess.stop_safely(pid) end)
 
     sock = connect(@port_a)
     assert {:error, :closed} = :gen_tcp.recv(sock, 0, 1_000)

--- a/projects/embervm/control/test/test_helper.exs
+++ b/projects/embervm/control/test/test_helper.exs
@@ -1,1 +1,43 @@
-ExUnit.start()
+# assert_receive_timeout raised from ExUnit's 100ms default. The suite runs on a
+# shared BuildBuddy executor, so 100ms is a wall-clock bet on scheduler latency
+# rather than a statement about the code: DrainCoordinatorTest's
+# `assert_receive {:drained, :serving, "node-4"}` failed CI on a PR that touched
+# no Elixir, and took the whole Test check red with it (issue #4078). Raising the
+# default costs nothing on the passing path (assert_receive returns the moment the
+# message lands) and only lengthens how long a genuinely failing assertion waits
+# before reporting. refute_receive is unaffected: it reads refute_receive_timeout,
+# which stays at 100ms, so no test that must wait out a full window got slower.
+ExUnit.start(assert_receive_timeout: 2_000)
+
+defmodule Embervm.TestProcess do
+  @moduledoc """
+  Test-teardown helpers shared by the control-plane suite.
+
+  Defined here rather than in a support/ tree because `mix test` evaluates
+  `test_helper.exs` before it compiles the test files, so every test module can
+  call this without a build-graph change.
+  """
+
+  @doc """
+  Stop `pid` gracefully, tolerating a process that has already exited.
+
+  The pattern this replaces, `if Process.alive?(pid), do: GenServer.stop(pid)`,
+  reads as if it handles the dead-process case, but check and stop are two steps:
+  the process can exit in the gap, and then `GenServer.stop/1` raises `:noproc`
+  INSIDE the teardown callback. ExUnit attributes that to the test whose body
+  already passed, so the failure surfaces as an unrelated test failing with a
+  stack ending in `ExUnit.OnExitHandler` and no assertion diff (issue #4078,
+  observed on `Embervm.Placement.RetryTest` and `Embervm.BrickControllerTest`).
+
+  Catching the exit closes the race instead of narrowing it. Graceful shutdown is
+  preserved, so a `terminate/2` a test depends on still runs; only the
+  already-dead case is swallowed. Works for `Agent` too, whose `stop/1` is
+  `GenServer.stop/1`.
+  """
+  @spec stop_safely(pid() | GenServer.name()) :: :ok
+  def stop_safely(pid) do
+    GenServer.stop(pid)
+  catch
+    :exit, _ -> :ok
+  end
+end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.254
+      targetRevision: 0.1.255
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Closes the two ExUnit races behind #4078. Both turned red on #4076, a PR containing
no `.ex`/`.exs` changes at all, on two consecutive runs with two different tests.

## Race 1: on_exit teardown

The guard already used across this suite is itself the race:

```elixir
on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
```

`alive?` and `stop` are two operations. The process can exit in the gap, and then
`GenServer.stop/1` raises `:noproc` INSIDE the teardown callback. ExUnit attributes
that to the test whose body already passed, which is why it surfaces as an unrelated
test failing with no assertion diff and a stack terminating in `ExUnit.OnExitHandler`:

```
1) test gate ON (reject/retry) a terminal {:error, _} stops immediately without retrying
   (Embervm.Placement.RetryTest) test/embervm/placement/retry_test.exs:92
   ** (exit) exited in: GenServer.stop(#PID<0.6979.0>, :normal, :infinity)
       ** (EXIT) no process: the process is not alive
     (ex_unit 1.18.4) lib/ex_unit/on_exit_handler.ex:136: ExUnit.OnExitHandler.exec_callback/1
```

The guard narrows the window; it does not close it. Catching the exit closes it. 22
sites across 5 files now call `Embervm.TestProcess.stop_safely/1`, which keeps the
graceful stop (so a `terminate/2` a test depends on still runs) and swallows only the
already-dead case. `Agent.stop/1` is `GenServer.stop/1`, so one helper covers both.

Notably `tcp_activator_test.exs` ALREADY had this fix inline, with a comment naming
the exact failure mode. It was correct in one place and never generalised, which is
the actual gap here.

## Race 2: fixed assert_receive deadline

```
1) test a class whose drain raises is skipped, the others still drain
   (Embervm.DrainCoordinatorTest) test/embervm/drain_coordinator_test.exs:71
   Assertion failed, no matching message after 100ms
   code: assert_receive {:drained, :serving, "node-4"}
```

ExUnit's 100ms default is a bet on scheduler latency, not a statement about the code,
and a shared BuildBuddy executor under load loses that bet. Raised suite-wide in
`test_helper.exs`:

```elixir
ExUnit.start(assert_receive_timeout: 2_000)
```

This is safe to do globally rather than per-assertion:

- it costs nothing on the passing path, since `assert_receive` returns the moment the
  message lands;
- it only lengthens how long a genuinely failing assertion waits before reporting;
- `refute_receive` reads a DIFFERENT setting (`refute_receive_timeout`, still 100ms),
  so the tests that must wait out a full window did not get slower.

## Why the helper lives in test_helper.exs

`mix test` evaluates `test_helper.exs` before compiling the test files, so every test
module can call it with no build-graph change. A `support/` tree would have needed
`elixirc_paths` plus Bazel srcs wiring for a 10-line helper.

## Verification

```
968 tests, 0 failures, 6 skipped
```

with `mix_test_smoke` genuinely re-executed rather than served from the action cache
(the test-file edits invalidate its key, which earlier green `ci test` runs in this
area did not).

Worth stating plainly: a green run does NOT prove the flakes are gone, because they
were never reproducible on demand. It proves the mechanical change did not break the
suite. The real evidence is the absence of these two failure shapes over the next
several PRs.

## Not addressed

The fourth checkbox in #4078, surfacing `MIX TEST FAILED` more visibly. Bazel's
summary currently reports `754 tests pass` while the check goes red, because the
Elixir suite runs inside a genrule and its 968 ExUnit tests are invisible to Bazel's
accounting. That is a build-plumbing change and belongs on its own.

Refs #4078
