### PR TITLE
feat(embervm): wire the codex OpenAI egress lane with a deferred credential (#4244)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.349
+version: 0.1.350

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1125,6 +1125,12 @@ egress:
   #     egressTo: [api.anthropic.com]              # exact hosts, no wildcards
   #     secretRef: {name: <secret>, key: <key>}    # the ONLY delivery path
   #
+  #   - header: Authorization                      # a second provider example
+  #     valuePrefix: "Bearer "
+  #     env: EMBER_OPENAI_API_KEY
+  #     egressTo: [api.openai.com]
+  #     secretRef: {name: <secret>, key: OPENAI_API_KEY}
+  #
   # Nothing here has to match anything in the guest. The guest sends whatever it
   # likes in that header and the sidecar discards it, so there is no byte-identical
   # coupling to keep in sync and a guest cannot authenticate as another account by

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.349
+      targetRevision: 0.1.350
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -258,8 +258,8 @@ warmthS3Gc:
 # claude runtime is the only guest that dials it; every other guest ignores the
 # listener, so this is a lane opening rather than a posture change for the fleet.
 #
-# Phase 6a only: plain allowlist-forward with the split-horizon guardrail. No
-# `secrets` catalog, so no CA is minted and the sidecar never terminates TLS. The
+# Phase 6b: allowlist-forward with the split-horizon guardrail and a
+# credential catalog. No CA is minted and the sidecar never terminates TLS. The
 # public internet is reachable (external: allow) and the cluster is not
 # (internal.default: deny), which is what stops an agent in a guest from reaching
 # in-cluster services.
@@ -300,6 +300,19 @@ egress:
       secretRef:
         name: embervm-embervm-egress
         key: CLAUDE_AUTH_TOKEN
+    # Note: credential field absent (deferred); fails closed until 1Password
+    # operator fills vaults/k8s-homelab/items/litellm-claude-auth. Co-location
+    # caveat: this item is also read by monolith gardener; adding a field is
+    # values-only; separate item would require onepassworditem-egress.yaml
+    # loop (deferred).
+    - header: "Authorization"
+      valuePrefix: "Bearer "
+      env: "EMBER_OPENAI_API_KEY"
+      egressTo:
+        - "api.openai.com"
+      secretRef:
+        name: "embervm-embervm-egress"
+        key: "OPENAI_API_KEY"
   # Shared with the monolith gardener, which reads the same item. Read-only sync,
   # so two consumers is fine; the field label CLAUDE_AUTH_TOKEN becomes the key.
   onepassword:

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -106,6 +106,21 @@ def _cli_privilege_kwargs():
     }
 
 
+def _ensure_cli_dir(path):
+    """Create a CLI state dir the CLI PROCESS can write into.
+
+    The shim may run as root while the CLI is dropped to the runtime uid, so a
+    bare makedirs here leaves a root-owned dir the CLI cannot create subdirs
+    in (observed live: pi dying with EACCES on mkdir /workspace/.pi/sessions).
+    Chown to the same uid/gid the CLI is spawned with whenever the shim is
+    root; a non-root shim already creates dirs the CLI owns.
+    """
+    os.makedirs(path, exist_ok=True)
+    kwargs = _cli_privilege_kwargs()
+    if kwargs:
+        os.chown(path, kwargs["user"], kwargs["group"])
+
+
 def _truncate_ring_for_error(ring, max_len=1500):
     """Truncate the ring buffer for inclusion in an error message."""
     if not ring:
@@ -846,7 +861,7 @@ class CodexProcess:
         # The workspace is also where session files must sit for thread resume to
         # survive bank/relight once workspaces ride the durable volume.
         codex_home = os.path.join(self.workspace, ".codex")
-        os.makedirs(codex_home, exist_ok=True)
+        _ensure_cli_dir(codex_home)
         child_env = os.environ.copy()
         child_env.update(
             {
@@ -1020,7 +1035,8 @@ class PiProcess:
         # guest, so pi's state dir lives under the writable workspace, which is
         # also where session files must sit to survive bank/relight.
         pi_home = os.path.join(self.workspace, ".pi")
-        os.makedirs(os.path.join(pi_home, "agent"), exist_ok=True)
+        _ensure_cli_dir(pi_home)
+        _ensure_cli_dir(os.path.join(pi_home, "agent"))
         child_env = os.environ.copy()
         child_env.update(
             {
@@ -1035,7 +1051,7 @@ class PiProcess:
 
     def _write_model_config(self, pi_home):
         agent_dir = os.path.join(pi_home, "agent")
-        os.makedirs(agent_dir, exist_ok=True)
+        _ensure_cli_dir(agent_dir)
         config = {
             "providers": {
                 "openai-completions": {

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -841,6 +841,8 @@ class CodexProcess:
         # The CLI state dir must live under the WORKSPACE, not $HOME: the guest's
         # $HOME is on the read-only rootfs and the codex CLI refuses to start when
         # CODEX_HOME does not exist (observed live as a 422 on every codex turn).
+        # The config.toml is regenerated per spawn; a stale workspace cannot pin
+        # an old base URL.
         # The workspace is also where session files must sit for thread resume to
         # survive bank/relight once workspaces ride the durable volume.
         codex_home = os.path.join(self.workspace, ".codex")
@@ -849,6 +851,7 @@ class CodexProcess:
         child_env.update(
             {
                 "CODEX_HOME": codex_home,
+                "OPENAI_API_KEY": "ember-guest-login-gate-dummy-not-a-credential",
                 "HTTPS_PROXY": proxy_url,
                 "HTTP_PROXY": proxy_url,
                 "NO_PROXY": "127.0.0.1,localhost",
@@ -856,9 +859,24 @@ class CodexProcess:
         )
         return child_env
 
+    @staticmethod
+    def _write_model_config(codex_home):
+        config = """model_provider = "ember-openai"
+
+[model_providers.ember-openai]
+name = "ember-openai"
+base_url = "http://api.openai.com/v1"
+env_key = "OPENAI_API_KEY"
+wire_api = "responses"
+"""
+        with open(os.path.join(codex_home, "config.toml"), "w") as stream:
+            stream.write(config)
+
     def _spawn(self, message, session_id, model):
         if not os.path.isdir(self.workspace):
             raise StartupError("workspace does not exist: %s" % self.workspace)
+        child_env = self._child_env()
+        self._write_model_config(child_env["CODEX_HOME"])
         model_name, effort = CODEX_MODELS.get(model, CODEX_MODELS[DEFAULT_CODEX_MODEL])
         if session_id:
             command = [self.executable, "exec", "resume", session_id, message]
@@ -883,7 +901,7 @@ class CodexProcess:
             cwd=self.workspace,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            env=self._child_env(),
+            env=child_env,
             **_cli_privilege_kwargs(),
         )
         output_queue = queue.Queue()

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -124,6 +124,12 @@ if args_path:
 # when the dir does not exist.
 assert os.environ.get("CODEX_HOME", "") == os.path.join(os.getcwd(), ".codex")
 assert os.path.isdir(os.environ["CODEX_HOME"])
+assert os.environ.get("OPENAI_API_KEY", "")
+config_path = os.path.join(os.environ["CODEX_HOME"], "config.toml")
+assert os.path.isfile(config_path)
+config = open(config_path).read()
+assert 'model_provider = "ember-openai"' in config
+assert 'base_url = "http://api.openai.com/v1"' in config
 assert "--skip-git-repo-check" in sys.argv
 assert "--model" in sys.argv
 assert "--config" in sys.argv


### PR DESCRIPTION
Everything from #4244 except the secret value. The egress catalog gains an api.openai.com entry (same Authorization/Bearer injection shape as the Anthropic leg); with the 1Password field absent the sidecar keeps the entry dead and DENIES api.openai.com rather than tunneling, so the deferred state is fail-closed. The shim writes a per-spawn CODEX_HOME/config.toml pinning an ember-openai provider at the cleartext base URL so codex traffic rides the injectable lane (the TLS/CONNECT path bypasses injection by design), and sets a dummy OPENAI_API_KEY so the CLI emits the header the proxy swaps.

To activate later: add an OPENAI_API_KEY field to vaults/k8s-homelab/items/litellm-claude-auth. No code change needed. The config.toml shape (model_provider, model_providers.base_url/env_key/wire_api) is verified against the codex rust-v0.146.0 tagged config.schema.json; the first live turn after the token lands remains the end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB