### PR TITLE
fix(embervm): carry prime failure reasons and dial volumes by instance (#4263)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.363
+version: 0.1.364

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -585,12 +585,30 @@ defmodule Embervm.SessionManager do
   defp mint_lineage_id(state), do: Embervm.SessionId.new(state.clock.())
 
   defp prime(state, node_id, snapshot_ref, entry, lineage_id) do
-    with {:ok, channel} <- state.channel_fun.(node_id),
-         {:ok, %PrimeResponse{vm_id: vm_id}} when is_binary(vm_id) and vm_id != "" <-
-           safe_prime(state, channel, snapshot_ref, entry, lineage_id) do
-      {:ok, vm_id}
-    else
-      _ -> {:error, :no_capacity}
+    # A prime failure is NOT a capacity problem, and reporting it as one cost a
+    # whole debugging cycle: the persistence flip denied every create with
+    # :no_capacity while the real reason (a rejected Prime) never left this
+    # function. Carry the reason out and log it; the caller still denies.
+    case state.channel_fun.(node_id) do
+      {:ok, channel} ->
+        case safe_prime(state, channel, snapshot_ref, entry, lineage_id) do
+          {:ok, %PrimeResponse{vm_id: vm_id}} when is_binary(vm_id) and vm_id != "" ->
+            {:ok, vm_id}
+
+          other ->
+            Logger.warning("embervm prime failed",
+              node_id: node_id,
+              snapshot_ref: snapshot_ref,
+              lineage_id: lineage_id,
+              reason: inspect(other)
+            )
+
+            {:error, {:prime_failed, other}}
+        end
+
+      other ->
+        Logger.warning("embervm prime dial failed", node_id: node_id, reason: inspect(other))
+        {:error, {:prime_dial_failed, other}}
     end
   end
 
@@ -2934,7 +2952,12 @@ defmodule Embervm.SessionManager do
     metering_reason =
       case reason do
         :quota -> :quota
-        other -> other
+        {:prime_failed, _} -> :prime_failed
+        {:prime_dial_failed, _} -> :prime_dial_failed
+        other when is_atom(other) -> other
+        # The metering reason space is atoms; a structured reason keeps its
+        # detail in the log line prime/5 already emitted.
+        _ -> :denied
       end
 
     Embervm.Metering.record_denial(principal, workload, metering_reason)
@@ -3058,9 +3081,13 @@ defmodule Embervm.SessionManager do
       req = %RetireVolumeRequest{trace: %Trace{workload: workload}, workload: workload, lineage_id: lineage_id}
       retire_fun = state.retire_volume_fun
       channel_fun = state.channel_fun
+      # Dial the INSTANCE owning this lineage on disk, not the bare node name:
+      # the node-name alias is an anchor, not a dial key, and dialing it fails
+      # :unknown_node forever (observed live when the flip armed retirement).
+      dial_id = Embervm.WakeInstance.dial_for_session_volume(state.capacity_table, node_id, lineage_id)
       spawn(fn ->
         result =
-          with {:ok, channel} <- safe_channel(channel_fun, node_id) do
+          with {:ok, channel} <- safe_channel(channel_fun, dial_id) do
             try do
               retire_fun.(channel, req)
             rescue

--- a/projects/embervm/control/lib/embervm/wake_instance.ex
+++ b/projects/embervm/control/lib/embervm/wake_instance.ex
@@ -327,6 +327,18 @@ defmodule Embervm.WakeInstance do
   # instance fact, or the row not re-reported yet). The shared core of the
   # instance-key dial resolution: every stateful/serving live-VM and bundle dial
   # routes through here so they cannot drift on the fail-open contract.
+  @doc """
+  The channel key of the instance on `node_id` currently holding the session
+  workspace volume for `lineage_id` (its `session_volumes` report it), or the
+  bare `node_id` when none is found. Volume retire/archive/delete must land on
+  the instance that owns the lineage directory on disk; dialing the node-name
+  alias fails with `:unknown_node` (observed live when the persistence flip
+  armed retirement). Same fail-open contract as `dial_for_vm/3`.
+  """
+  @spec dial_for_session_volume(atom(), String.t(), String.t()) :: String.t()
+  def dial_for_session_volume(table \\ NodeCapacity.table(), node_id, lineage_id),
+    do: dial_owning(table, node_id, :session_volumes, :lineage_id, lineage_id)
+
   defp dial_owning(table, node_id, key, field, ref)
        when is_binary(node_id) and is_binary(ref) and ref != "" do
     table

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -461,7 +461,9 @@ defmodule Embervm.SessionManagerTest do
     ctx = start_stack(claim_fun: fn _d, _n, _w -> :miss end, prime_fun: fn _ch, _req -> {:error, :boom} end)
     put_session_workload(ctx, "wl-miss")
 
-    assert {:error, {:denied, :no_capacity}} = SessionManager.create(ctx.mgr, "wl-miss", "p1")
+    # The denial now CARRIES the prime failure instead of flattening it to a
+    # capacity lie; the live persistence flip cost a debugging cycle to that.
+    assert {:error, {:denied, {:prime_failed, _}}} = SessionManager.create(ctx.mgr, "wl-miss", "p1")
   end
 
   test "create quota fail-closed denies a principal over budget" do
@@ -708,7 +710,8 @@ defmodule Embervm.SessionManagerTest do
     created = create_persistence_session(ctx)
     park_session(ctx, created)
 
-    assert {:error, {:relight_failed, :no_capacity}} =
+    # The rejoin failure carries the prime reason through now.
+    assert {:error, {:relight_failed, {:prime_failed, _}}} =
              SessionManager.invoke(ctx.mgr, created.session_id, %{body: "retry"})
 
     {:ok, session} = SessionStore.get(ctx.store, created.session_id)

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.363
+      targetRevision: 0.1.364
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Two of #4263's findings, both about a failure hiding its own cause.

prime/5 mapped EVERY failure (dial error, rejected Prime, crash) to :no_capacity, which is why the persistence flip looked like a capacity shortage and cost a full debugging cycle; it now logs the reason with node/lineage context and returns it, with metering mapping tuple reasons back into its atom space. Volume retirement now dials the instance that owns the lineage on disk (new WakeInstance.dial_for_session_volume, same fail-open contract as its siblings) instead of the bare node name, which failed :unknown_node on every attempt forever.

This does not re-enable persistence. It makes the next flip attempt diagnosable in one shot and removes the retirement blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB
EOF
)