### PR TITLE
fix(embervm): flush the session volume at end of turn so rejoin survives park

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.394
+version: 0.1.395

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.394
+      targetRevision: 0.1.395
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -1393,6 +1393,24 @@ class PiProcess:
         return None
 
 
+def _sync_session_volume():
+    """Flush guest writes to the durable session volume.
+
+    Park tears the VM down with a hard SIGKILL and the drive runs in
+    firecracker's Unsafe cache mode, so a turn's CLI session files sit in the
+    guest page cache until the periodic ext4 commit and are lost on the kill.
+    sync() after each turn pushes them to the device while the session is
+    still live, so a later park -> rejoin finds the conversation intact
+    (issue #4309).
+    """
+    try:
+        os.sync()
+    except OSError as exc:
+        # A sync failure must never fail a turn: log and continue.
+        sys.stderr.write("ember-claude-shim: session volume sync failed: %s\n" % exc)
+        sys.stderr.flush()
+
+
 class ProcessManager:
     """Route Claude-compatible turns to the selected CLI adapter."""
 
@@ -1420,11 +1438,22 @@ class ProcessManager:
 
     def turn(self, message, session_id=None, model=None):
         adapter = self._adapter(model)
-        if adapter is self.pi:
-            return adapter.turn(message, session_id, model or DEFAULT_PI_MODEL)
-        if adapter is self.codex:
-            return adapter.turn(message, session_id, model or DEFAULT_CODEX_MODEL)
-        return adapter.turn(message, session_id, model)
+        try:
+            if adapter is self.pi:
+                return adapter.turn(message, session_id, model or DEFAULT_PI_MODEL)
+            if adapter is self.codex:
+                return adapter.turn(message, session_id, model or DEFAULT_CODEX_MODEL)
+            return adapter.turn(message, session_id, model)
+        finally:
+            # End-of-turn quiescence point: park only happens after a completed
+            # turn plus idle, so flushing here guarantees the device has the
+            # full session file well before any later park SIGKILLs the VM
+            # (#4309). The finally covers every family, and both a normal
+            # return AND a raised turn (a read timeout, a mid-turn CLI death):
+            # the shim process stays alive through the exception, so the sync
+            # is still safe, and a raised turn may still have left durable-
+            # worth CLI state that a later park would otherwise lose.
+            _sync_session_volume()
 
     def interrupt(self):
         # An interrupt has no model in its request, so interrupt both adapters.

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -473,6 +473,55 @@ def test_manager_routes_only_known_models_to_codex(tmp_path, monkeypatch):
     assert manager._adapter("unknown") is claude
 
 
+def test_manager_turn_syncs_session_volume_for_codex(tmp_path, monkeypatch):
+    # A completed turn is the quiescence point park relies on (#4309): the
+    # sync must fire exactly once per turn, through the Manager chokepoint,
+    # for the codex lane.
+    codex = _codex_manager(tmp_path, monkeypatch)
+    manager = shim.ProcessManager(codex.workspace, codex.executable, codex.executable)
+    sync_calls = []
+    monkeypatch.setattr(shim.os, "sync", lambda: sync_calls.append(1))
+
+    manager.turn("first", model="luna")
+
+    assert len(sync_calls) == 1
+    manager._close_process()
+
+
+def test_manager_turn_syncs_session_volume_for_claude(tmp_path, monkeypatch):
+    # Same chokepoint, the claude lane: the sync is not adapter-specific.
+    claude = _manager(tmp_path, monkeypatch)
+    manager = shim.ProcessManager(claude.workspace, claude.executable)
+    monkeypatch.setattr(manager.claude, "_configure_git", lambda: None)
+    sync_calls = []
+    monkeypatch.setattr(shim.os, "sync", lambda: sync_calls.append(1))
+
+    manager.turn("make changes")
+
+    assert len(sync_calls) == 1
+
+
+def test_manager_turn_syncs_session_volume_even_when_adapter_raises(
+    tmp_path, monkeypatch
+):
+    # A raised turn (a read timeout, a mid-turn CLI death) may still have left
+    # durable-worth CLI state; the finally must still fire the sync (#4309).
+    codex = _codex_manager(tmp_path, monkeypatch)
+    manager = shim.ProcessManager(codex.workspace, codex.executable, codex.executable)
+
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(manager.codex, "turn", _raise)
+    sync_calls = []
+    monkeypatch.setattr(shim.os, "sync", lambda: sync_calls.append(1))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        manager.turn("first", model="luna")
+
+    assert len(sync_calls) == 1
+
+
 def _capture_spawn_kwargs(tmp_path, monkeypatch, geteuid, env=None):
     workspace = tmp_path / "workspace"
     workspace.mkdir()


### PR DESCRIPTION
Fixes the live regression exposed by PR #4307's 20s idle timer (issue #4309): a claude-runtime session that parks and then gets a follow-up turn loses its conversation, on both families (codex: empty rollout; claude: conversation not found).

## Root cause (diagnosed against the code, not guessed)

Park hard-**SIGKILL**s the firecracker VM (`driver.Release` -> `os.Process.Kill`) with no guest quiesce, the writable drive runs in firecracker's default **Unsafe cache mode** (guest FLUSH not honored), ext4 is mounted with default options (~5s commit), and nothing in the shim or guest-init flushes the CLI's session files at turn completion. So the CLI's just-written `.codex/sessions/*.jsonl` / `~/.claude/projects/*/*.jsonl` sit in the guest page cache and are discarded on the kill. The per-lineage volume is correctly preserved and re-attached on rejoin (verified: `park_session` never retires it, `Prime` re-attaches the same deterministic path, `CreateSession` is idempotent) -- only the writes are lost. The two symptoms are one cause: file-present-but-empty (data unflushed) or conversation-not-found (the mkfs superblock itself was unflushed, so the guest re-blanks the device).

## Fix

Flush the guest filesystem to the device at the end of every turn -- the natural quiescence point, since park only fires after a completed turn plus idle. An `os.sync()` there guarantees the device holds the full session file well before any later SIGKILL, with no park-signal plumbing, no firecracker cache-mode change, and no protocol change.

- `_sync_session_volume()`: a module-level helper, `os.sync()` wrapped so a sync failure logs and never fails a turn (matching the file's stderr idiom).
- Called once in `ProcessManager.turn`, the single dispatch chokepoint for all three families (claude/codex/pi), inside a `try/finally` so it fires on a normal return and on a raised turn (a read timeout or mid-turn CLI death may still have left durable-worth state).
- Adapter `turn()` methods untouched.

## Verification

- Full `shim_test.py` suite green (60 tests), including three new ones: `os.sync` called exactly once per turn for the codex lane, the claude lane, and when the adapter raises.
- **This is a hard-SIGKILL durability bug and cannot be unit-tested end to end.** The real gate is live: after deploy, re-run the park -> rejoin codeword test (plant a codeword, wait past the 20s idle for the session to reach `parked`, send a follow-up turn, confirm the codeword comes back) on both luna and sonnet. I will run it and post the result.

Related: #4307 (exposed it, merged), #4306 (cross-generation rehydrate builds on durable workspace), ADR embervm/027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS

---
_Generated by [Claude Code](https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS)_