### PR TITLE
fix(embervm): surface empty guest CLI event streams with the stderr ring (#4252)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.353
+version: 0.1.354

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.353
+      targetRevision: 0.1.354
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -845,6 +845,8 @@ class CodexProcess:
         self.session_id = None
         self.turn_lock = threading.Lock()
         self.process_lock = threading.Lock()
+        self.stderr_lines = collections.deque(maxlen=5)
+        self._stderr_thread = None
 
     def ready(self):
         with self.process_lock:
@@ -926,12 +928,26 @@ wire_api = "responses"
         threading.Thread(
             target=self._pump_codex_stdout, args=(process, output_queue), daemon=True
         ).start()
-        threading.Thread(
+        self.stderr_lines = collections.deque(maxlen=5)
+        self._stderr_thread = threading.Thread(
             target=ClaudeProcess._pump_stderr,
-            args=(self, process, collections.deque(maxlen=5)),
+            args=(self, process, self.stderr_lines),
             daemon=True,
-        ).start()
+        )
+        self._stderr_thread.start()
         return process, output_queue
+
+    def _empty_stream_error(self, process):
+        code = process.poll()
+        if code is None:
+            code = process.wait()
+        if self._stderr_thread is not None:
+            self._stderr_thread.join(timeout=1)
+        error_msg = "codex exited before turn.completed, exit code %s" % code
+        stderr = _truncate_ring_for_error(self.stderr_lines)
+        if stderr:
+            error_msg += "\nCLI stderr:\n%s" % stderr
+        return RuntimeError(error_msg)
 
     @staticmethod
     def _pump_codex_stdout(process, output_queue):
@@ -963,8 +979,7 @@ wire_api = "responses"
                         % TURN_READ_TIMEOUT
                     ) from exc
                 if raw is None:
-                    code = process.poll()
-                    raise RuntimeError("codex crashed during turn, exit code %s" % code)
+                    raise self._empty_stream_error(process)
                 try:
                     event = json.loads(raw.decode("utf-8"))
                 except (UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -1023,6 +1038,8 @@ class PiProcess:
         self.session_id = None
         self.turn_lock = threading.Lock()
         self.process_lock = threading.Lock()
+        self.stderr_lines = collections.deque(maxlen=5)
+        self._stderr_thread = None
 
     def ready(self):
         with self.process_lock:
@@ -1116,12 +1133,26 @@ class PiProcess:
             args=(process, output_queue),
             daemon=True,
         ).start()
-        threading.Thread(
+        self.stderr_lines = collections.deque(maxlen=5)
+        self._stderr_thread = threading.Thread(
             target=ClaudeProcess._pump_stderr,
-            args=(self, process, collections.deque(maxlen=5)),
+            args=(self, process, self.stderr_lines),
             daemon=True,
-        ).start()
+        )
+        self._stderr_thread.start()
         return process, output_queue
+
+    def _empty_stream_error(self, process):
+        code = process.poll()
+        if code is None:
+            code = process.wait()
+        if self._stderr_thread is not None:
+            self._stderr_thread.join(timeout=1)
+        error_msg = "pi exited before agent_end, exit code %s" % code
+        stderr = _truncate_ring_for_error(self.stderr_lines)
+        if stderr:
+            error_msg += "\nCLI stderr:\n%s" % stderr
+        return RuntimeError(error_msg)
 
     def turn(self, message, session_id=None, model=DEFAULT_PI_MODEL):
         with self.turn_lock:
@@ -1146,8 +1177,7 @@ class PiProcess:
                         % TURN_READ_TIMEOUT
                     ) from exc
                 if raw is None:
-                    code = process.poll()
-                    raise RuntimeError("pi crashed during turn, exit code %s" % code)
+                    raise self._empty_stream_error(process)
                 try:
                     event = json.loads(raw.decode("utf-8"))
                 except (UnicodeDecodeError, json.JSONDecodeError) as exc:

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -178,6 +178,20 @@ print(json.dumps({"type": "agent_end", "messages": []}), flush=True)
 """
 
 
+FAKE_EMPTY_CODEX_CLI = r"""#!/usr/bin/env python3
+import sys
+
+print("codex empty event stream", file=sys.stderr, flush=True)
+"""
+
+
+FAKE_EMPTY_PI_CLI = r"""#!/usr/bin/env python3
+import sys
+
+print("pi empty event stream", file=sys.stderr, flush=True)
+"""
+
+
 def test_fake_cli_fixture_syntax_is_valid():
     """Verify the FAKE_CLI embedded script is valid Python."""
     ast.parse(FAKE_CLI)
@@ -217,6 +231,34 @@ def _pi_manager(tmp_path, monkeypatch):
     monkeypatch.setenv("FAKE_PI_ARGS", str(tmp_path / "pi-args.jsonl"))
     monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
     return shim.PiProcess(str(workspace), str(executable))
+
+
+def _manager_with_empty_cli(tmp_path, monkeypatch, cli, process_type):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    executable = tmp_path / "empty-cli"
+    executable.write_text(cli)
+    os.chmod(executable, 0o755)
+    monkeypatch.setattr(shim.os, "geteuid", lambda: 1000)
+    return process_type(str(workspace), str(executable))
+
+
+def test_pi_empty_event_stream_raises_error(tmp_path, monkeypatch):
+    manager = _manager_with_empty_cli(
+        tmp_path, monkeypatch, FAKE_EMPTY_PI_CLI, shim.PiProcess
+    )
+    with pytest.raises(RuntimeError, match="pi empty event stream") as exc_info:
+        manager.turn("hello", model="qwen")
+    assert "exit code 0" in str(exc_info.value)
+
+
+def test_codex_empty_event_stream_raises_error(tmp_path, monkeypatch):
+    manager = _manager_with_empty_cli(
+        tmp_path, monkeypatch, FAKE_EMPTY_CODEX_CLI, shim.CodexProcess
+    )
+    with pytest.raises(RuntimeError, match="codex empty event stream") as exc_info:
+        manager.turn("hello", model="luna")
+    assert "exit code 0" in str(exc_info.value)
 
 
 def test_pi_first_turn_returns_text_session_and_usage(tmp_path, monkeypatch):


### PR DESCRIPTION
Robustness half of #4252: a guest CLI that exits without producing its terminal event now errors with the exit code and stderr ring instead of persisting an empty success (observed live: qwen turns with empty result_text, status warn, cost 0, and no error anywhere in monolith, CP, or guest console). Applies to both the pi and codex adapters. The pi model reference and models.json were verified against the pi 0.83 docs and are correct as-is, so the first live turn after this deploys names the actual root cause in the turn error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB