### PR TITLE
fix(argocd): expire the manifest cache in 10m so a wedged render self-heals

### DIFF
--- a/projects/platform/argocd/values-cluster.yaml
+++ b/projects/platform/argocd/values-cluster.yaml
@@ -33,6 +33,24 @@ argo-cd:
       server.basehref: "/app/argocd"
       server.rootpath: "/app/argocd"
       otlp.address: "signoz-otel-collector.signoz.svc.cluster.local:4317"
+      # Manifest-generation cache TTL, 24h default -> 10m. Populates
+      # ARGOCD_REPO_CACHE_EXPIRATION on repo-server.
+      #
+      # The repo-server caches manifest generation RESULTS, including FAILURES,
+      # keyed by revision (for a Helm OCI source that includes the chart
+      # version). A chart is published by CI on merge, so there is a window
+      # where a commit on main already names a targetRevision the registry does
+      # not have yet. ArgoCD renders in that window, caches "not found", and
+      # then serves it for 24h: `timeout.reconciliation` (180s) keeps re-reading
+      # the cached failure, so the app sits in ComparisonError and NEVER rolls
+      # until a human forces a hard refresh. Silent, because the app still
+      # reports Healthy while running the previous build. Hit on 3 of 3 embervm
+      # deploys on 2026-07-29 (issue #4165).
+      #
+      # 10m bounds that stall instead of eliminating it: the negative entry
+      # expires and the next reconcile renders successfully. It is not 180s
+      # because we want most of the cache benefit retained.
+      reposerver.repo.cache.expiration: "10m"
   # Enable metrics endpoints for all ArgoCD components
   # These expose Prometheus metrics including argocd_app_info for health/sync status
   # Pod annotations enable SigNoz autodiscovery (scraper uses role: pod)
@@ -76,13 +94,28 @@ argo-cd:
     # CPU limit raised 125m -> 1000m: manifest generation (helm template /
     # kustomize build) is CPU-bound and gates every ArgoCD sync; it was throttled
     # ~22% with p99 ~3.7s (max 34s) over 22k GenerateManifest calls.
+    #
+    # Raised again 1000m -> 10000m alongside the 10m repo cache TTL above, which
+    # makes 28 apps re-render every ~10m rather than being cached for 24h.
+    # Measured steady state before the change was 3m and 8m CPU across the two
+    # replicas, i.e. under 1% of the old limit, so this is burst headroom rather
+    # than expected consumption. CPU is compressible and the REQUEST stays 25m,
+    # so neighbours are protected by their own requests; the limit only stops
+    # throttling during a render storm.
+    #
+    # Memory 512Mi -> 1Gi is the change to actually watch. Memory is
+    # incompressible, so a render storm overshooting means OOMKill rather than
+    # slowdown, and the controller in this same file has an OOMKilled-x5 history
+    # from sync storms. Steady state was ~160Mi. If repo-server starts OOMing,
+    # raise the repo cache TTL back up before raising memory again: the cache
+    # TTL is the cause and this is the symptom.
     resources:
       requests:
         cpu: 25m
         memory: 128Mi
       limits:
-        cpu: 1000m
-        memory: 512Mi
+        cpu: 10000m
+        memory: 1Gi
     livenessProbe:
       timeoutSeconds: 5
       failureThreshold: 5


### PR DESCRIPTION
Fixes the failure in #4165: **every** EmberVM deploy on 2026-07-29 (charts 0.1.308, 0.1.312, 0.1.315, so 3 of 3) left the app in `ComparisonError` and never rolled until a human forced a sync.

## Root cause

repo-server caches manifest generation **results, including failures**, keyed by revision, which for a Helm OCI source includes the chart version.

CI publishes a chart **on merge**, so a commit on main can name a `targetRevision` the registry does not have yet. ArgoCD renders in that window, caches `not found`, and with `ARGOCD_REPO_CACHE_EXPIRATION` unset it serves that for **24 hours**. `timeout.reconciliation` (180s) then re-reads the cached failure every three minutes, forever.

The failure mode is **silent**: the app reports `Healthy` while running the previous build, so a PR can look merged and deployed when it is not. Observed 48 minutes of waiting changing nothing.

## The fix

`reposerver.repo.cache.expiration: "10m"`. The negative entry expires and the next reconcile renders successfully. Not 180s, so most of the cache benefit is retained.

Verified by rendering rather than assumed: the key lands in `argocd-cmd-params-cm`, and the repo-server deployment reads that key into `ARGOCD_REPO_CACHE_EXPIRATION` via `configMapKeyRef`. That matches the chain traced on the live cluster.

## Resource headroom, and the honest risk

28 apps now re-render every ~10m instead of being cached 24h.

**I measured before changing anything.** repo-server was using **3m and 8m CPU** across its two replicas, under 1% of the old 1000m limit, and ~160Mi of 512Mi memory. Nodes sit at 6-26% CPU with 11-16 cores each.

Worth correcting a misreading of my own: the existing comment in this file (`CPU limit raised 125m -> 1000m ... throttled ~22%, p99 3.7s over 22k GenerateManifest calls`) describes the state **before** that raise. I initially read it as a current constraint and argued against this change on those grounds. At 1000m there is already ~100x headroom.

| | Before | After | Why |
|---|---|---|---|
| CPU limit | 1000m | 10000m | Burst headroom, not expected use. CPU is compressible and the **request stays 25m**, so neighbours keep their guarantees; the limit only stops throttling during a render storm. |
| Memory limit | 512Mi | 1Gi | **This is the one to watch.** |

Memory is incompressible, so overshoot is an OOMKill rather than a slowdown, and the **controller in this same file carries an OOMKilled-x5 history from sync storms**. The comment states the remedy explicitly: if repo-server starts OOMing, **raise the cache TTL back up before raising memory again**, because the TTL is the cause and memory is the symptom. `reposerver.parallelism.limit` is currently `0` (unlimited) and is the next lever if concurrency turns out to be the spike.

## Considered and rejected

A CronWorkflow healer that hard-refreshes wedged apps. It has no steady-state cost, but it is new machinery (workflow, RBAC, chart wiring) that repairs **after the fact**, where this fixes the class for all 28 apps with no new moving parts. Recorded in #4165 as option 1 in case this proves too costly.

## Deployment note

No chart bump: this app renders from git at `targetRevision: HEAD`. So it takes effect on the next reconcile after merge, and pleasingly it **cannot be blocked by the OCI-chart bug it is fixing**.

## What to check after merge

- repo-server pods roll, then `kubectl get cm argocd-cmd-params-cm -n argocd -o jsonpath='{.data.reposerver\.repo\.cache\.expiration}'` reads `10m`
- `kubectl top pods -n argocd | grep repo-server` over the following hour, watching **memory** more than CPU
- next embervm deploy rolls without a manual sync

Refs #4165, #4147.