### PR TITLE
test(embervm): widen the three registry-expiry waits to the 2s norm

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.274
+version: 0.1.275

--- a/projects/embervm/control/test/embervm/node_registry_test.exs
+++ b/projects/embervm/control/test/embervm/node_registry_test.exs
@@ -72,6 +72,11 @@ defmodule Embervm.NodeRegistryTest do
     }
   end
 
+  # `tries` is a poll count at 10ms intervals, so 200 is a 2s budget, not 200ms.
+  # Waits here are bets on scheduler latency rather than properties of the code,
+  # and a budget that is generous costs nothing on the passing path: the poll
+  # returns as soon as the condition holds. Keep new waits at 200 rather than
+  # picking a tighter number that only ever loses on a loaded executor.
   defp eventually(_fun, 0), do: flunk("condition never became true")
 
   defp eventually(fun, tries) do
@@ -670,7 +675,7 @@ defmodule Embervm.NodeRegistryTest do
     # the stream goes dead (advance past down_after with no fresh status).
     advance.(100_000)
     NodeRegistry.tick(reg)
-    eventually(fn -> not Map.has_key?(NodeRegistry.status(reg), "node-4/uid-1") end, 50)
+    eventually(fn -> not Map.has_key?(NodeRegistry.status(reg), "node-4/uid-1") end, 200)
 
     # The instance_id was removed from NodeChannel; the bare node name was never a key,
     # so it never appears in the removal list.
@@ -737,7 +742,7 @@ defmodule Embervm.NodeRegistryTest do
     advance.(100_000)
     :ok = NodeRegistry.register(reg, %{"node" => node, "pod_uid" => "uid-B", "address" => b_addr})
     NodeRegistry.tick(reg)
-    eventually(fn -> not Map.has_key?(NodeRegistry.status(reg), a_id) end, 50)
+    eventually(fn -> not Map.has_key?(NodeRegistry.status(reg), a_id) end, 200)
 
     # A's own key is gone; B's instance_id is untouched; the bare node name still
     # resolves to nothing. A's expiry could not affect B because they never shared a key.
@@ -798,7 +803,7 @@ defmodule Embervm.NodeRegistryTest do
     # Now let the stream go dead too (advance past down_after with no fresh status).
     advance.(100_000)
     NodeRegistry.tick(reg)
-    eventually(fn -> not Map.has_key?(NodeRegistry.status(reg), "node-4/uid-1") end, 50)
+    eventually(fn -> not Map.has_key?(NodeRegistry.status(reg), "node-4/uid-1") end, 200)
     assert NodeRegistry.capacity(table) == []
   end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.274
+      targetRevision: 0.1.275
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Third race of the class closed by 629304b4d. `NodeRegistryTest` reddened #4096, a
CRD-only change with no `.ex`/`.exs` in it, failing on
`node_registry_test.exs:645` with `condition never became true` rather than an
assertion about behaviour.

## What the number actually is

`eventually/2` polls every 10ms, so its second argument is a budget in units of
10ms, not milliseconds. Three waits allowed **500ms**; the other twenty in the
file allow **2s**, including the registration wait in the same test.

All three follow the same shape: advance the clock, `tick`, then poll for a key
to disappear. That is strictly more work than the registration wait they are four
times tighter than, and nothing about the code justified the shorter budget.

Raising it costs nothing on the passing path, since the poll returns as soon as
the condition holds. It only lengthens how long a genuinely failing assertion
waits before flunking.

Budgets in the file after this change: 20 at 200, 2 at 100, none below.

## Chart bump

The test tree lives under `//projects/embervm/control:srcs`, which feeds the
embervm image, so editing `.exs` files moves the image digest. Bumped to 0.1.274.

## Verification

`ci test`: `MIX TEST OK on the executor`, 755 tests pass, with the Elixir suite
actually re-executed rather than served from the action cache.