### PR TITLE
fix(embervm): put codex and pi CLI state dirs on the writable workspace

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.345
+version: 0.1.347

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.345
+      targetRevision: 0.1.347
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -838,11 +838,17 @@ class CodexProcess:
     def _child_env(self):
         egress_port = os.environ.get(EGRESS_PORT_ENV, str(DEFAULT_EGRESS_PORT))
         proxy_url = "http://%s:%s" % (EGRESS_LOCALHOST, egress_port)
-        home = os.environ.get("HOME", "/root")
+        # The CLI state dir must live under the WORKSPACE, not $HOME: the guest's
+        # $HOME is on the read-only rootfs and the codex CLI refuses to start when
+        # CODEX_HOME does not exist (observed live as a 422 on every codex turn).
+        # The workspace is also where session files must sit for thread resume to
+        # survive bank/relight once workspaces ride the durable volume.
+        codex_home = os.path.join(self.workspace, ".codex")
+        os.makedirs(codex_home, exist_ok=True)
         child_env = os.environ.copy()
         child_env.update(
             {
-                "CODEX_HOME": os.path.join(home, ".codex"),
+                "CODEX_HOME": codex_home,
                 "HTTPS_PROXY": proxy_url,
                 "HTTP_PROXY": proxy_url,
                 "NO_PROXY": "127.0.0.1,localhost",
@@ -992,8 +998,11 @@ class PiProcess:
     def _child_env(self):
         egress_port = os.environ.get(EGRESS_PORT_ENV, str(DEFAULT_EGRESS_PORT))
         proxy_url = "http://%s:%s" % (EGRESS_LOCALHOST, egress_port)
-        home = os.environ.get("HOME", "/root")
-        pi_home = os.path.join(home, ".pi")
+        # Same constraint as the codex adapter: $HOME is read-only rootfs in the
+        # guest, so pi's state dir lives under the writable workspace, which is
+        # also where session files must sit to survive bank/relight.
+        pi_home = os.path.join(self.workspace, ".pi")
+        os.makedirs(os.path.join(pi_home, "agent"), exist_ok=True)
         child_env = os.environ.copy()
         child_env.update(
             {

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -119,7 +119,11 @@ if args_path:
     with open(args_path, "a") as stream:
         json.dump(sys.argv[1:], stream)
         stream.write("\n")
-assert os.environ.get("CODEX_HOME", "").startswith(os.environ.get("HOME", ""))
+# CODEX_HOME must be a writable dir under the WORKSPACE (the child's cwd), not
+# $HOME: the guest's $HOME is read-only rootfs and the real CLI refuses to start
+# when the dir does not exist.
+assert os.environ.get("CODEX_HOME", "") == os.path.join(os.getcwd(), ".codex")
+assert os.path.isdir(os.environ["CODEX_HOME"])
 assert "--skip-git-repo-check" in sys.argv
 assert "--model" in sys.argv
 assert "--config" in sys.argv


### PR DESCRIPTION
Live tri-CLI validation caught this: every codex-family turn 422'd because CODEX_HOME pointed under the guest's read-only-rootfs $HOME, which cannot exist, and the codex CLI refuses to start without it. Both codex and pi state dirs now live under the writable workspace, which is also where session files must sit for thread resume to survive bank/relight once workspaces ride the durable lineage volume (#4091).

Found by the live validation of the model-routing plumbing (#4238); monolith-side family pinning, per-turn override, and cross-family rejection all validated green in the same run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB