### PR TITLE
fix(embervm): force a rebuild when a hydrate fallback disproves the base ledger

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.333
+version: 0.1.334

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -505,6 +505,28 @@ defmodule Embervm.BaseBuilder do
     {:noreply, reconcile_desc(state, desc)}
   end
 
+  def handle_cast({:reconcile_force_rebuild, workload_name, signature_at_start}, state) do
+    case Map.get(state.workloads, workload_name) do
+      nil ->
+        {:noreply, state}
+
+      w ->
+        if signature(w) != signature_at_start do
+          {:noreply, reconcile_desc(state, hydrate_fallback_desc(w))}
+        else
+          cleared_ref = w.snapshot_ref
+
+          Logger.warning(
+            "embervm base builder: forcing rebuild for #{workload_name}, cleared snapshot ref #{inspect(cleared_ref)}"
+          )
+
+          w = %{w | built_signature: nil, snapshot_ref: nil}
+          state = put_in(state.workloads[workload_name], w)
+          {:noreply, reconcile_desc(state, hydrate_fallback_desc(w))}
+        end
+    end
+  end
+
   def handle_cast({:base_missing, workload, node_id}, state) do
     {:noreply, hydrate_for_anchor(state, workload, node_id)}
   end
@@ -589,7 +611,7 @@ defmodule Embervm.BaseBuilder do
 
   # Base-durability PR-2: a hydrate worker finished (hydrated, fell back, or
   # crashed in `after`). Clear the in-flight guard so a later reconcile can hydrate
-  # (or build) again; the fallback path already re-drove a build via :reconcile.
+  # (or build) again; the fallback path already sent the force-rebuild cast.
   def handle_info({:hydrate_done, name}, state) do
     {:noreply, update_in(state.hydrating, &MapSet.delete(&1, name))}
   end
@@ -818,6 +840,7 @@ defmodule Embervm.BaseBuilder do
   defp spawn_hydrate(state, w) do
     owner = self()
     name = w.name
+    signature_at_start = signature(w)
     node_id = w.node_id
     ref = w.snapshot_ref
     address = state.node_addr[node_id]
@@ -854,14 +877,11 @@ defmodule Embervm.BaseBuilder do
             record_base_restored(op_log_mod, op_log, tenant, clock, name, ref)
 
           {:fallback, reason} ->
-            Logger.info(
-              "embervm base builder: hydrate #{name}/#{ref} fell back to build (#{inspect(reason)})"
+            Logger.warning(
+              "embervm base builder: hydrate #{name}/#{ref} fell back, forcing a rebuild (#{inspect(reason)})"
             )
 
-            # Re-drive a build for the workload. The reconcile is idempotent and
-            # re-reads current desc/placement, so a spec that changed under the
-            # hydrate is handled correctly.
-            reconcile(owner, hydrate_fallback_desc(w))
+            GenServer.cast(owner, {:reconcile_force_rebuild, name, signature_at_start})
         end
       after
         send(owner, {:hydrate_done, name})

--- a/projects/embervm/control/test/embervm/base_builder_test.exs
+++ b/projects/embervm/control/test/embervm/base_builder_test.exs
@@ -1736,29 +1736,200 @@ defmodule Embervm.BaseBuilderTest do
     assert Agent.get(build_calls, &length(&1)) == 1
   end
 
-  test "restore-first falls back to BuildBase on an S3 miss (FAILED_PRECONDITION)" do
+  test "hydrate fallback disproves the ledger and forces a rebuild" do
     test_pid = self()
-
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
     # noded reports the ref is not in the store: a fast, distinguishable miss.
     restore_fun = fn :fake_channel, _req ->
       {:error, %GRPC.RPCError{status: 9, message: "not present in store"}}
     end
 
-    {builder, _agent, _table} =
+    {builder, agent, _table} =
       build_then_report_base_absent(
         restore_fun: restore_fun,
         hydrate_poll_interval_ms: 5,
         hydrate_poll_max: 50,
         build_fun: fn :fake_channel, _req ->
-          send(test_pid, :rebuilt)
-          {:ok, resp("snap1")}
+          call = Agent.get_and_update(calls, fn n -> {n + 1, n + 1} end)
+
+          if call == 2 do
+            send(test_pid, {:rebuilt, self()})
+
+            receive do
+              :release_rebuild -> {:ok, resp("snap1")}
+            end
+          else
+            {:ok, resp("snap1")}
+          end
         end
       )
 
     # Re-reconcile: restore-first tries, gets FAILED_PRECONDITION, falls back to a
     # rebuild AT ONCE (no poll wait).
     :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
-    assert_receive :rebuilt, 1_000
+    assert_receive {:rebuilt, rebuild_worker}, 1_000
+    assert_eventually(fn ->
+      case latest(agent, "w") do
+        nil -> false
+        status ->
+          base_built = condition(status, "BaseBuilt")
+          base_built["status"] == "False" and base_built["reason"] == "BaseBuilding"
+      end
+    end)
+    refute Map.has_key?(latest(agent, "w"), "snapshotRef")
+    send(rebuild_worker, :release_rebuild)
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap1"}, latest(agent, "w")) end)
+    assert Agent.get(calls, & &1) == 2
+  end
+
+  test "hydrate fallback with a changed signature uses plain reconcile semantics" do
+    test_pid = self()
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+    restore_fun = fn :fake_channel, _req ->
+      send(test_pid, {:restore_started, self()})
+
+      receive do
+        :release_restore ->
+          {:error, %GRPC.RPCError{status: 9, message: "not present in store"}}
+      end
+    end
+
+    build_fun = fn :fake_channel, req ->
+      call = Agent.get_and_update(calls, fn n -> {n + 1, n + 1} end)
+
+      case call do
+        1 -> {:ok, resp("snap1")}
+        2 ->
+          send(test_pid, {:rebuild_started, req.image_ref, self()})
+
+          receive do
+            {:release_rebuild, result} -> result
+          end
+      end
+    end
+
+    {builder, agent, _table} =
+      build_then_report_base_absent(
+        restore_fun: restore_fun,
+        hydrate_poll_interval_ms: 2,
+        hydrate_poll_max: 2,
+        build_fun: build_fun
+      )
+
+    desc_arg = desc(%{mem_mib: 4_000})
+    :ok = BaseBuilder.reconcile(builder, desc_arg)
+    assert_receive {:restore_started, restore_worker}, 1_000
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000, image_ref: "imgB"}))
+    assert_receive {:rebuild_started, "imgB", rebuild_worker}, 1_000
+    send(restore_worker, :release_restore)
+    Process.sleep(50)
+    assert BaseBuilder.status(builder).workloads["w"].snapshot_ref == "snap1"
+    send(rebuild_worker, {:release_rebuild, {:ok, resp("snap2")}})
+    assert_eventually(fn -> match?(%{"snapshotRef" => "snap2"}, latest(agent, "w")) end)
+
+    # The fallback's start signature is stale. It must not clear the newer ledger
+    # or enqueue a duplicate build for the already-recorded current signature.
+    assert Agent.get(calls, & &1) == 2
+  end
+
+  test "hydrate fallback does not duplicate a build already targeting the signature" do
+    test_pid = self()
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+    build_fun = fn :fake_channel, _req ->
+      call = Agent.get_and_update(calls, fn n -> {n + 1, n + 1} end)
+
+      case call do
+        1 -> {:ok, resp("snap1")}
+        2 ->
+          send(test_pid, {:other_started, self()})
+
+          receive do
+            {:release_other, result} -> result
+          end
+
+        3 ->
+          send(test_pid, {:rebuild_started, self()})
+
+          receive do
+            {:release_rebuild, result} -> result
+          end
+      end
+    end
+
+    {builder, _agent, _table} =
+      build_then_report_base_absent(build_fun: build_fun)
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{name: "other", mem_mib: 4_000}))
+    assert_receive {:other_started, other_worker}, 1_000
+
+    # Derive the signature tuple from the same desc the builder reconciled, in
+    # signature/1's field order, so a future field addition fails loudly here
+    # rather than silently flipping this test into the mismatch branch.
+    d = desc(%{mem_mib: 4_000})
+    signature_at_start = {d.image_ref, nil, d.vcpus, d.mem_mib, d.guest_port, d.ready_path, d.init_env}
+    GenServer.cast(builder, {:reconcile_force_rebuild, "w", signature_at_start})
+
+    # A second force message while the first build is queued must honor the
+    # already_targeting? guard and leave the build count unchanged.
+    GenServer.cast(builder, {:reconcile_force_rebuild, "w", signature_at_start})
+    Process.sleep(50)
+    assert Agent.get(calls, & &1) == 2
+
+    send(other_worker, {:release_other, {:ok, resp("snap-other")}})
+    assert_receive {:rebuild_started, rebuild_worker}, 1_000
+    send(rebuild_worker, {:release_rebuild, {:ok, resp("snap2")}})
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "snap2" end)
+    assert Agent.get(calls, & &1) == 3
+  end
+
+  test "hydrate fallback clears ledger fields before the building status write" do
+    test_pid = self()
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+    restore_fun = fn :fake_channel, _req ->
+      {:error, %GRPC.RPCError{status: 9, message: "not present in store"}}
+    end
+
+    build_fun = fn :fake_channel, _req ->
+      call = Agent.get_and_update(calls, fn n -> {n + 1, n + 1} end)
+
+      if call == 2 do
+        send(test_pid, {:rebuild_started, self()})
+
+        receive do
+          {:release_rebuild, result} -> result
+        end
+      else
+        {:ok, resp("snap1")}
+      end
+    end
+
+    {builder, agent, _table} =
+      build_then_report_base_absent(
+        restore_fun: restore_fun,
+        hydrate_poll_interval_ms: 2,
+        hydrate_poll_max: 2,
+        build_fun: build_fun
+      )
+
+    :ok = BaseBuilder.reconcile(builder, desc(%{mem_mib: 4_000}))
+    assert_receive {:rebuild_started, rebuild_worker}, 1_000
+
+    assert_eventually(fn ->
+      case latest(agent, "w") do
+        nil -> false
+        status ->
+          base_built = condition(status, "BaseBuilt")
+
+          not Map.has_key?(status, "snapshotRef") and base_built["status"] == "False" and
+            base_built["reason"] == "BaseBuilding"
+      end
+    end)
+
+    assert BaseBuilder.status(builder).workloads["w"].snapshot_ref == nil
+    send(rebuild_worker, {:release_rebuild, {:ok, resp("snap2")}})
+    assert_eventually(fn -> BaseBuilder.status(builder).workloads["w"].snapshot_ref == "snap2" end)
   end
 
   test "restore-first falls back to BuildBase when the hydrate never lands (poll timeout)" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.333
+      targetRevision: 0.1.334
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Summary

Implements defect 1 of #4207, found live while validating #4205: when a wake finds the recorded base absent on its anchor node and the S3 restore then misses too, the hydrate fallback re-entered plain reconcile, whose built-and-recorded no-op arm vetoed the rebuild using exactly the ledger state the hydrate had just disproven. The workload wedged in a 15-second wake/hydrate/no-op loop with no convergent path (claude-runtime was uncreatable until the next image-digest change).

The fallback now casts `reconcile_force_rebuild` carrying the signature captured at hydrate start. The handler clears the disproven `built_signature`/`snapshot_ref` (with a warning naming the cleared ref) and re-runs normal reconcile so the ordinary build branch enqueues. A spec change that landed mid-hydrate wins: on signature mismatch nothing is cleared and plain reconcile semantics apply. A build already queued for the same signature is not duplicated.

Defect 2 of #4207 (why the retention sweep judged the ledger-current ref superseded) stays open for separate diagnosis.

Chart bump to a fresh version rolls the control plane; the fix self-heals the live wedge on the first session-create wake after deploy.

## Testing

- New regression: ledger says built, node affirmatively reports NONE, store misses; a build IS enqueued (fails on main).
- Mid-hydrate signature change falls through untouched; concurrent queued build not duplicated; status transitions to Building with the stale snapshotRef gone.
- Full suite green including the Elixir corpus on the executor: 1074 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)