### PR TITLE
fix(embervm): do not report a capacity wall when the CP is blind

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.313
+version: 0.1.314

--- a/projects/embervm/control/lib/embervm/scheduler.ex
+++ b/projects/embervm/control/lib/embervm/scheduler.ex
@@ -32,24 +32,35 @@ defmodule Embervm.Scheduler do
   @doc """
   Places a cold request and distinguishes capacity from a missing workload base.
   A base-gated miss is retried without the base gate using the same request. An
-  empty ungated result records capacity demand; a non-empty ungated result tells
+  An empty resolved universe means the control plane is blind and returns
+  `:no_bricks` without recording demand. An empty ungated result from a
+  non-empty universe records capacity demand; a non-empty ungated result tells
   the base builder to provision on the brick that would have been selected.
   """
-  @spec place_with_demand(Request.t()) :: {:ok, [map()]} | {:error, :capacity | {:base_missing, term()}}
+  @spec place_with_demand(Request.t()) ::
+          {:ok, [map()]} | {:error, :no_bricks | :capacity | {:base_missing, term()}}
   def place_with_demand(%Request{base: base} = req) when base == :ready or is_tuple(base) do
-    case place(req) do
-      [_ | _] = candidates ->
-        {:ok, candidates}
+    bricks = req.bricks || Brick.bricks(req.table || NodeCapacity.table())
 
+    case bricks do
       [] ->
-        case place(%{req | base: :none}) do
-          [] ->
-            Embervm.BrickController.note_denial(req.need_mib || 0)
-            {:error, :capacity}
+        {:error, :no_bricks}
 
-          [brick | _] ->
-            Embervm.BaseBuilder.note_base_missing(req.workload, Map.get(brick, :configured_id))
-            {:error, {:base_missing, Map.get(brick, :configured_id)}}
+      _ ->
+        case place(%{req | bricks: bricks}) do
+          [_ | _] = candidates ->
+            {:ok, candidates}
+
+          [] ->
+            case place(%{req | bricks: bricks, base: :none}) do
+              [] ->
+                Embervm.BrickController.note_denial(req.need_mib || 0)
+                {:error, :capacity}
+
+              [brick | _] ->
+                Embervm.BaseBuilder.note_base_missing(req.workload, Map.get(brick, :configured_id))
+                {:error, {:base_missing, Map.get(brick, :configured_id)}}
+            end
         end
     end
   end

--- a/projects/embervm/control/lib/embervm/serving_manager.ex
+++ b/projects/embervm/control/lib/embervm/serving_manager.ex
@@ -498,6 +498,8 @@ defmodule Embervm.ServingManager do
                 %{instance_id: Brick.dial_id(brick), node_id: brick.configured_id, base_ref: Map.get(workload_entry, :serving_image_ref)}
               end)
 
+            {:error, :capacity} -> []
+            {:error, :no_bricks} -> []
             {:error, _reason} -> []
           end
 

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -489,6 +489,12 @@ defmodule Embervm.SessionManager do
         workload_entry = Map.get(brick.workloads, workload, %{})
         {:ok, brick.configured_id, Brick.dial_id(brick), Map.get(workload_entry, :snapshot_ref)}
 
+      {:error, :capacity} ->
+        {:error, :no_capacity}
+
+      {:error, :no_bricks} ->
+        {:error, :no_capacity}
+
       {:error, _reason} ->
         {:error, :no_capacity}
     end

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -1040,6 +1040,12 @@ defmodule Embervm.StatefulManager do
         dial_id = Brick.dial_id(brick)
         {:cold, node_id, dial_id, boot_image_ref(state, dial_id, workload), :fresh, nil}
 
+      {:error, :capacity} ->
+        {:error, :no_capacity}
+
+      {:error, :no_bricks} ->
+        {:error, :no_capacity}
+
       {:error, _reason} ->
         {:error, :no_capacity}
     end

--- a/projects/embervm/control/lib/embervm/wake_instance.ex
+++ b/projects/embervm/control/lib/embervm/wake_instance.ex
@@ -131,6 +131,12 @@ defmodule Embervm.WakeInstance do
     need_mib = Keyword.fetch!(opts, :need_mib)
 
     case Scheduler.place_with_demand(%Request{table: table, node_id: node_id, workload: workload, need_mib: need_mib, base: :ready}) do
+      {:error, :capacity} ->
+        {:error, :no_eligible_instance}
+
+      {:error, :no_bricks} ->
+        {:error, :no_eligible_instance}
+
       {:error, _reason} ->
         {:error, :no_eligible_instance}
 
@@ -397,10 +403,23 @@ defmodule Embervm.WakeInstance do
     req = %Request{table: table, node_id: node_id, workload: workload, need_mib: need_mib, base: :ready}
 
     case Scheduler.place_with_demand(req) do
-      {:error, reason} ->
-        capacity_denial? = reason == :capacity
+      {:error, :no_bricks} ->
+        # The CP is blind, not out of room: NodeCapacity is fail-closed empty until
+        # a brick dials home, so this is the restart window. The brick list is
+        # provably empty here (that is what :no_bricks means), so pass it rather
+        # than re-reading the table, and log capacity_denial? false so the line
+        # does not read as demand.
+        log_cold_rejection(node_id, workload, need_mib, [], false)
+        {:error, :no_eligible_instance}
+
+      {:error, :capacity} ->
         node_bricks = Brick.bricks(table) |> Enum.filter(&(&1.node_id == node_id))
-        log_cold_rejection(node_id, workload, need_mib, node_bricks, capacity_denial?)
+        log_cold_rejection(node_id, workload, need_mib, node_bricks, true)
+        {:error, :no_eligible_instance}
+
+      {:error, _reason} ->
+        node_bricks = Brick.bricks(table) |> Enum.filter(&(&1.node_id == node_id))
+        log_cold_rejection(node_id, workload, need_mib, node_bricks, false)
         {:error, :no_eligible_instance}
 
       {:ok, [brick | _]} ->

--- a/projects/embervm/control/test/embervm/scheduler_test.exs
+++ b/projects/embervm/control/test/embervm/scheduler_test.exs
@@ -104,6 +104,28 @@ defmodule Embervm.SchedulerTest do
     assert {:error, :capacity} = request.([no_capacity])
   end
 
+  test "empty candidate universe is distinct from a capacity wall" do
+    request = %Request{bricks: [], workload: "wl", need_mib: 512, base: :ready}
+
+    # BrickController.note_denial/2 casts to an optionally absent named process,
+    # so the returned distinction is the observable no-signal contract here.
+    assert {:error, :no_bricks} = Scheduler.place_with_demand(request)
+  end
+
+  test "a non-empty candidate universe with no eligible bricks is capacity" do
+    full = brick(free_slots: 0)
+
+    assert {:error, :capacity} =
+             Scheduler.place_with_demand(%Request{bricks: [full], workload: "wl", need_mib: 512, base: :ready})
+  end
+
+  test "a non-empty eligible brick without a ready base is base missing" do
+    not_ready = brick(configured_id: "node-base", workloads: %{})
+
+    assert {:error, {:base_missing, "node-base"}} =
+             Scheduler.place_with_demand(%Request{bricks: [not_ready], workload: "wl", need_mib: 512, base: :ready})
+  end
+
   test "snapshot and serving base variants require a non-empty field" do
     snapshot = brick(instance_id: "snapshot", workloads: ready("wl", %{snapshot_ref: "snap"}))
     serving = brick(instance_id: "serving", workloads: ready("wl", %{serving_image_ref: "image"}))

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.313
+      targetRevision: 0.1.314
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
`Scheduler.place_with_demand/1` called `BrickController.note_denial/1` whenever a placement found no candidates. `NodeCapacity` is **fail-closed empty** until bricks dial home and report, so in the window after a control-plane restart every placement legitimately finds nothing, and that read as capacity demand.

## Why it matters

Three denials inside 60s step a class `+1`, and production runs `bricks.autoscale.mode: up` where scale-down is observe-only. So a burst of session, serving or stateful creates arriving during the restart window could add a brick **permanently** that nothing needed.

It also pollutes the autoscaler signal that #4140's upcoming shadow-mode soak will be reading, where it would appear as denial spikes correlated with CP restarts.

## Why it was easy to miss

Every individual piece is correct. The placement genuinely found nothing. An empty universe genuinely means no brick passes the filters. The controller correctly counts denials as demand.

The defect is in the **composition**: a fail-closed-empty table means *"the CP does not know yet"*, which is not the same as *"the CP knows, and there is no room"*.

The task dispatcher already draws exactly this line for its own lane. `Dispatcher.pick_node/3` deliberately does **not** note when candidates are entirely absent, only when ready candidates exist and none has budget or memory. The lanes collapsed in #4160 inherited the signal path without inheriting that discrimination, which is what made this reachable from three more call sites than before.

## The fix

`place_with_demand/1` resolves the brick universe **before any filter** and returns `{:error, :no_bricks}` when it is empty, emitting neither `note_denial` nor `note_base_missing`.

The check is deliberately on the **whole** resolved universe, not the post-anchor list:

| Situation | Signal |
|---|---|
| Table empty (restart) | none, blind |
| Table non-empty, anchored node has no bricks | `note_denial`, real wall |
| Table non-empty, nothing passes slots/memory/subnet | `note_denial`, real wall |
| Bricks fit but none base-ready | `note_base_missing`, unchanged |

Both non-empty branches are untouched, so a true capacity wall and a provisioning gap signal exactly as before.

## No externally visible change

All five callers map `:no_bricks` to the same outcome they already produce for `:capacity`:

| Caller | Returns |
|---|---|
| `wake_instance` (both sites) | `:no_eligible_instance` |
| `session_manager` | `:no_capacity` |
| `serving_manager` | no candidates |
| `stateful_manager` | `:no_capacity` |

Only the autoscaler is told less. The cold-rejection log records it with `capacity_denial?` false so that line does not read as demand either.

## Provenance

Found by fact-checking #4160's claim that the collapse "preserves the demand signal each lane previously had". It does not. Three of the five sites were silent at their own stage before the collapse: session create never signalled, and serving and stateful only signalled after a node pick had already succeeded. So routing them through the shared helper was signal **expansion**, not restoration, and this is the edge that expansion opened.

The expansion itself is correct and stays: those are true capacity signals at a fleet-wide wall. Only the blind case is carved out.

```
MIX TEST OK on the executor
1026 tests, 0 failures, 6 skipped
```

Chart 0.1.313 to 0.1.314.

Refs #4140.