### PR TITLE
fix(embervm): run the guest claude CLI as uid 65532 so bypassPermissions is accepted

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.335
+version: 0.1.336

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.335
+      targetRevision: 0.1.336
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -49,11 +49,25 @@ INTERRUPT_TIMEOUT = 30.0
 CLI_PROBE_TIMEOUT = 10.0
 PERMISSION_MODE_ENV = "EMBER_PERMISSION_MODE"
 DEFAULT_PERMISSION_MODE = "bypassPermissions"
+CLI_UID_ENV = "EMBER_CLI_UID"
+CLI_GID_ENV = "EMBER_CLI_GID"
+DEFAULT_CLI_UID = 65532
+DEFAULT_CLI_GID = 65532
 VOICE_PROMPT = (
     "End every response with a single line: <voice>One or two plain sentences, "
     "no markdown, that a person could hear read aloud: what you did and anything "
     "you need from them.</voice>"
 )
+
+
+def _cli_privilege_kwargs():
+    """Return uid/gid kwargs only when the shim itself is running as root."""
+    if os.geteuid() != 0:
+        return {}
+    return {
+        "user": int(os.environ.get(CLI_UID_ENV, str(DEFAULT_CLI_UID))),
+        "group": int(os.environ.get(CLI_GID_ENV, str(DEFAULT_CLI_GID))),
+    }
 
 
 def _truncate_ring_for_error(ring, max_len=1500):
@@ -75,6 +89,7 @@ def _probe_cli_startup(executable):
             stderr=subprocess.PIPE,
             timeout=CLI_PROBE_TIMEOUT,
             text=True,
+            **_cli_privilege_kwargs(),
         )
         stdout = proc.stdout[:200] if proc.stdout else ""
         stderr = proc.stderr[:200] if proc.stderr else ""
@@ -410,8 +425,9 @@ class ClaudeProcess:
         if not os.path.isdir(self.workspace):
             raise StartupError("workspace does not exist: %s" % self.workspace)
         self._configure_git()
-        # The microVM is the security boundary. The shim and CLI run as root inside the guest
-        # (apko's run-as: 65532 is ignored on raw Firecracker boot, per review). In-guest
+        # The microVM is the security boundary. The shim may start as root inside the guest
+        # (apko's run-as: 65532 is ignored on raw Firecracker boot, per review), so drop the
+        # CLI to the runtime uid/gid only when the shim is root. In-guest
         # permission prompts add no containment that the VM boundary does not already provide.
         # There is no human on the other end of a prompt, by construction. So permission_mode
         # is bypassPermissions; future callers can override via EMBER_PERMISSION_MODE to tighten it.
@@ -447,6 +463,7 @@ class ClaudeProcess:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=child_env,
+            **_cli_privilege_kwargs(),
         )
         with self.process_lock:
             self.process = process

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -83,16 +83,65 @@ def test_fake_cli_fixture_syntax_is_valid():
     ast.parse(FAKE_CLI)
 
 
+def _capture_spawn_kwargs(tmp_path, monkeypatch, geteuid, env=None):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    manager = shim.ClaudeProcess.__new__(shim.ClaudeProcess)
+    manager.workspace = str(workspace)
+    manager.executable = "claude"
+    manager.fatal_error = None
+    monkeypatch.setattr(manager, "_configure_git", lambda: None)
+    monkeypatch.setattr(shim.os, "geteuid", lambda: geteuid)
+    for key, value in (env or {}).items():
+        monkeypatch.setenv(key, value)
+    captured = {}
+
+    def fake_popen(*args, **kwargs):
+        captured.update(kwargs)
+        raise RuntimeError("stop after capturing Popen kwargs")
+
+    monkeypatch.setattr(shim.subprocess, "Popen", fake_popen)
+    with pytest.raises(RuntimeError, match="stop after capturing"):
+        manager._spawn()
+    return captured
+
+
+def test_spawn_does_not_drop_privileges_when_shim_is_unprivileged(
+    tmp_path, monkeypatch
+):
+    kwargs = _capture_spawn_kwargs(tmp_path, monkeypatch, geteuid=1000)
+    assert "user" not in kwargs
+    assert "group" not in kwargs
+
+
+def test_spawn_drops_to_default_cli_identity_when_shim_is_root(tmp_path, monkeypatch):
+    kwargs = _capture_spawn_kwargs(tmp_path, monkeypatch, geteuid=0)
+    assert kwargs["user"] == 65532
+    assert kwargs["group"] == 65532
+
+
+def test_spawn_honors_cli_identity_environment_overrides(tmp_path, monkeypatch):
+    kwargs = _capture_spawn_kwargs(
+        tmp_path,
+        monkeypatch,
+        geteuid=0,
+        env={shim.CLI_UID_ENV: "1234", shim.CLI_GID_ENV: "2345"},
+    )
+    assert kwargs["user"] == 1234
+    assert kwargs["group"] == 2345
+
+
 def _manager(tmp_path, monkeypatch, api_key="none"):
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     executable = tmp_path / "fake-cli"
     executable.write_text(FAKE_CLI)
-    os.chmod(executable, executable.stat().st_mode | 0o111)
+    os.chmod(executable, 0o755)
     monkeypatch.setenv("FAKE_API_KEY", api_key)
     monkeypatch.setenv("EMBER_GIT_USER_NAME", "Test User")
     monkeypatch.setenv("EMBER_GIT_USER_EMAIL", "test@example.invalid")
     manager = shim.ClaudeProcess(str(workspace), str(executable))
+    monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
     monkeypatch.setattr(manager, "_configure_git", lambda: None)
     return manager
 
@@ -547,6 +596,7 @@ def test_unparseable_line_logged_to_stderr_and_retained(tmp_path, monkeypatch, c
 
 def test_init_failure_includes_ring_buffer_in_error_message(tmp_path, monkeypatch):
     """Verify init-failure errors include unparseable CLI output."""
+    monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     executable = tmp_path / "fake-cli"
@@ -557,7 +607,7 @@ def test_init_failure_includes_ring_buffer_in_error_message(tmp_path, monkeypatc
         'print("unparseable line 2", flush=True)\n'
         "sys.exit(1)\n"
     )
-    os.chmod(executable, executable.stat().st_mode | 0o111)
+    os.chmod(executable, 0o755)
     monkeypatch.setenv("EMBER_GIT_USER_NAME", "Test User")
     monkeypatch.setenv("EMBER_GIT_USER_EMAIL", "test@example.invalid")
     manager = shim.ClaudeProcess(str(workspace), str(executable))
@@ -573,6 +623,7 @@ def test_init_failure_includes_ring_buffer_in_error_message(tmp_path, monkeypatc
 
 def test_unparseable_line_truncation(tmp_path, monkeypatch, capsys):
     """Verify CLI lines are capped at 2000 chars and errors at about 1500."""
+    monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     executable = tmp_path / "fake-cli"
@@ -582,7 +633,7 @@ def test_unparseable_line_truncation(tmp_path, monkeypatch, capsys):
         'print("x" * 3000, flush=True)\n'
         "sys.exit(1)\n"
     )
-    os.chmod(executable, executable.stat().st_mode | 0o111)
+    os.chmod(executable, 0o755)
     monkeypatch.setenv("EMBER_GIT_USER_NAME", "Test User")
     monkeypatch.setenv("EMBER_GIT_USER_EMAIL", "test@example.invalid")
     manager = shim.ClaudeProcess(str(workspace), str(executable))
@@ -600,6 +651,7 @@ def test_unparseable_line_truncation(tmp_path, monkeypatch, capsys):
 
 def test_cli_startup_probe_logged(tmp_path, monkeypatch, capsys):
     """Verify CLI --version probe is logged at startup."""
+    monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
     manager = _manager(tmp_path, monkeypatch)
     captured = capsys.readouterr()
     # The probe should log something with "cli-probe:" prefix
@@ -609,6 +661,7 @@ def test_cli_startup_probe_logged(tmp_path, monkeypatch, capsys):
 
 def test_stderr_lines_captured_to_ring_and_console(tmp_path, monkeypatch, capsys):
     """Stderr lines land in the ring with a stderr prefix and on the console."""
+    monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     executable = tmp_path / "fake-cli"
@@ -627,7 +680,7 @@ def test_stderr_lines_captured_to_ring_and_console(tmp_path, monkeypatch, capsys
         "                  'modelUsage': {}, 'duration_ms': 1}), flush=True)\n"
     )
     executable.write_text(fake_cli_code)
-    os.chmod(executable, executable.stat().st_mode | 0o111)
+    os.chmod(executable, 0o755)
     monkeypatch.setenv("EMBER_GIT_USER_NAME", "Test User")
     monkeypatch.setenv("EMBER_GIT_USER_EMAIL", "test@example.invalid")
     manager = shim.ClaudeProcess(str(workspace), str(executable))
@@ -656,6 +709,7 @@ def test_stderr_lines_captured_to_ring_and_console(tmp_path, monkeypatch, capsys
 
 def test_parsed_non_init_events_retained(tmp_path, monkeypatch):
     """Parseable non-init events emitted before init are retained in the ring."""
+    monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     executable = tmp_path / "fake-cli"
@@ -672,7 +726,7 @@ def test_parsed_non_init_events_retained(tmp_path, monkeypatch):
         "                  'modelUsage': {}, 'duration_ms': 1}), flush=True)\n"
     )
     executable.write_text(fake_cli_code)
-    os.chmod(executable, executable.stat().st_mode | 0o111)
+    os.chmod(executable, 0o755)
     monkeypatch.setenv("EMBER_GIT_USER_NAME", "Test User")
     monkeypatch.setenv("EMBER_GIT_USER_EMAIL", "test@example.invalid")
     manager = shim.ClaudeProcess(str(workspace), str(executable))
@@ -687,6 +741,7 @@ def test_parsed_non_init_events_retained(tmp_path, monkeypatch):
 
 def test_parsed_event_in_init_failure_message(tmp_path, monkeypatch):
     """Verify parsed events appear in init-failure error messages."""
+    monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     executable = tmp_path / "fake-cli"
@@ -697,7 +752,7 @@ print('{"type": "error", "message": "startup failed"}', flush=True)
 sys.exit(1)
 """
     executable.write_text(fake_cli_code)
-    os.chmod(executable, executable.stat().st_mode | 0o111)
+    os.chmod(executable, 0o755)
     monkeypatch.setenv("EMBER_GIT_USER_NAME", "Test User")
     monkeypatch.setenv("EMBER_GIT_USER_EMAIL", "test@example.invalid")
     manager = shim.ClaudeProcess(str(workspace), str(executable))


### PR DESCRIPTION
## Summary

Root cause of #4205, found live once the stderr capture from #4209 deployed. The CLI's dying words:

```
--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
```

The shim spawns the CLI with `--permission-mode bypassPermissions`, and everything in the guest runs as root because apko's `run-as: 65532` is ignored on a raw Firecracker boot (guest-init is PID 1 and execs the shim directly). The CLI refuses that combination and exits 1 before writing any stdout, which is why the failure was silent: the first observability iteration had nothing to capture.

The shim now spawns the CLI (and its startup probe) as uid/gid 65532, the user the image already defines, overridable via `EMBER_CLI_UID`/`EMBER_CLI_GID`. The drop applies only when the shim is actually root, so local and test invocations spawn exactly as before. The guest was already prepared for this: guest-init chowns `/workspace`, `/home/runtime` and the seeded `.claude.json` to 65532, and mounts `/tmp` mode 1777.

This also moves the guest to the repo-wide non-root posture rather than relying on the microVM boundary alone.

## Testing

- New tests assert no privilege kwargs when the shim is unprivileged, uid/gid 65532 when it is root, and that the env overrides are honored; 28 shim tests pass (forced uncached).
- Full `ci test` green.

Verified sequence after deploy: the base rebuild runs the probe, then one live turn should complete. That closes #4205 and unblocks #4071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)