### PR TITLE
revert(embervm): disarm persistence, guest-init never runs on a lineage cold boot

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.376
+version: 0.1.377

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.376
+      targetRevision: 0.1.377
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -329,8 +329,10 @@ claudeRuntimeWorkload:
   # hardening gate merged: sessions ride per-lineage workspace volumes with
   # park/rejoin instead of memory-snapshot banking, S3 archival at retirement,
   # and restore-first rejoin. Raw files in S3 replace multi-GiB snapshots.
-  # Armed on the first-boot format fix (#4279): mkfs of the fresh 10 GiB
-  # workspace ran synchronously on the guest's boot path, which is why the
-  # guest never served /shim/ready. Lazy itable/journal init moves it off that
-  # path, and the format is timed in the guest log either way.
-  persistenceEnabled: true
+  # OFF. Six arms. The guest never runs its init on a lineage COLD BOOT: the
+  # kernel boots and mounts the rootfs read-only, then the console goes silent
+  # and guest-init logs nothing at all (not even the volume-format line it
+  # would emit first), so readiness never arrives. Next step is the full guest
+  # console for one failing VM plus the cold-boot kernel cmdline (init=), per
+  # #4271. Everything CP-side and the drive attach are proven working.
+  persistenceEnabled: false


### PR DESCRIPTION
Sixth arm. The first-boot format fix (#4279) did not change the outcome, and the reason is informative: the guest emits NO format log line at all, so guest-init is not reaching the volume mount, it is not running. On a lineage cold boot the kernel boots and mounts the rootfs read-only and the console then goes silent until the readiness deadline. Everything control-plane side is proven working now (placement, async create, prime deadline, drive attach: both vda rootfs and vdb 10 GiB appear in the guest's own kernel log). The remaining fault is the cold-boot guest entrypoint. Disarmed; #4271 carries the next step.