### PR TITLE
feat(embervm): arm session persistence on the cold-boot deadline fix

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.366
+version: 0.1.367

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.366
+      targetRevision: 0.1.367
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -329,10 +329,7 @@ claudeRuntimeWorkload:
   # hardening gate merged: sessions ride per-lineage workspace volumes with
   # park/rejoin instead of memory-snapshot banking, S3 archival at retirement,
   # and restore-first rejoin. Raw files in S3 replace multi-GiB snapshots.
-  # OFF while the cold-boot Prime deadline fix in this PR deploys. The probe
-  # proved the real cause: a persistence Prime cold boots with a fresh 10 GiB
-  # volume and blew elixir-grpc's 10s default deadline, so the CP cancelled
-  # mid-boot ("server_closed_request") and denied the create, while noded
-  # logged "vsock prime did not complete ... context canceled". Re-arm once
-  # this ships.
-  persistenceEnabled: false
+  # Armed on top of the cold-boot Prime deadline fix (#4268). The two earlier
+  # attempts died on elixir-grpc's 10s default cancelling a Prime mid cold
+  # boot; a lineage-carrying Prime now gets 120s.
+  persistenceEnabled: true


### PR DESCRIPTION
Third attempt, with the actual cause fixed: #4268 gives a lineage-carrying Prime a 120s budget instead of elixir-grpc's 10s default, which had been cancelling every persistence cold boot mid-flight. Probe follows immediately; revert stays one commit away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB
EOF
)