### PR TITLE
revert(embervm): disarm persistence, noded cancels the lineage Prime

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.370
+version: 0.1.371

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.370
+      targetRevision: 0.1.371
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -329,9 +329,10 @@ claudeRuntimeWorkload:
   # hardening gate merged: sessions ride per-lineage workspace volumes with
   # park/rejoin instead of memory-snapshot banking, S3 archival at retirement,
   # and restore-first rejoin. Raw files in S3 replace multi-GiB snapshots.
-  # Armed with all three causes of the earlier failures closed: prime failures
-  # carry their real reason (#4266), a lineage-carrying Prime gets a cold-boot
-  # deadline instead of the 10s default (#4268), and create no longer primes on
-  # the SessionManager process (#4271/#4273), which is what made a cold-boot
-  # create impossible inside the router call.
-  persistenceEnabled: true
+  # OFF. Four live attempts. Three causes found and FIXED (#4266 honest prime
+  # reasons, #4268 cold-boot Prime deadline, #4273 create off the manager), but
+  # the Prime still dies with the server CANCELLING the stream
+  # (server_closed_request) even with a 120s client deadline and noded's 60s
+  # BootReadyTimeout, so the abort is inside noded's lineage-volume Prime path
+  # and needs node-side investigation (#4271). Do not re-arm without it.
+  persistenceEnabled: false


### PR DESCRIPTION
Fourth attempt. The three causes found by attempts one through three are fixed and merged (#4266 honest prime reasons, #4268 cold-boot Prime deadline, #4273 create off the manager process), and the failure has moved accordingly each time. It now presents as the server cancelling the Prime stream (server_closed_request) despite a 120s client deadline and noded's 60s BootReadyTimeout being correctly configured, which places the abort inside noded's lineage-volume Prime path. That needs node-side logs captured at prime time on a quiet fleet, so persistence stays off. Details on #4271.