### PR TITLE
feat(embervm): guest codex handshake for the subscription lane (ADR 048, #4250 PR 4)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.362
+version: 0.1.363

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.361
+      targetRevision: 0.1.363
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -308,7 +308,9 @@ egress:
     - header: "Authorization"
       valuePrefix: "Bearer "
       egressTo:
-        - "api.openai.com"
+        # The subscription backend, not api.openai.com: codex in ChatGPT mode
+        # talks to chatgpt.com/backend-api (verified against rust-v0.146.0).
+        - "chatgpt.com"
       # The subscription grant supplies short-lived tokens. If the broker is
       # absent or unavailable, the sidecar fails closed and denies this host.
       brokerGrant: "codex-cluster"

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -2,6 +2,7 @@
 """HTTP over vsock shim for a long-lived Claude Code CLI session."""
 
 import http.server
+import base64
 import collections
 import json
 import math
@@ -40,6 +41,9 @@ CLAUDE_MODELS = {
     "fable": "claude-fable-5",
 }
 DEFAULT_CODEX_MODEL = "luna"
+CODEX_SUBSCRIPTION_BASE_URL_ENV = "CODEX_SUBSCRIPTION_BASE_URL"
+DEFAULT_CODEX_SUBSCRIPTION_BASE_URL = "http://chatgpt.com/backend-api/"
+CODEX_DUMMY_ACCOUNT_ID = "guest-subscription-account"
 PI_MODELS = {
     # Must match the vLLM --served-model-name (projects/inference/deploy/
     # values.yaml); a wrong name 404s at the provider ("The model does not
@@ -868,10 +872,13 @@ class CodexProcess:
         codex_home = os.path.join(self.workspace, ".codex")
         _ensure_cli_dir(codex_home)
         child_env = os.environ.copy()
+        # Subscription auth is carried by the inert auth.json below. An API
+        # key is not part of ChatGPT subscription mode and must not confuse
+        # the CLI or the egress sidecar.
+        child_env.pop("OPENAI_API_KEY", None)
         child_env.update(
             {
                 "CODEX_HOME": codex_home,
-                "OPENAI_API_KEY": "ember-guest-login-gate-dummy-not-a-credential",
                 "HTTPS_PROXY": proxy_url,
                 "HTTP_PROXY": proxy_url,
                 "NO_PROXY": "127.0.0.1,localhost",
@@ -880,15 +887,65 @@ class CodexProcess:
         return child_env
 
     @staticmethod
+    def _dummy_jwt():
+        """A syntactically valid, far-future JWT carrying no real credential.
+
+        The CLI decodes these tokens locally (expiry, account id), so a bare
+        placeholder string fails to parse and the CLI decides it is logged
+        out. The signature is nonsense on purpose: nothing verifies it here,
+        and the sidecar replaces the header with the broker's real token
+        before the request leaves the guest.
+        """
+        header = base64.urlsafe_b64encode(b'{"alg":"none","typ":"JWT"}').rstrip(b"=")
+        payload = base64.urlsafe_b64encode(
+            json.dumps(
+                {
+                    "exp": 4102444800,  # 2100-01-01, so the CLI never self-refreshes
+                    "https://api.openai.com/auth": {
+                        "chatgpt_account_id": CODEX_DUMMY_ACCOUNT_ID
+                    },
+                },
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).rstrip(b"=")
+        return b".".join([header, payload, b"ember"]).decode("ascii")
+
+    @staticmethod
+    def _write_auth_json(codex_home):
+        # Shape mirrors a real subscription auth.json (auth_mode, a null API key,
+        # JWT-shaped tokens): the CLI parses these, so a placeholder string reads
+        # as logged out. The broker owns refresh; a guest refresh would consume
+        # the rotating token and lock out the fleet (ADR 048 invariant), which is
+        # why last_refresh sits in the future and the tokens never expire.
+        token = CodexProcess._dummy_jwt()
+        auth = {
+            "auth_mode": "chatgpt",
+            "OPENAI_API_KEY": None,
+            "tokens": {
+                "id_token": token,
+                "access_token": token,
+                "refresh_token": token,
+                "account_id": CODEX_DUMMY_ACCOUNT_ID,
+            },
+            "last_refresh": "2099-12-31T23:59:59Z",
+        }
+        with open(os.path.join(codex_home, "auth.json"), "w") as stream:
+            json.dump(auth, stream)
+
+    @staticmethod
     def _write_model_config(codex_home):
+        base_url = os.environ.get(
+            CODEX_SUBSCRIPTION_BASE_URL_ENV, DEFAULT_CODEX_SUBSCRIPTION_BASE_URL
+        )
+        # Subscription backend endpoint over cleartext injection lane (token injection happens at sidecar).
         config = """model_provider = "ember-openai"
+enable_codex_api_key_env = false
 
 [model_providers.ember-openai]
 name = "ember-openai"
-base_url = "http://api.openai.com/v1"
-env_key = "OPENAI_API_KEY"
+base_url = %s
 wire_api = "responses"
-"""
+""" % json.dumps(base_url)
         with open(os.path.join(codex_home, "config.toml"), "w") as stream:
             stream.write(config)
 
@@ -896,6 +953,7 @@ wire_api = "responses"
         if not os.path.isdir(self.workspace):
             raise StartupError("workspace does not exist: %s" % self.workspace)
         child_env = self._child_env()
+        self._write_auth_json(child_env["CODEX_HOME"])
         self._write_model_config(child_env["CODEX_HOME"])
         model_name, effort = CODEX_MODELS.get(model, CODEX_MODELS[DEFAULT_CODEX_MODEL])
         if session_id:

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -2,6 +2,7 @@
 
 import json
 import ast
+import datetime
 import os
 import signal
 import socket
@@ -109,6 +110,7 @@ for line in sys.stdin:
 
 
 FAKE_CODEX_CLI = r"""#!/usr/bin/env python3
+import datetime
 import json
 import os
 import sys
@@ -124,12 +126,23 @@ if args_path:
 # when the dir does not exist.
 assert os.environ.get("CODEX_HOME", "") == os.path.join(os.getcwd(), ".codex")
 assert os.path.isdir(os.environ["CODEX_HOME"])
-assert os.environ.get("OPENAI_API_KEY", "")
+assert "OPENAI_API_KEY" not in os.environ
+auth_path = os.path.join(os.environ["CODEX_HOME"], "auth.json")
+assert os.path.isfile(auth_path)
+auth = json.load(open(auth_path))
+assert set(auth) == {"auth_mode", "OPENAI_API_KEY", "tokens", "last_refresh"}
+assert auth["auth_mode"] == "chatgpt"
+assert auth["OPENAI_API_KEY"] is None
+assert set(auth["tokens"]) == {"id_token", "access_token", "refresh_token", "account_id"}
+assert len(auth["tokens"]["access_token"].split(".")) == 3
+assert datetime.datetime.fromisoformat(auth["last_refresh"].replace("Z", "+00:00")).year >= 2099
 config_path = os.path.join(os.environ["CODEX_HOME"], "config.toml")
 assert os.path.isfile(config_path)
 config = open(config_path).read()
 assert 'model_provider = "ember-openai"' in config
-assert 'base_url = "http://api.openai.com/v1"' in config
+assert 'base_url = "http://chatgpt.com/backend-api/"' in config
+assert "enable_codex_api_key_env = false" in config
+assert 'wire_api = "responses"' in config
 assert "--skip-git-repo-check" in sys.argv
 assert "--model" in sys.argv
 assert "--config" in sys.argv
@@ -325,6 +338,49 @@ def test_codex_first_turn_returns_thread_voice_and_usage(tmp_path, monkeypatch):
         "activity": [],
     }
     manager._close_process()
+
+
+def test_codex_auth_json_has_inert_subscription_schema(tmp_path, monkeypatch):
+    manager = _codex_manager(tmp_path, monkeypatch)
+    child_env = manager._child_env()
+    manager._write_auth_json(child_env["CODEX_HOME"])
+    auth = json.loads((tmp_path / "workspace" / ".codex" / "auth.json").read_text())
+    assert set(auth) == {"auth_mode", "OPENAI_API_KEY", "tokens", "last_refresh"}
+    assert auth["auth_mode"] == "chatgpt"
+    assert auth["OPENAI_API_KEY"] is None
+    assert set(auth["tokens"]) == {
+        "id_token",
+        "access_token",
+        "refresh_token",
+        "account_id",
+    }
+    assert all(auth["tokens"].values())
+    assert (
+        datetime.datetime.fromisoformat(
+            auth["last_refresh"].replace("Z", "+00:00")
+        ).year
+        >= 2099
+    )
+
+
+def test_codex_config_uses_subscription_endpoint_override(tmp_path, monkeypatch):
+    manager = _codex_manager(tmp_path, monkeypatch)
+    endpoint = "http://broker.test/backend-api/"
+    monkeypatch.setenv(shim.CODEX_SUBSCRIPTION_BASE_URL_ENV, endpoint)
+    child_env = manager._child_env()
+    manager._write_model_config(child_env["CODEX_HOME"])
+    config = (tmp_path / "workspace" / ".codex" / "config.toml").read_text()
+    assert 'base_url = "%s"' % endpoint in config
+    assert "api.openai.com" not in config
+    assert 'name = "ember-openai"' in config
+    assert 'wire_api = "responses"' in config
+    assert "enable_codex_api_key_env = false" in config
+
+
+def test_codex_child_env_drops_openai_api_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-reach-codex")
+    manager = _codex_manager(tmp_path, monkeypatch)
+    assert "OPENAI_API_KEY" not in manager._child_env()
 
 
 def test_codex_resume_uses_positional_session_and_no_sandbox(tmp_path, monkeypatch):
@@ -1241,3 +1297,23 @@ def test_pi_argv_constrains_the_context_budget(tmp_path, monkeypatch):
     assert "--tools" in argv
     assert argv[argv.index("--tools") + 1] == "read,bash,edit,write"
     manager._close_process()
+
+
+def test_codex_auth_json_is_parseable_and_inert(tmp_path, monkeypatch):
+    """The CLI parses these tokens, so shape matters more than content."""
+    import base64 as _b64
+
+    manager = _codex_manager(tmp_path, monkeypatch)
+    manager.turn("hello", model="luna")
+    auth_path = os.path.join(str(tmp_path / "workspace"), ".codex", "auth.json")
+    auth = json.loads(open(auth_path).read())
+    assert auth["auth_mode"] == "chatgpt"
+    assert auth["OPENAI_API_KEY"] is None
+    token = auth["tokens"]["access_token"]
+    parts = token.split(".")
+    assert len(parts) == 3, "tokens must be JWT-shaped or the CLI reads as logged out"
+    padded = parts[1] + "=" * (-len(parts[1]) % 4)
+    claims = json.loads(_b64.urlsafe_b64decode(padded))
+    assert claims["exp"] > 4_000_000_000, (
+        "expiry must be far future so the guest never self-refreshes"
+    )


### PR DESCRIPTION
Last code PR of #4250. The guest writes an inert auth.json shaped like a real subscription credential (auth_mode chatgpt, null API key, JWT-shaped tokens, far-future expiry) because the CLI parses these locally: a bare placeholder string reads as logged out, and a future expiry stops the guest ever refreshing, which the broker owns exclusively (a guest refresh would consume the rotating token and lock out the fleet). The provider config targets the subscription backend over the cleartext lane, OPENAI_API_KEY leaves the child env, and the egress catalog entry follows the backend host to chatgpt.com.

Note the dummy-shape correction: the first cut used a plain string token, which the CLI's own JWT parsing would have rejected; the fixture on this machine confirmed the real file's shape.

After this merges the lane is complete end to end and waits only on the one-time device-code approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB