### PR TITLE
fix(embervm): dial the owning instance on rejoin restore and prime (#4271)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.379
+version: 0.1.380

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -1438,9 +1438,14 @@ defmodule Embervm.SessionManager do
            key: workload, need_mib: Map.get(entry, :mem_mib) || 512,
            base: {:ready, :snapshot_ref}
          }),
-         :ok <- restore_session_workspace(state, volume_node_id, workload, lineage_id),
+         # Both the restore and the prime must reach the INSTANCE that owns this
+         # lineage on disk. volume_node_id is a bare node name (an anchor), and
+         # dialing it fails :unknown_node, which is exactly how the first live
+         # rejoin died after create and park both worked.
+         dial_id <- Embervm.WakeInstance.dial_for_session_volume(state.capacity_table, volume_node_id, lineage_id),
+         :ok <- restore_session_workspace(state, dial_id, workload, lineage_id),
          snapshot_ref <- get_in(brick, [:workloads, workload, :snapshot_ref]),
-         {:ok, vm_id} <- prime(state, volume_node_id, snapshot_ref, entry, lineage_id) do
+         {:ok, vm_id} <- prime(state, dial_id, snapshot_ref, entry, lineage_id) do
       {:ok, vm_id}
     else
       {:error, reason} -> {:error, reason}

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.379
+      targetRevision: 0.1.380
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
Persistence now creates and parks correctly (session 34 answered on a lineage volume, then parked). The rejoin failed with {:relight_failed, {:session_workspace_restore_failed, :unknown_node}} because perform_rejoin_prime dialed volume_node_id, a bare node name, for both the workspace restore and the prime. The channel layer resolves qualified instance ids, which is why retirement already needed WakeInstance.dial_for_session_volume; the wake path needs the same resolution.