### PR TITLE
perf(ci): early-exit Buck2 rules and BDD future features

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -164,6 +164,22 @@ actions:
         merge_with_base: false
     steps:
       - run: |
+          # Cheap pre-check: the bazel query below loads the whole graph, and
+          # that load is the entire cost of this action in its normal state (no
+          # future-tagged specs exist). `future = True` on a bdd_test appends
+          # the `future` tag (projects/monolith/bdd_test.bzl), and a raw
+          # tags = ["future"] on any test rule would too, so match either to
+          # stay a superset of what the query selects.
+          #
+          # Deliberately no `set -e` here: this action is designed around an
+          # expected non-zero exit (a red future spec is the normal signal), and
+          # it is informational, never a required check. That is also why a grep
+          # proxy is acceptable here when it would not be for a gating action.
+          if ! git grep -qE '(^[[:space:]]*future[[:space:]]*=[[:space:]]*True|"future")' -- '*BUILD' '*BUILD.bazel'; then
+            echo "No future-tagged specs; skipping BDD future features."
+            exit 0
+          fi
+
           # grep '^//' keeps only real target labels. The bb CLI interleaves its
           # own operational log lines (connection warnings, a capabilities JSON
           # blob) into stdout, which transient proxy resets make frequent; without
@@ -378,6 +394,25 @@ actions:
       # BuildBuddy runner is provisioned.
       - run: |
           set -eu
+          # This action must always run on main, so a merge cannot land an
+          # unverified Buck2 tree. On PR branches, the path list MUST stay a
+          # SUPERSET of the real inputs: too broad only costs a redundant
+          # (cache-hit) build, too narrow silently skips real work.
+          #
+          # "Am I main?" is decided by SHA, not by `git rev-parse --abbrev-ref
+          # HEAD`. That returns "HEAD" on a detached checkout, and on main the
+          # path diff against origin/main is empty by construction, so a branch
+          # name test that degraded would silently skip this action on main
+          # forever. A SHA comparison cannot degrade that way, and if
+          # origin/main is unresolvable the diff errors non-zero and the action
+          # runs, which is the safe direction.
+          git fetch origin main --quiet 2>/dev/null || true
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main 2>/dev/null || echo none)" ] && \
+             git diff --quiet origin/main HEAD -- buck2 prelude .buckconfig buildbuddy.yaml; then
+            echo "No Buck2-relevant changes vs origin/main; skipping Buck2 rules."
+            exit 0
+          fi
+
           SUDO=""; [ "$(id -u)" -eq 0 ] || SUDO="sudo"
 
           # zstd/curl to fetch+decompress the buck2 release (best-effort — the


### PR DESCRIPTION
First lever from `/improve-buildbuddy-usage`. Measurement, not intuition.

## What the measurement found

Workflows runner traffic is the majority of this org's BuildBuddy downloads,
and it is **Firecracker VM snapshot traffic, not Bazel traffic**. The blob size
gives it away: runner traffic moves in a uniform ~4 MB chunk while Bazel's
averages 60 to 430 KB.

| TB/7d | GB/run | runs | action | resource_requests |
|---|---|---|---|---|
| 2.43 | 4.20 | 579 | `Push images` | 6cpu/10GB/120GB |
| 2.02 | 3.49 | 579 | `Test` | 6cpu/10GB/120GB |
| 0.43 | 0.73 | 579 | `Format check` | 8GB/20GB |
| 0.30 | 0.52 | 579 | **`Buck2 rules`** | 8GB/30GB |
| 0.22 | **0.38** | 579 | **`BDD future features`** | **6cpu/10GB/120GB** |
| 0.05 | 0.11 | 438 | `Visual regression` | 8GB/20GB |
| 0.02 | 0.04 | 438 | `Manifest diff` | 20GB |

Note row 5 against rows 1 and 2: `BDD future features` declares *identical*
resource_requests to `Test` and `Push images` yet costs 11x less. **Snapshot
size tracks pages the VM dirties, not what it requests.** So this PR changes no
`resource_requests` (that would be churn with no saving) and instead makes the
VM do less. A runner that exits early costs 0.04 to 0.38 GB against 3 to 4 GB.

## Why in-step exits rather than triggers

BuildBuddy Workflows has no path filtering. Triggers accept only
`push.branches`, `push.tags`, `pull_request.branches`, `pull_request.types`,
`pull_request.merge_with_base`, `schedule.crons`. So the gate has to be an
early exit, placed before anything expensive (for Buck2 that means before the
apt install and the buck2 release download, which are themselves part of what
dirties the VM). Both mirror the existing `Visual regression` gate, including
its rule that the path list stays a superset of real inputs.

## Safety

- **Buck2 rules always runs on main.** "Am I main?" is decided by SHA, not by
  `git rev-parse --abbrev-ref HEAD`, which returns `HEAD` when detached. Since
  the path diff against origin/main is empty on main by construction, a
  degraded branch test would silently skip the action on main forever. An
  unresolvable origin/main makes the diff error non-zero, so the action runs.
- `buildbuddy.yaml` is in Buck2's own path list, so any future edit to the
  action runs it at least once. Verified: this PR's own Buck2 check runs.
- **BDD's grep is a superset**: it matches `future = True` (which
  `projects/monolith/bdd_test.bzl` turns into the tag) *and* a raw `"future"`
  tag on any rule, so it cannot under-select relative to the `bazel query`.
  This action is informational and never a required check, which is what makes
  a grep proxy acceptable here.
- No `set -e` added to the BDD step: it is built around an expected non-zero
  exit (a red future spec is the normal signal).

## Verification

Both gates simulated locally against real refs:

```
this branch: buck2 gate RUN  (buildbuddy.yaml changed, self-reference works)
this branch: bdd   gate SKIP (no future-tagged specs, the normal state)
on main:     buck2 gate RUN  (correct, no silent skip)
```

YAML parses, all 7 actions intact, `ci lint` clean, no new em-dashes.

## Scope

~0.5 TB/7d, about 5% of total downloads. Deliberately small and low-risk.
`Push images` (2.43 TB) and `Test` (2.02 TB) are the real targets; `Push
images` needs a decision on whether PR image pushes to GHCR are load-bearing
before it can be gated safely, since that action carries the required
missed-chart-bump guard.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)