### PR TITLE
fix(embervm): deliver the claude guest's env from guest-init, not apko

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.263
+version: 0.1.264

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.263
+      targetRevision: 0.1.264
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/guest-init/cmd/main.go
+++ b/projects/embervm/runtimes/claude/guest-init/cmd/main.go
@@ -112,6 +112,22 @@ func setMmdsEnv(logger *slog.Logger) {
 	}
 }
 
+// setDefaultEnv is the ONLY thing that gives this guest its environment.
+//
+// apko's `environment:` block does NOT apply here. It becomes OCI image config,
+// which is manifest metadata, and the base rootfs is produced with `crane export`
+// (the filesystem alone). A raw Firecracker boot then starts init=<this binary>
+// and never reads the OCI config, so anything declared only in apko.yaml is
+// absent at runtime. That is why this map duplicates apko's values rather than
+// deriving from them: apko covers docker/crane execution, this covers every boot
+// that actually happens in the cluster. Adding a variable to apko.yaml alone is
+// therefore a silent no-op, which has already produced one live incident.
+//
+// These are FORCED, not defaulted-if-unset. The kernel hands PID 1 its own HOME
+// (`/`), so an if-unset guard left HOME at `/` and every turn 503'd on
+// `could not lock config file //.gitconfig: Read-only file system`. Nothing
+// legitimately pre-populates this environment, and setMmdsEnv runs AFTER this,
+// so per-boot overrides still win.
 func setDefaultEnv(logger *slog.Logger) {
 	defaults := map[string]string{
 		"PATH":                   "/usr/bin:/bin:/usr/local/bin",
@@ -119,6 +135,18 @@ func setDefaultEnv(logger *slog.Logger) {
 		"PYTHONUNBUFFERED":       "1",
 		"TERM":                   "dumb",
 		"EMBER_CLAUDE_WORKSPACE": "/workspace",
+		// Egress auth (ADR 023 6b). The CLI talks to the API in CLEARTEXT on
+		// purpose: its only route out is the shim's forwarder over a host-local
+		// vsock, which has no network segment on it, so the egress-proxy sidecar
+		// reads the plaintext request, swaps the placeholder below for the real
+		// token, and originates the real TLS to api.anthropic.com:443 itself.
+		//
+		// The placeholder MUST stay byte-identical to egress.secrets[].placeholder
+		// in the embervm chart values: the sidecar substring-matches this exact
+		// string in request headers, and a mismatch surfaces as a 401 from
+		// Anthropic inside a guest, a long way from the typo.
+		"ANTHROPIC_BASE_URL":      "http://api.anthropic.com",
+		"CLAUDE_CODE_OAUTH_TOKEN": "ember-egress-anthropic-oauth-placeholder-0f3a9c1d7b5e2846-not-a-credential",
 		// The shim treats a committer identity as mandatory and fails a spawn
 		// without one, so every turn would 503 on a guest that has none. A
 		// session-class guest is restored from a SHARED pristine snapshot, so
@@ -133,8 +161,11 @@ func setDefaultEnv(logger *slog.Logger) {
 		"EMBER_GIT_USER_EMAIL": "agent@jomcgi.dev",
 	}
 	for key, value := range defaults {
-		if _, set := os.LookupEnv(key); set {
-			continue
+		// Key only, never the value: one of these carries the egress placeholder,
+		// and a log line that prints credential-shaped values is a habit worth not
+		// forming even when today's value is inert.
+		if existing, set := os.LookupEnv(key); set && existing != value {
+			logger.Info("overriding inherited env", "key", key)
 		}
 		if err := os.Setenv(key, value); err != nil {
 			logger.Warn("could not set default env", "key", key, "err", err)

--- a/projects/embervm/runtimes/claude/guest-init/cmd/main_test.go
+++ b/projects/embervm/runtimes/claude/guest-init/cmd/main_test.go
@@ -222,3 +222,30 @@ func TestSeedTrustRecordDoesNotClobber(t *testing.T) {
 		}
 	})
 }
+
+// TestSetDefaultEnvOverridesInherited pins the two things that made every turn
+// 503 in the cluster while CI was green.
+//
+// The kernel hands PID 1 its own HOME (/), and the previous if-unset guard left
+// it there, so git tried to write //.gitconfig on the read-only rootfs. And the
+// egress auth variables lived only in apko.yaml, which is OCI image config that a
+// raw Firecracker boot never reads, so the CLI booted with no base URL and no
+// placeholder to swap.
+func TestSetDefaultEnvOverridesInherited(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	// Exactly what a kernel gives init: a HOME that is wrong for this guest.
+	t.Setenv("HOME", "/")
+
+	setDefaultEnv(logger)
+
+	if got := os.Getenv("HOME"); got != "/home/runtime" {
+		t.Errorf("HOME = %q, want /home/runtime; an inherited HOME must not win", got)
+	}
+	// Only guest-init can deliver these; apko.yaml alone is a silent no-op.
+	if got := os.Getenv("ANTHROPIC_BASE_URL"); got != "http://api.anthropic.com" {
+		t.Errorf("ANTHROPIC_BASE_URL = %q, want the cleartext egress lane", got)
+	}
+	if got := os.Getenv("CLAUDE_CODE_OAUTH_TOKEN"); got == "" {
+		t.Error("CLAUDE_CODE_OAUTH_TOKEN is empty; the sidecar has no placeholder to swap")
+	}
+}


### PR DESCRIPTION
Every turn 503s in the cluster. Found by driving a real session through the
control plane after #4092 made the base build succeed.

```
git config failed for user.name:
  could not lock config file //.gitconfig: Read-only file system
```

`//.gitconfig` is `HOME=/`, which is what the kernel hands PID 1. `setDefaultEnv`
skipped any key already set, so the inherited `/` won and HOME never became
`/home/runtime`.

## The larger thing that error proves

**apko's `environment:` block never reaches a running guest.** It becomes OCI
image config, which is manifest metadata, and the base rootfs is produced with
`crane export`, the filesystem alone. A raw Firecracker boot starts
`init=<guest-init>` and never reads the OCI config.

If apko env applied, HOME would already have been `/home/runtime` and this would
never have failed. `setDefaultEnv` duplicating `HOME`/`PATH`/`TERM` was the
evidence sitting in the file the whole time.

**So the egress credential lane has never worked in-cluster.**
`ANTHROPIC_BASE_URL` and `CLAUDE_CODE_OAUTH_TOKEN` went into `apko.yaml` with
#4082 and have never reached the CLI. I verified that lane end to end against the
live API, but off-cluster, where the env came from my test harness rather than
from the guest, so the harness supplied exactly the thing the guest was missing.
The swap logic was right; the delivery was untested. They move to `setDefaultEnv`,
where they are actually delivered.

## Changes

- `ANTHROPIC_BASE_URL` and `CLAUDE_CODE_OAUTH_TOKEN` move into `setDefaultEnv`.
- Defaults are **forced**, not applied-if-unset. Nothing legitimately
  pre-populates a PID 1 environment except the kernel, whose values are the wrong
  ones, and `setMmdsEnv` still runs afterwards so per-boot overrides keep winning.
- The override log line prints the key only, never the value.
- `apko.yaml` keeps its copies, which are correct for docker/crane execution.
  The duplication is now documented at `setDefaultEnv` as load-bearing, because
  adding a variable to `apko.yaml` alone is a silent no-op.
- Regression test pins both halves: an inherited `HOME=/` must not win, and the
  two egress variables must be present.

## Verification

`ci test` green, 754 targets, guest-init tests genuinely execute (Linux-only).
The turn itself can only be confirmed after deploy; I will drive a session
through the control plane again once the chart publishes.

Refs #4055, #4091