### PR TITLE
feat(monolith): preserve prior lineage through binding clears (#4306 slice 5)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.348
+version: 0.89.349
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.348
+      targetRevision: 0.89.349
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -281,14 +281,26 @@ async def _execute_pending_message(session_id: int) -> None:
             )
             return
         try:
-            # Reuse the session_id from the database (from first turn), or None for new sessions
-            cli_session_id = session_row.cli_session_id
             existing_ember = _ember_session(session_row)
+            if existing_ember is None and session_row.prior_ember_lineage_id:
+                # #4306 slice 5: the active binding is gone (a confirmed-dead
+                # session, EmberSessionGone, or an admin destroy), but a
+                # prior lineage survived the clear. Restore from it and
+                # resume the PRIOR generation's CLI transcript rather than
+                # starting a blank conversation despite the durable
+                # workspace still existing.
+                cli_session_id = session_row.prior_cli_session_id
+                restore_from = session_row.prior_ember_lineage_id
+            else:
+                # Reuse the session_id from the database (from first turn), or None for new sessions
+                cli_session_id = session_row.cli_session_id
+                restore_from = None
             turn, ember = await _transport.deliver(
                 existing_ember,
                 cli_session_id,
                 row.message_text,
                 row.model,
+                restore_from=restore_from,
             )
             # Check if claim was stolen while deliver was running
             if claim_stolen:

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -140,7 +140,9 @@ def test_same_family_override_reaches_transport_and_turn(monkeypatch, session):
     monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
     delivered_models = []
 
-    async def mock_deliver(_ember, _cli_session_id, message, model=None):
+    async def mock_deliver(
+        _ember, _cli_session_id, message, model=None, restore_from=None
+    ):
         delivered_models.append(model)
         return _completed_delivery(message)
 
@@ -169,7 +171,9 @@ def test_same_family_override_reaches_transport_and_turn(monkeypatch, session):
 def test_session_start_returns_immediately(monkeypatch, session):
     started = asyncio.Event()
 
-    async def blocking_deliver(_ember, _cli_session_id, _message, _model=None):
+    async def blocking_deliver(
+        _ember, _cli_session_id, _message, _model=None, restore_from=None
+    ):
         started.set()
         await asyncio.Event().wait()
 
@@ -195,7 +199,9 @@ def test_session_start_returns_immediately(monkeypatch, session):
 def test_session_start_happy_path_persists_result(monkeypatch, session):
     monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
 
-    async def mock_deliver(_ember, _cli_session_id, message, _model=None):
+    async def mock_deliver(
+        _ember, _cli_session_id, message, _model=None, restore_from=None
+    ):
         return _completed_delivery(message)
 
     async def notify(*args, **kwargs):
@@ -228,7 +234,9 @@ def test_session_start_happy_path_persists_result(monkeypatch, session):
 def test_failed_first_turn_does_not_wedge_session(monkeypatch, session):
     monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
 
-    async def failing_deliver(_ember, _cli_session_id, _message, _model=None):
+    async def failing_deliver(
+        _ember, _cli_session_id, _message, _model=None, restore_from=None
+    ):
         raise RuntimeError("first turn failed")
 
     monkeypatch.setattr(mcp._transport, "deliver", failing_deliver)
@@ -251,7 +259,9 @@ def test_concurrent_executors_on_first_turn_run_once(monkeypatch, session):
     monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
     executions: list[str] = []
 
-    async def mock_deliver(_ember, _cli_session_id, message, _model=None):
+    async def mock_deliver(
+        _ember, _cli_session_id, message, _model=None, restore_from=None
+    ):
         executions.append(message)
         await asyncio.sleep(0.01)
         return _completed_delivery(message)
@@ -301,7 +311,9 @@ def _completed_delivery(message: str) -> tuple[Turn, EmberSession]:
 def test_pending_message_executed_in_background(monkeypatch, session):
     row = store.create_session(session, "sid-123", "/workspace", "main")
 
-    async def mock_deliver(_ember, _cli_session_id, message, _model=None):
+    async def mock_deliver(
+        _ember, _cli_session_id, message, _model=None, restore_from=None
+    ):
         return _completed_delivery(message)
 
     monkeypatch.setattr(mcp._transport, "deliver", mock_deliver)
@@ -334,7 +346,9 @@ def test_failed_delivery_clears_reused_ember_session(monkeypatch, session):
     pending = store.create_pending_message(session, row.id, "hello")
     pending_seq = pending.seq
 
-    async def failing_deliver(_ember, _cli_session_id, _message, _model=None):
+    async def failing_deliver(
+        _ember, _cli_session_id, _message, _model=None, restore_from=None
+    ):
         raise EmberSessionGone("terminal invoke failure")
 
     monkeypatch.setattr(mcp._transport, "deliver", failing_deliver)
@@ -361,7 +375,9 @@ def test_failed_guest_delivery_does_not_clear_reused_session(monkeypatch, sessio
     session.commit()
     store.create_pending_message(session, row.id, "hello")
 
-    async def failing_deliver(_ember, _cli_session_id, _message, _model=None):
+    async def failing_deliver(
+        _ember, _cli_session_id, _message, _model=None, restore_from=None
+    ):
         raise EmberVMTransportError("422 Unprocessable Entity")
 
     monkeypatch.setattr(mcp._transport, "deliver", failing_deliver)
@@ -392,7 +408,9 @@ def test_recreated_ember_session_adopts_new_cli_session_id(monkeypatch, session)
         "ember-new", "token-new", 1754035300000, lineage_id="lineage-old", restored=True
     )
 
-    async def succeeding_delivery(_ember, _cli_session_id, _message, _model=None):
+    async def succeeding_delivery(
+        _ember, _cli_session_id, _message, _model=None, restore_from=None
+    ):
         return _completed_turn("hello")._replace(session_id="cli-new"), new_ember
 
     async def notify(*args, **kwargs):
@@ -456,6 +474,192 @@ def test_clear_ember_session_nulls_lineage_id(session):
     assert reloaded.ember_lineage_id is None
 
 
+# -- #4306 slice 5: prior_* preservation across a binding clear -------------
+
+
+def test_clear_ember_session_preserves_prior_lineage_and_cli(session):
+    row = store.create_session(session, "sid-prior-1", "/workspace", "main")
+    store.set_ember_session(session, row.id, "ember-1", "token-1", None, "lineage-1")
+    row.cli_session_id = "cli-1"
+    session.add(row)
+    session.commit()
+
+    store.clear_ember_session(session, row.id)
+
+    session.expire_all()
+    reloaded = store.get_session(session, row.id)
+    assert reloaded.ember_session_id is None
+    assert reloaded.ember_lineage_id is None
+    assert reloaded.cli_session_id is None
+    assert reloaded.prior_ember_lineage_id == "lineage-1"
+    assert reloaded.prior_cli_session_id == "cli-1"
+
+
+def test_clear_ember_session_does_not_clobber_a_good_prior_with_nil(session):
+    """A repeated clear on an already-blank binding must not overwrite a
+    good prior_* with the (now nil) active value."""
+    row = store.create_session(session, "sid-prior-2", "/workspace", "main")
+    store.set_ember_session(session, row.id, "ember-1", "token-1", None, "lineage-1")
+    row.cli_session_id = "cli-1"
+    session.add(row)
+    session.commit()
+
+    store.clear_ember_session(session, row.id)
+    # The binding is now blank; clearing it AGAIN must be a no-op on prior_*.
+    store.clear_ember_session(session, row.id)
+
+    session.expire_all()
+    reloaded = store.get_session(session, row.id)
+    assert reloaded.prior_ember_lineage_id == "lineage-1"
+    assert reloaded.prior_cli_session_id == "cli-1"
+
+
+def test_set_ember_session_clears_prior_on_new_live_binding(session):
+    row = store.create_session(session, "sid-prior-3", "/workspace", "main")
+    store.set_ember_session(session, row.id, "ember-1", "token-1", None, "lineage-1")
+    row.cli_session_id = "cli-1"
+    session.add(row)
+    session.commit()
+    store.clear_ember_session(session, row.id)
+    session.expire_all()
+    cleared = store.get_session(session, row.id)
+    assert cleared.prior_ember_lineage_id == "lineage-1"
+
+    # A NEW live binding (a successful restore or a fresh create) supersedes
+    # the preserved prior; it must not linger and shadow this live one.
+    store.set_ember_session(session, row.id, "ember-2", "token-2", None, "lineage-1")
+
+    session.expire_all()
+    reloaded = store.get_session(session, row.id)
+    assert reloaded.ember_session_id == "ember-2"
+    assert reloaded.prior_ember_lineage_id is None
+    assert reloaded.prior_cli_session_id is None
+
+
+def test_clear_ember_bindings_by_ember_id_preserves_prior_lineage_and_cli(session):
+    row = store.create_session(session, "sid-prior-4", "/workspace", "main")
+    store.set_ember_session(session, row.id, "ember-1", "token-1", None, "lineage-1")
+    row.cli_session_id = "cli-1"
+    session.add(row)
+    session.commit()
+
+    ids = store.clear_ember_bindings_by_ember_id(session, "ember-1")
+
+    assert ids == [row.id]
+    session.expire_all()
+    reloaded = store.get_session(session, row.id)
+    assert reloaded.ember_session_id is None
+    assert reloaded.ember_lineage_id is None
+    assert reloaded.cli_session_id is None
+    assert reloaded.prior_ember_lineage_id == "lineage-1"
+    assert reloaded.prior_cli_session_id == "cli-1"
+
+
+def test_send_after_cleared_binding_restores_from_prior_lineage(monkeypatch, session):
+    """#4306 slice 5: no active ember binding, but a prior lineage survived
+    the clear. The next send must restore from it and resume the prior CLI
+    transcript, not start a blank conversation."""
+    row = store.create_session(session, "sid-prior-5", "/workspace", "main")
+    store.set_ember_session(
+        session, row.id, "ember-old", "token-old", None, "lineage-old"
+    )
+    row.cli_session_id = "cli-old"
+    session.add(row)
+    session.commit()
+    store.clear_ember_session(session, row.id)
+    pending = store.create_pending_message(session, row.id, "hello")
+    pending_seq = pending.seq
+
+    deliver_calls = []
+    restored_ember = EmberSession(
+        "ember-new", "token-new", None, lineage_id="lineage-old", restored=True
+    )
+
+    async def mock_deliver(
+        ember, cli_session_id, message, model=None, restore_from=None
+    ):
+        deliver_calls.append(
+            {
+                "ember": ember,
+                "cli_session_id": cli_session_id,
+                "restore_from": restore_from,
+            }
+        )
+        return _completed_turn(message)._replace(session_id="cli-new"), restored_ember
+
+    async def notify(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(mcp._transport, "deliver", mock_deliver)
+    monkeypatch.setattr(mcp.agent_api, "notify", notify)
+
+    asyncio.run(mcp._execute_pending_message(row.id))
+
+    assert len(deliver_calls) == 1
+    call = deliver_calls[0]
+    assert call["ember"] is None
+    assert call["cli_session_id"] == "cli-old"
+    assert call["restore_from"] == "lineage-old"
+
+    session.expire_all()
+    updated = store.get_session(session, row.id)
+    assert updated.ember_session_id == "ember-new"
+    assert updated.ember_lineage_id == "lineage-old"
+    assert updated.cli_session_id == "cli-new"
+    # The new live binding superseded the preserved prior.
+    assert updated.prior_ember_lineage_id is None
+    assert store.get_pending_message(session, row.id, pending_seq) is None
+
+
+def test_send_with_live_binding_ignores_prior_lineage(monkeypatch, session):
+    """A live binding always wins: prior_* (however it got set) must never
+    override an ACTIVE binding's own ember/cli_session_id."""
+    row = store.create_session(session, "sid-prior-6", "/workspace", "main")
+    store.set_ember_session(
+        session, row.id, "ember-live", "token-live", None, "lineage-live"
+    )
+    row.cli_session_id = "cli-live"
+    # Simulate a stray prior_* despite a live binding (should not happen via
+    # the normal set_ember_session path, which clears it, but the deliver
+    # call site must not depend on that invariant holding).
+    row.prior_ember_lineage_id = "lineage-stale"
+    row.prior_cli_session_id = "cli-stale"
+    session.add(row)
+    session.commit()
+    pending = store.create_pending_message(session, row.id, "hello")
+    pending_seq = pending.seq
+
+    deliver_calls = []
+
+    async def mock_deliver(
+        ember, cli_session_id, message, model=None, restore_from=None
+    ):
+        deliver_calls.append(
+            {
+                "ember": ember,
+                "cli_session_id": cli_session_id,
+                "restore_from": restore_from,
+            }
+        )
+        return _completed_delivery(message)
+
+    async def notify(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(mcp._transport, "deliver", mock_deliver)
+    monkeypatch.setattr(mcp.agent_api, "notify", notify)
+
+    asyncio.run(mcp._execute_pending_message(row.id))
+
+    assert len(deliver_calls) == 1
+    call = deliver_calls[0]
+    assert call["ember"] is not None
+    assert call["ember"].session_id == "ember-live"
+    assert call["cli_session_id"] == "cli-live"
+    assert call["restore_from"] is None
+    assert store.get_pending_message(session, row.id, pending_seq) is None
+
+
 def test_startup_sweep_lists_orphaned_messages(session):
     row = store.create_session(session, "sid-123", "/workspace", "main")
     store.create_pending_message(session, row.id, "orphaned message")
@@ -470,7 +674,9 @@ def test_two_sends_are_serialized(monkeypatch, session):
     row = store.create_session(session, "sid-123", "/workspace", "main")
     execution_order = []
 
-    async def fake_deliver(_ember, _cli_session_id, message, _model=None):
+    async def fake_deliver(
+        _ember, _cli_session_id, message, _model=None, restore_from=None
+    ):
         execution_order.append(message)
         await asyncio.sleep(0.01)
         return _completed_delivery(message)
@@ -508,7 +714,9 @@ def test_concurrent_replicas_execute_pending_message_once(monkeypatch, session):
     )  # capture before expire_all(); the row is deleted on completion
     executions: list[str] = []
 
-    async def fake_deliver(_ember, _cli_session_id, message, _model=None):
+    async def fake_deliver(
+        _ember, _cli_session_id, message, _model=None, restore_from=None
+    ):
         executions.append(message)
         await asyncio.sleep(0.01)
         return _completed_delivery(message)

--- a/projects/monolith/agent_sessions/models.py
+++ b/projects/monolith/agent_sessions/models.py
@@ -26,6 +26,14 @@ class AgentSession(SQLModel, table=True):
     # create). This is what a later create passes as restore_lineage to
     # continue the same guest workspace/transcript across an expiry.
     ember_lineage_id: str | None = Field(default=None)
+    # #4306 slice 5: the LAST live binding's lineage/CLI transcript, copied
+    # here when the active binding is cleared (a confirmed-dead session or an
+    # admin destroy), so the next send can still restore the durable
+    # workspace even through the double-failure/destroy path that today
+    # drops the lineage handle entirely. Cleared whenever a new LIVE binding
+    # is established (set_ember_session), so a stale prior never shadows one.
+    prior_ember_lineage_id: str | None = Field(default=None)
+    prior_cli_session_id: str | None = Field(default=None)
     # BigInteger, not the default Integer: this is epoch MILLISECONDS from the
     # control plane, which overflows int4. The migration already declares BIGINT,
     # but SQLModel maps a plain int to sqlalchemy Integer and emits an explicit

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -63,6 +63,12 @@ def set_ember_session(
     # can restore from it instead of the (invalid, past generation zero)
     # session_id.
     row.ember_lineage_id = ember_lineage_id
+    # #4306 slice 5: a new LIVE binding supersedes any preserved prior one;
+    # clear it so a stale prior_* never shadows this live binding (see
+    # clear_ember_session/clear_ember_bindings_by_ember_id for where prior_*
+    # gets set).
+    row.prior_ember_lineage_id = None
+    row.prior_cli_session_id = None
     session.add(row)
     session.commit()
     session.refresh(row)
@@ -74,10 +80,24 @@ def clear_ember_session(session: Session, session_id: int) -> AgentSession:
 
     The VM and its CLI transcript are one unit of state; both must be cleared
     or neither, else the next turn attempts --resume on a fresh VM (503).
+
+    #4306 slice 5: before nulling, the ACTIVE lineage/CLI transcript are
+    copied to prior_ember_lineage_id/prior_cli_session_id, so the next send
+    can still restore the durable workspace even through this
+    confirmed-dead-binding path (EmberSessionGone: a 410/403 AND its retry
+    also failed), which otherwise drops the lineage handle entirely and
+    starts a blank conversation despite the S3 workspace still existing.
+    Only overwrites prior_* when the ACTIVE value is non-nil: a repeated
+    clear on an already-blank binding must not wipe out a good prior with a
+    nil.
     """
     row = session.get(AgentSession, session_id)
     if row is None:
         raise ValueError(f"Unknown agent session {session_id}")
+    if row.ember_lineage_id:
+        row.prior_ember_lineage_id = row.ember_lineage_id
+    if row.cli_session_id:
+        row.prior_cli_session_id = row.cli_session_id
     row.ember_session_id = None
     row.ember_session_token = None
     row.ember_session_expires_at = None
@@ -98,11 +118,15 @@ def clear_ember_bindings_by_ember_id(session: Session, ember_id: str) -> list[in
     via exec/select and mutated in place, then committed once; nothing is
     session.add-ed in a loop.
 
-    Deliberately does NOT null ember_lineage_id or cli_session_id (#4306
-    slice 4): destroying this specific VM/generation does not necessarily
-    destroy its durable workspace volume, so a future create can still
-    restore from the lineage and pick the transcript back up. Only
-    clear_ember_session (a confirmed-dead binding) clears the lineage too.
+    #4306 slice 5: mirrors clear_ember_session's prior_* preservation (see
+    there for the non-nil-guard rationale), so an admin destroy ALSO
+    survives as a restorable lineage. This supersedes Slice 4's original
+    carve-out here (which left ember_lineage_id/cli_session_id untouched,
+    reasoning the destroyed VM's volume might still be restorable from the
+    still-live ember_lineage_id): mcp.py's restore check now looks at
+    prior_ember_lineage_id uniformly for BOTH failure paths, so leaving this
+    one still populating the ACTIVE (not prior) field would make it
+    invisible to that check.
 
     Returns the ids of the affected AgentSession rows.
     """
@@ -111,9 +135,15 @@ def clear_ember_bindings_by_ember_id(session: Session, ember_id: str) -> list[in
     ).all()
     ids: list[int] = []
     for row in rows:
+        if row.ember_lineage_id:
+            row.prior_ember_lineage_id = row.ember_lineage_id
+        if row.cli_session_id:
+            row.prior_cli_session_id = row.cli_session_id
         row.ember_session_id = None
         row.ember_session_token = None
         row.ember_session_expires_at = None
+        row.ember_lineage_id = None
+        row.cli_session_id = None
         ids.append(row.id)
     session.commit()
     return ids

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -95,6 +95,7 @@ class ShimTransport(Protocol):
         cli_session_id: str | None,
         message: str,
         model: str | None = None,
+        restore_from: str | None = None,
     ) -> tuple[Turn, EmberSession]: ...
 
 
@@ -304,13 +305,24 @@ class EmberVmShimTransport:
         cli_session_id: str | None,
         message: str,
         model: str | None = None,
+        restore_from: str | None = None,
     ) -> tuple[Turn, EmberSession]:
         """Execute one turn on the guest session and return the result.
 
         Args:
             ember: Existing EmberVM session identity to reuse, or None to create new.
             cli_session_id: Claude CLI session ID for transcript resumption.
+                When ember is None and restore_from is set, this should be
+                the PRIOR generation's cli_session_id (#4306 slice 5): it is
+                only actually sent once the restore is confirmed to have
+                recovered the workspace (see restore_from below).
             message: User message / prompt to send to Claude.
+            restore_from: A prior LINEAGE handle to inherit the guest
+                workspace from when ember is None (#4306 slice 5: the
+                binding-was-cleared path, e.g. after an EmberSessionGone or
+                an admin destroy, where the active binding is gone but the
+                durable workspace may still exist). Ignored when ember is
+                not None (a live binding is reused as today).
 
         Returns:
             The guest Turn and the EmberVM session identity actually used.
@@ -325,7 +337,26 @@ class EmberVmShimTransport:
 
         created = ember is None
         if ember is None:
-            ember = await self.create_session()
+            if restore_from:
+                try:
+                    ember = await self.create_session(restore_from=restore_from)
+                except EmberVMTransportError as restore_exc:
+                    # Same degrade as the 410/403 arm below: the restore
+                    # create was itself DENIED or timed out, so fall back to
+                    # a BLANK session rather than failing the turn outright.
+                    logger.warning(
+                        "embervm restore create denied for lineage %s, "
+                        "falling back to a blank session: %s",
+                        restore_from,
+                        restore_exc,
+                    )
+                    ember = await self.create_session()
+                # Only resume the CLI transcript when the workspace was
+                # ACTUALLY recovered; a blank session has nothing for
+                # --resume to find (mirrors the 410 arm's cli gating below).
+                cli_session_id = cli_session_id if ember.restored else None
+            else:
+                ember = await self.create_session()
 
         async def invoke(
             current: EmberSession, current_cli_session_id: str | None

--- a/projects/monolith/agent_sessions/transport_test.py
+++ b/projects/monolith/agent_sessions/transport_test.py
@@ -439,3 +439,94 @@ def test_deliver_does_not_retry_fresh_session_failure(monkeypatch):
 
     assert len(requests) == 1
     assert create_calls == 1
+
+
+# -- #4306 slice 5: deliver(ember=None, restore_from=...) -------------------
+# The binding-was-cleared path: no ember to reuse, but a PRIOR lineage
+# survived clear_ember_session/clear_ember_bindings_by_ember_id.
+
+
+def test_deliver_with_no_ember_restores_and_keeps_cli_when_recovered(monkeypatch):
+    requests = []
+    restored_session = transport.EmberSession(
+        "s2", "t2", None, lineage_id="lineage-1", restored=True
+    )
+    create_calls = []
+
+    async def handler(request):
+        requests.append(request)
+        return _turn_response(request)
+
+    async def create_session(restore_from=None):
+        create_calls.append(restore_from)
+        return restored_session
+
+    _client(monkeypatch, handler)
+    client = transport.EmberVmShimTransport()
+    monkeypatch.setattr(client, "create_session", create_session)
+    turn, used = asyncio.run(
+        client.deliver(None, "cli-prior", "hello", restore_from="lineage-1")
+    )
+
+    assert create_calls == ["lineage-1"]
+    assert used == restored_session
+    # restored=True: the prior CLI transcript is resumed.
+    assert json.loads(requests[0].content)["session_id"] == "cli-prior"
+    assert turn.result == "ok"
+
+
+def test_deliver_with_no_ember_restore_denied_falls_back_to_blank(monkeypatch):
+    requests = []
+    blank = transport.EmberSession("s3", "t3", None)
+    create_calls = []
+
+    async def handler(request):
+        requests.append(request)
+        return _turn_response(request)
+
+    async def create_session(restore_from=None):
+        create_calls.append(restore_from)
+        if restore_from:
+            raise EmberVMTransportError("404 unknown_lineage")
+        return blank
+
+    _client(monkeypatch, handler)
+    client = transport.EmberVmShimTransport()
+    monkeypatch.setattr(client, "create_session", create_session)
+    turn, used = asyncio.run(
+        client.deliver(None, "cli-prior", "hello", restore_from="lineage-1")
+    )
+
+    # First call attempted the restore and was denied; second is the blank
+    # fallback (no restore_from), same degrade pattern as the 410 retry arm.
+    assert create_calls == ["lineage-1", None]
+    assert used == blank
+    # A blank session (restored=False) must not carry the prior CLI id forward.
+    assert json.loads(requests[0].content)["session_id"] is None
+    assert turn.result == "ok"
+
+
+def test_deliver_with_no_ember_and_no_restore_from_is_unchanged(monkeypatch):
+    """A normal first send (restore_from=None, the default) behaves exactly
+    as it did before slice 5: no cli gating applied at all."""
+    requests = []
+    fresh = transport.EmberSession("s1", "t1", None)
+    create_calls = []
+
+    async def handler(request):
+        requests.append(request)
+        return _turn_response(request)
+
+    async def create_session(restore_from=None):
+        create_calls.append(restore_from)
+        return fresh
+
+    _client(monkeypatch, handler)
+    client = transport.EmberVmShimTransport()
+    monkeypatch.setattr(client, "create_session", create_session)
+    turn, used = asyncio.run(client.deliver(None, "cli-x", "hello"))
+
+    assert create_calls == [None]
+    assert used == fresh
+    assert json.loads(requests[0].content)["session_id"] == "cli-x"
+    assert turn.result == "ok"

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.423
+version: 0.285.424
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260804130000_agent_sessions_prior_lineage.sql
+++ b/projects/monolith/chart/migrations/20260804130000_agent_sessions_prior_lineage.sql
@@ -1,0 +1,3 @@
+ALTER TABLE agent_sessions.agent_sessions
+    ADD COLUMN prior_ember_lineage_id TEXT,
+    ADD COLUMN prior_cli_session_id TEXT;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:1dGwivynNgJjJfxMF0a6wTbKSYk1wtOZsVH98D/Z+ck=
+h1:OXdoZo050L/Xx9wCFsiZD+C1cn1s6n/2Wn+XEJuePts=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -148,3 +148,4 @@ h1:1dGwivynNgJjJfxMF0a6wTbKSYk1wtOZsVH98D/Z+ck=
 20260801080000_agent_sessions_ember_session.sql h1:vNCgkKnCCS36E38kMowaXgillaARAmigysuvWMxLYlo=
 20260802090000_agent_sessions_model.sql h1:bXLzt7RR0ivSsYYSAIbfjQya906/QAEDRjKwCmGS+RM=
 20260804120000_agent_sessions_lineage.sql h1:z3Nd00j+dPGPeiYeXaPuJ8qPM2UPxmLXkUwtBcLjYbI=
+20260804130000_agent_sessions_prior_lineage.sql h1:iR7hDl+ZrGDhgAvnv0aLDyNDmiBF+NOBfFgqsfsZ7cA=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.423
+      targetRevision: 0.285.424
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

Final slice of the cross-generation workspace rehydrate feature (#4306). Hardens the two paths that previously dropped the ember lineage handle entirely, so a durable per-lineage workspace stays restorable even after the active binding is gone.

Two new nullable columns on `agent_sessions`, `prior_ember_lineage_id` and `prior_cli_session_id`, capture the last live binding when it is cleared:

- `clear_ember_session` (the confirmed-dead binding path: an `EmberSessionGone`, i.e. a 410/403 whose retry also failed) now copies the active `ember_lineage_id` / `cli_session_id` into the `prior_*` fields before nulling.
- `clear_ember_bindings_by_ember_id` (the admin-destroy path) does the same. This supersedes slice 4's carve-out that left the active lineage populated: the restore check now reads `prior_ember_lineage_id` uniformly for both failure paths, so leaving one path writing the active field would make it invisible to that check.
- Both copies are guarded to never overwrite a good prior with a nil, so a repeated clear on an already-blank binding is a no-op.
- `set_ember_session` clears the `prior_*` fields when a new live binding is established, so a stale prior never shadows a live binding.

On the next send, `mcp.py` restores from `prior_ember_lineage_id` (passing the prior `cli_session_id`) when there is no live binding but a prior exists. `transport.deliver` gains a `restore_from` arm on the `ember is None` branch that:

- degrades to a blank session if the restore create is denied or times out (mirrors the 410/403 degrade arm), and
- only resumes the CLI transcript when `ember.restored` confirms the workspace was actually recovered, so a blank fallback never runs `--resume` against a transcript that no longer exists.

## Why

Before this slice, the double-failure and admin-destroy paths nulled the lineage handle, so the next turn started a blank conversation even though the S3-exported workspace still existed. This closes that gap and completes the generation-boundary continuity story.

## Migration

`20260804130000_agent_sessions_prior_lineage.sql` adds the two nullable `TEXT` columns; `atlas.sum` is rehashed.

## Deploy

Carries the coupled `monolith` + `monolith-public` chart bumps so ArgoCD picks up the rebuilt image.

## Testing

- `transport_test.py` covers the restore arm: restore-then-resume on recovery, degrade-to-blank on a denied restore create, and CLI gating on the blank fallback.
- `mcp_test.py` covers the prior-lineage restore selection and the live-binding-wins case.
- `ci lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS

---
_Generated by [Claude Code](https://claude.ai/code/session_019YXq1yw1qupgeBTCbAsznS)_