### PR TITLE
fix(embervm): point the pi qwen alias at the real served model name (#4252)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.355
+version: 0.1.356

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.355
+      targetRevision: 0.1.356
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -41,7 +41,10 @@ CLAUDE_MODELS = {
 }
 DEFAULT_CODEX_MODEL = "luna"
 PI_MODELS = {
-    "qwen": "qwen-plus",  # vLLM endpoint serves OpenAI Chat Completions API
+    # Must match the vLLM --served-model-name (projects/inference/deploy/
+    # values.yaml); a wrong name 404s at the provider ("The model does not
+    # exist"), proven live in #4252.
+    "qwen": "qwen3.6-27b",
 }
 DEFAULT_PI_MODEL = "qwen"
 MAX_REQUEST_BODY_BYTES = 1 << 20

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -162,7 +162,7 @@ if args_path:
         stream.write("\n")
 assert "--provider" in sys.argv
 assert sys.argv[sys.argv.index("--provider") + 1] == "openai-completions"
-assert sys.argv[sys.argv.index("--model") + 1] == "qwen-plus"
+assert sys.argv[sys.argv.index("--model") + 1] == "qwen3.6-27b"
 for flag in ("--no-context-files", "--no-extensions", "--no-skills", "--no-prompt-templates"):
     assert flag in sys.argv
 assert sys.argv[sys.argv.index("--tools") + 1] == "read,bash,edit,write"


### PR DESCRIPTION
The final layer of #4252, in pi's own words at last: {"message":"The model `qwen-plus` does not exist."}. The adapter's model id was invented; the in-cluster vLLM serves --served-model-name qwen3.6-27b (projects/inference/deploy/values.yaml). One-line fix plus the fake-CLI assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB