### PR TITLE
fix(embervm): enforce the slot ceiling the daemon advertises

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.304
+version: 0.1.305

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.304
+      targetRevision: 0.1.305
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/group_member.go
+++ b/projects/embervm/noded/server/group_member.go
@@ -47,8 +47,8 @@ func (s *Server) startGroupMember(ctx context.Context, req *nodev1.StartGroupMem
 	if s.isDraining() {
 		return nil, status.Error(codes.Unavailable, "noded: draining")
 	}
-	if s.cfg.MaxLiveVMs > 0 && s.liveVMCount() >= s.cfg.MaxLiveVMs {
-		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.cfg.MaxLiveVMs)
+	if s.slotsExhausted() {
+		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.SlotCeiling())
 	}
 	// Cheap rejection under real memory pressure (ADR embervm/014 decision 3),
 	// BEFORE the member cold boot below. A group member's tap is pinned on its

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -921,8 +921,8 @@ func (s *Server) Prime(ctx context.Context, req *nodev1.PrimeRequest) (*nodev1.P
 	if ref == "" {
 		return nil, status.Error(codes.InvalidArgument, "noded: snapshot_ref required")
 	}
-	if s.cfg.MaxLiveVMs > 0 && s.liveVMCount() >= s.cfg.MaxLiveVMs {
-		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.cfg.MaxLiveVMs)
+	if s.slotsExhausted() {
+		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.SlotCeiling())
 	}
 	base, ok := s.bases.get(ref)
 	if !ok {
@@ -1134,6 +1134,15 @@ func (s *Server) liveVMCount() int {
 	return s.driver.LiveCount()
 }
 
+// slotsExhausted keeps the advertised and enforced ceilings identical. A
+// control plane that filters on the advertised number while the daemon admits
+// past it is the #4101 divergence. A zero ceiling preserves the existing
+// unlimited semantics.
+func (s *Server) slotsExhausted() bool {
+	ceiling := s.SlotCeiling()
+	return ceiling > 0 && s.liveVMCount() >= ceiling
+}
+
 // ---- Session verbs (R2) ----------------------------------------------------
 
 // adoptPrimedSession promotes a primed VM from the task registry into the session
@@ -1334,8 +1343,8 @@ func (s *Server) Relight(ctx context.Context, req *nodev1.RelightRequest) (*node
 	if ref == "" {
 		return nil, status.Error(codes.InvalidArgument, "noded: snapshot_ref required")
 	}
-	if s.cfg.MaxLiveVMs > 0 && s.liveVMCount() >= s.cfg.MaxLiveVMs {
-		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.cfg.MaxLiveVMs)
+	if s.slotsExhausted() {
+		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.SlotCeiling())
 	}
 	if !s.sessionSnap.has(ref) {
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: unknown session snapshot_ref %q", ref)
@@ -1669,16 +1678,7 @@ func (s *Server) WatchNode(req *nodev1.WatchNodeRequest, stream grpc.ServerStrea
 func (s *Server) nodeStatus() *nodev1.NodeStatus {
 	primed, taskLive := s.vms.capacity()
 	caps := s.workloadCapacities(primed)
-	maxLive := s.cfg.MaxLiveVMs
-	if maxLive < 0 {
-		maxLive = 0
-	}
-	// The reported MaxLiveVms is the brick's cgroup-derived slot ceiling (ADR
-	// embervm/013 section 7), with the configured backstop as an upper clamp:
-	// a size-class brick advertises a budget-honest slot count, never the raw
-	// configured default. When the cgroup budget is unknown the ceiling equals
-	// the configured backstop, preserving pre-budget behavior.
-	maxLive = int(s.slotCeiling(uint64(maxLive)))
+	maxLive := s.SlotCeiling()
 	// Session and serving VMs both count against the node live-VM total alongside
 	// task-pool VMs (all three classes Claim through the same driver, but this sum
 	// names the invariant at the call site).

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -602,6 +602,89 @@ func TestPrimeCapExhausted(t *testing.T) {
 	}
 }
 
+// TestSlotCeilingAdmissionParity4101 proves that admission stops at the same
+// cgroup-derived ceiling that NodeStatus advertises, including a second
+// lifecycle verb that shares the node-wide cap.
+func TestSlotCeilingAdmissionParity4101(t *testing.T) {
+	t.Run("Prime", func(t *testing.T) {
+		drv := &fakeDriver{}
+		client, srv := newTestServer(t, drv, &fakeTransport{}, 8)
+		srv.budget.memBudgetOverride = func() uint64 { return 1536 }
+		srv.slotCeiling = srv.budget.SlotCeiling
+		seedBase(srv, "echo__4101", "echo")
+
+		ns, err := client.GetNodeStatus(context.Background(), &nodev1.GetNodeStatusRequest{})
+		if err != nil {
+			t.Fatalf("GetNodeStatus: %v", err)
+		}
+		if got, want := ns.GetMaxLiveVms(), uint32(3); got != want {
+			t.Fatalf("advertised max_live_vms = %d, want %d", got, want)
+		}
+		for i := uint32(0); i < ns.GetMaxLiveVms(); i++ {
+			if _, err := client.Prime(context.Background(), &nodev1.PrimeRequest{SnapshotRef: "echo__4101"}); err != nil {
+				t.Fatalf("Prime %d: %v", i+1, err)
+			}
+		}
+		_, err = client.Prime(context.Background(), &nodev1.PrimeRequest{SnapshotRef: "echo__4101"})
+		if status.Code(err) != codes.ResourceExhausted {
+			t.Fatalf("Prime at advertised ceiling code = %v, want ResourceExhausted", status.Code(err))
+		}
+		if !strings.Contains(err.Error(), "cap 3 reached") {
+			t.Fatalf("Prime error = %q, want enforced ceiling 3", err)
+		}
+	})
+
+	t.Run("StartServing", func(t *testing.T) {
+		srv, _, fsd := newServingTestServer(t)
+		srv.budget.memBudgetOverride = func() uint64 { return 1536 }
+		fsd.mu.Lock()
+		fsd.live = 3
+		fsd.mu.Unlock()
+
+		if got, want := srv.nodeStatus().GetMaxLiveVms(), uint32(3); got != want {
+			t.Fatalf("advertised max_live_vms = %d, want %d", got, want)
+		}
+		_, err := srv.StartServing(context.Background(), &nodev1.StartServingRequest{})
+		if status.Code(err) != codes.ResourceExhausted {
+			t.Fatalf("StartServing at advertised ceiling code = %v, want ResourceExhausted", status.Code(err))
+		}
+		if !strings.Contains(err.Error(), "cap 3 reached") {
+			t.Fatalf("StartServing error = %q, want enforced ceiling 3", err)
+		}
+	})
+}
+
+func TestSlotCeilingUnknownBudgetPreservesBackstop(t *testing.T) {
+	drv := &fakeDriver{}
+	client, srv := newTestServer(t, drv, &fakeTransport{}, 2)
+	srv.budget.memBudgetOverride = func() uint64 { return 0 }
+	srv.slotCeiling = srv.budget.SlotCeiling
+	seedBase(srv, "echo__unknown", "echo")
+
+	if got := srv.nodeStatus().GetMaxLiveVms(); got != 2 {
+		t.Fatalf("unknown budget max_live_vms = %d, want 2", got)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := client.Prime(context.Background(), &nodev1.PrimeRequest{SnapshotRef: "echo__unknown"}); err != nil {
+			t.Fatalf("Prime %d with unknown budget: %v", i+1, err)
+		}
+	}
+	_, err := client.Prime(context.Background(), &nodev1.PrimeRequest{SnapshotRef: "echo__unknown"})
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("Prime beyond configured backstop code = %v, want ResourceExhausted", status.Code(err))
+	}
+}
+
+func TestSlotCeilingZeroRemainsUnlimited(t *testing.T) {
+	drv := &fakeDriver{live: 100}
+	s := New(Options{Config: config.Config{MaxLiveVMs: 0}, Driver: drv})
+	s.budget.memBudgetOverride = func() uint64 { return 0 }
+	s.slotCeiling = s.budget.SlotCeiling
+	if s.slotsExhausted() {
+		t.Fatal("zero configured backstop must remain unlimited")
+	}
+}
+
 // TestDestroyIdempotent: Destroy reaps a primed VM once, and a repeat Destroy is
 // a no-op OK.
 func TestDestroyIdempotent(t *testing.T) {

--- a/projects/embervm/noded/server/serving.go
+++ b/projects/embervm/noded/server/serving.go
@@ -34,8 +34,8 @@ func (s *Server) startServing(ctx context.Context, req *nodev1.StartServingReque
 	if s.isDraining() {
 		return nil, status.Error(codes.Unavailable, "noded: draining")
 	}
-	if s.cfg.MaxLiveVMs > 0 && s.liveVMCount() >= s.cfg.MaxLiveVMs {
-		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.cfg.MaxLiveVMs)
+	if s.slotsExhausted() {
+		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.SlotCeiling())
 	}
 	// Cheap rejection under real memory/tap pressure (ADR embervm/014 decision 3),
 	// BEFORE the tap allocation and cold boot below. Serving is tap-bearing, so

--- a/projects/embervm/noded/server/stateful.go
+++ b/projects/embervm/noded/server/stateful.go
@@ -64,8 +64,8 @@ func (s *Server) startStateful(ctx context.Context, req *nodev1.StartStatefulReq
 	if s.isDraining() {
 		return nil, status.Error(codes.Unavailable, "noded: draining")
 	}
-	if s.cfg.MaxLiveVMs > 0 && s.liveVMCount() >= s.cfg.MaxLiveVMs {
-		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.cfg.MaxLiveVMs)
+	if s.slotsExhausted() {
+		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.SlotCeiling())
 	}
 	// Cheap rejection under real memory/tap pressure (ADR embervm/014 decision 3),
 	// BEFORE the tap allocation and boot below. Stateful is tap-bearing; the


### PR DESCRIPTION
Closes #4101. Refs #4140.

## The defect

`nodeStatus()` advertised the cgroup-derived slot ceiling while **all five** admission sites gated on the raw configured backstop:

| site | verb |
|---|---|
| `server.go:924` | Prime |
| `server.go:1337` | session Relight |
| `serving.go:37` | StartServing |
| `stateful.go:67` | StartStateful |
| `group_member.go:50` | StartGroupMember |

A 2gi brick's `MemBudgetMib()` is 1536 (memory.max minus the 512 MiB `DaemonReserveMib`), so `SlotCeiling` = 1536/512 = **3**, while `cfg.MaxLiveVMs` defaults to 8. Observed live as `node-4/c7af332 live_vms=4 / max_live_vms=3`.

## The fix makes an existing claim true

`Server.SlotCeiling()` already existed, and its own docstring already said it is *"the same value nodeStatus reports as MaxLiveVms"*. It simply was not wired that way: `nodeStatus()` recomputed the ceiling inline, and admission ignored it.

Now `nodeStatus()` calls it, and a shared `slotsExhausted()` helper backs all five verbs. One function, all readers, so they cannot drift again. Zero-ceiling unlimited semantics are preserved exactly, and the rejection message reports the ceiling that actually refused rather than the configured value.

## Why tightening is the safe direction, not a regression

This narrows admission from 8 to 3 on a 2gi brick. That is fail-closed, and it matters more than it looks:

**noded's own memory gate reads the same laggy value the control plane's does.** `memPressured` calls `s.memHeadroom()`, which is `budget.go`'s `memory.max - working_set`. During the lazy-fault window after a snapshot restore, *both* memory gates are blind simultaneously, so the derived slot ceiling is currently the only anti-lag backstop a small brick has.

At a cap of 8: three 512 MiB guests land, headroom still reads ~1933 for seconds, a fourth and fifth clear `need + floor`, and 2560 MiB of declared guest memory sits on a 1536 MiB budget. That is a cgroup OOM, and per ADR embervm/012 guests are the first victims.

It is also invisible to a correct control plane, which already filters on the advertised `max_live_vms`. The change only stops the daemon being silently *looser* than what it advertises.

## Deliberately not in this PR

`minSlotWorkloadMib` is untouched, and the derived ceiling's arithmetic is unchanged; only who reads it changes. It remains the anti-lag backstop until declared-memory admission replaces that role in #4140 Phase B. Deleting it here would remove the guard and its replacement in a single change.

No claims ledger, no proto change, no new flag. Those are the next PR.

## Tests

- The #4101 regression, named after it: with a budget yielding a derived ceiling below the configured backstop, the advertised `NodeStatus.MaxLiveVms` and the count at which admission starts refusing are asserted to be the **same number**.
- An unknown or unlimited cgroup budget falls back to the configured backstop, so behaviour is unchanged there.
- A configured backstop of 0 still means unlimited.
- Two of the five verbs exercised, so the shared helper is covered from more than one call site.

## Verification

`ci lint` clean. `ci test` exit 0, `Executed 1 out of 743 tests: 743 tests pass` (the Go target re-ran). The Elixir suite reports `MIX TEST OK on the executor` with `1041 tests, 0 failures`, unchanged from main, confirming no `control/` files were touched.