### PR TITLE
fix(embervm): stop BaseBuilder crashing on a retry for an unplaced workload

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.271
+version: 0.1.274

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -1369,16 +1369,32 @@ defmodule Embervm.BaseBuilder do
   # Is a build for this signature already queued or in flight on the node? Avoids
   # enqueuing a duplicate while an identical build is pending.
   defp already_targeting?(state, node_id, name, sig) do
-    n = state.nodes[node_id]
-    building_this = n.building == name and worker_signature(state, node_id) == sig
-    queued = name in n.queue
-    building_this or queued
+    case state.nodes[node_id] do
+      # No live node entry, so there is nothing this workload could already be
+      # targeting: answer false and let the caller fall through to normal
+      # placement. `retry_workload/2` reaches here with `w.node_id`, which is nil
+      # for an unplaced workload (`remove_node_from_state/2` nils it when a node
+      # departs, and a workload that has never placed starts nil), and the old
+      # unguarded `state.nodes[node_id].building` raised KeyError on that, killing
+      # the builder and wiping every snapshot_ref it held (issue #4105).
+      nil ->
+        false
+
+      n ->
+        building_this = n.building == name and worker_signature(state, node_id) == sig
+        queued = name in n.queue
+        building_this or queued
+    end
   end
 
   defp worker_signature(state, node_id) do
-    case state.nodes[node_id].worker do
-      {pid, _ref} -> get_in(state.workers, [pid, :signature])
+    case state.nodes[node_id] do
       nil -> nil
+      n ->
+        case n.worker do
+          {pid, _ref} -> get_in(state.workers, [pid, :signature])
+          nil -> nil
+        end
     end
   end
 

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -502,6 +502,37 @@ defmodule Embervm.BaseBuilderTest do
     assert Agent.get(count, & &1) == 1
   end
 
+  # A retry timer that fires for a workload with no node placement used to kill the
+  # whole builder: `already_targeting?/4` did `state.nodes[node_id].building`, and
+  # `remove_node_from_state/2` nils a workload's node_id when its node goes away, so
+  # the deref raised `KeyError: key :building not found in: nil`. Each crash wiped
+  # every snapshot_ref and built_signature, re-placing and rebuilding the whole fleet
+  # on a ~30s cycle (issue #4105).
+  #
+  # `worker_signature/2` below the fix carries the same guard. It is defensive only:
+  # `remove_node_from_state/2` nils the workload's node_id rather than leaving it
+  # pointing at a departed node, so a stale non-nil node_id is not reachable through
+  # the public API, and there is no separate test for it.
+  test "a retry for a workload whose node went away keeps the builder alive" do
+    build_fun = fn :fake_channel, _req -> {:ok, resp("snap1")} end
+    builder = start_builder(build_fun: build_fun)
+
+    :ok = BaseBuilder.reconcile(builder, desc())
+
+    assert_eventually(fn ->
+      BaseBuilder.status(builder).workloads["w"].snapshot_ref == "snap1"
+    end)
+
+    :ok = BaseBuilder.remove_node(builder, @node.id)
+    send(builder, {:retry, "w"})
+
+    # status/1 is a call, so it cannot be served until the {:retry, "w"} ahead of it
+    # in the mailbox has been handled. That orders the assertion after the crash
+    # would have happened, without a sleep that would make this test racy.
+    assert BaseBuilder.status(builder).workloads["w"].node_id == nil
+    assert Process.alive?(builder)
+  end
+
   # -- forget -----------------------------------------------------------------
 
   test "forgetting a workload mid-queue drops it without building" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.271
+      targetRevision: 0.1.274
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Closes #4105. Found while verifying the fix for #4077.

## The crash

```
GenServer Embervm.BaseBuilder terminating
** (KeyError) key :building not found in: nil
    lib/embervm/base_builder.ex:1373: Embervm.BaseBuilder.already_targeting?/4
    lib/embervm/base_builder.ex:2394: Embervm.BaseBuilder.retry_workload/2
    lib/embervm/base_builder.ex:552: Embervm.BaseBuilder.handle_info/2
Last message: {:retry, "claude-runtime"}
```

`already_targeting?/4` dereferenced the node entry with no nil guard, and
`retry_workload/2` calls it with `w.node_id`. That is nil for an unplaced
workload: `remove_node_from_state/2` nils it when a node departs, and a workload
that has never placed starts nil. `claude-runtime` was in exactly that state in
production, so every retry tick killed the builder, roughly every 30 seconds.

## Why it mattered far more than one workload

Each restart wipes the builder's in-memory `workloads` and `nodes` maps, including
every `snapshot_ref` and `built_signature`. Three consecutive crash dumps show the
fleet being fully re-derived each time:

| crash | nodes known | demo-postgres node_id | demo-postgres snapshot_ref |
|---|---|---|---|
| 1 | node-1, node-2 x2 | node-1 | `demo-postgres__27e2a86568fb` |
| 2 | node-1, node-2, node-3 | node-3 | `demo-postgres__27e2a86568fb` |
| 3 | node-2, node-3 | node-2 | **nil** |

Every base re-placed onto a different node and rebuilt from scratch on a ~30s
cycle. That cascade produced several symptoms that each looked like an independent
bug:

- base builds killed mid-write: `publish base memfile: rename memfile.tmp ->
  memfile: no such file or directory`
- `status.snapshotRef` advertising `demo-postgres__27e2a86568fb`, a ref in NEITHER
  list of its own `status.snapshotRefs`
- **4410** `generation_blessed` ops for demo-postgres over ~26h against only 27
  `stateful_banked`, roughly 170 generations per hour burned by wakes that could
  not succeed
- the blessed-generation relight deadlock filed as #4104, which now looks
  downstream of this rather than independent

## The fix

Return `false` when there is no live node entry: a workload not placed on a node
cannot already have a build queued or in flight on one, so the caller falls through
to normal placement instead of killing the builder. `worker_signature/2` gets the
same guard because it has the identical unguarded shape.

Nothing else changes. Retry/backoff, placement, and the behaviour after
`already_targeting?` returns false are all untouched.

## Test

One regression test: a retry fired for a workload whose node has gone away leaves
the builder alive. It asserts through a `status/1` call rather than a sleep, since
a call cannot be served until the `{:retry, ...}` ahead of it in the mailbox has
been handled, which orders the assertion after the crash would have occurred
without making the test racy.

The generated version had a second test that was byte-identical to the first. I
removed it: `remove_node_from_state/2` nils the workload's node_id rather than
leaving it pointing at a departed node, so a stale non-nil node_id is not reachable
through the public API and the `worker_signature/2` guard is defensive only. That
is recorded in a comment rather than in a duplicate test.

## Production status

The crash loop stopped on its own before this landed: `claude-runtime` eventually
built (`BaseReady BaseBuilt`, real snapshotRef), which cleared the `node_id: nil`
condition. So this is no longer an active incident, but it recurs for any workload
that is unplaced when its retry timer fires, which is why it is still worth
landing.

## Verification

`ci lint` clean. `ci test` green: **989 tests, 0 failures**.
