### PR TITLE
fix(monolith): surface the guest error response body in transport errors

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.342
+version: 0.89.343
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.342
+      targetRevision: 0.89.343
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -25,6 +25,24 @@ from shared.k8s_auth import auth_headers
 
 logger = logging.getLogger(__name__)
 
+
+def _status_error_detail(exc: httpx.HTTPStatusError) -> str:
+    """The status line PLUS a bounded slice of the response body.
+
+    The guest shim reports WHY a turn failed in the error response body
+    (e.g. pi's provider errorMessage); persisting only the httpx status
+    line hid every root cause behind a bare 422 (#4252).
+    """
+    detail = str(exc)
+    try:
+        body = exc.response.text.strip()
+    except Exception:  # noqa: BLE001 - body read must never mask the error
+        body = ""
+    if body:
+        detail += "\nresponse body: " + body[:1500]
+    return detail
+
+
 # The control plane base URL, set on the monolith deployment (chart
 # templates/deployment.yaml). Read at import exactly like
 # faas/embervm_client.py does, so both clients resolve it the same way. The
@@ -150,7 +168,7 @@ class EmberVmShimTransport:
             raise EmberVMTimeout(str(exc)) from exc
         except httpx.HTTPStatusError as exc:
             logger.warning("embervm session creation failed: %s", exc)
-            raise EmberVMTransportError(str(exc)) from exc
+            raise EmberVMTransportError(_status_error_detail(exc)) from exc
         except httpx.TransportError as exc:
             logger.warning("embervm session creation transport error: %s", exc)
             raise EmberVMTransportError(str(exc)) from exc
@@ -243,9 +261,13 @@ class EmberVmShimTransport:
             return await invoke(ember, cli_session_id), ember
         except httpx.HTTPStatusError as exc:
             if created or exc.response.status_code not in (403, 410):
-                raise EmberVMTransportError(str(exc)) from exc
+                raise EmberVMTransportError(_status_error_detail(exc)) from exc
             ember = await self.create_session()
             try:
                 return await invoke(ember, None), ember
             except (httpx.HTTPStatusError, EmberVMTransportError) as retry_exc:
+                if isinstance(retry_exc, httpx.HTTPStatusError):
+                    raise EmberSessionGone(
+                        _status_error_detail(retry_exc)
+                    ) from retry_exc
                 raise EmberSessionGone(str(retry_exc)) from retry_exc

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.417
+version: 0.285.418
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.417
+      targetRevision: 0.285.418
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Closes the last visibility gap in #4252's chain: the shim reports the real failure (pi's provider errorMessage) in its error response body, but the transport persisted only the httpx status line, so turn records showed a bare 422. HTTPStatusError conversions append a bounded body slice; the next failed qwen turn's record names the actual provider error. Monolith-only, so deploying it does not roll the embervm fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB