### PR TITLE
fix(monolith): homepage agent card matches the current stack

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.395
+version: 0.89.396
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.395
+      targetRevision: 0.89.396
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.470
+version: 0.285.471
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.470
+      targetRevision: 0.285.471
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
+++ b/projects/monolith/frontend/src/routes/public/HomepageRack.svelte
@@ -1,12 +1,8 @@
 <script>
-  // Both timing figures come from metrics.js so neither is a hardcoded
+  // The timing figure comes from metrics.js so it is not a hardcoded
   // literal: the FIRECRACKER card quotes the trace-derived sandbox restore
-  // (sandboxRestoreMs, the demo it links to), the AGENT PLATFORM card quotes
-  // the agent-workload cold start (agentFirstModelCallMs).
-  import {
-    sandboxRestoreMs,
-    agentFirstModelCallMs,
-  } from "$lib/public/fcstory/metrics.js";
+  // (sandboxRestoreMs, the demo it links to).
+  import { sandboxRestoreMs } from "$lib/public/fcstory/metrics.js";
   import { apps } from "$lib/public/apps.js";
 
   // Live-maps chips render from the shared registry instead of a hardcoded
@@ -94,16 +90,16 @@
           <span class="where">NODE-4</span>
         </div>
         <p>
-          Tag <b>@Bosun</b> in a Discord thread and a <b>goose</b> agent wakes
-          in its own microVM, runs a recipe, and replies with an artifact or a
-          PR. Ambient chat, scheduled routines, and coding agents all dispatch
-          through <b>EmberVM</b> (~{agentFirstModelCallMs}ms to first model
-          call), the workload substrate for semgrep scans, warm HTTP serving,
-          and agent execution.
+          Tag <b>@Bosun</b> in a Discord thread and the chat bot answers: Qwen
+          served from this rack, per-channel and per-user ACLs, and a per-user
+          trust ledger that scores every interaction and soft-locks repeat
+          offenders. Underneath, <b>EmberVM</b> runs one microVM per workload: headless
+          Claude Code sessions, semgrep scans, warm HTTP serving, and a scale-to-zero
+          Postgres.
         </p>
         <div class="clinks">
-          <a class="more" href="/ember/firecracker">how &rarr;</a>
-          <a class="more" href="/docs/projects/firecracker">docs &rarr;</a>
+          <a class="more" href="/ember">how &rarr;</a>
+          <a class="more" href="/docs/projects/embervm">docs &rarr;</a>
         </div>
       </div>
       <div class="callout">


### PR DESCRIPTION
The AGENT PLATFORM card still described the retired goose dispatch flow in present tense (goose agents were decommissioned 2026-07-28) and linked /ember/firecracker plus the frozen firecracker docs tree.

The card now describes what runs today: Bosun answers as a Qwen-backed chat bot with per-channel and per-user ACLs and the per-user trust ledger; EmberVM's workload list names headless Claude Code sessions (the session-class runtime under projects/embervm/runtimes/claude), semgrep scans, warm HTTP serving, and the scale-to-zero Postgres. Links repoint to /ember and /docs/projects/embervm (both verified resolving), and the agentFirstModelCallMs import retires with the dispatch flow it measured.

ci lint green (prettier); pre-commit ran the remote test action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199b3KMsi9kHHs3UoG6Rjdg