### PR TITLE
feat(embervm): CP create-with-restore for cross-generation continuity (#4306 slice 3)

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.398
+version: 0.1.399

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -715,6 +715,11 @@ defmodule Embervm.Router do
       {:ok, created} ->
         send_json(conn, 201, %{
           session_id: created.session_id,
+          # #4306 slice 3 review fix (item B): the durable workspace handle,
+          # not the per-generation session_id, is the valid restore_lineage
+          # key for the NEXT generation (session_id != lineage_id after the
+          # first restore). Defaults to session_id for a normal create.
+          lineage_id: Map.get(created, :lineage_id, created.session_id),
           session_token: created.token,
           expires_at: created.expires_at,
           base_digest: created.base_digest,

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -816,6 +816,19 @@ defmodule Embervm.Router do
           retryable: false
         })
 
+      # #4306/#4313 review fix 2: also 409 (a state conflict on the lineage),
+      # but retryable: true, unlike lineage_live_heir. A committed heir never
+      # goes away on its own, so a live-heir denial is not worth retrying; an
+      # in-flight restore is transient and settles (to success or failure)
+      # within the create worker timeout, so the client may simply retry.
+      :lineage_restore_in_flight ->
+        send_json(conn, 409, %{
+          error: "another restore of this lineage is already in flight",
+          reason: "lineage_restore_in_flight",
+          workload: workload,
+          retryable: true
+        })
+
       # Brick capacity (PR-3): no brick of the workload's size class has room and
       # the class is flagged fleet-full (desired outran registered past the dwell),
       # so placement is TERMINALLY denied rather than parked. 503 (not the 429 the

--- a/projects/embervm/control/lib/embervm/router.ex
+++ b/projects/embervm/control/lib/embervm/router.ex
@@ -697,22 +697,29 @@ defmodule Embervm.Router do
   # -- session handlers (R2) -------------------------------------------------
 
   # POST /v1/workloads/:name/sessions (management auth). Delegates to the
-  # SessionManager, which owns capacity/quota/placement/claim. 201 with the token
-  # (returned ONCE), 429 for a capacity/quota denial, 403 for a class mismatch or
-  # unknown workload, 500 for an internal failure.
+  # SessionManager, which owns capacity/quota/placement/claim. Optional JSON
+  # body `{"restore_lineage": "<lineage-id>"}` requests a #4306 slice 3
+  # cross-generation create: the new session inherits that lineage's durable
+  # workspace instead of minting a fresh one (an absent/empty/malformed body
+  # is always a normal create). 201 with the token (returned ONCE) and
+  # `restored` (whether the inherited workspace was actually recovered), 429
+  # for a capacity/quota denial, 403/404/409 for a class, workload, or lineage
+  # mismatch, 500 for an internal failure.
   defp handle_create_session(conn, workload) do
     principal = conn.assigns.principal
+    {restore_lineage, conn} = optional_restore_lineage(conn)
 
     # Cold-boot persistence creates legitimately take tens of seconds; the
     # SessionManager call must not cut the claim/prime RPC at the old 5-second limit.
-    case session_manager().create(session_manager_server(), workload, principal) do
+    case session_manager().create(session_manager_server(), workload, principal, restore_lineage) do
       {:ok, created} ->
         send_json(conn, 201, %{
           session_id: created.session_id,
           session_token: created.token,
           expires_at: created.expires_at,
           base_digest: created.base_digest,
-          state: to_string(Map.get(created, :state, :running))
+          state: to_string(Map.get(created, :state, :running)),
+          restored: Map.get(created, :restored, false)
         })
 
       {:error, {:denied, reason}} ->
@@ -721,6 +728,28 @@ defmodule Embervm.Router do
       {:error, reason} ->
         Logger.error("embervm create session failed: #{inspect(reason)}")
         send_json(conn, 500, %{error: "create session failed", workload: workload, retryable: true})
+    end
+  end
+
+  # Reads the OPTIONAL create body for `restore_lineage` (#4306 slice 3).
+  # Absent, unreadable, malformed, or non-string all mean "no restore
+  # requested" rather than an error: an empty body is the normal, by-far-most-
+  # common case for this route, so this is tolerant by design, matching
+  # decode_registration/safe_decode's own body-parsing idiom elsewhere in this
+  # router.
+  defp optional_restore_lineage(conn) do
+    case read_capped_body(conn) do
+      {:ok, body, conn} ->
+        restore_lineage =
+          case safe_decode(body) do
+            %{"restore_lineage" => lineage} when is_binary(lineage) and lineage != "" -> lineage
+            _ -> nil
+          end
+
+        {restore_lineage, conn}
+
+      {:error, _} ->
+        {nil, conn}
     end
   end
 
@@ -744,6 +773,45 @@ defmodule Embervm.Router do
         send_json(conn, 403, %{
           error: "workload is not class session",
           reason: "not_session_class",
+          workload: workload,
+          retryable: false
+        })
+
+      # #4306 slice 3: restore_lineage validation denials. unknown_lineage
+      # mirrors unknown_workload (404, the referenced thing does not exist);
+      # the mismatch reasons mirror not_session_class (403, the request is
+      # wrong for this identity); lineage_live_heir is a state conflict with
+      # an existing resource (409), the same convention this router uses
+      # elsewhere for "the thing you are trying to act on is not in a state
+      # that allows it".
+      :unknown_lineage ->
+        send_json(conn, 404, %{
+          error: "unknown lineage",
+          reason: "unknown_lineage",
+          workload: workload,
+          retryable: false
+        })
+
+      :lineage_workload_mismatch ->
+        send_json(conn, 403, %{
+          error: "lineage belongs to a different workload",
+          reason: "lineage_workload_mismatch",
+          workload: workload,
+          retryable: false
+        })
+
+      :lineage_principal_mismatch ->
+        send_json(conn, 403, %{
+          error: "lineage belongs to a different principal",
+          reason: "lineage_principal_mismatch",
+          workload: workload,
+          retryable: false
+        })
+
+      :lineage_live_heir ->
+        send_json(conn, 409, %{
+          error: "lineage already has a live heir",
+          reason: "lineage_live_heir",
           workload: workload,
           retryable: false
         })

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -141,6 +141,12 @@ defmodule Embervm.SessionManager do
       principal (ADR embervm/025's cross-principal prohibition).
     * `:lineage_live_heir` -- the lineage's newest holder is not terminal yet
       (exclusivity: at most one live heir per lineage).
+    * `:lineage_restore_in_flight` -- another restoring create for this SAME
+      lineage is already mid-flight (TOCTOU guard: the durable heir row this
+      validates against does not exist until that create finishes, tens of
+      seconds later for a cold restore, so a client retry must be denied
+      rather than raced). Retryable once the in-flight restore settles,
+      unlike `:lineage_live_heir`, which is a committed heir.
 
   `restored` in the returned map is `true` when the inherited workspace was
   actually recovered (attached locally or an S3 restore hit), `false` for a
@@ -548,6 +554,7 @@ defmodule Embervm.SessionManager do
            :ok <- check_workload_cap(state, workload, entry),
            :ok <- check_quota(state, principal),
            :ok <- validate_restore_lineage(state, restore_lineage, workload, principal),
+           :ok <- check_restore_not_inflight(state, restore_lineage),
            pin_node_id = restore_lineage_volume_node(state, restore_lineage, workload),
            {:ok, node_id, dial_id, snapshot_ref} <- place_create(state, workload, entry, pin_node_id) do
         {:ok,
@@ -596,6 +603,44 @@ defmodule Embervm.SessionManager do
     end
   end
 
+  # #4306/#4313 review fix 2 (TOCTOU): validate_restore_lineage/4 only
+  # consults the durable store, but the heir row it looks for is written
+  # asynchronously (finish_create -> register_and_start), tens of seconds
+  # later for a cold-boot restore. A second restoring create of the SAME
+  # lineage (a client retrying a slow restore) would re-validate against the
+  # store, still see only the terminal predecessor, pass, and both would then
+  # prime and register_and_start with lineage_id = restore_lineage: two live
+  # heirs writing one volume concurrently. Worse, the LOSER's failure-branch
+  # reclaim (finish_create, keyed only by workload+lineage_id) would then
+  # re-arm retirement of the lineage the WINNER is live on, exporting then
+  # deleting a live volume out from under it.
+  #
+  # do_create_inline runs SYNCHRONOUSLY inside the {:create, ...}
+  # GenServer.call, strictly BEFORE the worker spawns and BEFORE
+  # create_inflight gains an entry for THIS create (that write happens back
+  # in handle_call, after do_create_inline returns). Every other create the
+  # manager is mid-processing is either already in create_inflight (its
+  # worker spawned, still primed/restoring) or blocked behind this same
+  # single-process mailbox waiting its own turn at do_create_inline. So a scan
+  # of create_inflight here can only ever see OTHER creates, never this one,
+  # and no other create can interleave a write between this read and this
+  # create's own create_inflight insert: check-then-proceed is atomic with
+  # respect to a concurrent restore of the same lineage, closing the window
+  # the store-only check leaves open.
+  defp check_restore_not_inflight(_state, nil), do: :ok
+
+  defp check_restore_not_inflight(state, restore_lineage) do
+    in_flight? =
+      state.create_inflight
+      |> Map.values()
+      |> Enum.any?(fn {_from, _lineage_id, _workload, _principal, _entry, _node_id, _snapshot_ref, _dial_id,
+                        inflight_restore_lineage} ->
+        inflight_restore_lineage == restore_lineage
+      end)
+
+    if in_flight?, do: {:error, :lineage_restore_in_flight}, else: :ok
+  end
+
   # The node currently reporting restore_lineage's workspace volume in its
   # fleet facts (the same session_volumes list retire_orphan_session_volumes
   # reads), or nil when no node reports it. A cold-restore create (no node
@@ -628,7 +673,7 @@ defmodule Embervm.SessionManager do
               end
 
             _ ->
-              restore_then_prime(state, node_id, workload, snapshot_ref, entry, restore_lineage)
+              restore_then_prime(state, node_id, workload, snapshot_ref, entry, restore_lineage, dial_id)
           end
         rescue
           exception -> {:error, {:create_worker_crashed, exception}}
@@ -653,8 +698,31 @@ defmodule Embervm.SessionManager do
   # volume attaches under the inherited identity rather than a fresh one.
   # restore-on-miss is tolerated (see restore_session_workspace/4): a genuine
   # store miss proceeds with a blank workspace and reports restored: false.
-  defp restore_then_prime(state, node_id, workload, snapshot_ref, entry, restore_lineage) do
-    dial_id = Embervm.WakeInstance.dial_for_session_volume(state.capacity_table, node_id, restore_lineage)
+  #
+  # placed_dial_id is place_create's OWN resolved brick instance dial (the
+  # same one the non-restore path dials via claim_or_prime), threaded through
+  # from spawn_create_worker's call site as the COLD-restore fallback. A warm
+  # restore (a session_volumes fact reports this lineage on node_id) still
+  # prefers the volume-owning instance. But dial_for_session_volume fails
+  # OPEN, not nil, on a miss: it returns the bare node_id itself when no
+  # instance reports the lineage, which is exactly the after-eviction
+  # S3-restore case (nothing local yet). Dialing that bare node name fails
+  # :unknown_node on the real fleet (channel_fun only ever accepts an
+  # instance dial, never the node-name alias; the node name is an anchor,
+  # not a dial key, same lesson perform_rejoin_prime's own comment
+  # documents), which turned a recoverable S3 restore into a hard 500 rather
+  # than the blank-workspace degrade this path is supposed to tolerate. So a
+  # plain `||` cannot detect the miss (the fallthrough value is truthy); this
+  # explicitly compares the resolved dial against the bare node_id instead,
+  # and falls back to placed_dial_id (always a real, dialable instance)
+  # whenever dial_for_session_volume did not actually find an owning
+  # instance.
+  defp restore_then_prime(state, node_id, workload, snapshot_ref, entry, restore_lineage, placed_dial_id) do
+    dial_id =
+      case Embervm.WakeInstance.dial_for_session_volume(state.capacity_table, node_id, restore_lineage) do
+        ^node_id -> placed_dial_id
+        resolved -> resolved
+      end
 
     with {:ok, restored} <- restore_session_workspace(state, dial_id, workload, restore_lineage),
          {:ok, vm_id} <- prime(state, dial_id, snapshot_ref, entry, restore_lineage) do

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -299,6 +299,16 @@ defmodule Embervm.SessionManager do
       create_inflight: %{},
       create_next_ref: 0,
       create_workers: %{},
+      # #4306/#4313 review fix 2 (TOCTOU): the set of restore_lineage values
+      # a restoring create currently has in flight (added synchronously in
+      # handle_call({:create,...}) when accepted, removed in finish_create
+      # regardless of outcome). check_restore_not_inflight/2 consults this
+      # directly instead of reverse-engineering it by scanning
+      # create_inflight's tuples, so a second restoring create for the same
+      # lineage is a plain MapSet.member?/2 check against a value this same
+      # GenServer call wrote synchronously, not an inference over another
+      # structure's shape.
+      inflight_restore_lineages: MapSet.new(),
       # session_id -> consecutive bank-failure count. Lives HERE (not in the session
       # process, which stops on admission) so three strikes across bank attempts fails
       # the session. Cleared on a successful bank or a successful invoke-driven relight.
@@ -398,6 +408,17 @@ defmodule Embervm.SessionManager do
             state.create_inflight[ref],
             {from, lineage_id, workload, principal, entry, node_id, snapshot_ref, dial_id, restore_lineage}
           )
+
+        # #4306/#4313 review fix 2: mark the lineage in flight in the SAME
+        # state update, synchronously, before this handle_call returns (so
+        # the very next {:create,...} this GenServer processes, for any
+        # caller, sees it).
+        state =
+          if restore_lineage do
+            %{state | inflight_restore_lineages: MapSet.put(state.inflight_restore_lineages, restore_lineage)}
+          else
+            state
+          end
 
         state = %{state | create_next_ref: ref + 1}
         {state, worker} =
@@ -626,29 +647,32 @@ defmodule Embervm.SessionManager do
   # deleting a live volume out from under it.
   #
   # do_create_inline runs SYNCHRONOUSLY inside the {:create, ...}
-  # GenServer.call, strictly BEFORE the worker spawns and BEFORE
-  # create_inflight gains an entry for THIS create (that write happens back
-  # in handle_call, after do_create_inline returns). Every other create the
-  # manager is mid-processing is either already in create_inflight (its
-  # worker spawned, still primed/restoring) or blocked behind this same
-  # single-process mailbox waiting its own turn at do_create_inline. So a scan
-  # of create_inflight here can only ever see OTHER creates, never this one,
-  # and no other create can interleave a write between this read and this
-  # create's own create_inflight insert: check-then-proceed is atomic with
-  # respect to a concurrent restore of the same lineage, closing the window
-  # the store-only check leaves open.
+  # GenServer.call, strictly BEFORE this create's own entry is written to
+  # state.inflight_restore_lineages (that write happens back in handle_call,
+  # after do_create_inline returns, in the SAME state update GenServer.call
+  # commits before this handle_call clause returns). Every other create the
+  # manager is mid-processing has therefore either already committed its own
+  # entry to that state (its worker spawned, still primed/restoring) or is
+  # blocked behind this same single-process mailbox waiting its own turn at
+  # do_create_inline. So a MapSet.member?/2 read here can only ever observe
+  # OTHER creates' entries, never this one's, and no other create can
+  # interleave a write between this read and this create's own insert:
+  # check-then-proceed is atomic with respect to a concurrent restore of the
+  # same lineage, closing the window the store-only check leaves open.
+  #
+  # This checks a dedicated MapSet (added/removed in handle_call/finish_create
+  # in lockstep with each restoring create's lifecycle) rather than
+  # reverse-engineering "is a restore of this lineage in flight" by scanning
+  # create_inflight's tuples: the set says exactly what it means, so there is
+  # no dependence on interpreting another structure's shape or write timing.
   defp check_restore_not_inflight(_state, nil), do: :ok
 
   defp check_restore_not_inflight(state, restore_lineage) do
-    in_flight? =
-      state.create_inflight
-      |> Map.values()
-      |> Enum.any?(fn {_from, _lineage_id, _workload, _principal, _entry, _node_id, _snapshot_ref, _dial_id,
-                        inflight_restore_lineage} ->
-        inflight_restore_lineage == restore_lineage
-      end)
-
-    if in_flight?, do: {:error, :lineage_restore_in_flight}, else: :ok
+    if MapSet.member?(state.inflight_restore_lineages, restore_lineage) do
+      {:error, :lineage_restore_in_flight}
+    else
+      :ok
+    end
   end
 
   # The node currently reporting restore_lineage's workspace volume in its
@@ -747,7 +771,19 @@ defmodule Embervm.SessionManager do
 
       {{from, lineage_id, workload, principal, entry, node_id, _snapshot_ref, dial_id, restore_lineage}, inflight} ->
         cleanup_create_worker(Map.get(state.create_workers, ref))
+
         state = %{state | create_inflight: inflight, create_workers: Map.delete(state.create_workers, ref)}
+
+        # #4306/#4313 review fix 2: clear the in-flight mark unconditionally
+        # (success or failure), in this SAME state update, before result is
+        # computed or replied. MapSet.delete/2 on an absent value is a no-op,
+        # so this is safe for a normal (non-restoring) create too.
+        state =
+          if restore_lineage do
+            %{state | inflight_restore_lineages: MapSet.delete(state.inflight_restore_lineages, restore_lineage)}
+          else
+            state
+          end
 
         result =
           case outcome do

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -109,16 +109,49 @@ defmodule Embervm.SessionManager do
 
   @doc """
   Creates a session for `workload` on behalf of `principal`. Returns
-  `{:ok, %{session_id, token, expires_at, base_digest}}` (the token is returned
-  ONCE, here), or `{:error, {:denied, reason}}` for a capacity/quota denial
-  (`:session_cap`, `:workload_cap`, `:quota`, `:no_capacity`, `:unknown_workload`,
-  `:not_session_class`) that the router maps to a 429/403.
+  `{:ok, %{session_id, token, expires_at, base_digest, restored}}` (the token
+  is returned ONCE, here), or `{:error, {:denied, reason}}` for a
+  capacity/quota denial (`:session_cap`, `:workload_cap`, `:quota`,
+  `:no_capacity`, `:unknown_workload`, `:not_session_class`) that the router
+  maps to a 429/403. `restored` is always `false` here (no restore requested);
+  see `create/4`.
   """
   @spec create(GenServer.server(), String.t(), String.t()) :: {:ok, map()} | {:error, term()}
   def create(server \\ __MODULE__, workload, principal) do
+    create(server, workload, principal, nil)
+  end
+
+  @doc """
+  Like `create/3`, but `restore_lineage` (nilable, empty treated as absent)
+  makes this a #4306 slice 3 CROSS-GENERATION create: the new session
+  inherits `restore_lineage`'s durable workspace instead of minting a fresh
+  one, so `session_id != lineage_id` for the first time in this codebase
+  (`lineage_id` becomes `restore_lineage`; a fresh `session_id` is still
+  minted). This is deliberately NOT called "adopt": that word already names
+  the unrelated boot-time rebind mechanism in this module (`adopt_state`/
+  adoption reconcile). Restore is a distinct, cross-generation concept and
+  stays a distinct word throughout.
+
+  Validated before anything is placed or primed, each denying with a distinct
+  reason the router maps to a 4xx:
+
+    * `:unknown_lineage` -- no session has ever carried `restore_lineage`.
+    * `:lineage_workload_mismatch` -- the lineage belongs to a different workload.
+    * `:lineage_principal_mismatch` -- the lineage belongs to a different
+      principal (ADR embervm/025's cross-principal prohibition).
+    * `:lineage_live_heir` -- the lineage's newest holder is not terminal yet
+      (exclusivity: at most one live heir per lineage).
+
+  `restored` in the returned map is `true` when the inherited workspace was
+  actually recovered (attached locally or an S3 restore hit), `false` for a
+  genuine blank/miss (tolerated, not an error) or for a normal create.
+  """
+  @spec create(GenServer.server(), String.t(), String.t(), String.t() | nil) ::
+          {:ok, map()} | {:error, term()}
+  def create(server, workload, principal, restore_lineage) do
     # Cold-boot persistence creates can legitimately take tens of seconds while
     # the manager remains responsive to other calls.
-    GenServer.call(server, {:create, workload, principal}, 180_000)
+    GenServer.call(server, {:create, workload, principal, normalize_restore_lineage(restore_lineage)}, 180_000)
   end
 
   @doc """
@@ -245,7 +278,8 @@ defmodule Embervm.SessionManager do
       # invoke can park (relighting ledger) and be relit once the bank completes.
       banking: %{},
       # create_ref -> {from, lineage_id, workload, principal, entry, node_id,
-      # snapshot_ref, dial_id}; claim/prime runs outside this process.
+      # snapshot_ref, dial_id, restore_lineage}; claim/prime runs outside this
+      # process. restore_lineage is nil for a normal create (#4306 slice 3).
       create_inflight: %{},
       create_next_ref: 0,
       create_workers: %{},
@@ -337,8 +371,8 @@ defmodule Embervm.SessionManager do
   end
 
   @impl true
-  def handle_call({:create, workload, principal}, from, state) do
-    case do_create_inline(state, workload, principal) do
+  def handle_call({:create, workload, principal, restore_lineage}, from, state) do
+    case do_create_inline(state, workload, principal, restore_lineage) do
       {:ok,
        %{entry: entry, node_id: node_id, dial_id: dial_id, snapshot_ref: snapshot_ref, lineage_id: lineage_id}} ->
         ref = state.create_next_ref
@@ -346,12 +380,12 @@ defmodule Embervm.SessionManager do
         state =
           put_in(
             state.create_inflight[ref],
-            {from, lineage_id, workload, principal, entry, node_id, snapshot_ref, dial_id}
+            {from, lineage_id, workload, principal, entry, node_id, snapshot_ref, dial_id, restore_lineage}
           )
 
         state = %{state | create_next_ref: ref + 1}
         {state, worker} =
-          spawn_create_worker(state, ref, dial_id, workload, snapshot_ref, entry, lineage_id)
+          spawn_create_worker(state, ref, node_id, dial_id, workload, snapshot_ref, entry, lineage_id, restore_lineage)
 
         {:noreply, put_in(state.create_workers[ref], worker)}
 
@@ -499,7 +533,7 @@ defmodule Embervm.SessionManager do
 
   # -- create ----------------------------------------------------------------
 
-  defp do_create_inline(state, workload, principal) do
+  defp do_create_inline(state, workload, principal, restore_lineage) do
     # The management create span covers the manager-owned fast path. The
     # claim/prime portion runs in a worker, so its pool-hit attributes are split.
     Tracer.with_span "embervm.session.create",
@@ -513,14 +547,22 @@ defmodule Embervm.SessionManager do
            :ok <- check_session_cap(state, workload, entry),
            :ok <- check_workload_cap(state, workload, entry),
            :ok <- check_quota(state, principal),
-           {:ok, node_id, dial_id, snapshot_ref} <- place_create(state, workload, entry) do
+           :ok <- validate_restore_lineage(state, restore_lineage, workload, principal),
+           pin_node_id = restore_lineage_volume_node(state, restore_lineage, workload),
+           {:ok, node_id, dial_id, snapshot_ref} <- place_create(state, workload, entry, pin_node_id) do
         {:ok,
          %{
            entry: entry,
            node_id: node_id,
            dial_id: dial_id,
            snapshot_ref: snapshot_ref,
-           lineage_id: if(persistence_enabled_workload?(entry), do: mint_lineage_id(state), else: nil)
+           # #4306 slice 3: a restoring create's lineage_id is the INHERITED
+           # restore_lineage, not a freshly minted one (this is the divergence
+           # point where session_id and lineage_id first differ; see
+           # register_and_start). Non-restoring behavior is unchanged.
+           lineage_id:
+             restore_lineage ||
+               if(persistence_enabled_workload?(entry), do: mint_lineage_id(state), else: nil)
          }}
       else
         {:error, reason} -> {:error, {:denied, reason}}
@@ -528,14 +570,66 @@ defmodule Embervm.SessionManager do
     end
   end
 
-  defp spawn_create_worker(state, ref, node_id, workload, snapshot_ref, entry, lineage_id) do
+  # restore_lineage present but no session has EVER carried it, belongs to a
+  # different workload or principal (ADR embervm/025's cross-principal
+  # prohibition), or its newest holder is not terminal yet (exclusivity: at
+  # most one live heir per lineage). nil/empty restore_lineage is always a
+  # normal create and always validates.
+  defp validate_restore_lineage(_state, nil, _workload, _principal), do: :ok
+
+  defp validate_restore_lineage(state, restore_lineage, workload, principal) do
+    case SessionStore.get_latest_by_lineage(state.session_store, restore_lineage) do
+      :error ->
+        {:error, :unknown_lineage}
+
+      {:ok, %{workload: lineage_workload}} when lineage_workload != workload ->
+        {:error, :lineage_workload_mismatch}
+
+      {:ok, %{principal: lineage_principal}} when lineage_principal != principal ->
+        {:error, :lineage_principal_mismatch}
+
+      {:ok, %{state: session_state}} when session_state not in [:expired, :evicted, :destroyed, :failed] ->
+        {:error, :lineage_live_heir}
+
+      {:ok, _terminal_holder} ->
+        :ok
+    end
+  end
+
+  # The node currently reporting restore_lineage's workspace volume in its
+  # fleet facts (the same session_volumes list retire_orphan_session_volumes
+  # reads), or nil when no node reports it. A cold-restore create (no node
+  # found) places anywhere, same as a normal create; restore_session_workspace
+  # then tries the object store instead of a local attach.
+  defp restore_lineage_volume_node(_state, nil, _workload), do: nil
+
+  defp restore_lineage_volume_node(state, restore_lineage, workload) do
+    state.capacity_table
+    |> NodeCapacity.all()
+    |> Enum.find_value(fn f ->
+      Enum.find_value(Map.get(f, :session_volumes, []) || [], fn volume ->
+        if volume.lineage_id == restore_lineage and volume.workload == workload, do: f.configured_id
+      end)
+    end)
+  end
+
+  defp spawn_create_worker(state, ref, node_id, dial_id, workload, snapshot_ref, entry, lineage_id, restore_lineage \\ nil) do
     owner = self()
     timeout_ref = Process.send_after(owner, {:create_timeout, ref}, @create_worker_timeout_ms)
 
     {pid, monitor_ref} = spawn_monitor(fn ->
       result =
         try do
-          claim_or_prime(state, node_id, workload, snapshot_ref, entry, lineage_id)
+          case restore_lineage do
+            nil ->
+              case claim_or_prime(state, dial_id, workload, snapshot_ref, entry, lineage_id) do
+                {:ok, vm_id} -> {:ok, vm_id, false}
+                {:error, reason} -> {:error, reason}
+              end
+
+            _ ->
+              restore_then_prime(state, node_id, workload, snapshot_ref, entry, restore_lineage)
+          end
         rescue
           exception -> {:error, {:create_worker_crashed, exception}}
         catch
@@ -548,21 +642,55 @@ defmodule Embervm.SessionManager do
     {state, {pid, monitor_ref, timeout_ref}}
   end
 
+  # Restore-then-prime for a restoring create (#4306 slice 3): the create-path
+  # mirror of perform_rejoin_prime's restore-before-boot ordering. place_create
+  # only PINS the bare node when the fleet facts locate the lineage's volume;
+  # it may still hand back a dial_id for the wrong co-located instance on that
+  # node (multiple instances can share one node_id), so this re-resolves the
+  # dial itself via the same session_volumes fact perform_rejoin_prime uses,
+  # restores the workspace onto it BEFORE prime so the guest boots with data
+  # already in place, then primes with lineage_id = restore_lineage so the
+  # volume attaches under the inherited identity rather than a fresh one.
+  # restore-on-miss is tolerated (see restore_session_workspace/4): a genuine
+  # store miss proceeds with a blank workspace and reports restored: false.
+  defp restore_then_prime(state, node_id, workload, snapshot_ref, entry, restore_lineage) do
+    dial_id = Embervm.WakeInstance.dial_for_session_volume(state.capacity_table, node_id, restore_lineage)
+
+    with {:ok, restored} <- restore_session_workspace(state, dial_id, workload, restore_lineage),
+         {:ok, vm_id} <- prime(state, dial_id, snapshot_ref, entry, restore_lineage) do
+      {:ok, vm_id, restored}
+    end
+  end
+
   defp finish_create(state, ref, outcome) do
     case Map.pop(state.create_inflight, ref) do
       {nil, _} ->
         state
 
-      {{from, lineage_id, workload, principal, entry, node_id, _snapshot_ref, dial_id}, inflight} ->
+      {{from, lineage_id, workload, principal, entry, node_id, _snapshot_ref, dial_id, restore_lineage}, inflight} ->
         cleanup_create_worker(Map.get(state.create_workers, ref))
         state = %{state | create_inflight: inflight, create_workers: Map.delete(state.create_workers, ref)}
 
         result =
           case outcome do
-            {:ok, vm_id} ->
-              register_and_start(state, workload, principal, entry, node_id, vm_id, dial_id, lineage_id)
+            {:ok, vm_id, restored} ->
+              register_and_start(state, workload, principal, entry, node_id, vm_id, dial_id, lineage_id, restore_lineage, restored)
+
             {:error, reason} ->
               audit_denial(state, principal, workload, reason)
+
+              # #4306/#4313: noded clears the lineage's retirement intent early
+              # in an adopting Prime, so a RESTORING create that fails after
+              # prime started (this branch only runs once the worker actually
+              # ran, i.e. validate_restore_lineage already passed) can leave
+              # the volume on disk with no retirement intent and no live VM.
+              # Re-drive reclamation so noded's sweep exports then deletes it
+              # instead of orphaning. node_id here is wherever the worker
+              # actually ran, pinned or not, so it is always the right target.
+              if restore_lineage do
+                _ = retire_session_volume(state, %{volume_node_id: node_id, workload: workload, lineage_id: restore_lineage})
+              end
+
               {:error, {:denied, reason}}
           end
 
@@ -638,11 +766,16 @@ defmodule Embervm.SessionManager do
     end
   end
 
-  defp place_create(state, workload, entry) do
+  # pin_node_id (#4306 slice 3, nil for every pre-existing caller) PINS
+  # placement to a specific node, the same way perform_rejoin_prime pins
+  # volume_node_id for a rejoin: a restoring create whose fleet facts locate
+  # restore_lineage's volume must land where the volume already is.
+  defp place_create(state, workload, entry, pin_node_id \\ nil) do
     case Scheduler.place_with_demand(%Request{
            table: state.capacity_table,
            workload: workload,
            key: workload,
+           node_id: pin_node_id,
            need_mib: Map.get(entry, :mem_mib) || 512,
            base: {:ready, :snapshot_ref}
          }) do
@@ -689,6 +822,12 @@ defmodule Embervm.SessionManager do
   defp mint_lineage_id(%{id_fun: fun}) when is_function(fun, 0), do: fun.()
   defp mint_lineage_id(%{id_fun: fun, clock: clock}) when is_function(fun, 1), do: fun.(clock.())
   defp mint_lineage_id(state), do: Embervm.SessionId.new(state.clock.())
+
+  # #4306 slice 3: absent, empty, or non-string all mean "no restore
+  # requested" (a normal create), the same tolerant contract the router's
+  # own optional_restore_lineage/1 body parse uses.
+  defp normalize_restore_lineage(lineage) when is_binary(lineage) and lineage != "", do: lineage
+  defp normalize_restore_lineage(_other), do: nil
 
   defp prime(state, node_id, snapshot_ref, entry, lineage_id) do
     # A prime failure is NOT a capacity problem, and reporting it as one cost a
@@ -747,25 +886,33 @@ defmodule Embervm.SessionManager do
   # PR-4 rebinds). If the process fails to start, the durable session is orphaned as
   # a live-but-unrouted row; PR-4 adoption rebinds it from NodeStatus, so we surface
   # the create as failed rather than leave the caller a token to a dead process.
-  defp register_and_start(state, workload, principal, entry, node_id, vm_id, dial_id, lineage_id) do
+  defp register_and_start(state, workload, principal, entry, node_id, vm_id, dial_id, lineage_id, restore_lineage \\ nil, restored \\ false) do
     attrs = %{
       tenant: state.tenant,
       principal: principal,
       workload: workload,
       node_id: node_id,
       vm_id: vm_id,
-      # session_id: lineage_id is intentional, not a naming slip: a
-      # persistence-enabled workload pre-mints its lineage id (mint_lineage_id/1)
-      # and that SAME value becomes the session's own session_id too (do_create
-      # mints a fresh one only when this is nil, the non-persistence case).
-      # #4306 slice 1 also records it explicitly as lineage_id below, rather
-      # than relying on do_create's session_id-default fallback, so the durable
-      # row's lineage_id traces back to the actual pre-minted value (nil here
-      # for a non-persistence workload, which still falls through to the same
-      # default: Map.get(attrs, :lineage_id) || session_id treats a present-but-
-      # nil key the same as an absent one).
-      session_id: lineage_id,
-      lineage_id: lineage_id,
+      # session_id: lineage_id is intentional for a normal persistence create,
+      # not a naming slip: a persistence-enabled workload pre-mints its
+      # lineage id (mint_lineage_id/1) and that SAME value becomes the
+      # session's own session_id too (do_create mints a fresh one only when
+      # this is nil, the non-persistence case). #4306 slice 1 also records it
+      # explicitly as lineage_id below, rather than relying on do_create's
+      # session_id-default fallback, so the durable row's lineage_id traces
+      # back to the actual pre-minted value (nil here for a non-persistence
+      # workload, which still falls through to the same default:
+      # Map.get(attrs, :lineage_id) || session_id treats a present-but-nil key
+      # the same as an absent one).
+      #
+      # #4306 slice 3 is the one place this diverges: a RESTORING create
+      # inherits restore_lineage as its lineage_id but still needs its OWN
+      # fresh session_id (the first place session_id != lineage_id in this
+      # codebase), so session_id is left nil here for do_create to mint, and
+      # lineage_id is pinned to restore_lineage explicitly rather than falling
+      # through to do_create's session_id default.
+      session_id: if(restore_lineage, do: nil, else: lineage_id),
+      lineage_id: restore_lineage || lineage_id,
       volume_node_id: if(persistence_enabled_workload?(entry), do: node_id, else: nil),
       base_snapshot_ref: Map.get(entry, :image_ref),
       base_digest: base_digest(entry),
@@ -776,7 +923,7 @@ defmodule Embervm.SessionManager do
       {:ok, %{session_id: session_id} = created} ->
         case start_session_process(state, session_id, workload, principal, entry, node_id, vm_id, dial_id) do
           {:ok, _pid} ->
-            {:ok, created}
+            {:ok, Map.put(created, :restored, restored)}
 
           {:error, reason} ->
             Logger.error("embervm session: process start failed for #{session_id}: #{inspect(reason)}")
@@ -1463,7 +1610,7 @@ defmodule Embervm.SessionManager do
          # dialing it fails :unknown_node, which is exactly how the first live
          # rejoin died after create and park both worked.
          dial_id <- Embervm.WakeInstance.dial_for_session_volume(state.capacity_table, volume_node_id, lineage_id),
-         :ok <- restore_session_workspace(state, dial_id, workload, lineage_id),
+         {:ok, _restored} <- restore_session_workspace(state, dial_id, workload, lineage_id),
          snapshot_ref <- get_in(brick, [:workloads, workload, :snapshot_ref]),
          {:ok, vm_id} <- prime(state, dial_id, snapshot_ref, entry, lineage_id) do
       # Return dial_id because this is the third distinct bare-anchor dial site.
@@ -1477,17 +1624,20 @@ defmodule Embervm.SessionManager do
 
   # Always ask noded about the workspace. A genuine store miss is the documented
   # first-boot case; any other restore failure must stop rejoin rather than prime
-  # a blank image over data that may exist remotely.
+  # a blank image over data that may exist remotely. Returns {:ok, true} on an
+  # actual hit, {:ok, false} on a tolerated store miss (#4306 slice 3 needs to
+  # tell these apart to report `restored` on a create; a rejoin's one caller,
+  # perform_rejoin_prime, only cares that it is `:ok`).
   defp restore_session_workspace(state, node_id, workload, lineage_id) do
     ref = %ArtifactRef{kind: :ARTIFACT_KIND_SESSION_WORKSPACE, workload: workload, ref: lineage_id}
 
     case safe_restore_artifact(state, node_id, node_id, ref) do
       {:ok, resp} ->
         record_restore(state, workload, :ARTIFACT_KIND_SESSION_WORKSPACE, lineage_id, resp)
-        :ok
+        {:ok, true}
 
       {:error, %GRPC.RPCError{status: 5}} ->
-        :ok
+        {:ok, false}
 
       {:error, reason} ->
         {:error, {:session_workspace_restore_failed, reason}}

--- a/projects/embervm/control/lib/embervm/session_manager.ex
+++ b/projects/embervm/control/lib/embervm/session_manager.ex
@@ -109,12 +109,13 @@ defmodule Embervm.SessionManager do
 
   @doc """
   Creates a session for `workload` on behalf of `principal`. Returns
-  `{:ok, %{session_id, token, expires_at, base_digest, restored}}` (the token
-  is returned ONCE, here), or `{:error, {:denied, reason}}` for a
-  capacity/quota denial (`:session_cap`, `:workload_cap`, `:quota`,
-  `:no_capacity`, `:unknown_workload`, `:not_session_class`) that the router
-  maps to a 429/403. `restored` is always `false` here (no restore requested);
-  see `create/4`.
+  `{:ok, %{session_id, lineage_id, token, expires_at, base_digest, restored}}`
+  (the token is returned ONCE, here; `lineage_id` equals `session_id` for a
+  normal create), or `{:error, {:denied, reason}}` for a capacity/quota denial
+  (`:session_cap`, `:workload_cap`, `:quota`, `:no_capacity`,
+  `:unknown_workload`, `:not_session_class`) that the router maps to a
+  429/403. `restored` is always `false` here (no restore requested); see
+  `create/4`.
   """
   @spec create(GenServer.server(), String.t(), String.t()) :: {:ok, map()} | {:error, term()}
   def create(server \\ __MODULE__, workload, principal) do
@@ -151,6 +152,15 @@ defmodule Embervm.SessionManager do
   `restored` in the returned map is `true` when the inherited workspace was
   actually recovered (attached locally or an S3 restore hit), `false` for a
   genuine blank/miss (tolerated, not an error) or for a normal create.
+
+  The returned map also carries `lineage_id`: the durable workspace handle a
+  caller passes as `restore_lineage` to restore THIS session's generation in
+  a future create. For a normal create it equals `session_id`; for a
+  restoring create it equals the inherited `restore_lineage` (session_id
+  diverges from it instead, per above). A caller chaining generations must
+  track `lineage_id`, not `session_id`: restoring a non-first generation's own
+  `session_id` finds no lineage at all (`:unknown_lineage`), since
+  `get_latest_by_lineage/2` keys strictly on `lineage_id`.
   """
   @spec create(GenServer.server(), String.t(), String.t(), String.t() | nil) ::
           {:ok, map()} | {:error, term()}
@@ -658,7 +668,7 @@ defmodule Embervm.SessionManager do
     end)
   end
 
-  defp spawn_create_worker(state, ref, node_id, dial_id, workload, snapshot_ref, entry, lineage_id, restore_lineage \\ nil) do
+  defp spawn_create_worker(state, ref, node_id, dial_id, workload, snapshot_ref, entry, lineage_id, restore_lineage) do
     owner = self()
     timeout_ref = Process.send_after(owner, {:create_timeout, ref}, @create_worker_timeout_ms)
 
@@ -838,7 +848,7 @@ defmodule Embervm.SessionManager do
   # placement to a specific node, the same way perform_rejoin_prime pins
   # volume_node_id for a rejoin: a restoring create whose fleet facts locate
   # restore_lineage's volume must land where the volume already is.
-  defp place_create(state, workload, entry, pin_node_id \\ nil) do
+  defp place_create(state, workload, entry, pin_node_id) do
     case Scheduler.place_with_demand(%Request{
            table: state.capacity_table,
            workload: workload,
@@ -954,7 +964,7 @@ defmodule Embervm.SessionManager do
   # PR-4 rebinds). If the process fails to start, the durable session is orphaned as
   # a live-but-unrouted row; PR-4 adoption rebinds it from NodeStatus, so we surface
   # the create as failed rather than leave the caller a token to a dead process.
-  defp register_and_start(state, workload, principal, entry, node_id, vm_id, dial_id, lineage_id, restore_lineage \\ nil, restored \\ false) do
+  defp register_and_start(state, workload, principal, entry, node_id, vm_id, dial_id, lineage_id, restore_lineage, restored) do
     attrs = %{
       tenant: state.tenant,
       principal: principal,

--- a/projects/embervm/control/lib/embervm/session_store.ex
+++ b/projects/embervm/control/lib/embervm/session_store.ex
@@ -70,10 +70,13 @@ defmodule Embervm.SessionStore do
   Creates a new session, minting its id and capability token. `attrs` is
   `%{tenant, principal, workload, node_id, vm_id, base_snapshot_ref, base_digest,
   expires_at, lineage_id}`. `lineage_id` is optional and defaults to the minted
-  `session_id` (#4306 slice 1: no adoption path exists yet to pass an existing
-  one, so today the two are always equal). Appends `session_created`
-  (write-through), inserts the ETS hot-set row in `:running` (the create claimed
-  a live VM), records the residency fact, and returns `{:ok, %{session_id,
+  `session_id`; a normal create leaves it absent (the two stay equal). A
+  restoring create (#4306 slice 3, `session_manager.ex`'s `register_and_start`)
+  passes an EXISTING lineage_id explicitly and `session_id` absent, so a fresh
+  session_id is minted while lineage_id stays pinned to the inherited value,
+  the one place the two diverge. Appends `session_created` (write-through),
+  inserts the ETS hot-set row in `:running` (the create claimed a live VM),
+  records the residency fact, and returns `{:ok, %{session_id, lineage_id,
   token, expires_at, base_digest, ...}}`. The plaintext token is returned ONLY
   here and never stored.
   """
@@ -610,6 +613,12 @@ defmodule Embervm.SessionStore do
 
     reply = %{
       session_id: session_id,
+      # #4306 slice 3 review fix (item B): the durable workspace handle a
+      # caller restores via for the NEXT generation. == session_id for a
+      # normal create; == the inherited restore_lineage for a restoring one
+      # (session_manager.ex's register_and_start, the only caller that ever
+      # diverges the two).
+      lineage_id: lineage_id,
       token: token,
       expires_at: session.expires_at,
       base_digest: session.base_digest,

--- a/projects/embervm/control/test/embervm/router_test.exs
+++ b/projects/embervm/control/test/embervm/router_test.exs
@@ -26,13 +26,29 @@ defmodule Embervm.RouterTest do
   # can drive the HTTP surface, and especially the SESSION-TOKEN auth boundary,
   # without a live daemon or the supervised SessionManager.
   defmodule FakeSessionManager do
-    def create(_srv, "wl-ok", _principal),
-      do: {:ok, %{session_id: "s-live", token: "sess-token-live", expires_at: 9_000_000, base_digest: "sha256:x", state: :running}}
+    def create(_srv, "wl-ok", _principal, _restore_lineage),
+      do:
+        {:ok,
+         %{session_id: "s-live", token: "sess-token-live", expires_at: 9_000_000, base_digest: "sha256:x", state: :running, restored: false}}
 
-    def create(_srv, "wl-cap", _principal), do: {:error, {:denied, :session_cap}}
-    def create(_srv, "wl-vmcap", _principal), do: {:error, {:denied, :workload_cap}}
-    def create(_srv, "wl-task", _principal), do: {:error, {:denied, :not_session_class}}
-    def create(_srv, _wl, _principal), do: {:error, {:denied, :unknown_workload}}
+    def create(_srv, "wl-cap", _principal, _restore_lineage), do: {:error, {:denied, :session_cap}}
+    def create(_srv, "wl-vmcap", _principal, _restore_lineage), do: {:error, {:denied, :workload_cap}}
+    def create(_srv, "wl-task", _principal, _restore_lineage), do: {:error, {:denied, :not_session_class}}
+
+    # #4306 slice 3: restore_lineage-carrying creates. wl-restore-ok only
+    # returns restored: true when it actually RECEIVED restore_lineage (a
+    # binary), so the test proves the router threads the body field through
+    # rather than the fake just always answering true.
+    def create(_srv, "wl-restore-ok", _principal, restore_lineage) when is_binary(restore_lineage) and restore_lineage != "",
+      do:
+        {:ok,
+         %{session_id: "s-restored", token: "sess-token-restored", expires_at: 9_000_000, base_digest: "sha256:x", state: :running, restored: true}}
+
+    def create(_srv, "wl-unknown-lineage", _principal, _restore_lineage), do: {:error, {:denied, :unknown_lineage}}
+    def create(_srv, "wl-lineage-workload-mismatch", _principal, _restore_lineage), do: {:error, {:denied, :lineage_workload_mismatch}}
+    def create(_srv, "wl-lineage-principal-mismatch", _principal, _restore_lineage), do: {:error, {:denied, :lineage_principal_mismatch}}
+    def create(_srv, "wl-lineage-live-heir", _principal, _restore_lineage), do: {:error, {:denied, :lineage_live_heir}}
+    def create(_srv, _wl, _principal, _restore_lineage), do: {:error, {:denied, :unknown_workload}}
 
     def invoke(_srv, "s-live", _req), do: {:ok, %{status_code: 200, headers: %{"content-type" => "text/plain"}, body: "echoed"}}
     def invoke(_srv, "s-queue", _req), do: {:error, :queue_full}
@@ -671,6 +687,61 @@ defmodule Embervm.RouterTest do
 
     unknown = req(:post, "/v1/workloads/wl-nope/sessions", auth("good"))
     assert unknown.status == 404
+  end
+
+  # -- restore_lineage (#4306 slice 3) ---------------------------------------
+
+  test "POST .../sessions with a restore_lineage body threads it through and reports restored" do
+    with_session_fakes()
+
+    resp =
+      req(:post, "/v1/workloads/wl-restore-ok/sessions", auth("good"), ~s({"restore_lineage": "lineage-abc"}))
+
+    assert resp.status == 201
+    body = json(resp.body)
+    assert body["session_id"] == "s-restored"
+    assert body["restored"] == true
+  end
+
+  test "a normal create (no restore_lineage body) reports restored: false" do
+    with_session_fakes()
+
+    resp = req(:post, "/v1/workloads/wl-ok/sessions", auth("good"))
+    assert resp.status == 201
+    assert json(resp.body)["restored"] == false
+  end
+
+  test "an empty or malformed restore_lineage body is treated as a normal create, not an error" do
+    with_session_fakes()
+
+    empty_body = req(:post, "/v1/workloads/wl-ok/sessions", auth("good"), ~s({"restore_lineage": ""}))
+    assert empty_body.status == 201
+    assert json(empty_body.body)["restored"] == false
+
+    garbage = req(:post, "/v1/workloads/wl-ok/sessions", auth("good"), "not json")
+    assert garbage.status == 201
+    assert json(garbage.body)["restored"] == false
+  end
+
+  test "restore_lineage validation denials map to distinguishable statuses" do
+    with_session_fakes()
+    body = ~s({"restore_lineage": "lineage-x"})
+
+    unknown = req(:post, "/v1/workloads/wl-unknown-lineage/sessions", auth("good"), body)
+    assert unknown.status == 404
+    assert json(unknown.body)["reason"] == "unknown_lineage"
+
+    wl_mismatch = req(:post, "/v1/workloads/wl-lineage-workload-mismatch/sessions", auth("good"), body)
+    assert wl_mismatch.status == 403
+    assert json(wl_mismatch.body)["reason"] == "lineage_workload_mismatch"
+
+    principal_mismatch = req(:post, "/v1/workloads/wl-lineage-principal-mismatch/sessions", auth("good"), body)
+    assert principal_mismatch.status == 403
+    assert json(principal_mismatch.body)["reason"] == "lineage_principal_mismatch"
+
+    live_heir = req(:post, "/v1/workloads/wl-lineage-live-heir/sessions", auth("good"), body)
+    assert live_heir.status == 409
+    assert json(live_heir.body)["reason"] == "lineage_live_heir"
   end
 
   test "invoke is gated on the SESSION token: a management token alone is rejected 403" do

--- a/projects/embervm/control/test/embervm/router_test.exs
+++ b/projects/embervm/control/test/embervm/router_test.exs
@@ -48,6 +48,11 @@ defmodule Embervm.RouterTest do
     def create(_srv, "wl-lineage-workload-mismatch", _principal, _restore_lineage), do: {:error, {:denied, :lineage_workload_mismatch}}
     def create(_srv, "wl-lineage-principal-mismatch", _principal, _restore_lineage), do: {:error, {:denied, :lineage_principal_mismatch}}
     def create(_srv, "wl-lineage-live-heir", _principal, _restore_lineage), do: {:error, {:denied, :lineage_live_heir}}
+
+    # #4306/#4313 review fix 2: TOCTOU guard denial.
+    def create(_srv, "wl-lineage-restore-in-flight", _principal, _restore_lineage),
+      do: {:error, {:denied, :lineage_restore_in_flight}}
+
     def create(_srv, _wl, _principal, _restore_lineage), do: {:error, {:denied, :unknown_workload}}
 
     def invoke(_srv, "s-live", _req), do: {:ok, %{status_code: 200, headers: %{"content-type" => "text/plain"}, body: "echoed"}}
@@ -742,6 +747,21 @@ defmodule Embervm.RouterTest do
     live_heir = req(:post, "/v1/workloads/wl-lineage-live-heir/sessions", auth("good"), body)
     assert live_heir.status == 409
     assert json(live_heir.body)["reason"] == "lineage_live_heir"
+    assert json(live_heir.body)["retryable"] == false
+  end
+
+  test "restore_lineage in-flight guard denial is 409 and retryable (#4306/#4313 review fix 2)" do
+    with_session_fakes()
+
+    resp =
+      req(:post, "/v1/workloads/wl-lineage-restore-in-flight/sessions", auth("good"), ~s({"restore_lineage": "lineage-x"}))
+
+    assert resp.status == 409
+    body = json(resp.body)
+    assert body["reason"] == "lineage_restore_in_flight"
+    # Unlike lineage_live_heir (a committed heir, not worth retrying), an
+    # in-flight restore is transient: the client may simply retry.
+    assert body["retryable"] == true
   end
 
   test "invoke is gated on the SESSION token: a management token alone is rejected 403" do

--- a/projects/embervm/control/test/embervm/router_test.exs
+++ b/projects/embervm/control/test/embervm/router_test.exs
@@ -29,7 +29,15 @@ defmodule Embervm.RouterTest do
     def create(_srv, "wl-ok", _principal, _restore_lineage),
       do:
         {:ok,
-         %{session_id: "s-live", token: "sess-token-live", expires_at: 9_000_000, base_digest: "sha256:x", state: :running, restored: false}}
+         %{
+           session_id: "s-live",
+           lineage_id: "s-live",
+           token: "sess-token-live",
+           expires_at: 9_000_000,
+           base_digest: "sha256:x",
+           state: :running,
+           restored: false
+         }}
 
     def create(_srv, "wl-cap", _principal, _restore_lineage), do: {:error, {:denied, :session_cap}}
     def create(_srv, "wl-vmcap", _principal, _restore_lineage), do: {:error, {:denied, :workload_cap}}
@@ -38,11 +46,21 @@ defmodule Embervm.RouterTest do
     # #4306 slice 3: restore_lineage-carrying creates. wl-restore-ok only
     # returns restored: true when it actually RECEIVED restore_lineage (a
     # binary), so the test proves the router threads the body field through
-    # rather than the fake just always answering true.
+    # rather than the fake just always answering true. lineage_id echoes the
+    # RECEIVED restore_lineage (item B): the response must expose the same
+    # inherited lineage handle the caller sent, not the fresh session_id.
     def create(_srv, "wl-restore-ok", _principal, restore_lineage) when is_binary(restore_lineage) and restore_lineage != "",
       do:
         {:ok,
-         %{session_id: "s-restored", token: "sess-token-restored", expires_at: 9_000_000, base_digest: "sha256:x", state: :running, restored: true}}
+         %{
+           session_id: "s-restored",
+           lineage_id: restore_lineage,
+           token: "sess-token-restored",
+           expires_at: 9_000_000,
+           base_digest: "sha256:x",
+           state: :running,
+           restored: true
+         }}
 
     def create(_srv, "wl-unknown-lineage", _principal, _restore_lineage), do: {:error, {:denied, :unknown_lineage}}
     def create(_srv, "wl-lineage-workload-mismatch", _principal, _restore_lineage), do: {:error, {:denied, :lineage_workload_mismatch}}
@@ -666,6 +684,10 @@ defmodule Embervm.RouterTest do
     assert resp.status == 201
     body = json(resp.body)
     assert body["session_id"] == "s-live"
+    # #4306 slice 3 review fix (item B): a normal create's lineage_id equals
+    # its session_id, and the RESPONSE (not just the internal created map)
+    # must expose it, since Slice 4 restores off this field.
+    assert body["lineage_id"] == "s-live"
     assert body["session_token"] == "sess-token-live"
     assert body["state"] == "running"
   end
@@ -706,6 +728,11 @@ defmodule Embervm.RouterTest do
     body = json(resp.body)
     assert body["session_id"] == "s-restored"
     assert body["restored"] == true
+    # #4306 slice 3 review fix (item B): the response's lineage_id is the
+    # INHERITED lineage handle, not the fresh session_id -- the divergence a
+    # Slice 4 caller chaining generations must see to restore again.
+    assert body["lineage_id"] == "lineage-abc"
+    assert body["session_id"] != body["lineage_id"]
   end
 
   test "a normal create (no restore_lineage body) reports restored: false" do

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -1082,11 +1082,29 @@ defmodule Embervm.SessionManagerTest do
   # call while the first worker is still mid-flight.
   test "a second restoring create of the same in-flight lineage is denied :lineage_restore_in_flight" do
     parent = self()
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
 
+    # Only prime calls AFTER the first block/signal. The FIRST prime call is
+    # create_persistence_session's own (normal, non-restoring) create of
+    # `original` below -- "wl-persist" is persistence-enabled, so that create
+    # ALSO goes through this same injected prime_fun. Without this counter, a
+    # plain unconditional blocking prime_fun sends its :restore_prime_started
+    # signal (and sleeps) during THAT create too, leaving a stale message in
+    # this process's mailbox that assert_receive below would consume instead
+    # of the real signal from the racing restore under test, letting the
+    # actual race (both SessionManager.create calls reaching the manager
+    # before either had provably registered) decide the outcome instead of
+    # the guard: this is what CI caught, not a fix-2 logic bug.
     prime_fun = fn _ch, _req ->
-      send(parent, :restore_prime_started)
-      Process.sleep(200)
-      {:ok, %PrimeResponse{vm_id: "vm-inflight-winner"}}
+      n = Agent.get_and_update(counter, fn c -> {c, c + 1} end)
+
+      if n == 0 do
+        {:ok, %PrimeResponse{vm_id: "vm-original"}}
+      else
+        send(parent, :restore_prime_started)
+        Process.sleep(200)
+        {:ok, %PrimeResponse{vm_id: "vm-inflight-winner"}}
+      end
     end
 
     ctx = start_stack(prime_fun: prime_fun, channel_fun: fake_channel_fun())
@@ -1100,16 +1118,27 @@ defmodule Embervm.SessionManagerTest do
 
     assert_receive :restore_prime_started, 1_000
 
-    # The first restoring create's worker is blocked in prime_fun (async, off
-    # the manager process): its create_inflight entry is already written, and
-    # the manager itself is free to process this SECOND call synchronously,
-    # exactly like reconcile does in the mirrored test above.
+    # do_create_inline runs SYNCHRONOUSLY inside first's {:create,...}
+    # handle_call, strictly BEFORE the worker spawns and calls prime_fun (see
+    # spawn_create_worker): by the time this message arrives, first's entry
+    # is unconditionally already in inflight_restore_lineages. Confirms the
+    # dedicated set (not an inference over create_inflight's shape) is
+    # actually populated, not just that the eventual denial happens to match.
+    assert MapSet.member?(:sys.get_state(ctx.mgr).inflight_restore_lineages, original.session_id)
+
+    # The manager processes messages one at a time from its own mailbox:
+    # first's {:create,...} has already been fully handled (its handle_call
+    # returned, per the assert above), so this SECOND call, whichever process
+    # sends it, is necessarily processed after and must see the guard.
     assert {:error, {:denied, :lineage_restore_in_flight}} =
              SessionManager.create(ctx.mgr, "wl-persist", "p1", original.session_id)
 
     assert {:ok, winner} = Task.await(first, 2_000)
     assert winner.restored == false
     assert winner.session_id != original.session_id
+
+    # finish_create clears the mark once the winner settles.
+    refute MapSet.member?(:sys.get_state(ctx.mgr).inflight_restore_lineages, original.session_id)
   end
 
   test "a restoring create is allowed once no restore of that lineage is in flight" do
@@ -1118,10 +1147,11 @@ defmodule Embervm.SessionManagerTest do
     {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
 
     # Completes synchronously (no gate): by the time create/4 returns,
-    # finish_create has already popped this ref out of create_inflight, so a
-    # SUBSEQUENT restore of the now-terminal result must not be falsely
-    # denied as still in flight.
+    # finish_create has already cleared original.session_id from
+    # inflight_restore_lineages, so a SUBSEQUENT restore of the now-terminal
+    # result must not be falsely denied as still in flight.
     assert {:ok, first} = SessionManager.create(ctx.mgr, "wl-persist", "p1", original.session_id)
+    refute MapSet.member?(:sys.get_state(ctx.mgr).inflight_restore_lineages, original.session_id)
     {:ok, _} = SessionManager.destroy(ctx.mgr, first.session_id)
 
     # Restore keys on LINEAGE, not session_id: first is itself a restoring

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -865,6 +865,133 @@ defmodule Embervm.SessionManagerTest do
     assert session.state == :running
   end
 
+  # -- restore_lineage: cross-generation create (#4306 slice 3) -------------
+  #
+  # "restore"/"inherit"/"restore_lineage" throughout, deliberately never
+  # "adopt": that word already names the unrelated boot-time rebind mechanism
+  # exercised by the reconcile/adoption tests elsewhere in this file.
+
+  test "restoring create against a terminal lineage mints a fresh session_id, inherits lineage_id, and pins placement to the volume's node" do
+    ctx =
+      start_stack(
+        prime_fun: fake_prime_fun("vm-restore-hit"),
+        channel_fun: fake_channel_fun(),
+        restore_artifact_fun: fn _ch, _req -> {:ok, %{}} end
+      )
+
+    original = create_persistence_session(ctx)
+    {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+
+    # The fleet still reports the lineage's volume on an instance co-located
+    # with (but distinct from) the base workload brick, modelling the real
+    # "several instances share a node_id" case restore_then_prime must
+    # resolve past rather than trust place_create's own dial pick.
+    put_brick(ctx, "wl-persist", "volume",
+      session_volumes: [%{workload: "wl-persist", lineage_id: original.session_id, size_bytes: 1}]
+    )
+
+    assert {:ok, restored} = SessionManager.create(ctx.mgr, "wl-persist", "p1", original.session_id)
+
+    assert restored.session_id != original.session_id
+    assert restored.restored == true
+
+    {:ok, row} = SessionStore.get(ctx.store, restored.session_id)
+    assert row.session_id == restored.session_id
+    assert row.lineage_id == original.session_id
+    assert row.node_id == "node-4"
+  end
+
+  test "a restore miss degrades to restored: false rather than a denial" do
+    ctx = start_stack(prime_fun: fake_prime_fun("vm-restore-miss"), channel_fun: fake_channel_fun())
+    # default restore_artifact_fun (see start_stack) is a clean gRPC NOT_FOUND miss.
+
+    original = create_persistence_session(ctx)
+    {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+
+    assert {:ok, restored} = SessionManager.create(ctx.mgr, "wl-persist", "p1", original.session_id)
+    assert restored.restored == false
+    assert restored.session_id != original.session_id
+
+    {:ok, row} = SessionStore.get(ctx.store, restored.session_id)
+    assert row.lineage_id == original.session_id
+  end
+
+  test "restore_lineage validation: unknown lineage is denied, not a normal create" do
+    ctx = start_stack()
+    put_session_workload(ctx, "wl-persist", persistence_workload_opts())
+
+    assert {:error, {:denied, :unknown_lineage}} =
+             SessionManager.create(ctx.mgr, "wl-persist", "p1", "lineage-never-existed")
+  end
+
+  test "restore_lineage validation: a lineage from a different workload is denied" do
+    ctx = start_stack(prime_fun: fake_prime_fun("vm-restore-source"), channel_fun: fake_channel_fun())
+    original = create_persistence_session(ctx, workload: "wl-persist-a")
+    {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+    put_session_workload(ctx, "wl-persist-b", persistence_workload_opts())
+
+    assert {:error, {:denied, :lineage_workload_mismatch}} =
+             SessionManager.create(ctx.mgr, "wl-persist-b", "p1", original.session_id)
+  end
+
+  test "restore_lineage validation: a lineage from a different principal is denied (ADR embervm/025)" do
+    ctx = start_stack(prime_fun: fake_prime_fun("vm-restore-owner"), channel_fun: fake_channel_fun())
+    original = create_persistence_session(ctx, principal: "p1")
+    {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+
+    assert {:error, {:denied, :lineage_principal_mismatch}} =
+             SessionManager.create(ctx.mgr, "wl-persist", "p2", original.session_id)
+  end
+
+  test "restore_lineage validation: a live (non-terminal) heir is denied (exclusivity)" do
+    ctx = start_stack(prime_fun: fake_prime_fun("vm-restore-live"), channel_fun: fake_channel_fun())
+    live = create_persistence_session(ctx)
+
+    assert {:error, {:denied, :lineage_live_heir}} =
+             SessionManager.create(ctx.mgr, "wl-persist", "p1", live.session_id)
+  end
+
+  test "a restoring create whose prime fails re-drives reclamation for the lineage (#4306/#4313)" do
+    parent = self()
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    prime_fun = fn _ch, _req ->
+      case Agent.get_and_update(counter, fn c -> {c, c + 1} end) do
+        0 -> {:ok, %PrimeResponse{vm_id: "vm-restore-original"}}
+        _ -> {:error, :boom}
+      end
+    end
+
+    ctx =
+      start_stack(
+        prime_fun: prime_fun,
+        channel_fun: fake_channel_fun(),
+        retire_volume_fun: fn _ch, req ->
+          send(parent, {:retired, req.lineage_id})
+          {:ok, %{}}
+        end
+      )
+
+    original = create_persistence_session(ctx)
+    {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+
+    assert {:error, {:denied, _reason}} =
+             SessionManager.create(ctx.mgr, "wl-persist", "p1", original.session_id)
+
+    assert_receive {:retired, lineage_id}, 1_000
+    assert lineage_id == original.session_id
+  end
+
+  test "a normal (non-restoring) create still returns restored: false and session_id == lineage_id" do
+    ctx = start_stack(prime_fun: fake_prime_fun("vm-normal-create"), channel_fun: fake_channel_fun())
+    created = create_persistence_session(ctx)
+
+    assert created.restored == false
+
+    {:ok, row} = SessionStore.get(ctx.store, created.session_id)
+    assert row.lineage_id == row.session_id
+  end
+
   test "orphan session volume with no row gets first-seen grace" do
     parent = self()
     {:ok, mono} = Agent.start_link(fn -> -800_000 end)

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -992,6 +992,131 @@ defmodule Embervm.SessionManagerTest do
     assert row.lineage_id == row.session_id
   end
 
+  # Review fix 1 (HIGH, PR #4313 hard review): a COLD restore (no
+  # session_volumes fact anywhere reports the lineage, the exact
+  # after-eviction S3-only case) must NOT dial the bare node name.
+  # dial_for_session_volume fails OPEN to the bare node_id on a miss, and the
+  # real fleet's channel_fun rejects a bare node dial with :unknown_node (the
+  # node name is an anchor, not a dial key), which turned a recoverable S3
+  # restore into a hard denial. A permissive channel_fun (like fake_channel_fun,
+  # used everywhere else in this file) accepts ANY string and hides this bug
+  # entirely, so this test uses a STRICT stub that only accepts the resolved
+  # INSTANCE dial place_create actually placed on.
+  test "cold restore dials the placed INSTANCE, never the bare node name" do
+    {:ok, dialed} = Agent.start_link(fn -> [] end)
+
+    strict_channel_fun = fn node ->
+      Agent.update(dialed, &[node | &1])
+
+      case node do
+        "node-4/inst-a" -> {:ok, :fake_channel}
+        "node-4" -> {:error, :unknown_node}
+        other -> {:error, {:unexpected_dial, other}}
+      end
+    end
+
+    ctx =
+      start_stack(
+        channel_fun: strict_channel_fun,
+        prime_fun: fn _ch, _req -> {:ok, %PrimeResponse{vm_id: "vm-cold-restore"}} end,
+        restore_artifact_fun: fn _ch, _req -> {:ok, %{}} end
+      )
+
+    wl = "wl-restore-cold"
+
+    WorkloadCatalog.upsert(ctx.cat_table, wl, %{
+      name: wl,
+      namespace: "embervm",
+      class: "session",
+      image_ref: "img@sha256:abc",
+      invoke_path: "/",
+      timeout_ms: 90_000,
+      cap: 8,
+      floor: 1,
+      session: %{
+        idle_bank_seconds: 300,
+        max_lifetime_seconds: 3600,
+        banked_ttl_seconds: 3600,
+        max_sessions: 16,
+        invoke_queue_cap: 4
+      },
+      persistence: %{memory: false, filesystem: %{enabled: true, size_bytes: 1_000_000}}
+    })
+
+    # ONE brick for this workload, with a real instance_id distinct from the
+    # bare node name (the shape a real co-located-instance node reports).
+    # session_volumes defaults to [] (put_brick), so no fact locates this
+    # lineage anywhere: a genuine cold restore.
+    put_brick(ctx, wl, "inst-a")
+
+    {:ok, original} = SessionManager.create(ctx.mgr, wl, "p1")
+    {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+    Agent.update(dialed, fn _ -> [] end)
+
+    assert {:ok, restored} = SessionManager.create(ctx.mgr, wl, "p1", original.session_id)
+    assert restored.restored == true
+
+    dials = Agent.get(dialed, & &1)
+    assert "node-4/inst-a" in dials
+    refute "node-4" in dials
+  end
+
+  # Review fix 2 (HIGH, PR #4313 hard review): a TOCTOU window. Two restoring
+  # creates for the SAME lineage racing (a client retrying a slow cold-boot
+  # restore) must not both proceed: validate_restore_lineage only sees the
+  # durable heir row, which does not exist until the WINNER's finish_create
+  # runs, tens of seconds later. Mirrors "create async completes slower
+  # claim/prime without blocking" above: a blocking prime_fun run under
+  # Task.async proves the manager stays responsive to a SECOND synchronous
+  # call while the first worker is still mid-flight.
+  test "a second restoring create of the same in-flight lineage is denied :lineage_restore_in_flight" do
+    parent = self()
+
+    prime_fun = fn _ch, _req ->
+      send(parent, :restore_prime_started)
+      Process.sleep(200)
+      {:ok, %PrimeResponse{vm_id: "vm-inflight-winner"}}
+    end
+
+    ctx = start_stack(prime_fun: prime_fun, channel_fun: fake_channel_fun())
+    original = create_persistence_session(ctx)
+    {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+
+    first =
+      Task.async(fn ->
+        SessionManager.create(ctx.mgr, "wl-persist", "p1", original.session_id)
+      end)
+
+    assert_receive :restore_prime_started, 1_000
+
+    # The first restoring create's worker is blocked in prime_fun (async, off
+    # the manager process): its create_inflight entry is already written, and
+    # the manager itself is free to process this SECOND call synchronously,
+    # exactly like reconcile does in the mirrored test above.
+    assert {:error, {:denied, :lineage_restore_in_flight}} =
+             SessionManager.create(ctx.mgr, "wl-persist", "p1", original.session_id)
+
+    assert {:ok, winner} = Task.await(first, 2_000)
+    assert winner.restored == false
+    assert winner.session_id != original.session_id
+  end
+
+  test "a restoring create is allowed once no restore of that lineage is in flight" do
+    ctx = start_stack(prime_fun: fake_prime_fun("vm-inflight-cleared"), channel_fun: fake_channel_fun())
+    original = create_persistence_session(ctx)
+    {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
+
+    # Completes synchronously (no gate): by the time create/4 returns,
+    # finish_create has already popped this ref out of create_inflight, so a
+    # SUBSEQUENT restore of the now-terminal result must not be falsely
+    # denied as still in flight.
+    assert {:ok, first} = SessionManager.create(ctx.mgr, "wl-persist", "p1", original.session_id)
+    {:ok, _} = SessionManager.destroy(ctx.mgr, first.session_id)
+
+    assert {:ok, second} = SessionManager.create(ctx.mgr, "wl-persist", "p1", first.session_id)
+    assert second.session_id != first.session_id
+  end
+
   test "orphan session volume with no row gets first-seen grace" do
     parent = self()
     {:ok, mono} = Agent.start_link(fn -> -800_000 end)

--- a/projects/embervm/control/test/embervm/session_manager_test.exs
+++ b/projects/embervm/control/test/embervm/session_manager_test.exs
@@ -895,6 +895,13 @@ defmodule Embervm.SessionManagerTest do
     assert restored.session_id != original.session_id
     assert restored.restored == true
 
+    # #4306 slice 3 review fix (item B): the RESPONSE map (not just the
+    # durable row) must carry the divergence, since a caller chaining
+    # generations restores via lineage_id, never session_id, and only sees
+    # this returned map (the durable row is an implementation detail).
+    assert restored.lineage_id == original.session_id
+    assert restored.session_id != restored.lineage_id
+
     {:ok, row} = SessionStore.get(ctx.store, restored.session_id)
     assert row.session_id == restored.session_id
     assert row.lineage_id == original.session_id
@@ -987,6 +994,10 @@ defmodule Embervm.SessionManagerTest do
     created = create_persistence_session(ctx)
 
     assert created.restored == false
+    # #4306 slice 3 review fix (item B): lineage_id must be in the RESPONSE
+    # map itself, not just the durable row, since Slice 4's monolith chains
+    # generations off what create/4 returns.
+    assert created.lineage_id == created.session_id
 
     {:ok, row} = SessionStore.get(ctx.store, created.session_id)
     assert row.lineage_id == row.session_id
@@ -1047,7 +1058,7 @@ defmodule Embervm.SessionManagerTest do
     # bare node name (the shape a real co-located-instance node reports).
     # session_volumes defaults to [] (put_brick), so no fact locates this
     # lineage anywhere: a genuine cold restore.
-    put_brick(ctx, wl, "inst-a")
+    put_brick(ctx, wl, "inst-a", [])
 
     {:ok, original} = SessionManager.create(ctx.mgr, wl, "p1")
     {:ok, _} = SessionManager.destroy(ctx.mgr, original.session_id)
@@ -1113,7 +1124,14 @@ defmodule Embervm.SessionManagerTest do
     assert {:ok, first} = SessionManager.create(ctx.mgr, "wl-persist", "p1", original.session_id)
     {:ok, _} = SessionManager.destroy(ctx.mgr, first.session_id)
 
-    assert {:ok, second} = SessionManager.create(ctx.mgr, "wl-persist", "p1", first.session_id)
+    # Restore keys on LINEAGE, not session_id: first is itself a restoring
+    # create, so first.session_id != first.lineage_id (original.session_id).
+    # get_latest_by_lineage/2 scans session.lineage_id only, so restoring
+    # first.session_id would find no row at all (:unknown_lineage) rather
+    # than exercising the in-flight guard's happy path. original.session_id
+    # is the stable lineage handle the whole chain shares; restoring it again
+    # now finds `first` (the newest holder) terminal and is allowed.
+    assert {:ok, second} = SessionManager.create(ctx.mgr, "wl-persist", "p1", original.session_id)
     assert second.session_id != first.session_id
   end
 

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.398
+      targetRevision: 0.1.399
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml


### PR DESCRIPTION
The identity-critical slice of cross-generation rehydrate (#4306): a create can now inherit a prior lineage's durable workspace instead of minting a fresh one, so a conversation survives a session-generation boundary (the 6h `maxLifetime` expiry). This is the first place `session_id != lineage_id`.

## What it does

- **`create/4`** takes an optional `restore_lineage` (`create/3` delegates with `nil`; empty/malformed normalizes to `nil` = normal create). The router parses it from an optional `{"restore_lineage": "..."}` JSON body and returns `restored: true|false` in the 201.
- **Validation before placing or priming**, each denying with a distinct reason the router maps to a 4xx (all via `get_latest_by_lineage`):
  - `unknown_lineage` -> 404
  - `lineage_workload_mismatch` -> 403
  - `lineage_principal_mismatch` -> 403 (ADR 025 cross-principal prohibition)
  - `lineage_live_heir` -> 409 (exclusivity: at most one live heir per lineage)
- **Placement pinning**: a restoring create pins to the node whose fleet facts report the lineage volume (the same `session_volumes` facts the orphan-reconcile reads); no node found -> places anywhere and `restore_session_workspace` tries the object store.
- **Restore-before-prime**: mirrors `perform_rejoin_prime` — restore the workspace, then prime under the inherited `lineage_id`, so the guest boots with data already in place. **Restore-on-miss is tolerated**: a store miss proceeds blank and reports `restored: false` rather than failing (the degrade-not-fail fork).
- **The divergence point** (`register_and_start`): a restoring create leaves `session_id` nil for `do_create` to mint fresh, and pins `lineage_id: restore_lineage`. Normal creates are unchanged (`session_id == lineage_id`, `restored: false`).
- **Failed-adopt reclaim** (the #4313 review obligation): if a restoring create fails after prime started — the point past which noded has cleared the lineage's retirement intent — the CP re-drives `retire_session_volume` for the lineage so the volume doesn't orphan.

## Terminology

Uses "restore"/"inherit" throughout, deliberately **not** "adopt" — that word already names the unrelated boot-time rebind mechanism (`adopt_state`) in this module.

## Verification

- 4 files: `router.ex` (+body parse, +4 denial mappings), `session_manager.ex` (+`create/4`, validation, restore-then-prime, reclaim, the `restore_session_workspace` `{:ok, hit?}` return threaded through its rejoin caller), and the two test files (+212 lines).
- Syntax-checked locally; full `mix test` needs CI (no elixir toolchain in-container). The Workflows Test check is the gate.
- End-to-end continuity across a generation boundary is Slice 4's live gate (monolith drives the 410 -> restore -> resume path); this slice's tests cover create-with-restore, the four denials, the miss-degrade, and the failed-adopt reclaim in isolation.

Next: Slice 4 (monolith resume-across-410), Slice 5 (double-failure hardening), then the live gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS

---
_Generated by [Claude Code](https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS)_