### PR TITLE
feat(embervm): raise claude-runtime session caps now the lane works end to end

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.340
+version: 0.1.341

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1152,11 +1152,13 @@ egress:
 #
 # Node disk arithmetic, documented so it is bounded rather than discovered (ADR
 # embervm/002 rule 4). memMib is 4096, so a banked session's memory snapshot is
-# worst-case ~4 GiB. maxSessions 2 (live + banked combined) caps the snapshot dir
-# at 2 x 4 GiB = 8 GiB, and cap 1 caps live RAM at 4 GiB. Deliberately small: this
-# is a single-operator feature sharing node-4 scratch with the task pools and the
-# 8-session sandbox tier, and it is the values knob to raise once the lane has
-# earned its keep.
+# worst-case ~4 GiB. maxSessions 4 (live + banked combined) caps the snapshot dir
+# at 4 x 4 GiB = 16 GiB, and cap 2 caps live RAM at 8 GiB, inside the 16gi brick's
+# ~15.8 GiB budget with room for the task pools it shares node-4 scratch with.
+# Raised from cap 1 / maxSessions 2 once the lane earned its keep (a turn reached
+# the API end to end, #4071): one concurrent sandbox and two total sessions meant
+# a single abandoned session locked the workload out, which is how the 429s during
+# that validation happened.
 #
 # floor is 0, unlike the sandbox tier: a pristine 4 GiB VM held warm is expensive,
 # and the runtime does not need warmth. A cold spawn to first request is ~250ms
@@ -1176,7 +1178,7 @@ claudeRuntimeWorkload:
   # back to (a session-class guest has no writable volume).
   memMib: 4096
   floor: 0
-  cap: 1
+  cap: 2
   session:
     # Bank an idle session after 5 minutes. Longer than the sandbox tier's 2: a
     # voice-driven conversation has human-length gaps between turns, and a bank
@@ -1186,7 +1188,7 @@ claudeRuntimeWorkload:
     # 410s onto the current base.
     maxLifetimeSeconds: 21600
     bankedTtlSeconds: 21600
-    maxSessions: 2
+    maxSessions: 4
     invokeQueueCap: 4
   invocation:
     # Total duration for a session invoke. CRD maximum is 900s (workload-crd.yaml:868).

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.340
+      targetRevision: 0.1.341
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Summary

`cap: 1` and `maxSessions: 2` meant **one** concurrent sandbox and **two** sessions total, so a single abandoned session locked the workload out completely.

That is not hypothetical: it happened repeatedly while validating #4071. Probe sessions held both slots, every subsequent create was denied 429, and there was no way to reclaim them short of the 6h TTL. The values comment already anticipated this, calling the caps "the values knob to raise once the lane has earned its keep" — it now has, with a turn reaching the Anthropic API end to end.

- `cap: 1 -> 2`: live RAM capped at 8 GiB, inside the 16gi brick's ~15.8 GiB budget with room for the task pools sharing node-4 scratch.
- `maxSessions: 2 -> 4`: snapshot dir capped at 4 x 4 GiB = 16 GiB.

The node disk arithmetic comment is updated to match rather than left describing the old numbers, since ADR embervm/002 rule 4 requires that budget be bounded in the values file rather than discovered at runtime.

Rendered and verified against production values: `cap: 2`, `maxSessions: 4`, `timeoutSeconds: 900`.

Related follow-up worth noting separately: a terminal session should release its slot promptly rather than holding it to TTL, otherwise higher caps only postpone the same lockout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)