### PR TITLE
fix(monolith): harden agent session flow across wakes and restores

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.354
+version: 0.89.355
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.354
+      targetRevision: 0.89.355
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -75,6 +75,23 @@ def _persist_ember_session(session_id: int, ember: EmberSession) -> None:
             ember.session_token,
             ember.expires_at,
             ember.lineage_id,
+            is_restored=ember.restored,
+        )
+
+
+def _persist_ember_session_and_cli(
+    session_id: int, ember: EmberSession, cli_session_id: str | None
+) -> None:
+    with Session(get_engine()) as db_session:
+        store.set_ember_session(
+            db_session,
+            session_id,
+            ember.session_id,
+            ember.session_token,
+            ember.expires_at,
+            ember.lineage_id,
+            cli_session_id=cli_session_id,
+            is_restored=ember.restored,
         )
 
 
@@ -284,9 +301,16 @@ async def _execute_pending_message(session_id: int) -> None:
             existing_ember = _ember_session(session_row)
             fresh_binding_persisted = False
 
-            async def persist_callback(ember: EmberSession) -> None:
+            async def persist_callback(
+                ember: EmberSession, cli_for_binding: str | None
+            ) -> None:
                 nonlocal fresh_binding_persisted
-                await asyncio.to_thread(_persist_ember_session, session_id, ember)
+                await asyncio.to_thread(
+                    _persist_ember_session_and_cli,
+                    session_id,
+                    ember,
+                    cli_for_binding,
+                )
                 fresh_binding_persisted = True
 
             if existing_ember is None and session_row.prior_ember_lineage_id:
@@ -319,6 +343,7 @@ async def _execute_pending_message(session_id: int) -> None:
                 )
                 return
             if ember != existing_ember:
+                # Safety: re-persist for transports without on_create support
                 await asyncio.to_thread(_persist_ember_session, session_id, ember)
         except EmberSessionGone as exc:
             # Session confirmed dead by CP; clear the binding and CLI id together.

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -282,6 +282,13 @@ async def _execute_pending_message(session_id: int) -> None:
             return
         try:
             existing_ember = _ember_session(session_row)
+            fresh_binding_persisted = False
+
+            async def persist_callback(ember: EmberSession) -> None:
+                nonlocal fresh_binding_persisted
+                await asyncio.to_thread(_persist_ember_session, session_id, ember)
+                fresh_binding_persisted = True
+
             if existing_ember is None and session_row.prior_ember_lineage_id:
                 # #4306 slice 5: the active binding is gone (a confirmed-dead
                 # session, EmberSessionGone, or an admin destroy), but a
@@ -301,6 +308,7 @@ async def _execute_pending_message(session_id: int) -> None:
                 row.message_text,
                 row.model,
                 restore_from=restore_from,
+                on_create=persist_callback,
             )
             # Check if claim was stolen while deliver was running
             if claim_stolen:
@@ -314,7 +322,8 @@ async def _execute_pending_message(session_id: int) -> None:
                 await asyncio.to_thread(_persist_ember_session, session_id, ember)
         except EmberSessionGone as exc:
             # Session confirmed dead by CP; clear the binding and CLI id together.
-            await asyncio.to_thread(_clear_ember_session_sync, session_id)
+            if not fresh_binding_persisted:
+                await asyncio.to_thread(_clear_ember_session_sync, session_id)
             await asyncio.to_thread(
                 _mark_turn_error_sync, session_id, claimed_seq, str(exc)
             )

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -382,6 +382,39 @@ def test_failed_delivery_clears_reused_ember_session(monkeypatch, session):
     assert pending_after is None
 
 
+def test_clear_ember_session_not_called_when_fresh_binding_persisted(
+    monkeypatch, session
+):
+    """A persisted heir must survive EmberSessionGone handling."""
+    row = store.create_session(session, "sid-123", "/workspace", "main")
+    pending = store.create_pending_message(session, row.id, "hello")
+    on_create_called = []
+
+    async def mock_deliver(
+        _ember,
+        _cli_session_id,
+        _message,
+        _model=None,
+        restore_from=None,
+        on_create=None,
+    ):
+        heir = EmberSession("heir-id", "heir-token", None)
+        if on_create is not None:
+            await on_create(heir, None)
+            on_create_called.append(True)
+        raise EmberSessionGone("heir invoke failed")
+
+    monkeypatch.setattr(mcp._transport, "deliver", mock_deliver)
+    asyncio.run(mcp._execute_pending_message(row.id))
+
+    session.expire_all()
+    updated_row = store.get_session(session, row.id)
+    assert on_create_called == [True]
+    assert updated_row.ember_session_id == "heir-id"
+    assert updated_row.prior_ember_lineage_id is None
+    assert store.get_pending_message(session, row.id, pending.seq) is None
+
+
 def test_failed_guest_delivery_does_not_clear_reused_session(monkeypatch, session):
     row = store.create_session(session, "sid-123", "/workspace", "main")
     store.set_ember_session(session, row.id, "ember-1", "token-1", 1754035200000)
@@ -539,7 +572,7 @@ def test_clear_ember_session_does_not_clobber_a_good_prior_with_nil(session):
     assert reloaded.prior_cli_session_id == "cli-1"
 
 
-def test_set_ember_session_clears_prior_on_new_live_binding(session):
+def test_set_ember_session_clears_prior_on_restored_binding(session):
     row = store.create_session(session, "sid-prior-3", "/workspace", "main")
     store.set_ember_session(session, row.id, "ember-1", "token-1", None, "lineage-1")
     row.cli_session_id = "cli-1"
@@ -550,9 +583,16 @@ def test_set_ember_session_clears_prior_on_new_live_binding(session):
     cleared = store.get_session(session, row.id)
     assert cleared.prior_ember_lineage_id == "lineage-1"
 
-    # A NEW live binding (a successful restore or a fresh create) supersedes
-    # the preserved prior; it must not linger and shadow this live one.
-    store.set_ember_session(session, row.id, "ember-2", "token-2", None, "lineage-1")
+    # Only a successful restore supersedes the preserved prior.
+    store.set_ember_session(
+        session,
+        row.id,
+        "ember-2",
+        "token-2",
+        None,
+        "lineage-1",
+        is_restored=True,
+    )
 
     session.expire_all()
     reloaded = store.get_session(session, row.id)

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -388,6 +388,7 @@ def test_clear_ember_session_not_called_when_fresh_binding_persisted(
     """A persisted heir must survive EmberSessionGone handling."""
     row = store.create_session(session, "sid-123", "/workspace", "main")
     pending = store.create_pending_message(session, row.id, "hello")
+    pending_seq = pending.seq
     on_create_called = []
 
     async def mock_deliver(
@@ -412,7 +413,7 @@ def test_clear_ember_session_not_called_when_fresh_binding_persisted(
     assert on_create_called == [True]
     assert updated_row.ember_session_id == "heir-id"
     assert updated_row.prior_ember_lineage_id is None
-    assert store.get_pending_message(session, row.id, pending.seq) is None
+    assert store.get_pending_message(session, row.id, pending_seq) is None
 
 
 def test_failed_guest_delivery_does_not_clear_reused_session(monkeypatch, session):

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -141,7 +141,7 @@ def test_same_family_override_reaches_transport_and_turn(monkeypatch, session):
     delivered_models = []
 
     async def mock_deliver(
-        _ember, _cli_session_id, message, model=None, restore_from=None
+        _ember, _cli_session_id, message, model=None, restore_from=None, on_create=None
     ):
         delivered_models.append(model)
         return _completed_delivery(message)
@@ -172,7 +172,12 @@ def test_session_start_returns_immediately(monkeypatch, session):
     started = asyncio.Event()
 
     async def blocking_deliver(
-        _ember, _cli_session_id, _message, _model=None, restore_from=None
+        _ember,
+        _cli_session_id,
+        _message,
+        _model=None,
+        restore_from=None,
+        on_create=None,
     ):
         started.set()
         await asyncio.Event().wait()
@@ -200,7 +205,7 @@ def test_session_start_happy_path_persists_result(monkeypatch, session):
     monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
 
     async def mock_deliver(
-        _ember, _cli_session_id, message, _model=None, restore_from=None
+        _ember, _cli_session_id, message, _model=None, restore_from=None, on_create=None
     ):
         return _completed_delivery(message)
 
@@ -235,7 +240,12 @@ def test_failed_first_turn_does_not_wedge_session(monkeypatch, session):
     monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
 
     async def failing_deliver(
-        _ember, _cli_session_id, _message, _model=None, restore_from=None
+        _ember,
+        _cli_session_id,
+        _message,
+        _model=None,
+        restore_from=None,
+        on_create=None,
     ):
         raise RuntimeError("first turn failed")
 
@@ -260,7 +270,7 @@ def test_concurrent_executors_on_first_turn_run_once(monkeypatch, session):
     executions: list[str] = []
 
     async def mock_deliver(
-        _ember, _cli_session_id, message, _model=None, restore_from=None
+        _ember, _cli_session_id, message, _model=None, restore_from=None, on_create=None
     ):
         executions.append(message)
         await asyncio.sleep(0.01)
@@ -312,7 +322,7 @@ def test_pending_message_executed_in_background(monkeypatch, session):
     row = store.create_session(session, "sid-123", "/workspace", "main")
 
     async def mock_deliver(
-        _ember, _cli_session_id, message, _model=None, restore_from=None
+        _ember, _cli_session_id, message, _model=None, restore_from=None, on_create=None
     ):
         return _completed_delivery(message)
 
@@ -347,7 +357,12 @@ def test_failed_delivery_clears_reused_ember_session(monkeypatch, session):
     pending_seq = pending.seq
 
     async def failing_deliver(
-        _ember, _cli_session_id, _message, _model=None, restore_from=None
+        _ember,
+        _cli_session_id,
+        _message,
+        _model=None,
+        restore_from=None,
+        on_create=None,
     ):
         raise EmberSessionGone("terminal invoke failure")
 
@@ -376,7 +391,12 @@ def test_failed_guest_delivery_does_not_clear_reused_session(monkeypatch, sessio
     store.create_pending_message(session, row.id, "hello")
 
     async def failing_deliver(
-        _ember, _cli_session_id, _message, _model=None, restore_from=None
+        _ember,
+        _cli_session_id,
+        _message,
+        _model=None,
+        restore_from=None,
+        on_create=None,
     ):
         raise EmberVMTransportError("422 Unprocessable Entity")
 
@@ -409,7 +429,12 @@ def test_recreated_ember_session_adopts_new_cli_session_id(monkeypatch, session)
     )
 
     async def succeeding_delivery(
-        _ember, _cli_session_id, _message, _model=None, restore_from=None
+        _ember,
+        _cli_session_id,
+        _message,
+        _model=None,
+        restore_from=None,
+        on_create=None,
     ):
         return _completed_turn("hello")._replace(session_id="cli-new"), new_ember
 
@@ -576,7 +601,7 @@ def test_send_after_cleared_binding_restores_from_prior_lineage(monkeypatch, ses
     )
 
     async def mock_deliver(
-        ember, cli_session_id, message, model=None, restore_from=None
+        ember, cli_session_id, message, model=None, restore_from=None, on_create=None
     ):
         deliver_calls.append(
             {
@@ -632,7 +657,7 @@ def test_send_with_live_binding_ignores_prior_lineage(monkeypatch, session):
     deliver_calls = []
 
     async def mock_deliver(
-        ember, cli_session_id, message, model=None, restore_from=None
+        ember, cli_session_id, message, model=None, restore_from=None, on_create=None
     ):
         deliver_calls.append(
             {
@@ -675,7 +700,7 @@ def test_two_sends_are_serialized(monkeypatch, session):
     execution_order = []
 
     async def fake_deliver(
-        _ember, _cli_session_id, message, _model=None, restore_from=None
+        _ember, _cli_session_id, message, _model=None, restore_from=None, on_create=None
     ):
         execution_order.append(message)
         await asyncio.sleep(0.01)
@@ -715,7 +740,7 @@ def test_concurrent_replicas_execute_pending_message_once(monkeypatch, session):
     executions: list[str] = []
 
     async def fake_deliver(
-        _ember, _cli_session_id, message, _model=None, restore_from=None
+        _ember, _cli_session_id, message, _model=None, restore_from=None, on_create=None
     ):
         executions.append(message)
         await asyncio.sleep(0.01)

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -400,6 +400,8 @@ def persist_turn_from_pending_sync(
         if not sess_row:
             raise ValueError(f"Session {session_id} not found")
         usage = {**turn.usage, "activities": turn.activities}
+        if turn.workspace_recovery is not None:
+            usage["workspace_recovery"] = turn.workspace_recovery
         row = create_turn(
             session,
             session_id,

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -14,6 +14,8 @@ from core.db import get_engine
 
 logger = logging.getLogger(__name__)
 
+_UNSET = object()
+
 
 def create_session(
     session: Session,
@@ -51,6 +53,8 @@ def set_ember_session(
     ember_token: str,
     ember_expires_at: int | None,
     ember_lineage_id: str | None = None,
+    cli_session_id: str | None | object = _UNSET,
+    is_restored: bool = False,
 ) -> AgentSession:
     row = session.get(AgentSession, session_id)
     if row is None:
@@ -63,12 +67,13 @@ def set_ember_session(
     # can restore from it instead of the (invalid, past generation zero)
     # session_id.
     row.ember_lineage_id = ember_lineage_id
-    # #4306 slice 5: a new LIVE binding supersedes any preserved prior one;
-    # clear it so a stale prior_* never shadows this live binding (see
-    # clear_ember_session/clear_ember_bindings_by_ember_id for where prior_*
-    # gets set).
-    row.prior_ember_lineage_id = None
-    row.prior_cli_session_id = None
+    if cli_session_id is not _UNSET:
+        row.cli_session_id = cli_session_id
+    # A blank fallback must preserve the durable restore handle until the
+    # replacement turn is known good.
+    if is_restored:
+        row.prior_ember_lineage_id = None
+        row.prior_cli_session_id = None
     session.add(row)
     session.commit()
     session.refresh(row)

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -125,7 +125,7 @@ class ShimTransport(Protocol):
         message: str,
         model: str | None = None,
         restore_from: str | None = None,
-        on_create: Callable[[EmberSession], Awaitable[None]] | None = None,
+        on_create: Callable[[EmberSession, str | None], Awaitable[None]] | None = None,
     ) -> tuple[Turn, EmberSession]: ...
 
 
@@ -341,7 +341,7 @@ class EmberVmShimTransport:
         message: str,
         model: str | None = None,
         restore_from: str | None = None,
-        on_create: Callable[[EmberSession], Awaitable[None]] | None = None,
+        on_create: Callable[[EmberSession, str | None], Awaitable[None]] | None = None,
     ) -> tuple[Turn, EmberSession]:
         """Execute one turn on the guest session and return the result.
 
@@ -399,12 +399,13 @@ class EmberVmShimTransport:
                         "restored": bool(ember.restored),
                         "degraded": None,
                     }
-                if on_create is not None:
-                    await on_create(ember)
                 # Only resume the CLI transcript when the workspace was
                 # ACTUALLY recovered; a blank session has nothing for
                 # --resume to find (mirrors the 410 arm's cli gating below).
-                cli_session_id = cli_session_id if ember.restored else None
+                cli_for_binding = cli_session_id if ember.restored else None
+                if on_create is not None:
+                    await on_create(ember, cli_for_binding)
+                cli_session_id = cli_for_binding
             else:
                 ember = await self.create_session()
                 workspace_recovery = {
@@ -413,7 +414,7 @@ class EmberVmShimTransport:
                     "degraded": None,
                 }
                 if on_create is not None:
-                    await on_create(ember)
+                    await on_create(ember, None)
 
         async def invoke(
             current: EmberSession, current_cli_session_id: str | None
@@ -506,8 +507,9 @@ class EmberVmShimTransport:
                 )
                 new_ember = await self.create_session()
 
+            cli_for_binding = cli_session_id if new_ember.restored else None
             if on_create is not None:
-                await on_create(new_ember)
+                await on_create(new_ember, cli_for_binding)
             workspace_recovery = {
                 "created": True,
                 "restored": bool(new_ember.restored),
@@ -517,7 +519,7 @@ class EmberVmShimTransport:
             # Only resume the CLI transcript when the guest workspace was
             # ACTUALLY recovered; a blank workspace has nothing for
             # --resume to find.
-            cli = cli_session_id if new_ember.restored else None
+            cli = cli_for_binding
             try:
                 turn = await _invoke_with_retryable_backoff(
                     lambda: invoke(new_ember, cli)

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -9,10 +9,11 @@ EMBERVM_URL, auth headers, error types, timeout shape).
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
-from typing import NamedTuple, Protocol
+from typing import Awaitable, Callable, NamedTuple, Protocol
 
 import httpx
 
@@ -24,6 +25,33 @@ from faas.embervm_client import (
 from shared.k8s_auth import auth_headers
 
 logger = logging.getLogger(__name__)
+
+
+def _retryable_from_response(exc: httpx.HTTPStatusError) -> bool:
+    try:
+        body = exc.response.json()
+        error = body.get("error") if isinstance(body, dict) else None
+        if isinstance(error, dict):
+            return error.get("retryable") is True
+        return isinstance(body, dict) and body.get("retryable") is True
+    except Exception:
+        return False
+
+
+async def _invoke_with_retryable_backoff(
+    invoke_fn: Callable[[], Awaitable["Turn"]],
+    max_attempts: int = 4,
+) -> "Turn":
+    """Call invoke_fn with exponential backoff on retryable errors."""
+    backoff_seconds = [2, 5, 10]
+    for attempt in range(max_attempts):
+        try:
+            return await invoke_fn()
+        except httpx.HTTPStatusError as exc:
+            if attempt == max_attempts - 1 or not _retryable_from_response(exc):
+                raise
+            await asyncio.sleep(backoff_seconds[attempt])
+    raise AssertionError("retry loop did not return or raise")
 
 
 def _status_error_detail(exc: httpx.HTTPStatusError) -> str:
@@ -70,6 +98,7 @@ class Turn(NamedTuple):
     total_cost_usd: float | None
     duration_ms: int | None
     activities: list[dict]
+    workspace_recovery: dict | None = None
 
 
 class EmberSession(NamedTuple):
@@ -96,6 +125,7 @@ class ShimTransport(Protocol):
         message: str,
         model: str | None = None,
         restore_from: str | None = None,
+        on_create: Callable[[EmberSession], Awaitable[None]] | None = None,
     ) -> tuple[Turn, EmberSession]: ...
 
 
@@ -138,7 +168,9 @@ class EmberVmShimTransport:
         self.workload = workload
         self.read_timeout = read_timeout
 
-    async def create_session(self, restore_from: str | None = None) -> EmberSession:
+    async def create_session(
+        self, restore_from: str | None = None, _attempt: int = 0
+    ) -> EmberSession:
         """Create a new session on the guest and return the session ID.
 
         Args:
@@ -205,6 +237,9 @@ class EmberVmShimTransport:
             raise EmberVMTimeout(str(exc)) from exc
         except httpx.HTTPStatusError as exc:
             logger.warning("embervm session creation failed: %s", exc)
+            if _attempt < 3 and _retryable_from_response(exc):
+                await asyncio.sleep((2, 5, 10)[_attempt])
+                return await self.create_session(restore_from, _attempt + 1)
             raise EmberVMTransportError(_status_error_detail(exc)) from exc
         except httpx.TransportError as exc:
             logger.warning("embervm session creation transport error: %s", exc)
@@ -306,6 +341,7 @@ class EmberVmShimTransport:
         message: str,
         model: str | None = None,
         restore_from: str | None = None,
+        on_create: Callable[[EmberSession], Awaitable[None]] | None = None,
     ) -> tuple[Turn, EmberSession]:
         """Execute one turn on the guest session and return the result.
 
@@ -336,6 +372,7 @@ class EmberVmShimTransport:
         timeout = httpx.Timeout(self.read_timeout, connect=SUBMIT_CONNECT_TIMEOUT)
 
         created = ember is None
+        workspace_recovery = None
         if ember is None:
             if restore_from:
                 try:
@@ -351,12 +388,32 @@ class EmberVmShimTransport:
                         restore_exc,
                     )
                     ember = await self.create_session()
+                    workspace_recovery = {
+                        "created": True,
+                        "restored": False,
+                        "degraded": "restore_denied",
+                    }
+                else:
+                    workspace_recovery = {
+                        "created": True,
+                        "restored": bool(ember.restored),
+                        "degraded": None,
+                    }
+                if on_create is not None:
+                    await on_create(ember)
                 # Only resume the CLI transcript when the workspace was
                 # ACTUALLY recovered; a blank session has nothing for
                 # --resume to find (mirrors the 410 arm's cli gating below).
                 cli_session_id = cli_session_id if ember.restored else None
             else:
                 ember = await self.create_session()
+                workspace_recovery = {
+                    "created": True,
+                    "restored": False,
+                    "degraded": None,
+                }
+                if on_create is not None:
+                    await on_create(ember)
 
         async def invoke(
             current: EmberSession, current_cli_session_id: str | None
@@ -414,7 +471,12 @@ class EmberVmShimTransport:
                 raise EmberVMTransportError(str(exc)) from exc
 
         try:
-            return await invoke(ember, cli_session_id), ember
+            turn = await _invoke_with_retryable_backoff(
+                lambda: invoke(ember, cli_session_id)
+            )
+            if workspace_recovery is not None:
+                turn = turn._replace(workspace_recovery=workspace_recovery)
+            return turn, ember
         except httpx.HTTPStatusError as exc:
             if created or exc.response.status_code not in (403, 410):
                 raise EmberVMTransportError(_status_error_detail(exc)) from exc
@@ -444,12 +506,23 @@ class EmberVmShimTransport:
                 )
                 new_ember = await self.create_session()
 
+            if on_create is not None:
+                await on_create(new_ember)
+            workspace_recovery = {
+                "created": True,
+                "restored": bool(new_ember.restored),
+                "degraded": None if new_ember.restored else "restore_fallback",
+            }
+
             # Only resume the CLI transcript when the guest workspace was
             # ACTUALLY recovered; a blank workspace has nothing for
             # --resume to find.
             cli = cli_session_id if new_ember.restored else None
             try:
-                return await invoke(new_ember, cli), new_ember
+                turn = await _invoke_with_retryable_backoff(
+                    lambda: invoke(new_ember, cli)
+                )
+                return turn._replace(workspace_recovery=workspace_recovery), new_ember
             except (httpx.HTTPStatusError, EmberVMTransportError) as retry_exc:
                 if isinstance(retry_exc, httpx.HTTPStatusError):
                     raise EmberSessionGone(

--- a/projects/monolith/agent_sessions/transport_test.py
+++ b/projects/monolith/agent_sessions/transport_test.py
@@ -42,7 +42,7 @@ def _turn_response(request: httpx.Request, status_code: int = 200):
 def _error_response(request: httpx.Request, status_code: int, retryable: bool):
     return httpx.Response(
         status_code,
-        json={"error": {"retryable": retryable}},
+        json={"error": "error message", "retryable": retryable},
         request=request,
     )
 
@@ -76,6 +76,37 @@ def test_create_session_parses_cp_session_identity(monkeypatch):
 
     assert result == transport.EmberSession("s1", "t1", 1754035200000)
     assert requests[0].headers["Authorization"] == "management"
+
+
+def test_create_session_retryable_backoff_and_restore_payload(monkeypatch):
+    attempts = []
+    sleeps = []
+
+    async def handler(request):
+        attempts.append(request)
+        if len(attempts) < 4:
+            return _error_response(request, 409, True)
+        return httpx.Response(
+            200,
+            json={"session_id": "s1", "session_token": "t1"},
+            request=request,
+        )
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    _client(monkeypatch, handler)
+    monkeypatch.setattr(transport.asyncio, "sleep", fake_sleep)
+    result = asyncio.run(
+        transport.EmberVmShimTransport().create_session(restore_from="lineage-1")
+    )
+
+    assert len(attempts) == 4
+    assert sleeps == [2, 5, 10]
+    assert [json.loads(request.content) for request in attempts] == [
+        {"restore_lineage": "lineage-1"}
+    ] * 4
+    assert result.session_id == "s1"
 
 
 @pytest.mark.parametrize("field", ["session_id", "session_token"])
@@ -516,8 +547,8 @@ def test_deliver_410_restore_heir_persisted_on_double_failure(monkeypatch):
         events.append("create")
         return heir
 
-    async def on_create(ember):
-        events.append(("persist", ember.session_id))
+    async def on_create(ember, cli_for_binding):
+        events.append(("persist", ember.session_id, cli_for_binding))
 
     _client(monkeypatch, handler)
     client = transport.EmberVmShimTransport()
@@ -532,7 +563,7 @@ def test_deliver_410_restore_heir_persisted_on_double_failure(monkeypatch):
             )
         )
 
-    assert events == ["invoke", "create", ("persist", "heir"), "invoke"]
+    assert events == ["invoke", "create", ("persist", "heir", None), "invoke"]
 
 
 def test_deliver_workspace_recovery_on_normal_create(monkeypatch):

--- a/projects/monolith/agent_sessions/transport_test.py
+++ b/projects/monolith/agent_sessions/transport_test.py
@@ -39,6 +39,14 @@ def _turn_response(request: httpx.Request, status_code: int = 200):
     )
 
 
+def _error_response(request: httpx.Request, status_code: int, retryable: bool):
+    return httpx.Response(
+        status_code,
+        json={"error": {"retryable": retryable}},
+        request=request,
+    )
+
+
 def _client(monkeypatch, handler):
     FakeAsyncClient.handler = staticmethod(handler)
     monkeypatch.setattr(transport.httpx, "AsyncClient", FakeAsyncClient)
@@ -439,6 +447,170 @@ def test_deliver_does_not_retry_fresh_session_failure(monkeypatch):
 
     assert len(requests) == 1
     assert create_calls == 1
+
+
+def test_deliver_fresh_session_retryable_then_fails(monkeypatch):
+    attempts = []
+    sleeps = []
+
+    async def handler(request):
+        attempts.append(request)
+        if len(attempts) < 4:
+            return _error_response(request, 409, True)
+        return _turn_response(request)
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    _client(monkeypatch, handler)
+    monkeypatch.setattr(transport.asyncio, "sleep", fake_sleep)
+    client = transport.EmberVmShimTransport()
+    fresh = transport.EmberSession("s1", "t1", None)
+
+    async def create_session(restore_from=None):
+        return fresh
+
+    monkeypatch.setattr(client, "create_session", create_session)
+    turn, _ = asyncio.run(client.deliver(None, "cli-1", "hello"))
+
+    assert turn.result == "ok"
+    assert len(attempts) == 4
+    assert sleeps == [2, 5, 10]
+
+
+def test_deliver_retryable_exhaustion(monkeypatch):
+    attempts = []
+    sleeps = []
+
+    async def handler(request):
+        attempts.append(request)
+        return _error_response(request, 429, True)
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    async def create_session(restore_from=None):
+        return transport.EmberSession("s1", "t1", None)
+
+    _client(monkeypatch, handler)
+    monkeypatch.setattr(transport.asyncio, "sleep", fake_sleep)
+    client = transport.EmberVmShimTransport()
+    monkeypatch.setattr(client, "create_session", create_session)
+    with pytest.raises(EmberVMTransportError):
+        asyncio.run(client.deliver(None, "cli-1", "hello"))
+
+    assert len(attempts) == 4
+    assert sleeps == [2, 5, 10]
+
+
+def test_deliver_410_restore_heir_persisted_on_double_failure(monkeypatch):
+    events = []
+    responses = [410, 410]
+    heir = transport.EmberSession("heir", "token", None)
+
+    async def handler(request):
+        events.append("invoke")
+        return _error_response(request, responses.pop(0), False)
+
+    async def create_session(restore_from=None):
+        events.append("create")
+        return heir
+
+    async def on_create(ember):
+        events.append(("persist", ember.session_id))
+
+    _client(monkeypatch, handler)
+    client = transport.EmberVmShimTransport()
+    monkeypatch.setattr(client, "create_session", create_session)
+    with pytest.raises(transport.EmberSessionGone):
+        asyncio.run(
+            client.deliver(
+                transport.EmberSession("old", "old-token", None),
+                "cli-1",
+                "hello",
+                on_create=on_create,
+            )
+        )
+
+    assert events == ["invoke", "create", ("persist", "heir"), "invoke"]
+
+
+def test_deliver_workspace_recovery_on_normal_create(monkeypatch):
+    async def handler(request):
+        return _turn_response(request)
+
+    async def create_session(restore_from=None):
+        return transport.EmberSession("s1", "t1", None)
+
+    _client(monkeypatch, handler)
+    client = transport.EmberVmShimTransport()
+    monkeypatch.setattr(client, "create_session", create_session)
+    turn, _ = asyncio.run(client.deliver(None, None, "hello"))
+
+    assert turn.workspace_recovery == {
+        "created": True,
+        "restored": False,
+        "degraded": None,
+    }
+
+
+def test_deliver_workspace_recovery_on_restore_success(monkeypatch):
+    async def handler(request):
+        return _turn_response(request)
+
+    async def create_session(restore_from=None):
+        return transport.EmberSession(
+            "s2", "t2", None, lineage_id="lineage-1", restored=True
+        )
+
+    _client(monkeypatch, handler)
+    client = transport.EmberVmShimTransport()
+    monkeypatch.setattr(client, "create_session", create_session)
+    turn, _ = asyncio.run(
+        client.deliver(None, "cli-1", "hello", restore_from="lineage-1")
+    )
+
+    assert turn.workspace_recovery == {
+        "created": True,
+        "restored": True,
+        "degraded": None,
+    }
+
+
+def test_deliver_workspace_recovery_on_restore_denial_fallback(monkeypatch):
+    async def handler(request):
+        return _turn_response(request)
+
+    async def create_session(restore_from=None):
+        if restore_from:
+            raise EmberVMTransportError("restore denied")
+        return transport.EmberSession("s3", "t3", None)
+
+    _client(monkeypatch, handler)
+    client = transport.EmberVmShimTransport()
+    monkeypatch.setattr(client, "create_session", create_session)
+    turn, _ = asyncio.run(
+        client.deliver(None, "cli-1", "hello", restore_from="lineage-1")
+    )
+
+    assert turn.workspace_recovery == {
+        "created": True,
+        "restored": False,
+        "degraded": "restore_denied",
+    }
+
+
+def test_deliver_workspace_recovery_absent_on_reuse(monkeypatch):
+    async def handler(request):
+        return _turn_response(request)
+
+    _client(monkeypatch, handler)
+    ember = transport.EmberSession("s1", "t1", None)
+    turn, _ = asyncio.run(
+        transport.EmberVmShimTransport().deliver(ember, None, "hello")
+    )
+
+    assert turn.workspace_recovery is None
 
 
 # -- #4306 slice 5: deliver(ember=None, restore_from=...) -------------------

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.429
+version: 0.285.430
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.429
+      targetRevision: 0.285.430
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Makes "a new message just wakes the session" hold under failure, per the wake-path trace. Closes #4326, closes #4327; backend half of #4329.

- Invoke and create calls now honor the control plane's `retryable` flag (409 not_ready, 429 wake_rate, 429 queue_full) with bounded 2/5/10s backoff instead of writing a terminal error turn and deleting the pending message. Non-retryable responses behave exactly as before; worst-case stacking stays ~102s, far inside both timeout windows, and the claim heartbeat runs through the sleeps.
- The heir binding (with its correctly gated cli_session_id) is persisted immediately after any successful create, before the follow-up invoke, so the 410-restore double failure can no longer strand a live heir that poisons the lineage, and a blank-fallback heir can no longer inherit a stale transcript id (the permanent resume-wedge the review caught). The prior_* restore handle survives fallback persists so transient restore denials remain retryable.
- Turns that created or restored a session now carry `workspace_recovery` {created, restored, degraded} in their usage, so a degraded restore is visible to the API and UI instead of being a log line.

Review applied in full: retry tests exercise the flat retryable body shape the control plane actually emits (the fallback-mutation now fails three tests), and the fresh-binding guard and create-side retry bounds are covered. The pre-push hook caught one test bug (reading a deliberately-deleted row's attribute after expire_all), fixed in the last commit.

Chart bumps: monolith 0.285.430, monolith-public 0.89.355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
