### PR TITLE
feat(embervm): enable session workspace persistence for claude-runtime

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.359
+version: 0.1.360

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.359
+      targetRevision: 0.1.360
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -324,3 +324,8 @@ egress:
 # session at all. Sizing and the node disk arithmetic are in chart/values.yaml.
 claudeRuntimeWorkload:
   enabled: true
+  # The ADR 027 memory:false/filesystem:true quadrant, armed after the #4241
+  # hardening gate merged: sessions ride per-lineage workspace volumes with
+  # park/rejoin instead of memory-snapshot banking, S3 archival at retirement,
+  # and restore-first rejoin. Raw files in S3 replace multi-GiB snapshots.
+  persistenceEnabled: true


### PR DESCRIPTION
The flip. #4241's gate is merged (orphan sweep with dual-clock discipline, per-lineage attach guards, mountPath wiring, roundtrip coverage), so claude-runtime sessions move off memory-snapshot banking onto per-lineage workspace volumes: park and rejoin for idle cycling, retirement archiving raw files to S3, restore-first rejoin. Live validation (park a qwen session past the idle window, rejoin, prove workspace continuity) runs immediately after this deploys; S3 retention lifecycle is #4258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB