### PR TITLE
fix(embervm): gate pool priming on memory, not just free slots

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.286
+version: 0.1.289

--- a/projects/embervm/control/lib/embervm/pool_manager.ex
+++ b/projects/embervm/control/lib/embervm/pool_manager.ex
@@ -27,7 +27,8 @@ defmodule Embervm.PoolManager do
   That is the floor-isolation property the acceptance test asserts.
 
   Primes are spread round-robin across eligible instances to prevent
-  concentration and allow autoscaling.
+  concentration and allow autoscaling. Instances must also satisfy the
+  workload's memory need according to `Embervm.Placement.mem_eligible?/2`.
 
   ## backpressure
 
@@ -69,7 +70,7 @@ defmodule Embervm.PoolManager do
   use GenServer
   require Logger
 
-  alias Embervm.{NodeCapacity, WorkloadCatalog}
+  alias Embervm.{NodeCapacity, Placement, WorkloadCatalog}
   alias Embervm.Node.V1.{PrimeRequest, PrimeResponse, Trace}
 
   @refill_interval_ms 1_000
@@ -229,7 +230,25 @@ defmodule Embervm.PoolManager do
     node_id = dial_id(facts)
     node_inflight = node_inflight_primes(state, node_id)
     budget = max(0, Map.get(facts, :max_live_vms, 0) - Map.get(facts, :live_vms, 0) - node_inflight)
-    %{node_id: node_id, budget: budget, workloads: ready_workloads(state, facts)}
+    %{
+      node_id: node_id,
+      budget: budget,
+      # Normalized exactly as `Embervm.BrickLedger.to_brick/1` does, so the shared
+      # `Placement.mem_eligible?/2` predicate reads the same shape here as on every
+      # other placement path. `||` rather than a Map.get default because the key can
+      # be PRESENT holding nil, which a default never covers.
+      #
+      # mem_headroom_mib is the one that MUST be normalized: mem_eligible?/2 compares
+      # `mem_headroom_mib >= need_mib`, and Elixir orders atoms above numbers, so a
+      # nil headroom would satisfy EVERY memory need rather than none. Empty
+      # size_class and zero mem_budget_mib deliberately read as the WILDCARD (the
+      # legacy DaemonSet, or a brick under no cgroup limit), which is always
+      # mem-eligible by design: see the Placement moduledoc.
+      size_class: Map.get(facts, :size_class) || "",
+      mem_headroom_mib: Map.get(facts, :mem_headroom_mib) || 0,
+      mem_budget_mib: Map.get(facts, :mem_budget_mib) || 0,
+      workloads: ready_workloads(state, facts)
+    }
   end
 
   # Workloads this node has a ready base for, paired with their catalog entry
@@ -238,7 +257,11 @@ defmodule Embervm.PoolManager do
     for {wl, wc} <- facts.workloads || %{},
         base_ready?(wc),
         {:ok, entry} <- [WorkloadCatalog.fetch(state.catalog_table, wl)] do
-      {wl, %{namespace: entry.namespace, floor: entry.floor,
+      # The catalog entry carries this directly: workload_watcher's catalog_entry/…
+      # sets `mem_mib: Map.get(resources, "memMib")`. nil for a CR that omits it.
+      mem_mib = Map.get(entry, :mem_mib)
+
+      {wl, %{namespace: entry.namespace, floor: entry.floor, mem_mib: mem_mib,
         snapshot_ref: Map.get(wc, :snapshot_ref), free: Map.get(wc, :free_primed_slots, 0)}}
     end
     |> Map.new()
@@ -325,10 +348,40 @@ defmodule Embervm.PoolManager do
 
     case Enum.find(candidates, fn i ->
            instance = Enum.at(instances, i)
-           instance.budget > 0 and Map.has_key?(instance.workloads, wl)
+           instance.budget > 0 and Map.has_key?(instance.workloads, wl) and
+             memory_eligible?(instance, wl)
          end) do
-      nil -> :none
-      index -> {index, List.update_at(instances, index, &%{&1 | budget: &1.budget - 1})}
+      nil ->
+        :none
+
+      index ->
+        {index, List.update_at(instances, index, &consume(&1, wl))}
+    end
+  end
+
+  # Charge one placement to the instance: a slot, AND the workload's memory.
+  #
+  # Decrementing headroom is what makes the memory gate CUMULATIVE within a pass.
+  # A single tick can place several VMs on one instance (a floor deficit, or the
+  # queue-depth surplus), and the capacity facts only refresh on the next
+  # heartbeat, so checking a static `mem_headroom_mib` per placement would happily
+  # commit three 1024 MiB guests to a brick reporting 1933 MiB: each one passes the
+  # gate alone, and the daemon then refuses all but the first with pressure:mem.
+  # That is the failure this whole change exists to stop (issue #4121), so it has
+  # to hold within the pass and not just across ticks.
+  defp consume(instance, wl) do
+    need = instance.workloads[wl].mem_mib || 0
+    %{instance | budget: instance.budget - 1, mem_headroom_mib: max(0, instance.mem_headroom_mib - need)}
+  end
+
+  # A wildcard brick satisfies any need, so this only ever binds on a classed one.
+  # A workload whose CR omits `resources.memMib` has no need to check and stays
+  # eligible: the pool must not stop priming a workload just because its spec did
+  # not pin a size.
+  defp memory_eligible?(instance, wl) do
+    case instance.workloads[wl].mem_mib do
+      nil -> true
+      mem_mib -> Placement.mem_eligible?(instance, mem_mib)
     end
   end
 

--- a/projects/embervm/control/test/embervm/pool_manager_test.exs
+++ b/projects/embervm/control/test/embervm/pool_manager_test.exs
@@ -61,8 +61,23 @@ defmodule Embervm.PoolManagerTest do
     %{pool: pool, cap_table: cap_table, cat_table: cat_table, depth_table: depth_table, primes: primes, status: status}
   end
 
-  defp put_catalog(ctx, wl, floor) do
-    WorkloadCatalog.upsert(ctx.cat_table, wl, %{name: wl, namespace: "embervm", floor: floor, cap: 100, invoke_path: "/"})
+  defp put_catalog(ctx, wl, floor, opts \\ []) do
+    resources = Keyword.get(opts, :resources, %{})
+
+    WorkloadCatalog.upsert(ctx.cat_table, wl, %{
+      name: wl,
+      namespace: "embervm",
+      floor: floor,
+      cap: 100,
+      invoke_path: "/",
+      resources: resources,
+      # Flattened exactly as Embervm.WorkloadWatcher's catalog_entry does
+      # (`mem_mib: Map.get(resources, "memMib")`), so these fixtures carry the same
+      # entry shape the pool actually reads in production. Keeping only the nested
+      # `resources` map here would have let the memory gate silently read nil and
+      # pass everything, which is the bug these tests exist to catch.
+      mem_mib: Map.get(resources, "memMib")
+    })
   end
 
   defp put_facts(ctx, workloads, opts) do
@@ -82,10 +97,12 @@ defmodule Embervm.PoolManagerTest do
       instance_id: instance_id,
       configured_id: instance_id,
       workloads: wl_map,
-      mem_headroom_mib: 8192,
+      mem_headroom_mib: Keyword.get(opts, :mem_headroom_mib, 8192),
       cpu_headroom_millicores: 8000,
       live_vms: Keyword.get(opts, :live, 0),
       max_live_vms: Keyword.fetch!(opts, :max),
+      size_class: Keyword.get(opts, :size_class, ""),
+      mem_budget_mib: Keyword.get(opts, :mem_budget_mib, 0),
       draining: false,
       updated_at: 1_000_000
     })
@@ -307,5 +324,79 @@ defmodule Embervm.PoolManagerTest do
 
     :ok = PoolManager.refill(ctx.pool)
     assert prime_counts(ctx) == %{}
+  end
+
+  test "does not prime a workload onto a classed instance too small for its memory need" do
+    ctx = start_pool()
+    put_catalog(ctx, "wl-a", 2, resources: %{"memMib" => 1024})
+    put_instance_facts(ctx, "small", [{"wl-a", 0}], max: 10,
+      size_class: "2gi", mem_budget_mib: 2048, mem_headroom_mib: 512)
+
+    :ok = PoolManager.refill(ctx.pool)
+
+    assert prime_counts(ctx) == %{}
+  end
+
+  test "primes a workload onto a larger instance when a smaller one has insufficient memory" do
+    parent = self()
+    ctx = start_pool(channel_fun: fn node -> {:ok, node} end,
+      prime_fun: fn node, %PrimeRequest{trace: %Trace{workload: wl}} ->
+        send(parent, {:prime, node, wl})
+        {:ok, %PrimeResponse{vm_id: "vm"}}
+      end)
+    put_catalog(ctx, "wl-a", 2, resources: %{"memMib" => 1024})
+    put_instance_facts(ctx, "small", [{"wl-a", 0}], max: 10,
+      size_class: "2gi", mem_budget_mib: 2048, mem_headroom_mib: 512)
+    put_instance_facts(ctx, "large", [{"wl-a", 0}], max: 20,
+      size_class: "16gi", mem_budget_mib: 16_384, mem_headroom_mib: 4096)
+
+    :ok = PoolManager.refill(ctx.pool)
+
+    primes = for _ <- 1..2, do: (receive do {:prime, node, "wl-a"} -> node end)
+    assert Enum.frequencies(primes) == %{"large" => 2}
+  end
+
+  test "wildcard brick (size_class empty, mem_budget_mib zero) is always memory-eligible" do
+    ctx = start_pool()
+    put_catalog(ctx, "wl-a", 2, resources: %{"memMib" => 4096})
+    put_instance_facts(ctx, "wildcard", [{"wl-a", 0}], max: 10,
+      size_class: "", mem_budget_mib: 0, mem_headroom_mib: 1)
+
+    :ok = PoolManager.refill(ctx.pool)
+
+    assert prime_counts(ctx) == %{"wl-a" => 2}
+  end
+
+  test "workload with no memMib in catalog is still primed (no regression)" do
+    ctx = start_pool()
+    put_catalog(ctx, "wl-a", 2)
+    put_instance_facts(ctx, "small", [{"wl-a", 0}], max: 10,
+      size_class: "2gi", mem_budget_mib: 2048, mem_headroom_mib: 512)
+
+    :ok = PoolManager.refill(ctx.pool)
+
+    assert prime_counts(ctx) == %{"wl-a" => 2}
+  end
+
+  test "fleet-wide floor isolation holds with memory gate" do
+    ctx = start_pool()
+    put_catalog(ctx, "wl-a", 2, resources: %{"memMib" => 512})
+    put_catalog(ctx, "wl-b", 2, resources: %{"memMib" => 2048})
+    put_instance_facts(ctx, "small", [{"wl-a", 0}, {"wl-b", 0}], max: 4,
+      size_class: "2gi", mem_budget_mib: 2048, mem_headroom_mib: 1024)
+    # large must hold BOTH floors at once, not just wl-b's: the memory gate is
+    # cumulative within a pass, so headroom has to cover wl-b's 2 x 2048 plus
+    # whatever wl-a lands here. At exactly 4096 the second wl-b prime is squeezed
+    # out by a single 512 MiB wl-a, which would test the arithmetic rather than the
+    # floor-isolation property this case is about.
+    put_instance_facts(ctx, "large", [{"wl-a", 0}, {"wl-b", 0}], max: 8,
+      size_class: "16gi", mem_budget_mib: 16_384, mem_headroom_mib: 8192)
+    set_depth(ctx, "wl-a", 500)
+
+    :ok = PoolManager.refill(ctx.pool)
+
+    counts = prime_counts(ctx)
+    assert counts["wl-b"] == 2
+    assert counts["wl-a"] >= 2
   end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.286
+      targetRevision: 0.1.289
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Closes #4121. Live fix: this is why `jomcgi.dev/health` is 503 on the bazel demo.

## The bug

`PoolManager` derived its refill budget from live-VM SLOTS alone, with no memory
term anywhere in the refill path:

```elixir
budget = max(0, max_live_vms - live_vms - node_inflight)
```

and `ready_workloads/2` filtered on base-readiness only. So a brick with a free slot
was a valid prime target regardless of whether the guest fit in memory.

Production, 362 failed Primes in three minutes, ALL `pressure:mem`:

```
180  sandbox-session (2048 MiB)  ->  2gi brick
180  bazel-query     (1024 MiB)  ->  2gi brick
```

A 2gi brick reports ~1933 MiB and sandbox's floor already holds 2 x 512 of it.

**This is not just wasted work.** `max_concurrent_primes` is 4, so doomed primes
occupy the global concurrency budget and starve the primes that would succeed.
bazel-query ended up with no primed VM at all, which is why the public bazel probe
dead-letters.

## The fix

Reuse `Embervm.Placement.mem_eligible?/2`, the predicate the dispatcher, session,
serving and wake-cold paths already share, rather than adding a fourth copy of the
memory rule. The DS wildcard stays always-eligible; a classed brick is gated on
`mem_headroom_mib >= need_mib`. The need comes from the catalog entry's `mem_mib`,
which `WorkloadWatcher` already sets, so no new plumbing.

## Two details worth reviewing carefully

**Nil normalization.** Instance facts are normalized exactly as
`BrickLedger.to_brick/1` does, with `||` rather than a `Map.get` default because the
key can be PRESENT holding nil. `mem_headroom_mib` matters most: `mem_eligible?/2`
compares `mem_headroom_mib >= need_mib`, and Elixir orders atoms above numbers, so
**a nil headroom would satisfy EVERY memory need** rather than none. That would have
been a fix that silently did nothing.

**The gate is cumulative within a pass.** One tick can place several VMs on an
instance (a floor deficit, or the queue-depth surplus), and the capacity facts only
refresh on the next heartbeat. Charging each placement against a static headroom
would commit three 1024 MiB guests to a brick reporting 1933 MiB, each passing the
gate alone, and the daemon would refuse all but the first: exactly the failure this
change exists to stop. Each placement now debits headroom alongside the slot.

## Behaviour notes

- A workload whose CR omits `resources.memMib` stays eligible (no regression for a
  spec that never pinned a size).
- A workload that fits NO current brick is simply not primed, and its
  `primedFloorSatisfied` stays false. That is the honest signal that the fleet has no
  brick that can hold it, and it replaces a failing RPC every tick.
- Fleet-wide floor semantics, floor-before-surplus isolation, round-robin fairness,
  `max_concurrent_primes`, the stale/draining filter and `dial_id/1` bookkeeping are
  all unchanged.

## Verification

`ci lint` clean. `ci test` green: **1004 tests, 0 failures** (the pool suite itself:
16 tests, 0 failures).

Five new tests: a workload too large for a classed brick is not primed there; the
same workload IS primed onto a larger brick in the same pass; a wildcard brick stays
eligible regardless of reported headroom; a workload with no `memMib` is still
primed; and fleet-wide floor isolation still holds with the gate active.

Three fixes were needed on top of the generated version, all covered above: the nil
fail-open, the missing cumulative debit, and a test fixture that built a catalog
entry shaped unlike the one production stores (which made the memory gate read nil
and pass everything, so the tests only passed because code and fixture shared the
same wrong shape).
