### PR TITLE
feat(monolith): attribute public health 503s to the failing component

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.322
+version: 0.89.323
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.322
+      targetRevision: 0.89.323
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.396
+version: 0.285.397
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.396
+      targetRevision: 0.285.397
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/framework/core.py
+++ b/projects/monolith/framework/core.py
@@ -261,9 +261,11 @@ def _add_health(app: FastAPI, profile: Profile, modules: Sequence[Module]) -> No
     if profile.tier is Tier.PUBLIC:
         health_logger = logging.getLogger("monolith.public")
         health_message = "public health check failed"
+        component_message = "public health components unhealthy"
     else:
         health_logger = logger
         health_message = "deep health check failed"
+        component_message = "deep health components unhealthy"
 
     component_checks: dict[str, HealthCheck] = {}
     for m in modules:
@@ -310,6 +312,21 @@ def _add_health(app: FastAPI, profile: Profile, modules: Sequence[Module]) -> No
             components = dict(zip(names, results))
 
         all_ok = db_ok and all(c.get("ok") for c in components.values())
+        # Ember checks return {"ok": False, detail} in-band and never raise
+        # (see ember_public/synthetic_probe.py), so _run_component's exception
+        # log never fires for them and a component-caused 503 was silent. This
+        # warning is the only server-side record of which component tripped.
+        if not all_ok:
+            failing = {n: c for n, c in components.items() if not c.get("ok")}
+            if failing:
+                health_logger.warning(
+                    "%s: %s",
+                    component_message,
+                    "; ".join(
+                        f"{n}={c.get('detail') or 'no detail'}"
+                        for n, c in sorted(failing.items())
+                    ),
+                )
         body = {"status": "ok" if all_ok else "unhealthy"}
         if components:
             body["components"] = components

--- a/projects/monolith/framework/core_test.py
+++ b/projects/monolith/framework/core_test.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import logging
 
 import pytest
 from fastapi import FastAPI
@@ -138,6 +139,30 @@ def _sqlite_engine(monkeypatch):
     return engine
 
 
+@pytest.fixture
+def _public_app_with_logs(caplog):
+    """Build a PUBLIC tier app without losing caplog capture.
+
+    build_app calls configure_logging, and logging.basicConfig(force=True)
+    removes every handler already on the root logger, including the one
+    caplog installed for this test. Records emitted after build_app are
+    therefore invisible to caplog unless the handler is put back, which is
+    what this fixture does.
+    """
+    root = logging.getLogger()
+
+    def _build(modules):
+        app = build_app(PUBLIC_PROFILE, modules)
+        if caplog.handler not in root.handlers:
+            root.addHandler(caplog.handler)
+        return app
+
+    try:
+        yield _build
+    finally:
+        root.removeHandler(caplog.handler)
+
+
 def test_public_tier_health_has_no_components_when_no_module_registers_health(
     _sqlite_engine,
 ):
@@ -164,7 +189,9 @@ def test_public_tier_health_folds_in_module_components(_sqlite_engine):
     assert body["components"] == {"widget": {"ok": True, "detail": "all good"}}
 
 
-def test_public_tier_health_503s_when_a_component_is_not_ok(_sqlite_engine):
+def test_public_tier_health_503_logs_failing_component(
+    _sqlite_engine, caplog, _public_app_with_logs
+):
     async def unhealthy_check():
         return {"ok": False, "detail": "widget is broken"}
 
@@ -173,16 +200,43 @@ def test_public_tier_health_503s_when_a_component_is_not_ok(_sqlite_engine):
         register_public=lambda app: None,
         register_health={"widget": unhealthy_check},
     )
-    app = build_app(PUBLIC_PROFILE, [module])
-    resp = TestClient(app).get("/api/health")
+    app = _public_app_with_logs([module])
+    with caplog.at_level(logging.WARNING, logger="monolith.public"):
+        resp = TestClient(app).get("/api/health")
     assert resp.status_code == 503
     body = resp.json()
     assert body["status"] == "unhealthy"
     assert body["components"]["widget"]["ok"] is False
+    records = [r for r in caplog.records if r.name == "monolith.public"]
+    assert len(records) == 1
+    assert records[0].levelno == logging.WARNING
+    assert "public health components unhealthy" in records[0].message
+    assert "widget" in records[0].message
+    assert "widget is broken" in records[0].message
+
+
+def test_public_tier_healthy_component_logs_no_component_warning(
+    _sqlite_engine, caplog, _public_app_with_logs
+):
+    async def healthy_check():
+        return {"ok": True, "detail": "all good"}
+
+    module = Module(
+        name="m",
+        register_public=lambda app: None,
+        register_health={"widget": healthy_check},
+    )
+    app = _public_app_with_logs([module])
+    with caplog.at_level(logging.WARNING, logger="monolith.public"):
+        resp = TestClient(app).get("/api/health")
+    assert resp.status_code == 200
+    assert not any(
+        "public health components unhealthy" in r.message for r in caplog.records
+    )
 
 
 def test_public_tier_health_crashing_component_reports_not_ok_not_500(
-    _sqlite_engine,
+    _sqlite_engine, caplog, _public_app_with_logs
 ):
     async def crashing_check():
         raise RuntimeError("kaboom")
@@ -192,12 +246,21 @@ def test_public_tier_health_crashing_component_reports_not_ok_not_500(
         register_public=lambda app: None,
         register_health={"widget": crashing_check},
     )
-    app = build_app(PUBLIC_PROFILE, [module])
-    resp = TestClient(app).get("/api/health")
+    app = _public_app_with_logs([module])
+    with caplog.at_level(logging.WARNING, logger="monolith.public"):
+        resp = TestClient(app).get("/api/health")
     assert resp.status_code == 503
     body = resp.json()
     assert body["components"]["widget"]["ok"] is False
     assert "kaboom" in body["components"]["widget"]["detail"]
+    assert any(
+        r.name == "monolith.public"
+        and r.levelno == logging.WARNING
+        and "public health components unhealthy" in r.message
+        and "widget" in r.message
+        and "kaboom" in r.message
+        for r in caplog.records
+    )
 
 
 def test_public_tier_has_no_lifespan_side_effects_or_mcp():

--- a/projects/monolith/frontend/src/routes/public/health/+server.js
+++ b/projects/monolith/frontend/src/routes/public/health/+server.js
@@ -28,8 +28,23 @@ export async function GET({ fetch }) {
   }
 
   if (!res.ok) {
+    // Expose component names for attribution, never internal detail strings.
+    let failing = [];
+    try {
+      const body = await res.json();
+      failing = Object.entries(body?.components ?? {})
+        .filter(([, c]) => !c?.ok)
+        .map(([name]) => name)
+        .sort();
+    } catch {
+      // Non-JSON or unreadable error body: names are simply unavailable.
+    }
     return json(
-      { status: "unhealthy", backendStatus: res.status },
+      {
+        status: "unhealthy",
+        backendStatus: res.status,
+        ...(failing.length ? { failing } : {}),
+      },
       { status: 503 },
     );
   }

--- a/projects/monolith/frontend/src/routes/public/health/server.test.js
+++ b/projects/monolith/frontend/src/routes/public/health/server.test.js
@@ -35,13 +35,40 @@ describe("/public/health GET", () => {
     const fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 503,
-      json: async () => ({ status: "unhealthy" }),
+      json: async () => ({
+        status: "unhealthy",
+        components: {
+          b: { ok: true },
+          a: { ok: false, detail: "secret" },
+        },
+      }),
     });
 
     const res = await GET({ fetch });
 
     expect(res.status).toBe(503);
     expect(res.headers.get("cache-control")).toBeNull();
+    const body = await res.json();
+    expect(body.failing).toEqual(["a"]);
+    expect(JSON.stringify(body)).not.toContain("secret");
+  });
+
+  it("omits failing names when the backend body is not parseable", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => {
+        throw new Error("not JSON");
+      },
+    });
+
+    const res = await GET({ fetch });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      status: "unhealthy",
+      backendStatus: 503,
+    });
   });
 
   it("returns an uncached 503 when the backend is unreachable", async () => {


### PR DESCRIPTION
## Why

UptimeRobot pages on `jomcgi.dev/health`, but that route asserts far more than the monolith. It is a composite: `SELECT 1` as `public_reader` plus five module-contributed components (`demo_postgres` and the four EmberVM synthetic probes). Any one of them false makes the whole response 503.

Until now a component-caused 503 left **no server-side record of which component tripped**, because attribution was destroyed at two layers:

1. `_run_component` logs only when a check *raises*. The ember checks are deliberately built never to raise, returning `{"ok": False, detail}` in-band ("a crashing probe IS the finding"). So the `monolith.public` / `"public health check failed"` line that SigNoz alerts and runbooks key on fires **only** for the `SELECT 1` path.
2. The frontend proxy dropped the `components` map on failure, returning just `{status, backendStatus}`.

Net effect: a multi-hour 503 could not be attributed after the fact, from inside or outside the cluster.

## What

- **Backend** (`framework/core.py`): log one warning naming the failing components and their details. It uses a **distinct** message (`"public health components unhealthy"`) so the existing DB-outage signal keeps its exact meaning and the two stay separately alertable. It logs once per poll on purpose, which gives an outage a timeline in SigNoz.
- **Frontend** (`routes/public/health/+server.js`): pass through the sorted **names** of failing components. Names only, never the `detail` strings: this route is internet-reachable and details carry internal error text (control plane URLs, connection errors). Names are already public in an open repo.

The 503 path still sets no cache header, and the "backend unreachable" branch is unchanged.

## Test note

The new tests build the app through a fixture that re-attaches caplog's handler. `build_app()` calls `configure_logging()`, and `logging.basicConfig(force=True)` removes every handler already on the root logger, including the one pytest installs for the test. Anything logged after `build_app()` is otherwise invisible to `caplog`, which is why no existing test asserts on a log line emitted through a built app.

## Scope

Attribution only. It deliberately does not add alert rules or any rollback automation: the point is to first measure which failure classes actually drive these pages, since most of what this route aggregates is not deploy-shaped and would not be fixed by a rollback.

Verified with `ci lint` and `ci test`: 744 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)