### PR TITLE
feat(embervm): inject egress credentials on explicit connector paths

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.393
+version: 0.1.394

--- a/projects/embervm/chart/templates/_noded-pod.tpl
+++ b/projects/embervm/chart/templates/_noded-pod.tpl
@@ -378,9 +378,9 @@ containers:
       {{- fail (printf "egress.secrets entry for %v must set exactly one of secretRef or brokerGrant, and secretRef entries need env" $s.egressTo) }}
       {{- end }}
       {{- if $hasBrokerGrant }}
-      {{- $catalog = append $catalog (dict "header" $s.header "valuePrefix" ($s.valuePrefix | default "") "brokerGrant" $s.brokerGrant "egressTo" $s.egressTo "claimHeader" ($s.claimHeader | default "") "claimPath" ($s.claimPath | default "")) }}
+      {{- $catalog = append $catalog (dict "header" $s.header "valuePrefix" ($s.valuePrefix | default "") "brokerGrant" $s.brokerGrant "egressTo" $s.egressTo "claimHeader" ($s.claimHeader | default "") "claimPath" ($s.claimPath | default "") "injectAlwaysPaths" ($s.injectAlwaysPaths | default (list))) }}
       {{- else }}
-      {{- $catalog = append $catalog (dict "header" $s.header "valuePrefix" ($s.valuePrefix | default "") "env" $s.env "egressTo" $s.egressTo "claimHeader" ($s.claimHeader | default "") "claimPath" ($s.claimPath | default "")) }}
+      {{- $catalog = append $catalog (dict "header" $s.header "valuePrefix" ($s.valuePrefix | default "") "env" $s.env "egressTo" $s.egressTo "claimHeader" ($s.claimHeader | default "") "claimPath" ($s.claimPath | default "") "injectAlwaysPaths" ($s.injectAlwaysPaths | default (list))) }}
       {{- end }}
       {{- end }}
       - name: EGRESS_SECRETS

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.393
+      targetRevision: 0.1.394
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -316,6 +316,12 @@ egress:
       brokerGrant: "codex-cluster"
       claimHeader: "chatgpt-account-id"
       claimPath: "https://api.openai.com/auth.chatgpt_account_id"
+      # The CLI's rmcp connector client sends no Authorization header at all
+      # (verified against rust-v0.146.0 and the 0.147.0-alpha line), so
+      # presence-keying can never admit it: this exact path is the explicit
+      # opt-in, and claim-resolution failure still denies (issue #4298).
+      injectAlwaysPaths:
+        - /backend-api/ps/mcp
   # Shared with the monolith gardener, which reads the same item. Read-only sync,
   # so two consumers is fine; the field label CLAUDE_AUTH_TOKEN becomes the key.
   onepassword:

--- a/projects/firecracker/substrate/egress-proxy/cmd/swap.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/swap.go
@@ -136,10 +136,31 @@ type secretEntry struct {
 	EgressTo    []string `json:"egressTo"`
 	ClaimHeader string   `json:"claimHeader"`
 	ClaimPath   string   `json:"claimPath"`
-	value       string   // resolved real value; never serialized, never logged
-	expiresAt   time.Time
-	broker      *tokenBroker
-	mu          *sync.RWMutex
+	// InjectAlwaysPaths is the explicit substitute signal for a client that
+	// sends NO credential header at all, so presence cannot signal intent for
+	// it (issue #4298: the codex CLI's rmcp connector client POSTs with no
+	// Authorization header). An exact match of the request's URL path against
+	// this list stands in for header presence, and only for that. Everything
+	// else about the entry stays fail-closed: an unlisted path with no header
+	// still denies, and a claim-configured entry that cannot resolve its claim
+	// still denies even on a listed path.
+	InjectAlwaysPaths []string `json:"injectAlwaysPaths"`
+	value             string   // resolved real value; never serialized, never logged
+	expiresAt         time.Time
+	broker            *tokenBroker
+	mu                *sync.RWMutex
+}
+
+// injectAlwaysPath reports whether path is one of this entry's
+// InjectAlwaysPaths (issue #4298's operator opt-in for a header-free
+// connector client), an exact match against req.URL.Path.
+func (e *secretEntry) injectAlwaysPath(path string) bool {
+	for _, p := range e.InjectAlwaysPaths {
+		if p == path {
+			return true
+		}
+	}
+	return false
 }
 
 // live reports whether this entry can actually inject. A catalog entry whose
@@ -492,12 +513,21 @@ func rejectSwapRequest(req *http.Request) bool {
 // injection by sending an empty value. Query, path and
 // every other header are left alone, which is the leak the substring swap had.
 //
+// A connector-style client can send no credential header at all (issue #4298:
+// the codex CLI's rmcp connector client POSTs with no Authorization header on
+// either rust-v0.146.0 or 0.147.0-alpha.6), so presence can never signal intent
+// for it. sec.InjectAlwaysPaths is the operator's explicit substitute signal for
+// exactly that case: an exact match of the request path stands in for presence,
+// and only for that request. Every other path on the same entry, and every
+// request on an entry with no InjectAlwaysPaths, still keys on presence exactly
+// as before.
+//
 // Whatever the guest put in the header is DISCARDED rather than matched. That is
 // the point: the guest's value is uncoupled config, and a prompt-injected guest
 // cannot authenticate as a different account by supplying its own token.
 func injectRequest(req *http.Request, sec *secretEntry) bool {
 	if sec.ClaimHeader != "" {
-		requested := len(req.Header.Values(sec.Header)) > 0
+		requested := len(req.Header.Values(sec.Header)) > 0 || sec.injectAlwaysPath(req.URL.Path)
 		// Both guest values go before either decision, so a prompt-injected guest
 		// cannot keep its own account id by making the credential lookup fail.
 		req.Header.Del(sec.Header)
@@ -519,7 +549,7 @@ func injectRequest(req *http.Request, sec *secretEntry) bool {
 		return true
 	}
 
-	requested := len(req.Header.Values(sec.Header)) > 0
+	requested := len(req.Header.Values(sec.Header)) > 0 || sec.injectAlwaysPath(req.URL.Path)
 	// Delete every guest value, including duplicate and empty values, before
 	// deciding whether the guest requested credential injection.
 	req.Header.Del(sec.Header)

--- a/projects/firecracker/substrate/egress-proxy/cmd/swap.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/swap.go
@@ -156,6 +156,12 @@ type secretEntry struct {
 // connector client), an exact match against req.URL.Path.
 func (e *secretEntry) injectAlwaysPath(path string) bool {
 	for _, p := range e.InjectAlwaysPaths {
+		// An empty entry (a bare "-" list item rendering as null -> "") is a
+		// config error, not a wildcard: skip it so it cannot match a path-less
+		// (e.g. CONNECT) request and inject the credential.
+		if p == "" {
+			continue
+		}
 		if p == path {
 			return true
 		}

--- a/projects/firecracker/substrate/egress-proxy/cmd/swap_test.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/swap_test.go
@@ -202,6 +202,138 @@ func TestInjectClaimHeaderDeniesOnInvalidJWT(t *testing.T) {
 	}
 }
 
+func TestInjectAlwaysPathInjectsWithoutPresenceOnClaimEntry(t *testing.T) {
+	sec := &secretEntry{
+		Header:            "Authorization",
+		ValuePrefix:       "Bearer ",
+		ClaimHeader:       "chatgpt-account-id",
+		ClaimPath:         "account_id",
+		InjectAlwaysPaths: []string{"/backend-api/ps/mcp"},
+		value:             testJWT(`{"account_id":"real-account"}`),
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/ps/mcp", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No Authorization header at all: the rmcp connector client (issue #4298)
+	// never sends one, so presence cannot signal intent here.
+
+	if !injectRequest(req, sec) {
+		t.Fatal("injectRequest denied a listed path with no Authorization header")
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer "+sec.value {
+		t.Errorf("Authorization = %q, want the injected credential", got)
+	}
+	if got := req.Header.Get("chatgpt-account-id"); got != "real-account" {
+		t.Errorf("chatgpt-account-id = %q, want the extracted account ID", got)
+	}
+}
+
+func TestInjectAlwaysPathDeniesAnUnlistedPathWithoutPresence(t *testing.T) {
+	sec := &secretEntry{
+		Header:            "Authorization",
+		ValuePrefix:       "Bearer ",
+		ClaimHeader:       "chatgpt-account-id",
+		ClaimPath:         "account_id",
+		InjectAlwaysPaths: []string{"/backend-api/ps/mcp"},
+		value:             testJWT(`{"account_id":"real-account"}`),
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/responses", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Same entry as above, but the request is not to a listed path, so it
+	// still needs header presence, exactly like an entry with no list at all.
+
+	if injectRequest(req, sec) {
+		t.Fatal("injectRequest allowed an unlisted path with no Authorization header")
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Errorf("Authorization = %q, want empty; an unlisted path must stay uncredentialed", got)
+	}
+}
+
+func TestInjectAlwaysPathClaimFailureStillDenies(t *testing.T) {
+	sec := &secretEntry{
+		Header:            "Authorization",
+		ClaimHeader:       "chatgpt-account-id",
+		ClaimPath:         "account_id",
+		InjectAlwaysPaths: []string{"/backend-api/ps/mcp"},
+		value:             "not-a-jwt",
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/ps/mcp", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The path is listed, so the request IS requested, but claim resolution
+	// still fails on a bad token: fail-closed must win regardless of which
+	// signal produced "requested".
+
+	if injectRequest(req, sec) {
+		t.Fatal("injectRequest allowed a listed path whose claim resolution failed")
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Errorf("Authorization = %q, want empty on claim failure", got)
+	}
+}
+
+func TestInjectAlwaysPathOnNonClaimEntry(t *testing.T) {
+	sec := &secretEntry{
+		Header:            "Authorization",
+		ValuePrefix:       "Bearer ",
+		InjectAlwaysPaths: []string{"/backend-api/ps/mcp"},
+		value:             "real-token",
+	}
+	tests := []struct {
+		name, path string
+		want       bool
+	}{
+		{"listed path, no header", "/backend-api/ps/mcp", true},
+		{"unlisted path, no header", "/backend-api/other", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, "https://chatgpt.com"+tt.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := injectRequest(req, sec); got != tt.want {
+				t.Fatalf("injected = %v, want %v", got, tt.want)
+			}
+			if tt.want {
+				if got := req.Header.Get("Authorization"); got != "Bearer real-token" {
+					t.Errorf("Authorization = %q, want the injected credential", got)
+				}
+			} else if got := req.Header.Get("Authorization"); got != "" {
+				t.Errorf("Authorization = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestInjectAlwaysPathDoesNotBreakPresenceOnUnlistedPath(t *testing.T) {
+	// No regression check: an entry with InjectAlwaysPaths configured must
+	// still honour ordinary presence-keyed injection on every other path.
+	sec := &secretEntry{
+		Header:            "Authorization",
+		ValuePrefix:       "Bearer ",
+		InjectAlwaysPaths: []string{"/backend-api/ps/mcp"},
+		value:             "real-token",
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/responses", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer guest-dummy")
+
+	if !injectRequest(req, sec) {
+		t.Fatal("injectRequest denied a request that sent the header, on an entry with InjectAlwaysPaths configured")
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer real-token" {
+		t.Errorf("Authorization = %q, want the injected credential", got)
+	}
+}
+
 func TestInjectRequestBackwardCompatible(t *testing.T) {
 	sec := &secretEntry{Header: "Authorization", ValuePrefix: "Bearer ", value: "real-token"}
 	req, err := http.NewRequest(http.MethodGet, "https://api.example.com", nil)

--- a/projects/firecracker/substrate/egress-proxy/cmd/swap_test.go
+++ b/projects/firecracker/substrate/egress-proxy/cmd/swap_test.go
@@ -279,9 +279,12 @@ func TestInjectAlwaysPathClaimFailureStillDenies(t *testing.T) {
 
 func TestInjectAlwaysPathOnNonClaimEntry(t *testing.T) {
 	sec := &secretEntry{
-		Header:            "Authorization",
-		ValuePrefix:       "Bearer ",
-		InjectAlwaysPaths: []string{"/backend-api/ps/mcp"},
+		Header:      "Authorization",
+		ValuePrefix: "Bearer ",
+		// The trailing "" pins the fail-open guard: an empty entry (a config
+		// typo, a bare "-" list item rendering as null -> "") must never match,
+		// or it would act as a wildcard for any path-less request.
+		InjectAlwaysPaths: []string{"/backend-api/ps/mcp", ""},
 		value:             "real-token",
 	}
 	tests := []struct {
@@ -290,6 +293,14 @@ func TestInjectAlwaysPathOnNonClaimEntry(t *testing.T) {
 	}{
 		{"listed path, no header", "/backend-api/ps/mcp", true},
 		{"unlisted path, no header", "/backend-api/other", false},
+		// Matching is on req.URL.Path, which excludes the query string, so a
+		// query on an otherwise-listed path must not change the outcome.
+		{"listed path with query string, no header", "/backend-api/ps/mcp?session_id=x", true},
+		// Exact match only: a trailing slash is a different path.
+		{"trailing slash variant, no header", "/backend-api/ps/mcp/", false},
+		// A path-less request (URL.Path == "") must not match the empty entry
+		// in InjectAlwaysPaths above.
+		{"path-less request, no header", "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Unblocks codex connectors/web search, the last item on #4298. The CLI's rmcp connector client sends its `POST /backend-api/ps/mcp` requests with **no Authorization header at all** (verified against both rust-v0.146.0 and 0.147.0-alpha.6 using a local header-capture harness with shim-identical dummy auth), so the sidecar's presence-keyed injection fail-closes every connector request. A CLI bump does not help: the newest alpha behaves identically and adds a new required sidecar binary, so we stay pinned on 0.146.0 (full evaluation on #4298).

## Design

Per-secret `injectAlwaysPaths`: an exact-request-path allowlist that serves as the operator's explicit substitute for the presence signal on clients that never send the credential header. Deliberately narrow:
- Presence-keying is unchanged for every unlisted path.
- Guest-sent header values are still deleted before any decision (the prompt-injected-guest defense is ordering-dependent and untouched).
- A claim-configured entry that cannot resolve its claim still denies, listed path or not.
- Exact path match on `req.URL.Path`, no prefixes or wildcards.

`docs/security.md` does not describe the injection design (checked); the posture lives in ADR agents/023, and this change stays inside its per-secret exfiltration-boundary framing. An ADR amendment noting the new field is a possible follow-up.

## Changes

- `swap.go`: `InjectAlwaysPaths []string` on `secretEntry`, `injectAlwaysPath/1` exact matcher, and both `injectRequest` branches treat a listed path as the requested signal.
- `swap_test.go`: five new tests: inject-without-presence on a listed path (claim and non-claim entries), deny on unlisted path, claim-failure still denies on a listed path, presence behavior unchanged on unlisted paths.
- `_noded-pod.tpl`: the `EGRESS_SECRETS` catalog is built field-by-field in two branches, so the new field is threaded through both; without this the values entry would silently never reach the sidecar. Verified by rendering the chart: the list lands on exactly the chatgpt.com entry.
- `deploy/values.yaml`: `injectAlwaysPaths: [/backend-api/ps/mcp]` on the chatgpt.com entry with rationale.
- Chart 0.1.393 -> 0.1.394.

## Verification

- `go build`, `go vet`, `gofmt`, and the full egress-proxy `go test ./...` pass locally (all pre-existing plus the five new tests).
- `helm template` with deploy values shows `injectAlwaysPaths":["/backend-api/ps/mcp"]` on the chatgpt entry and `[]` elsewhere.
- Post-merge live gate: a luna turn that exercises web search must complete, and the brick's egress log must show `/backend-api/ps/mcp` requests injected with `status` 200 instead of `claim injection failed; request denied`.

Related: #4298 (closes out its last remaining item once live-verified), ADR agents/023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS

---
_Generated by [Claude Code](https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS)_