### PR TITLE
fix(embervm): close CLI stdin on the spawns that do not read a turn from it

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.395
+version: 0.1.396

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.395
+      targetRevision: 0.1.396
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/runtimes/claude/shim.py
+++ b/projects/embervm/runtimes/claude/shim.py
@@ -189,8 +189,11 @@ def _truncate_ring_for_error(ring, max_len=1500):
 def _probe_cli_startup(executable):
     """Run CLI --version as a startup probe, log result, never fail."""
     try:
+        # A version probe reads nothing; close stdin rather than inherit the
+        # shim's, so a never-EOF stdin cannot block it.
         proc = subprocess.run(
             [executable, "--version"],
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             timeout=CLI_PROBE_TIMEOUT,
@@ -1043,9 +1046,13 @@ wire_api = "responses"
             # sets cwd there regardless.
             command.extend(["--sandbox", "workspace-write", "-C", self.workspace])
             command.append(message)
+        # The turn message rides argv (command above), on both a fresh exec
+        # and exec resume; codex never reads it from stdin, so close it
+        # rather than inherit the shim's never-EOF stdin.
         process = subprocess.Popen(
             command,
             cwd=self.workspace,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=child_env,
@@ -1246,9 +1253,12 @@ class PiProcess:
         if session_id:
             command.extend(["--session", session_id])
         command.append(message)
+        # The turn message rides argv (command above); pi never reads it from
+        # stdin, so close it rather than inherit the shim's never-EOF stdin.
         process = subprocess.Popen(
             command,
             cwd=self.workspace,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=child_env,

--- a/projects/embervm/runtimes/claude/shim_test.py
+++ b/projects/embervm/runtimes/claude/shim_test.py
@@ -570,6 +570,47 @@ def test_spawn_honors_cli_identity_environment_overrides(tmp_path, monkeypatch):
     assert kwargs["group"] == 2345
 
 
+def test_spawn_keeps_claude_stdin_as_a_pipe(tmp_path, monkeypatch):
+    # claude's stdin IS its turn channel (--input-format stream-json); pin
+    # this so a future stdin.DEVNULL change elsewhere never lands here too
+    # (#4303).
+    kwargs = _capture_spawn_kwargs(tmp_path, monkeypatch, geteuid=1000)
+    assert kwargs["stdin"] is subprocess.PIPE
+
+
+def test_spawn_closes_codex_stdin(tmp_path, monkeypatch):
+    # codex's message rides argv on both a fresh exec and exec resume, never
+    # stdin, so the shim closes it rather than inherit its own never-EOF
+    # stdin (#4303: otherwise a fresh exec prints "Reading additional input
+    # from stdin..." and could block on a guest that hands it a live stdin).
+    codex = _codex_manager(tmp_path, monkeypatch)
+    captured = {}
+
+    def fake_popen(*args, **kwargs):
+        captured.update(kwargs)
+        raise RuntimeError("stop after capturing Popen kwargs")
+
+    monkeypatch.setattr(shim.subprocess, "Popen", fake_popen)
+    with pytest.raises(RuntimeError, match="stop after capturing"):
+        codex._spawn("hello", None, "luna")
+    assert captured["stdin"] is subprocess.DEVNULL
+
+
+def test_spawn_closes_pi_stdin(tmp_path, monkeypatch):
+    # pi's message is argv too; same rationale as codex (#4303).
+    pi = _pi_manager(tmp_path, monkeypatch)
+    captured = {}
+
+    def fake_popen(*args, **kwargs):
+        captured.update(kwargs)
+        raise RuntimeError("stop after capturing Popen kwargs")
+
+    monkeypatch.setattr(shim.subprocess, "Popen", fake_popen)
+    with pytest.raises(RuntimeError, match="stop after capturing"):
+        pi._spawn("hello", None, "qwen")
+    assert captured["stdin"] is subprocess.DEVNULL
+
+
 def _manager(tmp_path, monkeypatch, api_key="none"):
     workspace = tmp_path / "workspace"
     workspace.mkdir()


### PR DESCRIPTION
Fixes #4303. The shim spawned the version probe, codex, and pi with stdin inherited from the shim process. Codex's fresh `exec` prints `Reading additional input from stdin...` and appends non-TTY stdin to the prompt, so an inherited never-EOF stdin could block the turn or corrupt the prompt.

## Changes

Close stdin (`subprocess.DEVNULL`) on the three spawns whose CLI takes its turn message via argv, not stdin:
- `_probe_cli_startup` (the `--version` probe)
- `CodexProcess._spawn` (message rides argv on both `exec` and `exec resume`)
- `PiProcess._spawn` (message rides argv)

`ClaudeProcess._spawn` keeps `stdin=subprocess.PIPE` untouched: that pipe is claude's `--input-format stream-json` turn channel, over which the persistent process receives every turn. A new test pins that invariant so a future change can't accidentally close it.

`_configure_git`'s `git config` call is left alone (git config never reads stdin; touching it would only widen the diff).

## Verification

- Full `shim_test.py` suite green (63 tests), including three new pinning tests: codex and pi spawn with `stdin is DEVNULL`, claude spawns with `stdin is PIPE`.
- Chart 0.1.395 -> 0.1.396 so the runtime image deploys.

Related: #4298 (this was filed during that investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS

---
_Generated by [Claude Code](https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS)_