### PR TITLE
revert(embervm): disarm session persistence, it denies every session create

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.360
+version: 0.1.361

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.360
+      targetRevision: 0.1.361
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -328,4 +328,9 @@ claudeRuntimeWorkload:
   # hardening gate merged: sessions ride per-lineage workspace volumes with
   # park/rejoin instead of memory-snapshot banking, S3 archival at retirement,
   # and restore-first rejoin. Raw files in S3 replace multi-GiB snapshots.
-  persistenceEnabled: true
+  # DISARMED 2026-08-03 after the live flip: enabling persistence made every
+  # claude-runtime session create deny with :no_capacity (all model families,
+  # since they share this workload), so the flip is reverted while #4262 finds
+  # why placement refuses a lineage-volume create. The hardening gate (#4241)
+  # and the archive/rejoin machinery stay merged and dormant.
+  persistenceEnabled: false


### PR DESCRIPTION
Live flip result: with persistenceEnabled true, every claude-runtime session create denied with :no_capacity (sessions 23 and 24, both 500 at the workload create endpoint), taking down ALL model families since they share the workload. The CP also logs session workspace retirement failing with :unknown_node, dialing the bare node name where a dial id is required (the dial-vs-anchor trap). Disarming restores the surface; #4241's hardening and the archive/rejoin machinery stay merged and dormant. Root cause tracked in #4262.