### PR TITLE
fix(embervm): evict a banked session whose snapshot vanished instead of looping on an illegal fail

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.339
+version: 0.1.340

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -270,6 +270,10 @@ defmodule Embervm.SessionManager do
       # Ids already alarmed for being stuck in destroying, so the error logs once
       # per stuck id rather than every reconcile tick (pruned as ids terminalize).
       destroying_alarmed: MapSet.new(),
+      # Session ids whose adoption transition was not applicable, with the state
+      # that produced the warning. A state change makes the warning eligible again.
+      logged_unapplicable: MapSet.new(),
+      unapplicable_states: %{},
       # EMBERVM_ASYNC_LIFECYCLE_WRITES (ADR embervm/014 decision 2). When on, the
       # Direction-2 orphan reconcile ADOPTS-and-backfills a reported session VM whose
       # store row is absent BUT a durable write is still in flight for it (a young
@@ -1548,6 +1552,8 @@ defmodule Embervm.SessionManager do
     live_vms = index_session_vms(facts)
     snapshots = index_session_snapshots(facts)
 
+    state = clear_changed_unapplicable(state)
+
     state =
       SessionStore.all(state.session_store)
       |> Enum.reject(&SessionState.terminal?(&1.state))
@@ -1831,11 +1837,65 @@ defmodule Embervm.SessionManager do
       # last updated) is honoured first, so an owner-resolved dial that momentarily
       # omits a just-created VM does not terminalize it (ADR embervm/014 decision 5).
       node_reporting?(state, session.node_id) and orphan_grace_elapsed?(state, session) ->
-        fail_session(state, sid, :failed, "vm_and_snapshot_vanished")
-        state
+        case session.state do
+          :banked ->
+            evict_banked(state, session, :snapshot_vanished)
+
+          session_state when session_state in [:running, :banking, :relighting, :creating] ->
+            fail_adopted_session(state, session)
+
+          _ ->
+            state
+        end
 
       true ->
         state
+    end
+  end
+
+  defp clear_changed_unapplicable(state) do
+    sessions = Map.new(SessionStore.all(state.session_store), &{&1.session_id, &1.state})
+
+    Enum.reduce(state.unapplicable_states, state, fn {session_id, logged_state}, acc ->
+      if Map.get(sessions, session_id) == logged_state do
+        acc
+      else
+        %{
+          acc
+          | logged_unapplicable: MapSet.delete(acc.logged_unapplicable, session_id),
+            unapplicable_states: Map.delete(acc.unapplicable_states, session_id)
+        }
+      end
+    end)
+  end
+
+  defp fail_adopted_session(state, session) do
+    case SessionStore.transition(
+           state.session_store,
+           session.session_id,
+           :fail,
+           :session_failed,
+           %{reason: :failed, detail: "vm_and_snapshot_vanished"},
+           %{}
+         ) do
+      {:ok, _} ->
+        state
+
+      {:error, err} ->
+        if MapSet.member?(state.logged_unapplicable, session.session_id) do
+          state
+        else
+          Logger.warning("embervm session fail transition failed",
+            session_id: session.session_id,
+            error: inspect(err)
+          )
+
+          %{
+            state
+            | logged_unapplicable: MapSet.put(state.logged_unapplicable, session.session_id),
+              unapplicable_states: Map.put(state.unapplicable_states, session.session_id, session.state)
+          }
+        end
     end
   end
 

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -667,6 +667,49 @@ defmodule Embervm.SessionManagerTest do
     assert MapSet.member?(:sys.get_state(ctx.mgr).destroying_alarmed, created.session_id)
   end
 
+  test "test_banked_session_with_vanished_vm_and_snapshot_evicts_not_loops" do
+    ctx = start_stack(evict_fun: fn _ch, _req -> {:ok, %{}} end)
+    put_session_workload(ctx, "wl-vanished-banked")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-vanished-banked", "p1")
+    bank_session(ctx, created.session_id)
+    report_empty_node(ctx)
+
+    :ok = SessionManager.reconcile(ctx.mgr)
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :evicted
+  end
+
+  test "test_running_session_with_vanished_vm_and_snapshot_fails" do
+    ctx = start_stack()
+    put_session_workload(ctx, "wl-vanished-running")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-vanished-running", "p1")
+    report_empty_node(ctx)
+
+    :ok = SessionManager.reconcile(ctx.mgr)
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :failed
+  end
+
+  test "test_repeated_adoption_sweep_does_not_double_log_unapplicable_transition" do
+    ctx = start_stack(evict_fun: fn _ch, _req -> {:ok, %{}} end)
+    put_session_workload(ctx, "wl-no-double-warning")
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl-no-double-warning", "p1")
+    bank_session(ctx, created.session_id)
+    report_empty_node(ctx)
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        :ok = SessionManager.reconcile(ctx.mgr)
+        :ok = SessionManager.reconcile(ctx.mgr)
+      end)
+
+    hits = (log |> String.split("session fail transition failed") |> length()) - 1
+    assert hits == 0
+  end
+
+
   test "gated: reconcile destroys an orphan reported session VM with no CP row" do
     parent = self()
 
@@ -866,6 +909,24 @@ defmodule Embervm.SessionManagerTest do
 
   # Direct unit tests for transport deadline arithmetic, ensuring the fix
   # (transport timeout EXCEEDS application deadline) cannot be reverted unnoticed.
+  defp bank_session(ctx, session_id) do
+    SessionStore.adopt_state(ctx.store, session_id, :banked)
+  end
+
+  defp report_empty_node(ctx) do
+    NodeCapacity.put(ctx.cap_table, "node-4", %{
+      node_id: "node-4",
+      configured_id: "node-4",
+      workloads: %{},
+      session_vms: [],
+      session_snapshots: [],
+      live_vms: 0,
+      max_live_vms: 8,
+      draining: false,
+      updated_at: 5_000_000
+    })
+  end
+
   describe "transport_timeout/1" do
     test "non-default positive timeout_ms adds headroom" do
       # Use 45s (non-default) so a hardcoded constant cannot pass by luck.

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.339
+      targetRevision: 0.1.340
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Summary

Fixes #4226, observed live: two `claude-runtime` sessions looped for 45+ minutes emitting

```
{"error":"{:illegal_transition, :banked, :fail}","message":"embervm session fail transition failed"}
```

every 10 seconds, permanently occupying both `maxSessions` slots so every create was denied 429. The workload had locked itself out of its own capacity.

The adoption sweep terminalizes any session the node covers as neither a live VM nor a snapshot, by transitioning `:fail`. The FSM has no `{:banked, :fail}` edge, deliberately: a banked session is not touching the daemon. So for a banked session the store rejected the transition, the row stayed `:banked`, and the sweep re-decided identically forever. A fleet roll reaches this state normally, since the replacement noded does not report the old session snapshots.

The sweep now branches on the session's state: `:evict` for `:banked`, which is precisely what that verb is defined for ("only a banked session holds an evictable snapshot"), with a distinct `snapshot_vanished` reason so the op-log still separates a vanished live VM from a vanished snapshot; `:fail` unchanged for the live daemon-touching states. It reuses the existing eviction path so a swept row is indistinguishable in kind from a GC-evicted one.

**The FSM table is untouched.** The first analysis on the issue proposed adding the missing edge, on a misreading of the docstring (the "banked" mention belongs to the *destroyed* bullet, not *failed*); that is corrected in the issue comments. The table is self-consistent and the caller was using the wrong verb.

## Testing

Regression: a banked session whose node reports neither VM nor snapshot now reaches a terminal state instead of staying banked (this loops forever on main). A running session in the same situation still fails exactly as before.

`ci test` green with the Elixir corpus executed: 1087 tests, 0 failures (up from 1084, confirming the new tests registered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)