### PR TITLE
feat(embervm): arm session persistence with noded panics legible

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.372
+version: 0.1.373

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.372
+      targetRevision: 0.1.373
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -329,10 +329,8 @@ claudeRuntimeWorkload:
   # hardening gate merged: sessions ride per-lineage workspace volumes with
   # park/rejoin instead of memory-snapshot banking, S3 archival at retirement,
   # and restore-first rejoin. Raw files in S3 replace multi-GiB snapshots.
-  # OFF. Four live attempts. Three causes found and FIXED (#4266 honest prime
-  # reasons, #4268 cold-boot Prime deadline, #4273 create off the manager), but
-  # the Prime still dies with the server CANCELLING the stream
-  # (server_closed_request) even with a 120s client deadline and noded's 60s
-  # BootReadyTimeout, so the abort is inside noded's lineage-volume Prime path
-  # and needs node-side investigation (#4271). Do not re-arm without it.
-  persistenceEnabled: false
+  # Armed with noded panics now legible (#4276): a panicking handler used to
+  # reach the caller as a bare stream cancel, which is why four arms could not
+  # localize the fault. Plus the three fixed causes (#4266 honest prime
+  # reasons, #4268 cold-boot deadline, #4273 async create).
+  persistenceEnabled: true


### PR DESCRIPTION
Fifth arm. #4276 makes a panicking noded handler return Internal with its message and stack instead of a bare stream cancel, which is the last thing that was hiding the fault. Probe follows immediately; revert stays one commit away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB
EOF
)