### PR TITLE
feat(monolith): arm the ember synthetic cron now all four probes are green

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.308
+version: 0.89.309
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.308
+      targetRevision: 0.89.309
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.382
+version: 0.285.383
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -737,14 +737,21 @@ jobs:
       concurrencyPolicy: Forbid
       # The trigger allows 180s for a demo-postgres cold boot, plus margin.
       activeDeadlineSeconds: 300
-      # SUSPENDED until a live API-pod run proves all four targets green. The
-      # previous job-pod implementation failed three probes on environment,
-      # not on broken demos: bazel lacked the admitted ServiceAccount, semgrep
-      # lacked FC_INVOKE_URL, and postgres used a public HTTP path that is not
-      # routed for direct calls. The API pod now supplies all of those values.
-      # Re-enable ONLY after a real run proves all four green, because a probe
-      # that cannot reach its target is worse than no probe.
-      suspend: true
+      # ARMED 2026-07-27 after a live API-pod run returned all four green:
+      #   bazel    ok  "warm, 501ms"       (was 403: wrong ServiceAccount)
+      #   semgrep  ok  "5 finding(s)"      (was missing FC_INVOKE_URL)
+      #   pages    ok  "all pages, 311ms"
+      #   postgres ok  "relight, 1137ms"   (was an unrouted public HTTP path)
+      # and jomcgi.dev/health returned 200. Each of the three original failures
+      # was environment, not a broken demo, which is why this stayed suspended
+      # until the API pod (which holds the admitted SA and all three env vars)
+      # actually proved them. Landing a prober you have not watched succeed is
+      # how #4074 paged on its own gaps.
+      #
+      # The postgres probe additionally earned its keep before being armed: it
+      # caught #4077 (demo-postgres unwakeable by any visitor) while the passive
+      # component still read "banked, pair valid", i.e. healthy. Fixed in #4081.
+      suspend: false
       env:
         # The in-cluster API service the trigger POSTs; injected here (not baked
         # in code) so a release rename cannot silently break the DNS name.

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.382
+      targetRevision: 0.285.383
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Arms the ember synthetic CronWorkflow (`suspend: true` -> `false`). One flag; the
rest of the diff is the chart bumps and the rationale comment.

## The gate this was held against, and the evidence it is met

#4076 moved the probes into the API pod but deliberately landed suspended, because
merging code that *looks* right is not evidence a prober can reach its targets. A
live run against the real cluster now returns all four green:

```
bazel    ok  "warm, 501ms"       (was 403: the job pod ran as monolith-workflows:argo-workflow)
semgrep  ok  "5 finding(s)"      (was missing FC_INVOKE_URL)
pages    ok  "all pages, 311ms"
postgres ok  "relight, 1137ms"   (was POSTing an unrouted public path, got the SvelteKit shell)
```

and the public uptime surface agrees:

```
https://jomcgi.dev/health -> 200 {"status":"ok"}
```

Every one of the three original failures was environment, not a broken demo. The API
pod holds the admitted ServiceAccount and all three env vars, so each failure
disappeared rather than being worked around. Verified on the live pod before
triggering, not inferred from the chart:

```
FC_INVOKE_URL  EMBERVM_URL  EMBER_SYNTHETIC_BASE_URL  DEMO_POSTGRES_DSN
```

`postgres` says `relight`, not `cold_booted`: the banked bundle was resumed, so the
sleep/wake exhibit itself is working, not merely answering on the port. A cold boot
would also have reported `ok` while meaning the bundle was unusable.

## The probe earned this before being armed

On its first real run it caught #4077: demo-postgres was unwakeable by any visitor
(noded's L4 activator closed every connection on 5401) while the passive health
component read `"banked, pair valid"` — healthy. The control plane could wake the
workload and did; nothing converted a *visitor's* connection into a wake, and only an
actual connection attempt can tell those apart. Fixed in #4081.

That is the blind spot #4065 was built for, demonstrated on live traffic rather than
argued from first principles.

## What arming actually changes

A `*/5` CronWorkflow now writes the latch rows that back `/api/health`, so a broken
exhibit 503s the uptime check without a visitor having to find it first. Failure
latches until a success overwrites it (last-write-wins), missing rows read healthy,
stale rows read down.

Cadence is unchanged at 5m for all four. The probe cannot hold demo-postgres awake:
its connection is short-lived by design and `demoPostgres.idleBankSeconds` is 1
against a ~1s sweeper tick, so the exhibit re-banks seconds later.

## Rollback

Set `suspend: true` and bump. No code path changes; the endpoint #4076 added stays
reachable for manual triggering either way.

Refs #4074, #4077
