### PR TITLE
fix(embervm): resolve a bare node name when moving a stateful volume

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.319
+version: 0.1.320

--- a/projects/embervm/control/lib/embervm/stateful_handover.ex
+++ b/projects/embervm/control/lib/embervm/stateful_handover.ex
@@ -113,17 +113,29 @@ defmodule Embervm.StatefulHandover do
 
     with {:ok, generation} <- export_source(ctx, workload, source_dial),
          :ok <- restore_target(ctx, workload, target_dial) do
-      # Re-anchor. From here the workload's next wake plans against the target,
-      # and StatefulManager issues a fresh blessed generation on that wake, so
+      # Re-anchor on the RESOLVED instance id, never the bare name a caller may
+      # have typed: StatefulManager.anchor_node/2 resolves the stored value
+      # through NodeCapacity.fetch, which is an exact match, so parking a bare
+      # node name in the volume row would make every subsequent wake fail
+      # `:volume_node_gone`. Writing the instance id keeps the row in the same
+      # shape the boot-report projection maintains.
+      #
+      # From here the workload's next wake plans against the target, and
+      # StatefulManager issues a fresh blessed generation on that wake, so
       # nothing needs to pre-bless the restored copy.
-      :ok = reanchor(ctx, workload, target)
+      :ok = reanchor(ctx, workload, target_dial)
 
       evicted = evict_source(ctx, workload, source_dial)
 
+      # Report the RESOLVED target, so the op log and the caller both record the
+      # anchor that was actually written rather than the shorthand that was
+      # typed. A drill that reads back "to: node-4" while the row says
+      # "node-4/<uuid>" is a drill that cannot be checked.
       append_op(ctx, :stateful_handover_finished, %{
         workload: workload,
         from: source,
-        to: target,
+        to: target_dial,
+        requested_target: target,
         generation: generation,
         source_evicted: evicted
       })
@@ -131,7 +143,7 @@ defmodule Embervm.StatefulHandover do
       Logger.info("embervm stateful handover: volume moved",
         workload: workload,
         from: source,
-        to: target,
+        to: target_dial,
         generation: generation,
         source_evicted: evicted
       )
@@ -140,7 +152,7 @@ defmodule Embervm.StatefulHandover do
        %{
          workload: workload,
          from: source,
-         to: target,
+         to: target_dial,
          generation: generation,
          source_evicted: evicted
        }}
@@ -245,8 +257,20 @@ defmodule Embervm.StatefulHandover do
 
   defp anchor_of(_), do: {:error, :volume_node_missing}
 
-  defp refuse_same_node(source, target) when source == target, do: {:error, :already_anchored}
-  defp refuse_same_node(_source, _target), do: :ok
+  # The anchor is an instance id ("node-3/<uuid>") while a caller names a node
+  # ("node-3"), so comparing them raw would never match and a "move" onto the
+  # node already holding the volume would proceed as an export and restore onto
+  # itself. Compare NODE identity: everything before the first "/". Both forms
+  # reduce to the same name, so this holds whichever the caller used.
+  defp refuse_same_node(source, target) do
+    if node_name(source) == node_name(target) do
+      {:error, :already_anchored}
+    else
+      :ok
+    end
+  end
+
+  defp node_name(id), do: id |> to_string() |> String.split("/", parts: 2) |> hd()
 
   # "Banked" means no LIVE instance. StatefulStore maintains `live` as
   # "non-terminal, non-banked", which is exactly the set that could be holding a
@@ -275,13 +299,40 @@ defmodule Embervm.StatefulHandover do
   # and it needs to push bytes, not host a guest. Selecting on capacity would
   # refuse precisely the moves worth making.
   #
-  # `configured_id` first because that is the key NodeChannel is configured with
-  # (`nodes: configured_nodes()`), so it is the name a dial resolves; node_id is
-  # the fallback for facts that predate the field.
-  defp dial_key(ctx, node_id) do
-    case NodeCapacity.fetch(ctx.capacity_table, node_id) do
-      {:ok, facts} -> {:ok, Map.get(facts, :configured_id) || node_id}
-      :error -> {:error, {:node_not_reporting, node_id}}
+  # Accepts EITHER an instance id ("node-4/<uuid>", which is what a volume row's
+  # node_id holds and what NodeCapacity keys on) OR a bare node name ("node-4").
+  #
+  # Both forms are required, for different callers. The anchor read hands us an
+  # instance id, so the exact match is the source path. A human moving a
+  # workload names a NODE, and must be able to: the instance id contains a "/"
+  # and cannot survive a URL path segment, so a target could not be expressed at
+  # all without this. Bare names resolve by "<node>/" prefix over the reporting
+  # set, newest fact winning, which is the same "any instance on that node will
+  # do" reasoning that makes a node-scoped volume transferable in the first
+  # place.
+  defp dial_key(ctx, node) do
+    case NodeCapacity.fetch(ctx.capacity_table, node) do
+      {:ok, facts} -> {:ok, Map.get(facts, :node_id) || node}
+      :error -> resolve_by_node_prefix(ctx, node)
+    end
+  end
+
+  defp resolve_by_node_prefix(ctx, node) do
+    prefix = node <> "/"
+
+    ctx.capacity_table
+    |> NodeCapacity.all()
+    |> Enum.filter(fn facts ->
+      id = Map.get(facts, :node_id)
+      is_binary(id) and String.starts_with?(id, prefix)
+    end)
+    |> case do
+      [] ->
+        {:error, {:node_not_reporting, node}}
+
+      matches ->
+        newest = Enum.max_by(matches, fn facts -> Map.get(facts, :updated_at, 0) end)
+        {:ok, Map.get(newest, :node_id)}
     end
   end
 

--- a/projects/embervm/control/test/embervm/stateful_handover_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_handover_test.exs
@@ -186,6 +186,60 @@ defmodule Embervm.StatefulHandoverTest do
     assert StatefulHandover.move("nonexistent", "node-b", opts(ctx)) == {:error, :no_volume}
   end
 
+  # The shape production actually uses, and the one the first live drill got
+  # wrong: NodeCapacity keys facts by INSTANCE id ("node-4/<uuid>") and a volume
+  # row anchors on one, while an operator naming a target says "node-4". A bare
+  # name cannot be an instance id because the "/" would not survive a URL path
+  # segment, so both forms must resolve.
+  defp put_brick(ctx, node, uuid, updated_at) do
+    NodeCapacity.put(ctx.cap_table, {node, uuid}, %{
+      node_id: "#{node}/#{uuid}",
+      updated_at: updated_at,
+      max_live_vms: 8,
+      live_vms: 0,
+      workloads: %{},
+      stateful_vms: [],
+      stateful_bundles: []
+    })
+  end
+
+  test "resolves a bare node name to a reporting instance and anchors on the instance id" do
+    ctx = start_stack()
+    put_brick(ctx, "node-c", "aaaa", 10)
+    put_brick(ctx, "node-d", "bbbb", 20)
+    seed_volume(ctx, "demo-postgres", "node-c/aaaa")
+
+    assert {:ok, moved} = StatefulHandover.move("demo-postgres", "node-d", opts(ctx))
+
+    assert moved.from == "node-c/aaaa"
+    # Resolved, not the shorthand that was typed.
+    assert moved.to == "node-d/bbbb"
+
+    # The anchor MUST be the instance id: StatefulManager resolves it through an
+    # exact NodeCapacity match, so a bare name here would make every subsequent
+    # wake fail :volume_node_gone.
+    assert anchor(ctx, "demo-postgres") == "node-d/bbbb"
+
+    assert calls(ctx.calls) == [
+             {:export, "node-c/aaaa"},
+             {:restore, "node-d/bbbb"},
+             {:evict, "node-c/aaaa"}
+           ]
+  end
+
+  test "refuses a bare-name move onto the node that already holds the volume" do
+    ctx = start_stack()
+    put_brick(ctx, "node-c", "aaaa", 10)
+    seed_volume(ctx, "demo-postgres", "node-c/aaaa")
+
+    # Comparing the raw strings would MISS this ("node-c/aaaa" != "node-c") and
+    # export and restore the volume onto the node that already holds it.
+    assert StatefulHandover.move("demo-postgres", "node-c", opts(ctx)) ==
+             {:error, :already_anchored}
+
+    assert calls(ctx.calls) == []
+  end
+
   test "a refused source eviction still completes the move" do
     ctx = start_stack()
     seed_volume(ctx, "demo-postgres", "node-a")

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.319
+      targetRevision: 0.1.320
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Follow-up to #4173, caught by the **first live drill** against demo-postgres, which is exactly what a manual-trigger verb is for.

`POST /v1/stateful/demo-postgres/handover/node-4` returned `409 node is not reporting` while node-4's brick was plainly serving.

## Cause

`NodeCapacity` keys facts by **instance id** (`node-4/<uuid>`) and a volume row anchors on one. So `fetch/2`'s exact match resolved the SOURCE (read from the anchor) and could never resolve a TARGET typed as a bare node name. Passing the instance id instead is not available to the caller: it contains a `/` and does not survive a URL path segment.

Bare names now resolve by `<node>/` prefix over the reporting set, newest fact winning, which is the same "any instance on that node will do" reasoning that makes a node-scoped volume transferable at all. Exact ids still match first, so the anchor read is unchanged.

## Two consequences that would each have been a live bug

| | What would have happened |
|---|---|
| Re-anchor wrote the typed name | `anchor_node/2` resolves the stored value through the same exact match, so parking `node-4` in the volume row would make every subsequent wake fail `:volume_node_gone`. The move would report **success** and leave the workload permanently unwakeable, worse than the outage it was fixing |
| Already-anchored guard compared raw strings | `"node-c/aaaa" != "node-c"` misses, so a move onto the node already holding the volume would export and restore it onto itself |

## Why the first tests missed it

They built their fixtures bare-name-everywhere, so they were self-consistent and green while the production shape was instance-keyed. The new tests use the real shape: instance-keyed capacity, instance-anchored volume, bare-name target.

`ci test` green: 1051 Elixir tests, 0 failures, `MIX TEST OK`.

Refs #4119

🤖 Generated with [Claude Code](https://claude.com/claude-code)