### PR TITLE
feat(embervm): arm the S3 warmth GC

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.401
+version: 0.1.402

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.401
+      targetRevision: 0.1.402
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -256,6 +256,13 @@ warmthRetention:
 # sweep (dry-run included) aborts.
 warmthS3Gc:
   allowEmptyKinds: "group"
+  # ARMED (Joe 2026-08-04) after reading dry-run manifest
+  # gc-manifests/1785867400387.json: plan 200 prefixes / ~98 GiB (198
+  # stateful, 1 session orphan, 1 group_set), 4410 stateful refs / ~2.19 TiB
+  # eligible beyond caps, holds proving the guards (3 tier2_protected_newest,
+  # 1 desired_ref, 69 younger_than_age_floor). Rollback: set enabled back to
+  # "" and bump the chart.
+  enabled: "1"
   maxPrefixes: "200"
   maxBytes: "107374182400"
   expectedNodes:


### PR DESCRIPTION
## Summary
The arming flip planned in #4325 and #4317, approved by Joe. One value: `warmthS3Gc.enabled: "1"` (plus the chart bump 0.1.401 -> 0.1.402).

Supervised dry-run evidence (manifest `gc-manifests/1785867400387.json`, produced and read before this flip):
- Plan = exactly the first armed sweep: **200 prefixes / ~98 GiB** (198 `stateful/`, the 4 GiB `session/` orphan, 1 `group_set/`)
- Beyond caps: **4,410 stateful refs / ~2.19 TiB** (drains in ~1 day of hourly sweeps)
- Holds prove the guards: 3 `tier2_protected_newest` (live workloads' newest checkpoints), 1 `desired_ref`, 69 `younger_than_age_floor`; nothing referenced or live planned
- TTLs live: stateful 8h, others 7d

## Test plan
- `ci test` green (config-only change; template test covers the render)
- Post-merge supervision: watch the first armed sweep via CP logs (not console `sweep_now`, whose 120s call timeout a ~4,600-GET sweep exceeds), confirm deleted counts match the plan and SeaweedFS vacuum starts reclaiming volumes; report on #4317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDjrfDPyRJKZYAYyutgd7Y