### PR TITLE
fix(embervm): point codex model provider at the codex responses path

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.389
+version: 0.1.390

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.389
+      targetRevision: 0.1.390
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -985,12 +985,24 @@ class CodexProcess:
         base_url = os.environ.get(
             CODEX_SUBSCRIPTION_BASE_URL_ENV, DEFAULT_CODEX_SUBSCRIPTION_BASE_URL
         )
+        provider_base_url = base_url.rstrip("/") + "/codex/"
         # Subscription backend endpoint over cleartext injection lane (token injection happens at sidecar).
         # chatgpt_base_url must be set too: the CLI's connector client (rmcp
         # transport) builds its URL from chatgpt_base_url, not from the model
         # provider base_url. Left at the https default it bypasses the sidecar's
         # injection lane, presents the guest's placeholder JWT, gets a 401, and
         # the CLI's resulting token refresh attempt aborts the turn (issue #4298).
+        #
+        # The model provider base_url is a different value on purpose. Codex
+        # turn requests get posted to {provider base_url}/responses, and the
+        # subscription backend only serves turns at /backend-api/codex/responses,
+        # not at /backend-api/responses. The rmcp connector client above builds
+        # from chatgpt_base_url at the backend-api root, so the two values must
+        # diverge: chatgpt_base_url stays at the root, provider_base_url gets a
+        # /codex/ suffix. The trailing slash on provider_base_url is load
+        # bearing: it makes both plausible client join behaviors, trimming the
+        # trailing slash and concatenating, or an RFC 3986 Url::join with a
+        # relative segment, land on the same /codex/responses path.
         config = """model_provider = "ember-openai"
 enable_codex_api_key_env = false
 chatgpt_base_url = %s
@@ -999,7 +1011,7 @@ chatgpt_base_url = %s
 name = "ember-openai"
 base_url = %s
 wire_api = "responses"
-""" % (json.dumps(base_url), json.dumps(base_url))
+""" % (json.dumps(base_url), json.dumps(provider_base_url))
         with open(os.path.join(codex_home, "config.toml"), "w") as stream:
             stream.write(config)
 

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -403,6 +403,21 @@ def test_codex_config_uses_subscription_endpoint_override(tmp_path, monkeypatch)
     assert "enable_codex_api_key_env = false" in config
 
 
+def test_codex_config_appends_codex_to_no_slash_endpoint(tmp_path, monkeypatch):
+    manager = _codex_manager(tmp_path, monkeypatch)
+    endpoint = "http://broker.test/backend-api"
+    monkeypatch.setenv(shim.CODEX_SUBSCRIPTION_BASE_URL_ENV, endpoint)
+    child_env = manager._child_env()
+    manager._write_model_config(child_env["CODEX_HOME"])
+    config = (tmp_path / "workspace" / ".codex" / "config.toml").read_text()
+    assert 'base_url = "http://broker.test/backend-api/codex/"' in config
+    assert 'chatgpt_base_url = "%s"' % endpoint in config
+    assert "api.openai.com" not in config
+    assert 'name = "ember-openai"' in config
+    assert 'wire_api = "responses"' in config
+    assert "enable_codex_api_key_env = false" in config
+
+
 def test_codex_child_env_drops_openai_api_key(tmp_path, monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "must-not-reach-codex")
     manager = _codex_manager(tmp_path, monkeypatch)

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -164,7 +164,7 @@ config_path = os.path.join(os.environ["CODEX_HOME"], "config.toml")
 assert os.path.isfile(config_path)
 config = open(config_path).read()
 assert 'model_provider = "ember-openai"' in config
-assert 'base_url = "http://chatgpt.com/backend-api/"' in config
+assert 'base_url = "http://chatgpt.com/backend-api/codex/"' in config
 assert 'chatgpt_base_url = "http://chatgpt.com/backend-api/"' in config
 assert "enable_codex_api_key_env = false" in config
 assert 'wire_api = "responses"' in config
@@ -395,7 +395,7 @@ def test_codex_config_uses_subscription_endpoint_override(tmp_path, monkeypatch)
     child_env = manager._child_env()
     manager._write_model_config(child_env["CODEX_HOME"])
     config = (tmp_path / "workspace" / ".codex" / "config.toml").read_text()
-    assert 'base_url = "%s"' % endpoint in config
+    assert 'base_url = "http://broker.test/backend-api/codex/"' in config
     assert 'chatgpt_base_url = "%s"' % endpoint in config
     assert "api.openai.com" not in config
     assert 'name = "ember-openai"' in config


### PR DESCRIPTION
Fixes the turn-killing 404 from #4298: the shim wrote one URL into both `chatgpt_base_url` and the model provider `base_url`, so the codex CLI posted turn requests to `/backend-api/responses`. The subscription backend serves codex turns at `/backend-api/codex/responses` and answered every attempt with an authenticated 404 (six retries, then exit 1), verified live via the sidecar's per-request status logging from PR #4299.

## Changes

- `shim.py` `_write_model_config`: derive `provider_base_url = base_url.rstrip("/") + "/codex/"` and write it into `[model_providers.ember-openai] base_url`, while `chatgpt_base_url` keeps the backend-api root for the CLI's rmcp connector client. The trailing slash is deliberate: both plausible client join behaviors (trim-and-concat, RFC 3986 join) land on `/codex/responses`.
- `shim_test.py`: both config assertions updated (default and `CODEX_SUBSCRIPTION_BASE_URL` override).
- Chart 0.1.389 -> 0.1.390 via `bump-chart.sh` so the runtime image change deploys.

## Verification

- `ci lint` and `ci regen` clean (gazelle churn from this container's missing orion plugins was reverted; the change adds no files or imports, so no BUILD changes are needed).
- `ci test` was not runnable in this environment (no `bb` and the proxy 403s its download); the Workflows Test check on this PR is the gate.
- Post-merge gate: after the bricks roll to 0.1.390, a `luna` READY turn on the agent-session lane must return `result_text` containing READY. I will run it and report on #4298.

Out of scope, tracked in #4298: the sidecar fail-closed denial of credential-less rmcp requests to `/backend-api/ps/mcp`, and the models-catalog decode skew in the pinned CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS

---
_Generated by [Claude Code](https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS)_