### PR TITLE
feat(embervm): record WHY a cold placement found no candidate

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.261
+version: 0.1.263

--- a/projects/embervm/control/lib/embervm/wake_instance.ex
+++ b/projects/embervm/control/lib/embervm/wake_instance.ex
@@ -62,7 +62,15 @@ defmodule Embervm.WakeInstance do
   key degrades gracefully.
   """
 
+  require Logger
+
   alias Embervm.{BrickLedger, NodeCapacity}
+
+  # How often one {workload, node} pair may log a cold-rejection diagnostic. An
+  # autoWake workload whose placement fails retries every ~10s indefinitely
+  # (issue #4077 ran ~900 rejections over 2.5h), so an unthrottled per-brick dump
+  # would bury the event it is meant to expose.
+  @rejection_log_interval_ms 60_000
 
   @typedoc "A warmth-inventory field on a per-instance capacity fact + the id key its rows carry."
   @type warmth_key :: :serving_snapshots | :stateful_bundles | :group_bundle_sets | :session_snapshots
@@ -361,7 +369,11 @@ defmodule Embervm.WakeInstance do
         # eligible at all is this a CAPACITY denial worth a demand signal. The
         # note is an async cast: a missing controller (tests, DS-only fleet)
         # makes it a silent no-op, and the wake outcome is unchanged either way.
-        unless Enum.any?(node_bricks, &Embervm.Placement.eligible?(&1, need_mib)) do
+        capacity_denial? = not Enum.any?(node_bricks, &Embervm.Placement.eligible?(&1, need_mib))
+
+        log_cold_rejection(node_id, workload, need_mib, node_bricks, capacity_denial?)
+
+        if capacity_denial? do
           Embervm.BrickController.note_denial(need_mib)
         end
 
@@ -369,6 +381,84 @@ defmodule Embervm.WakeInstance do
 
       brick ->
         {:ok, dial_id_from_brick(brick)}
+    end
+  end
+
+  # Record WHY a cold pick found nothing, at the moment it happens (issue #4077).
+  #
+  # `:no_eligible_instance` is returned for two unrelated reasons -- no brick had a
+  # free slot / the memory, or every eligible brick was not base-READY -- and from
+  # outside the process they are indistinguishable. #4077 burned hours on exactly
+  # that ambiguity: `/v1/nodes` (NodeRegistry) showed a brick with 6 free slots,
+  # 15698 MiB against a 512 MiB ask, AND the workload's base READY, while placement
+  # (which reads NodeCapacity, a SEPARATE store fed by the same node reports) kept
+  # rejecting it. Nothing in the logs said which half of `pick_ready/3` was false.
+  #
+  # `workload_facts` is the field that discriminates the leading hypothesis:
+  # `BrickLedger.to_brick/1` defaults a missing `:workloads` submap to `%{}`, which
+  # `Placement.base_ready?/2` reads as not-ready (fail-closed, deliberately). So a
+  # fact that LOST its workloads map is indistinguishable from a brick that has
+  # simply not advertised yet -- unless we record whether the map was there at all.
+  # A brick reporting `workload_facts: 0` while NodeRegistry shows bases READY is
+  # the capacity-write-path bug; `base_state` present but not READY is a genuine
+  # provisioning wait and not a bug at all.
+  defp log_cold_rejection(node_id, workload, need_mib, bricks, capacity_denial?) do
+    if throttle_rejection_log?(workload, node_id) do
+      Logger.warning("embervm wake: no cold-placement candidate on node",
+        workload: workload,
+        node_id: node_id,
+        need_mib: need_mib,
+        # true  -> a real capacity wall (this is what feeds the autoscaler)
+        # false -> bricks were eligible but none base-READY (provisioning wait)
+        capacity_denial: capacity_denial?,
+        brick_count: length(bricks),
+        bricks: Enum.map(bricks, &brick_rejection_view(&1, workload, need_mib))
+      )
+    end
+  end
+
+  @doc false
+  # Public only so the tests can assert the discriminator as DATA. Asserting it
+  # through the log would mean ExUnit.CaptureLog inside an async module, which
+  # captures concurrently-running tests' output too and would make these counts
+  # flaky, the exact failure class #4078 just cleaned up.
+  def brick_rejection_view(brick, workload, need_mib) do
+    workloads = Map.get(brick, :workloads) || %{}
+
+    %{
+      instance_id: Map.get(brick, :instance_id, ""),
+      size_class: Map.get(brick, :size_class, ""),
+      free_slots: Map.get(brick, :free_slots, 0),
+      mem_headroom_mib: Map.get(brick, :mem_headroom_mib, 0),
+      mem_budget_mib: Map.get(brick, :mem_budget_mib, 0),
+      eligible: Embervm.Placement.eligible?(brick, need_mib),
+      base_ready: Embervm.Placement.base_ready?(brick, workload),
+      # How many workloads this fact advertises at all. 0 means the submap is
+      # absent or empty, i.e. base_ready is false by the fail-closed default
+      # rather than by anything the daemon actually said about this workload.
+      workload_facts: map_size(workloads),
+      base_state: workloads |> Map.get(workload, %{}) |> Map.get(:base_state)
+    }
+  end
+
+  # At most one diagnostic per {workload, node} per @rejection_log_interval_ms.
+  # Kept in the process dictionary rather than ETS or :persistent_term because the
+  # retry loop for a given workload runs in one long-lived process (StatefulManager),
+  # so a process-local timestamp throttles it without adding a table, an owner, or a
+  # global write. A caller in another process simply gets its own budget, which is
+  # the desired behaviour: each caller reports its own first rejection.
+  @doc false
+  def throttle_rejection_log?(workload, node_id) do
+    key = {__MODULE__, :cold_rejection_logged_at, workload, node_id}
+    now = System.monotonic_time(:millisecond)
+
+    case Process.get(key) do
+      last when is_integer(last) and now - last < @rejection_log_interval_ms ->
+        false
+
+      _ ->
+        Process.put(key, now)
+        true
     end
   end
 

--- a/projects/embervm/control/test/embervm/wake_instance_test.exs
+++ b/projects/embervm/control/test/embervm/wake_instance_test.exs
@@ -354,4 +354,107 @@ defmodule Embervm.WakeInstanceTest do
                )
     end
   end
+
+  describe "cold-rejection diagnostics (#4077)" do
+    # :no_eligible_instance is returned for two unrelated reasons -- no slot/memory,
+    # or eligible bricks that are not base-READY -- and from outside the process they
+    # look identical. #4077 was hours spent guessing exactly that. These assert the
+    # diagnostic says WHICH.
+    #
+    # Asserted as DATA rather than through the emitted log on purpose: CaptureLog in
+    # an async module also captures concurrently-running tests, so counting log lines
+    # here would reintroduce the flake class #4078 just removed.
+
+    defp brick(opts) do
+      %{
+        instance_id: "node-4/pod-a",
+        size_class: Keyword.get(opts, :size_class, "8gi"),
+        free_slots: Keyword.get(opts, :free_slots, 4),
+        mem_headroom_mib: Keyword.get(opts, :mem_headroom_mib, 8_000),
+        mem_budget_mib: Keyword.get(opts, :mem_budget_mib, 8_192),
+        workloads: Keyword.get(opts, :workloads, %{})
+      }
+    end
+
+    test "a brick that advertised ANOTHER workload is a genuine provisioning wait" do
+      view =
+        WakeInstance.brick_rejection_view(
+          brick(workloads: %{"wl-other" => %{base_state: :BASE_BUILD_STATE_READY}}),
+          "wl-a",
+          512
+        )
+
+      # Room to spare, so a scale-up would not help and the autoscaler must not be
+      # told this was a capacity problem.
+      assert view.eligible
+      refute view.base_ready
+      # The submap EXISTS, so base_ready is false because the daemon really has not
+      # advertised wl-a -- not because the fact lost its map.
+      assert view.workload_facts == 1
+      assert view.base_state == nil
+    end
+
+    test "a fact with NO workloads submap is distinguishable from one that advertised" do
+      # The #4077 hypothesis shape: slots and memory fine, workloads absent, so
+      # BrickLedger.to_brick/1's `|| %{}` default makes base_ready false even though
+      # nothing ever said this workload was unready.
+      view = WakeInstance.brick_rejection_view(brick(workloads: %{}), "wl-a", 512)
+
+      assert view.eligible
+      refute view.base_ready
+      assert view.workload_facts == 0
+      assert view.base_state == nil
+    end
+
+    test "an advertised-but-not-READY base reports its actual state" do
+      view =
+        WakeInstance.brick_rejection_view(
+          brick(workloads: %{"wl-a" => %{base_state: :BASE_BUILD_STATE_BUILDING}}),
+          "wl-a",
+          512
+        )
+
+      refute view.base_ready
+      assert view.workload_facts == 1
+      # Present and named, so this is a build in flight, not a lost submap.
+      assert view.base_state == :BASE_BUILD_STATE_BUILDING
+    end
+
+    test "a real capacity wall reports ineligible with the numbers that caused it" do
+      view =
+        WakeInstance.brick_rejection_view(
+          brick(free_slots: 0, workloads: %{"wl-a" => %{base_state: :BASE_BUILD_STATE_READY}}),
+          "wl-a",
+          512
+        )
+
+      refute view.eligible
+      assert view.free_slots == 0
+      # Base was fine; the slot was not. Without both fields this is the ambiguity.
+      assert view.base_ready
+    end
+
+    test "a too-small classed brick reports the headroom that failed the ask" do
+      view = WakeInstance.brick_rejection_view(brick(mem_headroom_mib: 128), "wl-a", 512)
+
+      refute view.eligible
+      assert view.mem_headroom_mib == 128
+      assert view.mem_budget_mib == 8_192
+    end
+
+    test "the throttle allows one diagnostic per {workload, node} per window" do
+      # #4077 retried every ~10s for 2.5h (~900 rejections); unthrottled, the
+      # diagnostic would bury the event it exists to surface.
+      assert WakeInstance.throttle_rejection_log?("wl-a", "node-4")
+      refute WakeInstance.throttle_rejection_log?("wl-a", "node-4")
+      refute WakeInstance.throttle_rejection_log?("wl-a", "node-4")
+    end
+
+    test "the throttle is per workload and per node, so a second wedge is not silenced" do
+      assert WakeInstance.throttle_rejection_log?("wl-a", "node-4")
+      assert WakeInstance.throttle_rejection_log?("wl-b", "node-4")
+      assert WakeInstance.throttle_rejection_log?("wl-a", "node-3")
+      refute WakeInstance.throttle_rejection_log?("wl-a", "node-4")
+    end
+  end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.261
+      targetRevision: 0.1.263
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Instrumentation for the unexplained half of #4077: the CP's own placement rejecting a brick its registry reported as eligible and base-READY, every 10s for 2.5h.

## The ambiguity this removes

`:no_eligible_instance` is returned for two unrelated reasons — no brick had a free slot or the memory, or every eligible brick was not base-READY — and from outside the process they are indistinguishable. During #4077, `/v1/nodes` (NodeRegistry) showed a node-4 brick with 6 free slots and 15698 MiB against a 512 MiB ask, with demo-postgres base READY, while placement (which reads **NodeCapacity**, a separate store fed by the same node reports) kept rejecting it. Nothing logged which half of `pick_ready/3` was false.

The existing `note_denial` guard already branches on exactly that distinction, to avoid feeding the autoscaler a bogus demand signal. It simply never wrote the answer down. That is now reported as `capacity_denial`.

## The field that tests the hypothesis

`base_ready?` is false in two very different situations: the daemon genuinely has not advertised this workload, or the fact lost its `:workloads` submap and `BrickLedger.to_brick/1`'s fail-closed empty-map default made it look unready. `workload_facts` records the submap **size**, separating them.

- `workload_facts: 0` while NodeRegistry shows bases READY → the capacity write path dropped the submap. That is the bug.
- `base_state` present but not READY → a genuine provisioning wait, not a bug at all.

## Throttling

One diagnostic per `{workload, node}` per 60s, in the process dictionary — the retry loop for a workload runs in one long-lived `StatefulManager` process. #4077 produced ~900 rejections; unthrottled, a per-brick dump would bury the event it exists to surface.

## Why two functions are `@doc false` public

The tests assert the diagnostic as **data**, not through the emitted log. `ExUnit.CaptureLog` inside an `async: true` module also captures concurrently-running tests' output, so counting log lines would reintroduce the exact flake class #4085 just removed. Making `brick_rejection_view/3` and `throttle_rejection_log?/2` testable directly seemed the better trade against a test that fails randomly.

## Verification

```
977 tests, 0 failures, 6 skipped
```

970 before, +7 new: submap-present-but-other-workload, submap-absent, advertised-but-building, slot wall, memory wall, and the throttle in both directions. Confirmed the suite genuinely re-executed rather than cache-hit (the earlier count was 970).

## What this does NOT do

It does not fix #4077. The wedge cleared when an unrelated deploy rolled the CP, and the mechanism is still unproven — this is built to confirm or kill the hypothesis the next time it fires, not to assert it.

Refs #4077