### PR TITLE
fix(embervm): allow the token broker apiserver egress on 6443

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.384
+version: 0.1.385

--- a/projects/embervm/chart/templates/tokenbroker-networkpolicy.yaml
+++ b/projects/embervm/chart/templates/tokenbroker-networkpolicy.yaml
@@ -57,15 +57,28 @@ spec:
     # Persisting an approved grant writes a Secret through the apiserver, so this
     # rule is what makes a login durable rather than merely successful.
     #
-    # `kube-apiserver` alone is NOT enough here. The broker dials the kubernetes
-    # ClusterIP (10.43.0.1), which Cilium load-balances to one of the three
-    # masters' host IPs. When it picks the master the broker itself is scheduled
-    # on, the traffic is classified as `host`, and when it picks either other
-    # master it is `remote-node`; neither is the `kube-apiserver` identity. So
-    # the rule matched only sometimes, and the symptom was a silent dial timeout
-    # (packets dropped, not refused) rather than a 403. It cost a consumed
-    # single-use device code to find, because the flow completes and only the
-    # final Secret write fails (#4250).
+    # 6443 is the load-bearing port here, NOT 443. The broker dials the
+    # kubernetes ClusterIP 10.43.0.1:443, but Cilium enforces egress policy
+    # AFTER service translation, so what the datapath actually evaluates is the
+    # master's real endpoint, 192.168.1.x:6443 on k3s. A rule allowing only 443
+    # therefore denies every apiserver call while looking correct. Confirmed
+    # from the datapath rather than inferred:
+    #
+    #   xx drop (Policy denied) ... identity 49286->kube-apiserver:
+    #       10.42.3.116:38576 -> 192.168.1.119:6443 tcp SYN
+    #
+    # That trace also shows the peer identity resolving as `kube-apiserver`,
+    # so the entity was never the problem. `host` and `remote-node` are kept
+    # only because a master can serve its own node's traffic under that
+    # identity; they are not what fixed this.
+    #
+    # The symptom is a silent dial timeout, not a 403, so it reads as an
+    # apiserver outage. It costs a single-use device code per reproduction:
+    # the whole OAuth flow succeeds and only the final Secret write fails
+    # (#4250).
     - toEntities: [kube-apiserver, host, remote-node]
-      toPorts: [{ ports: [{ port: "443", protocol: TCP }] }]
+      toPorts:
+        - ports:
+            - { port: "443", protocol: TCP }
+            - { port: "6443", protocol: TCP }
 {{- end }}

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.384
+      targetRevision: 0.1.385
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Correcting my previous fix

#4292 added `host` and `remote-node` to the broker's apiserver egress rule on the theory that the ClusterIP load-balances to master host IPs and picks up those identities. **That was wrong**, and it did not fix the problem.

The datapath says so directly:

```
xx drop (Policy denied) ... identity 49286->kube-apiserver:
    10.42.3.116:38576 -> 192.168.1.119:6443 tcp SYN
```

Two things that trace settles:

1. The peer identity already resolves as `kube-apiserver`. The entity was never the issue.
2. The destination port is **6443**, not 443.

Cilium enforces egress policy **after** service translation. The broker dials `10.43.0.1:443`, but by the time policy is evaluated the packet is addressed to the master's real endpoint `192.168.1.119:6443`. A rule allowing only 443 denies every apiserver call while looking entirely correct on the page.

`host` and `remote-node` are kept, since a master can serve its own node's traffic under those identities, but they are not what fixes this.

## Verified

```yaml
- toEntities: [kube-apiserver, host, remote-node]
  toPorts:
    - ports:
        - { port: "443", protocol: TCP }
        - { port: "6443", protocol: TCP }
```

Chart bumped. I will confirm against the live broker with a `/token` probe (which exercises the same apiserver read path) BEFORE asking for another device approval, since each reproduction burns a single-use code.

## Lesson worth keeping

Both the original bug and my wrong fix came from reasoning about policy at the level it is *written* (ClusterIP, port 443) rather than the level it is *enforced* (translated endpoint, port 6443). For Cilium egress, read the drop trace first.

Related: #4250, #4292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB