### PR TITLE
fix(embervm): keep the first-boot volume format off the readiness path (#4271)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.374
+version: 0.1.375

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.374
+      targetRevision: 0.1.375
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/guest-init/cmd/volume_linux.go
+++ b/projects/embervm/runtimes/claude/guest-init/cmd/volume_linux.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -155,10 +156,20 @@ func mountVolumeDevice(logger *slog.Logger, dev, mountPath string) error {
 		return fmt.Errorf("probe volume device %s: %w", dev, err)
 	}
 	if blank {
+		// Lazy init keeps a first boot off the readiness cliff: a plain mkfs of
+		// a 10 GiB volume writes every inode table and the journal up front,
+		// inside the guest, ON the boot path, which blows the readiness budget
+		// and the guest never serves /shim/ready (observed live: the VM boots,
+		// both drives attach, then silence until the deadline). With lazy
+		// itable/journal init the kernel finishes that work in the background
+		// after mount, and discard skips trimming a freshly sparse file.
+		start := time.Now()
 		logger.Info("session volume: no filesystem signature, formatting ext4", "device", dev)
-		if out, err := exec.Command("mkfs.ext4", "-q", dev).CombinedOutput(); err != nil {
+		args := []string{"-q", "-E", "lazy_itable_init=1,lazy_journal_init=1,nodiscard", dev}
+		if out, err := exec.Command("mkfs.ext4", args...).CombinedOutput(); err != nil {
 			return fmt.Errorf("mkfs.ext4 %s: %w: %s", dev, err, string(out))
 		}
+		logger.Info("session volume: formatted", "device", dev, "took", time.Since(start).String())
 	}
 	if err := mkdirAllFn(mountPath, 0o755); err != nil {
 		return fmt.Errorf("mkdir volume mount path %s: %w", mountPath, err)


### PR DESCRIPTION
Fifth arm's evidence: the guest boots with both drives attached (vda rootfs ro, vdb 10 GiB workspace) and then goes silent until the readiness deadline. guest-init formats a blank workspace with a plain mkfs.ext4, which writes every inode table and the journal synchronously, inside the guest, on the boot path. Lazy itable/journal init defers that to the kernel after mount and nodiscard skips trimming a freshly sparse file; the format is also timed in the log now, so the next boot either shows a fast format (hypothesis confirmed) or names a different cost.

Persistence stays off in this PR; arming follows once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB
EOF
)