### PR TITLE
fix(embervm): ensure a blessing lease during registry resync so the grant actually fires

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.325
+version: 0.1.326

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -1619,7 +1619,7 @@ defmodule Embervm.NodeRegistry do
           stateful_volume_mount: Map.get(stateful, :volume_mount_path) || "",
           group_listen_port: group_listen_port(group, node_local_wake),
           group_member_plan: group_member_plan(group, node_local_wake),
-          blessing_leases: blessing_leases_for(node_id, name)
+          blessing_leases: blessing_leases_for(node_id, name, stateful)
         }
       end
 
@@ -1650,10 +1650,27 @@ defmodule Embervm.NodeRegistry do
     catalog_entries ++ identity_entries
   end
 
-  defp blessing_leases_for(node_id, workload) do
-    Embervm.StatefulStore.blessing_leases_for_node(Embervm.StatefulStore, node_id)
-    |> Enum.filter(&(&1.workload_name == workload))
-    |> Enum.map(fn lease -> %BlessingLease{workload_name: lease.workload_name, next_generation: lease.next_generation, lease_end: lease.lease_end} end)
+  defp blessing_leases_for(node_id, workload, stateful) do
+    node_local_wake = Map.get(stateful, :node_local_wake, false)
+
+    if node_local_wake do
+      case Embervm.StatefulStore.ensure_blessing_lease(Embervm.StatefulStore, workload, node_id) do
+        {:ok, leases} ->
+          Enum.map(leases, fn lease ->
+            %BlessingLease{
+              workload_name: lease.workload_name,
+              next_generation: lease.next_generation,
+              lease_end: lease.lease_end
+            }
+          end)
+
+        {:error, _reason} ->
+          Logger.warning("embervm node registry: ensure_blessing_lease for workload #{inspect(workload)} on node #{inspect(node_id)} failed; proceeding with empty leases")
+          []
+      end
+    else
+      []
+    end
   rescue
     e ->
       Logger.warning("embervm node registry: blessing_leases_for workload #{inspect(workload)} failed: #{inspect(e)}; if this persists, leases may silently never reach bricks")

--- a/projects/embervm/control/lib/embervm/stateful_manager.ex
+++ b/projects/embervm/control/lib/embervm/stateful_manager.ex
@@ -684,8 +684,8 @@ defmodule Embervm.StatefulManager do
   end
 
   defp maybe_grant_blessing_lease(state, workload, node_id) do
-    if node_local_wake?(state, workload) and lease_low_or_absent?(state, workload, node_id) do
-      StatefulStore.grant_blessing_lease(state.store, workload, node_id)
+    if node_local_wake?(state, workload) do
+      StatefulStore.ensure_blessing_lease(state.store, workload, node_id)
     end
   end
 
@@ -699,16 +699,6 @@ defmodule Embervm.StatefulManager do
           get_in(entry, [:serving, :node_local_wake]) == true or
           get_in(entry, [:stateful, :node_local_wake]) == true or
           get_in(entry, [:group, :node_local_wake]) == true
-    end
-  end
-
-  defp lease_low_or_absent?(state, workload, node_id) do
-    watermark = StatefulStore.blessing_watermark(state.store, workload)
-    leases = StatefulStore.blessing_leases_for_node(state.store, node_id)
-
-    case Enum.find(leases, &(&1.workload_name == workload)) do
-      nil -> true
-      lease -> lease.lease_end <= watermark or lease.lease_end - lease.next_generation < 12
     end
   end
 

--- a/projects/embervm/control/lib/embervm/stateful_store.ex
+++ b/projects/embervm/control/lib/embervm/stateful_store.ex
@@ -436,6 +436,12 @@ defmodule Embervm.StatefulStore do
     GenServer.call(store, {:grant_blessing_lease, workload, node_id, size})
   end
 
+  @spec ensure_blessing_lease(GenServer.server(), String.t(), String.t()) ::
+          {:ok, [map()]} | {:error, term()}
+  def ensure_blessing_lease(store \\ __MODULE__, workload, node_id) do
+    GenServer.call(store, {:ensure_blessing_lease, workload, node_id})
+  end
+
   def blessing_leases_for_node(store \\ __MODULE__, node_id) do
     GenServer.call(store, {:blessing_leases_for_node, node_id})
   end
@@ -969,16 +975,23 @@ defmodule Embervm.StatefulStore do
   end
 
   def handle_call({:grant_blessing_lease, workload, node_id, size}, _from, state) do
-    start = handle_call_next_blessed(state, workload)
-    lease_end = start + max(size, 1)
-    op = %Op{kind: :blessing_lease_granted, tenant: "homelab", principal: "system:stateful:#{workload}", workload: workload, ts: state.clock.(), payload: %{node_id: node_id, next_generation: start, lease_end: lease_end}}
-
-    case state.op_log_mod.append(state.op_log, op) do
-      {:ok, _seq} ->
-        row = %{workload: workload, node_id: node_id, next_generation: start, lease_end: lease_end, created_at: state.clock.(), updated_at: state.clock.()}
-        :ets.insert(state.blessing_leases, {{workload, node_id}, row})
-        {:reply, {:ok, %{start_generation: start, next_generation: start, lease_end: lease_end}}, state}
+    case append_blessing_lease(state, workload, node_id, size) do
+      {:ok, lease, state} -> {:reply, {:ok, lease}, state}
       {:error, reason} -> {:reply, {:error, reason}, state}
+    end
+  end
+
+  def handle_call({:ensure_blessing_lease, workload, node_id}, _from, state) do
+    if lease_low_or_absent?(state, workload, node_id) do
+      case append_blessing_lease(state, workload, node_id, @blessing_lease_size) do
+        {:ok, _lease, state} ->
+          {:reply, {:ok, blessing_leases_for_workload_node(state, workload, node_id)}, state}
+
+        {:error, reason} ->
+          {:reply, {:error, reason}, state}
+      end
+    else
+      {:reply, {:ok, blessing_leases_for_workload_node(state, workload, node_id)}, state}
     end
   end
 
@@ -1606,6 +1619,74 @@ defmodule Embervm.StatefulStore do
       |> Enum.map(fn {_key, row} -> row.lease_end end)
 
     Enum.max([current + 1 | ends])
+  end
+
+  defp append_blessing_lease(state, workload, node_id, size) do
+    start = handle_call_next_blessed(state, workload)
+    lease_end = start + max(size, 1)
+
+    op = %Op{
+      kind: :blessing_lease_granted,
+      tenant: "homelab",
+      principal: "system:stateful:#{workload}",
+      workload: workload,
+      ts: state.clock.(),
+      payload: %{node_id: node_id, next_generation: start, lease_end: lease_end}
+    }
+
+    case state.op_log_mod.append(state.op_log, op) do
+      {:ok, _seq} ->
+        row = %{
+          workload: workload,
+          node_id: node_id,
+          next_generation: start,
+          lease_end: lease_end,
+          created_at: state.clock.(),
+          updated_at: state.clock.()
+        }
+
+        :ets.insert(state.blessing_leases, {{workload, node_id}, row})
+        {:ok, %{start_generation: start, next_generation: start, lease_end: lease_end}, state}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp lease_low_or_absent?(state, workload, node_id) do
+    watermark = Map.get(fetch_blessing(state, workload), :blessed_generation, 0) || 0
+
+    leases =
+      :ets.foldl(
+        fn {{wl, node}, row}, acc ->
+          if wl == workload and node == node_id and row.next_generation < row.lease_end do
+            [%{workload_name: workload, next_generation: row.next_generation, lease_end: row.lease_end} | acc]
+          else
+            acc
+          end
+        end,
+        [],
+        state.blessing_leases
+      )
+
+    case leases do
+      [] -> true
+      [lease | _] -> lease.lease_end <= watermark or lease.lease_end - lease.next_generation < 12
+    end
+  end
+
+  defp blessing_leases_for_workload_node(state, workload, node_id) do
+    :ets.foldl(
+      fn {{wl, node}, row}, acc ->
+        if wl == workload and node == node_id and row.next_generation < row.lease_end do
+          [%{workload_name: workload, next_generation: row.next_generation, lease_end: row.lease_end} | acc]
+        else
+          acc
+        end
+      end,
+      [],
+      state.blessing_leases
+    )
   end
 
   # Re-derive and persist `workload`'s quarantine flag in the SEPARATE blessing

--- a/projects/embervm/control/test/embervm/node_registry_test.exs
+++ b/projects/embervm/control/test/embervm/node_registry_test.exs
@@ -12,7 +12,8 @@ defmodule Embervm.NodeRegistryTest do
   # test), proving connect -> emit -> ETS publish -> reconnect-on-drop.
   use ExUnit.Case, async: true
 
-  alias Embervm.{NodeRegistry, WorkloadCatalog}
+  alias Embervm.{NodeRegistry, StatefulStore, WorkloadCatalog}
+  alias Embervm.OpLog.SQLite
   alias Embervm.Node.V1.{GroupMemberVm, NodeStatus, WorkloadCapacity}
 
   # -- helpers ---------------------------------------------------------------
@@ -467,6 +468,83 @@ defmodule Embervm.NodeRegistryTest do
 
     assert Enum.map(entry.group_member_plan, & &1.member_name) == ["api", "worker-0", "worker-1"]
     assert Enum.all?(entry.group_member_plan, &(&1.ready_budget_seconds == 47))
+  end
+
+  test "registry resync grants a lease for a stateful node-local-wake workload" do
+    workload = "registry-stateful-lease-#{System.unique_integer([:positive])}"
+
+    WorkloadCatalog.upsert(WorkloadCatalog.table(), workload, %{
+      image_ref: "registry-stateful-lease-image",
+      stateful: %{node_local_wake: true, listen_port: 5411, port: 8080, volume_mount_path: "/data"},
+      serving: %{port: 8080, health_path: "/health"}
+    })
+
+    on_exit(fn -> WorkloadCatalog.drop(WorkloadCatalog.table(), workload) end)
+    test_pid = self()
+
+    {_reg, _table} =
+      start_registry(
+        watch_startup: true,
+        connect_fun: fn _address -> {:ok, :fake_channel} end,
+        watch_fun: blocking_watch(),
+        sync_registry_fun: fn :fake_channel, "node-4", request ->
+          send(test_pid, {:registry_sync, request})
+          :ok
+        end,
+        disconnect_fun: fn :fake_channel -> :ok end,
+        age_check_ms: 60_000,
+        unknown_after_ms: 60_000,
+        down_after_ms: 60_000
+      )
+
+    assert_receive {:registry_sync, request}, 1_000
+    entry = Enum.find(request.entries, &(&1.workload == workload))
+    assert entry.blessing_leases != []
+
+    leases =
+      StatefulStore.blessing_leases_for_node("node-4")
+      |> Enum.filter(&(&1.workload_name == workload))
+
+    assert [%{workload_name: ^workload, next_generation: next_generation, lease_end: lease_end}] = leases
+
+    assert lease_end > next_generation
+    {:ok, ops} = SQLite.read_from(Embervm.OpLog.SQLite, 0)
+    assert Enum.any?(ops, &(&1.kind == :blessing_lease_granted and &1.workload == workload))
+  end
+
+  test "registry resync does not grant a lease for a serving-only node-local-wake workload" do
+    workload = "registry-serving-lease-#{System.unique_integer([:positive])}"
+
+    WorkloadCatalog.upsert(WorkloadCatalog.table(), workload, %{
+      image_ref: "registry-serving-lease-image",
+      serving: %{node_local_wake: true, port: 8080, health_path: "/health"}
+    })
+
+    on_exit(fn -> WorkloadCatalog.drop(WorkloadCatalog.table(), workload) end)
+    test_pid = self()
+
+    {_reg, _table} =
+      start_registry(
+        watch_startup: true,
+        connect_fun: fn _address -> {:ok, :fake_channel} end,
+        watch_fun: blocking_watch(),
+        sync_registry_fun: fn :fake_channel, "node-4", request ->
+          send(test_pid, {:registry_sync, request})
+          :ok
+        end,
+        disconnect_fun: fn :fake_channel -> :ok end,
+        age_check_ms: 60_000,
+        unknown_after_ms: 60_000,
+        down_after_ms: 60_000
+      )
+
+    assert_receive {:registry_sync, request}, 1_000
+    entry = Enum.find(request.entries, &(&1.workload == workload))
+    assert entry.blessing_leases == []
+    refute Enum.any?(StatefulStore.blessing_leases_for_node("node-4"), &(&1.workload_name == workload))
+
+    {:ok, ops} = SQLite.read_from(Embervm.OpLog.SQLite, 0)
+    refute Enum.any?(ops, &(&1.kind == :blessing_lease_granted and &1.workload == workload))
   end
 
   test "SyncRegistry carries the configured control-plane activator IP, or empty when unset" do

--- a/projects/embervm/control/test/embervm/stateful_store_test.exs
+++ b/projects/embervm/control/test/embervm/stateful_store_test.exs
@@ -50,6 +50,52 @@ defmodule Embervm.StatefulStoreTest do
     assert StatefulStore.next_blessed_generation(restarted, "wl-a") == 1001
   end
 
+  test "ensure_blessing_lease grants when the lease is absent", %{path: path} do
+    {op_log, store} = start_pair(path)
+    expected_start = StatefulStore.next_blessed_generation(store, "wl-a")
+
+    assert {:ok, [lease]} = StatefulStore.ensure_blessing_lease(store, "wl-a", "node-4")
+    assert lease.next_generation == expected_start
+    assert lease.lease_end == expected_start + 50
+
+    {:ok, ops} = SQLite.read_from(op_log, 0)
+    assert [%{kind: :blessing_lease_granted, workload: "wl-a"}] =
+             Enum.filter(ops, &(&1.kind == :blessing_lease_granted))
+  end
+
+  test "ensure_blessing_lease grants when the lease is stale at the watermark", %{path: path} do
+    {op_log, store} = start_pair(path)
+
+    {:ok, old_lease} = StatefulStore.grant_blessing_lease(store, "wl-a", "node-4", 4)
+    assert old_lease.lease_end == 5
+    {:ok, _} = StatefulStore.bless_generation(store, "wl-a", 5)
+
+    assert {:ok, [new_lease]} = StatefulStore.ensure_blessing_lease(store, "wl-a", "node-4")
+    assert new_lease != old_lease
+    assert new_lease.next_generation > old_lease.lease_end
+
+    {:ok, ops} = SQLite.read_from(op_log, 0)
+    assert 2 == Enum.count(ops, &(&1.kind == :blessing_lease_granted and &1.workload == "wl-a"))
+  end
+
+  test "ensure_blessing_lease is a no-op when a healthy lease exists", %{path: path} do
+    {op_log, store} = start_pair(path)
+    {:ok, original} = StatefulStore.grant_blessing_lease(store, "wl-a", "node-4", 50)
+
+    results =
+      for _ <- 1..3 do
+        assert {:ok, leases} = StatefulStore.ensure_blessing_lease(store, "wl-a", "node-4")
+        leases
+      end
+
+    assert Enum.all?(results, &(&1 == [%{workload_name: "wl-a", next_generation: 1, lease_end: 51}]))
+    assert original.next_generation == 1
+    assert original.lease_end == 51
+
+    {:ok, ops} = SQLite.read_from(op_log, 0)
+    assert 1 == Enum.count(ops, &(&1.kind == :blessing_lease_granted and &1.workload == "wl-a"))
+  end
+
   defp start_instance(store, opts \\ []) do
     StatefulStore.start(store, %{
       instance_id: Keyword.get(opts, :instance_id, "sf-1"),

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.325
+      targetRevision: 0.1.326
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Closes #4187.

## Why

PR #4183 shipped blessing leases and they were **inert**. Verified on the fleet
after it rolled out: zero `blessing_lease_granted` ops had ever been written, and
demo-postgres's anchor showed `gen 6764 / genblessed 6416 / .blessing-lease
absent`.

The grant was only reachable from `bless_wake_generation`, which runs on a
**control-plane-driven wake**. Workloads with `nodeLocalWake: true` are woken
exclusively by their own node-local activator, so in steady state the control
plane never wakes them and the grant never fired, for exactly the workloads the
feature exists to serve. Their only CP-side event is `update_quarantine`
adoption, which advances the watermark without passing through the wake path.

The design frame was "wake paths"; the thing that needed hooking was "watermark
movers".

## What changed

A lease is now ensured during the **registry resync** (`:resync_registry`, ~60s),
which runs regardless of whether anything wakes.

- `StatefulStore.ensure_blessing_lease/3` is a single atomic `handle_call` doing
  check-and-grant inside the GenServer. There are now two grant sites, the
  manager wake and the resync, and splitting check from grant would race and
  burn ranges.
- `lease_low_or_absent?` has **one** definition. `maybe_grant_blessing_lease`
  delegates to it rather than keeping a copy, so the predicate cannot drift.
- `node_registry.ex` calls it in place of the previous `blessing_leases_for_node`
  call, so the GenServer call count per catalog entry per node per sync stays at
  one.

**The gate is the stateful-specific flag, not the class-agnostic one.**
`node_local_wake` at `node_registry.ex:1602` is an `or` across serving, stateful
and group. Blessing exists only for stateful volumes, so a serving or group
workload must never be leased: that would burn generations against a volume that
does not exist. The entry field stays class-agnostic; only the grant gate
narrows.

## Why this self-sustains

Adoption advances the CP watermark to whatever the brick reports, so as the brick
consumes leased generations the watermark follows it up. Eventually it passes
`lease_end`, the lease reads stale, and the next resync grants a fresh range. The
mechanism that makes a lease go stale is the same one that triggers its
replacement.

## Invariants, unchanged

1. The CP never blesses inside an outstanding granted range
   (`next_blessed_generation` stays lease-aware).
2. A new range starts strictly above every generation issued so far.
3. A workload without **stateful** `node_local_wake` is never granted a lease.
4. noded still fails OPEN on an absent, exhausted, or not-ahead-of-ledger lease.

## Testing

Five new tests, in `stateful_store_test.exs` and `node_registry_test.exs`:

- grants when the lease is absent
- grants when the lease is stale at the watermark
- **is a no-op when a healthy lease exists**: three calls, exactly one
  `blessing_lease_granted` op. Without this a 60s timer burns a range per tick,
  which is a runaway counter rather than a one-off waste, and is the failure mode
  moving the grant onto a timer introduces.
- the registry path grants for a stateful `node_local_wake` workload, driven
  through `blessing_leases_for` so the wiring itself is covered
- **the registry path does not grant for a serving-only workload**: asserts the
  wire payload is empty, no lease exists in the store, and no grant op was
  written

The `blessed_generation` 1, 2 and 4 assertions in `stateful_manager_test.exs` are
untouched (empty diff). They encode that non-activator workloads are never
leased and are the main guard on invariant 3.

Partly addresses #4189: the grant-and-deliver path now has coverage from
`blessing_leases_for` down. The remaining untested hop is proto -> entryFromProto
-> `server.SyncRegistry` -> `ApplyBlessingLease` on the Go side.

## Verification after merge

This ships inert-or-not by the same measure that caught #4183:

1. `select count(*) from ops where kind='blessing_lease_granted'` must become
   non-zero.
2. `gen == genblessed` on demo-postgres's brick after a subsequent **activator**
   wake.

Chart bumped to 0.1.326.
