### PR TITLE
feat(embervm): re-arm session persistence with prime failures now legible

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.364
+version: 0.1.365

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.364
+      targetRevision: 0.1.365
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -329,9 +329,8 @@ claudeRuntimeWorkload:
   # hardening gate merged: sessions ride per-lineage workspace volumes with
   # park/rejoin instead of memory-snapshot banking, S3 archival at retirement,
   # and restore-first rejoin. Raw files in S3 replace multi-GiB snapshots.
-  # DISARMED 2026-08-03 after the live flip: enabling persistence made every
-  # claude-runtime session create deny with :no_capacity (all model families,
-  # since they share this workload), so the flip is reverted while #4262 finds
-  # why placement refuses a lineage-volume create. The hardening gate (#4241)
-  # and the archive/rejoin machinery stay merged and dormant.
-  persistenceEnabled: false
+  # Re-armed 2026-08-03 on top of the prime-reason instrumentation (#4266):
+  # the first flip denied every create with :no_capacity, which turned out to
+  # be prime/5 flattening its real failure. This attempt is time-boxed: one
+  # probe, read the now-explicit reason, revert immediately if it fails.
+  persistenceEnabled: true


### PR DESCRIPTION
Time-boxed retry on top of #4266, which made prime failures self-describing. The first flip denied every create with :no_capacity, a reason prime/5 invented by flattening the real one. One probe after this deploys either validates persistence or names the actual cause; either way I act within minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB
EOF
)