### PR TITLE
refactor(monolith): make the ember synthetic probes the sole health source of truth

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.294
+version: 0.1.295

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.294
+      targetRevision: 0.1.295
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.323
+version: 0.89.324
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.323
+      targetRevision: 0.89.324
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -6508,6 +6508,25 @@ py_test(
     ],
 )
 
+# Hand-registered (ember_public is gazelle-excluded): the /api/health component
+# registration and the synthetic probe's fail-closed unconfigured branch. This
+# file had no target until 2026-07-28, so nothing in it ran; gazelle cannot
+# catch that here because the whole directory is excluded from it.
+py_test(
+    name = "ember_public_health_test",
+    srcs = ["ember_public/health_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+    ],
+)
+
 py_test(
     name = "ember_public_synthetic_health_test",
     srcs = ["ember_public/synthetic_health_test.py"],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.397
+version: 0.285.398
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.397
+      targetRevision: 0.285.398
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/ember_public/core.py
+++ b/projects/monolith/ember_public/core.py
@@ -97,10 +97,6 @@ async def fetch_demo_pg_status() -> dict:
 # caller past the TTL does the real fetch and every concurrent/near-concurrent
 # caller shares that one result instead of piling on the control plane.
 #
-# state_changed_at (monotonic) is bumped whenever the observed state differs
-# from the previous observation. Task 4's health check consumes it to detect a
-# transitional state (relighting/cold_booting/...) stuck past its timeout; no
-# health logic lives here, this module only records the timestamp.
 # ---------------------------------------------------------------------------
 
 _STATUS_CACHE_TTL_S = 0.5
@@ -108,8 +104,6 @@ _status_cache_lock = asyncio.Lock()
 _status_cache: dict = {
     "at": None,
     "payload": None,
-    "state": None,
-    "state_changed_at": None,
 }
 
 
@@ -117,8 +111,8 @@ async def cached_demo_pg_status() -> dict:
     """Single-flight, TTL-cached read through fetch_demo_pg_status.
 
     Concurrent callers within the TTL window share one upstream fetch. Also
-    used by the /status endpoint and (later) the health check, so both read
-    the exact same snapshot rather than racing separate control-plane calls.
+    used by the /status endpoint, so concurrent readers share the exact same
+    snapshot rather than racing separate control-plane calls.
     """
     async with _status_cache_lock:
         now = monotonic()
@@ -127,18 +121,9 @@ async def cached_demo_pg_status() -> dict:
             return _status_cache["payload"]
 
         payload = await fetch_demo_pg_status()
-        state = payload.get("state")
-        if state != _status_cache["state"]:
-            _status_cache["state_changed_at"] = now
-            _status_cache["state"] = state
         _status_cache["at"] = now
         _status_cache["payload"] = payload
         return payload
-
-
-def status_cache_state_changed_at() -> float | None:
-    """Monotonic timestamp of the most recent observed state change, if any."""
-    return _status_cache["state_changed_at"]
 
 
 # ---------------------------------------------------------------------------
@@ -259,25 +244,6 @@ def present_count() -> int:
     now = monotonic()
     _prune_presence(now)
     return len(_presence)
-
-
-# ---------------------------------------------------------------------------
-# Most recent query outcome, module-level. Task 4's health check consumes
-# this to detect a failed or slow wake with no newer success; no health logic
-# lives here, this module only records the observation.
-# ---------------------------------------------------------------------------
-
-_last_query_outcome: dict = {"at_monotonic": None, "ok": None, "connect_ms": None}
-
-
-def record_query_outcome(*, ok: bool, connect_ms: float | None) -> None:
-    _last_query_outcome["at_monotonic"] = monotonic()
-    _last_query_outcome["ok"] = ok
-    _last_query_outcome["connect_ms"] = connect_ms
-
-
-def last_query_outcome() -> dict:
-    return dict(_last_query_outcome)
 
 
 def shape_pg_status(status: dict) -> dict:

--- a/projects/monolith/ember_public/health.py
+++ b/projects/monolith/ember_public/health.py
@@ -1,116 +1,20 @@
-"""demo_postgres /api/health component (see framework/core.py's register_health).
+"""Ember public health components backed entirely by synthetic probe latches.
 
-Sourced ENTIRELY from the cached control-plane status read
-(``core.cached_demo_pg_status``) and the in-process query-outcome record
-(``core.last_query_outcome``): this check must never open a DB connection to
-the demo VM, since an asleep demo is healthy and a health probe that woke it
-would defeat the whole sleep story.
-
-Five unhealthy conditions (see the ember public-pages design, "Health +
-alerting"), checked in order and short-circuited at the first hit:
-
-1. The control plane is unreachable or the demo is unconfigured.
-2. The workload reports a broken snapshot/volume pairing while banked.
-3. The workload is stuck in a fault eviction (pair_broken) past the same 90s
-   window, a passive sign the wake path is broken (a benign ttl eviction is
-   never flagged). See the demo-postgres provisioning wedge RCA.
-4. A transitional state (relighting/cold_booting/starting/banking) has
-   persisted past 90s (wakeTimeoutSeconds is 60s plus margin), a passive
-   sign of a wedged cold boot.
-5. The most recent real query in the last 10 minutes failed or its connect
-   exceeded 60s, with no newer success superseding it.
+The active prober replaced an earlier passive check. Each component reads the
+latest latch row written by its synthetic probe, so the public health endpoint
+has one source of truth for the ember demos.
 """
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from time import monotonic
 
-from ember_public import core
 from ember_public.synthetic import read_probe
-
-_TRANSITIONAL_STATES = frozenset({"relighting", "cold_booting", "starting", "banking"})
-
-# Eviction reasons that signal a fault (a broken snapshot/volume pairing), not
-# benign recycling. A `ttl` eviction (banked-TTL expiry) is normal and never
-# flags unhealthy; only a `pair_broken` eviction that fails to recover does.
-_FAULT_EVICTION_REASONS = frozenset({"pair_broken"})
-
-_STUCK_TRANSITION_S = 90.0
-_SLOW_WAKE_CONNECT_MS = 60000.0
-_RECENT_OUTCOME_WINDOW_S = 600.0
 
 # All four synthetic probes run in the one ember-synthetic CronWorkflow every
 # 5 minutes (see the jobs.cronWorkflows entry). 2.5x that cadence, so a single
 # missed or slow run never flaps the check but a dead prober still surfaces.
 EMBER_SYNTHETIC_STALENESS_S = 750.0
-
-
-async def demo_postgres_health() -> dict:
-    """The demo_postgres /api/health component. Never connects to the demo DB."""
-    if not core.EMBERVM_URL or not core.demo_pg_dsn():
-        return {"ok": False, "detail": "control plane unreachable or unconfigured"}
-
-    try:  # nosemgrep: no-broad-except-swallow - the exception itself is the finding, returned in-band
-        status = await core.cached_demo_pg_status()
-    except Exception as exc:  # noqa: BLE001 - an unreachable control plane is the finding
-        return {"ok": False, "detail": f"control plane unreachable: {exc}"}
-
-    state = status.get("state")
-
-    if state == "banked" and status.get("pair_valid") is False:
-        return {"ok": False, "detail": "banked with invalid snapshot/volume pairing"}
-
-    # A fault eviction (pair_broken) is normally recoverable: the next wake
-    # cold-boots from the volume. But a demo that stays evicted past the wake
-    # window is not re-banking or re-serving, a passive sign the wake path is
-    # broken (observed 2026-07-19: an unprovisioned base image failed every cold
-    # boot, so the demo sat evicted/pair_broken for hours while a bare
-    # /api/health read looked healthy once the last failed-query outcome aged
-    # out). Gated on the same stuck window as a transitional state so a brief
-    # warmth discard never flaps. A benign ttl eviction never lands here.
-    instance = status.get("instance") or {}
-    if (
-        state == "evicted"
-        and instance.get("terminal_reason") in _FAULT_EVICTION_REASONS
-    ):
-        changed_at = core.status_cache_state_changed_at()
-        if changed_at is not None:
-            stuck_for = monotonic() - changed_at
-            if stuck_for > _STUCK_TRANSITION_S:
-                return {
-                    "ok": False,
-                    "detail": f"evicted (pair_broken) for {stuck_for:.0f}s, wake path likely broken",
-                }
-
-    if state in _TRANSITIONAL_STATES:
-        changed_at = core.status_cache_state_changed_at()
-        if changed_at is not None:
-            stuck_for = monotonic() - changed_at
-            if stuck_for > _STUCK_TRANSITION_S:
-                return {
-                    "ok": False,
-                    "detail": f"{state} for {stuck_for:.0f}s, wake likely wedged",
-                }
-
-    outcome = core.last_query_outcome()
-    at_monotonic = outcome.get("at_monotonic")
-    if at_monotonic is not None:
-        age_s = monotonic() - at_monotonic
-        if age_s <= _RECENT_OUTCOME_WINDOW_S:
-            ok = outcome.get("ok")
-            connect_ms = outcome.get("connect_ms")
-            if not ok:
-                return {"ok": False, "detail": "most recent wake attempt failed"}
-            if connect_ms is not None and connect_ms > _SLOW_WAKE_CONNECT_MS:
-                return {
-                    "ok": False,
-                    "detail": f"most recent wake took {connect_ms:.0f}ms, exceeds threshold",
-                }
-
-    if state == "banked":
-        return {"ok": True, "detail": "banked, pair valid"}
-    return {"ok": True, "detail": f"{state}"}
 
 
 def synthetic_probe_health(demo: str, staleness_s: float):

--- a/projects/monolith/ember_public/health_test.py
+++ b/projects/monolith/ember_public/health_test.py
@@ -1,307 +1,59 @@
-"""Tests for the demo_postgres /api/health component (ember_public/health.py).
-
-Each test patches ember_public.core's cache/status/outcome seams directly, so
-nothing here reaches the embervm control plane or a real Postgres, matching
-health.py's own never-connect invariant.
-"""
+"""Tests for ember public health registration and synthetic probe failures."""
 
 from __future__ import annotations
 
-from time import monotonic
+from datetime import datetime, timezone
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.pool import StaticPool
 from sqlmodel import create_engine
 
-import ember_public.core as core
-from ember_public.health import demo_postgres_health
+import ember_public.health as health
+import ember_public.synthetic_probe as probe
 from ember_public.module import MODULE
+from ember_public.synthetic_models import EmberSyntheticProbe
 from framework import PUBLIC_PROFILE, build_app
 
 
-@pytest.fixture(autouse=True)
-def _reset_ember_public_module_state():
-    """Mirror router_test.py's reset: the status cache and last-query-outcome
-    are process-global, so tests must not leak state across each other."""
-
-    def _reset():
-        core._status_cache.update(
-            {"at": None, "payload": None, "state": None, "state_changed_at": None}
-        )
-        core._last_query_outcome.update(
-            {"at_monotonic": None, "ok": None, "connect_ms": None}
-        )
-
-    _reset()
-    yield
-    _reset()
-
-
-def _pg_status_payload(**overrides):
-    base = {
-        "state": "banked",
-        "generation": 7,
-        "bundle_generation": 7,
-        "pair_valid": True,
-        "volume_bytes": 123456,
-        "instance": {"healthy": True},
-    }
-    base.update(overrides)
-    return base
-
-
-def test_module_registers_demo_postgres_health_hook():
-    assert MODULE.register_health["demo_postgres"] is demo_postgres_health
+def test_module_registers_synthetic_postgres_health_hook():
+    assert "ember_postgres" in MODULE.register_health
     assert set(MODULE.register_health) == {
-        "demo_postgres",
         "ember_bazel",
         "ember_semgrep",
         "ember_pages",
-        "ember_postgres_synthetic",
+        "ember_postgres",
     }
 
 
 @pytest.mark.asyncio
-async def test_unconfigured_is_not_ok(monkeypatch):
+async def test_probe_postgres_unconfigured_is_not_ok(monkeypatch):
     monkeypatch.delenv("DEMO_POSTGRES_DSN", raising=False)
-    monkeypatch.setattr(core, "EMBERVM_URL", "")
 
-    result = await demo_postgres_health()
-    assert result["ok"] is False
-    assert "unreachable or unconfigured" in result["detail"]
+    result = await probe.probe_postgres()
 
+    assert result == {
+        "ok": False,
+        "detail": "DEMO_POSTGRES_DSN not configured",
+        "latency_ms": None,
+    }
 
-@pytest.mark.asyncio
-async def test_control_plane_unreachable_is_not_ok(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
 
-    async def fake_status():
-        raise RuntimeError("connection refused")
-
-    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
-
-    result = await demo_postgres_health()
-    assert result["ok"] is False
-    assert "connection refused" in result["detail"]
-
-
-@pytest.mark.asyncio
-async def test_healthy_banked_pair_valid(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
-
-    async def fake_status():
-        return _pg_status_payload(state="banked", pair_valid=True)
-
-    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
-
-    result = await demo_postgres_health()
-    assert result == {"ok": True, "detail": "banked, pair valid"}
-
-
-@pytest.mark.asyncio
-async def test_healthy_serving(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
-
-    async def fake_status():
-        return _pg_status_payload(state="serving", pair_valid=None)
-
-    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
-
-    result = await demo_postgres_health()
-    assert result == {"ok": True, "detail": "serving"}
-
-
-@pytest.mark.asyncio
-async def test_banked_with_invalid_pair_is_not_ok(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
-
-    async def fake_status():
-        return _pg_status_payload(state="banked", pair_valid=False)
-
-    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
-
-    result = await demo_postgres_health()
-    assert result["ok"] is False
-    assert "pair" in result["detail"]
-
-
-@pytest.mark.asyncio
-async def test_transitional_state_under_threshold_is_ok(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
-
-    async def fake_status():
-        return _pg_status_payload(state="cold_booting", pair_valid=None)
-
-    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
-    # Prime the cache so state_changed_at is set, then patch it to look recent.
-    await core.cached_demo_pg_status()
-    core._status_cache["state_changed_at"] = monotonic() - 10
-
-    result = await demo_postgres_health()
-    assert result["ok"] is True
-
-
-@pytest.mark.asyncio
-async def test_stuck_transition_past_90s_is_not_ok(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
-
-    async def fake_status():
-        return _pg_status_payload(state="relighting", pair_valid=None)
-
-    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
-    await core.cached_demo_pg_status()
-    core._status_cache["state_changed_at"] = monotonic() - 91
-
-    result = await demo_postgres_health()
-    assert result["ok"] is False
-    assert "relighting" in result["detail"]
-    assert "wedged" in result["detail"]
-
-
-@pytest.mark.asyncio
-async def test_evicted_pair_broken_past_threshold_is_not_ok(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
-
-    async def fake_status():
-        return _pg_status_payload(
-            state="evicted",
-            pair_valid=False,
-            instance={"healthy": False, "terminal_reason": "pair_broken"},
-        )
-
-    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
-    await core.cached_demo_pg_status()
-    core._status_cache["state_changed_at"] = monotonic() - 91
-
-    result = await demo_postgres_health()
-    assert result["ok"] is False
-    assert "pair_broken" in result["detail"]
-    assert "broken" in result["detail"]
-
-
-@pytest.mark.asyncio
-async def test_evicted_pair_broken_under_threshold_is_ok(monkeypatch):
-    """A brief pair_broken eviction (warmth discard) recovers on the next wake and
-    must not flap the check before the stuck window elapses."""
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
-
-    async def fake_status():
-        return _pg_status_payload(
-            state="evicted",
-            pair_valid=False,
-            instance={"healthy": False, "terminal_reason": "pair_broken"},
-        )
-
-    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
-    await core.cached_demo_pg_status()
-    core._status_cache["state_changed_at"] = monotonic() - 10
-
-    result = await demo_postgres_health()
-    assert result["ok"] is True
-
-
-@pytest.mark.asyncio
-async def test_evicted_ttl_is_ok(monkeypatch):
-    """A ttl eviction is benign recycling, healthy even past the stuck window."""
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
-
-    async def fake_status():
-        return _pg_status_payload(
-            state="evicted",
-            pair_valid=False,
-            instance={"healthy": True, "terminal_reason": "ttl"},
-        )
-
-    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
-    await core.cached_demo_pg_status()
-    core._status_cache["state_changed_at"] = monotonic() - 120
-
-    result = await demo_postgres_health()
-    assert result["ok"] is True
-
-
-@pytest.mark.asyncio
-async def test_recent_failed_wake_is_not_ok(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
-
-    async def fake_status():
-        return _pg_status_payload(state="banked", pair_valid=True)
-
-    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
-    core.record_query_outcome(ok=False, connect_ms=None)
-
-    result = await demo_postgres_health()
-    assert result["ok"] is False
-    assert "wake attempt failed" in result["detail"]
-
-
-@pytest.mark.asyncio
-async def test_recent_slow_wake_is_not_ok(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
-
-    async def fake_status():
-        return _pg_status_payload(state="banked", pair_valid=True)
-
-    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
-    core.record_query_outcome(ok=True, connect_ms=65000.0)
-
-    result = await demo_postgres_health()
-    assert result["ok"] is False
-    assert "65000ms" in result["detail"]
-
-
-@pytest.mark.asyncio
-async def test_old_failed_wake_outside_window_does_not_count(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
-
-    async def fake_status():
-        return _pg_status_payload(state="banked", pair_valid=True)
-
-    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
-    core.record_query_outcome(ok=False, connect_ms=None)
-    core._last_query_outcome["at_monotonic"] = monotonic() - 601
-
-    result = await demo_postgres_health()
-    assert result["ok"] is True
-
-
-@pytest.mark.asyncio
-async def test_newer_success_supersedes_older_failure(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
-
-    async def fake_status():
-        return _pg_status_payload(state="banked", pair_valid=True)
-
-    monkeypatch.setattr(core, "fetch_demo_pg_status", fake_status)
-    core.record_query_outcome(ok=False, connect_ms=None)
-    core.record_query_outcome(ok=True, connect_ms=1200.0)
-
-    result = await demo_postgres_health()
-    assert result["ok"] is True
-
-
-def test_public_app_api_health_503s_when_demo_postgres_unconfigured(monkeypatch):
-    """End-to-end: build the real public app (via the real ember_public
-    module) and confirm the demo_postgres component propagates a 503 on
-    /api/health, exactly as the framework's generic component contract
-    promises (see framework/core_test.py for the generic mechanism tests)."""
+def test_public_app_api_health_surfaces_synthetic_probe_failure(monkeypatch):
+    """The public health component reports the probe latch, not a passive DB check."""
     monkeypatch.delenv("DEMO_POSTGRES_DSN", raising=False)
-    monkeypatch.setattr(core, "EMBERVM_URL", "")
 
+    row = EmberSyntheticProbe(
+        demo="postgres",
+        ok=False,
+        detail="DEMO_POSTGRES_DSN not configured",
+        checked_at=datetime.now(timezone.utc),
+    )
+
+    async def read_probe(_):
+        return row
+
+    monkeypatch.setattr(health, "read_probe", read_probe)
     engine = create_engine(
         "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
     )
@@ -312,4 +64,5 @@ def test_public_app_api_health_503s_when_demo_postgres_unconfigured(monkeypatch)
 
     assert resp.status_code == 503
     body = resp.json()
-    assert body["components"]["demo_postgres"]["ok"] is False
+    assert body["components"]["ember_postgres"]["ok"] is False
+    assert "demo_postgres" not in body["components"]

--- a/projects/monolith/ember_public/module.py
+++ b/projects/monolith/ember_public/module.py
@@ -8,7 +8,6 @@ demos/module.py.
 import ember_public as _domain
 from ember_public.health import (
     EMBER_SYNTHETIC_STALENESS_S,
-    demo_postgres_health,
     synthetic_probe_health,
 )
 
@@ -20,11 +19,10 @@ MODULE = _Module(
     register=_domain.register,
     register_public=_domain.register_public,
     register_health={
-        "demo_postgres": demo_postgres_health,
         "ember_bazel": synthetic_probe_health("bazel", EMBER_SYNTHETIC_STALENESS_S),
         "ember_semgrep": synthetic_probe_health("semgrep", EMBER_SYNTHETIC_STALENESS_S),
         "ember_pages": synthetic_probe_health("pages", EMBER_SYNTHETIC_STALENESS_S),
-        "ember_postgres_synthetic": synthetic_probe_health(
+        "ember_postgres": synthetic_probe_health(
             "postgres", EMBER_SYNTHETIC_STALENESS_S
         ),
     },

--- a/projects/monolith/ember_public/router.py
+++ b/projects/monolith/ember_public/router.py
@@ -159,7 +159,6 @@ async def postgres_query(body: PostgresQueryRequest, request: Request) -> dict:
             )
         except Exception as exc:  # noqa: BLE001 - surface connect/query failures in-band
             logger.warning("demo-postgres query roundtrip failed: %s", exc)
-            core.record_query_outcome(ok=False, connect_ms=None)
             return {
                 "error": str(exc),
                 "mode": body.mode,
@@ -170,7 +169,6 @@ async def postgres_query(body: PostgresQueryRequest, request: Request) -> dict:
     finally:
         core.release_query_slot()
 
-    core.record_query_outcome(ok=True, connect_ms=result["connect_ms"])
     return {
         **result,
         "total_ms": (perf_counter() - started) * 1000,

--- a/projects/monolith/ember_public/router_test.py
+++ b/projects/monolith/ember_public/router_test.py
@@ -34,21 +34,16 @@ def _client() -> TestClient:
 @pytest.fixture(autouse=True)
 def _reset_ember_public_module_state():
     """Every gating mechanism in core.py is process-global (status cache,
-    semaphore, insert bucket, last-query-outcome), so tests running back to
+    semaphore, insert bucket), so tests running back to
     back within the same 500ms status-cache TTL would otherwise leak state
     (a cached payload, a held slot, a bucket entry) across test functions.
     Reset before AND after each test.
     """
 
     def _reset():
-        core._status_cache.update(
-            {"at": None, "payload": None, "state": None, "state_changed_at": None}
-        )
+        core._status_cache.update({"at": None, "payload": None})
         core._insert_bucket.clear()
         core._presence.clear()
-        core._last_query_outcome.update(
-            {"at_monotonic": None, "ok": None, "connect_ms": None}
-        )
         core._savings_cache.update(
             {"at": None, "total_saved_mib_s": None, "as_of": None}
         )
@@ -691,32 +686,6 @@ def test_status_cache_refetches_after_ttl_expires(monkeypatch):
     assert calls["n"] == 2
 
 
-def test_status_cache_records_state_changed_at_on_transition(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "http://embervm")
-
-    fake_clock = {"t": 1000.0}
-    monkeypatch.setattr(core, "monotonic", lambda: fake_clock["t"])
-
-    state = {"s": "banked"}
-
-    async def variable_status():
-        return _pg_status_payload(state=state["s"])
-
-    monkeypatch.setattr(core, "fetch_demo_pg_status", variable_status)
-
-    client = _client()
-    client.get("/api/ember/postgres/status")
-    first_changed_at = core.status_cache_state_changed_at()
-    assert first_changed_at == 1000.0
-
-    fake_clock["t"] += core._STATUS_CACHE_TTL_S + 0.01
-    state["s"] = "relighting"
-    client.get("/api/ember/postgres/status")
-    assert core.status_cache_state_changed_at() == fake_clock["t"]
-    assert core.status_cache_state_changed_at() != first_changed_at
-
-
 def test_semaphore_exhausted_returns_in_band_busy(monkeypatch):
     monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
     monkeypatch.setattr(core, "EMBERVM_URL", "")
@@ -982,50 +951,6 @@ def test_sessionless_aggregate_allowed_regardless_of_turnstile_config(monkeypatc
     body = resp.json()
     assert body.get("session_required") is not True
     assert body["mode"] == "aggregate"
-
-
-def test_query_records_last_outcome_on_success(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "")
-
-    def fake_roundtrip(dsn, mode, session_tag):
-        return {
-            "connect_ms": 42.0,
-            "query_ms": 1.0,
-            "mode": mode,
-            "statements": [],
-            "inserted": None,
-            "rows": [],
-            "breakdown": [],
-            "total_orders": 0,
-            "total_revenue": 0.0,
-            "postmaster_start": "2026-07-17T08:00:00+00:00",
-        }
-
-    monkeypatch.setattr(core, "demo_pg_orders_roundtrip", fake_roundtrip)
-
-    _client().post("/api/ember/postgres/query", json={"mode": "aggregate"})
-
-    outcome = core.last_query_outcome()
-    assert outcome["ok"] is True
-    assert outcome["connect_ms"] == 42.0
-    assert outcome["at_monotonic"] is not None
-
-
-def test_query_records_last_outcome_on_failure(monkeypatch):
-    monkeypatch.setenv("DEMO_POSTGRES_DSN", "postgresql://x")
-    monkeypatch.setattr(core, "EMBERVM_URL", "")
-
-    def fake_roundtrip(dsn, mode, session_tag):
-        raise OSError("connection refused")
-
-    monkeypatch.setattr(core, "demo_pg_orders_roundtrip", fake_roundtrip)
-
-    _client().post("/api/ember/postgres/query", json={"mode": "aggregate"})
-
-    outcome = core.last_query_outcome()
-    assert outcome["ok"] is False
-    assert outcome["connect_ms"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/projects/monolith/ember_public/router_test.py
+++ b/projects/monolith/ember_public/router_test.py
@@ -34,10 +34,10 @@ def _client() -> TestClient:
 @pytest.fixture(autouse=True)
 def _reset_ember_public_module_state():
     """Every gating mechanism in core.py is process-global (status cache,
-    semaphore, insert bucket), so tests running back to
-    back within the same 500ms status-cache TTL would otherwise leak state
-    (a cached payload, a held slot, a bucket entry) across test functions.
-    Reset before AND after each test.
+    semaphore, insert bucket), so tests running back to back within the same
+    500ms status-cache TTL would otherwise leak state (a cached payload, a
+    held slot, a bucket entry) across test functions. Reset before AND after
+    each test.
     """
 
     def _reset():

--- a/projects/monolith/ember_public/synthetic_probe.py
+++ b/projects/monolith/ember_public/synthetic_probe.py
@@ -193,7 +193,14 @@ async def probe_postgres() -> dict:
     """
     dsn = core.demo_pg_dsn()
     if not dsn:
-        return {"ok": True, "detail": "not configured", "latency_ms": None}
+        # This used to fail open because demo_postgres caught the unconfigured
+        # case. With that check gone, a misconfigured deploy would otherwise
+        # read green.
+        return {
+            "ok": False,
+            "detail": "DEMO_POSTGRES_DSN not configured",
+            "latency_ms": None,
+        }
 
     before = None
     if core.EMBERVM_URL:
@@ -215,7 +222,6 @@ async def probe_postgres() -> dict:
         result = await asyncio.to_thread(
             core.demo_pg_orders_roundtrip, dsn, "aggregate", None
         )
-        core.record_query_outcome(ok=True, connect_ms=result["connect_ms"])
         return {
             "ok": True,
             "detail": f"{core.classify_wake(before)}, {result.get('connect_ms')}ms",
@@ -223,7 +229,6 @@ async def probe_postgres() -> dict:
         }
     except Exception as exc:  # noqa: BLE001 - probes report failures in-band
         logger.warning("demo-postgres synthetic roundtrip failed: %s", exc)
-        core.record_query_outcome(ok=False, connect_ms=None)
         return _failure(exc)
     finally:
         core.release_query_slot()

--- a/projects/monolith/ember_public/synthetic_probe_test.py
+++ b/projects/monolith/ember_public/synthetic_probe_test.py
@@ -37,8 +37,18 @@ async def test_postgres_busy_is_skipped(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_postgres_unconfigured_is_not_ok(monkeypatch):
+    monkeypatch.setattr(probe.core, "demo_pg_dsn", lambda: "")
+
+    result = await probe.probe_postgres()
+
+    assert result["ok"] is False
+    assert result["detail"] == "DEMO_POSTGRES_DSN not configured"
+
+
+@pytest.mark.asyncio
 async def test_postgres_aggregate_roundtrip_success(monkeypatch):
-    """Successful aggregate roundtrip records ok with connect_ms as latency."""
+    """Successful aggregate roundtrip reports connect_ms as latency."""
     monkeypatch.setattr(probe.core, "demo_pg_dsn", lambda: "postgres://test")
     monkeypatch.setattr(probe.core, "EMBERVM_URL", "http://test")
     monkeypatch.setattr(
@@ -52,7 +62,6 @@ async def test_postgres_aggregate_roundtrip_success(monkeypatch):
         "demo_pg_orders_roundtrip",
         lambda *_: {"connect_ms": 42, "total_ms": 100},
     )
-    monkeypatch.setattr(probe.core, "record_query_outcome", lambda **_: None)
     monkeypatch.setattr(probe.core, "classify_wake", lambda _: "cold")
     monkeypatch.setattr(probe.core, "release_query_slot", lambda: None)
 


### PR DESCRIPTION
## What

Deletes the passive `demo_postgres` `/api/health` component and the in-process query-outcome tracking that existed only to feed it. The four synthetic probes become the sole source of truth for the ember demos on `jomcgi.dev/health`.

## Why

`demo_postgres_health()` had five unhealthy conditions. Three of them (banked with an invalid pair, stuck `evicted`/`pair_broken` past 90s, stuck transitional past 90s) are passive INFERENCES that the wake path is broken. The synthetic probe tests the wake path directly every 5 minutes, so they are redundant.

They are also, by the code's own account, patches on a detector that had already failed. From the deleted comment:

> observed 2026-07-19: an unprovisioned base image failed every cold boot, so the demo sat evicted/pair_broken for hours while a bare /api/health read looked healthy once the last failed-query outcome aged out

The active prober is what caught the 2026-07-28 outage. Inferring "the wake is probably broken" from a state field is strictly worse than trying the wake.

The remaining two conditions are given up deliberately (see Tradeoffs).

## The deletion cascades

`last_query_outcome()` and `status_cache_state_changed_at()` had exactly one reader between them: `demo_postgres_health`. Removing it left `record_query_outcome()` write-only, called from `router.py` and `synthetic_probe.py` and read by nobody. So the whole mechanism goes, along with the `state` / `state_changed_at` bookkeeping inside `_status_cache`.

`cached_demo_pg_status()` and its single-flight TTL cache are untouched; the `/status` endpoint still uses them.

## One behaviour change, deliberately fail-closed

`probe_postgres()` returned `{"ok": True, "detail": "not configured"}` on an unset DSN. That was safe only because `demo_postgres` caught the unconfigured case. It is now `ok: False`, otherwise a misconfigured deploy would read green with nothing else watching.

Two other fail-opens are deliberately kept: `synthetic_probe_health`'s `row is None` (monolith-public rolls out before the migration creates the table) and `record()`'s early return on `skip`, which leaves `checked_at` stale so a permanently busy demo ages into the staleness check and goes red rather than sticking green.

## Also: a test file that never ran

`ember_public/health_test.py` had **no `py_test` target**, so its ~300 lines of `demo_postgres_health` cases never executed in CI. `ember_public` is `gazelle:exclude`d at `projects/monolith/BUILD`, so gazelle could not have generated one and nothing flagged it. Registered as `ember_public_health_test` here, which is why the test count moves 743 to 744.

## Renamed

`ember_postgres_synthetic` to `ember_postgres`, for symmetry with `ember_bazel` / `ember_semgrep` / `ember_pages`. It is a public `/api/health` JSON key; grep found no consumers (no SigNoz alert, no frontend). PR #4132's attribution iterates `components` generically rather than by name, so the rename does not affect it.

## Tradeoffs accepted

- **Detection latency** goes from real-time to at most 12.5 minutes (5 minute cadence, 750s staleness).
- **Real-visitor query failures** are no longer a signal. The probe runs in the private API pod; `demo_postgres` was the only check standing where the visitors are.
- **Password drift.** monolith-public authenticates with `DEMO_PG_PASSWORD`, the probe with `SCRATCH_PG_PASSWORD`, same `postgres` user on the same `...-serving.embervm.svc:5401/scratch`. If those two secrets diverge, visitors get auth failures while the synths stay green. Not addressed here (it touches live credentials); worth a follow-up.

## Verification

`ci lint` clean. `ci test`: `Executed 4 out of 744 tests: 744 tests pass` with 99 remote and 80 linux-sandbox executions, confirming the new and modified targets genuinely ran rather than reading back a warm cache. Two earlier runs were discarded as untrustworthy under #4118, which this exercise reproduced twice and which now carries that evidence.

Both charts bumped: `jomcgi.dev` is served by monolith-public, so a monolith-only bump would not move the public origin.

## Post-merge check

```
curl -s https://jomcgi.dev/health | jq '.components | keys'
```
should show four ember components with no `demo_postgres`, and `ember_postgres` in place of `ember_postgres_synthetic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmCiLAhyJ3rGH3NHfTpRse