### PR TITLE
fix(argocd): scope the replicas ignore to the apps whose controller owns it

### DIFF
--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -21,6 +21,24 @@ spec:
     server: https://kubernetes.default.svc
     # Own namespace; nothing monolith-coupled.
     namespace: embervm
+  ignoreDifferences:
+    # The BrickController owns each brick Deployment's replica count: the chart
+    # value is only the count at FIRST create, and the controller PATCHes /scale
+    # thereafter from demand-driven autoscale. With selfHeal on, ArgoCD would
+    # revert every scale decision back to the chart value, so /spec/replicas has
+    # to stay out of the diff for this app.
+    #
+    # This used to be inherited from a fleet-wide argocd-cm rule. That rule was
+    # removed because it applied to EVERY Deployment in the cluster, silently
+    # making any git-declared replica count unchangeable while the Application
+    # still reported Synced and Healthy (cloudflare-gateway PR #4168 merged
+    # green and moved nothing). monolith and monolith-public already carried
+    # their own copies of this; embervm was relying on the fleet-wide one, so it
+    # is made explicit here. Mirrors those two apps.
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas
   syncPolicy:
     automated:
       prune: true

--- a/projects/platform/argocd/values.yaml
+++ b/projects/platform/argocd/values.yaml
@@ -44,11 +44,22 @@ argo-cd:
         jsonPointers:
           - /spec/template/metadata/annotations/otel.injected-by
           - /spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt
-          # HPA-managed replicas: the chart omits replicas so the HPA owns it;
-          # keep live's HPA-set value out of the diff. Only HPAs mutate
-          # replicas in this cluster (kubectl scale is forbidden by
-          # convention), so a fleet-wide ignore is safe.
-          - /spec/replicas
+          # /spec/replicas used to be ignored HERE, fleet-wide. It is now scoped
+          # to the three Applications that actually have a controller owning
+          # replicas (monolith, monolith-public, embervm), via ignoreDifferences
+          # on each Application.
+          #
+          # The old rationale was "the chart omits replicas so the HPA owns it",
+          # which is true for the HPA charts and false for every other chart in
+          # the cluster. A chart that DOES render `replicas:` had its value
+          # silently ignored: no drift, no warning, and the Application still
+          # reported Synced and Healthy while the live count never moved.
+          # cloudflare-gateway hit exactly that (PR #4168 merged green and did
+          # nothing; the tunnel stayed at 2 replicas), which is a bad failure
+          # mode because every signal says success.
+          #
+          # Fleet-wide was never safe, only quiet. Keep replica ignores scoped
+          # to the specific Application whose controller owns the field.
     rbac:
       policy.csv: |
         p, mcp-agent, applications, *, */*, allow


### PR DESCRIPTION
## The bug

`argocd-cm` ignored Deployment `/spec/replicas` **fleet-wide**:

```yaml
resource.customizations.ignoreDifferences.apps_Deployment: |
  jsonPointers:
    - /spec/replicas
```

So any chart rendering an explicit `replicas:` had that value **silently
discarded**. No drift, no warning, no failed check, and the Application still
reported `Synced` and `Healthy`.

#4168 merged green, deployed, and left the tunnel at **2 replicas** for 12+
minutes of polling. A forced sync changed nothing, because by configuration
there was no diff to apply. That is a worse failure mode than a hard error:
every signal said success.

The rule's rationale was *"the chart omits replicas so the HPA owns it"*. True
for the HPA charts, which guard the field behind
`{{- if not autoscaling.enabled }}`. False for every chart that does render it.
Fleet-wide was never safe, only quiet.

## The change

Scoped to the three apps that actually have a controller owning replicas.

**monolith and monolith-public already carried their own `ignoreDifferences` for
`/spec/replicas`**, so the fleet-wide rule was pure redundancy for them and they
are untouched by this PR. Only **embervm** was relying on it, where
`BrickController` PATCHes `/scale` from demand-driven autoscale and `selfHeal`
would otherwise revert every decision, so it is made explicit there.

## Blast radius, checked before removing it

| Class | Finding |
|---|---|
| HPAs | Only `monolith`, `monolith-public-web`, `monolith-public-frontend`. All covered by existing per-app ignores. |
| Controller-scaled | embervm bricks (`BrickController`). Now explicitly covered. |
| Non-default replicas declared in git | argocd, cert-manager-webhook, cilium-operator, longhorn-ui, imgproxy, `loom-worker` (0 declared in `deploy/values.yaml:103`). Git simply becomes authoritative again, which is the intent. |
| Not ArgoCD-managed | coredns (k3s) and the longhorn `csi-*` Deployments (created by longhorn-manager). Unaffected. |

## Effect

`cloudflared` finally goes to the 4 replicas #4168 asked for. Everything else
keeps its current count, now because git says so rather than because the diff
was suppressed.

## Verification

Rendering the argocd chart confirms the pointer is gone from the live
`argocd-cm`, leaving only the two otel/restartedAt annotation pointers:

```
jsonPointers actually in effect:
  /spec/template/metadata/annotations/otel.injected-by
  /spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt
/spec/replicas still ignored fleet-wide? False
```

Both changed files are Helm values / an Application manifest with no Bazel test
coverage, so `ci test` is green but proves nothing here; the render above and
the blast-radius table are the verification. No chart bump: both the argocd and
embervm Applications changed only in git-path sources, and no image digest
moves.

**Post-merge check worth doing:** watch for any Application flipping OutOfSync
on a replicas diff. The table above says there should be none, but this removes
a cluster-wide suppression, so it deserves eyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)