### PR TITLE
fix(embervm): stop banked zombies from saturating the claude-runtime session cap

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.348
+version: 0.1.349

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1193,8 +1193,15 @@ claudeRuntimeWorkload:
     # A session rides its birth base until this expires, then the next invoke
     # 410s onto the current base.
     maxLifetimeSeconds: 21600
-    bankedTtlSeconds: 21600
-    maxSessions: 4
+    # One hour, deliberately far below maxLifetime: a failed or abandoned turn
+    # leaves a banked zombie counting against maxSessions, and at the old 6h
+    # TTL a handful of validation retries saturated the cap (live :session_cap
+    # denials, 2026-08-02). An hour keeps resume convenient without letting
+    # dead sessions squat 4 GiB snapshots and cap slots all day.
+    bankedTtlSeconds: 3600
+    # Live + banked. 8 x ~4 GiB snapshots = 32 GiB worst case on the snapshot
+    # dir, but the 1h banked TTL keeps the steady state far below it.
+    maxSessions: 8
     invokeQueueCap: 4
   invocation:
     # Total duration for a session invoke. CRD maximum is 900s (workload-crd.yaml:868).

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.348
+      targetRevision: 0.1.349
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Live finding from today's tri-CLI validation: claude-runtime allowed 4 sessions (live + banked) and banked zombies from failed turns squatted their slots for the full 6h TTL, so every new session-create denied with :session_cap (the 429s that blocked the qwen leg). Cap goes to 8 and the banked TTL drops to 3600s; the retroactive TTL clears today's zombies on the first sweep after deploy. maxLifetime is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB