### PR TITLE
fix(embervm): assert expiry directly instead of polling for it

### DIFF
--- a/bazel/erlang/mix_test.sh
+++ b/bazel/erlang/mix_test.sh
@@ -138,11 +138,28 @@ cd "$work/control"
 # exqlite.app"). --no-deps-check keeps mix from auditing against a (nonexistent)
 # lock or reaching hex.
 mix deps.compile --no-deps-check >&2
-if mix test --no-deps-check >"$out" 2>&1; then
+# EXUNIT_SEED replays a specific run's test ordering. ExUnit prints the seed it chose
+# ("Running ExUnit with seed: N"), but without this there was no way to feed one back,
+# so a captured seed from a failing CI run could not be replayed (#4078). Note a seed
+# only reproduces an ordering against the SAME test corpus: adding or removing a test
+# changes the permutation that seed yields, which is why the commit is echoed with it.
+seed_args=""
+if [ -n "${EXUNIT_SEED:-}" ]; then
+	seed_args="--seed ${EXUNIT_SEED}"
+	echo "MIX TEST replaying with EXUNIT_SEED=${EXUNIT_SEED}" >&2
+fi
+
+if mix test --no-deps-check $seed_args >"$out" 2>&1; then
 	echo "MIX TEST OK on the executor" >&2
 	cat "$out" >&2
 else
 	echo "MIX TEST FAILED on the executor:" >&2
 	cat "$out" >&2
+	# Reproduction recipe on one line, otherwise buried in thousands. The seed alone is
+	# NOT enough: ExUnit shuffles the actual test list, so the same seed over a different
+	# corpus yields a different ordering and silently fails to reproduce. The test count
+	# is a cheap corpus fingerprint (the commit is not available here: builds are not
+	# stamped, deliberately, and the sandbox has no .git).
+	echo "MIX TEST reproduce with: EXUNIT_SEED=$(grep -oE 'seed: [0-9]+' "$out" | head -1 | grep -oE '[0-9]+') against a $(grep -oE '[0-9]+ tests, [0-9]+ failures?' "$out" | tail -1 | grep -oE '^[0-9]+')-test corpus (a seed only replays the same ordering at the same test count)" >&2
 	exit 1
 fi

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.300
+version: 0.1.301

--- a/projects/embervm/control/test/embervm/node_registry_test.exs
+++ b/projects/embervm/control/test/embervm/node_registry_test.exs
@@ -674,8 +674,17 @@ defmodule Embervm.NodeRegistryTest do
     # Drive both expiry signals: registration lapses (advance past expire_after) AND
     # the stream goes dead (advance past down_after with no fresh status).
     advance.(100_000)
-    NodeRegistry.tick(reg)
-    eventually(fn -> not Map.has_key?(NodeRegistry.status(reg), "node-4/uid-1") end, 200)
+    :ok = NodeRegistry.tick(reg)
+
+    # Asserted, not polled. tick/1 is a GenServer.call whose handler runs evaluate_ages/1
+    # inline before replying, and status/1 is a call from this same process, so it is
+    # strictly ordered after that reply. No later expiry pass can land inside a poll
+    # window either (age_check_ms is 60_000 here). Waiting could therefore never turn a
+    # missed expiry into a pass; it only delayed the failure by the poll budget and
+    # reported "condition never became true" instead of what was actually in the map.
+    # This has failed intermittently (#4078): when it does, that is a real expiry bug,
+    # and refute prints the offending status map at the moment it happens.
+    refute Map.has_key?(NodeRegistry.status(reg), "node-4/uid-1")
 
     # The instance_id was removed from NodeChannel; the bare node name was never a key,
     # so it never appears in the removal list.
@@ -802,8 +811,11 @@ defmodule Embervm.NodeRegistryTest do
 
     # Now let the stream go dead too (advance past down_after with no fresh status).
     advance.(100_000)
-    NodeRegistry.tick(reg)
-    eventually(fn -> not Map.has_key?(NodeRegistry.status(reg), "node-4/uid-1") end, 200)
+    :ok = NodeRegistry.tick(reg)
+
+    # Asserted rather than polled, for the same reason as the expiry test above: tick/1
+    # applies the age-out inline before it replies, so there is nothing to wait for.
+    refute Map.has_key?(NodeRegistry.status(reg), "node-4/uid-1")
     assert NodeRegistry.capacity(table) == []
   end
 end

--- a/projects/embervm/control/test/test_helper.exs
+++ b/projects/embervm/control/test/test_helper.exs
@@ -7,7 +7,13 @@
 # message lands) and only lengthens how long a genuinely failing assertion waits
 # before reporting. refute_receive is unaffected: it reads refute_receive_timeout,
 # which stays at 100ms, so no test that must wait out a full window got slower.
-ExUnit.start(assert_receive_timeout: 2_000)
+# capture_log attributes log output to the test that produced it. The suite runs with
+# max_cases: 8, so without it eight concurrent tests interleave into one stream and the
+# lines next to a failure usually belong to some other test. That cost real debugging
+# time on #4078: an "expired; tearing down" line sat directly above a "registered" line
+# and read as one instance being resurrected, when they came from different tests.
+# Adjacency in a shared stream is not causality; captured logs make it causality again.
+ExUnit.start(assert_receive_timeout: 2_000, capture_log: true)
 
 defmodule Embervm.TestProcess do
   @moduledoc """

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.300
+      targetRevision: 0.1.301
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## The poll could never have worked

Both expiry checks in `node_registry_test.exs` polled with
`eventually(..., 200)` after calling `tick/1`. That cannot help:

- `tick/1` is `GenServer.call(server, :tick)` and its handler is
  `{:reply, :ok, evaluate_ages(state)}`, so the age-out runs inline *before* it
  replies.
- `status/1` is also a call from the same process, so it is strictly ordered
  after that reply.
- Both tests set `age_check_ms: 60_000`, so no later expiry pass can land
  inside a 2s poll window.

If the key is present when `tick` returns, waiting changes nothing.

So the intermittent failure tracked in #4078 is **not scheduler jitter**. It is
the registry genuinely failing to expire the instance on that tick. The poll was
delaying that signal by 2s and reporting `condition never became true` instead of
what was actually in the map.

## What changes

`refute Map.has_key?(NodeRegistry.status(reg), "node-4/uid-1")` directly, at both
sites. **Failure rate is unchanged (~1 in 10); diagnosability is not.** The next
occurrence fails instantly and prints the offending status map.

## Root cause still unknown

Being explicit, since this PR does not fix the bug. Ruled out:

- **The poll budget** - already at the post-#4109 maximum, and per the above,
  budget is irrelevant here.
- **Asynchronous re-registration** - the `:reconnect`, `:watch_result` and
  `:DOWN` handlers all guard on `state.streamers` / `node_runtime`, which
  `expire_instance` clears before killing the streamer. A late message is a
  no-op.

## Telemetry, because both gaps cost real time here

- **`capture_log: true`.** With `max_cases: 8`, concurrent tests interleave into
  one stream, so lines beside a failure usually belong to a different test. While
  debugging this I read an `expired; tearing down` line sitting directly above a
  `registered` line as one instance being resurrected. They were different tests.
  Adjacency in a shared stream is not causality.
- **`EXUNIT_SEED` passthrough.** ExUnit prints the seed it chose, but nothing
  could feed one back, so a seed captured from a failing CI run could not be
  replayed. Now: `ci test -- --action_env=EXUNIT_SEED=<n>`. On failure the driver
  prints the seed **with the test count**, because a seed only replays an ordering
  against the same corpus: this suite went 1009 -> 1014 tests during the
  investigation, which silently invalidated a replay I attempted.

Not included: JUnit XML output so BuildBuddy gets per-test history for these 1014
tests. That needs a hex formatter dep in the vendored-tarball setup, so it stays
the open item on #4078.

## Verification

`ci test` green: `MIX TEST OK on the executor`, `1014 tests, 0 failures`.

Chart bumped `0.1.299 -> 0.1.300`: editing anything under
`projects/embervm/control/`, test tree included, moves the image digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)