### PR TITLE
feat(embervm): arm session persistence on the first-boot format fix

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.375
+version: 0.1.376

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.375
+      targetRevision: 0.1.376
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -329,9 +329,8 @@ claudeRuntimeWorkload:
   # hardening gate merged: sessions ride per-lineage workspace volumes with
   # park/rejoin instead of memory-snapshot banking, S3 archival at retirement,
   # and restore-first rejoin. Raw files in S3 replace multi-GiB snapshots.
-  # OFF. Five arms. Fault is now localized to the GUEST: on a lineage cold
-  # boot noded logs "vsock prime ... context deadline exceeded", i.e. the guest
-  # never serves /shim/ready, so this is guest-init failing to come up with the
-  # workspace volume (suspect the ember.volume_dev boot-arg contract and the
-  # mount), not the CP. See #4271.
-  persistenceEnabled: false
+  # Armed on the first-boot format fix (#4279): mkfs of the fresh 10 GiB
+  # workspace ran synchronously on the guest's boot path, which is why the
+  # guest never served /shim/ready. Lazy itable/journal init moves it off that
+  # path, and the format is timed in the guest log either way.
+  persistenceEnabled: true


### PR DESCRIPTION
Sixth arm, on #4279: the guest's blank-workspace mkfs ran synchronously on the boot path, which kept /shim/ready from ever being served. Probe follows immediately; the guest now logs how long the format took either way.