### PR TITLE
fix(embervm): dial the scored brick on a task-dispatch miss

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.306
+version: 0.1.307

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -559,11 +559,8 @@ defmodule Embervm.Dispatcher do
         # DISTINCT candidate pools (R0 PR-2, brick-capacity). We deliberately do
         # NOT collapse a node to one instance: each brick is its own capacity unit,
         # so all of a node's healthy instances stay candidates. Warmth stays a
-        # two-tier decision here (prefer a brick that already holds a primed VM
-        # over a miss that must prime one); within each tier BrickLedger.choose is
-        # the deterministic sticky tie-break (sorted by instance_id, hashed on the
-        # workload) so misses spread across same-node bricks instead of hot-spotting
-        # the first one, and the choice is stable run to run. A draining instance
+        # two-tier decision here, with BrickLedger.choose selecting the warm brick
+        # and Score.order selecting the miss frontier. A draining instance
         # never reaches here (its capacity row is dropped fail-closed); the removed
         # prefer-newest also covered the seconds-wide surge window before the old
         # pod flips to draining, so we accept a rare, self-healing chance of picking
@@ -592,8 +589,17 @@ defmodule Embervm.Dispatcher do
                 has_budget?(f) and Embervm.Placement.mem_eligible?(f, need_mib)
               end)
 
-            case BrickLedger.choose(miss_candidates, wl) do
-              nil ->
+            # The ORDERED miss frontier (ADR 014 decision 3 reject/retry) and the
+            # committed brick, read from ONE `Score.order` result so they cannot
+            # diverge: the head IS the commit. They used to be computed apart, the
+            # frontier keeping a flat instance_id sort plus hash rotation from
+            # before scoring existed, and since the worker Primes the frontier head
+            # (gate off = exactly one attempt) that stale order was what actually
+            # placed, so packing and best-fit never reached this path.
+            ordered = Embervm.Placement.Score.order(miss_candidates, wl)
+
+            case ordered do
+              [] ->
                 # A true CAPACITY wall (Axis C demand signal): ready, base-holding
                 # candidates exist but every one is out of slots or too small for
                 # the workload's mem_mib. The no-base / stale branches above are
@@ -603,14 +609,20 @@ defmodule Embervm.Dispatcher do
                 Embervm.BrickController.note_denial(need_mib)
                 {:error, :no_capacity}
 
-              f ->
-                # The ORDERED miss frontier (ADR 014 decision 3 reject/retry): the
-                # eligible bricks in the SAME order BrickLedger.choose traverses, so
-                # its HEAD is exactly `f` (today's single pick, gate-off equivalence)
-                # and the tail is the next-candidate sequence the worker retries when
-                # a brick rejects under node pressure. Each entry carries the
-                # instance_id to dial AND that instance's base snapshot_ref for Prime.
-                miss_frontier = miss_candidate_frontier(miss_candidates, wl)
+              [f | _] ->
+                # Each entry is a MAP carrying the :instance_id to dial (the
+                # Retry.run contract reads it for logging/on_reject) plus that
+                # instance's own :snapshot_ref for the Prime. A bare tuple crashes
+                # Retry's Logger.debug with a BadMapError on the first rejection,
+                # so the map shape is load-bearing, not cosmetic.
+                miss_frontier =
+                  Enum.map(ordered, fn brick ->
+                    %{
+                      instance_id: instance_id_of(brick),
+                      snapshot_ref: snapshot_ref_of(brick, wl)
+                    }
+                  end)
+
                 {:ok, instance_id_of(f), :miss, snapshot_ref_of(f, wl), miss_frontier}
             end
 
@@ -623,27 +635,6 @@ defmodule Embervm.Dispatcher do
              [%{instance_id: instance_id_of(warm), snapshot_ref: snapshot_ref_of(warm, wl)}]}
         end
     end
-  end
-
-  # Order raw capacity FACTS the same way BrickLedger.choose/2 traverses them
-  # (sorted by :instance_id, rotated so the choose-selected fact is first), then
-  # project each to the {instance_id, snapshot_ref} pair the miss worker Primes.
-  # HEAD == BrickLedger.choose(facts, key), so a gate-off single attempt dials
-  # exactly the brick today's code would; the tail is the deterministic retry
-  # frontier. Mirrors Embervm.Placement's sort_by_choose_key rotation, but over
-  # raw facts (which carry `workloads` for snapshot_ref_of) rather than bricks.
-  # Each candidate is a MAP carrying :instance_id (the Retry.run contract, which
-  # reads Map.get(brick, :instance_id) for its logging/on_reject) plus the
-  # :snapshot_ref the Prime needs. A bare {id, ref} tuple would crash Retry's
-  # Logger.debug with a BadMapError on the first rejection, so the map shape is
-  # load-bearing, not cosmetic.
-  defp miss_candidate_frontier(facts, key) do
-    sorted = Enum.sort_by(facts, fn f -> instance_id_of(f) end)
-    idx = :erlang.phash2(key, length(sorted))
-    {head, tail} = Enum.split(sorted, idx)
-
-    (tail ++ head)
-    |> Enum.map(fn f -> %{instance_id: instance_id_of(f), snapshot_ref: snapshot_ref_of(f, key)} end)
   end
 
   # The instance handle the dispatcher keys inventory / NodeChannel / BaseBuilder

--- a/projects/embervm/control/test/embervm/dispatcher_test.exs
+++ b/projects/embervm/control/test/embervm/dispatcher_test.exs
@@ -15,6 +15,7 @@ defmodule Embervm.DispatcherTest do
 
   alias Embervm.{Dispatcher, NodeCapacity, TaskStore, WorkloadCatalog}
   alias Embervm.OpLog.SQLite
+  alias Embervm.Placement.Score
   alias Embervm.Node.V1.{AssignRequest, AssignResponse, GuestResponse, PrimeResponse, Trace, UsageStats}
 
   # -- harness ---------------------------------------------------------------
@@ -297,6 +298,74 @@ defmodule Embervm.DispatcherTest do
     stats = Dispatcher.stats(ctx.name)
     assert stats.misses >= 1
     assert stats.warm_hits == 0
+  end
+
+  test "a miss commits and retries in Score.order order" do
+    parent = self()
+    suffix =
+      Enum.find(0..1_024, fn n ->
+        :erlang.phash2("wl-test-ordering-#{n}", 2) == 0
+      end)
+
+    wl = "wl-test-ordering-#{suffix}"
+    flat_rotation = :erlang.phash2(wl, 2)
+    assert flat_rotation == 0
+
+    ctx =
+      start_stack(
+        stale_after_ms: 60_000,
+        channel_fun: fn instance ->
+          send(parent, {:miss_dialed, instance})
+          {:ok, instance}
+        end
+      )
+
+    put_catalog(ctx, wl, cap: 10, mem_mib: 1_000)
+
+    put_facts(ctx, wl,
+      key: {"node-4", "apple"},
+      instance_id: "apple",
+      size_class: "8gi",
+      mem_budget: 8_192,
+      mem_headroom: 8_192,
+      free: 0,
+      live: 0,
+      max: 8
+    )
+
+    put_facts(ctx, wl,
+      key: {"node-4", "zoo"},
+      instance_id: "zoo",
+      size_class: "8gi",
+      mem_budget: 8_192,
+      mem_headroom: 8_192,
+      free: 0,
+      live: 1,
+      max: 8
+    )
+
+    candidates = [
+      %{instance_id: "apple", size_class: "8gi", mem_budget_mib: 8_192, mem_headroom_mib: 8_192, live_vms: 0, max_live_vms: 8},
+      %{instance_id: "zoo", size_class: "8gi", mem_budget_mib: 8_192, mem_headroom_mib: 8_192, live_vms: 1, max_live_vms: 8}
+    ]
+
+    score_ids = Score.order(candidates, wl) |> Enum.map(& &1.instance_id)
+    flat_ids =
+      candidates
+      |> Enum.sort_by(& &1.instance_id)
+      |> then(fn sorted ->
+        {head, tail} = Enum.split(sorted, flat_rotation)
+        Enum.map(tail ++ head, & &1.instance_id)
+      end)
+
+    assert score_ids == ["zoo", "apple"]
+    assert flat_ids == ["apple", "zoo"]
+    assert score_ids != flat_ids
+    [score_head | _] = score_ids
+
+    tid = submit(ctx, wl, "p1")
+    assert eventually(fn -> state_of(ctx, tid) == :succeeded end)
+    assert_receive {:miss_dialed, ^score_head}, 2_000
   end
 
   # -- size-aware miss placement (Step 5) ------------------------------------

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.306
+      targetRevision: 0.1.307
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## The bug

`Dispatcher.pick_node/3` computed the committed brick one way and the retry frontier another, and the worker consumed the second one.

| | Ordering |
|---|---|
| committed brick `f` | `BrickLedger.choose/2` = `Score.order \|> List.first` |
| `miss_candidate_frontier/2` | flat `sort_by(instance_id)` + `phash2(key, len)` rotation |

The second is the pre-scoring algorithm, left in place when #4142 introduced `Score.order`. `pick_node/3` returns `f` as the committed instance, but `acquire_vm/4` routes a miss through `prime_with_retry/4`, which iterates `ctx.candidates` (the frontier) via `Retry.run/2`. `EMBERVM_PLACEMENT_RETRY` defaults **off**, so exactly one attempt is made, on the frontier head. `f` was used only for `ctx.node_id` bookkeeping and `ctx.snapshot_ref`.

The two orders coincide only when every eligible brick ties on rounded score **and** on `mem_budget_mib`. Otherwise the frontier head is a different brick from the scored winner, so on the live fleet the task-dispatch miss path (the highest-volume placement path) was still choosing by instance_id hash rotation, which is spread. **#4142's MostAllocated packing and #4152's best-fit tie-break were dead code there.**

The comment at the old `miss_candidate_frontier/2` asserted `HEAD == BrickLedger.choose(facts, key)`. That was true when written; #4142 falsified it without touching it.

## The fix

One `Score.order` result, read twice: the frontier is the ordered list and the committed brick is its head, so they cannot diverge. `miss_candidate_frontier/2` is deleted. This is the same projection pattern the rest of this program has been using (`choose/2` becoming `order |> List.first()`, `nodeStatus` becoming `SlotCeiling()`, `ClaimedMib()` becoming a sum over the live map): remove the category of bug rather than keep two values in sync.

No change to the warm tier, the stale/no-base error taxonomy, `has_budget?`, the `mem_eligible?` gate, the `note_denial` signal, or the return shape.

## Why the existing tests missed it

`dispatcher_test.exs:374` seeds two **identical** co-located bricks and asserts hash-agnostically, so both orderings produce the same answer.

The new guard forces them apart. It picks a workload key whose `phash2(wl, 2)` is 0, pinning the old flat order to `["apple", "zoo"]`, then gives `zoo` one live VM against `apple`'s zero so MostAllocated scores `zoo` at 0.0625 versus `apple` at 0.0 and the new order is `["zoo", "apple"]`. The assertion is against the real dispatcher, not a mirror.

## Evidence

Both directions run through `ci test` (BuildBuddy remote, the `mix_test_smoke` genrule).

Against `origin/main`'s `dispatcher.ex` with the new test retained:

```
1) test a miss commits and retries in Score.order order (Embervm.DispatcherTest)
   Assertion failed, no matching message after 2000ms
     score_head = "zoo"
     value:   {:miss_dialed, "apple"}
1042 tests, 1 failure, 6 skipped
```

With the fix:

```
1042 tests, 0 failures, 6 skipped
```

Worth noting that the failing run's bazel headline read `Executed 0 out of 743 tests: 743 tests pass.` while the Elixir suite had a real failure, because the control-plane suite is a genrule and not a test target. The `NNNN tests, N failures` line is the only signal that covers it.

Chart bumped 0.1.306 to 0.1.307 with `targetRevision` moved together.

Refs #4140.