### PR TITLE
feat(monolith): expose embervm session list and destroy over MCP

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.344
+version: 0.89.345
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.344
+      targetRevision: 0.89.345
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -25,6 +25,7 @@ from agent_sessions.transport import (
 )
 from core.db import get_engine
 from core.mcp_app import mcp
+from faas.embervm_client import EmberVMTransportError
 from framework import log_task_exception
 
 _transport = EmberVmShimTransport()
@@ -68,6 +69,11 @@ def _persist_ember_session(session_id: int, ember: EmberSession) -> None:
             ember.session_token,
             ember.expires_at,
         )
+
+
+def _clear_ember_bindings_for(ember_id: str) -> list[int]:
+    with Session(get_engine()) as db_session:
+        return store.clear_ember_bindings_by_ember_id(db_session, ember_id)
 
 
 def _persist_pending_message(
@@ -524,6 +530,43 @@ async def monolith_agent_detail(session_id: int, turn: int | None = None) -> dic
         "model": selected.model,
         "activities": _activities(selected),
     }
+
+
+@mcp.tool
+async def monolith_agent_session_vms(limit: int = 50, offset: int = 0) -> dict:
+    """List the EmberVM session VMs holding claude-runtime workload slots.
+
+    The workload cap counts parked sessions as live, so stale test sessions
+    can deny every new create with a workload_cap 429. This lists the slot
+    holders (state, timestamps, expiry) so the stale ones can be destroyed
+    with monolith-agent-session-destroy.
+    """
+    try:
+        return await _transport.list_sessions(limit=limit, offset=offset)
+    except EmberVMTransportError as exc:
+        return {"error": str(exc)}
+
+
+@mcp.tool
+async def monolith_agent_session_destroy(ember_session_id: str) -> dict:
+    """Destroy one EmberVM session VM, freeing its workload cap slot.
+
+    Args:
+        ember_session_id: The control plane session id (s-...), from
+            monolith-agent-session-vms or a session's stored binding.
+
+    Destroying a session an in-flight turn is using makes that turn fail;
+    intended for stale or parked test sessions. Any monolith agent session
+    bound to the destroyed id has its binding cleared so the next send
+    creates a fresh EmberVM session instead of invoking a dead one.
+    """
+    try:
+        result = await _transport.destroy_session(ember_session_id)
+    except EmberVMTransportError as exc:
+        return {"error": str(exc)}
+    cleared = await asyncio.to_thread(_clear_ember_bindings_for, ember_session_id)
+    result["cleared_bindings"] = cleared
+    return result
 
 
 # -- token broker login (ADR 048, #4250 PR 2) --------------------------------

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -555,8 +555,8 @@ async def monolith_agent_session_destroy(ember_session_id: str) -> dict:
         ember_session_id: The control plane session id (s-...), from
             monolith-agent-session-vms or a session's stored binding.
 
-    Destroying a session an in-flight turn is using makes that turn fail;
-    intended for stale or parked test sessions. Any monolith agent session
+    Destroying a session an in-flight turn is using makes that turn fail,
+    so this is intended for stale or parked test sessions. Any monolith agent session
     bound to the destroyed id has its binding cleared so the next send
     creates a fresh EmberVM session instead of invoking a dead one.
     """

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -783,6 +783,51 @@ def test_broker_login_status_granted_notifies(monkeypatch):
     assert notified and notified[0][1] == "info"
 
 
+def test_session_vms_returns_transport_payload(monkeypatch):
+    payload = {
+        "workload": "claude-runtime",
+        "items": [{"session_id": "s-abc", "state": "parked"}],
+        "total": 1,
+        "limit": 50,
+        "offset": 0,
+    }
+
+    async def fake_list_sessions(limit=50, offset=0):
+        return payload
+
+    monkeypatch.setattr(mcp._transport, "list_sessions", fake_list_sessions)
+    result = asyncio.run(mcp.monolith_agent_session_vms())
+    assert result == payload
+
+
+def test_session_destroy_clears_matching_binding(monkeypatch, session):
+    row = store.create_session(session, "sid-123", "/workspace", "main")
+    store.set_ember_session(session, row.id, "s-abc", "token-1", None)
+
+    async def fake_destroy_session(ember_session_id):
+        return {"session_id": "s-abc", "state": "destroyed"}
+
+    monkeypatch.setattr(mcp._transport, "destroy_session", fake_destroy_session)
+    result = asyncio.run(mcp.monolith_agent_session_destroy("s-abc"))
+
+    assert result["state"] == "destroyed"
+    assert result["cleared_bindings"] == [row.id]
+
+    session.expire_all()
+    reloaded = store.get_session(session, row.id)
+    assert reloaded.ember_session_id is None
+    assert reloaded.ember_session_token is None
+
+
+def test_session_destroy_surfaces_transport_error(monkeypatch):
+    async def failing_destroy_session(ember_session_id):
+        raise EmberVMTransportError("boom")
+
+    monkeypatch.setattr(mcp._transport, "destroy_session", failing_destroy_session)
+    result = asyncio.run(mcp.monolith_agent_session_destroy("s-abc"))
+    assert result == {"error": "boom"}
+
+
 def test_broker_login_rejects_bad_grant_and_unset_url(monkeypatch):
     monkeypatch.setenv("EMBER_TOKENBROKER_URL", "http://broker")
     with pytest.raises(ValueError):

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -82,6 +82,30 @@ def clear_ember_session(session: Session, session_id: int) -> AgentSession:
     return row
 
 
+def clear_ember_bindings_by_ember_id(session: Session, ember_id: str) -> list[int]:
+    """Null the ember binding on every AgentSession bound to ember_id.
+
+    A destroyed EmberVM session can be bound to more than one AgentSession
+    row over its lifetime (retries, resumed turns), so this clears all of
+    them in one commit rather than assuming a single owner. Rows are loaded
+    via exec/select and mutated in place, then committed once; nothing is
+    session.add-ed in a loop.
+
+    Returns the ids of the affected AgentSession rows.
+    """
+    rows = session.exec(
+        select(AgentSession).where(AgentSession.ember_session_id == ember_id)
+    ).all()
+    ids: list[int] = []
+    for row in rows:
+        row.ember_session_id = None
+        row.ember_session_token = None
+        row.ember_session_expires_at = None
+        ids.append(row.id)
+    session.commit()
+    return ids
+
+
 def create_turn(
     session: Session,
     session_id: int,

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -173,6 +173,95 @@ class EmberVmShimTransport:
             logger.warning("embervm session creation transport error: %s", exc)
             raise EmberVMTransportError(str(exc)) from exc
 
+    # The operator surface for the workload cap: parked sessions count as live
+    # slot holders, so a stale test session denies every new create until it
+    # is listed here and destroyed. Both calls use management auth, not a
+    # session bearer token, so they act on any session in the workload.
+
+    async def list_sessions(self, limit: int = 50, offset: int = 0) -> dict:
+        """List the control plane's sessions for this workload (management auth).
+
+        Args:
+            limit: Maximum sessions to return (clamped 1-500 server side).
+            offset: Offset into the workload's session list.
+
+        Returns:
+            The control plane's paginated session listing.
+
+        Raises:
+            EmberVMTransportError: If the listing request fails.
+        """
+        if not EMBERVM_URL:
+            raise EmberVMTransportError("EMBERVM_URL is not configured")
+
+        url = f"{EMBERVM_URL}/v1/workloads/{self.workload}/sessions"
+        headers = auth_headers()
+        timeout = httpx.Timeout(self.read_timeout, connect=SUBMIT_CONNECT_TIMEOUT)
+
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.get(
+                    url, params={"limit": limit, "offset": offset}, headers=headers
+                )
+                response.raise_for_status()
+                return response.json()
+        except httpx.TimeoutException as exc:
+            logger.warning("embervm session listing timed out: %s", exc)
+            raise EmberVMTimeout(str(exc)) from exc
+        except httpx.HTTPStatusError as exc:
+            logger.warning("embervm session listing failed: %s", exc)
+            raise EmberVMTransportError(_status_error_detail(exc)) from exc
+        except httpx.TransportError as exc:
+            logger.warning("embervm session listing transport error: %s", exc)
+            raise EmberVMTransportError(str(exc)) from exc
+
+    async def destroy_session(self, ember_session_id: str) -> dict:
+        """Destroy one control plane session by its EmberVM session id (management auth).
+
+        Args:
+            ember_session_id: The control plane session id (s-...) to destroy.
+
+        Returns:
+            The control plane's destroy response.
+
+        Raises:
+            EmberVMTransportError: If the destroy request fails, including a
+                404 for a session that is already gone.
+        """
+        if not EMBERVM_URL:
+            raise EmberVMTransportError("EMBERVM_URL is not configured")
+
+        url = f"{EMBERVM_URL}/v1/sessions/{ember_session_id}"
+        headers = auth_headers()
+        timeout = httpx.Timeout(self.read_timeout, connect=SUBMIT_CONNECT_TIMEOUT)
+
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.delete(url, headers=headers)
+                response.raise_for_status()
+                return response.json()
+        except httpx.TimeoutException as exc:
+            logger.warning(
+                "embervm session destroy timed out for session %s: %s",
+                ember_session_id,
+                exc,
+            )
+            raise EmberVMTimeout(str(exc)) from exc
+        except httpx.HTTPStatusError as exc:
+            logger.warning(
+                "embervm session destroy failed for session %s: %s",
+                ember_session_id,
+                exc,
+            )
+            raise EmberVMTransportError(_status_error_detail(exc)) from exc
+        except httpx.TransportError as exc:
+            logger.warning(
+                "embervm session destroy transport error for session %s: %s",
+                ember_session_id,
+                exc,
+            )
+            raise EmberVMTransportError(str(exc)) from exc
+
     async def deliver(
         self,
         ember: EmberSession | None,

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.419
+version: 0.285.420
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.419
+      targetRevision: 0.285.420
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

Adds the operator control that was missing when the codex verification hit the `workload_cap` trap (#4298 context): the `claude-runtime` workload cap is 4 live session VMs, parked counts as live, and nothing in the MCP surface could list or clear the slot holders, so stale test sessions denied every new create until their 6h `maxLifetimeSeconds` expiry.

Two curated MCP tools in `agent_sessions`, per the curated-verbs approach (Option A) over a generic control plane pass-through:

1. **`monolith-agent-session-vms`**: wraps the control plane's existing `GET /v1/workloads/:name/sessions` (management auth, paged) so the slot holders are visible with state and timestamps.
2. **`monolith-agent-session-destroy`**: wraps `DELETE /v1/sessions/:id` for one session id at a time (no bulk destroy), then clears any monolith-side `AgentSession` ember binding referencing the destroyed id so the next send creates a fresh EmberVM session instead of invoking a dead one.

Transport methods mirror `create_session`'s guard, auth, timeout, and exception mapping. MCP tools follow the async-must-not-touch-DB rule (`asyncio.to_thread` sync helpers). Store helper clears bindings across all matching rows in one commit.

Chart bumps for monolith (0.285.419 to 0.285.420) and, via the bump script's documented coupling, monolith-public (0.89.344 to 0.89.345).

## Verification

- Three new tests in `mcp_test.py` following the file's existing monkeypatch/fixture idioms: list passthrough, destroy clears the matching binding, transport error surfaces as `{"error": ...}` without raising.
- `py_compile` clean on all four edited files; this remote container cannot run the full `ci` loop (bootstrap needs crane), so PR CI is the gate.
- After merge and sync: use the new tools to clear today's stale test sessions and finish the #4298 luna verification.

Related: #4298, ADR 048.

---
_Generated by [Claude Code](https://claude.ai/code/session_011zhH74Mm8KHGpKj4wL6FwP)_