### PR TITLE
fix(embervm): sequence brick rollouts so a chart bump stops stampeding the fleet

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.317
+version: 0.1.318

--- a/projects/embervm/chart/templates/brick-deployment.yaml
+++ b/projects/embervm/chart/templates/brick-deployment.yaml
@@ -21,13 +21,47 @@
 # plane learns each brick by dial-home registration (POST /v1/nodes/register),
 # not Service/EndpointSlice discovery, so brick pods need not sit behind the noded
 # Service.
+#
+# ROLLOUT SEQUENCING (argocd.argoproj.io/sync-wave, below). Every brick
+# Deployment used to render at the default wave 0, so a chart bump applied all
+# of them in the same instant and ArgoCD rolled the whole fleet at once. Each
+# replacement pod runs the rootfs-builder init container and pulls its images,
+# so the fleet-wide roll is a CPU + disk + uplink stampede on every node
+# simultaneously. Observed 2026-07-30 06:06, one minute after a merge: ghcr.io
+# pulls failing with ImagePullBackOff, the whole wired LAN at 100% packet loss
+# while the gateway still answered in 3ms, and the cloudflared replica on an
+# unshaped node losing all four tunnel connections. With ~12 embervm merges in
+# a day that is a recurring self-inflicted outage.
+#
+# Each brick Deployment now gets its own ascending wave, so ArgoCD applies one,
+# waits for it to report Healthy (its rollout complete), and only then applies
+# the next. maxSurge:0/maxUnavailable:1 already serialised the pods WITHIN a
+# Deployment; waves serialise ACROSS them, which is the part that was missing.
+#
+# Waves are assigned by list position: classes take syncWaveBase + index, then
+# floors continue from syncWaveBase + len(classes) + index, so the two ranges
+# never collide and adding a class or a floor shifts only the entries after it.
+# Base defaults to 2, which leaves wave 0 for the control plane and shared infra
+# (bricks dial home to the CP, so it must be up first) and wave 1 for the
+# Workload CRs, both of which keep their current waves untouched.
+#
+# This is a stopgap, NOT ADR embervm/011. That decision is OnDelete pod
+# semantics with the control plane as the rollout controller, checking
+# interlocks, draining, confirming banked, deleting the pod and verifying the
+# replacement, so rolls land in idle windows and pause on an unhealthy store.
+# None of that is implemented; sync waves only remove the simultaneity. The
+# trade-off is real: a brick that never goes Healthy now stalls the sync at its
+# wave instead of letting later waves through, which is why the Application
+# keeps its retry limit.
 {{- $ctx := . }}
-{{- range $class := .Values.bricks.classes }}
+{{- range $i, $class := .Values.bricks.classes }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "embervm.noded.fullname" $ctx }}-brick-{{ $class.name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ add $ctx.Values.bricks.syncWaveBase $i | quote }}
   labels:
     {{- include "embervm.brick.labels" (dict "ctx" $ctx "class" $class.name) | nindent 4 }}
 spec:
@@ -92,13 +126,23 @@ spec:
 # top of the shared class selector, so this Deployment's selector is DISJOINT
 # from its class Deployment's. Reusing the class selector here would be a real
 # bug (two ReplicaSet controllers fighting over the same pods), not just style.
-{{- range $floor := .Values.bricks.nodeFloors }}
+#
+# Floors roll AFTER every class (wave syncWaveBase + len(classes) + index).
+# They are the fixed per-node capacity guarantee, so rolling them last keeps a
+# pinned brick alive on each node for as long as possible while the elastic
+# class Deployments cycle. Rolling them last also spreads them across distinct
+# waves, which matters more than it looks: the floors are pinned to different
+# nodes, so rolling them together would put a rootfs build on every node at once
+# even though no single node is over-subscribed.
+{{- range $j, $floor := .Values.bricks.nodeFloors }}
 {{- $class := $floor.class }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "embervm.noded.fullname" $ctx }}-brick-{{ $class }}-{{ $floor.node }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ add $ctx.Values.bricks.syncWaveBase (len $ctx.Values.bricks.classes) $j | quote }}
   labels:
     {{- include "embervm.brickFloor.labels" (dict "ctx" $ctx "class" $class "node" $floor.node) | nindent 4 }}
 spec:

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -955,6 +955,20 @@ noded:
 # netns), which the 16Gi class covers.
 bricks:
   enabled: false
+  # First ArgoCD sync-wave handed out to a brick Deployment. Each brick then
+  # takes its own ascending wave (classes by list index, then floors continuing
+  # after them), so ArgoCD rolls the fleet ONE Deployment at a time instead of
+  # applying all of them in the same instant. Before this every brick rendered
+  # at the default wave 0 and a single chart bump stampeded the whole fleet:
+  # every replacement pod running its rootfs-builder init and pulling images at
+  # once, which saturates the shared uplink hard enough to take the wired LAN to
+  # 100% packet loss and drop the cloudflared tunnel on unshaped nodes.
+  #
+  # 2 keeps the existing waves intact underneath it: wave 0 is the control plane
+  # and shared infra (bricks dial home to the CP, so it goes first) and wave 1 is
+  # the Workload CRs. Raise it only if something new needs to land between the CP
+  # and the bricks; the relative order of the bricks themselves is positional.
+  syncWaveBase: 2
   # Per-class DESIRED replica count the Embervm.BrickController reconciles the
   # brick Deployments to (and the value each renders at first create). A MAP keyed
   # by size-class label, not a per-class list field, so a deploy-values overlay can

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.317
+      targetRevision: 0.1.318
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## The bug

Every brick Deployment rendered at the **default sync-wave 0**, so a chart bump
applied all eight in the same instant and ArgoCD rolled the entire fleet at
once. Each replacement pod runs the `rootfs-builder` init container and pulls
its images, so a fleet-wide roll is a simultaneous CPU, disk and uplink
stampede on every node.

`maxSurge: 0` / `maxUnavailable: 1` already serialised pods **within** a
Deployment. Nothing serialised **across** them.

## Observed live

2026-07-30 06:06:49, one minute after #4167 merged:

| Time (UTC) | Event |
|---|---|
| 06:05:49 | #4167 merges, chart bump |
| 06:06:49 | All 6 live Deployments scale down and up **in the same second** |
| 06:06:57 | `ErrImagePull` -> `ImagePullBackOff` against ghcr.io |
| 06:09-06:15 | Entire wired LAN at **100% packet loss**, while the gateway answered in **3ms** |
| 06:11:32 | cloudflared on node-1 loses **all four** connections; Deployment drops to 1/2 |

The gateway staying healthy while every node went dark is the tell: uplink
saturation, not a node fault. With ~12 embervm merges in a day this is a
recurring self-inflicted outage, and it is the residual cause of the public 530s
that survived the `protocol: http2` fix in #4032. node-4's replica rides it out
only because that node has the CAKE shaper (#2598) and node-1/2/3 do not.

## The change

Each brick takes its own ascending wave, so ArgoCD applies one, waits for it to
report Healthy (rollout complete), then applies the next.

```
wave 0   Deployment  embervm-embervm            <- control plane + infra, unchanged
wave 1   Workload    (7 CRs)                    <- unchanged
wave 2-5 Deployment  brick-2gi / 4gi / 8gi / 16gi
wave 6-8 Deployment  brick-2gi-node-1 / -2 / -3
```

Classes take `syncWaveBase + index`, floors continue at
`syncWaveBase + len(classes) + index`, so the ranges cannot collide and adding
an entry shifts only what follows it. Base 2 preserves the existing wave 0 and
wave 1 exactly. Floors roll last so a pinned brick stays alive on each node
while the elastic classes cycle.

**Deploying this rolls nothing.** Only Deployment metadata annotations change,
so no pod template hash moves.

## Scope and trade-off, explicitly

This is a **stopgap, not ADR embervm/011**. That decision specifies `OnDelete`
semantics with the control plane as rollout controller: check interlocks, drain,
confirm banked, delete, verify the replacement, so rolls land in idle windows
and pause on an unhealthy store. None of that is implemented here. Waves only
remove the simultaneity.

The trade-off is real and worth stating: **an unhealthy wave now stalls later
waves** instead of letting them through. A wedged control plane at wave 0 will
block brick updates until it recovers, the Application's `retry: limit 5` runs
out, or someone syncs manually. ADR 011's staleness-bound guardrail (force-roll
with an alert when interlocks never go green) is the proper answer and is not in
this PR.

## Verification

`helm template` against `deploy/values.yaml` renders the wave table above.
`ci test` executed 1 test and packaged `embervm-0.1.318.tgz`, so a template
syntax error would have failed the build. Chart bumped 0.1.317 -> 0.1.318 with
`Chart.yaml` and `targetRevision` moving together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)