### PR TITLE
fix(embervm): reclaim a writable attach whose owning VM is gone

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.297
+version: 0.1.299

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.297
+      targetRevision: 0.1.299
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/stateful.go
+++ b/projects/embervm/noded/server/stateful.go
@@ -213,6 +213,7 @@ func (s *Server) startStatefulRelight(ctx context.Context, req *nodev1.StartStat
 	// further write must be witnessed by a strictly newer generation than the
 	// one the bundle was stamped with, or a future relight of a LATER bank
 	// could falsely re-match this now-stale bundle.
+	s.releaseOrphanedAttach(workload)
 	if err := s.volumes.Attach(workload); err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: %v", err)
 	}
@@ -296,6 +297,7 @@ func (s *Server) coldBootStateful(ctx context.Context, req *nodev1.StartStateful
 	// a losing racer strand the winner's generation (ledger ahead of the booted
 	// VM's stamp), making every later relight cold-boot. Singleton by construction
 	// upstream, but the daemon enforces it where the data physically lives.
+	s.releaseOrphanedAttach(workload)
 	if err := s.volumes.Attach(workload); err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: %v", err)
 	}
@@ -359,6 +361,7 @@ func (s *Server) finishStatefulStart(ctx context.Context, h substrate.Handle, wo
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: install stateful DNAT for %s: %v", ip, err)
 	}
 	probe := serving.StartTCPProbe(s.newTCPProber(), ip, port)
+	s.volumes.Bind(workload, h.ID)
 	s.statefulVMs.add(&statefulEntry{
 		vmID:        h.ID,
 		workload:    workload,
@@ -420,6 +423,25 @@ func (s *Server) waitStatefulReady(ctx context.Context, ip net.IP, port uint32, 
 // DEAD control plane cannot pin a paused VM's live-VM cap slot and memory for more
 // than this. A tuning knob to refine alongside the flap guard.
 const defaultStatefulResolveTimeout = 30 * time.Second
+
+// statefulPendingAttachGrace bounds how long an unbound writable attach may
+// sit before a new start may reclaim it. It is deliberately several times
+// BootReadyTimeout (60s), the longest legitimate in-flight start, so a slow
+// cold boot can never have its attach stolen out from under it.
+const statefulPendingAttachGrace = 5 * time.Minute
+
+// releaseOrphanedAttach clears a writable-attach lock whose owning VM the
+// registry no longer knows about, so a workload wedged by a lost Detach
+// self-heals on its next wake instead of needing a noded restart (#3648).
+func (s *Server) releaseOrphanedAttach(workload string) {
+	live := ""
+	if e, ok := s.statefulVMs.byWorkload(workload); ok {
+		live = e.vmID
+	}
+	if reason, released := s.volumes.ReleaseOrphaned(workload, live, statefulPendingAttachGrace); released {
+		s.logger.Warn("noded: reclaimed orphaned writable attach", "workload", workload, "reason", reason)
+	}
+}
 
 // StopStateful tears down a live stateful VM. BANK pauses it, writes a
 // stateful snapshot stamped with the CURRENT volume generation, evicts any

--- a/projects/embervm/noded/volume/volume.go
+++ b/projects/embervm/noded/volume/volume.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 // volFile / genFile / blessedFile are the files under a workload's volume
@@ -45,13 +46,22 @@ type Manager struct {
 	root string
 
 	mu       sync.Mutex
-	attached map[string]struct{}
+	attached map[string]attachment
+}
+
+// attachment records WHO holds a workload's writable-attach lock. owner is
+// the vmID, and is empty while a start is still in flight, because Attach is
+// acquired before the VM exists. Without an owner the lock cannot be
+// reconciled against reality, which is what wedged demo-postgres in #3648.
+type attachment struct {
+	owner string
+	since time.Time
 }
 
 // NewManager builds a Manager rooted at root (VolumeRoot). It does not touch
 // disk; callers create the root lazily via Create.
 func NewManager(root string) *Manager {
-	return &Manager{root: root, attached: make(map[string]struct{})}
+	return &Manager{root: root, attached: make(map[string]attachment)}
 }
 
 // dir is the per-workload volume directory.
@@ -140,8 +150,57 @@ func (m *Manager) Attach(workload string) error {
 	if _, ok := m.attached[workload]; ok {
 		return fmt.Errorf("volume: workload %q already has a writable attach in progress", workload)
 	}
-	m.attached[workload] = struct{}{}
+	m.attached[workload] = attachment{since: time.Now()}
 	return nil
+}
+
+// Bind records the vmID that owns workload's writable attach, once the VM
+// exists. A bound attach can be reclaimed by a later start when the registry
+// says that vm is gone; an unbound one can only age out. No-op if the workload
+// is not attached.
+func (m *Manager) Bind(workload, vmID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	attach, ok := m.attached[workload]
+	if !ok {
+		return
+	}
+	attach.owner = vmID
+	m.attached[workload] = attach
+}
+
+// ReleaseOrphaned reclaims workload's writable attach when it is provably
+// stale, returning the reason and true when it released. liveVMID is the vmID
+// the caller's live-instance registry currently has for this workload, empty
+// when it has none.
+//
+// Two stale cases, both conservative:
+//   - bound to an owner that is not liveVMID: the owning VM is gone or has
+//     been replaced, so nothing holds the device.
+//   - unbound for longer than pendingGrace: a start that never reached the VM.
+//     Gated on a grace far longer than any legitimate boot so a slow start is
+//     never robbed mid-flight.
+//
+// A healthy attach (owner == liveVMID, both non-empty) is never touched.
+func (m *Manager) ReleaseOrphaned(workload, liveVMID string, pendingGrace time.Duration) (string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	attach, ok := m.attached[workload]
+	if !ok {
+		return "", false
+	}
+	if attach.owner == "" {
+		if time.Since(attach.since) > pendingGrace {
+			delete(m.attached, workload)
+			return fmt.Sprintf("in-flight start exceeded %s without binding a vm", pendingGrace), true
+		}
+		return "", false
+	}
+	if attach.owner == liveVMID {
+		return "", false
+	}
+	delete(m.attached, workload)
+	return fmt.Sprintf("owner vm %q is no longer live", attach.owner), true
 }
 
 // Detach releases the writable-attach lock for a workload. Idempotent: an

--- a/projects/embervm/noded/volume/volume_test.go
+++ b/projects/embervm/noded/volume/volume_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestCreateSparseAndGenerationInit(t *testing.T) {
@@ -245,6 +246,88 @@ func TestDetachIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	m := NewManager(dir)
 	m.Detach("never-attached") // must not panic
+}
+
+func TestReleaseOrphanedHealthyBoundAttach(t *testing.T) {
+	m := NewManager(t.TempDir())
+	if err := m.Attach("wl-a"); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	m.Bind("wl-a", "vm-a")
+	if reason, released := m.ReleaseOrphaned("wl-a", "vm-a", 0); released || reason != "" {
+		t.Fatalf("ReleaseOrphaned healthy attach = %q, %v want empty, false", reason, released)
+	}
+	if !m.IsAttached("wl-a") {
+		t.Error("healthy bound attach should remain held")
+	}
+}
+
+func TestReleaseOrphanedReclaimsReplacedBoundAttach(t *testing.T) {
+	m := NewManager(t.TempDir())
+	if err := m.Attach("wl-a"); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	m.Bind("wl-a", "vm-a")
+	if reason, released := m.ReleaseOrphaned("wl-a", "vm-b", time.Hour); !released || reason != `owner vm "vm-a" is no longer live` {
+		t.Fatalf("ReleaseOrphaned replaced attach = %q, %v", reason, released)
+	}
+	if m.IsAttached("wl-a") {
+		t.Error("reclaimed attach should not remain held")
+	}
+	if err := m.Attach("wl-a"); err != nil {
+		t.Fatalf("Attach after reclaim: %v", err)
+	}
+}
+
+func TestReleaseOrphanedReclaimsUnboundAttachWithoutLiveVM(t *testing.T) {
+	m := NewManager(t.TempDir())
+	if err := m.Attach("wl-a"); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	m.Bind("wl-a", "vm-a")
+	if reason, released := m.ReleaseOrphaned("wl-a", "", time.Hour); !released || reason != `owner vm "vm-a" is no longer live` {
+		t.Fatalf("ReleaseOrphaned missing live VM = %q, %v", reason, released)
+	}
+}
+
+func TestReleaseOrphanedPendingAttachGrace(t *testing.T) {
+	t.Run("slow boot is retained", func(t *testing.T) {
+		m := NewManager(t.TempDir())
+		if err := m.Attach("wl-a"); err != nil {
+			t.Fatalf("Attach: %v", err)
+		}
+		if reason, released := m.ReleaseOrphaned("wl-a", "", time.Hour); released || reason != "" {
+			t.Fatalf("ReleaseOrphaned within grace = %q, %v want empty, false", reason, released)
+		}
+	})
+	t.Run("expired start is reclaimed", func(t *testing.T) {
+		m := NewManager(t.TempDir())
+		if err := m.Attach("wl-a"); err != nil {
+			t.Fatalf("Attach: %v", err)
+		}
+		if reason, released := m.ReleaseOrphaned("wl-a", "", 0); !released || reason == "" {
+			t.Fatalf("ReleaseOrphaned expired attach = %q, %v", reason, released)
+		}
+	})
+}
+
+func TestReleaseOrphanedNeverAttached(t *testing.T) {
+	m := NewManager(t.TempDir())
+	if reason, released := m.ReleaseOrphaned("never-attached", "", 0); released || reason != "" {
+		t.Fatalf("ReleaseOrphaned missing attach = %q, %v", reason, released)
+	}
+}
+
+func TestDetachReleasesAndBindUnattachedIsNoOp(t *testing.T) {
+	m := NewManager(t.TempDir())
+	m.Bind("never-attached", "vm-a")
+	if err := m.Attach("wl-a"); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	m.Detach("wl-a")
+	if m.IsAttached("wl-a") {
+		t.Error("Detach should fully release the attach")
+	}
 }
 
 // TestDeleteRefusesWhileAttached proves the ONLY destructive data verb refuses


### PR DESCRIPTION
Fixes #3648.

## The defect

The per-workload writable-attach lock was:

```go
attached map[string]struct{}
```

`Attach` inserted the key, `Detach` deleted it, and **nothing recorded who held it**. A lock with no owner cannot be reconciled against reality, so whenever the path that would have called `Detach` died, every later wake was refused with `FAILED_PRECONDITION: already has a writable attach in progress`, forever, until noded restarted.

This is why the documented reset verb returns `{destroyed: 0, evicted: 0}`: it looks for a live instance to tear down, but the wedge is precisely the state where the attach outlived its VM. There was nothing to compare the lock against.

## Reproduced in prod today

`demo-postgres` wedged again, identically to the 2026-07-17 incident in the issue. Symptoms while it was live:

- 158 failed cold boots in 80 minutes, roughly 2/min, each configuring the volume drive and then being refused
- both wake paths retrying forever (control plane auto-wake every 10s, noded's local activator every 30s)
- `jomcgi.dev/health` 503 throughout, which is how it was caught

Cleared with `kubectl rollout restart deploy/embervm-embervm-noded-brick-2gi-node-2`, after which the demo relights in ~58ms.

## The change

- `attachment{owner, since}` replaces `struct{}`, where `owner` is the vmID
- `Bind(workload, vmID)` in `finishStatefulStart`, at the same point the registry entry is created, so the registry and the attach agree on the owner by construction
- `ReleaseOrphaned(workload, liveVMID, grace)` at the top of both start paths, reclaiming an attach that is provably stale

`Detach` is untouched and remains the normal release path. This only adds a reclaim path for when `Detach` never ran.

## Safety

This lock is the only thing keeping two VMs off one volume, so a wrong release corrupts data. The reclaim is deliberately asymmetric:

- **Bound to a vm the live registry does not have:** released immediately. The registry is authoritative, so nothing is writing.
- **Unbound (a start still in flight):** released only after `statefulPendingAttachGrace` = 5 minutes, five times `BootReadyTimeout` (60s), the longest legitimate in-flight start. A slow cold boot cannot have its attach stolen.
- **Owner equals the live vm:** never touched.

Tuning that grace down would trade a recoverable outage for silent corruption, hence the named constant and the comment.

## Scope

This is a partial answer to gap 1 in the issue. Reconciliation happens on a wake attempt, not on a timer, so a stale attach on a workload nobody wakes still lingers and still shows in `IsAttached` for Inventory and the `DeleteVolume` guard. That is deliberate (the wedge only causes harm when a wake happens) but it is not a full registry reconciler. Gap 2, control-plane escalation after N refusals, is untouched.

Verified with `ci lint` and `ci test`: 744 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)