### PR TITLE
feat(embervm): declare persistence as flags, not a class property (ADR 027)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.267
+version: 0.1.268

--- a/projects/embervm/chart/crds/workload-crd.yaml
+++ b/projects/embervm/chart/crds/workload-crd.yaml
@@ -242,6 +242,83 @@ spec:
                         a mismatch with a status condition); floor is unused for
                         serving, minInstances is the floor concept there.
                       minimum: 1
+                persistence:
+                  type: object
+                  description: >-
+                    What survives a workload instance, declared INDEPENDENTLY of
+                    class (ADR embervm/027). Class bundled a persistence decision
+                    into itself (task never persists, session persists RAM,
+                    stateful owns a volume), which stranded the shape this block
+                    exists to express: disk-backed resume with NO memory
+                    snapshot.
+
+                    The space is the cross product of two orthogonal booleans,
+                    which is why these are flags rather than an enum:
+                    off/off is task today, on/on is session today, on/off is
+                    memory-only, and off/on is the mode that had no class to land
+                    in.
+
+                    ABSENT means "the class default", exactly as today. It is
+                    deliberately not defaulted in the schema: the default depends
+                    on spec.class, which OpenAPI cannot express, so the watcher
+                    applies it and needs to see that the block was omitted (the
+                    same reason session.bankedTtlSeconds carries no default).
+                  properties:
+                    memory:
+                      type: boolean
+                      description: >-
+                        Capture the guest's RAM, so an instance resumes mid-
+                        process. false means cold boot every time, which is the
+                        ONLY way an instance can carry its own per-instance disk:
+                        a restore never re-runs guest-init and never re-reads
+                        boot args, so a restored instance cannot be handed a
+                        device. false also decouples cost from conversation
+                        length, because a memory snapshot pays for every dirty
+                        page on every bank, relight and archive.
+                    filesystem:
+                      type: object
+                      description: >-
+                        The durable filesystem tier. Unlike the memory tier this
+                        pins nothing against GC (ADR embervm/016), which is what
+                        makes it portable across nodes: a memory snapshot is tied
+                        to CPU vendor and base generation and cannot be handed to
+                        an arbitrary node, a filesystem artifact can.
+                      properties:
+                        enabled:
+                          type: boolean
+                          description: Keep a durable filesystem artifact for this lineage.
+                        scope:
+                          type: string
+                          enum:
+                            - solo
+                            - shared
+                          default: solo
+                          description: >-
+                            `solo` is owned by one lineage. `shared` is readable
+                            by other workloads, which is only coherent BECAUSE
+                            the filesystem tier pins nothing; the memory tier
+                            could never offer it without smuggling placement
+                            constraints into a supposedly opaque blob.
+                        retention:
+                          type: integer
+                          description: >-
+                            Keep the latest artifact plus N previous ones. Above
+                            1 costs N times the steady-state storage and N times
+                            the GC bookkeeping (each generation needs its own
+                            liveness check rather than one is-this-latest test),
+                            so it is a declared bounded scalar and never
+                            "keep everything". solo scope only.
+                          minimum: 0
+                          default: 0
+                        sizeGi:
+                          type: integer
+                          description: >-
+                            Size of the sparse volume backing this tier. Sparse,
+                            so an unfilled volume costs only what is written.
+                            Size it for the artifact, not for RAM: this exists
+                            precisely so state does NOT have to fit in memMib.
+                          minimum: 1
+                          default: 8
                 session:
                   type: object
                   description: >-
@@ -251,6 +328,11 @@ spec:
                     OpenAPI schema cannot express class-conditional requiredness).
                     A session is a long-lived logical sandbox banked to a node
                     snapshot when idle and relit on the next invoke.
+
+                    NOTE: idleBankSeconds describes the `persistence.memory: true`
+                    path. Under `memory: false` there is no bank; the same idle
+                    threshold triggers a close (capture the filesystem artifact,
+                    destroy the VM) and the next invoke cold boots.
                   properties:
                     idleBankSeconds:
                       type: integer

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.267
+      targetRevision: 0.1.268
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Step 1 of #4091. Adds `spec.persistence` to the Workload CRD: two orthogonal
booleans, `memory` and `filesystem`, the latter carrying `scope`, `retention` and
`sizeGi`.

**Contract only. No consumer reads it yet, and no existing CR changes behavior.**

## Why flags rather than a fifth class

Class currently bundles a persistence decision into itself: task never persists,
session persists RAM, stateful owns a volume. That strands the shape #4091 needs,
disk-backed resume with **no** memory snapshot. Per ADR 027 the space is the cross
product of two booleans, not four independent modes:

| memory | filesystem | is |
|---|---|---|
| off | off | task today |
| on | on | session today |
| on | off | memory-only |
| off | on | the mode that had no class to land in |

Adding a class per persistence shape is the explosion ADR 013 already rejected for
the size and lane dimensions.

## `memory: false` is an enabler, not a tuning knob

Two independent reasons, both load-bearing for #4091:

- **A restored instance cannot be handed a disk.** A restore never re-runs
  guest-init and never re-reads boot args, so cold boot is the only way an
  instance carries a per-instance device. This is why the disk work waits on this
  flag rather than the other way round.
- **It decouples cost from conversation length.** A memory snapshot pays for every
  dirty page on every bank, relight and archive, and a session transcript reaches
  tens of MiB (measured: 34 MB for one session).

`scope: shared` lives on the filesystem row only, and that is derived rather than
arbitrary: the memory tier is pinned to CPU vendor and base generation (ADR 016),
so it cannot be handed to an arbitrary consumer without smuggling placement
constraints into a supposedly opaque blob. The filesystem tier pins nothing.

## Not defaulted, on purpose

The block carries no schema default. The default depends on `spec.class`, which
OpenAPI cannot express, so the watcher applies it and needs to see that the block
was omitted. That is the same reasoning `session.bankedTtlSeconds` already uses
("the schema leaves it absent so the watcher can see it was omitted"). Absent
therefore means exactly today's behavior for every existing CR.

I also corrected the `session` block's description, which asserted banking
unconditionally; under `memory: false` the same idle threshold triggers a close
rather than a bank.

## Verification

`ci test` green, 754 targets. CRD parses and the chart renders; the CRD grows
54 KB to 59 KB, comfortably under the 256 KiB client-side-apply annotation cap
that has bitten this repo before.

Refs #4091, ADR embervm/027