### PR TITLE
fix(embervm): give session invoke a transport deadline longer than the budget it advertises

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.336
+version: 0.1.337

--- a/projects/embervm/chart/templates/workload-claude-runtime.yaml
+++ b/projects/embervm/chart/templates/workload-claude-runtime.yaml
@@ -55,4 +55,14 @@ spec:
     bankedTtlSeconds: {{ .Values.claudeRuntimeWorkload.session.bankedTtlSeconds }}
     maxSessions: {{ .Values.claudeRuntimeWorkload.session.maxSessions }}
     invokeQueueCap: {{ .Values.claudeRuntimeWorkload.session.invokeQueueCap }}
+  invocation:
+    # Total duration bound for a session invoke (CP transport plus guest execution).
+    # Maximum of 900s per CRD schema (workload-crd.yaml:868); increase this only
+    # if CRD maximum is raised. The shim's per-event watchdog (TURN_READ_TIMEOUT)
+    # is 600s, and the monolith's outer bound (agent_sessions/transport.py) is 1800s,
+    # so the ordering is: shim inactivity 600s < CP total {{ .Values.claudeRuntimeWorkload.invocation.timeoutSeconds }}s < monolith outer 1800s.
+    # The innermost timeout always fires first, giving the caller a specific error
+    # rather than a generic transport cancel. A real agent turn (model round trip
+    # plus tool calls plus any VM build on cache miss) needs substantial headroom.
+    timeoutSeconds: {{ .Values.claudeRuntimeWorkload.invocation.timeoutSeconds }}
 {{- end }}

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1188,3 +1188,7 @@ claudeRuntimeWorkload:
     bankedTtlSeconds: 21600
     maxSessions: 2
     invokeQueueCap: 4
+  invocation:
+    # Total duration for a session invoke. CRD maximum is 900s (workload-crd.yaml:868).
+    # Ordering: shim per-event 600s < CP total 900s < monolith outer 1800s.
+    timeoutSeconds: 900

--- a/projects/embervm/control/lib/embervm/base_builder.ex
+++ b/projects/embervm/control/lib/embervm/base_builder.ex
@@ -2739,8 +2739,9 @@ defmodule Embervm.BaseBuilder do
   # frame, swallowing the error so BaseBuilder never logged a failure and the
   # Workload wedged in BaseBuilding. An explicit generous per-call timeout (10 min
   # in ms) covers any realistic base build; BuildBase's own BootReadyTimeout is the
-  # real inner bound. This is the SLOW-path build only; the hot-path Prime/Assign
-  # calls keep the short default deliberately.
+  # real inner bound. This is the SLOW-path build only; Prime keeps the short default
+  # deliberately (fast allocation); Assign and SessionAssign now pass explicit
+  # deadlines to match their application budgets.
   defp default_build(channel, %BuildBaseRequest{} = request) do
     NodeService.Stub.build_base(channel, request, timeout: 600_000)
   end

--- a/projects/embervm/control/lib/embervm/dispatcher.ex
+++ b/projects/embervm/control/lib/embervm/dispatcher.ex
@@ -1465,11 +1465,33 @@ defmodule Embervm.Dispatcher do
   defp default_mono, do: System.monotonic_time(:millisecond)
   defp default_wall, do: System.system_time(:millisecond)
 
-  defp default_assign(channel, %AssignRequest{} = req) do
-    Embervm.Node.V1.NodeService.Stub.assign(channel, req)
+  defp default_assign(channel, %AssignRequest{timeout_ms: timeout_ms} = req) do
+    Embervm.Node.V1.NodeService.Stub.assign(channel, req, timeout: transport_timeout(timeout_ms))
   end
 
+  # Prime is a fast VM allocation on a brick with guaranteed free slots;
+  # deliberately keep the short elixir-grpc default (10s) since a Prime should
+  # complete in <1s and this is not an application deadline like Assign/SessionAssign.
   defp default_prime(channel, %PrimeRequest{} = req) do
     Embervm.Node.V1.NodeService.Stub.prime(channel, req)
+  end
+
+  # Transport timeout must exceed the application deadline (timeout_ms) the guest is
+  # told it has, plus headroom so the guest-side timeout fires first and noded can
+  # respond with a structured deadline-exceeded error before the transport deadline
+  # hits. Without this, the caller gets {:server_closed_request, :cancel} (grpc-elixir
+  # 1.0.2 cancel-frame bug #4144) instead of noded's real status.
+  # Headroom is 5s: conservative, as a well-behaved guest should not approach its own
+  # timeout, and noded's error response is O(1ms). The misnamed default gRPC timeout
+  # is 10s; our guest default is 90s, so an explicit transport timeout is needed.
+  # MUST stay in sync with session.ex transport_timeout/1 (they are duplicated to avoid
+  # a module dependency; any change to one must be reflected in the other immediately).
+  @default_timeout_ms 90_000
+  @headroom_ms 5_000
+  @doc false
+  def transport_timeout(nil), do: @default_timeout_ms + @headroom_ms
+  def transport_timeout(0), do: @default_timeout_ms + @headroom_ms
+  def transport_timeout(timeout_ms) when is_integer(timeout_ms) and timeout_ms > 0 do
+    timeout_ms + @headroom_ms
   end
 end

--- a/projects/embervm/control/lib/embervm/session.ex
+++ b/projects/embervm/control/lib/embervm/session.ex
@@ -480,11 +480,29 @@ defmodule Embervm.Session do
 
   # -- defaults --------------------------------------------------------------
 
-  defp default_session_assign(channel, %SessionAssignRequest{} = req) do
-    Embervm.Node.V1.NodeService.Stub.session_assign(channel, req)
+  defp default_session_assign(channel, %SessionAssignRequest{timeout_ms: timeout_ms} = req) do
+    Embervm.Node.V1.NodeService.Stub.session_assign(channel, req, timeout: transport_timeout(timeout_ms))
   end
 
   defp default_destroy(channel, vm_id) do
     Embervm.Node.V1.NodeService.Stub.destroy(channel, %Embervm.Node.V1.DestroyRequest{vm_id: vm_id})
+  end
+
+  # Transport timeout must exceed the application deadline (timeout_ms) the guest is
+  # told it has, plus headroom so the guest-side timeout fires first and noded can
+  # respond with a structured deadline-exceeded error before the transport deadline
+  # hits. Without this, the caller gets {:server_closed_request, :cancel} (grpc-elixir
+  # 1.0.2 cancel-frame bug #4144) instead of noded's real status.
+  # Headroom is 5s: conservative, as a well-behaved guest should not approach its own
+  # timeout, and noded's error response is O(1ms). The misnamed default gRPC timeout
+  # is 10s; our guest default is 90s, so an explicit transport timeout is needed.
+  # MUST stay in sync with dispatcher.ex transport_timeout/1 (see there for motivation).
+  @default_timeout_ms 90_000
+  @headroom_ms 5_000
+  @doc false
+  def transport_timeout(nil), do: @default_timeout_ms + @headroom_ms
+  def transport_timeout(0), do: @default_timeout_ms + @headroom_ms
+  def transport_timeout(timeout_ms) when is_integer(timeout_ms) and timeout_ms > 0 do
+    timeout_ms + @headroom_ms
   end
 end

--- a/projects/embervm/control/test/embervm/dispatcher_test.exs
+++ b/projects/embervm/control/test/embervm/dispatcher_test.exs
@@ -105,7 +105,7 @@ defmodule Embervm.DispatcherTest do
       floor: Keyword.get(opts, :floor, 0),
       mem_mib: Keyword.get(opts, :mem_mib, 0),
       invoke_path: "/",
-      timeout_ms: 5_000,
+      timeout_ms: Keyword.get(opts, :timeout_ms, 5_000),
       result_ttl_ms: 60_000,
       result_max_bytes: Keyword.get(opts, :result_max_bytes, 1_048_576),
       retry: Keyword.get(opts, :retry, %{max_attempts: 3, backoff_ms: 1, backoff_cap_ms: 1, retry_on: [:transport, :timeout, :guest5xx]}),
@@ -1027,6 +1027,32 @@ defmodule Embervm.DispatcherTest do
     else
       Process.sleep(5)
       wait_open(gate)
+    end
+  end
+
+  # Direct unit tests for transport deadline arithmetic (see session_manager_test.exs).
+  describe "transport_timeout/1" do
+    test "non-default positive timeout_ms adds headroom" do
+      assert Embervm.Dispatcher.transport_timeout(45_000) == 50_000
+    end
+
+    test "default timeout_ms (90s) adds headroom" do
+      assert Embervm.Dispatcher.transport_timeout(90_000) == 95_000
+    end
+
+    test "nil timeout_ms falls back to 95s" do
+      assert Embervm.Dispatcher.transport_timeout(nil) == 95_000
+    end
+
+    test "zero timeout_ms falls back to 95s" do
+      assert Embervm.Dispatcher.transport_timeout(0) == 95_000
+    end
+
+    test "transport timeout ALWAYS exceeds application deadline (invariant)" do
+      for timeout_ms <- [1, 10, 100, 1_000, 50_000, 90_000] do
+        result = Embervm.Dispatcher.transport_timeout(timeout_ms)
+        assert result > timeout_ms, "transport timeout #{result} must exceed deadline #{timeout_ms}"
+      end
     end
   end
 end

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -163,7 +163,7 @@ defmodule Embervm.SessionManagerTest do
       class: Keyword.get(opts, :class, "session"),
       image_ref: "img@sha256:abc",
       invoke_path: "/",
-      timeout_ms: 90_000,
+      timeout_ms: Keyword.get(opts, :timeout_ms, 90_000),
       cap: Keyword.get(opts, :cap, 8),
       floor: 1,
       session:
@@ -862,5 +862,35 @@ defmodule Embervm.SessionManagerTest do
       draining: false,
       updated_at: 5_000_000
     })
+  end
+
+  # Direct unit tests for transport deadline arithmetic, ensuring the fix
+  # (transport timeout EXCEEDS application deadline) cannot be reverted unnoticed.
+  describe "transport_timeout/1" do
+    test "non-default positive timeout_ms adds headroom" do
+      # Use 45s (non-default) so a hardcoded constant cannot pass by luck.
+      assert Embervm.Session.transport_timeout(45_000) == 50_000
+    end
+
+    test "default timeout_ms (90s) adds headroom" do
+      assert Embervm.Session.transport_timeout(90_000) == 95_000
+    end
+
+    test "nil timeout_ms falls back to 95s" do
+      assert Embervm.Session.transport_timeout(nil) == 95_000
+    end
+
+    test "zero timeout_ms falls back to 95s" do
+      assert Embervm.Session.transport_timeout(0) == 95_000
+    end
+
+    test "transport timeout ALWAYS exceeds application deadline (invariant)" do
+      # Property: for any positive timeout_ms, result > timeout_ms.
+      # This is the bug that was fixed: the old code defaulted to 10s < 90s.
+      for timeout_ms <- [1, 10, 100, 1_000, 50_000, 90_000] do
+        result = Embervm.Session.transport_timeout(timeout_ms)
+        assert result > timeout_ms, "transport timeout #{result} must exceed deadline #{timeout_ms}"
+      end
+    end
   end
 end

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.336
+      targetRevision: 0.1.337
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Summary

Fixes #4212, the blocker for every live agent turn. Verified live: turns failed at **exactly 10.0s** with

```
502 {"reason":"%Mint.HTTPError{reason: {:server_closed_request, :cancel}, module: Mint.HTTP2}"}
```

and the session then went `failed`.

`default_session_assign` called the stub with no `:timeout`, so the stream carried elixir-grpc's default `grpc-timeout: 10S`, while the same request told noded it had 90s via `timeout_ms`. An advertise-versus-enforce mismatch where the shorter deadline is invisible in the message the daemon reads, and per the grpc-elixir 1.0.2 cancel-frame bug the real status is lost as `:cancel`. Same bug class as the BuildBase deadline fixed during the bazel-query work, at the hot-path call site.

- `session_assign` and the task-lane `assign` now derive an explicit transport timeout from the request's own `timeout_ms` plus headroom, so the transport deadline can never be shorter than the application deadline in the same message.
- `prime` deliberately keeps the short default (a fast claim, not an application deadline) and now says so, with the `base_builder.ex` comment corrected since its "Prime/Assign" claim is now true only of Prime.
- **Second layer the fix exposes**: with the transport deadline correct, the application deadline binds, and `claude-runtime` inherited the 90s watcher default because its Workload declared no `invocation` block. That is shorter than the shim's own 600s per-event watchdog, inverting the documented ordering so the control plane would kill healthy turns before the guest could report anything specific. The workload now declares `timeoutSeconds: 900` (the CRD schema maximum), giving: shim inactivity 600s < CP total 900s < monolith outer 1800s.

## Testing

`transport_timeout/1` is exposed `@doc false` purely so the deadline arithmetic is directly assertable, and both modules assert the real invariant: for any positive `timeout_ms` the result is strictly greater than `timeout_ms`, plus the explicit fallbacks for nil/0. An earlier revision's tests asserted only a request field that was already correct and would have stayed green with the fix deleted; those were replaced.

`ci test` green with the Elixir corpus genuinely executed: 1084 tests, 0 failures (up from 1074, confirming the new tests registered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)