### PR TITLE
feat(monolith): agent sessions carry a real repo and thread it to the guest

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5) and pruned
 type: application
-version: 0.89.357
+version: 0.89.358
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.89.357
+      targetRevision: 0.89.358
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1487,13 +1487,6 @@ py_library(
 )
 
 py_library(
-    name = "pkg_repo_catalog",
-    srcs = ["goosecracker/repo_catalog.py"],
-    imports = ["."],
-    visibility = ["//:__subpackages__"],
-)
-
-py_library(
     name = "pkg_agent_sessions",
     srcs = glob(
         [
@@ -1512,7 +1505,6 @@ py_library(
         ":pkg_cyclegroup",
         ":pkg_faas",
         ":pkg_framework",
-        ":pkg_repo_catalog",
         ":pkg_shared",
         "@pip//astral",
         "@pip//beautifulsoup4",

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1487,6 +1487,13 @@ py_library(
 )
 
 py_library(
+    name = "pkg_repo_catalog",
+    srcs = ["goosecracker/repo_catalog.py"],
+    imports = ["."],
+    visibility = ["//:__subpackages__"],
+)
+
+py_library(
     name = "pkg_agent_sessions",
     srcs = glob(
         [
@@ -1505,6 +1512,7 @@ py_library(
         ":pkg_cyclegroup",
         ":pkg_faas",
         ":pkg_framework",
+        ":pkg_repo_catalog",
         ":pkg_shared",
         "@pip//astral",
         "@pip//beautifulsoup4",

--- a/projects/monolith/agent_sessions/mcp.py
+++ b/projects/monolith/agent_sessions/mcp.py
@@ -110,11 +110,15 @@ def _persist_pending_message(
 
 
 def _persist_session(
-    local_session_id: str, workspace: str, branch: str, model: str | None
+    local_session_id: str,
+    workspace: str,
+    branch: str,
+    model: str | None,
+    repo: str | None = None,
 ) -> AgentSession:
     with Session(get_engine()) as db_session:
         return store.create_session(
-            db_session, local_session_id, workspace, branch, model
+            db_session, local_session_id, workspace, branch, model, repo
         )
 
 
@@ -326,13 +330,19 @@ async def _execute_pending_message(session_id: int) -> None:
                 # Reuse the session_id from the database (from first turn), or None for new sessions
                 cli_session_id = session_row.cli_session_id
                 restore_from = None
+            deliver_kwargs = {
+                "restore_from": restore_from,
+                "on_create": persist_callback,
+            }
+            if session_row.repo is not None:
+                deliver_kwargs["repo"] = session_row.repo
+                deliver_kwargs["branch"] = session_row.branch
             turn, ember = await _transport.deliver(
                 existing_ember,
                 cli_session_id,
                 row.message_text,
                 row.model,
-                restore_from=restore_from,
-                on_create=persist_callback,
+                **deliver_kwargs,
             )
             # Check if claim was stolen while deliver was running
             if claim_stolen:
@@ -375,7 +385,7 @@ async def _execute_pending_message(session_id: int) -> None:
                 turn.session_id,  # Store for resumption
                 row.model,
             )
-        except IntegrityError as e:
+        except IntegrityError:
             # Turn already exists (duplicate seq), likely from a retry of a completed turn.
             # Delete the pending row to prevent infinite retry.
             logger.warning(
@@ -494,7 +504,7 @@ async def monolith_agent_session_start(prompt: str, model: str | None = None) ->
     local_session_id = str(uuid4())
     workspace = "<guest>"  # Workspace is in the guest, not the pod
     row = await asyncio.to_thread(
-        _persist_session, local_session_id, workspace, "main", model
+        _persist_session, local_session_id, workspace, "main", model, None
     )
     turn = await asyncio.to_thread(_persist_pending_message, row.id, prompt, model)
     _schedule_next_message(row.id)

--- a/projects/monolith/agent_sessions/mcp_test.py
+++ b/projects/monolith/agent_sessions/mcp_test.py
@@ -141,7 +141,14 @@ def test_same_family_override_reaches_transport_and_turn(monkeypatch, session):
     delivered_models = []
 
     async def mock_deliver(
-        _ember, _cli_session_id, message, model=None, restore_from=None, on_create=None
+        _ember,
+        _cli_session_id,
+        message,
+        model=None,
+        restore_from=None,
+        on_create=None,
+        repo=None,
+        branch=None,
     ):
         delivered_models.append(model)
         return _completed_delivery(message)
@@ -178,6 +185,8 @@ def test_session_start_returns_immediately(monkeypatch, session):
         _model=None,
         restore_from=None,
         on_create=None,
+        repo=None,
+        branch=None,
     ):
         started.set()
         await asyncio.Event().wait()
@@ -205,7 +214,14 @@ def test_session_start_happy_path_persists_result(monkeypatch, session):
     monkeypatch.setattr(mcp, "_schedule_next_message", lambda _session_id: None)
 
     async def mock_deliver(
-        _ember, _cli_session_id, message, _model=None, restore_from=None, on_create=None
+        _ember,
+        _cli_session_id,
+        message,
+        _model=None,
+        restore_from=None,
+        on_create=None,
+        repo=None,
+        branch=None,
     ):
         return _completed_delivery(message)
 
@@ -270,7 +286,14 @@ def test_concurrent_executors_on_first_turn_run_once(monkeypatch, session):
     executions: list[str] = []
 
     async def mock_deliver(
-        _ember, _cli_session_id, message, _model=None, restore_from=None, on_create=None
+        _ember,
+        _cli_session_id,
+        message,
+        _model=None,
+        restore_from=None,
+        on_create=None,
+        repo=None,
+        branch=None,
     ):
         executions.append(message)
         await asyncio.sleep(0.01)
@@ -318,11 +341,53 @@ def _completed_delivery(message: str) -> tuple[Turn, EmberSession]:
     return _completed_turn(message), EmberSession("ember-1", "token-1", None)
 
 
+@pytest.mark.parametrize("repo", ["jomcgi/homelab", None])
+def test_executor_passes_session_repo_to_transport(monkeypatch, session, repo):
+    row = store.create_session(session, "sid-repo", "/workspace", "main", repo=repo)
+    store.create_pending_message(session, row.id, "hello")
+    deliver_kwargs = []
+
+    async def mock_deliver(
+        _ember,
+        _cli_session_id,
+        message,
+        _model=None,
+        restore_from=None,
+        on_create=None,
+        **kwargs,
+    ):
+        deliver_kwargs.append(kwargs)
+        return _completed_delivery(message)
+
+    async def notify(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(mcp._transport, "deliver", mock_deliver)
+    monkeypatch.setattr(mcp.agent_api, "notify", notify)
+
+    asyncio.run(mcp._execute_pending_message(row.id))
+
+    assert len(deliver_kwargs) == 1
+    if repo is None:
+        assert "repo" not in deliver_kwargs[0]
+        assert "branch" not in deliver_kwargs[0]
+    else:
+        assert deliver_kwargs[0]["repo"] == repo
+        assert deliver_kwargs[0]["branch"] == "main"
+
+
 def test_pending_message_executed_in_background(monkeypatch, session):
     row = store.create_session(session, "sid-123", "/workspace", "main")
 
     async def mock_deliver(
-        _ember, _cli_session_id, message, _model=None, restore_from=None, on_create=None
+        _ember,
+        _cli_session_id,
+        message,
+        _model=None,
+        restore_from=None,
+        on_create=None,
+        repo=None,
+        branch=None,
     ):
         return _completed_delivery(message)
 
@@ -363,6 +428,8 @@ def test_failed_delivery_clears_reused_ember_session(monkeypatch, session):
         _model=None,
         restore_from=None,
         on_create=None,
+        repo=None,
+        branch=None,
     ):
         raise EmberSessionGone("terminal invoke failure")
 
@@ -398,6 +465,8 @@ def test_clear_ember_session_not_called_when_fresh_binding_persisted(
         _model=None,
         restore_from=None,
         on_create=None,
+        repo=None,
+        branch=None,
     ):
         heir = EmberSession("heir-id", "heir-token", None)
         if on_create is not None:
@@ -642,7 +711,14 @@ def test_send_after_cleared_binding_restores_from_prior_lineage(monkeypatch, ses
     )
 
     async def mock_deliver(
-        ember, cli_session_id, message, model=None, restore_from=None, on_create=None
+        ember,
+        cli_session_id,
+        message,
+        model=None,
+        restore_from=None,
+        on_create=None,
+        repo=None,
+        branch=None,
     ):
         deliver_calls.append(
             {
@@ -698,7 +774,14 @@ def test_send_with_live_binding_ignores_prior_lineage(monkeypatch, session):
     deliver_calls = []
 
     async def mock_deliver(
-        ember, cli_session_id, message, model=None, restore_from=None, on_create=None
+        ember,
+        cli_session_id,
+        message,
+        model=None,
+        restore_from=None,
+        on_create=None,
+        repo=None,
+        branch=None,
     ):
         deliver_calls.append(
             {
@@ -741,7 +824,14 @@ def test_two_sends_are_serialized(monkeypatch, session):
     execution_order = []
 
     async def fake_deliver(
-        _ember, _cli_session_id, message, _model=None, restore_from=None, on_create=None
+        _ember,
+        _cli_session_id,
+        message,
+        _model=None,
+        restore_from=None,
+        on_create=None,
+        repo=None,
+        branch=None,
     ):
         execution_order.append(message)
         await asyncio.sleep(0.01)
@@ -781,7 +871,14 @@ def test_concurrent_replicas_execute_pending_message_once(monkeypatch, session):
     executions: list[str] = []
 
     async def fake_deliver(
-        _ember, _cli_session_id, message, _model=None, restore_from=None, on_create=None
+        _ember,
+        _cli_session_id,
+        message,
+        _model=None,
+        restore_from=None,
+        on_create=None,
+        repo=None,
+        branch=None,
     ):
         executions.append(message)
         await asyncio.sleep(0.01)

--- a/projects/monolith/agent_sessions/models.py
+++ b/projects/monolith/agent_sessions/models.py
@@ -14,6 +14,7 @@ class AgentSession(SQLModel, table=True):
     local_session_id: str = Field(unique=True)
     workspace: str
     branch: str
+    repo: str | None = None
     model: str | None = Field(default=None)
     cli_session_id: str | None = Field(
         default=None

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -26,12 +26,13 @@ from agent_sessions.mcp import (
 )
 from core.db import get_session
 from faas.embervm_client import EmberVMTransportError
-from goosecracker.repo_catalog import REPO_CATALOG
+from goosecracker.api import REPO_CATALOG
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/agents", tags=["agents"])
 _DEFAULT_BRANCH_CACHE: dict[str, tuple[float, str | None]] = {}
 _REPO_CACHE_TTL = 300.0
+_REPO_CACHE_FAILURE_TTL = 30.0
 
 
 def _as_utc(value: datetime | None) -> datetime | None:
@@ -239,20 +240,35 @@ async def _github_get(url: str) -> httpx.Response:
 @router.get("/repos")
 async def list_repos() -> dict:
     now = time.monotonic()
+    uncached = []
+    for repo_id in REPO_CATALOG:
+        cached = _DEFAULT_BRANCH_CACHE.get(repo_id)
+        if cached is None or cached[0] <= now:
+            uncached.append(repo_id)
+
+    async def fetch_default_branch(repo_id: str) -> None:
+        try:
+            response = await _github_get(f"https://api.github.com/repos/{repo_id}")
+            default_branch = response.json().get("default_branch")
+            if not isinstance(default_branch, str):
+                default_branch = None
+        except Exception:
+            _DEFAULT_BRANCH_CACHE[repo_id] = (
+                time.monotonic() + _REPO_CACHE_FAILURE_TTL,
+                None,
+            )
+            return
+        _DEFAULT_BRANCH_CACHE[repo_id] = (
+            time.monotonic() + _REPO_CACHE_TTL,
+            default_branch,
+        )
+
+    await asyncio.gather(*(fetch_default_branch(repo_id) for repo_id in uncached))
+
     repos = []
     for repo_id, entry in REPO_CATALOG.items():
         cached = _DEFAULT_BRANCH_CACHE.get(repo_id)
-        if cached is not None and cached[0] > now:
-            default_branch = cached[1]
-        else:
-            try:
-                response = await _github_get(f"https://api.github.com/repos/{repo_id}")
-                default_branch = response.json().get("default_branch")
-                if not isinstance(default_branch, str):
-                    default_branch = None
-            except Exception:
-                default_branch = None
-            _DEFAULT_BRANCH_CACHE[repo_id] = (now + _REPO_CACHE_TTL, default_branch)
+        default_branch = cached[1] if cached is not None else None
         repos.append(
             {
                 "id": repo_id,
@@ -278,15 +294,25 @@ async def list_repo_branches(owner: str, repo: str) -> dict:
         default_branch = repo_response.json().get("default_branch")
         if not isinstance(default_branch, str):
             default_branch = None
-        branches_response = await _github_get(
-            f"https://api.github.com/repos/{repo_id}/branches?per_page=100"
-        )
-        branches = [
-            {"name": branch["name"]}
-            for branch in branches_response.json()
-            if isinstance(branch, dict) and isinstance(branch.get("name"), str)
-        ]
-    except (httpx.HTTPError, ValueError, TypeError, KeyError) as exc:
+        branches = []
+        branches_url = f"https://api.github.com/repos/{repo_id}/branches?per_page=100"
+        for _ in range(10):
+            branches_response = await _github_get(branches_url)
+            page = branches_response.json()
+            if not isinstance(page, list):
+                raise HTTPException(
+                    status_code=502, detail="GitHub branches response was not a list"
+                )
+            branches.extend(
+                {"name": branch["name"]}
+                for branch in page
+                if isinstance(branch, dict) and isinstance(branch.get("name"), str)
+            )
+            next_link = branches_response.links.get("next")
+            if not next_link:
+                break
+            branches_url = next_link["url"]
+    except (httpx.HTTPError, ValueError, TypeError) as exc:
         raise HTTPException(
             status_code=502, detail=f"GitHub API request failed: {exc}"
         ) from exc

--- a/projects/monolith/agent_sessions/router.py
+++ b/projects/monolith/agent_sessions/router.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import time
 from datetime import datetime, timezone
 from uuid import uuid4
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlmodel import Session, func, select
@@ -23,9 +26,12 @@ from agent_sessions.mcp import (
 )
 from core.db import get_session
 from faas.embervm_client import EmberVMTransportError
+from goosecracker.repo_catalog import REPO_CATALOG
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/agents", tags=["agents"])
+_DEFAULT_BRANCH_CACHE: dict[str, tuple[float, str | None]] = {}
+_REPO_CACHE_TTL = 300.0
 
 
 def _as_utc(value: datetime | None) -> datetime | None:
@@ -93,6 +99,7 @@ def _session_payload(
         "local_session_id": row.local_session_id,
         "workspace": row.workspace,
         "branch": row.branch,
+        "repo": row.repo,
         "model": row.model,
         "status": row.status,
         "created_at": _iso(row.created_at),
@@ -120,6 +127,7 @@ class StartRequest(BaseModel):
     model: str | None = None
     workspace: str = "<guest>"
     branch: str = "main"
+    repo: str | None = None
 
 
 class MessageRequest(BaseModel):
@@ -191,6 +199,13 @@ def get_session_detail(
 
 @router.post("/sessions")
 async def start_session(request: StartRequest) -> dict:
+    if request.repo is not None and request.repo not in REPO_CATALOG:
+        return {
+            "accepted": False,
+            "error": (
+                f"unknown repo {request.repo}; catalog: {', '.join(REPO_CATALOG)}"
+            ),
+        }
     try:
         model_family(request.model)
     except ValueError as exc:
@@ -201,12 +216,82 @@ async def start_session(request: StartRequest) -> dict:
         request.workspace,
         request.branch,
         request.model,
+        request.repo,
     )
     turn = await asyncio.to_thread(
         _persist_pending_message, row.id, request.prompt, request.model
     )
     _schedule_next_message(row.id)
     return {"accepted": True, "session_id": row.id, "turn": turn}
+
+
+async def _github_get(url: str) -> httpx.Response:
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_API_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.get(url, headers=headers)
+        response.raise_for_status()
+        return response
+
+
+@router.get("/repos")
+async def list_repos() -> dict:
+    now = time.monotonic()
+    repos = []
+    for repo_id, entry in REPO_CATALOG.items():
+        cached = _DEFAULT_BRANCH_CACHE.get(repo_id)
+        if cached is not None and cached[0] > now:
+            default_branch = cached[1]
+        else:
+            try:
+                response = await _github_get(f"https://api.github.com/repos/{repo_id}")
+                default_branch = response.json().get("default_branch")
+                if not isinstance(default_branch, str):
+                    default_branch = None
+            except Exception:
+                default_branch = None
+            _DEFAULT_BRANCH_CACHE[repo_id] = (now + _REPO_CACHE_TTL, default_branch)
+        repos.append(
+            {
+                "id": repo_id,
+                "description": entry.description,
+                "default_branch": default_branch,
+            }
+        )
+    return {"repos": repos}
+
+
+@router.get("/repos/{owner}/{repo}/branches")
+async def list_repo_branches(owner: str, repo: str) -> dict:
+    repo_id = f"{owner}/{repo}"
+    if repo_id not in REPO_CATALOG:
+        raise HTTPException(status_code=404, detail="Repository not in catalog")
+    if not os.environ.get("GITHUB_API_TOKEN"):
+        raise HTTPException(
+            status_code=503,
+            detail="GITHUB_API_TOKEN is not set",
+        )
+    try:
+        repo_response = await _github_get(f"https://api.github.com/repos/{repo_id}")
+        default_branch = repo_response.json().get("default_branch")
+        if not isinstance(default_branch, str):
+            default_branch = None
+        branches_response = await _github_get(
+            f"https://api.github.com/repos/{repo_id}/branches?per_page=100"
+        )
+        branches = [
+            {"name": branch["name"]}
+            for branch in branches_response.json()
+            if isinstance(branch, dict) and isinstance(branch.get("name"), str)
+        ]
+    except (httpx.HTTPError, ValueError, TypeError, KeyError) as exc:
+        raise HTTPException(
+            status_code=502, detail=f"GitHub API request failed: {exc}"
+        ) from exc
+    branches.sort(key=lambda branch: (branch["name"] != default_branch, branch["name"]))
+    return {"branches": branches, "default_branch": default_branch}
 
 
 @router.post("/sessions/{session_id}/messages")

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -158,8 +158,8 @@ def test_get_session_not_found(client):
 def test_start_session_happy_path(client, session, monkeypatch):
     monkeypatch.setattr(
         "agent_sessions.router._persist_session",
-        lambda local, workspace, branch, model: store.create_session(
-            session, local, workspace, branch, model
+        lambda local, workspace, branch, model, repo: store.create_session(
+            session, local, workspace, branch, model, repo
         ),
     )
     monkeypatch.setattr(
@@ -173,6 +173,67 @@ def test_start_session_happy_path(client, session, monkeypatch):
     body = client.post("/api/agents/sessions", json={"prompt": "Hello"}).json()
     assert body["accepted"] is True
     assert body["turn"] == 1
+
+
+def test_start_session_persists_repo(client, session, monkeypatch):
+    monkeypatch.setattr(
+        "agent_sessions.router._persist_session",
+        lambda local, workspace, branch, model, repo: store.create_session(
+            session, local, workspace, branch, model, repo
+        ),
+    )
+    monkeypatch.setattr(
+        "agent_sessions.router._persist_pending_message",
+        lambda session_id, prompt, model: (
+            store.create_pending_message(session, session_id, prompt, model).seq
+        ),
+    )
+    monkeypatch.setattr("agent_sessions.router._schedule_next_message", lambda _: None)
+
+    body = client.post(
+        "/api/agents/sessions",
+        json={"prompt": "Hello", "repo": "jomcgi/homelab"},
+    ).json()
+    row = session.get(AgentSession, body["session_id"])
+    assert body["accepted"] is True
+    assert row.repo == "jomcgi/homelab"
+    assert client.get("/api/agents/sessions").json()[0]["repo"] == "jomcgi/homelab"
+
+
+def test_start_session_rejects_unknown_repo(client):
+    body = client.post(
+        "/api/agents/sessions", json={"prompt": "Hello", "repo": "bad/repo"}
+    ).json()
+    assert body["accepted"] is False
+    assert body["error"].startswith("unknown repo bad/repo; catalog:")
+
+
+def test_list_repos_degrades_when_github_is_down(client, monkeypatch):
+    async def github_down(url):
+        raise RuntimeError("offline")
+
+    monkeypatch.setattr("agent_sessions.router._github_get", github_down)
+    monkeypatch.setattr("agent_sessions.router._DEFAULT_BRANCH_CACHE", {})
+
+    response = client.get("/api/agents/repos")
+    assert response.status_code == 200
+    assert [repo["id"] for repo in response.json()["repos"]] == [
+        "jomcgi/homelab",
+        "weave-hand/loom",
+        "colincee/homelab",
+        "scotscottmca/parkedlikea",
+    ]
+    assert all(repo["default_branch"] is None for repo in response.json()["repos"])
+
+
+def test_list_repo_branches_requires_catalog_and_token(client, monkeypatch):
+    assert (
+        client.get("/api/agents/repos/not-cataloged/repo/branches").status_code == 404
+    )
+    monkeypatch.delenv("GITHUB_API_TOKEN", raising=False)
+    response = client.get("/api/agents/repos/jomcgi/homelab/branches")
+    assert response.status_code == 503
+    assert "GITHUB_API_TOKEN" in response.json()["detail"]
 
 
 def test_start_session_model_validation(client):
@@ -261,8 +322,8 @@ def test_mcp_tools_still_work(session, monkeypatch):
     monkeypatch.setattr(
         mcp,
         "_persist_session",
-        lambda local, workspace, branch, model: store.create_session(
-            session, local, workspace, branch, model
+        lambda local, workspace, branch, model, repo=None: store.create_session(
+            session, local, workspace, branch, model, repo
         ),
     )
     monkeypatch.setattr(

--- a/projects/monolith/agent_sessions/router_test.py
+++ b/projects/monolith/agent_sessions/router_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timedelta, timezone
 
+import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -224,6 +225,82 @@ def test_list_repos_degrades_when_github_is_down(client, monkeypatch):
         "scotscottmca/parkedlikea",
     ]
     assert all(repo["default_branch"] is None for repo in response.json()["repos"])
+
+
+def test_list_repos_success_cache_hit_and_expiry(client, monkeypatch):
+    repo_ids = [
+        "jomcgi/homelab",
+        "weave-hand/loom",
+        "colincee/homelab",
+        "scotscottmca/parkedlikea",
+    ]
+    calls = []
+    now = 1000.0
+
+    async def github_get(url):
+        calls.append(url)
+        repo_id = url.rsplit("/", 1)[-1]
+        return httpx.Response(200, json={"default_branch": f"branch-{repo_id}"})
+
+    monkeypatch.setattr("agent_sessions.router._DEFAULT_BRANCH_CACHE", {})
+    monkeypatch.setattr("agent_sessions.router.time.monotonic", lambda: now)
+    monkeypatch.setattr("agent_sessions.router._github_get", github_get)
+
+    first = client.get("/api/agents/repos")
+    assert first.status_code == 200
+    assert len(calls) == len(repo_ids)
+    assert [repo["id"] for repo in first.json()["repos"]] == repo_ids
+
+    async def github_failed(url):
+        raise AssertionError(f"unexpected cache miss: {url}")
+
+    monkeypatch.setattr("agent_sessions.router._github_get", github_failed)
+    second = client.get("/api/agents/repos")
+    assert second.json() == first.json()
+    assert len(calls) == len(repo_ids)
+
+    monkeypatch.setattr("agent_sessions.router.time.monotonic", lambda: now + 301)
+    monkeypatch.setattr("agent_sessions.router._github_get", github_get)
+    third = client.get("/api/agents/repos")
+    assert third.json() == first.json()
+    assert len(calls) == len(repo_ids) * 2
+
+
+def test_list_repo_branches_success_with_pagination(client, monkeypatch):
+    monkeypatch.setenv("GITHUB_API_TOKEN", "test-token")
+    page_one = [{"name": f"branch-{index:03d}"} for index in range(100)]
+    page_two = [{"name": "main"}] + [
+        {"name": f"branch-{index:03d}"} for index in range(100, 120)
+    ]
+    calls = []
+
+    async def github_get(url):
+        calls.append(url)
+        if url.endswith("/jomcgi/homelab"):
+            return httpx.Response(200, json={"default_branch": "main"})
+        if "page=2" in url:
+            return httpx.Response(200, json=page_two)
+        return httpx.Response(
+            200,
+            json=page_one,
+            headers={
+                "Link": '<https://api.github.com/repos/jomcgi/homelab/branches?per_page=100&page=2>; rel="next"'
+            },
+        )
+
+    monkeypatch.setattr("agent_sessions.router._github_get", github_get)
+
+    response = client.get("/api/agents/repos/jomcgi/homelab/branches")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["branches"]) == 121
+    assert body["branches"][0] == {"name": "main"}
+    assert body["branches"][1:] == sorted(
+        body["branches"][1:], key=lambda item: item["name"]
+    )
+    assert len(calls) == 3
+    assert "page=2" in calls[-1]
 
 
 def test_list_repo_branches_requires_catalog_and_token(client, monkeypatch):

--- a/projects/monolith/agent_sessions/store.py
+++ b/projects/monolith/agent_sessions/store.py
@@ -23,11 +23,13 @@ def create_session(
     workspace: str,
     branch: str,
     model: str | None = None,
+    repo: str | None = None,
 ) -> AgentSession:
     row = AgentSession(
         local_session_id=local_session_id,
         workspace=workspace,
         branch=branch,
+        repo=repo,
         model=model,
     )
     session.add(row)

--- a/projects/monolith/agent_sessions/transport.py
+++ b/projects/monolith/agent_sessions/transport.py
@@ -126,6 +126,8 @@ class ShimTransport(Protocol):
         model: str | None = None,
         restore_from: str | None = None,
         on_create: Callable[[EmberSession, str | None], Awaitable[None]] | None = None,
+        repo: str | None = None,
+        branch: str | None = None,
     ) -> tuple[Turn, EmberSession]: ...
 
 
@@ -342,6 +344,8 @@ class EmberVmShimTransport:
         model: str | None = None,
         restore_from: str | None = None,
         on_create: Callable[[EmberSession, str | None], Awaitable[None]] | None = None,
+        repo: str | None = None,
+        branch: str | None = None,
     ) -> tuple[Turn, EmberSession]:
         """Execute one turn on the guest session and return the result.
 
@@ -422,6 +426,9 @@ class EmberVmShimTransport:
             payload = {"message": message, "session_id": current_cli_session_id}
             if model is not None:
                 payload["model"] = model
+            if repo is not None:
+                payload["repo"] = repo
+                payload["branch"] = branch or "main"
             body = json.dumps(payload)
             url = f"{EMBERVM_URL}/v1/sessions/{current.session_id}/invoke"
             headers = {

--- a/projects/monolith/agent_sessions/transport_test.py
+++ b/projects/monolith/agent_sessions/transport_test.py
@@ -226,6 +226,56 @@ def test_deliver_includes_model_when_present(monkeypatch):
     }
 
 
+def test_deliver_includes_repo_and_branch_when_present(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        return _turn_response(request)
+
+    _client(monkeypatch, handler)
+    asyncio.run(
+        transport.EmberVmShimTransport().deliver(
+            transport.EmberSession("s1", "t1", None),
+            "cli-1",
+            "hello",
+            repo="jomcgi/homelab",
+            branch="develop",
+        )
+    )
+    assert json.loads(requests[0].content)["repo"] == "jomcgi/homelab"
+    assert json.loads(requests[0].content)["branch"] == "develop"
+
+
+def test_deliver_defaults_repo_branch_and_omits_repo_without_repo(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        return _turn_response(request)
+
+    _client(monkeypatch, handler)
+    client = transport.EmberVmShimTransport()
+    asyncio.run(
+        client.deliver(
+            transport.EmberSession("s1", "t1", None),
+            "cli-1",
+            "hello",
+            repo="jomcgi/homelab",
+            branch=None,
+        )
+    )
+    assert json.loads(requests[0].content)["branch"] == "main"
+    requests.clear()
+    asyncio.run(
+        client.deliver(
+            transport.EmberSession("s1", "t1", None), "cli-1", "hello", branch="dev"
+        )
+    )
+    assert "repo" not in json.loads(requests[0].content)
+    assert "branch" not in json.loads(requests[0].content)
+
+
 def test_deliver_recreates_reused_stale_session_once(monkeypatch):
     requests = []
     responses = [410, 200]

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.285.432
+version: 0.285.433
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260804170000_agent_sessions_repo.sql
+++ b/projects/monolith/chart/migrations/20260804170000_agent_sessions_repo.sql
@@ -1,0 +1,2 @@
+ALTER TABLE agent_sessions.agent_sessions
+    ADD COLUMN repo TEXT;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:g9RzwAxfoQR8lBlrhaz9r+c6Fp8mYxu0ltDeU1DXLBk=
+h1:zkb2opNZzn3M/jn4osalMM/Hj2EGvrl8LNjfilqaSB4=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -150,3 +150,4 @@ h1:g9RzwAxfoQR8lBlrhaz9r+c6Fp8mYxu0ltDeU1DXLBk=
 20260804120000_agent_sessions_lineage.sql h1:z3Nd00j+dPGPeiYeXaPuJ8qPM2UPxmLXkUwtBcLjYbI=
 20260804130000_agent_sessions_prior_lineage.sql h1:iR7hDl+ZrGDhgAvnv0aLDyNDmiBF+NOBfFgqsfsZ7cA=
 20260804150000_agent_turns_fts.sql h1:n3u7l9ZaWsmtQyd2UStYL3vTyMcj81gqaLxKb7lOYPg=
+20260804170000_agent_sessions_repo.sql h1:fO8QWpDxjjrGvGWe7TBK8BDjIG0NYbiIqcLRF1/EnZ4=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.285.432
+      targetRevision: 0.285.433
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/api.py
+++ b/projects/monolith/goosecracker/api.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from goosecracker.dispatch import status  # re-exported
 from goosecracker.recipe_catalog import CATALOG, enabled_enum  # re-exported
-from goosecracker.repo_catalog import describe_repos  # re-exported
+from goosecracker.repo_catalog import REPO_CATALOG, describe_repos  # re-exported
 from goosecracker.router_render import (  # re-exported
     render_plan_file,
     render_router,
@@ -20,6 +20,7 @@ from goosecracker.tiers import features_for_tier, tier_allows  # re-exported
 
 __all__ = [
     "CATALOG",
+    "REPO_CATALOG",
     "describe_repos",
     "enabled_enum",
     "features_for_tier",


### PR DESCRIPTION
Work item 3 of #4330, per ADR agents/050 (#4339).

- agent_sessions gains a nullable repo column (migration 20260804170000 plus regenerated atlas.sum).
- POST /api/agents/sessions accepts repo, validated against the mirror catalog and failing closed for anything uncatalogued (a repo the mirror does not register cannot hydrate).
- The pending-message executor threads repo and branch from the session row into the invoke payload; the EmberVM control plane proxies the body opaquely, so the guest shim PR (next) is the only other consumer of the new keys.
- Two catalog-gated listing endpoints feed the UI dropdowns from the GitHub API using GITHUB_API_TOKEN (already wired in the deployment; GITHUB_TOKEN is the kloak placeholder and never usable in-pod): GET /api/agents/repos with a 300s default-branch cache that degrades to null instead of failing the dropdown, and GET /api/agents/repos/{owner}/{repo}/branches with the default branch first.
- Voice-path sessions keep repo=None and are unaffected.

Contract frozen for the UI PR: repos/branches response shapes and the optional repo field on session create and session payloads.

Charts: monolith 0.285.433, monolith-public 0.89.358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)