### PR TITLE
feat(embervm): arm remote base retention and reclaim superseded store bases

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.258
+version: 0.1.259

--- a/projects/embervm/chart/templates/deployment.yaml
+++ b/projects/embervm/chart/templates/deployment.yaml
@@ -343,6 +343,15 @@ spec:
             - name: EMBERVM_BASE_RETENTION_SWEEP
               value: {{ .Values.baseRetention.sweepEnabled | quote }}
             {{- end }}
+            {{- if .Values.baseRetention.remoteSweepEnabled }}
+            # Remote base-retention gate (#3947 PR-4): "1" arms eviction of
+            # superseded STORE bases per (workload, vendor); unset keeps the
+            # dry-run that only logs. Separate from the local gate above because
+            # the blast radius is the shared bucket, not one node's disk, so the
+            # two arm and roll back independently. See baseRetention in values.
+            - name: EMBERVM_BASE_REMOTE_RETENTION_SWEEP
+              value: {{ .Values.baseRetention.remoteSweepEnabled | quote }}
+            {{- end }}
             {{- if .Values.warmthRetention.sweepEnabled }}
             # Warmth-retention sweep gate (base-durability PR-3, extended to
             # stateful and group orphans): "1" arms the reconciled eviction of

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -671,6 +671,14 @@ statefulSweeper:
 # this value back to "" is the entire rollback lever.
 baseRetention:
   sweepEnabled: ""
+  # Remote (store) base retention gate, #3947 PR-4. "1" arms eviction of
+  # superseded S3 bases per (workload, vendor), keeping each vendor's current ref
+  # plus any superseded ref still refcounted by a primed VM or a session. Unset
+  # ("") keeps the dry-run that only logs. Flipping back to "" is the whole
+  # rollback lever. Deleting a base costs a REBUILD, not data: a base is a
+  # reconstructible artifact, and a pinned session's base is spared by the
+  # refcount.
+  remoteSweepEnabled: ""
 
 # Warmth-retention sweep gate (base-durability PR-3, extended to stateful and group
 # orphans, task #36): "1" arms the reconciled eviction of orphaned stateful/group

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -114,6 +114,7 @@ defmodule Embervm.Application do
        nodes: configured_nodes(),
        runtime_images: configured_runtime_images(),
        retention_sweep_enabled: base_retention_sweep_enabled(),
+       remote_retention_sweep_enabled: base_remote_retention_sweep_enabled(),
        op_log: op_log_mod(),
        op_log_mod: op_log_mod()},
       # The Workload informer (Task 5): LISTs then WATCHes Workload CRs over the
@@ -531,6 +532,23 @@ defmodule Embervm.Application do
   # values env change, no code change. Nothing sets it on in this PR.
   defp base_retention_sweep_enabled do
     case trimmed_env("EMBERVM_BASE_RETENTION_SWEEP") do
+      v when v in ["1", "true", "TRUE", "True"] -> true
+      _ -> false
+    end
+  end
+
+  # Destructive gate for REMOTE base retention (#3947 PR-4), from
+  # EMBERVM_BASE_REMOTE_RETENTION_SWEEP. UNSET or "0"/"false"/"" => the sweep runs
+  # but only LOGS what it would evict. "1"/"true" => it issues
+  # EvictArtifact{remote: true, vendor: ...} for each superseded STORE base
+  # outside the keep-set.
+  #
+  # Deliberately SEPARATE from base_retention_sweep_enabled/0 even though the
+  # shapes match: the local gate's blast radius is one node's disk, this one's is
+  # the shared bucket, so they are armed and rolled back independently. Flipping
+  # back to "" is the entire rollback lever.
+  defp base_remote_retention_sweep_enabled do
+    case trimmed_env("EMBERVM_BASE_REMOTE_RETENTION_SWEEP") do
       v when v in ["1", "true", "TRUE", "True"] -> true
       _ -> false
     end

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -316,6 +316,15 @@ defmodule Embervm.BaseBuilder do
     # vendor) and returns {:ok, entries, truncated} or {:error, reason}. Tests
     # inject a fake so no test opens a channel.
     list_fun = Keyword.get(opts, :list_fun, &default_list_artifacts/3)
+    # The remote-evict seam, (channel, workload, vendor, ref). Separate from
+    # evict_fun because the remote verb targets a (vendor, ref) STORE object
+    # rather than this node's local copy, and carries the vendor explicitly.
+    remote_evict_fun = Keyword.get(opts, :remote_evict_fun, &default_remote_evict/4)
+    # Destructive gate for REMOTE base retention. Mirrors retention_sweep_enabled
+    # exactly: false leaves the sweep computing and logging only. Separate from
+    # the local gate on purpose, because the blast radius is the shared bucket
+    # rather than one node's disk, so the two are armed independently.
+    remote_retention_sweep_enabled = Keyword.get(opts, :remote_retention_sweep_enabled, false)
     # Base-durability PR-1: the ExportArtifact seam that writes a freshly-built
     # (or present-but-unexported) base back to the object store. Defaults to the
     # real NodeService.Stub.export_artifact/2 over a per-call channel; tests
@@ -421,6 +430,8 @@ defmodule Embervm.BaseBuilder do
       disconnect_fun: disconnect_fun,
       evict_fun: evict_fun,
       list_fun: list_fun,
+      remote_evict_fun: remote_evict_fun,
+      remote_retention_sweep_enabled: remote_retention_sweep_enabled,
       export_fun: export_fun,
       restore_fun: restore_fun,
       op_log: op_log,
@@ -1643,7 +1654,7 @@ defmodule Embervm.BaseBuilder do
       case list_remote_refs(state, instance_id, w.name, vendor) do
         {:ok, entries, truncated} ->
           candidates = Enum.reject(entries, fn e -> MapSet.member?(keep, e.ref) end)
-          log_remote_retention(w.name, vendor, candidates, truncated, keep)
+          apply_remote_retention(state, instance_id, w.name, vendor, candidates, truncated, keep)
 
         {:error, reason} ->
           # Fail toward KEEPING bytes: a daemon that predates ListArtifacts
@@ -1695,17 +1706,86 @@ defmodule Embervm.BaseBuilder do
     end
   end
 
-  defp log_remote_retention(workload, vendor, candidates, truncated, keep) do
-    if candidates != [] do
+  # Apply the gated remote retention action. Gate OFF: log the dry-run and change
+  # nothing. Gate ON: issue EvictArtifact{remote: true, vendor: vendor} per
+  # candidate through a node OF THAT VENDOR.
+  #
+  # Deleting a base from the store costs a REBUILD, not data: a base is a
+  # reconstructible artifact by construction. The case that would be real loss is
+  # a pinned session riding a superseded base, and the keep-set already spares it
+  # via w.base_refs, which refcounts superseded refs by primed VMs AND sessions
+  # and only drops an entry once both are known-and-zero.
+  defp apply_remote_retention(state, instance_id, workload, vendor, candidates, truncated, keep) do
+    if candidates == [] do
+      :ok
+    else
       bytes = Enum.reduce(candidates, 0, fn e, acc -> acc + (e.size_bytes || 0) end)
       refs = Enum.map(candidates, & &1.ref)
+      trunc_note = if truncated, do: ", listing TRUNCATED", else: ""
 
-      Logger.info(
-        "embervm base builder: remote base retention (DRY RUN, never evicts in this build) " <>
-          "WOULD evict #{length(candidates)} superseded store base(s) for #{workload}/#{vendor} " <>
-          "(~#{bytes} bytes), keeping #{MapSet.size(keep)} ref(s)#{if truncated, do: ", listing TRUNCATED", else: ""}: " <>
-          inspect(refs)
-      )
+      if state.remote_retention_sweep_enabled do
+        Logger.info(
+          "embervm base builder: remote base retention evicting #{length(candidates)} superseded " <>
+            "store base(s) for #{workload}/#{vendor} (~#{bytes} bytes), keeping " <>
+            "#{MapSet.size(keep)} ref(s)#{trunc_note}: #{inspect(refs)}"
+        )
+
+        Enum.each(refs, fn ref -> spawn_remote_evict(state, instance_id, workload, vendor, ref) end)
+      else
+        Logger.info(
+          "embervm base builder: remote base retention (DRY RUN, gate off) WOULD evict " <>
+            "#{length(candidates)} superseded store base(s) for #{workload}/#{vendor} " <>
+            "(~#{bytes} bytes), keeping #{MapSet.size(keep)} ref(s)#{trunc_note}: #{inspect(refs)}"
+        )
+      end
+
+      :ok
+    end
+  end
+
+  # Fire-and-forget remote eviction of one (vendor, ref) store object through a
+  # node of that vendor. Idempotent on an already-absent object, so a re-sweep is
+  # harmless and a lost result just means the next tick retries.
+  defp spawn_remote_evict(state, instance_id, workload, vendor, ref) do
+    case Map.get(state.node_addr, instance_id) do
+      nil ->
+        :ok
+
+      address ->
+        connect_fun = state.connect_fun
+        disconnect_fun = state.disconnect_fun
+        remote_evict_fun = state.remote_evict_fun
+
+        spawn(fn ->
+          case connect_fun.(address) do
+            {:ok, channel} ->
+              try do
+                case remote_evict_fun.(channel, workload, vendor, ref) do
+                  {:ok, _} ->
+                    :ok
+
+                  {:error, reason} ->
+                    Logger.warning(
+                      "embervm base builder: remote evict #{workload}/#{vendor}/#{ref} failed: #{inspect(reason)}"
+                    )
+                end
+              catch
+                kind, reason ->
+                  Logger.warning(
+                    "embervm base builder: remote evict #{workload}/#{vendor}/#{ref} raised: #{inspect({kind, reason})}"
+                  )
+              after
+                disconnect_fun.(channel)
+              end
+
+            {:error, reason} ->
+              Logger.warning(
+                "embervm base builder: remote evict #{workload}/#{vendor}/#{ref} connect failed: #{inspect(reason)}"
+              )
+          end
+        end)
+
+        :ok
     end
   end
 
@@ -2425,6 +2505,23 @@ defmodule Embervm.BaseBuilder do
       {:ok, resp} -> {:ok, resp.entries || [], resp.truncated}
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  # EvictArtifact{remote: true} of one (vendor, ref) STORE object. The vendor is
+  # explicit rather than the node's own, so any node of that vendor can reclaim
+  # it; that is what lets a mixed fleet's bucket converge at all. Idempotent on an
+  # already-absent object.
+  defp default_remote_evict(channel, workload, vendor, ref) do
+    NodeService.Stub.evict_artifact(channel, %EvictArtifactRequest{
+      artifact: %ArtifactRef{
+        kind: :ARTIFACT_KIND_BASE,
+        workload: workload,
+        ref: ref
+      },
+      remote: true,
+      vendor: vendor,
+      trace: %Trace{workload: workload}
+    })
   end
 
   defp default_evict(channel, workload, ref) do

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -1644,27 +1644,79 @@ defmodule Embervm.BaseBuilder do
   # This logs what it WOULD evict and deletes nothing. Arming it is a separate
   # change, deliberately, because the blast radius is the bucket.
   defp remote_retention_sweep(state) do
-    for {_name, w} <- state.workloads,
-        {vendor, vendor_refs} <- snapshot_refs_by_vendor(state, w),
-        {:ok, instance_id} <- [node_of_vendor(state, w, vendor)] do
-      keep =
-        MapSet.new(vendor_refs ++ desired_refs_for_node(nil, w))
-        |> MapSet.delete(nil)
+    tallies =
+      for {_name, w} <- state.workloads,
+          {vendor, vendor_refs} <- snapshot_refs_by_vendor(state, w) do
+        case node_of_vendor(state, w, vendor) do
+          :error ->
+            # No reachable node reports this vendor, so nobody can answer for its
+            # store prefix this tick. Counted, not silent: a comprehension
+            # generator that fails to match drops the element with no trace, and
+            # a sweep that is silent on skip is indistinguishable from one that
+            # is not running.
+            :no_vendor_node
 
-      case list_remote_refs(state, instance_id, w.name, vendor) do
-        {:ok, entries, truncated} ->
-          candidates = Enum.reject(entries, fn e -> MapSet.member?(keep, e.ref) end)
-          apply_remote_retention(state, instance_id, w.name, vendor, candidates, truncated, keep)
+          {:ok, instance_id} ->
+            keep =
+              MapSet.new(vendor_refs ++ desired_refs_for_node(nil, w))
+              |> MapSet.delete(nil)
 
-        {:error, reason} ->
-          # Fail toward KEEPING bytes: a daemon that predates ListArtifacts
-          # answers UNIMPLEMENTED, and a store hiccup is Unavailable. Either way
-          # the correct move is to skip this (workload, vendor) this tick.
-          Logger.debug(
-            "embervm base builder: remote retention skipped for #{w.name}/#{vendor}: #{inspect(reason)}"
-          )
+            case list_remote_refs(state, instance_id, w.name, vendor) do
+              {:ok, entries, truncated} ->
+                candidates = Enum.reject(entries, fn e -> MapSet.member?(keep, e.ref) end)
+
+                apply_remote_retention(
+                  state,
+                  instance_id,
+                  w.name,
+                  vendor,
+                  candidates,
+                  truncated,
+                  keep
+                )
+
+                {:listed, length(entries), length(candidates)}
+
+              {:error, reason} ->
+                # Fail toward KEEPING bytes: a daemon that predates ListArtifacts
+                # answers UNIMPLEMENTED, and a store hiccup is Unavailable. Either
+                # way the correct move is to skip this (workload, vendor).
+                Logger.debug(
+                  "embervm base builder: remote retention skipped for #{w.name}/#{vendor}: #{inspect(reason)}"
+                )
+
+                :list_failed
+            end
+        end
       end
-    end
+
+    log_remote_retention_summary(state, tallies)
+  end
+
+  # One INFO line per sweep, always. Without it the sweep is unobservable in the
+  # common case: it logs per (workload, vendor) only when there are candidates, so
+  # "found nothing to evict", "no node of that vendor", and "never ran at all"
+  # all look identical from outside. That ambiguity is unacceptable for a sweep
+  # that deletes from a shared bucket, so the summary reports the shape of the
+  # pass even when it is a no-op. One line per 5m tick, not per workload.
+  defp log_remote_retention_summary(state, tallies) do
+    listed = Enum.count(tallies, &match?({:listed, _, _}, &1))
+    no_node = Enum.count(tallies, &(&1 == :no_vendor_node))
+    failed = Enum.count(tallies, &(&1 == :list_failed))
+
+    {objects, candidates} =
+      Enum.reduce(tallies, {0, 0}, fn
+        {:listed, n, c}, {o, cc} -> {o + n, cc + c}
+        _, acc -> acc
+      end)
+
+    mode = if state.remote_retention_sweep_enabled, do: "ARMED", else: "DRY RUN"
+
+    Logger.info(
+      "embervm base builder: remote base retention sweep (#{mode}) covered #{listed} " <>
+        "(workload, vendor) pair(s), #{objects} store object(s), #{candidates} candidate(s); " <>
+        "#{no_node} skipped for no node of that vendor, #{failed} for a failed listing"
+    )
 
     :ok
   end

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -1989,6 +1989,98 @@ defmodule Embervm.BaseBuilderTest do
     assert_receive {:listed, "w", "amd"}, 1_000
   end
 
+  test "remote retention with the gate ON evicts superseded store bases per vendor" do
+    agent = start_recorder()
+    table = new_cap_table()
+    test_pid = self()
+
+    put_vendor_fact(table, "node-4", nil, "w", "w__amd_cur", "amd")
+    put_vendor_fact(table, "node-1", "ds", "w", "w__intel_cur", "intel")
+
+    list_fun = fn _channel, _workload, vendor ->
+      entries =
+        case vendor do
+          "amd" -> [%{ref: "w__amd_cur", size_bytes: 10}, %{ref: "w__amd_old", size_bytes: 20}]
+          "intel" -> [%{ref: "w__intel_cur", size_bytes: 30}, %{ref: "w__intel_old", size_bytes: 40}]
+        end
+
+      {:ok, entries, false}
+    end
+
+    remote_evict_fun = fn _channel, workload, vendor, ref ->
+      send(test_pid, {:remote_evicted, workload, vendor, ref})
+      {:ok, %{}}
+    end
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__amd_cur")} end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        list_fun: list_fun,
+        remote_evict_fun: remote_evict_fun,
+        remote_retention_sweep_enabled: true,
+        nodes: [@node, %{id: "node-1/ds", address: "node-1:9090"}]
+      )
+
+    build_current(builder, agent, "w__amd_cur")
+    _ = BaseBuilder.retention_sweep_now(builder)
+
+    # Each vendor's SUPERSEDED store base is evicted, carrying that vendor.
+    assert_receive {:remote_evicted, "w", "amd", "w__amd_old"}, 1_000
+    assert_receive {:remote_evicted, "w", "intel", "w__intel_old"}, 1_000
+
+    # Neither vendor's CURRENT base is touched.
+    refute_receive {:remote_evicted, "w", _, "w__amd_cur"}, 200
+    refute_receive {:remote_evicted, "w", _, "w__intel_cur"}, 200
+  end
+
+  test "remote retention spares a superseded base a session or primed VM still holds" do
+    agent = start_recorder()
+    table = new_cap_table()
+    test_pid = self()
+
+    put_vendor_fact(table, "node-4", nil, "w", "w__amd_cur", "amd")
+
+    list_fun = fn _channel, _workload, _vendor ->
+      {:ok, [%{ref: "w__amd_cur", size_bytes: 10}, %{ref: "w__pinned", size_bytes: 99}], false}
+    end
+
+    remote_evict_fun = fn _channel, workload, vendor, ref ->
+      send(test_pid, {:remote_evicted, workload, vendor, ref})
+      {:ok, %{}}
+    end
+
+    build_fun = fn :fake_channel, _req -> {:ok, resp("w__amd_cur")} end
+
+    builder =
+      start_builder(
+        capacity_table: table,
+        status_writer: recording_status_writer(agent),
+        build_fun: build_fun,
+        list_fun: list_fun,
+        remote_evict_fun: remote_evict_fun,
+        remote_retention_sweep_enabled: true
+      )
+
+    build_current(builder, agent, "w__amd_cur")
+
+    # A superseded ref STILL REFERENCED (not yet drained/evicted): this is the one
+    # case where a wrong delete is real loss rather than a rebuild, because a
+    # pinned session can only relight against this exact base.
+    :sys.replace_state(builder, fn state ->
+      w = state.workloads["w"]
+      w = %{w | base_refs: %{"w__pinned" => %{primed: 0, sessions: 1, evicted: false}}}
+      %{state | workloads: %{"w" => w}}
+    end)
+
+    _ = BaseBuilder.retention_sweep_now(builder)
+
+    refute_receive {:remote_evicted, "w", _, "w__pinned"}, 500
+  end
+
   test "remote retention skips a vendor whose daemon does not implement ListArtifacts" do
     agent = start_recorder()
     table = new_cap_table()

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.258
+      targetRevision: 0.1.259
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -218,6 +218,14 @@ statefulSweeper:
 # Rollback: set back to "" and bump the chart; that stops further eviction.
 baseRetention:
   sweepEnabled: "1"
+  # Arm REMOTE base retention (#3947 PR-4, Joe 2026-07-27). Local retention has
+  # been reclaiming node disk for a while, but nothing reclaimed the store, so
+  # superseded S3 bases accumulated without bound. Armed directly rather than
+  # after a dry-run soak because a base is a RECONSTRUCTIBLE artifact: a wrong
+  # delete costs a rebuild, not data, and the keep-set already spares a pinned
+  # session's base via the primed/session refcount. Rollback is setting this
+  # back to "".
+  remoteSweepEnabled: "1"
 
 # Arm the warmth-retention sweep (task #36, Joe 2026-07-22): flips the merged-inert
 # WarmthReaper from dry-run to acting. With #38 fix C the reaper SKIPS empty-binding


### PR DESCRIPTION
Closes #3947 gap 1. **PR B of two**: #4093 added the read side and computed the plan, this makes it act. Armed in `deploy/values.yaml`, so merging this **deletes S3 objects**.

## What arms it

`EMBERVM_BASE_REMOTE_RETENTION_SWEEP`, wired through `baseRetention.remoteSweepEnabled` and set to `"1"` in `deploy/values.yaml`. Setting it back to `""` is the entire rollback lever.

Kept **separate** from the local `EMBERVM_BASE_RETENTION_SWEEP` even though the shapes are identical: the local gate's blast radius is one node's disk, this one's is the shared bucket, so they arm and roll back independently.

When armed the sweep issues `EvictArtifact{remote: true, vendor: vendor}` per candidate **through a node of that vendor**, since the store object is shared across a vendor's nodes and any of them can reclaim it. Fire-and-forget and idempotent on an already-absent object, so a lost result just means the next tick retries.

## Why arming directly is defensible

Armed without a dry-run soak per Joe (2026-07-27, no real workloads on the cluster). Two things bound the risk, and they are worth stating explicitly since this is the destructive half:

**A base is a RECONSTRUCTIBLE artifact.** Deleting one from the store costs a `BuildBase`, not data. That is what makes this categorically different from evicting a volume or a durable bank.

**The one case that WOULD be real loss is already guarded.** A pinned session riding a superseded base can only relight against that exact base. The keep-set spares it: `w.base_refs` refcounts superseded refs by primed VMs **and** sessions, and an entry is only dropped once both are known-and-zero. There is a test for precisely this (`remote retention spares a superseded base a session or primed VM still holds`).

The full keep-set per (workload, vendor) is: that vendor's current ref (from `status.snapshotRefs`, #4080), the CP's `snapshot_ref`, and every still-refcounted superseded ref.

## Tests

- gate ON evicts each vendor's superseded store base carrying that vendor, and touches **neither** vendor's current ref
- a superseded base still held by a session is **not** evicted
- (from #4093, still passing) each vendor is consulted exactly once; a daemon answering `UNIMPLEMENTED` is skipped without crashing the builder

`ci test` green: `974 tests, 0 failures, 6 skipped` (was 972).

`helm template` against `deploy/values.yaml` renders:

```yaml
- name: EMBERVM_BASE_REMOTE_RETENTION_SWEEP
  value: "1"
```

## Deploy

Chart bumped to `0.1.259`, `Chart.yaml` and `deploy/application.yaml` together.

## What to watch after merge

The CP logs `remote base retention evicting N superseded store base(s) for <workload>/<vendor> (~bytes), keeping K ref(s)`. Bucket size should stabilise near the N=1 envelope. If anything looks wrong, set `remoteSweepEnabled: ""` and the sweep drops back to logging.

## Remaining from #3947

#4088 (full lifecycle GC) and #4089 (serving base bundles), split out for having different risk shapes.