### PR TITLE
docs(embervm): document the egress internal allowlist as the in-cluster model lane

### DIFF
--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1077,10 +1077,16 @@ egress:
   external: allow
   internal:
     default: deny
-    # Internal (cluster/private) destinations permitted under deny-by-default, as
-    # host[:port]. Empty: the claude runtime needs the public internet, not this
-    # cluster, and an agent that could reach in-cluster services is exactly the
-    # pivot this setting exists to prevent.
+    # Internal (cluster/private) destinations permitted under deny-by-default. Each
+    # entry is an exact host:port (e.g. vllm-qwen:8000): a deliberate hole in the
+    # split-horizon guardrail (ADR 023). The sidecar tries the entry against BOTH
+    # the requested host:port AND the resolved ip:port (classify.go internalAllows),
+    # so a name and its address are both accepted, and pinning the resolved IP is
+    # what defeats SSRF-by-name and DNS rebinding. Matching is an exact
+    # case-insensitive host compare (main.go allowed), so wildcards are NOT
+    # supported. Adding an entry is a security decision: an agent with internal
+    # reach can pivot to other cluster services. Empty list (the default) means
+    # deny-all-internal; the claude runtime needs only the public internet.
     allowlist: []
     # Extra CIDRs treated as internal beyond the baked private/loopback/link-local
     # ranges. This cluster's pod/service/node nets are already RFC1918.


### PR DESCRIPTION
## Summary

Comment-only change to `egress.internal.allowlist` in the embervm chart values, documenting it as the mechanism that would let a guest reach an in-cluster model endpoint (vLLM serves the Anthropic Messages API natively, so no translation service is needed) and recording precisely what the matcher does.

Accuracy matters here because a values comment about a security control gets trusted during later review. The comment now states: the sidecar tries each entry against **both** the requested `host:port` and the resolved `ip:port` (`classify.go` `internalAllows`); pinning the resolved IP is what defeats SSRF-by-name and DNS rebinding; and matching is an exact case-insensitive host compare (`main.go` `allowed`), so wildcards are **not** supported.

No values change: the allowlist stays empty and `helm template` against production values renders **byte-identically** to main.

The `claudeRuntimeWorkload.guestEnv` knob explored alongside this was deliberately dropped rather than shipped. Review established that `init_env` is part of the base signature (so setting it re-keys every base on every node and CPU vendor, the outage shape recorded in `base_builder.ex`'s moduledoc) while **noded never reads `BuildBaseRequest.init_env`**, so it would have bought a fleet-wide rebuild for no effect. That belongs with its noded consumer in a separate change.

## Testing

`ci lint` green; render diff against origin/main is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)