### PR TITLE
fix(monolith): map ember_session_expires_at to BigInteger, not Integer

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.336
+version: 0.89.337
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.336
+      targetRevision: 0.89.337
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -649,3 +649,23 @@ def test_turn_status_needs_input_on_permission_denials():
     assert status == "needs_input", (
         f"Turn with permission_denials should be needs_input, got {status}"
     )
+
+
+def test_ember_expires_at_column_is_bigint():
+    """The expiry column must be BigInteger, not Integer.
+
+    It holds epoch MILLISECONDS from the control plane, which overflow int4.
+    This asserts the mapped type rather than round-tripping a value because the
+    test database is SQLite, which stores integers dynamically and therefore
+    cannot reproduce the Postgres overflow this guards against: the production
+    failure was `psycopg.errors.NumericValueOutOfRange` from SQLModel emitting an
+    explicit ::INTEGER cast against a bigint column.
+    """
+    from sqlalchemy import BigInteger
+
+    from agent_sessions.models import AgentSession
+
+    column = AgentSession.__table__.c.ember_session_expires_at
+    assert isinstance(column.type, BigInteger), (
+        "ember_session_expires_at must map to BigInteger; got %r" % column.type
+    )

--- a/projects/monolith/agent_sessions/models.py
+++ b/projects/monolith/agent_sessions/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import UniqueConstraint
+from sqlalchemy import BigInteger, UniqueConstraint
 from sqlmodel import Field, SQLModel
 
 
@@ -19,7 +19,11 @@ class AgentSession(SQLModel, table=True):
     )  # Claude CLI session_id for resumption
     ember_session_id: str | None = Field(default=None)
     ember_session_token: str | None = Field(default=None)
-    ember_session_expires_at: int | None = Field(default=None)
+    # BigInteger, not the default Integer: this is epoch MILLISECONDS from the
+    # control plane, which overflows int4. The migration already declares BIGINT,
+    # but SQLModel maps a plain int to sqlalchemy Integer and emits an explicit
+    # ::INTEGER cast in the UPDATE, so the write failed against a bigint column.
+    ember_session_expires_at: int | None = Field(default=None, sa_type=BigInteger)
     status: str = Field(default="running")
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     last_turn_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.411
+version: 0.285.412
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.411
+      targetRevision: 0.285.412
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

Found in production while validating agent sessions. Every first turn died persisting the EmberVM session identity:

```
psycopg.errors.NumericValueOutOfRange: integer out of range
[SQL: UPDATE agent_sessions.agent_sessions SET ... ember_session_expires_at=%(...)s::INTEGER ...]
```

The migration declares the column `BIGINT` and the live schema is `bigint`, so the DDL was right. But SQLModel maps a plain `int` field to SQLAlchemy `Integer`, so the UPDATE carried an explicit `::INTEGER` cast. The value is **epoch milliseconds** from the control plane (~1.78e12), which overflows int4.

Declaring `sa_type=BigInteger` on the field aligns the ORM with the DDL.

## Why the existing tests missed it

They already stored a real epoch-ms value (`1754035200000`) and passed anyway, because **the test database is SQLite, which stores integers dynamically and cannot reproduce a Postgres int4 overflow**. Any test that round-trips a value is therefore incapable of catching this class of bug.

The regression test asserts the **mapped column type** instead, which holds on any backend. Verified it fails against `origin/main`'s model and passes with the fix (forced uncached, since a cached pass proves nothing).

Worth remembering generally: for a SQLite-backed test suite against a Postgres production database, integer width, strict typing, and constraint enforcement all differ, so type-level assertions are the only reliable guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)