### PR TITLE
fix(embervm): quarantine unblessed volumes from export (ADR 011)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.291
+version: 0.1.293

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.291
+      targetRevision: 0.1.293
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/store.go
+++ b/projects/embervm/noded/server/store.go
@@ -445,6 +445,33 @@ func (s *Server) ExportArtifact(ctx context.Context, req *nodev1.ExportArtifactR
 	if localDir == "" {
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: artifact kind %s not exportable on this node", ref.GetKind())
 	}
+	// ADR embervm/011: "an artifact whose generation was never blessed is
+	// quarantined, never exported." That invariant was declared but never
+	// implemented on this path, so an UNBLESSED writer could publish over the
+	// blessed copy of a volume.
+	//
+	// It matters because VOLUME keys as a SINGLETON (volume/<workload>: no ref, no
+	// vendor segment, since volume data is vendor-portable), so every node that has
+	// ever held the volume writes the SAME object. The generation fence added
+	// alongside this refuses an OLDER generation, which is the obvious regression.
+	// This refuses the subtle one: a node that self-bumped its ledger past the
+	// blessed watermark carries a HIGHER generation and would win that fence while
+	// holding state the control plane never blessed. GenerationBlessed is exactly
+	// the divergence StatefulStore.update_quarantine guards CP-side.
+	//
+	// Local-only check: the blessed marker is already on this node's disk
+	// (volume.Manager's genblessed file, written by RecordBlessed from the
+	// CP-issued blessed_generation), so this needs no proto change and no control
+	// plane round trip, and it holds during a CP gap when there is nobody to ask.
+	if ref.GetKind() == nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME && s.volumes != nil {
+		if !s.volumes.GenerationBlessed(ref.GetWorkload()) {
+			s.logger.Warn("noded: export REFUSED, volume generation is not blessed (ADR 011)",
+				"artifact", prefix,
+				"workload", ref.GetWorkload(),
+				"localGeneration", s.artifactGeneration(ref))
+			return &nodev1.ExportArtifactResponse{BytesMoved: 0, Skipped: true, Generation: 0}, nil
+		}
+	}
 	files, err := enumerateArtifactFiles(localDir)
 	if err != nil || len(files) == 0 {
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: local artifact %q absent or empty (nothing to export)", prefix)

--- a/projects/embervm/noded/server/store_test.go
+++ b/projects/embervm/noded/server/store_test.go
@@ -1305,10 +1305,12 @@ func TestVolumeExportSkipsUnchangedGeneration(t *testing.T) {
 	if err := s.volumes.Create("scratch-postgres", 1<<20); err != nil {
 		t.Fatalf("create volume: %v", err)
 	}
-	for i := 0; i < 5; i++ {
-		if _, err := s.volumes.BumpGeneration("scratch-postgres"); err != nil {
-			t.Fatalf("bump: %v", err)
-		}
+	// RecordBlessed, not BumpGeneration: a self-bump leaves the volume UNBLESSED,
+	// which ADR embervm/011 quarantines from export ("an artifact whose generation
+	// was never blessed is quarantined, never exported"). This test is about the
+	// same-generation export short-circuit, so it needs a realistic blessed volume.
+	if _, err := s.volumes.RecordBlessed("scratch-postgres", 5); err != nil {
+		t.Fatalf("bless: %v", err)
 	}
 	volRef := &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: "scratch-postgres"}
 
@@ -1354,8 +1356,10 @@ func TestRestoreArtifactRoundTrip(t *testing.T) {
 	if err := s.volumes.Create("scratch-postgres", 1<<20); err != nil {
 		t.Fatalf("create volume: %v", err)
 	}
-	if _, err := s.volumes.BumpGeneration("scratch-postgres"); err != nil {
-		t.Fatalf("bump: %v", err)
+	// Blessed, not self-bumped: ADR embervm/011 quarantines an unblessed volume
+	// from export, so a round-trip fixture must model a CP-blessed attach.
+	if _, err := s.volumes.RecordBlessed("scratch-postgres", 1); err != nil {
+		t.Fatalf("bless: %v", err)
 	}
 	if _, err := s.ExportArtifact(ctx, &nodev1.ExportArtifactRequest{
 		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: "scratch-postgres"},
@@ -1772,5 +1776,79 @@ func TestEnqueueIfMissingLegacyAliasGatedToAMDNode(t *testing.T) {
 	// The unrelated legacy (AMD) artifact must be untouched by this node's export.
 	if got, _, err := fs.Restore(ctx, legacyPrefix, t.TempDir()); err != nil || got == 0 {
 		t.Fatalf("legacy artifact should be untouched, restore err=%v bytes=%d", err, got)
+	}
+}
+
+// TestExportArtifactVolumeRefusedWhenUnblessed implements ADR embervm/011's
+// declared invariant: "an artifact whose generation was never blessed is
+// quarantined, never exported."
+//
+// VOLUME keys as a SINGLETON (volume/<workload>: no ref, no vendor segment,
+// because volume data is vendor-portable), so every node that has ever held the
+// volume writes the SAME object. The generation fence refuses an OLDER
+// generation; this refuses the subtle case it cannot see. A node that self-bumped
+// its ledger past the blessed watermark carries a HIGHER generation, so it would
+// WIN the generation fence while holding state the control plane never blessed.
+func TestExportArtifactVolumeRefusedWhenUnblessed(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx := context.Background()
+
+	// A self-bumped ledger: generation advances, the blessed marker never does.
+	if err := s.volumes.Create("demo-postgres", 1); err != nil {
+		t.Fatalf("Create volume: %v", err)
+	}
+	if _, err := s.volumes.BumpGeneration("demo-postgres"); err != nil {
+		t.Fatalf("BumpGeneration: %v", err)
+	}
+	if s.volumes.GenerationBlessed("demo-postgres") {
+		t.Fatal("precondition: a self-bumped generation must not read as blessed")
+	}
+
+	resp, err := s.ExportArtifact(ctx, &nodev1.ExportArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: "demo-postgres"},
+	})
+	if err != nil {
+		t.Fatalf("ExportArtifact should ack a refusal, not error: %v", err)
+	}
+	if !resp.GetSkipped() || resp.GetBytesMoved() != 0 {
+		t.Fatalf("refused export = (skipped=%v, moved=%d), want (true, 0)", resp.GetSkipped(), resp.GetBytesMoved())
+	}
+	if fs.has("volume/demo-postgres") {
+		t.Fatal("an unblessed volume must NOT reach the store")
+	}
+}
+
+// TestExportArtifactVolumeAllowedWhenBlessed is the other half: a CP-blessed
+// generation exports normally. Without this the gate could pass by refusing
+// everything.
+func TestExportArtifactVolumeAllowedWhenBlessed(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx := context.Background()
+
+	if err := s.volumes.Create("demo-postgres", 1); err != nil {
+		t.Fatalf("Create volume: %v", err)
+	}
+	// RecordBlessed writes BOTH the ledger and the blessed marker, which is what a
+	// CP-issued blessed_generation does via attachGeneration.
+	if _, err := s.volumes.RecordBlessed("demo-postgres", 7); err != nil {
+		t.Fatalf("RecordBlessed: %v", err)
+	}
+	if !s.volumes.GenerationBlessed("demo-postgres") {
+		t.Fatal("precondition: a CP-blessed generation must read as blessed")
+	}
+
+	resp, err := s.ExportArtifact(ctx, &nodev1.ExportArtifactRequest{
+		Artifact: &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: "demo-postgres"},
+	})
+	if err != nil {
+		t.Fatalf("ExportArtifact: %v", err)
+	}
+	if resp.GetSkipped() {
+		t.Fatal("a blessed volume export must not be skipped")
+	}
+	if !fs.has("volume/demo-postgres") {
+		t.Fatal("store missing volume/demo-postgres after a blessed export")
 	}
 }


### PR DESCRIPTION
Slice 1 of #4119. This closes an implementation gap against **already-accepted policy**, not a new decision.

ADR embervm/011 states it verbatim:

> "an artifact whose generation was never blessed is quarantined, never exported."

It was declared and never implemented on the export path.

## Why it matters

`VOLUME` keys as a **singleton** — `volume/<workload>`, no ref, no vendor segment, because volume data is vendor-portable — so every node that has ever held the volume writes the same object.

The generation fence in #4111 refuses an **older** generation. That's the obvious regression. This refuses the subtle one: a node that self-bumped its ledger past the blessed watermark carries a **higher** generation, so it would *win* that fence while holding state the control plane never blessed. Precisely the divergence `StatefulStore.update_quarantine` guards CP-side.

## Cost: none

The blessed marker is already on the node's disk — `volume.Manager`'s `genblessed` file, written by `RecordBlessed` from the CP-issued `blessed_generation`. So: no proto change, no CP round-trip, and it still holds during a CP gap when there is nobody to ask.

A refusal acks as `Skipped` rather than erroring — it's a policy outcome, not a transport failure, and an error would make the CP re-drive it every reconcile forever.

## Known interaction, deliberately not softened

`attachGeneration` **exempts the node-local activator** from requiring a blessing (ADR 018 Fork A — a CP-gap wake has nobody to issue one):

```go
if s.cfg.RequireBlessing && !activatorOrigin { ...refuse... }
gen, err := s.volumes.BumpGeneration(workload)   // unblessed
```

So an activator-woken workload self-bumps, is unblessed, and its volume **stops exporting until the next CP-blessed wake**.

That is ADR 011's intent — you cannot prove sole-writership during a gap, so publishing to a shared key is the split-brain risk — but it trades durability for safety on exactly the workloads Fork A serves, and demo-postgres only got `nodeLocalWake` yesterday (#4081). I've raised it as an open question on #4119 rather than resolving it by weakening the gate. It may well be why the invariant was never implemented.

## On the two changed fixtures

`TestVolumeExportSkipsUnchangedGeneration` and `TestRestoreArtifactRoundTrip` used `BumpGeneration` — the legacy self-bump that never touches the blessed marker — and were refused by the new gate. Both now use `RecordBlessed`, which is what a CP-issued blessing actually does. Neither test is about blessing; modelling an *unblessed* volume was the unrealistic part. Worth stating plainly since "the change broke tests so I changed the tests" deserves scrutiny.

## Verification

```
755 tests pass
```

New cases: refusal (asserting nothing reaches the store, and that it acks rather than errors) and the blessed path still exporting normally — so the gate can't pass by refusing everything.

Refs #4119