### PR TITLE
fix(embervm): make egress credential secretKeyRefs optional

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.350
+version: 0.1.351

--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -390,11 +390,16 @@ containers:
       {{- range $s := $ctx.Values.egress.secrets }}
       # secretRef ONLY. There is deliberately no literal-value branch: a chart that
       # accepts an inline credential is a chart someone eventually commits one to.
+      # optional: a catalog entry whose secret FIELD does not exist yet is the
+      # supported deferred state (the sidecar keeps the entry dead and DENIES its
+      # hosts); without optional the kubelet fails container creation on the
+      # missing key and wedges the brick roll (observed live, 0.1.350).
       - name: {{ $s.env }}
         valueFrom:
           secretKeyRef:
             name: {{ $s.secretRef.name }}
             key: {{ $s.secretRef.key }}
+            optional: true
       {{- end }}
       {{- end }}
     {{- if $ctx.Values.egress.ca.enabled }}

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.350
+      targetRevision: 0.1.351
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
The 0.1.350 roll wedged on the first brick wave with CreateContainerConfigError: the deferred OpenAI catalog entry references a secret key that deliberately does not exist yet, and a non-optional secretKeyRef fails container creation at the kubelet layer. The fail-closed analysis held for the proxy (an empty env keeps the entry dead and its hosts denied) but missed the layer below it. optional: true on the egress secret envs makes the absent-field state deploy cleanly with identical proxy semantics. This is also what ember_semgrep's red health check is: the wedged 2gi brick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB