### PR TITLE
feat(monolith): surface the token broker device-code login in chat (ADR 048, #4250 PR 2)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.356
+version: 0.1.357

--- a/projects/embervm/chart/templates/tokenbroker-networkpolicy.yaml
+++ b/projects/embervm/chart/templates/tokenbroker-networkpolicy.yaml
@@ -24,6 +24,15 @@ spec:
     - fromEntities:
         - host
         - health
+    # The monolith's agent surface proxies the device-code login flow
+    # (/grants/<name>/login/*) so a login can be kicked off from a chat and
+    # the code surfaced in the tool response (ADR 048, #4250 PR 2).
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monolith
+            app.kubernetes.io/name: monolith
+            app.kubernetes.io/component: app
+      toPorts: [{ ports: [{ port: "8080", protocol: TCP }] }]
   egress:
     # Cilium's toFQDNs proxy only learns rotating provider IPs when DNS is
     # allowed with the L7 dns rule. Keep this rule ahead of the FQDN rule.

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.356
+      targetRevision: 0.1.357
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.343
+version: 0.89.344
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.343
+      targetRevision: 0.89.344
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import platform
+import re
 from uuid import uuid4
 
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session
+
+import httpx
 
 import agent.api as agent_api
 from agent_sessions import store, voice
@@ -520,3 +524,70 @@ async def monolith_agent_detail(session_id: int, turn: int | None = None) -> dic
         "model": selected.model,
         "activities": _activities(selected),
     }
+
+
+# -- token broker login (ADR 048, #4250 PR 2) --------------------------------
+
+BROKER_URL_ENV = "EMBER_TOKENBROKER_URL"
+_DEFAULT_GRANT = "codex-cluster"
+_GRANT_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+
+
+def _broker_url() -> str:
+    url = os.environ.get(BROKER_URL_ENV, "")
+    if not url:
+        raise ValueError("token broker is not configured")
+    return url.rstrip("/")
+
+
+def _grant_or_raise(grant: str) -> str:
+    # The grant rides a URL path and names a Kubernetes Secret suffix.
+    if not _GRANT_NAME_RE.fullmatch(grant):
+        raise ValueError(f"invalid grant name {grant!r}")
+    return grant
+
+
+async def _broker_request(method: str, path: str) -> dict:
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.request(method, _broker_url() + path)
+        resp.raise_for_status()
+        return resp.json()
+
+
+@mcp.tool
+async def monolith_codex_broker_login_start(grant: str = _DEFAULT_GRANT) -> dict:
+    """Begin the token broker device-code login for an OAuth grant.
+
+    Returns the verification URL and one-time user code to approve in any
+    browser. The broker polls until the grant is approved and persists the
+    token bundle durably. Never share a device code with anyone.
+
+    Args:
+        grant: Grant name registered in the broker. Defaults to codex-cluster.
+    """
+    grant = _grant_or_raise(grant)
+    data = await _broker_request("POST", f"/grants/{grant}/login/start")
+    await agent_api.notify(
+        "codex broker login pending for grant %s. Approve code %s at %s"
+        % (grant, data.get("user_code", "?"), data.get("verification_url", "?")),
+        level="warn",
+    )
+    return data
+
+
+@mcp.tool
+async def monolith_codex_broker_login_status(grant: str = _DEFAULT_GRANT) -> dict:
+    """Report the token broker login state for an OAuth grant.
+
+    Args:
+        grant: Grant name registered in the broker. Defaults to codex-cluster.
+    """
+    grant = _grant_or_raise(grant)
+    data = await _broker_request("GET", f"/grants/{grant}/login/status")
+    if data.get("state") == "granted":
+        await agent_api.notify(
+            "codex broker grant %s is active. The lane refreshes itself from here."
+            % grant,
+            level="info",
+        )
+    return data

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -740,3 +740,53 @@ def test_ember_expires_at_column_is_bigint():
     assert isinstance(column.type, BigInteger), (
         "ember_session_expires_at must map to BigInteger; got %r" % column.type
     )
+
+
+def test_broker_login_start_surfaces_code_and_notifies(monkeypatch):
+    monkeypatch.setenv("EMBER_TOKENBROKER_URL", "http://broker")
+    calls = []
+    notified = []
+
+    async def fake_request(method, path):
+        calls.append((method, path))
+        return {
+            "verification_url": "https://auth/device",
+            "user_code": "ABCD-EFGH",
+            "expires_in": 900,
+        }
+
+    async def fake_notify(message, level="info"):
+        notified.append((message, level))
+
+    monkeypatch.setattr(mcp, "_broker_request", fake_request)
+    monkeypatch.setattr(mcp.agent_api, "notify", fake_notify)
+    result = asyncio.run(mcp.monolith_codex_broker_login_start())
+    assert result["user_code"] == "ABCD-EFGH"
+    assert calls == [("POST", "/grants/codex-cluster/login/start")]
+    assert "ABCD-EFGH" in notified[0][0] and notified[0][1] == "warn"
+
+
+def test_broker_login_status_granted_notifies(monkeypatch):
+    monkeypatch.setenv("EMBER_TOKENBROKER_URL", "http://broker")
+    notified = []
+
+    async def fake_request(method, path):
+        return {"state": "granted", "detail": ""}
+
+    async def fake_notify(message, level="info"):
+        notified.append((message, level))
+
+    monkeypatch.setattr(mcp, "_broker_request", fake_request)
+    monkeypatch.setattr(mcp.agent_api, "notify", fake_notify)
+    result = asyncio.run(mcp.monolith_codex_broker_login_status())
+    assert result["state"] == "granted"
+    assert notified and notified[0][1] == "info"
+
+
+def test_broker_login_rejects_bad_grant_and_unset_url(monkeypatch):
+    monkeypatch.setenv("EMBER_TOKENBROKER_URL", "http://broker")
+    with pytest.raises(ValueError):
+        asyncio.run(mcp.monolith_codex_broker_login_start(grant="../../etc"))
+    monkeypatch.delenv("EMBER_TOKENBROKER_URL")
+    with pytest.raises(ValueError):
+        asyncio.run(mcp.monolith_codex_broker_login_status())

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.418
+version: 0.285.419
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -95,6 +95,12 @@ spec:
             - name: EMBER_SYNTHETIC_BASE_URL
               value: {{ .Values.emberSynthetic.baseUrl | quote }}
             {{- end }}
+            {{- if .Values.tokenBroker.url }}
+            # OAuth token broker (ADR 048): the agent surface proxies its
+            # device-code login flow so a login can run from a chat.
+            - name: EMBER_TOKENBROKER_URL
+              value: {{ .Values.tokenBroker.url | quote }}
+            {{- end }}
             {{- if .Values.faas }}
             # FaaS zip-lane function registry (ADR 045 / embervm R1). The read
             # base is the in-cluster SeaweedFS S3 host noded GETs archives from;

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -750,6 +750,12 @@ jobs:
 emberSynthetic:
   baseUrl: "https://jomcgi.dev"
 
+# OAuth token broker (ADR 048). The agent surface proxies its device-code
+# login endpoints so a grant login can be kicked off from a chat with the
+# code surfaced in the tool response. Empty disables the tools.
+tokenBroker:
+  url: "http://embervm-embervm-tokenbroker.embervm.svc.cluster.local:8080"
+
 frontend:
   otelCollectorUrl: ""
   image:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.418
+      targetRevision: 0.285.419
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
PR 2 of #4250. Two MCP tools proxy the broker's login endpoints so the one-time grant login runs from a chat: login-start returns the verification URL and device code directly in the tool response and fires a Discord notify (never share a device code); login-status reports the poll state and notifies once granted. Grant names are slug-validated before riding the URL path. The broker netpol admits the monolith app pods on 8080. Remember the Context Forge schema lag: the new tools reach chat clients after the 10-minute refresh CronJob plus a fresh session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB