### PR TITLE
fix(embervm): ship pi's theme and wasm assets beside the vendored binary

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -694,6 +694,13 @@ multiarch_http_file(
     arm64_url = "https://github.com/earendil-works/pi/releases/download/v0.83.0/pi-linux-arm64.tar.gz",
     binary_name = "pi",
     extract_path = "pi/pi",
+    # The Bun-compiled binary loads its theme JSONs and wasm sidecar relative
+    # to argv0 (observed live: ENOENT /usr/local/bin/theme/dark.json killed
+    # every guest turn), so ship them beside it.
+    extract_extra_paths = [
+        "pi/theme",
+        "pi/photon_rs_bg.wasm",
+    ],
     package_dir = "/usr/local/bin",
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -693,7 +693,6 @@ multiarch_http_file(
     arm64_sha256 = "b84f9016610c738dd9440df62f649880dbe9951db97a7ae936cbf292850e9802",
     arm64_url = "https://github.com/earendil-works/pi/releases/download/v0.83.0/pi-linux-arm64.tar.gz",
     binary_name = "pi",
-    extract_path = "pi/pi",
     # The Bun-compiled binary loads its theme JSONs and wasm sidecar relative
     # to argv0 (observed live: ENOENT /usr/local/bin/theme/dark.json killed
     # every guest turn), so ship them beside it.
@@ -701,6 +700,7 @@ multiarch_http_file(
         "pi/theme",
         "pi/photon_rs_bg.wasm",
     ],
+    extract_path = "pi/pi",
     package_dir = "/usr/local/bin",
 )
 

--- a/bazel/tools/http/multiarch_http_file.bzl
+++ b/bazel/tools/http/multiarch_http_file.bzl
@@ -37,41 +37,59 @@ filegroup(
     package_dir = repository_ctx.attr.package_dir
     repo_name = repository_ctx.name
 
+    # Extra archive paths (dirs or files) shipped beside the binary. Each is
+    # symlinked into the repo as <arch>_extra_<i> and copied into package_dir
+    # under its basename, so a release whose binary loads assets relative to
+    # argv0 (e.g. pi's theme/ JSONs) works from the image.
+    extras = repository_ctx.attr.extract_extra_paths
+
+    def _extra_srcs(arch):
+        return "".join([', "%s_extra_%d"' % (arch, i) for i in range(len(extras))])
+
+    def _extra_cmds(arch):
+        lines = []
+        for i, path in enumerate(extras):
+            base = path.rstrip("/").split("/")[-1]
+            lines.append("        cp -LR $(location :%s_extra_%d) tmp/%s/%s" % (arch, i, package_dir, base))
+        return "\n".join(lines)
+
     if repository_ctx.attr.amd64_url:
         build_content += """
 # Create tar directly with genrule to control the exact structure
 genrule(
     name = "tar_amd64",
-    srcs = ["amd64_binary"],
+    srcs = ["amd64_binary"{extra_srcs}],
     outs = ["tar_amd64.tar"],
     cmd = '''
         mkdir -p tmp/{package_dir}
-        cp $< tmp/{package_dir}/{binary_name}
+        cp $(location :amd64_binary) tmp/{package_dir}/{binary_name}
         chmod 0755 tmp/{package_dir}/{binary_name}
+{extra_cmds}
         tar -C tmp -czf $@ .
     ''',
     visibility = ["//visibility:public"],
 )
 
-""".format(package_dir = package_dir, binary_name = binary_name)
+""".format(package_dir = package_dir, binary_name = binary_name, extra_srcs = _extra_srcs("amd64"), extra_cmds = _extra_cmds("amd64"))
 
     if repository_ctx.attr.arm64_url:
         build_content += """
 # Create tar directly with genrule to control the exact structure
 genrule(
     name = "tar_arm64",
-    srcs = ["arm64_binary"],
+    srcs = ["arm64_binary"{extra_srcs}],
     outs = ["tar_arm64.tar"],
     cmd = '''
         mkdir -p tmp/{package_dir}
-        cp $< tmp/{package_dir}/{binary_name}
+        cp $(location :arm64_binary) tmp/{package_dir}/{binary_name}
         chmod 0755 tmp/{package_dir}/{binary_name}
+{extra_cmds}
         tar -C tmp -czf $@ .
     ''',
     visibility = ["//visibility:public"],
 )
 
-""".format(package_dir = package_dir, binary_name = binary_name)
+""".format(package_dir = package_dir, binary_name = binary_name, extra_srcs = _extra_srcs("arm64"), extra_cmds = _extra_cmds("arm64"))
 
     # Add alias for the main target
     if repository_ctx.attr.amd64_url:
@@ -112,6 +130,8 @@ alias(
                 sha256 = repository_ctx.attr.amd64_sha256,
             )
             repository_ctx.symlink("amd64_extract/" + extract_path, "amd64_binary")
+            for i, extra in enumerate(repository_ctx.attr.extract_extra_paths):
+                repository_ctx.symlink("amd64_extract/" + extra.rstrip("/"), "amd64_extra_%d" % i)
         else:
             repository_ctx.download(
                 url = repository_ctx.attr.amd64_url,
@@ -128,6 +148,8 @@ alias(
                 sha256 = repository_ctx.attr.arm64_sha256,
             )
             repository_ctx.symlink("arm64_extract/" + extract_path, "arm64_binary")
+            for i, extra in enumerate(repository_ctx.attr.extract_extra_paths):
+                repository_ctx.symlink("arm64_extract/" + extra.rstrip("/"), "arm64_extra_%d" % i)
         else:
             repository_ctx.download(
                 url = repository_ctx.attr.arm64_url,
@@ -158,6 +180,11 @@ multiarch_http_file = repository_rule(
         "package_dir": attr.string(
             default = "/usr/local/bin",
             doc = "Directory to place the binary in the image",
+        ),
+        "extract_extra_paths": attr.string_list(
+            doc = "Archive-relative paths (dirs or files) copied into " +
+                  "package_dir beside the binary, each under its basename. " +
+                  "Only meaningful with extract_path.",
         ),
         "extract_path": attr.string(
             doc = "When set, the URLs are archives; extract and use the file at " +

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.351
+version: 0.1.352

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.351
+      targetRevision: 0.1.352
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.340
+version: 0.89.341
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.341
+version: 0.89.342
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.341
+      targetRevision: 0.89.342
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.340
+      targetRevision: 0.89.341
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.415
+version: 0.285.416
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.416
+version: 0.285.417
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.416
+      targetRevision: 0.285.417
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.415
+      targetRevision: 0.285.416
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Third layer of the qwen guest onion: with the state-dir ownership fixed, pi dies at theme init because the Bun binary loads theme/dark.json relative to argv0 and the vendor shipped only the bare binary. multiarch_http_file gains an extract_extra_paths attr (archive-relative dirs/files copied into package_dir under their basenames) and the pi vendor ships pi/theme plus the photon wasm sidecar. Verified: the generated tar contains /usr/local/bin/theme/dark.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB