### PR TITLE
feat(monolith): resume conversation across the expiry 410 (#4306 slice 4)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.347
+version: 0.89.348
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.347
+      targetRevision: 0.89.348
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -56,6 +56,12 @@ def _ember_session(row: AgentSession) -> EmberSession | None:
             row.ember_session_id,
             row.ember_session_token,
             row.ember_session_expires_at,
+            row.ember_lineage_id,
+            # restored is transient (whether THIS turn's create actually
+            # recovered the workspace, #4306 slice 4): a session loaded
+            # back out of the row is never "just restored", so this is
+            # always False here regardless of how it was created.
+            False,
         )
     return None
 
@@ -68,6 +74,7 @@ def _persist_ember_session(session_id: int, ember: EmberSession) -> None:
             ember.session_id,
             ember.session_token,
             ember.expires_at,
+            ember.lineage_id,
         )
 
 

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -385,7 +385,12 @@ def test_recreated_ember_session_adopts_new_cli_session_id(monkeypatch, session)
     session.commit()
     pending = store.create_pending_message(session, row.id, "hello")
     pending_seq = pending.seq
-    new_ember = EmberSession("ember-new", "token-new", 1754035300000)
+    # #4306 slice 4: the new ember also carries a lineage_id (the workspace
+    # this restoring create inherited), which must persist alongside the
+    # fresh session_id/token for the NEXT expiry to restore from.
+    new_ember = EmberSession(
+        "ember-new", "token-new", 1754035300000, lineage_id="lineage-old", restored=True
+    )
 
     async def succeeding_delivery(_ember, _cli_session_id, _message, _model=None):
         return _completed_turn("hello")._replace(session_id="cli-new"), new_ember
@@ -403,10 +408,52 @@ def test_recreated_ember_session_adopts_new_cli_session_id(monkeypatch, session)
     assert updated is not None
     assert updated.ember_session_id == "ember-new"
     assert updated.ember_session_token == "token-new"
+    assert updated.ember_lineage_id == "lineage-old"
     assert updated.cli_session_id == "cli-new"
     assert store.get_turn(session, row.id, pending_seq) is not None
     pending_after = store.get_pending_message(session, row.id, pending_seq)
     assert pending_after is None
+
+
+def test_ember_session_loaded_from_row_carries_lineage_id_but_never_restored(session):
+    """#4306 slice 4: lineage_id round-trips through the row, but restored is
+    always False for a session loaded back out of storage -- it is transient
+    (whether THIS turn's create just recovered the workspace), never durable."""
+    row = store.create_session(session, "sid-lineage", "/workspace", "main")
+    store.set_ember_session(session, row.id, "ember-1", "token-1", None, "lineage-1")
+
+    session.expire_all()
+    reloaded = store.get_session(session, row.id)
+    ember = mcp._ember_session(reloaded)
+
+    assert ember is not None
+    assert ember.session_id == "ember-1"
+    assert ember.lineage_id == "lineage-1"
+    assert ember.restored is False
+
+
+def test_persist_ember_session_persists_lineage_id(session):
+    row = store.create_session(session, "sid-lineage-2", "/workspace", "main")
+    new_ember = EmberSession("ember-2", "token-2", None, lineage_id="lineage-2")
+
+    mcp._persist_ember_session(row.id, new_ember)
+
+    session.expire_all()
+    reloaded = store.get_session(session, row.id)
+    assert reloaded.ember_session_id == "ember-2"
+    assert reloaded.ember_lineage_id == "lineage-2"
+
+
+def test_clear_ember_session_nulls_lineage_id(session):
+    row = store.create_session(session, "sid-lineage-3", "/workspace", "main")
+    store.set_ember_session(session, row.id, "ember-1", "token-1", None, "lineage-1")
+
+    store.clear_ember_session(session, row.id)
+
+    session.expire_all()
+    reloaded = store.get_session(session, row.id)
+    assert reloaded.ember_session_id is None
+    assert reloaded.ember_lineage_id is None
 
 
 def test_startup_sweep_lists_orphaned_messages(session):

--- a/projects/monolith/agent_sessions/models.py
+++ b/projects/monolith/agent_sessions/models.py
@@ -20,6 +20,12 @@ class AgentSession(SQLModel, table=True):
     )  # Claude CLI session_id for resumption
     ember_session_id: str | None = Field(default=None)
     ember_session_token: str | None = Field(default=None)
+    # The durable workspace handle (#4306 slice 4): a restored session's
+    # ember_session_id is a fresh per-generation id, not a valid restore key
+    # for the NEXT generation (session_id == lineage_id only for a gen-0
+    # create). This is what a later create passes as restore_lineage to
+    # continue the same guest workspace/transcript across an expiry.
+    ember_lineage_id: str | None = Field(default=None)
     # BigInteger, not the default Integer: this is epoch MILLISECONDS from the
     # control plane, which overflows int4. The migration already declares BIGINT,
     # but SQLModel maps a plain int to sqlalchemy Integer and emits an explicit

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -50,6 +50,7 @@ def set_ember_session(
     ember_id: str,
     ember_token: str,
     ember_expires_at: int | None,
+    ember_lineage_id: str | None = None,
 ) -> AgentSession:
     row = session.get(AgentSession, session_id)
     if row is None:
@@ -57,6 +58,11 @@ def set_ember_session(
     row.ember_session_id = ember_id
     row.ember_session_token = ember_token
     row.ember_session_expires_at = ember_expires_at
+    # #4306 slice 4: the durable workspace handle, persisted alongside the
+    # per-generation session_id/token so the NEXT create (after an expiry)
+    # can restore from it instead of the (invalid, past generation zero)
+    # session_id.
+    row.ember_lineage_id = ember_lineage_id
     session.add(row)
     session.commit()
     session.refresh(row)
@@ -75,6 +81,7 @@ def clear_ember_session(session: Session, session_id: int) -> AgentSession:
     row.ember_session_id = None
     row.ember_session_token = None
     row.ember_session_expires_at = None
+    row.ember_lineage_id = None
     row.cli_session_id = None
     session.add(row)
     session.commit()
@@ -90,6 +97,12 @@ def clear_ember_bindings_by_ember_id(session: Session, ember_id: str) -> list[in
     them in one commit rather than assuming a single owner. Rows are loaded
     via exec/select and mutated in place, then committed once; nothing is
     session.add-ed in a loop.
+
+    Deliberately does NOT null ember_lineage_id or cli_session_id (#4306
+    slice 4): destroying this specific VM/generation does not necessarily
+    destroy its durable workspace volume, so a future create can still
+    restore from the lineage and pick the transcript back up. Only
+    clear_ember_session (a confirmed-dead binding) clears the lineage too.
 
     Returns the ids of the affected AgentSession rows.
     """

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -76,6 +76,16 @@ class EmberSession(NamedTuple):
     session_id: str
     session_token: str
     expires_at: int | None
+    # #4306 slice 4: lineage_id is the durable workspace handle to pass as
+    # restore_from on a LATER create to continue this same lineage. It
+    # equals session_id for a normal (gen-0) create; a RESTORED session
+    # mints a fresh session_id but inherits the prior lineage_id, so the two
+    # diverge (session_id is NOT a valid restore key past generation zero).
+    # restored is True only when a restore_from create actually recovered
+    # the workspace (never set for a normal create, and never set on a
+    # denied restore, which raises instead of returning a session at all).
+    lineage_id: str | None = None
+    restored: bool = False
 
 
 class ShimTransport(Protocol):
@@ -127,14 +137,31 @@ class EmberVmShimTransport:
         self.workload = workload
         self.read_timeout = read_timeout
 
-    async def create_session(self) -> EmberSession:
+    async def create_session(self, restore_from: str | None = None) -> EmberSession:
         """Create a new session on the guest and return the session ID.
 
+        Args:
+            restore_from: A prior LINEAGE handle (EmberSession.lineage_id,
+                not necessarily session_id past generation zero) to inherit
+                the prior generation's guest workspace from (#4306 slice 4:
+                cross-generation continuity). None (the default) requests a
+                normal, blank create.
+
         Returns:
-            The EmberVM session identity and bearer token.
+            The EmberVM session identity and bearer token. lineage_id is the
+            durable workspace handle to pass as restore_from on a LATER
+            create to continue this same lineage (== session_id for a
+            normal create). restored is True only when restore_from was
+            actually honored (the workspace was recovered); a denied
+            restore raises below like any other create failure, it never
+            returns restored=False for "denied".
 
         Raises:
-            EmberVMTransportError: If session creation fails.
+            EmberVMTransportError: If session creation fails, including a
+                restore denial (unknown lineage, a workload/principal
+                mismatch, a live heir, or a concurrent in-flight restore of
+                the same lineage; see the control plane's create_denial
+                mapping, #4306 slice 3).
         """
         if not EMBERVM_URL:
             raise EmberVMTransportError("EMBERVM_URL is not configured")
@@ -142,10 +169,17 @@ class EmberVmShimTransport:
         url = f"{EMBERVM_URL}/v1/workloads/{self.workload}/sessions"
         headers = auth_headers()
         timeout = httpx.Timeout(self.read_timeout, connect=SUBMIT_CONNECT_TIMEOUT)
+        # A normal create posts no body at all: the CP's create route parses
+        # an OPTIONAL JSON body, and an absent one is exactly what it treats
+        # as "no restore requested" (see optional_restore_lineage in the CP
+        # router), so this stays a plain no-body POST unless restoring.
+        post_kwargs = {"headers": headers}
+        if restore_from:
+            post_kwargs["json"] = {"restore_lineage": restore_from}
 
         try:
             async with httpx.AsyncClient(timeout=timeout) as client:
-                response = await client.post(url, headers=headers)
+                response = await client.post(url, **post_kwargs)
                 response.raise_for_status()
                 data = response.json()
                 session_id = data.get("session_id")
@@ -162,6 +196,8 @@ class EmberVmShimTransport:
                     session_id=session_id,
                     session_token=session_token,
                     expires_at=data.get("expires_at"),
+                    lineage_id=data.get("lineage_id"),
+                    restored=bool(data.get("restored", False)),
                 )
         except httpx.TimeoutException as exc:
             logger.warning("embervm session creation timed out: %s", exc)
@@ -351,9 +387,38 @@ class EmberVmShimTransport:
         except httpx.HTTPStatusError as exc:
             if created or exc.response.status_code not in (403, 410):
                 raise EmberVMTransportError(_status_error_detail(exc)) from exc
-            ember = await self.create_session()
+
+            # #4306 slice 4: restore keys on the LINEAGE handle, not
+            # session_id (session_id == lineage_id only for a gen-0 create;
+            # a session_id from a PRIOR restore is not a valid restore key,
+            # restoring it 404s as unknown_lineage). Falls back to
+            # session_id for a pre-lineage binding: a row persisted before
+            # slice 3 landed never got a lineage_id back, so ember.lineage_id
+            # is None and session_id is the only handle it ever had.
+            restore_from = ember.lineage_id or ember.session_id
             try:
-                return await invoke(ember, None), ember
+                new_ember = await self.create_session(restore_from=restore_from)
+            except EmberVMTransportError as restore_exc:
+                # The restore create was itself DENIED (unknown_lineage, a
+                # workload/principal mismatch, a live heir, or a concurrent
+                # restore of the same lineage already in flight) or timed
+                # out: the workspace is not recoverable right now. Degrade
+                # to a BLANK session rather than bricking the turn; losing
+                # the transcript/workspace is better than failing outright.
+                logger.warning(
+                    "embervm restore create denied for lineage %s, "
+                    "falling back to a blank session: %s",
+                    restore_from,
+                    restore_exc,
+                )
+                new_ember = await self.create_session()
+
+            # Only resume the CLI transcript when the guest workspace was
+            # ACTUALLY recovered; a blank workspace has nothing for
+            # --resume to find.
+            cli = cli_session_id if new_ember.restored else None
+            try:
+                return await invoke(new_ember, cli), new_ember
             except (httpx.HTTPStatusError, EmberVMTransportError) as retry_exc:
                 if isinstance(retry_exc, httpx.HTTPStatusError):
                     raise EmberSessionGone(

--- a/projects/monolith/agent_sessions/transport_test.py
+++ b/projects/monolith/agent_sessions/transport_test.py
@@ -84,6 +84,66 @@ def test_create_session_rejects_missing_or_empty_identity(monkeypatch, field, va
         asyncio.run(transport.EmberVmShimTransport().create_session())
 
 
+def test_create_session_parses_lineage_and_restored(monkeypatch):
+    async def handler(request):
+        return httpx.Response(
+            201,
+            json={
+                "session_id": "s2",
+                "session_token": "t2",
+                "expires_at": 1754035200000,
+                "lineage_id": "s1",
+                "restored": True,
+            },
+            request=request,
+        )
+
+    _client(monkeypatch, handler)
+    result = asyncio.run(
+        transport.EmberVmShimTransport().create_session(restore_from="s1")
+    )
+
+    assert result.lineage_id == "s1"
+    assert result.restored is True
+
+
+def test_create_session_normal_posts_no_body(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        return httpx.Response(
+            201,
+            json={"session_id": "s1", "session_token": "t1"},
+            request=request,
+        )
+
+    _client(monkeypatch, handler)
+    result = asyncio.run(transport.EmberVmShimTransport().create_session())
+
+    assert not requests[0].content
+    # Absent lineage_id/restored in the CP response degrades to None/False.
+    assert result.lineage_id is None
+    assert result.restored is False
+
+
+def test_create_session_restoring_posts_restore_lineage_body(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        return httpx.Response(
+            201,
+            json={"session_id": "s2", "session_token": "t2", "lineage_id": "s1"},
+            request=request,
+        )
+
+    _client(monkeypatch, handler)
+    asyncio.run(transport.EmberVmShimTransport().create_session(restore_from="s1"))
+
+    assert json.loads(requests[0].content) == {"restore_lineage": "s1"}
+
+
 def test_deliver_uses_ember_identity_and_cli_id_in_body(monkeypatch):
     requests = []
 
@@ -130,16 +190,20 @@ def test_deliver_includes_model_when_present(monkeypatch):
 def test_deliver_recreates_reused_stale_session_once(monkeypatch):
     requests = []
     responses = [410, 200]
+    # restored defaults False: this fresh session is a BLANK create (no
+    # workspace recovered), so the retry invoke must drop the CLI id below.
     fresh = transport.EmberSession("s2", "t2", 1754035200000)
     create_calls = 0
+    seen_restore_from = []
 
     async def handler(request):
         requests.append(request)
         return _turn_response(request, responses.pop(0))
 
-    async def create_session():
+    async def create_session(restore_from=None):
         nonlocal create_calls
         create_calls += 1
+        seen_restore_from.append(restore_from)
         return fresh
 
     _client(monkeypatch, handler)
@@ -151,9 +215,15 @@ def test_deliver_recreates_reused_stale_session_once(monkeypatch):
 
     assert len(requests) == 2
     assert json.loads(requests[0].content)["session_id"] == "cli-1"
+    # restored=False on the retry create means no workspace was recovered,
+    # so the CLI transcript id must NOT be resumed against a blank session.
     assert json.loads(requests[1].content)["session_id"] is None
     assert str(requests[1].url).endswith("/v1/sessions/s2/invoke")
     assert create_calls == 1
+    # #4306 slice 4: the expiring session's lineage_id was never set (a
+    # pre-lineage binding, EmberSession("s1", "t1", None) defaults
+    # lineage_id=None), so the fallback is its session_id.
+    assert seen_restore_from == ["s1"]
     assert turn.result == "ok"
     assert used == fresh
 
@@ -163,26 +233,114 @@ def test_deliver_recreates_reused_session_on_403(monkeypatch):
     responses = [403, 200]
     fresh = transport.EmberSession("s2", "t2", None)
     create_calls = 0
+    seen_restore_from = []
 
     async def handler(request):
         requests.append(request)
         return _turn_response(request, responses.pop(0))
 
-    async def create_session():
+    async def create_session(restore_from=None):
         nonlocal create_calls
         create_calls += 1
+        seen_restore_from.append(restore_from)
         return fresh
 
     _client(monkeypatch, handler)
     client = transport.EmberVmShimTransport()
     monkeypatch.setattr(client, "create_session", create_session)
     asyncio.run(
-        client.deliver(transport.EmberSession("s1", "t1", None), "cli-1", "hello")
+        client.deliver(
+            transport.EmberSession("s1", "t1", None, lineage_id="lineage-1"),
+            "cli-1",
+            "hello",
+        )
     )
 
     assert len(requests) == 2
     assert str(requests[1].url).endswith("/v1/sessions/s2/invoke")
     assert create_calls == 1
+    # The expiring session DID carry a lineage_id: that, not session_id, is
+    # what must be sent as restore_from.
+    assert seen_restore_from == ["lineage-1"]
+
+
+def test_deliver_keeps_cli_session_id_when_restore_recovers_workspace(monkeypatch):
+    """#4306 slice 4: a restore that actually recovers the workspace
+    (restored=True) must let the retry --resume the CLI transcript; only a
+    BLANK fallback drops the CLI id (covered above, restored defaults False)."""
+    requests = []
+    responses = [410, 200]
+    restored_session = transport.EmberSession(
+        "s2", "t2", None, lineage_id="lineage-1", restored=True
+    )
+
+    async def handler(request):
+        requests.append(request)
+        return _turn_response(request, responses.pop(0))
+
+    async def create_session(restore_from=None):
+        return restored_session
+
+    _client(monkeypatch, handler)
+    client = transport.EmberVmShimTransport()
+    monkeypatch.setattr(client, "create_session", create_session)
+    turn, used = asyncio.run(
+        client.deliver(
+            transport.EmberSession("s1", "t1", None, lineage_id="lineage-1"),
+            "cli-1",
+            "hello",
+        )
+    )
+
+    assert len(requests) == 2
+    # restored=True: the retry resumes the ORIGINAL cli_session_id.
+    assert json.loads(requests[1].content)["session_id"] == "cli-1"
+    assert used == restored_session
+    assert turn.result == "ok"
+
+
+def test_deliver_falls_back_to_blank_session_when_restore_create_is_denied(
+    monkeypatch,
+):
+    """#4306 slice 4: the restore create itself can be DENIED (unknown_lineage,
+    a mismatch, a live heir, or an in-flight restore of the same lineage). This
+    must degrade to a blank session and still complete the turn, never raise
+    EmberSessionGone (the guest workspace being unrecoverable is not the same
+    as the ORIGINAL binding being confirmed dead)."""
+    requests = []
+    responses = [410, 200]
+    blank = transport.EmberSession("s3", "t3", None)
+    create_calls = []
+
+    async def handler(request):
+        requests.append(request)
+        return _turn_response(request, responses.pop(0))
+
+    async def create_session(restore_from=None):
+        create_calls.append(restore_from)
+        if restore_from:
+            raise EmberVMTransportError("404 unknown_lineage")
+        return blank
+
+    _client(monkeypatch, handler)
+    client = transport.EmberVmShimTransport()
+    monkeypatch.setattr(client, "create_session", create_session)
+    turn, used = asyncio.run(
+        client.deliver(
+            transport.EmberSession("s1", "t1", None, lineage_id="lineage-1"),
+            "cli-1",
+            "hello",
+        )
+    )
+
+    # First call attempted the restore and was denied; second call is the
+    # blank fallback (no restore_from).
+    assert create_calls == ["lineage-1", None]
+    assert len(requests) == 2
+    # A blank session (restored=False) must not carry the CLI id forward.
+    assert json.loads(requests[1].content)["session_id"] is None
+    assert used == blank
+    assert turn.result == "ok"
 
 
 def test_deliver_reused_session_403_with_failing_retry_raises_session_gone(monkeypatch):
@@ -194,7 +352,7 @@ def test_deliver_reused_session_403_with_failing_retry_raises_session_gone(monke
         requests.append(request)
         return _turn_response(request, responses.pop(0))
 
-    async def create_session():
+    async def create_session(restore_from=None):
         return fresh
 
     _client(monkeypatch, handler)

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.422
+version: 0.285.423
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260804120000_agent_sessions_lineage.sql
+++ b/projects/monolith/chart/migrations/20260804120000_agent_sessions_lineage.sql
@@ -1,0 +1,2 @@
+ALTER TABLE agent_sessions.agent_sessions
+    ADD COLUMN ember_lineage_id TEXT;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:JStoD99RFqi8pYVx8Kc5Ynd8gT3VC/YPCSGLlVcNgD0=
+h1:1dGwivynNgJjJfxMF0a6wTbKSYk1wtOZsVH98D/Z+ck=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -147,3 +147,4 @@ h1:JStoD99RFqi8pYVx8Kc5Ynd8gT3VC/YPCSGLlVcNgD0=
 20260727140000_ember_synthetic_probe_public_grants.sql h1:0RvmzKgBDZ95m8d5g2G4PVesouApxA1VTaJCLgKWi8s=
 20260801080000_agent_sessions_ember_session.sql h1:vNCgkKnCCS36E38kMowaXgillaARAmigysuvWMxLYlo=
 20260802090000_agent_sessions_model.sql h1:bXLzt7RR0ivSsYYSAIbfjQya906/QAEDRjKwCmGS+RM=
+20260804120000_agent_sessions_lineage.sql h1:z3Nd00j+dPGPeiYeXaPuJ8qPM2UPxmLXkUwtBcLjYbI=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.422
+      targetRevision: 0.285.423
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Slice 4 of cross-generation rehydrate (#4306), the monolith side that makes the feature real end to end: when a bound EmberVM session expires and the CP 410s the invoke, the transport creates a fresh session that **inherits the prior lineage's workspace** instead of starting blank, so `codex exec resume` / `claude --resume` picks the conversation up across the 6h version-convergence boundary.

## The lineage_id handle (why this is more than a one-liner)

The Slice 3 review established that restore keys on `lineage_id`, not `session_id`: a restored session has a fresh `session_id != lineage_id`, so restoring by `session_id` would work at the first generation boundary and then 404 at the second. The binding must persist the lineage handle:

- `EmberSession` and the `AgentSession` row gain `lineage_id` (plus a transient `restored` flag on the session).
- `create_session(restore_from=...)` posts `{"restore_lineage": ...}` and reads `lineage_id` + `restored` from the response.
- `deliver`'s 403/410 arm restores from `ember.lineage_id` (falling back to `session_id` for a pre-lineage binding), keeps the stored `cli_session_id` **only when `restored` is true**, and **degrades to a blank create** if the restore itself is denied (e.g. the lineage was GC'd) rather than failing the turn.
- `set_ember_session` persists `ember_lineage_id`; `clear_ember_session` nulls it.

## Migration

`20260804120000_agent_sessions_lineage.sql`: `ALTER TABLE agent_sessions.agent_sessions ADD COLUMN ember_lineage_id TEXT` (schema-qualified table name confirmed from the model). `atlas.sum` regenerated; ordering verified to sort after the latest on main.

## Verification

- 67/67 `agent_sessions` package tests pass (18 transport + 45 mcp + 4 store_voice), including new tests for lineage/restored parsing, the restore-body on the 410 path, `cli_session_id` kept on `restored:true` / dropped on `restored:false`, the degrade-to-blank fallback when the restore create is denied, and `ember_lineage_id` persistence end to end.
- The JSON contract is unit-tested against mocked httpx responses shaped to the CP's Slice 3 contract; true end-to-end verification is the live generation-boundary gate (next).
- Monolith 0.285.422 -> 0.285.423, monolith-public 0.89.347 -> 0.89.348 (coupled).

Public tier: touches `agent_sessions`, not public pages; Visual regression should be a no-op.

Next: Slice 5 (double-failure hardening) and the live gate proving a codeword survives an expiry -> 410 -> restore -> resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS

---
_Generated by [Claude Code](https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS)_