### PR TITLE
fix(embervm): hydrate a wake's anchor node when it has no base

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.289
+version: 0.1.291

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -291,6 +291,37 @@ defmodule Embervm.BaseBuilder do
     cast_if_alive(server, {:mark_watcher_synced})
   end
 
+  @doc """
+  A wake found NO base for `workload` on `node_id`, so hydrate one there.
+
+  This exists because nothing else owns the pair `(workload, anchor node)`. This
+  module pins a workload's base to ONE instance (`placement/3` takes the highest
+  `build_rank`, `keep_or_replace` keeps it sticky) and hydrates only that node. A
+  STATEFUL wake, though, is anchored to the node holding the VOLUME. Those two
+  selections are independent, and when they diverge the anchor node is nobody's
+  responsibility: no base is ever placed there and the wake fails
+  `:no_eligible_instance` on every retry, forever (issue #4127, which took the
+  public demo down for hours on a fleet that was otherwise entirely healthy).
+
+  Deliberately NOT gated on `node_reports_base_absent?/3`. That predicate demands
+  the node AFFIRMATIVELY report `BASE_BUILD_STATE_NONE`, treating a MISSING fact as
+  "not absent" so a post-build race cannot trigger a spurious hydrate. But a brick
+  that advertises no workloads at all reports no fact, so it can never satisfy it,
+  which is the second half of #4127. The caller here carries strictly better
+  evidence than the periodic reconcile has: a wake was attempted against this node
+  and the daemon answered that the base is not provisioned. That is affirmative,
+  so this path may proceed where the periodic one correctly will not.
+
+  An async cast, and a no-op when this GenServer is not running (tests, a CP that
+  has not started it), exactly like `Embervm.BrickController.note_denial/2` on the
+  capacity-denial branch this mirrors. The wake outcome is unchanged either way:
+  this only makes the NEXT wake able to succeed.
+  """
+  @spec note_base_missing(GenServer.server(), String.t(), String.t()) :: :ok
+  def note_base_missing(server \\ __MODULE__, workload, node_id) do
+    cast_if_alive(server, {:base_missing, workload, node_id})
+  end
+
   defp cast_if_alive(server, msg) do
     case GenServer.whereis(server) do
       nil -> :ok
@@ -472,6 +503,10 @@ defmodule Embervm.BaseBuilder do
   @impl true
   def handle_cast({:reconcile, desc}, state) do
     {:noreply, reconcile_desc(state, desc)}
+  end
+
+  def handle_cast({:base_missing, workload, node_id}, state) do
+    {:noreply, hydrate_for_anchor(state, workload, node_id)}
   end
 
   def handle_cast({:forget, name}, state) do
@@ -677,6 +712,74 @@ defmodule Embervm.BaseBuilder do
   #      hydrate against a build);
   #   4. no hydrate is already in flight for the workload (the in-flight guard, so
   #      a re-reconcile during the async download does not spawn a second worker).
+  # Hydrate `workload`'s recorded base onto `node_id` after a wake found none there
+  # (issue #4127). See note_base_missing/3 for why this is not gated on
+  # node_reports_base_absent?/3.
+  #
+  # `node_id` here is a BARE node name (the wake's volume anchor), while this module
+  # pins by INSTANCE id, so resolve the best build-eligible instance ON that node.
+  # Every other guard from should_hydrate?/3 still applies: there must be a recorded
+  # ref whose signature is current (never hydrate a stale or mid-change base), and
+  # `hydrating` dedupes so a 10s retry loop spawns one worker, not one per attempt.
+  defp hydrate_for_anchor(state, workload, node_id) when is_binary(workload) and is_binary(node_id) do
+    w = Map.get(state.workloads, workload)
+
+    cond do
+      is_nil(w) ->
+        state
+
+      not is_binary(w.snapshot_ref) ->
+        # Nothing recorded to hydrate FROM: a first build has to happen normally.
+        state
+
+      w.built_signature != signature(w) ->
+        # The spec moved under us; a rebuild owns this, not a hydrate.
+        state
+
+      MapSet.member?(state.hydrating, workload) ->
+        state
+
+      true ->
+        case build_instance_on_node(state, w, node_id) do
+          nil ->
+            # No build-eligible instance on the anchor node. Loud, because the wake
+            # will keep failing and no hydrate can help: the anchor itself is wrong
+            # (stale volume debris flapping it, #4127) or the node is not eligible.
+            Logger.warning(
+              "embervm base builder: wake found no base for #{workload} on #{node_id}, " <>
+                "and no build-eligible instance exists there to hydrate onto"
+            )
+
+            state
+
+          instance_id ->
+            Logger.warning(
+              "embervm base builder: hydrating #{workload} onto #{instance_id} after a wake " <>
+                "found no base on its anchor node #{node_id}"
+            )
+
+            state
+            |> mark_hydrating(workload)
+            |> spawn_hydrate(%{w | node_id: instance_id})
+        end
+    end
+  end
+
+  defp hydrate_for_anchor(state, _workload, _node_id), do: state
+
+  # The best build-eligible INSTANCE whose reported node_id is `node_id`. Reuses the
+  # same eligibility and ranking as placement/3 so a hydrate never targets an
+  # instance placement itself would reject.
+  defp build_instance_on_node(state, w, node_id) do
+    state
+    |> eligible_build_instances(Map.get(w, :mem_mib) || 0)
+    |> Enum.filter(fn i -> Map.get(i, :node_id) == node_id end)
+    |> case do
+      [] -> nil
+      instances -> instances |> Enum.max_by(&build_rank/1) |> Map.get(:instance_id)
+    end
+  end
+
   defp should_hydrate?(state, w, node_id) do
     is_binary(w.snapshot_ref) and w.built_signature == signature(w) and
       node_reports_base_absent?(state, node_id, w.name) and

--- a/projects/embervm/control/lib/embervm/wake_instance.ex
+++ b/projects/embervm/control/lib/embervm/wake_instance.ex
@@ -375,6 +375,16 @@ defmodule Embervm.WakeInstance do
 
         if capacity_denial? do
           Embervm.BrickController.note_denial(need_mib)
+        else
+          # Bricks here were slot/mem-eligible but NONE advertised the workload's
+          # base, so this is a provisioning gap, not a capacity wall. Tell the base
+          # builder, which pins a workload's base to ONE instance and would
+          # otherwise never place one on this node: a stateful wake anchors to the
+          # VOLUME's node, and when that diverges from the pin the anchor is nobody's
+          # responsibility and the wake fails forever (issue #4127). An async cast
+          # that no-ops when the builder is not running, exactly like note_denial
+          # above; the wake outcome is unchanged either way.
+          Embervm.BaseBuilder.note_base_missing(workload, node_id)
         end
 
         {:error, :no_eligible_instance}

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -2280,4 +2280,117 @@ defmodule Embervm.BaseBuilderTest do
                BaseBuilder.base_revision(zip_at.("bbb"))
     end
   end
+
+  # -- hydrate the wake's anchor node (#4127) ---------------------------------
+
+  # Nothing owned the pair (workload, anchor node): this module pins a base to ONE
+  # instance, a stateful wake anchors to the VOLUME's node, and when those diverge no
+  # base is ever placed where the wake needs one, so the wake fails
+  # :no_eligible_instance on every retry forever. That took the public demo down for
+  # hours on an otherwise healthy fleet.
+  test "note_base_missing hydrates the anchor node that reports NO base fact at all" do
+    test_pid = self()
+
+    restore_fun = fn :fake_channel, %Embervm.Node.V1.RestoreArtifactRequest{artifact: ref} ->
+      send(test_pid, {:restore_called, ref.ref})
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{accepted: true}}
+    end
+
+    {builder, _agent, table} =
+      build_then_report_base_absent(
+        restore_fun: restore_fun,
+        hydrate_poll_interval_ms: 5,
+        hydrate_poll_max: 50
+      )
+
+    # A SECOND node exists and advertises NOTHING: no base fact for "w" at all. That
+    # is the #4127 shape, and node_reports_base_absent?/3 is false for it (a MISSING
+    # fact is deliberately not "absent"), so the periodic reconcile can never hydrate
+    # it. A wake failure is stronger evidence: the daemon was asked and said no.
+    put_brick(table, "node-9", "b1", size_class: "16gi", mem_budget: 16_384, mem_headroom: 16_000)
+    # Registered too: eligible_build_instances/2 iterates state.node_ids, so a
+    # capacity fact alone is not enough to make it a build candidate.
+    :ok = BaseBuilder.add_node(builder, "node-9/b1", "a9")
+
+    :ok = BaseBuilder.note_base_missing(builder, "w", "node-9")
+
+    assert_receive {:restore_called, "snap1"}, 1_000
+  end
+
+  test "note_base_missing spawns ONE hydrate for a repeating wake failure" do
+    test_pid = self()
+
+    restore_fun = fn :fake_channel, %Embervm.Node.V1.RestoreArtifactRequest{artifact: ref} ->
+      send(test_pid, {:restore_called, ref.ref})
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{accepted: true}}
+    end
+
+    {builder, _agent, table} =
+      build_then_report_base_absent(
+        restore_fun: restore_fun,
+        hydrate_poll_interval_ms: 5,
+        hydrate_poll_max: 50
+      )
+
+    put_brick(table, "node-9", "b1", size_class: "16gi", mem_budget: 16_384, mem_headroom: 16_000)
+    # Registered too: eligible_build_instances/2 iterates state.node_ids, so a
+    # capacity fact alone is not enough to make it a build candidate.
+    :ok = BaseBuilder.add_node(builder, "node-9/b1", "a9")
+
+    # The wake retry loop runs every ~10s indefinitely; the `hydrating` dedupe is
+    # what keeps that from spawning a worker per attempt.
+    for _ <- 1..5, do: BaseBuilder.note_base_missing(builder, "w", "node-9")
+
+    assert_receive {:restore_called, "snap1"}, 1_000
+    refute_receive {:restore_called, _}, 200
+  end
+
+  test "note_base_missing does nothing when no build-eligible instance is on that node" do
+    test_pid = self()
+
+    restore_fun = fn :fake_channel, _req ->
+      send(test_pid, {:restore_called, :unexpected})
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{accepted: true}}
+    end
+
+    {builder, _agent, _table} =
+      build_then_report_base_absent(
+        restore_fun: restore_fun,
+        hydrate_poll_interval_ms: 5,
+        hydrate_poll_max: 50
+      )
+
+    # The anchor itself is wrong (stale volume debris flapping it onto a node that
+    # is not in the fleet). No hydrate can help, so it must not spawn one.
+    :ok = BaseBuilder.note_base_missing(builder, "w", "node-does-not-exist")
+
+    refute_receive {:restore_called, _}, 200
+  end
+
+  test "note_base_missing does nothing when there is no recorded base to hydrate from" do
+    test_pid = self()
+
+    restore_fun = fn :fake_channel, _req ->
+      send(test_pid, {:restore_called, :unexpected})
+      {:ok, %Embervm.Node.V1.RestoreArtifactResponse{accepted: true}}
+    end
+
+    {builder, _agent, _table} =
+      build_then_report_base_absent(
+        restore_fun: restore_fun,
+        hydrate_poll_interval_ms: 5,
+        hydrate_poll_max: 50
+      )
+
+    # A first build has to happen normally; there is no ref to restore.
+    :ok = BaseBuilder.note_base_missing(builder, "never-built", "node-4")
+
+    refute_receive {:restore_called, _}, 200
+  end
+
+  test "note_base_missing is a no-op when the builder is not running" do
+    # Mirrors BrickController.note_denial/2: a missing server must never raise into
+    # the wake path, whose outcome is unchanged either way.
+    assert BaseBuilder.note_base_missing(:no_such_base_builder_4127, "w", "node-9") == :ok
+  end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.289
+      targetRevision: 0.1.291
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Closes #4127. This is the change that would have prevented last night's multi-hour outage.

## The unowned pair

`BaseBuilder` pins a workload's base to **one** instance:

```elixir
node_id = placement(state, prev, mem_mib)      # Enum.max_by(instances, &build_rank/1)
should_hydrate?(state, w, node_id)             # hydrates only THAT node
```

A **stateful wake anchors to the volume's node**. Two independent selections, nothing
reconciling them. They normally coincide, so it works, until the volume anchor moves,
at which point the anchor node is nobody's responsibility: no base is ever placed
there and the wake fails `:no_eligible_instance` on every retry, forever.

The CP's own diagnostic named it exactly:

```
no cold-placement candidate on node need_mib=512 capacity_denial=false brick_count=2
bricks=[{id=node-1/e67831ee... eligible=true base_ready=false workload_facts=0
base_state=nil} {...}]  node_id=node-1 workload=demo-postgres
```

`capacity_denial=false` and `eligible=true` rule out capacity. `workload_facts=0` shows
the bricks advertise nothing at all, while a healthy banked instance sat on node-4 at
generation 5113. Restarting node-1 did not and could not help: a fresh pod stayed at
`workload_facts=0` for 14 consecutive polls, because nothing was ever going to request
a base there.

## The fix

`cold_instance` already discriminated the two failure modes (to avoid feeding the
autoscaler a bogus demand signal) and dropped the base-not-ready half on the floor:

```elixir
if capacity_denial? do
  Embervm.BrickController.note_denial(need_mib)
else
  Embervm.BaseBuilder.note_base_missing(workload, node_id)   # the missing half
end
```

Both are async casts that no-op when the target is not running, so the wake outcome is
unchanged either way. This only makes the NEXT wake able to succeed.

## Why it does not reuse node_reports_base_absent?/3

That predicate requires the node to AFFIRMATIVELY report `BASE_BUILD_STATE_NONE`,
treating a missing fact as "not absent" so a post-build race cannot trigger a spurious
restore. A brick advertising zero workloads reports no fact, so it can never satisfy
it, which is the second half of #4127.

The caller here has strictly better evidence than the periodic reconcile: a wake was
attempted and the daemon answered `not provisioned on this node`. That is affirmative,
so this path may proceed where the periodic one correctly will not.

## Guards kept

- A recorded ref whose signature is CURRENT (never hydrate a stale or mid-change base)
- The target must be a build-eligible REGISTERED instance on the anchor node, reusing
  `eligible_build_instances` + `build_rank` so a hydrate never lands somewhere
  placement itself would reject
- The existing `hydrating` dedupe: a ~10s retry loop spawns ONE worker, not one per
  attempt
- No eligible instance on the anchor: log loudly, do nothing. That means the ANCHOR is
  wrong, which no hydrate can fix

## Scope

This makes the failure self-healing, NOT impossible. It does not stop the anchor
flapping onto a node it should not be on (stale volume debris, #4119 slice 3). It
converts an indefinite outage into a slow wake.

## Verification

```
1009 tests, 0 failures, 6 skipped
MIX TEST OK on the executor
```

Five new tests: the exact #4127 shape (anchor reporting no fact at all), retry-loop
dedupe, no-eligible-instance must not spawn, no recorded base to restore from, and the
no-op-when-not-running contract matching `note_denial`.

One test-authoring note worth keeping: my first attempt registered only a capacity
fact for the target node and the hydrate correctly refused. `eligible_build_instances`
iterates `state.node_ids`, so a hydrate target must be a REGISTERED build candidate,
not merely a node reporting capacity. I fixed the test rather than loosening the
filter.
