### PR TITLE
fix(embervm): inject the ChatGPT account id alongside the codex token

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.387
+version: 0.1.388

--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -378,9 +378,9 @@ containers:
       {{- fail (printf "egress.secrets entry for %v must set exactly one of secretRef or brokerGrant, and secretRef entries need env" $s.egressTo) }}
       {{- end }}
       {{- if $hasBrokerGrant }}
-      {{- $catalog = append $catalog (dict "header" $s.header "valuePrefix" ($s.valuePrefix | default "") "brokerGrant" $s.brokerGrant "egressTo" $s.egressTo) }}
+      {{- $catalog = append $catalog (dict "header" $s.header "valuePrefix" ($s.valuePrefix | default "") "brokerGrant" $s.brokerGrant "egressTo" $s.egressTo "claimHeader" ($s.claimHeader | default "") "claimPath" ($s.claimPath | default "")) }}
       {{- else }}
-      {{- $catalog = append $catalog (dict "header" $s.header "valuePrefix" ($s.valuePrefix | default "") "env" $s.env "egressTo" $s.egressTo) }}
+      {{- $catalog = append $catalog (dict "header" $s.header "valuePrefix" ($s.valuePrefix | default "") "env" $s.env "egressTo" $s.egressTo "claimHeader" ($s.claimHeader | default "") "claimPath" ($s.claimPath | default "")) }}
       {{- end }}
       {{- end }}
       - name: EGRESS_SECRETS

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.387
+      targetRevision: 0.1.388
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -314,6 +314,8 @@ egress:
       # The subscription grant supplies short-lived tokens. If the broker is
       # absent or unavailable, the sidecar fails closed and denies this host.
       brokerGrant: "codex-cluster"
+      claimHeader: "chatgpt-account-id"
+      claimPath: "https://api.openai.com/auth.chatgpt_account_id"
   # Shared with the monolith gardener, which reads the same item. Read-only sync,
   # so two consumers is fine; the field label CLAUDE_AUTH_TOKEN becomes the key.
   onepassword:

--- a/projects/firecracker/substrate/egress-proxy/cmd/swap.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/swap.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -133,6 +134,8 @@ type secretEntry struct {
 	Env         string   `json:"env"`
 	BrokerGrant string   `json:"brokerGrant"`
 	EgressTo    []string `json:"egressTo"`
+	ClaimHeader string   `json:"claimHeader"`
+	ClaimPath   string   `json:"claimPath"`
 	value       string   // resolved real value; never serialized, never logged
 	expiresAt   time.Time
 	broker      *tokenBroker
@@ -412,6 +415,10 @@ func (p *proxy) swapPump(guestR *bufio.Reader, guestW io.Writer, up net.Conn, ho
 			return
 		}
 		injected := injectRequest(req, sec)
+		if sec.ClaimHeader != "" && !injected {
+			p.logger.Warn("egress swap: claim injection failed; request denied", "dest", host, "header", sec.ClaimHeader, "status", "denied")
+			return
+		}
 		// A guest on the plaintext lane addresses us as a proxy, so its request line
 		// is absolute-form ("POST http://host/path"). Clearing RequestURI and the
 		// URL's scheme/host makes req.Write emit origin-form with a Host header,
@@ -489,6 +496,29 @@ func rejectSwapRequest(req *http.Request) bool {
 // the point: the guest's value is uncoupled config, and a prompt-injected guest
 // cannot authenticate as a different account by supplying its own token.
 func injectRequest(req *http.Request, sec *secretEntry) bool {
+	if sec.ClaimHeader != "" {
+		requested := len(req.Header.Values(sec.Header)) > 0
+		// Both guest values go before either decision, so a prompt-injected guest
+		// cannot keep its own account id by making the credential lookup fail.
+		req.Header.Del(sec.Header)
+		req.Header.Del(sec.ClaimHeader)
+		if !requested || sec.ClaimPath == "" {
+			return false
+		}
+		claim, ok := jwtClaim(sec.resolvedValue(), sec.ClaimPath)
+		if !ok {
+			return false
+		}
+		// BOTH headers, always together. The credential and the account id come
+		// from the same token by construction, which is the point of sourcing the
+		// claim here rather than trusting the guest: they cannot drift, and a
+		// valid token paired with a stale account id is exactly the failure this
+		// fixes (the provider rejects the pair and calls it token_expired).
+		req.Header.Set(sec.Header, sec.ValuePrefix+sec.resolvedValue())
+		req.Header.Set(sec.ClaimHeader, claim)
+		return true
+	}
+
 	requested := len(req.Header.Values(sec.Header)) > 0
 	// Delete every guest value, including duplicate and empty values, before
 	// deciding whether the guest requested credential injection.
@@ -498,4 +528,54 @@ func injectRequest(req *http.Request, sec *secretEntry) bool {
 	}
 	req.Header.Set(sec.Header, sec.ValuePrefix+sec.resolvedValue())
 	return true
+}
+
+func jwtClaim(token, path string) (string, bool) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", false
+	}
+	payload, err := decodeJWTPart(parts[1])
+	if err != nil {
+		return "", false
+	}
+	var claims map[string]any
+	if json.Unmarshal(payload, &claims) != nil {
+		return "", false
+	}
+	value, ok := findClaim(claims, path)
+	if !ok {
+		return "", false
+	}
+	claim, ok := value.(string)
+	return claim, ok && claim != ""
+}
+
+func decodeJWTPart(part string) ([]byte, error) {
+	if payload, err := base64.RawURLEncoding.DecodeString(part); err == nil {
+		return payload, nil
+	}
+	return base64.URLEncoding.DecodeString(part)
+}
+
+func findClaim(value any, path string) (any, bool) {
+	if path == "" {
+		return value, true
+	}
+	object, ok := value.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	if exact, ok := object[path]; ok {
+		return exact, true
+	}
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] != '.' {
+			continue
+		}
+		if prefix, ok := object[path[:i]]; ok {
+			return findClaim(prefix, path[i+1:])
+		}
+	}
+	return nil, false
 }

--- a/projects/firecracker/substrate/egress-proxy/cmd/swap_test.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/swap_test.go
@@ -122,7 +122,10 @@ func TestInjectRequestHandlesEveryAuthorizationValue(t *testing.T) {
 
 func TestInjectClaimHeaderSetsValueFromToken(t *testing.T) {
 	sec := &secretEntry{
-		Header:      "Authorization",
+		Header: "Authorization",
+		// Mirrors the live catalog entry: the claim path is the real one, dots and
+		// all, and the prefix is what production actually sends.
+		ValuePrefix: "Bearer ",
 		ClaimHeader: "chatgpt-account-id",
 		ClaimPath:   "https://api.openai.com/auth.chatgpt_account_id",
 		value:       testJWT(`{"https://api.openai.com/auth":{"chatgpt_account_id":"account-123"}}`),
@@ -142,7 +145,7 @@ func TestInjectClaimHeaderSetsValueFromToken(t *testing.T) {
 	// The credential MUST still be injected on the claim path. An earlier draft of
 	// this branch set only the account id, silently dropping the token, and a test
 	// that asserted the new header alone was happy to let that through.
-	if got := req.Header.Get("Authorization"); got != "Bearer "+sec.value {
+	if got := req.Header.Get("Authorization"); got != sec.ValuePrefix+sec.value {
 		t.Errorf("Authorization = %q, want the injected credential, not the guest value", got)
 	}
 }

--- a/projects/firecracker/substrate/egress-proxy/cmd/swap_test.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/swap_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -117,6 +118,108 @@ func TestInjectRequestHandlesEveryAuthorizationValue(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInjectClaimHeaderSetsValueFromToken(t *testing.T) {
+	sec := &secretEntry{
+		Header:      "Authorization",
+		ClaimHeader: "chatgpt-account-id",
+		ClaimPath:   "https://api.openai.com/auth.chatgpt_account_id",
+		value:       testJWT(`{"https://api.openai.com/auth":{"chatgpt_account_id":"account-123"}}`),
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://chatgpt.com/backend-api", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer guest-token")
+
+	if !injectRequest(req, sec) {
+		t.Fatal("injectRequest denied a valid JWT claim")
+	}
+	if got := req.Header.Get("chatgpt-account-id"); got != "account-123" {
+		t.Errorf("chatgpt-account-id = %q, want the extracted account ID", got)
+	}
+	// The credential MUST still be injected on the claim path. An earlier draft of
+	// this branch set only the account id, silently dropping the token, and a test
+	// that asserted the new header alone was happy to let that through.
+	if got := req.Header.Get("Authorization"); got != "Bearer "+sec.value {
+		t.Errorf("Authorization = %q, want the injected credential, not the guest value", got)
+	}
+}
+
+func TestInjectClaimHeaderDeletesGuestValue(t *testing.T) {
+	sec := &secretEntry{
+		Header:      "Authorization",
+		ClaimHeader: "chatgpt-account-id",
+		ClaimPath:   "account_id",
+		value:       testJWT(`{"account_id":"real-account"}`),
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://chatgpt.com/backend-api", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer guest-token")
+	req.Header.Set("chatgpt-account-id", "guest-account")
+
+	if !injectRequest(req, sec) {
+		t.Fatal("injectRequest denied a valid JWT claim")
+	}
+	if got := req.Header.Get("chatgpt-account-id"); got != "real-account" {
+		t.Errorf("chatgpt-account-id = %q, want the guest value discarded", got)
+	}
+}
+
+func TestInjectClaimHeaderDeniesOnMissingClaim(t *testing.T) {
+	sec := &secretEntry{Header: "Authorization", ClaimHeader: "chatgpt-account-id", ClaimPath: "account_id", value: testJWT(`{"other":"value"}`)}
+	req, err := http.NewRequest(http.MethodGet, "https://chatgpt.com/backend-api", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer guest-token")
+	req.Header.Set("chatgpt-account-id", "guest-account")
+
+	if injectRequest(req, sec) {
+		t.Fatal("injectRequest allowed a request with a missing claim")
+	}
+	if got := req.Header.Get("chatgpt-account-id"); got != "" {
+		t.Errorf("chatgpt-account-id = %q, want the header deleted on denial", got)
+	}
+}
+
+func TestInjectClaimHeaderDeniesOnInvalidJWT(t *testing.T) {
+	sec := &secretEntry{Header: "Authorization", ClaimHeader: "chatgpt-account-id", ClaimPath: "account_id", value: "not-a-jwt"}
+	req, err := http.NewRequest(http.MethodGet, "https://chatgpt.com/backend-api", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer guest-token")
+
+	if injectRequest(req, sec) {
+		t.Fatal("injectRequest allowed an invalid JWT")
+	}
+}
+
+func TestInjectRequestBackwardCompatible(t *testing.T) {
+	sec := &secretEntry{Header: "Authorization", ValuePrefix: "Bearer ", value: "real-token"}
+	req, err := http.NewRequest(http.MethodGet, "https://api.example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "guest-token")
+
+	if !injectRequest(req, sec) {
+		t.Fatal("injectRequest denied a legacy catalog entry")
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer real-token" {
+		t.Errorf("Authorization = %q, want legacy credential injection", got)
+	}
+}
+
+func testJWT(payload string) string {
+	encode := func(value string) string {
+		return base64.RawURLEncoding.EncodeToString([]byte(value))
+	}
+	return encode(`{"alg":"none"}`) + "." + encode(payload) + ".signature"
 }
 
 func TestSwapPumpRejectsUnsupportedRequestModes(t *testing.T) {


### PR DESCRIPTION
Fixes #4295. This is the last blocker between the codex lane and a working turn.

## The bug

The codex CLI sends **two** pieces of identity to `chatgpt.com`, and the sidecar only fixed one:

| Header | Value on the wire |
|---|---|
| `Authorization` | the real broker token, injected |
| `chatgpt-account-id` | `guest-subscription-account`, the guest's placeholder |

So the backend received a valid token for a real account paired with an account header naming an account that does not exist, and rejected the pair as `code: "token_expired"`.

## That error string cost three wrong diagnoses

Worth recording, because the message actively misleads. Decoding the injected token (claims only) settled it:

```
iat  2026-08-03T15:32:32Z
exp  2026-08-13T15:32:32Z     862696 seconds remaining at the time of failure
aud  ["https://api.openai.com/v1"]
```

Not expired, right account, correct audience. Before reading the token I had blamed, in order: the dummy JWT passing through un-swapped (wrong, the sidecar logs `injected: true`), a startup-order race caching an empty grant (wrong, `main.go:199` re-resolves per request, which also makes #4296 an unnecessary roll), and TLS bypassing the sidecar (wrong, the lane is cleartext by design).

## The fix

Inject `chatgpt-account-id` from the `chatgpt_account_id` claim of the very token being injected. Sidecar-side, so:

- the guest never holds real identity, preserving the ADR 023 property, and
- the credential and the account id cannot drift, because both come from the same token.

Guest-supplied values for **both** headers are deleted before either decision, so a prompt-injected guest cannot keep its own account id by making the credential lookup fail. Missing claim or unparseable token denies rather than sending a half-correct pair. The JWT signature is deliberately not verified: the sidecar is not the audience and treats the token as an opaque data carrier.

Entries without the new `claimHeader` / `claimPath` fields behave exactly as before.

## Review notes

The first implementation deleted `Authorization` and set only the account id, silently dropping the credential. Its test passed, because it asserted only the new header. Fixed to set both, and the test now pins the credential too, with the fixture carrying the real `ValuePrefix` and the real dotted claim path so it mirrors production.

Verified by a full `ci test` on the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XPqvkgfcFNHzz5guSSsBB