### PR TITLE
fix(embervm): demote the async volume export gate to observe-only

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.322
+version: 0.1.323

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.322
+      targetRevision: 0.1.323
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/store.go
+++ b/projects/embervm/noded/server/store.go
@@ -1059,25 +1059,34 @@ func (s *Server) runExportJob(ctx context.Context, job exportJob) {
 	}()
 
 	generation := s.artifactGeneration(job.ref)
-	// SKIP an unblessed VOLUME, the async half of the ADR 011 "never exported"
-	// invariant that ExportArtifact enforces synchronously above. Both halves are
-	// needed and this is the one that fires most: the sync verb serves explicit
-	// control-plane exports, while THIS queue runs on every export-after-commit, so
-	// a self-bumped generation reaching the S3 singleton would do so through here.
-	// Same local-only GenerationBlessed check, same fail-closed reading of an absent
-	// marker, so the two paths cannot disagree about what is exportable.
+	// OBSERVE-ONLY blessing check for a VOLUME. ADR 011 says an unblessed
+	// generation is "never exported", and enforcing that here (as this queue
+	// briefly did) stopped volume durability fleet-wide within minutes: 31 skips
+	// and ZERO successful volume exports across every brick.
 	//
-	// Skipping (not failing) is right for a queue with no caller to answer: the
-	// generation is deliberately NOT recorded in s.exported, so nothing downstream
-	// can mistake the local copy for a durable one, and the next bank re-enqueues.
-	// A blessed generation exports on the following pass with no operator action.
+	// The invariant is right; its PRECONDITION does not hold. `genblessed` only
+	// advances on a WAKE (bless_wake_generation on the dispatch), while `gen`
+	// bumps on every BANK, and banks vastly outnumber wakes. Measured on the live
+	// fleet: demo-postgres gen 6494 vs blessed 6416, scratch-postgres gen 20767
+	// vs blessed 20182. A volume is therefore almost never blessed at the moment
+	// its export-after-commit fires, so a fail-closed gate here is not "refuse
+	// the divergent case", it is "refuse everything".
+	//
+	// Enforcing costs an immediate, silent loss of every off-node volume copy.
+	// The divergence it guards against is rarer and conditional, and the sync
+	// ExportArtifact path still refuses (unchanged, and that is the path a
+	// control-plane-driven move uses, where an unblessed copy really would be
+	// promoted to authoritative). So this logs and continues: the signal is kept,
+	// the durability is not sacrificed for it.
+	//
+	// Flipping this to enforce requires blessing to track generation first, which
+	// is the actual bug.
 	if job.ref.GetKind() == nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME && s.volumes != nil {
 		if !s.volumes.GenerationBlessed(job.ref.GetWorkload()) {
-			s.logger.Warn("noded: async export SKIPPED, volume generation is not blessed (ADR 011)",
+			s.logger.Warn("noded: exporting an UNBLESSED volume generation (ADR 011 observe-only; blessing watermark lags the ledger)",
 				"artifact", job.key,
 				"workload", job.ref.GetWorkload(),
 				"localGeneration", generation)
-			return
 		}
 	}
 	// Local short-circuit for a VOLUME whose current generation is already the

--- a/projects/embervm/noded/server/store_test.go
+++ b/projects/embervm/noded/server/store_test.go
@@ -1865,16 +1865,17 @@ func TestExportArtifactVolumeAllowedWhenBlessed(t *testing.T) {
 	}
 }
 
-// TestRunExportJobVolumeSkippedWhenUnblessed covers the ASYNC half of the same
-// ADR 011 invariant. Gating only the sync verb left the dominant path open: the
-// sync verb serves explicit control-plane exports, while this queue runs on every
-// export-after-commit, so a self-bumped generation reaching the S3 singleton in
-// practice does so through here.
+// TestRunExportJobVolumeExportsUnblessedWithWarning pins the OBSERVE-ONLY
+// decision on the async queue. Enforcing ADR 011 here stopped volume durability
+// fleet-wide (31 skips, zero successful volume exports) because `genblessed`
+// only advances on a WAKE while `gen` bumps on every BANK, so a volume is almost
+// never blessed at the moment its export-after-commit fires.
 //
-// runExportJob is called directly rather than through the queue so the assertion
-// is deterministic: proving a negative ("the bytes never landed") against a
-// worker pool would be a sleep-and-hope.
-func TestRunExportJobVolumeSkippedWhenUnblessed(t *testing.T) {
+// The sync ExportArtifact path still REFUSES, and that asymmetry is the point:
+// it is the path a control-plane-driven move uses, where an unblessed copy would
+// be promoted to authoritative on a peer. Losing every off-node copy to guard a
+// rarer, conditional hazard is the worse trade.
+func TestRunExportJobVolumeExportsUnblessedWithWarning(t *testing.T) {
 	fs := newFakeStore()
 	s := newStoreTestServer(t, fs)
 	ctx := context.Background()
@@ -1890,16 +1891,10 @@ func TestRunExportJobVolumeSkippedWhenUnblessed(t *testing.T) {
 	}
 
 	ref := &nodev1.ArtifactRef{Kind: nodev1.ArtifactKind_ARTIFACT_KIND_VOLUME, Workload: "demo-postgres"}
-	key := artifactPrefix(ref, s.cfg.CpuVendor)
-	s.runExportJob(ctx, exportJob{ref: ref, key: key})
+	s.runExportJob(ctx, exportJob{ref: ref, key: artifactPrefix(ref, s.cfg.CpuVendor)})
 
-	if fs.has("volume/demo-postgres") {
-		t.Fatal("an unblessed volume must NOT reach the store via the async queue")
-	}
-	// Deliberately not recorded as exported: claiming durability for bytes that
-	// never left would let a retention sweep treat the local copy as safe.
-	if _, ok := s.exported.generation(key); ok {
-		t.Fatal("a skipped export must not record an exported generation")
+	if !fs.has("volume/demo-postgres") {
+		t.Fatal("durability regression: an unblessed volume must still reach the store via the async queue")
 	}
 }
 


### PR DESCRIPTION
**Live durability regression, self-inflicted in #4173, fixed here.**

Enforcing ADR 011's "never exported" invariant on the async export queue stopped volume durability across the whole fleet within minutes. Measured on the live cluster:

```
16gi:       volume exports OK=0  SKIPPED=20
2gi-node-3: volume exports OK=0  SKIPPED=11
```

Zero successful volume exports on every brick.

## The invariant is right; its precondition does not hold

`genblessed` only advances on a **wake** (`bless_wake_generation`, on the dispatch), while `gen` bumps on every **bank**, and banks vastly outnumber wakes:

| Workload | gen | blessed | behind |
|---|---|---|---|
| demo-postgres | 6494 | 6416 | 78 |
| scratch-postgres | 20767 | 20182 | 585 |

A volume is therefore almost never blessed at the instant its export-after-commit fires. A fail-closed gate there does not mean "refuse the divergent case", it means **refuse everything**.

## Why the sync path keeps enforcing

The asymmetry is deliberate, not an oversight:

- **Sync `ExportArtifact`** (5ad95de02, pre-existing) is the path a control-plane-driven **move** uses, which is exactly where an unblessed copy would be promoted to authoritative on a peer. Refusing there is correct and cheap.
- **The async queue** is periodic durability. Refusing there costs every off-node copy.

Trading certain, silent durability loss against a rarer conditional hazard is the wrong way round.

So the check stays and logs, and the export proceeds. The signal that motivated it is preserved (we now know exactly how far blessing lags, which is how this was found) without paying for it in durability.

## Not fixed here

Flipping this back to enforce requires **blessing to track the generation**, which is the real bug. It also blocks the handover drill: demo-postgres cannot be moved while unblessed, and it cannot become blessed without a wake, which it cannot get without moving.

`ci test` green, `MIX TEST OK`.

Refs #4119

🤖 Generated with [Claude Code](https://claude.com/claude-code)