### PR TITLE
fix(embervm): make a noded handler panic name itself (#4271)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.371
+version: 0.1.372

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.371
+      targetRevision: 0.1.372
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/cmd/auth.go
+++ b/projects/embervm/noded/cmd/auth.go
@@ -3,6 +3,9 @@ package main
 import (
 	"context"
 	"crypto/subtle"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
 	"strings"
 
 	"google.golang.org/grpc"
@@ -35,12 +38,28 @@ func checkBearer(ctx context.Context, token string) error {
 	return nil
 }
 
-// unaryAuthInterceptor gates every unary RPC on the bearer token.
+// unaryAuthInterceptor gates every unary RPC on the bearer token, and converts
+// a handler panic into an Internal status carrying the panic and its stack.
+//
+// Without this a panicking handler kills the stream and the caller sees only
+// a bare CANCEL (%Mint.HTTPError{reason: {:server_closed_request, :cancel}}),
+// which is indistinguishable from a client-side deadline and cost a full
+// debugging cycle on the session-persistence rollout. A crash should name
+// itself.
 func unaryAuthInterceptor(token string) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		if err := checkBearer(ctx, token); err != nil {
-			return nil, err
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+		if berr := checkBearer(ctx, token); berr != nil {
+			return nil, berr
 		}
+		defer func() {
+			if r := recover(); r != nil {
+				stack := string(debug.Stack())
+				slog.Error("noded: rpc handler panicked",
+					"method", info.FullMethod, "panic", fmt.Sprint(r), "stack", stack)
+				resp = nil
+				err = status.Errorf(codes.Internal, "noded: %s panicked: %v", info.FullMethod, r)
+			}
+		}()
 		return handler(ctx, req)
 	}
 }

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -958,6 +958,12 @@ func (s *Server) Prime(ctx context.Context, req *nodev1.PrimeRequest) (*nodev1.P
 	}
 	volumeDiskPath := req.GetVolumeDiskPath()
 	if req.GetLineageId() != "" {
+		// Guard like every other volume RPC does: a nil manager here would be a
+		// nil-pointer panic inside the handler, which reaches the caller as an
+		// unexplained stream cancel rather than a diagnosis.
+		if s.volumes == nil {
+			return nil, status.Error(codes.FailedPrecondition, "noded: volume manager not configured; session persistence unavailable on this node")
+		}
 		volumeDiskPath = s.volumes.SessionVolumePath(base.workload, req.GetLineageId())
 		if err := s.volumes.CreateSession(base.workload, req.GetLineageId(), req.GetVolumeSizeBytes()); err != nil {
 			return nil, status.Errorf(codes.FailedPrecondition, "noded: provision session volume: %v", err)


### PR DESCRIPTION
Four persistence arms could not localize their failure because the caller only ever saw server_closed_request :cancel, which looks identical to a client-side deadline. That is what a panicking gRPC handler produces. The unary interceptor now recovers, logs the panic with method and stack, and returns Internal carrying the message; Prime additionally guards a nil volume manager on the lineage path, which every other volume RPC already does and which is one concrete way that panic could occur.

This does not enable persistence. It ensures the next arm reports a diagnosis instead of a cancellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB
EOF
)