### PR TITLE
feat(embervm): pack VM placement onto the fullest brick instead of spreading

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.299
+version: 0.1.300

--- a/projects/embervm/control/lib/embervm/brick_ledger.ex
+++ b/projects/embervm/control/lib/embervm/brick_ledger.ex
@@ -128,7 +128,7 @@ defmodule Embervm.BrickLedger do
 
   @doc """
   Deterministically choose one entry from an ALREADY-FILTERED candidate list,
-  keyed by `key`. The head of the shared MostAllocated order is selected, with
+  keyed by `key`. The head of the shared score order is selected, with
   equal-fullness candidates rotated by the sticky hash. Returns `nil` for an
   empty list.
 

--- a/projects/embervm/control/lib/embervm/brick_ledger.ex
+++ b/projects/embervm/control/lib/embervm/brick_ledger.ex
@@ -45,6 +45,7 @@ defmodule Embervm.BrickLedger do
   """
 
   alias Embervm.NodeCapacity
+  alias Embervm.Placement.Score
 
   @typedoc """
   One brick: a dispatchable noded instance, normalized from its capacity facts to
@@ -110,10 +111,9 @@ defmodule Embervm.BrickLedger do
   MiB, keyed by `key` (the workload/session identifier). `{:ok, brick}` when a
   brick can serve it, `{:error, :fleet_full}` when none can.
 
-  Selection hashes `key` across the sorted candidate list (`:erlang.phash2/2`), so
-  the same key sticks to the same brick as long as that brick stays a candidate
-  (warmth reuse) while distinct keys spread across the available bricks. It
-  deliberately does NOT prefer the newest instance per node: preferring newest
+  Selection prefers the fullest eligible brick. The same key sticks to the same
+  brick as long as that brick stays the FULLEST eligible one; equal-fullness
+  bricks still spread by hash. It deliberately does NOT prefer the newest instance per node: preferring newest
   collapses a node that holds several bricks down to a single instance, which is
   the exact multi-brick regression the placement rewrite must avoid.
   """
@@ -128,10 +128,8 @@ defmodule Embervm.BrickLedger do
 
   @doc """
   Deterministically choose one entry from an ALREADY-FILTERED candidate list,
-  keyed by `key`. Sorts by `:instance_id` so the order is stable regardless of the
-  caller's list order, then hashes `key` across it (`:erlang.phash2/2`, always
-  0..n-1 so the index is in-bounds). Same key sticks to the same entry as long as
-  it stays a candidate; distinct keys spread across the list. Returns `nil` for an
+  keyed by `key`. The head of the shared MostAllocated order is selected, with
+  equal-fullness candidates rotated by the sticky hash. Returns `nil` for an
   empty list.
 
   This is the selection primitive `pick/4` uses after applying the class/headroom/
@@ -145,10 +143,7 @@ defmodule Embervm.BrickLedger do
   @spec choose([map()], term()) :: map() | nil
   def choose([], _key), do: nil
 
-  def choose(candidates, key) do
-    sorted = Enum.sort_by(candidates, fn c -> Map.get(c, :instance_id, "") end)
-    Enum.at(sorted, :erlang.phash2(key, length(sorted)))
-  end
+  def choose(candidates, key), do: candidates |> Score.order(key) |> List.first()
 
   # A brick serves a request when its class matches (exact, or it is a wildcard/
   # empty-class brick) AND its headroom covers need plus the node admission floor

--- a/projects/embervm/control/lib/embervm/placement.ex
+++ b/projects/embervm/control/lib/embervm/placement.ex
@@ -1,6 +1,6 @@
 defmodule Embervm.Placement do
   @moduledoc """
-  The one shared brick-eligibility predicate every NEW-placement path reasons
+  The one shared brick-eligibility predicate and packing order every NEW-placement path reasons
   about (brick co-location foundation, Step 5). Before this module the memory
   gate lived in three shapes that could drift: `Embervm.WakeInstance` had the
   correct DS-wildcard-always-eligible rule (Step 4), `Embervm.BrickLedger.candidates/3`
@@ -50,6 +50,7 @@ defmodule Embervm.Placement do
   """
 
   alias Embervm.BrickLedger
+  alias Embervm.Placement.Score
 
   @typedoc "A brick or capacity-fact map carrying at least the fields the rule reads."
   @type brick :: map()
@@ -130,10 +131,9 @@ defmodule Embervm.Placement do
   defp base_state_ready?(_), do: false
 
   @doc """
-  Filter `bricks` to those `eligible?/2` for `need_mib`, then deterministically
-  pick one keyed by `key` (`BrickLedger.choose/2`: sorted by `instance_id`,
-  hashed on the key, so the same key sticks and distinct keys spread across the
-  eligible bricks). Returns the chosen brick map or `nil` when none is eligible.
+  Filter `bricks` to those `eligible?/2` for `need_mib`, then pick the fullest
+  eligible brick with sticky equal-fullness tie-breaking. Returns the chosen
+  brick map or `nil` when none is eligible.
   The NEW-placement primitive the wake cold pick and the session create pick
   share.
   """
@@ -146,8 +146,8 @@ defmodule Embervm.Placement do
 
   @doc """
   The COLD NEW-placement primitive: filter `bricks` to those `eligible?/2` for
-  `need_mib` AND `base_ready?/2` for `workload` (`workload` is also the sticky
-  `key`), then deterministically pick one via `BrickLedger.choose/2`. Returns the
+  `need_mib` AND `base_ready?/2` for `workload`, then pick the fullest via
+  `BrickLedger.choose/2`. Returns the
   chosen brick or `nil` when no brick is BOTH eligible and base-ready.
 
   This is the wake cold pick's primitive. It adds the co-location READINESS gate on
@@ -173,7 +173,7 @@ defmodule Embervm.Placement do
   @doc """
   The ORDERED cold-placement candidate list `pick_ready/3` chooses one from: the
   bricks that are BOTH `eligible?/2` for `need_mib` AND `base_ready?/2` for
-  `workload`, sorted deterministically by the same `BrickLedger.choose/2` key
+  `workload`, sorted by the same `BrickLedger.choose/2` key
   (`workload`) so the FIRST element is exactly what `pick_ready/3` would return and
   the tail is the reject/retry frontier (ADR embervm/014 decision 3).
 
@@ -189,7 +189,7 @@ defmodule Embervm.Placement do
   def candidates_ready(bricks, workload, need_mib) do
     bricks
     |> ready_candidates(workload, need_mib)
-    |> sort_by_choose_key(workload)
+    |> Score.order(workload)
   end
 
   # The shared eligible + base-ready filter both pick_ready/3 and candidates_ready/3
@@ -199,16 +199,4 @@ defmodule Embervm.Placement do
     Enum.filter(bricks, fn brick -> eligible?(brick, need_mib) and base_ready?(brick, workload) end)
   end
 
-  # Order the candidate list the SAME way BrickLedger.choose/2 would traverse it:
-  # sorted by :instance_id, then rotated so the choose/2-selected brick is first and
-  # the deterministic sticky order continues from there. This makes candidates_ready/3
-  # head == pick_ready/3 result, and the tail the natural next-candidate sequence.
-  defp sort_by_choose_key([], _key), do: []
-
-  defp sort_by_choose_key(candidates, key) do
-    sorted = Enum.sort_by(candidates, fn c -> Map.get(c, :instance_id, "") end)
-    idx = :erlang.phash2(key, length(sorted))
-    {head, tail} = Enum.split(sorted, idx)
-    tail ++ head
-  end
 end

--- a/projects/embervm/control/lib/embervm/placement/score.ex
+++ b/projects/embervm/control/lib/embervm/placement/score.ex
@@ -1,39 +1,49 @@
 defmodule Embervm.Placement.Score do
   @moduledoc """
-  MostAllocated scoring and deterministic brick ordering.
+  Brick placement scoring and deterministic ordering: the single ordering
+  primitive every placement path shares.
   """
 
   @doc """
-  Score a brick by its fullness. Higher score = fuller = preferred. This is
-  k8s's MostAllocated plugin (equal weight per resource), which is the prior
-  art ADR 016 section 4 cites.
+  Score a brick for placement. Two policies, one comparable scale.
 
-  A wildcard is the burst envelope (ADR 013): scored last so classed bricks
-  pack first and the wildcard only absorbs what nothing classed can hold.
+  Classed bricks are reclaimable (an empty one is the unit of reclaim, ADR
+  embervm/016 section 4) and have a real budget, so they PACK: k8s MostAllocated,
+  `(slot_ratio + mem_ratio) / 2`, range [0.0, 1.0], higher = fuller = preferred.
 
+  Wildcards (empty `size_class`, or an unreadable cgroup reporting zero budget)
+  are neither reclaimable nor measurable, so they SPREAD: k8s LeastAllocated,
+  `-1.0 - slot_ratio`, range [-2.0, -1.0], higher = emptier = preferred. That
+  keeps every wildcard below every classed brick while spreading among
+  themselves. Packing them would concentrate a workload onto one arbitrary brick
+  with the memory gate disabled (`Placement.mem_eligible?/2` short-circuits true
+  for a wildcard) for none of the reclaim benefit that justifies packing.
+
+  `slot_ratio` is an exact count and is the only signal trusted for wildcards.
   `mem_ratio` is derived from OBSERVED cgroup headroom, which lags: memory.max
   and memory.current are read separately and a just-restored Firecracker guest
-  faults its pages in lazily. The clamp exists for that race. Issue #4140
-  Phase B replaces this term with a reserved/allocatable reservation ledger.
-  Do not try to fix the lag here.
+  faults its pages in lazily. The clamp exists for that race. Issue #4140 Phase B
+  replaces that term with a reserved/allocatable reservation ledger, so do not
+  try to fix the lag here.
   """
-  @spec most_allocated(map()) :: float()
-  def most_allocated(brick) do
+  @spec score(map()) :: float()
+  def score(brick) do
+    max_live = Map.get(brick, :max_live_vms, 0)
+    live = Map.get(brick, :live_vms, 0)
+    slot_ratio = if max_live == 0, do: 0.0, else: live / max_live
+
     if Embervm.Placement.wildcard?(brick) do
-      -1.0
+      -1.0 - slot_ratio
     else
-      max_live = Map.get(brick, :max_live_vms, 0)
-      live = Map.get(brick, :live_vms, 0)
       budget = Map.get(brick, :mem_budget_mib, 0)
       headroom = Map.get(brick, :mem_headroom_mib, 0)
-      slot_ratio = if max_live == 0, do: 0.0, else: live / max_live
       mem_ratio = ((budget - headroom) / budget) |> clamp(0.0, 1.0)
       (slot_ratio + mem_ratio) / 2.0
     end
   end
 
   @doc """
-  Order candidates by MostAllocated score with sticky tie-breaking.
+  Order candidates by score with sticky tie-breaking.
   """
   @spec order([map()], term()) :: [map()]
   def order([], _key), do: []
@@ -51,7 +61,7 @@ defmodule Embervm.Placement.Score do
     rotated ++ Enum.flat_map(rest, fn {_score, items} -> Enum.sort_by(items, &Map.get(&1, :instance_id, "")) end)
   end
 
-  defp rounded_score(brick), do: Float.round(most_allocated(brick), 3)
+  defp rounded_score(brick), do: Float.round(score(brick), 3)
 
   defp rotate(items, 0), do: items
   defp rotate(items, offset) do

--- a/projects/embervm/control/lib/embervm/placement/score.ex
+++ b/projects/embervm/control/lib/embervm/placement/score.ex
@@ -1,0 +1,63 @@
+defmodule Embervm.Placement.Score do
+  @moduledoc """
+  MostAllocated scoring and deterministic brick ordering.
+  """
+
+  @doc """
+  Score a brick by its fullness. Higher score = fuller = preferred. This is
+  k8s's MostAllocated plugin (equal weight per resource), which is the prior
+  art ADR 016 section 4 cites.
+
+  A wildcard is the burst envelope (ADR 013): scored last so classed bricks
+  pack first and the wildcard only absorbs what nothing classed can hold.
+
+  `mem_ratio` is derived from OBSERVED cgroup headroom, which lags: memory.max
+  and memory.current are read separately and a just-restored Firecracker guest
+  faults its pages in lazily. The clamp exists for that race. Issue #4140
+  Phase B replaces this term with a reserved/allocatable reservation ledger.
+  Do not try to fix the lag here.
+  """
+  @spec most_allocated(map()) :: float()
+  def most_allocated(brick) do
+    if Embervm.Placement.wildcard?(brick) do
+      -1.0
+    else
+      max_live = Map.get(brick, :max_live_vms, 0)
+      live = Map.get(brick, :live_vms, 0)
+      budget = Map.get(brick, :mem_budget_mib, 0)
+      headroom = Map.get(brick, :mem_headroom_mib, 0)
+      slot_ratio = if max_live == 0, do: 0.0, else: live / max_live
+      mem_ratio = ((budget - headroom) / budget) |> clamp(0.0, 1.0)
+      (slot_ratio + mem_ratio) / 2.0
+    end
+  end
+
+  @doc """
+  Order candidates by MostAllocated score with sticky tie-breaking.
+  """
+  @spec order([map()], term()) :: [map()]
+  def order([], _key), do: []
+
+  def order(candidates, key) do
+    candidates
+    |> Enum.group_by(&rounded_score/1)
+    |> Enum.sort_by(&elem(&1, 0), :desc)
+    |> order_groups(key)
+  end
+
+  defp order_groups([{_score, group} | rest], key) do
+    leading = Enum.sort_by(group, &Map.get(&1, :instance_id, ""))
+    rotated = rotate(leading, :erlang.phash2(key, length(leading)))
+    rotated ++ Enum.flat_map(rest, fn {_score, items} -> Enum.sort_by(items, &Map.get(&1, :instance_id, "")) end)
+  end
+
+  defp rounded_score(brick), do: Float.round(most_allocated(brick), 3)
+
+  defp rotate(items, 0), do: items
+  defp rotate(items, offset) do
+    {head, tail} = Enum.split(items, offset)
+    tail ++ head
+  end
+
+  defp clamp(value, low, high), do: value |> max(low) |> min(high)
+end

--- a/projects/embervm/control/lib/embervm/pool_manager.ex
+++ b/projects/embervm/control/lib/embervm/pool_manager.ex
@@ -375,7 +375,11 @@ defmodule Embervm.PoolManager do
   # to hold within the pass and not just across ticks.
   defp consume(instance, wl) do
     need = instance.workloads[wl].mem_mib || 0
-    %{instance | budget: instance.budget - 1, mem_headroom_mib: max(0, instance.mem_headroom_mib - need)}
+    %{instance |
+      budget: instance.budget - 1,
+      live_vms: instance.live_vms + 1,
+      mem_headroom_mib: max(0, instance.mem_headroom_mib - need)
+    }
   end
 
   # A wildcard brick satisfies any need, so this only ever binds on a classed one.

--- a/projects/embervm/control/lib/embervm/pool_manager.ex
+++ b/projects/embervm/control/lib/embervm/pool_manager.ex
@@ -26,9 +26,9 @@ defmodule Embervm.PoolManager do
   the surplus phase only ever spends what is left after every floor is funded.
   That is the floor-isolation property the acceptance test asserts.
 
-  Primes are spread round-robin across eligible instances to prevent
-  concentration and allow autoscaling. Instances must also satisfy the
-  workload's memory need according to `Embervm.Placement.mem_eligible?/2`.
+  Primes prefer the fullest eligible instance so load concentrates and empty
+  bricks can drain. Instances must also satisfy the workload's memory need
+  according to `Embervm.Placement.mem_eligible?/2`.
 
   ## backpressure
 
@@ -232,6 +232,7 @@ defmodule Embervm.PoolManager do
     budget = max(0, Map.get(facts, :max_live_vms, 0) - Map.get(facts, :live_vms, 0) - node_inflight)
     %{
       node_id: node_id,
+      instance_id: node_id,
       budget: budget,
       # Normalized exactly as `Embervm.BrickLedger.to_brick/1` does, so the shared
       # `Placement.mem_eligible?/2` predicate reads the same shape here as on every
@@ -248,6 +249,8 @@ defmodule Embervm.PoolManager do
       mem_headroom_mib: Map.get(facts, :mem_headroom_mib) || 0,
       mem_reject_floor_mib: Map.get(facts, :mem_reject_floor_mib) || 0,
       mem_budget_mib: Map.get(facts, :mem_budget_mib) || 0,
+      live_vms: Map.get(facts, :live_vms) || 0,
+      max_live_vms: Map.get(facts, :max_live_vms) || 0,
       workloads: ready_workloads(state, facts)
     }
   end
@@ -316,46 +319,46 @@ defmodule Embervm.PoolManager do
 
   defp allocate_phase(demands, instances, budget, plan) do
     keys = demands |> Enum.filter(fn {_wl, n} -> n > 0 end) |> Enum.map(&elem(&1, 0))
-    allocate_phase_round(keys, demands, instances, budget, plan, %{})
+    allocate_phase_round(keys, demands, instances, budget, plan)
   end
 
-  defp allocate_phase_round(_keys, _demands, instances, budget, plan, _cursors) when budget <= 0,
+  defp allocate_phase_round(_keys, _demands, instances, budget, plan) when budget <= 0,
     do: {plan, instances, 0}
 
-  defp allocate_phase_round(keys, demands, instances, budget, plan, cursors) do
-    {plan, instances, budget, cursors, granted} =
-      Enum.reduce(keys, {plan, instances, budget, cursors, false}, fn wl, {p, is, b, cs, g} ->
+  defp allocate_phase_round(keys, demands, instances, budget, plan) do
+    {plan, instances, budget, granted} =
+      Enum.reduce(keys, {plan, instances, budget, false}, fn wl, {p, is, b, g} ->
         allocated = p |> Enum.filter(fn {{_node, key}, _n} -> key == wl end) |> Enum.map(&elem(&1, 1)) |> Enum.sum()
 
         if allocated >= Map.get(demands, wl, 0) or b <= 0 do
-          {p, is, b, cs, g}
+          {p, is, b, g}
         else
-          case place_one(is, wl, Map.get(cs, wl, 0)) do
-            :none -> {p, is, b, cs, g}
+          case place_one(is, wl) do
+            :none -> {p, is, b, g}
             {index, next} ->
               node_id = Enum.at(next, index).node_id
-              {Map.update(p, {node_id, wl}, 1, &(&1 + 1)), next, b - 1, Map.put(cs, wl, index + 1), true}
+              {Map.update(p, {node_id, wl}, 1, &(&1 + 1)), next, b - 1, true}
           end
         end
       end)
 
-    if granted and budget > 0, do: allocate_phase_round(keys, demands, instances, budget, plan, cursors), else: {plan, instances, budget}
+    if granted and budget > 0, do: allocate_phase_round(keys, demands, instances, budget, plan), else: {plan, instances, budget}
   end
 
-  defp place_one([], _wl, _cursor), do: :none
-  defp place_one(instances, wl, cursor) do
-    count = length(instances)
-    candidates = for offset <- 0..(count - 1), do: rem(cursor + offset, count)
+  defp place_one([], _wl), do: :none
+  defp place_one(instances, wl) do
+    candidates =
+      Enum.filter(instances, fn instance ->
+        instance.budget > 0 and Map.has_key?(instance.workloads, wl) and
+          memory_eligible?(instance, wl)
+      end)
 
-    case Enum.find(candidates, fn i ->
-           instance = Enum.at(instances, i)
-           instance.budget > 0 and Map.has_key?(instance.workloads, wl) and
-             memory_eligible?(instance, wl)
-         end) do
-      nil ->
+    case Embervm.Placement.Score.order(candidates, wl) do
+      [] ->
         :none
 
-      index ->
+      [selected | _] ->
+        index = Enum.find_index(instances, &(&1.instance_id == selected.instance_id))
         {index, List.update_at(instances, index, &consume(&1, wl))}
     end
   end

--- a/projects/embervm/control/test/embervm/brick_ledger_test.exs
+++ b/projects/embervm/control/test/embervm/brick_ledger_test.exs
@@ -156,5 +156,29 @@ defmodule Embervm.BrickLedgerTest do
       chosen = for k <- 1..60, do: BrickLedger.choose(cands, "wl-#{k}").instance_id
       assert chosen |> Enum.uniq() |> length() > 1
     end
+
+    test "chooses the fuller classed brick by headroom" do
+      table = new_table()
+      put_brick(table, node: "n", pod_uid: "full", size_class: "8gi", mem_headroom_mib: 2_000, mem_budget_mib: 8_192)
+      put_brick(table, node: "n", pod_uid: "empty", size_class: "8gi", mem_headroom_mib: 8_000, mem_budget_mib: 8_192)
+
+      assert BrickLedger.choose(BrickLedger.candidates("8gi", 1_000, table), "wl").pod_uid == "full"
+    end
+
+    test "chooses the fuller classed brick by live VM count" do
+      table = new_table()
+      put_brick(table, node: "n", pod_uid: "full", size_class: "8gi", live_vms: 6, max_live_vms: 8, mem_headroom_mib: 8_000, mem_budget_mib: 8_192)
+      put_brick(table, node: "n", pod_uid: "empty", size_class: "8gi", live_vms: 1, max_live_vms: 8, mem_headroom_mib: 8_000, mem_budget_mib: 8_192)
+
+      assert BrickLedger.choose(BrickLedger.candidates("8gi", 1_000, table), "wl").pod_uid == "full"
+    end
+
+    test "prefers a classed brick over a wildcard" do
+      table = new_table()
+      put_brick(table, node: "n", pod_uid: "wild", size_class: "", mem_headroom_mib: 8_000, mem_budget_mib: 0)
+      put_brick(table, node: "n", pod_uid: "classed", size_class: "8gi", mem_headroom_mib: 8_000, mem_budget_mib: 8_192)
+
+      assert BrickLedger.choose(BrickLedger.candidates("8gi", 1_000, table), "wl").pod_uid == "classed"
+    end
   end
 end

--- a/projects/embervm/control/test/embervm/placement/score_test.exs
+++ b/projects/embervm/control/test/embervm/placement/score_test.exs
@@ -1,0 +1,59 @@
+defmodule Embervm.Placement.ScoreTest do
+  use ExUnit.Case, async: true
+
+  alias Embervm.BrickLedger
+  alias Embervm.Placement.Score
+
+  defp brick(opts \\ []) do
+    %{
+      instance_id: Keyword.get(opts, :instance_id, "node/pod"),
+      size_class: Keyword.get(opts, :size_class, "8gi"),
+      mem_headroom_mib: Keyword.get(opts, :mem_headroom_mib, 4_096),
+      mem_budget_mib: Keyword.get(opts, :mem_budget_mib, 8_192),
+      live_vms: Keyword.get(opts, :live_vms, 2),
+      max_live_vms: Keyword.get(opts, :max_live_vms, 4)
+    }
+  end
+
+  test "wildcards score last" do
+    assert Score.most_allocated(brick(size_class: "")) == -1.0
+    assert Score.most_allocated(brick(mem_budget_mib: 0)) == -1.0
+  end
+
+  test "classed fullness scores from empty to full" do
+    assert Score.most_allocated(brick(mem_headroom_mib: 8_192, live_vms: 0)) == 0.0
+    assert Score.most_allocated(brick(mem_headroom_mib: 0, live_vms: 4)) == 1.0
+    assert_in_delta Score.most_allocated(brick(mem_headroom_mib: 4_096, live_vms: 2)), 0.5, 0.0001
+  end
+
+  test "headroom race is clamped" do
+    assert Score.most_allocated(brick(mem_headroom_mib: 16_384, live_vms: 0)) == 0.0
+  end
+
+  test "order prefers fuller classed bricks and classed bricks over wildcards" do
+    full = brick(instance_id: "full", mem_headroom_mib: 1_000, live_vms: 4)
+    empty = brick(instance_id: "empty", mem_headroom_mib: 8_192, live_vms: 0)
+    wildcard = brick(instance_id: "wild", size_class: "", mem_headroom_mib: 0)
+
+    assert [full, empty, wildcard] == Score.order([wildcard, empty, full], "key")
+  end
+
+  test "order head equals BrickLedger.choose/2" do
+    candidates = [brick(instance_id: "a"), brick(instance_id: "b", live_vms: 4)]
+    assert List.first(Score.order(candidates, "wl")) == BrickLedger.choose(candidates, "wl")
+  end
+
+  test "order is a permutation" do
+    candidates = for id <- ~w(a b c d), do: brick(instance_id: id, live_vms: String.to_integer(id, 36) - 10)
+    ordered = Score.order(candidates, "wl")
+    assert Enum.sort(Enum.map(ordered, & &1.instance_id)) == Enum.sort(Enum.map(candidates, & &1.instance_id))
+    assert length(ordered) == length(Enum.uniq_by(ordered, & &1.instance_id))
+  end
+
+  test "order breaks ties by instance_id rather than input order" do
+    first = brick(instance_id: "a")
+    second = brick(instance_id: "b")
+
+    assert Score.order([first, second], "wl") == Score.order([second, first], "wl")
+  end
+end

--- a/projects/embervm/control/test/embervm/placement/score_test.exs
+++ b/projects/embervm/control/test/embervm/placement/score_test.exs
@@ -16,18 +16,39 @@ defmodule Embervm.Placement.ScoreTest do
   end
 
   test "wildcards score last" do
-    assert Score.most_allocated(brick(size_class: "")) == -1.0
-    assert Score.most_allocated(brick(mem_budget_mib: 0)) == -1.0
+    assert Score.score(brick(size_class: "", live_vms: 0)) == -1.0
+    assert Score.score(brick(mem_budget_mib: 0, live_vms: 0)) == -1.0
   end
 
   test "classed fullness scores from empty to full" do
-    assert Score.most_allocated(brick(mem_headroom_mib: 8_192, live_vms: 0)) == 0.0
-    assert Score.most_allocated(brick(mem_headroom_mib: 0, live_vms: 4)) == 1.0
-    assert_in_delta Score.most_allocated(brick(mem_headroom_mib: 4_096, live_vms: 2)), 0.5, 0.0001
+    assert Score.score(brick(mem_headroom_mib: 8_192, live_vms: 0)) == 0.0
+    assert Score.score(brick(mem_headroom_mib: 0, live_vms: 4)) == 1.0
+    assert_in_delta Score.score(brick(mem_headroom_mib: 4_096, live_vms: 2)), 0.5, 0.0001
   end
 
   test "headroom race is clamped" do
-    assert Score.most_allocated(brick(mem_headroom_mib: 16_384, live_vms: 0)) == 0.0
+    assert Score.score(brick(mem_headroom_mib: 16_384, live_vms: 0)) == 0.0
+  end
+
+  test "emptier wildcards score ahead of fuller wildcards" do
+    emptier = brick(instance_id: "empty", size_class: "", live_vms: 1)
+    fuller = brick(instance_id: "full", size_class: "", live_vms: 3)
+
+    assert Score.score(emptier) > Score.score(fuller)
+    assert [emptier, fuller] == Score.order([fuller, emptier], "key")
+  end
+
+  test "wildcards score behind every classed brick, including a full one" do
+    full = brick(instance_id: "full", mem_headroom_mib: 0, live_vms: 4)
+    wildcard = brick(instance_id: "wild", size_class: "", live_vms: 0)
+
+    assert Score.score(full) == 1.0
+    assert Score.score(wildcard) == -1.0
+    assert [full, wildcard] == Score.order([wildcard, full], "key")
+  end
+
+  test "wildcard with no live-VM capacity scores -1.0" do
+    assert Score.score(brick(size_class: "", max_live_vms: 0, live_vms: 0)) == -1.0
   end
 
   test "order prefers fuller classed bricks and classed bricks over wildcards" do

--- a/projects/embervm/control/test/embervm/placement_test.exs
+++ b/projects/embervm/control/test/embervm/placement_test.exs
@@ -250,5 +250,14 @@ defmodule Embervm.PlacementTest do
       assert Enum.sort(frontier_ids) == ["n/a", "n/b", "n/c"]
       assert length(frontier_ids) == length(Enum.uniq(frontier_ids))
     end
+
+    test "HEAD == pick_ready/3 when ready bricks differ in fullness" do
+      fuller = brick(instance_id: "n/full", mem_headroom_mib: 2_000, mem_budget_mib: 8_192, workloads: advertising("wl"))
+      emptier = brick(instance_id: "n/empty", mem_headroom_mib: 8_000, mem_budget_mib: 8_192, workloads: advertising("wl"))
+
+      [head | _] = Placement.candidates_ready([emptier, fuller], "wl", 1_000)
+      assert head.instance_id == Placement.pick_ready([emptier, fuller], "wl", 1_000).instance_id
+      assert head.instance_id == "n/full"
+    end
   end
 end

--- a/projects/embervm/control/test/embervm/pool_manager_test.exs
+++ b/projects/embervm/control/test/embervm/pool_manager_test.exs
@@ -226,7 +226,7 @@ defmodule Embervm.PoolManagerTest do
     assert Agent.get(ctx.status, & &1) == writes1
   end
 
-  test "fleet-wide floor packs four total onto one of two equal wildcard instances" do
+  test "fleet-wide floor spreads four total across two equal wildcard instances" do
     parent = self()
     ctx = start_pool(channel_fun: fn node -> {:ok, node} end,
       prime_fun: fn node, %PrimeRequest{trace: %Trace{workload: wl}} ->
@@ -239,8 +239,7 @@ defmodule Embervm.PoolManagerTest do
 
     :ok = PoolManager.refill(ctx.pool)
     primes = for _ <- 1..4, do: (receive do {:prime, node, "wl-a"} -> node end)
-    assert primes |> Enum.uniq() |> length() == 1
-    assert length(primes) == 4
+    assert Enum.frequencies(primes) == %{"i-1" => 2, "i-2" => 2}
   end
 
   test "packs primes onto the fuller instance until its memory makes it ineligible" do

--- a/projects/embervm/control/test/embervm/pool_manager_test.exs
+++ b/projects/embervm/control/test/embervm/pool_manager_test.exs
@@ -226,7 +226,7 @@ defmodule Embervm.PoolManagerTest do
     assert Agent.get(ctx.status, & &1) == writes1
   end
 
-  test "fleet-wide floor primes four total across two instances" do
+  test "fleet-wide floor packs four total onto one of two equal wildcard instances" do
     parent = self()
     ctx = start_pool(channel_fun: fn node -> {:ok, node} end,
       prime_fun: fn node, %PrimeRequest{trace: %Trace{workload: wl}} ->
@@ -239,7 +239,25 @@ defmodule Embervm.PoolManagerTest do
 
     :ok = PoolManager.refill(ctx.pool)
     primes = for _ <- 1..4, do: (receive do {:prime, node, "wl-a"} -> node end)
-    assert Enum.frequencies(primes) == %{"i-1" => 2, "i-2" => 2}
+    assert primes |> Enum.uniq() |> length() == 1
+    assert length(primes) == 4
+  end
+
+  test "packs primes onto the fuller instance until its memory makes it ineligible" do
+    parent = self()
+    ctx = start_pool(channel_fun: fn node -> {:ok, node} end,
+      prime_fun: fn node, %PrimeRequest{trace: %Trace{workload: wl}} ->
+        send(parent, {:prime, node, wl})
+        {:ok, %PrimeResponse{vm_id: "vm-#{System.unique_integer([:positive])}"}}
+      end)
+
+    put_catalog(ctx, "wl-a", 3, resources: %{"memMib" => 2_048})
+    put_instance_facts(ctx, "full", [{"wl-a", 0}], max: 5, live: 1, mem_budget_mib: 8_192, mem_headroom_mib: 2_048, size_class: "8gi")
+    put_instance_facts(ctx, "empty", [{"wl-a", 0}], max: 5, live: 0, mem_budget_mib: 8_192, mem_headroom_mib: 8_192, size_class: "8gi")
+
+    :ok = PoolManager.refill(ctx.pool)
+    primes = for _ <- 1..3, do: (receive do {:prime, node, "wl-a"} -> node end)
+    assert Enum.frequencies(primes) == %{"full" => 1, "empty" => 2}
   end
 
   test "a third instance does not multiply an existing fleet floor" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.299
+      targetRevision: 0.1.300
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Phase A2/A3 of #4140. Replaces uniform-spread VM placement with MostAllocated
bin-packing, so bricks concentrate load and can actually reach `live_vms == 0`.

## The defect: we shipped the alternative our own ADR rejected

ADR embervm/016 section 4 specifies the packing policy, and ARCHITECTURE.md
section 7 repeats it as built behaviour:

> The CP's score function bin-packs toward empty bricks. Among bricks passing
> filters, placement prefers the fullest viable brick, so load concentrates and
> idle bricks drain to empty. An empty brick is the unit of reclaim.

There is no score function. `grep score` over `control/lib/` returned nothing.
Selection was `BrickLedger.choose/2` (`phash2(key, len)` into a sorted list),
two copies of `rendezvous_pick` (highest-random-weight), and `PoolManager`'s
round-robin cursor. All of those distribute uniformly. That is a spread policy,
and ADR 016's Alternatives table rejects it by name:

> Spread-scoring VM placement for resilience. Rejected because: inverts reclaim:
> no brick ever empties, EmberPool cannot shrink, consolidation never fires.

That prediction came true. `brick_controller.ex` `pick_victim` requires a brick
with `live_vms == 0`, spread means bricks rarely reach zero, so scale-down can
never find a safe victim. ARCHITECTURE.md records brick autoscale stuck at rung
`up` with scale-down "observe-only" and promoting to `full` as "the remaining
rung". It was not waiting on soak. It was waiting on this.

## What changed

**New `Embervm.Placement.Score`** with the k8s MostAllocated formula (equal
weight per resource, the prior art ADR 016 cites):

```
wildcard (empty size_class OR zero budget) -> -1.0, sorts last
otherwise: (live_vms/max_live_vms + (budget-headroom)/budget) / 2
```

Ties are bucketed at 3 decimal places (so float jitter cannot invent an ordering
between bricks that are effectively equally full) and broken by the existing
sticky `phash2`, preserving warmth reuse.

**One ordering primitive.** `Score.order/2` is now the only place placement order
is defined. `BrickLedger.choose/2` becomes `order(...) |> List.first()`, and
`Placement.sort_by_choose_key/2` is deleted. Those two previously maintained the
same ordering in parallel, kept in sync by a comment asserting "head == choose
result". Making one a projection of the other removes a drift seam rather than
documenting it, which is the same class of defect #4140 is about one level down.

**`PoolManager` round-robin removed.** `place_one/3` selected by rotating a cursor
and taking the first eligible instance; it now takes the highest-scoring one. The
cursor plumbing threaded through `allocate_phase_round/6` is deleted. The existing
`consume/2` debit (a slot plus the workload's memory, within the pass) is
unchanged and now makes packing self-reinforcing inside one tick.

**`PoolManager` instances now carry `instance_id`.** They had `node_id` only, so
`Score.order/2`'s tie-break read `""` for every instance, the sort collapsed to a
no-op, and equal-score ordering fell through to ETS scan order (nondeterministic
between ticks). The comment above that map already claimed it was "normalized
exactly as `BrickLedger.to_brick/1` does", which carries `instance_id`; this makes
the claim true.

## Two policies, because packing is only justified where it buys something

An intermediate version of this PR packed **everything**, including wildcard
bricks (empty `size_class`, or an unreadable cgroup reporting zero budget). That
was wrong and the second commit reverses it.

A wildcard has **no fullness signal**: every one scores identically, so they tie,
the hash pins a workload to one of them, and `Placement.mem_eligible?/2`
short-circuits to `true` for a wildcard regardless of headroom, so nothing ever
dislodges it on memory. The only brake left is its slot count. That is not
packing, it is concentrating a workload onto one arbitrary brick with the memory
gate switched off.

The justification does not survive either. MostAllocated exists to make bricks
reclaimable (`brick_controller.ex` `pick_victim` needs `live_vms == 0`), and a
wildcard is never a reclaim target: it is the legacy DaemonSet, one per node, or
a fault condition. So packing them took the concentration risk for none of the
benefit that motivates packing at all.

So the policy follows what each tier is for, on one comparable scale:

| Tier | Reclaimable? | Signal? | Policy | Range |
| --- | --- | --- | --- | --- |
| Classed brick | yes, that is the point | `mem_budget_mib` | **MostAllocated** (pack) | `[0.0, 1.0]` |
| Wildcard | no | none | **LeastAllocated** (spread) | `[-2.0, -1.0]` |

Wildcards stay strictly below every classed brick, exactly as before, while the
emptiest wins among themselves. k8s ships both plugins and `LeastAllocated` is
its scheduler default; MostAllocated is the consolidation-oriented one.

Doing it by score rather than by restoring the cursor keeps it **stateless**:
`consume/2` already decrements within a refill pass, so consecutive placements
alternate naturally. The `pool_manager` test therefore goes back to asserting the
original 2/2 split.

## Latent bug this exposed

`PoolManager.consume/2` advanced `budget` and `mem_headroom_mib` but **never
`live_vms`**. Making wildcards spread required it, and it turns out the classed
path needed it too: the MostAllocated `slot_ratio` term was frozen within a
refill pass, so packing was running on the memory term alone. Fixed in the same
commit.

## Tests

The two existing spread assertions are **unchanged and still pass**, which is the
tie-path regression guard: `brick_ledger_test.exs:104`'s bricks default to
`mem_budget_mib: 0` (wildcards) and `placement_test.exs:94`'s two bricks are
identical at 8000/8192, so both tie and fall through to the same hash as before.
Packing degenerates to today's behaviour exactly where there is nothing to pack
toward.

Added: `Score` unit tests (wildcard, empty, full, half, the headroom>budget read
race, classed-before-wildcard, order-is-a-permutation, tie order independent of
input order), ledger tests for preferring the fuller brick by headroom and by
`live_vms`, a `candidates_ready/3` head == `pick_ready/3` invariant test under
differing fullness, and a pool test that primes concentrate until `consume/2`
makes the fuller instance ineligible.

## Verification

`ci lint` clean on all 8 files. `ci test`:

```
MIX TEST OK on the executor
1029 tests, 0 failures, 6 skipped     <- the control suite (mix_test_smoke genrule)
Executed 2 out of 743 tests: 743 tests pass.
```

The count moving 1026 -> 1029 is the confirmation that the new tests actually
registered and ran, rather than being written and silently skipped.

Worth recording how that second line lies here, because it cost a round trip.
`Executed N out of M tests` counts **bazel test targets**, and the EmberVM
control-plane Elixir suite is not one: it runs inside
`//bazel/erlang:mix_test_smoke`, a genrule that shells out to `mix test` and
fails the build if the suite fails. Genrules never appear in that line. So a
green `Executed 743 out of 743` says nothing at all about 1,026 Elixir test
cases, and `--nocache_test_results` does not help either since it only forces
test targets.

On a cached run the genrule prints no ExUnit output whatsoever, so the visible
`16 tests, 0 failures` is a different target (the release boot smoke) and is
easy to mistake for the suite. The reliable lever is that the genrule takes
`//projects/embervm/control:srcs` (globbed) as an input and is tagged
`no-remote-cache`, so any edit under `control/` forces a genuine re-execution.
The `1026 tests` line above is from such a forced run, not a cache hit.

## Out of scope

- `SessionPlacement` / `ServingPlacement` / `StatefulManager` keep their
  node-scoped `rendezvous_pick` copies. They are single-node in practice and get
  collapsed in Phase B alongside #4011, where they stop being separate modules.
- Promoting brick autoscale scale-down from `observe` to acting is the next PR,
  deliberately separate so a misbehaviour is attributable to one change.
- The observed-usage lag in `mem_ratio` is Phase B's reservation ledger, not a
  bug to fix here.
