### PR TITLE
feat(embervm): add ListArtifacts and a dry-run remote base retention sweep

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.255
+version: 0.1.257

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -110,6 +110,7 @@ defmodule Embervm.BaseBuilder do
     BuildBaseResponse,
     EvictArtifactRequest,
     ExportArtifactRequest,
+    ListArtifactsRequest,
     NodeService,
     ResourceSpec,
     RestoreArtifactRequest,
@@ -310,6 +311,11 @@ defmodule Embervm.BaseBuilder do
     # takes (channel, workload, ref) so it can compose the vendor-keyed store prefix
     # (the BASE key is base/<vendor>/<workload>/<ref>).
     evict_fun = Keyword.get(opts, :evict_fun, &default_evict/3)
+    # Remote base retention (#3947 PR-4): the ListArtifacts seam that reads the
+    # STORE inventory for one (workload, vendor). Takes (channel, workload,
+    # vendor) and returns {:ok, entries, truncated} or {:error, reason}. Tests
+    # inject a fake so no test opens a channel.
+    list_fun = Keyword.get(opts, :list_fun, &default_list_artifacts/3)
     # Base-durability PR-1: the ExportArtifact seam that writes a freshly-built
     # (or present-but-unexported) base back to the object store. Defaults to the
     # real NodeService.Stub.export_artifact/2 over a per-call channel; tests
@@ -414,6 +420,7 @@ defmodule Embervm.BaseBuilder do
       connect_fun: connect_fun,
       disconnect_fun: disconnect_fun,
       evict_fun: evict_fun,
+      list_fun: list_fun,
       export_fun: export_fun,
       restore_fun: restore_fun,
       op_log: op_log,
@@ -471,6 +478,10 @@ defmodule Embervm.BaseBuilder do
 
   def handle_call(:retention_sweep_now, _from, state) do
     {plan, state} = retention_sweep_plan(state)
+    # Mirror the timer path (retention_sweep/1) exactly, so a test driving this
+    # hook exercises the same work the :retention_sweep tick does. Letting the two
+    # diverge is how a sweep passes its tests while doing something else in prod.
+    remote_retention_sweep(state)
     {:reply, plan, state}
   end
 
@@ -1601,7 +1612,101 @@ defmodule Embervm.BaseBuilder do
   # WorkloadWatcher has completed its initial LIST.
   defp retention_sweep(state) do
     {_plan, state} = retention_sweep_plan(state)
+    remote_retention_sweep(state)
     state
+  end
+
+  # REMOTE base retention (#3947 PR-4), dry-run only in this change.
+  #
+  # The local sweep above reclaims node disk. It cannot reclaim the STORE, because
+  # a superseded base leaves node disk long before its S3 object does: by the time
+  # remote retention runs, no node necessarily still holds the ref, so the bucket
+  # is the only record of it. ListArtifacts is that record.
+  #
+  # Keyed per (workload, VENDOR), not per node. The store key
+  # base/<vendor>/<workload>/<ref> has no node segment, so one object is shared by
+  # every node of that vendor: iterating nodes would compute the same candidate set
+  # once per node and (once armed) issue duplicate deletes. Contrast the local
+  # sweep, which IS per node because local bytes are node-local. That asymmetry is
+  # the same one #4079 established for export.
+  #
+  # This logs what it WOULD evict and deletes nothing. Arming it is a separate
+  # change, deliberately, because the blast radius is the bucket.
+  defp remote_retention_sweep(state) do
+    for {_name, w} <- state.workloads,
+        {vendor, vendor_refs} <- snapshot_refs_by_vendor(state, w),
+        {:ok, instance_id} <- [node_of_vendor(state, w, vendor)] do
+      keep =
+        MapSet.new(vendor_refs ++ desired_refs_for_node(nil, w))
+        |> MapSet.delete(nil)
+
+      case list_remote_refs(state, instance_id, w.name, vendor) do
+        {:ok, entries, truncated} ->
+          candidates = Enum.reject(entries, fn e -> MapSet.member?(keep, e.ref) end)
+          log_remote_retention(w.name, vendor, candidates, truncated, keep)
+
+        {:error, reason} ->
+          # Fail toward KEEPING bytes: a daemon that predates ListArtifacts
+          # answers UNIMPLEMENTED, and a store hiccup is Unavailable. Either way
+          # the correct move is to skip this (workload, vendor) this tick.
+          Logger.debug(
+            "embervm base builder: remote retention skipped for #{w.name}/#{vendor}: #{inspect(reason)}"
+          )
+      end
+    end
+
+    :ok
+  end
+
+  # Any instance on a node whose reported cpu_vendor matches. The store copy is
+  # shared across the vendor, so ANY of its nodes can answer for it; a node need
+  # not hold the base locally to list or (later) evict it.
+  defp node_of_vendor(state, w, vendor) do
+    state
+    |> representative_facts_by_node(w.name)
+    |> Enum.find(fn fact ->
+      fact |> Map.get(:cpu_vendor, "") |> to_string() |> String.trim() == vendor
+    end)
+    |> case do
+      nil -> :error
+      fact -> {:ok, fact[:instance_id]}
+    end
+  end
+
+  defp list_remote_refs(state, instance_id, workload, vendor) do
+    case Map.get(state.node_addr, instance_id) do
+      nil ->
+        {:error, {:connect, :no_address}}
+
+      address ->
+        case state.connect_fun.(address) do
+          {:ok, channel} ->
+            try do
+              state.list_fun.(channel, workload, vendor)
+            catch
+              kind, reason -> {:error, {kind, reason}}
+            after
+              state.disconnect_fun.(channel)
+            end
+
+          {:error, reason} ->
+            {:error, {:connect, reason}}
+        end
+    end
+  end
+
+  defp log_remote_retention(workload, vendor, candidates, truncated, keep) do
+    if candidates != [] do
+      bytes = Enum.reduce(candidates, 0, fn e, acc -> acc + (e.size_bytes || 0) end)
+      refs = Enum.map(candidates, & &1.ref)
+
+      Logger.info(
+        "embervm base builder: remote base retention (DRY RUN, never evicts in this build) " <>
+          "WOULD evict #{length(candidates)} superseded store base(s) for #{workload}/#{vendor} " <>
+          "(~#{bytes} bytes), keeping #{MapSet.size(keep)} ref(s)#{if truncated, do: ", listing TRUNCATED", else: ""}: " <>
+          inspect(refs)
+      )
+    end
   end
 
   # Compute the sweep plan (a per-node list of what to evict) AND apply the
@@ -2304,6 +2409,24 @@ defmodule Embervm.BaseBuilder do
   # ArtifactRef carries the workload so the node composes the vendor-keyed base
   # store prefix; the node stamps its own cpu vendor. Idempotent on an
   # already-gone base.
+  # ListArtifacts the STORE inventory for one (workload, vendor). The vendor is
+  # explicit rather than the node's own, because the object is shared across the
+  # vendor and any of its nodes can answer for it. Returns the entries plus
+  # whether the daemon truncated the listing.
+  defp default_list_artifacts(channel, workload, vendor) do
+    request = %ListArtifactsRequest{
+      kind: :ARTIFACT_KIND_BASE,
+      workload: workload,
+      vendor: vendor,
+      trace: %Trace{workload: workload}
+    }
+
+    case NodeService.Stub.list_artifacts(channel, request, timeout: 30_000) do
+      {:ok, resp} -> {:ok, resp.entries || [], resp.truncated}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   defp default_evict(channel, workload, ref) do
     NodeService.Stub.evict_artifact(channel, %EvictArtifactRequest{
       artifact: %ArtifactRef{

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -1936,6 +1936,85 @@ defmodule Embervm.BaseBuilderTest do
     assert status["snapshotRef"] == "w__amd"
   end
 
+  test "remote retention lists per vendor and spares the vendor's current ref" do
+    agent = start_recorder()
+    table = new_cap_table()
+    test_pid = self()
+
+    put_vendor_fact(table, "node-4", nil, "w", "w__amd_cur", "amd")
+    put_vendor_fact(table, "node-1", "ds", "w", "w__intel_cur", "intel")
+
+    # The store still holds each vendor's current ref plus one superseded ref.
+    list_fun = fn _channel, workload, vendor ->
+      send(test_pid, {:listed, workload, vendor})
+
+      entries =
+        case vendor do
+          "amd" ->
+            [%{ref: "w__amd_cur", size_bytes: 10}, %{ref: "w__amd_old", size_bytes: 20}]
+
+          "intel" ->
+            [%{ref: "w__intel_cur", size_bytes: 30}, %{ref: "w__intel_old", size_bytes: 40}]
+        end
+
+      {:ok, entries, false}
+    end
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__amd_cur")} end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        list_fun: list_fun,
+        # Both vendors' instances need a dialable address: the sweep asks a node
+        # OF THAT VENDOR for the store listing, and the intel node is not the
+        # build's placement node.
+        nodes: [@node, %{id: "node-1/ds", address: "node-1:9090"}]
+      )
+
+    build_current(builder, agent, "w__amd_cur")
+
+    # Drive one sweep. It must consult EACH vendor exactly once (the store object
+    # is shared across a vendor's nodes, so per-node iteration would duplicate).
+    _ = BaseBuilder.retention_sweep_now(builder)
+
+    assert_receive {:listed, "w", "amd"}, 1_000
+    assert_receive {:listed, "w", "intel"}, 1_000
+
+    # Dry run: nothing is evicted in this build, so a second sweep still sees the
+    # same store and simply logs again.
+    _ = BaseBuilder.retention_sweep_now(builder)
+    assert_receive {:listed, "w", "amd"}, 1_000
+  end
+
+  test "remote retention skips a vendor whose daemon does not implement ListArtifacts" do
+    agent = start_recorder()
+    table = new_cap_table()
+    put_vendor_fact(table, "node-4", nil, "w", "w__amd_cur", "amd")
+
+    # An older daemon answers UNIMPLEMENTED. The sweep must fail toward KEEPING
+    # bytes rather than crashing the builder.
+    list_fun = fn _channel, _workload, _vendor -> {:error, :unimplemented} end
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__amd_cur")} end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        list_fun: list_fun
+      )
+
+    build_current(builder, agent, "w__amd_cur")
+    _ = BaseBuilder.retention_sweep_now(builder)
+
+    # The builder is still alive and still serving status.
+    assert BaseBuilder.status(builder).workloads["w"].snapshot_ref == "w__amd_cur"
+  end
+
   test "the periodic reconcile picks up a vendor that advertised after the build" do
     agent = start_recorder()
     table = new_cap_table()

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.255
+      targetRevision: 0.1.257
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/store.go
+++ b/projects/embervm/noded/server/store.go
@@ -38,6 +38,17 @@ type artifactStore interface {
 	DeleteArtifact(ctx context.Context, prefix string) error
 	Present(ctx context.Context, prefix string) (present bool, generation uint64, cpuVendor, cpuTemplate string, err error)
 	Reachable(ctx context.Context) bool
+	// ListRefs enumerates the artifact refs stored under a prefix (PR-4 remote
+	// retention). Delimited, so the response tracks the ref count rather than the
+	// file count; truncated reports that the store held more than limit.
+	ListRefs(ctx context.Context, prefix string, limit int) (refs []string, truncated bool, err error)
+	// ArtifactInfo reads an artifact's completeness marker and returns the fields
+	// ListArtifacts reports that Present does not surface (created-at, total
+	// size), plus the vendor stamp so a caller can verify an object really
+	// belongs to the vendor prefix it was listed under. Returned flat rather than
+	// as a store.Meta so this seam keeps NOT importing the store package, per the
+	// note above.
+	ArtifactInfo(ctx context.Context, prefix string) (present bool, createdAtUnixMs int64, sizeBytes uint64, cpuVendor, cpuTemplate string, err error)
 }
 
 // artifactKindStr maps an ArtifactKind to its lowercase store-key segment (Fork
@@ -613,16 +624,104 @@ func (s *Server) EvictArtifact(ctx context.Context, req *nodev1.EvictArtifactReq
 			// (gone) already holds. Idempotent success.
 			return &nodev1.EvictArtifactResponse{}, nil
 		}
-		if err := s.store.DeleteArtifact(ctx, prefix); err != nil {
-			return nil, status.Errorf(codes.Unavailable, "noded: evict remote artifact %q: %v", prefix, err)
+		// Remote eviction targets a (vendor, ref) OBJECT, not this node's copy: the
+		// store key carries no node segment, so one object is shared by every node
+		// of that vendor. An explicit vendor therefore lets the control plane
+		// reclaim a vendor's superseded bases through ANY node, which is the only
+		// way a mixed fleet converges. Without it a node could compose only its own
+		// vendor's key, so nobody could ever clean up the other vendor's bases.
+		//
+		// This deliberately breaks the node-locality that LOCAL eviction keeps.
+		// Export is per (vendor, ref), local eviction is per node, and remote
+		// eviction is per (vendor, ref). Empty vendor preserves the pre-existing
+		// behaviour (this node's own), so an older caller is unaffected.
+		remotePrefix := prefix
+		if v := req.GetVendor(); v != "" && artifactVendorSegment(ref.GetKind()) {
+			remotePrefix = artifactPrefix(ref, v)
+			if remotePrefix == "" {
+				return nil, status.Error(codes.InvalidArgument, "noded: artifact kind and workload required")
+			}
 		}
-		s.exported.clear(prefix)
+		if err := s.store.DeleteArtifact(ctx, remotePrefix); err != nil {
+			return nil, status.Errorf(codes.Unavailable, "noded: evict remote artifact %q: %v", remotePrefix, err)
+		}
+		s.exported.clear(remotePrefix)
 		s.signalChange()
 		return &nodev1.EvictArtifactResponse{}, nil
 	}
 	// Local eviction over the typed ref: reuse the existing EvictSnapshot path for
 	// bundle kinds, DeleteVolume for a VOLUME.
 	return s.evictArtifactLocal(ctx, ref)
+}
+
+// listArtifactsDefaultLimit is the cap applied when a caller passes limit 0, and
+// listArtifactsMaxLimit is the ceiling the daemon enforces regardless of what the
+// caller asked for. Both are generous against the real shape (a handful of refs
+// per (workload, vendor), even mid-backlog) while keeping one response well
+// inside gRPC message limits.
+const (
+	listArtifactsDefaultLimit = 256
+	listArtifactsMaxLimit     = 1024
+)
+
+// ListArtifacts enumerates the STORE objects under one kind+vendor+workload
+// prefix, so the control plane can compute remote retention by count.
+//
+// This answers a question no LOCAL inventory can: a superseded base is reclaimed
+// from node disk long before its store object is, so by the time remote retention
+// runs, no node necessarily still holds the ref. The bucket is the only remaining
+// record of it.
+//
+// An entry whose completeness marker is missing or unreadable is OMITTED rather
+// than reported with zeroed fields. meta.json is the store's own definition of
+// "present", so an artifact without one is not present, and retention must never
+// order on (or evict) something it cannot describe.
+func (s *Server) ListArtifacts(ctx context.Context, req *nodev1.ListArtifactsRequest) (*nodev1.ListArtifactsResponse, error) {
+	if s.store == nil {
+		return nil, status.Error(codes.FailedPrecondition, "noded: object store not configured; list unavailable")
+	}
+	if artifactKindStr(req.GetKind()) == "" || req.GetWorkload() == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: artifact kind and workload required")
+	}
+	vendor := req.GetVendor()
+	if vendor == "" {
+		vendor = s.cfg.CpuVendor
+	}
+	// The WORKLOAD-level prefix (no ref segment): the refs under it are what the
+	// delimited list enumerates.
+	prefix := artifactPrefix(&nodev1.ArtifactRef{Kind: req.GetKind(), Workload: req.GetWorkload()}, vendor)
+	if prefix == "" {
+		return nil, status.Error(codes.InvalidArgument, "noded: vendor required for a vendor-bound artifact kind")
+	}
+
+	limit := int(req.GetLimit())
+	if limit <= 0 {
+		limit = listArtifactsDefaultLimit
+	}
+	if limit > listArtifactsMaxLimit {
+		limit = listArtifactsMaxLimit
+	}
+
+	refs, truncated, err := s.store.ListRefs(ctx, prefix, limit)
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "noded: list artifacts %q: %v", prefix, err)
+	}
+
+	entries := make([]*nodev1.ListArtifactsEntry, 0, len(refs))
+	for _, r := range refs {
+		present, createdAt, size, v, tmpl, ierr := s.store.ArtifactInfo(ctx, prefix+"/"+r)
+		if ierr != nil || !present {
+			continue
+		}
+		entries = append(entries, &nodev1.ListArtifactsEntry{
+			Ref:             r,
+			CreatedAtUnixMs: createdAt,
+			SizeBytes:       size,
+			CpuVendor:       v,
+			CpuTemplate:     tmpl,
+		})
+	}
+	return &nodev1.ListArtifactsResponse{Entries: entries, Truncated: truncated}, nil
 }
 
 // evictArtifactLocal deletes the on-disk copy of an artifact over the typed ref,

--- a/projects/embervm/noded/server/store_test.go
+++ b/projects/embervm/noded/server/store_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -45,6 +46,9 @@ type fakeArtifact struct {
 	gen         uint64
 	cpuVendor   string
 	cpuTemplate string
+	// createdAtMs mirrors the real store's meta.json CreatedAtUnixMs, which is
+	// what remote retention orders on.
+	createdAtMs int64
 }
 
 func newFakeStore() *fakeStore {
@@ -55,7 +59,7 @@ func newFakeStore() *fakeStore {
 	}
 }
 
-func (f *fakeStore) Export(_ context.Context, prefix, localDir string, files []string, generation uint64, _ int64, cpuVendor, cpuTemplate string) (int64, bool, error) {
+func (f *fakeStore) Export(_ context.Context, prefix, localDir string, files []string, generation uint64, nowMs int64, cpuVendor, cpuTemplate string) (int64, bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.exportCalls[prefix]++
@@ -74,7 +78,7 @@ func (f *fakeStore) Export(_ context.Context, prefix, localDir string, files []s
 	if existing, ok := f.arts[prefix]; ok && sameStringMap(existing.files, got) {
 		return 0, true, nil
 	}
-	f.arts[prefix] = fakeArtifact{files: got, gen: generation, cpuVendor: cpuVendor, cpuTemplate: cpuTemplate}
+	f.arts[prefix] = fakeArtifact{files: got, gen: generation, cpuVendor: cpuVendor, cpuTemplate: cpuTemplate, createdAtMs: nowMs}
 	f.order = append(f.order, prefix)
 	return total, false, nil
 }
@@ -120,6 +124,49 @@ func (f *fakeStore) Present(_ context.Context, prefix string) (bool, uint64, str
 	return true, art.gen, art.cpuVendor, art.cpuTemplate, nil
 }
 
+// ListRefs mirrors the real store's DELIMITED list: it returns the immediate
+// child segment under prefix for every seeded artifact beneath it, deduped, so a
+// caller sees refs rather than files. Sorted for deterministic assertions.
+func (f *fakeStore) ListRefs(_ context.Context, prefix string, limit int) ([]string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	p := strings.TrimSuffix(prefix, "/") + "/"
+	seen := make(map[string]bool)
+	for key := range f.arts {
+		if !strings.HasPrefix(key, p) {
+			continue
+		}
+		rest := strings.Trim(strings.TrimPrefix(key, p), "/")
+		if rest == "" || strings.Contains(rest, "/") {
+			continue
+		}
+		seen[rest] = true
+	}
+	refs := make([]string, 0, len(seen))
+	for r := range seen {
+		refs = append(refs, r)
+	}
+	sort.Strings(refs)
+	if limit > 0 && len(refs) > limit {
+		return refs[:limit], true, nil
+	}
+	return refs, false, nil
+}
+
+func (f *fakeStore) ArtifactInfo(_ context.Context, prefix string) (bool, int64, uint64, string, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	art, ok := f.arts[prefix]
+	if !ok {
+		return false, 0, 0, "", "", nil
+	}
+	var total uint64
+	for _, c := range art.files {
+		total += uint64(len(c))
+	}
+	return true, art.createdAtMs, total, art.cpuVendor, art.cpuTemplate, nil
+}
+
 func (f *fakeStore) Reachable(_ context.Context) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -144,9 +191,15 @@ func (f *fakeStore) has(prefix string) bool {
 // can construct an UNSTAMPED (both "") or a specific-sku artifact precisely,
 // including one this node never wrote itself.
 func (f *fakeStore) seedArtifact(prefix string, files map[string]string, generation uint64, cpuVendor, cpuTemplate string) {
+	f.seedArtifactAt(prefix, files, generation, cpuVendor, cpuTemplate, 0)
+}
+
+// seedArtifactAt is seedArtifact with an explicit meta.json created-at, for the
+// remote-retention tests that assert ordering by age.
+func (f *fakeStore) seedArtifactAt(prefix string, files map[string]string, generation uint64, cpuVendor, cpuTemplate string, createdAtMs int64) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.arts[prefix] = fakeArtifact{files: files, gen: generation, cpuVendor: cpuVendor, cpuTemplate: cpuTemplate}
+	f.arts[prefix] = fakeArtifact{files: files, gen: generation, cpuVendor: cpuVendor, cpuTemplate: cpuTemplate, createdAtMs: createdAtMs}
 }
 
 // errFakeNotPresent stands in for store.ErrNotPresent in these in-package tests
@@ -625,6 +678,128 @@ func TestExportQueueVolumeStillReExportsAtStaleGeneration(t *testing.T) {
 	}
 	if got := fs.calls(prefix); got == 0 {
 		t.Fatal("a VOLUME present at a STALE generation must still be re-exported, got 0 export calls")
+	}
+}
+
+// TestListArtifactsReturnsStoredRefsWithMeta proves the remote inventory read
+// (PR-4, #3947): ListArtifacts enumerates the refs stored under one
+// kind+vendor+workload prefix with the created-at retention orders on, and does
+// NOT leak refs from a sibling vendor's prefix.
+func TestListArtifactsReturnsStoredRefsWithMeta(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx := context.Background()
+
+	files := map[string]string{"imageref": "img", "memfile": "m", "snapfile": "s"}
+	fs.seedArtifactAt("base/amd/bazel-query/bazel-query__old", files, 0, "amd", "", 1000)
+	fs.seedArtifactAt("base/amd/bazel-query/bazel-query__new", files, 0, "amd", "", 2000)
+	// A different vendor's copy of the same workload must not appear.
+	fs.seedArtifactAt("base/intel/bazel-query/bazel-query__intel", files, 0, "intel", "", 3000)
+	// A different workload under the same vendor must not appear either.
+	fs.seedArtifactAt("base/amd/semgrep/semgrep__x", files, 0, "amd", "", 4000)
+
+	resp, err := s.ListArtifacts(ctx, &nodev1.ListArtifactsRequest{
+		Kind:     nodev1.ArtifactKind_ARTIFACT_KIND_BASE,
+		Workload: "bazel-query",
+		Vendor:   "amd",
+	})
+	if err != nil {
+		t.Fatalf("ListArtifacts: %v", err)
+	}
+
+	got := map[string]int64{}
+	for _, e := range resp.GetEntries() {
+		got[e.GetRef()] = e.GetCreatedAtUnixMs()
+	}
+	if len(got) != 2 {
+		t.Fatalf("entries = %v, want exactly the two amd bazel-query refs", got)
+	}
+	if got["bazel-query__old"] != 1000 || got["bazel-query__new"] != 2000 {
+		t.Fatalf("created-at not reported per ref: %v", got)
+	}
+	if resp.GetTruncated() {
+		t.Fatal("listing of 2 refs should not report truncated")
+	}
+}
+
+// TestListArtifactsOmitsAnArtifactWithNoMarker proves an artifact whose
+// completeness marker is unreadable is left OUT rather than reported with a zero
+// date. meta.json is the store's definition of "present", and retention must
+// never order on (or evict) something it cannot describe.
+func TestListArtifactsOmitsAnArtifactWithNoMarker(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+
+	files := map[string]string{"imageref": "img", "memfile": "m", "snapfile": "s"}
+	fs.seedArtifactAt("base/amd/bazel-query/bazel-query__good", files, 0, "amd", "", 1000)
+	// A ref directory that exists in the listing but has no readable marker: the
+	// fake's ListRefs derives refs from seeded keys, so seed a CHILD key to make
+	// the ref appear without the ref prefix itself being a described artifact.
+	fs.seedArtifactAt("base/amd/bazel-query/bazel-query__partial/inner", files, 0, "amd", "", 2000)
+
+	resp, err := s.ListArtifacts(context.Background(), &nodev1.ListArtifactsRequest{
+		Kind:     nodev1.ArtifactKind_ARTIFACT_KIND_BASE,
+		Workload: "bazel-query",
+		Vendor:   "amd",
+	})
+	if err != nil {
+		t.Fatalf("ListArtifacts: %v", err)
+	}
+	for _, e := range resp.GetEntries() {
+		if e.GetRef() == "bazel-query__partial" {
+			t.Fatal("an artifact with no readable meta.json must be omitted, not reported")
+		}
+	}
+}
+
+// TestEvictArtifactRemoteHonoursRequestedVendor proves a node can reclaim ANOTHER
+// vendor's store object (#3947). The store key has no node segment, so one object
+// is shared by every node of that vendor; without an explicit vendor a node could
+// only ever compose its own, and a mixed fleet's bucket never converged.
+func TestEvictArtifactRemoteHonoursRequestedVendor(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs) // this node is amd (newStoreTestServer's vendor)
+	ctx := context.Background()
+
+	files := map[string]string{"imageref": "img", "memfile": "m", "snapfile": "s"}
+	fs.seedArtifact("base/amd/bazel-query/bazel-query__amd", files, 0, "amd", "")
+	fs.seedArtifact("base/intel/bazel-query/bazel-query__intel", files, 0, "intel", "")
+
+	// Evict the INTEL object from this AMD node.
+	if _, err := s.EvictArtifact(ctx, &nodev1.EvictArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_BASE, Workload: "bazel-query", Ref: "bazel-query__intel"},
+		Remote:   true,
+		Vendor:   "intel",
+	}); err != nil {
+		t.Fatalf("EvictArtifact(vendor=intel): %v", err)
+	}
+
+	if fs.has("base/intel/bazel-query/bazel-query__intel") {
+		t.Fatal("the intel object should have been evicted")
+	}
+	if !fs.has("base/amd/bazel-query/bazel-query__amd") {
+		t.Fatal("this node's own amd object must be untouched")
+	}
+}
+
+// TestEvictArtifactRemoteEmptyVendorUsesOwn proves the additive field is
+// backward compatible: an empty vendor still targets the daemon's own prefix, so
+// a control plane that predates the field behaves exactly as before.
+func TestEvictArtifactRemoteEmptyVendorUsesOwn(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+
+	files := map[string]string{"imageref": "img", "memfile": "m", "snapfile": "s"}
+	fs.seedArtifact("base/amd/bazel-query/bazel-query__amd", files, 0, "amd", "")
+
+	if _, err := s.EvictArtifact(context.Background(), &nodev1.EvictArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_BASE, Workload: "bazel-query", Ref: "bazel-query__amd"},
+		Remote:   true,
+	}); err != nil {
+		t.Fatalf("EvictArtifact(no vendor): %v", err)
+	}
+	if fs.has("base/amd/bazel-query/bazel-query__amd") {
+		t.Fatal("an empty vendor should target this node's own prefix")
 	}
 }
 

--- a/projects/embervm/noded/store/store.go
+++ b/projects/embervm/noded/store/store.go
@@ -26,12 +26,15 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -432,6 +435,106 @@ func (s *Store) Reachable(ctx context.Context) bool {
 	// Any answered status means the endpoint is up; the reachability probe does
 	// not judge the bucket's contents, only that the store responds.
 	return true
+}
+
+// listBucketResult is the subset of the S3 ListObjectsV2 XML response this
+// client reads. Only CommonPrefixes matters: every artifact is a set of files
+// under a prefix, so a DELIMITED list one level below <kind>/<vendor>/<workload>
+// enumerates the artifact refs without paging through their individual files.
+type listBucketResult struct {
+	IsTruncated    bool `xml:"IsTruncated"`
+	CommonPrefixes []struct {
+		Prefix string `xml:"Prefix"`
+	} `xml:"CommonPrefixes"`
+}
+
+// ListRefs enumerates the immediate child "directories" under prefix and returns
+// the last path segment of each, i.e. the artifact refs stored under it.
+//
+// This is the REMOTE inventory read behind PR-4 remote base retention. It exists
+// because a superseded base is reclaimed from node disk long before its store
+// object is, so by the time remote retention runs, no node necessarily holds the
+// ref any more and the bucket is the only place that still knows.
+//
+// The S3 delimiter does the work: with delimiter=/ the store returns one
+// CommonPrefix per ref instead of one key per file, so the response size tracks
+// the ref count rather than the file count. limit caps max-keys; truncated
+// reports whether the store had more. A truncated listing is safe for retention
+// because the sweep only deletes BEYOND a keep-set computed from the newest
+// entries, so seeing fewer refs can only evict less, never more.
+func (s *Store) ListRefs(ctx context.Context, prefix string, limit int) (refs []string, truncated bool, err error) {
+	if s == nil {
+		return nil, false, ErrNotPresent
+	}
+	p := strings.TrimLeft(prefix, "/")
+	if !strings.HasSuffix(p, "/") {
+		p += "/"
+	}
+	q := url.Values{}
+	q.Set("list-type", "2")
+	q.Set("prefix", p)
+	q.Set("delimiter", "/")
+	if limit > 0 {
+		q.Set("max-keys", strconv.Itoa(limit))
+	}
+	endpoint := s.endpoint + "/" + s.bucket + "?" + q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("store: build LIST %q: %w", p, err)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, false, fmt.Errorf("store: LIST %q: %w", p, err)
+	}
+	defer drainClose(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		// An empty bucket or absent prefix is "nothing stored", not an error.
+		return nil, false, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, false, fmt.Errorf("store: LIST %q: unexpected status %d", p, resp.StatusCode)
+	}
+
+	var out listBucketResult
+	if derr := xml.NewDecoder(resp.Body).Decode(&out); derr != nil {
+		return nil, false, fmt.Errorf("store: decode LIST %q: %w", p, derr)
+	}
+	for _, cp := range out.CommonPrefixes {
+		ref := strings.Trim(strings.TrimPrefix(cp.Prefix, p), "/")
+		if ref == "" || strings.Contains(ref, "/") {
+			continue
+		}
+		refs = append(refs, ref)
+	}
+	return refs, out.IsTruncated, nil
+}
+
+// ArtifactInfo reports the completeness-marker fields ListArtifacts needs that
+// Present does not surface: the created-at it orders retention on and the summed
+// file size, plus the vendor stamp so a caller can verify an object really
+// belongs to the prefix it was listed under.
+//
+// Returned flat rather than as a Meta so the server package's artifactStore seam
+// can declare it without importing this package (see the seam's own note). Same
+// contract as getMeta: absent marker is (false, ...) with a nil error, so an
+// incomplete artifact reads as not present.
+func (s *Store) ArtifactInfo(ctx context.Context, prefix string) (present bool, createdAtUnixMs int64, sizeBytes uint64, cpuVendor, cpuTemplate string, err error) {
+	if s == nil {
+		return false, 0, 0, "", "", nil
+	}
+	ok, meta, merr := s.getMeta(ctx, prefix)
+	if merr != nil {
+		return false, 0, 0, "", "", merr
+	}
+	if !ok {
+		return false, 0, 0, "", "", nil
+	}
+	var total int64
+	for _, fm := range meta.Files {
+		total += fm.Size
+	}
+	return true, meta.CreatedAtUnixMs, uint64(total), meta.CpuVendor, meta.CpuTemplate, nil
 }
 
 // getMeta fetches and decodes meta.json for a prefix. It returns (false, _, nil)

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -461,6 +461,27 @@ service NodeService {
   // generation a banked bundle needs (standing decision 8). Idempotent on an
   // already-absent artifact (the desired end-state already holds).
   rpc EvictArtifact(EvictArtifactRequest) returns (EvictArtifactResponse);
+
+  // ListArtifacts enumerates the STORE (S3) objects under one kind+vendor+workload
+  // prefix, so the control plane can compute remote retention by count. This is the
+  // remote counterpart to the LOCAL BaseInventoryEntry repeated field on
+  // NodeStatus: that one is the daemon's on-disk truth, this one is the bucket's.
+  //
+  // Answering it requires no local copy, which is the point: a superseded base is
+  // reclaimed locally long before its store object is, so by the time remote
+  // retention runs, NO node necessarily holds the ref any more. The listing is
+  // therefore the only way to see what is still out there.
+  //
+  // Bounded by design: the caller passes a kind+vendor+workload prefix and a limit,
+  // and the response reports whether the listing was truncated rather than paging
+  // forever. A truncated listing is safe for retention because the sweep only ever
+  // DELETES beyond a keep-set it computes from the newest entries; seeing fewer
+  // objects can only make it evict less, never more.
+  //
+  // UNIMPLEMENTED on a daemon that predates this RPC, which the control plane
+  // treats as "no remote inventory known" and skips remote retention for that node
+  // (fail toward keeping bytes).
+  rpc ListArtifacts(ListArtifactsRequest) returns (ListArtifactsResponse);
 }
 
 // Trace carries the cross-cutting identifiers every RPC threads for tracing and
@@ -1743,12 +1764,71 @@ message EvictArtifactRequest {
   ArtifactRef artifact = 1;
   bool remote = 2;
   Trace trace = 3;
+  // vendor selects which vendor-segmented store prefix a remote evict targets
+  // (base/<vendor>/<workload>/<ref>). Additive and remote-only; ignored for
+  // remote=false, and ignored for VOLUME (vendor-portable, no vendor segment).
+  //
+  // Without this a node could only ever compose keys under its OWN detected
+  // vendor, so on a mixed fleet nobody could reclaim another vendor's superseded
+  // bases and the bucket never converged. Note this deliberately breaks the
+  // node-locality that LOCAL eviction keeps: export is per (vendor, ref) and local
+  // eviction is per node, but REMOTE eviction is per (vendor, ref) too, because
+  // the object is shared by every node of that vendor.
+  //
+  // EMPTY means "use the daemon's own vendor", preserving the pre-existing
+  // behaviour for a caller that predates the field.
+  string vendor = 4;
 }
 
 // EvictArtifactResponse reports the outcome. bytes_freed is best-effort (0 when
 // the artifact was already absent).
 message EvictArtifactResponse {
   uint64 bytes_freed = 1;
+}
+
+// ListArtifactsRequest asks for the STORE objects under one kind+vendor+workload
+// prefix. kind and workload are required; vendor is required for a vendor-bound
+// kind and ignored for VOLUME.
+message ListArtifactsRequest {
+  ArtifactKind kind = 1;
+  string workload = 2;
+  // vendor segments the prefix for a vendor-bound kind. Empty means "the daemon's
+  // own vendor", matching EvictArtifactRequest.vendor.
+  string vendor = 3;
+  // limit bounds the number of entries returned. 0 means the daemon's default
+  // cap. The daemon always applies its own hard ceiling regardless.
+  uint32 limit = 4;
+  Trace trace = 5;
+}
+
+// ListArtifactsEntry is one stored artifact under the requested prefix.
+message ListArtifactsEntry {
+  // ref is the artifact ref (the last prefix segment), e.g. the base's
+  // "<workload>__<sig>" key. Empty for a kind whose prefix has no ref segment.
+  string ref = 1;
+  // created_at_unix_ms is the artifact's meta.json CreatedAtUnixMs, which is what
+  // retention-by-count orders on. Always populated: an artifact whose marker is
+  // missing or unreadable is OMITTED from the listing entirely rather than
+  // reported with a zero date, since meta.json is the store's own definition of
+  // "present" and retention must never order on something it cannot describe.
+  int64 created_at_unix_ms = 2;
+  // size_bytes is the summed size of the artifact's files from meta.json,
+  // best-effort (0 when unknown).
+  uint64 size_bytes = 3;
+  // cpu_vendor and cpu_template are the stamp recorded at export time, so the
+  // caller can verify an object really belongs to the vendor it listed under.
+  string cpu_vendor = 4;
+  string cpu_template = 5;
+}
+
+// ListArtifactsResponse returns the entries plus whether the listing hit a cap.
+message ListArtifactsResponse {
+  repeated ListArtifactsEntry entries = 1;
+  // truncated is true when the store held more objects than were returned. The
+  // retention sweep may still act on a truncated listing: it only deletes beyond
+  // a keep-set computed from the NEWEST entries, so a short listing evicts less,
+  // never more.
+  bool truncated = 2;
 }
 
 // CpuSku is a node's full CPU-restore identity (PR-E, ADR embervm/012): the

--- a/projects/embervm/specs/vocabulary.exs
+++ b/projects/embervm/specs/vocabulary.exs
@@ -40,8 +40,11 @@
         ~w(StartStateful StopStateful ResolveStateful DeleteVolume)a ++
         # R5 groups: composite multi-member workloads, out of scope.
         ~w(CreateGroupNetwork DeleteGroupNetwork StartGroupMember StopGroupMember)a ++
-        # R6 continuity: off-node artifact durability, out of scope.
-        ~w(ExportArtifact RestoreArtifact EvictArtifact)a ++
+        # R6 continuity: off-node artifact durability, out of scope. ListArtifacts
+        # is the remote (store) inventory read that remote base retention computes
+        # its keep-set from; like its siblings it is durability plumbing, not VM
+        # lifecycle or adoption.
+        ~w(ExportArtifact RestoreArtifact EvictArtifact ListArtifacts)a ++
         # Artifact-decoupling Phase 2: control-plane -> daemon workload-registry
         # push verbs (SyncRegistry converges the pushed set; Register/Deregister
         # are the incremental forms). They deliver node-side image identity, not


### PR DESCRIPTION
Refs #3947 (gap 1). **PR A of two: this computes and logs, and deletes nothing.** Arming the eviction is a follow-up, deliberately, because the blast radius is the bucket rather than one node's disk.

## Why

Local base retention already reclaims node disk and is **enabled in production** (`EMBERVM_BASE_RETENTION_SWEEP=1`; it reclaimed a real 3.0 GiB earlier today). Nothing reclaims the store.

A superseded base leaves node disk long before its S3 object does, so by the time remote retention runs, **no node necessarily still holds the ref** and the bucket is the only remaining record of it. That is why this needs a remote inventory read rather than reusing the local `BaseInventoryEntry` list.

## proto

- **`ListArtifacts(kind, vendor, workload, limit)`** enumerates the store objects under one prefix: each ref's created-at (what retention orders on), size, and vendor stamp, plus whether the listing was truncated. A truncated listing is still safe to act on, because the sweep only deletes **beyond** a keep-set computed from the newest entries, so a short listing evicts less, never more.
- **`EvictArtifactRequest.vendor`**, additive. Without it a node can compose only its **own** vendor's key, so on a mixed fleet nobody can reclaim the other vendor's superseded bases and the bucket never converges. Empty preserves the previous behaviour, so an older caller is unaffected.

## noded

- `Store.ListRefs` uses a **delimited** S3 list, so the response tracks the ref count rather than the file count. `Store.ArtifactInfo` exposes the created-at and size the listing needs, returned flat so the server's `artifactStore` seam keeps **not** importing the store package (as its own comment requires).
- `ListArtifacts` **omits** an artifact whose completeness marker is unreadable rather than reporting it with a zero date. `meta.json` is the store's own definition of "present", and retention must never order on, or evict, something it cannot describe.
- Remote `EvictArtifact` honours the requested vendor.

## control plane

A **per-(workload, vendor)** sweep, not per node. One store object is shared across a vendor's nodes, so per-node iteration would compute the same candidate set repeatedly and (once armed) issue duplicate deletes.

It reuses the per-vendor view from #4080 and the existing `desired_refs_for_node` keep-set (the CP's current ref plus still-refcounted superseded refs), then logs what it would evict.

A daemon that predates the RPC answers `UNIMPLEMENTED`, treated as "no remote inventory known" and skipped for that (workload, vendor): **fail toward keeping bytes.**

## The asymmetry, now spanning three verbs

This is the part worth reviewing carefully, because assuming any one of these from another gets it wrong:

| verb | keyed by | why |
|---|---|---|
| export | `(vendor, ref)` | object is shared; #4079 |
| **local** evict | **node** | local bytes are node-local |
| **remote** evict | `(vendor, ref)` | object is shared |

Remote eviction deliberately breaks the node-locality local eviction keeps. It is commented at each site.

## Two bugs the tests caught in my own code

Worth noting since both would have been silent:

- I used a `state.channel_fun` that does not exist; base_builder dials via `node_addr` plus `connect_fun`. The test failed with an empty mailbox rather than a compile error, because the call was inside a `try`.
- `retention_sweep_now` bypassed the hook I added to `retention_sweep/1`, so the test drove a different path from the timer. Both now run the same work, which is exactly the two-paths-drift bug #4083 fixed elsewhere.

## Tests

noded: `ListArtifacts` returns refs with meta and does not leak a sibling vendor's or a sibling workload's prefix; an artifact with no marker is omitted; remote evict honours a requested vendor and leaves this node's own object alone; an empty vendor still targets the node's own prefix.

control plane: the sweep consults each vendor exactly once and spares each vendor's current ref; a daemon answering `UNIMPLEMENTED` is skipped without crashing the builder.

`ci test` green: `972 tests, 0 failures, 6 skipped` and `754 tests pass`.

## Deploy

New RPC plus a CP change, so chart bumped to `0.1.257` with `Chart.yaml` and `deploy/application.yaml` moved together.

## Not in this PR

Arming the evict (PR B), plus #4088 (full lifecycle GC) and #4089 (serving base bundles), which were split out of #3947 for having different risk shapes.