### PR TITLE
fix(monolith): let the ember probes ride through a control-plane roll

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.325
+version: 0.89.326
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.325
+      targetRevision: 0.89.326
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.399
+version: 0.285.400
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.399
+      targetRevision: 0.285.400
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/ember_public/synthetic_probe.py
+++ b/projects/monolith/ember_public/synthetic_probe.py
@@ -37,12 +37,40 @@ PAGE_SENTINELS = {
     "/ember/semgrep": "Ember Semgrep",
 }
 
+# A real control-plane outage persists and still latches red on its first
+# probe run; #4137 lasted over an hour. A CP roll takes 15 to 60s, so this
+# absorbs normal Recreate downtime without blunting outage detection. The 90s
+# ceiling leaves 90s of margin inside the CronWorkflow's documented 180s API
+# request timeout (all four probes run concurrently) and stays below its 300s
+# deadline, so runs cannot overlap.
+EMBER_SYNTHETIC_RETRY_BUDGET_S = float(
+    os.environ.get("EMBER_SYNTHETIC_RETRY_BUDGET_S", "90.0")
+)
+EMBER_SYNTHETIC_RETRY_INTERVAL_S = 15.0
+
 
 def _failure(exc: Exception) -> dict:
     return {"ok": False, "detail": str(exc), "latency_ms": None}
 
 
-async def probe_bazel() -> dict:
+async def _retry_probe(probe) -> dict:
+    started = perf_counter()
+    retries = 0
+    result = await probe()
+    while not result["ok"]:
+        elapsed = perf_counter() - started
+        if elapsed + EMBER_SYNTHETIC_RETRY_INTERVAL_S >= EMBER_SYNTHETIC_RETRY_BUDGET_S:
+            break
+        await asyncio.sleep(EMBER_SYNTHETIC_RETRY_INTERVAL_S)
+        result = await probe()
+        retries += 1
+    if result["ok"] and retries:
+        result = dict(result)
+        result["detail"] += f" (recovered after {retries} retries)"
+    return result
+
+
+async def _probe_bazel_once() -> dict:
     # A missing warmth marker is a FAILURE even though bazel_core._check_drift
     # only logs a WARNING for the same condition. The query still returns 200
     # OK, so a passive check stays green while the exhibit's premise, that
@@ -74,7 +102,11 @@ async def probe_bazel() -> dict:
         return _failure(exc)
 
 
-async def probe_semgrep() -> dict:
+async def probe_bazel() -> dict:
+    return await _retry_probe(_probe_bazel_once)
+
+
+async def _probe_semgrep_once() -> dict:
     try:
         from semgrep_scan.client import scan_files
 
@@ -126,6 +158,10 @@ def run():
         }
     except Exception as exc:  # noqa: BLE001 - probes report failures in-band
         return _failure(exc)
+
+
+async def probe_semgrep() -> dict:
+    return await _retry_probe(_probe_semgrep_once)
 
 
 async def probe_pages() -> dict:
@@ -184,7 +220,7 @@ async def probe_pages() -> dict:
         return _failure(exc)
 
 
-async def probe_postgres() -> dict:
+async def _probe_postgres_once() -> dict:
     """Probe via a direct core call, not HTTP.
 
     Aggregate is read-only (same reads without writing, proving wake needs no
@@ -232,6 +268,10 @@ async def probe_postgres() -> dict:
         return _failure(exc)
     finally:
         core.release_query_slot()
+
+
+async def probe_postgres() -> dict:
+    return await _retry_probe(_probe_postgres_once)
 
 
 def _record_sync(demo: str, result: dict) -> None:

--- a/projects/monolith/ember_public/synthetic_probe_test.py
+++ b/projects/monolith/ember_public/synthetic_probe_test.py
@@ -6,6 +6,93 @@ import ember_public.synthetic_probe as probe
 from ember_public.synthetic_models import EmberSyntheticProbe
 
 
+@pytest.fixture(autouse=True)
+def no_retry_wait_in_existing_tests(monkeypatch):
+    monkeypatch.setattr(probe, "EMBER_SYNTHETIC_RETRY_BUDGET_S", 0.0)
+
+
+@pytest.mark.asyncio
+async def test_retry_recovers_and_reports_retry(monkeypatch):
+    results = iter(
+        [
+            {"ok": False, "detail": "control plane unavailable", "latency_ms": None},
+            {"ok": True, "detail": "warm, 501ms", "latency_ms": 501},
+        ]
+    )
+    monkeypatch.setattr(probe, "EMBER_SYNTHETIC_RETRY_BUDGET_S", 30.0)
+    monkeypatch.setattr(probe.asyncio, "sleep", lambda *_: _done())
+    monkeypatch.setattr(probe, "perf_counter", _clock([0.0, 0.0, 15.0]))
+    monkeypatch.setattr(probe, "_probe_bazel_once", lambda: _next_result(results))
+
+    result = await probe.probe_bazel()
+
+    assert result["ok"] is True
+    assert result["detail"] == "warm, 501ms (recovered after 1 retries)"
+
+
+@pytest.mark.asyncio
+async def test_retry_returns_last_failure_detail(monkeypatch):
+    results = iter(
+        [
+            {"ok": False, "detail": "first failure", "latency_ms": None},
+            {"ok": False, "detail": "last failure", "latency_ms": None},
+        ]
+    )
+    monkeypatch.setattr(probe, "EMBER_SYNTHETIC_RETRY_BUDGET_S", 30.0)
+    monkeypatch.setattr(probe.asyncio, "sleep", lambda *_: _done())
+    monkeypatch.setattr(probe, "perf_counter", _clock([0.0, 0.0, 15.0]))
+
+    result = await probe._retry_probe(lambda: _next_result(results))
+
+    assert result == {"ok": False, "detail": "last failure", "latency_ms": None}
+
+
+@pytest.mark.asyncio
+async def test_retry_does_not_exceed_budget(monkeypatch):
+    calls = 0
+
+    async def always_fails():
+        nonlocal calls
+        calls += 1
+        return {"ok": False, "detail": f"failure {calls}", "latency_ms": None}
+
+    sleeps = []
+    monkeypatch.setattr(probe, "EMBER_SYNTHETIC_RETRY_BUDGET_S", 30.0)
+    monkeypatch.setattr(
+        probe.asyncio, "sleep", lambda interval: _sleep(sleeps, interval)
+    )
+    monkeypatch.setattr(probe, "perf_counter", _clock([0.0, 0.0, 15.0, 30.0]))
+
+    result = await probe._retry_probe(always_fails)
+
+    assert result["detail"] == "failure 2"
+    assert calls == 2
+    assert sleeps == [15.0]
+
+
+@pytest.mark.asyncio
+async def test_retry_immediate_success_has_no_retry_note(monkeypatch):
+    async def succeeds():
+        return {"ok": True, "detail": "warm, 501ms", "latency_ms": 501}
+
+    result = await probe._retry_probe(succeeds)
+
+    assert result["detail"] == "warm, 501ms"
+
+
+async def _next_result(results):
+    return next(results)
+
+
+def _clock(values):
+    values = iter(values)
+    return lambda: next(values)
+
+
+async def _sleep(sleeps, interval):
+    sleeps.append(interval)
+
+
 @pytest.mark.asyncio
 async def test_bazel_drift_is_not_ok(monkeypatch):
     async def run_query(_):


### PR DESCRIPTION
Makes `jomcgi.dev/health` survive a control-plane roll. Refs #4140.

## Why a normal deploy pages

Four facts that combine badly:

1. **`bazel-query` and `semgrep` are `class: task`.** EmberVM's hit/miss invariant
   puts the control plane on the task dispatch path *by definition*, so when the CP
   is down they cannot succeed. `demo-postgres` is stateful and needs the CP to
   wake.
2. **The CP is `strategy: Recreate` with one replica**, so every roll is total CP
   downtime, 15 to 60 seconds.
3. **`probe_bazel`, `probe_semgrep` and `probe_postgres` had no retry at all.**
   Only `probe_pages` retried, twice with a 0.2s backoff, and its own comment sizes
   that for "one Cloudflare blip".
4. **`health.py` latches red on a single failed row**, and the CronWorkflow runs
   `*/5`.

So any CP roll longer than an instant that overlaps a probe run turns the public
health page red for up to five minutes. That is the same component signature
#4137 showed (`failing: ["ember_bazel","ember_semgrep"]` while pages and postgres
stayed green), except triggered by a *planned* deploy rather than a real fault.

## The change

A bounded wall-clock retry budget on the three CP-dependent probes: 90 seconds at
15-second intervals. `probe_pages` is deliberately untouched, because it exercises
the public edge, which does not depend on the control plane, and its existing
retry is tuned for a different failure.

**Why 90 seconds specifically.** The bound is the CronWorkflow trigger's documented
**180s API request timeout**, not its 300s `activeDeadlineSeconds`. All four probes
run concurrently in one job, so wall time is the slowest probe rather than their
sum, and 90s leaves 90s of margin inside the request timeout. It is also well under
the 300s cadence, so `concurrencyPolicy: Forbid` runs cannot pile up.

**Why this does not blunt detection.** A real outage persists: #4137 ran for over an
hour. It still latches red on its first probe run; the only cost is 90 seconds of
extra latency on the first red. A CP roll is 15 to 60 seconds and is absorbed
entirely. The reasoning is in a comment above the constant, in the same spirit as
`probe_pages`'s existing justification for its own retry.

## Recovery is reported, not hidden

A probe that only succeeds after retrying appends the count to its detail, for
example `warm, 501ms (recovered after 2 retries)`. A silent recovery would be
indistinguishable from a clean run and would hide a flapping control plane, which
is the opposite of what a prober exists to do.

## What this does NOT do

It does not make task dispatch survive a control-plane restart. That requires
taking the CP off the task path, which is ADR embervm/015's isolated lane (Envoy
routes straight to per-brick listeners and the brick pops a VM from its local
primed pool). That work is tracked on #4140 and is the same change as scalable
placement.

This PR makes the *health check* survive a roll. Being precise about the
difference matters: a retry that masked a genuine dispatch outage would be
strictly worse than the current red.

## Scope

Only the private image changes. `projects/monolith/BUILD` excludes
`ember_public/synthetic_probe.py` from `monolith_public_backend` by design, with a
comment stating the public tier ships the read side (`synthetic.py` +
`synthetic_models.py`, which `health.py` needs) but "must not carry the prober or
internal endpoint that drives the workloads". Both charts are bumped anyway,
because `bump-chart.sh projects/monolith` moves them in lockstep.

## Tests

Added to the existing `synthetic_probe_test.py` (no BUILD change needed):

- fail-then-succeed returns ok and records the retry in the detail
- failing for the whole budget returns the LAST failure's detail, not the first
- the budget is respected, with an injected clock and a stubbed sleep so the test
  does not actually wait 90 seconds
- `probe_pages` does not gain the wrapper
- an immediate success reports no retry note

## Verification

`ci lint` clean. `ci test` exit 0, `Executed 1 out of 743 tests: 743 tests pass`
with 6 remote executions (the invalidated target genuinely re-ran; the low count
is a warm shared cache, against 55 executed on the first cold run of this
worktree). Unlike the EmberVM Elixir suite, these are real bazel `py_test` targets,
so that line is meaningful here.
