### PR TITLE
feat(monolith): pin agent-session model family and route per-turn models

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.344
+version: 0.1.345

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.344
+      targetRevision: 0.1.345
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -34,6 +34,11 @@ CODEX_MODELS = {
     "terra": ("gpt-5.6-terra", "high"),
     "sol": ("gpt-5.6-sol", "high"),
 }
+CLAUDE_MODELS = {
+    "opus": "opus",
+    "sonnet": "sonnet",
+    "fable": "claude-fable-5",
+}
 DEFAULT_CODEX_MODEL = "luna"
 PI_MODELS = {
     "qwen": "qwen-plus",  # vLLM endpoint serves OpenAI Chat Completions API
@@ -453,6 +458,7 @@ class ClaudeProcess:
         self.init_event = None
         self.fatal_error = None
         self.session_id = None
+        self.model = None
         self.turn_lock = threading.Lock()
         self.process_lock = threading.Lock()
         self.current_result = None
@@ -487,7 +493,7 @@ class ClaudeProcess:
                 detail = completed.stderr.decode("utf-8", "replace").strip()
                 raise StartupError("git config failed for %s: %s" % (key, detail))
 
-    def _spawn(self, session_id=None, first_message=None):
+    def _spawn(self, session_id=None, first_message=None, model=None):
         if self.fatal_error is not None:
             raise StartupError(self.fatal_error)
         if not os.path.isdir(self.workspace):
@@ -511,6 +517,8 @@ class ClaudeProcess:
             "--permission-mode",
             permission_mode,
         ]
+        if model is not None:
+            command.extend(["--model", CLAUDE_MODELS.get(model, model)])
         if session_id:
             command.extend(["--resume", session_id])
         command.extend(["--append-system-prompt", VOICE_PROMPT])
@@ -587,6 +595,7 @@ class ClaudeProcess:
                     self.session_id = actual_session_id
                 elif session_id:
                     self.session_id = session_id
+                self.model = model
                 if event.get("apiKeySource") != "none":
                     message = "apiKeySource must be none, got %r" % event.get(
                         "apiKeySource"
@@ -703,16 +712,30 @@ class ClaudeProcess:
                     "session_id %r does not match active session %r"
                     % (session_id, self.session_id)
                 )
+            model_changed = model is not None and model != self.model
+            if process is not None and process.poll() is None and model_changed:
+                self._close_process(kill=False)
+                self._spawn(
+                    self.session_id or session_id,
+                    first_message=message,
+                    model=model,
+                )
+                process = self.process
+                message_sent = True
+            else:
+                message_sent = False
             if process is None or process.poll() is not None:
                 if process is not None:
                     self._close_process(kill=False)
                 # A request without an id resumes the last session after an
                 # interrupt or relight instead of silently creating a new one.
-                self._spawn(session_id or self.session_id, first_message=message)
+                self._spawn(
+                    session_id or self.session_id,
+                    first_message=message,
+                    model=model,
+                )
                 process = self.process
                 message_sent = True
-            else:
-                message_sent = False
             if not self.ready():
                 raise StartupError(self.fatal_error or "shim not ready")
             self.current_result = None
@@ -1157,7 +1180,7 @@ class ProcessManager:
             return adapter.turn(message, session_id, model or DEFAULT_PI_MODEL)
         if adapter is self.codex:
             return adapter.turn(message, session_id, model or DEFAULT_CODEX_MODEL)
-        return adapter.turn(message, session_id)
+        return adapter.turn(message, session_id, model)
 
     def interrupt(self):
         # An interrupt has no model in its request, so interrupt both adapters.

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -699,7 +699,15 @@ class ClaudeProcess:
                 process.stdin.close()
             except OSError:
                 pass
-        process.wait()
+        # Bounded: most callers close an already-exited process (wait returns
+        # instantly), but the model-change respawn closes a LIVE CLI, and an
+        # unbounded wait there would hang the turn under turn_lock if the CLI
+        # ignores stdin EOF (interrupt() treats the same wait as unsafe).
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
         _managed_child_pids.discard(process.pid)
         _reap_orphans()
 
@@ -724,7 +732,11 @@ class ClaudeProcess:
                 message_sent = True
             else:
                 message_sent = False
-            if process is None or process.poll() is not None:
+            # After a model-change respawn the first_message is already in
+            # flight; falling into this branch would _spawn again and deliver
+            # (and bill) the same turn twice if the fresh CLI died between
+            # init and this poll.
+            if not message_sent and (process is None or process.poll() is not None):
                 if process is not None:
                     self._close_process(kill=False)
                 # A request without an id resumes the last session after an

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -380,6 +380,46 @@ def test_turn_extracts_voice_activity_and_tolerates_malformed_json(
     manager._close_process(kill=True)
 
 
+def test_claude_model_argv_and_mid_session_switch_resumes(tmp_path, monkeypatch):
+    args_path = tmp_path / "args.json"
+    monkeypatch.setenv("FAKE_ARGS", str(args_path))
+    manager = _manager(tmp_path, monkeypatch)
+    manager.turn("first", model="opus")
+    assert (
+        json.loads(args_path.read_text())[
+            json.loads(args_path.read_text()).index("--model") + 1
+        ]
+        == "opus"
+    )
+    manager.turn("second", session_id="init-sid", model="fable")
+    args = json.loads(args_path.read_text())
+    assert args[args.index("--resume") + 1] == "init-sid"
+    assert args[args.index("--model") + 1] == "claude-fable-5"
+    manager._close_process(kill=True)
+
+
+def test_claude_model_none_keeps_legacy_argv(tmp_path, monkeypatch):
+    args_path = tmp_path / "args.json"
+    monkeypatch.setenv("FAKE_ARGS", str(args_path))
+    manager = _manager(tmp_path, monkeypatch)
+    manager.turn("first")
+    assert "--model" not in json.loads(args_path.read_text())
+    manager._close_process(kill=True)
+
+
+def test_manager_passes_claude_model_to_adapter():
+    manager = object.__new__(shim.ProcessManager)
+
+    class Claude:
+        def turn(self, *args):
+            return args
+
+    manager.claude = Claude()
+    manager.codex = object()
+    manager.pi = object()
+    assert manager.turn("hello", "sid", "fable") == ("hello", "sid", "fable")
+
+
 def test_first_turn_is_sent_before_delayed_cli_init_and_only_once(
     tmp_path, monkeypatch
 ):
@@ -823,7 +863,7 @@ def test_cli_crash_is_422(tmp_path, monkeypatch):
     manager = _manager(tmp_path, monkeypatch)
     original = manager._spawn
 
-    def crash_spawn(session_id=None, first_message=None):
+    def crash_spawn(session_id=None, first_message=None, model=None):
         raise RuntimeError("claude crashed during turn, exit code 7")
 
     manager._spawn = crash_spawn

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.337
+version: 0.89.339
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.337
+      targetRevision: 0.89.339
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/__init__.py
+++ b/projects/monolith/agent_sessions/__init__.py
@@ -1,1 +1,14 @@
 """Voice-drivable Claude Code agent sessions."""
+
+
+def model_family(model: str | None) -> str:
+    """Return the adapter family for a supported model name."""
+    if model == "qwen":
+        return "pi"
+    if model in {"luna", "terra", "sol"}:
+        return "codex"
+    if model in {None, "opus", "sonnet", "fable"}:
+        return "claude"
+    raise ValueError(
+        f"Unknown model {model!r}; valid models: opus, sonnet, fable, luna, terra, sol, qwen"
+    )

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -11,6 +11,7 @@ from sqlmodel import Session
 
 import agent.api as agent_api
 from agent_sessions import store, voice
+from agent_sessions import model_family
 from agent_sessions.models import AgentSession, AgentTurn
 from agent_sessions.transport import (
     EmberSession,
@@ -55,18 +56,22 @@ def _persist_ember_session(session_id: int, ember: EmberSession) -> None:
         )
 
 
-def _persist_pending_message(session_id: int, message_text: str) -> int:
+def _persist_pending_message(
+    session_id: int, message_text: str, model: str | None
+) -> int:
     with Session(get_engine()) as db_session:
-        row = store.create_pending_message(db_session, session_id, message_text)
+        row = store.create_pending_message(db_session, session_id, message_text, model)
         assert row.seq is not None
         return row.seq
 
 
 def _persist_session(
-    local_session_id: str, workspace: str, branch: str
+    local_session_id: str, workspace: str, branch: str, model: str | None
 ) -> AgentSession:
     with Session(get_engine()) as db_session:
-        return store.create_session(db_session, local_session_id, workspace, branch)
+        return store.create_session(
+            db_session, local_session_id, workspace, branch, model
+        )
 
 
 def _turn_status(turn: Turn) -> str:
@@ -116,9 +121,17 @@ def _persist_turn_from_pending_sync(
     voice_summary: str,
     status: str,
     cli_session_id: str | None = None,
+    model: str | None = None,
 ) -> AgentTurn:
     return store.persist_turn_from_pending_sync(
-        session_id, turn_seq, prompt, turn, voice_summary, status, cli_session_id
+        session_id,
+        turn_seq,
+        prompt,
+        turn,
+        voice_summary,
+        status,
+        cli_session_id,
+        model,
     )
 
 
@@ -248,6 +261,7 @@ async def _execute_pending_message(session_id: int) -> None:
                 existing_ember,
                 cli_session_id,
                 row.message_text,
+                row.model,
             )
             # Check if claim was stolen while deliver was running
             if claim_stolen:
@@ -286,6 +300,7 @@ async def _execute_pending_message(session_id: int) -> None:
                 summary,
                 status,
                 turn.session_id,  # Store for resumption
+                row.model,
             )
         except IntegrityError as e:
             # Turn already exists (duplicate seq), likely from a retry of a completed turn.
@@ -389,20 +404,51 @@ def _activity_values(turns: list[AgentTurn]) -> tuple[list[str], list[str]]:
 
 
 @mcp.tool
-async def monolith_agent_session_start(prompt: str) -> dict:
+async def monolith_agent_session_start(prompt: str, model: str | None = None) -> dict:
     """Start a voice-drivable Claude Code session and queue its first turn."""
+    try:
+        model_family(model)
+    except ValueError as exc:
+        return {"accepted": False, "error": str(exc)}
     local_session_id = str(uuid4())
     workspace = "<guest>"  # Workspace is in the guest, not the pod
-    row = await asyncio.to_thread(_persist_session, local_session_id, workspace, "main")
-    turn = await asyncio.to_thread(_persist_pending_message, row.id, prompt)
+    row = await asyncio.to_thread(
+        _persist_session, local_session_id, workspace, "main", model
+    )
+    turn = await asyncio.to_thread(_persist_pending_message, row.id, prompt, model)
     _schedule_next_message(row.id)
     return {"accepted": True, "session_id": row.id, "turn": turn}
 
 
 @mcp.tool
-async def monolith_agent_session_send(session_id: int, message: str) -> dict:
+async def monolith_agent_session_send(
+    session_id: int, message: str, model: str | None = None
+) -> dict:
     """Enqueue a message for a session, returning once accepted rather than once complete."""
-    turn = await asyncio.to_thread(_persist_pending_message, session_id, message)
+    row, _ = await asyncio.to_thread(_load_session, session_id)
+    if row is None:
+        return {"accepted": False, "error": f"Unknown agent session {session_id}"}
+    try:
+        requested_family = (
+            model_family(model) if model is not None else model_family(row.model)
+        )
+    except ValueError as exc:
+        return {"accepted": False, "error": str(exc)}
+    session_family = model_family(row.model)
+    if requested_family != session_family:
+        return {
+            "accepted": False,
+            "error": (
+                f"Model family mismatch: session family is {session_family}, "
+                f"requested model family is {requested_family}"
+            ),
+        }
+    effective_model = model or row.model
+    turn = await asyncio.to_thread(
+        _persist_pending_message, session_id, message, effective_model
+    )
+    with Session(get_engine()) as db_session:
+        store.update_session_status(db_session, session_id, "running")
     _schedule_next_message(session_id)
     return {"accepted": True, "session_id": session_id, "turn": turn}
 
@@ -418,6 +464,7 @@ async def monolith_agent_session_status(session_id: int) -> dict:
     denials = _decode_json(last.permission_denials, []) if last else []
     return {
         "status": row.status,
+        "model": row.model,
         "voice": row.voice_summary,
         "files_touched": files,
         "commands_run": commands,
@@ -442,4 +489,8 @@ async def monolith_agent_detail(session_id: int, turn: int | None = None) -> dic
     """Return the verbatim result and tool activities for one session turn."""
     _, turns = await asyncio.to_thread(_load_session, session_id)
     selected = _select_turn(turns, turn)
-    return {"result_text": selected.result_text, "activities": _activities(selected)}
+    return {
+        "result_text": selected.result_text,
+        "model": selected.model,
+        "activities": _activities(selected),
+    }

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -35,6 +35,16 @@ def _load_session(session_id: int) -> tuple[AgentSession | None, list[AgentTurn]
         return row, store.get_turns(db_session, session_id) if row else []
 
 
+def _load_session_row(session_id: int) -> AgentSession | None:
+    with Session(get_engine()) as db_session:
+        return store.get_session(db_session, session_id)
+
+
+def _set_session_status(session_id: int, status: str) -> None:
+    with Session(get_engine()) as db_session:
+        store.update_session_status(db_session, session_id, status)
+
+
 def _ember_session(row: AgentSession) -> EmberSession | None:
     if row.ember_session_id and row.ember_session_token:
         return EmberSession(
@@ -405,7 +415,15 @@ def _activity_values(turns: list[AgentTurn]) -> tuple[list[str], list[str]]:
 
 @mcp.tool
 async def monolith_agent_session_start(prompt: str, model: str | None = None) -> dict:
-    """Start a voice-drivable Claude Code session and queue its first turn."""
+    """Start a voice-drivable coding agent session and queue its first turn.
+
+    Args:
+        prompt: The first message for the session.
+        model: Optional model, which also pins the session's adapter family.
+            Claude family: opus, sonnet, fable. Codex family: luna, terra,
+            sol. Pi family: qwen. Omit for the claude CLI default. Later
+            sends may only name models within the pinned family.
+    """
     try:
         model_family(model)
     except ValueError as exc:
@@ -424,17 +442,26 @@ async def monolith_agent_session_start(prompt: str, model: str | None = None) ->
 async def monolith_agent_session_send(
     session_id: int, message: str, model: str | None = None
 ) -> dict:
-    """Enqueue a message for a session, returning once accepted rather than once complete."""
-    row, _ = await asyncio.to_thread(_load_session, session_id)
+    """Enqueue a message for a session, returning once accepted rather than once complete.
+
+    Args:
+        session_id: The session to send to.
+        message: The message text for the next turn.
+        model: Optional per-turn model within the session's pinned family.
+            Claude family: opus, sonnet, fable. Codex family: luna, terra,
+            sol. Pi family: qwen. Defaults to the session's model.
+    """
+    row = await asyncio.to_thread(_load_session_row, session_id)
     if row is None:
         return {"accepted": False, "error": f"Unknown agent session {session_id}"}
     try:
-        requested_family = (
-            model_family(model) if model is not None else model_family(row.model)
-        )
+        # Both lookups stay inside the try: a session pinned to a model whose
+        # alias has since been retired must produce the readable rejection, not
+        # an uncaught ValueError out of the tool.
+        session_family = model_family(row.model)
+        requested_family = model_family(model) if model is not None else session_family
     except ValueError as exc:
         return {"accepted": False, "error": str(exc)}
-    session_family = model_family(row.model)
     if requested_family != session_family:
         return {
             "accepted": False,
@@ -447,8 +474,7 @@ async def monolith_agent_session_send(
     turn = await asyncio.to_thread(
         _persist_pending_message, session_id, message, effective_model
     )
-    with Session(get_engine()) as db_session:
-        store.update_session_status(db_session, session_id, "running")
+    await asyncio.to_thread(_set_session_status, session_id, "running")
     _schedule_next_message(session_id)
     return {"accepted": True, "session_id": session_id, "turn": turn}
 

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -3,14 +3,47 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
-from agent_sessions import mcp
-from agent_sessions import store
-from agent_sessions.models import AgentTurn
+from agent_sessions import mcp, model_family, store
+from agent_sessions.models import AgentSession, AgentTurn
 from agent_sessions.transport import EmberSession, EmberSessionGone, Turn
 from faas.embervm_client import EmberVMTransportError
+
+
+@pytest.mark.parametrize(
+    ("model", "family"),
+    [
+        (None, "claude"),
+        ("opus", "claude"),
+        ("sonnet", "claude"),
+        ("fable", "claude"),
+        ("luna", "codex"),
+        ("terra", "codex"),
+        ("sol", "codex"),
+        ("qwen", "pi"),
+    ],
+)
+def test_model_family(model, family):
+    assert model_family(model) == family
+
+
+def test_unknown_model_is_rejected_without_creating_session(session):
+    result = asyncio.run(mcp.monolith_agent_session_start("hello", model="unknown"))
+    assert result["accepted"] is False
+    assert "valid models" in result["error"]
+    assert session.exec(select(AgentSession)).first() is None
+
+
+@pytest.mark.parametrize("model", [None, "opus", "luna", "qwen"])
+def test_session_start_stores_model_on_session_and_pending(monkeypatch, session, model):
+    monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
+    result = asyncio.run(mcp.monolith_agent_session_start("hello", model=model))
+    row = store.get_session(session, result["session_id"])
+    pending = store.get_pending_message(session, row.id, result["turn"])
+    assert row.model == model
+    assert pending.model == model
 
 
 @pytest.fixture
@@ -95,10 +128,48 @@ def test_send_persists_and_returns_immediately(session):
     assert pending.seq == result["turn"]
 
 
+def test_cross_family_send_is_rejected_without_pending_row(session):
+    row = store.create_session(session, "sid-123", "/workspace", "main", model="luna")
+    result = asyncio.run(mcp.monolith_agent_session_send(row.id, "hello", model="qwen"))
+    assert result["accepted"] is False
+    assert "codex" in result["error"] and "pi" in result["error"]
+    assert store.get_pending_message(session, row.id, 1) is None
+
+
+def test_same_family_override_reaches_transport_and_turn(monkeypatch, session):
+    monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
+    delivered_models = []
+
+    async def mock_deliver(_ember, _cli_session_id, message, model=None):
+        delivered_models.append(model)
+        return _completed_delivery(message)
+
+    async def notify(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(mcp._transport, "deliver", mock_deliver)
+    monkeypatch.setattr(mcp.agent_api, "notify", notify)
+    row = store.create_session(session, "sid-123", "/workspace", "main", model="luna")
+    row.status = "completed"
+    session.add(row)
+    session.commit()
+    result = asyncio.run(
+        mcp.monolith_agent_session_send(row.id, "hello", model="terra")
+    )
+    assert result["accepted"] is True
+    # The send wrote status through its own Session; expire this one's identity
+    # map or get() returns the stale cached row instead of re-reading.
+    session.expire_all()
+    assert store.get_session(session, row.id).status == "running"
+    asyncio.run(mcp._execute_pending_message(row.id))
+    assert delivered_models == ["terra"]
+    assert store.get_turn(session, row.id, result["turn"]).model == "terra"
+
+
 def test_session_start_returns_immediately(monkeypatch, session):
     started = asyncio.Event()
 
-    async def blocking_deliver(_ember, _cli_session_id, _message):
+    async def blocking_deliver(_ember, _cli_session_id, _message, _model=None):
         started.set()
         await asyncio.Event().wait()
 
@@ -124,7 +195,7 @@ def test_session_start_returns_immediately(monkeypatch, session):
 def test_session_start_happy_path_persists_result(monkeypatch, session):
     monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
 
-    async def mock_deliver(_ember, _cli_session_id, message):
+    async def mock_deliver(_ember, _cli_session_id, message, _model=None):
         return _completed_delivery(message)
 
     async def notify(*args, **kwargs):
@@ -157,7 +228,7 @@ def test_session_start_happy_path_persists_result(monkeypatch, session):
 def test_failed_first_turn_does_not_wedge_session(monkeypatch, session):
     monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
 
-    async def failing_deliver(_ember, _cli_session_id, _message):
+    async def failing_deliver(_ember, _cli_session_id, _message, _model=None):
         raise RuntimeError("first turn failed")
 
     monkeypatch.setattr(mcp._transport, "deliver", failing_deliver)
@@ -180,7 +251,7 @@ def test_concurrent_executors_on_first_turn_run_once(monkeypatch, session):
     monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
     executions: list[str] = []
 
-    async def mock_deliver(_ember, _cli_session_id, message):
+    async def mock_deliver(_ember, _cli_session_id, message, _model=None):
         executions.append(message)
         await asyncio.sleep(0.01)
         return _completed_delivery(message)
@@ -230,7 +301,7 @@ def _completed_delivery(message: str) -> tuple[Turn, EmberSession]:
 def test_pending_message_executed_in_background(monkeypatch, session):
     row = store.create_session(session, "sid-123", "/workspace", "main")
 
-    async def mock_deliver(_ember, _cli_session_id, message):
+    async def mock_deliver(_ember, _cli_session_id, message, _model=None):
         return _completed_delivery(message)
 
     monkeypatch.setattr(mcp._transport, "deliver", mock_deliver)
@@ -263,7 +334,7 @@ def test_failed_delivery_clears_reused_ember_session(monkeypatch, session):
     pending = store.create_pending_message(session, row.id, "hello")
     pending_seq = pending.seq
 
-    async def failing_deliver(_ember, _cli_session_id, _message):
+    async def failing_deliver(_ember, _cli_session_id, _message, _model=None):
         raise EmberSessionGone("terminal invoke failure")
 
     monkeypatch.setattr(mcp._transport, "deliver", failing_deliver)
@@ -290,7 +361,7 @@ def test_failed_guest_delivery_does_not_clear_reused_session(monkeypatch, sessio
     session.commit()
     store.create_pending_message(session, row.id, "hello")
 
-    async def failing_deliver(_ember, _cli_session_id, _message):
+    async def failing_deliver(_ember, _cli_session_id, _message, _model=None):
         raise EmberVMTransportError("422 Unprocessable Entity")
 
     monkeypatch.setattr(mcp._transport, "deliver", failing_deliver)
@@ -316,7 +387,7 @@ def test_recreated_ember_session_adopts_new_cli_session_id(monkeypatch, session)
     pending_seq = pending.seq
     new_ember = EmberSession("ember-new", "token-new", 1754035300000)
 
-    async def succeeding_delivery(_ember, _cli_session_id, _message):
+    async def succeeding_delivery(_ember, _cli_session_id, _message, _model=None):
         return _completed_turn("hello")._replace(session_id="cli-new"), new_ember
 
     async def notify(*args, **kwargs):
@@ -352,7 +423,7 @@ def test_two_sends_are_serialized(monkeypatch, session):
     row = store.create_session(session, "sid-123", "/workspace", "main")
     execution_order = []
 
-    async def fake_deliver(_ember, _cli_session_id, message):
+    async def fake_deliver(_ember, _cli_session_id, message, _model=None):
         execution_order.append(message)
         await asyncio.sleep(0.01)
         return _completed_delivery(message)
@@ -390,7 +461,7 @@ def test_concurrent_replicas_execute_pending_message_once(monkeypatch, session):
     )  # capture before expire_all(); the row is deleted on completion
     executions: list[str] = []
 
-    async def fake_deliver(_ember, _cli_session_id, message):
+    async def fake_deliver(_ember, _cli_session_id, message, _model=None):
         executions.append(message)
         await asyncio.sleep(0.01)
         return _completed_delivery(message)

--- a/projects/monolith/agent_sessions/models.py
+++ b/projects/monolith/agent_sessions/models.py
@@ -14,6 +14,7 @@ class AgentSession(SQLModel, table=True):
     local_session_id: str = Field(unique=True)
     workspace: str
     branch: str
+    model: str | None = Field(default=None)
     cli_session_id: str | None = Field(
         default=None
     )  # Claude CLI session_id for resumption
@@ -41,6 +42,7 @@ class AgentTurn(SQLModel, table=True):
     session_id: int = Field(foreign_key="agent_sessions.agent_sessions.id", index=True)
     seq: int = Field(index=True)
     prompt: str
+    model: str | None = Field(default=None)
     voice_summary: str | None = Field(default=None)
     result_text: str
     terminal_reason: str | None = Field(default=None)
@@ -63,6 +65,7 @@ class PendingMessage(SQLModel, table=True):
     session_id: int = Field(foreign_key="agent_sessions.agent_sessions.id", index=True)
     seq: int
     message_text: str
+    model: str | None = Field(default=None)
     claimed_by_replica: str | None = Field(default=None)
     claimed_at: datetime | None = Field(default=None)  # For lease expiry detection
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -16,10 +16,17 @@ logger = logging.getLogger(__name__)
 
 
 def create_session(
-    session: Session, local_session_id: str, workspace: str, branch: str
+    session: Session,
+    local_session_id: str,
+    workspace: str,
+    branch: str,
+    model: str | None = None,
 ) -> AgentSession:
     row = AgentSession(
-        local_session_id=local_session_id, workspace=workspace, branch=branch
+        local_session_id=local_session_id,
+        workspace=workspace,
+        branch=branch,
+        model=model,
     )
     session.add(row)
     session.commit()
@@ -89,10 +96,12 @@ def create_turn(
     usage: dict | None,
     cost_usd: float | None,
     cli_session_id: str | None = None,
+    model: str | None = None,
 ) -> AgentTurn:
     row = AgentTurn(
         session_id=session_id,
         seq=seq,
+        model=model,
         prompt=prompt,
         voice_summary=voice_summary,
         result_text=result_text,
@@ -144,7 +153,7 @@ def get_turn(session: Session, session_id: int, turn_seq: int) -> AgentTurn | No
 
 
 def create_pending_message(
-    session: Session, session_id: int, message_text: str
+    session: Session, session_id: int, message_text: str, model: str | None = None
 ) -> PendingMessage:
     """Enqueue a message durably and return its per-session turn sequence.
 
@@ -175,6 +184,7 @@ def create_pending_message(
             row = PendingMessage(
                 session_id=session_id,
                 seq=seq,
+                model=model,
                 message_text=message_text,
             )
             session.add(row)
@@ -277,6 +287,7 @@ def persist_turn_from_pending_sync(
     voice_summary: str,
     status: str,
     cli_session_id: str | None = None,
+    model: str | None = None,
 ) -> AgentTurn:
     """Persist the result of a queued message using a fresh database session."""
     with Session(get_engine()) as session:
@@ -298,6 +309,7 @@ def persist_turn_from_pending_sync(
             usage,
             turn.total_cost_usd,
             cli_session_id,
+            model,
         )
         # The guest-reported CLI session_id is authoritative for this VM.
         if cli_session_id:
@@ -343,6 +355,7 @@ def mark_turn_error_sync(session_id: int, turn_seq: int, error_msg: str) -> None
             commit_sha=None,
             usage={},
             cost_usd=0.0,
+            model=row.model,
         )
         update_session_status(session, session_id, "warn", error_summary)
         # Delete the pending row to stop infinite retries

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -66,6 +66,7 @@ class ShimTransport(Protocol):
         ember: EmberSession | None,
         cli_session_id: str | None,
         message: str,
+        model: str | None = None,
     ) -> tuple[Turn, EmberSession]: ...
 
 
@@ -159,6 +160,7 @@ class EmberVmShimTransport:
         ember: EmberSession | None,
         cli_session_id: str | None,
         message: str,
+        model: str | None = None,
     ) -> tuple[Turn, EmberSession]:
         """Execute one turn on the guest session and return the result.
 
@@ -185,9 +187,10 @@ class EmberVmShimTransport:
         async def invoke(
             current: EmberSession, current_cli_session_id: str | None
         ) -> Turn:
-            body = json.dumps(
-                {"message": message, "session_id": current_cli_session_id}
-            )
+            payload = {"message": message, "session_id": current_cli_session_id}
+            if model is not None:
+                payload["model"] = model
+            body = json.dumps(payload)
             url = f"{EMBERVM_URL}/v1/sessions/{current.session_id}/invoke"
             headers = {
                 "Authorization": f"Bearer {current.session_token}",

--- a/projects/monolith/agent_sessions/transport_test.py
+++ b/projects/monolith/agent_sessions/transport_test.py
@@ -107,6 +107,26 @@ def test_deliver_uses_ember_identity_and_cli_id_in_body(monkeypatch):
     assert used == ember
 
 
+def test_deliver_includes_model_when_present(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        return _turn_response(request)
+
+    _client(monkeypatch, handler)
+    asyncio.run(
+        transport.EmberVmShimTransport().deliver(
+            transport.EmberSession("s1", "t1", None), "cli-1", "hello", "fable"
+        )
+    )
+    assert json.loads(requests[0].content) == {
+        "message": "hello",
+        "session_id": "cli-1",
+        "model": "fable",
+    }
+
+
 def test_deliver_recreates_reused_stale_session_once(monkeypatch):
     requests = []
     responses = [410, 200]

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.412
+version: 0.285.414
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260802090000_agent_sessions_model.sql
+++ b/projects/monolith/chart/migrations/20260802090000_agent_sessions_model.sql
@@ -1,0 +1,3 @@
+ALTER TABLE agent_sessions.agent_sessions ADD COLUMN model TEXT;
+ALTER TABLE agent_sessions.agent_turns ADD COLUMN model TEXT;
+ALTER TABLE agent_sessions.pending_messages ADD COLUMN model TEXT;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:205tRXghv1MmIVIyFl9iU7cO+81LUVLmSHFcyTK8DNs=
+h1:JStoD99RFqi8pYVx8Kc5Ynd8gT3VC/YPCSGLlVcNgD0=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -146,3 +146,4 @@ h1:205tRXghv1MmIVIyFl9iU7cO+81LUVLmSHFcyTK8DNs=
 20260727130000_ember_synthetic_probe.sql h1:754f49Fg/jwQajtoBRd/8XmhknlDS2vInHbGmIwNNcU=
 20260727140000_ember_synthetic_probe_public_grants.sql h1:0RvmzKgBDZ95m8d5g2G4PVesouApxA1VTaJCLgKWi8s=
 20260801080000_agent_sessions_ember_session.sql h1:vNCgkKnCCS36E38kMowaXgillaARAmigysuvWMxLYlo=
+20260802090000_agent_sessions_model.sql h1:bXLzt7RR0ivSsYYSAIbfjQya906/QAEDRjKwCmGS+RM=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.412
+      targetRevision: 0.285.414
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

Adds model routing to the agent-session surface, closing the gap where every MCP session ran the claude default even though the guest shim already routes turns by model.

- `monolith-agent-session-start` takes `model` and pins the session's adapter family (claude/codex/pi).
- `monolith-agent-session-send` takes an optional per-turn `model` within the pinned family; cross-family sends are rejected with an error naming both families. The effective model rides the pending row through the transport invoke body to the guest.
- The shim's claude adapter gains `--model` (opus/sonnet/fable), respawning with `--resume` on a mid-session model change so the transcript carries over. Codex and pi adapters already took a per-turn model.
- An accepted send resets session status to `running`, so status polling can distinguish a turn in flight from a finished one.
- Migration adds nullable `model` columns to `agent_sessions`, `agent_turns`, and `pending_messages`.

## Notes

Chart bumps for monolith and embervm follow before merge, after #4238 lands, to avoid version collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB