### PR TITLE
feat(embervm): add the CP reservation ledger, inert

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.312
+version: 0.1.313

--- a/projects/embervm/control/lib/embervm/application.ex
+++ b/projects/embervm/control/lib/embervm/application.ex
@@ -133,6 +133,10 @@ defmodule Embervm.Application do
       # Mint gRPC connection, so it does not depend on the Finch pool. With no node
       # wired (empty address), it supervises an empty node list and does nothing.
       {Embervm.NodeRegistry, node_registry_opts()},
+      # The shadow reservation ledger must be up before any claim site can use it.
+      # It is placed before the readers so a ledger restart also bounces them
+      # rather than leaving them reading a dead ETS table.
+      {Embervm.Scheduler.Reservation, []},
       # The shared per-node gRPC channel holder (Task 11): one long-lived, reused
       # Mint channel per node for the Prime/Assign hot path (unlike NodeRegistry/
       # BaseBuilder, which each own their own channel and can afford a per-op

--- a/projects/embervm/control/lib/embervm/scheduler/reservation.ex
+++ b/projects/embervm/control/lib/embervm/scheduler/reservation.ex
@@ -1,0 +1,291 @@
+defmodule Embervm.Scheduler.Reservation do
+  @moduledoc """
+  Shadow reservation ledger for declared VM memory.
+
+  The ledger is CP intent, not node runtime truth. It stores per-reference entries
+  in the public `:embervm_reservations` ETS table so rows can be reconciled as a
+  set rather than as a drifting counter. Claims are never refused in shadow.
+
+  Reconciliation has a grace age because a newly claimed VM may not have appeared
+  in the next node report yet. Pool targets are CP intent without one corresponding
+  reported VM and are never absence-collected. The table starts empty after a CP
+  restart, which is correct because NodeCapacity is fail-closed empty until a node
+  reports again.
+
+  NodeStatus does not report declared memory for any live VM. `adopt/3` therefore
+  requires a workload-to-memory catalog lookup supplied in its options; it must
+  not derive memory from observed node usage.
+  """
+
+  use GenServer
+
+  @table :embervm_reservations
+  @default_liveness_interval_ms 5_000
+
+  @type entry :: %{
+          ref: term(),
+          workload: term(),
+          mem_mib: non_neg_integer(),
+          count: pos_integer(),
+          kind: :instance | :pool_target,
+          claimed_at_ms: integer(),
+          confirmed_at_ms: integer() | nil
+        }
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @spec table() :: atom()
+  def table, do: @table
+
+  @spec claim(term(), term(), keyword()) :: :ok
+  def claim(instance_id, ref, opts) when is_list(opts) do
+    claim(Keyword.get(opts, :server, __MODULE__), instance_id, ref, opts)
+  end
+
+  @spec claim(GenServer.server(), term(), term(), keyword()) :: :ok
+  def claim(server, instance_id, ref, opts) when is_list(opts) do
+    GenServer.call(server, {:claim, instance_id, ref, opts})
+  end
+
+  @spec release(term(), term()) :: :ok
+  def release(instance_id, ref), do: release(__MODULE__, instance_id, ref)
+
+  @spec release(GenServer.server(), term(), term()) :: :ok
+  def release(server, instance_id, ref) do
+    GenServer.call(server, {:release, instance_id, ref})
+  end
+
+  @spec set_pool_target(term(), term(), non_neg_integer(), non_neg_integer()) :: :ok
+  def set_pool_target(instance_id, workload, count, mem_mib),
+    do: set_pool_target(__MODULE__, instance_id, workload, count, mem_mib)
+
+  @spec set_pool_target(GenServer.server(), term(), term(), non_neg_integer(), non_neg_integer()) :: :ok
+  def set_pool_target(server, instance_id, workload, count, mem_mib) do
+    GenServer.call(server, {:set_pool_target, instance_id, workload, count, mem_mib})
+  end
+
+  @spec reserved_mib(term(), atom()) :: non_neg_integer()
+  def reserved_mib(instance_id, table \\ @table) do
+    instance_id
+    |> row(table)
+    |> Enum.reduce(0, fn entry, total -> total + entry.mem_mib * entry.count end)
+  end
+
+  @spec entries(term(), atom()) :: [entry()]
+  def entries(instance_id, table \\ @table), do: row(instance_id, table)
+
+  @spec reconcile(term(), MapSet.t() | Enumerable.t(), integer()) :: {:ok, [term()]}
+  def reconcile(instance_id, live_refs, now_ms),
+    do: reconcile(__MODULE__, instance_id, live_refs, now_ms)
+
+  @spec reconcile(GenServer.server(), term(), MapSet.t() | Enumerable.t(), integer()) :: {:ok, [term()]}
+  def reconcile(server, instance_id, live_refs, now_ms) do
+    GenServer.call(server, {:reconcile, instance_id, MapSet.new(live_refs), now_ms})
+  end
+
+  @spec drop_instance(term()) :: :ok
+  def drop_instance(instance_id), do: drop_instance(__MODULE__, instance_id)
+
+  @spec drop_instance(GenServer.server(), term()) :: :ok
+  def drop_instance(server, instance_id), do: GenServer.call(server, {:drop_instance, instance_id})
+
+  @spec all(atom()) :: %{term() => [entry()]}
+  def all(table \\ @table) do
+    :ets.foldl(fn {instance_id, row}, acc -> Map.put(acc, instance_id, Map.values(row)) end, %{}, table)
+  end
+
+  @doc """
+  Seeds `:instance` entries from an instance's node-reported live VMs, for
+  rebuilding the row after a control-plane restart. Declared memory comes from
+  the catalog, NOT from the node: `NodeStatus` carries no per-VM memory field.
+
+  ## adoption is INCOMPLETE, by the wire format
+
+  `NodeStatus` enumerates live VMs in five mutually exclusive lists
+  (`WorkloadCapacity.primed_vm_ids`, `session_vms`, `serving_vms`,
+  `stateful_vms`, `group_member_vms`). An ASSIGNED task VM is in none of them:
+  it leaves `primed_vm_ids` the moment it stops being parked, and the only
+  other signal is `live_vms`, an aggregate COUNT with no ids. So a row rebuilt
+  by adoption under-counts by the number of in-flight task assignments.
+
+  That is safe in the direction it fails. An under-count means the CP believes
+  a brick has MORE room than it does, so it may over-place; noded's own
+  declared-memory admission then refuses, costing one rejected RPC and never an
+  overcommit. An over-count would be the dangerous direction, and adoption
+  cannot produce one.
+
+  It is NOT safe to mistake for a leak. Reading the shadow-mode divergence
+  data, a persistent CP-below-node gap after a restart is this, not a lost
+  release, and it shrinks as assigned tasks complete rather than staying flat.
+  """
+  @spec adopt(term(), Enumerable.t(), keyword()) :: :ok
+  def adopt(instance_id, live_refs, opts) when is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:adopt, instance_id, Enum.to_list(live_refs), opts})
+  end
+
+  @impl true
+  def init(opts) do
+    table = Keyword.get(opts, :table, @table)
+    create_empty_table(table)
+
+    liveness_interval_ms =
+      Keyword.get(
+        opts,
+        :liveness_interval_ms,
+        Application.get_env(:embervm, :node_liveness_interval_ms, @default_liveness_interval_ms)
+      )
+
+    {:ok, %{table: table, grace_age_ms: Keyword.get(opts, :grace_age_ms, liveness_interval_ms * 2)}}
+  end
+
+  @impl true
+  def handle_call({:claim, instance_id, ref, opts}, _from, state) do
+    now_ms = Keyword.get(opts, :now_ms, System.system_time(:millisecond))
+    existing = Map.get(row_map(instance_id, state.table), ref)
+    confirmed_at_ms = if existing, do: existing.confirmed_at_ms, else: nil
+    entry = build_entry(ref, opts, now_ms, confirmed_at_ms)
+    put_entry(state.table, instance_id, entry)
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:release, instance_id, ref}, _from, state) do
+    update_row(state.table, instance_id, fn row -> Map.delete(row, ref) end)
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:set_pool_target, instance_id, workload, count, mem_mib}, _from, state) do
+    ref = {:pool, workload}
+
+    update_row(state.table, instance_id, fn row ->
+      if count == 0 do
+        Map.delete(row, ref)
+      else
+        existing = Map.get(row, ref)
+        claimed_at_ms = if existing, do: existing.claimed_at_ms, else: System.system_time(:millisecond)
+
+        Map.put(row, ref, %{
+          ref: ref,
+          workload: workload,
+          mem_mib: mem_mib,
+          count: count,
+          kind: :pool_target,
+          claimed_at_ms: claimed_at_ms,
+          confirmed_at_ms: nil
+        })
+      end
+    end)
+
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:reconcile, instance_id, live_refs, now_ms}, _from, state) do
+    current = row_map(instance_id, state.table)
+
+    {next, released} =
+      Enum.reduce(current, {%{}, []}, fn {ref, entry}, {kept, released} ->
+        cond do
+          entry.kind == :pool_target -> {Map.put(kept, ref, entry), released}
+          MapSet.member?(live_refs, ref) ->
+            confirmed = if is_nil(entry.confirmed_at_ms), do: %{entry | confirmed_at_ms: now_ms}, else: entry
+            {Map.put(kept, ref, confirmed), released}
+          now_ms - entry.claimed_at_ms >= state.grace_age_ms ->
+            {kept, [ref | released]}
+          true ->
+            {Map.put(kept, ref, entry), released}
+        end
+      end)
+
+    write_row(state.table, instance_id, next)
+    {:reply, {:ok, Enum.reverse(released)}, state}
+  end
+
+  def handle_call({:drop_instance, instance_id}, _from, state) do
+    :ets.delete(state.table, instance_id)
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:adopt, instance_id, live_refs, opts}, _from, state) do
+    now_ms = Keyword.get(opts, :now_ms, System.system_time(:millisecond))
+
+    Enum.each(live_refs, fn live ->
+      {ref, workload} = live_ref(live)
+      mem_mib = catalog_memory!(workload, live, opts)
+      put_entry(state.table, instance_id, build_entry(ref, [workload: workload, mem_mib: mem_mib], now_ms, now_ms))
+    end)
+
+    {:reply, :ok, state}
+  end
+
+  defp build_entry(ref, opts, now_ms, confirmed_at_ms) do
+    %{
+      ref: ref,
+      workload: Keyword.fetch!(opts, :workload),
+      mem_mib: Keyword.fetch!(opts, :mem_mib),
+      count: Keyword.get(opts, :count, 1),
+      kind: Keyword.get(opts, :kind, :instance),
+      claimed_at_ms: now_ms,
+      confirmed_at_ms: confirmed_at_ms
+    }
+  end
+
+  defp live_ref(%{ref: ref, workload: workload}), do: {ref, workload}
+  defp live_ref(%{vm_id: ref, workload: workload}), do: {ref, workload}
+  defp live_ref({ref, workload}), do: {ref, workload}
+
+  defp catalog_memory!(workload, live, opts) do
+    source = Keyword.get(opts, :mem_mib, Keyword.get(opts, :memory_by_workload, Keyword.get(opts, :catalog)))
+
+    value =
+      cond do
+        is_function(source, 1) -> source.(workload)
+        is_map(source) -> Map.get(source, workload)
+        is_integer(source) -> source
+        is_map(live) and is_integer(live[:mem_mib]) -> live[:mem_mib]
+        true -> nil
+      end
+
+    if is_integer(value) and value >= 0 do
+      value
+    else
+      raise ArgumentError, "adopt requires declared memory from the workload catalog"
+    end
+  end
+
+  defp put_entry(table, instance_id, entry) do
+    row = row_map(instance_id, table)
+    write_row(table, instance_id, Map.put(row, entry.ref, entry))
+  end
+
+  defp update_row(table, instance_id, fun) do
+    next = fun.(row_map(instance_id, table))
+    write_row(table, instance_id, next)
+  end
+
+  defp write_row(table, instance_id, row) when map_size(row) == 0, do: :ets.delete(table, instance_id)
+  defp write_row(table, instance_id, row), do: :ets.insert(table, {instance_id, row})
+
+  defp row(instance_id, table), do: Map.values(row_map(instance_id, table))
+  defp row_map(instance_id, table) do
+    case :ets.lookup(table, instance_id) do
+      [{^instance_id, row}] -> row
+      [] -> %{}
+    end
+  end
+
+  defp create_empty_table(table) do
+    try do
+      :ets.new(table, [:set, :public, :named_table, read_concurrency: true])
+    rescue
+      ArgumentError ->
+        :ets.delete_all_objects(table)
+        table
+    end
+  end
+end

--- a/projects/embervm/control/lib/embervm/scheduler/reservation.ex
+++ b/projects/embervm/control/lib/embervm/scheduler/reservation.ex
@@ -12,9 +12,19 @@ defmodule Embervm.Scheduler.Reservation do
   restart, which is correct because NodeCapacity is fail-closed empty until a node
   reports again.
 
+  Because absence collection deliberately never reclaims a `:pool_target`, callers
+  must zero the target when retiring a workload and drop the instance when a brick
+  expires. The wiring PR that handles those lifecycle events owns that obligation;
+  otherwise a deleted workload's pool reservation persists for the lifetime of the
+  CP process.
+
   NodeStatus does not report declared memory for any live VM. `adopt/3` therefore
   requires a workload-to-memory catalog lookup supplied in its options; it must
-  not derive memory from observed node usage.
+  not derive memory from observed node usage. The per-VM declared memory is absent
+  from `NodeStatus`, but the node-level declared SUM crosses the wire as
+  `NodeStatus.mem_reserved_mib` (proto field 35), populated by noded in both
+  admission models. That makes the divergence directly measurable per brick in
+  shadow mode.
   """
 
   use GenServer
@@ -114,17 +124,28 @@ defmodule Embervm.Scheduler.Reservation do
   other signal is `live_vms`, an aggregate COUNT with no ids. So a row rebuilt
   by adoption under-counts by the number of in-flight task assignments.
 
-  That is safe in the direction it fails. An under-count means the CP believes
-  a brick has MORE room than it does, so it may over-place; noded's own
-  declared-memory admission then refuses, costing one rejected RPC and never an
-  overcommit. An over-count would be the dangerous direction, and adoption
-  cannot produce one.
+  That fails safe in the direction it fails: an under-count means the CP believes
+  a brick has more room than it does, so it may over-place. On today's fleet the
+  backstop is noded's OBSERVED headroom gate, because the missing VM's memory is
+  already inside the brick's cgroup usage: the node charges it by measurement,
+  with no ledger involved, and a genuinely full brick refuses the boot for one
+  rejected RPC. That protection is lag-bounded rather than absolute, since a
+  just-restored guest faults its pages in lazily, which is the same lag this ledger
+  exists to close. Once admission flips to `reserved` it becomes exact: noded's
+  claims are a projection of its own live VM map, which DOES include in-flight
+  assigned task VMs, so the node refuses precisely the placements an under-counted
+  CP row would allow.
+
+  A missing catalog entry is skipped rather than raised. Adoption runs in this
+  GenServer, which is supervised under `:rest_for_one`; raising here would restart
+  every control-plane child after `Reservation`, including the HTTP listener.
 
   It is NOT safe to mistake for a leak. Reading the shadow-mode divergence
   data, a persistent CP-below-node gap after a restart is this, not a lost
   release, and it shrinks as assigned tasks complete rather than staying flat.
   """
-  @spec adopt(term(), Enumerable.t(), keyword()) :: :ok
+  @spec adopt(term(), Enumerable.t(), keyword()) ::
+          {:ok, %{adopted: non_neg_integer(), skipped: non_neg_integer()}}
   def adopt(instance_id, live_refs, opts) when is_list(opts) do
     server = Keyword.get(opts, :server, __MODULE__)
     GenServer.call(server, {:adopt, instance_id, Enum.to_list(live_refs), opts})
@@ -214,13 +235,25 @@ defmodule Embervm.Scheduler.Reservation do
   def handle_call({:adopt, instance_id, live_refs, opts}, _from, state) do
     now_ms = Keyword.get(opts, :now_ms, System.system_time(:millisecond))
 
-    Enum.each(live_refs, fn live ->
+    counts = Enum.reduce(live_refs, %{adopted: 0, skipped: 0}, fn live, counts ->
       {ref, workload} = live_ref(live)
-      mem_mib = catalog_memory!(workload, live, opts)
-      put_entry(state.table, instance_id, build_entry(ref, [workload: workload, mem_mib: mem_mib], now_ms, now_ms))
+
+      case catalog_memory(workload, Keyword.put(opts, :live, live)) do
+        {:ok, mem_mib} ->
+          put_entry(
+            state.table,
+            instance_id,
+            build_entry(ref, [workload: workload, mem_mib: mem_mib], now_ms, now_ms)
+          )
+
+          %{counts | adopted: counts.adopted + 1}
+
+        :error ->
+          %{counts | skipped: counts.skipped + 1}
+      end
     end)
 
-    {:reply, :ok, state}
+    {:reply, {:ok, counts}, state}
   end
 
   defp build_entry(ref, opts, now_ms, confirmed_at_ms) do
@@ -239,8 +272,9 @@ defmodule Embervm.Scheduler.Reservation do
   defp live_ref(%{vm_id: ref, workload: workload}), do: {ref, workload}
   defp live_ref({ref, workload}), do: {ref, workload}
 
-  defp catalog_memory!(workload, live, opts) do
+  defp catalog_memory(workload, opts) do
     source = Keyword.get(opts, :mem_mib, Keyword.get(opts, :memory_by_workload, Keyword.get(opts, :catalog)))
+    live = Keyword.get(opts, :live)
 
     value =
       cond do
@@ -252,9 +286,9 @@ defmodule Embervm.Scheduler.Reservation do
       end
 
     if is_integer(value) and value >= 0 do
-      value
+      {:ok, value}
     else
-      raise ArgumentError, "adopt requires declared memory from the workload catalog"
+      :error
     end
   end
 

--- a/projects/embervm/control/test/embervm/scheduler/reservation_test.exs
+++ b/projects/embervm/control/test/embervm/scheduler/reservation_test.exs
@@ -77,6 +77,23 @@ defmodule Embervm.Scheduler.ReservationTest do
     assert Reservation.entries("n/a", table) == []
   end
 
+  test "adoption skips workloads absent from the catalog and keeps the server alive", %{
+    server: server,
+    table: table
+  } do
+    assert {:ok, %{adopted: 2, skipped: 1}} =
+             Reservation.adopt(
+               "n/a",
+               [{"vm-1", "known-a"}, {"vm-2", "missing"}, {"vm-3", "known-b"}],
+               server: server,
+               catalog: %{"known-a" => 128, "known-b" => 256}
+             )
+
+    assert Process.alive?(server)
+    assert Reservation.reserved_mib("n/a", table) == 384
+    assert :ok = claim(server, "n/a", "subsequent-claim")
+  end
+
   test "fresh table is empty and fail-closed", %{table: table} do
     assert Reservation.reserved_mib("missing", table) == 0
     assert Reservation.entries("missing", table) == []

--- a/projects/embervm/control/test/embervm/scheduler/reservation_test.exs
+++ b/projects/embervm/control/test/embervm/scheduler/reservation_test.exs
@@ -1,0 +1,85 @@
+defmodule Embervm.Scheduler.ReservationTest do
+  use ExUnit.Case, async: true
+
+  alias Embervm.Scheduler.Reservation
+
+  setup do
+    table = String.to_atom("reservation_#{System.unique_integer([:positive, :monotonic])}")
+    {:ok, server} = Reservation.start_link(name: nil, table: table, grace_age_ms: 100)
+    %{server: server, table: table}
+  end
+
+  defp claim(server, instance_id, ref, opts \\ []) do
+    Reservation.claim(server, instance_id, ref, Keyword.merge([workload: "wl", mem_mib: 100], opts))
+  end
+
+  test "claims sum across entries and instances", %{server: server, table: table} do
+    claim(server, "n/a", "a", mem_mib: 100)
+    claim(server, "n/a", "b", mem_mib: 200, count: 2)
+    claim(server, "n/b", "c", mem_mib: 50)
+    assert Reservation.reserved_mib("n/a", table) == 500
+    assert Reservation.reserved_mib("n/b", table) == 50
+  end
+
+  test "claim is idempotent on ref", %{server: server, table: table} do
+    claim(server, "n/a", "same", mem_mib: 100, now_ms: 10)
+    claim(server, "n/a", "same", mem_mib: 300, count: 2, now_ms: 20)
+    assert Reservation.reserved_mib("n/a", table) == 600
+    assert [%{ref: "same", mem_mib: 300, count: 2}] = Reservation.entries("n/a", table)
+  end
+
+  test "release removes and unknown release is a no-op", %{server: server, table: table} do
+    claim(server, "n/a", "a")
+    assert :ok = Reservation.release(server, "n/a", "missing")
+    assert :ok = Reservation.release(server, "n/a", "a")
+    assert Reservation.entries("n/a", table) == []
+  end
+
+  test "pool targets upsert and count zero removes", %{server: server, table: table} do
+    assert :ok = Reservation.set_pool_target(server, "n/a", "wl", 3, 512)
+    assert Reservation.reserved_mib("n/a", table) == 1536
+    assert :ok = Reservation.set_pool_target(server, "n/a", "wl", 2, 256)
+    assert Reservation.reserved_mib("n/a", table) == 512
+    assert :ok = Reservation.set_pool_target(server, "n/a", "wl", 0, 256)
+    assert Reservation.reserved_mib("n/a", table) == 0
+  end
+
+  test "reconcile releases old absent instance entries", %{server: server, table: table} do
+    claim(server, "n/a", "old", now_ms: 0)
+    assert {:ok, ["old"]} = Reservation.reconcile(server, "n/a", MapSet.new(), 101)
+    assert Reservation.entries("n/a", table) == []
+  end
+
+  test "reconcile keeps young absent entries", %{server: server, table: table} do
+    claim(server, "n/a", "young", now_ms: 50)
+    assert {:ok, []} = Reservation.reconcile(server, "n/a", [], 100)
+    assert Reservation.reserved_mib("n/a", table) == 100
+  end
+
+  test "reconcile never absence-collects pool targets", %{server: server, table: table} do
+    Reservation.set_pool_target(server, "n/a", "wl", 3, 512)
+    assert {:ok, []} = Reservation.reconcile(server, "n/a", [], 100_000)
+    assert Reservation.reserved_mib("n/a", table) == 1536
+  end
+
+  test "reconcile stamps confirmation once", %{server: server, table: table} do
+    claim(server, "n/a", "vm", now_ms: 1)
+    assert {:ok, []} = Reservation.reconcile(server, "n/a", ["vm"], 20)
+    [%{confirmed_at_ms: 20}] = Reservation.entries("n/a", table)
+    assert {:ok, []} = Reservation.reconcile(server, "n/a", ["vm"], 30)
+    [%{confirmed_at_ms: 20}] = Reservation.entries("n/a", table)
+  end
+
+  test "drop_instance removes instances and pool targets", %{server: server, table: table} do
+    claim(server, "n/a", "vm")
+    Reservation.set_pool_target(server, "n/a", "wl", 2, 512)
+    assert :ok = Reservation.drop_instance(server, "n/a")
+    assert Reservation.entries("n/a", table) == []
+  end
+
+  test "fresh table is empty and fail-closed", %{table: table} do
+    assert Reservation.reserved_mib("missing", table) == 0
+    assert Reservation.entries("missing", table) == []
+    assert Reservation.all(table) == %{}
+  end
+end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.312
+      targetRevision: 0.1.313
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Issue #4140 step **B5a**. Lands `Embervm.Scheduler.Reservation` and its supervision entry. **Nothing calls it.** Wiring the claim sites and emitting divergence data is B5b.

Split this way on the precedent of #4154, which landed noded's claims ledger inert before anything read it. The plan's own top-listed hazard is a leaked claim filling a brick with phantoms so every placement 503s, and that risk belongs in a PR where nothing can be wedged by it.

## Why the ledger exists

The CP schedules against **observed** cgroup memory, which lags: a just-restored Firecracker guest faults its pages in lazily and reports near-zero usage for seconds. Kubernetes never schedules on a measurement, it schedules on declared requests reserved at assume time. This is the CP half of that move, and it runs in shadow first so the divergence can be measured before anything depends on it.

## Design points worth reviewing

**Per-VM entries, not a counter.** Reconciliation against node truth is a set diff rather than a number that drifts. A bare counter cannot be reconciled against a reported set, and a drifting counter is exactly the failure this design exists to avoid.

**Two entry kinds, because entries are ASSIGNMENTS not boots.** `:instance` for session, serving, stateful and group, where one entry is one placed VM. `:pool_target` for the task and isolated lanes, where the CP sizes a primed pool rather than individual boots. That granularity is what makes a later move to forecast-cadence pool sizing a no-op rather than a rework.

**`:pool_target` entries are exempt from absence-collection.** No reported `vm_id` corresponds to a pool target, so collecting on absence would delete every pool reservation on the first reconcile. There is an explicit test asserting an old, absent pool target survives.

**The grace age is load-bearing.** An entry is released only when it is both missing from the node's reported live set *and* older than the grace age (default 2x the liveness interval), so a just-claimed entry the node has not reported yet is not collected.

**Invariants.** Node truth is what RELEASES reservations, so the ledger converges to the node and never overrules it (invariant 5). No op-log writes; this is a derived cache like every other CP ETS table (invariant 7). The table starts empty on restart, which is safe because `NodeCapacity` is fail-closed empty until a brick reports.

## The research finding: adoption is incomplete by the wire format

The plan asserted from proto comments that `NodeStatus` carries enough to reseed after a CP restart, and flagged it as unverified. Verified now, and the assertion is incomplete.

`NodeStatus` enumerates live VMs in five mutually exclusive lists (`WorkloadCapacity.primed_vm_ids`, `session_vms`, `serving_vms`, `stateful_vms`, `group_member_vms`). **An assigned task VM is in none of them**: it leaves `primed_vm_ids` the moment it stops being parked, and the only other signal is `live_vms`, an aggregate count with no ids. Declared per-VM memory is absent from `NodeStatus` entirely, so `adopt/3` takes it from the catalog.

So a row rebuilt by adoption under-counts by the number of in-flight task assignments.

That **fails safe in the direction it fails**: an under-count means the CP believes a brick has more room than it does, so it may over-place, and noded's own declared-memory admission then refuses. One rejected RPC, never an overcommit. An over-count would be the dangerous direction and adoption cannot produce one.

It must **not** be read as a leak when B5b's shadow data lands. A persistent CP-below-node gap after a restart is this, and it shrinks as assigned tasks complete rather than staying flat. Documented on `adopt/3` so the next reader does not misdiagnose it.

## One thing I want a second opinion on

It is supervised in its **final** position (after `NodeRegistry`, before the dispatcher) rather than parked somewhere harmless. Under `:rest_for_one` that means a crash in it would bounce the dispatcher and everything after.

I think that is right: it has no callers, so the only crash sources are its own init or a stray message, and soaking it in the position it will actually occupy is the whole value of shipping inert. But it is a live supervision-tree change for a feature that currently does nothing, so it is worth someone disagreeing with me before it lands.

## Tests

10 new, including the two traps above (pool targets survive absence-collection; an absent-but-young entry is not collected) and that `confirmed_at_ms` is stamped on first appearance and not moved afterwards, which is what will later make a leaked claim distinguishable from a live one.

```
MIX TEST OK on the executor
1033 tests, 0 failures, 6 skipped
```

Chart 0.1.312 to 0.1.313.

Refs #4140.