### PR TITLE
fix(embervm): key the base rootfs path on the guest digest, not the tag

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.316
+version: 0.1.317

--- a/projects/embervm/chart/templates/_helpers.tpl
+++ b/projects/embervm/chart/templates/_helpers.tpl
@@ -154,17 +154,29 @@ service name here (survives a release rename).
 {{- end -}}
 
 {{/*
-Per-guest-digest rootfs path: <dir>/rootfs-<tag>.ext4, so each pinned guest-image
+Per-guest-digest rootfs path: <dir>/rootfs-<digest>.ext4, so each pinned guest-image
 version bakes its OWN read-only rootfs file instead of overwriting one fixed path.
 The Firecracker memfile embeds this host path (restore re-attaches it, never
 re-issuing PutDrive), so a chart roll that rebuilt the fixed file in place used to
 swap the bytes under every banked session snapshot -> EXT4 corruption on restore.
-Digest-naming makes the artifact immutable per version; old files persist until an
-(external) reaper drains them. Input: (dict "wl" $wl "top" $top). MUST be used by
-BOTH the rootfs-builder BASE_ROOTFS_PATH and the EMBERVM_NODED_IMAGES rootfsPath so
-the built file and the path noded attaches are byte-identical.
+Digest-naming makes the artifact immutable per version; old files are reaped by the
+noded rootfs GC (#4088) once no registry ref and no READY base points at them.
+
+The suffix is the DIGEST, never the tag, and that distinction is load-bearing.
+Bazel stamps every build with a fresh <timestamp>-<commit> tag even when the image
+content is byte-identical, so a tag-derived name changed on EVERY deploy. That name
+is BASE_ROOTFS_PATH in the shared noded pod spec, so it rolled all brick
+Deployments on every chart bump, killing live VMs mid-flight for a rebuild that
+produced identical bytes (issue #4147: 11 brick rolls in a day against 1 real image
+change). The digest moves only when the guest image actually moves, which is the
+property this path always meant to express.
+
+Input: (dict "wl" $wl "top" $top). MUST be used by BOTH the rootfs-builder
+BASE_ROOTFS_PATH and the EMBERVM_NODED_IMAGES rootfsPath so the built file and the
+path noded attaches are byte-identical.
 */}}
 {{- define "embervm.noded.rootfsPath" -}}
-{{- $suffix := .top.guestImage.tag | toString | replace ":" "-" | replace "@" "-" | replace "/" "-" -}}
+{{- $digest := required "guestImage.digest is required to name a base rootfs (Bazel pins it via helm_chart images=). An empty suffix would collide across guest versions and swap bytes under banked snapshots." .top.guestImage.digest -}}
+{{- $suffix := $digest | toString | replace ":" "-" | replace "@" "-" | replace "/" "-" -}}
 {{- printf "%s-%s.ext4" (trimSuffix ".ext4" .wl.rootfsPath) $suffix -}}
 {{- end -}}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -529,6 +529,7 @@ sandbox:
   guestImage:
     repository: ghcr.io/jomcgi/homelab/projects/firecracker/sandbox/guest
     tag: latest
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
 
 # The semgrep guest image, Bazel-pinned (helm_chart images="semgrep.guestImage")
 # from the frozen fc-invoke semgrep guest's .info provider. Distinct top-level key
@@ -537,6 +538,7 @@ semgrep:
   guestImage:
     repository: ghcr.io/jomcgi/homelab/projects/firecracker/semgrep/guest
     tag: latest
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
 
 # The runtime-python base image (R1 zip lane, ADR embervm/002), Bazel-pinned
 # (helm_chart images="runtimePython.guestImage") from its .info provider. Distinct
@@ -552,6 +554,7 @@ runtimePython:
   guestImage:
     repository: ghcr.io/jomcgi/homelab/projects/embervm/runtimes/python
     tag: latest
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
 
 # The runtime-claude base image (issue #4055): a session-class guest running the
 # Claude Code CLI headlessly under a shim, driven over the vsock guest contract so
@@ -573,6 +576,7 @@ runtimeClaude:
   guestImage:
     repository: ghcr.io/jomcgi/homelab/projects/embervm/runtimes/claude
     tag: latest
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
 
 # R4 scratch-postgres stateful consumer (ADR embervm/001, D-R4.PR-11.1), the
 # named consumer that justifies the stateful rung. Bazel-pinned
@@ -602,6 +606,7 @@ scratchPostgres:
   guestImage:
     repository: ghcr.io/jomcgi/homelab/projects/embervm/runtimes/postgres
     tag: latest
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   onepassword:
     # 1Password item path (vaults/<vault>/items/<item>) whose POSTGRES_PASSWORD
     # field syncs into the <fullname>-scratch-postgres Secret. Empty leaves the
@@ -628,6 +633,7 @@ bazelQuery:
   guestImage:
     repository: ghcr.io/jomcgi/homelab/projects/embervm/runtimes/bazel
     tag: latest
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
 
 # these). WARMTH-ONLY: the cluster's state (nodes, pods, sqlite/etcd) lives in the
 # group snapshot only and evaporates on roll (maxLifetimeSeconds), banked-TTL

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.316
+      targetRevision: 0.1.317
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Problem

`embervm.noded.rootfsPath` named each workload's base rootfs after the guest image **tag**. Bazel stamps a fresh `<timestamp>-<commit>` tag on every CI build even when the image content is byte-identical, so the rendered `BASE_ROOTFS_PATH` changed on every deploy. That path is an env var in the **shared** noded pod spec, so every chart bump minted a new pod template for all seven brick Deployments and rolled them, killing live VMs mid-flight.

The helper's own docstring already called itself a "Per-guest-digest rootfs path". The implementation read `.tag`.

## Evidence

Measured on the live cluster for 2026-07-29:

| | Count |
|---|---|
| Brick pod-template revisions | 11 |
| Merges touching a brick image source | 1 |

Across those 11 revisions every pinned digest was identical except `noded`'s, which moved exactly once, matching the single merge that touched `projects/embervm/noded/`. Digest pinning and apko reproducibility were working. The bricks were rolling for a name change over provably identical bytes.

## Why this is the right layer

The rootfs-builder already fixed this one layer down, content-addressing its bake cache so an unchanged guest resolves to the same cache file "regardless of the per-build timestamp tag". That removed the 4-5 minute crane-export plus `mkfs.ext4` cost, but not the pod-template churn, because the Helm-supplied alias stayed tag-keyed. This completes the same fix at the Helm layer.

## Verification

Local renders against `deploy/values.yaml`:

- Two renders differing only in `sandbox.guestImage.tag` are **byte-identical**. This is the property the change exists for.
- Changing `sandbox.guestImage.digest` moves that workload's path and leaves every other workload's path untouched.
- All 7 occurrences of the sandbox path across the builder `BASE_ROOTFS_PATH`, the noded attach path, and the CP `EMBERVM_NODE_IMAGE_IDENTITY` agree, which the three-way join requires.

`ci lint` and `ci test` green (743 bazel tests, plus the Elixir suite genuinely executing at 1042 tests / 0 failures rather than cache-skipping).

## Safety

- The digest is `required` rather than defaulted. An empty suffix would collide across guest versions and swap bytes under banked snapshots, which is the EXT4-on-restore corruption the versioned naming exists to prevent. Both call sites already build `repository@digest` one line above the call, so this adds no new constraint.
- The six `guestImage` blocks gain the zeroed digest placeholder the chart's other five image blocks already carry, so a local `helm template` still renders. Bazel deep-merges the real digests at build time.
- Existing tag-named files are left in place, so banked snapshots whose memfile embeds the old path still restore. They sit in swept directories and are older than the GC min age, so the noded rootfs GC (#4088) reaps them on its next pass.

## Expected effect

Brick rolls drop from every deploy to only real image changes, roughly 11 per day to 1. On a CP-only deploy the bricks no longer restart at all, so no VM kill, no relight-and-recover, and no poking of the #4143 generation quarantine. The CP's own `Recreate` gap remains and is unaffected.

Refs #4147

🤖 Generated with [Claude Code](https://claude.com/claude-code)