### PR TITLE
fix(embervm): give the guest CLI a realistic init budget and diagnose timeouts

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.337
+version: 0.1.338

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.337
+      targetRevision: 0.1.338
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -4,6 +4,7 @@
 import http.server
 import collections
 import json
+import math
 import os
 import queue
 import re
@@ -34,7 +35,27 @@ MAX_TOOL_INPUT_BYTES = 4096
 # destination. Generous for real headers, bounded so a client that never sends
 # the terminating blank line cannot grow this buffer without limit.
 MAX_PROXY_HEAD_BYTES = 64 << 10
-INIT_READ_TIMEOUT = 15.0
+INIT_READ_TIMEOUT_ENV = "EMBER_INIT_READ_TIMEOUT"
+DEFAULT_INIT_READ_TIMEOUT = 90.0
+# Initialization waits inside a turn, so this must stay below the CP per-invoke
+# budget (spec.invocation.timeoutSeconds, currently 900 for claude-runtime),
+# below TURN_READ_TIMEOUT's 600 second role, and generous enough for the cold
+# first init of the 262MB Bun binary in a microVM. BuildBase also uses this
+# through /shim/ready and has its own generous budget.
+
+
+def _read_init_timeout():
+    """Return the positive finite init timeout from the environment."""
+    try:
+        value = float(os.environ.get(INIT_READ_TIMEOUT_ENV, DEFAULT_INIT_READ_TIMEOUT))
+    except (TypeError, ValueError):
+        return DEFAULT_INIT_READ_TIMEOUT
+    if not math.isfinite(value) or value <= 0:
+        return DEFAULT_INIT_READ_TIMEOUT
+    return value
+
+
+INIT_READ_TIMEOUT = _read_init_timeout()
 # Per-event inactivity timeout for the read loop in turn(). Resets on every
 # stream event, so a turn emitting steady output can run far longer than this.
 # Sized to span a single silent tool call: the CLI emits nothing while a Bash
@@ -391,6 +412,7 @@ class ClaudeProcess:
         self.current_result = None
         self._stdout_queue = None
         self.unparseable_lines = collections.deque(maxlen=5)
+        self.stderr_lines = collections.deque(maxlen=5)
         self.parsed_events = collections.deque(maxlen=5)
 
     def ready(self):
@@ -469,7 +491,15 @@ class ClaudeProcess:
             self.process = process
             self.init_event = None
             self._stdout_queue = queue.Queue()
-            self.unparseable_lines.clear()
+            # REPLACE the rings rather than clearing them: a stale pump thread from
+            # a previous process holds the old deque and would keep appending to a
+            # shared one, reporting a dead process's output as this one's last words.
+            # stderr gets its OWN ring because SIGINT on the timeout path always
+            # emits a multi-line traceback, which in a shared maxlen deque evicts the
+            # stdout dying words exactly when they matter most.
+            self.unparseable_lines = collections.deque(maxlen=5)
+            self.stderr_lines = collections.deque(maxlen=5)
+            self.parsed_events = collections.deque(maxlen=5)
             _managed_child_pids.add(process.pid)
         threading.Thread(
             target=self._pump_stdout,
@@ -478,18 +508,24 @@ class ClaudeProcess:
         ).start()
         threading.Thread(
             target=self._pump_stderr,
-            args=(process,),
+            args=(process, self.stderr_lines),
             daemon=True,
         ).start()
         # Note: unparseable-line stderr writes are synchronous on the read thread
-        # and race INIT_READ_TIMEOUT. This is fine for tens-of-lines Bun panics
+        # and race the init timeout. This is fine for tens-of-lines Bun panics
         # but could turn thousands-of-lines dumps into a generic init timeout.
+        init_read_timeout = _read_init_timeout()
         while True:
             try:
-                raw = self._read_output(process, INIT_READ_TIMEOUT)
+                raw = self._read_output(process, init_read_timeout)
             except TimeoutError:
-                self._timeout_interrupt(process, INIT_READ_TIMEOUT, "initialization")
-                raise StartupError("timed out waiting for Claude initialization")
+                self._timeout_interrupt(process, init_read_timeout, "initialization")
+                raise StartupError(
+                    self._assemble_error_with_rings(
+                        "timed out waiting for Claude initialization after %s seconds"
+                        % init_read_timeout
+                    )
+                )
             if raw is None:
                 break
             event = self._parse_line(raw)
@@ -521,13 +557,7 @@ class ClaudeProcess:
         code = process.poll()
         self._close_process(kill=False)
         error_msg = "claude exited before init, exit code %s" % code
-        ring_content = _truncate_ring_for_error(self.unparseable_lines)
-        if ring_content:
-            error_msg = error_msg + "\nCLI output:\n" + ring_content
-        events_content = _truncate_ring_for_error(self.parsed_events)
-        if events_content:
-            error_msg = error_msg + "\nParsed events:\n" + events_content
-        raise RuntimeError(error_msg)
+        raise RuntimeError(self._assemble_error_with_rings(error_msg))
 
     @staticmethod
     def _pump_stdout(process, output_queue):
@@ -537,8 +567,12 @@ class ClaudeProcess:
         finally:
             output_queue.put(None)
 
-    def _pump_stderr(self, process):
-        """Read stderr lines and add to unparseable ring with prefix."""
+    def _pump_stderr(self, process, ring):
+        """Read stderr lines onto the console and into the given ring.
+
+        The ring is passed in rather than read off self, so a pump left running
+        for a previous process cannot append into the current process's ring.
+        """
         try:
             # readline, not file iteration: iteration read-ahead buffers a pipe,
             # delaying lines until the buffer fills or EOF; readline yields each
@@ -552,7 +586,7 @@ class ClaudeProcess:
                     line_str = line_str[:2000]
                 sys.stderr.write("ember-claude-shim: cli-stderr: %s\n" % line_str)
                 sys.stderr.flush()
-                self.unparseable_lines.append("stderr: " + line_str)
+                ring.append(line_str)
         except Exception:
             pass
 
@@ -578,6 +612,20 @@ class ClaudeProcess:
             sys.stderr.flush()
             self.unparseable_lines.append(line_str)
             return None
+
+    def _assemble_error_with_rings(self, base_msg):
+        """Append truncated CLI output, stderr, and parsed events to an error."""
+        sections = [
+            ("CLI output:", self.unparseable_lines),
+            ("CLI stderr:", self.stderr_lines),
+            ("Parsed events:", self.parsed_events),
+        ]
+        error_msg = base_msg
+        for label, ring in sections:
+            content = _truncate_ring_for_error(ring)
+            if content:
+                error_msg += "\n%s\n%s" % (label, content)
+        return error_msg
 
     def _close_process(self, kill=False):
         with self.process_lock:
@@ -631,24 +679,19 @@ class ClaudeProcess:
             events = []
             while True:
                 try:
-                    raw = self._read_output(process, TURN_READ_TIMEOUT)
+                    turn_read_timeout = TURN_READ_TIMEOUT
+                    raw = self._read_output(process, turn_read_timeout)
                 except TimeoutError:
-                    self._timeout_interrupt(process, TURN_READ_TIMEOUT, "turn output")
+                    self._timeout_interrupt(process, turn_read_timeout, "turn output")
                     raise RuntimeError(
                         "timed out waiting for Claude output after %s seconds"
-                        % TURN_READ_TIMEOUT
+                        % turn_read_timeout
                     )
                 if raw is None:
                     code = process.poll()
                     self._close_process(kill=False)
                     error_msg = "claude crashed during turn, exit code %s" % code
-                    ring_content = _truncate_ring_for_error(self.unparseable_lines)
-                    if ring_content:
-                        error_msg = error_msg + "\nCLI output:\n" + ring_content
-                    events_content = _truncate_ring_for_error(self.parsed_events)
-                    if events_content:
-                        error_msg = error_msg + "\nParsed events:\n" + events_content
-                    raise RuntimeError(error_msg)
+                    raise RuntimeError(self._assemble_error_with_rings(error_msg))
                 event = self._parse_line(raw)
                 if event is None:
                     continue

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -621,6 +621,85 @@ def test_init_failure_includes_ring_buffer_in_error_message(tmp_path, monkeypatc
     assert "unparseable line" in error_msg
 
 
+def _write_delayed_init_cli(tmp_path, delay):
+    executable = tmp_path / "delayed-init-cli"
+    executable.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys, time\n"
+        "if '--version' in sys.argv:\n"
+        "    sys.exit(0)\n"
+        "print('init output before timeout', flush=True)\n"
+        "print('init stderr before timeout', file=sys.stderr, flush=True)\n"
+        "print(json.dumps({'type': 'error', 'message': 'init still starting'}), flush=True)\n"
+        "time.sleep(%s)\n"
+        "print(json.dumps({'type': 'system', 'subtype': 'init', 'session_id': 's',\n"
+        "                  'apiKeySource': 'none', 'mcp_servers': []}), flush=True)\n"
+        "sys.stdin.readline()\n"
+        "print(json.dumps({'type': 'result', 'result': 'ok', 'terminal_reason': 'end_turn',\n"
+        "                  'stop_reason': 'end_turn', 'is_error': False,\n"
+        "                  'permission_denials': [], 'num_turns': 1, 'session_id': 's',\n"
+        "                  'usage': {}, 'total_cost_usd': 0, 'modelUsage': {},\n"
+        "                  'duration_ms': 1}), flush=True)\n" % delay
+    )
+    os.chmod(executable, 0o755)
+    return executable
+
+
+def test_init_timeout_includes_diagnostics_and_honors_env_override(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
+    monkeypatch.setenv("EMBER_INIT_READ_TIMEOUT", "0.2")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    executable = _write_delayed_init_cli(tmp_path, 1)
+    monkeypatch.setenv("EMBER_GIT_USER_NAME", "Test User")
+    monkeypatch.setenv("EMBER_GIT_USER_EMAIL", "test@example.invalid")
+    manager = shim.ClaudeProcess(str(workspace), str(executable))
+    monkeypatch.setattr(manager, "_configure_git", lambda: None)
+
+    with pytest.raises(shim.StartupError) as exc_info:
+        manager.turn("test")
+
+    error_msg = str(exc_info.value)
+    assert "after 0.2 seconds" in error_msg
+    assert "CLI output:" in error_msg
+    assert "CLI stderr:" in error_msg
+    assert "Parsed events:" in error_msg
+
+
+def test_init_timeout_env_override_honored(tmp_path, monkeypatch):
+    monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
+    monkeypatch.setenv("EMBER_INIT_READ_TIMEOUT", "5.0")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    executable = _write_delayed_init_cli(tmp_path, 6)
+    monkeypatch.setenv("EMBER_GIT_USER_NAME", "Test User")
+    monkeypatch.setenv("EMBER_GIT_USER_EMAIL", "test@example.invalid")
+    manager = shim.ClaudeProcess(str(workspace), str(executable))
+    monkeypatch.setattr(manager, "_configure_git", lambda: None)
+
+    with pytest.raises(shim.StartupError, match="after 5.0 seconds"):
+        manager.turn("test")
+
+
+def test_init_timeout_env_override_falls_back_to_default_on_garbage(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
+    monkeypatch.setenv("EMBER_INIT_READ_TIMEOUT", "not a number")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    executable = _write_delayed_init_cli(tmp_path, 15)
+    monkeypatch.setenv("EMBER_GIT_USER_NAME", "Test User")
+    monkeypatch.setenv("EMBER_GIT_USER_EMAIL", "test@example.invalid")
+    manager = shim.ClaudeProcess(str(workspace), str(executable))
+    monkeypatch.setattr(manager, "_configure_git", lambda: None)
+
+    assert manager.turn("test")["terminal_reason"] == "end_turn"
+    manager._close_process(kill=True)
+
+
 def test_unparseable_line_truncation(tmp_path, monkeypatch, capsys):
     """Verify CLI lines are capped at 2000 chars and errors at about 1500."""
     monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
@@ -694,17 +773,14 @@ def test_stderr_lines_captured_to_ring_and_console(tmp_path, monkeypatch, capsys
     deadline = time.time() + 5
     while (
         time.time() < deadline
-        and sum(
-            1 for line in manager.unparseable_lines if "stderr: stderr line" in line
-        )
-        < 2
+        and sum(1 for line in manager.stderr_lines if "stderr line" in line) < 2
     ):
         time.sleep(0.05)
     captured = capsys.readouterr()
 
     assert "ember-claude-shim: cli-stderr: stderr line 1" in captured.err
     assert "ember-claude-shim: cli-stderr: stderr line 2" in captured.err
-    assert any("stderr: stderr line" in line for line in manager.unparseable_lines)
+    assert any("stderr line" in line for line in manager.stderr_lines)
 
 
 def test_parsed_non_init_events_retained(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Continues #4205. After #4210 the guest CLI starts correctly as uid 65532 (the root/bypassPermissions refusal is gone), and the live guest console now shows the next layer:

```
ember-claude-shim: initialization timed out after 15.0 seconds, sending SIGINT
```

which surfaces to the caller as a 503.

- `INIT_READ_TIMEOUT` goes from 15s to 90s and becomes env-overridable (`EMBER_INIT_READ_TIMEOUT`, garbage falls back to the default). 15s was calibrated for guests that boot in milliseconds; the claude runtime is a cold 262 MB Bun binary on a read-only rootfs with a tmpfs HOME. The comment records the ordering constraint rather than just the number: the init wait sits inside a turn, so it stays below the shim's 600s per-event watchdog and the CP's 900s per-invoke budget.
- The timeout arm was the one error path that dropped the diagnostics built in #4206/#4209, reporting only that it timed out. All three arms (exited-before-init, crashed-during-turn, timeout) now share one assembly helper and carry the CLI output, stderr, and pre-init event rings.
- The reported timeout value is now the value actually used, so the log can never disagree with the real budget.

**stderr keeps its own ring, and this PR is why.** An interim revision collapsed stderr back into the shared unparseable-lines deque with a prefix. Its own new test caught the consequence: SIGINT on the timeout path always emits a multi-line Python traceback on stderr, which filled the shared 5-slot ring and evicted the CLI's stdout line, so the diagnostic lost exactly the words it exists to capture, on exactly the path that needs them. The rings are separate and are replaced (not cleared) per spawn, so a stale pump thread cannot attribute a dead process's output to a live one.

## Testing

34 shim tests pass on a forced-uncached run (`--nocache_test_results`; an earlier cached "pass" on this branch was false and hid a real failure). Full `ci test` green with the Elixir corpus executed: 1084 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)