### PR TITLE
fix(embervm): refresh status.snapshotRefs on the periodic reconcile

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.251
+version: 0.1.252

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -533,6 +533,7 @@ defmodule Embervm.BaseBuilder do
   # any current base present-but-unexported, then re-arm the timer.
   def handle_info(:export_reconcile, state) do
     state = export_reconcile(state)
+    state = refresh_snapshot_refs(state)
     schedule_export_reconcile(state)
     {:noreply, state}
   end
@@ -1216,6 +1217,10 @@ defmodule Embervm.BaseBuilder do
       # (standing decision 5). Multiple superseded bases coexist here, each
       # TTL-bounded by its referencing sessions' maxLifetimeSeconds.
       base_refs: %{},
+      # The per-vendor fleet map (#4061) as last WRITTEN to status, so the periodic
+      # refresh can patch only on a change rather than every tick. nil means "never
+      # written", which forces one write as soon as any node reports a base.
+      last_snapshot_refs: nil,
       backoff_ms: nil,
       retry_timer: nil
     }
@@ -2145,6 +2150,48 @@ defmodule Embervm.BaseBuilder do
       empty when map_size(empty) == 0 -> status_map
       refs -> Map.put(status_map, "snapshotRefs", refs)
     end
+  end
+
+  # Re-patch status.snapshotRefs for any workload whose fleet view CHANGED since
+  # the last write (#4084).
+  #
+  # write_base_status/3 only fires on EVENTS (a build, a reconcile), so without
+  # this the map freezes whatever the fleet looked like at the last such event and
+  # stays frozen while the event stream is quiet. That is not hypothetical: a CP
+  # restart writes status during the base-advert dial-home window, so the map
+  # captured only the nodes that had already advertised. Observed 2026-07-27, every
+  # workload reporting {"intel" => [...]} while node-4 held a current amd base.
+  # The same staleness applies with the opposite sign: a base evicted by retention
+  # would stay listed until the next event.
+  #
+  # Patching only on a CHANGE keeps a converged fleet from generating a status
+  # write per workload per tick. An empty map never patches, for the same
+  # anti-clobber reason put_snapshot_refs/3 skips it.
+  defp refresh_snapshot_refs(state) do
+    Enum.reduce(state.workloads, state, fn {name, w}, acc ->
+      refs = snapshot_refs_by_vendor(acc, w)
+
+      cond do
+        map_size(refs) == 0 ->
+          acc
+
+        refs == w.last_snapshot_refs ->
+          acc
+
+        true ->
+          case acc.status_writer.(w.namespace, w.name, %{"snapshotRefs" => refs}) do
+            :ok ->
+              put_in(acc.workloads[name].last_snapshot_refs, refs)
+
+            {:error, reason} ->
+              Logger.warning(
+                "embervm base builder: snapshotRefs refresh failed for #{w.namespace}/#{w.name}: #{inspect(reason)}"
+              )
+
+              acc
+          end
+      end
+    end)
   end
 
   # The base refs the FLEET reports for this workload, grouped by CPU vendor:

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -1935,4 +1935,66 @@ defmodule Embervm.BaseBuilderTest do
     refute Map.has_key?(status, "snapshotRefs")
     assert status["snapshotRef"] == "w__amd"
   end
+
+  test "the periodic reconcile picks up a vendor that advertised after the build" do
+    agent = start_recorder()
+    table = new_cap_table()
+    # Only the AMD builder node has advertised its base at build time, which is
+    # what a CP restart inside the base-advert dial-home window looks like.
+    put_vendor_fact(table, "node-4", nil, "w", "w__amd", "amd")
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__amd")} end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        # Timer off: drive the reconcile explicitly so this is deterministic.
+        export_reconcile_interval_ms: 0
+      )
+
+    build_current(builder, agent, "w__amd")
+    assert latest(agent, "w")["snapshotRefs"] == %{"amd" => ["w__amd"]}
+
+    # An intel node finishes dial-home and advertises its own base AFTER the
+    # build. Before #4084 the map stayed frozen at amd-only until the next build.
+    put_vendor_fact(table, "node-1", "ds", "w", "w__intel", "intel")
+    send(builder, :export_reconcile)
+
+    assert_eventually(fn ->
+      latest(agent, "w")["snapshotRefs"] == %{"amd" => ["w__amd"], "intel" => ["w__intel"]}
+    end)
+  end
+
+  test "the periodic reconcile does not re-patch status when the fleet view is unchanged" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_vendor_fact(table, "node-4", nil, "w", "w__amd", "amd")
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__amd")} end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        export_reconcile_interval_ms: 0
+      )
+
+    build_current(builder, agent, "w__amd")
+
+    # One refresh settles last_snapshot_refs against what the build already wrote.
+    send(builder, :export_reconcile)
+    _ = :sys.get_state(builder)
+    settled = length(recorded(agent))
+
+    # Further ticks against an unchanged fleet must be silent, or a converged
+    # cluster writes status per workload per tick forever.
+    send(builder, :export_reconcile)
+    send(builder, :export_reconcile)
+    _ = :sys.get_state(builder)
+
+    assert length(recorded(agent)) == settled
+  end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.251
+      targetRevision: 0.1.252
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Closes #4084. Fixes a defect in #4080, which I merged earlier tonight.

## The bug

`status.snapshotRefs` could freeze a **partial** fleet view. On the live cluster every workload reported only `intel`, while node-4 held a current, correctly amd-keyed base for the **same digest**:

```
bazel-query  status.snapshotDigest = ...bazel@sha256:70f7d13e
             status.snapshotRefs   = {"intel":["bazel-query__00ada79f752f"]}
```

| node | base ref | imageref | current? |
|---|---|---|---|
| node-1/2/3 | `bazel-query__00ada79f752f` | `@sha256:70f7d13e` | yes |
| node-4 | `bazel-query__426e3036636c` | `@sha256:70f7d13e` | yes |

## Cause

`write_base_status/3` fires on EVENTS (a build, a reconcile), never on a timer. So the map captures whatever the fleet looked like at the last such event and stays frozen while the event stream is quiet. The CP restarted at 23:18:08Z and a build advanced status during the base-advert dial-home window, so only the nodes that had already advertised made it in.

**This is a gap in my own reasoning in #4080.** That PR wrote the map on every phase rather than only on `:built`, arguing it avoided staleness. Writing on every phase only helps if a phase OCCURS. Between events there is no write at all, so the map was exactly as stale as the event stream was quiet.

It is also the same failure class the per-vendor LIST was chosen to avoid: a field that is right in steady state and misleading during precisely the window someone consults it (a rollout).

## Ruling out the alternative

The competing hypothesis was that node-4's capacity fact carried an empty or raw vendor string, which `snapshot_refs_by_vendor/2` would drop via its `vendor != ""` filter. Ruled out:

| node | /proc/cpuinfo vendor_id | detectCPUVendorFrom |
|---|---|---|
| node-1/2/3 | `GenuineIntel` | `intel` |
| node-4 | `AuthenticAMD` | `amd` |

`config/config.go` maps both explicitly and no node sets a vendor via env, so node-4 reports the short token `amd` correctly.

## The fix

Recompute on the existing 60s `:export_reconcile` tick, which already walks the fleet, so no new timer is introduced.

Patches **only when the computed map differs** from the last written one (tracked per workload in `last_snapshot_refs`), so a converged fleet does not write status per workload per tick. An empty map still never patches, the same anti-clobber rule `put_snapshot_refs/3` already applies.

This also fixes the same staleness with the opposite sign: a base evicted by retention previously stayed listed until the next event.

## Tests

- `the periodic reconcile picks up a vendor that advertised after the build`: builds with only the AMD node advertised (the dial-home window), asserts the map is amd-only, then has an intel node advertise and drives one reconcile. Asserts the map becomes both.
- `the periodic reconcile does not re-patch status when the fleet view is unchanged`: settles, then drives two more ticks against an unchanged fleet and asserts the status-write count is unchanged.

`ci test` green: `970 tests, 0 failures, 6 skipped` (was 968).

## Deploy

Control-plane change, so chart bumped to `0.1.252` with `Chart.yaml` and `deploy/application.yaml` moved together.