### PR TITLE
fix(embervm): put the cold-rejection payload in the message, not metadata

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.278
+version: 0.1.281

--- a/projects/embervm/control/lib/embervm/wake_instance.ex
+++ b/projects/embervm/control/lib/embervm/wake_instance.ex
@@ -404,17 +404,45 @@ defmodule Embervm.WakeInstance do
   # provisioning wait and not a bug at all.
   defp log_cold_rejection(node_id, workload, need_mib, bricks, capacity_denial?) do
     if throttle_rejection_log?(workload, node_id) do
-      Logger.warning("embervm wake: no cold-placement candidate on node",
+      # The payload rides the MESSAGE, not Logger metadata. Embervm.LogFormatter
+      # encodes a fixed @meta_keys whitelist and drops everything else, on purpose,
+      # so an un-encodable term can never crash the formatter -- and its jsonable/1
+      # only accepts binary/integer/float/boolean, so a list of brick maps was never
+      # going to survive. Shipping this as metadata emitted the line with the two
+      # whitelisted keys and silently discarded every field worth reading, which is
+      # exactly what happened the first time this fired in prod.
+      Logger.warning(
+        "embervm wake: no cold-placement candidate on node " <>
+          rejection_summary(need_mib, capacity_denial?, bricks, workload),
         workload: workload,
-        node_id: node_id,
-        need_mib: need_mib,
-        # true  -> a real capacity wall (this is what feeds the autoscaler)
-        # false -> bricks were eligible but none base-READY (provisioning wait)
-        capacity_denial: capacity_denial?,
-        brick_count: length(bricks),
-        bricks: Enum.map(bricks, &brick_rejection_view(&1, workload, need_mib))
+        node_id: node_id
       )
     end
+  end
+
+  # One flat line describing the rejection. `capacity_denial=true` is a real
+  # capacity wall (the only case that feeds the autoscaler); `false` means bricks
+  # were slot/mem-eligible but none base-READY, i.e. a provisioning wait a
+  # scale-up would not help.
+  @doc false
+  def rejection_summary(need_mib, capacity_denial?, bricks, workload) do
+    rendered =
+      case bricks do
+        [] -> "none"
+        _ -> bricks |> Enum.map(&render_brick(&1, workload, need_mib)) |> Enum.join(" ")
+      end
+
+    "need_mib=#{need_mib} capacity_denial=#{capacity_denial?} " <>
+      "brick_count=#{length(bricks)} bricks=[#{rendered}]"
+  end
+
+  defp render_brick(brick, workload, need_mib) do
+    v = brick_rejection_view(brick, workload, need_mib)
+
+    "{id=#{v.instance_id} class=#{v.size_class} free=#{v.free_slots} " <>
+      "hr=#{v.mem_headroom_mib} budget=#{v.mem_budget_mib} eligible=#{v.eligible} " <>
+      "base_ready=#{v.base_ready} workload_facts=#{v.workload_facts} " <>
+      "base_state=#{inspect(v.base_state)}}"
   end
 
   @doc false

--- a/projects/embervm/control/test/embervm/wake_instance_test.exs
+++ b/projects/embervm/control/test/embervm/wake_instance_test.exs
@@ -457,4 +457,77 @@ defmodule Embervm.WakeInstanceTest do
       refute WakeInstance.throttle_rejection_log?("wl-a", "node-4")
     end
   end
+
+  describe "the rejection diagnostic survives the real log formatter (#4077)" do
+    # The regression this pins: the payload originally rode Logger METADATA, and
+    # Embervm.LogFormatter encodes a fixed @meta_keys whitelist and drops the rest
+    # (deliberately -- an un-encodable term must never crash the formatter). In prod
+    # the line emitted with only workload/node_id and every diagnostic field was
+    # silently discarded. Testing brick_rejection_view/3 alone did NOT catch that:
+    # the data was right and never reached a log line.
+
+    defp diag_brick(opts) do
+      %{
+        instance_id: "node-2/pod-a",
+        size_class: Keyword.get(opts, :size_class, "8gi"),
+        free_slots: Keyword.get(opts, :free_slots, 4),
+        mem_headroom_mib: Keyword.get(opts, :mem_headroom_mib, 8_000),
+        mem_budget_mib: 8_192,
+        workloads: Keyword.get(opts, :workloads, %{})
+      }
+    end
+
+    test "the summary carries every field needed to tell the two failures apart" do
+      summary =
+        WakeInstance.rejection_summary(512, false, [diag_brick(free_slots: 4)], "wl-a")
+
+      for field <- ~w(need_mib capacity_denial brick_count eligible base_ready workload_facts) do
+        assert summary =~ field, "summary must carry #{field}"
+      end
+    end
+
+    test "the payload renders through Embervm.LogFormatter, not just into a string" do
+      # End-to-end through the ACTUAL formatter, without ExUnit.CaptureLog (which in
+      # an async module also captures other tests' output).
+      summary = WakeInstance.rejection_summary(512, false, [diag_brick([])], "wl-a")
+
+      line =
+        Embervm.LogFormatter.format(
+          %{
+            level: :warning,
+            msg: {:string, "embervm wake: no cold-placement candidate on node " <> summary},
+            meta: %{workload: "wl-a", node_id: "node-2"}
+          },
+          %{}
+        )
+        |> IO.iodata_to_binary()
+
+      assert line =~ "no cold-placement candidate"
+      # The fields that were dropped when this rode metadata:
+      assert line =~ "capacity_denial=false"
+      assert line =~ "workload_facts=0"
+      assert line =~ "brick_count=1"
+      # And the whitelisted metadata still lands as structured JSON fields.
+      assert line =~ ~s("workload":"wl-a")
+      assert line =~ ~s("node_id":"node-2")
+    end
+
+    test "a capacity wall and a provisioning wait are distinguishable in the line" do
+      wall = WakeInstance.rejection_summary(512, true, [diag_brick(free_slots: 0)], "wl-a")
+      wait = WakeInstance.rejection_summary(512, false, [diag_brick(free_slots: 4)], "wl-a")
+
+      assert wall =~ "capacity_denial=true"
+      assert wall =~ "free=0"
+      assert wait =~ "capacity_denial=false"
+      assert wait =~ "eligible=true"
+    end
+
+    test "an empty brick list renders without crashing the formatter" do
+      # node scoping matching nothing is a real outcome; the diagnostic must still
+      # emit rather than raise inside a log call.
+      summary = WakeInstance.rejection_summary(512, true, [], "wl-a")
+      assert summary =~ "brick_count=0"
+      assert summary =~ "bricks=[none]"
+    end
+  end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.278
+      targetRevision: 0.1.281
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
The #4077 diagnostic fired in production and told us nothing. This makes it actually report.

## What happened

It rode Logger **metadata**, and `Embervm.LogFormatter` encodes a fixed whitelist:

```elixir
@meta_keys [:task_id, :workload, :principal, :node_id, :reason, :attempt, :kind, :mfa, :error]
```

Everything else is dropped on purpose, so an un-encodable term can never crash the formatter, and `jsonable/1` accepts only binary/integer/float/boolean — a list of brick maps was never going to survive.

The line that reached prod:

```
embervm wake: no cold-placement candidate on node
  node_id=node-2  workload=demo-postgres
```

`capacity_denial`, `brick_count` and every per-brick field silently discarded. So the tool built to separate *"real capacity wall"* from *"eligible but no base yet"* couldn't make that call at the one moment it mattered — while demo-postgres was wedged and `jomcgi.dev/health` was 503.

## The fix

The payload now rides the **message string**, which the formatter always emits. The two whitelisted keys stay as structured fields so SigNoz still gets `workload` and `node_id`.

```
embervm wake: no cold-placement candidate on node need_mib=512 capacity_denial=false
brick_count=1 bricks=[{id=node-2/pod-a class=8gi free=4 hr=8000 budget=8192
eligible=true base_ready=false workload_facts=0 base_state=nil}]
```

`workload_facts=0` with `eligible=true` is the #4077 hypothesis confirmed; `base_state` present but not READY would mean a genuine provisioning wait and no bug at all.

## The coverage gap, which is the real lesson

The original tests asserted `brick_rejection_view/3` as **data** and asserted the throttle. Both passed. Neither proved the payload reached a log line.

Worse, that was a *deliberate* choice: I avoided log-based assertions because `ExUnit.CaptureLog` in an async module also captures concurrently-running tests, which would have been flaky. Dodging the flake removed the only test that would have caught this.

There is now a round-trip test through `Embervm.LogFormatter.format/2` itself — the real formatter, called directly, no CaptureLog and no async interference — asserting both that the payload renders and that the whitelisted metadata still lands as JSON fields. It fails if either half regresses.

## Verification

```
992 tests, 0 failures, 6 skipped
```

988 before, +4 new.

Refs #4077