### PR TITLE
fix(embervm): fence artifact export on generation, not just on content

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.281
+version: 0.1.283

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.281
+      targetRevision: 0.1.283
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/BUILD
+++ b/projects/embervm/noded/server/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//projects/embervm/noded/egress",
         "//projects/embervm/noded/groupclock",
         "//projects/embervm/noded/serving",
+        "//projects/embervm/noded/store",
         "//projects/embervm/noded/substrate",
         "//projects/embervm/noded/volume",
         "//projects/embervm/proto/embervm/node/v1:nodev1",

--- a/projects/embervm/noded/server/store.go
+++ b/projects/embervm/noded/server/store.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -16,6 +17,7 @@ import (
 
 	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
 
+	"github.com/jomcgi/homelab/projects/embervm/noded/store"
 	"github.com/jomcgi/homelab/projects/embervm/noded/substrate"
 )
 
@@ -458,6 +460,22 @@ func (s *Server) ExportArtifact(ctx context.Context, req *nodev1.ExportArtifactR
 	}
 	generation := s.artifactGeneration(ref)
 	moved, skipped, err := s.store.Export(ctx, prefix, localDir, files, generation, time.Now().UnixMilli(), s.cfg.CpuVendor, s.cfg.CpuTemplate)
+	// A refused export is an ANOMALY, not a transport failure: this node holds an
+	// older copy than the store does. Returning Unavailable would make the control
+	// plane retry it on every reconcile forever, so ack it as skipped and say so
+	// loudly. Deliberately NOT marked in s.exported: our bytes are not in the store,
+	// and claiming otherwise would let a retention sweep treat the local copy as
+	// durable. The repeat log every reconcile is the point -- two nodes holding
+	// divergent copies of a singleton volume should not be quiet.
+	if errors.Is(err, store.ErrStaleGeneration) {
+		s.logger.Warn("noded: export REFUSED, store holds a newer generation (divergent copies)",
+			"artifact", prefix,
+			"kind", ref.GetKind().String(),
+			"workload", ref.GetWorkload(),
+			"localGeneration", generation,
+			"err", err)
+		return &nodev1.ExportArtifactResponse{BytesMoved: 0, Skipped: true, Generation: generation}, nil
+	}
 	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "noded: export artifact %q: %v", prefix, err)
 	}
@@ -1044,6 +1062,16 @@ func (s *Server) runExportJob(ctx context.Context, job exportJob) {
 		return
 	}
 	_, skipped, err := s.store.Export(ctx, job.key, localDir, files, generation, time.Now().UnixMilli(), s.cfg.CpuVendor, s.cfg.CpuTemplate)
+	// Not a transport failure and NOT retryable: retrying cannot make our older
+	// copy newer. Only BASE rides this queue today (generation 0, so the fence
+	// cannot fire), but handling it here keeps the log honest if another kind is
+	// ever enqueued, rather than claiming "will retry on reconcile" forever.
+	if errors.Is(err, store.ErrStaleGeneration) {
+		s.logger.Warn("noded: async export REFUSED, store holds a newer generation (divergent copies)",
+			"artifact", job.key, "kind", job.ref.GetKind().String(),
+			"localGeneration", generation, "err", err)
+		return
+	}
 	if err != nil {
 		s.logger.Warn("noded: async export failed (will retry on reconcile)", "artifact", job.key, "err", err)
 		return

--- a/projects/embervm/noded/store/store.go
+++ b/projects/embervm/noded/store/store.go
@@ -57,6 +57,25 @@ const reachableTimeout = 3 * time.Second
 // local state with bad bytes.
 var ErrNotPresent = errors.New("store: artifact not present (no meta.json)")
 
+// ErrStaleGeneration is returned by Export when the store already holds a copy of
+// this artifact at a HIGHER generation than the local one. Exporting anyway would
+// overwrite newer durable state with older bytes.
+//
+// This matters most for VOLUME, which keys as a SINGLETON (volume/<workload>: no
+// ref, no vendor segment), so every node that has ever held the volume writes the
+// SAME object. Observed 2026-07-28 on demo-postgres: node-1 exported
+// generation 5076 while node-2 exported generation 1472 to the same key, minutes
+// apart. Whichever landed last won, so a node carrying a long-stale copy could
+// silently replace the live one -- for a Postgres volume, that is data loss.
+//
+// The generation was already the fence everywhere else: the control plane
+// quarantines a stateful volume whose reported generation runs ahead of the
+// blessed watermark, and meta.json has carried `generation` since the artifact
+// layout was introduced. Export simply never compared it, short-circuiting only
+// on byte-identical content -- which is exactly the case that does NOT arise when
+// two nodes have diverged.
+var ErrStaleGeneration = errors.New("store: refusing export, store holds a newer generation")
+
 // FileMeta is one file's completeness record within an artifact's meta.json:
 // its exact byte size and hex SHA-256, verified on restore so a corrupt or
 // truncated object never overwrites good local bytes.
@@ -258,8 +277,22 @@ func (s *Store) Export(ctx context.Context, prefix, localDir string, files []str
 	// per-file checksums match ours, the artifact is already durable at this
 	// content. HEAD-then-GET the marker; a Head miss (or a mismatch) falls
 	// through to a full re-upload.
-	if present, remoteMeta, merr := s.getMeta(ctx, prefix); merr == nil && present && sameFiles(remoteMeta.Files, meta.Files) {
-		return 0, true, nil
+	if present, remoteMeta, merr := s.getMeta(ctx, prefix); merr == nil && present {
+		if sameFiles(remoteMeta.Files, meta.Files) {
+			return 0, true, nil
+		}
+		// Content DIFFERS. Before this fence that fell straight through to a full
+		// re-upload, so an older copy silently overwrote a newer one on the shared
+		// singleton volume key. Compare the generation the marker already carries.
+		// Strictly-greater only: equal generations still re-upload, which keeps the
+		// repair path for a partially-written or corrupted remote copy at the
+		// current generation, and generation 0 (unknown) can never win against a
+		// known one.
+		if remoteMeta.Generation > generation {
+			return 0, false, fmt.Errorf(
+				"%w: local generation %d, store generation %d",
+				ErrStaleGeneration, generation, remoteMeta.Generation)
+		}
 	}
 
 	for name, fm := range meta.Files {

--- a/projects/embervm/noded/store/store_test.go
+++ b/projects/embervm/noded/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -82,6 +83,14 @@ func (f *fakeObjectStore) has(key string) bool {
 	defer f.mu.Unlock()
 	_, ok := f.objects[key]
 	return ok
+}
+
+// object returns a stored object's bytes, for asserting that a REFUSED export
+// left the newer copy byte-for-byte intact.
+func (f *fakeObjectStore) object(key string) []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.objects[key]
 }
 
 func (f *fakeObjectStore) putOrderCopy() []string {
@@ -400,5 +409,100 @@ func TestReachable(t *testing.T) {
 	var nilStore *Store
 	if nilStore.Reachable(context.Background()) {
 		t.Fatal("a nil (disabled) store is never reachable")
+	}
+}
+
+// TestExportRefusesOlderGenerationOverNewer is the split-brain guard. VOLUME keys
+// as a singleton (volume/<workload>: no ref, no vendor segment), so every node
+// that has ever held the volume writes the SAME object. Observed 2026-07-28 on
+// demo-postgres: node-1 exported generation 5076 and node-2 exported generation
+// 1472 to the same key minutes apart, and whichever landed last won. Before the
+// fence, differing content fell straight through to a full re-upload, so a stale
+// node could silently replace the live volume -- data loss for a Postgres volume.
+func TestExportRefusesOlderGenerationOverNewer(t *testing.T) {
+	s, fake := newTestStore(t)
+	ctx := context.Background()
+	prefix := "volume/demo-postgres"
+
+	newer, newerNames := writeLocalArtifact(t, map[string]string{"vol.img": "live-data-gen-5076"})
+	if _, _, err := s.Export(ctx, prefix, newer, newerNames, 5076, 1, "", ""); err != nil {
+		t.Fatalf("seed Export: %v", err)
+	}
+	putsAfterSeed := len(fake.putOrderCopy())
+
+	// A different node, holding a long-stale copy, exports the same singleton key.
+	stale, staleNames := writeLocalArtifact(t, map[string]string{"vol.img": "stale-data-gen-1472"})
+	moved, skipped, err := s.Export(ctx, prefix, stale, staleNames, 1472, 2, "", "")
+
+	if !errors.Is(err, ErrStaleGeneration) {
+		t.Fatalf("Export err = %v, want ErrStaleGeneration", err)
+	}
+	if moved != 0 || skipped {
+		t.Fatalf("refused Export = (moved=%d, skipped=%v), want (0, false)", moved, skipped)
+	}
+	if got := len(fake.putOrderCopy()); got != putsAfterSeed {
+		t.Fatalf("refused Export issued %d PUTs, want 0 (it must not overwrite)", got-putsAfterSeed)
+	}
+	// The newer bytes are still what the store holds.
+	if got := string(fake.object("/embervm/" + prefix + "/vol.img")); got != "live-data-gen-5076" {
+		t.Fatalf("store content = %q, want the newer copy intact", got)
+	}
+}
+
+// TestExportAllowsNewerGenerationOverOlder is the other half: real progress must
+// still land. The fence is strictly-greater on the REMOTE generation, so a newer
+// local copy overwrites an older store copy exactly as before.
+func TestExportAllowsNewerGenerationOverOlder(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	prefix := "volume/demo-postgres"
+
+	old, oldNames := writeLocalArtifact(t, map[string]string{"vol.img": "old"})
+	if _, _, err := s.Export(ctx, prefix, old, oldNames, 100, 1, "", ""); err != nil {
+		t.Fatalf("seed Export: %v", err)
+	}
+
+	newer, newerNames := writeLocalArtifact(t, map[string]string{"vol.img": "new"})
+	if _, skipped, err := s.Export(ctx, prefix, newer, newerNames, 101, 2, "", ""); err != nil || skipped {
+		t.Fatalf("Export = (skipped=%v, %v), want (false, nil): progress must not be fenced", skipped, err)
+	}
+}
+
+// TestExportAllowsEqualGenerationRepair keeps the repair path open: an equal
+// generation with differing content re-uploads, so a partially-written or
+// corrupted remote copy at the CURRENT generation can be fixed. Only a strictly
+// newer remote generation is refused.
+func TestExportAllowsEqualGenerationRepair(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	prefix := "volume/demo-postgres"
+
+	a, aNames := writeLocalArtifact(t, map[string]string{"vol.img": "corrupt"})
+	if _, _, err := s.Export(ctx, prefix, a, aNames, 42, 1, "", ""); err != nil {
+		t.Fatalf("seed Export: %v", err)
+	}
+
+	b, bNames := writeLocalArtifact(t, map[string]string{"vol.img": "repaired"})
+	if _, skipped, err := s.Export(ctx, prefix, b, bNames, 42, 2, "", ""); err != nil || skipped {
+		t.Fatalf("Export = (skipped=%v, %v), want a repair re-upload", skipped, err)
+	}
+}
+
+// TestExportUnknownGenerationCannotWin: generation 0 means "unknown" (the server's
+// artifactGeneration returns 0 when it cannot resolve one). It must never
+// overwrite a copy with a known, higher generation.
+func TestExportUnknownGenerationCannotWin(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+	prefix := "volume/demo-postgres"
+
+	known, knownNames := writeLocalArtifact(t, map[string]string{"vol.img": "known-good"})
+	if _, _, err := s.Export(ctx, prefix, known, knownNames, 900, 1, "", ""); err != nil {
+		t.Fatalf("seed Export: %v", err)
+	}
+
+	unknown, unknownNames := writeLocalArtifact(t, map[string]string{"vol.img": "unknown-gen"})
+	if _, _, err := s.Export(ctx, prefix, unknown, unknownNames, 0, 2, "", ""); !errors.Is(err, ErrStaleGeneration) {
+		t.Fatalf("Export err = %v, want ErrStaleGeneration for an unknown generation", err)
 	}
 }


### PR DESCRIPTION
Found while checking logs for the demo-postgres relight question. This is a data-loss hazard, not telemetry.

## What the logs showed

Two nodes exporting the **same singleton key** minutes apart, with wildly divergent generations:

```
node-1  exported artifact off node  artifact=volume/demo-postgres  generation=5076
node-2  exported artifact off node  artifact=volume/demo-postgres  generation=1472
```

`VOLUME` keys as a singleton — `volume/<workload>`, no ref, no vendor segment, because volume data is vendor-portable — so **every node that has ever held the volume writes the same object**.

## Why nothing stopped it

`Store.Export`'s only short-circuit was byte-identical content:

```go
if present, remoteMeta, merr := s.getMeta(ctx, prefix); merr == nil && present && sameFiles(remoteMeta.Files, meta.Files) {
    return 0, true, nil
}
// ...otherwise: full re-upload, unconditionally
```

Differing content is precisely the diverged case, and it fell through to an unconditional overwrite. `meta.Generation` was written into the marker but **never compared**. Last writer wins, no ordering — so a node holding generation 1472 could replace generation 5076. For a Postgres volume that is data loss, and it stays invisible until something restores from it.

The generation was already the fence everywhere else: the control plane quarantines a stateful volume whose reported generation runs ahead of the blessed watermark (`update_quarantine`), and `meta.json` has carried `generation` since the artifact layout was introduced. Export simply didn't look at it.

## The fence

A strictly-greater **remote** generation now refuses the upload with `ErrStaleGeneration`. Strictly-greater is deliberate:

- **equal** generation still re-uploads → keeps the repair path open for a partially-written or corrupted remote copy at the current generation;
- **generation 0** ("unknown" — what `artifactGeneration` returns when it cannot resolve one) can never win against a known one.

The caller acks a refusal as `Skipped` rather than `Unavailable`, because retrying cannot make an older copy newer and an error would make the CP re-drive it every reconcile forever. It is deliberately **not** marked in `s.exported`: our bytes aren't in the store, and claiming otherwise would let a retention sweep treat the local copy as durable. The repeat WARN each reconcile is the point — two nodes holding divergent copies of a singleton volume should not be quiet.

## Verification

```
755 tests pass
```

Four new cases: refusal (asserting zero PUTs and that the newer bytes survive byte-for-byte), normal progress still landing, equal-generation repair, and unknown-generation losing to a known one.

## Not in scope

Why demo-postgres's volume exists on multiple nodes at all, and whether the node-2 wake was a relight or a cold boot. This fence stops the divergence causing data loss; it does not explain the divergence. Tracking under #4077.