### PR TITLE
fix(embervm): keep the sandbox pool floor below a brick's slot ceiling

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.264
+version: 0.1.267

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -354,10 +354,26 @@ sandboxWorkload:
   invokePath: /invoke
   vcpus: 1
   memMib: 512
-  # Task 14b full side-by-side: floor 4 / cap 16 matches the plan's sizing (and
-  # fc-invoke's pre-halving sandbox cap). See the node-4 memory arithmetic on
-  # noded.resources below.
-  floor: 4
+  # floor MUST stay strictly below the SMALLEST brick's live-VM slot ceiling.
+  #
+  # PoolManager applies floor PER BRICK INSTANCE (`refill_node/2` runs once per
+  # capacity fact and compares this floor against that instance's own
+  # `free_primed_slots`), and a brick's real ceiling is not `noded.maxLiveVMs`:
+  # `budget.SlotCeiling` derives it as `memBudgetMib / 512`, so a 2gi brick
+  # reporting ~1933 MiB advertises just THREE slots. The Task 14b sizing of 4 was
+  # written for the wildcard DaemonSet (16 slots on a 63Gi node-4); the DS is now
+  # retired and bricks are the only capacity, which made 4 unsatisfiable on a
+  # 3-slot brick. An unsatisfiable floor never stops priming, so the pool claimed
+  # 100% of every 2gi brick and a node-pinned stateful wake could never find a
+  # free slot (issue #4077: demo-postgres wedged evicted for 2.5h while both
+  # node-2 bricks sat at 3/3, all six slots primed sandbox VMs). Autoscaling made
+  # it worse, not better: because the floor is per instance, each new brick
+  # arrived wanting its own 4.
+  #
+  # 2 leaves at least one free slot on the smallest brick for real demand. This
+  # is a STOPGAP for the per-instance semantics; once floor is a fleet-wide pool
+  # size it should go back up (issue #4077 follow-up).
+  floor: 2
   cap: 16
   timeoutSeconds: 30
 

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.264
+      targetRevision: 0.1.267
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Stopgap for #4077. The structural fix follows in a second PR.

## What was wrong

`PoolManager` applies `floor` **per brick instance**: `do_refill/1` folds
`refill_node/2` over every capacity fact, and each one compares the catalog's
`floor` against *that instance's* `free_primed_slots`.

A brick's live-VM ceiling is also not `noded.maxLiveVMs` (16). `budget.SlotCeiling`
(`noded/server/budget.go:188`) derives it as `memBudgetMib / minSlotWorkloadMib`
with `minSlotWorkloadMib = 512`. A 2gi brick reports ~1933 MiB, so it advertises
**3 slots**.

`sandboxWorkload.floor` was 4. Four is larger than three, so the floor deficit
never reached zero and the pool primed into every slot of every 2gi brick,
permanently. That is the closed loop in #4077:

1. demo-postgres is evicted, so it holds no slot
2. PoolManager sees free slots on node-2 and primes sandbox VMs into them
3. the wake finds `free_slots == 0` and fails `:no_eligible_instance`
4. back to 1

Nothing in that loop yields, which is why it ran 2.5h rather than self-correcting.
Autoscaling could not break it either: because the floor is per instance, the 2gi
class going 1 -> 4 replicas just added three more bricks that each wanted their
own 4. Supply created its own demand.

The 4 came from Task 14b, sized for the wildcard DaemonSet (16 slots on a 63Gi
node-4). That DaemonSet is retired (`noded.enabled: false`) and bricks are the
only capacity now, so the sizing outlived its premise.

## What this changes

`sandboxWorkload.floor: 4` -> `2`, so the smallest brick always keeps a slot for
real demand, plus a comment recording the rule (floor must stay strictly below
the smallest brick's slot ceiling) and why.

## What this deliberately does not do

- **It does not reclaim the slots already primed.** There is no pool-shrink path:
  `plan_primes` only computes `max(0, floor - have)`, never a negative. This takes
  effect as bricks roll, and the chart bump in this PR rolls them.
- **It does not reserve the slot for the workload that needs it.** A lower floor
  makes starvation unlikely rather than impossible. That is the follow-up.
- **It does not touch `semgrepWorkload.floor`**, also 4. Semgrep's base only builds
  on 16gi bricks, whose ceiling is 16, so its floor is satisfiable where it runs.

## Follow-ups

- The structural fix: make `floor` a fleet-wide pool size rather than per brick
  instance, so adding bricks spreads the primed VMs instead of multiplying them,
  plus inline preemption so a pinned stateful wake can reclaim a speculative
  primed slot. `floor` should go back up when that lands.
- #4101, found while reviewing this: noded advertises the derived slot ceiling but
  admits against the raw configured backstop, so a 2gi brick claims 3 slots and
  will accept 16.

## Verification

`ci lint` clean. `ci test` green (754 tests pass, chart packages at 0.1.267).
No test asserts on the floor value; only comments referenced it.
