### PR TITLE
fix(embervm): give a session cold boot its guest entrypoint (#4271)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.377
+version: 0.1.378

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.377
+      targetRevision: 0.1.378
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/noded/fcvm/driver/driver.go
+++ b/projects/embervm/noded/fcvm/driver/driver.go
@@ -802,6 +802,7 @@ func (d *Driver) Claim(ctx context.Context, spec substrate.ClaimSpec) (substrate
 		nic:            spec.NIC,
 		volumeDiskPath: spec.VolumeDiskPath,
 		volumeMount:    spec.VolumeMount,
+		harnessInit:    spec.ColdBootHarnessInit,
 	})
 }
 

--- a/projects/embervm/noded/fcvm/driver/driver_test.go
+++ b/projects/embervm/noded/fcvm/driver/driver_test.go
@@ -1298,3 +1298,14 @@ func TestWarmthRootLayout(t *testing.T) {
 		t.Errorf("DS StatefulDir = %q, want flat %q", d, root+"/stateful")
 	}
 }
+
+func TestBootArgsForCarriesSessionHarnessInit(t *testing.T) {
+	// A session cold boot MUST emit init=: without it the kernel finds no init
+	// and drops to /bin/sh, which is how the first live session cold boots
+	// failed (guest silent, readiness never arrived).
+	d := &Driver{}
+	args := d.bootArgsFor(coldBootSpec{harnessInit: "/usr/local/bin/ember-runtime-guest-init"})
+	if !strings.Contains(args, "init=/usr/local/bin/ember-runtime-guest-init") {
+		t.Fatalf("boot args = %q, want the harness init", args)
+	}
+}

--- a/projects/embervm/noded/server/server.go
+++ b/projects/embervm/noded/server/server.go
@@ -989,6 +989,19 @@ func (s *Server) Prime(ctx context.Context, req *nodev1.PrimeRequest) (*nodev1.P
 			}
 			return ""
 		}(),
+		// A lineage prime cold boots, so it must carry the guest entrypoint the
+		// way the serving cold boot does. Resolve it from the workload's image
+		// with the node default as fallback; without init= the kernel drops to
+		// /bin/sh and the guest never serves readiness.
+		ColdBootHarnessInit: func() string {
+			if req.GetLineageId() == "" {
+				return ""
+			}
+			if img, ok := s.resolveImage(base.workload, ""); ok && img.HarnessInit != "" {
+				return img.HarnessInit
+			}
+			return s.cfg.HarnessInit
+		}(),
 	}
 	h, err := s.driver.Claim(ctx, spec)
 	if err != nil {

--- a/projects/embervm/noded/substrate/substrate.go
+++ b/projects/embervm/noded/substrate/substrate.go
@@ -50,6 +50,13 @@ type ClaimSpec struct {
 	// ColdBootRootfsPath, when non-empty, is the per-workload base rootfs a
 	// volume-forced cold boot uses instead of the node default; empty for every other path.
 	ColdBootRootfsPath string
+	// ColdBootHarnessInit is the guest entrypoint emitted as init=<path> for a
+	// volume-forced cold boot. WITHOUT it the kernel finds no init and drops to
+	// /bin/sh, so the shim never runs and readiness never arrives: that is
+	// exactly how the first session cold boots failed, silently, since a warm
+	// restore resumes a snapshot where the shim is already running and never
+	// needed this. Empty for every path that does not cold boot a session.
+	ColdBootHarnessInit string
 }
 
 // NICSpec describes the tap network interface a serving-class microVM cold-boots


### PR DESCRIPTION
The root cause under six persistence arms, and the driver's own comment named it: harnessInit is 'Empty for task/session boots', and the daemon's driver-global is empty too, so a lineage prime emitted no init= and 'the kernel finds no init and falls back to /bin/sh'. The guest booted, mounted its rootfs read-only, attached both drives (visible in its own kernel log), and then sat at a shell until readiness expired. Warm restores never needed init= because they resume a snapshot whose shim is already running, which is why only session persistence ever hit this.

ClaimSpec now carries ColdBootHarnessInit, Prime resolves it from the workload image with the node default as fallback, and a driver test asserts the boot args contain init=. Persistence is armed in the same PR because this fix is the whole reason it can work; the probe follows immediately and revert stays one commit away.