### PR TITLE
fix(embervm): let the token broker reach the apiserver to persist a grant

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.383
+version: 0.1.384

--- a/projects/embervm/chart/templates/tokenbroker-networkpolicy.yaml
+++ b/projects/embervm/chart/templates/tokenbroker-networkpolicy.yaml
@@ -54,6 +54,18 @@ spec:
     - toFQDNs: [{ matchName: {{ .fqdn | quote }} }]
       toPorts: [{ ports: [{ port: "443", protocol: TCP }] }]
     {{- end }}
-    - toEntities: [kube-apiserver]
+    # Persisting an approved grant writes a Secret through the apiserver, so this
+    # rule is what makes a login durable rather than merely successful.
+    #
+    # `kube-apiserver` alone is NOT enough here. The broker dials the kubernetes
+    # ClusterIP (10.43.0.1), which Cilium load-balances to one of the three
+    # masters' host IPs. When it picks the master the broker itself is scheduled
+    # on, the traffic is classified as `host`, and when it picks either other
+    # master it is `remote-node`; neither is the `kube-apiserver` identity. So
+    # the rule matched only sometimes, and the symptom was a silent dial timeout
+    # (packets dropped, not refused) rather than a 403. It cost a consumed
+    # single-use device code to find, because the flow completes and only the
+    # final Secret write fails (#4250).
+    - toEntities: [kube-apiserver, host, remote-node]
       toPorts: [{ ports: [{ port: "443", protocol: TCP }] }]
 {{- end }}

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.383
+      targetRevision: 0.1.384
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## What happened

A codex device login was **approved successfully** and then lost. The broker completed the OAuth flow, obtained the token bundle, and failed on the last step:

```
Get "https://10.43.0.1:443/api/v1/namespaces/embervm/secrets/embervm-oauth-grant-codex-cluster":
dial tcp 10.43.0.1:443: i/o timeout
```

State went to `failed`, and because device codes are single-use, the approval had to be redone.

## Root cause

The egress rule allowed only the `kube-apiserver` entity. That is not sufficient for a pod dialling the kubernetes **ClusterIP**: Cilium load-balances 10.43.0.1 across the three masters' host IPs, so the peer identity is

- `host` when it lands on the master the broker is scheduled on (it is on node-2, itself an apiserver endpoint), and
- `remote-node` when it lands on either of the other two.

Neither is the `kube-apiserver` identity, so the rule matched only some of the time.

## Why it was expensive to find

The failure mode is maximally unhelpful: a policy drop surfaces as a **dial timeout, not a 403**, so it reads as an apiserver outage rather than a policy gap. And it only triggers on the final Secret write, meaning every cheap part of the flow succeeds first. Reproducing it costs a human approval each time.

## Verified

`helm template` renders:

```yaml
- toEntities: [kube-apiserver, host, remote-node]
  toPorts: [{ ports: [{ port: "443", protocol: TCP }] }]
```

Chart bumped so it deploys.

## Follow-up worth doing separately

The broker should not discard an approved grant when persistence fails. A retry, or holding the bundle in memory so `login/status` can report "approved but not saved", would turn this from "the human approves again" into "it recovers itself". Filed against #4250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB