### PR TITLE
feat(embervm): session-volume hardening gating the persistence flip (#4241)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.358
+version: 0.1.359

--- a/projects/embervm/chart/crds/workload-crd.yaml
+++ b/projects/embervm/chart/crds/workload-crd.yaml
@@ -295,7 +295,7 @@ spec:
                             the GC bookkeeping (each generation needs its own
                             liveness check rather than one is-this-latest test),
                             so it is a declared bounded scalar and never
-                            "keep everything". solo scope only.
+                            "keep everything".
                           minimum: 0
                           default: 0
                         sizeGi:

--- a/projects/embervm/chart/crds/workload-crd.yaml
+++ b/projects/embervm/chart/crds/workload-crd.yaml
@@ -287,18 +287,6 @@ spec:
                         enabled:
                           type: boolean
                           description: Keep a durable filesystem artifact for this lineage.
-                        scope:
-                          type: string
-                          enum:
-                            - solo
-                            - shared
-                          default: solo
-                          description: >-
-                            `solo` is owned by one lineage. `shared` is readable
-                            by other workloads, which is only coherent BECAUSE
-                            the filesystem tier pins nothing; the memory tier
-                            could never offer it without smuggling placement
-                            constraints into a supposedly opaque blob.
                         retention:
                           type: integer
                           description: >-
@@ -322,8 +310,15 @@ spec:
                         sizeBytes:
                           type: integer
                           format: int64
-                          description: Sparse per-lineage size cap in bytes.
+                          description: >-
+                            Sparse per-lineage size cap in bytes. When both
+                            sizeBytes and sizeGi are set, sizeBytes takes
+                            precedence; they must not describe different caps.
                           minimum: 1
+                        mountPath:
+                          type: string
+                          default: /session
+                          description: Guest mount path for the durable workspace.
                 session:
                   type: object
                   description: >-

--- a/projects/embervm/chart/templates/workload-claude-runtime.yaml
+++ b/projects/embervm/chart/templates/workload-claude-runtime.yaml
@@ -35,9 +35,9 @@ spec:
     memory: false
     filesystem:
       enabled: true
-      scope: solo
       retention: 1
       sizeBytes: {{ .Values.claudeRuntimeWorkload.workspaceSizeBytes }}
+      mountPath: /session
   {{- end }}
   source:
     image:

--- a/projects/embervm/control/lib/embervm/node_registry.ex
+++ b/projects/embervm/control/lib/embervm/node_registry.ex
@@ -99,6 +99,7 @@ defmodule Embervm.NodeRegistry do
     ServingSnapshot,
     ServingVm,
     SessionSnapshot,
+    SessionVolume,
     SessionVm,
     StatefulBundle,
     StatefulVm,
@@ -676,6 +677,7 @@ defmodule Embervm.NodeRegistry do
       # them (wire-compatible), which reads as "no session state, no disk pressure".
       session_vms: session_vms_from_status(s),
       session_snapshots: session_snapshots_from_status(s),
+      session_volumes: session_volumes_from_status(s),
       snapshot_disk_free_bytes: s.snapshot_disk_free_bytes,
       snapshot_disk_used_bytes: s.snapshot_disk_used_bytes,
       # Serving facts (R3): the node's LIVE serving VMs (with the daemon's health
@@ -931,6 +933,15 @@ defmodule Embervm.NodeRegistry do
   end
 
   defp session_snapshots_from_status(_s), do: []
+
+  defp session_volumes_from_status(%NodeStatus{session_volumes: volumes}) when is_list(volumes) do
+    for %SessionVolume{} = volume <- volumes do
+      %{workload: volume.workload, lineage_id: volume.lineage_id,
+        size_bytes: volume.size_bytes, allocated_bytes: volume.allocated_bytes}
+    end
+  end
+
+  defp session_volumes_from_status(_s), do: []
 
   # The node's CPUID vendor for restore-on-miss vendor keying (R7, ADR embervm/011).
   # Prefers the richer CpuSku.vendor (field 28) when the daemon reports it, falls

--- a/projects/embervm/control/lib/embervm/s3_warmth_gc.ex
+++ b/projects/embervm/control/lib/embervm/s3_warmth_gc.ex
@@ -99,9 +99,9 @@ defmodule Embervm.S3WarmthGc do
   # (4-segment) key layout.
   @vendors ["amd", "intel"]
 
-  # The ONLY prefixes this GC may ever touch. base/ (base retention owns it),
-  # session/, serving/, and volume/ are hard-excluded by not being here.
-  @allowlist ["stateful/", "group_set/"]
+  # The ONLY prefixes this GC may ever touch. Each rule is explicit: base/,
+  # session/, serving/, and volume/ remain hard-excluded.
+  @allowlist ["stateful/", "group_set/", "session-workspace/"]
 
   # -- Client API --------------------------------------------------------------
 

--- a/projects/embervm/control/lib/embervm/s3_warmth_gc.ex
+++ b/projects/embervm/control/lib/embervm/s3_warmth_gc.ex
@@ -101,7 +101,7 @@ defmodule Embervm.S3WarmthGc do
 
   # The ONLY prefixes this GC may ever touch. Each rule is explicit: base/,
   # session/, serving/, and volume/ remain hard-excluded.
-  @allowlist ["stateful/", "group_set/", "session-workspace/"]
+  @allowlist ["stateful/", "group_set/"]
 
   # -- Client API --------------------------------------------------------------
 

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -90,6 +90,10 @@ defmodule Embervm.SessionManager do
   # that cannot bank must not squat live capacity forever.
   @bank_fail_limit 3
 
+  # NodeCapacity.updated_at is stamped from a monotonic clock. Keep its freshness
+  # gate in that domain instead of comparing it with session row wall-clock times.
+  @fleet_freshness_window_ms 120_000
+
   # -- Client API ------------------------------------------------------------
 
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -188,6 +192,7 @@ defmodule Embervm.SessionManager do
       capacity_table: Keyword.get(opts, :capacity_table, NodeCapacity.table()),
       catalog_table: Keyword.get(opts, :catalog_table, WorkloadCatalog.table()),
       clock: Keyword.get(opts, :clock, &default_clock/0),
+      monotonic_clock: Keyword.get(opts, :monotonic_clock, fn -> System.monotonic_time(:millisecond) end),
       quota_table: Keyword.get(opts, :quota_table, Embervm.Metering.table()),
       quota_config: Keyword.get(opts, :quota_config, Embervm.Metering.quota_config()),
       # Injected for tests; production uses the real claim/prime/channel seams.
@@ -274,6 +279,8 @@ defmodule Embervm.SessionManager do
       # only bite under the node_confirmed_destroy gate.
       destroying_alarm_ms: Keyword.get(opts, :destroying_alarm_ms, 300_000),
       orphan_grace_ms: Keyword.get(opts, :orphan_grace_ms, 60_000),
+      fleet_freshness_window_ms: Keyword.get(opts, :fleet_freshness_window_ms, @fleet_freshness_window_ms),
+      orphan_volume_first_seen: %{},
       # Ids already alarmed for being stuck in destroying, so the error logs once
       # per stuck id rather than every reconcile tick (pruned as ids terminalize).
       destroying_alarmed: MapSet.new(),
@@ -412,15 +419,6 @@ defmodule Embervm.SessionManager do
         {:noreply, state}
       _ -> {:noreply, state}
     end
-  end
-
-  def handle_info({:registry_sweep_retry, supervisor, spec, attempts}, state) do
-    case start_child_over_registry_sweep(supervisor, spec, attempts) do
-      {:ok, _pid} -> :ok
-      {:error, reason} -> Logger.warning("embervm session registry retry failed", reason: inspect(reason))
-      _ -> :ok
-    end
-    {:noreply, state}
   end
 
   # The async bank worker finished: complete the durable transition + failure
@@ -696,14 +694,15 @@ defmodule Embervm.SessionManager do
   # bank->relight (or adoption restart) can land here while a DEAD pid still holds
   # the key and spuriously fail the session. Retry over that window for a dead
   # holder only; a LIVE holder is a genuine double start and is surfaced as-is.
+  # The async variant was reverted because it lost the continuation that starts the session.
   defp start_child_over_registry_sweep(supervisor, spec, attempts \\ 10) do
     case DynamicSupervisor.start_child(supervisor, spec) do
       {:error, {:already_started, pid}} = error ->
         if Process.alive?(pid) or attempts <= 1 do
           error
         else
-          Process.send_after(self(), {:registry_sweep_retry, supervisor, spec, attempts - 1}, 10)
-          {:error, :registry_retry_scheduled}
+          Process.sleep(10)
+          start_child_over_registry_sweep(supervisor, spec, attempts - 1)
         end
 
       other ->
@@ -2351,31 +2350,56 @@ defmodule Embervm.SessionManager do
   end
 
   # Raw session workspaces are node facts, not snapshot warmth. Retire them so
-  # the node exports to S3 before removing the local copy. Use the freshest fact
-  # for each node and require its report to be newer than the row (or older than
-  # the orphan grace when the row is absent), avoiding stale-fact deletion.
+  # the node exports to S3 before removing the local copy. NodeCapacity freshness
+  # and row age use their respective clock domains; first-seen grace protects
+  # create-in-flight windows when the row is absent.
   defp retire_orphan_session_volumes(state, facts, nodes_facts) do
-    for f <- facts, volume <- Map.get(f, :session_volumes, []) || [], reduce: state do
-      acc ->
-        case SessionStore.get(acc.session_store, volume.lineage_id) do
+    monotonic_now = state.monotonic_clock.()
+    wall_now = state.clock.()
+
+    reported =
+      for f <- facts, volume <- Map.get(f, :session_volumes, []) || [], into: MapSet.new() do
+        {f.configured_id, volume.lineage_id}
+      end
+
+    first_seen =
+      state.orphan_volume_first_seen
+      |> Enum.filter(fn {key, _} -> MapSet.member?(reported, key) end)
+      |> Map.new()
+
+    state = %{state | orphan_volume_first_seen: first_seen}
+
+    Enum.reduce(facts, state, fn f, acc ->
+      fact = Map.get(nodes_facts, f.configured_id, f)
+      fact_updated = Map.get(fact, :updated_at, 0)
+      fact_current = monotonic_now - fact_updated <= acc.fleet_freshness_window_ms
+
+      Enum.reduce(Map.get(f, :session_volumes, []) || [], acc, fn volume, inner ->
+        key = {f.configured_id, volume.lineage_id}
+
+        case SessionStore.get(inner.session_store, volume.lineage_id) do
           {:ok, %{workload: workload, state: session_state}}
               when workload == volume.workload and session_state not in [:expired, :evicted, :destroyed, :failed] ->
-            acc
+            %{inner | orphan_volume_first_seen: Map.delete(inner.orphan_volume_first_seen, key)}
 
-          row ->
-            fact_updated = Map.get(Map.get(nodes_facts, f.configured_id, f), :updated_at, 0)
-            row_updated = if match?({:ok, _}, row), do: elem(row, 1).updated_at, else: fact_updated
-            if state.clock.() - row_updated >= state.orphan_grace_ms and
-                 fact_updated >= row_updated do
-              # retire_session_volume spawns fire-and-forget and returns :ok,
-              # never state; the reduce must keep threading acc.
-              _ = retire_session_volume(acc, %{volume_node_id: f.configured_id, workload: volume.workload, session_id: volume.lineage_id})
-              acc
-            else
-              acc
+          {:ok, %{state: session_state, updated_at: row_updated}}
+              when session_state in [:expired, :evicted, :destroyed, :failed] ->
+            inner = %{inner | orphan_volume_first_seen: Map.delete(inner.orphan_volume_first_seen, key)}
+            if fact_current and wall_now - row_updated >= inner.orphan_grace_ms do
+              _ = retire_session_volume(inner, %{volume_node_id: f.configured_id, workload: volume.workload, session_id: volume.lineage_id})
             end
+            inner
+
+          _ ->
+            seen = Map.get(inner.orphan_volume_first_seen, key, monotonic_now)
+            inner = %{inner | orphan_volume_first_seen: Map.put(inner.orphan_volume_first_seen, key, seen)}
+            if fact_current and monotonic_now - seen >= inner.orphan_grace_ms do
+              _ = retire_session_volume(inner, %{volume_node_id: f.configured_id, workload: volume.workload, session_id: volume.lineage_id})
+            end
+            inner
         end
-    end
+      end)
+    end)
   end
 
   # -- sweep: expiry, banked-TTL GC, disk-pressure eviction (Task 7) ---------
@@ -3004,6 +3028,10 @@ defmodule Embervm.SessionManager do
         end
 
       case result do
+        {:ok, %{skipped: true}} ->
+          Logger.warning("embervm drain archive skipped, lineage still attached",
+            workload: workload, lineage_id: lineage_id, node_id: node_id)
+          {:error, :archive_skipped}
         {:ok, _} -> :ok
         other ->
           Logger.warning("embervm session workspace archive failed; keeping volume",

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -192,6 +192,7 @@ defmodule Embervm.SessionManager do
       quota_config: Keyword.get(opts, :quota_config, Embervm.Metering.quota_config()),
       # Injected for tests; production uses the real claim/prime/channel seams.
       claim_fun: Keyword.get(opts, :claim_fun, &default_claim/3),
+      id_fun: Keyword.get(opts, :id_fun),
       channel_fun: Keyword.get(opts, :channel_fun, &Embervm.NodeChannel.get/1),
       prime_fun: Keyword.get(opts, :prime_fun, &default_prime/2),
       # Daemon session verb seams (Bank/Relight/EvictSnapshot). Injected for tests;
@@ -413,6 +414,15 @@ defmodule Embervm.SessionManager do
     end
   end
 
+  def handle_info({:registry_sweep_retry, supervisor, spec, attempts}, state) do
+    case start_child_over_registry_sweep(supervisor, spec, attempts) do
+      {:ok, _pid} -> :ok
+      {:error, reason} -> Logger.warning("embervm session registry retry failed", reason: inspect(reason))
+      _ -> :ok
+    end
+    {:noreply, state}
+  end
+
   # The async bank worker finished: complete the durable transition + failure
   # recovery on this (serialized) process. See finish_bank.
   def handle_info({:bank_done, session_id, node_id, outcome}, state) do
@@ -446,7 +456,7 @@ defmodule Embervm.SessionManager do
                          "ember.principal" => principal
                        }
                      } do
-      minted_lineage_id = Embervm.SessionId.new(state.clock.())
+      minted_lineage_id = mint_lineage_id(state)
       result =
         with {:ok, entry} <- fetch_session_workload(state, workload),
              :ok <- check_session_cap(state, workload, entry),
@@ -572,6 +582,10 @@ defmodule Embervm.SessionManager do
   defp persistence_enabled_workload?(%{persistence: %{memory: false, filesystem: %{enabled: true}}}), do: true
   defp persistence_enabled_workload?(_), do: false
 
+  defp mint_lineage_id(%{id_fun: fun}) when is_function(fun, 0), do: fun.()
+  defp mint_lineage_id(%{id_fun: fun, clock: clock}) when is_function(fun, 1), do: fun.(clock.())
+  defp mint_lineage_id(state), do: Embervm.SessionId.new(state.clock.())
+
   defp prime(state, node_id, snapshot_ref, entry, lineage_id) do
     with {:ok, channel} <- state.channel_fun.(node_id),
          {:ok, %PrimeResponse{vm_id: vm_id}} when is_binary(vm_id) and vm_id != "" <-
@@ -592,7 +606,7 @@ defmodule Embervm.SessionManager do
       req = %PrimeRequest{
         trace: %Trace{},
         snapshot_ref: snapshot_ref || "",
-        volume_mount: if(enabled, do: "/session", else: ""),
+        volume_mount: if(enabled, do: Map.get(fs, :mount_path, "/session"), else: ""),
         volume_size_bytes: if(enabled, do: Map.get(fs, :size_bytes, 0), else: 0),
         lineage_id: if(enabled, do: lineage_id, else: "")
       }
@@ -688,8 +702,8 @@ defmodule Embervm.SessionManager do
         if Process.alive?(pid) or attempts <= 1 do
           error
         else
-          Process.sleep(10)
-          start_child_over_registry_sweep(supervisor, spec, attempts - 1)
+          Process.send_after(self(), {:registry_sweep_retry, supervisor, spec, attempts - 1}, 10)
+          {:error, :registry_retry_scheduled}
         end
 
       other ->
@@ -1868,6 +1882,7 @@ defmodule Embervm.SessionManager do
       end)
 
     state = evict_orphan_snapshots(state, facts)
+    state = retire_orphan_session_volumes(state, facts, nodes_facts)
 
     # Fail-closed reconciliation toward destruction (ADR embervm/014 decision 5),
     # gated: re-drive stuck destroying sessions (Direction 1 completion + alarm) and
@@ -2333,6 +2348,34 @@ defmodule Embervm.SessionManager do
     end
 
     state
+  end
+
+  # Raw session workspaces are node facts, not snapshot warmth. Retire them so
+  # the node exports to S3 before removing the local copy. Use the freshest fact
+  # for each node and require its report to be newer than the row (or older than
+  # the orphan grace when the row is absent), avoiding stale-fact deletion.
+  defp retire_orphan_session_volumes(state, facts, nodes_facts) do
+    for f <- facts, volume <- Map.get(f, :session_volumes, []) || [], reduce: state do
+      acc ->
+        case SessionStore.get(acc.session_store, volume.lineage_id) do
+          {:ok, %{workload: workload, state: session_state}}
+              when workload == volume.workload and session_state not in [:expired, :evicted, :destroyed, :failed] ->
+            acc
+
+          row ->
+            fact_updated = Map.get(Map.get(nodes_facts, f.configured_id, f), :updated_at, 0)
+            row_updated = if match?({:ok, _}, row), do: elem(row, 1).updated_at, else: fact_updated
+            if state.clock.() - row_updated >= state.orphan_grace_ms and
+                 fact_updated >= row_updated do
+              # retire_session_volume spawns fire-and-forget and returns :ok,
+              # never state; the reduce must keep threading acc.
+              _ = retire_session_volume(acc, %{volume_node_id: f.configured_id, workload: volume.workload, session_id: volume.lineage_id})
+              acc
+            else
+              acc
+            end
+        end
+    end
   end
 
   # -- sweep: expiry, banked-TTL GC, disk-pressure eviction (Task 7) ---------
@@ -2983,7 +3026,7 @@ defmodule Embervm.SessionManager do
   # durable, while the control plane advances the session lifecycle immediately.
   defp retire_session_volume(state, %{volume_node_id: node_id, workload: workload, session_id: lineage_id})
        when is_binary(node_id) and is_binary(workload) and is_binary(lineage_id) do
-    if persistence_enabled_workload?(session_workload_entry(state, workload)) do
+    if persistence_enabled_workload?(session_workload_entry(state, workload)) or session_workload_entry(state, workload) == %{} do
       req = %RetireVolumeRequest{trace: %Trace{workload: workload}, workload: workload, lineage_id: lineage_id}
       retire_fun = state.retire_volume_fun
       channel_fun = state.channel_fun

--- a/projects/embervm/control/lib/embervm/workload_watcher.ex
+++ b/projects/embervm/control/lib/embervm/workload_watcher.ex
@@ -822,16 +822,17 @@ defmodule Embervm.WorkloadWatcher do
 
   defp parse_persistence(spec, "session", _workload_name) do
     case Map.get(spec, "persistence") do
-      nil -> %{memory: true, filesystem: %{enabled: false, scope: "solo", retention: 0, size_bytes: 0}}
+      nil -> %{memory: true, filesystem: %{enabled: false, retention: 0, size_bytes: 0, mount_path: "/session"}}
       p when is_map(p) ->
         fs = Map.get(p, "filesystem") || %{}
         size_bytes = Map.get(fs, "sizeBytes") ||
           (Map.get(fs, "sizeGi") && Map.get(fs, "sizeGi") * 1_073_741_824) || 0
         %{memory: Map.get(p, "memory", true), filesystem: %{
-          enabled: Map.get(fs, "enabled", false), scope: Map.get(fs, "scope", "solo"),
-          retention: Map.get(fs, "retention", 0), size_bytes: size_bytes
+          enabled: Map.get(fs, "enabled", false),
+          retention: Map.get(fs, "retention", 0), size_bytes: size_bytes,
+          mount_path: Map.get(fs, "mountPath", "/session")
         }}
-      _ -> %{memory: true, filesystem: %{enabled: false, scope: "solo", retention: 0, size_bytes: 0}}
+      _ -> %{memory: true, filesystem: %{enabled: false, retention: 0, size_bytes: 0, mount_path: "/session"}}
     end
   end
 

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -769,6 +769,72 @@ defmodule Embervm.SessionManagerTest do
     assert session.state == :running
   end
 
+  test "orphan session volume with no row is retired after grace" do
+    parent = self()
+    ctx = start_stack(
+      orphan_grace_ms: 0,
+      retire_volume_fun: fn _ch, req -> send(parent, {:retired, req.lineage_id}); {:ok, %{}} end
+    )
+    NodeCapacity.put(ctx.cap_table, "node-4", %{
+      node_id: "node-4",
+      configured_id: "node-4",
+      workloads: %{},
+      session_vms: [],
+      session_snapshots: [],
+      session_volumes: [%{workload: "wl-ghost", lineage_id: "s-orphan-lineage", size_bytes: 1}],
+      live_vms: 0,
+      max_live_vms: 8,
+      draining: false,
+      updated_at: 5_000_000
+    })
+
+    :ok = SessionManager.reconcile(ctx.mgr)
+    assert_receive {:retired, "s-orphan-lineage"}, 1_000
+  end
+
+  test "parked session's reported volume is not retired" do
+    parent = self()
+    ctx = start_stack(
+      orphan_grace_ms: 0,
+      prime_fun: fake_prime_fun("vm-volfact"),
+      channel_fun: fake_channel_fun(),
+      retire_volume_fun: fn _ch, req -> send(parent, {:retired, req.lineage_id}); {:ok, %{}} end
+    )
+    created = create_persistence_session(ctx)
+    park_session(ctx, created)
+    sid = created.session_id
+    {:ok, fact} = NodeCapacity.fetch(ctx.cap_table, "node-4")
+    NodeCapacity.put(ctx.cap_table, "node-4", Map.put(fact, :session_volumes, [
+      %{workload: "wl-persist", lineage_id: sid, size_bytes: 1}
+    ]))
+
+    :ok = SessionManager.reconcile(ctx.mgr)
+    refute_receive {:retired, ^sid}, 300
+  end
+
+  test "orphan session volume inside the grace window is left alone" do
+    parent = self()
+    ctx = start_stack(
+      orphan_grace_ms: 60_000_000,
+      retire_volume_fun: fn _ch, req -> send(parent, {:retired, req.lineage_id}); {:ok, %{}} end
+    )
+    NodeCapacity.put(ctx.cap_table, "node-4", %{
+      node_id: "node-4",
+      configured_id: "node-4",
+      workloads: %{},
+      session_vms: [],
+      session_snapshots: [],
+      session_volumes: [%{workload: "wl-ghost", lineage_id: "s-young-lineage", size_bytes: 1}],
+      live_vms: 0,
+      max_live_vms: 8,
+      draining: false,
+      updated_at: 5_000_000
+    })
+
+    :ok = SessionManager.reconcile(ctx.mgr)
+    refute_receive {:retired, _}, 300
+  end
+
   test "parked_session_expires_on_ttl" do
     ctx = start_stack(prime_fun: fake_prime_fun("vm-expire"), channel_fun: fake_channel_fun())
     created = create_persistence_session(ctx, max_lifetime_seconds: -1)

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -96,7 +96,8 @@ defmodule Embervm.SessionManagerTest do
         registry: registry,
         capacity_table: cap_table,
         catalog_table: cat_table,
-        clock: fn -> 5_000_000 end,
+        clock: Keyword.get(opts, :clock, fn -> 5_000_000 end),
+        monotonic_clock: Keyword.get(opts, :monotonic_clock, fn -> -800_000 end),
         channel_fun: Keyword.get(opts, :channel_fun, fake_channel_fun()),
         claim_fun: Keyword.get(opts, :claim_fun, fn _d, _n, _w -> {:ok, "vm-primed-#{suffix}"} end),
         prime_fun: Keyword.get(opts, :prime_fun, fn _ch, _req -> {:error, :no_prime} end),
@@ -769,10 +770,12 @@ defmodule Embervm.SessionManagerTest do
     assert session.state == :running
   end
 
-  test "orphan session volume with no row is retired after grace" do
+  test "orphan session volume with no row gets first-seen grace" do
     parent = self()
+    {:ok, mono} = Agent.start_link(fn -> -800_000 end)
     ctx = start_stack(
-      orphan_grace_ms: 0,
+      orphan_grace_ms: 60_000,
+      monotonic_clock: fn -> Agent.get(mono, & &1) end,
       retire_volume_fun: fn _ch, req -> send(parent, {:retired, req.lineage_id}); {:ok, %{}} end
     )
     NodeCapacity.put(ctx.cap_table, "node-4", %{
@@ -785,11 +788,36 @@ defmodule Embervm.SessionManagerTest do
       live_vms: 0,
       max_live_vms: 8,
       draining: false,
-      updated_at: 5_000_000
+      updated_at: -800_000
     })
 
     :ok = SessionManager.reconcile(ctx.mgr)
+    refute_receive {:retired, "s-orphan-lineage"}, 300
+    Agent.update(mono, &(&1 + 60_001))
+    :ok = SessionManager.reconcile(ctx.mgr)
     assert_receive {:retired, "s-orphan-lineage"}, 1_000
+  end
+
+  test "terminal orphan session volume retires on wall-clock row age" do
+    parent = self()
+    ctx = start_stack(
+      orphan_grace_ms: 60_000,
+      store_clock: fn -> 4_000_000 end,
+      retire_volume_fun: fn _ch, req -> send(parent, {:retired, req.lineage_id}); {:ok, %{}} end
+    )
+    {:ok, session} = SessionStore.create(ctx.store, %{
+      tenant: "homelab", principal: "p1", workload: "wl-failed", node_id: "node-4",
+      vm_id: "vm-failed", base_snapshot_ref: "base", base_digest: "digest", expires_at: 9_999_999
+    })
+    assert {:ok, _} = SessionStore.transition(ctx.store, session.session_id, :fail, :session_failed, %{}, %{})
+    NodeCapacity.put(ctx.cap_table, "node-4", %{
+      node_id: "node-4", configured_id: "node-4", workloads: %{}, session_vms: [], session_snapshots: [],
+      session_volumes: [%{workload: "wl-failed", lineage_id: session.session_id, size_bytes: 1}],
+      live_vms: 0, max_live_vms: 8, draining: false, updated_at: -800_000
+    })
+    :ok = SessionManager.reconcile(ctx.mgr)
+    session_id = session.session_id
+    assert_receive {:retired, ^session_id}, 1_000
   end
 
   test "parked session's reported volume is not retired" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.358
+      targetRevision: 0.1.359
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/server/registry.go
+++ b/projects/embervm/noded/server/registry.go
@@ -28,6 +28,7 @@ type vmEntry struct {
 	id           string
 	workload     string
 	snapshotRef  string
+	lineageID    string
 	handle       substrate.Handle
 	egressCancel func()
 
@@ -137,6 +138,18 @@ func (r *vmRegistry) capacity() (primedPerWorkload map[string][]string, live int
 	return primedPerWorkload, len(r.vms)
 }
 
+func (r *vmRegistry) lineageVMIDs() map[string]struct{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[string]struct{})
+	for _, e := range r.vms {
+		if e.lineageID != "" {
+			out[e.id] = struct{}{}
+		}
+	}
+	return out
+}
+
 // liveCount is the current number of supervised VMs, for the node-level backstop
 // cap check in Prime.
 func (r *vmRegistry) liveCount() int {
@@ -180,6 +193,7 @@ type sessionEntry struct {
 	vmID        string
 	sessionID   string
 	workload    string
+	lineageID   string
 	snapshotRef string // the base ref it was relit/primed from (for correlation)
 	handle      substrate.Handle
 	// egressCancel stops this VM's egress forwarder (ADR 023 phase 6a). Never

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -1015,10 +1015,17 @@ func (s *Server) Prime(ctx context.Context, req *nodev1.PrimeRequest) (*nodev1.P
 	}
 	rtCancel()
 
+	if req.GetLineageId() != "" {
+		if err := s.volumes.AttachLineage(base.workload, req.GetLineageId(), h.ID); err != nil {
+			s.reap(h, func() {})
+			return nil, status.Errorf(codes.FailedPrecondition, "noded: attach session volume: %v", err)
+		}
+	}
 	s.vms.add(&vmEntry{
 		id:           h.ID,
 		workload:     base.workload,
 		snapshotRef:  ref,
+		lineageID:    req.GetLineageId(),
 		handle:       h,
 		egressCancel: s.startEgress(uds, h.ID, base.workload),
 		state:        vmPrimed,
@@ -1055,6 +1062,9 @@ func (s *Server) Assign(ctx context.Context, req *nodev1.AssignRequest) (*nodev1
 	// is never Released twice.
 	defer func() {
 		if removed := s.vms.remove(vmID); removed != nil {
+			if removed.lineageID != "" {
+				s.volumes.DetachLineage(removed.workload, removed.lineageID)
+			}
 			s.reap(removed.handle, removed.egressCancel)
 		}
 		s.signalChange()
@@ -1131,6 +1141,9 @@ func (s *Server) Assign(ctx context.Context, req *nodev1.AssignRequest) (*nodev1
 // not happen (ADR embervm/014 decision 5).
 func (s *Server) Destroy(_ context.Context, req *nodev1.DestroyRequest) (*nodev1.DestroyResponse, error) {
 	if e := s.vms.remove(req.GetVmId()); e != nil {
+		if e.lineageID != "" {
+			s.volumes.DetachLineage(e.workload, e.lineageID)
+		}
 		if err := s.reap(e.handle, e.egressCancel); err != nil {
 			return nil, status.Errorf(codes.Internal, "noded: reap vm %q: %v", req.GetVmId(), err)
 		}
@@ -1140,6 +1153,9 @@ func (s *Server) Destroy(_ context.Context, req *nodev1.DestroyRequest) (*nodev1
 	// A session VM destroyed out of band (e.g. the control plane tearing down a
 	// suspect or terminal session) lives in the distinct session registry.
 	if e := s.sessionVMs.remove(req.GetVmId()); e != nil {
+		if e.lineageID != "" {
+			s.volumes.DetachLineage(e.workload, e.lineageID)
+		}
 		if err := s.reap(e.handle, e.egressCancel); err != nil {
 			return nil, status.Errorf(codes.Internal, "noded: reap session vm %q: %v", req.GetVmId(), err)
 		}
@@ -1199,6 +1215,7 @@ func (s *Server) adoptPrimedSession(vmID, sessionID, workload string) (*sessionE
 		vmID:        ve.id,
 		sessionID:   sessionID,
 		workload:    workload,
+		lineageID:   ve.lineageID,
 		snapshotRef: ve.snapshotRef,
 		handle:      ve.handle,
 		// Inherit the forwarder Prime opened for this physical VM. Only the
@@ -1341,6 +1358,9 @@ func (s *Server) Bank(ctx context.Context, req *nodev1.BankRequest) (*nodev1.Ban
 	}
 	// Destroy the VM: the session releases its live capacity and holds only disk.
 	if removed := s.sessionVMs.remove(vmID); removed != nil {
+		if removed.lineageID != "" {
+			s.volumes.DetachLineage(removed.workload, removed.lineageID)
+		}
 		s.reap(removed.handle, removed.egressCancel)
 	}
 	s.sessionSnap.add(sessionSnapshotEntry{
@@ -1726,6 +1746,7 @@ func (s *Server) nodeStatus() *nodev1.NodeStatus {
 		BuildError:            s.bases.firstBuildError(),
 		SessionVms:            sessionVMs,
 		SessionSnapshots:      snaps,
+		SessionVolumes:        s.sessionVolumesStatus(),
 		SnapshotDiskFreeBytes: freeBytes,
 		SnapshotDiskUsedBytes: usedBytes,
 		ServingVms:            servingVMs,
@@ -2126,6 +2147,30 @@ func (s *Server) sessionSnapshotsStatus() []*nodev1.SessionSnapshot {
 		})
 	}
 	return out
+}
+
+func (s *Server) sessionVolumesStatus() []*nodev1.SessionVolume {
+	if s.volumes == nil {
+		return nil
+	}
+	inventory, err := s.volumes.ScanSessions()
+	if err != nil {
+		s.logger.Warn("noded: scan session volumes", "err", err)
+		return nil
+	}
+	out := make([]*nodev1.SessionVolume, 0, len(inventory))
+	for _, v := range inventory {
+		out = append(out, &nodev1.SessionVolume{Workload: v.Workload, LineageId: v.LineageID, SizeBytes: v.SizeBytes, AllocatedBytes: v.AllocatedBytes})
+	}
+	return out
+}
+
+func (s *Server) lineageAttached(workload, lineageID string) bool {
+	ids := s.vms.lineageVMIDs()
+	for _, e := range s.sessionVMs.snapshot() {
+		ids[e.vmID] = struct{}{}
+	}
+	return s.volumes != nil && s.volumes.IsLineageAttached(workload, lineageID, ids)
 }
 
 // workloadCapacities merges the primed vm_ids with base build state per

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -2173,6 +2173,12 @@ func (s *Server) lineageAttached(workload, lineageID string) bool {
 	return s.volumes != nil && s.volumes.IsLineageAttached(workload, lineageID, ids)
 }
 
+// PruneStaleAttach makes the load-bearing IsLineageAttached cleanup explicit for
+// destructive volume operations. The returned status is intentionally ignored.
+func (s *Server) PruneStaleAttach(workload, lineageID string) {
+	_ = s.lineageAttached(workload, lineageID)
+}
+
 // workloadCapacities merges the primed vm_ids with base build state per
 // workload. Every workload that has a base OR primed VMs gets one entry.
 // free_primed_slots is the count of the primed ids so the two never disagree.

--- a/projects/embervm/noded/server/stateful.go
+++ b/projects/embervm/noded/server/stateful.go
@@ -771,7 +771,9 @@ func (s *Server) DeleteVolume(_ context.Context, req *nodev1.DeleteVolumeRequest
 	}
 	var err error
 	if req.GetLineageId() != "" {
-		_ = s.lineageAttached(workload, req.GetLineageId())
+		// Deliberately prune stale attachment records before DeleteSession. Removing
+		// this call strands crashed lineages forever.
+		s.PruneStaleAttach(workload, req.GetLineageId())
 		err = s.volumes.DeleteSession(workload, req.GetLineageId())
 	} else {
 		err = s.volumes.Delete(workload)

--- a/projects/embervm/noded/server/stateful.go
+++ b/projects/embervm/noded/server/stateful.go
@@ -771,6 +771,7 @@ func (s *Server) DeleteVolume(_ context.Context, req *nodev1.DeleteVolumeRequest
 	}
 	var err error
 	if req.GetLineageId() != "" {
+		_ = s.lineageAttached(workload, req.GetLineageId())
 		err = s.volumes.DeleteSession(workload, req.GetLineageId())
 	} else {
 		err = s.volumes.Delete(workload)
@@ -794,6 +795,10 @@ func (s *Server) ArchiveVolume(ctx context.Context, req *nodev1.ArchiveVolumeReq
 	}
 	if s.volumes == nil {
 		return nil, status.Error(codes.FailedPrecondition, "noded: volume manager not configured")
+	}
+	if s.lineageAttached(req.GetWorkload(), req.GetLineageId()) {
+		s.logger.Warn("noded: skip archive of attached session workspace", "workload", req.GetWorkload(), "lineage_id", req.GetLineageId())
+		return &nodev1.ArchiveVolumeResponse{Skipped: true}, nil
 	}
 	path := s.volumes.SessionVolumePath(req.GetWorkload(), req.GetLineageId())
 	if _, err := os.Stat(path); err != nil {

--- a/projects/embervm/noded/server/store.go
+++ b/projects/embervm/noded/server/store.go
@@ -425,6 +425,9 @@ func (s *Server) RetireVolume(_ context.Context, req *nodev1.RetireVolumeRequest
 	if s.volumes == nil {
 		return nil, status.Error(codes.FailedPrecondition, "noded: volume manager not configured")
 	}
+	if s.lineageAttached(req.GetWorkload(), req.GetLineageId()) {
+		return nil, status.Error(codes.FailedPrecondition, "noded: session workspace is attached to a live VM")
+	}
 	path := s.volumes.SessionVolumePath(req.GetWorkload(), req.GetLineageId())
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {

--- a/projects/embervm/noded/volume/volume.go
+++ b/projects/embervm/noded/volume/volume.go
@@ -58,9 +58,10 @@ type BlessingLease struct {
 type Manager struct {
 	root string
 
-	mu       sync.Mutex
-	attached map[string]attachment
-	leaseMu  sync.Mutex
+	mu              sync.Mutex
+	attached        map[string]attachment
+	lineageAttached map[string]attachment
+	leaseMu         sync.Mutex
 }
 
 // attachment records WHO holds a workload's writable-attach lock. owner is
@@ -75,7 +76,7 @@ type attachment struct {
 // NewManager builds a Manager rooted at root (VolumeRoot). It does not touch
 // disk; callers create the root lazily via Create.
 func NewManager(root string) *Manager {
-	return &Manager{root: root, attached: make(map[string]attachment)}
+	return &Manager{root: root, attached: make(map[string]attachment), lineageAttached: make(map[string]attachment)}
 }
 
 // dir is the per-workload volume directory.
@@ -238,6 +239,48 @@ func (m *Manager) IsAttached(workload string) bool {
 	defer m.mu.Unlock()
 	_, ok := m.attached[workload]
 	return ok
+}
+
+func lineageKey(workload, lineageID string) string { return workload + "\x00" + lineageID }
+
+// AttachLineage records the VM that owns a session workspace. Unlike the
+// stateful workload lock, this key is per lineage so separate sessions never
+// block one another.
+func (m *Manager) AttachLineage(workload, lineageID, vmID string) error {
+	if workload == "" || lineageID == "" || vmID == "" {
+		return fmt.Errorf("volume: workload, lineage and vm required")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := lineageKey(workload, lineageID)
+	if _, ok := m.lineageAttached[key]; ok {
+		return fmt.Errorf("volume: lineage %q is already attached", lineageID)
+	}
+	m.lineageAttached[key] = attachment{owner: vmID, since: time.Now()}
+	return nil
+}
+
+func (m *Manager) DetachLineage(workload, lineageID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.lineageAttached, lineageKey(workload, lineageID))
+}
+
+// IsLineageAttached ignores records whose VM is not in liveVMIDs. This makes
+// teardown crash-tolerant: a daemon restart or an already-reaped VM cannot
+// strand a workspace forever.
+func (m *Manager) IsLineageAttached(workload, lineageID string, liveVMIDs map[string]struct{}) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	a, ok := m.lineageAttached[lineageKey(workload, lineageID)]
+	if !ok {
+		return false
+	}
+	if _, live := liveVMIDs[a.owner]; !live {
+		delete(m.lineageAttached, lineageKey(workload, lineageID))
+		return false
+	}
+	return true
 }
 
 // BumpGeneration increments a workload's generation ledger and returns the new
@@ -610,6 +653,12 @@ func (m *Manager) DeleteSession(workload, lineageID string) error {
 	if m.IsAttached(workload) {
 		return fmt.Errorf("volume: workload %q volume is attached; detach before deleting", workload)
 	}
+	m.mu.Lock()
+	_, attached := m.lineageAttached[lineageKey(workload, lineageID)]
+	m.mu.Unlock()
+	if attached {
+		return fmt.Errorf("volume: lineage %q is attached; detach before deleting", lineageID)
+	}
 	return os.RemoveAll(filepath.Join(m.root, "session", workload, lineageID))
 }
 
@@ -639,6 +688,13 @@ type Inventory struct {
 	AllocatedBytes    uint64
 	Attached          bool
 	GenerationBlessed bool
+}
+
+type SessionInventory struct {
+	Workload       string
+	LineageID      string
+	SizeBytes      uint64
+	AllocatedBytes uint64
 }
 
 // Scan walks VolumeRoot for every workload's volume directory and returns its
@@ -691,4 +747,55 @@ func (m *Manager) Scan() ([]Inventory, error) {
 		})
 	}
 	return out, nil
+}
+
+// ScanSessions reports durable per-lineage workspace files. It deliberately
+// does not require a control-plane row: that is the fact needed to reap leaks
+// created before a session passed the readiness gate.
+func (m *Manager) ScanSessions() ([]SessionInventory, error) {
+	root := filepath.Join(m.root, "session")
+	workloads, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("volume: scan sessions %q: %w", root, err)
+	}
+	var out []SessionInventory
+	for _, w := range workloads {
+		if !w.IsDir() {
+			continue
+		}
+		lineages, err := os.ReadDir(filepath.Join(root, w.Name()))
+		if err != nil {
+			continue
+		}
+		for _, l := range lineages {
+			if !l.IsDir() {
+				continue
+			}
+			path := m.SessionVolumePath(w.Name(), l.Name())
+			fi, err := os.Stat(path)
+			if err != nil || !fi.Mode().IsRegular() {
+				continue
+			}
+			alloc, err := m.sessionAllocatedBytes(path)
+			if err != nil {
+				continue
+			}
+			out = append(out, SessionInventory{Workload: w.Name(), LineageID: l.Name(), SizeBytes: uint64(fi.Size()), AllocatedBytes: alloc})
+		}
+	}
+	return out, nil
+}
+
+func (m *Manager) sessionAllocatedBytes(path string) (uint64, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	if blocks, ok := statBlocks(fi); ok {
+		return uint64(blocks) * 512, nil
+	}
+	return uint64(fi.Size()), nil
 }

--- a/projects/embervm/noded/volume/volume_test.go
+++ b/projects/embervm/noded/volume/volume_test.go
@@ -52,6 +52,28 @@ func TestRetirementIntentIsDurableAndSeparateFromWorkspace(t *testing.T) {
 	}
 }
 
+func TestLineageAttachLifecycleAndStaleSafety(t *testing.T) {
+	m := NewManager(t.TempDir())
+	if err := m.CreateSession("wl", "lineage", 4096); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.AttachLineage("wl", "lineage", "vm-live"); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.DeleteSession("wl", "lineage"); err == nil {
+		t.Fatal("delete should refuse while attached")
+	}
+	if !m.IsLineageAttached("wl", "lineage", map[string]struct{}{"vm-live": {}}) {
+		t.Fatal("live attach missing")
+	}
+	if m.IsLineageAttached("wl", "lineage", map[string]struct{}{}) {
+		t.Fatal("stale attach should be ignored")
+	}
+	if err := m.DeleteSession("wl", "lineage"); err != nil {
+		t.Fatalf("delete after stale attach: %v", err)
+	}
+}
+
 func TestCreateSparseAndGenerationInit(t *testing.T) {
 	dir := t.TempDir()
 	m := NewManager(dir)

--- a/projects/embervm/proto/embervm/node/v1/fakenode/main.go
+++ b/projects/embervm/proto/embervm/node/v1/fakenode/main.go
@@ -58,7 +58,7 @@ func (*fakeServer) BuildBase(_ context.Context, req *nodev1.BuildBaseRequest) (*
 }
 
 func (*fakeServer) Prime(_ context.Context, req *nodev1.PrimeRequest) (*nodev1.PrimeResponse, error) {
-	return &nodev1.PrimeResponse{VmId: "vm:" + req.GetSnapshotRef()}, nil
+	return &nodev1.PrimeResponse{VmId: "vm:" + req.GetLineageId() + ":" + req.GetVolumeMount()}, nil
 }
 
 func (*fakeServer) Assign(_ context.Context, req *nodev1.AssignRequest) (*nodev1.AssignResponse, error) {
@@ -234,9 +234,9 @@ func (*fakeServer) ResolveStateful(_ context.Context, req *nodev1.ResolveStatefu
 	return &nodev1.ResolveStatefulResponse{}, nil
 }
 
-// DeleteVolume is idempotent and returns an empty response for any workload.
-func (*fakeServer) DeleteVolume(_ context.Context, _ *nodev1.DeleteVolumeRequest) (*nodev1.DeleteVolumeResponse, error) {
-	return &nodev1.DeleteVolumeResponse{}, nil
+// DeleteVolume is idempotent and echoes the lineage for round-trip coverage.
+func (*fakeServer) DeleteVolume(_ context.Context, req *nodev1.DeleteVolumeRequest) (*nodev1.DeleteVolumeResponse, error) {
+	return &nodev1.DeleteVolumeResponse{LineageId: req.GetLineageId()}, nil
 }
 
 func (*fakeServer) ArchiveVolume(_ context.Context, _ *nodev1.ArchiveVolumeRequest) (*nodev1.ArchiveVolumeResponse, error) {
@@ -413,6 +413,9 @@ func (s *fakeServer) GetNodeStatus(_ context.Context, req *nodev1.GetNodeStatusR
 				SizeBytes:       4096,
 				CreatedAtUnixMs: 1_700_000_000_000,
 			},
+		},
+		SessionVolumes: []*nodev1.SessionVolume{
+			{Workload: "sandbox-session", LineageId: "s-sess3", SizeBytes: 1024, AllocatedBytes: 512},
 		},
 		SnapshotDiskFreeBytes: 9_000_000_000,
 		SnapshotDiskUsedBytes: 1_000_000_000,

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -1020,7 +1020,9 @@ message DeleteVolumeRequest {
   string lineage_id = 3;
 }
 
-message DeleteVolumeResponse {}
+message DeleteVolumeResponse {
+  string lineage_id = 1;
+}
 
 message ArchiveVolumeRequest {
   Trace trace = 1;

--- a/projects/embervm/proto/embervm/node/v1/node.proto
+++ b/projects/embervm/proto/embervm/node/v1/node.proto
@@ -1520,6 +1520,13 @@ message SessionSnapshot {
   bool exported = 6;
 }
 
+message SessionVolume {
+  string workload = 1;
+  string lineage_id = 2;
+  uint64 size_bytes = 3;
+  uint64 allocated_bytes = 4;
+}
+
 // ServingVm is one LIVE serving VM the node currently holds, reported so a
 // restarted control plane adopts rather than orphans it and so the control
 // plane can consume the daemon's health-probe fact. healthy and
@@ -1945,6 +1952,7 @@ message NodeStatus {
   // session_snapshots is the banked-snapshot inventory scanned from the sessions
   // snapshot dir on disk. The source of truth for what banked sessions survive.
   repeated SessionSnapshot session_snapshots = 10;
+  repeated SessionVolume session_volumes = 38;
   // snapshot_disk_free_bytes / snapshot_disk_used_bytes report the sessions
   // snapshot dir's filesystem usage so the control plane's LRU eviction can fire
   // on a low-watermark crossing and the watermark alert can trip.

--- a/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
+++ b/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
@@ -85,7 +85,7 @@ defmodule Embervm.NodeRoundtripTest do
       volume_size_bytes: 10_737_418_240,
       lineage_id: "lineage-1"
     })
-    assert pr.vm_id == "vm:snapX"
+    assert pr.vm_id == "vm:lineage-1:/workspace"
 
     {:ok, asg} =
       NodeService.Stub.assign(ch, %AssignRequest{
@@ -104,6 +104,7 @@ defmodule Embervm.NodeRoundtripTest do
     {:ok, ns} = NodeService.Stub.get_node_status(ch, %GetNodeStatusRequest{node_id: "node-4"})
     assert ns.node_id == "node-4"
     assert ns.max_live_vms == 10
+    assert [%{workload: "sandbox-session", lineage_id: "s-sess3", size_bytes: 1024, allocated_bytes: 512}] = ns.session_volumes
   end
 
   test "session verbs round-trip across the wire (R2 additive contract)", %{channel: ch} do
@@ -334,8 +335,8 @@ defmodule Embervm.NodeRoundtripTest do
     assert aborted.generation == 0
     assert aborted.size_bytes == 0
 
-    # DeleteVolume: idempotent, returns an empty response.
-    assert {:ok, _} =
+    # DeleteVolume: idempotent, and echoes the lineage that was deleted.
+    assert {:ok, %Embervm.Node.V1.DeleteVolumeResponse{lineage_id: "lineage-1"}} =
              NodeService.Stub.delete_volume(ch, %DeleteVolumeRequest{workload: "scratch-postgres", lineage_id: "lineage-1"})
   end
 

--- a/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
+++ b/projects/embervm/proto/embervm/node/v1/roundtrip/node_roundtrip_test.exs
@@ -78,7 +78,13 @@ defmodule Embervm.NodeRoundtripTest do
     assert bb.base_size_bytes == 512 * 1024 * 1024
     assert bb.arch == "amd64"
 
-    {:ok, pr} = NodeService.Stub.prime(ch, %PrimeRequest{snapshot_ref: "snapX"})
+    {:ok, pr} = NodeService.Stub.prime(ch, %PrimeRequest{
+      snapshot_ref: "snapX",
+      volume_disk_path: "/var/lib/ember/session/w/workspace.img",
+      volume_mount: "/workspace",
+      volume_size_bytes: 10_737_418_240,
+      lineage_id: "lineage-1"
+    })
     assert pr.vm_id == "vm:snapX"
 
     {:ok, asg} =
@@ -330,7 +336,7 @@ defmodule Embervm.NodeRoundtripTest do
 
     # DeleteVolume: idempotent, returns an empty response.
     assert {:ok, _} =
-             NodeService.Stub.delete_volume(ch, %DeleteVolumeRequest{workload: "scratch-postgres"})
+             NodeService.Stub.delete_volume(ch, %DeleteVolumeRequest{workload: "scratch-postgres", lineage_id: "lineage-1"})
   end
 
   test "StartStateful honors blessed_generation and volume_device (R7 additive fields)", %{


### PR DESCRIPTION
The #4241 gate, review-hardened: session lineage volumes become NodeStatus facts and the CP sweep retires orphans (archive-then-delete) under a dual-clock contract (monotonic fact freshness with per-lineage first-seen grace, wall-clock terminal-row age, no cross-domain comparison; tests inject divergent clock origins so a reintroduced mix fails). Per-lineage attach records guard deletion and export against live writers with explicit stale-attach pruning. filesystem.mountPath wired CRD-to-Prime; load-bearing proto fields get echo-asserted roundtrip coverage including NodeStatus.session_volumes. S3 retention for retired workspaces is deliberately NOT here (#4258); the GC allowlist stays hard.

After this merges: the persistenceEnabled flip PR, then live park/retire/rejoin validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB