### PR TITLE
fix(embervm): reap idle parked sessions and park claude-runtime in 20s

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.392
+version: 0.1.393

--- a/projects/embervm/chart/crds/workload-crd.yaml
+++ b/projects/embervm/chart/crds/workload-crd.yaml
@@ -332,8 +332,8 @@ spec:
 
                     NOTE: idleBankSeconds describes the `persistence.memory: true`
                     path. Under `memory: false` there is no bank; the same idle
-                    threshold triggers a close (capture the filesystem artifact,
-                    destroy the VM) and the next invoke cold boots.
+                    threshold parks instead (VM teardown, the workspace stays on
+                    its volume) and the next invoke rejoins it.
                   properties:
                     idleBankSeconds:
                       type: integer
@@ -354,10 +354,11 @@ spec:
                     bankedTtlSeconds:
                       type: integer
                       description: >-
-                        GC a banked snapshot untouched this long. Defaults to
-                        maxLifetimeSeconds when unset (the watcher applies that
-                        default; the schema leaves it absent so the watcher can
-                        see it was omitted).
+                        GC a banked snapshot, or reap an idle parked session
+                        (its workspace volume), untouched this long. Defaults
+                        to maxLifetimeSeconds when unset (the watcher applies
+                        that default; the schema leaves it absent so the
+                        watcher can see it was omitted).
                       minimum: 60
                     maxSessions:
                       type: integer

--- a/projects/embervm/chart/crds/workload-crd.yaml
+++ b/projects/embervm/chart/crds/workload-crd.yaml
@@ -332,8 +332,12 @@ spec:
 
                     NOTE: idleBankSeconds describes the `persistence.memory: true`
                     path. Under `memory: false` there is no bank; the same idle
-                    threshold parks instead (VM teardown, the workspace stays on
-                    its volume) and the next invoke rejoins it.
+                    threshold instead triggers whichever `persistence.filesystem`
+                    quadrant applies: with `filesystem.enabled: true` it parks
+                    (VM teardown, the workspace stays on its volume) and the next
+                    invoke rejoins it; with `filesystem.enabled: false` it
+                    destroys the VM outright and the next invoke cold boots
+                    (no volume to preserve, the legacy close behavior).
                   properties:
                     idleBankSeconds:
                       type: integer

--- a/projects/embervm/chart/values.yaml
+++ b/projects/embervm/chart/values.yaml
@@ -1221,10 +1221,14 @@ claudeRuntimeWorkload:
   floor: 0
   cap: 3
   session:
-    # Bank an idle session after 5 minutes. Longer than the sandbox tier's 2: a
-    # voice-driven conversation has human-length gaps between turns, and a bank
-    # plus relight inside one conversation is wasted work.
-    idleBankSeconds: 300
+    # 20s, not 5 minutes: that figure was priced for memory banking (a
+    # multi-GiB snapshot write per bank), but this quadrant parks instead (VM
+    # teardown, workspace stays on its volume). Rejoin is a ~250ms cold spawn
+    # plus volume attach against a 1-5s model API leg, and a parked session
+    # holds no concurrency.cap slot (ADR embervm/029), so a short grace window
+    # only needs to keep rapid back-and-forth exchanges live; 20s does that
+    # while abandoned sessions park almost immediately.
+    idleBankSeconds: 20
     # A session rides its birth base until this expires, then the next invoke
     # 410s onto the current base.
     maxLifetimeSeconds: 21600
@@ -1232,7 +1236,12 @@ claudeRuntimeWorkload:
     # leaves a banked zombie counting against maxSessions, and at the old 6h
     # TTL a handful of validation retries saturated the cap (live :session_cap
     # denials, 2026-08-02). An hour keeps resume convenient without letting
-    # dead sessions squat 4 GiB snapshots and cap slots all day.
+    # dead sessions squat 4 GiB snapshots and cap slots all day. This sweep now
+    # also reaps idle PARKED sessions the same way (#4305): before, a parked
+    # session was reaped only by maxLifetimeSeconds (6h) or explicit destroy,
+    # so an abandoned one could squat a maxSessions slot for hours; the same
+    # TTL now applies to both, so a dead session stops squatting maxSessions
+    # within the hour.
     bankedTtlSeconds: 3600
     # Live + banked. 8 x ~4 GiB snapshots = 32 GiB worst case on the snapshot
     # dir, but the 1h banked TTL keeps the steady state far below it.

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -172,10 +172,10 @@ defmodule Embervm.SessionManager do
 
   @doc """
   Runs one capacity/TTL sweep synchronously: expires sessions past `expires_at`
-  (live -> destroy VM, banked -> EvictSnapshot), GCs banked sessions untouched past
-  `bankedTtlSeconds`, and evicts banked sessions LRU while any node is below its
-  snapshot-disk low watermark. Tests drive it deterministically; production fires
-  it on the sweeper timer.
+  (live -> destroy VM, banked/parked -> EvictSnapshot), GCs banked or parked
+  sessions untouched past `bankedTtlSeconds` (#4305), and evicts banked sessions
+  LRU while any node is below its snapshot-disk low watermark. Tests drive it
+  deterministically; production fires it on the sweeper timer.
   """
   @spec sweep(GenServer.server()) :: :ok
   def sweep(server \\ __MODULE__) do
@@ -2638,12 +2638,18 @@ defmodule Embervm.SessionManager do
     state
   end
 
-  # Banked-TTL GC: a banked session untouched (last_invoke_at, or banked-at via
-  # updated_at) for longer than its workload's bankedTtlSeconds is evicted
-  # (session_evicted, reason idle_ttl).
+  # Banked/parked-TTL GC (#4305): a banked or parked session untouched
+  # (last_invoke_at, or banked/parked-at via updated_at) for longer than its
+  # workload's bankedTtlSeconds is evicted (session_evicted, reason idle_ttl).
+  # A banked session's snapshot is released via EvictSnapshot (evict_banked); a
+  # parked session holds no snapshot, so it retires its workspace volume
+  # instead (evict_parked), the same disk it would surrender on max-lifetime
+  # expiry (expire_session's parked arm). Without this, an abandoned parked
+  # session sat only behind maxLifetimeSeconds (hours) and could squat a
+  # session.maxSessions slot for the whole window.
   defp sweep_banked_ttl(state, now) do
     SessionStore.all(state.session_store)
-    |> Enum.filter(&(&1.state == :banked))
+    |> Enum.filter(&(&1.state in [:banked, :parked]))
     |> Enum.reduce(state, fn session, acc ->
       case fetch_session_workload(acc, session.workload) do
         {:ok, entry} ->
@@ -2651,7 +2657,10 @@ defmodule Embervm.SessionManager do
           last = session.last_invoke_at || session.updated_at || 0
 
           if now - last >= ttl_ms do
-            evict_banked(acc, session, :idle_ttl)
+            case session.state do
+              :banked -> evict_banked(acc, session, :idle_ttl)
+              :parked -> evict_parked(acc, session, :idle_ttl)
+            end
           else
             acc
           end
@@ -2712,6 +2721,36 @@ defmodule Embervm.SessionManager do
   # the reason. The session becomes terminal (evicted -> next invoke 410s).
   defp evict_banked(state, session, reason) do
     _ = evict_snapshot(state, session)
+
+    _ =
+      SessionStore.transition(
+        state.session_store,
+        session.session_id,
+        :evict,
+        :session_evicted,
+        %{reason: reason},
+        %{}
+      )
+
+    Logger.warning("embervm session evicted",
+      session_id: session.session_id,
+      workload: session.workload,
+      principal: session.principal,
+      reason: reason
+    )
+
+    state
+  end
+
+  # Evict a parked session: skips stop_session_process (park already tore down
+  # the VM), evict_snapshot is a no-op (a parked session has no node_id/
+  # snapshot_ref, see evict_snapshot/2's fallback clause), and
+  # retire_session_volume releases the workspace volume it holds instead,
+  # mirroring expire_session's parked arm. Appends session_evicted with the
+  # reason, same as evict_banked.
+  defp evict_parked(state, session, reason) do
+    _ = evict_snapshot(state, session)
+    retire_session_volume(state, session)
 
     _ =
       SessionStore.transition(

--- a/projects/embervm/control/lib/embervm/session_state.ex
+++ b/projects/embervm/control/lib/embervm/session_state.ex
@@ -26,8 +26,10 @@ defmodule Embervm.SessionState do
       creating (a create that could not bring the VM up).
     * `expired` (max-lifetime TTL): reachable from running and banked (a live or
       banked session past `expires_at`).
-    * `evicted` (banked-TTL GC or disk-pressure eviction): reachable only from
-      `banked` (only a banked session holds an evictable snapshot).
+    * `evicted` (banked-TTL GC or disk-pressure eviction): reachable from
+      `banked` (a banked session holds an evictable snapshot) and from `parked`
+      (idle-TTL GC of a parked session reclaims its workspace volume rather
+      than a snapshot).
 
   `bank`/`relight` (the PR-4 idle-bank and relight-on-invoke events) are enumerated
   here so the transition table is COMPLETE for the whole rung even though PR-3 only
@@ -112,8 +114,10 @@ defmodule Embervm.SessionState do
     # Max-lifetime expiry: a live or banked session past its deadline.
     {:running, :expire} => :expired,
     {:banked, :expire} => :expired,
-    # Banked-TTL GC / disk-pressure eviction: only a banked session.
+    # Banked-TTL GC / disk-pressure eviction: a banked session (snapshot) or a
+    # parked session past the same idle TTL (workspace volume).
     {:banked, :evict} => :evicted,
+    {:parked, :evict} => :evicted,
     # Destroy (DELETE). Two shapes, selected by the EMBERVM_NODE_CONFIRMED_DESTROY
     # gate in the manager:
     #   * gate off (today's behaviour): the direct `:destroy` edge records

--- a/projects/embervm/control/test/embervm/session_bank_relight_test.exs
+++ b/projects/embervm/control/test/embervm/session_bank_relight_test.exs
@@ -34,7 +34,6 @@ defmodule Embervm.SessionBankRelightTest do
   alias Embervm.Node.V1.{
     BankResponse,
     GuestResponse,
-    PrimeResponse,
     RelightResponse,
     SessionAssignResponse,
     UsageStats
@@ -98,17 +97,10 @@ defmodule Embervm.SessionBankRelightTest do
         clock: clock,
         channel_fun: fn _node -> {:ok, :ch} end,
         claim_fun: fn _d, _n, _w -> {:ok, "vm-#{suffix}-#{System.unique_integer([:positive])}"} end,
-        # Every other test in this file creates against a non-persistence
-        # workload, which claims from the primed pool via claim_fun above and
-        # never reaches prime_fun, so the default here staying a failure is
-        # harmless. A persistence-enabled (parked) workload's create bypasses
-        # claim_fun entirely (claim_or_prime/6 primes directly for it), so a
-        # test that creates against one MUST pass a working prime_fun.
-        prime_fun: Keyword.get(opts, :prime_fun, fn _ch, _req -> {:error, :no_prime} end),
+        prime_fun: fn _ch, _req -> {:error, :no_prime} end,
         bank_fun: Keyword.get(opts, :bank_fun, &default_bank/2),
         relight_fun: Keyword.get(opts, :relight_fun, &default_relight/2),
         evict_fun: Keyword.get(opts, :evict_fun, fn _ch, req -> send(test_pid, {:evicted, req.snapshot_ref}) && {:ok, %{}} end),
-        retire_volume_fun: Keyword.get(opts, :retire_volume_fun, fn _ch, req -> send(test_pid, {:retired, req.lineage_id}) && {:ok, %{}} end),
         session_opts: session_opts,
         # Timers off by default: tests drive reconcile/1 + sweep/1 explicitly.
         reconcile_interval_ms: 0,
@@ -156,11 +148,6 @@ defmodule Embervm.SessionBankRelightTest do
     {:ok, %RelightResponse{vm_id: "vm-relit-#{System.unique_integer([:positive])}"}}
   end
 
-  # A working prime_fun, for the tests that create against a persistence-
-  # enabled workload (claim_or_prime/6 primes directly for those, never
-  # touching claim_fun).
-  defp prime_ok(vm_id), do: fn _ch, _req -> {:ok, %PrimeResponse{vm_id: vm_id}} end
-
   defp put_workload(ctx, wl, opts \\ []) do
     NodeCapacity.put(ctx.cap_table, "node-4", node_fact(wl, opts))
 
@@ -179,8 +166,7 @@ defmodule Embervm.SessionBankRelightTest do
         banked_ttl_seconds: Keyword.get(opts, :banked_ttl_seconds, 3600),
         max_sessions: Keyword.get(opts, :max_sessions, 16),
         invoke_queue_cap: Keyword.get(opts, :queue_cap, 4)
-      },
-      persistence: Keyword.get(opts, :persistence)
+      }
     })
   end
 
@@ -215,16 +201,6 @@ defmodule Embervm.SessionBankRelightTest do
     [{pid, _}] = Registry.lookup(ctx.registry, session_id)
     send(pid, :maybe_bank)
     wait_state(ctx, session_id, :banked)
-  end
-
-  # Same idle timer, a persistence-enabled workload (memory: false, filesystem:
-  # true) routes it through park instead of bank (do_bank's
-  # persistence_enabled_workload? branch), so the session lands on :parked with
-  # its VM torn down rather than :banked with a snapshot.
-  defp force_idle_park(ctx, session_id) do
-    [{pid, _}] = Registry.lookup(ctx.registry, session_id)
-    send(pid, :maybe_bank)
-    wait_state(ctx, session_id, :parked)
   end
 
   defp wait_state(ctx, session_id, expected, tries \\ 100) do
@@ -673,51 +649,6 @@ defmodule Embervm.SessionBankRelightTest do
     {:ok, session} = SessionStore.get(ctx.store, created.session_id)
     assert session.state == :evicted
     assert session.terminal_reason == "idle_ttl"
-  end
-
-  test "banked-TTL GC also reaps a parked session untouched past bankedTtlSeconds (#4305)" do
-    ctx = start_stack(prime_fun: prime_ok("vm-parked-ttl-evicted"))
-
-    put_workload(ctx, "wl",
-      max_lifetime_seconds: 100_000,
-      banked_ttl_seconds: 5,
-      persistence: %{memory: false, filesystem: %{enabled: true, size_bytes: 1_000_000}}
-    )
-
-    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
-    :ok = force_idle_park(ctx, created.session_id)
-
-    advance(ctx.clock_pid, 10_000)
-    :ok = SessionManager.sweep(ctx.mgr)
-
-    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
-    assert session.state == :evicted
-    assert session.terminal_reason == "idle_ttl"
-    # evict_parked retires the workspace volume instead of EvictSnapshot (a parked
-    # session has no snapshot to evict); retirement is a spawned RPC, so
-    # assert_receive (waits) rather than assert_received (checks the mailbox now).
-    assert_receive {:retired, lineage_id}, 1_000
-    assert lineage_id == created.session_id
-  end
-
-  test "a parked session inside bankedTtlSeconds survives the sweep" do
-    ctx = start_stack(prime_fun: prime_ok("vm-parked-ttl-survives"))
-
-    put_workload(ctx, "wl",
-      max_lifetime_seconds: 100_000,
-      banked_ttl_seconds: 5,
-      persistence: %{memory: false, filesystem: %{enabled: true, size_bytes: 1_000_000}}
-    )
-
-    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
-    :ok = force_idle_park(ctx, created.session_id)
-
-    advance(ctx.clock_pid, 3_000)
-    :ok = SessionManager.sweep(ctx.mgr)
-
-    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
-    assert session.state == :parked
-    refute_received {:retired, _}
   end
 
   test "a banked-TTL eviction ALSO issues EvictArtifact(remote) for the session bundle" do

--- a/projects/embervm/control/test/embervm/session_bank_relight_test.exs
+++ b/projects/embervm/control/test/embervm/session_bank_relight_test.exs
@@ -101,6 +101,7 @@ defmodule Embervm.SessionBankRelightTest do
         bank_fun: Keyword.get(opts, :bank_fun, &default_bank/2),
         relight_fun: Keyword.get(opts, :relight_fun, &default_relight/2),
         evict_fun: Keyword.get(opts, :evict_fun, fn _ch, req -> send(test_pid, {:evicted, req.snapshot_ref}) && {:ok, %{}} end),
+        retire_volume_fun: Keyword.get(opts, :retire_volume_fun, fn _ch, req -> send(test_pid, {:retired, req.lineage_id}) && {:ok, %{}} end),
         session_opts: session_opts,
         # Timers off by default: tests drive reconcile/1 + sweep/1 explicitly.
         reconcile_interval_ms: 0,
@@ -166,7 +167,8 @@ defmodule Embervm.SessionBankRelightTest do
         banked_ttl_seconds: Keyword.get(opts, :banked_ttl_seconds, 3600),
         max_sessions: Keyword.get(opts, :max_sessions, 16),
         invoke_queue_cap: Keyword.get(opts, :queue_cap, 4)
-      }
+      },
+      persistence: Keyword.get(opts, :persistence)
     })
   end
 
@@ -201,6 +203,16 @@ defmodule Embervm.SessionBankRelightTest do
     [{pid, _}] = Registry.lookup(ctx.registry, session_id)
     send(pid, :maybe_bank)
     wait_state(ctx, session_id, :banked)
+  end
+
+  # Same idle timer, a persistence-enabled workload (memory: false, filesystem:
+  # true) routes it through park instead of bank (do_bank's
+  # persistence_enabled_workload? branch), so the session lands on :parked with
+  # its VM torn down rather than :banked with a snapshot.
+  defp force_idle_park(ctx, session_id) do
+    [{pid, _}] = Registry.lookup(ctx.registry, session_id)
+    send(pid, :maybe_bank)
+    wait_state(ctx, session_id, :parked)
   end
 
   defp wait_state(ctx, session_id, expected, tries \\ 100) do
@@ -649,6 +661,51 @@ defmodule Embervm.SessionBankRelightTest do
     {:ok, session} = SessionStore.get(ctx.store, created.session_id)
     assert session.state == :evicted
     assert session.terminal_reason == "idle_ttl"
+  end
+
+  test "banked-TTL GC also reaps a parked session untouched past bankedTtlSeconds (#4305)" do
+    ctx = start_stack()
+
+    put_workload(ctx, "wl",
+      max_lifetime_seconds: 100_000,
+      banked_ttl_seconds: 5,
+      persistence: %{memory: false, filesystem: %{enabled: true, size_bytes: 1_000_000}}
+    )
+
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+    :ok = force_idle_park(ctx, created.session_id)
+
+    advance(ctx.clock_pid, 10_000)
+    :ok = SessionManager.sweep(ctx.mgr)
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :evicted
+    assert session.terminal_reason == "idle_ttl"
+    # evict_parked retires the workspace volume instead of EvictSnapshot (a parked
+    # session has no snapshot to evict); retirement is a spawned RPC, so
+    # assert_receive (waits) rather than assert_received (checks the mailbox now).
+    assert_receive {:retired, lineage_id}, 1_000
+    assert lineage_id == created.session_id
+  end
+
+  test "a parked session inside bankedTtlSeconds survives the sweep" do
+    ctx = start_stack()
+
+    put_workload(ctx, "wl",
+      max_lifetime_seconds: 100_000,
+      banked_ttl_seconds: 5,
+      persistence: %{memory: false, filesystem: %{enabled: true, size_bytes: 1_000_000}}
+    )
+
+    {:ok, created} = SessionManager.create(ctx.mgr, "wl", "p1")
+    :ok = force_idle_park(ctx, created.session_id)
+
+    advance(ctx.clock_pid, 3_000)
+    :ok = SessionManager.sweep(ctx.mgr)
+
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :parked
+    refute_received {:retired, _}
   end
 
   test "a banked-TTL eviction ALSO issues EvictArtifact(remote) for the session bundle" do

--- a/projects/embervm/control/test/embervm/session_bank_relight_test.exs
+++ b/projects/embervm/control/test/embervm/session_bank_relight_test.exs
@@ -34,6 +34,7 @@ defmodule Embervm.SessionBankRelightTest do
   alias Embervm.Node.V1.{
     BankResponse,
     GuestResponse,
+    PrimeResponse,
     RelightResponse,
     SessionAssignResponse,
     UsageStats
@@ -97,7 +98,13 @@ defmodule Embervm.SessionBankRelightTest do
         clock: clock,
         channel_fun: fn _node -> {:ok, :ch} end,
         claim_fun: fn _d, _n, _w -> {:ok, "vm-#{suffix}-#{System.unique_integer([:positive])}"} end,
-        prime_fun: fn _ch, _req -> {:error, :no_prime} end,
+        # Every other test in this file creates against a non-persistence
+        # workload, which claims from the primed pool via claim_fun above and
+        # never reaches prime_fun, so the default here staying a failure is
+        # harmless. A persistence-enabled (parked) workload's create bypasses
+        # claim_fun entirely (claim_or_prime/6 primes directly for it), so a
+        # test that creates against one MUST pass a working prime_fun.
+        prime_fun: Keyword.get(opts, :prime_fun, fn _ch, _req -> {:error, :no_prime} end),
         bank_fun: Keyword.get(opts, :bank_fun, &default_bank/2),
         relight_fun: Keyword.get(opts, :relight_fun, &default_relight/2),
         evict_fun: Keyword.get(opts, :evict_fun, fn _ch, req -> send(test_pid, {:evicted, req.snapshot_ref}) && {:ok, %{}} end),
@@ -148,6 +155,11 @@ defmodule Embervm.SessionBankRelightTest do
   defp default_relight(_ch, _req) do
     {:ok, %RelightResponse{vm_id: "vm-relit-#{System.unique_integer([:positive])}"}}
   end
+
+  # A working prime_fun, for the tests that create against a persistence-
+  # enabled workload (claim_or_prime/6 primes directly for those, never
+  # touching claim_fun).
+  defp prime_ok(vm_id), do: fn _ch, _req -> {:ok, %PrimeResponse{vm_id: vm_id}} end
 
   defp put_workload(ctx, wl, opts \\ []) do
     NodeCapacity.put(ctx.cap_table, "node-4", node_fact(wl, opts))
@@ -664,7 +676,7 @@ defmodule Embervm.SessionBankRelightTest do
   end
 
   test "banked-TTL GC also reaps a parked session untouched past bankedTtlSeconds (#4305)" do
-    ctx = start_stack()
+    ctx = start_stack(prime_fun: prime_ok("vm-parked-ttl-evicted"))
 
     put_workload(ctx, "wl",
       max_lifetime_seconds: 100_000,
@@ -689,7 +701,7 @@ defmodule Embervm.SessionBankRelightTest do
   end
 
   test "a parked session inside bankedTtlSeconds survives the sweep" do
-    ctx = start_stack()
+    ctx = start_stack(prime_fun: prime_ok("vm-parked-ttl-survives"))
 
     put_workload(ctx, "wl",
       max_lifetime_seconds: 100_000,

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -178,7 +178,7 @@ defmodule Embervm.SessionManagerTest do
         Keyword.get(opts, :session, %{
           idle_bank_seconds: 300,
           max_lifetime_seconds: Keyword.get(opts, :max_lifetime_seconds, 3600),
-          banked_ttl_seconds: 3600,
+          banked_ttl_seconds: Keyword.get(opts, :banked_ttl_seconds, 3600),
           max_sessions: Keyword.get(opts, :max_sessions, 16),
           invoke_queue_cap: Keyword.get(opts, :queue_cap, 4)
         }),
@@ -1001,6 +1001,46 @@ defmodule Embervm.SessionManagerTest do
     assert_receive {:retire_failed, ^sid}
     {:ok, session} = SessionStore.get(ctx.store, sid)
     assert session.state == :expired
+  end
+
+  test "banked-TTL GC also reaps a parked session untouched past bankedTtlSeconds (#4305)" do
+    # The manager clock is fixed at 5_000_000 (see start_stack); store_clock: fn
+    # -> 0 end stamps the park_complete row's updated_at at 0, so sweep sees
+    # 5_000_000ms elapsed against a 60s (60_000ms) bankedTtlSeconds, comfortably
+    # past it, the same fixed-clock-vs-store-clock idiom the destroying-alarm
+    # test uses (store_clock: fn -> 0 end).
+    ctx =
+      start_stack(
+        prime_fun: fake_prime_fun("vm-parked-ttl-evicted"),
+        channel_fun: fake_channel_fun(),
+        store_clock: fn -> 0 end
+      )
+
+    created = create_persistence_session(ctx, banked_ttl_seconds: 60)
+    park_session(ctx, created)
+
+    assert :ok = SessionManager.sweep(ctx.mgr)
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :evicted
+    assert session.terminal_reason == "idle_ttl"
+  end
+
+  test "a parked session inside bankedTtlSeconds survives the sweep" do
+    # store_clock: fn -> 4_999_000 end stamps park_complete 1s before the fixed
+    # 5_000_000 manager clock, well inside a 60s bankedTtlSeconds.
+    ctx =
+      start_stack(
+        prime_fun: fake_prime_fun("vm-parked-ttl-survives"),
+        channel_fun: fake_channel_fun(),
+        store_clock: fn -> 4_999_000 end
+      )
+
+    created = create_persistence_session(ctx, banked_ttl_seconds: 60)
+    park_session(ctx, created)
+
+    assert :ok = SessionManager.sweep(ctx.mgr)
+    {:ok, session} = SessionStore.get(ctx.store, created.session_id)
+    assert session.state == :parked
   end
 
   test "parked_session_can_be_destroyed" do

--- a/projects/embervm/control/test/embervm/session_state_test.exs
+++ b/projects/embervm/control/test/embervm/session_state_test.exs
@@ -30,6 +30,7 @@ defmodule Embervm.SessionStateTest do
     {:running, :expire} => :expired,
     {:banked, :expire} => :expired,
     {:banked, :evict} => :evicted,
+    {:parked, :evict} => :evicted,
     {:creating, :destroy} => :destroyed,
     {:running, :destroy} => :destroyed,
     {:banking, :destroy} => :destroyed,
@@ -50,7 +51,7 @@ defmodule Embervm.SessionStateTest do
   }
 
   test "exhaustive transition table: every (state, event) pair matches the documented outcome" do
-    assert map_size(@legal) == 33
+    assert map_size(@legal) == 34
     assert length(SessionState.events()) == 16
     assert length(SessionState.states()) == 12
 
@@ -74,10 +75,11 @@ defmodule Embervm.SessionStateTest do
     end
   end
 
-  test "parked transitions to relighting, expired, and destroyed" do
+  test "parked transitions to relighting, expired, destroyed, and evicted" do
     assert SessionState.transition(:parked, :relight) == {:ok, :relighting}
     assert SessionState.transition(:parked, :expire) == {:ok, :expired}
     assert SessionState.transition(:parked, :destroy) == {:ok, :destroyed}
+    assert SessionState.transition(:parked, :evict) == {:ok, :evicted}
   end
 
   test "only running can park" do

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.392
+      targetRevision: 0.1.393
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
The two agreed lifecycle changes completing the parked-first session model from ADR embervm/029: sessions should drop to their no-slot parked state seconds after a turn, and abandoned parked sessions should be reclaimed within the hour rather than squatting `maxSessions` until the 6h lifetime.

## Changes

**Parked TTL reap (closes #4305).** The banked TTL sweep filtered on `:banked` only, so a parked session was reclaimed only by `maxLifetimeSeconds` or explicit destroy. `sweep_banked_ttl` now also reaps parked sessions untouched past `bankedTtlSeconds`:
- New FSM edge `{:parked, :evict} => :evicted` (moduledoc updated; the exhaustive edge-table test goes 33 -> 34).
- New `evict_parked/3` mirroring `expire_session`'s parked arm: no VM to stop (park already tore it down), `evict_snapshot` no-ops on nil `node_id`/`snapshot_ref` via its existing fallback clause, and `retire_session_volume` releases the workspace volume. Appends `session_evicted` with reason `idle_ttl`, same shape as banked eviction.
- `evict_banked` is byte-for-byte unchanged.
- Tests: parked-past-TTL is reaped (terminal `evicted`/`idle_ttl`, volume retirement observed via a new `retire_volume_fun` fixture hook), parked-inside-TTL survives, and the existing banked TTL test is untouched.

**Idle-park tuning.** claude-runtime `session.idleBankSeconds` 300 -> 20. The 5-minute figure was priced for memory banking (multi-GiB snapshot per suspend). This quadrant parks instead: VM teardown with the workspace on its volume, ~250ms cold spawn to rejoin against a 1-5s model API leg, and (post ADR 029) no `concurrency.cap` slot held while parked. 20s keeps rapid back-and-forth live while abandoned sessions park almost immediately.

**Docs.** CRD `bankedTtlSeconds` description covers parked reaping; the `idleBankSeconds` NOTE for the `memory: false` quadrant now says parks/rejoins instead of the stale close/cold-boot wording. Values comments rewritten with the new rationale. The generic 300s CRD schema default is unchanged (only claude-runtime's override moves), and the only 300 assertions in tests are generic fixtures or schema-default tests, both unaffected.

Chart 0.1.392 -> 0.1.393 so the control plane and workload config deploy.

## Verification

- `ci lint` clean; Elixir tests are CI-gated (not runnable in this container).
- Post-merge live gate: start a claude-runtime session, confirm it reaches `parked` in ~20-30s via `monolith-agent-session-vms` (previously 5+ minutes), and confirm a rejoin works after parking. The TTL reap itself is asserted by the new sweep tests (an hour is impractical live).

Related: ADR embervm/029, #4306 (conversation-lifetime decoupling, next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS

---
_Generated by [Claude Code](https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS)_