### PR TITLE
fix(embervm): stop the rootfs GC deleting rootfs files base snapshots hold open

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.285
+version: 0.1.286

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.285
+      targetRevision: 0.1.286
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/registry.go
+++ b/projects/embervm/noded/server/registry.go
@@ -491,12 +491,16 @@ func (b *baseRegistry) register(e baseEntry) {
 		sizeBytes:   e.sizeBytes,
 		readyPath:   e.readyPath,
 		state:       e.state,
+		// Carried, not dropped: a base reconciled from disk as NONE explains WHY in
+		// buildErr (a missing backing rootfs), and that reason is the only thing
+		// distinguishing it from a base that was simply never built.
+		buildErr: e.buildErr,
 	}
 }
 
-// rootfsPaths returns rootfs files referenced by READY bases. Snapshot state
-// stores these paths directly, so GC must preserve them even when the workload
-// registry has moved on to a newer rootfs.
+// rootfsPaths returns rootfs files referenced by bases in ANY state. Snapshot
+// state stores these paths directly, so GC must preserve them even when the
+// workload registry has moved on to a newer rootfs.
 func (b *baseRegistry) rootfsPaths() []string {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/projects/embervm/noded/server/registry.go
+++ b/projects/embervm/noded/server/registry.go
@@ -374,6 +374,7 @@ type baseEntry struct {
 	snapshotRef string
 	workload    string
 	imageDigest string
+	rootfsPath  string
 	sizeBytes   int64
 	readyPath   string
 	state       nodev1.BaseBuildState
@@ -430,7 +431,7 @@ func (b *baseRegistry) readyByWorkload(workload string) (string, bool) {
 // blocking. A READY or FAILED entry is re-driven (a rebuild after failure, or a
 // forced rebuild) - the READY idempotency short-circuit is checked by the caller
 // before beginBuild.
-func (b *baseRegistry) beginBuild(ref, workload, readyPath string) bool {
+func (b *baseRegistry) beginBuild(ref, workload, rootfsPath, readyPath string) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if e, ok := b.bases[ref]; ok && e.state == nodev1.BaseBuildState_BASE_BUILD_STATE_BUILDING {
@@ -439,6 +440,7 @@ func (b *baseRegistry) beginBuild(ref, workload, readyPath string) bool {
 	b.bases[ref] = &baseEntry{
 		snapshotRef: ref,
 		workload:    workload,
+		rootfsPath:  rootfsPath,
 		readyPath:   readyPath,
 		state:       nodev1.BaseBuildState_BASE_BUILD_STATE_BUILDING,
 	}
@@ -446,13 +448,14 @@ func (b *baseRegistry) beginBuild(ref, workload, readyPath string) bool {
 }
 
 // readyBuild records a completed base build.
-func (b *baseRegistry) readyBuild(ref, workload, imageDigest, readyPath string, sizeBytes int64) {
+func (b *baseRegistry) readyBuild(ref, workload, imageDigest, rootfsPath, readyPath string, sizeBytes int64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.bases[ref] = &baseEntry{
 		snapshotRef: ref,
 		workload:    workload,
 		imageDigest: imageDigest,
+		rootfsPath:  rootfsPath,
 		sizeBytes:   sizeBytes,
 		readyPath:   readyPath,
 		state:       nodev1.BaseBuildState_BASE_BUILD_STATE_READY,
@@ -484,10 +487,50 @@ func (b *baseRegistry) register(e baseEntry) {
 		snapshotRef: e.snapshotRef,
 		workload:    e.workload,
 		imageDigest: e.imageDigest,
+		rootfsPath:  e.rootfsPath,
 		sizeBytes:   e.sizeBytes,
 		readyPath:   e.readyPath,
 		state:       e.state,
 	}
+}
+
+// rootfsPaths returns rootfs files referenced by READY bases. Snapshot state
+// stores these paths directly, so GC must preserve them even when the workload
+// registry has moved on to a newer rootfs.
+func (b *baseRegistry) rootfsPaths() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var paths []string
+	for _, e := range b.bases {
+		// Any state, not just READY: a BUILDING base is actively writing against its
+		// rootfs, and sweeping it mid-build is the same corruption by a narrower
+		// window. A base that names a rootfs is holding it open, whatever its state.
+		if e.rootfsPath != "" {
+			paths = append(paths, e.rootfsPath)
+		}
+	}
+	return paths
+}
+
+// unknownRootfsWorkloads names the workloads holding at least one base that does
+// NOT record which rootfs it was built against: every base that predates the
+// rootfsPath field, since it is repopulated from disk with no path to read.
+//
+// Their true keep-set is unknowable, so sweepRootfs declines to sweep those
+// workloads' directories entirely rather than deleting a file that might be the
+// one a base still has open. That trades reclaimed bytes for correctness on
+// exactly the bases that caused the outage, and it drains by itself: each rebuild
+// records a path, so a workload leaves this set for good once its bases turn over.
+func (b *baseRegistry) unknownRootfsWorkloads() map[string]bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	unknown := make(map[string]bool)
+	for _, e := range b.bases {
+		if e.rootfsPath == "" && e.workload != "" {
+			unknown[e.workload] = true
+		}
+	}
+	return unknown
 }
 
 // remove forgets a base entry by snapshot_ref (after its on-disk dir is deleted),

--- a/projects/embervm/noded/server/rootfs_gc.go
+++ b/projects/embervm/noded/server/rootfs_gc.go
@@ -16,12 +16,10 @@ import (
 // ~279 GB, with the registry referencing exactly ONE per workload (semgrep alone
 // held 193 files / 119.7 GB).
 //
-// Why deleting an unreferenced rootfs is safe, and not merely "probably unused":
-// every boot and every snapshot restore resolves its rootfs THROUGH the workload
-// registry (imageForWorkload, getByImageRef). A file no registry entry names is
-// unreachable, not idle. That is the same condition #3992 hit from the other
-// side, where a base whose image was no longer registered failed to export with
-// "not provisioned on this node".
+// The workload registry names the rootfs NEW boots will use. Existing base
+// snapshots are different: their snapshot state embeds absolute paths to the
+// backing rootfs files. GC therefore keeps the union of workload registry refs
+// and rootfs paths recorded by READY bases.
 //
 // Two guards keep that argument honest:
 //
@@ -77,6 +75,9 @@ func (s *Server) sweepRootfs(now time.Time) (removed int, freed int64) {
 		// every rootfs on the node. Fail toward keeping bytes.
 		return 0, 0
 	}
+	for _, path := range s.bases.rootfsPaths() {
+		keep[path] = true
+	}
 
 	// Sweep only the directories the registry itself points into.
 	dirs := make(map[string]bool, len(keep))
@@ -84,7 +85,17 @@ func (s *Server) sweepRootfs(now time.Time) (removed int, freed int64) {
 		dirs[filepath.Dir(ref)] = true
 	}
 
+	// Skip a workload holding any base that does not record its rootfs (every base
+	// predating the field). We cannot compute their keep-set, and deleting on absent
+	// information is exactly what broke the fleet, so those directories are left
+	// whole until their bases turn over. The rootfs layout is one directory per
+	// workload, which is the same assumption filepath.Dir above already relies on.
+	unknown := s.bases.unknownRootfsWorkloads()
+
 	for dir := range dirs {
+		if unknown[filepath.Base(dir)] {
+			continue
+		}
 		ents, err := os.ReadDir(dir)
 		if err != nil {
 			continue

--- a/projects/embervm/noded/server/rootfs_gc_test.go
+++ b/projects/embervm/noded/server/rootfs_gc_test.go
@@ -3,8 +3,11 @@ package server
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
 )
 
 // writeRootfs creates a rootfs file with a given age, mirroring what the
@@ -124,5 +127,142 @@ func TestSweepRootfsOnlyTouchesRegisteredDirectories(t *testing.T) {
 	}
 	if _, err := os.Stat(untouched); err != nil {
 		t.Fatalf("a directory the registry does not reference must not be swept: %v", err)
+	}
+}
+
+// TestSweepRootfsKeepsBaseRootfs proves a base's absolute rootfs reference
+// survives registry turnover. Existing snapshots still need their original
+// rootfs even after new workloads point at a different file.
+func TestSweepRootfsKeepsBaseRootfs(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+	dir := filepath.Join(t.TempDir(), "semgrep")
+	baseRootfs := writeRootfs(t, dir, "rootfs-A.ext4", 48*time.Hour)
+	currentRootfs := writeRootfs(t, dir, "rootfs-B.ext4", 48*time.Hour)
+
+	s.registry.sync([]workloadEntry{{Workload: "semgrep", ImageRef: "img", RootfsRef: currentRootfs}})
+	s.bases.readyBuild("semgrep__base", "semgrep", "img", baseRootfs, "", 0)
+
+	if removed, _ := s.sweepRootfs(time.Now()); removed != 0 {
+		t.Fatalf("removed = %d, want 0 when both rootfs files are referenced", removed)
+	}
+	for _, path := range []string{baseRootfs, currentRootfs} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("referenced rootfs %s must survive: %v", path, err)
+		}
+	}
+}
+
+// TestSweepRootfsRemovesCompletelyOrphanedRootfs proves an old file is
+// reclaimable once the registry has completed an authoritative empty sync.
+// The second registry entry only establishes the directory to scan; it points
+// at a different, absent rootfs and does not reference the orphan.
+func TestSweepRootfsRemovesCompletelyOrphanedRootfs(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+	dir := filepath.Join(t.TempDir(), "semgrep")
+	orphaned := writeRootfs(t, dir, "rootfs-orphaned.ext4", 48*time.Hour)
+
+	s.registry.sync([]workloadEntry{{Workload: "semgrep", ImageRef: "img", RootfsRef: filepath.Join(dir, "rootfs-current.ext4")}})
+
+	if removed, _ := s.sweepRootfs(time.Now()); removed != 1 {
+		t.Fatalf("removed = %d, want 1 for the orphaned rootfs", removed)
+	}
+	if _, err := os.Stat(orphaned); !os.IsNotExist(err) {
+		t.Fatalf("orphaned rootfs should be gone, stat error = %v", err)
+	}
+}
+
+// TestSweepRootfsEmptyRegistryGuard proves an unsynced empty registry is a
+// boot-safety condition, not evidence that every rootfs is disposable.
+func TestSweepRootfsEmptyRegistryGuard(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+	rootfs := writeRootfs(t, filepath.Join(t.TempDir(), "semgrep"), "rootfs.ext4", 48*time.Hour)
+
+	if removed, _ := s.sweepRootfs(time.Now()); removed != 0 {
+		t.Fatalf("removed = %d, want 0 with an unsynced empty registry", removed)
+	}
+	if _, err := os.Stat(rootfs); err != nil {
+		t.Fatalf("rootfs must survive the empty-registry guard: %v", err)
+	}
+}
+
+// TestSweepRootfsMinAgeGuard proves a freshly baked file is spared while its
+// registry update may still be in flight.
+func TestSweepRootfsMinAgeGuard(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+	rootfs := writeRootfs(t, filepath.Join(t.TempDir(), "semgrep"), "rootfs.ext4", time.Minute)
+
+	if removed, _ := s.sweepRootfs(time.Now()); removed != 0 {
+		t.Fatalf("removed = %d, want 0 for a young rootfs", removed)
+	}
+	if _, err := os.Stat(rootfs); err != nil {
+		t.Fatalf("young rootfs must survive the min-age guard: %v", err)
+	}
+}
+
+// TestReconcileBasesCheckRootfsExists proves restart reconciliation reports a base
+// with a lost backing file as NONE, which is the ONLY state the control plane acts
+// on: Embervm.BaseBuilder.node_reports_base_absent?/3 matches NONE and nothing there
+// matches FAILED, so reporting FAILED would leave the base unusable AND unrecovered.
+func TestReconcileBasesCheckRootfsExists(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+	baseKey := "semgrep__missing-rootfs"
+	baseDir := filepath.Join(s.cfg.SnapshotRoot, "bases", baseKey)
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatalf("mkdir base dir: %v", err)
+	}
+	for name, contents := range map[string]string{
+		"snapfile":   "snap",
+		"imageref":   "img",
+		"rootfspath": filepath.Join(t.TempDir(), "does-not-exist.ext4"),
+	} {
+		if err := os.WriteFile(filepath.Join(baseDir, name), []byte(contents), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	s.ReconcileBasesFromDisk()
+	got, ok := s.bases.get(baseKey)
+	if !ok {
+		t.Fatal("missing-rootfs base was not registered")
+	}
+	if got.state != nodev1.BaseBuildState_BASE_BUILD_STATE_NONE {
+		t.Fatalf("base state = %v, want NONE", got.state)
+	}
+	if !(strings.Contains(got.buildErr, "rootfs") &&
+		(strings.Contains(got.buildErr, "missing") || strings.Contains(got.buildErr, "rebuild"))) {
+		t.Fatalf("build error = %q, want rootfs missing/rebuild explanation", got.buildErr)
+	}
+}
+
+// TestReconcileBasesAcceptsExistingRootfs proves a restart adopts a complete
+// base as READY when its persisted backing rootfs is still present.
+func TestReconcileBasesAcceptsExistingRootfs(t *testing.T) {
+	s := newStoreTestServer(t, newFakeStore())
+	baseKey := "semgrep__existing-rootfs"
+	baseDir := filepath.Join(s.cfg.SnapshotRoot, "bases", baseKey)
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatalf("mkdir base dir: %v", err)
+	}
+	rootfs := writeRootfs(t, t.TempDir(), "rootfs.ext4", 0)
+	for name, contents := range map[string]string{
+		"snapfile":   "snap",
+		"imageref":   "img",
+		"rootfspath": rootfs,
+	} {
+		if err := os.WriteFile(filepath.Join(baseDir, name), []byte(contents), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	s.ReconcileBasesFromDisk()
+	got, ok := s.bases.get(baseKey)
+	if !ok {
+		t.Fatal("existing-rootfs base was not registered")
+	}
+	if got.state != nodev1.BaseBuildState_BASE_BUILD_STATE_READY {
+		t.Fatalf("base state = %v, want READY", got.state)
+	}
+	if got.buildErr != "" {
+		t.Fatalf("build error = %q, want empty", got.buildErr)
 	}
 }

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -710,7 +710,7 @@ func (s *Server) driveBuild(ctx context.Context, req *nodev1.BuildBaseRequest, b
 	}
 	// Serialize builds per key. A concurrent duplicate is rejected rather than
 	// double-booting a build guest.
-	if !s.bases.beginBuild(baseKey, workload, readyPath) {
+	if !s.bases.beginBuild(baseKey, workload, img.RootfsPath, readyPath) {
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: base build already in progress for %q", baseKey)
 	}
 	s.signalChange()
@@ -742,13 +742,14 @@ func (s *Server) driveBuild(ctx context.Context, req *nodev1.BuildBaseRequest, b
 		s.signalChange()
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: build base %q: %v", baseKey, err)
 	}
-	s.bases.readyBuild(baseKey, workload, imageDigest, readyPath, sizeBytes)
+	s.bases.readyBuild(baseKey, workload, imageDigest, img.RootfsPath, readyPath, sizeBytes)
 	// Persist the runtime image ref alongside the snapshot so a daemon restart can
 	// restore it (ReconcileBasesFromDisk). The base dir name is <workload>__<sig>
 	// and does NOT encode the runtime image, but a stateful cold boot resolves the
 	// rootfs via base.imageDigest -> cfg.Images, so a base adopted from disk without
 	// it is unbootable. Best-effort: a missing ref file just forces a rebuild.
 	s.writeBaseImageRef(baseKey, imageDigest)
+	s.writeBaseRootfsPath(baseKey, img.RootfsPath)
 
 	// Serving base (R3, D-R3.11.2): additionally persist a cold-boot-readable handler
 	// artifact from the SAME verified archive bytes noded already holds, so a serving
@@ -2494,6 +2495,30 @@ func (s *Server) ReconcileBasesFromDisk() {
 			}
 			continue
 		}
+		// A base whose backing rootfs has been deleted cannot restore: Firecracker
+		// reopens the absolute path baked into the snapshot state, so the failure is
+		// a hard `PUT /snapshot/load` 400 on every attempt, not a degraded boot.
+		//
+		// Report NONE, not FAILED. NONE is the ONLY state the control plane acts on:
+		// `Embervm.BaseBuilder.node_reports_base_absent?/3` matches
+		// `:BASE_BUILD_STATE_NONE` and nothing there matches FAILED, so a FAILED base
+		// would be both unusable AND never recovered.
+		//
+		// An UNRECORDED path (a base built before this field existed) is UNKNOWN, not
+		// missing, so it stays READY: we never invalidate a working base on absent
+		// information. sweepRootfs applies the matching rule from the other side and
+		// declines to sweep that workload's directory at all.
+		rootfsPath := s.readBaseRootfsPath(baseKey)
+		state := nodev1.BaseBuildState_BASE_BUILD_STATE_READY
+		buildErr := ""
+		if rootfsPath != "" {
+			if _, err := os.Stat(rootfsPath); err != nil {
+				state = nodev1.BaseBuildState_BASE_BUILD_STATE_NONE
+				buildErr = fmt.Sprintf("rootfs missing at %q, base cannot restore", rootfsPath)
+				s.logger.Warn("noded: base rootfs missing during reconcile, reporting base absent",
+					"base", baseKey, "rootfs", rootfsPath, "err", err)
+			}
+		}
 		memfile := filepath.Join(root, baseKey, "memfile")
 		var size int64 = fi.Size()
 		if mfi, err := os.Stat(memfile); err == nil {
@@ -2503,9 +2528,11 @@ func (s *Server) ReconcileBasesFromDisk() {
 			snapshotRef: baseKey,
 			workload:    workloadFromBaseKey(baseKey),
 			imageDigest: imageRef,
+			rootfsPath:  rootfsPath,
 			readyPath:   defaultReadyPath,
 			sizeBytes:   size,
-			state:       nodev1.BaseBuildState_BASE_BUILD_STATE_READY,
+			state:       state,
+			buildErr:    buildErr,
 		})
 		n++
 	}
@@ -2551,6 +2578,26 @@ func (s *Server) writeBaseImageRef(baseKey, imageRef string) {
 // file is absent (a base built before persistence, or a partial write).
 func (s *Server) readBaseImageRef(baseKey string) string {
 	b, err := os.ReadFile(filepath.Join(s.cfg.SnapshotRoot, "bases", baseKey, "imageref"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// writeBaseRootfsPath persists the rootfs backing a base snapshot. Snapshot
+// restore reads the absolute path from snapshot state, independently of the
+// current workload registry.
+func (s *Server) writeBaseRootfsPath(baseKey, rootfsPath string) {
+	path := filepath.Join(s.cfg.SnapshotRoot, "bases", baseKey, "rootfspath")
+	if err := os.WriteFile(path, []byte(rootfsPath), 0o644); err != nil {
+		s.logger.Warn("noded: persist base rootfs path", "base", baseKey, "err", err)
+	}
+}
+
+// readBaseRootfsPath reads the rootfs backing a base snapshot, or "" when the
+// metadata is absent.
+func (s *Server) readBaseRootfsPath(baseKey string) string {
+	b, err := os.ReadFile(filepath.Join(s.cfg.SnapshotRoot, "bases", baseKey, "rootfspath"))
 	if err != nil {
 		return ""
 	}

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -427,7 +427,7 @@ func primeSessionVM(t *testing.T, srv *Server, drv *fakeDriver, sessionID, workl
 }
 
 func seedBase(s *Server, snapshotRef, workload string) {
-	s.bases.readyBuild(snapshotRef, workload, "img@sha256:deadbeef", "/shim/ready", 2048)
+	s.bases.readyBuild(snapshotRef, workload, "img@sha256:deadbeef", "", "/shim/ready", 2048)
 }
 
 func contains(ids []string, id string) bool {
@@ -2009,8 +2009,8 @@ func TestStaleRegistryRefusesColdPrimeButServesWarm(t *testing.T) {
 	s.registry.synced = false
 	s.registry.mu.Unlock()
 	// Register a READY base for two workloads so Prime gets past the base checks.
-	s.bases.readyBuild("snap-cold", "wl-cold", "img-a", "/shim/ready", 2048)
-	s.bases.readyBuild("snap-warm", "wl-warm", "img-a", "/shim/ready", 2048)
+	s.bases.readyBuild("snap-cold", "wl-cold", "img-a", "", "/shim/ready", 2048)
+	s.bases.readyBuild("snap-warm", "wl-warm", "img-a", "", "/shim/ready", 2048)
 	// Seed an EXISTING primed VM for wl-warm so it counts as already-warm.
 	s.vms.add(&vmEntry{id: "vm-warm-1", workload: "wl-warm", snapshotRef: "snap-warm", state: vmPrimed})
 

--- a/projects/embervm/noded/server/stateful_test.go
+++ b/projects/embervm/noded/server/stateful_test.go
@@ -290,7 +290,7 @@ func newStatefulTestServer(t *testing.T) (*Server, *fakeServingNet, *fakeStatefu
 	// serving-image inventory: an opaque-L4 guest has no handler artifact), then
 	// cold-boots the runtime rootfs behind base.imageDigest ("img-a" is in cfg
 	// Images above) with no drive-2 handler.
-	s.bases.readyBuild("img-a", "wl-state", "img-a", "/shim/ready", 2048)
+	s.bases.readyBuild("img-a", "wl-state", "img-a", "", "/shim/ready", 2048)
 	return s, fsn, fsd
 }
 

--- a/projects/embervm/noded/server/store_test.go
+++ b/projects/embervm/noded/server/store_test.go
@@ -467,7 +467,7 @@ func TestExportArtifactBaseReportsExported(t *testing.T) {
 	// Provision the runtime image so imageProvisioned(digest) is true (else the
 	// READY base is filtered out of NodeStatus and never reports exported).
 	s.registry.sync([]workloadEntry{{Workload: workload, ImageRef: digest, RootfsRef: "/rootfs/semgrep"}})
-	s.bases.readyBuild(ref, workload, digest, "/shim/ready", 2048)
+	s.bases.readyBuild(ref, workload, digest, "", "/shim/ready", 2048)
 
 	dir := filepath.Join(s.cfg.SnapshotRoot, "bases", ref)
 	writeBundleFiles(t, dir, map[string]string{"imageref": "img", "memfile": "mem", "snapfile": "snap"})
@@ -529,7 +529,7 @@ func TestExportArtifactBaseIsAsyncWhenQueueStarted(t *testing.T) {
 	digest := "img@sha256:cafef00d"
 
 	s.registry.sync([]workloadEntry{{Workload: workload, ImageRef: digest, RootfsRef: "/rootfs/bazel-query"}})
-	s.bases.readyBuild(ref, workload, digest, "/shim/ready", 2048)
+	s.bases.readyBuild(ref, workload, digest, "", "/shim/ready", 2048)
 
 	dir := filepath.Join(s.cfg.SnapshotRoot, "bases", ref)
 	writeBundleFiles(t, dir, map[string]string{"imageref": "img", "memfile": "mem", "snapfile": "snap"})
@@ -603,7 +603,7 @@ func TestExportArtifactBaseSkipsWhenSiblingVendorCopyExists(t *testing.T) {
 	fs.seedArtifact(prefix, sibling, 0, "amd", "")
 
 	s.registry.sync([]workloadEntry{{Workload: workload, ImageRef: digest, RootfsRef: "/rootfs/bazel-query"}})
-	s.bases.readyBuild(ref, workload, digest, "/shim/ready", 2048)
+	s.bases.readyBuild(ref, workload, digest, "", "/shim/ready", 2048)
 
 	dir := filepath.Join(s.cfg.SnapshotRoot, "bases", ref)
 	// Deliberately DIFFERENT bytes from the seeded sibling copy, which is the
@@ -817,7 +817,7 @@ func seedLocalBase(t *testing.T, s *Server, workload, ref string) string {
 	t.Helper()
 	dir := filepath.Join(s.cfg.SnapshotRoot, "bases", ref)
 	writeBundleFiles(t, dir, map[string]string{"imageref": "img", "memfile": "mem", "snapfile": "snap"})
-	s.bases.readyBuild(ref, workload, "img@sha256:seed", "/shim/ready", 2048)
+	s.bases.readyBuild(ref, workload, "img@sha256:seed", "", "/shim/ready", 2048)
 	return dir
 }
 
@@ -898,7 +898,7 @@ func TestEvictBaseLocalRefusesBuilding(t *testing.T) {
 	building := "bazel-query__building"
 	dir := filepath.Join(s.cfg.SnapshotRoot, "bases", building)
 	writeBundleFiles(t, dir, map[string]string{"imageref": "img", "memfile": "mem", "snapfile": "snap"})
-	s.bases.beginBuild(building, "bazel-query", "/shim/ready")
+	s.bases.beginBuild(building, "bazel-query", "", "/shim/ready")
 
 	err := evictBase(s, "bazel-query", building)
 	if status.Code(err) != codes.FailedPrecondition {
@@ -1008,7 +1008,7 @@ func TestLocalBasesStatusSkipsStagingDirectories(t *testing.T) {
 func TestLocalBasesStatusBuildingReportsOnceNotTwice(t *testing.T) {
 	s := newStoreTestServer(t, newFakeStore())
 	ref := "scratch-k8s__building0"
-	s.bases.beginBuild(ref, "scratch-k8s", "/shim/ready")
+	s.bases.beginBuild(ref, "scratch-k8s", "", "/shim/ready")
 	stagingDir := filepath.Join(s.cfg.SnapshotRoot, "bases", ref+".building")
 	if err := os.MkdirAll(stagingDir, 0o700); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Closes #4114. **Live outage fix**: every primed-VM restore on the fleet is failing
and `jomcgi.dev/health` has been 503 since 04:10 UTC.

## The bug

`sweepRootfs` built its keep-set from the workload registry alone:

```go
keep := s.registry.rootfsRefs()   // the CURRENT rootfs per workload, one each
```

on the stated argument that "every boot and every snapshot restore resolves its
rootfs THROUGH the workload registry".

**True for boots, false for snapshot restores.** A Firecracker snapshot serialises
the ABSOLUTE path of its backing block device into the snapshot state, and
`PUT /snapshot/load` reopens that exact path without consulting the registry. So a
base built against `rootfs-A.ext4` needs it for life; the registry advances to
`rootfs-B.ext4`; the GC deletes `rootfs-A.ext4` as unreferenced; every restore of
that base fails:

```
Block: Virtio backend error: Error manipulating the backing file:
No such file or directory (os error 2)
/var/lib/embervm/scratch/embervm-noded/bazel-query/rootfs-2026.07.28.00.4...
```

`rootfsGCMinAge` cannot help: the deleted file is old precisely because it is no
longer current. `baseEntry` recorded no rootfs at all, so the GC structurally could
not compute the real keep-set.

Measured: `primed=0` on all five bricks, `primedFloorSatisfied: false` for every
workload, 108 failed Primes for bazel-query and 107 for sandbox in one 5-minute
window.

## The fix

**Correct the keep-set.** Record the rootfs each base was built against on
`baseEntry`, persist it beside the snapshot so it survives the disk repopulate, and
keep `registry.rootfsRefs()` UNION every base's rootfs. Paths are kept for bases in
ANY state, not just READY: a BUILDING base is actively writing against its rootfs,
and sweeping it is the same corruption through a narrower window.

**Recover the fleet.** Correcting the GC alone leaves every already-broken base
broken, because bases are repopulated from disk and advertised READY without
checking their backing file. On repopulate, stat the recorded rootfs and report the
base `NONE` when it is gone.

`NONE`, specifically: it is the only state the control plane acts on
(`BaseBuilder.node_reports_base_absent?/3` matches `:BASE_BUILD_STATE_NONE`, and
nothing in the control plane matches `FAILED`). Reporting FAILED would leave the
base unusable AND never recovered, which is worse than the status quo while looking
like a fix.

**Unknown is not missing.** A base with no recorded path (every base predating the
field, since they repopulate from disk with no path to read) stays READY, and the GC
declines to sweep that workload's directory at all. Deleting on absent information
is exactly what caused this outage, so the rule is applied from both sides. That set
drains by itself: each rebuild records a path, so a workload leaves it permanently
once its bases turn over.

## Tests

Six, in `rootfs_gc_test.go`:

- a rootfs referenced ONLY by a base snapshot is not swept (the regression test)
- a rootfs referenced by neither registry nor base is still swept (GC still works)
- the empty-registry boot guard still declines to sweep
- the min-age guard still spares a young file
- a base whose backing rootfs is missing is reported NONE
- a base whose backing rootfs exists is still READY

## Verification caveat, please read

`ci lint` is clean. **`ci test` could not run locally**: `bb remote` fails to set up
its git repo (`error: cmd: patch does not apply`, `Action failed: failed to set up
git repo`), diffing against a stale cached base whose patch list includes files this
branch never touched. It reproduced after a rebase onto current main.

Worse, **`ci test` exits 0 when that happens**, so the failure is silent and a green
`ci test` here would have meant nothing. I am relying on this PR's Test check for
real verification rather than claiming local green. Filing the exit-code issue
separately.

## Out of scope, worth its own issue

The sweep only visits directories the registry points into, so it skips
`scratch-k8s-agent` and `scratch-k8s-server` at 131 rootfs files each, i.e. most of
the ~279 GB #4088 set out to reclaim. It freed little and broke what it did touch.
Left alone here to keep the outage fix reviewable.
