### PR TITLE
fix(embervm): surface pi provider errorMessage on textless terminal events (#4252)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.354
+version: 0.1.355

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.354
+      targetRevision: 0.1.355
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -1213,6 +1213,34 @@ class PiProcess:
                                     if item.get("type") == "text"
                                 )
                                 break
+                    if not result_text:
+                        # A textless terminal event is an ERROR, never an empty
+                        # success: pi normalizes provider failures into the
+                        # assistant message's errorMessage (docs/custom-provider.md),
+                        # and live turns persisted blank records with no error
+                        # anywhere. Surface the errorMessage when present, else
+                        # the raw terminal event, so the cause reaches the turn
+                        # record instead of vanishing.
+                        error_detail = ""
+                        for message_event in reversed(event.get("messages", [])):
+                            if message_event.get("errorMessage"):
+                                error_detail = str(message_event["errorMessage"])
+                                break
+                        if not error_detail:
+                            error_detail = (
+                                "terminal event carried no text: %s"
+                                % (json.dumps(event)[:1500])
+                            )
+                        stderr = _truncate_ring_for_error(self.stderr_lines)
+                        if stderr:
+                            error_detail += "\nCLI stderr:\n%s" % stderr
+                        # Reap before raising: the success path hands the child
+                        # to a reaper thread, and skipping that here leaks a
+                        # zombie the PID-1 orphan reaper must not touch.
+                        CodexProcess._reap_process(process)
+                        raise RuntimeError(
+                            "pi turn produced no output: %s" % error_detail
+                        )
                     record = {
                         "result": result_text,
                         "terminal_reason": terminal_reason,

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -167,6 +167,14 @@ for flag in ("--no-context-files", "--no-extensions", "--no-skills", "--no-promp
     assert flag in sys.argv
 assert sys.argv[sys.argv.index("--tools") + 1] == "read,bash,edit,write"
 assert "End every response with a single line" in sys.argv[sys.argv.index("--system-prompt") + 1]
+if os.environ.get("FAKE_PI_MODE") == "provider-error":
+    print(json.dumps({"type": "session", "id": "pi-session", "version": 3}), flush=True)
+    print(json.dumps({"type": "agent_end", "messages": [{
+        "role": "assistant",
+        "content": [],
+        "errorMessage": "connect ECONNREFUSED inference.inference.svc.cluster.local:8080"
+    }]}), flush=True)
+    sys.exit(0)
 print(json.dumps({"type": "session", "id": "pi-session", "version": 3}), flush=True)
 print(json.dumps({"type": "message_end", "message": {
     "role": "assistant",
@@ -268,6 +276,17 @@ def test_pi_first_turn_returns_text_session_and_usage(tmp_path, monkeypatch):
     assert record["session_id"] == "pi-session"
     assert "input_tokens" in record["usage"]
     manager._close_process()
+
+
+def test_pi_textless_terminal_event_surfaces_error_message(tmp_path, monkeypatch):
+    # A provider failure arrives as errorMessage on a textless assistant
+    # message (pi docs/custom-provider.md); it must become a turn ERROR, not
+    # an empty success (live turns persisted blank records, #4252).
+    monkeypatch.setenv("FAKE_PI_MODE", "provider-error")
+    manager = _pi_manager(tmp_path, monkeypatch)
+    with pytest.raises(RuntimeError) as excinfo:
+        manager.turn("hello", model="qwen")
+    assert "ECONNREFUSED" in str(excinfo.value)
 
 
 def test_pi_resume_uses_session_flag(tmp_path, monkeypatch):


### PR DESCRIPTION
Second half of #4252: the empty-stream guard from #4253 correctly did not fire because pi emits events; the terminal assistant message carries a provider errorMessage with zero text, which the parser summed to an empty string and returned as success. A textless terminal event now raises carrying the errorMessage (or the raw terminal event when absent) plus the stderr ring, and reaps the child on the error path. Regression test drives the fake pi in provider-error mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB