### PR TITLE
revert(embervm): disarm persistence, leaked workspace volumes filled node disk

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.380
+version: 0.1.381

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.380
+      targetRevision: 0.1.381
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -325,7 +325,9 @@ egress:
 # session at all. Sizing and the node disk arithmetic are in chart/values.yaml.
 claudeRuntimeWorkload:
   enabled: true
-  # Armed on the session cold-boot init fix (#4282): a lineage prime emitted no
-  # init= on the kernel command line, so the guest dropped to /bin/sh and never
-  # served readiness. That was the root cause under six earlier arms.
-  persistenceEnabled: true
+  # OFF, urgently: seven arms of testing left 10 GiB lineage workspace images on
+  # node scratch (retirement could not dial its owning instance until #4283, so
+  # nothing reclaimed them) and a node now reports "No space left on device",
+  # which is failing stateful checkpoints cluster-wide. Do not re-arm until the
+  # leaked volumes are reclaimed and node disk headroom is verified.
+  persistenceEnabled: false


### PR DESCRIPTION
Urgent. Seven persistence validation arms each created a 10 GiB sparse lineage workspace, and retirement could not reach the instance owning them (the dial-vs-anchor bug, fixed only in #4283), so nothing reclaimed them. A node now reports 'No space left on device', which is failing demo-postgres stateful checkpoints in a tight retry loop. Disarming stops the bleeding; reclaiming the leaked images and verifying node headroom comes next.