### PR TITLE
fix(embervm): probe the CLI at shim startup and capture stderr and pre-init events

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.334
+version: 0.1.335

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.334
+      targetRevision: 0.1.335
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -46,6 +46,7 @@ INIT_READ_TIMEOUT = 15.0
 # and reports a specific error, rather than the caller timing out generically.
 TURN_READ_TIMEOUT = 600.0
 INTERRUPT_TIMEOUT = 30.0
+CLI_PROBE_TIMEOUT = 10.0
 PERMISSION_MODE_ENV = "EMBER_PERMISSION_MODE"
 DEFAULT_PERMISSION_MODE = "bypassPermissions"
 VOICE_PROMPT = (
@@ -63,6 +64,30 @@ def _truncate_ring_for_error(ring, max_len=1500):
     if len(content) > max_len:
         content = content[:max_len] + "... (truncated)"
     return content
+
+
+def _probe_cli_startup(executable):
+    """Run CLI --version as a startup probe, log result, never fail."""
+    try:
+        proc = subprocess.run(
+            [executable, "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=CLI_PROBE_TIMEOUT,
+            text=True,
+        )
+        stdout = proc.stdout[:200] if proc.stdout else ""
+        stderr = proc.stderr[:200] if proc.stderr else ""
+        msg = "ember-claude-shim: cli-probe: exit=%d stdout=%r stderr=%r\n" % (
+            proc.returncode,
+            stdout,
+            stderr,
+        )
+        sys.stderr.write(msg)
+        sys.stderr.flush()
+    except Exception as exc:
+        sys.stderr.write("ember-claude-shim: cli-probe failed: %s\n" % exc)
+        sys.stderr.flush()
 
 
 class StartupError(Exception):
@@ -341,6 +366,7 @@ class ClaudeProcess:
             "EMBER_CLAUDE_WORKSPACE", DEFAULT_WORKSPACE
         )
         self.executable = executable
+        _probe_cli_startup(executable)
         self.process = None
         self.init_event = None
         self.fatal_error = None
@@ -350,6 +376,7 @@ class ClaudeProcess:
         self.current_result = None
         self._stdout_queue = None
         self.unparseable_lines = collections.deque(maxlen=5)
+        self.parsed_events = collections.deque(maxlen=5)
 
     def ready(self):
         with self.process_lock:
@@ -418,7 +445,7 @@ class ClaudeProcess:
             cwd=self.workspace,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=None,
+            stderr=subprocess.PIPE,
             env=child_env,
         )
         with self.process_lock:
@@ -430,6 +457,11 @@ class ClaudeProcess:
         threading.Thread(
             target=self._pump_stdout,
             args=(process, self._stdout_queue),
+            daemon=True,
+        ).start()
+        threading.Thread(
+            target=self._pump_stderr,
+            args=(process,),
             daemon=True,
         ).start()
         # Note: unparseable-line stderr writes are synchronous on the read thread
@@ -444,11 +476,9 @@ class ClaudeProcess:
             if raw is None:
                 break
             event = self._parse_line(raw)
-            if (
-                event
-                and event.get("type") == "system"
-                and event.get("subtype") == "init"
-            ):
+            if event is None:
+                continue
+            if event.get("type") == "system" and event.get("subtype") == "init":
                 self.init_event = event
                 actual_session_id = event.get("session_id")
                 if isinstance(actual_session_id, str) and actual_session_id:
@@ -463,12 +493,23 @@ class ClaudeProcess:
                     self._close_process(kill=True)
                     raise StartupError(message)
                 return
+            else:
+                try:
+                    raw_str = raw.decode("utf-8", errors="replace").rstrip("\n")
+                except Exception:
+                    raw_str = repr(raw[:200])
+                if len(raw_str) > 200:
+                    raw_str = raw_str[:200]
+                self.parsed_events.append("event: " + raw_str)
         code = process.poll()
         self._close_process(kill=False)
         error_msg = "claude exited before init, exit code %s" % code
         ring_content = _truncate_ring_for_error(self.unparseable_lines)
         if ring_content:
             error_msg = error_msg + "\nCLI output:\n" + ring_content
+        events_content = _truncate_ring_for_error(self.parsed_events)
+        if events_content:
+            error_msg = error_msg + "\nParsed events:\n" + events_content
         raise RuntimeError(error_msg)
 
     @staticmethod
@@ -478,6 +519,25 @@ class ClaudeProcess:
                 output_queue.put(raw)
         finally:
             output_queue.put(None)
+
+    def _pump_stderr(self, process):
+        """Read stderr lines and add to unparseable ring with prefix."""
+        try:
+            # readline, not file iteration: iteration read-ahead buffers a pipe,
+            # delaying lines until the buffer fills or EOF; readline yields each
+            # line as the CLI writes it.
+            for raw in iter(process.stderr.readline, b""):
+                try:
+                    line_str = raw.decode("utf-8", errors="replace").rstrip("\n")
+                except Exception:
+                    line_str = repr(raw[:2000])
+                if len(line_str) > 2000:
+                    line_str = line_str[:2000]
+                sys.stderr.write("ember-claude-shim: cli-stderr: %s\n" % line_str)
+                sys.stderr.flush()
+                self.unparseable_lines.append("stderr: " + line_str)
+        except Exception:
+            pass
 
     def _read_output(self, process, timeout):
         with self.process_lock:
@@ -568,6 +628,9 @@ class ClaudeProcess:
                     ring_content = _truncate_ring_for_error(self.unparseable_lines)
                     if ring_content:
                         error_msg = error_msg + "\nCLI output:\n" + ring_content
+                    events_content = _truncate_ring_for_error(self.parsed_events)
+                    if events_content:
+                        error_msg = error_msg + "\nParsed events:\n" + events_content
                     raise RuntimeError(error_msg)
                 event = self._parse_line(raw)
                 if event is None:

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -596,3 +596,116 @@ def test_unparseable_line_truncation(tmp_path, monkeypatch, capsys):
     assert len(manager.unparseable_lines[-1]) == 2000
     assert len(error_msg) < 3500
     assert "truncated" in error_msg
+
+
+def test_cli_startup_probe_logged(tmp_path, monkeypatch, capsys):
+    """Verify CLI --version probe is logged at startup."""
+    manager = _manager(tmp_path, monkeypatch)
+    captured = capsys.readouterr()
+    # The probe should log something with "cli-probe:" prefix
+    assert "ember-claude-shim: cli-probe:" in captured.err
+    manager._close_process(kill=True)
+
+
+def test_stderr_lines_captured_to_ring_and_console(tmp_path, monkeypatch, capsys):
+    """Stderr lines land in the ring with a stderr prefix and on the console."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    executable = tmp_path / "fake-cli"
+    fake_cli_code = (
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        "sys.stderr.write('stderr line 1\\n')\n"
+        "sys.stderr.write('stderr line 2\\n')\n"
+        "sys.stderr.flush()\n"
+        "print(json.dumps({'type': 'system', 'subtype': 'init', 'session_id': 's',\n"
+        "                  'apiKeySource': 'none', 'mcp_servers': []}), flush=True)\n"
+        "line = sys.stdin.readline()\n"
+        "print(json.dumps({'type': 'result', 'result': 'ok', 'terminal_reason': 'end_turn',\n"
+        "                  'stop_reason': 'end_turn', 'is_error': False, 'permission_denials': [],\n"
+        "                  'num_turns': 1, 'session_id': 's', 'usage': {}, 'total_cost_usd': 0,\n"
+        "                  'modelUsage': {}, 'duration_ms': 1}), flush=True)\n"
+    )
+    executable.write_text(fake_cli_code)
+    os.chmod(executable, executable.stat().st_mode | 0o111)
+    monkeypatch.setenv("EMBER_GIT_USER_NAME", "Test User")
+    monkeypatch.setenv("EMBER_GIT_USER_EMAIL", "test@example.invalid")
+    manager = shim.ClaudeProcess(str(workspace), str(executable))
+    monkeypatch.setattr(manager, "_configure_git", lambda: None)
+
+    manager.turn("test")
+    manager._close_process(kill=True)
+    # The pump drains asynchronously after process exit: each line hits the
+    # console before the ring, so once the ring holds both lines the console
+    # writes have happened too.
+    deadline = time.time() + 5
+    while (
+        time.time() < deadline
+        and sum(
+            1 for line in manager.unparseable_lines if "stderr: stderr line" in line
+        )
+        < 2
+    ):
+        time.sleep(0.05)
+    captured = capsys.readouterr()
+
+    assert "ember-claude-shim: cli-stderr: stderr line 1" in captured.err
+    assert "ember-claude-shim: cli-stderr: stderr line 2" in captured.err
+    assert any("stderr: stderr line" in line for line in manager.unparseable_lines)
+
+
+def test_parsed_non_init_events_retained(tmp_path, monkeypatch):
+    """Parseable non-init events emitted before init are retained in the ring."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    executable = tmp_path / "fake-cli"
+    fake_cli_code = (
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        "print(json.dumps({'type': 'error', 'message': 'pre-init error'}), flush=True)\n"
+        "print(json.dumps({'type': 'system', 'subtype': 'init', 'session_id': 's',\n"
+        "                  'apiKeySource': 'none', 'mcp_servers': []}), flush=True)\n"
+        "line = sys.stdin.readline()\n"
+        "print(json.dumps({'type': 'result', 'result': 'ok', 'terminal_reason': 'end_turn',\n"
+        "                  'stop_reason': 'end_turn', 'is_error': False, 'permission_denials': [],\n"
+        "                  'num_turns': 1, 'session_id': 's', 'usage': {}, 'total_cost_usd': 0,\n"
+        "                  'modelUsage': {}, 'duration_ms': 1}), flush=True)\n"
+    )
+    executable.write_text(fake_cli_code)
+    os.chmod(executable, executable.stat().st_mode | 0o111)
+    monkeypatch.setenv("EMBER_GIT_USER_NAME", "Test User")
+    monkeypatch.setenv("EMBER_GIT_USER_EMAIL", "test@example.invalid")
+    manager = shim.ClaudeProcess(str(workspace), str(executable))
+    monkeypatch.setattr(manager, "_configure_git", lambda: None)
+
+    manager.turn("test")
+
+    assert len(manager.parsed_events) > 0
+    assert any("pre-init error" in event for event in manager.parsed_events)
+    manager._close_process(kill=True)
+
+
+def test_parsed_event_in_init_failure_message(tmp_path, monkeypatch):
+    """Verify parsed events appear in init-failure error messages."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    executable = tmp_path / "fake-cli"
+    fake_cli_code = r"""#!/usr/bin/env python3
+import sys
+# Emit an error event then exit
+print('{"type": "error", "message": "startup failed"}', flush=True)
+sys.exit(1)
+"""
+    executable.write_text(fake_cli_code)
+    os.chmod(executable, executable.stat().st_mode | 0o111)
+    monkeypatch.setenv("EMBER_GIT_USER_NAME", "Test User")
+    monkeypatch.setenv("EMBER_GIT_USER_EMAIL", "test@example.invalid")
+    manager = shim.ClaudeProcess(str(workspace), str(executable))
+    monkeypatch.setattr(manager, "_configure_git", lambda: None)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        manager.turn("test")
+
+    error_msg = str(exc_info.value)
+    assert "claude exited before init" in error_msg
+    assert "Parsed events:" in error_msg or "error" in error_msg


### PR DESCRIPTION
## Summary

Iteration 2 of the #4205 observability, driven by the live result of iteration 1: the deployed ring captured zero lines, meaning the CLI dies before its first stdout write, so the remaining blind spots are stderr and the pre-init window.

- Startup self-probe: the shim runs \`claude --version\` once before serving, logging one \`cli-probe\` line with exit code and output snippets. Since /shim/ready gates the base build, the probe result lands in the base-build console, answering "does the binary execute in this guest at all" from noded's log alone. Non-fatal by construction.
- The CLI now spawns with stderr piped and pumped (readline, not file iteration, so lines surface as written rather than at buffer-fill/EOF) into the console and the diagnostic ring.
- Parseable-but-non-init events emitted before init are retained and included in the exited-before-init error, closing the case where the CLI's dying words are valid JSON.

## Testing

- 28 shim tests green including the three new behaviors; full \`ci test\` green (Elixir corpus 1074/0 on the executor).
- Review note: the initial commit set \`stderr=PIPE\` without starting the pump thread (an unpumped pipe would eventually deadlock a chatty CLI); caught and fixed before merge, with the test asserting the pumped lines.

Chart bump rolls the runtime image; the resulting base rebuild will print the probe line for the current guest environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)