### PR TITLE
fix(monolith): apply /agents review findings

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.351
+version: 0.89.352
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.351
+      targetRevision: 0.89.352
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -83,11 +83,6 @@ def _clear_ember_bindings_for(ember_id: str) -> list[int]:
         return store.clear_ember_bindings_by_ember_id(db_session, ember_id)
 
 
-def _clear_ember_bindings_for_session(session_id: int) -> None:
-    with Session(get_engine()) as db_session:
-        store.clear_ember_session(db_session, session_id)
-
-
 def _persist_pending_message(
     session_id: int, message_text: str, model: str | None
 ) -> int:

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, timezone
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlmodel import Session, func, select
 
@@ -14,7 +14,6 @@ from agent_sessions import model_family, store
 from agent_sessions.models import AgentSession, AgentTurn, PendingMessage
 from agent_sessions.mcp import (
     _clear_ember_bindings_for,
-    _clear_ember_bindings_for_session,
     _load_session_row,
     _persist_pending_message,
     _persist_session,
@@ -79,7 +78,7 @@ def _aggregate_statement(status: str | None = None):
         )
         .outerjoin(turns, turns.c.session_id == AgentSession.id)
         .outerjoin(pending, pending.c.session_id == AgentSession.id)
-        .order_by(AgentSession.last_turn_at.desc().nullslast())
+        .order_by(AgentSession.last_turn_at.desc())
     )
     if status is not None:
         statement = statement.where(AgentSession.status == status)
@@ -139,21 +138,20 @@ def list_sessions(
 
 @router.get("/sessions/{session_id}")
 def get_session_detail(
-    session_id: int, session: Session = Depends(get_session)
+    session_id: int,
+    after_seq: int | None = Query(default=None, ge=0),
+    session: Session = Depends(get_session),
 ) -> dict:
     result = session.exec(
         _aggregate_statement().where(AgentSession.id == session_id)
     ).first()
     if result is None:
-        from fastapi import HTTPException
-
         raise HTTPException(status_code=404, detail="Agent session not found")
     row, turn_count, total_cost_usd, pending_count = result
-    turns = session.exec(
-        select(AgentTurn)
-        .where(AgentTurn.session_id == session_id)
-        .order_by(AgentTurn.seq)
-    ).all()
+    turns_statement = select(AgentTurn).where(AgentTurn.session_id == session_id)
+    if after_seq is not None:
+        turns_statement = turns_statement.where(AgentTurn.seq > after_seq)
+    turns = session.exec(turns_statement.order_by(AgentTurn.seq)).all()
     pending = session.exec(
         select(PendingMessage)
         .where(PendingMessage.session_id == session_id)
@@ -195,20 +193,20 @@ def get_session_detail(
 async def start_session(request: StartRequest) -> dict:
     try:
         model_family(request.model)
-        row = await asyncio.to_thread(
-            _persist_session,
-            str(uuid4()),
-            request.workspace,
-            request.branch,
-            request.model,
-        )
-        turn = await asyncio.to_thread(
-            _persist_pending_message, row.id, request.prompt, request.model
-        )
-        _schedule_next_message(row.id)
-        return {"accepted": True, "session_id": row.id, "turn": turn}
     except ValueError as exc:
         return {"accepted": False, "error": str(exc)}
+    row = await asyncio.to_thread(
+        _persist_session,
+        str(uuid4()),
+        request.workspace,
+        request.branch,
+        request.model,
+    )
+    turn = await asyncio.to_thread(
+        _persist_pending_message, row.id, request.prompt, request.model
+    )
+    _schedule_next_message(row.id)
+    return {"accepted": True, "session_id": row.id, "turn": turn}
 
 
 @router.post("/sessions/{session_id}/messages")
@@ -241,16 +239,18 @@ async def send_message(session_id: int, request: MessageRequest) -> dict:
 
 
 @router.delete("/sessions/{session_id}")
-async def delete_session(session_id: int, ember_session_id: str | None = None) -> dict:
+async def delete_session(session_id: int) -> dict:
     try:
-        if ember_session_id is not None:
-            result = await _transport.destroy_session(ember_session_id)
-            result["cleared_bindings"] = await asyncio.to_thread(
-                _clear_ember_bindings_for, ember_session_id
-            )
-            return result
-        await asyncio.to_thread(_clear_ember_bindings_for_session, session_id)
-        return {}
+        row = await asyncio.to_thread(_load_session_row, session_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail="Agent session not found")
+        if row.ember_session_id is None:
+            return {}
+        result = await _transport.destroy_session(row.ember_session_id)
+        result["cleared_bindings"] = await asyncio.to_thread(
+            _clear_ember_bindings_for, row.ember_session_id
+        )
+        return result
     except EmberVMTransportError as exc:
         return {"error": str(exc)}
 

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -140,6 +140,16 @@ def test_get_session_detail(client, session):
     assert body["turns"][1]["usage"] == {"activities": ["shell"]}
     assert body["pending_queue"][0]["prompt"] == "next"
 
+    newer = client.get(f"/api/agents/sessions/{row.id}?after_seq=1").json()
+    assert [turn["seq"] for turn in newer["turns"]] == [2]
+    assert newer["session"]["id"] == row.id
+    assert newer["pending_queue"][0]["prompt"] == "next"
+
+
+def test_get_session_detail_rejects_negative_after_seq(client, session):
+    row = _session(session, "after-seq")
+    assert client.get(f"/api/agents/sessions/{row.id}?after_seq=-1").status_code == 422
+
 
 def test_get_session_not_found(client):
     assert client.get("/api/agents/sessions/999").status_code == 404
@@ -218,12 +228,29 @@ def test_send_message_session_not_found(client, monkeypatch):
 
 def test_delete_session(client, session, monkeypatch):
     row = _session(session, "delete", ember_session_id="ember-1")
+    destroyed = []
+
+    async def fake_destroy(ember_session_id):
+        destroyed.append(ember_session_id)
+        return {"session_id": ember_session_id, "state": "destroyed"}
+
+    monkeypatch.setattr("agent_sessions.router._load_session_row", lambda _: row)
     monkeypatch.setattr(
-        "agent_sessions.router._clear_ember_bindings_for_session",
-        lambda session_id: store.clear_ember_session(session, session_id),
+        "agent_sessions.router._transport.destroy_session", fake_destroy
     )
-    assert client.delete(f"/api/agents/sessions/{row.id}").json() == {}
+    monkeypatch.setattr(
+        "agent_sessions.router._clear_ember_bindings_for",
+        lambda ember_id: store.clear_ember_bindings_by_ember_id(session, ember_id),
+    )
+    body = client.delete(f"/api/agents/sessions/{row.id}").json()
+    assert destroyed == ["ember-1"]
+    assert body["cleared_bindings"] == [row.id]
     assert session.get(AgentSession, row.id).ember_session_id is None
+
+
+def test_delete_session_not_found(client, monkeypatch):
+    monkeypatch.setattr("agent_sessions.router._load_session_row", lambda _: None)
+    assert client.delete("/api/agents/sessions/999").status_code == 404
 
 
 def test_search_empty_query(client):

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -226,14 +226,19 @@ def lexical_search(session: Session, query_text: str, limit: int = 20) -> list[d
 
     sql = text(
         "WITH q AS (SELECT websearch_to_tsquery('english', :q) AS q) "
+        "SELECT ranked.session_id, ranked.local_session_id, ranked.workspace, "
+        "ranked.seq, ranked.created_at, ranked.rank, "
+        "ts_headline('english', ranked.prompt || ' ' || ranked.result_text, "
+        "ranked.query, 'MaxWords=20,MinWords=3,ShortWord=0,StartSel=,StopSel=') "
+        "AS snippet FROM ("
         "SELECT t.session_id, s.local_session_id, s.workspace, t.seq, "
-        "t.created_at, ts_rank_cd(t.fts_vector, q.q) AS rank, "
-        "ts_headline('english', t.prompt || ' ' || t.result_text, q.q, "
-        "'MaxWords=20,MinWords=3,ShortWord=0') AS snippet "
+        "t.created_at, t.prompt, t.result_text, q.q AS query, "
+        "ts_rank_cd(t.fts_vector, q.q) AS rank "
         "FROM agent_sessions.agent_turns t "
         "JOIN agent_sessions.agent_sessions s ON t.session_id = s.id, q "
         "WHERE t.fts_vector @@ q.q "
         "ORDER BY rank DESC, t.created_at DESC LIMIT :limit"
+        ") AS ranked"
     )
     result = session.exec(sql, params={"q": query_text, "limit": limit})
     keys = (

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.426
+version: 0.285.427
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.426
+      targetRevision: 0.285.427
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/private/+layout.svelte
@@ -25,7 +25,8 @@
   let showBack = $derived.by(() => {
     const path = $page.url.pathname.replace(/^\/private(?=\/|$)/, "") || "/";
     if (path === "/") return false;
-    if (/^\/(app|demos|review|chat|notes)(\/|$)/.test(path)) return false;
+    if (/^\/(app|demos|review|chat|notes|agents)(\/|$)/.test(path))
+      return false;
     return true;
   });
 </script>

--- a/projects/monolith/frontend/src/routes/private/agents/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/agents/+page.svelte
@@ -1,7 +1,7 @@
 <script>
   let { data } = $props();
 
-  const MODELS = ["opus", "fable", "luna", "terra", "sol", "qwen"];
+  const MODELS = ["opus", "fable", "sonnet", "luna", "terra", "sol", "qwen"];
 
   let selectedId = $state(null);
   let sessions = $state(data.sessions ?? []);
@@ -10,12 +10,13 @@
   let searchResults = $state(null);
   let searchLoading = $state(false);
   let prompt = $state("");
-  let composerModel = $state("luna");
+  let composerModel = $state("");
   let sending = $state(false);
   let creating = $state(false);
+  let showNewPanel = $state(false);
   let newSession = $state({
     prompt: "",
-    model: "luna",
+    model: "",
     workspace: "",
     branch: "",
   });
@@ -113,15 +114,30 @@
     return tool;
   }
 
-  async function loadDetail(id, sequence = requestSequence) {
+  async function loadDetail(
+    id,
+    sequence = requestSequence,
+    incremental = false,
+  ) {
     if (id == null) return;
     try {
-      const response = await fetch(`/agents/session/${encodeURIComponent(id)}`);
+      const maxSeq = incremental
+        ? Math.max(0, ...(detail?.turns ?? []).map((turn) => turn.seq))
+        : 0;
+      const suffix = incremental ? `?after_seq=${maxSeq}` : "";
+      const response = await fetch(
+        `/agents/session/${encodeURIComponent(id)}${suffix}`,
+      );
       if (!response.ok) throw new Error("Unable to load session");
       const body = await response.json();
       if (sequence === requestSequence && String(selectedId) === String(id)) {
-        detail = body;
-        if (body.session?.model) composerModel = body.session.model;
+        detail = incremental
+          ? {
+              session: body.session,
+              turns: [...(detail?.turns ?? []), ...(body.turns ?? [])],
+              pending_queue: body.pending_queue,
+            }
+          : body;
       }
     } catch (error) {
       if (sequence === requestSequence) errorMessage = error.message;
@@ -156,7 +172,7 @@
     searchResults = null;
     loadDetail(id, requestSequence);
     const session = sessions.find((item) => String(item.id) === String(id));
-    composerModel = session?.model || "luna";
+    composerModel = session?.model || "";
   }
 
   async function runSearch() {
@@ -192,22 +208,19 @@
     }
   }
 
-  function onSearchInput() {
-    clearTimeout(searchTimer);
-    searchTimer = setTimeout(runSearch, 200);
-  }
-
   async function sendPrompt() {
     if (!selectedId || !prompt.trim() || sending) return;
     sending = true;
     errorMessage = null;
     try {
+      const requestBody = { prompt: prompt.trim() };
+      if (composerModel) requestBody.model = composerModel;
       const response = await fetch(
         `/agents/session/${encodeURIComponent(selectedId)}/messages`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ prompt: prompt.trim(), model: composerModel }),
+          body: JSON.stringify(requestBody),
         },
       );
       const body = await response.json();
@@ -216,7 +229,7 @@
       prompt = "";
       await Promise.all([
         loadSessions(),
-        loadDetail(selectedId, requestSequence),
+        loadDetail(selectedId, requestSequence, true),
       ]);
     } catch (error) {
       errorMessage = error.message;
@@ -230,21 +243,23 @@
     creating = true;
     errorMessage = null;
     try {
+      const requestBody = {
+        prompt: newSession.prompt.trim(),
+        workspace: newSession.workspace.trim(),
+        branch: newSession.branch.trim(),
+      };
+      if (newSession.model) requestBody.model = newSession.model;
       const response = await fetch("/agents/sessions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          prompt: newSession.prompt.trim(),
-          model: newSession.model,
-          workspace: newSession.workspace.trim(),
-          branch: newSession.branch.trim(),
-        }),
+        body: JSON.stringify(requestBody),
       });
       const body = await response.json();
       if (!response.ok || body.accepted === false)
         throw new Error(body.error || "Session was not created");
       creating = false;
-      newSession = { prompt: "", model: "luna", workspace: "", branch: "" };
+      showNewPanel = false;
+      newSession = { prompt: "", model: "", workspace: "", branch: "" };
       await loadSessions();
       selectSession(body.session_id);
     } catch (error) {
@@ -264,7 +279,6 @@
       selectedId = null;
       detail = null;
       await loadSessions();
-      if (sessions[0]) selectSession(sessions[0]);
     } catch (error) {
       errorMessage = error.message;
     }
@@ -287,7 +301,8 @@
     const interval = setInterval(
       async () => {
         await loadSessions();
-        if (selectedId != null) await loadDetail(selectedId, requestSequence);
+        if (selectedId != null)
+          await loadDetail(selectedId, requestSequence, true);
       },
       hasActiveSessions ? 2000 : 15000,
     );
@@ -309,7 +324,7 @@
       <button
         class="new-button"
         type="button"
-        onclick={() => (creating = !creating)}>+ new</button
+        onclick={() => (showNewPanel = !showNewPanel)}>+ new</button
       >
     </div>
 
@@ -317,7 +332,6 @@
       <span class="sr-only">Search sessions</span>
       <input
         bind:value={searchQuery}
-        oninput={onSearchInput}
         placeholder="search transcript"
         autocomplete="off"
       />
@@ -436,6 +450,7 @@
           rows="3"></textarea>
         <div class="composer-actions">
           <select bind:value={composerModel} aria-label="Model">
+            <option value="">session default</option>
             {#each MODELS as model}<option value={model}>{model}</option>{/each}
           </select>
           <button
@@ -451,7 +466,7 @@
     {/if}
   </section>
 
-  {#if creating}
+  {#if showNewPanel}
     <section class="new-panel">
       <div class="eyebrow">new session</div>
       <form
@@ -468,6 +483,7 @@
         >
         <label
           >model<select bind:value={newSession.model}
+            ><option value="">session default</option
             >{#each MODELS as model}<option value={model}>{model}</option
               >{/each}</select
           ></label
@@ -488,12 +504,12 @@
           <button
             type="button"
             class="quiet-button"
-            onclick={() => (creating = false)}>cancel</button
+            onclick={() => (showNewPanel = false)}>cancel</button
           ><button
             class="send-button"
             type="submit"
-            disabled={creating && !newSession.prompt.trim()}
-            >{creating ? "create" : "create"}</button
+            disabled={creating || !newSession.prompt.trim()}
+            >{creating ? "creating" : "create"}</button
           >
         </div>
       </form>


### PR DESCRIPTION
Follow-up to #4323, which auto-merged at the ci-format-bot's head while this commit was being pushed, leaving the review findings out of main. Implements the reviewer's findings for #4320.

## What

- New-session form actually submits: the panel-visibility flag no longer doubles as the in-flight guard.
- Composer defaults to the session's own model ("session default") instead of hardcoded luna, so sends to model-less (claude-family) sessions are no longer rejected with a family mismatch; sonnet added to the model list.
- Destroy destroys: the endpoint derives the EmberVM session id server-side from the session row and performs the same transport destroy plus binding clear as the MCP tool (the caller-supplied `ember_session_id` query param is gone; previously the UI path only cleared DB bindings and leaked the workload-cap slot).
- Session detail accepts `after_seq` and the 2s poll appends new turns instead of re-downloading the transcript.
- Search headlines are markup-free (`StartSel=,StopSel=`) and computed only over the LIMITed rows.
- The private layout back-link no longer overlaps the /agents chrome.
- Chart bumps: monolith 0.285.427, monolith-public 0.89.352.

Pre-push `ci test` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
