### PR TITLE
fix(embervm): give the claude guest a writable HOME on a read-only rootfs

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.257
+version: 0.1.258

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.257
+      targetRevision: 0.1.258
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/BUILD
+++ b/projects/embervm/runtimes/claude/BUILD
@@ -36,11 +36,17 @@ tar(
 # interactive, so a fresh guest with nobody at a keyboard would wedge on first
 # boot. The record is keyed by ABSOLUTE workspace path and must match
 # EMBER_CLAUDE_WORKSPACE in apko.yaml exactly.
+#
+# Baked under /usr/share, NOT at its final ~/.claude.json: the rootfs is read-only
+# on every boot, so guest-init bind-mounts a writable HOME over /home/runtime, and
+# a file baked underneath that mount point would be hidden the moment it lands.
+# guest-init copies this master into the writable HOME when none is already there
+# (trustRecordSeedPath in guest-init/cmd/volume_linux.go).
 tar(
     name = "guest_config_tar",
     srcs = ["guest-config/claude.json"],
     mtree = [
-        "./home/runtime/.claude.json type=file content=$(execpath guest-config/claude.json) mode=0644 uid=65532 gid=65532",
+        "./usr/share/ember-claude/claude.json type=file content=$(execpath guest-config/claude.json) mode=0644 uid=0 gid=0",
     ],
 )
 

--- a/projects/embervm/runtimes/claude/apko.lock.json
+++ b/projects/embervm/runtimes/claude/apko.lock.json
@@ -2,7 +2,7 @@
   "version": "v1",
   "config": {
     "name": "apko.yaml",
-    "checksum": "sha256-ZaU7T87pMpsuDI01XjqMM2660LP+qWJ46t1CMxs8Hco="
+    "checksum": "sha256-ldkhw8qHgJnsDm5qV1nR3nOVJj3WzaH7BpJDhl/5uCo="
   },
   "contents": {
     "keyring": [

--- a/projects/embervm/runtimes/claude/apko.yaml
+++ b/projects/embervm/runtimes/claude/apko.yaml
@@ -51,7 +51,9 @@ accounts:
 environment:
   # Claude Code writes its config and session transcripts under $HOME
   # (~/.claude.json, ~/.claude/projects/<dir>/<session-id>.jsonl), so HOME must
-  # be a real writable path owned by uid 65532.
+  # be a real writable path owned by uid 65532. The rootfs is read-only on every
+  # boot, so this path is a BIND MOUNT that guest-init lays over the image's
+  # directory, sourced from /session (see the paths block below).
   HOME: /home/runtime
   PYTHONUNBUFFERED: "1"
   # Guests are driven headlessly over vsock. No TTY is attached, so anything that
@@ -96,6 +98,17 @@ paths:
     type: directory
     uid: 65532
     gid: 65532
+    permissions: 0o755
+  # Mount point for the guest's ONE writable filesystem: a per-session disk once
+  # noded attaches one (#4091), a tmpfs until then. guest-init mounts it here and
+  # bind-mounts its `workspace` and `home` subdirectories onto /workspace and
+  # /home/runtime. It MUST exist in the image: the rootfs is read-only on every
+  # boot, so an init that tried to mkdir its own mount point would fail with the
+  # same EROFS that this whole arrangement exists to avoid.
+  - path: /session
+    type: directory
+    uid: 0
+    gid: 0
     permissions: 0o755
 
 entrypoint:

--- a/projects/embervm/runtimes/claude/guest-init/cmd/main.go
+++ b/projects/embervm/runtimes/claude/guest-init/cmd/main.go
@@ -15,8 +15,18 @@ var shimCmd = []string{"/usr/local/bin/ember-claude-shim"}
 var procCmdlinePath = "/proc/cmdline"
 
 const (
-	workspaceDevCmdlineKey = "ember.workspace_dev"
-	mmdsEnvCmdlinePrefix   = "ember.env."
+	// The keys noded ACTUALLY emits (fcvm/driver bootArgsFor). This guest used to
+	// read ember.workspace_dev, which noded has never emitted, so a drive attached
+	// through the existing volume path would have been silently ignored: both
+	// halves looked wired in isolation and neither could reach the other. Reuse
+	// noded's convention rather than teach the daemon a second one.
+	//
+	// volume_dev is the actual device, NOT a fixed /dev/vdc: drives land on
+	// /dev/vd{a,b,c...} in attach order, so a boot with no handler disk (which is
+	// every session boot) puts the writable volume on vdb.
+	volumeDevCmdlineKey   = "ember.volume_dev"
+	volumeMountCmdlineKey = "ember.volume_mount"
+	mmdsEnvCmdlinePrefix  = "ember.env."
 )
 
 func main() {

--- a/projects/embervm/runtimes/claude/guest-init/cmd/main_test.go
+++ b/projects/embervm/runtimes/claude/guest-init/cmd/main_test.go
@@ -16,11 +16,11 @@ func TestValueFromCmdline(t *testing.T) {
 	for _, tc := range []struct {
 		name, cmdline, key, want string
 	}{
-		{"present", "console=ttyS0 ember.workspace_dev=/dev/vdb", workspaceDevCmdlineKey, "/dev/vdb"},
-		{"absent", "console=ttyS0 init=/init", workspaceDevCmdlineKey, ""},
-		{"empty value", "ember.workspace_dev=", workspaceDevCmdlineKey, ""},
-		{"duplicate last wins", "ember.workspace_dev=/dev/vdb ember.workspace_dev=/dev/vdc", workspaceDevCmdlineKey, "/dev/vdc"},
-		{"not a prefix match", "other.ember.workspace_dev=/dev/vdb", workspaceDevCmdlineKey, ""},
+		{"present", "console=ttyS0 ember.volume_dev=/dev/vdb", volumeDevCmdlineKey, "/dev/vdb"},
+		{"absent", "console=ttyS0 init=/init", volumeDevCmdlineKey, ""},
+		{"empty value", "ember.volume_dev=", volumeDevCmdlineKey, ""},
+		{"duplicate last wins", "ember.volume_dev=/dev/vdb ember.volume_dev=/dev/vdc", volumeDevCmdlineKey, "/dev/vdc"},
+		{"not a prefix match", "other.ember.volume_dev=/dev/vdb", volumeDevCmdlineKey, ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := valueFromCmdline(tc.cmdline, tc.key); got != tc.want {
@@ -140,15 +140,27 @@ func TestMountWorkspaceVolumePathsAreIsolated(t *testing.T) {
 		chownFn = originalChown
 		chmodFn = originalChmod
 	})
+	originalStat := statFn
+	originalRead := readFileFn
+	originalWrite := writeFileFn
+	t.Cleanup(func() {
+		statFn = originalStat
+		readFileFn = originalRead
+		writeFileFn = originalWrite
+	})
 	mountFn = func(string, string, string, uintptr, string) error { return nil }
 	mkdirAllFn = func(string, os.FileMode) error { return nil }
 	chownFn = func(string, int, int) error { return nil }
 	chmodFn = func(string, os.FileMode) error { return nil }
+	// No trust record on the writable HOME yet, so the seed path runs.
+	statFn = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+	readFileFn = func(string) ([]byte, error) { return []byte("{}"), nil }
+	writeFileFn = func(string, []byte, os.FileMode) error { return nil }
 	for _, tc := range []struct {
 		name, cmdline string
 		wantErr       bool
 	}{
-		{"device path fails closed", "init=/init ember.workspace_dev=/dev/does-not-exist\n", true},
+		{"device path fails closed", "init=/init ember.volume_dev=/dev/does-not-exist\n", true},
 		{"tmpfs path", "init=/init console=ttyS0\n", false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -173,4 +185,40 @@ func withCmdlinePath(t *testing.T, path string) {
 	previous := procCmdlinePath
 	procCmdlinePath = path
 	t.Cleanup(func() { procCmdlinePath = previous })
+}
+
+// TestSeedTrustRecordDoesNotClobber covers the branch that matters once a session
+// has a real disk: the CLI's own writes to ~/.claude.json (onboarding state) must
+// survive a cold boot, so the image's baked master seeds ONLY into an empty HOME.
+func TestSeedTrustRecordDoesNotClobber(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	originalStat, originalRead, originalWrite, originalChown := statFn, readFileFn, writeFileFn, chownFn
+	t.Cleanup(func() {
+		statFn, readFileFn, writeFileFn, chownFn = originalStat, originalRead, originalWrite, originalChown
+	})
+	chownFn = func(string, int, int) error { return nil }
+	readFileFn = func(string) ([]byte, error) { return []byte(`{"projects":{}}`), nil }
+
+	t.Run("absent seeds", func(t *testing.T) {
+		wrote := ""
+		statFn = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+		writeFileFn = func(path string, _ []byte, _ os.FileMode) error { wrote = path; return nil }
+		if err := seedTrustRecord(logger); err != nil {
+			t.Fatalf("seedTrustRecord() = %v", err)
+		}
+		if wrote != runtimeHomePath+"/.claude.json" {
+			t.Errorf("seeded %q, want the record in HOME", wrote)
+		}
+	})
+
+	t.Run("present is left alone", func(t *testing.T) {
+		statFn = func(string) (os.FileInfo, error) { return nil, nil }
+		writeFileFn = func(string, []byte, os.FileMode) error {
+			t.Fatal("overwrote an existing trust record; the CLI's own state would be rolled back")
+			return nil
+		}
+		if err := seedTrustRecord(logger); err != nil {
+			t.Fatalf("seedTrustRecord() = %v", err)
+		}
+	})
 }

--- a/projects/embervm/runtimes/claude/guest-init/cmd/volume_linux.go
+++ b/projects/embervm/runtimes/claude/guest-init/cmd/volume_linux.go
@@ -12,7 +12,21 @@ import (
 )
 
 const (
-	workspaceTmpfsSize = "size=2g,mode=755"
+	// The tmpfs fallback covers the base build, which attaches no device. It also
+	// backs a session until noded learns to attach a per-session drive (#4091),
+	// which cannot happen while sessions are RESTORED from a shared pristine
+	// snapshot: a restore never re-runs this init and never re-reads boot args, so
+	// cold boot is what unlocks a per-session disk, not a drive-attach patch.
+	sessionTmpfsSize = "size=2g,mode=755"
+	// Where the writable device (or its tmpfs stand-in) is mounted. Both the
+	// checkout and HOME are subdirectories of it, bind-mounted onto the paths the
+	// image already uses, so when a real disk lands here BOTH become disk-backed
+	// with no further guest change.
+	defaultSessionRoot = "/session"
+	// The trust record's read-only master. It cannot live at its final path: a
+	// bind mount over /home/runtime would hide it, so the image bakes it here and
+	// this init seeds a copy into the writable HOME.
+	trustRecordSeedPath = "/usr/share/ember-claude/claude.json"
 )
 
 var (
@@ -23,60 +37,131 @@ var (
 	mkdirAllFn          = os.MkdirAll
 	chownFn             = os.Chown
 	chmodFn             = os.Chmod
+	readFileFn          = os.ReadFile
+	writeFileFn         = os.WriteFile
+	statFn              = os.Stat
 )
 
+// mountWorkspaceVolume gives the guest its writable state.
+//
+// The rootfs is attached READ-ONLY on every boot (noded RootfsReadOnly: one
+// rootfs file backs every restored clone), so nothing under / can be written,
+// including /home/runtime. That is not incidental to this runtime: the CLI keeps
+// its config at ~/.claude.json and its session transcript at
+// ~/.claude/projects/<dir>/<session-id>.jsonl, and the transcript is what
+// `claude --resume` replays when the shim respawns a CLI that died mid-session.
+//
+// So HOME must be writable, and it must NOT stay tmpfs: tmpfs pages are
+// unreclaimable, so memMib would have to be sized for the largest transcript a
+// session will ever write (they reach tens of MiB) and the memfile would grow
+// with the conversation. Putting HOME on the same mount as the checkout means the
+// disk #4091 attaches makes both disk-backed at once.
 func mountWorkspaceVolume(logger *slog.Logger) error {
-	raw, err := os.ReadFile(procCmdlinePath)
-	if err == nil {
-		if dev := valueFromCmdline(string(raw), workspaceDevCmdlineKey); dev != "" {
-			// If workspace_dev is present, fail closed: a guest cannot run correctly
-			// without its persistent volume.
-			if err := mountVolumeDeviceFn(logger, dev, workspaceMountPath); err != nil {
-				return fmt.Errorf("mount requested workspace device %s: %w", dev, err)
-			}
-			logger.Info("workspace volume: mounted", "device", dev)
-			return ensureRuntimeHome()
+	root, dev := defaultSessionRoot, ""
+	if raw, err := os.ReadFile(procCmdlinePath); err == nil {
+		dev = valueFromCmdline(string(raw), volumeDevCmdlineKey)
+		if mount := valueFromCmdline(string(raw), volumeMountCmdlineKey); mount != "" {
+			root = mount
 		}
 	}
 
-	if err := mkdirAllFn(workspaceMountPath, 0o755); err != nil {
-		return fmt.Errorf("mkdir workspace mount path %s: %w", workspaceMountPath, err)
+	if dev != "" {
+		// Fail closed: a guest told it has a persistent device cannot run correctly
+		// without it, and silently continuing on tmpfs would lose the session.
+		if err := mountVolumeDeviceFn(logger, dev, root); err != nil {
+			return fmt.Errorf("mount requested volume device %s at %s: %w", dev, root, err)
+		}
+		logger.Info("session volume: mounted", "device", dev, "mount", root)
+	} else {
+		if err := mkdirAllFn(root, 0o755); err != nil {
+			return fmt.Errorf("mkdir session root %s: %w", root, err)
+		}
+		if err := mountFn("tmpfs", root, "tmpfs", 0, sessionTmpfsSize); err != nil {
+			return fmt.Errorf("mount tmpfs session root %s: %w", root, err)
+		}
+		logger.Info("session volume: no device attached, using tmpfs", "mount", root)
 	}
-	// A tmpfs workspace is only valid for a base build with no persistent device.
-	// Two GiB covers typical repository checkouts and git working-tree overhead.
-	if err := mountFn("tmpfs", workspaceMountPath, "tmpfs", 0, workspaceTmpfsSize); err != nil {
-		return fmt.Errorf("mount tmpfs workspace: %w", err)
+
+	if err := bindWritable(root+"/workspace", workspaceMountPath); err != nil {
+		return err
 	}
-	logger.Info("workspace volume: using tmpfs, no device attached")
-	return ensureRuntimeHome()
+	if err := bindWritable(root+"/home", runtimeHomePath); err != nil {
+		return err
+	}
+	// The image creates /home/runtime/.claude, but the bind above hides it. Just
+	// create it on the writable side; it is already reachable through the bind, so
+	// it needs no mount of its own. The CLI would almost certainly mkdir it on
+	// demand, but this costs two syscalls and removes a failure mode that would
+	// only surface as a missing transcript after a full deploy.
+	claudeDir := root + "/home/.claude"
+	if err := mkdirAllFn(claudeDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", claudeDir, err)
+	}
+	if err := chownFn(claudeDir, 65532, 65532); err != nil {
+		return fmt.Errorf("chown %s: %w", claudeDir, err)
+	}
+	return seedTrustRecord(logger)
 }
 
-func ensureRuntimeHome() error {
-	if err := mkdirAllFn(runtimeHomePath, 0o755); err != nil {
-		return fmt.Errorf("mkdir runtime home %s: %w", runtimeHomePath, err)
+// bindWritable creates src on the writable mount, bind-mounts it over target (a
+// read-only rootfs directory the image already provides), and hands it to the
+// runtime uid. The chown lands on the bind SOURCE, which is writable; chowning
+// the rootfs path directly is exactly what failed the base build with EROFS.
+func bindWritable(src, target string) error {
+	if err := mkdirAllFn(src, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", src, err)
 	}
-	if err := chownFn(runtimeHomePath, 65532, 65532); err != nil {
-		return fmt.Errorf("chown runtime home %s: %w", runtimeHomePath, err)
+	if err := chownFn(src, 65532, 65532); err != nil {
+		return fmt.Errorf("chown %s: %w", src, err)
 	}
-	if err := chmodFn(runtimeHomePath, 0o755); err != nil {
-		return fmt.Errorf("chmod runtime home %s: %w", runtimeHomePath, err)
+	if err := chmodFn(src, 0o755); err != nil {
+		return fmt.Errorf("chmod %s: %w", src, err)
 	}
+	if err := mountFn(src, target, "", unix.MS_BIND, ""); err != nil {
+		return fmt.Errorf("bind %s onto %s: %w", src, target, err)
+	}
+	return nil
+}
+
+// seedTrustRecord copies the baked ~/.claude.json into the now-writable HOME.
+//
+// Without it the CLI reports "Error: Workspace not trusted" and waits on a dialog
+// no one is there to answer. Only when ABSENT: on a session whose disk already
+// carries a record, the CLI's own writes (onboarding state) must win over the
+// image's copy, or every cold boot would silently roll that state back.
+func seedTrustRecord(logger *slog.Logger) error {
+	dst := runtimeHomePath + "/.claude.json"
+	if _, err := statFn(dst); err == nil {
+		logger.Info("trust record: already present, leaving it alone", "path", dst)
+		return nil
+	}
+	record, err := readFileFn(trustRecordSeedPath)
+	if err != nil {
+		return fmt.Errorf("read trust record seed %s: %w", trustRecordSeedPath, err)
+	}
+	if err := writeFileFn(dst, record, 0o644); err != nil {
+		return fmt.Errorf("write trust record %s: %w", dst, err)
+	}
+	if err := chownFn(dst, 65532, 65532); err != nil {
+		return fmt.Errorf("chown trust record %s: %w", dst, err)
+	}
+	logger.Info("trust record: seeded", "path", dst)
 	return nil
 }
 
 func mountVolumeDevice(logger *slog.Logger, dev, mountPath string) error {
 	blank, err := deviceIsBlank(dev)
 	if err != nil {
-		return fmt.Errorf("probe workspace device %s: %w", dev, err)
+		return fmt.Errorf("probe volume device %s: %w", dev, err)
 	}
 	if blank {
-		logger.Info("workspace volume: no filesystem signature, formatting ext4", "device", dev)
+		logger.Info("session volume: no filesystem signature, formatting ext4", "device", dev)
 		if out, err := exec.Command("mkfs.ext4", "-q", dev).CombinedOutput(); err != nil {
 			return fmt.Errorf("mkfs.ext4 %s: %w: %s", dev, err, string(out))
 		}
 	}
 	if err := mkdirAllFn(mountPath, 0o755); err != nil {
-		return fmt.Errorf("mkdir workspace mount path %s: %w", mountPath, err)
+		return fmt.Errorf("mkdir volume mount path %s: %w", mountPath, err)
 	}
 	if err := mountFn(dev, mountPath, "ext4", 0, ""); err != nil {
 		return fmt.Errorf("mount %s at %s: %w", dev, mountPath, err)


### PR DESCRIPTION
Fixes the two problems blocking `claude-runtime` from ever reaching Ready. Both
are guest-side; the larger half of #4091 (cold boot + a real per-session disk)
follows separately.

## 1. The base build could never succeed

It has looped on a ~60s retry since #4075 landed:

```
ember-runtime-guest-init exited with error
err="chown runtime home /home/runtime: chown /home/runtime: read-only file system"
```

`ensureRuntimeHome()` chowned `/home/runtime`, which is on the rootfs, and noded
attaches the rootfs read-only on **every** boot (`RootfsReadOnly`, unconditional
in `noded/cmd/main.go:402`) because one rootfs file backs every restored clone.
The chown could never succeed.

Dropping it would only move the failure. `apko.yaml` says HOME "must be a real
writable path" because the CLI keeps `~/.claude.json` there and writes its
transcript to `~/.claude/projects/<dir>/<session-id>.jsonl`, which is what
`claude --resume` replays when the shim respawns a CLI that died mid-session. It
could write none of them.

Writable state now hangs off one mount at `/session`, with `workspace` and `home`
subdirectories bind-mounted onto `/workspace` and `/home/runtime`. The chowns
land on the bind sources, which are writable.

**tmpfs backs it only until #4091, and is explicitly not the destination.** tmpfs
pages are unreclaimable, so `memMib` would have to be sized for the largest
transcript a session ever writes (measured: 34 MB for one session, plus 105 MB of
`file-history`) and the memfile would grow with the conversation. Hanging both
the checkout and HOME off a single mount is what makes the disk a drop-in: when
noded attaches one, both become disk-backed with no further guest change.

## 2. The two halves of the volume lane never agreed on a name

Found while wiring the first fix. noded emits `ember.volume_dev` /
`ember.volume_mount` (`fcvm/driver/driver.go:437`), but this guest read
`ember.workspace_dev` (`guest-init/cmd/main.go:18`), which noded has never
emitted. A drive attached through the existing volume path would have been
**silently ignored**, and both halves look correct read in isolation. Same shape
as the `ServeEgress` gap in #4071.

The guest now reads noded's keys, rather than teaching the daemon a second
convention.

## Knock-on changes

- The baked trust record moves to `/usr/share/ember-claude/claude.json`. A file
  baked under `/home/runtime` is hidden the moment the bind lands, so guest-init
  seeds it into HOME **only when absent**: a session disk that already carries
  the CLI's own onboarding state must not be rolled back on cold boot. Tested
  both branches.
- `/session` is baked into the image via apko `paths:`, for the same read-only
  reason the chown failed: an init cannot mkdir its own mount point. I hit this
  writing the fix.

## Verification

`ci test` green, 754 Bazel targets, and the guest-init tests are Linux-only so
they genuinely execute on the remote rather than being skipped locally. The base
build itself can only be confirmed after deploy, since it needs a real
Firecracker boot; I will watch `claude-runtime` reach `BaseBuilt` once the chart
publishes.

Refs #4055, #4091