### PR TITLE
docs(embervm): correct the persistence disarm rationale in values

### DIFF
--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -325,9 +325,24 @@ egress:
 # session at all. Sizing and the node disk arithmetic are in chart/values.yaml.
 claudeRuntimeWorkload:
   enabled: true
-  # OFF, urgently: seven arms of testing left 10 GiB lineage workspace images on
-  # node scratch (retirement could not dial its owning instance until #4283, so
-  # nothing reclaimed them) and a node now reports "No space left on device",
-  # which is failing stateful checkpoints cluster-wide. Do not re-arm until the
-  # leaked volumes are reclaimed and node disk headroom is verified.
+  # OFF, but read the corrected story before re-arming, because both halves of
+  # what this comment used to say were wrong.
+  #
+  # The Prime failures were once blamed on noded's lineage-volume path. The real
+  # cause was a session cold boot dropping into /bin/sh, because init= was never
+  # put on its kernel cmdline (#4271, fixed). Create and cold boot are validated
+  # live now: a session on a lineage volume answered a turn and recalled a
+  # codeword across it. Park and rejoin, the half that makes this worth having,
+  # is still unvalidated.
+  #
+  # The disarm reason was "seven arms left 10 GiB images and filled a node". The
+  # volumes are sparse (noded/volume/volume.go:142 Truncates rather than
+  # zero-fills), so they cost what is written, not 10 GiB each. node-4 reports
+  # DiskPressure False and its scratch is a dedicated NVMe mount, so what filled
+  # is EmberVM's own filesystem, not the host. Rootfs base churn from ~25 chart
+  # publishes in one day is the likelier consumer (#4286).
+  #
+  # Re-arm gate is therefore disk headroom under /var/lib/embervm/scratch, not
+  # code. Lineage volumes drain on their own once sessions hit maxLifetimeSeconds
+  # and the orphan sweep retires them (#4287 lets that run with this flag off).
   persistenceEnabled: false


### PR DESCRIPTION
## What

Rewrites the `claudeRuntimeWorkload.persistenceEnabled` comment. Both claims it made were wrong, and it is the first thing anyone reads before deciding whether to re-arm.

## Why

**On the failure diagnosis.** The comment blamed the Prime stream abort on noded's lineage-volume path and said it needed node-side investigation. The actual cause was that a session cold boot never had `init=` on its kernel cmdline, so the guest booted into `/bin/sh`, never signalled ready, and the Prime timed out (#4271). With that fixed, create and cold boot are validated live: a session riding a lineage volume answered a turn and recalled a codeword across it. Park and rejoin remain unvalidated, and the comment now says so plainly, because that is the half that justifies the feature.

**On the disarm reason.** I wrote that seven test arms left 10 GiB images and filled a node. Verified since:

- The volumes are sparse. `noded/volume/volume.go:142` Truncates rather than zero-fills and `volume_test.go:105` asserts it, so each costs what is written, not 10 GiB.
- node-4 reports `DiskPressure: False`, and `/var/lib/embervm/scratch` is a dedicated NVMe mount, so what filled is EmberVM's own filesystem rather than the host.
- The likelier consumer is guest rootfs base churn from roughly 25 chart publishes in a day (#4286).
- Lineage volumes drain unattended once sessions pass `maxLifetimeSeconds` and the orphan sweep retires them, which #4287 permits with the flag off.

So the re-arm gate is scratch headroom, not an outstanding code fix. Someone reading the old text would have gone looking for a noded bug that is not there.

## Deploy

Comment only, and deliberately **no chart bump**: publishing another chart version is the thing currently suspected of consuming that scratch, so this must not deploy until there is headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB