### PR TITLE
feat(embervm): give noded a declared-memory claims ledger, off by default

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.305
+version: 0.1.306

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.305
+      targetRevision: 0.1.306
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -117,6 +117,13 @@ type Config struct {
 	// EMBERVM_NODED_MEM_REJECT_FLOOR_MIB. Read only by the pressure predicate; a
 	// cgroup reporting unknown (unlimited) headroom fails the check open regardless.
 	MemRejectFloorMib int
+	// AdmissionModel selects memory admission: observed preserves the current
+	// cgroup-headroom predicate; reserved gates on declared live claims.
+	// Env EMBERVM_NODED_ADMISSION_MODEL. Default observed.
+	AdmissionModel string
+	// VMOverheadMib is host memory charged per live VM in the reserved model.
+	// Env EMBERVM_NODED_VM_OVERHEAD_MIB. Default 0.
+	VMOverheadMib int
 
 	// DaemonReserveMib is subtracted from the cgroup memory.max ceiling
 	// before it is reported as NodeStatus.mem_budget_mib, covering the
@@ -388,6 +395,8 @@ func Load() (Config, error) {
 		// footprint); the two live in different packages (config cannot import
 		// server), so the literal is duplicated with this note tying them together.
 		MemRejectFloorMib:   atoiDefault("EMBERVM_NODED_MEM_REJECT_FLOOR_MIB", 512),
+		AdmissionModel:      getenvDefault("EMBERVM_NODED_ADMISSION_MODEL", "observed"),
+		VMOverheadMib:       atoiDefault("EMBERVM_NODED_VM_OVERHEAD_MIB", 0),
 		SnapshotRoot:        os.Getenv("EMBERVM_NODED_SNAPSHOT_ROOT"),
 		BinPath:             getenvDefault("EMBERVM_NODED_FIRECRACKER_BIN", "/opt/fc/firecracker"),
 		KernelImagePath:     getenvDefault("EMBERVM_NODED_KERNEL_IMAGE", "/opt/fc/vmlinux.container"),
@@ -432,6 +441,9 @@ func Load() (Config, error) {
 		StoreBucket:   getenvDefault("EMBERVM_NODED_STORE_BUCKET", "embervm"),
 
 		RequireBlessing: boolDefault("EMBERVM_NODED_REQUIRE_BLESSING", false),
+	}
+	if c.AdmissionModel != "observed" && c.AdmissionModel != "reserved" {
+		return Config{}, fmt.Errorf("EMBERVM_NODED_ADMISSION_MODEL must be observed or reserved, got %q", c.AdmissionModel)
 	}
 	statefulActivatorRangeRaw := "5400-5409"
 	if raw, ok := os.LookupEnv("EMBERVM_NODED_STATEFUL_ACTIVATOR_PORT_RANGE"); ok {

--- a/projects/embervm/noded/config/config_test.go
+++ b/projects/embervm/noded/config/config_test.go
@@ -87,6 +87,22 @@ func TestLoadCpuVendorEnvOverride(t *testing.T) {
 	}
 }
 
+func TestLoadAdmissionConfig(t *testing.T) {
+	t.Setenv("EMBERVM_NODED_ADMISSION_MODEL", "reserved")
+	t.Setenv("EMBERVM_NODED_VM_OVERHEAD_MIB", "64")
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.AdmissionModel != "reserved" || c.VMOverheadMib != 64 {
+		t.Fatalf("admission config = (%q, %d), want (reserved, 64)", c.AdmissionModel, c.VMOverheadMib)
+	}
+	t.Setenv("EMBERVM_NODED_ADMISSION_MODEL", "invalid")
+	if _, err := Load(); err == nil {
+		t.Fatal("Load accepted an unknown admission model")
+	}
+}
+
 func TestLoadActivatorAddress(t *testing.T) {
 	t.Setenv("EMBERVM_NODED_ACTIVATOR_ADDR", "127.0.0.1:18081")
 	c, err := Load()

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -189,6 +189,7 @@ type instance struct {
 	client fcAPI
 	dir    string
 	sock   string
+	memMib int
 }
 
 var (
@@ -754,7 +755,7 @@ func (d *Driver) loadInto(ctx context.Context, threadID, snapPath, memPath, sock
 		return d.abort(proc, err)
 	}
 	h := substrate.Handle{ThreadID: threadID, ID: vmID, Node: d.cfg.Node}
-	d.track(&instance{handle: h, proc: proc, client: client, dir: dir, sock: sock})
+	d.track(&instance{handle: h, proc: proc, client: client, dir: dir, sock: sock, memMib: d.cfg.MemMib})
 	return h, nil
 }
 
@@ -952,7 +953,7 @@ func (d *Driver) coldBoot(ctx context.Context, threadID string, cb coldBootSpec)
 	}
 
 	h := substrate.Handle{ThreadID: threadID, ID: vmID, Node: d.cfg.Node}
-	d.track(&instance{handle: h, proc: proc, client: client, dir: dir, sock: sock})
+	d.track(&instance{handle: h, proc: proc, client: client, dir: dir, sock: sock, memMib: cb.memMib})
 	return h, nil
 }
 
@@ -2191,6 +2192,22 @@ func (d *Driver) LiveCount() int {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return len(d.live)
+}
+
+// ClaimedMib derives the declared memory sum from the live map. It is a
+// projection, never a counter, so it cannot leak: Release removes the live-map
+// entry, and a daemon restart starts with an empty map because Firecracker
+// children are owned by noded and there is no adoption path for pre-existing VMs.
+func (d *Driver) ClaimedMib() uint64 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	var total uint64
+	for _, inst := range d.live {
+		if inst.memMib > 0 {
+			total += uint64(inst.memMib)
+		}
+	}
+	return total
 }
 
 func bundleSize(paths ...string) int64 {

--- a/projects/embervm/noded/fcvm/driver/driver_test.go
+++ b/projects/embervm/noded/fcvm/driver/driver_test.go
@@ -135,6 +135,45 @@ func TestDriverClaimBootsMicroVM(t *testing.T) {
 	}
 }
 
+func TestDriverClaimedMibProjectsLiveMap(t *testing.T) {
+	d := testDriver(t)
+	ctx := context.Background()
+	handles := make([]substrate.Handle, 0, 4)
+	h, err := d.Claim(ctx, substrate.ClaimSpec{ThreadID: "claimed-task"})
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	handles = append(handles, h)
+	for _, claim := range []func() (substrate.Handle, error){
+		func() (substrate.Handle, error) {
+			return d.ClaimServing(ctx, "", "", 1, 200, substrate.NICSpec{HostDevName: "tap-serving"}, "", 0)
+		},
+		func() (substrate.Handle, error) {
+			return d.ClaimStateful(ctx, "", "", 1, 300, substrate.NICSpec{HostDevName: "tap-stateful"}, "", 0, "/volume", "/data", nil)
+		},
+		func() (substrate.Handle, error) {
+			return d.ClaimGroupMember(ctx, "", "", 1, 400, substrate.NICSpec{HostDevName: "tap-group"}, nil)
+		},
+	} {
+		h, err := claim()
+		if err != nil {
+			t.Fatalf("mixed claim path: %v", err)
+		}
+		handles = append(handles, h)
+	}
+	if got, want := d.ClaimedMib(), uint64(d.cfg.MemMib+200+300+400); got != want {
+		t.Fatalf("ClaimedMib = %d, want %d", got, want)
+	}
+	for _, h := range handles {
+		if err := d.Release(ctx, h); err != nil {
+			t.Fatalf("Release %s: %v", h.ID, err)
+		}
+	}
+	if got := d.ClaimedMib(); got != 0 {
+		t.Fatalf("ClaimedMib after releasing all live entries = %d, want 0", got)
+	}
+}
+
 // TestDriverClaimClearsStaleVsockUDS reproduces the orphan-recovery failure
 // after a pod roll: a thread's bundle dir persists on the snapshot disk, so a
 // vsock.sock left by the dead incarnation makes Firecracker's PUT /vsock bind

--- a/projects/embervm/noded/server/pressure.go
+++ b/projects/embervm/noded/server/pressure.go
@@ -90,13 +90,49 @@ func (s *Server) admitOrReject(needMib uint64, class pressureClass) error {
 // admission check can reuse the verdict without producing a gRPC error, and so it
 // is unit-testable in isolation from the wire path.
 func (s *Server) underPressure(needMib uint64, class pressureClass) (rejectReason, bool) {
-	if s.memPressured(needMib) {
+	if s.memExhausted(needMib) {
 		return reasonPressureMem, true
 	}
 	if class == classTapBearing && s.tapsExhausted() {
 		return reasonPressureTaps, true
 	}
 	return "", false
+}
+
+// memExhausted selects the node's memory admission model. The observed model
+// delegates unchanged to today's cgroup-headroom predicate. The reserved model
+// derives declared claims from the driver's live map, charging the requested VM
+// and configured host overhead for the VM about to be admitted. A zero budget
+// means unlimited or unreadable cgroup and fails open for the reserved model
+// only.
+func (s *Server) memExhausted(needMib uint64) bool {
+	// Observed model: unchanged from before the claims ledger existed. The
+	// budget guards below belong to the reserved arithmetic only; applying them
+	// here would fail open on a brick whose memory.max is at or below the daemon
+	// reserve, where budget reads 0 but headroom is still positive.
+	if s.cfg.AdmissionModel != "reserved" {
+		return s.memPressured(needMib)
+	}
+	if s.memBudget == nil {
+		return false
+	}
+	budget := s.memBudget()
+	if budget == 0 {
+		return false
+	}
+	live := uint64(s.driver.LiveCount())
+	overhead := uint64(0)
+	if s.cfg.VMOverheadMib > 0 {
+		overhead = uint64(s.cfg.VMOverheadMib)
+	}
+	return s.claimedMib()+needMib+overhead*(live+1) > budget
+}
+
+func (s *Server) claimedMib() uint64 {
+	if d, ok := s.driver.(interface{ ClaimedMib() uint64 }); ok {
+		return d.ClaimedMib()
+	}
+	return 0
 }
 
 // memPressured reports whether free schedulable memory is below the workload's

--- a/projects/embervm/noded/server/pressure_test.go
+++ b/projects/embervm/noded/server/pressure_test.go
@@ -153,3 +153,60 @@ func TestUnderPressureFloorFallback(t *testing.T) {
 		t.Fatalf("memRejectFloorMib fallback = %d, want %d", got, minSlotWorkloadMib)
 	}
 }
+
+func TestReservedAdmissionBoundaryAndOverhead(t *testing.T) {
+	_, srv := newTestServer(t, &fakeDriver{live: 1, claimedMib: 400}, &fakeTransport{}, 8)
+	srv.cfg.AdmissionModel = "reserved"
+	srv.memBudget = func() uint64 { return 1000 }
+	if got := srv.memExhausted(600); got {
+		t.Fatal("reserved admission rejected the exact claimed+need boundary")
+	}
+	if got := srv.memExhausted(601); !got {
+		t.Fatal("reserved admission admitted above the claimed+need boundary")
+	}
+	srv.cfg.VMOverheadMib = 1
+	if got := srv.memExhausted(599); !got {
+		t.Fatal("positive VM overhead did not tighten reserved admission")
+	}
+	srv.cfg.VMOverheadMib = 0
+	if got := srv.memExhausted(600); got {
+		t.Fatal("zero VM overhead changed the boundary")
+	}
+}
+
+func TestObservedAdmissionMatchesExistingPredicate(t *testing.T) {
+	_, srv := newTestServer(t, &fakeDriver{live: 1, claimedMib: 9999}, &fakeTransport{}, 8)
+	srv.cfg.AdmissionModel = "observed"
+	srv.memBudget = func() uint64 { return 4096 }
+	for _, headroom := range []uint64{0, 511, 512, 1024} {
+		srv.memHeadroom = func() uint64 { return headroom }
+		for _, need := range []uint64{0, 512, 1024} {
+			if got, want := srv.memExhausted(need), srv.memPressured(need); got != want {
+				t.Fatalf("observed admission headroom=%d need=%d = %v, want existing %v", headroom, need, got, want)
+			}
+		}
+	}
+}
+
+func TestObservedModelRefusesOnLowHeadroomEvenWhenBudgetReadsZero(t *testing.T) {
+	_, srv := newTestServer(t, &fakeDriver{}, &fakeTransport{}, 8)
+	// The admission model is unset, so this is the observed model. A zero budget
+	// with positive headroom is the memory.max <= DaemonReserveMib case.
+	srv.memBudget = func() uint64 { return 0 }
+	srv.memHeadroom = func() uint64 { return minSlotWorkloadMib - 1 }
+
+	if got := srv.memExhausted(0); !got {
+		t.Fatal("observed model admitted on low headroom even when budget reads zero")
+	}
+}
+
+func TestUnknownBudgetAdmitsBothModels(t *testing.T) {
+	_, srv := newTestServer(t, &fakeDriver{live: 2, claimedMib: 9999}, &fakeTransport{}, 8)
+	srv.memBudget = func() uint64 { return 0 }
+	for _, model := range []string{"observed", "reserved"} {
+		srv.cfg.AdmissionModel = model
+		if got := srv.memExhausted(1 << 30); got {
+			t.Fatalf("unknown budget in %s model exhausted admission", model)
+		}
+	}
+}

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1346,6 +1346,9 @@ func (s *Server) Relight(ctx context.Context, req *nodev1.RelightRequest) (*node
 	if s.slotsExhausted() {
 		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.SlotCeiling())
 	}
+	if err := s.admitOrReject(0, classMemOnly); err != nil {
+		return nil, err
+	}
 	if !s.sessionSnap.has(ref) {
 		return nil, status.Errorf(codes.FailedPrecondition, "noded: unknown session snapshot_ref %q", ref)
 	}
@@ -1696,6 +1699,10 @@ func (s *Server) nodeStatus() *nodev1.NodeStatus {
 	live := taskLive + len(sessionVMs) + len(servingVMs) + len(statefulVMs) + len(groupMemberVMs)
 	snaps := s.sessionSnapshotsStatus()
 	freeBytes, usedBytes := s.snapshotDiskUsage()
+	vmOverheadMib := uint64(0)
+	if s.cfg.VMOverheadMib > 0 {
+		vmOverheadMib = uint64(s.cfg.VMOverheadMib)
+	}
 	ns := &nodev1.NodeStatus{
 		NodeId:                s.cfg.Node,
 		PodUid:                s.cfg.PodUID,
@@ -1725,6 +1732,9 @@ func (s *Server) nodeStatus() *nodev1.NodeStatus {
 		GroupBundleSets:       s.groupBundleSetsStatus(),
 		StoreReachable:        s.storeReachableNow(),
 		MemBudgetMib:          s.memBudget(),
+		MemReservedMib:        s.claimedMib(),
+		AdmitsOnReservation:   s.cfg.AdmissionModel == "reserved",
+		VmOverheadMib:         vmOverheadMib,
 		CpuBudgetMillicores:   s.cpuBudget(),
 		CpuSku:                s.cpuSku(),
 		LocalBases:            s.localBasesStatus(),

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -42,6 +42,7 @@ type fakeDriver struct {
 	statsCalls    int
 	snapshots     int
 	live          int
+	claimedMib    uint64
 	failClaim     error
 	// failRelease injects a driver Release failure so a test can prove a reap
 	// failure surfaces as a Destroy error (teardown NOT confirmed), not a false
@@ -124,6 +125,12 @@ func (f *fakeDriver) LiveCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.live
+}
+
+func (f *fakeDriver) ClaimedMib() uint64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.claimedMib
 }
 
 func (f *fakeDriver) SnapshotBase(_ context.Context, _ substrate.Handle, baseKey string) (substrate.SnapshotRef, error) {
@@ -1337,6 +1344,18 @@ func TestNodeStatusCarriesBudgetFields(t *testing.T) {
 	}
 	if got, want := ns.GetCpuHeadroomMillicores(), uint32(1500); got != want {
 		t.Errorf("cpu_headroom_millicores = %d, want %d (must no longer be hard-coded 0)", got, want)
+	}
+	if ns.GetAdmitsOnReservation() {
+		t.Error("default admission model advertises admits_on_reservation=true")
+	}
+	if got := ns.GetMemReservedMib(); got != 0 {
+		t.Errorf("empty brick mem_reserved_mib = %d, want 0", got)
+	}
+	if got := ns.GetVmOverheadMib(); got != 0 {
+		t.Errorf("default vm_overhead_mib = %d, want 0", got)
+	}
+	if ns.GetMemReservedMib() == 0 && ns.GetAdmitsOnReservation() {
+		t.Error("zero mem_reserved_mib must not be interpreted as reservation model off")
 	}
 }
 

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -2080,4 +2080,17 @@ message NodeStatus {
   // forward-compat but only the L7 serving lane consumes an activator this phase;
   // the L4 lane moves node-local in Fork A Phase 2. Empty until then.
   string activator_ip = 33;
+
+  // -- Admission reservation facts (Phase B2b, additive) --------------------
+  // mem_reserved_mib is the declared-memory sum projected from the daemon's
+  // live VM map. It is the reconciliation counterpart to the control plane's
+  // own reservation view and is 0 on an empty brick.
+  uint64 mem_reserved_mib = 35;
+  // admits_on_reservation explicitly identifies the daemon's admission model.
+  // It MUST NOT be inferred from mem_reserved_mib: zero is a legitimate empty
+  // reservation, and proto3 has no null value.
+  bool admits_on_reservation = 36;
+  // vm_overhead_mib is the configured per-VM host overhead charged by the
+  // reserved admission model. It is additive and may be 0.
+  uint64 vm_overhead_mib = 37;
 }


### PR DESCRIPTION
Refs #4140, Phase B PR B2b. **Ships inert**: the new arithmetic is behind a flag defaulting to today's behaviour.

## Why

EmberVM admits VMs by reading **observed** cgroup headroom (`budget.go` `MemHeadroomMib` = `memory.max - working_set`, consumed by `pressure.go` `memPressured`). Kubernetes never does this: it sums **declared** requests and reserves them at *assume* time, before the pod runs, and kubelet admission checks the same arithmetic. Observed usage lags badly here because a restored Firecracker guest faults its pages in lazily, so a just-started VM reports almost no usage for seconds.

Most of the compensating machinery in this repo exists only because the number is a measurement rather than a reservation: the reject floor cushion, `Placement.Retry`, `minSlotWorkloadMib`, and the advertise/admit split that was #4101.

ADR embervm/020 decision 4 independently requires this on the brick side: *"Candidates decrement capacity at **accept** under a short reservation TTL, and an inbound acceptance runs the same `admitOrReject` predicate."*

## Derived, not counted

The ledger is a **projection of the driver's live VM map**, not a parallel counter:

- every `Claim*` path already computes its `memMib`, so `instance` now carries it
- `ClaimedMib()` sums over `d.live` under the same lock `LiveCount()` uses
- `Release` already removes the entry, so **release is automatic**

This is deliberate. A counter can leak, and a leaked claim fills a brick with phantom reservations that wedge every placement on it. That was the single worst failure this design could produce, and a projection cannot exhibit it.

**No reseeding on restart**, also deliberate: Firecracker processes are children of noded (`exec.Command` in `launcher.go`), there is no adoption path for pre-existing VMs, and noded drains on SIGTERM. So an empty live map after a restart is *correct*, not a gap to repair.

## Inert by default, and byte-identical means byte-identical

`EMBERVM_NODED_ADMISSION_MODEL` defaults to `observed`. The model dispatch happens **before** any of the new budget guards, so the observed path is literally the old `memPressured` call.

That ordering is load-bearing and was a review fix. An earlier revision put the `budget == 0` guard above the dispatch, which is not equivalent: `parseMemBudgetMib` returns 0 when `memory.max <= reserveMib`, while `parseMemHeadroomMib` never subtracts the reserve. On a brick at or below the 512 MiB reserve, budget reads 0 while headroom is still positive, so the guard would have **admitted where the old code refused**. Unreachable on today's fleet (smallest class is 2gi), which is exactly why it needed catching now rather than the day someone adds a smaller class. There is a regression test asserting the property directly.

`EMBERVM_NODED_VM_OVERHEAD_MIB` defaults to **0**. It exists now so that setting a real per-VM host overhead (jailer, vsock buffers, restore page cache) later needs no wire change.

## Proto

Additive on `NodeStatus`: `mem_reserved_mib`, `admits_on_reservation`, `vm_overhead_mib`.

`admits_on_reservation` is an **explicit bool and must never be inferred** from `mem_reserved_mib == 0`. Proto3 has no null, a zero reserved is legitimate on an empty brick, and that exact confusion is behind #4101, #4141 and #4145. ADR embervm/020 specified it as a bool for the same reason.

## Tests

`ClaimedMib()` sums across mixed claim paths and returns to 0 after each `Release`, proving the projection tracks the map. The reserved model refuses past budget and admits at exactly the boundary. The observed model is asserted unchanged, including the zero-budget-positive-headroom case above. Unknown budget admits under both models. Overhead at 0 changes nothing; positive tightens. `NodeStatus` carries the capability bool independently of the reserved count.

## Verification

`ci lint` clean. `ci test` exit 0, `Executed 3 out of 743 tests: 743 tests pass` (driver, server and config targets re-ran). Elixir reports `MIX TEST OK on the executor`, `1041 tests, 0 failures`, unchanged from main, confirming no `control/` file was touched.

## What this does not do

Nothing flips yet. The control plane still filters on observed headroom, and this daemon still admits on it too until the model is switched. The flip, the control plane's advisory ledger, and the shadow-mode divergence measurement that must gate the flip are later PRs on #4140.