### PR TITLE
feat(git-mirror): open mirror to cluster-wide reads for workspace hydration

### DIFF
--- a/projects/embervm/chart/Chart.yaml
+++ b/projects/embervm/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: embervm
 description: EmberVM control plane — durable, fair, retried task execution over the Firecracker fleet (BEAM/Go control plane; GET /healthz on :8080)
 type: application
-version: 0.1.402
+version: 0.1.403

--- a/projects/embervm/deploy/application.yaml
+++ b/projects/embervm/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: embervm
-      targetRevision: 0.1.402
+      targetRevision: 0.1.403
       helm:
         valueFiles:
           - $values/projects/embervm/deploy/values.yaml

--- a/projects/embervm/deploy/values.yaml
+++ b/projects/embervm/deploy/values.yaml
@@ -289,16 +289,22 @@ warmthS3Gc:
 egress:
   enabled: true
   internal:
-    # ONE deliberate hole in the split-horizon guardrail: the pi adapter drives
-    # the in-cluster Qwen model, which lives on this exact host:port. Matching is
-    # an exact case-insensitive host compare against BOTH the requested host:port
-    # and the resolved ip:port, so a name and its address are both accepted and
-    # pinning the resolved IP is what defeats SSRF-by-name and DNS rebinding. No
-    # wildcards. internal.default stays deny: this permits the model endpoint and
+    # TWO deliberate holes in the split-horizon guardrail. Matching is an exact
+    # case-insensitive host compare against BOTH the requested host:port and the
+    # resolved ip:port, so a name and its address are both accepted and pinning
+    # the resolved IP is what defeats SSRF-by-name and DNS rebinding. No
+    # wildcards. internal.default stays deny: this permits these endpoints and
     # nothing else, so a prompt-injected guest still cannot pivot into the
     # cluster. Adding an entry here is a security decision, not tuning.
+    #
+    # inference: the pi adapter drives the in-cluster Qwen model on this exact
+    # host:port.
+    # git-mirror: workspace hydration (ADR agents/050). Anonymous read-only
+    # upload-pack plus receive-pack restricted to refs/agents/** by the mirror's
+    # pre-receive hook; no credential exists on this path.
     allowlist:
       - inference.inference.svc.cluster.local:8080
+      - git-mirror.monolith.svc.cluster.local:9418
   # The claude runtime's subscription OAuth token. The sidecar SETS the
   # Authorization header on requests to api.anthropic.com and originates the
   # verified TLS to :443 itself, so the credential never exists inside a guest

--- a/projects/firecracker/git-mirror/chart/Chart.yaml
+++ b/projects/firecracker/git-mirror/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: git-mirror
 description: Hot git mirror for Firecracker agent workspaces on node-4. Keeps bare clones warm via a supervisor loop; serves git:// (port 9418) with a pre-receive hook restricting writes to refs/agents/**.
 type: application
-version: 0.1.13
+version: 0.1.14
 appVersion: "0.1.0"
 maintainers:
   - name: jomcgi

--- a/projects/firecracker/git-mirror/chart/templates/service.yaml
+++ b/projects/firecracker/git-mirror/chart/templates/service.yaml
@@ -6,11 +6,12 @@ metadata:
     {{- include "git-mirror.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
-  # Node-local traffic policy: Firecracker guests are on node-4 and reach the
-  # mirror via the egress-proxy sidecar on the same node. This ensures git://
-  # connections are served by the co-located pod, not forwarded to a remote
-  # endpoint (which would be unavailable anyway since we pin to a single node).
-  internalTrafficPolicy: Local
+  # Cluster-wide ClusterIP (ADR agents/050). This was internalTrafficPolicy:
+  # Local while the only consumer was a node-4-local guest; claude-runtime
+  # session guests schedule across every firecracker-labeled node, so the
+  # Service must route from any node. What it exposes is anonymous read-only
+  # upload-pack plus receive-pack gated to refs/agents/** by the pre-receive
+  # hook; the hook, not the network boundary, is the write boundary.
   selector:
     {{- include "git-mirror.selectorLabels" . | nindent 4 }}
   ports:

--- a/projects/firecracker/git-mirror/deploy/application.yaml
+++ b/projects/firecracker/git-mirror/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: git-mirror
-      targetRevision: 0.1.13
+      targetRevision: 0.1.14
       helm:
         releaseName: git-mirror
         valueFiles:


### PR DESCRIPTION
Work item 1 of #4330, per ADR agents/050 (#4339).

- git-mirror Service drops internalTrafficPolicy: Local. Session guests schedule across every firecracker-labeled node; node-local routing would silently fail hydration everywhere but node-4. Exposure is unchanged: anonymous read-only upload-pack, receive-pack restricted to refs/agents/** by the pre-receive hook.
- EmberVM internal egress allowlist gains its second entry, git-mirror.monolith.svc.cluster.local:9418, recorded in the values comment as a security decision. internal.default stays deny.

Verified: helm template renders the Service without the field and EGRESS_INTERNAL_ALLOWLIST with both entries; the only CiliumNetworkPolicy in the repo scopes the tokenbroker, so nothing at the CNI layer blocks the path.

Deploy note: the allowlist is noded pod env, and bricks are BrickController-managed; this PR changes the pod template, so the controller rolls bricks. Post-merge check is a noded pod showing the new EGRESS_INTERNAL_ALLOWLIST, not the chart version.

Charts: git-mirror 0.1.14, embervm 0.1.403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)