### PR TITLE
fix(monolith): enqueue the first agent turn instead of running it inline

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.333
+version: 0.89.336
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.333
+      targetRevision: 0.89.336
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -62,45 +62,11 @@ def _persist_pending_message(session_id: int, message_text: str) -> int:
         return row.seq
 
 
-def _persist_start(
-    local_session_id: str,
-    workspace: str,
-    branch: str,
-    prompt: str,
-    turn: Turn,
-    ember: EmberSession,
+def _persist_session(
+    local_session_id: str, workspace: str, branch: str
 ) -> AgentSession:
     with Session(get_engine()) as db_session:
-        row = store.create_session(db_session, local_session_id, workspace, branch)
-        assert row.id is not None
-        summary = voice.extract_voice_summary(turn.result)
-        usage = {**turn.usage, "activities": turn.activities}
-        status = _turn_status(turn)
-        store.create_turn(
-            db_session,
-            row.id,
-            1,
-            prompt,
-            summary,
-            turn.result,
-            turn.terminal_reason,
-            turn.stop_reason,
-            turn.permission_denials,
-            None,  # commit_sha now from guest, not pod
-            usage,
-            turn.total_cost_usd,
-            turn.session_id,  # Store CLI session_id for resumption
-        )
-        # Store the CLI's session_id in the agent session for reuse
-        row.cli_session_id = turn.session_id
-        store.set_ember_session(
-            db_session,
-            row.id,
-            ember.session_id,
-            ember.session_token,
-            ember.expires_at,
-        )
-        return store.update_session_status(db_session, row.id, status, summary)
+        return store.create_session(db_session, local_session_id, workspace, branch)
 
 
 def _turn_status(turn: Turn) -> str:
@@ -424,16 +390,13 @@ def _activity_values(turns: list[AgentTurn]) -> tuple[list[str], list[str]]:
 
 @mcp.tool
 async def monolith_agent_session_start(prompt: str) -> dict:
-    """Start a voice-drivable Claude Code session and complete its first turn."""
+    """Start a voice-drivable Claude Code session and queue its first turn."""
     local_session_id = str(uuid4())
-    turn, ember = await _transport.deliver(None, None, prompt)
     workspace = "<guest>"  # Workspace is in the guest, not the pod
-    row = await asyncio.to_thread(
-        _persist_start, local_session_id, workspace, "main", prompt, turn, ember
-    )
-    summary = voice.extract_voice_summary(turn.result)
-    await _notify_terminal(turn, summary, row.status)
-    return {"session_id": row.id, "voice": summary}
+    row = await asyncio.to_thread(_persist_session, local_session_id, workspace, "main")
+    turn = await asyncio.to_thread(_persist_pending_message, row.id, prompt)
+    _schedule_next_message(row.id)
+    return {"accepted": True, "session_id": row.id, "turn": turn}
 
 
 @mcp.tool

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -95,6 +95,118 @@ def test_send_persists_and_returns_immediately(session):
     assert pending.seq == result["turn"]
 
 
+def test_session_start_returns_immediately(monkeypatch, session):
+    started = asyncio.Event()
+
+    async def blocking_deliver(_ember, _cli_session_id, _message):
+        started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(mcp._transport, "deliver", blocking_deliver)
+
+    async def run():
+        result = await asyncio.wait_for(
+            mcp.monolith_agent_session_start("hello"), timeout=0.1
+        )
+        pending = store.get_pending_message(session, result["session_id"], 1)
+        return result, pending
+
+    result, pending = asyncio.run(run())
+
+    assert result["accepted"] is True
+    assert result["session_id"] > 0
+    assert result["turn"] == 1
+    assert pending is not None
+    assert pending.claimed_by_replica is None
+    assert not started.is_set()
+
+
+def test_session_start_happy_path_persists_result(monkeypatch, session):
+    monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
+
+    async def mock_deliver(_ember, _cli_session_id, message):
+        return _completed_delivery(message)
+
+    async def notify(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(mcp._transport, "deliver", mock_deliver)
+    monkeypatch.setattr(mcp.agent_api, "notify", notify)
+
+    async def start():
+        return await mcp.monolith_agent_session_start("hello")
+
+    result = asyncio.run(start())
+    row = store.get_session(session, result["session_id"])
+    assert row is not None
+    assert row.status == "running"
+
+    asyncio.run(mcp._execute_pending_message(row.id))
+
+    session.expire_all()
+    turn = store.get_turn(session, row.id, 1)
+    assert turn is not None
+    assert turn.result_text == "Done: hello"
+    assert turn.terminal_reason == "completed"
+    assert turn.stop_reason == "end_turn"
+    assert turn.cost_usd == 0.01
+    assert store.get_pending_message(session, row.id, 1) is None
+    assert store.get_session(session, row.id).status == "completed"
+
+
+def test_failed_first_turn_does_not_wedge_session(monkeypatch, session):
+    monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
+
+    async def failing_deliver(_ember, _cli_session_id, _message):
+        raise RuntimeError("first turn failed")
+
+    monkeypatch.setattr(mcp._transport, "deliver", failing_deliver)
+
+    result = asyncio.run(mcp.monolith_agent_session_start("hello"))
+    asyncio.run(mcp._execute_pending_message(result["session_id"]))
+
+    session.expire_all()
+    row = store.get_session(session, result["session_id"])
+    assert row is not None
+    assert row.status == "warn"
+    assert store.get_turn(session, row.id, 1) is not None
+    assert store.get_pending_message(session, row.id, 1) is None
+
+    follow_up = asyncio.run(mcp.monolith_agent_session_send(row.id, "follow up"))
+    assert follow_up["turn"] == 2
+
+
+def test_concurrent_executors_on_first_turn_run_once(monkeypatch, session):
+    monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
+    executions: list[str] = []
+
+    async def mock_deliver(_ember, _cli_session_id, message):
+        executions.append(message)
+        await asyncio.sleep(0.01)
+        return _completed_delivery(message)
+
+    async def notify(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(mcp._transport, "deliver", mock_deliver)
+    monkeypatch.setattr(mcp.agent_api, "notify", notify)
+
+    result = asyncio.run(mcp.monolith_agent_session_start("hello"))
+
+    async def run_executors():
+        await asyncio.gather(
+            mcp._execute_pending_message(result["session_id"]),
+            mcp._execute_pending_message(result["session_id"]),
+        )
+
+    asyncio.run(run_executors())
+
+    session.expire_all()
+    assert executions == ["hello"]
+    assert store.get_turn(session, result["session_id"], 1) is not None
+    assert store.get_pending_message(session, result["session_id"], 1) is None
+
+
 def _completed_turn(message: str) -> Turn:
     return Turn(
         result=f"Done: {message}",

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -329,12 +329,13 @@ def mark_turn_error_sync(session_id: int, turn_seq: int, error_msg: str) -> None
         row = get_pending_message(session, session_id, turn_seq)
         if row is None or get_turn(session, session_id, turn_seq) is not None:
             return
+        error_summary = "Error: " + error_msg[:100]
         create_turn(
             session,
             session_id,
             turn_seq,
             row.message_text,
-            "Error: " + error_msg[:100],
+            error_summary,
             f"Error executing turn: {error_msg}",
             terminal_reason="error",
             stop_reason=None,
@@ -343,6 +344,7 @@ def mark_turn_error_sync(session_id: int, turn_seq: int, error_msg: str) -> None
             usage={},
             cost_usd=0.0,
         )
+        update_session_status(session, session_id, "warn", error_summary)
         # Delete the pending row to stop infinite retries
         session.delete(row)
         session.commit()

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.408
+version: 0.285.411
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.408
+      targetRevision: 0.285.411
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

Fixes #4229, the blocker that made agent sessions unusable even though the substrate works.

Observed live: a turn ran in the EmberVM guest and **billed a real Anthropic API call** (`cost_usd: 0.056028`), but the answer was lost and the session was left permanently wedged at `status: running`. A follow-up message was accepted as turn 2 and never executed, because the stuck row blocked it. One dropped client bricked the session.

Cause: `monolith_agent_session_start` executed the first turn **synchronously inside the MCP tool call**. A cold turn plus model call exceeds Cloudflare's ~100s proxy limit, the client disconnects, and the server-side task is cancelled after the tokens are spent.

`session_start` now creates the session, enqueues the first turn, and returns immediately with `{accepted, session_id, turn}`. That gives **one execution route for every turn** rather than two: the same `_persist_pending_message` + `_schedule_next_message` path `session_send` already used, which demonstrably worked in the same live test (it returned `{"accepted": true, "turn": 2}` promptly). Callers poll `session_status` for the result.

Recovery from a dead executor is already sound and is left as-is: `reclaim_stale_claims_sync` releases claims whose `claimed_at` is older than the 30s lease, driven by the leader-owned pending-message sweep, so a claim from a crashed replica is picked up within one lease interval rather than wedging the session. A terminal error now also writes the session status, so a failed turn surfaces rather than looking idle.

## Testing

`ci test` green. The two agent_sessions targets were additionally forced **uncached** (`--nocache_test_results`: `Executed 2 out of 2 tests: 2 tests pass`), since a cached pass proves nothing about new tests.

Covers: `session_start` returns without awaiting the turn (fails on main), a stale claim is reclaimed, heartbeat refresh honors the replica id, and concurrent seq allocation races retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)