### PR TITLE
fix(embervm): exclude reclaimable page cache from brick admission headroom

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.310
+version: 0.1.311

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.310
+      targetRevision: 0.1.311
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/budget.go
+++ b/projects/embervm/noded/server/budget.go
@@ -305,32 +305,43 @@ func parseMemHeadroomMib(maxRaw, curRaw, statRaw string) uint64 {
 	if err != nil || curB < 0 {
 		return 0
 	}
-	workingSetB := curB
+	var fileB, shmemB uint64
 	for _, line := range strings.Split(statRaw, "\n") {
 		fields := strings.Fields(line)
-		if len(fields) != 2 || fields[0] != "inactive_file" {
+		if len(fields) != 2 || (fields[0] != "file" && fields[0] != "shmem") {
 			continue
 		}
-		inactiveFileB, statErr := strconv.ParseUint(fields[1], 10, 64)
+		statB, statErr := strconv.ParseUint(fields[1], 10, 64)
 		if statErr != nil {
-			break
+			continue
 		}
-		// kubelet uses inactive_file for working_set because this cache is
-		// reclaimed first under pressure. Do not subtract all file cache,
-		// or anon plus slab, since those are not equivalent eviction signals.
-		// The cgroup files are read separately, so inactive_file can race
-		// memory.current. Keep the conservative current-based working set when
-		// the sample is racy instead of treating it as fully reclaimable.
-		if inactiveFileB < uint64(curB) {
-			workingSetB = curB - int64(inactiveFileB)
+		if fields[0] == "file" {
+			fileB = statB
+		} else {
+			shmemB = statB
 		}
-		break
 	}
 
-	if uint64(maxB) <= uint64(workingSetB) {
+	var reclaimableB uint64
+	if fileB > shmemB {
+		reclaimableB = fileB - shmemB
+	}
+	if reclaimableB > uint64(curB) {
+		reclaimableB = uint64(curB)
+	}
+	nonReclaimableB := uint64(curB) - reclaimableB
+
+	// Kubelet's working set answers "how close is this container to being
+	// OOM-killed", where reclaiming active_file has a cost, so counting it as
+	// free under-predicts OOM risk. noded asks a different question: "can a VM
+	// of N MiB allocate here". Clean page cache is available for that question
+	// because the kernel evicts it long before it OOM-kills. shmem is excluded
+	// because it is not reclaimable without swap.
+	// Subtracting only inactive_file was the incomplete earlier fix for #4058.
+	if uint64(maxB) <= nonReclaimableB {
 		return 0
 	}
-	return (uint64(maxB) - uint64(workingSetB)) / (1 << 20)
+	return (uint64(maxB) - nonReclaimableB) / (1 << 20)
 }
 
 // parseMemBudgetMib computes (max - reserve) in MiB from cgroup v2

--- a/projects/embervm/noded/server/budget_test.go
+++ b/projects/embervm/noded/server/budget_test.go
@@ -33,7 +33,7 @@ func TestBudgetReadsCgroupV2(t *testing.T) {
 	withBudgetFsRoot(t, map[string]string{
 		"memory.max":     "4294967296\n", // 4 GiB
 		"memory.current": "1073741824\n", // 1 GiB
-		"memory.stat":    "inactive_file 0\n",
+		"memory.stat":    "file 0\n",
 		"cpu.max":        "200000 100000\n", // 2 cores
 		"cpu.stat":       "usage_usec 1000000\nnr_periods 5\n",
 	})
@@ -86,51 +86,100 @@ func TestParseMemHeadroomMibWithPageCache(t *testing.T) {
 		name                    string
 		maxRaw, curRaw, statRaw string
 		want                    uint64
+		min                     uint64
 	}{
+		// #4058 was the same bug on node-2, with only 13 percent of cache active.
+		// Its fix subtracted inactive_file alone and passed because of that ratio.
+		// The ratio reflects recent access patterns, not the workload itself.
+		// That is why #4157 recurred once active_file reached half the cache.
 		{
-			name:    "issue 4058 reclaimable cache",
+			name:    "issue 4058 reclaimable cache regression",
 			maxRaw:  "2147483648",
 			curRaw:  "1482084352",
-			statRaw: "inactive_file 1263054848\n",
-			want:    1839,
+			statRaw: "file 1456840704\nshmem 0\n",
+			want:    2023,
+			min:     1024,
 		},
 		{
-			name:    "current equals max with reclaimable",
+			name:    "issue 4157 production cache regression",
 			maxRaw:  "2147483648",
-			curRaw:  "2147483648",
-			statRaw: "inactive_file 1073741824\n",
+			curRaw:  "2144251904",
+			statRaw: "file 2111016960\nshmem 0\n",
+			want:    2016,
+			min:     1024,
+		},
+		{
+			name:    "shmem is not reclaimable",
+			maxRaw:  "2147483648",
+			curRaw:  "1073741824",
+			statRaw: "file 1073741824\nshmem 1073741824\n",
 			want:    1024,
 		},
 		{
-			name:    "stat missing falls back to max minus current",
+			name:    "racy file sample is clamped to current",
 			maxRaw:  "2147483648",
-			curRaw:  "1482084352",
-			statRaw: "",
-			want:    634,
+			curRaw:  "536870912",
+			statRaw: "file 1073741824\n",
+			want:    2048,
 		},
-		{name: "missing stat", maxRaw: "4294967296", curRaw: "1073741824", want: 3072},
 		{
-			name:    "stat without inactive file",
+			name:    "missing shmem defaults to zero",
 			maxRaw:  "4294967296",
 			curRaw:  "1073741824",
-			statRaw: "anon 123456\nfile 987654\n",
+			statRaw: "file 987654\n",
 			want:    3072,
 		},
 		{
-			name:    "racy inactive file",
-			maxRaw:  "2147483648",
-			curRaw:  "536870912",
-			statRaw: "inactive_file 1073741824\n",
-			want:    1536,
+			name:    "missing stat",
+			maxRaw:  "4294967296",
+			curRaw:  "1073741824",
+			statRaw: "",
+			want:    3072,
 		},
-		{name: "unlimited", maxRaw: "max", curRaw: "1073741824", statRaw: "inactive_file 1\n", want: 0},
-		{name: "invalid inputs", maxRaw: "garbage", curRaw: "1", statRaw: "inactive_file 1\n", want: 0},
-		{name: "invalid current", maxRaw: "2147483648", curRaw: "garbage", statRaw: "inactive_file 1\n", want: 0},
+		{
+			name:    "max is unknown",
+			maxRaw:  "max",
+			curRaw:  "1073741824",
+			statRaw: "file 1\n",
+			want:    0,
+		},
+		{
+			name:    "empty max is unknown",
+			maxRaw:  "",
+			curRaw:  "1073741824",
+			statRaw: "file 1\n",
+			want:    0,
+		},
+		{
+			name:    "invalid max",
+			maxRaw:  "garbage",
+			curRaw:  "1",
+			statRaw: "file 1\n",
+			want:    0,
+		},
+		{
+			name:    "invalid current",
+			maxRaw:  "2147483648",
+			curRaw:  "garbage",
+			statRaw: "file 1\n",
+			want:    0,
+		},
+		{
+			name:    "max is no greater than nonreclaimable",
+			maxRaw:  "2147483648",
+			curRaw:  "2147483648",
+			statRaw: "file 1\nshmem 1\n",
+			want:    0,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := parseMemHeadroomMib(c.maxRaw, c.curRaw, c.statRaw); got != c.want {
+			got := parseMemHeadroomMib(c.maxRaw, c.curRaw, c.statRaw)
+			if got != c.want {
 				t.Errorf("parseMemHeadroomMib(%q, %q, %q) = %d, want %d", c.maxRaw, c.curRaw, c.statRaw, got, c.want)
+			}
+			if c.min != 0 && got <= c.min {
+				t.Errorf("parseMemHeadroomMib(%q, %q, %q) = %d, want comfortably above %d", c.maxRaw, c.curRaw, c.statRaw, got, c.min)
 			}
 		})
 	}
@@ -290,7 +339,7 @@ func TestCgroupDirResolvesHostNsPath(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(leaf, "memory.current"), []byte("536870912\n"), 0o644); err != nil {
 		t.Fatalf("write leaf memory.current: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(leaf, "memory.stat"), []byte("inactive_file 0\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(leaf, "memory.stat"), []byte("file 0\n"), 0o644); err != nil {
 		t.Fatalf("write leaf memory.stat: %v", err)
 	}
 	withSelfCgroup(t, "0::/kubepods.slice/cri-containerd-abc.scope\n")


### PR DESCRIPTION
Closes #4157. This is a recurrence of #4058, whose fix was incomplete.

## The brick refused a wake at 8 MiB of real usage

`demo-postgres` failed to relight every 15 seconds with `noded: pressure:mem (need 512 MiB, floor 512 MiB)`. Only one brick was ever tried, because a stateful workload is anchored to the node holding its volume. That brick's leaf cgroup:

| field | MiB |
|---|---|
| `memory.max` | 2048 |
| `memory.current` | 2044.9 |
| **`anon`** | **8.2** |
| `file` | 2013 |
| `inactive_file` | 999.6 |
| `active_file` | 1013.7 |

Advertised headroom was 2048 - (2044.9 - 999.6) = 1003 MiB, against the 1024 MiB that `need + reject floor` requires. **Refused by 21 MiB on a brick whose processes held 8 MiB.**

## Why the old formula was wrong here

`parseMemHeadroomMib` used kubelet's working set, and the comment correctly explained kubelet's reasoning: reclaiming `active_file` has a cost, so counting it as free under-predicts OOM risk.

That is the right answer to kubelet's question, "how close is this container to being OOM-killed". noded asks a different one: "can a VM of N MiB allocate here". For that question clean page cache is available, because the kernel evicts it long before it OOM-kills. Same number, correct for one caller, wrong for the other.

## Why it never cleared on its own

It self-sustains: volume I/O fills the cache, repeat access promotes pages to `active_file`, headroom drops below the threshold, the wake is refused, and **a refused wake never allocates, so nothing creates the pressure that would reclaim the cache**. Pinned per-node bricks are worst affected, since an anchored workload has exactly one candidate and no fallback.

## Recurrence of #4058

#4058 was the same bug on node-2 two days earlier and was closed as fixed. Its fix subtracted `inactive_file`, which was sufficient only because that brick's cache was **13 percent** active when measured. On node-3 it was **50 percent** active. The active/inactive split reflects recent access patterns, not the workload, so it was never a stable thing to depend on.

The fix must therefore subtract cache that is reclaimable *at all*, not cache that is reclaimed *first*. Both production samples are now regression cases in the table, and the comment records the lineage so the incomplete fix is not reintroduced.

## Change

Headroom is computed against non-reclaimable memory: `file - shmem` (shmem is not reclaimable without swap), clamped to `memory.current` so a racy sample across separately-read cgroup files can never yield headroom above `memory.max`.

Deliberately **one** number, not two. `MemHeadroomMib` has exactly two consumers, `pressure.go` (noded's own admission) and `server.go` (the `NodeStatus.mem_headroom_mib` the control plane places against), and both ask the same question. A separate "admission" number beside a working-set one would manufacture exactly the advertise-versus-enforce divergence behind #4141 and #4101.

Every unknown and boundary case is preserved, including the contract that 0 means unknown and fails open.

## Confirmed in production

The 0.1.309 rollout restarted node-3's brick, which drops the cgroup and its cache. Working set went 1045Mi to 9Mi, and the wake that had been refused on that node for roughly 90 minutes succeeded immediately:

```
16:15:13  embervm stateful adopted (activator-woken, relit)   node_id=node-3
16:15:17  embervm stateful checkpoint committed               node_id=node-3
```

Probe latched `postgres | t | relight, 1080ms`; public `/health` returned 200.

Worth noting for future triage: **any embervm rollout masks this bug**, because every brick restart clears the cache that causes it. A quiet period after a deploy is not evidence it is fixed.

## Verification

`ci test` green with `Executed 1 out of 743 tests` and 49 processes, so the noded test target genuinely ran rather than serving a warm cache.

Not included, deliberately: `POSIX_FADV_DONTNEED` on the volume image after banking. It is worthwhile, but once cache stops counting against headroom it is an optimisation rather than a correctness fix, and it touches the volume write path.