### PR TITLE
chore(embervm): pair the demo-postgres coupling comments both sides (#4198)

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -248,6 +248,12 @@ scratchPostgres:
 # itself moments after a query and relighting on the next connection. Reuses the
 # scratch-postgres guest image pin + Secret; its own volume keeps demo rows out
 # of real tenants' data.
+#
+# COUPLING (#4198): the monolith side gates DEMO_POSTGRES_DSN on its own
+# scratchPostgres.demoListenPort (projects/monolith/deploy/values.yaml) and
+# nothing cross-checks the two. If you disable this demo, clear demoListenPort
+# there in the same change, or the monolith renders a DSN to a nonexistent
+# workload and the synthetic probe latches red (503 /api/health).
 demoPostgres:
   enabled: true
 

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -439,6 +439,11 @@ scratchPostgres:
   enabled: false
   # Renders DEMO_POSTGRES_DSN for the firecracker demos page's sleep/wake
   # exhibit (matches the embervm chart's demoPostgres.listenPort).
+  # COUPLING (#4198): the demo workload itself is gated on demoPostgres.enabled
+  # in projects/embervm/deploy/values.yaml and nothing cross-checks the two. If
+  # the embervm side disables the demo, clear this to "" in the same change, or
+  # the DSN points at a nonexistent workload and the synthetic probe latches
+  # red (503 /api/health).
   demoListenPort: 5401
   onepassword:
     itemPath: "vaults/k8s-homelab/items/scratch-postgres"


### PR DESCRIPTION
Addresses the in-repo part of #4198 (item 4, the latent config coupling). The other items are cluster-side physical residue (brick state dirs, the SeaweedFS loom bucket, the one-off CP instance DELETE) and are not actionable from Git.

**What changed**

- `projects/embervm/deploy/values.yaml`: warning comment on `demoPostgres.enabled` naming the monolith-side `scratchPostgres.demoListenPort` knob and the failure mode (DSN to a nonexistent workload, synthetic probe latches red, 503 /api/health).
- `projects/monolith/deploy/values.yaml`: the matching comment on `demoListenPort` pointing back at the embervm side.

Comments only, rendered manifests unchanged, so no chart bump.

**Residue sweep findings (loom, scratch-postgres, goosecracker), what was deliberately left**

- embervm/monolith scratch-postgres chart blocks: NOT residue. PR #4195 deliberately kept them gated off because the live demo-postgres exhibit shares the guest image pin and the 1Password Secret, and the deploy values document the flip-back path.
- `projects/firecracker/goosecracker/` and the monolith goosecracker BUILD wiring: still depended on by `projects/monolith/BUILD` (`recipe_yamls` data deps, chat/goosecracker test targets), so it has to go out together with the monolith-side code removal, which is in flight separately.
- `bazel/images/BUILD` goosecracker push lines: the file is auto-generated from BUILD-file image macros, so the pushes disappear only when the goosecracker image targets are deleted (same coupled removal as above).
- Remaining `loom` matches outside docs/ are the buck2 toolchain comments (`.buckconfig`, `buildbuddy.yaml`) that reference the separate loom repo's buck2 pins, plus historical markdown (`projects/grimoire/loom-mapping.md`); rationale, not residue.
- `projects/monolith/chart/migrations/20260629120000_goosecracker_sessions.sql` stays (migration history is append-only) and the goosecracker dashboard JSON is left for the monolith-side cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRo3gDfwCz6E8Z9Ywf2bef