### PR TITLE
feat(embervm): arm session persistence on the cold-boot init fix

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.378
+version: 0.1.379

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.378
+      targetRevision: 0.1.379
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -325,14 +325,7 @@ egress:
 # session at all. Sizing and the node disk arithmetic are in chart/values.yaml.
 claudeRuntimeWorkload:
   enabled: true
-  # The ADR 027 memory:false/filesystem:true quadrant, armed after the #4241
-  # hardening gate merged: sessions ride per-lineage workspace volumes with
-  # park/rejoin instead of memory-snapshot banking, S3 archival at retirement,
-  # and restore-first rejoin. Raw files in S3 replace multi-GiB snapshots.
-  # OFF. Six arms. The guest never runs its init on a lineage COLD BOOT: the
-  # kernel boots and mounts the rootfs read-only, then the console goes silent
-  # and guest-init logs nothing at all (not even the volume-format line it
-  # would emit first), so readiness never arrives. Next step is the full guest
-  # console for one failing VM plus the cold-boot kernel cmdline (init=), per
-  # #4271. Everything CP-side and the drive attach are proven working.
-  persistenceEnabled: false
+  # Armed on the session cold-boot init fix (#4282): a lineage prime emitted no
+  # init= on the kernel command line, so the guest dropped to /bin/sh and never
+  # served readiness. That was the root cause under six earlier arms.
+  persistenceEnabled: true


### PR DESCRIPTION
Seventh arm, on #4282, which fixed the root cause six arms were chasing: a session cold boot emitted no init= so the guest dropped to /bin/sh and never served readiness. Probe follows immediately.