### PR TITLE
fix(embervm): dispatch the handover op-log at the configured backend

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.320
+version: 0.1.321

--- a/projects/embervm/control/lib/embervm/stateful_handover.ex
+++ b/projects/embervm/control/lib/embervm/stateful_handover.ex
@@ -105,13 +105,13 @@ defmodule Embervm.StatefulHandover do
   # ---- sequence ---------------------------------------------------------------
 
   defp run(ctx, workload, source, target, source_dial, target_dial) do
-    append_op(ctx, :stateful_handover_started, %{
-      workload: workload,
-      from: source,
-      to: target
-    })
-
-    with {:ok, generation} <- export_source(ctx, workload, source_dial),
+    with :ok <-
+           require_op(ctx, :stateful_handover_started, %{
+             workload: workload,
+             from: source,
+             to: target
+           }),
+         {:ok, generation} <- export_source(ctx, workload, source_dial),
          :ok <- restore_target(ctx, workload, target_dial) do
       # Re-anchor on the RESOLVED instance id, never the bare name a caller may
       # have typed: StatefulManager.anchor_node/2 resolves the stored value
@@ -131,7 +131,7 @@ defmodule Embervm.StatefulHandover do
       # anchor that was actually written rather than the shorthand that was
       # typed. A drill that reads back "to: node-4" while the row says
       # "node-4/<uuid>" is a drill that cannot be checked.
-      append_op(ctx, :stateful_handover_finished, %{
+      note_op(ctx, :stateful_handover_finished, %{
         workload: workload,
         from: source,
         to: target_dial,
@@ -158,7 +158,7 @@ defmodule Embervm.StatefulHandover do
        }}
     else
       {:error, reason} = error ->
-        append_op(ctx, :stateful_handover_aborted, %{
+        note_op(ctx, :stateful_handover_aborted, %{
           workload: workload,
           from: source,
           to: target,
@@ -351,28 +351,62 @@ defmodule Embervm.StatefulHandover do
     e -> {:error, {:rpc_raised, inspect(e)}}
   end
 
+  # The STARTED op is load-bearing and must land before anything is dispatched:
+  # it is the record that adjudicates a crash mid-move, so proceeding without it
+  # would mutate the fleet with no durable trace of an in-flight handover. A
+  # failure here aborts, and nothing has happened yet.
+  defp require_op(ctx, kind, payload) do
+    case append_op(ctx, kind, payload) do
+      :ok -> :ok
+      {:error, reason} -> {:error, {:op_log_unavailable, reason}}
+    end
+  end
+
+  # Terminal ops are best-effort by contrast: the move has already happened, and
+  # refusing to report it would not un-happen it. Logged loudly instead.
+  defp note_op(ctx, kind, payload) do
+    case append_op(ctx, kind, payload) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("embervm stateful handover: op-log append failed after the move",
+          kind: kind,
+          reason: inspect(reason)
+        )
+
+        :ok
+    end
+  end
+
+  # Both a raise and an EXIT have to be caught. The first live drill 500'd on the
+  # latter: a GenServer.call to a name that is not running exits rather than
+  # raising, so a `rescue` alone let it escape as an unhandled error with an
+  # empty body.
   defp append_op(ctx, kind, payload) do
     op = %Op{kind: kind, tenant: ctx.tenant, ts: ctx.clock.(), payload: payload}
     _ = ctx.append_fun.(ctx.op_log, op)
     :ok
   rescue
-    e ->
-      Logger.warning("embervm stateful handover: op-log append raised",
-        kind: kind,
-        error: inspect(e)
-      )
-
-      :ok
+    e -> {:error, e}
+  catch
+    :exit, reason -> {:error, reason}
   end
 
   defp context(opts) do
-    op_log_mod = Keyword.get(opts, :op_log_mod, Embervm.OpLog.SQLite)
+    # The op-log backend is SELECTED AT BOOT (SQLite or Postgres, per
+    # EMBERVM_OPLOG_DSN), so hardcoding one dispatches at a GenServer name that
+    # does not exist in production. The first live drill 500'd on exactly that:
+    # prod runs Postgres, and the call went to Embervm.OpLog.SQLite. Ask the
+    # application, as every store and sweeper does via its :op_log_mod opt.
+    op_log_mod = Keyword.get(opts, :op_log_mod, Embervm.Application.op_log_mod())
 
     %{
       store: Keyword.get(opts, :store, StatefulStore),
       capacity_table: Keyword.get(opts, :capacity_table, NodeCapacity.table()),
       op_log: Keyword.get(opts, :op_log, op_log_mod),
-      append_fun: Keyword.get(opts, :append_fun, &default_append/2),
+      append_fun:
+        Keyword.get(opts, :append_fun, fn op_log, op -> op_log_mod.append(op_log, op) end),
       channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
       export_fun: Keyword.get(opts, :export_fun, &default_export/2),
       restore_fun: Keyword.get(opts, :restore_fun, &default_restore/2),
@@ -381,8 +415,6 @@ defmodule Embervm.StatefulHandover do
       clock: Keyword.get(opts, :clock, fn -> System.system_time(:millisecond) end)
     }
   end
-
-  defp default_append(op_log, op), do: Embervm.OpLog.SQLite.append(op_log, op)
 
   defp default_export(channel, req),
     do: Embervm.Node.V1.NodeService.Stub.export_artifact(channel, req)

--- a/projects/embervm/control/test/embervm/stateful_handover_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_handover_test.exs
@@ -240,6 +240,27 @@ defmodule Embervm.StatefulHandoverTest do
     assert calls(ctx.calls) == []
   end
 
+  test "an op-log failure aborts before anything is dispatched" do
+    ctx = start_stack()
+    seed_volume(ctx, "demo-postgres", "node-a")
+
+    # The started op is the record that adjudicates a crash mid-move, so a move
+    # that cannot record it must not begin. Note the EXIT rather than a raise:
+    # a GenServer.call to a name that is not running exits, which is exactly how
+    # the first live drill escaped as an unhandled 500 with an empty body.
+    boom = fn _op_log, _op -> exit(:noproc) end
+
+    assert {:error, {:op_log_unavailable, _}} =
+             StatefulHandover.move(
+               "demo-postgres",
+               "node-b",
+               Keyword.put(opts(ctx), :append_fun, boom)
+             )
+
+    assert anchor(ctx, "demo-postgres") == "node-a"
+    assert calls(ctx.calls) == []
+  end
+
   test "a refused source eviction still completes the move" do
     ctx = start_stack()
     seed_volume(ctx, "demo-postgres", "node-a")

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.320
+      targetRevision: 0.1.321
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Second live drill failure against demo-postgres, and a more interesting one than the first: the verb returned **500 with an empty body**.

## Cause

It appended to `Embervm.OpLog.SQLite` while production runs **Postgres** (the backend is selected at boot from `EMBERVM_OPLOG_DSN`, PR #4047). The call went to a GenServer name that is not running.

Two distinct defects, both of which needed the drill to find:

| Defect | Why it survived CI |
|---|---|
| Backend hardcoded to SQLite | Every store, sweeper and coordinator takes it as an `:op_log_mod` opt fed from `Embervm.Application.op_log_mod/0`. This module is called straight from the router with no opts, so it silently defaulted to the module that only exists in dev and test, which is also the module the tests inject |
| Error escaped as an unhandled 500 | A `GenServer.call` to a dead name **exits** rather than raising, and the guard was `rescue`, which does not catch exits |

## The precondition distinction

The started op is now a hard precondition while the terminal ops are best-effort, which is what record-before-dispatch actually needs:

- a move that cannot record its **start** must not begin, because that record is what adjudicates a crash mid-move
- a move that cannot record its **finish** has already happened, and refusing to report it would not un-happen it

## Test note

The new test uses `exit/1` rather than `raise/1` deliberately. A raising fake would have passed against the old `rescue` and reproduced nothing.

`ci test` green: 1052 Elixir tests, 0 failures, `MIX TEST OK`.

Refs #4119

🤖 Generated with [Claude Code](https://claude.com/claude-code)