### PR TITLE
fix(embervm): give a cold-boot Prime the boot budget, not the 10s default (#4263)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.365
+version: 0.1.366

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -2975,8 +2975,17 @@ defmodule Embervm.SessionManager do
     Embervm.Dispatcher.claim(dispatcher, node_id, workload)
   end
 
+  # A persistence Prime COLD BOOTS with a freshly created workspace volume, so it
+  # runs for the guest's boot-ready budget (60s) rather than a warm restore's
+  # couple of seconds. The elixir-grpc default is 10s, which cancelled every
+  # such Prime mid-boot: the CP saw server_closed_request and denied the create,
+  # and noded logged "vsock prime did not complete ... context canceled". Same
+  # deadline-family trap as #4212/#4215.
+  @prime_cold_boot_timeout_ms 120_000
+
   defp default_prime(channel, %PrimeRequest{} = req) do
-    Embervm.Node.V1.NodeService.Stub.prime(channel, req)
+    timeout = if req.lineage_id in [nil, ""], do: 30_000, else: @prime_cold_boot_timeout_ms
+    Embervm.Node.V1.NodeService.Stub.prime(channel, req, timeout: timeout)
   end
 
   defp default_bank(channel, %BankRequest{} = req) do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.365
+      targetRevision: 0.1.366
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -329,8 +329,10 @@ claudeRuntimeWorkload:
   # hardening gate merged: sessions ride per-lineage workspace volumes with
   # park/rejoin instead of memory-snapshot banking, S3 archival at retirement,
   # and restore-first rejoin. Raw files in S3 replace multi-GiB snapshots.
-  # Re-armed 2026-08-03 on top of the prime-reason instrumentation (#4266):
-  # the first flip denied every create with :no_capacity, which turned out to
-  # be prime/5 flattening its real failure. This attempt is time-boxed: one
-  # probe, read the now-explicit reason, revert immediately if it fails.
-  persistenceEnabled: true
+  # OFF while the cold-boot Prime deadline fix in this PR deploys. The probe
+  # proved the real cause: a persistence Prime cold boots with a fresh 10 GiB
+  # volume and blew elixir-grpc's 10s default deadline, so the CP cancelled
+  # mid-boot ("server_closed_request") and denied the create, while noded
+  # logged "vsock prime did not complete ... context canceled". Re-arm once
+  # this ships.
+  persistenceEnabled: false


### PR DESCRIPTION
The instrumented re-flip named the cause in one probe. A persistence Prime cold boots with a freshly created 10 GiB workspace volume; elixir-grpc's 10s default deadline cancelled it mid-boot, so the CP saw server_closed_request and denied every create (the :no_capacity of the first attempt), while noded logged 'vsock prime did not complete ... context canceled'. Exactly the deadline family of #4212/#4215.

A Prime carrying a lineage_id now gets 120s; everything else keeps a 30s bound. Persistence is disarmed in this PR and re-arms once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB
EOF
)