### PR TITLE
chore(embervm): roll the bricks so egress sidecars pick up the codex grant

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.386
+version: 0.1.387

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.386
+      targetRevision: 0.1.387
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
## Why

The egress-proxy sidecar fetches its broker grant **once at startup** and caches it. Every sidecar started before the first codex login completed, so all of them cached the miss:

```
15:31:55 ERROR broker token empty; its egressTo hosts will be DENIED
         grant=codex-cluster err=broker returned 503 Service Unavailable
15:31:55 ERROR ...; restart the pod after it resolves
```

The login landed at 15:32:32, 37 seconds later. Nothing re-reads it, so the fleet is stuck holding an empty token and the codex lane fails with a provider `token_expired`.

This ordering is unavoidable by construction: a first-time login can only happen after the bricks are up, so a fresh grant *always* leaves every sidecar with a cached miss.

## What this is and is not

A version-only bump, no image change, so bricks restart without rebuilding guest bases. That distinction matters while retired bases still leak (#4290): image-changing publishes cost ~4 GiB per brick, this one costs nothing.

It is a workaround. The real fixes are in #4295:

1. Re-fetch the grant on a miss instead of caching a startup failure forever, which removes the roll-after-login requirement entirely.
2. Make the empty-token path actually **deny**. The sidecar logged that these hosts "will be DENIED" and then injected an empty credential anyway, so a local fail-closed turned into an opaque provider error. `deploy/values.yaml` states the invariant plainly: "If the broker is absent or unavailable, the sidecar fails closed and denies this host." It did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB