### PR TITLE
feat(embervm): arm session persistence with the create path fixed

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.369
+version: 0.1.370

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.369
+      targetRevision: 0.1.370
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -329,10 +329,9 @@ claudeRuntimeWorkload:
   # hardening gate merged: sessions ride per-lineage workspace volumes with
   # park/rejoin instead of memory-snapshot banking, S3 archival at retirement,
   # and restore-first rejoin. Raw files in S3 replace multi-GiB snapshots.
-  # OFF. Three live attempts, each exposing the next layer: :no_capacity (a
-  # flattened reason), then a 10s gRPC cancel mid cold boot (#4268 fixed it),
-  # and now the structural one: do_create runs the prime INLINE on the
-  # SessionManager, so a cold boot cannot finish inside the router's 5s
-  # GenServer.call and blocks every other session while it tries. Persistence
-  # cannot arm until create is asynchronous (#4270).
-  persistenceEnabled: false
+  # Armed with all three causes of the earlier failures closed: prime failures
+  # carry their real reason (#4266), a lineage-carrying Prime gets a cold-boot
+  # deadline instead of the 10s default (#4268), and create no longer primes on
+  # the SessionManager process (#4271/#4273), which is what made a cold-boot
+  # create impossible inside the router call.
+  persistenceEnabled: true


### PR DESCRIPTION
Fourth arm, with every cause the previous three exposed now closed: #4266 (prime failures carry their reason), #4268 (cold-boot Prime deadline), #4273 (create runs off the manager process). Probe follows immediately; revert stays one commit away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB
EOF
)