### PR TITLE
fix(embervm): route codex connector traffic through the inject lane, log injected status

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.388
+version: 0.1.389

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.388
+      targetRevision: 0.1.389
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -986,14 +986,20 @@ class CodexProcess:
             CODEX_SUBSCRIPTION_BASE_URL_ENV, DEFAULT_CODEX_SUBSCRIPTION_BASE_URL
         )
         # Subscription backend endpoint over cleartext injection lane (token injection happens at sidecar).
+        # chatgpt_base_url must be set too: the CLI's connector client (rmcp
+        # transport) builds its URL from chatgpt_base_url, not from the model
+        # provider base_url. Left at the https default it bypasses the sidecar's
+        # injection lane, presents the guest's placeholder JWT, gets a 401, and
+        # the CLI's resulting token refresh attempt aborts the turn (issue #4298).
         config = """model_provider = "ember-openai"
 enable_codex_api_key_env = false
+chatgpt_base_url = %s
 
 [model_providers.ember-openai]
 name = "ember-openai"
 base_url = %s
 wire_api = "responses"
-""" % json.dumps(base_url)
+""" % (json.dumps(base_url), json.dumps(base_url))
         with open(os.path.join(codex_home, "config.toml"), "w") as stream:
             stream.write(config)
 

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -165,6 +165,7 @@ assert os.path.isfile(config_path)
 config = open(config_path).read()
 assert 'model_provider = "ember-openai"' in config
 assert 'base_url = "http://chatgpt.com/backend-api/"' in config
+assert 'chatgpt_base_url = "http://chatgpt.com/backend-api/"' in config
 assert "enable_codex_api_key_env = false" in config
 assert 'wire_api = "responses"' in config
 assert "--skip-git-repo-check" in sys.argv
@@ -395,6 +396,7 @@ def test_codex_config_uses_subscription_endpoint_override(tmp_path, monkeypatch)
     manager._write_model_config(child_env["CODEX_HOME"])
     config = (tmp_path / "workspace" / ".codex" / "config.toml").read_text()
     assert 'base_url = "%s"' % endpoint in config
+    assert 'chatgpt_base_url = "%s"' % endpoint in config
     assert "api.openai.com" not in config
     assert 'name = "ember-openai"' in config
     assert 'wire_api = "responses"' in config

--- a/projects/firecracker/substrate/egress-proxy/cmd/swap.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/swap.go
@@ -453,7 +453,7 @@ func (p *proxy) swapPump(guestR *bufio.Reader, guestW io.Writer, up net.Conn, ho
 			p.logger.Warn("egress swap: return response", "dest", host, "err", err)
 			return
 		}
-		p.logger.Info("egress injected", "dest", host, "header", sec.Header, "injected", injected, "path", req.URL.Path)
+		p.logger.Info("egress injected", "dest", host, "header", sec.Header, "injected", injected, "path", req.URL.Path, "status", resp.StatusCode)
 		// Honour the guest's Connection: close rather than blocking on a request it
 		// has already told us will not come; the caller's defer closes both sides.
 		if closeAfter {


### PR DESCRIPTION
## What

Two small changes toward #4298 (codex turn still failing after the #4295 fix), plus the chart bump that deploys them:

1. **`shim.py`: write `chatgpt_base_url` into the codex `config.toml`**, set to the same cleartext endpoint as the model provider `base_url`. Verified against rust-v0.146.0 source (`core/src/connectors.rs`): the CLI's rmcp connector client builds its URL from `config.chatgpt_base_url`, not from the provider `base_url`, so it was dialing `https://chatgpt.com` directly, blind-tunneling past the sidecar, presenting the guest's placeholder JWT, and the resulting 401 tripped a guest-side token refresh whose failure aborted the turn. With this override the connector traffic rides the injection lane and carries the broker credential. Both `shim_test.py` config assertions extended.

2. **`swap.go`: add the upstream response status to the `egress injected` log line.** During the #4298 verification the six `/backend-api/responses` retries were indistinguishable from successes in the sidecar log; this makes the next failure diagnosable from pod logs alone. `resp.StatusCode` stays valid after `Body.Close()`, so the line keeps its position. No test asserts on this log line.

3. `bump-chart.sh projects/embervm`: 0.1.388 to 0.1.389 so ArgoCD rolls the new shim and sidecar together.

## Verification

- `go test ./...` green in `projects/firecracker/substrate/egress-proxy` (local toolchain; this remote container cannot run the full `ci` loop because bootstrap needs crane, so PR CI is the gate).
- `py_compile` clean on shim and test; gofmt clean.
- After merge and sync: re-run the luna verification turn from #4298. Success gate is `result_text` containing READY; if it still fails, the new `status` field in the sidecar log says exactly how the `/responses` requests are failing.

Related: #4298, #4295, ADR 048, ADR 023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zhH74Mm8KHGpKj4wL6FwP

---
_Generated by [Claude Code](https://claude.ai/code/session_011zhH74Mm8KHGpKj4wL6FwP)_