### PR TITLE
fix(embervm): whitelist the capacity observer's log metadata

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.315
+version: 0.1.316

--- a/projects/embervm/control/lib/embervm/log_formatter.ex
+++ b/projects/embervm/control/lib/embervm/log_formatter.ex
@@ -14,8 +14,32 @@ defmodule Embervm.LogFormatter do
 
   # Metadata keys the control plane sets on structured log calls (plus a few the
   # runtime always provides). Anything else in metadata is dropped, so the JSON
-  # encode only ever sees strings/numbers.
-  @meta_keys [:task_id, :workload, :principal, :node_id, :reason, :attempt, :kind, :mfa, :error]
+  # encode only ever sees strings/numbers. A caller adding new metadata MUST add
+  # its keys here or they are silently dropped.
+  @meta_keys [
+    :task_id,
+    :workload,
+    :principal,
+    :node_id,
+    :reason,
+    :attempt,
+    :kind,
+    :mfa,
+    :error,
+    # CapacityObserver metadata.
+    :instance_id,
+    :size_class,
+    :mem_budget_mib,
+    :mem_headroom_mib,
+    :mem_reserved_mib,
+    :admits_on_reservation,
+    :live_vms,
+    :max_live_vms,
+    :nameplate_mib,
+    :total_working_set_mib,
+    :guest_free?,
+    :cp_reserved_mib
+  ]
 
   @doc """
   The Erlang `:logger` formatter callback. `event` is `%{level, msg, meta}`;

--- a/projects/embervm/control/test/embervm/log_formatter_test.exs
+++ b/projects/embervm/control/test/embervm/log_formatter_test.exs
@@ -1,0 +1,46 @@
+defmodule Embervm.LogFormatterTest do
+  use ExUnit.Case, async: true
+
+  alias Embervm.CapacityObserver
+
+  test "preserves every CapacityObserver record field in structured JSON" do
+    reservation_table =
+      String.to_atom("log_formatter_reservation_#{System.unique_integer([:positive])}")
+
+    record =
+      CapacityObserver.build_record(
+        %{
+          instance_id: "node-1/pod-a",
+          node_id: "node-1",
+          size_class: "2gi",
+          mem_budget_mib: 1_536,
+          mem_headroom_mib: 1_111,
+          mem_reserved_mib: 0,
+          admits_on_reservation: false,
+          live_vms: 0,
+          max_live_vms: 8
+        },
+        reservation_table
+      )
+
+    line =
+      Embervm.LogFormatter.format(
+        # :logger metadata is a MAP, not a keyword list. Passing a list makes
+        # whitelisted_meta/1 raise, and the formatter's rescue then emits its
+        # plain-text fallback, so the assertion failure points at the JSON
+        # decoder rather than at the real cause.
+        %{level: :info, msg: {:string, "embervm capacity brick"}, meta: record},
+        %{}
+      )
+      |> IO.iodata_to_binary()
+
+    decoded = :json.decode(line)
+
+    for key <- Map.keys(record) do
+      assert Map.has_key?(decoded, Atom.to_string(key)),
+             "record field #{inspect(key)} was dropped from structured JSON"
+    end
+
+    assert Map.has_key?(decoded, Atom.to_string(:guest_free?))
+  end
+end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.315
+      targetRevision: 0.1.316
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
The observer from #4163 emits a span **and** a structured log per brick. The span carried every attribute. The log carried only `node_id`, so in production every measurement field was silently absent:

```json
{"level":"info","message":"embervm capacity brick","mfa":"{Embervm.CapacityObserver, :emit, 1}","node_id":"node-1","time":"..."}
```

## Cause

`Embervm.LogFormatter` encodes a **fixed whitelist** (`@meta_keys`) and drops everything else by design, so an un-encodable term (a pid, ref, or tuple) can never break the JSON encode. `node_id` was already on that list from other call sites and passed through. None of the observer's twelve fields were, so they went in the bin.

## Why it matters

The observer exists to accumulate the daemon working-set measurement that gates #4140's **B6** across a multi-day soak, and a log line is what you aggregate over days. The data was only reaching SigNoz as span attributes.

## Why CI missed it

The observer's own tests assert the **record map its builder returns**, not what the logger actually writes. Nothing exercised the formatter with observer metadata, so the whitelist gap was invisible to the suite.

That makes the guard the more important half of this PR.

## The guard

The new formatter test builds a **real** observer record and asserts every key in it survives into the decoded JSON. It is driven **from the record**, not from a hand-copied key list, so adding an observer field without whitelisting it now fails the test instead of vanishing in production.

Verified in both directions. Against the unfixed formatter:

```
1) test preserves every CapacityObserver record field in structured JSON
   record field :instance_id was dropped from structured JSON
```

With the fix, 1042 tests, 0 failures.

`@meta_keys` also gets a comment stating that a caller adding metadata must add its keys there, since that is precisely the trap.

## One diagnostic note worth carrying forward

While writing the guard, passing `meta: Map.to_list(record)` made `whitelisted_meta/1` raise (real `:logger` metadata is a **map**), and the formatter's `rescue` then emitted its plain-text `fallback/2`. So the failure surfaced as `{:invalid_byte, 105}` from the JSON decoder on a line beginning `info`, rather than as the actual cause.

That degrade-never-lose-a-log behaviour is deliberate and correct. It just means a formatter bug points somewhere other than itself, which is worth knowing next time.

```
MIX TEST OK on the executor
1042 tests, 0 failures, 6 skipped
```

Chart 0.1.315 to 0.1.316.

Refs #4140.