### PR TITLE
fix(embervm): key the base on what shapes it, not on the CR generation

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.259
+version: 0.1.261

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -59,10 +59,18 @@ defmodule Embervm.BaseBuilder do
   in the response and is recorded in `status.snapshotDigest` for auditability.
 
   The daemon's own `BuildBase` idempotency (keyed on the resolved digest plus
-  the `workload_revision` we send, the CR's `generation`) is the correctness
-  backstop: re-driving a build we already made returns the existing snapshot
-  with `already_built: true`, cheaply, so the signature map here is a
-  latency optimization, not a source of truth we must persist across restarts.
+  the `workload_revision` we send, a digest of `signature/1` -- see
+  `base_revision/1`) is the correctness backstop: re-driving a build we already
+  made returns the existing snapshot with `already_built: true`, cheaply, so the
+  signature map here is a latency optimization, not a source of truth we must
+  persist across restarts.
+
+  That token is deliberately NOT the CR's `generation`. noded derives the base
+  cache key from it, so `generation` made every spec edit re-key the base --
+  including edits `signature/1` excludes precisely because they cannot shape the
+  base VM. A `nodeLocalWake` flag flip rebuilt the public demo's base and took it
+  offline for the duration; `base_revision/1` is what keeps the "a cap-only edit
+  never rebuilds" property true at the daemon, not just here.
 
   ## failure, backoff, and the Ready gate
 
@@ -1275,8 +1283,70 @@ defmodule Embervm.BaseBuilder do
     # can be identical, only the sha256 changes, and the no-gap turnover property
     # requires that to rebuild. The runtime is included too, so switching runtime
     # (a different base image) also rebuilds even if the archive is unchanged.
-    zip_sig = if w.zip, do: {w.zip.runtime, w.zip.sha256}, else: nil
-    {w.image_ref, zip_sig, w.vcpus, w.mem_mib, w.guest_port, w.ready_path, w.init_env}
+    # Map.get rather than w.zip: `:zip` is optional on a raw reconcile descriptor
+    # (only the normalized workload map is guaranteed to carry it), and this is now
+    # reachable from base_revision/1 with either shape. Identical for a normalized
+    # map, which always has the key.
+    zip = Map.get(w, :zip)
+    zip_sig = if zip, do: {zip.runtime, zip.sha256}, else: nil
+
+    {Map.get(w, :image_ref), zip_sig, Map.get(w, :vcpus), Map.get(w, :mem_mib),
+     Map.get(w, :guest_port), Map.get(w, :ready_path), Map.get(w, :init_env)}
+  end
+
+  @doc false
+  # The `workload_revision` we send the daemon: a stable digest of `signature/1`,
+  # NOT the CR's `metadata.generation`.
+  #
+  # noded keys a base as `sha256(image_ref, workload_revision, cpu_vendor)`, so
+  # whatever we put here IS the base's cache identity. Sending `generation` made
+  # that identity change on EVERY spec edit, including edits `signature/1`
+  # deliberately excludes because they cannot shape the base VM -- defeating this
+  # module's own "a cap-only edit never rebuilds" property one hop downstream.
+  #
+  # Observed 2026-07-27: adding `nodeLocalWake` to the demo-postgres CR (a flag
+  # that gates an activator on the node and provably cannot touch a guest rootfs)
+  # took generation 86 -> 87, re-keyed the base on every node and every CPU
+  # vendor, and left the PUBLIC demo unwakeable until the rebuild finished. The
+  # proto documents this field as "the control plane's opaque revision token", so
+  # narrowing it is a control-plane-only change: no proto change, no daemon change.
+  #
+  # Built as explicit sorted iodata rather than :erlang.term_to_binary/1 because
+  # this is a persisted cache key: map iteration order is not part of the term's
+  # contract, so an unsorted init_env could hash two different ways for identical
+  # input and cause a spurious rebuild -- the exact failure being fixed.
+  def base_revision(w) do
+    {image_ref, zip_sig, vcpus, mem_mib, guest_port, ready_path, init_env} = signature(w)
+
+    zip_part =
+      case zip_sig do
+        {runtime, sha256} -> [to_string(runtime), "\0", to_string(sha256)]
+        _ -> ["", "\0", ""]
+      end
+
+    env_part =
+      (init_env || %{})
+      |> Enum.sort()
+      |> Enum.map(fn {k, v} -> [to_string(k), "=", to_string(v), "\n"] end)
+
+    :sha256
+    |> :crypto.hash([
+      to_string(image_ref || ""),
+      "\0",
+      zip_part,
+      "\0",
+      to_string(vcpus || 0),
+      "\0",
+      to_string(mem_mib || 0),
+      "\0",
+      to_string(guest_port || 0),
+      "\0",
+      to_string(ready_path || ""),
+      "\0",
+      env_part
+    ])
+    |> Base.encode16(case: :lower)
+    |> binary_part(0, 16)
   end
 
   # A zip workload whose runtime does not resolve to a pinned image ref: unknown
@@ -1411,7 +1481,7 @@ defmodule Embervm.BaseBuilder do
   defp build_request(%{zip: %{} = zip} = w, runtime_images) do
     %BuildBaseRequest{
       trace: %Trace{workload: w.name},
-      workload_revision: to_string(w.generation || 0),
+      workload_revision: base_revision(w),
       guest_port: w.guest_port || 0,
       ready_path: w.ready_path,
       resources: %ResourceSpec{vcpus: w.vcpus || 0, mem_mib: w.mem_mib || 0},
@@ -1437,7 +1507,7 @@ defmodule Embervm.BaseBuilder do
     %BuildBaseRequest{
       trace: %Trace{workload: w.name},
       image_ref: w.image_ref,
-      workload_revision: to_string(w.generation || 0),
+      workload_revision: base_revision(w),
       guest_port: w.guest_port || 0,
       ready_path: w.ready_path,
       resources: %ResourceSpec{vcpus: w.vcpus || 0, mem_mib: w.mem_mib || 0},

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -2168,4 +2168,85 @@ defmodule Embervm.BaseBuilderTest do
 
     assert length(recorded(agent)) == settled
   end
+
+  describe "base_revision/1 (the daemon's base cache key)" do
+    # noded keys a base as sha256(image_ref, workload_revision, cpu_vendor), so this
+    # token IS the base's cache identity. It used to be the CR's metadata.generation,
+    # which changes on ANY spec edit -- so a flag that cannot touch a guest rootfs
+    # re-keyed the base and took the public demo offline for the rebuild (2026-07-27,
+    # nodeLocalWake on demo-postgres, generation 86 -> 87).
+
+    test "a generation bump alone does NOT change the revision" do
+      # The exact shape of the outage: same base inputs, new CR generation.
+      assert BaseBuilder.base_revision(desc(%{generation: 86})) ==
+               BaseBuilder.base_revision(desc(%{generation: 87}))
+    end
+
+    test "fields signature/1 excludes do not change the revision" do
+      # "a cap-only edit never rebuilds" must hold at the DAEMON, not just in the
+      # signature map this module keeps in memory.
+      base = BaseBuilder.base_revision(desc())
+
+      for extra <- [
+            %{generation: 999},
+            %{idle_bank_seconds: 1},
+            %{node_local_wake: true},
+            %{metering_fail_open: true},
+            %{banked_ttl_seconds: 60}
+          ] do
+        assert BaseBuilder.base_revision(desc(extra)) == base,
+               "#{inspect(extra)} must not re-key the base"
+      end
+    end
+
+    test "every field that DOES shape the base changes the revision" do
+      base = BaseBuilder.base_revision(desc())
+
+      for change <- [
+            %{image_ref: "imgB"},
+            %{vcpus: 2},
+            %{mem_mib: 512},
+            %{guest_port: 9090},
+            %{ready_path: "/other/ready"},
+            %{init_env: %{"A" => "1"}}
+          ] do
+        refute BaseBuilder.base_revision(desc(change)) == base,
+               "#{inspect(change)} must re-key the base"
+      end
+    end
+
+    test "init_env hashes independently of map insertion order" do
+      # This is a PERSISTED cache key: map iteration order is not part of the term's
+      # contract, so an unsorted encoding could hash two ways for identical input and
+      # cause exactly the spurious rebuild being fixed here.
+      a = desc(%{init_env: %{"A" => "1", "B" => "2", "C" => "3"}})
+      b = desc(%{init_env: %{"C" => "3", "B" => "2", "A" => "1"}})
+
+      assert BaseBuilder.base_revision(a) == BaseBuilder.base_revision(b)
+    end
+
+    test "a different init_env VALUE still changes the revision" do
+      refute BaseBuilder.base_revision(desc(%{init_env: %{"A" => "1"}})) ==
+               BaseBuilder.base_revision(desc(%{init_env: %{"A" => "2"}}))
+    end
+
+    test "the revision is a stable short hex digest" do
+      rev = BaseBuilder.base_revision(desc())
+      assert byte_size(rev) == 16
+      assert rev =~ ~r/^[0-9a-f]{16}$/
+      # Deterministic across calls: a cache key that moved on its own would rebuild
+      # the base on every reconcile.
+      assert rev == BaseBuilder.base_revision(desc())
+    end
+
+    test "a zip workload keys on its archive sha256, not on generation" do
+      zip_at = fn sha -> desc(%{zip: %{runtime: "python3.12", sha256: sha}}) end
+
+      assert BaseBuilder.base_revision(zip_at.("aaa")) ==
+               BaseBuilder.base_revision(Map.put(zip_at.("aaa"), :generation, 42))
+
+      refute BaseBuilder.base_revision(zip_at.("aaa")) ==
+               BaseBuilder.base_revision(zip_at.("bbb"))
+    end
+  end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.259
+      targetRevision: 0.1.261
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
A public exhibit went offline because a flag that gates a node-local activator changed a base-image cache key. Root cause of the outage window found while validating #4081.

## The mechanism

noded derives a base's cache identity as:

```go
func baseKeyFor(workload, imageRef, revision, vendor string) string {
	sum := sha256.Sum256([]byte(imageRef + "\x00" + revision + "\x00" + vendor))
```

so whatever the CP sends as `workload_revision` **is** the base's identity. It sent:

```elixir
workload_revision: to_string(w.generation || 0),
```

`metadata.generation` increments on **any** spec edit.

Meanwhile `BaseBuilder.signature/1` already names exactly the base-shaping fields — `image_ref`, zip `{runtime, sha256}`, `vcpus`, `mem_mib`, `guest_port`, `ready_path`, `init_env` — with the comment:

> Deliberately excludes concurrency/invocation/retry (they do not change the base VM), so a cap-only edit never rebuilds.

That property held in this module's own memory and was **false one hop downstream**. The CP would correctly decide no rebuild was needed while the daemon, seeing a new key, rebuilt from scratch.

## Evidence

Adding `nodeLocalWake` to the demo-postgres CR (#4081) took generation 86 → 87, re-keyed the base on every node and every CPU vendor, and left the public demo unwakeable until the rebuild finished — `jomcgi.dev/health` 503.

The control: **scratch-postgres carries the identical image digest** (`sha256:cd11367a…`) and its base ref never moved, because its spec did not change. Same image, same vendors, different outcome — isolating `generation` as the variable.

```
snapshotRefs:
  amd:   [demo-postgres__3005844365a3]
  intel: [demo-postgres__21c944ac8918, demo-postgres__e247e530f3ae]   <- two refs = a real rebuild
generation: 87   observedGeneration: 87
only spec writer: argocd-controller @ 23:20:04   (that was #4081)
```

## The change

Send a digest of `signature/1` instead. The proto documents `workload_revision` as *"the control plane's opaque revision token"*, and grep confirms it is used for nothing else, so this needs **no proto change and no daemon change**.

Two details that matter:

- `base_revision/1` builds explicit **sorted** iodata rather than `:erlang.term_to_binary/1`. This is a persisted cache key and map iteration order is not contractual, so an unsorted `init_env` could hash two ways for identical input — reintroducing the exact spurious rebuild being fixed.
- `signature/1` now reads `:zip` via `Map.get`, because that key is **optional** on a raw reconcile descriptor and only guaranteed on the normalized workload map.

## Deployment cost

Landing this causes **one final base rebuild** as keys migrate from generation-based to signature-based. Unavoidable and one-time. After that, a flag-only CR edit stops taking a public exhibit offline.

## Verification

```
981 tests, 0 failures, 6 skipped
```

974 before, +7 new — including the exact failure shape (a generation bump alone must not change the revision), every base-shaping field that *must* still rebuild, and `init_env` hashing independently of insertion order.

Refs #4077