### PR TITLE
fix(embervm): stop passing -C to codex exec resume

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -723,9 +723,10 @@ multiarch_http_file(
 # per-arch extract paths, not just adding a URL.
 #
 # Pinned, not floating: the shim's adapter depends on observed behaviour
-# (thread.started/thread_id, item.completed agent_message, turn.completed usage,
-# and the `exec resume <id> <prompt>` argument order, which differs from plain
-# `exec` in that it rejects --sandbox and -C). A silent upgrade could change those.
+# (thread.started/thread_id, item.completed agent_message, turn.completed
+# usage, and the `exec resume <id> <prompt>` argument order, which differs from
+# plain `exec` in that it rejects --sandbox and -C). A silent upgrade could
+# change those.
 multiarch_http_file(
     name = "codex_cli",
     amd64_sha256 = "5ba3b9405543953081f661d0854d266f76e2abbe51d41349355a36de7673776a",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -725,7 +725,7 @@ multiarch_http_file(
 # Pinned, not floating: the shim's adapter depends on observed behaviour
 # (thread.started/thread_id, item.completed agent_message, turn.completed usage,
 # and the `exec resume <id> <prompt>` argument order, which differs from plain
-# `exec` in that it rejects --sandbox). A silent upgrade could change those.
+# `exec` in that it rejects --sandbox and -C). A silent upgrade could change those.
 multiarch_http_file(
     name = "codex_cli",
     amd64_sha256 = "5ba3b9405543953081f661d0854d266f76e2abbe51d41349355a36de7673776a",

--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.390
+version: 0.1.391

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.390
+      targetRevision: 0.1.391
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -1035,10 +1035,13 @@ wire_api = "responses"
                 "model_reasoning_effort=%s" % effort,
             ]
         )
+        command.append("--skip-git-repo-check")
         if not session_id:
-            command.extend(["--sandbox", "workspace-write"])
-        command.extend(["--skip-git-repo-check", "-C", self.workspace])
-        if not session_id:
+            # exec resume rejects both --sandbox and -C on the pinned CLI
+            # (rust-v0.146.0); resume reuses the session's recorded cwd, and
+            # a fresh exec still lands in the workspace because Popen below
+            # sets cwd there regardless.
+            command.extend(["--sandbox", "workspace-write", "-C", self.workspace])
             command.append(message)
         process = subprocess.Popen(
             command,

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -432,9 +432,12 @@ def test_codex_resume_uses_positional_session_and_no_sandbox(tmp_path, monkeypat
         json.loads(line)
         for line in (tmp_path / "codex-args.jsonl").read_text().splitlines()
     ]
+    first = calls[0]
+    assert "-C" in first
     resume = calls[1]
     assert resume[:4] == ["exec", "resume", "codex-thread", "second"]
     assert "--sandbox" not in resume
+    assert "-C" not in resume
     assert resume[resume.index("--model") + 1] == "gpt-5.6-terra"
     assert resume[resume.index("--config") + 1] == "model_reasoning_effort=high"
     manager._close_process()

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -434,6 +434,8 @@ def test_codex_resume_uses_positional_session_and_no_sandbox(tmp_path, monkeypat
     ]
     first = calls[0]
     assert "-C" in first
+    assert first[first.index("-C") + 1] == str(tmp_path / "workspace")
+    assert first[-1] == "first"
     resume = calls[1]
     assert resume[:4] == ["exec", "resume", "codex-thread", "second"]
     assert "--sandbox" not in resume


### PR DESCRIPTION
Found while running the multi-turn resume matrix after #4301: sonnet and qwen carry context across turns fine, but every codex resume turn died with `codex exited before turn.completed, exit code 2` on a clap usage error, `unexpected argument '-C' found`.

The shim appended `--skip-git-repo-check -C <workspace>` to both `exec` and `exec resume`, and the pinned CLI (rust-v0.146.0) has no `-C` option on `exec resume`. Verified against the actual release binary (checksum matches the MODULE.bazel pin): resume accepts `--json`, `--model`, `--config`, and `--skip-git-repo-check`, and reuses the session's recorded cwd, which `Popen` already sets to the workspace.

## Changes

- `shim.py` `CodexProcess._spawn`: `-C <workspace>` moves into the fresh-exec branch alongside `--sandbox` and the prompt positional; resume keeps only the supported flags.
- `shim_test.py`: the resume argv test now asserts `-C` is present on the fresh call and absent on resume, closing the gap that let this ship.
- `MODULE.bazel`: the codex_cli pin comment documented that resume rejects `--sandbox`; it now documents `-C` too.
- Chart 0.1.390 -> 0.1.391 via `bump-chart.sh` so the runtime image change deploys.

## Verification

- Reproduced the exact failing argv against the pinned binary locally, and confirmed the corrected argv parses and proceeds to session lookup.
- Post-merge gate: after the bricks roll to 0.1.391, a two-turn luna session (plant a codeword, ask for it back) must return the codeword on turn 2. I will run it and report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS

---
_Generated by [Claude Code](https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS)_