### PR TITLE
fix(embervm): tolerate string-serialized numbers from the OAuth device endpoint

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.357
+version: 0.1.358

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.357
+      targetRevision: 0.1.358
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/tokenbroker/internal/provider/codexchatgpt/adapter_test.go
+++ b/projects/embervm/tokenbroker/internal/provider/codexchatgpt/adapter_test.go
@@ -19,7 +19,7 @@ func TestDeviceFlowAndExchange(t *testing.T) {
 	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/accounts/deviceauth/usercode":
-			json.NewEncoder(w).Encode(map[string]any{"device_auth_id": "id", "user_code": "code", "interval": 1, "expires_in": 900})
+			json.NewEncoder(w).Encode(map[string]any{"device_auth_id": "id", "user_code": "code", "interval": "1", "expires_in": "900"})
 		case "/api/accounts/deviceauth/token":
 			polls++
 			if polls < 2 {

--- a/projects/embervm/tokenbroker/internal/provider/provider.go
+++ b/projects/embervm/tokenbroker/internal/provider/provider.go
@@ -1,19 +1,39 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"time"
 )
 
 var ErrRefreshTokenReused = errors.New("refresh_token_reused")
 
+// FlexInt tolerates providers that serialize numbers as JSON strings: the
+// live auth.openai.com device endpoint returns interval as "5" (observed on
+// the first real login attempt), which a plain int field refuses.
+type FlexInt int
+
+func (f *FlexInt) UnmarshalJSON(data []byte) error {
+	var n json.Number
+	if err := json.Unmarshal(bytes.Trim(data, `"`), &n); err != nil {
+		return err
+	}
+	v, err := n.Int64()
+	if err != nil {
+		return err
+	}
+	*f = FlexInt(v)
+	return nil
+}
+
 type DeviceCodeResponse struct {
-	DeviceAuthID    string `json:"device_auth_id"`
-	UserCode        string `json:"user_code"`
-	Interval        int    `json:"interval"`
-	VerificationURL string `json:"verification_url"`
-	ExpiresIn       int    `json:"expires_in"`
+	DeviceAuthID    string  `json:"device_auth_id"`
+	UserCode        string  `json:"user_code"`
+	Interval        FlexInt `json:"interval"`
+	VerificationURL string  `json:"verification_url"`
+	ExpiresIn       FlexInt `json:"expires_in"`
 }
 
 type AuthorizationCodeResponse struct {
@@ -26,7 +46,7 @@ type TokenResponse struct {
 	IDToken      string    `json:"id_token"`
 	AccessToken  string    `json:"access_token"`
 	RefreshToken string    `json:"refresh_token"`
-	ExpiresIn    int       `json:"expires_in"`
+	ExpiresIn    FlexInt   `json:"expires_in"`
 	ExpiresAt    time.Time `json:"-"`
 	Error        string    `json:"error"`
 }


### PR DESCRIPTION
The broker's first live round trip to auth.openai.com proved the whole egress chain (DNS rule, FQDN proxy, netpol) and found one wire truth: the device endpoint serializes interval as the string "5". FlexInt tolerates string-or-number across the device and token responses; the fake OAuth server now serves string numbers to lock the regression. Unblocks the one-time grant login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB