### PR TITLE
fix(embervm): apply noded's memory reject floor when placing a brick

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.295
+version: 0.1.297

--- a/projects/embervm/control/lib/embervm/brick_ledger.ex
+++ b/projects/embervm/control/lib/embervm/brick_ledger.ex
@@ -56,6 +56,7 @@ defmodule Embervm.BrickLedger do
           instance_id: String.t(),
           size_class: String.t(),
           mem_headroom_mib: non_neg_integer(),
+          mem_reject_floor_mib: non_neg_integer(),
           mem_budget_mib: non_neg_integer(),
           live_vms: non_neg_integer(),
           max_live_vms: non_neg_integer(),
@@ -90,7 +91,9 @@ defmodule Embervm.BrickLedger do
   @doc """
   The bricks that can currently serve a request for `size_class` needing
   `need_mib` MiB: class matches (an exact-class brick OR a wildcard/empty-class
-  brick), memory headroom covers the need, and at least one live-VM slot is free.
+  brick), memory headroom covers the workload's need PLUS the node's admission
+  floor, because a brick that clears need but not need+floor is one noded will
+  refuse, and at least one live-VM slot is free.
   Sorted by `instance_id` so the order is deterministic regardless of ETS scan
   order (the stable base `pick/4` selects over).
   """
@@ -148,10 +151,12 @@ defmodule Embervm.BrickLedger do
   end
 
   # A brick serves a request when its class matches (exact, or it is a wildcard/
-  # empty-class brick) AND it has the memory headroom AND a free live-VM slot.
+  # empty-class brick) AND its headroom covers need plus the node admission floor
+  # AND it has a free live-VM slot.
   defp serves?(brick, size_class, need_mib) do
     class_ok = brick.size_class == size_class or brick.size_class == ""
-    class_ok and brick.mem_headroom_mib >= need_mib and brick.free_slots > 0
+    required_mib = need_mib + brick.mem_reject_floor_mib
+    class_ok and brick.mem_headroom_mib >= required_mib and brick.free_slots > 0
   end
 
   # Normalize one capacity-facts map to a brick. Missing numeric facts read as 0
@@ -167,6 +172,7 @@ defmodule Embervm.BrickLedger do
       instance_id: Map.get(facts, :instance_id, ""),
       size_class: Map.get(facts, :size_class, ""),
       mem_headroom_mib: Map.get(facts, :mem_headroom_mib, 0),
+      mem_reject_floor_mib: Map.get(facts, :mem_reject_floor_mib, 0),
       mem_budget_mib: Map.get(facts, :mem_budget_mib, 0),
       live_vms: live,
       max_live_vms: max_live,

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -643,6 +643,7 @@ defmodule Embervm.NodeRegistry do
       cpu_vendor: cpu_vendor_from_status(s),
       workloads: workloads,
       mem_headroom_mib: s.mem_headroom_mib,
+      mem_reject_floor_mib: s.mem_reject_floor_mib,
       cpu_headroom_millicores: s.cpu_headroom_millicores,
       live_vms: s.live_vms,
       max_live_vms: s.max_live_vms,

--- a/projects/embervm/control/lib/embervm/placement.ex
+++ b/projects/embervm/control/lib/embervm/placement.ex
@@ -21,7 +21,9 @@ defmodule Embervm.Placement do
       headroom it reports (a zero-budget wildcard reports `mem_headroom_mib = 0`
       but can still boot the guest);
     * a CLASSED brick with a real budget is mem-eligible only when its
-      `mem_headroom_mib >= need_mib`.
+      `mem_headroom_mib >= need_mib + mem_reject_floor_mib`. The node rejects
+      on need plus its floor, so gating on need alone places workloads the node
+      refuses, forever.
 
   This is exactly the rule `Embervm.WakeInstance` encoded for the WAKE dial;
   extracting it here lets the dispatcher miss tier and the session/serving CREATE
@@ -30,9 +32,9 @@ defmodule Embervm.Placement do
 
   ## why NOT `BrickLedger.candidates/3`
 
-  `candidates/3` gates every brick on `mem_headroom_mib >= need_mib` (correct for
-  a fleet of only classed bricks, where a wildcard reports a real budget), which
-  wrongly excludes a zero-headroom wildcard. On the still-DS-only fleet the single
+  `candidates/3` gates every brick on its class and headroom, including the node
+  admission floor (correct for a fleet of only classed bricks, where a wildcard
+  reports a real budget), which wrongly excludes a zero-headroom wildcard. On the still-DS-only fleet the single
   DS instance IS a zero-budget wildcard, so gating it on headroom would deny every
   placement. Keeping the wildcard always-eligible is what makes this change INERT
   today: the sole DS brick per node is a wildcard, so it is always the (only)
@@ -66,12 +68,16 @@ defmodule Embervm.Placement do
   @doc """
   The MEMORY half of eligibility (no slot check): a wildcard brick is always
   mem-eligible; a classed brick with a real budget needs `mem_headroom_mib >=
-  need_mib`. Split out so a caller that has already applied its own slot check
+  need_mib + mem_reject_floor_mib`. The node rejects on need plus its floor, so
+  gating on need alone places workloads the node refuses, forever. Split out so
+  a caller that has already applied its own slot check
   (the dispatcher's `has_budget?`) can reuse just the memory rule.
   """
   @spec mem_eligible?(brick(), non_neg_integer()) :: boolean()
   def mem_eligible?(brick, need_mib) do
-    wildcard?(brick) or Map.get(brick, :mem_headroom_mib, 0) >= need_mib
+    wildcard?(brick) or
+      Map.get(brick, :mem_headroom_mib, 0) >=
+        need_mib + Map.get(brick, :mem_reject_floor_mib, 0)
   end
 
   @doc """

--- a/projects/embervm/control/lib/embervm/pool_manager.ex
+++ b/projects/embervm/control/lib/embervm/pool_manager.ex
@@ -239,13 +239,14 @@ defmodule Embervm.PoolManager do
       # be PRESENT holding nil, which a default never covers.
       #
       # mem_headroom_mib is the one that MUST be normalized: mem_eligible?/2 compares
-      # `mem_headroom_mib >= need_mib`, and Elixir orders atoms above numbers, so a
+      # `mem_headroom_mib >= need_mib + mem_reject_floor_mib`, and Elixir orders atoms above numbers, so a
       # nil headroom would satisfy EVERY memory need rather than none. Empty
       # size_class and zero mem_budget_mib deliberately read as the WILDCARD (the
       # legacy DaemonSet, or a brick under no cgroup limit), which is always
       # mem-eligible by design: see the Placement moduledoc.
       size_class: Map.get(facts, :size_class) || "",
       mem_headroom_mib: Map.get(facts, :mem_headroom_mib) || 0,
+      mem_reject_floor_mib: Map.get(facts, :mem_reject_floor_mib) || 0,
       mem_budget_mib: Map.get(facts, :mem_budget_mib) || 0,
       workloads: ready_workloads(state, facts)
     }

--- a/projects/embervm/control/lib/embervm/wake_instance.ex
+++ b/projects/embervm/control/lib/embervm/wake_instance.ex
@@ -468,6 +468,7 @@ defmodule Embervm.WakeInstance do
       size_class: Map.get(brick, :size_class, ""),
       free_slots: Map.get(brick, :free_slots, 0),
       mem_headroom_mib: Map.get(brick, :mem_headroom_mib, 0),
+      mem_reject_floor_mib: Map.get(brick, :mem_reject_floor_mib, 0),
       mem_budget_mib: Map.get(brick, :mem_budget_mib, 0),
       eligible: Embervm.Placement.eligible?(brick, need_mib),
       base_ready: Embervm.Placement.base_ready?(brick, workload),

--- a/projects/embervm/control/test/embervm/brick_ledger_test.exs
+++ b/projects/embervm/control/test/embervm/brick_ledger_test.exs
@@ -23,6 +23,7 @@ defmodule Embervm.BrickLedgerTest do
       instance_id: "#{node}/#{pod_uid}",
       size_class: Keyword.get(opts, :size_class, ""),
       mem_headroom_mib: Keyword.get(opts, :mem_headroom_mib, 100_000),
+      mem_reject_floor_mib: Keyword.get(opts, :mem_reject_floor_mib, 0),
       mem_budget_mib: Keyword.get(opts, :mem_budget_mib, 0),
       live_vms: Keyword.get(opts, :live_vms, 0),
       max_live_vms: Keyword.get(opts, :max_live_vms, 8),
@@ -86,6 +87,15 @@ defmodule Embervm.BrickLedgerTest do
   end
 
   describe "pick/4" do
+    test "does not pick a brick that clears need but not need plus the admission floor" do
+      table = new_table()
+      put_brick(table, node: "n", pod_uid: "small", size_class: "2gi", mem_headroom_mib: 1_933, mem_reject_floor_mib: 512, mem_budget_mib: 2_048)
+      put_brick(table, node: "n", pod_uid: "large", size_class: "2gi", mem_headroom_mib: 16_384, mem_reject_floor_mib: 512, mem_budget_mib: 16_384)
+
+      {:ok, brick} = BrickLedger.pick("2gi", 1_536, "key", table)
+      assert brick.pod_uid == "large"
+    end
+
     test "fleet_full when no brick can serve the request" do
       table = new_table()
       put_brick(table, node: "n", pod_uid: "wrong", size_class: "2gi", mem_headroom_mib: 100)

--- a/projects/embervm/control/test/embervm/placement_test.exs
+++ b/projects/embervm/control/test/embervm/placement_test.exs
@@ -19,6 +19,7 @@ defmodule Embervm.PlacementTest do
       node_id: Keyword.get(opts, :node_id, "node"),
       size_class: Keyword.get(opts, :size_class, "8gi"),
       mem_headroom_mib: Keyword.get(opts, :mem_headroom_mib, 8_000),
+      mem_reject_floor_mib: Keyword.get(opts, :mem_reject_floor_mib, 0),
       mem_budget_mib: Keyword.get(opts, :mem_budget_mib, 8_192),
       free_slots: Keyword.get(opts, :free_slots, 4),
       workloads: Keyword.get(opts, :workloads, %{})
@@ -50,9 +51,25 @@ defmodule Embervm.PlacementTest do
       assert Placement.mem_eligible?(brick(size_class: "", mem_headroom_mib: 0, mem_budget_mib: 0), 4_000)
     end
 
-    test "a classed brick needs headroom >= need" do
+    test "a classed brick needs headroom >= need plus the admission floor" do
       assert Placement.mem_eligible?(brick(mem_headroom_mib: 8_000), 4_000)
       refute Placement.mem_eligible?(brick(mem_headroom_mib: 100), 4_000)
+    end
+
+    test "rejects the semgrep-sized request when headroom clears need but not need plus floor" do
+      refute Placement.mem_eligible?(brick(mem_headroom_mib: 1_933, mem_reject_floor_mib: 512), 1_536)
+    end
+
+    test "a zero floor preserves eligibility for a classed brick" do
+      assert Placement.mem_eligible?(brick(mem_headroom_mib: 1_933, mem_reject_floor_mib: 0), 1_536)
+    end
+
+    test "accepts the exact need plus floor boundary" do
+      assert Placement.mem_eligible?(brick(mem_headroom_mib: 2_048, mem_reject_floor_mib: 512), 1_536)
+    end
+
+    test "wildcard remains eligible regardless of the admission floor" do
+      assert Placement.mem_eligible?(brick(size_class: "", mem_budget_mib: 0, mem_headroom_mib: 0, mem_reject_floor_mib: 512), 1_536)
     end
   end
 

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.295
+      targetRevision: 0.1.297
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1703,6 +1703,7 @@ func (s *Server) nodeStatus() *nodev1.NodeStatus {
 		CpuVendor:             s.cfg.CpuVendor,
 		Workloads:             caps,
 		MemHeadroomMib:        s.memHeadroom(),
+		MemRejectFloorMib:     s.memRejectFloorMib(),
 		CpuHeadroomMillicores: uint32(s.cpuHeadroom()),
 		LiveVms:               uint32(live),
 		MaxLiveVms:            uint32(maxLive),

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -1257,6 +1257,21 @@ func TestNodeStatusCarriesBudgetFields(t *testing.T) {
 	}
 }
 
+func TestNodeStatusCarriesMemRejectFloor(t *testing.T) {
+	drv := &fakeDriver{}
+	tr := &fakeTransport{}
+	client, srv := newTestServer(t, drv, tr, 8)
+	srv.cfg.MemRejectFloorMib = 512
+
+	ns, err := client.GetNodeStatus(context.Background(), &nodev1.GetNodeStatusRequest{})
+	if err != nil {
+		t.Fatalf("GetNodeStatus: %v", err)
+	}
+	if got, want := ns.GetMemRejectFloorMib(), uint64(512); got != want {
+		t.Errorf("mem_reject_floor_mib = %d, want %d", got, want)
+	}
+}
+
 // ---- R2 session verb tests -------------------------------------------------
 
 // sessionVMIDs / sessionSnapRefs extract the session facts from a NodeStatus.

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -2005,6 +2005,16 @@ message NodeStatus {
   // refreshes, rather than hard-coded 0.
   uint64 cpu_budget_millicores = 27;
 
+  // -- Admission floor fact (additive) -----------------------------------------
+  // mem_reject_floor_mib is the cushion this daemon requires ON TOP of a
+  // workload's own footprint before it will admit a boot: it rejects unless
+  // mem_headroom_mib >= need_mib + mem_reject_floor_mib (see noded's
+  // pressure predicate). The control plane MUST apply the same term when it
+  // picks a brick, or it will place a workload on a brick that structurally
+  // cannot admit it and retry forever. 0 means unknown/unset, which reads as
+  // "no floor" and is wire-compatible with a daemon that predates this field.
+  uint64 mem_reject_floor_mib = 34;
+
   // -- CPU-sku fact (PR-E, additive) -------------------------------------------
   // cpu_sku is this node's full CPU-restore identity: vendor plus the CPU
   // template in force (standing decision from the artifact-decoupling plan:


### PR DESCRIPTION
## The defect: two predicates that disagree by exactly one constant

**noded admits** (`noded/server/pressure.go`, `memPressured`):

```go
headroom >= needMib + s.memRejectFloorMib()   // floor default 512
```

**The control plane placed** (`placement.ex` `mem_eligible?/2`, `brick_ledger.ex` `serves?/3`):

```elixir
mem_headroom_mib >= need_mib                   // no floor term
```

Any workload whose need falls in the gap between those two is placed by the CP and refused by the node, forever.

## What it did in prod

`semgrep` needs 1536 MiB. A 2gi brick reports ~1933 MiB headroom:

- `1933 >= 1536` so the CP placed it
- `1933 < 2048` so the node refused it

**A 2gi brick can never admit semgrep, not even empty.** The pool retried at roughly 2.8 primes per second for over an hour:

```
Prime for semgrep on node-1/2/3 failed: RESOURCE_EXHAUSTED
  noded: pressure:mem (need 1536 MiB, floor 512 MiB)
```

`jomcgi.dev/health` served 503 throughout, attributed to `ember_semgrep` by the component reporting added in #4132.

## Why publish the floor rather than add 512 to the CP

Hardcoding the constant on the CP side would duplicate it across two languages and drift the moment anyone sets `EMBERVM_NODED_MEM_REJECT_FLOOR_MIB`, which is exactly how the divergence arose. Instead the node publishes the floor it actually enforces and the CP consumes it, so admissibility has one definition owned by the side that enforces it.

- new `NodeStatus.mem_reject_floor_mib` (field 34, additive)
- populated by noded from its own `memRejectFloorMib()`
- carried through `node_registry` -> `brick_ledger` / `pool_manager` / `wake_instance`
- applied in `Placement.mem_eligible?/2` and `BrickLedger.serves?/3`

Absent or zero reads as "no floor", so a daemon predating the field behaves exactly as today and this is wire-compatible in both directions. The wildcard branch is untouched: a zero-budget wildcard stays always-eligible.

This is the same advertise-versus-enforce divergence as #4101, which is the slot-ceiling instance of it. Refs #4101.

## Verification

`ci lint` clean. `ci test` green: 743 tests pass, plus `MIX TEST OK on the executor` for the Elixir suite.

Tests cover the boundary explicitly: headroom 1933 / need 1536 / floor 512 is not eligible (the prod case), headroom 2048 with the same need and floor is eligible (need+floor exactly equals headroom), floor 0 keeps the old behaviour, and a wildcard stays eligible regardless.

## Note for whoever merges

This and #4138 both bump the embervm chart (`0.1.297` here, `0.1.296` there). Whichever merges second will go BEHIND, and its bump should be regenerated with `bump-chart.sh` on rebase rather than hand-resolved, or the loser's bump is silently dropped and ArgoCD keeps deploying the old chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)