### PR TITLE
feat(embervm): move a banked stateful volume between nodes (#4119 slice 4)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.318
+version: 0.1.319

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -163,6 +163,22 @@ defmodule Embervm.Router do
     handle_delete_stateful_volume(conn, name)
   end
 
+  # POST /v1/stateful/:name/handover/:target (management auth): move the
+  # workload's VOLUME off its current anchor node onto :target and re-anchor it
+  # there (#4119 slice 4), so a workload whose anchor cannot host its wake stops
+  # being pinned to a node that will never have room. REFUSED (409) while any
+  # live instance exists: the move is defined only for a banked workload,
+  # because moving a volume out from under a writable attach is exactly the
+  # split brain the single-writer fence exists to prevent.
+  #
+  # The target is a PATH segment rather than a body field so the verb needs no
+  # request parser and stays drillable with a bare curl, which matters for a
+  # manual-trigger verb whose whole point is being rehearsed by hand before
+  # anything automates it.
+  post "/v1/stateful/:name/handover/:target" do
+    handle_stateful_handover(conn, name, target)
+  end
+
   # -- composite (group) routes (R5, management introspection) ---------------
 
   get "/v1/groups/:name" do
@@ -1145,8 +1161,57 @@ defmodule Embervm.Router do
     end
   end
 
+  # POST /v1/stateful/:name/handover/:target. Every refusal that leaves the
+  # anchor untouched is a 4xx with retryable:false unless waiting would actually
+  # change the answer: :not_banked clears itself once the sweeper banks the live
+  # instance, so it is retryable, while a refused export means the source's
+  # bytes are not the authoritative ones and no amount of retrying fixes that.
+  defp handle_stateful_handover(conn, workload, target) do
+    case stateful_handover().move(workload, target) do
+      {:ok, moved} ->
+        send_json(conn, 200, %{
+          workload: workload,
+          from: moved.from,
+          to: moved.to,
+          generation: moved.generation,
+          source_evicted: moved.source_evicted
+        })
+
+      {:error, :no_volume} ->
+        send_json(conn, 404, %{error: "no volume for this workload", workload: workload, retryable: false})
+
+      {:error, :volume_node_missing} ->
+        send_json(conn, 409, %{error: "volume has no anchor node recorded", workload: workload, retryable: false})
+
+      {:error, :already_anchored} ->
+        send_json(conn, 409, %{error: "volume is already anchored on that node", workload: workload, target: target, retryable: false})
+
+      {:error, {:not_banked, live}} ->
+        send_json(conn, 409, %{
+          error: "workload has a live instance; it must be banked before its volume can move",
+          workload: workload,
+          live: live,
+          retryable: true
+        })
+
+      {:error, :source_export_refused} ->
+        send_json(conn, 409, %{
+          error: "source refused to export the volume (unblessed or superseded generation); anchor unchanged",
+          workload: workload,
+          retryable: false
+        })
+
+      {:error, {:node_not_reporting, node}} ->
+        send_json(conn, 409, %{error: "node is not reporting", node: node, workload: workload, retryable: true})
+
+      {:error, reason} ->
+        send_json(conn, 500, %{error: "handover failed", reason: inspect(reason), workload: workload, retryable: true})
+    end
+  end
+
   defp stateful_manager, do: Application.get_env(:embervm, :stateful_manager_mod, Embervm.StatefulManager)
   defp stateful_manager_server, do: Application.get_env(:embervm, :stateful_manager, Embervm.StatefulManager)
+  defp stateful_handover, do: Application.get_env(:embervm, :stateful_handover_mod, Embervm.StatefulHandover)
 
   # GET /v1/groups/:name (management auth): the composite group's instance state,
   # members with health, set id + completeness (the banked set_id, null when nothing

--- a/projects/embervm/control/lib/embervm/stateful_handover.ex
+++ b/projects/embervm/control/lib/embervm/stateful_handover.ex
@@ -1,0 +1,344 @@
+defmodule Embervm.StatefulHandover do
+  @moduledoc """
+  Manual, control-plane-sequenced move of a BANKED stateful workload's volume
+  from its current anchor node onto a peer (#4119 slice 4).
+
+  ## Why this exists
+
+  A stateful workload is pinned to its volume's anchor node by the single-writer
+  fence: `volume.Manager` permits one writable attach, and the control plane
+  never places a stateful wake anywhere but the anchor. That pin is correct for
+  safety and total for availability. When the anchor node cannot host the wake,
+  placement has exactly ONE candidate and retries it forever, which is the
+  never-converging loop behind demo-postgres sitting unwakeable while a peer
+  brick sat idle. Moving the anchor is the only thing that breaks that tie.
+
+  ## What it is NOT
+
+  Not live migration, and deliberately not overlapped: the workload is banked
+  before the move and cold-boots on the target afterwards, so it is unreachable
+  between its final bank on the source and its first wake on the target. That
+  relaxation ("slow cutover due to activity is fine") is what lets the transfer
+  be a plain store round-trip instead of a pre-staged standby costing double
+  disk and continuous refresh reads on the hot-path NVMe.
+
+  Volume-only by design. The stateful bundle is vendor-BOUND while the volume is
+  a vendor-portable singleton, so moving only the volume is the mode that works
+  across any pair of nodes; the target cold-boots from its own base rather than
+  relighting a foreign memory image. #4119 names this as the cross-vendor
+  behaviour, and taking it as the ONLY behaviour keeps the first version free of
+  vendor-matching logic that a homogeneous fleet would never exercise.
+
+  ## Ordering, and why it is this order
+
+  Record before dispatch, then export, restore, re-anchor, evict. The invariant
+  the order protects is that **at no instant does a node other than the anchor
+  hold a writable claim**, and that a crash at any step leaves at most one
+  legitimate copy:
+
+    * export before restore, so the target reads bytes that exist;
+    * restore before re-anchor, so the anchor never names a node without data;
+    * re-anchor before evict, so the source copy outlives the switch and a crash
+      mid-move is recoverable by pointing the anchor back.
+
+  A crash between restore and re-anchor leaves a harmless extra copy on the
+  target with the anchor still on the source: the workload keeps working and the
+  leftover is exactly what #4119 slice 3's reconcile is for.
+
+  ## The export gate is load-bearing
+
+  The export refuses an unblessed generation (ADR embervm/011, enforced on both
+  the sync verb and the async queue). A move is the first moment an exported
+  copy becomes the AUTHORITATIVE one on another node, so a refused export must
+  abort the move rather than be logged past: restoring an unblessed generation
+  onto a peer and then pointing the anchor at it is precisely how a self-bumped
+  writer's divergent state would win. `{:error, :source_export_refused}` is a
+  correctness outcome here, not a transport problem.
+  """
+
+  require Logger
+
+  alias Embervm.Node.V1.ArtifactRef
+  alias Embervm.Node.V1.EvictArtifactRequest
+  alias Embervm.Node.V1.ExportArtifactRequest
+  alias Embervm.Node.V1.RestoreArtifactRequest
+  alias Embervm.Node.V1.Trace
+  alias Embervm.NodeCapacity
+  alias Embervm.OpLog.Op
+  alias Embervm.StatefulStore
+
+  @typedoc "Outcome detail for a completed move."
+  @type result :: %{
+          workload: String.t(),
+          from: String.t(),
+          to: String.t(),
+          generation: non_neg_integer(),
+          source_evicted: boolean()
+        }
+
+  @doc """
+  Move `workload`'s volume from its current anchor onto `target_node`.
+
+  Refuses unless the workload is fully banked: a live or in-flight instance
+  means someone holds a writable attach, and moving the volume out from under it
+  is the split brain the fence exists to prevent.
+
+  Options exist for the test seams (`:store`, `:capacity_table`, `:op_log`,
+  `:append_fun`, `:channel_fun`, `:export_fun`, `:restore_fun`, `:evict_fun`,
+  `:tenant`, `:clock`); production supplies none of them.
+  """
+  @spec move(String.t(), String.t(), keyword()) :: {:ok, result()} | {:error, term()}
+  def move(workload, target_node, opts \\ [])
+      when is_binary(workload) and is_binary(target_node) do
+    ctx = context(opts)
+
+    with {:ok, volume} <- fetch_volume(ctx, workload),
+         {:ok, source} <- anchor_of(volume),
+         :ok <- refuse_same_node(source, target_node),
+         :ok <- refuse_unless_banked(ctx, workload),
+         {:ok, source_dial} <- dial_key(ctx, source),
+         {:ok, target_dial} <- dial_key(ctx, target_node) do
+      run(ctx, workload, source, target_node, source_dial, target_dial)
+    end
+  end
+
+  # ---- sequence ---------------------------------------------------------------
+
+  defp run(ctx, workload, source, target, source_dial, target_dial) do
+    append_op(ctx, :stateful_handover_started, %{
+      workload: workload,
+      from: source,
+      to: target
+    })
+
+    with {:ok, generation} <- export_source(ctx, workload, source_dial),
+         :ok <- restore_target(ctx, workload, target_dial) do
+      # Re-anchor. From here the workload's next wake plans against the target,
+      # and StatefulManager issues a fresh blessed generation on that wake, so
+      # nothing needs to pre-bless the restored copy.
+      :ok = reanchor(ctx, workload, target)
+
+      evicted = evict_source(ctx, workload, source_dial)
+
+      append_op(ctx, :stateful_handover_finished, %{
+        workload: workload,
+        from: source,
+        to: target,
+        generation: generation,
+        source_evicted: evicted
+      })
+
+      Logger.info("embervm stateful handover: volume moved",
+        workload: workload,
+        from: source,
+        to: target,
+        generation: generation,
+        source_evicted: evicted
+      )
+
+      {:ok,
+       %{
+         workload: workload,
+         from: source,
+         to: target,
+         generation: generation,
+         source_evicted: evicted
+       }}
+    else
+      {:error, reason} = error ->
+        append_op(ctx, :stateful_handover_aborted, %{
+          workload: workload,
+          from: source,
+          to: target,
+          reason: inspect(reason)
+        })
+
+        Logger.warning("embervm stateful handover: aborted, anchor unchanged",
+          workload: workload,
+          from: source,
+          to: target,
+          reason: inspect(reason)
+        )
+
+        error
+    end
+  end
+
+  # Flush the source's copy to the store at its current generation. `skipped`
+  # means the daemon refused: either an unblessed generation (ADR 011) or a
+  # store copy that is already newer (#4111's ordering fence). Both mean the
+  # bytes a restore would read are NOT the ones this node holds, so the move
+  # must not proceed.
+  defp export_source(ctx, workload, source_dial) do
+    req = %ExportArtifactRequest{
+      artifact: volume_ref(workload),
+      trace: %Trace{workload: workload}
+    }
+
+    case rpc(ctx, ctx.export_fun, source_dial, req) do
+      {:ok, %{skipped: true}} ->
+        {:error, :source_export_refused}
+
+      {:ok, resp} ->
+        {:ok, Map.get(resp, :generation, 0)}
+
+      {:error, reason} ->
+        {:error, {:export_failed, reason}}
+    end
+  end
+
+  defp restore_target(ctx, workload, target_dial) do
+    req = %RestoreArtifactRequest{
+      artifact: volume_ref(workload),
+      trace: %Trace{workload: workload}
+    }
+
+    case rpc(ctx, ctx.restore_fun, target_dial, req) do
+      {:ok, _resp} -> :ok
+      {:error, reason} -> {:error, {:restore_failed, reason}}
+    end
+  end
+
+  defp reanchor(ctx, workload, target) do
+    _ = StatefulStore.upsert_volume(ctx.store, workload, %{node_id: target})
+    :ok
+  end
+
+  # Best-effort, and deliberately non-fatal. EvictArtifact refuses a volume that
+  # is still paired with a local stateful bundle (standing decision 8), which is
+  # the common case immediately after a bank, so making this fatal would fail
+  # most otherwise-correct moves. The anchor has already moved, so the leftover
+  # is a stale copy rather than a competing writer; #4119 slice 3's reconcile is
+  # what converges it. Reported in the op and the result so it is never silent.
+  defp evict_source(ctx, workload, source_dial) do
+    req = %EvictArtifactRequest{
+      artifact: volume_ref(workload),
+      remote: false,
+      trace: %Trace{workload: workload}
+    }
+
+    case rpc(ctx, ctx.evict_fun, source_dial, req) do
+      {:ok, _resp} ->
+        true
+
+      {:error, reason} ->
+        Logger.info("embervm stateful handover: source copy left in place",
+          workload: workload,
+          reason: inspect(reason)
+        )
+
+        false
+    end
+  end
+
+  # ---- guards -----------------------------------------------------------------
+
+  defp fetch_volume(ctx, workload) do
+    case StatefulStore.get_volume(ctx.store, workload) do
+      nil -> {:error, :no_volume}
+      volume -> {:ok, volume}
+    end
+  end
+
+  defp anchor_of(%{node_id: node_id}) when is_binary(node_id) and node_id != "",
+    do: {:ok, node_id}
+
+  defp anchor_of(_), do: {:error, :volume_node_missing}
+
+  defp refuse_same_node(source, target) when source == target, do: {:error, :already_anchored}
+  defp refuse_same_node(_source, _target), do: :ok
+
+  # "Banked" means no LIVE instance. StatefulStore maintains `live` as
+  # "non-terminal, non-banked", which is exactly the set that could be holding a
+  # writable attach, so reading the counter beats re-deriving which states are
+  # terminal. `list/2` would be the WRONG source here: it returns terminal
+  # history alongside the current instance, so filtering it for "everything is
+  # banked" would refuse every workload that has ever stopped an instance.
+  defp refuse_unless_banked(ctx, workload) do
+    case ctx.store |> StatefulStore.counts() |> Map.get(workload) do
+      nil -> :ok
+      %{live: 0} -> :ok
+      %{live: live} -> {:error, {:not_banked, live}}
+    end
+  end
+
+  # A VOLUME lives on the node's shared scratch, so ANY reporting brick instance
+  # on that node can serve the transfer. NodeCapacity's bare-string form is the
+  # node-scoped read built for exactly this ("volumes are NODE resources, not pod
+  # resources"), and it doubles as a liveness check: an unreported node is one
+  # whose daemon cannot move bytes.
+  #
+  # Deliberately NOT WakeInstance.select/2, the resolver the wake path uses. That
+  # one filters candidates on VM capacity, which is right when the caller is
+  # about to boot a VM and exactly wrong here: the SOURCE of a handover is very
+  # often a node that is out of VM slots (that being the reason to move at all),
+  # and it needs to push bytes, not host a guest. Selecting on capacity would
+  # refuse precisely the moves worth making.
+  #
+  # `configured_id` first because that is the key NodeChannel is configured with
+  # (`nodes: configured_nodes()`), so it is the name a dial resolves; node_id is
+  # the fallback for facts that predate the field.
+  defp dial_key(ctx, node_id) do
+    case NodeCapacity.fetch(ctx.capacity_table, node_id) do
+      {:ok, facts} -> {:ok, Map.get(facts, :configured_id) || node_id}
+      :error -> {:error, {:node_not_reporting, node_id}}
+    end
+  end
+
+  # ---- plumbing ---------------------------------------------------------------
+
+  defp volume_ref(workload) do
+    %ArtifactRef{kind: :ARTIFACT_KIND_VOLUME, workload: workload}
+  end
+
+  defp rpc(ctx, fun, dial_id, req) do
+    case ctx.channel_fun.(dial_id) do
+      {:ok, channel} -> fun.(channel, req)
+      {:error, reason} -> {:error, {:dial_failed, reason}}
+    end
+  rescue
+    e -> {:error, {:rpc_raised, inspect(e)}}
+  end
+
+  defp append_op(ctx, kind, payload) do
+    op = %Op{kind: kind, tenant: ctx.tenant, ts: ctx.clock.(), payload: payload}
+    _ = ctx.append_fun.(ctx.op_log, op)
+    :ok
+  rescue
+    e ->
+      Logger.warning("embervm stateful handover: op-log append raised",
+        kind: kind,
+        error: inspect(e)
+      )
+
+      :ok
+  end
+
+  defp context(opts) do
+    op_log_mod = Keyword.get(opts, :op_log_mod, Embervm.OpLog.SQLite)
+
+    %{
+      store: Keyword.get(opts, :store, StatefulStore),
+      capacity_table: Keyword.get(opts, :capacity_table, NodeCapacity.table()),
+      op_log: Keyword.get(opts, :op_log, op_log_mod),
+      append_fun: Keyword.get(opts, :append_fun, &default_append/2),
+      channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
+      export_fun: Keyword.get(opts, :export_fun, &default_export/2),
+      restore_fun: Keyword.get(opts, :restore_fun, &default_restore/2),
+      evict_fun: Keyword.get(opts, :evict_fun, &default_evict/2),
+      tenant: Keyword.get(opts, :tenant, "homelab"),
+      clock: Keyword.get(opts, :clock, fn -> System.system_time(:millisecond) end)
+    }
+  end
+
+  defp default_append(op_log, op), do: Embervm.OpLog.SQLite.append(op_log, op)
+
+  defp default_export(channel, req),
+    do: Embervm.Node.V1.NodeService.Stub.export_artifact(channel, req)
+
+  defp default_restore(channel, req),
+    do: Embervm.Node.V1.NodeService.Stub.restore_artifact(channel, req)
+
+  defp default_evict(channel, req),
+    do: Embervm.Node.V1.NodeService.Stub.evict_artifact(channel, req)
+end

--- a/projects/embervm/control/test/embervm/stateful_handover_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_handover_test.exs
@@ -1,0 +1,206 @@
+defmodule Embervm.StatefulHandoverTest do
+  @moduledoc """
+  Exercises Embervm.StatefulHandover (#4119 slice 4) against a real
+  StatefulStore + op-log and a real NodeCapacity table, with the three daemon
+  verbs (export/restore/evict) injected as recording seams.
+
+  The properties that matter are about what survives a refusal, not the happy
+  path:
+
+    * a refused export ABORTS with the anchor untouched (the ADR 011 gate is the
+      only thing standing between a self-bumped divergent copy and it becoming
+      authoritative on a peer);
+    * a live instance refuses the move outright (moving a volume out from under
+      a writable attach is the split brain the fence exists to prevent);
+    * a refused source eviction still SUCCEEDS, because the anchor has already
+      moved and the leftover is a stale copy rather than a competing writer.
+
+  No test sleeps; the clock is injected.
+  """
+  use ExUnit.Case, async: false
+
+  alias Embervm.{NodeCapacity, StatefulHandover, StatefulStore}
+  alias Embervm.OpLog.SQLite
+
+  defp start_stack(_opts \\ []) do
+    suffix = System.unique_integer([:positive])
+    cap_table = :"sfhocap_#{suffix}"
+    NodeCapacity.create(cap_table)
+
+    path = Path.join(System.tmp_dir!(), "embervm_statefulhandover_test_#{suffix}.db")
+    on_exit(fn -> File.rm_rf!(path) end)
+
+    {:ok, op_log} = SQLite.start_link(name: nil, path: path)
+    {:ok, store} = StatefulStore.start_link(name: nil, op_log: op_log, op_log_mod: SQLite)
+
+    # Two reporting nodes. configured_id is what a dial resolves against.
+    for node <- ["node-a", "node-b"] do
+      NodeCapacity.put(cap_table, node, %{
+        configured_id: node,
+        node_id: node,
+        max_live_vms: 8,
+        live_vms: 0,
+        workloads: %{},
+        stateful_vms: [],
+        stateful_bundles: []
+      })
+    end
+
+    {:ok, calls} = Agent.start_link(fn -> [] end)
+    %{store: store, op_log: op_log, cap_table: cap_table, calls: calls}
+  end
+
+  defp record(calls, tag, dial, result) do
+    Agent.update(calls, &(&1 ++ [{tag, dial}]))
+    result
+  end
+
+  defp calls(calls), do: Agent.get(calls, & &1)
+
+  # Base options wiring the seams. Each verb records (tag, dial_id) so the test
+  # can assert WHICH node each RPC went to, which is the part a move gets wrong.
+  defp opts(ctx, overrides \\ []) do
+    export = Keyword.get(overrides, :export, {:ok, %{skipped: false, generation: 7}})
+    restore = Keyword.get(overrides, :restore, {:ok, %{}})
+    evict = Keyword.get(overrides, :evict, {:ok, %{}})
+
+    [
+      store: ctx.store,
+      capacity_table: ctx.cap_table,
+      op_log: ctx.op_log,
+      op_log_mod: SQLite,
+      clock: fn -> 1_000 end,
+      # The channel seam hands the dial id straight through so each verb sees it.
+      channel_fun: fn dial -> {:ok, dial} end,
+      export_fun: fn dial, _req -> record(ctx.calls, :export, dial, export) end,
+      restore_fun: fn dial, _req -> record(ctx.calls, :restore, dial, restore) end,
+      evict_fun: fn dial, _req -> record(ctx.calls, :evict, dial, evict) end
+    ]
+  end
+
+  defp anchor(ctx, workload) do
+    case StatefulStore.get_volume(ctx.store, workload) do
+      nil -> nil
+      volume -> Map.get(volume, :node_id)
+    end
+  end
+
+  defp seed_volume(ctx, workload, node) do
+    {:ok, _} =
+      StatefulStore.create_volume(ctx.store, workload, %{
+        node_id: node,
+        generation: 1,
+        size_bytes: 1024,
+        allocated_bytes: 1024
+      })
+
+    :ok
+  end
+
+  test "moves a banked volume, re-anchors it, and evicts the source copy" do
+    ctx = start_stack()
+    seed_volume(ctx, "demo-postgres", "node-a")
+
+    assert {:ok, moved} = StatefulHandover.move("demo-postgres", "node-b", opts(ctx))
+
+    assert moved.from == "node-a"
+    assert moved.to == "node-b"
+    assert moved.generation == 7
+    assert moved.source_evicted
+
+    # The anchor is the whole point: the next wake must plan against node-b.
+    assert anchor(ctx, "demo-postgres") == "node-b"
+
+    # Export off the SOURCE, restore onto the TARGET, evict the SOURCE. Getting
+    # either direction backwards would still "succeed" without this assertion.
+    assert calls(ctx.calls) == [{:export, "node-a"}, {:restore, "node-b"}, {:evict, "node-a"}]
+  end
+
+  test "a refused export aborts the move and leaves the anchor untouched" do
+    ctx = start_stack()
+    seed_volume(ctx, "demo-postgres", "node-a")
+
+    # skipped: true is what noded returns for an unblessed generation (ADR 011)
+    # or a store copy that is already newer (#4111).
+    result =
+      StatefulHandover.move(
+        "demo-postgres",
+        "node-b",
+        opts(ctx, export: {:ok, %{skipped: true, generation: 0}})
+      )
+
+    assert result == {:error, :source_export_refused}
+    assert anchor(ctx, "demo-postgres") == "node-a"
+    # Nothing was restored onto the target: a peer must never receive bytes the
+    # control plane never blessed.
+    assert calls(ctx.calls) == [{:export, "node-a"}]
+  end
+
+  test "refuses to move while a live instance exists" do
+    ctx = start_stack()
+    seed_volume(ctx, "demo-postgres", "node-a")
+
+    {:ok, _instance} =
+      StatefulStore.start(ctx.store, %{
+        instance_id: "sf-live-1",
+        tenant: "homelab",
+        principal: "p1",
+        workload: "demo-postgres",
+        node_id: "node-a",
+        vm_id: "vm-1",
+        generation: 1
+      })
+
+    assert {:error, {:not_banked, live}} =
+             StatefulHandover.move("demo-postgres", "node-b", opts(ctx))
+
+    assert live > 0
+    assert anchor(ctx, "demo-postgres") == "node-a"
+    assert calls(ctx.calls) == []
+  end
+
+  test "refuses a move onto the node that already holds the volume" do
+    ctx = start_stack()
+    seed_volume(ctx, "demo-postgres", "node-a")
+
+    assert StatefulHandover.move("demo-postgres", "node-a", opts(ctx)) ==
+             {:error, :already_anchored}
+
+    assert calls(ctx.calls) == []
+  end
+
+  test "refuses a target that is not reporting" do
+    ctx = start_stack()
+    seed_volume(ctx, "demo-postgres", "node-a")
+
+    assert StatefulHandover.move("demo-postgres", "node-gone", opts(ctx)) ==
+             {:error, {:node_not_reporting, "node-gone"}}
+
+    assert anchor(ctx, "demo-postgres") == "node-a"
+    assert calls(ctx.calls) == []
+  end
+
+  test "a workload with no volume is a clean refusal, not a crash" do
+    ctx = start_stack()
+
+    assert StatefulHandover.move("nonexistent", "node-b", opts(ctx)) == {:error, :no_volume}
+  end
+
+  test "a refused source eviction still completes the move" do
+    ctx = start_stack()
+    seed_volume(ctx, "demo-postgres", "node-a")
+
+    # EvictArtifact refuses a volume still paired with a local bundle (standing
+    # decision 8), which is the COMMON case right after a bank. Failing the move
+    # on it would reject most otherwise-correct handovers.
+    assert {:ok, moved} =
+             StatefulHandover.move(
+               "demo-postgres",
+               "node-b",
+               opts(ctx, evict: {:error, :still_paired})
+             )
+
+    refute moved.source_evicted
+    assert anchor(ctx, "demo-postgres") == "node-b"
+  end
+end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.318
+      targetRevision: 0.1.319
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/store.go
+++ b/projects/embervm/noded/server/store.go
@@ -1059,6 +1059,27 @@ func (s *Server) runExportJob(ctx context.Context, job exportJob) {
 	}()
 
 	generation := s.artifactGeneration(job.ref)
+	// SKIP an unblessed VOLUME, the async half of the ADR 011 "never exported"
+	// invariant that ExportArtifact enforces synchronously above. Both halves are
+	// needed and this is the one that fires most: the sync verb serves explicit
+	// control-plane exports, while THIS queue runs on every export-after-commit, so
+	// a self-bumped generation reaching the S3 singleton would do so through here.
+	// Same local-only GenerationBlessed check, same fail-closed reading of an absent
+	// marker, so the two paths cannot disagree about what is exportable.
+	//
+	// Skipping (not failing) is right for a queue with no caller to answer: the
+	// generation is deliberately NOT recorded in s.exported, so nothing downstream
+	// can mistake the local copy for a durable one, and the next bank re-enqueues.
+	// A blessed generation exports on the following pass with no operator action.
+	if job.ref.GetKind() == nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME && s.volumes != nil {
+		if !s.volumes.GenerationBlessed(job.ref.GetWorkload()) {
+			s.logger.Warn("noded: async export SKIPPED, volume generation is not blessed (ADR 011)",
+				"artifact", job.key,
+				"workload", job.ref.GetWorkload(),
+				"localGeneration", generation)
+			return
+		}
+	}
 	// Local short-circuit for a VOLUME whose current generation is already the
 	// exported one (standing decision 6: skip a re-export when gen is unchanged).
 	if job.ref.GetKind() == nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME {

--- a/projects/embervm/noded/server/store_test.go
+++ b/projects/embervm/noded/server/store_test.go
@@ -659,8 +659,20 @@ func TestExportQueueVolumeStillReExportsAtStaleGeneration(t *testing.T) {
 	if err := s.volumes.Create(workload, 1<<20); err != nil {
 		t.Fatalf("create volume: %v", err)
 	}
-	if _, err := s.volumes.BumpGeneration(workload); err != nil {
-		t.Fatalf("bump: %v", err)
+	// Advance the generation via a CP-style BLESSING rather than a bare self-bump.
+	// This test is about the PRESENCE gate, not the ADR 011 blessing gate, but the
+	// queue now refuses an unblessed volume ahead of the presence check, so a
+	// self-bumped fixture would make this pass for the wrong reason (0 export calls
+	// because it was quarantined, not because presence skipped it). RecordBlessed
+	// advances the ledger and writes the blessed marker together, exactly as a
+	// CP-issued blessed_generation does, and requires the new generation to exceed
+	// the current one.
+	gen0, err := s.volumes.Generation(workload)
+	if err != nil {
+		t.Fatalf("generation: %v", err)
+	}
+	if _, err := s.volumes.RecordBlessed(workload, gen0+1); err != nil {
+		t.Fatalf("RecordBlessed: %v", err)
 	}
 	cur, err := s.volumes.Generation(workload)
 	if err != nil {
@@ -1850,5 +1862,66 @@ func TestExportArtifactVolumeAllowedWhenBlessed(t *testing.T) {
 	}
 	if !fs.has("volume/demo-postgres") {
 		t.Fatal("store missing volume/demo-postgres after a blessed export")
+	}
+}
+
+// TestRunExportJobVolumeSkippedWhenUnblessed covers the ASYNC half of the same
+// ADR 011 invariant. Gating only the sync verb left the dominant path open: the
+// sync verb serves explicit control-plane exports, while this queue runs on every
+// export-after-commit, so a self-bumped generation reaching the S3 singleton in
+// practice does so through here.
+//
+// runExportJob is called directly rather than through the queue so the assertion
+// is deterministic: proving a negative ("the bytes never landed") against a
+// worker pool would be a sleep-and-hope.
+func TestRunExportJobVolumeSkippedWhenUnblessed(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx := context.Background()
+
+	if err := s.volumes.Create("demo-postgres", 1); err != nil {
+		t.Fatalf("Create volume: %v", err)
+	}
+	if _, err := s.volumes.BumpGeneration("demo-postgres"); err != nil {
+		t.Fatalf("BumpGeneration: %v", err)
+	}
+	if s.volumes.GenerationBlessed("demo-postgres") {
+		t.Fatal("precondition: a self-bumped generation must not read as blessed")
+	}
+
+	ref := &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: "demo-postgres"}
+	key := artifactPrefix(ref, s.cfg.CpuVendor)
+	s.runExportJob(ctx, exportJob{ref: ref, key: key})
+
+	if fs.has("volume/demo-postgres") {
+		t.Fatal("an unblessed volume must NOT reach the store via the async queue")
+	}
+	// Deliberately not recorded as exported: claiming durability for bytes that
+	// never left would let a retention sweep treat the local copy as safe.
+	if _, ok := s.exported.generation(key); ok {
+		t.Fatal("a skipped export must not record an exported generation")
+	}
+}
+
+// TestRunExportJobVolumeExportsWhenBlessed is the paired positive, so the async
+// gate cannot pass by skipping everything.
+func TestRunExportJobVolumeExportsWhenBlessed(t *testing.T) {
+	fs := newFakeStore()
+	s := newStoreTestServer(t, fs)
+	ctx := context.Background()
+
+	if err := s.volumes.Create("demo-postgres", 1); err != nil {
+		t.Fatalf("Create volume: %v", err)
+	}
+	if _, err := s.volumes.RecordBlessed("demo-postgres", 7); err != nil {
+		t.Fatalf("RecordBlessed: %v", err)
+	}
+
+	ref := &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: "demo-postgres"}
+	key := artifactPrefix(ref, s.cfg.CpuVendor)
+	s.runExportJob(ctx, exportJob{ref: ref, key: key})
+
+	if !fs.has("volume/demo-postgres") {
+		t.Fatal("a blessed volume must reach the store via the async queue")
 	}
 }


### PR DESCRIPTION
Closes the gap behind a live outage: **demo-postgres has been unwakeable since 00:50Z** because node-3's brick is at its live-VM cap, retrying every 15 seconds with `no capacity left within budget (attempt 1/1)`, while node-4's brick sits with room. Nothing in the system could break that tie, because breaking it means moving the anchor.

## What lands

**Slice 1's missing half.** `5ad95de02` gated the synchronous `ExportArtifact` and left `runExportJob`, the async export-after-commit queue, open. That is the path that actually fires, since the sync verb serves explicit CP exports while the queue runs on every bank. ADR 011's "never exported" invariant was open on the dominant path.

**Slice 4.** `POST /v1/stateful/:name/handover/:target` exports the volume off its anchor, restores it onto the target, re-anchors, then evicts the source copy.

## Ordering

Record-before-dispatch, and the order protects the invariant that no node other than the anchor ever holds a writable claim:

- export before restore, so the target reads bytes that exist
- restore before re-anchor, so the anchor never names a node without data
- re-anchor before evict, so the source outlives the switch and a crash mid-move is recoverable by pointing the anchor back

A crash between restore and re-anchor leaves a harmless extra copy with the anchor still on the source; the workload keeps working and slice 3's reconcile converges it.

## Three refusals carry the safety

| Refusal | Why |
|---|---|
| Refused export aborts, anchor untouched | A move is the first moment an exported copy becomes authoritative elsewhere. Restoring an unblessed generation onto a peer and pointing the anchor at it is exactly how a self-bumped writer's divergent state would win. This is why the async gate landed first |
| Live instance refuses outright | Moving a volume out from under a writable attach is the split brain the fence exists to prevent |
| Refused source eviction still succeeds | `EvictArtifact` refuses a volume still paired with a local bundle, the common case right after a bank. The anchor has already moved, so the leftover is a stale copy, not a competing writer. Reported, never silent |

## Two deliberate non-choices

**Volume-only, target cold-boots.** The stateful bundle is vendor-bound while the volume is a vendor-portable singleton, so volume-only is the mode that works between any pair of nodes. #4119 names this as the cross-vendor behaviour; taking it as the only behaviour keeps v1 free of vendor-matching logic a homogeneous fleet never exercises.

**Not `WakeInstance.select`.** The wake path's resolver filters on VM capacity. The source of a handover is very often a node out of VM slots, that being the reason to move, and it needs to push bytes rather than host a guest. Selecting on capacity would refuse precisely the moves worth making.

## Tests

`ci test` green: **1049 Elixir tests, 0 failures** (7 new), `MIX TEST OK`, plus the Go async-gate pair. The Go suite caught a real fixture bug on the way in: `TestExportQueueVolumeStillReExportsAtStaleGeneration` advanced its volume with a bare `BumpGeneration`, so once the gate existed it would have passed for the wrong reason, zero export calls because the volume was quarantined rather than because presence skipped it. It now advances via `RecordBlessed`.

## Validation plan

Drill on demo-postgres after deploy: move it node-3 to node-4, then confirm it wakes. That is both the acceptance test and the fix for the outage.

Refs #4119

🤖 Generated with [Claude Code](https://claude.com/claude-code)