### PR TITLE
fix(embervm): make session persistence actually persist (workspace chown + rejoin dial)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.385
+version: 0.1.386

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -1411,10 +1411,10 @@ defmodule Embervm.SessionManager do
                                "ember.principal" => session.principal,
                                "ember.volume_node_id" => volume_node_id
                              }} do
-              with {:ok, vm_id} <- perform_rejoin_prime(state, volume_node_id, session.workload, session_id) do
+              with {:ok, vm_id, dial_id} <- perform_rejoin_prime(state, volume_node_id, session.workload, session_id) do
                 # noded's auto-destroy timer covers PrimeAssign after delivery starts.
                 # The CP destroys a successfully primed VM when delivery never starts.
-                {:ok, volume_node_id, vm_id, 0, volume_node_id}
+                {:ok, volume_node_id, vm_id, 0, dial_id}
               else
                 {:error, reason} -> {:error, reason}
                 other -> {:error, other}
@@ -1446,7 +1446,9 @@ defmodule Embervm.SessionManager do
          :ok <- restore_session_workspace(state, dial_id, workload, lineage_id),
          snapshot_ref <- get_in(brick, [:workloads, workload, :snapshot_ref]),
          {:ok, vm_id} <- prime(state, dial_id, snapshot_ref, entry, lineage_id) do
-      {:ok, vm_id}
+      # Return dial_id because this is the third distinct bare-anchor dial site.
+      # The previous fix resolved it correctly, then stopped one hop short by discarding it.
+      {:ok, vm_id, dial_id}
     else
       {:error, reason} -> {:error, reason}
       other -> {:error, other}

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -253,6 +253,7 @@ defmodule Embervm.SessionManagerTest do
           primed_vm_ids: []
         }
       },
+      session_volumes: Keyword.get(opts, :session_volumes, []),
       live_vms: 0,
       max_live_vms: 8,
       draining: false,
@@ -675,6 +676,37 @@ defmodule Embervm.SessionManagerTest do
     assert session.volume_node_id == parked.volume_node_id
     assert session.node_id == parked.volume_node_id
     assert session.vm_id == "vm-rejoined"
+  end
+
+  test "rejoin propagates the qualified volume dial to the first invoke" do
+    {:ok, dials} = Agent.start_link(fn -> [] end)
+    dial_fun = fn dial_id ->
+      Agent.update(dials, &[dial_id | &1])
+      {:ok, :fake_channel}
+    end
+
+    ctx =
+      start_stack(
+        prime_fun: fake_prime_fun("vm-rejoined-qualified"),
+        channel_fun: dial_fun,
+        session_channel_fun: dial_fun
+      )
+
+    created = create_persistence_session(ctx)
+    park_session(ctx, created)
+
+    put_brick(ctx, "wl-persist", "volume", session_volumes: [%{lineage_id: created.session_id}])
+    Agent.update(dials, fn _ -> [] end)
+
+    assert {:ok, %{status_code: 200}} =
+             SessionManager.invoke(ctx.mgr, created.session_id, %{body: "wake"})
+
+    rejoin_dials = Agent.get(dials, & &1)
+    assert "node-4/volume" in rejoin_dials
+    refute "node-4" in rejoin_dials
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.node_id == "node-4"
+    assert session.volume_node_id == "node-4"
   end
 
   test "rejoin delivery failure destroys the primed VM and leaves session parked" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.385
+      targetRevision: 0.1.386
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -96,6 +96,8 @@ CLI_UID_ENV = "EMBER_CLI_UID"
 CLI_GID_ENV = "EMBER_CLI_GID"
 DEFAULT_CLI_UID = 65532
 DEFAULT_CLI_GID = 65532
+PERSISTENCE_MOUNT_PATH_ENV = "EMBER_PERSISTENCE_MOUNT_PATH"
+DEFAULT_PERSISTENCE_MOUNT_PATH = "/session"
 VOICE_PROMPT = (
     "End every response with a single line: <voice>One or two plain sentences, "
     "no markdown, that a person could hear read aloud: what you did and anything "
@@ -126,6 +128,52 @@ def _ensure_cli_dir(path):
     kwargs = _cli_privilege_kwargs()
     if kwargs:
         os.chown(path, kwargs["user"], kwargs["group"])
+
+
+def _persistence_mount_path():
+    """Return the configured persistence mount path."""
+    path = os.environ.get(PERSISTENCE_MOUNT_PATH_ENV)
+    if path:
+        return path
+
+    try:
+        with open("/proc/cmdline") as stream:
+            cmdline = stream.read()
+    except OSError:
+        cmdline = ""
+    for token in cmdline.split():
+        if token.startswith("ember.volume_mount="):
+            configured_path = token.split("=", 1)[1]
+            if configured_path:
+                return configured_path
+
+    # The CR defines this durable volume path, but keep a default for non-init
+    # startup paths that do not provide the boot argument.
+    return DEFAULT_PERSISTENCE_MOUNT_PATH
+
+
+def _ensure_persistence_mountpoint_writable(path):
+    """Make the persistence mountpoint writable by the CLI process."""
+    kwargs = _cli_privilege_kwargs()
+    if not kwargs:
+        return
+
+    try:
+        ownership = os.stat(path)
+    except OSError:
+        return
+
+    if ownership.st_uid == kwargs["user"] and kwargs["group"] == ownership.st_gid:
+        return
+
+    # Only the mountpoint is chowned. Its contents can be a 10 GiB volume, so
+    # recursing would put unbounded work on every boot.
+    #
+    # A failure here is deliberately NOT swallowed. The bug this fixes was
+    # invisible precisely because the CLI fell back to ephemeral storage and
+    # the session looked healthy while persisting nothing, so a mountpoint the
+    # CLI still cannot write is worth failing loudly on (#4291).
+    os.chown(path, kwargs["user"], kwargs["group"])
 
 
 def _truncate_ring_for_error(ring, max_len=1500):
@@ -1334,6 +1382,7 @@ class ProcessManager:
         codex_executable="codex",
         pi_executable="pi",
     ):
+        _ensure_persistence_mountpoint_writable(_persistence_mount_path())
         self.claude = ClaudeProcess(workspace, claude_executable)
         self.codex = CodexProcess(workspace, codex_executable)
         self.pi = PiProcess(workspace, pi_executable)

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -79,6 +79,30 @@ for line in sys.stdin:
 """
 
 
+def test_ensure_persistence_mountpoint_writable(tmp_path, monkeypatch):
+    if os.geteuid() != 0:
+        pytest.skip("chown test requires root")
+
+    mountpoint = tmp_path / "session"
+    mountpoint.mkdir()
+    monkeypatch.setattr(shim.os, "geteuid", lambda: 0)
+    monkeypatch.setenv(shim.CLI_UID_ENV, str(shim.DEFAULT_CLI_UID))
+    monkeypatch.setenv(shim.CLI_GID_ENV, str(shim.DEFAULT_CLI_GID))
+
+    os.chown(mountpoint, 0, 0)
+    shim._ensure_persistence_mountpoint_writable(str(mountpoint))
+    ownership = os.stat(mountpoint)
+    assert ownership.st_uid == shim.DEFAULT_CLI_UID
+    assert ownership.st_gid == shim.DEFAULT_CLI_GID
+
+    shim._ensure_persistence_mountpoint_writable(str(mountpoint))
+    ownership = os.stat(mountpoint)
+    assert ownership.st_uid == shim.DEFAULT_CLI_UID
+    assert ownership.st_gid == shim.DEFAULT_CLI_GID
+
+    shim._ensure_persistence_mountpoint_writable(str(tmp_path / "missing"))
+
+
 FAKE_CLI_INIT_AFTER_INPUT = r"""#!/usr/bin/env python3
 import json
 import os


### PR DESCRIPTION
Two fixes that together make ADR 027 park/rejoin work, plus one chart bump covering both.

## 1. The workspace volume mounted but was unwritable (#4291)

Proven live on chart 0.1.383. Asked to write to `/session`, the agent replied:

> Wrote the codeword MERIDIAN to `/workspace/session/codeword.txt` since `/session` was inaccessible

From inside that guest:

```
drwxr-xr-x    5 root     root          4096 Aug  3 15:00 /session
/dev/vdb                  9.7G     84.0K      9.2G   0% /session
uid=65532(runtime) gid=65532(runtime)
```

The mount is healthy and correctly sized, and simply root-owned while the CLI runs as the non-root uid the guest deliberately uses. The agent falls back to ephemeral `/workspace`, so **persistence persisted nothing** while every health signal stayed green.

Fixed by chowning the mountpoint at shim startup, resolving the path from the `ember.volume_mount` boot arg noded already sets (`driver.go:421`). Only the mountpoint, never its contents: recursing a 10 GiB volume every boot would add unbounded startup latency. A chown failure is left to **raise**, because this bug survived precisely by failing silently.

## 2. Rejoin discarded its qualified dial

Rejoining a parked session restored and primed correctly, then died on the first invoke:

```
{"error":"session invoke failed","reason":"{:no_channel, :unknown_node}","retryable":false}
```

`perform_rejoin_prime` resolves the qualified volume dial and uses it for both the restore and the prime, then returned only `{:ok, vm_id}`. The rejoin worker therefore filled the dial slot of its outcome tuple with the bare `volume_node_id`, and that value becomes the session process's per-invoke dial key. A bare node anchor is not dialable on the brick fleet.

This is the **third distinct site** of the same bare-anchor-versus-qualified-dial bug in this file. The previous fix resolved the dial correctly and then discarded it one line later, so the defect moved rather than died. The new test asserts the qualified dial is used and the bare anchor is not.

## One bump for both, deliberately

Every chart publish lands another ~4 GiB guest base on every brick and nothing reclaims retired ones (#4290), so extra chart versions carry a real disk cost until that GC lands. That leak took the session lane down earlier today.

Fixes #4291

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB