### PR TITLE
feat(monolith): route agent-session notifications to their own Discord channel

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.408
+version: 0.89.409
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.408
+      targetRevision: 0.89.409
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent/api.py
+++ b/projects/monolith/agent/api.py
@@ -8,6 +8,7 @@ Other domains must import from ``agent.api`` (enforced by
 from __future__ import annotations
 
 from agent.checks import check_firing_alerts  # re-exported
+from agent.config import agent_sessions_channel_id  # re-exported
 from agent.notify import notify  # re-exported
 
-__all__ = ["notify", "check_firing_alerts"]
+__all__ = ["notify", "check_firing_alerts", "agent_sessions_channel_id"]

--- a/projects/monolith/agent/config.py
+++ b/projects/monolith/agent/config.py
@@ -28,3 +28,15 @@ def load_settings() -> AgentSettings:
             "MONOLITH_AGENT_DISCORD_DEFAULT_CHANNEL_ID"
         ],
     )
+
+
+def agent_sessions_channel_id() -> str | None:
+    """Channel for agent-session turn notifications, or None for the default.
+
+    Read on its own rather than through AgentSettings: notifying a turn must not
+    depend on the unrelated required Discord settings, and a session that cannot
+    resolve an optional channel should fall back, never fail. Sessions notify on
+    EVERY terminal turn by design (they are voice-driven), so routing them apart
+    keeps validation noise off the channel real alerts use.
+    """
+    return os.environ.get("MONOLITH_AGENT_DISCORD_AGENT_SESSIONS_CHANNEL_ID") or None

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -242,7 +242,6 @@ async def _notify_terminal(
         level = "info"
     else:
         level = "warn"
-
     thread = row.discord_thread if row is not None else None
     if thread:
         # A thread is a reading surface, so post the VERBATIM result. The voice
@@ -259,15 +258,18 @@ async def _notify_terminal(
             await agent_api.notify(chunk, level=level, channel=thread)
         return
 
-    # No thread bound (MCP or /agents UI): the short voice summary is the right
-    # shape for the default channel, which is a notification surface. The status
-    # prefix stays gated on `row` exactly as before, so this change is confined
-    # to the thread lane.
+    # No thread bound (MCP or /agents UI): the short voice summary goes to the
+    # agent-session notification channel when configured. Unset falls back to
+    # notify()'s default channel.
     if row is not None and status == "needs_input":
         summary = f"Needs input: {summary}"
     elif row is not None and status == "warn":
         summary = f"Warning: {summary}"
-    await agent_api.notify(summary[:2000], level=level, channel=None)
+    await agent_api.notify(
+        summary[:2000],
+        level=level,
+        channel=agent_api.agent_sessions_channel_id(),
+    )
 
 
 def _get_pending_message_sync(session_id: int, turn_seq: int):

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -1156,7 +1156,7 @@ def test_notify_terminal_with_no_terminal_reason_warns(monkeypatch):
     notify_calls = []
 
     async def mock_notify(summary, level, channel=None):
-        notify_calls.append((summary, level))
+        notify_calls.append((summary, level, channel))
 
     monkeypatch.setattr(mcp.agent_api, "notify", mock_notify)
 
@@ -1179,7 +1179,7 @@ def test_notify_terminal_with_no_terminal_reason_warns(monkeypatch):
     asyncio.run(run())
 
     assert len(notify_calls) == 1
-    summary, level = notify_calls[0]
+    summary, level, _channel = notify_calls[0]
     assert summary == "Test summary"
     assert level == "warn"
 
@@ -1465,3 +1465,29 @@ def test_session_start_rejects_a_repo_outside_the_catalog(monkeypatch, session):
     # before _persist_session, so a rejected repo leaves no row to clean up.
     assert "session_id" not in result
     assert session.exec(select(AgentSession)).all() == []
+
+
+def test_terminal_notification_uses_the_agent_sessions_channel(monkeypatch):
+    """Session turn notifications must not ring the default alert channel."""
+    monkeypatch.setenv(
+        "MONOLITH_AGENT_DISCORD_AGENT_SESSIONS_CHANNEL_ID", "sessions-chan"
+    )
+    assert mcp.agent_api.agent_sessions_channel_id() == "sessions-chan"
+
+    seen = {}
+
+    async def fake_notify(message, level="info", channel=None):
+        seen["channel"] = channel
+        return {"ok": True}
+
+    monkeypatch.setattr(mcp.agent_api, "notify", fake_notify)
+    asyncio.run(mcp._notify_terminal(_completed_turn("hi"), "summary", "completed"))
+    assert seen["channel"] == "sessions-chan"
+
+
+def test_agent_sessions_channel_unset_falls_back_to_default(monkeypatch):
+    """An unset channel must fall through to notify()'s default, not crash."""
+    monkeypatch.delenv(
+        "MONOLITH_AGENT_DISCORD_AGENT_SESSIONS_CHANNEL_ID", raising=False
+    )
+    assert mcp.agent_api.agent_sessions_channel_id() is None

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.483
+version: 0.285.484
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -312,6 +312,13 @@ spec:
               value: {{ .Values.agent.discord.defaultServerId | quote }}
             - name: MONOLITH_AGENT_DISCORD_DEFAULT_CHANNEL_ID
               value: {{ .Values.agent.discord.defaultChannelId | quote }}
+            {{- with .Values.agent.discord.agentSessionsChannelId }}
+            # Agent-session turn notifications only. Sessions notify on EVERY
+            # terminal turn by design, so validating the lane would otherwise page
+            # the same channel as real alerts. Unset falls back to the default.
+            - name: MONOLITH_AGENT_DISCORD_AGENT_SESSIONS_CHANNEL_ID
+              value: {{ . | quote }}
+            {{- end }}
             # Owner allowlist for /goosecracker (ADR 024 Task 4). Synced from the
             # discord-bot 1Password item into monolith-chat-secrets (alongside the
             # bot token); the gate fails closed if absent. Sourced from the secret

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.483
+      targetRevision: 0.285.484
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -297,6 +297,10 @@ agent:
   discord:
     defaultServerId: "1501965852042330302"
     defaultChannelId: "1501965852969402517"
+    # Agent-session turn notifications land here instead of the default channel.
+    # Sessions notify on every terminal turn (they are voice-driven), so probing
+    # the lane would otherwise ring the same bell as real alerts.
+    agentSessionsChannelId: "1533337680463663254"
     # Owner allowlist for /goosecracker (ADR 024 Task 4) is OWNER_DISCORD_USER_ID,
     # synced from the discord-bot 1Password item into monolith-chat-secrets and
     # sourced via secretKeyRef in the deployment (not a plain value here).


### PR DESCRIPTION
## Summary

Fixes #4233. Agent sessions notify on **every** terminal turn by design, since they are voice-driven and the operator should hear when a turn lands. The side effect is that validating the lane pages the same channel real alerts use: bringing sessions up today sent live Discord messages for each probe, including failures at `warn` level.

`agent.discord.agentSessionsChannelId` routes turn notifications to a dedicated channel. Unset falls back to the default inside `notify()`, so nothing goes silent by accident.

Two design notes worth keeping:

- The lookup is a **single-purpose helper**, not a field on `AgentSettings`. A first attempt loaded the whole settings struct in `_notify_terminal` and broke unrelated tests, because notifying a turn then required two unrelated required Discord env vars. An optional channel that cannot resolve should fall back, never fail.
- It is re-exported through `agent.api` because `agent_sessions` may not import `agent.config`. The repo's `import_boundaries_test` caught that directly: `agent_sessions/mcp.py: imports agent.config (use agent.api)`.

## Testing

`ci test` green (`Executed 208 out of 744 tests: 744 tests pass`). New tests assert the configured channel is passed through and that an unset channel falls back, both run forced-uncached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)