### PR TITLE
revert(embervm): disarm persistence, the guest never boots ready with a volume

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.373
+version: 0.1.374

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.373
+      targetRevision: 0.1.374
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -329,8 +329,9 @@ claudeRuntimeWorkload:
   # hardening gate merged: sessions ride per-lineage workspace volumes with
   # park/rejoin instead of memory-snapshot banking, S3 archival at retirement,
   # and restore-first rejoin. Raw files in S3 replace multi-GiB snapshots.
-  # Armed with noded panics now legible (#4276): a panicking handler used to
-  # reach the caller as a bare stream cancel, which is why four arms could not
-  # localize the fault. Plus the three fixed causes (#4266 honest prime
-  # reasons, #4268 cold-boot deadline, #4273 async create).
-  persistenceEnabled: true
+  # OFF. Five arms. Fault is now localized to the GUEST: on a lineage cold
+  # boot noded logs "vsock prime ... context deadline exceeded", i.e. the guest
+  # never serves /shim/ready, so this is guest-init failing to come up with the
+  # workspace volume (suspect the ember.volume_dev boot-arg contract and the
+  # mount), not the CP. See #4271.
+  persistenceEnabled: false


### PR DESCRIPTION
Fifth arm, and the evidence finally moved off the control plane. With panics legible (#4276) the failure is NOT a panic: noded logs 'vsock prime did not complete ... context deadline exceeded' on the lineage cold boot, meaning the guest never serves /shim/ready at all. So the remaining fault is the guest booting with a workspace volume attached, which is where #4091 started (guest-init and the ember.volume_dev boot-arg contract). Disarmed; #4271 carries the next step.