### PR TITLE
fix(embervm): send the first turn before waiting for CLI init

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.338
+version: 0.1.339

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.338
+      targetRevision: 0.1.339
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -166,6 +166,18 @@ def _json_line(value):
     return (json.dumps(value, separators=(",", ":")) + "\n").encode("utf-8")
 
 
+def _user_message_line(message):
+    return _json_line(
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": message}],
+            },
+        }
+    )
+
+
 def voice_summary(result):
     text = result if isinstance(result, str) else str(result or "")
     match = re.search(r"<voice>\s*(.*?)\s*</voice>", text, re.DOTALL)
@@ -441,7 +453,7 @@ class ClaudeProcess:
                 detail = completed.stderr.decode("utf-8", "replace").strip()
                 raise StartupError("git config failed for %s: %s" % (key, detail))
 
-    def _spawn(self, session_id=None):
+    def _spawn(self, session_id=None, first_message=None):
         if self.fatal_error is not None:
             raise StartupError(self.fatal_error)
         if not os.path.isdir(self.workspace):
@@ -511,6 +523,9 @@ class ClaudeProcess:
             args=(process, self.stderr_lines),
             daemon=True,
         ).start()
+        if first_message is not None:
+            process.stdin.write(_user_message_line(first_message))
+            process.stdin.flush()
         # Note: unparseable-line stderr writes are synchronous on the read thread
         # and race the init timeout. This is fine for tens-of-lines Bun panics
         # but could turn thousands-of-lines dumps into a generic init timeout.
@@ -659,23 +674,17 @@ class ClaudeProcess:
                     self._close_process(kill=False)
                 # A request without an id resumes the last session after an
                 # interrupt or relight instead of silently creating a new one.
-                self._spawn(session_id or self.session_id)
+                self._spawn(session_id or self.session_id, first_message=message)
                 process = self.process
+                message_sent = True
+            else:
+                message_sent = False
             if not self.ready():
                 raise StartupError(self.fatal_error or "shim not ready")
             self.current_result = None
-            process.stdin.write(
-                _json_line(
-                    {
-                        "type": "user",
-                        "message": {
-                            "role": "user",
-                            "content": [{"type": "text", "text": message}],
-                        },
-                    }
-                )
-            )
-            process.stdin.flush()
+            if not message_sent:
+                process.stdin.write(_user_message_line(message))
+                process.stdin.flush()
             events = []
             while True:
                 try:

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -78,6 +78,36 @@ for line in sys.stdin:
 """
 
 
+FAKE_CLI_INIT_AFTER_INPUT = r"""#!/usr/bin/env python3
+import json
+import os
+import signal
+import sys
+
+lines_path = os.environ["FAKE_LINES"]
+
+def interrupted(_signum, _frame):
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, interrupted)
+first_line = sys.stdin.readline()
+print(json.dumps({"type": "system", "subtype": "init", "session_id": "delayed-sid",
+                  "model": "fake", "apiKeySource": "none", "mcp_servers": []}), flush=True)
+
+def respond(line):
+    with open(lines_path, "a") as stream:
+        stream.write(line)
+    request = json.loads(line)
+    text = request["message"]["content"][0]["text"]
+    print(json.dumps({"type": "result", "result": "Done <voice>Processed %s.</voice>" % text,
+                      "terminal_reason": "end_turn", "session_id": "delayed-sid"}), flush=True)
+
+respond(first_line)
+for line in sys.stdin:
+    respond(line)
+"""
+
+
 def test_fake_cli_fixture_syntax_is_valid():
     """Verify the FAKE_CLI embedded script is valid Python."""
     ast.parse(FAKE_CLI)
@@ -160,6 +190,44 @@ def test_turn_extracts_voice_activity_and_tolerates_malformed_json(
         {"type": "bash", "command": "git status"},
     ]
     assert manager.ready()
+    manager._close_process(kill=True)
+
+
+def test_first_turn_is_sent_before_delayed_cli_init_and_only_once(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    executable = tmp_path / "fake-cli"
+    executable.write_text(FAKE_CLI_INIT_AFTER_INPUT)
+    os.chmod(executable, 0o755)
+    lines_path = tmp_path / "lines.jsonl"
+    monkeypatch.setenv("FAKE_LINES", str(lines_path))
+    monkeypatch.setenv("EMBER_INIT_READ_TIMEOUT", "2")
+    monkeypatch.setenv("EMBER_GIT_USER_NAME", "Test User")
+    monkeypatch.setenv("EMBER_GIT_USER_EMAIL", "test@example.invalid")
+    manager = shim.ClaudeProcess(str(workspace), str(executable))
+    monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(manager, "_configure_git", lambda: None)
+
+    first = manager.turn("first")
+    assert first["terminal_reason"] == "end_turn"
+    assert manager.session_id == "delayed-sid"
+    assert json.loads(lines_path.read_text()) == {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [{"type": "text", "text": "first"}],
+        },
+    }
+
+    second = manager.turn("second")
+    assert second["terminal_reason"] == "end_turn"
+    assert manager.process.poll() is None
+    assert [
+        json.loads(line)["message"]["content"][0]["text"]
+        for line in lines_path.read_text().splitlines()
+    ] == ["first", "second"]
     manager._close_process(kill=True)
 
 
@@ -568,7 +636,7 @@ def test_cli_crash_is_422(tmp_path, monkeypatch):
     manager = _manager(tmp_path, monkeypatch)
     original = manager._spawn
 
-    def crash_spawn(session_id=None):
+    def crash_spawn(session_id=None, first_message=None):
         raise RuntimeError("claude crashed during turn, exit code 7")
 
     manager._spawn = crash_spawn


### PR DESCRIPTION
## Summary

Root cause of every failing agent turn on EmberVM (#4205), reproduced deterministically off-cluster.

The startup probe added in #4209 proved the guest is healthy:

```
ember-claude-shim: cli-probe: exit=0 stdout='2.1.220 (Claude Code)\n' stderr=''
```

Binary, Bun runtime, uid 65532, and filesystem all fine. Yet a session turn produced **zero bytes on stdout and stderr for 90 seconds**, with all three diagnostic rings empty, then SIGINT.

`turn()` spawned the CLI, blocked until the `system`/`init` event arrived, and only then wrote the user message. But `claude 2.1.220 --input-format stream-json` **emits nothing until it receives input**, so on a fresh spawn each side waited for the other: the shim timed out and killed a perfectly healthy CLI.

Verified locally with the same argv and env:

| stdin state | result |
|---|---|
| open pipe, no data (the shim's exact state) | 0 bytes, hangs until killed |
| immediate EOF (`< /dev/null`) | exits 0, 0 bytes |
| message written first | init appears immediately, turn completes |

That last row is why this survived: every earlier verification, including the timings recorded when this feature was designed, piped a message in at spawn, so the CLI always had input. Only the shim's spawn-then-wait ordering deadlocks, and only on the first spawn, which is why multi-turn timings looked healthy.

The first message is now written immediately after `Popen`, before the init wait, and `turn()` writes only when it did not just spawn, so exactly one message reaches the CLI per turn.

## Testing

The new regression test uses a fake CLI that reads stdin **before** emitting init, matching the real CLI. **Confirmed it fails against main's shim** (checked out main's `shim.py` under the new tests: FAILED) and passes with this change, so it genuinely reproduces the deadlock rather than asserting current behavior. Also asserts exactly one user message reaches the CLI on a fresh-spawn turn, so a double-send cannot regress in.

34 shim tests pass forced-uncached; full `ci test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)