### PR TITLE
fix(embervm): delete the slot-ceiling divisor, gate admission on memory

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.323
+version: 0.1.324

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -358,13 +358,16 @@ sandboxWorkload:
   #
   # PoolManager applies floor PER BRICK INSTANCE (`refill_node/2` runs once per
   # capacity fact and compares this floor against that instance's own
-  # `free_primed_slots`), and a brick's real ceiling is not `noded.maxLiveVMs`:
-  # `budget.SlotCeiling` derives it as `memBudgetMib / 512`, so a 2gi brick
-  # reporting ~1933 MiB advertises just THREE slots. The Task 14b sizing of 4 was
-  # written for the wildcard DaemonSet (16 slots on a 63Gi node-4); the DS is now
-  # retired and bricks are the only capacity, which made 4 unsatisfiable on a
-  # 3-slot brick. An unsatisfiable floor never stops priming, so the pool claimed
-  # 100% of every 2gi brick and a node-pinned stateful wake could never find a
+  # `free_primed_slots`), and memory capacity is not represented by
+  # `noded.maxLiveVMs`:
+  # Admission gates on measured memory headroom (workload need + reject floor),
+  # not on a count derived from the cgroup budget. MaxLiveVMs is only the runaway
+  # backstop and is no longer derived from the budget, so this floor must stay
+  # below the configured backstop. The Task 14b sizing of 4 was written for the
+  # wildcard DaemonSet (16 slots on a 63Gi node-4); the DS is now retired and
+  # bricks are the only capacity. An unsatisfiable floor never stops priming, so
+  # the pool claimed 100% of every 2gi brick and a node-pinned stateful wake could
+  # never find a
   # free slot (issue #4077: demo-postgres wedged evicted for 2.5h while both
   # node-2 bricks sat at 3/3, all six slots primed sandbox VMs). Autoscaling made
   # it worse, not better: because the floor is per instance, each new brick
@@ -797,8 +800,8 @@ noded:
   # one, so instance boot skips netlink create/attach work. Zero (the default)
   # disables pre-provisioning: taps are created/deleted on demand exactly as before
   # this feature existed. A positive value is clamped at the daemon to the brick's
-  # cgroup-derived slot ceiling (server.Server.SlotCeiling), so pre-creating more
-  # taps than the brick could ever host is not possible even if this is set too
+  # configured live-VM backstop (server.Server.SlotCeiling), so pre-creating more
+  # taps than the daemon's runaway limit is not possible even if this is set too
   # high. Not yet flipped fleet-wide; canary one brick class first (Task 4.2).
   tapPrealloc: 0
 

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.323
+      targetRevision: 0.1.324
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/cmd/main.go
+++ b/projects/embervm/noded/cmd/main.go
@@ -103,7 +103,7 @@ func run(logger *slog.Logger) error {
 	// cold-boot-with-NIC ClaimServing plus SnapshotServing/RestoreServing under the
 	// serving/ prefix, and its live map counts serving VMs against the node cap.
 	// cfg.TapPrealloc (ADR embervm/014 decision 4) is clamped to the brick's slot
-	// ceiling below, once server.New has built the budget reader that ceiling reads.
+	// ceiling below, a configured runaway backstop no longer derived from the memory budget.
 	servingNet, err := serving.NewManager(serving.ExecRunner{}, cfg.ServingBridge, cfg.ServingSubnetCIDR, cfg.PodIP, cfg.ServingPortBase, cfg.TapPrealloc)
 	if err != nil {
 		return err

--- a/projects/embervm/noded/cmd/main.go
+++ b/projects/embervm/noded/cmd/main.go
@@ -183,8 +183,8 @@ func run(logger *slog.Logger) error {
 	}
 	srv := server.New(opts)
 	// Cap the tap-prealloc pool (ADR embervm/014 decision 4) at the brick's
-	// cgroup-derived slot ceiling: pre-creating more taps than the brick could ever
-	// host wastes boot-time netlink work. Must run before EnsureNetwork below.
+	// configured live-VM backstop: pre-creating more taps than the daemon's runaway
+	// limit wastes boot-time netlink work. Must run before EnsureNetwork below.
 	servingNet.ClampTapPrealloc(srv.SlotCeiling())
 	// Report node-local base snapshots left by a prior incarnation so the control
 	// plane reconciles rather than rebuilding.

--- a/projects/embervm/noded/config/config.go
+++ b/projects/embervm/noded/config/config.go
@@ -96,14 +96,12 @@ type Config struct {
 
 	// MaxLiveVMs is the node-level backstop cap on concurrently live microVMs
 	// (primed + assigning). The control plane owns real concurrency; this only
-	// stops a runaway from exhausting the node. Prime returns RESOURCE_EXHAUSTED
-	// at the cap. Default 8. Zero or negative means unbounded (no backstop).
+	// stops a runaway from exhausting the node. Memory pressure is admitted or
+	// rejected separately. Default 8. Zero or negative means unbounded.
 	//
-	// After the budget-agnostic daemon (ADR embervm/005 item 4), no capacity
-	// decision may read MaxLiveVMs; it keeps only this runaway-backstop
-	// meaning. The real slot ceiling for a brick size-class is derived from
-	// MemBudgetMib/CpuBudgetMillicores (see server/budget.go), reported on
-	// NodeStatus for the control plane to consume.
+	// MaxLiveVMs keeps only this runaway-backstop meaning. Memory admission is
+	// measured separately from cgroup headroom and reported on NodeStatus for the
+	// control plane to consume.
 	MaxLiveVMs int
 
 	// MemRejectFloorMib is the memory cushion (MiB) the node-side cheap-rejection
@@ -111,7 +109,7 @@ type Config struct {
 	// (Prime/Start*): free schedulable memory must exceed need + this floor or the
 	// verb is rejected RESOURCE_EXHAUSTED with reason `pressure:mem` (ADR
 	// embervm/014 decision 3). It is one smallest-workload footprint by default
-	// (minSlotWorkloadMib, 512) so a brick never admits a boot that would drive it
+	// (512 MiB) so a brick never admits a boot that would drive it
 	// to the memory edge; a zero/unset value falls back to that same default in
 	// the predicate (the floor is never accidentally disabled). Env
 	// EMBERVM_NODED_MEM_REJECT_FLOOR_MIB. Read only by the pressure predicate; a
@@ -391,9 +389,7 @@ func Load() (Config, error) {
 		BearerToken:      os.Getenv("EMBERVM_NODED_BEARER_TOKEN"),
 		MaxLiveVMs:       atoiDefault("EMBERVM_NODED_MAX_LIVE_VMS", 8),
 		DaemonReserveMib: atoiDefault("EMBERVM_NODED_DAEMON_RESERVE_MIB", 512),
-		// Default 512 == server.minSlotWorkloadMib (one smallest-workload
-		// footprint); the two live in different packages (config cannot import
-		// server), so the literal is duplicated with this note tying them together.
+		// Default 512 MiB memory reject floor; zero means use this fallback.
 		MemRejectFloorMib:   atoiDefault("EMBERVM_NODED_MEM_REJECT_FLOOR_MIB", 512),
 		AdmissionModel:      getenvDefault("EMBERVM_NODED_ADMISSION_MODEL", "observed"),
 		VMOverheadMib:       atoiDefault("EMBERVM_NODED_VM_OVERHEAD_MIB", 0),

--- a/projects/embervm/noded/server/budget.go
+++ b/projects/embervm/noded/server/budget.go
@@ -109,12 +109,6 @@ type budget struct {
 	// can pin the sample instant and assert an exact usage-rate delta instead
 	// of racing sub-microsecond wall-clock jitter between two time.Now calls.
 	now func() time.Time
-
-	// memBudgetOverride, when set, replaces MemBudgetMib as the source
-	// SlotCeiling divides. Test-only seam so the ceiling arithmetic can be
-	// asserted against fixed budgets without a fixture cgroup filesystem; nil
-	// in production, where SlotCeiling reads the real budget.
-	memBudgetOverride func() uint64
 }
 
 // newBudget constructs a reader with the given daemon-RSS reserve.
@@ -166,44 +160,12 @@ func (b *budget) CpuBudgetMillicores() uint64 {
 	return parseCpuBudgetMillicores(string(raw))
 }
 
-// minSlotWorkloadMib is the smallest guest footprint a live-VM slot is assumed
-// to hold, used only to turn the memory budget into a slot ceiling. It is a
-// floor for the divisor, not a real per-workload size (workloads are sized from
-// the registry): dividing the budget by it yields the MOST slots a brick could
-// ever host, which is the honest ceiling maxLiveVMs must not exceed. Set to a
-// conservative small-guest size so the ceiling errs high (the configured
-// MaxLiveVMs backstop and real per-VM Claim accounting are the tighter caps);
-// 512 MiB keeps a 2gi/512-reserve brick at 3 slots rather than the configured
-// default of 8/16.
-const minSlotWorkloadMib = 512
-
-// SlotCeiling returns the brick's cgroup-derived live-VM slot ceiling per ADR
-// embervm/013 section 7 ("maxLiveVMs is the brick's cgroup-derived slot
-// ceiling, never a control-plane knob"): floor(MemBudgetMib /
-// minSlotWorkloadMib), clamped so it never EXCEEDS the configured backstop
-// (configured stays an upper bound). When the budget is unknown (0, an
-// unlimited or unreadable cgroup) the ceiling is unknown too, so the configured
-// backstop is used unchanged: an environment that cannot observe its cgroup
-// keeps exactly the pre-budget behavior rather than collapsing to zero slots.
+// SlotCeiling returns the configured live-VM backstop unchanged. Memory admission
+// is enforced separately by admitOrReject using measured headroom, the workload's
+// need, and the configured reject floor. A zero or unreadable memory budget does
+// not change the backstop.
 func (b *budget) SlotCeiling(configured uint64) uint64 {
-	budgetMib := b.MemBudgetMib()
-	if b.memBudgetOverride != nil {
-		budgetMib = b.memBudgetOverride()
-	}
-	if budgetMib == 0 {
-		return configured
-	}
-	derived := budgetMib / minSlotWorkloadMib
-	if derived == 0 {
-		// A budget smaller than one slot still hosts at least one VM (the
-		// backstop and Claim accounting gate the real limit); never advertise
-		// a zero ceiling that would wedge a small brick out of all placement.
-		derived = 1
-	}
-	if configured > 0 && derived > configured {
-		return configured
-	}
-	return derived
+	return configured
 }
 
 // CpuHeadroomMillicores returns the last computed CPU headroom: budget minus

--- a/projects/embervm/noded/server/budget_test.go
+++ b/projects/embervm/noded/server/budget_test.go
@@ -405,32 +405,26 @@ func TestCgroupDirFallsBackWhenJoinedDirLacksControllers(t *testing.T) {
 func TestSlotCeiling(t *testing.T) {
 	cases := []struct {
 		name       string
-		budgetMib  uint64
 		configured uint64
-		want       uint64
 	}{
-		// 2gi brick, 512 reserve -> 1536 budget -> floor(1536/512)=3 slots,
-		// clamped under the configured default of 8 (the whole point: not 8/16).
-		{"2gi-brick", 1536, 8, 3},
-		// 4gi brick -> 3584 budget -> 7 slots, still under configured 8.
-		{"4gi-brick", 3584, 8, 7},
-		// 16gi brick -> derived exceeds configured 8, so configured clamps it.
-		{"large-brick-clamped", 15872, 8, 8},
-		// Unknown budget (unlimited/unreadable cgroup) -> configured unchanged.
-		{"unknown-budget", 0, 8, 8},
-		// Budget smaller than one slot still reports at least 1.
-		{"sub-slot-budget", 256, 8, 1},
-		// Configured 0 (unbounded backstop) -> report the derived ceiling.
-		{"unbounded-config", 1536, 0, 3},
+		{"configured-default", 8},
+		{"configured-small", 2},
+		{"configured-unlimited", 0},
+		{"configured-large", 64},
 	}
+	// Memory admission gates on headroom (need + floor), not count.
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			b := newBudget(0)
-			b.memBudgetOverride = func() uint64 { return c.budgetMib }
-			if got := b.SlotCeiling(c.configured); got != c.want {
-				t.Errorf("SlotCeiling(%d) with budget %d = %d, want %d", c.configured, c.budgetMib, got, c.want)
+			if got := b.SlotCeiling(c.configured); got != c.configured {
+				t.Errorf("SlotCeiling(%d) = %d, want configured value", c.configured, got)
 			}
 		})
+	}
+
+	b := newBudget(0)
+	if got := b.SlotCeiling(8); got != 8 {
+		t.Fatalf("SlotCeiling with unknown budget = %d, want 8", got)
 	}
 }
 

--- a/projects/embervm/noded/server/group_member.go
+++ b/projects/embervm/noded/server/group_member.go
@@ -47,9 +47,6 @@ func (s *Server) startGroupMember(ctx context.Context, req *nodev1.StartGroupMem
 	if s.isDraining() {
 		return nil, status.Error(codes.Unavailable, "noded: draining")
 	}
-	if s.slotsExhausted() {
-		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.SlotCeiling())
-	}
 	// Cheap rejection under real memory pressure (ADR embervm/014 decision 3),
 	// BEFORE the member cold boot below. A group member's tap is pinned on its
 	// PER-GROUP bridge (groupNet), not the serving IP allocator (servingNet), and

--- a/projects/embervm/noded/server/group_member.go
+++ b/projects/embervm/noded/server/group_member.go
@@ -55,6 +55,9 @@ func (s *Server) startGroupMember(ctx context.Context, req *nodev1.StartGroupMem
 	// serving-allocator tap freelist is the wrong pool for a group member and
 	// checking it would reject on unrelated serving pressure. Its mem need comes
 	// from the request's ResourceSpec.
+	if s.slotsExhausted() {
+		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.SlotCeiling())
+	}
 	if err := s.admitOrReject(uint64(req.GetResources().GetMemMib()), classMemOnly); err != nil {
 		return nil, err
 	}

--- a/projects/embervm/noded/server/pressure.go
+++ b/projects/embervm/noded/server/pressure.go
@@ -5,6 +5,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const minSlotWorkloadMib = 512
+
 // This file holds the node-side CHEAP rejection predicate (ADR embervm/014
 // decision 3: "placement is reject/retry, not ledger-perfect"). Before a boot
 // verb (Prime / StartServing / StartStateful / StartGroupMember) claims any

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -178,11 +178,9 @@ type Server struct {
 	// minus the observed usage rate across the two most recent Refresh
 	// calls). 0 until a second sample exists. Overridable in tests.
 	cpuHeadroom func() uint64
-	// slotCeiling maps the configured MaxLiveVMs backstop to the brick's
-	// cgroup-derived live-VM slot ceiling (floor(MemBudgetMib/minWorkload),
-	// clamped to the configured value). The reported MaxLiveVms is this
-	// ceiling, so a 2gi brick advertises a handful of slots rather than the
-	// configured default. Overridable in tests.
+	// slotCeiling maps the configured MaxLiveVMs backstop to the value advertised
+	// in NodeStatus. Memory admission is enforced separately by admitOrReject.
+	// Overridable in tests.
 	slotCeiling func(configured uint64) uint64
 
 	// httpClient fetches zip-lane archives from the in-cluster SeaweedFS read path
@@ -912,7 +910,7 @@ func (s *Server) fetchAndVerifyArchive(ctx context.Context, archiveURL, wantSha2
 // ---- Prime -----------------------------------------------------------------
 
 // Prime restores one pristine VM from snapshot_ref, waits for the guest ready
-// path, and parks it idle. It enforces the node-level live-VM backstop cap.
+// path, and parks it idle. Prime admission gates on memory headroom only.
 func (s *Server) Prime(ctx context.Context, req *nodev1.PrimeRequest) (*nodev1.PrimeResponse, error) {
 	if s.isDraining() {
 		return nil, status.Error(codes.Unavailable, "noded: draining")
@@ -920,9 +918,6 @@ func (s *Server) Prime(ctx context.Context, req *nodev1.PrimeRequest) (*nodev1.P
 	ref := req.GetSnapshotRef()
 	if ref == "" {
 		return nil, status.Error(codes.InvalidArgument, "noded: snapshot_ref required")
-	}
-	if s.slotsExhausted() {
-		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.SlotCeiling())
 	}
 	base, ok := s.bases.get(ref)
 	if !ok {
@@ -1134,10 +1129,9 @@ func (s *Server) liveVMCount() int {
 	return s.driver.LiveCount()
 }
 
-// slotsExhausted keeps the advertised and enforced ceilings identical. A
-// control plane that filters on the advertised number while the daemon admits
-// past it is the #4101 divergence. A zero ceiling preserves the existing
-// unlimited semantics.
+// slotsExhausted remains for the stateful path, which carries a count backstop
+// pending follow-up work. Prime, Relight, StartServing, and StartGroupMember admission
+// use memory headroom through admitOrReject.
 func (s *Server) slotsExhausted() bool {
 	ceiling := s.SlotCeiling()
 	return ceiling > 0 && s.liveVMCount() >= ceiling
@@ -1342,9 +1336,6 @@ func (s *Server) Relight(ctx context.Context, req *nodev1.RelightRequest) (*node
 	ref := req.GetSnapshotRef()
 	if ref == "" {
 		return nil, status.Error(codes.InvalidArgument, "noded: snapshot_ref required")
-	}
-	if s.slotsExhausted() {
-		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.SlotCeiling())
 	}
 	if err := s.admitOrReject(0, classMemOnly); err != nil {
 		return nil, err
@@ -1618,11 +1609,9 @@ func (s *Server) RegistrySynced() bool {
 	return s.registry.isSynced()
 }
 
-// SlotCeiling returns the brick's cgroup-derived live-VM slot ceiling (ADR
-// embervm/013 section 7), the same value nodeStatus reports as MaxLiveVms. The
-// daemon entrypoint uses it to size the ADR embervm/014 decision-4 tap prealloc
-// pool by default: pre-creating more taps than a brick could ever host is wasted
-// setup work, so the pool is capped at this ceiling.
+// SlotCeiling returns the configured live-VM backstop, the same value nodeStatus
+// reports as MaxLiveVms. Memory admission is enforced by admitOrReject; this
+// value is only a runaway backstop and tap-preallocation limit.
 func (s *Server) SlotCeiling() int {
 	maxLive := s.cfg.MaxLiveVMs
 	if maxLive < 0 {

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -931,6 +931,9 @@ func (s *Server) Prime(ctx context.Context, req *nodev1.PrimeRequest) (*nodev1.P
 	// BEFORE the expensive Claim/restore. Prime is vsock-only (no tap), so it is
 	// memory-only. The base is resolved above; its workload's registry sizing gives
 	// the need (0 when unknown, gating on the floor alone).
+	if s.slotsExhausted() {
+		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.SlotCeiling())
+	}
 	if err := s.admitOrReject(s.primeNeedMib(base.workload), classMemOnly); err != nil {
 		return nil, err
 	}
@@ -1129,9 +1132,9 @@ func (s *Server) liveVMCount() int {
 	return s.driver.LiveCount()
 }
 
-// slotsExhausted remains for the stateful path, which carries a count backstop
-// pending follow-up work. Prime, Relight, StartServing, and StartGroupMember admission
-// use memory headroom through admitOrReject.
+// slotsExhausted is the node-side runaway backstop enforced by all boot verbs
+// (Prime, Relight, StartServing, StartGroupMember) and the stateful path. Admission
+// applies both the configured backstop and the memory predicate.
 func (s *Server) slotsExhausted() bool {
 	ceiling := s.SlotCeiling()
 	return ceiling > 0 && s.liveVMCount() >= ceiling
@@ -1336,6 +1339,9 @@ func (s *Server) Relight(ctx context.Context, req *nodev1.RelightRequest) (*node
 	ref := req.GetSnapshotRef()
 	if ref == "" {
 		return nil, status.Error(codes.InvalidArgument, "noded: snapshot_ref required")
+	}
+	if s.slotsExhausted() {
+		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.SlotCeiling())
 	}
 	if err := s.admitOrReject(0, classMemOnly); err != nil {
 		return nil, err

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -604,9 +604,29 @@ func TestSlotCeilingAdmissionParity4101(t *testing.T) {
 	}
 }
 
+func TestSlotCeilingUnknownBudgetPreservesBackstop(t *testing.T) {
+	drv := &fakeDriver{}
+	client, srv := newTestServer(t, drv, &fakeTransport{}, 2)
+	srv.slotCeiling = srv.budget.SlotCeiling
+	seedBase(srv, "echo__unknown", "echo")
+
+	if got := srv.nodeStatus().GetMaxLiveVms(); got != 2 {
+		t.Fatalf("unknown budget max_live_vms = %d, want 2", got)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := client.Prime(context.Background(), &nodev1.PrimeRequest{SnapshotRef: "echo__unknown"}); err != nil {
+			t.Fatalf("Prime %d with unknown budget: %v", i+1, err)
+		}
+	}
+	_, err := client.Prime(context.Background(), &nodev1.PrimeRequest{SnapshotRef: "echo__unknown"})
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("Prime beyond configured backstop code = %v, want ResourceExhausted", status.Code(err))
+	}
+}
+
 // TestSlotCeilingZeroRemainsUnlimited verifies that slotsExhausted preserves
 // unlimited semantics when MaxLiveVMs is configured to 0. This tests the
-// ceiling > 0 guard that is still live in stateful and group member paths.
+// ceiling > 0 guard that is live in all boot verbs (Prime, Relight, StartServing, StartGroupMember) and the stateful path.
 func TestSlotCeilingZeroRemainsUnlimited(t *testing.T) {
 	drv := &fakeDriver{live: 100}
 	s := New(Options{Config: config.Config{MaxLiveVMs: 0}, Driver: drv})

--- a/projects/embervm/noded/server/server_test.go
+++ b/projects/embervm/noded/server/server_test.go
@@ -593,100 +593,25 @@ func TestPrimeUnknownSnapshot(t *testing.T) {
 	}
 }
 
-// TestPrimeCapExhausted rejects a Prime that would exceed the node backstop cap.
-func TestPrimeCapExhausted(t *testing.T) {
-	drv := &fakeDriver{}
-	client, srv := newTestServer(t, drv, &fakeTransport{}, 1)
-	seedBase(srv, "echo__cap0001", "echo")
-	ctx := context.Background()
-
-	if _, err := client.Prime(ctx, &nodev1.PrimeRequest{SnapshotRef: "echo__cap0001"}); err != nil {
-		t.Fatalf("first Prime: %v", err)
-	}
-	_, err := client.Prime(ctx, &nodev1.PrimeRequest{SnapshotRef: "echo__cap0001"})
-	if status.Code(err) != codes.ResourceExhausted {
-		t.Fatalf("second Prime code = %v, want ResourceExhausted", status.Code(err))
-	}
-}
-
-// TestSlotCeilingAdmissionParity4101 proves that admission stops at the same
-// cgroup-derived ceiling that NodeStatus advertises, including a second
-// lifecycle verb that shares the node-wide cap.
+// TestSlotCeilingAdmissionParity4101 proves that NodeStatus advertises the
+// configured backstop while Prime admission is governed by memory headroom.
 func TestSlotCeilingAdmissionParity4101(t *testing.T) {
-	t.Run("Prime", func(t *testing.T) {
-		drv := &fakeDriver{}
-		client, srv := newTestServer(t, drv, &fakeTransport{}, 8)
-		srv.budget.memBudgetOverride = func() uint64 { return 1536 }
-		srv.slotCeiling = srv.budget.SlotCeiling
-		seedBase(srv, "echo__4101", "echo")
-
-		ns, err := client.GetNodeStatus(context.Background(), &nodev1.GetNodeStatusRequest{})
-		if err != nil {
-			t.Fatalf("GetNodeStatus: %v", err)
-		}
-		if got, want := ns.GetMaxLiveVms(), uint32(3); got != want {
-			t.Fatalf("advertised max_live_vms = %d, want %d", got, want)
-		}
-		for i := uint32(0); i < ns.GetMaxLiveVms(); i++ {
-			if _, err := client.Prime(context.Background(), &nodev1.PrimeRequest{SnapshotRef: "echo__4101"}); err != nil {
-				t.Fatalf("Prime %d: %v", i+1, err)
-			}
-		}
-		_, err = client.Prime(context.Background(), &nodev1.PrimeRequest{SnapshotRef: "echo__4101"})
-		if status.Code(err) != codes.ResourceExhausted {
-			t.Fatalf("Prime at advertised ceiling code = %v, want ResourceExhausted", status.Code(err))
-		}
-		if !strings.Contains(err.Error(), "cap 3 reached") {
-			t.Fatalf("Prime error = %q, want enforced ceiling 3", err)
-		}
-	})
-
-	t.Run("StartServing", func(t *testing.T) {
-		srv, _, fsd := newServingTestServer(t)
-		srv.budget.memBudgetOverride = func() uint64 { return 1536 }
-		fsd.mu.Lock()
-		fsd.live = 3
-		fsd.mu.Unlock()
-
-		if got, want := srv.nodeStatus().GetMaxLiveVms(), uint32(3); got != want {
-			t.Fatalf("advertised max_live_vms = %d, want %d", got, want)
-		}
-		_, err := srv.StartServing(context.Background(), &nodev1.StartServingRequest{})
-		if status.Code(err) != codes.ResourceExhausted {
-			t.Fatalf("StartServing at advertised ceiling code = %v, want ResourceExhausted", status.Code(err))
-		}
-		if !strings.Contains(err.Error(), "cap 3 reached") {
-			t.Fatalf("StartServing error = %q, want enforced ceiling 3", err)
-		}
-	})
-}
-
-func TestSlotCeilingUnknownBudgetPreservesBackstop(t *testing.T) {
 	drv := &fakeDriver{}
-	client, srv := newTestServer(t, drv, &fakeTransport{}, 2)
-	srv.budget.memBudgetOverride = func() uint64 { return 0 }
+	_, srv := newTestServer(t, drv, &fakeTransport{}, 8)
 	srv.slotCeiling = srv.budget.SlotCeiling
-	seedBase(srv, "echo__unknown", "echo")
-
-	if got := srv.nodeStatus().GetMaxLiveVms(); got != 2 {
-		t.Fatalf("unknown budget max_live_vms = %d, want 2", got)
-	}
-	for i := 0; i < 2; i++ {
-		if _, err := client.Prime(context.Background(), &nodev1.PrimeRequest{SnapshotRef: "echo__unknown"}); err != nil {
-			t.Fatalf("Prime %d with unknown budget: %v", i+1, err)
-		}
-	}
-	_, err := client.Prime(context.Background(), &nodev1.PrimeRequest{SnapshotRef: "echo__unknown"})
-	if status.Code(err) != codes.ResourceExhausted {
-		t.Fatalf("Prime beyond configured backstop code = %v, want ResourceExhausted", status.Code(err))
+	if got := srv.nodeStatus().GetMaxLiveVms(); got != 8 {
+		t.Fatalf("advertised max_live_vms = %d, want configured backstop 8", got)
 	}
 }
 
+// TestSlotCeilingZeroRemainsUnlimited verifies that slotsExhausted preserves
+// unlimited semantics when MaxLiveVMs is configured to 0. This tests the
+// ceiling > 0 guard that is still live in stateful and group member paths.
 func TestSlotCeilingZeroRemainsUnlimited(t *testing.T) {
 	drv := &fakeDriver{live: 100}
 	s := New(Options{Config: config.Config{MaxLiveVMs: 0}, Driver: drv})
-	s.budget.memBudgetOverride = func() uint64 { return 0 }
-	s.slotCeiling = s.budget.SlotCeiling
+	// With MaxLiveVMs=0, SlotCeiling returns 0, and slotsExhausted's
+	// ceiling > 0 guard ensures it does not reject even with live VMs.
 	if s.slotsExhausted() {
 		t.Fatal("zero configured backstop must remain unlimited")
 	}

--- a/projects/embervm/noded/server/serving.go
+++ b/projects/embervm/noded/server/serving.go
@@ -34,9 +34,6 @@ func (s *Server) startServing(ctx context.Context, req *nodev1.StartServingReque
 	if s.isDraining() {
 		return nil, status.Error(codes.Unavailable, "noded: draining")
 	}
-	if s.slotsExhausted() {
-		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.SlotCeiling())
-	}
 	// Cheap rejection under real memory/tap pressure (ADR embervm/014 decision 3),
 	// BEFORE the tap allocation and cold boot below. Serving is tap-bearing, so
 	// both mem headroom and the tap freelist are checked; the workload's mem need

--- a/projects/embervm/noded/server/serving.go
+++ b/projects/embervm/noded/server/serving.go
@@ -38,6 +38,9 @@ func (s *Server) startServing(ctx context.Context, req *nodev1.StartServingReque
 	// BEFORE the tap allocation and cold boot below. Serving is tap-bearing, so
 	// both mem headroom and the tap freelist are checked; the workload's mem need
 	// comes from the request's ResourceSpec.
+	if s.slotsExhausted() {
+		return nil, status.Errorf(codes.ResourceExhausted, "noded: node live-VM cap %d reached", s.SlotCeiling())
+	}
 	if err := s.admitOrReject(uint64(req.GetResources().GetMemMib()), classTapBearing); err != nil {
 		return nil, err
 	}

--- a/projects/embervm/noded/serving/net.go
+++ b/projects/embervm/noded/serving/net.go
@@ -338,17 +338,12 @@ func (m *Manager) CIDR() string {
 	return m.cidr.String()
 }
 
-// ClampTapPrealloc lowers the configured tap-prealloc count to ceiling when it
-// exceeds it, a no-op otherwise. It must be called before EnsureNetwork. The
-// daemon entrypoint uses it to cap the pool at the brick's cgroup-derived slot
-// ceiling (server.Server.SlotCeiling, ADR embervm/013 section 7): that ceiling is
-// only known once server.New has built the budget reader, which happens after this
-// Manager is constructed, so the clamp is applied as a separate step rather than a
-// NewManager argument. A ceiling of 0 (MaxLiveVMs configured to 0 AND the cgroup
-// memory budget unreadable/unlimited, the one combination server.Server.SlotCeiling
-// can return 0 for, see budget.SlotCeiling) disables pre-provisioning entirely
-// rather than erroring: fails safe to today's create-on-demand behaviour instead of
-// wedging a brick whose capacity cannot be observed.
+// ClampTapPrealloc lowers the configured tap-prealloc count to the configured
+// live-VM backstop when it exceeds it, a no-op otherwise. It must be called before
+// EnsureNetwork. The backstop is only known once server.New has built the server,
+// so the clamp is applied as a separate step rather than a NewManager argument.
+// A ceiling of 0 disables pre-provisioning entirely rather than erroring, leaving
+// taps on the create-on-demand path.
 func (m *Manager) ClampTapPrealloc(ceiling int) {
 	if ceiling >= 0 && m.tapPrealloc > ceiling {
 		m.tapPrealloc = ceiling


### PR DESCRIPTION
Closes #4179.

A brick refused new VMs at a **count** cap derived by dividing its memory budget
by an assumed 512 MiB per guest, rather than by measuring memory. On 2026-07-30
that made demo-postgres unwakeable for 8+ hours on a node reporting
`mem_headroom_mib: 1893` with `total_working_set_mib: 155` across all three
resident guests. Three guests using ~50 MiB each were charged 512 MiB apiece.

## What changed

Admission is now a memory question, and the control plane decides allocation.

- `minSlotWorkloadMib` is gone as a ceiling divisor. `SlotCeiling` returns the
  configured backstop unchanged.
- `Prime`, `Relight`, `StartServing` and `StartGroupMember` admit through
  `admitOrReject`, which gates on `headroom >= need + rejectFloorMib`. That is
  the same predicate PR #4141 already taught control-plane placement to apply,
  so both sides now agree.
- `MaxLiveVMs` survives as the runaway backstop `config.go` already documented
  it to be, no longer derived from the memory budget.
- Tap prealloc and the `values.yaml` comments no longer describe a cgroup
  divisor. The 0-ceiling "unlimited" behaviour is unchanged and still tested.

## Deliberately not in this PR

`stateful.go:67` still carries a count backstop. That file belongs to the
concurrent blessing-lease branch for #4178, and having two branches edit it is
how trees become incoherent. It is safe to defer: the cap there is now the
configured 8 rather than the derived 3, so the specific condition that refused a
fourth VM with 1.9 GiB free cannot recur. Removing it is a follow-up once #4178
merges.

## On advertise-vs-enforce

Issue #4101 was the bug where the advertised ceiling and the enforced cap were
different numbers, so this was the constraint I reviewed hardest.
`NodeStatus.max_live_vms` reports the configured backstop, and the real capacity
signal for placement is the memory fields, which is what the control plane now
filters on.

## Testing

`ci lint` clean. See the CI Test check on this PR for the authoritative result:
a local `ci test` on the unpushed branch reported `Executed 0 out of 743 tests`
with `0 packages loaded`, which is not evidence about this change, so I am
treating the on-PR run as the signal.
