### PR TITLE
fix(cloudflare-gateway): run one tunnel replica per node

### DIFF
--- a/projects/platform/cloudflare-gateway/values.yaml
+++ b/projects/platform/cloudflare-gateway/values.yaml
@@ -40,7 +40,25 @@ gateway:
 
 # --- Cloudflare Tunnel ---
 tunnel:
-  replicaCount: 2
+  # One replica per node (4), up from 2. The tunnel only serves a 530 when
+  # EVERY connection across EVERY replica is gone, so replica count is the
+  # redundancy budget for that. At 2 it was routinely spent: measured over a
+  # 78h window, the node-1 replica alone was blacked out for 96.5 min across 87
+  # episodes (159 `dial tcp :7844 i/o timeout`, against 1 on node-4), so the
+  # tunnel spent most of that time one blip away from having no origin at all.
+  # All 5 full outages in the window were exactly that overlap.
+  #
+  # The asymmetry is not node-1 being broken: an EmberVM rollout applies all its
+  # brick Deployments in the same sync wave, and the resulting rootfs-build plus
+  # image-pull stampede saturates the shared uplink (observed 2026-07-30 06:06,
+  # whole wired LAN at 100% loss while the gateway answered in 3ms). node-4
+  # survives it because it has the node-local CAKE shaper and node-1/2/3 do not.
+  #
+  # So this is defence in depth, not the fix: node-2 and node-3 are unshaped too,
+  # and their replicas can die in the same stampede. It buys 4 chances instead of
+  # 2. The root fix is sequencing the rollout; the durable one is shaping every
+  # node. Each replica costs 25m CPU / 64Mi, so the headroom is free.
+  replicaCount: 4
   fullnameOverride: "cloudflared"
 
   image:


### PR DESCRIPTION
## Why

A Cloudflare 530 is edge-generated and means "no origin reachable", so the
tunnel only serves one when **every connection across every replica** is gone.
`replicaCount` is the redundancy budget for exactly that, and at 2 it was
routinely spent.

Measured over a 78h window (2026-07-26 to 07-29, after the `protocol: http2`
fix in #4032):

| | node-1 replica | node-4 replica |
|---|---|---|
| `dial tcp :7844 i/o timeout` | **159** | 1 |
| solo blackouts | 87 (**96.5 min**) | 9 (2.8 min) |

With only 2 replicas the tunnel therefore spent much of that window one blip
away from having no origin at all. All 5 full outages were exactly that
overlap, 3 of them inside the single hour where both replicas failed together.

## What the asymmetry actually is

node-1 is not faulty. Its NIC counters, netfilter conntrack, Cilium BPF NAT,
CPU and PoP selection all measure clean, and every edge IP it times out on is
one it also registers with successfully at other moments.

The cause is a rollout stampede. An EmberVM sync applies all eight brick
Deployments in the same wave, and the resulting `rootfs-builder` plus image-pull
burst saturates the shared uplink. Observed live 2026-07-30 06:06 (one minute
after #4167 merged): `ImagePullBackOff` against ghcr.io, the whole wired LAN at
100% packet loss while the gateway still answered in 3ms, and node-1's
cloudflared losing all four connections at 06:11:32.

node-4 rides it out because it has the node-local CAKE ingress shaper
(PR #2598); node-1, node-2 and node-3 have nothing.

## Scope, honestly

This is **defence in depth, not the fix**. node-2 and node-3 are unshaped too,
so their replicas can die in the same stampede. It buys 4 chances instead of 2,
for 25m CPU and 64Mi each, on nodes with ample headroom.

- Root fix: sequencing the EmberVM rollout, landing separately.
- Durable fix: promoting the CAKE shaper to every node.

## Verification

`helm template` with `values.yaml` + `values-prod.yaml` renders `replicas: 4`,
and the pod labels carry `app.kubernetes.io/name: cloudflare-tunnel`, which
matches the existing `topologySpreadConstraints` selector, so `maxSkew: 1` over
`kubernetes.io/hostname` genuinely places one per node. The constraint is
`ScheduleAnyway`, so an unschedulable node doubles replicas up rather than
leaving them Pending.

`ci test` is green but **covered zero of this change**: no Bazel target depends
on this Helm values file (`Executed 0 out of 743`). The render above is the
verification.

No chart bump: this Application is a git-path source on `targetRevision: HEAD`
and no image digest moves, the same situation as #4032.

🤖 Generated with [Claude Code](https://claude.com/claude-code)