### PR TITLE
revert(embervm): disarm persistence, cold-boot create needs an async path

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.367
+version: 0.1.368

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.367
+      targetRevision: 0.1.368
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -329,7 +329,10 @@ claudeRuntimeWorkload:
   # hardening gate merged: sessions ride per-lineage workspace volumes with
   # park/rejoin instead of memory-snapshot banking, S3 archival at retirement,
   # and restore-first rejoin. Raw files in S3 replace multi-GiB snapshots.
-  # Armed on top of the cold-boot Prime deadline fix (#4268). The two earlier
-  # attempts died on elixir-grpc's 10s default cancelling a Prime mid cold
-  # boot; a lineage-carrying Prime now gets 120s.
-  persistenceEnabled: true
+  # OFF. Three live attempts, each exposing the next layer: :no_capacity (a
+  # flattened reason), then a 10s gRPC cancel mid cold boot (#4268 fixed it),
+  # and now the structural one: do_create runs the prime INLINE on the
+  # SessionManager, so a cold boot cannot finish inside the router's 5s
+  # GenServer.call and blocks every other session while it tries. Persistence
+  # cannot arm until create is asynchronous (#4270).
+  persistenceEnabled: false


### PR DESCRIPTION
Third attempt, third layer, and this one is structural. With #4268's deadline fix in place the create no longer dies on a gRPC cancel; it dies on the router's 5s GenServer.call to the SessionManager, because do_create runs the prime inline on that process. A persistence create cold-boots a VM with a freshly created 10 GiB volume, which cannot finish in 5s and blocks every other session's routing while it tries. Disarming restores service; #4270 tracks making create asynchronous the way bank and relight already are.