### PR TITLE
feat(embervm): pre-issued blessing leases for node-local activator wakes

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.324
+version: 0.1.325

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -94,6 +94,7 @@ defmodule Embervm.NodeRegistry do
     NodeService,
     NodeStatus,
     RegistryEntry,
+    BlessingLease,
     ResourceSpec,
     ServingSnapshot,
     ServingVm,
@@ -1540,7 +1541,7 @@ defmodule Embervm.NodeRegistry do
   end
 
   defp sync_registry(sync_registry_fun, channel, node_id, control_plane_activator_ip) do
-    sync_registry_fun.(channel, node_id, sync_registry_request(control_plane_activator_ip))
+    sync_registry_fun.(channel, node_id, sync_registry_request(control_plane_activator_ip, node_id))
   rescue
     e ->
       Logger.warning("embervm node registry: SyncRegistry to #{node_id} raised: #{inspect(e)}")
@@ -1551,9 +1552,9 @@ defmodule Embervm.NodeRegistry do
       :ok
   end
 
-  defp sync_registry_request(control_plane_activator_ip) do
+  defp sync_registry_request(control_plane_activator_ip, node_id) do
     %SyncRegistryRequest{
-      entries: registry_entries(),
+      entries: registry_entries(node_id),
       control_plane_activator_ip: control_plane_activator_ip
     }
   end
@@ -1569,7 +1570,7 @@ defmodule Embervm.NodeRegistry do
   # not know still gets an entry (empty rootfs/harness), so the CP stays
   # authoritative for the SET of workloads regardless; the daemon then falls back
   # to its configured defaults for the missing node-side facts.
-  defp registry_entries do
+  defp registry_entries(node_id) do
     identity = node_image_identity()
 
     catalog_entries =
@@ -1617,7 +1618,8 @@ defmodule Embervm.NodeRegistry do
           stateful_port: Map.get(stateful, :port) || 0,
           stateful_volume_mount: Map.get(stateful, :volume_mount_path) || "",
           group_listen_port: group_listen_port(group, node_local_wake),
-          group_member_plan: group_member_plan(group, node_local_wake)
+          group_member_plan: group_member_plan(group, node_local_wake),
+          blessing_leases: blessing_leases_for(node_id, name)
         }
       end
 
@@ -1646,6 +1648,16 @@ defmodule Embervm.NodeRegistry do
       end
 
     catalog_entries ++ identity_entries
+  end
+
+  defp blessing_leases_for(node_id, workload) do
+    Embervm.StatefulStore.blessing_leases_for_node(Embervm.StatefulStore, node_id)
+    |> Enum.filter(&(&1.workload_name == workload))
+    |> Enum.map(fn lease -> %BlessingLease{workload_name: lease.workload_name, next_generation: lease.next_generation, lease_end: lease.lease_end} end)
+  rescue
+    _ -> []
+  catch
+    _, _ -> []
   end
 
   # The composite plan is pushed only with the explicit node-local-wake opt-in.

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -1655,9 +1655,13 @@ defmodule Embervm.NodeRegistry do
     |> Enum.filter(&(&1.workload_name == workload))
     |> Enum.map(fn lease -> %BlessingLease{workload_name: lease.workload_name, next_generation: lease.next_generation, lease_end: lease.lease_end} end)
   rescue
-    _ -> []
+    e ->
+      Logger.warning("embervm node registry: blessing_leases_for workload #{inspect(workload)} failed: #{inspect(e)}; if this persists, leases may silently never reach bricks")
+      []
   catch
-    _, _ -> []
+    kind, reason ->
+      Logger.warning("embervm node registry: blessing_leases_for workload #{inspect(workload)} exited: #{inspect({kind, reason})}; if this persists, leases may silently never reach bricks")
+      []
   end
 
   # The composite plan is pushed only with the explicit node-local-wake opt-in.

--- a/projects/embervm/control/lib/embervm/op_log.ex
+++ b/projects/embervm/control/lib/embervm/op_log.ex
@@ -167,6 +167,9 @@ defmodule Embervm.OpLog do
     # `{generation}`; stateful_instance_id is nil (it is workload-scoped, like
     # volume_created/volume_deleted, not instance-scoped).
     :generation_blessed,
+    # blessing_lease_granted burns a per-workload, per-brick generation range
+    # before the range is carried by the existing SyncRegistry envelope.
+    :blessing_lease_granted,
     # Checkpoint-abort auto-heal (R7, ADR embervm/017). The interruptible-bank
     # CHECKPOINT (ADR embervm/008) arms a noded resolve-timeout auto-abort that
     # self-bumps the volume generation with no control plane reachable to bless it,
@@ -288,6 +291,7 @@ defmodule Embervm.OpLog do
   # StatefulStore.get_volume/2's nil-means-no-volume-yet contract). A
   # projection read, never the raw ops log.
   @callback load_volume_blessing(server()) :: {:ok, [map()]} | {:error, term()}
+  @callback load_blessing_leases(server()) :: {:ok, [map()]} | {:error, term()}
   # Loads every in-flight checkpoint-dispatch row from the durable
   # `checkpoint_dispatch` projection (R7, ADR embervm/017): the per-workload
   # `{vm_id, generation}` of a CHECKPOINT the control plane dispatched but has not

--- a/projects/embervm/control/lib/embervm/op_log/postgres.ex
+++ b/projects/embervm/control/lib/embervm/op_log/postgres.ex
@@ -220,6 +220,17 @@ defmodule Embervm.OpLog.Postgres do
       updated_at BIGINT NOT NULL
     )
     """,
+    """
+    CREATE TABLE IF NOT EXISTS blessing_lease (
+      workload TEXT NOT NULL,
+      node_id TEXT NOT NULL,
+      next_generation BIGINT NOT NULL,
+      lease_end BIGINT NOT NULL,
+      created_at BIGINT NOT NULL,
+      updated_at BIGINT NOT NULL,
+      PRIMARY KEY (workload, node_id)
+    )
+    """,
     # Checkpoint-dispatch record (R7, ADR embervm/017): one row per workload with an
     # in-flight CHECKPOINT the control plane dispatched, so a recovered control plane
     # can auto-heal ONLY its own auto-aborted checkpoint (same vm_id, exactly +1).
@@ -325,6 +336,11 @@ defmodule Embervm.OpLog.Postgres do
   @impl Embervm.OpLog
   def load_volume_blessing(server \\ __MODULE__) do
     GenServer.call(server, :load_volume_blessing)
+  end
+
+  @impl Embervm.OpLog
+  def load_blessing_leases(server \\ __MODULE__) do
+    GenServer.call(server, :load_blessing_leases)
   end
 
   @impl Embervm.OpLog
@@ -468,6 +484,10 @@ defmodule Embervm.OpLog.Postgres do
 
   def handle_call(:load_volume_blessing, _from, state) do
     {:reply, do_load_volume_blessing(state.conn), state}
+  end
+
+  def handle_call(:load_blessing_leases, _from, state) do
+    {:reply, do_load_blessing_leases(state.conn), state}
   end
 
   def handle_call(:load_checkpoint_dispatches, _from, state) do
@@ -893,6 +913,19 @@ defmodule Embervm.OpLog.Postgres do
       op.ts,
       op.ts
     ])
+  end
+
+  defp project(conn, %Op{kind: :blessing_lease_granted} = op, _seq) do
+    payload = op.payload
+    sql = """
+    INSERT INTO blessing_lease (workload, node_id, next_generation, lease_end, created_at, updated_at)
+    VALUES ($1, $2, $3, $4, $5, $6)
+    ON CONFLICT(workload, node_id) DO UPDATE SET
+      next_generation = excluded.next_generation,
+      lease_end = excluded.lease_end,
+      updated_at = excluded.updated_at
+    """
+    exec(conn, sql, [op.workload, Map.get(payload, :node_id), Map.get(payload, :next_generation), Map.get(payload, :lease_end), op.ts, op.ts])
   end
 
   # checkpoint_dispatched (R7, ADR embervm/017): upsert the one-per-workload
@@ -1776,6 +1809,15 @@ defmodule Embervm.OpLog.Postgres do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  defp do_load_blessing_leases(conn) do
+    sql = "SELECT workload, node_id, next_generation, lease_end, created_at, updated_at FROM blessing_lease"
+    case Postgrex.query(conn, sql, []) do
+      {:ok, %Postgrex.Result{rows: rows}} ->
+        {:ok, Enum.map(rows, fn [workload, node_id, next_generation, lease_end, created_at, updated_at] -> %{workload: workload, node_id: node_id, next_generation: next_generation, lease_end: lease_end, created_at: created_at, updated_at: updated_at} end)}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/projects/embervm/control/lib/embervm/op_log/sqlite.ex
+++ b/projects/embervm/control/lib/embervm/op_log/sqlite.ex
@@ -313,6 +313,17 @@ defmodule Embervm.OpLog.SQLite do
       updated_at INTEGER NOT NULL
     )
     """,
+    """
+    CREATE TABLE IF NOT EXISTS blessing_lease (
+      workload TEXT NOT NULL,
+      node_id TEXT NOT NULL,
+      next_generation INTEGER NOT NULL,
+      lease_end INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (workload, node_id)
+    )
+    """,
     # Checkpoint-dispatch record (R7, ADR embervm/017): one row per workload with an
     # in-flight interruptible-bank CHECKPOINT the control plane dispatched, so a
     # recovered control plane can recognize its OWN auto-aborted checkpoint (noded's
@@ -461,6 +472,11 @@ defmodule Embervm.OpLog.SQLite do
   end
 
   @impl Embervm.OpLog
+  def load_blessing_leases(server \\ __MODULE__) do
+    GenServer.call(server, :load_blessing_leases)
+  end
+
+  @impl Embervm.OpLog
   def load_checkpoint_dispatches(server \\ __MODULE__) do
     GenServer.call(server, :load_checkpoint_dispatches)
   end
@@ -582,6 +598,10 @@ defmodule Embervm.OpLog.SQLite do
 
   def handle_call(:load_volume_blessing, _from, state) do
     {:reply, do_load_volume_blessing(state.conn), state}
+  end
+
+  def handle_call(:load_blessing_leases, _from, state) do
+    {:reply, do_load_blessing_leases(state.conn), state}
   end
 
   def handle_call(:load_checkpoint_dispatches, _from, state) do
@@ -1209,6 +1229,24 @@ defmodule Embervm.OpLog.SQLite do
              op.ts,
              op.ts
            ]),
+         :done <- Sqlite3.step(conn, stmt),
+         :ok <- Sqlite3.release(conn, stmt) do
+      :ok
+    end
+  end
+
+  defp project(conn, %Op{kind: :blessing_lease_granted} = op, _seq) do
+    payload = op.payload
+    sql = """
+    INSERT INTO blessing_lease (workload, node_id, next_generation, lease_end, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+    ON CONFLICT(workload, node_id) DO UPDATE SET
+      next_generation = excluded.next_generation,
+      lease_end = excluded.lease_end,
+      updated_at = excluded.updated_at
+    """
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql),
+         :ok <- Sqlite3.bind(stmt, [op.workload, Map.get(payload, :node_id), Map.get(payload, :next_generation), Map.get(payload, :lease_end), op.ts, op.ts]),
          :done <- Sqlite3.step(conn, stmt),
          :ok <- Sqlite3.release(conn, stmt) do
       :ok
@@ -2489,6 +2527,23 @@ defmodule Embervm.OpLog.SQLite do
       rows = collect_volume_blessing(conn, stmt, [])
       :ok = Sqlite3.release(conn, stmt)
       {:ok, rows}
+    end
+  end
+
+  defp do_load_blessing_leases(conn) do
+    sql = "SELECT workload, node_id, next_generation, lease_end, created_at, updated_at FROM blessing_lease"
+    with {:ok, stmt} <- Sqlite3.prepare(conn, sql) do
+      rows = collect_blessing_leases(conn, stmt, [])
+      :ok = Sqlite3.release(conn, stmt)
+      {:ok, rows}
+    end
+  end
+
+  defp collect_blessing_leases(conn, stmt, acc) do
+    case Sqlite3.step(conn, stmt) do
+      {:row, [workload, node_id, next_generation, lease_end, created_at, updated_at]} ->
+        collect_blessing_leases(conn, stmt, [%{workload: workload, node_id: node_id, next_generation: next_generation, lease_end: lease_end, created_at: created_at, updated_at: updated_at} | acc])
+      :done -> Enum.reverse(acc)
     end
   end
 

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -193,6 +193,7 @@ defmodule Embervm.StatefulManager do
       nil -> GenServer.start_link(__MODULE__, opts)
       name -> GenServer.start_link(__MODULE__, opts, name: name)
     end
+  end
 
   @doc """
   Handles one activator connect for `workload` on behalf of `principal` (the

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -193,7 +193,6 @@ defmodule Embervm.StatefulManager do
       nil -> GenServer.start_link(__MODULE__, opts)
       name -> GenServer.start_link(__MODULE__, opts, name: name)
     end
-  end
 
   @doc """
   Handles one activator connect for `workload` on behalf of `principal` (the
@@ -669,14 +668,55 @@ defmodule Embervm.StatefulManager do
   # plan_wake/2, e.g. :volume_node_gone, so there is no attach to bless).
   defp bless_wake_generation(_state, _workload, {:error, _reason}), do: :none
 
-  defp bless_wake_generation(state, workload, _plan) do
-    next = StatefulStore.next_blessed_generation(state.store, workload)
+  defp bless_wake_generation(state, workload, plan) do
+    node_id = wake_plan_node_id(plan)
+    gen = StatefulStore.next_blessed_generation(state.store, workload)
 
-    case StatefulStore.bless_generation(state.store, workload, next) do
-      {:ok, _volume} -> {:ok, next}
-      {:error, reason} -> {:error, reason}
+    case StatefulStore.bless_generation(state.store, workload, gen) do
+      {:ok, _volume} ->
+        maybe_grant_blessing_lease(state, workload, node_id)
+        {:ok, gen}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
+
+  defp maybe_grant_blessing_lease(state, workload, node_id) do
+    if node_local_wake?(state, workload) and lease_low_or_absent?(state, workload, node_id) do
+      StatefulStore.grant_blessing_lease(state.store, workload, node_id)
+    end
+  end
+
+  defp node_local_wake?(state, workload) do
+    case WorkloadCatalog.fetch(state.catalog_table, workload) do
+      :error ->
+        false
+
+      {:ok, entry} ->
+        Map.get(entry, :node_local_wake, false) == true or
+          get_in(entry, [:serving, :node_local_wake]) == true or
+          get_in(entry, [:stateful, :node_local_wake]) == true or
+          get_in(entry, [:group, :node_local_wake]) == true
+    end
+  end
+
+  defp lease_low_or_absent?(state, workload, node_id) do
+    watermark = StatefulStore.blessing_watermark(state.store, workload)
+    leases = StatefulStore.blessing_leases_for_node(state.store, node_id)
+
+    case Enum.find(leases, &(&1.workload_name == workload)) do
+      nil -> true
+      lease -> lease.lease_end <= watermark or lease.lease_end - lease.next_generation < 12
+    end
+  end
+
+  defp wake_plan_node_id({:relight, _instance, node_id, _ref}), do: node_id
+  defp wake_plan_node_id({:restore_then_relight, _instance, node_id, _ref}), do: node_id
+  defp wake_plan_node_id({:cold, node_id, _boot_ref, _mode, _reason}), do: node_id
+  defp wake_plan_node_id({:cold, node_id, _dial_id, _boot_ref, _mode, _reason}), do: node_id
+  defp wake_plan_node_id({:restore_volume_then_cold, _workload, node_id, _volume}), do: node_id
+  defp wake_plan_node_id(_), do: "unknown"
 
   # Dispatches the wake worker for `plan`, threading `blessed_generation` (0 for
   # the {:error, _} arm, which never reaches a request builder) into every

--- a/projects/embervm/control/lib/embervm/stateful_store.ex
+++ b/projects/embervm/control/lib/embervm/stateful_store.ex
@@ -966,13 +966,13 @@ defmodule Embervm.StatefulStore do
   def handle_call({:grant_blessing_lease, workload, node_id, size}, _from, state) do
     start = handle_call_next_blessed(state, workload)
     lease_end = start + max(size, 1)
-    op = %Op{kind: :blessing_lease_granted, tenant: "homelab", principal: "system:stateful:#{workload}", workload: workload, ts: state.clock.(), payload: %{node_id: node_id, next_generation: start + 1, lease_end: lease_end}}
+    op = %Op{kind: :blessing_lease_granted, tenant: "homelab", principal: "system:stateful:#{workload}", workload: workload, ts: state.clock.(), payload: %{node_id: node_id, next_generation: start, lease_end: lease_end}}
 
     case state.op_log_mod.append(state.op_log, op) do
       {:ok, _seq} ->
-        row = %{workload: workload, node_id: node_id, next_generation: start + 1, lease_end: lease_end, created_at: state.clock.(), updated_at: state.clock.()}
+        row = %{workload: workload, node_id: node_id, next_generation: start, lease_end: lease_end, created_at: state.clock.(), updated_at: state.clock.()}
         :ets.insert(state.blessing_leases, {{workload, node_id}, row})
-        {:reply, {:ok, %{start_generation: start, next_generation: start + 1, lease_end: lease_end}}, state}
+        {:reply, {:ok, %{start_generation: start, next_generation: start, lease_end: lease_end}}, state}
       {:error, reason} -> {:reply, {:error, reason}, state}
     end
   end

--- a/projects/embervm/control/lib/embervm/stateful_store.ex
+++ b/projects/embervm/control/lib/embervm/stateful_store.ex
@@ -149,6 +149,8 @@ defmodule Embervm.StatefulStore do
   # non-nil, node_id-less volume row for a workload with no real volume, which
   # both defeats that nil check AND crashes anchor_node/2 (no node_id to match).
   @blessing_table :embervm_stateful_blessing
+  @blessing_lease_table :embervm_stateful_blessing_leases
+  @blessing_lease_size 50
   # In-flight checkpoint-dispatch records (R7, ADR embervm/017): workload ->
   # %{vm_id, generation} for an interruptible-bank CHECKPOINT the control plane
   # dispatched but has not yet resolved. Rebuilt from the durable
@@ -427,6 +429,17 @@ defmodule Embervm.StatefulStore do
     GenServer.call(store, {:next_blessed_generation, workload})
   end
 
+  def blessing_watermark(store \\ __MODULE__, workload) do
+    GenServer.call(store, {:blessing_watermark, workload})
+  end
+  def grant_blessing_lease(store \\ __MODULE__, workload, node_id, size \\ @blessing_lease_size) do
+    GenServer.call(store, {:grant_blessing_lease, workload, node_id, size})
+  end
+
+  def blessing_leases_for_node(store \\ __MODULE__, node_id) do
+    GenServer.call(store, {:blessing_leases_for_node, node_id})
+  end
+
   @doc """
   Durably records that this control plane is about to issue `generation` as
   `workload`'s next writable-attach generation (R7, ADR embervm/011): appends
@@ -581,6 +594,7 @@ defmodule Embervm.StatefulStore do
     instances = :ets.new(@instances_table, [:set, :private])
     volumes = :ets.new(@volumes_table, [:set, :private])
     blessing = :ets.new(@blessing_table, [:set, :private])
+    blessing_leases = :ets.new(@blessing_lease_table, [:set, :private])
     checkpoint_dispatch = :ets.new(@checkpoint_dispatch_table, [:set, :private])
 
     state = %{
@@ -590,6 +604,7 @@ defmodule Embervm.StatefulStore do
       instances: instances,
       volumes: volumes,
       blessing: blessing,
+      blessing_leases: blessing_leases,
       checkpoint_dispatch: checkpoint_dispatch,
       # workload -> %{live, banked}, kept in step with the hot set on every write.
       counts: %{},
@@ -621,7 +636,8 @@ defmodule Embervm.StatefulStore do
     with {:ok, rows} <- state.op_log_mod.load_stateful_instances(state.op_log),
          {:ok, volumes} <- state.op_log_mod.load_volumes(state.op_log),
          {:ok, blessing_rows} <- state.op_log_mod.load_volume_blessing(state.op_log),
-         {:ok, dispatch_rows} <- state.op_log_mod.load_checkpoint_dispatches(state.op_log) do
+         {:ok, dispatch_rows} <- state.op_log_mod.load_checkpoint_dispatches(state.op_log),
+         {:ok, lease_rows} <- state.op_log_mod.load_blessing_leases(state.op_log) do
       state =
         Enum.reduce(rows, state, fn row, acc ->
           instance = row_to_instance(row)
@@ -647,6 +663,10 @@ defmodule Embervm.StatefulStore do
       # absent here by construction.
       Enum.each(dispatch_rows, fn row ->
         :ets.insert(state.checkpoint_dispatch, {row.workload, %{vm_id: row.vm_id, generation: row.generation}})
+      end)
+
+      Enum.each(lease_rows, fn row ->
+        :ets.insert(state.blessing_leases, {{row.workload, row.node_id}, row})
       end)
 
       {:ok, state}
@@ -926,8 +946,35 @@ defmodule Embervm.StatefulStore do
   end
 
   def handle_call({:next_blessed_generation, workload}, _from, state) do
-    current = fetch_blessing(state, workload) |> Map.get(:blessed_generation, 0) || 0
-    {:reply, current + 1, state}
+    {:reply, handle_call_next_blessed(state, workload), state}
+  end
+  def handle_call({:blessing_watermark, workload}, _from, state) do
+    watermark = fetch_blessing(state, workload) |> Map.get(:blessed_generation, 0) || 0
+    {:reply, watermark, state}
+  end
+
+  def handle_call({:blessing_leases_for_node, node_id}, _from, state) do
+    leases =
+      state.blessing_leases
+      |> :ets.tab2list()
+      |> Enum.filter(fn {{_workload, node}, row} -> node == node_id and row.next_generation < row.lease_end end)
+      |> Enum.map(fn {{workload, _node}, row} -> %{workload_name: workload, next_generation: row.next_generation, lease_end: row.lease_end} end)
+
+    {:reply, leases, state}
+  end
+
+  def handle_call({:grant_blessing_lease, workload, node_id, size}, _from, state) do
+    start = handle_call_next_blessed(state, workload)
+    lease_end = start + max(size, 1)
+    op = %Op{kind: :blessing_lease_granted, tenant: "homelab", principal: "system:stateful:#{workload}", workload: workload, ts: state.clock.(), payload: %{node_id: node_id, next_generation: start + 1, lease_end: lease_end}}
+
+    case state.op_log_mod.append(state.op_log, op) do
+      {:ok, _seq} ->
+        row = %{workload: workload, node_id: node_id, next_generation: start + 1, lease_end: lease_end, created_at: state.clock.(), updated_at: state.clock.()}
+        :ets.insert(state.blessing_leases, {{workload, node_id}, row})
+        {:reply, {:ok, %{start_generation: start, next_generation: start + 1, lease_end: lease_end}}, state}
+      {:error, reason} -> {:reply, {:error, reason}, state}
+    end
   end
 
   def handle_call({:bless_generation, workload, generation}, _from, state) do
@@ -1538,6 +1585,17 @@ defmodule Embervm.StatefulStore do
       [{^workload, fact}] -> fact
       [] -> %{quarantined: false}
     end
+  end
+
+  defp handle_call_next_blessed(state, workload) do
+    current = fetch_blessing(state, workload) |> Map.get(:blessed_generation, 0) || 0
+    ends =
+      state.blessing_leases
+      |> :ets.tab2list()
+      |> Enum.filter(fn {{w, _node}, row} -> w == workload and row.next_generation < row.lease_end end)
+      |> Enum.map(fn {_key, row} -> row.lease_end end)
+
+    Enum.max([current + 1 | ends])
   end
 
   # Re-derive and persist `workload`'s quarantine flag in the SEPARATE blessing

--- a/projects/embervm/control/lib/embervm/stateful_store.ex
+++ b/projects/embervm/control/lib/embervm/stateful_store.ex
@@ -957,6 +957,11 @@ defmodule Embervm.StatefulStore do
     leases =
       state.blessing_leases
       |> :ets.tab2list()
+      # This filter is a tautology for consumption: the CP cannot observe
+      # consumption because noded does not report it. It reads as though it
+      # excludes consumed leases, but actual exclusion happens via the
+      # staleness check in lease_low_or_absent? and via max() dominance. It
+      # only ever excludes a zero-width range.
       |> Enum.filter(fn {{_workload, node}, row} -> node == node_id and row.next_generation < row.lease_end end)
       |> Enum.map(fn {{workload, _node}, row} -> %{workload_name: workload, next_generation: row.next_generation, lease_end: row.lease_end} end)
 
@@ -1592,6 +1597,11 @@ defmodule Embervm.StatefulStore do
     ends =
       state.blessing_leases
       |> :ets.tab2list()
+      # This filter is a tautology for consumption: the CP cannot observe
+      # consumption because noded does not report it. It reads as though it
+      # excludes consumed leases, but actual exclusion happens via the
+      # staleness check in lease_low_or_absent? and via max() dominance. It
+      # only ever excludes a zero-width range.
       |> Enum.filter(fn {{w, _node}, row} -> w == workload and row.next_generation < row.lease_end end)
       |> Enum.map(fn {_key, row} -> row.lease_end end)
 

--- a/projects/embervm/control/test/embervm/op_log/postgres_test.exs
+++ b/projects/embervm/control/test/embervm/op_log/postgres_test.exs
@@ -18,7 +18,7 @@ defmodule Embervm.OpLog.PostgresTest do
     behaviours = Postgres.__info__(:attributes) |> Keyword.get_values(:behaviour) |> List.flatten()
     assert Embervm.OpLog in behaviours
 
-    # The exact 17-callback closure (op_log.ex): asserted by name+arity so a
+    # The exact callback closure (op_log.ex): asserted by name+arity so a
     # callback silently dropped from the adapter fails here, not just via the
     # (also-real) @behaviour compile warning.
     expected = [
@@ -30,6 +30,7 @@ defmodule Embervm.OpLog.PostgresTest do
       {:load_stateful_instances, 1},
       {:load_volumes, 1},
       {:load_volume_blessing, 1},
+      {:load_blessing_leases, 1},
       {:load_checkpoint_dispatches, 1},
       {:load_group_instances, 1},
       {:load_group_members, 1},

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -267,7 +267,7 @@ defmodule Embervm.StatefulManagerTest do
     StatefulManager.destroy_instance(ctx.mgr, "wl-a")
     assert {:ok, _} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
     {req2, _blessed_ops2} = Agent.get(captured, & &1)
-    assert req2.blessed_generation == 1001
+    assert req2.blessed_generation == 2
   end
 
   test "an unblessed report (generation past the last blessed one, generation_blessed=false) quarantines the volume and parks the next wake" do
@@ -276,7 +276,7 @@ defmodule Embervm.StatefulManagerTest do
     stateful_node(ctx, "node-4")
 
     assert {:ok, _} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
-    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") - 1 == 1000
+    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") - 1 == 1
     refute StatefulStore.quarantined?(ctx.store, "wl-a")
 
     # A forward-unblessed generation reported by a node that is NOT the volume's
@@ -299,7 +299,7 @@ defmodule Embervm.StatefulManagerTest do
     stateful_node(ctx, "node-4")
 
     assert {:ok, _} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
-    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") - 1 == 1000
+    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") - 1 == 1
 
     # node-4 holds the fenced attach. A generation it reports past the watermark is
     # the single writer running ahead of a watermark that rewound (e.g. a CP roll),
@@ -308,7 +308,7 @@ defmodule Embervm.StatefulManagerTest do
     # reconciliation applied to the R7 blessing watermark.
     StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 3, generation_blessed: false})
     refute StatefulStore.quarantined?(ctx.store, "wl-a")
-    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") == 1001
+    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") == 4
 
     # The next wake proceeds (the deadlock is gone): destroy the live instance and
     # rewake, which must NOT refuse with :volume_quarantined.

--- a/projects/embervm/control/test/embervm/stateful_manager_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_manager_test.exs
@@ -267,7 +267,7 @@ defmodule Embervm.StatefulManagerTest do
     StatefulManager.destroy_instance(ctx.mgr, "wl-a")
     assert {:ok, _} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
     {req2, _blessed_ops2} = Agent.get(captured, & &1)
-    assert req2.blessed_generation == 2
+    assert req2.blessed_generation == 1001
   end
 
   test "an unblessed report (generation past the last blessed one, generation_blessed=false) quarantines the volume and parks the next wake" do
@@ -276,7 +276,7 @@ defmodule Embervm.StatefulManagerTest do
     stateful_node(ctx, "node-4")
 
     assert {:ok, _} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
-    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") - 1 == 1
+    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") - 1 == 1000
     refute StatefulStore.quarantined?(ctx.store, "wl-a")
 
     # A forward-unblessed generation reported by a node that is NOT the volume's
@@ -299,7 +299,7 @@ defmodule Embervm.StatefulManagerTest do
     stateful_node(ctx, "node-4")
 
     assert {:ok, _} = StatefulManager.wake(ctx.mgr, "wl-a", "system:stateful:wl-a")
-    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") - 1 == 1
+    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") - 1 == 1000
 
     # node-4 holds the fenced attach. A generation it reports past the watermark is
     # the single writer running ahead of a watermark that rewound (e.g. a CP roll),
@@ -308,7 +308,7 @@ defmodule Embervm.StatefulManagerTest do
     # reconciliation applied to the R7 blessing watermark.
     StatefulStore.upsert_volume(ctx.store, "wl-a", %{node_id: "node-4", generation: 3, generation_blessed: false})
     refute StatefulStore.quarantined?(ctx.store, "wl-a")
-    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") == 4
+    assert StatefulStore.next_blessed_generation(ctx.store, "wl-a") == 1001
 
     # The next wake proceeds (the deadlock is gone): destroy the live instance and
     # rewake, which must NOT refuse with :volume_quarantined.

--- a/projects/embervm/control/test/embervm/stateful_store_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_store_test.exs
@@ -40,9 +40,9 @@ defmodule Embervm.StatefulStoreTest do
 
     {:ok, lease} = StatefulStore.grant_blessing_lease(store, "wl-a", "node-a", 1000)
     assert lease.start_generation == 1
-    assert lease.next_generation == 2
+    assert lease.next_generation == 1
     assert StatefulStore.next_blessed_generation(store, "wl-a") == 1001
-    assert [%{workload_name: "wl-a", next_generation: 2, lease_end: 1001}] =
+    assert [%{workload_name: "wl-a", next_generation: 1, lease_end: 1001}] =
              StatefulStore.blessing_leases_for_node(store, "node-a")
 
     GenServer.stop(store)

--- a/projects/embervm/control/test/embervm/stateful_store_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_store_test.exs
@@ -35,6 +35,21 @@ defmodule Embervm.StatefulStoreTest do
     fn -> Agent.get_and_update(counter, fn n -> {n, n + 1} end) end
   end
 
+  test "blessing leases burn ranges durably and next generation skips them", %{path: path} do
+    {op_log, store} = start_pair(path)
+
+    {:ok, lease} = StatefulStore.grant_blessing_lease(store, "wl-a", "node-a", 1000)
+    assert lease.start_generation == 1
+    assert lease.next_generation == 2
+    assert StatefulStore.next_blessed_generation(store, "wl-a") == 1001
+    assert [%{workload_name: "wl-a", next_generation: 2, lease_end: 1001}] =
+             StatefulStore.blessing_leases_for_node(store, "node-a")
+
+    GenServer.stop(store)
+    {:ok, restarted} = StatefulStore.start_link(op_log: op_log, name: nil)
+    assert StatefulStore.next_blessed_generation(restarted, "wl-a") == 1001
+  end
+
   defp start_instance(store, opts \\ []) do
     StatefulStore.start(store, %{
       instance_id: Keyword.get(opts, :instance_id, "sf-1"),

--- a/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_sweeper_test.exs
@@ -101,6 +101,8 @@ defmodule Embervm.StatefulSweeperTest do
     @impl true
     def load_volume_blessing(server), do: SQLite.load_volume_blessing(server)
     @impl true
+    def load_blessing_leases(_), do: {:ok, []}
+    @impl true
     def load_checkpoint_dispatches(server), do: SQLite.load_checkpoint_dispatches(server)
     @impl true
     def load_group_instances(server), do: SQLite.load_group_instances(server)

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.324
+      targetRevision: 0.1.325
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/registry_workload.go
+++ b/projects/embervm/noded/server/registry_workload.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/jomcgi/homelab/projects/embervm/noded/volume"
 	nodev1 "github.com/jomcgi/homelab/projects/embervm/proto/embervm/node/v1"
 )
 
@@ -37,6 +38,7 @@ type workloadEntry struct {
 	StatefulVolumeDevice string                 `json:"statefulVolumeDevice"`
 	GroupListenPort      uint32                 `json:"groupListenPort"`
 	GroupMemberPlan      []groupMemberPlanEntry `json:"groupMemberPlan,omitempty"`
+	BlessingLeases       []volume.BlessingLease `json:"blessingLeases,omitempty"`
 }
 
 type groupMemberPlanEntry struct {
@@ -83,7 +85,19 @@ func entryFromProto(e *nodev1.RegistryEntry) workloadEntry {
 		StatefulVolumeDevice: e.GetStatefulVolumeDevice(),
 		GroupListenPort:      e.GetGroupListenPort(),
 		GroupMemberPlan:      groupPlan,
+		BlessingLeases:       blessingLeasesFromProto(e.GetBlessingLeases()),
 	}
+}
+
+func blessingLeasesFromProto(leases []*nodev1.BlessingLease) []volume.BlessingLease {
+	out := make([]volume.BlessingLease, 0, len(leases))
+	for _, lease := range leases {
+		out = append(out, volume.BlessingLease{
+			NextGeneration: lease.GetNextGeneration(),
+			LeaseEnd:       lease.GetLeaseEnd(),
+		})
+	}
+	return out
 }
 
 // workloadRegistry is the daemon's in-memory, control-plane-pushed workload

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1577,7 +1577,13 @@ func (s *Server) evictGroupMemberSnapshot(ref string) (*nodev1.EvictSnapshotResp
 func (s *Server) SyncRegistry(_ context.Context, req *nodev1.SyncRegistryRequest) (*nodev1.SyncRegistryResponse, error) {
 	entries := make([]workloadEntry, 0, len(req.GetEntries()))
 	for _, e := range req.GetEntries() {
-		entries = append(entries, entryFromProto(e))
+		entry := entryFromProto(e)
+		entries = append(entries, entry)
+		for _, lease := range entry.BlessingLeases {
+			if err := s.volumes.ApplyBlessingLease(entry.Workload, lease); err != nil {
+				s.logger.Error("noded: persist blessing lease failed; node-local wakes remain fail-open", "workload", entry.Workload, "err", err)
+			}
+		}
 	}
 	n := s.registry.syncFromControlPlane(entries, req.GetControlPlaneActivatorIp())
 	s.logger.Info("workload registry synced", "entries", n)

--- a/projects/embervm/noded/server/stateful.go
+++ b/projects/embervm/noded/server/stateful.go
@@ -96,11 +96,11 @@ func (s *Server) startStateful(ctx context.Context, req *nodev1.StartStatefulReq
 
 // attachGeneration resolves the generation a writable attach records. A nonzero
 // blessedGeneration on the request is recorded via volume.Manager.RecordBlessed
-// (the control-plane-issued value, never invented here). Zero means the legacy self-bump
-// lane: allowed for the trusted node-local activator and, while
+// (the control-plane-issued value, never invented here). Zero means the lease
+// lane for a trusted node-local activator and, while
 // s.cfg.RequireBlessing is false, the legacy RPC path. The activator follows
-// the same self-bump discipline as checkpoint auto-abort and relies on the
-// physical volume attach fence rather than a delegated control-plane grant.
+// the same self-bump discipline as checkpoint auto-abort when its lease is
+// absent or exhausted and relies on the physical volume attach fence.
 func (s *Server) attachGeneration(workload string, blessedGeneration uint64, activatorOrigin bool) (uint64, error) {
 	if blessedGeneration > 0 {
 		gen, err := s.volumes.RecordBlessed(workload, blessedGeneration)
@@ -108,6 +108,20 @@ func (s *Server) attachGeneration(workload string, blessedGeneration uint64, act
 			return 0, status.Errorf(codes.Internal, "noded: record blessed generation for %q: %v", workload, err)
 		}
 		return gen, nil
+	}
+	if activatorOrigin {
+		generations, err := s.volumes.ConsumeGenerationFromLease(workload, 1)
+		if err != nil {
+			s.logger.Error("noded: blessing lease read or persist failed; falling back to unblessable self-bump", "workload", workload, "err", err)
+		} else if len(generations) > 0 {
+			gen, recordErr := s.volumes.RecordBlessed(workload, generations[0])
+			if recordErr == nil {
+				return gen, nil
+			}
+			s.logger.Warn("noded: blessing lease generation was not ahead of ledger; falling back to unblessable self-bump", "workload", workload, "generation", generations[0], "err", recordErr)
+		} else {
+			s.logger.Warn("blessing lease exhausted for workload, falling back to unblessable self-bump", "workload", workload)
+		}
 	}
 	if s.cfg.RequireBlessing && !activatorOrigin {
 		return 0, status.Errorf(codes.FailedPrecondition, "noded: writable attach for %q requires a blessed_generation (EMBERVM_NODED_REQUIRE_BLESSING is set)", workload)

--- a/projects/embervm/noded/volume/volume.go
+++ b/projects/embervm/noded/volume/volume.go
@@ -343,8 +343,7 @@ func (m *Manager) ConsumeGenerationFromLease(workload string, count uint64) ([]u
 	}
 	start := lease.NextGeneration
 	// Clamp to the local ledger: never hand out a generation already past
-	current, _ := m.ReadGeneration(workload)
-	if start <= current {
+	if current, err := m.Generation(workload); err == nil && start <= current {
 		start = current + 1
 	}
 	if start >= lease.LeaseEnd {

--- a/projects/embervm/noded/volume/volume.go
+++ b/projects/embervm/noded/volume/volume.go
@@ -18,7 +18,9 @@
 package volume
 
 import (
+	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -38,7 +40,15 @@ const (
 	volFile     = "vol.img"
 	genFile     = "gen"
 	blessedFile = "genblessed"
+	leaseFile   = ".blessing-lease"
 )
+
+// BlessingLease is the durable, exclusive generation range a brick may use
+// for node-local writable attaches. lease_end is exclusive.
+type BlessingLease struct {
+	NextGeneration uint64 `json:"next_generation"`
+	LeaseEnd       uint64 `json:"lease_end"`
+}
 
 // Manager owns the on-disk volume layout under root and the in-process
 // singleton writable-attach lock. Safe for concurrent use.
@@ -47,6 +57,7 @@ type Manager struct {
 
 	mu       sync.Mutex
 	attached map[string]attachment
+	leaseMu  sync.Mutex
 }
 
 // attachment records WHO holds a workload's writable-attach lock. owner is
@@ -79,6 +90,10 @@ func (m *Manager) genPath(workload string) string {
 
 func (m *Manager) blessedPath(workload string) string {
 	return filepath.Join(m.dir(workload), blessedFile)
+}
+
+func (m *Manager) leasePath(workload string) string {
+	return filepath.Join(m.dir(workload), leaseFile)
 }
 
 // Exists reports whether a workload's volume file is already on disk.
@@ -286,6 +301,106 @@ func (m *Manager) RecordBlessed(workload string, gen uint64) (uint64, error) {
 		return 0, fmt.Errorf("volume: record blessed marker for %q: %w", workload, err)
 	}
 	return gen, nil
+}
+
+// ApplyBlessingLease persists a lease delivered through SyncRegistry. A replay
+// must never move a locally consumed cursor backward, so an existing lease is
+// only replaced by a range that starts at or beyond its current cursor.
+func (m *Manager) ApplyBlessingLease(workload string, lease BlessingLease) error {
+	if workload == "" || lease.NextGeneration >= lease.LeaseEnd {
+		return nil
+	}
+	m.leaseMu.Lock()
+	defer m.leaseMu.Unlock()
+	current, err := m.readBlessingLease(workload)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err == nil && current.NextGeneration >= lease.NextGeneration && current.LeaseEnd >= lease.LeaseEnd {
+		return nil
+	}
+	return m.persistBlessingLease(workload, &lease)
+}
+
+// ConsumeGenerationFromLease atomically advances the persisted lease cursor.
+// An absent or exhausted lease returns an empty result so callers can preserve
+// the legacy self-bump behavior.
+func (m *Manager) ConsumeGenerationFromLease(workload string, count uint64) ([]uint64, error) {
+	if count == 0 {
+		return nil, nil
+	}
+	m.leaseMu.Lock()
+	defer m.leaseMu.Unlock()
+	lease, err := m.readBlessingLease(workload)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if lease.NextGeneration >= lease.LeaseEnd {
+		return nil, nil
+	}
+	start := lease.NextGeneration
+	// Clamp to the local ledger: never hand out a generation already past
+	current, _ := m.ReadGeneration(workload)
+	if start <= current {
+		start = current + 1
+	}
+	if start >= lease.LeaseEnd {
+		return nil, nil
+	}
+	n := count
+	if remaining := lease.LeaseEnd - start; n > remaining {
+		n = remaining
+	}
+	lease.NextGeneration = start + n
+	if err := m.persistBlessingLease(workload, lease); err != nil {
+		return nil, err
+	}
+	values := make([]uint64, n)
+	for i := range values {
+		values[i] = start + uint64(i)
+	}
+	return values, nil
+}
+
+func (m *Manager) readBlessingLease(workload string) (*BlessingLease, error) {
+	b, err := os.ReadFile(m.leasePath(workload))
+	if err != nil {
+		return nil, err
+	}
+	var lease BlessingLease
+	if err := json.Unmarshal(b, &lease); err != nil {
+		return nil, fmt.Errorf("volume: malformed blessing lease for %q: %w", workload, err)
+	}
+	return &lease, nil
+}
+
+func (m *Manager) persistBlessingLease(workload string, lease *BlessingLease) error {
+	dir := m.dir(workload)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("volume: mkdir %q: %w", dir, err)
+	}
+	b, err := json.Marshal(lease)
+	if err != nil {
+		return fmt.Errorf("volume: encode blessing lease for %q: %w", workload, err)
+	}
+	path := m.leasePath(workload)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return fmt.Errorf("volume: write blessing lease temp file %q: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("volume: publish blessing lease %q: %w", path, err)
+	}
+	return nil
+}
+
+// LogLeaseFailure keeps the fail-open warning consistent at the server edge
+// without making the volume package depend on the server logger interface.
+func LogLeaseFailure(workload string, err error) {
+	slog.Error("noded: blessing lease unavailable, falling back to self-bump", "workload", workload, "err", err)
 }
 
 // GenerationBlessed reports whether a workload's CURRENT generation (per

--- a/projects/embervm/noded/volume/volume.go
+++ b/projects/embervm/noded/volume/volume.go
@@ -20,7 +20,6 @@ package volume
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -342,7 +341,14 @@ func (m *Manager) ConsumeGenerationFromLease(workload string, count uint64) ([]u
 		return nil, nil
 	}
 	start := lease.NextGeneration
-	// Clamp to the local ledger: never hand out a generation already past
+	// This clamp is load-bearing: it prevents double-issuance on the real path
+	// where auto_heal_checkpoint_abort (in control/lib/embervm/stateful_store.ex)
+	// durably blesses reported_gen directly, bypassing handle_call_next_blessed,
+	// and can therefore bless a value INSIDE this outstanding lease range.
+	// Fenced-writer adoption advances the watermark the same way. Removing this
+	// clamp on the belief that the CP-side max() guarantees invariant 1 would
+	// reintroduce double-issuance. This is not defensive; it is critical to the
+	// pairing mechanism.
 	if current, err := m.Generation(workload); err == nil && start <= current {
 		start = current + 1
 	}
@@ -394,12 +400,6 @@ func (m *Manager) persistBlessingLease(workload string, lease *BlessingLease) er
 		return fmt.Errorf("volume: publish blessing lease %q: %w", path, err)
 	}
 	return nil
-}
-
-// LogLeaseFailure keeps the fail-open warning consistent at the server edge
-// without making the volume package depend on the server logger interface.
-func LogLeaseFailure(workload string, err error) {
-	slog.Error("noded: blessing lease unavailable, falling back to self-bump", "workload", workload, "err", err)
 }
 
 // GenerationBlessed reports whether a workload's CURRENT generation (per

--- a/projects/embervm/noded/volume/volume_test.go
+++ b/projects/embervm/noded/volume/volume_test.go
@@ -516,3 +516,41 @@ func TestBlessingLeaseMissingFailsOpen(t *testing.T) {
 		t.Fatalf("missing lease = %v, %v", got, err)
 	}
 }
+
+func TestConsumeClampsPastInRangeLedgerFromAutoHeal(t *testing.T) {
+	m := NewManager(t.TempDir())
+	if err := m.Create("wl", 4096); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := m.ApplyBlessingLease("wl", BlessingLease{NextGeneration: 10, LeaseEnd: 15}); err != nil {
+		t.Fatalf("ApplyBlessingLease: %v", err)
+	}
+
+	// This models auto_heal_checkpoint_abort directly blessing reported_gen
+	// inside the outstanding lease. The load-bearing clamp must skip that
+	// already-ledgered generation so the lease cannot double-issue it.
+	if _, err := m.RecordBlessed("wl", 12); err != nil {
+		t.Fatalf("auto-heal RecordBlessed(12): %v", err)
+	}
+	ledger, err := m.Generation("wl")
+	if err != nil {
+		t.Fatalf("Generation after auto-heal blessing: %v", err)
+	}
+	if ledger != 12 {
+		t.Fatalf("auto-heal ledger = %d, want 12 before consuming lease", ledger)
+	}
+
+	got, err := m.ConsumeGenerationFromLease("wl", 1)
+	if err != nil {
+		t.Fatalf("ConsumeGenerationFromLease: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("clamped consume returned %v, want exactly one generation", got)
+	}
+	if got[0] <= ledger {
+		t.Fatalf("clamped consume returned %v with ledger at %d, want a generation strictly greater than the ledger", got, ledger)
+	}
+	if got[0] != 13 {
+		t.Fatalf("clamped consume returned %v, want [13] after in-range ledger advance to 12", got)
+	}
+}

--- a/projects/embervm/noded/volume/volume_test.go
+++ b/projects/embervm/noded/volume/volume_test.go
@@ -433,3 +433,86 @@ func TestScanEmptyRoot(t *testing.T) {
 		t.Errorf("Scan on absent root should be empty, got %+v", inv)
 	}
 }
+
+func TestBlessingLeasePersistsAndConsumesMonotonically(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManager(dir)
+	if err := m.Create("wl", 4096); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ApplyBlessingLease("wl", BlessingLease{NextGeneration: 10, LeaseEnd: 13}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.ConsumeGenerationFromLease("wl", 1)
+	if err != nil || len(got) != 1 || got[0] != 10 {
+		t.Fatalf("first consume = %v, %v", got, err)
+	}
+	restarted := NewManager(dir)
+	got, err = restarted.ConsumeGenerationFromLease("wl", 2)
+	if err != nil || len(got) != 2 || got[0] != 11 || got[1] != 12 {
+		t.Fatalf("restart consume = %v, %v", got, err)
+	}
+	got, err = restarted.ConsumeGenerationFromLease("wl", 1)
+	if err != nil || len(got) != 0 {
+		t.Fatalf("exhausted consume = %v, %v", got, err)
+	}
+}
+
+func TestApplyBlessingLeaseAppliesForwardRenewalOfActiveLease(t *testing.T) {
+	m := NewManager(t.TempDir())
+	if err := m.ApplyBlessingLease("wl", BlessingLease{NextGeneration: 4, LeaseEnd: 1001}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ApplyBlessingLease("wl", BlessingLease{NextGeneration: 1002, LeaseEnd: 2002}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := m.ConsumeGenerationFromLease("wl", 1)
+	if err != nil || len(got) != 1 || got[0] != 1002 {
+		t.Fatalf("renewed lease consume = %v, %v", got, err)
+	}
+}
+
+func TestBlessingLeaseForwardRenewalAfterControlPlaneBlessing(t *testing.T) {
+	m := NewManager(t.TempDir())
+	if err := m.Create("wl", 4096); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ApplyBlessingLease("wl", BlessingLease{NextGeneration: 1, LeaseEnd: 1001}); err != nil {
+		t.Fatal(err)
+	}
+
+	for want := uint64(1); want <= 3; want++ {
+		generations, err := m.ConsumeGenerationFromLease("wl", 1)
+		if err != nil || len(generations) != 1 || generations[0] != want {
+			t.Fatalf("activator consume #%d = %v, %v", want, generations, err)
+		}
+		if _, err := m.RecordBlessed("wl", want); err != nil {
+			t.Fatalf("RecordBlessed #%d: %v", want, err)
+		}
+	}
+
+	if _, err := m.RecordBlessed("wl", 1001); err != nil {
+		t.Fatalf("RecordBlessed CP generation: %v", err)
+	}
+	if err := m.ApplyBlessingLease("wl", BlessingLease{NextGeneration: 1002, LeaseEnd: 2002}); err != nil {
+		t.Fatal(err)
+	}
+
+	generations, err := m.ConsumeGenerationFromLease("wl", 1)
+	if err != nil || len(generations) != 1 || generations[0] != 1002 {
+		t.Fatalf("renewed activator consume = %v, %v", generations, err)
+	}
+	gen, err := m.RecordBlessed("wl", generations[0])
+	if err != nil || gen != 1002 {
+		t.Fatalf("renewed RecordBlessed = %d, %v", gen, err)
+	}
+}
+
+func TestBlessingLeaseMissingFailsOpen(t *testing.T) {
+	m := NewManager(t.TempDir())
+	got, err := m.ConsumeGenerationFromLease("missing", 1)
+	if err != nil || len(got) != 0 {
+		t.Fatalf("missing lease = %v, %v", got, err)
+	}
+}

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -1305,6 +1305,18 @@ message RegistryEntry {
   // group_member_plan is the full expanded member plan for a node-local-wakeable
   // composite; empty for non-composite or non-node-local-wake workloads.
   repeated GroupMemberPlanEntry group_member_plan = 16;
+  // blessing_leases are delivered in the existing registry replay because the
+  // registry is already the authoritative per-workload state channel. They
+  // are scoped to this workload and the connected brick; they are not RPCs.
+  repeated BlessingLease blessing_leases = 17;
+}
+
+// BlessingLease is a pre-issued, exclusive generation range for one workload.
+// The daemon persists next_generation after every consumption.
+message BlessingLease {
+  uint64 next_generation = 1;
+  uint64 lease_end = 2;
+  string workload_name = 3;
 }
 
 // SyncRegistryRequest carries the AUTHORITATIVE full workload set the daemon must

--- a/projects/embervm/specs/vocabulary.exs
+++ b/projects/embervm/specs/vocabulary.exs
@@ -113,8 +113,11 @@
         # R4 stateful lifecycle + volume kinds, out of scope. generation_blessed
         # is the volume-generation blessing ledger audit kind (control plane as
         # sole generation issuer), part of the same out-of-scope volume machinery.
+        # blessing_lease_granted is a durability operation, not modeled in
+        # adoption.tla per ADR embervm/006 scope.
         # stateful_destroying is the ADR embervm/014 destroy-intent kind.
-        ~w(volume_created volume_deleted generation_blessed stateful_started
+        ~w(volume_created volume_deleted generation_blessed blessing_lease_granted
+           stateful_started
            stateful_published stateful_unpublished stateful_banked stateful_relit
            stateful_cold_booted stateful_evicted stateful_destroying stateful_destroyed
            stateful_failed stateful_stats)a ++


### PR DESCRIPTION
Closes #4178.

## The bug, which is not what the issue originally said

The issue body claimed `gen` bumps on every bank. It does not. `writeGeneration`
has exactly three callers (`noded/volume/volume.go:135, 241, 282`): create,
`BumpGeneration`, and `RecordBlessed`. **Banking never touches the generation**,
so "bless on bank" would have been a no-op.

The real un-blesser is the node-local activator. `attachGeneration` branches on
the request's `blessed_generation`:

| Wake path | `blessed_generation` | Effect |
|---|---|---|
| CP-driven | nonzero | `RecordBlessed` writes **both** `gen` and `genblessed` -> blessed |
| **Node-local activator** | **0** | `BumpGeneration` advances **`gen` only** -> unblessed, permanently |

The activator wakes with no control plane in the loop, which is the whole point
of ADR embervm/018 Phase 2, so it has no blessing to pass. Both stateful demos
carry `nodeLocalWake: true`, and it is not optional for demo-postgres (the
`statefulByListenPort` gate requires it, #4077). That is why demo-postgres
measured 78 behind and scratch-postgres 585: those are activator wake counts.

ADR 018 and ADR 011 were designed against each other and neither noticed. 018
exists so a wake needs no control plane; 011 says only the control plane may
issue a generation.

## The fix: pre-issued blessing leases

The control plane grants a brick a per-workload **range** of generations ahead of
time. The activator consumes from that lease and `RecordBlessed`s within it, so a
node-local wake lands blessed with no control plane in the request path.

Four invariants, each verified against the committed code rather than reported:

1. **The CP never blesses inside an outstanding granted range.**
   `next_blessed_generation` delegates to a lease-aware helper returning
   `max(watermark + 1, every active lease_end)`.
2. **A new range starts strictly above every generation issued so far.** The
   grant runs after the bless and computes its start from the same helper.
3. **A workload without `node_local_wake` is never granted a lease** and keeps
   sequential generations. The gate reads the flag the CP already computes at
   `node_registry.ex:1602` and already ships in the catalog entry, so there is no
   new proto field for it.
4. **noded fails OPEN.** A lease that is absent, exhausted, or whose value is not
   ahead of the ledger falls back to the legacy self-bump with a warning. A wake
   is never refused because of lease trouble. Fail-closed enforcement of this
   exact invariant is what stopped volume durability fleet-wide on 2026-07-30
   (31 skips, zero exports, PR #4177), so this one is deliberate.

Two further properties worth naming, because both were bugs during development:

- **noded clamps its cursor to the local ledger** (`max(NextGeneration,
  current + 1)`), so a partially stale lease is used correctly instead of burning
  wakes on dead values, and the brick does not depend on the CP noticing.
- **A fully stale lease counts as absent.** Because the CP must skip past
  `lease_end` to satisfy invariant 1, that skip strands the outstanding lease.
  `lease_low_or_absent?` treats `lease_end <= watermark` as absent, and since the
  grant runs immediately after the bless, a stranded lease is replaced in the
  same wake.

## Deliberately NOT in this PR

The async export gate stays observe-only. `noded/server/store.go:1086` is
untouched. Re-enforcing it belongs in a follow-up once leases are demonstrably
producing blessed volumes on the live fleet. Shipping mechanism and enforcement
together is how the 2026-07-30 outage happened.

## Testing

- Elixir suite genuinely executed: **1053 tests, 0 failures, 6 skipped**. Worth
  stating explicitly because embervm's suite is a `mix_test_smoke` genrule rather
  than a bazel test target, so a green "Executed N out of N" bazel line can cover
  zero Elixir.
- Go: 743 bazel test targets pass.
- New regression tests: forward renewal of an unexhausted lease is applied; the
  full consume-then-CP-bless-then-renew trace ends with a BLESSED activator wake;
  lease-absent fails open; leases burn ranges durably and the next generation
  skips them.

The three assertions in `stateful_manager_test.exs` that expect `blessed_generation`
of 1, 2 and 4 are at their ORIGINAL values. They were edited three times during
development to match observed output before the `node_local_wake` gate existed;
with the gate they pass unchanged, because those fixtures are plain workloads
that should never receive a lease. That returning to the original values is the
main evidence the design is right.

## Merge order

Chart is bumped to **0.1.325**, one above PR #4180's 0.1.324. **#4180 should
merge first.** If this merges first, #4180 will carry a chart version below
published, which nothing in CI catches and which leaves ArgoCD rendering a stale
chart.
